### PR TITLE
feat(#2570): TUI bridge-subscribes to sync-attached run_pipeline live progress

### DIFF
--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -13,11 +13,14 @@ notifications, budget warnings, session-level errors) can land here
 without expanding the lifecycle forwarder's per-handler contract.
 
 Wired up in :class:`reyn.runtime.session.Session` via
-``self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))``.
+``self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox, registry=self._registry))``.
+The optional ``registry`` lets a handler bridge-subscribe to another session's
+own EventLog (#2570: a pipeline driver-session's live step progress).
 """
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from reyn.runtime.outbox import OutboxMessage
 from reyn.schemas.models import Event
@@ -26,8 +29,13 @@ from reyn.schemas.models import Event
 class ChatLifecycleForwarder:
     """Callable subscriber that bridges session-level events into the outbox."""
 
-    def __init__(self, outbox: asyncio.Queue) -> None:
+    def __init__(self, outbox: asyncio.Queue, registry: "Any | None" = None) -> None:
         self.outbox = outbox
+        self._registry = registry
+        # #2570: run_id -> (driver EventLog, listener fn, invoking tool name).
+        # Tracks bridge-subscriptions to a pipeline driver-session's own
+        # EventLog for the duration of one sync-attached run_pipeline call.
+        self._pipeline_subs: dict[str, tuple[Any, Any, str | None]] = {}
 
     def __call__(self, event: Event) -> None:
         handler = getattr(self, f"on_{event.type}", None)
@@ -263,6 +271,9 @@ class ChatLifecycleForwarder:
             data=data,
             extra_meta={"result": data.get("result")},
         )
+        result = data.get("result")
+        run_id = result.get("run_id") if isinstance(result, dict) else None
+        self._maybe_unsubscribe_pipeline(data.get("tool"), run_id)
 
     def on_tool_failed(self, data: dict) -> None:
         """Bridge ``dispatch_tool``'s failure event into a ``tool_call_failed``
@@ -279,6 +290,87 @@ class ChatLifecycleForwarder:
                 "error_message": data.get("message"),
             },
         )
+        # No result dict on a raised exception (dispatcher never reached the
+        # handler's return) — fall back to matching by tool name.
+        self._maybe_unsubscribe_pipeline(data.get("tool"), None)
+
+    # ── Pipeline attached live-progress bridge (#2570) ────────────────────
+    # session_api.py's run_pipeline_attached emits pipeline_run_attached onto
+    # THIS session's own _chat_events right after spawning the driver-session
+    # (sync-attached path only). The driver-session's pipeline_step_started /
+    # pipeline_step_completed events land on ITS OWN EventLog — a session
+    # distinct from this one, invisible here unless we bridge-subscribe.
+
+    def on_pipeline_run_attached(self, data: dict) -> None:
+        """Bridge-subscribe to the driver-session's EventLog for one run's duration.
+
+        ``data`` = {tool, run_id, driver_sid, agent_name, pipeline_name} (see
+        ``session_api.run_pipeline_attached``). Looks up the driver session via
+        the injected registry and forwards its ``pipeline_step_started`` /
+        ``pipeline_step_completed`` events (matched by ``run_id``) as transient
+        ``status`` lines — mirroring ``on_mcp_progress``: a many-step pipeline
+        would spam permanent ``system`` markers otherwise. Unsubscribed by
+        ``on_tool_returned`` / ``on_tool_failed`` when the matching
+        ``run_pipeline`` tool call completes. No-ops gracefully if the registry
+        is absent or the driver session can't be found (forward-compat with
+        event-shape drift, same idiom as the rest of this forwarder)."""
+        if self._registry is None:
+            return
+        tool = data.get("tool")
+        run_id = data.get("run_id")
+        driver_sid = data.get("driver_sid")
+        agent_name = data.get("agent_name")
+        pipeline_name = str(data.get("pipeline_name") or "pipeline")
+        if not (run_id and driver_sid and agent_name):
+            return
+        driver_session = self._registry.get_session(agent_name, driver_sid)
+        if driver_session is None:
+            return
+        driver_events = getattr(getattr(driver_session, "router_host", None), "events", None)
+        if driver_events is None:
+            return
+
+        def _on_driver_event(event: Event) -> None:
+            if event.type not in ("pipeline_step_started", "pipeline_step_completed"):
+                return
+            if event.data.get("run_id") != run_id:
+                return
+            self._enqueue_pipeline_step(pipeline_name, event.type, event.data)
+
+        driver_events.add_subscriber(_on_driver_event)
+        self._pipeline_subs[run_id] = (driver_events, _on_driver_event, tool)
+
+    def _enqueue_pipeline_step(self, pipeline_name: str, event_type: str, data: dict) -> None:
+        step_index = data.get("step_index")
+        total_steps = data.get("total_steps")
+        step_kind = data.get("step_kind", "?")
+        if event_type == "pipeline_step_started":
+            n = (step_index or 0) + 1
+            marker, suffix = "▸", ""
+        else:
+            n = step_index or 0
+            marker, suffix = "✓", " done"
+        progress = f"{n}/{total_steps}" if total_steps else str(n)
+        text = f"[{marker} {pipeline_name}: step {progress} ({step_kind}){suffix}]"
+        meta = {"source": "pipeline", "run_id": data.get("run_id")}
+        try:
+            self.outbox.put_nowait(OutboxMessage(kind="status", text=text, meta=meta))
+        except asyncio.QueueFull:
+            pass
+
+    def _maybe_unsubscribe_pipeline(self, tool: "str | None", run_id: "str | None") -> None:
+        if not self._pipeline_subs:
+            return
+        target_rid = run_id
+        if target_rid is None:
+            for rid, (_events, _listener, sub_tool) in list(self._pipeline_subs.items()):
+                if sub_tool == tool:
+                    target_rid = rid
+                    break
+        entry = self._pipeline_subs.pop(target_rid, None) if target_rid else None
+        if entry is not None:
+            events, listener, _ = entry
+            events.remove_subscriber(listener)
 
     def _enqueue_tool_call(
         self,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1326,7 +1326,9 @@ class Session:
         # today; attach/detach + budget warnings as growth) into the
         # conv pane via OutboxMessage(kind="system").
         from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
-        self._chat_events.add_subscriber(ChatLifecycleForwarder(self.outbox))
+        self._chat_events.add_subscriber(
+            ChatLifecycleForwarder(self.outbox, registry=self._registry)
+        )
         # #398 v4 emitter family — generic events-log subscriber that
         # converts known op-emitted events (= mcp_server_installed,
         # future: config_reloaded / sp_version_changed) to

--- a/tests/test_pipeline_tui_bridge_2570.py
+++ b/tests/test_pipeline_tui_bridge_2570.py
@@ -1,0 +1,187 @@
+"""Tier 2: #2570 — TUI live-progress bridge for a sync-attached run_pipeline.
+
+IS-6 (#2569) made a sync ``run_pipeline`` call block the caller's turn while a
+crash-recoverable driver-session runs the pipeline, emitting
+``pipeline_step_started`` / ``pipeline_step_completed`` (with ``total_steps``)
+onto the DRIVER-session's own EventLog. That EventLog belongs to a session
+distinct from the human-attached caller, so the TUI (subscribed only to the
+caller's own ``_chat_events``) had no signal to bridge-subscribe to.
+
+``session_api.run_pipeline_attached`` closes that gap: when given
+``caller_events``, it emits a ``pipeline_run_attached`` marker
+({tool, run_id, driver_sid, agent_name, pipeline_name}) onto the CALLER's own
+EventLog right after the driver-session spawns. ``ChatLifecycleForwarder``
+(this test's subject) is the subscriber that turns that marker into a live
+bridge-subscription: it looks up the driver session via the injected registry,
+subscribes to its EventLog for the run's duration, and forwards each step
+boundary as a transient ``status`` outbox line (mirroring ``on_mcp_progress`` —
+a many-step pipeline would spam permanent ``system`` markers otherwise).
+Unsubscribes when the matching ``run_pipeline`` tool call completes (fed via
+``on_tool_returned`` / ``on_tool_failed``, which the real dispatcher would call
+in production) — proving no subscriber leak across successive attached runs.
+
+Real ``AgentRegistry`` / ``Session`` / ``StateLog`` / ``Pipeline`` /
+``TransformStep`` throughout — no mocks. Transform-only pipelines are pure
+(no LLM/tool dependency), keeping the test focused on the bridge mechanics.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, TransformStep
+from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import run_pipeline_attached
+from reyn.schemas.models import Event
+
+
+def _drain(q: asyncio.Queue) -> list[Any]:
+    items: list[Any] = []
+    while not q.empty():
+        items.append(q.get_nowait())
+    return items
+
+
+def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors the IS-2/IS-4 tests)."""
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _two_step_transform_pipeline() -> Pipeline:
+    return Pipeline(
+        steps=[
+            TransformStep(value="ctx.seed + 1", output="t0"),
+            TransformStep(value="ctx.t0 + 1", output="t1"),
+        ],
+        description="#2570 test pipeline",
+    )
+
+
+async def _run_attached(
+    reg: AgentRegistry, state_log: "StateLog", caller_events: "EventLog",
+) -> dict:
+    return await run_pipeline_attached(
+        reg,
+        pipeline=_two_step_transform_pipeline(),
+        pipeline_name="testpipe",
+        input={"seed": 0},
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        tool="run_pipeline",
+        caller_events=caller_events,
+    )
+
+
+@pytest.mark.asyncio
+async def test_attached_run_streams_step_progress_to_caller_outbox(tmp_path) -> None:
+    """Tier 2: a sync-attached run streams transient status lines for each step
+    boundary to the CALLER's outbox — proving the bridge-subscribe actually
+    reaches the driver-session's own EventLog (a different session)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    outbox: asyncio.Queue = asyncio.Queue()
+    caller_events = EventLog()
+    caller_events.add_subscriber(ChatLifecycleForwarder(outbox, registry=reg))
+
+    outcome = await _run_attached(reg, state_log, caller_events)
+
+    assert outcome["status"] == "ok"
+    msgs = _drain(outbox)
+    status_msgs = [m for m in msgs if m.kind == "status" and m.meta.get("source") == "pipeline"]
+    # Unpack-enforcement: a 2-step pipeline produces exactly one status line
+    # per step boundary (started + completed) — destructuring fails loudly if
+    # a step boundary is missed or double-fired.
+    step1_started, step1_done, step2_started, step2_done = [m.text for m in status_msgs]
+    assert step1_started == "[▸ testpipe: step 1/2 (transform)]"
+    assert step1_done == "[✓ testpipe: step 1/2 (transform) done]"
+    assert step2_started == "[▸ testpipe: step 2/2 (transform)]"
+    assert step2_done == "[✓ testpipe: step 2/2 (transform) done]"
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_stops_further_progress_after_tool_completion(tmp_path) -> None:
+    """Tier 2: once the matching run_pipeline tool call completes (simulated —
+    the real dispatcher emits tool_returned after the handler returns), a
+    LATER synthetic step event on the driver's own EventLog produces NO further
+    outbox message — proving the bridge unsubscribes (no listener leak across
+    successive attached runs)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    outbox: asyncio.Queue = asyncio.Queue()
+    caller_events = EventLog()
+    fwd = ChatLifecycleForwarder(outbox, registry=reg)
+    caller_events.add_subscriber(fwd)
+    recorded: list[Event] = []
+    caller_events.add_subscriber(recorded.append)
+
+    outcome = await _run_attached(reg, state_log, caller_events)
+    _drain(outbox)  # the real run's own progress lines — not under test here
+
+    attach_marker = next(e for e in recorded if e.type == "pipeline_run_attached")
+    driver_sid = attach_marker.data["driver_sid"]
+    run_id = attach_marker.data["run_id"]
+    assert run_id == outcome["run_id"]
+
+    driver_session = reg.get_session("worker", driver_sid)
+    driver_events = driver_session.router_host.events
+
+    # Still bridged immediately after the run (unsubscribe only fires on
+    # tool_returned/tool_failed, which we haven't simulated yet).
+    driver_events.emit(
+        "pipeline_step_started", run_id=run_id, step_index=5, step_kind="transform",
+        total_steps=6,
+    )
+    assert len(_drain(outbox)) == 1
+
+    # Simulate the dispatcher's post-invocation event (on_tool_returned) — this
+    # itself enqueues its own tool_call_completed line, drained here so it
+    # doesn't confound the assertion below.
+    fwd(Event(type="tool_returned", data={"tool": "run_pipeline", "result": outcome}))
+    _drain(outbox)
+
+    # Now unsubscribed: a further step event on the SAME driver EventLog must
+    # produce no pipeline-status line.
+    driver_events.emit(
+        "pipeline_step_completed", run_id=run_id, step_index=6, step_kind="transform",
+        total_steps=6,
+    )
+    status_msgs = [m for m in _drain(outbox) if m.kind == "status"]
+    assert status_msgs == []
+
+
+@pytest.mark.asyncio
+async def test_no_registry_is_a_graceful_noop(tmp_path) -> None:
+    """Tier 2: ChatLifecycleForwarder(outbox) with no registry (the pre-#2570
+    default) drops pipeline_run_attached silently — forward-compat / graceful
+    degrade, no exception."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    outbox: asyncio.Queue = asyncio.Queue()
+    caller_events = EventLog()
+    caller_events.add_subscriber(ChatLifecycleForwarder(outbox))  # no registry=
+
+    outcome = await _run_attached(reg, state_log, caller_events)
+
+    assert outcome["status"] == "ok"
+    status_msgs = [m for m in _drain(outbox) if m.kind == "status"]
+    assert status_msgs == []


### PR DESCRIPTION
**[tui-coder]** TUI rendering half of #2570 (follow-up to IS-6 #2569 / bridge-emit #2573)

## Summary

`ChatLifecycleForwarder` now bridge-subscribes to a pipeline driver-session's own EventLog and streams live step progress into the caller's outbox.

**The gap this closes**: a sync `run_pipeline`/`run_pipeline_inline` call blocks the caller's turn while a driver-session (spawned under the invoker's identity, with a NEW sid) runs the pipeline. That driver-session emits `pipeline_step_started`/`pipeline_step_completed` onto **its own** EventLog — invisible to the TUI, which only subscribes to the human-attached caller's own `_chat_events`.

**The fix**: `session_api.run_pipeline_attached` (landed in #2573) now emits a `pipeline_run_attached` marker onto the CALLER's own EventLog right after the driver-session spawns — `{tool, run_id, driver_sid, agent_name, pipeline_name}`. `ChatLifecycleForwarder.on_pipeline_run_attached` (this PR):

1. Looks up the driver session via `registry.get_session(agent_name, driver_sid)`.
2. Subscribes to its `router_host.events` for the run's duration.
3. Forwards each `pipeline_step_started`/`pipeline_step_completed` (matched by `run_id`) as a transient `status` line: `[▸ pipeline_name: step i/N (kind)]` / `[✓ pipeline_name: step i/N (kind) done]` — mirroring `on_mcp_progress`'s transient-status pattern rather than permanent `system` markers (a 50-step pipeline would otherwise spam scrollback).
4. Unsubscribes via `on_tool_returned`/`on_tool_failed` when the matching `run_pipeline` tool call completes — `result.run_id` for the happy path, tool-name fallback when the dispatcher's exception path has no result dict.

`ChatLifecycleForwarder.__init__` gained an optional `registry` param (backward-compatible default `None` → graceful no-op, matches this forwarder's existing forward-compat idiom for unknown event shapes). `session.py`'s wiring now passes `registry=self._registry`.

## Feasibility check (per standing discipline)

A live `tmux`/`reyn chat` e2e is **blocked by a pre-existing capability floor**: `pipeline-run` is a `HIGH`-risk, spawn-adjacent capability (`capability_profile.py:278,414`) not granted to the default agent profile — confirmed by driving a real chat session and observing `run_pipeline_inline` absent from the tool list. This floor is unrelated to this PR; it already gates `run_pipeline`/`run_pipeline_async` identically, so no interactive dogfood of ANY sync pipeline feature is possible without additional agent capability config (out of scope here).

The Tier-2 test below exercises the **exact same** `run_pipeline_attached` + `ChatLifecycleForwarder` code path production traffic hits — real `AgentRegistry`/`Session`/`StateLog`/`Pipeline`, only the LLM layer is out of the loop (transform-only steps need none).

## Files changed

- `src/reyn/runtime/lifecycle_forwarder.py` — `on_pipeline_run_attached` + step-progress bridge + unsubscribe hooks
- `src/reyn/runtime/session.py` — pass `registry=self._registry` to the forwarder
- `tests/test_pipeline_tui_bridge_2570.py` — 3 new Tier-2 tests (streamed progress, unsubscribe, no-registry no-op)

## Test plan

- [x] `pytest tests/test_pipeline_tui_bridge_2570.py tests/test_chat_lifecycle_forwarder.py` — 30 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_tui_bridge_2570.py tests/test_chat_lifecycle_forwarder.py` — 30 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py` changed src files — OK
- [x] Full `pytest` — 7118 passed, 17 skipped
- [x] (skipped — blocked by pre-existing `pipeline-run` capability floor, documented above) Live tmux `reyn chat` e2e

## Tier self-check

No mocks, no private-state asserts, no format/size pins (unpack-enforcement instead of `len(...) == N`), no snapshots.