### PR TITLE
feat(#2597): S2b — async server->client notifications bridge (tools/prompts list_changed + progress)

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -65,6 +65,7 @@ class MCPClient:
         config: dict[str, Any],
         *,
         agent_id: str | None = None,
+        message_handler: Any = None,
     ) -> None:
         if not isinstance(config, dict):
             raise ValueError(f"MCP server config must be a dict, got {type(config).__name__}")
@@ -82,6 +83,14 @@ class MCPClient:
         # agent. None preserves prior behaviour for direct callers (= the
         # session factory passes ReynConfig.agent.id; tests can omit).
         self._agent_id: str | None = agent_id
+        # #2597 S2b: optional async server->client notifications bridge — a
+        # ReynMCPMessageHandler (fastmcp.client.tasks.TaskNotificationHandler subclass;
+        # see reyn.mcp.message_handler) that receives tools/prompts list_changed +
+        # progress notifications on this client's held connection and emits them onto
+        # reyn's EventLog. None (default) preserves pre-S2b behaviour — no bridge, no
+        # behaviour change for callers that don't pass one (e.g. the ephemeral
+        # per-call MCPClientPool path never installs a handler).
+        self._message_handler: Any = message_handler
         self._client: Any = None  # fastmcp.Client when initialized
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
@@ -145,7 +154,17 @@ class MCPClient:
                 # default ``read_timeout_seconds`` (same knob call_tool's
                 # per-call ``timeout_seconds`` overrides).
                 client_kwargs["timeout"] = self._config.get("timeout", 30)
+            # #2597 S2b: install the notifications bridge, if one was supplied. Passed
+            # as a constructor kwarg per FastMCP's own contract (Client(transport,
+            # message_handler=...)); ReynMCPMessageHandler's weakref binding to THIS
+            # client is completed via bind_client() right below — see
+            # reyn/mcp/message_handler.py's module docstring ("two-phase client
+            # binding") for why that two-step is necessary.
+            if self._message_handler is not None:
+                client_kwargs["message_handler"] = self._message_handler
             client = FastMCPClient(transport, **client_kwargs)
+            if self._message_handler is not None:
+                self._message_handler.bind_client(client)
             await client.__aenter__()
         except MCPError:
             self.close_stderr_capture()

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -52,6 +52,14 @@ boundary into an LLM-visible error result, same as the pre-S2a per-call path.
 Runtime-only state (S2a scope note): held connections are NOT WAL-derived / recoverable
 state — they are reconstructed fresh (lazy-connect) after any process restart, exactly
 like the pool's per-call clients were. Nothing here writes to the WAL.
+
+#2597 S2b: because the connection stays open, FastMCP's ``session_task`` keeps its
+receive loop running, so server-pushed notifications (tools/prompts ``list_changed``,
+``notifications/progress``) arrive on the wire even between calls. ``emit_sink`` /
+``tools_cache_invalidate`` (both optional; None = no bridge, byte-identical to pre-S2b
+behaviour) are threaded down to a per-server :class:`~reyn.mcp.message_handler.
+ReynMCPMessageHandler` built fresh each time :meth:`_ensure_open` opens (or reopens, on
+reconnect) a held client — see that module for the notification->EventLog bridge design.
 """
 from __future__ import annotations
 
@@ -60,6 +68,7 @@ import logging
 from typing import Any, Awaitable, Callable
 
 from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCacheInvalidate
 from reyn.mcp.pool import describe_fault, is_real_control_flow
 
 logger = logging.getLogger(__name__)
@@ -81,7 +90,18 @@ class MCPConnectionService:
         await service.aclose()  # session teardown — closes every held connection
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        emit_sink: EmitSink | None = None,
+        tools_cache_invalidate: ToolsCacheInvalidate | None = None,
+    ) -> None:
+        # #2597 S2b: threaded into a fresh ReynMCPMessageHandler per held server
+        # connection (see _ensure_open). None (default) = no notifications bridge —
+        # the ephemeral per-call MCPClientPool path never constructs this service with
+        # a sink, so it stays byte-identical to pre-S2b behaviour.
+        self._emit_sink = emit_sink
+        self._tools_cache_invalidate = tools_cache_invalidate
         self._clients: dict[str, MCPClient] = {}
         # One handle per server, cached so repeated get() calls for the same server
         # return the SAME object (connection-reuse identity) across the connection's
@@ -135,7 +155,16 @@ class MCPConnectionService:
             self._clients.pop(server, None)
             client = None
         if client is None:
-            client = MCPClient(config, agent_id=agent_id)
+            # #2597 S2b: a fresh handler per open (including every reconnect) — bound
+            # to the server name closed over here, so a reconnected client's
+            # notifications keep landing under the same server attribution.
+            handler = None
+            if self._emit_sink is not None:
+                handler = ReynMCPMessageHandler(
+                    self._emit_sink, server,
+                    tools_cache_invalidate=self._tools_cache_invalidate,
+                )
+            client = MCPClient(config, agent_id=agent_id, message_handler=handler)
             await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
             self._clients[server] = client
         return client

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -1,0 +1,150 @@
+"""ReynMCPMessageHandler — server->client notifications bridge (#2597 S2b).
+
+S2a (``MCPConnectionService``) holds one ``fastmcp.Client`` open per server for the
+whole session lifetime. Because the connection stays open, FastMCP's ``session_task``
+keeps its receive loop running — so server-pushed notifications (``tools/list_changed``,
+``prompts/list_changed``, ``notifications/progress``) ARRIVE on the wire, but nothing
+consumed them before S2b. This module installs the consumer.
+
+Design (verified against the installed ``fastmcp`` 3.4.2 source — see S2-pre spike):
+
+  - **Base class**: :class:`fastmcp.client.tasks.TaskNotificationHandler`, NOT the bare
+    ``fastmcp.client.messages.MessageHandler``. ``TaskNotificationHandler`` is FastMCP's
+    own SEP-1686 task-status router — its ``dispatch()`` peeks every incoming
+    ``ServerNotification`` for a ``TaskStatusNotification`` and forwards it to the owning
+    ``Client`` BEFORE calling ``super().dispatch()`` (the base ``MessageHandler`` match/case
+    that invokes ``on_tool_list_changed`` / ``on_prompt_list_changed`` / ``on_progress``
+    etc). Subclassing (and NOT overriding ``dispatch`` itself) means task-status routing
+    keeps running unconditionally on every message — our hook overrides only add behavior
+    on top, they never replace or skip it.
+
+  - **Two-phase client binding**: ``TaskNotificationHandler.__init__(self, client)``
+    requires an already-constructed ``fastmcp.Client`` (it stores ``weakref.ref(client)``
+    for the task-status routing above) — but FastMCP's own
+    ``Client(transport, message_handler=...)`` constructor takes the handler as an
+    argument, so the handler must exist BEFORE the ``Client`` object does. There is no
+    factory hook for this in the public API (verified: ``fastmcp.client.client.Client``
+    stores whatever ``message_handler`` object it's given verbatim in
+    ``_session_kwargs["message_handler"]``, consumed later at ``__aenter__``/session-connect
+    time — the client's *own* default path sidesteps this by constructing
+    ``TaskNotificationHandler(self)`` INLINE inside its own ``__init__``, where ``self``
+    already exists). This class breaks the same chicken-and-egg cycle explicitly:
+    ``__init__`` skips ``TaskNotificationHandler.__init__`` (calls
+    ``MessageHandler.__init__`` instead, which takes no arguments) and leaves
+    ``_client_ref`` pointing at a ``lambda: None``; :meth:`bind_client` — called by
+    :class:`~reyn.mcp.client.MCPClient` immediately after constructing the
+    ``fastmcp.Client`` and before ``__aenter__()`` opens the transport — completes the
+    weakref binding. No message can be dispatched before ``__aenter__()`` completes the
+    handshake, so ``bind_client`` always runs before the first ``dispatch()`` call.
+
+  - **Synchronous hook bodies**: the handler runs on FastMCP's ``session_task`` (not the
+    agent turn task), but ``EventLog.emit()`` is fully synchronous and asyncio is
+    single-loop with no preemption mid-sync-call, so calling ``emit_sink(...)`` directly
+    from a hook is safe — no marshalling, no ``call_soon``, no queue (verified against the
+    WAL's lock-free design — see S2-pre spike / connection_service.py's Option C
+    docstring). Each hook below calls the sink SYNCHRONOUSLY (never ``await``s it) so a
+    sink fault or a slow sink can never stall the receive loop or delay task-status
+    routing; a fault in the sink is caught and swallowed (logged) rather than propagated,
+    since notification handling must never crash the held connection's receive loop. The
+    sole ``await super().<hook>(...)`` call in every override resolves against the base
+    ``MessageHandler``'s bare ``pass`` body — no real async work, no scheduler yield of any
+    consequence — so overriding these ``async def`` hooks (the base signature requires
+    ``async def``; that is a FastMCP interface constraint, not a body-level await) does not
+    reintroduce blocking.
+"""
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Any, Callable
+
+from fastmcp.client.messages import MessageHandler
+from fastmcp.client.tasks import TaskNotificationHandler
+
+logger = logging.getLogger(__name__)
+
+# Matches EventLog.emit(type: str, **data) -> Event; a plain callable sink lets callers
+# (session.py) defer resolution of a not-yet-constructed EventLog via a closure — see
+# MCPConnectionService's emit_sink wiring.
+EmitSink = Callable[..., Any]
+ToolsCacheInvalidate = Callable[[str], None]
+
+
+class ReynMCPMessageHandler(TaskNotificationHandler):
+    """Bridges FastMCP server-pushed notifications on a held connection to reyn's
+    ``EventLog`` (#2597 S2b). One instance per held server connection.
+
+    Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``, ``notifications/
+    progress``. ``resources/updated`` / ``resources/subscribe`` are DEFERRED to the
+    resources-consumption slice (nothing is subscribed yet) — the inherited
+    ``on_resource_updated`` / ``on_resource_list_changed`` stay base-class no-ops.
+    """
+
+    def __init__(
+        self,
+        emit_sink: EmitSink,
+        server_name: str,
+        *,
+        tools_cache_invalidate: ToolsCacheInvalidate | None = None,
+    ) -> None:
+        # Deliberately bypass TaskNotificationHandler.__init__ — see module docstring
+        # ("two-phase client binding"). MessageHandler.__init__ takes no arguments.
+        MessageHandler.__init__(self)
+        self._client_ref: Callable[[], Any] = lambda: None
+        self._emit_sink = emit_sink
+        self._server_name = server_name
+        self._tools_cache_invalidate = tools_cache_invalidate
+
+    def bind_client(self, client: Any) -> None:
+        """Complete the ``TaskNotificationHandler`` weakref binding once the owning
+        ``fastmcp.Client`` exists. MUST run before the first message is dispatched —
+        :meth:`reyn.mcp.client.MCPClient.initialize` calls this immediately after
+        constructing the ``fastmcp.Client`` and before ``__aenter__()`` opens the
+        transport (= before any notification can possibly arrive)."""
+        self._client_ref = weakref.ref(client)
+
+    # ── notification hooks — synchronous bodies, see module docstring ──────────────
+
+    async def on_tool_list_changed(self, message: Any) -> None:
+        if self._tools_cache_invalidate is not None:
+            try:
+                self._tools_cache_invalidate(self._server_name)
+            except Exception:  # noqa: BLE001 — a cache-invalidation fault must not drop the notification
+                logger.warning(
+                    "ReynMCPMessageHandler: tools_cache_invalidate failed for %r",
+                    self._server_name, exc_info=True,
+                )
+        self._emit("mcp_tool_list_changed", server=self._server_name)
+        await super().on_tool_list_changed(message)
+
+    async def on_prompt_list_changed(self, message: Any) -> None:
+        self._emit("mcp_prompt_list_changed", server=self._server_name)
+        await super().on_prompt_list_changed(message)
+
+    async def on_progress(self, message: Any) -> None:
+        params = getattr(message, "params", None)
+        token = getattr(params, "progressToken", None)
+        self._emit(
+            "mcp_progress",
+            server=self._server_name,
+            tool=None,
+            progress=getattr(params, "progress", None),
+            total=getattr(params, "total", None),
+            message=getattr(params, "message", None),
+            progress_token=str(token) if token is not None else None,
+        )
+        await super().on_progress(message)
+
+    # ── sink dispatch ───────────────────────────────────────────────────────────────
+
+    def _emit(self, event_type: str, **data: Any) -> None:
+        """Call the emit sink SYNCHRONOUSLY (never awaited — see module docstring).
+        Never raises: a fault in the sink must not break notification dispatch on the
+        held connection's receive loop."""
+        try:
+            self._emit_sink(event_type, **data)
+        except Exception:  # noqa: BLE001 — sink faults must not break the receive loop
+            logger.warning(
+                "ReynMCPMessageHandler: emit_sink failed for %r on server %r",
+                event_type, self._server_name, exc_info=True,
+            )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1576,6 +1576,39 @@ class RouterHostAdapter:
                 cache_path, exc,
             )
 
+    def invalidate_mcp_tools_cache(self, server: str) -> None:
+        """Invalidate the lazy MCP tools cache (#2597 S2b) so the next
+        ``ensure_mcp_tools_cached()`` re-probes every configured server.
+
+        Called from the async notifications bridge
+        (``reyn.mcp.message_handler.ReynMCPMessageHandler.on_tool_list_changed``) when
+        a held MCP connection reports a server-pushed
+        ``notifications/tools/list_changed`` for ``server`` — issue #160's lazy cache
+        has no other way to learn the cached tool list may now be stale (it probes
+        ONCE per session by design).
+
+        Resets the WHOLE in-memory cache (not just ``server``'s entry), because
+        ``ensure_mcp_tools_cached``'s populated-guard is all-or-nothing (``if
+        self._mcp_tools_cache is not None: return``) — there is no cheaper
+        single-server re-probe path today. The next turn boundary's
+        ``ensure_mcp_tools_cached()`` re-probes every configured server in parallel
+        (cheap; the existing per-server timeout already caps a slow/unreachable one),
+        so a list-changed notification for ONE server causes a full (but bounded)
+        re-probe rather than a targeted one. ``server`` is accepted (not ``*args``)
+        so the call site + a future targeted implementation both have a stable
+        signature; unused beyond that today.
+
+        Known interaction (not a regression, flagged for awareness): FP-0037 S1's
+        on-disk warm-start cache (``<state_dir>/mcp_tools_cache.json``) is consulted
+        BEFORE a live probe in ``ensure_mcp_tools_cached`` — if that file exists and
+        wasn't itself refreshed, invalidation still warm-starts from it (stale)
+        instead of forcing a live probe. This mirrors the disk-cache's own existing
+        staleness window (``reyn mcp refresh`` is the operator-driven cache-buster)
+        and is out of scope for #2597 S2b to close.
+        """
+        self._mcp_tools_cache = None
+        self._mcp_tools_cache_mtime = None
+
     def maybe_reload_mcp_tools_cache_from_disk(self) -> None:
         """Reload the in-memory MCP tools cache if the on-disk file is newer.
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1059,8 +1059,19 @@ class Session:
         # per-call MCPClientPool so a sub-second-lived session never holds a
         # connection open. Closed at session teardown via aclose_mcp_connections
         # (registry.remove_session / archive_agent's main-session path).
+        # #2597 S2b: emit_sink / tools_cache_invalidate are lambdas that defer
+        # resolution of ``self._chat_events`` / ``self._router_host`` to CALL time
+        # (mirrors the ``emit_event=lambda et, **d: self._chat_events.emit(et, **d)``
+        # pattern used a few lines below) — both attributes are assigned LATER in this
+        # __init__ (``_chat_events`` at construction of the EventLog; ``_router_host``
+        # when the RouterHostAdapter is built), but neither lambda is ever CALLED until
+        # a held MCP connection actually receives a server-pushed notification, long
+        # after __init__ has finished.
         from reyn.mcp.connection_service import MCPConnectionService
-        self._mcp_connection_service = MCPConnectionService()
+        self._mcp_connection_service = MCPConnectionService(
+            emit_sink=lambda et, **d: self._chat_events.emit(et, **d),
+            tools_cache_invalidate=lambda server: self._router_host.invalidate_mcp_tools_cache(server),
+        )
         self.output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled
         self._project_context = project_context

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -12,6 +12,12 @@ Tools:
                             real FastMCP ``Context.report_progress`` API, so
                             progress-callback plumbing is exercised against the
                             real protocol (not a hand-rolled fake).
+  - ``notify_tool_list_changed()``   -> sends a real
+                            ``notifications/tools/list_changed`` via
+                            ``Context.send_notification`` (#2597 S2b — the
+                            async notifications bridge).
+  - ``notify_prompt_list_changed()`` -> sends a real
+                            ``notifications/prompts/list_changed`` (#2597 S2b).
   - ``pid()``            -> returns ``os.getpid()`` of THIS server process. Used
                             by #2597 S2a connection-reuse tests to prove a second
                             ``call_tool`` hit the SAME held subprocess (no
@@ -103,6 +109,26 @@ async def progress(steps: int, ctx: Context) -> str:
     for i in range(1, steps + 1):
         await ctx.report_progress(progress=i, total=steps, message=f"step-{i}")
     return "done"
+
+
+# #2597 S2b: real server-pushed list_changed notifications, for the async
+# notifications-bridge tests (ReynMCPMessageHandler.on_tool_list_changed /
+# on_prompt_list_changed). ``Context.send_notification`` sends immediately on the
+# session — a real SEP-1686 notification, not a fake.
+@mcp.tool()
+async def notify_tool_list_changed(ctx: Context) -> str:
+    import mcp.types as types
+
+    await ctx.send_notification(types.ToolListChangedNotification())
+    return "sent"
+
+
+@mcp.tool()
+async def notify_prompt_list_changed(ctx: Context) -> str:
+    import mcp.types as types
+
+    await ctx.send_notification(types.PromptListChangedNotification())
+    return "sent"
 
 
 if __name__ == "__main__":

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -1,0 +1,299 @@
+"""Tests for the async server->client notifications bridge (#2597 S2b).
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``. The
+notification-carrying tests spawn a REAL subprocess running
+``tests/_support/mcp_fastmcp_echo_server.py`` (a real FastMCP server) whose
+``notify_tool_list_changed`` / ``notify_prompt_list_changed`` / ``progress`` tools send
+REAL SEP-1686 notifications over the wire on a held (S2a) connection — proving
+``ReynMCPMessageHandler`` actually receives server-pushed notifications on a held
+connection, not just that its methods work if called directly.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import mcp.types as types
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.llm.model_resolver import ModelResolver
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.mcp.message_handler import ReynMCPMessageHandler
+from reyn.runtime.services import MemoryService, RouterHostAdapter
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_CFG = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+
+
+async def _null_file_read(path: str) -> dict:
+    return {"content": ""}
+
+
+async def _null_file_write(path: str, content: str) -> dict:
+    return {"path": path, "written": True}
+
+
+async def _null_file_delete(path: str) -> dict:
+    return {"path": path, "deleted": True}
+
+
+async def _null_file_list(path: str) -> dict:
+    return {"path": path, "entries": []}
+
+
+async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
+    return {"path": path, "output_path": output_path, "entries": 0}
+
+
+async def _null_mcp_list_servers() -> list:
+    return []
+
+
+async def _null_send_to_agent(*, to, request, depth, chain_id) -> None:
+    pass
+
+
+async def _null_put_outbox(msg) -> None:
+    pass
+
+
+def _null_append_history(msg) -> None:
+    pass
+
+
+def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
+    """Real RouterHostAdapter with one configured server ("srv"), an isolated
+    per-test state_dir (never reads a stale on-disk tools cache), and a probe
+    callback that returns a fixed tool list — mirrors
+    tests/test_mcp_lazy_tools_cache.py's construction helper."""
+
+    async def _probe(server: str) -> list[dict]:
+        return [{"name": f"{server}_tool", "description": "d"}]
+
+    async def _null_mcp_call_tool(server: str, tool: str, args: dict) -> dict:
+        return {}
+
+    workspace = tmp_path / "agents" / "test-agent"
+    memory = MemoryService(
+        agent_workspace_dir=workspace,
+        events=events,
+        file_write=_null_file_write,
+        file_read=_null_file_read,
+        file_delete=_null_file_delete,
+        file_regenerate_index=_null_file_regen,
+    )
+    return RouterHostAdapter(
+        agent_name="test-agent",
+        agent_role="test",
+        output_language="en",
+        allowed_mcp=None,
+        permission_resolver=None,
+        mcp_servers={"srv": {}},
+        project_context="",
+        events=events,
+        resolver=ModelResolver({}),
+        memory=memory,
+        journal=None,
+        agent_registry=None,
+        agent_workspace_dir=workspace,
+        file_read=_null_file_read,
+        file_write=_null_file_write,
+        file_delete=_null_file_delete,
+        file_list_directory=_null_file_list,
+        file_regenerate_index=_null_file_regen,
+        mcp_list_servers=_null_mcp_list_servers,
+        mcp_list_tools=_probe,
+        mcp_call_tool=_null_mcp_call_tool,
+        send_to_agent=_null_send_to_agent,
+        put_outbox=_null_put_outbox,
+        append_history=_null_append_history,
+        delegation_tracker=lambda: None,
+        agent_replies_tracker=lambda: None,
+        state_dir=tmp_path / "state",
+    )
+
+
+# ── (a) real server-pushed tools/list_changed -> event + cache invalidation ────────
+
+
+@pytest.mark.asyncio
+async def test_tool_list_changed_notification_emits_event_and_invalidates_cache(
+    tmp_path: Path,
+):
+    """Tier 2: a REAL server-pushed ``notifications/tools/list_changed`` on a held
+    (S2a) connection lands as an ``mcp_tool_list_changed`` event on the session's
+    EventLog AND invalidates the RouterHostAdapter's lazy MCP tools cache (#160/
+    FP-0037), so the next ``ensure_mcp_tools_cached()`` re-probes instead of serving
+    the now-possibly-stale cached list."""
+    events = EventLog(subscribers=[])
+    adapter = _make_adapter(tmp_path=tmp_path, events=events)
+
+    service = MCPConnectionService(
+        emit_sink=lambda et, **d: events.emit(et, **d),
+        tools_cache_invalidate=adapter.invalidate_mcp_tools_cache,
+    )
+    try:
+        # Populate the cache first so invalidation has something to undo.
+        await adapter.ensure_mcp_tools_cached()
+        assert adapter.mcp_tools_cache_snapshot == {
+            "srv": [{"name": "srv_tool", "description": "d"}]
+        }
+
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("notify_tool_list_changed", {})
+        assert result["isError"] is False
+
+        # The notification is delivered asynchronously on FastMCP's session_task;
+        # give the event loop a beat to run the receive loop's callback.
+        import asyncio
+
+        for _ in range(50):
+            if adapter.mcp_tools_cache_snapshot is None:
+                break
+            await asyncio.sleep(0.02)
+
+        matching = [e for e in events.all() if e.type == "mcp_tool_list_changed"]
+        (only_event,) = matching  # exactly one — the single real notification sent
+        assert only_event.data.get("server") == "srv"
+        assert adapter.mcp_tools_cache_snapshot is None, (
+            "on_tool_list_changed must invalidate the lazy MCP tools cache"
+        )
+    finally:
+        await service.aclose()
+
+
+# ── (b) real server-pushed progress -> mcp_progress event ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_progress_notification_emits_mcp_progress_event(tmp_path: Path):
+    """Tier 2: a REAL server-pushed ``notifications/progress`` on a held connection
+    lands as an ``mcp_progress`` event on the EventLog — the SAME event type
+    ``op_runtime/mcp.py`` already emits for the per-call progress_handler path
+    (issue #264/#271), so ``ChatLifecycleForwarder.on_mcp_progress`` surfaces it
+    without a new consumer."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _CFG)
+
+        async def _progress_cb(progress, total, message) -> None:
+            pass
+
+        result = await client.call_tool(
+            "progress", {"steps": 2}, progress_callback=_progress_cb,
+        )
+        assert result["isError"] is False
+
+        matching = [e for e in events.all() if e.type == "mcp_progress"]
+        first_step, second_step = matching  # one event per reported progress step
+        assert first_step.data.get("server") == "srv"
+        assert second_step.data.get("server") == "srv"
+        assert (first_step.data.get("progress"), second_step.data.get("progress")) == (
+            1.0, 2.0,
+        )
+        assert (
+            first_step.data.get("message"), second_step.data.get("message"),
+        ) == ("step-1", "step-2")
+    finally:
+        await service.aclose()
+
+
+# ── (c) subclassing TaskNotificationHandler preserves task-status routing ─────────
+
+
+class _FakeClient:
+    """Duck-typed stand-in for fastmcp.Client — only the ONE method
+    TaskNotificationHandler.dispatch actually calls (``_handle_task_status_
+    notification``). A real (hand-written) object, not a Mock/patch."""
+
+    def __init__(self) -> None:
+        self.routed: list[types.TaskStatusNotification] = []
+
+    def _handle_task_status_notification(self, root) -> None:
+        self.routed.append(root)
+
+
+def _make_task_status_notification() -> types.ServerNotification:
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    params = types.TaskStatusNotificationParams(
+        taskId="task-1",
+        status="working",
+        createdAt=now,
+        lastUpdatedAt=now,
+        ttl=None,
+    )
+    return types.ServerNotification(types.TaskStatusNotification(params=params))
+
+
+@pytest.mark.asyncio
+async def test_task_status_routing_preserved_through_subclass():
+    """Tier 1: ReynMCPMessageHandler subclasses TaskNotificationHandler and does NOT
+    override ``dispatch`` — so TaskNotificationHandler's own SEP-1686 task-status
+    routing (peek for a TaskStatusNotification, forward to the bound client, THEN
+    fall through to the base MessageHandler match/case that invokes our hooks) keeps
+    running unmodified. Drives the REAL inherited ``dispatch()`` (not a private-state
+    assertion) and observes the routing side effect on a real fake client object."""
+    from fastmcp.client.tasks import TaskNotificationHandler
+
+    handler = ReynMCPMessageHandler(lambda *a, **k: None, "srv")
+    assert isinstance(handler, TaskNotificationHandler)
+
+    fake_client = _FakeClient()
+    handler.bind_client(fake_client)
+
+    notification = _make_task_status_notification()
+    await handler.dispatch(notification)
+
+    (routed,) = fake_client.routed  # exactly one status notification was dispatched
+    assert routed.params.taskId == "task-1"
+
+
+# ── (d) synchronous handler body — sink faults never escape dispatch ──────────────
+
+
+@pytest.mark.asyncio
+async def test_emit_sink_fault_does_not_break_dispatch():
+    """Tier 1: the notification hooks call the emit sink SYNCHRONOUSLY (never
+    ``await`` it — see message_handler.py's module docstring) and never let a sink
+    fault escape: a raising sink must not propagate out of ``dispatch()``, since
+    that would crash/stall the held connection's FastMCP receive loop for every
+    subsequent message, not just the one notification that triggered the fault."""
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("sink exploded")
+
+    handler = ReynMCPMessageHandler(_boom, "srv")
+    handler.bind_client(_FakeClient())
+
+    notification = types.ServerNotification(types.ToolListChangedNotification())
+    await handler.dispatch(notification)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_tools_cache_invalidate_fault_does_not_block_event_emit(tmp_path: Path):
+    """Tier 1: a faulting ``tools_cache_invalidate`` callback must not prevent the
+    ``mcp_tool_list_changed`` event from still being emitted — the two side effects
+    are independent and one failing must not silently swallow the other."""
+    events = EventLog(subscribers=[])
+
+    def _boom_invalidate(server: str) -> None:
+        raise RuntimeError("cache invalidation exploded")
+
+    handler = ReynMCPMessageHandler(
+        lambda et, **d: events.emit(et, **d), "srv",
+        tools_cache_invalidate=_boom_invalidate,
+    )
+    handler.bind_client(_FakeClient())
+
+    notification = types.ServerNotification(types.ToolListChangedNotification())
+    await handler.dispatch(notification)  # must not raise
+
+    matching = [e for e in events.all() if e.type == "mcp_tool_list_changed"]
+    (only_event,) = matching  # exactly one — invalidate faulting must not swallow the emit
+    assert only_event.data.get("server") == "srv"


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

S2a (#2600, merged) holds one `fastmcp.Client` open per server for the
session lifetime, so FastMCP's `session_task` keeps its receive loop
running — server-pushed notifications (`tools/list_changed`,
`prompts/list_changed`, `notifications/progress`) arrive on the wire, but
nothing consumed them. This is S2b: the bridge.

- **`src/reyn/mcp/message_handler.py`** (new) — `ReynMCPMessageHandler`, a
  subclass of `fastmcp.client.tasks.TaskNotificationHandler` (verified
  against the installed fastmcp 3.4.2 source — NOT the bare
  `MessageHandler`, so SEP-1686 task-status routing keeps running
  unmodified; we only override `on_tool_list_changed` /
  `on_prompt_list_changed` / `on_progress`, never `dispatch`).
  - **Two-phase client binding**: `TaskNotificationHandler.__init__`
    requires an already-constructed `fastmcp.Client` (for its
    `weakref.ref`), but `Client(transport, message_handler=...)` needs the
    handler *before* the `Client` exists. Verified there's no public
    factory hook for this in fastmcp's own API (its own default path
    sidesteps the problem by constructing `TaskNotificationHandler(self)`
    inline inside `Client.__init__`, where `self` already exists). Our
    handler's `__init__` skips `TaskNotificationHandler.__init__` (calls
    `MessageHandler.__init__` instead) and exposes `bind_client(client)`,
    called by `MCPClient.initialize()` right after constructing the
    `fastmcp.Client` and before `__aenter__()` opens the transport — no
    message can arrive before the handshake completes, so binding always
    happens before the first `dispatch()`.
  - Hook bodies are synchronous: `EventLog.emit()` is fully sync and
    asyncio has no preemption mid-sync-call, so calling the emit sink
    directly from the `session_task` is safe (no marshalling/queue —
    verified against the WAL's lock-free design, same reasoning as S2a's
    Option C). Each hook calls the sink and never `await`s it; a sink
    fault (or a faulting tools-cache-invalidate callback) is caught and
    logged, never propagated, so it can't stall/crash the receive loop.
    The one `await super().<hook>(...)` per override resolves against the
    base `MessageHandler`'s bare `pass` (no real async work).
  - `on_tool_list_changed` also invalidates the RouterHostAdapter's lazy
    MCP tools cache (issue #160/FP-0037) for the server, so the next
    `ensure_mcp_tools_cached()` re-probes instead of serving a stale list.
- **`src/reyn/mcp/client.py`** — `MCPClient.__init__` gains an optional
  `message_handler=None`; `initialize()` passes it to
  `FastMCPClient(transport, message_handler=...)` and calls
  `handler.bind_client(client)` right after construction. `None` (default)
  = today's behaviour, byte-identical — no shim, just the no-bridge path.
- **`src/reyn/mcp/connection_service.py`** — `MCPConnectionService.__init__`
  gains optional `emit_sink` / `tools_cache_invalidate`; `_ensure_open`
  builds a fresh `ReynMCPMessageHandler` per server (including on every
  reconnect, so a healed connection's notifications keep landing under the
  right server name) when `emit_sink` is set.
- **`src/reyn/runtime/session.py`** — wires
  `emit_sink=lambda et, **d: self._chat_events.emit(et, **d)` and
  `tools_cache_invalidate=lambda server: self._router_host.invalidate_mcp_tools_cache(server)`
  into the session's `MCPConnectionService`. Both are deferred-resolution
  lambdas (mirrors the existing `emit_event=lambda et, **d:
  self._chat_events.emit(et, **d)` pattern a few lines below) since
  `_chat_events` / `_router_host` are assigned later in `__init__` — safe
  because neither lambda is ever called until an actual notification
  arrives, long after construction completes.
- **`src/reyn/runtime/services/router_host_adapter.py`** —
  `invalidate_mcp_tools_cache(server)`: resets the WHOLE in-memory lazy
  tools cache (not per-server — `ensure_mcp_tools_cached`'s populated-guard
  is all-or-nothing) so the next turn boundary re-probes every configured
  server in parallel (cheap, per-server-timeout-capped).
- **`tests/_support/mcp_fastmcp_echo_server.py`** — added
  `notify_tool_list_changed` / `notify_prompt_list_changed` tools (real
  `Context.send_notification`) to the shared real-FastMCP-server test
  fixture used across the #2597 arc.

## Known interaction (flagged, not a blocker)

FP-0037 S1's on-disk warm-start tools-cache file
(`<state_dir>/mcp_tools_cache.json`) is consulted BEFORE a live probe in
`ensure_mcp_tools_cached`. If that file exists and wasn't independently
refreshed, our invalidation still warm-starts from it (stale) instead of
forcing a live probe. This mirrors the disk-cache's own pre-existing
staleness window (`reyn mcp refresh` is the operator-driven cache-buster)
and is out of scope for S2b to close.

## Out of scope (later slices, per the umbrella)

`resources/updated` + `resources/subscribe` + reconnect resync-probe
(nothing subscribed yet — the resources-consumption slice); proactive
ping/health supervision loop; server->client REQUESTS (S3); turn-cancel
notifications (S2c); OAuth (S6).

## Test plan

- [x] Real stdio FastMCP server (`tests/_support/mcp_fastmcp_echo_server.py`)
  sends a genuine `notifications/tools/list_changed` on a held connection
  → `mcp_tool_list_changed` event lands on the EventLog AND the
  RouterHostAdapter's lazy tools cache is invalidated
  (`test_tool_list_changed_notification_emits_event_and_invalidates_cache`).
- [x] Real server-pushed `notifications/progress` → `mcp_progress` events
  land on the EventLog, same event type/shape as the existing per-call
  progress path (`test_progress_notification_emits_mcp_progress_event`).
- [x] `ReynMCPMessageHandler` subclasses `TaskNotificationHandler` and does
  NOT override `dispatch` — drives the real inherited `dispatch()` with a
  real `TaskStatusNotification` and observes routing land on a duck-typed
  fake client, proving task-status routing survives our override
  (`test_task_status_routing_preserved_through_subclass`).
- [x] A faulting emit sink, and separately a faulting
  tools-cache-invalidate callback, never escape `dispatch()` and never
  block the other side effect
  (`test_emit_sink_fault_does_not_break_dispatch`,
  `test_tools_cache_invalidate_fault_does_not_block_event_emit`).
- [x] Full S2a suite (`tests/test_2597_s2a_mcp_connection_service.py`) +
  S1 (`tests/test_mcp_client.py`) + lazy-tools-cache
  (`tests/test_mcp_lazy_tools_cache.py`) + P1
  (`tests/test_mcp_structured_client_p1.py`) all still green — 34/34.

### 4 CI gates (all run locally)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2597_s2b_mcp_notifications_bridge.py
Summary: 5 tests inspected
  ✓ OK: 5
  ⚠️ warnings: 0 (bounded-life candidates)
  ✗ errors: 0 (Tier 4 violations)

$ python -m pytest -q -n auto --timeout=120
5 failed, 7271 passed, 21 skipped, 30 warnings in 40.75s
```

The 5 failures are the pre-existing #2599 web-route-mount failures
(`test_fp0001_routes_mounted`, `test_a2a_routes_mounted`,
`test_mcp_routes_mounted`, `test_resources_route_is_mounted_on_app`,
`test_loader_disambiguates_via_package_field`) — confirmed identical on
`main` (`git stash` + re-run before this diff), zero NEW failures from
this change.

```
$ python scripts/verify_module_docstrings.py src/reyn/mcp/message_handler.py src/reyn/mcp/client.py src/reyn/mcp/connection_service.py src/reyn/runtime/session.py src/reyn/runtime/services/router_host_adapter.py tests/_support/mcp_fastmcp_echo_server.py
OK: no module-docstring refactor narrative in ...
```