### PR TITLE
feat(pipeline): IS-2 async pipeline driver-session + crash-resume

### DIFF
--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -1,0 +1,142 @@
+"""Pipeline ⇄ JSON-dict serialization (IS-2 work-order support).
+
+The async pipeline driver-session (IS-2) is *born with its work-order*: the
+full Pipeline definition is persisted to
+``.reyn/pipeline/state/<run_id>/invocation.json`` at spawn so a crashed
+driver-session can be re-created from disk alone — the same full-state,
+file-not-WAL-event recovery philosophy as the R4 step-boundary generations
+(``reyn.core.events.pipeline_recovery``). That requires a faithful round-trip
+between the executor's frozen step dataclasses
+(:class:`~reyn.core.pipeline.executor.Pipeline` /
+``TransformStep``/``ToolStep``/``AgentStep``) and plain JSON — this module is
+that round-trip, and nothing else (no YAML, no validation beyond shape: the
+DSL parser already validated the pipeline when it was registered).
+
+The one non-mechanical part is :class:`~reyn.core.pipeline.executor.ExprRef`
+inside ``ToolStep.args``: a JSON dict cannot carry a Python type, so an
+``ExprRef(src)`` value is encoded as the kind-marked dict
+``{"__exprref__": src}``. Kind-markers invite collisions, so the ambiguity is
+closed at ENCODE time: a *literal* args dict that itself contains the
+``"__exprref__"`` key is refused with :class:`PipelineSerdeError` naming the
+colliding arg — it must not silently round-trip into an ``ExprRef`` (decode
+would misread it) nor silently survive (a literal that decodes differently
+than it encoded is corruption). Decode only recognises the exact one-key
+marker shape ``{"__exprref__": <str>}`` as an ``ExprRef``; any other dict is
+a literal.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    ExprRef,
+    Pipeline,
+    Step,
+    ToolStep,
+    TransformStep,
+)
+
+_EXPRREF_KEY = "__exprref__"
+
+
+class PipelineSerdeError(ValueError):
+    """Raised when a Pipeline cannot be faithfully serialized/deserialized —
+    e.g. an ``ExprRef`` marker-key collision in a literal ``ToolStep.args``
+    value, or an unknown step ``kind`` in a stored work-order."""
+
+
+def _encode_arg(step_name: str, key: str, value: Any) -> Any:
+    if isinstance(value, ExprRef):
+        return {_EXPRREF_KEY: value.src}
+    if isinstance(value, dict) and _EXPRREF_KEY in value:
+        raise PipelineSerdeError(
+            f"tool step {step_name!r} arg {key!r} is a literal dict containing "
+            f"the reserved key {_EXPRREF_KEY!r} — it would be indistinguishable "
+            "from an ExprRef marker on decode. Rename the key or wrap the "
+            "value differently."
+        )
+    return value
+
+
+def _decode_arg(value: Any) -> Any:
+    if (
+        isinstance(value, dict)
+        and set(value) == {_EXPRREF_KEY}
+        and isinstance(value[_EXPRREF_KEY], str)
+    ):
+        return ExprRef(value[_EXPRREF_KEY])
+    return value
+
+
+def step_to_dict(step: "Step") -> "dict[str, Any]":
+    """One executor step dataclass → a JSON-serializable dict (``kind`` tagged)."""
+    if isinstance(step, TransformStep):
+        return {"kind": "transform", "value": step.value, "output": step.output}
+    if isinstance(step, ToolStep):
+        return {
+            "kind": "tool",
+            "name": step.name,
+            "args": {k: _encode_arg(step.name, k, v) for k, v in step.args.items()},
+            "output": step.output,
+            "schema": step.schema,
+        }
+    if isinstance(step, AgentStep):
+        return {
+            "kind": "agent",
+            "prompt": step.prompt,
+            "identity": step.identity,
+            "capabilities": list(step.capabilities) if step.capabilities is not None else None,
+            "schema": step.schema,
+            "output": step.output,
+        }
+    raise PipelineSerdeError(f"unknown step type: {step!r}")
+
+
+def step_from_dict(data: "dict[str, Any]") -> "Step":
+    """The inverse of :func:`step_to_dict`."""
+    kind = data.get("kind")
+    if kind == "transform":
+        return TransformStep(value=data["value"], output=data.get("output"))
+    if kind == "tool":
+        return ToolStep(
+            name=data["name"],
+            args={k: _decode_arg(v) for k, v in dict(data.get("args") or {}).items()},
+            output=data.get("output"),
+            schema=data.get("schema"),
+        )
+    if kind == "agent":
+        caps = data.get("capabilities")
+        return AgentStep(
+            prompt=data["prompt"],
+            identity=data.get("identity"),
+            capabilities=list(caps) if caps is not None else None,
+            schema=data.get("schema"),
+            output=data.get("output"),
+        )
+    raise PipelineSerdeError(f"unknown step kind in stored pipeline: {kind!r}")
+
+
+def pipeline_to_dict(pipeline: "Pipeline") -> "dict[str, Any]":
+    """A :class:`Pipeline` → a JSON-serializable dict (the work-order shape)."""
+    return {
+        "description": pipeline.description,
+        "steps": [step_to_dict(s) for s in pipeline.steps],
+    }
+
+
+def pipeline_from_dict(data: "dict[str, Any]") -> "Pipeline":
+    """The inverse of :func:`pipeline_to_dict`."""
+    return Pipeline(
+        steps=[step_from_dict(s) for s in data.get("steps", [])],
+        description=str(data.get("description") or ""),
+    )
+
+
+__all__ = [
+    "PipelineSerdeError",
+    "pipeline_to_dict",
+    "pipeline_from_dict",
+    "step_to_dict",
+    "step_from_dict",
+]

--- a/src/reyn/core/pipeline/work_order.py
+++ b/src/reyn/core/pipeline/work_order.py
@@ -1,0 +1,153 @@
+"""Pipeline work-order + run-lifecycle files (IS-2 async driver-session recovery core).
+
+A pipeline driver-session (D案) is *born with its work-order*: everything
+needed to run — or, after a crash, to RE-CREATE the driver-session and resume
+— lives in ``.reyn/pipeline/state/<run_id>/invocation.json``, written at
+spawn, BEFORE step 0 runs. It is a FILE, not a WAL event, so like the R4
+``gen-<seq>.json`` step snapshots next to it (``generations/``, see
+``reyn.core.events.pipeline_recovery``) it survives WAL truncation — the
+CLAUDE.md recovery-gate requirement. Three files make up a run's lifecycle
+under its run dir:
+
+- ``invocation.json`` — the :class:`PipelineWorkOrder`: the full serialized
+  pipeline (``reyn.core.pipeline.serde``), the seed input, the reply
+  address, the (agent, sid) of the driver-session itself (so recovery can
+  re-create the session from scratch when it crashed before its own session
+  snapshot ever landed), and the WAL seq at spawn (the rewind guard's
+  default-open predicate — see ``AgentRegistry._rewake_pipeline_runs``).
+- ``attempts.json`` — the poison-pipeline cap: a monotonic resume-attempt
+  counter the recovery scan bumps durably BEFORE each re-wake. A run whose
+  resume crashes the process every restart increments this on every scan;
+  once past the driver's cap the driver terminal-fails the run instead of
+  resuming — bounded by construction (monotonic counter + finite cap),
+  never a restart crash-loop amplifier.
+- ``result.json`` — the TERMINAL marker, written by the driver only AFTER
+  the result was posted to the reply address. Terminal therefore means
+  "result delivered", NOT "all steps done": a crash between the last step
+  and delivery leaves no marker, so recovery re-wakes, the driver replays
+  every completed step from the R4 snapshot (exactly-once execution) and
+  re-delivers. Net contract: **step execution exactly-once, result delivery
+  at-least-once** (a consumer can dedup by ``run_id``). Its presence also
+  lets the startup scan skip terminal run dirs with one ``stat`` — no WAL
+  read per historical run.
+
+All writes are atomic (tmp + rename), mirroring
+``PipelineStateStore.record``.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from reyn.core.events.pipeline_recovery import pipeline_state_dir
+
+_INVOCATION_FILE = "invocation.json"
+_RESULT_FILE = "result.json"
+_ATTEMPTS_FILE = "attempts.json"
+
+
+def pipeline_run_dir(reyn_dir: "Path", run_id: str) -> "Path":
+    """The run-lifecycle directory for one pipeline run — the parent of the R4
+    generation store (single source: derived from ``pipeline_state_dir``)."""
+    return pipeline_state_dir(reyn_dir, run_id).parent
+
+
+@dataclass(frozen=True)
+class PipelineWorkOrder:
+    """The driver-session's birth state — see the module docstring.
+
+    ``reply_to_agent``/``reply_to_sid`` name the invoker session the result is
+    posted back to; ``driver_agent``/``driver_sid`` name the driver-session
+    itself (recovery re-creates it from these when the session record is
+    gone); ``spawn_seq`` is the WAL head at spawn time (``None`` in
+    no-WAL/test contexts — the rewind guard then defaults open)."""
+
+    run_id: str
+    pipeline_name: str
+    pipeline: "dict[str, Any]"  # serde.pipeline_to_dict shape
+    input: "dict[str, Any] | None"
+    reply_to_agent: str
+    reply_to_sid: str
+    driver_agent: str
+    driver_sid: str
+    spawn_seq: "int | None" = None
+
+
+def _atomic_write(path: "Path", content: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(content, ensure_ascii=False, default=str), encoding="utf-8")
+    tmp.replace(path)
+
+
+def write_invocation(run_dir: "Path", work_order: PipelineWorkOrder) -> "Path":
+    """Persist the work-order as ``invocation.json`` (atomic)."""
+    path = Path(run_dir) / _INVOCATION_FILE
+    _atomic_write(path, asdict(work_order))
+    return path
+
+
+def load_invocation(run_dir: "Path") -> "PipelineWorkOrder | None":
+    """Read the run dir's work-order, or ``None`` when absent/corrupt (a
+    corrupt invocation cannot be resumed — the caller logs and skips)."""
+    path = Path(run_dir) / _INVOCATION_FILE
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return PipelineWorkOrder(**data)
+    except (ValueError, TypeError):
+        return None
+
+
+def write_result(
+    run_dir: "Path", *, status: str, delivered: bool,
+    output: Any = None, error: "str | None" = None,
+) -> "Path":
+    """Write the terminal marker (atomic). ``delivered=False`` records a
+    permanently-undeliverable result (reply target gone) — still terminal, so
+    a vanished consumer can never turn the run into an infinite re-wake."""
+    path = Path(run_dir) / _RESULT_FILE
+    _atomic_write(path, {
+        "status": status, "delivered": delivered, "output": output, "error": error,
+    })
+    return path
+
+
+def has_result(run_dir: "Path") -> bool:
+    """True when the run reached terminal (result delivered / terminal-failed)."""
+    return (Path(run_dir) / _RESULT_FILE).is_file()
+
+
+def read_resume_attempts(run_dir: "Path") -> int:
+    """The persisted recovery re-wake count for this run (0 when never re-woken)."""
+    path = Path(run_dir) / _ATTEMPTS_FILE
+    if not path.is_file():
+        return 0
+    try:
+        return int(json.loads(path.read_text(encoding="utf-8")).get("attempts", 0))
+    except (ValueError, TypeError):
+        return 0
+
+
+def bump_resume_attempts(run_dir: "Path") -> int:
+    """Durably increment the resume-attempt counter BEFORE a recovery re-wake
+    (so a resume that crashes the process still advanced the counter) and
+    return the new count."""
+    attempts = read_resume_attempts(run_dir) + 1
+    _atomic_write(Path(run_dir) / _ATTEMPTS_FILE, {"attempts": attempts})
+    return attempts
+
+
+__all__ = [
+    "PipelineWorkOrder",
+    "pipeline_run_dir",
+    "write_invocation",
+    "load_invocation",
+    "write_result",
+    "has_result",
+    "read_resume_attempts",
+    "bump_resume_attempts",
+]

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1019,7 +1019,102 @@ class AgentRegistry:
         # #2187 §3.6 (5d): the RE-DELIVERY half — now that the actionable sessions are
         # live, re-publish their missed events through each session's OWN production waker.
         await self._redeliver_recovery_wakes(recovery_work)
+
+        # IS-2: pipeline driver-session re-wake — a SELF-SUFFICIENT scan of
+        # `.reyn/pipeline/state/` (invocation.json + terminal marker), deliberately
+        # independent of the task-backend subscription machinery above AND of the
+        # snapshot-driven step-5 loop: a driver-session that crashed before its
+        # first session snapshot has no snapshot.json (never enters all_snaps),
+        # and its start-nudge was already consumed (empty inbox) — the #2187-5d
+        # "RUNNING-but-empty-inbox" trap. The scan re-creates + re-wakes it from
+        # the work-order FILE alone (truncation-surviving, like the R4 gens).
+        await self._rewake_pipeline_runs()
         return snapshots
+
+    async def _rewake_pipeline_runs(self) -> "list[str]":
+        """IS-2: re-create + re-wake the driver-session of every NON-TERMINAL
+        pipeline run found under ``.reyn/pipeline/state/`` (see
+        ``reyn.core.pipeline.work_order`` for the run-dir lifecycle files and
+        the exactly-once/at-least-once contract). Returns the re-woken run ids
+        (for the log / tests).
+
+        Per run dir, in order:
+        - terminal marker present → one-stat skip (a delivered run never
+          resurrects; scan cost over historical runs stays trivial).
+        - work-order absent/corrupt → logged skip (nothing to resume from).
+        - rewind guard (DEFAULT-OPEN polarity): skip ONLY when the recorded
+          ``spawn_seq`` is provably on an abandoned WAL branch
+          (``is_active_seq`` False — the run was rewound away). A missing /
+          truncated-away spawn record keeps the run eligible: requiring the
+          event to be present would make recovery depend on a truncatable WAL
+          entry, exactly what the CLAUDE.md truncate-falsify gate forbids.
+        - bump ``attempts.json`` durably BEFORE the wake (the A8 poison cap's
+          monotonic counter — a resume that crashes the process still counted;
+          the driver terminal-fails past the cap instead of crash-looping).
+        - ensure the driver-session EXISTS (re-create via ``spawn_session(name,
+          sid=...)`` when the crash predated any session record), swap in a
+          fresh ``PipelineExecutorDriver`` built from the work-order, nudge
+          (empty user turn), and boot the run-loop pump — the same
+          wake-triple shape ``TaskWaker._wake`` uses."""
+        if self._state_log is None:
+            return []
+        from reyn.core.events.config_recovery import reyn_root
+        from reyn.core.pipeline.work_order import (
+            bump_resume_attempts,
+            has_result,
+            load_invocation,
+        )
+        from reyn.runtime.services.pipeline_executor_driver import (
+            PipelineExecutorDriver,
+        )
+
+        root = reyn_root(self._state_log.path)
+        if root is None:
+            return []
+        state_root = root / "pipeline" / "state"
+        if not state_root.is_dir():
+            return []
+        rewoken: "list[str]" = []
+        for run_dir in sorted(state_root.iterdir()):
+            if not run_dir.is_dir() or has_result(run_dir):
+                continue
+            work_order = load_invocation(run_dir)
+            if work_order is None:
+                logger.warning(
+                    "pipeline recovery: run dir %s has no readable invocation.json "
+                    "— skipping (nothing to resume from)", run_dir,
+                )
+                continue
+            if work_order.spawn_seq is not None and not is_active_seq(
+                self._state_log, work_order.spawn_seq,
+            ):
+                # Provably rewound-away (abandoned WAL branch) — do not resurrect.
+                continue
+            name, sid = work_order.driver_agent, work_order.driver_sid
+            if not self.exists(name):
+                logger.warning(
+                    "pipeline recovery: run %r's driver agent %r no longer exists "
+                    "— skipping", work_order.run_id, name,
+                )
+                continue
+            bump_resume_attempts(run_dir)
+            if not self._has_session(name, sid):
+                self.spawn_session(name, sid=sid)
+            session = self._peek_session(name, sid)
+            if session is None:
+                continue
+            session.set_loop_driver(PipelineExecutorDriver(
+                work_order, registry=self, state_log=self._state_log,
+            ))
+            await session.submit_user_text("")  # the no-payload resume nudge (D案)
+            self.ensure_session_running(name, sid)
+            rewoken.append(work_order.run_id)
+        if rewoken:
+            logger.info(
+                "pipeline recovery: re-woke %d non-terminal run(s): %s",
+                len(rewoken), ", ".join(rewoken),
+            )
+        return rewoken
 
     # ── Global rewind (ADR-0038 Stage 1c-2, D2 consistent-cut) ──────────────
 

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -1,0 +1,301 @@
+"""PipelineExecutorDriver — the driver-session's ExecutionDriver for async pipelines (IS-2).
+
+The D案 execution model: ``run_pipeline_async`` spawns a dedicated
+driver-session that is *born with its work-order*
+(``reyn.core.pipeline.work_order`` — persisted to
+``.reyn/pipeline/state/<run_id>/invocation.json`` before step 0 runs). This
+class is that session's :class:`~reyn.runtime.services.execution_driver.ExecutionDriver`:
+where ``RouterLoopDriver`` interprets ``run_turn(user_text, ...)`` as a user
+utterance to route through the LLM, this driver treats the turn as a bare
+**run/resume nudge** — ``user_text`` carries no meaning — and drives the
+already-tested :class:`~reyn.core.pipeline.executor.PipelineExecutor` instead.
+No protocol change: the Session's run-loop, inbox, WAL journaling and
+crash-restore machinery all work on this session exactly as on a chat session,
+which is the entire point (crash auto-resume rides the existing session
+substrate).
+
+One nudge = drive the run to a terminal:
+
+- **new vs resume** is decided by whether an R4 generation snapshot exists for
+  the run (``latest_pipeline_state``): none → ``executor.run`` seeded with the
+  work-order's ORIGINAL ``input`` (a resume-always shortcut would silently
+  drop it — ``resume``'s no-snapshot fallback hardcodes ``initial_context=None``);
+  some → ``executor.resume``, which replays completed steps from the snapshot
+  (exactly-once) and continues.
+- the result (or step failure) is posted to the work-order's reply address as
+  a ``pipeline_result`` inbox message (mirroring how delegation returns
+  ``agent_response`` — see ``Session.submit_pipeline_result``), and only THEN
+  is the terminal marker (``result.json``) written. Terminal =
+  "result delivered", so a crash between last step and delivery re-delivers
+  on recovery: execution exactly-once, delivery at-least-once (the
+  work_order module docstring states the full contract).
+- after terminal, the driver marks its session ephemeral so the standard
+  post-turn vanish teardown (``Session._maybe_schedule_ephemeral_vanish`` →
+  ``registry.remove_session``) reclaims it — the driver-session never leaks
+  past its run, on the initial path and the recovered path alike.
+- the poison-pipeline cap: the recovery scan durably bumps
+  ``attempts.json`` before every re-wake; when the count exceeds
+  ``MAX_RESUME_ATTEMPTS`` this driver's FIRST action is to terminal-fail the
+  run (failure result delivered) instead of resuming — a run whose resume
+  crashes the process on every restart is bounded by construction.
+
+Tool steps dispatch through the SAME ``_make_tool_dispatch`` the sync
+``run_pipeline`` tool uses (``reyn.tools.pipeline_verbs``), fed a
+``ToolContext`` built from THIS session's own host adapter (events /
+permission_resolver / resolver / state_log — the session's narrowed
+permission context, ⊆ the invoker's since the driver-session is spawned under
+the invoker's identity). **Known v1 divergence from the sync path**:
+``router_state`` is ``None`` here (there is no RouterLoop to build a
+RouterCallerState, and hand-duplicating ``_build_router_caller_state``'s
+binding map would be a drift trap), so tool steps that resolve through
+resource-category dynamic routes needing router_state (mcp tools, rag
+corpus reads, nested ``pipeline__run``) are unavailable in ASYNC pipelines
+until the caller-state construction is extracted to a shared seam —
+plain registered tools (``file__*``, ``shell``, ...) work identically.
+
+The driver is bound to its session AFTER construction
+(``Session.set_loop_driver`` calls :meth:`bind_session` — the post-ctor
+observer seam), because the session cannot exist before a driver argument
+would be needed and the recovery path re-creates sessions through the plain
+factory anyway.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.core.events.state_log import StateLog
+    from reyn.core.pipeline.work_order import PipelineWorkOrder
+    from reyn.runtime.registry import AgentRegistry
+
+logger = logging.getLogger(__name__)
+
+# A8: recovery re-wakes past this count terminal-fail instead of resuming.
+MAX_RESUME_ATTEMPTS = 3
+
+
+class PipelineExecutorDriver:
+    """ExecutionDriver that runs/resumes ONE pipeline work-order per nudge."""
+
+    def __init__(
+        self,
+        work_order: "PipelineWorkOrder",
+        *,
+        registry: "AgentRegistry",
+        state_log: "StateLog",
+    ) -> None:
+        self._work_order = work_order
+        self._registry = registry
+        self._state_log = state_log
+        self._cancel_requested = False
+        self._session: Any = None
+        self._router_host: Any = None
+
+    # ── post-ctor binding (Session.set_loop_driver calls this) ────────────────
+
+    def bind_session(self, session: Any, router_host: Any) -> None:
+        """Late-bind the owning Session + its RouterHostAdapter (the source of
+        the ToolContext fields). Called by ``Session.set_loop_driver``."""
+        self._session = session
+        self._router_host = router_host
+
+    # ── ExecutionDriver protocol ───────────────────────────────────────────────
+
+    async def run_turn(self, user_text: str, chain_id: str) -> None:
+        """Drive the work-order to terminal. ``user_text`` is a meaningless
+        nudge payload (D案) and is ignored. Idempotent: a nudge after terminal
+        no-ops (delivery is at-least-once, so double wakes are expected)."""
+        from reyn.core.events.pipeline_recovery import latest_pipeline_state
+        from reyn.core.pipeline.executor import PipelineExecutionError, PipelineExecutor
+        from reyn.core.pipeline.serde import pipeline_from_dict
+        from reyn.core.pipeline.work_order import has_result, read_resume_attempts
+
+        wo = self._work_order
+        run_dir = self._run_dir()
+        if has_result(run_dir):
+            return  # already terminal — spurious/duplicate nudge
+
+        # A8 poison cap: the recovery scan bumped attempts.json durably before
+        # this wake; past the cap, fail terminally BEFORE touching the executor.
+        attempts = read_resume_attempts(run_dir)
+        if attempts > MAX_RESUME_ATTEMPTS:
+            await self._finish(
+                status="failed",
+                error=(
+                    f"pipeline run {wo.run_id!r} exhausted its resume budget "
+                    f"({attempts - 1} recovery attempts > cap {MAX_RESUME_ATTEMPTS}) "
+                    "— giving up instead of crash-looping."
+                ),
+            )
+            return
+
+        pipeline = pipeline_from_dict(wo.pipeline)
+        executor = PipelineExecutor()
+        try:
+            if latest_pipeline_state(wo.run_id, self._state_log) is None:
+                # Fresh run (or crashed before the first R4 snapshot): seed the
+                # ORIGINAL work-order input — resume()'s fallback would lose it.
+                result = await executor.run(
+                    pipeline,
+                    dict(wo.input) if wo.input else None,
+                    tool_dispatch=self._make_dispatch(),
+                    state_log=self._state_log,
+                    run_id=wo.run_id,
+                    registry=self._registry,
+                    default_identity=wo.reply_to_agent,
+                )
+            else:
+                result = await executor.resume(
+                    wo.run_id,
+                    pipeline=pipeline,
+                    tool_dispatch=self._make_dispatch(),
+                    state_log=self._state_log,
+                    registry=self._registry,
+                    default_identity=wo.reply_to_agent,
+                )
+        except PipelineExecutionError as exc:
+            await self._finish(status="failed", error=str(exc))
+            return
+        await self._finish(status="ok", output=result.pipe_data)
+
+    def is_cancel_requested(self) -> bool:
+        """Cooperative cancel flag (protocol conformance; the executor has no
+        mid-step cancel hook yet, so this only reports the request)."""
+        return self._cancel_requested
+
+    def request_cancel(self) -> None:
+        """Record a cancel request (see ``is_cancel_requested``)."""
+        self._cancel_requested = True
+
+    async def _check_cap(self, user_text: str) -> None:
+        """No-op: the router invocation cap has no meaning for a deterministic
+        pipeline turn (the executor's own step list is the bound)."""
+        return None
+
+    # ── internals ──────────────────────────────────────────────────────────────
+
+    def _run_dir(self) -> "Path":
+        from reyn.core.events.config_recovery import reyn_root
+        from reyn.core.pipeline.work_order import pipeline_run_dir
+
+        root = reyn_root(self._state_log.path)
+        if root is None:  # construction guards this; defend against re-pathing
+            raise RuntimeError(
+                "PipelineExecutorDriver requires a .reyn-anchored StateLog "
+                f"(got {self._state_log.path!r})"
+            )
+        return pipeline_run_dir(root, self._work_order.run_id)
+
+    def _make_dispatch(self) -> Any:
+        """The SAME tool-step dispatch the sync ``run_pipeline`` tool builds
+        (``pipeline_verbs._make_tool_dispatch``), fed a ToolContext from THIS
+        session's host adapter. router_state=None — see the module docstring
+        for the documented v1 degradation."""
+        from reyn.tools.pipeline_verbs import _make_tool_dispatch
+        from reyn.tools.types import ToolContext
+
+        host = self._router_host
+        if host is None:
+            raise RuntimeError(
+                "PipelineExecutorDriver is not bound to a session — "
+                "Session.set_loop_driver(driver) must run before the first nudge."
+            )
+        ctx = ToolContext(
+            events=host.events,
+            permission_resolver=getattr(host, "permission_resolver", None),
+            workspace=getattr(host, "workspace", None),
+            caller_kind="router",
+            router_state=None,
+            resolver=getattr(host, "resolver", None),
+            hot_reloader=getattr(host, "hot_reloader", None),
+            state_log=getattr(host, "state_log", None),
+        )
+        return _make_tool_dispatch(ctx)
+
+    async def _finish(
+        self, *, status: str, output: Any = None, error: "str | None" = None,
+    ) -> None:
+        """Deliver the result to the reply address, THEN write the terminal
+        marker, then arm the standard ephemeral vanish for this session (A10:
+        the driver-session must not leak past terminal)."""
+        from reyn.core.pipeline.work_order import write_result
+
+        delivered = await self._deliver(status=status, output=output, error=error)
+        write_result(
+            self._run_dir(), status=status, delivered=delivered,
+            output=_json_safe(output), error=error,
+        )
+        # Reuse the existing ephemeral auto-vanish teardown (quiesce + cancel
+        # run-loop + drop + session_vanished + per-session dir purge) instead of
+        # a second teardown path. Same private poke spawn_session_recorded uses.
+        if self._session is not None:
+            self._session._ephemeral = True
+
+    async def _deliver(
+        self, *, status: str, output: Any, error: "str | None",
+    ) -> bool:
+        """Post the ``pipeline_result`` to the reply (agent, sid). Mirrors
+        ``Session._a2a_send_response``'s routing (non-main sid → the specific
+        live session; main → cold-load + ensure_running) including its
+        fail-safe: a vanished reply target is LOGGED and dropped (never
+        rerouted to main), and the run still goes terminal (``delivered:
+        false`` in result.json) so it cannot re-wake forever."""
+        wo = self._work_order
+        registry = self._registry
+        if not registry.exists(wo.reply_to_agent):
+            logger.warning(
+                "pipeline_result for run %r dropped: reply agent %r no longer exists",
+                wo.run_id, wo.reply_to_agent,
+            )
+            return False
+        if wo.reply_to_sid and wo.reply_to_sid != "main":
+            target = registry.get_session(wo.reply_to_agent, wo.reply_to_sid)
+            if target is None:
+                logger.warning(
+                    "pipeline_result for run %r dropped: reply session (%r, %r) is "
+                    "no longer loaded (fail-safe — NOT rerouted to main)",
+                    wo.run_id, wo.reply_to_agent, wo.reply_to_sid,
+                )
+                return False
+            registry.ensure_session_running(wo.reply_to_agent, wo.reply_to_sid)
+        else:
+            target = registry.get_or_load(wo.reply_to_agent)
+            await registry.ensure_running(wo.reply_to_agent)
+        text = self._format_result_text(status=status, output=output, error=error)
+        await target.submit_pipeline_result(
+            run_id=wo.run_id, pipeline_name=wo.pipeline_name, status=status,
+            text=text, chain_id=uuid.uuid4().hex,
+        )
+        return True
+
+    def _format_result_text(
+        self, *, status: str, output: Any, error: "str | None",
+    ) -> str:
+        """The OS-framed message the reply session's LLM turn sees (the
+        ``agent_response`` mirror: trusted OS framing + the payload as data)."""
+        wo = self._work_order
+        head = (
+            f"[pipeline] run {wo.run_id} (pipeline {wo.pipeline_name!r}) "
+            f"finished: status={status}"
+        )
+        if status == "ok":
+            return f"{head}\nOutput:\n{json.dumps(_json_safe(output), ensure_ascii=False)}"
+        return f"{head}\nError: {error}"
+
+
+def _json_safe(value: Any) -> Any:
+    """Best-effort JSON projection of a step result (steps normally return
+    JSON-shaped values; anything else is stringified rather than crashing the
+    terminal write)."""
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return repr(value)
+
+
+__all__ = ["PipelineExecutorDriver", "MAX_RESUME_ATTEMPTS"]

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -546,6 +546,15 @@ class RouterHostAdapter:
         return self._agent_role
 
     @property
+    def live_session_id(self) -> "str | None":
+        """The owning session's LIVE sid (#2130 pattern: the constructor's cached
+        ``session_id`` is stale for a spawned session — it is stamped
+        post-construction, so the live fn wins when wired). IS-2 reads this as
+        the ``run_pipeline_async`` reply address; the ``spawn_session``
+        result-routing path reads the same expression."""
+        return self._live_session_id_fn() if self._live_session_id_fn else self._session_id
+
+    @property
     def events(self) -> Any:
         """EventLog for dispatch_tool events."""
         return self._events
@@ -961,7 +970,7 @@ class RouterHostAdapter:
         # spawned session, stamped post-construction). This lifts the #2103 S1bc-exec
         # non-main-spawn guard: a non-main session may now spawn — its result routes back
         # correctly by (agent, from_sid). (None / "main" → main-case, byte-identical.)
-        from_sid = self._live_session_id_fn() if self._live_session_id_fn else self._session_id
+        from_sid = self.live_session_id
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
         )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2082,6 +2082,26 @@ class Session:
         """Forwarding → RouterLoopDriver.is_cancel_requested (PR-3)."""
         return self._loop_driver.is_cancel_requested()
 
+    def set_loop_driver(self, driver: "ExecutionDriver") -> None:
+        """IS-2: swap this session's execution driver post-construction.
+
+        The pipeline driver-session seam: ``spawn_session`` builds every
+        session through the fixed one-arg factory (default ``RouterLoopDriver``),
+        and the crash-recovery scan re-creates driver-sessions through that
+        same factory — so per-session driver injection happens HERE, after
+        construction, at both birth sites uniformly (the post-ctor observer
+        seam; the discarded default driver is accepted overhead). Safe by
+        construction: ``_loop_driver`` is only read at call time (run_turn /
+        cancel forwarding), and the swap always precedes the run-loop start.
+
+        A driver exposing ``bind_session`` (``PipelineExecutorDriver``) is
+        handed this session + its RouterHostAdapter so it can build the
+        tool-step ToolContext from the session's OWN (narrowed) context."""
+        self._loop_driver = driver
+        bind = getattr(driver, "bind_session", None)
+        if callable(bind):
+            bind(self, self._router_host)
+
     async def cancel_inflight(self) -> str:
         """#1468: cancel all in-flight work — running turn + tasks/plans.
 
@@ -3099,6 +3119,27 @@ class Session:
             "responder_sid": responder_sid,
         })
 
+    async def submit_pipeline_result(
+        self, *, run_id: str, pipeline_name: str, status: str, text: str,
+        chain_id: "str | None" = None,
+    ) -> None:
+        """IS-2: deliver an async pipeline run's terminal result to this session.
+
+        The ``agent_response`` mirror for the pipeline driver-session
+        architecture: the invoker's ``run_pipeline_async`` returned
+        ``{status: started}`` immediately (no pending chain), so the result
+        arrives as a NEW turn trigger — ``run_one_iteration`` routes the
+        ``pipeline_result`` kind to one router turn (like a task wake), with
+        ``text`` the OS-framed message the driver formatted. Delivery is
+        at-least-once (the driver's terminal marker is written only after this
+        lands — see ``reyn.core.pipeline.work_order``), so a consumer that
+        must dedup can key on ``run_id``."""
+        await self._put_inbox("pipeline_result", {
+            "run_id": run_id, "pipeline_name": pipeline_name, "status": status,
+            "text": text, "chain_id": chain_id or _new_chain_id(),
+            "sender": "pipeline:os",
+        })
+
     # ── #2103 S1bc-exec: spawned-task correlation record (bounded) ──────────────
 
     def record_spawned_task(self, sid: str, task: str) -> None:
@@ -3827,6 +3868,12 @@ class Session:
                 await self._handle_agent_request(payload)
             elif kind == "agent_response":
                 await self._handle_agent_response(payload)
+            elif kind == "pipeline_result":
+                # IS-2: an async pipeline driver-session posted its terminal
+                # result here (the agent_response mirror — but chainless: the
+                # launch returned immediately, so this is a fresh turn, routed
+                # exactly like a task wake).
+                await self._handle_pipeline_result(payload)
             elif kind in ("task_ready", "task_dependency_aborted"):
                 # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
                 # (a dependent became ready, or a parent must decide recovery). Both
@@ -3919,9 +3966,12 @@ class Session:
           (the #1800 self-continuation), ``agent_response`` (a reply to a request THIS
           agent sent). These never switch tasks, so preserving is interleaving-safe.
         - RESET→None (a genuinely NEW external context = session-owned creates):
-          ``user``, ``agent_request`` (an INCOMING peer ask). An unknown future kind
-          falls here — fail-safe to session-owned (a mis-own/leak is worse than an
-          orphan); a new self-continuation kind must be added to the PRESERVE set.
+          ``user``, ``agent_request`` (an INCOMING peer ask), ``pipeline_result``
+          (IS-2: an async pipeline's terminal result — a fresh external context,
+          not a continuation of a task the receiver was executing). An unknown
+          future kind falls here — fail-safe to session-owned (a mis-own/leak is
+          worse than an orphan); a new self-continuation kind must be added to
+          the PRESERVE set.
 
         Linger note (B1.5, considered + accepted): a post-completion hook can preserve
         current=T past T's completion. Functionally harmless — §16 B2's
@@ -3943,6 +3993,15 @@ class Session:
         """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /
         ``task_dependency_aborted``) to the LLM as one router turn, so it resumes /
         recovers the work via ordinary task ops."""
+        await self._handle_user_message(
+            payload.get("text", ""),
+            chain_id=payload.get("chain_id") or _new_chain_id(),
+        )
+
+    async def _handle_pipeline_result(self, payload: dict) -> None:
+        """IS-2: surface an async pipeline's terminal result (``pipeline_result``)
+        to the LLM as one router turn — same shape as ``_handle_task_wake``: the
+        driver already formatted the OS-framed ``text``."""
         await self._handle_user_message(
             payload.get("text", ""),
             chain_id=payload.get("chain_id") or _new_chain_id(),

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -39,10 +39,19 @@ existing primitives — it adds no new session/LLM machinery of its own:
      defensively and validated post-hoc (exactly the executor's
      ``ToolStep`` pattern — there is no schema-constrained *generation* in
      the router path today).
+
+``start_pipeline_run`` (IS-2) is the ASYNC counterpart of the sync
+``run_pipeline`` tool: it spawns a dedicated pipeline driver-session (born
+with its work-order — the D案 architecture), persists ``invocation.json``
+before step 0 can run, swaps in the ``PipelineExecutorDriver`` and nudges the
+run — returning the ``run_id`` immediately while the result arrives later as
+a ``pipeline_result`` inbox message. See its docstring for the crash-safety
+ordering.
 """
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from typing import TYPE_CHECKING, Any
 
@@ -60,15 +69,18 @@ if TYPE_CHECKING:
 #     ``MessageBus.request``'s quiescence predicate (inbox.empty()) return
 #     early on a pending chain the spawned session is still awaiting a reply
 #     for (see the module docstring).
-#   - ``run_pipeline`` (IS-1, R6 S3): nesting a pipeline launch inside an
-#     ``agent`` step would let a step spawn ANOTHER pipeline at runtime,
-#     defeating the transitive-closure cost-bound approval a REGISTERED
-#     pipeline gets at ``run_pipeline`` call time — nesting is ``call``-only.
+#   - ``run_pipeline`` / ``run_pipeline_async`` (IS-1/IS-2, R6 S3): nesting a
+#     pipeline launch inside an ``agent`` step would let a step spawn ANOTHER
+#     pipeline at runtime, defeating the transitive-closure cost-bound approval
+#     a REGISTERED pipeline gets at launch time — nesting is ``call``-only.
+#     The async launch is the same escape hatch as the sync one (sibling).
 # ``_expand_tool_forms`` (capability_profile.py) derives every invocable alias
 # (bare + qualified) from each name here, so listing the bare tool name is
 # sufficient — the qualified catalog form (``multi_agent__delegate`` /
 # ``pipeline__run``) is covered too.
-_DELEGATION_DENY_TOOLS: tuple[str, ...] = ("delegate_to_agent", "run_pipeline")
+_DELEGATION_DENY_TOOLS: tuple[str, ...] = (
+    "delegate_to_agent", "run_pipeline", "run_pipeline_async",
+)
 
 # MessageBus.request has no default — an agent step needs one so callers
 # aren't forced to pick a number for the common case.
@@ -190,3 +202,86 @@ async def run_agent_step(
             f"conform to schema: {details}"
         )
     return parsed
+
+
+async def start_pipeline_run(
+    registry: "AgentRegistry",
+    *,
+    pipeline: "object",
+    pipeline_name: str,
+    input: "dict | None",
+    reply_to_agent: str,
+    reply_to_sid: str,
+    state_log: "object",
+    run_id: "str | None" = None,
+) -> str:
+    """IS-2: launch an async pipeline run in a dedicated driver-session (D案).
+
+    The launch sequence, in crash-safety order:
+
+      1. spawn the driver-session under the INVOKER's identity
+         (``spawn_session_recorded(mode="persistent")`` — the same recorded
+         seam as every other programmatic spawn; persistent because the
+         session must survive a crash to be re-woken, and its reclamation is
+         the driver's own terminal ephemeral-vanish, not inbox-idleness).
+         Same identity ⇒ the driver's permission envelope is the invoker's
+         (⊆ by construction).
+      2. persist the work-order (``invocation.json`` — full serialized
+         pipeline + input + reply address + the driver's own (agent, sid) +
+         the WAL seq at spawn) BEFORE step 0 can possibly run. From this
+         point the run is crash-recoverable: ``AgentRegistry.restore_all``'s
+         pipeline scan re-creates + re-wakes the driver-session from this
+         file alone.
+      3. swap in the :class:`~reyn.runtime.services.pipeline_executor_driver.
+         PipelineExecutorDriver` (``Session.set_loop_driver``) and nudge the
+         run-loop with an empty user turn — the D案 "run/resume" nudge whose
+         text carries no meaning — then boot the detached run-loop pump
+         (``ensure_session_running``; no forwarder — a driver-session has no
+         user-facing output).
+
+    Returns the ``run_id`` immediately; the result arrives later on the
+    invoker's inbox as a ``pipeline_result`` message."""
+    from reyn.core.events.config_recovery import reyn_root
+    from reyn.core.pipeline.serde import pipeline_to_dict
+    from reyn.core.pipeline.work_order import (
+        PipelineWorkOrder,
+        pipeline_run_dir,
+        write_invocation,
+    )
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    root = reyn_root(state_log.path)
+    if root is None:
+        raise ValueError(
+            "start_pipeline_run requires a .reyn-anchored StateLog (the "
+            f"work-order/recovery files live under it); got {state_log.path!r}"
+        )
+    # The run_id becomes a directory segment (.reyn/pipeline/state/<run_id>/),
+    # so the embedded pipeline name is sanitized to one safe path component.
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", pipeline_name) or "pipeline"
+    rid = run_id or f"pipeline-{safe_name}-{uuid.uuid4().hex}"
+    sid = await registry.spawn_session_recorded(reply_to_agent, mode="persistent")
+    work_order = PipelineWorkOrder(
+        run_id=rid,
+        pipeline_name=pipeline_name,
+        pipeline=pipeline_to_dict(pipeline),
+        input=dict(input) if input else None,
+        reply_to_agent=reply_to_agent,
+        reply_to_sid=reply_to_sid,
+        driver_agent=reply_to_agent,
+        driver_sid=sid,
+        spawn_seq=state_log.current_seq,
+    )
+    write_invocation(pipeline_run_dir(root, rid), work_order)
+    session = registry.get_session(reply_to_agent, sid)
+    if session is None:
+        raise RuntimeError(
+            f"start_pipeline_run: spawned driver-session ({reply_to_agent!r}, "
+            f"{sid!r}) not found in the registry"
+        )
+    session.set_loop_driver(
+        PipelineExecutorDriver(work_order, registry=registry, state_log=state_log)
+    )
+    await session.submit_user_text("")  # the no-payload run nudge (D案)
+    registry.ensure_session_running(reply_to_agent, sid)
+    return rid

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -266,7 +266,10 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     # Has a qualified route (pipeline__run) unlike the bare-only spawn
     # trio, so its bare alias (run_pipeline) is derived by
     # _with_unwrapped_aliases below — no _FLOORED_BARE_ONLY entry needed.
-    "pipeline-run": frozenset({"pipeline__run"}),
+    # IS-2: the async launch (pipeline__run_async → run_pipeline_async) is
+    # the SAME threat class — it additionally spawns a driver-session, so it
+    # must not be floored looser than the sync verb.
+    "pipeline-run": frozenset({"pipeline__run", "pipeline__run_async"}),
 }
 
 # Intentionally BARE-ONLY floored names: router-only tools with NO invoke_action

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -86,7 +86,7 @@ def get_default_registry() -> ToolRegistry:
         REMEMBER_AGENT,
         REMEMBER_SHARED,
     )
-    from reyn.tools.pipeline_verbs import RUN_PIPELINE
+    from reyn.tools.pipeline_verbs import RUN_PIPELINE, RUN_PIPELINE_ASYNC
     from reyn.tools.recall import RECALL
     from reyn.tools.reyn_src import (
         REYN_SRC_GLOB,
@@ -213,6 +213,10 @@ def get_default_registry() -> ToolRegistry:
     # universal-catalog wrapper uses, NOT build_tools() (which is
     # hand-assembled and strips direct tools once wrappers are on).
     registry.register(RUN_PIPELINE)
+    # IS-2: run_pipeline_async — background launch in a crash-recoverable
+    # driver-session; returns {status: started, run_id} immediately, the
+    # result arrives later as a pipeline_result inbox message.
+    registry.register(RUN_PIPELINE_ASYNC)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -84,6 +84,18 @@ _RUN_PIPELINE_PARAMETERS: dict[str, Any] = {
     "required": ["name"],
 }
 
+# R6 S3 structural deny for pipeline TOOL steps (IS-2 sibling sweep of the
+# agent-step ``_DELEGATION_DENY_TOOLS`` in ``runtime/session_api.py``): a
+# ``ToolStep`` that dispatches a pipeline launch (sync or async) or a
+# delegation would nest agentic work under a step, defeating the
+# transitive-closure cost-bound approval a REGISTERED pipeline gets at launch
+# time — nesting is ``call``-only. Checked on BOTH the raw step name and the
+# post-``resolve_invoke_action`` target, so the qualified forms
+# (``pipeline__run`` / ``multi_agent__delegate``) are covered too.
+_PIPELINE_STEP_DENY_TOOLS: "frozenset[str]" = frozenset({
+    "run_pipeline", "run_pipeline_async", "delegate_to_agent",
+})
+
 
 def _make_tool_dispatch(ctx: ToolContext) -> "Callable[[str, dict], Any]":
     """Build the real ``tool_dispatch`` a pipeline ``ToolStep`` invokes through.
@@ -119,6 +131,14 @@ def _make_tool_dispatch(ctx: ToolContext) -> "Callable[[str, dict], Any]":
         if resolved is not None:
             target_name = resolved.target_tool_name
             target_args = dict(resolved.target_args)
+
+        if name in _PIPELINE_STEP_DENY_TOOLS or target_name in _PIPELINE_STEP_DENY_TOOLS:
+            raise PipelineExecutionError(
+                f"pipeline tool step {name!r} is structurally denied (R6 S3): "
+                "a step must not launch a pipeline or delegate — nesting is "
+                "call-only, so the launch-time cost-bound approval stays a "
+                "transitive closure."
+            )
 
         target = registry.lookup(target_name)
         if target is None:
@@ -212,4 +232,100 @@ RUN_PIPELINE = ToolDefinition(
     purity="side_effect",
 )
 
-__all__ = ["RUN_PIPELINE"]
+
+_RUN_PIPELINE_ASYNC_DESCRIPTION = (
+    "Launch a REGISTERED pipeline by name in the background and return "
+    "immediately with {status: started, run_id}. The pipeline runs in a "
+    "dedicated crash-recoverable driver session; its final result arrives "
+    "later as a [pipeline] message on your conversation. 'input' seeds the "
+    "pipeline's initial named context (ctx.*) for its first step."
+)
+
+
+async def _handle_run_pipeline_async(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """IS-2: resolve the registered pipeline, hand it to
+    ``runtime.session_api.start_pipeline_run`` (spawn driver-session → persist
+    ``invocation.json`` BEFORE step 0 → inject ``PipelineExecutorDriver`` →
+    nudge), and return ``{status: started, run_id}`` without waiting. The
+    result routes back to THIS caller's (agent, live sid) as a
+    ``pipeline_result`` inbox message. Requires a WAL (``ctx.state_log``) —
+    the async architecture IS the crash-recovery architecture, so a
+    non-persistent context has no async launch."""
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return {"status": "error", "data": {"error": "name is required"}}
+    raw_input = args.get("input")
+    if raw_input is not None and not isinstance(raw_input, Mapping):
+        return {
+            "status": "error",
+            "data": {"error": "input must be an object (mapping), if given"},
+        }
+
+    rs = ctx.router_state
+    pipeline_registry = rs.pipeline_registry if rs is not None else None
+    agent_registry = rs.agent_registry if rs is not None else None
+    host = rs.host if rs is not None else None
+    if pipeline_registry is None or agent_registry is None or host is None:
+        return {
+            "status": "error",
+            "data": {
+                "error": (
+                    "run_pipeline_async requires a fully-wired router context "
+                    "(pipeline_registry + agent_registry + host on "
+                    "ctx.router_state)"
+                ),
+            },
+        }
+    state_log = ctx.state_log
+    if state_log is None:
+        return {
+            "status": "error",
+            "data": {
+                "error": (
+                    "run_pipeline_async requires WAL persistence "
+                    "(ctx.state_log) — the async run is crash-recoverable by "
+                    "construction; use run_pipeline for a non-persistent sync run"
+                ),
+            },
+        }
+
+    try:
+        pipeline = pipeline_registry.get(name)
+    except PipelineNotFoundError:
+        return {
+            "status": "error",
+            "data": {"error": f"pipeline {name!r} is not registered"},
+        }
+
+    from reyn.runtime.session_api import start_pipeline_run
+
+    reply_sid = getattr(host, "live_session_id", None) or "main"
+    try:
+        run_id = await start_pipeline_run(
+            agent_registry,
+            pipeline=pipeline,
+            pipeline_name=name,
+            input=dict(raw_input) if raw_input else None,
+            reply_to_agent=host.agent_name,
+            reply_to_sid=reply_sid,
+            state_log=state_log,
+        )
+    except ValueError as exc:
+        return {"status": "error", "data": {"error": str(exc)}}
+
+    return {"status": "started", "data": {"run_id": run_id}}
+
+
+RUN_PIPELINE_ASYNC = ToolDefinition(
+    name="run_pipeline_async",
+    description=_RUN_PIPELINE_ASYNC_DESCRIPTION,
+    parameters=_RUN_PIPELINE_PARAMETERS,  # same surface: name + optional input
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_run_pipeline_async,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = ["RUN_PIPELINE", "RUN_PIPELINE_ASYNC"]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -84,10 +84,11 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # ``skill__`` resource category (per-skill dynamic dispatch); this is the
     # management plane — mirrors the ``mcp`` category pattern.
     "skill_management",
-    # IS-1 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6):
-    # pipeline launch verb(s). ``pipeline__run`` = run_pipeline (sync,
-    # REGISTERED-only). run_pipeline_inline / run_pipeline_async / the
-    # ad-hoc-async combo join this category in later slices.
+    # IS-1/IS-2 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6):
+    # pipeline launch verbs. ``pipeline__run`` = run_pipeline (sync,
+    # REGISTERED-only); ``pipeline__run_async`` = run_pipeline_async (IS-2:
+    # background launch in a crash-recoverable driver-session).
+    # run_pipeline_inline / the ad-hoc-async combo join in later slices.
     "pipeline",
 )
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -337,8 +337,10 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     "skill_management__install_local":  ("skill_install_local",  _passthrough_args),
     "skill_management__install_source": ("skill_install_source", _passthrough_args),
 
-    # pipeline category (IS-1: sync + REGISTERED-only run_pipeline).
+    # pipeline category (IS-1: sync + REGISTERED-only run_pipeline;
+    # IS-2: async launch in a crash-recoverable driver-session).
     "pipeline__run": ("run_pipeline", _passthrough_args),
+    "pipeline__run_async": ("run_pipeline_async", _passthrough_args),
 }
 
 

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -168,7 +168,8 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "skill_management__install_local, skill_install_local, "  # #2548 PR-C: skill-install class
         "skill_management__install_source, skill_install_source, "  # #2548 PR-D: source install
         "session_spawn, agent_spawn, topology_create, "  # #2103: the full spawn class (session + agent + topology)
-        "pipeline__run, run_pipeline]\n",  # IS-1: pipeline-run class (spawn-adjacent)
+        "pipeline__run, run_pipeline, "  # IS-1: pipeline-run class (spawn-adjacent)
+        "pipeline__run_async, run_pipeline_async]\n",  # IS-2: async launch, same class
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -1,0 +1,583 @@
+"""Tier 2: IS-2 async pipeline driver-session — launch, crash-resume, recovery gates.
+
+Covers the D案 architecture end-to-end with real collaborators (real
+``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor``; the only fake
+is the scripted LLM callable injected through the real ``RouterLoopDriver``
+``_loop_observer`` seam, the same discipline as
+``test_run_pipeline_tool_is1.py``):
+
+- ``run_pipeline_async`` returns ``{status: started, run_id}`` immediately;
+  the run completes in its driver-session and the result arrives on the
+  invoker's inbox as a ``pipeline_result`` turn (scripted LLM consumed it).
+- the CLAUDE.md recovery gate: truncate-falsify (invocation.json + R4 gens
+  survive WAL truncation below their source events; recovery resumes
+  EXACTLY-ONCE — completed steps replay, only the remaining step executes).
+- crash windows: before the first R4 gen (original input preserved — resume's
+  ``initial_context=None`` fallback must not be reached), before the first
+  session snapshot (the scan re-CREATES the driver-session from
+  invocation.json alone), and between last step and delivery (steps-complete
+  but unmarked run re-delivers without re-executing).
+- A8 poison cap (attempts past the cap → terminal failure, not a crash-loop),
+- A9 rewind-guard polarity (abandoned-branch spawn_seq skipped; the truncated
+  case re-waking is proven by the truncate-falsify test),
+- R6 S3 structural deny for pipeline tool steps (launch/delegate tools).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    ExprRef,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.serde import (
+    PipelineSerdeError,
+    pipeline_from_dict,
+    pipeline_to_dict,
+)
+from reyn.core.pipeline.work_order import (
+    PipelineWorkOrder,
+    bump_resume_attempts,
+    pipeline_run_dir,
+    read_resume_attempts,
+    write_invocation,
+)
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.tools.pipeline_verbs import (
+    _handle_run_pipeline_async,
+    _make_tool_dispatch,
+)
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text turn — the LLM is incidental
+    to what's under test (same rationale as test_run_pipeline_tool_is1.py)."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _agent_registry(
+    tmp_path: Path, state_log: "StateLog", scripted: "_ScriptedAgentReply | None",
+) -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors the IS-1 test)."""
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _install_side_effect_tool(monkeypatch) -> None:
+    """Make a REAL side-effecting tool resolvable through the production
+    dispatch (appends a line to a file AND a WAL entry via ctx.state_log — so
+    R4 gens land at distinct seqs, same shape as test_pipeline_executor_r3_r4's
+    counting dispatch). ``get_default_registry`` builds a FRESH registry per
+    call, so the tool is added by wrapping the real builder with a real
+    callable (the policy-allowed monkeypatch idiom — every lookup still goes
+    through the real ``ToolRegistry.register``/``lookup`` contract)."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        p = Path(args["path"])
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(str(args["line"]) + "\n")
+        if ctx.state_log is not None:
+            await ctx.state_log.append("inbox_put", note="is2-side-effect")
+        return {"line": str(args["line"])}
+
+    tool = ToolDefinition(
+        name="is2_append",
+        description="IS-2 test: append a line to a file (real side effect).",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow", phase="allow"),
+        handler=_handler,
+        category="io",
+        purity="side_effect",
+    )
+    base_build = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base_build()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
+def _bare_ctx(state_log: "StateLog | None" = None) -> ToolContext:
+    from reyn.core.events.events import EventLog
+    return ToolContext(
+        events=EventLog(), permission_resolver=None, workspace=None,
+        caller_kind="router", router_state=None, state_log=state_log,
+    )
+
+
+def _three_step_pipeline(out_file: Path) -> Pipeline:
+    return Pipeline(
+        steps=[
+            TransformStep(value="ctx.seed + 1", output="t0"),
+            ToolStep(
+                name="is2_append",
+                args={"path": str(out_file), "line": ExprRef("ctx.t0")},
+                output="t1",
+            ),
+            ToolStep(
+                name="is2_append",
+                args={"path": str(out_file), "line": "second"},
+                output="t2",
+            ),
+        ],
+        description="IS-2 test pipeline",
+    )
+
+
+async def _wait_for(pred, timeout: float = 15.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+def _result_json(run_dir: Path) -> "dict | None":
+    p = run_dir / "result.json"
+    if not p.is_file():
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def _crash_state_work_order(
+    run_id: str, pipeline: Pipeline, *, input: "dict | None",
+    driver_sid: str = "drv1", spawn_seq: "int | None" = None,
+) -> PipelineWorkOrder:
+    return PipelineWorkOrder(
+        run_id=run_id,
+        pipeline_name="p",
+        pipeline=pipeline_to_dict(pipeline),
+        input=input,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        driver_agent="worker",
+        driver_sid=driver_sid,
+        spawn_seq=spawn_seq,
+    )
+
+
+# ── serde round-trip + kind-marker collision ────────────────────────────────
+
+
+def test_serde_round_trip_non_default_values() -> None:
+    """Tier 1: Pipeline ⇄ dict ⇄ JSON round-trips every step kind with
+    NON-DEFAULT field values (ExprRef args, schema, capabilities, output,
+    description) — the work-order persistence contract."""
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="ctx.a + 1", output="t"),
+            ToolStep(
+                name="is2_append",
+                args={"path": "/tmp/x", "line": ExprRef("ctx.t"), "n": 3,
+                      "nested": {"deep": [1, "two"]}},
+                output="w",
+                schema="OutShape",
+            ),
+            AgentStep(
+                prompt="summarize {ctx.w}",
+                identity="worker",
+                capabilities=["read_file"],
+                schema="Reply",
+                output="summary",
+            ),
+        ],
+        description="round-trip pipeline",
+    )
+    wire = json.loads(json.dumps(pipeline_to_dict(pipeline)))
+    assert pipeline_from_dict(wire) == pipeline
+
+
+def test_serde_exprref_marker_collision_is_refused_both_directions() -> None:
+    """Tier 1: the ``__exprref__`` kind-marker cannot be spoofed. Encode: a
+    LITERAL arg dict carrying the marker key is a hard error naming the arg
+    (not a silent mis-round-trip). Decode: only the exact one-key marker shape
+    decodes to ExprRef — a marker-key dict with extra keys stays a literal."""
+    colliding = Pipeline(steps=[
+        ToolStep(name="t", args={"payload": {"__exprref__": "ctx.x"}}),
+    ])
+    with pytest.raises(PipelineSerdeError) as exc:
+        pipeline_to_dict(colliding)
+    assert "payload" in str(exc.value) and "__exprref__" in str(exc.value)
+
+    # Decode direction: extra keys → NOT an ExprRef (stays a literal dict).
+    wire = {
+        "description": "",
+        "steps": [{
+            "kind": "tool", "name": "t",
+            "args": {"payload": {"__exprref__": "ctx.x", "other": 1}},
+            "output": None, "schema": None,
+        }],
+    }
+    decoded = pipeline_from_dict(wire)
+    assert decoded.steps[0].args["payload"] == {"__exprref__": "ctx.x", "other": 1}
+    # ...and the exact marker shape DOES decode to an ExprRef.
+    wire["steps"][0]["args"] = {"payload": {"__exprref__": "ctx.x"}}
+    assert pipeline_from_dict(wire).steps[0].args["payload"] == ExprRef("ctx.x")
+
+
+# ── R6 S3 structural deny for tool steps (sync + async share the dispatch) ──
+
+
+@pytest.mark.asyncio
+async def test_tool_step_dispatch_structurally_denies_launch_and_delegation() -> None:
+    """Tier 2b: a pipeline ToolStep must not launch a pipeline (sync OR async)
+    or delegate — R6 S3 (nesting is call-only). Checked through the SHARED
+    ``_make_tool_dispatch`` (both the sync run_pipeline path and the IS-2
+    driver path build their dispatch here), for bare AND qualified names."""
+    dispatch = _make_tool_dispatch(_bare_ctx())
+    for denied in ("run_pipeline", "run_pipeline_async", "delegate_to_agent",
+                   "pipeline__run", "multi_agent__delegate"):
+        with pytest.raises(PipelineExecutionError) as exc:
+            await dispatch(denied, {})
+        assert "structurally denied" in str(exc.value)
+
+
+def test_agent_step_narrowing_denies_async_launch() -> None:
+    """Tier 2b: the agent-step spawn narrowing (R5/R6 S3) denies the ASYNC
+    launch alongside the sync one — the sibling escape hatch is closed."""
+    from reyn.runtime.session_api import _build_agent_step_narrowing
+    deny = _build_agent_step_narrowing(["read_file"])["tool_deny"]
+    assert "run_pipeline_async" in deny and "run_pipeline" in deny
+
+
+# ── async launch e2e: tool → driver-session → pipeline_result ───────────────
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2c: ``run_pipeline_async`` returns {status: started, run_id}
+    IMMEDIATELY; the driver-session runs the pipeline to completion (real tool
+    side effect), posts the result to the invoker (whose scripted-LLM turn
+    consumes it), writes the terminal marker AFTER delivery, and the
+    driver-session is reclaimed (A10 — no leak past terminal)."""
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("p", _three_step_pipeline(out_file))
+
+    caller = reg.get_or_load("worker")
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline_async({"name": "p", "input": {"seed": 10}}, ctx)
+    assert result["status"] == "started"
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+    # invocation.json is on disk BEFORE completion (work-order-at-birth).
+    assert (run_dir / "invocation.json").is_file()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    # Real tool side effects: transform seeded 10 → 11, then the fixed line.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
+    # The invoker actually CONSUMED the pipeline_result (a scripted-LLM turn ran).
+    assert await _wait_for(lambda: scripted.calls >= 1)
+    # A10: the driver-session vanishes after terminal.
+    invocation = json.loads((run_dir / "invocation.json").read_text(encoding="utf-8"))
+    assert await _wait_for(
+        lambda: reg.get_session("worker", invocation["driver_sid"]) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_async_error_contracts(tmp_path: Path) -> None:
+    """Tier 1: unregistered pipeline name and missing WAL each yield a clear
+    error (never a silent no-op launch)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    registry = PipelineRegistry()
+
+    def _ctx(sl):
+        return ToolContext(
+            events=caller._router_host.events, permission_resolver=None,
+            workspace=None, caller_kind="router",
+            router_state=RouterCallerState(
+                pipeline_registry=registry, agent_registry=reg,
+                host=caller._router_host,
+            ),
+            state_log=sl,
+        )
+
+    missing = await _handle_run_pipeline_async({"name": "nope"}, _ctx(state_log))
+    assert missing["status"] == "error"
+    assert "not registered" in missing["data"]["error"]
+
+    registry.register("p", Pipeline(steps=[TransformStep(value="1")]))
+    no_wal = await _handle_run_pipeline_async({"name": "p"}, _ctx(None))
+    assert no_wal["status"] == "error"
+    assert "state_log" in no_wal["data"]["error"]
+
+
+# ── recovery: the CLAUDE.md truncate-falsify gate + kill/restore/resume ─────
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_recovery_source_survives_wal_truncation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: MANDATORY CLAUDE.md recovery gate + the kill→restore→resume
+    e2e. A run crashes mid-pipeline (steps 0-1 done, R4 gens + invocation.json
+    on disk; the driver-session died BEFORE any session snapshot — the
+    binding-(3) zero-snapshot window; its spawn WAL record is then TRUNCATED
+    away). ``restore_all`` must still re-CREATE the driver-session from
+    invocation.json alone, resume EXACTLY-ONCE (steps 0-1 replayed from the
+    gen FILE, only step 2 executes a new tool call), and deliver the result.
+    RED if any recovery source rode a truncatable WAL event, or if the rewind
+    guard had the wrong (default-closed) polarity — the truncated spawn_seq
+    must NOT block the re-wake."""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    full = _three_step_pipeline(out_file)
+    reg = _agent_registry(tmp_path, state_log, None)  # creates agent "worker"
+
+    # Crash state: the first TWO steps completed (run a 2-step prefix — the
+    # same phase-1 idiom as test_pipeline_executor_r3_r4), gens recorded at
+    # real WAL seqs (the side-effect tool appends an entry per call).
+    prefix = Pipeline(steps=list(full.steps[:2]))
+    await PipelineExecutor().run(
+        prefix, {"seed": 10},
+        tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)),
+        state_log=state_log, run_id="run-t",
+    )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11"]
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-t")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-t", full, input={"seed": 10}, spawn_seq=1,
+    ))
+
+    # Other activity advances the WAL head; GC truncates below 40 — the
+    # crash-state's source seqs (incl. spawn_seq=1) are GONE from the WAL.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    assert all(e["seq"] >= 40 for e in state_log.iter_from(0))
+
+    # ── restart: fresh StateLog + fresh registry, then recovery. ──
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("resumed ok")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    # Exactly-once: steps 0-1 replayed (no new "11" line), only step 2 ran.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
+    # The invoker consumed the re-delivered result.
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+@pytest.mark.asyncio
+async def test_recovery_before_first_gen_preserves_original_input(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the binding-(1) crash window — invocation.json written, NO R4
+    gen yet (crash before step 0 completed), no driver-session record. Recovery
+    must run the pipeline with the ORIGINAL work-order input (10 → the tool
+    writes '11'), not resume's hardcoded initial_context=None fallback."""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    full = _three_step_pipeline(out_file)
+    reg = _agent_registry(tmp_path, state_log, None)
+    assert reg.exists("worker")
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-fresh")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-fresh", full, input={"seed": 10},
+    ))
+
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("ok")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    assert _result_json(run_dir)["status"] == "ok"
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
+
+
+@pytest.mark.asyncio
+async def test_recovery_steps_done_but_undelivered_redelivers_without_rerun(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: A6 — terminal means RESULT DELIVERED, not steps-done. A run
+    whose steps ALL completed but crashed before delivery (gens complete, no
+    result.json) is re-woken; the driver replays every step from the snapshot
+    (zero new tool calls) and delivers the result. RED if the recovery scan
+    treated steps-done as terminal (the result would be lost forever)."""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    full = _three_step_pipeline(out_file)
+    reg = _agent_registry(tmp_path, state_log, None)
+    assert reg.exists("worker")
+
+    await PipelineExecutor().run(
+        full, {"seed": 10},
+        tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)),
+        state_log=state_log, run_id="run-done",
+    )
+    await state_log.flush()
+    lines_before = out_file.read_text(encoding="utf-8").splitlines()
+    assert lines_before == ["11", "second"]
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-done")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-done", full, input={"seed": 10},
+    ))
+
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("ok")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    # Exactly-once: nothing re-ran.
+    assert out_file.read_text(encoding="utf-8").splitlines() == lines_before
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+@pytest.mark.asyncio
+async def test_poison_run_past_resume_cap_fails_terminally(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: A8 — a run whose resume keeps crashing must not amplify a
+    restart crash-loop. With the persisted attempt counter already at the cap,
+    the next recovery re-wake terminal-FAILS the run (failure result
+    delivered, marker written, NO step executed) instead of resuming."""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    full = _three_step_pipeline(out_file)
+    reg = _agent_registry(tmp_path, state_log, None)
+    assert reg.exists("worker")
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-poison")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-poison", full, input={"seed": 10},
+    ))
+    from reyn.runtime.services.pipeline_executor_driver import MAX_RESUME_ATTEMPTS
+    for _ in range(MAX_RESUME_ATTEMPTS):
+        bump_resume_attempts(run_dir)
+
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("ok")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "failed"
+    assert "resume" in terminal["error"]
+    assert not out_file.exists(), "no step may execute past the poison cap"
+    assert await _wait_for(lambda: scripted.calls >= 1)  # failure IS delivered
+
+
+@pytest.mark.asyncio
+async def test_rewound_away_run_is_not_resurrected(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: A9 guard, abandoned-branch side — a run whose recorded
+    spawn_seq is PROVABLY on an abandoned WAL branch (a rewind to before the
+    spawn) is skipped by the recovery scan: no driver-session, no attempt
+    bump, no result. (The DEFAULT-OPEN side — spawn record truncated away →
+    still re-woken — is proven by the truncate-falsify test above.)"""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    full = _three_step_pipeline(out_file)
+    reg = _agent_registry(tmp_path, state_log, None)
+    assert reg.exists("worker")
+
+    # Advance the WAL past the spawn point, then rewind to BEFORE it — the
+    # real reset-record shape (snapshot_generations.REWIND_KIND semantics).
+    for i in range(6):
+        await state_log.append("inbox_put", n=i)
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-rewound")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-rewound", full, input={"seed": 10}, spawn_seq=5,
+    ))
+    from reyn.core.events.snapshot_generations import rewind
+    await state_log.flush()
+    await rewind(state_log, target_n=3)
+    await state_log.flush()
+
+    state_log2 = StateLog(wal_path)
+    reg2 = _agent_registry(tmp_path, state_log2, None)
+    rewoken = await reg2._rewake_pipeline_runs()
+
+    assert rewoken == []
+    assert _result_json(run_dir) is None
+    assert read_resume_attempts(run_dir) == 0
+    assert reg2.get_session("worker", "drv1") is None

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -210,16 +210,21 @@ async def test_agent_step_narrowing_denies_delegation_when_spawned(tmp_path: Pat
     assert contextual is not None
     assert {"delegate_to_agent", "multi_agent__delegate"} <= contextual.tool_deny
     assert {"run_pipeline", "pipeline__run"} <= contextual.tool_deny
+    # IS-2: the async launch is the same S3 escape hatch — denied alongside.
+    assert {"run_pipeline_async", "pipeline__run_async"} <= contextual.tool_deny
 
 
 def test_build_agent_step_narrowing_no_capabilities_is_restrict_only(tmp_path: Path) -> None:
     """Tier 2: OS invariant — omitting ``capabilities`` (None) leaves
     ``tool_allow`` unset (no re-grant beyond the agent's normal envelope);
-    only the structural leaf-worker deny (delegation + IS-1's nested
-    run_pipeline, R6 S3) is imposed. Pure function, no session needed."""
+    only the structural leaf-worker deny (delegation + the nested pipeline
+    launches, sync AND async — R6 S3) is imposed. Pure function, no session
+    needed."""
     narrowing = _build_agent_step_narrowing(None)
     assert "tool_allow" not in narrowing
-    assert narrowing["tool_deny"] == ["delegate_to_agent", "run_pipeline"]
+    assert set(narrowing["tool_deny"]) == {
+        "delegate_to_agent", "run_pipeline", "run_pipeline_async",
+    }
 
 
 # ── ephemeral cleanup ────────────────────────────────────────────────────────

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -102,6 +102,12 @@ _NOT_EXTERNAL = {
     # own tool-result path when it runs (same "ACK here, fenced at its own
     # seam" pattern as delegate_to_agent / session_spawn above).
     "run_pipeline",
+    # IS-2: run_pipeline_async returns only {status: started, run_id} — an
+    # OS-assembled launch ACK, no content at all. The eventual result arrives
+    # as an OS-framed pipeline_result inbox message; any external content a
+    # step fetched was fenced at that step's own tool-result seam when it
+    # ran (same rationale as run_pipeline above).
+    "run_pipeline_async",
 }
 
 

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -590,6 +590,8 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("skill_management__install_source", {"source": "https://github.com/user/skill-repo"}),
     # pipeline category (IS-1) — run_pipeline requires name; input is optional.
     ("pipeline__run", {"name": "my_pipeline", "input": {"topic": "x"}}),
+    # pipeline category (IS-2) — async launch, same surface as the sync verb.
+    ("pipeline__run_async", {"name": "my_pipeline", "input": {"topic": "x"}}),
 ]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — IS-2: async pipeline invocation via a pipeline driver-session (owner-approved D案), part of #2187.

## Architecture (D案 — work-order-as-driver-birth-state, ExecutionDriver protocol UNCHANGED)

- `run_pipeline_async` (new tool, `pipeline__run_async` invoke_action route) resolves a REGISTERED pipeline, spawns a dedicated **driver-session** under the invoker's identity (`spawn_session_recorded(mode="persistent")` — permission envelope ⊆ invoker by construction), persists the **work-order** to `.reyn/pipeline/state/<run_id>/invocation.json` **before step 0 can run**, swaps in `PipelineExecutorDriver` via the new `Session.set_loop_driver` post-ctor seam, nudges with an empty user turn (the D案 no-payload run/resume nudge), and returns `{status: started, run_id}` immediately.
- `PipelineExecutorDriver` (`runtime/services/pipeline_executor_driver.py`) conforms to the `ExecutionDriver` protocol — no changes to the protocol, `Session.run`, or `run_turn`'s signature. New-vs-resume: no R4 gen → `executor.run` seeded with the work-order's ORIGINAL input (lead-flagged bug: always-resume would lose it via `resume`'s `initial_context=None` fallback); gen present → `executor.resume` (exactly-once replay).
- Result posts to the invoker as a **`pipeline_result` inbox message** (the `agent_response` mirror; routed to one router turn like a task wake), and only THEN is `result.json` written. **Terminal = result delivered, not steps-done** → execution exactly-once, delivery at-least-once (dedup key: `run_id`). After terminal the driver-session is reclaimed via the standard ephemeral vanish (A10 — no leak, initial and recovered paths alike).

## Crash-resume (Seam 2)

`restore_all` gains `_rewake_pipeline_runs` — a **self-sufficient** scan of `.reyn/pipeline/state/` (deliberately independent of the #2187 task-backend subscription machinery AND of the snapshot-driven step-5 loop): for each run dir with `invocation.json` and no `result.json` it re-CREATES the driver-session if missing (`spawn_session(name, sid=…)` — covers the crash-before-first-session-snapshot window), injects a fresh driver, bumps the persisted attempt counter durably BEFORE the wake, and re-wakes (nudge + `ensure_session_running`). Guards:
- **A9 rewind guard, DEFAULT-OPEN polarity**: skip ONLY when the recorded `spawn_seq` is provably on an abandoned WAL branch (`is_active_seq` false); absent/truncated spawn record → re-wake normally (the truncate-falsify test proves the truncated case resumes).
- **A8 poison cap**: `attempts.json` (monotonic, durable, bumped pre-wake) + cap 3 → past the cap the driver terminal-FAILS the run (failure result delivered) instead of crash-looping. Bounded by construction.
- Terminal run dirs are skipped with one stat (no per-run WAL read).

## Security / gating

- R6 S3 structural deny in the SHARED tool-step dispatch (`_make_tool_dispatch`, used by sync IS-1 AND the async driver): a `ToolStep` cannot invoke `run_pipeline` / `run_pipeline_async` / `delegate_to_agent` (bare or qualified) — closes the nesting escape hatch the agent-step deny already closed; `run_pipeline_async` added to `_DELEGATION_DENY_TOOLS` (sibling sweep).
- `pipeline__run_async` added to the `pipeline-run` capability floor (same spawn-adjacent threat class as the sync verb) and to the external-content flagset (`_NOT_EXTERNAL`: launch ACK only).
- Serde: `ExprRef` encoded as the `{"__exprref__": …}` kind-marker; a literal args dict carrying that key is a HARD ERROR at encode (collision closed), decode recognises only the exact one-key marker shape. RED tests both directions.

## Documented v1 divergence

The driver builds its `ToolContext` from its OWN session's host adapter with `router_state=None` (no RouterLoop in a driver-session; hand-duplicating `_build_router_caller_state` would be a drift trap — lead-approved shape). Tool steps needing router_state-backed dynamic routes (mcp tools, rag corpus, nested `pipeline__run`) are unavailable in ASYNC pipelines until caller-state construction is extracted to a shared seam; plain registered tools work identically. Follow-up to be tracked.

## Test plan (all in `tests/test_pipeline_is2_driver_session.py` unless noted; real collaborators, scripted-LLM-only fake)

- [x] **Truncate-falsify (CLAUDE.md recovery gate) + kill→restore→resume e2e**: mid-run crash state (invocation.json + R4 gens, ZERO session snapshot, spawn WAL record truncated away) → `restore_all` re-creates the driver-session from the file alone, resumes EXACTLY-ONCE (steps 0-1 replayed, only step 2 executes a new tool call), delivers the result (scripted-LLM turn consumed it) — also proves the A9 default-open polarity for the truncated case.
- [x] Crash before first R4 gen → recovery runs with the ORIGINAL work-order input (not resume's None fallback).
- [x] A6: steps-all-done but undelivered → re-wake re-delivers with ZERO re-execution.
- [x] A8: attempts at cap → terminal failure delivered, no step executed.
- [x] A9 abandoned-branch side: rewound-away run is not resurrected (no session, no bump, no result).
- [x] Async launch e2e: `{status: started, run_id}` immediate; invocation.json on disk pre-completion; real tool side effects; result delivered then marker written; driver-session vanishes (A10).
- [x] Serde round-trip (non-default values, all 3 step kinds) + ExprRef marker-collision RED both directions.
- [x] R6 S3 deny: shared dispatch denies launch/delegation tools (bare + qualified); agent-step narrowing denies `run_pipeline_async`.
- [x] Gate 1 `ruff check src tests` — clean.
- [x] Gate 2 `python scripts/test_tier_audit.py --strict` on all 5 changed test files — 66 OK / 0 warnings / 0 errors.
- [x] Gate 3 `pytest` from repo root — **10 failed / 10 errors = exactly the pre-existing mcp/uvicorn/a2a baseline, zero new failures** (7011 passed).
- [x] Gate 4 `python scripts/verify_module_docstrings.py` on all 12 changed src files — clean (new modules have narrative docstrings).

part of #2187
🤖 Generated with [Claude Code](https://claude.com/claude-code)