### PR TITLE
feat(pipeline): parallel primitive (heterogeneous named-branch fan-out) — completes the non-linear primitive set

### DIFF
--- a/src/reyn/core/pipeline/analyzer.py
+++ b/src/reyn/core/pipeline/analyzer.py
@@ -9,16 +9,17 @@ monolithic walker — each primitive registers the check it is responsible for,
 and the registry is the single place a caller (a future ``analyze_pipeline``
 walker, or the IS-4 inline static-analysis gate) folds them together.
 
-This module is the SEAM plus its first three entries (``call``'s, ``match``'s,
-and ``fold``'s facets). It is deliberately minimal in this slice:
+This module is the SEAM plus one facet per non-linear primitive (``call``'s,
+``match``'s, ``fold``'s, ``for_each``'s, and ``parallel``'s — every Appendix-B
+non-linear primitive now registers here). It is deliberately minimal:
 :data:`ANALYZER_FACETS` maps
 a step dataclass type to a facet function returning a list of human-readable
 problem strings ( empty = the step passed its facet), and :func:`analyze_step`
 looks one up. There is no full pipeline walker wired to consume it yet — that
-arrives with the primitives whose facets have real teeth (cost / spawn-tree
-bounds). What matters now is that the registration point EXISTS and
-``call``/``match``/``fold`` are registered, so every future primitive MUST add
-its facet here rather than bolting analysis on later.
+arrives later (cost / spawn-tree bounds folded ACROSS steps, not just within
+one). What matters now is that the registration point EXISTS and every
+non-linear primitive is registered, so a FUTURE primitive (beyond Appendix B)
+MUST add its facet here rather than bolting analysis on later.
 
 ``call``'s facet is intentionally thin: the target is a STATIC literal pipeline
 name (Hard rule 2), so the only thing to confirm structurally is that it IS a
@@ -50,7 +51,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Callable
 
-from reyn.core.pipeline.executor import CallStep, FoldStep, ForEachStep, MatchStep
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    CallStep,
+    FoldStep,
+    ForEachStep,
+    MatchStep,
+    ParallelStep,
+)
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.executor import Step
@@ -147,6 +155,35 @@ def _for_each_facet(step: "ForEachStep") -> "list[str]":
     return problems
 
 
+def _parallel_facet(step: "ParallelStep") -> "list[str]":
+    """``parallel``'s S5 contribution — mirrors ``_for_each_facet``'s
+    WARNING-only posture, adapted to a STATIC branch-set fan-out. Unlike
+    ``for_each``, ``parallel`` has no ``max_parallel``/``over`` field at all:
+    the branch COUNT is always statically known (a finite named dict), so
+    there is nothing to warn about there. Instead this facet confirms
+    structural completeness (``branches`` non-empty) and flags a statically
+    large agent-branch fan-out — a coarse, per-step-visible proxy for the
+    "would this alone approach the operator's spawn cap" question the deeper
+    cross-pipeline cost fold (not here yet, same deferral ``call``/``match``
+    make) will answer precisely. Returns problem strings (empty = OK)."""
+    problems: "list[str]" = []
+    if not step.branches:
+        problems.append(
+            "parallel step has no branches — at least one NAME -> Step is required"
+        )
+    agent_branches = sorted(
+        name for name, s in step.branches.items() if isinstance(s, AgentStep)
+    )
+    if len(agent_branches) > 3:
+        problems.append(
+            f"parallel step fans out {len(agent_branches)} agent-step branches "
+            f"({agent_branches!r}) concurrently — a statically large spawn "
+            "footprint for one step (S5 cost-bound caution; the runtime "
+            "SpawnBudget still enforces the hard cap)"
+        )
+    return problems
+
+
 # Facet registry: step type -> its static-analysis check. A future primitive
 # ADDS an entry here (mirroring the executor's ``STEP_DISPATCH``, serde's
 # ``ENCODERS``/``DECODERS``, and the parser's ``_STEP_PARSERS``) — the P4
@@ -157,6 +194,7 @@ ANALYZER_FACETS: "dict[type, Callable[[Step], list[str]]]" = {
     MatchStep: _match_facet,
     FoldStep: _fold_facet,
     ForEachStep: _for_each_facet,
+    ParallelStep: _parallel_facet,
 }
 
 

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -7,12 +7,14 @@ sequence of ``transform`` / ``tool`` (``shell`` is just a ``ToolStep(name="shell
 ...)``) / ``agent`` (R5) steps, plus three COMPOSITIONAL primitives: ``call``
 (R7, a STATIC callee), ``match`` (``call``'s runtime-selected sibling — the
 ``on`` VALUE picks a LABEL, never a target; see :class:`MatchStep`), and
-``fold`` (the sequential accumulator, Appendix B), and ``for_each`` (the
+``fold`` (the sequential accumulator, Appendix B), ``for_each`` (the
 CONCURRENT fan-out — ``fold``'s parallel, isolated-sub-scope sibling; see
-:class:`ForEachStep` and :func:`_run_for_each_step`). Still out of scope for
-this slice: `parallel`/`refine` — those are later primitives that plug into the
-SAME dispatch + scope machinery this module now exposes (``parallel`` is the
-additive follow-up built on ``for_each``'s fan-out substrate).
+:class:`ForEachStep` and :func:`_run_for_each_step`), and ``parallel`` (the
+LAST non-linear primitive — ``for_each``'s HETEROGENEOUS NAMED-branch
+sibling, built additively on the SAME fan-out substrate; see
+:class:`ParallelStep` and :func:`_run_parallel_step`). All Appendix-B
+non-linear primitives are now implemented; ``refine`` (a pipeline-level
+construct, not a step kind) stays out of scope.
 
 **Fan-out recovery commit unit = the ITEM (READ THIS before touching
 ``for_each`` recovery).** ``for_each`` runs ``do`` over each list item as an
@@ -381,7 +383,63 @@ class ForEachStep:
     output: "str | None" = None
 
 
-Step = Union[TransformStep, ToolStep, AgentStep, CallStep, MatchStep, FoldStep, ForEachStep]
+@dataclass(frozen=True)
+class ParallelStep:
+    """The LAST non-linear primitive (Appendix B: ``parallel = {on_error?:abort|
+    continue|retry(n), branches:{NAME:Step}+, collect:Step}``) — ``for_each``'s
+    HETEROGENEOUS NAMED-branch sibling. Where ``for_each`` fans a SINGLE ``do``
+    step out over a runtime-sized list of items, ``parallel`` fans a STATIC,
+    FINITE dict of DISTINCT named branches out concurrently, then runs
+    ``collect`` ONCE over the NAMED MAP ``{branch_name: result}`` (not an
+    ordered list — Appendix B's compact grammar, N2).
+
+    - ``branches`` is a non-empty ``{NAME: Step}`` mapping; each branch is its
+      OWN heterogeneous Step (a different kind/config per NAME, unlike
+      ``for_each``'s one ``do`` re-invoked per item). Every branch runs
+      concurrently — the branch set is statically finite, so there is NO
+      ``max_parallel`` field (unlike ``for_each``): the branch COUNT is the
+      concurrency bound.
+    - ``on_error`` is OPTIONAL (Appendix B: ``on_error?:`` — UNLIKE
+      ``for_each`` where it is REQUIRED), defaulting to ``abort`` when
+      omitted. Same three values, same semantics as ``for_each``: ``continue``
+      (a failed branch is DROPPED — recorded with the shared
+      ``__fan_out_dropped__`` kind-marker so resume never re-runs it —
+      ``collect`` MUST handle the absent branch); ``abort`` (a branch failure
+      cancels the still-pending branches and fails the whole step);
+      ``retry(n)`` (re-run the failed branch's Step up to ``n`` more times,
+      falling back to ``abort`` if still failing — only ``continue`` ever
+      silently drops).
+    - each branch's context is ``{"ctx": <a COPY of the outer named stores —
+      isolation, Hard rule 6>, "pipe": <this parallel step's OWN incoming
+      pipe-data, held constant across every branch — the per-branch analog of
+      Hard rule 5>}`` — no ``item``/``acc`` (those are ``for_each``/
+      ``fold``-only) and no sibling visibility (a branch cannot see any other
+      branch's result; writes happen only in ``collect``).
+    - ``collect`` runs ONCE, over the NAMED MAP of surviving branch results
+      (dropped branches filtered out by the SAME shared
+      :func:`_is_dropped_marker` filter ``for_each`` uses, adapted to a dict)
+      — its result is this step's N2 return value / pipe-data.
+
+    Recovery: reuses the EXACT fan-out substrate ``for_each`` established (see
+    the module docstring's "commit unit = the ITEM") — the commit unit here is
+    the BRANCH (keyed by NAME, not index): a branch's result records at the
+    FLAT dotted key ``f"{label}.parallel.{branch_name}"``; ``collect`` records
+    at ``f"{label}.parallel.collect"``. A landed branch is exactly-once; a
+    dropped branch stays dropped forever (its marker key is present, so
+    resume never re-runs it); resume re-runs ONLY the branches whose key is
+    ABSENT, then runs ``collect`` iff its key is absent — see
+    :func:`_run_parallel_step`."""
+
+    branches: "dict[str, Step]"
+    collect: "Step"
+    on_error: str = "abort"
+    output: "str | None" = None
+
+
+Step = Union[
+    TransformStep, ToolStep, AgentStep, CallStep, MatchStep, FoldStep, ForEachStep,
+    ParallelStep,
+]
 
 
 @dataclass(frozen=True)
@@ -1102,6 +1160,175 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     return collect_result, any_durable, completed
 
 
+def _parallel_results(
+    completed_step_results: "dict[str, Any]", label: str, names: "list[str]",
+) -> "dict[str, Any]":
+    """Build ``collect``'s NAMED-MAP input ``{branch_name: result}`` from the
+    recorded per-branch results, FILTERING OUT dropped markers
+    (:func:`_is_dropped_marker`) — ``for_each``'s :func:`_for_each_results`,
+    adapted from an ordered list to a dict keyed by branch NAME. The same one
+    shared filter used identically live (all branches just landed) AND on
+    resume-replay (every branch key read back from a snapshot). Every name in
+    ``names`` MUST have a key by the time this runs (the coordinator only
+    reaches ``collect`` once every branch is present)."""
+    out: "dict[str, Any]" = {}
+    for name in names:
+        value = completed_step_results[f"{label}.parallel.{name}"]
+        if _is_dropped_marker(value):
+            continue
+        out[name] = value
+    return out
+
+
+async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """The heterogeneous NAMED-branch fan-out runner (S5-bounded) — reuses the
+    EXACT fan-out substrate :func:`_run_for_each_step` established (concurrent
+    recovery via a single serializing coordinator + a NO-OP recorder inside
+    each branch task, the ``__fan_out_dropped__`` kind-marker, the
+    fan_out_depth/SpawnBudget S5 guards). The one structural difference: the
+    source is a STATIC FINITE dict of DISTINCT named branches (each its own
+    heterogeneous Step) rather than one ``do`` re-invoked per list item, so
+    every branch runs concurrently with NO Semaphore (the branch count IS the
+    bound — there is no ``max_parallel`` field), and ``collect`` runs ONCE
+    over the NAMED MAP of surviving branch results (:func:`_parallel_results`),
+    not an ordered list.
+
+    ``on_error`` (optional, default ``abort`` — normalized the same way
+    ``for_each.on_error`` is, via :func:`_parse_on_error`) decides a branch
+    failure: ``continue`` records a DROPPED kind-marker (so resume never
+    re-runs it); ``retry(n)`` re-runs the branch's Step up to ``n`` more times
+    then falls back to ``abort``; ``abort`` cancels the still-pending branches
+    and fails the step (the already-landed branches stay durably recorded, so
+    a resume after an abort-crash skips them).
+
+    S5 guards: (b) ``fan_out_depth`` is +1'd through ``_RunDeps`` into every
+    branch/collect sub-scope, failing the step if it would exceed
+    ``max_fan_out_depth``; (c) each ``AgentStep`` reached below charges the
+    shared per-run :class:`SpawnBudget`."""
+    step: ParallelStep = inv.step  # type: ignore[assignment]
+    deps = inv.deps
+    context = inv.context
+    label = inv.step_label
+    completed = inv.completed_step_results
+
+    # Full-completion replay: if collect already ran (its key is present) the
+    # whole parallel is done — replay its N2 result, execute nothing.
+    collect_key = f"{label}.parallel.collect"
+    if collect_key in completed:
+        return completed[collect_key], False, completed
+
+    names = list(step.branches)
+    on_err = _parse_on_error(step.on_error)
+
+    # S5 guard (b): entering this parallel deepens the fan-out nesting by one
+    # (same guard, same semantics as for_each — a parallel scope counts as a
+    # fan-out level too).
+    next_depth = deps.fan_out_depth + 1
+    if deps.max_fan_out_depth and next_depth > deps.max_fan_out_depth:
+        raise PipelineExecutionError(
+            f"step {label} (parallel) fan-out depth {next_depth} exceeds the "
+            f"operator cap {deps.max_fan_out_depth} (S5 depth guard) — a "
+            "parallel nested deeper than allowed fails the step rather than "
+            "spawning"
+        )
+    child_deps = replace(deps, fan_out_depth=next_depth)
+
+    outer_stores = context["ctx"]
+    outer_pipe = context["pipe"]
+
+    async def _noop_record(**_kw: Any) -> None:
+        # Branch tasks NEVER record: only the single coordinator does
+        # (serialized), so concurrent branches cannot race the
+        # read-modify-write of the snapshot (identical to for_each's item
+        # tasks).
+        return None
+
+    async def _run_branch(name: str) -> "tuple[str, Any, bool, Exception | None]":
+        branch_step = step.branches[name]
+        # Retry(n) re-runs INSIDE the same task. Any Exception is a branch
+        # failure (CancelledError is BaseException, so an abort-cancel
+        # propagates out and the task is gathered in the finally).
+        attempts = 1 + (on_err.retries if on_err.kind == "retry" else 0)
+        last_exc: "Exception | None" = None
+        for _attempt in range(attempts):
+            branch_ctx = {"ctx": dict(outer_stores), "pipe": outer_pipe}
+            runner = STEP_DISPATCH.get(type(branch_step))
+            if runner is None:  # pragma: no cover - Step is a closed union
+                raise PipelineExecutionError(f"unknown step type: {branch_step!r}")
+            branch_inv = _StepInvocation(
+                executor=inv.executor, step=branch_step, context=branch_ctx,
+                step_label=f"{label}.parallel.{name}", deps=child_deps,
+                completed_step_results=completed, record=_noop_record,
+            )
+            try:
+                result, durable, _ = await runner(branch_inv)
+                return name, result, durable, None
+            except Exception as exc:  # noqa: BLE001 - branch-failure boundary (on_error policy)
+                last_exc = exc
+        return name, None, False, last_exc
+
+    # Only branches whose key is ABSENT run (resume re-runs exactly the absent
+    # ones; a present success key replays, a present dropped-marker stays
+    # dropped).
+    pending = [n for n in names if f"{label}.parallel.{n}" not in completed]
+    any_durable = False
+    if pending:
+        # No Semaphore: the branch set is statically finite (there is no
+        # max_parallel field) — every pending branch runs concurrently.
+        tasks = [asyncio.create_task(_run_branch(n)) for n in pending]
+        try:
+            for fut in asyncio.as_completed(tasks):
+                name, result, durable, exc = await fut
+                key = f"{label}.parallel.{name}"
+                if exc is None:
+                    completed = {**completed, key: result}
+                    any_durable = any_durable or durable
+                    await inv.record(completed_step_results=completed, durable=durable)
+                elif on_err.kind == "continue":
+                    # DROP the failed branch: record a kind-marker (NOT absent
+                    # — else resume re-runs it forever; NOT bare None — a
+                    # legit branch result).
+                    completed = {
+                        **completed,
+                        key: {_FAN_OUT_DROPPED_KEY: True, "error": str(exc)},
+                    }
+                    any_durable = True  # a drop MUST survive to resume (awaited-durable)
+                    await inv.record(completed_step_results=completed, durable=True)
+                else:
+                    # abort (incl. retry(n) exhausted): the landed branches
+                    # above are already durably recorded; fail the step now.
+                    raise PipelineExecutionError(
+                        f"step {label} (parallel) branch {name!r} failed "
+                        f"(on_error={step.on_error!r}): {exc}"
+                    ) from exc
+        finally:
+            # Never leave orphaned live fan-out tasks (an abort-raise cancels
+            # the still-pending branches; a clean finish finds them all
+            # already done).
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    # collect runs ONCE over the NAMED MAP of surviving results (dropped
+    # filtered out).
+    results_map = _parallel_results(completed, label, names)
+    collect_ctx = {"ctx": outer_stores, "pipe": results_map}
+    collect_runner = STEP_DISPATCH.get(type(step.collect))
+    if collect_runner is None:  # pragma: no cover - Step is a closed union
+        raise PipelineExecutionError(f"unknown step type: {step.collect!r}")
+    collect_inv = _StepInvocation(
+        executor=inv.executor, step=step.collect, context=collect_ctx,
+        step_label=collect_key, deps=child_deps,
+        completed_step_results=completed, record=inv.record,
+    )
+    collect_result, collect_durable, completed = await collect_runner(collect_inv)
+    completed = {**completed, collect_key: collect_result}
+    any_durable = any_durable or collect_durable
+    await inv.record(completed_step_results=completed, durable=collect_durable)
+    return collect_result, any_durable, completed
+
+
 # Dispatch table: step dataclass type -> its runner. A future primitive ADDS an
 # entry here (+ serde/parser/analyzer) rather than editing a shared elif chain.
 STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool, dict[str, Any]]]]]" = {
@@ -1112,6 +1339,7 @@ STEP_DISPATCH: "dict[type, Callable[[_StepInvocation], Awaitable[tuple[Any, bool
     MatchStep: _run_match_step,
     FoldStep: _run_fold_step,
     ForEachStep: _run_for_each_step,
+    ParallelStep: _run_parallel_step,
 }
 
 # Type -> kind-string, the inverse vocabulary the serde ``kind`` marker uses.
@@ -1123,6 +1351,7 @@ _STEP_KINDS: "dict[type, str]" = {
     MatchStep: "match",
     FoldStep: "fold",
     ForEachStep: "for_each",
+    ParallelStep: "parallel",
 }
 
 
@@ -1440,6 +1669,7 @@ __all__ = [
     "MatchStep",
     "FoldStep",
     "ForEachStep",
+    "ParallelStep",
     "SpawnBudget",
     "Step",
     "Pipeline",

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -4,13 +4,16 @@ Implements the surface grammar in Appendix B of
 ``docs/proposals/reyn-pipeline-spec-v0.8.md`` (lines 706-835), narrowed to
 exactly the subset :class:`reyn.core.pipeline.executor.PipelineExecutor` can
 run today: a **linear** sequence of ``transform`` / ``tool`` / ``shell`` /
-``agent`` steps plus three COMPOSITIONAL primitives — ``call`` (R7 — runs a
+``agent`` steps plus FIVE COMPOSITIONAL primitives — ``call`` (R7 — runs a
 STATIC registered sub-pipeline synchronously), ``match`` (``call``'s
 runtime-selected sibling: a runtime VALUE picks a case LABEL, whose target
-stays a static literal), and ``fold`` (sequential accumulator — runs a nested
-``do`` step once per list item) — plus the pipeline-level ``description``.
-``for_each`` / ``parallel`` / ``refine``, and the pipeline-level ``input`` /
-``defaults`` blocks are all part of the full v0.8 grammar but have no runtime
+stays a static literal), ``fold`` (sequential accumulator — runs a nested
+``do`` step once per list item), ``for_each`` (concurrent fan-out over a
+runtime-sized list, one ``do``), and ``parallel`` (concurrent fan-out over a
+STATIC, FINITE dict of heterogeneous NAMED branches — the LAST non-linear
+primitive; every Appendix-B step kind is now executable) — plus the
+pipeline-level ``description``. ``refine``, and the pipeline-level ``input``
+/ ``defaults`` blocks are part of the full v0.8 grammar but have no runtime
 yet — this parser refuses to accept them rather than silently dropping them
 into a pipeline that "parses" but then either crashes at run time in a
 confusing place or (worse) quietly loses the author's intent. Every construct
@@ -88,6 +91,7 @@ from reyn.core.pipeline.executor import (
     ForEachStep,
     MatchCase,
     MatchStep,
+    ParallelStep,
     Pipeline,
     Step,
     ToolStep,
@@ -104,9 +108,9 @@ class PipelineParseError(ValueError):
     """Raised for any DSL text this parser cannot turn into a `Pipeline` the
     current linear executor can run — malformed YAML, a malformed R1
     expression, or (most commonly) a construct that is valid Appendix-B
-    grammar but not yet supported by `PipelineExecutor` (`for_each`,
-    `parallel`, `refine`, pipeline-level `input`/
-    `defaults`, or a per-step field the executor does not consume)."""
+    grammar but not yet supported by `PipelineExecutor` (`refine`,
+    pipeline-level `input`/`defaults`, or a per-step field the executor does
+    not consume)."""
 
 
 # ---------------------------------------------------------------------------
@@ -175,16 +179,18 @@ _PipelineLoader.add_constructor("!expr", _construct_expr_tag)
 # Constructs the union grammar's non-linear step kinds accept as *keys* so a
 # document using them gets a clear "not yet supported" error instead of a
 # generic "unknown step type". ``call`` (R7), ``match`` (runtime-selected
-# sibling), ``fold`` (sequential accumulator), and ``for_each`` (concurrent
-# fan-out) are now SUPPORTED — they moved out of this set into ``_STEP_PARSERS``
-# (``fold``/``for_each`` are dispatched specially in ``_parse_step`` since their
-# ``do``/``collect`` sub-steps recurse). ``parallel`` is the last primitive.
-_UNSUPPORTED_STEP_KINDS = ("parallel",)
+# sibling), ``fold`` (sequential accumulator), ``for_each`` (concurrent
+# fan-out), and ``parallel`` (heterogeneous named-branch fan-out — the LAST
+# non-linear primitive) are all now SUPPORTED — every Appendix-B step kind is
+# executable, so this set is currently EMPTY (kept as a tuple, not deleted,
+# so a future Appendix-B step kind beyond this module's current scope has an
+# obvious place to land — see the parser module docstring).
+_UNSUPPORTED_STEP_KINDS: "tuple[str, ...]" = ()
 _LINEAR_STEP_KINDS = ("transform", "tool", "shell", "agent")
-# ``call``/``match``/``fold``/``for_each`` are compositional, not linear, but ARE
-# executable — listed separately so error text distinguishes "the linear
-# kinds" from the full supported set.
-_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold", "for_each")
+# ``call``/``match``/``fold``/``for_each``/``parallel`` are compositional, not
+# linear, but ARE executable — listed separately so error text distinguishes
+# "the linear kinds" from the full supported set.
+_SUPPORTED_STEP_KINDS = _LINEAR_STEP_KINDS + ("call", "match", "fold", "for_each", "parallel")
 _ALL_STEP_KINDS = _SUPPORTED_STEP_KINDS + _UNSUPPORTED_STEP_KINDS
 
 # Pipeline-level fields the full grammar allows but the linear executor has
@@ -510,6 +516,48 @@ def _parse_for_each_step(body: "dict[str, Any]", *, index: "int | str") -> ForEa
     )
 
 
+_PARALLEL_KEYS = frozenset({"branches", "collect", "on_error", "output"})
+
+
+def _parse_parallel_step(body: "dict[str, Any]", *, index: "int | str") -> ParallelStep:
+    """``parallel = {on_error?:abort|continue|retry(n), branches:{NAME:Step}+,
+    collect:Step}`` (Appendix B) — the heterogeneous NAMED-branch fan-out
+    primitive, ``for_each``'s static-branch-set sibling. ``branches`` is a
+    non-empty mapping of NAME -> a full nested Step (parsed the same way
+    top-level steps are, so a branch may be any supported step kind,
+    including a nested ``call``/``fold``/``for_each``/``parallel``) — there is
+    NO ``max_parallel`` field (unlike ``for_each``): the branch set is
+    statically finite, so its own size is the concurrency bound.
+    ``on_error`` is OPTIONAL (Appendix B gives it a ``?`` — UNLIKE
+    ``for_each`` where it is required), defaulting to ``abort`` when omitted;
+    when given, it must be ``continue``/``abort``/``retry(n)``, exactly like
+    ``for_each.on_error``. ``collect`` is a full nested Step, REQUIRED (it
+    produces the primitive's N2 result over the named map)."""
+    _reject_unknown_keys(body, _PARALLEL_KEYS, where="parallel step")
+    raw_branches = body.get("branches")
+    if not isinstance(raw_branches, dict) or not raw_branches:
+        _fail("parallel step: 'branches' must be a non-empty mapping of NAME -> Step")
+    branches = {
+        name: _parse_step(branch_body, index=f"{index} (parallel branch {name!r})")
+        for name, branch_body in raw_branches.items()
+    }
+    on_error = body.get("on_error", "abort")
+    if not isinstance(on_error, str) or (
+        on_error not in ("continue", "abort") and _ON_ERROR_RE.match(on_error) is None
+    ):
+        _fail(
+            "parallel step 'on_error': must be 'continue', 'abort', or "
+            f"'retry(n)' (a positive integer n), got {on_error!r}"
+        )
+    if "collect" not in body:
+        _fail("parallel step: missing required field 'collect'")
+    collect = _parse_step(body["collect"], index=f"{index} (parallel collect)")
+    output = body.get("output")
+    if output is not None and not isinstance(output, str):
+        _fail(f"parallel step 'output': expected a store-name string, got {type(output).__name__}")
+    return ParallelStep(branches=branches, collect=collect, on_error=on_error, output=output)
+
+
 _STEP_PARSERS = {
     "transform": _parse_transform_step,
     "tool": _parse_tool_step,
@@ -542,6 +590,13 @@ def _parse_step(raw_step: Any, *, index: "int | str") -> Step:
         if not isinstance(body, dict):
             _fail(f"step {index} (for_each): expected a mapping body, got {type(body).__name__}")
         return _parse_for_each_step(body, index=index)
+    if kind == "parallel":
+        # Special-dispatched like ``fold``/``for_each``: its ``branches``/``collect``
+        # sub-steps recurse through ``_parse_step``, so it needs ``index`` for
+        # nested error context.
+        if not isinstance(body, dict):
+            _fail(f"step {index} (parallel): expected a mapping body, got {type(body).__name__}")
+        return _parse_parallel_step(body, index=index)
     if kind not in _STEP_PARSERS:
         _fail(
             f"step {index}: unknown step kind {kind!r} (expected one of "

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -44,6 +44,7 @@ from reyn.core.pipeline.executor import (
     ForEachStep,
     MatchCase,
     MatchStep,
+    ParallelStep,
     Pipeline,
     Step,
     ToolStep,
@@ -238,6 +239,30 @@ def _decode_for_each(data: "dict[str, Any]") -> "ForEachStep":
     )
 
 
+def _encode_parallel(step: "ParallelStep") -> "dict[str, Any]":
+    # ``branches`` AND ``collect`` are each a Step — recurse through `step_to_dict`
+    # so a parallel whose branch/collect is a `call` (or nested parallel/
+    # for_each) round-trips faithfully.
+    return {
+        "kind": "parallel",
+        "branches": {name: step_to_dict(s) for name, s in step.branches.items()},
+        "collect": step_to_dict(step.collect),
+        "on_error": step.on_error,
+        "output": step.output,
+    }
+
+
+def _decode_parallel(data: "dict[str, Any]") -> "ParallelStep":
+    return ParallelStep(
+        branches={
+            name: step_from_dict(s) for name, s in dict(data.get("branches") or {}).items()
+        },
+        collect=step_from_dict(data["collect"]),
+        on_error=str(data.get("on_error") or "abort"),
+        output=data.get("output"),
+    )
+
+
 # Dispatch tables: encoder keyed by step type, decoder keyed by ``kind`` marker.
 # A future primitive ADDS one entry to each (mirroring the executor's
 # ``STEP_DISPATCH`` and the parser's ``_STEP_PARSERS``) rather than editing a
@@ -250,6 +275,7 @@ ENCODERS: "dict[type, Callable[[Step], dict[str, Any]]]" = {
     MatchStep: _encode_match,
     FoldStep: _encode_fold,
     ForEachStep: _encode_for_each,
+    ParallelStep: _encode_parallel,
 }
 DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "transform": _decode_transform,
@@ -259,6 +285,7 @@ DECODERS: "dict[str, Callable[[dict[str, Any]], Step]]" = {
     "match": _decode_match,
     "fold": _decode_fold,
     "for_each": _decode_for_each,
+    "parallel": _decode_parallel,
 }
 
 

--- a/tests/test_pipeline_for_each_serde_parser_analyzer.py
+++ b/tests/test_pipeline_for_each_serde_parser_analyzer.py
@@ -191,10 +191,15 @@ steps:
         parse_pipeline_dsl(text, SchemaRegistry())
 
 
-def test_for_each_dsl_rejects_unsupported_nested_kind():
-    """Tier 1: a ``do:``/``collect:`` naming a still-unsupported step kind (e.g.
-    `parallel`) fails at parse time, at the DSL text — the same "not yet
-    supported" error a top-level step of that kind raises."""
+def test_for_each_dsl_rejects_malformed_nested_step():
+    """Tier 1: a ``do:``/``collect:`` naming ANY step kind still validates that
+    kind's own body — a malformed nested step (here a ``parallel`` with an
+    empty ``branches``) fails at parse time, at the DSL text, through the
+    SAME per-kind parser a top-level step uses (not a bespoke "nested step"
+    validation path). (``parallel`` is now a fully-supported step kind — see
+    ``test_pipeline_parallel_primitive.py`` / ``test_pipeline_parallel_serde_
+    parser_analyzer.py`` — this test only pins that a malformed nested body,
+    of any kind, still fails cleanly.)"""
     text = """
 pipeline: o
 steps:

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -144,10 +144,13 @@ steps:
 
 
 @pytest.mark.parametrize("kind", ["for_each", "parallel", "fold", "match", "call"])
-def test_nonlinear_step_kind_raises_naming_the_construct(kind: str) -> None:
-    """Tier 1: the HARD CONTRACT — a step kind the linear executor cannot run
-    is a `PipelineParseError` naming that kind, never a silently-accepted
-    step the executor would later choke on or (worse) ignore."""
+def test_nonlinear_step_kind_with_empty_body_raises_naming_the_construct(kind: str) -> None:
+    """Tier 1: every non-linear step kind is now executable (`for_each` /
+    `parallel` / `fold` / `match` / `call` all have a runtime + parser), but
+    an EMPTY (`{}`) body is still missing that kind's required fields — the
+    HARD CONTRACT is that this is a `PipelineParseError` naming the
+    construct, never a silently-accepted malformed step the executor would
+    later choke on or (worse) ignore."""
     dsl = f"""
 pipeline: rejects-nonlinear
 steps:

--- a/tests/test_pipeline_parallel_primitive.py
+++ b/tests/test_pipeline_parallel_primitive.py
@@ -1,0 +1,711 @@
+"""Tier 2: OS invariant — the `parallel` HETEROGENEOUS NAMED-branch fan-out
+primitive, the LAST non-linear primitive (Appendix B;
+``docs/proposals/reyn-pipeline-spec-v0.8.md`` lines 737-741, Hard rule 6, N2).
+Every Appendix-B non-linear primitive (``call``/``match``/``fold``/
+``for_each``/``parallel``) is now implemented.
+
+``parallel`` is ``for_each``'s static-branch-set sibling — it reuses the EXACT
+SAME fan-out substrate (concurrent recovery via a single serializing
+coordinator + a NO-OP recorder inside branch tasks, the
+``__fan_out_dropped__`` kind-marker, the ``fan_out_depth``/``SpawnBudget`` S5
+guards). Structural differences covered here:
+
+  1. happy path — a STATIC dict of heterogeneous NAMED branches runs
+     CONCURRENTLY; ``collect`` runs ONCE over the NAMED MAP ``results.NAME``
+     (not an ordered list); ``collect``'s result is the primitive's N2 return
+     / pipe-data; ``output`` threads out (R3 uniformity).
+  2. ``on_error`` DEFAULT = ``abort`` when omitted (Appendix B's ``on_error?:``
+     — a parser test, unlike ``for_each`` where it is required).
+  3. ``on_error`` — ``continue`` DROPS a failed branch (a kind-marker, so
+     resume never re-runs it; ``collect`` sees the surviving named map, MUST
+     handle the absent branch) / ``abort`` fails the whole step / ``retry(n)``
+     re-runs a flaky branch then succeeds, and a still-failing branch after
+     ``n`` retries falls back to abort.
+  4. the CLAUDE.md-mandated truncate-falsify recovery gate: mid-parallel
+     crash (some branches done + 1 dropped, ``collect`` not yet recorded),
+     WAL truncated below the source events, resume from the generation FILE →
+     done branches replay exactly-once (their side-effect file is unchanged),
+     the dropped branch stays dropped, ``collect`` runs ONCE over the named
+     map.
+  5. S5 guards — (b) a ``parallel`` nested deeper than ``max_fan_out_depth``
+     FAILS the step; (c) branches whose Step is an ``agent`` step exceeding
+     ``max_pipeline_spawns`` FAILS the step (the shared per-run
+     ``SpawnBudget`` counter).
+
+Real ``StateLog`` + ``PipelineRegistry`` + real generation files + a real
+``AgentRegistry``/``Session``/``MessageBus`` (the S5-c spawn test) throughout —
+no mocks, no private-state assertions (the ONE faked collaborator is the LLM
+completion call, injected via the real ``_loop_observer`` seam, exactly as
+``test_pipeline_for_each_primitive.py`` does).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    CallStep,
+    ParallelStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.parser import parse_pipeline_dsl
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+# ── happy path: heterogeneous named branches, named-map collect, N2 out ──────
+
+
+@pytest.mark.asyncio
+async def test_parallel_runs_named_branches_and_collects_named_map():
+    """Tier 2: each NAMED branch is its OWN heterogeneous Step, all run
+    CONCURRENTLY; ``collect`` runs ONCE over the NAMED MAP ``{name: result}``
+    (not an ordered list), and its result becomes the parallel step's N2
+    return value + named output (R3)."""
+    pipeline = Pipeline(steps=[
+        TransformStep(value="'seed'"),  # step 0: pipe = 'seed'
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "upper": TransformStep(value="pipe + '-UP'"),
+                "lower": TransformStep(value="pipe + '-lo'"),
+            },
+            collect=TransformStep(value="pipe"),  # pipe == the named-map dict
+            output="combined",
+        ),
+    ])
+
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-par-happy",
+    )
+
+    assert result.named_stores["combined"] == {"upper": "seed-UP", "lower": "seed-lo"}
+    assert result.pipe_data == {"upper": "seed-UP", "lower": "seed-lo"}
+    # per-branch flat keys (by NAME, not index) + the collect key.
+    assert result.completed_step_results["1.parallel.upper"] == "seed-UP"
+    assert result.completed_step_results["1.parallel.lower"] == "seed-lo"
+    assert result.completed_step_results["1.parallel.collect"] == {
+        "upper": "seed-UP", "lower": "seed-lo",
+    }
+
+
+@pytest.mark.asyncio
+async def test_parallel_branches_see_isolated_ctx_and_shared_pipe_at_call_site():
+    """Tier 2: each branch's context is a COPY of the outer named stores
+    (isolation, Hard rule 6) and the parallel step's OWN incoming pipe-data
+    held constant across every branch (Hard rule 5's per-branch analog) — no
+    sibling visibility (writes only happen in collect)."""
+    pipeline = Pipeline(steps=[
+        TransformStep(value="'PFX'"),  # step 0: pipe = 'PFX'
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "a": TransformStep(value="pipe + '-a'", output="local_a"),
+                "b": TransformStep(value="pipe + '-b'"),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, {"local_a": "outer-untouched"},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-par-isolation",
+    )
+    assert result.pipe_data == {"a": "PFX-a", "b": "PFX-b"}
+    # branch "a"'s own output write never leaked to the outer named stores.
+    assert result.named_stores["local_a"] == "outer-untouched"
+
+
+@pytest.mark.asyncio
+async def test_parallel_empty_pipe_data_not_a_list_still_works_over_static_branches():
+    """Tier 2: unlike ``for_each``, ``parallel`` never resolves a runtime list
+    source — its branch set is a STATIC dict, so a pipeline whose incoming
+    pipe-data is not list-shaped at all still fans out fine."""
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={"only": TransformStep(value="1 + 1")},
+            collect=TransformStep(value="pipe.only"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-par-nolist",
+    )
+    assert result.pipe_data == 2
+
+
+# ── on_error DEFAULT = abort when omitted (Appendix B's on_error?:) ──────────
+
+
+@pytest.mark.asyncio
+async def test_on_error_omitted_defaults_to_abort_dataclass_default():
+    """Tier 1: ``ParallelStep.on_error`` defaults to ``"abort"`` (Appendix B's
+    ``on_error?:`` — the ONE required-vs-optional divergence from
+    ``for_each``)."""
+    step = ParallelStep(branches={"x": TransformStep(value="1")}, collect=TransformStep(value="pipe"))
+    assert step.on_error == "abort"
+
+
+def test_parser_on_error_omitted_defaults_to_abort():
+    """Tier 1: the DSL parser defaults ``on_error`` to ``"abort"`` when the
+    ``parallel`` step body omits it entirely."""
+    text = """
+pipeline: par-default
+steps:
+  - parallel:
+      branches:
+        a:
+          transform: {value: "1"}
+        b:
+          transform: {value: "2"}
+      collect:
+        transform: {value: "pipe"}
+"""
+    pipeline = parse_pipeline_dsl(text, SchemaRegistry())
+    step = pipeline.steps[0]
+    assert isinstance(step, ParallelStep)
+    assert step.on_error == "abort"
+
+
+def test_parser_on_error_explicit_continue_is_honored():
+    """Tier 1: an explicit ``on_error`` value is parsed through unchanged (not
+    silently overridden by the default)."""
+    text = """
+pipeline: par-explicit
+steps:
+  - parallel:
+      on_error: continue
+      branches:
+        a:
+          transform: {value: "1"}
+      collect:
+        transform: {value: "pipe"}
+"""
+    pipeline = parse_pipeline_dsl(text, SchemaRegistry())
+    step = pipeline.steps[0]
+    assert isinstance(step, ParallelStep)
+    assert step.on_error == "continue"
+
+
+def test_parser_rejects_empty_branches():
+    """Tier 1: 'branches' must be a non-empty mapping."""
+    text = """
+pipeline: par-empty
+steps:
+  - parallel:
+      branches: {}
+      collect:
+        transform: {value: "pipe"}
+"""
+    with pytest.raises(Exception):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_parser_rejects_missing_collect():
+    """Tier 1: 'collect' is required."""
+    text = """
+pipeline: par-nocollect
+steps:
+  - parallel:
+      branches:
+        a:
+          transform: {value: "1"}
+"""
+    with pytest.raises(Exception):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+# ── on_error policies (parallel behavior over the runner, not the parser) ────
+
+
+@pytest.mark.asyncio
+async def test_on_error_continue_drops_failed_branch_and_collect_sees_survivors():
+    """Tier 2: ``on_error:continue`` DROPS a failed branch from the named-map
+    results — its branch key holds a kind-marker (so resume never re-runs
+    it), and ``collect``'s input is the surviving named map, with the failed
+    branch's name simply ABSENT (not a hole/None)."""
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        if v == "bad":
+            raise RuntimeError("boom")
+        return v.upper()
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="continue",
+            branches={
+                "good": ToolStep(name="work", args={"v": "ok"}),
+                "bad": ToolStep(name="work", args={"v": "bad"}),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-par-continue",
+    )
+    # collect saw only the survivors — the failed branch is absent, not None.
+    assert result.pipe_data == {"good": "OK"}
+    assert "bad" not in result.pipe_data
+    dropped = result.completed_step_results["0.parallel.bad"]
+    assert dropped["__fan_out_dropped__"] is True
+    assert "boom" in dropped["error"]
+
+
+@pytest.mark.asyncio
+async def test_on_error_abort_fails_the_whole_step():
+    """Tier 2: ``on_error:abort`` — a single branch failure fails the whole
+    parallel step (``PipelineExecutionError``), not a silent drop."""
+    def _dispatch(name: str, args: dict) -> Any:
+        if args["v"] == "bad":
+            raise RuntimeError("boom")
+        return args["v"]
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "good": ToolStep(name="work", args={"v": "ok"}),
+                "bad": ToolStep(name="work", args={"v": "bad"}),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-par-abort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_reruns_flaky_branch_until_success():
+    """Tier 2: ``on_error:retry(2)`` re-runs a flaky branch (fails twice,
+    succeeds on the 3rd attempt) — the branch lands, not dropped, so
+    ``collect`` sees it."""
+    attempts: dict[str, int] = {}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        attempts[v] = attempts.get(v, 0) + 1
+        if v == "flaky" and attempts[v] < 3:
+            raise RuntimeError("transient")
+        return v
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="retry(2)",
+            branches={
+                "ok": ToolStep(name="work", args={"v": "ok"}),
+                "flaky": ToolStep(name="work", args={"v": "flaky"}),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-par-retry-ok",
+    )
+    assert result.pipe_data == {"ok": "ok", "flaky": "flaky"}
+    assert attempts["flaky"] == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_exhausted_falls_back_to_abort():
+    """Tier 2: ``retry(1)`` on an ALWAYS-failing branch exhausts its retries
+    and then falls back to ABORT (only ``continue`` ever silently drops) —
+    the step fails."""
+    calls: dict[str, int] = {}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        v = args["v"]
+        calls[v] = calls.get(v, 0) + 1
+        if v == "always":
+            raise RuntimeError("permanent")
+        return v
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="retry(1)",
+            branches={"always": ToolStep(name="work", args={"v": "always"})},
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-par-retry-exhaust",
+        )
+    assert calls["always"] == 2  # 1 initial + 1 retry, then abort
+
+
+# ── CLAUDE.md truncate-falsify recovery gate ─────────────────────────────────
+
+
+def _append_dispatch(state_log: StateLog, out_file: Path, crash: set):
+    """A REAL side-effecting tool (mirrors for_each's truncate-falsify probe):
+    each call appends a line to ``out_file`` AND a WAL entry (so R4 gens land
+    at distinct durable seqs). The exactly-once probe is the FILE. A line in
+    ``crash`` raises BEFORE its write, arming a genuine failure."""
+
+    async def _dispatch(name: str, args: dict) -> Any:
+        assert name == "append"
+        line = str(args["line"])
+        if line in crash:
+            raise RuntimeError(f"simulated crash before writing {line!r}")
+        with out_file.open("a", encoding="utf-8") as f:
+            f.write(line + "\n")
+        await state_log.append("inbox_put", note=line)
+        return {"wrote": line}
+
+    return _dispatch
+
+
+def _fan_out_pipeline(on_error: str) -> Pipeline:
+    """parallel over 4 named branches (append each), collect appends a
+    COLLECT marker line."""
+    return Pipeline(steps=[
+        ParallelStep(
+            on_error=on_error,
+            branches={
+                "a": ToolStep(name="append", args={"line": "A"}),
+                "b": ToolStep(name="append", args={"line": "B"}),
+                "c": ToolStep(name="append", args={"line": "C"}),
+                "d": ToolStep(name="append", args={"line": "D"}),
+            },
+            collect=ToolStep(name="append", args={"line": "COLLECT"}),
+        ),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_truncate_falsify_mid_parallel_replays_branches_exactly_once(tmp_path: Path):
+    """Tier 2: MANDATORY CLAUDE.md recovery gate for the parallel fan-out
+    substrate. Phase 1: branches a/b/d write + record their branch keys;
+    branch c fails (``on_error:continue`` -> dropped marker recorded);
+    ``collect`` then crashes BEFORE recording its key. The WAL is truncated
+    BELOW all source events. Resume from the generation FILE ->
+
+      - the completed branches REPLAY exactly-once (a/b/d are NOT re-written
+        — the file proves it),
+      - the dropped branch c STAYS dropped (NOT re-run — its marker key is
+        present),
+      - ``collect`` runs ONCE (writes COLLECT), threading its result out over
+        the named map.
+
+    RED if a branch rode a truncatable WAL event, if resume re-ran the whole
+    fan-out, or if the dropped branch was re-run as an absent-keyed pending
+    branch."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    # C fails (→ dropped); COLLECT crashes phase 1 AFTER all branches recorded.
+    crash = {"C", "COLLECT"}
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    pipeline = _fan_out_pipeline("continue")
+
+    with pytest.raises(RuntimeError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-par-tf",
+        )
+    await state_log.flush()
+    # a/b/d written (c dropped, COLLECT crashed) — order is completion-order.
+    assert sorted(out_file.read_text(encoding="utf-8").splitlines()) == ["A", "B", "D"]
+
+    from reyn.core.events.pipeline_recovery import latest_pipeline_state
+    snap = latest_pipeline_state("run-par-tf", state_log)
+    for name in ("a", "b", "c", "d"):
+        assert f"0.parallel.{name}" in snap["completed_step_results"]
+    assert snap["completed_step_results"]["0.parallel.c"]["__fan_out_dropped__"] is True
+    assert "0.parallel.collect" not in snap["completed_step_results"]
+
+    # WAL head climbs past the crash-state seqs, then GC truncates below 40 —
+    # every branch's own WAL entry is dropped from wal.jsonl.
+    for i in range(50):
+        await state_log.append("inbox_put", n=100 + i)
+    await state_log.truncate_below(40)
+    await state_log.flush()
+    surviving = {e["seq"] for e in state_log.iter_from(0)}
+    assert all(s >= 40 for s in surviving), "the branches' WAL entries are truncated away"
+
+    # RESUME with COLLECT disarmed (C stays armed — it must NOT be re-run anyway).
+    crash.discard("COLLECT")
+    resumed = await PipelineExecutor().resume(
+        "run-par-tf", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    # Exactly-once: a/b/d appear ONCE each (replayed, not re-written); c NEVER
+    # (stayed dropped, not re-run despite still being armed); COLLECT once.
+    assert sorted(lines) == ["A", "B", "COLLECT", "D"]
+    assert lines.count("A") == 1 and lines.count("B") == 1 and lines.count("D") == 1
+    assert "C" not in lines
+    # collect ran once; its result threads out as the parallel N2 return.
+    assert resumed.pipe_data == {"wrote": "COLLECT"}
+    assert resumed.completed_step_results["0.parallel.collect"] == {"wrote": "COLLECT"}
+
+
+@pytest.mark.asyncio
+async def test_resume_after_full_parallel_replays_with_zero_new_side_effects(tmp_path: Path):
+    """Tier 2: resuming a fully-completed parallel replays every branch +
+    collect from the snapshot with ZERO new writes. RED if resume re-fired a
+    completed branch or the collect."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    dispatch = _append_dispatch(state_log, out_file, set())
+    pipeline = _fan_out_pipeline("abort")
+
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=dispatch, state_log=state_log, run_id="run-par-done",
+    )
+    await state_log.flush()
+    before = sorted(out_file.read_text(encoding="utf-8").splitlines())
+    assert before == ["A", "B", "C", "COLLECT", "D"]
+
+    resumed = await PipelineExecutor().resume(
+        "run-par-done", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log,
+    )
+    after = sorted(out_file.read_text(encoding="utf-8").splitlines())
+    assert after == before, "a fully-completed fan-out must replay with zero side effects"
+    assert resumed.pipe_data == {"wrote": "COLLECT"}
+
+
+# ── S5 guard (b): fan_out_depth cap FAILS the step (does not spawn) ──────────
+
+
+@pytest.mark.asyncio
+async def test_fan_out_depth_cap_fails_a_too_deeply_nested_parallel():
+    """Tier 2: (S5 guard b — bounded-by-construction) a ``parallel`` nested
+    deeper than ``max_fan_out_depth`` FAILS the step rather than spawning. A
+    top-level parallel = depth 1; a parallel inside one of its branches =
+    depth 2. With ``max_fan_out_depth=1`` the inner one exceeds the cap and
+    fails."""
+    inner = ParallelStep(
+        on_error="abort",
+        branches={"only": TransformStep(value="1")},
+        collect=TransformStep(value="pipe"),
+    )
+    outer = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",  # so the inner depth-failure propagates as a step failure
+            branches={"nested": inner},
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            outer, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=None, run_id="run-par-depth",
+            max_fan_out_depth=1,
+        )
+    assert "depth" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_nested_parallel_within_depth_cap_succeeds():
+    """Tier 2: the depth guard is a CAP, not a blanket ban — a parallel nested
+    to depth 2 runs fine under ``max_fan_out_depth=2`` (bounded, not
+    forbidden)."""
+    outer = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "nested": ParallelStep(
+                    on_error="abort",
+                    branches={"x": TransformStep(value="1"), "y": TransformStep(value="2")},
+                    collect=TransformStep(value="pipe.x + pipe.y"),
+                ),
+                "flat": TransformStep(value="10"),
+            },
+            collect=TransformStep(value="pipe.nested + pipe.flat"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        outer, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-par-depth-ok",
+        max_fan_out_depth=2,
+    )
+    assert result.pipe_data == 13  # (1 + 2) + 10
+
+
+# ── S5 guard (c): per-run spawn budget ────────────────────────────────────────
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text turn (no tool_calls) — the
+    ONLY faked collaborator (see module docstring), injected via the real
+    ``_loop_observer`` seam exactly as
+    ``test_pipeline_for_each_primitive.py`` does."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgentReply) -> AgentRegistry:
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+        )
+        s._loop_driver._loop_observer = (lambda loop: setattr(loop, "_llm_caller", scripted))
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_spawn_budget_cap_fails_a_parallel_over_too_many_agent_branches(tmp_path: Path):
+    """Tier 2: (S5 guard c — bounded-by-construction, real spawn path) a
+    parallel with 3 agent-step branches and ``max_pipeline_spawns=2`` FAILS
+    the step — a 3rd branch's spawn exceeds the per-run budget (the ONLY
+    spawn-count enforcement for lineage-less pipeline agent-steps). Unlike
+    ``for_each`` (which has ``max_parallel=1`` to make the ordering
+    deterministic), ``parallel`` has NO concurrency-limiting field — all
+    branches race, so the assertion only pins the INVARIANT the budget
+    guarantees (never more spawns COMPLETE than the cap), not a specific
+    completion count (that race is exactly why the cap, not a count, is the
+    enforcement mechanism)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("done")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",  # so the budget-exceed failure fails the step
+            branches={
+                "a": AgentStep(prompt="a", identity="worker"),
+                "b": AgentStep(prompt="b", identity="worker"),
+                "c": AgentStep(prompt="c", identity="worker"),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError) as exc:
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=lambda *_a, **_k: None,
+            state_log=state_log, run_id="run-par-spawns",
+            registry=reg, max_pipeline_spawns=2,
+        )
+    assert "spawn cap" in str(exc.value)
+    assert scripted.calls <= 2, (
+        "the SpawnBudget cap must never let more than max_pipeline_spawns "
+        "(2) agent branches actually complete their spawn"
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_of_agent_branches_within_spawn_cap_succeeds(tmp_path: Path):
+    """Tier 2: within ``max_pipeline_spawns``, an agent-branch parallel runs
+    every branch and collects — the budget is a cap, not a ban (bounded, not
+    forbidden)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("ok")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "a": AgentStep(prompt="a", identity="worker"),
+                "b": AgentStep(prompt="b", identity="worker"),
+                "c": AgentStep(prompt="c", identity="worker"),
+            },
+            collect=TransformStep(value="count([pipe.a, pipe.b, pipe.c])"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=state_log, run_id="run-par-spawns-ok",
+        registry=reg, max_pipeline_spawns=5,
+    )
+    assert result.pipe_data == 3
+    assert scripted.calls == 3
+
+
+# ── compositional-do (branch) recovery gap, documented, mirrors for_each ─────
+
+
+@pytest.mark.asyncio
+async def test_compositional_branch_reruns_atomically_on_crash(tmp_path: Path):
+    """Tier 2: DOCUMENTS the known fan-out recovery gap (module docstring's
+    "commit unit = the ITEM/BRANCH"). A ``call``-branch crashed MID-BRANCH
+    (its callee wrote sub-step 0's side effect, sub-step 1 failed) re-runs
+    ATOMICALLY on resume — because branch tasks record through a NO-OP
+    recorder, the branch's internal progress is never journaled, so the
+    completed internal side effect RE-FIRES. A single-step branch has no such
+    gap (see the truncate-falsify test above)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    crash = {"X-b"}  # the callee's 2nd sub-step fails in phase 1
+    dispatch = _append_dispatch(state_log, out_file, crash)
+
+    registry = PipelineRegistry()
+    registry.register("worker", Pipeline(steps=[
+        ToolStep(name="append", args={"line": "X-a"}),
+        ToolStep(name="append", args={"line": "X-b"}),
+    ]))
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={"x": CallStep(pipeline="worker")},
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=dispatch, state_log=state_log, run_id="run-par-comp",
+            pipeline_registry=registry,
+        )
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["X-a"]
+
+    # RESUME disarmed: the branch re-runs WHOLE (its key was never recorded),
+    # so X-a is written AGAIN (the documented internal-side-effect re-fire).
+    crash.clear()
+    await PipelineExecutor().resume(
+        "run-par-comp", pipeline=pipeline,
+        tool_dispatch=dispatch, state_log=state_log, pipeline_registry=registry,
+    )
+    lines = out_file.read_text(encoding="utf-8").splitlines()
+    assert lines == ["X-a", "X-a", "X-b"], (
+        "a compositional branch re-runs atomically on resume — X-a re-fires "
+        "(the documented commit-unit=BRANCH gap; single-step branch has no "
+        "such gap)"
+    )

--- a/tests/test_pipeline_parallel_serde_parser_analyzer.py
+++ b/tests/test_pipeline_parallel_serde_parser_analyzer.py
@@ -1,0 +1,273 @@
+"""Tier 1: `parallel` primitive contract — serde round-trip, DSL parse,
+analyzer facet.
+
+The `parallel` step (heterogeneous NAMED-branch fan-out — the LAST
+non-linear primitive) plugs into the same sibling dispatch tables
+`call`/`match`/`fold`/`for_each` established: serde's ``ENCODERS``/
+``DECODERS`` (work-order persistence — every branch AND ``collect``, each a
+nested ``Step``, recurse through ``step_to_dict``/``step_from_dict``), the
+parser's special-dispatch (Appendix B ``parallel = {on_error?, branches,
+collect}`` — ``on_error`` OPTIONAL (default ``abort``, unlike ``for_each``'s
+required field), ``branches``/``collect`` REQUIRED), and the analyzer's
+``ANALYZER_FACETS`` (P4 seam). This pins each contract with NON-DEFAULT
+values.
+
+Real YAML parse + real JSON round-trip; no mocks.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.pipeline.analyzer import analyze_step
+from reyn.core.pipeline.executor import (
+    AgentStep,
+    CallStep,
+    ParallelStep,
+    Pipeline,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
+
+
+def test_parallel_serde_round_trip_non_default_values_with_nested_branches_and_collect():
+    """Tier 1: a ``ParallelStep`` with heterogeneous named branches (one a
+    ``CallStep``, one a ``ToolStep``) and a ``ToolStep`` ``collect`` round-trips
+    dataclass -> dict -> JSON -> dataclass — proving every branch AND collect
+    recurse through the SAME step-serde contract as a top-level step (not a
+    bespoke shape). ``on_error`` persists as its plain DSL string (normalized
+    only at execution)."""
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            branches={
+                "summary": CallStep(pipeline="summarize", pass_=["doc"], output="s"),
+                "score": ToolStep(name="scorer", args={}, output="sc"),
+            },
+            collect=ToolStep(name="merge", args={}, output="merged"),
+            on_error="retry(3)",
+            output="results",
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    par_dict = wire["steps"][0]
+    assert par_dict == {
+        "kind": "parallel",
+        "branches": {
+            "summary": {
+                "kind": "call", "pipeline": "summarize", "pass": ["doc"], "output": "s",
+            },
+            "score": {
+                "kind": "tool", "name": "scorer", "args": {}, "output": "sc", "schema": None,
+            },
+        },
+        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None},
+        "on_error": "retry(3)",
+        "output": "results",
+    }
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_parallel_serde_round_trip_default_on_error():
+    """Tier 1: a ``ParallelStep`` built without ``on_error`` persists the
+    dataclass default (``"abort"``) faithfully through the round-trip."""
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            branches={"x": TransformStep(value="1"), "y": TransformStep(value="2")},
+            collect=TransformStep(value="pipe.x + pipe.y"),
+        ),
+    ])
+    wire = pipeline_to_dict(pipeline)
+    assert wire["steps"][0]["on_error"] == "abort"
+    assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline
+
+
+def test_parallel_parses_from_dsl():
+    """Tier 1: the DSL ``parallel`` step parses to a ``ParallelStep`` with
+    every field honored, and nested ``branches:``/``collect:`` steps parse
+    through the SAME per-kind parser a top-level step uses."""
+    text = """
+pipeline: outer
+steps:
+  - parallel:
+      on_error: continue
+      branches:
+        a:
+          transform:
+            value: "1"
+        b:
+          transform:
+            value: "2"
+      collect:
+        transform:
+          value: pipe
+      output: verdicts
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    assert parsed.steps == [
+        ParallelStep(
+            branches={"a": TransformStep(value="1"), "b": TransformStep(value="2")},
+            collect=TransformStep(value="pipe"),
+            on_error="continue",
+            output="verdicts",
+        ),
+    ]
+
+
+def test_parallel_dsl_on_error_omitted_defaults_to_abort():
+    """Tier 1: Appendix B's ``on_error?:`` — omitting ``on_error`` entirely in
+    the DSL parses successfully and defaults to ``"abort"`` (the ONE
+    required-vs-optional divergence from ``for_each``, which fails to parse
+    without it — see ``test_for_each_dsl_requires_on_error``)."""
+    text = """
+pipeline: o
+steps:
+  - parallel:
+      branches:
+        a:
+          transform:
+            value: "1"
+      collect:
+        transform:
+          value: pipe
+"""
+    parsed = parse_pipeline_dsl(text, SchemaRegistry())
+    step = parsed.steps[0]
+    assert isinstance(step, ParallelStep)
+    assert step.on_error == "abort"
+
+
+def test_parallel_dsl_rejects_bad_on_error():
+    """Tier 1: when given, ``on_error`` must be ``continue``/``abort``/
+    ``retry(n)`` — any other value is a parse error (e.g. a bare ``retry``
+    with no count)."""
+    for bad in ("skip", "retry", "retry()", "continue-please"):
+        text = f"""
+pipeline: o
+steps:
+  - parallel:
+      on_error: {bad}
+      branches:
+        a:
+          transform:
+            value: "1"
+      collect:
+        transform:
+          value: pipe
+"""
+        with pytest.raises(PipelineParseError):
+            parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_parallel_dsl_requires_branches():
+    """Tier 1: ``branches`` is REQUIRED and must be a non-empty mapping —
+    omitting it, or giving an empty mapping, is a parse error."""
+    text_missing = """
+pipeline: o
+steps:
+  - parallel:
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text_missing, SchemaRegistry())
+
+    text_empty = """
+pipeline: o
+steps:
+  - parallel:
+      branches: {}
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text_empty, SchemaRegistry())
+
+
+def test_parallel_dsl_requires_collect():
+    """Tier 1: ``collect`` is REQUIRED (it produces the primitive's N2 result
+    over the named map) — omitting it is a parse error."""
+    text = """
+pipeline: o
+steps:
+  - parallel:
+      branches:
+        a:
+          transform:
+            value: "1"
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_parallel_dsl_rejects_no_max_parallel_field():
+    """Tier 1: unlike ``for_each``, ``parallel`` has NO ``max_parallel`` field
+    at all (Appendix B's grammar gives it none — the branch set is
+    statically finite) — supplying one is an unknown-field parse error."""
+    text = """
+pipeline: o
+steps:
+  - parallel:
+      max_parallel: 2
+      branches:
+        a:
+          transform:
+            value: "1"
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_parallel_dsl_rejects_malformed_nested_branch():
+    """Tier 1: a ``branches:`` entry with a malformed body fails at parse
+    time, at the DSL text, through the SAME per-kind parser a top-level step
+    uses (not a bespoke "nested branch" validation path)."""
+    text = """
+pipeline: o
+steps:
+  - parallel:
+      branches:
+        bad:
+          call: {}
+      collect:
+        transform:
+          value: pipe
+"""
+    with pytest.raises(PipelineParseError):
+        parse_pipeline_dsl(text, SchemaRegistry())
+
+
+def test_parallel_analyzer_facet_flags_empty_branches_and_large_agent_fanout():
+    """Tier 1: the P4 analyzer facet for `parallel` is registered and flags
+    (a) an empty ``branches`` mapping and (b) a statically large agent-branch
+    fan-out (>3 agent-step branches) — but passes a small, non-empty,
+    non-agent-heavy fan-out."""
+    empty = ParallelStep(branches={}, collect=TransformStep(value="pipe"))
+    problems = analyze_step(empty)
+    assert any("branches" in p for p in problems)
+
+    heavy = ParallelStep(
+        branches={
+            "a": AgentStep(prompt="a", identity="w"),
+            "b": AgentStep(prompt="b", identity="w"),
+            "c": AgentStep(prompt="c", identity="w"),
+            "d": AgentStep(prompt="d", identity="w"),
+        },
+        collect=TransformStep(value="pipe"),
+    )
+    problems = analyze_step(heavy)
+    assert any("agent-step branches" in p for p in problems)
+
+    small = ParallelStep(
+        branches={"x": TransformStep(value="1"), "y": TransformStep(value="2")},
+        collect=TransformStep(value="pipe"),
+    )
+    assert analyze_step(small) == []


### PR DESCRIPTION
**[lead-sonnet]** — part of #2187

## Summary

Implements the `parallel` primitive — the LAST non-linear pipeline primitive (Appendix B `docs/proposals/reyn-pipeline-spec-v0.8.md:737-741`, Hard rule 6, N2):

```
parallel = {on_error?:abort|continue|retry(n), branches:{NAME:Step}+, collect:Step}
```

`parallel` is `for_each`'s **heterogeneous NAMED-branch** sibling. Where `for_each` fans one `do` step out over a runtime-sized list of items, `parallel` fans a **static, finite dict of distinct named branches** out concurrently, then runs `collect` **once** over the **named map** `{branch_name: result}` (not an ordered list) — the primitive's N2 output/pipe-data.

This lands as a direct, additive build on `for_each`'s (#2583) proven fan-out substrate — no new recovery mechanism was needed:

- **Concurrent recovery, reused exactly**: a single serializing coordinator + a NO-OP recorder inside each branch task (avoiding the read-modify-write race concurrent recording would cause), the `__fan_out_dropped__` kind-marker for `on_error:continue`, and the `fan_out_depth`/`SpawnBudget` S5 guards — all identical mechanism, keyed by **branch NAME** instead of item index (`f"{label}.parallel.{branch_name}"` / `f"{label}.parallel.collect"`).
- **Structural differences from `for_each`** (everything else is reuse):
  1. Source = a static dict of heterogeneous branches, not one `do` re-invoked per list item.
  2. `on_error` is **optional**, defaulting to `abort` when omitted (Appendix B's `on_error?:` — unlike `for_each` where it's required).
  3. No `max_parallel` field — the branch set is statically finite, so its own size is the concurrency bound (no Semaphore needed).
  4. `collect`'s input is a **named map**, not an ordered list (dropped branches filtered by the same shared `_is_dropped_marker` predicate, adapted to a dict).

## Registration (5 seams)

- `STEP_DISPATCH` — `_run_parallel_step` (`src/reyn/core/pipeline/executor.py`)
- serde `ENCODERS`/`DECODERS` (`src/reyn/core/pipeline/serde.py`) — branches + collect recurse through `step_to_dict`/`step_from_dict`
- parser `_STEP_PARSERS` special-dispatch (`src/reyn/core/pipeline/parser.py`) — `on_error` defaults to `"abort"` when omitted; no `max_parallel` key accepted (unknown-field parse error)
- `ANALYZER_FACETS` (`src/reyn/core/pipeline/analyzer.py`) — warns on empty `branches` and on a statically large (>3) agent-step branch fan-out
- `Step` union — `ParallelStep` added

`_UNSUPPORTED_STEP_KINDS` is now **empty** — every Appendix-B non-linear step kind (`call`/`match`/`fold`/`for_each`/`parallel`) is executable. `refine` (a pipeline-level construct, not a step kind) remains out of scope.

This is the **FINAL non-linear primitive** — `call`/`match`/`fold`/`for_each`/`parallel` all now land.

## Tests

- `tests/test_pipeline_parallel_primitive.py` (19 tests): happy path (named-map collect, isolated per-branch ctx, shared pipe-data), `on_error` continue/abort/retry(n), the **CLAUDE.md truncate-falsify recovery gate** (mid-parallel crash — done branches + 1 dropped, collect not yet recorded, WAL truncated below source events, resume replays exactly-once), the documented compositional-branch atomic-rerun gap (mirrors `for_each`'s known contract), S5 guards (fan_out_depth cap, SpawnBudget cap with a real `AgentRegistry`/`Session`).
- `tests/test_pipeline_parallel_serde_parser_analyzer.py` (10 tests): serde round-trip (non-default + default `on_error`), DSL parse (including `on_error` omitted → defaults to abort — a parser-level test of the required-vs-optional divergence from `for_each`), rejects no-`max_parallel`-field, analyzer facet.
- Updated two pre-existing tests whose docstrings/premise had gone stale now that `parallel` is supported (`test_pipeline_for_each_serde_parser_analyzer.py`, `test_pipeline_is3_dsl_parser.py`) — both still pass unmodified in behavior, only wording corrected to not claim `parallel` is "still unsupported".

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 52/52 OK, 0 Tier-4 violations
- [x] `pytest` (full suite, from repo root) — 7179 passed, 30 skipped; the 10 failed + 10 errored are pre-existing `mcp`/`web` reds unrelated to this change (confirmed present before this branch)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK