### PR TITLE
feat(#2608): H4 — filesystem watcher external-event source (file_changed hook)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,8 @@ jobs:
         #   dev  — pytest + pytest-asyncio + ruff + mypy
         #   mcp  — `fastmcp` (v3.4.2; #2597 S1), used by tests/test_mcp_client.py
         #   web  — fastapi + uvicorn + websockets, used by tests/web/
-        run: pip install -e ".[dev,mcp,web]"
+        #   fs-watch — `watchdog` (#2608 H4), used by tests/test_fs_watcher.py
+        run: pip install -e ".[dev,mcp,web,fs-watch]"
 
       - name: Run tests
         # --timeout=120: a per-test wall-clock cap (pytest-timeout). Without it a

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -825,6 +825,42 @@ cron:
 - `docs/concepts/data-retrieval/operational-intelligence.md` — scheduling a
   recurring events-log indexing agent
 
+## `fs_watch:` block
+
+Operator-declared filesystem watch paths (#2608 H4). Each path is watched
+recursively; a create/modify/delete under it fires the `file_changed`
+external-event hook (see the `hooks:` block above — `on: file_changed`, plus
+a `matcher: {path: "..."}` glob to scope a hook to a sub-tree).
+
+```yaml
+fs_watch:
+  paths:
+    - /repo/src
+    - /repo/docs
+  debounce_seconds: 0.2   # coalesce a write-burst on one path into ONE fire
+```
+
+### Fields
+
+- **`paths`** (optional, default `[]`) — list of directories to watch,
+  recursively. Empty (the default) → the watcher never starts.
+- **`debounce_seconds`** (optional, default `0.2`) — a burst of writes to the
+  SAME path within this window coalesces to one hook fire.
+
+### Security
+
+`fs_watch:` is **OUT-set only** — restart-only, loaded from
+`reyn.yaml`/`reyn.local.yaml`, never from a `.reyn/*.yaml` hot-reload file.
+There is no op or tool verb an agent can use to register or widen a watch —
+a filesystem-wide change-notification feed is an info-gathering surface, so
+it gets the same operator-only gate as `sandbox:` policy.
+
+### Requirements
+
+Requires the optional `watchdog` package (`pip install reyn[fs-watch]`). If
+`paths` is configured but `watchdog` isn't installed, the feature logs a
+warning and stays off — the rest of the session is unaffected.
+
 ## `permissions` block
 
 Project-wide capability defaults. Per-skill permissions in `skill.md` override these.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ web = [
 # Web UI (= `reyn web` + openui) と TUI (= `reyn chat`) と並列に動かす。
 chainlit = ["chainlit>=2.0"]
 mcp = ["fastmcp==3.4.2"]
+# #2608 H4: filesystem watcher external-event source (`fs_watch:` config block ->
+# `file_changed` hook). Extras-only — a build with no fs_watch config configured
+# never imports this, and a build WITH config but no extra installed degrades to
+# "feature off + warn" (see reyn.runtime.fs_watcher module docstring).
+fs-watch = ["watchdog>=4.0"]
 release = [
     "build>=1.0",
     "twine>=5.0",

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -827,6 +827,26 @@
 
 
 # -----------------------------------------------------------------------------
+# fs_watch: operator-declared filesystem watch paths (#2608 H4). Each path is
+# watched recursively for create/modify/delete events; a change fires the
+# ``file_changed`` external-event hook (see ``hooks:`` above, ``on:
+# file_changed``, matcher field ``path`` globs via fnmatch).
+#
+# SECURITY: this is the ONLY place watched paths are declared — there is no
+# op/tool verb an agent can use to register or widen a watch (same OUT-set-
+# only gate as ``sandbox:``). Requires the optional ``watchdog`` package
+# (`pip install reyn[fs-watch]`); absent -> the feature logs a warning and
+# stays off, rest of the session unaffected. Empty ``paths`` (default) -> the
+# watcher never starts.
+# -----------------------------------------------------------------------------
+# fs_watch:
+#   paths:
+#     - /repo/src
+#     - /repo/docs
+#   debounce_seconds: 0.2   # coalesce a write-burst on one path into ONE fire
+
+
+# -----------------------------------------------------------------------------
 # external_transports: map external transport names
 # (Slack / LINE / Discord / ...) to the MCP tool that delivers replies, plus
 # an ``args_template`` describing how router output is shaped into the tool's

--- a/src/reyn/config/infra.py
+++ b/src/reyn/config/infra.py
@@ -592,6 +592,62 @@ def _build_cron_config(raw: object) -> CronConfig:
     return CronConfig(jobs=jobs)
 
 
+@dataclass
+class FsWatchConfig:
+    """``fs_watch:`` — operator-declared filesystem watch paths (#2608 H4).
+
+    Each entry in ``paths`` is a directory watched (recursively) for
+    create/modify/delete events; a change fires the ``file_changed``
+    external-event hook (see ``reyn.runtime.fs_watcher.FsWatcher`` and
+    ``reyn.hooks.schema.ALLOWED_HOOK_POINTS``).
+
+    SECURITY (F7-5, do not relitigate): this is the ONLY place watched paths
+    are declared. There is no runtime op or tool verb that lets an agent
+    register or widen a watch — like ``sandbox:``'s policy, ``fs_watch:``
+    is OUT-set-only (restart-only, ``reyn.yaml``/``reyn.local.yaml``, never
+    a ``.reyn/*.yaml`` hot-reload file — see ``config/loader.py``'s
+    ``_HOT_RELOAD_FILES``), so an LLM-driven config-write op can never touch
+    it. Letting an agent name arbitrary watch paths would be an
+    info-gathering surface (a filesystem-wide change-notification feed) —
+    same class of concern as sandbox policy, hence the same OUT-set gate.
+    """
+
+    paths: list[str] = field(default_factory=list)
+    debounce_seconds: float = 0.2
+
+
+def _build_fs_watch_config(raw: object) -> FsWatchConfig:
+    """Parse the ``fs_watch:`` section from ``reyn.yaml``/``reyn.local.yaml``
+    (OUT-set only — see :class:`FsWatchConfig`'s docstring).
+
+    Shape::
+
+        fs_watch:
+          paths:
+            - /repo/src
+            - /repo/docs
+          debounce_seconds: 0.2   # optional, default 0.2
+
+    ``None`` / missing block / empty dict / non-dict → ``FsWatchConfig()``
+    (``paths=[]`` — the watcher never starts; see
+    ``reyn.runtime.fs_watcher.FsWatcher.start``'s no-op-when-empty
+    contract). Non-string / blank entries in ``paths`` are dropped
+    (forward-compatible / defensive — never raises on a malformed entry).
+    """
+    if not isinstance(raw, dict):
+        return FsWatchConfig()
+    raw_paths = raw.get("paths") or []
+    if not isinstance(raw_paths, list):
+        raw_paths = []
+    paths = [p for p in (str(p).strip() for p in raw_paths if p) if p]
+    debounce = raw.get("debounce_seconds", 0.2)
+    try:
+        debounce_seconds = float(debounce)
+    except (TypeError, ValueError):
+        debounce_seconds = 0.2
+    return FsWatchConfig(paths=paths, debounce_seconds=debounce_seconds)
+
+
 def _build_python_config(raw: object) -> PythonConfig:
     if not isinstance(raw, dict):
         return PythonConfig()

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -26,6 +26,7 @@ from reyn.config.infra import (  # #1682 #3 cross-section
     _build_cron_config,
     _build_delegation_config,
     _build_events_config,
+    _build_fs_watch_config,
     _build_llm_config,
     _build_python_config,
     _build_sandbox_config,
@@ -480,6 +481,10 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         hooks=merged.get("hooks") or [],
         action_retrieval=_build_action_retrieval_config(merged.get("action_retrieval")),
         cron=_build_cron_config(merged.get("cron")),
+        # #2608 H4: OUT-set only — read from ``merged`` (reyn.yaml/reyn.local.yaml),
+        # never from the ``.reyn/*.yaml`` hot-reload IN-set (see
+        # ``_HOT_RELOAD_FILES`` below + ``FsWatchConfig``'s docstring for why).
+        fs_watch=_build_fs_watch_config(merged.get("fs_watch")),
         external_transports=_build_external_transports_config(
             merged.get("external_transports"),
         ),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -49,6 +49,7 @@ from reyn.config.infra import (
     CronConfig,
     DelegationConfig,
     EventsConfig,
+    FsWatchConfig,
     LLMConfig,
     PythonConfig,
     SandboxConfig,
@@ -254,6 +255,12 @@ class ReynConfig:
     # FP-0009 Component B — cron-driven scheduled message dispatch.
     # Empty by default; operator declares jobs in reyn.yaml ``cron.jobs``.
     cron: CronConfig = field(default_factory=CronConfig)
+    # #2608 H4 — operator-declared filesystem watch paths -> ``file_changed``
+    # external-event hook. Empty by default (paths=[]) → the session-owned
+    # FsWatcher never starts (byte-identical to pre-H4). OUT-set only (restart-
+    # only, reyn.yaml/reyn.local.yaml) — see FsWatchConfig's docstring for why
+    # this must never be an agent-settable / hot-reloadable surface.
+    fs_watch: FsWatchConfig = field(default_factory=FsWatchConfig)
     # FP-0041 #489 PR-D2 — external chat transport routing (= Slack /
     # LINE / Discord etc.). Empty by default; operator declares
     # transport → MCP tool mapping in reyn.yaml ``external_transports``.

--- a/src/reyn/hooks/matcher.py
+++ b/src/reyn/hooks/matcher.py
@@ -10,12 +10,13 @@ action runs.
 Shape
 -----
 ``matcher: dict[str, str] | None`` — e.g. ``{"server": "github", "uri":
-"file:///repo/**"}``. A hook fires iff **every** field named in the matcher
-matches:
+"file:///repo/**"}`` or (H4) ``{"path": "/repo/src/**"}``. A hook fires iff
+**every** field named in the matcher matches:
 
-- exact string equality for every field EXCEPT ``uri``;
-- ``uri`` matches via a shell-style glob (``fnmatch.fnmatch``), so
-  ``"file:///repo/**"`` matches any URI under that prefix.
+- exact string equality for every field EXCEPT ``uri``/``path``;
+- ``uri``/``path`` match via a shell-style glob (``fnmatch.fnmatch``), so
+  ``"file:///repo/**"`` matches any URI under that prefix and
+  ``"/repo/src/**"`` matches any watched path under that directory.
 
 A field named in the matcher that is ABSENT from ``template_vars`` (e.g. a
 lifecycle hook-point's vars have no ``server``/``uri``, or a future source's
@@ -27,18 +28,24 @@ every hook that predates H2, and for an external-event hook that opts not to
 filter). This is the byte-identical-to-H1 default: ``matches(None, ...)`` and
 ``matches({}, ...)`` are both ``True`` unconditionally.
 
-Deliberately general: the ``uri``-globs-others-exact rule is keyed off the
-FIELD NAME, not the hook-point, so a future external-event source (cron/
-webhook/fs-watcher, H4/H5) that also emits a ``uri``-shaped field gets glob
-matching for free, and any other field it introduces gets exact matching
-with zero code changes here.
+Deliberately general: the glob-vs-exact rule is keyed off the FIELD NAME, not
+the hook-point, so a future external-event source (cron/webhook, H5) that
+also emits a ``uri``- or ``path``-shaped field gets glob matching for free,
+and any other field it introduces gets exact matching with zero code changes
+here.
+
+#2608 H4 adds ``path`` to ``_GLOB_FIELDS`` for the ``file_changed`` point
+(see ``reyn.runtime.fs_watcher``): a hook's matcher can scope to a watched
+sub-tree, e.g. ``{"path": "/repo/src/**"}``.
 """
 from __future__ import annotations
 
 from fnmatch import fnmatch
 
 # Field names matched via glob (fnmatch) rather than exact string equality.
-_GLOB_FIELDS: frozenset[str] = frozenset({"uri"})
+# "uri" — #2608 H1 (mcp_resource_updated). "path" — #2608 H4 (file_changed):
+# lets a hook's matcher scope to a sub-tree via e.g. {"path": "/repo/src/**"}.
+_GLOB_FIELDS: frozenset[str] = frozenset({"uri", "path"})
 
 
 def matches(matcher: "dict[str, str] | None", template_vars: dict) -> bool:

--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -61,6 +61,11 @@ ALLOWED_HOOK_POINTS: frozenset[str] = frozenset({
     # #2608 H1: external-event point — fired by a pushed MCP resources/updated
     # notification for a subscribed resource, NOT by the lifecycle run-loop.
     "mcp_resource_updated",
+    # #2608 H4: external-event point — fired by the session-owned FsWatcher
+    # (reyn.runtime.fs_watcher) on a create/modify/delete under an
+    # operator-declared ``fs_watch.paths`` entry. Matchable field: ``path``
+    # (glob via fnmatch — see hooks/matcher.py's _GLOB_FIELDS).
+    "file_changed",
 })
 
 

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -411,6 +411,7 @@ def run(args: argparse.Namespace) -> None:
             state_log=state_log,
             budget_tracker=budget_tracker,
             hooks_config=session_cfg.config.hooks,  # #1800 slice 5b (pass-through, not bundled)
+            fs_watch_config=session_cfg.config.fs_watch,  # #2608 H4 (pass-through, not bundled)
             # #2093: the uniform reyn.yaml-derived per-session config bundle (sandbox /
             # multimodal / action_retrieval / embedding / router / retry /
             # tool-use-scheme) — one source point for all five sites.

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -489,6 +489,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 state_log=None,  # no WAL for dogfood dispatch
                 budget_tracker=budget_tracker,
                 hooks_config=config.hooks,  # #1800 slice 5b (pass-through, not bundled)
+                fs_watch_config=config.fs_watch,  # #2608 H4 (pass-through, not bundled)
                 # #2093: the uniform per-session config bundle. dogfood deliberately
                 # keeps embedding_config=None (the documented gap — it had
                 # action_retrieval but not its sibling embedding), preserved via

--- a/src/reyn/runtime/fs_watcher.py
+++ b/src/reyn/runtime/fs_watcher.py
@@ -1,0 +1,300 @@
+"""reyn.runtime.fs_watcher — filesystem watcher external-event source (#2608 H4).
+
+The 4th external-event source in the external-event->hooks arc (after H1's MCP
+``resources/updated`` bridge). Mirrors H1's shape — a source fires
+``HookDispatcher.dispatch(point, template_vars)`` for its events, here
+``point="file_changed"`` — but with one load-bearing difference: the producer
+runs on a SEPARATE THREAD, not the session's asyncio task.
+
+Uses the third-party ``watchdog`` library (extras-only — ``pip install
+reyn[fs-watch]``; see ``pyproject.toml``'s ``fs-watch`` extra) to run an OS-level
+filesystem observer. ``watchdog.observers.Observer`` owns a dedicated OS thread;
+every event callback (``on_created``/``on_modified``/``on_deleted``) fires
+ON THAT THREAD. It is therefore UNSAFE to touch an ``asyncio.Queue`` from the
+callback directly (``Queue.put_nowait`` is not thread-safe — no lock protects
+its internal deque against a concurrent ``get()`` on the loop thread). The
+thread->async handoff instead goes through ``loop.call_soon_threadsafe(...)``
+(``loop`` is captured, on the SESSION's own event loop, at :meth:`FsWatcher.start`
+time): the watchdog-thread callback schedules a plain callable onto the loop,
+which is the ONLY thing safe to call from a foreign thread per the asyncio
+docs. That scheduled callable does the actual (loop-thread-only) bounded
+``Queue.put_nowait`` — mirroring H1's ``MCPConnectionService.enqueue_external_event``
+bound+drop+log discipline (``_QUEUE_MAXSIZE``, overflow drops the newest event
++ logs, never grows unboundedly, never blocks the watchdog thread).
+
+Debounce (F7-3): editors emit event BURSTS for one logical change (temp files,
+multiple writes, create-then-modify). Coalesced per-path on the watchdog
+thread with a simple leading-edge scheme: :meth:`_FsEventHandler._maybe_fire`
+tracks the last-fired monotonic time per path; an event within
+``debounce_seconds`` of the previous fire for the SAME path is dropped
+(coalesced), so one write-burst = one hook fire. A quiet path that fires again
+after the window elapses is a NEW logical change and fires again. Per-path
+state only — a burst on path A never suppresses path B.
+
+SECURITY (F7-5, do not relitigate): watched paths are OPERATOR-DECLARED via
+``fs_watch.paths`` in ``reyn.yaml``/``reyn.local.yaml`` (see
+``reyn.config.infra.FsWatchConfig`` — OUT-set only, restart-only, never a
+``.reyn/*.yaml`` hot-reload file). There is no op/tool verb anywhere that lets
+an agent register or widen a watch — a filesystem-wide change-notification
+feed is an info-gathering surface, same class of concern as sandbox policy,
+so it gets the same OUT-set-only gate. :class:`FsWatcher` itself has no
+"add a path" method; its watched set is FIXED at construction from the
+config the session was started with.
+
+Session-owned lifecycle (mirrors ``MCPConnectionService``): constructed
+unconditionally by ``Session.__init__`` (cheap — the watchdog ``Observer`` is
+only created inside :meth:`start`), started from ``Session.run()`` right after
+the ``session_start`` hook dispatch (only if ``fs_watch.paths`` is non-empty),
+and stopped in ``run()``'s ``finally`` alongside the ``session_end`` hook via
+:meth:`aclose` (idempotent, ``finally``-guaranteed so a ``CancelledError``
+during teardown can never orphan the drain task or the observer thread — see
+:meth:`aclose`).
+
+Watchdog-optional (graceful degrade): ``fs_watch.paths`` configured but the
+``watchdog`` package not installed -> :meth:`start` logs a warning and returns
+without starting anything (the feature is off; the rest of the session is
+unaffected). ``fs_watch.paths`` empty (the default, no config) -> :meth:`start`
+returns immediately without even importing ``watchdog`` — byte-identical to
+pre-H4 behaviour for every existing build.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Bound on the thread->async bridge queue — mirrors H1's
+# ``_HOOK_EVENT_QUEUE_MAXSIZE`` (MCPConnectionService). A burst of fs events
+# beyond this is dropped (+logged), never queued unboundedly, never
+# backpressured onto the watchdog thread.
+_QUEUE_MAXSIZE = 32
+
+HookTrigger = Callable[[str, dict], Awaitable[Any]]
+
+# watchdog event class name -> our normalized event_type vocabulary.
+_EVENT_TYPE_BY_WATCHDOG_ATTR = {
+    "on_created": "created",
+    "on_modified": "modified",
+    "on_deleted": "deleted",
+}
+
+
+def _import_watchdog() -> Any:
+    """Import and return the ``watchdog.events``/``watchdog.observers`` modules
+    as a ``(events_mod, observers_mod)`` tuple, or ``None`` if ``watchdog`` is
+    not installed. Isolated behind a function so :meth:`FsWatcher.start` can
+    degrade gracefully (warn + no-op) rather than raising ``ImportError`` at
+    session start."""
+    try:
+        from watchdog.events import FileSystemEventHandler
+        from watchdog.observers import Observer
+    except ImportError:
+        return None
+    return FileSystemEventHandler, Observer
+
+
+class FsWatcher:
+    """Session-owned filesystem watcher — see module docstring for the full
+    thread->async bridge, debounce, and security design.
+
+    Usage (mirrors ``MCPConnectionService``)::
+
+        watcher = FsWatcher(paths=["/repo/src"], hook_trigger=dispatcher.dispatch)
+        await watcher.start()      # no-op if paths=[] or watchdog not installed
+        ...
+        await watcher.aclose()     # session teardown — idempotent
+    """
+
+    def __init__(
+        self,
+        *,
+        paths: "list[str] | None" = None,
+        hook_trigger: "HookTrigger | None" = None,
+        debounce_seconds: float = 0.2,
+    ) -> None:
+        self._paths: list[str] = list(paths or [])
+        self._hook_trigger = hook_trigger
+        self._debounce_seconds = debounce_seconds
+        self._observer: Any = None
+        self._loop: "asyncio.AbstractEventLoop | None" = None
+        self._queue: "asyncio.Queue[tuple[str, str]] | None" = None
+        self._drain_task: "asyncio.Task | None" = None
+        self._started = False
+
+    def is_started(self) -> bool:
+        """Read-only introspection for callers/tests — mirrors
+        ``MCPConnectionService.held_servers()``'s public-surface pattern."""
+        return self._started
+
+    async def start(self) -> None:
+        """Start the watchdog observer + the loop-side drain task.
+
+        No-op (returns immediately) when:
+          - ``paths`` is empty (no ``fs_watch:`` config — the default), or
+          - ``hook_trigger`` is None, or
+          - ``watchdog`` is not installed (logs a warning once).
+
+        Idempotent — a second call while already started is a no-op.
+        """
+        if self._started:
+            return
+        if not self._paths or self._hook_trigger is None:
+            return
+        imported = _import_watchdog()
+        if imported is None:
+            logger.warning(
+                "FsWatcher: fs_watch.paths configured (%d path(s)) but the "
+                "'watchdog' package is not installed — filesystem watching is "
+                "DISABLED for this session. Install with `pip install "
+                "reyn[fs-watch]` to enable file_changed hooks.",
+                len(self._paths),
+            )
+            return
+        FileSystemEventHandler, Observer = imported
+
+        self._loop = asyncio.get_running_loop()
+        self._queue = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
+        self._drain_task = asyncio.create_task(self._drain_events())
+
+        handler = _build_handler(FileSystemEventHandler, self)
+        observer = Observer()
+        for path in self._paths:
+            observer.schedule(handler, path, recursive=True)
+        observer.start()
+        self._observer = observer
+        self._started = True
+
+    # ── thread->async bridge (called from the watchdog OS thread) ──────────
+
+    def _on_fs_event(self, event_type: str, path: str) -> None:
+        """Called synchronously ON THE WATCHDOG THREAD by ``_FsEventHandler``.
+        Never touches ``asyncio`` state directly — schedules
+        :meth:`_enqueue` onto the session's event loop via
+        ``call_soon_threadsafe``, the one thread-safe entry point asyncio
+        exposes for exactly this cross-thread handoff."""
+        loop = self._loop
+        if loop is None:
+            return  # stopped/never started — defensive, should not happen mid-callback
+        try:
+            loop.call_soon_threadsafe(self._enqueue, event_type, path)
+        except RuntimeError:
+            # Loop already closed (session tearing down concurrently with a
+            # trailing fs event) — drop, never raise from the watchdog thread.
+            logger.warning(
+                "FsWatcher: dropped %r event for %r — event loop already closed",
+                event_type, path,
+            )
+
+    def _enqueue(self, event_type: str, path: str) -> None:
+        """Runs ON THE LOOP THREAD (scheduled via call_soon_threadsafe) — safe
+        to touch ``self._queue`` here."""
+        if self._queue is None:
+            return
+        try:
+            self._queue.put_nowait((event_type, path))
+        except asyncio.QueueFull:
+            # Bounded by construction (mirrors H1): a burst faster than hooks
+            # can be dispatched drops the newest event rather than growing the
+            # queue unboundedly.
+            logger.warning(
+                "FsWatcher: file_changed hook queue full (maxsize=%d) — "
+                "dropping %r event (path=%r)",
+                _QUEUE_MAXSIZE, event_type, path,
+            )
+
+    async def _drain_events(self) -> None:
+        """Runs on the session's event loop; the only place that ``await``s
+        ``hook_trigger``. Per-event ``try/except`` mirrors H1's drain task —
+        one bad dispatch must not kill the drain loop."""
+        assert self._queue is not None
+        assert self._hook_trigger is not None
+        while True:
+            event_type, path = await self._queue.get()
+            try:
+                await self._hook_trigger(
+                    "file_changed",
+                    {"point": "file_changed", "path": path, "event_type": event_type},
+                )
+            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
+                logger.warning(
+                    "FsWatcher: hook_trigger failed for path=%r event_type=%r",
+                    path, event_type, exc_info=True,
+                )
+
+    async def aclose(self) -> None:
+        """Stop the observer thread + cancel the drain task. Idempotent — safe
+        to call repeatedly (e.g. a session teardown seam that may run more
+        than once) and safe to call even if :meth:`start` was never called or
+        no-op'd (empty paths / no watchdog)."""
+        try:
+            if self._drain_task is not None and not self._drain_task.done():
+                self._drain_task.cancel()
+                try:
+                    await self._drain_task
+                except asyncio.CancelledError:
+                    pass
+        finally:
+            self._drain_task = None
+
+        observer = self._observer
+        self._observer = None
+        if observer is not None:
+            # observer.stop() + join() are synchronous/blocking (thread join) —
+            # run off the loop thread so a slow-to-exit watchdog thread never
+            # stalls the session's event loop during teardown.
+            loop = asyncio.get_running_loop()
+
+            def _stop_and_join() -> None:
+                observer.stop()
+                observer.join(timeout=5.0)
+
+            await loop.run_in_executor(None, _stop_and_join)
+        self._started = False
+        self._loop = None
+        self._queue = None
+
+
+def _build_handler(file_system_event_handler_cls: Any, watcher: FsWatcher) -> Any:
+    """Build a ``watchdog.events.FileSystemEventHandler`` subclass instance
+    bound to ``watcher``. Factored into a function (rather than a module-level
+    class) because ``FileSystemEventHandler`` only exists when ``watchdog`` is
+    importable — a module-level subclass would make the whole module
+    import-fail without ``watchdog`` installed, defeating the graceful-degrade
+    contract :meth:`FsWatcher.start` promises."""
+
+    class _FsEventHandler(file_system_event_handler_cls):  # type: ignore[misc,valid-type]
+        def __init__(self) -> None:
+            super().__init__()
+            # #2608 H4 debounce (F7-3): per-path last-fire monotonic time,
+            # touched ONLY on the watchdog thread (this handler's callbacks all
+            # run there) — no lock needed, single-writer/single-reader on one
+            # thread.
+            self._last_fire: dict[str, float] = {}
+
+        def _maybe_fire(self, event_type: str, src_path: str) -> None:
+            now = time.monotonic()
+            last = self._last_fire.get(src_path)
+            if last is not None and (now - last) < watcher._debounce_seconds:
+                return  # coalesced: part of the same logical-change burst
+            self._last_fire[src_path] = now
+            watcher._on_fs_event(event_type, src_path)
+
+        def on_created(self, event: Any) -> None:
+            if not event.is_directory:
+                self._maybe_fire("created", str(event.src_path))
+
+        def on_modified(self, event: Any) -> None:
+            if not event.is_directory:
+                self._maybe_fire("modified", str(event.src_path))
+
+        def on_deleted(self, event: Any) -> None:
+            if not event.is_directory:
+                self._maybe_fire("deleted", str(event.src_path))
+
+    return _FsEventHandler()

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -668,6 +668,11 @@ class Session:
         # mirroring sandbox_config's seam). None/absent → empty registry → every
         # HookDispatcher.dispatch() is a no-op (the no-hooks equivalence property).
         hooks_config: "object | None" = None,
+        # #2608 H4: the resolved ``fs_watch:`` config block (``FsWatchConfig``,
+        # mirroring ``hooks_config``'s seam). None/absent -> FsWatchConfig()
+        # (paths=[]) -> the session-owned FsWatcher never starts (byte-identical
+        # to pre-H4). OUT-set-only in practice (see reyn.config.infra.FsWatchConfig).
+        fs_watch_config: "object | None" = None,
         # #1200 PR-F1 (agent-level-uniform backend, FS seam): the agent's
         # EnvironmentBackend INSTANCE, threaded to the chat Workspace so chat's
         # file ops run on the SAME backend as the phase path. None → HostBackend (the
@@ -1092,6 +1097,26 @@ class Session:
             elicitation_bus=self.as_request_bus(),
             elicitation_gate=lambda: self._interventions.has_active_listener(),
             agent_name=self.agent_name,
+        )
+        # #2608 H4: the session-owned filesystem watcher (see
+        # reyn.runtime.fs_watcher's module docstring for the thread->async
+        # bridge design). Constructed unconditionally (cheap — no OS thread
+        # spun up here, only inside FsWatcher.start()); ``hook_trigger`` is the
+        # SAME deferred-lambda-over-``self._hook_dispatcher`` pattern H1 uses
+        # above (the dispatcher itself is built later in this __init__, but
+        # this lambda is never CALLED until FsWatcher.start() is awaited from
+        # ``run()``, long after __init__ has finished). ``paths``/
+        # ``debounce_seconds`` default to empty/0.2 when no ``fs_watch:``
+        # config block was resolved (mirrors ``hooks_config`` defaulting to []).
+        from reyn.config.infra import FsWatchConfig
+        from reyn.runtime.fs_watcher import FsWatcher
+        _fs_watch_cfg = (
+            fs_watch_config if isinstance(fs_watch_config, FsWatchConfig) else FsWatchConfig()
+        )
+        self._fs_watcher = FsWatcher(
+            paths=_fs_watch_cfg.paths,
+            debounce_seconds=_fs_watch_cfg.debounce_seconds,
+            hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
         )
         self.output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled
@@ -4260,6 +4285,9 @@ class Session:
             "session_start",
             {"point": "session_start", "agent_name": self.agent_name},
         )
+        # #2608 H4: start the filesystem watcher (no-op if no fs_watch.paths
+        # configured or 'watchdog' isn't installed — see FsWatcher.start).
+        await self._fs_watcher.start()
 
         # #1830 / FP-0052: warn if the startup model is above the cost threshold.
         # Fires once per session per model class (de-duped in maybe_emit_model_cost_warn).
@@ -4270,19 +4298,30 @@ class Session:
             while await self.run_one_iteration():
                 pass
         finally:
-            await self._drain_on_shutdown()
-            self._chat_events.emit("chat_stopped", agent_name=self.agent_name)
-            # #1800 slice 5a: session lifecycle audit event (P6). Emitted alongside
-            # chat_stopped; marks the end of the session's resource scope.
-            self._chat_events.emit("session_completed", agent_name=self.agent_name)
-            # #1800 slice 5b: session_end lifecycle hooks (F's natural resource
-            # scope). The run-loop has exited, so an E push here is not drained
-            # (harmless); session_end is the C/F point in practice.
-            await self._hook_dispatcher.dispatch(
-                "session_end",
-                {"point": "session_end", "agent_name": self.agent_name},
-            )
-            await self._put_outbox(OutboxMessage(kind="__end__", text=""))
+            try:
+                await self._drain_on_shutdown()
+            finally:
+                # #2608 H4: stop the filesystem watcher (join the observer
+                # thread). Nested finally so a raising ``_drain_on_shutdown``
+                # can never skip this — the watcher must be torn down whenever
+                # ``run()`` exits, cleanly or not. FsWatcher.aclose() itself is
+                # idempotent + CancelledError-safe (see its own finally).
+                try:
+                    await self._fs_watcher.aclose()
+                except Exception:  # noqa: BLE001 — teardown fault isolation, never blocks shutdown
+                    logger.warning("FsWatcher.aclose() raised during session teardown", exc_info=True)
+                self._chat_events.emit("chat_stopped", agent_name=self.agent_name)
+                # #1800 slice 5a: session lifecycle audit event (P6). Emitted alongside
+                # chat_stopped; marks the end of the session's resource scope.
+                self._chat_events.emit("session_completed", agent_name=self.agent_name)
+                # #1800 slice 5b: session_end lifecycle hooks (F's natural resource
+                # scope). The run-loop has exited, so an E push here is not drained
+                # (harmless); session_end is the C/F point in practice.
+                await self._hook_dispatcher.dispatch(
+                    "session_end",
+                    {"point": "session_end", "agent_name": self.agent_name},
+                )
+                await self._put_outbox(OutboxMessage(kind="__end__", text=""))
 
     async def _drain_on_shutdown(self) -> None:
         """Cancel any in-flight background work, then tear down on shutdown.
@@ -5877,6 +5916,22 @@ class Session:
         async with MCPClientPool() as pool:
             ctx.mcp_pool = pool
             return await execute_op(op, ctx)
+
+    def fs_watcher_is_started(self) -> bool:
+        """Read-only introspection: whether this session's filesystem watcher
+        (#2608 H4) is currently running (``False`` when no ``fs_watch.paths``
+        were configured, or ``watchdog`` isn't installed, or ``start()``
+        hasn't run yet). Public surface for callers/tests to observe lifecycle
+        state without reaching into ``_fs_watcher`` directly."""
+        return self._fs_watcher.is_started()
+
+    async def aclose_fs_watcher(self) -> None:
+        """#2608 H4 teardown: stop this session's filesystem watcher (join the
+        observer thread). Idempotent (``FsWatcher.aclose`` is idempotent).
+        ``run()`` already calls this in its own ``finally`` (session_end
+        scope); exposed publicly for a caller/test that tears a session down
+        without going through ``run()``."""
+        await self._fs_watcher.aclose()
 
     def mcp_held_servers(self) -> list[str]:
         """Read-only introspection: names of MCP servers with a currently held-open

--- a/tests/test_2608_h4_fs_watcher.py
+++ b/tests/test_2608_h4_fs_watcher.py
@@ -1,0 +1,310 @@
+"""Tests for #2608 H4 — the filesystem watcher external-event source.
+
+H4 adds the 4th external-event hook-point, ``file_changed``: a REAL file
+create/modify/delete under an operator-declared ``fs_watch.paths`` entry fires
+a user-configured hook via a bounded thread->async bridge from the watchdog
+observer's OS thread into ``HookDispatcher.dispatch`` (the session's event
+loop).
+
+Coverage plan
+-------------
+Tier 1 (contract): ``file_changed`` is registered in ALLOWED_HOOK_POINTS; a
+  ``hooks:`` entry with ``on: file_changed`` loads via the real ``load_hooks``
+  seam; ``path`` globs (not exact-matches) via ``reyn.hooks.matcher.matches``.
+Tier 2 (OS invariant): a REAL ``watchdog`` ``Observer`` + REAL file writes
+  under a real temp directory, bridged into a real (recording) async
+  ``hook_trigger`` — proves the thread->async handoff actually lands events
+  from the watchdog OS thread onto the session's event loop. Covers: create/
+  modify fires with correct path + event_type; a burst of writes to one path
+  debounces to ONE fire; a path NOT under a watched dir never fires; empty
+  ``paths`` config -> the watcher never starts (byte-identical to pre-H4);
+  ``watchdog`` not importable -> warn + no-op (never raises).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. ``pytest.importorskip``
+guards every test that needs a real ``watchdog`` Observer.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from reyn.hooks.matcher import matches
+from reyn.hooks.schema import ALLOWED_HOOK_POINTS
+from reyn.runtime.fs_watcher import FsWatcher
+
+watchdog = pytest.importorskip("watchdog", reason="fs-watch extra ('pip install reyn[fs-watch]') not installed")
+
+
+# ---------------------------------------------------------------------------
+# Recording seam (mirrors test_2608_h2_hook_matcher.py's _Recorder)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A real recording async callable — the ``hook_trigger`` DI shape
+    (``(point, template_vars) -> Awaitable``), no mock."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    async def __call__(self, point: str, template_vars: dict) -> None:
+        self.calls.append((point, dict(template_vars)))
+
+
+async def _wait_for(predicate, *, attempts: int = 200, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` until True or give up — fs events arrive
+    asynchronously off a separate OS thread, not synchronously with the
+    triggering file write."""
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: schema + matcher — the new hook-point + matchable field
+# ---------------------------------------------------------------------------
+
+
+def test_file_changed_is_an_allowed_hook_point():
+    """Tier 1: ``file_changed`` is registered alongside the other hook-points —
+    the schema-level gate a ``hooks.yaml`` entry with ``on: file_changed``
+    must pass."""
+    assert "file_changed" in ALLOWED_HOOK_POINTS
+
+
+def test_file_changed_hook_loads_via_production_loader():
+    """Tier 1: a ``hooks:`` config entry with ``on: file_changed`` and a
+    ``template_push`` action parses through the REAL ``load_hooks`` seam."""
+    from reyn.hooks.loader import load_hooks
+
+    raw = [
+        {
+            "on": "file_changed",
+            "template_push": {"message": "{{ path }} {{ event_type }}"},
+        },
+    ]
+    registry = load_hooks(raw)
+    (hook,) = registry.hooks_for("file_changed")
+    assert hook.matcher is None
+
+
+def test_path_matcher_field_globs_not_exact_matches():
+    """Tier 1: ``path`` is in ``_GLOB_FIELDS`` — a matcher naming ``path`` uses
+    ``fnmatch`` glob semantics (a sub-tree prefix pattern), not exact string
+    equality."""
+    template_vars = {"point": "file_changed", "path": "/repo/src/a.py", "event_type": "modified"}
+    assert matches({"path": "/repo/src/**"}, template_vars) is True
+    assert matches({"path": "/repo/docs/**"}, template_vars) is False
+    # exact equality would have failed here (the glob is what makes it match):
+    assert matches({"path": "/repo/src/a.py"}, template_vars) is True
+
+
+def test_path_matcher_absent_field_never_matches():
+    """Tier 1: a matcher naming ``path`` against an event with no ``path`` in
+    its template_vars (e.g. a lifecycle hook-point) never matches — a matcher
+    only narrows, never invents a signal that was never fired."""
+    assert matches({"path": "/repo/**"}, {"point": "session_start"}) is False
+
+
+def test_fs_watch_config_parses_paths_and_debounce():
+    """Tier 1: the ``fs_watch:`` reyn.yaml block parses through the real
+    ``_build_fs_watch_config`` seam into ``FsWatchConfig``."""
+    from reyn.config.infra import _build_fs_watch_config
+
+    cfg = _build_fs_watch_config({"paths": ["/repo/src", "/repo/docs"], "debounce_seconds": 0.5})
+    assert cfg.paths == ["/repo/src", "/repo/docs"]
+    assert cfg.debounce_seconds == 0.5
+
+
+def test_fs_watch_config_absent_block_defaults_to_no_paths():
+    """Tier 1: no ``fs_watch:`` block (None / missing / non-dict) -> empty
+    ``paths`` — the byte-identical-to-pre-H4 default."""
+    from reyn.config.infra import FsWatchConfig, _build_fs_watch_config
+
+    assert _build_fs_watch_config(None) == FsWatchConfig()
+    assert _build_fs_watch_config("not-a-dict") == FsWatchConfig()
+    assert _build_fs_watch_config({}) == FsWatchConfig()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: real watchdog Observer + real file writes — thread->async bridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_file_write_fires_hook_with_path_and_event_type(tmp_path):
+    """Tier 2: THE core H4 proof. A REAL watchdog Observer watching a REAL temp
+    directory; a REAL file write under it must reach ``hook_trigger`` on the
+    session's event loop with the correct ``path``/``event_type`` — proving the
+    watchdog-OS-thread -> call_soon_threadsafe -> asyncio.Queue -> drain-task
+    bridge actually works end-to-end."""
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[str(tmp_path)], hook_trigger=trigger, debounce_seconds=0.05)
+    try:
+        await watcher.start()
+        assert watcher.is_started()
+
+        target = tmp_path / "a.txt"
+        target.write_text("hello")
+
+        await _wait_for(lambda: len(trigger.calls) >= 1)
+        (point, template_vars) = trigger.calls[0]
+        assert point == "file_changed"
+        assert template_vars["point"] == "file_changed"
+        assert Path(template_vars["path"]) == target
+        assert template_vars["event_type"] in ("created", "modified")
+    finally:
+        await watcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_burst_of_writes_to_one_path_debounces_to_one_fire(tmp_path):
+    """Tier 2: (F7-3) editors emit event BURSTS for one logical change — a rapid
+    burst of writes to the SAME path within the debounce window must coalesce
+    to exactly ONE hook fire, not one per underlying OS event."""
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[str(tmp_path)], hook_trigger=trigger, debounce_seconds=2.0)
+    try:
+        await watcher.start()
+        target = tmp_path / "burst.txt"
+        for i in range(10):
+            target.write_text(f"write {i}")
+            time.sleep(0.01)  # real OS writes, well inside the 2s debounce window
+
+        # Give the (single, debounced) event a fair chance to arrive.
+        await _wait_for(lambda: trigger.calls != [])
+        await asyncio.sleep(0.2)  # settle window — assert no SECOND fire trickles in
+        # Tuple-unpack asserts EXACTLY one recorded call (raises on 0 or >1) —
+        # a behavioral assertion on the debounce invariant, not a length pin.
+        ((point, template_vars),) = trigger.calls
+        assert point == "file_changed"
+        assert Path(template_vars["path"]) == target
+    finally:
+        await watcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_path_outside_watched_dir_never_fires(tmp_path):
+    """Tier 2: a write under a directory that is NOT watched must never reach
+    ``hook_trigger`` — scoping is by the operator-declared ``paths`` set, not
+    global."""
+    watched = tmp_path / "watched"
+    unwatched = tmp_path / "unwatched"
+    watched.mkdir()
+    unwatched.mkdir()
+
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[str(watched)], hook_trigger=trigger, debounce_seconds=0.05)
+    try:
+        await watcher.start()
+        (unwatched / "b.txt").write_text("nope")
+        await asyncio.sleep(0.3)
+        assert trigger.calls == []
+
+        # Confirm the harness itself is live: a write INSIDE the watched dir
+        # still fires (rules out "the watcher silently never started").
+        (watched / "a.txt").write_text("yes")
+        await _wait_for(lambda: len(trigger.calls) >= 1)
+    finally:
+        await watcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_empty_paths_config_never_starts_watcher():
+    """Tier 2: no ``fs_watch.paths`` configured (the default) -> ``start()`` is a
+    no-op — byte-identical to today for every build with no fs_watch config."""
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[], hook_trigger=trigger)
+    await watcher.start()
+    assert watcher.is_started() is False
+    await watcher.aclose()  # must not raise even though start() no-op'd
+
+
+@pytest.mark.asyncio
+async def test_watchdog_unavailable_warns_and_disables_feature_without_crashing(tmp_path, monkeypatch):
+    """Tier 2: paths ARE configured but ``watchdog`` is not importable -> the
+    watcher logs a warning and disables the feature — never crashes the
+    session. ``monkeypatch.setattr`` here replaces our OWN module-level import
+    helper with a real callable (not a collaborator's behavior) returning
+    ``None``, exactly the "not installed" contract ``_import_watchdog``
+    documents — allowed per the monkeypatch-with-a-real-callable policy."""
+    import reyn.runtime.fs_watcher as fs_watcher_mod
+
+    monkeypatch.setattr(fs_watcher_mod, "_import_watchdog", lambda: None)
+
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[str(tmp_path)], hook_trigger=trigger)
+    await watcher.start()  # must not raise
+    assert watcher.is_started() is False
+
+    # And the feature really is off: a real write under the configured path
+    # never fires (there is no observer running).
+    (tmp_path / "a.txt").write_text("x")
+    await asyncio.sleep(0.2)
+    assert trigger.calls == []
+    await watcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_hook_trigger_wired_start_is_a_pure_noop(tmp_path):
+    """Tier 2: ``hook_trigger=None`` (never wired) — ``start()``/``aclose()``
+    never raise and no observer is ever created, mirroring
+    ``MCPConnectionService``'s ``hook_trigger=None`` no-op contract."""
+    watcher = FsWatcher(paths=[str(tmp_path)], hook_trigger=None)
+    await watcher.start()
+    assert watcher.is_started() is False
+    await watcher.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: session-level integration — real Session, real hooks_config, real
+# fs_watch_config, real inbox landing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_owned_watcher_fires_configured_hook_into_inbox(tmp_path):
+    """Tier 2: end-to-end through a REAL ``Session`` — ``fs_watch_config`` wires
+    an ``FsWatcher`` whose ``hook_trigger`` closes over THIS session's OWN
+    ``HookDispatcher`` (per-session attribution, mirroring H1's
+    ``MCPConnectionService`` wiring), a REAL file write fires the configured
+    ``file_changed`` hook, and the templated push lands in the session's
+    (public) inbox."""
+    from reyn.config.infra import FsWatchConfig
+    from reyn.core.events.state_log import StateLog
+    from reyn.runtime.session import Session
+
+    watched_dir = tmp_path / "watched"
+    watched_dir.mkdir()
+    hooks_config = [
+        {
+            "on": "file_changed",
+            "template_push": {"message": "changed: {{ path }} ({{ event_type }})"},
+        },
+    ]
+    session = Session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+        fs_watch_config=FsWatchConfig(paths=[str(watched_dir)], debounce_seconds=0.05),
+    )
+    try:
+        await session._fs_watcher.start()  # mirrors run()'s own call; started via the public surface below is asserted
+        assert session.fs_watcher_is_started()
+
+        target = watched_dir / "c.txt"
+        target.write_text("hi")
+
+        await _wait_for(lambda: not session.inbox.empty())
+        kind, payload = session.inbox.get_nowait()
+        assert kind == "hook"
+        assert payload["name"] == "file_changed"  # no name: set -> defaults to the point
+        assert str(target) in payload["text"]
+    finally:
+        await session.aclose_fs_watcher()


### PR DESCRIPTION
**[per-PR-coder]** — part of #2608

## H4 — filesystem watcher external-event source (`file_changed` hook)

The 4th external-event source in the external-event->hooks arc (after H1's MCP
`resources/updated` bridge, H2's matcher, H3's `pipeline_launch` action).
Mirrors H1's shape (a source fires `HookDispatcher.dispatch(point,
template_vars)`), but with the load-bearing difference the issue flagged:
the producer runs on a **separate OS thread**, not the session's asyncio task.

### Thread->async bridge (the crux)

`watchdog.observers.Observer` owns a dedicated OS thread; every
`on_created`/`on_modified`/`on_deleted` callback fires ON THAT THREAD.
`asyncio.Queue.put_nowait` is not thread-safe, so the callback cannot touch it
directly. The fix (`src/reyn/runtime/fs_watcher.py`):

1. `FsWatcher.start()` captures `asyncio.get_running_loop()` on the session's
   own loop.
2. The watchdog-thread callback calls `loop.call_soon_threadsafe(self._enqueue,
   event_type, path)` — the one thread-safe handoff asyncio exposes.
3. `_enqueue` (now running ON the loop thread) does the bounded
   `Queue.put_nowait`, drop+log on overflow (mirrors H1's
   `MCPConnectionService._HOOK_EVENT_QUEUE_MAXSIZE` discipline: never grows
   unboundedly, never blocks the watchdog thread).
4. A drain task on the loop `await`s `hook_trigger("file_changed", {point,
   path, event_type})` — the session's own `HookDispatcher.dispatch`.

### Debounce (F7-3)

Editors emit bursts (temp files, multiple writes) for one logical change.
Per-path **leading-edge** debounce on the watchdog thread (`_FsEventHandler._maybe_fire`):
an event within `debounce_seconds` (default 0.2) of the previous fire for the
SAME path is coalesced; a quiet path firing again after the window is a new
logical change. Per-path state only — a burst on path A never suppresses
path B.

### Security (F7-5) — operator-scoped paths

Watched paths are declared **only** via `fs_watch.paths` in
`reyn.yaml`/`reyn.local.yaml` (`reyn.config.infra.FsWatchConfig`) — OUT-set
only (restart-only; never a `.reyn/*.yaml` hot-reload file, so no LLM-driven
config-write op can ever touch it). `FsWatcher` has no "add a path" method;
its watched set is fixed at construction. Same OUT-set gate as `sandbox:`
policy — a filesystem-wide change-notification feed is an info-gathering
surface.

### watchdog-optional handling

`watchdog` is extras-only (`pip install reyn[fs-watch]`, added to
`pyproject.toml` + CI's `test.yml` install line). `fs_watch.paths` configured
but `watchdog` not installed -> `FsWatcher.start()` logs a warning and returns
— feature off, rest of the session unaffected (never raises). No config /
empty `paths` -> `start()` returns before even importing `watchdog` —
byte-identical to pre-H4 for every existing build.

### Session-owned lifecycle

Constructed unconditionally in `Session.__init__` (cheap — no OS thread until
`start()`), started in `run()` right after the `session_start` hook dispatch,
stopped in `run()`'s `finally` (nested so a raising `_drain_on_shutdown` can
never skip it) alongside `session_end`. `FsWatcher.aclose()` cancels the drain
task (`CancelledError`-safe, `finally`-guaranteed) then joins the observer
thread off the loop via `run_in_executor` so a slow-to-exit thread never
stalls teardown. Public introspection: `Session.fs_watcher_is_started()` /
`Session.aclose_fs_watcher()` (mirrors `mcp_held_servers()`/
`aclose_mcp_connections()`).

### Other changes

- `hooks/schema.py`: `ALLOWED_HOOK_POINTS` += `file_changed`.
- `hooks/matcher.py`: `_GLOB_FIELDS` += `path` (a hook's `matcher: {path:
  "/repo/**"}` now globs).
- `config/infra.py`: `FsWatchConfig` (`paths`, `debounce_seconds`) +
  `_build_fs_watch_config`; wired through `config/root.py` / `config/loader.py`.
- `reyn.local.yaml.example` + `docs/reference/config/reyn-yaml.md`: documented
  the new `fs_watch:` block (required by `test_config_mirror_coverage_1056.py`).
- `cli/commands/chat.py` + `cli/commands/dogfood.py`: thread `fs_watch_config`
  through (same seam as `hooks_config`).

### Out of scope (per issue)

H5 cron/webhook sources, MCP, OAuth. Did not touch `src/reyn/mcp/`.

## Test plan

- [x] Tier 1: `file_changed` in `ALLOWED_HOOK_POINTS`; loads via real
  `load_hooks`; `path` matcher globs (not exact); absent-field matcher never
  matches; `FsWatchConfig` parse round-trip + empty-block default.
- [x] Tier 2 (real `watchdog` Observer, real temp-dir file writes, real
  `hook_trigger` recorder — no mocks): create/modify fires with correct
  path+event_type; a 10-write burst on one path debounces to exactly one
  fire (tuple-unpack assertion, not `len()==N`); a write outside the watched
  dir never fires; empty `paths` -> watcher never starts; `watchdog`
  unimportable (`monkeypatch.setattr` on our own `_import_watchdog` helper
  with a real callable, not a collaborator mock) -> warns + stays off, never
  raises; `hook_trigger=None` -> pure no-op.
- [x] Tier 2 session-level: a real `Session` with real `hooks_config` +
  `fs_watch_config`, a real file write under a watched dir fires the
  configured `template_push` hook into the session's own (public) inbox.
- [x] `pytest.importorskip("watchdog")` guards the whole file; `watchdog` is
  now in CI's install line (`test.yml`'s `fs-watch` extra) so these run for
  real in CI, not skipped.

## Gate results (all run locally, foreground)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_2608_h4_fs_watcher.py
Summary: 13 tests inspected
  OK: 13, warnings: 0, errors: 0
Exit code: 0

$ python -m pytest -q -n auto --timeout=120
5 failed, 7412 passed, 21 skipped
FAILED tests/test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted
FAILED tests/web/test_a2a.py::test_a2a_routes_mounted
FAILED tests/web/test_plugin_loader.py::test_loader_disambiguates_via_package_field
FAILED tests/web/test_mcp_sse.py::test_mcp_routes_mounted
FAILED tests/web/test_resources_router.py::test_resources_route_is_mounted_on_app
(all 5 verified identical on main pre-branch — pre-existing #2599, unrelated to this PR — zero NEW failures)

$ python scripts/verify_module_docstrings.py <changed src files>
OK: no module-docstring refactor narrative in <changed src files>.
```
