### PR TITLE
docs(pipeline): add canonical formal DSL grammar

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -2,7 +2,7 @@
 type: reference
 topic: runtime
 audience: [human, agent]
-search_hints: [pipeline DSL, pipeline grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
 ---
 
 # Pipeline DSL リファレンス
@@ -38,6 +38,95 @@ steps:
 | `steps` | 必須 | 順に実行される、空でないステップのリスト(下記の「ステップ種別」と「合成プリミティブ」参照)。 |
 
 `input` / `defaults` / `refine` は pipeline 設計のより完全な文法の一部ですが、まだランタイムがありません — これらを使ったドキュメントは、静かに無視されるのではなく、明示的な「まだサポートされていない」エラーで parse に失敗します。
+
+## 形式文法
+
+以下の EBNF は**規範的な、現行の**文法です — 初期の設計提案からではなく、`parse_pipeline_dsl`(`src/reyn/core/pipeline/parser.py`)から直接導出されています。今日パーサが受け付けるものを正確にカバーしています: これに適合する定義はクリーンに parse でき、違反は拒否されます。YAML のマッピングキーは無順序です — 以下の線形な並びは可読性のためであり、位置的な要求ではありません。`NAME` は識別子的な bare 文字列、`EXPR` は [R1 expression](#r1-expression) のソース文字列、`TPL` は `agent.prompt` のテンプレート文字列(`{ctx.dotted.path}` / `{pipe}` 補間、R1 ではない)です。
+
+```ebnf
+Document      ::= YamlDoc ("---" YamlDoc)*        (* テキスト全体で PipelineDoc はちょうど 1 つ *)
+YamlDoc       ::= SchemaDoc | PipelineDoc
+
+SchemaDoc     ::= "schema:" NAME "fields:" FieldMap
+PipelineDoc   ::= "pipeline:" NAME
+                  ("description:" STRING)?
+                  "steps:" Step+
+
+Step          ::= "transform:" TransformBody
+                 | "tool:"      ToolBody
+                 | "shell:"     ShellBody
+                 | "agent:"     AgentBody
+                 | "call:"      CallBody
+                 | "match:"     MatchBody
+                 | "fold:"      FoldBody
+                 | "for_each:"  ForEachBody
+                 | "parallel:"  ParallelBody
+
+TransformBody ::= "{" "value:" EXPR ["output:" NAME] "}"
+
+ToolBody      ::= "{" "name:" STRING
+                      ["args:" ArgMap]
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+ArgMap        ::= "{" (KEY ":" ArgValue ("," KEY ":" ArgValue)*)? "}"
+ArgValue      ::= LITERAL | "!expr" EXPR        (* !expr は値全体としてのみ、ネスト不可 *)
+
+ShellBody     ::= "{" "command:" ArgValue
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+
+AgentBody     ::= "{" "prompt:" TPL
+                      ["identity:" NAME]
+                      ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+
+CallBody      ::= "{" "pipeline:" NAME            (* 静的リテラル、EXPR ではない *)
+                      ["pass:" "[" NAME* "]"]
+                      ["output:" NAME] "}"
+
+MatchBody     ::= "{" "on:" EXPR
+                      "cases:" "{" (LABEL ":" MatchTarget)+ "}"
+                      ["default:" MatchTarget]
+                      ["output:" NAME] "}"
+MatchTarget   ::= "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] "}"
+
+FoldBody      ::= "{" [ListSource]
+                      "init:" EXPR
+                      "do:" Step
+                      "output:" NAME              (* 必須。call とは異なる *)
+                      ["max_items:" INT] "}"
+
+ForEachBody   ::= "{" [ListSource]
+                      ["max_parallel:" INT]
+                      "on_error:" OnError          (* 必須 — デフォルト無し *)
+                      "do:" Step
+                      "collect:" Step
+                      ["output:" NAME] "}"
+
+ParallelBody  ::= "{" ["on_error:" OnError]        (* 任意 — デフォルトは "abort" *)
+                      "branches:" "{" (NAME ":" Step)+ "}"
+                      "collect:" Step
+                      ["output:" NAME] "}"
+
+ListSource    ::= "over:" EXPR | "items:" "[" LITERAL* "]"   (* 互いに排他的 *)
+OnError       ::= "continue" | "abort" | "retry(" INT ")"
+
+FieldMap      ::= "{" (NAME ":" FieldType)+ "}"
+FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
+                 | "{" "type:" "enum" "values:" "[" LITERAL+ "]" "}"
+                 | "{" "type:" "list" "of:" FieldType "}"     (* 'of' は list 不可。リストのリスト無し *)
+                 | "{" "type:" "object" "fields:" FieldMap "}"
+                 | "{" "type:" "ref" "schema:" NAME "}"
+```
+
+文法だけでは示されない構造的な不変条件(単なる慣習ではなく、パーサとエグゼキュータによって強制されます):
+
+- `call`/`match`/`fold` の `do`、`for_each` の `do`/`collect`、`parallel` の branch/`collect` は**完全にネストされた `Step`** です — どのステップ種別でもよく、別の合成プリミティブでも構いません。
+- `call`、`match` の case/`default`、`parallel` の `branches` は、いずれも**静的リテラル**の pipeline / ステップターゲットを指定します — 実行時の expression では決してありません。実行時に評価されるのは `match.on` と `for_each`/`fold` の `over` だけです。
+- `pass:` は `call`/`match` の callee のコンテキストが構築される*唯一の*チャネルです — そこに列挙されていない caller の named store は callee から不可視です。
+- `for_each`/`parallel` のブランチはそれぞれ、外側の named store の**隔離されたコピー**を受け取ります — 並行なアイテム/ブランチ間の sibling 通信はありません。
+- `!expr` は `tool`/`shell` の引数を解決すべき expression にする*唯一の*方法です — リスト / マッピングの中にネストすると静かな no-op ではなく parse エラーになります。
 
 ## ステップ種別
 
@@ -233,6 +322,35 @@ callee の最初のステップは call サイトでの caller の pipe data を
 
 `transform.value`、`!expr` タグの付いた `tool`/`shell` の引数、`match.on` は、いずれも同じ小さな**total**な expression 言語(R1)に対して解決されます — 汎用のスクリプト言語でも、コード実行サンドボックスでもない、専用のツリーウォーク・インタプリタです。再帰も、ユーザー定義関数も、無限ループも(すべてのコンビネータは既に実体化された 1 つのリストをちょうど 1 回だけ走査する)、IO も、`eval`/`exec` もありません。
 
+```ebnf
+expr           ::= or_expr
+or_expr        ::= and_expr ("or" and_expr)*
+and_expr       ::= not_expr ("and" not_expr)*
+not_expr       ::= "not" not_expr | comparison
+comparison     ::= additive (cmp_op additive)?
+additive       ::= multiplicative (("+" | "-") multiplicative)*
+multiplicative ::= unary (("*" | "/") unary)*
+unary          ::= "-" unary | primary
+primary        ::= NUMBER | STRING | "true" | "false" | "null"
+                  | "(" expr ")"
+                  | "[" (expr ("," expr)*)? "]"
+                  | "{" (IDENT ":" expr ("," IDENT ":" expr)*)? "}"
+                  | combinator
+                  | path
+combinator     ::= "map" "(" expr "," lambda ")"
+                  | "filter" "(" expr "," lambda ")"
+                  | "all" "(" expr "," lambda ")"
+                  | "any" "(" expr "," lambda ")"
+                  | "find" "(" expr "," lambda ")"
+                  | "count" "(" expr ")"
+                  | "sum" "(" expr ")"
+                  | "join" "(" expr "," expr ")"
+                  | "get" "(" expr "," STRING ("," expr)? ")"
+lambda         ::= IDENT "->" expr        (* コンビネータ自身の引数としてのみ有効 *)
+path           ::= IDENT ("." IDENT)*
+cmp_op         ::= "==" | "!=" | "<" | ">" | "<=" | ">="
+```
+
 **リテラル**: `true` / `false` / `null`、整数、浮動小数点数、シングルまたはダブルクォート文字列。
 
 **フィールド参照**: コンテキストに対するドット区切りのパス。例: `ctx.review.passed`、または bare な `pipe`。パスが存在しないか、中間セグメントが非マッピングであれば例外を送出します — bare なパスは安全なナビゲーションではありません。それには下記の `get(...)` を使ってください。
@@ -328,3 +446,81 @@ safety:
 ## セキュリティ
 
 [Pipeline registration § セキュリティ](../../concepts/runtime/pipeline-registration.md#security-launching-a-pipeline-stays-gated)参照: pipeline を起動すること(上記 4 ツールのいずれでも)は、別のエージェントへの delegate と同じ `HIGH` severity の、spawn-adjacent な capability floor に位置します。untrusted-content floor、または unbound な delegate の floor に narrowing されたコンテキストは、登録済みであれ inline であれ、pipeline を起動できません。
+
+## 文法(生成用)
+
+実行時に pipeline 定義を作成するエージェント(例: `run_pipeline_inline`)向けの、コンパクトで自己完結したブロックです — 文法そのものに加え、文法だけからは導けないルール、そして 1 つの規範的な例。このセクションは単独で成立します。上記の文章を読んでいることを前提としません。
+
+**文法** — 上記の形式文法と同じ EBNF を、参照の便宜のため再掲します:
+
+```ebnf
+Document      ::= YamlDoc ("---" YamlDoc)*        (* 全体でちょうど 1 つの PipelineDoc *)
+YamlDoc       ::= SchemaDoc | PipelineDoc
+SchemaDoc     ::= "schema:" NAME "fields:" FieldMap
+PipelineDoc   ::= "pipeline:" NAME ("description:" STRING)? "steps:" Step+
+
+Step          ::= "transform:" "{" "value:" EXPR ["output:" NAME] "}"
+                 | "tool:"     "{" "name:" STRING ["args:" ArgMap] ["schema:" NAME] ["output:" NAME] "}"
+                 | "shell:"    "{" "command:" ArgValue ["schema:" NAME] ["output:" NAME] "}"
+                 | "agent:"    "{" "prompt:" TPL ["identity:" NAME]
+                                    ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
+                                    ["schema:" NAME] ["output:" NAME] "}"
+                 | "call:"     "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] ["output:" NAME] "}"
+                 | "match:"    "{" "on:" EXPR "cases:" "{" (LABEL ":" MatchTarget)+ "}"
+                                    ["default:" MatchTarget] ["output:" NAME] "}"
+                 | "fold:"     "{" [ListSource] "init:" EXPR "do:" Step "output:" NAME
+                                    ["max_items:" INT] "}"
+                 | "for_each:" "{" [ListSource] ["max_parallel:" INT] "on_error:" OnError
+                                    "do:" Step "collect:" Step ["output:" NAME] "}"
+                 | "parallel:" "{" ["on_error:" OnError] "branches:" "{" (NAME ":" Step)+ "}"
+                                    "collect:" Step ["output:" NAME] "}"
+
+MatchTarget   ::= "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] "}"
+ArgMap        ::= "{" (KEY ":" ArgValue ("," KEY ":" ArgValue)*)? "}"
+ArgValue      ::= LITERAL | "!expr" EXPR
+ListSource    ::= "over:" EXPR | "items:" "[" LITERAL* "]"
+OnError       ::= "continue" | "abort" | "retry(" INT ")"
+FieldMap      ::= "{" (NAME ":" FieldType)+ "}"
+FieldType     ::= "{type: bool}" | "{type: string}" | "{type: number}"
+                 | "{type: enum, values: [" LITERAL+ "]}"
+                 | "{type: list, of:" FieldType "}"
+                 | "{type: object, fields:" FieldMap "}"
+                 | "{type: ref, schema:" NAME "}"
+EXPR          ::= (* 上記の R1 expression 言語を参照 *)
+TPL           ::= (* {ctx.dotted.path} / {pipe} 補間を持つ文字列、値のみ *)
+```
+
+**Hard rules**(これらのいずれかへの違反は parse エラーか実行時のステップ失敗になります — 静かな誤った結果になることは決してありません):
+
+1. `call` の `pipeline:`、`match` の case/`default` の `pipeline:`、そして各 `parallel` ブランチのステップ: `call`/`match` における `pipeline:` ターゲットは常に静的リテラル名です — 実行時の expression では決してありません。実行時に評価される `match.on` が選ぶのは常に case の*ラベル*であり、ターゲット自体ではありません。
+2. `!expr` は `tool`/`shell` の引数を R1 expression としてマークします。それ以外はすべてリテラルで、そのまま渡されます。補間を期待してマークしていない引数の中に `{ctx.x}` と書かないでください — それが機能するのは `agent.prompt`(`TPL`)だけで、そこだけです。
+3. `pass:` は、`call`/`match` の callee が caller のどの named store を見られるかを決める唯一の方法です — callee が必要とするすべての名前を列挙してください。省略された名前は callee から不可視であり、暗黙に継承されることはありません。
+4. `for_each.on_error` は**必須**です — `continue`/`abort`/`retry(n)` を明示的に指定してください。`parallel.on_error` は任意で、デフォルトは `abort` です。
+5. `for_each`/`parallel` のアイテム / ブランチは、他のどのアイテム / ブランチの結果も見ることができません — マージされた集合を見るのは `collect` だけです(`for_each` は順序付きリスト、`parallel` は `{branch_name: result}` マップ)。
+6. `fold.output` は必須です(fold の存在意義は名前付きの累積結果を生成すること)。他のすべてのステップ種別の `output` は任意です。
+7. すべての `agent` ステップは、起動しているセッション自身の envelope 以下に capability を narrowing されます — 起動者が持つより広い `capabilities` 集合を指定しても、それが付与されることはありません。inline(エージェントが生成した、ファイル登録されていない)定義では、`agent` ステップの `identity` は省略するか起動者自身と等しくなければなりません — それ以外の identity を指定すると拒否されます。
+8. `!expr` は `args`/`command` エントリの*値全体*としてのみ有効です — リストやマッピングの値の中にネストすることはできません。
+
+**1 つの規範的な例**(3 つのステップ種別すべて、1 つのプリミティブ、1 つの schema):
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+---
+pipeline: review_and_report
+description: Review a document and summarize the verdict.
+steps:
+  - agent:
+      prompt: "Review {ctx.doc}. Reply with passed (bool) and notes (string)."
+      schema: Review
+      output: review
+  - transform:
+      value: "review.passed and 'OK' or 'NEEDS WORK'"
+      output: verdict
+  - tool:
+      name: shell
+      args: {command: !expr "'echo ' + verdict"}
+      output: shouted
+```

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -2,7 +2,7 @@
 type: reference
 topic: runtime
 audience: [human, agent]
-search_hints: [pipeline DSL, pipeline grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
 ---
 
 # Pipeline DSL reference
@@ -46,6 +46,112 @@ steps:
 `input`, `defaults`, and `refine` are part of the pipeline design's fuller
 grammar but have no runtime yet — a document using them fails to parse with
 an explicit "not yet supported" error rather than being silently ignored.
+
+## Formal grammar
+
+The EBNF below is the **canonical, current** grammar — derived directly from
+`parse_pipeline_dsl` (`src/reyn/core/pipeline/parser.py`), not from an
+earlier design proposal. It covers exactly what the parser accepts today: a
+definition conforming to it parses cleanly; a violation is rejected. Mapping
+keys are unordered in YAML — the linear order below is for readability, not
+a positional requirement. `NAME` is a bare identifier-like string; `EXPR` is
+an [R1 expression](#the-r1-expression-language) source string; `TPL` is an
+`agent.prompt` template string (`{ctx.dotted.path}` / `{pipe}` interpolation,
+not R1).
+
+```ebnf
+Document      ::= YamlDoc ("---" YamlDoc)*        (* exactly one PipelineDoc across the whole text *)
+YamlDoc       ::= SchemaDoc | PipelineDoc
+
+SchemaDoc     ::= "schema:" NAME "fields:" FieldMap
+PipelineDoc   ::= "pipeline:" NAME
+                  ("description:" STRING)?
+                  "steps:" Step+
+
+Step          ::= "transform:" TransformBody
+                 | "tool:"      ToolBody
+                 | "shell:"     ShellBody
+                 | "agent:"     AgentBody
+                 | "call:"      CallBody
+                 | "match:"     MatchBody
+                 | "fold:"      FoldBody
+                 | "for_each:"  ForEachBody
+                 | "parallel:"  ParallelBody
+
+TransformBody ::= "{" "value:" EXPR ["output:" NAME] "}"
+
+ToolBody      ::= "{" "name:" STRING
+                      ["args:" ArgMap]
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+ArgMap        ::= "{" (KEY ":" ArgValue ("," KEY ":" ArgValue)*)? "}"
+ArgValue      ::= LITERAL | "!expr" EXPR        (* !expr only as the WHOLE value, never nested *)
+
+ShellBody     ::= "{" "command:" ArgValue
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+
+AgentBody     ::= "{" "prompt:" TPL
+                      ["identity:" NAME]
+                      ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
+                      ["schema:" NAME]
+                      ["output:" NAME] "}"
+
+CallBody      ::= "{" "pipeline:" NAME            (* static literal, never EXPR *)
+                      ["pass:" "[" NAME* "]"]
+                      ["output:" NAME] "}"
+
+MatchBody     ::= "{" "on:" EXPR
+                      "cases:" "{" (LABEL ":" MatchTarget)+ "}"
+                      ["default:" MatchTarget]
+                      ["output:" NAME] "}"
+MatchTarget   ::= "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] "}"
+
+FoldBody      ::= "{" [ListSource]
+                      "init:" EXPR
+                      "do:" Step
+                      "output:" NAME              (* required, unlike call's *)
+                      ["max_items:" INT] "}"
+
+ForEachBody   ::= "{" [ListSource]
+                      ["max_parallel:" INT]
+                      "on_error:" OnError          (* required — no default *)
+                      "do:" Step
+                      "collect:" Step
+                      ["output:" NAME] "}"
+
+ParallelBody  ::= "{" ["on_error:" OnError]        (* optional — defaults to "abort" *)
+                      "branches:" "{" (NAME ":" Step)+ "}"
+                      "collect:" Step
+                      ["output:" NAME] "}"
+
+ListSource    ::= "over:" EXPR | "items:" "[" LITERAL* "]"   (* mutually exclusive *)
+OnError       ::= "continue" | "abort" | "retry(" INT ")"
+
+FieldMap      ::= "{" (NAME ":" FieldType)+ "}"
+FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
+                 | "{" "type:" "enum" "values:" "[" LITERAL+ "]" "}"
+                 | "{" "type:" "list" "of:" FieldType "}"     (* 'of' non-list; no lists-of-lists *)
+                 | "{" "type:" "object" "fields:" FieldMap "}"
+                 | "{" "type:" "ref" "schema:" NAME "}"
+```
+
+Structural invariants the grammar alone doesn't show (enforced by the parser
+and executor, not just documented convention):
+
+- A `call`/`match`/`fold`'s `do`/`for_each`'s `do`/`collect`/`parallel`'s
+  branch/`collect` is a **full nested `Step`** — any step kind, including
+  another compositional primitive.
+- `call`, `match`'s case/`default`, and `parallel`'s `branches` all name a
+  **static literal** pipeline/step target — never a runtime expression. Only
+  `match.on` and `for_each`/`fold`'s `over` are runtime-evaluated.
+- `pass:` is the *only* channel a `call`/`match` callee's context is built
+  from — a caller's named store not listed there is invisible to the callee.
+- `for_each`/`parallel` branches each get an **isolated copy** of the outer
+  named stores — no sibling communication between concurrent items/branches.
+- `!expr` is the *only* way a `tool`/`shell` argument becomes a resolved
+  expression instead of a literal — nesting it inside a list/mapping value is
+  a parse error, not a silent no-op.
 
 ## Step kinds
 
@@ -284,6 +390,35 @@ not a code-execution sandbox. It has no recursion, no user-defined functions,
 no unbounded loops (every combinator iterates one already-materialized list
 exactly once), no IO, and no `eval`/`exec`.
 
+```ebnf
+expr           ::= or_expr
+or_expr        ::= and_expr ("or" and_expr)*
+and_expr       ::= not_expr ("and" not_expr)*
+not_expr       ::= "not" not_expr | comparison
+comparison     ::= additive (cmp_op additive)?
+additive       ::= multiplicative (("+" | "-") multiplicative)*
+multiplicative ::= unary (("*" | "/") unary)*
+unary          ::= "-" unary | primary
+primary        ::= NUMBER | STRING | "true" | "false" | "null"
+                  | "(" expr ")"
+                  | "[" (expr ("," expr)*)? "]"
+                  | "{" (IDENT ":" expr ("," IDENT ":" expr)*)? "}"
+                  | combinator
+                  | path
+combinator     ::= "map" "(" expr "," lambda ")"
+                  | "filter" "(" expr "," lambda ")"
+                  | "all" "(" expr "," lambda ")"
+                  | "any" "(" expr "," lambda ")"
+                  | "find" "(" expr "," lambda ")"
+                  | "count" "(" expr ")"
+                  | "sum" "(" expr ")"
+                  | "join" "(" expr "," expr ")"
+                  | "get" "(" expr "," STRING ("," expr)? ")"
+lambda         ::= IDENT "->" expr        (* only valid as a combinator's own argument *)
+path           ::= IDENT ("." IDENT)*
+cmp_op         ::= "==" | "!=" | "<" | ">" | "<=" | ">="
+```
+
 **Literals**: `true` / `false` / `null`, integers, floats, single- or
 double-quoted strings.
 
@@ -444,3 +579,103 @@ launching a pipeline (any of the four tools above) sits on the same
 `HIGH`-severity, spawn-adjacent capability floor as delegating to another
 agent. A context narrowed by the untrusted-content floor or an unbound
 delegate's floor cannot launch a pipeline, registered or inline.
+
+## Grammar (for generation)
+
+A compact, self-contained block for an agent authoring a pipeline definition
+at run time (e.g. for `run_pipeline_inline`) — the grammar plus the rules
+that don't fall out of the grammar alone, plus one canonical example. This
+section stands on its own; it does not assume the prose above has been read.
+
+**Grammar** — same EBNF as [Formal grammar](#formal-grammar) above, repeated
+here for convenience:
+
+```ebnf
+Document      ::= YamlDoc ("---" YamlDoc)*        (* exactly one PipelineDoc total *)
+YamlDoc       ::= SchemaDoc | PipelineDoc
+SchemaDoc     ::= "schema:" NAME "fields:" FieldMap
+PipelineDoc   ::= "pipeline:" NAME ("description:" STRING)? "steps:" Step+
+
+Step          ::= "transform:" "{" "value:" EXPR ["output:" NAME] "}"
+                 | "tool:"     "{" "name:" STRING ["args:" ArgMap] ["schema:" NAME] ["output:" NAME] "}"
+                 | "shell:"    "{" "command:" ArgValue ["schema:" NAME] ["output:" NAME] "}"
+                 | "agent:"    "{" "prompt:" TPL ["identity:" NAME]
+                                    ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
+                                    ["schema:" NAME] ["output:" NAME] "}"
+                 | "call:"     "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] ["output:" NAME] "}"
+                 | "match:"    "{" "on:" EXPR "cases:" "{" (LABEL ":" MatchTarget)+ "}"
+                                    ["default:" MatchTarget] ["output:" NAME] "}"
+                 | "fold:"     "{" [ListSource] "init:" EXPR "do:" Step "output:" NAME
+                                    ["max_items:" INT] "}"
+                 | "for_each:" "{" [ListSource] ["max_parallel:" INT] "on_error:" OnError
+                                    "do:" Step "collect:" Step ["output:" NAME] "}"
+                 | "parallel:" "{" ["on_error:" OnError] "branches:" "{" (NAME ":" Step)+ "}"
+                                    "collect:" Step ["output:" NAME] "}"
+
+MatchTarget   ::= "{" "pipeline:" NAME ["pass:" "[" NAME* "]"] "}"
+ArgMap        ::= "{" (KEY ":" ArgValue ("," KEY ":" ArgValue)*)? "}"
+ArgValue      ::= LITERAL | "!expr" EXPR
+ListSource    ::= "over:" EXPR | "items:" "[" LITERAL* "]"
+OnError       ::= "continue" | "abort" | "retry(" INT ")"
+FieldMap      ::= "{" (NAME ":" FieldType)+ "}"
+FieldType     ::= "{type: bool}" | "{type: string}" | "{type: number}"
+                 | "{type: enum, values: [" LITERAL+ "]}"
+                 | "{type: list, of:" FieldType "}"
+                 | "{type: object, fields:" FieldMap "}"
+                 | "{type: ref, schema:" NAME "}"
+EXPR          ::= (* see The R1 expression language above *)
+TPL           ::= (* a string with {ctx.dotted.path} / {pipe} interpolation, values only *)
+```
+
+**Hard rules** (violating any of these is either a parse error or a
+run-time step failure — never a silent wrong result):
+
+1. `call`'s `pipeline:`, `match`'s case/`default` `pipeline:`, and every
+   `parallel` branch's step: only `pipeline:` targets in `call`/`match` are
+   ever a static literal name — never an expression. The runtime-evaluated
+   `match.on` only ever selects a case *label*, never a target directly.
+2. `!expr` marks a `tool`/`shell` argument as an R1 expression; everything
+   else is a literal, passed through untouched. Do not write `{ctx.x}`
+   inside an unmarked argument expecting interpolation — that only works
+   for `agent.prompt` (`TPL`), and only there.
+3. `pass:` is the only way a `call`/`match` callee sees any of the caller's
+   named stores — list every name the callee needs. An omitted name is
+   invisible to the callee, not silently inherited.
+4. `for_each.on_error` is **required** — state `continue`/`abort`/`retry(n)`
+   explicitly. `parallel.on_error` is optional and defaults to `abort`.
+5. A `for_each`/`parallel` item or branch cannot see any other item's or
+   branch's result — only `collect` sees the merged set (an ordered list for
+   `for_each`, a `{branch_name: result}` map for `parallel`).
+6. `fold.output` is required (a fold's entire point is a named accumulated
+   result); every other step kind's `output` is optional.
+7. Every `agent` step is capability-narrowed to at most the invoking
+   session's own envelope — naming a wider `capabilities` set than the
+   invoker has does not grant it. In an inline (agent-generated, not
+   file-registered) definition, an `agent` step's `identity` must be omitted
+   or equal to the invoker's own — naming any other identity is rejected.
+8. `!expr` may only be the *entire* value of an `args`/`command` entry —
+   never nested inside a list or mapping value.
+
+**One canonical example** (all three step kinds, one primitive, one schema):
+
+```yaml
+schema: Review
+fields:
+  passed: {type: bool}
+  notes: {type: string}
+---
+pipeline: review_and_report
+description: Review a document and summarize the verdict.
+steps:
+  - agent:
+      prompt: "Review {ctx.doc}. Reply with passed (bool) and notes (string)."
+      schema: Review
+      output: review
+  - transform:
+      value: "review.passed and 'OK' or 'NEEDS WORK'"
+      output: verdict
+  - tool:
+      name: shell
+      args: {command: !expr "'echo ' + verdict"}
+      output: shouted
+```


### PR DESCRIPTION
**[docs-maintainer]** — Owner follow-up on the pipeline docs (#2586): adds a canonical, formal DSL grammar to `pipeline-dsl.md`, authored from the impl rather than the (drifted) design-proposal Appendix B.

## Summary
- **"Formal grammar" section** — EBNF for the document/step/primitive/schema productions, derived directly from `src/reyn/core/pipeline/parser.py`'s `_STEP_PARSERS` / `_*_KEYS` frozensets, plus a "structural invariants" list for what the grammar alone doesn't show (static-literal targets, `pass:` isolation, `!expr` whole-value-only).
- **R1 expression EBNF** — added inline in the existing "The R1 expression language" section, derived from `expr.py`'s recursive-descent parser.
- **"Grammar (for generation)" section** — a compact, self-contained block (grammar + 8 hard rules + one worked example) meant to be shown directly to an agent authoring an ad-hoc `run_pipeline_inline` definition.
- Both new sections + the R1 EBNF mirrored to `.ja.md`.

## Verified drifts (owner-flagged + additional ones found during verification)
- `for_each.on_error` is **required**, no default; `parallel.on_error` is **optional**, defaults to `abort` — these diverge and the grammar shows it.
- `!expr` YAML tag is the sole literal-vs-expression marker for `tool`/`shell` args — not in the original Appendix B model (which used template-string interpolation for all args).
- `pipeline:` documents carry an authoritative declared `name` (`Pipeline.name`, #2575) for `call`/`match` resolution + registration.
- All 5 primitives are final: `_UNSUPPORTED_STEP_KINDS` is now empty in `parser.py`.
- R1 combinator set (`map`/`filter`/`all`/`any`/`find`/`count`/`sum`/`join`/`get`) matches `expr.py`'s `COMBINATOR_NAMES` exactly.
- Nested schema grammar (`schema.py`): `list.of` may not itself be `list` (no lists-of-lists), enforced at registration.

## Test plan
- [x] `mkdocs build --strict` (from `.mkdocs/`) — exit 0. Verified every new anchor (`#formal-grammar`, `#grammar-for-generation`, ja headings) against the actual generated `id=` attributes in the built HTML on both the EN and JA pages.
- [x] `ruff check src tests` — all checks passed (no src changes).
- [x] Manual: every EBNF production cross-checked one-for-one against `parser.py`'s step-body parsers (`_parse_call_step`, `_parse_match_step`, `_parse_fold_step`, `_parse_for_each_step`, `_parse_parallel_step`) and their `_*_KEYS` frozensets.

Ping for co-vet (grammar-vs-parser doc-mirror).