### PR TITLE
feat(pipeline): nested schema/type system + validator + path resolver (R2)

### DIFF
--- a/src/reyn/core/pipeline/__init__.py
+++ b/src/reyn/core/pipeline/__init__.py
@@ -1,0 +1,10 @@
+"""Pipeline control-plane subsystem (reyn-pipeline-v0.9).
+
+Home for the Pipeline DSL's pure, IO-free building blocks: the expression
+evaluator (`expr.py`) and the schema/type registry + validator + static
+path resolver (`schema.py`, R2 of
+`docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`). Both modules are
+standalone — no executor, no WAL, no agent runtime wiring lives here yet;
+this package is the shared foundation the thin executor vertical-slice
+(R3/R4) will build on.
+"""

--- a/src/reyn/core/pipeline/schema.py
+++ b/src/reyn/core/pipeline/schema.py
@@ -1,0 +1,407 @@
+"""Pipeline schema/type registry, validator, and static path resolver (R2).
+
+Implements R2 of `docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`:
+a nested, monomorphic (no generics) type system for Pipeline step outputs.
+A `Schema` names a set of `FieldType`s; a `FieldType` is a scalar
+(`bool`/`string`/`number`), an `enum`, a typed `list` (`of` is mandatory —
+no untyped lists), an inline nested `object`, or a `ref` to another
+registered schema. This is what makes `match.on` / `until` / `carry_forward`
+/ `for_each over` paths statically resolvable (spec rule 7 / N8) instead of
+free-form dict navigation.
+
+Three pieces, all pure / IO-free (a YAML-backed loader belongs in a
+separate thin wrapper, not here):
+
+  - `SchemaRegistry` — register/get named schemas by dict. Registration
+    validates the schema's own shape (known field types, `list.of` present,
+    `enum.values` non-empty, ...) and rejects a **recursive schema**: v0.9
+    schemas may not reference themselves transitively via `ref` (this is
+    what keeps `validate`/`resolve_path` total — no risk of infinite
+    descent). Detection runs a cycle check over the ref-dependency graph
+    of all currently-registered schemas after each registration and rolls
+    back on cycle.
+  - `validate(value, schema, registry) -> ValidationResult` — recursively
+    checks a value against a schema (or schema name), producing a list of
+    typed `ValidationError`s (`missing_required` / `type_mismatch` /
+    `enum_invalid` / `unresolved_ref` / `unknown_type`) rather than raising,
+    so callers can report every violation instead of just the first.
+  - `resolve_path(schema, "dotted.path", registry) -> FieldType | None` —
+    walks a dotted path through a (possibly nested) schema, transparently
+    unwrapping `object` fields, `ref` fields (via the registry), and `list`
+    fields (into their `of` element type) at each intermediate segment, so
+    a path like `"suspects.path"` against `suspects: list of ref(file)`
+    resolves through the list into `file`'s `path` field. Returns `None`
+    for any path that doesn't resolve — this is the seam the pipeline
+    static analyzer uses to validate `match.on` / `until` / `carry_forward`
+    / `for_each over` path references.
+
+ElemType (the type allowed inside `list.of`) intentionally excludes `list`
+itself — no lists-of-lists — matching the grammar in R2 / appendix B; this
+is enforced at registration time, not just documented.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Field-type vocabulary
+# ---------------------------------------------------------------------------
+
+SCALAR_TYPES = frozenset({"bool", "string", "number"})
+_KNOWN_TYPES = SCALAR_TYPES | {"enum", "list", "object", "ref"}
+
+# Sentinel distinguishing "key absent from the value dict" from "key present
+# with an explicit None" — only the former is a missing-required-field error;
+# the latter is a type mismatch against every current field type.
+_MISSING = object()
+
+
+class SchemaError(ValueError):
+    """Raised when a schema registration is malformed or recursive."""
+
+
+# ---------------------------------------------------------------------------
+# Validation result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    """One violation found while validating a value against a schema.
+
+    `path` is the dotted/indexed path to the offending value (e.g.
+    `"feedbacks[1].comment"`, `""` for the root). `kind` is one of
+    `missing_required` / `type_mismatch` / `enum_invalid` / `unresolved_ref`
+    / `unknown_type` — stable tokens callers may branch on.
+    """
+
+    path: str
+    message: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    """Outcome of `validate()`: either conforming, or a list of errors."""
+
+    conforming: bool
+    errors: tuple[ValidationError, ...] = ()
+
+    @classmethod
+    def ok(cls) -> ValidationResult:
+        return cls(conforming=True, errors=())
+
+    @classmethod
+    def fail(cls, errors: list[ValidationError]) -> ValidationResult:
+        return cls(conforming=False, errors=tuple(errors))
+
+
+# ---------------------------------------------------------------------------
+# Schema registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SchemaRegistry:
+    """Named-schema store. Register with a plain dict; refs resolve by name.
+
+    Decoupled from disk on purpose (per R2 / task scope) — a `.reyn/schemas/
+    <name>.yaml` loader can sit in front of this and call `register()` per
+    file; the registry itself never touches IO.
+    """
+
+    _schemas: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def register(self, name: str, schema: dict[str, Any]) -> None:
+        """Register `schema` under `name`.
+
+        Raises `SchemaError` if the schema's own shape is malformed, or if
+        registering it would introduce a recursive `ref` cycle (self- or
+        mutually-referential) among currently-registered schemas.
+        """
+        _check_schema_shape(name, schema)
+        normalized = dict(schema)
+        normalized.setdefault("name", name)
+
+        previous = self._schemas.get(name)
+        self._schemas[name] = normalized
+        cycle = _find_ref_cycle(self._schemas)
+        if cycle is not None:
+            if previous is None:
+                del self._schemas[name]
+            else:
+                self._schemas[name] = previous
+            raise SchemaError(
+                f"recursive schema detected: {' -> '.join(cycle)}"
+            )
+
+    def get(self, name: str) -> dict[str, Any]:
+        if name not in self._schemas:
+            raise KeyError(f"unknown schema: {name!r}")
+        return self._schemas[name]
+
+    def has(self, name: str) -> bool:
+        return name in self._schemas
+
+
+# ---------------------------------------------------------------------------
+# Schema-shape validation (registration-time — catches malformed schemas
+# early, independent of any value being validated against them)
+# ---------------------------------------------------------------------------
+
+
+def _check_field_type_shape(ft: Any, path: str, *, allow_list: bool) -> None:
+    if not isinstance(ft, dict):
+        raise SchemaError(f"{path}: field type must be a dict, got {type(ft).__name__}")
+    t = ft.get("type")
+    if t in SCALAR_TYPES:
+        return
+    if t == "enum":
+        values = ft.get("values")
+        if not isinstance(values, list) or not values:
+            raise SchemaError(f"{path}: enum type requires non-empty 'values'")
+        return
+    if t == "list":
+        if not allow_list:
+            raise SchemaError(f"{path}: list element type may not itself be a list")
+        of = ft.get("of")
+        if of is None:
+            raise SchemaError(f"{path}: list type requires 'of' (no untyped lists)")
+        _check_field_type_shape(of, f"{path}.of", allow_list=False)
+        return
+    if t == "object":
+        fields = ft.get("fields")
+        if not isinstance(fields, dict) or not fields:
+            raise SchemaError(f"{path}: object type requires non-empty 'fields'")
+        for fname, sub in fields.items():
+            _check_field_type_shape(sub, f"{path}.{fname}", allow_list=True)
+        return
+    if t == "ref":
+        if not ft.get("schema"):
+            raise SchemaError(f"{path}: ref type requires 'schema'")
+        return
+    raise SchemaError(f"{path}: unknown field type {t!r} (expected one of {sorted(_KNOWN_TYPES)})")
+
+
+def _check_schema_shape(name: str, schema: Any) -> None:
+    if not isinstance(schema, dict):
+        raise SchemaError(f"schema {name!r} must be a dict")
+    fields = schema.get("fields")
+    if not isinstance(fields, dict) or not fields:
+        raise SchemaError(f"schema {name!r} requires non-empty 'fields'")
+    for fname, ft in fields.items():
+        _check_field_type_shape(ft, f"{name}.{fname}", allow_list=True)
+
+
+# ---------------------------------------------------------------------------
+# Recursive-schema detection (v0.9: no self- or mutually-referential schemas)
+# ---------------------------------------------------------------------------
+
+
+def _direct_refs(ft: dict[str, Any]) -> set[str]:
+    """`ref` schema names directly reachable from one FieldType."""
+    t = ft.get("type")
+    if t == "ref":
+        return {ft["schema"]}
+    if t == "list":
+        return _direct_refs(ft["of"])
+    if t == "object":
+        refs: set[str] = set()
+        for sub in ft["fields"].values():
+            refs |= _direct_refs(sub)
+        return refs
+    return set()
+
+
+def _schema_direct_refs(schema: dict[str, Any]) -> set[str]:
+    refs: set[str] = set()
+    for ft in schema["fields"].values():
+        refs |= _direct_refs(ft)
+    return refs
+
+
+def _find_ref_cycle(schemas: dict[str, dict[str, Any]]) -> list[str] | None:
+    """DFS cycle detection over the ref-dependency graph of `schemas`.
+
+    Edges to a schema name not (yet) present in `schemas` are ignored —
+    an unresolved forward ref is not itself a cycle; it surfaces as an
+    `unresolved_ref` validation error instead, only if it never resolves.
+    Returns the cycle as a list of schema names (closed loop, first ==
+    last) if one exists, else None.
+    """
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color: dict[str, int] = {name: WHITE for name in schemas}
+    stack: list[str] = []
+
+    def dfs(node: str) -> list[str] | None:
+        color[node] = GRAY
+        stack.append(node)
+        for ref in sorted(_schema_direct_refs(schemas[node])):
+            if ref not in schemas:
+                continue
+            if color[ref] == GRAY:
+                idx = stack.index(ref)
+                return [*stack[idx:], ref]
+            if color[ref] == WHITE:
+                found = dfs(ref)
+                if found is not None:
+                    return found
+        stack.pop()
+        color[node] = BLACK
+        return None
+
+    for name in schemas:
+        if color[name] == WHITE:
+            found = dfs(name)
+            if found is not None:
+                return found
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Value validation
+# ---------------------------------------------------------------------------
+
+
+def validate(
+    value: Any, schema: dict[str, Any] | str, registry: SchemaRegistry
+) -> ValidationResult:
+    """Validate `value` against `schema` (a schema dict, or a registered name).
+
+    Recurses through nested `object`/`list`/`ref` fields. Returns a
+    `ValidationResult` — never raises for a non-conforming value (only
+    malformed *schemas*, caught earlier at registration, raise).
+    """
+    if isinstance(schema, str):
+        schema = registry.get(schema)
+    errors: list[ValidationError] = []
+    if not isinstance(value, dict):
+        errors.append(
+            ValidationError("", f"expected object, got {type(value).__name__}", "type_mismatch")
+        )
+        return ValidationResult.fail(errors)
+    _validate_object_fields(value, schema["fields"], "", registry, errors)
+    return ValidationResult(conforming=not errors, errors=tuple(errors))
+
+
+def _validate_object_fields(
+    value: dict[str, Any],
+    fields: dict[str, dict[str, Any]],
+    path: str,
+    registry: SchemaRegistry,
+    errors: list[ValidationError],
+) -> None:
+    for fname, ft in fields.items():
+        fpath = f"{path}.{fname}" if path else fname
+        fvalue = value.get(fname, _MISSING)
+        if fvalue is _MISSING:
+            if ft.get("required"):
+                errors.append(ValidationError(fpath, "required field missing", "missing_required"))
+            continue
+        _validate_field(fvalue, ft, fpath, registry, errors)
+
+
+def _validate_field(
+    value: Any,
+    ft: dict[str, Any],
+    path: str,
+    registry: SchemaRegistry,
+    errors: list[ValidationError],
+) -> None:
+    t = ft.get("type")
+    if t in SCALAR_TYPES:
+        ok = {
+            "bool": isinstance(value, bool),
+            "string": isinstance(value, str),
+            "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+        }[t]
+        if not ok:
+            errors.append(ValidationError(path, f"expected {t}, got {type(value).__name__}", "type_mismatch"))
+        return
+    if t == "enum":
+        if value not in ft["values"]:
+            errors.append(ValidationError(path, f"{value!r} not in {ft['values']}", "enum_invalid"))
+        return
+    if t == "list":
+        if not isinstance(value, list):
+            errors.append(ValidationError(path, f"expected list, got {type(value).__name__}", "type_mismatch"))
+            return
+        for i, item in enumerate(value):
+            _validate_field(item, ft["of"], f"{path}[{i}]", registry, errors)
+        return
+    if t == "object":
+        if not isinstance(value, dict):
+            errors.append(ValidationError(path, f"expected object, got {type(value).__name__}", "type_mismatch"))
+            return
+        _validate_object_fields(value, ft["fields"], path, registry, errors)
+        return
+    if t == "ref":
+        ref_name = ft["schema"]
+        if not registry.has(ref_name):
+            errors.append(ValidationError(path, f"unresolved ref: {ref_name}", "unresolved_ref"))
+            return
+        if not isinstance(value, dict):
+            errors.append(
+                ValidationError(path, f"expected object (ref {ref_name}), got {type(value).__name__}", "type_mismatch")
+            )
+            return
+        _validate_object_fields(value, registry.get(ref_name)["fields"], path, registry, errors)
+        return
+    errors.append(ValidationError(path, f"unknown field type: {t!r}", "unknown_type"))
+
+
+# ---------------------------------------------------------------------------
+# Static path resolution
+# ---------------------------------------------------------------------------
+
+
+def _fields_of(ft: dict[str, Any], registry: SchemaRegistry) -> dict[str, dict[str, Any]] | None:
+    """The nested field map reachable by descending one more path segment
+    past `ft`, transparently unwrapping `object` / `ref` / `list`.
+
+    Returns None for scalars/enums (nothing further to descend into) or
+    an unresolved ref.
+    """
+    t = ft.get("type")
+    if t == "object":
+        return ft["fields"]
+    if t == "ref":
+        ref_name = ft["schema"]
+        if not registry.has(ref_name):
+            return None
+        return registry.get(ref_name)["fields"]
+    if t == "list":
+        return _fields_of(ft["of"], registry)
+    return None
+
+
+def resolve_path(
+    schema: dict[str, Any] | str, path: str, registry: SchemaRegistry
+) -> dict[str, Any] | None:
+    """Resolve a dotted path through `schema`, returning the FieldType at
+    that path, or None if the path doesn't exist.
+
+    Intermediate `list` fields are transparently unwrapped into their `of`
+    element type (so `"suspects.path"` against `suspects: {type: list, of:
+    {type: ref, schema: file}}` resolves through the list into `file`'s
+    `path` field) — this is the seam `for_each over` / `match.on` / `until`
+    / `carry_forward` path checks use.
+    """
+    if isinstance(schema, str):
+        schema = registry.get(schema)
+    parts = path.split(".")
+    fields = schema["fields"]
+    current: dict[str, Any] | None = None
+    for i, part in enumerate(parts):
+        if part not in fields:
+            return None
+        current = fields[part]
+        if i == len(parts) - 1:
+            return current
+        nested = _fields_of(current, registry)
+        if nested is None:
+            return None
+        fields = nested
+    return current

--- a/tests/test_pipeline_schema_validator.py
+++ b/tests/test_pipeline_schema_validator.py
@@ -1,0 +1,331 @@
+"""Tier 1: Pipeline schema/type system public API (R2) — registry, validate, resolve_path.
+
+Pins the contract of `reyn.core.pipeline.schema`: nested nested/object/list/
+ref field types, `SchemaRegistry.register`/`get`/`has`, `validate()`'s
+conforming/error-kind shape, `resolve_path()`'s dotted-path resolution
+(including through `list` and `ref`), and the no-recursive-schema rule from
+`docs/proposals/reyn-pipeline-v0.9-design-resolutions.md` R2. Uses the
+spec's own example schemas (`review`/`feedback`) — no mocks, pure dict/value
+fixtures throughout.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.pipeline.schema import (
+    SchemaError,
+    SchemaRegistry,
+    resolve_path,
+    validate,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — spec-realistic schemas
+# ---------------------------------------------------------------------------
+
+FEEDBACK_SCHEMA = {
+    "fields": {
+        "file": {"type": "string", "required": True},
+        "comment": {"type": "string", "required": True},
+    }
+}
+
+REVIEW_SCHEMA = {
+    "fields": {
+        "approved": {"type": "bool", "required": True},
+        "feedbacks": {
+            "type": "list",
+            "of": {"type": "ref", "schema": "feedback"},
+            "required": True,
+        },
+    }
+}
+
+FILE_SCHEMA = {
+    "fields": {
+        "path": {"type": "string", "required": True},
+        "risk": {"type": "enum", "values": ["low", "medium", "high"], "required": False},
+    }
+}
+
+SUSPECTS_SCHEMA = {
+    "fields": {
+        "suspects": {"type": "list", "of": {"type": "ref", "schema": "file"}, "required": True},
+    }
+}
+
+
+@pytest.fixture
+def registry() -> SchemaRegistry:
+    reg = SchemaRegistry()
+    reg.register("feedback", FEEDBACK_SCHEMA)
+    reg.register("review", REVIEW_SCHEMA)
+    reg.register("file", FILE_SCHEMA)
+    reg.register("suspects", SUSPECTS_SCHEMA)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# SchemaRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_register_get_has_roundtrip(registry: SchemaRegistry) -> None:
+    """Tier 1: registered schema is retrievable by name; `has` reflects membership."""
+    assert registry.has("review")
+    assert not registry.has("nonexistent-schema")
+    fetched = registry.get("review")
+    assert fetched["fields"]["approved"]["type"] == "bool"
+
+
+def test_get_unknown_schema_raises_keyerror(registry: SchemaRegistry) -> None:
+    """Tier 1: `get` on an unregistered name raises KeyError, not a silent None."""
+    with pytest.raises(KeyError):
+        registry.get("does-not-exist")
+
+
+@pytest.mark.parametrize(
+    "bad_schema",
+    [
+        {"fields": {}},  # empty fields
+        {"fields": {"x": {"type": "bogus-type"}}},  # unknown type
+        {"fields": {"x": {"type": "list"}}},  # list missing 'of'
+        {"fields": {"x": {"type": "enum", "values": []}}},  # empty enum values
+        {"fields": {"x": {"type": "object", "fields": {}}}},  # empty nested object fields
+        {"fields": {"x": {"type": "ref"}}},  # ref missing 'schema'
+        {"fields": {"x": {"type": "list", "of": {"type": "list", "of": {"type": "string"}}}}},  # list of list
+    ],
+)
+def test_register_rejects_malformed_schema(bad_schema: dict) -> None:
+    """Tier 1: malformed FieldType shapes are rejected at registration, not later."""
+    reg = SchemaRegistry()
+    with pytest.raises(SchemaError):
+        reg.register("bad", bad_schema)
+
+
+def test_register_rejects_self_referential_schema() -> None:
+    """Tier 1: a schema referencing itself is rejected (CLAUDE.md R2 — no recursion in v0.9)."""
+    reg = SchemaRegistry()
+    with pytest.raises(SchemaError):
+        reg.register(
+            "node",
+            {"fields": {"children": {"type": "list", "of": {"type": "ref", "schema": "node"}}}},
+        )
+    assert not reg.has("node")  # rejected registration leaves no partial state
+
+
+def test_register_rejects_mutually_recursive_schemas() -> None:
+    """Tier 1: A -> ref B -> ref A is a cycle even though neither directly self-refs."""
+    reg = SchemaRegistry()
+    reg.register("a", {"fields": {"b": {"type": "ref", "schema": "b"}}})
+    with pytest.raises(SchemaError):
+        reg.register("b", {"fields": {"a": {"type": "ref", "schema": "a"}}})
+    # "a" registered fine (no cycle yet at that point); "b" was rejected and rolled back.
+    assert reg.has("a")
+    assert not reg.has("b")
+
+
+def test_register_allows_forward_ref_to_not_yet_registered_schema() -> None:
+    """Tier 1: registering a ref to an unregistered (not-yet-defined) schema is not a cycle."""
+    reg = SchemaRegistry()
+    reg.register("review", REVIEW_SCHEMA)  # refs "feedback", not yet registered
+    assert reg.has("review")
+    assert not reg.has("feedback")
+    reg.register("feedback", FEEDBACK_SCHEMA)
+    assert reg.has("feedback")
+
+
+# ---------------------------------------------------------------------------
+# validate() — conforming + each error kind
+# ---------------------------------------------------------------------------
+
+
+def test_validate_conforming_nested_value(registry: SchemaRegistry) -> None:
+    """Tier 1: a fully-conforming nested value (ref + list of ref) validates clean."""
+    value = {
+        "approved": True,
+        "feedbacks": [
+            {"file": "a.py", "comment": "looks good"},
+            {"file": "b.py", "comment": "needs work"},
+        ],
+    }
+    result = validate(value, "review", registry)
+    assert result.conforming
+    assert result.errors == ()
+
+
+def test_validate_missing_required_field(registry: SchemaRegistry) -> None:
+    """Tier 1: a required field absent from the value produces missing_required."""
+    result = validate({"feedbacks": []}, "review", registry)
+    assert not result.conforming
+    assert any(e.kind == "missing_required" and e.path == "approved" for e in result.errors)
+
+
+def test_validate_type_mismatch_scalar(registry: SchemaRegistry) -> None:
+    """Tier 1: wrong scalar type (string where bool expected) is type_mismatch."""
+    result = validate({"approved": "yes", "feedbacks": []}, "review", registry)
+    assert not result.conforming
+    assert any(e.kind == "type_mismatch" and e.path == "approved" for e in result.errors)
+
+
+def test_validate_bool_not_accepted_as_number() -> None:
+    """Tier 1: bool is a distinct scalar from number — True must not satisfy a number field."""
+    reg = SchemaRegistry()
+    reg.register("s", {"fields": {"n": {"type": "number", "required": True}}})
+    result = validate({"n": True}, "s", reg)
+    assert not result.conforming
+    assert any(e.kind == "type_mismatch" and e.path == "n" for e in result.errors)
+
+
+def test_validate_enum_not_in_values(registry: SchemaRegistry) -> None:
+    """Tier 1: enum value outside declared `values` is enum_invalid."""
+    result = validate({"path": "x.py", "risk": "critical"}, "file", registry)
+    assert not result.conforming
+    assert any(e.kind == "enum_invalid" and e.path == "risk" for e in result.errors)
+
+
+def test_validate_enum_valid_value_conforms(registry: SchemaRegistry) -> None:
+    """Tier 1: enum value within declared `values` conforms."""
+    result = validate({"path": "x.py", "risk": "high"}, "file", registry)
+    assert result.conforming
+
+
+def test_validate_list_element_invalid_reports_indexed_path(registry: SchemaRegistry) -> None:
+    """Tier 1: an invalid element inside a typed list is reported at its indexed path."""
+    value = {
+        "approved": True,
+        "feedbacks": [
+            {"file": "a.py", "comment": "ok"},
+            {"file": "b.py"},  # missing required 'comment'
+        ],
+    }
+    result = validate(value, "review", registry)
+    assert not result.conforming
+    assert any(
+        e.kind == "missing_required" and e.path == "feedbacks[1].comment" for e in result.errors
+    )
+
+
+def test_validate_list_wrong_container_type(registry: SchemaRegistry) -> None:
+    """Tier 1: a non-list value for a list field is type_mismatch, not a crash."""
+    result = validate({"approved": True, "feedbacks": "not-a-list"}, "review", registry)
+    assert not result.conforming
+    assert any(e.kind == "type_mismatch" and e.path == "feedbacks" for e in result.errors)
+
+
+def test_validate_unresolved_ref(registry: SchemaRegistry) -> None:
+    """Tier 1: a `ref` to a schema absent from the registry is unresolved_ref, not KeyError."""
+    reg = SchemaRegistry()
+    reg.register("orphan", {"fields": {"thing": {"type": "ref", "schema": "missing-schema"}}})
+    result = validate({"thing": {}}, "orphan", reg)
+    assert not result.conforming
+    assert any(e.kind == "unresolved_ref" and e.path == "thing" for e in result.errors)
+
+
+def test_validate_nested_object_conforming_and_error() -> None:
+    """Tier 1: inline nested `object` fields recurse for both conforming and error cases."""
+    reg = SchemaRegistry()
+    reg.register(
+        "with-address",
+        {
+            "fields": {
+                "address": {
+                    "type": "object",
+                    "required": True,
+                    "fields": {
+                        "city": {"type": "string", "required": True},
+                        "zip": {"type": "string", "required": False},
+                    },
+                }
+            }
+        },
+    )
+    ok = validate({"address": {"city": "Tokyo"}}, "with-address", reg)
+    assert ok.conforming
+
+    bad = validate({"address": {}}, "with-address", reg)
+    assert not bad.conforming
+    assert any(e.kind == "missing_required" and e.path == "address.city" for e in bad.errors)
+
+
+def test_validate_root_not_object() -> None:
+    """Tier 1: a non-dict root value is reported, not a crash."""
+    reg = SchemaRegistry()
+    reg.register("s", {"fields": {"x": {"type": "string", "required": True}}})
+    result = validate("not-a-dict", "s", reg)
+    assert not result.conforming
+    assert any(e.kind == "type_mismatch" for e in result.errors)
+
+
+# ---------------------------------------------------------------------------
+# resolve_path()
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_path_top_level_scalar(registry: SchemaRegistry) -> None:
+    """Tier 1: single-segment path to a scalar field resolves directly."""
+    ft = resolve_path("review", "approved", registry)
+    assert ft is not None
+    assert ft["type"] == "bool"
+
+
+def test_resolve_path_list_field_itself(registry: SchemaRegistry) -> None:
+    """Tier 1: a path ending AT a list field (e.g. carry_forward target) returns the list FieldType."""
+    ft = resolve_path("review", "feedbacks", registry)
+    assert ft is not None
+    assert ft["type"] == "list"
+    assert ft["of"] == {"type": "ref", "schema": "feedback"}
+
+
+def test_resolve_path_through_list_of_ref_element(registry: SchemaRegistry) -> None:
+    """Tier 1: path into a `list of ref` element resolves the element schema's field (N8)."""
+    ft = resolve_path("suspects", "suspects.path", registry)
+    assert ft is not None
+    assert ft == {"type": "string", "required": True}
+
+
+def test_resolve_path_through_plain_ref(registry: SchemaRegistry) -> None:
+    """Tier 1: path through a direct (non-list) `ref` field resolves into the referenced schema."""
+    reg = registry
+    reg.register(
+        "with-file",
+        {"fields": {"target": {"type": "ref", "schema": "file", "required": True}}},
+    )
+    ft = resolve_path("with-file", "target.risk", reg)
+    assert ft is not None
+    assert ft["type"] == "enum"
+
+
+def test_resolve_path_through_inline_object(registry: SchemaRegistry) -> None:
+    """Tier 1: path through an inline nested `object` field resolves the nested field."""
+    reg = registry
+    reg.register(
+        "wrapper",
+        {
+            "fields": {
+                "meta": {
+                    "type": "object",
+                    "fields": {"tag": {"type": "string", "required": True}},
+                }
+            }
+        },
+    )
+    ft = resolve_path("wrapper", "meta.tag", reg)
+    assert ft == {"type": "string", "required": True}
+
+
+def test_resolve_path_invalid_field_name_returns_none(registry: SchemaRegistry) -> None:
+    """Tier 1: a path segment that doesn't name a declared field resolves to None."""
+    assert resolve_path("review", "nonexistent", registry) is None
+
+
+def test_resolve_path_descending_past_scalar_returns_none(registry: SchemaRegistry) -> None:
+    """Tier 1: a path that tries to descend past a scalar leaf resolves to None."""
+    assert resolve_path("review", "approved.nested", registry) is None
+
+
+def test_resolve_path_descending_past_unresolved_ref_returns_none() -> None:
+    """Tier 1: a path descending through a ref to an unregistered schema resolves to None."""
+    reg = SchemaRegistry()
+    reg.register("orphan", {"fields": {"thing": {"type": "ref", "schema": "missing"}}})
+    assert resolve_path("orphan", "thing.anything", reg) is None


### PR DESCRIPTION
**[lead-sonnet]** — Second Pipeline control-plane brick per `docs/proposals/reyn-pipeline-v0.9-design-resolutions.md` R2 (nested, monomorphic schema/type system).

## Summary
- New `src/reyn/core/pipeline/schema.py` (+ minimal `__init__.py` for the `pipeline` subsystem — `expr.py`, the first brick, is a peer's concern and untouched here):
  - `SchemaRegistry` — `register(name, schema_dict)` / `get(name)` / `has(name)`. Registration validates the schema's own shape (list requires `of`, enum requires non-empty `values`, object requires non-empty `fields`, ref requires `schema`, `list.of` may not itself be `list` per the ElemType grammar) and rejects recursive schemas (self- or mutually-referential via `ref`) with rollback — cycle detection runs a DFS over the ref-dependency graph of all currently-registered schemas after each registration.
  - `validate(value, schema, registry) -> ValidationResult` — recurses through nested `object`/`list`/`ref` fields, returns `conforming: bool` + a tuple of typed `ValidationError(path, message, kind)`, `kind` one of `missing_required` / `type_mismatch` / `enum_invalid` / `unresolved_ref` / `unknown_type`. Never raises for a non-conforming value.
  - `resolve_path(schema, "dotted.path", registry) -> FieldType | None` — walks a dotted path through a (possibly nested) schema, transparently unwrapping `object` fields, `ref` fields (via registry), and `list` fields (into their `of` element) at each intermediate segment. E.g. `resolve_path(suspects_schema, "suspects.path", registry)` resolves through `list of ref(file)` into `file.path`. This is the seam the static analyzer uses to validate `match.on` / `until` / `carry_forward` / `for_each over` paths (spec rule 7 / N8).

## Recursive-schema handling
- Self-ref (`node.children: list of ref(node)`) rejected at registration.
- Mutual cycles (`a -> ref b`, `b -> ref a`) rejected on the second registration; the first schema stays registered (no partial rollback of unrelated schemas), only the cycle-closing registration is rolled back.
- Forward refs to not-yet-registered schemas are allowed (not a cycle until/unless the loop actually closes) — surfaces as `unresolved_ref` at `validate`/`resolve_path` time if the ref is never registered.

## Tests
`tests/test_pipeline_schema_validator.py` — 25 Tier 1 (contract) tests using the spec's own `review`/`feedback`/`file`/`suspects` example schemas: conforming + every error kind, nested object validation, typed list (`list of ref`, list of scalar), enum membership, ref resolution (direct + through list), required-field enforcement, `resolve_path` (valid nested paths incl. through list/ref/object, invalid paths → None, descending past a scalar/unresolved-ref → None), recursive/mutual-recursive schema rejection, forward-ref allowance.

## Gates
- `ruff check` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_schema_validator.py` — 25/25 OK, 0 errors.
- `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/schema.py src/reyn/core/pipeline/__init__.py tests/test_pipeline_schema_validator.py` — OK.
- Full `pytest` from repo root: `10 failed, 6898 passed, 30 skipped, 11 warnings, 10 errors in 107.13s` — all failures/errors are in pre-existing `test_fp0001_a2a_endpoints` / `test_fp0016_e_agent_id` / `test_mcp_structured_client_p1` / `test_web_ws_max_size_config_1934` / `web/test_a2a` / `web/test_plugin_loader` / `web/test_resources_router` / `test_config_mcp_headers` / `test_mcp_client` — none touch `pipeline`/`schema`.

No expressiveness gap found vs the spec's R2 grammar / examples — implemented exactly as specified.

## Test plan
- [x] `ruff check src tests` — clean on changed files.
- [x] `pytest` full suite — 0 new failures beyond documented pre-existing mcp/uvicorn/a2a set.
- [x] `scripts/test_tier_audit.py --strict` on changed test file — 0 errors.
- [x] `scripts/verify_module_docstrings.py` on changed src files — OK.