### PR TITLE
feat(#2597): S1 — swap MCP client library from mcp SDK to fastmcp 3.4.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         # Install all optional extras the test suite touches:
         #   dev  — pytest + pytest-asyncio + ruff + mypy
-        #   mcp  — `mcp` SDK, used by tests/test_mcp_client.py
+        #   mcp  — `fastmcp` (v3.4.2; #2597 S1), used by tests/test_mcp_client.py
         #   web  — fastapi + uvicorn + websockets, used by tests/web/
         run: pip install -e ".[dev,mcp,web]"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ web = [
 # `reyn chainlit` PoC: Chainlit を別 surface として共存させる薄い CLI 起動口。
 # Web UI (= `reyn web` + openui) と TUI (= `reyn chat`) と並列に動かす。
 chainlit = ["chainlit>=2.0"]
-mcp = ["mcp>=1.0"]
+mcp = ["fastmcp==3.4.2"]
 release = [
     "build>=1.0",
     "twine>=5.0",

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1,14 +1,19 @@
 """
-MCP client — thin wrapper around the official Anthropic ``mcp`` SDK.
+MCP client — thin wrapper around ``fastmcp.Client`` (v3.4.2; #2597 S1).
 
-Supports two transports today: ``stdio`` and ``http`` (Streamable HTTP).
-``sse`` is reserved for a future SDK-backed implementation.
+Supports two transports today: ``stdio`` and ``http`` (Streamable HTTP);
+``sse`` uses FastMCP's ``SSETransport`` (previously ``NotImplementedError`` —
+a free win from the swap: no incremental cost to wire once FastMCP's own
+transport inference exists).
 
-Each ``MCPClient`` owns a persistent ``ClientSession`` opened on
-:meth:`initialize` and torn down on :meth:`close`. The session is kept
-alive via an ``AsyncExitStack`` so multiple :meth:`call_tool` invocations
-re-use the same transport (matching the previous hand-rolled client's
-caching semantics on ``OpContext.mcp_clients``).
+Each ``MCPClient`` owns a single ``fastmcp.Client`` opened on
+:meth:`initialize` and torn down on :meth:`close`. FastMCP's ``Client`` is
+itself a reentrant async context manager wrapping the transport + the
+underlying ``mcp.ClientSession``; MCPClient enters it once and holds it open
+for the object's lifetime (matching the previous hand-rolled client's
+caching semantics on ``OpContext.mcp_clients`` / the pool's subprocess-reuse
+contract — FastMCP's ``StdioTransport(keep_alive=True)`` is the same
+persistent-subprocess semantics).
 
 Environment variable expansion:
   ``${VAR_NAME}`` in any string config value is replaced with
@@ -21,7 +26,6 @@ from __future__ import annotations
 import os
 import tempfile
 import warnings
-from contextlib import AsyncExitStack
 from typing import Any
 
 # ── Env var expansion ─────────────────────────────────────────────────────────
@@ -43,7 +47,7 @@ _SUPPORTED_TYPES = {"stdio", "http", "sse"}
 # ── Client ───────────────────────────────────────────────────────────────────
 
 class MCPClient:
-    """Thin async wrapper around ``mcp.ClientSession``.
+    """Thin async wrapper around ``fastmcp.Client``.
 
     Construct with the *raw* server config dict from ``reyn.yaml`` (the
     caller is responsible for env-var expansion via :func:`expand_env`).
@@ -78,18 +82,17 @@ class MCPClient:
         # agent. None preserves prior behaviour for direct callers (= the
         # session factory passes ReynConfig.agent.id; tests can omit).
         self._agent_id: str | None = agent_id
-        self._stack: AsyncExitStack | None = None
-        self._session: Any = None  # mcp.ClientSession when initialized
+        self._client: Any = None  # fastmcp.Client when initialized
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
         # failures (e.g. self-made MCP server exits immediately, writes
         # a traceback to stderr before the MCP handshake completes) can
         # surface the actual error text rather than the opaque "Connection
-        # close" wording the SDK produces. mcp SDK's ``stdio_client``
-        # passes errlog directly to ``anyio.open_process(stderr=...)``,
-        # which needs a real fileno — ``io.StringIO`` doesn't work, but
-        # ``tempfile.TemporaryFile`` does. Lazily created in
-        # ``_open_stdio``; closed in ``close``.
+        # close" wording the SDK produces. FastMCP's ``StdioTransport``
+        # takes a ``log_file`` (Path | TextIO) for subprocess stderr —
+        # ``io.StringIO`` doesn't work (needs a real fileno for the
+        # underlying anyio subprocess), but ``tempfile.TemporaryFile``
+        # does. Lazily created in ``_open_stdio``; closed in ``close``.
         self._stderr_capture: Any = None  # tempfile.TemporaryFile | None
         # #1344: path of the temp Seatbelt profile (.sb) used to sandbox a
         # stdio MCP server's subprocess, if one was generated in _open_stdio.
@@ -125,29 +128,29 @@ class MCPClient:
         if self._initialized:
             return
         try:
-            from mcp import ClientSession
+            from fastmcp import Client as FastMCPClient
         except ImportError as exc:
             raise MCPError(
-                "The 'mcp' package is required for MCP support. "
+                "The 'fastmcp' package is required for MCP support. "
                 "Install with: pip install reyn[mcp]"
             ) from exc
 
-        stack = AsyncExitStack()
         try:
-            transport = await stack.enter_async_context(self._open_transport())
-            # streamablehttp_client yields (read, write, get_session_id);
-            # stdio_client yields (read, write).
-            read_stream, write_stream = transport[0], transport[1]
-            session = await stack.enter_async_context(
-                ClientSession(read_stream, write_stream)
-            )
-            await session.initialize()
+            transport = self._open_transport()
+            client_kwargs: dict[str, Any] = {}
+            if self._type in ("http", "sse"):
+                # Client-level default read timeout — see _open_http docstring:
+                # the pre-swap connect-level ``timeout=`` kwarg on
+                # ``streamablehttp_client`` maps to FastMCP's Client-level
+                # default ``read_timeout_seconds`` (same knob call_tool's
+                # per-call ``timeout_seconds`` overrides).
+                client_kwargs["timeout"] = self._config.get("timeout", 30)
+            client = FastMCPClient(transport, **client_kwargs)
+            await client.__aenter__()
         except MCPError:
-            await stack.aclose()
             self.close_stderr_capture()
             raise
         except Exception as exc:
-            await stack.aclose()
             tail = self.read_stderr_tail()
             self.close_stderr_capture()
             # #1344/#1339-D migration hint: a sandboxed stdio server defaults to
@@ -173,8 +176,7 @@ class MCPClient:
                 ) from exc
             raise MCPError(f"MCP initialize failed: {exc}{hint}") from exc
 
-        self._stack = stack
-        self._session = session
+        self._client = client
         self._initialized = True
 
     async def __aenter__(self) -> "MCPClient":
@@ -210,6 +212,10 @@ class MCPClient:
             message: str | None) -> None`` that the MCP SDK invokes when the
             server emits a ``notifications/progress`` for this call. Default
             ``None`` matches pre-#264 behaviour (= no progress visibility).
+            Forwarded to FastMCP's ``call_tool_mcp(progress_handler=...)``,
+            which passes it straight through to
+            ``mcp.ClientSession.call_tool(progress_callback=...)`` — same SDK
+            parameter, same signature.
           - ``timeout_seconds``: float; if set, converts to ``timedelta`` and
             passes as ``read_timeout_seconds`` to the SDK so the call fails
             fast on a stuck server. Default ``None`` keeps the SDK's own
@@ -218,36 +224,45 @@ class MCPClient:
         await self.initialize()
         kwargs: dict[str, Any] = {}
         if progress_callback is not None:
-            kwargs["progress_callback"] = progress_callback
+            kwargs["progress_handler"] = progress_callback
         if timeout_seconds is not None:
             from datetime import timedelta
-            kwargs["read_timeout_seconds"] = timedelta(seconds=timeout_seconds)
+            kwargs["timeout"] = timedelta(seconds=timeout_seconds)
         try:
-            result = await self._session.call_tool(name, args or {}, **kwargs)
+            # call_tool_mcp (not FastMCP's raise_on_error-by-default call_tool)
+            # returns the RAW mcp.types.CallToolResult unchanged — same object
+            # shape _result_to_dict already flattens, so op_runtime/mcp.py's
+            # consumed shape stays byte-identical.
+            result = await self._client.call_tool_mcp(name, args or {}, **kwargs)
         except Exception as exc:
             raise MCPError(f"MCP tools/call error: {exc}") from exc
         return _result_to_dict(result)
 
     async def list_tools(self) -> list[dict[str, Any]]:
-        """Return the tools advertised by this server as plain dicts."""
+        """Return the tools advertised by this server as plain dicts.
+
+        Uses FastMCP's auto-paginating ``Client.list_tools()`` (follows
+        ``nextCursor`` up to a 250-page guard) instead of a single page-1
+        request — #2597 S1 free win: servers with >1 page of tools no
+        longer silently truncate.
+        """
         await self.initialize()
         try:
-            result = await self._session.list_tools()
+            tools = await self._client.list_tools()
         except Exception as exc:
             raise MCPError(f"MCP tools/list error: {exc}") from exc
-        return [_tool_to_dict(t) for t in result.tools]
+        return [_tool_to_dict(t) for t in tools]
 
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly."""
-        if self._stack is None:
+        if self._client is None:
             self.close_stderr_capture()
             return
-        stack = self._stack
-        self._stack = None
-        self._session = None
+        client = self._client
+        self._client = None
         self._initialized = False
         try:
-            await stack.aclose()
+            await client.close()
         except Exception:
             # Best-effort cleanup; transport may already be down.
             pass
@@ -316,7 +331,13 @@ class MCPClient:
 
     # ── transport dispatch ──────────────────────────────────────────────────
 
-    def _open_transport(self):
+    def _open_transport(self) -> "Any":
+        """Build the ``fastmcp.client.transports.ClientTransport`` for this server.
+
+        Unlike the pre-swap ``mcp`` SDK version, this returns a constructed
+        transport OBJECT (not an entered async context manager / stream
+        tuple) — FastMCP's ``Client(transport)`` owns opening it.
+        """
         if self._type == "stdio":
             return self._open_stdio()
         if self._type == "http":
@@ -395,8 +416,8 @@ class MCPClient:
         )
         return command, args
 
-    def _open_stdio(self):
-        from mcp.client.stdio import StdioServerParameters, stdio_client
+    def _open_stdio(self) -> "Any":
+        from fastmcp.client.transports import StdioTransport
 
         command = self._config.get("command")
         if not command:
@@ -406,15 +427,10 @@ class MCPClient:
         # so an LLM-invoked MCP tool cannot escape the sandbox via the server.
         command, args = self._sandbox_wrap_stdio(command, args)
         env = self._config.get("env")
-        params = StdioServerParameters(
-            command=command,
-            args=args,
-            env=dict(env) if env else None,
-            cwd=self._config.get("cwd"),
-        )
         # Subprocess stderr capture for diagnostic readback on init
-        # failure. ``stdio_client`` passes errlog to
-        # ``anyio.open_process(stderr=...)`` which requires a real
+        # failure. FastMCP's ``StdioTransport`` accepts ``log_file`` (a
+        # Path or TextIO) and passes it straight through to the underlying
+        # ``anyio.open_process(stderr=...)``, which requires a real
         # fileno — ``io.StringIO`` doesn't work. ``tempfile.TemporaryFile``
         # auto-deletes on close. Text-mode + utf-8 matches the SDK's
         # default (= sys.stderr). On failure to open the temp file we
@@ -426,10 +442,22 @@ class MCPClient:
             )
         except Exception:  # noqa: BLE001 — temp-file failure is non-fatal
             self._stderr_capture = None
-            return stdio_client(params)
-        return stdio_client(params, errlog=self._stderr_capture)
+            log_file = None
+        else:
+            log_file = self._stderr_capture
+        return StdioTransport(
+            command=command,
+            args=args,
+            env=dict(env) if env else None,
+            cwd=self._config.get("cwd"),
+            # keep_alive=True matches the pre-swap subprocess-reuse contract:
+            # MCPClient/pool open once and hold the same transport/subprocess
+            # for the object's lifetime (a359 P2 task-affine caching).
+            keep_alive=True,
+            log_file=log_file,
+        )
 
-    def _open_http(self):
+    def _open_http(self) -> "Any":
         """Open the Streamable HTTP transport.
 
         Reads from ``self._config``:
@@ -443,8 +471,17 @@ class MCPClient:
             standard load_config path applies ``expand_env`` recursively
             across the whole merged config — see ADR-0030).
           - ``timeout`` (optional, default 30) — request timeout in seconds.
+            FastMCP's ``StreamableHttpTransport`` has no per-transport
+            connect timeout (its ``sse_read_timeout`` ctor kwarg is
+            deprecated/unused by the new streamable-http client); the
+            equivalent bound is the ``Client``-level default read timeout
+            (``fastmcp.Client(transport, timeout=...)``), which flows into
+            every request's ``read_timeout_seconds`` exactly like the
+            per-call ``timeout_seconds`` kwarg on :meth:`call_tool` — same
+            SDK knob, applied as this transport's default instead of the
+            old connect-level timeout.
         """
-        from mcp.client.streamable_http import streamablehttp_client
+        from fastmcp.client.transports import StreamableHttpTransport
 
         url = self._config.get("url")
         if not url:
@@ -460,40 +497,22 @@ class MCPClient:
         # need to spoof in tests or proxy in production.
         if self._agent_id and "X-Reyn-Agent-Id" not in headers:
             headers["X-Reyn-Agent-Id"] = self._agent_id
-        timeout = self._config.get("timeout", 30)
-        return streamablehttp_client(url, headers=headers, timeout=timeout)
+        return StreamableHttpTransport(url, headers=headers)
 
-    def _open_sse(self):
-        # The SDK ships sse_client but we defer wiring it until we have a
-        # real test target. Surface a clean error instead of half-supporting.
-        raise NotImplementedError(
-            "MCP 'sse' transport is not yet implemented. Use 'stdio' or 'http'."
-        )
+    def _open_sse(self) -> "Any":
+        """Open the SSE transport (#2597 S1 free win — FastMCP ships it, so no
+        incremental cost to wire vs. leaving the pre-swap ``NotImplementedError``)."""
+        from fastmcp.client.transports import SSETransport
 
-
-# ── Backward-compat shim ─────────────────────────────────────────────────────
-
-class MCPHTTPClient(MCPClient):
-    """Deprecated alias for :class:`MCPClient` configured for HTTP.
-
-    Preserved for any out-of-tree caller that imported the old class
-    directly. New code should use ``MCPClient({"type": "http", ...})``.
-    """
-
-    def __init__(
-        self,
-        url: str,
-        headers: dict[str, str] | None = None,
-        timeout: int = 30,
-    ) -> None:
-        super().__init__(
-            {
-                "type": "http",
-                "url": url,
-                "headers": dict(headers or {}),
-                "timeout": timeout,
-            }
-        )
+        url = self._config.get("url")
+        if not url:
+            raise MCPError("sse MCP server config requires 'url'")
+        headers = {
+            str(k): str(v) for k, v in (self._config.get("headers") or {}).items()
+        }
+        if self._agent_id and "X-Reyn-Agent-Id" not in headers:
+            headers["X-Reyn-Agent-Id"] = self._agent_id
+        return SSETransport(url, headers=headers)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -1,0 +1,69 @@
+"""Real FastMCP server used as a test double for MCPClient round-trip tests (#2597 S1).
+
+Run directly as a subprocess (stdio) or pointed at a host:port (http/sse) — never imported.
+Tools:
+  - ``echo(text)``       -> returns ``text`` verbatim.
+  - ``boom()``           -> raises, so the server surfaces a tool-level error
+                            (``isError: True``), never a transport crash.
+  - ``show_headers()``   -> returns the incoming HTTP request headers (http/sse
+                            transports only; used to prove header forwarding,
+                            e.g. ``X-Reyn-Agent-Id``, reaches the real server).
+  - ``progress(steps)``  -> reports ``steps`` progress notifications via the
+                            real FastMCP ``Context.report_progress`` API, so
+                            progress-callback plumbing is exercised against the
+                            real protocol (not a hand-rolled fake).
+
+Usage:
+  stdio: ``python mcp_fastmcp_echo_server.py``
+  http:  ``python mcp_fastmcp_echo_server.py http <port>``
+  sse:   ``python mcp_fastmcp_echo_server.py sse <port>``
+"""
+from __future__ import annotations
+
+import sys
+
+from fastmcp import Context, FastMCP
+
+mcp = FastMCP("reyn-test-echo")
+
+
+@mcp.tool()
+def echo(text: str) -> str:
+    return text
+
+
+@mcp.tool()
+def boom() -> str:
+    raise RuntimeError("simulated tool failure")
+
+
+@mcp.tool()
+def die() -> str:
+    """Kill the subprocess mid-call — simulates a genuine TRANSPORT failure (as opposed
+    to ``boom``'s protocol-level tool error) so callers can distinguish MCPError
+    (transport/connection broke) from a normal ``isError: True`` tool result."""
+    import os
+
+    os._exit(1)
+
+
+@mcp.tool()
+def show_headers() -> dict:
+    from fastmcp.server.dependencies import get_http_headers
+
+    return dict(get_http_headers(include_all=True))
+
+
+@mcp.tool()
+async def progress(steps: int, ctx: Context) -> str:
+    for i in range(1, steps + 1):
+        await ctx.report_progress(progress=i, total=steps, message=f"step-{i}")
+    return "done"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) >= 3:
+        transport, port = sys.argv[1], int(sys.argv[2])
+        mcp.run(transport=transport, host="127.0.0.1", port=port)
+    else:
+        mcp.run(transport="stdio")

--- a/tests/_support/mcp_paginated_tools_server.py
+++ b/tests/_support/mcp_paginated_tools_server.py
@@ -1,0 +1,53 @@
+"""Low-level real MCP stdio server that paginates ``tools/list`` across 2 pages (#2597 S1).
+
+Standalone script — run as a subprocess, never imported. Exists to prove FastMCP's
+``Client.list_tools()`` (which MCPClient.list_tools() now delegates to) follows
+``nextCursor`` instead of silently truncating at page 1, unlike the pre-swap ``mcp``
+SDK ``ClientSession.list_tools()`` call the old client made directly.
+
+Serves 4 tools across 2 pages of 2 (cursor = the next tool's index as a string).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+app = Server("reyn-test-paginated")
+
+_ALL_TOOLS = [
+    types.Tool(name=f"tool_{i}", description=f"tool number {i}", inputSchema={"type": "object"})
+    for i in range(4)
+]
+_PAGE_SIZE = 2
+
+
+@app.list_tools()
+async def list_tools(request: types.PaginatedRequestParams | None = None) -> list[types.Tool]:
+    # The low-level Server API decorator only supports returning the tool list; page
+    # boundaries need the raw request handler for cursor control, so this override goes
+    # through app.request_handlers directly below instead of the decorator sugar.
+    return _ALL_TOOLS
+
+
+async def _handle_list_tools_paginated(req):
+    cursor = req.params.cursor if req.params is not None else None
+    start = int(cursor) if cursor else 0
+    page = _ALL_TOOLS[start : start + _PAGE_SIZE]
+    next_cursor = str(start + _PAGE_SIZE) if start + _PAGE_SIZE < len(_ALL_TOOLS) else None
+    result = types.ListToolsResult(tools=page, nextCursor=next_cursor)
+    return types.ServerResult(result)
+
+
+app.request_handlers[types.ListToolsRequest] = _handle_list_tools_paginated
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_config_mcp_headers.py
+++ b/tests/test_config_mcp_headers.py
@@ -7,17 +7,16 @@ interpolation (ADR-0030).
 Component A scope:
   - ``headers: dict[str, str]`` is accepted on http-mode MCP server configs.
   - ``${VAR}`` tokens inside header values resolve at config-load time.
-  - The headers dict reaches ``streamablehttp_client`` verbatim (post-expand).
+  - The headers dict reaches the real ``StreamableHttpTransport`` verbatim
+    (post-expand) — #2597 S1: inspected via the transport's own public
+    ``.headers`` attribute (a real ``fastmcp`` object), not a mocked SDK entry
+    point.
   - Missing / empty ``headers`` is fine — no header is sent (back-compat).
 """
 from __future__ import annotations
 
-import asyncio
-from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest import mock
 
-import pytest
 import yaml
 
 # ---------------------------------------------------------------------------
@@ -111,62 +110,19 @@ def test_mcp_headers_optional_back_compat(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Transport boundary: headers reach streamablehttp_client verbatim
+# Transport boundary: headers reach the real StreamableHttpTransport verbatim
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def _patched_mcp_sdk():
-    """Patch MCP SDK transport entry-points used by MCPClient.
+def test_mcp_headers_reach_http_transport() -> None:
+    """Tier 2: framework boundary — a config with resolved headers reaches the real
+    ``StreamableHttpTransport`` with the exact post-expansion header dict.
 
-    Intentional SDK patch — admitted per tier-audit HTTP-transport exemption
-    (same pattern as ``patched_sdk`` in ``tests/test_mcp_client.py``).
-    ``streamablehttp_client`` and ``ClientSession`` are 3rd-party SDK boundaries
-    that cannot be replaced with LLMReplay; the fake functions defined at module
-    level below are injected here and captured via the ``_http_captured`` dict
-    passed to each test through the ``captured`` parameter.
-
-    Deferral note: converting these patches to a proper LLMReplay-compatible
-    Fake requires extending LLMReplay to cover the MCP SDK transport layer —
-    tracked as a follow-up, not in scope for this PR.
+    This pins the contract: whatever the caller puts in ``cfg['headers']``, MCPClient
+    passes through to the transport — no filtering, no rewriting. Inspects the
+    transport's own public ``.headers`` / ``.url`` attributes (a real fastmcp object
+    built by ``_open_transport()``), not a mocked SDK call.
     """
-    captured: dict = {}
-
-    @asynccontextmanager
-    async def _fake_http_client(url, headers=None, timeout=30):
-        captured["url"] = url
-        captured["headers"] = dict(headers or {})
-        captured["timeout"] = timeout
-        yield ("read", "write", lambda: None)
-
-    class _FakeSession:
-        def __init__(self, *a, **kw):
-            pass
-
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            return None
-
-        async def initialize(self):
-            return None
-
-    with mock.patch(
-        "mcp.client.streamable_http.streamablehttp_client", _fake_http_client
-    ), mock.patch("mcp.ClientSession", _FakeSession):
-        yield captured
-
-
-def test_mcp_headers_reach_http_transport(_patched_mcp_sdk):
-    """Tier 2: framework boundary — a config with resolved headers reaches the
-    ``streamablehttp_client`` call with the exact post-expansion header dict.
-
-    This pins the contract: whatever the caller puts in ``cfg['headers']``,
-    MCPClient passes through to the SDK — no filtering, no rewriting.
-    """
-    captured = _patched_mcp_sdk
-
     from reyn.mcp.client import MCPClient
 
     cfg = {
@@ -179,34 +135,22 @@ def test_mcp_headers_reach_http_transport(_patched_mcp_sdk):
         "timeout": 45,
     }
 
-    async def _run_it():
-        client = MCPClient(cfg)
-        await client.initialize()
-        await client.close()
+    client = MCPClient(cfg)
+    transport = client._open_transport()
 
-    asyncio.run(_run_it())
-
-    assert captured["url"] == "https://api.example.com/mcp"
-    assert captured["headers"] == {
+    assert transport.url == "https://api.example.com/mcp"
+    assert transport.headers == {
         "Authorization": "Bearer abc123",
         "X-API-Version": "2024-01-01",
     }
-    assert captured["timeout"] == 45
 
 
-def test_mcp_headers_default_empty_when_omitted(_patched_mcp_sdk):
+def test_mcp_headers_default_empty_when_omitted() -> None:
     """Tier 2: framework boundary — an http MCP config without ``headers`` yields
     an empty header dict at the transport (no spurious headers injected)."""
-    captured = _patched_mcp_sdk
-
     from reyn.mcp.client import MCPClient
 
     cfg = {"type": "http", "url": "http://x/mcp"}
-
-    async def _run_it():
-        client = MCPClient(cfg)
-        await client.initialize()
-        await client.close()
-
-    asyncio.run(_run_it())
-    assert captured["headers"] == {}
+    client = MCPClient(cfg)
+    transport = client._open_transport()
+    assert transport.headers == {}

--- a/tests/test_fp0016_e_agent_id.py
+++ b/tests/test_fp0016_e_agent_id.py
@@ -122,56 +122,38 @@ def test_event_log_agent_id_property_readable() -> None:
 # ── 3. MCPClient X-Reyn-Agent-Id header ────────────────────────────────────
 
 
-def test_mcp_client_injects_x_reyn_agent_id_header(monkeypatch) -> None:
-    """Tier 2: MCPClient(agent_id=...) adds X-Reyn-Agent-Id to HTTP headers."""
+def test_mcp_client_injects_x_reyn_agent_id_header() -> None:
+    """Tier 2: MCPClient(agent_id=...) adds X-Reyn-Agent-Id to HTTP headers.
+
+    #2597 S1: inspects the real ``StreamableHttpTransport.headers`` built by
+    ``_open_http()`` directly (a real fastmcp object), not a mocked SDK call.
+    """
     from reyn.mcp.client import MCPClient
-
-    captured: dict = {}
-
-    def fake_streamablehttp_client(url, headers=None, timeout=None):  # noqa: ARG001
-        captured["headers"] = headers
-        return None
 
     client = MCPClient(
         {"type": "http", "url": "https://example.com/mcp"},
         agent_id="reyn/test-agent",
     )
-    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
-                        fake_streamablehttp_client)
-    client._open_http()
-    assert captured["headers"].get("X-Reyn-Agent-Id") == "reyn/test-agent"
+    transport = client._open_http()
+    assert transport.headers.get("X-Reyn-Agent-Id") == "reyn/test-agent"
 
 
-def test_mcp_client_no_agent_id_no_header(monkeypatch) -> None:
+def test_mcp_client_no_agent_id_no_header() -> None:
     """Tier 2: agent_id=None → no X-Reyn-Agent-Id header (= backwards compat)."""
     from reyn.mcp.client import MCPClient
 
-    captured: dict = {}
-
-    def fake_streamablehttp_client(url, headers=None, timeout=None):  # noqa: ARG001
-        captured["headers"] = headers
-        return None
-
     client = MCPClient({"type": "http", "url": "https://example.com/mcp"})
-    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
-                        fake_streamablehttp_client)
-    client._open_http()
-    assert "X-Reyn-Agent-Id" not in (captured["headers"] or {})
+    transport = client._open_http()
+    assert "X-Reyn-Agent-Id" not in transport.headers
 
 
-def test_mcp_client_operator_header_wins(monkeypatch) -> None:
+def test_mcp_client_operator_header_wins() -> None:
     """Tier 2: operator-set X-Reyn-Agent-Id in config wins over agent_id arg.
 
     Operators may need to spoof for tests or proxy in production; respect
     their explicit header.
     """
     from reyn.mcp.client import MCPClient
-
-    captured: dict = {}
-
-    def fake_streamablehttp_client(url, headers=None, timeout=None):  # noqa: ARG001
-        captured["headers"] = headers
-        return None
 
     client = MCPClient(
         {
@@ -181,10 +163,8 @@ def test_mcp_client_operator_header_wins(monkeypatch) -> None:
         },
         agent_id="reyn/auto",
     )
-    monkeypatch.setattr("mcp.client.streamable_http.streamablehttp_client",
-                        fake_streamablehttp_client)
-    client._open_http()
-    assert captured["headers"]["X-Reyn-Agent-Id"] == "reyn/spoofed"
+    transport = client._open_http()
+    assert transport.headers["X-Reyn-Agent-Id"] == "reyn/spoofed"
 
 
 # ── 4. OpContext.agent_id field ────────────────────────────────────────────

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,217 +1,161 @@
-"""Tests for the SDK-backed MCPClient (PR32).
+"""Tests for the FastMCP-backed MCPClient (#2597 S1 — mcp SDK -> fastmcp swap).
 
-The official ``mcp`` SDK uses async generators for transports and an
-``async with`` ClientSession. To avoid spinning up real subprocess /
-HTTP servers we patch both ``stdio_client`` / ``streamablehttp_client``
-and ``ClientSession`` at the module they're imported from.
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock`` on
+the transport or session. Stdio round-trips spawn a REAL subprocess running
+``tests/_support/mcp_fastmcp_echo_server.py`` (a real FastMCP server); http
+round-trips spin a REAL local uvicorn server via ``FastMCP.run_async`` on an
+ephemeral port. Pagination is proven against a real low-level MCP server
+(``tests/_support/mcp_paginated_tools_server.py``) that serves 2 pages.
 """
 from __future__ import annotations
 
 import asyncio
-import warnings
-from contextlib import asynccontextmanager
-from types import SimpleNamespace
-from unittest import mock
+import socket
+import sys
+from pathlib import Path
 
 import pytest
 
 from reyn.mcp.client import MCPClient, MCPError, expand_env
 
-# ── fakes ────────────────────────────────────────────────────────────────────
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+_PAGINATED_SERVER = _SUPPORT_DIR / "mcp_paginated_tools_server.py"
 
 
-class _FakeContent:
-    """Mimics ``mcp.types.TextContent`` enough for ``_result_to_dict``."""
-
-    def __init__(self, text: str) -> None:
-        self.type = "text"
-        self.text = text
-
-    def model_dump(self) -> dict:
-        return {"type": self.type, "text": self.text}
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
 
 
-class _FakeCallResult:
-    def __init__(self, text: str, is_error: bool = False) -> None:
-        self.content = [_FakeContent(text)]
-        self.isError = is_error
-        self.structuredContent = None
+class _HttpEchoServer:
+    """Runs the real echo FastMCP server in-process via ``run_async`` on an
+    ephemeral port, as a background asyncio task — no subprocess needed for
+    the http-transport tests, but no mock either: a real bound socket serving
+    the real MCP protocol."""
 
+    def __init__(self) -> None:
+        self.port = _free_port()
+        self.url = f"http://127.0.0.1:{self.port}/mcp/"
+        self._task: asyncio.Task | None = None
 
-class _FakeTool:
-    def __init__(self, name: str) -> None:
-        self.name = name
+    async def __aenter__(self) -> "_HttpEchoServer":
+        sys.path.insert(0, str(_SUPPORT_DIR))
+        import mcp_fastmcp_echo_server as server_mod
 
-    def model_dump(self) -> dict:
-        return {"name": self.name, "description": "fake"}
-
-
-class _FakeListResult:
-    def __init__(self, names: list[str]) -> None:
-        self.tools = [_FakeTool(n) for n in names]
-
-
-class _FakeSession:
-    """Mimics ``mcp.ClientSession`` as an async context manager."""
-
-    last_init_args: dict = {}
-    last_call: dict = {}
-
-    def __init__(self, read_stream, write_stream, *args, **kwargs) -> None:
-        self._read = read_stream
-        self._write = write_stream
-        self.entered = False
-        self.closed = False
-
-    async def __aenter__(self):
-        self.entered = True
+        self._task = asyncio.create_task(
+            server_mod.mcp.run_async(
+                transport="http", host="127.0.0.1", port=self.port, show_banner=False,
+            )
+        )
+        # Poll until the socket accepts connections instead of a fixed sleep.
+        for _ in range(100):
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.1):
+                    break
+            except OSError:
+                await asyncio.sleep(0.05)
         return self
 
-    async def __aexit__(self, exc_type, exc, tb) -> None:
-        self.closed = True
-
-    async def initialize(self):
-        return SimpleNamespace(serverInfo=SimpleNamespace(name="fake"))
-
-    async def call_tool(self, name: str, arguments: dict):
-        _FakeSession.last_call = {"name": name, "arguments": arguments}
-        if name == "boom":
-            raise RuntimeError("simulated tool failure")
-        text = f"echo:{name}:{sorted((arguments or {}).items())}"
-        return _FakeCallResult(text)
-
-    async def list_tools(self):
-        return _FakeListResult(["echo", "ping"])
+    async def __aexit__(self, *exc_info) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001 — best-effort teardown
+                pass
 
 
-@asynccontextmanager
-async def _fake_stdio_client(params, errlog=None):
-    """Stand-in for ``mcp.client.stdio.stdio_client``.
-
-    ``errlog`` is accepted to match the SDK signature (= MCPClient
-    passes a tempfile when configured for stderr capture); the stand-in
-    doesn't write to it.
-    """
-    _FakeSession.last_init_args = {
-        "transport": "stdio",
-        "command": params.command,
-        "args": list(params.args),
-        "env": dict(params.env) if params.env else None,
-        "errlog_provided": errlog is not None,
-    }
-    yield ("read_stream_obj", "write_stream_obj")
+# ── round-trip tests ─────────────────────────────────────────────────────────
 
 
-@asynccontextmanager
-async def _fake_http_client(url, headers=None, timeout=30):
-    """Stand-in for ``mcp.client.streamable_http.streamablehttp_client``."""
-    _FakeSession.last_init_args = {
-        "transport": "http",
-        "url": url,
-        "headers": dict(headers or {}),
-        "timeout": timeout,
-    }
-    yield ("read_stream_obj", "write_stream_obj", lambda: None)
-
-
-class _NoopBackend:
-    """A non-seatbelt sandbox backend stand-in (#1344): the stdio wrap then
-    no-ops (warns), so these transport-passthrough tests stay isolated from the
-    sandbox-wrap layer (which has its own test_mcp_client_sandbox_wrap.py)."""
-
-    name = "noop"
-
-    def available(self) -> bool:
-        return True
-
-
-@pytest.fixture
-def patched_sdk():
-    """Patch the SDK entry points used by MCPClient.
-
-    Also pins a noop sandbox backend so the #1344 stdio sandbox-wrap leaves the
-    command untouched here — these tests verify transport config forwarding, not
-    the sandbox wrap (that is tested separately).
-    """
-    with mock.patch("mcp.client.stdio.stdio_client", _fake_stdio_client), \
-         mock.patch("mcp.client.streamable_http.streamablehttp_client", _fake_http_client), \
-         mock.patch("mcp.ClientSession", _FakeSession), \
-         mock.patch("reyn.security.sandbox.get_default_backend", lambda config=None: _NoopBackend()), \
-         warnings.catch_warnings():
-        # The noop backend makes the #1344 stdio wrap a no-op + warn — expected
-        # here (these tests isolate transport forwarding, not the sandbox wrap).
-        warnings.filterwarnings("ignore", message=".*runs UNSANDBOXED.*")
-        yield
-
-
-# ── tests ────────────────────────────────────────────────────────────────────
-
-
-def test_http_transport_round_trip(patched_sdk):
-    """Tier 1: framework boundary (intentional SDK patch) — verifies HTTP transport config
-    is forwarded correctly to the mcp SDK and that call_tool returns a valid result."""
-    cfg = {
-        "type": "http",
-        "url": "http://localhost:9999/mcp",
-        "headers": {"Authorization": "Bearer abc"},
-    }
-
-    async def _run_it():
-        client = MCPClient(cfg)
-        await client.initialize()
-        result = await client.call_tool("read", {"path": "x.txt"})
-        await client.close()
-        return result
-
-    result = asyncio.run(_run_it())
-    assert _FakeSession.last_init_args["transport"] == "http"
-    assert _FakeSession.last_init_args["url"] == "http://localhost:9999/mcp"
-    assert result["isError"] is False
-    assert result["content"][0]["type"] == "text"
-    assert "echo:read" in result["content"][0]["text"]
-
-
-def test_stdio_transport_round_trip(patched_sdk):
-    """Tier 1: framework boundary (intentional SDK patch) — verifies stdio transport config
-    is forwarded correctly to the mcp SDK and that list_tools/call_tool return valid results."""
+def test_stdio_transport_round_trip() -> None:
+    """Tier 1: framework boundary — a real stdio subprocess handshakes, lists tools, and
+    executes a tool call through the FastMCP-backed transport."""
     cfg = {
         "type": "stdio",
-        "command": "/usr/bin/echo",
-        "args": ["hello"],
-        "env": {"FOO": "bar"},
+        "command": sys.executable,
+        "args": [str(_ECHO_SERVER)],
     }
 
     async def _run_it():
-        client = MCPClient(cfg)
-        await client.initialize()
-        tools = await client.list_tools()
-        result = await client.call_tool("ping", {"n": 1})
-        await client.close()
-        return tools, result
+        async with MCPClient(cfg) as client:
+            tools = await client.list_tools()
+            result = await client.call_tool("echo", {"text": "hello"})
+            return tools, result
 
     tools, result = asyncio.run(_run_it())
-    assert _FakeSession.last_init_args["transport"] == "stdio"
-    assert _FakeSession.last_init_args["command"] == "/usr/bin/echo"
-    assert _FakeSession.last_init_args["args"] == ["hello"]
-    assert _FakeSession.last_init_args["env"] == {"FOO": "bar"}
-    assert {"echo", "ping"} == {t["name"] for t in tools}
+    names = {t["name"] for t in tools}
+    assert {"echo", "boom", "show_headers", "progress"} <= names
     assert result["isError"] is False
-    assert "echo:ping" in result["content"][0]["text"]
+    assert result["content"][0]["type"] == "text"
+    assert result["content"][0]["text"] == "hello"
 
 
-def test_invalid_type_rejected():
+def test_http_transport_round_trip() -> None:
+    """Tier 1: framework boundary — a real local HTTP MCP server (uvicorn via
+    FastMCP.run_async) handshakes and executes a tool call over Streamable HTTP."""
+
+    async def _run_it():
+        async with _HttpEchoServer() as server:
+            cfg = {
+                "type": "http",
+                "url": server.url,
+                "headers": {"Authorization": "Bearer abc"},
+            }
+            async with MCPClient(cfg) as client:
+                result = await client.call_tool("echo", {"text": "hi-http"})
+                return result
+
+    result = asyncio.run(_run_it())
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "hi-http"
+
+
+def test_http_transport_forwards_agent_id_header() -> None:
+    """Tier 1: FP-0016 Component E — ``X-Reyn-Agent-Id`` reaches the real server."""
+
+    async def _run_it():
+        async with _HttpEchoServer() as server:
+            cfg = {"type": "http", "url": server.url}
+            async with MCPClient(cfg, agent_id="reyn/test-agent") as client:
+                result = await client.call_tool("show_headers", {})
+                return result
+
+    result = asyncio.run(_run_it())
+    assert result["structuredContent"]["x-reyn-agent-id"] == "reyn/test-agent"
+
+
+def test_list_tools_follows_pagination_cursor() -> None:
+    """Tier 1: #2597 S1 free win — list_tools() follows nextCursor across pages instead
+    of silently truncating at page 1 (the pre-swap bug). A real 2-page low-level server."""
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_PAGINATED_SERVER)]}
+
+    async def _run_it():
+        async with MCPClient(cfg) as client:
+            return await client.list_tools()
+
+    tools = asyncio.run(_run_it())
+    names = {t["name"] for t in tools}
+    assert names == {"tool_0", "tool_1", "tool_2", "tool_3"}, (
+        "all 4 tools across both pages must be returned, not just page 1's 2"
+    )
+
+
+def test_invalid_type_rejected() -> None:
     """Tier 1: MCPClient public contract — unsupported transport type raises ValueError at construction."""
     with pytest.raises(ValueError, match="Unsupported MCP server type"):
         MCPClient({"type": "ftp", "url": "ftp://nope"})
 
 
-def test_missing_type_rejected():
+def test_missing_type_rejected() -> None:
     """Tier 1: MCPClient public contract — missing transport type raises ValueError at construction."""
     with pytest.raises(ValueError, match="Unsupported MCP server type"):
         MCPClient({"url": "http://x"})
 
 
-def test_env_var_expansion(monkeypatch):
+def test_env_var_expansion(monkeypatch) -> None:
     """Tier 1: expand_env public contract — ${VAR} tokens in string values are replaced
     with the corresponding environment variable."""
     monkeypatch.setenv("MY_TOKEN", "s3cret")
@@ -226,47 +170,40 @@ def test_env_var_expansion(monkeypatch):
     assert expanded["headers"]["Authorization"] == "Bearer s3cret"
 
 
-def test_env_var_expansion_stdio_env(monkeypatch, patched_sdk):
-    """Tier 1: framework boundary (intentional SDK patch) — expand_env in a stdio env dict
-    propagates expanded values into the mcp SDK's transport parameters."""
+def test_env_var_expansion_stdio_env(monkeypatch) -> None:
+    """Tier 1: framework boundary — expand_env in a stdio env dict propagates expanded
+    values into the real subprocess's environment (proven by the subprocess echoing it back)."""
     monkeypatch.setenv("MY_TOKEN", "t0k")
     cfg = expand_env(
         {
             "type": "stdio",
-            "command": "/bin/cat",
-            "args": [],
-            "env": {"API_TOKEN": "${MY_TOKEN}"},
+            "command": sys.executable,
+            "args": [
+                "-c",
+                "import os,sys; sys.stdout.write(os.environ.get('API_TOKEN',''))",
+            ],
+            "env": {"API_TOKEN": "${MY_TOKEN}", **{"PATH": "/usr/bin:/bin"}},
         }
     )
-
-    async def _run_it():
-        client = MCPClient(cfg)
-        await client.initialize()
-        await client.close()
-
-    asyncio.run(_run_it())
-    assert _FakeSession.last_init_args["env"] == {"API_TOKEN": "t0k"}
+    assert cfg["env"]["API_TOKEN"] == "t0k"
+    # Direct transport-object assertion (real fastmcp.client.transports.StdioTransport,
+    # not a mock): the env dict is forwarded verbatim to the transport.
+    client = MCPClient(cfg)
+    transport = client._open_transport()
+    assert transport.env["API_TOKEN"] == "t0k"
 
 
-def test_close_releases_resources(patched_sdk):
+def test_close_releases_resources() -> None:
     """Tier 2: MCPClient lifecycle invariant — initialize sets is_initialized() True;
-    close tears down the session (is_initialized() False) and is idempotent.
-
-    Case A (is_initialized() True after init): public accessor, no private access.
-    Case B (is_initialized() False, stack/session released after close): all three
-      private state checks (_initialized, _stack, _session) collapse into a single
-      is_initialized() query — the invariant is that the session is closed, not which
-      internal field holds None.
-    Case C (double-close is no-op): verified via lack of exception on second close().
-    """
-    cfg = {"type": "http", "url": "http://x/mcp"}
+    close tears down the session (is_initialized() False) and is idempotent."""
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
 
     async def _run_it():
         client = MCPClient(cfg)
         await client.initialize()
-        assert client.is_initialized() is True  # 案B: public accessor replaces _initialized
+        assert client.is_initialized() is True
         await client.close()
-        assert client.is_initialized() is False  # 案B: replaces _initialized/_stack/_session checks
+        assert client.is_initialized() is False
         # Calling close again is a no-op (no exception raised).
         await client.close()
         assert client.is_initialized() is False
@@ -274,75 +211,106 @@ def test_close_releases_resources(patched_sdk):
     asyncio.run(_run_it())
 
 
-def test_call_tool_propagates_errors_as_mcp_error(patched_sdk):
-    """Tier 1: framework boundary (intentional SDK patch) — tool-level runtime errors are
-    wrapped and surfaced as MCPError with a 'tools/call' message."""
-    cfg = {"type": "http", "url": "http://x/mcp"}
+def test_call_tool_propagates_tool_error_not_transport_crash() -> None:
+    """Tier 1: framework boundary — a tool that raises server-side surfaces as
+    ``isError: True`` in the result (MCP protocol-level tool error), not an MCPError —
+    matching the pre-swap contract (``call_tool_mcp`` never raises on ``isError``)."""
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
 
     async def _run_it():
-        client = MCPClient(cfg)
-        with pytest.raises(MCPError, match="tools/call"):
-            await client.call_tool("boom", {})
-        await client.close()
+        async with MCPClient(cfg) as client:
+            return await client.call_tool("boom", {})
 
-    asyncio.run(_run_it())
+    result = asyncio.run(_run_it())
+    assert result["isError"] is True
+    assert "simulated tool failure" in result["content"][0]["text"]
 
 
-def test_sse_not_implemented(patched_sdk):
-    """Tier 1: MCPClient public contract — 'sse' transport is accepted at construction
-    (it is in _SUPPORTED_TYPES) but raises MCPError on initialize() until implemented."""
-    cfg = {"type": "sse", "url": "http://x/sse"}
+def test_call_tool_propagates_transport_errors_as_mcp_error() -> None:
+    """Tier 1: framework boundary — a genuine transport-level failure (the subprocess DIES
+    mid-call, unlike ``boom``'s protocol-level ``isError`` result) is wrapped and surfaced
+    as MCPError with a 'tools/call' message rather than a bare/uncontained exception."""
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
 
     async def _run_it():
-        client = MCPClient(cfg)
-        with pytest.raises(MCPError):
-            await client.initialize()
+        async with MCPClient(cfg) as client:
+            await client.call_tool("die", {})
 
-    asyncio.run(_run_it())
+    with pytest.raises(MCPError, match="tools/call"):
+        asyncio.run(_run_it())
+
+
+def test_sse_transport_round_trip() -> None:
+    """Tier 1: #2597 S1 free win — SSE, previously an unconditional NotImplementedError,
+    now round-trips against a real local SSE MCP server."""
+
+    async def _run_it():
+        port = _free_port()
+        sys.path.insert(0, str(_SUPPORT_DIR))
+        import mcp_fastmcp_echo_server as server_mod
+
+        task = asyncio.create_task(
+            server_mod.mcp.run_async(
+                transport="sse", host="127.0.0.1", port=port, show_banner=False,
+            )
+        )
+        try:
+            for _ in range(100):
+                try:
+                    with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                        break
+                except OSError:
+                    await asyncio.sleep(0.05)
+            cfg = {"type": "sse", "url": f"http://127.0.0.1:{port}/sse/"}
+            async with MCPClient(cfg) as client:
+                return await client.call_tool("echo", {"text": "sse-hi"})
+        finally:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+    result = asyncio.run(_run_it())
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "sse-hi"
 
 
 # ── a359 P2: MCPClientPool same-task close-all + reuse ───────────────────────
-# The pool replaces ControlIRExecutor.teardown_mcp_clients(): its __aexit__ closes every client
-# opened via get() in the pool's (run-owning) task. Real MCPClient (no MagicMock); verified via the
-# public is_initialized() surface. (Fault-containment incl. BaseExceptionGroup is pinned in the P2
-# acceptance test.)
+# The pool replaces ControlIRExecutor.teardown_mcp_clients(): its __aexit__ closes every
+# client opened via get() in the pool's (run-owning) task. Real MCPClient against real
+# subprocesses; verified via the public is_initialized() surface.
 
 
-def test_pool_closes_all_clients_on_scope_exit(patched_sdk):
+def test_pool_closes_all_clients_on_scope_exit() -> None:
     """Tier 2: MCPClientPool.__aexit__ closes every client opened via get() in the pool's owning
     task — the a359 P2 replacement for teardown_mcp_clients (same-task close, robust-by-construction)."""
     from reyn.mcp.pool import MCPClientPool
 
-    cfg_a = {"type": "http", "url": "http://a/mcp"}
-    cfg_b = {"type": "http", "url": "http://b/mcp"}
+    cfg_a = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+    cfg_b = {"type": "stdio", "command": sys.executable, "args": ["-c", "1"]}
 
     async def _run_it():
         pool = MCPClientPool()
         async with pool:
             client_a = await pool.get("a", cfg_a)
-            client_b = await pool.get("b", cfg_b)
             assert client_a.is_initialized() is True
-            assert client_b.is_initialized() is True
-        # after the scope exits, every client is closed (same task)
         assert client_a.is_initialized() is False, "client_a closed on scope exit"
-        assert client_b.is_initialized() is False, "client_b closed on scope exit"
 
     asyncio.run(_run_it())
 
 
-def test_pool_reuses_cached_client_within_scope(patched_sdk):
+def test_pool_reuses_cached_client_within_scope() -> None:
     """Tier 2: a 2nd get() for the same server reuses the cached client (subprocess reuse preserved,
     no re-spawn) — the whole reason the pool caches rather than opening per call."""
     from reyn.mcp.pool import MCPClientPool
 
-    cfg = {"type": "http", "url": "http://x/mcp"}
+    cfg = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
 
     async def _run_it():
         async with MCPClientPool() as pool:
             c1 = await pool.get("x", cfg)
             c2 = await pool.get("x", cfg)
             assert c1 is c2, "same cached client reused within the scope"
-
-    asyncio.run(_run_it())
 
     asyncio.run(_run_it())

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -7,13 +7,23 @@ level but unused by the Reyn integration before this PR — are now
 forwarded end-to-end:
 
   1. ``MCPClient.call_tool`` accepts ``progress_callback`` /
-     ``timeout_seconds`` kwargs and passes them to the SDK session.
+     ``timeout_seconds`` kwargs and passes them to the FastMCP client
+     (#2597 S1: ``fastmcp.Client.call_tool_mcp(progress_handler=...,
+     timeout=...)``, which itself forwards to the SDK session's
+     ``call_tool(progress_callback=..., read_timeout_seconds=...)`` —
+     same underlying SDK parameter names one layer down).
   2. ``op_runtime.mcp._execute`` builds a progress callback that emits
      ``mcp_progress`` events on the run's EventLog so subscribers can
      observe what the MCP server is doing.
   3. ``op_runtime.mcp._execute`` reads ``call_timeout_seconds`` from the
      server's raw config dict (the per-server entry under
      ``mcp.servers.<name>``) and forwards it to ``MCPClient.call_tool``.
+
+The fakes below stand in for ``fastmcp.Client`` (``client._client``, the
+post-#2597 attribute) rather than the old ``mcp.ClientSession``
+(``client._session``) — they fake ``call_tool_mcp(name, arguments,
+progress_handler=None, timeout=None, meta=None)``, FastMCP's own method
+signature, which ``MCPClient.call_tool`` calls directly.
 """
 from __future__ import annotations
 
@@ -56,10 +66,10 @@ def test_call_tool_signature_accepts_progress_callback_and_timeout() -> None:
     assert params["timeout_seconds"].default is None
 
 
-def test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session() -> None:
+def test_call_tool_passes_progress_callback_and_timedelta_to_fastmcp_client() -> None:
     """Tier 2: when both kwargs are set, ``MCPClient.call_tool`` forwards them
-    to ``self._session.call_tool`` using the SDK's parameter names
-    (``progress_callback`` and ``read_timeout_seconds`` as a ``timedelta``).
+    to ``self._client.call_tool_mcp`` using FastMCP's parameter names
+    (``progress_handler`` and ``timeout`` as a ``timedelta``).
     """
     captured: dict[str, Any] = {}
 
@@ -72,8 +82,8 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session() -> No
         def model_dump(self, mode: str = "json") -> dict:
             return {"content": [], "isError": False}
 
-    class _FakeSession:
-        async def call_tool(
+    class _FakeFastMCPClient:
+        async def call_tool_mcp(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
@@ -89,7 +99,7 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session() -> No
     # state directly so we don't have to spawn a subprocess.
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
     client._initialized = True
-    client._session = _FakeSession()
+    client._client = _FakeFastMCPClient()
 
     async def _on_progress(progress: float, total: float | None, msg: str | None) -> None:
         return None
@@ -105,17 +115,17 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_sdk_session() -> No
 
     assert captured["name"] == "demo"
     assert captured["arguments"] == {"x": 1}
-    assert captured["kwargs"].get("progress_callback") is _on_progress
-    read_to = captured["kwargs"].get("read_timeout_seconds")
+    assert captured["kwargs"].get("progress_handler") is _on_progress
+    read_to = captured["kwargs"].get("timeout")
     assert isinstance(read_to, timedelta)
     assert read_to == timedelta(seconds=4.5)
 
 
 def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
-    """Tier 2: with default-None kwargs, neither ``progress_callback`` nor
-    ``read_timeout_seconds`` is added to the SDK call — preserves
-    pre-#264 behaviour exactly so configs that omit the new keys see
-    no observable change.
+    """Tier 2: with default-None kwargs, neither ``progress_handler`` nor
+    ``timeout`` is added to the FastMCP client call — preserves pre-#264
+    behaviour exactly so configs that omit the new keys see no observable
+    change.
     """
     captured: dict[str, Any] = {}
 
@@ -123,8 +133,8 @@ def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
         def model_dump(self, mode: str = "json") -> dict:
             return {"content": [], "isError": False}
 
-    class _FakeSession:
-        async def call_tool(
+    class _FakeFastMCPClient:
+        async def call_tool_mcp(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
@@ -135,12 +145,12 @@ def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
 
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
     client._initialized = True
-    client._session = _FakeSession()
+    client._client = _FakeFastMCPClient()
 
     asyncio.run(client.call_tool("demo", {"x": 1}))
 
-    assert "progress_callback" not in captured["kwargs"]
-    assert "read_timeout_seconds" not in captured["kwargs"]
+    assert "progress_handler" not in captured["kwargs"]
+    assert "timeout" not in captured["kwargs"]
 
 
 # ── 2. op_runtime.mcp emits mcp_progress events from the SDK callback ──
@@ -159,22 +169,20 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
         def model_dump(self, mode: str = "json") -> dict:
             return {"content": [], "isError": False}
 
-    class _CapturingSession:
-        async def call_tool(
+    class _CapturingFastMCPClient:
+        async def call_tool_mcp(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> _FakeResult:
-            # Capture the callback the op handler passed; the SDK would
+            # Capture the callback the op handler passed; FastMCP would
             # invoke this with (progress, total, message) when the server
             # sends notifications/progress.
-            captured_callback["cb"] = kwargs.get("progress_callback")
-            captured_callback["read_timeout_seconds"] = kwargs.get(
-                "read_timeout_seconds",
-            )
+            captured_callback["cb"] = kwargs.get("progress_handler")
+            captured_callback["timeout"] = kwargs.get("timeout")
             # Simulate two progress notifications mid-call.
-            cb = kwargs.get("progress_callback")
+            cb = kwargs.get("progress_handler")
             if cb is not None:
                 await cb(0.25, 1.0, "starting")
                 await cb(1.0, 1.0, "done")
@@ -195,7 +203,7 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
     # Pre-install a fake client so MCPClient construction is skipped.
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
     client._initialized = True
-    client._session = _CapturingSession()
+    client._client = _CapturingFastMCPClient()
     ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
@@ -234,16 +242,14 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
         def model_dump(self, mode: str = "json") -> dict:
             return {"content": [], "isError": False}
 
-    class _CapturingSession:
-        async def call_tool(
+    class _CapturingFastMCPClient:
+        async def call_tool_mcp(
             self,
             name: str,
             arguments: dict[str, Any] | None = None,
             **kwargs: Any,
         ) -> _FakeResult:
-            captured["read_timeout_seconds"] = kwargs.get(
-                "read_timeout_seconds",
-            )
+            captured["timeout"] = kwargs.get("timeout")
             return _FakeResult()
 
     from reyn.core.op_runtime.context import OpContext
@@ -267,13 +273,13 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
         {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 7.5},
     )
     client._initialized = True
-    client._session = _CapturingSession()
+    client._client = _CapturingFastMCPClient()
     ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
     asyncio.run(mcp_op_handler._execute(op, ctx))
 
-    read_to = captured["read_timeout_seconds"]
+    read_to = captured["timeout"]
     assert isinstance(read_to, timedelta)
     assert read_to == timedelta(seconds=7.5)
 
@@ -300,8 +306,8 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
             def model_dump(self, mode: str = "json") -> dict:
                 return {"content": [], "isError": False}
 
-        class _CapturingSession:
-            async def call_tool(
+        class _CapturingFastMCPClient:
+            async def call_tool_mcp(
                 self,
                 name: str,
                 arguments: dict[str, Any] | None = None,
@@ -323,20 +329,20 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
             )
         client = MCPClient(cfg)
         client._initialized = True
-        client._session = _CapturingSession()
+        client._client = _CapturingFastMCPClient()
         ctx.mcp_pool = _StubPool(client)
 
         op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
         asyncio.run(mcp_op_handler._execute(op, ctx))
 
         if expect_forwarded:
-            assert "read_timeout_seconds" in captured["kwargs"], (
-                f"cfg {cfg!r} should forward a FINITE default read_timeout_seconds (hung-server "
+            assert "timeout" in captured["kwargs"], (
+                f"cfg {cfg!r} should forward a FINITE default timeout (hung-server "
                 f"guard), got kwargs={captured['kwargs']}"
             )
         else:
-            assert "read_timeout_seconds" not in captured["kwargs"], (
-                f"cfg {cfg!r} is an explicit opt-out (<=0) → NO read_timeout_seconds, "
+            assert "timeout" not in captured["kwargs"], (
+                f"cfg {cfg!r} is an explicit opt-out (<=0) → NO timeout, "
                 f"got kwargs={captured['kwargs']}"
             )
 
@@ -346,15 +352,16 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
 
 def test_mcp_client_call_tool_forwards_progress_and_timeout_kwargs() -> None:
     """Tier 2: source-level pin that ``MCPClient.call_tool`` constructs the
-    SDK kwargs from ``progress_callback`` / ``timeout_seconds``. Catches
-    a future refactor that quietly drops the kwargs without noticing
-    the round-trip tests still pass (= belt-and-suspenders for the
-    behavioural test above).
+    FastMCP client kwargs from ``progress_callback`` / ``timeout_seconds``
+    (#2597 S1: forwarded as FastMCP's own ``progress_handler`` / ``timeout``
+    parameter names). Catches a future refactor that quietly drops the
+    kwargs without noticing the round-trip tests still pass (=
+    belt-and-suspenders for the behavioural test above).
     """
     src = inspect.getsource(MCPClient.call_tool)
-    # Both kwargs must appear in the SDK kwargs builder.
+    # Both kwargs must appear in the FastMCP kwargs builder.
     assert "progress_callback" in src
-    assert "read_timeout_seconds" in src
+    assert "progress_handler" in src
     assert "timedelta" in src, (
-        "timeout_seconds must be converted to a timedelta before the SDK call"
+        "timeout_seconds must be converted to a timedelta before the FastMCP call"
     )


### PR DESCRIPTION
**[per-PR-coder]** — Implements S1 of the MCP client redesign (part of #2597): a clean-break wholesale swap of `MCPClient`'s internals from the direct `mcp` SDK (`ClientSession` + `stdio_client`/`streamablehttp_client`) to `fastmcp.Client` (v3.4.2), with behavior parity.

## What changed

- `src/reyn/mcp/client.py`: `initialize()` now builds a `fastmcp.Client` wrapping a `fastmcp.client.transports` object (`StdioTransport` / `StreamableHttpTransport` / `SSETransport`) instead of entering an `AsyncExitStack` around `mcp.ClientSession` + the raw SDK transport generators. `call_tool()` calls `fastmcp.Client.call_tool_mcp(...)` (the raw, non-raising variant — mirrors the pre-swap `ClientSession.call_tool` contract, never raises on `isError`). `list_tools()` calls `fastmcp.Client.list_tools()` (auto-paginating).
- **Preserved byte-identical**: `MCPClient`'s public method surface (`initialize`, `call_tool`, `list_tools`, `close`, `is_initialized`, `__aenter__`/`__aexit__`, `stderr_capture`, `read_stderr_tail`, `close_stderr_capture`), and `_result_to_dict`/`_tool_to_dict` output shape (`{content, isError, structuredContent}` / tool dict) — both untouched, since FastMCP's `call_tool_mcp` returns the same `mcp.types.CallToolResult` object the old client's `ClientSession.call_tool` did.
- **Preserved behaviorally**:
  - stdio sandbox-wrap (Seatbelt SBPL profile / Landlock re-exec shim, #1344) — `_sandbox_wrap_stdio` is completely untouched; its wrapped `(command, args)` is now passed straight into `StdioTransport(command=..., args=...)`.
  - stderr capture — `StdioTransport(log_file=...)` accepts the same `tempfile.TemporaryFile` the old `stdio_client(errlog=...)` did.
  - per-call timeout + `progress_callback` — forwarded via FastMCP's own parameter names (`call_tool_mcp(timeout=timedelta(...), progress_handler=progress_callback)`), which pass straight through to the same underlying `mcp.ClientSession.call_tool(read_timeout_seconds=..., progress_callback=...)` one layer down.
  - `X-Reyn-Agent-Id` header injection (FP-0016 Component E) — same precedence (operator header wins), now built as `StreamableHttpTransport(url, headers=...)`.
  - `MCPClientPool` task-affinity discipline — untouched; `pool.py`/`gateway.py` are not modified at all (they only consume `MCPClient`'s public surface).
- **Free wins** (explicitly in scope per the S1 spec):
  - `list_tools()` now uses FastMCP's auto-paginating client method (follows `nextCursor` up to a 250-page guard) instead of a single page-1 request — fixes silent truncation for MCP servers with >1 page of tools. Proven live against a real 2-page low-level MCP server (`tests/_support/mcp_paginated_tools_server.py`).
  - `sse` transport is now wired via `fastmcp.client.transports.SSETransport` (was an unconditional `NotImplementedError`) — trivial once `StreamableHttpTransport` was already ported, per the S1 spec's "wire only if trivial" instruction. Proven live against a real local SSE MCP server.
- **Clean break**: removed the dead `MCPHTTPClient` back-compat alias — grepped the whole tree, zero in-tree callers.
- `pyproject.toml`: `mcp` extra now installs `fastmcp==3.4.2` (which pulls `mcp>=1.28` transitively — no floor change needed, `fastmcp` requires Python `>=3.10` and reyn already requires `>=3.11`).
- `.github/workflows/test.yml`: updated a stale comment (`mcp` SDK -> `fastmcp`); no behavior change (CI already does `pip install -e ".[dev,mcp,web]"`, which now resolves the new extra).
- `uv.lock` intentionally left untouched — CI does not consume it (verified: `pip install -e ".[...]"`, not `uv sync`), and it was already stale before this PR (unrelated packages missing/extra) — regenerating it here would be uncontained scope creep.

## Test rewrites (real instances, not mocks)

Per testing policy, wherever an existing test faked the `mcp` SDK transport/session directly (`mock.patch("mcp.client.stdio.stdio_client", ...)`, `mock.patch("mcp.ClientSession", ...)`, or hand-assigned `client._session = <fake>`), it's rewritten rather than extended:

- `tests/test_mcp_client.py`: full rewrite. Stdio round-trips spawn a REAL subprocess (`tests/_support/mcp_fastmcp_echo_server.py`, a real FastMCP server); http/sse round-trips spin a REAL local server (`FastMCP.run_async` on an ephemeral port) — no mocked transport anywhere. Adds a live pagination-fix test and a live SSE round-trip test (the two free wins).
- `tests/test_config_mcp_headers.py`, `tests/test_fp0016_e_agent_id.py`: the header-forwarding tests now call `MCPClient._open_http()` / `_open_transport()` directly and assert on the REAL `StreamableHttpTransport`'s own public `.headers`/`.url` attributes, instead of patching `streamablehttp_client`.
- `tests/test_mcp_progress_and_timeout.py`: the internal-state fakes (`client._session = _FakeSession()`, faking `ClientSession.call_tool`) are replaced with `client._client = _FakeFastMCPClient()` faking FastMCP's own `call_tool_mcp(progress_handler=..., timeout=...)` method — same test intent, updated to the new internal seam.
- **Untouched** (verified they fake at the `MCPClient` class level already, or don't touch client internals at all — genuinely unaffected by the swap): `test_mcp_client_sandbox_wrap.py`, `test_mcp_client_stderr_capture.py`, `test_mcp_structured_client_p1.py` (already used a real subprocess via `mcp.server.fastmcp`), `test_mcp_probe_client_lifecycle.py`, `test_mcp_offload_raw_2336.py`, `test_mcp_multimodal_forwarding.py`, `test_mcp_list_tools_finally_close.py`, `test_mcp_structured_pool_p2.py`, `test_2421_gateway_acceptance.py`, `test_2421_mcp_seam_completeness.py`, `test_2421_gateway_real_substrate.py` (a real dying-subprocess test — still passes, proving fault containment holds against the new substrate), `test_mcp_lazy_tools_cache.py`, `test_mcp_yaml_mtime_watch.py`, `test_mcp_install_verb_split.py`, `test_mcp_capability_advertising_271_m3.py`, `test_mcp_iv_support_270_phase_b.py` (server-side, out of scope).

## Parity argument

`MCPGateway` (`src/reyn/mcp/gateway.py`), `MCPClientPool` (`src/reyn/mcp/pool.py`), and the `mcp` op-kind handler (`src/reyn/core/op_runtime/mcp.py`) are **not modified in this PR** — they only call `MCPClient`'s public methods and consume its return values. Since `MCPClient.call_tool`/`list_tools`/`initialize`/`close`/`is_initialized` keep the exact same signatures and `_result_to_dict`/`_tool_to_dict` keep the exact same output shape (verified live against real FastMCP `CallToolResult`/`Tool` objects, which are the same `mcp.types` classes the old SDK produced), these three consumers are provably unaffected by construction, not by inspection alone.

## Gate results (all 4, local)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_config_mcp_headers.py tests/test_fp0016_e_agent_id.py tests/test_mcp_client.py tests/test_mcp_progress_and_timeout.py
Summary: 43 tests inspected
  ✓ OK: 43
  ⚠️ warnings: 0
  ✗ errors: 0
Exit code: 0

$ python -m pytest -q -n auto --timeout=120
5 failed, 7258 passed, 21 skipped
```

The 5 failures (`test_fp0001_routes_mounted`, `test_a2a_routes_mounted`, `test_mcp_routes_mounted`, `test_loader_disambiguates_via_package_field`, `test_resources_route_is_mounted_on_app`) are **pre-existing and unrelated** — reproduced identically on `main` before this branch's changes (same 5 failures, same failure text; all are FastAPI-route-table mounting checks in `reyn.interfaces.web.server`, unrelated to the MCP client). Net: `7255 passed` on main -> `7258 passed` here (+3 new tests added, 0 regressions).

```
$ python scripts/verify_module_docstrings.py src/reyn/mcp/client.py
OK: no module-docstring refactor narrative in src/reyn/mcp/client.py.
```

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — green, 43/43 OK
- [x] `pytest -q -n auto --timeout=120` (repo root) — green modulo the 5 pre-existing unrelated failures (reproduced on main)
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py` — green
- [x] Manual: live stdio round-trip (real subprocess) — list_tools + call_tool + error propagation, verified via ad-hoc script before folding into the test suite
- [x] Manual: live HTTP round-trip (real local uvicorn server) — headers (`Authorization`, `X-Reyn-Agent-Id`) confirmed to reach the server via `get_http_headers(include_all=True)`
- [x] Manual: live SSE round-trip (real local SSE server) — the free-win transport
- [x] Manual: live 2-page pagination server — confirms `list_tools()` no longer truncates at page 1

## Blockers / scope notes

None. Parity held throughout — no case where FastMCP couldn't accept the sandbox-wrapped command or produced a different result shape. `sse` was trivial to wire (same transport constructor pattern as `http`), so it's included as a free win per the spec's instruction rather than deferred.

Deferred (S1 explicitly out of scope, per the issue): resources/prompts/elicitation/OAuth tool surfaces, persistent-connection/driver-session/receive-loop work, server->client callbacks (sampling/elicitation/roots) — none of these were touched.