### PR TITLE
feat(pipeline): match primitive (runtime-selected sub-pipeline)

### DIFF
--- a/src/reyn/core/pipeline/analyzer.py
+++ b/src/reyn/core/pipeline/analyzer.py
@@ -9,15 +9,15 @@ monolithic walker — each primitive registers the check it is responsible for,
 and the registry is the single place a caller (a future ``analyze_pipeline``
 walker, or the IS-4 inline static-analysis gate) folds them together.
 
-This module is the SEAM plus the first entry (``call``'s facet). It is
-deliberately minimal in this slice: :data:`ANALYZER_FACETS` maps a step
-dataclass type to a facet function returning a list of human-readable problem
-strings ( empty = the step passed its facet), and :func:`analyze_step` looks one
-up. There is no full pipeline walker wired to consume it yet — that arrives with
-the primitives whose facets have real teeth (cost / spawn-tree bounds). What
-matters now is that the registration point EXISTS and ``call`` is registered, so
-every future primitive MUST add its facet here rather than bolting analysis on
-later.
+This module is the SEAM plus its first two entries (``call``'s and ``match``'s
+facets). It is deliberately minimal in this slice: :data:`ANALYZER_FACETS` maps
+a step dataclass type to a facet function returning a list of human-readable
+problem strings ( empty = the step passed its facet), and :func:`analyze_step`
+looks one up. There is no full pipeline walker wired to consume it yet — that
+arrives with the primitives whose facets have real teeth (cost / spawn-tree
+bounds). What matters now is that the registration point EXISTS and
+``call``/``match`` are registered, so every future primitive MUST add its
+facet here rather than bolting analysis on later.
 
 ``call``'s facet is intentionally thin: the target is a STATIC literal pipeline
 name (Hard rule 2), so the only thing to confirm structurally is that it IS a
@@ -27,12 +27,20 @@ want (the callee is registered; the transitive spawn-tree/cost bound folds the
 callee's envelope into the caller's — S5) need cross-pipeline context the
 per-step facet does not have, and land with the analyzer walker + registry
 plumbing, not here.
+
+``match``'s facet has the real path-enumeration teeth this module's docstring
+promises above: it walks every case LABEL (plus ``default``) and confirms each
+target is a non-empty STATIC literal pipeline name (Hard rule 2 — the runtime
+``on`` VALUE only ever selects a LABEL). That enumeration is the seed a future
+cross-pipeline analyzer walker needs to fold every reachable case's transitive
+cost/spawn-tree bound into the caller's own — same "not here yet, but the
+registration point exists" posture as ``call``'s deeper checks.
 """
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
-from reyn.core.pipeline.executor import CallStep
+from reyn.core.pipeline.executor import CallStep, MatchStep
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.executor import Step
@@ -50,6 +58,29 @@ def _call_facet(step: "CallStep") -> "list[str]":
     return problems
 
 
+def _match_facet(step: "MatchStep") -> "list[str]":
+    """``match``'s real P4 contribution (more than ``call``'s placeholder):
+    enumerate every (LABEL -> pipeline) case target plus ``default``, and
+    confirm each is a non-empty STATIC literal pipeline name (Hard rule 2 —
+    the runtime ``on`` VALUE only ever selects a LABEL, never a target).
+    Also flags an empty ``cases`` mapping (the parser already rejects this,
+    but the facet stays defensive for a hand-built ``MatchStep``, e.g. one
+    round-tripped through ``serde``). Returns problem strings (empty = OK)."""
+    problems: "list[str]" = []
+    if not step.cases:
+        problems.append("match step has no cases — at least one LABEL -> pipeline is required")
+    targets = dict(step.cases)
+    if step.default is not None:
+        targets["default"] = step.default
+    for label, case in targets.items():
+        if not isinstance(case.pipeline, str) or not case.pipeline:
+            problems.append(
+                f"match case {label!r} target must be a non-empty literal "
+                f"pipeline name, got {case.pipeline!r}"
+            )
+    return problems
+
+
 # Facet registry: step type -> its static-analysis check. A future primitive
 # ADDS an entry here (mirroring the executor's ``STEP_DISPATCH``, serde's
 # ``ENCODERS``/``DECODERS``, and the parser's ``_STEP_PARSERS``) — the P4
@@ -57,6 +88,7 @@ def _call_facet(step: "CallStep") -> "list[str]":
 # structural.
 ANALYZER_FACETS: "dict[type, Callable[[Step], list[str]]]" = {
     CallStep: _call_facet,
+    MatchStep: _match_facet,
 }
 
 

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -3,10 +3,12 @@ compositional foundation (``_run_scope`` + dotted-path recovery + ``call``).
 
 The executor for ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a
 sequence of ``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell",
-...)``) / ``agent`` (R5) steps, plus the first COMPOSITIONAL primitive, ``call``
-(R7). Still out of scope for this slice: `for_each`/`parallel`/`fold`/`match`/
-`refine` — those are later primitives that plug into the SAME dispatch + scope
-machinery this module now exposes.
+...)``) / ``agent`` (R5) steps, plus two COMPOSITIONAL primitives: ``call`` (R7,
+a STATIC callee) and ``match`` (``call``'s runtime-selected sibling — the ``on``
+VALUE picks a LABEL, never a target; see :class:`MatchStep`). Still out of scope
+for this slice: `for_each`/`parallel`/`fold`/`refine` — those are later
+primitives that plug into the SAME dispatch + scope machinery this module now
+exposes.
 
 **Dispatch tables (R7 — the parallel-primitive seam).** Step execution is a
 ``dict``-dispatch keyed by the step's dataclass type
@@ -175,7 +177,55 @@ class CallStep:
     output: "str | None" = None
 
 
-Step = Union[TransformStep, ToolStep, AgentStep, CallStep]
+@dataclass(frozen=True)
+class MatchCase:
+    """One ``match`` case target: a REGISTERED sub-pipeline (``pipeline``, a
+    STATIC literal — Hard rule 2, never a runtime expression) plus its own
+    ``pass_`` caller-store projection, run exactly like a ``call`` step's
+    callee (see :class:`CallStep`) once this case's LABEL is selected."""
+
+    pipeline: str
+    pass_: "list[str]" = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class MatchStep:
+    """A COMPOSITIONAL step (R7 — ``call``'s runtime-selected sibling):
+    evaluate ``on`` (an R1 expression source, resolved exactly like
+    ``TransformStep.value``) against the current context to get a VALUE, then
+    select the :class:`MatchCase` whose LABEL string-equals that value —
+    ``default`` runs when no case LABEL matches, and a step with no matching
+    case and no ``default`` fails cleanly (Appendix B: ``match = {on: PATH,
+    cases: {LABEL: {pipeline: LIT, pass: [NAME*]}}+, default?: {pipeline: LIT,
+    pass: [NAME*]}, output?: NAME}``).
+
+    - Hard rule 2: every case/``default`` target is a STATIC literal pipeline
+      name — the runtime VALUE only ever selects a LABEL, never a target.
+    - Hard rule 7: ``on`` should reference a schema-declared field; the
+      analyzer facet (P4) warns when it does not (see ``analyzer.py``).
+    - the SELECTED case runs exactly like ``call``'s callee: its own
+      ``pass_`` projects the caller's named stores into an isolated
+      sub-context, the callee's first step sees the caller's pipe-data at the
+      match site (Hard rule 5), and the callee's FINAL step output is this
+      ``match`` step's N2 return value.
+    - a non-string ``on`` value is stringified the same way
+      ``_interpolate_prompt`` stringifies a non-string interpolation value,
+      before the LABEL string-equality comparison — case LABELs are always
+      strings (YAML mapping keys), so this is the one coercion needed to let
+      e.g. a boolean or numeric ``on`` value select a LABEL at all.
+
+    Recovery: the selected case's callee runs under a dotted scope
+    (``f"{i}.match.{j}"``) — IDENTICAL mechanism to ``call`` (single chosen
+    sub-scope; the other, unselected cases never execute and so leave no
+    dotted keys at all)."""
+
+    on: str
+    cases: "dict[str, MatchCase]"
+    default: "MatchCase | None" = None
+    output: "str | None" = None
+
+
+Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep]
 
 
 @dataclass(frozen=True)
@@ -438,6 +488,77 @@ async def _run_call_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
     return final_pipe, any_durable, completed_step_results
 
 
+def _stringify_match_value(value: Any) -> str:
+    """Coerce an evaluated ``on`` value to the string a case LABEL
+    string-equality-compares against — same non-string stringification
+    :func:`_interpolate_prompt` applies, so ``true``/``42``/etc. select a
+    LABEL the same way they'd splice into a prompt."""
+    return value if isinstance(value, str) else str(value)
+
+
+async def _run_match_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """``call``'s runtime-selected sibling (R7): evaluate ``on`` against the
+    context, select the :class:`MatchCase` whose LABEL string-equals the
+    result (falling back to ``default``, else failing the step), then run
+    that ONE case's callee exactly like :func:`_run_call_step` — same
+    ``pass_`` isolation, same ``f"{label}.match"`` dotted sub-scope, same
+    Hard-rule-5 pipe-data-at-call-site, same N2 final-output threading."""
+    step: MatchStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    try:
+        raw_value = evaluate_expr(step.on, inv.context)
+    except ExprEvalError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (match) failed evaluating 'on': {exc}"
+        ) from exc
+    label = _stringify_match_value(raw_value)
+
+    case = step.cases.get(label, step.default)
+    if case is None:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (match) value {raw_value!r} (label {label!r}) "
+            f"matched no case in {sorted(step.cases)!r} and no 'default' was given"
+        )
+
+    if deps.pipeline_registry is None:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (match label {label!r}) requires a "
+            "pipeline_registry to resolve its target, but none was passed to "
+            "run/resume"
+        )
+    try:
+        callee = deps.pipeline_registry.get(case.pipeline)
+    except PipelineNotFoundError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (match label {label!r}) target pipeline "
+            f"{case.pipeline!r} is not registered"
+        ) from exc
+
+    outer_stores = inv.context["ctx"]
+    sub_stores: "dict[str, Any]" = {}
+    for name in case.pass_:
+        if name not in outer_stores:
+            raise PipelineExecutionError(
+                f"step {inv.step_label} (match label {label!r} -> {case.pipeline!r}) "
+                f"pass: names {name!r}, which is not in the caller's named stores"
+            )
+        sub_stores[name] = outer_stores[name]
+
+    final_pipe, _final_stores, completed_step_results, any_durable = await (
+        inv.executor._run_scope(
+            callee.steps,
+            scope_prefix=f"{inv.step_label}.match",
+            seed_named_stores=sub_stores,
+            # Hard rule 5: the callee's first step gets the caller's pipe-data.
+            seed_pipe_data=inv.context["pipe"],
+            completed_step_results=inv.completed_step_results,
+            deps=deps,
+            record=inv.record,
+        )
+    )
+    return final_pipe, any_durable, completed_step_results
+
+
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
 # entry here (+ serde/parser/analyzer) rather than editing a shared elif chain.
 STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
@@ -445,6 +566,7 @@ STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool
     ToolStep: _run_tool_step,
     AgentStep: _run_agent_step,
     CallStep: _run_call_step,
+    MatchStep: _run_match_step,
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
@@ -453,6 +575,7 @@ _STEP_KINDS: "dict[type, str]" = {
     ToolStep: "tool",
     AgentStep: "agent",
     CallStep: "call",
+    MatchStep: "match",
 }
 
 
@@ -733,6 +856,8 @@ __all__ = [
     "ToolStep",
     "AgentStep",
     "CallStep",
+    "MatchCase",
+    "MatchStep",
     "Step",
     "Pipeline",
     "PipelineResult",

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -4,14 +4,16 @@ Implements the surface grammar in Appendix B of
 ``docs/proposals/reyn-pipeline-spec-v0.8.md`` (lines 706-835), narrowed to
 exactly the subset :class:`reyn.core.pipeline.executor.PipelineExecutor` can
 run today: a **linear** sequence of ``transform`` / ``tool`` / ``shell`` /
-``agent`` steps plus the first COMPOSITIONAL primitive ``call`` (R7 — runs a
-registered sub-pipeline synchronously), plus the pipeline-level ``description``.
-``for_each`` / ``parallel`` / ``fold`` / ``match`` / ``refine``, and the
-pipeline-level ``input`` / ``defaults`` blocks are all part of the full v0.8
-grammar but have no runtime yet — this parser refuses to accept them rather
-than silently dropping them into a pipeline that "parses" but then either
-crashes at run time in a confusing place or (worse) quietly loses the
-author's intent. Every construct not yet executable raises
+``agent`` steps plus two COMPOSITIONAL primitives — ``call`` (R7 — runs a
+STATIC registered sub-pipeline synchronously) and ``match`` (``call``'s
+runtime-selected sibling: a runtime VALUE picks a case LABEL, whose target
+stays a static literal) — plus the pipeline-level ``description``.
+``for_each`` / ``parallel`` / ``fold`` / ``refine``, and the pipeline-level
+``input`` / ``defaults`` blocks are all part of the full v0.8 grammar but
+have no runtime yet — this parser refuses to accept them rather than
+silently dropping them into a pipeline that "parses" but then either crashes
+at run time in a confusing place or (worse) quietly loses the author's
+intent. Every construct not yet executable raises
 :class:`PipelineParseError` naming it explicitly, so authoring a
 not-yet-supported pipeline fails at parse time, at the DSL text, not deep in
 an executor stack trace.
@@ -72,6 +74,7 @@ from one file per pipeline).
 """
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import yaml
@@ -80,6 +83,8 @@ from reyn.core.pipeline.executor import (
     AgentStep,
     CallStep,
     ExprRef,
+    MatchCase,
+    MatchStep,
     Pipeline,
     Step,
     ToolStep,
@@ -97,7 +102,7 @@ class PipelineParseError(ValueError):
     current linear executor can run — malformed YAML, a malformed R1
     expression, or (most commonly) a construct that is valid Appendix-B
     grammar but not yet supported by `PipelineExecutor` (`for_each`,
-    `parallel`, `fold`, `match`, `call`, `refine`, pipeline-level `input`/
+    `parallel`, `fold`, `refine`, pipeline-level `input`/
     `defaults`, or a per-step field the executor does not consume)."""
 
 
@@ -120,10 +125,42 @@ class _ExprTag:
 
 
 class _PipelineLoader(yaml.SafeLoader):
-    """`yaml.SafeLoader` plus the `!expr` tag constructor. A dedicated
-    subclass (rather than mutating `SafeLoader` globally) keeps this
-    parser's tag vocabulary from leaking into unrelated YAML loads
-    elsewhere in the process."""
+    """`yaml.SafeLoader` plus the `!expr` tag constructor, minus YAML 1.1's
+    `on`/`off`/`yes`/`no` implicit-bool resolution ("the Norway problem"). A
+    dedicated subclass (rather than mutating `SafeLoader` globally) keeps
+    this parser's tag vocabulary / resolver narrowing from leaking into
+    unrelated YAML loads elsewhere in the process.
+
+    The bool-resolver narrowing matters because Appendix B's `match` step
+    names its selector field literally `on` (`match = {on: PATH, cases:
+    ...}`) — under `SafeLoader`'s stock YAML 1.1 resolver, an unquoted `on:`
+    key (or `off`/`yes`/`no`) resolves to the Python `bool` `True`/`False`
+    instead of the string key/value the DSL author wrote, silently breaking
+    every `match` step (and any tool/shell arg literally named or valued
+    `on`/`off`/`yes`/`no`) unless every author remembers to quote it. This
+    loader instead resolves `bool` only for YAML 1.2 core-schema spellings
+    (`true`/`True`/`TRUE`/`false`/`False`/`FALSE`) — `on`/`off`/`yes`/`no`
+    pass through as plain strings, matching how most modern YAML tooling
+    (e.g. `ruamel.yaml`'s default) already resolved this ambiguity."""
+
+
+_BOOL_TAG = "tag:yaml.org,2002:bool"
+# `SafeLoader` registers ONE shared bool regex (matching
+# yes/Yes/YES/no/No/NO/true/True/TRUE/false/False/FALSE/on/On/ON/off/Off/OFF)
+# under EVERY first-character bucket it could start with. Dropping the entry
+# from just the `on`/`off`/`yes`/`no` buckets (o/O/y/Y/n/N) — while leaving
+# the t/T/f/F buckets (`true`/`false`) untouched — is enough: resolution
+# looks up by the scalar's OWN first character, so `"true"` still hits the
+# t-bucket entry while `on`/`off`/`yes`/`no` no longer match anything and
+# fall through to plain strings.
+_PipelineLoader.yaml_implicit_resolvers = {
+    first_char: [
+        (tag, regexp)
+        for tag, regexp in resolvers
+        if not (tag == _BOOL_TAG and first_char in "oOyYnN")
+    ]
+    for first_char, resolvers in _PipelineLoader.yaml_implicit_resolvers.items()
+}
 
 
 def _construct_expr_tag(loader: yaml.SafeLoader, node: yaml.Node) -> _ExprTag:
@@ -134,13 +171,14 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 
 # Constructs the union grammar's non-linear step kinds accept as *keys* so a
 # document using them gets a clear "not yet supported" error instead of a
-# generic "unknown step type". ``call`` is now SUPPORTED (R7) — it moved out of
-# this set into ``_STEP_PARSERS``.
-_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel", "fold", "match")
+# generic "unknown step type". ``call``/``match`` are now SUPPORTED (R7) —
+# they moved out of this set into ``_STEP_PARSERS``.
+_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel", "fold")
 _LINEAR_STEP_KINDS = ("transform", "tool", "shell", "agent")
-# ``call`` is compositional, not linear, but it IS executable — listed separately
-# so error text distinguishes "the linear kinds" from the full supported set.
-_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call",)
+# ``call``/``match`` are compositional, not linear, but ARE executable —
+# listed separately so error text distinguishes "the linear kinds" from the
+# full supported set.
+_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match")
 _ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has
@@ -213,6 +251,8 @@ _TOOL_KEYS = frozenset({"name", "args", "schema", "output"})
 _SHELL_KEYS = frozenset({"command", "schema", "output"})
 _AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "output"})
 _CALL_KEYS = frozenset({"pipeline", "pass", "output"})
+_MATCH_KEYS = frozenset({"on", "cases", "default", "output"})
+_MATCH_CASE_KEYS = frozenset({"pipeline", "pass"})
 
 
 def _parse_transform_step(body: "dict[str, Any]") -> TransformStep:
@@ -310,12 +350,61 @@ def _parse_call_step(body: "dict[str, Any]") -> CallStep:
     return CallStep(pipeline=name, pass_=list(raw_pass), output=output)
 
 
+def _parse_match_case(body: Any, *, where: str) -> MatchCase:
+    """A ``match`` case/``default`` body: ``{pipeline: LIT, pass: [NAME*]}`` —
+    the SAME shape (and Hard-rule-2 static-literal-target rule) as a ``call``
+    step's own ``{pipeline, pass}``, just nested under a case LABEL / the
+    ``default`` key instead of being the step body itself."""
+    if not isinstance(body, dict):
+        _fail(f"{where}: expected a mapping {{pipeline, pass?}}, got {type(body).__name__}")
+    _reject_unknown_keys(body, _MATCH_CASE_KEYS, where=where)
+    if "pipeline" not in body:
+        _fail(f"{where}: missing required field 'pipeline'")
+    name = body["pipeline"]
+    if not isinstance(name, str) or not name:
+        _fail(f"{where} 'pipeline': expected a non-empty literal pipeline name, got {name!r}")
+    raw_pass = body.get("pass") or []
+    if not isinstance(raw_pass, list) or not all(isinstance(n, str) for n in raw_pass):
+        _fail(f"{where} 'pass': expected a list of store-name strings, got {raw_pass!r}")
+    return MatchCase(pipeline=name, pass_=list(raw_pass))
+
+
+def _parse_match_step(body: "dict[str, Any]") -> MatchStep:
+    """``match = {on: PATH, cases: {LABEL: {pipeline: LIT, pass: [NAME*]}}+,
+    default?: {pipeline: LIT, pass: [NAME*]}, output?: NAME}`` (Appendix B).
+    ``on`` is an R1 expression source (same as ``transform.value``) whose
+    RUNTIME VALUE selects a case LABEL by string equality — every case/
+    ``default`` TARGET stays a static literal (Hard rule 2)."""
+    _reject_unknown_keys(body, _MATCH_KEYS, where="match step")
+    if "on" not in body:
+        _fail("match step: missing required field 'on'")
+    on = _validate_expr_source(body["on"], where="match step 'on'")
+    raw_cases = body.get("cases")
+    if not isinstance(raw_cases, dict) or not raw_cases:
+        _fail("match step: 'cases' must be a non-empty mapping of LABEL -> {pipeline, pass?}")
+    cases = {
+        label: _parse_match_case(case_body, where=f"match step case {label!r}")
+        for label, case_body in raw_cases.items()
+    }
+    raw_default = body.get("default")
+    default = (
+        _parse_match_case(raw_default, where="match step 'default'")
+        if raw_default is not None
+        else None
+    )
+    output = body.get("output")
+    if output is not None and not isinstance(output, str):
+        _fail(f"match step 'output': expected a store-name string, got {type(output).__name__}")
+    return MatchStep(on=on, cases=cases, default=default, output=output)
+
+
 _STEP_PARSERS = {
     "transform": _parse_transform_step,
     "tool": _parse_tool_step,
     "shell": _parse_shell_step,
     "agent": _parse_agent_step,
     "call": _parse_call_step,
+    "match": _parse_match_step,
 }
 
 

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -40,6 +40,8 @@ from reyn.core.pipeline.executor import (
     AgentStep,
     CallStep,
     ExprRef,
+    MatchCase,
+    MatchStep,
     Pipeline,
     Step,
     ToolStep,
@@ -150,6 +152,37 @@ def _decode_call(data: "dict[str, Any]") -> "CallStep":
     )
 
 
+def _encode_match_case(case: "MatchCase") -> "dict[str, Any]":
+    return {"pipeline": case.pipeline, "pass": list(case.pass_)}
+
+
+def _decode_match_case(data: "dict[str, Any]") -> "MatchCase":
+    return MatchCase(pipeline=data["pipeline"], pass_=list(data.get("pass") or []))
+
+
+def _encode_match(step: "MatchStep") -> "dict[str, Any]":
+    return {
+        "kind": "match",
+        "on": step.on,
+        "cases": {label: _encode_match_case(case) for label, case in step.cases.items()},
+        "default": _encode_match_case(step.default) if step.default is not None else None,
+        "output": step.output,
+    }
+
+
+def _decode_match(data: "dict[str, Any]") -> "MatchStep":
+    raw_default = data.get("default")
+    return MatchStep(
+        on=data["on"],
+        cases={
+            label: _decode_match_case(case)
+            for label, case in dict(data.get("cases") or {}).items()
+        },
+        default=_decode_match_case(raw_default) if raw_default is not None else None,
+        output=data.get("output"),
+    )
+
+
 # Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
 # A future primitive ADDS one entry to each (mirroring the executor's
 # ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
@@ -159,12 +192,14 @@ ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
     ToolStep: _encode_tool,
     AgentStep: _encode_agent,
     CallStep: _encode_call,
+    MatchStep: _encode_match,
 }
 DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "transform": _decode_transform,
     "tool": _decode_tool,
     "agent": _decode_agent,
     "call": _decode_call,
+    "match": _decode_match,
 }
 
 

--- a/tests/test_pipeline_match_primitive.py
+++ b/tests/test_pipeline_match_primitive.py
@@ -1,0 +1,318 @@
+"""Tier 2: OS invariant — the `match` compositional primitive + dotted-path R7
+recovery.
+
+Covers `call`'s runtime-selected sibling (Appendix B `match = {on: PATH, cases:
+{LABEL: {pipeline: LIT, pass: [NAME*]}}+, default?: {...}, output?: NAME}`,
+built on the same `_run_scope` + dotted-path recovery + dispatch-table
+foundation `call` uses):
+
+  1. happy path — the ``on`` VALUE selects a case LABEL by string equality;
+     that ONE case's REGISTERED callee runs synchronously exactly like
+     ``call``'s callee (``pass:[...]`` projection, pipe-data-at-call-site,
+     N2 final-output threading).
+  2. no case matches but ``default`` is present — ``default``'s callee runs.
+  3. no case matches and no ``default`` — the step fails cleanly.
+  4. ``pass:[...]`` isolation on the selected case.
+  5. the CLAUDE.md-mandated truncate-falsify recovery gate: crash mid-selected-
+     case, truncate the WAL below the source events, resume from the
+     generation FILE, and prove the completed case sub-steps replay
+     exactly-once while only the remaining sub-step executes.
+  6. an unregistered case-target pipeline fails cleanly.
+
+Real ``StateLog`` + ``PipelineRegistry`` + real generation files throughout;
+the recovery tests build the executor directly (the same discipline as
+``call``'s truncate-falsify test) — no mocks, no private-state assertions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    MatchCase,
+    MatchStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.registry import PipelineRegistry
+
+# ── happy path: on-value selects a case, pass:[...] scoping, N2 out ─────────
+
+
+@pytest.mark.asyncio
+async def test_match_selects_case_by_on_value_and_threads_final_output():
+    """Tier 2: a ``match`` evaluates ``on``, selects the case whose LABEL
+    string-equals the value, runs ONLY that case's callee (``pass:[brief]``
+    projects ONLY ``brief`` — the caller's other store is invisible), the
+    callee's first step sees the caller's pipe-data via bare ``pipe`` (Hard
+    rule 5), and the callee's final output becomes the ``match`` step's
+    return value + named output."""
+    registry = PipelineRegistry()
+    registry.register(
+        "on-cat",
+        Pipeline(steps=[TransformStep(value="'cat: ' + pipe", output="r")]),
+    )
+    registry.register(
+        "on-dog",
+        Pipeline(steps=[TransformStep(value="'dog: ' + pipe", output="r")]),
+    )
+
+    outer = Pipeline(steps=[
+        TransformStep(value="ctx.kind", output="carried"),  # pipe_data = "cat"
+        MatchStep(
+            on="ctx.kind",
+            cases={
+                "cat": MatchCase(pipeline="on-cat", pass_=["brief"]),
+                "dog": MatchCase(pipeline="on-dog", pass_=["brief"]),
+            },
+            output="matched",
+        ),
+        TransformStep(value="ctx.matched + '!'", output="final"),
+    ])
+
+    result = await PipelineExecutor().run(
+        outer,
+        {"kind": "cat", "brief": "hi", "secret": "nope"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None,
+        run_id="run-match-happy",
+        pipeline_registry=registry,
+    )
+
+    assert result.named_stores["matched"] == "cat: cat"
+    assert result.named_stores["final"] == "cat: cat!"
+    assert result.pipe_data == "cat: cat!"
+    # Outer flat key for the match's N2 result; selected case's sub-step under
+    # the dotted scope. The UNSELECTED case ("dog") never ran — no dotted key.
+    assert result.completed_step_results["1"] == "cat: cat"
+    assert result.completed_step_results["1.match.0"] == "cat: cat"
+
+
+@pytest.mark.asyncio
+async def test_match_runs_default_when_no_case_matches():
+    """Tier 2: an ``on`` value matching no case LABEL runs ``default``'s
+    callee instead."""
+    registry = PipelineRegistry()
+    registry.register(
+        "known",
+        Pipeline(steps=[TransformStep(value="'known'", output="r")]),
+    )
+    registry.register(
+        "fallback",
+        Pipeline(steps=[TransformStep(value="'fallback'", output="r")]),
+    )
+    outer = Pipeline(steps=[
+        MatchStep(
+            on="ctx.kind",
+            cases={"known": MatchCase(pipeline="known", pass_=[])},
+            default=MatchCase(pipeline="fallback", pass_=[]),
+            output="out",
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, {"kind": "unrecognized"},
+        tool_dispatch=lambda *_a, **_k: None, state_log=None,
+        run_id="run-match-default", pipeline_registry=registry,
+    )
+    assert result.named_stores["out"] == "fallback"
+
+
+@pytest.mark.asyncio
+async def test_match_fails_cleanly_when_no_case_and_no_default():
+    """Tier 2: an ``on`` value matching no case and no ``default`` present
+    fails the step with a clear error, not a silent no-op or KeyError."""
+    outer = Pipeline(steps=[
+        MatchStep(on="ctx.kind", cases={"known": MatchCase(pipeline="known", pass_=[])}),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            outer, {"kind": "unrecognized"},
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-match-nodefault", pipeline_registry=PipelineRegistry(),
+        )
+    assert "matched no case" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_match_pass_isolation_denies_unpassed_store():
+    """Tier 2: the selected case's callee referencing a caller store NOT in
+    its own ``pass:[...]`` fails the step — structural, not silent None."""
+    registry = PipelineRegistry()
+    registry.register(
+        "leaky",
+        Pipeline(steps=[TransformStep(value="ctx.secret", output="x")]),
+    )
+    outer = Pipeline(steps=[
+        MatchStep(on="ctx.kind", cases={"x": MatchCase(pipeline="leaky", pass_=[])}, output="o"),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            outer, {"kind": "x", "secret": "s"},
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-match-iso", pipeline_registry=registry,
+        )
+
+
+@pytest.mark.asyncio
+async def test_selected_case_failure_fails_the_match_step():
+    """Tier 2: the selected case's callee step failure propagates out of the
+    ``match`` as a caller step failure (never silently swallowed)."""
+    registry = PipelineRegistry()
+    registry.register(
+        "boom",
+        Pipeline(steps=[TransformStep(value="ctx.missing_field", output="x")]),
+    )
+    outer = Pipeline(steps=[
+        MatchStep(on="ctx.kind", cases={"x": MatchCase(pipeline="boom", pass_=[])}, output="o"),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            outer, {"kind": "x"},
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-match-boom", pipeline_registry=registry,
+        )
+
+
+@pytest.mark.asyncio
+async def test_unregistered_match_case_target_fails_cleanly():
+    """Tier 2: a ``match`` case pointing at an unregistered pipeline name
+    fails the step with a clear error, not an unhandled KeyError."""
+    outer = Pipeline(steps=[
+        MatchStep(on="ctx.kind", cases={"x": MatchCase(pipeline="nope", pass_=[])}, output="o"),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            outer, {"kind": "x"},
+            tool_dispatch=lambda *_a, **_k: None, state_log=None,
+            run_id="run-match-missing", pipeline_registry=PipelineRegistry(),
+        )
+    assert "not registered" in str(exc.value)
+
+
+# ── dotted-path R4 recovery: the CLAUDE.md truncate-falsify gate ────────────
+
+
+def _append_dispatch(state_log: StateLog, out_file, crash):
+    """A REAL side-effecting tool (mirrors the `call` primitive's own recovery
+    test): each call appends a line to ``out_file`` AND a WAL entry (so R4 gens
+    land at distinct durable seqs). The exactly-once probe is the FILE — a
+    re-fired step leaves a duplicate line."""
+
+    async def _dispatch(name: str, args: dict):
+        assert name == "append"
+        line = str(args["line"])
+        if crash.get("line") == line:
+            raise RuntimeError(f"simulated crash before writing {line!r}")
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        await state_log.append("inbox_put", note=line)
+        return {"wrote": line}
+
+    return _dispatch
+
+
+def _two_write_case() -> Pipeline:
+    """A 2-step case callee that writes ``A`` then ``B`` — both side-effecting,
+    so a crash between them leaves exactly ``A`` on disk."""
+    return Pipeline(steps=[
+        ToolStep(name="append", args={"line": "A"}, output="a"),
+        ToolStep(name="append", args={"line": "B"}, output="b"),
+    ])
+
+
+def _outer_matching(case_name: str) -> Pipeline:
+    return Pipeline(steps=[
+        TransformStep(value="ctx.seed", output="carried"),
+        MatchStep(
+            on="ctx.kind",
+            cases={"go": MatchCase(pipeline=case_name, pass_=["seed"])},
+            output="match_out",
+        ),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_mid_match_snapshot_uses_dotted_keys_and_isolates_outer_stores(tmp_path):
+    """Tier 2: a genuine MID-CASE crash (sub-step 0 recorded, sub-step 1
+    failed) records the finished sub-step under ``f"{i}.match.0"`` and keeps
+    ``step_index`` at the OUTER ``match`` index — and the case's local ``a``
+    store does NOT appear in the persisted OUTER ``named_stores`` (pass:[...]
+    isolation on the recovery axis)."""
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"line": "B"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("case-pipe", _two_write_case())
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            _outer_matching("case-pipe"), {"seed": 5, "kind": "go"},
+            tool_dispatch=dispatch, state_log=state_log,
+            run_id="run-match-dotted", pipeline_registry=registry,
+        )
+    await state_log.flush()
+
+    snap = latest_pipeline_state("run-match-dotted", state_log)
+    assert "1.match.0" in snap["completed_step_results"]
+    assert "1.match.1" not in snap["completed_step_results"]
+    assert "1" not in snap["completed_step_results"]
+    assert snap["step_index"] == 1
+    assert "a" not in snap["named_stores"]
+    assert snap["named_stores"].get("carried") == 5
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_match_resumes_case_substeps_exactly_once(tmp_path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate for the `match` primitive. A
+    run crashes MID-SELECTED-CASE (sub-step 0 wrote ``A`` + recorded its R4
+    gen + dotted key; sub-step 1 failed before writing ``B``). The WAL is then
+    truncated BELOW those source events. ``resume`` must reconstruct from the
+    generation FILE, REPLAY the finished sub-step exactly-once (``A`` is NOT
+    written again), execute ONLY the remaining sub-step (writes ``B`` once),
+    and complete — threading the case's final output out. RED if a case
+    sub-step rode a truncatable WAL event, or if resume re-ran the whole
+    ``match`` instead of replaying the completed sub-steps."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"line": "B"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("case-pipe", _two_write_case())
+    outer = _outer_matching("case-pipe")
+
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            outer, {"seed": 5, "kind": "go"},
+            tool_dispatch=dispatch, state_log=state_log,
+            run_id="run-match-tf", pipeline_registry=registry,
+        )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
+
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "the case sub-step's WAL entry is truncated away"
+
+    crash.clear()
+    resumed = await PipelineExecutor().resume(
+        "run-match-tf", pipeline=outer,
+        tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+    )
+
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+    assert resumed.completed_step_results["1.match.0"] == {"wrote": "A"}
+    assert resumed.completed_step_results["1.match.1"] == {"wrote": "B"}
+    assert resumed.named_stores["match_out"] == {"wrote": "B"}
+    assert resumed.pipe_data == {"wrote": "B"}
+    assert resumed.step_index == 2

--- a/tests/test_pipeline_match_serde_parser_analyzer.py
+++ b/tests/test_pipeline_match_serde_parser_analyzer.py
@@ -1,0 +1,162 @@
+"""Tier 1: `match` primitive contract — serde round-trip, DSL parse, analyzer facet.
+
+The `match` step (R7, `call`'s runtime-selected sibling) plugs into the three
+sibling dispatch tables the foundation established: serde's
+``ENCODERS``/``DECODERS`` (work-order persistence — the ``pass_`` field ⇄
+wire key ``"pass"`` split on each nested case), the parser's ``_STEP_PARSERS``
+(Appendix B ``match = {on, cases, default?, output?}``), and the analyzer's
+``ANALYZER_FACETS`` (P4 — path enumeration over every case target). This pins
+each contract with NON-DEFAULT values.
+
+Real YAML parse + real JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.analyzer import analyze_step
+from reyn.core.pipeline.executor import MatchCase, MatchStep, Pipeline, ToolStep
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def test_match_serde_round_trip_non_default_values():
+    """Tier 1: a ``MatchStep`` with multiple cases + a ``default`` + non-default
+    ``pass_``/``output`` round-trips dataclass -> dict -> JSON -> dataclass, and
+    the wire form uses the Appendix-B key ``"pass"`` on each nested case (not
+    the Python field name ``pass_``)."""
+    pipeline = Pipeline(steps=[
+        MatchStep(
+            on="ctx.kind",
+            cases={
+                "cat": MatchCase(pipeline="on-cat", pass_=["brief"]),
+                "dog": MatchCase(pipeline="on-dog", pass_=["brief", "budget"]),
+            },
+            default=MatchCase(pipeline="on-other", pass_=[]),
+            output="result",
+        ),
+        ToolStep(name="noop", args={}),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    match_dict = wire["steps"][0]
+    assert match_dict == {
+        "kind": "match",
+        "on": "ctx.kind",
+        "cases": {
+            "cat": {"pipeline": "on-cat", "pass": ["brief"]},
+            "dog": {"pipeline": "on-dog", "pass": ["brief", "budget"]},
+        },
+        "default": {"pipeline": "on-other", "pass": []},
+        "output": "result",
+    }
+    assert "pass_" not in json.dumps(match_dict)  # wire key is Appendix-B `pass`
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_match_serde_round_trip_no_default():
+    """Tier 1: ``default=None`` round-trips as a null wire value, not a key
+    that decodes into a spurious ``MatchCase``."""
+    pipeline = Pipeline(steps=[
+        MatchStep(on="ctx.k", cases={"a": MatchCase(pipeline="p", pass_=[])}),
+    ])
+    wire = json.loads(json.dumps(pipeline_to_dict(pipeline)))
+    assert wire["steps"][0]["default"] is None
+    assert pipeline_from_dict(wire) == pipeline
+
+
+def test_match_parses_from_dsl():
+    """Tier 1: the DSL ``match`` step parses to a ``MatchStep`` (moved out of
+    the not-yet-supported set) with ``cases``/``default``/``output`` honored."""
+    text = """
+pipeline: outer
+steps:
+  - match:
+      on: ctx.kind
+      cases:
+        cat:
+          pipeline: on-cat
+          pass: [brief]
+        dog:
+          pipeline: on-dog
+      default:
+        pipeline: on-other
+      output: summary
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    assert parsed.steps == [
+        MatchStep(
+            on="ctx.kind",
+            cases={
+                "cat": MatchCase(pipeline="on-cat", pass_=["brief"]),
+                "dog": MatchCase(pipeline="on-dog", pass_=[]),
+            },
+            default=MatchCase(pipeline="on-other", pass_=[]),
+            output="summary",
+        )
+    ]
+
+
+def test_match_dsl_requires_non_empty_cases():
+    """Tier 1: a ``match`` with no ``cases`` at all is a parse error, not a
+    step that silently always falls through to ``default``/failure."""
+    text = "pipeline: o\nsteps:\n  - match:\n      on: ctx.kind\n      cases: {}\n"
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_match_dsl_case_requires_literal_pipeline_name():
+    """Tier 1: an empty/missing ``pipeline`` name inside a case is a parse
+    error (Hard rule 2 — every case target is a static literal)."""
+    text = (
+        "pipeline: o\nsteps:\n  - match:\n      on: ctx.kind\n      "
+        "cases:\n        a:\n          pass: [x]\n"
+    )
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_match_dsl_rejects_malformed_on_expression():
+    """Tier 1: a malformed ``on`` R1 expression fails at parse time (same
+    contract as ``transform.value``), not deep in the executor."""
+    text = (
+        "pipeline: o\nsteps:\n  - match:\n      on: 'ctx. .bad'\n      "
+        "cases:\n        a:\n          pipeline: p\n"
+    )
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_match_analyzer_facet_registered_and_enumerates_case_targets():
+    """Tier 1: the P4 analyzer facet for ``match`` is registered, passes valid
+    literal case/default targets, and flags a pathological empty target
+    (constructor-bypassing the parser) — the path-enumeration teeth ``match``
+    contributes beyond ``call``'s placeholder facet."""
+    ok_step = MatchStep(
+        on="ctx.kind",
+        cases={
+            "a": MatchCase(pipeline="pa", pass_=[]),
+            "b": MatchCase(pipeline="pb", pass_=[]),
+        },
+        default=MatchCase(pipeline="pd", pass_=[]),
+    )
+    assert analyze_step(ok_step) == []
+
+    bad_step = MatchStep(
+        on="ctx.kind",
+        cases={"a": MatchCase(pipeline="", pass_=[])},
+        default=MatchCase(pipeline="", pass_=[]),
+    )
+    problems = analyze_step(bad_step)
+    assert any("'a'" in p and "literal pipeline name" in p for p in problems)
+    assert any("'default'" in p and "literal pipeline name" in p for p in problems)
+
+
+def test_match_analyzer_facet_flags_empty_cases():
+    """Tier 1: a hand-built ``MatchStep`` with an empty ``cases`` mapping
+    (the parser already refuses this at DSL parse time — this pins the
+    facet's own defensive check for a round-tripped/hand-built instance)."""
+    problems = analyze_step(MatchStep(on="ctx.k", cases={}))
+    assert problems and "no cases" in problems[0]


### PR DESCRIPTION
**[lead-sonnet]** — part of #2187

## Summary

Adds `match` — Appendix B's `call`-sibling compositional primitive, runtime-selected instead of statically targeted:

```
match = {on: PATH, cases: {LABEL: {pipeline: LIT, pass: [NAME*]}}+, default?: {pipeline: LIT, pass: [NAME*]}, output?: NAME}
```

- `on` is an R1 expression (same evaluation path `transform.value` uses) resolved against the live context to a VALUE.
- That value selects a case LABEL by string equality (non-string values are stringified the same way `_interpolate_prompt` stringifies a prompt interpolation) — falling back to `default` when no case matches, else failing the step cleanly.
- The **selected** case's `{pipeline, pass}` then runs exactly like a `call` step's callee: `pass:[...]` builds an isolated sub-context (KeyError on an unpassed name), the callee's first step sees the caller's pipe-data at the match site (Hard rule 5), and the callee's FINAL step output threads out as this step's N2 return value.
- Hard rule 2: every case/`default` **target** stays a static literal pipeline name — only the LABEL is runtime-selected, never the target.

Wired into all four dispatch-table seams the foundation (#2577) established, mirroring `call`:
- `STEP_DISPATCH` (`_run_match_step` in `executor.py`)
- `ENCODERS`/`DECODERS` (`serde.py` — nested `MatchCase` round-trips `pass_` ⇄ wire key `"pass"`, same split as `CallStep`)
- `_STEP_PARSERS` (`parser.py` — `match` moved out of `_UNSUPPORTED_STEP_KINDS`)
- `ANALYZER_FACETS` (`analyzer.py` — `match`'s real P4 contribution: enumerates every case + `default` target and confirms each is a non-empty static literal; more than `call`'s placeholder facet, as the proposal anticipates)

Recovery: the selected case's callee runs under a dotted `f"{i}.match.{j}"` scope — IDENTICAL mechanism to `call` (single chosen sub-scope; unselected cases never execute, so leave no dotted keys at all).

## A real bug this primitive exposed (fixed in the same PR)

Appendix B names `match`'s selector field literally `on`. PyYAML's `SafeLoader` resolves unquoted `on`/`off`/`yes`/`no` scalars — **including as mapping keys** — to Python `bool` under YAML 1.1's "Norway problem" resolver, so `on: ctx.kind` in the DSL silently became key `True`, not `"on"`, before ever reaching the parser.

Fixed structurally in `_PipelineLoader` (the same dedicated `SafeLoader` subclass that already carries the `!expr` tag): narrowed its bool resolution to the YAML 1.2 core-schema spellings (`true`/`True`/`TRUE`/`false`/`False`/`FALSE`) only, dropping the `on`/`off`/`yes`/`no` implicit-bool entries. `true`/`false` still resolve correctly (t/T/f/F buckets untouched); `on`/`off`/`yes`/`no` now pass through as plain strings everywhere in this DSL — matching how most modern YAML tooling already resolves this ambiguity (e.g. `ruamel.yaml`'s default core-schema behavior).

## Tests (new, Tier 2 + Tier 1, no mocks)

`tests/test_pipeline_match_primitive.py` (Tier 2, mirrors `test_pipeline_call_primitive.py`):
- happy path: `on`-value selects a case by LABEL, `pass:[...]` isolation, pipe-data-at-call-site, N2 output threading; unselected case never runs (no dotted key for it).
- `default` runs when no case matches.
- no case + no `default` fails cleanly.
- `pass:[...]` isolation denies an unpassed store (structural, not silent None).
- selected-case failure propagates as the `match` step's failure.
- unregistered case-target pipeline fails cleanly.
- **CLAUDE.md recovery gate**: mid-selected-case crash → WAL truncated below source events → resume from the generation file → completed sub-step replays exactly-once (file-based side-effect probe) → remaining sub-step executes once → completes. Also a mid-crash dotted-key/outer-isolation snapshot test.

`tests/test_pipeline_match_serde_parser_analyzer.py` (Tier 1, mirrors `test_pipeline_call_serde_parser_analyzer.py`):
- serde round-trip with non-default `cases`/`default`/`pass_`/`output`, and with `default=None`.
- DSL parse (including the `on:`-as-boolean-key regression this PR fixes).
- DSL rejects empty `cases`, a case missing/empty `pipeline`, and a malformed `on` expression.
- analyzer facet: registered, passes valid targets, flags a pathological empty case/default target and an empty `cases` mapping.

## Gates (all run locally)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_match_primitive.py tests/test_pipeline_match_serde_parser_analyzer.py` — 16/16 OK, 0 Tier-4 violations (one `len(problems) == 2` format pin caught and fixed to a behavioral assertion during authoring).
- `pytest` (full suite) — 7089 passed; the 10 failed / 10 errored are pre-existing local `mcp`/`web` optional-dep reds, verified identical on the pre-change commit (`git stash` diff) — CI has full deps.
- `python scripts/verify_module_docstrings.py <4 changed src files>` — OK.
- New/recovery tests also run in isolation (`pytest tests/test_pipeline_match_primitive.py` / `tests/test_pipeline_match_serde_parser_analyzer.py` standalone) — pass, not just as part of the full-suite run.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on both new test files
- [x] `pytest` full suite (pre-existing optional-dep reds only, verified against base commit)
- [x] `python scripts/verify_module_docstrings.py` on the 4 changed src files
- [x] New tests run standalone in isolation (not just full-suite-masked)