### PR TITLE
feat(pipeline): fold primitive (sequential accumulator)

### DIFF
--- a/src/reyn/core/pipeline/analyzer.py
+++ b/src/reyn/core/pipeline/analyzer.py
@@ -9,15 +9,16 @@ monolithic walker — each primitive registers the check it is responsible for,
 and the registry is the single place a caller (a future ``analyze_pipeline``
 walker, or the IS-4 inline static-analysis gate) folds them together.
 
-This module is the SEAM plus its first two entries (``call``'s and ``match``'s
-facets). It is deliberately minimal in this slice: :data:`ANALYZER_FACETS` maps
+This module is the SEAM plus its first three entries (``call``'s, ``match``'s,
+and ``fold``'s facets). It is deliberately minimal in this slice:
+:data:`ANALYZER_FACETS` maps
 a step dataclass type to a facet function returning a list of human-readable
 problem strings ( empty = the step passed its facet), and :func:`analyze_step`
 looks one up. There is no full pipeline walker wired to consume it yet — that
 arrives with the primitives whose facets have real teeth (cost / spawn-tree
 bounds). What matters now is that the registration point EXISTS and
-``call``/``match`` are registered, so every future primitive MUST add its
-facet here rather than bolting analysis on later.
+``call``/``match``/``fold`` are registered, so every future primitive MUST add
+its facet here rather than bolting analysis on later.
 
 ``call``'s facet is intentionally thin: the target is a STATIC literal pipeline
 name (Hard rule 2), so the only thing to confirm structurally is that it IS a
@@ -35,12 +36,21 @@ target is a non-empty STATIC literal pipeline name (Hard rule 2 — the runtime
 cross-pipeline analyzer walker needs to fold every reachable case's transitive
 cost/spawn-tree bound into the caller's own — same "not here yet, but the
 registration point exists" posture as ``call``'s deeper checks.
-"""
+
+``fold``'s facet is the cost-bound half of §7.3's rule 4 ("``fold`` は
+``max_items``（over 使用時。省略時はランタイムデフォルト）× budget で上界を取る"):
+an ``items``-sourced fold (or one with an explicit ``max_items``) has a
+STATICALLY known iteration count, so the transitive cost bound (folded in by
+the future walker) is a real number; an ``over``-sourced fold with no
+``max_items`` reads its iteration count from a runtime ctx value the analyzer
+cannot see ahead of time — flagged as a WARNING (not a hard failure — the
+runtime default budget still keeps it finite, per Hard rule 9), the same
+"navigating unvalidated structure" caution N5-style facets raise elsewhere."""
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
-from reyn.core.pipeline.executor import CallStep, MatchStep
+from reyn.core.pipeline.executor import CallStep, FoldStep, MatchStep
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.executor import Step
@@ -81,6 +91,25 @@ def _match_facet(step: "MatchStep") -> "list[str]":
     return problems
 
 
+def _fold_facet(step: "FoldStep") -> "list[str]":
+    """Flag a ``fold`` whose list source has no STATICALLY known bound: an
+    ``over`` (runtime ctx path) source with no ``max_items`` cap. An
+    ``items``-sourced fold (a static literal list) always has a known length
+    regardless of ``max_items``, so it never triggers this. Returns problem
+    strings (empty = OK; this is a WARNING, not a hard failure — Hard rule 9's
+    runtime-default budget still bounds an uncapped ``over`` fold, it is just
+    not a number the analyzer can state ahead of time)."""
+    problems: "list[str]" = []
+    if step.over is not None and step.max_items is None:
+        problems.append(
+            "fold step reads its list from 'over' with no 'max_items' bound — "
+            "the iteration count is not statically known ahead of run time "
+            "(cost bound is runtime-list-length x budget, not a static "
+            "number, until 'max_items' is set)"
+        )
+    return problems
+
+
 # Facet registry: step type -> its static-analysis check. A future primitive
 # ADDS an entry here (mirroring the executor's ``STEP_DISPATCH``, serde's
 # ``ENCODERS``/``DECODERS``, and the parser's ``_STEP_PARSERS``) — the P4
@@ -89,6 +118,7 @@ def _match_facet(step: "MatchStep") -> "list[str]":
 ANALYZER_FACETS: "dict[type, Callable[[Step], list[str]]]" = {
     CallStep: _call_facet,
     MatchStep: _match_facet,
+    FoldStep: _fold_facet,
 }
 
 

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -1,14 +1,15 @@
 """Pipeline executor — R3 pipe-data threading + R4 recovery + the non-linear
-compositional foundation (``_run_scope`` + dotted-path recovery + ``call``).
+compositional foundation (``_run_scope`` + dotted-path recovery + ``call`` +
+``fold``).
 
 The executor for ``docs/proposals/reyn-pipeline-v0.9-design-resolutions.md``: a
 sequence of ``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell",
-...)``) / ``agent`` (R5) steps, plus two COMPOSITIONAL primitives: ``call`` (R7,
-a STATIC callee) and ``match`` (``call``'s runtime-selected sibling — the ``on``
-VALUE picks a LABEL, never a target; see :class:`MatchStep`). Still out of scope
-for this slice: `for_each`/`parallel`/`fold`/`refine` — those are later
-primitives that plug into the SAME dispatch + scope machinery this module now
-exposes.
+...)``) / ``agent`` (R5) steps, plus three COMPOSITIONAL primitives: ``call``
+(R7, a STATIC callee), ``match`` (``call``'s runtime-selected sibling — the
+``on`` VALUE picks a LABEL, never a target; see :class:`MatchStep`), and
+``fold`` (the sequential accumulator, Appendix B). Still out of scope for this
+slice: `for_each`/`parallel`/`refine` — those are later primitives that plug
+into the SAME dispatch + scope machinery this module now exposes.
 
 **Dispatch tables (R7 — the parallel-primitive seam).** Step execution is a
 ``dict``-dispatch keyed by the step's dataclass type
@@ -18,9 +19,14 @@ and an analyzer facet) instead of editing a shared ``elif`` block. Every runner
 has the uniform signature ``(_StepInvocation) -> (result, durable,
 completed_step_results)``: leaf runners (``transform``/``tool``/``agent``) return
 ``completed_step_results`` unchanged and never record; a COMPOSITIONAL runner
-(``call``) recurses into :meth:`PipelineExecutor._run_scope`, grows
-``completed_step_results`` with its sub-scope's dotted keys, and records each
-sub-step through the frozen recovery closure it is handed.
+(``call``, ``fold``) grows ``completed_step_results`` with its sub-scope's
+dotted keys and records each sub-step through the frozen recovery closure it is
+handed. ``call`` recurses into :meth:`PipelineExecutor._run_scope` (a LIST of
+distinct sub-steps sharing one evolving local scope); ``fold`` instead loops
+its OWN dispatch calls directly (see :func:`_run_fold_step`) because each
+iteration re-invokes the SAME ``do`` step under a fresh ``{item, acc}``
+binding — a shape ``_run_scope``'s "walk this fixed step list once" model does
+not fit.
 
 **R3 (uniform pipe-data / output rule)**: every step produces exactly one return
 value. That value is simultaneously (1) the pipe data handed to the next step and
@@ -39,10 +45,16 @@ completes (before advancing), the executor records the full control-plane state 
 truncation-surviving generation (``reyn.core.events.pipeline_recovery``). The
 ``completed_step_results`` key space is a DOTTED SCOPE PATH: a top-level step ``i``
 keeps its flat key ``str(i)`` (byte-identical to the pre-``call`` linear format —
-a pipeline with no ``call`` records exactly as before), and a ``call`` at index
-``i`` records its callee's sub-steps under ``f"{i}.call.{j}"`` while the callee
-runs, then records its OWN N2 scalar result at ``str(i)`` once the callee is done.
-Nesting composes (``"3.call.1.call.0"``). The persisted ``named_stores`` /
+a pipeline with no ``call``/``fold`` records exactly as before), and a ``call``
+at index ``i`` records its callee's sub-steps under ``f"{i}.call.{j}"`` while
+the callee runs, then records its OWN N2 scalar result at ``str(i)`` once the
+callee is done. A ``fold`` at index ``i`` records each iteration's ``do``
+result under ``f"{i}.fold.{k}"`` (``k`` = iteration index, NOT a nested scope —
+each key is ``do``'s own flat result, since every iteration runs the SAME
+``do`` step once) as it walks the list in order, then records its own final
+``acc`` at ``str(i)``. Nesting composes (``"3.call.1.call.0"``,
+``"3.fold.2.call.0"`` for a ``call`` used as a fold's ``do``). The persisted
+``named_stores`` /
 ``pipe_data`` / ``step_index`` stay the OUTER scope's throughout a call (a
 callee's local stores NEVER leak into the outer snapshot — this is what gives
 ``pass:[...]`` isolation on the RECOVERY axis, not just the live one); a callee's
@@ -225,7 +237,67 @@ class MatchStep:
     output: "str | None" = None
 
 
-Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep]
+@dataclass(frozen=True)
+class FoldStep:
+    """The second COMPOSITIONAL primitive: a SEQUENTIAL walk over a list,
+    threading an accumulator (Appendix B: ``fold = {over?:PATH | items?:[LIT*]
+    init:EXPR do:Step output:NAME max_items?}``). Unlike ``call``, ``do`` is a
+    single :data:`Step` re-invoked once PER ITEM, not a fixed list of distinct
+    sub-steps — see :func:`_run_fold_step` for the loop.
+
+    - List source (mutually exclusive; the parser rejects both together):
+      ``over`` (an R1 expression source, evaluated against ``{ctx, pipe}``
+      exactly like ``transform.value`` — e.g. ``"ctx.items"``) | ``items``
+      (a static Python literal list, stored as-is — Appendix B's ``[LIT*]``)
+      | neither, which falls back to the incoming PIPE DATA (the same
+      "over (ctx path) | items (static) | pipe data" convention Appendix B
+      states for ``for_each``).
+    - ``init`` is an R1 expression evaluated ONCE, before the first iteration,
+      against the fold step's own ``{ctx, pipe}`` — its result seeds ``acc``.
+    - ``do`` runs once per list item, in order; item ``k``'s context is
+      ``{"ctx": <a LOCAL named-store copy, seeded from the outer ctx and
+      grown by ``do.output`` across iterations>, "pipe": <this fold step's
+      OWN incoming pipe-data, held CONSTANT across every iteration — the
+      per-iteration analog of Hard rule 5's "callee's first step sees the
+      caller's pipe-data at the call site">, "item": <the k-th list element>,
+      "acc": <the running accumulator>}``. ``item``/``acc`` are bare
+      top-level context names, so a transform ``do`` reads them as
+      ``acc + item`` and an agent ``do`` prompt interpolates them as
+      ``{item}``/``{acc}`` — the SAME ``Path``/``{...}`` resolution
+      ``ctx.NAME``/``pipe`` already use, just against two more top-level keys.
+    - ``do``'s RETURN VALUE becomes the next ``acc`` (never its ``pipe``/
+      ``ctx`` output — those are local bookkeeping only); the FINAL ``acc``
+      (after the last item, or ``init`` unchanged for an empty list) is this
+      step's N2 return value and — per R3 — its named ``output``.
+    - No ``collect`` (unlike ``for_each``): a fold's whole point is that each
+      item depends on the accumulated result of the ones before it, so there
+      is nothing to collect independently.
+    - Item failure (``do`` raising, after any retry the leaf step itself
+      implements) fails the WHOLE fold — the exception propagates unchanged,
+      mirroring ``call``'s "callee failure fails this step".
+    - ``max_items`` (Hard rule 9 — always finite): caps the walk to the first
+      ``max_items`` elements of the resolved list; a longer source is
+      silently truncated, never an error (the cap is a bound, not a
+      length-equality assertion).
+
+    Recovery: iteration ``k`` records at the FLAT dotted key
+    ``f"{label}.fold.{k}"`` (not a nested scope prefix — every iteration runs
+    the exact same ``do``, so there is no sub-scope of distinct steps to
+    prefix, unlike ``call``). On resume, a key already present in
+    ``completed_step_results`` REPLAYS: ``acc`` is read back from the stored
+    result and ``do`` is NOT re-executed (its side effect does not re-fire) —
+    walking the dotted keys in order rebuilds ``acc`` exactly as the live run
+    computed it, then execution resumes at the first absent iteration."""
+
+    init: str
+    do: "Step"
+    output: str
+    over: "str | None" = None
+    items: "list[Any] | None" = None
+    max_items: "int | None" = None
+
+
+Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep, FoldStep]
 
 
 @dataclass(frozen=True)
@@ -559,6 +631,85 @@ async def _run_match_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str,
     return final_pipe, any_durable, completed_step_results
 
 
+async def _run_fold_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """The second COMPOSITIONAL runner (the sequential-accumulator primitive):
+    resolve the list source, evaluate ``init``, then walk the list IN ORDER
+    running ``do`` once per item — see :class:`FoldStep` for the full context-
+    injection + recovery contract. Returns the FINAL ``acc`` (N2), whether any
+    executed iteration was side-effecting, and the GROWN
+    ``completed_step_results`` (with this fold's ``f"{label}.fold.{k}"`` keys)."""
+    step: FoldStep = inv.step  # type: ignore[assignment]
+    context = inv.context
+
+    if step.over is not None and step.items is not None:  # pragma: no cover - parser-enforced
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (fold): 'over' and 'items' are mutually "
+            "exclusive list sources"
+        )
+    if step.over is not None:
+        try:
+            source = evaluate_expr(step.over, context)
+        except ExprEvalError as exc:
+            raise PipelineExecutionError(
+                f"step {inv.step_label} (fold) 'over' failed: {exc}"
+            ) from exc
+    elif step.items is not None:
+        source = list(step.items)
+    else:
+        source = context["pipe"]
+    if not isinstance(source, list):
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (fold) list source resolved to a "
+            f"{type(source).__name__}, not a list"
+        )
+    if step.max_items is not None:
+        source = source[: step.max_items]
+
+    try:
+        acc = evaluate_expr(step.init, context)
+    except ExprEvalError as exc:
+        raise PipelineExecutionError(
+            f"step {inv.step_label} (fold) 'init' failed: {exc}"
+        ) from exc
+
+    # Hard rule 5's per-iteration analog: `do` sees the fold step's OWN
+    # incoming pipe-data, held constant across every iteration (never the
+    # running acc/item — those get their own dedicated names).
+    outer_pipe = context["pipe"]
+    # A LOCAL named-store copy `do.output` (if set) grows across iterations;
+    # it never writes back to the outer scope (only `fold.output` does, via
+    # the caller's normal step.output handling — same as `call`).
+    local_stores: "dict[str, Any]" = dict(context["ctx"])
+    completed_step_results = inv.completed_step_results
+    any_durable = False
+
+    for k, item in enumerate(source):
+        key = f"{inv.step_label}.fold.{k}"
+        if key in completed_step_results:
+            # REPLAY exactly-once: rebuild `acc` from the recorded result; `do`
+            # does NOT re-execute (its side effect must not re-fire).
+            acc = completed_step_results[key]
+            continue
+        do_context = {"ctx": local_stores, "pipe": outer_pipe, "item": item, "acc": acc}
+        runner = STEP_DISPATCH.get(type(step.do))
+        if runner is None:  # pragma: no cover - Step is a closed union
+            raise PipelineExecutionError(f"unknown step type: {step.do!r}")
+        do_inv = _StepInvocation(
+            executor=inv.executor, step=step.do, context=do_context, step_label=key,
+            deps=inv.deps, completed_step_results=completed_step_results,
+            record=inv.record,
+        )
+        result, durable, completed_step_results = await runner(do_inv)
+        any_durable = any_durable or durable
+        acc = result
+        completed_step_results = {**completed_step_results, key: result}
+        if step.do.output:
+            local_stores = {**local_stores, step.do.output: result}
+        await inv.record(completed_step_results=completed_step_results, durable=durable)
+
+    return acc, any_durable, completed_step_results
+
+
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
 # entry here (+ serde/parser/analyzer) rather than editing a shared elif chain.
 STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
@@ -567,6 +718,7 @@ STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool
     AgentStep: _run_agent_step,
     CallStep: _run_call_step,
     MatchStep: _run_match_step,
+    FoldStep: _run_fold_step,
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
@@ -576,6 +728,7 @@ _STEP_KINDS: "dict[type, str]" = {
     AgentStep: "agent",
     CallStep: "call",
     MatchStep: "match",
+    FoldStep: "fold",
 }
 
 
@@ -858,6 +1011,7 @@ __all__ = [
     "CallStep",
     "MatchCase",
     "MatchStep",
+    "FoldStep",
     "Step",
     "Pipeline",
     "PipelineResult",

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -4,16 +4,17 @@ Implements the surface grammar in Appendix B of
 ``docs/proposals/reyn-pipeline-spec-v0.8.md`` (lines 706-835), narrowed to
 exactly the subset :class:`reyn.core.pipeline.executor.PipelineExecutor` can
 run today: a **linear** sequence of ``transform`` / ``tool`` / ``shell`` /
-``agent`` steps plus two COMPOSITIONAL primitives — ``call`` (R7 — runs a
-STATIC registered sub-pipeline synchronously) and ``match`` (``call``'s
+``agent`` steps plus three COMPOSITIONAL primitives — ``call`` (R7 — runs a
+STATIC registered sub-pipeline synchronously), ``match`` (``call``'s
 runtime-selected sibling: a runtime VALUE picks a case LABEL, whose target
-stays a static literal) — plus the pipeline-level ``description``.
-``for_each`` / ``parallel`` / ``fold`` / ``refine``, and the pipeline-level
-``input`` / ``defaults`` blocks are all part of the full v0.8 grammar but
-have no runtime yet — this parser refuses to accept them rather than
-silently dropping them into a pipeline that "parses" but then either crashes
-at run time in a confusing place or (worse) quietly loses the author's
-intent. Every construct not yet executable raises
+stays a static literal), and ``fold`` (sequential accumulator — runs a nested
+``do`` step once per list item) — plus the pipeline-level ``description``.
+``for_each`` / ``parallel`` / ``refine``, and the pipeline-level ``input`` /
+``defaults`` blocks are all part of the full v0.8 grammar but have no runtime
+yet — this parser refuses to accept them rather than silently dropping them
+into a pipeline that "parses" but then either crashes at run time in a
+confusing place or (worse) quietly loses the author's intent. Every construct
+not yet executable raises
 :class:`PipelineParseError` naming it explicitly, so authoring a
 not-yet-supported pipeline fails at parse time, at the DSL text, not deep in
 an executor stack trace.
@@ -83,6 +84,7 @@ from reyn.core.pipeline.executor import (
     AgentStep,
     CallStep,
     ExprRef,
+    FoldStep,
     MatchCase,
     MatchStep,
     Pipeline,
@@ -102,7 +104,7 @@ class PipelineParseError(ValueError):
     current linear executor can run — malformed YAML, a malformed R1
     expression, or (most commonly) a construct that is valid Appendix-B
     grammar but not yet supported by `PipelineExecutor` (`for_each`,
-    `parallel`, `fold`, `refine`, pipeline-level `input`/
+    `parallel`, `refine`, pipeline-level `input`/
     `defaults`, or a per-step field the executor does not consume)."""
 
 
@@ -171,14 +173,16 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 
 # Constructs the union grammar's non-linear step kinds accept as *keys* so a
 # document using them gets a clear "not yet supported" error instead of a
-# generic "unknown step type". ``call``/``match`` are now SUPPORTED (R7) —
-# they moved out of this set into ``_STEP_PARSERS``.
-_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel", "fold")
+# generic "unknown step type". ``call`` (R7), ``match`` (runtime-selected
+# sibling), and ``fold`` (sequential accumulator) are now SUPPORTED — they
+# moved out of this set into ``_STEP_PARSERS`` (``fold`` is dispatched
+# specially in ``_parse_step`` since its ``do`` recurses).
+_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel")
 _LINEAR_STEP_KINDS = ("transform", "tool", "shell", "agent")
-# ``call``/``match`` are compositional, not linear, but ARE executable —
-# listed separately so error text distinguishes "the linear kinds" from the
-# full supported set.
-_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match")
+# ``call``/``match``/``fold`` are compositional, not linear, but ARE
+# executable — listed separately so error text distinguishes "the linear
+# kinds" from the full supported set.
+_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold")
 _ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has
@@ -398,6 +402,53 @@ def _parse_match_step(body: "dict[str, Any]") -> MatchStep:
     return MatchStep(on=on, cases=cases, default=default, output=output)
 
 
+_FOLD_KEYS = frozenset({"over", "items", "init", "do", "output", "max_items"})
+
+
+def _parse_fold_step(body: "dict[str, Any]", *, index: "int | str") -> FoldStep:
+    """``fold = {over?:PATH | items?:[LIT*] init:EXPR do:Step output:NAME
+    max_items?}`` (Appendix B) — the sequential-accumulator primitive.
+    ``over``/``items`` are mutually exclusive (both together is an ambiguous
+    list source, never silently resolved one way); neither given falls back to
+    the incoming pipe data at run time (the executor's own fallback — see
+    ``FoldStep``'s docstring), so the parser does not require either. ``do`` is
+    itself a full nested Step definition, parsed the same way a pipeline's
+    top-level steps are (so a fold's ``do`` may be any supported step kind,
+    including a nested ``call``/``fold``). ``output`` (unlike ``call``'s,
+    which is optional) is REQUIRED — Appendix B gives it no ``?``, since a
+    fold's whole point is producing a named accumulator result."""
+    _reject_unknown_keys(body, _FOLD_KEYS, where="fold step")
+    if "over" in body and "items" in body:
+        _fail("fold step: 'over' and 'items' are mutually exclusive list sources")
+    over = body.get("over")
+    if over is not None:
+        over = _validate_expr_source(over, where="fold step 'over'")
+    raw_items = body.get("items")
+    items: "list[Any] | None" = None
+    if raw_items is not None:
+        if not isinstance(raw_items, list):
+            _fail(f"fold step 'items': expected a list, got {type(raw_items).__name__}")
+        _reject_nested_expr_tag(raw_items, where="fold step 'items'")
+        items = list(raw_items)
+    if "init" not in body:
+        _fail("fold step: missing required field 'init'")
+    init = _validate_expr_source(body["init"], where="fold step 'init'")
+    if "do" not in body:
+        _fail("fold step: missing required field 'do'")
+    do = _parse_step(body["do"], index=f"{index} (fold do)")
+    output = body.get("output")
+    if not isinstance(output, str) or not output:
+        _fail(f"fold step 'output': expected a non-empty store-name string, got {output!r}")
+    max_items = body.get("max_items")
+    if max_items is not None and (
+        isinstance(max_items, bool) or not isinstance(max_items, int) or max_items <= 0
+    ):
+        _fail(f"fold step 'max_items': expected a positive integer, got {max_items!r}")
+    return FoldStep(
+        init=init, do=do, output=output, over=over, items=items, max_items=max_items,
+    )
+
+
 _STEP_PARSERS = {
     "transform": _parse_transform_step,
     "tool": _parse_tool_step,
@@ -408,7 +459,7 @@ _STEP_PARSERS = {
 }
 
 
-def _parse_step(raw_step: Any, *, index: int) -> Step:
+def _parse_step(raw_step: Any, *, index: "int | str") -> Step:
     if not isinstance(raw_step, dict) or len(raw_step) != 1:
         _fail(
             f"step {index}: expected a single-key mapping naming its step kind "
@@ -420,6 +471,10 @@ def _parse_step(raw_step: Any, *, index: int) -> Step:
             f"step {index}: step kind {kind!r} is not yet supported (later slice) — "
             f"the executor runs {_SUPPORTED_STEP_KINDS!r}"
         )
+    if kind == "fold":
+        if not isinstance(body, dict):
+            _fail(f"step {index} (fold): expected a mapping body, got {type(body).__name__}")
+        return _parse_fold_step(body, index=index)
     if kind not in _STEP_PARSERS:
         _fail(
             f"step {index}: unknown step kind {kind!r} (expected one of "

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -40,6 +40,7 @@ from reyn.core.pipeline.executor import (
     AgentStep,
     CallStep,
     ExprRef,
+    FoldStep,
     MatchCase,
     MatchStep,
     Pipeline,
@@ -183,6 +184,31 @@ def _decode_match(data: "dict[str, Any]") -> "MatchStep":
     )
 
 
+def _encode_fold(step: "FoldStep") -> "dict[str, Any]":
+    # ``do`` is itself a Step — recurse through `step_to_dict` so a fold whose
+    # `do` is a `call` (or a nested `fold`) round-trips just as faithfully.
+    return {
+        "kind": "fold",
+        "over": step.over,
+        "items": list(step.items) if step.items is not None else None,
+        "init": step.init,
+        "do": step_to_dict(step.do),
+        "output": step.output,
+        "max_items": step.max_items,
+    }
+
+
+def _decode_fold(data: "dict[str, Any]") -> "FoldStep":
+    return FoldStep(
+        init=data["init"],
+        do=step_from_dict(data["do"]),
+        output=data["output"],
+        over=data.get("over"),
+        items=list(data["items"]) if data.get("items") is not None else None,
+        max_items=data.get("max_items"),
+    )
+
+
 # Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
 # A future primitive ADDS one entry to each (mirroring the executor's
 # ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
@@ -193,6 +219,7 @@ ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
     AgentStep: _encode_agent,
     CallStep: _encode_call,
     MatchStep: _encode_match,
+    FoldStep: _encode_fold,
 }
 DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "transform": _decode_transform,
@@ -200,6 +227,7 @@ DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "agent": _decode_agent,
     "call": _decode_call,
     "match": _decode_match,
+    "fold": _decode_fold,
 }
 
 

--- a/tests/test_pipeline_fold_primitive.py
+++ b/tests/test_pipeline_fold_primitive.py
@@ -1,0 +1,335 @@
+"""Tier 2: OS invariant — the `fold` compositional primitive (sequential
+accumulator) + its dotted-path R4 recovery.
+
+Covers the second consumer of the non-linear foundation (Appendix B ``fold =
+{over?:PATH | items?:[LIT*] init:EXPR do:Step output:NAME max_items?}`` +
+Hard rule 9 finiteness):
+
+  1. happy path — `fold` walks a list IN ORDER, threading `acc` through `do`
+     (a transform computing `acc + item`), `init` seeds the first `acc`, and
+     the FINAL `acc` becomes the fold's return value + named output.
+  2. `items:` (static literal source) is honored the same way `over:` is.
+  3. an empty list leaves `acc` == `init`, unchanged.
+  4. `max_items` caps the walk to the first N elements of a longer source.
+  5. context injection — `do` sees bare `{item}`/`{acc}` (a transform `value`
+     reads them as bare names; an agent-style prompt interpolation would too,
+     though this exercises it via `transform`, the deterministic leaf).
+  6. item failure fails the WHOLE fold (propagates, never swallowed).
+  7. the CLAUDE.md-mandated truncate-falsify recovery gate: crash mid-fold
+     (some iterations done), truncate the WAL below the source events, resume
+     from the generation FILE, and prove the completed iterations REPLAY
+     exactly-once (a `do` side effect does NOT re-fire for a finished
+     iteration) while `acc` rebuilds correctly and only the remaining
+     iterations execute once.
+
+Real `StateLog` + real generation files throughout; the recovery tests build
+the executor directly (the same discipline as `call`'s truncate-falsify test)
+— no mocks, no private-state assertions.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    FoldStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+
+# ── happy path: accumulation, over/items sources, empty list, max_items ─────
+
+
+@pytest.mark.asyncio
+async def test_fold_accumulates_sequentially_via_over():
+    """Tier 2: `fold` walks `ctx.items` in order, threading `acc` through a
+    transform `do` (`acc + item`); `init` seeds the first `acc`, and the FINAL
+    `acc` threads out as the fold's return value + named output."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="0", do=TransformStep(value="acc + item"), output="total",
+            over="ctx.numbers",
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, {"numbers": [1, 2, 3, 4]},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-over",
+    )
+    assert result.named_stores["total"] == 10
+    assert result.pipe_data == 10
+    assert result.completed_step_results["0.fold.0"] == 1
+    assert result.completed_step_results["0.fold.1"] == 3
+    assert result.completed_step_results["0.fold.2"] == 6
+    assert result.completed_step_results["0.fold.3"] == 10
+    assert result.completed_step_results["0"] == 10
+
+
+@pytest.mark.asyncio
+async def test_fold_accumulates_via_static_items_source():
+    """Tier 2: `items:` (a static literal list) is an equally valid list
+    source to `over:` — same accumulation semantics."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="''", do=TransformStep(value="acc + item"), output="joined",
+            items=["a", "b", "c"],
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-items",
+    )
+    assert result.named_stores["joined"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_fold_empty_list_leaves_init_unchanged():
+    """Tier 2: an empty list source means `do` never runs — the final `acc`
+    is exactly `init`, and no `fold.{k}` dotted keys are recorded."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="42", do=TransformStep(value="acc + item"), output="total",
+            items=[],
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-empty",
+    )
+    assert result.named_stores["total"] == 42
+    assert not any(k.startswith("0.fold.") for k in result.completed_step_results)
+
+
+@pytest.mark.asyncio
+async def test_fold_max_items_caps_the_walk():
+    """Tier 2: `max_items` truncates a longer source to its first N elements
+    (Hard rule 9 — always finite) rather than erroring on a longer list."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="0", do=TransformStep(value="acc + item"), output="total",
+            items=[1, 2, 3, 4, 5], max_items=2,
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-cap",
+    )
+    assert result.named_stores["total"] == 3  # 1 + 2, item 3/4/5 never run
+    assert "0.fold.2" not in result.completed_step_results
+
+
+@pytest.mark.asyncio
+async def test_fold_item_failure_fails_the_whole_fold():
+    """Tier 2: a `do` step failure (an unresolvable expression) propagates as
+    a `PipelineExecutionError` out of the fold — never silently dropped."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="0", do=TransformStep(value="acc + ctx.missing"), output="total",
+            items=[1, 2],
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=None, run_id="run-fold-fail",
+        )
+
+
+# ── dotted-path R4 recovery: the CLAUDE.md truncate-falsify gate ────────────
+
+
+def _append_dispatch(state_log: StateLog, out_file, crash):
+    """A REAL side-effecting tool (mirrors the `call` truncate-falsify test's
+    own fixture): each call appends `args["line"]` to `out_file` (the
+    exactly-once probe — a re-fired step leaves a duplicate line) AND a WAL
+    entry, so R4 gens land at distinct durable seqs. `crash["line"]` arms a
+    mid-execution failure BEFORE that line's side effect. The tool RETURNS
+    `args["acc"] + args["line"]` — a `do` that passes `{acc}`/`{item}` as
+    `acc`/`line` args threads the running concatenation the same way a
+    transform `do`'s `acc + item` would, so this doubles as the fold's `do`
+    for the recovery gate."""
+
+    async def _dispatch(name: str, args: dict):
+        assert name == "append"
+        line = str(args["line"])
+        if crash.get("line") == line:
+            raise RuntimeError(f"simulated crash before writing {line!r}")
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        await state_log.append("inbox_put", note=line)
+        return str(args["acc"]) + line
+
+    return _dispatch
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(tmp_path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate for the `fold` primitive. A run
+    crashes MID-FOLD (iteration 0 wrote 'A' + recorded its R4 gen + dotted key
+    `0.fold.0`; iteration 1 failed before writing 'B'). The WAL is then
+    truncated BELOW those source events. `resume` must reconstruct from the
+    generation FILE, REPLAY the finished iteration exactly-once ('A' is NOT
+    written again — the file proves it), rebuild `acc` from the replayed
+    result, execute ONLY the remaining iteration (writes 'B' once), and
+    complete with the correct final `acc`. RED if an iteration's side effect
+    rode a truncatable WAL event, or if resume re-ran the whole fold instead of
+    replaying the completed iteration."""
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    from reyn.core.pipeline.executor import ExprRef
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"line": "B"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="''",
+            do=ToolStep(name="append", args={"line": ExprRef("item"), "acc": ExprRef("acc")}),
+            output="joined",
+            items=["A", "B"],
+        ),
+    ])
+
+    # CRASH STATE: iteration 0 writes A + records its gen at a real WAL seq;
+    # iteration 1 raises before writing B.
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=dispatch, state_log=state_log,
+            run_id="run-fold-tf",
+        )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
+
+    snap_mid = latest_pipeline_state("run-fold-tf", state_log)
+    assert snap_mid["completed_step_results"]["0.fold.0"] == "A"
+    assert "0.fold.1" not in snap_mid["completed_step_results"]
+    assert "0" not in snap_mid["completed_step_results"]
+    assert snap_mid["step_index"] == 0  # the fold step itself is not done
+
+    # The WAL head climbs past the crash-state seqs, then GC truncates below
+    # 40 — the finished iteration's own WAL entry is dropped from wal.jsonl.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "iteration 0's WAL entry is truncated away"
+
+    # RESUME with the crash DISARMED: iteration 0 replays from the gen FILE
+    # (no re-write of A), only iteration 1 executes (writes B once).
+    crash.clear()
+    resumed = await PipelineExecutor().resume(
+        "run-fold-tf", pipeline=outer,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+
+    # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+    assert resumed.completed_step_results["0.fold.0"] == "A"
+    # iteration 1's `do` receives the REPLAYED acc ("A") + item "B" == "AB" —
+    # proof the accumulator was correctly rebuilt from the replayed result
+    # before the remaining iteration ran, not re-derived from scratch.
+    assert resumed.completed_step_results["0.fold.1"] == "AB"
+    assert resumed.named_stores["joined"] == "AB"
+    assert resumed.pipe_data == "AB"
+    assert resumed.completed_step_results["0"] == "AB"
+
+
+@pytest.mark.asyncio
+async def test_fold_resume_after_full_run_replays_with_zero_new_side_effects(tmp_path):
+    """Tier 2: resuming a run whose fold already completed replays every
+    iteration from the snapshot (zero new writes) and re-threads the final
+    `acc`. RED if resume re-ran a completed iteration's side effect."""
+    from reyn.core.pipeline.executor import ExprRef
+
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    dispatch = _append_dispatch(state_log, out_file, {})
+
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="''",
+            do=ToolStep(name="append", args={"line": ExprRef("item"), "acc": ExprRef("acc")}),
+            output="joined",
+            items=["A", "B"],
+        ),
+    ])
+
+    await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=dispatch, state_log=state_log,
+        run_id="run-fold-done",
+    )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+
+    resumed = await PipelineExecutor().resume(
+        "run-fold-done", pipeline=outer,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
+    assert resumed.named_stores["joined"] == "AB"
+
+
+# ── context injection: {item}/{acc} available to `do` ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_do_context_binds_item_and_acc_in_the_right_order():
+    """Tier 2: `do` resolves `{item}`/`{acc}` as DISTINCT bare top-level
+    context names, bound in the documented order (never swapped) — proven with
+    an order-sensitive op (`acc - item`, not the commutative `acc + item`
+    the other happy-path tests use): 100, then 100-1=99, 99-2=97, 97-3=94.
+    A swapped binding (`item - acc`) would yield a different, easily
+    distinguishable result."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="100", do=TransformStep(value="acc - item"), output="total",
+            items=[1, 2, 3],
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-order",
+    )
+    assert result.named_stores["total"] == 94
+
+
+@pytest.mark.asyncio
+async def test_do_output_grows_local_ctx_across_iterations_not_outer_scope():
+    """Tier 2: a `do` with `output: seen` writes into fold's LOCAL ctx copy,
+    readable by a LATER iteration's `do` via `ctx.seen` (proven: iteration 1's
+    `do` adds `ctx.seen` — iteration 0's stashed running total — on top of the
+    plain `acc + item` sum) — but that name never reaches the outer pipeline's
+    named stores (only `fold.output` does; `get(ctx, 'seen', 'ABSENT')` outside
+    the fold resolves to the default)."""
+    outer = Pipeline(steps=[
+        FoldStep(
+            init="0",
+            do=TransformStep(value="acc + item + get(ctx, 'seen', 0)", output="seen"),
+            output="total",
+            items=[1, 2, 3],
+        ),
+        # A later top-level step: `seen` must NOT be visible outside the fold.
+        TransformStep(value="get(ctx, 'seen', 'ABSENT')", output="leaked"),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fold-local-ctx",
+    )
+    # iter0: acc=0+1+get(seen,0)=1 -> seen=1
+    # iter1: acc=1+2+get(seen,0)=1+2+1=4 -> seen=4
+    # iter2: acc=4+3+get(seen,0)=4+3+4=11 -> seen=11
+    assert result.named_stores["total"] == 11
+    assert result.named_stores["leaked"] == "ABSENT"

--- a/tests/test_pipeline_fold_serde_parser_analyzer.py
+++ b/tests/test_pipeline_fold_serde_parser_analyzer.py
@@ -1,0 +1,172 @@
+"""Tier 1: `fold` primitive contract — serde round-trip, DSL parse, analyzer facet.
+
+The `fold` step (sequential accumulator) plugs into the three sibling dispatch
+tables `call` established: serde's ``ENCODERS``/``DECODERS`` (work-order
+persistence — `do`, itself a nested `Step`, recurses through `step_to_dict`/
+`step_from_dict`), the parser's ``_STEP_PARSERS`` (Appendix B ``fold =
+{over?, items?, init, do, output, max_items?}``), and the analyzer's
+``ANALYZER_FACETS`` (P4 seam — the `max_items`/`over` cost-bound warning).
+This pins each contract with NON-DEFAULT values.
+
+Real YAML parse + real JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.analyzer import analyze_step
+from reyn.core.pipeline.executor import CallStep, FoldStep, Pipeline, TransformStep
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def test_fold_serde_round_trip_non_default_values_with_nested_do():
+    """Tier 1: a ``FoldStep`` whose ``do`` is itself a ``CallStep`` (a nested
+    compositional step) round-trips dataclass -> dict -> JSON -> dataclass —
+    proving `do` recurses through the SAME step-serde contract as a
+    top-level step, not a bespoke shape."""
+    pipeline = Pipeline(steps=[
+        FoldStep(
+            init="[]", do=CallStep(pipeline="summarize-one", pass_=["item"], output="r"),
+            output="results", over="ctx.docs", max_items=5,
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    fold_dict = wire["steps"][0]
+    assert fold_dict == {
+        "kind": "fold",
+        "over": "ctx.docs",
+        "items": None,
+        "init": "[]",
+        "do": {"kind": "call", "pipeline": "summarize-one", "pass": ["item"], "output": "r"},
+        "output": "results",
+        "max_items": 5,
+    }
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_fold_serde_round_trip_static_items_source():
+    """Tier 1: a ``FoldStep`` using the ``items:`` static-literal-list source
+    (instead of ``over``) round-trips too."""
+    pipeline = Pipeline(steps=[
+        FoldStep(
+            init="0", do=TransformStep(value="acc + item"), output="total",
+            items=[1, 2, 3],
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    assert wire["steps"][0]["items"] == [1, 2, 3]
+    assert wire["steps"][0]["over"] is None
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_fold_parses_from_dsl():
+    """Tier 1: the DSL ``fold`` step parses to a ``FoldStep`` (moved out of the
+    not-yet-supported set) with ``over``/``init``/``do``/``output``/
+    ``max_items`` all honored, and a nested ``do:`` step parses through the
+    SAME per-kind parser a top-level step uses."""
+    text = """
+pipeline: outer
+steps:
+  - fold:
+      over: ctx.numbers
+      init: "0"
+      do:
+        transform:
+          value: "acc + item"
+      output: total
+      max_items: 10
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    assert parsed.steps == [
+        FoldStep(
+            init="0", do=TransformStep(value="acc + item"), output="total",
+            over="ctx.numbers", max_items=10,
+        ),
+    ]
+
+
+def test_fold_dsl_requires_output():
+    """Tier 1: ``output`` has no ``?`` in Appendix B's fold grammar — a
+    missing/empty ``output`` is a parse error."""
+    text = """
+pipeline: o
+steps:
+  - fold:
+      items: [1, 2]
+      init: "0"
+      do:
+        transform:
+          value: "acc + item"
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_fold_dsl_rejects_over_and_items_together():
+    """Tier 1: ``over`` and ``items`` are mutually exclusive list sources —
+    specifying both is a parse error, never a silent "one wins" resolution."""
+    text = """
+pipeline: o
+steps:
+  - fold:
+      over: ctx.numbers
+      items: [1, 2]
+      init: "0"
+      do:
+        transform:
+          value: "acc + item"
+      output: total
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_fold_dsl_rejects_unsupported_nested_do_kind():
+    """Tier 1: a ``do:`` naming a still-unsupported step kind (e.g. `match`)
+    fails at parse time, at the DSL text — the same "not yet supported" error
+    a top-level step of that kind would raise, not a confusing failure deep
+    inside fold-specific parsing."""
+    text = """
+pipeline: o
+steps:
+  - fold:
+      items: [1]
+      init: "0"
+      do:
+        match:
+          on: x
+          cases: {}
+      output: total
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_fold_analyzer_facet_flags_uncapped_over_source():
+    """Tier 1: the P4 analyzer facet for `fold` is registered and flags an
+    `over`-sourced fold with no `max_items` (no statically known iteration
+    bound) — but passes the same fold once `max_items` is set, and always
+    passes an `items`-sourced fold (a static literal list has a known length
+    regardless of `max_items`)."""
+    uncapped = FoldStep(
+        init="0", do=TransformStep(value="acc + item"), output="total",
+        over="ctx.numbers",
+    )
+    problems = analyze_step(uncapped)
+    assert problems and "max_items" in problems[0]
+
+    capped = FoldStep(
+        init="0", do=TransformStep(value="acc + item"), output="total",
+        over="ctx.numbers", max_items=5,
+    )
+    assert analyze_step(capped) == []
+
+    static_source = FoldStep(
+        init="0", do=TransformStep(value="acc + item"), output="total",
+        items=[1, 2, 3],
+    )
+    assert analyze_step(static_source) == []


### PR DESCRIPTION
**[lead-sonnet]** — part of #2187

## Summary
- Adds `FoldStep` (Appendix B: `fold = {over?:PATH | items?:[LIT*] init:EXPR do:Step output:NAME max_items?}`) — the second compositional primitive, built directly on the `_run_scope`/dotted-path-recovery/dispatch-table foundation `call` (#2577) established.
- `fold` walks a list SEQUENTIALLY, running `do` once per item and threading its return value as the next `acc`. Registered in `STEP_DISPATCH`/`_STEP_KINDS` (executor), `ENCODERS`/`DECODERS` (serde — `do` recurses through the same step serde as a top-level step), `_STEP_PARSERS` (parser — `fold` removed from `_UNSUPPORTED_STEP_KINDS`), and `ANALYZER_FACETS` (P4 — flags an `over`-sourced fold with no `max_items` as having no statically known iteration bound).

## Design decisions (stated explicitly per the task)
- **Context injection**: `do` sees `{"ctx": <a LOCAL named-store copy, seeded from the fold step's own ctx and grown by do.output across iterations — never written back to the outer scope>, "pipe": <the fold step's OWN incoming pipe-data, held constant across every iteration — the per-iteration analog of Hard rule 5's "callee's first step sees the caller's pipe-data at the call site">, "item": <the k-th list element>, "acc": <the running accumulator>}`. `item`/`acc` are bare top-level context names, so `Path`/`{...}` resolution (`evaluate_expr`/`_interpolate_prompt`) picks them up with zero new machinery.
- **Structural fork from `call`**: `call` recurses into `_run_scope` (a fixed list of distinct sub-steps sharing one evolving local scope). `fold` does NOT reuse `_run_scope` — it loops its own dispatch calls directly (`_run_fold_step`), because every iteration re-invokes the SAME `do` step under a fresh `{item, acc}` binding, a shape `_run_scope`'s "walk this step list once" model doesn't fit. Recorded dotted keys are FLAT (`f"{label}.fold.{k}"`), not a nested scope prefix like `call`'s `f"{label}.call.{j}"`.
- Recovery: an iteration's key already in `completed_step_results` REPLAYS (`acc` read back from the stored result, `do` NOT re-executed) — proven by the mandatory truncate-falsify test with a side-effecting `ToolStep` `do`.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_pipeline_fold_primitive.py tests/test_pipeline_fold_serde_parser_analyzer.py` — 16/16 OK, 0 Tier-4
- [x] `pytest` (full repo) — 7089 passed; the 10 failed/10 errored are pre-existing mcp/web optional-dep reds, verified identical on `5fbc6ef9` (base) before this change
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] New/recovery/invariant tests run in isolation (`pytest tests/test_pipeline_fold_primitive.py tests/test_pipeline_fold_serde_parser_analyzer.py tests/test_pipeline_call_primitive.py tests/test_pipeline_call_serde_parser_analyzer.py`) — 27/27 passed
- [x] All `test_pipeline*.py` files together — 184/184 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)