### PR TITLE
feat(pipeline): total expression evaluator (R1)

### DIFF
--- a/src/reyn/core/pipeline/__init__.py
+++ b/src/reyn/core/pipeline/__init__.py
@@ -1,0 +1,8 @@
+"""Reyn Pipeline control plane — the deterministic-DSL successor to the skill/task system.
+
+This package holds the pipeline feature's pure, non-agentic building blocks (see
+``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``, resolution R1). The first
+brick is ``expr``: the total expression evaluator used by ``transform.value`` / ``until`` /
+``verify.condition`` / ``fold.init``.
+"""
+from __future__ import annotations

--- a/src/reyn/core/pipeline/expr.py
+++ b/src/reyn/core/pipeline/expr.py
@@ -1,0 +1,708 @@
+"""Total expression evaluator for the Pipeline control plane (R1).
+
+Implements the expression grammar pinned in
+``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R1: a small,
+purpose-built tree-walking interpreter for ``transform.value`` / ``until`` /
+``verify.condition`` / ``fold.init``. It is deliberately **not** a general
+scripting language and **not** the CodeAct safe-AST gate
+(``op_runtime`` / ``_validate_safe_ast``) — that gate restricts a
+Turing-complete Python surface for `agent`-invoked tool code, a different
+trust context. This module is total by construction instead:
+
+- No recursion and no user-defined functions: the grammar has no call syntax
+  beyond a fixed, closed set of combinators (``map``/``filter``/``all``/
+  ``any``/``count``/``sum``/``find``/``join``/``get``), and a ``Lambda`` node
+  can only be produced as the direct argument of one of those combinators —
+  it is never a value, so it can't be stored, named, returned, or invoked
+  more than once per element.
+- No unbounded loops: every combinator iterates a single already-materialized
+  Python list exactly once.
+- No IO, no imports of runtime modules, no ``eval``/``exec``: evaluation is a
+  pure recursive function over an immutable AST and a ``Mapping`` context;
+  the only Python builtins touched are arithmetic/comparison operators and
+  container literals.
+
+Because every construct is structural and finite, every well-formed program
+provably terminates and the parser can statically enumerate every context
+path an expression reads (feeds the future data-flow analyzer).
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Union
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ExprError(Exception):
+    """Base class for expression-language errors."""
+
+
+class ExprParseError(ExprError):
+    """Raised when source text does not conform to the R1 grammar."""
+
+
+class ExprEvalError(ExprError):
+    """Raised for a runtime failure while evaluating an AST against a context.
+
+    Covers: a bare ``Path`` resolving to an absent field, and type errors
+    (e.g. ``count`` on a non-list, ``+`` on incompatible operand types).
+    Callers (the pipeline executor) map this to a step failure.
+    """
+
+
+# ---------------------------------------------------------------------------
+# AST
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Literal:
+    """A bool / number / string / null literal."""
+
+    value: Any
+
+
+@dataclass(frozen=True)
+class Path:
+    """Dotted static context access, e.g. ``ctx.review.passed``."""
+
+    parts: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ListLit:
+    """A list literal ``[expr, expr, ...]``."""
+
+    items: tuple["ExprNode", ...]
+
+
+@dataclass(frozen=True)
+class ObjectLit:
+    """An object literal ``{key: expr, ...}``."""
+
+    fields: tuple[tuple[str, "ExprNode"], ...]
+
+
+@dataclass(frozen=True)
+class Unary:
+    """``not expr`` or ``-expr``."""
+
+    op: str  # "not" | "-"
+    operand: "ExprNode"
+
+
+@dataclass(frozen=True)
+class Binary:
+    """A binary operator application."""
+
+    op: str  # "==" "!=" "<" ">" "<=" ">=" "and" "or" "+" "-" "*" "/"
+    left: "ExprNode"
+    right: "ExprNode"
+
+
+@dataclass(frozen=True)
+class Lambda:
+    """``param -> body``. Only ever appears as a combinator argument node —
+
+    never returned as a standalone evaluation result, never storable in a
+    context value, never itself an argument of another combinator except as
+    that combinator's own direct lambda slot.
+    """
+
+    param: str
+    body: "ExprNode"
+
+
+@dataclass(frozen=True)
+class Combinator:
+    """One of the fixed R1 combinators applied to its (already-parsed) args."""
+
+    name: str
+    args: tuple["ExprNode", ...]
+
+
+ExprNode = Union[Literal, Path, ListLit, ObjectLit, Unary, Binary, Lambda, Combinator]
+
+COMBINATOR_NAMES = frozenset(
+    {"map", "filter", "all", "any", "count", "sum", "find", "join", "get"}
+)
+_LAMBDA_COMBINATORS = frozenset({"map", "filter", "all", "any", "find"})
+
+# ---------------------------------------------------------------------------
+# Tokenizer
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Token:
+    kind: str
+    text: str
+    pos: int
+
+
+_TOKEN_SPEC = [
+    ("SKIP", r"[ \t\r\n]+"),
+    ("NUMBER", r"\d+\.\d+|\d+"),
+    ("STRING", r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\""),
+    ("ARROW", r"->"),
+    ("DOT", r"\."),
+    ("EQ", r"=="),
+    ("NE", r"!="),
+    ("LE", r"<="),
+    ("GE", r">="),
+    ("LT", r"<"),
+    ("GT", r">"),
+    ("LPAREN", r"\("),
+    ("RPAREN", r"\)"),
+    ("LBRACE", r"\{"),
+    ("RBRACE", r"\}"),
+    ("LBRACKET", r"\["),
+    ("RBRACKET", r"\]"),
+    ("COMMA", r","),
+    ("COLON", r":"),
+    ("PLUS", r"\+"),
+    ("MINUS", r"-"),
+    ("STAR", r"\*"),
+    ("SLASH", r"/"),
+    ("IDENT", r"[A-Za-z_][A-Za-z0-9_]*"),
+]
+_TOKEN_RE = re.compile("|".join(f"(?P<{name}>{pat})" for name, pat in _TOKEN_SPEC))
+
+_KEYWORDS = {"true", "false", "null", "not", "and", "or"}
+
+
+def _tokenize(src: str) -> list[_Token]:
+    tokens: list[_Token] = []
+    pos = 0
+    n = len(src)
+    while pos < n:
+        m = _TOKEN_RE.match(src, pos)
+        if not m:
+            raise ExprParseError(
+                f"unexpected character {src[pos]!r} at position {pos} in {src!r}"
+            )
+        kind = m.lastgroup
+        text = m.group()
+        if kind != "SKIP":
+            tokens.append(_Token(kind, text, pos))
+        pos = m.end()
+    tokens.append(_Token("EOF", "", n))
+    return tokens
+
+
+def _unescape_string(raw: str) -> str:
+    # raw includes the surrounding quotes.
+    quote = raw[0]
+    body = raw[1:-1]
+    out = []
+    i = 0
+    while i < len(body):
+        ch = body[i]
+        if ch == "\\" and i + 1 < len(body):
+            nxt = body[i + 1]
+            mapping = {"n": "\n", "t": "\t", "\\": "\\", "'": "'", '"': '"'}
+            out.append(mapping.get(nxt, nxt))
+            i += 2
+        else:
+            out.append(ch)
+            i += 1
+    _ = quote
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Parser (recursive descent)
+# ---------------------------------------------------------------------------
+
+
+class _Parser:
+    def __init__(self, tokens: list[_Token], src: str) -> None:
+        self._tokens = tokens
+        self._src = src
+        self._i = 0
+
+    def _peek(self) -> _Token:
+        return self._tokens[self._i]
+
+    def _advance(self) -> _Token:
+        tok = self._tokens[self._i]
+        self._i += 1
+        return tok
+
+    def _expect(self, kind: str) -> _Token:
+        tok = self._peek()
+        if tok.kind != kind:
+            raise ExprParseError(
+                f"expected {kind} but found {tok.kind} ({tok.text!r}) at position "
+                f"{tok.pos} in {self._src!r}"
+            )
+        return self._advance()
+
+    def parse_program(self) -> ExprNode:
+        node = self._parse_or()
+        self._expect("EOF")
+        return node
+
+    # or -> and ("or" and)*
+    def _parse_or(self) -> ExprNode:
+        left = self._parse_and()
+        while self._peek().kind == "IDENT" and self._peek().text == "or":
+            self._advance()
+            right = self._parse_and()
+            left = Binary("or", left, right)
+        return left
+
+    # and -> not_expr ("and" not_expr)*
+    def _parse_and(self) -> ExprNode:
+        left = self._parse_not()
+        while self._peek().kind == "IDENT" and self._peek().text == "and":
+            self._advance()
+            right = self._parse_not()
+            left = Binary("and", left, right)
+        return left
+
+    # not_expr -> "not" not_expr | comparison
+    def _parse_not(self) -> ExprNode:
+        if self._peek().kind == "IDENT" and self._peek().text == "not":
+            self._advance()
+            operand = self._parse_not()
+            return Unary("not", operand)
+        return self._parse_comparison()
+
+    _CMP_OPS = {"EQ": "==", "NE": "!=", "LT": "<", "GT": ">", "LE": "<=", "GE": ">="}
+
+    # comparison -> additive (cmp_op additive)?
+    def _parse_comparison(self) -> ExprNode:
+        left = self._parse_additive()
+        if self._peek().kind in self._CMP_OPS:
+            op_tok = self._advance()
+            right = self._parse_additive()
+            left = Binary(self._CMP_OPS[op_tok.kind], left, right)
+        return left
+
+    # additive -> multiplicative (("+"|"-") multiplicative)*
+    def _parse_additive(self) -> ExprNode:
+        left = self._parse_multiplicative()
+        while self._peek().kind in ("PLUS", "MINUS"):
+            op_tok = self._advance()
+            right = self._parse_multiplicative()
+            left = Binary(op_tok.text, left, right)
+        return left
+
+    # multiplicative -> unary (("*"|"/") unary)*
+    def _parse_multiplicative(self) -> ExprNode:
+        left = self._parse_unary()
+        while self._peek().kind in ("STAR", "SLASH"):
+            op_tok = self._advance()
+            right = self._parse_unary()
+            left = Binary(op_tok.text, left, right)
+        return left
+
+    # unary -> "-" unary | primary
+    def _parse_unary(self) -> ExprNode:
+        if self._peek().kind == "MINUS":
+            self._advance()
+            operand = self._parse_unary()
+            return Unary("-", operand)
+        return self._parse_primary()
+
+    def _parse_primary(self) -> ExprNode:
+        tok = self._peek()
+        if tok.kind == "NUMBER":
+            self._advance()
+            if "." in tok.text:
+                return Literal(float(tok.text))
+            return Literal(int(tok.text))
+        if tok.kind == "STRING":
+            self._advance()
+            return Literal(_unescape_string(tok.text))
+        if tok.kind == "LPAREN":
+            self._advance()
+            node = self._parse_or()
+            self._expect("RPAREN")
+            return node
+        if tok.kind == "LBRACKET":
+            return self._parse_list()
+        if tok.kind == "LBRACE":
+            return self._parse_object()
+        if tok.kind == "IDENT":
+            return self._parse_ident_led()
+        raise ExprParseError(
+            f"unexpected token {tok.kind} ({tok.text!r}) at position {tok.pos} "
+            f"in {self._src!r}"
+        )
+
+    def _parse_list(self) -> ExprNode:
+        self._expect("LBRACKET")
+        items: list[ExprNode] = []
+        if self._peek().kind != "RBRACKET":
+            items.append(self._parse_or())
+            while self._peek().kind == "COMMA":
+                self._advance()
+                items.append(self._parse_or())
+        self._expect("RBRACKET")
+        return ListLit(tuple(items))
+
+    def _parse_object(self) -> ExprNode:
+        self._expect("LBRACE")
+        fields: list[tuple[str, ExprNode]] = []
+        if self._peek().kind != "RBRACE":
+            fields.append(self._parse_object_field())
+            while self._peek().kind == "COMMA":
+                self._advance()
+                fields.append(self._parse_object_field())
+        self._expect("RBRACE")
+        return ObjectLit(tuple(fields))
+
+    def _parse_object_field(self) -> tuple[str, ExprNode]:
+        key_tok = self._expect("IDENT")
+        self._expect("COLON")
+        value = self._parse_or()
+        return key_tok.text, value
+
+    def _parse_ident_led(self) -> ExprNode:
+        tok = self._advance()
+        name = tok.text
+        if name == "true":
+            return Literal(True)
+        if name == "false":
+            return Literal(False)
+        if name == "null":
+            return Literal(None)
+        if name in ("and", "or", "not"):
+            raise ExprParseError(
+                f"keyword {name!r} used as an expression at position {tok.pos} "
+                f"in {self._src!r}"
+            )
+        if self._peek().kind == "LPAREN":
+            if name not in COMBINATOR_NAMES:
+                raise ExprParseError(
+                    f"{name!r} is not a known combinator (arbitrary function "
+                    f"calls are not part of the R1 grammar) at position {tok.pos} "
+                    f"in {self._src!r}"
+                )
+            return self._parse_combinator(name)
+        # dotted path
+        parts = [name]
+        while self._peek().kind == "DOT":
+            self._advance()  # consume '.'
+            part_tok = self._expect("IDENT")
+            parts.append(part_tok.text)
+        return Path(tuple(parts))
+
+    def _parse_combinator(self, name: str) -> ExprNode:
+        self._expect("LPAREN")
+        args: list[ExprNode] = []
+        if name in _LAMBDA_COMBINATORS:
+            list_expr = self._parse_or()
+            self._expect("COMMA")
+            lam = self._parse_lambda()
+            args = [list_expr, lam]
+        elif name in ("count", "sum"):
+            args = [self._parse_or()]
+        elif name == "join":
+            list_expr = self._parse_or()
+            self._expect("COMMA")
+            sep_expr = self._parse_or()
+            args = [list_expr, sep_expr]
+        elif name == "get":
+            base_expr = self._parse_or()
+            self._expect("COMMA")
+            path_tok = self._expect("STRING")
+            args = [base_expr, Literal(_unescape_string(path_tok.text))]
+            if self._peek().kind == "COMMA":
+                self._advance()
+                default_expr = self._parse_or()
+                args.append(default_expr)
+        else:  # pragma: no cover - COMBINATOR_NAMES is exhaustive above
+            raise ExprParseError(f"unknown combinator {name!r}")
+        self._expect("RPAREN")
+        return Combinator(name, tuple(args))
+
+    def _parse_lambda(self) -> ExprNode:
+        param_tok = self._expect("IDENT")
+        if param_tok.text in _KEYWORDS:
+            raise ExprParseError(
+                f"lambda parameter cannot be keyword {param_tok.text!r} at "
+                f"position {param_tok.pos} in {self._src!r}"
+            )
+        self._expect("ARROW")
+        body = self._parse_or()
+        return Lambda(param_tok.text, body)
+
+
+def parse(src: str) -> ExprNode:
+    """Parse ``src`` into an :class:`ExprNode` AST. Raises :class:`ExprParseError`."""
+    if not isinstance(src, str) or not src.strip():
+        raise ExprParseError("expression source must be a non-empty string")
+    tokens = _tokenize(src)
+    parser = _Parser(tokens, src)
+    return parser.parse_program()
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+class _ChildContext(Mapping):
+    """A context overlaying a single lambda binding on top of a base mapping."""
+
+    __slots__ = ("_base", "_name", "_value")
+
+    def __init__(self, base: Mapping[str, Any], name: str, value: Any) -> None:
+        self._base = base
+        self._name = name
+        self._value = value
+
+    def __getitem__(self, key: str) -> Any:
+        if key == self._name:
+            return self._value
+        return self._base[key]
+
+    def __iter__(self):
+        seen = {self._name}
+        yield self._name
+        for k in self._base:
+            if k not in seen:
+                yield k
+
+    def __len__(self) -> int:
+        return len({self._name, *self._base.keys()})
+
+    def __contains__(self, key: object) -> bool:
+        return key == self._name or key in self._base
+
+
+def evaluate(node: ExprNode, context: Mapping[str, Any]) -> Any:
+    """Evaluate ``node`` (from :func:`parse`) against ``context``. Pure; total.
+
+    Raises :class:`ExprEvalError` on an absent bare-``Path`` field or a type
+    error (e.g. arithmetic/``count``/``sum``/``join`` on the wrong shape).
+    """
+    if isinstance(node, Literal):
+        return node.value
+    if isinstance(node, Path):
+        return _resolve_path(node.parts, context)
+    if isinstance(node, ListLit):
+        return [evaluate(item, context) for item in node.items]
+    if isinstance(node, ObjectLit):
+        return {key: evaluate(value, context) for key, value in node.fields}
+    if isinstance(node, Unary):
+        return _eval_unary(node, context)
+    if isinstance(node, Binary):
+        return _eval_binary(node, context)
+    if isinstance(node, Combinator):
+        return _eval_combinator(node, context)
+    if isinstance(node, Lambda):  # pragma: no cover - defensive; never reached
+        raise ExprEvalError("a lambda cannot be evaluated outside a combinator")
+    raise ExprEvalError(f"unknown AST node: {node!r}")  # pragma: no cover
+
+
+def evaluate_expr(src: str, context: Mapping[str, Any]) -> Any:
+    """Convenience: ``evaluate(parse(src), context)``."""
+    return evaluate(parse(src), context)
+
+
+def _resolve_path(parts: Sequence[str], context: Mapping[str, Any]) -> Any:
+    current: Any = context
+    consumed: list[str] = []
+    for part in parts:
+        consumed.append(part)
+        if isinstance(current, Mapping):
+            if part not in current:
+                raise ExprEvalError(
+                    f"path {'.'.join(parts)!r} is absent: no field "
+                    f"{'.'.join(consumed)!r} in context"
+                )
+            current = current[part]
+        else:
+            raise ExprEvalError(
+                f"path {'.'.join(parts)!r} is absent: {'.'.join(consumed[:-1]) or '<root>'} "
+                f"is not an object, cannot access {part!r}"
+            )
+    return current
+
+
+def _resolve_path_safe(parts: Sequence[str], base: Any, default: Any) -> Any:
+    current = base
+    for part in parts:
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return default
+    return current
+
+
+def _eval_unary(node: Unary, context: Mapping[str, Any]) -> Any:
+    value = evaluate(node.operand, context)
+    if node.op == "not":
+        return not _truthy(value)
+    if node.op == "-":
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ExprEvalError(f"unary '-' requires a number, got {type(value).__name__}")
+        return -value
+    raise ExprEvalError(f"unknown unary operator {node.op!r}")  # pragma: no cover
+
+
+def _truthy(value: Any) -> bool:
+    return bool(value)
+
+
+_NUMERIC_OPS = {"+", "-", "*", "/"}
+_CMP_SYMBOLS = {"==", "!=", "<", ">", "<=", ">="}
+
+
+def _eval_binary(node: Binary, context: Mapping[str, Any]) -> Any:
+    op = node.op
+    if op == "and":
+        left = evaluate(node.left, context)
+        if not _truthy(left):
+            return left
+        return evaluate(node.right, context)
+    if op == "or":
+        left = evaluate(node.left, context)
+        if _truthy(left):
+            return left
+        return evaluate(node.right, context)
+
+    left = evaluate(node.left, context)
+    right = evaluate(node.right, context)
+
+    if op in _CMP_SYMBOLS:
+        return _eval_comparison(op, left, right)
+    if op in _NUMERIC_OPS:
+        return _eval_arithmetic(op, left, right)
+    raise ExprEvalError(f"unknown binary operator {op!r}")  # pragma: no cover
+
+
+def _eval_comparison(op: str, left: Any, right: Any) -> bool:
+    if op == "==":
+        return left == right
+    if op == "!=":
+        return left != right
+    ordering_ok = isinstance(left, (int, float)) and isinstance(right, (int, float))
+    ordering_ok = ordering_ok or (isinstance(left, str) and isinstance(right, str))
+    if not ordering_ok:
+        raise ExprEvalError(
+            f"comparison {op!r} requires two numbers or two strings, got "
+            f"{type(left).__name__} and {type(right).__name__}"
+        )
+    if op == "<":
+        return left < right
+    if op == ">":
+        return left > right
+    if op == "<=":
+        return left <= right
+    if op == ">=":
+        return left >= right
+    raise ExprEvalError(f"unknown comparison operator {op!r}")  # pragma: no cover
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _eval_arithmetic(op: str, left: Any, right: Any) -> Any:
+    if op == "+" and isinstance(left, str) and isinstance(right, str):
+        return left + right
+    if op == "+" and isinstance(left, list) and isinstance(right, list):
+        return left + right
+    if not (_is_number(left) and _is_number(right)):
+        raise ExprEvalError(
+            f"arithmetic {op!r} requires two numbers (or '+' on two strings/lists), "
+            f"got {type(left).__name__} and {type(right).__name__}"
+        )
+    if op == "+":
+        return left + right
+    if op == "-":
+        return left - right
+    if op == "*":
+        return left * right
+    if op == "/":
+        if right == 0:
+            raise ExprEvalError("division by zero")
+        result = left / right
+        if isinstance(left, int) and isinstance(right, int) and left % right == 0:
+            return left // right
+        return result
+    raise ExprEvalError(f"unknown arithmetic operator {op!r}")  # pragma: no cover
+
+
+def _require_list(value: Any, combinator: str) -> list:
+    if not isinstance(value, list):
+        raise ExprEvalError(f"{combinator}() requires a list, got {type(value).__name__}")
+    return value
+
+
+def _eval_combinator(node: Combinator, context: Mapping[str, Any]) -> Any:
+    name = node.name
+    if name in _LAMBDA_COMBINATORS:
+        list_node, lam = node.args
+        items = _require_list(evaluate(list_node, context), name)
+        assert isinstance(lam, Lambda)
+        if name == "map":
+            return [evaluate(lam.body, _ChildContext(context, lam.param, item)) for item in items]
+        if name == "filter":
+            return [
+                item
+                for item in items
+                if _truthy(evaluate(lam.body, _ChildContext(context, lam.param, item)))
+            ]
+        if name == "all":
+            return all(
+                _truthy(evaluate(lam.body, _ChildContext(context, lam.param, item)))
+                for item in items
+            )
+        if name == "any":
+            return any(
+                _truthy(evaluate(lam.body, _ChildContext(context, lam.param, item)))
+                for item in items
+            )
+        if name == "find":
+            for item in items:
+                if _truthy(evaluate(lam.body, _ChildContext(context, lam.param, item))):
+                    return item
+            return None
+        raise ExprEvalError(f"unhandled lambda combinator {name!r}")  # pragma: no cover
+
+    if name == "count":
+        items = _require_list(evaluate(node.args[0], context), name)
+        return len(items)
+
+    if name == "sum":
+        items = _require_list(evaluate(node.args[0], context), name)
+        total = 0
+        for item in items:
+            if not _is_number(item):
+                raise ExprEvalError(f"sum() requires a list of numbers, found {type(item).__name__}")
+            total += item
+        return total
+
+    if name == "join":
+        list_node, sep_node = node.args
+        items = _require_list(evaluate(list_node, context), name)
+        sep = evaluate(sep_node, context)
+        if not isinstance(sep, str):
+            raise ExprEvalError(f"join() separator must be a string, got {type(sep).__name__}")
+        for item in items:
+            if not isinstance(item, str):
+                raise ExprEvalError(
+                    f"join() requires a list of strings, found {type(item).__name__}"
+                )
+        return sep.join(items)
+
+    if name == "get":
+        base = evaluate(node.args[0], context)
+        path_literal = node.args[1]
+        assert isinstance(path_literal, Literal) and isinstance(path_literal.value, str)
+        parts = path_literal.value.split(".")
+        default = evaluate(node.args[2], context) if len(node.args) > 2 else None
+        return _resolve_path_safe(parts, base, default)
+
+    raise ExprEvalError(f"unknown combinator {name!r}")  # pragma: no cover

--- a/tests/test_pipeline_expr_evaluator.py
+++ b/tests/test_pipeline_expr_evaluator.py
@@ -1,0 +1,214 @@
+"""Tier 1 Contract tests for the Pipeline expression evaluator (R1 grammar).
+
+``reyn.core.pipeline.expr`` is the pipeline control plane's first code brick:
+a pure, total, tree-walking evaluator for the expression language used by
+``transform.value`` / ``until`` / ``verify.condition`` / ``fold.init``
+(``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R1). These tests
+pin the public surface (``parse`` / ``evaluate`` / ``evaluate_expr`` /
+``ExprEvalError`` / ``ExprParseError``): the spec's own example expressions
+must evaluate correctly, the combinator set must cover the reshape needs
+appendix A/C call out, and the totality/safety properties (no recursion, no
+calls, no IO) must hold structurally — not just as an untested claim.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.pipeline.expr import (
+    Combinator,
+    ExprEvalError,
+    ExprParseError,
+    Lambda,
+    evaluate,
+    evaluate_expr,
+    parse,
+)
+
+# ---------------------------------------------------------------------------
+# Spec's own example expressions (R1 notes + appendix B canonical example)
+# ---------------------------------------------------------------------------
+
+
+def test_all_combinator_matches_spec_example() -> None:
+    """Tier 1: `all(results, r -> r.verified)` (R1 notes example) evaluates correctly."""
+    ctx = {"results": [{"verified": True}, {"verified": True}]}
+    assert evaluate_expr("all(results, r -> r.verified)", ctx) is True
+
+    ctx_fail = {"results": [{"verified": True}, {"verified": False}]}
+    assert evaluate_expr("all(results, r -> r.verified)", ctx_fail) is False
+
+
+def test_object_construction_with_nested_combinator_matches_spec_example() -> None:
+    """Tier 1: `{passed: all(...), items: results}` (R1 notes example) evaluates correctly."""
+    ctx = {"results": [{"verified": True}, {"verified": True}]}
+    out = evaluate_expr("{passed: all(results, r -> r.verified), items: results}", ctx)
+    assert out == {"passed": True, "items": ctx["results"]}
+
+
+def test_join_matches_spec_example() -> None:
+    """Tier 1: `join(review.comments, "\\n")` (R1 notes example) evaluates correctly."""
+    ctx = {"review": {"comments": ["fix typo", "add test"]}}
+    out = evaluate_expr('join(review.comments, "\\n")', ctx)
+    assert out == "fix typo\nadd test"
+
+
+def test_empty_object_and_list_literals_match_spec_example() -> None:
+    """Tier 1: `{glossary: {}, summaries: []}` (R1 notes example) evaluates correctly."""
+    out = evaluate_expr("{glossary: {}, summaries: []}", {})
+    assert out == {"glossary": {}, "summaries": []}
+
+
+def test_dotted_ctx_path_access() -> None:
+    """Tier 1: `ctx.review.passed` dotted static path access resolves nested context."""
+    ctx = {"ctx": {"review": {"passed": True}}}
+    assert evaluate_expr("ctx.review.passed", ctx) is True
+
+
+def test_comparisons_and_booleans() -> None:
+    """Tier 1: comparison and boolean operators (==, !=, <, >, and, or, not) evaluate correctly."""
+    ctx = {"a": 3, "b": 5}
+    assert evaluate_expr("a < b and not (a == b)", ctx) is True
+    assert evaluate_expr("a > b or a == 3", ctx) is True
+    assert evaluate_expr("a != b", ctx) is True
+
+
+def test_refine_until_predicate_from_canonical_example() -> None:
+    """Tier 1: `ctx.review.passed` as used in appendix B's `refine.until` evaluates correctly."""
+    ctx = {"ctx": {"review": {"passed": False}}}
+    assert evaluate_expr("ctx.review.passed", ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# Reshape coverage (the calibration goal)
+# ---------------------------------------------------------------------------
+
+
+def test_map_pluck() -> None:
+    """Tier 1: `map(list, x -> x.field)` projects (plucks) a field across a list."""
+    ctx = {"items": [{"field": "a"}, {"field": "b"}]}
+    assert evaluate_expr("map(items, x -> x.field)", ctx) == ["a", "b"]
+
+
+def test_filter_keeps_matching_elements() -> None:
+    """Tier 1: `filter(list, x -> pred)` keeps only elements where the lambda is true."""
+    ctx = {"items": [{"n": 1}, {"n": 2}, {"n": 3}]}
+    assert evaluate_expr("filter(items, x -> x.n > 1)", ctx) == [{"n": 2}, {"n": 3}]
+
+
+def test_count_returns_list_length() -> None:
+    """Tier 1: `count(list)` returns the list length."""
+    assert evaluate_expr("count(items)", {"items": [1, 2, 3, 4]}) == 4
+
+
+def test_sum_returns_numeric_total() -> None:
+    """Tier 1: `sum(list)` returns the numeric sum of a list."""
+    assert evaluate_expr("sum(items)", {"items": [1, 2, 3.5]}) == 6.5
+
+
+def test_find_returns_first_match_or_null() -> None:
+    """Tier 1: `find(list, x -> pred)` returns the first match, or null when none matches."""
+    ctx = {"items": [{"n": 1}, {"n": 2}]}
+    assert evaluate_expr("find(items, x -> x.n == 2)", ctx) == {"n": 2}
+    assert evaluate_expr("find(items, x -> x.n == 99)", ctx) is None
+
+
+def test_nested_object_construction() -> None:
+    """Tier 1: object literals can nest and reference other paths in their field expressions."""
+    ctx = {"a": 1, "b": {"c": 2}}
+    out = evaluate_expr("{outer: {inner: b.c, echo: a}}", ctx)
+    assert out == {"outer": {"inner": 2, "echo": 1}}
+
+
+def test_any_combinator() -> None:
+    """Tier 1: `any(list, x -> pred)` is existential quantification over the list."""
+    ctx = {"items": [{"ok": False}, {"ok": True}]}
+    assert evaluate_expr("any(items, x -> x.ok)", ctx) is True
+    assert evaluate_expr("any(items, x -> x.ok)", {"items": [{"ok": False}]}) is False
+
+
+def test_get_with_default_on_absent_path() -> None:
+    """Tier 1: `get(expr, "path", default)` is safe access — absent path returns the default."""
+    ctx = {"review": {"passed": True}}
+    assert evaluate_expr('get(review, "passed")', ctx) is True
+    assert evaluate_expr('get(review, "missing.nested", "fallback")', ctx) == "fallback"
+    assert evaluate_expr('get(review, "missing.nested")', ctx) is None
+
+
+# ---------------------------------------------------------------------------
+# Totality / safety
+# ---------------------------------------------------------------------------
+
+
+def test_arbitrary_function_call_is_a_parse_error() -> None:
+    """Tier 1: an IDENT(...) call outside the closed combinator set is a parse error, not IO."""
+    with pytest.raises(ExprParseError):
+        parse("shell('rm -rf /')")
+
+
+def test_lambda_outside_a_combinator_is_a_parse_error() -> None:
+    """Tier 1: a bare `x -> expr` (not inside a combinator argument slot) is a parse error."""
+    with pytest.raises(ExprParseError):
+        parse("x -> x")
+
+
+def test_lambda_cannot_be_passed_as_a_value() -> None:
+    """Tier 1: there is no syntax to bind/name/pass a lambda — only `IDENT -> Expr` inline."""
+    with pytest.raises(ExprParseError):
+        parse("map(items, f)")  # f is not a Lambda: "IDENT -> Expr" is required
+
+
+def test_malformed_input_is_a_parse_error() -> None:
+    """Tier 1: unterminated/incomplete/empty source strings raise ExprParseError."""
+    with pytest.raises(ExprParseError):
+        parse("{unterminated:")
+    with pytest.raises(ExprParseError):
+        parse("1 +")
+    with pytest.raises(ExprParseError):
+        parse("")
+
+
+def test_bare_absent_path_is_an_eval_error() -> None:
+    """Tier 1: a bare Path to an absent field raises ExprEvalError (R1 error semantics)."""
+    with pytest.raises(ExprEvalError):
+        evaluate_expr("ctx.missing.field", {"ctx": {}})
+
+
+def test_type_errors_raise_eval_error() -> None:
+    """Tier 1: type errors (count on non-list, + on incompatible types) raise ExprEvalError."""
+    with pytest.raises(ExprEvalError):
+        evaluate_expr("count(not_a_list)", {"not_a_list": 5})
+    with pytest.raises(ExprEvalError):
+        evaluate_expr("1 + 'x'", {})
+
+
+def test_ast_has_no_call_or_recursion_construct() -> None:
+    """Tier 1: the only invocation-shaped AST node is Combinator (closed name set);
+
+    its Lambda argument (when present) is a leaf evaluated once per element,
+    never itself invoked as a value — there is no user-defined-function or
+    self-reference node in the AST.
+    """
+    node = parse("map(items, x -> x.n)")
+    assert isinstance(node, Combinator)
+    assert node.name == "map"
+    assert isinstance(node.args[1], Lambda)
+
+
+def test_totality_deep_nesting_still_terminates() -> None:
+    """Tier 1: deep nesting is bounded by source length, not an unbounded runtime loop."""
+    src = "1" + " + 1" * 200
+    assert evaluate_expr(src, {}) == 201
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_same_expr_and_context_yields_same_result() -> None:
+    """Tier 1: evaluating the same (AST, context) pair twice yields an identical result."""
+    ctx = {"results": [{"verified": True}, {"verified": False}]}
+    node = parse("{passed: all(results, r -> r.verified), n: count(results)}")
+    first = evaluate(node, ctx)
+    second = evaluate(node, ctx)
+    assert first == second == {"passed": False, "n": 2}


### PR DESCRIPTION
**[lead-sonnet]** — First code brick of the Reyn Pipeline feature, per `docs/proposals/reyn-pipeline-v0.9-design-resolutions.md` resolution **R1**.

## Summary
- New subsystem `src/reyn/core/pipeline/` with `expr.py`: a pure, total, tree-walking parser + evaluator for the pipeline control plane's expression language, used by `transform.value` / `until` / `verify.condition` / `fold.init`.
- Grammar implements R1 exactly: literals (bool/number/string/null), dotted static `Path`, unary (`not`/`-`), binary (`== != < > <= >= and or + - * /`), list/object literals, and the closed combinator set `map/filter/all/any/count/sum/find/join/get` with lambdas (`x -> expr`) valid **only** as a direct combinator argument — never storable, named, or passed as a plain value (no parse path produces a first-class lambda).
- Public API: `parse(src) -> ExprNode`, `evaluate(node, context) -> Any`, `evaluate_expr(src, context)` convenience, plus `ExprParseError` / `ExprEvalError`.
- Error semantics per R1: a bare `Path` to an absent field raises `ExprEvalError`; `get(expr, "path", default)` returns the default on an absent path; type errors (e.g. `count` on a non-list, `+` on incompatible types) raise `ExprEvalError` with a clear message.

## Totality — how recursion/IO are structurally impossible
- **No recursion, no user-defined functions**: the only "invocation-shaped" AST node is `Combinator`, whose `name` is restricted at parse time to the closed R1 set (`shell(...)`, `foo(...)`, etc. are parse errors, not calls). There is no AST node for defining or naming a function.
- **Lambdas are inline-only**: `Lambda` nodes are produced by the parser exclusively inside the fixed lambda-argument slot of `map`/`filter`/`all`/`any`/`find`; a bare `x -> expr` or passing a lambda as a plain value (`map(items, f)`) is a parse error. So a lambda body can never invoke itself or another lambda — no recursion is syntactically expressible.
- **Bounded iteration**: every combinator iterates over an already-materialized Python `list` exactly once (`for item in items`); no `while`, no user-controlled loop bound.
- **No IO / no runtime imports / no eval-exec**: the module imports only `re`, `dataclasses`, `collections.abc`, `typing` — no `reyn.core.op_runtime`, no shell/tool/LLM access, no `eval`/`exec`. Evaluation is a pure recursive function over an immutable AST + a `Mapping` context.
- Explicitly **not** the CodeAct safe-AST (`_validate_safe_ast`) — that gate restricts a Turing-complete Python surface for `agent`-invoked tool code, a different trust context; this is a small, purpose-built, non-Python grammar.

## Reshape-coverage finding (calibration, R1's "validate against appendix A/C" commitment)
All reshape shapes exercised in the spec's own examples and appendix C's FP mapping (map/pluck, filter, count, sum, find, join, nested object construction/rename via object literals, safe optional access via `get`) are expressible with the R1 combinator set as specified — **no additional combinator was needed** for anything in scope for this PR. Appendix A's 10 general-agent-task rows don't themselves require a reshape beyond object literals (they're mostly `agent`/`match`/`for_each` structural concerns, not expression-level). **Flag for the executor-integration follow-up**: appendix C names `group_by` as R1's one pre-approved addition "if a genuine reshape need can't be expressed" — none of the examples validated here needed it, but the executor vertical-slice work should re-check once real pipeline definitions are written, since `group_by` is explicitly pre-approved (not an open design question) if that need surfaces.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `pytest` from repo root — 6891 passed, 30 skipped; 10 failed + 10 errors, all pre-existing `tests/test_fp0001_a2a_endpoints.py`, `tests/test_fp0016_e_agent_id.py`, `tests/test_mcp_structured_client_p1.py`, `tests/test_web_ws_max_size_config_1934.py`, `tests/web/test_a2a.py`, `tests/web/test_plugin_loader.py`, `tests/web/test_resources_router.py`, `tests/test_config_mcp_headers.py`, `tests/test_mcp_client.py` (mcp/uvicorn/a2a) — confirmed via `git status` that this PR touches only `src/reyn/core/pipeline/` + the new test file, zero overlap with the failing modules.
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_expr_evaluator.py` — 24/24 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/expr.py src/reyn/core/pipeline/__init__.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)