### PR TITLE
feat(#2608): H1 — external-event TRIGGER: MCP resources/updated fires a hook

### DIFF
--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -10,6 +10,17 @@ starter set agreed in #1800 (skill_start/skill_end removed — never dispatched)
     turn_start   turn_end
     session_start  session_end
     task_start   task_end
+
+#2608 H1 adds the first EXTERNAL-event hook-point, ``mcp_resource_updated``
+(fired by a server-pushed MCP ``resources/updated`` notification on a
+subscribed resource — see ``reyn.mcp.message_handler.on_resource_updated``
+and ``reyn.mcp.connection_service.MCPConnectionService``'s bounded
+sync->async bridge). Unlike the six lifecycle points above (fired from the
+session/turn/task run-loop on the agent's own task), this point is fired
+from the MCP receive-loop task via a bounded queue drained on the session's
+event loop. ``HookDef.matcher`` stays reserved/uninterpreted for this
+point in H1 (scoping is via which resources the user subscribed to) — a
+later slice (H2) may add matcher filtering.
 """
 from __future__ import annotations
 
@@ -27,6 +38,9 @@ ALLOWED_HOOK_POINTS: frozenset[str] = frozenset({
     "session_end",
     "task_start",
     "task_end",
+    # #2608 H1: external-event point — fired by a pushed MCP resources/updated
+    # notification for a subscribed resource, NOT by the lifecycle run-loop.
+    "mcp_resource_updated",
 })
 
 

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -86,6 +86,35 @@ memory of what the OLD (now-dead) session's client subscribed to. :meth:`_ensure
 does this re-subscribe immediately after opening a NEW client (whether that is the very
 first open, where the tracked set is empty and the loop is a no-op, or a reconnect, where
 it is the whole point) — see that method's inline comment.
+
+#2608 H1 — external-event->hooks bridge (the first slice of the external-event arc):
+``hook_trigger`` (optional, mirrors ``emit_sink``'s None-default no-op pattern) is an
+ASYNC callable ``(point, template_vars) -> Awaitable`` — in practice a closure over the
+owning session's ``HookDispatcher.dispatch``. It is never called directly from the MCP
+receive-loop task (:class:`~reyn.mcp.message_handler.ReynMCPMessageHandler` runs
+SYNCHRONOUSLY there and cannot ``await`` it — see that module's docstring). Instead this
+service exposes :meth:`enqueue_external_event` — a SYNCHRONOUS, non-blocking
+``put_nowait`` onto a BOUNDED ``asyncio.Queue`` (``_HOOK_EVENT_QUEUE_MAXSIZE`` entries)
+— and drains it with a single background task (:meth:`_drain_hook_events`) running on
+THIS service's (= the session's) event loop, which is what actually ``await``s
+``hook_trigger``. Two invariants this buys:
+
+  - **The receive loop never blocks and never stalls** on a slow/stuck hook — enqueue is
+    O(1) and non-blocking; on overflow (a burst of resource updates arriving faster than
+    hooks can be dispatched) the newest event is DROPPED + logged, never queued
+    unboundedly and never backpressured onto the receive loop. This is the same
+    "never stall / never delay other notification routing" discipline the module
+    docstring establishes for the synchronous EventLog emit.
+  - **Per-session dispatcher identity holds naturally**: because ``MCPConnectionService``
+    is constructed per-session (see ``session.py``), the ``hook_trigger`` closure it is
+    given targets THAT session's own ``HookDispatcher`` — a resource update on session A's
+    held connection can only ever fire session A's hooks.
+
+The drain task is lazily created on first ``enqueue_external_event`` call (mirrors the
+lazy client-open pattern elsewhere in this class) and cancelled in :meth:`aclose`.
+``hook_trigger=None`` (the ephemeral ``MCPClientPool`` path, or any session that never
+wires one) → :meth:`enqueue_external_event` and the whole queue/drain-task machinery
+never activate — byte-identical to pre-H1 behaviour.
 """
 from __future__ import annotations
 
@@ -98,6 +127,14 @@ from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCache
 from reyn.mcp.pool import describe_fault, is_real_control_flow
 
 logger = logging.getLogger(__name__)
+
+# #2608 H1: bound on the sync->async external-event bridge queue. Small and fixed —
+# a burst of resource-update pushes beyond this is dropped (+logged), never queued
+# unboundedly. Not currently exposed as config (H1 scope: prove the trigger mechanism;
+# tuning the bound is a follow-up if a real workload needs it).
+_HOOK_EVENT_QUEUE_MAXSIZE = 32
+
+HookTrigger = Callable[[str, dict], Awaitable[Any]]
 
 
 class MCPConnectionService:
@@ -121,6 +158,8 @@ class MCPConnectionService:
         *,
         emit_sink: EmitSink | None = None,
         tools_cache_invalidate: ToolsCacheInvalidate | None = None,
+        hook_trigger: "HookTrigger | None" = None,
+        agent_name: str | None = None,
     ) -> None:
         # #2597 S2b: threaded into a fresh ReynMCPMessageHandler per held server
         # connection (see _ensure_open). None (default) = no notifications bridge —
@@ -128,6 +167,12 @@ class MCPConnectionService:
         # a sink, so it stays byte-identical to pre-S2b behaviour.
         self._emit_sink = emit_sink
         self._tools_cache_invalidate = tools_cache_invalidate
+        # #2608 H1: the async closure over the owning session's HookDispatcher.dispatch.
+        # None = no external-event hook bridge — see module docstring's H1 section.
+        self._hook_trigger = hook_trigger
+        self._agent_name = agent_name
+        self._hook_event_queue: "asyncio.Queue[tuple[str, dict]] | None" = None
+        self._hook_drain_task: "asyncio.Task | None" = None
         self._clients: dict[str, MCPClient] = {}
         # #2597 slice ②b: runtime-only, in-memory, NO WAL (Q4 — see module docstring).
         # server name -> set of URIs currently subscribed on that server's held
@@ -196,6 +241,13 @@ class MCPConnectionService:
                 handler = ReynMCPMessageHandler(
                     self._emit_sink, server,
                     tools_cache_invalidate=self._tools_cache_invalidate,
+                    # #2608 H1: wired only when a hook_trigger was injected (this
+                    # service's enqueue_external_event is itself a no-op without one) —
+                    # so a session with no hook_trigger stays byte-identical to pre-H1.
+                    on_external_event=(
+                        self.enqueue_external_event if self._hook_trigger is not None else None
+                    ),
+                    agent_name=self._agent_name,
                 )
             client = MCPClient(
                 config, agent_id=agent_id, message_handler=handler, server_name=server,
@@ -261,6 +313,53 @@ class MCPConnectionService:
         public-surface pattern) — never reach into ``_subscriptions`` directly."""
         return sorted(self._subscriptions.get(server, ()))
 
+    # ── #2608 H1: bounded sync->async external-event->hook bridge ──────────────────
+
+    def enqueue_external_event(self, point: str, template_vars: dict) -> None:
+        """SYNCHRONOUS, non-blocking entry point called from the MCP receive-loop task
+        (``ReynMCPMessageHandler.on_resource_updated``). Never awaits, never raises,
+        never blocks — see module docstring's H1 section for the full bridge design.
+
+        No-op when ``hook_trigger`` is None (no hook wired for this session)."""
+        if self._hook_trigger is None:
+            return
+        self._ensure_hook_drain_task()
+        assert self._hook_event_queue is not None
+        try:
+            self._hook_event_queue.put_nowait((point, template_vars))
+        except asyncio.QueueFull:
+            # Bounded by construction (#2608 H1): a burst of resource updates faster
+            # than hooks can be dispatched DROPS the newest event rather than growing
+            # the queue unboundedly or blocking the receive loop.
+            logger.warning(
+                "MCPConnectionService: external-event hook queue full (maxsize=%d) — "
+                "dropping %r event (server=%r)",
+                _HOOK_EVENT_QUEUE_MAXSIZE, point, template_vars.get("server"),
+            )
+
+    def _ensure_hook_drain_task(self) -> None:
+        if self._hook_event_queue is None:
+            self._hook_event_queue = asyncio.Queue(maxsize=_HOOK_EVENT_QUEUE_MAXSIZE)
+        if self._hook_drain_task is None or self._hook_drain_task.done():
+            self._hook_drain_task = asyncio.create_task(self._drain_hook_events())
+
+    async def _drain_hook_events(self) -> None:
+        """Runs on the session's event loop (this service's owning loop — the same
+        loop the held ``fastmcp.Client`` was opened on, see module docstring), so it
+        can safely ``await hook_trigger(...)``. Per-event ``try/except``: a raising
+        (or hanging-then-raising) hook dispatch must not kill the drain task — the
+        NEXT queued event still gets a chance."""
+        assert self._hook_event_queue is not None
+        assert self._hook_trigger is not None
+        while True:
+            point, template_vars = await self._hook_event_queue.get()
+            try:
+                await self._hook_trigger(point, template_vars)
+            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
+                logger.warning(
+                    "MCPConnectionService: hook_trigger failed for %r", point, exc_info=True,
+                )
+
     def _track_subscription(self, server: str, uri: str) -> None:
         self._subscriptions.setdefault(server, set()).add(uri)
 
@@ -270,6 +369,19 @@ class MCPConnectionService:
     async def aclose(self) -> None:
         """Close every held connection. Idempotent — safe to call repeatedly (e.g. a
         session teardown seam that may run more than once)."""
+        # #2608 H1: cancel the hook-event drain task FIRST (finally-guaranteed, not
+        # except-Exception — CancelledError is a BaseException) so a client-teardown
+        # fault below can never leave the drain task orphaned across session teardown.
+        try:
+            if self._hook_drain_task is not None and not self._hook_drain_task.done():
+                self._hook_drain_task.cancel()
+                try:
+                    await self._hook_drain_task
+                except asyncio.CancelledError:
+                    pass
+        finally:
+            self._hook_drain_task = None
+
         clients = list(self._clients.items())
         self._clients.clear()
         self._handles.clear()

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -68,6 +68,14 @@ logger = logging.getLogger(__name__)
 # MCPConnectionService's emit_sink wiring.
 EmitSink = Callable[..., Any]
 ToolsCacheInvalidate = Callable[[str], None]
+# #2608 H1: SYNCHRONOUS enqueue callable (never awaited here — the handler runs on the
+# receive-loop task, see module docstring's "synchronous hook bodies"). Matches
+# ``MCPConnectionService.enqueue_external_event(point, template_vars)`` — a bounded,
+# non-blocking hand-off to the session's async HookDispatcher, drained by a task on the
+# session's own event loop. None = no external-event hook bridge (byte-identical to
+# pre-H1 behaviour — the ephemeral MCPClientPool path and any session with no
+# ``mcp_resource_updated`` hook configured never wire this).
+OnExternalEvent = Callable[[str, dict], None]
 
 
 class ReynMCPMessageHandler(TaskNotificationHandler):
@@ -81,6 +89,10 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
     ``on_resource_list_changed`` stays a base-class no-op (out of ②b's scope —
     no reyn caller subscribes to the resource LIST changing, only individual
     resource content updates).
+
+    #2608 H1: ``on_resource_updated`` ALSO fires a user-configured
+    ``mcp_resource_updated`` hook (external-event->hooks arc, first slice) via
+    ``self._on_external_event`` — see that method for the sync->async bridge design.
 
     #2597 F2 (live-verified, NOT emitted here — see :meth:`on_progress`):
     ``notifications/progress`` is NOT bridged to ``mcp_progress`` by this handler.
@@ -114,6 +126,8 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         server_name: str,
         *,
         tools_cache_invalidate: ToolsCacheInvalidate | None = None,
+        on_external_event: "OnExternalEvent | None" = None,
+        agent_name: str | None = None,
     ) -> None:
         # Deliberately bypass TaskNotificationHandler.__init__ — see module docstring
         # ("two-phase client binding"). MessageHandler.__init__ takes no arguments.
@@ -122,6 +136,10 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         self._emit_sink = emit_sink
         self._server_name = server_name
         self._tools_cache_invalidate = tools_cache_invalidate
+        # #2608 H1: the bounded sync->async bridge into this session's HookDispatcher.
+        # None = no bridge (no hook trigger wired — byte-identical to pre-H1).
+        self._on_external_event = on_external_event
+        self._agent_name = agent_name
 
     def bind_client(self, client: Any) -> None:
         """Complete the ``TaskNotificationHandler`` weakref binding once the owning
@@ -155,10 +173,35 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         # thin "something changed, re-read if you care" signal — see
         # reyn.mcp.client.MCPClient.subscribe_resource's docstring), so that's all
         # this event needs to carry too; a caller that wants the new content reads
-        # the resource again. EventLog-only — deliberately NOT wired into the hook
-        # dispatcher here (that's a future hooks-arc slice, per ②b's scope note).
+        # the resource again. EventLog emit stays the audit-trail write (unchanged).
+        #
+        # #2608 H1: in ADDITION to the EventLog emit, this ALSO fires a user-configured
+        # ``mcp_resource_updated`` hook (external-event trigger, first slice of the
+        # external-event->hooks arc). The hook trigger goes through
+        # ``self._on_external_event`` — a SYNCHRONOUS, non-blocking enqueue (never
+        # awaited here; this method runs on the receive-loop task and cannot await the
+        # async HookDispatcher.dispatch — see MCPConnectionService's bounded queue +
+        # drain-task bridge). None (no hook wired for this session, or the ephemeral
+        # per-call MCPClientPool path) → this call is a no-op, byte-identical to pre-H1.
         uri = getattr(getattr(message, "params", None), "uri", None)
-        self._emit("mcp_resource_updated", server=self._server_name, uri=str(uri) if uri is not None else None)
+        uri_str = str(uri) if uri is not None else None
+        self._emit("mcp_resource_updated", server=self._server_name, uri=uri_str)
+        if self._on_external_event is not None:
+            try:
+                self._on_external_event(
+                    "mcp_resource_updated",
+                    {
+                        "point": "mcp_resource_updated",
+                        "server": self._server_name,
+                        "uri": uri_str,
+                        "agent_name": self._agent_name,
+                    },
+                )
+            except Exception:  # noqa: BLE001 — a trigger fault must not break the receive loop
+                logger.warning(
+                    "ReynMCPMessageHandler: on_external_event failed for %r on server %r",
+                    "mcp_resource_updated", self._server_name, exc_info=True,
+                )
         await super().on_resource_updated(message)
 
     async def on_progress(self, message: Any) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1067,10 +1067,20 @@ class Session:
         # when the RouterHostAdapter is built), but neither lambda is ever CALLED until
         # a held MCP connection actually receives a server-pushed notification, long
         # after __init__ has finished.
+        # #2608 H1: ``hook_trigger`` is the SAME deferred-lambda pattern, over
+        # ``self._hook_dispatcher`` — constructed further below in this __init__ (the
+        # HookDispatcher itself needs ``self._put_inbox`` / ``self._stage_next_turn_context``
+        # / etc, already bound methods, so it's built after this point) — but, like
+        # ``emit_sink``/``tools_cache_invalidate`` above, never CALLED until a held MCP
+        # connection's receive loop enqueues an external event, long after __init__ has
+        # finished. ``self.agent_name`` IS already resolvable here (``self._agent`` is
+        # set earlier in this __init__), so it's passed eagerly (not deferred).
         from reyn.mcp.connection_service import MCPConnectionService
         self._mcp_connection_service = MCPConnectionService(
             emit_sink=lambda et, **d: self._chat_events.emit(et, **d),
             tools_cache_invalidate=lambda server: self._router_host.invalidate_mcp_tools_cache(server),
+            hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
+            agent_name=self.agent_name,
         )
         self.output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -1,0 +1,231 @@
+"""Tests for #2608 H1 — the external-event->hooks TRIGGER mechanism.
+
+H1 adds the FIRST external-event hook-point, ``mcp_resource_updated``: a REAL
+MCP ``resources/updated`` push (from a subscribed resource) fires a
+user-configured hook via a bounded sync->async bridge from
+``ReynMCPMessageHandler`` (the MCP receive-loop task) into
+``HookDispatcher.dispatch`` (the session's event loop).
+
+Real instances only, per the testing policy: no ``unittest.mock`` /
+``MagicMock`` / ``AsyncMock`` / ``patch``. The end-to-end proof spawns the SAME
+real low-level MCP server subprocess #2597 slice ②b's own tests use
+(``tests/_support/mcp_subscribable_resources_server.py``) through a REAL
+``Session`` (so the per-session ``HookDispatcher`` wiring — the deferred
+``hook_trigger`` closure over ``self._hook_dispatcher.dispatch`` in
+``session.py`` — is exercised, not bypassed), with a REAL ``hooks_config``
+loaded by the production ``load_hooks`` seam and a REAL ``template_push``
+action landing in the session's own (public) inbox.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.runtime.session import Session
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
+_URI = "resource://counter"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` until True or give up — the push notification arrives
+    asynchronously on the MCP receive-loop task, not synchronously with the
+    triggering call (mirrors test_2597_s2b_resource_subscriptions.py's pattern)."""
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
+    return Session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: schema — the new hook-point is registered and config-loadable
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_resource_updated_is_an_allowed_hook_point():
+    """Tier 1: ``mcp_resource_updated`` is registered in ALLOWED_HOOK_POINTS
+    alongside the 6 lifecycle points — the schema-level gate a hooks.yaml
+    entry with ``on: mcp_resource_updated`` must pass."""
+    from reyn.hooks.schema import ALLOWED_HOOK_POINTS
+
+    assert "mcp_resource_updated" in ALLOWED_HOOK_POINTS
+
+
+def test_mcp_resource_updated_hook_loads_via_production_loader():
+    """Tier 1: a ``hooks:`` config entry with ``on: mcp_resource_updated`` and a
+    ``template_push`` action parses through the REAL ``load_hooks`` seam (the
+    same one Session uses) into a HookRegistry that serves it back for that
+    point — no HookConfigError, matcher stays unset (reserved, not H1 scope)."""
+    from reyn.hooks.loader import load_hooks
+
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "resource {{ uri }} updated"},
+        },
+    ]
+    registry = load_hooks(raw)
+    (hook,) = registry.hooks_for("mcp_resource_updated")  # exactly one registered for this point
+    assert hook.matcher is None  # reserved/uninterpreted for H1
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: real Session + real subprocess MCP server — end-to-end trigger proof
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_mcp_push_fires_configured_hook_into_session_inbox(tmp_path):
+    """Tier 2: THE core H1 proof. A REAL Session with a ``mcp_resource_updated``
+    ``template_push`` hook configured, subscribed to a REAL server's resource
+    through the session's OWN (per-session) ``MCPConnectionService`` — a real
+    ``notifications/resources/updated`` push from that server both (a) emits the
+    existing ``mcp_resource_updated`` EventLog event (②b, unchanged) AND (b) now
+    ALSO fires the configured hook, landing the templated push in the session's
+    public inbox. Proves: subscribe -> server push -> bounded sync->async bridge
+    -> this session's OWN HookDispatcher -> template_push -> inbox."""
+    hooks_config = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {
+                "message": "[{{ server }}] {{ uri }} updated for {{ agent_name }}",
+                "wake": True,
+            },
+        },
+    ]
+    session = _make_session(tmp_path, hooks_config=hooks_config)
+    try:
+        client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        # The EventLog side (②b, unchanged) still fires — confirms the receive-loop
+        # actually processed the push before we assert on the NEW hook side.
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in session._chat_events.all())
+        )
+
+        # #2608 H1: the hook side — the templated push landed in the (public) inbox.
+        await _wait_for(lambda: not session.inbox.empty())
+        kind, payload = session.inbox.get_nowait()
+        assert kind == "hook"
+        assert payload["wake"] is True
+        assert payload["text"] == f"[srv] {_URI} updated for test-agent"
+        assert payload["name"] == "mcp_resource_updated"  # no ``name:`` set -> defaults to the point
+    finally:
+        await session._mcp_connection_service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_configured_hook_leaves_hook_side_a_pure_noop(tmp_path):
+    """Tier 2: empty-hook-registry equivalence. Same real subscribe+push, but with
+    NO ``mcp_resource_updated`` hook configured — the EventLog side still fires
+    (②b unchanged), but the hook side is a pure no-op: the inbox stays empty. This
+    is the byte-identical-to-today behavior the H1 design requires when no such
+    hook is configured for the session."""
+    session = _make_session(tmp_path, hooks_config=None)
+    try:
+        client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in session._chat_events.all())
+        )
+        # Give the (no-op) hook dispatch a fair chance to have run before asserting
+        # the negative — the drain task still runs, HookDispatcher.dispatch() is
+        # just a no-op over an empty hooks_for("mcp_resource_updated") list.
+        await asyncio.sleep(0.1)
+        assert session.inbox.empty()
+    finally:
+        await session._mcp_connection_service.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: bounded sync->async bridge — overflow drops, never blocks
+# ---------------------------------------------------------------------------
+
+
+class _BlockingTrigger:
+    """A real recording async callable that blocks on an ``asyncio.Event`` — used
+    to hold the drain task's first dispatch open long enough to observe the
+    bounded queue's overflow-drop behavior deterministically (not a mock: a plain
+    async function object, exactly the ``hook_trigger`` DI shape)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self.gate = asyncio.Event()
+
+    async def __call__(self, point: str, template_vars: dict) -> None:
+        self.calls.append((point, template_vars))
+        await self.gate.wait()
+
+
+@pytest.mark.asyncio
+async def test_bounded_queue_drops_overflow_without_blocking_or_raising():
+    """Tier 2: F7-1's load-bearing safety property. A burst of
+    ``enqueue_external_event`` calls (all synchronous, no ``await`` between them —
+    so the drain task never gets a scheduling chance mid-burst) beyond the bounded
+    queue's capacity must never raise or block the caller; the excess is DROPPED
+    (never queued unboundedly), and once the (blocked) drain task's first dispatch
+    is released, only the events that actually fit in the queue were ever
+    delivered to ``hook_trigger``."""
+    from reyn.mcp.connection_service import _HOOK_EVENT_QUEUE_MAXSIZE
+
+    trigger = _BlockingTrigger()
+    service = MCPConnectionService(hook_trigger=trigger)
+    try:
+        burst = _HOOK_EVENT_QUEUE_MAXSIZE + 20
+        for i in range(burst):
+            # Must never raise / never block, regardless of queue fullness.
+            service.enqueue_external_event("mcp_resource_updated", {"i": i})
+
+        # Let the drain task start; its first dispatch blocks on the gate.
+        await asyncio.sleep(0.05)
+        (first_call,) = trigger.calls  # exactly one item drained so far (blocked on the gate)
+        assert first_call[0] == "mcp_resource_updated"
+        trigger.gate.set()  # release — every item that DID fit in the queue drains now
+        await asyncio.sleep(0.05)
+
+        assert len(trigger.calls) == _HOOK_EVENT_QUEUE_MAXSIZE, (
+            "the bounded queue must drop exactly the overflow — everything beyond "
+            "its capacity, never fewer (a stall) and never more (unbounded growth)"
+        )
+        assert len(trigger.calls) < burst  # the overflow really was dropped
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_hook_trigger_wired_enqueue_is_a_pure_noop():
+    """Tier 2: ``hook_trigger=None`` (the ephemeral MCPClientPool path, or any
+    session that never wires one) — ``enqueue_external_event`` never raises and
+    ``aclose`` afterward never raises either (nothing was ever created to cancel).
+    Public-surface smoke: byte-identical to a pre-H1 ``MCPConnectionService``
+    that never had this method called on it at all."""
+    service = MCPConnectionService()  # hook_trigger defaults to None
+    service.enqueue_external_event("mcp_resource_updated", {"server": "srv"})  # must not raise
+    await service.aclose()  # must not raise


### PR DESCRIPTION
**[per-PR-coder]** — part of #2608

## What

H1 of the external-event→hooks arc: the external-event TRIGGER mechanism. An MCP `resources/updated` push for a subscribed resource now ALSO fires a user-configured `mcp_resource_updated` hook (in addition to the existing ②b `mcp_resource_updated` EventLog emit, unchanged).

## Design

### 1. New external-event hook-point (`src/reyn/hooks/schema.py`)
`mcp_resource_updated` added to `ALLOWED_HOOK_POINTS` alongside the 6 lifecycle points. Unlike those (fired from the session/turn/task run-loop), this one is fired from the MCP receive-loop task. `HookDef.matcher` stays reserved/uninterpreted for H1 (scoping is via which resources the user subscribed to — matcher filtering is H2).

### 2. Bounded sync→async bridge (the load-bearing piece, F7-1)
`ReynMCPMessageHandler.on_resource_updated` (`src/reyn/mcp/message_handler.py`) runs SYNCHRONOUSLY on FastMCP's receive-loop task — it cannot `await` the async `HookDispatcher.dispatch`. The bridge:

- `MCPConnectionService` (`src/reyn/mcp/connection_service.py`) owns a bounded `asyncio.Queue` (`_HOOK_EVENT_QUEUE_MAXSIZE = 32`) and a single drain task (`_drain_hook_events`), lazily created on first use, running on the session's own event loop (the same loop the held `fastmcp.Client` was opened on — verified precondition from ②b).
- `enqueue_external_event(point, template_vars)` is the synchronous, non-blocking entry point (`put_nowait`) called from `on_resource_updated`. On `QueueFull` it DROPS the event and logs — never blocks the receive loop, never grows unboundedly.
- The drain task `await`s `hook_trigger(point, template_vars)` — an async closure over `HookDispatcher.dispatch` — one at a time, per-event `try/except` so one bad dispatch never kills the drain task.
- `aclose()` cancels the drain task first, in a `try/finally` (not `except Exception`, since `CancelledError` is a `BaseException`), before tearing down held clients.

### 3. Wiring (`src/reyn/runtime/session.py`)
`MCPConnectionService` now takes `hook_trigger` + `agent_name`. `Session.__init__` passes `hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars)` — the SAME deferred-lambda pattern already used for `emit_sink`/`tools_cache_invalidate` (the lambda is defined before `self._hook_dispatcher` exists, but is never called until a real push arrives, long after `__init__` finishes). `agent_name` is passed eagerly (`self._agent` is already set at that point in `__init__`).

Because `MCPConnectionService` is per-session, the closure it holds targets THAT session's own `HookDispatcher` — a push on session A's held connection can only ever fire session A's hooks. No cross-session leakage by construction.

`template_vars` passed to the hook: `{"point": "mcp_resource_updated", "server": ..., "uri": ..., "agent_name": ...}`.

### Empty-hook-registry equivalence
With no `mcp_resource_updated` hook configured, `HookDispatcher.dispatch()` loops over an empty `hooks_for(point)` list — a pure no-op. Verified by test (inbox stays empty after a real push, while the ②b EventLog emit still fires unchanged).

## Out of scope (later slices, per design doc)
- `matcher` filtering (H2)
- `pipeline_launch` action (H3), fs-watcher (H4), cron/webhook sources (H5)
- Background shell-hook consent (F7-2) — proved with `template_push` only, no consent complexity
- Debounce/rate-limit (F7-3) — noted, not built

## Test plan

- [x] `test_mcp_resource_updated_is_an_allowed_hook_point` — schema gate
- [x] `test_mcp_resource_updated_hook_loads_via_production_loader` — real `load_hooks` parse
- [x] `test_real_mcp_push_fires_configured_hook_into_session_inbox` — THE core E2E proof: real Session + real subprocess MCP server (`tests/_support/mcp_subscribable_resources_server.py`, same double ②b's own tests use) + real per-session `HookDispatcher` + real `template_push` → subscribe → server push → hook fires → templated message lands in the session's public inbox
- [x] `test_no_configured_hook_leaves_hook_side_a_pure_noop` — empty-hook-registry equivalence: same real push, no hook configured → inbox stays empty (②b EventLog emit still fires, confirming the receive loop did process the push)
- [x] `test_bounded_queue_drops_overflow_without_blocking_or_raising` — F7-1's safety property: a synchronous burst of `enqueue_external_event` calls beyond the queue's bound never raises/blocks; overflow is dropped deterministically (exactly `_HOOK_EVENT_QUEUE_MAXSIZE` delivered, never more)
- [x] `test_no_hook_trigger_wired_enqueue_is_a_pure_noop` — `hook_trigger=None` path (ephemeral `MCPClientPool` / no wiring) never raises

All real instances — no `MagicMock`/`AsyncMock`/`patch` (real subprocess MCP server, real `Session`, real `HookDispatcher`, real `HookRegistry` via `load_hooks`).

## Gate output (all 4, local)

**ruff check src tests**
```
All checks passed!
```

**python scripts/test_tier_audit.py --strict tests/test_2608_h1_mcp_resource_updated_hook.py**
```
Summary: 6 tests inspected
  ✓ OK: 6
  ⚠️ warnings: 0 (bounded-life candidates)
  ✗ errors: 0 (Tier 4 violations)
Exit code: 0
```

**pytest** (full suite, from repo root)
```
5 failed, 7335 passed, 21 skipped, 11 warnings in 150.06s
```
The 5 failures are the pre-existing #2599 web-route-mount failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `web/test_a2a.py::test_a2a_routes_mounted`, `web/test_mcp_sse.py::test_mcp_routes_mounted`, `web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `web/test_resources_router.py::test_resources_route_is_mounted_on_app`) — confirmed identical on `main` with this branch's changes stashed out (same 5 fail, same assertion messages). Zero NEW failures from this change.

**python scripts/verify_module_docstrings.py <changed src files>**
```
OK: no module-docstring refactor narrative in src/reyn/hooks/schema.py src/reyn/mcp/message_handler.py src/reyn/mcp/connection_service.py src/reyn/runtime/session.py.
```
