### PR TITLE
fix(#2589): surface async + inline pipeline launch verbs to the default agent (mirror mcp hybrid enumeration)

### DIFF
--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -720,26 +720,31 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
         return out2
 
     if category == "pipeline":
-        # IS-5: enumerate REGISTERED pipelines from the caller state's
-        # PipelineRegistry (mirrors the rag_corpus branch above). Each
-        # ``pipeline__<name>`` entry is directly invokable — D19 resource
-        # invoke, ``universal_dispatch._RESOURCE_RULES["pipeline"]`` curries
-        # ``name`` and forwards ``input`` to ``run_pipeline`` — same pattern
-        # as ``rag_corpus__<name>`` currying ``sources`` into ``recall``. The
-        # pre-existing static ``pipeline__run`` verb (``args={name, input}``)
-        # keeps working unchanged (exact _OPERATION_RULES match wins first).
-        # None registry (narrow test hosts / a host that doesn't support
-        # run_pipeline) → empty list.
+        # #2589: HYBRID enumeration — mirrors the ``mcp`` category above.
+        # Static launch verbs (pipeline__run / _async / _inline / _inline_async)
+        # are in ``_OPERATION_RULES`` (universal_dispatch.py), floored under
+        # "pipeline-run" (capability_profile.py), and classified — but were
+        # NEVER enumerated, so a default enumerate-all agent could dispatch
+        # them (invoke_action) yet never discover them (list_actions never
+        # surfaced them). Enumerate the static verbs FIRST, then extend with
+        # the IS-5 dynamic per-registered-pipeline ``pipeline__<name>``
+        # entries (D19 resource invoke, ``universal_dispatch._RESOURCE_
+        # RULES["pipeline"]`` curries ``name`` and forwards ``input`` to
+        # ``run_pipeline`` — same pattern as ``rag_corpus__<name>`` currying
+        # ``sources`` into ``recall``). None registry (narrow test hosts / a
+        # host that doesn't support run_pipeline) → static verbs only.
+        items = list(_enumerate_static_category("pipeline"))
         pipeline_registry = getattr(rs, "pipeline_registry", None) if rs is not None else None
         if pipeline_registry is None:
-            return []
-        return [
+            return items
+        items.extend(
             {
                 "qualified_name": build_qualified_name("pipeline", name),
                 "short_description": _truncate_short_description(description),
             }
             for name, description in pipeline_registry.entries()
-        ]
+        )
+        return items
 
     # exec category — sandboxed_exec (FP-0017).
     # Visible only when a real sandbox backend is configured (D14-ext).

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -346,6 +346,59 @@ async def test_run_pipeline_async_launches_and_delivers_result(tmp_path: Path, m
 
 
 @pytest.mark.asyncio
+async def test_pipeline_run_async_reachable_via_invoke_action(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2c: #2589 — ``pipeline__run_async`` (one of the 4 verbs that were
+    dispatch-wired but NEVER enumerated for a default agent) is reachable
+    end-to-end through ``invoke_action``, not just the direct handler call
+    the test above exercises. Drives the SAME production entry point a
+    default enumerate-all agent would use (``INVOKE_ACTION.handler({
+    "action_name": "pipeline__run_async", ...})``), proving resolve →
+    lookup → dispatch → real async driver-session launch all connect for
+    the previously-unreachable verb."""
+    from reyn.tools.universal_catalog import INVOKE_ACTION
+
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry(tmp_path, state_log, scripted)
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("p", _three_step_pipeline(out_file))
+
+    caller = reg.get_or_load("worker")
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await INVOKE_ACTION.handler(
+        {"action_name": "pipeline__run_async", "args": {"name": "p", "input": {"seed": 10}}},
+        ctx,
+    )
+    assert result["status"] == "started"
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+    assert (run_dir / "invocation.json").is_file()
+
+    assert await _wait_for(lambda: _result_json(run_dir) is not None)
+    terminal = _result_json(run_dir)
+    assert terminal["status"] == "ok" and terminal["delivered"] is True
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["11", "second"]
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+@pytest.mark.asyncio
 async def test_run_pipeline_async_error_contracts(tmp_path: Path) -> None:
     """Tier 1: unregistered pipeline name and missing WAL each yield a clear
     error (never a silent no-op launch)."""

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -216,13 +216,21 @@ async def test_list_actions_pipeline_category_surfaces_registered_pipeline() -> 
     assert items["pipeline__digest_report"]["short_description"] == (
         "Summarize the week's incoming reports."
     )
+    # #2589: the static launch verbs (incl. the previously-unreachable
+    # async/inline ones) are ALSO surfaced alongside the dynamic per-name
+    # entry — the hybrid enumeration mirroring the ``mcp`` category.
+    assert {
+        "pipeline__run", "pipeline__run_async",
+        "pipeline__run_inline", "pipeline__run_inline_async",
+    } <= items.keys()
 
 
 @pytest.mark.asyncio
-async def test_list_actions_pipeline_category_empty_registry_returns_empty() -> None:
+async def test_list_actions_pipeline_category_empty_registry_returns_static_verbs_only() -> None:
     """Tier 2: no registered pipelines -> list_actions(category=["pipeline"])
-    returns an empty item list (not an error), same graceful-empty posture
-    as the other resource categories (mcp.server / rag_corpus)."""
+    returns ONLY the static launch verbs (#2589 hybrid enumeration), not an
+    empty list — the ``mcp`` category's hybrid pattern always surfaces its
+    static verbs regardless of dynamic population; ``pipeline`` now matches."""
     from reyn.tools.types import ToolContext
     from reyn.tools.universal_catalog import LIST_ACTIONS
 
@@ -238,7 +246,11 @@ async def test_list_actions_pipeline_category_empty_registry_returns_empty() -> 
 
     result = await LIST_ACTIONS.handler({"category": ["pipeline"]}, ctx)
 
-    assert result["items"] == []
+    names = {it["qualified_name"] for it in result["items"]}
+    assert names == {
+        "pipeline__run", "pipeline__run_async",
+        "pipeline__run_inline", "pipeline__run_inline_async",
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[lead-sonnet]** — Closes #2589

## Summary
- `_enumerate_category("pipeline")` in `src/reyn/tools/universal_catalog.py` only enumerated dynamic per-registered-pipeline entries (`pipeline__<name>`) from `rs.pipeline_registry.entries()` and returned immediately — it never called `_enumerate_static_category("pipeline")`. As a result the 4 static launch verbs (`pipeline__run`, `pipeline__run_async`, `pipeline__run_inline`, `pipeline__run_inline_async`) — already present in `_OPERATION_RULES` (`universal_dispatch.py`), floored under `"pipeline-run"` (`capability_profile.py`), and classified — were dispatch-wired but NOT enumerated, so a default enumerate-all agent could never discover 3 of the 4 (`run`'s sibling was only reachable via `pipeline__<name>`, and `run_async`/`run_inline`/`run_inline_async` were unreachable entirely via `list_actions`).
- Fix mirrors the existing `mcp` category's hybrid pattern: enumerate the static verbs first (`_enumerate_static_category("pipeline")`), then extend with the existing dynamic per-registered-pipeline entries. ~3-line change, no new `_RESOURCE_RULES`, no `build_tools` change, no capability-floor changes (already correct — verified below).
- This is a pure discoverability fix: dispatch for all 4 verbs already worked; only enumeration was missing.

## Test plan
- [x] `tests/test_pipeline_is5_surfacing.py` — updated the empty-registry test (now asserts the 4 static verbs are present instead of an empty list) and the registered-pipeline test (asserts static verbs are surfaced ALONGSIDE the dynamic `pipeline__<name>` entry) — closes the "dogfood gap" (list_actions now surfaces `pipeline__run_async`, `pipeline__run_inline`, `pipeline__run_inline_async`, plus `pipeline__run` and per-registered `pipeline__<name>`).
- [x] `tests/test_pipeline_is2_driver_session.py::test_pipeline_run_async_reachable_via_invoke_action` (new) — live invoke: drives `INVOKE_ACTION.handler({"action_name": "pipeline__run_async", ...})` (the actual production entry point a default agent would use) end-to-end through a real router/session/WAL substrate; asserts the async driver-session launches, runs the real pipeline, and delivers the result — proves reachability, not just enumeration.
- [x] Security regression — `tests/test_2575_pipeline_disk_registration.py::test_floor_still_denies_pipeline_launch_verbs` (pre-existing, unmodified) already asserts BOTH the untrusted-content floor and the unbound-delegate floor deny all 4 verbs (bare + qualified); reran green — confirms surfacing did not loosen the floor.
- [x] Dispatch-completeness invariants — `tests/test_universal_catalog.py`, `tests/test_universal_dispatch.py`, `tests/test_2081_s3_delegation_audit.py`, `tests/test_returns_external_content_flagset_1822.py`, `tests/test_2123_router_dispatch_sot_1953.py` reran green in isolation — no new invariant work needed (these verbs were already classified/floored).
- [x] All 4 CI gates run locally: `ruff check src tests` (clean), `python scripts/test_tier_audit.py --strict tests/test_pipeline_is5_surfacing.py tests/test_pipeline_is2_driver_session.py` (26/26 OK), `pytest` full suite (7187 passed — 10 pre-existing failures on unmodified HEAD unrelated to this change, confirmed via `git stash`), `python scripts/verify_module_docstrings.py` (OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)