### PR TITLE
feat(pipeline): run_agent_step — spawn+run+collect ephemeral session for agent steps (R5)

### DIFF
--- a/src/reyn/runtime/errors.py
+++ b/src/reyn/runtime/errors.py
@@ -27,3 +27,17 @@ class RouterCapExceeded(Exception):
         self.count = count
         self.cap = cap
         self.last_reason = last_reason
+
+
+class AgentStepError(Exception):
+    """Raised by ``session_api.run_agent_step`` (R5: agent-step run+collect).
+
+    Covers every way the collected output of a spawned ephemeral session's
+    turn fails to become the caller's requested result: the spawn's session
+    id resolved to no live ``Session`` (mis-wired registry), the collected
+    text is not valid JSON under a declared ``schema``, or the parsed JSON
+    fails ``core.pipeline.schema.validate`` against that schema. In the
+    eventual Pipeline executor this is an ordinary step failure (→ the
+    step's retry/error path), not a construction-time / programming error.
+    """
+

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -1,4 +1,4 @@
-"""Programmatic session-spawn entry point for non-LLM callers.
+"""Programmatic session-spawn + run+collect entry points for non-LLM callers.
 
 ``AgentRegistry.spawn_session_recorded`` is the clean action-layer seam behind
 ``session_spawn`` (the LLM tool): it spawns a fresh-context session, persists +
@@ -15,13 +15,54 @@ target identity. It hardcodes ``mode="ephemeral"`` (the only mode a
 programmatic driver needs today) and returns the new session id. Turn/token
 budgeting for spawned sessions is a separate, harder mechanism (per-session
 ``max_turns``) and is deliberately out of scope here.
+
+``run_agent_step`` (R5: agent-step run+collect,
+``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``) composes THREE
+existing primitives — it adds no new session/LLM machinery of its own:
+
+  1. ``spawn_ephemeral_session`` (above) — spawn the leaf worker, with a
+     narrowing that STRUCTURALLY denies delegation (see
+     ``_build_agent_step_narrowing``): an ``agent`` step must not itself
+     delegate mid-turn, because ``MessageBus.request``'s quiescence
+     predicate only checks ``inbox.empty()`` — a mid-turn ``delegate_to_agent``
+     would make it return early on a pending chain the spawned session is
+     still awaiting a reply for.
+  2. ``MessageBus.request`` (``runtime/message_bus.py``) — the existing
+     synchronous run+collect: put a ``user`` message on the spawned
+     session's inbox, pump ``run_one_iteration`` on the caller's own task
+     until quiescent, and return every ``OutboxMessage`` emitted during the
+     turn. The ephemeral session self-vanishes via
+     ``_maybe_schedule_ephemeral_vanish`` once the turn leaves it quiescent
+     with no pending chains — no explicit close needed here.
+  3. ``core.pipeline.schema.validate`` — when the caller declares a
+     ``schema``, the joined ``kind="agent"`` reply text is JSON-parsed
+     defensively and validated post-hoc (exactly the executor's
+     ``ToolStep`` pattern — there is no schema-constrained *generation* in
+     the router path today).
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from reyn.runtime.errors import AgentStepError
+from reyn.runtime.transport import SystemRef
 
 if TYPE_CHECKING:
+    from reyn.core.pipeline.schema import SchemaRegistry
     from reyn.runtime.registry import AgentRegistry
+
+# Tool names that let a session hand a turn off to a peer / sub-session mid-run
+# (a pending chain / async dispatch the caller's inbox-emptiness check cannot
+# see). ``_expand_tool_forms`` (capability_profile.py) derives every invocable
+# alias (bare + qualified) from each name here, so listing the bare tool name
+# is sufficient — the qualified catalog form is covered too.
+_DELEGATION_DENY_TOOLS: tuple[str, ...] = ("delegate_to_agent",)
+
+# MessageBus.request has no default — an agent step needs one so callers
+# aren't forced to pick a number for the common case.
+_DEFAULT_AGENT_STEP_TIMEOUT_S: float = 120.0
 
 
 async def spawn_ephemeral_session(
@@ -42,3 +83,100 @@ async def spawn_ephemeral_session(
     return await registry.spawn_session_recorded(
         identity, mode="ephemeral", narrowing=narrowing,
     )
+
+
+def _build_agent_step_narrowing(capabilities: "list[str] | None") -> dict:
+    """The per-session narrowing an ``agent`` step spawns under.
+
+    ``tool_deny`` always includes ``_DELEGATION_DENY_TOOLS`` — a v1
+    structural constraint (R5), not something the caller's ``capabilities``
+    can re-open: ``capability_profile`` resolution is deny-always-wins
+    (``profile_permits``: ``in_allow and tool not in tool_deny``), so even a
+    ``capabilities`` list that names a delegation tool is denied at the live
+    gate. ``tool_allow`` is set only when the caller passes an explicit
+    ``capabilities`` list — omitting it (``None``) leaves the agent's normal
+    envelope untouched (restrict-only narrowing, never a re-grant)."""
+    narrowing: dict[str, Any] = {"tool_deny": list(_DELEGATION_DENY_TOOLS)}
+    if capabilities is not None:
+        narrowing["tool_allow"] = list(capabilities)
+    return narrowing
+
+
+async def run_agent_step(
+    registry: "AgentRegistry",
+    *,
+    identity: str,
+    prompt: str,
+    capabilities: "list[str] | None" = None,
+    schema: "str | None" = None,
+    schema_registry: "SchemaRegistry | None" = None,
+    chain_id: "str | None" = None,
+    timeout: "float | None" = None,
+) -> Any:
+    """Spawn an ephemeral session, run one turn, collect + return its output.
+
+    The future Pipeline executor's ``agent`` step primitive (R5): spawn a
+    leaf-worker session under ``identity`` (capability-narrowed to
+    ``capabilities`` plus a structural delegation deny, see
+    ``_build_agent_step_narrowing``), feed it ``prompt`` as a single ``user``
+    turn via ``MessageBus.request``, and return its collected reply.
+
+    With ``schema`` unset, returns the joined ``kind="agent"`` reply text
+    verbatim. With ``schema`` set (a name registered in ``schema_registry``),
+    the text is JSON-parsed and validated against it; the parsed + validated
+    value is returned. A ``schema`` without a ``schema_registry``, non-JSON
+    text, or a schema-non-conforming value each raise ``AgentStepError`` — a
+    normal step failure for the executor's retry/error path, not a
+    construction-time error.
+
+    ``chain_id`` defaults to a fresh uuid4 hex (mirrors ``MessageBus``'s own
+    ``_new_request_id``). ``timeout`` defaults to
+    ``_DEFAULT_AGENT_STEP_TIMEOUT_S`` seconds.
+    """
+    from reyn.core.pipeline.schema import validate
+    from reyn.runtime.message_bus import MessageBus
+
+    narrowing = _build_agent_step_narrowing(capabilities)
+    sid = await spawn_ephemeral_session(registry, identity=identity, narrowing=narrowing)
+    session = registry.get_session(identity, sid)
+    if session is None:
+        raise AgentStepError(
+            f"run_agent_step: spawn_ephemeral_session({identity!r}) returned "
+            f"sid={sid!r}, but registry.get_session({identity!r}, {sid!r}) "
+            "found no live session — the registry's session_factory may not "
+            "register the spawned session under its own name/sid."
+        )
+
+    bus = MessageBus()
+    replies = await bus.request(
+        session,
+        kind="user",
+        payload={"text": prompt, "chain_id": chain_id or uuid.uuid4().hex},
+        reply_to=SystemRef(),
+        timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,
+    )
+    text = "\n\n".join(r.text for r in replies if r.kind == "agent")
+
+    if schema is None:
+        return text
+
+    if schema_registry is None:
+        raise AgentStepError(
+            f"run_agent_step(schema={schema!r}) requires schema_registry "
+            "(no registry to validate against)."
+        )
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise AgentStepError(
+            f"run_agent_step(schema={schema!r}): agent step output is not "
+            f"valid JSON: {exc}. Output: {text!r}"
+        ) from exc
+    result = validate(parsed, schema, schema_registry)
+    if not result.conforming:
+        details = "; ".join(f"{e.path or '<root>'}: {e.message}" for e in result.errors)
+        raise AgentStepError(
+            f"run_agent_step(schema={schema!r}): agent step output does not "
+            f"conform to schema: {details}"
+        )
+    return parsed

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -1,0 +1,251 @@
+"""Tier 2c: pipeline-R5 — run_agent_step, the agent-step run+collect primitive.
+
+``run_agent_step`` (``runtime/session_api.py``) composes
+``spawn_ephemeral_session`` + ``MessageBus.request`` + ``core.pipeline.schema.
+validate`` — real ``AgentRegistry`` / ``Session`` / ``RouterLoop`` /
+``MessageBus`` throughout. The ONLY faked collaborator is the LLM completion
+call itself, injected via ``RouterLoop``'s designed ``_llm_caller`` Tier-2
+test seam (``router_loop.py``), reached through ``RouterLoopDriver``'s
+``_loop_observer`` seam (``router_loop_driver.py``) on the session's
+ALREADY-CONSTRUCTED ``_loop_driver`` — a post-construction observer, not a
+factory-seam bypass (every other Session collaborator: router host, history
+buffer, budget advisor, dispatch, permission gate, is the real production
+object; see ``test_execution_driver_seam.py`` for the same seam's own
+invariant tests).
+
+Per ``docs/deep-dives/contributing/testing.md``, this is Tier 2c ("Multi-
+component integration ... LLM is faked via a stub real callable NOT via
+LLMReplay — that path is Tier 3"), not Tier 3: Tier 3 today is scoped to
+Tier 3a (single LLM call replay); a full router turn through a real Session
+(system prompt + tool catalog + history) is Tier 3b, explicitly deferred
+pending the CLI/ChatSession-driver redesign. The LLM's actual content here is
+incidental to what's under test (the run+collect composition), which is
+exactly Tier 2c's carve-out — a real recorded ``LLMReplay`` fixture would
+also embed the live host clock (``get_environment_info()``'s ``date``) into
+its cache key, breaking replay across days.
+
+``_ScriptedAgentReply`` is a concrete class with a typed ``__call__`` (NOT
+``unittest.mock.MagicMock``/``AsyncMock``/``patch``) — a signature drift in
+the ``call_llm_tools`` contract it stands in for raises ``TypeError`` here
+exactly as it would in production.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.errors import AgentStepError
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import (
+    _build_agent_step_narrowing,
+    run_agent_step,
+    spawn_ephemeral_session,
+)
+
+# ── real-callable LLM stub (Tier 2c: LLM is incidental) ─────────────────────
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text/JSON turn (no tool_calls) —
+    the RouterLoop's enumerate-all scheme classifies empty ``tool_calls`` as
+    ``PlainText`` (``schemes/enumerate_all.py``), so the OS emits ``content``
+    to the outbox and stops; no LLM signature is bypassed."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(),
+        )
+
+
+def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors
+    ``test_pipeline_a2_spawn_ephemeral_session.py`` / ``test_2103_A_...``'s
+    ``holder`` deferred-registry-ref trick so the factory can pass
+    ``registry=`` for ephemeral auto-vanish). When ``scripted`` is given, every
+    constructed session's real ``RouterLoopDriver`` gets the scripted LLM
+    wired in via ``_loop_observer`` before the driver's first turn."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+# ── run+collect happy path ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_returns_reply_text(tmp_path: Path) -> None:
+    """Tier 2c: run_agent_step spawns an ephemeral session, runs one turn,
+    and returns the plain-text reply verbatim (no schema declared)."""
+    scripted = _ScriptedAgentReply("hello from the leaf worker")
+    reg = _registry(tmp_path, scripted)
+
+    result = await run_agent_step(reg, identity="worker", prompt="say hi")
+
+    assert result == "hello from the leaf worker"
+    assert scripted.calls == 1
+
+
+# ── structured output: success ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_schema_success_returns_parsed_value(tmp_path: Path) -> None:
+    """Tier 2c: with schema= set, JSON text conforming to the registered
+    schema is parsed + validated, and the PARSED value (not raw text) is
+    returned."""
+    scripted = _ScriptedAgentReply('{"verdict": "approve", "confidence": 0.9}')
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", {
+        "fields": {
+            "verdict": {"type": "enum", "values": ["approve", "reject"], "required": True},
+            "confidence": {"type": "number", "required": True},
+        },
+    })
+
+    result = await run_agent_step(
+        reg, identity="worker", prompt="review this",
+        schema="review", schema_registry=schema_registry,
+    )
+
+    assert result == {"verdict": "approve", "confidence": 0.9}
+
+
+# ── structured output: malformed JSON ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_schema_malformed_json_raises(tmp_path: Path) -> None:
+    """Tier 2c: schema declared but the agent's reply text is not JSON at
+    all → AgentStepError (a normal step failure), not a bare JSONDecodeError
+    or a silent pass-through of the raw text."""
+    scripted = _ScriptedAgentReply("Sure — looks good to me!")
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", {
+        "fields": {"verdict": {"type": "string", "required": True}},
+    })
+
+    with pytest.raises(AgentStepError):
+        await run_agent_step(
+            reg, identity="worker", prompt="review this",
+            schema="review", schema_registry=schema_registry,
+        )
+
+
+# ── structured output: schema non-conformance ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_schema_nonconforming_raises(tmp_path: Path) -> None:
+    """Tier 2c: valid JSON that does NOT conform to the declared schema
+    (missing the required field) → AgentStepError, not a silently-accepted
+    partial value."""
+    scripted = _ScriptedAgentReply('{"unexpected": 123}')
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", {
+        "fields": {"verdict": {"type": "string", "required": True}},
+    })
+
+    with pytest.raises(AgentStepError):
+        await run_agent_step(
+            reg, identity="worker", prompt="review this",
+            schema="review", schema_registry=schema_registry,
+        )
+
+
+# ── delegation forbidden (structural — no LLM turn needed) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_narrowing_denies_delegation_when_spawned(tmp_path: Path) -> None:
+    """Tier 2: OS invariant — the SAME narrowing run_agent_step builds
+    (``_build_agent_step_narrowing``), spawned via ``spawn_ephemeral_session``,
+    is LIVE-enforced (``registry.resolved_profile_for``) to deny
+    ``delegate_to_agent`` (+ its qualified ``multi_agent__delegate`` alias)
+    even when the caller's own ``capabilities`` list explicitly names it —
+    ``capability_profile`` resolution is deny-always-wins
+    (``profile_permits``), so an ``agent`` step cannot re-open delegation via
+    its ``capabilities`` argument. Purely structural: no LLM turn / actual
+    delegation attempt needed to prove the gate."""
+    reg = _registry(tmp_path, scripted=None)
+    narrowing = _build_agent_step_narrowing(["delegate_to_agent", "file__read"])
+
+    sid = await spawn_ephemeral_session(reg, identity="worker", narrowing=narrowing)
+    contextual, _excluded = reg.resolved_profile_for("worker", sid=sid)
+
+    assert contextual is not None
+    assert {"delegate_to_agent", "multi_agent__delegate"} <= contextual.tool_deny
+
+
+def test_build_agent_step_narrowing_no_capabilities_is_restrict_only(tmp_path: Path) -> None:
+    """Tier 2: OS invariant — omitting ``capabilities`` (None) leaves
+    ``tool_allow`` unset (no re-grant beyond the agent's normal envelope);
+    only the delegation deny is imposed. Pure function, no session needed."""
+    narrowing = _build_agent_step_narrowing(None)
+    assert "tool_allow" not in narrowing
+    assert narrowing["tool_deny"] == ["delegate_to_agent"]
+
+
+# ── ephemeral cleanup ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_ephemeral_session_vanishes(tmp_path: Path) -> None:
+    """Tier 2c: after run_agent_step completes, the ephemeral session it
+    spawned is torn down (public ``registry.session_ids`` surface) — R5's
+    "close" step (self-vanish via ``_maybe_schedule_ephemeral_vanish``, fired
+    automatically at the end of the turn's ``run_one_iteration``) needs no
+    explicit call from ``run_agent_step`` itself.
+
+    Mirrors ``test_2103_A_ephemeral_auto_vanish_1953.py``'s precedent of
+    awaiting the scheduled (but not yet run) detached teardown task before
+    asserting — without this, a synchronous check right after
+    ``run_agent_step`` returns could race the vanish and see the session
+    still present, hiding a regression either way."""
+    scripted = _ScriptedAgentReply("done")
+    reg = _registry(tmp_path, scripted)
+
+    result = await run_agent_step(reg, identity="worker", prompt="say bye")
+    assert result == "done"
+
+    # Tuple-unpack (not a size check): raises ValueError itself if
+    # run_agent_step spawned zero or more than one non-main session —
+    # behavioral, not a format/size pin.
+    (spawned_sid,) = [sid for sid in reg.session_ids("worker") if sid != "main"]
+    spawned = reg._peek_session("worker", spawned_sid)  # noqa: SLF001 — test-bridge, precedent above
+    if spawned is not None:
+        vanish_task = spawned._vanish_task  # noqa: SLF001 — test-bridge, precedent above
+        if vanish_task is not None:
+            await vanish_task
+
+    assert spawned_sid not in reg.session_ids("worker")


### PR DESCRIPTION
**[lead-sonnet]** — Adds `run_agent_step` (`src/reyn/runtime/session_api.py`), the programmatic run+collect primitive the future Pipeline executor's `agent` steps will use, per R5 of `docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`.

## Summary

`run_agent_step(registry, *, identity, prompt, capabilities=None, schema=None, schema_registry=None, chain_id=None, timeout=None)` is a thin composition over three existing primitives — no new session/LLM machinery:

1. **`spawn_ephemeral_session`** (A2) — spawns the leaf worker under a narrowing (`_build_agent_step_narrowing`) that **structurally denies delegation**: `tool_deny` always includes `delegate_to_agent` (+ its qualified `multi_agent__delegate` alias, via `capability_profile`'s bidirectional `_expand_tool_forms`), regardless of what the caller's `capabilities` allow-list names — `capability_profile` resolution is deny-always-wins (`profile_permits`). This closes R5's v1 risk: `MessageBus.request`'s quiescence predicate only checks `inbox.empty()`, so a mid-turn `delegate_to_agent` would make it return early on a pending chain the leaf worker is still awaiting a reply for.
2. **`MessageBus.request(session, kind="user", payload={...}, reply_to=SystemRef(), timeout=...)`** — runs one turn and collects every `OutboxMessage`; the joined `kind="agent"` text is the reply. Reused the existing `SystemRef` `TransportRef` variant ("internal OS message with no external sender") as the bare/no-transport reply_to — no new `TransportRef` variant needed.
3. **`core.pipeline.schema.validate`** — when the caller declares `schema`, the joined text is JSON-parsed defensively and validated post-hoc against the registered schema (the same pattern the executor's `ToolStep` already uses — no schema-constrained *generation* in the router path). Both a JSON-parse failure and a schema-non-conformance raise the new `AgentStepError` (`src/reyn/runtime/errors.py`) — a normal step failure for the executor's future retry/error path, not a construction-time error.

## Deviation from the original design brief (worth flagging)

The brief called for Tier 3 (`LLMReplay`) tests. After reading `docs/deep-dives/contributing/testing.md`, a full router turn through a real `Session` (system prompt + tool catalog + history) is **Tier 3b — explicitly deferred** pending the CLI/`ChatSession`-driver redesign; today's Tier 3a scope is single isolated LLM calls only. A full-session `LLMReplay` fixture would also embed the live host clock (`RouterHostAdapter.get_environment_info()`'s `date` field) into its cache key, breaking replay determinism across days.

Per testing.md's own Tier 2c carve-out ("LLM is faked via a stub real callable... The LLM is the only collaborator that may be faked"), the tests use a real `Session`/`RouterLoop`/`MessageBus`/`AgentRegistry` throughout, with only the LLM completion faked via a concrete scripted class (`_ScriptedAgentReply`, not `MagicMock`/`AsyncMock`/`patch`) injected through `RouterLoop`'s designed `_llm_caller` Tier-2 test seam, reached via `RouterLoopDriver`'s `_loop_observer` seam on the session's already-constructed `_loop_driver` (a post-construction observer, matching the same seam `test_execution_driver_seam.py` exercises — not a factory bypass).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_r5_run_agent_step.py` — 7/7 OK, 0 Tier-4 violations
- [x] `pytest` (full suite, repo root) — 6939 passed, 10 failed, 10 errors, 30 skipped; failures/errors are the **pre-existing** mcp/uvicorn/a2a baseline (verified identical via `git stash` + re-run on bare `main`: same 10 failed + 10 errors, same test names). Zero new failures introduced.
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session_api.py src/reyn/runtime/errors.py` — OK
- [x] (skipped — no visual/manual surface: this is a backend runtime primitive with no CLI/UI/TUI output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)