### PR TITLE
feat(#2597): capability/version gate — negotiate MCP version + capabilities at connect, gate tool calls

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -20,6 +20,26 @@ Environment variable expansion:
   ``os.environ.get("VAR_NAME", "")``. Missing variables expand to empty
   string and a warning is emitted. Apply :func:`expand_env` BEFORE
   handing config to the SDK.
+
+Capability / version gate (#2597 capability slice):
+  MCP's ``initialize`` handshake natively negotiates BOTH a protocol version
+  and a set of server capabilities (tools/resources/prompts/logging/
+  completions) in one round trip — rather than sprinkling version checks
+  across reyn, :meth:`initialize` captures both ONCE, right after FastMCP's
+  ``client.__aenter__()`` completes the handshake (verified against fastmcp
+  3.4.2: ``Client.initialize_result`` — an ``mcp.types.InitializeResult`` —
+  is populated at that point; see ``initialize()``'s inline comment for the
+  exact source-file/line trail). :meth:`supports` answers "did the server
+  advertise capability X" (conservative False before initialize / on a
+  missing result); :func:`require_capability` is the enforcement seam —
+  call it before issuing a request for a gated feature so an unsupported
+  one fails fast with a reyn-authored error instead of a confusing raw
+  protocol error. Today only ``call_tool``/``list_tools`` call it (gated on
+  ``"tools"``); a later slice plugs resources/prompts requests into the
+  SAME helper before they reach the server. :attr:`negotiated_version`
+  exposes the raw protocol version string for callers/later slices to
+  branch on — this slice deliberately does not build a version-semantics
+  matrix, just makes the version + capabilities readable and gated.
 """
 from __future__ import annotations
 
@@ -42,6 +62,36 @@ class MCPError(RuntimeError):
 
 
 _SUPPORTED_TYPES = {"stdio", "http", "sse"}
+
+# #2597 capability/version gate slice: the ``ServerCapabilities`` fields FastMCP's
+# ``mcp.types.InitializeResult.capabilities`` may carry — each is either a capability
+# object (server advertises it) or None (server does not). ``experimental`` and
+# ``tasks`` are deliberately excluded: they aren't reyn features today (no gate to
+# apply), unlike the five below which map 1:1 onto MCP feature surfaces reyn calls
+# or will call in a later slice (resources/prompts).
+_CAPABILITY_NAMES = frozenset({"tools", "resources", "prompts", "logging", "completions"})
+
+
+def require_capability(client: "MCPClient", capability: str) -> None:
+    """Fail fast with a clear reyn error if ``client``'s connected server did not
+    advertise ``capability`` in its initialize handshake — the #2597 enforcement
+    seam. Call this BEFORE issuing a request for a gated feature (today: tool
+    calls, gated on ``"tools"``; a later slice plugs resources/prompts requests
+    into this same helper before they reach the server) so an unsupported feature
+    fails with a reyn-authored message instead of a confusing raw protocol error
+    from the server.
+
+    Raises :class:`MCPError` if not supported; no-op (returns None) otherwise.
+    """
+    if client.supports(capability):
+        return
+    server = client.server_name or "<unknown>"
+    version = client.negotiated_version or "<unknown>"
+    raise MCPError(
+        f"MCP server {server!r} does not advertise the {capability!r} capability "
+        f"(negotiated protocol version {version}). Refusing to call a "
+        f"{capability!r} feature against it."
+    )
 
 
 # ── Client ───────────────────────────────────────────────────────────────────
@@ -66,6 +116,7 @@ class MCPClient:
         *,
         agent_id: str | None = None,
         message_handler: Any = None,
+        server_name: str | None = None,
     ) -> None:
         if not isinstance(config, dict):
             raise ValueError(f"MCP server config must be a dict, got {type(config).__name__}")
@@ -83,6 +134,13 @@ class MCPClient:
         # agent. None preserves prior behaviour for direct callers (= the
         # session factory passes ReynConfig.agent.id; tests can omit).
         self._agent_id: str | None = agent_id
+        # #2597 capability/version gate: the server name this client connects to, for
+        # error messages only (this object never uses it to look itself up — callers
+        # that construct MCPClient directly, e.g. tests, may omit it; the fail-fast
+        # message then falls back to "<unknown>"). Threaded in by MCPClientPool /
+        # MCPConnectionService, both of which already know the server name at
+        # construction time.
+        self._server_name: str | None = server_name
         # #2597 S2b: optional async server->client notifications bridge — a
         # ReynMCPMessageHandler (fastmcp.client.tasks.TaskNotificationHandler subclass;
         # see reyn.mcp.message_handler) that receives tools/prompts list_changed +
@@ -107,6 +165,54 @@ class MCPClient:
         # stdio MCP server's subprocess, if one was generated in _open_stdio.
         # Unlinked in close(). None for non-stdio / non-seatbelt / unsandboxed.
         self._sandbox_profile_path: str | None = None
+        # #2597 capability/version gate: captured in initialize() right after
+        # ``client.__aenter__()`` completes FastMCP's initialize handshake (verified
+        # against fastmcp 3.4.2: ``fastmcp.Client.initialize_result`` is populated at
+        # that point — see client.py module docstring's fact-check). None until then
+        # (or if the server's InitializeResult was unavailable — handled defensively,
+        # never raises).
+        self._negotiated_version: str | None = None
+        self._server_capabilities: Any = None  # mcp.types.ServerCapabilities | None
+
+    @property
+    def server_name(self) -> str | None:
+        """The configured name of the server this client connects to, or None if
+        the caller didn't supply one at construction. Used only for error-message
+        context (:func:`require_capability`) — never for lookup."""
+        return self._server_name
+
+    @property
+    def negotiated_version(self) -> str | None:
+        """The MCP protocol version negotiated at connect (e.g. ``"2025-11-25"``),
+        or None before :meth:`initialize` runs (or if the server's
+        ``InitializeResult`` was unavailable). Read-only — later slices branch on
+        this to apply version-specific behaviour; this slice only exposes it."""
+        return self._negotiated_version
+
+    def supports(self, capability: str) -> bool:
+        """Return True iff the connected server advertised ``capability`` in its
+        initialize handshake. ``capability`` must be one of ``"tools"``,
+        ``"resources"``, ``"prompts"``, ``"logging"``, ``"completions"``.
+
+        Conservative False before :meth:`initialize` runs (or if the server's
+        capabilities were unavailable) — an un-negotiated connection advertises
+        nothing rather than everything.
+        """
+        if capability not in _CAPABILITY_NAMES:
+            raise ValueError(
+                f"Unknown MCP capability: {capability!r}. "
+                f"Expected one of {sorted(_CAPABILITY_NAMES)}."
+            )
+        if self._server_capabilities is None:
+            return False
+        return getattr(self._server_capabilities, capability, None) is not None
+
+    def advertised_capabilities(self) -> list[str]:
+        """Sorted list of capability names the connected server advertised (subset
+        of the five :meth:`supports` recognizes). Empty before :meth:`initialize`
+        runs. Used for observability (the ``mcp_initialized`` event) — see
+        :mod:`reyn.mcp.connection_service`."""
+        return sorted(name for name in _CAPABILITY_NAMES if self.supports(name))
 
     @property
     def stderr_capture(self) -> "Any":
@@ -197,6 +303,21 @@ class MCPClient:
 
         self._client = client
         self._initialized = True
+        # #2597 capability/version gate: read the negotiated version + capabilities
+        # right after the handshake completes. ``initialize_result`` is populated by
+        # ``client.__aenter__()`` above (fastmcp 3.4.2: ``Client.initialize_result``
+        # property backed by ``_session_state.initialize_result``, set inside
+        # ``Client.initialize()`` which ``__aenter__`` calls) — but read it
+        # defensively: None here would mean FastMCP's own contract changed
+        # underneath us, not a reyn bug, so degrade to "unknown" (supports() ->
+        # False, negotiated_version -> None) rather than raise.
+        init_result = getattr(client, "initialize_result", None)
+        if init_result is not None:
+            self._negotiated_version = str(init_result.protocolVersion)
+            self._server_capabilities = init_result.capabilities
+        else:
+            self._negotiated_version = None
+            self._server_capabilities = None
 
     async def __aenter__(self) -> "MCPClient":
         """#a359: structured lifecycle. ``initialize()`` here + ``close()`` in ``__aexit__`` run in
@@ -241,6 +362,10 @@ class MCPClient:
             transport-level default.
         """
         await self.initialize()
+        # #2597 capability/version gate: fail fast with a clear reyn error if the
+        # server never advertised "tools" rather than let the request reach the
+        # server and bounce back as a confusing raw protocol error.
+        require_capability(self, "tools")
         kwargs: dict[str, Any] = {}
         if progress_callback is not None:
             kwargs["progress_handler"] = progress_callback
@@ -266,6 +391,8 @@ class MCPClient:
         longer silently truncate.
         """
         await self.initialize()
+        # #2597 capability/version gate: same seam as call_tool — see there.
+        require_capability(self, "tools")
         try:
             tools = await self._client.list_tools()
         except Exception as exc:
@@ -280,6 +407,12 @@ class MCPClient:
         client = self._client
         self._client = None
         self._initialized = False
+        # #2597 capability/version gate: a closed client re-negotiates on the next
+        # initialize() (or duck-typed callers who happen to keep querying supports()
+        # on a closed client should see the conservative False, not stale state from
+        # the old connection).
+        self._negotiated_version = None
+        self._server_capabilities = None
         try:
             await client.close()
         except Exception:

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -164,9 +164,25 @@ class MCPConnectionService:
                     self._emit_sink, server,
                     tools_cache_invalidate=self._tools_cache_invalidate,
                 )
-            client = MCPClient(config, agent_id=agent_id, message_handler=handler)
+            client = MCPClient(
+                config, agent_id=agent_id, message_handler=handler, server_name=server,
+            )
             await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
             self._clients[server] = client
+            # #2597 capability/version gate: observability seam. This is the first
+            # point in the live (non-ephemeral) session path that HAS the emit_sink
+            # (the ephemeral per-call MCPClientPool path never wires one — see class
+            # docstring — so it stays silent, matching pre-#2597 behaviour there).
+            # Fires once per (re)connect, including reconnects (a version/capability
+            # renegotiation is itself worth a trace event, not just the first
+            # connect).
+            if self._emit_sink is not None:
+                self._emit_sink(
+                    "mcp_initialized",
+                    server=server,
+                    negotiated_version=client.negotiated_version,
+                    capabilities=client.advertised_capabilities(),
+                )
         return client
 
     async def _reconnect(

--- a/src/reyn/mcp/pool.py
+++ b/src/reyn/mcp/pool.py
@@ -109,7 +109,7 @@ class MCPClientPool:
                 "ops in the pool's owning task."
             )
         if server not in self._clients:
-            client = MCPClient(config, agent_id=agent_id)
+            client = MCPClient(config, agent_id=agent_id, server_name=server)
             await client.__aenter__()  # enter (initialize) in the pool's task
             self._clients[server] = client
         return self._clients[server]

--- a/tests/_support/mcp_resources_server.py
+++ b/tests/_support/mcp_resources_server.py
@@ -1,0 +1,47 @@
+"""Low-level real MCP stdio server that advertises the ``resources`` capability
+(#2597 capability gate slice).
+
+Standalone script — run as a subprocess, never imported. Uses the LOW-LEVEL
+``mcp.server.lowlevel.Server`` (like ``mcp_paginated_tools_server.py``) rather
+than ``FastMCP`` — verified empirically that a FastMCP-built server ALWAYS
+advertises non-None ``tools``/``resources``/``prompts``/``logging``
+capabilities regardless of what it registers (FastMCP itself implements all
+four handler types for every server it builds), so it cannot demonstrate a
+server that does NOT advertise a capability. The low-level SDK ``Server``
+instead derives ``ServerCapabilities`` from which handler types were actually
+registered (``get_capabilities()``), so a server that registers ONLY
+``@app.list_resources()``/``@app.read_resource()`` (no ``@app.list_tools()``)
+gets ``resources`` non-None and ``tools`` None — the real differentiator this
+gate slice needs to prove ``MCPClient.supports()`` reads the ACTUAL negotiated
+capabilities rather than a hardcoded reyn-side assumption.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+app = Server("reyn-test-resources")
+
+_URI = "resource://greeting"
+
+
+@app.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [types.Resource(uri=_URI, name="greeting", mimeType="text/plain")]
+
+
+@app.read_resource()
+async def read_resource(uri) -> str:
+    return "hello from a resource"
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_2421_gateway_acceptance.py
+++ b/tests/test_2421_gateway_acceptance.py
@@ -31,7 +31,7 @@ class _FaultClient:
 
     _next_exc: BaseException = RuntimeError("unset")
 
-    def __init__(self, config, *, agent_id=None) -> None:
+    def __init__(self, config, *, agent_id=None, server_name=None) -> None:
         self._exc = _FaultClient._next_exc
 
     async def __aenter__(self):
@@ -85,7 +85,7 @@ class _SlowClient:
 
     hang_on: str = "op"  # "init" | "op"
 
-    def __init__(self, config, *, agent_id=None) -> None:
+    def __init__(self, config, *, agent_id=None, server_name=None) -> None:
         pass
 
     async def __aenter__(self):

--- a/tests/test_2597_capability_version_gate.py
+++ b/tests/test_2597_capability_version_gate.py
@@ -1,0 +1,186 @@
+"""Tests for the #2597 capability/version gate slice — negotiated protocol version
++ server capabilities captured at connect, gated feature calls.
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``.
+Round-trips spawn REAL MCP servers (stdio subprocess):
+
+  - ``mcp_fastmcp_echo_server.py`` (FastMCP) — the happy-path ``call_tool``
+    round-trip. NOT used for capability-absence assertions: verified empirically
+    that a FastMCP-built server always advertises non-None
+    tools/resources/prompts/logging regardless of what it registers (FastMCP
+    itself implements all four handler types for every server), so it cannot
+    demonstrate an UNADVERTISED capability.
+  - ``mcp_paginated_tools_server.py`` (low-level ``mcp.server.lowlevel.Server``,
+    tools-only) — the negotiated ``ServerCapabilities`` there are DERIVED from
+    which handler types were actually registered, so ``resources``/``prompts``/
+    ``logging`` are genuinely None: the real "server did not advertise X" case.
+  - ``mcp_resources_server.py`` (same low-level SDK, registers ONLY
+    ``list_resources``/``read_resource``) — ``resources`` non-None, ``tools``
+    None: proves ``supports()`` reads the server's ACTUAL negotiated
+    capabilities in both directions, not a hardcoded reyn-side assumption.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPClient, MCPError, require_capability
+from reyn.mcp.connection_service import MCPConnectionService
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+_TOOLS_ONLY_SERVER = _SUPPORT_DIR / "mcp_paginated_tools_server.py"
+_RESOURCES_SERVER = _SUPPORT_DIR / "mcp_resources_server.py"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {
+        "type": "stdio",
+        "command": sys.executable,
+        "args": [str(script)],
+    }
+
+
+def test_negotiated_version_and_tools_capability_on_tools_only_server() -> None:
+    """Tier 1: framework boundary — a real tools-only (low-level SDK) server
+    negotiates a dated protocol version string and advertises "tools" but not
+    "resources"/"prompts"."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_TOOLS_ONLY_SERVER)) as client:
+            return (
+                client.negotiated_version,
+                client.supports("tools"),
+                client.supports("resources"),
+                client.supports("prompts"),
+                client.advertised_capabilities(),
+            )
+
+    version, supports_tools, supports_resources, supports_prompts, advertised = asyncio.run(_run_it())
+    assert isinstance(version, str) and version  # a dated revision, e.g. "2025-11-25"
+    assert supports_tools is True
+    assert supports_resources is False
+    assert supports_prompts is False
+    assert advertised == ["tools"]
+
+
+def test_resources_capability_advertised_when_server_registers_a_resource() -> None:
+    """Tier 1: framework boundary — a real server that registers ONLY a resource
+    handler (no tools) negotiates a non-None ``resources`` capability and a None
+    ``tools`` one, proving ``supports()`` reads the server's actual declared
+    capabilities in both directions (not a reyn-side guess)."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_RESOURCES_SERVER)) as client:
+            return client.supports("resources"), client.supports("tools")
+
+    supports_resources, supports_tools = asyncio.run(_run_it())
+    assert supports_resources is True
+    assert supports_tools is False
+
+
+def test_call_tool_succeeds_when_tools_capability_advertised() -> None:
+    """Tier 1: the gate does not block a legitimate tool call on a real FastMCP
+    server that advertises "tools" (the common case must stay unaffected)."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_ECHO_SERVER)) as client:
+            return await client.call_tool("echo", {"text": "gated-ok"})
+
+    result = asyncio.run(_run_it())
+    assert result["isError"] is False
+    assert result["content"][0]["text"] == "gated-ok"
+
+
+def test_call_tool_fails_fast_against_a_server_that_does_not_advertise_tools() -> None:
+    """Tier 1: the gate blocks ``call_tool`` against a real server that never
+    advertised "tools" — the enforcement seam (:func:`require_capability`,
+    called from ``MCPClient.call_tool``) fires before the request reaches the
+    server, raising a clear reyn ``MCPError`` instead of a raw protocol error."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_RESOURCES_SERVER), server_name="resources-srv") as client:
+            await client.call_tool("anything", {})
+
+    with pytest.raises(MCPError) as exc_info:
+        asyncio.run(_run_it())
+    message = str(exc_info.value)
+    assert "tools" in message
+    assert "resources-srv" in message
+
+
+def test_require_capability_fails_fast_with_clear_error_when_not_advertised() -> None:
+    """Tier 1: :func:`require_capability` raises a clear reyn ``MCPError`` — naming
+    the ungated capability, the server, and the negotiated version — instead of
+    letting a request reach the server. Uses the public accessors (``supports`` /
+    ``negotiated_version``), never private state."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_TOOLS_ONLY_SERVER), server_name="tools-only-srv") as client:
+            assert client.supports("resources") is False
+            try:
+                require_capability(client, "resources")
+            except MCPError as exc:
+                return str(exc), client.negotiated_version
+            return None, client.negotiated_version
+
+    message, version = asyncio.run(_run_it())
+    assert message is not None
+    assert "resources" in message
+    assert "tools-only-srv" in message
+    assert version is not None and version in message
+
+
+def test_supports_rejects_unknown_capability_name() -> None:
+    """Tier 1: ``supports`` fails fast on a typo'd / unsupported capability name
+    rather than silently returning False forever."""
+
+    async def _run_it():
+        async with MCPClient(_stdio_cfg(_ECHO_SERVER)) as client:
+            try:
+                client.supports("subscribe")
+            except ValueError as exc:
+                return str(exc)
+            return None
+
+    message = asyncio.run(_run_it())
+    assert message is not None
+    assert "subscribe" in message
+
+
+def test_supports_is_conservative_before_initialize() -> None:
+    """Tier 1: a not-yet-initialized client advertises nothing (conservative
+    False) and has no negotiated version — never "everything supported" by
+    default."""
+    client = MCPClient(_stdio_cfg(_ECHO_SERVER))
+    assert client.negotiated_version is None
+    assert client.supports("tools") is False
+    assert client.advertised_capabilities() == []
+
+
+@pytest.mark.asyncio
+async def test_connection_service_emits_mcp_initialized_with_version_and_capabilities():
+    """Tier 2: the held-connection service (#2597 S2a) — the live session's MCP
+    entry point — emits an ``mcp_initialized`` event carrying the REAL negotiated
+    version + advertised capabilities on first connect, via the same ``emit_sink``
+    seam S2b's notifications bridge uses. Observability seam per the #2597
+    capability slice."""
+    recorded: list[tuple[str, dict]] = []
+
+    def _emit_sink(event_type: str, **data) -> None:
+        recorded.append((event_type, data))
+
+    service = MCPConnectionService(emit_sink=_emit_sink)
+    try:
+        await service.get("srv", _stdio_cfg(_TOOLS_ONLY_SERVER))
+    finally:
+        await service.aclose()
+
+    init_events = [d for et, d in recorded if et == "mcp_initialized"]
+    (event,) = init_events  # exactly one mcp_initialized event fired for this connect
+    assert event["server"] == "srv"
+    assert isinstance(event["negotiated_version"], str) and event["negotiated_version"]
+    assert event["capabilities"] == ["tools"]

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -62,7 +62,7 @@ class _FakeMCPClient:
 
     instances: list = []
 
-    def __init__(self, config, *, agent_id=None) -> None:
+    def __init__(self, config, *, agent_id=None, server_name=None) -> None:
         self.closed = False
         self.close_task = None
         self.list_task = None

--- a/tests/test_mcp_probe_client_lifecycle.py
+++ b/tests/test_mcp_probe_client_lifecycle.py
@@ -22,7 +22,7 @@ class _FakeMCPClient:
 
     last_config = None
 
-    def __init__(self, config, *, agent_id=None) -> None:
+    def __init__(self, config, *, agent_id=None, server_name=None) -> None:
         if not isinstance(config, dict):
             raise ValueError("MCP server config must be a dict")
         _FakeMCPClient.last_config = config

--- a/tests/test_mcp_progress_and_timeout.py
+++ b/tests/test_mcp_progress_and_timeout.py
@@ -48,6 +48,32 @@ class _StubPool:
     def owner_task(self): return None
     async def get(self, server, config, *, agent_id=None): return self._client
 
+
+class _FakeServerCapabilities:
+    """Stand-in for ``mcp.types.ServerCapabilities`` — advertises "tools" only
+    (non-None), matching the transport-level fakes in this file, which only ever
+    exercise ``call_tool_mcp``. #2597 capability/version gate: the tests below
+    hand-construct a half-initialised ``MCPClient`` that bypasses the real
+    ``initialize()`` handshake (see each test), so ``supports("tools")`` must be
+    primed the same way ``_initialized``/``_client`` are, or the gate added in
+    ``MCPClient.call_tool`` fails these fakes fast for a reason unrelated to what
+    they're testing (progress/timeout wiring, not the capability gate)."""
+    tools: Any = object()
+    resources: Any = None
+    prompts: Any = None
+    logging: Any = None
+    completions: Any = None
+
+
+def _bypass_initialize(client: MCPClient, fake_fastmcp_client: Any) -> None:
+    """Prime ``client`` as if ``initialize()`` had run against a real server that
+    advertises "tools" (protocol version fixed for determinism), without spawning
+    a real transport. See ``_FakeServerCapabilities``."""
+    client._initialized = True
+    client._client = fake_fastmcp_client
+    client._negotiated_version = "2025-11-25"
+    client._server_capabilities = _FakeServerCapabilities()
+
 # ── 1. MCPClient.call_tool signature accepts the new kwargs ────────────
 
 
@@ -98,8 +124,7 @@ def test_call_tool_passes_progress_callback_and_timedelta_to_fastmcp_client() ->
     # transport. The signature accepts a config dict + sets internal
     # state directly so we don't have to spawn a subprocess.
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
-    client._initialized = True
-    client._client = _FakeFastMCPClient()
+    _bypass_initialize(client, _FakeFastMCPClient())
 
     async def _on_progress(progress: float, total: float | None, msg: str | None) -> None:
         return None
@@ -144,8 +169,7 @@ def test_call_tool_omits_kwargs_when_none_for_backwards_compat() -> None:
             return _FakeResult()
 
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
-    client._initialized = True
-    client._client = _FakeFastMCPClient()
+    _bypass_initialize(client, _FakeFastMCPClient())
 
     asyncio.run(client.call_tool("demo", {"x": 1}))
 
@@ -202,8 +226,7 @@ def test_op_handler_progress_callback_emits_mcp_progress_event() -> None:
     )
     # Pre-install a fake client so MCPClient construction is skipped.
     client = MCPClient({"type": "stdio", "command": "/bin/true"})
-    client._initialized = True
-    client._client = _CapturingFastMCPClient()
+    _bypass_initialize(client, _CapturingFastMCPClient())
     ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
@@ -272,8 +295,7 @@ def test_op_handler_reads_call_timeout_from_server_config() -> None:
     client = MCPClient(
         {"type": "stdio", "command": "/bin/true", "call_timeout_seconds": 7.5},
     )
-    client._initialized = True
-    client._client = _CapturingFastMCPClient()
+    _bypass_initialize(client, _CapturingFastMCPClient())
     ctx.mcp_pool = _StubPool(client)
 
     op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})
@@ -328,8 +350,7 @@ def test_op_handler_call_timeout_default_finite_and_optout() -> None:
             mcp_servers={"demo": cfg},
             )
         client = MCPClient(cfg)
-        client._initialized = True
-        client._client = _CapturingFastMCPClient()
+        _bypass_initialize(client, _CapturingFastMCPClient())
         ctx.mcp_pool = _StubPool(client)
 
         op = MCPIROp(kind="mcp", server="demo", tool="thing", args={})

--- a/tests/test_mcp_structured_pool_p2.py
+++ b/tests/test_mcp_structured_pool_p2.py
@@ -120,7 +120,7 @@ async def test_pool_contains_teardown_exception_group(monkeypatch):
     raising = _RaisingCloseClient(
         BaseExceptionGroup("teardown", [RuntimeError("BrokenResourceError"), RuntimeError("ConnectionReset")])
     )
-    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None, server_name=None: raising)
 
     async with MCPClientPool() as pool:
         await pool.get("srv", {"type": "stdio", "command": "x"})
@@ -138,7 +138,7 @@ async def test_pool_contains_spurious_cancel_in_teardown(monkeypatch):
     raising = _RaisingCloseClient(
         BaseExceptionGroup("teardown", [ConnectionResetError("subprocess died"), asyncio.CancelledError()])
     )
-    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None, server_name=None: raising)
 
     async with MCPClientPool() as pool:  # no raise — the spurious cancel-mixed teardown is contained
         await pool.get("srv", {"type": "stdio", "command": "x"})
@@ -237,7 +237,7 @@ async def test_pool_reraises_keyboardinterrupt_in_teardown(monkeypatch):
     """Tier 2: the pool re-raises a KeyboardInterrupt-containing teardown group (control flow is
     never contained) — the required refinement beyond cancellation."""
     raising = _RaisingCloseClient(BaseExceptionGroup("teardown", [KeyboardInterrupt()]))
-    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None: raising)
+    monkeypatch.setattr(pool_mod, "MCPClient", lambda cfg, *, agent_id=None, server_name=None: raising)
 
     with pytest.raises(BaseException) as ei:
         async with MCPClientPool() as pool:


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

MCP's `initialize` handshake natively negotiates BOTH a protocol version and a set of server capabilities in one round trip. This slice captures both ONCE at connect and gates reyn's MCP feature usage on the result, rather than sprinkling version logic across reyn.

- `MCPClient.initialize()` reads `self._client.initialize_result` (fastmcp's `mcp.types.InitializeResult`) right after `client.__aenter__()` completes the handshake, and stores:
  - `negotiated_version: str | None` — the dated protocol revision string (e.g. `"2025-11-25"`).
  - the server's `ServerCapabilities` object.
- New public read accessors: `MCPClient.negotiated_version`, `MCPClient.supports(capability)` (one of `tools`/`resources`/`prompts`/`logging`/`completions`), `MCPClient.advertised_capabilities()`. Conservative (`False`/`None`/`[]`) before `initialize()` runs or if the result is unavailable — never "everything supported" by default.
- **Enforcement seam**: `require_capability(client, capability)` in `src/reyn/mcp/client.py` raises a clear `MCPError` — naming the server, the capability, and the negotiated version — if the server didn't advertise it. Wired into `MCPClient.call_tool` / `MCPClient.list_tools` (gated on `"tools"`, the only feature reyn calls today). **A later slice plugs resources/prompts requests into this SAME helper before they reach the server** — no gate logic to rebuild, just call `require_capability(client, "resources")` before issuing the request.
- **Observability**: `MCPConnectionService` (the live/persistent session's held-connection path, #2597 S2a) emits an `mcp_initialized` event (`server`, `negotiated_version`, `capabilities`) via the same `emit_sink` seam the S2b notifications bridge already uses — fires on every (re)connect. The ephemeral per-call `MCPClientPool` path has no `emit_sink` wired (pre-existing), so it stays silent, matching pre-#2597 behaviour there.
- `MCPClient`/`MCPClientPool`/`MCPConnectionService` now thread an optional `server_name` through construction, used only for clear error-message context (never for lookup).

## Fact-check against installed fastmcp 3.4.2 (done before implementing, not assumed)

- `fastmcp.Client.initialize_result` is populated by `client.__aenter__()` — verified live against real servers (see `fastmcp/client/client.py:116,387`).
- **Correction to the ticket's stated assumption**: a FastMCP-built server (`FastMCP("name")` + `@mcp.tool()`/`@mcp.resource()`) ALWAYS advertises non-None `tools`/`resources`/`prompts`/`logging` capabilities regardless of what it registers — FastMCP itself implements all four handler types for every server it builds. So a FastMCP server cannot demonstrate an *unadvertised* capability. The low-level `mcp.server.lowlevel.Server` SDK instead derives `ServerCapabilities` from which handler types are actually registered (`get_capabilities()`), so tests use a low-level tools-only server (`tests/_support/mcp_paginated_tools_server.py`, already existed) and a new low-level resources-only server (`tests/_support/mcp_resources_server.py`) to exercise both directions against real negotiated capabilities.

## Out of scope (per ticket)

resources/prompts consumption itself, subscribe, elicitation/sampling/roots, OAuth, logging. No version-semantics matrix — `negotiated_version` is exposed read-only for later slices to branch on.

## Test plan

- [x] `test_2597_capability_version_gate.py` (new, 8 tests, real stdio subprocess servers, no mocks):
  - negotiated version + `tools`/`resources`/`prompts` capability read correctly on a real tools-only server.
  - `resources` capability flips True (and `tools` False) on a real resources-only server — proves `supports()` reads the ACTUAL negotiated capabilities, not a hardcoded assumption.
  - `call_tool` succeeds unaffected when `tools` is advertised (no regression on the common path).
  - `call_tool` fails fast with `MCPError` against a server that doesn't advertise `tools`.
  - `require_capability` error message names the capability, server, and negotiated version.
  - `supports()` rejects an unknown capability name; conservative before `initialize()`.
  - `MCPConnectionService` emits `mcp_initialized` with the real negotiated version + capabilities.
- [x] Updated 6 pre-existing test files whose hand-constructed `MCPClient`/pool fakes needed the new `server_name` kwarg or tools-capability priming (`test_2421_gateway_acceptance.py`, `test_mcp_structured_pool_p2.py`, `test_mcp_progress_and_timeout.py`, `test_mcp_probe_client_lifecycle.py`, `test_mcp_list_tools_finally_close.py`) — confirmed each failure was the new gate/kwarg, not a real regression, before fixing.

## Gate results (local, from repo root)

**ruff check src tests**: `All checks passed!`

**python scripts/test_tier_audit.py --strict <changed test files>**: `Summary: 34 tests inspected — OK: 34, warnings: 0, errors: 0` (exit 0)

**pytest** (full suite): `5 failed, 7279 passed, 21 skipped, 11 warnings in ~124s`
- The 5 failures are `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `web/test_a2a.py::test_a2a_routes_mounted`, `web/test_mcp_sse.py::test_mcp_routes_mounted`, `web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `web/test_resources_router.py::test_resources_route_is_mounted_on_app` — **confirmed identical on unmodified main** (`git stash` + re-run reproduced the exact same 5 failures), the known pre-existing #2599 web-route-mount issue. Zero NEW failures from this PR.

**python scripts/verify_module_docstrings.py <changed src files>**: `OK: no module-docstring refactor narrative in src/reyn/mcp/client.py src/reyn/mcp/connection_service.py src/reyn/mcp/pool.py`

## Enforcement seam for later slices

`require_capability(client: MCPClient, capability: str) -> None` in `src/reyn/mcp/client.py` (module-level function, next to `MCPError`). Call it with `client.supports(capability)`'s capability name right before issuing the gated request — it raises `MCPError` if unsupported, no-op otherwise. Today `MCPClient.call_tool`/`list_tools` call `require_capability(self, "tools")` right after `await self.initialize()`. A resources/prompts slice adds its own `list_resources`/`read_resource`/`list_prompts`/`get_prompt` methods to `MCPClient`, each starting with `require_capability(self, "resources")` / `require_capability(self, "prompts")` — same helper, same error shape, no new gate design needed.