### PR TITLE
feat(#2575): production pipeline registration — load pipelines from disk into the session registry

### DIFF
--- a/docs/concepts/runtime/pipeline-registration.md
+++ b/docs/concepts/runtime/pipeline-registration.md
@@ -1,0 +1,94 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [pipeline registration, pipelines directory, register pipeline, run_pipeline, pipeline DSL, PipelineRegistry, scan_dirs, pipeline__run, call step target, load pipeline from disk, add a pipeline]
+---
+
+# Pipeline registration
+
+A **pipeline** is a deterministic, multi-step control flow written in the
+pipeline DSL (a directory of YAML documents). Once registered, an agent can
+launch it by name with `run_pipeline` (or the catalog verb `pipeline__<name>`),
+and one pipeline can `call` another by name.
+
+Pipelines are registered from disk: the operator drops DSL files into a scanned
+directory and they are loaded, parsed, and registered when a session starts.
+This mirrors how skills are registered — pipeline definition files are
+operator-owned **source** (like `skills/` and `reyn.yaml`), not runtime state,
+so they live at the project root, not under `.reyn/`.
+
+## Adding a pipeline
+
+1. Create a `pipelines/` directory at the project root (the default scan dir).
+2. Drop one Appendix-B DSL document per `*.yaml` file into it. Each file
+   declares its name with a top-level `pipeline:` key:
+
+   ```yaml
+   # pipelines/hello.yaml
+   pipeline: hello
+   description: Minimal greeting pipeline.
+   steps:
+     - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+   ```
+
+3. Start (or restart) the session. The pipeline is now registered under its
+   declared name and an agent can launch it:
+
+   ```
+   run_pipeline(name="hello", input={name: "Reyn"})
+   ```
+
+   or via the qualified catalog verb the action catalog surfaces:
+
+   ```
+   pipeline__hello({name: "Reyn"})
+   ```
+
+No `reyn.yaml` entry is required — dropping a file in `pipelines/` is enough.
+
+## The declared name is authoritative
+
+A pipeline registers under the name in its `pipeline:` key, **not** its file
+name. A file `greet.yaml` that declares `pipeline: hello` registers as `hello`.
+The declared name is the identity a `call` (or `match`) step's `pipeline:`
+target resolves against, so the file name is just a container — name your files
+however you like.
+
+## Configuration
+
+The scan directories are configurable. The default is `["pipelines"]`
+(project-root-relative):
+
+```yaml
+# reyn.yaml
+pipelines:
+  scan_dirs: ["pipelines", "shared/pipelines"]
+```
+
+## Failure behavior — fail loud
+
+Loading is strict, so a broken definition is never silently dropped:
+
+| Condition | Behavior |
+|-----------|----------|
+| Malformed DSL file | Session start fails, naming the offending file. |
+| Two files declaring the same `pipeline:` name | Session start fails, naming the collision. |
+| A configured scan dir that does not exist | Skipped (not an error) — add files later. |
+| No `pipelines/` dir / no files | No pipelines registered (empty registry). |
+
+## Security — launching a pipeline stays gated
+
+Registering a pipeline does **not** loosen the capability floor. Launching a
+pipeline (`run_pipeline` / `run_pipeline_async` / the inline launch verbs, and
+their `pipeline__*` catalog forms) is on the same restricted floor as spawning a
+sub-session or re-delegating: a pipeline step can itself write, execute, or
+delegate, so a pipeline launch is a cost-bound multi-step dispatch.
+
+As a result, a context narrowed by the `_untrusted` floor (untrusted external
+content is live) or the `_delegate` floor (an unbound delegate under
+`delegation.capability_default=deny`) **cannot launch a pipeline**, whether or
+not one is registered. Loading a pipeline definition makes it available to
+authorized agents; it never creates a bypass of those floors. See
+[Capability profiles](capability-profile.md) and
+[Delegation policy](delegation-policy.md).

--- a/pipelines/hello.yaml
+++ b/pipelines/hello.yaml
@@ -1,0 +1,18 @@
+# Sample pipeline (#2575) — the minimal end-to-end example.
+#
+# Drop an Appendix-B DSL file into this directory (`pipelines/`, the default
+# scan dir) and it is loaded + registered at session start under its declared
+# `pipeline:` name. This one registers as `hello` (the file name is just a
+# container — the `pipeline:` key below is authoritative).
+#
+# An agent can then launch it:
+#     run_pipeline(name="hello", input={name: "Reyn"})
+# or via the qualified catalog verb the enumerator surfaces:
+#     pipeline__hello({name: "Reyn"})
+#
+# It is a single pure `transform` step so it runs with no external tools —
+# safe to keep as a live smoke/dogfood pipeline.
+pipeline: hello
+description: Minimal greeting pipeline — concatenates the seed `name` into a greeting.
+steps:
+  - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -484,6 +484,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
             merged.get("external_transports"),
         ),
         skills=_as_config_dict(merged.get("skills"), "skills"),
+        pipelines=_as_config_dict(merged.get("pipelines"), "pipelines"),
     )
     _reconcile_embedding_class(_cfg)
     return _cfg

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -274,6 +274,18 @@ class ReynConfig:
     #         auto_invoke: true
     # Merged across config tiers by name (explicit entries win on collision).
     skills: dict = field(default_factory=dict)
+    # #2575: pipeline registration config. Raw dict passed to
+    # reyn.data.pipelines.registry.build_pipeline_registry at session-factory
+    # time (SessionFactoryConfig.from_config). Shape:
+    #   pipelines:
+    #     scan_dirs: ["pipelines"]       # project-root-relative; default ["pipelines"]
+    # Each ``*.yaml`` under a scan dir is an Appendix-B DSL document parsed via
+    # ``parse_pipeline_dsl``; the pipeline registers under its own declared
+    # ``pipeline:`` name (the file name is just a container). Absent/empty →
+    # no pipelines loaded (byte-identical to pre-#2575). Cross-tier: the whole
+    # ``pipelines`` block is last-tier-wins (generic ``_merge`` else-branch —
+    # no per-entry union, unlike ``skills``, since scan_dirs is a plain list).
+    pipelines: dict = field(default_factory=dict)
 
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -238,10 +238,21 @@ class Pipeline:
     deciding whether to ``run_pipeline`` a registered pipeline sees what it
     does, not just its bare name. Empty string when the registrant omits
     it — the enumerator still lists the pipeline (name is enough to invoke
-    it), just with no description text."""
+    it), just with no description text.
+
+    ``name`` (#2575): the declared ``pipeline:`` name from the DSL document.
+    The DSL parser populates it from the ``pipeline:`` key; a hand-built
+    ``Pipeline`` (tests, inline construction) may leave it ``""``. It is the
+    AUTHORITATIVE key the disk loader registers under and the identity a
+    ``call``/``match`` step's ``pipeline: LIT`` resolves against. Additive
+    (default ``""``) so it travels with the pipeline through work-order /
+    invocation.json persistence + recovery for free; an on-disk
+    invocation.json written before this field existed simply decodes to
+    ``""`` (default-tolerant round-trip)."""
 
     steps: "list[Step]"
     description: str = ""
+    name: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -447,7 +447,10 @@ def _parse_pipeline_doc(doc: "dict[str, Any]") -> Pipeline:
     if not isinstance(raw_steps, list) or not raw_steps:
         _fail(f"pipeline {name!r}: 'steps' must be a non-empty list")
     steps = [_parse_step(s, index=i) for i, s in enumerate(raw_steps)]
-    return Pipeline(steps=steps, description=description)
+    # #2575: carry the declared ``pipeline:`` name on the Pipeline so the disk
+    # loader can register under it (authoritative for ``call``/``match``
+    # resolution) and it persists through work-order/recovery.
+    return Pipeline(steps=steps, description=description, name=name)
 
 
 def _parse_schema_doc(doc: "dict[str, Any]", schema_registry: SchemaRegistry) -> None:

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -224,15 +224,23 @@ def pipeline_to_dict(pipeline: "Pipeline") -> "dict[str, Any]":
     """A :class:`Pipeline` → a JSON-serializable dict (the work-order shape)."""
     return {
         "description": pipeline.description,
+        # #2575: the declared ``pipeline:`` name travels with the work-order so
+        # a recovered pipeline keeps its identity (``call``/``match`` targets).
+        "name": pipeline.name,
         "steps": [step_to_dict(s) for s in pipeline.steps],
     }
 
 
 def pipeline_from_dict(data: "dict[str, Any]") -> "Pipeline":
-    """The inverse of :func:`pipeline_to_dict`."""
+    """The inverse of :func:`pipeline_to_dict`.
+
+    ``name`` is default-tolerant (#2575): an invocation.json persisted before
+    the field existed has no ``name`` key → ``""`` (a benign identity gap for a
+    long-since-launched inline run, which does not re-resolve by name)."""
     return Pipeline(
         steps=[step_from_dict(s) for s in data.get("steps", [])],
         description=str(data.get("description") or ""),
+        name=str(data.get("name") or ""),
     )
 
 

--- a/src/reyn/data/pipelines/registry.py
+++ b/src/reyn/data/pipelines/registry.py
@@ -1,0 +1,132 @@
+"""reyn.data.pipelines.registry — disk → PipelineRegistry loader (#2575).
+
+The production population path for the pipeline feature. Before #2575 a
+``Session`` owned an EMPTY :class:`~reyn.core.pipeline.registry.PipelineRegistry`
+(``run_pipeline`` had a live registry to look up against, but nothing ever
+registered into it in production — registration was programmatic/test-only),
+so no pipeline was launchable in a real session. This loader closes that gap by
+mirroring the skill loader (``reyn.data.skills.registry.build_skill_registry``):
+an operator drops Appendix-B DSL ``*.yaml`` files into a scanned directory
+(default ``pipelines/`` at the project root, sibling to ``skills/`` — operator-
+owned SOURCE, NOT ``.reyn/`` run-authored state per reyn-dir-layout.md) and each
+is parsed + registered at session-factory time.
+
+Unlike skills (explicit ``entries`` config, metadata only, never parses the
+file), a pipeline must be PARSED to be usable — the ``PipelineRegistry`` stores
+live ``Pipeline`` objects and surfaces their name+description to the LLM (IS-5's
+D19 catalog enumerator). So this loader parses each file via
+:func:`~reyn.core.pipeline.parser.parse_pipeline_dsl` and registers the result
+under the pipeline's OWN declared ``pipeline:`` name (``Pipeline.name``, #2575) —
+authoritative because that is the identity a ``call``/``match`` step's
+``pipeline: LIT`` resolves against. The file name is just a container: a
+``greet.yaml`` declaring ``pipeline: hello`` registers under ``hello`` (and is
+callable as ``hello``), not ``greet``.
+
+Failure posture is FAIL-LOUD (not silent-skip): a malformed DSL file raises with
+its path (a typo must not silently drop a pipeline the operator meant to ship),
+and a duplicate declared name across files surfaces the registry's own
+re-registration ``ValueError``. ``raw_pipelines=None`` (the util/no-root path)
+→ an empty registry; an empty/absent ``pipelines:`` block still scans the
+default ``pipelines/`` dir (zero-config UX), yielding an empty registry only
+when that dir is absent/empty.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from reyn.core.pipeline.registry import PipelineRegistry
+
+# Default directories scanned for pipeline DSL files, project-root-relative.
+# Mirrors the skills ``scan_dirs: ["skills"]`` documented default.
+_DEFAULT_SCAN_DIRS: "tuple[str, ...]" = ("pipelines",)
+
+
+class PipelineLoadError(ValueError):
+    """A pipeline DSL file under a scan dir could not be loaded (unreadable,
+    malformed DSL, or a duplicate declared name). Carries the offending file
+    path so the operator can find it — fail-loud, never silent-skip."""
+
+
+def _scan_dirs(raw_pipelines: "dict[str, Any]") -> "list[str]":
+    """The configured scan dirs, or the default. A non-list / empty ``scan_dirs``
+    falls back to the default (lenient, like the skills builder)."""
+    raw = raw_pipelines.get("scan_dirs")
+    if not isinstance(raw, list) or not raw:
+        return list(_DEFAULT_SCAN_DIRS)
+    return [str(d) for d in raw]
+
+
+def build_pipeline_registry(
+    raw_pipelines: "dict[str, Any] | None", project_root: "Path",
+) -> PipelineRegistry:
+    """Build a populated :class:`PipelineRegistry` from the ``pipelines:`` config.
+
+    For each configured (or default) scan dir under ``project_root``, every
+    ``*.yaml`` file (sorted, for deterministic registration order) is read and
+    parsed via ``parse_pipeline_dsl`` into a ``Pipeline`` + its own
+    ``SchemaRegistry`` (so a registered pipeline's ``verify: schema`` steps
+    resolve), then registered under the pipeline's declared ``pipeline:`` name.
+
+    ``raw_pipelines=None`` → an empty registry (the util/no-root path). An
+    empty/absent ``pipelines:`` block still scans the default ``pipelines/``
+    dir (zero-config UX) — empty only when the dir is absent/empty.
+
+    Raises :class:`PipelineLoadError` for a malformed / unreadable file or a
+    duplicate declared name — fail-loud with the path, never silent-skip.
+    """
+    # Deferred import: parser pulls the pipeline executor/schema stack, which is
+    # heavier than this loader's own surface — keep module import cheap.
+    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+    from reyn.core.pipeline.schema import SchemaRegistry
+
+    registry = PipelineRegistry()
+    # ``None`` = the util/no-root path (from_config without a project_root) →
+    # never scan. An empty dict ``{}`` = the DEFAULT config (no ``pipelines:``
+    # block declared) → STILL scan the default ``pipelines/`` dir, so dropping a
+    # file in ``pipelines/`` needs zero config (the intended zero-config UX).
+    if not isinstance(raw_pipelines, dict):
+        return registry
+
+    for rel_dir in _scan_dirs(raw_pipelines):
+        scan_dir = (project_root / rel_dir).resolve()
+        if not scan_dir.is_dir():
+            # A configured dir that doesn't exist yet is not an error (the
+            # operator may add files later) — nothing to load from it.
+            continue
+        for path in sorted(scan_dir.glob("*.yaml")):
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise PipelineLoadError(
+                    f"could not read pipeline file {path}: {exc}"
+                ) from exc
+            schema_registry = SchemaRegistry()
+            try:
+                pipeline = parse_pipeline_dsl(text, schema_registry)
+            except PipelineParseError as exc:
+                raise PipelineLoadError(
+                    f"malformed pipeline file {path}: {exc}"
+                ) from exc
+            name = pipeline.name
+            if not name:
+                # parse_pipeline_dsl requires a non-empty ``pipeline:`` name, so
+                # this is defensive — a hand-built Pipeline with no name has no
+                # key to register under.
+                raise PipelineLoadError(
+                    f"pipeline file {path} produced a pipeline with no declared "
+                    "name — a 'pipeline:' name is required to register it"
+                )
+            try:
+                registry.register(name, pipeline, schema_registry)
+            except ValueError as exc:
+                # Duplicate declared name across files — surface loudly with the
+                # path (the registry's re-registration guard).
+                raise PipelineLoadError(
+                    f"pipeline file {path} declares name {name!r} which is "
+                    f"already registered by an earlier file: {exc}"
+                ) from exc
+    return registry
+
+
+__all__ = ["build_pipeline_registry", "PipelineLoadError"]

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -215,7 +215,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 state_log=state_log,
                 budget_tracker=budget_tracker,
                 # #2093: the uniform reyn.yaml-derived per-session config bundle.
-                factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+                factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
                 agent_id=session_cfg.config.agent.id,
                 # #1402: scoped surface passed EXPLICITLY (required by
                 # build_scoped_chat_session). chainlit's current behaviour
@@ -244,7 +244,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
             session_factory=_session_factory,
             state_log=state_log,
             # #2093: the uniform reyn.yaml-derived registry config bundle.
-            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
         )
         registry_ref.append(registry)
         _REGISTRY = registry

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -414,7 +414,7 @@ def run(args: argparse.Namespace) -> None:
             # #2093: the uniform reyn.yaml-derived per-session config bundle (sandbox /
             # multimodal / action_retrieval / embedding / router / retry /
             # tool-use-scheme) — one source point for all five sites.
-            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
             eager_embedding_build=getattr(args, "eager_embedding_build", False),
             agent_id=session_cfg.config.agent.id,  # FP-0016 E
             exclude_tools=_exclude_tools,  # #187: hide tools (e.g. web) from the LLM catalog
@@ -461,7 +461,7 @@ def run(args: argparse.Namespace) -> None:
         state_log=state_log,
         # #2093: the uniform reyn.yaml-derived registry config bundle
         # (delegation_capability_default) — one source point.
-        factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+        factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
         environment_backend=env_backend,
         workspace_state_dir=ws_state_dir,
     )

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -495,7 +495,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # replace() as an EXPLICIT, visible deviation (not a silent miss) →
                 # behavior byte-identical to before the bundle.
                 factory_config=replace(
-                    SessionFactoryConfig.from_config(config), embedding_config=None,
+                    SessionFactoryConfig.from_config(config, project_root), embedding_config=None,
                 ),
                 # #1289: same backend instance to both seams (single-shared-sandbox).
                 environment_backend=env_backend,
@@ -525,7 +525,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             session_factory=_session_factory,
             state_log=None,
             # #2093: the uniform reyn.yaml-derived registry config bundle.
-            factory_config=SessionFactoryConfig.from_config(config),
+            factory_config=SessionFactoryConfig.from_config(config, project_root),
             environment_backend=env_backend,   # #1544: container shadow-git
             workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
         )

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -426,7 +426,7 @@ def run_serve(args: argparse.Namespace) -> None:
             # #2093: the uniform reyn.yaml-derived per-session config bundle. (The same
             # sandbox_config the A2A/MCP-serve factory once dropped — now it's in the
             # bundle, so it can't be missed here.)
-            factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+            factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
             # #1402: scoped capability surface, passed EXPLICITLY (required by
             # build_scoped_chat_session). The stdio-MCP factory's current
             # behaviour — defaults that document the gaps, NOT new capabilities
@@ -455,7 +455,7 @@ def run_serve(args: argparse.Namespace) -> None:
         session_factory=_session_factory,
         state_log=state_log,
         # #2093: the uniform reyn.yaml-derived registry config bundle.
-        factory_config=SessionFactoryConfig.from_config(session_cfg.config),
+        factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
     )
 
     timeout = float(getattr(args, "timeout", 60.0) or 60.0)

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -327,7 +327,7 @@ def _get_registry():
                 # multimodal / action_retrieval / embedding / router / retry /
                 # op-loops / tool-use-scheme) — one bundle, so a new uniform arg
                 # can't be missed here (the sandbox_config B52 drift class is gone).
-                factory_config=SessionFactoryConfig.from_config(config),
+                factory_config=SessionFactoryConfig.from_config(config, root),
                 eager_embedding_build=_eager_embedding_build,
                 # #1401: the 3 scoped capabilities, filled from the CLI override
                 # holder (env-backend INSTANCE → both FS+exec seams = single-shared
@@ -375,7 +375,7 @@ def _get_registry():
             # #2093: the uniform reyn.yaml-derived registry config
             # (delegation_capability_default) — one bundle, so a new one can't be
             # missed here (the delegation_capability_default #2081 drift).
-            factory_config=SessionFactoryConfig.from_config(config),
+            factory_config=SessionFactoryConfig.from_config(config, root),
             # ``_scoped`` is local to the session factory above; fetch the overrides
             # at this scope via the accessor.
             environment_backend=get_cli_scoped_overrides().environment_backend,

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -39,6 +39,13 @@ class SessionFactoryConfig:
     # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]), built from
     # config.skills. Uniform config-derived arg → reaches all factory sites.
     available_skills: Any
+    # #2575: the populated PipelineRegistry, built ONCE per frontend from
+    # config.pipelines (disk scan → parse → register). Threaded to every Session
+    # (incl. spawns, which reuse this bundle) so the pipelines dir is parsed once
+    # per session tree, not re-globbed per session — mirrors the build-once
+    # available_skills snapshot. Empty registry when project_root is unknown
+    # (direct/test from_config(config)) → byte-identical to pre-#2575.
+    pipeline_registry: Any
     # ── AgentRegistry uniform config (3) ────────────────────────────────────
     delegation_capability_default: str
     # #2103 C3: operator spawn-tree bounds (safety.spawn.*) — the LLM spawn seams
@@ -47,10 +54,27 @@ class SessionFactoryConfig:
     max_spawn_children: int
 
     @classmethod
-    def from_config(cls, config: Any) -> "SessionFactoryConfig":
+    def from_config(
+        cls, config: Any, project_root: "Any | None" = None,
+    ) -> "SessionFactoryConfig":
         """The single mapping point ``ReynConfig`` → the uniform factory args. Add a
-        new uniform arg HERE (and as a field above) → all five factory sites get it."""
+        new uniform arg HERE (and as a field above) → all five factory sites get it.
+
+        ``project_root`` (#2575) is required only to LOAD pipelines from disk (the
+        scan is project-root-relative). The five frontend factory sites pass it;
+        utility/test callers may omit it → an empty PipelineRegistry (no pipelines,
+        byte-identical to pre-#2575). It stays optional (not a bundle field) because
+        it is a filesystem locus, not a ``ReynConfig``-derived value."""
+        from pathlib import Path
+
+        from reyn.data.pipelines.registry import build_pipeline_registry
         from reyn.data.skills.registry import build_skill_registry
+        root = Path(project_root) if project_root is not None else None
+        pipeline_registry = (
+            build_pipeline_registry(config.pipelines, root)
+            if root is not None
+            else build_pipeline_registry(None, Path.cwd())
+        )
         return cls(
             sandbox_config=config.sandbox,
             multimodal_config=config.multimodal,
@@ -62,6 +86,8 @@ class SessionFactoryConfig:
             # #2548 PR-A: build the enabled skill registry once here (filtered to
             # enabled=True) so every factory site threads the same snapshot.
             available_skills=build_skill_registry(config.skills),
+            # #2575: built once here (empty when project_root is unknown).
+            pipeline_registry=pipeline_registry,
             delegation_capability_default=config.delegation.capability_default,
             max_spawn_depth=config.safety.spawn.max_depth,
             max_spawn_children=config.safety.spawn.max_children,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -127,5 +127,6 @@ def build_scoped_chat_session(
         retry_config=factory_config.retry_config,  # #1835
         chat_tool_use_scheme=factory_config.chat_tool_use_scheme,
         available_skills=factory_config.available_skills,  # #2548 PR-A
+        pipeline_registry=factory_config.pipeline_registry,  # #2575
         **base,
     )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -727,6 +727,11 @@ class Session:
         # RouterLoopDriver construction.  None (default) = build RouterLoopDriver
         # from the existing args unchanged (byte-identical behaviour).
         loop_driver: "ExecutionDriver | None" = None,
+        # #2575: the pre-built PipelineRegistry (populated from disk once at the
+        # session factory, SessionFactoryConfig.from_config → build_scoped_chat_
+        # session). None (direct/test construction) → an empty registry, byte-
+        # identical to pre-#2575's own-constructed empty one.
+        pipeline_registry: "PipelineRegistry | None" = None,
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -1056,13 +1061,18 @@ class Session:
         # and for agent-to-agent message routing (PR11). The factory in
         # cli/commands/chat.py wires this; tests can leave it None.
         self._registry = registry
-        # IS-5: Session owns a real (initially empty) PipelineRegistry so
-        # ``run_pipeline`` has a live registry to look up against in
-        # production — populating it from disk / a YAML DSL parser is a
-        # later slice; registration is programmatic for now (mirrors the
-        # pre-parser AgentRegistry posture). Threaded to RouterHostAdapter
-        # below (mirrors ``agent_registry=self._registry`` just above).
-        self._pipeline_registry = PipelineRegistry()
+        # IS-5 / #2575: Session owns a live PipelineRegistry so ``run_pipeline``
+        # has a registry to look up against. The session factory builds it ONCE
+        # from ``config.pipelines`` (disk scan → parse → register) and passes it
+        # in; a direct/test construction with no registry falls back to an empty
+        # one (byte-identical to the pre-#2575 own-constructed empty registry).
+        # Threaded to RouterHostAdapter below (mirrors ``agent_registry=
+        # self._registry`` just above) → RouterCallerState.pipeline_registry →
+        # the universal catalog's ``pipeline`` category enumerator surfaces each
+        # registered pipeline as ``pipeline__<name>`` to the LLM (IS-5 D19).
+        self._pipeline_registry = (
+            pipeline_registry if pipeline_registry is not None else PipelineRegistry()
+        )
         # PR11: max delegation hop depth (LangGraph-style). 0 = user input,
         # each `_send_to_agent` increments. Refuse send when depth > limit.
         self._max_hop_depth = _safety.loop.max_agent_hops

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -1,0 +1,478 @@
+"""#2575 — production pipeline registration: disk dir → session PipelineRegistry.
+
+Before #2575 a ``Session`` owned an EMPTY ``PipelineRegistry`` and nothing in
+production ever populated it, so no pipeline was launchable in a real session.
+This slice adds the disk loader (``reyn.data.pipelines.registry.
+build_pipeline_registry``): an operator drops Appendix-B DSL ``*.yaml`` files
+into ``pipelines/`` (the default scan dir) and each is parsed + registered under
+its OWN declared ``pipeline:`` name at session-factory time.
+
+Coverage:
+  1. Contract — the parser now carries the declared name on ``Pipeline.name``,
+     and serde round-trips it (default-tolerant for pre-existing on-disk data).
+  2. Loader — disk dir → registry keyed by the declared name (filename is a
+     container); malformed / duplicate → FAIL LOUD with the path; empty → empty.
+  3. Wiring — ``from_config(config, project_root)`` builds the registry once;
+     ``Session(pipeline_registry=)`` adopts it.
+  4. Surfacing + invoke — a disk-loaded pipeline surfaces as ``pipeline__<name>``
+     (list_actions) and runs end-to-end through the real router loop.
+  5. Cross-pipeline ``call`` — a loaded pipeline whose step ``call``s ANOTHER
+     loaded pipeline resolves + runs (the foundation's deferred named-callee
+     production registration, now closed).
+  6. Security invariant — the untrusted + delegate floors STILL deny the
+     pipeline launch verbs, independent of what is registered (loading a
+     pipeline does not loosen the floor).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+unittest.mock. The LLM in the full-loop test is a real async callable stub
+(Tier 2c), the designed seam, mirroring test_pipeline_is5_surfacing.py.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, TransformStep
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+from reyn.data.pipelines.registry import PipelineLoadError, build_pipeline_registry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _write(dir_: Path, filename: str, text: str) -> None:
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / filename).write_text(text, encoding="utf-8")
+
+
+_HELLO_DSL = """
+pipeline: hello
+description: greet the seed name
+steps:
+  - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+"""
+
+
+# ── 1. Contract: parser carries the declared name; serde round-trips it ───────
+
+
+def test_parser_populates_declared_name_on_pipeline() -> None:
+    """Tier 1: parse_pipeline_dsl records the declared ``pipeline:`` name on
+    ``Pipeline.name`` — the authoritative key the disk loader registers under
+    and a ``call``/``match`` step resolves against."""
+    from reyn.core.pipeline.parser import parse_pipeline_dsl
+
+    pipeline = parse_pipeline_dsl(_HELLO_DSL, SchemaRegistry())
+
+    assert pipeline.name == "hello"
+
+
+def test_pipeline_name_serde_round_trips_non_default_value() -> None:
+    """Tier 1: a non-default ``name`` survives pipeline_to_dict → from_dict
+    (the work-order / invocation.json persistence used for recovery)."""
+    original = Pipeline(
+        steps=[TransformStep(value="1 + 1", output="two")],
+        description="d",
+        name="my_pipeline",
+    )
+
+    restored = pipeline_from_dict(pipeline_to_dict(original))
+
+    assert restored.name == "my_pipeline"
+    assert restored == original
+
+
+def test_pipeline_from_dict_defaults_name_when_absent() -> None:
+    """Tier 1: an invocation.json persisted before the ``name`` field existed
+    (no ``name`` key) decodes to ``""`` — default-tolerant, never a KeyError."""
+    legacy = {"description": "d", "steps": [{"kind": "transform", "value": "1", "output": "o"}]}
+
+    restored = pipeline_from_dict(legacy)
+
+    assert restored.name == ""
+
+
+# ── 2. Loader: disk → registry, keyed by declared name; fail-loud ─────────────
+
+
+def test_loader_registers_pipeline_from_disk_under_declared_name(tmp_path: Path) -> None:
+    """Tier 2: a DSL file under the scan dir is parsed + registered under its
+    declared ``pipeline:`` name, with its name + description surfaced via
+    ``entries()`` (what the catalog enumerator reads)."""
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+
+    registry = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    assert set(registry.names()) == {"hello"}
+    assert registry.entries() == (("hello", "greet the seed name"),)
+    assert registry.get("hello").name == "hello"
+
+
+def test_loader_default_scan_dir_is_pipelines(tmp_path: Path) -> None:
+    """Tier 2: an absent ``scan_dirs`` falls back to the default ``pipelines/``
+    dir (the documented default), so a bare ``pipelines: {}`` still loads."""
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+
+    registry = build_pipeline_registry({}, tmp_path)
+
+    assert set(registry.names()) == {"hello"}
+
+
+def test_loader_keys_on_declared_name_not_filename(tmp_path: Path) -> None:
+    """Tier 2: the declared ``pipeline:`` name is authoritative — a file named
+    ``greet.yaml`` declaring ``pipeline: hello`` registers as ``hello`` (the
+    identity a ``call`` resolves against), NOT under the file stem. Registering
+    under the filename while ``call`` resolves the declared name would be a
+    call that can never find its target."""
+    _write(tmp_path / "pipelines", "greet.yaml", _HELLO_DSL)  # file stem = "greet"
+
+    registry = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    assert set(registry.names()) == {"hello"}  # declared name, not "greet"
+
+
+def test_loader_malformed_file_fails_loudly_with_path(tmp_path: Path) -> None:
+    """Tier 2: a malformed DSL file raises PipelineLoadError naming the file —
+    NOT a silent skip (a typo must not silently drop a pipeline the operator
+    meant to ship)."""
+    _write(tmp_path / "pipelines", "broken.yaml", "pipeline: broken\nsteps: not-a-list\n")
+
+    with pytest.raises(PipelineLoadError) as exc:
+        build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    assert "broken.yaml" in str(exc.value)
+
+
+def test_loader_duplicate_declared_name_fails_loudly(tmp_path: Path) -> None:
+    """Tier 2: two files declaring the SAME ``pipeline:`` name surface the
+    registry's re-registration guard as a loud load error (with the offending
+    file path), never a silent last-wins overwrite."""
+    _write(tmp_path / "pipelines", "a.yaml", _HELLO_DSL)
+    _write(tmp_path / "pipelines", "b.yaml", _HELLO_DSL)  # also declares "hello"
+
+    with pytest.raises(PipelineLoadError) as exc:
+        build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    assert "hello" in str(exc.value)
+
+
+def test_loader_empty_config_yields_empty_registry(tmp_path: Path) -> None:
+    """Tier 2: ``None`` (util/no-root path) → empty. An empty ``{}`` block scans
+    the default ``pipelines/`` dir but yields empty here because that dir is
+    absent — byte-identical to the pre-#2575 own-constructed empty registry."""
+    assert build_pipeline_registry(None, tmp_path).names() == ()
+    assert build_pipeline_registry({}, tmp_path).names() == ()  # dir absent → nothing
+
+
+def test_loader_missing_scan_dir_is_not_an_error(tmp_path: Path) -> None:
+    """Tier 2: a configured scan dir that does not exist yet is not an error
+    (the operator may add files later) — it simply contributes nothing."""
+    registry = build_pipeline_registry({"scan_dirs": ["does_not_exist"]}, tmp_path)
+
+    assert registry.names() == ()
+
+
+# ── 3. Wiring: from_config build-once + Session adoption ──────────────────────
+
+
+def test_from_config_builds_populated_registry_from_project_root(tmp_path: Path) -> None:
+    """Tier 2: SessionFactoryConfig.from_config(config, project_root) builds the
+    registry ONCE from ``config.pipelines`` + the project root — the build-once
+    locus (mirrors the available_skills snapshot)."""
+    from reyn.config.loader import load_config
+    from reyn.runtime.factory_config import SessionFactoryConfig
+
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+    config = load_config()  # no reyn.yaml → default pipelines: {} → default scan dir
+
+    fc = SessionFactoryConfig.from_config(config, tmp_path)
+
+    assert set(fc.pipeline_registry.names()) == {"hello"}
+
+
+def test_from_config_without_project_root_is_empty(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: from_config(config) with no project_root → an EMPTY registry even
+    if a pipelines/ dir exists at cwd — the util/test path stays byte-identical
+    to pre-#2575 (no accidental disk scan without an explicit root)."""
+    from reyn.config.loader import load_config
+    from reyn.runtime.factory_config import SessionFactoryConfig
+
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+    monkeypatch.chdir(tmp_path)
+
+    fc = SessionFactoryConfig.from_config(load_config())
+
+    assert fc.pipeline_registry.names() == ()
+
+
+def test_session_adopts_passed_pipeline_registry(tmp_path: Path) -> None:
+    """Tier 2: Session(pipeline_registry=X) adopts X as its live registry (the
+    factory threads the disk-loaded one); None → its own empty registry."""
+    from reyn.runtime.session import Session
+
+    loaded = PipelineRegistry()
+    loaded.register("hello", Pipeline(steps=[TransformStep(value="1", output="o")], name="hello"))
+
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "wal.jsonl"),
+        pipeline_registry=loaded,
+    )
+
+    assert session.pipeline_registry is loaded
+    assert session.router_host.get_pipeline_registry() is loaded
+
+
+def test_session_without_registry_owns_empty_one(tmp_path: Path) -> None:
+    """Tier 2: a direct/test Session with no pipeline_registry falls back to its
+    own empty PipelineRegistry — byte-identical to pre-#2575."""
+    from reyn.runtime.session import Session
+
+    session = Session(agent_name="a", state_log=StateLog(tmp_path / "wal.jsonl"))
+
+    assert isinstance(session.pipeline_registry, PipelineRegistry)
+    assert session.pipeline_registry.names() == ()
+
+
+# ── 4. Surfacing: a disk-loaded pipeline shows as pipeline__<name> ────────────
+
+
+class _FakeHost:
+    """Minimal RouterLoopHost stub — real shape, no mock framework (mirrors
+    test_pipeline_is5_surfacing.py's precedent)."""
+
+    agent_name: str = "test-agent"
+    agent_role: str = ""
+    output_language: str = "en"
+
+    def __init__(self, *, pipeline_registry: Any) -> None:
+        self._pipeline_registry = pipeline_registry
+
+        class _E:
+            def emit(self, *a, **kw): pass
+            subscribers: list = []
+        self._events = _E()
+        self.get_pipeline_registry = lambda: self._pipeline_registry  # type: ignore[method-assign]
+        self.get_agent_registry = lambda: None  # type: ignore[method-assign]
+
+    @property
+    def events(self): return self._events
+
+    def get_universal_wrappers_enabled(self) -> bool: return True
+    def get_action_usage_tracker(self): return None
+    def get_action_embedding_index(self): return None
+    def get_embedding_provider(self): return None
+    def get_embedding_model_class(self): return None
+    def get_action_retrieval_config(self): return None
+    def list_available_skills(self) -> list[dict]: return []
+    def list_available_agents(self) -> list[dict]: return []
+    def get_memory_index(self) -> dict: return {"status": "not_found", "content": ""}
+    def get_file_permissions(self): return None
+    def get_mcp_servers(self) -> list[dict]: return []
+    def get_web_fetch_allowed(self) -> bool: return False
+    def get_project_context(self) -> str: return ""
+    def get_sandbox_backend(self): return None
+    def resolve_model(self, name: str) -> str: return "fake-model"
+
+
+@pytest.mark.asyncio
+async def test_disk_loaded_pipeline_surfaces_in_list_actions(tmp_path: Path) -> None:
+    """Tier 2: a pipeline loaded from disk surfaces as ``pipeline__<name>`` with
+    its own description via list_actions(category=["pipeline"]) — the enumerate
+    path the default scheme flat-lists. Proves disk-load → catalog end-to-end."""
+    from reyn.runtime.router_loop import RouterLoop
+    from reyn.tools.types import ToolContext
+    from reyn.tools.universal_catalog import LIST_ACTIONS
+
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+    registry = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    loop = RouterLoop(host=_FakeHost(pipeline_registry=registry), chain_id="c1", router_model="standard")
+    rs = await loop._build_router_caller_state()
+    ctx = ToolContext(
+        events=loop.host.events, permission_resolver=None, workspace=None,
+        caller_kind="router", router_state=rs,
+    )
+
+    result = await LIST_ACTIONS.handler({"category": ["pipeline"]}, ctx)
+
+    items = {it["qualified_name"]: it for it in result["items"]}
+    assert "pipeline__hello" in items
+    assert items["pipeline__hello"]["short_description"] == "greet the seed name"
+
+
+# ── 5. Cross-pipeline call: a loaded pipeline calls another loaded pipeline ────
+
+
+@pytest.mark.asyncio
+async def test_disk_loaded_pipeline_call_resolves_and_runs_end_to_end(tmp_path: Path) -> None:
+    """Tier 2: two pipelines loaded FROM DISK — one whose ``call`` step targets
+    the other by its declared name — resolve + run end-to-end. This closes the
+    foundation's deferred named-callee production registration: a ``call``
+    against a disk-registered pipeline now works in production."""
+    callee_dsl = """
+pipeline: inner
+description: inner callee
+steps:
+  - transform: {value: "ctx.seed + '-inner'", output: out}
+"""
+    caller_dsl = """
+pipeline: outer
+description: calls inner
+steps:
+  - call: {pipeline: inner, pass: [seed], output: called}
+  - transform: {value: "ctx.called + '-outer'", output: final}
+"""
+    _write(tmp_path / "pipelines", "inner.yaml", callee_dsl)
+    _write(tmp_path / "pipelines", "outer.yaml", caller_dsl)
+
+    registry = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+    outer = registry.get("outer")
+
+    result = await PipelineExecutor().run(
+        outer, {"seed": "x"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None,
+        run_id="run-2575-call",
+        pipeline_registry=registry,  # the SAME disk-loaded registry resolves the callee
+    )
+
+    assert result.named_stores["called"] == "x-inner"
+    assert result.named_stores["final"] == "x-inner-outer"
+
+
+# ── 6. Security invariant: the floors STILL deny the launch verbs ─────────────
+
+
+_PIPELINE_LAUNCH_VERBS = (
+    "run_pipeline", "pipeline__run",
+    "run_pipeline_async", "pipeline__run_async",
+    "run_pipeline_inline", "pipeline__run_inline",
+    "run_pipeline_inline_async", "pipeline__run_inline_async",
+)
+
+
+@pytest.mark.parametrize("profile_factory_name", ["builtin_untrusted_profile", "builtin_delegate_profile"])
+def test_floor_still_denies_pipeline_launch_verbs(profile_factory_name: str) -> None:
+    """Tier 2: BOTH the untrusted-content floor and the unbound-delegate floor
+    deny every pipeline launch verb (bare + qualified, sync/async/inline) — the
+    #2575 security invariant. This slice adds a POPULATION path; it must not
+    loosen the floor. A regression here (floor drops a pipeline verb) means an
+    untrusted-content turn / an unbound delegate could launch a pipeline (a
+    cost-bound multi-step spawn)."""
+    import reyn.security.permissions.capability_profile as cp
+    from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+
+    profile = getattr(cp, profile_factory_name)()
+    contextual, _ = cp.resolve_profile(profile)
+    layer = ContextualLayer(contextual)
+
+    for verb in _PIPELINE_LAUNCH_VERBS:
+        assert layer.allows(CapabilityAxis.TOOL, verb) is False, verb
+
+
+def test_loading_a_pipeline_does_not_loosen_the_floor(tmp_path: Path) -> None:
+    """Tier 2: the floor is registration-INDEPENDENT — a populated registry
+    (a real disk-loaded pipeline) does not create a bypass. The resolved
+    untrusted floor still denies the launch verbs the loaded pipeline would be
+    reached through (``pipeline__<name>`` curries to the denied run_pipeline
+    target)."""
+    import reyn.security.permissions.capability_profile as cp
+    from reyn.security.permissions.effective import CapabilityAxis, ContextualLayer
+
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+    registry = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+    assert "hello" in registry.names()  # a pipeline IS registered
+
+    contextual, _ = cp.resolve_profile(cp.builtin_untrusted_profile())
+    layer = ContextualLayer(contextual)
+
+    # the loaded pipeline resolves (D19) to the run_pipeline target — still denied
+    assert layer.allows(CapabilityAxis.TOOL, "run_pipeline") is False
+    assert layer.allows(CapabilityAxis.TOOL, "pipeline__run") is False
+
+
+# ── 4b. Full live loop: disk-loaded pipeline invoked via pipeline__<name> ─────
+
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _make_llm_stub(results: list[LLMToolCallResult]):
+    call_count = [0]
+
+    async def _stub(**kwargs) -> LLMToolCallResult:
+        idx = call_count[0]
+        call_count[0] += 1
+        return results[idx] if idx < len(results) else results[-1]
+
+    return _stub
+
+
+@pytest.mark.asyncio
+async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2c: an agent launches a DISK-LOADED pipeline through the REAL router
+    loop via the ``pipeline__<name>`` form the enumerator advertises, and its
+    real transform output round-trips into chat history — the disk→surface→
+    invoke chain end-to-end (not the handler in isolation)."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+    loaded = build_pipeline_registry({"scan_dirs": ["pipelines"]}, tmp_path)
+
+    state_log = StateLog(tmp_path / ".reyn" / "state.wal")
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            chat_tool_use_scheme="universal-category",
+            pipeline_registry=loaded,  # the disk-loaded registry, threaded as the factory would
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("test_agent")
+    session = reg.get_or_load("test_agent")
+    session.is_attached = True
+
+    invoke = LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": "tc_1", "type": "function",
+            "function": {
+                "name": "invoke_action",
+                "arguments": json.dumps({
+                    "action_name": "pipeline__hello",
+                    "args": {"input": {"name": "Reyn"}},
+                }),
+            },
+        }],
+        finish_reason="tool_calls", usage=_EMPTY_USAGE,
+    )
+    text = LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+    )
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools", _make_llm_stub([invoke, text]),
+    )
+
+    await session._handle_user_message("run hello", chain_id="chain-2575")
+
+    tool_messages = [m for m in session.history if m.role == "tool"]
+    assert tool_messages, "expected a tool-result history entry"
+    payload = json.loads(tool_messages[-1].content)
+    assert payload["status"] == "ok"
+    inner = payload["data"]
+    assert inner["status"] == "ok"
+    assert inner["data"]["output"] == "Hello, Reyn!"

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -50,6 +50,7 @@ steps:
 
     assert pipeline == Pipeline(
         description="a small linear pipeline",
+        name="demo",  # #2575: the parser now carries the declared ``pipeline:`` name
         steps=[
             TransformStep(value="ctx.x + 1", output="bumped"),
             ToolStep(


### PR DESCRIPTION
**[lead-sonnet]** — Stage 1 of #2575, direction A (owner-confirmed via lead-coder). Makes the pipeline feature reachable in production by **populating** the session's `PipelineRegistry` from disk.

## Premise correction (why this replaced the original "grant a capability" framing)
The Phase-1 trace found the reachability block was **not** the capability floor. A default/root chat agent is already unconstrained on the tool axis (`resolved_profile_for` → `(None, ∅)`); the untrusted/`_delegate` floors only apply to tainted-context / unbound-delegate loads. The real gap was two-fold: (1) the `PipelineRegistry` was **never populated** in production (zero non-test `register()` callers), and (2) the default `enumerate-all` scheme only flat-lists **registered** `pipeline__<name>` entries. So the fix is a registration path, not a capability grant. Owner confirmed direction A.

## What this does
An operator drops Appendix-B DSL `*.yaml` files into `pipelines/` (project-root source, like `skills/` — **not** `.reyn/` run-authored state, per `reyn-dir-layout.md`) and each is parsed + registered at session start under its **declared `pipeline:` name** (authoritative for `call`/`match` resolution; the file name is just a container).

- **`Pipeline.name`** — the parser now carries the declared name on the dataclass (default `""`); serde round-trips it (default-tolerant for pre-existing on-disk `invocation.json`). No `parse_pipeline_dsl` signature change (no caller ripple).
- **Loader** `src/reyn/data/pipelines/registry.py` — glob `*.yaml` (sorted) → `parse_pipeline_dsl` → register under the declared name. Malformed / duplicate name → **fail loud with the path** (never silent-skip). Empty/no dir → empty registry.
- **Config** — `pipelines: {scan_dirs: [...]}` on `ReynConfig` (default `["pipelines"]`). Zero-config: dropping a file in `pipelines/` needs no `reyn.yaml` entry.
- **Build-once wiring** — `SessionFactoryConfig.from_config(config, project_root)` builds the registry once (mirrors the `available_skills` snapshot) → `build_scoped_chat_session` → `Session(pipeline_registry=)`. `None`/no-root → empty (byte-identical). All 5 frontend factory sites pass `project_root`.
- **Sample** `pipelines/hello.yaml` (dogfoodable out of the box) + operator doc `docs/concepts/runtime/pipeline-registration.md`.

## Security invariant (intact)
Registration does **not** loosen the floor. The untrusted (`_untrusted`) and unbound-delegate (`_delegate`) floors still deny every pipeline launch verb (`run_pipeline`/`_async`/`_inline`/`_inline_async` + `pipeline__*`), independent of what is registered — a loaded `pipeline__<name>` curries to the denied `run_pipeline` target. Regression test covers both floors + a "loading doesn't loosen" assertion.

## Tests (real instances, no mocks; Tier docstrings)
`tests/test_2575_pipeline_disk_registration.py` (20 tests): contract (parser name + serde round-trip, default-tolerant); loader (declared-name key, filename≠declared, malformed-loud, duplicate-loud, empty, zero-config default dir); wiring (`from_config` build-once, `Session` adoption); surfacing (`list_actions` → `pipeline__hello`); **cross-pipeline `call`** loaded→loaded e2e (closes the foundation's deferred named-callee production registration); **full live router loop** disk→invoke via `pipeline__<name>`; **security floor** regression (both profiles). Updated one IS-3 exact-equality assertion for the new `name` field.

## CI gates (local)
- `ruff check src tests` — clean.
- `test_tier_audit.py --strict` (both changed test files) — 33/33 OK, 0 Tier-4.
- `verify_module_docstrings.py` (all changed src) — OK.
- `pytest` — changed area green: pipeline/session/factory/config sweeps (273 + 61 + 574 passed). The only local reds are pre-existing env gaps (`ModuleNotFoundError: mcp`, missing `uvicorn`) — those tests fail at optional-dep import before any of my code runs; CI has the deps.

## Test plan
- [x] Loader parses + registers a real DSL file from disk (unit + smoke).
- [x] Surfaces as `pipeline__<name>` in `list_actions`.
- [x] Invokable end-to-end through the real router loop.
- [x] Cross-pipeline `call` resolves against another disk-loaded pipeline.
- [x] Malformed / duplicate fail loud with the path.
- [x] Untrusted + `_delegate` floors still deny pipeline launch verbs.
- [x] `pipelines/hello.yaml` loads via the default scan dir (verified live).

Closes #2575

🤖 Generated with [Claude Code](https://claude.com/claude-code)