### PR TITLE
feat(pipeline): wire agent steps into executor (run_agent_step + R3 threading + R4 replay)

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -2,10 +2,10 @@
 
 The thin vertical-slice executor for
 ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a **linear** sequence of
-``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell", ...)``) steps.
-Deliberately out of scope for this slice: `agent` steps, `for_each`/`parallel`/`fold`/
+``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell", ...)``) / ``agent``
+(R5) steps. Deliberately out of scope for this slice: `for_each`/`parallel`/`fold`/
 `match`/`call`/`refine`, the YAML DSL parser, and driver-as-session integration — those
-are later slices; this module proves the core loop + recovery only.
+are later slices; this module proves the core loop + recovery (+ agent-step wiring) only.
 
 **R3 (uniform pipe-data / output rule)**: every step produces exactly one return value.
 That value is simultaneously (1) the pipe data handed to the next step and (2) written
@@ -16,32 +16,42 @@ module never hand-rolls expression evaluation), evaluated against a context of
 named output and bare ``pipe`` reaches the immediately-preceding step's return value even
 when it had no ``output:``. A ``tool`` step's ``args`` may mark any value as an
 expression to resolve (rather than a literal) by wrapping it in :class:`ExprRef`; both
-resolve through the same context via the same evaluator.
+resolve through the same context via the same evaluator. An ``agent`` step's ``prompt``
+is a R5-spec ``TPL`` string — ``{ctx.NAME.field}`` / ``{pipe}`` references interpolated
+via :func:`_interpolate_prompt` (which reuses ``expr.evaluate_expr``'s ``Path``
+resolution for the dotted lookup — no second path-resolver) — then handed to
+:func:`reyn.runtime.session_api.run_agent_step` to spawn+run+collect; its return value
+is threaded exactly like the other step kinds.
 
 **R4 (step-boundary recovery)**: after each step completes (before advancing), the
 executor calls :func:`reyn.core.events.pipeline_recovery.record_pipeline_state` with the
 full control-plane state — ``{run_id, step_index, named_stores, pipe_data,
-completed_step_results}`` — keyed at the durable WAL head. Side-effecting ``tool`` steps
-use the awaited-durable path (narrowing the effect-done/snapshot-not-yet-durable crash
-window); pure ``transform`` steps use the non-blocking path. :meth:`PipelineExecutor.run`
-starts a run from scratch; :meth:`PipelineExecutor.resume` loads the latest recorded
-generation for a run and REPLAYS every step already present in
+completed_step_results}`` — keyed at the durable WAL head. Side-effecting ``tool``/
+``agent`` steps use the awaited-durable path (narrowing the effect-done/snapshot-not-yet-
+durable crash window); pure ``transform`` steps use the non-blocking path.
+:meth:`PipelineExecutor.run` starts a run from scratch; :meth:`PipelineExecutor.resume`
+loads the latest recorded generation for a run and REPLAYS every step already present in
 ``completed_step_results`` (not re-executing it — the exactly-once contract that keeps a
-crash from re-running a `tool` step's side effect), resuming live execution at the first
-step with no recorded result.
+crash from re-running a `tool` step's side effect, or an ``agent`` step's LLM turn and any
+tool side effects it made), resuming live execution at the first step with no recorded
+result.
 """
 from __future__ import annotations
 
 import inspect
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
-from reyn.core.pipeline.expr import ExprEvalError, evaluate_expr
+from reyn.core.pipeline.expr import ExprEvalError, ExprParseError, evaluate_expr
 from reyn.core.pipeline.schema import SchemaRegistry, validate
+from reyn.runtime.errors import AgentStepError
+from reyn.runtime.session_api import run_agent_step
 
 if TYPE_CHECKING:
     from reyn.core.events.state_log import StateLog
+    from reyn.runtime.registry import AgentRegistry
 
 # ---------------------------------------------------------------------------
 # Pipeline representation (pre-built dataclasses — no YAML parser in scope)
@@ -83,7 +93,27 @@ class ToolStep:
     schema: "str | None" = None
 
 
-Step = Union[TransformStep, ToolStep]
+@dataclass(frozen=True)
+class AgentStep:
+    """An LLM-driven step (R5): ``prompt`` (a ``TPL`` template — see
+    :func:`_interpolate_prompt`) is interpolated against the current context and handed
+    to :func:`reyn.runtime.session_api.run_agent_step`, which spawns an ephemeral
+    session under ``identity`` (``None`` = inherit the run's ``default_identity``, per
+    the design doc's "identity defaults to invoker"), runs one turn, and collects the
+    result — capability-narrowed to ``capabilities`` plus a structural delegation deny
+    (``run_agent_step``'s own contract; this step introduces no additional narrowing).
+    ``schema``, if set, names a ``SchemaRegistry``-registered schema the parsed JSON
+    reply must conform to — non-conformance fails the step exactly like a ``tool``
+    step's ``verify: schema``."""
+
+    prompt: str
+    identity: "str | None" = None
+    capabilities: "list[str] | None" = None
+    schema: "str | None" = None
+    output: "str | None" = None
+
+
+Step = Union[TransformStep, ToolStep, AgentStep]
 
 
 @dataclass(frozen=True)
@@ -118,6 +148,33 @@ class PipelineExecutionError(PipelineError):
 
 ToolDispatch = Callable[[str, "dict[str, Any]"], Any]
 
+_PROMPT_REF_RE = re.compile(r"\{([^{}]+)\}")
+
+
+def _interpolate_prompt(template: str, context: "dict[str, Any]") -> str:
+    """Resolve every ``{ctx.dotted.path}`` / ``{pipe}`` reference in an ``AgentStep``
+    prompt (R5 spec ``TPL``: "string with {item} {ctx.NAME.field} interpolation
+    (values only)") against ``context`` (the SAME ``{"ctx": named_stores, "pipe":
+    pipe_data}`` shape a ``transform``/``tool`` step resolves against). Each ``{...}``
+    reference is evaluated as a bare R1 ``expr`` source via ``evaluate_expr`` — reusing
+    its ``Path`` resolution for the dotted lookup rather than a second path-resolver —
+    NOT a full expression (no operators/combinators inside the braces; that keeps this
+    pure string interpolation, matching the spec's "values only"). A non-string value
+    is stringified for splicing into the prompt text. A missing path or malformed
+    reference raises :class:`PipelineExecutionError` naming the failing ``{...}``."""
+
+    def _sub(match: "re.Match[str]") -> str:
+        ref = match.group(1).strip()
+        try:
+            value = evaluate_expr(ref, context)
+        except (ExprEvalError, ExprParseError) as exc:
+            raise PipelineExecutionError(
+                f"prompt template reference {{{ref}}} could not be resolved: {exc}"
+            ) from exc
+        return value if isinstance(value, str) else str(value)
+
+    return _PROMPT_REF_RE.sub(_sub, template)
+
 
 # ---------------------------------------------------------------------------
 # Executor
@@ -137,10 +194,15 @@ class PipelineExecutor:
         state_log: "StateLog | None",
         run_id: str,
         schema_registry: "SchemaRegistry | None" = None,
+        registry: "AgentRegistry | None" = None,
+        default_identity: "str | None" = None,
     ) -> PipelineResult:
         """Run `pipeline` from the first step. `initial_context` seeds the named
         stores (``ctx.*``) available to the first step; there is no incoming pipe
-        data (``pipe`` resolves to ``None`` until the first step produces one)."""
+        data (``pipe`` resolves to ``None`` until the first step produces one).
+        `registry` (an `AgentRegistry`) and `default_identity` are required only if
+        `pipeline` contains an `AgentStep` — a pipeline with none never touches
+        either, so existing transform/tool-only callers are unaffected."""
         named_stores: "dict[str, Any]" = dict(initial_context) if initial_context else {}
         return await self._run_from(
             pipeline,
@@ -152,6 +214,8 @@ class PipelineExecutor:
             state_log=state_log,
             run_id=run_id,
             schema_registry=schema_registry,
+            registry=registry,
+            default_identity=default_identity,
         )
 
     async def resume(
@@ -162,9 +226,13 @@ class PipelineExecutor:
         tool_dispatch: ToolDispatch,
         state_log: "StateLog",
         schema_registry: "SchemaRegistry | None" = None,
+        registry: "AgentRegistry | None" = None,
+        default_identity: "str | None" = None,
     ) -> PipelineResult:
         """Resume `run_id`: load the latest recorded generation (R4) and replay every
-        step already in ``completed_step_results`` (no re-execution — exactly-once),
+        step already in ``completed_step_results`` (no re-execution — exactly-once —
+        this covers a completed ``AgentStep`` exactly like a completed ``tool`` step:
+        its recorded result replays from the snapshot, the LLM turn never re-runs),
         resuming live execution at the first step with no recorded result. With no
         snapshot at all, resume == run from scratch."""
         snapshot = latest_pipeline_state(run_id, state_log)
@@ -176,6 +244,8 @@ class PipelineExecutor:
                 state_log=state_log,
                 run_id=run_id,
                 schema_registry=schema_registry,
+                registry=registry,
+                default_identity=default_identity,
             )
         return await self._run_from(
             pipeline,
@@ -187,6 +257,8 @@ class PipelineExecutor:
             state_log=state_log,
             run_id=run_id,
             schema_registry=schema_registry,
+            registry=registry,
+            default_identity=default_identity,
         )
 
     async def _run_from(
@@ -201,6 +273,8 @@ class PipelineExecutor:
         state_log: "StateLog | None",
         run_id: str,
         schema_registry: "SchemaRegistry | None",
+        registry: "AgentRegistry | None" = None,
+        default_identity: "str | None" = None,
     ) -> PipelineResult:
         steps = pipeline.steps
         for i in range(start_index, len(steps)):
@@ -235,6 +309,34 @@ class PipelineExecutor:
                             f"{step.schema!r}: {validation.errors}"
                         )
                 durable = True
+            elif isinstance(step, AgentStep):
+                identity = step.identity or default_identity
+                if identity is None:
+                    raise PipelineExecutionError(
+                        f"step {i} (agent) has no identity and no default_identity "
+                        "was given to run/resume — the design doc's 'identity "
+                        "defaults to invoker' requires the caller to supply one"
+                    )
+                if registry is None:
+                    raise PipelineExecutionError(
+                        f"step {i} (agent) requires a registry (AgentRegistry) to "
+                        "spawn its session, but none was passed to run/resume"
+                    )
+                prompt = _interpolate_prompt(step.prompt, context)
+                try:
+                    result = await run_agent_step(
+                        registry,
+                        identity=identity,
+                        prompt=prompt,
+                        capabilities=step.capabilities,
+                        schema=step.schema,
+                        schema_registry=schema_registry,
+                    )
+                except AgentStepError as exc:
+                    raise PipelineExecutionError(
+                        f"step {i} (agent) failed: {exc}"
+                    ) from exc
+                durable = True
             else:  # pragma: no cover - Step is a closed union
                 raise PipelineExecutionError(f"unknown step type: {step!r}")
 
@@ -268,6 +370,7 @@ __all__ = [
     "ExprRef",
     "TransformStep",
     "ToolStep",
+    "AgentStep",
     "Step",
     "Pipeline",
     "PipelineResult",

--- a/tests/test_pipeline_r5_agent_step_executor.py
+++ b/tests/test_pipeline_r5_agent_step_executor.py
@@ -1,0 +1,365 @@
+"""Tier 2c: pipeline-R5 — AgentStep wired into PipelineExecutor.
+
+Covers the slice ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R5
+describes as the eventual wiring: an :class:`~reyn.core.pipeline.executor.AgentStep`
+composed into the linear executor's step loop, threading its result through R3
+(pipe-data / named-store) exactly like ``transform``/``tool`` steps, and covered by
+R4's step-boundary exactly-once replay on resume.
+
+Same real-collaborator discipline as ``test_pipeline_r5_run_agent_step.py``: a REAL
+``AgentRegistry``/``Session``/``MessageBus`` throughout; the ONLY faked collaborator
+is the LLM completion call, injected via the real ``RouterLoopDriver._loop_observer``
+seam with a concrete typed ``_ScriptedAgentReply`` (NOT ``unittest.mock``). See that
+file's module docstring for the full Tier-2c rationale (LLM content is incidental to
+what's under test — the run+collect *composition* into the executor).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    ExprRef,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+# ── real-callable LLM stub (Tier 2c: LLM is incidental — see module docstring) ──
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text/JSON turn (no tool_calls)."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop",
+            usage=TokenUsage(),
+        )
+
+
+def _registry(
+    tmp_path: Path, state_log: "StateLog", scripted: "_ScriptedAgentReply | None",
+) -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors
+    ``test_pipeline_r5_run_agent_step.py``'s ``holder`` deferred-registry-ref trick).
+    ``scripted`` (when given) wires the fixed LLM reply into every spawned session's
+    real ``RouterLoopDriver`` via ``_loop_observer``, before the driver's first turn."""
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+# ── agent step in a linear pipeline (R3 threading) ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_in_linear_pipeline_threads_pipe_data_and_named_store(
+    tmp_path: Path,
+) -> None:
+    """Tier 2c: transform -> agent -> transform. The agent step's scripted reply
+    flows as pipe-data (R3) into the next transform AND into its named store, read
+    by the downstream transform via ``ctx.NAME``."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("the leaf worker's answer")
+    reg = _registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="'topic: ' + ctx.topic", output="brief"),
+            AgentStep(prompt="{ctx.brief}", identity="worker", output="verdict"),
+            TransformStep(value="ctx.verdict + ' (reviewed)'", output="final"),
+        ]
+    )
+    executor = PipelineExecutor()
+
+    result = await executor.run(
+        pipeline, {"topic": "reyn pipelines"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-agent-linear",
+        registry=reg,
+    )
+
+    assert result.named_stores["verdict"] == "the leaf worker's answer"
+    assert result.pipe_data == "the leaf worker's answer (reviewed)"
+    assert scripted.calls == 1
+
+
+# ── prompt interpolation ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_prompt_interpolates_ctx_before_running(tmp_path: Path) -> None:
+    """Tier 2c: ``{ctx.NAME}`` in the prompt resolves to the store value BEFORE the
+    agent runs — proven by having the scripted reply echo the resolved prompt text
+    it was called with is not directly observable, so instead assert via a
+    ``ctx.NAME.field`` dotted reference resolving correctly against a nested store,
+    which would raise (not silently pass a literal `{ctx...}` string) if
+    interpolation were skipped."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ack")
+    reg = _registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="{summary: 'nested value', priority: 3}", output="brief"),
+            AgentStep(
+                prompt="please review: {ctx.brief.summary} (priority {ctx.brief.priority})",
+                identity="worker",
+                output="verdict",
+            ),
+        ]
+    )
+    executor = PipelineExecutor()
+
+    result = await executor.run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-agent-interp",
+        registry=reg,
+    )
+
+    assert result.pipe_data == "ack"
+
+    # A missing dotted path in the prompt raises a clear PipelineExecutionError
+    # (proves the reference is actually resolved, not passed through literally).
+    bad_pipeline = Pipeline(
+        steps=[AgentStep(prompt="{ctx.does_not_exist}", identity="worker")]
+    )
+    with pytest.raises(PipelineExecutionError):
+        await executor.run(
+            bad_pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-agent-interp-missing",
+            registry=reg,
+        )
+
+
+# ── structured output ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_schema_success_threads_parsed_value(tmp_path: Path) -> None:
+    """Tier 2c: an agent step with ``schema`` set threads the parsed/validated
+    value (not raw text) as pipe data / named output."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply('{"verdict": "approve", "confidence": 0.9}')
+    reg = _registry(tmp_path, state_log, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", {
+        "fields": {
+            "verdict": {"type": "enum", "values": ["approve", "reject"], "required": True},
+            "confidence": {"type": "number", "required": True},
+        },
+    })
+
+    pipeline = Pipeline(
+        steps=[
+            AgentStep(
+                prompt="review this", identity="worker", schema="review", output="review",
+            ),
+            TransformStep(value="ctx.review.verdict", output="final_verdict"),
+        ]
+    )
+    executor = PipelineExecutor()
+
+    result = await executor.run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-agent-schema-ok",
+        registry=reg, schema_registry=schema_registry,
+    )
+
+    assert result.named_stores["review"] == {"verdict": "approve", "confidence": 0.9}
+    assert result.pipe_data == "approve"
+
+
+@pytest.mark.asyncio
+async def test_agent_step_schema_nonconforming_fails_step(tmp_path: Path) -> None:
+    """Tier 2c: a non-conforming reply fails the step (``PipelineExecutionError``,
+    wrapping the underlying ``AgentStepError``) — same failure path a bad tool-step
+    schema takes, not a silently-accepted partial value."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("Sure — looks good to me!")
+    reg = _registry(tmp_path, state_log, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", {
+        "fields": {"verdict": {"type": "string", "required": True}},
+    })
+
+    pipeline = Pipeline(
+        steps=[AgentStep(prompt="review this", identity="worker", schema="review")]
+    )
+    executor = PipelineExecutor()
+
+    with pytest.raises(PipelineExecutionError):
+        await executor.run(
+            pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-agent-schema-bad",
+            registry=reg, schema_registry=schema_registry,
+        )
+
+
+# ── R4 recovery: exactly-once replay of a completed agent step ──────────────
+
+
+@pytest.mark.asyncio
+async def test_resume_replays_completed_agent_step_without_rerunning_llm_turn(
+    tmp_path: Path,
+) -> None:
+    """Tier 2c: MANDATORY CLAUDE.md recovery gate + R5's exactly-once proof. Run a
+    pipeline through a completed ``AgentStep``, truncate the WAL below its recorded
+    generation seq, `resume` -> the agent step must NOT re-run (its result replays
+    from the step-boundary snapshot, proven via the scripted LLM's call count),
+    and execution resumes at the step after it with the correct threaded state."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("the one true answer")
+    reg = _registry(tmp_path, state_log, scripted)
+
+    step0 = TransformStep(value="'seed: ' + ctx.seed", output="brief")
+    step1 = AgentStep(prompt="{ctx.brief}", identity="worker", output="verdict")
+    step2 = TransformStep(value="ctx.verdict + ' (final)'", output="done")
+
+    executor = PipelineExecutor()
+    phase1 = Pipeline(steps=[step0, step1])  # run through the agent step (K=1)
+    phase1_result = await executor.run(
+        phase1, {"seed": "abc"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-agent-truncate",
+        registry=reg,
+    )
+    await state_log.flush()
+    assert phase1_result.step_index == 2
+    assert scripted.calls == 1
+
+    seq_after_phase1 = state_log.current_seq
+    assert seq_after_phase1 >= 1
+
+    # WAL head climbs well past the agent step's key seq (other activity).
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    stats = state_log.last_truncate_stats
+    assert stats["dropped"] >= 1, "the agent step's own WAL entries must be truncated"
+    surviving_seqs = {e["seq"] for e in state_log.iter_from(0)}
+    assert seq_after_phase1 not in surviving_seqs, (
+        "the agent step's own WAL entries are gone — the generation FILE, not a "
+        "WAL event, must be what resume reconstructs from"
+    )
+
+    full_pipeline = Pipeline(steps=[step0, step1, step2])
+    resumed = await executor.resume(
+        "run-agent-truncate", pipeline=full_pipeline,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, registry=reg,
+    )
+
+    assert scripted.calls == 1, (
+        "the agent step must NOT be re-run on resume (exactly-once) — the LLM "
+        "was called exactly once total, before AND after truncate+resume"
+    )
+    assert resumed.step_index == 3
+    assert resumed.named_stores["brief"] == "seed: abc"
+    assert resumed.named_stores["verdict"] == "the one true answer"
+    assert resumed.named_stores["done"] == "the one true answer (final)"
+    assert resumed.pipe_data == "the one true answer (final)"
+
+
+# ── structural guardrails ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_without_identity_or_default_fails_structurally(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: an AgentStep with no ``identity`` and no ``default_identity`` given
+    to ``run`` fails with a clear PipelineExecutionError (not a bare AttributeError
+    / silently picking an arbitrary identity)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log, _ScriptedAgentReply("x"))
+    pipeline = Pipeline(steps=[AgentStep(prompt="hi")])
+    executor = PipelineExecutor()
+
+    with pytest.raises(PipelineExecutionError):
+        await executor.run(
+            pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-agent-no-identity",
+            registry=reg,
+        )
+
+
+@pytest.mark.asyncio
+async def test_agent_step_without_registry_fails_structurally(tmp_path: Path) -> None:
+    """Tier 2: an AgentStep in a pipeline run with no ``registry`` fails clearly
+    rather than crashing on a ``None`` call — the guard the executor must add since
+    ``registry`` is optional for transform/tool-only pipelines."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    pipeline = Pipeline(steps=[AgentStep(prompt="hi", identity="worker")])
+    executor = PipelineExecutor()
+
+    with pytest.raises(PipelineExecutionError):
+        await executor.run(
+            pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-agent-no-registry",
+        )
+
+
+# ── pre-existing byte-identical behavior when no agent step is present ──────
+
+
+@pytest.mark.asyncio
+async def test_no_agent_step_pipeline_unaffected_by_new_params(tmp_path: Path) -> None:
+    """Tier 2: a transform/tool-only pipeline run with no ``registry``/
+    ``default_identity`` behaves exactly as before (R3 threading untouched)."""
+    def _shout(_name: str, args: dict) -> str:
+        return args["text"].upper()
+
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="'hi ' + ctx.name", output="greeting"),
+            ToolStep(name="shout", args={"text": ExprRef("pipe")}, output="shouted"),
+        ]
+    )
+    executor = PipelineExecutor()
+    result = await executor.run(
+        pipeline, {"name": "world"},
+        tool_dispatch=_shout, state_log=None, run_id="run-no-agent",
+    )
+
+    assert result.pipe_data == "HI WORLD"
+    assert result.named_stores == {"name": "world", "greeting": "hi world", "shouted": "HI WORLD"}


### PR DESCRIPTION
**[lead-sonnet]** —

## Summary
- Adds `AgentStep(prompt, identity=None, capabilities=None, schema=None, output=None)` to `reyn.core.pipeline.executor`'s `Step` union.
- The executor's step loop now handles `AgentStep`: interpolates `{ctx.dotted.path}` / `{pipe}` references in `prompt` (new `_interpolate_prompt`, reusing `expr.evaluate_expr`'s `Path` resolution for the dotted lookup — no second path-resolver), resolves `identity` as `step.identity or default_identity` (new `default_identity` param on `run`/`resume`, matching the design doc's "identity defaults to invoker"), then calls `run_agent_step(registry, identity=..., prompt=..., capabilities=step.capabilities, schema=step.schema, schema_registry=schema_registry)`. Its return value threads through R3 exactly like `transform`/`tool` steps (next `pipe_data` + `output:NAME` write). `AgentStepError` is caught and re-raised as `PipelineExecutionError`, the same step-failure path a bad tool/schema step takes.
- `run`/`resume`/`_run_from` gained a `registry: AgentRegistry | None = None` param — required only when the pipeline actually contains an `AgentStep` (a clear `PipelineExecutionError` otherwise); transform/tool-only pipelines are unaffected (verified by a dedicated regression test).
- Agent steps use the durable (`await`-ed) step-boundary recovery path, same as side-effecting tool steps.

## R4 exactly-once replay for agent steps
The existing R4 machinery (`record_pipeline_state` after every step boundary, `resume` replaying from `completed_step_results` before live-executing past the first uncompleted step) required no changes — an `AgentStep`'s result is recorded and replayed identically to a `ToolStep`'s. Proved with a dedicated truncate-falsify test: run through a completed `AgentStep` → truncate the WAL below its recorded generation seq → `resume` → the scripted LLM's call count stays at 1 (the turn is NOT re-run) and execution resumes correctly at the step after it.

## Tests
New `tests/test_pipeline_r5_agent_step_executor.py` (Tier 2c, same real-collaborator discipline as `test_pipeline_r5_run_agent_step.py`: real `AgentRegistry`/`Session`/`MessageBus`, only the LLM completion is faked via a concrete `_ScriptedAgentReply` through the real `RouterLoopDriver._loop_observer` seam — no `MagicMock`):
- agent step in a `transform -> agent -> transform` linear pipeline (R3 threading)
- prompt interpolation (`{ctx.NAME.field}` resolves before the agent runs; a missing path fails clearly)
- structured output (schema success threads the parsed value; non-conforming reply fails the step)
- **the mandatory recovery/exactly-once test** (truncate + resume, LLM call count proof)
- structural guardrails (missing identity/default_identity, missing registry)
- a regression test proving transform/tool-only pipelines are byte-identical with the new optional params absent

## Gates (all green)
- `ruff check src tests` → All checks passed!
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_r5_agent_step_executor.py` → 8/8 OK, 0 Tier-4 violations
- `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/executor.py` → OK
- Full `pytest` from repo root: **`10 failed, 6947 passed, 30 skipped, 11 warnings, 10 errors in 98.33s (0:01:38)`** — confirmed byte-identical to the `origin/main` baseline run (same 10 failed + 10 errors, all pre-existing mcp/uvicorn/a2a; `6947` vs baseline `6939` passed = exactly the +8 new tests, zero new failures).

## Test plan
- [x] `ruff check src tests`
- [x] `pytest` (full suite, 0 new failures vs baseline)
- [x] `test_tier_audit.py --strict` on the new test file
- [x] `verify_module_docstrings.py` on the changed src file
- [x] Manual: confirmed no circular import (`reyn.core.pipeline.executor` importing `reyn.runtime.session_api`/`reyn.runtime.errors` at module scope)