### PR TITLE
feat(#2597): P1 — MCP reconnect resync-read (re-signal missed resource updates)

### DIFF
--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -115,6 +115,29 @@ lazy client-open pattern elsewhere in this class) and cancelled in :meth:`aclose
 ``hook_trigger=None`` (the ephemeral ``MCPClientPool`` path, or any session that never
 wires one) → :meth:`enqueue_external_event` and the whole queue/drain-task machinery
 never activate — byte-identical to pre-H1 behaviour.
+
+#2597 P1 — reconnect resync-read (follow-up to ②b, higher-priority now that H1 makes a
+missed update a missed hook fire): ②b re-subscribes every tracked URI on a
+transport-death reconnect (the loop in :meth:`_ensure_open`, described above), but a
+resource that actually CHANGED while the connection was dead never produced a
+``resources/updated`` push — that notification simply never arrived on the dead
+transport, and the fresh ``mcp.ClientSession`` has no way to redeliver a notification it
+never received. Q4 (S2-pre spike, decided, do not relitigate): reyn keeps NO resource
+content cache — subscriptions are runtime-only (see ②b's docstring above), so there is
+no baseline to diff the post-reconnect content against and no way to know WHICH tracked
+URIs, if any, actually changed during the down window. The chosen trade-off:
+conservatively treat every reconnect as an implicit "may have changed, re-read if you
+care" signal for every re-subscribed URI, rather than silently dropping a real update. So
+:meth:`_ensure_open` distinguishes the very first open for a server (``_ever_opened`` has
+not seen it yet — nothing to resync, no synthetic emit) from a RE-open (``is_reopen`` —
+the same server was already opened once before in this service's lifetime): on a
+re-open, after each successful re-subscribe, it calls
+:meth:`~reyn.mcp.message_handler.ReynMCPMessageHandler.emit_resource_updated` (the
+producer factored out of ``on_resource_updated`` for exactly this reuse) with
+``resync=True`` — the SAME event type, through the SAME emit_sink + H1 hook-trigger
+path a real push uses, so EventLog subscribers and H1 hooks fire identically to a real
+push. A possibly-spurious re-read on a (rare) reconnect is cheap; a silently dropped real
+update is not.
 """
 from __future__ import annotations
 
@@ -181,6 +204,13 @@ class MCPConnectionService:
         # re-subscribe every tracked URI on a fresh client (first open: empty, no-op;
         # reconnect: the whole point).
         self._subscriptions: dict[str, set[str]] = {}
+        # #2597 P1 (reconnect resync-read): servers for which _ensure_open has
+        # completed at least one successful open in THIS service's lifetime — the
+        # boundary that distinguishes the very first open (nothing to resync yet,
+        # no synthetic emit) from a RE-open after a transport-death drop (every
+        # tracked subscription may have missed a real update while dead, so each
+        # gets a synthetic mcp_resource_updated). See _ensure_open.
+        self._ever_opened: set[str] = set()
         # One handle per server, cached so repeated get() calls for the same server
         # return the SAME object (connection-reuse identity) across the connection's
         # whole lifetime, including through a reconnect: the handle looks up the
@@ -233,6 +263,12 @@ class MCPConnectionService:
             self._clients.pop(server, None)
             client = None
         if client is None:
+            # #2597 P1: computed BEFORE this open completes — True iff a PRIOR open
+            # for this server already succeeded in this service's lifetime, i.e.
+            # this is a RE-open (reconnect after a transport-death drop), not the
+            # very first open. See _ever_opened's field comment + the re-subscribe
+            # loop below.
+            is_reopen = server in self._ever_opened
             # #2597 S2b: a fresh handler per open (including every reconnect) — bound
             # to the server name closed over here, so a reconnected client's
             # notifications keep landing under the same server attribution.
@@ -254,6 +290,7 @@ class MCPConnectionService:
             )
             await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
             self._clients[server] = client
+            self._ever_opened.add(server)
             # #2597 capability/version gate: observability seam. This is the first
             # point in the live (non-ephemeral) session path that HAS the emit_sink
             # (the ephemeral per-call MCPClientPool path never wires one — see class
@@ -278,6 +315,20 @@ class MCPConnectionService:
             # server that no longer supports subscribe post-reconnect (or a single
             # bad URI) must not abort re-subscribing the REST of the tracked set,
             # and must not crash the reconnect itself.
+            #
+            # #2597 P1 (reconnect resync-read, follow-up to ②b): on a RE-open
+            # (``is_reopen`` — NOT the very first open), reyn cannot know whether any
+            # of these URIs actually changed during the disconnect window (Q4: no
+            # content cache to diff against — see message_handler.py's
+            # ``emit_resource_updated`` docstring), so it conservatively fires a
+            # SYNTHETIC ``mcp_resource_updated`` for each URI it successfully
+            # re-subscribes — through the exact same emit_sink + H1 hook-trigger path
+            # a real push uses, so a missed-during-disconnect update is never
+            # silently dropped. A URI whose re-subscribe itself failed gets no
+            # synthetic event (there's no live subscription to have missed anything
+            # on). First open: the tracked set is empty, so this loop is a no-op and
+            # nothing is ever emitted — only a genuine re-open with tracked URIs
+            # produces synthetic events.
             for uri in self._subscriptions.get(server, ()):
                 try:
                     await client.subscribe_resource(uri)
@@ -286,6 +337,9 @@ class MCPConnectionService:
                         "MCPConnectionService: failed to re-subscribe %r on %r after "
                         "(re)connect", uri, server, exc_info=True,
                     )
+                    continue
+                if is_reopen and handler is not None:
+                    handler.emit_resource_updated(uri, resync=True)
         return client
 
     async def _reconnect(

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -94,6 +94,11 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
     ``mcp_resource_updated`` hook (external-event->hooks arc, first slice) via
     ``self._on_external_event`` — see that method for the sync->async bridge design.
 
+    #2597 P1 (reconnect resync-read, follow-up to ②b): :meth:`emit_resource_updated`
+    factors the real-push producer logic out so ``MCPConnectionService`` can also
+    call it synthetically, once per re-subscribed URI, on a transport-death
+    reconnect — see that method's docstring.
+
     #2597 F2 (live-verified, NOT emitted here — see :meth:`on_progress`):
     ``notifications/progress`` is NOT bridged to ``mcp_progress`` by this handler.
     A live probe (real fastmcp 3.4.2 stdio server + a held ``MCPConnectionService``
@@ -175,17 +180,40 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         # this event needs to carry too; a caller that wants the new content reads
         # the resource again. EventLog emit stays the audit-trail write (unchanged).
         #
-        # #2608 H1: in ADDITION to the EventLog emit, this ALSO fires a user-configured
-        # ``mcp_resource_updated`` hook (external-event trigger, first slice of the
-        # external-event->hooks arc). The hook trigger goes through
-        # ``self._on_external_event`` — a SYNCHRONOUS, non-blocking enqueue (never
-        # awaited here; this method runs on the receive-loop task and cannot await the
-        # async HookDispatcher.dispatch — see MCPConnectionService's bounded queue +
-        # drain-task bridge). None (no hook wired for this session, or the ephemeral
-        # per-call MCPClientPool path) → this call is a no-op, byte-identical to pre-H1.
+        # #2608 H1 / #2597 P1: the actual emit + hook-trigger work is factored into
+        # :meth:`emit_resource_updated` — see its docstring — so P1's synthetic
+        # reconnect-resync path (``MCPConnectionService._ensure_open``) can produce
+        # the IDENTICAL event shape and hook fire as a real push, just with
+        # ``resync=True``.
         uri = getattr(getattr(message, "params", None), "uri", None)
         uri_str = str(uri) if uri is not None else None
-        self._emit("mcp_resource_updated", server=self._server_name, uri=uri_str)
+        self.emit_resource_updated(uri_str, resync=False)
+        await super().on_resource_updated(message)
+
+    def emit_resource_updated(self, uri: str | None, *, resync: bool) -> None:
+        """The shared ``mcp_resource_updated`` producer: EventLog emit +
+        (#2608 H1) hook-trigger enqueue. Called from two places:
+
+          - :meth:`on_resource_updated` (a REAL server push, ``resync=False``).
+          - ``MCPConnectionService._ensure_open`` (#2597 P1: on a genuine
+            transport-death RECONNECT, once per re-subscribed tracked URI,
+            ``resync=True``) — a synthetic "may have changed while disconnected,
+            re-read if you care" signal. reyn keeps NO resource content cache
+            (Q4 spike decision — subscriptions are runtime-only, no baseline to
+            diff against), so it cannot tell whether a specific resource
+            actually changed during the down window; it conservatively
+            re-signals EVERY re-subscribed URI rather than silently dropping a
+            real update that happened while the connection was dead.
+
+        Both call sites produce the SAME event TYPE (``mcp_resource_updated``)
+        through the SAME two downstream paths (EventLog ``emit_sink`` + H1's
+        ``_on_external_event`` bridge into the hook dispatcher), so an existing
+        ``mcp_resource_updated`` consumer or hook fires unchanged either way —
+        only the added ``resync`` field distinguishes a synthetic re-signal
+        from a real push for anyone inspecting the payload. Never raises: a
+        fault in either downstream path must not break the receive loop (real
+        push) or the reconnect (synthetic path)."""
+        self._emit("mcp_resource_updated", server=self._server_name, uri=uri, resync=resync)
         if self._on_external_event is not None:
             try:
                 self._on_external_event(
@@ -193,8 +221,9 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
                     {
                         "point": "mcp_resource_updated",
                         "server": self._server_name,
-                        "uri": uri_str,
+                        "uri": uri,
                         "agent_name": self._agent_name,
+                        "resync": resync,
                     },
                 )
             except Exception:  # noqa: BLE001 — a trigger fault must not break the receive loop
@@ -202,7 +231,6 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
                     "ReynMCPMessageHandler: on_external_event failed for %r on server %r",
                     "mcp_resource_updated", self._server_name, exc_info=True,
                 )
-        await super().on_resource_updated(message)
 
     async def on_progress(self, message: Any) -> None:
         # #2597 F2: deliberately does NOT emit ``mcp_progress`` — see this class's

--- a/tests/test_2597_p1_reconnect_resync_read.py
+++ b/tests/test_2597_p1_reconnect_resync_read.py
@@ -1,0 +1,165 @@
+"""Tests for #2597 P1 — MCP reconnect resync-read (follow-up to slice ②b, #2607).
+
+②b re-subscribes every tracked URI on a transport-death reconnect, but a
+resource that actually changed WHILE the connection was dead never produced a
+``resources/updated`` push (the notification never arrived on the dead
+transport, and a fresh ``mcp.ClientSession`` has no memory of what it missed).
+P1 closes that gap: on a genuine RE-open (not the very first open),
+``MCPConnectionService._ensure_open`` emits a SYNTHETIC ``mcp_resource_updated``
+(``resync=True``) for each successfully re-subscribed URI, through the exact
+same emit_sink + H1 hook-trigger path a real push uses — see
+``connection_service.py``'s P1 module-docstring section and
+``message_handler.py``'s ``emit_resource_updated``.
+
+Real instances only, per the testing policy: no ``unittest.mock`` /
+``MagicMock`` / ``AsyncMock`` / ``patch``. Uses the SAME real low-level MCP
+server subprocess ②b's own tests use
+(``tests/_support/mcp_subscribable_resources_server.py``) through a REAL
+``MCPConnectionService`` + REAL ``EventLog``.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.mcp.client import MCPError
+from reyn.mcp.connection_service import MCPConnectionService
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
+_URI = "resource://counter"
+
+
+def _stdio_cfg(script: Path) -> dict:
+    return {"type": "stdio", "command": sys.executable, "args": [str(script)]}
+
+
+async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` until True or give up — mirrors
+    test_2597_s2b_resource_subscriptions.py's pattern (async delivery, not
+    synchronous with the triggering call)."""
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+# ── Tier 2: reconnect resync — the core P1 proof ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconnect_emits_synthetic_resource_updated_for_missed_disconnect_window():
+    """Tier 2: THE core P1 proof. Subscribe, kill the subprocess (genuine
+    transport death -> F1 heal), then trigger the heal via an IDEMPOTENT read
+    (``list_resources`` — NOT ``bump_and_notify``, so the server issues no real
+    push at all). The reconnect's re-subscribe loop must still produce an
+    ``mcp_resource_updated`` event for the tracked URI — proving a real update
+    that could have happened during the disconnect window (and would otherwise
+    be silently lost, since the fresh session never received any push for it)
+    is surfaced via the synthetic resync signal, not dropped."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        # Genuine transport death (mirrors ②b's own reconnect test).
+        with pytest.raises(MCPError):
+            await client.call_tool("die", {})
+
+        # Trigger the heal via an IDEMPOTENT READ that the server never notifies
+        # on — isolates the synthetic resync signal from any real push.
+        await client.list_resources()
+
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+        )
+        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        (only_event,) = matching  # exactly one — the synthetic resync, no real push occurred
+        assert only_event.data.get("server") == "srv"
+        assert only_event.data.get("uri") == _URI
+        assert only_event.data.get("resync") is True, (
+            "a reconnect-driven re-signal must be distinguishable (resync=True) "
+            "from a real server push"
+        )
+        assert service.subscribed_uris("srv") == [_URI]
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_first_open_emits_no_synthetic_update():
+    """Tier 2: the first-open/re-open boundary. The VERY FIRST ``_ensure_open``
+    for a server (nothing tracked yet, no prior open) must emit NOTHING — only
+    a genuine RE-open after a drop re-signals. Subscribe (which itself opens
+    the connection for the first time) and let the connection sit idle: no
+    ``mcp_resource_updated`` event of any kind (real or synthetic) may appear,
+    since neither a push nor a reconnect happened."""
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(emit_sink=lambda et, **d: events.emit(et, **d))
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+        # A second idempotent call against the SAME still-live connection must
+        # not re-open (no reconnect happened) and so must not emit anything either.
+        await client.list_resources()
+
+        await asyncio.sleep(0.1)  # give any (wrongly) synthetic emit a fair chance
+        matching = [e for e in events.all() if e.type == "mcp_resource_updated"]
+        assert matching == [], (
+            "the first open (and further calls against the still-live "
+            "connection) must not emit any mcp_resource_updated — only a "
+            "genuine reconnect re-signals"
+        )
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_reconnect_resync_also_fires_hook_trigger_identically_to_real_push():
+    """Tier 2: the synthetic resync event flows through the SAME H1
+    hook-trigger bridge (``enqueue_external_event`` -> drain task -> real async
+    ``hook_trigger`` callable) a real push uses — proving a consumer cannot
+    tell a resync-driven re-read from a real push except by inspecting
+    ``resync`` in the payload. Uses a real recording async callable directly
+    wired as ``hook_trigger`` (mirrors test_2608_h1's ``MCPConnectionService(
+    hook_trigger=...)`` DI pattern) — confined to connection_service.py, no
+    session.py/hooks/ involvement needed to prove this bridge fires."""
+
+    class _RecordingTrigger:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict]] = []
+
+        async def __call__(self, point: str, template_vars: dict) -> None:
+            self.calls.append((point, template_vars))
+
+    trigger = _RecordingTrigger()
+    events = EventLog(subscribers=[])
+    service = MCPConnectionService(
+        emit_sink=lambda et, **d: events.emit(et, **d),
+        hook_trigger=trigger,
+    )
+    try:
+        client = await service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        with pytest.raises(MCPError):
+            await client.call_tool("die", {})
+        await client.list_resources()
+
+        await _wait_for(
+            lambda: any(e.type == "mcp_resource_updated" for e in events.all())
+        )
+        await _wait_for(lambda: len(trigger.calls) >= 1)
+
+        (point, template_vars) = trigger.calls[0]
+        assert point == "mcp_resource_updated"
+        assert template_vars.get("uri") == _URI
+        assert template_vars.get("server") == "srv"
+        assert template_vars.get("resync") is True
+    finally:
+        await service.aclose()


### PR DESCRIPTION
**[lead-coder]** (shipping [per-PR-coder]'s completed implementation — the dispatched agent finished the code but stalled at a backgrounded pytest before committing; committed+pushed by lead so CI runs pytest authoritatively, then lead-reviews) — `part of #2597`.

## What this adds
P1 closes the ②b-deferred gap: on a transport-death reconnect, an update that happened while the connection was dead was silently lost (the `resources/updated` push never arrived on the fresh session). Now, on reconnect, each re-subscribed resource gets a **synthetic `mcp_resource_updated`** routed through the same emit_sink + hook-trigger path as a real push — so EventLog subscribers AND H1 hooks learn of possibly-missed updates. reyn keeps no content cache (Q4), so it re-signals "may have changed → re-read" rather than diffing. **First-open emits nothing; only a reopen (re-subscribe after a drop) re-signals.**

## Gate status
Deferred pytest to CI (agent stalled at a backgrounded run). Lead verifies CI green + reviews the diff before merge; will NOT merge if pytest is red beyond the known #2599 web-route-mount failures. Confined to `connection_service.py` + `message_handler.py` + a new test.

## Test plan
- [ ] pytest — deferred to CI (lead verifies)
- [x] New `tests/test_2597_p1_reconnect_resync_read.py` (real killed-and-reconnected subscribable server; lead confirms coverage on review: reconnect re-signals, first-open does not)