### PR TITLE
feat(#2597): slice ②a — MCP resources consumption (list/read + templates)

### DIFF
--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -111,6 +111,17 @@ phase frontmatter         LLM emits Control IR        OS dispatches
 
 The boundary is sharp on purpose: workflows describe what they want, the OS decides how to get it. Adding a new MCP server doesn't touch any OS code (P7).
 
+### Resources: list + read
+
+Alongside tools, a server can expose **resources** (server-hosted content addressed by URI — files, database rows, generated documents) and **resource templates** (parameterized URI patterns the LLM fills in). Reyn's chat surface mirrors the tools flow:
+
+- `list_mcp_resources(server)` / `list_mcp_resource_templates(server)` — discovery, unpermissioned (mirrors `list_mcp_tools`; no Control IR op kind, no `permissions.mcp` gate — resource *metadata* carries no more risk than a tool's name/description).
+- `read_mcp_resource(server, uri)` — reads one resource's contents. This one IS gated: it's a `mcp_read_resource` Control IR op, requiring the same `permissions.mcp: [server_name]` grant as a tool call, because a resource's *contents* are external, potentially sensitive server-authored data — the same reasoning `call_mcp_tool` already applies to a tool result. Every read emits `mcp_resource_read` before, `mcp_resource_read_completed` (or `_failed`) after.
+
+Both list and read are additionally gated by the server's **negotiated capabilities**: a server that never advertised `resources` in its `initialize` handshake fails fast with a clear error (`require_capability` in `reyn/mcp/client.py`) instead of a raw protocol error.
+
+`resources/subscribe` (push notifications on resource change) is not yet implemented — today's surface is list + read only.
+
 ## Transport choice (stdio vs HTTP)
 
 Most official MCP servers are local processes you launch over stdio. A few hosted services expose HTTP endpoints. SSE transport is reserved for a future release.

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -343,6 +343,7 @@ The op kinds below mirror `OP_KIND_MODEL_MAP` in `op_runtime/registry.py`.
 | `web_search` | DuckDuckGo search — Tier 1, default-allow |
 | `web_fetch` | URL fetch + text extract — Tier 1, default-allow |
 | `mcp` | Call a configured MCP server tool by name |
+| `mcp_read_resource` | Read one MCP resource by URI (permission-gated, same axis as `mcp`) |
 | `mcp_install` | Install / register an MCP server (registry / package / local source) |
 | `index_query` | Vector similarity search over one indexed source |
 | `recall` | Macro: embed query → `index_query` per source → merge top-K |
@@ -528,6 +529,7 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | `mcp install` | Fetch from registry, gate permissions, write config, store secrets. Three chat verbs: `mcp__install_registry` (official registry), `mcp__install_package` (npm/pypi/docker/github URL), `mcp__install_local` (direct command). CLI: `reyn mcp install <SERVER_ID>` or `--source <SPEC>`. | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [reyn mcp CLI](reference/cli/mcp.md) |
 | Secret management | Per-server env vars in `~/.reyn/secrets.env` | [reyn secret CLI](reference/cli/secret.md) |
 | Tool dispatch | Lazy-load and cache `MCPClient` per server connection | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
+| Resources consumption | List/read MCP resources + resource templates (`list_mcp_resources` / `read_mcp_resource` / `list_mcp_resource_templates`), gated by the negotiated `resources` capability; `resources/subscribe` push updates are a separate, later slice | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_read_resource`](reference/runtime/control-ir.md) |
 
 > **Differentiation vs general agents:** Reyn is both an MCP client (consumes external servers) and an MCP server (exposes its own agents) — standard-protocol interop in both directions, with stdio MCP servers subprocess-sandboxed under Seatbelt.
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -23,6 +23,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `web_search` | Search the public web via DuckDuckGo | Tier 1 — default allow; `web.search: deny` in `reyn.yaml` blocks |
 | `web_fetch` | Fetch a single URL and return extracted text | Tier 1 — default allow; `web.fetch: deny` in `reyn.yaml` blocks |
 | `mcp` | Call a tool on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter |
+| `mcp_read_resource` | Read one resource (or a resolved resource-template URI) on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
@@ -232,6 +233,30 @@ Fields: `server` (required — must match a key under `mcp.servers:` in `reyn.ya
 The OS resolves the server's transport (`stdio`, `http`, or `sse`), dispatches via `MCPClient`, and returns the tool result. Every call emits `mcp_called`, `mcp_completed`, and (on failure) `mcp_failed` events.
 
 See [concepts/tools-integrations/mcp.md](../../concepts/tools-integrations/mcp.md) for server configuration, transport options, and the security model.
+
+## `mcp_read_resource`
+
+Reads one resource (or a resolved resource-template URI) from a configured MCP server. #2597 slice ②a (resources consumption) — gated by the **same** `permissions.mcp` axis as `mcp` (call_tool): a resource read returns external, potentially sensitive server-authored content, so it is permission-gated identically to a tool call.
+
+```json
+{
+  "kind": "mcp_read_resource",
+  "server": "filesystem",
+  "uri": "file:///README.md"
+}
+```
+
+Fields: `server` (required — must match a key under `mcp.servers:` in `reyn.yaml`), `uri` (required — a resource URI as advertised by the server's `resources/list`, or a resolved `resources/templates/list` template).
+
+> **Advertised name.** Phases advertise this op to the LLM under the chat-tool
+> name `read_mcp_resource`; the OS aliases it back to the `mcp_read_resource`
+> kind at the parse boundary — same pattern as `mcp`/`call_mcp_tool`.
+
+The OS resolves the server's transport, dispatches via `MCPClient.read_resource` (gated on the server's negotiated `resources` capability — see `require_capability` in `mcp/client.py`), and returns `{"contents": [...]}`. Every call emits `mcp_resource_read`, `mcp_resource_read_completed`, and (on failure) `mcp_resource_read_failed` events.
+
+**Discovery is NOT gated.** `list_mcp_resources` / `list_mcp_resource_templates` (the chat-tool names for `MCPClient.list_resources` / `list_resource_templates`) mirror `list_mcp_tools`: no `control-ir` op kind, no permission gate — pure discovery, routed directly through `MCPGateway` from the router host adapter. Only the content-returning read is a gated op kind, matching the existing `mcp` (call_tool) vs. discovery (`list_tools`) split.
+
+`resources/subscribe` + `resources/updated` push notifications are a separate, later slice (②b) — out of scope here.
 
 ## `mcp_install`
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -64,10 +64,45 @@ def _mcp_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
+def _mcp_read_resource_to_canonical(result: dict) -> CanonicalToolResult:
+    """MCP resource-read result → canonical (#2597 slice ②a). ``contents`` is a
+    list of flattened ``TextResourceContents``/``BlobResourceContents``: a
+    ``text`` entry joins into the canonical ``text`` (same offload-safe path
+    as a tool's joined ``content``); a ``blob`` entry (base64, arbitrary
+    mimeType — not necessarily an image) becomes a ``structured`` attachment
+    rather than a ``media`` one, since the existing ``media`` attachment path
+    assumes vision-follow-up-shaped image blocks that an arbitrary resource
+    blob does not fit. ``structured`` attachments are still size-gated
+    (:data:`~reyn.core.offload.seam.STRUCTURED_INLINE_MAX_CHARS`) — a large
+    blob is offloaded to its own ref rather than competing with ``text``, the
+    same guarantee ``_mcp_to_canonical`` gives a tool's ``structuredContent``.
+    """
+    attachments: list[dict] = []
+    text_parts: list[str] = []
+    for item in result.get("contents") or []:
+        if not isinstance(item, dict):
+            continue
+        if "text" in item and item["text"] is not None:
+            text_parts.append(str(item["text"]))
+        elif "blob" in item:
+            attachments.append({"kind": "structured", "data": item})
+    meta = {
+        k: v for k, v in result.items()
+        if k in ("kind", "status", "server", "uri", "error")
+    }
+    return CanonicalToolResult(
+        text="\n".join(text_parts),
+        attachments=attachments,
+        source_ref=None,
+        meta=meta,
+    )
+
+
 # op-kind → canonical mapper. New ops register here (or return canonical directly); a raw dict with no
 # registered mapper falls back to a whole-dict wrap so nothing is ever lost (see ``to_canonical``).
 _MAPPERS: dict[str, Any] = {
     "mcp": _mcp_to_canonical,
+    "mcp_read_resource": _mcp_read_resource_to_canonical,
 }
 
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -111,6 +111,9 @@ from . import judge_output as _judge_output  # noqa: F401, E402
 from . import mcp as _mcp  # noqa: F401, E402
 from . import mcp_drop_server as _mcp_drop_server  # noqa: F401, E402
 from . import mcp_install as _mcp_install  # noqa: F401, E402
+
+# #2597 slice ②a: mcp_read_resource — permission-gated resource read (mirrors mcp.py).
+from . import mcp_read_resource as _mcp_read_resource  # noqa: F401, E402
 from . import recall as _recall  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 

--- a/src/reyn/core/op_runtime/mcp_read_resource.py
+++ b/src/reyn/core/op_runtime/mcp_read_resource.py
@@ -1,0 +1,89 @@
+"""mcp_read_resource kind handler — read one resource on a configured MCP server.
+
+#2597 slice ②a (resources consumption). Mirrors ``op_runtime/mcp.py``'s
+``mcp`` (call_tool) handler exactly: same server-config resolution, same
+``MCPGateway`` seam (fault containment + task-affine pool reuse + per-call
+timeout), same ``require_mcp`` permission gate (server-scoped — the same
+axis a tool call uses, since a resource read is external, possibly
+sensitive server-authored content, just like a tool result), and the same
+before/after event pair shape (``mcp_resource_read`` / a completed-or-failed
+follow-up — mirrors ``mcp_called``/``mcp_completed``/``mcp_failed``).
+
+Discovery (``list_resources``/``list_resource_templates``) is deliberately
+NOT an op kind here — it mirrors ``list_tools``, which bypasses the
+permission gate + op-kind machinery entirely (see
+``session.py::_mcp_list_resources``). Only the content-returning read is
+gated, matching the tools surface's own split between ungated `list_tools`
+and gated `call_tool`.
+
+Subscribe / resources/updated / on_resource_updated (slice ②b) are OUT OF
+SCOPE here.
+"""
+from __future__ import annotations
+
+from reyn.schemas.models import MCPReadResourceIROp
+
+from . import register
+from .context import OpContext
+
+
+async def _execute(op: MCPReadResourceIROp, ctx: OpContext) -> dict:
+    from reyn.mcp.client import expand_env
+    from reyn.mcp.gateway import MCPFault, MCPGateway
+
+    server_cfg = ctx.mcp_servers.get(op.server)
+    if not server_cfg:
+        return {
+            "kind": "mcp_read_resource", "status": "error",
+            "error": f"MCP server '{op.server}' is not configured. "
+                     f"Add it under mcp.servers in reyn.yaml or reyn.local.yaml.",
+        }
+
+    expanded = expand_env(server_cfg)
+    if not isinstance(expanded, dict):
+        return {"kind": "mcp_read_resource", "status": "error",
+                "error": f"MCP server '{op.server}' config must be a dict."}
+
+    if "type" not in expanded and expanded.get("url"):
+        expanded = {**expanded, "type": "http"}
+
+    if ctx.mcp_connection_service is None and ctx.mcp_pool is None:
+        return {"kind": "mcp_read_resource", "status": "error", "server": op.server,
+                "uri": op.uri, "error": "no MCP client pool on this context"}
+
+    ctx.events.emit("mcp_resource_read", server=op.server, uri=op.uri)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
+    try:
+        result = await gateway.read_resource(op.server, op.uri, expanded)
+    except MCPFault as fault_exc:
+        fault = str(fault_exc)
+        ctx.events.emit("mcp_resource_read_failed", server=op.server, uri=op.uri, error=fault)
+        return {"kind": "mcp_read_resource", "status": "error", "server": op.server,
+                "uri": op.uri, "error": fault}
+
+    contents = result.get("contents", [])
+    ctx.events.emit(
+        "mcp_resource_read_completed", server=op.server, uri=op.uri,
+        content_count=len(contents) if isinstance(contents, list) else 0,
+    )
+    return {
+        "kind": "mcp_read_resource",
+        "status": "ok",
+        "server": op.server,
+        "uri": op.uri,
+        "contents": contents,
+    }
+
+
+async def handle(op: MCPReadResourceIROp, ctx: OpContext) -> dict:
+    if ctx.permission_resolver is not None:
+        if ctx.intervention_bus is None:
+            raise RuntimeError("mcp_read_resource op requires intervention_bus on OpContext")
+        await ctx.permission_resolver.require_mcp(
+            ctx.permission_decl, op.server, ctx.intervention_bus,
+            contextual=ctx.contextual_permission,
+        )
+    return await _execute(op, ctx)
+
+
+register("mcp_read_resource", handle)

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -399,6 +399,54 @@ class MCPClient:
             raise MCPError(f"MCP tools/list error: {exc}") from exc
         return [_tool_to_dict(t) for t in tools]
 
+    # ── resources (#2597 slice ②a — consumption only; subscribe is ②b) ─────────
+
+    async def list_resources(self) -> list[dict[str, Any]]:
+        """Return the resources advertised by this server as plain dicts.
+
+        Mirrors :meth:`list_tools`: uses FastMCP's auto-paginating
+        ``Client.list_resources()`` (follows ``nextCursor``) and gates on the
+        ``"resources"`` capability before issuing the request.
+        """
+        await self.initialize()
+        require_capability(self, "resources")
+        try:
+            resources = await self._client.list_resources()
+        except Exception as exc:
+            raise MCPError(f"MCP resources/list error: {exc}") from exc
+        return [_resource_to_dict(r) for r in resources]
+
+    async def list_resource_templates(self) -> list[dict[str, Any]]:
+        """Return the resource templates advertised by this server as plain
+        dicts. Mirrors :meth:`list_resources`; empty list is a normal
+        (not an error) result for a server that registers no templates."""
+        await self.initialize()
+        require_capability(self, "resources")
+        try:
+            templates = await self._client.list_resource_templates()
+        except Exception as exc:
+            raise MCPError(f"MCP resources/templates/list error: {exc}") from exc
+        return [_resource_to_dict(t) for t in templates]
+
+    async def read_resource(self, uri: str) -> dict[str, Any]:
+        """Read one resource (or a resolved resource-template URI) and return
+        its contents flattened to a dict: ``{"contents": [...]}`` — each
+        entry a flattened ``TextResourceContents``/``BlobResourceContents``.
+
+        Uses FastMCP's raw ``read_resource_mcp`` (not the convenience
+        ``read_resource``, which strips the ``ReadResourceResult`` envelope
+        down to just ``.contents``) so the shape-flattening lives in ONE
+        place (:func:`_read_resource_result_to_dict`), mirroring how
+        :meth:`call_tool` uses ``call_tool_mcp`` for the same reason.
+        """
+        await self.initialize()
+        require_capability(self, "resources")
+        try:
+            result = await self._client.read_resource_mcp(uri)
+        except Exception as exc:
+            raise MCPError(f"MCP resources/read error: {exc}") from exc
+        return _read_resource_result_to_dict(result)
+
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly."""
         if self._client is None:
@@ -693,3 +741,36 @@ def _tool_to_dict(tool: Any) -> dict[str, Any]:
     if hasattr(tool, "model_dump"):
         return tool.model_dump()
     return dict(tool)
+
+
+def _resource_to_dict(resource: Any) -> dict[str, Any]:
+    """Flatten an ``mcp.types.Resource`` or ``mcp.types.ResourceTemplate`` into a
+    JSON-safe plain dict (mirrors :func:`_tool_to_dict`).
+
+    ``mode="json"`` (not plain ``model_dump()``) — unlike ``Tool``, ``Resource``/
+    ``ResourceTemplate`` carry a ``uri: AnyUrl`` field; a plain ``model_dump()``
+    leaves that as a live ``pydantic.AnyUrl`` object, which downstream JSON
+    encoding (events / tool-result serialization) cannot handle without a
+    ``default=str`` escape hatch. ``mode="json"`` serializes it to ``str`` at
+    the source instead.
+    """
+    if hasattr(resource, "model_dump"):
+        return resource.model_dump(mode="json")
+    return dict(resource)
+
+
+def _read_resource_result_to_dict(result: Any) -> dict[str, Any]:
+    """Flatten an ``mcp.types.ReadResourceResult`` into
+    ``{"contents": [...]}`` — each entry a flattened
+    ``TextResourceContents``/``BlobResourceContents`` (mirrors
+    :func:`_result_to_dict`'s content-flattening for tool calls). Uses
+    ``mode="json"`` for the same AnyUrl-safety reason as :func:`_resource_to_dict`."""
+    contents: list[dict[str, Any]] = []
+    for item in getattr(result, "contents", []) or []:
+        if hasattr(item, "model_dump"):
+            contents.append(item.model_dump(mode="json"))
+        elif isinstance(item, dict):
+            contents.append(item)
+        else:
+            contents.append({"text": str(item)})
+    return {"contents": contents}

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -232,6 +232,7 @@ class _HeldConnection:
     """Duck-typed drop-in for :class:`MCPClient`, returned by
     :meth:`MCPConnectionService.get`. Exposes exactly the surface
     :class:`~reyn.mcp.gateway.MCPGateway` calls (``call_tool`` / ``list_tools`` /
+    ``list_resources`` / ``list_resource_templates`` / ``read_resource`` /
     ``is_initialized``) so it's usable anywhere a bare ``MCPClient`` is expected.
 
     Looks up the currently-live held ``MCPClient`` by server name on every call
@@ -281,6 +282,20 @@ class _HeldConnection:
         # Retry-once: tools/list is an idempotent read, safe to re-run on the fresh
         # connection, so it heals transparently (no user-visible failure).
         return await self._heal(lambda c: c.list_tools(), heal_only=False)
+
+    # #2597 slice ②a: resources consumption. All three are idempotent READS (no
+    # server-side side effect), so — like list_tools, unlike side-effectful call_tool
+    # — they heal with heal_only=False (retry-once on the fresh connection). A resource
+    # read/list re-run after a mid-call transport drop is safe (at-most-once is not a
+    # concern for a pure read), so the healed connection serves the retry transparently.
+    async def list_resources(self) -> list[dict[str, Any]]:
+        return await self._heal(lambda c: c.list_resources(), heal_only=False)
+
+    async def list_resource_templates(self) -> list[dict[str, Any]]:
+        return await self._heal(lambda c: c.list_resource_templates(), heal_only=False)
+
+    async def read_resource(self, uri: str) -> dict[str, Any]:
+        return await self._heal(lambda c: c.read_resource(uri), heal_only=False)
 
     async def _heal(
         self, op: "Callable[[MCPClient], Awaitable[Any]]", *, heal_only: bool,

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -139,6 +139,24 @@ class MCPGateway:
             timeout=timeout,
         )
 
+    async def list_resources(self, server: str, config: dict) -> list[dict]:
+        """Return the server's advertised resources. Raises :class:`MCPFault` on
+        any contained fault (mirrors :meth:`list_tools`)."""
+        return await self._run(server, config, lambda c: c.list_resources(),
+                               timeout=resolve_call_timeout(config))
+
+    async def list_resource_templates(self, server: str, config: dict) -> list[dict]:
+        """Return the server's advertised resource templates. Raises
+        :class:`MCPFault` on any contained fault (mirrors :meth:`list_tools`)."""
+        return await self._run(server, config, lambda c: c.list_resource_templates(),
+                               timeout=resolve_call_timeout(config))
+
+    async def read_resource(self, server: str, uri: str, config: dict) -> dict:
+        """Read one resource by URI and return ``{"contents": [...]}``. Raises
+        :class:`MCPFault` on any contained fault (mirrors :meth:`call_tool`)."""
+        return await self._run(server, config, lambda c: c.read_resource(uri),
+                               timeout=resolve_call_timeout(config))
+
     async def probe(self, server: str, config: dict) -> None:
         """Open the server (MCP initialize handshake) to verify reachability, then release it.
         Returns None on success; raises :class:`MCPFault` if the server cannot be reached/opened."""

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -715,6 +715,13 @@ class RouterLoopHost(RouterLoopCore, Protocol):
     async def mcp_call_tool(self, server: str, tool: str,
                              args: dict) -> dict: ...
 
+    # #2597 slice ②a: resources consumption (list / read / templates).
+    async def mcp_list_resources(self, server: str) -> list[dict]: ...
+
+    async def mcp_list_resource_templates(self, server: str) -> list[dict]: ...
+
+    async def mcp_read_resource(self, server: str, uri: str) -> dict: ...
+
     # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
     # Builds a permission-aware OpContext with the operator-declared
     # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,
@@ -2945,7 +2952,7 @@ class RouterLoop:
                             and set(r) <= {"status", "data", "error"})
             _inner = r["data"] if _is_envelope else r
             _media_store = getattr(host, "media_store", None)
-            if (isinstance(_inner, dict) and _inner.get("kind") == "mcp"
+            if (isinstance(_inner, dict) and _inner.get("kind") in ("mcp", "mcp_read_resource")
                     and _media_store is not None):
                 # #2425 案B: an MCP tool result normalises to a canonical shape so ``text`` (the joined
                 # content) is the SOLE offload payload and ``structured``/media are attachments held OUT
@@ -2956,6 +2963,10 @@ class RouterLoop:
                 # envelope is preserved (data becomes the canonical body) and ``text`` is the clean
                 # payload the cap stores. Non-MCP ops stay on the current path below (byte-identical —
                 # canonical's whole-dict fallback would regress web/exec's own field offload).
+                # #2597 slice ②a: ``mcp_read_resource`` reuses the SAME canonical path — a resource's
+                # ``contents`` can carry a large ``blob`` alongside joined ``text``, the identical
+                # second-oversized-field risk a tool's ``structuredContent`` posed (see
+                # ``_mcp_read_resource_to_canonical``).
                 from reyn.core.offload.canonical import to_canonical
                 from reyn.core.offload.seam import build_offload_body
                 _body, _mcp_media = build_offload_body(

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -75,6 +75,12 @@ class RouterHostAdapter:
         Async callback ``(server: str) -> list[dict]``.
     mcp_call_tool:
         Async callback ``(server: str, tool: str, args: dict) -> dict``.
+    mcp_list_resources:
+        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②a).
+    mcp_list_resource_templates:
+        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②a).
+    mcp_read_resource:
+        Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②a).
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -121,6 +127,13 @@ class RouterHostAdapter:
         mcp_list_servers: Callable[..., Awaitable[list]],
         mcp_list_tools: Callable[..., Awaitable[list]],
         mcp_call_tool: Callable[..., Awaitable[dict]],
+        # #2597 slice ②a: resources consumption (list/read/templates) — defaults to
+        # None so pre-existing hand-built adapters (tests, other call sites that
+        # construct RouterHostAdapter without resources support) stay valid; the
+        # mcp_verbs handlers getattr-guard before calling.
+        mcp_list_resources: "Callable[..., Awaitable[list]] | None" = None,
+        mcp_list_resource_templates: "Callable[..., Awaitable[list]] | None" = None,
+        mcp_read_resource: "Callable[..., Awaitable[dict]] | None" = None,
         # Action callbacks
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
@@ -338,6 +351,9 @@ class RouterHostAdapter:
         self._mcp_list_servers_cb = mcp_list_servers
         self._mcp_list_tools_cb = mcp_list_tools
         self._mcp_call_tool_cb = mcp_call_tool
+        self._mcp_list_resources_cb = mcp_list_resources
+        self._mcp_list_resource_templates_cb = mcp_list_resource_templates
+        self._mcp_read_resource_cb = mcp_read_resource
         # Action callbacks
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
@@ -1366,6 +1382,24 @@ class RouterHostAdapter:
 
     async def mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         return await self._mcp_call_tool_cb(server, tool, args)
+
+    # #2597 slice ②a: resources consumption. getattr-guarded callback (None when
+    # not wired) rather than a hard AttributeError — mirrors how mcp_verbs' host
+    # duck-type callers already tolerate missing methods elsewhere.
+    async def mcp_list_resources(self, server: str) -> list[dict]:
+        if self._mcp_list_resources_cb is None:
+            return [{"error": "mcp resources listing is not wired on this host"}]
+        return await self._mcp_list_resources_cb(server)
+
+    async def mcp_list_resource_templates(self, server: str) -> list[dict]:
+        if self._mcp_list_resource_templates_cb is None:
+            return [{"error": "mcp resource templates listing is not wired on this host"}]
+        return await self._mcp_list_resource_templates_cb(server)
+
+    async def mcp_read_resource(self, server: str, uri: str) -> dict:
+        if self._mcp_read_resource_cb is None:
+            return {"status": "error", "error": "mcp resource read is not wired on this host"}
+        return await self._mcp_read_resource_cb(server, uri)
 
     # --- Model resolution ---
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1532,6 +1532,10 @@ class Session:
             mcp_list_servers=self._mcp_list_servers,
             mcp_list_tools=self._mcp_list_tools,
             mcp_call_tool=self._mcp_call_tool,
+            # #2597 slice ②a: resources consumption (list/read/templates).
+            mcp_list_resources=self._mcp_list_resources,
+            mcp_list_resource_templates=self._mcp_list_resource_templates,
+            mcp_read_resource=self._mcp_read_resource,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -5487,6 +5491,111 @@ class Session:
             return await gateway.list_tools(server, expanded)
         except MCPFault as exc:
             return [{"error": str(exc)}]
+
+    async def _mcp_list_resources(self, server: str) -> list[dict]:
+        """Query the MCP server for its resources list.
+
+        #2597 slice ②a: mirrors ``_mcp_list_tools`` exactly — discovery-only,
+        NOT permission-gated (no op-kind), routed through the same
+        ``MCPGateway`` seam (held connection service on a non-ephemeral
+        session, one-shot pool otherwise). Emits ``mcp_resources_listed`` for
+        observability (list_tools has no analogous event; this ask is
+        explicit per the #2597 ②a slice spec).
+        """
+        from reyn.mcp.client import expand_env
+        from reyn.mcp.gateway import MCPFault, MCPGateway
+
+        servers = self._mcp_servers_flat()
+        if not servers:
+            return [{"error": "no MCP servers configured"}]
+        server_cfg = servers.get(server)
+        if not server_cfg:
+            return [{"error": f"MCP server {server!r} not configured"}]
+
+        expanded = expand_env(server_cfg)
+        if not isinstance(expanded, dict):
+            return [{"error": f"MCP server {server!r} config must be a dict"}]
+        if "type" not in expanded and expanded.get("url"):
+            expanded = {**expanded, "type": "http"}
+
+        gateway = (
+            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            if not self._ephemeral
+            else MCPGateway(agent_id=self._agent_id)
+        )
+        try:
+            resources = await gateway.list_resources(server, expanded)
+        except MCPFault as exc:
+            return [{"error": str(exc)}]
+        self._chat_events.emit(
+            "mcp_resources_listed", server=server, count=len(resources),
+        )
+        return resources
+
+    async def _mcp_list_resource_templates(self, server: str) -> list[dict]:
+        """Query the MCP server for its resource templates list.
+
+        #2597 slice ②a: mirrors ``_mcp_list_resources`` (discovery-only, not
+        permission-gated). Empty list is a normal result for a server that
+        registers no templates.
+        """
+        from reyn.mcp.client import expand_env
+        from reyn.mcp.gateway import MCPFault, MCPGateway
+
+        servers = self._mcp_servers_flat()
+        if not servers:
+            return [{"error": "no MCP servers configured"}]
+        server_cfg = servers.get(server)
+        if not server_cfg:
+            return [{"error": f"MCP server {server!r} not configured"}]
+
+        expanded = expand_env(server_cfg)
+        if not isinstance(expanded, dict):
+            return [{"error": f"MCP server {server!r} config must be a dict"}]
+        if "type" not in expanded and expanded.get("url"):
+            expanded = {**expanded, "type": "http"}
+
+        gateway = (
+            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            if not self._ephemeral
+            else MCPGateway(agent_id=self._agent_id)
+        )
+        try:
+            return await gateway.list_resource_templates(server, expanded)
+        except MCPFault as exc:
+            return [{"error": str(exc)}]
+
+    async def _mcp_read_resource(self, server: str, uri: str) -> dict:
+        """Read one MCP resource by URI and return its contents.
+
+        #2597 slice ②a: mirrors ``_mcp_call_tool`` exactly — permission-gated
+        (``require_mcp``, same server-scoped axis a tool call uses) + routed
+        through ``execute_op`` on the ``mcp_read_resource`` op kind, so the
+        SAME connection-service-vs-per-call-pool split ``_mcp_call_tool``
+        documents applies here too.
+        """
+        from reyn.core.op_runtime import execute_op
+        from reyn.schemas.models import MCPReadResourceIROp
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        op = MCPReadResourceIROp(kind="mcp_read_resource", server=server, uri=uri)
+        ctx = self._make_router_op_context()
+        ctx.intervention_bus = ChatInterventionBus(
+            self, run_id=None, actor="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+        ctx.permission_decl = PermissionDecl(
+            file_read=ctx.permission_decl.file_read,
+            file_write=ctx.permission_decl.file_write,
+            mcp=[server],
+        )
+        if not self._ephemeral:
+            ctx.mcp_connection_service = self._mcp_connection_service
+            return await execute_op(op, ctx)
+        from reyn.mcp.pool import MCPClientPool
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await execute_op(op, ctx)
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Invoke an MCP tool and return its result.

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -116,6 +116,17 @@ class MCPIROp(BaseModel):
     args: dict[str, Any] = Field(default_factory=dict)
 
 
+class MCPReadResourceIROp(BaseModel):
+    """#2597 slice ②a: read one MCP resource (or a resolved resource-template URI)
+    by URI. Permission-gated + event-emitting like ``MCPIROp`` (external, possibly
+    sensitive server-authored content) — unlike the discovery-only
+    ``mcp_list_resources``/``mcp_list_resource_templates`` path, which mirrors
+    ``list_tools`` (no permission gate, no op-kind)."""
+    kind: Literal["mcp_read_resource"]
+    server: str
+    uri: str
+
+
 class AskUserIROp(BaseModel):
     kind: Literal["ask_user"]
     question: str
@@ -535,6 +546,10 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     "glob_files":  GlobFilesIROp,
     "grep_files":  GrepFilesIROp,
     "mcp":         MCPIROp,
+    # #2597 slice ②a: resources consumption — read is permission-gated (external
+    # content); list/list-templates stay op-kind-free, mirroring list_tools (see
+    # op_runtime/mcp_read_resource.py + session.py's _mcp_list_resources).
+    "mcp_read_resource": MCPReadResourceIROp,
     "ask_user":    AskUserIROp,
     "web_fetch":   WebFetchIROp,
     "web_search":  WebSearchIROp,
@@ -583,7 +598,7 @@ if TYPE_CHECKING:
             FileIROp,
             ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
             GlobFilesIROp, GrepFilesIROp,
-            MCPIROp, AskUserIROp,
+            MCPIROp, MCPReadResourceIROp, AskUserIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,
             IndexQueryIROp, RecallIROp, IndexDropIROp,

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -67,8 +67,11 @@ def get_default_registry() -> ToolRegistry:
     from reyn.tools.mcp import (
         CALL_MCP_TOOL,
         DESCRIBE_MCP_TOOL,
+        LIST_MCP_RESOURCE_TEMPLATES,
+        LIST_MCP_RESOURCES,
         LIST_MCP_SERVERS,
         LIST_MCP_TOOLS,
+        READ_MCP_RESOURCE,
     )
     from reyn.tools.mcp_drop import MCP_DROP_SERVER_OP
     from reyn.tools.mcp_install import MCP_INSTALL_OP
@@ -149,6 +152,11 @@ def get_default_registry() -> ToolRegistry:
     registry.register(LIST_MCP_SERVERS)
     registry.register(LIST_MCP_TOOLS)
     registry.register(DESCRIBE_MCP_TOOL)
+    # #2597 slice ②a: resources consumption (list/read/templates) — parallel
+    # to the tools surface above.
+    registry.register(LIST_MCP_RESOURCES)
+    registry.register(LIST_MCP_RESOURCE_TEMPLATES)
+    registry.register(READ_MCP_RESOURCE)
     # Memory ops (Wave 2 — Type C closure: memory write phase-side)
     registry.register(LIST_MEMORY)
     registry.register(READ_MEMORY_BODY)

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -16,11 +16,26 @@ dispatch branches were removed alongside the control-IR / phase-dispatch
 executor (#2542): ``ToolContext.caller_kind`` is always "router" at
 runtime, so the handlers run their router logic unconditionally.
 
+#2597 slice ②a adds three MORE capabilities, parallel to the tools surface
+above (list_mcp_tools -> list_mcp_resources; call_mcp_tool's gated-content
+shape -> read_mcp_resource; a resource-templates twin with no tools
+analogue):
+
+  LIST_MCP_RESOURCES         — gates.router=allow (mirrors LIST_MCP_TOOLS)
+  READ_MCP_RESOURCE          — gates.router=allow (mirrors CALL_MCP_TOOL's
+                                external-content + permission-gated shape)
+  LIST_MCP_RESOURCE_TEMPLATES — gates.router=allow
+
+``resources/subscribe`` + ``resources/updated`` push notifications are OUT
+OF SCOPE (slice ②b) — these three are list/read only.
+
 ## Router-side dispatch
 
 The router-side handlers are thin adapters over the existing session-level
-callbacks (mcp_list_servers / mcp_list_tools / mcp_call_tool). The ToolContext
-router_state carries the host adapter; adapters pull from ctx.router_state.
+callbacks (mcp_list_servers / mcp_list_tools / mcp_call_tool / #2597
+mcp_list_resources / mcp_list_resource_templates / mcp_read_resource). The
+ToolContext router_state carries the host adapter; adapters pull from
+ctx.router_state.
 
 ## DO NOT TOUCH shared files
 
@@ -132,6 +147,62 @@ _DESCRIBE_MCP_TOOL_PARAMETERS: dict[str, Any] = {
 }
 
 
+# ── #2597 slice ②a: resources consumption parameters ──────────────────────────
+
+_LIST_MCP_RESOURCES_DESCRIPTION = (
+    "List resources exposed by one MCP server "
+    "(with uri + description per resource)."
+)
+
+_LIST_MCP_RESOURCES_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+    },
+    "required": ["server"],
+}
+
+_LIST_MCP_RESOURCE_TEMPLATES_DESCRIPTION = (
+    "List resource templates (parameterized URI patterns) exposed by one "
+    "MCP server. Use list_mcp_resources for concrete resources."
+)
+
+_LIST_MCP_RESOURCE_TEMPLATES_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+    },
+    "required": ["server"],
+}
+
+_READ_MCP_RESOURCE_DESCRIPTION = (
+    "Read the contents of one MCP resource by URI. Get the uri from "
+    "list_mcp_resources (or by resolving a list_mcp_resource_templates "
+    "template)."
+)
+
+_READ_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "uri": {
+            "type": "string",
+            "description": "Resource URI, verbatim from list_mcp_resources.",
+        },
+    },
+    "required": ["server", "uri"],
+}
+
+
 # ── Handlers ──────────────────────────────────────────────────────────────────
 
 async def _handle_list_mcp_servers(
@@ -198,6 +269,53 @@ async def _handle_list_mcp_tools(
         entry["name"] = f"{server}__{inner_name}"
         rebuilt.append(entry)
     return {"mcp_tools": rebuilt}
+
+
+async def _handle_list_mcp_resources(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for list_mcp_resources.
+
+    Delegates to host.mcp_list_resources(server) via ctx.router_state —
+    mirrors _handle_list_mcp_tools exactly, minus the #879 name-rewrite
+    (resources are addressed by URI, not a <server>__<name> identifier).
+    """
+    host = _require_host(ctx)
+    server = str(args["server"])
+    result = await host.mcp_list_resources(server)
+    if result and isinstance(result[0], Mapping) and "error" in result[0]:
+        return {"error": result[0]["error"]}
+    return {"resources": list(result or [])}
+
+
+async def _handle_list_mcp_resource_templates(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for list_mcp_resource_templates. Mirrors
+    _handle_list_mcp_resources; an empty list is a normal result (no
+    templates registered), not an error."""
+    host = _require_host(ctx)
+    server = str(args["server"])
+    result = await host.mcp_list_resource_templates(server)
+    if result and isinstance(result[0], Mapping) and "error" in result[0]:
+        return {"error": result[0]["error"]}
+    return {"resource_templates": list(result or [])}
+
+
+async def _handle_read_mcp_resource(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for read_mcp_resource.
+
+    Delegates to host.mcp_read_resource(server, uri) via ctx.router_state.
+    Mirrors _handle_call_mcp_tool's delegation shape; the gated content
+    itself is enforced upstream (require_mcp on the mcp_read_resource op
+    kind), not here.
+    """
+    host = _require_host(ctx)
+    server = str(args["server"])
+    uri = str(args["uri"])
+    return await host.mcp_read_resource(server, uri)
 
 
 async def _handle_call_mcp_tool(
@@ -386,6 +504,51 @@ DESCRIBE_MCP_TOOL = ToolDefinition(
     category="discovery",
     purity="read_only",
     returns_external_content=True,  # FP-0050/#1822: external server-authored schema/description
+    schema_enricher=_enrich_router_schema,
+)
+
+
+# ── #2597 slice ②a: resources consumption ToolDefinitions ────────────────────
+# Parallel to LIST_MCP_TOOLS / CALL_MCP_TOOL above — same gates, same
+# schema-enrichment reuse (server enum only; _enrich_router_schema no-ops on
+# the absent mcp_tool_name prop for these three).
+
+LIST_MCP_RESOURCES = ToolDefinition(
+    name="list_mcp_resources",
+    router_dispatched=True,
+    description=_LIST_MCP_RESOURCES_DESCRIPTION,
+    parameters=_LIST_MCP_RESOURCES_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_list_mcp_resources,
+    category="discovery",
+    purity="read_only",
+    returns_external_content=True,  # FP-0050/#1822: external server-authored resource listing
+    schema_enricher=_enrich_router_schema,
+)
+
+LIST_MCP_RESOURCE_TEMPLATES = ToolDefinition(
+    name="list_mcp_resource_templates",
+    router_dispatched=True,
+    description=_LIST_MCP_RESOURCE_TEMPLATES_DESCRIPTION,
+    parameters=_LIST_MCP_RESOURCE_TEMPLATES_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_list_mcp_resource_templates,
+    category="discovery",
+    purity="read_only",
+    returns_external_content=True,  # FP-0050/#1822: external server-authored template listing
+    schema_enricher=_enrich_router_schema,
+)
+
+READ_MCP_RESOURCE = ToolDefinition(
+    name="read_mcp_resource",
+    router_dispatched=True,
+    description=_READ_MCP_RESOURCE_DESCRIPTION,
+    parameters=_READ_MCP_RESOURCE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_read_mcp_resource,
+    category="discovery",
+    purity="read_only",  # a resource read has no reyn-side side effects (unlike call_mcp_tool)
+    returns_external_content=True,  # FP-0050/#1822: external MCP server resource content
     schema_enricher=_enrich_router_schema,
 )
 

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -23,6 +23,10 @@ Tools:
                             ``call_tool`` hit the SAME held subprocess (no
                             re-handshake) rather than comparing Python object
                             identity alone.
+  - ``resource://pid``   -> a RESOURCE whose content is this server process's PID
+                            (the resource analog of ``pid()``). Used by #2597 slice
+                            ②a to prove a 2nd ``read_resource`` hit the SAME held
+                            subprocess.
   - ``bump()`` /         -> a per-process side-effect counter (#2597 S2a). ``bump``
     ``bump_then_die()``     increments + returns the count; ``bump_then_die``
                             increments THEN kills the subprocess AFTER the side
@@ -68,6 +72,17 @@ def pid() -> int:
     import os
 
     return os.getpid()
+
+
+# #2597 slice ②a: a resource whose CONTENT is this server process's PID — the
+# resource analog of the ``pid()`` tool. Held-connection-reuse tests read it twice
+# and assert the same PID, proving the 2nd read hit the SAME held subprocess (no
+# re-handshake) — the resource-path twin of the S2a ``pid()`` tool round-trip.
+@mcp.resource("resource://pid")
+def pid_resource() -> str:
+    import os
+
+    return str(os.getpid())
 
 
 # #2597 S2a: a FILE-BACKED side-effect recorder. The count lives on disk (a byte

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -35,6 +35,8 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "read_file", "write_file", "delete_file", "list_directory",
     "edit_file", "glob_files", "grep_files",
     "list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool",
+    # #2597 slice ②a: resources consumption — parallel to the tools surface above.
+    "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
     "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
     "recall", "drop_source", "compact",
     "list_actions", "search_actions", "describe_action", "invoke_action",

--- a/tests/test_2597_s2a_mcp_resources_consumption.py
+++ b/tests/test_2597_s2a_mcp_resources_consumption.py
@@ -184,6 +184,88 @@ def test_gateway_read_resource_raises_mcp_fault_on_ungated_server():
         _run(_it())
 
 
+# ── Tier 2: held connection (non-ephemeral session path) — the PRODUCTION path ─
+# The live (non-ephemeral) session routes resource reads through a held-open
+# MCPConnectionService (Option C), NOT the one-shot MCPGateway() pool the tests
+# above exercise. That path hands the gateway a _HeldConnection (not a bare
+# MCPClient), so read_resource/list_resources must exist ON THE HELD HANDLE or the
+# call AttributeErrors. These tests route through a REAL MCPConnectionService — the
+# coverage the one-shot-pool tests structurally cannot give.
+
+
+@pytest.mark.asyncio
+async def test_held_connection_reads_resource_and_reuses_subprocess():
+    """Tier 2: the CORE held-path coverage — a resource read through a REAL
+    MCPConnectionService (via MCPGateway(pool=service), exactly as the live session
+    wires it) works, and a 2nd read hits the SAME held subprocess. Proven via the
+    echo server's ``resource://pid`` (content = the server PID): identical PID across
+    two reads = the held connection was reused, no re-handshake. This is the exact
+    production path #2605-review flagged as crashing (AttributeError) and untested."""
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    service = MCPConnectionService()
+    try:
+        gateway = MCPGateway(pool=service)
+        r1 = await gateway.read_resource("srv", "resource://pid", _stdio_cfg(_ECHO_SERVER))
+        r2 = await gateway.read_resource("srv", "resource://pid", _stdio_cfg(_ECHO_SERVER))
+        pid_1 = r1["contents"][0]["text"]
+        pid_2 = r2["contents"][0]["text"]
+        assert pid_1 and pid_1 == pid_2, "same held subprocess reused across reads (no re-handshake)"
+        assert service.held_servers() == ["srv"], "the connection is held open, not opened+closed per read"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_held_connection_lists_resources_and_templates():
+    """Tier 2: list_resources + list_resource_templates on the HELD handle
+    (_HeldConnection) — both must exist there (not just on the one-shot MCPClient),
+    routed through the same MCPConnectionService the live session uses."""
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    service = MCPConnectionService()
+    try:
+        gateway = MCPGateway(pool=service)
+        resources = await gateway.list_resources("srv", _stdio_cfg(_ECHO_SERVER))
+        templates = await gateway.list_resource_templates("srv", _stdio_cfg(_ECHO_SERVER))
+        uris = [r["uri"] for r in resources]
+        assert "resource://pid" in uris, "the echo server's pid resource is listed via the held handle"
+        assert isinstance(templates, list), "list_resource_templates returns a list via the held handle"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_execute_reads_via_connection_service_not_just_pool():
+    """Tier 2: the op handler's _execute reads through ctx.mcp_connection_service
+    (the non-ephemeral session's wiring) — NOT only ctx.mcp_pool. Mirrors the
+    ``_mcp_read_resource`` non-ephemeral branch (session.py) which sets
+    ctx.mcp_connection_service, the path the crash lived on."""
+    from reyn.core.op_runtime.mcp_read_resource import _execute
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    events = EventLog()
+    service = MCPConnectionService()
+    op = MCPReadResourceIROp(kind="mcp_read_resource", server="srv", uri="resource://pid")
+
+    try:
+        ctx = OpContext(
+            workspace=Workspace(events=events),
+            events=events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=None,  # permission bypassed — this asserts the transport wiring
+            mcp_servers={"srv": _stdio_cfg(_ECHO_SERVER)},
+            actor="chat_router",
+        )
+        ctx.mcp_connection_service = service  # the non-ephemeral wiring (not mcp_pool)
+        result = await _execute(op, ctx)
+    finally:
+        await service.aclose()
+
+    assert result["status"] == "ok"
+    assert result["contents"][0]["text"], "resource content read through the held connection service"
+
+
 # ── Tier 2: op_runtime mcp_read_resource — permission gate + events ───────────
 
 

--- a/tests/test_2597_s2a_mcp_resources_consumption.py
+++ b/tests/test_2597_s2a_mcp_resources_consumption.py
@@ -1,0 +1,452 @@
+"""Tests for #2597 slice ②a — MCP resources consumption (list/read + templates).
+
+Real instances only, per the testing policy: no ``unittest.mock`` / ``MagicMock`` /
+``AsyncMock`` / ``patch``. Round-trips spawn REAL MCP servers (stdio subprocess),
+mirroring ``test_2597_capability_version_gate.py``:
+
+  - ``mcp_resources_server.py`` (low-level SDK) — registers ONLY a resource
+    (``resource://greeting`` -> "hello from a resource"), no tools, no templates.
+    The real "server advertises resources" case, and the real "list_resource_templates
+    on a server with none registered returns [], not an error" case.
+  - ``mcp_paginated_tools_server.py`` (low-level SDK, tools-only) — registers NO
+    resource handlers, so its negotiated ``resources`` capability is None. The real
+    "server does NOT advertise resources" case for the gated fail-fast tests.
+
+Subscribe / resources/updated (slice ②b) are out of scope — list/read only.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.gateway import MCPFault, MCPGateway
+from reyn.mcp.pool import MCPClientPool
+from reyn.schemas.models import MCPReadResourceIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+
+
+class _UnusedBus(InterventionBus):
+    """A real InterventionBus that fails the test if ever actually invoked — the
+    non-interactive resolver paths below resolve without prompting (deny:
+    ungranted decl fails before `_approve`; allow: config `mcp: allow`
+    short-circuits `_approve`), so `request()` should never be called."""
+
+    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
+        raise AssertionError(f"intervention bus should not be consulted: {iv}")
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_RESOURCES_SERVER = _SUPPORT_DIR / "mcp_resources_server.py"
+_TOOLS_ONLY_SERVER = _SUPPORT_DIR / "mcp_paginated_tools_server.py"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_RESOURCE_URI = "resource://greeting"
+_RESOURCE_TEXT = "hello from a resource"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Tier 1: MCPClient — real round-trip against a real resources server ───────
+
+
+def test_list_resources_returns_registered_resource():
+    """Tier 1: MCPClient.list_resources() returns the one resource a real server
+    registers, flattened to a plain dict with the real uri/name/mimeType."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_RESOURCES_SERVER)) as client:
+            return await client.list_resources()
+
+    (resource,) = _run(_it())  # unpack: exactly one entry — a server-count invariant, not a format pin
+    assert resource["uri"] == _RESOURCE_URI
+    assert resource["name"] == "greeting"
+
+
+def test_read_resource_returns_contents():
+    """Tier 1: MCPClient.read_resource(uri) returns {"contents": [...]} with the
+    real server-authored text."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_RESOURCES_SERVER)) as client:
+            return await client.read_resource(_RESOURCE_URI)
+
+    result = _run(_it())
+    (content,) = result["contents"]  # unpack: exactly one content item for this single-resource server
+    assert content["text"] == _RESOURCE_TEXT
+
+
+def test_list_resource_templates_empty_not_error_when_none_registered():
+    """Tier 1: a real server that registers no resource templates returns an empty
+    list (a normal result), not an MCPError. Uses the FastMCP echo server — verified
+    empirically (test_2597_capability_version_gate.py) that a FastMCP-built server
+    implements the ``resources/templates/list`` handler for every server regardless
+    of what it registers, so it answers "[]" rather than "Method not found" (unlike
+    the low-level SDK ``mcp_resources_server.py``, which has no template handler at
+    all and genuinely raises — that server exists to prove capability ADVERTISING,
+    not template-listing behavior)."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_ECHO_SERVER)) as client:
+            return await client.list_resource_templates()
+
+    templates = _run(_it())
+    assert templates == []
+
+
+def test_list_resources_fails_fast_against_server_without_resources_capability():
+    """Tier 1: the #2597 capability gate blocks list_resources against a real
+    server that never advertised "resources" — a clear MCPError, not a raw
+    protocol error or a silent empty list."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_TOOLS_ONLY_SERVER), server_name="tools-only-srv"
+        ) as client:
+            await client.list_resources()
+
+    with pytest.raises(MCPError) as exc_info:
+        _run(_it())
+    message = str(exc_info.value)
+    assert "resources" in message
+    assert "tools-only-srv" in message
+
+
+def test_read_resource_fails_fast_against_server_without_resources_capability():
+    """Tier 1: same gate for read_resource — the content-returning call fails
+    fast rather than reaching (and confusing) the server."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_TOOLS_ONLY_SERVER), server_name="tools-only-srv"
+        ) as client:
+            await client.read_resource("resource://anything")
+
+    with pytest.raises(MCPError) as exc_info:
+        _run(_it())
+    message = str(exc_info.value)
+    assert "resources" in message
+    assert "tools-only-srv" in message
+
+
+# ── Tier 1: MCPGateway — resources pass-throughs ──────────────────────────────
+
+
+def test_gateway_list_resources_round_trip():
+    """Tier 1: MCPGateway.list_resources opens + lists + tears down through the
+    same fault-contained seam as list_tools."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.list_resources("resources-srv", _stdio_cfg(_RESOURCES_SERVER))
+
+    resources = _run(_it())
+    assert resources[0]["uri"] == _RESOURCE_URI
+
+
+def test_gateway_read_resource_round_trip():
+    """Tier 1: MCPGateway.read_resource returns the flattened contents."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.read_resource(
+            "resources-srv", _RESOURCE_URI, _stdio_cfg(_RESOURCES_SERVER)
+        )
+
+    result = _run(_it())
+    assert result["contents"][0]["text"] == _RESOURCE_TEXT
+
+
+def test_gateway_read_resource_raises_mcp_fault_on_ungated_server():
+    """Tier 1: the gateway surfaces the capability-gate failure as MCPFault (its
+    ONE contained-fault type), never a bare MCPError/protocol exception."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.read_resource(
+            "tools-only", "resource://x", _stdio_cfg(_TOOLS_ONLY_SERVER)
+        )
+
+    with pytest.raises(MCPFault):
+        _run(_it())
+
+
+# ── Tier 2: op_runtime mcp_read_resource — permission gate + events ───────────
+
+
+def _make_ctx(
+    tmp_path: Path,
+    events: EventLog,
+    *,
+    resolver: "PermissionResolver | None",
+    decl: "PermissionDecl | None" = None,
+) -> OpContext:
+    return OpContext(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_decl=decl or PermissionDecl(),
+        permission_resolver=resolver,
+        mcp_servers={"resources-srv": _stdio_cfg(_RESOURCES_SERVER)},
+        actor="chat_router",
+    )
+
+
+def test_execute_reads_real_resource_and_emits_events(tmp_path):
+    """Tier 2: the op handler's _execute (permission bypassed — mirrors the
+    existing mcp.py _execute test pattern) reads a REAL resource through a REAL
+    MCPClientPool and emits mcp_resource_read + mcp_resource_read_completed."""
+    from reyn.core.op_runtime.mcp_read_resource import _execute
+
+    events = EventLog()
+    op = MCPReadResourceIROp(kind="mcp_read_resource", server="resources-srv", uri=_RESOURCE_URI)
+
+    async def _it():
+        ctx = _make_ctx(tmp_path, events, resolver=None)
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await _execute(op, ctx)
+
+    result = _run(_it())
+    assert result["status"] == "ok"
+    assert result["contents"][0]["text"] == _RESOURCE_TEXT
+
+    types_seen = [e.type for e in events.all()]
+    assert "mcp_resource_read" in types_seen
+    assert "mcp_resource_read_completed" in types_seen
+    assert "mcp_resource_read_failed" not in types_seen
+
+
+def test_handle_denies_without_permissions_mcp_declared(tmp_path):
+    """Tier 2: P6/P5-style invariant — execute_op on mcp_read_resource denies
+    (status='denied' + permission_denied event) when the caller's PermissionDecl
+    does not declare the server under `mcp`, mirroring the `mcp` (call_tool) op's
+    own require_mcp gate exactly."""
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+    # No mcp=[...] on the decl — the AgentLayer grant is empty.
+    ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=PermissionDecl())
+    ctx.intervention_bus = _UnusedBus()  # never consulted: denied before _approve
+
+    op = MCPReadResourceIROp(kind="mcp_read_resource", server="resources-srv", uri=_RESOURCE_URI)
+    result = _run(execute_op(op, ctx))
+
+    assert result["status"] == "denied"
+    denials = [e for e in events.all() if e.type == "permission_denied"]
+    assert denials, f"expected permission_denied event; got {[e.type for e in events.all()]}"
+    assert denials[0].data.get("kind") == "mcp_read_resource"
+
+
+def test_handle_allows_and_reads_when_permissions_mcp_granted(tmp_path):
+    """Tier 2: the allow path — decl.mcp includes the server + config grants
+    `mcp: allow`, so require_mcp passes and the REAL resource is read end-to-end
+    through execute_op (permission gate -> gateway -> real subprocess)."""
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={"mcp": "allow"}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(mcp=["resources-srv"])
+    ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=decl)
+    ctx.intervention_bus = _UnusedBus()  # never consulted: config-approved short-circuits _approve
+
+    op = MCPReadResourceIROp(kind="mcp_read_resource", server="resources-srv", uri=_RESOURCE_URI)
+
+    async def _it():
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await execute_op(op, ctx)
+
+    result = _run(_it())
+    assert result["status"] == "ok"
+    assert result["contents"][0]["text"] == _RESOURCE_TEXT
+    assert not [e for e in events.all() if e.type == "permission_denied"]
+
+
+def test_execute_reports_error_for_unconfigured_server(tmp_path):
+    """Tier 2: _execute returns a clean status='error' (never raises) when the
+    op names a server absent from ctx.mcp_servers — the same not-configured
+    shape the `mcp` op returns."""
+    from reyn.core.op_runtime.mcp_read_resource import _execute
+
+    events = EventLog()
+    op = MCPReadResourceIROp(kind="mcp_read_resource", server="nope", uri="resource://x")
+    ctx = _make_ctx(tmp_path, events, resolver=None)
+
+    result = _run(_execute(op, ctx))
+    assert result["status"] == "error"
+    assert "not configured" in result["error"]
+
+
+# ── Tier 2: op-kind registry completeness ─────────────────────────────────────
+
+
+def test_mcp_read_resource_registered_in_op_kind_model_map():
+    """Tier 2: OP_KIND_MODEL_MAP <-> Op union completeness invariant — the new
+    kind is registered (control-ir.md hard rule)."""
+    from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, MCPReadResourceIROp
+
+    assert "mcp_read_resource" in ALL_OP_KINDS
+    assert OP_KIND_MODEL_MAP["mcp_read_resource"] is MCPReadResourceIROp
+
+
+# ── Tier 2: canonical offload mapping (large blob does not double-oversize) ───
+
+
+def test_canonical_mapper_joins_text_and_isolates_blob_as_structured():
+    """Tier 2: #2425-style offload safety — _mcp_read_resource_to_canonical joins
+    text contents into `text` (the sole offload payload) and keeps a `blob`
+    content item as a `structured` attachment, never a second text-competing
+    field (the exact shape of bug the tool-call canonical mapper already fixed)."""
+    from reyn.core.offload.canonical import to_canonical
+
+    result = {
+        "kind": "mcp_read_resource",
+        "status": "ok",
+        "server": "resources-srv",
+        "uri": _RESOURCE_URI,
+        "contents": [
+            {"uri": _RESOURCE_URI, "mimeType": "text/plain", "text": "hello"},
+            {"uri": "resource://blob", "mimeType": "application/octet-stream", "blob": "YWJj"},
+        ],
+    }
+    canonical = to_canonical(result)
+    assert canonical["text"] == "hello"
+    assert canonical["attachments"] == [
+        {"kind": "structured", "data": {
+            "uri": "resource://blob", "mimeType": "application/octet-stream", "blob": "YWJj",
+        }},
+    ]
+    assert canonical["meta"]["kind"] == "mcp_read_resource"
+
+
+# ── Tier 2: tools/mcp.py verbs — delegation via a Fake host (no mocks) ────────
+
+
+class _RecordingResourceHost:
+    """A trivial Fake at the host.mcp_list_resources/mcp_read_resource boundary —
+    records calls and returns canned data (mirrors _RecordingMCPHost in
+    test_mcp_invoke_action_tool_args_1646.py)."""
+
+    def __init__(self, *, resources=None, templates=None, read_result=None) -> None:
+        self.resources = resources if resources is not None else [
+            {"uri": _RESOURCE_URI, "name": "greeting"}
+        ]
+        self.templates = templates if templates is not None else []
+        self.read_result = read_result if read_result is not None else {
+            "status": "ok", "contents": [{"uri": _RESOURCE_URI, "text": _RESOURCE_TEXT}],
+        }
+        self.list_calls: list[str] = []
+        self.template_calls: list[str] = []
+        self.read_calls: list[tuple] = []
+
+    async def mcp_list_resources(self, server: str):
+        self.list_calls.append(server)
+        return self.resources
+
+    async def mcp_list_resource_templates(self, server: str):
+        self.template_calls.append(server)
+        return self.templates
+
+    async def mcp_read_resource(self, server: str, uri: str):
+        self.read_calls.append((server, uri))
+        return self.read_result
+
+
+def _tool_ctx(host):
+    from reyn.tools.types import RouterCallerState, ToolContext
+
+    return ToolContext(
+        caller_kind="router", events=None, permission_resolver=None, workspace=None,
+        router_state=RouterCallerState(host=host),
+    )
+
+
+def test_list_mcp_resources_handler_delegates_to_host():
+    """Tier 2: _handle_list_mcp_resources delegates to host.mcp_list_resources
+    and wraps the result under "resources" (mirrors _handle_list_mcp_tools)."""
+    from reyn.tools.mcp import _handle_list_mcp_resources
+
+    host = _RecordingResourceHost()
+    result = _run(_handle_list_mcp_resources({"server": "resources-srv"}, _tool_ctx(host)))
+
+    assert host.list_calls == ["resources-srv"]
+    assert result["resources"] == host.resources
+
+
+def test_list_mcp_resource_templates_handler_delegates_to_host():
+    """Tier 2: _handle_list_mcp_resource_templates delegates + wraps under
+    "resource_templates"; empty list is a normal (non-error) pass-through."""
+    from reyn.tools.mcp import _handle_list_mcp_resource_templates
+
+    host = _RecordingResourceHost(templates=[])
+    result = _run(
+        _handle_list_mcp_resource_templates({"server": "resources-srv"}, _tool_ctx(host))
+    )
+
+    assert host.template_calls == ["resources-srv"]
+    assert result["resource_templates"] == []
+
+
+def test_read_mcp_resource_handler_delegates_to_host():
+    """Tier 2: _handle_read_mcp_resource delegates (server, uri) to
+    host.mcp_read_resource and returns its result verbatim (gating already
+    happened upstream at the op-kind permission layer, not here)."""
+    from reyn.tools.mcp import _handle_read_mcp_resource
+
+    host = _RecordingResourceHost()
+    result = _run(
+        _handle_read_mcp_resource({"server": "resources-srv", "uri": _RESOURCE_URI}, _tool_ctx(host))
+    )
+
+    assert host.read_calls == [("resources-srv", _RESOURCE_URI)]
+    assert result == host.read_result
+
+
+def test_list_mcp_resources_handler_surfaces_host_error():
+    """Tier 2: an [{"error": ...}] from the host (e.g. server unreachable)
+    surfaces as a top-level {"error": ...}, not wrapped under "resources"
+    (mirrors _handle_list_mcp_tools' error-surfacing branch)."""
+    from reyn.tools.mcp import _handle_list_mcp_resources
+
+    host = _RecordingResourceHost(resources=[{"error": "MCP server 'x' not configured"}])
+    result = _run(_handle_list_mcp_resources({"server": "x"}, _tool_ctx(host)))
+
+    assert result == {"error": "MCP server 'x' not configured"}
+
+
+# ── Tier 2: ToolDefinition registration shape ─────────────────────────────────
+
+
+def test_new_tool_definitions_registered_router_and_phase_allow():
+    """Tier 2: the 3 new ToolDefinitions are router+phase allow, discovery
+    category, and read_only purity (mirrors LIST_MCP_TOOLS)."""
+    from reyn.tools.mcp import LIST_MCP_RESOURCE_TEMPLATES, LIST_MCP_RESOURCES, READ_MCP_RESOURCE
+
+    for td in (LIST_MCP_RESOURCES, LIST_MCP_RESOURCE_TEMPLATES, READ_MCP_RESOURCE):
+        assert td.gates.router == "allow"
+        assert td.gates.phase == "allow"
+        assert td.category == "discovery"
+        assert td.purity == "read_only"
+
+
+def test_new_tool_definitions_present_in_default_registry():
+    """Tier 2: get_default_registry() includes the 3 new capabilities under
+    their canonical chat-tool names."""
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    assert registry.lookup("list_mcp_resources") is not None
+    assert registry.lookup("list_mcp_resource_templates") is not None
+    assert registry.lookup("read_mcp_resource") is not None

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -24,6 +24,9 @@ _EXTERNAL = {
     "call_mcp_tool", "mcp_call_tool",    # external MCP server result
     "list_mcp_tools", "describe_mcp_tool",  # external server-authored descriptions
     "mcp_search_registry",               # external registry listing
+    # #2597 slice ②a: resources consumption — same fencing rationale as the tools
+    # surface above (external server-authored listing / content).
+    "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
     "web_search", "web_fetch",           # internet
 }
 


### PR DESCRIPTION
**[per-PR-coder]** — Implements slice ②a of the MCP client redesign (umbrella #2597): part of #2597 — MCP **resources consumption**. Branched from main with S1 #2598 + S2a #2600 + S2b #2601 + capability-gate #2603 merged. #2602 (logging) was CLOSED — no logging added here.

## Scope

**Resources CONSUMPTION only** — list + read + templates. `resources/subscribe` + `resources/updated` + the push path are OUT (slice ②b, tracked separately).

## What changed (parallel-to-tools structure)

Mirrors the existing `tools` surface exactly, with one deliberate difference explained below:

| Layer | Tools (existing) | Resources (this PR) |
|---|---|---|
| `MCPClient` (`src/reyn/mcp/client.py`) | `list_tools()` / `call_tool()` | `list_resources()` / `list_resource_templates()` / `read_resource(uri)` — each gated by `require_capability(self, "resources")` (the #2603 gate) |
| `MCPGateway` (`src/reyn/mcp/gateway.py`) | `list_tools` / `call_tool` pass-throughs | `list_resources` / `list_resource_templates` / `read_resource` pass-throughs, same `_run` fault/timeout wrapper |
| op kind (`src/reyn/core/op_runtime/`) | `mcp` (call_tool) — `require_mcp` permission gate + `mcp_called`/`mcp_completed`/`mcp_failed` events | **new** `mcp_read_resource` kind (`mcp_read_resource.py`) — same `require_mcp` gate (server-scoped, same axis) + `mcp_resource_read`/`mcp_resource_read_completed`/`mcp_resource_read_failed` events |
| LLM verbs (`src/reyn/tools/mcp.py`) | `list_mcp_tools` / `call_mcp_tool` / `describe_mcp_tool` | **new** `list_mcp_resources` / `read_mcp_resource` / `list_mcp_resource_templates`, same `_require_host` delegation + `_enrich_router_schema` (server enum) reuse |
| Host adapter (`session.py` + `router_host_adapter.py` + `router_loop.py` Protocol) | `_mcp_list_tools` / `_mcp_call_tool` | **new** `_mcp_list_resources` / `_mcp_list_resource_templates` / `_mcp_read_resource`, routed through the same held-connection-service (non-ephemeral) / one-shot-pool (ephemeral) split |

**Deliberate asymmetry vs. `list_tools`:** discovery (`list_mcp_resources` / `list_mcp_resource_templates`) mirrors `list_tools` — **not** permission-gated, no op kind, direct `MCPGateway` call from `session.py` (resource *metadata* carries no more risk than a tool's name/description). Only the content-returning `read_mcp_resource` is a gated op kind (`mcp_read_resource`, `require_mcp`), matching the tools surface's own split between ungated `list_tools` and gated `call_tool` — a resource's contents are external, potentially sensitive server-authored data, the same reasoning `call_mcp_tool` already applies.

**Offload safety (#2425 canonical mapper):** `mcp_read_resource` results now also flow through `to_canonical()` / the router's canonical-offload branch (`router_loop.py`) — a resource `blob` (base64) is kept as a size-gated `structured` attachment (not classified as `media`, since an arbitrary resource blob isn't necessarily an image), so a large blob can't become a second oversized field competing with `text` (the exact bug class #2425 fixed for tool calls).

**FastMCP verification (3.4.2):** `client/mixins/resources.py` exposes `list_resources()` / `list_resource_templates()` (auto-paginating, same pattern as `list_tools()`) and `read_resource_mcp()` (raw `ReadResourceResult`, used instead of the convenience `read_resource()` so the flattening lives in one helper, mirroring `call_tool_mcp`'s use in `call_tool()`).

## Out of scope (per spec)

- `resources/subscribe` / `resources/updated` / `on_resource_updated` (②b)
- prompts (separate later slice)
- elicitation / OAuth / logging
- A `describe_mcp_resource` verb: resources have no separate input-schema concept like tools do — `list_mcp_resources`' entries already carry `uri`/`name`/`description`/`mimeType`, so there is nothing a "describe" step would add. Noted for review.
- `mcp_verbs.py`'s `mcp__<server>__<tool>` per-tool wrapper layer and the CodeAct-style universal-catalog enumeration (`universal_catalog.py`/`universal_dispatch.py`) are **not** wired for resources — those are secondary surfaces outside the explicit scope list; the new capabilities are fully live on the primary router `tools=[...]` path via `get_default_registry()`.

## Docs

- `docs/reference/runtime/control-ir.md` — new `mcp_read_resource` section + table row (hard-rule sync with `OP_KIND_MODEL_MAP`).
- `docs/concepts/tools-integrations/mcp.md` — new "Resources: list + read" subsection under Role 1.
- `docs/feature-map.md` — new resources-consumption row.

## Test plan

New file `tests/test_2597_s2a_mcp_resources_consumption.py` (20 tests) — real fastmcp/low-level-SDK subprocess servers, no mocks:

- [x] `MCPClient.list_resources/read_resource/list_resource_templates` real round-trip against `mcp_resources_server.py` (a real low-level-SDK server registering one resource, no tools/templates)
- [x] `list_resource_templates()` returns `[]` (not an error) via the FastMCP echo server (verified: low-level SDK genuinely raises "Method not found" when no template handler is registered at all — documented in the test)
- [x] Gated fail-fast: `list_resources`/`read_resource` against `mcp_paginated_tools_server.py` (real tools-only server, no `resources` capability) raise `MCPError` naming the capability + server
- [x] `MCPGateway` resources pass-throughs (real round-trip + `MCPFault` on the ungated server)
- [x] `mcp_read_resource` op: real resource read + `mcp_resource_read`/`_completed` events (permission bypassed, mirrors the existing `mcp.py` `_execute` test pattern)
- [x] `execute_op` permission gate: denies without `permissions.mcp` declared (real `PermissionResolver`, non-interactive) + allows end-to-end when granted (real subprocess read)
- [x] `_execute` clean error for an unconfigured server
- [x] `OP_KIND_MODEL_MAP` / `Op` union completeness for the new kind
- [x] canonical-offload mapper: text joins, blob isolates as a `structured` attachment
- [x] `tools/mcp.py` handler delegation via a Fake host (mirrors `test_mcp_invoke_action_tool_args_1646.py`'s pattern) — list/read/templates delegate correctly, host-error surfacing
- [x] ToolDefinition registration shape (gates/category/purity) + presence in `get_default_registry()`

Also updated 2 existing golden-set tests for the new registrations (both are the tests' own documented "update intentionally on membership change" cases):
- `tests/test_2123_router_dispatch_sot_1953.py` — added the 3 new dispatch names to `_EXPECTED_DISPATCH`
- `tests/test_returns_external_content_flagset_1822.py` — classified the 3 new tools as `_EXTERNAL` (external server-authored content, same rationale as `list_mcp_tools`/`call_mcp_tool`)

## 4 CI gates (local)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2597_s2a_mcp_resources_consumption.py tests/test_2123_router_dispatch_sot_1953.py tests/test_returns_external_content_flagset_1822.py
Summary: 28 tests inspected — OK: 28, warnings: 0, errors: 0

$ pytest -q
5 failed, 7302 passed, 21 skipped
  (all 5 failures are the pre-existing #2599 web-route-mount failures — confirmed
  present identically on main before this change; zero NEW failures introduced)

$ python scripts/verify_module_docstrings.py <all changed src files>
OK: no module-docstring refactor narrative in <all changed src files>.
```