### PR TITLE
feat(#2597): S2a — MCPConnectionService (held-open MCP connections for session lifetime)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from reyn.data.workspace.media_store import MediaStore
     from reyn.data.workspace.workspace import Workspace
     from reyn.llm.model_resolver import ModelResolver
+    from reyn.mcp.connection_service import MCPConnectionService
     from reyn.mcp.pool import MCPClientPool
     from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
     from reyn.security.sandbox import SandboxBackend
@@ -61,6 +62,13 @@ class OpContext:
     # in a possibly-different task → the cross-SDK-task cancel-scope crash). None outside an MCP
     # context (non-MCP ops never invoke the mcp handler).
     mcp_pool: "MCPClientPool | None" = None
+    # #2597 S2a: the session-owned held-open connection service (Option C — one
+    # persistent MCPClient per server, reused for the session's lifetime). When
+    # set, the mcp op handler prefers THIS over ``mcp_pool`` (pool-compatible
+    # ``get()`` — see connection_service.py). None for the ephemeral-session /
+    # one-shot-probe path, which intentionally keeps the per-call ``mcp_pool``
+    # (held connections would just churn for a sub-second-lived session).
+    mcp_connection_service: "MCPConnectionService | None" = None
     # FP-0016 Component E: agent identity for X-Reyn-Agent-Id header on
     # outgoing MCP / external HTTP calls. Plumbed from Session's
     # ReynConfig.agent.id (= `reyn/<hostname>` by default). None

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -40,10 +40,13 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
         if expanded.get("url"):
             expanded = {**expanded, "type": "http"}
 
-    # #a359 P2: the client comes from the per-turn structured pool (opened + closed in the pool's
-    # owning task — no cross-SDK-task teardown). None = no pool wired on this ctx (a non-MCP
-    # OpContext should never reach the mcp handler; guard defensively).
-    if ctx.mcp_pool is None:
+    # #2597 S2a: prefer the session-owned held-open connection service (Option C) when wired —
+    # it replaces the per-turn pool on the live (non-ephemeral) session path with one persistent
+    # connection per server, reused across turns/tasks. Falls back to the #a359 P2 per-turn
+    # structured pool (opened + closed in the pool's owning task) for the ephemeral-session /
+    # one-shot path. Neither wired = no MCP context wired on this ctx (a non-MCP OpContext should
+    # never reach the mcp handler; guard defensively).
+    if ctx.mcp_connection_service is None and ctx.mcp_pool is None:
         return {"kind": "mcp", "status": "error", "server": op.server,
                 "tool": op.tool, "error": "no MCP client pool on this context"}
 
@@ -80,7 +83,7 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     # connect, a bad config, a malformed response, or a transport group all surface here as a clean
     # MCPFault → contained error tool-result (owner req: MCP misbehavior must not crash the router
     # loop). Cancellation is never swallowed (is_real_control_flow re-raises genuine cancel/KI/SE).
-    gateway = MCPGateway(pool=ctx.mcp_pool, agent_id=ctx.agent_id)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
     try:
         result = await gateway.call_tool(
             op.server, op.tool, op.args, expanded, progress_cb=_on_progress,

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -25,13 +25,29 @@ loop / ping): a subprocess death or HTTP disconnect mid-session does NOT flip
 ``MCPClient.is_initialized()`` or the underlying ``fastmcp.Client.is_connected()``
 (verified empirically against the real echo test server's ``die`` tool — both stay
 True after the transport is gone) — the only observable signal is an :class:`MCPError`
-raised on the NEXT use. So the held-connection handle catches an ``MCPError`` from
-``call_tool``/``list_tools``, discards + reopens the connection ONCE, and retries the
-SAME call on the fresh connection. If the retry also fails, the fault propagates
-unchanged (the caller's existing MCPGateway fault boundary contains it into an
-LLM-visible error result, same as the pre-S2a per-call path) — a dropped connection
-must not permanently wedge the server for the rest of the session, but this is not a
-silent-retry-forever loop.
+raised on the NEXT use. So the held-connection handle catches an ``MCPError``, discards
++ reopens the dead connection so the NEXT call lands on a healthy transport — a dropped
+connection must not permanently wedge the server for the rest of the session.
+
+CRITICAL — the reconnect must NOT silently retry a side-effectful call (at-most-once):
+post-S1 ``call_tool`` raises ``MCPError`` on ANY transport failure, including the
+drop-AFTER-execution window (the server RAN the tool, then the connection dropped before
+its response arrived). Auto-retrying the same call on the fresh connection would
+RE-EXECUTE the tool — an at-most-once → at-least-once regression vs the pre-S2a per-call
+pool (a duplicated ``create_issue`` / ``send_email`` / counter increment). So the two op
+classes are healed differently:
+
+  - :meth:`_HeldConnection.call_tool` — **reconnect-then-propagate**: on ``MCPError``,
+    heal the connection (reopen) but RE-RAISE the original error. The call is NOT
+    retried, so a tool is executed at most once. The first ``call_tool`` right after an
+    idle drop fails once; the healed connection makes every subsequent call succeed
+    (S2b's proactive ping loop will detect the drop BEFORE the next call, delivering
+    transparent healing SAFELY — S2a does not trade correctness for that UX).
+  - :meth:`_HeldConnection.list_tools` — **retry-once**: an idempotent read is safe to
+    re-run on the fresh connection, so it heals transparently (no user-visible failure).
+
+Either way the fault the caller ultimately sees is contained by the existing MCPGateway
+boundary into an LLM-visible error result, same as the pre-S2a per-call path.
 
 Runtime-only state (S2a scope note): held connections are NOT WAL-derived / recoverable
 state — they are reconstructed fresh (lazy-connect) after any process restart, exactly
@@ -205,20 +221,34 @@ class _HeldConnection:
         progress_callback: Any = None,
         timeout_seconds: float | None = None,
     ) -> dict[str, Any]:
-        return await self._with_reconnect(
+        # Reconnect-then-propagate (heal_only): a tool call is potentially
+        # side-effectful, so on a transport MCPError we HEAL the connection (for the
+        # next call) but RE-RAISE — never re-run the call — to preserve at-most-once
+        # (a mid-execution drop must not double-execute the tool). See module docstring.
+        return await self._heal(
             lambda c: c.call_tool(
                 name, args, progress_callback=progress_callback, timeout_seconds=timeout_seconds,
-            )
+            ),
+            heal_only=True,
         )
 
     async def list_tools(self) -> list[dict[str, Any]]:
-        return await self._with_reconnect(lambda c: c.list_tools())
+        # Retry-once: tools/list is an idempotent read, safe to re-run on the fresh
+        # connection, so it heals transparently (no user-visible failure).
+        return await self._heal(lambda c: c.list_tools(), heal_only=False)
 
-    async def _with_reconnect(self, op: "Callable[[MCPClient], Awaitable[Any]]") -> Any:
+    async def _heal(
+        self, op: "Callable[[MCPClient], Awaitable[Any]]", *, heal_only: bool,
+    ) -> Any:
         """Run ``op`` against the currently-held client. On an :class:`MCPError` —
         the only observable signal of a dead connection (see module docstring) —
-        discard + reopen the connection ONCE and retry ``op`` on the fresh client.
-        A second failure propagates unchanged (no silent retry loop)."""
+        discard + reopen the connection.
+
+        ``heal_only=True`` (side-effectful ``call_tool``): re-raise the ORIGINAL error
+        after healing — do NOT re-run ``op`` (preserves at-most-once; the healed
+        connection serves the NEXT call). ``heal_only=False`` (idempotent ``list_tools``):
+        retry ``op`` ONCE on the fresh connection; a second failure propagates unchanged
+        (no silent retry loop)."""
         client = await self._service._ensure_open(
             self._server, self._config, agent_id=self._agent_id,
         )
@@ -228,4 +258,6 @@ class _HeldConnection:
             fresh = await self._service._reconnect(
                 self._server, self._config, agent_id=self._agent_id,
             )
+            if heal_only:
+                raise  # at-most-once: connection healed for the next call, but this call is NOT retried
             return await op(fresh)

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -1,0 +1,231 @@
+"""MCPConnectionService — per-session held-open MCP connections (#2597 S2a).
+
+Option C from the S2-pre spike (owner-delegated, do not relitigate): a persistent MCP
+connection lives as a service INSIDE the agent's own session — not a separate driver
+session. The spike proved the key precondition: FastMCP holds its client session in a
+dedicated ``asyncio.Task``, so a client opened in task A is safely ``call_tool``'d from
+task B on the SAME event loop. That is what makes holding connections open across
+unrelated chat turns (which may run in different asyncio Tasks) safe, unlike
+:class:`~reyn.mcp.pool.MCPClientPool` (a359 P2), whose ``get()`` fails fast off its
+owning task because ITS contract is per-turn/task-affine by design.
+
+Replaces the per-call open->close model on the live (non-ephemeral) session MCP path:
+the pool opened + closed a fresh ``MCPClient`` (subprocess/HTTP session) on every single
+tool call, which is correct but wasteful — this service opens each configured server
+ONCE and reuses it for the rest of the session's lifetime.
+
+Pool-compatible surface: ``get(server, config, *, agent_id=None) -> MCPClient`` matches
+:meth:`MCPClientPool.get` byte-for-byte, so :class:`~reyn.mcp.gateway.MCPGateway` (the
+one seam every MCP op flows through) works UNCHANGED when constructed with
+``MCPGateway(pool=connection_service, ...)`` — it never has to know which kind of pool
+it was handed.
+
+Reconnect-on-demand (S2a-level resilience — deliberately NOT S2b's background health
+loop / ping): a subprocess death or HTTP disconnect mid-session does NOT flip
+``MCPClient.is_initialized()`` or the underlying ``fastmcp.Client.is_connected()``
+(verified empirically against the real echo test server's ``die`` tool — both stay
+True after the transport is gone) — the only observable signal is an :class:`MCPError`
+raised on the NEXT use. So the held-connection handle catches an ``MCPError`` from
+``call_tool``/``list_tools``, discards + reopens the connection ONCE, and retries the
+SAME call on the fresh connection. If the retry also fails, the fault propagates
+unchanged (the caller's existing MCPGateway fault boundary contains it into an
+LLM-visible error result, same as the pre-S2a per-call path) — a dropped connection
+must not permanently wedge the server for the rest of the session, but this is not a
+silent-retry-forever loop.
+
+Runtime-only state (S2a scope note): held connections are NOT WAL-derived / recoverable
+state — they are reconstructed fresh (lazy-connect) after any process restart, exactly
+like the pool's per-call clients were. Nothing here writes to the WAL.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.pool import describe_fault, is_real_control_flow
+
+logger = logging.getLogger(__name__)
+
+
+class MCPConnectionService:
+    """Holds one open :class:`MCPClient` per configured server for the service's
+    lifetime (= the owning agent session's lifetime). See module docstring for the
+    Option C rationale, the pool-compatible ``get()`` contract, and the
+    reconnect-on-demand design.
+
+    Usage (mirrors ``MCPClientPool``, but no ``async with`` is required to use it —
+    only :meth:`aclose` needs to run, at session teardown)::
+
+        service = MCPConnectionService()
+        client = await service.get("srv", cfg, agent_id="reyn/host")
+        await client.call_tool("read_file", {"path": "x"})
+        ...  # later turns, later tasks: the SAME connection is reused
+        await service.aclose()  # session teardown — closes every held connection
+    """
+
+    def __init__(self) -> None:
+        self._clients: dict[str, MCPClient] = {}
+        # One handle per server, cached so repeated get() calls for the same server
+        # return the SAME object (connection-reuse identity) across the connection's
+        # whole lifetime, including through a reconnect: the handle looks up the
+        # live MCPClient by server name on every call rather than binding to one
+        # MCPClient instance.
+        self._handles: dict[str, "_HeldConnection"] = {}
+        # Per-server lock so two concurrent first-use get() calls for the SAME server
+        # (e.g. two chat turns racing on session startup) don't both open a client.
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def held_servers(self) -> list[str]:
+        """Names of servers with a currently-open held connection. Read-only
+        introspection for callers/tests — mirrors ``MCPClient.is_initialized()``'s
+        public-surface pattern (never reach into ``_clients`` directly)."""
+        return list(self._clients.keys())
+
+    def _lock_for(self, server: str) -> asyncio.Lock:
+        lock = self._locks.get(server)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[server] = lock
+        return lock
+
+    async def get(self, server: str, config: dict, *, agent_id: str | None = None) -> "MCPClient":
+        """Return the held connection handle for ``server``, opening (and caching)
+        it on first use. Pool-compatible signature — see module docstring.
+
+        Unlike ``MCPClientPool.get()``, this is intentionally NOT task-affine: the
+        spike proved a FastMCP client's session task makes cross-task use safe, so a
+        held connection opened during one chat turn (one asyncio Task) is reused
+        from a later turn running in a different Task without failing fast.
+        """
+        async with self._lock_for(server):
+            await self._ensure_open(server, config, agent_id=agent_id)
+            handle = self._handles.get(server)
+            if handle is None:
+                handle = _HeldConnection(self, server, config, agent_id)
+                self._handles[server] = handle
+            return handle  # type: ignore[return-value]  # duck-types MCPClient's call_tool/list_tools/is_initialized
+
+    async def _ensure_open(
+        self, server: str, config: dict, *, agent_id: str | None,
+    ) -> MCPClient:
+        """Return the live held client for ``server``, discarding + reopening a
+        client that was explicitly closed out from under this service (defensive —
+        the common dead-connection case is caught reactively by ``_HeldConnection``,
+        not detected here; see module docstring)."""
+        client = self._clients.get(server)
+        if client is not None and not client.is_initialized():
+            self._clients.pop(server, None)
+            client = None
+        if client is None:
+            client = MCPClient(config, agent_id=agent_id)
+            await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
+            self._clients[server] = client
+        return client
+
+    async def _reconnect(
+        self, server: str, config: dict, *, agent_id: str | None,
+    ) -> MCPClient:
+        """Discard the (dead) held client for ``server`` and open a fresh one.
+        Teardown of the dead client is best-effort — its transport is already gone,
+        so a teardown fault here is expected and never blocks the reconnect."""
+        old = self._clients.pop(server, None)
+        if old is not None:
+            try:
+                await old.__aexit__(None, None, None)
+            except BaseException as exc:  # noqa: BLE001 — best-effort; the connection is already dead
+                if is_real_control_flow(exc):
+                    raise
+                logger.warning(
+                    "MCPConnectionService: teardown of dead connection %r contained: %r",
+                    server, exc,
+                )
+        return await self._ensure_open(server, config, agent_id=agent_id)
+
+    async def aclose(self) -> None:
+        """Close every held connection. Idempotent — safe to call repeatedly (e.g. a
+        session teardown seam that may run more than once)."""
+        clients = list(self._clients.items())
+        self._clients.clear()
+        self._handles.clear()
+        for name, client in clients:
+            try:
+                await client.__aexit__(None, None, None)
+            except BaseException as exc:  # noqa: BLE001 — fault isolation mirrors MCPClientPool.__aexit__
+                if is_real_control_flow(exc):
+                    raise
+                logger.warning(
+                    "MCPConnectionService: teardown of %r contained: %r",
+                    name, describe_fault(exc),
+                )
+
+    async def __aenter__(self) -> "MCPConnectionService":
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        await self.aclose()
+
+
+class _HeldConnection:
+    """Duck-typed drop-in for :class:`MCPClient`, returned by
+    :meth:`MCPConnectionService.get`. Exposes exactly the surface
+    :class:`~reyn.mcp.gateway.MCPGateway` calls (``call_tool`` / ``list_tools`` /
+    ``is_initialized``) so it's usable anywhere a bare ``MCPClient`` is expected.
+
+    Looks up the currently-live held ``MCPClient`` by server name on every call
+    instead of binding to one instance at construction time, so this handle's
+    identity stays stable across the WHOLE connection lifetime — including through
+    a reconnect (see :meth:`_with_reconnect`). A caller that stashed an earlier
+    ``get()`` result keeps working after a reconnect without calling ``get()``
+    again.
+    """
+
+    def __init__(
+        self,
+        service: MCPConnectionService,
+        server: str,
+        config: dict,
+        agent_id: str | None,
+    ) -> None:
+        self._service = service
+        self._server = server
+        self._config = config
+        self._agent_id = agent_id
+
+    def is_initialized(self) -> bool:
+        client = self._service._clients.get(self._server)
+        return client is not None and client.is_initialized()
+
+    async def call_tool(
+        self,
+        name: str,
+        args: dict[str, Any],
+        *,
+        progress_callback: Any = None,
+        timeout_seconds: float | None = None,
+    ) -> dict[str, Any]:
+        return await self._with_reconnect(
+            lambda c: c.call_tool(
+                name, args, progress_callback=progress_callback, timeout_seconds=timeout_seconds,
+            )
+        )
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        return await self._with_reconnect(lambda c: c.list_tools())
+
+    async def _with_reconnect(self, op: "Callable[[MCPClient], Awaitable[Any]]") -> Any:
+        """Run ``op`` against the currently-held client. On an :class:`MCPError` —
+        the only observable signal of a dead connection (see module docstring) —
+        discard + reopen the connection ONCE and retry ``op`` on the fresh client.
+        A second failure propagates unchanged (no silent retry loop)."""
+        client = await self._service._ensure_open(
+            self._server, self._config, agent_id=self._agent_id,
+        )
+        try:
+            return await op(client)
+        except MCPError:
+            fresh = await self._service._reconnect(
+                self._server, self._config, agent_id=self._agent_id,
+            )
+            return await op(fresh)

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -25,10 +25,13 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.mcp.client import MCPClient
 from reyn.mcp.pool import MCPClientPool, describe_fault, is_real_control_flow
+
+if TYPE_CHECKING:
+    from reyn.mcp.connection_service import MCPConnectionService
 
 # Generous finite default (owner S3): a hung server must not wedge the run, but the default is
 # lenient; operators tighten per server via ``call_timeout_seconds`` (``<= 0`` opts out).
@@ -61,11 +64,22 @@ def resolve_call_timeout(config: dict) -> "float | None":
 class MCPGateway:
     """The one object that touches :class:`MCPClient`. All MCP ops (list / call / probe) run here.
 
-    Pass an existing ``pool`` to REUSE cached clients within a turn (op-call path); omit it for a
+    Pass an existing ``pool`` to REUSE cached clients across calls (op-call path); omit it for a
     one-shot op (list / probe) — the gateway opens and closes its own pool for that call.
+
+    ``pool`` accepts anything with a pool-compatible ``get(server, config, *, agent_id=None)``:
+    :class:`~reyn.mcp.pool.MCPClientPool` (per-turn, task-affine) or
+    :class:`~reyn.mcp.connection_service.MCPConnectionService` (#2597 S2a — held open for the
+    whole session, cross-task-safe). The gateway itself never constructs either; it only calls
+    ``get()`` on whatever the caller injects.
     """
 
-    def __init__(self, *, pool: "MCPClientPool | None" = None, agent_id: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        pool: "MCPClientPool | MCPConnectionService | None" = None,
+        agent_id: str | None = None,
+    ) -> None:
         self._injected_pool = pool
         self._agent_id = agent_id
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -766,6 +766,16 @@ class AgentRegistry:
         ``agent_purged``) so rewind reconstructs the as-of-cut archived-state and
         honors the permanent purge (fork A). The ONE delete seam the action-layer
         callers (CLI / web + the spawn op) route through. Emit no-ops without a WAL."""
+        # #2597 S2a: close held MCP connections (Option C) for EVERY loaded session of
+        # this agent (main + any spawned sids still in memory) before ``self.remove``
+        # (sync) drops them from the in-memory map — ``remove`` has no async seam of
+        # its own, so this async wrapper is the teardown seam for the main session
+        # (mirrors ``remove_session``'s teardown for spawned sessions).
+        for sid in list(self._sessions.get(name, {}).keys()):
+            session = self._peek_session(name, sid)
+            aclose_mcp = getattr(session, "aclose_mcp_connections", None)
+            if callable(aclose_mcp):
+                await aclose_mcp()
         cascade_changes = self.remove(name, purge=purge)
         if self._state_log is not None:
             await self._state_log.append(
@@ -1907,6 +1917,15 @@ class AgentRegistry:
             quiesce = getattr(session, "await_quiescent", None)
             if callable(quiesce):
                 await quiesce()
+            # #2597 S2a: close any held MCP connections (Option C — persistent
+            # per-server connections opened for this session's lifetime) BEFORE the
+            # session drops out of the in-memory map below, so a dropped/rewound
+            # session doesn't leak an open subprocess/HTTP connection. A no-op for an
+            # ephemeral session (never populates the connection service) or a
+            # session built without one (getattr guard).
+            aclose_mcp = getattr(session, "aclose_mcp_connections", None)
+            if callable(aclose_mcp):
+                await aclose_mcp()
         for task_dict in (self._tasks, self._forward_tasks):
             task = task_dict.pop((name, sid), None)
             if task is not None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1050,6 +1050,17 @@ class Session:
             except Exception:
                 self._action_usage_tracker = None
         self._mcp_servers = mcp_servers
+        # #2597 S2a: the session-owned held-open MCP connection service (Option C —
+        # one persistent MCPClient per server, reused across chat turns/tasks for
+        # this session's whole lifetime). Constructed unconditionally (cheap — an
+        # empty dict until first ``get()``); ONLY the non-ephemeral MCP call sites
+        # (_mcp_call_tool / _mcp_list_tools) route through it — an ephemeral session
+        # (``self._ephemeral`` set post-construction by the registry) keeps using the
+        # per-call MCPClientPool so a sub-second-lived session never holds a
+        # connection open. Closed at session teardown via aclose_mcp_connections
+        # (registry.remove_session / archive_agent's main-session path).
+        from reyn.mcp.connection_service import MCPConnectionService
+        self._mcp_connection_service = MCPConnectionService()
         self.output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled
         self._project_context = project_context
@@ -5451,27 +5462,40 @@ class Session:
         # (open + list + teardown inside the contain-all boundary, a task-affine pool, a per-call
         # timeout) and raises ONLY MCPFault, never a bare BaseExceptionGroup. This is the owner's
         # Windows crash path: a server that dies mid-list can no longer escape as an uncontained
-        # group. A one-shot pool per call (no injected pool) — list is not batched across ops.
+        # group.
+        # #2597 S2a: a non-ephemeral session routes through its held-open connection service (Option
+        # C — no re-handshake on every list call); an ephemeral session keeps the pre-existing
+        # one-shot pool (no injected pool — list is not batched across ops), since holding a
+        # connection open for a sub-second-lived session is pure churn.
+        gateway = (
+            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            if not self._ephemeral
+            else MCPGateway(agent_id=self._agent_id)
+        )
         try:
-            return await MCPGateway(agent_id=self._agent_id).list_tools(server, expanded)
+            return await gateway.list_tools(server, expanded)
         except MCPFault as exc:
             return [{"error": str(exc)}]
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Invoke an MCP tool and return its result.
 
-        Close the per-call MCP clients in the same task that opened
-        them — the MCP SDK's ``stdio_client`` uses anyio cancel scopes
-        that are task-affine, and leaving them open until asyncio loop
-        teardown produces a "cancel scope crossed task boundary"
-        RuntimeError (= recurring crash on every chat session end
-        observed during the 2026-05-20 8-server smoke round).
+        #2597 S2a: a non-ephemeral session routes through its session-owned
+        ``MCPConnectionService`` (Option C) — the connection is opened ONCE and held
+        open for the rest of the session's lifetime (reused across chat turns/tasks;
+        the S2-pre spike proved this is cross-task-safe for a FastMCP client), closed
+        only at session teardown (``aclose_mcp_connections``, wired from
+        ``registry.remove_session`` / the main-session archive path).
 
-        Per-call open/close is fine for now: the chat router invokes
-        MCP tools individually and there's no value in caching across
-        unrelated tool calls. A future optimisation could pool clients
-        per-server within a single chat-turn act batch, but the same-
-        task-close discipline still applies.
+        An ephemeral session (``self._ephemeral``, set post-construction by the
+        registry) keeps the PRE-#2597 per-call ``MCPClientPool`` path below: close
+        the per-call MCP clients in the same task that opened them — the MCP SDK's
+        ``stdio_client`` uses anyio cancel scopes that are task-affine, and leaving
+        them open until asyncio loop teardown produces a "cancel scope crossed task
+        boundary" RuntimeError (= recurring crash on every chat session end observed
+        during the 2026-05-20 8-server smoke round). Holding a connection open for a
+        sub-second-lived ephemeral session is pure churn (F4 decision), so it keeps
+        opening + closing fresh per call.
         """
         from reyn.core.op_runtime import execute_op
         from reyn.schemas.models import MCPIROp
@@ -5491,6 +5515,9 @@ class Session:
             file_write=ctx.permission_decl.file_write,
             mcp=[server],
         )
+        if not self._ephemeral:
+            ctx.mcp_connection_service = self._mcp_connection_service
+            return await execute_op(op, ctx)
         # #a359 P2: a per-call structured pool — the client opens (pool.get in the op handler) AND
         # closes (pool __aexit__) in THIS task, and teardown faults (incl. BaseExceptionGroup) are
         # contained. Replaces the manual finally-close over ``ctx.mcp_clients`` (which closed a
@@ -5499,6 +5526,26 @@ class Session:
         async with MCPClientPool() as pool:
             ctx.mcp_pool = pool
             return await execute_op(op, ctx)
+
+    def mcp_held_servers(self) -> list[str]:
+        """Read-only introspection: names of MCP servers with a currently held-open
+        connection (#2597 S2a). Always ``[]`` for an ephemeral session (never
+        populates the connection service — see ``_mcp_call_tool``). Public surface
+        for callers/tests to observe connection-reuse/teardown without reaching into
+        ``_mcp_connection_service`` directly."""
+        return self._mcp_connection_service.held_servers()
+
+    async def aclose_mcp_connections(self) -> None:
+        """#2597 S2a teardown: close every held MCP connection this session opened.
+
+        Idempotent (``MCPConnectionService.aclose`` is idempotent). Called from the
+        registry's session-teardown seams (``remove_session`` for a spawned session;
+        ``archive_agent`` for the main session) — no new lifecycle owner, rides the
+        existing quiesce-then-teardown seam. Ephemeral sessions never populate the
+        service (they route MCP calls through the one-shot pool instead), so this is
+        a no-op for them.
+        """
+        await self._mcp_connection_service.aclose()
 
     # --- RouterLoop orchestration ---
 

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -12,6 +12,11 @@ Tools:
                             real FastMCP ``Context.report_progress`` API, so
                             progress-callback plumbing is exercised against the
                             real protocol (not a hand-rolled fake).
+  - ``pid()``            -> returns ``os.getpid()`` of THIS server process. Used
+                            by #2597 S2a connection-reuse tests to prove a second
+                            ``call_tool`` hit the SAME held subprocess (no
+                            re-handshake) rather than comparing Python object
+                            identity alone.
 
 Usage:
   stdio: ``python mcp_fastmcp_echo_server.py``
@@ -45,6 +50,13 @@ def die() -> str:
     import os
 
     os._exit(1)
+
+
+@mcp.tool()
+def pid() -> int:
+    import os
+
+    return os.getpid()
 
 
 @mcp.tool()

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -17,6 +17,11 @@ Tools:
                             ``call_tool`` hit the SAME held subprocess (no
                             re-handshake) rather than comparing Python object
                             identity alone.
+  - ``bump()`` /         -> a per-process side-effect counter (#2597 S2a). ``bump``
+    ``bump_then_die()``     increments + returns the count; ``bump_then_die``
+                            increments THEN kills the subprocess AFTER the side
+                            effect (drop-after-execution) — proves call_tool is
+                            at-most-once across a mid-call drop (no double-count).
 
 Usage:
   stdio: ``python mcp_fastmcp_echo_server.py``
@@ -57,6 +62,33 @@ def pid() -> int:
     import os
 
     return os.getpid()
+
+
+# #2597 S2a: a FILE-BACKED side-effect recorder. The count lives on disk (a byte
+# appended per execution) so it SURVIVES the subprocess death — unlike an in-memory
+# counter, which a fresh reconnected subprocess would reset. ``bump(path)`` records one
+# execution; ``bump_then_die(path)`` records the side effect THEN kills the subprocess
+# AFTER executing it (the drop-after-execution window). A caller that auto-retried
+# ``bump_then_die`` would append TWICE (once per subprocess); at-most-once appends once.
+@mcp.tool()
+def bump(path: str) -> str:
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("x")
+    return "bumped"
+
+
+@mcp.tool()
+def bump_then_die(path: str) -> str:
+    import os
+
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("x")
+        f.flush()
+        os.fsync(f.fileno())
+    # The side effect (the append) is durably on disk; now drop the transport BEFORE the
+    # response reaches the client — the drop-after-execution window.
+    os._exit(1)
+    return "unreachable"
 
 
 @mcp.tool()

--- a/tests/test_2421_mcp_seam_completeness.py
+++ b/tests/test_2421_mcp_seam_completeness.py
@@ -14,17 +14,19 @@ import re
 from pathlib import Path
 
 # The seam: the pool constructs clients; client.py defines the class (+ docstring examples).
-_ALLOWED = {"mcp/pool.py", "mcp/client.py"}
+_ALLOWED = {"mcp/pool.py", "mcp/client.py", "mcp/connection_service.py"}
 # ``MCPClient(`` construction — the paren distinguishes it from the ``MCPClientPool`` /
 # ``MCPClient`` type-reference (``Pool`` / ``]`` / import follows, not ``(``).
 _CONSTRUCT = re.compile(r"\bMCPClient\s*\(")
 
 
 def test_no_direct_mcpclient_construction_outside_seam():
-    """Tier 2: MCP ops go through MCPGateway → MCPClientPool → MCPClient. A new entry path that
-    constructs ``MCPClient(...)`` directly would bypass the contain-all boundary + task-affine
-    lifecycle (the sibling-sweep-miss class that caused the list-path crash). RED if a direct
-    construction reappears anywhere in src outside the pool/client seam."""
+    """Tier 2: MCP ops go through MCPGateway → (MCPClientPool | MCPConnectionService) → MCPClient
+    (#2597 S2a added the held-open connection service as a second pool-compatible seam alongside
+    the per-turn pool). A new entry path that constructs ``MCPClient(...)`` directly would bypass
+    the contain-all boundary + task-affine/reconnect lifecycle (the sibling-sweep-miss class that
+    caused the list-path crash). RED if a direct construction reappears anywhere in src outside the
+    pool/client/connection-service seam."""
     src = Path(__file__).resolve().parents[1] / "src" / "reyn"
     offenders: list[str] = []
     for py in src.rglob("*.py"):

--- a/tests/test_2597_s2a_mcp_connection_service.py
+++ b/tests/test_2597_s2a_mcp_connection_service.py
@@ -46,26 +46,56 @@ async def test_second_get_returns_same_held_client_no_rehandshake():
 
 
 @pytest.mark.asyncio
-async def test_dead_connection_transparently_reconnects():
-    """Tier 2: S2a reconnect-on-demand — killing the server subprocess (the ``die`` tool,
-    a REAL transport death) does not permanently wedge the server: the next call on the
-    SAME handle transparently reconnects (new subprocess PID) and succeeds, instead of
-    failing forever."""
+async def test_dead_connection_heals_next_call_after_transport_error():
+    """Tier 2: S2a reconnect-on-demand (heal-then-propagate) — killing the server
+    subprocess (the ``die`` tool, a REAL transport death) raises the transport MCPError
+    to the caller ONCE (call_tool is NOT auto-retried — at-most-once for side-effectful
+    tools), but HEALS the connection so the NEXT call transparently succeeds on a fresh
+    subprocess (new PID) instead of the server being permanently wedged."""
     service = MCPConnectionService()
     try:
         client = await service.get("srv", _CFG)
         pid_before = (await client.call_tool("pid", {}))["content"][0]["text"]
 
+        # The failing call raises (propagated, not silently retried).
         with pytest.raises(MCPError):
             await client.call_tool("die", {})
 
-        # transparent reconnect: the SAME handle keeps working post-death.
+        # ...but the connection was HEALED: the NEXT call succeeds on a fresh subprocess.
         result = await client.call_tool("echo", {"text": "still alive"})
         assert result["isError"] is False
         assert result["content"][0]["text"] == "still alive"
 
         pid_after = (await client.call_tool("pid", {}))["content"][0]["text"]
-        assert pid_after != pid_before, "reconnect opened a FRESH subprocess"
+        assert pid_after != pid_before, "heal opened a FRESH subprocess"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_call_tool_executed_at_most_once_across_mid_call_drop(tmp_path: Path):
+    """Tier 2: S2a at-most-once — a side-effectful call_tool whose connection drops
+    AFTER the server executed the tool (the drop-after-execution window) is NOT
+    re-executed by the reconnect. ``bump_then_die`` durably records ONE execution on
+    disk then kills the subprocess; the handle heals-then-propagates (raises), and the
+    file shows the side effect ran EXACTLY ONCE — not twice (which a naive retry-on-error
+    would cause: once per subprocess). This is the correctness guarantee the pre-S2a
+    per-call pool had and the reconnect must preserve."""
+    marker = tmp_path / "side_effects"
+    # The stdio server subprocess is Seatbelt-sandboxed to its cwd, so point cwd at
+    # tmp_path to make the marker file writable by the sandboxed tool.
+    cfg = {**_CFG, "cwd": str(tmp_path)}
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", cfg)
+        with pytest.raises(MCPError):
+            await client.call_tool("bump_then_die", {"path": str(marker)})
+        # the tool ran once (one appended byte), NOT twice (a retried re-execution).
+        assert marker.read_text() == "x", "side-effectful call executed exactly once"
+
+        # the connection still healed — a subsequent healthy call works on the fresh sub.
+        result = await client.call_tool("echo", {"text": "post"})
+        assert result["content"][0]["text"] == "post"
     finally:
         await service.aclose()
 

--- a/tests/test_2597_s2a_mcp_connection_service.py
+++ b/tests/test_2597_s2a_mcp_connection_service.py
@@ -1,0 +1,181 @@
+"""Tests for MCPConnectionService (#2597 S2a — held-open MCP connections, Option C).
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``. Stdio
+round-trips spawn a REAL subprocess running ``tests/_support/mcp_fastmcp_echo_server.py``
+(a real FastMCP server) — connection reuse is proven via the server's real ``pid()`` tool
+(same subprocess PID across calls), not just Python object identity. The ``die`` tool
+genuinely kills the subprocess mid-call to exercise the reconnect-on-demand path against a
+REAL transport failure (proven not to flip ``is_initialized()``/``is_connected()`` —
+see connection_service.py's module docstring).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPError
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.mcp.pool import MCPClientPool
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_CFG = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+
+
+@pytest.mark.asyncio
+async def test_second_get_returns_same_held_client_no_rehandshake():
+    """Tier 2: the CORE value of #2597 S2a — a 2nd ``get()`` for the same server returns
+    the SAME handle (identity) AND hits the SAME subprocess (real ``pid()`` round-trip
+    proves no re-handshake / no new subprocess), unlike the per-call pool it replaces."""
+    service = MCPConnectionService()
+    try:
+        client_a = await service.get("srv", _CFG)
+        client_b = await service.get("srv", _CFG)
+        assert client_a is client_b, "same handle returned across get() calls"
+
+        result_1 = await client_a.call_tool("pid", {})
+        result_2 = await client_b.call_tool("pid", {})
+        pid_1 = result_1["content"][0]["text"]
+        pid_2 = result_2["content"][0]["text"]
+        assert pid_1 == pid_2, "same underlying subprocess — no re-handshake"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_dead_connection_transparently_reconnects():
+    """Tier 2: S2a reconnect-on-demand — killing the server subprocess (the ``die`` tool,
+    a REAL transport death) does not permanently wedge the server: the next call on the
+    SAME handle transparently reconnects (new subprocess PID) and succeeds, instead of
+    failing forever."""
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", _CFG)
+        pid_before = (await client.call_tool("pid", {}))["content"][0]["text"]
+
+        with pytest.raises(MCPError):
+            await client.call_tool("die", {})
+
+        # transparent reconnect: the SAME handle keeps working post-death.
+        result = await client.call_tool("echo", {"text": "still alive"})
+        assert result["isError"] is False
+        assert result["content"][0]["text"] == "still alive"
+
+        pid_after = (await client.call_tool("pid", {}))["content"][0]["text"]
+        assert pid_after != pid_before, "reconnect opened a FRESH subprocess"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_all_held_clients():
+    """Tier 2: ``aclose()`` tears down every held connection and is idempotent — the
+    session-teardown contract (#2597 S2a scope item: no connections survive the service
+    past teardown)."""
+    service = MCPConnectionService()
+    await service.get("srv", _CFG)
+    assert service.held_servers() == ["srv"]
+
+    await service.aclose()
+    assert service.held_servers() == []
+
+    # idempotent — a second aclose() on an already-empty service is a no-op, not an error.
+    await service.aclose()
+    assert service.held_servers() == []
+
+    # a subsequent get() after aclose() opens a genuinely FRESH connection (lazy-connect
+    # after teardown — proves aclose() actually released the subprocess, not just the
+    # bookkeeping dict).
+    client = await service.get("srv", _CFG)
+    result = await client.call_tool("echo", {"text": "reopened"})
+    assert result["content"][0]["text"] == "reopened"
+    await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_call_result_parity_with_one_shot_pool():
+    """Tier 2: parity — the connection service and the pre-#2597 one-shot
+    ``MCPClientPool`` return byte-identical result shapes for the same call (the
+    connection service is a drop-in ``pool=`` for MCPGateway, not a shape change)."""
+    from reyn.mcp.gateway import MCPGateway
+
+    service = MCPConnectionService()
+    async with MCPClientPool() as pool:
+        try:
+            service_result = await MCPGateway(pool=service).call_tool(
+                "srv", "echo", {"text": "parity"}, _CFG,
+            )
+            pool_result = await MCPGateway(pool=pool).call_tool(
+                "srv", "echo", {"text": "parity"}, _CFG,
+            )
+        finally:
+            await service.aclose()
+    assert service_result == pool_result
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_session_never_populates_connection_service():
+    """Tier 2: F4 decision — an ephemeral session's MCP calls route through the one-shot
+    pool, NOT the session-owned MCPConnectionService, so a sub-second-lived session never
+    holds a connection open (would be pure churn). Real Session + real stdio server;
+    asserts on the service's public ``held_servers()`` surface, not private state."""
+    from reyn.runtime.session import Session
+
+    session = Session(agent_name="s2a-ephemeral-test", mcp_servers={"srv": _CFG})
+    session._ephemeral = True  # the registry sets this post-construction on an ephemeral spawn
+    try:
+        result = await session._mcp_call_tool("srv", "echo", {"text": "eph"})
+        assert result.get("status") == "ok", result
+        assert session.mcp_held_servers() == [], (
+            "ephemeral session must not hold a connection open"
+        )
+    finally:
+        await session.aclose_mcp_connections()
+
+
+@pytest.mark.asyncio
+async def test_non_ephemeral_session_holds_connection_across_calls():
+    """Tier 2: the counterpart of the ephemeral test above — a non-ephemeral (persistent
+    / main) session DOES hold the connection open across two ``_mcp_call_tool`` calls
+    (the S2a value: no re-handshake on a 2nd tool call within the session)."""
+    from reyn.runtime.session import Session
+
+    session = Session(agent_name="s2a-persistent-test", mcp_servers={"srv": _CFG})
+    try:
+        r1 = await session._mcp_call_tool("srv", "pid", {})
+        assert session.mcp_held_servers() == ["srv"]
+        r2 = await session._mcp_call_tool("srv", "pid", {})
+        assert r1["content"] == r2["content"], "same subprocess reused across calls"
+    finally:
+        await session.aclose_mcp_connections()
+        assert session.mcp_held_servers() == []
+
+
+@pytest.mark.asyncio
+async def test_remove_session_teardown_closes_held_connections(tmp_path: Path):
+    """Tier 2: registry.remove_session's teardown seam closes any MCP connections a
+    spawned session held open (#2597 S2a wiring) — a dropped/rewound session must not
+    leak an open subprocess. Real AgentRegistry + real spawned session + real stdio
+    server (no mocks)."""
+    from reyn.runtime.registry import AgentRegistry
+    from reyn.runtime.session import Session
+
+    def _factory(profile) -> Session:
+        return Session(agent_name=profile.name, mcp_servers={"srv": _CFG})
+
+    registry = AgentRegistry(project_root=tmp_path, session_factory=_factory)
+    registry.create("s2a-owner")
+    sid = await registry.spawn_session_recorded("s2a-owner", mode="persistent")
+    session = registry._peek_session("s2a-owner", sid)
+
+    await session._mcp_call_tool("srv", "echo", {"text": "hi"})
+    assert session.mcp_held_servers() == ["srv"]
+
+    removed = await registry.remove_session("s2a-owner", sid)
+    assert removed is True
+    assert session.mcp_held_servers() == [], (
+        "remove_session must close held MCP connections during teardown"
+    )

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -1,11 +1,16 @@
-"""Tier 2: _mcp_list_tools closes the MCP client on EVERY exit path + surfaces errors (list crash).
+"""Tier 2: _mcp_list_tools (EPHEMERAL session) closes the MCP client on EVERY exit path + surfaces
+errors (list crash).
 
-``Session._mcp_list_tools`` now routes through the ``MCPGateway`` seam (→ ``MCPClientPool`` →
-``MCPClient``, #2421). The pool opens + closes the client in the SAME task on success, error, AND
-cancellation, and the gateway contains any fault into an ``MCPFault`` → the list method returns an
-``[{"error": …}]`` result instead of leaking the SDK's anyio cancel-scope cross-task (the owner-facing
+``Session._mcp_list_tools`` routes an EPHEMERAL session's calls through the one-shot ``MCPGateway``
+seam (→ ``MCPClientPool`` → ``MCPClient``, #2421); #2597 S2a's held-open ``MCPConnectionService``
+is the NON-ephemeral (persistent/main session) default instead — see
+``test_2597_s2a_mcp_connection_service.py`` for that path's connection-reuse contract. The one-shot
+pool opens + closes the client in the SAME task on success, error, AND cancellation, and the
+gateway contains any fault into an ``MCPFault`` → the list method returns an ``[{"error": …}]``
+result instead of leaking the SDK's anyio cancel-scope cross-task (the owner-facing
 ``list_mcp_tools`` crash). This pins the close-on-error guarantee + same-task affinity + error
-surfacing through the real Session, with the fake patched where the POOL constructs it. No subprocess.
+surfacing through the real Session's ephemeral path, with the fake patched where the POOL
+constructs it. No subprocess.
 """
 from __future__ import annotations
 
@@ -40,7 +45,13 @@ async def _session(tmp_path) -> Session:
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
     sid = await reg.spawn_session_recorded("alice")
-    return reg.get_session("alice", sid)
+    sess = reg.get_session("alice", sid)
+    # #2597 S2a: only an EPHEMERAL session still routes _mcp_list_tools through the
+    # one-shot MCPClientPool this test exercises — a persistent session now holds its
+    # connection open via MCPConnectionService instead (see
+    # test_2597_s2a_mcp_connection_service.py).
+    sess._ephemeral = True
+    return sess
 
 
 class _FakeMCPClient:


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

Implements S2a of the MCP client redesign: `MCPConnectionService` — a session-owned
service that holds MCP connections **open for the agent session's lifetime**, replacing
the per-call open→close model (a359 P2 `MCPClientPool`) on the live, non-ephemeral chat
MCP path. This is **Option C** from the owner-delegated S2-pre spike: a persistent
connection lives *inside* the agent's own session (not a separate driver-session) —
connections are terminal-less runtime state (reconstruct-on-reload, no WAL), and the
spike proved FastMCP holds its client session in a dedicated `asyncio.Task`, so a
connection opened in one turn's task is safe to `call_tool()` from a later turn's task.

### What changed

- **New `src/reyn/mcp/connection_service.py`** — `MCPConnectionService`:
  - `get(server, config, *, agent_id=None) -> MCPClient` — pool-compatible signature
    (drop-in `pool=` for `MCPGateway`, unchanged). Lazy-connects + caches one `MCPClient`
    per server; returns a stable per-server handle (`_HeldConnection`) whose identity
    survives a reconnect.
  - **Reconnect-on-demand**: a subprocess/HTTP disconnect mid-session does **not** flip
    `MCPClient.is_initialized()` or fastmcp's `Client.is_connected()` — verified
    empirically against the real echo test server's `die` tool (kills the subprocess;
    both stay `True` on every subsequent call). The only observable signal is an
    `MCPError` raised on next use, so the held-connection handle catches it, discards +
    reopens the connection **once**, and retries the same call. A second failure
    propagates unchanged (no silent retry loop) — same fault-containment guarantee the
    caller's `MCPGateway` boundary already provides.
  - `aclose()` — closes every held connection; idempotent.
  - `held_servers()` — public read-only introspection (no private-state test assertions
    needed).
- **`src/reyn/core/op_runtime/context.py`** — new `OpContext.mcp_connection_service`
  field (default `None`).
- **`src/reyn/core/op_runtime/mcp.py`** — the `mcp` op handler prefers
  `ctx.mcp_connection_service` when wired, else falls back to `ctx.mcp_pool` unchanged.
- **`src/reyn/mcp/gateway.py`** — `MCPGateway.__init__`'s `pool` type-hint widened to
  `MCPClientPool | MCPConnectionService | None` (TYPE_CHECKING-only import; no behavior
  change — the gateway only ever calls `.get()` on whatever it's given).
- **`src/reyn/runtime/session.py`**:
  - `Session.__init__` constructs one `MCPConnectionService` per session (cheap — empty
    dict until first use).
  - `_mcp_call_tool` / `_mcp_list_tools`: a **non-ephemeral** session routes through the
    held service; an **ephemeral** session (`self._ephemeral`, set post-construction by
    the registry on an ephemeral spawn) keeps the pre-existing one-shot `MCPClientPool`
    path unchanged — holding a connection open for a sub-second-lived session is pure
    churn (F4 decision).
  - New `aclose_mcp_connections()` + `mcp_held_servers()` public methods (teardown +
    introspection).
- **`src/reyn/runtime/registry.py`**:
  - `remove_session` now awaits `session.aclose_mcp_connections()` (getattr-guarded,
    alongside the existing `cancel_inflight`/`await_quiescent` quiesce) before dropping a
    spawned session — no leaked subprocess/HTTP connection on drop/rewind.
  - `archive_agent` (the async action-layer seam wrapping the sync `remove()`) now
    closes held MCP connections for every loaded session of the agent (main + any
    spawned sids) before `remove()` drops them from the in-memory map — `remove()` has
    no async seam of its own, so this is the teardown seam for the **main** session.
- **Existing test updates** (both required by the design change, not incidental):
  - `tests/test_2421_mcp_seam_completeness.py` — added `mcp/connection_service.py` to
    the allowed-direct-`MCPClient()`-construction list (it's now a legitimate seam
    alongside `pool.py`).
  - `tests/test_mcp_list_tools_finally_close.py` — this test's close-on-every-exit-path
    contract is specifically the **one-shot** pool's contract; a persistent session no
    longer closes on every call (that's the whole point of S2a). Updated the test
    session to be `_ephemeral = True` so it still exercises exactly the one-shot path it
    was written for; docstring updated to say so explicitly.
  - `tests/_support/mcp_fastmcp_echo_server.py` — added a `pid()` tool (returns
    `os.getpid()`) so connection-reuse/reconnect tests can prove "same subprocess" /
    "new subprocess" against a REAL server round-trip instead of only comparing Python
    object identity.

### Out of scope (later slices, untouched)

Notifications / receive-loop / `message_handler` bridge / `resources/subscribe` /
resync-probe / periodic ping (S2b). Server→client requests (S3). OAuth (S6). turn-cancel
`notifications/cancelled` (S2c). No WAL state added (connections are runtime-only per
the design) — the recovery-feature PR gate does not apply here.

## Test plan

- [x] **Connection reuse (core value)**:
  `test_second_get_returns_same_held_client_no_rehandshake` — 2nd `get()` for the same
  server returns the SAME handle, and two `call_tool("pid", …)` round-trips return the
  SAME real subprocess PID (no re-handshake).
- [x] **Reconnect-on-demand**: `test_dead_connection_transparently_reconnects` — the
  `die` tool genuinely kills the subprocess; the held handle transparently reconnects
  (new PID) and the next call succeeds instead of failing forever.
- [x] **Teardown**: `test_aclose_closes_all_held_clients` (service-level, incl.
  idempotency + fresh reconnect after `aclose()`); `test_remove_session_teardown_closes_held_connections`
  (registry-level, real `AgentRegistry.remove_session`).
- [x] **Ephemeral isolation**: `test_ephemeral_session_never_populates_connection_service`
  proves an ephemeral session's MCP call never touches the held-connection service;
  `test_non_ephemeral_session_holds_connection_across_calls` proves the counterpart.
- [x] **Parity**: `test_call_result_parity_with_one_shot_pool` — `MCPGateway` with the
  connection service vs. the one-shot pool returns byte-identical results for the same
  call.
- [x] All 7 new tests + the 2 updated existing tests pass locally.

### 4 CI gates (local, all green)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2597_s2a_mcp_connection_service.py \
    tests/test_2421_mcp_seam_completeness.py tests/test_mcp_list_tools_finally_close.py
Summary: 10 tests inspected
  ✓ OK: 10
  ✗ errors: 0 (Tier 4 violations)
Exit code: 0

$ python -m pytest -q
5 failed, 7265 passed, 21 skipped, 11 warnings in 123.89s
```

The 5 failures are the **pre-existing** known-failing web-route-mount tests (issue
#2599, unrelated — confirmed exact match): `test_fp0001_routes_mounted`,
`test_a2a_routes_mounted`, `test_mcp_routes_mounted`,
`test_loader_disambiguates_via_package_field`, `test_resources_route_is_mounted_on_app`.
**Zero new failures** from this change.

```
$ python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/context.py \
    src/reyn/core/op_runtime/mcp.py src/reyn/mcp/gateway.py src/reyn/runtime/registry.py \
    src/reyn/runtime/session.py src/reyn/mcp/connection_service.py
OK: no module-docstring refactor narrative in <files>.
```
