### PR TITLE
feat(#2597): S2b-log — consume MCP notifications/message (logging) -> mcp_log EventLog bridge

### DIFF
--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -1,10 +1,30 @@
-"""ReynMCPMessageHandler — server->client notifications bridge (#2597 S2b).
+"""ReynMCPMessageHandler — server->client notifications bridge (#2597 S2b / S2b-log).
 
 S2a (``MCPConnectionService``) holds one ``fastmcp.Client`` open per server for the
 whole session lifetime. Because the connection stays open, FastMCP's ``session_task``
 keeps its receive loop running — so server-pushed notifications (``tools/list_changed``,
-``prompts/list_changed``, ``notifications/progress``) ARRIVE on the wire, but nothing
-consumed them before S2b. This module installs the consumer.
+``prompts/list_changed``, ``notifications/progress``, ``notifications/message``
+logging) ARRIVE on the wire, but nothing consumed them before S2b. This module installs
+the consumer.
+
+S2b-log routing (verified against the installed ``fastmcp`` 3.4.2 / ``mcp`` SDK source
+— a live experiment against a real log-emitting FastMCP server, not guessed): MCP
+logging (``notifications/message`` / ``LoggingMessageNotification``) reaches a held
+client via TWO independent paths that both fire for the SAME wire message —
+``mcp.client.session.ClientSession._received_notification`` routes it to the
+Client-level ``log_handler`` kwarg (FastMCP's own ``default_log_handler`` if none is
+given), AND ``shared.session.BaseSession._handle_incoming`` separately calls the
+``message_handler`` (our ``ReynMCPMessageHandler``, via the inherited
+``MessageHandler.dispatch`` match/case) — both call sites run unconditionally for every
+notification (``shared/session.py``'s receive loop calls
+``_received_notification(...)`` THEN ``_handle_incoming(...)``, not either/or). Since
+``ReynMCPMessageHandler`` is already installed as the ``message_handler`` on every held
+connection (S2b), the correct wiring is to add an ``on_logging_message`` hook to THIS
+class (mirroring the existing hooks) rather than also wiring the separate
+``log_handler`` kwarg — the latter would double-emit the same notification through a
+second, redundant code path. No ``logging/setLevel`` is required to receive logs: the
+experiment server emitted at its default level with no client-side ``setLevel`` call
+and the notification arrived normally.
 
 Design (verified against the installed ``fastmcp`` 3.4.2 source — see S2-pre spike):
 
@@ -72,12 +92,13 @@ ToolsCacheInvalidate = Callable[[str], None]
 
 class ReynMCPMessageHandler(TaskNotificationHandler):
     """Bridges FastMCP server-pushed notifications on a held connection to reyn's
-    ``EventLog`` (#2597 S2b). One instance per held server connection.
+    ``EventLog`` (#2597 S2b / S2b-log). One instance per held server connection.
 
-    Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``, ``notifications/
-    progress``. ``resources/updated`` / ``resources/subscribe`` are DEFERRED to the
-    resources-consumption slice (nothing is subscribed yet) — the inherited
-    ``on_resource_updated`` / ``on_resource_list_changed`` stay base-class no-ops.
+    Scope (S2b + S2b-log): ``tools/list_changed``, ``prompts/list_changed``,
+    ``notifications/progress``, ``notifications/message`` (logging). ``resources/
+    updated`` / ``resources/subscribe`` are DEFERRED to the resources-consumption slice
+    (nothing is subscribed yet) — the inherited ``on_resource_updated`` /
+    ``on_resource_list_changed`` stay base-class no-ops.
     """
 
     def __init__(
@@ -134,6 +155,17 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
             progress_token=str(token) if token is not None else None,
         )
         await super().on_progress(message)
+
+    async def on_logging_message(self, message: Any) -> None:
+        params = getattr(message, "params", None)
+        self._emit(
+            "mcp_log",
+            server=self._server_name,
+            level=getattr(params, "level", None),
+            logger=getattr(params, "logger", None),
+            data=getattr(params, "data", None),
+        )
+        await super().on_logging_message(message)
 
     # ── sink dispatch ───────────────────────────────────────────────────────────────
 

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -18,6 +18,10 @@ Tools:
                             async notifications bridge).
   - ``notify_prompt_list_changed()`` -> sends a real
                             ``notifications/prompts/list_changed`` (#2597 S2b).
+  - ``notify_log(level, logger_name, msg)`` -> sends a real
+                            ``notifications/message`` (logging) via ``Context.log``
+                            (#2597 S2b-log — the logging-notification consumption
+                            slice of the async notifications bridge).
   - ``pid()``            -> returns ``os.getpid()`` of THIS server process. Used
                             by #2597 S2a connection-reuse tests to prove a second
                             ``call_tool`` hit the SAME held subprocess (no
@@ -128,6 +132,16 @@ async def notify_prompt_list_changed(ctx: Context) -> str:
     import mcp.types as types
 
     await ctx.send_notification(types.PromptListChangedNotification())
+    return "sent"
+
+
+# #2597 S2b-log: a real server-pushed logging notification (``notifications/message``),
+# for the logging-consumption bridge test (ReynMCPMessageHandler.on_logging_message).
+# ``Context.log`` sends immediately on the session (real MCP logging notification, per
+# the 2025-11-25 spec — not a fake).
+@mcp.tool()
+async def notify_log(level: str, logger_name: str, msg: str, ctx: Context) -> str:
+    await ctx.log(msg, level=level, logger_name=logger_name)
     return "sent"
 
 

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -1,12 +1,13 @@
-"""Tests for the async server->client notifications bridge (#2597 S2b).
+"""Tests for the async server->client notifications bridge (#2597 S2b / S2b-log).
 
 Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``. The
 notification-carrying tests spawn a REAL subprocess running
 ``tests/_support/mcp_fastmcp_echo_server.py`` (a real FastMCP server) whose
-``notify_tool_list_changed`` / ``notify_prompt_list_changed`` / ``progress`` tools send
-REAL SEP-1686 notifications over the wire on a held (S2a) connection — proving
-``ReynMCPMessageHandler`` actually receives server-pushed notifications on a held
-connection, not just that its methods work if called directly.
+``notify_tool_list_changed`` / ``notify_prompt_list_changed`` / ``progress`` /
+``notify_log`` tools send REAL SEP-1686 / MCP-logging notifications over the wire on a
+held (S2a) connection — proving ``ReynMCPMessageHandler`` actually receives
+server-pushed notifications on a held connection, not just that its methods work if
+called directly.
 """
 from __future__ import annotations
 
@@ -198,6 +199,38 @@ async def test_progress_notification_emits_mcp_progress_event(tmp_path: Path):
         assert (
             first_step.data.get("message"), second_step.data.get("message"),
         ) == ("step-1", "step-2")
+    finally:
+        await service.aclose()
+
+
+# ── (b2) real server-pushed logging notification -> mcp_log event ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_logging_notification_emits_mcp_log_event(tmp_path: Path):
+    """Tier 2: a REAL server-pushed ``notifications/message`` (MCP logging) on a held
+    connection lands as an ``mcp_log`` event on the session's EventLog — routing
+    verified against the installed fastmcp/mcp SDK (see message_handler.py's module
+    docstring, S2b-log section): the base ``MessageHandler.dispatch`` match/case calls
+    ``on_logging_message`` for a ``LoggingMessageNotification`` on the SAME
+    ``message_handler`` that already bridges ``tools/list_changed`` etc, no separate
+    ``log_handler`` wiring needed."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool(
+            "notify_log",
+            {"level": "warning", "logger_name": "exp.logger", "msg": "hello from server"},
+        )
+        assert result["isError"] is False
+
+        matching = [e for e in events.all() if e.type == "mcp_log"]
+        (only_event,) = matching  # exactly one — the single real notification sent
+        assert only_event.data.get("server") == "srv"
+        assert only_event.data.get("level") == "warning"
+        assert only_event.data.get("logger") == "exp.logger"
+        assert only_event.data.get("data", {}).get("msg") == "hello from server"
     finally:
         await service.aclose()
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

Completes the S2b server->client-notifications-consume story by adding logging
(`notifications/message`) consumption to the existing `ReynMCPMessageHandler`
bridge (S2b landed tools/prompts `list_changed` + `progress`; this adds the
remaining notification type). A new `mcp_log` event lands on the session
`EventLog` with `server`, `level`, `logger`, `data` fields, mirroring the shape
of the existing `mcp_tool_list_changed` / `mcp_prompt_list_changed` / `mcp_progress`
events.

## Routing-question result (VERIFIED, not assumed)

I ran a live experiment (a real FastMCP server calling `ctx.log(...)`, held via a
real `fastmcp.Client`) before touching any code. Result: **both** paths fire for the
same `notifications/message` wire message —

- `mcp.client.session.ClientSession._received_notification` routes it to the
  Client-level `log_handler` kwarg (FastMCP's `default_log_handler` if none given).
- `mcp.shared.session.BaseSession._handle_incoming` separately calls the
  `message_handler` — i.e. our existing `ReynMCPMessageHandler`, via the inherited
  `MessageHandler.dispatch` match/case, which already has an `on_logging_message`
  hook point (`case mcp.types.LoggingMessageNotification(): await
  self.on_logging_message(message.root)`).

Both call sites run unconditionally per notification (the receive loop calls
`_received_notification(...)` THEN `_handle_incoming(...)`, not either/or) — I
verified this directly by instrumenting both a `MessageHandler.on_logging_message`
override AND a `log_handler` callback on the same held client and observing **both**
fire for one `ctx.log()` call from the server.

Since `ReynMCPMessageHandler` is already installed as the `message_handler` on
every held connection (S2b), the correct/minimal wiring is to add
`on_logging_message` to it (mirrors the existing hook pattern exactly) — NOT to
also wire the separate `log_handler` kwarg, which would double-emit the same
notification through a second, redundant path.

No `logging/setLevel` call was needed: the experiment server emitted at its
default level with no client-side `setLevel`, and the notification arrived
normally — so no default-level wiring was added (out of scope per the ticket,
confirmed unnecessary).

Note (precedent check, not new scope): `mcp_tool_list_changed` /
`mcp_prompt_list_changed` (S2b) have **no** `ChatLifecycleForwarder.on_mcp_*`
consumer either — only `mcp_progress` does. `mcp_log` follows the same
majority precedent (EventLog-only, no UI forwarder) rather than introducing an
inconsistent new wiring; adding a forwarder consumer is a separate concern if/when
wanted.

## Changes

- `src/reyn/mcp/message_handler.py`: `ReynMCPMessageHandler.on_logging_message`
  hook — synchronous body (never awaits the sink), swallows sink faults, calls
  `await super().on_logging_message(...)` to preserve the inherited
  `TaskNotificationHandler` task-status routing (same pattern as the other three
  hooks). Emits `mcp_log` with `server`, `level`, `logger`, `data`. Module +
  class docstrings extended to document the routing-question finding.
- `tests/_support/mcp_fastmcp_echo_server.py`: added `notify_log(level,
  logger_name, msg)` tool — sends a real MCP logging notification via
  `Context.log`, mirroring the existing `notify_tool_list_changed` /
  `notify_prompt_list_changed` pattern.
- `tests/test_2597_s2b_mcp_notifications_bridge.py`: new Tier 2 test
  `test_logging_notification_emits_mcp_log_event` — spawns the real echo-server
  subprocess over a held (S2a) connection, calls `notify_log`, and asserts the
  `mcp_log` event lands on the EventLog with the right `server`/`level`/`logger`/
  `data` fields. Real subprocess + real EventLog, no mocks.

## Out of scope (unchanged from ticket)

resources/updated + subscribe; proactive ping supervision; server->client
requests (elicitation/sampling, S3); turn-cancel (S2c); OAuth (S6);
`logging/setLevel` sending (verified unnecessary above).

## Test plan

- [x] `ruff check src tests` — All checks passed!
- [x] `python scripts/test_tier_audit.py --strict tests/test_2597_s2b_mcp_notifications_bridge.py` — 6/6 OK, 0 warnings, 0 errors.
- [x] `pytest` (repo root) — 7272 passed, 21 skipped, **5 failed** (all pre-existing
      `#2599` web-route-mount failures: `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`,
      `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`,
      `test_plugin_loader.py::test_loader_disambiguates_via_package_field`,
      `test_resources_router.py::test_resources_route_is_mounted_on_app` — confirmed by
      running the same 5 tests against `main` with this branch's diff stashed: **identical
      5/5 failures**, zero new failures introduced by this change).
- [x] `python scripts/verify_module_docstrings.py src/reyn/mcp/message_handler.py` — OK.
- [x] Manual: ran the live routing-experiment script against a real FastMCP stdio
      server + a real held `fastmcp.Client` with both an `on_logging_message`
      override and a `log_handler` callback installed simultaneously — observed
      both fire for one `ctx.log()` call, confirming the routing-question result
      above before writing any production code.