### PR TITLE
feat(pipeline): IS-5 surface pipelines + wire PipelineRegistry/agent_registry into production

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -118,9 +118,18 @@ Step = Union[TransformStep, ToolStep, AgentStep]
 
 @dataclass(frozen=True)
 class Pipeline:
-    """A linear sequence of steps."""
+    """A linear sequence of steps.
+
+    ``description`` (IS-5): optional human-readable summary surfaced to the
+    LLM by the universal catalog's ``pipeline`` category enumerator
+    (``tools/universal_catalog.py:_enumerate_category``), so an agent
+    deciding whether to ``run_pipeline`` a registered pipeline sees what it
+    does, not just its bare name. Empty string when the registrant omits
+    it — the enumerator still lists the pipeline (name is enough to invoke
+    it), just with no description text."""
 
     steps: "list[Step]"
+    description: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/reyn/core/pipeline/registry.py
+++ b/src/reyn/core/pipeline/registry.py
@@ -71,5 +71,14 @@ class PipelineRegistry:
         surfacing, e.g. an L1-style list like the skill registry's)."""
         return tuple(self._pipelines)
 
+    def entries(self) -> "tuple[tuple[str, str], ...]":
+        """``(name, description)`` for every registered pipeline (IS-5:
+        consumed by the universal catalog's ``pipeline`` category
+        enumerator so ``list_actions(category=["pipeline"])`` surfaces
+        each registered pipeline's name + description to the LLM)."""
+        return tuple(
+            (name, pipeline.description) for name, pipeline in self._pipelines.items()
+        )
+
 
 __all__ = ["PipelineRegistry", "PipelineNotFoundError"]

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3468,6 +3468,21 @@ class RouterLoop:
             available_skills=(
                 getattr(self.host, "get_available_skills", lambda: None)()
             ),
+            # IS-5: real AgentRegistry / PipelineRegistry so ``run_pipeline``
+            # (and any future AgentStep-bearing pipeline) resolve against
+            # live production state instead of the None landmine — prior to
+            # this, ``rs.agent_registry`` / ``rs.pipeline_registry`` were
+            # never populated by the live router path, so run_pipeline
+            # always errored "no PipelineRegistry" at call time. getattr
+            # fallback keeps narrow test hosts (FakeRouterHost, plan-step
+            # host without these accessors) at None (= graceful degrade,
+            # same posture as mcp_servers / available_skills above).
+            agent_registry=(
+                getattr(self.host, "get_agent_registry", lambda: None)()
+            ),
+            pipeline_registry=(
+                getattr(self.host, "get_pipeline_registry", lambda: None)()
+            ),
         )
 
     async def _invoke_via_registry(self, name: str, args: dict) -> Any:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -54,6 +54,9 @@ class RouterHostAdapter:
         SnapshotJournal instance for plan-lifecycle persistence.
     agent_registry:
         AgentRegistry (or None) for listing reachable peers.
+    pipeline_registry:
+        PipelineRegistry (or None, IS-5) — the ``run_pipeline`` tool's
+        lookup source, exposed via ``get_pipeline_registry()``.
     agent_workspace_dir:
         Path to ``.reyn/agents/<agent_name>`` — used for ``get_memory_index``.
     file_read:
@@ -103,6 +106,7 @@ class RouterHostAdapter:
         journal: Any,                           # SnapshotJournal
         state_log: Any = None,                  # StateLog | None — #2248 PR-A2 (config emit)
         agent_registry: Any,                    # AgentRegistry | None
+        pipeline_registry: Any = None,          # PipelineRegistry | None — IS-5
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
         current_task_id_fn: "Callable[[], str | None] | None" = None,     # #1953 §16
@@ -319,6 +323,7 @@ class RouterHostAdapter:
         self._journal = journal
         self._state_log = state_log  # #2259 PR-1: WAL head for config generation emit
         self._registry = agent_registry
+        self._pipeline_registry = pipeline_registry  # IS-5: run_pipeline lookup source
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
         self._current_task_id_fn = current_task_id_fn      # #1953 §16
@@ -585,6 +590,22 @@ class RouterHostAdapter:
 
     def get_mcp_servers(self) -> list[dict]:
         return self._get_mcp_servers_for_router()
+
+    def get_agent_registry(self) -> Any:
+        """The real AgentRegistry (or None) — IS-5: exposes the private
+        ``self._registry`` (already threaded in for peer-listing/delegation)
+        through a public accessor so ``RouterLoop._build_router_caller_state``
+        can populate ``RouterCallerState.agent_registry`` without reaching
+        into the adapter's private attribute."""
+        return self._registry
+
+    def get_pipeline_registry(self) -> Any:
+        """The real PipelineRegistry (or None) — IS-5: read by
+        ``RouterLoop._build_router_caller_state`` to populate
+        ``RouterCallerState.pipeline_registry`` so ``run_pipeline`` resolves
+        against the session's actual registered pipelines instead of the
+        None landmine."""
+        return self._pipeline_registry
 
     def get_web_fetch_allowed(self) -> bool:
         """Always returns True — FP-0022: web_fetch is now always in the catalog.

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -32,6 +32,7 @@ from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.snapshot_generations import SnapshotGenerationStore
 from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.registry import PipelineRegistry
 from reyn.hooks.dispatcher import HOOK_INBOX_KIND
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.agent import Agent
@@ -1055,6 +1056,13 @@ class Session:
         # and for agent-to-agent message routing (PR11). The factory in
         # cli/commands/chat.py wires this; tests can leave it None.
         self._registry = registry
+        # IS-5: Session owns a real (initially empty) PipelineRegistry so
+        # ``run_pipeline`` has a live registry to look up against in
+        # production — populating it from disk / a YAML DSL parser is a
+        # later slice; registration is programmatic for now (mirrors the
+        # pre-parser AgentRegistry posture). Threaded to RouterHostAdapter
+        # below (mirrors ``agent_registry=self._registry`` just above).
+        self._pipeline_registry = PipelineRegistry()
         # PR11: max delegation hop depth (LangGraph-style). 0 = user input,
         # each `_send_to_agent` increments. Refuse send when depth > limit.
         self._max_hop_depth = _safety.loop.max_agent_hops
@@ -1466,6 +1474,12 @@ class Session:
             memory=self._memory,
             journal=self._journal,
             agent_registry=self._registry,
+            # IS-5: the session's real (initially empty) PipelineRegistry —
+            # mirrors agent_registry above. Exposed via
+            # RouterHostAdapter.get_pipeline_registry() and read onto
+            # RouterCallerState.pipeline_registry by
+            # RouterLoop._build_router_caller_state.
+            pipeline_registry=self._pipeline_registry,
             # #2103 S1bc-exec: record a spawned session's sid→task (the trusted result
             # header source) + read this session's LIVE sid (the cached session_id above
             # is stale for spawned sessions, stamped post-construction) for the non-main
@@ -2000,6 +2014,22 @@ class Session:
         surface.
         """
         return self._registry
+
+    @property
+    def pipeline_registry(self) -> "PipelineRegistry":
+        """Read-only accessor for the session's owning PipelineRegistry.
+
+        IS-5: Session constructs + owns a real (initially empty)
+        ``PipelineRegistry`` instance — populating it from disk / a YAML
+        DSL parser is a later slice; this property + the constructor
+        wiring below exist so ``run_pipeline`` has a real registry to
+        look up against in production, not the ``None`` landmine
+        (``ctx.router_state.pipeline_registry`` was never populated
+        before this). Threaded into ``RouterHostAdapter`` at
+        construction (mirrors ``agent_registry`` above), then onto
+        ``RouterCallerState`` by ``RouterLoop._build_router_caller_state``.
+        """
+        return self._pipeline_registry
 
     @property
     def interventions(self) -> "InterventionRegistry":

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -206,8 +206,12 @@ def get_default_registry() -> ToolRegistry:
     # #2548 PR-D: skill install verb (git/GitHub URL source fetch).
     registry.register(SKILL_INSTALL_SOURCE)
     # IS-1 (pipeline v0.9 R6): run_pipeline — sync launch of a REGISTERED
-    # pipeline. Router+phase allow; not yet in build_tools() (surfacing is a
-    # later slice, mirrors the universal-catalog wrappers' own PR-3b deferral).
+    # pipeline. Router+phase allow. IS-5: surfaced to the live LLM catalog
+    # via the ``pipeline`` universal-catalog category enumerator (lists
+    # registered pipelines) + invoke_action (``pipeline__run`` /
+    # ``run_pipeline``) — the same PR-3b-shipped path every other
+    # universal-catalog wrapper uses, NOT build_tools() (which is
+    # hand-assembled and strips direct tools once wrappers are on).
     registry.register(RUN_PIPELINE)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -33,14 +33,22 @@ Dependencies the handler assembles for :class:`~reyn.core.pipeline.executor.Pipe
     ``ctx.router_state.host.agent_name`` when a host is present.
   - ``tool_dispatch`` — see :func:`_make_tool_dispatch`.
 
-NOTE (surfacing): this tool is registered in the unified ``ToolRegistry``
-(dispatch-completeness: routable via ``invoke_action``/``pipeline__run``,
-classified for the content-threat + capability-floor guards) but is NOT yet
-added to ``build_tools()`` — the live LLM tool list. That wiring is the same
-"PR-3b" follow-up already deferred for the other universal-catalog wrappers
-(``list_actions``/``search_actions``/``describe_action``/``invoke_action``);
-``run_pipeline`` rides the same follow-up, tracked as IS-1's "surfacing"
-deferral.
+NOTE (surfacing, IS-5): this tool is registered in the unified
+``ToolRegistry`` (dispatch-completeness: routable via
+``invoke_action``/``pipeline__run``, classified for the content-threat +
+capability-floor guards) and IS surfaced to the live LLM — not via
+``build_tools()`` (which is hand-assembled and strips direct tools once the
+universal-catalog wrappers are on; PR-3b already shipped that default-on),
+but via the same modern path every other universal-catalog wrapper uses: the
+``pipeline`` resource category in ``tools/universal_catalog.py:
+_enumerate_category`` lists each REGISTERED pipeline (name + description)
+from ``ctx.router_state.pipeline_registry``, and the LLM launches a chosen
+one through ``invoke_action(action="pipeline__run", args={name, input})``.
+``Session`` (``runtime/session.py``) constructs + owns the production
+``PipelineRegistry`` that backs this (empty until a later slice populates it
+from disk / a parser); it is threaded through ``RouterHostAdapter`` onto
+``RouterCallerState.pipeline_registry`` by
+``RouterLoop._build_router_caller_state``.
 """
 from __future__ import annotations
 

--- a/src/reyn/tools/types.py
+++ b/src/reyn/tools/types.py
@@ -57,9 +57,11 @@ class RouterCallerState:
     # IS-1 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6): the
     # PipelineRegistry the run_pipeline tool looks up a registered Pipeline by
     # name in. Threaded explicitly (mirrors agent_registry above) rather than a
-    # hidden global, since IS-1 registration is programmatic per-owner. None =
-    # host doesn't support run_pipeline (surfacing to the live LLM catalog is
-    # a later slice; this field exists so the handler + tests have a seam).
+    # hidden global, since IS-1 registration is programmatic per-owner. IS-5:
+    # populated in production by RouterLoop._build_router_caller_state from
+    # Session's real PipelineRegistry (host.get_pipeline_registry()) — no
+    # longer None on the live path. None only for narrow test hosts that
+    # don't support run_pipeline.
     pipeline_registry: Any = None
 
     # Async dispatch callbacks (= for delegate_to_agent / plan

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -716,6 +716,28 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
             })
         return out2
 
+    if category == "pipeline":
+        # IS-5: enumerate REGISTERED pipelines from the caller state's
+        # PipelineRegistry (mirrors the rag_corpus branch above). Each
+        # ``pipeline__<name>`` entry is directly invokable — D19 resource
+        # invoke, ``universal_dispatch._RESOURCE_RULES["pipeline"]`` curries
+        # ``name`` and forwards ``input`` to ``run_pipeline`` — same pattern
+        # as ``rag_corpus__<name>`` currying ``sources`` into ``recall``. The
+        # pre-existing static ``pipeline__run`` verb (``args={name, input}``)
+        # keeps working unchanged (exact _OPERATION_RULES match wins first).
+        # None registry (narrow test hosts / a host that doesn't support
+        # run_pipeline) → empty list.
+        pipeline_registry = getattr(rs, "pipeline_registry", None) if rs is not None else None
+        if pipeline_registry is None:
+            return []
+        return [
+            {
+                "qualified_name": build_qualified_name("pipeline", name),
+                "short_description": _truncate_short_description(description),
+            }
+            for name, description in pipeline_registry.entries()
+        ]
+
     # exec category — sandboxed_exec (FP-0017).
     # Visible only when a real sandbox backend is configured (D14-ext).
     # RouterCallerState.sandbox_backend carries the backend name (None = noop).
@@ -1294,6 +1316,9 @@ def _resource_input_schema(
       - ``mcp__<server>__<tool>`` — scans ``ctx.router_state.mcp_servers``
         for the tool's declared ``inputSchema`` (#1647 per-tool action; static
         mcp verbs fall through to the verb's parameters).
+      - ``pipeline__<name>`` (IS-5) — ``run_pipeline`` parameters minus
+        ``name`` (the registered pipeline's own name, curried from the
+        qualified name).
 
     Returns ``None`` when the category isn't a resource category, or when
     the per-resource metadata isn't reachable (= test sites with stub
@@ -1322,6 +1347,17 @@ def _resource_input_schema(
         if t is not None and isinstance(t.get("inputSchema"), Mapping):
             return dict(t["inputSchema"])
         return None
+
+    if category == "pipeline":
+        # IS-5: pipeline__<name> curries the pipeline name (mirrors rag_corpus
+        # currying ``sources``) — strip ``name`` from run_pipeline's
+        # parameters so the LLM only sees ``input``. The static
+        # ``pipeline__run`` verb itself is an exact _OPERATION_RULES match
+        # (checked first) so it never reaches this per-category fallback.
+        tool = registry.lookup("run_pipeline")
+        if tool is None:
+            return None
+        return _drop_field_from_schema(tool.parameters, "name")
 
     # memory_entry__X and any other category: pre-existing dispatch shape
     # mismatch (memory_entry's transform sends {name} but read_memory_body
@@ -1354,6 +1390,8 @@ def _resource_description(
         action; static mcp verbs fall through to the verb's description).
       - ``mcp.server__<name>`` — pulls server-level ``description`` from
         ``ctx.router_state.mcp_servers``.
+      - ``pipeline__<name>`` (IS-5) — pulls the registered ``Pipeline``'s
+        own ``description`` from ``ctx.router_state.pipeline_registry``.
 
     Falls through to ``target.description`` (= caller default) for:
       - ``rag_corpus__<name>`` — no per-corpus description metadata
@@ -1390,6 +1428,22 @@ def _resource_description(
             desc = t.get("description")
             return str(desc) if desc else None
         return None
+
+    if category == "pipeline":
+        # IS-5: pipeline__<name> — the REGISTERED pipeline's own description
+        # (so describe_action / the enumerate-all flat tool description shows
+        # what THIS pipeline does, not the generic run_pipeline blurb).
+        # None registry / not-found → caller falls back to run_pipeline's text.
+        from reyn.core.pipeline.registry import PipelineNotFoundError
+
+        pipeline_registry = getattr(rs, "pipeline_registry", None) if rs is not None else None
+        if pipeline_registry is None:
+            return None
+        try:
+            pipeline = pipeline_registry.get(entry_name)
+        except PipelineNotFoundError:
+            return None
+        return pipeline.description or None
 
     # rag_corpus / memory_entry / unknown — fall through to target.description
     return None

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -158,6 +158,29 @@ def _recall_single_source_args(
     return out
 
 
+def _pipeline_run_args(entry_name: str, args: Mapping[str, Any]) -> dict[str, Any]:
+    """``pipeline__<name>`` → ``run_pipeline({name, input})`` (IS-5 D19
+    resource invoke).
+
+    The catalog's ``pipeline`` resource category (``universal_catalog.py:
+    _enumerate_category``) lists each REGISTERED pipeline as
+    ``pipeline__<name>``; invoking that qualified name curries the pipeline
+    name from the entry (same pattern as ``rag_corpus__<name>`` currying
+    ``sources``) and forwards the caller's ``input`` object unchanged as the
+    pipeline's seed context. This is ADDITIVE to the pre-existing static
+    ``pipeline__run`` verb in ``_OPERATION_RULES`` (checked first by
+    ``resolve_invoke_action``/``resolve_describe_action`` — an explicit
+    qualified-name match always wins over this per-category fallback), so
+    both ``invoke_action(action="pipeline__run", args={name, input})`` and
+    ``invoke_action(action="pipeline__<name>", args={input})`` reach
+    ``run_pipeline`` with the same effective args.
+    """
+    out: dict[str, Any] = {"name": entry_name}
+    if "input" in args:
+        out["input"] = args["input"]
+    return out
+
+
 def _mcp_tool_args(entry_name: str, args: Mapping[str, Any]) -> dict[str, Any]:
     """``mcp__<server>__<tool>`` → ``mcp_call_tool({tool, tool_args})`` (#1647).
 
@@ -223,6 +246,9 @@ _RESOURCE_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], d
     # (mcp__call_tool / mcp__list_tools / …) match _OPERATION_RULES FIRST, so they
     # are unaffected; only dynamic per-tool names reach this rule.
     "mcp":           ("mcp_call_tool",       _mcp_tool_args),
+    # IS-5: pipeline__<name> → run_pipeline({name, input}) — see
+    # _pipeline_run_args. Additive alongside the static pipeline__run verb.
+    "pipeline":      ("run_pipeline",        _pipeline_run_args),
 }
 
 

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -72,6 +72,7 @@ def make_adapter(
     session_id: "str | None" = None,
     current_task_id_fn: "object | None" = None,  # #1953 §16: per-turn execution context
     agent_registry: object = None,  # #2103: real AgentRegistry for spawn/topology seams
+    pipeline_registry: object = None,  # IS-5: real PipelineRegistry for run_pipeline lookup
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
     safety_extensions: "dict | None" = None,  # #2175: shared per-run extension dict
     intervention_answer: "str | None" = None,  # #2175: interactive-mode bus answer (choice_id, e.g. "yes")
@@ -134,6 +135,7 @@ def make_adapter(
         memory=memory,
         journal=None,
         agent_registry=agent_registry,
+        pipeline_registry=pipeline_registry,  # IS-5
         handle_chat_limit_checkpoint=_checkpoint,  # #2175
         safety_extensions=_ext,  # #2175
         agent_workspace_dir=workspace,

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -366,3 +366,121 @@ async def test_run_pipeline_via_invoke_action_full_live_loop(
     agent_msgs = [m for m in msgs if m.kind == "agent"]
     assert agent_msgs, "expected an agent outbox message after the tool round"
     assert agent_msgs[-1].text == "the pipeline ran successfully"
+
+
+# ---------------------------------------------------------------------------
+# 5. The D19 pipeline__<name> resource-invoke path (the scope IS-5 adds
+#    beyond IS-1's static pipeline__run verb).
+# ---------------------------------------------------------------------------
+
+
+def test_d19_pipeline_name_resolves_to_run_pipeline_with_curried_args() -> None:
+    """Tier 2: OS invariant — the D19 resource-invoke rule routes
+    ``pipeline__<name>`` to the ``run_pipeline`` target, currying the pipeline
+    name from the qualified name and forwarding ``input`` unchanged. This is
+    the whole point of the IS-5 D19 addition (the enumerate-all default scheme
+    surfaces ``pipeline__<name>`` as a flat callable, so it MUST resolve) — and
+    it is EQUIVALENT to invoking the pre-existing static ``pipeline__run`` verb
+    with an explicit ``name``. Pure routing assertion (no handler invoked),
+    same discipline as ``resolve_invoke_action``'s other resource-category
+    tests."""
+    from reyn.tools.universal_dispatch import resolve_invoke_action
+
+    seed = {"name": "world"}
+
+    # D19 per-name form: pipeline__greet, name curried from the qualified name.
+    by_name = resolve_invoke_action("pipeline__greet", {"input": seed})
+    # Static verb form: pipeline__run, name passed explicitly.
+    by_verb = resolve_invoke_action("pipeline__run", {"name": "greet", "input": seed})
+
+    assert by_name.target_tool_name == "run_pipeline"
+    assert dict(by_name.target_args) == {"name": "greet", "input": seed}
+    # The equivalence the _pipeline_run_args docstring claims: both spellings
+    # reach run_pipeline with the SAME effective args.
+    assert by_name.target_tool_name == by_verb.target_tool_name
+    assert dict(by_name.target_args) == dict(by_verb.target_args)
+
+
+def test_d19_pipeline_name_resolves_without_input_when_omitted() -> None:
+    """Tier 2: OS invariant — ``pipeline__<name>`` with no ``input`` arg
+    resolves to ``run_pipeline`` carrying only the curried ``name`` (a
+    seed-less pipeline is a valid launch; the handler treats a missing
+    ``input`` as no seed). Guards against the transformer injecting a
+    spurious empty ``input`` key."""
+    from reyn.tools.universal_dispatch import resolve_invoke_action
+
+    resolved = resolve_invoke_action("pipeline__greet", {})
+
+    assert resolved.target_tool_name == "run_pipeline"
+    assert dict(resolved.target_args) == {"name": "greet"}
+
+
+def _pipeline_by_name_invoke_result(name: str, seed_input: dict) -> LLMToolCallResult:
+    """LLMToolCallResult that makes RouterLoop call the D19 per-name form
+    ``invoke_action(action_name="pipeline__<name>", args={input})`` (the
+    resource-invoke path, distinct from the static ``pipeline__run`` verb)."""
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[
+            {
+                "id": "tc_pipeline_byname_001",
+                "type": "function",
+                "function": {
+                    "name": "invoke_action",
+                    "arguments": json.dumps({
+                        "action_name": f"pipeline__{name}",
+                        "args": {"input": seed_input},
+                    }),
+                },
+            }
+        ],
+        finish_reason="tool_calls",
+        usage=_EMPTY_USAGE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_via_d19_pipeline_name_full_live_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2c: the D19 ``pipeline__<name>`` resource-invoke path end-to-end
+    through the REAL router loop — proves the surfacing form the enumerator
+    advertises (``pipeline__<name>``, not the generic ``pipeline__run`` verb)
+    actually launches the registered pipeline and returns its real output.
+    Same harness as the ``pipeline__run`` live-loop test above; only the
+    LLM's chosen action name differs (the per-name D19 form), so this closes
+    the coverage gap on exactly the path IS-5 adds."""
+    monkeypatch.chdir(tmp_path)
+    session = Session(
+        agent_name="test_agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        chat_tool_use_scheme="universal-category",
+    )
+    session.is_attached = True
+
+    session.pipeline_registry.register(
+        "greet",
+        Pipeline(
+            steps=[TransformStep(value="'hello ' + ctx.name", output="greeting")],
+            description="Greet the named recipient.",
+        ),
+    )
+
+    stub = _make_llm_stub([
+        _pipeline_by_name_invoke_result("greet", {"name": "world"}),
+        _text_result("the pipeline ran successfully"),
+    ])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
+
+    await session._handle_user_message(
+        "please run the greet pipeline", chain_id="chain-is5-002",
+    )
+
+    tool_messages = [m for m in session.history if m.role == "tool"]
+    assert tool_messages, "expected at least one tool-result history entry"
+    payload = json.loads(tool_messages[-1].content)
+    assert payload["status"] == "ok"
+    inner = payload["data"]
+    assert inner["status"] == "ok"
+    assert inner["data"]["output"] == "hello world"
+    assert inner["data"]["named_stores"]["greeting"] == "hello world"

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -1,0 +1,368 @@
+"""Tier 2 / Tier 2c: IS-5 — run_pipeline surfacing + production registry wiring.
+
+Prior to IS-5, ``PipelineRegistry`` (``core/pipeline/registry.py``) was never
+wired into production: ``RouterCallerState.pipeline_registry`` (consumed by
+the ``run_pipeline`` tool, ``tools/pipeline_verbs.py``) defaulted to ``None``
+and nothing ever populated it on the live router path, so ``run_pipeline``
+always errored "no PipelineRegistry" when an agent tried to call it. Likewise
+``RouterCallerState.agent_registry`` was never populated by
+``RouterLoop._build_router_caller_state`` (needed for a pipeline's
+``AgentStep``). And the ``pipeline`` universal-catalog category had no
+``_enumerate_category`` branch, so ``list_actions(category=["pipeline"])``
+never surfaced a registered pipeline to the LLM.
+
+This file covers:
+  1. ``RouterCallerState.pipeline_registry`` / ``.agent_registry`` are
+     populated from ``host.get_pipeline_registry()`` / ``get_agent_registry()``
+     by ``RouterLoop._build_router_caller_state`` (mirrors the pre-existing
+     ``test_router_caller_state_mcp_servers.py`` pattern for ``mcp_servers``).
+  2. A real ``Session`` constructs + owns a real (non-None) ``PipelineRegistry``,
+     threaded through ``RouterHostAdapter`` — the "landmine gone" invariant.
+  3. ``list_actions(category=["pipeline"])`` surfaces a registered pipeline's
+     name + description.
+  4. The FULL live router loop: a scripted LLM emits
+     ``invoke_action(action_name="pipeline__run", args={name, input})``;
+     the OS drives it through the real Session → real PipelineRegistry →
+     real PipelineExecutor, and the pipeline's actual output round-trips
+     back into chat history.
+
+Policy compliance (docs/deep-dives/contributing/testing.md): no
+unittest.mock.MagicMock/AsyncMock/patch — the LLM is faked via a real async
+callable stub (Tier 2c), monkeypatched onto ``reyn.runtime.router_loop.
+call_llm_tools`` (the designed Tier-2 test seam), same precedent as
+``tests/test_session_invariants.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, TransformStep
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# 1. RouterCallerState wiring (RouterLoop + minimal fake host — mirrors
+#    tests/test_router_caller_state_mcp_servers.py's precedent).
+# ---------------------------------------------------------------------------
+
+
+class _FakeHost:
+    """Minimal RouterLoopHost stub — real shape, no mock framework."""
+
+    agent_name: str = "test-agent"
+    agent_role: str = ""
+    output_language: str = "en"
+
+    def __init__(
+        self,
+        *,
+        pipeline_registry: Any = None,
+        agent_registry: Any = None,
+        expose_pipeline_registry: bool = True,
+        expose_agent_registry: bool = True,
+    ) -> None:
+        self._pipeline_registry = pipeline_registry
+        self._agent_registry = agent_registry
+
+        class _E:
+            def emit(self, *a, **kw): pass
+            subscribers: list = []
+        self._events = _E()
+
+        if expose_pipeline_registry:
+            self.get_pipeline_registry = lambda: self._pipeline_registry  # type: ignore[method-assign]
+        if expose_agent_registry:
+            self.get_agent_registry = lambda: self._agent_registry  # type: ignore[method-assign]
+
+    @property
+    def events(self): return self._events
+
+    def get_universal_wrappers_enabled(self) -> bool: return True
+    def get_action_usage_tracker(self): return None
+    def get_action_embedding_index(self): return None
+    def get_embedding_provider(self): return None
+    def get_embedding_model_class(self): return None
+    def get_action_retrieval_config(self): return None
+    def list_available_skills(self) -> list[dict]: return []
+    def list_available_agents(self) -> list[dict]: return []
+    def get_memory_index(self) -> dict: return {"status": "not_found", "content": ""}
+    def get_file_permissions(self): return None
+    def get_mcp_servers(self) -> list[dict]: return []
+    def get_web_fetch_allowed(self) -> bool: return False
+    def get_project_context(self) -> str: return ""
+    def get_sandbox_backend(self): return None
+    def resolve_model(self, name: str) -> str: return "fake-model"
+
+
+def _build_router_loop(host: _FakeHost) -> Any:
+    from reyn.runtime.router_loop import RouterLoop
+    return RouterLoop(host=host, chain_id="c1", router_model="standard")
+
+
+def test_pipeline_registry_threaded_into_router_caller_state() -> None:
+    """Tier 2: host.get_pipeline_registry() lands on rs.pipeline_registry.
+
+    The pre-fix landmine: RouterCallerState(...) construction never set
+    ``pipeline_registry=``, so the dataclass default (None) always won and
+    run_pipeline always errored "no PipelineRegistry available"."""
+    registry = PipelineRegistry()
+    loop = _build_router_loop(_FakeHost(pipeline_registry=registry))
+
+    rs = asyncio.run(loop._build_router_caller_state())
+
+    assert rs.pipeline_registry is registry
+
+
+def test_agent_registry_threaded_into_router_caller_state() -> None:
+    """Tier 2: host.get_agent_registry() lands on rs.agent_registry (needed
+    for a pipeline's AgentStep — a pipeline with no agent step degrades fine
+    with registry=None, but AgentStep pipelines need the real registry)."""
+    sentinel_registry = object()
+    loop = _build_router_loop(_FakeHost(agent_registry=sentinel_registry))
+
+    rs = asyncio.run(loop._build_router_caller_state())
+
+    assert rs.agent_registry is sentinel_registry
+
+
+def test_pipeline_and_agent_registry_missing_method_falls_back_to_none() -> None:
+    """Tier 2: a host without get_pipeline_registry()/get_agent_registry()
+    (narrow test hosts / FakeRouterHost variants) degrades to None rather
+    than raising AttributeError — the getattr-fallback posture every other
+    RouterCallerState field uses (mirrors mcp_servers' precedent)."""
+    loop = _build_router_loop(
+        _FakeHost(expose_pipeline_registry=False, expose_agent_registry=False)
+    )
+
+    rs = asyncio.run(loop._build_router_caller_state())
+
+    assert rs.pipeline_registry is None
+    assert rs.agent_registry is None
+
+
+# ---------------------------------------------------------------------------
+# 2. list_actions surfaces a registered pipeline (name + description).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_actions_pipeline_category_surfaces_registered_pipeline() -> None:
+    """Tier 2: list_actions(category=["pipeline"]) returns the registered
+    pipeline's qualified name + its OWN description (not a generic
+    run_pipeline blurb) — proves the enumerator + registry wiring end-to-end
+    at the universal-catalog layer."""
+    from reyn.tools.types import ToolContext
+    from reyn.tools.universal_catalog import LIST_ACTIONS
+
+    registry = PipelineRegistry()
+    registry.register(
+        "digest_report",
+        Pipeline(
+            steps=[TransformStep(value="1 + 1", output="two")],
+            description="Summarize the week's incoming reports.",
+        ),
+    )
+    loop = _build_router_loop(_FakeHost(pipeline_registry=registry))
+    rs = await loop._build_router_caller_state()
+    ctx = ToolContext(
+        events=loop.host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=rs,
+    )
+
+    result = await LIST_ACTIONS.handler({"category": ["pipeline"]}, ctx)
+
+    items = {it["qualified_name"]: it for it in result["items"]}
+    assert "pipeline__digest_report" in items
+    assert items["pipeline__digest_report"]["short_description"] == (
+        "Summarize the week's incoming reports."
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_actions_pipeline_category_empty_registry_returns_empty() -> None:
+    """Tier 2: no registered pipelines -> list_actions(category=["pipeline"])
+    returns an empty item list (not an error), same graceful-empty posture
+    as the other resource categories (mcp.server / rag_corpus)."""
+    from reyn.tools.types import ToolContext
+    from reyn.tools.universal_catalog import LIST_ACTIONS
+
+    loop = _build_router_loop(_FakeHost(pipeline_registry=PipelineRegistry()))
+    rs = await loop._build_router_caller_state()
+    ctx = ToolContext(
+        events=loop.host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=rs,
+    )
+
+    result = await LIST_ACTIONS.handler({"category": ["pipeline"]}, ctx)
+
+    assert result["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Session owns a real, non-None PipelineRegistry, threaded to the adapter.
+# ---------------------------------------------------------------------------
+
+
+def test_session_pipeline_registry_is_real_instance_not_none(tmp_path: Path) -> None:
+    """Tier 2: Session.pipeline_registry is a real PipelineRegistry (the
+    "landmine gone" invariant) — threaded through RouterHostAdapter so
+    ``adapter.get_pipeline_registry() is session.pipeline_registry``, the
+    exact accessor RouterLoop._build_router_caller_state reads in
+    production."""
+    session = Session(agent_name="test_agent", state_log=StateLog(tmp_path / "wal.jsonl"))
+
+    assert isinstance(session.pipeline_registry, PipelineRegistry)
+    assert session.router_host.get_pipeline_registry() is session.pipeline_registry
+
+
+def test_session_agent_registry_threaded_to_adapter_accessor(tmp_path: Path) -> None:
+    """Tier 2: Session.agent_registry (possibly None outside a registry) is
+    exposed on the adapter via the SAME public accessor pattern IS-5 adds for
+    pipelines, so RouterLoop can read it without reaching into a private
+    attribute."""
+    session = Session(agent_name="test_agent", state_log=StateLog(tmp_path / "wal.jsonl"))
+
+    assert session.router_host.get_agent_registry() is session.agent_registry
+
+
+# ---------------------------------------------------------------------------
+# 4. Full live router loop: LLM calls invoke_action("pipeline__run", ...).
+# ---------------------------------------------------------------------------
+
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _pipeline_invoke_result(name: str, seed_input: dict) -> LLMToolCallResult:
+    """LLMToolCallResult that makes RouterLoop call run_pipeline via the
+    invoke_action universal-catalog wrapper (the modern surfacing path)."""
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[
+            {
+                "id": "tc_pipeline_001",
+                "type": "function",
+                "function": {
+                    "name": "invoke_action",
+                    "arguments": json.dumps({
+                        "action_name": "pipeline__run",
+                        "args": {"name": name, "input": seed_input},
+                    }),
+                },
+            }
+        ],
+        finish_reason="tool_calls",
+        usage=_EMPTY_USAGE,
+    )
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=text, tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+    )
+
+
+def _make_llm_stub(results: list[LLMToolCallResult]):
+    """Real async callable stub (Tier 2c) — NOT unittest.mock.AsyncMock — a
+    signature drift in call_llm_tools would raise TypeError here exactly as
+    it would in production."""
+    call_count = [0]
+
+    async def _stub(**kwargs) -> LLMToolCallResult:
+        idx = call_count[0]
+        call_count[0] += 1
+        return results[idx] if idx < len(results) else results[-1]
+
+    return _stub
+
+
+def _drain_outbox(session: Session) -> list:
+    msgs = []
+    while not session.outbox.empty():
+        msgs.append(session.outbox.get_nowait())
+    return msgs
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_via_invoke_action_full_live_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2c: an agent actually launches a registered pipeline through the
+    REAL router loop — the end-to-end proof IS-5 sets out to establish.
+
+    Registers a real Pipeline into a real Session's production
+    PipelineRegistry, scripts the LLM to emit
+    ``invoke_action(action_name="pipeline__run", args={name, input})``, and
+    drives one full user turn. Asserts the pipeline's REAL transform output
+    (not a stub) round-trips into the tool-result chat history entry, and
+    the router's second-round text reply reaches the outbox — proving the
+    registry wiring + catalog surfacing + dispatch seam all connect, not
+    just the handler in isolation (which test_run_pipeline_tool_is1.py
+    already covers)."""
+    monkeypatch.chdir(tmp_path)
+    session = Session(
+        agent_name="test_agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        # #1657 precedent: pin the scheme to match the scripted invoke_action
+        # tool-call shape (universal-category interprets the wrapper; the
+        # owner-default enumerate-all scheme would advertise a DIFFERENT flat
+        # tool name for the same pipeline — see the per-pipeline qualified
+        # name test above for that path).
+        chat_tool_use_scheme="universal-category",
+    )
+    session.is_attached = True
+
+    # Register a real pipeline into the session's OWN production registry —
+    # not a test-local instance — proving Session.pipeline_registry is what
+    # the live loop actually consults.
+    session.pipeline_registry.register(
+        "greet",
+        Pipeline(
+            steps=[TransformStep(value="'hello ' + ctx.name", output="greeting")],
+            description="Greet the named recipient.",
+        ),
+    )
+
+    stub = _make_llm_stub([
+        _pipeline_invoke_result("greet", {"name": "world"}),
+        _text_result("the pipeline ran successfully"),
+    ])
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", stub)
+
+    await session._handle_user_message(
+        "please run the greet pipeline", chain_id="chain-is5-001",
+    )
+
+    # The tool-result history entry carries the REAL pipeline output.
+    tool_messages = [m for m in session.history if m.role == "tool"]
+    assert tool_messages, "expected at least one tool-result history entry"
+    # invoke_action wraps the target handler's own {status, data} envelope
+    # inside its own {status, data} — unwrap one level to reach run_pipeline's
+    # actual result shape ({run_id, output, named_stores}).
+    payload = json.loads(tool_messages[-1].content)
+    assert payload["status"] == "ok"
+    inner = payload["data"]
+    assert inner["status"] == "ok"
+    assert inner["data"]["output"] == "hello world"
+    assert inner["data"]["named_stores"]["greeting"] == "hello world"
+
+    # The router's second round reached the outbox (the loop didn't hang or
+    # error out after the tool call).
+    msgs = _drain_outbox(session)
+    agent_msgs = [m for m in msgs if m.kind == "agent"]
+    assert agent_msgs, "expected an agent outbox message after the tool round"
+    assert agent_msgs[-1].text == "the pipeline ran successfully"


### PR DESCRIPTION
**[lead-sonnet]** — IS-5: make `run_pipeline` actually agent-callable (wire the PipelineRegistry into production + surface pipelines to the LLM).

## Summary

Fixes the two gaps that made `run_pipeline` (IS-1, #2563) dispatch-wired but not actually usable by an agent:

1. **Registry wiring (the landmine)**: `Session` (`runtime/session.py`) now constructs + owns a real `PipelineRegistry` (`self._pipeline_registry`, initially empty — population from disk/a YAML parser is a later slice). Threaded through `RouterHostAdapter.__init__(pipeline_registry=...)` (mirrors the pre-existing `agent_registry` param), exposed via a new `get_pipeline_registry()` accessor (mirrors `get_mcp_servers()`), and read onto `RouterCallerState.pipeline_registry` by `RouterLoop._build_router_caller_state()` (`router_loop.py`). Prior to this, `rs.pipeline_registry` was *always* `None` on the live path — `run_pipeline` unconditionally errored "no PipelineRegistry available".
2. **`agent_registry` onto `RouterCallerState`**: same pattern — a new `RouterHostAdapter.get_agent_registry()` accessor, read by `_build_router_caller_state()`. Needed for a pipeline's `AgentStep` (pipelines without an agent step already degraded fine with `registry=None`).
3. **Pipeline surfacing**: added a `"pipeline"` resource-category branch to `_enumerate_category` (`tools/universal_catalog.py`), mirroring the `rag_corpus`/`mcp` enumerators — `list_actions(category=["pipeline"])` now lists every REGISTERED pipeline (`pipeline__<name>` qualified names + each pipeline's own `description`). Added an optional `description: str = ""` field to `Pipeline` (`core/pipeline/executor.py`) and `PipelineRegistry.entries()` (`core/pipeline/registry.py`) to back it.
   - Also added a D19 resource-invoke rule: `universal_dispatch._RESOURCE_RULES["pipeline"] = ("run_pipeline", _pipeline_run_args)`, so `pipeline__<name>` is directly callable/describable (curries `name`, forwards `input`) under BOTH the default `enumerate-all` scheme (flat native tool-call, via `catalog_entries()`) and the `universal-category` scheme (`invoke_action(action_name="pipeline__<name>", args={input})`). This was necessary — without it, `catalog_entries()` silently drops any qualified name `resolve_describe_action` can't resolve, so the enumerated pipeline names would never actually reach the LLM's tool list under the *default* production scheme. The pre-existing static `pipeline__run` verb (`args={name, input}`) is unchanged (exact `_OPERATION_RULES` match wins first).
4. **Stale docstrings fixed**: `pipeline_verbs.py` module docstring, `tools/__init__.py`'s `RUN_PIPELINE` registration comment, and `RouterCallerState.pipeline_registry`'s field comment all claimed surfacing was "deferred like PR-3b" — PR-3b already shipped; corrected to describe the actual (now-live) surfacing path.

## Tests

New `tests/test_pipeline_is5_surfacing.py` (8 tests, Tier 2 / 2c):
- `RouterCallerState.pipeline_registry` / `.agent_registry` populated from `host.get_pipeline_registry()` / `get_agent_registry()` (+ graceful `None` fallback for narrow hosts) — mirrors the pre-existing `test_router_caller_state_mcp_servers.py` precedent.
- `Session.pipeline_registry` is a real (non-`None`) `PipelineRegistry`; `session.router_host.get_pipeline_registry() is session.pipeline_registry` (the "landmine gone" invariant) — same for `agent_registry`.
- `list_actions(category=["pipeline"])` surfaces a registered pipeline's qualified name + its own description (and empty-registry → `[]`, not an error).
- **Full live router-loop e2e**: registers a real `Pipeline` into a real `Session`'s production `PipelineRegistry`, scripts the LLM (real async callable stub, not `AsyncMock`, via the `reyn.runtime.router_loop.call_llm_tools` seam) to emit `invoke_action(action_name="pipeline__run", args={name, input})`, drives one full user turn via `session._handle_user_message`, and asserts the pipeline's REAL transform output round-trips into the tool-result chat-history entry, and the router's second-round reply reaches the outbox.

Pre-existing suites: `pytest -k pipeline` (110 passed, 9 skipped) and `-k "universal_catalog or universal_dispatch or catalog or router_caller_state or router_host_adapter"` (297 passed) both green.

## Gates (all run locally)

- `ruff check src tests` — **All checks passed!**
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_is5_surfacing.py` — **8 tests inspected, 0 errors, 0 warnings**
- `python scripts/verify_module_docstrings.py <changed src files>` — **OK**
- Full `pytest` from repo root: **10 failed, 6969 passed, 30 skipped, 10 errors** — confirmed (via `git stash` diff against origin/main) to be the SAME pre-existing mcp/uvicorn/a2a failures (`test_fp0001_a2a_endpoints`, `test_fp0016_e_agent_id`, `test_mcp_structured_client_p1`, `test_web_ws_max_size_config_1934`, `web/test_a2a`, `web/test_plugin_loader`, `web/test_resources_router`, `test_config_mcp_headers`, `test_mcp_client` — all pre-existing per CLAUDE.md, zero new failures.

## Scope

IS-5 is surfacing + registry wiring only. Deferred (unchanged from IS-1): async `run_pipeline_async`, a YAML DSL parser for pipeline definitions, and ad-hoc (non-registered) `run_pipeline_inline`.

## Test plan

- [x] `ruff check src tests` clean
- [x] `pytest -k pipeline` green (110 passed)
- [x] Full `pytest` — 0 new failures vs origin/main baseline (verified via git stash diff)
- [x] `test_tier_audit.py --strict` on the new test file — 0 errors
- [x] `verify_module_docstrings.py` on changed src files — OK