### PR TITLE
feat(#2597): slice ②b — MCP resource subscriptions

### DIFF
--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -120,7 +120,14 @@ Alongside tools, a server can expose **resources** (server-hosted content addres
 
 Both list and read are additionally gated by the server's **negotiated capabilities**: a server that never advertised `resources` in its `initialize` handshake fails fast with a clear error (`require_capability` in `reyn/mcp/client.py`) instead of a raw protocol error.
 
-`resources/subscribe` (push notifications on resource change) is not yet implemented — today's surface is list + read only.
+### Resource subscriptions: the async push event-source
+
+`resources/subscribe` is a **state-sync/watch** mechanism, not a message queue: subscribe to a URI, and the server pushes a thin `notifications/resources/updated {uri}` signal (no content) whenever that resource changes — the client re-reads (`read_mcp_resource`) to see what changed.
+
+- `subscribe_mcp_resource(server, uri)` / `unsubscribe_mcp_resource(server, uri)` — both gated the same way `read_mcp_resource` is (`mcp_subscribe_resource` / `mcp_unsubscribe_resource` Control IR ops, `permissions.mcp: [server_name]`), plus an ADDITIONAL gate on the server's negotiated `resources.subscribe` sub-capability — a server can advertise `resources` (list/read work) without advertising `subscribe` (e.g. every server built with FastMCP's high-level `FastMCP()` class today — the underlying SDK hard-codes `resources.subscribe=False` regardless of what handlers a FastMCP server registers).
+- **Persistent connection required.** A subscription only makes sense on a held (session-lifetime) connection — the subscribed-URI set lives in-memory on `MCPConnectionService` (runtime-only; a subscription carries no data of its own, so it's fully re-establishable, never WAL'd). An ephemeral chat session refuses both ops with a clear error rather than accept a subscription that dies the instant its one-shot connection closes.
+- **Survives a transport-death reconnect.** A dropped connection (subprocess death, broken HTTP) re-opens a fresh MCP session with no memory of prior subscriptions; `MCPConnectionService` automatically re-issues every tracked subscription against the fresh connection, so a subscription set up before a drop keeps delivering pushes after reyn heals the connection.
+- **The push lands on the EventLog, not in a tool result.** `mcp_resource_updated` (`server`, `uri`) is emitted asynchronously whenever the notification arrives — independent of any Control IR op call. Wiring it into the hook dispatcher (so a workflow can react to it directly) is a later slice; today it's an audit-trail signal a workflow author reads back via the EventLog.
 
 ## Transport choice (stdio vs HTTP)
 

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -344,6 +344,7 @@ The op kinds below mirror `OP_KIND_MODEL_MAP` in `op_runtime/registry.py`.
 | `web_fetch` | URL fetch + text extract — Tier 1, default-allow |
 | `mcp` | Call a configured MCP server tool by name |
 | `mcp_read_resource` | Read one MCP resource by URI (permission-gated, same axis as `mcp`) |
+| `mcp_subscribe_resource` / `mcp_unsubscribe_resource` | Subscribe/unsubscribe to server-pushed `resources/updated` for one URI (requires a persistent connection; push lands as an `mcp_resource_updated` event) |
 | `mcp_install` | Install / register an MCP server (registry / package / local source) |
 | `index_query` | Vector similarity search over one indexed source |
 | `recall` | Macro: embed query → `index_query` per source → merge top-K |
@@ -529,7 +530,8 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | `mcp install` | Fetch from registry, gate permissions, write config, store secrets. Three chat verbs: `mcp__install_registry` (official registry), `mcp__install_package` (npm/pypi/docker/github URL), `mcp__install_local` (direct command). CLI: `reyn mcp install <SERVER_ID>` or `--source <SPEC>`. | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [reyn mcp CLI](reference/cli/mcp.md) |
 | Secret management | Per-server env vars in `~/.reyn/secrets.env` | [reyn secret CLI](reference/cli/secret.md) |
 | Tool dispatch | Lazy-load and cache `MCPClient` per server connection | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
-| Resources consumption | List/read MCP resources + resource templates (`list_mcp_resources` / `read_mcp_resource` / `list_mcp_resource_templates`), gated by the negotiated `resources` capability; `resources/subscribe` push updates are a separate, later slice | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_read_resource`](reference/runtime/control-ir.md) |
+| Resources consumption | List/read MCP resources + resource templates (`list_mcp_resources` / `read_mcp_resource` / `list_mcp_resource_templates`), gated by the negotiated `resources` capability | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_read_resource`](reference/runtime/control-ir.md) |
+| Resource subscriptions | Subscribe/unsubscribe to server-pushed `resources/updated` (`subscribe_mcp_resource` / `unsubscribe_mcp_resource`), gated by the negotiated `resources.subscribe` sub-capability; runtime-only subscribed-URI set survives a transport-death reconnect (re-subscribed); push lands as an `mcp_resource_updated` EventLog event | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_subscribe_resource`](reference/runtime/control-ir.md) |
 
 > **Differentiation vs general agents:** Reyn is both an MCP client (consumes external servers) and an MCP server (exposes its own agents) — standard-protocol interop in both directions, with stdio MCP servers subprocess-sandboxed under Seatbelt.
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -24,6 +24,8 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `web_fetch` | Fetch a single URL and return extracted text | Tier 1 — default allow; `web.fetch: deny` in `reyn.yaml` blocks |
 | `mcp` | Call a tool on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter |
 | `mcp_read_resource` | Read one resource (or a resolved resource-template URI) on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
+| `mcp_subscribe_resource` | Subscribe to server-pushed `resources/updated` notifications for one resource URI (requires a persistent connection — see below) | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
+| `mcp_unsubscribe_resource` | Cancel a previous `mcp_subscribe_resource` | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
@@ -256,7 +258,31 @@ The OS resolves the server's transport, dispatches via `MCPClient.read_resource`
 
 **Discovery is NOT gated.** `list_mcp_resources` / `list_mcp_resource_templates` (the chat-tool names for `MCPClient.list_resources` / `list_resource_templates`) mirror `list_mcp_tools`: no `control-ir` op kind, no permission gate — pure discovery, routed directly through `MCPGateway` from the router host adapter. Only the content-returning read is a gated op kind, matching the existing `mcp` (call_tool) vs. discovery (`list_tools`) split.
 
-`resources/subscribe` + `resources/updated` push notifications are a separate, later slice (②b) — out of scope here.
+`resources/subscribe` + `resources/updated` push notifications are `mcp_subscribe_resource` / `mcp_unsubscribe_resource` below (#2597 slice ②b).
+
+## `mcp_subscribe_resource` / `mcp_unsubscribe_resource`
+
+Subscribe to (or cancel a subscription to) server-pushed `notifications/resources/updated` for one resource URI on a configured MCP server. #2597 slice ②b — the async push event-source: MCP's `resources/subscribe` is a **state-sync/watch** mechanism, not a message queue — the server pushes a thin "this URI changed" signal (no payload), and the OS re-reads (`mcp_read_resource` / `read_mcp_resource`) to see the new content.
+
+```json
+{"kind": "mcp_subscribe_resource", "server": "filesystem", "uri": "file:///README.md"}
+```
+
+```json
+{"kind": "mcp_unsubscribe_resource", "server": "filesystem", "uri": "file:///README.md"}
+```
+
+Fields (both kinds): `server` (required), `uri` (required — a resource URI as advertised by `resources/list`).
+
+Gated by the **same** `permissions.mcp` axis as `mcp` / `mcp_read_resource` (subscribing is a stateful action against the server). Gated ALSO on the server's negotiated `resources.subscribe` sub-capability — distinct from the coarser `resources` capability `mcp_read_resource` gates on: a server may support reading resources without supporting subscriptions to them (`MCPClient.subscribe_resource` fails fast with `MCPCapabilityError` if the server didn't advertise `resources.subscribe=True` at connect).
+
+**Persistent connection required.** A subscription is only meaningful on a HELD (session-lifetime) MCP connection — the subscribed-URI set is tracked in-memory on `MCPConnectionService` (runtime-only, no WAL: a subscription carries no data of its own, so it is fully re-establishable and matches the gen-store runtime-only-state invariant). An ephemeral session (whose per-call `MCPClientPool` closes the connection immediately after the op returns) refuses both ops with a clear error rather than silently accept a subscription that can never observe a push.
+
+**Reconnect re-subscribes automatically.** A transport-death reconnect (the same F1 healing path `mcp`/`mcp_read_resource` use) opens a fresh `mcp.ClientSession`, which starts with no subscriptions of its own — `MCPConnectionService` re-issues `subscribe_resource` for every URI still tracked for that server immediately after the fresh connection opens, so a subscription survives a dropped transport transparently.
+
+**The push notification itself is an EventLog event, not a `control_ir_results` value.** When the server sends `notifications/resources/updated {uri}`, `reyn.mcp.message_handler.ReynMCPMessageHandler.on_resource_updated` emits an `mcp_resource_updated` event (`server`, `uri`) onto the session's `EventLog` — asynchronously, independent of any op call. This slice deliberately stops at the EventLog: wiring `mcp_resource_updated` into the hook dispatcher is a later (hooks-arc) slice. Re-reading subscribed resources on reconnect to catch updates missed while disconnected (a resync-READ, distinct from the re-**subscribe** above) is also a follow-up, not this slice.
+
+Advertised to the LLM under the chat-tool names `subscribe_mcp_resource` / `unsubscribe_mcp_resource` — same alias pattern as `mcp`/`call_mcp_tool`.
 
 ## `mcp_install`
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -114,6 +114,10 @@ from . import mcp_install as _mcp_install  # noqa: F401, E402
 
 # #2597 slice ②a: mcp_read_resource — permission-gated resource read (mirrors mcp.py).
 from . import mcp_read_resource as _mcp_read_resource  # noqa: F401, E402
+
+# #2597 slice ②b: resource subscriptions — subscribe/unsubscribe (mirrors mcp_read_resource.py).
+from . import mcp_subscribe_resource as _mcp_subscribe_resource  # noqa: F401, E402
+from . import mcp_unsubscribe_resource as _mcp_unsubscribe_resource  # noqa: F401, E402
 from . import recall as _recall  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 

--- a/src/reyn/core/op_runtime/mcp_subscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_subscribe_resource.py
@@ -1,0 +1,91 @@
+"""mcp_subscribe_resource kind handler — subscribe to a resource's
+``resources/updated`` push notifications on a configured MCP server.
+
+#2597 slice ②b (resource subscriptions). Mirrors
+``op_runtime/mcp_read_resource.py`` exactly: same server-config resolution,
+same ``MCPGateway`` seam, same ``require_mcp`` permission gate (server-scoped —
+subscribing is a stateful action against the server, gated identically to a
+read), and the same before/after event pair shape.
+
+Requires ``ctx.mcp_connection_service`` specifically (not ``ctx.mcp_pool``) —
+a subscription is only meaningful on a HELD (persistent) connection; the
+session-level caller (``session.py``'s ``_mcp_subscribe_resource``) already
+refuses this op for an ephemeral session before an ``Op`` is even built, but
+this handler re-checks defensively (an ``OpContext`` built any other way with
+only ``mcp_pool`` set must not silently "succeed" a subscribe that dies the
+instant the one-shot pool closes).
+
+The push notification itself lands as an ``mcp_resource_updated`` EventLog
+event via ``reyn.mcp.message_handler.ReynMCPMessageHandler.on_resource_updated``
+— NOT as this op's return value, which only confirms the subscribe request
+itself succeeded.
+"""
+from __future__ import annotations
+
+from reyn.schemas.models import MCPSubscribeResourceIROp
+
+from . import register
+from .context import OpContext
+
+
+async def _execute(op: MCPSubscribeResourceIROp, ctx: OpContext) -> dict:
+    from reyn.mcp.client import expand_env
+    from reyn.mcp.gateway import MCPFault, MCPGateway
+
+    server_cfg = ctx.mcp_servers.get(op.server)
+    if not server_cfg:
+        return {
+            "kind": "mcp_subscribe_resource", "status": "error",
+            "error": f"MCP server '{op.server}' is not configured. "
+                     f"Add it under mcp.servers in reyn.yaml or reyn.local.yaml.",
+        }
+
+    expanded = expand_env(server_cfg)
+    if not isinstance(expanded, dict):
+        return {"kind": "mcp_subscribe_resource", "status": "error",
+                "error": f"MCP server '{op.server}' config must be a dict."}
+
+    if "type" not in expanded and expanded.get("url"):
+        expanded = {**expanded, "type": "http"}
+
+    if ctx.mcp_connection_service is None:
+        return {
+            "kind": "mcp_subscribe_resource", "status": "error", "server": op.server,
+            "uri": op.uri,
+            "error": "MCP resource subscriptions require a held (persistent) "
+                     "connection — no MCPConnectionService on this context.",
+        }
+
+    ctx.events.emit("mcp_resource_subscribe", server=op.server, uri=op.uri)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id)
+    try:
+        await gateway.subscribe_resource(op.server, op.uri, expanded)
+    except MCPFault as fault_exc:
+        fault = str(fault_exc)
+        ctx.events.emit(
+            "mcp_resource_subscribe_failed", server=op.server, uri=op.uri, error=fault,
+        )
+        return {"kind": "mcp_subscribe_resource", "status": "error", "server": op.server,
+                "uri": op.uri, "error": fault}
+
+    ctx.events.emit("mcp_resource_subscribed", server=op.server, uri=op.uri)
+    return {
+        "kind": "mcp_subscribe_resource",
+        "status": "ok",
+        "server": op.server,
+        "uri": op.uri,
+    }
+
+
+async def handle(op: MCPSubscribeResourceIROp, ctx: OpContext) -> dict:
+    if ctx.permission_resolver is not None:
+        if ctx.intervention_bus is None:
+            raise RuntimeError("mcp_subscribe_resource op requires intervention_bus on OpContext")
+        await ctx.permission_resolver.require_mcp(
+            ctx.permission_decl, op.server, ctx.intervention_bus,
+            contextual=ctx.contextual_permission,
+        )
+    return await _execute(op, ctx)
+
+
+register("mcp_subscribe_resource", handle)

--- a/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
@@ -1,0 +1,75 @@
+"""mcp_unsubscribe_resource kind handler — inverse of mcp_subscribe_resource.
+
+#2597 slice ②b. Mirrors ``op_runtime/mcp_subscribe_resource.py`` exactly —
+see that module's docstring for the full rationale (persistent-connection
+requirement, permission gate, event shape).
+"""
+from __future__ import annotations
+
+from reyn.schemas.models import MCPUnsubscribeResourceIROp
+
+from . import register
+from .context import OpContext
+
+
+async def _execute(op: MCPUnsubscribeResourceIROp, ctx: OpContext) -> dict:
+    from reyn.mcp.client import expand_env
+    from reyn.mcp.gateway import MCPFault, MCPGateway
+
+    server_cfg = ctx.mcp_servers.get(op.server)
+    if not server_cfg:
+        return {
+            "kind": "mcp_unsubscribe_resource", "status": "error",
+            "error": f"MCP server '{op.server}' is not configured. "
+                     f"Add it under mcp.servers in reyn.yaml or reyn.local.yaml.",
+        }
+
+    expanded = expand_env(server_cfg)
+    if not isinstance(expanded, dict):
+        return {"kind": "mcp_unsubscribe_resource", "status": "error",
+                "error": f"MCP server '{op.server}' config must be a dict."}
+
+    if "type" not in expanded and expanded.get("url"):
+        expanded = {**expanded, "type": "http"}
+
+    if ctx.mcp_connection_service is None:
+        return {
+            "kind": "mcp_unsubscribe_resource", "status": "error", "server": op.server,
+            "uri": op.uri,
+            "error": "MCP resource subscriptions require a held (persistent) "
+                     "connection — no MCPConnectionService on this context.",
+        }
+
+    ctx.events.emit("mcp_resource_unsubscribe", server=op.server, uri=op.uri)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id)
+    try:
+        await gateway.unsubscribe_resource(op.server, op.uri, expanded)
+    except MCPFault as fault_exc:
+        fault = str(fault_exc)
+        ctx.events.emit(
+            "mcp_resource_unsubscribe_failed", server=op.server, uri=op.uri, error=fault,
+        )
+        return {"kind": "mcp_unsubscribe_resource", "status": "error", "server": op.server,
+                "uri": op.uri, "error": fault}
+
+    ctx.events.emit("mcp_resource_unsubscribed", server=op.server, uri=op.uri)
+    return {
+        "kind": "mcp_unsubscribe_resource",
+        "status": "ok",
+        "server": op.server,
+        "uri": op.uri,
+    }
+
+
+async def handle(op: MCPUnsubscribeResourceIROp, ctx: OpContext) -> dict:
+    if ctx.permission_resolver is not None:
+        if ctx.intervention_bus is None:
+            raise RuntimeError("mcp_unsubscribe_resource op requires intervention_bus on OpContext")
+        await ctx.permission_resolver.require_mcp(
+            ctx.permission_decl, op.server, ctx.intervention_bus,
+            contextual=ctx.contextual_permission,
+        )
+    return await _execute(op, ctx)
+
+
+register("mcp_unsubscribe_resource", handle)

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -509,7 +509,7 @@ class MCPClient:
             _classify_and_raise(exc, f"MCP tools/list error: {exc}")
         return [_tool_to_dict(t) for t in tools]
 
-    # ── resources (#2597 slice ②a — consumption only; subscribe is ②b) ─────────
+    # ── resources (#2597 slice ②a — consumption; ②b adds subscribe below) ──────
 
     async def list_resources(self) -> list[dict[str, Any]]:
         """Return the resources advertised by this server as plain dicts.
@@ -556,6 +556,70 @@ class MCPClient:
         except Exception as exc:
             _classify_and_raise(exc, f"MCP resources/read error: {exc}")
         return _read_resource_result_to_dict(result)
+
+    # ── resource subscriptions (#2597 slice ②b) ─────────────────────────────────
+
+    def _require_resources_subscribe_capability(self) -> None:
+        """Fail fast with :class:`MCPCapabilityError` if the connected server
+        does not advertise the ``resources.subscribe`` sub-capability.
+
+        Verified against the installed mcp SDK 3.4.2's ``ServerCapabilities``:
+        ``resources: ResourcesCapability | None`` where ``ResourcesCapability``
+        carries its OWN ``subscribe: bool | None`` field, independent of whether
+        the server advertises ``resources`` at all (a server may support reading
+        resources but not subscribing to their updates — the base SDK's
+        ``mcp.server.lowlevel.server.Server.get_capabilities`` in fact hard-codes
+        ``subscribe=False`` for every server that doesn't explicitly override it,
+        including every server built with FastMCP's high-level ``FastMCP()``
+        class — see ``tests/_support/mcp_subscribable_resources_server.py``'s
+        module docstring for the full fact-check). This is a REFUSAL, the same
+        shape as :func:`require_capability` — not a transport failure.
+        """
+        server = self.server_name or "<unknown>"
+        version = self.negotiated_version or "<unknown>"
+        resources_cap = getattr(self._server_capabilities, "resources", None)
+        if resources_cap is None or not getattr(resources_cap, "subscribe", False):
+            raise MCPCapabilityError(
+                f"MCP server {server!r} does not advertise the resources.subscribe "
+                f"sub-capability (negotiated protocol version {version}). Refusing "
+                f"to subscribe to a resource on it."
+            )
+
+    async def subscribe_resource(self, uri: str) -> None:
+        """Subscribe to server-pushed ``notifications/resources/updated`` for
+        ``uri``. Gated on BOTH the ``resources`` capability (via
+        :func:`require_capability`, same as :meth:`read_resource`) AND the
+        resources ``subscribe`` sub-capability (via
+        :meth:`_require_resources_subscribe_capability`) — a server may support
+        reading resources without supporting subscriptions to them.
+
+        Uses the RAW ``mcp.ClientSession.subscribe_resource`` (verified: FastMCP's
+        ``Client`` has no subscribe convenience method of its own — only the
+        underlying ``mcp.ClientSession``, reached via ``Client.session``, does).
+        The notification itself carries no payload (just ``uri``) — callers
+        re-read the resource to see the new content; see
+        :mod:`reyn.mcp.message_handler`'s ``on_resource_updated`` for the
+        EventLog bridge.
+        """
+        await self.initialize()
+        require_capability(self, "resources")
+        self._require_resources_subscribe_capability()
+        try:
+            await self._client.session.subscribe_resource(uri)
+        except Exception as exc:
+            _classify_and_raise(exc, f"MCP resources/subscribe error: {exc}")
+
+    async def unsubscribe_resource(self, uri: str) -> None:
+        """Unsubscribe from server-pushed updates for ``uri``. Same gating as
+        :meth:`subscribe_resource`; mirrors it via the raw
+        ``mcp.ClientSession.unsubscribe_resource``."""
+        await self.initialize()
+        require_capability(self, "resources")
+        self._require_resources_subscribe_capability()
+        try:
+            await self._client.session.unsubscribe_resource(uri)
+        except Exception as exc:
+            _classify_and_raise(exc, f"MCP resources/unsubscribe error: {exc}")
 
     async def close(self) -> None:
         """Tear down the transport and session. Safe to call repeatedly."""

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -71,6 +71,21 @@ receive loop running, so server-pushed notifications (tools/prompts ``list_chang
 behaviour) are threaded down to a per-server :class:`~reyn.mcp.message_handler.
 ReynMCPMessageHandler` built fresh each time :meth:`_ensure_open` opens (or reopens, on
 reconnect) a held client — see that module for the notification->EventLog bridge design.
+
+#2597 slice ②b — resource subscriptions (Q4, decided, do not relitigate): the
+subscribed-URI set is RUNTIME-ONLY, in-memory, per server, held on THIS service
+(``self._subscriptions``) — never WAL'd. A subscription carries no data of its own (MCP's
+resources/subscribe is a thin "something changed, re-read if you care" signal, not a
+message queue — see ``reyn.mcp.client.MCPClient.subscribe_resource``'s docstring), so it
+is fully re-establishable and matches the gen-store runtime-only-state invariant. The
+consequence: a fresh session (post-restart) starts with NO subscriptions (same as a fresh
+``MCPClient`` starts with none), and a RECONNECT within the same live session (the F1
+transport-death path) must explicitly RE-ISSUE ``subscribe_resource`` for every URI
+tracked for that server on the fresh client — a brand-new ``mcp.ClientSession`` has no
+memory of what the OLD (now-dead) session's client subscribed to. :meth:`_ensure_open`
+does this re-subscribe immediately after opening a NEW client (whether that is the very
+first open, where the tracked set is empty and the loop is a no-op, or a reconnect, where
+it is the whole point) — see that method's inline comment.
 """
 from __future__ import annotations
 
@@ -114,6 +129,13 @@ class MCPConnectionService:
         self._emit_sink = emit_sink
         self._tools_cache_invalidate = tools_cache_invalidate
         self._clients: dict[str, MCPClient] = {}
+        # #2597 slice ②b: runtime-only, in-memory, NO WAL (Q4 — see module docstring).
+        # server name -> set of URIs currently subscribed on that server's held
+        # connection. Populated by _HeldConnection.subscribe_resource on success,
+        # discarded by unsubscribe_resource, and consulted by _ensure_open to
+        # re-subscribe every tracked URI on a fresh client (first open: empty, no-op;
+        # reconnect: the whole point).
+        self._subscriptions: dict[str, set[str]] = {}
         # One handle per server, cached so repeated get() calls for the same server
         # return the SAME object (connection-reuse identity) across the connection's
         # whole lifetime, including through a reconnect: the handle looks up the
@@ -194,6 +216,24 @@ class MCPConnectionService:
                     negotiated_version=client.negotiated_version,
                     capabilities=client.advertised_capabilities(),
                 )
+            # #2597 slice ②b: re-issue subscribe_resource for every URI tracked for
+            # THIS server on the fresh client. On the very first open the tracked set
+            # is empty (nothing to do yet); on a reconnect (this same branch runs
+            # because the dead client was already popped from self._clients by
+            # _reconnect below) this is what makes a subscription survive a
+            # transport-death reconnect — a brand-new mcp.ClientSession has no
+            # memory of what the OLD session subscribed to. Per-URI try/except: a
+            # server that no longer supports subscribe post-reconnect (or a single
+            # bad URI) must not abort re-subscribing the REST of the tracked set,
+            # and must not crash the reconnect itself.
+            for uri in self._subscriptions.get(server, ()):
+                try:
+                    await client.subscribe_resource(uri)
+                except Exception:  # noqa: BLE001 — one bad re-subscribe must not block the rest
+                    logger.warning(
+                        "MCPConnectionService: failed to re-subscribe %r on %r after "
+                        "(re)connect", uri, server, exc_info=True,
+                    )
         return client
 
     async def _reconnect(
@@ -214,6 +254,18 @@ class MCPConnectionService:
                     server, exc,
                 )
         return await self._ensure_open(server, config, agent_id=agent_id)
+
+    def subscribed_uris(self, server: str) -> list[str]:
+        """Sorted list of URIs currently tracked as subscribed for ``server``.
+        Read-only introspection for callers/tests (mirrors :meth:`held_servers`'s
+        public-surface pattern) — never reach into ``_subscriptions`` directly."""
+        return sorted(self._subscriptions.get(server, ()))
+
+    def _track_subscription(self, server: str, uri: str) -> None:
+        self._subscriptions.setdefault(server, set()).add(uri)
+
+    def _untrack_subscription(self, server: str, uri: str) -> None:
+        self._subscriptions.get(server, set()).discard(uri)
 
     async def aclose(self) -> None:
         """Close every held connection. Idempotent — safe to call repeatedly (e.g. a
@@ -244,7 +296,8 @@ class _HeldConnection:
     :meth:`MCPConnectionService.get`. Exposes exactly the surface
     :class:`~reyn.mcp.gateway.MCPGateway` calls (``call_tool`` / ``list_tools`` /
     ``list_resources`` / ``list_resource_templates`` / ``read_resource`` /
-    ``is_initialized``) so it's usable anywhere a bare ``MCPClient`` is expected.
+    ``subscribe_resource`` / ``unsubscribe_resource`` / ``is_initialized``) so it's
+    usable anywhere a bare ``MCPClient`` is expected.
 
     Looks up the currently-live held ``MCPClient`` by server name on every call
     instead of binding to one instance at construction time, so this handle's
@@ -307,6 +360,23 @@ class _HeldConnection:
 
     async def read_resource(self, uri: str) -> dict[str, Any]:
         return await self._heal(lambda c: c.read_resource(uri), heal_only=False)
+
+    # #2597 slice ②b: resource subscriptions. Unlike call_tool, subscribe/unsubscribe
+    # are connection-MANAGEMENT operations, not data reads — but they still go through
+    # _heal (heal_only=False) rather than a bespoke path: if the connection is dead,
+    # heal reconnects it (which — via MCPConnectionService._ensure_open — re-issues
+    # subscribe for every ALREADY-tracked URI, but NOT this one, since it is only
+    # tracked below AFTER the call succeeds) and then _heal's heal_only=False retries
+    # THIS call once on the fresh connection. That sequencing is what avoids a double
+    # subscribe: the reconnect's re-subscribe loop and this method's own retry never
+    # target the same URI in the same pass.
+    async def subscribe_resource(self, uri: str) -> None:
+        await self._heal(lambda c: c.subscribe_resource(uri), heal_only=False)
+        self._service._track_subscription(self._server, uri)
+
+    async def unsubscribe_resource(self, uri: str) -> None:
+        await self._heal(lambda c: c.unsubscribe_resource(uri), heal_only=False)
+        self._service._untrack_subscription(self._server, uri)
 
     async def _heal(
         self, op: "Callable[[MCPClient], Awaitable[Any]]", *, heal_only: bool,

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -157,6 +157,28 @@ class MCPGateway:
         return await self._run(server, config, lambda c: c.read_resource(uri),
                                timeout=resolve_call_timeout(config))
 
+    async def subscribe_resource(self, server: str, uri: str, config: dict) -> None:
+        """Subscribe to server-pushed ``resources/updated`` for ``uri``. Raises
+        :class:`MCPFault` on any contained fault (mirrors :meth:`read_resource`).
+
+        #2597 slice ②b: the injected pool MUST be a
+        :class:`~reyn.mcp.connection_service.MCPConnectionService` (a HELD
+        connection) for a subscription to be meaningful — see
+        ``session.py``'s ``_mcp_subscribe_resource`` docstring, which refuses
+        the call before it ever reaches here for an ephemeral (one-shot-pool)
+        session. This method itself doesn't re-check that (the gateway is a
+        thin dispatch seam, not a policy seam) — it just runs the op against
+        whatever pool the caller injected.
+        """
+        return await self._run(server, config, lambda c: c.subscribe_resource(uri),
+                               timeout=resolve_call_timeout(config))
+
+    async def unsubscribe_resource(self, server: str, uri: str, config: dict) -> None:
+        """Unsubscribe from ``uri``. Raises :class:`MCPFault` on any contained
+        fault (mirrors :meth:`subscribe_resource`)."""
+        return await self._run(server, config, lambda c: c.unsubscribe_resource(uri),
+                               timeout=resolve_call_timeout(config))
+
     async def probe(self, server: str, config: dict) -> None:
         """Open the server (MCP initialize handshake) to verify reachability, then release it.
         Returns None on success; raises :class:`MCPFault` if the server cannot be reached/opened."""

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -75,9 +75,12 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
     ``EventLog`` (#2597 S2b). One instance per held server connection.
 
     Scope (S2b): ``tools/list_changed``, ``prompts/list_changed``. ``resources/
-    updated`` / ``resources/subscribe`` are DEFERRED to the resources-consumption
-    slice (nothing is subscribed yet) — the inherited ``on_resource_updated`` /
-    ``on_resource_list_changed`` stay base-class no-ops.
+    updated`` is bridged by slice ②b (see :meth:`on_resource_updated`) now that
+    :class:`~reyn.mcp.connection_service.MCPConnectionService` actually tracks
+    subscribed URIs — S2b itself deferred it because nothing was subscribed yet.
+    ``on_resource_list_changed`` stays a base-class no-op (out of ②b's scope —
+    no reyn caller subscribes to the resource LIST changing, only individual
+    resource content updates).
 
     #2597 F2 (live-verified, NOT emitted here — see :meth:`on_progress`):
     ``notifications/progress`` is NOT bridged to ``mcp_progress`` by this handler.
@@ -145,6 +148,18 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
     async def on_prompt_list_changed(self, message: Any) -> None:
         self._emit("mcp_prompt_list_changed", server=self._server_name)
         await super().on_prompt_list_changed(message)
+
+    async def on_resource_updated(self, message: Any) -> None:
+        # #2597 slice ②b: the async push event-source this bridge exists for. The
+        # notification carries ONLY the uri (MCP's resources/subscribe model is a
+        # thin "something changed, re-read if you care" signal — see
+        # reyn.mcp.client.MCPClient.subscribe_resource's docstring), so that's all
+        # this event needs to carry too; a caller that wants the new content reads
+        # the resource again. EventLog-only — deliberately NOT wired into the hook
+        # dispatcher here (that's a future hooks-arc slice, per ②b's scope note).
+        uri = getattr(getattr(message, "params", None), "uri", None)
+        self._emit("mcp_resource_updated", server=self._server_name, uri=str(uri) if uri is not None else None)
+        await super().on_resource_updated(message)
 
     async def on_progress(self, message: Any) -> None:
         # #2597 F2: deliberately does NOT emit ``mcp_progress`` — see this class's

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -722,6 +722,13 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     async def mcp_read_resource(self, server: str, uri: str) -> dict: ...
 
+    # #2597 slice ②b: resource subscriptions (subscribe/unsubscribe — the async
+    # push event-source; the resulting notifications land on the EventLog as
+    # mcp_resource_updated, not through this Protocol).
+    async def mcp_subscribe_resource(self, server: str, uri: str) -> dict: ...
+
+    async def mcp_unsubscribe_resource(self, server: str, uri: str) -> dict: ...
+
     # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
     # Builds a permission-aware OpContext with the operator-declared
     # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -81,6 +81,10 @@ class RouterHostAdapter:
         Async callback ``(server: str) -> list[dict]`` (#2597 slice ②a).
     mcp_read_resource:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②a).
+    mcp_subscribe_resource:
+        Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
+    mcp_unsubscribe_resource:
+        Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -134,6 +138,10 @@ class RouterHostAdapter:
         mcp_list_resources: "Callable[..., Awaitable[list]] | None" = None,
         mcp_list_resource_templates: "Callable[..., Awaitable[list]] | None" = None,
         mcp_read_resource: "Callable[..., Awaitable[dict]] | None" = None,
+        # #2597 slice ②b: resource subscriptions — same None-default /
+        # getattr-guard pattern as the ②a resources callbacks above.
+        mcp_subscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
+        mcp_unsubscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
         # Action callbacks
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
@@ -354,6 +362,8 @@ class RouterHostAdapter:
         self._mcp_list_resources_cb = mcp_list_resources
         self._mcp_list_resource_templates_cb = mcp_list_resource_templates
         self._mcp_read_resource_cb = mcp_read_resource
+        self._mcp_subscribe_resource_cb = mcp_subscribe_resource
+        self._mcp_unsubscribe_resource_cb = mcp_unsubscribe_resource
         # Action callbacks
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
@@ -1400,6 +1410,18 @@ class RouterHostAdapter:
         if self._mcp_read_resource_cb is None:
             return {"status": "error", "error": "mcp resource read is not wired on this host"}
         return await self._mcp_read_resource_cb(server, uri)
+
+    # #2597 slice ②b: resource subscriptions. Same getattr-guarded-callback
+    # pattern as the ②a resources methods above.
+    async def mcp_subscribe_resource(self, server: str, uri: str) -> dict:
+        if self._mcp_subscribe_resource_cb is None:
+            return {"status": "error", "error": "mcp resource subscribe is not wired on this host"}
+        return await self._mcp_subscribe_resource_cb(server, uri)
+
+    async def mcp_unsubscribe_resource(self, server: str, uri: str) -> dict:
+        if self._mcp_unsubscribe_resource_cb is None:
+            return {"status": "error", "error": "mcp resource unsubscribe is not wired on this host"}
+        return await self._mcp_unsubscribe_resource_cb(server, uri)
 
     # --- Model resolution ---
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1536,6 +1536,9 @@ class Session:
             mcp_list_resources=self._mcp_list_resources,
             mcp_list_resource_templates=self._mcp_list_resource_templates,
             mcp_read_resource=self._mcp_read_resource,
+            # #2597 slice ②b: resource subscriptions.
+            mcp_subscribe_resource=self._mcp_subscribe_resource,
+            mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -5596,6 +5599,75 @@ class Session:
         async with MCPClientPool() as pool:
             ctx.mcp_pool = pool
             return await execute_op(op, ctx)
+
+    async def _mcp_subscribe_resource(self, server: str, uri: str) -> dict:
+        """Subscribe to server-pushed ``resources/updated`` for ``uri`` on
+        ``server``. #2597 slice ②b: mirrors ``_mcp_read_resource`` — permission-
+        gated (``require_mcp``, same server-scoped axis) + routed through
+        ``execute_op`` on the ``mcp_subscribe_resource`` op kind.
+
+        Unlike ``_mcp_read_resource``, a subscription is only meaningful on a
+        PERSISTENT connection — the subscribed-URI set lives on
+        ``MCPConnectionService`` (runtime-only, Q4) and the push notification
+        arrives asynchronously, sometime after this call returns. An ephemeral
+        session's per-call ``MCPClientPool`` closes the connection before this
+        method even returns, so a "successful" subscribe there could never
+        actually observe a push — refuse fast with a clear error instead of a
+        silently-useless no-op subscription.
+        """
+        if self._ephemeral:
+            return {
+                "kind": "mcp_subscribe_resource", "status": "error", "server": server,
+                "uri": uri,
+                "error": "MCP resource subscriptions require a persistent connection "
+                         "(not available in an ephemeral session).",
+            }
+        from reyn.core.op_runtime import execute_op
+        from reyn.schemas.models import MCPSubscribeResourceIROp
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server=server, uri=uri)
+        ctx = self._make_router_op_context()
+        ctx.intervention_bus = ChatInterventionBus(
+            self, run_id=None, actor="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+        ctx.permission_decl = PermissionDecl(
+            file_read=ctx.permission_decl.file_read,
+            file_write=ctx.permission_decl.file_write,
+            mcp=[server],
+        )
+        ctx.mcp_connection_service = self._mcp_connection_service
+        return await execute_op(op, ctx)
+
+    async def _mcp_unsubscribe_resource(self, server: str, uri: str) -> dict:
+        """Unsubscribe from server-pushed updates for ``uri`` on ``server``.
+        Mirrors :meth:`_mcp_subscribe_resource` — same persistent-connection
+        requirement, same permission gate."""
+        if self._ephemeral:
+            return {
+                "kind": "mcp_unsubscribe_resource", "status": "error", "server": server,
+                "uri": uri,
+                "error": "MCP resource subscriptions require a persistent connection "
+                         "(not available in an ephemeral session).",
+            }
+        from reyn.core.op_runtime import execute_op
+        from reyn.schemas.models import MCPUnsubscribeResourceIROp
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        op = MCPUnsubscribeResourceIROp(kind="mcp_unsubscribe_resource", server=server, uri=uri)
+        ctx = self._make_router_op_context()
+        ctx.intervention_bus = ChatInterventionBus(
+            self, run_id=None, actor="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+        ctx.permission_decl = PermissionDecl(
+            file_read=ctx.permission_decl.file_read,
+            file_write=ctx.permission_decl.file_write,
+            mcp=[server],
+        )
+        ctx.mcp_connection_service = self._mcp_connection_service
+        return await execute_op(op, ctx)
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Invoke an MCP tool and return its result.

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -127,6 +127,27 @@ class MCPReadResourceIROp(BaseModel):
     uri: str
 
 
+class MCPSubscribeResourceIROp(BaseModel):
+    """#2597 slice ②b: subscribe to server-pushed ``resources/updated`` for one
+    URI on a configured MCP server. Permission-gated like ``MCPReadResourceIROp``
+    (same server-scoped ``require_mcp`` axis — subscribing is a stateful action
+    against the server, gated the same way a read is). The push notification
+    itself lands as an ``mcp_resource_updated`` EventLog event (see
+    ``reyn.mcp.message_handler.ReynMCPMessageHandler.on_resource_updated``), not
+    as this op's return value — this op only confirms the subscribe request
+    succeeded."""
+    kind: Literal["mcp_subscribe_resource"]
+    server: str
+    uri: str
+
+
+class MCPUnsubscribeResourceIROp(BaseModel):
+    """#2597 slice ②b: inverse of ``MCPSubscribeResourceIROp``."""
+    kind: Literal["mcp_unsubscribe_resource"]
+    server: str
+    uri: str
+
+
 class AskUserIROp(BaseModel):
     kind: Literal["ask_user"]
     question: str
@@ -550,6 +571,12 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # content); list/list-templates stay op-kind-free, mirroring list_tools (see
     # op_runtime/mcp_read_resource.py + session.py's _mcp_list_resources).
     "mcp_read_resource": MCPReadResourceIROp,
+    # #2597 slice ②b: resource subscriptions — subscribe/unsubscribe are
+    # permission-gated the same way read is (stateful action against the
+    # server); the resulting push notification is an EventLog event
+    # (mcp_resource_updated), not routed through the Op union at all.
+    "mcp_subscribe_resource": MCPSubscribeResourceIROp,
+    "mcp_unsubscribe_resource": MCPUnsubscribeResourceIROp,
     "ask_user":    AskUserIROp,
     "web_fetch":   WebFetchIROp,
     "web_search":  WebSearchIROp,
@@ -598,7 +625,9 @@ if TYPE_CHECKING:
             FileIROp,
             ReadFileIROp, WriteFileIROp, EditFileIROp, DeleteFileIROp,
             GlobFilesIROp, GrepFilesIROp,
-            MCPIROp, MCPReadResourceIROp, AskUserIROp,
+            MCPIROp, MCPReadResourceIROp,
+            MCPSubscribeResourceIROp, MCPUnsubscribeResourceIROp,
+            AskUserIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,
             IndexQueryIROp, RecallIROp, IndexDropIROp,

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -72,6 +72,8 @@ def get_default_registry() -> ToolRegistry:
         LIST_MCP_SERVERS,
         LIST_MCP_TOOLS,
         READ_MCP_RESOURCE,
+        SUBSCRIBE_MCP_RESOURCE,
+        UNSUBSCRIBE_MCP_RESOURCE,
     )
     from reyn.tools.mcp_drop import MCP_DROP_SERVER_OP
     from reyn.tools.mcp_install import MCP_INSTALL_OP
@@ -157,6 +159,9 @@ def get_default_registry() -> ToolRegistry:
     registry.register(LIST_MCP_RESOURCES)
     registry.register(LIST_MCP_RESOURCE_TEMPLATES)
     registry.register(READ_MCP_RESOURCE)
+    # #2597 slice ②b: resource subscriptions.
+    registry.register(SUBSCRIBE_MCP_RESOURCE)
+    registry.register(UNSUBSCRIBE_MCP_RESOURCE)
     # Memory ops (Wave 2 — Type C closure: memory write phase-side)
     registry.register(LIST_MEMORY)
     registry.register(READ_MEMORY_BODY)

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -26,8 +26,14 @@ analogue):
                                 external-content + permission-gated shape)
   LIST_MCP_RESOURCE_TEMPLATES — gates.router=allow
 
-``resources/subscribe`` + ``resources/updated`` push notifications are OUT
-OF SCOPE (slice ②b) — these three are list/read only.
+#2597 slice ②b adds TWO more, parallel to the ②a set (the async push
+event-source itself — the resulting notification lands as an
+``mcp_resource_updated`` EventLog event, not through either of these):
+
+  SUBSCRIBE_MCP_RESOURCE    — gates.router=allow (permission-gated like
+                               READ_MCP_RESOURCE — a stateful action against
+                               the server)
+  UNSUBSCRIBE_MCP_RESOURCE  — gates.router=allow
 
 ## Router-side dispatch
 
@@ -203,6 +209,51 @@ _READ_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
 }
 
 
+# ── #2597 slice ②b: resource subscriptions parameters ─────────────────────────
+
+_SUBSCRIBE_MCP_RESOURCE_DESCRIPTION = (
+    "Subscribe to server-pushed updates for one MCP resource by URI. When the "
+    "server-side content changes, a mcp_resource_updated event is recorded — "
+    "call read_mcp_resource again to see the new content (the push notification "
+    "itself carries no content, just a signal that something changed)."
+)
+
+_SUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "uri": {
+            "type": "string",
+            "description": "Resource URI, verbatim from list_mcp_resources.",
+        },
+    },
+    "required": ["server", "uri"],
+}
+
+_UNSUBSCRIBE_MCP_RESOURCE_DESCRIPTION = (
+    "Unsubscribe from server-pushed updates for one MCP resource by URI "
+    "(previously subscribed via subscribe_mcp_resource)."
+)
+
+_UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "uri": {
+            "type": "string",
+            "description": "Resource URI, verbatim from list_mcp_resources.",
+        },
+    },
+    "required": ["server", "uri"],
+}
+
+
 # ── Handlers ──────────────────────────────────────────────────────────────────
 
 async def _handle_list_mcp_servers(
@@ -316,6 +367,34 @@ async def _handle_read_mcp_resource(
     server = str(args["server"])
     uri = str(args["uri"])
     return await host.mcp_read_resource(server, uri)
+
+
+async def _handle_subscribe_mcp_resource(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for subscribe_mcp_resource.
+
+    Delegates to host.mcp_subscribe_resource(server, uri) via ctx.router_state.
+    Mirrors _handle_read_mcp_resource's delegation shape; the persistent-
+    connection requirement + permission gate are enforced upstream (session.py
+    ``_mcp_subscribe_resource`` / the ``mcp_subscribe_resource`` op kind), not
+    here.
+    """
+    host = _require_host(ctx)
+    server = str(args["server"])
+    uri = str(args["uri"])
+    return await host.mcp_subscribe_resource(server, uri)
+
+
+async def _handle_unsubscribe_mcp_resource(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for unsubscribe_mcp_resource. Mirrors
+    _handle_subscribe_mcp_resource."""
+    host = _require_host(ctx)
+    server = str(args["server"])
+    uri = str(args["uri"])
+    return await host.mcp_unsubscribe_resource(server, uri)
 
 
 async def _handle_call_mcp_tool(
@@ -549,6 +628,35 @@ READ_MCP_RESOURCE = ToolDefinition(
     category="discovery",
     purity="read_only",  # a resource read has no reyn-side side effects (unlike call_mcp_tool)
     returns_external_content=True,  # FP-0050/#1822: external MCP server resource content
+    schema_enricher=_enrich_router_schema,
+)
+
+
+# ── #2597 slice ②b: resource subscriptions ToolDefinitions ────────────────────
+# Parallel to READ_MCP_RESOURCE above — same gates, same schema-enrichment
+# reuse (server enum only).
+
+SUBSCRIBE_MCP_RESOURCE = ToolDefinition(
+    name="subscribe_mcp_resource",
+    router_dispatched=True,
+    description=_SUBSCRIBE_MCP_RESOURCE_DESCRIPTION,
+    parameters=_SUBSCRIBE_MCP_RESOURCE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_subscribe_mcp_resource,
+    category="discovery",
+    purity="side_effect",  # registers server-side subscription state
+    schema_enricher=_enrich_router_schema,
+)
+
+UNSUBSCRIBE_MCP_RESOURCE = ToolDefinition(
+    name="unsubscribe_mcp_resource",
+    router_dispatched=True,
+    description=_UNSUBSCRIBE_MCP_RESOURCE_DESCRIPTION,
+    parameters=_UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_unsubscribe_mcp_resource,
+    category="discovery",
+    purity="side_effect",
     schema_enricher=_enrich_router_schema,
 )
 

--- a/tests/_support/mcp_subscribable_resources_server.py
+++ b/tests/_support/mcp_subscribable_resources_server.py
@@ -1,0 +1,127 @@
+"""Real MCP stdio server that supports ``resources/subscribe`` (#2597 slice ②b).
+
+Standalone script — run as a subprocess, never imported.
+
+Why this is a NEW low-level server, not the existing FastMCP-built
+``mcp_fastmcp_echo_server.py`` / ``mcp_resources_server.py`` doubles: the base
+``mcp`` SDK's ``mcp.server.lowlevel.server.Server.get_capabilities`` HARD-CODES
+``ResourcesCapability(subscribe=False, ...)`` whenever a ``ListResourcesRequest``
+handler is registered — regardless of whether ``SubscribeRequest``/
+``UnsubscribeRequest`` handlers are ALSO registered (verified by reading the
+installed mcp SDK source: ``resources_capability = types.ResourcesCapability(
+subscribe=False, listChanged=notification_options.resources_changed)`` — no
+branch anywhere sets ``subscribe=True``). FastMCP's own low-level subclass
+(``fastmcp.server.low_level.LowLevelServer.get_capabilities``) only patches
+``capabilities.tasks``/``capabilities.extensions`` on top of the base result —
+it never touches ``resources.subscribe`` either. Net effect: **no server built
+with FastMCP's high-level ``FastMCP()`` class can ever advertise
+``resources.subscribe=True``**, and slice ②b needs a REAL server that does (to
+prove ``MCPClient.subscribe_resource`` on a server that DOES support it, not
+just the already-covered fail-fast path against a server that doesn't).
+
+This module subclasses the LOW-LEVEL ``mcp.server.lowlevel.Server`` directly
+(the same base class FastMCP itself subclasses in ``fastmcp/server/low_level.py``)
+and overrides ``get_capabilities`` to flip ``resources.subscribe`` to True
+whenever a ``SubscribeRequest`` handler is registered — extending the SDK's own
+"derive capabilities from registered handlers" contract (already used for
+tools/prompts/resources ``listChanged``) to the one field the SDK's base
+implementation never sets. This is a real MCP server object, not a mock.
+
+Exposes:
+  - resource ``resource://counter`` — content is the current counter value.
+  - ``@app.subscribe_resource()`` / ``@app.unsubscribe_resource()`` — no-op
+    handlers (accepting the subscription is all a real server needs to do;
+    the interesting behaviour is the PUSH below).
+  - tool ``bump_and_notify()`` — increments the counter and pushes a REAL
+    ``notifications/resources/updated`` for ``resource://counter`` via
+    ``app.request_context.session.send_resource_updated(...)`` (the same raw
+    ``ServerSession`` API a real MCP server implementer would call).
+  - tool ``die()`` — kills the subprocess (transport-death simulation, mirrors
+    ``mcp_fastmcp_echo_server.py``'s ``die`` tool) so reconnect/re-subscribe
+    tests can simulate a genuine transport drop.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+_URI = "resource://counter"
+
+
+class _SubscribableServer(Server):
+    def get_capabilities(self, notification_options, experimental_capabilities):
+        capabilities = super().get_capabilities(notification_options, experimental_capabilities)
+        if types.SubscribeRequest in self.request_handlers and capabilities.resources is not None:
+            capabilities = capabilities.model_copy(
+                update={
+                    "resources": capabilities.resources.model_copy(update={"subscribe": True}),
+                }
+            )
+        return capabilities
+
+
+app = _SubscribableServer("reyn-test-subscribable-resources")
+
+_counter = {"value": 0}
+
+
+@app.list_resources()
+async def list_resources() -> list[types.Resource]:
+    return [types.Resource(uri=_URI, name="counter", mimeType="text/plain")]
+
+
+@app.read_resource()
+async def read_resource(uri) -> str:
+    return str(_counter["value"])
+
+
+@app.subscribe_resource()
+async def subscribe_resource(uri) -> None:
+    return None
+
+
+@app.unsubscribe_resource()
+async def unsubscribe_resource(uri) -> None:
+    return None
+
+
+@app.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="bump_and_notify",
+            description="Increment the counter resource and push a real "
+            "notifications/resources/updated for resource://counter.",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+        types.Tool(
+            name="die",
+            description="Kill the subprocess (transport-death simulation).",
+            inputSchema={"type": "object", "properties": {}},
+        ),
+    ]
+
+
+@app.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+    if name == "bump_and_notify":
+        _counter["value"] += 1
+        session = app.request_context.session
+        await session.send_resource_updated(types.AnyUrl(_URI))
+        return [types.TextContent(type="text", text=str(_counter["value"]))]
+    if name == "die":
+        os._exit(1)
+    raise ValueError(f"unknown tool {name!r}")
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -37,6 +37,8 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "list_mcp_servers", "list_mcp_tools", "call_mcp_tool", "describe_mcp_tool",
     # #2597 slice ②a: resources consumption — parallel to the tools surface above.
     "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
+    # #2597 slice ②b: resource subscriptions — the async push event-source.
+    "subscribe_mcp_resource", "unsubscribe_mcp_resource",
     "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
     "recall", "drop_source", "compact",
     "list_actions", "search_actions", "describe_action", "invoke_action",

--- a/tests/test_2597_s2b_resource_subscriptions.py
+++ b/tests/test_2597_s2b_resource_subscriptions.py
@@ -1,0 +1,469 @@
+"""Tests for #2597 slice ②b — MCP resource subscriptions.
+
+Real instances only, per the testing policy: no ``unittest.mock`` / ``MagicMock`` /
+``AsyncMock`` / ``patch``. The subscribe/push/reconnect tests spawn a REAL MCP
+server subprocess (``tests/_support/mcp_subscribable_resources_server.py`` — a
+low-level ``mcp.server.lowlevel.Server`` that actually advertises
+``resources.subscribe=True`` and pushes a REAL ``notifications/resources/updated``
+via ``ServerSession.send_resource_updated`` when its ``bump_and_notify`` tool is
+called) through a REAL ``MCPConnectionService`` (the held-connection production
+path — not a bare one-shot ``MCPGateway()``/``MCPClientPool``, per the ②a lesson
+that a held-handle-only method silently AttributeErrors against a bare pool).
+
+The fail-fast-without-subscribe-capability test uses the EXISTING
+``mcp_fastmcp_echo_server.py`` double: verified (see
+``mcp_subscribable_resources_server.py``'s module docstring) that the base mcp
+SDK hard-codes ``resources.subscribe=False`` for every server built with
+FastMCP's high-level ``FastMCP()`` class, so the echo server is a real
+"resources capability present, subscribe sub-capability absent" double without
+needing a new server for that case.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.mcp.client import MCPCapabilityError, MCPClient
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.mcp.gateway import MCPFault, MCPGateway
+from reyn.schemas.models import MCPSubscribeResourceIROp, MCPUnsubscribeResourceIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_URI = "resource://counter"
+
+
+class _UnusedBus(InterventionBus):
+    """A real InterventionBus that fails the test if ever actually invoked —
+    mirrors test_2597_s2a_mcp_resources_consumption.py's helper."""
+
+    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
+        raise AssertionError(f"intervention bus should not be consulted: {iv}")
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` until True or give up — the notification arrives
+    asynchronously on FastMCP/the SDK's receive loop, not synchronously with the
+    triggering call (mirrors test_2597_s2b_mcp_notifications_bridge.py's pattern)."""
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+# ── Tier 1: MCPClient — real subscribe/unsubscribe round-trip ─────────────────
+
+
+def test_subscribe_resource_succeeds_against_a_real_subscribable_server():
+    """Tier 1: MCPClient.subscribe_resource against a real server that
+    advertises resources.subscribe=True succeeds (no exception)."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_SUBSCRIBABLE_SERVER)) as client:
+            await client.subscribe_resource(_URI)
+            await client.unsubscribe_resource(_URI)
+
+    _run(_it())  # must not raise
+
+
+def test_subscribe_resource_fails_fast_without_subscribe_subcapability():
+    """Tier 1: the #2597 ②b gate blocks subscribe_resource against a real server
+    that advertises "resources" (list/read work) but NOT the subscribe
+    sub-capability — a clear MCPCapabilityError, not a raw protocol error."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_ECHO_SERVER), server_name="echo-srv",
+        ) as client:
+            await client.subscribe_resource("resource://pid")
+
+    with pytest.raises(MCPCapabilityError) as exc_info:
+        _run(_it())
+    message = str(exc_info.value)
+    assert "subscribe" in message
+    assert "echo-srv" in message
+
+
+def test_unsubscribe_resource_fails_fast_without_subscribe_subcapability():
+    """Tier 1: same gate for unsubscribe_resource."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_ECHO_SERVER), server_name="echo-srv",
+        ) as client:
+            await client.unsubscribe_resource("resource://pid")
+
+    with pytest.raises(MCPCapabilityError):
+        _run(_it())
+
+
+# ── Tier 2: MCPGateway pass-throughs ───────────────────────────────────────────
+
+
+def test_gateway_subscribe_and_unsubscribe_round_trip():
+    """Tier 2: MCPGateway.subscribe_resource/unsubscribe_resource run through
+    the same fault-contained seam as read_resource."""
+    gateway = MCPGateway()
+
+    async def _it():
+        await gateway.subscribe_resource("srv", _URI, _stdio_cfg(_SUBSCRIBABLE_SERVER))
+
+    _run(_it())  # must not raise
+
+
+def test_gateway_subscribe_raises_mcp_fault_on_ungated_server():
+    """Tier 2: the gateway surfaces the sub-capability-gate failure as
+    MCPFault (its ONE contained-fault type), never a bare MCPCapabilityError."""
+    gateway = MCPGateway()
+
+    async def _it():
+        await gateway.subscribe_resource("echo-srv", "resource://pid", _stdio_cfg(_ECHO_SERVER))
+
+    with pytest.raises(MCPFault):
+        _run(_it())
+
+
+# ── Tier 2: held connection — subscribe -> real server push -> EventLog event ──
+
+
+@pytest.mark.asyncio
+async def test_held_connection_subscribe_receives_real_push_as_event():
+    """Tier 2: the CORE ②b coverage. A REAL subscribe through a REAL
+    MCPConnectionService (the production held-connection path), then a REAL
+    server-triggered notifications/resources/updated push lands as an
+    mcp_resource_updated event on the session's EventLog — proving the whole
+    chain (MCPClient.subscribe_resource -> ReynMCPMessageHandler.
+    on_resource_updated -> emit_sink -> EventLog) end to end."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+        assert service.subscribed_uris("srv") == [_URI]
+
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+        )
+
+        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        (only_event,) = matching  # exactly one push for one bump_and_notify call
+        assert only_event.data.get("server") == "srv"
+        assert only_event.data.get("uri") == _URI
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_held_connection_unsubscribe_untracks_uri():
+    """Tier 2: unsubscribe_resource removes the URI from the service's tracked
+    set (public introspection surface — subscribed_uris — never private state)."""
+    service = MCPConnectionService()
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+        assert service.subscribed_uris("srv") == [_URI]
+
+        await client.unsubscribe_resource(_URI)
+        assert service.subscribed_uris("srv") == []
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_subscription_survives_transport_death_reconnect():
+    """Tier 2: THE core ②b resilience proof. Subscribe, kill the subprocess
+    (genuine transport death -> F1 heal), then a server-side push on the FRESH
+    (reconnected) connection still produces an mcp_resource_updated event —
+    proving MCPConnectionService re-issued the subscribe against the new
+    mcp.ClientSession (which otherwise has no memory of the old session's
+    subscriptions)."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        # Genuine transport death: the server's "die" tool os._exit()s mid-call, so
+        # this call itself fails with MCPError (its response never arrives) — that
+        # is the expected shape, not a test bug (mirrors mcp_fastmcp_echo_server.py's
+        # "die" tool usage in test_2597_f1_heal_transport_classifier.py).
+        from reyn.mcp.client import MCPError
+
+        with pytest.raises(MCPError):
+            await client.call_tool("die", {})
+
+        # The NEXT call against the held handle triggers _heal -> reconnect, which
+        # (per _ensure_open's re-subscribe loop) re-issues subscribe_resource for
+        # every URI this test tracked BEFORE re-running the call itself.
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+        )
+        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        assert matching, (
+            "a server-side push on the RECONNECTED session produced no "
+            "mcp_resource_updated event — the subscription did not survive the "
+            "transport-death reconnect"
+        )
+        assert service.subscribed_uris("srv") == [_URI], (
+            "the tracked subscription set itself must also survive the reconnect"
+        )
+    finally:
+        await service.aclose()
+
+
+# ── Tier 2: op_runtime mcp_subscribe_resource / mcp_unsubscribe_resource ──────
+
+
+def _make_ctx(
+    events: EventLog,
+    *,
+    resolver: "PermissionResolver | None",
+    decl: "PermissionDecl | None" = None,
+    connection_service=None,
+) -> OpContext:
+    ctx = OpContext(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_decl=decl or PermissionDecl(),
+        permission_resolver=resolver,
+        mcp_servers={"srv": _stdio_cfg(_SUBSCRIBABLE_SERVER)},
+        actor="chat_router",
+    )
+    ctx.mcp_connection_service = connection_service
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_subscribe_execute_requires_connection_service():
+    """Tier 2: the op handler refuses (status='error', never raises) when
+    ctx.mcp_connection_service is None — a subscription without a persistent
+    connection can never observe a push, so it must not silently "succeed"."""
+    from reyn.core.op_runtime.mcp_subscribe_resource import _execute
+
+    events = EventLog()
+    op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
+    ctx = _make_ctx(events, resolver=None, connection_service=None)
+
+    result = await _execute(op, ctx)
+    assert result["status"] == "error"
+    assert "persistent" in result["error"] or "held" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_execute_real_subscribe_and_emits_events():
+    """Tier 2: _execute (permission bypassed) subscribes through a REAL
+    MCPConnectionService and emits mcp_resource_subscribe + _subscribed."""
+    from reyn.core.op_runtime.mcp_subscribe_resource import _execute
+
+    events = EventLog()
+    service = MCPConnectionService()
+    op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
+
+    try:
+        ctx = _make_ctx(events, resolver=None, connection_service=service)
+        result = await _execute(op, ctx)
+    finally:
+        await service.aclose()
+
+    assert result["status"] == "ok"
+    assert result["uri"] == _URI
+    types_seen = [e.type for e in events.all()]
+    assert "mcp_resource_subscribe" in types_seen
+    assert "mcp_resource_subscribed" in types_seen
+    assert "mcp_resource_subscribe_failed" not in types_seen
+
+
+@pytest.mark.asyncio
+async def test_unsubscribe_execute_real_round_trip():
+    """Tier 2: mcp_unsubscribe_resource's _execute mirrors subscribe's, after a
+    real subscribe already happened."""
+    from reyn.core.op_runtime.mcp_subscribe_resource import _execute as _sub_execute
+    from reyn.core.op_runtime.mcp_unsubscribe_resource import _execute as _unsub_execute
+
+    events = EventLog()
+    service = MCPConnectionService()
+    sub_op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
+    unsub_op = MCPUnsubscribeResourceIROp(kind="mcp_unsubscribe_resource", server="srv", uri=_URI)
+
+    try:
+        ctx = _make_ctx(events, resolver=None, connection_service=service)
+        await _sub_execute(sub_op, ctx)
+        result = await _unsub_execute(unsub_op, ctx)
+    finally:
+        await service.aclose()
+
+    assert result["status"] == "ok"
+    types_seen = [e.type for e in events.all()]
+    assert "mcp_resource_unsubscribed" in types_seen
+
+
+def test_subscribe_handle_denies_without_permissions_mcp_declared():
+    """Tier 2: require_mcp gate — status='denied' when the caller's
+    PermissionDecl does not declare the server under `mcp` (mirrors
+    mcp_read_resource's own test)."""
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=Path("."), interactive=False)
+    ctx = _make_ctx(events, resolver=resolver, decl=PermissionDecl())
+    ctx.intervention_bus = _UnusedBus()
+
+    op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="srv", uri=_URI)
+    result = _run(execute_op(op, ctx))
+
+    assert result["status"] == "denied"
+    denials = [e for e in events.all() if e.type == "permission_denied"]
+    assert denials
+    assert denials[0].data.get("kind") == "mcp_subscribe_resource"
+
+
+def test_unsubscribe_handle_denies_without_permissions_mcp_declared():
+    """Tier 2: same gate for mcp_unsubscribe_resource."""
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=Path("."), interactive=False)
+    ctx = _make_ctx(events, resolver=resolver, decl=PermissionDecl())
+    ctx.intervention_bus = _UnusedBus()
+
+    op = MCPUnsubscribeResourceIROp(kind="mcp_unsubscribe_resource", server="srv", uri=_URI)
+    result = _run(execute_op(op, ctx))
+
+    assert result["status"] == "denied"
+
+
+def test_subscribe_execute_reports_error_for_unconfigured_server():
+    """Tier 2: _execute returns status='error' (never raises) for an
+    unconfigured server — mirrors mcp_read_resource's own test."""
+    from reyn.core.op_runtime.mcp_subscribe_resource import _execute
+
+    events = EventLog()
+    op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server="nope", uri=_URI)
+    ctx = _make_ctx(events, resolver=None, connection_service=MCPConnectionService())
+
+    result = _run(_execute(op, ctx))
+    assert result["status"] == "error"
+    assert "not configured" in result["error"]
+
+
+# ── Tier 2: op-kind registry completeness ─────────────────────────────────────
+
+
+def test_subscribe_ops_registered_in_op_kind_model_map():
+    """Tier 2: OP_KIND_MODEL_MAP <-> Op union completeness invariant — the two
+    new kinds are registered (control-ir.md hard rule)."""
+    from reyn.schemas.models import (
+        ALL_OP_KINDS,
+        OP_KIND_MODEL_MAP,
+        MCPSubscribeResourceIROp,
+        MCPUnsubscribeResourceIROp,
+    )
+
+    assert "mcp_subscribe_resource" in ALL_OP_KINDS
+    assert "mcp_unsubscribe_resource" in ALL_OP_KINDS
+    assert OP_KIND_MODEL_MAP["mcp_subscribe_resource"] is MCPSubscribeResourceIROp
+    assert OP_KIND_MODEL_MAP["mcp_unsubscribe_resource"] is MCPUnsubscribeResourceIROp
+
+
+# ── Tier 2: tools/mcp.py verbs — delegation via a Fake host (no mocks) ────────
+
+
+class _RecordingSubscribeHost:
+    """A trivial Fake at the host.mcp_subscribe_resource/mcp_unsubscribe_resource
+    boundary — records calls and returns canned data (mirrors
+    _RecordingResourceHost in test_2597_s2a_mcp_resources_consumption.py)."""
+
+    def __init__(self) -> None:
+        self.subscribe_calls: list[tuple] = []
+        self.unsubscribe_calls: list[tuple] = []
+
+    async def mcp_subscribe_resource(self, server: str, uri: str):
+        self.subscribe_calls.append((server, uri))
+        return {"status": "ok", "server": server, "uri": uri}
+
+    async def mcp_unsubscribe_resource(self, server: str, uri: str):
+        self.unsubscribe_calls.append((server, uri))
+        return {"status": "ok", "server": server, "uri": uri}
+
+
+def _tool_ctx(host):
+    from reyn.tools.types import RouterCallerState, ToolContext
+
+    return ToolContext(
+        caller_kind="router", events=None, permission_resolver=None, workspace=None,
+        router_state=RouterCallerState(host=host),
+    )
+
+
+def test_subscribe_mcp_resource_handler_delegates_to_host():
+    """Tier 2: _handle_subscribe_mcp_resource delegates (server, uri) to
+    host.mcp_subscribe_resource and returns its result verbatim."""
+    from reyn.tools.mcp import _handle_subscribe_mcp_resource
+
+    host = _RecordingSubscribeHost()
+    result = _run(
+        _handle_subscribe_mcp_resource({"server": "srv", "uri": _URI}, _tool_ctx(host))
+    )
+
+    assert host.subscribe_calls == [("srv", _URI)]
+    assert result == {"status": "ok", "server": "srv", "uri": _URI}
+
+
+def test_unsubscribe_mcp_resource_handler_delegates_to_host():
+    """Tier 2: _handle_unsubscribe_mcp_resource mirrors subscribe's delegation."""
+    from reyn.tools.mcp import _handle_unsubscribe_mcp_resource
+
+    host = _RecordingSubscribeHost()
+    result = _run(
+        _handle_unsubscribe_mcp_resource({"server": "srv", "uri": _URI}, _tool_ctx(host))
+    )
+
+    assert host.unsubscribe_calls == [("srv", _URI)]
+    assert result == {"status": "ok", "server": "srv", "uri": _URI}
+
+
+# ── Tier 2: ToolDefinition registration shape ─────────────────────────────────
+
+
+def test_subscribe_tool_definitions_registered_router_allow_side_effect():
+    """Tier 2: the 2 new ToolDefinitions are router+phase allow, discovery
+    category, side_effect purity (subscribing mutates server-side state,
+    unlike read_only list/read)."""
+    from reyn.tools.mcp import SUBSCRIBE_MCP_RESOURCE, UNSUBSCRIBE_MCP_RESOURCE
+
+    for td in (SUBSCRIBE_MCP_RESOURCE, UNSUBSCRIBE_MCP_RESOURCE):
+        assert td.gates.router == "allow"
+        assert td.gates.phase == "allow"
+        assert td.category == "discovery"
+        assert td.purity == "side_effect"
+
+
+def test_subscribe_tool_definitions_present_in_default_registry():
+    """Tier 2: get_default_registry() includes the 2 new capabilities under
+    their canonical chat-tool names."""
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    assert registry.lookup("subscribe_mcp_resource") is not None
+    assert registry.lookup("unsubscribe_mcp_resource") is not None

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -73,6 +73,12 @@ _NOT_EXTERNAL = {
     # repo content. The cloned SKILL.md is threat-scanned before registration;
     # the scan result is internal OS state, not forwarded external content.
     # Same classification rationale as mcp_install_package (installs, does not relay).
+    # #2597 slice ②b: subscribe_mcp_resource / unsubscribe_mcp_resource return an
+    # {status, server, uri} subscribe-confirmation ACK, never resource CONTENT (the
+    # push notification itself carries no payload — a caller re-reads via
+    # read_mcp_resource, which IS fenced above). Same "status ACK, not content"
+    # classification rationale as mcp_install_local / topology_create.
+    "subscribe_mcp_resource", "unsubscribe_mcp_resource",
     "skill_install_source",
     "cron_register", "cron_unregister", "cron_enable", "cron_disable",
     # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

Implements slice ②b of the MCP client redesign: MCP resource **subscriptions** — subscribe to a resource, receive server-pushed `resources/updated` notifications, and emit them as reyn events (`mcp_resource_updated`). This is the async push event-source the redesign exists to enable.

### Raw subscribe API verified (fastmcp 3.4.2 / mcp SDK)

Confirmed empirically against the installed packages:
- `fastmcp.Client` has **no subscribe convenience method** (Q5 finding confirmed — `grep` across the fastmcp package tree finds zero `subscribe_resource` hits in `client/`).
- `mcp.client.session.ClientSession.subscribe_resource(uri)` / `.unsubscribe_resource(uri)` are the raw calls, reached via `fastmcp.Client.session` (a public property). `MCPClient.subscribe_resource`/`unsubscribe_resource` call these directly.
- `ServerCapabilities.resources: ResourcesCapability | None`, and `ResourcesCapability.subscribe: bool | None` is a field distinct from the coarser `resources` capability — gated separately in `MCPClient._require_resources_subscribe_capability`.
- **New finding, not in the original spike**: the base `mcp` SDK's `Server.get_capabilities` **hard-codes `subscribe=False`** whenever a `ListResourcesRequest` handler is registered, regardless of whether `SubscribeRequest`/`UnsubscribeRequest` handlers are ALSO registered. FastMCP's own `LowLevelServer.get_capabilities` override only patches `capabilities.tasks`/`capabilities.extensions`, never `resources.subscribe`. **Net effect: no server built with FastMCP's high-level `FastMCP()` class can ever advertise `resources.subscribe=True`.** The existing `mcp_fastmcp_echo_server.py` test double is therefore a real "resources capability present, subscribe absent" double for free (used for the fail-fast tests). For the "subscribe actually works" + reconnect tests, a NEW low-level test-support server (`tests/_support/mcp_subscribable_resources_server.py`) subclasses `mcp.server.lowlevel.Server` directly (same base class FastMCP itself subclasses) and overrides `get_capabilities` to flip `subscribe=True` when a `SubscribeRequest` handler is registered — extending the SDK's own "derive capabilities from registered handlers" contract to the one field it doesn't already cover. This is a real MCP server, not a mock.

### Op-kind vs verb-only: op-kind (mirrors `mcp_read_resource`)

Added `mcp_subscribe_resource`/`mcp_unsubscribe_resource` as new op kinds (`OP_KIND_MODEL_MAP` + `docs/reference/runtime/control-ir.md` updated in this same PR, per the hard rule) rather than verb-only host-adapter methods. Rationale: subscribing is a **stateful action against the server**, gated the same `require_mcp` axis `mcp_read_resource` (②a) already established as precedent for exactly this kind of action — a verb-only path would have skipped the permission gate ②a deliberately added for read. `subscribe_mcp_resource`/`unsubscribe_mcp_resource` are the LLM-facing chat-tool names (mirrors `read_mcp_resource` → `mcp_read_resource`).

### Reconnect integration with the F1 healing path

- `MCPConnectionService` tracks a **runtime-only, in-memory, per-server** subscribed-URI set (`self._subscriptions: dict[str, set[str]]`) — never WAL'd (Q4, decided: a subscription carries no data of its own, fully re-establishable, matches the gen-store runtime-only-state invariant).
- `_HeldConnection.subscribe_resource`/`unsubscribe_resource` go through `_heal(..., heal_only=False)` (idempotent-retry semantics, same as `list_tools`/`read_resource`) and only update the tracked set **after** the call succeeds.
- `_ensure_open` (the method both the first-open path AND F1's `_reconnect` path funnel through) re-issues `subscribe_resource` for every URI already tracked for that server immediately after opening a fresh client — a brand-new `mcp.ClientSession` has no memory of what the OLD (dead) session subscribed to. First open: tracked set is empty, no-op. Reconnect: this is the whole point. Per-URI try/except so one bad re-subscribe doesn't block the rest or crash the reconnect.
- This sequencing (track only after success, re-subscribe only already-tracked URIs) avoids a double-subscribe race: a subscribe call that itself triggers a heal+reconnect won't have its own URI re-subscribed by the reconnect's loop (not tracked yet), then gets picked up by `_heal`'s own retry.

### Scope

- `ReynMCPMessageHandler.on_resource_updated` now emits `mcp_resource_updated` (server, uri) synchronously via the S2b `emit_sink` bridge seam — EventLog-only, deliberately NOT wired into the hook dispatcher (future hooks-arc slice).
- Ephemeral sessions refuse `mcp_subscribe_resource`/`mcp_unsubscribe_resource` with a clear error (a subscription on a one-shot connection that closes immediately after the op returns can never observe a push).
- Out of scope (per the umbrella issue): reconnect resync-READ (re-reading subscribed resources to catch updates missed while disconnected — this PR does re-**subscribe**, which is the essential correctness property; resync-read is a follow-up), wiring `mcp_resource_updated` into the hook dispatcher, prompts/elicitation/OAuth.
- No WAL/recovery — subscriptions are runtime-only (Q4); truncate-falsify N/A.

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 27 tests inspected across the 3 touched/new test files, 0 Tier-4 violations.
- [x] `pytest` (repo root) — 7329 passed, 21 skipped, **5 failed** (all pre-existing #2599 web-route-mount failures, confirmed unrelated — `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `web/test_a2a.py::test_a2a_routes_mounted`, `web/test_mcp_sse.py::test_mcp_routes_mounted`, `web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `web/test_resources_router.py::test_resources_route_is_mounted_on_app`). Zero new failures.
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean.
- [x] Manual: real end-to-end smoke against `tests/_support/mcp_subscribable_resources_server.py` through `MCPConnectionService` — subscribe → `bump_and_notify` tool call → real `notifications/resources/updated` → `mcp_resource_updated` event on EventLog; then `die` tool (transport death) → next call heals/reconnects → tracked subscription automatically re-issued → a second push still lands as an event. Same scenario is also covered as `tests/test_2597_s2b_resource_subscriptions.py::test_subscription_survives_transport_death_reconnect`.
- [x] Fixed 2 pre-existing completeness-gate regressions the new tools/ops tripped (both are the "deliberate golden update" case their own docstrings anticipate, not bugs): `test_2123_router_dispatch_sot_1953.py::test_dispatch_set_is_migration_equivalent` (added `subscribe_mcp_resource`/`unsubscribe_mcp_resource` to the frozen dispatch-set golden) and `test_returns_external_content_flagset_1822.py::test_classification_is_exhaustive` (classified both as `_NOT_EXTERNAL` — they return a `{status, server, uri}` ACK, never resource content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)