### PR TITLE
feat(pipeline): IS-1 sync run_pipeline tool + pipeline registry

### DIFF
--- a/src/reyn/core/pipeline/registry.py
+++ b/src/reyn/core/pipeline/registry.py
@@ -1,0 +1,75 @@
+"""Pipeline registry — name -> Pipeline lookup for the ``run_pipeline`` tool (IS-1).
+
+IS-1 (``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R6) is SYNC +
+REGISTERED only: a pipeline must already be registered under a name before an
+agent can launch it via ``run_pipeline(name, input)``. Registration is
+PROGRAMMATIC in this slice — an implementer/test builds a
+:class:`~reyn.core.pipeline.executor.Pipeline` dataclass directly and calls
+:meth:`PipelineRegistry.register`. A YAML DSL parser that produces ``Pipeline``
+instances from a pipeline definition file is a later slice; once it lands, real
+pipelines register through it instead of by hand, but this registry's
+lookup contract (name -> Pipeline) does not change.
+
+This is deliberately a plain in-memory mapping, not a process-wide singleton:
+callers (a session, a test) construct their own ``PipelineRegistry`` and thread
+it through explicitly (mirrors how ``AgentRegistry`` / ``StateLog`` are threaded
+rather than reached via a hidden global), keeping registrations scoped to the
+owner that created them.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.core.pipeline.executor import Pipeline
+
+
+class PipelineNotFoundError(KeyError):
+    """Raised by :meth:`PipelineRegistry.get` when ``name`` has no registered
+    :class:`~reyn.core.pipeline.executor.Pipeline`. A ``KeyError`` subclass so
+    callers that already handle ``KeyError`` (dict-lookup idiom) catch this
+    too, while still giving ``run_pipeline`` a specific type to match on for
+    a clear "pipeline not found" tool error (rather than a generic KeyError
+    with just the bare name in its args)."""
+
+
+class PipelineRegistry:
+    """In-memory ``name -> Pipeline`` registry.
+
+    ``register``/``get`` are the whole contract for IS-1 — no update/unregister
+    (re-registration under the same name is rejected, same shadowing-prevention
+    posture as :class:`~reyn.tools.registry.ToolRegistry`)."""
+
+    def __init__(self) -> None:
+        self._pipelines: "dict[str, Pipeline]" = {}
+
+    def register(self, name: str, pipeline: "Pipeline") -> None:
+        """Register ``pipeline`` under ``name``. Re-registration under an
+        already-used name raises ``ValueError`` (prevents accidentally
+        shadowing a previously registered pipeline)."""
+        if name in self._pipelines:
+            raise ValueError(
+                f"a pipeline is already registered under name {name!r}; "
+                "re-registration is not allowed — remove the prior "
+                "registration first."
+            )
+        self._pipelines[name] = pipeline
+
+    def get(self, name: str) -> "Pipeline":
+        """Look up the ``Pipeline`` registered under ``name``.
+
+        Raises :class:`PipelineNotFoundError` (a ``KeyError``) when absent —
+        the ``run_pipeline`` tool handler catches this to produce a clear
+        "pipeline not found" tool error rather than an unhandled exception."""
+        try:
+            return self._pipelines[name]
+        except KeyError:
+            raise PipelineNotFoundError(name) from None
+
+    def names(self) -> "tuple[str, ...]":
+        """All registered pipeline names (for introspection / future
+        surfacing, e.g. an L1-style list like the skill registry's)."""
+        return tuple(self._pipelines)
+
+
+__all__ = ["PipelineRegistry", "PipelineNotFoundError"]

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -53,12 +53,22 @@ if TYPE_CHECKING:
     from reyn.core.pipeline.schema import SchemaRegistry
     from reyn.runtime.registry import AgentRegistry
 
-# Tool names that let a session hand a turn off to a peer / sub-session mid-run
-# (a pending chain / async dispatch the caller's inbox-emptiness check cannot
-# see). ``_expand_tool_forms`` (capability_profile.py) derives every invocable
-# alias (bare + qualified) from each name here, so listing the bare tool name
-# is sufficient — the qualified catalog form is covered too.
-_DELEGATION_DENY_TOOLS: tuple[str, ...] = ("delegate_to_agent",)
+# Tool names an ``agent`` pipeline step must never reach — a leaf worker (R6
+# session-hierarchy constraint 4: "E_i are spawn-tree LEAVES"). Two distinct
+# reasons collapse into one deny-set:
+#   - ``delegate_to_agent``: a mid-turn delegation would make
+#     ``MessageBus.request``'s quiescence predicate (inbox.empty()) return
+#     early on a pending chain the spawned session is still awaiting a reply
+#     for (see the module docstring).
+#   - ``run_pipeline`` (IS-1, R6 S3): nesting a pipeline launch inside an
+#     ``agent`` step would let a step spawn ANOTHER pipeline at runtime,
+#     defeating the transitive-closure cost-bound approval a REGISTERED
+#     pipeline gets at ``run_pipeline`` call time — nesting is ``call``-only.
+# ``_expand_tool_forms`` (capability_profile.py) derives every invocable alias
+# (bare + qualified) from each name here, so listing the bare tool name is
+# sufficient — the qualified catalog form (``multi_agent__delegate`` /
+# ``pipeline__run``) is covered too.
+_DELEGATION_DENY_TOOLS: tuple[str, ...] = ("delegate_to_agent", "run_pipeline")
 
 # MessageBus.request has no default — an agent step needs one so callers
 # aren't forced to pick a number for the common case.

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -258,6 +258,15 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     # future qualified route would be floored by the same _with_unwrapped_aliases
     # derivation.
     "spawn": frozenset({"session_spawn", "agent_spawn", "topology_create"}),
+    # IS-1 (pipeline v0.9 R6): no launching a registered pipeline from
+    # untrusted content / an unbound delegate — a pipeline step can itself
+    # write / exec / delegate (bounded ⊆ the invoker per R6, but still a
+    # cost-bound multi-step dispatch), so pipeline launch gets the same
+    # spawn-adjacent floor as session_spawn/agent_spawn/topology_create.
+    # Has a qualified route (pipeline__run) unlike the bare-only spawn
+    # trio, so its bare alias (run_pipeline) is derived by
+    # _with_unwrapped_aliases below — no _FLOORED_BARE_ONLY entry needed.
+    "pipeline-run": frozenset({"pipeline__run"}),
 }
 
 # Intentionally BARE-ONLY floored names: router-only tools with NO invoke_action
@@ -390,6 +399,7 @@ _FLOORED_AUDIT_SEVERITY: "dict[str, str]" = {
     "skill-install": "HIGH",  # #2548: registering skills from untrusted content is a persistence vector
     "memory-write": "MED",
     "spawn": "HIGH",  # #2103: unbounded sub-session spawn (DoS) — peer of re-delegation
+    "pipeline-run": "HIGH",  # IS-1: pipeline launch is spawn-adjacent (peer of "spawn")
 }
 DELEGATION_AUDIT_CLASSES: "dict[str, tuple[str, frozenset[str]]]" = {
     cls: (_FLOORED_AUDIT_SEVERITY[cls], tools)

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -86,6 +86,7 @@ def get_default_registry() -> ToolRegistry:
         REMEMBER_AGENT,
         REMEMBER_SHARED,
     )
+    from reyn.tools.pipeline_verbs import RUN_PIPELINE
     from reyn.tools.recall import RECALL
     from reyn.tools.reyn_src import (
         REYN_SRC_GLOB,
@@ -204,6 +205,10 @@ def get_default_registry() -> ToolRegistry:
     registry.register(SKILL_INSTALL_LOCAL)
     # #2548 PR-D: skill install verb (git/GitHub URL source fetch).
     registry.register(SKILL_INSTALL_SOURCE)
+    # IS-1 (pipeline v0.9 R6): run_pipeline — sync launch of a REGISTERED
+    # pipeline. Router+phase allow; not yet in build_tools() (surfacing is a
+    # later slice, mirrors the universal-catalog wrappers' own PR-3b deferral).
+    registry.register(RUN_PIPELINE)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -1,0 +1,207 @@
+"""``run_pipeline`` router tool — IS-1 (sync + REGISTERED pipeline launch).
+
+Per ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R6: an agent
+launches a REGISTERED pipeline (pre-built via
+:class:`reyn.core.pipeline.registry.PipelineRegistry` — a YAML DSL parser is a
+later slice) and gets its result back inline. IS-1 is deliberately narrow:
+
+  - **Sync only.** ``run_pipeline`` runs the pipeline to completion on the
+    caller's own turn via :meth:`~reyn.core.pipeline.executor.PipelineExecutor.run`
+    and returns the final output — no separate driver-session spawn (R6's
+    ``run_pipeline_async`` + the driver-session-per-run architecture are
+    deferred; this slice proves the "launch registered pipeline, get result"
+    round trip in-process).
+  - **Registered only.** No ad-hoc ``run_pipeline_inline`` (deferred — needs
+    the §7.3 static-analysis gate first, per R6).
+  - **Real tool-step dispatch, not a stub.** A pipeline ``ToolStep``'s
+    ``tool_dispatch`` is wired through the SAME routing seam
+    ``invoke_action`` uses (``universal_dispatch.resolve_invoke_action`` +
+    the unified ``ToolRegistry`` — see :func:`_make_tool_dispatch`), so a
+    ``tool`` step actually executes a real capability (qualified action name
+    OR bare registered tool name), not a caller-supplied fake.
+  - **S3 cost-bound**: denied to pipeline-internal ``agent`` steps (an
+    ``agent`` step is a leaf worker — nesting is ``call``-only, a later
+    slice) — enforced structurally in
+    ``reyn.runtime.session_api._build_agent_step_narrowing``, not here.
+
+Dependencies the handler assembles for :class:`~reyn.core.pipeline.executor.PipelineExecutor`:
+  - ``registry`` (an ``AgentRegistry``, only needed if the pipeline has an
+    ``AgentStep``) from ``ctx.router_state.agent_registry``.
+  - ``state_log`` (for R4 step-boundary recovery) from ``ctx.state_log`` —
+    the SAME process-shared WAL every other recovery-aware tool threads.
+  - ``default_identity`` (the calling actor) from
+    ``ctx.router_state.host.agent_name`` when a host is present.
+  - ``tool_dispatch`` — see :func:`_make_tool_dispatch`.
+
+NOTE (surfacing): this tool is registered in the unified ``ToolRegistry``
+(dispatch-completeness: routable via ``invoke_action``/``pipeline__run``,
+classified for the content-threat + capability-floor guards) but is NOT yet
+added to ``build_tools()`` — the live LLM tool list. That wiring is the same
+"PR-3b" follow-up already deferred for the other universal-catalog wrappers
+(``list_actions``/``search_actions``/``describe_action``/``invoke_action``);
+``run_pipeline`` rides the same follow-up, tracked as IS-1's "surfacing"
+deferral.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Callable, Mapping
+
+from reyn.core.pipeline.executor import PipelineExecutionError, PipelineExecutor
+from reyn.core.pipeline.registry import PipelineNotFoundError
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_RUN_PIPELINE_DESCRIPTION = (
+    "Run a REGISTERED pipeline by name to completion and return its final "
+    "output. Blocks until the pipeline finishes (sync). 'input' seeds the "
+    "pipeline's initial named context (ctx.*) for its first step. Fails "
+    "clearly if 'name' is not a registered pipeline, or if any step fails."
+)
+
+_RUN_PIPELINE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The registered pipeline's name.",
+        },
+        "input": {
+            "type": "object",
+            "description": (
+                "Initial named context (ctx.*) for the pipeline's first "
+                "step. Omit for a pipeline that needs no seed input."
+            ),
+        },
+    },
+    "required": ["name"],
+}
+
+
+def _make_tool_dispatch(ctx: ToolContext) -> "Callable[[str, dict], Any]":
+    """Build the real ``tool_dispatch`` a pipeline ``ToolStep`` invokes through.
+
+    Routes ``step.name`` through the SAME seam ``invoke_action`` uses
+    (``universal_dispatch.resolve_invoke_action`` — see
+    ``tools/universal_catalog.py:_handle_invoke_action``, the precedent this
+    mirrors): a qualified action name (``file__read``) resolves to its target
+    tool + shaped args; a name with no operation-rule route falls back to a
+    direct bare-name lookup in the unified registry (so a pipeline can also
+    name a tool directly, e.g. ``"web_search"``). Either way the target
+    handler is invoked with ``ctx`` forwarded VERBATIM — same as
+    ``invoke_action`` forwards it — so router_state callbacks (permission
+    resolver, workspace, etc.) reach the target exactly as if the caller had
+    invoked it directly. No stub, no op_runtime bridge: this IS the real
+    tool-execution path.
+    """
+
+    async def _dispatch(name: str, resolved_args: "dict[str, Any]") -> Any:
+        from reyn.tools import get_default_registry
+        from reyn.tools.universal_dispatch import (
+            UnknownActionError,
+            resolve_invoke_action,
+        )
+
+        registry = get_default_registry()
+        target_name = name
+        target_args: "dict[str, Any]" = dict(resolved_args)
+        try:
+            resolved = resolve_invoke_action(name, resolved_args)
+        except UnknownActionError:
+            resolved = None
+        if resolved is not None:
+            target_name = resolved.target_tool_name
+            target_args = dict(resolved.target_args)
+
+        target = registry.lookup(target_name)
+        if target is None:
+            raise PipelineExecutionError(
+                f"pipeline tool step {name!r} does not resolve to a "
+                f"registered tool (tried qualified-action routing, then a "
+                f"bare lookup of {target_name!r})"
+            )
+        return await target.handler(target_args, ctx)
+
+    return _dispatch
+
+
+async def _handle_run_pipeline(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """Look up the registered pipeline, run it synchronously, return its
+    final output. See the module docstring for the dependency wiring."""
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return {"status": "error", "data": {"error": "name is required"}}
+
+    raw_input = args.get("input")
+    if raw_input is not None and not isinstance(raw_input, Mapping):
+        return {
+            "status": "error",
+            "data": {"error": "input must be an object (mapping), if given"},
+        }
+
+    rs = ctx.router_state
+    pipeline_registry = rs.pipeline_registry if rs is not None else None
+    if pipeline_registry is None:
+        return {
+            "status": "error",
+            "data": {
+                "error": (
+                    "no PipelineRegistry available — run_pipeline requires "
+                    "ctx.router_state.pipeline_registry to be populated"
+                ),
+            },
+        }
+
+    try:
+        pipeline = pipeline_registry.get(name)
+    except PipelineNotFoundError:
+        return {
+            "status": "error",
+            "data": {"error": f"pipeline {name!r} is not registered"},
+        }
+
+    agent_registry = rs.agent_registry if rs is not None else None
+    host = rs.host if rs is not None else None
+    default_identity = getattr(host, "agent_name", None) if host is not None else None
+    state_log = ctx.state_log
+
+    executor = PipelineExecutor()
+    run_id = f"pipeline-{name}-{uuid.uuid4().hex}"
+    try:
+        result = await executor.run(
+            pipeline,
+            dict(raw_input) if raw_input else None,
+            tool_dispatch=_make_tool_dispatch(ctx),
+            state_log=state_log,
+            run_id=run_id,
+            registry=agent_registry,
+            default_identity=default_identity,
+        )
+    except PipelineExecutionError as exc:
+        return {
+            "status": "error",
+            "data": {"error": f"pipeline {name!r} failed: {exc}"},
+        }
+
+    return {
+        "status": "ok",
+        "data": {
+            "run_id": result.run_id,
+            "output": result.pipe_data,
+            "named_stores": result.named_stores,
+        },
+    }
+
+
+RUN_PIPELINE = ToolDefinition(
+    name="run_pipeline",
+    description=_RUN_PIPELINE_DESCRIPTION,
+    parameters=_RUN_PIPELINE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_run_pipeline,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = ["RUN_PIPELINE"]

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -210,6 +210,11 @@ def build_universal_tool_use_slots(
             "`skill_management__install_source` to fetch and install a skill from "
             "a git/GitHub URL (shallow-clones to .reyn/skills/<name>/)."
         )
+        _r2.append(
+            "- **pipeline** — launch a registered pipeline: "
+            "`pipeline__run` runs a REGISTERED pipeline by name to completion "
+            "and returns its final output (synchronous — blocks until done)."
+        )
         _r2.append("")
         if has_hot_list_aliases:
             _r2.append(

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -54,6 +54,14 @@ class RouterCallerState:
     agent_registry: Any = None
     available_agents: list[Mapping[str, Any]] | None = None
 
+    # IS-1 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6): the
+    # PipelineRegistry the run_pipeline tool looks up a registered Pipeline by
+    # name in. Threaded explicitly (mirrors agent_registry above) rather than a
+    # hidden global, since IS-1 registration is programmatic per-owner. None =
+    # host doesn't support run_pipeline (surfacing to the live LLM catalog is
+    # a later slice; this field exists so the handler + tests have a seam).
+    pipeline_registry: Any = None
+
     # Async dispatch callbacks (= for delegate_to_agent / plan
     # handlers that need to interact with chain / task lifecycle)
     send_to_agent: Callable[..., Awaitable[Any]] | None = None

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -84,6 +84,11 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # ``skill__`` resource category (per-skill dynamic dispatch); this is the
     # management plane — mirrors the ``mcp`` category pattern.
     "skill_management",
+    # IS-1 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6):
+    # pipeline launch verb(s). ``pipeline__run`` = run_pipeline (sync,
+    # REGISTERED-only). run_pipeline_inline / run_pipeline_async / the
+    # ad-hoc-async combo join this category in later slices.
+    "pipeline",
 )
 
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -310,6 +310,9 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     # colliding with that resource namespace — mirrors mcp__ (mgmt) vs mcp.<s>.<t> (res).
     "skill_management__install_local":  ("skill_install_local",  _passthrough_args),
     "skill_management__install_source": ("skill_install_source", _passthrough_args),
+
+    # pipeline category (IS-1: sync + REGISTERED-only run_pipeline).
+    "pipeline__run": ("run_pipeline", _passthrough_args),
 }
 
 

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -167,7 +167,8 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "
         "skill_management__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
         "skill_management__install_source, skill_install_source, "  # #2548 PR-D: source install
-        "session_spawn, agent_spawn, topology_create]\n",  # #2103: the full spawn class (session + agent + topology)
+        "session_spawn, agent_spawn, topology_create, "  # #2103: the full spawn class (session + agent + topology)
+        "pipeline__run, run_pipeline]\n",  # IS-1: pipeline-run class (spawn-adjacent)
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -192,28 +192,34 @@ async def test_agent_step_narrowing_denies_delegation_when_spawned(tmp_path: Pat
     (``_build_agent_step_narrowing``), spawned via ``spawn_ephemeral_session``,
     is LIVE-enforced (``registry.resolved_profile_for``) to deny
     ``delegate_to_agent`` (+ its qualified ``multi_agent__delegate`` alias)
-    even when the caller's own ``capabilities`` list explicitly names it —
+    AND ``run_pipeline`` (+ its qualified ``pipeline__run`` alias, IS-1 R6 S3:
+    an agent step is a spawn-tree LEAF — no launching a nested pipeline)
+    even when the caller's own ``capabilities`` list explicitly names them —
     ``capability_profile`` resolution is deny-always-wins
-    (``profile_permits``), so an ``agent`` step cannot re-open delegation via
-    its ``capabilities`` argument. Purely structural: no LLM turn / actual
-    delegation attempt needed to prove the gate."""
+    (``profile_permits``), so an ``agent`` step cannot re-open either via its
+    ``capabilities`` argument. Purely structural: no LLM turn / actual
+    delegation or pipeline-launch attempt needed to prove the gate."""
     reg = _registry(tmp_path, scripted=None)
-    narrowing = _build_agent_step_narrowing(["delegate_to_agent", "file__read"])
+    narrowing = _build_agent_step_narrowing(
+        ["delegate_to_agent", "run_pipeline", "file__read"]
+    )
 
     sid = await spawn_ephemeral_session(reg, identity="worker", narrowing=narrowing)
     contextual, _excluded = reg.resolved_profile_for("worker", sid=sid)
 
     assert contextual is not None
     assert {"delegate_to_agent", "multi_agent__delegate"} <= contextual.tool_deny
+    assert {"run_pipeline", "pipeline__run"} <= contextual.tool_deny
 
 
 def test_build_agent_step_narrowing_no_capabilities_is_restrict_only(tmp_path: Path) -> None:
     """Tier 2: OS invariant — omitting ``capabilities`` (None) leaves
     ``tool_allow`` unset (no re-grant beyond the agent's normal envelope);
-    only the delegation deny is imposed. Pure function, no session needed."""
+    only the structural leaf-worker deny (delegation + IS-1's nested
+    run_pipeline, R6 S3) is imposed. Pure function, no session needed."""
     narrowing = _build_agent_step_narrowing(None)
     assert "tool_allow" not in narrowing
-    assert narrowing["tool_deny"] == ["delegate_to_agent"]
+    assert narrowing["tool_deny"] == ["delegate_to_agent", "run_pipeline"]
 
 
 # ── ephemeral cleanup ────────────────────────────────────────────────────────

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -95,6 +95,13 @@ _NOT_EXTERNAL = {
     "task.add_dependency", "task.remove_dependency", "task.repoint_dependency",
     "task.abort", "task.heartbeat", "task.register_unblock_predicate",
     "task.comment", "task.assign",
+    # IS-1 (pipeline v0.9 R6): run_pipeline returns the pipeline's OWN final
+    # output (run_id / output / named_stores) — an OS-assembled result of
+    # internal step execution, not fetched external content. Any external
+    # content a tool/agent step's own result carries is fenced on THAT step's
+    # own tool-result path when it runs (same "ACK here, fenced at its own
+    # seam" pattern as delegate_to_agent / session_spawn above).
+    "run_pipeline",
 }
 
 

--- a/tests/test_run_pipeline_tool_is1.py
+++ b/tests/test_run_pipeline_tool_is1.py
@@ -1,0 +1,216 @@
+"""Tier 2c: run_pipeline router tool (IS-1 — sync + REGISTERED pipeline launch).
+
+Covers ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R6's first
+end-to-end slice: an agent (here, the tool handler's caller) launches a
+REGISTERED pipeline and gets its result inline. Real collaborators throughout
+— a real ``PipelineRegistry``, real ``Workspace``/``PermissionResolver`` (so
+the ``tool`` step's ``file__write`` actually writes through
+``op_runtime.execute_op``, not a stub), and a real ``AgentRegistry``/
+``Session`` for the ``agent`` step (same real-collaborator discipline as
+``test_pipeline_r5_agent_step_executor.py`` — the ONLY faked collaborator is
+the LLM completion call, injected via the real ``RouterLoopDriver``
+``_loop_observer`` seam).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import AgentStep, ExprRef, Pipeline, ToolStep, TransformStep
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.data.workspace.workspace import Workspace
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import _build_agent_step_narrowing
+from reyn.security.permissions.permissions import PermissionResolver
+from reyn.tools.pipeline_verbs import _handle_run_pipeline
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text turn (no tool_calls) — the
+    LLM is incidental to what's under test (the run_pipeline composition),
+    same rationale as test_pipeline_r5_agent_step_executor.py."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _agent_registry(
+    tmp_path: Path, state_log: "StateLog", scripted: "_ScriptedAgentReply | None",
+) -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors
+    test_pipeline_r5_agent_step_executor.py's ``_registry`` helper)."""
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    pipeline_registry: "PipelineRegistry | None" = None,
+    agent_registry: "AgentRegistry | None" = None,
+    state_log: "StateLog | None" = None,
+) -> ToolContext:
+    events = EventLog()
+    return ToolContext(
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={"file.read": "allow", "file.write": "allow"},
+            project_root=tmp_path,
+            interactive=False,
+        ),
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry,
+            agent_registry=agent_registry,
+        ),
+        state_log=state_log,
+    )
+
+
+# ── end-to-end: transform -> tool -> agent ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_e2e_transform_tool_agent(tmp_path: Path) -> None:
+    """Tier 2c: register a transform->tool->agent pipeline, invoke the
+    run_pipeline handler with a real OpContext/AgentRegistry/StateLog, assert
+    the pipeline runs to completion, the tool step's file__write REALLY wrote
+    the file (op_runtime execute_op, not a stub), and the final output is the
+    agent step's (scripted) reply."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("the pipeline's final answer")
+    agent_reg = _agent_registry(tmp_path, state_log, scripted)
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register(
+        "greet_and_review",
+        Pipeline(steps=[
+            TransformStep(value="'hello ' + ctx.name", output="msg"),
+            ToolStep(
+                name="file__write",
+                args={"path": "out.txt", "content": ExprRef("pipe")},
+                output="write_result",
+            ),
+            AgentStep(prompt="review: {ctx.msg}", identity="worker", output="verdict"),
+        ]),
+    )
+
+    ctx = _ctx(
+        tmp_path, pipeline_registry=pipeline_registry,
+        agent_registry=agent_reg, state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline(
+        {"name": "greet_and_review", "input": {"name": "world"}}, ctx,
+    )
+
+    assert result["status"] == "ok"
+    assert result["data"]["output"] == "the pipeline's final answer"
+    assert result["data"]["named_stores"]["msg"] == "hello world"
+    assert scripted.calls == 1
+    # the tool step's file__write is the REAL op_runtime path — assert the
+    # file was actually written, not a stubbed pass-through.
+    assert (tmp_path / "out.txt").read_text() == "hello world"
+
+
+# ── missing pipeline ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_missing_name_returns_clear_error(tmp_path: Path) -> None:
+    """Tier 2: run_pipeline("nonexistent") -> a clear tool error, not a raw
+    KeyError / unhandled exception."""
+    ctx = _ctx(tmp_path, pipeline_registry=PipelineRegistry())
+
+    result = await _handle_run_pipeline({"name": "nonexistent"}, ctx)
+
+    assert result["status"] == "error"
+    assert "nonexistent" in result["data"]["error"]
+    assert "not registered" in result["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_empty_name_returns_clear_error(tmp_path: Path) -> None:
+    """Tier 2: an empty/missing 'name' arg fails clearly, not a KeyError."""
+    ctx = _ctx(tmp_path, pipeline_registry=PipelineRegistry())
+
+    result = await _handle_run_pipeline({}, ctx)
+
+    assert result["status"] == "error"
+    assert "name" in result["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_no_registry_returns_clear_error(tmp_path: Path) -> None:
+    """Tier 2: no PipelineRegistry threaded via ctx.router_state -> a clear
+    error (not an AttributeError on a None registry)."""
+    ctx = _ctx(tmp_path)  # pipeline_registry defaults to None
+
+    result = await _handle_run_pipeline({"name": "anything"}, ctx)
+
+    assert result["status"] == "error"
+    assert "PipelineRegistry" in result["data"]["error"]
+
+
+# ── tool-step failure surfaces as a clear pipeline error ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_unknown_tool_step_fails_clearly(tmp_path: Path) -> None:
+    """Tier 2: a ToolStep naming an unresolvable tool fails the run with a
+    clear error (the real tool_dispatch seam, not a silent no-op)."""
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register(
+        "bad_tool_step",
+        Pipeline(steps=[ToolStep(name="does_not_exist__nope", args={})]),
+    )
+    ctx = _ctx(tmp_path, pipeline_registry=pipeline_registry)
+
+    result = await _handle_run_pipeline({"name": "bad_tool_step"}, ctx)
+
+    assert result["status"] == "error"
+    assert "bad_tool_step" in result["data"]["error"]
+
+
+# ── S3: agent-step narrowing structurally denies run_pipeline ───────────────
+
+
+def test_agent_step_narrowing_denies_run_pipeline() -> None:
+    """Tier 2: OS invariant (R6 S3) — a pipeline's agent step is a spawn-tree
+    LEAF: its narrowing structurally denies run_pipeline (nesting is
+    call-only), same posture as the pre-existing delegate_to_agent deny.
+    Purely structural — inspects the deny-set the narrowing builds."""
+    narrowing = _build_agent_step_narrowing(None)
+    assert "run_pipeline" in narrowing["tool_deny"]
+    assert "delegate_to_agent" in narrowing["tool_deny"]

--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -68,6 +68,8 @@ def test_categories_master_table_order() -> None:
         # #2548 PR-C: skill management ops (install_local). NOT the ``skill__``
         # resource category; this is the management plane (mirrors ``mcp``).
         "skill_management",
+        # IS-1: pipeline launch verb(s) (pipeline__run = run_pipeline).
+        "pipeline",
     )
 
 

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -588,6 +588,8 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("skill_management__install_local",  {"path": "/tmp/my-skill"}),
     # skill_management category (#2548 PR-D) — install_source requires source URL.
     ("skill_management__install_source", {"source": "https://github.com/user/skill-repo"}),
+    # pipeline category (IS-1) — run_pipeline requires name; input is optional.
+    ("pipeline__run", {"name": "my_pipeline", "input": {"topic": "x"}}),
 ]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — IS-1: the first end-to-end "an agent launches a registered pipeline and gets its result" slice, per `docs/proposals/reyn-pipeline-v0.9-design-resolutions.md` R6.

## Scope (explicit narrowing — IS-1 only)
- **Sync + REGISTERED only.** `run_pipeline(name, input)` blocks the caller's own turn and runs the pipeline to completion via `PipelineExecutor().run(...)` in-process — no separate driver-session spawn.
- **Deferred** (per R6, not attempted here): `run_pipeline_async` (driver-session + auto-resume), `run_pipeline_inline` (ad-hoc + static-analysis gate), the YAML DSL parser (pipelines are registered programmatically), and live-LLM surfacing (`run_pipeline` is registered in the unified `ToolRegistry` + fully dispatch-complete, but not yet added to `build_tools()` — the same "PR-3b" follow-up already deferred for `list_actions`/`search_actions`/`describe_action`/`invoke_action`).

## What's implemented
1. **`PipelineRegistry`** (`src/reyn/core/pipeline/registry.py`) — plain `name -> Pipeline` map, `register`/`get`/`names`. Not a process singleton — threaded explicitly (mirrors `AgentRegistry`/`StateLog`), via a new `RouterCallerState.pipeline_registry` field.
2. **`run_pipeline` tool** (`src/reyn/tools/pipeline_verbs.py`):
   - Looks up the pipeline; clear tool error if absent or `name` missing.
   - **`tool_dispatch` → REAL tool execution**: routes a `ToolStep.name` through the SAME seam `invoke_action` uses (`universal_dispatch.resolve_invoke_action` + the unified `ToolRegistry`, falling back to a bare-name lookup) — `ctx` is forwarded verbatim, so a `tool` step transitively reaches `op_runtime.execute_op` exactly like a direct tool call (proven in the e2e test: the tool step's `file__write` really writes the file).
   - `registry` (`AgentRegistry`, for `AgentStep`s) and `default_identity` (the calling actor) come from `ctx.router_state.agent_registry` / `ctx.router_state.host.agent_name`.
   - `state_log` (R4 recovery) comes from `ctx.state_log` — the same process-shared WAL every other recovery-aware tool threads, so a `run_pipeline` call gets step-boundary recovery for free from the existing executor.
   - Pipeline failure → clear `{"status": "error", ...}` tool result (not a raw exception).
3. **S3 constraint**: an `agent` pipeline step is a spawn-tree leaf — `_build_agent_step_narrowing` (`runtime/session_api.py`) now also denies `run_pipeline` (alongside the pre-existing `delegate_to_agent` deny), so a pipeline's agent step cannot launch a nested pipeline. Nesting stays `call`-only (future slice).
4. **Dispatch-completeness** (the class of gap that bit skill verbs): new `pipeline` category in `CATEGORIES` (`universal_catalog.py`) + matching SP bullet (`_universal_sp.py`, order-checked against `CATEGORIES` by an existing test) + `pipeline__run` route in `universal_dispatch._OPERATION_RULES` + classified in `_NOT_EXTERNAL` (`test_returns_external_content_flagset_1822.py` — returns the pipeline's own output, not external content) + a `_ROUTE_CONTRACT_SAMPLES` entry (`test_universal_dispatch.py`) + a new `pipeline-run` floored class in `capability_profile._FLOORED_QUALIFIED` (spawn-adjacent — a pipeline step can itself write/exec/delegate, so launching one from untrusted content is floored like `session_spawn`/`agent_spawn`).

## Tests
- `tests/test_run_pipeline_tool_is1.py` (new, Tier 2c): full transform→tool→agent e2e with a real `PipelineRegistry`/`Workspace`/`PermissionResolver`/`AgentRegistry`/`Session` (only the LLM completion is scripted, via the same `_loop_observer` seam `test_pipeline_r5_agent_step_executor.py` uses) + missing-pipeline / missing-name / no-registry / unknown-tool-step-failure / S3-deny cases.
- Updated `tests/test_pipeline_r5_run_agent_step.py` (the pre-existing narrowing pin now covers `run_pipeline` too) and `tests/test_2081_s3_delegation_audit.py` (the "tight profile" fixture now also denies the new `pipeline-run` floored class).

## Gates (all green)
- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 88 tests inspected, 0 errors/warnings.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.
- Full `pytest` from repo root: **`10 failed, 6961 passed, 30 skipped, 11 warnings, 10 errors in 96.93s`** — verified byte-identical to the pre-existing main baseline (stashed my diff and re-ran the exact same 10 failing + 10 erroring test files: identical failure set, all mcp/uvicorn/a2a — 0 new failures from this change).

## Test plan
- [x] Full pytest suite run, 0 new failures vs main baseline (verified via git-stash A/B).
- [x] ruff clean.
- [x] tier-audit --strict clean on all changed/added test files.
- [x] module-docstrings clean on all changed/added src files.
- [x] Manual: exercised the e2e path via the new Tier-2c test (real registry/session/workspace, scripted LLM only) — confirmed the tool step's file write is real (not a stub) and the agent step's scripted reply threads through as the pipeline's final output.