### PR TITLE
fix(#2588): propagate attached-caller Ctrl-C to the sync pipeline driver-session

### DIFF
--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -42,9 +42,15 @@ because no registry ever reached the executor):
 - IS-6 attached run: the driver threads THIS session's ``EventLog`` as the
   executor's ``events`` sink (``pipeline_step_started`` / ``_completed`` per
   step — the emit half of the seam an attached caller / the TUI subscribes to)
-  and its own ``is_cancel_requested`` as the executor's ``cancel_check``. A
-  Ctrl-C reaching ``Session.cancel_inflight`` → ``request_cancel`` is observed
-  at the next step boundary, raising ``PipelineCancelled``: the driver writes a
+  and its own ``is_cancel_requested`` as the executor's ``cancel_check``, polled
+  at each step boundary. #2588: a Ctrl-C hits ``cancel_inflight`` on the
+  ATTACHED CALLER session (a DIFFERENT session than this driver-session), which
+  by itself cancels only the caller's own turn-driver. ``run_pipeline_attached``
+  bridges the gap: for the duration of the attached pump it registers THIS
+  driver's ``request_cancel`` as a cancel-forward on the caller session (via
+  ``Session.register_cancel_forward``), so the caller's ``cancel_inflight`` also
+  flips this driver's ``_cancel_requested``. The executor then observes it at
+  the next step boundary and raises ``PipelineCancelled``: the driver writes a
   TERMINAL ``cancelled`` marker (so the recovery scan never resurrects an
   intentionally-cancelled run) while LEAVING the R4 generation snapshots on
   disk (abort-now, resume-later — R6). Cancel only reaches a sync/attached run
@@ -254,9 +260,12 @@ class PipelineExecutorDriver:
         return self._cancel_requested
 
     def request_cancel(self) -> None:
-        """Record a cancel request (``Session.cancel_inflight`` → here on Ctrl-C).
-        The executor observes it at the next step boundary via
-        ``is_cancel_requested`` and raises ``PipelineCancelled``."""
+        """Record a cancel request. #2588: reached from the ATTACHED CALLER
+        session's ``cancel_inflight`` — ``run_pipeline_attached`` registers this
+        method as a cancel-forward on that caller session for the attached run's
+        duration, so a Ctrl-C on the caller flips THIS driver-session's flag. The
+        executor observes it at the next step boundary via ``is_cancel_requested``
+        and raises ``PipelineCancelled``."""
         self._cancel_requested = True
 
     async def _check_cap(self, user_text: str) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1778,6 +1778,17 @@ class Session:
             )
         )
 
+        # #2588: additional cancel-forward targets. ``cancel_inflight`` always
+        # cancels this session's OWN ``_loop_driver`` (the turn); it ALSO fires
+        # ``request_cancel`` on every callable registered here. Populated only
+        # transiently — e.g. ``run_pipeline_attached`` registers the spawned
+        # pipeline driver-session's ``request_cancel`` for the duration of a sync
+        # attached run so a Ctrl-C on THIS (the attached caller) session reaches
+        # the driver-session's cooperative cancel flag (the executor's
+        # step-boundary ``cancel_check``). Empty for every ordinary turn, so the
+        # normal turn-cancel path is byte-identical when nothing is registered.
+        self._cancel_forward_targets: list[Callable[[], None]] = []
+
         # session.py refactor PR-4 (FP-0019 series final): ChainTimeoutGlue owns
         # chain timeout lifecycle.
         from reyn.runtime.services.chain_timeout_glue import ChainTimeoutGlue
@@ -2125,9 +2136,40 @@ class Session:
         already in flight completes before the cancel takes effect (subprocess
         kill is a follow-up scope). Any spawned tasks are cancelled immediately
         via asyncio task cancellation (existing behaviour, preserved here).
+
+        #2588: after cancelling this session's own turn, forward the cancel to
+        every registered cancel-forward target (see ``register_cancel_forward``).
+        No-op for an ordinary turn (the list is empty), so the normal turn-cancel
+        path is unchanged; the one live user is ``run_pipeline_attached``, which
+        registers the spawned pipeline driver-session's ``request_cancel`` for the
+        duration of a sync attached run so a Ctrl-C here reaches the driver.
         """
         self._loop_driver.request_cancel()
+        for forward in list(self._cancel_forward_targets):
+            forward()
         return "✗ cancelled turn"
+
+    def register_cancel_forward(self, forward: "Callable[[], None]") -> "Callable[[], None]":
+        """#2588: register ``forward`` to also fire on the next ``cancel_inflight``.
+
+        Returns an idempotent unregister closure — the caller MUST invoke it
+        (try/finally) when the forward is no longer relevant so it does not leak
+        past its window. Used by ``run_pipeline_attached``: while the caller is
+        attached-and-pumping a spawned pipeline driver-session, register that
+        driver's ``request_cancel`` so a Ctrl-C on THIS (the attached caller)
+        session — which only cancels THIS session's own ``_loop_driver`` — also
+        reaches the driver-session's cooperative cancel flag (the executor polls
+        it at each step boundary). Unregistered when the attached run ends, so
+        the bridge never fires for a later, unrelated turn."""
+        self._cancel_forward_targets.append(forward)
+
+        def _unregister() -> None:
+            try:
+                self._cancel_forward_targets.remove(forward)
+            except ValueError:
+                pass  # already removed — idempotent
+
+        return _unregister
 
     async def await_quiescent(self) -> None:
         """Block until every append-capable task has settled (ADR-0038 Stage 1c).

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -393,6 +393,21 @@ async def run_pipeline_attached(
     ``notify_reply=True`` → the result then degrades to async inbox delivery to
     this same caller. One reply address serves both paths; no new plumbing.
 
+    **Cancel bridge (#2588)**: because the caller drives the driver-session inline
+    via ``MessageBus.request`` (which is cancel-agnostic — it only pumps to
+    quiescence), a Ctrl-C reaching ``cancel_inflight`` on the CALLER session would
+    otherwise only cancel the caller's own turn-driver, never the spawned
+    driver-session's ``PipelineExecutorDriver`` whose ``cancel_check`` the
+    executor polls at each step boundary. Since the reply address IS the caller's
+    own (agent, sid), it resolves (via ``registry.get_session``) to the SAME live
+    Session instance whose ``cancel_inflight`` the Ctrl-C fires; this registers
+    the driver's ``request_cancel`` as a cancel-forward on that caller session for
+    the DURATION of the attached pump (unregistered in a ``finally`` so it never
+    leaks past the run). A Ctrl-C then stops the pipeline at the next step
+    boundary with a terminal ``cancelled`` marker, which ``read_result`` below
+    returns to the caller as ``status="cancelled"``. Best-effort: an unresolvable
+    caller session (should not happen on the attached path) skips the bridge.
+
     **TUI bridge marker (#2570)**: the driver-session's ``pipeline_step_*``
     events land on the DRIVER's own ``EventLog`` — a session distinct from the
     human-attached caller, which the TUI has no signal to bridge-subscribe to.
@@ -448,14 +463,40 @@ async def run_pipeline_attached(
         )
     run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
 
+    # #2588: bridge the attached caller's Ctrl-C to the DRIVER-session. The
+    # caller drives the driver-session inline via ``MessageBus.request`` below,
+    # but a Ctrl-C reaches ``Session.cancel_inflight`` on the CALLER session and
+    # (pre-fix) only cancelled the caller's OWN RouterLoopDriver — never the
+    # spawned driver-session's ``PipelineExecutorDriver`` whose ``cancel_check``
+    # the executor polls at each step boundary. The reply address is the caller's
+    # own (agent, sid) by construction (see this function's contract), so it
+    # resolves to the SAME live Session instance whose ``cancel_inflight`` the
+    # human Ctrl-C fires. Register the driver's ``request_cancel`` as a
+    # cancel-forward for the DURATION of the attached pump, unregistered in
+    # ``finally`` so it never leaks past the run. Best-effort: if the caller
+    # session is not resolvable (should not happen on the attached path — the
+    # caller is live), skip the bridge (degrades to the pre-fix behavior, never
+    # blocks the run).
+    driver = getattr(session, "_loop_driver", None)
+    caller_session = registry.get_session(reply_to_agent, reply_to_sid)
+    unregister_cancel: "Any | None" = None
+    if caller_session is not None and driver is not None:
+        register = getattr(caller_session, "register_cancel_forward", None)
+        if callable(register):
+            unregister_cancel = register(driver.request_cancel)
+
     bus = MessageBus()
-    await bus.request(
-        session,
-        kind="user",
-        payload={"text": "", "chain_id": uuid.uuid4().hex},  # the D案 run nudge
-        reply_to=SystemRef(),
-        timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,
-    )
+    try:
+        await bus.request(
+            session,
+            kind="user",
+            payload={"text": "", "chain_id": uuid.uuid4().hex},  # the D案 run nudge
+            reply_to=SystemRef(),
+            timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,
+        )
+    finally:
+        if unregister_cancel is not None:
+            unregister_cancel()
 
     marker = read_result(run_dir)
     if marker is not None:

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -85,9 +85,13 @@ before ``run_pipeline_attached`` / ``start_pipeline_run`` is called).
     to the driver_sid's events for the run's duration. The async handlers
     (``_handle_run_pipeline_async`` / ``_handle_run_pipeline_inline_async``) have
     no attached live viewer and never pass these — no marker.
-    Ctrl-C (``Session.cancel_inflight`` → the driver's ``request_cancel``) stops
-    the run cooperatively at the next step BOUNDARY, leaving a resumable R4
-    journal under a terminal ``cancelled`` marker.
+    Ctrl-C stops the run cooperatively at the next step BOUNDARY, leaving a
+    resumable R4 journal under a terminal ``cancelled`` marker. #2588: the
+    Ctrl-C hits ``cancel_inflight`` on the ATTACHED CALLER session, not the
+    spawned driver-session; ``run_pipeline_attached`` bridges it by registering
+    the driver's ``request_cancel`` as a cancel-forward on the caller for the
+    attached run's duration (``Session.register_cancel_forward``), so the
+    caller's Ctrl-C reaches the driver's step-boundary ``cancel_check``.
   - **Real tool-step dispatch, not a stub.** A pipeline ``ToolStep``'s
     ``tool_dispatch`` is wired through the SAME routing seam
     ``invoke_action`` uses (``universal_dispatch.resolve_invoke_action`` +

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -421,6 +421,101 @@ async def test_driver_cancel_writes_terminal_marker_recovery_skips(
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1", "s2"]
 
 
+# ── §3b: the ATTACHED CALLER's Ctrl-C reaches the driver (#2588) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_attached_caller_cancel_inflight_stops_pipeline_at_boundary(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: #2588 — a Ctrl-C on the ATTACHED CALLER session drives the cancel
+    through the CALLER's public ``cancel_inflight`` seam (NOT a direct
+    ``driver.request_cancel``), and it must reach the spawned driver-session so
+    the pipeline STOPS at the next step boundary: step 1 (index 1) never runs and
+    the caller collects ``status="cancelled"`` inline. This is the end-to-end
+    caller→driver bridge IS-6 lacked. RED against pre-#2588 main — there the
+    caller's ``cancel_inflight`` only cancelled the caller's OWN turn-driver, the
+    driver-session never saw it, both steps ran, and the result was ``ok``.
+
+    A real gate (``asyncio.Event``) makes step 0 an AWAITING step so a concurrent
+    task can fire the caller cancel WHILE step 0 is in flight and the event loop
+    is free — the same shape a human Ctrl-C takes against a running pipeline. No
+    mock: real Session/AgentRegistry/StateLog/MessageBus/PipelineExecutor and a
+    real gated tool; the cancel is driven only through ``Session.cancel_inflight``.
+    """
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+
+    step0_running = asyncio.Event()
+    release_step0 = asyncio.Event()
+
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        tag = str(args.get("tag", "x"))
+        p = Path(out_file)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(tag + "\n")
+        if tag == "s0":  # gate step 0 so the loop is free for a concurrent cancel
+            step0_running.set()
+            await release_step0.wait()
+        return {"tag": tag}
+
+    tool = ToolDefinition(
+        name="is6_step",
+        description="#2588 test: a gated step tool (real side effect + await gate).",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow", phase="allow"),
+        handler=_handler, category="io", purity="side_effect",
+    )
+    base = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+    reg = _agent_registry(tmp_path, state_log, None)
+    caller = reg.get_or_load("worker")  # (worker, main) — the reply/caller address
+
+    run_task = asyncio.ensure_future(run_pipeline_attached(
+        reg,
+        pipeline=_steps(2),
+        pipeline_name="p",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+    ))
+    try:
+        # Wait until step 0 is really in flight (started + awaiting the gate).
+        assert await _wait_for(step0_running.is_set)
+        # THE BUG UNDER TEST: cancel via the CALLER session's public seam — the
+        # SAME instance run_pipeline_attached resolves as the reply address. Not
+        # a direct driver.request_cancel.
+        assert caller is reg.get_session("worker", "main")  # same live instance
+        await caller.cancel_inflight()
+        # Release step 0 → the executor reaches the step-1 boundary and observes
+        # the now-forwarded cancel.
+        release_step0.set()
+        outcome = await run_task
+    finally:
+        release_step0.set()  # never wedge the loop if an assertion above fired
+
+    assert outcome["status"] == "cancelled"
+    # Step 1 (index 1) never executed — only step 0's line is present.
+    await state_log.flush()
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["s0"]
+    # Terminal cancelled marker on disk (so recovery won't resurrect it).
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", outcome["run_id"])
+    marker = _result_json(run_dir)
+    assert marker is not None and marker["status"] == "cancelled"
+
+
 # ── §4: crash while attached → recovery re-wakes + delivers via inbox ────────
 
 


### PR DESCRIPTION
**[lead-sonnet]** — Fixes #2588: a Ctrl-C during a sync-attached `run_pipeline` did NOT cancel the pipeline (a real IS-6 gap found by live dogfood).

## Root cause
A sync `run_pipeline` spawns a driver-session and the caller ATTACHES via `MessageBus.request` (`session_api.run_pipeline_attached`). IS-6 wired the executor's step-boundary `cancel_check` to the driver-session's `PipelineExecutorDriver.request_cancel` — but **nothing ever called `request_cancel` on that driver from the attached caller's Ctrl-C**. `Session.cancel_inflight()` only cancels the CALLER's own `RouterLoopDriver`; `MessageBus.request` is cancel-agnostic (pumps to quiescence). So both steps ran to completion, status `ok`. The `PipelineExecutorDriver` docstring CLAIMED this propagation worked — it was aspirational; the wiring was missing.

## The bridge (purely caller→driver; no executor / MessageBus change)
- `Session` gains `_cancel_forward_targets` + `register_cancel_forward(forward) -> unregister`. `cancel_inflight` fires every registered forward *after* cancelling its own turn-driver. **No-op / byte-identical for ordinary turns** — the list is empty, so the normal turn-cancel path is untouched.
- `run_pipeline_attached` resolves the caller session from the reply address (the caller's own agent/sid by construction — the SAME live instance whose `cancel_inflight` the human Ctrl-C fires) and registers the spawned driver's `request_cancel` as a cancel-forward **for the duration of the attached pump**, unregistered in a `finally` so it never leaks past the run. Best-effort: an unresolvable caller (should not happen on the attached path) skips the bridge and degrades to pre-fix behavior.

Composition: caller Ctrl-C -> forwarded `driver.request_cancel()` -> next `PipelineExecutor` step boundary raises `PipelineCancelled` -> driver writes terminal `cancelled` marker -> driver-session inbox drains -> `MessageBus.request` quiescence trips -> `run_pipeline_attached` reads the marker and returns `status="cancelled"` inline. Composes cleanly with the existing crash/timeout fallback (forward is unregistered before those paths matter).

Per reviewer caveat: the forward registers on the identical live Session instance the registry holds (the single live-session container), and the new test asserts `caller is reg.get_session(...)` and drives cancel on that same object — so a wrong-instance regression is caught.

## Test (the one IS-6 should have had)
`test_attached_caller_cancel_inflight_stops_pipeline_at_boundary` — a REAL sync-attached run (real Session/AgentRegistry/StateLog/MessageBus/PipelineExecutor + a real gated tool; no mocks) cancelled via the CALLER's `cancel_inflight` (NOT a direct `driver.request_cancel`) while step 0 is in flight. Asserts: `status="cancelled"`, step 1 (index 1) never runs (`out == ["s0"]`), terminal `cancelled` marker on disk. **Verified RED against pre-#2588 main** (stashed the source edits → test failed: both steps ran, status ok) and green with the fix. Also fixes the aspirational docstrings (`pipeline_executor_driver.py`, `pipeline_verbs.py`, `session_api.py`) to describe the real bridge.

## Test plan
- [x] 4 CI gates locally: ruff (pass), tier audit `--strict` (9/9 OK), module-docstrings (OK), pytest on touched areas + all cancel/session invariants in isolation (`test_turn_cancel_1468`, `test_subprocess_cancel_1470`, `test_execution_driver_seam`, rewind/session-drop — 32 passed / 2 skipped; `-k "pipeline or session or cancel"` — 704 passed).
- [x] Falsification: new test RED on pre-fix source, GREEN with fix.
- [x] Full suite run: 7187 passed; the 10 failures + 10 errors are pre-existing optional-dep `ModuleNotFoundError` in unrelated MCP/web tests (confirmed identical on clean base with my changes stashed), not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)