### PR TITLE
feat(#2597): slice ③ — MCP elicitation (server->client structured input)

### DIFF
--- a/src/reyn/intervention_choices.py
+++ b/src/reyn/intervention_choices.py
@@ -15,6 +15,8 @@ NO = "no"             # one-shot deny
 NEVER = "never"       # deny + persist
 JUST_PATH = "just_path"  # file approval: persist for this exact path
 RECURSIVE = "recursive"  # file approval: persist for parent/declared dir
+ACCEPT = "accept"     # #2597 slice ③: MCP elicitation gate — proceed
+DECLINE = "decline"   # #2597 slice ③: MCP elicitation gate — refuse to answer
 
 
 def generic_yn_choices() -> list[InterventionChoice]:
@@ -69,13 +71,32 @@ def file_access_choices(recursive_label: str) -> list[InterventionChoice]:
     ]
 
 
+def elicitation_gate_choices() -> list[InterventionChoice]:
+    """`[y]es / [N]o` for an MCP elicitation accept/decline gate (#2597 slice ③).
+
+    Distinct ids (``ACCEPT``/``DECLINE``) from the generic ``YES``/``NO``
+    permission-grant vocabulary: an elicitation gate answers "will you engage
+    with this server's question at all", not "grant this permission" — a
+    separate MCP protocol action (``action: accept | decline | cancel``), not
+    a reyn permission decision. No ``ALWAYS``/``NEVER`` — an elicitation gate
+    decision is never persisted; every elicitation is asked fresh.
+    """
+    return [
+        InterventionChoice(id=ACCEPT, label="[y]es", hotkey="y"),
+        InterventionChoice(id=DECLINE, label="[N]o", hotkey="N"),
+    ]
+
+
 __all__ = [
+    "ACCEPT",
     "ALWAYS",
+    "DECLINE",
     "JUST_PATH",
     "NEVER",
     "NO",
     "RECURSIVE",
     "YES",
+    "elicitation_gate_choices",
     "file_access_choices",
     "generic_yn_choices",
     "python_choices",

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -40,6 +40,16 @@ Capability / version gate (#2597 capability slice):
   exposes the raw protocol version string for callers/later slices to
   branch on — this slice deliberately does not build a version-semantics
   matrix, just makes the version + capabilities readable and gated.
+
+Elicitation (#2597 slice ③ — server->client ``elicitation/create``):
+  an optional ``elicitation_handler`` (constructor kwarg, same shape as
+  ``message_handler``) is forwarded verbatim to ``fastmcp.Client(...,
+  elicitation_handler=...)`` — passing ANY non-None handler is itself what
+  makes FastMCP declare the ``elicitation`` client capability during the
+  initialize handshake. See :mod:`reyn.mcp.elicitation` for the handler
+  that routes a server's structured question through reyn's consent path
+  (:class:`~reyn.mcp.connection_service.MCPConnectionService` builds one per
+  held connection); this module only plumbs the constructor kwarg through.
 """
 from __future__ import annotations
 
@@ -226,6 +236,7 @@ class MCPClient:
         *,
         agent_id: str | None = None,
         message_handler: Any = None,
+        elicitation_handler: Any = None,
         server_name: str | None = None,
     ) -> None:
         if not isinstance(config, dict):
@@ -259,6 +270,15 @@ class MCPClient:
         # behaviour change for callers that don't pass one (e.g. the ephemeral
         # per-call MCPClientPool path never installs a handler).
         self._message_handler: Any = message_handler
+        # #2597 slice ③: optional FastMCP ``ElicitationHandler`` (see
+        # ``reyn.mcp.elicitation.build_elicitation_handler``) — routes a
+        # server->client ``elicitation/create`` request through reyn's
+        # consent path. Passing ANY non-None handler to ``fastmcp.Client``
+        # is itself what causes FastMCP to declare the ``elicitation`` client
+        # capability during the initialize handshake (D6 — held connections
+        # always install one; the ephemeral per-call ``MCPClientPool`` path
+        # never does, same None-default no-op pattern as ``message_handler``).
+        self._elicitation_handler: Any = elicitation_handler
         self._client: Any = None  # fastmcp.Client when initialized
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
@@ -378,6 +398,10 @@ class MCPClient:
             # binding") for why that two-step is necessary.
             if self._message_handler is not None:
                 client_kwargs["message_handler"] = self._message_handler
+            # #2597 slice ③: same constructor-kwarg contract as message_handler —
+            # FastMCP's ``Client(transport, elicitation_handler=...)``.
+            if self._elicitation_handler is not None:
+                client_kwargs["elicitation_handler"] = self._elicitation_handler
             client = FastMCPClient(transport, **client_kwargs)
             if self._message_handler is not None:
                 self._message_handler.bind_client(client)

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -1,5 +1,15 @@
 """MCPConnectionService — per-session held-open MCP connections (#2597 S2a).
 
+#2597 slice ③ (elicitation): every held connection installs an
+``elicitation_handler`` (see :mod:`reyn.mcp.elicitation`), built fresh on
+every open/reopen alongside the existing ``ReynMCPMessageHandler`` (mirrors
+the S2b per-open handler-rebuild pattern). ``elicitation_bus``/
+``elicitation_gate`` (both optional, mirroring ``hook_trigger``'s None-
+default no-op pattern) are the SAME "fixed bus + per-call gate" split #2095's
+shell-hook consent uses (``session.py`` wires ``consent_bus=
+self.as_request_bus()`` / ``consent_gate=lambda: self._interventions.
+has_active_listener()``) — see :meth:`_resolve_elicitation_bus`.
+
 Option C from the S2-pre spike (owner-delegated, do not relitigate): a persistent MCP
 connection lives as a service INSIDE the agent's own session — not a separate driver
 session. The spike proved the key precondition: FastMCP holds its client session in a
@@ -143,11 +153,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from reyn.mcp.client import MCPClient, MCPTransportError
+from reyn.mcp.elicitation import DEFAULT_ELICITATION_TIMEOUT_SECONDS, build_elicitation_handler
 from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCacheInvalidate
 from reyn.mcp.pool import describe_fault, is_real_control_flow
+
+if TYPE_CHECKING:
+    from reyn.user_intervention import RequestBus
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +172,14 @@ logger = logging.getLogger(__name__)
 _HOOK_EVENT_QUEUE_MAXSIZE = 32
 
 HookTrigger = Callable[[str, dict], Awaitable[Any]]
+
+# #2597 slice ③: same "bus + gate" split #2095's shell-hook consent uses
+# (session.py wires ``consent_bus=self.as_request_bus()`` /
+# ``consent_gate=lambda: self._interventions.has_active_listener()``) — a
+# fixed bus REFERENCE plus a per-call GATE, so "is a human attached right
+# now" is re-evaluated fresh on every elicitation, not frozen at connection-
+# open time (a TUI can mount/unmount between one elicitation and the next).
+ElicitationGate = Callable[[], bool]
 
 
 class MCPConnectionService:
@@ -182,6 +204,8 @@ class MCPConnectionService:
         emit_sink: EmitSink | None = None,
         tools_cache_invalidate: ToolsCacheInvalidate | None = None,
         hook_trigger: "HookTrigger | None" = None,
+        elicitation_bus: "RequestBus | None" = None,
+        elicitation_gate: "ElicitationGate | None" = None,
         agent_name: str | None = None,
     ) -> None:
         # #2597 S2b: threaded into a fresh ReynMCPMessageHandler per held server
@@ -193,6 +217,19 @@ class MCPConnectionService:
         # #2608 H1: the async closure over the owning session's HookDispatcher.dispatch.
         # None = no external-event hook bridge — see module docstring's H1 section.
         self._hook_trigger = hook_trigger
+        # #2597 slice ③: mirrors #2095's consent_bus/consent_gate split (see
+        # ElicitationGate's field comment above). None/None (the default —
+        # every call site that doesn't explicitly wire elicitation, including
+        # every existing test that constructs this service directly) means
+        # every held connection's elicitation_bus_resolver always returns
+        # None, i.e. every elicitation auto-declines (headless) — byte-
+        # identical to pre-③ behaviour (no elicitation_handler installed
+        # would have meant no elicitation capability declared at all; a
+        # resolver that always returns None still declares the capability
+        # per D6, but a server that never gets asked because no test
+        # exercises it sees no behaviour change).
+        self._elicitation_bus = elicitation_bus
+        self._elicitation_gate = elicitation_gate
         self._agent_name = agent_name
         self._hook_event_queue: "asyncio.Queue[tuple[str, dict]] | None" = None
         self._hook_drain_task: "asyncio.Task | None" = None
@@ -285,8 +322,29 @@ class MCPConnectionService:
                     ),
                     agent_name=self._agent_name,
                 )
+            # #2597 slice ③ D6: EVERY held connection installs an elicitation
+            # handler (unconditionally — no "does this session have a bus"
+            # branch here; that branch lives INSIDE the handler, see
+            # reyn.mcp.elicitation's module docstring), so every held
+            # connection always declares the ``elicitation`` client
+            # capability. Per-server config overrides:
+            #   - ``elicitation: "auto_decline"`` — always decline, even with
+            #     a live listener (operator wants this server silenced).
+            #   - ``elicitation_timeout_seconds`` — per-server deadline
+            #     override (default DEFAULT_ELICITATION_TIMEOUT_SECONDS).
+            elicitation_handler = build_elicitation_handler(
+                server_name=server,
+                bus_resolver=self._resolve_elicitation_bus,
+                emit_sink=self._emit_sink,
+                timeout_seconds=float(
+                    config.get("elicitation_timeout_seconds")
+                    or DEFAULT_ELICITATION_TIMEOUT_SECONDS
+                ),
+                mode=str(config.get("elicitation") or "prompt"),
+            )
             client = MCPClient(
-                config, agent_id=agent_id, message_handler=handler, server_name=server,
+                config, agent_id=agent_id, message_handler=handler,
+                elicitation_handler=elicitation_handler, server_name=server,
             )
             await client.__aenter__()  # initialize; held open (no matching __aexit__ until aclose/reconnect)
             self._clients[server] = client
@@ -366,6 +424,21 @@ class MCPConnectionService:
         Read-only introspection for callers/tests (mirrors :meth:`held_servers`'s
         public-surface pattern) — never reach into ``_subscriptions`` directly."""
         return sorted(self._subscriptions.get(server, ()))
+
+    def _resolve_elicitation_bus(self) -> "RequestBus | None":
+        """#2597 slice ③ D4/D6: called by an elicitation handler at request
+        time (never cached) — mirrors #2095's ``consent_gate`` re-check.
+        Returns None (= headless, auto-decline) when either no
+        ``elicitation_bus`` was wired for this service (the default — no
+        session behaviour change for any caller that doesn't opt in) or the
+        wired ``elicitation_gate`` reports no live listener attached right
+        now (a TUI can mount/unmount between one elicitation and the next).
+        """
+        if self._elicitation_bus is None:
+            return None
+        if self._elicitation_gate is not None and not self._elicitation_gate():
+            return None
+        return self._elicitation_bus
 
     # ── #2608 H1: bounded sync->async external-event->hook bridge ──────────────────
 

--- a/src/reyn/mcp/elicitation.py
+++ b/src/reyn/mcp/elicitation.py
@@ -1,0 +1,388 @@
+"""MCP elicitation — server->client structured-input requests (#2597 slice ③).
+
+An MCP server can send ``elicitation/create`` mid-session to ask the human a
+structured question (a flat, primitive-only JSON-object schema per the
+2025-11-25 spec — string / number / integer / boolean / enum; NO nesting).
+FastMCP's ``fastmcp.Client(elicitation_handler=...)`` (verified against the
+installed fastmcp 3.4.2, ``fastmcp/client/elicitation.py``) is the
+capability-declaring seam: passing a handler is what causes FastMCP to
+declare the ``elicitation`` client capability during the initialize
+handshake. The handler signature (verified against
+``fastmcp.client.elicitation.ElicitationHandler``)::
+
+    async def handler(
+        message: str,
+        response_type: type[T] | None,   # a dataclass FastMCP built from the
+                                          # server's JSON schema, or None for a
+                                          # no-data / URL-based elicitation
+        params: mcp.types.ElicitRequestParams,  # carries the RAW requestedSchema
+        context: RequestContext[ClientSession, LifespanContextT],
+    ) -> T | dict[str, Any] | ElicitResult[T | dict[str, Any]]
+
+FastMCP auto-converts the JSON schema to ``response_type`` but ERASES the
+per-field metadata (enum choices, descriptions) needed to prompt one field at
+a time — so this module reads field specs from ``params.requestedSchema``
+(the raw JSON Schema dict) directly, and only uses ``response_type`` as the
+None-vs-not-None signal for "does this elicitation carry a schema at all".
+
+D2 — receive-loop dispatch (verified by reading the installed mcp SDK):
+``mcp.shared.session.BaseSession._receive_loop`` awaits
+``ClientSession._received_request`` INLINE for every incoming server request,
+and ``_received_request`` awaits the installed ``_elicitation_callback``
+INLINE too (``mcp/client/session.py``) — no per-request task is spawned by the
+SDK. So awaiting a human answer here blocks THAT server's receive loop for as
+long as the wait takes (bounded by ``timeout_seconds`` below) — other
+notifications/responses on the SAME connection queue behind it. Since each
+held MCP connection (:class:`~reyn.mcp.connection_service.MCPConnectionService`)
+owns its own ``fastmcp.Client``/``ClientSession`` with its own receive-loop
+task, this block is contained to the ONE server connection that asked the
+question — every other held server connection (and the rest of reyn) keeps
+running. Cleanly spinning the wait onto a separate asyncio Task would not
+avoid the block: the SDK requires this callback's coroutine to complete
+(with a ``ClientResult``/``ErrorData``) before it will process the NEXT
+message on this connection's read stream at all, so a fire-and-forget task
+here would just mean the elicitation response is never sent. Per the design
+doc (D2), this bounded per-connection block is ACCEPTABLE — never faked with
+an early return.
+
+D3 — timeout semantics: no answer within ``timeout_seconds`` (default 120,
+per-server override via server config key ``elicitation_timeout_seconds``) ->
+``action="cancel"`` (nobody judged the request). The human explicitly
+declining (via the accept/decline gate prompt, or a per-field sensitive-value
+confirmation) -> ``action="decline"``.
+
+D4 — headless (no attached intervention listener): auto-decline (never
+cancel — ``decline`` signals "don't retry the same way", matching reyn's
+no-blocking-AskUser-in-autonomous-mode principle) + emit
+``mcp_elicitation_auto_declined``. Per-server override via server config key
+``elicitation: "prompt" | "auto_decline"`` (default ``"prompt"`` — i.e. try
+the bus when one is available; ``"auto_decline"`` always declines even with a
+live listener, for an operator who wants a server's elicitations silenced
+outright).
+
+D5 — security (all 5, see :func:`_attributed_message` / :func:`_is_sensitive_field`
+/ :func:`build_elicitation_handler`):
+  1. every prompt is prefixed with clear server-attribution.
+  2. a field whose name/description matches password|token|key|secret|credential
+     gets an extra yes/no confirmation + an explicit "sent to server '<name>'"
+     warning before the free-text prompt.
+  3. answers are human-typed ONLY — this module never reads env vars / secrets
+     to prefill a field.
+  4. audit events record the server name + the schema's field KEY names, never
+     the field VALUES (a user's answer content never appears in an emitted event).
+  5. the message is rendered as plain text (``UserIntervention.prompt`` is
+     never markdown/HTML-interpreted) and length-capped (:data:`_MAX_MESSAGE_LEN`)
+     as a prompt-injection defense — an oversized server message is truncated
+     before it ever reaches the human-facing prompt.
+
+D6 — capability: :meth:`build_elicitation_handler` is installed unconditionally
+by every HELD connection (:mod:`reyn.mcp.connection_service`) — the "is there a
+human" branch lives INSIDE the handler (this module), not at wiring time, so
+the ``elicitation`` capability is always declared and every server always gets
+an answer of some kind (prompt-and-wait, or a bus-less auto-decline).
+
+D1 — structured response, sequential per-field prompting: a multi-field flat
+schema is answered ONE FIELD AT A TIME (never crammed into a single message +
+free-text-parsed), preceded by ONE accept/decline gate prompt so the human can
+refuse the whole exchange before answering anything. bool -> yes/no choice;
+enum -> a choice per enum value; string/number/integer -> free text (best-
+effort ``int``/``float`` coercion — a coercion failure falls back to the raw
+string; reyn does not re-implement full JSON-Schema validation client-side,
+the server is the source of truth for that).
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from reyn.intervention_choices import ACCEPT, elicitation_gate_choices
+from reyn.user_intervention import InterventionChoice, UserIntervention
+
+if TYPE_CHECKING:
+    from reyn.user_intervention import RequestBus
+
+logger = logging.getLogger(__name__)
+
+# #2597 slice ③ D3: default per-elicitation deadline (seconds). Per-server
+# override: server config key ``elicitation_timeout_seconds``.
+DEFAULT_ELICITATION_TIMEOUT_SECONDS = 120.0
+
+# #2597 slice ③ D5.5: prompt-injection defense — an oversized server-authored
+# message is truncated before it is ever rendered to the human.
+_MAX_MESSAGE_LEN = 1500
+
+# #2597 slice ③ D5.2: substring match (case-insensitive) against a field's
+# name OR JSON-schema description. Intentionally broad (over-triggers on e.g.
+# "primary_key") — the cost of a false positive is one extra confirmation
+# step, not a blocked feature; the cost of a false negative is a credential
+# silently typed into an untrusted MCP server's field.
+_SENSITIVE_KEYWORDS = ("password", "token", "key", "secret", "credential")
+
+# Bus resolver: called at request time (mirrors the deferred-lambda pattern
+# already used for emit_sink/hook_trigger in MCPConnectionService/session.py).
+# Returns None when no live intervention listener is attached (headless).
+ElicitationBusResolver = Callable[[], "RequestBus | None"]
+
+EmitSink = Callable[..., Any]
+
+
+def _attributed_message(server_name: str, message: str) -> str:
+    """D5.1 — prefix every elicitation prompt with unambiguous server
+    attribution so the human never mistakes a server's question for reyn's
+    own. D5.5 — length-capped BEFORE the prefix is added (the prefix itself
+    is reyn-authored, not attacker-controlled, so it is never truncated)."""
+    body = message if len(message) <= _MAX_MESSAGE_LEN else (
+        message[:_MAX_MESSAGE_LEN] + "...(truncated)"
+    )
+    return f"⚠️ MCP server {server_name!r} asks (this is NOT reyn): {body}"
+
+
+def _field_prefix(server_name: str) -> str:
+    """D5.1 — per-field prompts carry a SHORT server-attribution prefix (the
+    gate prompt above already carries the full disclaimer; repeating it
+    verbatim on every one of N sequential field prompts would be noisy) so a
+    human who scrolls directly to a field prompt (e.g. TUI scrollback, past
+    the gate) still sees which server is asking BEFORE typing an answer."""
+    return f"[MCP server {server_name!r}] "
+
+
+def _is_sensitive_field(name: str, description: str | None) -> bool:
+    haystack = f"{name} {description or ''}".lower()
+    return any(kw in haystack for kw in _SENSITIVE_KEYWORDS)
+
+
+def _schema_fields(requested_schema: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten ``requestedSchema["properties"]`` (a flat, primitives-only JSON
+    object per the MCP spec — verified against the 2025-11-25 spec's
+    elicitation section: no nested object/array properties are permitted) into
+    an ordered list of per-field specs. Order follows the schema's own
+    declaration order (Python dicts + FastMCP's own schema builder both
+    preserve insertion order) — this is presentation sequencing, not a pinned
+    algorithmic detail a test should assert on."""
+    properties = requested_schema.get("properties") or {}
+    required = set(requested_schema.get("required") or [])
+    out = []
+    for name, spec in properties.items():
+        spec = spec if isinstance(spec, dict) else {}
+        out.append({
+            "name": name,
+            "type": spec.get("type", "string"),
+            "enum": spec.get("enum"),
+            "description": spec.get("description"),
+            "required": name in required,
+        })
+    return out
+
+
+def _coerce(value: str, field_type: str) -> Any:
+    """Best-effort scalar coercion for the free-text path (string/number/
+    integer). A coercion failure falls back to the raw string — reyn is not
+    re-implementing JSON-Schema validation client-side; the server validates
+    the final answer and is the source of truth for rejecting a bad value."""
+    if field_type == "integer":
+        try:
+            return int(value.strip())
+        except (ValueError, AttributeError):
+            return value
+    if field_type == "number":
+        try:
+            return float(value.strip())
+        except (ValueError, AttributeError):
+            return value
+    if field_type == "boolean":
+        return value.strip().lower() in ("true", "yes", "y", "1")
+    return value
+
+
+def _enum_choices(values: list[Any]) -> list[InterventionChoice]:
+    return [
+        InterventionChoice(id=str(v), label=f"[{i + 1}] {v}", hotkey=str(i + 1))
+        for i, v in enumerate(values)
+    ]
+
+
+def _bool_choices() -> list[InterventionChoice]:
+    return [
+        InterventionChoice(id="true", label="[y]es", hotkey="y"),
+        InterventionChoice(id="false", label="[n]o", hotkey="n"),
+    ]
+
+
+class _Cancelled(Exception):
+    """Internal signal: the elicitation deadline elapsed mid-flow."""
+
+
+class _Declined(Exception):
+    """Internal signal: the human explicitly declined mid-flow."""
+
+
+def build_elicitation_handler(
+    *,
+    server_name: str,
+    bus_resolver: "ElicitationBusResolver",
+    emit_sink: "EmitSink | None" = None,
+    timeout_seconds: float = DEFAULT_ELICITATION_TIMEOUT_SECONDS,
+    mode: str = "prompt",
+) -> Callable[..., Awaitable[Any]]:
+    """Build a FastMCP-shaped ``elicitation_handler`` bound to ``server_name``.
+
+    ``bus_resolver`` is called ONCE per elicitation (at request time, not at
+    build time) — mirrors ``MCPConnectionService``'s deferred-lambda pattern
+    for ``emit_sink``/``hook_trigger`` — so the "is a human attached right
+    now" check (:meth:`InterventionRegistry.has_active_listener`, the SAME
+    gate #2095's shell-hook consent uses) is re-evaluated fresh on every call,
+    not frozen at connection-open time.
+
+    ``mode``: ``"prompt"`` (default) tries the bus when one is available;
+    ``"auto_decline"`` (per-server config override ``elicitation:
+    auto_decline``) always auto-declines, even with a live listener attached.
+    """
+    from fastmcp.client.elicitation import ElicitResult
+    from mcp.types import ElicitRequestFormParams
+
+    async def _emit(event: str, **fields: Any) -> None:
+        if emit_sink is None:
+            return
+        try:
+            emit_sink(event, server=server_name, **fields)
+        except Exception:  # noqa: BLE001 — observability must never break the handler
+            logger.warning("mcp elicitation: emit_sink raised for %r", event, exc_info=True)
+
+    async def _ask(bus: "RequestBus", iv: UserIntervention, deadline: float):
+        import asyncio
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise _Cancelled()
+        try:
+            return await asyncio.wait_for(bus.request(iv), timeout=remaining)
+        except TimeoutError:
+            raise _Cancelled() from None
+
+    async def handler(
+        message: str,
+        response_type: "type | None",
+        params: Any,
+        context: Any,
+    ) -> Any:
+        field_keys: list[str] = []
+        if isinstance(params, ElicitRequestFormParams):
+            field_keys = sorted((params.requestedSchema.get("properties") or {}).keys())
+
+        await _emit("mcp_elicitation_requested", field_keys=field_keys)
+
+        if mode == "auto_decline":
+            await _emit("mcp_elicitation_auto_declined", field_keys=field_keys, reason="server_configured")
+            return ElicitResult(action="decline")
+
+        bus = bus_resolver()
+        if bus is None:
+            # D4: headless — no live intervention listener attached. Never
+            # cancel (cancel means "nobody judged it" and invites a retry
+            # loop) — decline, so the server sees a definitive "no".
+            await _emit("mcp_elicitation_auto_declined", field_keys=field_keys, reason="headless")
+            return ElicitResult(action="decline")
+
+        deadline = time.monotonic() + timeout_seconds
+        attributed = _attributed_message(server_name, message)
+
+        try:
+            field_specs = (
+                _schema_fields(params.requestedSchema)
+                if isinstance(params, ElicitRequestFormParams)
+                else []
+            )
+
+            if not field_specs:
+                # No-data elicitation (empty-properties schema, or a
+                # non-form/URL request): a single accept/decline gate is the
+                # whole exchange.
+                gate = UserIntervention(
+                    kind="mcp_elicitation",
+                    prompt=attributed,
+                    choices=elicitation_gate_choices(),
+                )
+                answer = await _ask(bus, gate, deadline)
+                if answer.choice_id != ACCEPT:
+                    raise _Declined()
+                await _emit("mcp_elicitation_answered", field_keys=field_keys, action="accept")
+                return ElicitResult(action="accept", content={})
+
+            field_summary = ", ".join(f["name"] for f in field_specs)
+            gate = UserIntervention(
+                kind="mcp_elicitation",
+                prompt=attributed,
+                detail=f"Will ask for: {field_summary}" if len(field_specs) > 1 else "",
+                choices=elicitation_gate_choices(),
+            )
+            gate_answer = await _ask(bus, gate, deadline)
+            if gate_answer.choice_id != ACCEPT:
+                raise _Declined()
+
+            content: dict[str, Any] = {}
+            for spec in field_specs:
+                name = spec["name"]
+                sensitive = _is_sensitive_field(name, spec["description"])
+                if sensitive:
+                    warn_iv = UserIntervention(
+                        kind="mcp_elicitation_sensitive_field",
+                        prompt=(
+                            f"{_field_prefix(server_name)}field {name!r} looks like a "
+                            "credential (password/token/key/secret/credential). "
+                            f"Your answer will be SENT TO server {server_name!r}. "
+                            "reyn never autofills this from env vars or stored "
+                            "secrets — provide it anyway?"
+                        ),
+                        choices=elicitation_gate_choices(),
+                    )
+                    warn_answer = await _ask(bus, warn_iv, deadline)
+                    if warn_answer.choice_id != ACCEPT:
+                        continue  # skip this field; server sees it absent
+
+                if spec["enum"]:
+                    field_iv = UserIntervention(
+                        kind="mcp_elicitation_field",
+                        prompt=f"{_field_prefix(server_name)}{name}: {spec['description'] or 'choose a value'}",
+                        choices=_enum_choices(list(spec["enum"])),
+                    )
+                    field_answer = await _ask(bus, field_iv, deadline)
+                    if field_answer.choice_id is not None:
+                        content[name] = field_answer.choice_id
+                elif spec["type"] == "boolean":
+                    field_iv = UserIntervention(
+                        kind="mcp_elicitation_field",
+                        prompt=f"{_field_prefix(server_name)}{name}: {spec['description'] or 'yes or no?'}",
+                        choices=_bool_choices(),
+                    )
+                    field_answer = await _ask(bus, field_iv, deadline)
+                    if field_answer.choice_id is not None:
+                        content[name] = field_answer.choice_id == "true"
+                else:
+                    field_iv = UserIntervention(
+                        kind="mcp_elicitation_field",
+                        prompt=f"{_field_prefix(server_name)}{name}: {spec['description'] or 'enter a value'}",
+                    )
+                    field_answer = await _ask(bus, field_iv, deadline)
+                    text = field_answer.text or ""
+                    if text or spec["required"]:
+                        content[name] = _coerce(text, spec["type"])
+
+            await _emit("mcp_elicitation_answered", field_keys=field_keys, action="accept")
+            return ElicitResult(action="accept", content=content)
+
+        except _Cancelled:
+            await _emit("mcp_elicitation_timed_out", field_keys=field_keys)
+            return ElicitResult(action="cancel")
+        except _Declined:
+            await _emit("mcp_elicitation_answered", field_keys=field_keys, action="decline")
+            return ElicitResult(action="decline")
+
+    return handler
+
+
+__all__ = [
+    "DEFAULT_ELICITATION_TIMEOUT_SECONDS",
+    "ElicitationBusResolver",
+    "build_elicitation_handler",
+]

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1075,11 +1075,22 @@ class Session:
         # connection's receive loop enqueues an external event, long after __init__ has
         # finished. ``self.agent_name`` IS already resolvable here (``self._agent`` is
         # set earlier in this __init__), so it's passed eagerly (not deferred).
+        # #2597 slice ③ (elicitation): SAME consent_bus/consent_gate split
+        # #2095's shell-hook consent already uses (see the HookDispatcher
+        # construction above) — a server->client elicitation is routed
+        # through THIS session's RequestBus ONLY when a live intervention
+        # listener is attached; headless (no listener) auto-declines inside
+        # the handler (reyn.mcp.elicitation), never here. ``as_request_bus()``
+        # is safe to call eagerly here (unlike the deferred lambdas above) —
+        # it just wraps ``self`` in an adapter, no attribute it reads is
+        # constructed later in this __init__.
         from reyn.mcp.connection_service import MCPConnectionService
         self._mcp_connection_service = MCPConnectionService(
             emit_sink=lambda et, **d: self._chat_events.emit(et, **d),
             tools_cache_invalidate=lambda server: self._router_host.invalidate_mcp_tools_cache(server),
             hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
+            elicitation_bus=self.as_request_bus(),
+            elicitation_gate=lambda: self._interventions.has_active_listener(),
             agent_name=self.agent_name,
         )
         self.output_language = output_language

--- a/tests/_support/mcp_elicitation_server.py
+++ b/tests/_support/mcp_elicitation_server.py
@@ -1,0 +1,82 @@
+"""Real FastMCP server that ELICITS structured input from the client (#2597 slice ③).
+
+Run directly as a subprocess (stdio) — never imported. Every tool below calls the
+real ``fastmcp.Context.elicit`` API (SEP-1686 ``elicitation/create``), so the
+elicitation round-trip these tests exercise is the genuine MCP protocol
+exchange, not a hand-rolled fake.
+
+Tools:
+  - ``confirm(question)``       -> ``ctx.elicit(question, response_type=bool)`` —
+                                    a single-field (scalar) schema; the client's
+                                    handler answers via the yes/no bool-field
+                                    prompt path. Returns the elicited bool as text
+                                    (``"true"``/``"false"``), or ``"declined"`` /
+                                    ``"cancelled"`` on those actions — lets a test
+                                    assert on the SERVER's observed action, not
+                                    just the client-side ElicitResult.
+  - ``ask_credential(field)``   -> a ONE-field dataclass schema whose single field
+                                    name is caller-supplied (a test passes e.g.
+                                    ``"api_key"`` to exercise the sensitive-field
+                                    warning path, or ``"comment"`` for the
+                                    non-sensitive control case).
+  - ``ask_multi()``             -> a THREE-field flat dataclass schema
+                                    (``name: str``, ``count: int``, ``proceed:
+                                    bool``) — exercises D1's sequential
+                                    per-field prompting for a genuinely
+                                    multi-field flat object.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, make_dataclass
+
+from fastmcp import Context, FastMCP
+
+mcp = FastMCP("reyn-test-elicitation")
+
+
+def _render(result) -> str:
+    if result.action == "accept":
+        return str(result.data)
+    return result.action  # "decline" | "cancel"
+
+
+@mcp.tool()
+async def confirm(question: str, ctx: Context) -> str:
+    result = await ctx.elicit(question, response_type=bool)
+    return _render(result)
+
+
+@mcp.tool()
+async def ask_credential(field_name: str, ctx: Context) -> str:
+    # Build a one-field dataclass named after ``field_name`` at call time so a
+    # single tool can drive both the sensitive-keyword path (field_name=
+    # "api_key") and the non-sensitive control case (field_name="comment").
+    schema = make_dataclass("OneField", [(field_name, str)])
+    result = await ctx.elicit(
+        f"Please provide {field_name}", response_type=schema,
+    )
+    if result.action != "accept":
+        return result.action
+    return str(getattr(result.data, field_name))
+
+
+@dataclass
+class _MultiField:
+    name: str
+    count: int
+    proceed: bool
+
+
+@mcp.tool()
+async def ask_multi(ctx: Context) -> str:
+    result = await ctx.elicit(
+        "Fill in the multi-field form", response_type=_MultiField,
+    )
+    if result.action != "accept":
+        return result.action
+    d = result.data
+    return f"{d.name}|{d.count}|{d.proceed}"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/test_2597_slice3_mcp_elicitation.py
+++ b/tests/test_2597_slice3_mcp_elicitation.py
@@ -1,0 +1,271 @@
+"""Tier 2: #2597 slice ③ — MCP elicitation (server->client structured input).
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``.
+The server side is a REAL FastMCP stdio subprocess
+(``tests/_support/mcp_elicitation_server.py``) that calls the genuine
+``fastmcp.Context.elicit`` API (SEP-1686 ``elicitation/create``) — so every
+test here exercises the actual MCP protocol exchange, not a hand-rolled fake
+of it. The client side is a REAL ``MCPConnectionService`` +
+``reyn.mcp.elicitation.build_elicitation_handler``. Only the HUMAN answer
+source is a test double (``_ScriptedBus`` / ``_HangingBus``) — concrete
+``RequestBus`` implementations (the same pattern
+``test_2095_shell_hook_consent_bus.py``'s ``_RecordingBus`` uses), not mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.intervention_choices import ACCEPT
+from reyn.mcp.connection_service import MCPConnectionService
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ELICIT_SERVER = _SUPPORT_DIR / "mcp_elicitation_server.py"
+_CFG = {"type": "stdio", "command": sys.executable, "args": [str(_ELICIT_SERVER)]}
+
+
+class _ScriptedBus:
+    """A real ``RequestBus`` that answers each ``request(iv)`` with the next
+    preset answer in ``script`` (in call order) and records every iv seen —
+    lets a test assert on prompt content (server attribution, sensitive-field
+    warning) as well as drive the sequential per-field flow deterministically."""
+
+    def __init__(self, script: list[InterventionAnswer]) -> None:
+        self._script = list(script)
+        self.seen: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.seen.append(iv)
+        return self._script.pop(0)
+
+
+class _HangingBus:
+    """A real ``RequestBus`` whose ``request`` never resolves — simulates a
+    listener that is attached but never answers, so the elicitation
+    handler's OWN timeout (not the bus) is what fires."""
+
+    def __init__(self) -> None:
+        self.seen: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.seen.append(iv)
+        await asyncio.sleep(9999)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+
+class _EventRecorder:
+    """A real emit_sink — records every (event_type, fields) call."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def __call__(self, event_type: str, **fields) -> None:
+        self.events.append((event_type, fields))
+
+
+@pytest.mark.asyncio
+async def test_bool_schema_accept_routes_through_bus_with_attribution():
+    """Tier 2: (a) a bool-schema elicitation is routed through the intervention
+    bus with forced server-attribution; a human ACCEPT (gate) + "true" (field)
+    answer resolves to {action: accept, content: {value: True}} — observed via
+    the REAL server's own rendering of the elicitation result."""
+    bus = _ScriptedBus([
+        InterventionAnswer(choice_id=ACCEPT),  # the gate: engage with this elicitation
+        InterventionAnswer(choice_id="true"),  # the single bool field
+    ])
+    events = _EventRecorder()
+    service = MCPConnectionService(
+        emit_sink=events, elicitation_bus=bus, elicitation_gate=lambda: True,
+    )
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("confirm", {"question": "Delete the file?"})
+        assert result["content"][0]["text"] == "True", (
+            "server observed action=accept, data=True"
+        )
+    finally:
+        await service.aclose()
+
+    # Server attribution: every prompt the human saw carries the server name
+    # (either the full gate disclaimer, or the short per-field prefix); the
+    # gate prompt specifically carries the explicit "NOT reyn" disclaimer.
+    assert bus.seen, "the elicitation must route through the bus"
+    for iv in bus.seen:
+        assert "srv" in iv.prompt
+    gate_ivs = [iv for iv in bus.seen if iv.kind == "mcp_elicitation"]
+    assert gate_ivs and "NOT reyn" in gate_ivs[0].prompt
+
+    event_names = [name for name, _ in events.events]
+    assert "mcp_elicitation_requested" in event_names
+    assert "mcp_elicitation_answered" in event_names
+
+
+@pytest.mark.asyncio
+async def test_headless_no_bus_auto_declines():
+    """Tier 2: (b) no elicitation_bus wired at all (headless / no attached
+    listener) -> auto-decline (never cancel) + mcp_elicitation_auto_declined,
+    without ever touching a bus (there isn't one)."""
+    events = _EventRecorder()
+    service = MCPConnectionService(emit_sink=events)  # no elicitation_bus
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("confirm", {"question": "Delete the file?"})
+        assert result["content"][0]["text"] == "decline"
+    finally:
+        await service.aclose()
+
+    event_names = [name for name, _ in events.events]
+    assert "mcp_elicitation_auto_declined" in event_names
+    assert "mcp_elicitation_answered" not in event_names
+
+
+@pytest.mark.asyncio
+async def test_gate_false_auto_declines_even_with_bus_wired():
+    """Tier 2: (b) variant — a bus IS wired but ``elicitation_gate`` reports no
+    live listener right now (mirrors #2095's consent_gate re-check) -> same
+    auto-decline path as no bus at all; the bus is never consulted."""
+    bus = _ScriptedBus([])
+    events = _EventRecorder()
+    service = MCPConnectionService(
+        emit_sink=events, elicitation_bus=bus, elicitation_gate=lambda: False,
+    )
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("confirm", {"question": "Delete?"})
+        assert result["content"][0]["text"] == "decline"
+    finally:
+        await service.aclose()
+    assert bus.seen == [], "gate=False must never reach the bus"
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_cancel():
+    """Tier 2: (c) no answer within the per-server deadline -> cancel (nobody
+    judged), observed via the server's own action-branch rendering, plus a
+    mcp_elicitation_timed_out event."""
+    bus = _HangingBus()
+    events = _EventRecorder()
+    cfg = {**_CFG, "elicitation_timeout_seconds": 0.2}
+    service = MCPConnectionService(
+        emit_sink=events, elicitation_bus=bus, elicitation_gate=lambda: True,
+    )
+    try:
+        client = await service.get("srv", cfg)
+        result = await client.call_tool("confirm", {"question": "Delete?"})
+        assert result["content"][0]["text"] == "cancel"
+    finally:
+        await service.aclose()
+
+    event_names = [name for name, _ in events.events]
+    assert "mcp_elicitation_timed_out" in event_names
+
+
+@pytest.mark.asyncio
+async def test_sensitive_field_name_triggers_extra_warning():
+    """Tier 2: (d) a field named ``api_key`` (matches the sensitive-keyword
+    list) gets an EXTRA confirmation intervention (kind
+    ``mcp_elicitation_sensitive_field``) before the free-text prompt, carrying
+    the "sent to server" warning — distinct from a non-sensitive field name,
+    which skips straight to the free-text prompt."""
+    bus = _ScriptedBus([
+        InterventionAnswer(choice_id=ACCEPT),   # gate
+        InterventionAnswer(choice_id=ACCEPT),   # sensitive-field extra confirm
+        InterventionAnswer(text="sekrit-val"),  # the free-text value itself
+    ])
+    service = MCPConnectionService(elicitation_bus=bus, elicitation_gate=lambda: True)
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("ask_credential", {"field_name": "api_key"})
+        assert result["content"][0]["text"] == "sekrit-val"
+    finally:
+        await service.aclose()
+
+    sensitive_ivs = [iv for iv in bus.seen if iv.kind == "mcp_elicitation_sensitive_field"]
+    assert sensitive_ivs, "a sensitive field name must trigger the extra warning"
+    assert "sent" in sensitive_ivs[0].prompt.lower()
+    assert "srv" in sensitive_ivs[0].prompt
+
+
+@pytest.mark.asyncio
+async def test_non_sensitive_field_name_skips_warning():
+    """Tier 2: (d) control case — a field named ``comment`` (no sensitive
+    keyword match) never gets the extra warning step."""
+    bus = _ScriptedBus([
+        InterventionAnswer(choice_id=ACCEPT),   # gate
+        InterventionAnswer(text="just a note"),  # straight to free text
+    ])
+    service = MCPConnectionService(elicitation_bus=bus, elicitation_gate=lambda: True)
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("ask_credential", {"field_name": "comment"})
+        assert result["content"][0]["text"] == "just a note"
+    finally:
+        await service.aclose()
+
+    assert not [iv for iv in bus.seen if iv.kind == "mcp_elicitation_sensitive_field"]
+
+
+@pytest.mark.asyncio
+async def test_audit_events_record_field_keys_not_values():
+    """Tier 2: (e) the requested/answered events record the schema's field KEY
+    names (for observability) but never the user's answer VALUES — a
+    completed elicitation with a sensitive-looking answer must not leak that
+    value into the EventLog."""
+    bus = _ScriptedBus([
+        InterventionAnswer(choice_id=ACCEPT),
+        InterventionAnswer(choice_id=ACCEPT),
+        InterventionAnswer(text="super-secret-value-12345"),
+    ])
+    events = _EventRecorder()
+    service = MCPConnectionService(
+        emit_sink=events, elicitation_bus=bus, elicitation_gate=lambda: True,
+    )
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("ask_credential", {"field_name": "api_key"})
+        assert result["content"][0]["text"] == "super-secret-value-12345"
+    finally:
+        await service.aclose()
+
+    for _name, fields in events.events:
+        serialized = repr(fields)
+        assert "super-secret-value-12345" not in serialized, (
+            "the answer VALUE must never appear in an emitted event"
+        )
+        if "field_keys" in fields:
+            assert "api_key" in fields["field_keys"], (
+                "the field KEY name is expected observability content"
+            )
+
+
+@pytest.mark.asyncio
+async def test_multi_field_flat_schema_prompts_sequentially():
+    """Tier 2: D1 — a THREE-field flat schema is answered ONE FIELD AT A TIME
+    (never crammed into one free-text-parsed message): the gate, then exactly
+    one intervention per field, in order."""
+    bus = _ScriptedBus([
+        InterventionAnswer(choice_id=ACCEPT),   # gate
+        InterventionAnswer(text="alice"),       # name
+        InterventionAnswer(text="3"),           # count
+        InterventionAnswer(choice_id="true"),   # proceed
+    ])
+    service = MCPConnectionService(elicitation_bus=bus, elicitation_gate=lambda: True)
+    try:
+        client = await service.get("srv", _CFG)
+        result = await client.call_tool("ask_multi", {})
+        assert result["content"][0]["text"] == "alice|3|True"
+    finally:
+        await service.aclose()
+
+    field_ivs = [iv for iv in bus.seen if iv.kind == "mcp_elicitation_field"]
+    # Each prompt is "[MCP server 'srv'] <field>: <description>" — strip the
+    # server-attribution prefix before extracting the field name.
+    field_names = [iv.prompt.split("] ", 1)[1].split(":")[0] for iv in field_ivs]
+    assert field_names == ["name", "count", "proceed"], (
+        "one intervention per field, in the schema's declared order"
+    )
+


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Summary

Implements MCP **elicitation** (`elicitation/create` — a server asking the human a structured question) as the third slice of the MCP client redesign (#2597), following the flow-trace-first discipline: MCP receive path (`fastmcp`/`mcp` SDK) + reyn's existing consent/intervention path (`RequestBus`/`UserIntervention`, and the #2095 shell-hook `consent_bus`/`consent_gate` split).

## What I verified before implementing

**FastMCP `elicitation_handler` signature** (installed fastmcp 3.4.2, `fastmcp/client/elicitation.py`):

```python
async def handler(
    message: str,
    response_type: type[T] | None,   # a dataclass FastMCP built from the JSON schema,
                                      # or None for a no-data/URL elicitation
    params: mcp.types.ElicitRequestParams,   # carries the RAW requestedSchema
    context: RequestContext[ClientSession, LifespanContextT],
) -> T | dict[str, Any] | ElicitResult[T | dict[str, Any]]
```
Passed as `fastmcp.Client(transport, elicitation_handler=...)` — a `Client(elicitation_handler=...)` kwarg is itself what causes FastMCP to declare the `elicitation` client capability during the initialize handshake (no separate capability-flag call needed). `response_type` erases per-field metadata (enum choices, descriptions), so the handler reads field specs from `params.requestedSchema` (the raw flat JSON-Schema dict) directly.

**D2 — receive-loop dispatch (verified by reading the installed mcp SDK)**: `mcp.shared.session.BaseSession._receive_loop` awaits `ClientSession._received_request` **inline**, which awaits the installed `_elicitation_callback` **inline** too — no per-request task is spawned by the SDK for server->client requests. So awaiting a human answer **blocks that server's receive loop** for the duration of the wait (bounded by the per-server timeout). Since each held MCP connection (`MCPConnectionService`) owns its own `ClientSession`/receive-loop task, this block is contained to the ONE connection that asked — every other held connection and the rest of reyn keeps running. A fire-and-forget task inside the handler would not help: the SDK requires this callback to complete with a response before it processes the next message on that connection at all. Per the design doc, this bounded per-connection block is **accepted**, not faked around.

## Consent-path routing

Reused the **existing** mechanism verbatim — did not extend the intervention bus, since it already supports free-text + closed-set choices (not yes/no-only):

- `ctx.intervention_bus is not None` / `session._interventions.has_active_listener()` is the established "is there a human" convention (`mcp_install.py`, and #2095's `consent_bus`/`consent_gate` split for shell-hook consent).
- `session.py` now wires `elicitation_bus=self.as_request_bus()` + `elicitation_gate=lambda: self._interventions.has_active_listener()` into `MCPConnectionService`, mirroring the `HookDispatcher`'s `consent_bus`/`consent_gate` construction one-for-one.
- `MCPConnectionService._resolve_elicitation_bus()` re-checks the gate on **every** elicitation (not frozen at connection-open time) — a TUI can mount/unmount between one elicitation and the next.
- `reyn.mcp.elicitation.build_elicitation_handler` is the new module: builds a FastMCP-shaped handler bound to one server, routes through `UserIntervention`/`RequestBus` — a flat single-field bool -> yes/no choice; enum -> a choice per value; string/number/integer -> free text (best-effort `int`/`float` coercion); a multi-field flat schema is answered **sequentially, one field at a time**, preceded by one accept/decline gate so the human can refuse the whole exchange up front.

## Security (all 5, D5)

1. Every prompt is prefixed with server-attribution — the gate carries the full `"⚠️ MCP server '<name>' asks (this is NOT reyn): <message>"` disclaimer; every per-field prompt carries a short `"[MCP server '<name>'] "` prefix.
2. A field whose name/description matches `password|token|key|secret|credential` (case-insensitive substring) gets an **extra** yes/no confirmation + an explicit "sent to server '<name>'" warning before the free-text prompt.
3. Answers are human-typed only — the handler never reads env vars/secrets to prefill a field.
4. Audit events (`mcp_elicitation_requested`/`_answered`/`_timed_out`/`_auto_declined`) record the server name + schema field **key** names, never field **values** (verified by a dedicated test asserting the answer text never appears in any emitted event).
5. The server's message is rendered as plain text (never markdown/HTML-interpreted, matching `UserIntervention.prompt`'s existing behaviour) and length-capped at 1500 chars before display (prompt-injection defense).

## Semantics

- **D3 timeout**: no answer within the per-server deadline (default 120s, override via server config `elicitation_timeout_seconds`) -> `action="cancel"`. Explicit human refusal (the gate, or a sensitive-field warning declined) -> `action="decline"`.
- **D4/D6 headless**: no `elicitation_bus` wired, or the gate reports no live listener -> auto-decline (never cancel) + `mcp_elicitation_auto_declined`, per-server override via server config `elicitation: "auto_decline"`. The "is there a human" branch lives **inside** the handler — every held connection installs the handler unconditionally and always declares the `elicitation` capability.
- **Op-kind check**: elicitation is server-initiated, not a reyn-issued Control-IR op — no `Op` union / `OP_KIND_MODEL_MAP` entry needed, confirmed no doc-sync obligation applies.
- No WAL/recovery involved (runtime-only, like the rest of #2597's connection-service state) — truncate-falsify gate N/A.

## Files

- `src/reyn/mcp/elicitation.py` (new) — the handler builder + schema/field helpers.
- `src/reyn/mcp/client.py` — `elicitation_handler` constructor kwarg, forwarded to `fastmcp.Client`.
- `src/reyn/mcp/connection_service.py` — `elicitation_bus`/`elicitation_gate` params; builds + installs a handler per held connection (every open/reopen).
- `src/reyn/runtime/session.py` — wires the session's `RequestBus` + listener-presence gate into `MCPConnectionService`.
- `src/reyn/intervention_choices.py` — `ACCEPT`/`DECLINE` ids + `elicitation_gate_choices()` factory.
- `tests/_support/mcp_elicitation_server.py` (new) — a real FastMCP stdio server calling the genuine `ctx.elicit(...)` API (bool scalar, one-field dataclass for the sensitive-field case, three-field dataclass for the sequential-prompting case).
- `tests/test_2597_slice3_mcp_elicitation.py` (new) — 8 Tier 2 tests, all against a real subprocess server + real `MCPConnectionService`; only the human answer source is a hand-rolled `RequestBus` double (not a mock), same pattern as `test_2095_shell_hook_consent_bus.py`'s `_RecordingBus`.

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_2597_slice3_mcp_elicitation.py` — 8/8 OK, 0 Tier-4 violations.
- [x] `pytest` (full suite, foreground) — 7380 passed, 21 skipped, **5 failed** — all 5 are the pre-existing #2599 web-route-mount failures (`test_fp0001_routes_mounted`, `test_a2a_routes_mounted`, `test_mcp_routes_mounted`, `test_loader_disambiguates_via_package_field`, `test_resources_route_is_mounted_on_app`), confirmed identical on `main` pre-change (same assertion, same missing routes) — **zero new failures**.
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK.
- [x] Manual: ran the new elicitation test file standalone (8/8 pass) covering: (a) bool schema -> accept -> `{action: accept, content}`, (b) headless/no-bus -> auto-decline + event, (b-variant) gate=False with a bus wired -> auto-decline without touching the bus, (c) timeout -> cancel + event, (d) sensitive field name -> extra warning intervention fires; non-sensitive control case skips it, (e) audit events carry field keys, never the answered value, (D1) three-field flat schema -> exactly one intervention per field in declared order.

## Blockers

None. Out of scope per the design doc (not touched): sampling/roots, OAuth, hooks (`H2` matcher in flight there), matcher.