### PR TITLE
feat(#2608): H2 — interpret HookDef.matcher to filter external-event hooks

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -7,6 +7,10 @@ Slice C (#1800): shell-hook runner (side-effect only; output ignored).
 Slice H3 (#2608): ``pipeline_launch`` action — launch a registered Pipeline
 from a hook, with an input rendered from the event payload.
 
+Slice H2 (#2608): ``matcher`` interpretation — a hook filters WHICH events
+of an external-event hook-point it fires on (field->pattern dict evaluated
+against ``template_vars``; see ``reyn.hooks.matcher``).
+
 Exposes:
     HookDef        — typed model for a single hook definition.
     PushBlock      — typed model for the inbox-push sub-schema.
@@ -20,8 +24,10 @@ Exposes:
     render_pipeline_input — render a ``PipelineLaunchBlock.input_template``
                      against a context dict (H3).
     run_shell_hook — execute a shell HookDef command (slice C).
+    matcher_matches — evaluate a ``HookDef.matcher`` against ``template_vars`` (H2).
 """
 from reyn.hooks.loader import load_hooks
+from reyn.hooks.matcher import matches as matcher_matches
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.render import ResolvedPush, render_pipeline_input, render_push
 from reyn.hooks.schema import HookConfigError, HookDef, PipelineLaunchBlock, PushBlock
@@ -38,4 +44,5 @@ __all__ = [
     "render_push",
     "render_pipeline_input",
     "run_shell_hook",
+    "matcher_matches",
 ]

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -30,6 +30,7 @@ import json
 import logging
 from typing import Any, Awaitable, Callable
 
+from reyn.hooks.matcher import matches as matcher_matches
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.render import ResolvedPush, render_pipeline_input, render_push
 from reyn.hooks.schema import HookDef
@@ -138,10 +139,17 @@ class HookDispatcher:
         Per-hook ``try/except``: a raising hook is logged + skipped; siblings and
         the lifecycle point proceed. Never propagates out of ``dispatch()``.
         Empty registry → the loop body never runs → byte-identical no-op.
+
+        #2608 H2: before running a hook's action, its (optional) ``matcher`` is
+        evaluated against ``template_vars`` (``reyn.hooks.matcher.matches``) — a
+        non-matching hook is skipped, same as a disabled hook. A hook with no
+        matcher always matches (fire-always, unchanged from pre-H2).
         """
         for hook in self._registry.hooks_for(point):
             if self._is_hook_disabled is not None and self._is_hook_disabled(hook):
                 continue  # #2285: hook disabled for THIS session (live applicability toggle)
+            if not matcher_matches(hook.matcher, template_vars):
+                continue  # #2608 H2: matcher didn't match this event's template_vars
             try:
                 await self._dispatch_one(hook, point, template_vars)
             except Exception as exc:  # noqa: BLE001 — per-hook isolation boundary

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -138,6 +138,42 @@ def _parse_pipeline_launch_block(raw: object, entry_index: int) -> PipelineLaunc
     return PipelineLaunchBlock(name=name, input_template=input_template)
 
 
+def _parse_matcher(raw: object, entry_index: int) -> "dict[str, str] | None":
+    """Validate and convert the ``matcher:`` sub-dict (#2608 H2).
+
+    Structural only: ``matcher`` must be a mapping of string keys to string
+    values (a per-hook-point matchable-field ALLOWLIST is deliberately NOT
+    enforced here — the loader has no per-point payload schema, and a future
+    external-event source (H4/H5) may introduce its own matchable fields
+    with zero change to this function; ``reyn.hooks.matcher.matches`` is the
+    seam that interprets field names). ``None`` or ``{}`` -> ``None``
+    (fire-always default, unchanged from H1).
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise HookConfigError(
+            f"hooks[{entry_index}].matcher must be a mapping of string field -> "
+            f"string pattern, got {type(raw).__name__!r}."
+        )
+    if not raw:
+        return None
+    matcher: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str) or not key.strip():
+            raise HookConfigError(
+                f"hooks[{entry_index}].matcher keys must be non-empty strings, "
+                f"got {key!r}."
+            )
+        if not isinstance(value, str):
+            raise HookConfigError(
+                f"hooks[{entry_index}].matcher[{key!r}] must be a string pattern, "
+                f"got {type(value).__name__!r}."
+            )
+        matcher[key] = value
+    return matcher
+
+
 def _parse_entry(raw: object, entry_index: int) -> HookDef:
     """Validate one raw hooks list entry and return a ``HookDef``."""
     if not isinstance(raw, dict):
@@ -213,14 +249,8 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
     if "pipeline_launch" in raw:
         pipeline_launch = _parse_pipeline_launch_block(raw["pipeline_launch"], entry_index)
 
-    # ── matcher (optional, reserved) ───────────────────────────────────────
-    matcher_raw = raw.get("matcher", None)
-    if matcher_raw is not None and not isinstance(matcher_raw, str):
-        raise HookConfigError(
-            f"hooks[{entry_index}].matcher must be a string or null, "
-            f"got {type(matcher_raw).__name__!r}."
-        )
-    matcher: str | None = matcher_raw if matcher_raw else None
+    # ── matcher (optional, #2608 H2 — a field->pattern filter dict) ────────
+    matcher: "dict[str, str] | None" = _parse_matcher(raw.get("matcher", None), entry_index)
 
     # ── name (optional, #1800 slice 6) — the [hook:name] attribution label; ──
     # absent / blank → None (the dispatcher defaults it to the hook-point).

--- a/src/reyn/hooks/matcher.py
+++ b/src/reyn/hooks/matcher.py
@@ -1,0 +1,68 @@
+"""reyn.hooks.matcher — interpret ``HookDef.matcher`` to filter hook firing (#2608 H2).
+
+H1 added the first EXTERNAL-event hook-point, ``mcp_resource_updated``, but a
+hook registered on it fires for ANY subscribed-resource update — scoping is
+only via which resources the user chose to subscribe to. H2 lets a hook
+narrow further: ``matcher`` is a small ``field -> pattern`` dict evaluated
+against the event's ``template_vars`` at dispatch time, BEFORE the hook's
+action runs.
+
+Shape
+-----
+``matcher: dict[str, str] | None`` — e.g. ``{"server": "github", "uri":
+"file:///repo/**"}``. A hook fires iff **every** field named in the matcher
+matches:
+
+- exact string equality for every field EXCEPT ``uri``;
+- ``uri`` matches via a shell-style glob (``fnmatch.fnmatch``), so
+  ``"file:///repo/**"`` matches any URI under that prefix.
+
+A field named in the matcher that is ABSENT from ``template_vars`` (e.g. a
+lifecycle hook-point's vars have no ``server``/``uri``, or a future source's
+vars don't carry a field this hook's matcher names) never matches — a
+matcher can only narrow, never invent a signal that was never fired.
+
+Absent or empty matcher -> the hook always fires (unchanged behavior for
+every hook that predates H2, and for an external-event hook that opts not to
+filter). This is the byte-identical-to-H1 default: ``matches(None, ...)`` and
+``matches({}, ...)`` are both ``True`` unconditionally.
+
+Deliberately general: the ``uri``-globs-others-exact rule is keyed off the
+FIELD NAME, not the hook-point, so a future external-event source (cron/
+webhook/fs-watcher, H4/H5) that also emits a ``uri``-shaped field gets glob
+matching for free, and any other field it introduces gets exact matching
+with zero code changes here.
+"""
+from __future__ import annotations
+
+from fnmatch import fnmatch
+
+# Field names matched via glob (fnmatch) rather than exact string equality.
+_GLOB_FIELDS: frozenset[str] = frozenset({"uri"})
+
+
+def matches(matcher: "dict[str, str] | None", template_vars: dict) -> bool:
+    """Return whether a hook whose ``HookDef.matcher`` is *matcher* should fire
+    for an event whose dispatch context is *template_vars*.
+
+    ``matcher`` is ``None``/empty -> always ``True`` (fire-always default,
+    preserving pre-H2 behavior for every existing hook — lifecycle hooks never
+    set a matcher, and an H1-era external-event hook with no matcher keeps
+    firing on every subscribed-resource update).
+    """
+    if not matcher:
+        return True
+    for field_name, pattern in matcher.items():
+        value = template_vars.get(field_name)
+        if value is None:
+            return False  # the field this matcher names was never fired with a value
+        value_str = str(value)
+        if field_name in _GLOB_FIELDS:
+            if not fnmatch(value_str, pattern):
+                return False
+        elif value_str != pattern:
+            return False
+    return True
+
+
+__all__ = ["matches"]

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -18,9 +18,16 @@ and ``reyn.mcp.connection_service.MCPConnectionService``'s bounded
 sync->async bridge). Unlike the six lifecycle points above (fired from the
 session/turn/task run-loop on the agent's own task), this point is fired
 from the MCP receive-loop task via a bounded queue drained on the session's
-event loop. ``HookDef.matcher`` stays reserved/uninterpreted for this
-point in H1 (scoping is via which resources the user subscribed to) — a
-later slice (H2) may add matcher filtering.
+event loop. ``HookDef.matcher`` stayed reserved/uninterpreted for this
+point in H1 (scoping was via which resources the user subscribed to).
+
+#2608 H2 interprets ``matcher``: a ``dict[str, str]`` of field -> pattern,
+evaluated against the event's ``template_vars`` BEFORE the hook's action runs
+(``reyn.hooks.matcher.matches``, called from ``HookDispatcher.dispatch``).
+For ``mcp_resource_updated`` the two matchable fields are ``server`` (exact
+match) and ``uri`` (glob via ``fnmatch``) — e.g. ``{"server": "github", "uri":
+"file:///repo/**"}``. Absent/empty matcher -> fires always (unchanged for
+every pre-H2 hook, lifecycle or external-event).
 
 #2608 H3 adds the 4th action, ``pipeline_launch`` — a hook can launch a
 REGISTERED Pipeline (``reyn.core.pipeline.registry.PipelineRegistry.get``)
@@ -181,7 +188,13 @@ class HookDef:
         later on this session's inbox as a ``pipeline_result`` message).
         Mutually exclusive with the other actions.
     matcher:
-        Reserved optional filter string.  Not interpreted in this slice.
+        Optional ``dict[str, str]`` filter (#2608 H2) — a hook fires only when
+        every named field matches the event's ``template_vars``: exact string
+        equality for every field except ``uri`` (glob via ``fnmatch``). See
+        ``reyn.hooks.matcher.matches`` for the match semantics and
+        ``reyn.hooks.dispatcher.HookDispatcher.dispatch`` for where it's
+        applied (before the hook's action runs). Absent/empty -> always fires
+        (unchanged for every hook that predates H2).
     """
 
     on: str
@@ -190,4 +203,4 @@ class HookDef:
     shell_exec: str | None = field(default=None)
     shell_push: str | None = field(default=None)
     pipeline_launch: PipelineLaunchBlock | None = field(default=None)
-    matcher: str | None = field(default=None)
+    matcher: "dict[str, str] | None" = field(default=None)

--- a/tests/test_1800_hook_config_schema.py
+++ b/tests/test_1800_hook_config_schema.py
@@ -36,7 +36,7 @@ def _raw_push(
     wake: bool | str = True,
     push_when: str = "true",
     session: str | None = None,
-    matcher: str | None = None,
+    matcher: "dict[str, str] | None" = None,
 ) -> dict:
     """Build a raw push-hook dict (valid by default)."""
     push: dict = {"message": message, "wake": wake, "push_when": push_when}
@@ -66,7 +66,9 @@ def test_hookdef_push_shape() -> None:
         push_when="{{ ctx.condition }}",
         session="session-abc",
     )
-    hd = HookDef(on="turn_end", template_push=push, shell_exec=None, matcher="my-matcher")
+    hd = HookDef(
+        on="turn_end", template_push=push, shell_exec=None, matcher={"server": "my-matcher"}
+    )
 
     assert hd.on == "turn_end"
     assert hd.template_push is push
@@ -74,7 +76,7 @@ def test_hookdef_push_shape() -> None:
     assert hd.template_push.wake == "{{ ctx.needs_wake }}"
     assert hd.template_push.push_when == "{{ ctx.condition }}"
     assert hd.template_push.session == "session-abc"
-    assert hd.matcher == "my-matcher"
+    assert hd.matcher == {"server": "my-matcher"}
     assert hd.shell_exec is None
 
 
@@ -138,7 +140,7 @@ def test_load_hooks_push_all_fields_accepted() -> None:
                 "push_when": "{{ ctx.should_push }}",
                 "session": "{{ ctx.target_session }}",
             },
-            "matcher": "my-task-filter",
+            "matcher": {"server": "my-task-filter"},
         }
     ]
     registry = load_hooks(raw)
@@ -149,7 +151,7 @@ def test_load_hooks_push_all_fields_accepted() -> None:
     assert hd.template_push.wake == "{{ ctx.wake_needed }}"
     assert hd.template_push.push_when == "{{ ctx.should_push }}"
     assert hd.template_push.session == "{{ ctx.target_session }}"
-    assert hd.matcher == "my-task-filter"
+    assert hd.matcher == {"server": "my-task-filter"}
 
 
 def test_load_hooks_shell_valid() -> None:
@@ -330,11 +332,13 @@ hooks:
       wake: false
       push_when: "{{ ctx.should_notify }}"
       session: "{{ ctx.target_session }}"
-    matcher: task-done-filter
+    matcher:
+      server: task-done-filter
 
   - on: session_start
     shell_exec: "scripts/on-session-start.sh"
-    matcher: session-filter
+    matcher:
+      server: session-filter
 """.lstrip()
 
     reyn_yaml = tmp_path / "reyn.yaml"
@@ -356,7 +360,7 @@ hooks:
     # non-default session template (default is None)
     assert h1.template_push.session == "{{ ctx.target_session }}"
     # non-default matcher (default is None)
-    assert h1.matcher == "task-done-filter"
+    assert h1.matcher == {"server": "task-done-filter"}
 
     # ── Hook 2: shell hook at session_start ───────────────────────────────
     session_start_hooks = registry.hooks_for("session_start")
@@ -364,7 +368,7 @@ hooks:
     assert h2.on == "session_start"
     assert h2.shell_exec == "scripts/on-session-start.sh"
     assert h2.template_push is None
-    assert h2.matcher == "session-filter"
+    assert h2.matcher == {"server": "session-filter"}
 
     # ── Hooks at other points are empty (no stray registrations) ─────────
     assert registry.hooks_for("turn_end") == []

--- a/tests/test_2608_h2_hook_matcher.py
+++ b/tests/test_2608_h2_hook_matcher.py
@@ -1,0 +1,309 @@
+"""Tests for #2608 H2 — ``HookDef.matcher`` interpretation (filter external events).
+
+H1 added the first EXTERNAL-event hook-point, ``mcp_resource_updated``, but a
+hook on it fired for ANY subscribed-resource update — scoping was only via
+which resources were subscribed. H2 interprets the (previously reserved/
+uninterpreted) ``matcher`` field so a hook can filter WHICH events it fires
+on: a ``dict[str, str]`` of field -> pattern, evaluated against the event's
+``template_vars`` BEFORE the hook's action runs. For ``mcp_resource_updated``:
+``server`` matches exactly, ``uri`` matches via a shell-style glob.
+
+Coverage plan
+-------------
+Tier 1 (contract): loader validation — a dict matcher round-trips through
+  ``load_hooks``; a malformed matcher (non-dict, non-string key/value) raises
+  ``HookConfigError`` at load time.
+Tier 1 (contract): ``reyn.hooks.matcher.matches`` — the pure predicate, unit
+  tested directly (server exact, uri glob, absent-field, empty/None matcher).
+Tier 2 (OS invariant, dispatcher-unit): ``HookDispatcher.dispatch`` skips a
+  non-matching hook's action entirely (never reaches ``_dispatch_one``) and
+  runs a matching hook's action, driven through the REAL dispatcher + REAL
+  registry loaded via the REAL ``load_hooks`` seam, observed via the action
+  seam (a real recording async callable — no mock). Also covers: a hook with
+  NO matcher fires for every event (byte-identical to H1), and a lifecycle
+  hook (no external payload fields) with no matcher is unaffected.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.loader import load_hooks
+from reyn.hooks.matcher import matches
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookConfigError, HookDef
+
+# ---------------------------------------------------------------------------
+# Recording seam (mirrors test_2608_h3_pipeline_launch_hook.py's _Recorder)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A real recording async callable — generic seam stand-in for
+    ``put_inbox``/``stage_next_turn_context`` (accepts any args/kwargs)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def _dispatcher(hooks: list[HookDef]) -> "tuple[HookDispatcher, _Recorder]":
+    put_inbox = _Recorder()
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=put_inbox,
+        stage_next_turn_context=_Recorder(),
+    )
+    return disp, put_inbox
+
+
+def _mcp_vars(*, server: str = "github", uri: str = "file:///repo/a.txt") -> dict:
+    return {
+        "point": "mcp_resource_updated",
+        "server": server,
+        "uri": uri,
+        "agent_name": "test-agent",
+        "resync": False,
+    }
+
+
+# ===========================================================================
+# Tier 1 — Contract: loader validation
+# ===========================================================================
+
+
+def test_matcher_dict_round_trips_through_loader() -> None:
+    """Tier 1: a ``matcher:`` dict on an ``mcp_resource_updated`` hook parses
+    through the REAL ``load_hooks`` seam unchanged."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "{{ uri }} updated"},
+            "matcher": {"server": "github", "uri": "file:///repo/**"},
+        },
+    ]
+    registry = load_hooks(raw)
+    (hook,) = registry.hooks_for("mcp_resource_updated")
+    assert hook.matcher == {"server": "github", "uri": "file:///repo/**"}
+
+
+def test_matcher_absent_stays_none() -> None:
+    """Tier 1: no ``matcher:`` key -> ``HookDef.matcher is None`` (fire-always)."""
+    raw = [{"on": "turn_end", "shell_exec": "echo hi"}]
+    registry = load_hooks(raw)
+    (hook,) = registry.hooks_for("turn_end")
+    assert hook.matcher is None
+
+
+def test_matcher_empty_dict_normalises_to_none() -> None:
+    """Tier 1: an empty ``matcher: {}`` normalises to ``None`` (same fire-always
+    semantics as absent — no functional difference the operator should rely on
+    a distinction for)."""
+    raw = [{"on": "turn_end", "shell_exec": "echo hi", "matcher": {}}]
+    registry = load_hooks(raw)
+    (hook,) = registry.hooks_for("turn_end")
+    assert hook.matcher is None
+
+
+@pytest.mark.parametrize(
+    "bad_matcher",
+    [
+        "a-plain-string",  # H1-era reserved-string shape no longer accepted
+        ["server", "github"],
+        {"server": 123},
+        {1: "github"},
+        {"": "github"},
+    ],
+)
+def test_malformed_matcher_raises_hook_config_error(bad_matcher) -> None:
+    """Tier 1: a malformed matcher (non-dict, non-string key/value, or an empty
+    key) raises ``HookConfigError`` at load time — decision-enabling, not a
+    silent ignore."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "x"},
+            "matcher": bad_matcher,
+        },
+    ]
+    with pytest.raises(HookConfigError):
+        load_hooks(raw)
+
+
+# ===========================================================================
+# Tier 1 — Contract: reyn.hooks.matcher.matches — the pure predicate
+# ===========================================================================
+
+
+def test_matches_none_matcher_always_true() -> None:
+    """Tier 1: no matcher -> always fires."""
+    assert matches(None, {}) is True
+    assert matches(None, _mcp_vars()) is True
+
+
+def test_matches_empty_matcher_always_true() -> None:
+    """Tier 1: an empty matcher dict -> always fires (same as None)."""
+    assert matches({}, _mcp_vars()) is True
+
+
+def test_matches_server_exact() -> None:
+    """Tier 1: ``server`` matches by exact string equality only."""
+    assert matches({"server": "github"}, _mcp_vars(server="github")) is True
+    assert matches({"server": "github"}, _mcp_vars(server="gitlab")) is False
+    assert matches({"server": "git*"}, _mcp_vars(server="github")) is False  # no glob for server
+
+
+def test_matches_uri_glob() -> None:
+    """Tier 1: ``uri`` matches via a shell-style glob (fnmatch)."""
+    assert matches({"uri": "file:///repo/**"}, _mcp_vars(uri="file:///repo/a.txt")) is True
+    assert matches({"uri": "file:///repo/*.txt"}, _mcp_vars(uri="file:///repo/a.txt")) is True
+    assert matches({"uri": "file:///repo/*.txt"}, _mcp_vars(uri="file:///other/a.txt")) is False
+    assert matches({"uri": "file:///repo/*.md"}, _mcp_vars(uri="file:///repo/a.txt")) is False
+
+
+def test_matches_multiple_fields_all_must_match() -> None:
+    """Tier 1: a multi-field matcher requires EVERY named field to match."""
+    matcher = {"server": "github", "uri": "file:///repo/**"}
+    assert matches(matcher, _mcp_vars(server="github", uri="file:///repo/a.txt")) is True
+    # server matches, uri doesn't -> overall no match
+    assert matches(matcher, _mcp_vars(server="github", uri="file:///other/a.txt")) is False
+    # uri matches, server doesn't -> overall no match
+    assert matches(matcher, _mcp_vars(server="gitlab", uri="file:///repo/a.txt")) is False
+
+
+def test_matches_field_absent_from_template_vars_is_no_match() -> None:
+    """Tier 1: a matcher naming a field that ``template_vars`` doesn't carry
+    (e.g. a lifecycle hook's vars have no ``server``/``uri``) never matches —
+    a matcher can only narrow, never invent an unfired signal."""
+    assert matches({"server": "github"}, {"point": "turn_end"}) is False
+
+
+# ===========================================================================
+# Tier 2 — OS invariant: HookDispatcher applies the matcher before dispatch
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_hook_whose_matcher_server_does_not_match() -> None:
+    """Tier 2: a hook with ``matcher: {server: X}`` fires for server=X, SKIPS
+    server=Y — driven through the REAL dispatcher + REAL registry."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "{{ uri }} updated"},
+            "matcher": {"server": "github"},
+        },
+    ]
+    registry = load_hooks(raw)
+    disp = HookDispatcher(
+        registry,
+        put_inbox=(recorder := _Recorder()),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(server="gitlab"))
+    assert recorder.calls == []  # skipped — server didn't match
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(server="github"))
+    (_,) = recorder.calls  # exactly one call — fired, server matched
+
+
+@pytest.mark.asyncio
+async def test_dispatch_uri_glob_match_and_no_match() -> None:
+    """Tier 2: a hook with ``matcher: {uri: glob}`` fires on a matching URI and
+    is skipped on a non-matching one."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "{{ uri }} updated"},
+            "matcher": {"uri": "file:///repo/**"},
+        },
+    ]
+    registry = load_hooks(raw)
+    disp = HookDispatcher(
+        registry,
+        put_inbox=(recorder := _Recorder()),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(uri="file:///other/a.txt"))
+    assert recorder.calls == []
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(uri="file:///repo/a.txt"))
+    (_,) = recorder.calls  # exactly one call — fired, uri matched the glob
+
+
+@pytest.mark.asyncio
+async def test_dispatch_no_matcher_fires_for_every_event() -> None:
+    """Tier 2: a hook with NO matcher fires for every event on its point —
+    byte-identical to pre-H2 (H1) behavior."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {"message": "{{ uri }} updated"},
+        },
+    ]
+    registry = load_hooks(raw)
+    disp = HookDispatcher(
+        registry,
+        put_inbox=(recorder := _Recorder()),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(server="github"))
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(server="gitlab"))
+    (_, _) = recorder.calls  # exactly two calls — both fired, no matcher to filter on
+
+
+@pytest.mark.asyncio
+async def test_dispatch_lifecycle_hook_with_no_matcher_unaffected() -> None:
+    """Tier 2: a lifecycle hook (no external-event payload fields at all) with
+    no matcher configured is completely unaffected by H2 — fires exactly as
+    it did pre-H2 on its point's (lifecycle) ``template_vars``."""
+    raw = [{"on": "turn_end", "template_push": {"message": "turn done"}}]
+    registry = load_hooks(raw)
+    disp = HookDispatcher(
+        registry,
+        put_inbox=(recorder := _Recorder()),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("turn_end", {})
+    (_,) = recorder.calls  # exactly one call — fired unchanged
+
+
+@pytest.mark.asyncio
+async def test_dispatch_matching_and_nonmatching_hooks_are_isolated_siblings() -> None:
+    """Tier 2: two hooks on the same point, one matching and one not — the
+    matching one fires, the non-matching one is silently skipped, and neither
+    affects the other (per-hook isolation, same as the disabled-hook gate)."""
+    raw = [
+        {
+            "on": "mcp_resource_updated",
+            "name": "github-only",
+            "template_push": {"message": "github: {{ uri }}"},
+            "matcher": {"server": "github"},
+        },
+        {
+            "on": "mcp_resource_updated",
+            "name": "gitlab-only",
+            "template_push": {"message": "gitlab: {{ uri }}"},
+            "matcher": {"server": "gitlab"},
+        },
+    ]
+    registry = load_hooks(raw)
+    disp = HookDispatcher(
+        registry,
+        put_inbox=(recorder := _Recorder()),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("mcp_resource_updated", _mcp_vars(server="github"))
+    (call,) = recorder.calls  # exactly one call — the matching hook fired, its sibling didn't
+    _, payload = call[0]
+    assert payload["text"] == "github: file:///repo/a.txt"


### PR DESCRIPTION
**[per-PR-coder]** — part of #2608

## Summary

H1 (#2610) added the first EXTERNAL-event hook-point, `mcp_resource_updated`, but a hook on it fired for ANY subscribed-resource update — scoping was only via which resources were subscribed. `HookDef.matcher` was a reserved/uninterpreted field. This PR (H2) interprets it so a hook can filter WHICH events it fires on.

## Matcher shape + semantics

- `matcher: dict[str, str] | None` — a small field→pattern dict, e.g. `matcher: {server: "github", uri: "file:///repo/**"}`.
- A hook fires iff **every** field named in the matcher matches the event's `template_vars`:
  - `server` (and any other non-`uri` field): **exact string equality**.
  - `uri`: **shell-style glob** via `fnmatch.fnmatch` (e.g. `"file:///repo/**"` matches any URI under that prefix).
- A field named in the matcher that is **absent** from `template_vars` (e.g. a lifecycle hook-point's vars have no `server`/`uri`) never matches — a matcher can only narrow, never invent a signal that was never fired.
- **Absent or empty matcher → the hook always fires** — byte-identical to pre-H2 (H1) behavior for every existing hook, lifecycle or external-event.
- Deliberately general: the `uri`-globs / others-exact rule is keyed off the **field name**, not the hook-point, so a future external-event source (cron/webhook/fs-watcher — H4/H5) that emits its own `uri`-shaped field gets glob matching for free, and any other field it introduces gets exact matching with zero code changes to `reyn/hooks/matcher.py`.

## Implementation

- `src/reyn/hooks/matcher.py` (new): the pure `matches(matcher, template_vars) -> bool` predicate.
- `src/reyn/hooks/schema.py`: `HookDef.matcher` retyped `str | None` → `dict[str, str] | None`; docstrings updated.
- `src/reyn/hooks/loader.py`: `matcher:` now validated structurally (must be a mapping of non-empty string keys → string values); malformed input raises `HookConfigError` at load time. Empty dict normalises to `None`.
- `src/reyn/hooks/dispatcher.py`: `HookDispatcher.dispatch` evaluates the matcher against `template_vars` **before** `_dispatch_one` — a non-matching hook is skipped (same per-hook-isolation posture as the existing disabled-hook gate); its siblings are unaffected.
- `src/reyn/hooks/__init__.py`: exports `matcher_matches`.

**Clean break, no shim**: `HookDef.matcher` was previously an arbitrary uninterpreted string (H1). Since the field is now a structured, interpreted dict, the old string shape is a `HookConfigError` at load time. `tests/test_1800_hook_config_schema.py`'s pre-existing matcher assertions (which exercised the old opaque-string shape) are updated to the new dict shape — same test intent (structural round-trip / non-default-field coverage), new representation.

## Out of scope (per issue)

`pipeline_launch` (H3, done in #2611). fs-watcher (H4), cron/webhook (H5) — not wired here; only `mcp_resource_updated`'s `server`/`uri` fields are tested. No changes to `src/reyn/mcp/` or `session.py`. No WAL/recovery surface touched — truncate-falsify N/A.

## Test plan

- [x] `tests/test_2608_h2_hook_matcher.py` (new, 15 tests): loader validation (dict round-trip, absent→None, empty-dict→None, malformed→`HookConfigError` parametrized over 5 bad shapes); `matches()` unit coverage (None/empty always-true, server exact, uri glob, multi-field AND, absent-field→no-match); dispatcher integration through the REAL `HookDispatcher`+`HookRegistry`+`load_hooks` (server-filter skip/fire, uri-glob skip/fire, no-matcher fires every event, lifecycle hook unaffected, sibling isolation) — all driven via `dispatch()` and observed through a real recording `put_inbox` seam, no mocks.
- [x] `tests/test_1800_hook_config_schema.py` updated for the `str`→`dict` type change (3 assertions + 1 YAML fixture).
- [x] All pre-existing hooks tests still pass (`test_2608_h1_mcp_resource_updated_hook.py`, `test_2608_h3_pipeline_launch_hook.py`, `test_hook_dispatcher_1800_5b.py`, `test_hook_applicability_2285.py`).

## Gate output (all run locally, foreground)

**ruff check src tests**: `All checks passed!`

**python scripts/test_tier_audit.py --strict tests/test_2608_h2_hook_matcher.py tests/test_1800_hook_config_schema.py**: `Summary: 40 tests inspected — ✓ OK: 40, ✗ errors: 0`

**python scripts/verify_module_docstrings.py** (all 5 changed/added src files): `OK: no module-docstring refactor narrative`

**pytest** (full suite, repo root): `5 failed, 7391 passed, 21 skipped, 11 warnings in 153.63s`
The 5 failures are the pre-existing #2599 known-unrelated route-mount flakiness (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`, `test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `test_resources_router.py::test_resources_route_is_mounted_on_app`) — all in `tests/web/` / FastAPI route registration, unrelated to `hooks/`. Confirmed zero NEW failures introduced by this change (same 5, same names, pre-existing on main).