### PR TITLE
fix(#2597): F1 _heal transport-death classifier + F2 double mcp_progress

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 import os
 import tempfile
 import warnings
-from typing import Any
+from typing import Any, NoReturn
 
 # ── Env var expansion ─────────────────────────────────────────────────────────
 # Shared resolver lives in reyn.security.secrets.interpolation (ADR-0030).
@@ -59,6 +59,33 @@ from reyn.security.secrets.interpolation import expand_env as expand_env  # noqa
 
 class MCPError(RuntimeError):
     """Raised on any MCP transport / protocol / tool error."""
+
+
+class MCPCapabilityError(MCPError):
+    """Raised by :func:`require_capability` when the connected server did not
+    advertise the requested capability. This is a REFUSAL, not a transport
+    failure — the connection is healthy, reyn is just declining to send a
+    request the server never said it supports. :class:`~reyn.mcp.
+    connection_service.MCPConnectionService`'s ``_HeldConnection._heal`` must
+    NOT treat this as a dead-connection signal (see :class:`MCPTransportError`
+    for the one exception type that IS)."""
+
+
+class MCPTransportError(MCPError):
+    """Raised in place of plain :class:`MCPError` when the underlying failure is
+    genuine transport-death — a dead subprocess (stdio) or a broken connection
+    (http/sse) — as opposed to an application-level protocol error (unknown
+    tool/resource, invalid params, a tool that raised) or a capability-gate
+    refusal (:class:`MCPCapabilityError`). Raised by :func:`_classify_and_raise`
+    at every SDK-call boundary in this module (``call_tool``/``list_tools``/
+    ``read_resource``/``list_resources``/``list_resource_templates``) — see that
+    function's docstring for the exact predicate, verified against the
+    installed fastmcp 3.4.2 + mcp SDK. This is the ONLY exception type
+    ``_HeldConnection._heal`` (connection_service.py) treats as a dead-
+    connection signal that should discard + reopen the held connection; a
+    plain ``MCPError`` (app-level) or ``MCPCapabilityError`` (gate refusal)
+    propagates WITHOUT recycling a perfectly healthy connection (#2597 F1 —
+    the pre-fix ``except MCPError:`` over-caught both of those)."""
 
 
 _SUPPORTED_TYPES = {"stdio", "http", "sse"}
@@ -81,17 +108,100 @@ def require_capability(client: "MCPClient", capability: str) -> None:
     fails with a reyn-authored message instead of a confusing raw protocol error
     from the server.
 
-    Raises :class:`MCPError` if not supported; no-op (returns None) otherwise.
+    Raises :class:`MCPCapabilityError` (an :class:`MCPError` subclass — existing
+    ``except MCPError`` callers keep working unchanged) if not supported; no-op
+    (returns None) otherwise. #2597 F1: this is a REFUSAL raised before any
+    request reaches the server, never a transport failure — a distinct
+    subclass from :class:`MCPTransportError` so ``_HeldConnection._heal`` can
+    tell "gate refused this call" apart from "the connection died" and leave a
+    healthy held connection alone on a gate refusal.
     """
     if client.supports(capability):
         return
     server = client.server_name or "<unknown>"
     version = client.negotiated_version or "<unknown>"
-    raise MCPError(
+    raise MCPCapabilityError(
         f"MCP server {server!r} does not advertise the {capability!r} capability "
         f"(negotiated protocol version {version}). Refusing to call a "
         f"{capability!r} feature against it."
     )
+
+
+def _is_transport_death(exc: BaseException) -> bool:
+    """Return True iff ``exc`` (caught at an SDK-call boundary in this module)
+    signals genuine MCP transport death — as opposed to an application-level
+    protocol error the server responded with while alive and connected.
+
+    #2597 F1 predicate — verified by reading the installed fastmcp 3.4.2 +
+    mcp SDK source AND by live-probing both branches against the real
+    ``tests/_support/mcp_fastmcp_echo_server.py`` test double over stdio:
+
+      - ``mcp.shared.exceptions.McpError`` whose ``.error.code`` equals
+        ``mcp.types.CONNECTION_CLOSED`` (``-32000``). ``mcp.shared.session.
+        BaseSession``'s receive loop (session.py) catches
+        ``anyio.ClosedResourceError`` when the transport's read stream closes
+        underneath it and, in the ``finally``, synthesizes exactly this
+        ``ErrorData`` for every still-pending in-flight request — this is how
+        a dead stdio subprocess actually surfaces to an in-flight
+        ``call_tool``/``read_resource``/etc. call. **Live-verified**: killing
+        the echo server's subprocess mid-call (the ``die`` tool) raised
+        ``MCPError('MCP tools/call error: Connection closed')`` whose
+        ``__cause__`` was ``McpError(error=ErrorData(code=-32000,
+        message='Connection closed', ...))`` — exactly this branch.
+      - ``RuntimeError("Server session was closed unexpectedly")`` — fastmcp's
+        ``Client._context_manager`` (client.py) wraps a
+        ``anyio.ClosedResourceError`` leaking out of the session's context
+        scope in this EXACT message. Not observed directly in the stdio-die
+        probe above (that death surfaced via the McpError branch instead),
+        but included defensively per fastmcp's own source — a different
+        failure timing (e.g. mid-``initialize``, or the read stream closing
+        while the caller is inside the ``async with`` scope rather than
+        mid-request) could route through this wrapper instead.
+      - Raw ``anyio.ClosedResourceError`` / ``anyio.BrokenResourceError`` /
+        ``ConnectionError`` — defensive: these are anyio's/stdlib's own
+        dead-stream / dead-socket signal types; not observed leaking
+        unwrapped to this call site in the probes above, but a conservative
+        predicate treats them as transport-death if they ever do.
+
+    Anything else — including OTHER ``McpError`` codes (**live-verified**:
+    calling an unknown resource URI raised ``McpError(error=ErrorData(
+    code=-32002, message="Resource not found: ..."))``; ``METHOD_NOT_FOUND``/
+    ``INVALID_PARAMS`` are the same "server responded, it's just an app-level
+    error" shape), a tool-level failure (a tool raising inside its handler
+    comes back as a normal ``CallToolResult`` with ``isError: True`` — never
+    an exception at all, so it never reaches this predicate), or any other
+    exception type — is NOT transport death: the server is alive and
+    responded, just with an error. Default is False (= NOT transport) so an
+    unrecognized exception propagates as a plain :class:`MCPError` rather
+    than triggering an unnecessary reconnect.
+    """
+    import anyio
+
+    if isinstance(exc, (anyio.ClosedResourceError, anyio.BrokenResourceError, ConnectionError)):
+        return True
+    if isinstance(exc, RuntimeError) and str(exc) == "Server session was closed unexpectedly":
+        return True
+    try:
+        from mcp.shared.exceptions import McpError as _SdkMcpError
+        from mcp.types import CONNECTION_CLOSED
+    except ImportError:  # pragma: no cover — mcp SDK always installed alongside fastmcp
+        return False
+    if isinstance(exc, _SdkMcpError):
+        error = getattr(exc, "error", None)
+        return getattr(error, "code", None) == CONNECTION_CLOSED
+    return False
+
+
+def _classify_and_raise(exc: Exception, message: str) -> NoReturn:
+    """Raise :class:`MCPTransportError` if ``exc`` is genuine transport-death
+    (see :func:`_is_transport_death`), else plain :class:`MCPError` — either
+    way with ``exc`` preserved as ``__cause__``. Shared by every SDK-call
+    boundary below (``call_tool``/``list_tools``/``read_resource``/
+    ``list_resources``/``list_resource_templates``) so the classification
+    logic lives in exactly one place."""
+    if _is_transport_death(exc):
+        raise MCPTransportError(message) from exc
+    raise MCPError(message) from exc
 
 
 # ── Client ───────────────────────────────────────────────────────────────────
@@ -379,7 +489,7 @@ class MCPClient:
             # consumed shape stays byte-identical.
             result = await self._client.call_tool_mcp(name, args or {}, **kwargs)
         except Exception as exc:
-            raise MCPError(f"MCP tools/call error: {exc}") from exc
+            _classify_and_raise(exc, f"MCP tools/call error: {exc}")
         return _result_to_dict(result)
 
     async def list_tools(self) -> list[dict[str, Any]]:
@@ -396,7 +506,7 @@ class MCPClient:
         try:
             tools = await self._client.list_tools()
         except Exception as exc:
-            raise MCPError(f"MCP tools/list error: {exc}") from exc
+            _classify_and_raise(exc, f"MCP tools/list error: {exc}")
         return [_tool_to_dict(t) for t in tools]
 
     # ── resources (#2597 slice ②a — consumption only; subscribe is ②b) ─────────
@@ -413,7 +523,7 @@ class MCPClient:
         try:
             resources = await self._client.list_resources()
         except Exception as exc:
-            raise MCPError(f"MCP resources/list error: {exc}") from exc
+            _classify_and_raise(exc, f"MCP resources/list error: {exc}")
         return [_resource_to_dict(r) for r in resources]
 
     async def list_resource_templates(self) -> list[dict[str, Any]]:
@@ -425,7 +535,7 @@ class MCPClient:
         try:
             templates = await self._client.list_resource_templates()
         except Exception as exc:
-            raise MCPError(f"MCP resources/templates/list error: {exc}") from exc
+            _classify_and_raise(exc, f"MCP resources/templates/list error: {exc}")
         return [_resource_to_dict(t) for t in templates]
 
     async def read_resource(self, uri: str) -> dict[str, Any]:
@@ -444,7 +554,7 @@ class MCPClient:
         try:
             result = await self._client.read_resource_mcp(uri)
         except Exception as exc:
-            raise MCPError(f"MCP resources/read error: {exc}") from exc
+            _classify_and_raise(exc, f"MCP resources/read error: {exc}")
         return _read_resource_result_to_dict(result)
 
     async def close(self) -> None:

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -24,10 +24,21 @@ Reconnect-on-demand (S2a-level resilience — deliberately NOT S2b's background 
 loop / ping): a subprocess death or HTTP disconnect mid-session does NOT flip
 ``MCPClient.is_initialized()`` or the underlying ``fastmcp.Client.is_connected()``
 (verified empirically against the real echo test server's ``die`` tool — both stay
-True after the transport is gone) — the only observable signal is an :class:`MCPError`
-raised on the NEXT use. So the held-connection handle catches an ``MCPError``, discards
-+ reopens the dead connection so the NEXT call lands on a healthy transport — a dropped
+True after the transport is gone) — the only observable signal is an exception raised
+on the NEXT use. So the held-connection handle catches that signal, discards + reopens
+the dead connection so the NEXT call lands on a healthy transport — a dropped
 connection must not permanently wedge the server for the rest of the session.
+
+#2597 F1 fix (post-S1 over-catch): ``MCPClient`` wraps EVERY exception (transport
+death, application-level protocol errors, capability-gate refusals) into some
+``MCPError`` subclass — so catching bare ``MCPError`` here would reconnect a perfectly
+healthy connection on a capability-gate refusal or an app-level error (e.g. an unknown
+tool/resource), needlessly killing+respawning a live stdio subprocess. ``_heal`` below
+catches ONLY :class:`~reyn.mcp.client.MCPTransportError` — the narrower subclass
+``reyn.mcp.client`` raises (via its ``_is_transport_death`` predicate, verified against
+fastmcp 3.4.2 + the mcp SDK) exclusively for genuine transport-death. A
+``MCPCapabilityError`` (gate refusal) or a plain ``MCPError`` (app-level) propagates
+WITHOUT touching the connection.
 
 CRITICAL — the reconnect must NOT silently retry a side-effectful call (at-most-once):
 post-S1 ``call_tool`` raises ``MCPError`` on ANY transport failure, including the
@@ -67,7 +78,7 @@ import asyncio
 import logging
 from typing import Any, Awaitable, Callable
 
-from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.client import MCPClient, MCPTransportError
 from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCacheInvalidate
 from reyn.mcp.pool import describe_fault, is_real_control_flow
 
@@ -300,9 +311,20 @@ class _HeldConnection:
     async def _heal(
         self, op: "Callable[[MCPClient], Awaitable[Any]]", *, heal_only: bool,
     ) -> Any:
-        """Run ``op`` against the currently-held client. On an :class:`MCPError` —
-        the only observable signal of a dead connection (see module docstring) —
-        discard + reopen the connection.
+        """Run ``op`` against the currently-held client. On an :class:`MCPTransportError`
+        — genuine transport-death, the only signal that actually means the held
+        connection is dead (see module docstring + ``client.py``'s ``_is_transport_death``
+        predicate) — discard + reopen the connection.
+
+        #2597 F1: this deliberately catches ONLY ``MCPTransportError``, not the base
+        ``MCPError``. Post-S1, every ``MCPClient`` method wraps ALL exceptions into some
+        ``MCPError`` subclass, so a bare ``except MCPError:`` here used to over-catch two
+        cases that are NOT a dead connection: a capability-gate refusal
+        (``MCPCapabilityError`` — the server is alive, reyn just declined to send the
+        request) and an application-level protocol error (unknown tool/resource, invalid
+        params — the server responded, just with an error). Both of those propagate
+        WITHOUT touching the connection now; only ``MCPTransportError`` triggers
+        discard+reopen.
 
         ``heal_only=True`` (side-effectful ``call_tool``): re-raise the ORIGINAL error
         after healing — do NOT re-run ``op`` (preserves at-most-once; the healed
@@ -314,7 +336,7 @@ class _HeldConnection:
         )
         try:
             return await op(client)
-        except MCPError:
+        except MCPTransportError:
             fresh = await self._service._reconnect(
                 self._server, self._config, agent_id=self._agent_id,
             )

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -74,10 +74,35 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
     """Bridges FastMCP server-pushed notifications on a held connection to reyn's
     ``EventLog`` (#2597 S2b). One instance per held server connection.
 
-    Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``, ``notifications/
-    progress``. ``resources/updated`` / ``resources/subscribe`` are DEFERRED to the
-    resources-consumption slice (nothing is subscribed yet) — the inherited
-    ``on_resource_updated`` / ``on_resource_list_changed`` stay base-class no-ops.
+    Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``. ``resources/
+    updated`` / ``resources/subscribe`` are DEFERRED to the resources-consumption
+    slice (nothing is subscribed yet) — the inherited ``on_resource_updated`` /
+    ``on_resource_list_changed`` stay base-class no-ops.
+
+    #2597 F2 (live-verified, NOT emitted here — see :meth:`on_progress`):
+    ``notifications/progress`` is NOT bridged to ``mcp_progress`` by this handler.
+    A live probe (real fastmcp 3.4.2 stdio server + a held ``MCPConnectionService``
+    connection + a per-call ``progress_callback``, both wired simultaneously)
+    confirmed the SDK dual-delivers every in-call progress notification: FastMCP's
+    ``mcp.shared.session.BaseSession`` receive loop invokes the per-call
+    ``progress_callback`` registered for that request's ``progressToken`` via
+    ``ClientSession.call_tool(progress_callback=...)`` (``op_runtime/mcp.py``'s
+    ``_on_progress`` — richer context: carries the tool name) AND separately
+    dispatches the SAME notification through the installed ``message_handler``
+    (this class) — a 3-step ``progress`` tool call produced 3
+    ``PER_CALL_progress_cb`` events AND 3 ``mcp_progress`` bridge events with
+    identical progress/total/message payloads. Emitting from BOTH paths would
+    double every in-call progress event on the EventLog (mirrors the S2b-log
+    dual-delivery already documented for LOGGING notifications). Since the
+    per-call callback path already covers ALL call-scoped progress with richer
+    context (the tool name; ``on_progress`` here can't see it — the bridge has no
+    visibility into which in-flight request a ``progressToken`` belongs to), the
+    minimal correct fix is: this bridge does not emit ``mcp_progress`` at all.
+    Unsolicited/out-of-band progress (a notification with no per-call handler,
+    e.g. a long-running server-initiated task with no corresponding client
+    request) is out of scope until a real case demonstrates the SDK delivering
+    one ONLY through the message_handler path — nothing observed here proves
+    that path exists independently of the per-call one.
     """
 
     def __init__(
@@ -122,17 +147,11 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         await super().on_prompt_list_changed(message)
 
     async def on_progress(self, message: Any) -> None:
-        params = getattr(message, "params", None)
-        token = getattr(params, "progressToken", None)
-        self._emit(
-            "mcp_progress",
-            server=self._server_name,
-            tool=None,
-            progress=getattr(params, "progress", None),
-            total=getattr(params, "total", None),
-            message=getattr(params, "message", None),
-            progress_token=str(token) if token is not None else None,
-        )
+        # #2597 F2: deliberately does NOT emit ``mcp_progress`` — see this class's
+        # docstring for the live-verified dual-delivery observation + the decision.
+        # The per-call ``progress_callback`` path (``op_runtime/mcp.py``'s
+        # ``_on_progress``) already emits ``mcp_progress`` (with tool-name context)
+        # for every call-scoped progress notification the SDK also routes here.
         await super().on_progress(message)
 
     # ── sink dispatch ───────────────────────────────────────────────────────────────

--- a/tests/_support/mcp_tools_only_pid_server.py
+++ b/tests/_support/mcp_tools_only_pid_server.py
@@ -1,0 +1,55 @@
+"""Low-level real MCP stdio server that advertises ONLY the ``tools`` capability,
+with a ``pid`` tool (#2597 F1 — ``_heal`` reconnect-classifier tests).
+
+Standalone script — run as a subprocess, never imported. Combines two properties
+neither existing test-support fixture has both of:
+
+  - Like ``mcp_paginated_tools_server.py``: uses the LOW-LEVEL ``mcp.server.
+    lowlevel.Server`` (not FastMCP — verified empirically in that fixture's
+    docstring that a FastMCP-built server always advertises ALL four capabilities
+    regardless of what it registers, so it cannot demonstrate a server that
+    genuinely does NOT advertise ``resources``). Registers ONLY
+    ``@app.list_tools()``/``@app.call_tool()`` — no resource handlers — so its
+    negotiated ``resources`` capability is None, the real "gate refuses" case
+    F1's ``MCPCapabilityError`` test needs.
+  - Like ``mcp_fastmcp_echo_server.py``'s ``pid()`` tool: exposes a ``pid`` tool
+    returning ``os.getpid()`` of THIS server subprocess, so a held-connection
+    test can prove the SAME subprocess survives a gate-refused / app-level-error
+    call (no reconnect) by comparing PIDs before and after.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+app = Server("reyn-test-tools-only-pid")
+
+_PID_TOOL = types.Tool(
+    name="pid", description="Return this server subprocess's PID.",
+    inputSchema={"type": "object"},
+)
+
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [_PID_TOOL]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+    if name != "pid":
+        raise ValueError(f"Unknown tool: {name!r}")
+    return [types.TextContent(type="text", text=str(os.getpid()))]
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_2597_f1_heal_transport_classifier.py
+++ b/tests/test_2597_f1_heal_transport_classifier.py
@@ -1,0 +1,118 @@
+"""Tests for #2597 F1 — ``_HeldConnection._heal`` reconnect-classifier fix.
+
+Real instances only, per the testing policy: no ``unittest.mock`` / ``MagicMock`` /
+``AsyncMock`` / ``patch``. All three tests drive a REAL ``MCPConnectionService``
+(the held-connection path) against REAL stdio MCP server subprocesses, reusing the
+PID-survival idiom already established in ``test_2597_s2a_mcp_connection_service.py``
+(the ``die`` test) / ``test_2597_s2a_mcp_resources_consumption.py`` (the
+``resource://pid`` read): a tool/resource that returns ``os.getpid()`` of the SERVER
+subprocess proves whether the held connection was discarded+reopened (PID changes) or
+left untouched (PID survives) — not just Python object identity, which would not
+distinguish "the same MCPClient object, but internally reconnected" from "genuinely
+never touched".
+
+Before the F1 fix, ``_heal`` caught bare ``MCPError`` — since post-S1 EVERY
+``MCPClient`` method wraps ALL exceptions into some ``MCPError`` subclass, a
+capability-gate refusal or an application-level protocol error (neither of which mean
+the connection is dead) would ALSO trigger a spurious discard+reopen of a perfectly
+healthy stdio subprocess. These tests pin the fix: only genuine transport-death
+(``MCPTransportError``) heals; gate refusals (``MCPCapabilityError``) and app-level
+errors (plain ``MCPError``) propagate with the connection left alone.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPCapabilityError, MCPError, MCPTransportError
+from reyn.mcp.connection_service import MCPConnectionService
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+_TOOLS_ONLY_PID_SERVER = _SUPPORT_DIR / "mcp_tools_only_pid_server.py"
+
+_ECHO_CFG = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+_TOOLS_ONLY_PID_CFG = {
+    "type": "stdio", "command": sys.executable, "args": [str(_TOOLS_ONLY_PID_SERVER)],
+}
+
+
+async def _pid_via_call_tool(client) -> str:
+    result = await client.call_tool("pid", {})
+    return result["content"][0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_capability_gate_refusal_does_not_recycle_held_connection():
+    """Tier 2: a capability-gate refusal (``MCPCapabilityError``, raised by
+    ``require_capability`` BEFORE any request reaches the server) on a held
+    connection propagates WITHOUT discarding the connection — the ``mcp_tools_only_
+    pid_server.py`` fixture advertises ``tools`` but NOT ``resources``, so
+    ``list_resources()`` refuses fast. The SAME subprocess (identical PID, proven via
+    the real ``pid`` tool) serves the call immediately before and after."""
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", _TOOLS_ONLY_PID_CFG)
+        pid_before = await _pid_via_call_tool(client)
+
+        with pytest.raises(MCPCapabilityError):
+            await client.list_resources()
+
+        pid_after = await _pid_via_call_tool(client)
+        assert pid_after == pid_before, (
+            "a gate refusal must NOT recycle a healthy held connection"
+        )
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_app_level_protocol_error_does_not_recycle_held_connection():
+    """Tier 2: an application-level protocol error — the server is alive and
+    responded, just with an error (reading an unknown resource URI against the real
+    echo server raises a plain ``MCPError`` whose ``McpError`` cause carries the
+    JSON-RPC "Resource not found" code, NOT the transport-death "Connection closed"
+    code) — on a held connection propagates WITHOUT discarding the connection. The
+    SAME subprocess (identical PID) serves the call immediately before and after."""
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", _ECHO_CFG)
+        pid_before = await _pid_via_call_tool(client)
+
+        with pytest.raises(MCPError) as exc_info:
+            await client.read_resource("resource://does_not_exist")
+        assert not isinstance(exc_info.value, MCPTransportError), (
+            "an app-level protocol error must classify as plain MCPError, "
+            "not MCPTransportError — only genuine transport-death does"
+        )
+
+        pid_after = await _pid_via_call_tool(client)
+        assert pid_after == pid_before, (
+            "an app-level protocol error must NOT recycle a healthy held connection"
+        )
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_genuine_transport_death_recycles_held_connection():
+    """Tier 2: genuine transport death (killing the server subprocess via the real
+    ``die`` tool) DOES classify as ``MCPTransportError`` and DOES heal the held
+    connection — preserves the S2a die-test intent (see
+    ``test_2597_s2a_mcp_connection_service.py``), now pinning the EXACT exception
+    type the F1 classifier must raise for this case."""
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", _ECHO_CFG)
+        pid_before = await _pid_via_call_tool(client)
+
+        with pytest.raises(MCPTransportError):
+            await client.call_tool("die", {})
+
+        # the connection healed: the NEXT call succeeds on a FRESH subprocess.
+        pid_after = await _pid_via_call_tool(client)
+        assert pid_after != pid_before, "transport death must heal to a fresh subprocess"
+    finally:
+        await service.aclose()

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -165,23 +165,36 @@ async def test_tool_list_changed_notification_emits_event_and_invalidates_cache(
         await service.aclose()
 
 
-# ── (b) real server-pushed progress -> mcp_progress event ─────────────────────────
+# ── (b) real server-pushed progress: per-call callback is the ONE mcp_progress
+#        source; the bridge does not double-emit (#2597 F2) ───────────────────────
 
 
 @pytest.mark.asyncio
-async def test_progress_notification_emits_mcp_progress_event(tmp_path: Path):
-    """Tier 2: a REAL server-pushed ``notifications/progress`` on a held connection
-    lands as an ``mcp_progress`` event on the EventLog — the SAME event type
-    ``op_runtime/mcp.py`` already emits for the per-call progress_handler path
-    (issue #264/#271), so ``ChatLifecycleForwarder.on_mcp_progress`` surfaces it
-    without a new consumer."""
+async def test_progress_notification_not_double_emitted_by_bridge(tmp_path: Path):
+    """Tier 2: #2597 F2 — a REAL server-pushed ``notifications/progress`` on a held
+    connection with BOTH a per-call ``progress_callback`` (the ``op_runtime/mcp.py``
+    path, which itself emits ``mcp_progress`` with tool-name context) AND the
+    S2b notifications bridge installed simultaneously must NOT double-emit
+    ``mcp_progress`` — a live probe proved the SDK dual-delivers each in-call
+    progress notification to BOTH the per-call callback AND the installed
+    ``message_handler`` (``ReynMCPMessageHandler.on_progress``); emitting from both
+    would double every in-call progress event on the EventLog. The bridge is fixed to
+    never emit ``mcp_progress`` (see ``ReynMCPMessageHandler.on_progress``'s
+    docstring) — this test proves that with the caller's own per-call callback
+    ALSO emitting (mirroring ``op_runtime/mcp.py``'s ``_on_progress``), exactly ONE
+    ``mcp_progress`` event lands per reported progress step, not two."""
     events = EventLog(subscribers=[])
     service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
     try:
         client = await service.get("srv", _CFG)
 
         async def _progress_cb(progress, total, message) -> None:
-            pass
+            # Mirrors op_runtime/mcp.py's _on_progress — the ONE place that should
+            # emit mcp_progress for call-scoped progress.
+            events.emit(
+                "mcp_progress", server="srv", tool="progress",
+                progress=progress, total=total, message=message,
+            )
 
         result = await client.call_tool(
             "progress", {"steps": 2}, progress_callback=_progress_cb,
@@ -189,9 +202,13 @@ async def test_progress_notification_emits_mcp_progress_event(tmp_path: Path):
         assert result["isError"] is False
 
         matching = [e for e in events.all() if e.type == "mcp_progress"]
-        first_step, second_step = matching  # one event per reported progress step
+        first_step, second_step = matching  # exactly ONE event per progress step, not two
         assert first_step.data.get("server") == "srv"
         assert second_step.data.get("server") == "srv"
+        assert first_step.data.get("tool") == "progress", (
+            "the surviving mcp_progress event carries tool-name context — "
+            "proof it came from the per-call callback, not the (tool-blind) bridge"
+        )
         assert (first_step.data.get("progress"), second_step.data.get("progress")) == (
             1.0, 2.0,
         )


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## F1 (confirmed bug) — `_heal` reconnect classifier over-catches

Post-S1, `MCPClient.call_tool`/`list_tools`/`read_resource`/`list_resources`/
`list_resource_templates` wrap EVERY exception into `MCPError`, and
`require_capability` also raises plain `MCPError`. `_HeldConnection._heal`
(connection_service.py) caught bare `except MCPError:` as its dead-connection
signal, so a capability-gate refusal OR an app-level error (unknown
tool/resource, invalid params) would ALSO discard + reopen a perfectly healthy
held connection — for stdio, killing + respawning a live subprocess for no
reason.

**Fix**: two new `MCPError` subclasses in `src/reyn/mcp/client.py`:
- `MCPCapabilityError` — `require_capability` raises this now (a refusal, not a
  transport failure).
- `MCPTransportError` — raised by a new `_classify_and_raise` helper at every
  SDK-call boundary, ONLY for genuine transport-death.

`_HeldConnection._heal` now catches `MCPTransportError` (not bare `MCPError`).

**Transport-death predicate verified** against the installed fastmcp 3.4.2 +
mcp SDK (read the actual source, then live-probed both branches against
`tests/_support/mcp_fastmcp_echo_server.py` over stdio):

- `mcp.shared.exceptions.McpError` whose `.error.code == mcp.types.
  CONNECTION_CLOSED` (`-32000`) — `mcp.shared.session.BaseSession`'s receive
  loop synthesizes this `ErrorData` for every in-flight request when the
  transport's read stream closes underneath it. **Live-verified**: killing the
  echo server subprocess mid-call (the `die` tool) raised exactly this.
- `RuntimeError("Server session was closed unexpectedly")` — fastmcp's
  `Client._context_manager` wraps a leaked `anyio.ClosedResourceError` in this
  exact message (fastmcp/client/client.py). Included defensively (not observed
  directly in the die-probe — that routed through the McpError branch above —
  but it's fastmcp's own source-verified wrap for a different failure timing).
- Raw `anyio.ClosedResourceError` / `anyio.BrokenResourceError` /
  `ConnectionError` — defensive, not observed leaking unwrapped in the probes.

Anything else (other `McpError` codes, e.g. **live-verified**: reading an
unknown resource URI raised `McpError(code=-32002, "Resource not found...")`;
a tool raising inside its handler comes back as a normal `isError: True`
result, never an exception) is classified as app-level → plain `MCPError`,
NOT `MCPTransportError` → `_heal` leaves the connection alone.

## F2 (verified, confirmed dual-delivery) — double `mcp_progress`

Live-verified via a scratchpad experiment: a real fastmcp server tool that
reports 3 progress steps, called through a held `MCPConnectionService`
connection WITH a per-call `progress_callback` (mirroring `op_runtime/mcp.py`'s
`_on_progress`) AND the S2b notifications bridge installed simultaneously.
Observed: 3 `PER_CALL_progress_cb` events AND 3 separate `mcp_progress` bridge
events (`tool=None`) with identical progress/total/message payloads — the SDK
dual-delivers every in-call progress notification to both the per-call
callback and the installed `message_handler`, exactly like the S2b-log
dual-delivery already documented for LOGGING notifications.

**Fix**: `ReynMCPMessageHandler.on_progress` (message_handler.py) no longer
emits `mcp_progress` at all — the per-call callback path (`op_runtime/mcp.py`)
already covers all call-scoped progress with richer context (the tool name;
the bridge can't see which in-flight request a `progressToken` belongs to).
Unsolicited/out-of-band progress (no per-call handler) is documented as out of
scope until a real case demonstrates the SDK delivering one independently of
the per-call path.

Updated the pre-existing S2b bridge test
(`test_2597_s2b_mcp_notifications_bridge.py`) to assert exactly ONE
`mcp_progress` event lands per progress step (from the per-call callback, not
doubled by the bridge) — its prior form asserted the bridge alone produced the
event, which was the bug's premise.

## Constraints honored
- Real fastmcp/low-level MCP servers + real `MCPConnectionService` throughout
  — no `mock.patch`/`MagicMock`/`AsyncMock`.
- New tests in `tests/test_2597_f1_heal_transport_classifier.py` reuse the
  held-path PID-survival idiom (a `pid` tool/resource returning the real
  server subprocess PID) already established in
  `test_2597_s2a_mcp_connection_service.py` / `_resources_consumption.py`, to
  prove the SAME subprocess survives a gate refusal and an app-level error
  (no reconnect), and that genuine transport death DOES heal to a fresh
  subprocess (new PID).
- New low-level test-support fixture
  `tests/_support/mcp_tools_only_pid_server.py` — advertises `tools` but NOT
  `resources` (proves the real capability-gate-refusal case) AND exposes a
  `pid` tool (for the PID-survival assertion); no existing fixture had both.
- No WAL/recovery involved — truncate-falsify N/A.

## Test plan
- [x] `test_capability_gate_refusal_does_not_recycle_held_connection` — gate
  refusal (`MCPCapabilityError`) propagates, same subprocess PID survives.
- [x] `test_app_level_protocol_error_does_not_recycle_held_connection` —
  unknown-resource app error (plain `MCPError`, NOT `MCPTransportError`)
  propagates, same subprocess PID survives.
- [x] `test_genuine_transport_death_recycles_held_connection` — killing the
  subprocess raises `MCPTransportError` and heals to a fresh subprocess (new
  PID) — preserves the existing S2a die-test intent.
- [x] `test_progress_notification_not_double_emitted_by_bridge` (updated) —
  exactly one `mcp_progress` per progress step, carrying tool-name context
  (proof it's from the per-call path, not doubled by the bridge).

## 4-gate output (all green)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2597_f1_heal_transport_classifier.py tests/test_2597_s2b_mcp_notifications_bridge.py
Summary: 8 tests inspected
  ✓ OK: 8
  ⚠️ warnings: 0
  ✗ errors: 0
Exit code: 0

$ pytest tests/ -q
5 failed, 7308 passed, 21 skipped, 9 warnings in 134.84s
FAILED tests/test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted
FAILED tests/web/test_a2a.py::test_a2a_routes_mounted
FAILED tests/web/test_mcp_sse.py::test_mcp_routes_mounted
FAILED tests/web/test_plugin_loader.py::test_loader_disambiguates_via_package_field
FAILED tests/web/test_resources_router.py::test_resources_route_is_mounted_on_app
```
(all 5 are the known pre-existing #2599 web-route-mount failures — confirmed
identical failure set reproduces on main before this change; zero NEW
failures)

```
$ python scripts/verify_module_docstrings.py src/reyn/mcp/client.py src/reyn/mcp/connection_service.py src/reyn/mcp/message_handler.py
OK: no module-docstring refactor narrative in src/reyn/mcp/client.py src/reyn/mcp/connection_service.py src/reyn/mcp/message_handler.py.
```