### PR TITLE
feat(pipeline): executor slice — linear steps + R3 pipe-data threading + R4 step-boundary recovery

### DIFF
--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -1,0 +1,170 @@
+"""Pipeline recovery producer/reader seam — R4 step-boundary generation snapshots.
+
+Implements the R4 recovery model of
+``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: the pipeline executor's
+control-plane state (``run_id``, ``step_index``, ``named_stores``, ``pipe_data``,
+``completed_step_results``) is recorded as a **full-state generation**, keyed by the
+current durable WAL seq, after every step boundary. This mirrors the config-recovery
+pattern in ``config_recovery.py``/``config_generations.py`` exactly: a generation is a
+file (a base), not a truncatable WAL event, so it SURVIVES WAL truncation — the same
+fix #2259 PR-1 applied to config registries applies here to pipeline runs. Reconstruct
+is "latest generation on the active branch", no forward-replay (each generation is a
+complete snapshot).
+
+Layout: ``<.reyn>/pipeline/state/<run_id>/generations/gen-<seq>.json`` — one
+generation directory per run, mirroring the per-agent
+``.reyn/agents/<name>/state/generations/gen-<seq>.json`` convention (see
+``docs/reference/runtime/reyn-dir-layout.md``).
+
+Two entry points:
+  - ``record_pipeline_state`` — the producer seam the executor calls after each step
+    boundary. Side-effecting (``tool``/``shell``) steps use the AWAITED-durable path
+    (``state_log.submit_durable``) to narrow the effect-done/snapshot-not-yet-durable
+    window per R4; pure ``transform`` steps may use the fire-and-forget
+    (``state_log.submit_durable_nowait``) path, mirroring the durable/non-durable
+    split ``StateLog.append``/``append_nowait`` already draws for WAL entries.
+  - ``latest_pipeline_state`` — the reader seam ``resume`` calls: the latest
+    generation for a run ON THE ACTIVE WAL BRANCH (``is_active_seq``), mirroring
+    ``ConfigGenerationStore.latest_active``'s semantics exactly.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from reyn.core.events.config_recovery import reyn_root
+
+if TYPE_CHECKING:
+    from reyn.core.events.state_log import StateLog
+
+_GEN_RE = re.compile(r"^gen-(?P<seq>\d+)\.json$")
+
+
+def pipeline_state_dir(reyn_dir: "Path", run_id: str) -> "Path":
+    """The generation-store directory for one pipeline run under a ``.reyn/`` dir."""
+    return Path(reyn_dir) / "pipeline" / "state" / run_id / "generations"
+
+
+class PipelineStateStore:
+    """Directory of full control-plane-state generations for ONE pipeline run,
+    keyed by seq. Mirrors ``ConfigGenerationStore`` (config_generations.py) but
+    scoped to a single run (no per-path multiplexing — a run has exactly one
+    control-plane state stream)."""
+
+    def __init__(self, generations_dir: "Path") -> None:
+        self._dir = Path(generations_dir)
+
+    def _path_for(self, seq: int) -> "Path":
+        return self._dir / f"gen-{seq}.json"
+
+    def record(self, content: dict, seq: int) -> "Path":
+        """Persist `content` as the generation at `seq` (atomic; idempotent per
+        seq — re-recording overwrites, harmless since content is FULL-STATE)."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        path = self._path_for(seq)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(content, ensure_ascii=False), encoding="utf-8")
+        tmp.replace(path)
+        return path
+
+    def _seqs(self) -> "list[int]":
+        if not self._dir.is_dir():
+            return []
+        out: list[int] = []
+        for child in self._dir.iterdir():
+            m = _GEN_RE.match(child.name)
+            if m:
+                out.append(int(m.group("seq")))
+        out.sort()
+        return out
+
+    def latest_at_or_below(self, cut: int) -> "tuple[int, dict] | None":
+        """The (seq, content) of the highest generation with seq <= cut, or
+        None if no generation exists at or below cut."""
+        seqs = [s for s in self._seqs() if s <= cut]
+        if not seqs:
+            return None
+        seq = seqs[-1]
+        content = json.loads(self._path_for(seq).read_text(encoding="utf-8"))
+        return seq, content
+
+    def latest_active(self, state_log: object) -> "tuple[int, dict] | None":
+        """The (seq, content) of the highest generation on the ACTIVE WAL branch
+        (``is_active_seq``), or None if no active generation exists. Mirrors
+        ``ConfigGenerationStore.latest_active``."""
+        from reyn.core.events.snapshot_generations import is_active_seq  # noqa: PLC0415
+        seqs = [s for s in self._seqs() if is_active_seq(state_log, s)]  # type: ignore[arg-type]
+        if not seqs:
+            return None
+        seq = seqs[-1]
+        content = json.loads(self._path_for(seq).read_text(encoding="utf-8"))
+        return seq, content
+
+
+def _store(state_log: "StateLog", run_id: str) -> "PipelineStateStore | None":
+    root = reyn_root(state_log.path)
+    if root is None:
+        return None
+    return PipelineStateStore(pipeline_state_dir(root, run_id))
+
+
+async def record_pipeline_state(
+    state_log: "StateLog | None",
+    run_id: str,
+    control_plane_state: dict,
+    *,
+    durable: bool = True,
+) -> None:
+    """Record `control_plane_state` as the pipeline's full-state generation,
+    keyed at the DURABLE WAL head (``state_log.last_durable_seq``) — the
+    truncation-surviving recovery base for this run (R4). No-op when
+    `state_log` is None (opt-in / non-persistence contract) or its path is
+    not under a ``.reyn/`` dir.
+
+    `durable=True` (the default; use for side-effecting `tool`/`shell` steps)
+    routes the write through ``state_log.submit_durable`` — AWAITED, so the
+    caller only proceeds to the next step once the snapshot is durable,
+    narrowing the effect-done/snapshot-not-yet-durable crash window per R4.
+    `durable=False` (pure `transform` steps) uses
+    ``state_log.submit_durable_nowait`` — fire-and-forget, mirroring the
+    `append`/`append_nowait` distinction `StateLog` already draws.
+    """
+    if state_log is None:
+        return
+    store = _store(state_log, run_id)
+    if store is None:
+        return
+    seq = state_log.last_durable_seq
+    content = dict(control_plane_state)
+
+    async def _record() -> None:
+        store.record(content, seq)
+
+    if durable:
+        await state_log.submit_durable(_record)
+    else:
+        state_log.submit_durable_nowait(_record)
+
+
+def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any] | None":
+    """The latest pipeline control-plane-state generation for `run_id` on the
+    active WAL branch, or None if no generation was ever recorded (a fresh
+    run — `resume` should treat this as run-from-scratch)."""
+    store = _store(state_log, run_id)
+    if store is None:
+        return None
+    latest = store.latest_active(state_log)
+    if latest is None:
+        return None
+    _seq, content = latest
+    return content
+
+
+__all__ = [
+    "PipelineStateStore",
+    "pipeline_state_dir",
+    "record_pipeline_state",
+    "latest_pipeline_state",
+]

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -1,0 +1,277 @@
+"""Linear Pipeline executor — R3 pipe-data threading + R4 step-boundary recovery.
+
+The thin vertical-slice executor for
+``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a **linear** sequence of
+``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell", ...)``) steps.
+Deliberately out of scope for this slice: `agent` steps, `for_each`/`parallel`/`fold`/
+`match`/`call`/`refine`, the YAML DSL parser, and driver-as-session integration — those
+are later slices; this module proves the core loop + recovery only.
+
+**R3 (uniform pipe-data / output rule)**: every step produces exactly one return value.
+That value is simultaneously (1) the pipe data handed to the next step and (2) written
+to a named store under ``output`` iff the step declares one. A ``transform`` step's
+``value`` is a R1 expression (``reyn.core.pipeline.expr`` — the total evaluator; this
+module never hand-rolls expression evaluation), evaluated against a context of
+``{"ctx": named_stores, "pipe": pipe_data}`` — so ``ctx.NAME`` reaches an earlier step's
+named output and bare ``pipe`` reaches the immediately-preceding step's return value even
+when it had no ``output:``. A ``tool`` step's ``args`` may mark any value as an
+expression to resolve (rather than a literal) by wrapping it in :class:`ExprRef`; both
+resolve through the same context via the same evaluator.
+
+**R4 (step-boundary recovery)**: after each step completes (before advancing), the
+executor calls :func:`reyn.core.events.pipeline_recovery.record_pipeline_state` with the
+full control-plane state — ``{run_id, step_index, named_stores, pipe_data,
+completed_step_results}`` — keyed at the durable WAL head. Side-effecting ``tool`` steps
+use the awaited-durable path (narrowing the effect-done/snapshot-not-yet-durable crash
+window); pure ``transform`` steps use the non-blocking path. :meth:`PipelineExecutor.run`
+starts a run from scratch; :meth:`PipelineExecutor.resume` loads the latest recorded
+generation for a run and REPLAYS every step already present in
+``completed_step_results`` (not re-executing it — the exactly-once contract that keeps a
+crash from re-running a `tool` step's side effect), resuming live execution at the first
+step with no recorded result.
+"""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Union
+
+from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.pipeline.expr import ExprEvalError, evaluate_expr
+from reyn.core.pipeline.schema import SchemaRegistry, validate
+
+if TYPE_CHECKING:
+    from reyn.core.events.state_log import StateLog
+
+# ---------------------------------------------------------------------------
+# Pipeline representation (pre-built dataclasses — no YAML parser in scope)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExprRef:
+    """Marks a ``ToolStep.args`` value as an R1 expression SOURCE to resolve against
+    the step's context, rather than a literal Python value passed through as-is. A bare
+    Python value (``"shell"``, ``42``, ``["a", "b"]``) in ``args`` is always a literal —
+    only an explicit ``ExprRef`` is evaluated, so there is no parse-ambiguity between "a
+    literal string that happens to look like an expression" and "an expression"."""
+
+    src: str
+
+
+@dataclass(frozen=True)
+class TransformStep:
+    """A pure step: ``value`` (an R1 expression source) is evaluated against the
+    current context; its result is the step's pipe data / named output per R3."""
+
+    value: str
+    output: "str | None" = None
+
+
+@dataclass(frozen=True)
+class ToolStep:
+    """A side-effecting step: ``tool_dispatch(name, resolved_args)`` is invoked (``args``
+    values wrapped in :class:`ExprRef` are resolved against the context first; other
+    values pass through literally). ``shell`` is just ``ToolStep(name="shell", ...)`` —
+    there is no separate shell-step type. ``schema``, if set, names a
+    ``SchemaRegistry``-registered schema the step's result must conform to (verify:
+    schema) — non-conformance fails the step."""
+
+    name: str
+    args: "dict[str, Any]" = field(default_factory=dict)
+    output: "str | None" = None
+    schema: "str | None" = None
+
+
+Step = Union[TransformStep, ToolStep]
+
+
+@dataclass(frozen=True)
+class Pipeline:
+    """A linear sequence of steps."""
+
+    steps: "list[Step]"
+
+
+@dataclass(frozen=True)
+class PipelineResult:
+    """The outcome of a completed `run`/`resume`: the final pipe data, every named
+    store, and every step's result (keyed by ``step_path`` — the linear step index as a
+    string; a later multi-scope slice would use dotted scope paths)."""
+
+    run_id: str
+    pipe_data: Any
+    named_stores: "dict[str, Any]"
+    completed_step_results: "dict[str, Any]"
+    step_index: int
+
+
+class PipelineError(Exception):
+    """Base class for pipeline-execution errors."""
+
+
+class PipelineExecutionError(PipelineError):
+    """Raised when a step fails: an expression error, an unresolvable tool result
+    against its declared schema, or an unrecognized step type. The executor never
+    silently continues past a failed step."""
+
+
+ToolDispatch = Callable[[str, "dict[str, Any]"], Any]
+
+
+# ---------------------------------------------------------------------------
+# Executor
+# ---------------------------------------------------------------------------
+
+
+class PipelineExecutor:
+    """Runs a :class:`Pipeline` sequentially, threading pipe data + named stores
+    (R3) and recording a step-boundary recovery generation after each step (R4)."""
+
+    async def run(
+        self,
+        pipeline: Pipeline,
+        initial_context: "dict[str, Any] | None",
+        *,
+        tool_dispatch: ToolDispatch,
+        state_log: "StateLog | None",
+        run_id: str,
+        schema_registry: "SchemaRegistry | None" = None,
+    ) -> PipelineResult:
+        """Run `pipeline` from the first step. `initial_context` seeds the named
+        stores (``ctx.*``) available to the first step; there is no incoming pipe
+        data (``pipe`` resolves to ``None`` until the first step produces one)."""
+        named_stores: "dict[str, Any]" = dict(initial_context) if initial_context else {}
+        return await self._run_from(
+            pipeline,
+            named_stores=named_stores,
+            pipe_data=None,
+            completed_step_results={},
+            start_index=0,
+            tool_dispatch=tool_dispatch,
+            state_log=state_log,
+            run_id=run_id,
+            schema_registry=schema_registry,
+        )
+
+    async def resume(
+        self,
+        run_id: str,
+        *,
+        pipeline: Pipeline,
+        tool_dispatch: ToolDispatch,
+        state_log: "StateLog",
+        schema_registry: "SchemaRegistry | None" = None,
+    ) -> PipelineResult:
+        """Resume `run_id`: load the latest recorded generation (R4) and replay every
+        step already in ``completed_step_results`` (no re-execution — exactly-once),
+        resuming live execution at the first step with no recorded result. With no
+        snapshot at all, resume == run from scratch."""
+        snapshot = latest_pipeline_state(run_id, state_log)
+        if snapshot is None:
+            return await self.run(
+                pipeline,
+                None,
+                tool_dispatch=tool_dispatch,
+                state_log=state_log,
+                run_id=run_id,
+                schema_registry=schema_registry,
+            )
+        return await self._run_from(
+            pipeline,
+            named_stores=dict(snapshot["named_stores"]),
+            pipe_data=snapshot["pipe_data"],
+            completed_step_results=dict(snapshot["completed_step_results"]),
+            start_index=int(snapshot["step_index"]),
+            tool_dispatch=tool_dispatch,
+            state_log=state_log,
+            run_id=run_id,
+            schema_registry=schema_registry,
+        )
+
+    async def _run_from(
+        self,
+        pipeline: Pipeline,
+        *,
+        named_stores: "dict[str, Any]",
+        pipe_data: Any,
+        completed_step_results: "dict[str, Any]",
+        start_index: int,
+        tool_dispatch: ToolDispatch,
+        state_log: "StateLog | None",
+        run_id: str,
+        schema_registry: "SchemaRegistry | None",
+    ) -> PipelineResult:
+        steps = pipeline.steps
+        for i in range(start_index, len(steps)):
+            step = steps[i]
+            context = {"ctx": named_stores, "pipe": pipe_data}
+
+            if isinstance(step, TransformStep):
+                try:
+                    result = evaluate_expr(step.value, context)
+                except ExprEvalError as exc:
+                    raise PipelineExecutionError(
+                        f"step {i} (transform) failed: {exc}"
+                    ) from exc
+                durable = False
+            elif isinstance(step, ToolStep):
+                resolved_args = {
+                    k: (evaluate_expr(v.src, context) if isinstance(v, ExprRef) else v)
+                    for k, v in step.args.items()
+                }
+                raw = tool_dispatch(step.name, resolved_args)
+                result = await raw if inspect.isawaitable(raw) else raw
+                if step.schema is not None:
+                    if schema_registry is None:
+                        raise PipelineExecutionError(
+                            f"step {i} (tool {step.name!r}) declares verify: schema "
+                            f"{step.schema!r} but no schema_registry was provided"
+                        )
+                    validation = validate(result, step.schema, schema_registry)
+                    if not validation.conforming:
+                        raise PipelineExecutionError(
+                            f"step {i} (tool {step.name!r}) output failed schema "
+                            f"{step.schema!r}: {validation.errors}"
+                        )
+                durable = True
+            else:  # pragma: no cover - Step is a closed union
+                raise PipelineExecutionError(f"unknown step type: {step!r}")
+
+            pipe_data = result
+            step_index = i + 1
+            completed_step_results = {**completed_step_results, str(i): result}
+            if step.output:
+                named_stores = {**named_stores, step.output: result}
+
+            control_plane_state = {
+                "run_id": run_id,
+                "step_index": step_index,
+                "named_stores": named_stores,
+                "pipe_data": pipe_data,
+                "completed_step_results": completed_step_results,
+            }
+            await record_pipeline_state(
+                state_log, run_id, control_plane_state, durable=durable,
+            )
+
+        return PipelineResult(
+            run_id=run_id,
+            pipe_data=pipe_data,
+            named_stores=named_stores,
+            completed_step_results=completed_step_results,
+            step_index=len(steps),
+        )
+
+
+__all__ = [
+    "ExprRef",
+    "TransformStep",
+    "ToolStep",
+    "Step",
+    "Pipeline",
+    "PipelineResult",
+    "PipelineError",
+    "PipelineExecutionError",
+    "PipelineExecutor",
+]

--- a/tests/test_pipeline_executor_r3_r4.py
+++ b/tests/test_pipeline_executor_r3_r4.py
@@ -1,0 +1,237 @@
+"""Tier 2: OS invariant — Pipeline executor R3 pipe-data threading + R4 step-boundary recovery.
+
+Covers the thin linear-executor vertical-slice
+(`docs/proposals/reyn-pipeline-v0.9-design-resolutions.md` R3 + R4):
+  1. pipe-data / named-store threading through the REAL R1 expression evaluator,
+  2. `verify: schema` step validation via the REAL `SchemaRegistry`,
+  3. the CLAUDE.md-mandated truncate-falsify test: a recorded step-boundary
+     generation must survive WAL truncation below its own key seq, and `resume`
+     must reconstruct correctly from it without re-executing completed steps,
+  4. exactly-once replay on resume (no double side effect for a completed tool step).
+
+Real `StateLog` + `SchemaRegistry` throughout — no mocks, no private-state assertions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.schema import SchemaRegistry
+
+
+def _shout_dispatch(name: str, args: dict) -> str:
+    assert name == "shout"
+    return args["text"].upper() + "!!!"
+
+
+@pytest.mark.asyncio
+async def test_linear_pipeline_threads_pipe_data_and_named_stores_via_real_evaluator():
+    """Tier 2: transform -> tool -> transform threads pipe data + named stores (R3)
+    through the REAL `expr.evaluate_expr` (string concat + bare `pipe` access +
+    `ctx.NAME` named-store access), not a hand-rolled stand-in."""
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="'hello ' + ctx.seed", output="greeting"),
+            ToolStep(name="shout", args={"text": ExprRef("pipe")}, output="shouted"),
+            TransformStep(value="ctx.shouted + ' (done)'", output="final"),
+        ]
+    )
+    executor = PipelineExecutor()
+    result = await executor.run(
+        pipeline,
+        {"seed": "world"},
+        tool_dispatch=_shout_dispatch,
+        state_log=None,
+        run_id="run-threading",
+    )
+
+    assert result.pipe_data == "HELLO WORLD!!! (done)"
+    assert result.named_stores == {
+        "seed": "world",
+        "greeting": "hello world",
+        "shouted": "HELLO WORLD!!!",
+        "final": "HELLO WORLD!!! (done)",
+    }
+    assert result.completed_step_results == {
+        "0": "hello world",
+        "1": "HELLO WORLD!!!",
+        "2": "HELLO WORLD!!! (done)",
+    }
+
+
+@pytest.mark.asyncio
+async def test_verify_schema_passes_conforming_and_fails_non_conforming():
+    """Tier 2: a tool step's `verify: schema` validates its output through the REAL
+    `SchemaRegistry`/`validate` — conforming output passes the step; non-conforming
+    output fails the step (raises), it is never silently swallowed."""
+    registry = SchemaRegistry()
+    registry.register(
+        "greeting_schema", {"fields": {"msg": {"type": "string", "required": True}}}
+    )
+
+    def _ok_dispatch(_name: str, _args: dict) -> dict:
+        return {"msg": "hi"}
+
+    def _bad_dispatch(_name: str, _args: dict) -> dict:
+        return {"count": 1}  # missing required "msg"
+
+    executor = PipelineExecutor()
+
+    ok_pipeline = Pipeline(
+        steps=[ToolStep(name="greet", args={}, output="g", schema="greeting_schema")]
+    )
+    ok_result = await executor.run(
+        ok_pipeline, None,
+        tool_dispatch=_ok_dispatch, state_log=None, run_id="run-schema-ok",
+        schema_registry=registry,
+    )
+    assert ok_result.pipe_data == {"msg": "hi"}
+
+    bad_pipeline = Pipeline(
+        steps=[ToolStep(name="greet", args={}, output="g", schema="greeting_schema")]
+    )
+    with pytest.raises(PipelineExecutionError):
+        await executor.run(
+            bad_pipeline, None,
+            tool_dispatch=_bad_dispatch, state_log=None, run_id="run-schema-bad",
+            schema_registry=registry,
+        )
+
+
+def _make_counting_dispatch(state_log: StateLog, call_counts: dict) -> "callable":
+    """A REAL side-effecting tool: each call appends a genuine WAL entry (the
+    step's side effect) before returning — so distinct steps land distinct
+    `state_log.last_durable_seq` values for the truncation test to exercise."""
+
+    async def _dispatch(name: str, args: dict) -> dict:
+        assert name == "echo"
+        call_counts["count"] += 1
+        await state_log.append("inbox_put", n=call_counts["count"])
+        return {"value": args["val"], "call": call_counts["count"]}
+
+    return _dispatch
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_generation_survives_wal_truncation_below_its_seq(tmp_path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate. Run a pipeline through step K (a
+    real StateLog); truncate the WAL below step K's recorded generation seq;
+    `resume` must still reconstruct `named_stores`/`pipe_data` correctly and resume
+    at step K+1 WITHOUT re-executing steps <= K (proven via a call-counting
+    tool_dispatch). RED if pipeline recovery rode a truncatable WAL event instead
+    of a truncation-surviving generation FILE."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    call_counts = {"count": 0}
+    dispatch = _make_counting_dispatch(state_log, call_counts)
+
+    step0 = TransformStep(value="ctx.seed + 1", output="t0")
+    step1 = ToolStep(name="echo", args={"val": ExprRef("ctx.t0")}, output="t1")
+    step2 = ToolStep(name="echo", args={"val": ExprRef("pipe.value")}, output="t2")
+    step3 = ToolStep(name="echo", args={"val": ExprRef("pipe.value")}, output="t3")
+
+    executor = PipelineExecutor()
+    phase1 = Pipeline(steps=[step0, step1, step2])  # run through step K=2 (0-indexed)
+    phase1_result = await executor.run(
+        phase1, {"seed": 10},
+        tool_dispatch=dispatch, state_log=state_log, run_id="run-truncate",
+    )
+    await state_log.flush()
+    assert phase1_result.step_index == 3
+    assert call_counts["count"] == 2, "steps 1 and 2 each made exactly one tool call"
+
+    # the two tool steps' side effects (WAL appends) landed at seq 1 and 2 —
+    # step K=2's generation is keyed at seq 2.
+    seq_after_phase1 = state_log.current_seq
+    assert seq_after_phase1 == 2
+
+    # the WAL head climbs well past the generation's key seq (simulating other
+    # agents' activity advancing the retention floor).
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+
+    # GC truncates the WAL below floor 40 — seq 1 and 2 (step K's own WAL
+    # entries) are dropped from wal.jsonl.
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    stats = state_log.last_truncate_stats
+    assert stats["dropped"] >= 2, "the early tool-step WAL entries must be truncated"
+    surviving_seqs = {e["seq"] for e in state_log.iter_from(0)}
+    assert 1 not in surviving_seqs and 2 not in surviving_seqs, (
+        "step K's own WAL entries are gone from the WAL — the generation FILE, "
+        "not a WAL event, must be what resume reconstructs from"
+    )
+
+    full_pipeline = Pipeline(steps=[step0, step1, step2, step3])
+    resumed = await executor.resume(
+        "run-truncate", pipeline=full_pipeline,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+
+    assert call_counts["count"] == 3, (
+        "steps 0-2 must NOT be re-executed on resume (exactly-once) — only step 3 "
+        "(the first step with no recorded result) makes a new tool call"
+    )
+    assert resumed.step_index == 4
+    assert resumed.named_stores["t0"] == 11
+    assert resumed.named_stores["t1"] == {"value": 11, "call": 1}
+    assert resumed.named_stores["t2"] == {"value": 11, "call": 2}
+    assert resumed.named_stores["t3"] == {"value": 11, "call": 3}
+    assert resumed.pipe_data == resumed.named_stores["t3"]
+
+
+@pytest.mark.asyncio
+async def test_exactly_once_resume_does_not_replay_completed_tool_side_effect(tmp_path):
+    """Tier 2: a crash immediately after a tool step completes (before advancing)
+    must not re-run that tool's side effect on resume — its result comes from the
+    step-boundary generation snapshot, not re-execution."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    call_counts = {"count": 0}
+    dispatch = _make_counting_dispatch(state_log, call_counts)
+
+    step0 = ToolStep(name="echo", args={"val": 1}, output="a")
+    step1 = ToolStep(name="echo", args={"val": 2}, output="b")
+
+    executor = PipelineExecutor()
+    # simulate a crash after step0 completes: only step0 is in the run pipeline.
+    crashed_result = await executor.run(
+        Pipeline(steps=[step0]), None,
+        tool_dispatch=dispatch, state_log=state_log, run_id="run-exactly-once",
+    )
+    await state_log.flush()
+    assert crashed_result.step_index == 1
+    assert call_counts["count"] == 1
+
+    resumed = await executor.resume(
+        "run-exactly-once", pipeline=Pipeline(steps=[step0, step1]),
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+
+    assert call_counts["count"] == 2, "step0 must not be re-run; only step1 is new"
+    assert resumed.named_stores["a"] == {"value": 1, "call": 1}
+    assert resumed.named_stores["b"] == {"value": 2, "call": 2}
+    assert resumed.step_index == 2
+
+
+@pytest.mark.asyncio
+async def test_resume_with_no_snapshot_runs_from_scratch(tmp_path):
+    """Tier 2: `resume` on a run_id with no recorded generation behaves as
+    run-from-scratch (the no-snapshot-yet contract)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    executor = PipelineExecutor()
+    pipeline = Pipeline(steps=[TransformStep(value="1 + 1", output="two")])
+
+    result = await executor.resume(
+        "never-run-before", pipeline=pipeline,
+        tool_dispatch=lambda *_a, **_k: None, state_log=state_log,
+    )
+
+    assert result.pipe_data == 2
+    assert result.named_stores == {"two": 2}


### PR DESCRIPTION
**[lead-sonnet]** — part of the Reyn Pipeline feature (v0.9 R3/R4).

The core-loop + crash-recovery vertical-slice. **Linear-only by design** (transform/tool steps); agent steps, non-linear primitives, the YAML parser, and driver-as-session integration are deferred to later slices. Consumes the merged `core/pipeline/{expr,schema}`.

## R3 — pipe-data threading
Each step's context = `{ctx: named_stores, pipe: pipe_data}`. `transform.value` evaluated via the real `expr.evaluate_expr`; `tool` args are literals unless wrapped `ExprRef(src)` (slice-internal; the future YAML parser maps `{ctx...}` templates to this). A step's return value → next `pipe_data` + `output:NAME` named store if declared. `verify: schema` via the real `schema.validate`.

## R4 — step-boundary recovery (exactly-once)
`core/events/pipeline_recovery.py`: `record_pipeline_state` writes full `{run_id, step_index, named_stores, pipe_data, completed_step_results}` as a generation file at `.reyn/pipeline/state/<run_id>/generations/gen-<seq>.json`, keyed at `state_log.last_durable_seq` — mirrors `config_recovery` exactly (truncation-surviving, not a truncatable WAL event). Recorded after each step, before advancing; side-effecting tool steps use the awaited durable path. `resume` loads the latest active-branch snapshot and starts the loop at the recorded `step_index` — completed steps are **structurally never re-entered** (exactly-once by construction).

## Test plan
- [x] ruff · [x] tier-audit 5/5 · [x] module-docstrings · [x] full pytest (0 new failures)
- [x] R3 threading (transform→tool→transform, named stores)
- [x] verify:schema (conforming/non-conforming)
- [x] **truncate-falsify** — truncate WAL below a tool step's snapshot seq → resume reconstructs + does NOT re-invoke the tool
- [x] exactly-once (tool call-count = 1 across crash+resume)