### PR TITLE
refactor(pipeline-a2): programmatic spawn_ephemeral_session for non-LLM callers

### DIFF
--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -1,0 +1,44 @@
+"""Programmatic session-spawn entry point for non-LLM callers.
+
+``AgentRegistry.spawn_session_recorded`` is the clean action-layer seam behind
+``session_spawn`` (the LLM tool): it spawns a fresh-context session, persists +
+enforces any capability narrowing, and emits the rewind-tracked
+``session_spawned`` WAL event. The LLM tool path reaches it only through
+``RouterCallerState.spawn_session_fn``, a closure the router loop builds — so a
+deterministic, non-LLM caller (e.g. a Pipeline executor's ``agent`` step) has no
+router-free way in.
+
+``spawn_ephemeral_session`` closes that gap: it calls the SAME
+``spawn_session_recorded`` primitive directly, with no ``RouterLoopHost`` /
+``RouterCallerState`` / router-loop involvement at all — just a registry and a
+target identity. It hardcodes ``mode="ephemeral"`` (the only mode a
+programmatic driver needs today) and returns the new session id. Turn/token
+budgeting for spawned sessions is a separate, harder mechanism (per-session
+``max_turns``) and is deliberately out of scope here.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.runtime.registry import AgentRegistry
+
+
+async def spawn_ephemeral_session(
+    registry: "AgentRegistry", *, identity: str, narrowing: "dict | None" = None,
+) -> str:
+    """Spawn an ephemeral session under ``identity`` for a non-LLM caller.
+
+    Thin, direct wrapper over ``registry.spawn_session_recorded(identity,
+    mode="ephemeral", narrowing=narrowing)`` — the same call the
+    ``session_spawn`` tool's handler reaches via ``spawn_session_fn``, so the
+    emitted ``session_spawned`` WAL event + the spawned session's narrowing
+    enforcement are byte-identical to the tool path. Returns the new session id
+    (the ``session_spawned`` event's ``sid``).
+
+    No task is submitted here — that stays the caller's job (the Pipeline
+    executor's ``agent`` step, in the eventual wiring), same as the S1bc
+    action-layer seam does not submit either."""
+    return await registry.spawn_session_recorded(
+        identity, mode="ephemeral", narrowing=narrowing,
+    )

--- a/tests/test_pipeline_a2_spawn_ephemeral_session.py
+++ b/tests/test_pipeline_a2_spawn_ephemeral_session.py
@@ -1,0 +1,123 @@
+"""Tier 2: pipeline-A2 — spawn_ephemeral_session, a programmatic non-LLM seam.
+
+``spawn_ephemeral_session`` (``runtime/session_api.py``) wraps the SAME
+``AgentRegistry.spawn_session_recorded`` primitive the ``session_spawn`` LLM tool
+reaches via ``RouterCallerState.spawn_session_fn`` — but calls it directly, with
+no ``RouterLoopHost`` / ``RouterCallerState`` / router-loop object anywhere on
+the path. These tests assert gate-equivalence (same WAL event shape, same
+narrowing enforcement) against the existing tool-path tests
+(``tests/test_2103_s1bc_session_spawn_tool.py``), plus the router-free property
+that is the whole point of this seam.
+
+Real AgentRegistry + real Session factory + real StateLog (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import spawn_ephemeral_session
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile) -> Session:
+        return Session(agent_name=profile.name, state_log=state_log)
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    reg.create("worker")
+    return reg
+
+
+# ── gate-equivalence: same WAL event shape as the tool path ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_ephemeral_session_emits_config_complete_event(tmp_path: Path) -> None:
+    """Tier 2: spawn_ephemeral_session emits a config-complete session_spawned WAL
+    event (entity_kind/name/sid/mode="ephemeral") — the identical event shape
+    ``reg.spawn_session_recorded`` emits for the LLM tool path."""
+    reg = _registry(tmp_path)
+    sid = await spawn_ephemeral_session(reg, identity="worker")
+    ev = next(
+        e for e in reg.state_log.iter_from(0)
+        if e.get("kind") == "session_spawned" and e.get("sid") == sid
+    )
+    assert ev["entity_kind"] == "session"
+    assert ev["name"] == "worker"
+    assert ev["mode"] == "ephemeral"
+    # the session is registered + reachable via the same public surface the tool
+    # path's spawned session is reachable through.
+    assert reg.get_session("worker", sid) is not None
+
+
+# ── programmatic: no RouterLoopHost / RouterCallerState anywhere ────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_ephemeral_session_works_with_no_router_state(tmp_path: Path) -> None:
+    """Tier 2: the whole point — a plain non-LLM caller with only an
+    AgentRegistry reaches the primitive. No RouterLoopHost / RouterCallerState /
+    ToolContext is constructed anywhere in this test, and session_api.py imports
+    neither at module scope (grep-checked below)."""
+    reg = _registry(tmp_path)
+    sid = await spawn_ephemeral_session(reg, identity="worker")
+    assert isinstance(sid, str) and sid
+
+
+def test_session_api_module_has_no_router_loop_import() -> None:
+    """Tier 2: session_api.py's import statements do not name router_loop /
+    RouterCallerState / ToolContext — the programmatic seam is structurally
+    decoupled from the router loop (not merely by prose convention). Parses
+    only the ``import``/``from ... import`` nodes so a doc-comment mentioning
+    these names (to explain what the seam bypasses) doesn't false-fail."""
+    import ast
+
+    import reyn.runtime.session_api as mod
+
+    tree = ast.parse(Path(mod.__file__).read_text(encoding="utf-8"))
+    imported_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_names.update(a.name for a in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_names.add(node.module)
+            imported_names.update(a.name for a in node.names)
+    assert not any("router_loop" in n for n in imported_names)
+    assert "RouterCallerState" not in imported_names
+    assert "ToolContext" not in imported_names
+
+
+# ── narrowing applied: reuses the existing ⊆-parent enforcement ─────────────
+
+
+@pytest.mark.asyncio
+async def test_spawn_ephemeral_session_narrowing_applied(tmp_path: Path) -> None:
+    """Tier 2: narrowing passed to spawn_ephemeral_session is persisted + enforced
+    on the LIVE spawned session — the identical #2126 re-inject the tool path
+    exercises, reached via the programmatic seam instead of the tool handler."""
+    reg = _registry(tmp_path)
+    sid = await spawn_ephemeral_session(
+        reg, identity="worker", narrowing={"tool_deny": ["delete_file"]},
+    )
+    session = reg.get_session("worker", sid)
+    effective = session._effective_contextual_for_turn()
+    assert effective is not None, (
+        "narrowing passed through spawn_ephemeral_session must be enforced on "
+        "the live session (⊆-parent), not merely persisted to config.yaml"
+    )
+    assert {"delete_file", "file__delete"} <= effective.tool_deny
+
+
+@pytest.mark.asyncio
+async def test_spawn_ephemeral_session_no_narrowing_is_inert(tmp_path: Path) -> None:
+    """Tier 2: no narrowing → the per-session capability layer stays inert
+    (byte-identical to the no-narrowing tool-path case)."""
+    reg = _registry(tmp_path)
+    sid = await spawn_ephemeral_session(reg, identity="worker")
+    assert reg.resolved_profile_for("worker", sid=sid) == (None, frozenset())


### PR DESCRIPTION
**[lead-sonnet]** — A2 from `docs/proposals/reyn-pipeline-refactor-plan.md` (Mechanism 1 / PR breakdown). Adds a clean programmatic entry point so a non-LLM caller (the Pipeline executor's upcoming `agent` steps) can spawn an ephemeral session without going through the router loop / the `session_spawn` LLM tool.

## What
- New `src/reyn/runtime/session_api.py::spawn_ephemeral_session(registry, *, identity, narrowing=None) -> str`.
- Thin, direct wrapper over `AgentRegistry.spawn_session_recorded(identity, mode="ephemeral", narrowing=narrowing)` (`src/reyn/runtime/registry.py:2537`) — the SAME primitive the `session_spawn` LLM tool reaches via `RouterCallerState.spawn_session_fn` → `RouterHostAdapter.spawn_session` (`src/reyn/runtime/services/router_host_adapter.py:921`).
- No fork of the spawn logic, no budget/`max_turns` (deferred to C1), no Pipeline-executor wiring (next slice) — this PR is the seam only.
- `spawn_session_recorded`'s current signature on main matches the audit exactly: `async def spawn_session_recorded(self, name: str, *, mode: str = "persistent", narrowing: dict | None = None) -> str` — no delta to note. It auto-generates the sid internally (`spawn_session`'s `uuid4().hex[:8]`), so there is no caller-supplied-sid parameter to thread through.

## Bypasses RouterLoopHost — confirmed
`session_api.py` imports only `reyn.runtime.registry.AgentRegistry` (TYPE_CHECKING-only) — no `router_loop`, `RouterCallerState`, or `ToolContext` anywhere on the import graph. A dedicated test parses the module's AST import nodes to assert this structurally (not just by prose), and another test spawns a session with nothing but a bare `AgentRegistry` (no host/router objects constructed at all).

## Gate-equivalence approach
New tests in `tests/test_pipeline_a2_spawn_ephemeral_session.py` mirror the existing tool-path tests in `tests/test_2103_s1bc_session_spawn_tool.py` (real `AgentRegistry` + real `Session` factory + real `StateLog`, no mocks):
- Same `session_spawned` WAL event shape (`entity_kind="session"`, `name`, `sid`, `mode="ephemeral"`).
- Same narrowing enforcement (`{"tool_deny": ["delete_file"]}` → live session's `_effective_contextual_for_turn()` denies both `delete_file` and the qualified `file__delete`), reusing the existing #2126 re-inject path unchanged.
- Same inert-when-no-narrowing behavior (`resolved_profile_for(sid=sid) == (None, frozenset())`).

## Gates
- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_a2_spawn_ephemeral_session.py` — 5/5 OK, 0 errors.
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session_api.py tests/test_pipeline_a2_spawn_ephemeral_session.py` — OK.
- Full `pytest` from repo root: **`10 failed, 6932 passed, 30 skipped, 11 warnings, 10 errors in 102.99s`**. Verified by stashing this PR's changes and re-running the exact same 10 failed + 10 error tests against unmodified `origin/main` — byte-identical failure set (all pre-existing mcp/uvicorn/a2a infra failures: `test_fp0001_a2a_endpoints`, `test_fp0016_e_agent_id`, `test_mcp_structured_client_p1`, `test_web_ws_max_size_config_1934`, `web/test_a2a`, `web/test_plugin_loader`, `web/test_resources_router`, `test_config_mcp_headers`, `test_mcp_client`). Zero new failures introduced by this change.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_a2_spawn_ephemeral_session.py`
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session_api.py tests/test_pipeline_a2_spawn_ephemeral_session.py`
- [x] Full `pytest` from repo root — confirmed 0 new failures vs origin/main baseline