### PR TITLE
feat(#2608): H3 — pipeline_launch hook action

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -4,30 +4,38 @@ Slice A (#1800): schema + loader + registry.
 Slice B (#1800): Jinja2 push-directive renderer.
 Slice C (#1800): shell-hook runner (side-effect only; output ignored).
 
+Slice H3 (#2608): ``pipeline_launch`` action — launch a registered Pipeline
+from a hook, with an input rendered from the event payload.
+
 Exposes:
     HookDef        — typed model for a single hook definition.
     PushBlock      — typed model for the inbox-push sub-schema.
+    PipelineLaunchBlock — typed model for the pipeline-launch sub-schema (H3).
     HookRegistry   — ordered store; query via hooks_for(point).
     load_hooks     — parse the ``hooks:`` list from a raw config dict
                      and return a ready ``HookRegistry``.
     HookConfigError — raised for config validation failures.
     ResolvedPush   — fully-rendered push directive (slice B).
     render_push    — render a ``PushBlock`` against a context dict (slice B).
+    render_pipeline_input — render a ``PipelineLaunchBlock.input_template``
+                     against a context dict (H3).
     run_shell_hook — execute a shell HookDef command (slice C).
 """
 from reyn.hooks.loader import load_hooks
 from reyn.hooks.registry import HookRegistry
-from reyn.hooks.render import ResolvedPush, render_push
-from reyn.hooks.schema import HookConfigError, HookDef, PushBlock
+from reyn.hooks.render import ResolvedPush, render_pipeline_input, render_push
+from reyn.hooks.schema import HookConfigError, HookDef, PipelineLaunchBlock, PushBlock
 from reyn.hooks.shell_runner import run_shell_hook
 
 __all__ = [
     "HookDef",
     "PushBlock",
+    "PipelineLaunchBlock",
     "HookRegistry",
     "HookConfigError",
     "load_hooks",
     "ResolvedPush",
     "render_push",
+    "render_pipeline_input",
     "run_shell_hook",
 ]

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -13,13 +13,16 @@ No-hooks equivalence (the critical property): an empty registry makes
 ``dispatch()`` a no-op (the ``hooks_for`` loop body never runs), so the run-loop
 is byte-identical to a hooks-free build.
 
-The three Session seams the dispatcher needs are injected as bound callables
+The four Session seams the dispatcher needs are injected as bound callables
 (DI), so the dispatcher is decoupled from ``Session`` and unit-testable against a
 real Session's methods (no mocks):
 
 - ``put_inbox(kind, payload)``           — E (wake=true): a turn trigger.
 - ``stage_next_turn_context(kind, payload)`` — C (wake=false): a passive ride-along.
 - ``run_shell(command, event_context, **sandbox)`` — F: an external side-effect.
+- ``launch_pipeline(name, input)``       — #2608 H3: launch a registered
+  Pipeline (async/detached — the launched pipeline's result arrives later on
+  the session's own inbox as a ``pipeline_result`` message).
 """
 from __future__ import annotations
 
@@ -28,7 +31,7 @@ import logging
 from typing import Any, Awaitable, Callable
 
 from reyn.hooks.registry import HookRegistry
-from reyn.hooks.render import ResolvedPush, render_push
+from reyn.hooks.render import ResolvedPush, render_pipeline_input, render_push
 from reyn.hooks.schema import HookDef
 from reyn.hooks.shell_runner import run_shell_hook
 
@@ -45,6 +48,10 @@ HOOK_STAGE_KIND = "hook"
 PutInbox = Callable[[str, dict], Awaitable[Any]]
 StageContext = Callable[[str, dict], Awaitable[Any]]
 RunShell = Callable[..., Awaitable[Any]]
+# #2608 H3: launch a registered pipeline by name with a rendered input dict
+# (or None). Returns whatever the injected callable returns (unused by the
+# dispatcher — the launch is fire-and-continue).
+LaunchPipeline = Callable[[str, "dict | None"], Awaitable[Any]]
 
 
 class HookDispatcher:
@@ -57,6 +64,11 @@ class HookDispatcher:
         put_inbox: PutInbox,
         stage_next_turn_context: StageContext,
         run_shell: RunShell = run_shell_hook,
+        # #2608 H3: launch a registered pipeline (async/detached). None (the
+        # default — e.g. a unit test that never configures pipeline_launch) →
+        # a pipeline_launch hook logs a clear warning and is skipped, same
+        # per-hook-isolation posture as every other action.
+        launch_pipeline: "LaunchPipeline | None" = None,
         sandbox_config: Any = None,
         sandbox_backend: Any = None,
         consent_bus: Any = None,
@@ -83,6 +95,7 @@ class HookDispatcher:
         self._cross_session_put = cross_session_put
         self._current_session_id = current_session_id
         self._run_shell = run_shell
+        self._launch_pipeline = launch_pipeline
         self._sandbox_config = sandbox_config
         self._sandbox_backend = sandbox_backend
         # #2095 P3: P6-event sink for shell-hook executions, so an auto-run
@@ -140,7 +153,9 @@ class HookDispatcher:
 
     async def _dispatch_one(self, hook: HookDef, point: str, template_vars: dict) -> None:
         """Dispatch a single hook by scheme: template_push (C/E) / shell_exec (F)
-        / shell_push (run + parse stdout → the same C/E path as template_push)."""
+        / shell_push (run + parse stdout → the same C/E path as template_push)
+        / pipeline_launch (#2608 H3: render input_template, launch via the
+        injected ``launch_pipeline`` callable)."""
         if hook.template_push is not None:
             resolved = render_push(hook.template_push, template_vars)
             await self._push_resolved(resolved, hook, point)
@@ -178,6 +193,37 @@ class HookDispatcher:
             resolved = _parse_shell_push(stdout)
             if resolved is not None:
                 await self._push_resolved(resolved, hook, point)
+        elif hook.pipeline_launch is not None:
+            # pipeline_launch (#2608 H3) — render input_template against
+            # template_vars, then hand off to the injected launch_pipeline
+            # callable (async/detached — the result returns later on this
+            # session's own inbox as a pipeline_result message, same as the
+            # run_pipeline_async tool verb). Fail-safe on either failure mode:
+            # a render error (bad Jinja2 / non-JSON-object output) or no
+            # launch_pipeline callable injected both log a clear WARNING and
+            # skip the launch — never raise out of this branch (dispatch()'s
+            # per-hook isolation would catch it anyway, but a specific message
+            # here names exactly what went wrong).
+            try:
+                input_data = render_pipeline_input(
+                    hook.pipeline_launch.input_template, template_vars,
+                )
+            except Exception as exc:  # noqa: BLE001 — render failure must not crash; skip launch
+                _log.warning(
+                    "Hook pipeline_launch input_template render failed — launch "
+                    "skipped. hook=%r pipeline=%r error=%s: %s",
+                    hook.name, hook.pipeline_launch.name, type(exc).__name__, exc,
+                )
+                return
+            if self._launch_pipeline is None:
+                _log.warning(
+                    "Hook %r declares pipeline_launch (pipeline=%r) but this "
+                    "session's HookDispatcher has no launch_pipeline callable "
+                    "injected — launch skipped.",
+                    hook.name or point, hook.pipeline_launch.name,
+                )
+                return
+            await self._launch_pipeline(hook.pipeline_launch.name, input_data)
 
     async def _push_resolved(self, resolved, hook: HookDef, point: str) -> None:
         """Dispatch a resolved push directive via C/E (#1800 slice 5b/6) — shared

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -4,8 +4,9 @@ Entry point: ``load_hooks(raw)`` — accepts the raw value of the ``hooks:``
 key from a reyn.yaml dict and returns a ``HookRegistry``.
 
 Validation is *structural only* (field presence, types, hook-point membership,
-the template_push / shell_exec / shell_push mutual-exclusion — exactly one).
-Template *semantics* are not validated here — rendering is a later slice.
+the template_push / shell_exec / shell_push / pipeline_launch mutual-exclusion
+— exactly one, #2608 H3 adds ``pipeline_launch``). Template *semantics* are
+not validated here — rendering is a later slice.
 
 Validation errors raise ``HookConfigError`` with a decision-enabling message
 that names the entry index and the failing field so the operator can fix the
@@ -20,6 +21,7 @@ from reyn.hooks.schema import (
     ALLOWED_HOOK_POINTS,
     HookConfigError,
     HookDef,
+    PipelineLaunchBlock,
     PushBlock,
 )
 
@@ -97,6 +99,45 @@ def _parse_push_block(raw: object, entry_index: int) -> PushBlock:
     )
 
 
+def _parse_pipeline_launch_block(raw: object, entry_index: int) -> PipelineLaunchBlock:
+    """Validate and convert the ``pipeline_launch:`` sub-dict to a
+    ``PipelineLaunchBlock`` (#2608 H3).
+
+    ``input_template`` is stored raw (a dict or a Jinja2 template string); no
+    rendering here — rendering happens at dispatch time against the hook's
+    ``template_vars`` (``reyn.hooks.render.render_pipeline_input``).
+    """
+    if not isinstance(raw, dict):
+        raise HookConfigError(
+            f"hooks[{entry_index}].pipeline_launch must be a mapping, "
+            f"got {type(raw).__name__!r}."
+        )
+
+    name = raw.get("name")
+    if name is None:
+        raise HookConfigError(
+            f"hooks[{entry_index}].pipeline_launch.name is required."
+        )
+    if not isinstance(name, str):
+        raise HookConfigError(
+            f"hooks[{entry_index}].pipeline_launch.name must be a string, "
+            f"got {type(name).__name__!r}."
+        )
+    if not name.strip():
+        raise HookConfigError(
+            f"hooks[{entry_index}].pipeline_launch.name must not be empty."
+        )
+
+    input_template = raw.get("input_template", None)
+    if input_template is not None and not isinstance(input_template, (dict, str)):
+        raise HookConfigError(
+            f"hooks[{entry_index}].pipeline_launch.input_template must be a "
+            f"mapping, string, or null, got {type(input_template).__name__!r}."
+        )
+
+    return PipelineLaunchBlock(name=name, input_template=input_template)
+
+
 def _parse_entry(raw: object, entry_index: int) -> HookDef:
     """Validate one raw hooks list entry and return a ``HookDef``."""
     if not isinstance(raw, dict):
@@ -129,17 +170,22 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
             f"Allowed: {sorted_points}."
         )
 
-    # ── scheme: exactly one of template_push / shell_exec / shell_push (#2069) ─
-    present = [k for k in ("template_push", "shell_exec", "shell_push") if k in raw]
+    # ── scheme: exactly one of template_push / shell_exec / shell_push /
+    # pipeline_launch (#2069, #2608 H3) ─────────────────────────────────────
+    present = [
+        k for k in ("template_push", "shell_exec", "shell_push", "pipeline_launch")
+        if k in raw
+    ]
     if len(present) > 1:
         raise HookConfigError(
-            f"hooks[{entry_index}]: template_push / shell_exec / shell_push are "
-            f"mutually exclusive; specify exactly one (got {present})."
+            f"hooks[{entry_index}]: template_push / shell_exec / shell_push / "
+            f"pipeline_launch are mutually exclusive; specify exactly one "
+            f"(got {present})."
         )
     if not present:
         raise HookConfigError(
             f"hooks[{entry_index}]: exactly one of template_push / shell_exec / "
-            f"shell_push is required."
+            f"shell_push / pipeline_launch is required."
         )
 
     # ── template_push block ──────────────────────────────────────────────────
@@ -161,6 +207,11 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
 
     shell_exec: str | None = _shell_cmd("shell_exec") if "shell_exec" in raw else None
     shell_push: str | None = _shell_cmd("shell_push") if "shell_push" in raw else None
+
+    # ── pipeline_launch block (#2608 H3) ──────────────────────────────────────
+    pipeline_launch: PipelineLaunchBlock | None = None
+    if "pipeline_launch" in raw:
+        pipeline_launch = _parse_pipeline_launch_block(raw["pipeline_launch"], entry_index)
 
     # ── matcher (optional, reserved) ───────────────────────────────────────
     matcher_raw = raw.get("matcher", None)
@@ -187,6 +238,7 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
         template_push=template_push,
         shell_exec=shell_exec,
         shell_push=shell_push,
+        pipeline_launch=pipeline_launch,
         matcher=matcher,
     )
 

--- a/src/reyn/hooks/render.py
+++ b/src/reyn/hooks/render.py
@@ -51,6 +51,7 @@ must **not** crash the agent.  On any exception in ``render_push``:
 """
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 
@@ -205,3 +206,69 @@ def _render_push_inner(push: PushBlock, context: dict) -> ResolvedPush:
         push_when=push_when,
         session=session,
     )
+
+
+# ---------------------------------------------------------------------------
+# pipeline_launch input rendering (#2608 H3)
+# ---------------------------------------------------------------------------
+
+
+def render_pipeline_input(input_template: "dict | str | None", context: dict) -> "dict | None":
+    """Render a hook's ``pipeline_launch.input_template`` against ``context``
+    into the ``input: dict`` a launched Pipeline receives (#2608 H3).
+
+    ``input_template`` shapes
+    --------------------------
+    - ``None``: no input — the launched pipeline gets ``input=None``.
+    - ``dict``: every STRING leaf (recursively, through nested dicts/lists) is
+      rendered as a Jinja2 template against ``context``; non-string leaves
+      (int/float/bool/None) pass through unchanged. The dict's STRUCTURE
+      (keys, nesting) is never templated — only leaf strings are.
+    - ``str``: the whole string is rendered as ONE Jinja2 template, and the
+      rendered text is parsed as JSON — the result must be a JSON object
+      (mirrors ``shell_push``'s stdout-is-a-JSON-object contract). Use this
+      form to build the input from a single templated JSON blob.
+
+    Rendering uses a ``SandboxedEnvironment`` with silent ``Undefined`` (an
+    undefined variable renders as the empty string) — an event payload
+    missing a referenced field yields an empty string in that slot rather
+    than crashing; this mirrors the ``wake``/``push_when``/``session`` fields
+    in ``render_push``, not ``message`` (which is intentionally strict).
+
+    Raises on a genuine failure (bad Jinja2 syntax, a ``str`` template that
+    does not render to valid JSON or a JSON object, or an unsupported
+    ``input_template`` type). Unlike ``render_push``, this function does NOT
+    swallow errors itself — a silently-empty pipeline input is a worse
+    failure mode than a loud skip, so the caller (the hook dispatcher) is
+    responsible for catching and skipping the launch.
+    """
+    if input_template is None:
+        return None
+    env = _make_env_silent()
+    if isinstance(input_template, str):
+        rendered = env.from_string(input_template).render(context)
+        obj = json.loads(rendered)
+        if not isinstance(obj, dict):
+            raise ValueError(
+                f"pipeline_launch.input_template rendered to a JSON "
+                f"{type(obj).__name__}, expected a JSON object: {rendered!r}"
+            )
+        return obj
+    if isinstance(input_template, dict):
+        return _render_template_leaves(input_template, env, context)
+    raise TypeError(
+        f"pipeline_launch.input_template must be a dict, string, or null, "
+        f"got {type(input_template).__name__!r}."
+    )
+
+
+def _render_template_leaves(value: object, env: SandboxedEnvironment, context: dict) -> object:
+    """Recursively render every STRING leaf of ``value`` (through nested dicts
+    and lists) as a Jinja2 template; non-string leaves pass through unchanged."""
+    if isinstance(value, str):
+        return env.from_string(value).render(context)
+    if isinstance(value, dict):
+        return {k: _render_template_leaves(v, env, context) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_render_template_leaves(v, env, context) for v in value]
+    return value

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -21,6 +21,19 @@ from the MCP receive-loop task via a bounded queue drained on the session's
 event loop. ``HookDef.matcher`` stays reserved/uninterpreted for this
 point in H1 (scoping is via which resources the user subscribed to) — a
 later slice (H2) may add matcher filtering.
+
+#2608 H3 adds the 4th action, ``pipeline_launch`` — a hook can launch a
+REGISTERED Pipeline (``reyn.core.pipeline.registry.PipelineRegistry.get``)
+with an ``input`` built from the event payload (``PipelineLaunchBlock.
+input_template``, Jinja2-rendered over the hook's ``template_vars`` — see
+``reyn.hooks.render.render_pipeline_input``). Works from ANY hook-point
+(the six lifecycle points and ``mcp_resource_updated``) since it dispatches
+through the same ``HookDispatcher._dispatch_one`` scheme-branch as the other
+three actions. Launch is ASYNC/detached (``reyn.runtime.session_api.
+start_pipeline_run`` — the same call the ``run_pipeline_async`` tool verb
+makes): the hook fires-and-continues, the pipeline runs in its own
+recoverable driver-session, and the result arrives later on the hook's own
+session inbox as a ``pipeline_result`` message.
 """
 from __future__ import annotations
 
@@ -96,6 +109,37 @@ class PushBlock:
 
 
 # ---------------------------------------------------------------------------
+# PipelineLaunchBlock — launch-a-registered-pipeline sub-schema (#2608 H3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PipelineLaunchBlock:
+    """Launch-a-registered-pipeline directive for a hook definition (#2608 H3).
+
+    Fields
+    ------
+    name:
+        The pipeline's registered name — resolved via
+        ``PipelineRegistry.get(name)`` at dispatch time.  Required.
+    input_template:
+        Optional input for the launched pipeline, Jinja2-rendered against the
+        hook's ``template_vars`` (see ``reyn.hooks.render.render_pipeline_input``
+        for the exact rendering contract):
+
+        - a ``dict``: every STRING leaf (recursively, through nested dicts/
+          lists) is rendered as a Jinja2 template; the dict's structure and
+          non-string leaves pass through unchanged.
+        - a ``str``: rendered as ONE Jinja2 template whose output is parsed as
+          a JSON object (mirrors the ``shell_push`` stdout-is-JSON contract).
+        - ``None`` (default): the pipeline launches with ``input=None``.
+    """
+
+    name: str
+    input_template: "dict | str | None" = None
+
+
+# ---------------------------------------------------------------------------
 # HookDef — the top-level hook entry
 # ---------------------------------------------------------------------------
 
@@ -104,10 +148,11 @@ class PushBlock:
 class HookDef:
     """A single lifecycle hook definition.
 
-    Exactly one of ``template_push`` / ``shell_exec`` / ``shell_push`` must be set
-    (validated by the loader, not by the dataclass itself — the dataclass is a
-    plain data container). The three consistent ``<source>_<action>`` keywords
-    (#2069 converged design):
+    Exactly one of ``template_push`` / ``shell_exec`` / ``shell_push`` /
+    ``pipeline_launch`` must be set (validated by the loader, not by the
+    dataclass itself — the dataclass is a plain data container). The
+    consistent ``<source>_<action>`` keywords (#2069 converged design;
+    #2608 H3 adds ``pipeline_launch``):
 
     Fields
     ------
@@ -120,15 +165,21 @@ class HookDef:
     template_push:
         Declarative inbox-push block from config Jinja2 templates (C/E). The
         push directive is computed from the template against event/context.
-        Mutually exclusive with ``shell_exec`` / ``shell_push``.
+        Mutually exclusive with the other actions.
     shell_exec:
         Shell command run as a pure side-effect — **output IGNORED**. Mutually
-        exclusive with ``template_push`` / ``shell_push``.
+        exclusive with the other actions.
     shell_push:
         Shell command whose **stdout is a JSON push-directive**
         (``{push_when, wake, message, session?}``, #2069) → pushed via the same
         C/E dispatch path as ``template_push``. Mutually exclusive with the
-        other two.
+        other actions.
+    pipeline_launch:
+        Launch a registered Pipeline (#2608 H3) with an input built from the
+        event payload — see ``PipelineLaunchBlock``. Async/detached (the
+        launched pipeline runs in its own driver-session; the result arrives
+        later on this session's inbox as a ``pipeline_result`` message).
+        Mutually exclusive with the other actions.
     matcher:
         Reserved optional filter string.  Not interpreted in this slice.
     """
@@ -138,4 +189,5 @@ class HookDef:
     template_push: PushBlock | None = field(default=None)
     shell_exec: str | None = field(default=None)
     shell_push: str | None = field(default=None)
+    pipeline_launch: PipelineLaunchBlock | None = field(default=None)
     matcher: str | None = field(default=None)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -32,7 +32,7 @@ from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.snapshot_generations import SnapshotGenerationStore
 from reyn.core.events.state_log import StateLog
-from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.registry import PipelineNotFoundError, PipelineRegistry
 from reyn.hooks.dispatcher import HOOK_INBOX_KIND
 from reyn.llm.model_resolver import ModelResolver
 from reyn.runtime.agent import Agent
@@ -1226,6 +1226,11 @@ class Session:
             # (cross-session); `current_session_id` keeps a self/unnamed push local.
             cross_session_put=self._cross_session_hook_put,
             current_session_id=self._session_id,
+            # #2608 H3: launch a registered pipeline from a hook's
+            # pipeline_launch action (async/detached start_pipeline_run) —
+            # the closure resolves against THIS session's own PipelineRegistry
+            # / AgentRegistry / StateLog / (agent, sid) identity.
+            launch_pipeline=self._launch_pipeline_from_hook,
             # #2285: per-session hook applicability gate — skip a hook this session disabled. A
             # callable (not a snapshot) so a toggle applies live to the next dispatch.
             is_hook_disabled=lambda hook: hook.name is not None and hook.name in self._disabled_hooks,
@@ -3708,6 +3713,63 @@ class Session:
         inbox). Byte-behavior-identical extraction of the prior inline pair."""
         self._next_turn_context.append({"kind": kind, "payload": payload})
         await self._journal.record_next_turn_context_staged(kind=kind, payload=payload)
+
+    async def _launch_pipeline_from_hook(self, name: str, input_data: "dict | None") -> None:
+        """#2608 H3: launch a registered Pipeline from a hook's
+        ``pipeline_launch`` action — the ``HookDispatcher``'s injected
+        ``launch_pipeline`` seam.
+
+        Async/detached (``start_pipeline_run``, same call the
+        ``run_pipeline_async`` tool verb makes): fire-and-continue — the
+        pipeline runs in its own recoverable driver-session, spawned under
+        THIS session's own (agent, sid) identity (permission-bounded ⊆ this
+        session's own capability), and the result arrives later on THIS
+        session's inbox as a ``pipeline_result`` message.
+
+        Fail-fast-but-non-crashing: a missing collaborator (no AgentRegistry /
+        no WAL) or an unregistered ``name`` logs a decision-enabling WARNING
+        naming exactly what's missing and returns — never raises. The
+        dispatcher's own per-hook ``try/except`` isolation is a second line of
+        defense; resolving the failure HERE (rather than letting
+        ``PipelineRegistry.get`` raise a bare ``PipelineNotFoundError`` up
+        through the dispatcher's generic catch) gives the operator a clearer,
+        more specific message.
+        """
+        if self._registry is None:
+            logger.warning(
+                "hook pipeline_launch %r: this session has no AgentRegistry — "
+                "cannot launch a pipeline from a hook. Skipping.", name,
+            )
+            return
+        if self._state_log is None:
+            logger.warning(
+                "hook pipeline_launch %r: this session has no WAL (state_log) "
+                "— an async pipeline launch requires persistence. Skipping.",
+                name,
+            )
+            return
+        try:
+            pipeline = self._pipeline_registry.get(name)
+            schema_registry = self._pipeline_registry.get_schema_registry(name)
+        except PipelineNotFoundError:
+            logger.warning(
+                "hook pipeline_launch: pipeline %r is not registered on this "
+                "session's PipelineRegistry — register it before referencing "
+                "it from a hook. Skipping launch.", name,
+            )
+            return
+
+        from reyn.runtime.session_api import start_pipeline_run
+        await start_pipeline_run(
+            self._registry,
+            pipeline=pipeline,
+            pipeline_name=name,
+            input=input_data,
+            reply_to_agent=self.agent_name,
+            reply_to_sid=self._session_id,
+            state_log=self._state_log,
+            schema_registry=schema_registry,
+        )
 
     async def _drain_to_wake(
         self,

--- a/tests/test_2608_h3_pipeline_launch_hook.py
+++ b/tests/test_2608_h3_pipeline_launch_hook.py
@@ -1,0 +1,442 @@
+"""Tests for #2608 H3 — the ``pipeline_launch`` hook action.
+
+H3 adds the 4th hook action (alongside ``template_push`` / ``shell_exec`` /
+``shell_push``): a hook can launch a REGISTERED Pipeline with an input built
+from the event payload, via the async/detached ``start_pipeline_run`` (the
+same call the ``run_pipeline_async`` tool verb makes) — fire-and-continue;
+the pipeline runs in its own recoverable driver-session and its result
+arrives later on the hook's own session inbox as a ``pipeline_result``
+message.
+
+Coverage plan
+-------------
+Tier 1 (contract): ``pipeline_launch`` schema shape + the loader's mutual-
+  exclusion / required-field validation.
+Tier 2 (OS invariant, dispatcher-unit): ``_dispatch_one`` renders
+  ``input_template`` against ``template_vars`` and calls the injected
+  ``launch_pipeline`` seam with the rendered dict; a render failure or a
+  missing ``launch_pipeline`` callable logs + skips (never raises out of
+  ``dispatch()``).
+Tier 2 (OS invariant, end-to-end): a REAL Session + REAL AgentRegistry +
+  REAL PipelineRegistry + a REAL registered Pipeline — the hook actually
+  LAUNCHES the pipeline (observable side effect + ``pipeline_result``
+  delivered to the invoking session's inbox), with the input threaded from
+  ``template_vars``; an UNregistered pipeline name logs + skips without
+  crashing the dispatcher (a sibling hook on the same point still fires).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. The dispatcher-unit
+tests use a real recording async callable (the same idiom as
+test_hook_dispatcher_1800_5b.py's ``_Recorder``); the end-to-end tests use a
+real ``Session``/``AgentRegistry``/``PipelineRegistry``/``PipelineExecutor``,
+mirroring test_pipeline_is2_driver_session.py's fixture pattern (the only
+"fake" is a scripted LLM callable injected through the real
+``RouterLoopDriver`` ``_loop_observer`` seam — the LLM is incidental to what's
+under test).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, ToolStep
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookConfigError, HookDef, PipelineLaunchBlock, PushBlock
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Recording seam (mirrors test_hook_dispatcher_1800_5b.py's _Recorder)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A real recording async callable — the generic seam stand-in for
+    ``put_inbox``/``stage_next_turn_context``/``run_shell`` (accepts any
+    args/kwargs, mirroring test_hook_dispatcher_1800_5b.py's ``_Recorder``)."""
+
+    def __init__(self, *, raises: BaseException | None = None) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+        self._raises = raises
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        if self._raises is not None:
+            raise self._raises
+
+
+class _LaunchRecorder:
+    """A real recording async callable standing in for ``launch_pipeline``
+    (the strict (name, input_data) signature)."""
+
+    def __init__(self, *, raises: BaseException | None = None) -> None:
+        self.calls: list[tuple[str, "dict | None"]] = []
+        self._raises = raises
+
+    async def __call__(self, name: str, input_data: "dict | None") -> None:
+        self.calls.append((name, input_data))
+        if self._raises is not None:
+            raise self._raises
+
+
+def _dispatcher(hooks: list[HookDef], **seams) -> "tuple[HookDispatcher, dict]":
+    seams.setdefault("put_inbox", _Recorder())
+    seams.setdefault("stage_next_turn_context", _Recorder())
+    seams.setdefault("run_shell", _Recorder())
+    seams.setdefault("launch_pipeline", _LaunchRecorder())
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage_next_turn_context"],
+        run_shell=seams["run_shell"],
+        launch_pipeline=seams["launch_pipeline"],
+    )
+    return disp, seams
+
+
+# ===========================================================================
+# Tier 1 — Contract: schema shape + loader validation
+# ===========================================================================
+
+
+def test_hookdef_pipeline_launch_shape() -> None:
+    """Tier 1: ``HookDef`` with a ``PipelineLaunchBlock`` carries the expected
+    fields; the other three action fields stay unset."""
+    block = PipelineLaunchBlock(name="digest", input_template={"n": "{{ event.n }}"})
+    hd = HookDef(on="turn_end", pipeline_launch=block)
+
+    assert hd.pipeline_launch is block
+    assert hd.pipeline_launch.name == "digest"
+    assert hd.pipeline_launch.input_template == {"n": "{{ event.n }}"}
+    assert hd.template_push is None
+    assert hd.shell_exec is None
+    assert hd.shell_push is None
+
+
+def test_load_hooks_pipeline_launch_parses() -> None:
+    """Tier 1: a ``hooks:`` entry with ``pipeline_launch`` parses through the
+    REAL ``load_hooks`` seam into a ``HookDef`` carrying the block, both with
+    and without ``input_template``."""
+    from reyn.hooks.loader import load_hooks
+
+    raw = [
+        {
+            "on": "session_start",
+            "pipeline_launch": {"name": "digest", "input_template": {"a": "{{ x }}"}},
+        },
+        {"on": "task_end", "pipeline_launch": {"name": "no-input"}},
+    ]
+    registry = load_hooks(raw)
+    (h1,) = registry.hooks_for("session_start")
+    (h2,) = registry.hooks_for("task_end")
+    assert h1.pipeline_launch.name == "digest"
+    assert h1.pipeline_launch.input_template == {"a": "{{ x }}"}
+    assert h2.pipeline_launch.name == "no-input"
+    assert h2.pipeline_launch.input_template is None
+
+
+def test_load_hooks_pipeline_launch_missing_name_rejected() -> None:
+    """Tier 1: a ``pipeline_launch`` block without ``name`` raises
+    ``HookConfigError``."""
+    from reyn.hooks.loader import load_hooks
+
+    with pytest.raises(HookConfigError, match="pipeline_launch.name is required"):
+        load_hooks([{"on": "turn_end", "pipeline_launch": {}}])
+
+
+def test_load_hooks_pipeline_launch_mutually_exclusive_with_template_push() -> None:
+    """Tier 1: ``pipeline_launch`` alongside ``template_push`` on the same
+    entry raises ``HookConfigError`` (the 4-way mutual exclusion, #2608 H3)."""
+    from reyn.hooks.loader import load_hooks
+
+    with pytest.raises(HookConfigError, match="mutually exclusive"):
+        load_hooks([
+            {
+                "on": "turn_end",
+                "template_push": {"message": "hi"},
+                "pipeline_launch": {"name": "p"},
+            },
+        ])
+
+
+# ===========================================================================
+# Tier 2 — dispatcher-unit: routing + rendering (recording seam)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_pipeline_launch_routes_to_launch_pipeline_with_rendered_input():
+    """Tier 2: a ``pipeline_launch`` hook renders ``input_template`` against
+    ``template_vars`` and calls the injected ``launch_pipeline`` seam with the
+    rendered dict — the input is ACTUALLY threaded from the event payload
+    (not just passed through statically)."""
+    hook = HookDef(
+        on="mcp_resource_updated",
+        pipeline_launch=PipelineLaunchBlock(
+            name="digest", input_template={"uri": "{{ event.uri }}", "static": 1},
+        ),
+    )
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("mcp_resource_updated", {"event": {"uri": "resource://x"}})
+
+    assert seams["launch_pipeline"].calls == [
+        ("digest", {"uri": "resource://x", "static": 1}),
+    ]
+    # No push/shell path touched — pipeline_launch is its own scheme branch.
+    assert seams["put_inbox"].calls == []
+    assert seams["stage_next_turn_context"].calls == []
+    assert seams["run_shell"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_launch_with_no_input_template_launches_with_none():
+    """Tier 2: ``input_template`` absent (None) → the pipeline launches with
+    ``input=None`` — no accidental empty-dict substitution."""
+    hook = HookDef(on="turn_end", pipeline_launch=PipelineLaunchBlock(name="no-input"))
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_end", {})
+
+    assert seams["launch_pipeline"].calls == [("no-input", None)]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_launch_render_failure_skips_without_crashing():
+    """Tier 2: an ``input_template`` that fails to render (bad Jinja2 syntax)
+    logs + skips the launch — ``dispatch()`` never raises, and
+    ``launch_pipeline`` is never called."""
+    hook = HookDef(
+        on="turn_end",
+        pipeline_launch=PipelineLaunchBlock(name="p", input_template="{{ not valid jinja !!"),
+    )
+    disp, seams = _dispatcher([hook])
+
+    await disp.dispatch("turn_end", {})  # must not raise
+
+    assert seams["launch_pipeline"].calls == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_launch_missing_callable_skips_without_crashing():
+    """Tier 2: no ``launch_pipeline`` callable was injected (the default None)
+    — a ``pipeline_launch`` hook logs + is skipped, siblings still proceed."""
+    hooks = [
+        HookDef(on="turn_end", pipeline_launch=PipelineLaunchBlock(name="p")),
+        HookDef(on="turn_end", shell_exec="echo sibling"),
+    ]
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=_Recorder(),
+        stage_next_turn_context=_Recorder(),
+        run_shell=(shell_recorder := _Recorder()),
+        # launch_pipeline intentionally omitted -> defaults to None
+    )
+
+    await disp.dispatch("turn_end", {})  # must not raise
+
+    (args, _kwargs), = shell_recorder.calls
+    assert args[0] == "echo sibling"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_launch_raising_callable_isolated_siblings_proceed():
+    """Tier 2: a ``launch_pipeline`` callable that raises (e.g. simulating an
+    unregistered pipeline propagating past the session-level catch) is caught
+    by the per-hook isolation — the sibling hook still runs."""
+    raising = _LaunchRecorder(raises=RuntimeError("boom"))
+    hooks = [
+        HookDef(on="turn_end", pipeline_launch=PipelineLaunchBlock(name="missing")),
+        HookDef(on="turn_end", shell_exec="echo sibling"),
+    ]
+    disp, seams = _dispatcher(hooks, launch_pipeline=raising)
+
+    await disp.dispatch("turn_end", {})  # must not raise
+
+    assert raising.calls == [("missing", None)]
+    (args, _kwargs), = seams["run_shell"].calls
+    assert args[0] == "echo sibling"
+
+
+# ===========================================================================
+# Tier 2 — end-to-end: real Session + real AgentRegistry + real Pipeline
+# ===========================================================================
+
+
+class _ScriptedAgentReply:
+    """Always answers with one fixed plain-text turn — the LLM is incidental
+    to what's under test (same rationale as test_pipeline_is2_driver_session.py)."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _install_side_effect_tool(monkeypatch) -> None:
+    """Register a REAL side-effecting tool (appends a line to a file) through
+    the production tool registry — mirrors test_pipeline_is2_driver_session.py's
+    ``_install_side_effect_tool``."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        p = Path(args["path"])
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(str(args["line"]) + "\n")
+        return {"line": str(args["line"])}
+
+    tool = ToolDefinition(
+        name="h3_append",
+        description="H3 test: append a line to a file (real side effect).",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow", phase="allow"),
+        handler=_handler,
+        category="io",
+        purity="side_effect",
+    )
+    base_build = tools_pkg.get_default_registry
+
+    def _with_tool():
+        reg = base_build()
+        reg.register(tool)
+        return reg
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
+def _one_step_pipeline(out_file: Path) -> Pipeline:
+    from reyn.core.pipeline.executor import ExprRef
+
+    return Pipeline(
+        steps=[
+            ToolStep(
+                name="h3_append",
+                args={"path": str(out_file), "line": ExprRef("ctx.number")},
+                output="t",
+            ),
+        ],
+        description="H3 test pipeline",
+    )
+
+
+def _agent_registry_with_hooks(
+    tmp_path: Path, state_log: "StateLog", hooks_config: list,
+    pipeline_registry: "PipelineRegistry", scripted: "_ScriptedAgentReply | None",
+) -> AgentRegistry:
+    holder: dict = {}
+
+    def _factory(profile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            hooks_config=hooks_config, pipeline_registry=pipeline_registry,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+async def _wait_for(pred, timeout: float = 15.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_e2e_hook_launches_registered_pipeline_with_threaded_input(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: THE core H3 proof. A REAL Session with a ``pipeline_launch``
+    hook configured launches a REAL registered Pipeline via the production DI
+    wiring (``Session._launch_pipeline_from_hook`` -> ``start_pipeline_run``):
+    the launched pipeline's real tool side effect proves the input was
+    THREADED from ``template_vars`` (not a static default), and the terminal
+    ``pipeline_result`` is delivered back to the invoking session (a scripted-
+    LLM turn consumes it)."""
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+
+    pipeline_registry = PipelineRegistry()
+    pipeline_registry.register("digest", _one_step_pipeline(out_file))
+
+    hooks_config = [
+        {
+            "on": "session_start",
+            "pipeline_launch": {
+                "name": "digest",
+                "input_template": {"number": "{{ event.count }}"},
+            },
+        },
+    ]
+    scripted = _ScriptedAgentReply("acknowledged")
+    reg = _agent_registry_with_hooks(
+        tmp_path, state_log, hooks_config, pipeline_registry, scripted,
+    )
+    caller = reg.get_or_load("worker")
+
+    await caller._hook_dispatcher.dispatch("session_start", {"event": {"count": 7}})
+
+    assert await _wait_for(lambda: out_file.exists() and out_file.read_text(encoding="utf-8").strip())
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["7"]
+    # The invoker actually consumed the pipeline_result (a scripted-LLM turn ran).
+    assert await _wait_for(lambda: scripted.calls >= 1)
+
+
+@pytest.mark.asyncio
+async def test_e2e_unregistered_pipeline_name_logs_and_skips_dispatcher_survives(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: a ``pipeline_launch`` naming an UNregistered pipeline logs a
+    clear warning and is skipped — the dispatcher survives (no crash) and a
+    SIBLING hook on the same point still fires (proven via the real Session
+    inbox, the same public surface test_hook_dispatcher_1800_5b.py uses)."""
+    _install_side_effect_tool(monkeypatch)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    pipeline_registry = PipelineRegistry()  # deliberately empty — "digest" unregistered
+
+    hooks_config = [
+        {"on": "session_start", "pipeline_launch": {"name": "does-not-exist"}},
+        {
+            "on": "session_start",
+            "template_push": {"message": "sibling ran", "wake": True},
+        },
+    ]
+    reg = _agent_registry_with_hooks(
+        tmp_path, state_log, hooks_config, pipeline_registry, None,
+    )
+    caller = reg.get_or_load("worker")
+
+    await caller._hook_dispatcher.dispatch("session_start", {})  # must not raise
+
+    # The sibling template_push hook still landed in the (public) inbox —
+    # proof the unregistered pipeline_launch did not crash the dispatcher.
+    kind, payload = caller.inbox.get_nowait()
+    assert kind == "hook"
+    assert payload["text"] == "sibling ran"


### PR DESCRIPTION
**[lead-coder]** (shipping [per-PR-coder]'s completed implementation — the dispatched agent finished the code + 3 gates but stalled at a backgrounded pytest before committing; committed+pushed by lead so CI runs pytest authoritatively, then lead-reviews) — `part of #2608`.

## What this adds
H3 of the external-event→hooks arc: a 4th `HookDef` action `pipeline_launch` — a hook can launch a registered Pipeline with an input rendered from the event payload. Works with any hook-point (the 6 lifecycle points + the `mcp_resource_updated` external point from H1). Design: new `HookDef.pipeline_launch` field ({name, input_template}) + `_dispatch_one` branch → an injected `launch_pipeline` closure (session DI) over **async-detached `start_pipeline_run`** (pipeline runs in its own recoverable driver-session, result returns to the session inbox); input rendered from `template_vars` via Jinja2; unregistered-name fail-safe.

## Gate status
3 of 4 gates were green locally per the implementing agent (ruff, tier-audit, module-docstrings). The full `pytest` gate was not confirmed locally (agent stalled) — **relying on CI to run pytest authoritatively**; lead-coder will verify CI green + review the diff before merge, and will NOT merge if pytest is red (beyond the known pre-existing #2599 web-route-mount failures).

## Test plan
- [x] ruff (agent-reported green)
- [x] tier audit (agent-reported green)
- [x] module docstrings (agent-reported green)
- [x] pytest — 5 failed (all known #2599 web-route-mount), 7369 passed, 0 NEW failures (per-PR-coder local, HEAD d6bad042; see PR comment)
- [x] New `tests/test_2608_h3_pipeline_launch_hook.py` (real registered pipeline + real dispatcher; lead will confirm coverage on review)
