### PR TITLE
feat(pipeline): non-linear foundation (_run_scope + dotted-path recovery + dispatch tables) + call primitive

### DIFF
--- a/src/reyn/core/pipeline/analyzer.py
+++ b/src/reyn/core/pipeline/analyzer.py
@@ -1,0 +1,71 @@
+"""Pipeline static-analysis facet registry (P4 seam).
+
+The v0.9 approach (proposal P4, "static analyzer built incrementally —
+completeness-by-construction, not big-bang §7.3") mandates that no primitive
+lands without its analysis contribution: ``match`` brings path enumeration,
+``for_each`` / ``parallel`` bring cost + spawn-tree bounds, named-stores bring a
+dataflow graph. So the analyzer is a per-step-type FACET registry, not a
+monolithic walker — each primitive registers the check it is responsible for,
+and the registry is the single place a caller (a future ``analyze_pipeline``
+walker, or the IS-4 inline static-analysis gate) folds them together.
+
+This module is the SEAM plus the first entry (``call``'s facet). It is
+deliberately minimal in this slice: :data:`ANALYZER_FACETS` maps a step
+dataclass type to a facet function returning a list of human-readable problem
+strings ( empty = the step passed its facet), and :func:`analyze_step` looks one
+up. There is no full pipeline walker wired to consume it yet — that arrives with
+the primitives whose facets have real teeth (cost / spawn-tree bounds). What
+matters now is that the registration point EXISTS and ``call`` is registered, so
+every future primitive MUST add its facet here rather than bolting analysis on
+later.
+
+``call``'s facet is intentionally thin: the target is a STATIC literal pipeline
+name (Hard rule 2), so the only thing to confirm structurally is that it IS a
+non-empty literal — the parser already enforces this, so the facet is mostly the
+proof that the seam is wired. The deeper ``call`` checks the full analyzer will
+want (the callee is registered; the transitive spawn-tree/cost bound folds the
+callee's envelope into the caller's — S5) need cross-pipeline context the
+per-step facet does not have, and land with the analyzer walker + registry
+plumbing, not here.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+from reyn.core.pipeline.executor import CallStep
+
+if TYPE_CHECKING:
+    from reyn.core.pipeline.executor import Step
+
+
+def _call_facet(step: "CallStep") -> "list[str]":
+    """Confirm a ``call`` targets a non-empty STATIC literal pipeline name
+    (Hard rule 2). Returns problem strings (empty = OK)."""
+    problems: "list[str]" = []
+    if not isinstance(step.pipeline, str) or not step.pipeline:
+        problems.append(
+            f"call step target must be a non-empty literal pipeline name, "
+            f"got {step.pipeline!r}"
+        )
+    return problems
+
+
+# Facet registry: step type -> its static-analysis check. A future primitive
+# ADDS an entry here (mirroring the executor's ``STEP_DISPATCH``, serde's
+# ``ENCODERS``/``DECODERS``, and the parser's ``_STEP_PARSERS``) — the P4
+# "no primitive lands without its analysis contribution" contract, made
+# structural.
+ANALYZER_FACETS: "dict[type, Callable[[Step], list[str]]]" = {
+    CallStep: _call_facet,
+}
+
+
+def analyze_step(step: "Step") -> "list[str]":
+    """Run the registered static-analysis facet for `step`'s type, or return an
+    empty list when the type has no facet (a step kind whose only checks are the
+    parser's shape validation contributes nothing extra here)."""
+    facet = ANALYZER_FACETS.get(type(step))
+    return facet(step) if facet is not None else []
+
+
+__all__ = ["ANALYZER_FACETS", "analyze_step"]

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -1,68 +1,67 @@
-"""Linear Pipeline executor — R3 pipe-data threading + R4 step-boundary recovery.
+"""Pipeline executor — R3 pipe-data threading + R4 recovery + the non-linear
+compositional foundation (``_run_scope`` + dotted-path recovery + ``call``).
 
-The thin vertical-slice executor for
-``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a **linear** sequence of
-``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell", ...)``) / ``agent``
-(R5) steps. Deliberately out of scope for this slice: `for_each`/`parallel`/`fold`/
-`match`/`call`/`refine`, the YAML DSL parser, and driver-as-session integration — those
-are later slices; this module proves the core loop + recovery (+ agent-step wiring) only.
+The executor for ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a
+sequence of ``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell",
+...)``) / ``agent`` (R5) steps, plus the first COMPOSITIONAL primitive, ``call``
+(R7). Still out of scope for this slice: `for_each`/`parallel`/`fold`/`match`/
+`refine` — those are later primitives that plug into the SAME dispatch + scope
+machinery this module now exposes.
 
-**Dispatch table (the parallel-primitive seam).** Step execution is a ``dict``-dispatch
-keyed by the step's dataclass type (:data:`STEP_DISPATCH`) rather than an ``isinstance``
-chain — so a future primitive ADDS one registry entry (plus a serde encoder/decoder and a
-parser) instead of editing a shared ``elif`` block. Every runner has the uniform signature
-``(_StepInvocation) -> (result, durable, completed_step_results)``: a leaf runner
-(``transform``/``tool``/``agent``) returns ``completed_step_results`` unchanged and never
-records (its caller records after threading). ``_StepInvocation`` also carries a
-``record`` recorder + a ``step_label`` (the step's path, for error messages) that a
-future COMPOSITIONAL runner will use for its own sub-scope recording; leaf runners ignore
-both, but the surface is uniform so the compositional primitive plugs in without touching
-the leaf runners.
+**Dispatch tables (R7 — the parallel-primitive seam).** Step execution is a
+``dict``-dispatch keyed by the step's dataclass type
+(:data:`STEP_DISPATCH`) rather than an ``isinstance`` chain — so a future
+primitive ADDS one registry entry (here, plus a serde encoder/decoder, a parser,
+and an analyzer facet) instead of editing a shared ``elif`` block. Every runner
+has the uniform signature ``(_StepInvocation) -> (result, durable,
+completed_step_results)``: leaf runners (``transform``/``tool``/``agent``) return
+``completed_step_results`` unchanged and never record; a COMPOSITIONAL runner
+(``call``) recurses into :meth:`PipelineExecutor._run_scope`, grows
+``completed_step_results`` with its sub-scope's dotted keys, and records each
+sub-step through the frozen recovery closure it is handed.
 
-**R3 (uniform pipe-data / output rule)**: every step produces exactly one return value.
-That value is simultaneously (1) the pipe data handed to the next step and (2) written
-to a named store under ``output`` iff the step declares one. A ``transform`` step's
-``value`` is a R1 expression (``reyn.core.pipeline.expr`` — the total evaluator; this
-module never hand-rolls expression evaluation), evaluated against a context of
-``{"ctx": named_stores, "pipe": pipe_data}`` — so ``ctx.NAME`` reaches an earlier step's
-named output and bare ``pipe`` reaches the immediately-preceding step's return value even
-when it had no ``output:``. A ``tool`` step's ``args`` may mark any value as an
-expression to resolve (rather than a literal) by wrapping it in :class:`ExprRef`; both
-resolve through the same context via the same evaluator. An ``agent`` step's ``prompt``
-is a R5-spec ``TPL`` string — ``{ctx.NAME.field}`` / ``{pipe}`` references interpolated
-via :func:`_interpolate_prompt` (which reuses ``expr.evaluate_expr``'s ``Path``
-resolution for the dotted lookup — no second path-resolver) — then handed to
-:func:`reyn.runtime.session_api.run_agent_step` to spawn+run+collect; its return value
-is threaded exactly like the other step kinds.
+**R3 (uniform pipe-data / output rule)**: every step produces exactly one return
+value. That value is simultaneously (1) the pipe data handed to the next step and
+(2) written to a named store under ``output`` iff the step declares one. N2's
+uniform rule extends this to compositional steps: a ``call`` step's return value
+is its callee pipeline's FINAL step output (see :class:`CallStep`). A
+``transform`` step's ``value`` is a R1 expression (``reyn.core.pipeline.expr``);
+a ``tool`` step's ``args`` may mark a value as an expression via :class:`ExprRef`;
+an ``agent`` step's ``prompt`` is an R5 ``TPL`` string interpolated by
+:func:`_interpolate_prompt`. All resolve against a context of ``{"ctx":
+named_stores, "pipe": pipe_data}``.
 
-**R4 (step-boundary recovery)**: after each step completes (before advancing), the
-executor calls :func:`reyn.core.events.pipeline_recovery.record_pipeline_state` with the
-full control-plane state — ``{run_id, step_index, named_stores, pipe_data,
-completed_step_results}`` — keyed at the durable WAL head. Side-effecting ``tool``/
-``agent`` steps use the awaited-durable path (narrowing the effect-done/snapshot-not-yet-
-durable crash window); pure ``transform`` steps use the non-blocking path.
-:meth:`PipelineExecutor.run` starts a run from scratch; :meth:`PipelineExecutor.resume`
-loads the latest recorded generation for a run and REPLAYS every step already present in
-``completed_step_results`` (not re-executing it — the exactly-once contract that keeps a
-crash from re-running a `tool` step's side effect, or an ``agent`` step's LLM turn and any
-tool side effects it made), resuming live execution at the first step with no recorded
-result.
+**R4 + dotted-path recovery (R7 — THE load-bearing decision)**: after each step
+completes (before advancing), the executor records the full control-plane state —
+``{run_id, step_index, named_stores, pipe_data, completed_step_results}`` — as a
+truncation-surviving generation (``reyn.core.events.pipeline_recovery``). The
+``completed_step_results`` key space is a DOTTED SCOPE PATH: a top-level step ``i``
+keeps its flat key ``str(i)`` (byte-identical to the pre-``call`` linear format —
+a pipeline with no ``call`` records exactly as before), and a ``call`` at index
+``i`` records its callee's sub-steps under ``f"{i}.call.{j}"`` while the callee
+runs, then records its OWN N2 scalar result at ``str(i)`` once the callee is done.
+Nesting composes (``"3.call.1.call.0"``). The persisted ``named_stores`` /
+``pipe_data`` / ``step_index`` stay the OUTER scope's throughout a call (a
+callee's local stores NEVER leak into the outer snapshot — this is what gives
+``pass:[...]`` isolation on the RECOVERY axis, not just the live one); a callee's
+local state is reconstructed at resume by RE-WALKING its pipeline definition and
+replaying the dotted keys already present — the same one recursive
+:meth:`PipelineExecutor._run_scope` used live. Resume detects a completed
+sub-step by EXACT key membership (``f"{prefix}.{j}" in completed_step_results``) —
+never a string-prefix scan — so a mid-``call`` crash resumes replaying the
+finished callee sub-steps EXACTLY-ONCE (a side-effecting sub-step does not
+re-fire) and executes only the remainder.
 
-**IS-6 (attached run: live events + step-boundary cancel)**: two optional hooks let a
-caller *attach* to a run without changing the core loop. ``events`` (an ``EventLog``)
-receives a ``pipeline_step_started`` / ``pipeline_step_completed`` pair around every step
-boundary — each carrying ``total_steps`` (``len(pipeline.steps)``) alongside ``run_id`` /
-``step_index`` / ``step_kind`` so a "step i/N" display never needs a second lookup — the
-emit half of the emit+subscribe seam a sync ``run_pipeline`` tool (or the
-TUI) uses to render live progress; when None the executor stays silent (pure callers are
-unaffected). ``cancel_check`` (a ``Callable[[], bool]``) is polled at each step BOUNDARY,
-before the next step starts — never mid-step, so a step's side effect is never half-applied
-— and a True reading raises :class:`PipelineCancelled` from that boundary. Because every
-step before the boundary is already complete AND its R4 generation is on disk, the last
-recorded snapshot is a consistent resume point: an intentional cancel is a *clean* stop the
-driver-session turns into a terminal ``cancelled`` marker while preserving the R4 journal
-(abort-now, resume-later). Both hooks default off, so the sync/async driver-session paths
-opt in without disturbing the R3/R4 contract above.
+**IS-6 (attached run: live events + step-boundary cancel)**: two optional hooks
+let a caller *attach* to a run. ``events`` (an ``EventLog``) receives a
+``pipeline_step_started`` / ``pipeline_step_completed`` pair around every
+TOP-LEVEL step boundary (a ``call`` is ONE such boundary — its callee sub-steps
+do not emit their own ``i/N`` events, keeping the "step i/N" display coherent),
+each carrying ``total_steps``. ``cancel_check`` (a ``Callable[[], bool]``) is
+polled at each TOP-LEVEL step boundary before the next step starts — never
+mid-step — and a True reading raises :class:`PipelineCancelled` from that
+boundary, leaving the last recorded snapshot as a consistent resume point. Both
+hooks default off.
 """
 from __future__ import annotations
 
@@ -73,6 +72,7 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
 from reyn.core.pipeline.expr import ExprEvalError, ExprParseError, evaluate_expr
+from reyn.core.pipeline.registry import PipelineNotFoundError
 from reyn.core.pipeline.schema import SchemaRegistry, validate
 from reyn.runtime.errors import AgentStepError
 from reyn.runtime.session_api import run_agent_step
@@ -80,6 +80,7 @@ from reyn.runtime.session_api import run_agent_step
 if TYPE_CHECKING:
     from reyn.core.events.events import EventLog
     from reyn.core.events.state_log import StateLog
+    from reyn.core.pipeline.registry import PipelineRegistry
     from reyn.runtime.registry import AgentRegistry
 
 # ---------------------------------------------------------------------------
@@ -142,12 +143,44 @@ class AgentStep:
     output: "str | None" = None
 
 
-Step = Union[TransformStep, ToolStep, AgentStep]
+@dataclass(frozen=True)
+class CallStep:
+    """A COMPOSITIONAL step (R7 — the first non-linear primitive): synchronously
+    run a REGISTERED sub-pipeline and thread ITS final output out as this step's
+    N2 return value (Appendix B: ``call = {pipeline: LIT, pass: [NAME*], output:
+    NAME}``).
+
+    - ``pipeline`` is a STATIC literal name (Hard rule 2 — never a runtime
+      expression), resolved through the run's ``PipelineRegistry`` at execution.
+      An absent target fails the step (never a silent no-op).
+    - ``pass_`` (wire/DSL key ``pass`` — the Python field can't be the ``pass``
+      keyword) is the ONLY channel by which the caller's named stores reach the
+      callee: the callee's context is built FRESH from ``{name: caller_ctx[name]
+      for name in pass_}``, so the callee structurally cannot see any caller
+      store not listed here (Hard rule 8's ``{ctx.X}``-only-for-X-in-``pass``
+      isolation). A ``pass_`` name absent from the caller's stores fails the step.
+    - the callee's FIRST step receives the caller's pipe-data at the call site
+      (Hard rule 5) — bare ``{pipe}`` in the callee's first step is the outer
+      pipe-data.
+    - the callee's FINAL step output is this ``call`` step's return value (N2),
+      re-entering the caller's uniform pipe-data / ``output`` threading unchanged.
+    - callee failure fails THIS step (the ``PipelineExecutionError`` propagates
+      out of the sub-scope unchanged — Hard rule 5/8).
+
+    Recovery: the callee runs under a dotted scope (``f"{i}.call.{j}"``); its
+    completed sub-steps replay EXACTLY-ONCE on resume (see the module docstring)."""
+
+    pipeline: str
+    pass_: "list[str]" = field(default_factory=list)
+    output: "str | None" = None
+
+
+Step = Union[TransformStep, ToolStep, AgentStep, CallStep]
 
 
 @dataclass(frozen=True)
 class Pipeline:
-    """A linear sequence of steps.
+    """A sequence of steps.
 
     ``description`` (IS-5): optional human-readable summary surfaced to the
     LLM by the universal catalog's ``pipeline`` category enumerator
@@ -164,8 +197,11 @@ class Pipeline:
 @dataclass(frozen=True)
 class PipelineResult:
     """The outcome of a completed `run`/`resume`: the final pipe data, every named
-    store, and every step's result (keyed by ``step_path`` — the linear step index as a
-    string; a later multi-scope slice would use dotted scope paths)."""
+    store, and every step's result keyed by ``step_path`` — a DOTTED SCOPE PATH
+    (R7). A top-level step ``i`` keys as ``str(i)``; a ``call``'s callee sub-steps
+    key as ``f"{i}.call.{j}"`` (nesting composes). ``step_index`` is the OUTER
+    scope's next-step cursor (a mid-``call`` snapshot keeps it at the ``call``
+    step's index — the callee's progress lives entirely in the dotted keys)."""
 
     run_id: str
     pipe_data: Any
@@ -180,8 +216,9 @@ class PipelineError(Exception):
 
 class PipelineExecutionError(PipelineError):
     """Raised when a step fails: an expression error, an unresolvable tool result
-    against its declared schema, or an unrecognized step type. The executor never
-    silently continues past a failed step."""
+    against its declared schema, a ``call`` whose target/pass is unresolvable or
+    whose callee failed, or an unrecognized step type. The executor never silently
+    continues past a failed step."""
 
 
 class PipelineCancelled(PipelineError):
@@ -206,10 +243,10 @@ class PipelineCancelled(PipelineError):
 
 ToolDispatch = Callable[[str, "dict[str, Any]"], Any]
 
-# An async recorder handed to a step runner: it writes a full-state R4 generation
-# given the current ``completed_step_results`` + a durability flag. Leaf runners
-# ignore it (their caller records); the surface exists so a future compositional
-# runner can record its own sub-steps without a signature change.
+# An async recorder handed down into every nested scope: it writes a full-state
+# R4 generation using a FROZEN outer frame (the top-level ``call`` step's
+# step_index / named_stores / pipe_data at the moment the call was entered),
+# with only ``completed_step_results`` growing. See ``_run_from``/``_run_scope``.
 Recorder = Callable[..., Awaitable[None]]
 
 _PROMPT_REF_RE = re.compile(r"\{([^{}]+)\}")
@@ -241,8 +278,8 @@ def _interpolate_prompt(template: str, context: "dict[str, Any]") -> str:
 
 
 def _step_kind(step: Step) -> str:
-    """The step's kind string (``transform`` / ``tool`` / ``agent``) for the
-    IS-6 live-progress events — the same vocabulary the serde ``kind`` marker
+    """The step's kind string (``transform`` / ``tool`` / ``agent`` / ``call``) for
+    the IS-6 live-progress events — the same vocabulary the serde ``kind`` marker
     uses, derived from the dataclass type so it never drifts from the union."""
     return _STEP_KINDS.get(type(step), "unknown")
 
@@ -255,7 +292,9 @@ def _step_kind(step: Step) -> str:
 @dataclass(frozen=True)
 class _RunDeps:
     """The read-only per-run collaborators, bundled once so a step runner has a
-    single uniform argument surface instead of a long positional signature."""
+    single uniform argument surface instead of a 9-parameter signature. Threaded
+    unchanged into every nested scope (a ``call``'s callee runs under the SAME
+    deps — same tool dispatch, same registries)."""
 
     tool_dispatch: ToolDispatch
     state_log: "StateLog | None"
@@ -263,16 +302,18 @@ class _RunDeps:
     schema_registry: "SchemaRegistry | None"
     registry: "AgentRegistry | None"
     default_identity: "str | None"
+    pipeline_registry: "PipelineRegistry | None"
     events: "EventLog | None"
     cancel_check: "Callable[[], bool] | None"
 
 
 @dataclass(frozen=True)
 class _StepInvocation:
-    """One dispatch call's inputs. ``step_label`` is the step's path (``"3"`` at
-    top level) — used for error messages. ``record`` is the R4 recorder a future
-    compositional runner uses for its sub-steps; leaf runners ignore it (their
-    caller records)."""
+    """One dispatch call's inputs. ``step_label`` is the step's DOTTED SCOPE PATH
+    (``"3"`` at top level, ``"3.call.0"`` in a callee) — used both for error
+    messages and (by a compositional runner) as the prefix for its sub-scope's
+    dotted keys. ``record`` is the frozen R4 recorder a compositional runner uses
+    for its sub-steps; leaf runners ignore it (their caller records)."""
 
     executor: "PipelineExecutor"
     step: Step
@@ -350,12 +391,60 @@ async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str,
     return result, True, inv.completed_step_results
 
 
+async def _run_call_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """The first COMPOSITIONAL runner (R7): resolve the callee, build its isolated
+    ``pass_`` context, and recurse into ``_run_scope`` under a ``f"{label}.call"``
+    prefix. Returns the callee's FINAL output (N2), whether any executed sub-step
+    was side-effecting (so the outer record durability is right), and the GROWN
+    ``completed_step_results`` (with the callee's dotted keys)."""
+    step: CallStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    if deps.pipeline_registry is None:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (call {step.pipeline!r}) requires a "
+            "pipeline_registry to resolve its target, but none was passed to "
+            "run/resume"
+        )
+    try:
+        callee = deps.pipeline_registry.get(step.pipeline)
+    except PipelineNotFoundError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (call) target pipeline {step.pipeline!r} is "
+            "not registered"
+        ) from exc
+
+    outer_stores = inv.context["ctx"]
+    sub_stores: "dict[str, Any]" = {}
+    for name in step.pass_:
+        if name not in outer_stores:
+            raise PipelineExecutionError(
+                f"step {inv.step_label} (call {step.pipeline!r}) pass: names "
+                f"{name!r}, which is not in the caller's named stores"
+            )
+        sub_stores[name] = outer_stores[name]
+
+    final_pipe, _final_stores, completed_step_results, any_durable = await (
+        inv.executor._run_scope(
+            callee.steps,
+            scope_prefix=f"{inv.step_label}.call",
+            seed_named_stores=sub_stores,
+            # Hard rule 5: the callee's first step gets the caller's pipe-data.
+            seed_pipe_data=inv.context["pipe"],
+            completed_step_results=inv.completed_step_results,
+            deps=deps,
+            record=inv.record,
+        )
+    )
+    return final_pipe, any_durable, completed_step_results
+
+
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
-# entry here (+ serde/parser) rather than editing a shared elif chain.
+# entry here (+ serde/parser/analyzer) rather than editing a shared elif chain.
 STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
     TransformStep: _run_transform_step,
     ToolStep: _run_tool_step,
     AgentStep: _run_agent_step,
+    CallStep: _run_call_step,
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
@@ -363,6 +452,7 @@ _STEP_KINDS: "dict[type, str]" = {
     TransformStep: "transform",
     ToolStep: "tool",
     AgentStep: "agent",
+    CallStep: "call",
 }
 
 
@@ -372,8 +462,10 @@ _STEP_KINDS: "dict[type, str]" = {
 
 
 class PipelineExecutor:
-    """Runs a :class:`Pipeline` sequentially, threading pipe data + named stores
-    (R3) and recording a step-boundary recovery generation after each step (R4)."""
+    """Runs a :class:`Pipeline`, threading pipe data + named stores (R3),
+    recording a dotted-path step-boundary recovery generation after each step
+    (R4/R7), and executing compositional steps (``call``) via a recursive
+    sub-scope (:meth:`_run_scope`)."""
 
     async def run(
         self,
@@ -386,24 +478,21 @@ class PipelineExecutor:
         schema_registry: "SchemaRegistry | None" = None,
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
+        pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
     ) -> PipelineResult:
         """Run `pipeline` from the first step. `initial_context` seeds the named
         stores (``ctx.*``) available to the first step; there is no incoming pipe
         data (``pipe`` resolves to ``None`` until the first step produces one).
-        `registry` (an `AgentRegistry`) and `default_identity` are required only if
-        `pipeline` contains an `AgentStep` — a pipeline with none never touches
-        either, so existing transform/tool-only callers are unaffected.
+        `registry` / `default_identity` are required only if `pipeline` contains an
+        `AgentStep`; `pipeline_registry` (a `PipelineRegistry`) is required only if
+        it contains a `CallStep` — a pipeline with neither never touches either, so
+        existing transform/tool-only callers are unaffected.
 
-        `events` (IS-6), when given, receives a ``pipeline_step_started`` /
-        ``pipeline_step_completed`` event around each step boundary so an attached
-        caller (a sync ``run_pipeline`` tool, the TUI) can render live progress —
-        the emit+subscribe seam; None keeps the executor silent for pure callers.
-        `cancel_check` (IS-6), when given, is polled at each step BOUNDARY (before
-        the next step starts, never mid-step); a True reading raises
-        :class:`PipelineCancelled` leaving the last-recorded R4 snapshot intact
-        (resumable). None disables cooperative cancel."""
+        `events` / `cancel_check` (IS-6) behave as documented on the module: an
+        attached caller renders live progress from `events`, and a True
+        `cancel_check` at a step boundary raises :class:`PipelineCancelled`."""
         named_stores: "dict[str, Any]" = dict(initial_context) if initial_context else {}
         return await self._run_from(
             pipeline,
@@ -417,6 +506,7 @@ class PipelineExecutor:
             schema_registry=schema_registry,
             registry=registry,
             default_identity=default_identity,
+            pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
         )
@@ -431,20 +521,21 @@ class PipelineExecutor:
         schema_registry: "SchemaRegistry | None" = None,
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
+        pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
     ) -> PipelineResult:
         """Resume `run_id`: load the latest recorded generation (R4) and replay every
-        step already in ``completed_step_results`` (no re-execution — exactly-once —
-        this covers a completed ``AgentStep`` exactly like a completed ``tool`` step:
-        its recorded result replays from the snapshot, the LLM turn never re-runs),
-        resuming live execution at the first step with no recorded result. With no
-        snapshot at all, resume == run from scratch.
+        step already in ``completed_step_results`` (no re-execution — exactly-once).
+        For a mid-``call`` crash this means resuming at the ``call`` step's index and
+        replaying the finished callee sub-steps from their dotted keys (the callee's
+        side effects do not re-fire), executing only the remainder. With no snapshot
+        at all, resume == run from scratch.
 
-        `events` / `cancel_check` (IS-6) behave exactly as in :meth:`run` — a
-        cancel observed at the first not-yet-run step boundary raises
-        :class:`PipelineCancelled` from the resumed position, so a resumed run is
-        as interruptible as a fresh one."""
+        `pipeline_registry` (R7) is required only if the resumed run re-enters a
+        `CallStep` — the callee is re-resolved by name and re-walked to reconstruct
+        its local state from the dotted keys. `events` / `cancel_check` behave as in
+        :meth:`run`."""
         snapshot = latest_pipeline_state(run_id, state_log)
         if snapshot is None:
             return await self.run(
@@ -456,6 +547,7 @@ class PipelineExecutor:
                 schema_registry=schema_registry,
                 registry=registry,
                 default_identity=default_identity,
+                pipeline_registry=pipeline_registry,
                 events=events,
                 cancel_check=cancel_check,
             )
@@ -471,6 +563,7 @@ class PipelineExecutor:
             schema_registry=schema_registry,
             registry=registry,
             default_identity=default_identity,
+            pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
         )
@@ -489,6 +582,7 @@ class PipelineExecutor:
         schema_registry: "SchemaRegistry | None",
         registry: "AgentRegistry | None" = None,
         default_identity: "str | None" = None,
+        pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
     ) -> PipelineResult:
@@ -499,16 +593,16 @@ class PipelineExecutor:
             schema_registry=schema_registry,
             registry=registry,
             default_identity=default_identity,
+            pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
         )
         steps = pipeline.steps
         total_steps = len(steps)
         for i in range(start_index, total_steps):
-            # IS-6 cancel checkpoint: poll at the step BOUNDARY, before this step
-            # starts. Every step < i is already complete + snapshotted, so the
-            # last record_pipeline_state (at step_index=i) is a consistent resume
-            # point — raising here never leaves a half-applied step.
+            # IS-6 cancel checkpoint: poll at the TOP-LEVEL step BOUNDARY, before
+            # this step starts. Every step < i is complete + snapshotted, so the
+            # last record_pipeline_state is a consistent resume point.
             if cancel_check is not None and cancel_check():
                 raise PipelineCancelled(run_id=run_id, step_index=i)
             step = steps[i]
@@ -520,9 +614,12 @@ class PipelineExecutor:
                 )
             context = {"ctx": named_stores, "pipe": pipe_data}
 
-            # A recorder bound to THIS step's frame, for a compositional runner's
-            # sub-steps (leaf runners never invoke it; their record happens below,
-            # post-threading).
+            # A frozen R4 recorder for any nested scope this step opens (a call):
+            # every generation recorded WHILE inside the call carries THIS outer
+            # frame (step_index=i, the pre-threading outer stores/pipe) with only
+            # completed_step_results growing — the callee's local stores never
+            # persist, giving pass:[...] isolation on the recovery axis. Leaf
+            # steps never invoke it (their record happens below, post-threading).
             async def _record(
                 *, completed_step_results: "dict[str, Any]", durable: bool,
                 _i: int = i, _named: "dict[str, Any]" = named_stores, _pipe: Any = pipe_data,
@@ -576,12 +673,66 @@ class PipelineExecutor:
             step_index=total_steps,
         )
 
+    async def _run_scope(
+        self,
+        steps: "list[Step]",
+        *,
+        scope_prefix: str,
+        seed_named_stores: "dict[str, Any]",
+        seed_pipe_data: Any,
+        completed_step_results: "dict[str, Any]",
+        deps: _RunDeps,
+        record: Recorder,
+    ) -> "tuple[Any, dict[str, Any], dict[str, Any], bool]":
+        """Run a SUB-scope's ``steps`` under ``scope_prefix`` (e.g. ``"3.call"``),
+        threading its OWN local ``named_stores`` / ``pipe_data`` seeded from the
+        call site. Each sub-step keys as ``f"{scope_prefix}.{j}"``: if that key is
+        ALREADY in ``completed_step_results`` it REPLAYS (no execution, no record —
+        the exactly-once contract for a mid-scope crash), else it executes via the
+        same :data:`STEP_DISPATCH` and records through the frozen ``record`` closure.
+        A nested ``call`` sub-step recurses here again (``"3.call.1.call"``), sharing
+        the SAME ``record`` (the frozen outer frame propagates all the way down).
+        Returns ``(final_pipe_data, final_local_named_stores, grown_completed, any_durable)``.
+
+        Note: no ``cancel_check`` / ``events`` here — a ``call`` is ONE top-level
+        boundary; its sub-steps neither emit ``i/N`` progress nor add cancel points,
+        keeping the attached-caller view coherent. The callee runs to completion or
+        failure once entered; cancel takes effect at the next TOP-LEVEL boundary."""
+        named_stores = seed_named_stores
+        pipe_data = seed_pipe_data
+        any_durable = False
+        for j, step in enumerate(steps):
+            key = f"{scope_prefix}.{j}"
+            if key in completed_step_results:
+                # REPLAY exactly-once: the finished sub-step's result comes from the
+                # snapshot; it is NOT re-executed (no side effect refires).
+                result = completed_step_results[key]
+            else:
+                context = {"ctx": named_stores, "pipe": pipe_data}
+                runner = STEP_DISPATCH.get(type(step))
+                if runner is None:  # pragma: no cover - Step is a closed union
+                    raise PipelineExecutionError(f"unknown step type: {step!r}")
+                inv = _StepInvocation(
+                    executor=self, step=step, context=context, step_label=key,
+                    deps=deps, completed_step_results=completed_step_results,
+                    record=record,
+                )
+                result, durable, completed_step_results = await runner(inv)
+                any_durable = any_durable or durable
+                completed_step_results = {**completed_step_results, key: result}
+                await record(completed_step_results=completed_step_results, durable=durable)
+            pipe_data = result
+            if step.output:
+                named_stores = {**named_stores, step.output: result}
+        return pipe_data, named_stores, completed_step_results, any_durable
+
 
 __all__ = [
     "ExprRef",
     "TransformStep",
     "ToolStep",
     "AgentStep",
+    "CallStep",
     "Step",
     "Pipeline",
     "PipelineResult",

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -7,6 +7,18 @@ The thin vertical-slice executor for
 `match`/`call`/`refine`, the YAML DSL parser, and driver-as-session integration — those
 are later slices; this module proves the core loop + recovery (+ agent-step wiring) only.
 
+**Dispatch table (the parallel-primitive seam).** Step execution is a ``dict``-dispatch
+keyed by the step's dataclass type (:data:`STEP_DISPATCH`) rather than an ``isinstance``
+chain — so a future primitive ADDS one registry entry (plus a serde encoder/decoder and a
+parser) instead of editing a shared ``elif`` block. Every runner has the uniform signature
+``(_StepInvocation) -> (result, durable, completed_step_results)``: a leaf runner
+(``transform``/``tool``/``agent``) returns ``completed_step_results`` unchanged and never
+records (its caller records after threading). ``_StepInvocation`` also carries a
+``record`` recorder + a ``step_label`` (the step's path, for error messages) that a
+future COMPOSITIONAL runner will use for its own sub-scope recording; leaf runners ignore
+both, but the surface is uniform so the compositional primitive plugs in without touching
+the leaf runners.
+
 **R3 (uniform pipe-data / output rule)**: every step produces exactly one return value.
 That value is simultaneously (1) the pipe data handed to the next step and (2) written
 to a named store under ``output`` iff the step declares one. A ``transform`` step's
@@ -57,7 +69,7 @@ from __future__ import annotations
 import inspect
 import re
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
 from reyn.core.pipeline.expr import ExprEvalError, ExprParseError, evaluate_expr
@@ -194,6 +206,12 @@ class PipelineCancelled(PipelineError):
 
 ToolDispatch = Callable[[str, "dict[str, Any]"], Any]
 
+# An async recorder handed to a step runner: it writes a full-state R4 generation
+# given the current ``completed_step_results`` + a durability flag. Leaf runners
+# ignore it (their caller records); the surface exists so a future compositional
+# runner can record its own sub-steps without a signature change.
+Recorder = Callable[..., Awaitable[None]]
+
 _PROMPT_REF_RE = re.compile(r"\{([^{}]+)\}")
 
 
@@ -226,13 +244,126 @@ def _step_kind(step: Step) -> str:
     """The step's kind string (``transform`` / ``tool`` / ``agent``) for the
     IS-6 live-progress events — the same vocabulary the serde ``kind`` marker
     uses, derived from the dataclass type so it never drifts from the union."""
-    if isinstance(step, TransformStep):
-        return "transform"
-    if isinstance(step, ToolStep):
-        return "tool"
-    if isinstance(step, AgentStep):
-        return "agent"
-    return "unknown"  # pragma: no cover - Step is a closed union
+    return _STEP_KINDS.get(type(step), "unknown")
+
+
+# ---------------------------------------------------------------------------
+# Per-run collaborators + step-invocation bundle (dispatch-table plumbing)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RunDeps:
+    """The read-only per-run collaborators, bundled once so a step runner has a
+    single uniform argument surface instead of a long positional signature."""
+
+    tool_dispatch: ToolDispatch
+    state_log: "StateLog | None"
+    run_id: str
+    schema_registry: "SchemaRegistry | None"
+    registry: "AgentRegistry | None"
+    default_identity: "str | None"
+    events: "EventLog | None"
+    cancel_check: "Callable[[], bool] | None"
+
+
+@dataclass(frozen=True)
+class _StepInvocation:
+    """One dispatch call's inputs. ``step_label`` is the step's path (``"3"`` at
+    top level) — used for error messages. ``record`` is the R4 recorder a future
+    compositional runner uses for its sub-steps; leaf runners ignore it (their
+    caller records)."""
+
+    executor: "PipelineExecutor"
+    step: Step
+    context: "dict[str, Any]"
+    step_label: str
+    deps: _RunDeps
+    completed_step_results: "dict[str, Any]"
+    record: Recorder
+
+
+async def _run_transform_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    step: TransformStep = inv.step  # type: ignore[assignment]
+    try:
+        result = evaluate_expr(step.value, inv.context)
+    except ExprEvalError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (transform) failed: {exc}"
+        ) from exc
+    return result, False, inv.completed_step_results
+
+
+async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    step: ToolStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    resolved_args = {
+        k: (evaluate_expr(v.src, inv.context) if isinstance(v, ExprRef) else v)
+        for k, v in step.args.items()
+    }
+    raw = deps.tool_dispatch(step.name, resolved_args)
+    result = await raw if inspect.isawaitable(raw) else raw
+    if step.schema is not None:
+        if deps.schema_registry is None:
+            raise PipelineExecutionError(
+                f"step {inv.step_label} (tool {step.name!r}) declares verify: schema "
+                f"{step.schema!r} but no schema_registry was provided"
+            )
+        validation = validate(result, step.schema, deps.schema_registry)
+        if not validation.conforming:
+            raise PipelineExecutionError(
+                f"step {inv.step_label} (tool {step.name!r}) output failed schema "
+                f"{step.schema!r}: {validation.errors}"
+            )
+    return result, True, inv.completed_step_results
+
+
+async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    step: AgentStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    identity = step.identity or deps.default_identity
+    if identity is None:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (agent) has no identity and no default_identity "
+            "was given to run/resume — the design doc's 'identity "
+            "defaults to invoker' requires the caller to supply one"
+        )
+    if deps.registry is None:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (agent) requires a registry (AgentRegistry) to "
+            "spawn its session, but none was passed to run/resume"
+        )
+    prompt = _interpolate_prompt(step.prompt, inv.context)
+    try:
+        result = await run_agent_step(
+            deps.registry,
+            identity=identity,
+            prompt=prompt,
+            capabilities=step.capabilities,
+            schema=step.schema,
+            schema_registry=deps.schema_registry,
+        )
+    except AgentStepError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (agent) failed: {exc}"
+        ) from exc
+    return result, True, inv.completed_step_results
+
+
+# Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
+# entry here (+ serde/parser) rather than editing a shared elif chain.
+STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
+    TransformStep: _run_transform_step,
+    ToolStep: _run_tool_step,
+    AgentStep: _run_agent_step,
+}
+
+# Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
+_STEP_KINDS: "dict[type, str]" = {
+    TransformStep: "transform",
+    ToolStep: "tool",
+    AgentStep: "agent",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -361,8 +492,19 @@ class PipelineExecutor:
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
     ) -> PipelineResult:
+        deps = _RunDeps(
+            tool_dispatch=tool_dispatch,
+            state_log=state_log,
+            run_id=run_id,
+            schema_registry=schema_registry,
+            registry=registry,
+            default_identity=default_identity,
+            events=events,
+            cancel_check=cancel_check,
+        )
         steps = pipeline.steps
-        for i in range(start_index, len(steps)):
+        total_steps = len(steps)
+        for i in range(start_index, total_steps):
             # IS-6 cancel checkpoint: poll at the step BOUNDARY, before this step
             # starts. Every step < i is already complete + snapshotted, so the
             # last record_pipeline_state (at step_index=i) is a consistent resume
@@ -371,7 +513,6 @@ class PipelineExecutor:
                 raise PipelineCancelled(run_id=run_id, step_index=i)
             step = steps[i]
             kind = _step_kind(step)
-            total_steps = len(steps)
             if events is not None:
                 events.emit(
                     "pipeline_step_started",
@@ -379,64 +520,31 @@ class PipelineExecutor:
                 )
             context = {"ctx": named_stores, "pipe": pipe_data}
 
-            if isinstance(step, TransformStep):
-                try:
-                    result = evaluate_expr(step.value, context)
-                except ExprEvalError as exc:
-                    raise PipelineExecutionError(
-                        f"step {i} (transform) failed: {exc}"
-                    ) from exc
-                durable = False
-            elif isinstance(step, ToolStep):
-                resolved_args = {
-                    k: (evaluate_expr(v.src, context) if isinstance(v, ExprRef) else v)
-                    for k, v in step.args.items()
-                }
-                raw = tool_dispatch(step.name, resolved_args)
-                result = await raw if inspect.isawaitable(raw) else raw
-                if step.schema is not None:
-                    if schema_registry is None:
-                        raise PipelineExecutionError(
-                            f"step {i} (tool {step.name!r}) declares verify: schema "
-                            f"{step.schema!r} but no schema_registry was provided"
-                        )
-                    validation = validate(result, step.schema, schema_registry)
-                    if not validation.conforming:
-                        raise PipelineExecutionError(
-                            f"step {i} (tool {step.name!r}) output failed schema "
-                            f"{step.schema!r}: {validation.errors}"
-                        )
-                durable = True
-            elif isinstance(step, AgentStep):
-                identity = step.identity or default_identity
-                if identity is None:
-                    raise PipelineExecutionError(
-                        f"step {i} (agent) has no identity and no default_identity "
-                        "was given to run/resume — the design doc's 'identity "
-                        "defaults to invoker' requires the caller to supply one"
-                    )
-                if registry is None:
-                    raise PipelineExecutionError(
-                        f"step {i} (agent) requires a registry (AgentRegistry) to "
-                        "spawn its session, but none was passed to run/resume"
-                    )
-                prompt = _interpolate_prompt(step.prompt, context)
-                try:
-                    result = await run_agent_step(
-                        registry,
-                        identity=identity,
-                        prompt=prompt,
-                        capabilities=step.capabilities,
-                        schema=step.schema,
-                        schema_registry=schema_registry,
-                    )
-                except AgentStepError as exc:
-                    raise PipelineExecutionError(
-                        f"step {i} (agent) failed: {exc}"
-                    ) from exc
-                durable = True
-            else:  # pragma: no cover - Step is a closed union
+            # A recorder bound to THIS step's frame, for a compositional runner's
+            # sub-steps (leaf runners never invoke it; their record happens below,
+            # post-threading).
+            async def _record(
+                *, completed_step_results: "dict[str, Any]", durable: bool,
+                _i: int = i, _named: "dict[str, Any]" = named_stores, _pipe: Any = pipe_data,
+            ) -> None:
+                await record_pipeline_state(
+                    state_log, run_id,
+                    {
+                        "run_id": run_id, "step_index": _i,
+                        "named_stores": _named, "pipe_data": _pipe,
+                        "completed_step_results": completed_step_results,
+                    },
+                    durable=durable,
+                )
+
+            runner = STEP_DISPATCH.get(type(step))
+            if runner is None:  # pragma: no cover - Step is a closed union
                 raise PipelineExecutionError(f"unknown step type: {step!r}")
+            inv = _StepInvocation(
+                executor=self, step=step, context=context, step_label=str(i),
+                deps=deps, completed_step_results=completed_step_results, record=_record,
+            )
+            result, durable, completed_step_results = await runner(inv)
 
             pipe_data = result
             step_index = i + 1
@@ -444,15 +552,14 @@ class PipelineExecutor:
             if step.output:
                 named_stores = {**named_stores, step.output: result}
 
-            control_plane_state = {
-                "run_id": run_id,
-                "step_index": step_index,
-                "named_stores": named_stores,
-                "pipe_data": pipe_data,
-                "completed_step_results": completed_step_results,
-            }
             await record_pipeline_state(
-                state_log, run_id, control_plane_state, durable=durable,
+                state_log, run_id,
+                {
+                    "run_id": run_id, "step_index": step_index,
+                    "named_stores": named_stores, "pipe_data": pipe_data,
+                    "completed_step_results": completed_step_results,
+                },
+                durable=durable,
             )
             if events is not None:
                 events.emit(
@@ -466,7 +573,7 @@ class PipelineExecutor:
             pipe_data=pipe_data,
             named_stores=named_stores,
             completed_step_results=completed_step_results,
-            step_index=len(steps),
+            step_index=total_steps,
         )
 
 
@@ -482,4 +589,5 @@ __all__ = [
     "PipelineExecutionError",
     "PipelineCancelled",
     "PipelineExecutor",
+    "STEP_DISPATCH",
 ]

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -4,8 +4,9 @@ Implements the surface grammar in Appendix B of
 ``docs/proposals/reyn-pipeline-spec-v0.8.md`` (lines 706-835), narrowed to
 exactly the subset :class:`reyn.core.pipeline.executor.PipelineExecutor` can
 run today: a **linear** sequence of ``transform`` / ``tool`` / ``shell`` /
-``agent`` steps, plus the pipeline-level ``description``. ``for_each`` /
-``parallel`` / ``fold`` / ``match`` / ``call`` / ``refine``, and the
+``agent`` steps plus the first COMPOSITIONAL primitive ``call`` (R7 — runs a
+registered sub-pipeline synchronously), plus the pipeline-level ``description``.
+``for_each`` / ``parallel`` / ``fold`` / ``match`` / ``refine``, and the
 pipeline-level ``input`` / ``defaults`` blocks are all part of the full v0.8
 grammar but have no runtime yet — this parser refuses to accept them rather
 than silently dropping them into a pipeline that "parses" but then either
@@ -77,6 +78,7 @@ import yaml
 
 from reyn.core.pipeline.executor import (
     AgentStep,
+    CallStep,
     ExprRef,
     Pipeline,
     Step,
@@ -132,10 +134,14 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 
 # Constructs the union grammar's non-linear step kinds accept as *keys* so a
 # document using them gets a clear "not yet supported" error instead of a
-# generic "unknown step type".
-_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel", "fold", "match", "call")
+# generic "unknown step type". ``call`` is now SUPPORTED (R7) — it moved out of
+# this set into ``_STEP_PARSERS``.
+_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel", "fold", "match")
 _LINEAR_STEP_KINDS = ("transform", "tool", "shell", "agent")
-_ALL_STEP_KINDS = _LINEAR_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
+# ``call`` is compositional, not linear, but it IS executable — listed separately
+# so error text distinguishes "the linear kinds" from the full supported set.
+_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call",)
+_ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has
 # no runtime concept of at all (R4 recovery / R3 threading only understand
@@ -206,6 +212,7 @@ _TRANSFORM_KEYS = frozenset({"value", "output"})
 _TOOL_KEYS = frozenset({"name", "args", "schema", "output"})
 _SHELL_KEYS = frozenset({"command", "schema", "output"})
 _AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "output"})
+_CALL_KEYS = frozenset({"pipeline", "pass", "output"})
 
 
 def _parse_transform_step(body: "dict[str, Any]") -> TransformStep:
@@ -280,11 +287,35 @@ def _parse_agent_step(body: "dict[str, Any]") -> AgentStep:
     )
 
 
+def _parse_call_step(body: "dict[str, Any]") -> CallStep:
+    """``call = {pipeline: LIT, pass: [NAME*], output: NAME}`` (Appendix B, R7).
+    ``pipeline`` is a STATIC literal name (Hard rule 2 — never an expression);
+    ``pass`` is the caller-store projection the callee may reference; ``output``
+    binds the callee's final result to a caller named store."""
+    _reject_unknown_keys(body, _CALL_KEYS, where="call step")
+    if "pipeline" not in body:
+        _fail("call step: missing required field 'pipeline'")
+    name = body["pipeline"]
+    if not isinstance(name, str) or not name:
+        _fail(
+            f"call step 'pipeline': expected a non-empty literal pipeline name, "
+            f"got {name!r}"
+        )
+    raw_pass = body.get("pass") or []
+    if not isinstance(raw_pass, list) or not all(isinstance(n, str) for n in raw_pass):
+        _fail(f"call step 'pass': expected a list of store-name strings, got {raw_pass!r}")
+    output = body.get("output")
+    if output is not None and not isinstance(output, str):
+        _fail(f"call step 'output': expected a store-name string, got {type(output).__name__}")
+    return CallStep(pipeline=name, pass_=list(raw_pass), output=output)
+
+
 _STEP_PARSERS = {
     "transform": _parse_transform_step,
     "tool": _parse_tool_step,
     "shell": _parse_shell_step,
     "agent": _parse_agent_step,
+    "call": _parse_call_step,
 }
 
 
@@ -298,7 +329,7 @@ def _parse_step(raw_step: Any, *, index: int) -> Step:
     if kind in _UNSUPPORTED_STEP_KINDS:
         _fail(
             f"step {index}: step kind {kind!r} is not yet supported (later slice) — "
-            f"the linear executor only runs {_LINEAR_STEP_KINDS!r}"
+            f"the executor runs {_SUPPORTED_STEP_KINDS!r}"
         )
     if kind not in _STEP_PARSERS:
         _fail(

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -34,7 +34,7 @@ alone on a crash-resume.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.core.pipeline.executor import (
     AgentStep,
@@ -80,52 +80,86 @@ def _decode_arg(value: Any) -> Any:
     return value
 
 
+def _encode_transform(step: "TransformStep") -> "dict[str, Any]":
+    return {"kind": "transform", "value": step.value, "output": step.output}
+
+
+def _encode_tool(step: "ToolStep") -> "dict[str, Any]":
+    return {
+        "kind": "tool",
+        "name": step.name,
+        "args": {k: _encode_arg(step.name, k, v) for k, v in step.args.items()},
+        "output": step.output,
+        "schema": step.schema,
+    }
+
+
+def _encode_agent(step: "AgentStep") -> "dict[str, Any]":
+    return {
+        "kind": "agent",
+        "prompt": step.prompt,
+        "identity": step.identity,
+        "capabilities": list(step.capabilities) if step.capabilities is not None else None,
+        "schema": step.schema,
+        "output": step.output,
+    }
+
+
+def _decode_transform(data: "dict[str, Any]") -> "TransformStep":
+    return TransformStep(value=data["value"], output=data.get("output"))
+
+
+def _decode_tool(data: "dict[str, Any]") -> "ToolStep":
+    return ToolStep(
+        name=data["name"],
+        args={k: _decode_arg(v) for k, v in dict(data.get("args") or {}).items()},
+        output=data.get("output"),
+        schema=data.get("schema"),
+    )
+
+
+def _decode_agent(data: "dict[str, Any]") -> "AgentStep":
+    caps = data.get("capabilities")
+    return AgentStep(
+        prompt=data["prompt"],
+        identity=data.get("identity"),
+        capabilities=list(caps) if caps is not None else None,
+        schema=data.get("schema"),
+        output=data.get("output"),
+    )
+
+
+# Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
+# A future primitive ADDS one entry to each (mirroring the executor's
+# ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
+# shared isinstance/``kind==`` chain.
+ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
+    TransformStep: _encode_transform,
+    ToolStep: _encode_tool,
+    AgentStep: _encode_agent,
+}
+DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
+    "transform": _decode_transform,
+    "tool": _decode_tool,
+    "agent": _decode_agent,
+}
+
+
 def step_to_dict(step: "Step") -> "dict[str, Any]":
     """One executor step dataclass → a JSON-serializable dict (``kind`` tagged)."""
-    if isinstance(step, TransformStep):
-        return {"kind": "transform", "value": step.value, "output": step.output}
-    if isinstance(step, ToolStep):
-        return {
-            "kind": "tool",
-            "name": step.name,
-            "args": {k: _encode_arg(step.name, k, v) for k, v in step.args.items()},
-            "output": step.output,
-            "schema": step.schema,
-        }
-    if isinstance(step, AgentStep):
-        return {
-            "kind": "agent",
-            "prompt": step.prompt,
-            "identity": step.identity,
-            "capabilities": list(step.capabilities) if step.capabilities is not None else None,
-            "schema": step.schema,
-            "output": step.output,
-        }
-    raise PipelineSerdeError(f"unknown step type: {step!r}")
+    encoder = ENCODERS.get(type(step))
+    if encoder is None:
+        raise PipelineSerdeError(f"unknown step type: {step!r}")
+    return encoder(step)
 
 
 def step_from_dict(data: "dict[str, Any]") -> "Step":
     """The inverse of :func:`step_to_dict`."""
     kind = data.get("kind")
-    if kind == "transform":
-        return TransformStep(value=data["value"], output=data.get("output"))
-    if kind == "tool":
-        return ToolStep(
-            name=data["name"],
-            args={k: _decode_arg(v) for k, v in dict(data.get("args") or {}).items()},
-            output=data.get("output"),
-            schema=data.get("schema"),
-        )
-    if kind == "agent":
-        caps = data.get("capabilities")
-        return AgentStep(
-            prompt=data["prompt"],
-            identity=data.get("identity"),
-            capabilities=list(caps) if caps is not None else None,
-            schema=data.get("schema"),
-            output=data.get("output"),
-        )
-    raise PipelineSerdeError(f"unknown step kind in stored pipeline: {kind!r}")
+    decoder = DECODERS.get(kind) if isinstance(kind, str) else None
+    if decoder is None:
+        raise PipelineSerdeError(f"unknown step kind in stored pipeline: {kind!r}")
+    return decoder(data)
 
 
 def pipeline_to_dict(pipeline: "Pipeline") -> "dict[str, Any]":

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.core.pipeline.executor import (
     AgentStep,
+    CallStep,
     ExprRef,
     Pipeline,
     Step,
@@ -129,6 +130,26 @@ def _decode_agent(data: "dict[str, Any]") -> "AgentStep":
     )
 
 
+def _encode_call(step: "CallStep") -> "dict[str, Any]":
+    # ``pass_`` (the Python field — ``pass`` is a keyword) serializes under the
+    # Appendix-B wire/DSL key ``"pass"``. This is the one place a step field name
+    # differs from its wire key.
+    return {
+        "kind": "call",
+        "pipeline": step.pipeline,
+        "pass": list(step.pass_),
+        "output": step.output,
+    }
+
+
+def _decode_call(data: "dict[str, Any]") -> "CallStep":
+    return CallStep(
+        pipeline=data["pipeline"],
+        pass_=list(data.get("pass") or []),
+        output=data.get("output"),
+    )
+
+
 # Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
 # A future primitive ADDS one entry to each (mirroring the executor's
 # ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
@@ -137,11 +158,13 @@ ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
     TransformStep: _encode_transform,
     ToolStep: _encode_tool,
     AgentStep: _encode_agent,
+    CallStep: _encode_call,
 }
 DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "transform": _decode_transform,
     "tool": _decode_tool,
     "agent": _decode_agent,
+    "call": _decode_call,
 }
 
 

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -187,6 +187,11 @@ class PipelineExecutorDriver:
         # attached caller subscribes to it) and poll THIS driver's cooperative
         # cancel flag at each step boundary.
         events = getattr(self._router_host, "events", None)
+        # R7: a `call` step resolves its target through the session's
+        # PipelineRegistry (the same host-derived registry the sync run_pipeline
+        # tool resolves against). None-safe: a pipeline with no `call` step never
+        # touches it; a `call` with no registry available fails the step cleanly.
+        pipeline_registry = self._pipeline_registry()
         try:
             if latest_pipeline_state(wo.run_id, self._state_log) is None:
                 # Fresh run (or crashed before the first R4 snapshot): seed the
@@ -199,6 +204,7 @@ class PipelineExecutorDriver:
                     run_id=wo.run_id,
                     registry=self._registry,
                     default_identity=wo.reply_to_agent,
+                    pipeline_registry=pipeline_registry,
                     events=events,
                     cancel_check=self.is_cancel_requested,
                     schema_registry=schema_registry,
@@ -211,6 +217,7 @@ class PipelineExecutorDriver:
                     state_log=self._state_log,
                     registry=self._registry,
                     default_identity=wo.reply_to_agent,
+                    pipeline_registry=pipeline_registry,
                     events=events,
                     cancel_check=self.is_cancel_requested,
                     schema_registry=schema_registry,
@@ -254,6 +261,17 @@ class PipelineExecutorDriver:
         return None
 
     # ── internals ──────────────────────────────────────────────────────────────
+
+    def _pipeline_registry(self) -> Any:
+        """R7: the session's ``PipelineRegistry`` (or None) — the resolution
+        source a ``call`` step's target name is looked up in, via the host
+        adapter's ``get_pipeline_registry()`` (the SAME registry the sync
+        ``run_pipeline`` tool resolves against through
+        ``RouterCallerState.pipeline_registry``). None-safe: a pipeline with no
+        ``call`` step never touches it."""
+        host = self._router_host
+        getter = getattr(host, "get_pipeline_registry", None) if host is not None else None
+        return getter() if getter is not None else None
 
     def _run_dir(self) -> "Path":
         from reyn.core.events.config_recovery import reyn_root

--- a/tests/test_pipeline_call_primitive.py
+++ b/tests/test_pipeline_call_primitive.py
@@ -1,0 +1,311 @@
+"""Tier 2: OS invariant — the `call` compositional primitive + dotted-path R7 recovery.
+
+Covers the non-linear foundation's first consumer
+(``docs/proposals/reyn-pipeline-improvements-proposal.md`` N2 + Appendix B ``call``,
+built on the ``_run_scope`` + dotted-path recovery + dispatch-table foundation):
+
+  1. happy path — a ``call`` runs its REGISTERED callee synchronously, ``pass:[...]``
+     projects ONLY the listed caller stores into the callee, the callee's first step
+     receives the caller's pipe-data at the call site (Hard rule 5), and the callee's
+     FINAL output threads out as the ``call`` step's N2 return value.
+  2. ``pass:[...]`` isolation — a callee referencing a caller store NOT in ``pass``
+     fails the step (structural, not silent-None).
+  3. callee failure fails the caller (the sub-scope's ``PipelineExecutionError``
+     propagates out of the ``call`` step unchanged).
+  4. dotted-path R4 keys — a mid-``call`` snapshot keys the callee's sub-steps under
+     ``f"{i}.call.{j}"`` while keeping the OUTER ``named_stores`` free of callee
+     leakage (``pass:[...]`` isolation on the recovery axis).
+  5. the CLAUDE.md-mandated truncate-falsify recovery gate: crash mid-callee, truncate
+     the WAL below the source events, resume from the generation FILE, and prove the
+     completed callee sub-steps REPLAY exactly-once (a callee side-effect does not
+     re-fire) while only the remaining callee step executes.
+  6. an unregistered ``call`` target fails cleanly.
+
+Real ``StateLog`` + ``PipelineRegistry`` + real generation files throughout; the
+recovery tests build the executor directly (the same discipline as IS-2's
+truncate-falsify) — no mocks, no private-state assertions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    CallStep,
+    ExprRef,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.registry import PipelineRegistry
+
+# ── happy path: callee runs, pass:[...] scoping, pipe-data-at-call-site, N2 out ──
+
+
+@pytest.mark.asyncio
+async def test_call_runs_callee_and_threads_final_output_with_pass_scoping():
+    """Tier 2: a ``call`` runs its callee synchronously; ``pass:[brief]`` projects
+    ONLY ``brief`` into the callee (``ctx.brief`` resolves; the caller's other store
+    is invisible), the callee's first step sees the caller's pipe-data via bare
+    ``pipe`` (Hard rule 5), and the callee's final output becomes the ``call`` step's
+    return value + named output."""
+    registry = PipelineRegistry()
+    registry.register(
+        "summarize",
+        Pipeline(steps=[
+            # first callee step: bare `pipe` == the caller's pipe-data at the call site
+            TransformStep(value="pipe + '-bumped'", output="bumped"),
+            # `ctx.brief` reaches the passed store; the caller's `secret` is NOT here
+            TransformStep(value="ctx.brief + '::' + ctx.bumped", output="summary"),
+        ]),
+    )
+
+    outer = Pipeline(steps=[
+        TransformStep(value="ctx.n", output="carried"),      # step 0: pipe_data = "seven"
+        CallStep(pipeline="summarize", pass_=["brief"], output="called_out"),  # step 1
+        TransformStep(value="ctx.called_out + '!'", output="final"),           # step 2
+    ])
+
+    result = await PipelineExecutor().run(
+        outer,
+        {"n": "seven", "brief": "hi", "secret": "nope"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None,
+        run_id="run-call-happy",
+        pipeline_registry=registry,
+    )
+
+    # callee: bumped = "seven-bumped" ; summary = "hi::seven-bumped" ; threads out.
+    assert result.named_stores["called_out"] == "hi::seven-bumped"
+    assert result.named_stores["final"] == "hi::seven-bumped!"
+    assert result.pipe_data == "hi::seven-bumped!"
+    # Outer flat key for the call's N2 result; callee sub-steps under the dotted scope.
+    assert result.completed_step_results["1"] == "hi::seven-bumped"
+    assert result.completed_step_results["1.call.0"] == "seven-bumped"
+    assert result.completed_step_results["1.call.1"] == "hi::seven-bumped"
+    # pass:[...] isolation — the callee's local `bumped`/`summary` never leaked into
+    # the OUTER named stores (only the declared `output` did).
+    assert "bumped" not in result.named_stores
+    assert "summary" not in result.named_stores
+
+
+@pytest.mark.asyncio
+async def test_call_pass_isolation_denies_unpassed_store():
+    """Tier 2: a callee that references a caller store NOT in ``pass:[...]`` fails the
+    step — the isolation is structural (a Key-projected context), not a silent None."""
+    registry = PipelineRegistry()
+    registry.register(
+        "leaky",
+        Pipeline(steps=[TransformStep(value="ctx.secret", output="x")]),
+    )
+    outer = Pipeline(steps=[CallStep(pipeline="leaky", pass_=[], output="o")])
+
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            outer, {"secret": "s"},
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-iso", pipeline_registry=registry,
+        )
+
+
+@pytest.mark.asyncio
+async def test_callee_failure_fails_the_call_step():
+    """Tier 2: a callee step failure propagates out of the ``call`` as a caller
+    step failure (Hard rule 5) — never silently swallowed."""
+    registry = PipelineRegistry()
+    registry.register(
+        "boom",
+        Pipeline(steps=[TransformStep(value="ctx.missing_field", output="x")]),
+    )
+    outer = Pipeline(steps=[CallStep(pipeline="boom", pass_=[], output="o")])
+
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-boom", pipeline_registry=registry,
+        )
+
+
+@pytest.mark.asyncio
+async def test_unregistered_call_target_fails_cleanly():
+    """Tier 2: a ``call`` to an unregistered pipeline name fails the step with a
+    clear error, not an unhandled KeyError."""
+    outer = Pipeline(steps=[CallStep(pipeline="nope", pass_=[], output="o")])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-missing", pipeline_registry=PipelineRegistry(),
+        )
+    assert "not registered" in str(exc.value)
+
+
+# ── dotted-path R4 recovery: the CLAUDE.md truncate-falsify gate ─────────────────
+
+
+def _append_dispatch(state_log: StateLog, out_file, crash):
+    """A REAL side-effecting tool (mirrors IS-2's ``is2_append``): each call appends
+    a line to ``out_file`` AND a WAL entry (so R4 gens land at distinct durable
+    seqs). The exactly-once probe is the FILE — a re-fired step leaves a duplicate
+    line. ``crash["line"]`` arms a mid-execution failure BEFORE that line's side
+    effect, so a snapshot with the prior sub-step recorded but this one absent is a
+    genuine mid-callee crash."""
+
+    async def _dispatch(name: str, args: dict):
+        assert name == "append"
+        line = str(args["line"])
+        if crash.get("line") == line:
+            raise RuntimeError(f"simulated crash before writing {line!r}")
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        await state_log.append("inbox_put", note=line)
+        return {"wrote": line}
+
+    return _dispatch
+
+
+def _two_write_callee() -> Pipeline:
+    """A 2-step callee that writes ``A`` then ``B`` — both side-effecting, so a crash
+    between them leaves exactly ``A`` on disk."""
+    return Pipeline(steps=[
+        ToolStep(name="append", args={"line": "A"}, output="a"),
+        ToolStep(name="append", args={"line": "B"}, output="b"),
+    ])
+
+
+def _outer_calling(callee_name: str) -> Pipeline:
+    return Pipeline(steps=[
+        TransformStep(value="ctx.seed", output="carried"),
+        CallStep(pipeline=callee_name, pass_=["seed"], output="call_out"),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_mid_call_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp_path):
+    """Tier 2: a genuine MID-CALLEE crash (sub-step 0 recorded, sub-step 1 failed)
+    records the finished sub-step under ``f"{i}.call.0"`` and keeps ``step_index`` at
+    the OUTER ``call`` index (the call is not done) — and the callee's local ``a``
+    store does NOT appear in the persisted OUTER ``named_stores`` (pass:[...]
+    isolation on the recovery axis)."""
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"line": "B"}  # sub-step 1 (writes B) fails mid-callee
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("callee", _two_write_callee())
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            _outer_calling("callee"), {"seed": 5},
+            tool_dispatch=dispatch, state_log=state_log,
+            run_id="run-dotted", pipeline_registry=registry,
+        )
+    await state_log.flush()
+
+    snap = latest_pipeline_state("run-dotted", state_log)
+    # The finished callee sub-step is present under the dotted key; the failed one
+    # and the outer call's own key are absent (the call is not done).
+    assert "1.call.0" in snap["completed_step_results"]
+    assert "1.call.1" not in snap["completed_step_results"]
+    assert "1" not in snap["completed_step_results"]
+    # step_index stayed at the outer call index — the callee's progress lives in the
+    # dotted keys, not the outer cursor.
+    assert snap["step_index"] == 1
+    # pass:[...] isolation: the callee's local `a` never leaked into OUTER stores.
+    assert "a" not in snap["named_stores"]
+    assert snap["named_stores"].get("carried") == 5
+    # exactly one line on disk pre-crash.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_call_resumes_callee_substeps_exactly_once(tmp_path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate for the `call` primitive. A run
+    crashes MID-CALLEE (callee sub-step 0 wrote ``A`` + recorded its R4 gen + dotted
+    key; sub-step 1 failed before writing ``B``). The WAL is then truncated BELOW
+    those source events. ``resume`` must reconstruct from the generation FILE, REPLAY
+    the finished sub-step exactly-once (``A`` is NOT written again — the file proves
+    it), execute ONLY the remaining sub-step (writes ``B`` once), and complete —
+    threading the callee's final output out. RED if a callee sub-step rode a
+    truncatable WAL event, or if resume re-ran the whole ``call`` instead of
+    replaying the completed sub-steps."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"line": "B"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("callee", _two_write_callee())
+    outer = _outer_calling("callee")
+
+    # CRASH STATE: sub-step 0 writes A + records its gen at a real WAL seq; sub-step
+    # 1 raises before writing B.
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            outer, {"seed": 5},
+            tool_dispatch=dispatch, state_log=state_log,
+            run_id="run-tf", pipeline_registry=registry,
+        )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
+
+    # The WAL head climbs past the crash-state seqs, then GC truncates below 40 —
+    # the callee sub-step's own WAL entry is dropped from wal.jsonl.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "the callee sub-step's WAL entry is truncated away"
+
+    # RESUME with the crash DISARMED: the finished sub-step replays from the gen
+    # FILE (no re-write of A), only sub-step 1 executes (writes B once).
+    crash.clear()
+    resumed = await PipelineExecutor().resume(
+        "run-tf", pipeline=outer,
+        tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+    )
+
+    # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+    assert resumed.completed_step_results["1.call.0"] == {"wrote": "A"}
+    assert resumed.completed_step_results["1.call.1"] == {"wrote": "B"}
+    # The callee's final output (sub-step 1's result) threads out as the call's N2.
+    assert resumed.named_stores["call_out"] == {"wrote": "B"}
+    assert resumed.pipe_data == {"wrote": "B"}
+    assert resumed.step_index == 2
+
+
+@pytest.mark.asyncio
+async def test_call_resume_after_full_run_replays_with_zero_new_side_effects(tmp_path):
+    """Tier 2: resuming a run whose ``call`` already completed replays every callee
+    sub-step from the snapshot (zero new writes) and re-threads the N2 result. RED if
+    resume re-ran a completed callee sub-step's side effect."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    dispatch = _append_dispatch(state_log, out_file, {})
+
+    registry = PipelineRegistry()
+    registry.register("callee", _two_write_callee())
+    outer = _outer_calling("callee")
+
+    await PipelineExecutor().run(
+        outer, {"seed": 5},
+        tool_dispatch=dispatch, state_log=state_log,
+        run_id="run-done", pipeline_registry=registry,
+    )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+
+    resumed = await PipelineExecutor().resume(
+        "run-done", pipeline=outer,
+        tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+    )
+    # No new lines — a fully-completed run replays with zero side effects.
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+    assert resumed.named_stores["call_out"] == {"wrote": "B"}

--- a/tests/test_pipeline_call_serde_parser_analyzer.py
+++ b/tests/test_pipeline_call_serde_parser_analyzer.py
@@ -1,0 +1,71 @@
+"""Tier 1: `call` primitive contract — serde round-trip, DSL parse, analyzer facet.
+
+The `call` step (R7) plugs into the three sibling dispatch tables the foundation
+established: serde's ``ENCODERS``/``DECODERS`` (work-order persistence — the
+``pass_`` field ⇄ wire key ``"pass"`` split), the parser's ``_STEP_PARSERS``
+(Appendix B ``call = {pipeline, pass, output}``), and the analyzer's
+``ANALYZER_FACETS`` (P4 seam). This pins each contract with NON-DEFAULT values.
+
+Real YAML parse + real JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.analyzer import analyze_step
+from reyn.core.pipeline.executor import CallStep, Pipeline, ToolStep
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def test_call_serde_round_trip_non_default_values():
+    """Tier 1: a ``CallStep`` with non-default ``pass_`` + ``output`` round-trips
+    dataclass -> dict -> JSON -> dataclass, and the wire form uses the Appendix-B
+    key ``"pass"`` (not the Python field name ``pass_``)."""
+    pipeline = Pipeline(steps=[
+        CallStep(pipeline="sub-flow", pass_=["brief", "budget"], output="result"),
+        ToolStep(name="noop", args={}),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    call_dict = wire["steps"][0]
+    assert call_dict == {
+        "kind": "call", "pipeline": "sub-flow",
+        "pass": ["brief", "budget"], "output": "result",
+    }
+    assert "pass_" not in call_dict  # the wire key is the Appendix-B `pass`
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_call_parses_from_dsl():
+    """Tier 1: the DSL ``call`` step parses to a ``CallStep`` (moved out of the
+    not-yet-supported set) with ``pass``/``output`` honored."""
+    text = """
+pipeline: outer
+steps:
+  - call:
+      pipeline: inner
+      pass: [brief]
+      output: summary
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    assert parsed.steps == [CallStep(pipeline="inner", pass_=["brief"], output="summary")]
+
+
+def test_call_dsl_requires_literal_pipeline_name():
+    """Tier 1: an empty/missing ``pipeline`` name is a parse error (Hard rule 2 —
+    the target is a static literal, and it must be present)."""
+    missing = "pipeline: o\nsteps:\n  - call:\n      pass: [x]\n"
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(missing, SchemaRegistry())
+
+
+def test_call_analyzer_facet_registered_and_passes_literal_target():
+    """Tier 1: the P4 analyzer facet for ``call`` is registered and returns no
+    problems for a valid literal target — the seam future primitives must extend."""
+    assert analyze_step(CallStep(pipeline="inner", pass_=[], output=None)) == []
+    # A pathological empty target (constructor-bypassing the parser) is flagged.
+    problems = analyze_step(CallStep(pipeline="", pass_=[], output=None))
+    assert problems and "literal pipeline name" in problems[0]

--- a/tests/test_pipeline_dispatch_table_equivalence.py
+++ b/tests/test_pipeline_dispatch_table_equivalence.py
@@ -1,0 +1,80 @@
+"""Tier 2: OS invariant — the dispatch-table restructure is behaviour-preserving.
+
+The executor's per-step ``isinstance`` chain became a type-keyed ``STEP_DISPATCH``
+table, and serde's encode/decode ``isinstance``/``kind==`` chains became
+``ENCODERS``/``DECODERS`` tables (the seam that lets a future primitive ADD an entry
+instead of editing a shared branch). This test pins that the three EXISTING kinds
+(``transform``/``tool``/``agent``) execute and serialize IDENTICALLY across the
+refactor — same threaded pipe data, same flat ``str(i)`` recovery keys, same named
+stores, same JSON round-trip — so the restructure is provably byte-identical for the
+kinds it touched, not a behaviour change riding along with the seam.
+
+Real ``expr`` evaluator + real serde JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    Pipeline,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def _echo_dispatch(name: str, args: dict) -> dict:
+    assert name == "echo"
+    return {"echoed": args["v"]}
+
+
+@pytest.mark.asyncio
+async def test_transform_tool_transform_threads_identically_through_dispatch_table():
+    """Tier 2: a transform -> tool -> transform pipeline threads pipe data + named
+    stores and records FLAT ``str(i)`` keys exactly as the pre-restructure linear
+    loop did — the dispatch table changed HOW a step is selected, not WHAT it does."""
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="ctx.seed * 2", output="doubled"),
+            ToolStep(name="echo", args={"v": ExprRef("pipe")}, output="echoed"),
+            TransformStep(value="ctx.echoed.echoed + 1", output="final"),
+        ]
+    )
+    result = await PipelineExecutor().run(
+        pipeline, {"seed": 21},
+        tool_dispatch=_echo_dispatch, state_log=None, run_id="run-equiv",
+    )
+
+    assert result.pipe_data == 43
+    assert result.named_stores == {
+        "seed": 21, "doubled": 42, "echoed": {"echoed": 42}, "final": 43,
+    }
+    # Flat linear keys — no dotted paths appear for a pipeline with no `call`.
+    assert result.completed_step_results == {
+        "0": 42, "1": {"echoed": 42}, "2": 43,
+    }
+    assert result.step_index == 3
+
+
+def test_serde_round_trip_identical_through_dispatch_tables():
+    """Tier 2: every existing kind round-trips (dataclass -> dict -> JSON ->
+    dataclass) unchanged through ``ENCODERS``/``DECODERS`` — the marker collision
+    guard and ExprRef handling are preserved by the table form."""
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="ctx.a + 1", output="t"),
+            ToolStep(
+                name="echo",
+                args={"v": ExprRef("ctx.t"), "n": 3, "nested": {"deep": [1, "two"]}},
+                output="w",
+                schema="OutShape",
+            ),
+        ],
+        description="equivalence round-trip",
+    )
+    wire = json.loads(json.dumps(pipeline_to_dict(pipeline)))
+    assert pipeline_from_dict(wire) == pipeline


### PR DESCRIPTION
**[lead-sonnet]** — Non-linear pipeline primitives FOUNDATION + the `call` primitive: the compositional substrate every future non-linear primitive (`for_each`/`parallel`/`fold`/`match`) plugs into, bundled with `call` as its first real consumer + recovery-test vehicle. `part of #2187`.

Locked-architecture implementation from the design trace (Phase-1 plan acked by lead-coder before impl). Two commits for clean review/bisect.

## Commit 1 — dispatch-table restructure (byte-identical, 3 kinds)
The executor's per-step `isinstance` chain → a type-keyed `STEP_DISPATCH` with a uniform `(_StepInvocation) -> (result, durable, completed_step_results)` runner signature; serde's encode/decode chains → `ENCODERS`/`DECODERS` tables — mirroring the parser's already-dict-shaped `_STEP_PARSERS`. This is the seam that lets each future primitive ADD one registry entry across the four sibling tables instead of editing a shared `elif` block. **Behaviour-preserving for `transform`/`tool`/`agent`**, proven by a new equivalence test (identical threaded pipe data, flat `str(i)` recovery keys, named stores, JSON round-trip) plus the full existing executor/driver/parser suites.

## Commit 2 — `call` + `_run_scope` + dotted-path recovery + analyzer facet (R7)
- **`_run_scope`**: one recursive sub-scope executor used both live and on resume. A `CallStep` runs its REGISTERED callee synchronously, seeding a FRESH context from `pass:[...]` (structural isolation — the callee cannot see an unpassed caller store) and the caller's pipe-data at the call site (Hard rule 5). The callee's FINAL output threads out as the call's N2 return value (re-entering the caller's uniform threading unchanged); callee failure fails the call step.
- **Dotted-path R4 recovery** (the load-bearing decision): `completed_step_results` keys generalize from flat `str(i)` to a dotted scope path — a call's callee sub-steps key `f"{i}.call.{j}"` (nesting composes: `"3.call.1.call.0"`); the call's own N2 result keys at `str(i)` once the callee completes. The persisted outer `named_stores`/`pipe_data`/`step_index` stay the OUTER scope's throughout a call (**`pass:[...]` isolation on the recovery axis too** — no callee-local leakage), and the callee's local state is reconstructed at resume by re-walking its definition and replaying the dotted keys by **EXACT key membership** (never a string-prefix scan — robust as the key grammar grows, per lead's hardening note). A mid-call crash resumes replaying finished callee sub-steps EXACTLY-ONCE (side effects do not re-fire).
- **`call` added to all four sibling tables**: executor `STEP_DISPATCH`, serde `ENCODERS`/`DECODERS` (`pass_` field ⇄ wire key `"pass"` — the one field-name/wire-key split), parser `_STEP_PARSERS` (moved out of the unsupported set), and the new `analyzer.py` `ANALYZER_FACETS` (P4 seam + call's literal-target facet — future primitives MUST register a facet).
- **Driver wiring**: `run_turn` threads `pipeline_registry=host.get_pipeline_registry()` into `executor.run`/`resume` (the single production seam) — integrated as a sibling of #2576's `schema_registry` threading (rebased onto f9ed4b6f). `schema_registry` already flows into callee steps via the shared `_RunDeps`, so a callee's `verify:schema` steps work by construction.

## CLAUDE.md recovery gate
Truncate-falsify test: crash **mid-callee** (sub-step 0 wrote a line + recorded its R4 gen; sub-step 1 failed before its side effect), truncate the WAL below the source events, resume from the generation FILE, and assert the completed callee sub-step **replays exactly-once** (its file-append side effect does NOT re-fire) while only the remaining sub-step executes and the callee's output threads out. Modeled on `test_pipeline_is2_driver_session.py`'s truncate-falsify. Plus: call happy-path (pass scoping, pipe-at-call-site, N2 threading, dotted keys), pass-isolation deny, callee-failure-fails-caller, unregistered target, mid-call snapshot isolation, full-completion replay, serde round-trip, DSL parse, analyzer facet.

## Scope note
Production registration of *named* callees is itself a not-yet-built slice (`registry.py`: "registration is PROGRAMMATIC in this slice"). So `call`'s live/recovery behavior is proven via direct-executor tests with an explicit `PipelineRegistry` (the same discipline IS-2's truncate-falsify uses). The driver seam is wired (`get_pipeline_registry()` confirmed available); populating that registry for cross-session `call` resolution rides on the future registration path.

## Gates (local)
- `ruff check src tests` — clean.
- `test_tier_audit.py --strict` (3 new test files) — 13/13 OK, 0 Tier-4.
- `verify_module_docstrings.py` (5 changed src) — OK.
- `pytest` — 214 pipeline tests pass (+ new call/recovery tests pass in ISOLATION too). Full-suite: the only failures are pre-existing `mcp`/`web`/`a2a` optional-dependency env gaps (`ModuleNotFoundError: No module named 'mcp'`), none touching pipeline code — CI (full deps) runs them green.

## Test plan
- [x] Byte-identical equivalence of the 3 existing kinds through the dispatch tables (`test_pipeline_dispatch_table_equivalence.py`).
- [x] `call` happy path: callee runs, `pass:[...]` scoping honored, pipe-at-call-site, callee-final output threads out.
- [x] `pass:[...]` isolation deny + callee-failure-fails-caller + unregistered-target-fails-cleanly.
- [x] CLAUDE.md truncate-falsify: mid-callee crash → WAL truncated below source → resume from invocation/gen files → completed callee sub-step replays exactly-once (side effect does not re-fire).
- [x] New recovery/invariant tests pass in ISOLATION (ordering cannot mask).
- [x] Rebased onto f9ed4b6f; #2576's `schema_registry` threading kept intact alongside `pipeline_registry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
