### PR TITLE
fix(pipeline): #2572 enforce runtime verify:schema in driver-session (registered + inline) + persist schemas for recovery

### DIFF
--- a/src/reyn/core/pipeline/registry.py
+++ b/src/reyn/core/pipeline/registry.py
@@ -15,6 +15,16 @@ callers (a session, a test) construct their own ``PipelineRegistry`` and thread
 it through explicitly (mirrors how ``AgentRegistry`` / ``StateLog`` are threaded
 rather than reached via a hidden global), keeping registrations scoped to the
 owner that created them.
+
+(#2572) A registered pipeline may also carry a
+:class:`~reyn.core.pipeline.schema.SchemaRegistry` alongside it — a bare
+``name -> Pipeline`` map has no other home for the schemas its ``verify:
+schema`` steps validate against, unlike an inline launch (whose schemas live
+in the same DSL string that parses into the ``Pipeline``). ``register``'s
+``schema_registry`` param and :meth:`PipelineRegistry.get_schema_registry`
+close that gap; the registered launch handlers thread the retrieved registry
+into ``start_pipeline_run``/``run_pipeline_attached`` alongside the pipeline
+itself.
 """
 from __future__ import annotations
 
@@ -22,6 +32,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.executor import Pipeline
+    from reyn.core.pipeline.schema import SchemaRegistry
 
 
 class PipelineNotFoundError(KeyError):
@@ -42,11 +53,21 @@ class PipelineRegistry:
 
     def __init__(self) -> None:
         self._pipelines: "dict[str, Pipeline]" = {}
+        self._schema_registries: "dict[str, SchemaRegistry | None]" = {}
 
-    def register(self, name: str, pipeline: "Pipeline") -> None:
+    def register(
+        self, name: str, pipeline: "Pipeline",
+        schema_registry: "SchemaRegistry | None" = None,
+    ) -> None:
         """Register ``pipeline`` under ``name``. Re-registration under an
         already-used name raises ``ValueError`` (prevents accidentally
-        shadowing a previously registered pipeline)."""
+        shadowing a previously registered pipeline).
+
+        ``schema_registry`` (#2572, additive/optional — a registered pipeline
+        with no ``verify: schema`` steps needs none) carries the schemas a
+        registered pipeline's ``verify: schema`` steps validate against; a
+        plain name -> Pipeline map has no other home for them. Retrieve it via
+        :meth:`get_schema_registry`."""
         if name in self._pipelines:
             raise ValueError(
                 f"a pipeline is already registered under name {name!r}; "
@@ -54,6 +75,7 @@ class PipelineRegistry:
                 "registration first."
             )
         self._pipelines[name] = pipeline
+        self._schema_registries[name] = schema_registry
 
     def get(self, name: str) -> "Pipeline":
         """Look up the ``Pipeline`` registered under ``name``.
@@ -65,6 +87,16 @@ class PipelineRegistry:
             return self._pipelines[name]
         except KeyError:
             raise PipelineNotFoundError(name) from None
+
+    def get_schema_registry(self, name: str) -> "SchemaRegistry | None":
+        """The ``SchemaRegistry`` registered alongside ``name`` (#2572), or
+        ``None`` when the pipeline was registered without one.
+
+        Raises :class:`PipelineNotFoundError` when ``name`` itself is not
+        registered — same contract as :meth:`get`."""
+        if name not in self._pipelines:
+            raise PipelineNotFoundError(name)
+        return self._schema_registries[name]
 
     def names(self) -> "tuple[str, ...]":
         """All registered pipeline names (for introspection / future

--- a/src/reyn/core/pipeline/schema.py
+++ b/src/reyn/core/pipeline/schema.py
@@ -145,6 +145,15 @@ class SchemaRegistry:
     def has(self, name: str) -> bool:
         return name in self._schemas
 
+    def as_dict(self) -> "dict[str, dict[str, Any]]":
+        """A plain ``name -> schema dict`` snapshot of every registered schema
+        (#2572: the work-order persistence shape — see
+        ``reyn.core.pipeline.serde.schema_registry_from_dict`` for the
+        inverse). A PUBLIC accessor over the already-JSON-primitive
+        ``_schemas`` values, so a caller needs no private-state reach to
+        serialize a registry."""
+        return dict(self._schemas)
+
 
 # ---------------------------------------------------------------------------
 # Schema-shape validation (registration-time — catches malformed schemas

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -23,10 +23,18 @@ would misread it) nor silently survive (a literal that decodes differently
 than it encoded is corruption). Decode only recognises the exact one-key
 marker shape ``{"__exprref__": <str>}`` as an ``ExprRef``; any other dict is
 a literal.
+
+(#2572) :func:`schema_registry_from_dict` is the same round-trip idea applied
+to a launch's :class:`~reyn.core.pipeline.schema.SchemaRegistry` —
+``PipelineWorkOrder.schema_defs`` persists ``SchemaRegistry.as_dict()`` (an
+already plain-JSON-primitive ``name -> schema dict`` map, no custom encoder
+needed), and this rebuilds the registry so a ``verify: schema`` step is
+enforceable on a fresh driver-session, including one re-created from disk
+alone on a crash-resume.
 """
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from reyn.core.pipeline.executor import (
     AgentStep,
@@ -36,6 +44,9 @@ from reyn.core.pipeline.executor import (
     ToolStep,
     TransformStep,
 )
+
+if TYPE_CHECKING:
+    from reyn.core.pipeline.schema import SchemaRegistry
 
 _EXPRREF_KEY = "__exprref__"
 
@@ -133,10 +144,34 @@ def pipeline_from_dict(data: "dict[str, Any]") -> "Pipeline":
     )
 
 
+def schema_registry_from_dict(data: "dict[str, dict[str, Any]] | None") -> "SchemaRegistry":
+    """(#2572) The inverse of :meth:`~reyn.core.pipeline.schema.SchemaRegistry.
+    as_dict`: rebuild a :class:`~reyn.core.pipeline.schema.SchemaRegistry` from
+    a persisted ``name -> schema dict`` map (``PipelineWorkOrder.schema_defs``),
+    mirroring how :func:`pipeline_from_dict` rebuilds the ``Pipeline`` from its
+    own work-order field.
+
+    Registers each entry via ``SchemaRegistry.register`` — the same
+    shape/cycle validation a live registration goes through, so a corrupted
+    ``schema_defs`` fails loudly here rather than silently at first use. Entry
+    order does not matter: the cycle check tolerates forward refs among
+    schemas not yet registered (see ``SchemaRegistry.register``'s docstring),
+    so registering in dict-iteration order round-trips correctly regardless of
+    the original registration order. ``None`` (no schemas at launch) and
+    ``{}`` both yield an empty registry."""
+    from reyn.core.pipeline.schema import SchemaRegistry
+
+    registry = SchemaRegistry()
+    for name, schema in (data or {}).items():
+        registry.register(name, schema)
+    return registry
+
+
 __all__ = [
     "PipelineSerdeError",
     "pipeline_to_dict",
     "pipeline_from_dict",
     "step_to_dict",
     "step_from_dict",
+    "schema_registry_from_dict",
 ]

--- a/src/reyn/core/pipeline/work_order.py
+++ b/src/reyn/core/pipeline/work_order.py
@@ -13,8 +13,17 @@ under its run dir:
   pipeline (``reyn.core.pipeline.serde``), the seed input, the reply
   address, the (agent, sid) of the driver-session itself (so recovery can
   re-create the session from scratch when it crashed before its own session
-  snapshot ever landed), and the WAL seq at spawn (the rewind guard's
-  default-open predicate — see ``AgentRegistry._rewake_pipeline_runs``).
+  snapshot ever landed), the WAL seq at spawn (the rewind guard's
+  default-open predicate — see ``AgentRegistry._rewake_pipeline_runs``), and
+  (#2572) ``schema_defs`` — the launch's :class:`~reyn.core.pipeline.schema.
+  SchemaRegistry` serialized to a plain dict (``SchemaRegistry.as_dict()``).
+  A ``verify: schema`` step needs its registry at RUN time (including on a
+  recovery re-wake), and this file is the run's only crash-truncation-proof
+  recovery source — so the schemas travel with the work-order itself, same
+  as the pipeline definition, rather than a live constructor arg the
+  recovery path would have no way to reach. ``None`` (the default) is
+  backward-compatible with on-disk ``invocation.json`` files written before
+  this field existed, and with a launch that has no schemas at all.
 - ``attempts.json`` — the poison-pipeline cap: a monotonic resume-attempt
   counter the recovery scan bumps durably BEFORE each re-wake. A run whose
   resume crashes the process every restart increments this on every scan;
@@ -73,6 +82,7 @@ class PipelineWorkOrder:
     driver_agent: str
     driver_sid: str
     spawn_seq: "int | None" = None
+    schema_defs: "dict[str, dict[str, Any]] | None" = None
 
 
 def _atomic_write(path: "Path", content: dict) -> None:

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -14,7 +14,12 @@ crash-restore machinery all work on this session exactly as on a chat session,
 which is the entire point (crash auto-resume rides the existing session
 substrate).
 
-One nudge = drive the run to a terminal:
+One nudge = drive the run to a terminal (#2572: including the run's
+``SchemaRegistry``, rebuilt from ``work_order.schema_defs`` via
+``reyn.core.pipeline.serde.schema_registry_from_dict`` and threaded into
+``executor.run``/``resume`` so a ``verify: schema`` step is enforced —
+previously it raised ``PipelineExecutionError``/``AgentStepError`` unconditionally
+because no registry ever reached the executor):
 
 - **new vs resume** is decided by whether an R4 generation snapshot exists for
   the run (``latest_pipeline_state``): none → ``executor.run`` seeded with the
@@ -147,7 +152,7 @@ class PipelineExecutorDriver:
             PipelineExecutionError,
             PipelineExecutor,
         )
-        from reyn.core.pipeline.serde import pipeline_from_dict
+        from reyn.core.pipeline.serde import pipeline_from_dict, schema_registry_from_dict
         from reyn.core.pipeline.work_order import has_result, read_resume_attempts
 
         wo = self._work_order
@@ -170,6 +175,13 @@ class PipelineExecutorDriver:
             return
 
         pipeline = pipeline_from_dict(wo.pipeline)
+        # #2572: rebuild the launch's SchemaRegistry from the persisted
+        # work-order field — the SAME recovery source as ``pipeline`` above
+        # (a FILE, not a live constructor arg), so a ``verify: schema`` step
+        # is enforced identically on the original run and on a re-created,
+        # crash-resumed driver-session (the recovery scan builds this driver
+        # from ``work_order`` alone — see ``AgentRegistry._rewake_pipeline_runs``).
+        schema_registry = schema_registry_from_dict(wo.schema_defs)
         executor = PipelineExecutor()
         # IS-6: emit step-boundary progress to THIS session's EventLog (an
         # attached caller subscribes to it) and poll THIS driver's cooperative
@@ -189,6 +201,7 @@ class PipelineExecutorDriver:
                     default_identity=wo.reply_to_agent,
                     events=events,
                     cancel_check=self.is_cancel_requested,
+                    schema_registry=schema_registry,
                 )
             else:
                 result = await executor.resume(
@@ -200,6 +213,7 @@ class PipelineExecutorDriver:
                     default_identity=wo.reply_to_agent,
                     events=events,
                     cancel_check=self.is_cancel_requested,
+                    schema_registry=schema_registry,
                 )
         except PipelineCancelled as exc:
             # IS-6: an intentional Ctrl-C stop at a step boundary. TERMINAL (so

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -236,6 +236,7 @@ async def _spawn_pipeline_driver_session(
     state_log: "object",
     notify_reply: bool,
     run_id: "str | None" = None,
+    schema_registry: "SchemaRegistry | None" = None,
 ) -> "tuple[Any, str, str]":
     """Spawn + arm a pipeline driver-session, up to (but NOT including) the
     run/resume nudge — the shared launch prefix of the async (``start_pipeline_run``)
@@ -250,10 +251,14 @@ async def _spawn_pipeline_driver_session(
          permission envelope is the invoker's (⊆ by construction).
       2. persist the work-order (``invocation.json`` — full serialized pipeline +
          input + reply address + the driver's own (agent, sid) + the WAL seq at
-         spawn) BEFORE step 0 can possibly run. From this point the run is
-         crash-recoverable: the recovery scan re-creates + re-wakes the
-         driver-session from this file alone (with ``notify_reply=True`` — the
-         originally-attached caller is gone after a crash).
+         spawn + (#2572) ``schema_defs``, the launch's ``schema_registry``
+         serialized via ``SchemaRegistry.as_dict()``) BEFORE step 0 can possibly
+         run. From this point the run is crash-recoverable: the recovery scan
+         re-creates + re-wakes the driver-session from this file alone (with
+         ``notify_reply=True`` — the originally-attached caller is gone after a
+         crash), and ``PipelineExecutorDriver.run_turn`` rebuilds the registry
+         from ``schema_defs`` on every wake — so a ``verify: schema`` step is
+         enforced on the original run and on a re-created driver-session alike.
       3. swap in the :class:`~reyn.runtime.services.pipeline_executor_driver.
          PipelineExecutorDriver` (``Session.set_loop_driver``), carrying the
          runtime ``notify_reply`` — True for the async fire-and-forget path
@@ -292,6 +297,7 @@ async def _spawn_pipeline_driver_session(
         driver_agent=reply_to_agent,
         driver_sid=sid,
         spawn_seq=state_log.current_seq,
+        schema_defs=schema_registry.as_dict() if schema_registry is not None else None,
     )
     write_invocation(pipeline_run_dir(root, rid), work_order)
     session = registry.get_session(reply_to_agent, sid)
@@ -319,6 +325,7 @@ async def start_pipeline_run(
     reply_to_sid: str,
     state_log: "object",
     run_id: "str | None" = None,
+    schema_registry: "SchemaRegistry | None" = None,
 ) -> str:
     """IS-2: launch an ASYNC pipeline run in a dedicated driver-session (D案).
 
@@ -328,6 +335,10 @@ async def start_pipeline_run(
     text carries no meaning), then boots the DETACHED run-loop pump
     (``ensure_session_running``; no forwarder — a driver-session has no
     user-facing output).
+
+    ``schema_registry`` (#2572), when given, is persisted onto the work-order
+    (``schema_defs``) so the driver-session's ``verify: schema`` steps are
+    enforced — on the original run and on any later crash-recovery re-wake.
 
     Returns the ``run_id`` immediately; the result arrives later on the invoker's
     inbox as a ``pipeline_result`` message."""
@@ -341,6 +352,7 @@ async def start_pipeline_run(
         state_log=state_log,
         notify_reply=True,
         run_id=run_id,
+        schema_registry=schema_registry,
     )
     await session.submit_user_text("")  # the no-payload run nudge (D案)
     registry.ensure_session_running(reply_to_agent, sid)
@@ -360,6 +372,7 @@ async def run_pipeline_attached(
     run_id: "str | None" = None,
     tool: "str | None" = None,
     caller_events: "Any | None" = None,
+    schema_registry: "SchemaRegistry | None" = None,
 ) -> dict:
     """IS-6: launch a SYNC pipeline run in a driver-session the caller ATTACHES to.
 
@@ -406,7 +419,11 @@ async def run_pipeline_attached(
         NOTE: with the D案 single-nudge driver a step runs to completion inside one
         non-preemptible ``run_one_iteration``, so ``timeout`` bounds the
         quiescence-polling loop, not a step already in flight — it is a safety net
-        against a pump that returns non-terminal, not a mid-step wall-clock kill."""
+        against a pump that returns non-terminal, not a mid-step wall-clock kill.
+
+    ``schema_registry`` (#2572), when given, is persisted onto the work-order
+    (``schema_defs``) so the driver-session's ``verify: schema`` steps are
+    enforced — on the original run and on any later crash-recovery re-wake."""
     from reyn.core.events.config_recovery import reyn_root
     from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
     from reyn.runtime.message_bus import MessageBus
@@ -421,6 +438,7 @@ async def run_pipeline_attached(
         state_log=state_log,
         notify_reply=False,
         run_id=run_id,
+        schema_registry=schema_registry,
     )
     if caller_events is not None:
         caller_events.emit(

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -282,6 +282,7 @@ async def _handle_run_pipeline(
 
     try:
         pipeline = pipeline_registry.get(name)
+        schema_registry = pipeline_registry.get_schema_registry(name)
     except PipelineNotFoundError:
         return {
             "status": "error",
@@ -331,6 +332,7 @@ async def _handle_run_pipeline(
             state_log=state_log,
             tool="run_pipeline",
             caller_events=ctx.events,
+            schema_registry=schema_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -438,6 +440,7 @@ async def _handle_run_pipeline_async(
 
     try:
         pipeline = pipeline_registry.get(name)
+        schema_registry = pipeline_registry.get_schema_registry(name)
     except PipelineNotFoundError:
         return {
             "status": "error",
@@ -456,6 +459,7 @@ async def _handle_run_pipeline_async(
             reply_to_agent=host.agent_name,
             reply_to_sid=reply_sid,
             state_log=state_log,
+            schema_registry=schema_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -603,11 +607,18 @@ def _prepare_inline_launch(
 
     Returns ``(error_result, None)`` on any validation / parse / gate failure
     (the caller returns ``error_result`` verbatim, having spawned NOTHING), or
-    ``(None, (pipeline, agent_registry, host, state_log, raw_input))`` when the
-    definition is clean and ready to launch. The fresh registry is deliberately
-    NOT threaded onto the work-order or router state — an inline definition is
-    self-contained (its schemas live only in the string), matching the
-    "no persistent inline registry" design decision."""
+    ``(None, (pipeline, schema_registry, agent_registry, host, state_log,
+    raw_input))`` when the definition is clean and ready to launch.
+
+    ``schema_registry`` is NOT threaded onto ``ctx.router_state`` or any
+    persistent registry — an inline definition is self-contained (its schemas
+    live only in the DSL string), matching the "no persistent inline
+    registry" design decision. It IS (#2572) threaded to the launch call
+    (``run_pipeline_attached``/``start_pipeline_run``), which persists it onto
+    the work-order (``schema_defs``) so the driver-session's ``verify:
+    schema`` steps are actually enforced — the per-call registry was
+    previously parsed and then discarded, so an inline ``verify: schema`` step
+    crashed the driver with "no schema_registry" instead of validating."""
     from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
     from reyn.core.pipeline.schema import SchemaError, SchemaRegistry
 
@@ -673,7 +684,7 @@ def _prepare_inline_launch(
             "data": {"error": f"inline pipeline rejected by static gate: {gate_error}"},
         }, None
 
-    return None, (pipeline, agent_registry, host, state_log, raw_input)
+    return None, (pipeline, schema_registry, agent_registry, host, state_log, raw_input)
 
 
 async def _handle_run_pipeline_inline(
@@ -687,7 +698,7 @@ async def _handle_run_pipeline_inline(
     error_result, launch = _prepare_inline_launch(args, ctx)
     if error_result is not None:
         return error_result
-    pipeline, agent_registry, host, state_log, raw_input = launch
+    pipeline, schema_registry, agent_registry, host, state_log, raw_input = launch
 
     from reyn.runtime.session_api import run_pipeline_attached
 
@@ -703,6 +714,7 @@ async def _handle_run_pipeline_inline(
             state_log=state_log,
             tool="run_pipeline_inline",
             caller_events=ctx.events,
+            schema_registry=schema_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -746,7 +758,7 @@ async def _handle_run_pipeline_inline_async(
     error_result, launch = _prepare_inline_launch(args, ctx)
     if error_result is not None:
         return error_result
-    pipeline, agent_registry, host, state_log, raw_input = launch
+    pipeline, schema_registry, agent_registry, host, state_log, raw_input = launch
 
     from reyn.runtime.session_api import start_pipeline_run
 
@@ -760,6 +772,7 @@ async def _handle_run_pipeline_inline_async(
             reply_to_agent=host.agent_name,
             reply_to_sid=reply_sid,
             state_log=state_log,
+            schema_registry=schema_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -42,6 +42,7 @@ from reyn.core.pipeline.executor import (
     TransformStep,
 )
 from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.schema import SchemaRegistry
 from reyn.core.pipeline.serde import (
     PipelineSerdeError,
     pipeline_from_dict,
@@ -59,6 +60,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.tools.pipeline_verbs import (
+    _handle_run_pipeline,
     _handle_run_pipeline_async,
     _make_tool_dispatch,
 )
@@ -189,6 +191,7 @@ def _result_json(run_dir: Path) -> "dict | None":
 def _crash_state_work_order(
     run_id: str, pipeline: Pipeline, *, input: "dict | None",
     driver_sid: str = "drv1", spawn_seq: "int | None" = None,
+    schema_defs: "dict | None" = None,
 ) -> PipelineWorkOrder:
     return PipelineWorkOrder(
         run_id=run_id,
@@ -200,6 +203,7 @@ def _crash_state_work_order(
         driver_agent="worker",
         driver_sid=driver_sid,
         spawn_seq=spawn_seq,
+        schema_defs=schema_defs,
     )
 
 
@@ -371,6 +375,127 @@ async def test_run_pipeline_async_error_contracts(tmp_path: Path) -> None:
     assert "state_log" in no_wal["data"]["error"]
 
 
+# ── #2572: registered pipeline runtime verify:schema enforcement ───────────
+#
+# Before this fix the driver-session's ``executor.run``/``resume`` never
+# received a ``schema_registry`` (regardless of what the caller registered
+# it with), so ANY ``verify: schema`` step — pass or fail — crashed with
+# "declares verify: schema ... but no schema_registry was provided". The
+# tests below prove the registry now actually reaches the executor: a
+# CONFORMING result runs to ``ok``, and a VIOLATING result fails with a real
+# schema-validation error (not the old "no schema_registry" construction
+# error).
+
+
+def _line_schema_registry(*, required_field: str) -> SchemaRegistry:
+    """A one-field schema registry naming the schema "LineOut". Passing
+    ``required_field="line"`` matches the ``is2_append`` tool's real return
+    shape (``{"line": <str>}``) — conforming; any other name makes every
+    result violate it (the required field is always absent) — a controlled
+    non-conforming case that never depends on value content."""
+    schema_registry = SchemaRegistry()
+    schema_registry.register(
+        "LineOut", {"fields": {required_field: {"type": "string", "required": True}}},
+    )
+    return schema_registry
+
+
+def _schema_checked_pipeline(out_file: Path, *, line: str) -> Pipeline:
+    return Pipeline(steps=[
+        ToolStep(
+            name="is2_append", args={"path": str(out_file), "line": line},
+            output="t", schema="LineOut",
+        ),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_registered_pipeline_enforces_verify_schema_sync_attached(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: a REGISTERED pipeline's ``verify: schema`` step is enforced in
+    the sync-attached driver-session: a conforming tool result runs to
+    ``ok``, a violating one fails with a real schema-validation error naming
+    the schema (not the "no schema_registry" construction error the runtime
+    used to raise unconditionally, since it never threaded a registry)."""
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register(
+        "ok", _schema_checked_pipeline(out_file, line="10"),
+        _line_schema_registry(required_field="line"),
+    )
+    pipeline_registry.register(
+        "bad", _schema_checked_pipeline(out_file, line="11"),
+        _line_schema_registry(required_field="nonexistent_field"),
+    )
+
+    def _ctx() -> ToolContext:
+        return ToolContext(
+            events=caller._router_host.events, permission_resolver=None,
+            workspace=None, caller_kind="router",
+            router_state=RouterCallerState(
+                pipeline_registry=pipeline_registry, agent_registry=reg,
+                host=caller._router_host,
+            ),
+            state_log=state_log,
+        )
+
+    ok_result = await _handle_run_pipeline({"name": "ok"}, _ctx())
+    assert ok_result["status"] == "ok"
+
+    bad_result = await _handle_run_pipeline({"name": "bad"}, _ctx())
+    assert bad_result["status"] == "error"
+    assert "failed schema" in bad_result["data"]["error"]
+    assert "no schema_registry was provided" not in bad_result["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_registered_pipeline_enforces_verify_schema_async(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: the SAME enforcement on the async launch path
+    (``run_pipeline_async``) — the terminal marker records ``failed`` with a
+    real schema error for a violating result, ``ok`` for a conforming one."""
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ack")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register(
+        "bad-async", _schema_checked_pipeline(out_file, line="20"),
+        _line_schema_registry(required_field="nonexistent_field"),
+    )
+
+    ctx = ToolContext(
+        events=caller._router_host.events, permission_resolver=None,
+        workspace=None, caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry, agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline_async({"name": "bad-async"}, ctx)
+    assert result["status"] == "started"
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "failed"
+    assert "failed schema" in terminal["error"]
+    assert "no schema_registry was provided" not in terminal["error"]
+
+
 # ── recovery: the CLAUDE.md truncate-falsify gate + kill/restore/resume ─────
 
 
@@ -432,6 +557,86 @@ async def test_truncate_falsify_recovery_source_survives_wal_truncation(
     # Exactly-once: steps 0-1 replayed (no new "11" line), only step 2 ran.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
     # The invoker consumed the re-delivered result.
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_schema_defs_survives_wal_truncation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: CLAUDE.md recovery gate for #2572's ``schema_defs`` specifically
+    — the run's SchemaRegistry must survive WAL truncation via
+    ``invocation.json`` ALONE, not a WAL event, same as the pipeline
+    definition itself. Steps 0-1 (no schema) run to completion pre-crash;
+    step 2 declares ``verify: schema`` against a schema that step's real tool
+    result does NOT conform to. The WAL is truncated below the crash-state's
+    source seqs (incl. spawn_seq), then a FRESH StateLog + registry recovers.
+    RED if ``schema_defs`` rode a truncatable WAL event (the resumed step
+    would either crash with "no schema_registry" instead of a real schema
+    failure, or the recovery source would be gone entirely) — the resumed
+    run must reach a real, enforced schema failure on step 2."""
+    _install_side_effect_tool(monkeypatch)
+    wal_path = tmp_path / ".reyn" / "wal.jsonl"
+    state_log = StateLog(wal_path)
+    out_file = tmp_path / "out.txt"
+    # step 2 (the one NOT yet run at crash time) declares a schema the real
+    # is2_append return ({"line": ...}) does not conform to (required field
+    # "nonexistent_field" is never present) — a controlled, guaranteed failure
+    # that proves the schema was actually reached and enforced, not skipped.
+    full = Pipeline(steps=[
+        *_three_step_pipeline(out_file).steps[:2],
+        ToolStep(
+            name="is2_append", args={"path": str(out_file), "line": "second"},
+            output="t2", schema="LineOut",
+        ),
+    ])
+    schema_defs = _line_schema_registry(required_field="nonexistent_field").as_dict()
+    reg = _agent_registry(tmp_path, state_log, None)  # creates agent "worker"
+
+    # Crash state: the first TWO steps completed (schema-free), gens recorded
+    # at real WAL seqs.
+    prefix = Pipeline(steps=list(full.steps[:2]))
+    await PipelineExecutor().run(
+        prefix, {"seed": 10},
+        tool_dispatch=_make_tool_dispatch(_bare_ctx(state_log)),
+        state_log=state_log, run_id="run-schema-t",
+    )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11"]
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", "run-schema-t")
+    write_invocation(run_dir, _crash_state_work_order(
+        "run-schema-t", full, input={"seed": 10}, spawn_seq=1,
+        schema_defs=schema_defs,
+    ))
+
+    # Other activity advances the WAL head; truncate below 40 — the crash
+    # state's source seqs (incl. spawn_seq=1) are GONE from the WAL. schema_defs
+    # lives only in invocation.json, never in a WAL record, so it is untouched.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    assert all(e["seq"] >= 40 for e in state_log.iter_from(0))
+
+    # ── restart: fresh StateLog + fresh registry, then recovery. ──
+    state_log2 = StateLog(wal_path)
+    scripted = _ScriptedAgentReply("resumed")
+    reg2 = _agent_registry(tmp_path, state_log2, scripted)
+    await reg2.restore_all()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    # The resumed step 2 hit a REAL schema violation (schema_defs survived
+    # truncation intact) — not "no schema_registry was provided", which is
+    # what would happen if the recovery path lost/never rebuilt the registry.
+    assert terminal["status"] == "failed"
+    assert "failed schema" in terminal["error"]
+    assert "no schema_registry was provided" not in terminal["error"]
+    # Exactly-once on the schema-free prefix (no new "11" line from a re-run);
+    # step 2's tool call DOES execute (the schema check runs on its result,
+    # AFTER the real side effect — same order as a live, non-recovered run).
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
     assert await _wait_for(lambda: scripted.calls >= 1)
 
 

--- a/tests/test_pipeline_is4_inline.py
+++ b/tests/test_pipeline_is4_inline.py
@@ -269,6 +269,98 @@ async def test_inline_async_happy_path_launches_and_delivers(
     assert await _wait_for(lambda: scripted.calls >= 1)
 
 
+# ── #2572: inline pipeline runtime verify:schema enforcement ────────────────
+#
+# ``_prepare_inline_launch`` parses a per-call SchemaRegistry from the
+# definition's own ``schema:`` documents (IS-3) but, before this fix,
+# discarded it instead of threading it to the launch — so ANY inline
+# ``verify: schema`` step (declared alongside a ``schema:`` doc that the
+# static gate itself requires resolve, check 2) crashed the driver-session
+# with "no schema_registry was provided" REGARDLESS of whether the tool's
+# result actually conformed. These tests prove the registry now reaches the
+# executor: a conforming result runs to ``ok``; a violating one fails with a
+# real schema-validation error.
+
+_SCHEMA_OK_DEF = """
+schema: Out
+fields:
+  content: {type: string, required: true}
+---
+pipeline: schema_ok
+steps:
+  - tool: {name: is4_write, args: {path: !expr ctx.out_path, content: "hello"}, schema: Out}
+"""
+
+_SCHEMA_BAD_DEF = """
+schema: Out
+fields:
+  nonexistent_field: {type: string, required: true}
+---
+pipeline: schema_bad
+steps:
+  - tool: {name: is4_write, args: {path: !expr ctx.out_path, content: "hello"}, schema: Out}
+"""
+
+
+@pytest.mark.asyncio
+async def test_inline_sync_enforces_verify_schema_pass_and_fail(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: an inline pipeline's ``verify: schema`` step is enforced in the
+    sync-attached driver-session — a conforming tool result runs to ``ok``, a
+    violating one fails with a real schema-validation error naming the
+    schema (not the "no schema_registry" construction error the runtime used
+    to raise unconditionally, since the per-call registry was parsed then
+    discarded instead of threaded to the launch)."""
+    _install_write_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    ok_result = await _handle_run_pipeline_inline(
+        {"definition": _SCHEMA_OK_DEF, "input": {"out_path": str(out_file)}},
+        _ctx(reg, caller, state_log),
+    )
+    assert ok_result["status"] == "ok"
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["hello"]
+
+    bad_result = await _handle_run_pipeline_inline(
+        {"definition": _SCHEMA_BAD_DEF, "input": {"out_path": str(out_file)}},
+        _ctx(reg, caller, state_log),
+    )
+    assert bad_result["status"] == "error"
+    assert "failed schema" in bad_result["data"]["error"]
+    assert "no schema_registry was provided" not in bad_result["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_inline_async_enforces_verify_schema_failure(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the SAME enforcement on the async inline launch path — the
+    terminal marker records ``failed`` with a real schema error."""
+    _install_write_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ack")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    caller = reg.get_or_load("worker")
+    out_file = tmp_path / "out.txt"
+
+    result = await _handle_run_pipeline_inline_async(
+        {"definition": _SCHEMA_BAD_DEF, "input": {"out_path": str(out_file)}},
+        _ctx(reg, caller, state_log),
+    )
+    assert result["status"] == "started"
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", result["data"]["run_id"])
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "failed"
+    assert "failed schema" in terminal["error"]
+    assert "no schema_registry was provided" not in terminal["error"]
+
+
 # ── static gate rejections — each fails, NOTHING spawned ─────────────────────
 
 

--- a/tests/test_pipeline_schema_validator.py
+++ b/tests/test_pipeline_schema_validator.py
@@ -329,3 +329,49 @@ def test_resolve_path_descending_past_unresolved_ref_returns_none() -> None:
     reg = SchemaRegistry()
     reg.register("orphan", {"fields": {"thing": {"type": "ref", "schema": "missing"}}})
     assert resolve_path("orphan", "thing.anything", reg) is None
+
+
+# ── #2572: SchemaRegistry.as_dict() / schema_registry_from_dict round-trip ──
+
+
+def test_schema_registry_as_dict_round_trips_through_serde_with_nested_schema() -> None:
+    """Tier 1: ``SchemaRegistry.as_dict()`` ⇄ ``schema_registry_from_dict`` (the
+    work-order ``schema_defs`` persistence shape, #2572) round-trips a
+    registry with NON-DEFAULT, nested field values (a ``list of ref`` plus an
+    ``enum``, not a bare scalar) — the recovery-source shape a crash-resumed
+    driver-session must rebuild identically to the original. Also proves the
+    intermediate value is JSON-primitive (no custom encoder needed): it
+    survives a real ``json.dumps``/``json.loads`` hop."""
+    import json
+
+    from reyn.core.pipeline.serde import schema_registry_from_dict
+
+    reg = SchemaRegistry()
+    reg.register("file", FILE_SCHEMA)
+    reg.register("suspects", SUSPECTS_SCHEMA)
+
+    wire = json.loads(json.dumps(reg.as_dict()))
+    rebuilt = schema_registry_from_dict(wire)
+
+    assert rebuilt.has("file") and rebuilt.has("suspects")
+    # Validate a conforming AND a non-conforming value against the REBUILT
+    # registry to prove the nested ref/list/enum shape survived, not just the
+    # top-level keys.
+    ok = validate(
+        {"suspects": [{"path": "a.py", "risk": "high"}]}, "suspects", rebuilt,
+    )
+    assert ok.conforming
+    bad = validate(
+        {"suspects": [{"path": "a.py", "risk": "not-a-risk-level"}]}, "suspects", rebuilt,
+    )
+    assert not bad.conforming and bad.errors[0].kind == "enum_invalid"
+
+
+def test_schema_registry_from_dict_none_and_empty_yield_empty_registry() -> None:
+    """Tier 1: ``schema_defs=None`` (a work-order with no schemas, or one
+    written before this field existed) and ``{}`` both rebuild to an empty,
+    usable registry rather than raising."""
+    from reyn.core.pipeline.serde import schema_registry_from_dict
+
+    assert schema_registry_from_dict(None).as_dict() == {}
+    assert schema_registry_from_dict({}).as_dict() == {}


### PR DESCRIPTION
**[lead-sonnet]** — 

## Framing correction

Phase-1 trace found the current behavior is **not** "silently unenforced" — the executor already **raises** (`PipelineExecutionError` from a `ToolStep`, `AgentStepError` → wrapped `PipelineExecutionError` from an `AgentStep`) whenever a step declares `verify: schema` but `schema_registry is None`. Since neither driver-session launch path (`start_pipeline_run` / `run_pipeline_attached`) ever passed a `schema_registry` to `executor.run`/`resume`, **every** schema-verified step in a driver-session pipeline crashed unconditionally — pass or fail — with "no schema_registry was provided". So the bug is that the feature was **broken (loud)**, not lax: a schema-conforming step failed just as hard as a violating one. This PR makes the enforcement real: conforming results now run to `ok`, violating ones now fail with an actual schema-validation error.

## Changes

1. **`PipelineWorkOrder.schema_defs`** (`src/reyn/core/pipeline/work_order.py`) — new optional field (`dict[str, dict] | None`, default `None`) persisting the launch's `SchemaRegistry` as a plain dict, additive/backward-compatible with existing `invocation.json` files.
2. **Serde**: `SchemaRegistry.as_dict()` (public accessor, `src/reyn/core/pipeline/schema.py`) and `schema_registry_from_dict()` (the inverse, `src/reyn/core/pipeline/serde.py`, mirrors `pipeline_from_dict`).
3. **`PipelineExecutorDriver.run_turn`** (`src/reyn/runtime/services/pipeline_executor_driver.py`) reconstructs the registry from `wo.schema_defs` and threads it into `executor.run`/`resume` — same reconstruction pattern as `pipeline_from_dict(wo.pipeline)`, so the recovery re-wake path (`AgentRegistry._rewake_pipeline_runs`, which builds `PipelineExecutorDriver` from the work-order alone) gets schema enforcement **for free**.
4. **`_spawn_pipeline_driver_session`** (`src/reyn/runtime/session_api.py`) accepts `schema_registry` and persists `schema_defs` before `write_invocation` (BEFORE step 0, same crash-safety ordering as the pipeline itself). Threaded through both `start_pipeline_run` and `run_pipeline_attached`.
5. **Inline launch** (`pipeline_verbs.py:_prepare_inline_launch`) stops discarding the parsed per-call `SchemaRegistry` — now returned and threaded to the launch call.
6. **`PipelineRegistry`** (`src/reyn/core/pipeline/registry.py`) gets an optional `schema_registry` param on `register()` plus `get_schema_registry()` — a registered pipeline previously had no home for its schemas at all. Threaded through `run_pipeline`/`run_pipeline_async`.

## Tests

- `tests/test_pipeline_is2_driver_session.py`: `test_registered_pipeline_enforces_verify_schema_sync_attached`, `test_registered_pipeline_enforces_verify_schema_async` — registered pipeline, both launch modes, conforming passes / violating fails with a real schema error (not the old construction crash).
- `tests/test_pipeline_is4_inline.py`: `test_inline_sync_enforces_verify_schema_pass_and_fail`, `test_inline_async_enforces_verify_schema_failure` — same for the inline launch verbs.
- **CLAUDE.md recovery gate**: `test_truncate_falsify_schema_defs_survives_wal_truncation` (`test_pipeline_is2_driver_session.py`, modeled on the existing `test_truncate_falsify_recovery_source_survives_wal_truncation`) — a schema-verified step's registry is set at launch, the run crashes mid-pipeline, other WAL activity pushes the head forward, `truncate_below` removes the crash-state's source seqs (including `spawn_seq`), then a fresh `StateLog` + `restore_all()` recovers. The resumed run still enforces the schema (fails with a real schema-validation error on the previously-unrun step), proving `schema_defs` survived via `invocation.json` alone, not a WAL event.
- `tests/test_pipeline_schema_validator.py`: `test_schema_registry_as_dict_round_trips_through_serde_with_nested_schema` (nested `list of ref` + `enum`, non-default values) and `test_schema_registry_from_dict_none_and_empty_yield_empty_registry`.

## Gates (all run locally)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 55/55 OK, 0 Tier-4 violations.
- `pytest` (full suite) — 7057 passed; the only failures (10 failed / 10 errored) are pre-existing on baseline (`git stash` confirmed identical failures before this change — MCP/web-route environment issues unrelated to this PR).
- `python scripts/verify_module_docstrings.py <changed src files>` — clean.
- New/changed test files also run in isolation (each file alone) — all green, no ordering-masked failures.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `pytest` full suite — 7057 passed, pre-existing unrelated failures only (confirmed via `git stash` diff)
- [x] `python scripts/test_tier_audit.py --strict` on changed test files — 55/55 OK
- [x] `python scripts/verify_module_docstrings.py` on changed src files — clean
- [x] New tests run in isolation per-file — all green

Closes #2572