### PR TITLE
feat(pipeline): TUI-bridge event emit — total_steps + pipeline_run_attached marker (#2570)

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -39,7 +39,9 @@ result.
 **IS-6 (attached run: live events + step-boundary cancel)**: two optional hooks let a
 caller *attach* to a run without changing the core loop. ``events`` (an ``EventLog``)
 receives a ``pipeline_step_started`` / ``pipeline_step_completed`` pair around every step
-boundary — the emit half of the emit+subscribe seam a sync ``run_pipeline`` tool (or the
+boundary — each carrying ``total_steps`` (``len(pipeline.steps)``) alongside ``run_id`` /
+``step_index`` / ``step_kind`` so a "step i/N" display never needs a second lookup — the
+emit half of the emit+subscribe seam a sync ``run_pipeline`` tool (or the
 TUI) uses to render live progress; when None the executor stays silent (pure callers are
 unaffected). ``cancel_check`` (a ``Callable[[], bool]``) is polled at each step BOUNDARY,
 before the next step starts — never mid-step, so a step's side effect is never half-applied
@@ -369,9 +371,11 @@ class PipelineExecutor:
                 raise PipelineCancelled(run_id=run_id, step_index=i)
             step = steps[i]
             kind = _step_kind(step)
+            total_steps = len(steps)
             if events is not None:
                 events.emit(
-                    "pipeline_step_started", run_id=run_id, step_index=i, step_kind=kind,
+                    "pipeline_step_started",
+                    run_id=run_id, step_index=i, step_kind=kind, total_steps=total_steps,
                 )
             context = {"ctx": named_stores, "pipe": pipe_data}
 
@@ -454,6 +458,7 @@ class PipelineExecutor:
                 events.emit(
                     "pipeline_step_completed",
                     run_id=run_id, step_index=step_index, step_kind=kind,
+                    total_steps=total_steps,
                 )
 
         return PipelineResult(

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -58,6 +58,11 @@ prefix and differing only in how the caller drives + collects:
     driver-session, a crash mid-attach is auto-resumed by the existing recovery
     scan (which re-creates the driver with ``notify_reply=True`` → the result
     degrades to inbox delivery), so sync pipelines are crash-recoverable too.
+    Optional ``tool``/``caller_events`` params (#2570, the TUI bridge) let it
+    also emit a ``pipeline_run_attached`` marker onto the CALLER's own
+    ``EventLog`` (see the function docstring) — the driver-session's live
+    events are on a DIFFERENT EventLog than the one the human-attached caller
+    (the TUI) watches, so this marker is the signal that bridges the two.
 """
 from __future__ import annotations
 
@@ -353,6 +358,8 @@ async def run_pipeline_attached(
     state_log: "object",
     timeout: "float | None" = None,
     run_id: "str | None" = None,
+    tool: "str | None" = None,
+    caller_events: "Any | None" = None,
 ) -> dict:
     """IS-6: launch a SYNC pipeline run in a driver-session the caller ATTACHES to.
 
@@ -372,6 +379,21 @@ async def run_pipeline_attached(
     the driver is destroyed and the recovery scan re-creates it with
     ``notify_reply=True`` → the result then degrades to async inbox delivery to
     this same caller. One reply address serves both paths; no new plumbing.
+
+    **TUI bridge marker (#2570)**: the driver-session's ``pipeline_step_*``
+    events land on the DRIVER's own ``EventLog`` — a session distinct from the
+    human-attached caller, which the TUI has no signal to bridge-subscribe to.
+    When ``caller_events`` (an ``EventLog``) is given, right after the driver-
+    session is spawned this emits a ``pipeline_run_attached`` marker onto it —
+    ``{kind: "pipeline_run_attached", tool, run_id, driver_sid, agent_name,
+    pipeline_name}`` — so a live view (the TUI) watching the CALLER's own
+    EventLog learns the driver_sid to bridge-subscribe to for the run's
+    duration (unsubscribing on the matching ``tool_call_completed``). ``tool``
+    is the caller-supplied invoking tool name (``run_pipeline`` /
+    ``run_pipeline_inline``) — this helper is shared by both, so it never
+    hardcodes one. None (the default) skips the emit — used by callers with no
+    attached live viewer to bridge to. Sync-attached-only: the async path
+    (``start_pipeline_run``) has no attached caller and never emits this.
 
     Returns a ``dict``:
       - terminal reached → ``{"status": <ok|failed|cancelled>, "run_id", "output",
@@ -400,6 +422,12 @@ async def run_pipeline_attached(
         notify_reply=False,
         run_id=run_id,
     )
+    if caller_events is not None:
+        caller_events.emit(
+            "pipeline_run_attached",
+            tool=tool, run_id=rid, driver_sid=sid,
+            agent_name=reply_to_agent, pipeline_name=pipeline_name,
+        )
     run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
 
     bus = MessageBus()

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -69,11 +69,22 @@ before ``run_pipeline_attached`` / ``start_pipeline_run`` is called).
     ``PipelineExecutorDriver`` driver-session as ``run_pipeline_async`` and
     ATTACHES: ``reyn.runtime.session_api.run_pipeline_attached`` pumps the run on
     the caller's own task via ``MessageBus.request``, streams
-    ``pipeline_step_started`` / ``pipeline_step_completed`` events to the
-    driver-session's ``EventLog`` (the emit+subscribe seam a live view / the TUI
-    consumes), and reads the terminal marker back in-band — no redundant reply
-    turn (``notify_reply=False``). A crash mid-attach degrades to async recovery:
-    the recovery scan resumes the run and delivers to THIS caller's inbox.
+    ``pipeline_step_started`` / ``pipeline_step_completed`` events (each carrying
+    ``total_steps``, #2570) to the driver-session's ``EventLog`` (the emit+
+    subscribe seam a live view / the TUI consumes), and reads the terminal marker
+    back in-band — no redundant reply turn (``notify_reply=False``). A crash
+    mid-attach degrades to async recovery: the recovery scan resumes the run and
+    delivers to THIS caller's inbox.
+    **TUI bridge marker (#2570)**: the ``pipeline_step_*`` events above land on
+    the DRIVER-session's own ``EventLog`` — a session distinct from the
+    human-attached caller the TUI actually watches. So both sync handlers pass
+    ``tool``/``caller_events=ctx.events`` through to ``run_pipeline_attached``,
+    which emits a ``pipeline_run_attached`` marker (``{tool, run_id, driver_sid,
+    agent_name, pipeline_name}``) onto the CALLER's own ``EventLog`` right after
+    the driver-session spawns — the signal a live view uses to bridge-subscribe
+    to the driver_sid's events for the run's duration. The async handlers
+    (``_handle_run_pipeline_async`` / ``_handle_run_pipeline_inline_async``) have
+    no attached live viewer and never pass these — no marker.
     Ctrl-C (``Session.cancel_inflight`` → the driver's ``request_cancel``) stops
     the run cooperatively at the next step BOUNDARY, leaving a resumable R4
     journal under a terminal ``cancelled`` marker.
@@ -318,6 +329,8 @@ async def _handle_run_pipeline(
             reply_to_agent=host.agent_name,
             reply_to_sid=reply_sid,
             state_log=state_log,
+            tool="run_pipeline",
+            caller_events=ctx.events,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -688,6 +701,8 @@ async def _handle_run_pipeline_inline(
             reply_to_agent=host.agent_name,
             reply_to_sid=reply_sid,
             state_log=state_log,
+            tool="run_pipeline_inline",
+            caller_events=ctx.events,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -31,6 +31,13 @@ The four behaviors, each with a falsifiable assertion:
   crashes before terminal is re-woken by the recovery scan with
   ``notify_reply=True`` and delivered to the caller's inbox (sync degrades to
   async-recovery) — exactly-once.
+- **TUI bridge marker + total_steps (§5, #2570)**: step events carry
+  ``total_steps`` (= ``len(pipeline.steps)``), and a sync ATTACHED run, when
+  given ``caller_events``, emits a ``pipeline_run_attached`` marker onto the
+  CALLER's own ``EventLog`` (a different EventLog than the driver-session's,
+  where the ``pipeline_step_*`` events land) right after the driver spawns —
+  the bridge signal a live view (the TUI) uses to subscribe to the driver's
+  events. The ASYNC path (``start_pipeline_run``) never emits this marker.
 """
 from __future__ import annotations
 
@@ -61,7 +68,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 from reyn.runtime.session import Session
-from reyn.runtime.session_api import run_pipeline_attached
+from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
 from reyn.tools.pipeline_verbs import _make_tool_dispatch
 from reyn.tools.types import ToolContext
 
@@ -469,3 +476,98 @@ async def test_crash_while_attached_recovers_and_delivers_via_inbox(
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]
     # The caller consumed the re-delivered pipeline_result.
     assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+# ── §5: TUI bridge marker + total_steps (#2570) ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attached_run_emits_bridge_marker_on_callers_own_eventlog(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: §5 — a sync attached run, given ``caller_events``, emits a
+    ``pipeline_run_attached`` marker onto the CALLER's own EventLog (observed
+    via a real subscriber on the caller session, NOT the driver-session) right
+    after the driver-session spawns, carrying the run_id/driver_sid/agent_name/
+    pipeline_name/tool the TUI needs to bridge-subscribe to the driver's own
+    events. RED if the marker were dropped, emitted on the wrong EventLog, or
+    missing a field the bridge contract requires."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    _install_counting_tool(monkeypatch, out_file)
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")  # (worker, main) = the reply/caller address
+    caller_events: list = []
+    caller.router_host.events.add_subscriber(caller_events.append)
+
+    outcome = await run_pipeline_attached(
+        reg,
+        pipeline=_steps(2),
+        pipeline_name="p",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        tool="run_pipeline",
+        caller_events=caller.router_host.events,
+    )
+    assert outcome["status"] == "ok"
+
+    markers = [e for e in caller_events if e.type == "pipeline_run_attached"]
+    (marker,) = markers  # exactly one — unpack fails RED if 0 or >1 landed
+    assert marker.data["tool"] == "run_pipeline"
+    assert marker.data["run_id"] == outcome["run_id"]
+    assert marker.data["agent_name"] == "worker"
+    assert marker.data["pipeline_name"] == "p"
+    driver_sid = marker.data["driver_sid"]
+    assert isinstance(driver_sid, str) and driver_sid
+
+    # The driver_sid actually names a real, distinct session (the driver, not
+    # the caller's own "main" sid) whose EventLog carries the step events.
+    assert driver_sid != "main"
+    driver_session = reg.get_session("worker", driver_sid)
+    assert driver_session is not None
+    driver_events = driver_session.router_host.events.all()
+    started = [e for e in driver_events if e.type == "pipeline_step_started"]
+    completed = [e for e in driver_events if e.type == "pipeline_step_completed"]
+    assert {e.data["step_index"] for e in started} == {0, 1}
+    assert {e.data["step_index"] for e in completed} == {1, 2}
+    assert all(e.data["total_steps"] == 2 for e in started + completed)
+    assert all(e.data["step_kind"] == "tool" for e in started + completed)
+
+
+@pytest.mark.asyncio
+async def test_async_launch_does_not_emit_bridge_marker(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: §5 negative — the ASYNC launch path (``start_pipeline_run``) has
+    no attached live viewer to bridge, so it must never emit the
+    ``pipeline_run_attached`` marker onto the caller's EventLog. RED if the
+    marker leaked onto an async-launched caller's events (it has no
+    ``caller_events``/``tool`` param at all — this asserts the runtime effect,
+    not just the absent parameter)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    _install_counting_tool(monkeypatch, out_file)
+    scripted = _ScriptedAgentReply("ack")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    caller_events: list = []
+    caller.router_host.events.add_subscriber(caller_events.append)
+
+    rid = await start_pipeline_run(
+        reg,
+        pipeline=_steps(1),
+        pipeline_name="p",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+    )
+    assert rid
+
+    # Let the detached pump run to completion so the async result actually
+    # reaches the caller's inbox — the marker-absence check covers the whole
+    # async lifecycle, not just the launch instant.
+    assert await _wait_for(lambda: scripted.calls >= 1)
+    assert not any(e.type == "pipeline_run_attached" for e in caller_events)


### PR DESCRIPTION
**[lead-sonnet]** — part of #2570.

Implements the CORE emit half of the pipeline-arc-owned TUI bridge signal (contract locked on #2570 by lead-coder + tui-coder). TUI subscribe/render is out of scope here (tui-coder's).

## What changed

1. **`total_steps: int`** (= `len(pipeline.steps)`) added to both `pipeline_step_started` and `pipeline_step_completed` (`src/reyn/core/pipeline/executor.py` `_run_from`) — trivial, the executor already has `pipeline.steps` in scope.

2. **`pipeline_run_attached` bridge marker** — `run_pipeline_attached` (`src/reyn/runtime/session_api.py`, the SYNC attached path only) now takes two new optional params, `tool: str | None` and `caller_events: EventLog | None`. Right after `_spawn_pipeline_driver_session` returns, when `caller_events` is given it emits:
   `{kind: "pipeline_run_attached", tool, run_id, driver_sid, agent_name, pipeline_name}`
   onto the CALLER's own EventLog — a different EventLog than the driver-session's (where `pipeline_step_*` land), which is exactly the bridge gap #2570 identified. `agent_name` = `reply_to_agent` (the driver spawns under the invoker's own identity, so this is the invoker's agent name).

   `src/reyn/tools/pipeline_verbs.py`'s two SYNC handlers (`_handle_run_pipeline`, `_handle_run_pipeline_inline`) now pass `tool="run_pipeline"` / `tool="run_pipeline_inline"` and `caller_events=ctx.events` (the caller's own EventLog, reachable via `ToolContext.events` — traced to `router_loop.py`'s `tool_ctx = ToolContext(events=self.host.events, ...)`, i.e. the invoking session's own EventLog). The two ASYNC handlers (`_handle_run_pipeline_async`, `_handle_run_pipeline_inline_async`) are untouched — `start_pipeline_run` has no `caller_events`/`tool` params at all, so the async path structurally cannot emit this marker.

3. **Inline `pipeline_name` choice**: `_handle_run_pipeline_inline` already passed the literal string `"inline"` as `pipeline_name` to `run_pipeline_attached` (pre-existing, used for the run_id path-segment sanitization) — since the marker just forwards whichever `pipeline_name` was already threaded through, inline runs get `pipeline_name="inline"` on the marker for free. No new field was added to the `Pipeline` dataclass for this (deliberately, per the ticket's "don't over-engineer" note) — a registered run gets its real registered name, an inline run gets the existing `"inline"` placeholder.

## Tests (`tests/test_pipeline_is6_attached.py`, §5 section added)

- `test_attached_run_emits_bridge_marker_on_callers_own_eventlog` — Tier 2: a real subscriber on the CALLER session's own EventLog observes exactly one `pipeline_run_attached` marker with the right `run_id`/`agent_name`/`pipeline_name`/`tool`, whose `driver_sid` names a real, distinct driver-session whose own EventLog carries `pipeline_step_started`/`pipeline_step_completed` with `total_steps == 2`, correct `step_index`, and `step_kind == "tool"`.
- `test_async_launch_does_not_emit_bridge_marker` — Tier 2 negative: `start_pipeline_run`, run to completion, never emits the marker onto the caller's EventLog.
- Reused the existing IS-6 no-mock harness (real `AgentRegistry`/`Session`/`StateLog`, scripted-LLM only for the reply turn).

## Gates (all run locally)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_is6_attached.py` — 8/8 OK (fixed one Tier-4 `len(...) == 1` format-pin flag by switching to the unpack idiom `(marker,) = markers`).
- `pytest` (full suite) — 7050 passed; the two new tests also run individually in isolation (pass). 10 pre-existing failures/errors (a2a/mcp/web-plugin-loader) confirmed present on `main` before this change (stashed + re-ran), unrelated to this PR.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK, no narrative-refactor flags.

## Test plan
- [x] `pytest tests/test_pipeline_is6_attached.py` green (8/8)
- [x] Both new tests pass in isolation individually
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean
- [x] `verify_module_docstrings.py` clean
- [x] Confirmed pre-existing full-suite failures are unrelated (present on main pre-change)