### PR TITLE
feat(pipeline): for_each primitive + fan-out substrate (concurrent recovery + S5 spawn bound)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -411,8 +411,10 @@ safety:
     block_severity: block      # min severity that blocks at write seams: block | warn
     custom_patterns: []        # operator [regex, id, scope, severity] extensions
   spawn:
-    max_depth: 10              # max LLM spawn-lineage chain depth (agent_spawn); 0 = unlimited
-    max_children: 20           # max fan-out: direct children per parent AND topology size; 0 = unlimited
+    max_depth: 10                     # max LLM spawn-lineage chain depth (agent_spawn); 0 = unlimited
+    max_children: 20                  # max fan-out: direct children per parent AND topology size; 0 = unlimited
+    max_pipeline_fan_out_depth: 5     # max pipeline for_each fan-out NESTING depth; 0 = unlimited
+    max_pipeline_spawns: 100          # max ephemeral sessions ONE pipeline run may spawn; 0 = unlimited
 ```
 
 ### `safety.loop` fields
@@ -470,6 +472,8 @@ When a spawn would exceed a limit, the `safety.on_limit` checkpoint fires — th
 |------|------|---------|-------------|
 | `safety.spawn.max_depth` | int | `10` | Maximum spawn-lineage chain depth (operator-top = 0; each `agent_spawn` +1). Exceeding this fires the `safety.on_limit` checkpoint. `0` = unlimited. |
 | `safety.spawn.max_children` | int | `20` | Maximum fan-out: governs BOTH the direct spawn-children per parent (`agent_spawn`) AND the member count of a `topology_create`d topology (org size). Exceeding this fires the `safety.on_limit` checkpoint. `0` = unlimited. |
+| `safety.spawn.max_pipeline_fan_out_depth` | int | `5` | Pipeline fan-out NESTING bound: the max depth of nested `for_each` scopes (a top-level `for_each` = 1; a `for_each` inside another's `do`/`collect` = 2; …). A `for_each` exceeding this FAILS the step (bounded-by-construction; no `on_limit` prompt — pipeline runs are non-interactive). Distinct from `max_depth` (spawn lineage): a pipeline agent-step carries no lineage, so `max_depth` does not cover fan-out. `0` = unlimited. |
+| `safety.spawn.max_pipeline_spawns` | int | `100` | Pipeline spawn-COUNT bound: the max ephemeral sessions ONE pipeline run may spawn across all its `agent` steps (top-level or fanned out via `for_each`). A per-run monotonic counter; the spawn past the cap FAILS the step. The ONLY spawn-count enforcement for lineage-less pipeline agent-steps (`max_children` does not cover them). `0` = unlimited. |
 
 See [`safety.on_limit` fields](#safetyonlimit-fields) for the mode settings.
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -601,6 +601,8 @@
 #   spawn:                          # #2103 C3: operator bounds on the LLM spawn tree (DoS guard)
 #     max_depth: 10                 # max spawn-lineage chain depth (agent_spawn); 0 = unlimited
 #     max_children: 20              # max fan-out: direct children per parent AND topology size; 0 = unlimited
+#     max_pipeline_fan_out_depth: 5 # #2187 for_each: max pipeline for_each fan-out NESTING depth; 0 = unlimited
+#     max_pipeline_spawns: 100      # #2187 for_each: max ephemeral sessions ONE pipeline run may spawn; 0 = unlimited
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -219,10 +219,29 @@ class SpawnConfig:
             single parent may have (``agent_spawn``) AND (b) the member count of a
             ``topology_create``d topology (org size). A spawn/wire that would exceed
             it is rejected. ``0`` = unlimited.
+        max_pipeline_fan_out_depth:
+            Pipeline S5 guard (b): the maximum NESTING depth of ``for_each``
+            fan-out scopes (a top-level for_each = depth 1; a for_each inside
+            another for_each's ``do``/``collect`` = depth 2; …). A for_each that
+            would exceed this fails the step rather than spawning. Distinct from
+            ``max_depth`` (the spawn-LINEAGE chain): a pipeline agent-step reaches
+            ``spawn_ephemeral_session`` with no lineage, so ``max_depth`` does not
+            cover fan-out — this is the fan-out-nesting bound. ``0`` = unlimited.
+        max_pipeline_spawns:
+            Pipeline S5 guard (c): the maximum number of ephemeral sessions ONE
+            pipeline run may spawn across ALL its ``agent`` steps (top-level or
+            fanned out via ``for_each``). The ONLY spawn-COUNT enforcement for
+            pipeline agent-steps (they carry no spawn lineage, so ``max_children``
+            does not cover them). A per-run monotonic counter; a spawn past the cap
+            fails the step. ``0`` = unlimited.
     """
 
     max_depth: int = 10
     max_children: int = 20
+    # Pipeline S5 fan-out spawn bounds (#2187 for_each). Conservative finite
+    # defaults; 0 = unlimited (operator opt-out).
+    max_pipeline_fan_out_depth: int = 5
+    max_pipeline_spawns: int = 100
 
 
 @dataclass

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -664,6 +664,12 @@ def _build_safety_config(raw: object) -> SafetyConfig:
     spawn = SpawnConfig(
         max_depth=int(spawn_raw.get("max_depth", spawn_defaults.max_depth)),
         max_children=int(spawn_raw.get("max_children", spawn_defaults.max_children)),
+        max_pipeline_fan_out_depth=int(spawn_raw.get(
+            "max_pipeline_fan_out_depth", spawn_defaults.max_pipeline_fan_out_depth,
+        )),
+        max_pipeline_spawns=int(spawn_raw.get(
+            "max_pipeline_spawns", spawn_defaults.max_pipeline_spawns,
+        )),
     )
     return SafetyConfig(
         loop=loop, timeout=timeout, on_limit=on_limit, threat_scan=threat_scan,

--- a/src/reyn/core/pipeline/analyzer.py
+++ b/src/reyn/core/pipeline/analyzer.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
-from reyn.core.pipeline.executor import CallStep, FoldStep, MatchStep
+from reyn.core.pipeline.executor import CallStep, FoldStep, ForEachStep, MatchStep
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.executor import Step
@@ -110,6 +110,43 @@ def _fold_facet(step: "FoldStep") -> "list[str]":
     return problems
 
 
+def _for_each_facet(step: "ForEachStep") -> "list[str]":
+    """``for_each``'s S5 STATIC contribution (the analysis-time half of the
+    spawn-bound guards — the runtime half is the Semaphore / fan_out_depth /
+    SpawnBudget in the executor). WARNING-only, mirroring ``_fold_facet``'s
+    posture (the runtime defaults keep an omitted cap finite per Hard rule 9):
+
+    - flags a ``max_parallel``-less fan-out (runtime falls back to a bounded
+      default, but the concurrency width is not a number the analyzer can state
+      ahead of time — same "not statically known" caution ``fold`` raises for an
+      uncapped ``over``);
+    - flags an ``over``-sourced fan-out (the item COUNT is a runtime ctx value,
+      so the total spawn footprint = count x do-spawns is not statically
+      computable — ``for_each`` has no ``max_items`` field to bound it, unlike
+      ``fold``).
+
+    The precise items x depth x do-spawn total-spawn computation (rejecting at
+    analysis time when a STATICALLY-countable fan-out already exceeds the total
+    cap) needs cross-pipeline context — the callee/do's own transitive spawn
+    footprint — which the per-step facet does not have; it lands with the
+    cross-pipeline analyzer walker, the same deferral ``call``/``match`` make.
+    Returns problem strings (empty = OK)."""
+    problems: "list[str]" = []
+    if step.max_parallel is None:
+        problems.append(
+            "for_each step has no 'max_parallel' — live concurrency falls back to a "
+            "runtime-bounded default (never unbounded), but the fan-out width is not "
+            "statically known ahead of run time"
+        )
+    if step.over is not None:
+        problems.append(
+            "for_each step reads its item list from 'over' (a runtime ctx path) — the "
+            "item COUNT, hence the total spawn footprint, is not statically known "
+            "ahead of run time (for_each has no 'max_items' bound)"
+        )
+    return problems
+
+
 # Facet registry: step type -> its static-analysis check. A future primitive
 # ADDS an entry here (mirroring the executor's ``STEP_DISPATCH``, serde's
 # ``ENCODERS``/``DECODERS``, and the parser's ``_STEP_PARSERS``) — the P4
@@ -119,6 +156,7 @@ ANALYZER_FACETS: "dict[type, Callable[[Step], list[str]]]" = {
     CallStep: _call_facet,
     MatchStep: _match_facet,
     FoldStep: _fold_facet,
+    ForEachStep: _for_each_facet,
 }
 
 

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -7,9 +7,29 @@ sequence of ``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell
 ...)``) / ``agent`` (R5) steps, plus three COMPOSITIONAL primitives: ``call``
 (R7, a STATIC callee), ``match`` (``call``'s runtime-selected sibling — the
 ``on`` VALUE picks a LABEL, never a target; see :class:`MatchStep`), and
-``fold`` (the sequential accumulator, Appendix B). Still out of scope for this
-slice: `for_each`/`parallel`/`refine` — those are later primitives that plug
-into the SAME dispatch + scope machinery this module now exposes.
+``fold`` (the sequential accumulator, Appendix B), and ``for_each`` (the
+CONCURRENT fan-out — ``fold``'s parallel, isolated-sub-scope sibling; see
+:class:`ForEachStep` and :func:`_run_for_each_step`). Still out of scope for
+this slice: `parallel`/`refine` — those are later primitives that plug into the
+SAME dispatch + scope machinery this module now exposes (``parallel`` is the
+additive follow-up built on ``for_each``'s fan-out substrate).
+
+**Fan-out recovery commit unit = the ITEM (READ THIS before touching
+``for_each`` recovery).** ``for_each`` runs ``do`` over each list item as an
+ISOLATED concurrent sub-scope (Hard rule 6: read-only ctx, no sibling comm), a
+coordinator recording each item's result AS IT LANDS via ``asyncio.as_completed``
+(never bare ``gather``). The recovery commit unit is the ITEM: a LANDED item is
+exactly-once (its key is durable before the next boundary; resume replays it,
+never re-runs it). A single-step ``do`` (the common case) therefore has NO
+recovery gap — it is exactly-once identical to a durable step. The ONE gap: a
+COMPOSITIONAL ``do`` (``call``/``match``/``fold``) that is IN-FLIGHT at a crash
+re-runs ATOMICALLY on resume (its item key was never recorded), so its already-
+completed INTERNAL side effects may re-fire — because item tasks record through a
+NO-OP recorder (only the single coordinator coroutine calls the real ``record``,
+serialized by construction, avoiding the read-modify-write race concurrent
+per-task recording would cause). Per-internal-sub-step durability for
+compositional fan-out items (a lock-guarded serialized-recorder path) is a
+tracked follow-up, not a silent gap.
 
 **Dispatch tables (R7 — the parallel-primitive seam).** Step execution is a
 ``dict``-dispatch keyed by the step's dataclass type
@@ -79,9 +99,10 @@ hooks default off.
 """
 from __future__ import annotations
 
+import asyncio
 import inspect
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
@@ -297,7 +318,70 @@ class FoldStep:
     max_items: "int | None" = None
 
 
-Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep, FoldStep]
+@dataclass(frozen=True)
+class ForEachStep:
+    """The CONCURRENT fan-out primitive (Appendix B: ``for_each = {over?:PATH |
+    items?:[LIT*] max_parallel? on_error:continue|abort|retry(n) do:Step
+    collect:Step}``) — ``fold``'s parallel, isolated sibling. Where ``fold``
+    walks a list SEQUENTIALLY threading an accumulator, ``for_each`` runs ``do``
+    over each item as an ISOLATED concurrent sub-scope (Hard rule 6: each item
+    gets its OWN copied ``ctx``, no sibling communication), then runs ``collect``
+    ONCE over the ordered results list — ``collect``'s result is this step's N2
+    return value / pipe-data.
+
+    - List source (mutually exclusive; the parser rejects both together):
+      ``over`` (an R1 expression source, evaluated against ``{ctx, pipe}`` like
+      ``transform.value``) | ``items`` (a static Python literal list) | neither,
+      falling back to the incoming PIPE DATA (the same convention ``fold`` uses).
+    - ``do`` runs once per item; item ``item_idx``'s context is ``{"ctx": <a
+      COPY of the outer named stores — isolation>, "pipe": <this for_each step's
+      OWN incoming pipe-data, held constant across every item, the per-item analog
+      of Hard rule 5's "callee's first step sees the caller's pipe-data at the
+      call site">, "item": <the item_idx-th element>}``. There is NO ``acc``
+      (that is ``fold``-only) and NO sibling visibility — an item cannot see any
+      other item's result (writes happen only in ``collect``, Hard rule 6).
+    - ``max_parallel`` (S5 guard a — the Semaphore cap): live concurrency is
+      gated to ``max_parallel`` items at once; omitted, it defaults to a
+      conservative finite value (``min(len(items), _DEFAULT_MAX_PARALLEL)``) —
+      NEVER unbounded-by-omission.
+    - ``on_error`` is REQUIRED (Appendix B gives it no ``?`` — a fan-out author
+      MUST state the completeness policy explicitly, unlike ``parallel`` whose
+      ``on_error?`` defaults to ``abort``). One of: ``continue`` (a failed item
+      is DROPPED from the results list — recorded with a kind-marker so resume
+      does not re-run it, see :func:`_run_for_each_step`); ``abort`` (a failed
+      item cancels the still-pending items and fails the whole step); or
+      ``retry(n)`` (re-run the failed item's ``do`` up to ``n`` more times, then
+      fall back to ``abort`` if still failing — only ``continue`` ever silently
+      drops).
+    - ``collect`` runs ONCE, sequentially, AFTER the fan-out, over the ordered
+      list of surviving item results (dropped items filtered out via the ONE
+      shared filter used identically live and on resume-replay).
+
+    Recovery (see the module docstring's "commit unit = the ITEM"): item
+    ``item_idx``'s ``do`` result records at the FLAT dotted key
+    ``f"{label}.for_each.{item_idx}"`` (a compositional ``do`` adds its own
+    deeper levels naturally, e.g. ``f"{label}.for_each.{item_idx}.call.{j}"`` —
+    ``for_each`` invents no extra index level of its own, same as ``fold``).
+    ``collect`` records at ``f"{label}.for_each.collect"``. A landed item is
+    exactly-once; a dropped item stays dropped forever (its kind-marker key is
+    present, so resume never re-runs it); resume re-runs ONLY the items whose key
+    is ABSENT, then runs ``collect`` iff its key is absent."""
+
+    do: "Step"
+    collect: "Step"
+    on_error: str
+    over: "str | None" = None
+    items: "list[Any] | None" = None
+    max_parallel: "int | None" = None
+    # R3's uniform output rule: ``collect``'s result is this step's N2 return /
+    # pipe-data, and is ALSO written to a named store iff ``output`` is declared
+    # (optional, like ``call``/``match`` — Appendix B's compact grammar omits it,
+    # but the uniform rule applies to every step). The executor's outer loop reads
+    # ``step.output`` on every Step, so this field must exist on the union member.
+    output: "str | None" = None
+
+
+Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep, FoldStep, ForEachStep]
 
 
 @dataclass(frozen=True)
@@ -384,6 +468,95 @@ Recorder = Callable[..., Awaitable[None]]
 
 _PROMPT_REF_RE = re.compile(r"\{([^{}]+)\}")
 
+# S5 spawn-bound conservative defaults (used when run/resume is called without
+# explicit operator caps — never unbounded-by-omission). ``0`` on the effective
+# cap means "unlimited" (operator opt-out), mirroring ``SpawnConfig``'s convention.
+_DEFAULT_MAX_PARALLEL = 8
+_DEFAULT_MAX_FAN_OUT_DEPTH = 5
+_DEFAULT_MAX_PIPELINE_SPAWNS = 100
+
+# The kind-marker an ``on_error:continue`` DROPPED fan-out item records under its
+# item key — NOT absent (resume would re-run an absent key) and NOT bare None
+# (a legit ``do`` result). Recognised on read by EXACT key-set equality (see
+# :func:`_is_dropped_marker`), the same collision-narrowing discipline
+# ``serde``'s ``__exprref__`` marker uses.
+_FAN_OUT_DROPPED_KEY = "__fan_out_dropped__"
+
+_ON_ERROR_RETRY_RE = re.compile(r"^retry\((?P<n>\d+)\)$")
+
+
+@dataclass(frozen=True)
+class _OnError:
+    """The normalized ``for_each.on_error`` policy. ``kind`` is ``"continue"`` |
+    ``"abort"`` | ``"retry"``; ``retries`` is the extra-attempt count (>0 only
+    for ``retry``). Parsed from the DSL string once (see :func:`_parse_on_error`)
+    so the coordinator branches on an enum, not a re-parsed string."""
+
+    kind: str
+    retries: int = 0
+
+
+def _parse_on_error(raw: str) -> "_OnError":
+    """Normalize a ``for_each.on_error`` DSL string (``"continue"`` / ``"abort"``
+    / ``"retry(N)"``) to an :class:`_OnError`. Raises :class:`PipelineExecutionError`
+    on an unrecognized value (the parser validates this at parse time too — this
+    is the runtime-side defensive parse for a hand-built / serde-round-tripped
+    ``ForEachStep``)."""
+    if raw in ("continue", "abort"):
+        return _OnError(kind=raw)
+    m = _ON_ERROR_RETRY_RE.match(raw)
+    if m is not None:
+        return _OnError(kind="retry", retries=int(m.group("n")))
+    raise PipelineExecutionError(
+        f"for_each on_error {raw!r} is not one of continue|abort|retry(n)"
+    )
+
+
+def _is_dropped_marker(value: Any) -> bool:
+    """True iff ``value`` is a fan-out DROPPED kind-marker (exact 2-key set
+    ``{_FAN_OUT_DROPPED_KEY, 'error'}``) — the ONE shared predicate the collect
+    filter uses identically live AND on resume-replay so a dropped item is
+    excluded from ``collect``'s input the same way both times."""
+    return isinstance(value, dict) and set(value) == {_FAN_OUT_DROPPED_KEY, "error"}
+
+
+class SpawnBudget:
+    """S5 guard (c) — a per-RUN monotonic session-spawn counter. Constructed ONCE
+    per top-level ``run``/``resume`` and shared BY REFERENCE across every nested
+    scope (the one deliberate piece of run-scoped mutable state in this otherwise
+    immutable-threading executor). Every ``AgentStep`` — top-level or reached from
+    a ``call``/``match``/``fold``/``for_each`` — funnels through
+    :func:`_run_agent_step`, which calls :meth:`consume` before spawning, so the
+    cap is COMPLETE-BY-CONSTRUCTION across the whole surface, not just fan-out.
+
+    This closes the CRITICAL GAP the fan-out design found: pipeline agent-steps
+    reach ``spawn_ephemeral_session`` with NO parent/lineage, so the registry's
+    ``SpawnConfig`` (max_depth/max_children over the spawn-lineage) does NOT cover
+    them — this counter is the ONLY enforcement. ``cap == 0`` = unlimited
+    (operator opt-out), mirroring ``SpawnConfig``. Monotonic counter vs a static
+    operator-set finite cap: no LLM-writable path raises it."""
+
+    def __init__(self, cap: int) -> None:
+        self._cap = cap
+        self._spent = 0
+
+    def consume(self, *, label: str) -> None:
+        """Charge one spawn; raise :class:`PipelineExecutionError` (fail the step,
+        never silent) if the cap is already reached."""
+        if self._cap and self._spent >= self._cap:
+            raise PipelineExecutionError(
+                f"step {label} (agent) would exceed the per-run pipeline spawn cap "
+                f"({self._cap}): {self._spent} ephemeral session(s) already spawned "
+                "this run — a for_each fanned out more agent-steps than the operator "
+                "bound allows (S5 spawn guard)"
+            )
+        self._spent += 1
+
+    @property
+    def spent(self) -> int:
+        """The number of spawns charged so far this run (test/observability read)."""
+        return self._spent
+
 
 def _interpolate_prompt(template: str, context: "dict[str, Any]") -> str:
     """Resolve every ``{ctx.dotted.path}`` / ``{pipe}`` reference in an ``AgentStep``
@@ -438,6 +611,17 @@ class _RunDeps:
     pipeline_registry: "PipelineRegistry | None"
     events: "EventLog | None"
     cancel_check: "Callable[[], bool] | None"
+    # S5 fan-out spawn bounds. ``fan_out_depth`` is a PER-BRANCH frozen value:
+    # entering a ``for_each`` threads a ``replace(deps, fan_out_depth=+1)`` copy
+    # into its item/collect sub-scopes, so a nested for_each sees a deeper value
+    # (guard b). ``max_fan_out_depth`` is the run-constant cap (0 = unlimited).
+    # ``spawn_budget`` is the per-RUN mutable counter (guard c), shared by
+    # reference through every ``replace`` (so a bumped ``fan_out_depth`` copy
+    # still charges the SAME budget). Defaults keep pre-for_each callers (and any
+    # ``_RunDeps`` built without these) safe: depth 0, a fresh unlimited budget.
+    fan_out_depth: int = 0
+    max_fan_out_depth: int = _DEFAULT_MAX_FAN_OUT_DEPTH
+    spawn_budget: SpawnBudget = field(default_factory=lambda: SpawnBudget(0))
 
 
 @dataclass(frozen=True)
@@ -507,6 +691,12 @@ async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str,
             f"step {inv.step_label} (agent) requires a registry (AgentRegistry) to "
             "spawn its session, but none was passed to run/resume"
         )
+    # S5 guard (c): charge the per-run spawn budget BEFORE spawning the ephemeral
+    # session. This is the ONLY spawn-count enforcement for pipeline agent-steps
+    # (they reach spawn_ephemeral_session with no parent/lineage, so the
+    # registry's SpawnConfig does not cover them). Every AgentStep — top-level or
+    # fanned out inside a for_each — funnels here, so the cap is complete.
+    deps.spawn_budget.consume(label=inv.step_label)
     prompt = _interpolate_prompt(step.prompt, inv.context)
     try:
         result = await run_agent_step(
@@ -721,6 +911,197 @@ async def _run_fold_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
     return acc, any_durable, completed_step_results
 
 
+def _resolve_list_source(
+    step: "ForEachStep | FoldStep", context: "dict[str, Any]", label: str, kind: str,
+) -> "list[Any]":
+    """Resolve a ``for_each``/``fold`` list source (``over`` R1 expr | ``items``
+    static literal | fallback to incoming pipe-data), validating it IS a list.
+    Shared shape both primitives use (see :class:`FoldStep`/:class:`ForEachStep`)."""
+    if step.over is not None and step.items is not None:  # pragma: no cover - parser-enforced
+        raise PipelineExecutionError(
+            f"step {label} ({kind}): 'over' and 'items' are mutually exclusive list sources"
+        )
+    if step.over is not None:
+        try:
+            source = evaluate_expr(step.over, context)
+        except ExprEvalError as exc:
+            raise PipelineExecutionError(
+                f"step {label} ({kind}) 'over' failed: {exc}"
+            ) from exc
+    elif step.items is not None:
+        source = list(step.items)
+    else:
+        source = context["pipe"]
+    if not isinstance(source, list):
+        raise PipelineExecutionError(
+            f"step {label} ({kind}) list source resolved to a "
+            f"{type(source).__name__}, not a list"
+        )
+    return source
+
+
+def _for_each_results(
+    completed_step_results: "dict[str, Any]", label: str, n: int,
+) -> "list[Any]":
+    """Build ``collect``'s ORDERED input list from the recorded per-item results,
+    FILTERING OUT dropped markers (:func:`_is_dropped_marker`). The ONE shared
+    filter used identically live (all items just landed) AND on resume-replay
+    (all item keys read back from a snapshot) — so a dropped item is excluded
+    from ``collect``'s input exactly the same way both times. Every index in
+    ``range(n)`` MUST have a key by the time this runs (the coordinator only
+    reaches ``collect`` once all items are present)."""
+    out: "list[Any]" = []
+    for item_idx in range(n):
+        value = completed_step_results[f"{label}.for_each.{item_idx}"]
+        if _is_dropped_marker(value):
+            continue
+        out.append(value)
+    return out
+
+
+async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """The CONCURRENT fan-out runner (S5-bounded) — ``fold``'s parallel sibling.
+
+    Resolve the list source, then a SINGLE coordinator coroutine fans ``do`` out
+    over the items via ``asyncio.as_completed`` gated by a ``Semaphore`` (S5 guard
+    a), recording each item's result AS IT LANDS (only the coordinator ever calls
+    the real ``record`` — item tasks use a NO-OP recorder, so there is no
+    concurrent read-modify-write race on ``completed_step_results``; see the
+    module docstring's "commit unit = the ITEM"). ``on_error`` decides an item
+    failure: ``continue`` records a DROPPED kind-marker (so resume never re-runs
+    it); ``retry(n)`` re-runs the item up to ``n`` more times then falls back to
+    ``abort``; ``abort`` cancels the still-pending items and fails the step (the
+    already-landed items stay durably recorded, so a resume after an abort-crash
+    skips them). After every item index has a key, ``collect`` runs ONCE over the
+    filtered ordered results and its result is this step's N2 return value.
+
+    S5 guards: (a) the ``Semaphore`` caps live concurrency; (b) ``fan_out_depth``
+    is +1'd through ``_RunDeps`` into every item/collect sub-scope, failing the
+    step if it would exceed ``max_fan_out_depth``; (c) each ``AgentStep`` reached
+    below charges the shared per-run :class:`SpawnBudget`."""
+    step: ForEachStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    context = inv.context
+    label = inv.step_label
+    completed = inv.completed_step_results
+
+    # Full-completion replay: if collect already ran (its key is present) the whole
+    # for_each is done — replay its N2 result, execute nothing.
+    collect_key = f"{label}.for_each.collect"
+    if collect_key in completed:
+        return completed[collect_key], False, completed
+
+    source = _resolve_list_source(step, context, label, "for_each")
+    n = len(source)
+    on_err = _parse_on_error(step.on_error)
+
+    # S5 guard (b): entering this for_each deepens the fan-out nesting by one.
+    next_depth = deps.fan_out_depth + 1
+    if deps.max_fan_out_depth and next_depth > deps.max_fan_out_depth:
+        raise PipelineExecutionError(
+            f"step {label} (for_each) fan-out depth {next_depth} exceeds the "
+            f"operator cap {deps.max_fan_out_depth} (S5 depth guard) — a for_each "
+            "nested deeper than allowed fails the step rather than spawning"
+        )
+    # Same spawn_budget by reference (guard c is per-run, not per-branch); only the
+    # per-branch fan_out_depth is bumped. Threaded into every item task AND collect.
+    child_deps = replace(deps, fan_out_depth=next_depth)
+
+    outer_stores = context["ctx"]
+    outer_pipe = context["pipe"]
+
+    async def _noop_record(**_kw: Any) -> None:
+        # Item tasks NEVER record: only the single coordinator does (serialized),
+        # so concurrent items cannot race the read-modify-write of the snapshot.
+        return None
+
+    async def _run_item(item_idx: int, item: Any) -> "tuple[int, Any, bool, Exception | None]":
+        # Retry(n) re-runs INSIDE the same task (same semaphore slot — a retry
+        # does not raise live concurrency). Any Exception is an item failure
+        # (CancelledError is BaseException, so it is NOT swallowed here — an
+        # abort-cancel propagates out and the task is gathered in the finally).
+        attempts = 1 + (on_err.retries if on_err.kind == "retry" else 0)
+        last_exc: "Exception | None" = None
+        for _attempt in range(attempts):
+            item_ctx = {"ctx": dict(outer_stores), "pipe": outer_pipe, "item": item}
+            runner = STEP_DISPATCH.get(type(step.do))
+            if runner is None:  # pragma: no cover - Step is a closed union
+                raise PipelineExecutionError(f"unknown step type: {step.do!r}")
+            do_inv = _StepInvocation(
+                executor=inv.executor, step=step.do, context=item_ctx,
+                step_label=f"{label}.for_each.{item_idx}", deps=child_deps,
+                completed_step_results=completed, record=_noop_record,
+            )
+            try:
+                result, durable, _ = await runner(do_inv)
+                return item_idx, result, durable, None
+            except Exception as exc:  # noqa: BLE001 - item-failure boundary (on_error policy)
+                last_exc = exc
+        return item_idx, None, False, last_exc
+
+    # Only items whose key is ABSENT run (resume re-runs exactly the absent ones;
+    # a present success key replays, a present dropped-marker stays dropped).
+    pending = [i for i in range(n) if f"{label}.for_each.{i}" not in completed]
+    any_durable = False
+    if pending:
+        effective_max_parallel = step.max_parallel or min(len(pending), _DEFAULT_MAX_PARALLEL)
+        sem = asyncio.Semaphore(effective_max_parallel)
+
+        async def _gated(item_idx: int, item: Any) -> "tuple[int, Any, bool, Exception | None]":
+            async with sem:
+                return await _run_item(item_idx, item)
+
+        tasks = [asyncio.create_task(_gated(i, source[i])) for i in pending]
+        try:
+            for fut in asyncio.as_completed(tasks):
+                item_idx, result, durable, exc = await fut
+                key = f"{label}.for_each.{item_idx}"
+                if exc is None:
+                    completed = {**completed, key: result}
+                    any_durable = any_durable or durable
+                    await inv.record(completed_step_results=completed, durable=durable)
+                elif on_err.kind == "continue":
+                    # DROP the failed item: record a kind-marker (NOT absent — else
+                    # resume re-runs it forever; NOT bare None — a legit result).
+                    completed = {
+                        **completed,
+                        key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
+                    }
+                    any_durable = True  # a drop MUST survive to resume (awaited-durable)
+                    await inv.record(completed_step_results=completed, durable=True)
+                else:
+                    # abort (incl. retry(n) exhausted): the landed items above are
+                    # already durably recorded; fail the step now.
+                    raise PipelineExecutionError(
+                        f"step {label} (for_each) item {item_idx} failed "
+                        f"(on_error={step.on_error!r}): {exc}"
+                    ) from exc
+        finally:
+            # Never leave orphaned live fan-out tasks (an abort-raise cancels the
+            # still-pending items; a clean finish finds them all already done).
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    # collect runs ONCE over the ordered surviving results (dropped filtered out).
+    results_list = _for_each_results(completed, label, n)
+    collect_ctx = {"ctx": outer_stores, "pipe": results_list}
+    collect_runner = STEP_DISPATCH.get(type(step.collect))
+    if collect_runner is None:  # pragma: no cover - Step is a closed union
+        raise PipelineExecutionError(f"unknown step type: {step.collect!r}")
+    collect_inv = _StepInvocation(
+        executor=inv.executor, step=step.collect, context=collect_ctx,
+        step_label=collect_key, deps=child_deps,
+        completed_step_results=completed, record=inv.record,
+    )
+    collect_result, collect_durable, completed = await collect_runner(collect_inv)
+    completed = {**completed, collect_key: collect_result}
+    any_durable = any_durable or collect_durable
+    await inv.record(completed_step_results=completed, durable=collect_durable)
+    return collect_result, any_durable, completed
+
+
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
 # entry here (+ serde/parser/analyzer) rather than editing a shared elif chain.
 STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
@@ -730,6 +1111,7 @@ STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool
     CallStep: _run_call_step,
     MatchStep: _run_match_step,
     FoldStep: _run_fold_step,
+    ForEachStep: _run_for_each_step,
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
@@ -740,6 +1122,7 @@ _STEP_KINDS: "dict[type, str]" = {
     CallStep: "call",
     MatchStep: "match",
     FoldStep: "fold",
+    ForEachStep: "for_each",
 }
 
 
@@ -768,6 +1151,8 @@ class PipelineExecutor:
         pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
+        max_fan_out_depth: "int | None" = None,
+        max_pipeline_spawns: "int | None" = None,
     ) -> PipelineResult:
         """Run `pipeline` from the first step. `initial_context` seeds the named
         stores (``ctx.*``) available to the first step; there is no incoming pipe
@@ -779,7 +1164,14 @@ class PipelineExecutor:
 
         `events` / `cancel_check` (IS-6) behave as documented on the module: an
         attached caller renders live progress from `events`, and a True
-        `cancel_check` at a step boundary raises :class:`PipelineCancelled`."""
+        `cancel_check` at a step boundary raises :class:`PipelineCancelled`.
+
+        `max_fan_out_depth` / `max_pipeline_spawns` are the S5 fan-out spawn caps
+        (guards b/c). Both default to conservative finite module constants when
+        omitted (NEVER unbounded-by-omission); the operator wires reyn.yaml's
+        ``safety.spawn.*`` values here via the driver. ``0`` = unlimited (opt-out).
+        Deliberately decoupled from `registry`: a `for_each` needs its caps even
+        with no `AgentStep` (so no `registry`) in the pipeline."""
         named_stores: "dict[str, Any]" = dict(initial_context) if initial_context else {}
         return await self._run_from(
             pipeline,
@@ -796,6 +1188,8 @@ class PipelineExecutor:
             pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
+            max_fan_out_depth=max_fan_out_depth,
+            max_pipeline_spawns=max_pipeline_spawns,
         )
 
     async def resume(
@@ -811,6 +1205,8 @@ class PipelineExecutor:
         pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
+        max_fan_out_depth: "int | None" = None,
+        max_pipeline_spawns: "int | None" = None,
     ) -> PipelineResult:
         """Resume `run_id`: load the latest recorded generation (R4) and replay every
         step already in ``completed_step_results`` (no re-execution — exactly-once).
@@ -837,6 +1233,8 @@ class PipelineExecutor:
                 pipeline_registry=pipeline_registry,
                 events=events,
                 cancel_check=cancel_check,
+                max_fan_out_depth=max_fan_out_depth,
+                max_pipeline_spawns=max_pipeline_spawns,
             )
         return await self._run_from(
             pipeline,
@@ -853,6 +1251,8 @@ class PipelineExecutor:
             pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
+            max_fan_out_depth=max_fan_out_depth,
+            max_pipeline_spawns=max_pipeline_spawns,
         )
 
     async def _run_from(
@@ -872,7 +1272,20 @@ class PipelineExecutor:
         pipeline_registry: "PipelineRegistry | None" = None,
         events: "EventLog | None" = None,
         cancel_check: "Callable[[], bool] | None" = None,
+        max_fan_out_depth: "int | None" = None,
+        max_pipeline_spawns: "int | None" = None,
     ) -> PipelineResult:
+        # S5 caps: default to conservative finite constants when the caller omits
+        # them (never unbounded-by-omission). ``0`` (an explicit operator opt-out)
+        # is preserved as unlimited by the guards. The SpawnBudget is constructed
+        # ONCE here — this is the single funnel both run() and resume() reach — and
+        # shared by reference through every nested scope's _RunDeps (guard c).
+        eff_max_depth = (
+            _DEFAULT_MAX_FAN_OUT_DEPTH if max_fan_out_depth is None else max_fan_out_depth
+        )
+        eff_max_spawns = (
+            _DEFAULT_MAX_PIPELINE_SPAWNS if max_pipeline_spawns is None else max_pipeline_spawns
+        )
         deps = _RunDeps(
             tool_dispatch=tool_dispatch,
             state_log=state_log,
@@ -883,6 +1296,9 @@ class PipelineExecutor:
             pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
+            fan_out_depth=0,
+            max_fan_out_depth=eff_max_depth,
+            spawn_budget=SpawnBudget(eff_max_spawns),
         )
         steps = pipeline.steps
         total_steps = len(steps)
@@ -1023,6 +1439,8 @@ __all__ = [
     "MatchCase",
     "MatchStep",
     "FoldStep",
+    "ForEachStep",
+    "SpawnBudget",
     "Step",
     "Pipeline",
     "PipelineResult",

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -85,6 +85,7 @@ from reyn.core.pipeline.executor import (
     CallStep,
     ExprRef,
     FoldStep,
+    ForEachStep,
     MatchCase,
     MatchStep,
     Pipeline,
@@ -174,15 +175,16 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 # Constructs the union grammar's non-linear step kinds accept as *keys* so a
 # document using them gets a clear "not yet supported" error instead of a
 # generic "unknown step type". ``call`` (R7), ``match`` (runtime-selected
-# sibling), and ``fold`` (sequential accumulator) are now SUPPORTED — they
-# moved out of this set into ``_STEP_PARSERS`` (``fold`` is dispatched
-# specially in ``_parse_step`` since its ``do`` recurses).
-_UNSUPPORTED_STEP_KINDS = ("for_each", "parallel")
+# sibling), ``fold`` (sequential accumulator), and ``for_each`` (concurrent
+# fan-out) are now SUPPORTED — they moved out of this set into ``_STEP_PARSERS``
+# (``fold``/``for_each`` are dispatched specially in ``_parse_step`` since their
+# ``do``/``collect`` sub-steps recurse). ``parallel`` is the last primitive.
+_UNSUPPORTED_STEP_KINDS = ("parallel",)
 _LINEAR_STEP_KINDS = ("transform", "tool", "shell", "agent")
-# ``call``/``match``/``fold`` are compositional, not linear, but ARE
+# ``call``/``match``/``fold``/``for_each`` are compositional, not linear, but ARE
 # executable — listed separately so error text distinguishes "the linear
 # kinds" from the full supported set.
-_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold")
+_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold", "for_each")
 _ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has
@@ -449,6 +451,65 @@ def _parse_fold_step(body: "dict[str, Any]", *, index: "int | str") -> FoldStep:
     )
 
 
+_FOR_EACH_KEYS = frozenset(
+    {"over", "items", "max_parallel", "on_error", "do", "collect", "output"}
+)
+_ON_ERROR_RE = re.compile(r"^retry\(\d+\)$")
+
+
+def _parse_for_each_step(body: "dict[str, Any]", *, index: "int | str") -> ForEachStep:
+    """``for_each = {over?:PATH | items?:[LIT*] max_parallel? on_error:continue|
+    abort|retry(n) do:Step collect:Step}`` (Appendix B) — the concurrent fan-out
+    primitive. ``over``/``items`` are mutually exclusive (both together is an
+    ambiguous list source); neither falls back to the incoming pipe data at run
+    time (like ``fold``). ``on_error`` is REQUIRED (Appendix B gives it no ``?`` —
+    a fan-out author MUST state the completeness policy; unlike ``parallel`` whose
+    ``on_error?`` defaults to ``abort``) and must be ``continue``/``abort``/
+    ``retry(n)``. ``do`` AND ``collect`` are each a full nested Step (parsed the
+    same way top-level steps are, so either may be a nested ``call``/``fold``/
+    ``for_each``); ``collect`` is REQUIRED (it produces the primitive's N2
+    result). ``max_parallel`` (S5 Semaphore cap) is an optional positive int."""
+    _reject_unknown_keys(body, _FOR_EACH_KEYS, where="for_each step")
+    if "over" in body and "items" in body:
+        _fail("for_each step: 'over' and 'items' are mutually exclusive list sources")
+    over = body.get("over")
+    if over is not None:
+        over = _validate_expr_source(over, where="for_each step 'over'")
+    raw_items = body.get("items")
+    items: "list[Any] | None" = None
+    if raw_items is not None:
+        if not isinstance(raw_items, list):
+            _fail(f"for_each step 'items': expected a list, got {type(raw_items).__name__}")
+        _reject_nested_expr_tag(raw_items, where="for_each step 'items'")
+        items = list(raw_items)
+    on_error = body.get("on_error")
+    if not isinstance(on_error, str) or (
+        on_error not in ("continue", "abort") and _ON_ERROR_RE.match(on_error) is None
+    ):
+        _fail(
+            "for_each step 'on_error': REQUIRED — must be 'continue', 'abort', or "
+            f"'retry(n)' (a positive integer n), got {on_error!r}"
+        )
+    if "do" not in body:
+        _fail("for_each step: missing required field 'do'")
+    do = _parse_step(body["do"], index=f"{index} (for_each do)")
+    if "collect" not in body:
+        _fail("for_each step: missing required field 'collect'")
+    collect = _parse_step(body["collect"], index=f"{index} (for_each collect)")
+    max_parallel = body.get("max_parallel")
+    if max_parallel is not None and (
+        isinstance(max_parallel, bool) or not isinstance(max_parallel, int) or max_parallel <= 0
+    ):
+        _fail(f"for_each step 'max_parallel': expected a positive integer, got {max_parallel!r}")
+    output = body.get("output")
+    if output is not None and not isinstance(output, str):
+        _fail(f"for_each step 'output': expected a store-name string, got {type(output).__name__}")
+    return ForEachStep(
+        do=do, collect=collect, on_error=on_error, over=over, items=items,
+        max_parallel=max_parallel, output=output,
+    )
+
+
 _STEP_PARSERS = {
     "transform": _parse_transform_step,
     "tool": _parse_tool_step,
@@ -475,6 +536,12 @@ def _parse_step(raw_step: Any, *, index: "int | str") -> Step:
         if not isinstance(body, dict):
             _fail(f"step {index} (fold): expected a mapping body, got {type(body).__name__}")
         return _parse_fold_step(body, index=index)
+    if kind == "for_each":
+        # Special-dispatched like ``fold``: its ``do``/``collect`` sub-steps recurse
+        # through ``_parse_step``, so it needs ``index`` for nested error context.
+        if not isinstance(body, dict):
+            _fail(f"step {index} (for_each): expected a mapping body, got {type(body).__name__}")
+        return _parse_for_each_step(body, index=index)
     if kind not in _STEP_PARSERS:
         _fail(
             f"step {index}: unknown step kind {kind!r} (expected one of "

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -41,6 +41,7 @@ from reyn.core.pipeline.executor import (
     CallStep,
     ExprRef,
     FoldStep,
+    ForEachStep,
     MatchCase,
     MatchStep,
     Pipeline,
@@ -209,6 +210,34 @@ def _decode_fold(data: "dict[str, Any]") -> "FoldStep":
     )
 
 
+def _encode_for_each(step: "ForEachStep") -> "dict[str, Any]":
+    # ``do`` AND ``collect`` are each a Step — recurse through `step_to_dict` so a
+    # for_each whose `do`/`collect` is a `call` (or nested for_each) round-trips
+    # faithfully. ``on_error`` is a plain DSL string (normalized at execution).
+    return {
+        "kind": "for_each",
+        "over": step.over,
+        "items": list(step.items) if step.items is not None else None,
+        "max_parallel": step.max_parallel,
+        "on_error": step.on_error,
+        "do": step_to_dict(step.do),
+        "collect": step_to_dict(step.collect),
+        "output": step.output,
+    }
+
+
+def _decode_for_each(data: "dict[str, Any]") -> "ForEachStep":
+    return ForEachStep(
+        do=step_from_dict(data["do"]),
+        collect=step_from_dict(data["collect"]),
+        on_error=data["on_error"],
+        over=data.get("over"),
+        items=list(data["items"]) if data.get("items") is not None else None,
+        max_parallel=data.get("max_parallel"),
+        output=data.get("output"),
+    )
+
+
 # Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
 # A future primitive ADDS one entry to each (mirroring the executor's
 # ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
@@ -220,6 +249,7 @@ ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
     CallStep: _encode_call,
     MatchStep: _encode_match,
     FoldStep: _encode_fold,
+    ForEachStep: _encode_for_each,
 }
 DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "transform": _decode_transform,
@@ -228,6 +258,7 @@ DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "call": _decode_call,
     "match": _decode_match,
     "fold": _decode_fold,
+    "for_each": _decode_for_each,
 }
 
 

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -52,6 +52,10 @@ class SessionFactoryConfig:
     # enforce these; 0 = unlimited.
     max_spawn_depth: int
     max_spawn_children: int
+    # #2187 for_each S5: pipeline fan-out spawn bounds (safety.spawn.*) — the
+    # pipeline executor enforces these (guards b/c); 0 = unlimited.
+    max_pipeline_fan_out_depth: int
+    max_pipeline_spawns: int
 
     @classmethod
     def from_config(
@@ -91,4 +95,6 @@ class SessionFactoryConfig:
             delegation_capability_default=config.delegation.capability_default,
             max_spawn_depth=config.safety.spawn.max_depth,
             max_spawn_children=config.safety.spawn.max_children,
+            max_pipeline_fan_out_depth=config.safety.spawn.max_pipeline_fan_out_depth,
+            max_pipeline_spawns=config.safety.spawn.max_pipeline_spawns,
         )

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -153,6 +153,8 @@ class AgentRegistry:
         delegation_capability_default: str = "inherit",
         max_spawn_depth: int = 0,
         max_spawn_children: int = 0,
+        max_pipeline_fan_out_depth: int = 0,
+        max_pipeline_spawns: int = 0,
         factory_config: "object | None" = None,
         create_event_kinds: "frozenset[str] | None" = None,
     ) -> None:
@@ -178,12 +180,19 @@ class AgentRegistry:
             delegation_capability_default = factory_config.delegation_capability_default
             max_spawn_depth = factory_config.max_spawn_depth
             max_spawn_children = factory_config.max_spawn_children
+            max_pipeline_fan_out_depth = factory_config.max_pipeline_fan_out_depth
+            max_pipeline_spawns = factory_config.max_pipeline_spawns
         # #2103 C3: operator spawn-tree bounds (safety.spawn.*), enforced at the LLM
         # spawn seams (host adapter). 0 = unlimited. Util/test callers default to
         # unlimited (byte-identical); the 5 frontend factory sites supply them via the
         # factory_config bundle.
         self._max_spawn_depth = max_spawn_depth
         self._max_spawn_children = max_spawn_children
+        # #2187 for_each S5: pipeline fan-out spawn bounds (safety.spawn.*),
+        # enforced by the pipeline executor (guards b/c). The driver-session reads
+        # them off this registry and threads them into run()/resume(). 0 = unlimited.
+        self._max_pipeline_fan_out_depth = max_pipeline_fan_out_depth
+        self._max_pipeline_spawns = max_pipeline_spawns
         self._dir = project_root / ".reyn" / "agents"
         self._dir.mkdir(parents=True, exist_ok=True)
         self._topology_dir = project_root / ".reyn" / TOPOLOGY_DIRNAME
@@ -631,6 +640,18 @@ class AgentRegistry:
         """#2175: the operator base max fan-out — direct children + topology size
         (0 = unlimited)."""
         return self._max_spawn_children
+
+    @property
+    def max_pipeline_fan_out_depth(self) -> int:
+        """#2187 for_each S5: the operator max ``for_each`` fan-out NESTING depth
+        the pipeline executor enforces (guard b; 0 = unlimited)."""
+        return self._max_pipeline_fan_out_depth
+
+    @property
+    def max_pipeline_spawns(self) -> int:
+        """#2187 for_each S5: the operator max ephemeral-session spawn COUNT per
+        pipeline run the executor enforces (guard c; 0 = unlimited)."""
+        return self._max_pipeline_spawns
 
     async def create_agent(
         self, name: str, *, role: str = "", parent: "str | None" = None

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -208,6 +208,8 @@ class PipelineExecutorDriver:
                     events=events,
                     cancel_check=self.is_cancel_requested,
                     schema_registry=schema_registry,
+                    max_fan_out_depth=self._registry.max_pipeline_fan_out_depth,
+                    max_pipeline_spawns=self._registry.max_pipeline_spawns,
                 )
             else:
                 result = await executor.resume(
@@ -221,6 +223,8 @@ class PipelineExecutorDriver:
                     events=events,
                     cancel_check=self.is_cancel_requested,
                     schema_registry=schema_registry,
+                    max_fan_out_depth=self._registry.max_pipeline_fan_out_depth,
+                    max_pipeline_spawns=self._registry.max_pipeline_spawns,
                 )
         except PipelineCancelled as exc:
             # IS-6: an intentional Ctrl-C stop at a step boundary. TERMINAL (so

--- a/tests/test_pipeline_for_each_primitive.py
+++ b/tests/test_pipeline_for_each_primitive.py
@@ -1,0 +1,655 @@
+"""Tier 2: OS invariant — the `for_each` CONCURRENT fan-out primitive + fan-out
+substrate (concurrent recovery + S5 spawn bounds).
+
+Covers ``for_each`` (Appendix B; ``docs/proposals/reyn-pipeline-spec-v0.8.md``
+Hard rule 6, N2) — ``fold``'s parallel, isolated sibling built on the same
+``_run_scope`` + dotted-path recovery + dispatch-table foundation as
+``call``/``match``/``fold``:
+
+  1. happy path — ``do`` runs over each item as an ISOLATED sub-scope; ``collect``
+     runs ONCE over the ORDERED results list (by item index, NOT completion
+     order); ``collect``'s result is the primitive's N2 return / pipe-data.
+  2. ``max_parallel`` bounds live concurrency (S5 guard a — bounded-by-
+     construction: never more than ``max_parallel`` items in flight at once).
+  3. ``on_error`` — ``continue`` DROPS a failed item (a kind-marker, so resume
+     never re-runs it; ``collect`` sees the surviving list); ``abort`` fails the
+     whole step; ``retry(n)`` re-runs a flaky item then succeeds, and a still-
+     failing item after ``n`` retries falls back to abort.
+  4. the CLAUDE.md-mandated truncate-falsify recovery gate over a SINGLE-STEP
+     ``do`` (the exactly-once item-commit case): M/N items done + 1 dropped,
+     crash before ``collect`` records, WAL truncated below the source events,
+     resume from the generation FILE → completed items REPLAY exactly-once (their
+     side-effect file is unchanged), the dropped item STAYS dropped (not re-run),
+     only absent items run, ``collect`` runs ONCE.
+  5. the documented COMPOSITIONAL-``do`` recovery gap: a ``call``-``do`` item
+     in-flight at crash re-runs ATOMICALLY on resume (its completed internal side
+     effects re-fire) — a known, TESTED contract, not a silent surprise (the
+     module docstring's "commit unit = the ITEM"; follow-up issue tracks closing
+     it).
+  6. S5 guards — (b) a ``for_each`` nested deeper than ``max_fan_out_depth``
+     FAILS the step (does not spawn); (c) a fan-out spawning more ephemeral
+     sessions than ``max_pipeline_spawns`` FAILS the step (the per-run
+     ``SpawnBudget`` counter is the only enforcement for lineage-less pipeline
+     agent-steps).
+
+Real ``StateLog`` + ``PipelineRegistry`` + real generation files + a real
+``AgentRegistry``/``Session``/``MessageBus`` (the S5-c spawn test) throughout —
+no mocks, no private-state assertions (the ONE faked collaborator is the LLM
+completion call, injected via the real ``_loop_observer`` seam, exactly as
+``test_pipeline_r5_agent_step_executor.py`` does).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    CallStep,
+    ExprRef,
+    ForEachStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    SpawnBudget,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+# ── happy path: concurrent isolated items, ordered collect, N2 out ───────────
+
+
+@pytest.mark.asyncio
+async def test_for_each_runs_items_and_collects_ordered_results():
+    """Tier 2: ``do`` runs once per item (each seeing its own ``{item}`` and the
+    fan-out step's pipe-data), and ``collect`` runs ONCE over the ORDERED results
+    list (item-index order, regardless of completion order), its result becoming
+    the for_each step's N2 return value + named output."""
+    pipeline = Pipeline(steps=[
+        TransformStep(value="'seed'", output="carried"),  # step 0: pipe = 'seed'
+        ForEachStep(
+            over="ctx.words",
+            on_error="abort",
+            do=TransformStep(value="item + '!'"),
+            collect=TransformStep(value="pipe"),  # pipe == the ordered results list
+            output="shouted",
+        ),
+    ])
+
+    result = await PipelineExecutor().run(
+        pipeline, {"words": ["a", "b", "c"]},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fe-happy",
+    )
+
+    assert result.named_stores["shouted"] == ["a!", "b!", "c!"]
+    assert result.pipe_data == ["a!", "b!", "c!"]
+    # per-item flat keys + the collect key.
+    assert result.completed_step_results["1.for_each.0"] == "a!"
+    assert result.completed_step_results["1.for_each.1"] == "b!"
+    assert result.completed_step_results["1.for_each.2"] == "c!"
+    assert result.completed_step_results["1.for_each.collect"] == ["a!", "b!", "c!"]
+
+
+@pytest.mark.asyncio
+async def test_for_each_items_source_and_pipe_data_at_fan_out_site():
+    """Tier 2: a static ``items`` list is the source, and each item's ``do`` sees
+    the fan-out step's OWN incoming pipe-data via bare ``pipe`` (Hard rule 5's
+    per-item analog) held constant across items."""
+    pipeline = Pipeline(steps=[
+        TransformStep(value="'PFX'"),  # step 0: pipe = 'PFX' → each item sees it
+        ForEachStep(
+            items=["x", "y"],
+            on_error="abort",
+            do=TransformStep(value="pipe + '-' + item"),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fe-items",
+    )
+    assert result.pipe_data == ["PFX-x", "PFX-y"]
+
+
+@pytest.mark.asyncio
+async def test_for_each_empty_list_runs_collect_once_over_empty():
+    """Tier 2: an empty item list fans out nothing and runs ``collect`` ONCE over
+    the empty list — the primitive still produces its N2 result (no items ≠ no
+    collect)."""
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=[],
+            on_error="abort",
+            do=TransformStep(value="item"),
+            collect=TransformStep(value="count(pipe)"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fe-empty",
+    )
+    assert result.pipe_data == 0
+    assert result.completed_step_results["0.for_each.collect"] == 0
+
+
+# ── S5 guard (a): max_parallel bounds live concurrency ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_max_parallel_bounds_live_concurrency():
+    """Tier 2: (S5 guard a — bounded-by-construction) with ``max_parallel=2`` over
+    6 items, never more than 2 items' ``do`` are in flight at once. Proven by a
+    real async tool tracking peak concurrency — the Semaphore is the bound, not a
+    reject."""
+    live = 0
+    peak = 0
+
+    async def _dispatch(name: str, args: dict) -> Any:
+        nonlocal live, peak
+        assert name == "work"
+        live += 1
+        peak = max(peak, live)
+        await asyncio.sleep(0.01)  # hold the slot so siblings would pile up if unbounded
+        live -= 1
+        return args["v"]
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=[1, 2, 3, 4, 5, 6],
+            max_parallel=2,
+            on_error="abort",
+            do=ToolStep(name="work", args={"v": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fe-parallel",
+    )
+    assert result.pipe_data == [1, 2, 3, 4, 5, 6]  # ordered, all processed
+    assert peak <= 2, f"live concurrency {peak} exceeded max_parallel=2 (S5 guard a)"
+    assert peak == 2, "with 6 items and a held slot, concurrency should reach the cap"
+
+
+# ── on_error policies ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_error_continue_drops_failed_item_and_collect_sees_survivors():
+    """Tier 2: ``on_error:continue`` DROPS a failed item from the results — its
+    item key holds a kind-marker (so resume never re-runs it), and ``collect``'s
+    input is the surviving ordered list, not a hole/None."""
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        if v == "bad":
+            raise RuntimeError("boom")
+        return v.upper()
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["a", "bad", "c"],
+            on_error="continue",
+            do=ToolStep(name="work", args={"v": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fe-continue",
+    )
+    # collect saw only the survivors, in item order.
+    assert result.pipe_data == ["A", "C"]
+    # the dropped item's key holds the kind-marker (NOT absent, NOT bare None).
+    dropped = result.completed_step_results["0.for_each.1"]
+    assert dropped["__fan_out_dropped__"] is True
+    assert "boom" in dropped["error"]
+
+
+@pytest.mark.asyncio
+async def test_on_error_abort_fails_the_whole_step():
+    """Tier 2: ``on_error:abort`` — a single item failure fails the whole for_each
+    step (``PipelineExecutionError``), not a silent drop."""
+    def _dispatch(name: str, args: dict) -> Any:
+        if args["v"] == "bad":
+            raise RuntimeError("boom")
+        return args["v"]
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["a", "bad", "c"],
+            on_error="abort",
+            do=ToolStep(name="work", args={"v": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-fe-abort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_reruns_flaky_item_until_success():
+    """Tier 2: ``on_error:retry(2)`` re-runs a flaky item (fails twice, succeeds on
+    the 3rd attempt) — the item lands, not dropped, so ``collect`` sees it."""
+    attempts: dict[Any, int] = {}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        attempts[v] = attempts.get(v, 0) + 1
+        if v == "flaky" and attempts[v] < 3:
+            raise RuntimeError("transient")
+        return v
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["ok", "flaky"],
+            on_error="retry(2)",
+            do=ToolStep(name="work", args={"v": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fe-retry-ok",
+    )
+    assert sorted(result.pipe_data) == ["flaky", "ok"]
+    assert attempts["flaky"] == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_exhausted_falls_back_to_abort():
+    """Tier 2: ``retry(1)`` on an ALWAYS-failing item exhausts its retries and then
+    falls back to ABORT (only ``continue`` ever silently drops) — the step fails."""
+    calls: dict[Any, int] = {}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        calls[v] = calls.get(v, 0) + 1
+        if v == "always":
+            raise RuntimeError("permanent")
+        return v
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["always"],
+            on_error="retry(1)",
+            do=ToolStep(name="work", args={"v": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-fe-retry-exhaust",
+        )
+    assert calls["always"] == 2  # 1 initial + 1 retry, then abort
+
+
+# ── CLAUDE.md truncate-falsify recovery gate (single-step do = exactly-once) ──
+
+
+def _append_dispatch(state_log: StateLog, out_file: Path, crash: set):
+    """A REAL side-effecting tool (mirrors the call primitive's ``is2_append``):
+    each call appends a line to ``out_file`` AND a WAL entry (so R4 gens land at
+    distinct durable seqs). The exactly-once probe is the FILE. A line in
+    ``crash`` raises BEFORE its write, arming a genuine failure."""
+
+    async def _dispatch(name: str, args: dict) -> Any:
+        assert name == "append"
+        line = str(args["line"])
+        if line in crash:
+            raise RuntimeError(f"simulated crash before writing {line!r}")
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        await state_log.append("inbox_put", note=line)
+        return {"wrote": line}
+
+    return _dispatch
+
+
+def _fan_out_pipeline(on_error: str) -> Pipeline:
+    """for_each over 4 items (append each), collect appends a COLLECT marker line."""
+    return Pipeline(steps=[
+        ForEachStep(
+            items=["A", "B", "C", "D"],
+            on_error=on_error,
+            do=ToolStep(name="append", args={"line": ExprRef("item")}),
+            collect=ToolStep(name="append", args={"line": "COLLECT"}),
+        ),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_mid_fan_out_replays_items_exactly_once(tmp_path: Path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate for the fan-out substrate over a
+    SINGLE-STEP ``do`` (the exactly-once item-commit case). Phase 1: items A/B/D
+    write + record their item keys; item C fails (``on_error:continue`` → dropped
+    marker recorded); ``collect`` then crashes BEFORE recording its key. The WAL is
+    truncated BELOW all source events. Resume from the generation FILE →
+
+      - the completed items REPLAY exactly-once (A/B/D are NOT re-written — the
+        file proves it),
+      - the dropped item C STAYS dropped (NOT re-run — its marker key is present),
+      - ``collect`` runs ONCE (writes COLLECT), threading its result out.
+
+    RED if an item rode a truncatable WAL event, if resume re-ran the whole
+    fan-out, or if the dropped item was re-run as an absent-keyed pending item."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    # C fails (→ dropped); COLLECT crashes phase 1 AFTER all items are recorded.
+    crash = {"C", "COLLECT"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    pipeline = _fan_out_pipeline("continue")
+
+    # The collect tool raises a raw RuntimeError (tool-dispatch failures are not
+    # wrapped) — the same crash shape the call primitive's truncate-falsify uses.
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-fe-tf",
+        )
+    await state_log.flush()
+    # A/B/D written (C dropped, COLLECT crashed) — order is completion-order, so sort.
+    assert sorted(out_file.read_text(encoding="utf-8").splitlines()) == ["A", "B", "D"]
+
+    # Latest generation on disk: all 4 item keys present, collect key absent.
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    snap = latest_pipeline_state("run-fe-tf", state_log)
+    for idx in range(4):
+        assert f"0.for_each.{idx}" in snap["completed_step_results"]
+    assert snap["completed_step_results"]["0.for_each.2"]["__fan_out_dropped__"] is True
+    assert "0.for_each.collect" not in snap["completed_step_results"]
+
+    # WAL head climbs past the crash-state seqs, then GC truncates below 40 — every
+    # item's own WAL entry is dropped from wal.jsonl.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "the items' WAL entries are truncated away"
+
+    # RESUME with COLLECT disarmed (C stays armed — it must NOT be re-run anyway).
+    crash.discard("COLLECT")
+    resumed = await PipelineExecutor().resume(
+        "run-fe-tf", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    # Exactly-once: A/B/D appear ONCE each (replayed, not re-written); C NEVER
+    # (stayed dropped, not re-run despite still being armed); COLLECT once.
+    assert sorted(lines) == ["A", "B", "COLLECT", "D"]
+    assert lines.count("A") == 1 and lines.count("B") == 1 and lines.count("D") == 1
+    assert "C" not in lines
+    # collect ran once; its result threads out as the for_each N2 return.
+    assert resumed.pipe_data == {"wrote": "COLLECT"}
+    assert resumed.completed_step_results["0.for_each.collect"] == {"wrote": "COLLECT"}
+
+
+@pytest.mark.asyncio
+async def test_resume_after_full_fan_out_replays_with_zero_new_side_effects(tmp_path: Path):
+    """Tier 2: resuming a fully-completed for_each replays every item + collect from
+    the snapshot with ZERO new writes. RED if resume re-fired a completed item or
+    the collect."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    dispatch = _append_dispatch(state_log, out_file, set())
+    pipeline = _fan_out_pipeline("abort")
+
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=dispatch, state_log=state_log, run_id="run-fe-done",
+    )
+    await state_log.flush()
+    before = sorted(out_file.read_text(encoding="utf-8").splitlines())
+    assert before == ["A", "B", "C", "COLLECT", "D"]
+
+    resumed = await PipelineExecutor().resume(
+        "run-fe-done", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+    after = sorted(out_file.read_text(encoding="utf-8").splitlines())
+    assert after == before, "a fully-completed fan-out must replay with zero side effects"
+    assert resumed.pipe_data == {"wrote": "COLLECT"}
+
+
+# ── the DOCUMENTED compositional-do atomic-re-run gap (commit unit = the ITEM) ─
+
+
+@pytest.mark.asyncio
+async def test_compositional_do_item_reruns_atomically_on_crash(tmp_path: Path):
+    """Tier 2: DOCUMENTS the known fan-out recovery gap (module docstring's "commit
+    unit = the ITEM"). A ``call``-``do`` item crashed MID-ITEM (its callee wrote
+    sub-step 0's side effect, sub-step 1 failed) re-runs ATOMICALLY on resume —
+    because item tasks record through a NO-OP recorder, the item's internal
+    progress is never journaled, so the completed internal side effect RE-FIRES.
+    This is a TESTED contract, not a silent surprise; a follow-up issue tracks
+    closing it (per-internal-sub-step durability). A single-step ``do`` has no such
+    gap (see the truncate-falsify test above)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"X-b"}  # the callee's 2nd sub-step fails in phase 1
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("worker", Pipeline(steps=[
+        ToolStep(name="append", args={"line": "X-a"}),
+        ToolStep(name="append", args={"line": "X-b"}),
+    ]))
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["X"],
+            on_error="abort",
+            do=CallStep(pipeline="worker"),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-fe-comp",
+            pipeline_registry=registry,
+        )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["X-a"]
+
+    # RESUME disarmed: the item re-runs WHOLE (its key was never recorded), so X-a
+    # is written AGAIN (the documented internal-side-effect re-fire).
+    crash.clear()
+    await PipelineExecutor().resume(
+        "run-fe-comp", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+    )
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    assert lines == ["X-a", "X-a", "X-b"], (
+        "a compositional-do item re-runs atomically on resume — X-a re-fires "
+        "(the documented commit-unit=ITEM gap; single-step do has no such gap)"
+    )
+
+
+# ── S5 guard (b): fan_out_depth cap FAILS the step (does not spawn) ───────────
+
+
+@pytest.mark.asyncio
+async def test_fan_out_depth_cap_fails_a_too_deeply_nested_for_each():
+    """Tier 2: (S5 guard b — bounded-by-construction) a ``for_each`` nested deeper
+    than ``max_fan_out_depth`` FAILS the step rather than spawning. A top-level
+    for_each = depth 1; a for_each inside its ``do`` = depth 2. With
+    ``max_fan_out_depth=1`` the inner one exceeds the cap and fails."""
+    inner = ForEachStep(
+        items=[1],
+        on_error="abort",
+        do=TransformStep(value="item"),
+        collect=TransformStep(value="pipe"),
+    )
+    outer = Pipeline(steps=[
+        ForEachStep(
+            items=[1],
+            on_error="abort",  # so the inner depth-failure propagates as a step failure
+            do=inner,
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=None, run_id="run-fe-depth",
+            max_fan_out_depth=1,
+        )
+    assert "depth" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_nested_for_each_within_depth_cap_succeeds():
+    """Tier 2: the depth guard is a CAP, not a blanket ban — a for_each nested to
+    depth 2 runs fine under ``max_fan_out_depth=2`` (bounded, not forbidden)."""
+    outer = Pipeline(steps=[
+        ForEachStep(
+            items=[[1, 2], [3]],
+            on_error="abort",
+            do=ForEachStep(
+                over="item",
+                on_error="abort",
+                do=TransformStep(value="item"),
+                collect=TransformStep(value="count(pipe)"),
+            ),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-fe-depth-ok",
+        max_fan_out_depth=2,
+    )
+    assert result.pipe_data == [2, 1]  # inner collect = count of each sublist
+
+
+# ── S5 guard (c): per-run spawn budget ───────────────────────────────────────
+
+
+def test_spawn_budget_consume_rejects_past_cap():
+    """Tier 1: the ``SpawnBudget`` contract (S5 guard c mechanism) — ``consume``
+    charges monotonically and raises once the cap is reached; ``cap=0`` is
+    unlimited."""
+    budget = SpawnBudget(2)
+    budget.consume(label="0")
+    budget.consume(label="1")
+    assert budget.spent == 2
+    with pytest.raises(PipelineExecutionError):
+        budget.consume(label="2")
+
+    unlimited = SpawnBudget(0)
+    for i in range(100):
+        unlimited.consume(label=str(i))
+    assert unlimited.spent == 100
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text turn (no tool_calls) — the ONLY
+    faked collaborator (see module docstring), injected via the real
+    ``_loop_observer`` seam exactly as ``test_pipeline_r5_agent_step_executor``."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgentReply) -> AgentRegistry:
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        s._loop_driver._loop_observer = (lambda loop: setattr(loop, "_llm_caller", scripted))
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_spawn_budget_cap_fails_a_fan_out_over_too_many_agent_items(tmp_path: Path):
+    """Tier 2: (S5 guard c — bounded-by-construction, real spawn path) a for_each
+    whose ``do`` is an ``agent`` step, fanned out over 3 items with
+    ``max_pipeline_spawns=2``, FAILS the step — the 3rd item's spawn exceeds the
+    per-run budget (the ONLY spawn-count enforcement for lineage-less pipeline
+    agent-steps). ``max_parallel=1`` makes the budget exhaustion deterministic."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("done")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["a", "b", "c"],
+            max_parallel=1,
+            on_error="abort",  # so the budget-exceed failure fails the step
+            do=AgentStep(prompt="{item}", identity="worker"),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-fe-spawns",
+            registry=reg, max_pipeline_spawns=2,
+        )
+    assert "spawn cap" in str(exc.value)
+    assert scripted.calls == 2, "exactly the 2 budgeted spawns ran before the cap failed the 3rd"
+
+
+@pytest.mark.asyncio
+async def test_fan_out_of_agent_items_within_spawn_cap_succeeds(tmp_path: Path):
+    """Tier 2: within ``max_pipeline_spawns``, an agent fan-out runs every item and
+    collects — the budget is a cap, not a ban (bounded, not forbidden)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ok")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["a", "b", "c"],
+            max_parallel=1,
+            on_error="abort",
+            do=AgentStep(prompt="{item}", identity="worker"),
+            collect=TransformStep(value="count(pipe)"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-fe-spawns-ok",
+        registry=reg, max_pipeline_spawns=5,
+    )
+    assert result.pipe_data == 3
+    assert scripted.calls == 3

--- a/tests/test_pipeline_for_each_serde_parser_analyzer.py
+++ b/tests/test_pipeline_for_each_serde_parser_analyzer.py
@@ -1,0 +1,232 @@
+"""Tier 1: `for_each` primitive contract — serde round-trip, DSL parse, analyzer facet.
+
+The `for_each` step (concurrent fan-out) plugs into the same four sibling
+dispatch tables `call`/`match`/`fold` established: serde's ``ENCODERS``/
+``DECODERS`` (work-order persistence — ``do`` AND ``collect``, each a nested
+``Step``, recurse through ``step_to_dict``/``step_from_dict``), the parser's
+special-dispatch (Appendix B ``for_each = {over?, items?, max_parallel?,
+on_error, do, collect}`` — ``on_error`` REQUIRED, ``collect`` REQUIRED), and the
+analyzer's ``ANALYZER_FACETS`` (P4 seam — the S5 ``max_parallel``/``over``
+spawn-bound warnings). This pins each contract with NON-DEFAULT values.
+
+Real YAML parse + real JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.analyzer import analyze_step
+from reyn.core.pipeline.executor import (
+    CallStep,
+    ForEachStep,
+    Pipeline,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def test_for_each_serde_round_trip_non_default_values_with_nested_do_and_collect():
+    """Tier 1: a ``ForEachStep`` whose ``do`` is a ``CallStep`` and whose
+    ``collect`` is a ``ToolStep`` round-trips dataclass -> dict -> JSON ->
+    dataclass — proving BOTH sub-steps recurse through the SAME step-serde
+    contract as a top-level step (not a bespoke shape). ``on_error`` persists as
+    its plain DSL string (normalized only at execution)."""
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            do=CallStep(pipeline="summarize-one", pass_=["item"], output="r"),
+            collect=ToolStep(name="merge", args={}, output="merged"),
+            on_error="retry(3)",
+            over="ctx.docs",
+            max_parallel=4,
+            output="results",
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    fe_dict = wire["steps"][0]
+    assert fe_dict == {
+        "kind": "for_each",
+        "over": "ctx.docs",
+        "items": None,
+        "max_parallel": 4,
+        "on_error": "retry(3)",
+        "do": {"kind": "call", "pipeline": "summarize-one", "pass": ["item"], "output": "r"},
+        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None},
+        "output": "results",
+    }
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_for_each_serde_round_trip_static_items_source():
+    """Tier 1: a ``ForEachStep`` using the ``items:`` static-literal source (instead
+    of ``over``), no ``max_parallel``, and ``on_error:continue`` round-trips too."""
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            do=TransformStep(value="item + '!'"),
+            collect=TransformStep(value="pipe"),
+            on_error="continue",
+            items=["a", "b", "c"],
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    assert wire["steps"][0]["items"] == ["a", "b", "c"]
+    assert wire["steps"][0]["over"] is None
+    assert wire["steps"][0]["max_parallel"] is None
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_for_each_parses_from_dsl():
+    """Tier 1: the DSL ``for_each`` step parses to a ``ForEachStep`` (moved out of
+    the not-yet-supported set) with every field honored, and nested ``do:``/
+    ``collect:`` steps parse through the SAME per-kind parser a top-level step
+    uses."""
+    text = """
+pipeline: outer
+steps:
+  - for_each:
+      over: ctx.suspects
+      max_parallel: 3
+      on_error: continue
+      do:
+        transform:
+          value: "item + '?'"
+      collect:
+        transform:
+          value: pipe
+      output: verdicts
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    assert parsed.steps == [
+        ForEachStep(
+            do=TransformStep(value="item + '?'"),
+            collect=TransformStep(value="pipe"),
+            on_error="continue",
+            over="ctx.suspects",
+            max_parallel=3,
+            output="verdicts",
+        ),
+    ]
+
+
+def test_for_each_dsl_requires_on_error():
+    """Tier 1: ``on_error`` has no ``?`` in Appendix B's for_each grammar (a
+    fan-out author MUST state the completeness policy) — omitting it is a parse
+    error, NOT a silent default to abort (that is ``parallel``'s optional field)."""
+    text = """
+pipeline: o
+steps:
+  - for_each:
+      items: [1, 2]
+      do:
+        transform:
+          value: item
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_for_each_dsl_rejects_bad_on_error():
+    """Tier 1: ``on_error`` must be ``continue``/``abort``/``retry(n)`` — any other
+    value is a parse error (e.g. a bare ``retry`` with no count)."""
+    for bad in ("skip", "retry", "retry()", "continue-please"):
+        text = f"""
+pipeline: o
+steps:
+  - for_each:
+      items: [1]
+      on_error: {bad}
+      do:
+        transform:
+          value: item
+      collect:
+        transform:
+          value: pipe
+"""
+        with pytest.raises(PipelineParseError):
+            parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_for_each_dsl_requires_collect():
+    """Tier 1: ``collect`` is REQUIRED (it produces the primitive's N2 result) —
+    omitting it is a parse error."""
+    text = """
+pipeline: o
+steps:
+  - for_each:
+      items: [1, 2]
+      on_error: abort
+      do:
+        transform:
+          value: item
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_for_each_dsl_rejects_over_and_items_together():
+    """Tier 1: ``over`` and ``items`` are mutually exclusive list sources —
+    specifying both is a parse error, never a silent "one wins" resolution."""
+    text = """
+pipeline: o
+steps:
+  - for_each:
+      over: ctx.xs
+      items: [1, 2]
+      on_error: abort
+      do:
+        transform:
+          value: item
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_for_each_dsl_rejects_unsupported_nested_kind():
+    """Tier 1: a ``do:``/``collect:`` naming a still-unsupported step kind (e.g.
+    `parallel`) fails at parse time, at the DSL text — the same "not yet
+    supported" error a top-level step of that kind raises."""
+    text = """
+pipeline: o
+steps:
+  - for_each:
+      items: [1]
+      on_error: abort
+      do:
+        parallel:
+          branches: {}
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_for_each_analyzer_facet_flags_uncapped_and_over_sources():
+    """Tier 1: the P4 analyzer facet for `for_each` is registered and flags (a) a
+    fan-out with no ``max_parallel`` (fan-out width not statically known) and (b)
+    an ``over``-sourced fan-out (item count not statically known) — but passes a
+    fully-static, capped fan-out."""
+    unbounded = ForEachStep(
+        do=TransformStep(value="item"), collect=TransformStep(value="pipe"),
+        on_error="abort", over="ctx.xs",
+    )
+    problems = analyze_step(unbounded)
+    assert any("max_parallel" in p for p in problems)
+    assert any("over" in p for p in problems)
+
+    static_capped = ForEachStep(
+        do=TransformStep(value="item"), collect=TransformStep(value="pipe"),
+        on_error="abort", items=[1, 2, 3], max_parallel=2,
+    )
+    assert analyze_step(static_capped) == []


### PR DESCRIPTION
**[lead-sonnet]** — The 4th pipeline primitive: `for_each`, `fold`'s CONCURRENT, isolated sibling, plus the fan-out substrate `parallel` will build on. `part of #2187`.

## What
Runs `do` over each list item as an ISOLATED concurrent sub-scope (Hard rule 6: read-only ctx copy, no sibling comm), a SINGLE coordinator recording each item's result AS IT LANDS via `asyncio.as_completed` gated by a `Semaphore`; `collect` runs ONCE over the ordered surviving results — its result is the primitive's N2 output/pipe-data.

Registered across all five seams (`STEP_DISPATCH` / serde `ENCODERS`+`DECODERS` / parser `_STEP_PARSERS` / `ANALYZER_FACETS` / the `Step` union), removed from `_UNSUPPORTED_STEP_KINDS`. `on_error` is REQUIRED (Appendix B gives it no `?` — a fan-out author must state the completeness policy; unlike `parallel`'s optional `on_error?`); `collect` is REQUIRED.

## Concurrent recovery — commit unit = the ITEM
- Item result records at the flat dotted key `{label}.for_each.{item_idx}` (a compositional `do` adds its own deeper levels naturally, same as `fold`); `collect` at `{label}.for_each.collect`.
- **Only the coordinator records** — item tasks use a NO-OP recorder, so concurrent items cannot race the read-modify-write of `completed_step_results` (the coordinator is a single coroutine, serialized by construction).
- **DROPPED-vs-PENDING**: `on_error:continue` records a **kind-marker** (`{"__fan_out_dropped__": true, "error": …}`) — NOT absent (resume would re-run it forever), NOT bare None (a legit result). `collect`'s input is built by ONE shared filter used identically live AND on resume-replay.
- **Exactly-once for single-step `do`** (the common case): a landed item replays from the snapshot, never re-runs.

### ⚠️ Known, TESTED recovery gap (design-accepted for v1, tracked in #2582)
A **compositional `do`** (`call`/`match`/`fold`) IN-FLIGHT at a crash re-runs **ATOMICALLY** on resume — its completed INTERNAL side effects may re-fire (its item key was never journaled). This is a deliberate v1 trade-off (per-internal-sub-step durability needs a lock-guarded serialized recorder — a P7 divergence from the clean immutable-threading model). Documented in the executor module docstring + `ForEachStep` docstring, and asserted explicitly by `test_compositional_do_item_reruns_atomically_on_crash`. **Single-step `do` has no such gap.** Follow-up: #2582.

## S5 spawn bounds (3 monotonic guards vs static operator caps; no LLM-writable raise path)
- **(a) `max_parallel` Semaphore** — caps live concurrency; omitted → `min(len(items), 8)`, never unbounded-by-omission.
- **(b) `fan_out_depth`** — threaded (frozen, +1 per for_each) through `_RunDeps`; exceeding `max_fan_out_depth` FAILS the step (not silent, not spawned).
- **(c) per-run `SpawnBudget`** — a shared-by-reference monotonic counter charged at `_run_agent_step` (the ONE funnel every AgentStep hits). This is the CRITICAL GAP the design found: pipeline agent-steps reach `spawn_ephemeral_session` with NO lineage, so `SpawnConfig`'s lineage caps (`max_depth`/`max_children`) do NOT cover fan-out — this counter is the only enforcement.

Operator caps: `safety.spawn.max_pipeline_fan_out_depth` (5) / `max_pipeline_spawns` (100), threaded `SessionFactoryConfig.from_config` → `AgentRegistry` properties → the driver's `run`/`resume` (decoupled from `registry` so a for_each with no agent step still gets its caps). Documented in `reyn-yaml.md`. The analyzer `_for_each_facet` does the STATIC half (warn on missing `max_parallel` / `over` source).

## Tests (no mocks; real StateLog / registries / generation files; Tier docstrings)
- happy path (concurrent, ordered collect, items/over/pipe sources, empty list); `max_parallel` bounds live concurrency (peak ≤ cap, real async probe).
- `on_error`: continue drops + collect sees survivors; abort fails step; retry(n) re-runs a flaky item then succeeds; retry exhausted → abort.
- **CLAUDE.md truncate-falsify gate** (single-step `do`): M/N done + 1 dropped, crash before collect records, WAL truncated below source events, resume → completed items replay exactly-once (side-effect file unchanged), dropped stays dropped (NOT re-run), collect runs once.
- compositional-`do` atomic-re-run (documents the #2582 gap); full-completion zero-side-effect replay.
- **S5**: each guard rejects at its cap (depth fails a too-deep nest; SpawnBudget fails a too-large agent fan-out via the real spawn path with an LLMReplay-style scripted reply) + within-cap success for both.
- serde/parser/analyzer contract (non-default values; on_error/collect required; over+items rejected; nested-do recursion).

## CI gates (all green locally)
`ruff check` ✓ · `test_tier_audit --strict` (25/25) ✓ · `pytest` (full suite: 7147 passed; the 13 fails + 10 errors are ALL pre-existing mcp/web env reds — `ModuleNotFoundError: mcp` / uvicorn / a2a — confirmed identical on the base commit 445178ce) ✓ · `verify_module_docstrings` ✓.

**Note:** `parallel` (heterogeneous named branches) is the additive follow-up built on THIS fan-out substrate — same coordinator, same S5 guards, a named-branch map instead of an item list.