### PR TITLE
feat(#2597): slice ②c — MCP prompts consumption (list/get)

### DIFF
--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -129,6 +129,17 @@ Both list and read are additionally gated by the server's **negotiated capabilit
 - **Survives a transport-death reconnect.** A dropped connection (subprocess death, broken HTTP) re-opens a fresh MCP session with no memory of prior subscriptions; `MCPConnectionService` automatically re-issues every tracked subscription against the fresh connection, so a subscription set up before a drop keeps delivering pushes after reyn heals the connection.
 - **The push lands on the EventLog, not in a tool result.** `mcp_resource_updated` (`server`, `uri`) is emitted asynchronously whenever the notification arrives — independent of any Control IR op call. Wiring it into the hook dispatcher (so a workflow can react to it directly) is a later slice; today it's an audit-trail signal a workflow author reads back via the EventLog.
 
+### Prompts: list + get
+
+Alongside tools and resources, a server can expose **prompts** (named, server-authored prompt templates the LLM can render with arguments). Reyn's chat surface mirrors the resources flow exactly:
+
+- `list_mcp_prompts(server)` — discovery, unpermissioned (mirrors `list_mcp_resources`/`list_mcp_tools`; no Control IR op kind, no `permissions.mcp` gate). Returns each prompt's `name` + `description` + `arguments` schema.
+- `get_mcp_prompt(server, name, arguments?)` — fetches one rendered prompt's messages. This one IS gated: it's a `mcp_get_prompt` Control IR op, requiring the same `permissions.mcp: [server_name]` grant as a tool call / resource read, because a rendered prompt's *messages* are external, potentially sensitive server-authored content. Every get emits `mcp_prompt_get` before, `mcp_prompt_get_completed` (or `_failed`) after.
+
+Both list and get are additionally gated by the server's **negotiated capabilities**: a server that never advertised `prompts` in its `initialize` handshake fails fast with a clear error (`require_capability` in `reyn/mcp/client.py`) instead of a raw protocol error.
+
+Prompts have no subscribe concept — MCP defines no per-prompt push notification (only the coarser `notifications/prompts/list_changed`, already bridged to an `mcp_prompt_list_changed` EventLog event); there is no `subscribe_mcp_prompt`.
+
 ## Transport choice (stdio vs HTTP)
 
 Most official MCP servers are local processes you launch over stdio. A few hosted services expose HTTP endpoints. SSE transport is reserved for a future release.

--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -345,6 +345,7 @@ The op kinds below mirror `OP_KIND_MODEL_MAP` in `op_runtime/registry.py`.
 | `mcp` | Call a configured MCP server tool by name |
 | `mcp_read_resource` | Read one MCP resource by URI (permission-gated, same axis as `mcp`) |
 | `mcp_subscribe_resource` / `mcp_unsubscribe_resource` | Subscribe/unsubscribe to server-pushed `resources/updated` for one URI (requires a persistent connection; push lands as an `mcp_resource_updated` event) |
+| `mcp_get_prompt` | Fetch one rendered MCP prompt's messages by name (permission-gated, same axis as `mcp`) |
 | `mcp_install` | Install / register an MCP server (registry / package / local source) |
 | `index_query` | Vector similarity search over one indexed source |
 | `recall` | Macro: embed query → `index_query` per source → merge top-K |
@@ -532,6 +533,7 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | Tool dispatch | Lazy-load and cache `MCPClient` per server connection | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
 | Resources consumption | List/read MCP resources + resource templates (`list_mcp_resources` / `read_mcp_resource` / `list_mcp_resource_templates`), gated by the negotiated `resources` capability | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_read_resource`](reference/runtime/control-ir.md) |
 | Resource subscriptions | Subscribe/unsubscribe to server-pushed `resources/updated` (`subscribe_mcp_resource` / `unsubscribe_mcp_resource`), gated by the negotiated `resources.subscribe` sub-capability; runtime-only subscribed-URI set survives a transport-death reconnect (re-subscribed); push lands as an `mcp_resource_updated` EventLog event | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_subscribe_resource`](reference/runtime/control-ir.md) |
+| Prompts consumption | List/get MCP prompts (`list_mcp_prompts` / `get_mcp_prompt`), gated by the negotiated `prompts` capability; no subscribe concept | [Concepts: MCP](concepts/tools-integrations/mcp.md) · [Control IR: `mcp_get_prompt`](reference/runtime/control-ir.md) |
 
 > **Differentiation vs general agents:** Reyn is both an MCP client (consumes external servers) and an MCP server (exposes its own agents) — standard-protocol interop in both directions, with stdio MCP servers subprocess-sandboxed under Seatbelt.
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -26,6 +26,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `mcp_read_resource` | Read one resource (or a resolved resource-template URI) on a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
 | `mcp_subscribe_resource` | Subscribe to server-pushed `resources/updated` notifications for one resource URI (requires a persistent connection — see below) | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
 | `mcp_unsubscribe_resource` | Cancel a previous `mcp_subscribe_resource` | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
+| `mcp_get_prompt` | Fetch one rendered prompt (messages) by name from a configured MCP server | `permissions.mcp: [server_name]` in skill frontmatter (same axis as `mcp`) |
 | `mcp_install` | Install an MCP server from the registry into the project config | `permissions.mcp_install: true` in skill frontmatter |
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
@@ -283,6 +284,32 @@ Gated by the **same** `permissions.mcp` axis as `mcp` / `mcp_read_resource` (sub
 **The push notification itself is an EventLog event, not a `control_ir_results` value.** When the server sends `notifications/resources/updated {uri}`, `reyn.mcp.message_handler.ReynMCPMessageHandler.on_resource_updated` emits an `mcp_resource_updated` event (`server`, `uri`) onto the session's `EventLog` — asynchronously, independent of any op call. This slice deliberately stops at the EventLog: wiring `mcp_resource_updated` into the hook dispatcher is a later (hooks-arc) slice. Re-reading subscribed resources on reconnect to catch updates missed while disconnected (a resync-READ, distinct from the re-**subscribe** above) is also a follow-up, not this slice.
 
 Advertised to the LLM under the chat-tool names `subscribe_mcp_resource` / `unsubscribe_mcp_resource` — same alias pattern as `mcp`/`call_mcp_tool`.
+
+## `mcp_get_prompt`
+
+Fetches one rendered prompt (its messages) from a configured MCP server. #2597 slice ②c (prompts consumption) — gated by the **same** `permissions.mcp` axis as `mcp` (call_tool) / `mcp_read_resource`: a rendered prompt returns external, potentially sensitive server-authored content, so it is permission-gated identically.
+
+```json
+{
+  "kind": "mcp_get_prompt",
+  "server": "filesystem",
+  "name": "summarize",
+  "arguments": {"style": "brief"}
+}
+```
+
+Fields: `server` (required — must match a key under `mcp.servers:` in `reyn.yaml`), `name` (required — prompt name as advertised by the server's `prompts/list` response), `arguments` (optional, default `{}` — rendering arguments matching the prompt's declared `arguments` schema).
+
+> **Advertised name.** Phases advertise this op to the LLM under the chat-tool
+> name `get_mcp_prompt`; the OS aliases it back to the `mcp_get_prompt` kind
+> at the parse boundary — same pattern as `mcp`/`call_mcp_tool` and
+> `mcp_read_resource`/`read_mcp_resource`.
+
+The OS resolves the server's transport, dispatches via `MCPClient.get_prompt` (gated on the server's negotiated `prompts` capability — see `require_capability` in `mcp/client.py`), and returns `{"description": str | None, "messages": [...]}` — each message a flattened `PromptMessage` (`role` + `content`). Every call emits `mcp_prompt_get`, `mcp_prompt_get_completed`, and (on failure) `mcp_prompt_get_failed` events.
+
+**Discovery is NOT gated.** `list_mcp_prompts` (the chat-tool name for `MCPClient.list_prompts`) mirrors `list_mcp_resources`/`list_mcp_tools`: no `control-ir` op kind, no permission gate — pure discovery, routed directly through `MCPGateway` from the router host adapter. Only the content-returning get is a gated op kind, matching the existing `mcp`/`mcp_read_resource` vs. discovery split.
+
+**Prompts have no subscribe concept.** Unlike resources (`mcp_subscribe_resource`/`mcp_unsubscribe_resource`), MCP's `prompts` capability has no server-push notification for a specific prompt's content changing — only the coarser `notifications/prompts/list_changed` (bridged to an EventLog event by `reyn.mcp.message_handler.ReynMCPMessageHandler.on_prompt_list_changed`, independent of this op kind). There is no `mcp_subscribe_prompt` to build.
 
 ## `mcp_install`
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -98,11 +98,49 @@ def _mcp_read_resource_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
+def _mcp_get_prompt_to_canonical(result: dict) -> CanonicalToolResult:
+    """MCP get-prompt result → canonical (#2597 slice ②c). ``messages`` is a
+    list of flattened ``PromptMessage`` dicts (``{"role": ..., "content":
+    {...}}``); each message's text-bearing content joins into the canonical
+    ``text`` (same offload-safe path as a resource's joined ``contents``); a
+    non-text content block (image/audio/embedded-resource) becomes a
+    ``structured`` attachment rather than a ``media`` one, for the same
+    reason ``_mcp_read_resource_to_canonical`` isolates a resource ``blob`` —
+    the existing ``media`` attachment path assumes vision-follow-up-shaped
+    image blocks a prompt's arbitrary content block does not fit. A large
+    rendered prompt (many/long messages) is the SAME second-oversized-field
+    risk a tool's ``structuredContent`` or a resource's ``blob`` posed — this
+    mapper keeps ``text`` the sole offload-decision payload, same as its two
+    siblings above.
+    """
+    attachments: list[dict] = []
+    text_parts: list[str] = []
+    for message in result.get("messages") or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, dict) and content.get("type") == "text" and content.get("text") is not None:
+            text_parts.append(str(content["text"]))
+        elif content is not None:
+            attachments.append({"kind": "structured", "data": content})
+    meta = {
+        k: v for k, v in result.items()
+        if k in ("kind", "status", "server", "name", "description", "error")
+    }
+    return CanonicalToolResult(
+        text="\n".join(text_parts),
+        attachments=attachments,
+        source_ref=None,
+        meta=meta,
+    )
+
+
 # op-kind → canonical mapper. New ops register here (or return canonical directly); a raw dict with no
 # registered mapper falls back to a whole-dict wrap so nothing is ever lost (see ``to_canonical``).
 _MAPPERS: dict[str, Any] = {
     "mcp": _mcp_to_canonical,
     "mcp_read_resource": _mcp_read_resource_to_canonical,
+    "mcp_get_prompt": _mcp_get_prompt_to_canonical,
 }
 
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -110,6 +110,9 @@ from . import index_query as _index_query  # noqa: F401, E402
 from . import judge_output as _judge_output  # noqa: F401, E402
 from . import mcp as _mcp  # noqa: F401, E402
 from . import mcp_drop_server as _mcp_drop_server  # noqa: F401, E402
+
+# #2597 slice ②c: mcp_get_prompt — permission-gated prompt fetch (mirrors mcp_read_resource.py).
+from . import mcp_get_prompt as _mcp_get_prompt  # noqa: F401, E402
 from . import mcp_install as _mcp_install  # noqa: F401, E402
 
 # #2597 slice ②a: mcp_read_resource — permission-gated resource read (mirrors mcp.py).

--- a/src/reyn/core/op_runtime/mcp_get_prompt.py
+++ b/src/reyn/core/op_runtime/mcp_get_prompt.py
@@ -1,0 +1,89 @@
+"""mcp_get_prompt kind handler — fetch one rendered prompt on a configured MCP server.
+
+#2597 slice ②c (prompts consumption). Mirrors ``op_runtime/mcp_read_resource.py``'s
+``mcp_read_resource`` handler exactly: same server-config resolution, same
+``MCPGateway`` seam (fault containment + task-affine pool reuse + per-call
+timeout), same ``require_mcp`` permission gate (server-scoped — the same
+axis a tool call / resource read uses, since a rendered prompt is external,
+possibly sensitive server-authored content, just like a resource read), and
+the same before/after event pair shape (``mcp_prompt_get`` / a
+completed-or-failed follow-up — mirrors ``mcp_resource_read``/
+``mcp_resource_read_completed``/``mcp_resource_read_failed``).
+
+Discovery (``list_prompts``) is deliberately NOT an op kind here — it mirrors
+``list_resources``/``list_tools``, which bypass the permission gate + op-kind
+machinery entirely (see ``session.py::_mcp_list_prompts``). Only the
+content-returning get is gated, matching the tools/resources surface's own
+split between ungated `list_*` and gated `call_tool`/`read_resource`.
+
+Prompts have no subscribe concept — out of scope entirely, unlike resources.
+"""
+from __future__ import annotations
+
+from reyn.schemas.models import MCPGetPromptIROp
+
+from . import register
+from .context import OpContext
+
+
+async def _execute(op: MCPGetPromptIROp, ctx: OpContext) -> dict:
+    from reyn.mcp.client import expand_env
+    from reyn.mcp.gateway import MCPFault, MCPGateway
+
+    server_cfg = ctx.mcp_servers.get(op.server)
+    if not server_cfg:
+        return {
+            "kind": "mcp_get_prompt", "status": "error",
+            "error": f"MCP server '{op.server}' is not configured. "
+                     f"Add it under mcp.servers in reyn.yaml or reyn.local.yaml.",
+        }
+
+    expanded = expand_env(server_cfg)
+    if not isinstance(expanded, dict):
+        return {"kind": "mcp_get_prompt", "status": "error",
+                "error": f"MCP server '{op.server}' config must be a dict."}
+
+    if "type" not in expanded and expanded.get("url"):
+        expanded = {**expanded, "type": "http"}
+
+    if ctx.mcp_connection_service is None and ctx.mcp_pool is None:
+        return {"kind": "mcp_get_prompt", "status": "error", "server": op.server,
+                "name": op.name, "error": "no MCP client pool on this context"}
+
+    ctx.events.emit("mcp_prompt_get", server=op.server, name=op.name)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
+    try:
+        result = await gateway.get_prompt(op.server, op.name, op.arguments, expanded)
+    except MCPFault as fault_exc:
+        fault = str(fault_exc)
+        ctx.events.emit("mcp_prompt_get_failed", server=op.server, name=op.name, error=fault)
+        return {"kind": "mcp_get_prompt", "status": "error", "server": op.server,
+                "name": op.name, "error": fault}
+
+    messages = result.get("messages", [])
+    ctx.events.emit(
+        "mcp_prompt_get_completed", server=op.server, name=op.name,
+        message_count=len(messages) if isinstance(messages, list) else 0,
+    )
+    return {
+        "kind": "mcp_get_prompt",
+        "status": "ok",
+        "server": op.server,
+        "name": op.name,
+        "description": result.get("description"),
+        "messages": messages,
+    }
+
+
+async def handle(op: MCPGetPromptIROp, ctx: OpContext) -> dict:
+    if ctx.permission_resolver is not None:
+        if ctx.intervention_bus is None:
+            raise RuntimeError("mcp_get_prompt op requires intervention_bus on OpContext")
+        await ctx.permission_resolver.require_mcp(
+            ctx.permission_decl, op.server, ctx.intervention_bus,
+            contextual=ctx.contextual_permission,
+        )
+    return await _execute(op, ctx)
+
+
+register("mcp_get_prompt", handle)

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -557,6 +557,43 @@ class MCPClient:
             _classify_and_raise(exc, f"MCP resources/read error: {exc}")
         return _read_resource_result_to_dict(result)
 
+    # ── prompts (#2597 slice ②c — consumption) ──────────────────────────────────
+
+    async def list_prompts(self) -> list[dict[str, Any]]:
+        """Return the prompts advertised by this server as plain dicts.
+
+        Mirrors :meth:`list_resources`: uses FastMCP's auto-paginating
+        ``Client.list_prompts()`` (follows ``nextCursor``) and gates on the
+        ``"prompts"`` capability before issuing the request.
+        """
+        await self.initialize()
+        require_capability(self, "prompts")
+        try:
+            prompts = await self._client.list_prompts()
+        except Exception as exc:
+            _classify_and_raise(exc, f"MCP prompts/list error: {exc}")
+        return [_prompt_to_dict(p) for p in prompts]
+
+    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Fetch one rendered prompt's messages and return them flattened to a
+        dict: ``{"description": str | None, "messages": [...]}`` — each entry
+        a flattened ``PromptMessage``.
+
+        Uses FastMCP's raw ``get_prompt_mcp`` (not the convenience
+        ``get_prompt``, which additionally supports background-task /
+        version kwargs this slice does not need) so the shape-flattening
+        lives in ONE place (:func:`_get_prompt_result_to_dict`), mirroring
+        how :meth:`read_resource` uses ``read_resource_mcp`` for the same
+        reason.
+        """
+        await self.initialize()
+        require_capability(self, "prompts")
+        try:
+            result = await self._client.get_prompt_mcp(name=name, arguments=arguments)
+        except Exception as exc:
+            _classify_and_raise(exc, f"MCP prompts/get error: {exc}")
+        return _get_prompt_result_to_dict(result)
+
     # ── resource subscriptions (#2597 slice ②b) ─────────────────────────────────
 
     def _require_resources_subscribe_capability(self) -> None:
@@ -931,6 +968,36 @@ def _resource_to_dict(resource: Any) -> dict[str, Any]:
     if hasattr(resource, "model_dump"):
         return resource.model_dump(mode="json")
     return dict(resource)
+
+
+def _prompt_to_dict(prompt: Any) -> dict[str, Any]:
+    """Flatten an ``mcp.types.Prompt`` into a JSON-safe plain dict (mirrors
+    :func:`_resource_to_dict`). ``mode="json"`` for the same reason: a
+    ``Prompt`` has no ``AnyUrl`` field today, but ``mode="json"`` is the
+    uniform, future-proof choice across this module's model-dump helpers."""
+    if hasattr(prompt, "model_dump"):
+        return prompt.model_dump(mode="json")
+    return dict(prompt)
+
+
+def _get_prompt_result_to_dict(result: Any) -> dict[str, Any]:
+    """Flatten an ``mcp.types.GetPromptResult`` into
+    ``{"description": str | None, "messages": [...]}`` — each entry a
+    flattened ``PromptMessage`` (mirrors :func:`_read_resource_result_to_dict`'s
+    content-flattening for resource reads). Uses ``mode="json"`` for the same
+    AnyUrl-safety reason as :func:`_resource_to_dict`."""
+    messages: list[dict[str, Any]] = []
+    for item in getattr(result, "messages", []) or []:
+        if hasattr(item, "model_dump"):
+            messages.append(item.model_dump(mode="json"))
+        elif isinstance(item, dict):
+            messages.append(item)
+        else:
+            messages.append({"role": "user", "content": {"type": "text", "text": str(item)}})
+    return {
+        "description": getattr(result, "description", None),
+        "messages": messages,
+    }
 
 
 def _read_resource_result_to_dict(result: Any) -> dict[str, Any]:

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -296,7 +296,8 @@ class _HeldConnection:
     :meth:`MCPConnectionService.get`. Exposes exactly the surface
     :class:`~reyn.mcp.gateway.MCPGateway` calls (``call_tool`` / ``list_tools`` /
     ``list_resources`` / ``list_resource_templates`` / ``read_resource`` /
-    ``subscribe_resource`` / ``unsubscribe_resource`` / ``is_initialized``) so it's
+    ``subscribe_resource`` / ``unsubscribe_resource`` / ``list_prompts`` /
+    ``get_prompt`` / ``is_initialized``) so it's
     usable anywhere a bare ``MCPClient`` is expected.
 
     Looks up the currently-live held ``MCPClient`` by server name on every call
@@ -360,6 +361,15 @@ class _HeldConnection:
 
     async def read_resource(self, uri: str) -> dict[str, Any]:
         return await self._heal(lambda c: c.read_resource(uri), heal_only=False)
+
+    # #2597 slice ②c: prompts consumption. Both are idempotent READS (no
+    # server-side side effect), so — like list_resources/read_resource above —
+    # they heal with heal_only=False (retry-once on the fresh connection).
+    async def list_prompts(self) -> list[dict[str, Any]]:
+        return await self._heal(lambda c: c.list_prompts(), heal_only=False)
+
+    async def get_prompt(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        return await self._heal(lambda c: c.get_prompt(name, arguments), heal_only=False)
 
     # #2597 slice ②b: resource subscriptions. Unlike call_tool, subscribe/unsubscribe
     # are connection-MANAGEMENT operations, not data reads — but they still go through

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -157,6 +157,19 @@ class MCPGateway:
         return await self._run(server, config, lambda c: c.read_resource(uri),
                                timeout=resolve_call_timeout(config))
 
+    async def list_prompts(self, server: str, config: dict) -> list[dict]:
+        """Return the server's advertised prompts. Raises :class:`MCPFault` on
+        any contained fault (mirrors :meth:`list_resources`)."""
+        return await self._run(server, config, lambda c: c.list_prompts(),
+                               timeout=resolve_call_timeout(config))
+
+    async def get_prompt(self, server: str, name: str, arguments: dict, config: dict) -> dict:
+        """Fetch one rendered prompt's messages by name and return
+        ``{"description": ..., "messages": [...]}``. Raises :class:`MCPFault`
+        on any contained fault (mirrors :meth:`read_resource`)."""
+        return await self._run(server, config, lambda c: c.get_prompt(name, arguments),
+                               timeout=resolve_call_timeout(config))
+
     async def subscribe_resource(self, server: str, uri: str, config: dict) -> None:
         """Subscribe to server-pushed ``resources/updated`` for ``uri``. Raises
         :class:`MCPFault` on any contained fault (mirrors :meth:`read_resource`).

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -729,6 +729,13 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     async def mcp_unsubscribe_resource(self, server: str, uri: str) -> dict: ...
 
+    # #2597 slice ②c: prompts consumption (list / get). Prompts have no
+    # subscribe concept.
+    async def mcp_list_prompts(self, server: str) -> list[dict]: ...
+
+    async def mcp_get_prompt(self, server: str, name: str,
+                              arguments: dict | None = None) -> dict: ...
+
     # OpContext factory for unified-registry handlers (ADR-0026 Phase 3.5).
     # Builds a permission-aware OpContext with the operator-declared
     # PermissionDecl + Workspace(actor="chat_router") + mcp_servers,
@@ -2959,7 +2966,7 @@ class RouterLoop:
                             and set(r) <= {"status", "data", "error"})
             _inner = r["data"] if _is_envelope else r
             _media_store = getattr(host, "media_store", None)
-            if (isinstance(_inner, dict) and _inner.get("kind") in ("mcp", "mcp_read_resource")
+            if (isinstance(_inner, dict) and _inner.get("kind") in ("mcp", "mcp_read_resource", "mcp_get_prompt")
                     and _media_store is not None):
                 # #2425 案B: an MCP tool result normalises to a canonical shape so ``text`` (the joined
                 # content) is the SOLE offload payload and ``structured``/media are attachments held OUT
@@ -2974,6 +2981,10 @@ class RouterLoop:
                 # ``contents`` can carry a large ``blob`` alongside joined ``text``, the identical
                 # second-oversized-field risk a tool's ``structuredContent`` posed (see
                 # ``_mcp_read_resource_to_canonical``).
+                # #2597 slice ②c: ``mcp_get_prompt`` reuses the SAME canonical path — a rendered
+                # prompt's ``messages`` can carry a large non-text content block alongside joined
+                # ``text``, the identical second-oversized-field risk (see
+                # ``_mcp_get_prompt_to_canonical``).
                 from reyn.core.offload.canonical import to_canonical
                 from reyn.core.offload.seam import build_offload_body
                 _body, _mcp_media = build_offload_body(

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -85,6 +85,11 @@ class RouterHostAdapter:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
     mcp_unsubscribe_resource:
         Async callback ``(server: str, uri: str) -> dict`` (#2597 slice ②b).
+    mcp_list_prompts:
+        Async callback ``(server: str) -> list[dict]`` (#2597 slice ②c).
+    mcp_get_prompt:
+        Async callback ``(server: str, name: str, arguments: dict | None) -> dict``
+        (#2597 slice ②c).
     send_to_agent:
         Async callback ``(*, to, request, depth, chain_id) -> None``.
     put_outbox:
@@ -142,6 +147,10 @@ class RouterHostAdapter:
         # getattr-guard pattern as the ②a resources callbacks above.
         mcp_subscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
         mcp_unsubscribe_resource: "Callable[..., Awaitable[dict]] | None" = None,
+        # #2597 slice ②c: prompts consumption — same None-default / getattr-guard
+        # pattern as the ②a resources callbacks above. No subscribe analogue.
+        mcp_list_prompts: "Callable[..., Awaitable[list]] | None" = None,
+        mcp_get_prompt: "Callable[..., Awaitable[dict]] | None" = None,
         # Action callbacks
         send_to_agent: Callable[..., Awaitable[None]],
         put_outbox: Callable[..., Awaitable[None]],
@@ -364,6 +373,8 @@ class RouterHostAdapter:
         self._mcp_read_resource_cb = mcp_read_resource
         self._mcp_subscribe_resource_cb = mcp_subscribe_resource
         self._mcp_unsubscribe_resource_cb = mcp_unsubscribe_resource
+        self._mcp_list_prompts_cb = mcp_list_prompts
+        self._mcp_get_prompt_cb = mcp_get_prompt
         # Action callbacks
         self._send_to_agent_cb = send_to_agent
         self._put_outbox_cb = put_outbox
@@ -1422,6 +1433,18 @@ class RouterHostAdapter:
         if self._mcp_unsubscribe_resource_cb is None:
             return {"status": "error", "error": "mcp resource unsubscribe is not wired on this host"}
         return await self._mcp_unsubscribe_resource_cb(server, uri)
+
+    # #2597 slice ②c: prompts consumption. Same getattr-guarded-callback
+    # pattern as the ②a resources methods above. No subscribe analogue.
+    async def mcp_list_prompts(self, server: str) -> list[dict]:
+        if self._mcp_list_prompts_cb is None:
+            return [{"error": "mcp prompts listing is not wired on this host"}]
+        return await self._mcp_list_prompts_cb(server)
+
+    async def mcp_get_prompt(self, server: str, name: str, arguments: dict | None = None) -> dict:
+        if self._mcp_get_prompt_cb is None:
+            return {"status": "error", "error": "mcp prompt get is not wired on this host"}
+        return await self._mcp_get_prompt_cb(server, name, arguments)
 
     # --- Model resolution ---
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1539,6 +1539,9 @@ class Session:
             # #2597 slice ②b: resource subscriptions.
             mcp_subscribe_resource=self._mcp_subscribe_resource,
             mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
+            # #2597 slice ②c: prompts consumption (list/get).
+            mcp_list_prompts=self._mcp_list_prompts,
+            mcp_get_prompt=self._mcp_get_prompt,
             send_to_agent=self._send_to_agent,
             put_outbox=self._put_outbox,
             append_history=self._append_history,
@@ -5668,6 +5671,79 @@ class Session:
         )
         ctx.mcp_connection_service = self._mcp_connection_service
         return await execute_op(op, ctx)
+
+    async def _mcp_list_prompts(self, server: str) -> list[dict]:
+        """Query the MCP server for its prompts list.
+
+        #2597 slice ②c: mirrors ``_mcp_list_resources`` exactly — discovery-only,
+        NOT permission-gated (no op-kind), routed through the same
+        ``MCPGateway`` seam (held connection service on a non-ephemeral
+        session, one-shot pool otherwise). Emits ``mcp_prompts_listed`` for
+        observability, same rationale as ``mcp_resources_listed``.
+        """
+        from reyn.mcp.client import expand_env
+        from reyn.mcp.gateway import MCPFault, MCPGateway
+
+        servers = self._mcp_servers_flat()
+        if not servers:
+            return [{"error": "no MCP servers configured"}]
+        server_cfg = servers.get(server)
+        if not server_cfg:
+            return [{"error": f"MCP server {server!r} not configured"}]
+
+        expanded = expand_env(server_cfg)
+        if not isinstance(expanded, dict):
+            return [{"error": f"MCP server {server!r} config must be a dict"}]
+        if "type" not in expanded and expanded.get("url"):
+            expanded = {**expanded, "type": "http"}
+
+        gateway = (
+            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            if not self._ephemeral
+            else MCPGateway(agent_id=self._agent_id)
+        )
+        try:
+            prompts = await gateway.list_prompts(server, expanded)
+        except MCPFault as exc:
+            return [{"error": str(exc)}]
+        self._chat_events.emit(
+            "mcp_prompts_listed", server=server, count=len(prompts),
+        )
+        return prompts
+
+    async def _mcp_get_prompt(self, server: str, name: str, arguments: "dict | None" = None) -> dict:
+        """Fetch one rendered MCP prompt by name and return its messages.
+
+        #2597 slice ②c: mirrors ``_mcp_read_resource`` exactly — permission-gated
+        (``require_mcp``, same server-scoped axis a tool call / resource read
+        uses) + routed through ``execute_op`` on the ``mcp_get_prompt`` op kind,
+        so the SAME connection-service-vs-per-call-pool split ``_mcp_call_tool``
+        documents applies here too.
+        """
+        from reyn.core.op_runtime import execute_op
+        from reyn.schemas.models import MCPGetPromptIROp
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        op = MCPGetPromptIROp(
+            kind="mcp_get_prompt", server=server, name=name, arguments=dict(arguments or {}),
+        )
+        ctx = self._make_router_op_context()
+        ctx.intervention_bus = ChatInterventionBus(
+            self, run_id=None, actor="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+        ctx.permission_decl = PermissionDecl(
+            file_read=ctx.permission_decl.file_read,
+            file_write=ctx.permission_decl.file_write,
+            mcp=[server],
+        )
+        if not self._ephemeral:
+            ctx.mcp_connection_service = self._mcp_connection_service
+            return await execute_op(op, ctx)
+        from reyn.mcp.pool import MCPClientPool
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await execute_op(op, ctx)
 
     async def _mcp_call_tool(self, server: str, tool: str, args: dict) -> dict:
         """Invoke an MCP tool and return its result.

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -148,6 +148,18 @@ class MCPUnsubscribeResourceIROp(BaseModel):
     uri: str
 
 
+class MCPGetPromptIROp(BaseModel):
+    """#2597 slice ②c: fetch one rendered MCP prompt (messages) by name.
+    Permission-gated + event-emitting like ``MCPReadResourceIROp`` (external,
+    possibly sensitive server-authored content) — unlike the discovery-only
+    ``mcp_list_prompts`` path, which mirrors ``list_tools``/``list_resources``
+    (no permission gate, no op-kind)."""
+    kind: Literal["mcp_get_prompt"]
+    server: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
 class AskUserIROp(BaseModel):
     kind: Literal["ask_user"]
     question: str
@@ -577,6 +589,10 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # (mcp_resource_updated), not routed through the Op union at all.
     "mcp_subscribe_resource": MCPSubscribeResourceIROp,
     "mcp_unsubscribe_resource": MCPUnsubscribeResourceIROp,
+    # #2597 slice ②c: prompts consumption — get is permission-gated (external
+    # content); list stays op-kind-free, mirroring list_tools/list_resources (see
+    # op_runtime/mcp_get_prompt.py + session.py's _mcp_list_prompts).
+    "mcp_get_prompt": MCPGetPromptIROp,
     "ask_user":    AskUserIROp,
     "web_fetch":   WebFetchIROp,
     "web_search":  WebSearchIROp,
@@ -627,6 +643,7 @@ if TYPE_CHECKING:
             GlobFilesIROp, GrepFilesIROp,
             MCPIROp, MCPReadResourceIROp,
             MCPSubscribeResourceIROp, MCPUnsubscribeResourceIROp,
+            MCPGetPromptIROp,
             AskUserIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -67,6 +67,8 @@ def get_default_registry() -> ToolRegistry:
     from reyn.tools.mcp import (
         CALL_MCP_TOOL,
         DESCRIBE_MCP_TOOL,
+        GET_MCP_PROMPT,
+        LIST_MCP_PROMPTS,
         LIST_MCP_RESOURCE_TEMPLATES,
         LIST_MCP_RESOURCES,
         LIST_MCP_SERVERS,
@@ -162,6 +164,9 @@ def get_default_registry() -> ToolRegistry:
     # #2597 slice ②b: resource subscriptions.
     registry.register(SUBSCRIBE_MCP_RESOURCE)
     registry.register(UNSUBSCRIBE_MCP_RESOURCE)
+    # #2597 slice ②c: prompts consumption (list/get).
+    registry.register(LIST_MCP_PROMPTS)
+    registry.register(GET_MCP_PROMPT)
     # Memory ops (Wave 2 — Type C closure: memory write phase-side)
     registry.register(LIST_MEMORY)
     registry.register(READ_MEMORY_BODY)

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -35,13 +35,20 @@ event-source itself — the resulting notification lands as an
                                the server)
   UNSUBSCRIBE_MCP_RESOURCE  — gates.router=allow
 
+#2597 slice ②c adds TWO more, parallel to the ②a resources set (prompts
+have no subscribe concept, so no ②b-style pair here):
+
+  LIST_MCP_PROMPTS  — gates.router=allow (mirrors LIST_MCP_RESOURCES)
+  GET_MCP_PROMPT    — gates.router=allow (mirrors READ_MCP_RESOURCE's
+                       external-content + permission-gated shape)
+
 ## Router-side dispatch
 
 The router-side handlers are thin adapters over the existing session-level
 callbacks (mcp_list_servers / mcp_list_tools / mcp_call_tool / #2597
-mcp_list_resources / mcp_list_resource_templates / mcp_read_resource). The
-ToolContext router_state carries the host adapter; adapters pull from
-ctx.router_state.
+mcp_list_resources / mcp_list_resource_templates / mcp_read_resource /
+mcp_list_prompts / mcp_get_prompt). The ToolContext router_state carries the
+host adapter; adapters pull from ctx.router_state.
 
 ## DO NOT TOUCH shared files
 
@@ -254,6 +261,53 @@ _UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
 }
 
 
+# ── #2597 slice ②c: prompts consumption parameters ────────────────────────────
+
+_LIST_MCP_PROMPTS_DESCRIPTION = (
+    "List prompts exposed by one MCP server "
+    "(with name + description + arguments per prompt)."
+)
+
+_LIST_MCP_PROMPTS_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+    },
+    "required": ["server"],
+}
+
+_GET_MCP_PROMPT_DESCRIPTION = (
+    "Fetch one rendered MCP prompt's messages by name. Get the name (and its "
+    "argument schema) from list_mcp_prompts."
+)
+
+_GET_MCP_PROMPT_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "server": {
+            "type": "string",
+            "description": "MCP server name — choose from the enum (verbatim).",
+        },
+        "name": {
+            "type": "string",
+            "description": "Prompt name, verbatim from list_mcp_prompts.",
+        },
+        "arguments": {
+            "type": "object",
+            "description": (
+                "Arguments to render the prompt with, matching the shape "
+                "from list_mcp_prompts' arguments field. Optional — omit "
+                "for a prompt that takes none."
+            ),
+        },
+    },
+    "required": ["server", "name"],
+}
+
+
 # ── Handlers ──────────────────────────────────────────────────────────────────
 
 async def _handle_list_mcp_servers(
@@ -395,6 +449,40 @@ async def _handle_unsubscribe_mcp_resource(
     server = str(args["server"])
     uri = str(args["uri"])
     return await host.mcp_unsubscribe_resource(server, uri)
+
+
+async def _handle_list_mcp_prompts(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for list_mcp_prompts.
+
+    Delegates to host.mcp_list_prompts(server) via ctx.router_state —
+    mirrors _handle_list_mcp_resources exactly (prompts are addressed by
+    name, not URI, but the discovery shape is otherwise identical).
+    """
+    host = _require_host(ctx)
+    server = str(args["server"])
+    result = await host.mcp_list_prompts(server)
+    if result and isinstance(result[0], Mapping) and "error" in result[0]:
+        return {"error": result[0]["error"]}
+    return {"prompts": list(result or [])}
+
+
+async def _handle_get_mcp_prompt(
+    args: Mapping[str, Any], ctx: ToolContext
+) -> ToolResult:
+    """Adapter for get_mcp_prompt.
+
+    Delegates to host.mcp_get_prompt(server, name, arguments) via
+    ctx.router_state. Mirrors _handle_read_mcp_resource's delegation shape;
+    the gated content itself is enforced upstream (require_mcp on the
+    mcp_get_prompt op kind), not here.
+    """
+    host = _require_host(ctx)
+    server = str(args["server"])
+    name = str(args["name"])
+    arguments = dict(args.get("arguments") or {})
+    return await host.mcp_get_prompt(server, name, arguments)
 
 
 async def _handle_call_mcp_tool(
@@ -657,6 +745,38 @@ UNSUBSCRIBE_MCP_RESOURCE = ToolDefinition(
     handler=_handle_unsubscribe_mcp_resource,
     category="discovery",
     purity="side_effect",
+    schema_enricher=_enrich_router_schema,
+)
+
+
+# ── #2597 slice ②c: prompts consumption ToolDefinitions ───────────────────────
+# Parallel to LIST_MCP_RESOURCES / READ_MCP_RESOURCE above — same gates, same
+# schema-enrichment reuse (server enum only; _enrich_router_schema no-ops on
+# the absent mcp_tool_name prop for these two). No subscribe analogue.
+
+LIST_MCP_PROMPTS = ToolDefinition(
+    name="list_mcp_prompts",
+    router_dispatched=True,
+    description=_LIST_MCP_PROMPTS_DESCRIPTION,
+    parameters=_LIST_MCP_PROMPTS_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_list_mcp_prompts,
+    category="discovery",
+    purity="read_only",
+    returns_external_content=True,  # FP-0050/#1822: external server-authored prompt listing
+    schema_enricher=_enrich_router_schema,
+)
+
+GET_MCP_PROMPT = ToolDefinition(
+    name="get_mcp_prompt",
+    router_dispatched=True,
+    description=_GET_MCP_PROMPT_DESCRIPTION,
+    parameters=_GET_MCP_PROMPT_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_get_mcp_prompt,
+    category="discovery",
+    purity="read_only",  # a prompt fetch has no reyn-side side effects (unlike call_mcp_tool)
+    returns_external_content=True,  # FP-0050/#1822: external MCP server prompt content
     schema_enricher=_enrich_router_schema,
 )
 

--- a/tests/_support/mcp_fastmcp_echo_server.py
+++ b/tests/_support/mcp_fastmcp_echo_server.py
@@ -27,6 +27,10 @@ Tools:
                             (the resource analog of ``pid()``). Used by #2597 slice
                             ②a to prove a 2nd ``read_resource`` hit the SAME held
                             subprocess.
+  - ``pid_prompt``       -> a PROMPT whose rendered message is this server
+                            process's PID (the prompt analog of ``pid()``). Used
+                            by #2597 slice ②c to prove a 2nd ``get_prompt`` hit
+                            the SAME held subprocess.
   - ``bump()`` /         -> a per-process side-effect counter (#2597 S2a). ``bump``
     ``bump_then_die()``     increments + returns the count; ``bump_then_die``
                             increments THEN kills the subprocess AFTER the side
@@ -80,6 +84,17 @@ def pid() -> int:
 # re-handshake) — the resource-path twin of the S2a ``pid()`` tool round-trip.
 @mcp.resource("resource://pid")
 def pid_resource() -> str:
+    import os
+
+    return str(os.getpid())
+
+
+# #2597 slice ②c: a prompt whose RENDERED MESSAGE is this server process's PID —
+# the prompt analog of the ``pid()`` tool / ``resource://pid`` resource.
+# Held-connection-reuse tests get it twice and assert the same PID, proving the
+# 2nd get hit the SAME held subprocess (no re-handshake).
+@mcp.prompt()
+def pid_prompt() -> str:
     import os
 
     return str(os.getpid())

--- a/tests/_support/mcp_prompts_server.py
+++ b/tests/_support/mcp_prompts_server.py
@@ -1,0 +1,64 @@
+"""Low-level real MCP stdio server that advertises the ``prompts`` capability
+(#2597 slice ②c — prompts consumption).
+
+Standalone script — run as a subprocess, never imported. Uses the LOW-LEVEL
+``mcp.server.lowlevel.Server`` (like ``mcp_resources_server.py`` /
+``mcp_paginated_tools_server.py``) rather than ``FastMCP`` — verified
+empirically (see ``mcp_resources_server.py``'s module docstring) that a
+FastMCP-built server ALWAYS advertises non-None ``tools``/``resources``/
+``prompts``/``logging`` capabilities regardless of what it registers, so it
+cannot demonstrate a server that does NOT advertise a capability. The
+low-level SDK ``Server`` instead derives ``ServerCapabilities`` from which
+handler types were actually registered (``get_capabilities()``), so a server
+that registers ONLY ``@app.list_prompts()``/``@app.get_prompt()`` (no
+``@app.list_tools()``) gets ``prompts`` non-None and ``tools`` None — the
+real differentiator this gate slice needs to prove ``MCPClient.supports()``
+reads the ACTUAL negotiated capabilities rather than a hardcoded reyn-side
+assumption.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
+
+app = Server("reyn-test-prompts")
+
+_NAME = "greeting"
+_DESCRIPTION = "A simple greeting prompt"
+_RENDERED_TEXT = "hello from a prompt"
+
+
+@app.list_prompts()
+async def list_prompts() -> list[types.Prompt]:
+    return [
+        types.Prompt(
+            name=_NAME,
+            description=_DESCRIPTION,
+            arguments=[types.PromptArgument(name="style", description="tone", required=False)],
+        )
+    ]
+
+
+@app.get_prompt()
+async def get_prompt(name: str, arguments: dict | None) -> types.GetPromptResult:
+    return types.GetPromptResult(
+        description=_DESCRIPTION,
+        messages=[
+            types.PromptMessage(
+                role="user",
+                content=types.TextContent(type="text", text=_RENDERED_TEXT),
+            )
+        ],
+    )
+
+
+async def main() -> None:
+    async with stdio_server() as (read, write):
+        await app.run(read, write, app.create_initialization_options())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -39,6 +39,8 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
     # #2597 slice ②b: resource subscriptions — the async push event-source.
     "subscribe_mcp_resource", "unsubscribe_mcp_resource",
+    # #2597 slice ②c: prompts consumption — parallel to the resources surface above.
+    "list_mcp_prompts", "get_mcp_prompt",
     "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
     "recall", "drop_source", "compact",
     "list_actions", "search_actions", "describe_action", "invoke_action",

--- a/tests/test_2597_prompts_consumption.py
+++ b/tests/test_2597_prompts_consumption.py
@@ -1,0 +1,498 @@
+"""Tests for #2597 slice ②c — MCP prompts consumption (list/get).
+
+Real instances only, per the testing policy: no ``unittest.mock`` / ``MagicMock`` /
+``AsyncMock`` / ``patch``. Round-trips spawn REAL MCP servers (stdio subprocess),
+mirroring ``test_2597_s2a_mcp_resources_consumption.py``:
+
+  - ``mcp_prompts_server.py`` (low-level SDK) — registers ONLY a prompt
+    (``greeting`` -> "hello from a prompt"), no tools, no resources. The real
+    "server advertises prompts" case.
+  - ``mcp_paginated_tools_server.py`` (low-level SDK, tools-only) — registers NO
+    prompt handlers, so its negotiated ``prompts`` capability is None. The real
+    "server does NOT advertise prompts" case for the gated fail-fast tests.
+
+Prompts have no subscribe concept — out of scope entirely, unlike resources.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.gateway import MCPFault, MCPGateway
+from reyn.mcp.pool import MCPClientPool
+from reyn.schemas.models import MCPGetPromptIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, InterventionBus, UserIntervention
+
+
+class _UnusedBus(InterventionBus):
+    """A real InterventionBus that fails the test if ever actually invoked — the
+    non-interactive resolver paths below resolve without prompting (deny:
+    ungranted decl fails before `_approve`; allow: config `mcp: allow`
+    short-circuits `_approve`), so `request()` should never be called."""
+
+    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
+        raise AssertionError(f"intervention bus should not be consulted: {iv}")
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_PROMPTS_SERVER = _SUPPORT_DIR / "mcp_prompts_server.py"
+_TOOLS_ONLY_SERVER = _SUPPORT_DIR / "mcp_paginated_tools_server.py"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_PROMPT_NAME = "greeting"
+_PROMPT_TEXT = "hello from a prompt"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Tier 1: MCPClient — real round-trip against a real prompts server ─────────
+
+
+def test_list_prompts_returns_registered_prompt():
+    """Tier 1: MCPClient.list_prompts() returns the one prompt a real server
+    registers, flattened to a plain dict with the real name/description/arguments."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_PROMPTS_SERVER)) as client:
+            return await client.list_prompts()
+
+    (prompt,) = _run(_it())  # unpack: exactly one entry — a server-count invariant, not a format pin
+    assert prompt["name"] == _PROMPT_NAME
+    assert prompt["description"] == "A simple greeting prompt"
+    assert prompt["arguments"][0]["name"] == "style"
+
+
+def test_get_prompt_returns_rendered_messages():
+    """Tier 1: MCPClient.get_prompt(name) returns {"description", "messages"}
+    with the real server-rendered text."""
+
+    async def _it():
+        async with MCPClient(_stdio_cfg(_PROMPTS_SERVER)) as client:
+            return await client.get_prompt(_PROMPT_NAME)
+
+    result = _run(_it())
+    assert result["description"] == "A simple greeting prompt"
+    (message,) = result["messages"]  # unpack: exactly one message for this single-prompt server
+    assert message["content"]["text"] == _PROMPT_TEXT
+
+
+def test_list_prompts_fails_fast_against_server_without_prompts_capability():
+    """Tier 1: the #2597 capability gate blocks list_prompts against a real
+    server that never advertised "prompts" — a clear MCPError, not a raw
+    protocol error or a silent empty list."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_TOOLS_ONLY_SERVER), server_name="tools-only-srv"
+        ) as client:
+            await client.list_prompts()
+
+    with pytest.raises(MCPError) as exc_info:
+        _run(_it())
+    message = str(exc_info.value)
+    assert "prompts" in message
+    assert "tools-only-srv" in message
+
+
+def test_get_prompt_fails_fast_against_server_without_prompts_capability():
+    """Tier 1: same gate for get_prompt — the content-returning call fails
+    fast rather than reaching (and confusing) the server."""
+
+    async def _it():
+        async with MCPClient(
+            _stdio_cfg(_TOOLS_ONLY_SERVER), server_name="tools-only-srv"
+        ) as client:
+            await client.get_prompt("anything")
+
+    with pytest.raises(MCPError) as exc_info:
+        _run(_it())
+    message = str(exc_info.value)
+    assert "prompts" in message
+    assert "tools-only-srv" in message
+
+
+# ── Tier 1: MCPGateway — prompts pass-throughs ─────────────────────────────────
+
+
+def test_gateway_list_prompts_round_trip():
+    """Tier 1: MCPGateway.list_prompts opens + lists + tears down through the
+    same fault-contained seam as list_resources/list_tools."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.list_prompts("prompts-srv", _stdio_cfg(_PROMPTS_SERVER))
+
+    prompts = _run(_it())
+    assert prompts[0]["name"] == _PROMPT_NAME
+
+
+def test_gateway_get_prompt_round_trip():
+    """Tier 1: MCPGateway.get_prompt returns the flattened messages."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.get_prompt(
+            "prompts-srv", _PROMPT_NAME, {}, _stdio_cfg(_PROMPTS_SERVER)
+        )
+
+    result = _run(_it())
+    assert result["messages"][0]["content"]["text"] == _PROMPT_TEXT
+
+
+def test_gateway_get_prompt_raises_mcp_fault_on_ungated_server():
+    """Tier 1: the gateway surfaces the capability-gate failure as MCPFault (its
+    ONE contained-fault type), never a bare MCPError/protocol exception."""
+    gateway = MCPGateway()
+
+    async def _it():
+        return await gateway.get_prompt(
+            "tools-only", "x", {}, _stdio_cfg(_TOOLS_ONLY_SERVER)
+        )
+
+    with pytest.raises(MCPFault):
+        _run(_it())
+
+
+# ── Tier 2: held connection (non-ephemeral session path) — the PRODUCTION path ─
+# The live (non-ephemeral) session routes prompt gets through a held-open
+# MCPConnectionService (Option C), NOT the one-shot MCPGateway() pool the tests
+# above exercise. That path hands the gateway a _HeldConnection (not a bare
+# MCPClient), so get_prompt/list_prompts must exist ON THE HELD HANDLE or the
+# call AttributeErrors (the exact #2605-review gap ②a hit) — these tests route
+# through a REAL MCPConnectionService — the coverage the one-shot-pool tests
+# structurally cannot give.
+
+
+@pytest.mark.asyncio
+async def test_held_connection_gets_prompt_and_reuses_subprocess():
+    """Tier 2: the CORE held-path coverage — a prompt get through a REAL
+    MCPConnectionService (via MCPGateway(pool=service), exactly as the live session
+    wires it) works, and a 2nd get hits the SAME held subprocess. Proven via the
+    echo server's ``pid_prompt`` (rendered text = the server PID): identical PID
+    across two gets = the held connection was reused, no re-handshake."""
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    service = MCPConnectionService()
+    try:
+        gateway = MCPGateway(pool=service)
+        r1 = await gateway.get_prompt("srv", "pid_prompt", {}, _stdio_cfg(_ECHO_SERVER))
+        r2 = await gateway.get_prompt("srv", "pid_prompt", {}, _stdio_cfg(_ECHO_SERVER))
+        pid_1 = r1["messages"][0]["content"]["text"]
+        pid_2 = r2["messages"][0]["content"]["text"]
+        assert pid_1 and pid_1 == pid_2, "same held subprocess reused across gets (no re-handshake)"
+        assert service.held_servers() == ["srv"], "the connection is held open, not opened+closed per get"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_held_connection_lists_prompts():
+    """Tier 2: list_prompts on the HELD handle (_HeldConnection) — must exist
+    there (not just on the one-shot MCPClient), routed through the same
+    MCPConnectionService the live session uses."""
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    service = MCPConnectionService()
+    try:
+        gateway = MCPGateway(pool=service)
+        prompts = await gateway.list_prompts("srv", _stdio_cfg(_ECHO_SERVER))
+        names = [p["name"] for p in prompts]
+        assert "pid_prompt" in names, "the echo server's pid prompt is listed via the held handle"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_execute_gets_via_connection_service_not_just_pool():
+    """Tier 2: the op handler's _execute gets through ctx.mcp_connection_service
+    (the non-ephemeral session's wiring) — NOT only ctx.mcp_pool. Mirrors the
+    ``_mcp_get_prompt`` non-ephemeral branch (session.py) which sets
+    ctx.mcp_connection_service, the path the ②a resources crash lived on."""
+    from reyn.core.op_runtime.mcp_get_prompt import _execute
+    from reyn.mcp.connection_service import MCPConnectionService
+
+    events = EventLog()
+    service = MCPConnectionService()
+    op = MCPGetPromptIROp(kind="mcp_get_prompt", server="srv", name="pid_prompt", arguments={})
+
+    try:
+        ctx = OpContext(
+            workspace=Workspace(events=events),
+            events=events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=None,  # permission bypassed — this asserts the transport wiring
+            mcp_servers={"srv": _stdio_cfg(_ECHO_SERVER)},
+            actor="chat_router",
+        )
+        ctx.mcp_connection_service = service  # the non-ephemeral wiring (not mcp_pool)
+        result = await _execute(op, ctx)
+    finally:
+        await service.aclose()
+
+    assert result["status"] == "ok"
+    assert result["messages"][0]["content"]["text"], "prompt content read through the held connection service"
+
+
+# ── Tier 2: op_runtime mcp_get_prompt — permission gate + events ──────────────
+
+
+def _make_ctx(
+    tmp_path: Path,
+    events: EventLog,
+    *,
+    resolver: "PermissionResolver | None",
+    decl: "PermissionDecl | None" = None,
+) -> OpContext:
+    return OpContext(
+        workspace=Workspace(events=events),
+        events=events,
+        permission_decl=decl or PermissionDecl(),
+        permission_resolver=resolver,
+        mcp_servers={"prompts-srv": _stdio_cfg(_PROMPTS_SERVER)},
+        actor="chat_router",
+    )
+
+
+def test_execute_gets_real_prompt_and_emits_events(tmp_path):
+    """Tier 2: the op handler's _execute (permission bypassed — mirrors the
+    existing mcp_read_resource.py _execute test pattern) gets a REAL prompt
+    through a REAL MCPClientPool and emits mcp_prompt_get + mcp_prompt_get_completed."""
+    from reyn.core.op_runtime.mcp_get_prompt import _execute
+
+    events = EventLog()
+    op = MCPGetPromptIROp(kind="mcp_get_prompt", server="prompts-srv", name=_PROMPT_NAME, arguments={})
+
+    async def _it():
+        ctx = _make_ctx(tmp_path, events, resolver=None)
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await _execute(op, ctx)
+
+    result = _run(_it())
+    assert result["status"] == "ok"
+    assert result["messages"][0]["content"]["text"] == _PROMPT_TEXT
+
+    types_seen = [e.type for e in events.all()]
+    assert "mcp_prompt_get" in types_seen
+    assert "mcp_prompt_get_completed" in types_seen
+    assert "mcp_prompt_get_failed" not in types_seen
+
+
+def test_handle_denies_without_permissions_mcp_declared(tmp_path):
+    """Tier 2: P6/P5-style invariant — execute_op on mcp_get_prompt denies
+    (status='denied' + permission_denied event) when the caller's PermissionDecl
+    does not declare the server under `mcp`, mirroring the `mcp_read_resource`
+    op's own require_mcp gate exactly."""
+    events = EventLog()
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+    # No mcp=[...] on the decl — the AgentLayer grant is empty.
+    ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=PermissionDecl())
+    ctx.intervention_bus = _UnusedBus()  # never consulted: denied before _approve
+
+    op = MCPGetPromptIROp(kind="mcp_get_prompt", server="prompts-srv", name=_PROMPT_NAME, arguments={})
+    result = _run(execute_op(op, ctx))
+
+    assert result["status"] == "denied"
+    denials = [e for e in events.all() if e.type == "permission_denied"]
+    assert denials, f"expected permission_denied event; got {[e.type for e in events.all()]}"
+    assert denials[0].data.get("kind") == "mcp_get_prompt"
+
+
+def test_handle_allows_and_gets_when_permissions_mcp_granted(tmp_path):
+    """Tier 2: the allow path — decl.mcp includes the server + config grants
+    `mcp: allow`, so require_mcp passes and the REAL prompt is fetched end-to-end
+    through execute_op (permission gate -> gateway -> real subprocess)."""
+    events = EventLog()
+    resolver = PermissionResolver(
+        config_permissions={"mcp": "allow"}, project_root=tmp_path, interactive=False,
+    )
+    decl = PermissionDecl(mcp=["prompts-srv"])
+    ctx = _make_ctx(tmp_path, events, resolver=resolver, decl=decl)
+    ctx.intervention_bus = _UnusedBus()  # never consulted: config-approved short-circuits _approve
+
+    op = MCPGetPromptIROp(kind="mcp_get_prompt", server="prompts-srv", name=_PROMPT_NAME, arguments={})
+
+    async def _it():
+        async with MCPClientPool() as pool:
+            ctx.mcp_pool = pool
+            return await execute_op(op, ctx)
+
+    result = _run(_it())
+    assert result["status"] == "ok"
+    assert result["messages"][0]["content"]["text"] == _PROMPT_TEXT
+    assert not [e for e in events.all() if e.type == "permission_denied"]
+
+
+def test_execute_reports_error_for_unconfigured_server(tmp_path):
+    """Tier 2: _execute returns a clean status='error' (never raises) when the
+    op names a server absent from ctx.mcp_servers — the same not-configured
+    shape the `mcp_read_resource` op returns."""
+    from reyn.core.op_runtime.mcp_get_prompt import _execute
+
+    events = EventLog()
+    op = MCPGetPromptIROp(kind="mcp_get_prompt", server="nope", name="x", arguments={})
+    ctx = _make_ctx(tmp_path, events, resolver=None)
+
+    result = _run(_execute(op, ctx))
+    assert result["status"] == "error"
+    assert "not configured" in result["error"]
+
+
+# ── Tier 2: op-kind registry completeness ─────────────────────────────────────
+
+
+def test_mcp_get_prompt_registered_in_op_kind_model_map():
+    """Tier 2: OP_KIND_MODEL_MAP <-> Op union completeness invariant — the new
+    kind is registered (control-ir.md hard rule)."""
+    from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, MCPGetPromptIROp
+
+    assert "mcp_get_prompt" in ALL_OP_KINDS
+    assert OP_KIND_MODEL_MAP["mcp_get_prompt"] is MCPGetPromptIROp
+
+
+# ── Tier 2: canonical offload mapping (a large non-text block does not double-oversize) ─
+
+
+def test_canonical_mapper_joins_text_and_isolates_non_text_as_structured():
+    """Tier 2: #2425-style offload safety — _mcp_get_prompt_to_canonical joins
+    text content into `text` (the sole offload payload) and keeps a non-text
+    content block as a `structured` attachment, never a second text-competing
+    field (the exact shape of bug the tool-call / resource-read canonical
+    mappers already fixed)."""
+    from reyn.core.offload.canonical import to_canonical
+
+    result = {
+        "kind": "mcp_get_prompt",
+        "status": "ok",
+        "server": "prompts-srv",
+        "name": _PROMPT_NAME,
+        "description": "A simple greeting prompt",
+        "messages": [
+            {"role": "user", "content": {"type": "text", "text": "hello"}},
+            {"role": "user", "content": {"type": "image", "data": "YWJj", "mimeType": "image/png"}},
+        ],
+    }
+    canonical = to_canonical(result)
+    assert canonical["text"] == "hello"
+    assert canonical["attachments"] == [
+        {"kind": "structured", "data": {"type": "image", "data": "YWJj", "mimeType": "image/png"}},
+    ]
+    assert canonical["meta"]["kind"] == "mcp_get_prompt"
+
+
+# ── Tier 2: tools/mcp.py verbs — delegation via a Fake host (no mocks) ────────
+
+
+class _RecordingPromptHost:
+    """A trivial Fake at the host.mcp_list_prompts/mcp_get_prompt boundary —
+    records calls and returns canned data (mirrors _RecordingResourceHost in
+    test_2597_s2a_mcp_resources_consumption.py)."""
+
+    def __init__(self, *, prompts=None, get_result=None) -> None:
+        self.prompts = prompts if prompts is not None else [
+            {"name": _PROMPT_NAME, "description": "A simple greeting prompt", "arguments": []}
+        ]
+        self.get_result = get_result if get_result is not None else {
+            "status": "ok",
+            "messages": [{"role": "user", "content": {"type": "text", "text": _PROMPT_TEXT}}],
+        }
+        self.list_calls: list[str] = []
+        self.get_calls: list[tuple] = []
+
+    async def mcp_list_prompts(self, server: str):
+        self.list_calls.append(server)
+        return self.prompts
+
+    async def mcp_get_prompt(self, server: str, name: str, arguments=None):
+        self.get_calls.append((server, name, arguments))
+        return self.get_result
+
+
+def _tool_ctx(host):
+    from reyn.tools.types import RouterCallerState, ToolContext
+
+    return ToolContext(
+        caller_kind="router", events=None, permission_resolver=None, workspace=None,
+        router_state=RouterCallerState(host=host),
+    )
+
+
+def test_list_mcp_prompts_handler_delegates_to_host():
+    """Tier 2: _handle_list_mcp_prompts delegates to host.mcp_list_prompts
+    and wraps the result under "prompts" (mirrors _handle_list_mcp_resources)."""
+    from reyn.tools.mcp import _handle_list_mcp_prompts
+
+    host = _RecordingPromptHost()
+    result = _run(_handle_list_mcp_prompts({"server": "prompts-srv"}, _tool_ctx(host)))
+
+    assert host.list_calls == ["prompts-srv"]
+    assert result["prompts"] == host.prompts
+
+
+def test_get_mcp_prompt_handler_delegates_to_host():
+    """Tier 2: _handle_get_mcp_prompt delegates (server, name, arguments) to
+    host.mcp_get_prompt and returns its result verbatim (gating already
+    happened upstream at the op-kind permission layer, not here)."""
+    from reyn.tools.mcp import _handle_get_mcp_prompt
+
+    host = _RecordingPromptHost()
+    result = _run(
+        _handle_get_mcp_prompt(
+            {"server": "prompts-srv", "name": _PROMPT_NAME, "arguments": {"style": "brief"}},
+            _tool_ctx(host),
+        )
+    )
+
+    assert host.get_calls == [("prompts-srv", _PROMPT_NAME, {"style": "brief"})]
+    assert result == host.get_result
+
+
+def test_list_mcp_prompts_handler_surfaces_host_error():
+    """Tier 2: an [{"error": ...}] from the host (e.g. server unreachable)
+    surfaces as a top-level {"error": ...}, not wrapped under "prompts"
+    (mirrors _handle_list_mcp_resources' error-surfacing branch)."""
+    from reyn.tools.mcp import _handle_list_mcp_prompts
+
+    host = _RecordingPromptHost(prompts=[{"error": "MCP server 'x' not configured"}])
+    result = _run(_handle_list_mcp_prompts({"server": "x"}, _tool_ctx(host)))
+
+    assert result == {"error": "MCP server 'x' not configured"}
+
+
+# ── Tier 2: ToolDefinition registration shape ─────────────────────────────────
+
+
+def test_new_tool_definitions_registered_router_and_phase_allow():
+    """Tier 2: the 2 new ToolDefinitions are router+phase allow, discovery
+    category, and read_only purity (mirrors LIST_MCP_RESOURCES/READ_MCP_RESOURCE)."""
+    from reyn.tools.mcp import GET_MCP_PROMPT, LIST_MCP_PROMPTS
+
+    for td in (LIST_MCP_PROMPTS, GET_MCP_PROMPT):
+        assert td.gates.router == "allow"
+        assert td.gates.phase == "allow"
+        assert td.category == "discovery"
+        assert td.purity == "read_only"
+
+
+def test_new_tool_definitions_present_in_default_registry():
+    """Tier 2: get_default_registry() includes the 2 new capabilities under
+    their canonical chat-tool names."""
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    assert registry.lookup("list_mcp_prompts") is not None
+    assert registry.lookup("get_mcp_prompt") is not None

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -27,6 +27,9 @@ _EXTERNAL = {
     # #2597 slice ②a: resources consumption — same fencing rationale as the tools
     # surface above (external server-authored listing / content).
     "list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource",
+    # #2597 slice ②c: prompts consumption — same fencing rationale as the
+    # resources surface above (external server-authored listing / content).
+    "list_mcp_prompts", "get_mcp_prompt",
     "web_search", "web_fetch",           # internet
 }
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

Adds `list_mcp_prompts` / `get_mcp_prompt`, mirroring the already-merged ②a resources-consumption slice (`list_mcp_resources` / `read_mcp_resource`) exactly:

- `MCPClient.list_prompts()` / `get_prompt(name, arguments)` — gated on the negotiated `"prompts"` capability (`require_capability`), using FastMCP 3.4.2's auto-paginating `list_prompts()` + raw `get_prompt_mcp()` (verified against the installed SDK: `Client.get_prompt_mcp(name, arguments, meta) -> mcp.types.GetPromptResult`).
- `MCPGateway.list_prompts` / `get_prompt` pass-throughs (fault-contained, per-call timeout — mirrors `list_resources`/`read_resource`).
- `_HeldConnection.list_prompts` / `get_prompt` on `MCPConnectionService` — the ②a-lesson wiring: the held (non-ephemeral session) path MUST expose these or the production path AttributeErrors. Both heal with `heal_only=False` (idempotent reads, retry-once on a fresh connection).
- New `mcp_get_prompt` op kind (`src/reyn/core/op_runtime/mcp_get_prompt.py`) — permission-gated (`require_mcp`, same axis as `mcp`/`mcp_read_resource`), emits `mcp_prompt_get` / `mcp_prompt_get_completed` / `mcp_prompt_get_failed`. Registered in `OP_KIND_MODEL_MAP` (`schemas/models.py`) + documented in `docs/reference/runtime/control-ir.md` in this same PR (hard rule). Discovery (`list_prompts`) is unpermissioned metadata, like `list_tools`/`list_resources` — only `get_prompt` is gated.
- `tools/mcp.py` + `tools/__init__.py` — `list_mcp_prompts(server)` / `get_mcp_prompt(server, name, arguments?)` LLM verbs, `returns_external_content=True`, `read_only` purity.
- `session.py` / `router_host_adapter.py` / `router_loop.py` — host-adapter methods routed through the held connection service (non-ephemeral) / one-shot pool (ephemeral), exactly as ②a wired resources.
- `core/offload/canonical.py` — `mcp_get_prompt` plugged into the #2425 canonical-offload mapper (`_mcp_get_prompt_to_canonical`): a rendered prompt's `messages` joins text content into the sole `text` payload; a non-text content block (image/audio/embedded-resource) becomes a `structured` attachment, same isolation `_mcp_read_resource_to_canonical` gives a resource's `blob`.
- Docs: `docs/concepts/tools-integrations/mcp.md` (new "Prompts: list + get" section) + `docs/feature-map.md` mirroring the ②a resources entries.

**Out of scope**: prompts have no subscribe concept (MCP defines no per-prompt push — only the coarser `prompts/list_changed`, already bridged to `mcp_prompt_list_changed` by the existing S2b-log message handler). Resources/subscribe/elicitation/OAuth/logging are untouched.

## Testing

`tests/test_2597_prompts_consumption.py` — real instances only (no `MagicMock`/`AsyncMock`/`patch`), mirrors `test_2597_s2a_mcp_resources_consumption.py`:

- Two new real MCP stdio test-double servers: `tests/_support/mcp_prompts_server.py` (low-level SDK — registers ONLY a prompt, so `prompts` capability is negotiated non-None, `tools`/`resources` are None — the real capability-gate differentiator) and reuse of `mcp_paginated_tools_server.py` (tools-only, `prompts` is None) for the gated fail-fast tests.
- `mcp_fastmcp_echo_server.py` gained a `pid_prompt` prompt (rendered text = the server PID) — the prompt analog of the existing `resource://pid` / `pid()` reuse probes.
- **Held-path coverage (the ②a lesson) — confirmed**: `test_held_connection_gets_prompt_and_reuses_subprocess` and `test_held_connection_lists_prompts` route through a REAL `MCPConnectionService` (via `MCPGateway(pool=service)`), asserting a 2nd `get_prompt` reuses the SAME held subprocess (PID parity). `test_execute_gets_via_connection_service_not_just_pool` exercises the op handler's `_execute` through `ctx.mcp_connection_service`, not just `ctx.mcp_pool` — the exact production path that crashed on ②a's first pass.
- Capability-gate fail-fast (list + get against a server without `prompts`), permission gate (deny/allow via `execute_op`), canonical-offload mapper isolation, tool-verb delegation via a Fake host, `OP_KIND_MODEL_MAP` completeness, `ToolDefinition` registration shape.
- Golden-test updates (mirrors how ②a updated them): `test_2123_router_dispatch_sot_1953.py` (dispatch-set completeness) and `test_returns_external_content_flagset_1822.py` (external-content fencing) both gained `list_mcp_prompts`/`get_mcp_prompt` entries.

## 4-gate output (all green; ran from repo root)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2597_prompts_consumption.py tests/test_2123_router_dispatch_sot_1953.py tests/test_returns_external_content_flagset_1822.py
Summary: 29 tests inspected
  ✓ OK: 29
  ⚠️ warnings: 0 (bounded-life candidates)
  ✗ errors: 0 (Tier 4 violations)
Exit code: 0

$ pytest -q
5 failed, 7352 passed, 21 skipped, 11 warnings in 155.77s
```

The 5 failures are the pre-existing, known-unrelated #2599 web-route-mount failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`, `test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `test_resources_router.py::test_resources_route_is_mounted_on_app`) — **zero NEW failures** from this PR (confirmed: none of the 5 touch mcp/prompts/canonical/tools code).

```
$ python scripts/verify_module_docstrings.py <all changed src files>
OK: no module-docstring refactor narrative in ...
```

## Test plan

- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green on all changed/new test files (29/29 OK, 0 Tier-4 violations)
- [x] `pytest` from repo root — 7352 passed, 0 new failures (5 pre-existing #2599 web-route-mount failures, confirmed unrelated)
- [x] `verify_module_docstrings.py` green on all changed src files
- [x] Held-connection (non-ephemeral, production) path directly tested — not just the one-shot `MCPGateway()` pool (the ②a review gap)
- [x] `control-ir.md` updated with the new `mcp_get_prompt` op kind in the same PR (hard rule)
- [x] `docs/feature-map.md` + `docs/concepts/tools-integrations/mcp.md` mirror the ②a resources entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)