### PR TITLE
feat(pipeline): IS-4 run_pipeline_inline + static-analysis gate

### DIFF
--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -80,17 +80,22 @@ if TYPE_CHECKING:
 #     ``MessageBus.request``'s quiescence predicate (inbox.empty()) return
 #     early on a pending chain the spawned session is still awaiting a reply
 #     for (see the module docstring).
-#   - ``run_pipeline`` / ``run_pipeline_async`` (IS-1/IS-2, R6 S3): nesting a
-#     pipeline launch inside an ``agent`` step would let a step spawn ANOTHER
-#     pipeline at runtime, defeating the transitive-closure cost-bound approval
-#     a REGISTERED pipeline gets at launch time — nesting is ``call``-only.
-#     The async launch is the same escape hatch as the sync one (sibling).
+#   - ``run_pipeline`` / ``run_pipeline_async`` / ``run_pipeline_inline`` /
+#     ``run_pipeline_inline_async`` (IS-1/IS-2/IS-4, R6 S3): nesting a pipeline
+#     launch inside an ``agent`` step would let a step spawn ANOTHER pipeline at
+#     runtime, defeating the transitive-closure cost-bound approval a pipeline
+#     gets at launch time — nesting is ``call``-only. The async + inline launch
+#     verbs are the same escape hatch as the sync registered one (siblings); the
+#     inline verbs get NO exemption (an ad-hoc pipeline is still non-grantable
+#     inside a pipeline). Kept in lock-step with ``pipeline_verbs.
+#     _PIPELINE_STEP_DENY_TOOLS`` (the tool-step sibling of this agent-step deny).
 # ``_expand_tool_forms`` (capability_profile.py) derives every invocable alias
 # (bare + qualified) from each name here, so listing the bare tool name is
 # sufficient — the qualified catalog form (``multi_agent__delegate`` /
 # ``pipeline__run``) is covered too.
 _DELEGATION_DENY_TOOLS: tuple[str, ...] = (
     "delegate_to_agent", "run_pipeline", "run_pipeline_async",
+    "run_pipeline_inline", "run_pipeline_inline_async",
 )
 
 # MessageBus.request has no default — an agent step needs one so callers

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -269,7 +269,16 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     # IS-2: the async launch (pipeline__run_async → run_pipeline_async) is
     # the SAME threat class — it additionally spawns a driver-session, so it
     # must not be floored looser than the sync verb.
-    "pipeline-run": frozenset({"pipeline__run", "pipeline__run_async"}),
+    # IS-4: the ad-hoc INLINE launches (pipeline__run_inline /
+    # pipeline__run_inline_async → run_pipeline_inline{,_async}) run an
+    # agent-GENERATED pipeline — an even STRICTER-to-trust surface than a
+    # registered one (no trusted registrant chose the steps), so they belong on
+    # the SAME spawn-adjacent floor. Bare aliases are auto-derived by
+    # ``_with_unwrapped_aliases`` (both have an invoke_action route).
+    "pipeline-run": frozenset({
+        "pipeline__run", "pipeline__run_async",
+        "pipeline__run_inline", "pipeline__run_inline_async",
+    }),
 }
 
 # Intentionally BARE-ONLY floored names: router-only tools with NO invoke_action

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -86,7 +86,12 @@ def get_default_registry() -> ToolRegistry:
         REMEMBER_AGENT,
         REMEMBER_SHARED,
     )
-    from reyn.tools.pipeline_verbs import RUN_PIPELINE, RUN_PIPELINE_ASYNC
+    from reyn.tools.pipeline_verbs import (
+        RUN_PIPELINE,
+        RUN_PIPELINE_ASYNC,
+        RUN_PIPELINE_INLINE,
+        RUN_PIPELINE_INLINE_ASYNC,
+    )
     from reyn.tools.recall import RECALL
     from reyn.tools.reyn_src import (
         REYN_SRC_GLOB,
@@ -217,6 +222,13 @@ def get_default_registry() -> ToolRegistry:
     # driver-session; returns {status: started, run_id} immediately, the
     # result arrives later as a pipeline_result inbox message.
     registry.register(RUN_PIPELINE_ASYNC)
+    # IS-4: run_pipeline_inline / run_pipeline_inline_async — launch an ad-hoc,
+    # agent-GENERATED pipeline (a DSL string in 'definition'), parsed + put
+    # through a static-analysis gate before spawn, then run through the SAME
+    # attached / background driver-session the registered verbs use. Recovery is
+    # identical (invocation.json carries the full serialized Pipeline).
+    registry.register(RUN_PIPELINE_INLINE)
+    registry.register(RUN_PIPELINE_INLINE_ASYNC)
     # ── FP-0034 universal catalog wrappers (router-only) ─────────────────
     # PR-3a registers them in the registry; PR-3b will add them to
     # build_tools() output and refactor the SP. Handlers wire through

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -1,11 +1,67 @@
-"""``run_pipeline`` router tool — sync ATTACHED launch of a REGISTERED pipeline.
+"""Pipeline launch router tools — REGISTERED + ad-hoc INLINE, sync + async.
 
 Per ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R6: an agent
-launches a REGISTERED pipeline (pre-built via
-:class:`reyn.core.pipeline.registry.PipelineRegistry`) and gets its result back
-inline. This module hosts the two launch verbs — ``run_pipeline`` (sync
-attached) and ``run_pipeline_async`` (fire-and-forget) — plus the tool-step
-dispatch they share.
+launches a pipeline and collects its result. This module hosts the four launch
+verbs plus the tool-step dispatch they share:
+
+  - ``run_pipeline`` / ``run_pipeline_async`` — launch a REGISTERED pipeline
+    (pre-built via :class:`reyn.core.pipeline.registry.PipelineRegistry`) by
+    name, sync-attached or fire-and-forget.
+  - ``run_pipeline_inline`` / ``run_pipeline_inline_async`` (IS-4) — launch an
+    ad-hoc, agent-GENERATED pipeline whose ``definition`` is a DSL STRING the
+    agent produced at runtime (Appendix B grammar). The string is parsed
+    (``reyn.core.pipeline.parser.parse_pipeline_dsl``, IS-3 — including any
+    inline ``schema:`` documents in the same string, into a fresh per-call
+    :class:`~reyn.core.pipeline.schema.SchemaRegistry`) into a ``Pipeline``,
+    which then feeds the SAME downstream every registered launch uses. The
+    inline verbs SKIP the registry entirely — the only extra machinery over the
+    registered verbs is the parse ENTRY and a **static-analysis gate** (see
+    :func:`_static_analysis_gate`) that runs BEFORE anything is spawned.
+
+The inline + registered verbs converge immediately after the pipeline is in
+hand: both call ``reyn.runtime.session_api.run_pipeline_attached`` (sync) /
+``start_pipeline_run`` (async), which serialize the FULL ``Pipeline`` into the
+work-order's ``invocation.json`` (NOT a registry name). So an inline run is
+crash-recoverable IDENTICALLY to a registered one — the recovery scan
+(``AgentRegistry._rewake_pipeline_runs``) re-creates the driver-session from
+``invocation.json`` alone, with no registry lookup and no new recovery source.
+
+**The static-analysis gate (IS-4, R6 §7.3 — the validation gate for
+agent-GENERATED artifacts).** A generated pipeline is untrusted-by-shape: it
+must be checked before it can spawn a driver-session. For the LINEAR subset the
+gate is deliberately MINIMAL (the full cost-bound / dataflow / spawn-tree
+analyzer belongs with the non-linear primitives, a later slice) — six checks,
+all statically decidable over the parsed ``Pipeline`` + its ``SchemaRegistry``:
+
+  1. **parse succeeds** — ``parse_pipeline_dsl`` raises ``PipelineParseError``
+     for malformed DSL; the handler turns that into a clear tool error.
+  2. **schema refs resolve** — every step ``schema:`` REF is registered in the
+     parsed registry (i.e. a ``schema:`` document in the SAME definition string
+     defines it). Catches a typo'd / undefined ref before the run.
+  3. **tool names resolve** — every ``tool`` step name resolves to a registered
+     tool (qualified-action routing, then a bare registry lookup — the SAME
+     resolution :func:`_make_tool_dispatch` performs at run time).
+  4. **capability ⊆ invoker** — already STRUCTURAL, no runtime re-check needed:
+     the driver-session is spawned under the INVOKER's own identity
+     (``_spawn_pipeline_driver_session``), and an ``agent`` step narrows
+     RESTRICT-ONLY (``_build_agent_step_narrowing``), so a generated pipeline
+     can never exceed the invoker's envelope by construction. The gate only
+     DOCUMENTS this; check 6 closes the one hole it leaves.
+  5. **S3 no nested launch** — a ``tool`` step must not itself launch a pipeline
+     or delegate (nesting is ``call``-only; enforced structurally at dispatch
+     via ``_PIPELINE_STEP_DENY_TOOLS``, validated statically here so a bad
+     generated pipeline fails fast at the gate, not mid-run).
+  6. **agent-step identity == invoker** (INLINE-ONLY, escalation prevention) —
+     an ``agent`` step may only run under the invoker's own identity
+     (``identity`` unset = inherit invoker, or explicitly the invoker's name).
+     A generated pipeline naming ANOTHER agent's identity would run under that
+     agent's (possibly larger) profile — a capability escalation, since check
+     4's ⊆-invoker guarantee holds only for identity==invoker. Registered
+     pipelines are exempt (a trusted registrant deliberately chose the
+     identity); this check applies to inline definitions only.
+
+A gate failure returns a clear tool error and spawns NOTHING (the checks run
+before ``run_pipeline_attached`` / ``start_pipeline_run`` is called).
 
   - **Sync = async + an attached live view (IS-6).** ``run_pipeline`` no longer
     runs the executor inline on the caller's turn (that was IS-1, which meant a
@@ -21,8 +77,6 @@ dispatch they share.
     Ctrl-C (``Session.cancel_inflight`` → the driver's ``request_cancel``) stops
     the run cooperatively at the next step BOUNDARY, leaving a resumable R4
     journal under a terminal ``cancelled`` marker.
-  - **Registered only.** No ad-hoc ``run_pipeline_inline`` (deferred — needs
-    the §7.3 static-analysis gate first, per R6).
   - **Real tool-step dispatch, not a stub.** A pipeline ``ToolStep``'s
     ``tool_dispatch`` is wired through the SAME routing seam
     ``invoke_action`` uses (``universal_dispatch.resolve_invoke_action`` +
@@ -66,11 +120,19 @@ from disk / a parser); it is threaded through ``RouterHostAdapter`` onto
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable, Mapping
 
-from reyn.core.pipeline.executor import PipelineExecutionError
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    Pipeline,
+    PipelineExecutionError,
+    ToolStep,
+)
 from reyn.core.pipeline.registry import PipelineNotFoundError
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+if TYPE_CHECKING:
+    from reyn.core.pipeline.schema import SchemaRegistry
 
 _RUN_PIPELINE_DESCRIPTION = (
     "Run a REGISTERED pipeline by name to completion and return its final "
@@ -107,6 +169,11 @@ _RUN_PIPELINE_PARAMETERS: dict[str, Any] = {
 # (``pipeline__run`` / ``multi_agent__delegate``) are covered too.
 _PIPELINE_STEP_DENY_TOOLS: "frozenset[str]" = frozenset({
     "run_pipeline", "run_pipeline_async", "delegate_to_agent",
+    # IS-4 sibling sweep: the inline launch verbs are the same escape hatch as
+    # the registered ones — an inline pipeline is STILL non-grantable inside a
+    # pipeline step (nesting is call-only). Kept in lock-step with the
+    # ``_DELEGATION_DENY_TOOLS`` agent-step deny in ``runtime/session_api.py``.
+    "run_pipeline_inline", "run_pipeline_inline_async",
 })
 
 
@@ -393,4 +460,322 @@ RUN_PIPELINE_ASYNC = ToolDefinition(
     purity="side_effect",
 )
 
-__all__ = ["RUN_PIPELINE", "RUN_PIPELINE_ASYNC"]
+# ── IS-4: ad-hoc INLINE launch (agent-GENERATED DSL + static-analysis gate) ──
+
+_RUN_PIPELINE_INLINE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "definition": {
+            "type": "string",
+            "description": (
+                "The pipeline as a DSL string (Appendix B grammar): one or "
+                "more '---'-separated YAML documents — exactly one 'pipeline:' "
+                "document plus any 'schema:' documents its steps reference. "
+                "Generated at call time; parsed + statically validated before "
+                "anything runs."
+            ),
+        },
+        "input": {
+            "type": "object",
+            "description": (
+                "Initial named context (ctx.*) for the pipeline's first step. "
+                "Omit for a pipeline that needs no seed input."
+            ),
+        },
+    },
+    "required": ["definition"],
+}
+
+_RUN_PIPELINE_INLINE_DESCRIPTION = (
+    "Run an ad-hoc pipeline you DEFINE inline (no pre-registration) to "
+    "completion and return its final output. Blocks until it finishes (sync). "
+    "'definition' is a pipeline DSL string (Appendix B); 'input' seeds the "
+    "first step's ctx.*. The definition is statically validated (parse, schema "
+    "refs, tool names, no nested pipeline launch, agent steps run as you) "
+    "BEFORE anything is spawned — a bad definition fails clearly and runs "
+    "nothing."
+)
+
+_RUN_PIPELINE_INLINE_ASYNC_DESCRIPTION = (
+    "Launch an ad-hoc pipeline you DEFINE inline in the background and return "
+    "immediately with {status: started, run_id}. It runs in a dedicated "
+    "crash-recoverable driver session; its final result arrives later as a "
+    "[pipeline] message on your conversation. 'definition' is a pipeline DSL "
+    "string (Appendix B), statically validated before spawn; 'input' seeds the "
+    "first step's ctx.*."
+)
+
+
+def _static_analysis_gate(
+    pipeline: "Pipeline",
+    schema_registry: "SchemaRegistry",
+    *,
+    invoker_agent: str,
+) -> "str | None":
+    """The IS-4 minimal static-analysis gate for an agent-GENERATED pipeline.
+
+    Runs the six R6 §7.3 checks (see the module docstring) over the already-
+    parsed ``pipeline`` + its ``schema_registry``, returning a clear error
+    string on the FIRST failing check or ``None`` when all pass. Check 1
+    (parse) is handled by the caller (``parse_pipeline_dsl`` raises before this
+    is reached); check 4 (capability ⊆ invoker) is structural and needs no
+    runtime probe here (documented in the module docstring). This function is
+    PURE — it inspects the parsed artifact and the tool registry, spawns
+    nothing, so the caller can run it strictly before any driver-session launch.
+    """
+    from reyn.tools import get_default_registry
+    from reyn.tools.universal_dispatch import (
+        UnknownActionError,
+        resolve_invoke_action,
+    )
+
+    registry = get_default_registry()
+    for i, step in enumerate(pipeline.steps):
+        # Check 2: schema REF resolves in the parsed (inline) registry.
+        schema = getattr(step, "schema", None)
+        if schema is not None and not schema_registry.has(schema):
+            return (
+                f"step {i}: schema ref {schema!r} does not resolve — no "
+                "'schema:' document in the definition defines it"
+            )
+        # Checks 3 + 5: tool-step name resolution + S3 nested-launch deny. Mirror
+        # the run-time resolution ``_make_tool_dispatch`` performs (qualified
+        # action routing first, then a bare registry lookup) so the static verdict
+        # matches what would actually dispatch.
+        if isinstance(step, ToolStep):
+            name = step.name
+            target_name = name
+            try:
+                resolved = resolve_invoke_action(name, {})
+            except UnknownActionError:
+                resolved = None
+            if resolved is not None:
+                target_name = resolved.target_tool_name
+            # Check 5 (S3): reject BEFORE the registry lookup — a launch/delegate
+            # verb IS a registered tool, so lookup would pass; the deny must win.
+            if name in _PIPELINE_STEP_DENY_TOOLS or target_name in _PIPELINE_STEP_DENY_TOOLS:
+                return (
+                    f"step {i}: tool {name!r} is structurally denied (R6 S3) — an "
+                    "inline pipeline step must not launch a pipeline or delegate "
+                    "(nesting is call-only)"
+                )
+            # Check 3: the tool name must resolve to a registered tool.
+            if registry.lookup(target_name) is None:
+                return (
+                    f"step {i}: tool {name!r} does not resolve to a registered "
+                    f"tool (tried qualified-action routing, then a bare lookup of "
+                    f"{target_name!r})"
+                )
+        # Check 6 (INLINE-ONLY): an agent step may only run under the invoker's
+        # own identity — a non-invoker identity is a capability escalation.
+        if isinstance(step, AgentStep):
+            if step.identity is not None and step.identity != invoker_agent:
+                return (
+                    f"step {i}: agent step identity {step.identity!r} is not the "
+                    f"invoker {invoker_agent!r} — an inline pipeline may only run "
+                    "agent steps under the invoker's own identity (capability "
+                    "escalation prevention, R6 constraint b); omit 'identity' to "
+                    "inherit the invoker, or name the invoker explicitly"
+                )
+    return None
+
+
+def _prepare_inline_launch(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> "tuple[dict | None, tuple | None]":
+    """Shared inline prelude for both inline verbs: validate args, require a
+    fully-wired persistent context, parse the ``definition`` DSL string into a
+    ``Pipeline`` (with a FRESH per-call ``SchemaRegistry`` populated from the
+    definition's own inline ``schema:`` docs), and run the static-analysis gate.
+
+    Returns ``(error_result, None)`` on any validation / parse / gate failure
+    (the caller returns ``error_result`` verbatim, having spawned NOTHING), or
+    ``(None, (pipeline, agent_registry, host, state_log, raw_input))`` when the
+    definition is clean and ready to launch. The fresh registry is deliberately
+    NOT threaded onto the work-order or router state — an inline definition is
+    self-contained (its schemas live only in the string), matching the
+    "no persistent inline registry" design decision."""
+    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+    from reyn.core.pipeline.schema import SchemaError, SchemaRegistry
+
+    definition = args.get("definition")
+    if not isinstance(definition, str) or not definition.strip():
+        return {
+            "status": "error",
+            "data": {"error": "definition is required (a pipeline DSL string)"},
+        }, None
+
+    raw_input = args.get("input")
+    if raw_input is not None and not isinstance(raw_input, Mapping):
+        return {
+            "status": "error",
+            "data": {"error": "input must be an object (mapping), if given"},
+        }, None
+
+    rs = ctx.router_state
+    agent_registry = rs.agent_registry if rs is not None else None
+    host = rs.host if rs is not None else None
+    if agent_registry is None or host is None:
+        return {
+            "status": "error",
+            "data": {
+                "error": (
+                    "run_pipeline_inline requires a fully-wired router context "
+                    "(agent_registry + host on ctx.router_state) to spawn its "
+                    "driver-session"
+                ),
+            },
+        }, None
+    state_log = ctx.state_log
+    if state_log is None:
+        return {
+            "status": "error",
+            "data": {
+                "error": (
+                    "run_pipeline_inline requires WAL persistence (ctx.state_log) "
+                    "— an inline run is a crash-recoverable driver-session"
+                ),
+            },
+        }, None
+
+    # Check 1 (parse): a fresh registry so an inline definition is self-contained
+    # (its schemas never leak across calls). Malformed DSL / expression / a
+    # schema-shape error surfaces as a clear gate error, nothing spawned.
+    schema_registry = SchemaRegistry()
+    try:
+        pipeline = parse_pipeline_dsl(definition, schema_registry)
+    except (PipelineParseError, SchemaError) as exc:
+        return {
+            "status": "error",
+            "data": {"error": f"inline pipeline definition is invalid: {exc}"},
+        }, None
+
+    # Checks 2/3/5/6 (schema refs, tool names, S3, agent identity).
+    gate_error = _static_analysis_gate(
+        pipeline, schema_registry, invoker_agent=host.agent_name,
+    )
+    if gate_error is not None:
+        return {
+            "status": "error",
+            "data": {"error": f"inline pipeline rejected by static gate: {gate_error}"},
+        }, None
+
+    return None, (pipeline, agent_registry, host, state_log, raw_input)
+
+
+async def _handle_run_pipeline_inline(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """IS-4 sync INLINE launch: parse + statically gate the agent-generated
+    ``definition``, then run it in the SAME attached driver-session
+    ``run_pipeline`` uses (``run_pipeline_attached``) — so the inline run is
+    crash-recoverable and returns its output inline, exactly like a registered
+    run. A gate failure returns a clear error and spawns nothing."""
+    error_result, launch = _prepare_inline_launch(args, ctx)
+    if error_result is not None:
+        return error_result
+    pipeline, agent_registry, host, state_log, raw_input = launch
+
+    from reyn.runtime.session_api import run_pipeline_attached
+
+    reply_sid = getattr(host, "live_session_id", None) or "main"
+    try:
+        outcome = await run_pipeline_attached(
+            agent_registry,
+            pipeline=pipeline,
+            pipeline_name="inline",
+            input=dict(raw_input) if raw_input else None,
+            reply_to_agent=host.agent_name,
+            reply_to_sid=reply_sid,
+            state_log=state_log,
+        )
+    except ValueError as exc:
+        return {"status": "error", "data": {"error": str(exc)}}
+
+    status = outcome["status"]
+    if status == "failed":
+        return {
+            "status": "error",
+            "data": {
+                "error": f"inline pipeline failed: {outcome.get('error')}",
+                "run_id": outcome["run_id"],
+            },
+        }
+    if status == "cancelled":
+        return {
+            "status": "cancelled",
+            "data": {"run_id": outcome["run_id"], "error": outcome.get("error")},
+        }
+    if status == "running_async":
+        return {"status": "started", "data": {"run_id": outcome["run_id"]}}
+
+    return {
+        "status": "ok",
+        "data": {
+            "run_id": outcome["run_id"],
+            "output": outcome.get("output"),
+            "named_stores": outcome.get("named_stores"),
+        },
+    }
+
+
+async def _handle_run_pipeline_inline_async(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """IS-4 async INLINE launch: parse + statically gate the agent-generated
+    ``definition``, then hand it to the SAME background driver-session
+    ``run_pipeline_async`` uses (``start_pipeline_run``) and return
+    ``{status: started, run_id}`` immediately; the result arrives later as a
+    ``pipeline_result`` inbox message. A gate failure returns a clear error and
+    spawns nothing."""
+    error_result, launch = _prepare_inline_launch(args, ctx)
+    if error_result is not None:
+        return error_result
+    pipeline, agent_registry, host, state_log, raw_input = launch
+
+    from reyn.runtime.session_api import start_pipeline_run
+
+    reply_sid = getattr(host, "live_session_id", None) or "main"
+    try:
+        run_id = await start_pipeline_run(
+            agent_registry,
+            pipeline=pipeline,
+            pipeline_name="inline",
+            input=dict(raw_input) if raw_input else None,
+            reply_to_agent=host.agent_name,
+            reply_to_sid=reply_sid,
+            state_log=state_log,
+        )
+    except ValueError as exc:
+        return {"status": "error", "data": {"error": str(exc)}}
+
+    return {"status": "started", "data": {"run_id": run_id}}
+
+
+RUN_PIPELINE_INLINE = ToolDefinition(
+    name="run_pipeline_inline",
+    description=_RUN_PIPELINE_INLINE_DESCRIPTION,
+    parameters=_RUN_PIPELINE_INLINE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_run_pipeline_inline,
+    category="io",
+    purity="side_effect",
+)
+
+
+RUN_PIPELINE_INLINE_ASYNC = ToolDefinition(
+    name="run_pipeline_inline_async",
+    description=_RUN_PIPELINE_INLINE_ASYNC_DESCRIPTION,
+    parameters=_RUN_PIPELINE_INLINE_PARAMETERS,  # same surface: definition + input
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_run_pipeline_inline_async,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = [
+    "RUN_PIPELINE",
+    "RUN_PIPELINE_ASYNC",
+    "RUN_PIPELINE_INLINE",
+    "RUN_PIPELINE_INLINE_ASYNC",
+]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -84,11 +84,13 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # ``skill__`` resource category (per-skill dynamic dispatch); this is the
     # management plane — mirrors the ``mcp`` category pattern.
     "skill_management",
-    # IS-1/IS-2 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md R6):
-    # pipeline launch verbs. ``pipeline__run`` = run_pipeline (sync,
+    # IS-1/IS-2/IS-4 (docs/proposals/reyn-pipeline-v0.9-design-resolutions.md
+    # R6): pipeline launch verbs. ``pipeline__run`` = run_pipeline (sync,
     # REGISTERED-only); ``pipeline__run_async`` = run_pipeline_async (IS-2:
-    # background launch in a crash-recoverable driver-session).
-    # run_pipeline_inline / the ad-hoc-async combo join in later slices.
+    # background launch in a crash-recoverable driver-session);
+    # ``pipeline__run_inline`` / ``pipeline__run_inline_async`` (IS-4) = the
+    # ad-hoc INLINE launches of an agent-GENERATED DSL definition, gated by a
+    # static-analysis pass before spawn.
     "pipeline",
 )
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -338,9 +338,13 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     "skill_management__install_source": ("skill_install_source", _passthrough_args),
 
     # pipeline category (IS-1: sync + REGISTERED-only run_pipeline;
-    # IS-2: async launch in a crash-recoverable driver-session).
+    # IS-2: async launch in a crash-recoverable driver-session;
+    # IS-4: ad-hoc INLINE launches — agent-GENERATED DSL + a static-analysis
+    # gate, sync-attached and async, sharing the registered launch downstream).
     "pipeline__run": ("run_pipeline", _passthrough_args),
     "pipeline__run_async": ("run_pipeline_async", _passthrough_args),
+    "pipeline__run_inline": ("run_pipeline_inline", _passthrough_args),
+    "pipeline__run_inline_async": ("run_pipeline_inline_async", _passthrough_args),
 }
 
 

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -169,7 +169,9 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
         "skill_management__install_source, skill_install_source, "  # #2548 PR-D: source install
         "session_spawn, agent_spawn, topology_create, "  # #2103: the full spawn class (session + agent + topology)
         "pipeline__run, run_pipeline, "  # IS-1: pipeline-run class (spawn-adjacent)
-        "pipeline__run_async, run_pipeline_async]\n",  # IS-2: async launch, same class
+        "pipeline__run_async, run_pipeline_async, "  # IS-2: async launch, same class
+        "pipeline__run_inline, run_pipeline_inline, "  # IS-4: inline launch, same class
+        "pipeline__run_inline_async, run_pipeline_inline_async]\n",  # IS-4: inline async
         encoding="utf-8",
     )
     assert not _by(_findings(monkeypatch, tmp_path), contains="worker")

--- a/tests/test_pipeline_is4_inline.py
+++ b/tests/test_pipeline_is4_inline.py
@@ -1,0 +1,531 @@
+"""Tier 2: IS-4 ad-hoc INLINE pipeline launch + the static-analysis gate.
+
+Covers ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md`` R6's inline
+launch verbs (``run_pipeline_inline`` / ``run_pipeline_inline_async``): an agent
+GENERATES a pipeline as a DSL string at runtime, the string is parsed (IS-3) +
+statically gated, then run through the SAME crash-recoverable driver-session the
+REGISTERED verbs use (IS-2/IS-6). Real collaborators throughout — real
+``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor``/parser; the only
+fake is the scripted LLM callable injected through the real ``RouterLoopDriver``
+``_loop_observer`` seam (same discipline as ``test_run_pipeline_tool_is1.py``).
+No ``MagicMock``/``patch`` of collaborators.
+
+The behaviors, each with a falsifiable assertion:
+
+- **inline happy path (sync + async)**: a generated DSL string parses, passes
+  the gate, runs to completion (real tool side effect + a real agent step), and
+  the result is returned inline (sync) / delivered via the inbox (async).
+- **static gate rejections (all six checks)**: a bad definition is rejected
+  with a clear error and NOTHING is spawned (no run dir under
+  ``.reyn/pipeline/state/``) — malformed DSL, an unresolvable schema ref, an
+  unknown tool, an S3 nested pipeline launch, and (the INLINE-ONLY security
+  check) an agent step naming a NON-invoker identity (capability escalation).
+- **S3 sibling sweep**: the inline verbs are added to BOTH the pipeline-tool-step
+  deny (``_PIPELINE_STEP_DENY_TOOLS``) and the agent-step delegation deny
+  (``_DELEGATION_DENY_TOOLS``) — an inline launch is non-grantable inside a
+  pipeline (nesting is call-only).
+- **inline crash-resume e2e (truncate-falsify)**: an inline run whose generated
+  definition was serialized into ``invocation.json`` crash-resumes EXACTLY-ONCE
+  after the WAL is truncated below its source events — proving the recovery
+  source is the serialized generated Pipeline, not a registry lookup.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import PipelineExecutor
+from reyn.core.pipeline.parser import parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_to_dict
+from reyn.core.pipeline.work_order import (
+    PipelineWorkOrder,
+    pipeline_run_dir,
+    write_invocation,
+)
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.tools.pipeline_verbs import (
+    _handle_run_pipeline_inline,
+    _handle_run_pipeline_inline_async,
+    _make_tool_dispatch,
+)
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+class _ScriptedAgentReply:
+    """One fixed plain-text turn — the LLM is incidental to what's under test."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _agent_registry(
+    tmp_path: Path, state_log: "StateLog", scripted: "_ScriptedAgentReply | None",
+) -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors the IS-1/IS-2 tests)."""
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _install_write_tool(monkeypatch) -> None:
+    """Register a REAL side-effecting tool (append a line per call to the file
+    named in ``args['path']`` — workspace-independent). Same monkeypatch idiom as
+    the IS-2 test: every lookup still routes through the real
+    ``ToolRegistry.register``/``lookup`` contract."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        p = Path(args["path"])
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(str(args["content"]) + "\n")
+        return {"content": str(args["content"])}
+
+    tool = ToolDefinition(
+        name="is4_write",
+        description="IS-4 test: append content to a file (real side effect).",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow", phase="allow"),
+        handler=_handler,
+        category="io",
+        purity="side_effect",
+    )
+    base = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
+def _bare_ctx(state_log: "StateLog | None" = None) -> ToolContext:
+    from reyn.core.events.events import EventLog
+    return ToolContext(
+        events=EventLog(), permission_resolver=None, workspace=None,
+        caller_kind="router", router_state=None, state_log=state_log,
+    )
+
+
+def _ctx(
+    reg: AgentRegistry, caller: Session, state_log: "StateLog | None",
+    *, wired: bool = True,
+) -> ToolContext:
+    """A full router ToolContext (agent_registry + host + WAL) — inline needs no
+    PipelineRegistry. ``wired=False`` drops agent_registry/host to exercise the
+    wiring-error path."""
+    return ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            agent_registry=reg if wired else None,
+            host=caller._router_host if wired else None,
+        ),
+        state_log=state_log,
+    )
+
+
+def _run_dirs(tmp_path: Path) -> "list[Path]":
+    state_root = tmp_path / ".reyn" / "pipeline" / "state"
+    if not state_root.is_dir():
+        return []
+    return [d for d in state_root.iterdir() if d.is_dir()]
+
+
+def _result_json(run_dir: Path) -> "dict | None":
+    p = run_dir / "result.json"
+    return json.loads(p.read_text(encoding="utf-8")) if p.is_file() else None
+
+
+async def _wait_for(pred, timeout: float = 15.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+# A generated definition an agent might emit: transform -> tool -> agent, plus a
+# named store — the whole point is that this is a STRING, parsed at call time.
+_GOOD_DEF = """
+pipeline: greet_and_write
+description: a generated pipeline
+steps:
+  - transform: {value: "'hello ' + ctx.name", output: msg}
+  - tool: {name: is4_write, args: {path: !expr ctx.out_path, content: !expr ctx.msg}}
+  - agent: {prompt: "review {ctx.msg}"}
+"""
+
+# tool-only variant (no agent step) for the async path — the invoker's own
+# scripted turn (consuming the pipeline_result) is then the ONLY LLM call.
+_GOOD_DEF_TOOL_ONLY = """
+pipeline: write_only
+steps:
+  - transform: {value: "'hi ' + ctx.name", output: msg}
+  - tool: {name: is4_write, args: {path: !expr ctx.out_path, content: !expr ctx.msg}}
+"""
+
+
+# ── inline happy path: sync ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inline_sync_happy_path_runs_and_returns_inline(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a generated DSL string passes the gate and runs to completion in
+    the attached driver-session — the tool step REALLY wrote the file, the final
+    output is the (scripted) agent reply, and it is returned INLINE. RED if the
+    inline entry stopped feeding the parsed Pipeline into the shared attached
+    launch, or the gate wrongly rejected a valid definition."""
+    _install_write_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("the final answer")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": _GOOD_DEF, "input": {"name": "world", "out_path": str(out_file)}},
+        _ctx(reg, caller, state_log),
+    )
+
+    assert result["status"] == "ok"
+    assert result["data"]["output"] == "the final answer"
+    assert result["data"]["named_stores"]["msg"] == "hello world"
+    # Real tool side effect (not a stub); exactly the agent step called the LLM.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["hello world"]
+    assert scripted.calls == 1
+
+
+# ── inline happy path: async ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inline_async_happy_path_launches_and_delivers(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: ``run_pipeline_inline_async`` returns {status: started, run_id}
+    immediately (invocation.json on disk before completion), the driver-session
+    runs the generated pipeline, and the result is delivered to the invoker's
+    inbox (its scripted turn consumes it). RED if the async inline path stopped
+    persisting the generated def / stopped delivering."""
+    _install_write_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    result = await _handle_run_pipeline_inline_async(
+        {"definition": _GOOD_DEF_TOOL_ONLY,
+         "input": {"name": "async", "out_path": str(out_file)}},
+        _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "started"
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", result["data"]["run_id"])
+    assert (run_dir / "invocation.json").is_file()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["hi async"]
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+# ── static gate rejections — each fails, NOTHING spawned ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_malformed_dsl_nothing_spawned(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: check 1 — a definition the parser cannot turn into exactly one
+    pipeline (here: zero pipeline docs) is rejected with a clear error and
+    spawns nothing."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": "schema: S\nfields: {a: {type: string}}"},
+        _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "error"
+    assert "invalid" in result["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_unresolvable_schema_ref_nothing_spawned(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: check 2 — a step ``schema:`` REF not defined by any inline
+    ``schema:`` document is rejected before spawn."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    definition = (
+        "pipeline: p\n"
+        "steps:\n"
+        "  - tool: {name: web_search, args: {query: hi}, schema: NoSuchSchema}\n"
+    )
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": definition}, _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "error"
+    assert "NoSuchSchema" in result["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_unknown_tool_nothing_spawned(tmp_path: Path) -> None:
+    """Tier 2: check 3 — a ``tool`` step naming a tool that resolves to no
+    registered tool is rejected before spawn."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    definition = "pipeline: p\nsteps:\n  - tool: {name: does_not_exist_xyz, args: {}}\n"
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": definition}, _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "error"
+    assert "does_not_exist_xyz" in result["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_s3_nested_launch_nothing_spawned(tmp_path: Path) -> None:
+    """Tier 2: check 5 (R6 S3) — a ``tool`` step that would itself launch a
+    pipeline (here the inline verb, closing the sibling loophole) is rejected
+    statically before spawn (nesting is call-only)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    definition = "pipeline: p\nsteps:\n  - tool: {name: run_pipeline_inline, args: {}}\n"
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": definition}, _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "error"
+    assert "structurally denied" in result["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_rejects_non_invoker_agent_identity_nothing_spawned(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: check 6 (INLINE-ONLY, escalation prevention) — a generated
+    pipeline whose ``agent`` step declares an identity OTHER than the invoker
+    would run under that agent's (possibly larger) envelope. The gate rejects it
+    before spawn; a step with ``identity`` unset (inherit invoker) or naming the
+    invoker is allowed. RED if the gate let a non-invoker identity through — a
+    real capability-escalation hole."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    if not reg.exists("privileged_agent"):
+        reg.create("privileged_agent")
+    caller = reg.get_or_load("worker")  # invoker = "worker"
+    definition = (
+        "pipeline: p\n"
+        "steps:\n"
+        "  - agent: {prompt: do it, identity: privileged_agent}\n"
+    )
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": definition}, _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "error"
+    assert "privileged_agent" in result["data"]["error"]
+    assert "escalation" in result["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+@pytest.mark.asyncio
+async def test_gate_allows_invoker_identity_and_unset(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: check 6 positive control — an agent step with ``identity`` unset
+    (inherit invoker) OR explicitly the invoker's own name PASSES the gate and
+    runs (so the rejection above is not vacuous — the check keys on identity,
+    not on the mere presence of an agent step)."""
+    _install_write_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ok")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    definition = (
+        "pipeline: p\n"
+        "steps:\n"
+        "  - agent: {prompt: unset identity}\n"
+        "  - agent: {prompt: explicit invoker, identity: worker}\n"
+    )
+
+    result = await _handle_run_pipeline_inline(
+        {"definition": definition}, _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "ok"
+
+
+# ── inline arg / wiring error contracts ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_inline_missing_definition_and_wiring_errors(tmp_path: Path) -> None:
+    """Tier 1: a missing ``definition`` and a non-wired context each fail
+    clearly (never a silent no-op launch), and spawn nothing."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+
+    empty = await _handle_run_pipeline_inline({}, _ctx(reg, caller, state_log))
+    assert empty["status"] == "error" and "definition" in empty["data"]["error"]
+
+    no_wire = await _handle_run_pipeline_inline(
+        {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"},
+        _ctx(reg, caller, state_log, wired=False),
+    )
+    assert no_wire["status"] == "error"
+    assert "router context" in no_wire["data"]["error"]
+    assert _run_dirs(tmp_path) == []
+
+
+# ── S3 sibling sweep: inline verbs are non-grantable inside a pipeline ───────
+
+
+@pytest.mark.asyncio
+async def test_tool_step_dispatch_denies_inline_launch() -> None:
+    """Tier 2b: the SHARED tool-step dispatch (both the sync tool path and the
+    driver path build it here) structurally denies the inline launch verbs — a
+    ToolStep may not launch an inline pipeline (bare AND qualified names)."""
+    from reyn.core.pipeline.executor import PipelineExecutionError
+
+    dispatch = _make_tool_dispatch(_bare_ctx())
+    for denied in ("run_pipeline_inline", "run_pipeline_inline_async",
+                   "pipeline__run_inline", "pipeline__run_inline_async"):
+        with pytest.raises(PipelineExecutionError) as exc:
+            await dispatch(denied, {})
+        assert "structurally denied" in str(exc.value)
+
+
+def test_agent_step_narrowing_denies_inline_launch() -> None:
+    """Tier 2b: OS invariant (R6 S3 sibling sweep) — the agent-step spawn
+    narrowing denies the inline launch verbs alongside the registered ones, so
+    an agent step cannot re-open the inline escape hatch."""
+    from reyn.runtime.session_api import _build_agent_step_narrowing
+
+    deny = _build_agent_step_narrowing(["read_file"])["tool_deny"]
+    assert "run_pipeline_inline" in deny
+    assert "run_pipeline_inline_async" in deny
+
+
+# ── inline crash-resume e2e (truncate-falsify: generated def survives) ───────
+
+
+@pytest.mark.asyncio
+async def test_inline_run_crash_resumes_exactly_once_after_wal_truncation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: an INLINE run's recovery source is the GENERATED definition
+    serialized into invocation.json — not a registry entry. A run whose steps
+    0-1 completed (R4 gens on disk) crashes before the terminal marker; the WAL
+    is then truncated below the crash-state's source events. ``restore_all``
+    re-creates the driver-session from invocation.json alone and resumes
+    EXACTLY-ONCE (steps 0-1 replay from the gen FILE, only step 2 executes),
+    then delivers. RED if the inline recovery source rode a truncatable WAL
+    event, or if resume re-ran a completed step."""
+    _install_write_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    reg = _agent_registry(tmp_path, state_log, None)  # creates agent "worker"
+
+    # A three-tool-step generated definition (deterministic, no agent step so the
+    # exactly-once file assertion is unambiguous).
+    definition = (
+        "pipeline: gen\n"
+        "steps:\n"
+        f"  - tool: {{name: is4_write, args: {{path: {json.dumps(str(out_file))}, content: a}}}}\n"
+        f"  - tool: {{name: is4_write, args: {{path: {json.dumps(str(out_file))}, content: b}}}}\n"
+        f"  - tool: {{name: is4_write, args: {{path: {json.dumps(str(out_file))}, content: c}}}}\n"
+    )
+    full = parse_pipeline_dsl(definition, SchemaRegistry())
+
+    # Crash state: run a 2-step prefix (steps 0-1 → gens on disk), then persist
+    # the FULL generated pipeline as the work-order (exactly what
+    # start_pipeline_run serializes via pipeline_to_dict — a generated Pipeline,
+    # no registry name).
+    from reyn.core.pipeline.executor import Pipeline as _Pipeline
+    prefix = _Pipeline(steps=list(full.steps[:2]))
+    await PipelineExecutor().run(
+        prefix, None, tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)),
+        state_log=state_log, run_id="run-inline",
+    )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["a", "b"]
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-inline")
+    write_invocation(run_dir, PipelineWorkOrder(
+        run_id="run-inline", pipeline_name="inline",
+        pipeline=pipeline_to_dict(full), input=None,
+        reply_to_agent="worker", reply_to_sid="main",
+        driver_agent="worker", driver_sid="drv-inline", spawn_seq=1,
+    ))
+
+    # Advance + truncate the WAL below the crash-state's source seqs (incl.
+    # spawn_seq=1) — the serialized generated def must survive.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    assert all(e["seq"] >= 40 for e in state_log.iter_from(0))
+
+    # Restart + recover.
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("resumed")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    # Exactly-once: steps 0-1 replayed (no duplicate a/b), only step 2 executed.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["a", "b", "c"]
+    assert await _wait_for(lambda: scripted.calls >= 1)

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -218,12 +218,13 @@ def test_build_agent_step_narrowing_no_capabilities_is_restrict_only(tmp_path: P
     """Tier 2: OS invariant — omitting ``capabilities`` (None) leaves
     ``tool_allow`` unset (no re-grant beyond the agent's normal envelope);
     only the structural leaf-worker deny (delegation + the nested pipeline
-    launches, sync AND async — R6 S3) is imposed. Pure function, no session
-    needed."""
+    launches — registered AND inline, sync AND async — R6 S3) is imposed.
+    Pure function, no session needed."""
     narrowing = _build_agent_step_narrowing(None)
     assert "tool_allow" not in narrowing
     assert set(narrowing["tool_deny"]) == {
         "delegate_to_agent", "run_pipeline", "run_pipeline_async",
+        "run_pipeline_inline", "run_pipeline_inline_async",
     }
 
 

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -108,6 +108,15 @@ _NOT_EXTERNAL = {
     # step fetched was fenced at that step's own tool-result seam when it
     # ran (same rationale as run_pipeline above).
     "run_pipeline_async",
+    # IS-4: run_pipeline_inline returns the ad-hoc pipeline's OWN final output
+    # (run_id / output / named_stores), and run_pipeline_inline_async returns
+    # only {status: started, run_id} — identical OS-assembled framing to
+    # run_pipeline / run_pipeline_async respectively. The definition is an
+    # AGENT-GENERATED DSL string, not fetched external content; any external
+    # content a step pulls is fenced at THAT step's own tool-result seam when it
+    # runs (same "ACK here, fenced at its own seam" rationale as above).
+    "run_pipeline_inline",
+    "run_pipeline_inline_async",
 }
 
 

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -592,6 +592,12 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("pipeline__run", {"name": "my_pipeline", "input": {"topic": "x"}}),
     # pipeline category (IS-2) — async launch, same surface as the sync verb.
     ("pipeline__run_async", {"name": "my_pipeline", "input": {"topic": "x"}}),
+    # pipeline category (IS-4) — ad-hoc INLINE launches: a DSL 'definition'
+    # string (+ optional input), sync-attached and async.
+    ("pipeline__run_inline",
+     {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
+    ("pipeline__run_inline_async",
+     {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
 ]
 
 


### PR DESCRIPTION
**[lead-sonnet]** — IS-4: ad-hoc agent-GENERATED inline pipelines + a static-analysis gate before execution (R6). `part of #2187`.

## What
Two new router tools that let an agent GENERATE a pipeline as a DSL string at runtime and run it — no pre-registration:
- **`run_pipeline_inline(definition, input)`** — sync, attached (reuses IS-6 `run_pipeline_attached`).
- **`run_pipeline_inline_async(definition, input)`** — async (reuses IS-2 `start_pipeline_run`).

`definition` is parsed by IS-3 `parse_pipeline_dsl` (into a fresh per-call `SchemaRegistry` populated from the definition's own inline `schema:` docs) → a `Pipeline`, which feeds the SAME downstream every registered launch uses. The inline verbs skip the registry entirely; the only new machinery is the parse ENTRY + a static gate.

## Static-analysis gate (runs BEFORE any spawn — validation gate for generated artifacts)
Minimal set for the linear subset (the full cost-bound/dataflow/spawn-tree analyzer belongs with the non-linear primitives, a later slice):
1. **parse succeeds** — `PipelineParseError` otherwise.
2. **schema refs resolve** — each step `schema:` REF registered in the parsed registry.
3. **tool names resolve** — each `tool` step resolves (qualified-action routing, then bare lookup — same as `_make_tool_dispatch`).
4. **capability ⊆ invoker** — already STRUCTURAL (driver spawns under the invoker's identity; agent steps narrow restrict-only). Documented, no runtime re-check.
5. **S3 no nested launch** — a `tool` step must not launch a pipeline / delegate (nesting is call-only).
6. **agent-step identity == invoker** (INLINE-ONLY, escalation prevention, per lead-coder's binding addition) — a generated pipeline naming another agent's identity would run under that agent's (possibly larger) envelope. Registered pipelines are exempt (trusted registrant chose the identity); inline rejects a non-invoker identity.

A gate failure returns a clear tool error and spawns NOTHING.

## Recovery
Identical to IS-2 — `invocation.json` carries the full serialized (generated) `Pipeline`, so `_rewake_pipeline_runs` re-creates the driver from the file alone. No new recovery source; the inline crash-resume test adds a WAL truncate-falsify proving the generated def survives.

## Dispatch-completeness + S3 sibling sweep
- 2 `ToolDefinition`s registered in `tools/__init__.py`.
- 2 `_OPERATION_RULES` passthrough routes (`pipeline__run_inline{,_async}`) — auto-populate `KNOWN_STATIC_QUALIFIED_NAMES`; no catalog resource-enumeration branch (inline has no registry to enumerate).
- 2 `capability_profile` `pipeline-run` floor entries (bare aliases auto-derived).
- Inline verbs added to BOTH `_PIPELINE_STEP_DENY_TOOLS` (tool steps) and `_DELEGATION_DENY_TOOLS` (agent steps).

## Known pre-existing limitation (NOT introduced here, flagged for a separate issue)
The `PipelineExecutorDriver` runs the executor with `schema_registry=None`, so runtime `verify: schema` enforcement is unwired for BOTH registered and inline pipelines. Gate check 2 still adds value (catches an unresolvable/typo'd ref before spawn), but a schema-referencing pipeline that passes the gate would fail at run time on the schema step — equally for registered and inline. Threading schemas through the driver (persist into the work-order + pass to `executor.run/resume`) is a separate, recovery-touching change; out of IS-4's inline-entry+gate scope.

## Tests (`tests/test_pipeline_is4_inline.py`, real collaborators / scripted-LLM, no mocks)
- inline happy path sync + async;
- all six gate rejections, each asserting a clear error + NOTHING spawned (no run dir), plus a positive control for check 6 (unset / invoker identity passes);
- S3 sibling-sweep deny (shared dispatch + agent-step narrowing);
- inline crash-resume e2e with WAL truncate-falsify.

Updated three invariant SoT-completeness tests (route-contract samples, agent-step deny set, delegation-audit tight profile).

## Test plan
- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_is4_inline.py` — 12/12 OK, 0 Tier-4.
- [x] `pytest` — new file 12/12; related pipeline/permissions/dispatch suites green; full run has zero NEW failures vs baseline (the 11 failed / 10 errored are pre-existing web/mcp optional-dep failures, confirmed identical on unmodified main).
- [x] `python scripts/verify_module_docstrings.py <changed src>` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)