### PR TITLE
docs(pipeline): document the pipeline feature

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
               - guide/for-users/popular-mcp-servers.md
               - guide/for-users/oauth-login.md
               - guide/for-users/manage-memory.md
+              - guide/for-users/write-a-pipeline.md
       - For Reyn developers:
           - guide/for-reyn-developers/index.md
           - Concepts & principles:
@@ -139,6 +140,7 @@ nav:
           - reference/runtime/llm-output-contract.md
           - reference/runtime/control-ir.md
           - reference/runtime/events.md
+          - reference/runtime/pipeline-dsl.md
       - Config:
           - Core:
               - reference/config/reyn-yaml.md
@@ -180,6 +182,8 @@ nav:
           - concepts/runtime/delegation-policy.md
           - concepts/runtime/sandbox.md
           - concepts/runtime/secret-handling.md
+          - concepts/runtime/pipelines.md
+          - concepts/runtime/pipeline-registration.md
       - Multi-agent:
           - concepts/multi-agent/sessions.md
           - concepts/multi-agent/multi-agent.md

--- a/docs/concepts/runtime/pipelines.ja.md
+++ b/docs/concepts/runtime/pipelines.ja.md
@@ -1,0 +1,61 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [pipeline, pipeline DSL, control plane, execution plane, driver-as-session, PipelineExecutorDriver, crash recovery pipeline, run_pipeline, safety by structure, Turing-incomplete]
+---
+
+# Pipeline
+
+**pipeline** とは、小さな YAML DSL で書かれた決定的なマルチステップ制御フローです: `transform` / `tool` / `agent` ステップの固定シーケンスに、必要に応じて少数の構造的プリミティブ(`call` / `match` / `fold` / `for_each`)を組み合わせます。エージェントは他のツールと同じように名前 + input でパイプラインを起動し、パイプラインは(起動したエージェントがその後何をするかとは独立に)自身のクラッシュ耐性を持った実行の下で完了(または失敗)まで走ります。
+
+pipeline が存在する理由は、すべてのマルチステップタスクを毎回 LLM がターンごとに再導出すべきではないから、です。繰り返し発生する既知の手順 — N 人のレビュアーにレビューを fan out して結果をマージする、リストを走査して同じ transform を適用する、flaky なチェックを retry してから escalate する — は、エージェントが毎回ゼロから再計画するより、*書かれた*制御フローとして表現する方が信頼性が高く、安価で、監査しやすいものです。pipeline はその書かれた制御フローです: ステップとその合成は DSL の中で固定されており、実行時に変わるのはそこを流れる *データ* だけです。
+
+## Control plane と Execution plane
+
+Reyn には既に非決定的な execution plane が存在します: エージェントターン — LLM が利用可能なツールとコンテキストから次の行動を決める場所です。pipeline はそれと並ぶ**別個の、決定的な control plane** です:
+
+- **Execution plane**(エージェントターン)は判断が宿る場所です — LLM がコンテキストを読み、行動を選びます。その制御フローは事前に固定されておらず、モデルの決定から動的に生じます。
+- **Control plane**(pipeline)は既知の形を持つ手順が宿る場所です — そのステップと合成(sequence / branch / fan-out / accumulate)は DSL 内で固定されています。`agent` ステップは両者の継ぎ目です: pipeline のステップは一つの限定された判断を LLM に委譲できます(capability を narrowing された leaf worker として)が、pipeline 自体が自らの形を即興で変えることはありません。
+
+この分離こそが、pipeline を設計上 **Turing-incomplete** にしているものです: プリミティブは合成可能です(`call` は別の pipeline を呼び出せ、`fold` は per-item ステップとして `call` を実行できます)が、一般的な再帰も、動的なステップ生成も、実行中の pipeline が自身のステップリストを書き換えるプリミティブもありません。pipeline の完全なステップグラフはその DSL ドキュメントを読めば分かります — エージェントターンが未想定のツールを呼ぶことを決められるのとは異なり、pipeline は実行時に新しい制御フローを構築できません。
+
+## 構造による安全性(Safety by structure)
+
+制御フローが固定され閉じているため、いくつかの安全性の性質は、上に乗せた実行時ポリシーではなく DSL の形そのものから導かれます:
+
+- **ネストされた起動は不可。** pipeline の `tool` ステップは自分自身で別の pipeline を起動したり別のエージェントに delegate したりできません — ネストは `call` のみです。これにより、エージェントが pipeline を起動する際に許可する cost-bound の承認は、実行中のステップが拡張し得るオープンエンドなものではなく、*既知の*ステップグラフに対する推移閉包のままになります。
+- **capability の narrowing は実行時チェックではなく構造的です。** `agent` ステップの ephemeral session は*起動者自身の identity* の下で spawn され、restrict-only で narrowing されます — pipeline のステップは、構造上、それを起動したエージェントの capability envelope を超えることが決してできません。エージェントがその場で生成する ad-hoc な pipeline については([Invocation](pipeline-registration.md) 参照)、別のエージェントの identity を指定するステップは capability escalation となるため、何かが spawn される前に静的ゲートがそれを拒否します。
+- **fan-out は「省略時に無制限」ではなく、境界を持ちます。** `for_each` の並行分岐は operator が設定した spawn budget で上限が課されます([Pipeline DSL リファレンス § Safety caps](../../reference/runtime/pipeline-dsl.md) 参照)。これは実行中どこで到達しても — トップレベルでも fan-out 経由でも — `agent` ステップごとに課金されます。これらのステップは通常の spawn-lineage の記帳の外側で ephemeral session を spawn するためです。
+
+## Driver-as-session
+
+pipeline は起動元エージェント自身のターン上でインラインには実行されません。`run_pipeline` / `run_pipeline_async` / `run_pipeline_inline` / `run_pipeline_inline_async` のいずれで起動しても、`PipelineExecutorDriver` を実行する専用セッションが spawn され、pipeline は*その*セッションの中で実行されます。
+
+これは、専用の実行パスではなく通常のセッション基盤を意図的に再利用したものです: driver-session の run-loop、inbox、WAL journaling、crash-restore の仕組みは、チャットセッションが使うものとまったく同じです — driver は単に「ターン」を LLM に通すユーザー発話としてではなく、run/resume の nudge として解釈するだけです。実務上の利点は、pipeline の crash-recovery が、他のあらゆるセッションにとってもともと正しくなければならないインフラの上に乗ることであり、そこからズレうる第二の recovery パスにはならないことです。
+
+エージェントが起動した pipeline の run と関わる方法は二通りあります:
+
+- **Sync / attached**(`run_pipeline`、`run_pipeline_inline`): 呼び出し元が driver-session の run に attach し、terminal 状態に達するのを in-band で待ちます — その間ライブなステップ進捗イベントが呼び出し元にストリームされ(TUI のライブビューが描画するもの)、協調的な Ctrl-C は run を途中で kill するのではなく、次のステップ境界でクリーンに停止させます。attach 中にプロセスがクラッシュしても run 自体は失われません — recovery が resume し、結果は代わりに後で inbox メッセージとして届きます。
+- **Async / detached**(`run_pipeline_async`、`run_pipeline_inline_async`): 呼び出し元は即座に `{status: started, run_id}` を受け取り、結果は run が terminal 状態に達した時点で後から inbox メッセージとして届きます。
+
+## Crash recovery
+
+Crash-recovery は、同じ手順を毎回エージェントに再計画させるのに対する pipeline 機能の差別化要因です: pipeline の run は、既に副作用を起こしたステップを再実行することなく、中断した箇所からちょうど resume できます。
+
+これを実現する部品は二つです:
+
+- **run 単位の work order**(`invocation.json` として永続化)。最初のステップが走る*前に*書き込まれます。何もない状態から run を再構成するのに必要なもの一式を運びます — pipeline 定義そのもの(そのため resume は ad-hoc な inline pipeline であっても外部レジストリを一切必要としません)、seed input、reply address、`verify: schema` ステップが検証対象とするスキーマ、などです。
+- **ステップ境界での generation スナップショット**、各ステップ完了後に記録されます: run の pipe data、named store、そして既に完了したステップの集合です。resume は最新のスナップショットを読み、既に完了として記録されているすべてのステップをリプレイします — `call` / `match` / `fold` / `for_each` の内部進捗も含みます(それぞれ自身のサブステップをネストしたキーの下に記録します)。そのため合成の途中でのクラッシュが、既に着地した副作用を再発火させることはありません。したがって recovery は **exactly-once execution** です: ステップの副作用は、run が何度 resume されても一度だけ発火します。対照的に、*最終結果*の reply address への配送は **at-least-once** です — 最後のステップの完了と結果の post の間でクラッシュすると、次の recovery パスで再配送されます。呼び出し元が結果を静かに失うことは決してない代わりに、重複配送を許容する必要があります。
+
+pipeline 定義がどのようにしてセッションに届くかは [Pipeline registration](pipeline-registration.md) を、規範的なステップ / プリミティブ文法と 4 つの起動ツールは [Pipeline DSL リファレンス](../../reference/runtime/pipeline-dsl.md) を参照してください。
+
+## 現時点でスコープ外のもの
+
+ディスク上の `pipelines/` の変更を実行中セッションの pipeline レジストリにホットリロードする機能は、まだ構築されていません。実行中または完了した pipeline run の rewind/fork セマンティクスは、上述の crash-recovery の exactly-once 保証とは別の、先送りされた関心事です。
+
+## 関連ドキュメント
+
+- [Pipeline registration](pipeline-registration.md) — pipeline 定義がどのようにディスクから読み込まれ、起動可能になるか。
+- [Pipeline DSL リファレンス](../../reference/runtime/pipeline-dsl.md) — 規範的なステップ / プリミティブ文法、expression 言語、起動ツール。
+- [Capability profiles](capability-profile.md) — pipeline 起動を制限する capability floor。

--- a/docs/concepts/runtime/pipelines.md
+++ b/docs/concepts/runtime/pipelines.md
@@ -1,0 +1,153 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [pipeline, pipeline DSL, control plane, execution plane, driver-as-session, PipelineExecutorDriver, crash recovery pipeline, run_pipeline, safety by structure, Turing-incomplete]
+---
+
+# Pipelines
+
+A **pipeline** is a deterministic, multi-step control flow written in a small
+YAML DSL: a fixed sequence of `transform` / `tool` / `agent` steps, optionally
+composed with a handful of structural primitives (`call`, `match`, `fold`,
+`for_each`). An agent launches a pipeline the same way it calls any other
+tool — by name, with an input — and the pipeline runs to completion (or
+failure) under its own crash-recoverable execution, independent of whatever
+else the launching agent does next.
+
+Pipelines exist because not every multi-step task should be re-derived by an
+LLM turn by turn. A recurring, well-understood procedure — fan out a review
+across N reviewers and merge their verdicts, walk a list applying the same
+transform, retry-then-escalate a flaky check — is more reliable, cheaper, and
+auditable as a *written* control flow than as an agent re-planning it from
+scratch every time. A pipeline is that written control flow: the steps and
+their composition are fixed in the DSL; only the *data* flowing through them
+varies at run time.
+
+## Control plane vs execution plane
+
+Reyn already has a non-deterministic execution plane: an agent turn, where an
+LLM decides what to do next from the tools and context available to it. A
+pipeline is a **separate, deterministic control plane** layered alongside it:
+
+- The **execution plane** (an agent turn) is where judgment lives — an LLM
+  reads context and picks an action. Its control flow is not fixed in
+  advance; it emerges from the model's decisions.
+- The **control plane** (a pipeline) is where a known-shape procedure lives —
+  its steps and their composition (sequence, branch, fan-out, accumulate) are
+  fixed in the DSL. An `agent` step is the seam between the two: a pipeline
+  step can delegate one bounded piece of judgment to an LLM (a capability-
+  narrowed leaf worker), but the pipeline itself never improvises its own
+  shape.
+
+This separation is what makes a pipeline **Turing-incomplete by design**: the
+primitives compose (a `call` can invoke another pipeline, a `fold` can run a
+`call` as its per-item step) but there is no general recursion, no dynamic
+step generation, and no primitive that lets a running pipeline rewrite its
+own step list. A pipeline's full step graph is knowable by reading its DSL
+document — it cannot construct new control flow at run time the way an agent
+turn can decide to call an unanticipated tool.
+
+## Safety by structure
+
+Because the control flow is fixed and closed, several safety properties fall
+out of the DSL's shape rather than needing a runtime policy layered on top:
+
+- **No nested launch.** A pipeline `tool` step cannot itself launch another
+  pipeline or delegate to another agent — nesting is `call`-only. This keeps
+  the cost-bound approval an agent grants when it launches a pipeline a
+  transitive closure over a *known* step graph, not an open-ended one a
+  running step could extend.
+- **Capability narrowing is structural, not a runtime check.** An `agent`
+  step's ephemeral session is spawned under the *invoker's own identity* and
+  narrowed restrict-only — a pipeline step can never exceed the capability
+  envelope of the agent that launched it, by construction. For an ad-hoc
+  pipeline an agent generates on the fly (see
+  [Invocation](pipeline-registration.md)), a step naming a different agent's
+  identity would be a capability escalation, so a static gate rejects that
+  before anything spawns.
+- **Fan-out is bounded, not unbounded-by-omission.** `for_each`'s concurrent
+  branches are capped by an operator-set spawn budget (see
+  [Pipeline DSL reference § Safety caps](../../reference/runtime/pipeline-dsl.md)),
+  charged for every `agent` step reached anywhere in the run — top-level or
+  fanned out — since those steps spawn ephemeral sessions outside the normal
+  spawn-lineage bookkeeping.
+
+## Driver-as-session
+
+A pipeline does not run inline on the launching agent's own turn. Launching
+one — via any of `run_pipeline`, `run_pipeline_async`, `run_pipeline_inline`,
+or `run_pipeline_inline_async` — spawns a dedicated session running a
+`PipelineExecutorDriver`, and the pipeline executes inside *that* session.
+
+This is a deliberate reuse of the ordinary session substrate rather than a
+bespoke execution path: the driver-session's run-loop, inbox, WAL journaling,
+and crash-restore machinery are the exact same ones a chat session uses — the
+driver just interprets a "turn" as a run/resume nudge instead of a user
+utterance to route through an LLM. The practical payoff is that pipeline
+crash-recovery rides infrastructure that already has to be correct for every
+other session, rather than a second recovery path that could drift out of
+sync with it.
+
+Two ways an agent can relate to a launched pipeline's run:
+
+- **Sync / attached** (`run_pipeline`, `run_pipeline_inline`): the caller
+  attaches to the driver-session's run and waits for it to reach a terminal
+  state in-band — live step-progress events stream to the caller for the
+  duration (what a TUI live view renders), and a cooperative Ctrl-C stops the
+  run cleanly at the next step boundary rather than killing it mid-step. If
+  the process crashes while attached, the run itself is not lost — recovery
+  resumes it, and the result is delivered later as an inbox message instead.
+- **Async / detached** (`run_pipeline_async`, `run_pipeline_inline_async`):
+  the caller gets `{status: started, run_id}` immediately and the result
+  arrives later as an inbox message, whenever the run reaches a terminal
+  state.
+
+## Crash recovery
+
+Crash-recovery is the pipeline feature's differentiator relative to just
+having an agent re-plan the same procedure every time: a pipeline run is
+resumable exactly where it left off, without re-running steps that already
+had a side effect.
+
+Two pieces make this work:
+
+- **A per-run work order**, persisted (as `invocation.json`) *before* the
+  first step runs. It carries everything needed to reconstruct the run from
+  nothing — the pipeline definition itself (so a resume needs no external
+  registry, even for an ad-hoc inline pipeline), the seed input, the reply
+  address, and any schemas its `verify: schema` steps validate against.
+- **Step-boundary generation snapshots**, recorded after every step
+  completes: the run's pipe data, named stores, and the set of steps already
+  completed. A resume reads the latest snapshot and replays every step
+  already recorded as complete — including partial progress inside a `call`,
+  `match`, `fold`, or `for_each` (each records its own sub-steps under a
+  nested key), so a crash mid-composition does not re-fire an already-landed
+  side effect. Recovery is thus **exactly-once execution**: a step's side
+  effect fires once, no matter how many times the run is resumed. Delivery of
+  the *final result* to the reply address, by contrast, is **at-least-once**
+  — a crash between the last step finishing and the result being posted
+  re-delivers on the next recovery pass, so the caller never silently loses a
+  result, at the cost of a caller needing to tolerate a duplicate delivery.
+
+See [Pipeline registration](pipeline-registration.md) for how a pipeline
+definition reaches a session in the first place, and the
+[Pipeline DSL reference](../../reference/runtime/pipeline-dsl.md) for the
+normative step/primitive grammar and the four invocation tools.
+
+## What's out of scope today
+
+Hot-reloading a running session's pipeline registry when `pipelines/` changes
+on disk is not yet built. Rewind/fork semantics for an in-flight or completed
+pipeline run are a deferred, separate concern from the crash-recovery
+exactly-once guarantee described above.
+
+## See also
+
+- [Pipeline registration](pipeline-registration.md) — how a pipeline
+  definition is loaded from disk and made launchable.
+- [Pipeline DSL reference](../../reference/runtime/pipeline-dsl.md) — the
+  normative step/primitive grammar, the expression language, and the
+  invocation tools.
+- [Capability profiles](capability-profile.md) — the capability floor a
+  pipeline launch is gated by.

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -151,6 +151,13 @@ mindmap
       Session visibility toggle
       install_local
       install_source
+    🔗 Pipeline
+      Step kinds
+      Primitives
+      Invocation tools
+      Driver-as-session
+      Crash recovery
+      Registration
     🌐 Web and Protocol
       FastAPI gateway
       WebSocket chat
@@ -539,6 +546,26 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | `skill_management__install_source` | Fetch + shallow-clone a skill from a git/GitHub URL into `.reyn/skills/<name>/`; same threat-scan/gate/recovery pipeline, plus path-traversal-hardened name sanitization and containment checks | [Concepts: Skills](concepts/tools-integrations/skills.md) |
 
 > **Differentiation vs general agents:** skills are instructions the model chooses to read, not programs the OS executes — the same layered-disclosure shape (menu → on-demand load) as MCP tool discovery, applied to task-specific technique instead of external APIs.
+
+---
+
+### Pipeline
+
+| Feature | Description | Documentation |
+|---------|-------------|---------------|
+| Step kinds | `transform` (pure R1 expression), `tool` (+ `shell` sugar; `!expr` YAML tag marks an expression arg vs a literal), `agent` (LLM leaf-worker, capability-narrowed to ⊆ the invoker) | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| Compositional primitives | `call` (sub-pipeline), `match` (runtime-value-selected sub-pipeline), `fold` (sequential accumulator), `for_each` (concurrent fan-out over a list + collect, S5-bounded), `parallel` (concurrent heterogeneous named branches + collect) — the full Appendix-B primitive set | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| R1 expression language | Field refs, comparisons, `map`/`filter`/`all`/`any`/`count`/`join`, lambdas in combinator slots — the total expression language `transform.value` / `tool.args` (`!expr`) / `match.on` resolve against | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| Nested schemas + `verify: schema` | `SchemaRegistry`-backed schema documents a `tool`/`agent` step's result is validated against | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| Registration from disk | Drop `pipelines/*.yaml` (Appendix-B DSL) into a scanned directory (default `pipelines/`, configurable via `reyn.yaml`'s `pipelines.scan_dirs`); auto-loaded + registered at session start; surfaces as `pipeline__<name>`. Declared `pipeline:` name is authoritative, not the file name. Fail-loud: malformed DSL or a name collision fails session start | [Concepts: Pipeline registration](concepts/runtime/pipeline-registration.md) |
+| `run_pipeline` / `run_pipeline_async` | Launch a registered pipeline by name — sync-attached (live step-progress events, Ctrl-C cancel) or detached (result delivered later as an inbox message) | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| `run_pipeline_inline` / `run_pipeline_inline_async` | Launch an ad-hoc, agent-generated DSL string — parsed and passed through a static-analysis gate (schema refs resolve, tool names resolve, no nested pipeline/delegate launch, agent steps run only under the invoker's own identity) before anything spawns | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| Driver-as-session architecture | A pipeline run executes inside a spawned `PipelineExecutorDriver` session — reuses the ordinary session's run-loop, inbox, and WAL/crash-restore substrate rather than a bespoke execution path | [Concepts: Pipelines](concepts/runtime/pipelines.md) |
+| Crash recovery | Per-run work-order (`invocation.json`) persisted before step 0; step-boundary generation snapshots give exactly-once, truncation-surviving resume (including mid-`call`/`fold`/`for_each` state) | [Concepts: Pipelines](concepts/runtime/pipelines.md) |
+| S5 spawn bounds | `safety.spawn.max_pipeline_fan_out_depth` (`for_each` nesting depth, default 5) and `safety.spawn.max_pipeline_spawns` (ephemeral sessions per run, default 100) — both `0` = unlimited (operator opt-out) | [Reference: Pipeline DSL](reference/runtime/pipeline-dsl.md) |
+| Security floor | Launching a pipeline (any of the 4 tools) sits on the same `HIGH`-severity spawn-adjacent floor as `delegate_to_agent` — an `_untrusted`- or `_delegate`-narrowed context cannot launch one, registered or inline | [Concepts: Pipeline registration § Security](concepts/runtime/pipeline-registration.md) |
+
+> **Differentiation vs general agents:** a pipeline is a deterministic, Turing-incomplete control-plane DSL, not another agent loop — the composition primitives are structurally closed (no nested launch, no arbitrary recursion), so safety and crash-recovery come from the DSL's shape rather than runtime policy layered on top of an unbounded execution graph.
 
 ---
 

--- a/docs/guide/for-users/write-a-pipeline.ja.md
+++ b/docs/guide/for-users/write-a-pipeline.ja.md
@@ -1,0 +1,113 @@
+# pipeline を書いて実行する
+
+pipeline は、決定的なマルチステップ制御フローを記述する小さな YAML ファイルです。本ガイドでは、pipeline を書き、プロジェクトに配置し、起動するまでを扱います — さらに、エージェントがその場で生成する一回限りの手順向けに、登録不要な ad-hoc の代替手段も扱います。完全な文法と起動ツールのリファレンスは [Pipeline DSL リファレンス](../../reference/runtime/pipeline-dsl.ja.md) を、why / アーキテクチャは [Pipeline](../../concepts/runtime/pipelines.ja.md) を参照してください。
+
+## 1. pipeline を書く
+
+プロジェクトルートに `pipelines/` ディレクトリ(デフォルトのスキャン対象ディレクトリ)を作成し、`*.yaml` ファイルを配置します。以下は `name` を受け取り、挨拶し、その結果を叫ぶ pipeline です:
+
+```yaml
+# pipelines/greet.yaml
+pipeline: greet
+description: Greet a name and shout it.
+steps:
+  - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+  - tool: {name: shell, args: {command: !expr "'echo ' + greeting"}, output: shouted}
+```
+
+このファイルについて注目すべき点がいくつかあります:
+
+- pipeline は `pipeline:` キーの名前(`greet`)の下に登録されます。ファイル名ではありません — `pipelines/greet.yaml` は何にリネームしても `greet` として登録され続けます。
+- 各ステップは、自身の種別(`transform`、`tool`、`agent`、または合成プリミティブ(Pipeline DSL リファレンス参照)のいずれか)を名前とする単一キーのマッピングです。
+- `ctx.name` はこの pipeline が期待する seed input です。`greeting` は最初のステップの `output` で書き込まれた後、後続のステップで `ctx.greeting` として利用可能になります — ここでは 2 番目のステップのコンテキストがそれを named store として公開しているため、`!expr` 文字列連結の中で bare な `greeting` として参照しています。
+- `!expr` は `command` をリテラル文字列ではなく評価すべき expression としてマークします — [リテラル vs `!expr`](../../reference/runtime/pipeline-dsl.ja.md#vs-expr) 参照。
+
+## 2. セッションを開始(または再起動)する
+
+pipeline はセッション開始時にディスクから登録されます — 別途「インストール」ステップは無く、デフォルトの `pipelines/` ディレクトリには `reyn.yaml` へのエントリも不要です。セッションを再起動する(または新しく開始する)と `greet` が登録されます。
+
+ファイルの parse に失敗した場合、または 2 つのファイルが同じ `pipeline:` 名を宣言した場合、セッション開始は問題のファイルを名指しして大きく失敗します — タイプミスが、出荷するつもりだった pipeline を静かに消すことはありません。詳細な表は [Pipeline registration § Failure behavior](../../concepts/runtime/pipeline-registration.md#failure-behavior-fail-loud) を参照してください。
+
+## 3. 起動する
+
+エージェントは通常のツール呼び出しで `greet` を起動できます:
+
+```
+run_pipeline(name="greet", input={name: "Reyn"})
+```
+
+または、登録済みのすべての pipeline についてアクションカタログが提示する qualified なカタログ verb で:
+
+```
+pipeline__greet({name: "Reyn"})
+```
+
+どちらも pipeline が完了するまで block し、最終出力(ここでは叫ばれた挨拶)を返します。run の間、ライブなステップ進捗が TUI で見え、Ctrl-C は途中で kill するのではなく次のステップ境界でクリーンに停止させます。
+
+### 同期 vs 非同期
+
+手順が長時間実行され、それを待って block したくない場合は、非同期形式を使います:
+
+```
+run_pipeline_async(name="greet", input={name: "Reyn"})
+```
+
+これは即座に `{status: "started", run_id: "..."}` を返します。結果は後で会話の中に `[pipeline]` メッセージとして届きます。結果をインラインで受け取りたく、待つのが問題なければ `run_pipeline` を、fire-and-forget な起動には `run_pipeline_async` を使ってください。どちらも同等に crash-recoverable です — run の途中でのプロセス再起動は、完了済みステップを再実行するのではなく、中断した箇所からちょうど resume します([Pipeline § Crash recovery](../../concepts/runtime/pipelines.ja.md#crash-recovery)参照)。
+
+## 4. Ad-hoc な、登録不要の代替手段
+
+手順が一回限りのこともあります — crash-recovery と構造的な安全性のために pipeline として書く価値はあるが、ファイルとして登録する価値は無い場合です。`run_pipeline_inline`(とその非同期版 `run_pipeline_inline_async`)は `pipeline:` ドキュメントと同じ DSL を受け取りますが、呼び出し時にエージェントが生成する文字列としてです:
+
+```
+run_pipeline_inline(
+  definition="""
+    pipeline: adhoc_greet
+    steps:
+      - transform: {value: "'Hi, ' + ctx.name", output: greeting}
+  """,
+  input={name: "Reyn"},
+)
+```
+
+定義は parse され、静的解析ゲートを通されます — schema 参照が解決すること、ツール名が解決すること、どのステップも別の pipeline を起動したり delegate したりしないこと、`agent` ステップが起動者自身の identity の下でのみ実行されること — **何かが spawn される前に**。不正な定義は明確に失敗し何も spawn しません。良い定義は、登録済み pipeline と全く同様に crash-recoverable です。その完全な定義が run 自身の recovery 状態と共に移動するためです。完全なゲートのチェックリストは [Ad-hoc inline 起動](../../reference/runtime/pipeline-dsl.ja.md#ad-hoc-inline) を参照してください。
+
+## 実践例: fan out してから merge する
+
+`for_each` と `match` を使った、もう少し大きな例です — 複数のレビュアーで文書を並行レビューし、全員が合意したかどうかで分岐します:
+
+```yaml
+# pipelines/review.yaml
+pipeline: review
+description: Fan a document out to reviewers, then branch on the verdict.
+steps:
+  - for_each:
+      over: ctx.reviewers
+      max_parallel: 4
+      on_error: "retry(1)"
+      do:
+        agent:
+          prompt: "Review this document as {item}: {ctx.doc}. Reply with passed (bool) and notes (string)."
+          schema: Review
+      collect: {transform: {value: "pipe"}}
+      output: reviews
+  - transform: {value: "all(reviews, r -> r.passed)", output: all_passed}
+  - match:
+      on: all_passed
+      cases:
+        "True": {pipeline: report_pass, pass: [reviews]}
+        "False": {pipeline: report_fail, pass: [reviews]}
+      output: report
+---
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+```
+
+レビュアーの identity のリストと文書を渡して起動します:
+
+```
+run_pipeline(name="review", input={reviewers: ["reviewer_a", "reviewer_b"], doc: "..."})
+```
+
+各レビュアーは隔離された並行 `agent` ステップとして実行され(最大 4 並行、失敗時は 1 回リトライ)、全員の結果が揃うと、R1 の `all()` コンビネータで `all_passed` という 1 つの boolean に畳み込まれ、`match` がそれに応じて `report_pass` または `report_fail` の sub-pipeline にルーティングします(どちらも別途登録が必要です。単一ファイルで完結させたい場合は、素の `transform`/`tool` ステップに置き換えてください)。

--- a/docs/guide/for-users/write-a-pipeline.md
+++ b/docs/guide/for-users/write-a-pipeline.md
@@ -1,0 +1,163 @@
+# Write and run a pipeline
+
+A pipeline is a small YAML file describing a deterministic, multi-step
+control flow. This guide walks through writing one, dropping it into your
+project, and invoking it — plus the ad-hoc, no-registration alternative for a
+one-off procedure an agent generates on the fly. For the full grammar and
+invocation-tool reference, see the [Pipeline DSL reference](../../reference/runtime/pipeline-dsl.md);
+for the why/architecture, see [Pipelines](../../concepts/runtime/pipelines.md).
+
+## 1. Write the pipeline
+
+Create a `pipelines/` directory at your project root (the default scan
+directory) and drop in a `*.yaml` file. This one takes a `name`, greets it,
+and shouts the result:
+
+```yaml
+# pipelines/greet.yaml
+pipeline: greet
+description: Greet a name and shout it.
+steps:
+  - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+  - tool: {name: shell, args: {command: !expr "'echo ' + greeting"}, output: shouted}
+```
+
+A few things worth noting about this file:
+
+- The pipeline registers under the name in its `pipeline:` key (`greet`), not
+  the file name — `pipelines/greet.yaml` could be renamed to anything and
+  still register as `greet`.
+- Each step is a single-key mapping naming its kind (`transform`, `tool`,
+  `agent`, or one of the [compositional primitives](../../reference/runtime/pipeline-dsl.md#compositional-primitives)).
+- `ctx.name` is the seed input this pipeline expects; `greeting`, once
+  written by the first step's `output`, becomes available as `ctx.greeting`
+  in later steps — here referenced bare as `greeting` inside the `!expr`
+  string-concat, since the second step's context still exposes it as a named
+  store.
+- `!expr` marks `command` as an expression to evaluate, not a literal string
+  — see [Literals vs `!expr`](../../reference/runtime/pipeline-dsl.md#literals-vs-expr).
+
+## 2. Start (or restart) the session
+
+Pipelines are registered from disk at session start — there's no separate
+"install" step and no `reyn.yaml` entry required for the default `pipelines/`
+directory. Restart your session (or start a fresh one) and `greet` is
+registered.
+
+If a file fails to parse, or two files declare the same `pipeline:` name,
+session start fails loudly, naming the offending file — a typo never
+silently drops a pipeline you meant to ship. See
+[Pipeline registration § Failure behavior](../../concepts/runtime/pipeline-registration.md#failure-behavior-fail-loud)
+for the full table.
+
+## 3. Invoke it
+
+An agent can launch `greet` either through the plain tool call:
+
+```
+run_pipeline(name="greet", input={name: "Reyn"})
+```
+
+or the qualified catalog verb the action catalog surfaces for every
+registered pipeline:
+
+```
+pipeline__greet({name: "Reyn"})
+```
+
+Both block until the pipeline finishes and return its final output — here,
+the shouted greeting. Live step-progress is visible in the TUI for the
+duration of the run, and Ctrl-C stops it cleanly at the next step boundary
+rather than killing it mid-step.
+
+### Sync vs async
+
+If the procedure is long-running and you don't want to block on it, use the
+async form instead:
+
+```
+run_pipeline_async(name="greet", input={name: "Reyn"})
+```
+
+This returns `{status: "started", run_id: "..."}` immediately; the result
+arrives later as a `[pipeline]` message in your conversation. Use `run_pipeline`
+when you want the result inline and are fine waiting; use `run_pipeline_async`
+for a fire-and-forget launch. Both are equally crash-recoverable — a process
+restart mid-run resumes exactly where it left off rather than re-running
+completed steps (see [Pipelines § Crash recovery](../../concepts/runtime/pipelines.md#crash-recovery)).
+
+## 4. Ad-hoc, no-registration alternative
+
+Sometimes a procedure is one-off — worth writing as a pipeline for its
+crash-recovery and structural safety properties, but not worth registering as
+a file. `run_pipeline_inline` (and its async counterpart
+`run_pipeline_inline_async`) take the same DSL as a `pipeline:` document, but
+as a string an agent generates at call time:
+
+```
+run_pipeline_inline(
+  definition="""
+    pipeline: adhoc_greet
+    steps:
+      - transform: {value: "'Hi, ' + ctx.name", output: greeting}
+  """,
+  input={name: "Reyn"},
+)
+```
+
+The definition is parsed and run through a static-analysis gate — schema
+references resolve, tool names resolve, no step launches another pipeline or
+delegates, and any `agent` step runs only under the invoker's own identity —
+**before** anything is spawned. A bad definition fails clearly and spawns
+nothing; a good one is exactly as crash-recoverable as a registered pipeline,
+since its full definition travels with the run's own recovery state. See
+[Ad-hoc inline launch](../../reference/runtime/pipeline-dsl.md#ad-hoc-inline-launch)
+for the complete gate checklist.
+
+## A worked end-to-end example: fan out then merge
+
+A slightly larger example putting `for_each` and `match` to use — review a
+document with several reviewers in parallel, then branch on whether they all
+agreed:
+
+```yaml
+# pipelines/review.yaml
+pipeline: review
+description: Fan a document out to reviewers, then branch on the verdict.
+steps:
+  - for_each:
+      over: ctx.reviewers
+      max_parallel: 4
+      on_error: "retry(1)"
+      do:
+        agent:
+          prompt: "Review this document as {item}: {ctx.doc}. Reply with passed (bool) and notes (string)."
+          schema: Review
+      collect: {transform: {value: "pipe"}}
+      output: reviews
+  - transform: {value: "all(reviews, r -> r.passed)", output: all_passed}
+  - match:
+      on: all_passed
+      cases:
+        "True": {pipeline: report_pass, pass: [reviews]}
+        "False": {pipeline: report_fail, pass: [reviews]}
+      output: report
+---
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+```
+
+Launch it with a list of reviewer identities and a document:
+
+```
+run_pipeline(name="review", input={reviewers: ["reviewer_a", "reviewer_b"], doc: "..."})
+```
+
+Each reviewer runs as an isolated, concurrent `agent` step (up to 4 at once,
+each retried once on failure); once all have landed, `all_passed` folds them
+into one boolean via the R1 `all()` combinator, and `match` routes to a
+`report_pass` or `report_fail` sub-pipeline accordingly (both would need to
+be registered separately, or replaced with plain `transform`/`tool` steps for
+a self-contained single-file version).

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -1,0 +1,330 @@
+---
+type: reference
+topic: runtime
+audience: [human, agent]
+search_hints: [pipeline DSL, pipeline grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+---
+
+# Pipeline DSL リファレンス
+
+pipeline 定義の規範的な文法 — ステップ種別、合成プリミティブ、それらが評価される expression 言語、schema / `verify: schema` の仕組み、そして pipeline を起動する 4 つのツール。why / アーキテクチャは [Pipeline](../../concepts/runtime/pipelines.ja.md) を、定義がセッションにどう届くかは [Pipeline registration](../../concepts/runtime/pipeline-registration.md) を参照してください。
+
+## ドキュメントの形
+
+pipeline 定義は `---` で区切られた 1 つ以上の YAML ドキュメントです:
+
+- `pipeline:` ドキュメントちょうど 1 つ — pipeline 本体。
+- `schema:` ドキュメント 0 個以上 — pipeline のステップが `verify: schema` で参照できる、名前付き schema([Schema](#schema-verify-schema) 参照)。
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+---
+pipeline: review_and_report
+description: Review a document and summarize the verdict.
+steps:
+  - agent: {prompt: "Review {ctx.doc}. Reply with passed/notes.", schema: Review, output: review}
+  - transform: {value: "review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
+```
+
+### `pipeline:` ドキュメントのキー
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `pipeline` | 必須 | 宣言された名前。登録時、および `call`/`match` ステップのターゲットにとって authoritative — [Pipeline registration § 宣言された名前が authoritative](../../concepts/runtime/pipeline-registration.md#the-declared-name-is-authoritative) 参照。 |
+| `description` | 任意 | 人間可読な要約。登録済み pipeline が `pipeline__<name>` カタログアクションとして列挙される際、名前と併せて LLM に提示される。デフォルトは空。 |
+| `steps` | 必須 | 順に実行される、空でないステップのリスト(下記の「ステップ種別」と「合成プリミティブ」参照)。 |
+
+`input` / `defaults` / `refine` は pipeline 設計のより完全な文法の一部ですが、まだランタイムがありません — これらを使ったドキュメントは、静かに無視されるのではなく、明示的な「まだサポートされていない」エラーで parse に失敗します。
+
+## ステップ種別
+
+すべてのステップは、自身の種別を名前とする単一キーのマッピングです。3 つは**線形な leaf ステップ**です — コンテキストを読み、ひとつの作業を行い、結果を生成します:
+
+### `transform`
+
+純粋なステップです: `value` は現在のコンテキストに対して [R1 expression](#r1-expression) として評価され、その結果がこのステップの pipe data になります(`output` が設定されていれば、その named store にも書き込まれます)。
+
+```yaml
+- transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `value` | 必須 | R1 expression のソース。 |
+| `output` | 任意 | 結果を書き込む named store。 |
+
+### `tool`(+ `shell` シュガー)
+
+副作用を伴うステップです: `name` を `args` と共に、ライブな `invoke_action` 呼び出しと同じ「qualified action ルーティング → bare lookup」の順で dispatch します — そのため `tool` ステップは qualified action(`file__read`)にも bare な登録済みツール名(`web_search`)にも名前を付けられます。
+
+```yaml
+- tool: {name: web_search, args: {query: !expr ctx.brief, limit: 5}, output: results}
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `name` | 必須 | ツール / アクション名(リテラル文字列)。 |
+| `args` | 任意 | 引数名 → 値 のマッピング。各値は `!expr` タグが付いていない限り**リテラル**([リテラル vs `!expr`](#vs-expr)参照)。 |
+| `schema` | 任意 | 結果が適合すべき登録済み schema 名(`verify: schema` — [Schema](#schema-verify-schema)参照)。不適合はステップを失敗させる。 |
+| `output` | 任意 | 結果を書き込む named store。 |
+
+`shell` は `"shell"` という名前の `tool` ステップのシュガーです:
+
+```yaml
+- shell: {command: !expr "'ls ' + ctx.dir", output: listing}
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `command` | 必須 | リテラルまたは `!expr`。`tool` ステップの `args` の値と同じルール。 |
+| `schema` | 任意 | `tool` と同じ。 |
+| `output` | 任意 | `tool` と同じ。 |
+
+#### リテラル vs `!expr`
+
+`tool`/`shell` の引数値は — YAML タグ `!expr` が付いていない限り — **リテラル**です。書かれた通りそのままツールに渡されます:
+
+```yaml
+args: {query: !expr ctx.brief, limit: !expr "ctx.n + 1", label: "a plain string"}
+```
+
+`query` と `limit` は R1 expression のソースで、実行時にステップのコンテキストに対して解決されます。`label` はリテラル文字列 `"a plain string"` です。`!expr` は引数の**値全体**としてのみ有効です — ネストしたリスト / マッピングの中に隠れていると parse エラーになるため、「たまたま expression に見えるリテラル」と「expression」の間に曖昧さはありません。
+
+`transform.value` は常に R1 expression です(`transform` ステップにリテラル形式は無いため `!expr` タグは不要)。`agent` ステップの `prompt` は決して R1 expression ではありません — 下記参照。
+
+### `agent`
+
+LLM 駆動の leaf ステップです: `prompt`(テンプレート文字列)が現在のコンテキストに対して補間され、`identity`(省略時は起動者自身)の下で `capabilities`(省略時は起動者自身のプロファイル)に capability を narrowing された ephemeral session の中で 1 ターンとして実行されます。
+
+```yaml
+- agent: {prompt: "Summarize: {ctx.doc}", capabilities: {tools: [file__read]}, schema: Summary, output: summary}
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `prompt` | 必須 | テンプレート文字列 — `{ctx.dotted.path}` / `{pipe}` 参照が補間される(値のみ、演算子なし — これは R1 expression ではなく文字列補間)。 |
+| `identity` | 任意 | 実行するエージェント identity。デフォルトは run の起動者。**登録済み** pipeline は任意の identity を指定できるが、**inline で エージェントが生成した** pipeline は起動者自身の identity のみ指定可能 — 別のエージェントの identity を指定すると capability escalation として静的解析ゲートに拒否される([Ad-hoc inline 起動](#ad-hoc-inline)参照)。 |
+| `capabilities` | 任意 | `{tools: [NAME*]}` — ephemeral session のツール surface を narrowing する。restrict-only: pipeline のステップが起動者自身の envelope を超えることは決してない。 |
+| `schema` | 任意 | `tool` と同じ `verify: schema` セマンティクスを、parse された JSON 応答に適用。 |
+| `output` | 任意 | 結果を書き込む named store。 |
+
+どこで到達しても(トップレベルでも `for_each` 経由の fan-out でも)、すべての `agent` ステップは run 共有の spawn budget を消費します — [Safety caps](#safety-caps)参照。
+
+## 合成プリミティブ
+
+5 つのプリミティブがステップを非線形な制御フローに合成します — Appendix-B の完全な集合で、今日すべてサポートされています。
+
+### `call` — sub-pipeline
+
+**登録済み**の sub-pipeline を静的な名前で同期実行し、その最終出力をこのステップの結果として通します。
+
+```yaml
+- call: {pipeline: validate_doc, pass: [doc, rules], output: validation}
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `pipeline` | 必須 | 静的なリテラルの pipeline 名 — 実行時の expression ではない。未登録のターゲットはステップを失敗させる。 |
+| `pass` | 任意 | callee に公開する、この pipeline の named store 名のリスト。callee のコンテキストはこれらの名前のみから**新規に**構築される — ここに列挙されていない store は callee から構造的に不可視。caller の store に存在しない名前を指定するとステップが失敗する。 |
+| `output` | 任意 | callee の最終結果を書き込む named store。 |
+
+callee の最初のステップは call サイトでの caller の pipe data を受け取る。callee 自身の最終ステップの出力がこの `call` ステップの結果になる。callee の失敗は `call` ステップを失敗させる。
+
+### `match` — 実行時選択の sub-pipeline
+
+`on` を値へと評価し、その値と文字列として等しいラベルを持つ case を選択して、`call` ステップと全く同様にそのターゲットを実行します。
+
+```yaml
+- match:
+    on: "review.passed"
+    cases:
+      "True": {pipeline: report_pass, pass: [review]}
+      "False": {pipeline: report_fail, pass: [review]}
+    default: {pipeline: report_unknown}
+    output: report
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `on` | 必須 | 現在のコンテキストに対して評価される R1 expression。その文字列化された結果が case ラベルを選択する。 |
+| `cases` | 必須 | `LABEL: {pipeline, pass?}` の空でないマッピング — 各ターゲットは `call` と全く同様の静的リテラル名。 |
+| `default` | 任意 | どの case ラベルにもマッチしなかった場合に実行される `{pipeline, pass?}`。マッチする case が無く `default` も無いステップは失敗する。 |
+| `output` | 任意 | 選択された callee の結果を書き込む named store。 |
+
+すべての case / `default` のターゲットは静的リテラルです — 実行時の値が選ぶのは常に*ラベル*であり、ターゲット自体ではありません。
+
+### `fold` — 逐次アキュムレータ
+
+リストを順に走査し、繰り返される `do` ステップを通してアキュムレータを引き継ぎます。
+
+```yaml
+- fold:
+    over: ctx.items
+    init: "0"
+    do: {transform: {value: "acc + item"}}
+    output: total
+    max_items: 1000
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `init` | 必須 | 最初のイテレーションの前に一度だけ評価され、`acc` の初期値となる R1 expression。 |
+| `do` | 必須 | リストの各アイテムごとに 1 回、`{ctx, pipe, item, acc}` というコンテキストで再実行される単一のステップ — `item` は現在の要素、`acc` は実行中のアキュムレータ。`do` の戻り値が次の `acc` になる。 |
+| `output` | 必須 | 最終的な `acc` を書き込む named store(`fold` の存在意義は名前付き結果を生成すること — `call` の任意な `output` とは異なり必須)。 |
+| `over` | 任意* | 走査するリストへと解決される R1 expression。 |
+| `items` | 任意* | 静的なリテラルリスト。 |
+| `max_items` | 任意 | 走査を先頭 N 要素に制限する(それより長いソースは静かに切り詰められ、エラーにはならない)。 |
+
+\* `over` と `items` は互いに排他的です。どちらも無ければ、リストはステップの受け取った pipe data にフォールバックします。アイテムの失敗は fold 全体を失敗させます。(`for_each` と異なり)`collect` はありません — 各アイテムの結果はそれより前のアイテムで積み上がった状態に依存するため、独立して collect するものが無いのです。
+
+### `for_each` — 並行 fan-out
+
+各リストアイテムに対して `do` を隔離された並行サブスコープとして実行し、その後 `collect` を一度だけ結果に対して実行します。
+
+```yaml
+- for_each:
+    over: ctx.reviewers
+    max_parallel: 4
+    on_error: "retry(2)"
+    do: {agent: {prompt: "Review as {item}: {ctx.doc}", schema: Review}}
+    collect: {transform: {value: "pipe"}}
+    output: reviews
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `do` | 必須 | アイテムごとに一度、`{ctx, pipe, item}` というコンテキストで実行されるステップ — `ctx` は外側の named store の隔離された**コピー**(アイテム間の sibling 可視性なし)、`pipe` はこのステップ自身が受け取った pipe data で全アイテムを通じて一定。 |
+| `collect` | 必須 | fan-out の後に一度だけ、生き残ったアイテム結果の順序付きリストに対して実行されるステップ(その `pipe` コンテキスト)。その結果がこのステップ全体の結果になる。 |
+| `on_error` | 必須 | `continue`(失敗したアイテムは結果から除外され、resume で再実行されることは無い)、`abort`(失敗したアイテムは残りの pending アイテムをキャンセルしステップ全体を失敗させる)、`retry(N)`(失敗したアイテムの `do` を最大 N 回追加で再実行し、それでも失敗すれば `abort` にフォールバック)のいずれか。 |
+| `over` | 任意* | `fold` と同じ。 |
+| `items` | 任意* | `fold` と同じ。 |
+| `max_parallel` | 任意 | ライブな並行度の上限(`Semaphore`)。省略時は控えめな有限値がデフォルト — 省略による無制限にはならない。 |
+| `output` | 任意 | `collect` の結果を書き込む named store。 |
+
+\* `over`/`items` は `fold` と同様に互いに排他的で、無ければ受け取った pipe data にフォールバックします。(`fold` 専用の)アイテムレベルの `acc` はありません — あるアイテムが他のアイテムの結果を見ることはできません。
+
+### `parallel` — 異種・名前付きブランチの fan-out
+
+`for_each` の異種版の兄弟です: 実行時サイズのリストに対して単一の `do` を fan-out する代わりに、`parallel` は静的で有限な、*それぞれ異なる*名前付きブランチの集合を並行に fan-out し、その後 `collect` を一度だけそれらの結果の名前付きマップに対して実行します。
+
+```yaml
+- parallel:
+    on_error: "abort"
+    branches:
+      security: {agent: {prompt: "Security-review {ctx.doc}", schema: Review}}
+      style: {agent: {prompt: "Style-review {ctx.doc}", schema: Review}}
+    collect: {transform: {value: "{'security': security, 'style': style}"}}
+    output: reviews
+```
+
+| キー | 必須 | 意味 |
+|-----|------|------|
+| `branches` | 必須 | 空でない `{NAME: Step}` マッピング — 各ブランチはそれぞれ独立した形のステップです(名前ごとに種別 / 設定が異なってよい)。`for_each` の、アイテムごとに再実行される単一の `do` とは異なります。すべてのブランチが並行に実行され、ブランチ数そのものが並行度の上限です(`max_parallel` は無い — 集合は静的に有限であるため)。 |
+| `collect` | 必須 | すべてのブランチが着地した後に一度だけ、**名前付きマップ** `{branch_name: result}` に対して実行されるステップ(`for_each` と異なり順序付きリストではない)。その結果がこのステップ全体の結果になる。 |
+| `on_error` | 任意 | `continue`、`abort`(省略時のデフォルト — `on_error` が必須の `for_each` とは異なる)、または `retry(N)` のいずれか — `for_each` の `on_error` と同じセマンティクス。`continue` でドロップされたブランチのキーは `collect` の名前付きマップから欠落します。 |
+| `output` | 任意 | `collect` の結果を書き込む named store。 |
+
+各ブランチのコンテキストは `{ctx, pipe}` です — `ctx` は外側の named store の隔離されたコピー、`pipe` はこのステップ自身が受け取った pipe data で全ブランチを通じて一定です。(`for_each`/`fold` 専用の)`item`/`acc` は無く、ブランチ間の sibling 可視性もありません。
+
+## R1 expression 言語
+
+`transform.value`、`!expr` タグの付いた `tool`/`shell` の引数、`match.on` は、いずれも同じ小さな**total**な expression 言語(R1)に対して解決されます — 汎用のスクリプト言語でも、コード実行サンドボックスでもない、専用のツリーウォーク・インタプリタです。再帰も、ユーザー定義関数も、無限ループも(すべてのコンビネータは既に実体化された 1 つのリストをちょうど 1 回だけ走査する)、IO も、`eval`/`exec` もありません。
+
+**リテラル**: `true` / `false` / `null`、整数、浮動小数点数、シングルまたはダブルクォート文字列。
+
+**フィールド参照**: コンテキストに対するドット区切りのパス。例: `ctx.review.passed`、または bare な `pipe`。パスが存在しないか、中間セグメントが非マッピングであれば例外を送出します — bare なパスは安全なナビゲーションではありません。それには下記の `get(...)` を使ってください。
+
+**演算子**: `and` / `or` / `not`。比較 `==` `!=` `<` `>` `<=` `>=`(`<`/`>`/`<=`/`>=` は 2 つの数値または 2 つの文字列を要求、`==`/`!=` は何にでも使える)。算術 `+` `-` `*` `/`(数値。`+` は文字列とリストの連結にも使える)。ゼロ除算は例外を送出します。
+
+**コンビネータ** — この文法が持つ唯一の呼び出しに似た構文で、固定された閉じた集合です:
+
+| コンビネータ | シグネチャ | 意味 |
+|---|---|---|
+| `map` | `map(list, item -> expr)` | 各要素を変換。 |
+| `filter` | `filter(list, item -> expr)` | ラムダが true となる要素を残す。 |
+| `all` | `all(list, item -> expr)` | 全要素がラムダを満たせば true。 |
+| `any` | `any(list, item -> expr)` | いずれかの要素がラムダを満たせば true。 |
+| `find` | `find(list, item -> expr)` | 最初にマッチした要素、無ければ `null`。 |
+| `count` | `count(list)` | 要素数。 |
+| `sum` | `sum(list)` | 数値の合計。 |
+| `join` | `join(list, sep)` | 文字列 join。 |
+| `get` | `get(base, "dotted.path", default?)` | **安全な**ナビゲーション — bare な `Path` と異なり、パスが存在しなくても例外を送出せず、`default`(無ければ `null`)を返す。 |
+
+`lambda`(`item -> expr`)は `map`/`filter`/`all`/`any`/`find` の直接の引数としてのみ有効です — 代入したり受け渡したりできる値ではありません。この固定コンビネータ集合の外にある名前を関数呼び出しとして書くと parse エラーになります。
+
+expression の例: `"'Hello, ' + ctx.name + '!'"`、`"ctx.n + 1"`、`"all(ctx.reviews, r -> r.passed)"`。
+
+`agent` ステップの `prompt` は**別の**仕組みです: `{ctx.dotted.path}` / `{pipe}` 参照が単なる値として補間されるテンプレート文字列であり — R1 expression ではなく、波括弧の中に演算子はありません。
+
+## Schema — `verify: schema`
+
+schema はネストされた単相(ジェネリクスなし)型に名前を付けたものです: 各フィールドはスカラー(`bool`/`string`/`number`)、`enum`、型付きの `list`(要素型 `of` は必須 — 型なしリストは無く、リストのリストも許可されない)、ネストされたインラインの `object`、または別の登録済み schema への `ref`(登録済み集合全体にわたる再帰参照のサイクルは登録時に拒否される)のいずれかです。
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+  tags: {type: list, of: {type: string}}
+```
+
+`tool`/`shell`/`agent` ステップの `schema: NAME` キーは、その結果(`agent` の場合は parse された JSON 応答)が適合すべき登録済み schema を指定します — 不適合はステップを失敗させます。同じ DSL ドキュメント集合内で宣言された schema(独立した `schema:` ドキュメント)は、[ad-hoc な inline pipeline](#ad-hoc-inline) でもこれを可能にするものです。その schema は同じ定義文字列と共に移動するためです。
+
+## 起動
+
+pipeline を起動するツールは 4 つあります。いずれも同じ実行に収束します: 起動は専用の `PipelineExecutorDriver` セッションを spawn し、pipeline はその中で走ります([Driver-as-session](../../concepts/runtime/pipelines.ja.md#driver-as-session)参照)— これら 4 つのどれも、呼び出し元自身のターン上でインラインに pipeline を実行しません。
+
+| ツール | 登録済み / inline | 同期 / 非同期 |
+|------|---------------------|---------------|
+| `run_pipeline` | 登録済み、`name` 指定 | 同期 — attached、terminal まで block |
+| `run_pipeline_async` | 登録済み、`name` 指定 | 非同期 — detached、即座に返る |
+| `run_pipeline_inline` | inline、ad-hoc な `definition` 文字列 | 同期 — attached、terminal まで block |
+| `run_pipeline_inline_async` | inline、ad-hoc な `definition` 文字列 | 非同期 — detached、即座に返る |
+
+### 登録済み起動
+
+`run_pipeline(name, input?)` と `run_pipeline_async(name, input?)` は登録された名前で pipeline を検索します([Pipeline registration](../../concepts/runtime/pipeline-registration.md)参照)。`input` は pipeline の最初のステップの初期 named context(`ctx.*`)をシードします — シード入力を必要としない pipeline では省略できます。登録されていない `name` は明確に失敗します。
+
+### 同期 vs 非同期
+
+- **同期**(`run_pipeline`、`run_pipeline_inline`): 呼び出し元は driver-session の run に attach し、terminal 状態に達するまで block して、結果を in-band で読み戻します(`{status: "ok", data: {run_id, output, named_stores}}`、または `error`/`cancelled`)。ライブな `pipeline_step_started` / `pipeline_step_completed` イベントが run の間、呼び出し元にストリームされ(TUI のライブビューが描画するもの)、協調的な Ctrl-C は次のステップ境界で run をクリーンに停止させます。attach 自体がクラッシュで中断された場合、run は失われません — 非同期と同じ recovery パスに引き渡され、結果は代わりに後で inbox メッセージとして届きます(`{status: "started", data: {run_id}}`)。
+- **非同期**(`run_pipeline_async`、`run_pipeline_inline_async`): 即座に `{status: "started", data: {run_id}}` を返します。最終結果は後で `[pipeline]` inbox メッセージとして届きます。
+
+### Ad-hoc inline 起動
+
+`run_pipeline_inline(definition, input?)` と `run_pipeline_inline_async(definition, input?)` は、呼び出しているエージェントが実行時に生成する pipeline DSL 文字列を受け取ります — 登録済み pipeline ファイルと同じ Appendix-B 文法で、その定義自身のステップが参照する `schema:` ドキュメントも含みます。事前登録は不要です: 文字列は parse され、何かが spawn される前に**静的解析ゲート**を通されます。そのため不正な定義は明確に失敗し、何も spawn しません:
+
+1. 定義が parse できる。
+2. すべてのステップの `schema:` 参照が、定義自身の schema 内で解決する。
+3. すべての `tool` ステップ名が、登録済みツールまたは qualified action に解決する。
+4. *(構造的、実行時チェックではない)* driver-session は起動者自身の identity の下で spawn され、restrict-only で narrowing されるため、生成された pipeline が起動者自身の envelope を超えることは構造上あり得ない。
+5. どの `tool` ステップも pipeline を起動したり delegate したりしない — ネストは `call` のみ。
+6. **Inline 専用**: `agent` ステップの `identity` は、設定されている場合、起動者自身の identity と等しくなければならない。登録済み pipeline はこのチェックの対象外(信頼された登録者が意図的に identity を選んだため)。別の identity を指定する inline の、エージェントが生成した pipeline は capability escalation として拒否される。
+
+inline run は、登録済みのものと全く同様に crash-recoverable です — その完全な parse 済み定義(schema を含む)が work-order に永続化されるため、recovery は再 parse も再検索も必要としません。
+
+## Safety caps
+
+`reyn.yaml` の `safety.spawn` ブロック内の 2 つの operator 設定キャップが、pipeline run の fan-out に境界を課し、すべての `run`/`resume` 呼び出しに渡されます:
+
+```yaml
+# reyn.yaml
+safety:
+  spawn:
+    max_pipeline_fan_out_depth: 5   # デフォルト
+    max_pipeline_spawns: 100        # デフォルト
+```
+
+| キー | デフォルト | 意味 |
+|-----|-----------|------|
+| `max_pipeline_fan_out_depth` | `5` | `for_each` fan-out スコープの最大**ネスト深度**(トップレベルの `for_each` は深度 1、別の `for_each` の `do`/`collect` の中の `for_each` は深度 2、…)。これを超える `for_each` は spawn せずステップを失敗させる。`0` = 無制限。 |
+| `max_pipeline_spawns` | `100` | **1 つの pipeline run** がそのすべての `agent` ステップ(トップレベルでも `for_each` 経由でも)を通じて spawn できる ephemeral session の最大数。run ごとの単調カウンタ。キャップを超える spawn はステップを失敗させる。`0` = 無制限。 |
+
+いずれも控えめな有限値がデフォルトです — run は省略によって無制限にはなりません。どちらのキャップも LLM が実行時に到達できるものではなく、両方とも operator 設定かつ再起動時のみ反映されます。
+
+## セキュリティ
+
+[Pipeline registration § セキュリティ](../../concepts/runtime/pipeline-registration.md#security-launching-a-pipeline-stays-gated)参照: pipeline を起動すること(上記 4 ツールのいずれでも)は、別のエージェントへの delegate と同じ `HIGH` severity の、spawn-adjacent な capability floor に位置します。untrusted-content floor、または unbound な delegate の floor に narrowing されたコンテキストは、登録済みであれ inline であれ、pipeline を起動できません。

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -1,0 +1,446 @@
+---
+type: reference
+topic: runtime
+audience: [human, agent]
+search_hints: [pipeline DSL, pipeline grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+---
+
+# Pipeline DSL reference
+
+Normative grammar for a pipeline definition — the step kinds, the
+compositional primitives, the expression language they evaluate against, the
+schema/`verify: schema` mechanism, and the four tools that launch a pipeline.
+See [Pipelines](../../concepts/runtime/pipelines.md) for the why/architecture,
+and [Pipeline registration](../../concepts/runtime/pipeline-registration.md)
+for how a definition reaches a session.
+
+## Document shape
+
+A pipeline definition is one or more `---`-separated YAML documents:
+
+- Exactly one `pipeline:` document — the pipeline itself.
+- Zero or more `schema:` documents — named schemas the pipeline's steps can
+  reference via `verify: schema` (see [Schemas](#schemas-verify-schema)).
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+---
+pipeline: review_and_report
+description: Review a document and summarize the verdict.
+steps:
+  - agent: {prompt: "Review {ctx.doc}. Reply with passed/notes.", schema: Review, output: review}
+  - transform: {value: "review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
+```
+
+### `pipeline:` document keys
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `pipeline` | yes | The declared name. Authoritative for registration and for a `call`/`match` step's target — see [Pipeline registration](../../concepts/runtime/pipeline-registration.md#the-declared-name-is-authoritative). |
+| `description` | no | Human-readable summary; surfaced to the LLM alongside the name when a registered pipeline is listed as a `pipeline__<name>` catalog action. Defaults to empty. |
+| `steps` | yes | Non-empty list of steps, executed in order (see [Step kinds](#step-kinds) and [Primitives](#compositional-primitives)). |
+
+`input`, `defaults`, and `refine` are part of the pipeline design's fuller
+grammar but have no runtime yet — a document using them fails to parse with
+an explicit "not yet supported" error rather than being silently ignored.
+
+## Step kinds
+
+Every step is a single-key mapping naming its kind. Three are **linear leaf
+steps** — they read the context, do one piece of work, and produce a result:
+
+### `transform`
+
+A pure step: `value` is evaluated as an [R1 expression](#the-r1-expression-language)
+against the current context; the result becomes this step's pipe data (and,
+if `output` is set, is also written to that named store).
+
+```yaml
+- transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `value` | yes | An R1 expression source. |
+| `output` | no | Named store to write the result to. |
+
+### `tool` (+ `shell` sugar)
+
+A side-effecting step: dispatches `name` with `args` through the same
+qualified-action-routing-then-bare-lookup a live `invoke_action` call uses —
+so a `tool` step can name either a qualified action (`file__read`) or a bare
+registered tool name (`web_search`).
+
+```yaml
+- tool: {name: web_search, args: {query: !expr ctx.brief, limit: 5}, output: results}
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `name` | yes | The tool/action name (literal string). |
+| `args` | no | Mapping of argument name → value. Each value is a **literal** unless tagged `!expr` (see [Literals vs `!expr`](#literals-vs-expr) below). |
+| `schema` | no | A registered schema name the result must conform to (`verify: schema` — see [Schemas](#schemas-verify-schema)). Non-conformance fails the step. |
+| `output` | no | Named store to write the result to. |
+
+`shell` is sugar for a `tool` step named `"shell"`:
+
+```yaml
+- shell: {command: !expr "'ls ' + ctx.dir", output: listing}
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `command` | yes | Literal or `!expr`, same rule as a `tool` step's `args` values. |
+| `schema` | no | Same as `tool`. |
+| `output` | no | Same as `tool`. |
+
+#### Literals vs `!expr`
+
+A `tool`/`shell` argument value is a **literal** — passed through to the tool
+exactly as written — unless it is tagged with the YAML tag `!expr`:
+
+```yaml
+args: {query: !expr ctx.brief, limit: !expr "ctx.n + 1", label: "a plain string"}
+```
+
+`query` and `limit` are R1 expression sources, resolved against the step's
+context at run time; `label` is the literal string `"a plain string"`.
+`!expr` is only honored as the **whole value** of an argument — one hiding
+inside a nested list or mapping is a parse error, so there is no ambiguity
+between "a literal that happens to look like an expression" and "an
+expression."
+
+`transform.value` is always an R1 expression (no `!expr` tag needed — there is
+no literal form for a `transform` step). An `agent` step's `prompt` is never
+an R1 expression — see below.
+
+### `agent`
+
+An LLM-driven leaf step: `prompt` (a template string) is interpolated against
+the current context and run as one turn in an ephemeral session,
+capability-narrowed to `capabilities` (or the invoker's own profile if
+omitted) under `identity` (or the invoker's own identity if omitted).
+
+```yaml
+- agent: {prompt: "Summarize: {ctx.doc}", capabilities: {tools: [file__read]}, schema: Summary, output: summary}
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `prompt` | yes | A template string — `{ctx.dotted.path}` / `{pipe}` references are interpolated (values only, no operators — this is string interpolation, not an R1 expression). |
+| `identity` | no | The agent identity to run under. Defaults to the run's invoker. A **registered** pipeline may name any identity; an **inline, agent-generated** pipeline may only name the invoker's own identity — naming another agent's identity is rejected by the static-analysis gate as a capability escalation (see [Ad-hoc inline launch](#ad-hoc-inline-launch)). |
+| `capabilities` | no | `{tools: [NAME*]}` — narrows the ephemeral session's tool surface. Restrict-only: a pipeline step can never exceed the invoker's own envelope. |
+| `schema` | no | Same `verify: schema` semantics as `tool`, applied to the parsed JSON reply. |
+| `output` | no | Named store to write the result to. |
+
+Every `agent` step, wherever it is reached (top-level or fanned out inside a
+`for_each`), charges the run's shared spawn budget — see
+[Safety caps](#safety-caps).
+
+## Compositional primitives
+
+Five primitives compose steps into non-linear control flow — the full
+Appendix-B set, all supported today.
+
+### `call` — sub-pipeline
+
+Synchronously runs a **registered** sub-pipeline by static name and threads
+its final output out as this step's result.
+
+```yaml
+- call: {pipeline: validate_doc, pass: [doc, rules], output: validation}
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `pipeline` | yes | A static literal pipeline name — never a runtime expression. An unregistered target fails the step. |
+| `pass` | no | List of this pipeline's named-store names to expose to the callee. The callee's context is built **fresh** from only these names — a store not listed here is structurally invisible to the callee. A name absent from the caller's stores fails the step. |
+| `output` | no | Named store to write the callee's final result to. |
+
+The callee's first step receives the caller's pipe data at the call site; the
+callee's own final step output becomes this `call` step's result. A callee
+failure fails the `call` step.
+
+### `match` — runtime-selected sub-pipeline
+
+Evaluates `on` to a value, selects the case whose label string-equals it, and
+runs that case's target exactly like a `call` step.
+
+```yaml
+- match:
+    on: "review.passed"
+    cases:
+      "True": {pipeline: report_pass, pass: [review]}
+      "False": {pipeline: report_fail, pass: [review]}
+    default: {pipeline: report_unknown}
+    output: report
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `on` | yes | An R1 expression evaluated against the current context; its stringified result selects a case label. |
+| `cases` | yes | Non-empty mapping of `LABEL: {pipeline, pass?}` — each target a static literal name, exactly like `call`. |
+| `default` | no | `{pipeline, pass?}` run when no case label matches. A step with no matching case and no `default` fails. |
+| `output` | no | Named store to write the selected callee's result to. |
+
+Every case/`default` target is a static literal — the runtime value only ever
+selects a *label*, never a target directly.
+
+### `fold` — sequential accumulator
+
+Walks a list in order, threading an accumulator through a repeated `do` step.
+
+```yaml
+- fold:
+    over: ctx.items
+    init: "0"
+    do: {transform: {value: "acc + item"}}
+    output: total
+    max_items: 1000
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `init` | yes | An R1 expression evaluated once, before the first iteration, seeding `acc`. |
+| `do` | yes | A single step re-invoked once per list item, in a context of `{ctx, pipe, item, acc}` — `item` is the current element, `acc` the running accumulator; `do`'s return value becomes the next `acc`. |
+| `output` | yes | Named store for the final `acc` (a `fold`'s whole point is producing a named result — required, unlike `call`'s optional `output`). |
+| `over` | no* | An R1 expression resolving to the list to walk. |
+| `items` | no* | A static literal list. |
+| `max_items` | no | Caps the walk to the first N elements (a longer source is silently truncated, never an error). |
+
+\* `over` and `items` are mutually exclusive; if neither is given, the list
+falls back to the step's incoming pipe data. Item failure fails the whole
+fold. There is no `collect` (unlike `for_each`) — each item's result depends
+on the accumulated state of the ones before it, so there is nothing to
+collect independently.
+
+### `for_each` — concurrent fan-out
+
+Runs `do` over each list item as an isolated concurrent sub-scope, then runs
+`collect` once over the ordered results.
+
+```yaml
+- for_each:
+    over: ctx.reviewers
+    max_parallel: 4
+    on_error: "retry(2)"
+    do: {agent: {prompt: "Review as {item}: {ctx.doc}", schema: Review}}
+    collect: {transform: {value: "pipe"}}
+    output: reviews
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `do` | yes | A step run once per item, in a context of `{ctx, pipe, item}` — `ctx` is an isolated **copy** of the outer named stores (no sibling visibility between items), `pipe` is this step's own incoming pipe data held constant across every item. |
+| `collect` | yes | A step run once, after the fan-out, over the ordered list of surviving item results (its `pipe` context). Its result is this step's overall result. |
+| `on_error` | yes | One of `continue` (a failed item is dropped from the results, never re-run on resume), `abort` (a failed item cancels the still-pending items and fails the whole step), or `retry(N)` (re-run the failed item up to N more times, then fall back to `abort`). |
+| `over` | no* | Same as `fold`. |
+| `items` | no* | Same as `fold`. |
+| `max_parallel` | no | Caps live concurrency (a `Semaphore`). Omitted, defaults to a conservative finite value — never unbounded by omission. |
+| `output` | no | Named store to write `collect`'s result to. |
+
+\* `over`/`items` are mutually exclusive, falling back to incoming pipe data
+like `fold`. There is no `item`-level `acc` (that is `fold`-only) — an item
+cannot see any other item's result.
+
+### `parallel` — heterogeneous named-branch fan-out
+
+`for_each`'s heterogeneous sibling: instead of fanning one `do` step out over
+a runtime-sized list, `parallel` fans a static, finite set of *distinct*
+named branches out concurrently, then runs `collect` once over the named map
+of their results.
+
+```yaml
+- parallel:
+    on_error: "abort"
+    branches:
+      security: {agent: {prompt: "Security-review {ctx.doc}", schema: Review}}
+      style: {agent: {prompt: "Style-review {ctx.doc}", schema: Review}}
+    collect: {transform: {value: "{'security': security, 'style': style}"}}
+    output: reviews
+```
+
+| Key | Required | Meaning |
+|-----|----------|---------|
+| `branches` | yes | A non-empty `{NAME: Step}` mapping — each branch is its own, independently-shaped step (a different kind/config per name), unlike `for_each`'s one `do` re-invoked per item. Every branch runs concurrently; the branch count itself is the concurrency bound (no `max_parallel` — the set is statically finite). |
+| `collect` | yes | A step run once, after every branch lands, over the **named map** `{branch_name: result}` (not an ordered list, unlike `for_each`). Its result is this step's overall result. |
+| `on_error` | no | One of `continue`, `abort` (the default when omitted — unlike `for_each`, where `on_error` is required), or `retry(N)` — same semantics as `for_each`'s `on_error`. A `continue`-dropped branch's key is absent from `collect`'s named map. |
+| `output` | no | Named store to write `collect`'s result to. |
+
+Each branch's context is `{ctx, pipe}` — `ctx` an isolated copy of the outer
+named stores, `pipe` this step's own incoming pipe data held constant across
+every branch. There is no `item`/`acc` (those are `for_each`/`fold`-only) and
+no sibling visibility between branches.
+
+## The R1 expression language
+
+`transform.value`, a `tool`/`shell` argument tagged `!expr`, and `match.on`
+all resolve against the same small, **total** expression language (R1) — a
+purpose-built tree-walking interpreter, not a general scripting language and
+not a code-execution sandbox. It has no recursion, no user-defined functions,
+no unbounded loops (every combinator iterates one already-materialized list
+exactly once), no IO, and no `eval`/`exec`.
+
+**Literals**: `true` / `false` / `null`, integers, floats, single- or
+double-quoted strings.
+
+**Field refs**: a dotted path against the context, e.g. `ctx.review.passed`
+or bare `pipe`. A missing path or a non-mapping intermediate segment raises —
+bare paths are not safe navigation; use `get(...)` for that (below).
+
+**Operators**: `and` / `or` / `not`; comparisons `==` `!=` `<` `>` `<=` `>=`
+(`<`/`>`/`<=`/`>=` require two numbers or two strings; `==`/`!=` work on
+anything); arithmetic `+` `-` `*` `/` (numeric; `+` also concatenates strings
+and lists). Division by zero raises.
+
+**Combinators** — the only call-like syntax the grammar has, a fixed closed
+set:
+
+| Combinator | Signature | Meaning |
+|---|---|---|
+| `map` | `map(list, item -> expr)` | Transform each element. |
+| `filter` | `filter(list, item -> expr)` | Keep elements where the lambda is true. |
+| `all` | `all(list, item -> expr)` | True iff every element satisfies the lambda. |
+| `any` | `any(list, item -> expr)` | True iff some element satisfies the lambda. |
+| `find` | `find(list, item -> expr)` | First matching element, or `null`. |
+| `count` | `count(list)` | Element count. |
+| `sum` | `sum(list)` | Numeric sum. |
+| `join` | `join(list, sep)` | String-join. |
+| `get` | `get(base, "dotted.path", default?)` | **Safe** navigation — unlike a bare `Path`, never raises on a missing path; returns `default` (or `null`) instead. |
+
+A `lambda` (`item -> expr`) is only ever valid as the direct argument of
+`map`/`filter`/`all`/`any`/`find` — it is not a value that can be assigned or
+passed around, and naming anything outside this fixed combinator set as a
+function call is a parse error.
+
+Example expressions: `"'Hello, ' + ctx.name + '!'"`, `"ctx.n + 1"`,
+`"all(ctx.reviews, r -> r.passed)"`.
+
+An `agent` step's `prompt` is a **different** mechanism: a template string
+where `{ctx.dotted.path}` / `{pipe}` references are interpolated as plain
+values — not R1 expressions, no operators inside the braces.
+
+## Schemas — `verify: schema`
+
+A schema names a nested, monomorphic type: a set of fields, each a scalar
+(`bool`/`string`/`number`), an `enum`, a typed `list` (its element type,
+`of`, is mandatory — no untyped lists, and lists-of-lists are not allowed), a
+nested inline `object`, or a `ref` to another registered schema (a
+recursive-reference cycle across the registered set is rejected at
+registration time).
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+  tags: {type: list, of: {type: string}}
+```
+
+A `tool`/`shell`/`agent` step's `schema: NAME` key names a registered schema
+its result (or, for `agent`, its parsed JSON reply) must conform to —
+non-conformance fails the step. Schemas declared in the same DSL document set
+(standalone `schema:` documents) are what makes this possible for an ad-hoc
+[inline pipeline](#ad-hoc-inline-launch) too, since its schemas travel with
+the same definition string.
+
+## Invocation
+
+Four tools launch a pipeline. All four converge on the same execution: a
+launch spawns a dedicated `PipelineExecutorDriver` session and the pipeline
+runs inside it (see [Driver-as-session](../../concepts/runtime/pipelines.md#driver-as-session)) —
+none of them run a pipeline inline on the caller's own turn.
+
+| Tool | Registered / inline | Sync / async |
+|------|---------------------|---------------|
+| `run_pipeline` | Registered, by `name` | Sync — attached, blocks until terminal |
+| `run_pipeline_async` | Registered, by `name` | Async — detached, returns immediately |
+| `run_pipeline_inline` | Inline, ad-hoc `definition` string | Sync — attached, blocks until terminal |
+| `run_pipeline_inline_async` | Inline, ad-hoc `definition` string | Async — detached, returns immediately |
+
+### Registered launch
+
+`run_pipeline(name, input?)` and `run_pipeline_async(name, input?)` look a
+pipeline up by its registered name (see
+[Pipeline registration](../../concepts/runtime/pipeline-registration.md)).
+`input` seeds the pipeline's initial named context (`ctx.*`) for its first
+step; omit it for a pipeline that needs no seed input. A `name` that isn't
+registered fails clearly.
+
+### Sync vs async
+
+- **Sync** (`run_pipeline`, `run_pipeline_inline`): the caller attaches to the
+  driver-session's run and blocks until it reaches a terminal state, reading
+  the result back in-band (`{status: "ok", data: {run_id, output,
+  named_stores}}`, or `error`/`cancelled`). Live `pipeline_step_started` /
+  `pipeline_step_completed` events stream to the caller for the run's
+  duration (what a TUI live view renders), and a cooperative Ctrl-C stops the
+  run cleanly at the next step boundary. If the attach itself is interrupted
+  by a crash, the run is not lost — it is handed to the same recovery path
+  async uses, and the result arrives later as an inbox message instead
+  (`{status: "started", data: {run_id}}`).
+- **Async** (`run_pipeline_async`, `run_pipeline_inline_async`): returns
+  `{status: "started", data: {run_id}}` immediately; the final result arrives
+  later as a `[pipeline]` inbox message.
+
+### Ad-hoc inline launch
+
+`run_pipeline_inline(definition, input?)` and
+`run_pipeline_inline_async(definition, input?)` take a pipeline DSL string
+the calling agent generates at run time — the same Appendix-B grammar as a
+registered pipeline file, including any `schema:` documents the definition's
+own steps reference. There is no pre-registration: the string is parsed and
+run through a **static-analysis gate** before anything is spawned, so a bad
+definition fails clearly and spawns nothing:
+
+1. The definition parses.
+2. Every step `schema:` reference resolves within the definition's own
+   schemas.
+3. Every `tool` step's name resolves to a registered tool or qualified
+   action.
+4. *(Structural, not runtime-checked)* the driver-session spawns under the
+   invoker's own identity and narrows restrict-only, so a generated pipeline
+   can never exceed the invoker's own envelope by construction.
+5. No `tool` step launches a pipeline or delegates — nesting is `call`-only.
+6. **Inline-only**: an `agent` step's `identity`, if set, must equal the
+   invoker's own identity. A registered pipeline is exempt from this check (a
+   trusted registrant deliberately chose the identity); an inline,
+   agent-generated one naming a different identity is a capability
+   escalation and is rejected.
+
+An inline run is crash-recoverable identically to a registered one — its
+full parsed definition (including its schemas) is persisted into the
+work-order, so recovery never needs to re-parse or look anything up.
+
+## Safety caps
+
+Two operator-set caps in `reyn.yaml`'s `safety.spawn` block bound a pipeline
+run's fan-out, threaded into every `run`/`resume` call:
+
+```yaml
+# reyn.yaml
+safety:
+  spawn:
+    max_pipeline_fan_out_depth: 5   # default
+    max_pipeline_spawns: 100        # default
+```
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `max_pipeline_fan_out_depth` | `5` | Maximum **nesting depth** of `for_each` fan-out scopes (a top-level `for_each` is depth 1; a `for_each` inside another's `do`/`collect` is depth 2; …). A `for_each` that would exceed this fails the step rather than spawning. `0` = unlimited. |
+| `max_pipeline_spawns` | `100` | Maximum number of ephemeral sessions **one pipeline run** may spawn across all its `agent` steps — top-level or fanned out via `for_each`. A per-run monotonic counter; a spawn past the cap fails the step. `0` = unlimited. |
+
+Both default to conservative finite values — a run is never unbounded by
+omission. Neither cap is reachable by an LLM at run time; both are
+operator-set and restart-only.
+
+## Security
+
+See [Pipeline registration § Security](../../concepts/runtime/pipeline-registration.md#security-launching-a-pipeline-stays-gated):
+launching a pipeline (any of the four tools above) sits on the same
+`HIGH`-severity, spawn-adjacent capability floor as delegating to another
+agent. A context narrowed by the untrusted-content floor or an unbound
+delegate's floor cannot launch a pipeline, registered or inline.


### PR DESCRIPTION
**[docs-maintainer]** — Owner-requested pipeline feature docs (per lead-coder dispatch), mirroring the Skills docs structure (#2555).

## Summary
- `docs/concepts/runtime/pipelines.md` + `.ja.md` — why/architecture: control-plane vs execution-plane, safety-by-structure, driver-as-session, crash recovery (exactly-once execution, at-least-once delivery).
- `docs/reference/runtime/pipeline-dsl.md` + `.ja.md` — normative DSL grammar: all 3 step kinds, all 5 compositional primitives (`call`/`match`/`fold`/`for_each`/`parallel` — `parallel` just merged in e67014dd, included per lead-coder's cascade-trigger ping), the R1 expression language, the schema/`verify: schema` mechanism, the 4 invocation tools (`run_pipeline`, `run_pipeline_async`, `run_pipeline_inline`, `run_pipeline_inline_async`), and the S5 safety caps (`safety.spawn.max_pipeline_fan_out_depth`/`max_pipeline_spawns`).
- `docs/guide/for-users/write-a-pipeline.md` + `.ja.md` — how-to: write a pipeline, register it, invoke sync/async, the ad-hoc inline alternative, a worked `for_each`+`match` example.
- `docs/feature-map.md` — new Pipeline section + mindmap node.
- `.mkdocs/mkdocs.yml` — nav entries for all of the above, plus fixing a pre-existing nav-drop: `concepts/runtime/pipeline-registration.md` (from #2580) was never added to nav.

Every claim was verified directly against `src/reyn/core/pipeline/{executor,registry,parser,expr,schema,work_order,analyzer}.py`, `src/reyn/data/pipelines/registry.py`, `src/reyn/runtime/services/pipeline_executor_driver.py`, `src/reyn/tools/pipeline_verbs.py`, and the `safety.spawn.*` config path in `src/reyn/config/chat.py` — not from the dispatch description alone.

No PR/issue refs in doc bodies. No mermaid diagrams added. No CLAUDE.md hard rule touched.

## Test plan
- [x] `ruff check src tests` — all checks passed (no src changes in this PR; ran as a matter of course).
- [x] `mkdocs build --strict` (from `.mkdocs/`) — exit 0, no new broken links/anchors introduced (verified anchor-by-anchor against the actual generated `id=` attributes in the built HTML, including for the Japanese pages, which slugify differently than the English ones).
- [x] Manual: cross-checked every DSL key/grammar claim against parser.py's `_STEP_PARSERS`/`_*_KEYS` frozensets, and every invocation-tool behavior against `pipeline_verbs.py`'s handlers.

Ping for co-vet against impl, as discussed.