### PR TITLE
fix(#2593): implement shell step via sandboxed_exec (pipe-data→stdin, stdout→output) + exec floor parity

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -148,7 +148,8 @@ Executes `argv` under a declared `SandboxPolicy` via the OS's selected `SandboxB
   "write_paths": ["{{workspace}}/output"],
   "allow_subprocess": false,
   "env_passthrough": ["PATH"],
-  "timeout_seconds": 60
+  "timeout_seconds": 60,
+  "stdin": null
 }
 ```
 
@@ -160,6 +161,7 @@ Fields:
 - `allow_subprocess` (optional, default `false`) — may spawn children.
 - `env_passthrough` (optional) — env-var names that pass through (others are stripped).
 - `timeout_seconds` (optional, default `60`) — wall-clock cap.
+- `stdin` (optional, default `None`) — bytes written to the process's stdin, if any (#2593: the pipeline DSL's `shell` step threads the previous step's pipe-data here as JSON).
 
 **Backend selection**: `get_default_backend()` chooses per platform. On macOS < 26, `SeatbeltBackend` (sandbox-exec SBPL). On Linux ≥ 5.13 with the `sandbox-linux` extra installed, `LandlockBackend` (+ optional seccomp-BPF stack). On other platforms or when the chosen backend is unavailable, falls back to `NoopBackend` (audit-only, no enforcement) — emits a one-line WARN on first use. Override via `reyn.yaml` `sandbox.backend` (`auto` | `seatbelt` | `landlock` | `noop`) and `sandbox.on_unsupported` (`warn` | `error` | `ignore`).
 

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -88,7 +88,7 @@ async def handle(
     )
 
     result = await backend.run(
-        list(op.argv), policy, cwd=cwd, cancel_event=ctx.cancel_event,
+        list(op.argv), policy, cwd=cwd, cancel_event=ctx.cancel_event, stdin=op.stdin,
     )
 
     stdout_text = result.stdout.decode("utf-8", errors="replace")

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -260,7 +260,7 @@ def _reject_unknown_keys(
 
 _TRANSFORM_KEYS = frozenset({"value", "output"})
 _TOOL_KEYS = frozenset({"name", "args", "schema", "output"})
-_SHELL_KEYS = frozenset({"command", "schema", "output"})
+_SHELL_KEYS = frozenset({"command", "schema", "output", "timeout"})
 _AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "output"})
 _CALL_KEYS = frozenset({"pipeline", "pass", "output"})
 _MATCH_KEYS = frozenset({"on", "cases", "default", "output"})
@@ -296,6 +296,14 @@ def _parse_tool_step(body: "dict[str, Any]") -> ToolStep:
 
 
 def _parse_shell_step(body: "dict[str, Any]") -> ToolStep:
+    """``shell`` is tool-step sugar (#2593): the command is STATIC (a literal or
+    ``!expr``-tagged value, same rule as any tool ``args`` entry — see the module
+    docstring); the previous step's pipe-data is threaded to the process STDIN via
+    an ``ExprRef("pipe")`` arg, resolved for free by the executor's existing
+    ``ToolStep`` arg-resolution (``evaluate_expr("pipe", context)`` against the
+    ``{"ctx": ..., "pipe": pipe_data}`` context every step already receives) — no
+    executor change needed. STDOUT becomes the step's output/pipe-data, optionally
+    ``verify: schema``-checked, same as any other tool step."""
     _reject_unknown_keys(body, _SHELL_KEYS, where="shell step")
     if "command" not in body:
         _fail("shell step: missing required field 'command'")
@@ -303,8 +311,14 @@ def _parse_shell_step(body: "dict[str, Any]") -> ToolStep:
     schema = body.get("schema")
     if schema is not None and not isinstance(schema, str):
         _fail(f"shell step 'schema': expected a schema-name string, got {type(schema).__name__}")
+    args: "dict[str, Any]" = {"command": command, "stdin_pipe": ExprRef("pipe")}
+    if "timeout" in body:
+        timeout = body["timeout"]
+        if not isinstance(timeout, int) or isinstance(timeout, bool):
+            _fail(f"shell step 'timeout': expected an integer, got {type(timeout).__name__}")
+        args["timeout"] = timeout
     return ToolStep(
-        name="shell", args={"command": command}, output=body.get("output"), schema=schema,
+        name="shell", args=args, output=body.get("output"), schema=schema,
     )
 
 

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -147,6 +147,7 @@ class SandboxedExecIROp(BaseModel):
     allow_subprocess: bool = False                       # may spawn children
     env_passthrough: list[str] = Field(default_factory=list)  # env-var allowlist
     timeout_seconds: int = 60                            # wall-clock cap
+    stdin: bytes | None = None                           # #2593: bytes written to the process's stdin, if any
 
 
 

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -234,8 +234,10 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
     }),
     # re-delegation — no spawning peers from untrusted content
     "re-delegation": frozenset({"multi_agent__delegate"}),
-    # code execution
-    "exec": frozenset({"exec__sandboxed_exec"}),
+    # code execution. #2593: `shell` (the pipeline DSL `shell` step's sugar
+    # tool — thin sugar over sandboxed_exec, same subprocess-exec threat
+    # surface) joins the same class for untrusted/delegate deny-parity.
+    "exec": frozenset({"exec__sandboxed_exec", "shell"}),
     # MCP install — no installing servers from untrusted content
     "mcp-install": frozenset({
         "mcp__install_registry", "mcp__install_package", "mcp__install_local",
@@ -291,7 +293,9 @@ _FLOORED_QUALIFIED: "dict[str, frozenset[str]]" = {
 # opposite direction). Invariant (enforced by tests/test_2111_floor_alias_completeness):
 # every name in ``_FLOORED_QUALIFIED`` either unwraps to a bare alias OR is listed here.
 _FLOORED_BARE_ONLY: "frozenset[str]" = frozenset(
-    {"session_spawn", "agent_spawn", "topology_create"}
+    # #2593: `shell` is a bare-registry tool with no invoke_action qualified
+    # route (unlike `exec__sandboxed_exec`), same shape as the spawn trio.
+    {"session_spawn", "agent_spawn", "topology_create", "shell"}
 )
 
 

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -101,6 +101,7 @@ def get_default_registry() -> ToolRegistry:
     )
     from reyn.tools.sandboxed_exec import SANDBOXED_EXEC
     from reyn.tools.session_spawn import SESSION_SPAWN
+    from reyn.tools.shell import SHELL
     from reyn.tools.skill_verbs import SKILL_INSTALL_LOCAL, SKILL_INSTALL_SOURCE
     from reyn.tools.topology_create import TOPOLOGY_CREATE
 
@@ -164,6 +165,12 @@ def get_default_registry() -> ToolRegistry:
     # "gates.router=deny" comment alongside the now-removed `shell` op (the only
     # true router=deny here was shell / ask_user). ASK_USER=router="deny".
     registry.register(SANDBOXED_EXEC)
+    # #2593: pipeline DSL `shell` step sugar — a bare-registry tool (no
+    # invoke_action qualified route; a pipeline `tool` step resolves it by
+    # bare name via ``pipeline_verbs._make_tool_dispatch``'s bare-lookup
+    # fallback, same as SANDBOXED_EXEC's own qualified route falls back for
+    # unqualified callers).
+    registry.register(SHELL)
     registry.register(ASK_USER)
     # ── Router-only capabilities (gates.router=allow, gates.phase=deny) ──
     registry.register(DELEGATE_TO_AGENT)

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -48,29 +48,19 @@ _SANDBOXED_EXEC_PARAMETERS: dict[str, Any] = {
 }
 
 
-async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Adapter wrapping op_runtime.sandboxed_exec.handle.
+async def op_context_from_tool_context(ctx: ToolContext) -> Any:
+    """Bridge a (args, ctx) ``ToolContext`` into the legacy ``OpContext`` the
+    ``op_runtime.sandboxed_exec`` handler (and any other op_runtime handler
+    reached this way) expects.
 
-    Bridges between the unified (args, ctx) signature and the
-    existing (op, ctx) signature for the sandboxed_exec handler.
-    Builds a SandboxedExecIROp from args and a legacy OpContext from
-    ToolContext, then delegates to the op_runtime handler.
+    Shared by :func:`_handle` (the ``sandboxed_exec`` tool) and the ``shell``
+    tool (:mod:`reyn.tools.shell`, #2593) — both need the SAME
+    router_state → legacy-OpContext bridge (sandbox_config derivation +
+    op_context_factory-or-minimal-synthesis); duplicating it would let the two
+    surfaces drift on sandbox policy derivation.
     """
     from reyn.core.op_runtime.context import OpContext
-    from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
-    from reyn.schemas.models import SandboxedExecIROp
     from reyn.security.permissions.permissions import PermissionDecl
-
-    # #1339 / sandbox-model completion: the LLM supplies only argv (+ timeout).
-    # The op's policy fields keep their defaults here — the effective sandbox
-    # policy is operator-or-default, resolved onto the OpContext
-    # (ctx.default_sandbox_policy), which the op_runtime handler applies over the
-    # op fields. The LLM cannot set network / fs scope via this tool.
-    op = SandboxedExecIROp(
-        kind="sandboxed_exec",
-        argv=args["argv"],
-        timeout_seconds=int(args.get("timeout_seconds", 60)),
-    )
 
     # Derive sandbox_config from RouterCallerState.sandbox_backend when
     # available, otherwise fall back to None (= op_runtime auto-detects).
@@ -91,12 +81,10 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         # Inject derived sandbox_config so the handler uses the configured backend.
         if sandbox_config is not None:
             legacy_ctx = _with_sandbox_config(legacy_ctx, sandbox_config)
-        return await handle_sandboxed_exec(
-            op=op, ctx=legacy_ctx,
-        )
+        return legacy_ctx
 
     # Minimal synthesis path (= test sites / narrow callers).
-    legacy_ctx = OpContext(
+    return OpContext(
         workspace=ctx.workspace,
         events=ctx.events,
         permission_decl=PermissionDecl(),
@@ -119,6 +107,30 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         parent_run_id=None,
         sandbox_config=sandbox_config,
     )
+
+
+async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Adapter wrapping op_runtime.sandboxed_exec.handle.
+
+    Bridges between the unified (args, ctx) signature and the
+    existing (op, ctx) signature for the sandboxed_exec handler.
+    Builds a SandboxedExecIROp from args and a legacy OpContext from
+    ToolContext, then delegates to the op_runtime handler.
+    """
+    from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
+    from reyn.schemas.models import SandboxedExecIROp
+
+    # #1339 / sandbox-model completion: the LLM supplies only argv (+ timeout).
+    # The op's policy fields keep their defaults here — the effective sandbox
+    # policy is operator-or-default, resolved onto the OpContext
+    # (ctx.default_sandbox_policy), which the op_runtime handler applies over the
+    # op fields. The LLM cannot set network / fs scope via this tool.
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec",
+        argv=args["argv"],
+        timeout_seconds=int(args.get("timeout_seconds", 60)),
+    )
+    legacy_ctx = await op_context_from_tool_context(ctx)
     return await handle_sandboxed_exec(op=op, ctx=legacy_ctx)
 
 

--- a/src/reyn/tools/shell.py
+++ b/src/reyn/tools/shell.py
@@ -1,0 +1,106 @@
+"""``shell`` ToolDefinition — pipeline DSL ``shell`` step sugar (#2593).
+
+The pipeline DSL's ``shell = {command, timeout?, schema?, output?}`` step
+(``reyn.core.pipeline.parser._parse_shell_step``) is tool-step SUGAR: it
+compiles to a ``ToolStep(name="shell", args={"command": ..., "stdin_pipe":
+ExprRef("pipe"), ["timeout": ...]})``. This module is that tool's
+``ToolDefinition`` + handler.
+
+Design (locked, #2593):
+- ``command`` is STATIC (a literal or ``!expr``-resolved value at parse/step
+  time — never re-templated here).
+- the PREVIOUS step's pipe-data is threaded to the process's STDIN, JSON
+  -encoded (so a structured pipe value survives the byte boundary).
+- STDOUT becomes the step's return value (= next step's pipe-data / this
+  step's ``output`` store) — JSON-decoded when it parses (so ``verify:
+  schema``, which requires a ``dict``, can apply to a JSON-emitting shell
+  command), else the raw text — optionally ``verify: schema``-checked by the
+  executor's existing ``ToolStep`` schema-check (unchanged).
+
+This is thin sugar over the EXISTING ``sandboxed_exec`` op — it does not
+reinvent subprocess handling: it builds a ``SandboxedExecIROp`` running
+``/bin/sh -c <command>`` with ``stdin`` set to the JSON-encoded pipe data,
+and delegates to ``reyn.core.op_runtime.sandboxed_exec.handle`` via the SAME
+``ToolContext`` → ``OpContext`` bridge ``reyn.tools.sandboxed_exec._handle``
+uses (:func:`reyn.tools.sandboxed_exec.op_context_from_tool_context`) — same
+sandbox confinement, same policy precedence, same audit events.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates
+
+_SHELL_DESCRIPTION = (
+    "Run a shell command (via sandboxed_exec) whose STDIN receives the "
+    "previous pipeline step's pipe-data JSON-encoded, and whose STDOUT "
+    "becomes this step's output. command: the shell command line "
+    "(argv[0]='/bin/sh', argv[1]='-c'). timeout: wall-clock time limit in "
+    "seconds (default 60). The sandbox policy (network access + filesystem "
+    "scope) is the OPERATOR's, resolved by the OS — it is not chosen here."
+)
+
+_SHELL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "command": {
+            "type": "string",
+            "description": "Shell command line, run as `/bin/sh -c <command>`.",
+        },
+        "stdin_pipe": {
+            "description": "The previous pipeline step's pipe-data (JSON-encoded onto stdin).",
+        },
+        "timeout": {
+            "type": "integer",
+            "description": "Wall-clock time limit in seconds (default 60).",
+        },
+    },
+    "required": ["command"],
+}
+
+
+async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> Any:
+    """Build a ``SandboxedExecIROp`` for ``/bin/sh -c <command>`` with the
+    resolved ``stdin_pipe`` JSON-encoded onto stdin, and delegate to the
+    EXISTING ``op_runtime.sandboxed_exec.handle`` (no new subprocess handling).
+
+    Returns ``result["stdout"]`` (#2593 locked design) — JSON-decoded when it
+    parses, else the raw text. The decode is required for ``verify: schema``
+    to ever apply to a shell step's output at all: the executor's schema
+    validator (``reyn.core.pipeline.schema.validate``) requires a ``dict``
+    value (non-dict → an immediate ``type_mismatch``, by construction — see
+    its top-of-function ``isinstance(value, dict)`` guard), and a subprocess's
+    STDOUT is always raw text. A plain-text command's output still threads
+    through unparsed (JSON-decode failure falls back to the text verbatim),
+    so this is additive, not a behavior change for non-JSON commands.
+    """
+    from reyn.core.op_runtime.sandboxed_exec import handle as handle_sandboxed_exec
+    from reyn.schemas.models import SandboxedExecIROp
+    from reyn.tools.sandboxed_exec import op_context_from_tool_context
+
+    stdin_bytes = json.dumps(args.get("stdin_pipe")).encode("utf-8")
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec",
+        argv=["/bin/sh", "-c", args["command"]],
+        timeout_seconds=int(args.get("timeout", 60)),
+        stdin=stdin_bytes,
+    )
+    legacy_ctx = await op_context_from_tool_context(ctx)
+    result = await handle_sandboxed_exec(op=op, ctx=legacy_ctx)
+    stdout = result["stdout"]
+    try:
+        return json.loads(stdout)
+    except (json.JSONDecodeError, TypeError):
+        return stdout
+
+
+SHELL = ToolDefinition(
+    name="shell",
+    description=_SHELL_DESCRIPTION,
+    parameters=_SHELL_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle,
+    category="execution",
+    purity="side_effect",
+)

--- a/tests/test_2081_s3_delegation_audit.py
+++ b/tests/test_2081_s3_delegation_audit.py
@@ -161,7 +161,8 @@ def test_reachable_role_that_denies_is_clean(tmp_path: Path, monkeypatch) -> Non
     # denying only the qualified form would still re-grant the bare one).
     (_profiles(tmp_path) / "tight.yaml").write_text(
         "name: tight\ntool_deny: [delegate_to_agent, multi_agent__delegate, sandboxed_exec, "
-        "exec__sandboxed_exec, delete_file, file__delete, memory_operation__remember_shared, "
+        "exec__sandboxed_exec, shell, "  # #2593: shell joins the exec class (sugar over sandboxed_exec)
+        "delete_file, file__delete, memory_operation__remember_shared, "
         "memory_operation__remember_agent, memory_operation__forget, remember_shared, "
         "remember_agent, forget_memory, mcp__install_registry, mcp__install_package, "
         "mcp__install_local, mcp_install_registry, mcp_install_package, mcp_install_local, "

--- a/tests/test_2593_pipeline_shell_step.py
+++ b/tests/test_2593_pipeline_shell_step.py
@@ -1,0 +1,282 @@
+"""Tier 2: #2593 — the pipeline DSL `shell` step, implemented via `sandboxed_exec`.
+
+Before this PR, `shell: {command, ...}` parsed to `ToolStep(name="shell")` but no
+"shell" tool was registered — every `shell` step failed at dispatch (100% fail).
+The fix (locked design, #2593): `shell` is tool-step SUGAR — the command is
+STATIC; the previous step's pipe-data is JSON-encoded onto the process's STDIN;
+STDOUT becomes the step's output. Implemented as thin sugar over the EXISTING
+`sandboxed_exec` op (no new subprocess handling): `reyn.tools.shell._handle`
+builds a `SandboxedExecIROp` and delegates to
+`reyn.core.op_runtime.sandboxed_exec.handle` via the SAME `ToolContext` →
+`OpContext` bridge `reyn.tools.sandboxed_exec._handle` uses.
+
+Covers:
+1. registry wiring: `registry.lookup("shell")` resolves (the static-analysis
+   gate's check 3 + the executor's bare-name tool_dispatch fallback both need this).
+2. happy path: a real `PipelineExecutor.run`, through the real
+   `pipeline_verbs._make_tool_dispatch`, with a `NoopBackend`-injected
+   `ToolContext` — the previous step's pipe-data reaches the shell command's
+   STDIN (a `cat`-like command echoes it back), and STDOUT becomes the step's
+   output/pipe-data.
+3. `verify: schema` on a shell step's STDOUT (conforming passes, violating fails).
+4. `timeout` maps to `SandboxedExecIROp.timeout_seconds` (a `sleep`-past-timeout
+   command returns quickly with status "timeout", not blocking the 60s default).
+5. SECURITY regression: the untrusted + delegate floors DENY "shell" (mirrors
+   the `exec__sandboxed_exec` floor regression) at the REAL contextual gate.
+6. round-trip: a `shell` DSL step round-trips through the parser with its
+   `ExprRef("pipe")` stdin-threading arg, static `command`, and `timeout`.
+
+No mocks of collaborators — real EventLog / Workspace / NoopBackend /
+PipelineExecutor / SchemaRegistry / CapabilityProfile resolution throughout.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.parser import parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.capability_profile import (
+    builtin_untrusted_profile,
+    resolve_profile,
+)
+from reyn.security.permissions.effective import tool_contextually_denied
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.security.sandbox import NoopBackend
+from reyn.tools import RouterCallerState, ToolContext, get_default_registry
+from reyn.tools.pipeline_verbs import _make_tool_dispatch
+
+# ─── shared fixture helper ───────────────────────────────────────────────────
+
+
+def _noop_tool_context() -> ToolContext:
+    """A real ToolContext whose op_context_factory yields an OpContext pinned to
+    NoopBackend — deterministic sandbox execution for the test (no platform
+    Seatbelt/Landlock variance)."""
+    events = EventLog()
+    ws = Workspace(events=events)
+
+    def _factory() -> OpContext:
+        return OpContext(
+            workspace=ws,
+            events=events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=None,
+            sandbox_backend=NoopBackend(),
+        )
+
+    return ToolContext(
+        events=events,
+        permission_resolver=None,
+        workspace=ws,
+        caller_kind="router",
+        router_state=RouterCallerState(op_context_factory=_factory),
+    )
+
+
+# ─── 1. registry wiring ──────────────────────────────────────────────────────
+
+
+def test_shell_resolves_in_the_default_registry():
+    """Tier 2: registry.lookup("shell") resolves — the #2593 bug was exactly
+    that this returned None (ToolStep(name="shell") had no registered tool)."""
+    registry = get_default_registry()
+    assert registry.lookup("shell") is not None
+
+
+# ─── 2. happy path: real PipelineExecutor + real dispatch + NoopBackend ─────
+
+
+@pytest.mark.asyncio
+async def test_shell_step_threads_pipe_data_to_stdin_and_stdout_to_output():
+    """Tier 2: a shell step's STDIN receives the previous step's pipe-data
+    JSON-encoded (proven via `cat`, which echoes stdin verbatim to stdout), and
+    its STDOUT becomes the step's own pipe-data / output."""
+    ctx = _noop_tool_context()
+    pipeline = Pipeline(
+        steps=[
+            TransformStep(value="{n: 3, msg: 'hi'}", output="seed"),
+            ToolStep(
+                name="shell",
+                args={"command": "cat", "stdin_pipe": ExprRef("pipe")},
+                output="echoed",
+            ),
+        ]
+    )
+    result = await PipelineExecutor().run(
+        pipeline,
+        {},
+        tool_dispatch=_make_tool_dispatch(ctx),
+        state_log=None,
+        run_id="run-shell-stdin",
+    )
+    assert result.pipe_data == {"n": 3, "msg": "hi"}
+    assert result.named_stores["echoed"] == {"n": 3, "msg": "hi"}
+
+
+# ─── 3. verify: schema on shell output ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shell_step_schema_verify_passes_conforming_output():
+    """Tier 2: a shell step's STDOUT, when JSON-shaped, passes a matching
+    `verify: schema` through the REAL SchemaRegistry/validate path."""
+    ctx = _noop_tool_context()
+    registry = SchemaRegistry()
+    registry.register("greeting", {"fields": {"msg": {"type": "string", "required": True}}})
+    pipeline = Pipeline(
+        steps=[
+            ToolStep(
+                name="shell",
+                args={"command": "echo '{\"msg\": \"hello\"}'", "stdin_pipe": ExprRef("pipe")},
+                output="out",
+                schema="greeting",
+            ),
+        ]
+    )
+    result = await PipelineExecutor().run(
+        pipeline,
+        {},
+        tool_dispatch=_make_tool_dispatch(ctx),
+        state_log=None,
+        run_id="run-shell-schema-ok",
+        schema_registry=registry,
+    )
+    assert result.pipe_data == {"msg": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_shell_step_schema_verify_fails_violating_output():
+    """Tier 2: non-conforming STDOUT fails the step's `verify: schema` — the
+    violation is never silently swallowed."""
+    ctx = _noop_tool_context()
+    registry = SchemaRegistry()
+    registry.register("greeting", {"fields": {"msg": {"type": "string", "required": True}}})
+    pipeline = Pipeline(
+        steps=[
+            ToolStep(
+                name="shell",
+                args={"command": "echo '{\"nope\": 1}'", "stdin_pipe": ExprRef("pipe")},
+                output="out",
+                schema="greeting",
+            ),
+        ]
+    )
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline,
+            {},
+            tool_dispatch=_make_tool_dispatch(ctx),
+            state_log=None,
+            run_id="run-shell-schema-bad",
+            schema_registry=registry,
+        )
+
+
+# ─── 4. timeout maps to timeout_seconds ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shell_step_timeout_maps_to_sandboxed_exec_timeout_seconds():
+    """Tier 2: a shell step's `timeout` arg reaches `SandboxedExecIROp.timeout_seconds`
+    — a `sleep 5` command with `timeout: 1` returns promptly (NoopBackend's
+    wall-clock enforcement fires at 1s), instead of blocking the 60s default."""
+    ctx = _noop_tool_context()
+    pipeline = Pipeline(
+        steps=[
+            ToolStep(
+                name="shell",
+                args={"command": "sleep 5", "stdin_pipe": ExprRef("pipe"), "timeout": 1},
+                output="out",
+            ),
+        ]
+    )
+    import asyncio
+    import time
+
+    start = time.monotonic()
+    await asyncio.wait_for(
+        PipelineExecutor().run(
+            pipeline,
+            {},
+            tool_dispatch=_make_tool_dispatch(ctx),
+            state_log=None,
+            run_id="run-shell-timeout",
+        ),
+        timeout=10,
+    )
+    elapsed = time.monotonic() - start
+    assert elapsed < 5, (
+        f"shell step took {elapsed:.1f}s — timeout=1 did not reach "
+        "SandboxedExecIROp.timeout_seconds (fell back to the 60s default)"
+    )
+
+
+# ─── 5. SECURITY regression: exec floor parity ──────────────────────────────
+
+
+def test_untrusted_floor_denies_shell():
+    """Tier 2: #2593 exec-floor parity — the #1827 untrusted-content floor denies
+    "shell" at the REAL contextual gate, mirroring exec__sandboxed_exec's own
+    floor denial (same subprocess-exec threat surface)."""
+    contextual, _ = resolve_profile(builtin_untrusted_profile())
+    assert tool_contextually_denied(contextual, "shell")
+
+
+def test_delegate_floor_denies_shell(tmp_path):
+    """Tier 2: #2593 exec-floor parity — the #2081 unbound-delegate floor (under
+    delegation.capability_default=deny) denies "shell" via the REAL registry
+    resolution path (resolved_profile_for) → the real gate seam."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None,
+        delegation_capability_default="deny",
+    )
+    contextual, _ = reg.resolved_profile_for("worker", is_delegate=True)
+    assert contextual is not None
+    assert tool_contextually_denied(contextual, "shell")
+
+
+def test_inherit_allows_shell(tmp_path):
+    """Tier 2: regression guard — under capability_default=inherit (the default),
+    an unbound delegate gets NO floor → "shell" is allowed (the floor is what
+    denies; over-denying under inherit would break byte-identical pre-#2081
+    behavior for every OTHER floored tool too)."""
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None,
+        delegation_capability_default="inherit",
+    )
+    contextual, _ = reg.resolved_profile_for("worker", is_delegate=True)
+    assert not tool_contextually_denied(contextual, "shell")
+
+
+# ─── 6. round-trip: shell DSL parse ─────────────────────────────────────────
+
+
+def test_shell_dsl_round_trips_command_timeout_and_pipe_stdin():
+    """Tier 1: a `shell` DSL step with a non-default `timeout` round-trips through
+    the parser: the static `command`, the `timeout`, and the `ExprRef("pipe")`
+    stdin-threading arg all persist in the parsed `ToolStep`."""
+    dsl = """
+pipeline: shell-roundtrip
+steps:
+  - shell: {command: "grep -c foo", timeout: 45, output: matches}
+"""
+    pipeline = parse_pipeline_dsl(dsl, SchemaRegistry())
+    step = pipeline.steps[0]
+    assert isinstance(step, ToolStep)
+    assert step.name == "shell"
+    assert step.args["command"] == "grep -c foo"
+    assert step.args["stdin_pipe"] == ExprRef("pipe")
+    assert step.args["timeout"] == 45
+    assert step.output == "matches"

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -61,7 +61,10 @@ steps:
             ),
             ToolStep(
                 name="shell",
-                args={"command": ExprRef("'echo ' + ctx.bumped")},
+                args={
+                    "command": ExprRef("'echo ' + ctx.bumped"),
+                    "stdin_pipe": ExprRef("pipe"),
+                },
                 output="shelled",
                 schema=None,
             ),

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -34,6 +34,7 @@ _NOT_EXTERNAL = {
     # file content / exec output: agent work-products, secondary vector; fencing
     # every such result = broad bloat at low precision → content-origin follow-up.
     "read_file", "grep_files", "glob_files", "list_directory", "sandboxed_exec",
+    "shell",  # #2593: pipeline `shell` step sugar over sandboxed_exec — same exec-output class
     # — principal / peer (lead finding: explicitly classified) —
     # ask_user: the user is the trust ROOT — their input is the legitimate
     # instruction channel, not untrusted-data (fencing it would break the


### PR DESCRIPTION
**[lead-sonnet]** — Implements pipeline DSL `shell` step (#2593).

## Summary

The `shell: {command, timeout?, schema?, output?}` pipeline DSL step parsed to `ToolStep(name="shell")` but no `"shell"` tool was registered — every `shell` step failed at dispatch (100% fail). This implements `shell` as tool-step sugar over the existing `sandboxed_exec` op, per the locked design:

- **Parser** (`src/reyn/core/pipeline/parser.py::_parse_shell_step`): emits `ToolStep(name="shell", args={"command": ..., "stdin_pipe": ExprRef("pipe"), ["timeout": ...]})`. `command` is static; `stdin_pipe` is an `ExprRef("pipe")` — the executor's *existing* `ToolStep` arg-resolution (`evaluate_expr(v.src, ctx)`) resolves it to the previous step's pipe-data **for free**, no executor change needed. Also added `"timeout"` to `_SHELL_KEYS` (previously wrongly rejected).
- **New `shell` ToolDefinition + handler** (`src/reyn/tools/shell.py`): builds a `SandboxedExecIROp` running `/bin/sh -c <command>` with the pipe-data JSON-encoded onto stdin, and delegates to the **existing** `op_runtime.sandboxed_exec.handle` via the same `ToolContext → OpContext` bridge `sandboxed_exec`'s own tool uses (factored out as `sandboxed_exec.op_context_from_tool_context`, shared by both). No new subprocess handling — pure reuse. Returns `stdout`, JSON-decoded when it parses (so `verify: schema`, which requires a `dict`, can apply to a JSON-emitting command), else the raw text — additive, no behavior change for plain-text commands. Registered in `tools/__init__.py`.
- **STDIN threaded through the exec op**: added `stdin: bytes | None = None` to `SandboxedExecIROp` (the sandbox backends already supported `stdin`, only the IROp/op-handler dropped it); `op_runtime/sandboxed_exec.py` now passes `stdin=op.stdin` to `backend.run(...)`.
- **`docs/reference/runtime/control-ir.md` synced** — added the `stdin` field to the `sandboxed_exec` op-field reference (CLAUDE.md hard rule).
- **Security — exec floor parity**: added `"shell"` to `_FLOORED_QUALIFIED["exec"]` (alongside `exec__sandboxed_exec`) and to `_FLOORED_BARE_ONLY` (no `invoke_action` qualified route, same shape as `session_spawn`/`agent_spawn`/`topology_create`) in `capability_profile.py`, so the untrusted-content floor and the unbound-delegate floor both deny `"shell"` — same subprocess-exec threat surface as `sandboxed_exec`.

## Consumer-audit fallout (two pre-existing tests correctly went RED on the new registered tool)

- `tests/test_2081_s3_delegation_audit.py::test_reachable_role_that_denies_is_clean` — its "tight" fixture profile didn't deny `"shell"`, so the delegation-unsafe audit correctly flagged a new re-grant. Added `"shell"` to the fixture's deny list.
- `tests/test_returns_external_content_flagset_1822.py::test_classification_is_exhaustive` — the exhaustiveness gate correctly flagged the new unclassified tool. Classified `"shell"` as `_NOT_EXTERNAL` (same class as `sandboxed_exec`: exec output is an agent work-product, not external content).

## Gates run locally

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <all changed test files>` — 35/35 OK, 0 Tier-4.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.
- Full `pytest` (7196 passed, 30 skipped) — the 11 failures / 10 errors seen in a full local run are **pre-existing** in this sandbox (missing `mcp` module, and a pre-existing FastAPI route-mount issue), verified unrelated by reproducing them on `git stash` (before this change).
- **Isolation runs** (per the "local-green masking real CI" lesson): `tests/test_2111_floor_alias_completeness.py` (101 passed), `tests/test_op_sandboxed_exec.py` (16 passed — control-ir op registry), `tests/test_2593_pipeline_shell_step.py` (9 passed) — all green standalone.

## Design note flagged for review

The locked design said "(d) return `result["stdout"]` as the step's value" without mentioning JSON-decoding. I added a JSON-decode-if-parseable step before returning, because the schema validator (`reyn.core.pipeline.schema.validate`) hard-requires a `dict` value (any non-dict is an immediate `type_mismatch`) — so `verify: schema` on a shell step's output could otherwise never pass, which conflicts with the "schema on shell output" test requirement. This is additive (non-JSON stdout still threads through as raw text unchanged) but is a interpretation call on an underspecified point — flagging per usual practice.

## Test plan

- [x] Happy path: shell step runs, previous step's pipe-data reaches STDIN as JSON (proven via `cat`), STDOUT becomes the step's output — via a real `PipelineExecutor.run` + `NoopBackend`.
- [x] `verify: schema` on shell output: conforming passes, violating fails (real `SchemaRegistry`).
- [x] `timeout` maps to `SandboxedExecIROp.timeout_seconds` (a `sleep 5` + `timeout: 1` returns promptly).
- [x] Security regression: untrusted + delegate floors DENY `"shell"` at the real contextual gate; floor-alias-completeness invariant passes.
- [x] Round-trip: shell DSL parse preserves `command` + `timeout` + `ExprRef("pipe")`.

Closes #2593

🤖 Generated with [Claude Code](https://claude.com/claude-code)