### PR TITLE
feat(#2597): slice ④ — MCP OAuth 2.1 + token storage (LAST slice)

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -50,10 +50,52 @@ Elicitation (#2597 slice ③ — server->client ``elicitation/create``):
   that routes a server's structured question through reyn's consent path
   (:class:`~reyn.mcp.connection_service.MCPConnectionService` builds one per
   held connection); this module only plumbs the constructor kwarg through.
+
+OAuth 2.1 (#2597 slice ④ — the umbrella's LAST slice, hosted MCP servers like
+GitHub MCP / Atlassian that require browser-based OAuth rather than a static
+bearer token):
+
+  A server config's ``auth`` key selects the auth mode for the ``http``
+  transport (``sse``/``stdio`` reject a non-empty ``auth`` — OAuth only makes
+  sense over Streamable HTTP). Static bearer/API-key auth is UNCHANGED —
+  still expressed via ``headers: {Authorization: "Bearer ..."}`` and carries
+  no ``auth`` key at all (the pre-#2597-④ path, still exercised by
+  ``test_http_transport_round_trip``). ``auth`` is new and, when present,
+  MUST resolve to ``{"type": "oauth", ...}`` (a bare string ``"oauth"`` is
+  shorthand for ``{"type": "oauth"}``) — any other ``type`` is a config
+  error raised eagerly at transport-open time, matching this module's
+  existing lazy-validate-at-connect-time posture (``type``/``url`` are
+  validated the same way).
+
+  :meth:`_open_http` builds a ``fastmcp.client.auth.OAuth(mcp_url=url,
+  scopes=..., client_id=..., client_secret=..., token_storage=
+  MCPOAuthTokenStorage())`` (see :mod:`reyn.mcp.oauth_token_storage` for the
+  exact verified FastMCP contract — NOT the ``mcp.client.auth.TokenStorage``
+  ABC the umbrella issue originally assumed; FastMCP 3.4.2 instead wants a
+  generic ``key_value.aio`` ``AsyncKeyValue`` store) and passes it as
+  ``StreamableHttpTransport(url, headers=..., auth=oauth)`` — FastMCP's own
+  ``OAuth`` object IS an ``httpx.Auth`` (via ``OAuthClientProvider``), so it
+  slots into the same ``auth=`` parameter ``StreamableHttpTransport`` already
+  exposed (unused pre-④). FastMCP's ``OAuth`` runs the full Authorization
+  Code Grant + PKCE + browser-open + localhost-callback dance internally on
+  first use — reyn does NOT reimplement any of that; it only supplies the
+  token_storage backend + the pre-flight headless check below.
+
+  Headless graceful failure: before constructing ``OAuth``,
+  :meth:`_open_http` checks :func:`~reyn.mcp.oauth_token_storage.
+  has_stored_token` for this URL. If no usable token is cached AND this
+  client is running non-interactively (``non_interactive`` constructor kwarg,
+  or auto-detected via ``sys.stdin.isatty()`` when not explicitly passed —
+  mirrors ``reyn.runtime.session``'s own ``non_interactive`` flag's "no user
+  to ask" rationale), :meth:`_open_http` raises :class:`MCPError` immediately
+  with a clear message rather than let FastMCP open a browser + wait (bounded
+  only by ``OAuth``'s own ``callback_timeout``, default 300s) for a callback
+  nobody can complete.
 """
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 import warnings
 from typing import Any, NoReturn
@@ -238,6 +280,7 @@ class MCPClient:
         message_handler: Any = None,
         elicitation_handler: Any = None,
         server_name: str | None = None,
+        non_interactive: bool | None = None,
     ) -> None:
         if not isinstance(config, dict):
             raise ValueError(f"MCP server config must be a dict, got {type(config).__name__}")
@@ -246,6 +289,14 @@ class MCPClient:
             raise ValueError(
                 f"Unsupported MCP server type: {srv_type!r}. "
                 f"Expected one of {sorted(_SUPPORTED_TYPES)}."
+            )
+        # #2597 slice ④: 'auth' (OAuth) only makes sense over Streamable HTTP —
+        # reject it eagerly at construction time for stdio/sse rather than
+        # silently ignoring it (only _open_http ever reads 'auth').
+        if config.get("auth") and srv_type != "http":
+            raise ValueError(
+                f"MCP server 'auth' config is only supported for 'http' "
+                f"(Streamable HTTP) servers, not {srv_type!r}."
             )
         self._config: dict[str, Any] = dict(config)
         self._type: str = srv_type
@@ -279,6 +330,11 @@ class MCPClient:
         # always install one; the ephemeral per-call ``MCPClientPool`` path
         # never does, same None-default no-op pattern as ``message_handler``).
         self._elicitation_handler: Any = elicitation_handler
+        # #2597 slice ④: explicit override for the headless-OAuth pre-flight check
+        # in _open_http (see module docstring's "Headless graceful failure").
+        # None (default) means auto-detect via sys.stdin.isatty() at the point
+        # _open_http actually needs the answer — see _is_non_interactive().
+        self._non_interactive_override: bool | None = non_interactive
         self._client: Any = None  # fastmcp.Client when initialized
         self._initialized = False
         # Captures subprocess stderr for stdio transport so initialize
@@ -892,6 +948,90 @@ class MCPClient:
             log_file=log_file,
         )
 
+    def _is_non_interactive(self) -> bool:
+        """Resolve the effective headless/non-interactive posture for the
+        #2597 slice ④ OAuth pre-flight check (see :meth:`_build_oauth_auth`).
+
+        The explicit constructor kwarg wins when given; otherwise auto-detect
+        via ``sys.stdin.isatty()`` — no attached TTY means there is no human
+        to complete a browser OAuth round-trip. Defensive: any failure while
+        probing stdin (closed / non-file-backed stdin, seen in some
+        subprocess / CI harnesses) is treated as non-interactive — the
+        conservative choice, since raising a clear error beats hanging.
+        """
+        if self._non_interactive_override is not None:
+            return self._non_interactive_override
+        try:
+            return not sys.stdin.isatty()
+        except Exception:  # noqa: BLE001
+            return True
+
+    def _build_oauth_auth(self, url: str) -> "Any":
+        """Build the ``fastmcp.client.auth.OAuth`` object for ``self._config
+        ["auth"]``, or return None if this server config carries no ``auth``
+        key at all (the pre-④ static-bearer-via-``headers`` path, unchanged).
+
+        See the module docstring's "OAuth 2.1 (#2597 slice ④)" section for
+        the full contract this implements. Raises :class:`MCPError` eagerly
+        (this module's existing lazy-validate-at-connect-time posture, same
+        as the ``type``/``url`` checks above) for: a non-``oauth`` ``auth``
+        type, an ``auth`` key on a non-``http`` transport, or a headless
+        caller with no cached token yet.
+        """
+        auth_cfg = self._config.get("auth")
+        if not auth_cfg:
+            return None
+        if isinstance(auth_cfg, str):
+            if auth_cfg != "oauth":
+                raise MCPError(
+                    f"Unsupported MCP 'auth' shorthand: {auth_cfg!r}. "
+                    "The only supported string shorthand is 'oauth'."
+                )
+            auth_cfg = {"type": "oauth"}
+        if not isinstance(auth_cfg, dict):
+            raise MCPError(
+                "MCP server 'auth' config must be the string 'oauth' or a "
+                f"dict, got {type(auth_cfg).__name__}."
+            )
+        auth_type = auth_cfg.get("type")
+        if auth_type != "oauth":
+            raise MCPError(
+                f"Unsupported MCP 'auth.type': {auth_type!r}. Only 'oauth' is "
+                "supported today — static bearer/API-key auth uses the "
+                "'headers' key instead (e.g. headers: {Authorization: "
+                "'Bearer ${TOKEN}'})."
+            )
+        # Note: the http-only restriction is already enforced eagerly in
+        # __init__ (config.get("auth") + srv_type != "http" raises there) —
+        # this method is only ever reached via _open_http, so self._type is
+        # guaranteed "http" here.
+
+        from reyn.mcp.oauth_token_storage import (
+            MCPOAuthTokenStorage,
+            has_stored_token,
+        )
+
+        server = self.server_name or url
+        if self._is_non_interactive() and not has_stored_token(url):
+            raise MCPError(
+                f"MCP server {server!r} requires OAuth authentication and no "
+                "cached token was found at ~/.reyn/oauth_tokens.json. Run "
+                "reyn interactively once against this server to complete the "
+                "browser-based OAuth flow — the token is then cached for "
+                "subsequent headless/non-interactive runs."
+            )
+
+        from fastmcp.client.auth import OAuth
+
+        scopes = auth_cfg.get("scopes")
+        return OAuth(
+            mcp_url=url,
+            scopes=scopes,
+            client_id=auth_cfg.get("client_id"),
+            client_secret=auth_cfg.get("client_secret"),
+            token_storage=MCPOAuthTokenStorage(),
+        )
+
     def _open_http(self) -> "Any":
         """Open the Streamable HTTP transport.
 
@@ -905,6 +1045,11 @@ class MCPClient:
             ``${VAR}`` interpolation is the caller's responsibility (the
             standard load_config path applies ``expand_env`` recursively
             across the whole merged config — see ADR-0030).
+          - ``auth`` (optional — #2597 slice ④) — ``"oauth"`` or
+            ``{"type": "oauth", "scopes": [...], "client_id": ..., "client_secret":
+            ...}``. Mutually additive with ``headers`` (both can be set; a
+            server that also needs a static header alongside OAuth is
+            supported). See :meth:`_build_oauth_auth`.
           - ``timeout`` (optional, default 30) — request timeout in seconds.
             FastMCP's ``StreamableHttpTransport`` has no per-transport
             connect timeout (its ``sse_read_timeout`` ctor kwarg is
@@ -932,7 +1077,8 @@ class MCPClient:
         # need to spoof in tests or proxy in production.
         if self._agent_id and "X-Reyn-Agent-Id" not in headers:
             headers["X-Reyn-Agent-Id"] = self._agent_id
-        return StreamableHttpTransport(url, headers=headers)
+        auth = self._build_oauth_auth(url)
+        return StreamableHttpTransport(url, headers=headers, auth=auth)
 
     def _open_sse(self) -> "Any":
         """Open the SSE transport (#2597 S1 free win — FastMCP ships it, so no

--- a/src/reyn/mcp/oauth_token_storage.py
+++ b/src/reyn/mcp/oauth_token_storage.py
@@ -1,0 +1,213 @@
+"""MCP OAuth token storage — #2597 slice ④ (OAuth 2.1 + Streamable HTTP completion).
+
+FastMCP's browser-based OAuth helper (``fastmcp.client.auth.OAuth`` — verified
+against the installed fastmcp 3.4.2 source at
+``fastmcp/client/auth/oauth.py``) does NOT implement its own bare
+``mcp.client.auth.TokenStorage`` (get_tokens/set_tokens/get_client_info/
+set_client_info) as the module docstring of the umbrella issue originally
+assumed. Instead ``OAuth(..., token_storage=...)`` takes a
+``key_value.aio.protocols.AsyncKeyValue``-conforming store (the
+``key-value-aio`` package's generic async KV protocol: ``get``/``put``/
+``delete``/``ttl`` + ``*_many`` bulk variants, each keyed by ``(key,
+collection)``) and wraps it internally in its own
+``TokenStorageAdapter(async_key_value, server_url)`` — a ``PydanticAdapter``
+that serialises ``mcp.shared.auth.OAuthToken`` / ``OAuthClientInformationFull``
+to/from plain JSON-safe dicts before calling ``get``/``put`` on whatever store
+we hand it, under two collections (``"mcp-oauth-token"``,
+``"mcp-oauth-client-info"``) plus one bare key (``"<url>/token_expiry"``,
+collection ``"mcp-oauth-token-expiry"``) it manages directly on the KV store
+for the ABSOLUTE access-token expiry (added upstream to fix a stale-relative-
+``expires_in`` bug on reload). :class:`MCPOAuthTokenStorage` below is reyn's
+implementation of that ``AsyncKeyValue`` protocol — NOT FastMCP's assumed
+``TokenStorage`` ABC — verified by reading ``fastmcp/client/auth/oauth.py``
+and ``key_value/aio/protocols/key_value.py`` directly (see this module's PR
+for the read-out).
+
+Storage location — the reyn-dir-layout "outside" bucket (see
+``docs/reference/runtime/reyn-dir-layout.md``): tokens land in the SAME
+``~/.reyn/oauth_tokens.json`` (chmod 600) that reyn's existing RFC 8628
+device-grant store (:mod:`reyn.security.secrets.oauth`, FP-0016 Component
+B/C — merged before this slice) already reads/writes. This module reuses
+THAT module's ``_read_store``/``_write_store``/``_default_oauth_path``
+helpers (single-file read-modify-write + chmod 600 enforcement) rather than
+introducing a second on-disk JSON-store implementation — "grep existing
+mechanism first" — and namespaces every entry it writes under an
+``"mcp:"``-prefixed compound key (``mcp:<collection>::<key>``) so MCP OAuth
+entries can never collide with the device-grant module's provider-keyed
+entries in the same file. Neither store is under ``.reyn/`` (project-scoped
+recovery-core) — both are ``~/.reyn/`` (operator/user-owned, outside bucket):
+never written through a WAL-emitting op, never captured by rewind/PITR, and
+this module contains no logging of token VALUES (only keys/URLs ever appear
+in any warning/error text).
+
+Headless / no-token graceful failure: FastMCP's ``OAuth`` opens a browser +
+a localhost callback server to complete the FIRST authorization — that only
+works with an attached interactive session. :func:`has_stored_token` lets
+:mod:`reyn.mcp.client` check, BEFORE constructing the transport, whether a
+usable token is already cached for a given MCP server URL; if not, and the
+caller is running non-interactively, ``client.py`` raises a clear
+``MCPError`` instead of letting FastMCP hang (bounded only by its own
+``callback_timeout``, default 300s) waiting for a browser round-trip nobody
+can complete.
+"""
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from reyn.security.secrets.oauth import (
+    _default_oauth_path,
+    _read_store,
+    _write_store,
+)
+
+# Same collection + key-shape FastMCP's ``TokenStorageAdapter._get_token_cache_key``
+# uses (``f"{server_url}/tokens"``, collection ``"mcp-oauth-token"``) — verified
+# against the installed fastmcp 3.4.2 source. Duplicated here (not imported) so
+# :func:`has_stored_token` can answer the "do we already have a token" question
+# with a plain synchronous file read, without instantiating FastMCP's OAuth /
+# PydanticAdapter machinery just to ask.
+_TOKEN_COLLECTION = "mcp-oauth-token"
+
+
+def _mcp_compound_key(key: str, collection: str | None) -> str:
+    """Namespace ``(key, collection)`` into the single flat dict the shared
+    ``oauth_tokens.json`` file stores, prefixed so MCP OAuth entries can never
+    collide with :mod:`reyn.security.secrets.oauth`'s device-grant keys."""
+    return f"mcp:{collection or '_default'}::{key}"
+
+
+def _server_token_key(mcp_url: str) -> str:
+    """Mirror FastMCP's ``TokenStorageAdapter._get_token_cache_key`` exactly:
+    the URL is right-stripped of a trailing slash first (verified against
+    ``OAuth._bind``, which does ``mcp_url = mcp_url.rstrip("/")`` before
+    constructing its ``TokenStorageAdapter``)."""
+    return f"{mcp_url.rstrip('/')}/tokens"
+
+
+def has_stored_token(mcp_url: str, *, path: Path | None = None) -> bool:
+    """Return True iff a (not-yet-expired-by-our-own-TTL) OAuth token is
+    already cached for ``mcp_url``. Used by :mod:`reyn.mcp.client` to decide,
+    BEFORE opening a transport, whether a non-interactive caller can proceed
+    without hitting FastMCP's browser flow. Never raises; a corrupt/missing
+    store answers False (= "no usable token yet", the conservative default —
+    same posture as :class:`~reyn.mcp.client.MCPClient.supports`)."""
+    store_path = path if path is not None else _default_oauth_path()
+    data = _read_store(store_path)
+    entry = data.get(_mcp_compound_key(_server_token_key(mcp_url), _TOKEN_COLLECTION))
+    if not isinstance(entry, dict):
+        return False
+    expires_at = entry.get("_expires_at")
+    if expires_at is not None and time.time() >= expires_at:
+        return False
+    return isinstance(entry.get("_value"), dict)
+
+
+class MCPOAuthTokenStorage:
+    """``key_value.aio.protocols.AsyncKeyValue``-conforming store FastMCP's
+    ``OAuth(token_storage=...)`` accepts (see module docstring for the exact
+    verified contract). Backed by the shared ``~/.reyn/oauth_tokens.json``
+    (outside bucket, chmod 600) via :mod:`reyn.security.secrets.oauth`'s
+    ``_read_store``/``_write_store`` helpers — a full-file read-modify-write
+    per call, which is fine at OAuth's write frequency (login + occasional
+    refresh, not a hot path).
+
+    Never logs token values: every method here only ever formats *keys* /
+    *collection names* into anything user-visible (there is nothing
+    user-visible in this class at all — it's pure file I/O).
+    """
+
+    def __init__(self, *, path: Path | None = None) -> None:
+        self._path = path if path is not None else _default_oauth_path()
+
+    def _load(self) -> dict[str, Any]:
+        return _read_store(self._path)
+
+    def _save(self, data: dict[str, Any]) -> None:
+        _write_store(self._path, data)
+
+    async def get(self, key: str, *, collection: str | None = None) -> dict[str, Any] | None:
+        value, _ttl = await self.ttl(key, collection=collection)
+        return value
+
+    async def ttl(
+        self, key: str, *, collection: str | None = None
+    ) -> tuple[dict[str, Any] | None, float | None]:
+        entry = self._load().get(_mcp_compound_key(key, collection))
+        if not isinstance(entry, dict):
+            return None, None
+        expires_at = entry.get("_expires_at")
+        value = entry.get("_value")
+        if not isinstance(value, dict):
+            return None, None
+        if expires_at is not None:
+            remaining = expires_at - time.time()
+            if remaining <= 0:
+                return None, None
+            return dict(value), remaining
+        return dict(value), None
+
+    async def put(
+        self,
+        key: str,
+        value: Mapping[str, Any],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        data = self._load()
+        data[_mcp_compound_key(key, collection)] = {
+            "_value": dict(value),
+            "_expires_at": (time.time() + float(ttl)) if ttl is not None else None,
+        }
+        self._save(data)
+
+    async def delete(self, key: str, *, collection: str | None = None) -> bool:
+        data = self._load()
+        compound = _mcp_compound_key(key, collection)
+        if compound not in data:
+            return False
+        del data[compound]
+        self._save(data)
+        return True
+
+    async def get_many(
+        self, keys: Sequence[str], *, collection: str | None = None
+    ) -> list[dict[str, Any] | None]:
+        return [await self.get(k, collection=collection) for k in keys]
+
+    async def ttl_many(
+        self, keys: Sequence[str], *, collection: str | None = None
+    ) -> list[tuple[dict[str, Any] | None, float | None]]:
+        return [await self.ttl(k, collection=collection) for k in keys]
+
+    async def put_many(
+        self,
+        keys: Sequence[str],
+        values: Sequence[Mapping[str, Any]],
+        *,
+        collection: str | None = None,
+        ttl: float | None = None,
+    ) -> None:
+        data = self._load()
+        expires_at = (time.time() + float(ttl)) if ttl is not None else None
+        for k, v in zip(keys, values):
+            data[_mcp_compound_key(k, collection)] = {
+                "_value": dict(v),
+                "_expires_at": expires_at,
+            }
+        self._save(data)
+
+    async def delete_many(self, keys: Sequence[str], *, collection: str | None = None) -> int:
+        data = self._load()
+        removed = 0
+        for k in keys:
+            compound = _mcp_compound_key(k, collection)
+            if compound in data:
+                del data[compound]
+                removed += 1
+        if removed:
+            self._save(data)
+        return removed

--- a/tests/test_mcp_oauth_2597_s4.py
+++ b/tests/test_mcp_oauth_2597_s4.py
@@ -1,0 +1,388 @@
+"""Tests for #2597 slice ④ — MCP OAuth 2.1 + Streamable HTTP completion.
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``
+on collaborators. The full browser-based OAuth Authorization Code Grant +
+PKCE round-trip needs a real authorization server and a human to click
+"Allow" — that is a manual/dogfood step (see the PR's Test plan), NOT
+something a unit test fakes. These tests instead exercise the real WIRING
+with real components: real ``load_config``, the real
+``fastmcp.client.auth.OAuth`` object (built and inspected, never invoked),
+the real ``StreamableHttpTransport``, and real file I/O against a tmp
+``oauth_tokens.json``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPClient, MCPError
+from reyn.mcp.oauth_token_storage import MCPOAuthTokenStorage, has_stored_token
+
+
+@pytest.fixture
+def oauth_store_path(tmp_path, monkeypatch) -> Path:
+    """Per-test OAuth token store — mirrors the FP-0016 fixture pattern in
+    test_fp0016_b_oauth_refresh.py (same env-var override, same file shape)."""
+    p = tmp_path / "oauth_tokens.json"
+    monkeypatch.setenv("REYN_OAUTH_TOKENS_PATH", str(p))
+    return p
+
+
+# ── (a) config parses + validates via the real load_config ────────────────
+
+
+def test_oauth_server_config_parses_via_load_config(tmp_path, monkeypatch) -> None:
+    """Tier 1: an ``auth: oauth`` MCP server entry survives the real
+    reyn.yaml -> load_config -> ReynConfig.mcp round trip intact, including
+    the nested scopes/client_id fields."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text(
+        "mcp:\n"
+        "  servers:\n"
+        "    github:\n"
+        "      type: http\n"
+        "      url: https://api.githubcopilot.com/mcp/\n"
+        "      auth:\n"
+        "        type: oauth\n"
+        "        scopes: [repo, read:org]\n"
+        "        client_id: my-client-id\n",
+        encoding="utf-8",
+    )
+    from reyn.config.loader import load_config
+
+    cfg = load_config(cwd=tmp_path)
+    server_cfg = cfg.mcp["servers"]["github"]
+    assert server_cfg["type"] == "http"
+    assert server_cfg["auth"]["type"] == "oauth"
+    assert server_cfg["auth"]["scopes"] == ["repo", "read:org"]
+    assert server_cfg["auth"]["client_id"] == "my-client-id"
+
+    # And the parsed dict, fed straight into MCPClient, builds an OAuth
+    # transport auth object without raising (this client never connects).
+    client = MCPClient(dict(server_cfg), non_interactive=False)
+    transport = client._open_transport()
+    from fastmcp.client.auth import OAuth
+
+    assert isinstance(transport.auth, OAuth)
+
+
+def test_bare_oauth_string_shorthand_parses() -> None:
+    """Tier 1: ``auth: oauth`` (bare string) is shorthand for ``{"type": "oauth"}``."""
+    cfg = {"type": "http", "url": "https://example.com/mcp", "auth": "oauth"}
+    client = MCPClient(cfg, non_interactive=False)
+    transport = client._open_transport()
+    from fastmcp.client.auth import OAuth
+
+    assert isinstance(transport.auth, OAuth)
+    assert transport.auth.mcp_url == "https://example.com/mcp"
+
+
+def test_unsupported_auth_type_rejected() -> None:
+    """Tier 1: a non-'oauth' auth.type is a clear config error, not a silent no-op."""
+    cfg = {"type": "http", "url": "https://example.com/mcp", "auth": {"type": "saml"}}
+    client = MCPClient(cfg, non_interactive=False)
+    with pytest.raises(MCPError, match="saml"):
+        client._open_transport()
+
+
+def test_auth_on_stdio_server_rejected_at_construction() -> None:
+    """Tier 1: OAuth is meaningless over stdio — reject eagerly, don't silently ignore."""
+    with pytest.raises(ValueError, match="stdio"):
+        MCPClient({"type": "stdio", "command": "x", "auth": "oauth"})
+
+
+def test_auth_on_sse_server_rejected_at_construction() -> None:
+    """Tier 1: same restriction for sse — OAuth only wired for Streamable HTTP."""
+    with pytest.raises(ValueError, match="sse"):
+        MCPClient({"type": "sse", "url": "https://x/sse", "auth": "oauth"})
+
+
+# ── (b) TokenStorage round-trips through oauth_tokens.json (outside bucket) ─
+
+
+def test_token_storage_round_trips_through_outside_bucket_file(oauth_store_path) -> None:
+    """Tier 2: MCPOAuthTokenStorage persists + reloads a token through the
+    real oauth_tokens.json file, 0600-permissioned, keyed per server URL —
+    the SAME on-disk file reyn.security.secrets.oauth's device-grant store
+    uses (outside bucket, per reyn-dir-layout.md), never a private in-memory
+    dict a test would need to reach into."""
+    storage_a = MCPOAuthTokenStorage(path=oauth_store_path)
+    non_default_value = {
+        "access_token": "at-nondefault-9f3c",
+        "refresh_token": "rt-nondefault-2b71",
+        "token_type": "Bearer",
+    }
+
+    async def _round_trip() -> None:
+        await storage_a.put(
+            "https://server-a.example.com/tokens",
+            non_default_value,
+            collection="mcp-oauth-token",
+        )
+
+    asyncio.run(_round_trip())
+
+    assert oauth_store_path.exists()
+    assert oct(oauth_store_path.stat().st_mode & 0o777) == "0o600"
+
+    # A FRESH storage instance (same path) reads back the same value —
+    # proves it round-trips through the file, not an in-process cache.
+    storage_b = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _reload() -> dict:
+        return await storage_b.get(
+            "https://server-a.example.com/tokens", collection="mcp-oauth-token"
+        )
+
+    reloaded = asyncio.run(_reload())
+    assert reloaded == non_default_value
+
+
+def test_token_storage_per_server_keying_does_not_collide(oauth_store_path) -> None:
+    """Tier 2: two different server URLs under the same collection are
+    stored independently — writing server B's token must not disturb
+    server A's (per-server keying invariant)."""
+    storage = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _write_both() -> None:
+        await storage.put(
+            "https://server-a.example.com/tokens",
+            {"access_token": "token-a-4471"},
+            collection="mcp-oauth-token",
+        )
+        await storage.put(
+            "https://server-b.example.com/tokens",
+            {"access_token": "token-b-8823"},
+            collection="mcp-oauth-token",
+        )
+
+    asyncio.run(_write_both())
+
+    async def _read_both():
+        a = await storage.get(
+            "https://server-a.example.com/tokens", collection="mcp-oauth-token"
+        )
+        b = await storage.get(
+            "https://server-b.example.com/tokens", collection="mcp-oauth-token"
+        )
+        return a, b
+
+    a, b = asyncio.run(_read_both())
+    assert a == {"access_token": "token-a-4471"}
+    assert b == {"access_token": "token-b-8823"}
+
+
+def test_has_stored_token_reflects_real_store_state(oauth_store_path) -> None:
+    """Tier 2: has_stored_token() is a thin, real (non-mocked) read of the
+    same file MCPOAuthTokenStorage writes — used by the headless pre-flight
+    check in client.py."""
+    url = "https://server-c.example.com/mcp"
+    assert has_stored_token(url, path=oauth_store_path) is False
+
+    storage = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _write() -> None:
+        # Mirrors FastMCP's own TokenStorageAdapter key shape exactly
+        # (f"{url.rstrip('/')}/tokens", collection "mcp-oauth-token") —
+        # verified against the installed fastmcp 3.4.2 source.
+        await storage.put(
+            f"{url}/tokens",
+            {"access_token": "at-real-6620"},
+            collection="mcp-oauth-token",
+        )
+
+    asyncio.run(_write())
+    assert has_stored_token(url, path=oauth_store_path) is True
+
+
+def test_expired_token_entry_not_reported_as_stored(oauth_store_path) -> None:
+    """Tier 2: a TTL'd-out entry must not be reported as a usable token —
+    has_stored_token() checks the real (not-a-private-field) expiry the
+    entry carries."""
+    url = "https://server-d.example.com/mcp"
+    storage = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _write_expired() -> None:
+        await storage.put(
+            f"{url}/tokens",
+            {"access_token": "at-expiring-3391"},
+            collection="mcp-oauth-token",
+            ttl=-1,  # already expired
+        )
+
+    asyncio.run(_write_expired())
+    assert has_stored_token(url, path=oauth_store_path) is False
+
+
+# ── (c) an OAuth-configured server builds the right transport/auth object ──
+
+
+def test_http_oauth_server_builds_real_oauth_transport_auth(oauth_store_path) -> None:
+    """Tier 1: inspect the REAL fastmcp.client.auth.OAuth object attached to
+    the REAL StreamableHttpTransport (mirrors the ②a header tests that
+    inspect the real StreamableHttpTransport) — proves the config->transport
+    wiring, not a hand-rolled fake. Uses only PUBLIC surface: ``mcp_url``,
+    the public ``context.client_metadata.scope`` (never the leading-
+    underscore ``_scopes``/``_client_id`` ctor-cache fields), and a real
+    round trip through the public ``token_storage_adapter.get_tokens()`` /
+    ``set_tokens()`` to prove the storage binding — never reaching into
+    ``token_storage_adapter``'s private ``_key_value_store``."""
+    cfg = {
+        "type": "http",
+        "url": "https://mcp.example.com/mcp",
+        "auth": {
+            "type": "oauth",
+            "scopes": ["a", "b"],
+            "client_id": "client-123",
+            "client_secret": "secret-456",
+        },
+    }
+    client = MCPClient(cfg, non_interactive=False)
+    transport = client._open_transport()
+
+    from fastmcp.client.auth import OAuth
+
+    assert isinstance(transport.auth, OAuth)
+    assert transport.auth.mcp_url == "https://mcp.example.com/mcp"
+    # public dataclass field on the public `context` attribute
+    assert transport.auth.context.client_metadata.scope == "a b"
+
+    # Prove the OAuth object's storage really is bound to OUR
+    # MCPOAuthTokenStorage / oauth_store_path — round-trip a token through
+    # the built object's OWN public token_storage_adapter, then confirm a
+    # separate MCPOAuthTokenStorage pointed at the same path sees it.
+    from mcp.shared.auth import OAuthToken
+
+    async def _round_trip() -> None:
+        await transport.auth.token_storage_adapter.set_tokens(
+            OAuthToken(access_token="at-wiring-proof-5510", token_type="Bearer")
+        )
+
+    asyncio.run(_round_trip())
+
+    independent_storage = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _read_independently() -> dict:
+        return await independent_storage.get(
+            "https://mcp.example.com/mcp/tokens", collection="mcp-oauth-token"
+        )
+
+    seen = asyncio.run(_read_independently())
+    assert seen is not None
+    assert seen["access_token"] == "at-wiring-proof-5510"
+
+
+# ── (d) static bearer / header auth regression — unaffected by slice ④ ─────
+
+
+def test_static_bearer_header_auth_unaffected(oauth_store_path) -> None:
+    """Tier 1: pre-④ static bearer auth (headers, no 'auth' key at all) still
+    builds a transport with auth=None and the header intact — the ④ wiring
+    is additive, never a behavior change for the existing header-auth path."""
+    cfg = {
+        "type": "http",
+        "url": "https://mcp.example.com/mcp",
+        "headers": {"Authorization": "Bearer static-token-abc"},
+    }
+    client = MCPClient(cfg)
+    transport = client._open_transport()
+    assert transport.auth is None
+    assert transport.headers["Authorization"] == "Bearer static-token-abc"
+
+
+# ── (e) headless + no stored token -> clear MCPError, never a hang ─────────
+
+
+def test_headless_no_token_raises_clear_mcp_error_not_hang(oauth_store_path) -> None:
+    """Tier 1: a non-interactive caller with no cached token gets a clear,
+    immediate MCPError instead of FastMCP opening a browser + waiting on a
+    localhost callback nobody can complete."""
+    cfg = {
+        "type": "http",
+        "url": "https://mcp.example.com/mcp",
+        "auth": {"type": "oauth"},
+    }
+    client = MCPClient(cfg, non_interactive=True)
+    with pytest.raises(MCPError, match="requires OAuth authentication"):
+        client._open_transport()
+
+
+def test_headless_with_stored_token_proceeds(oauth_store_path) -> None:
+    """Tier 1: once a token IS cached for this exact server URL, the same
+    non-interactive client builds the transport without raising — the
+    pre-flight check is scoped to "no token yet", not "always block
+    headless"."""
+    url = "https://mcp.example.com/mcp"
+    storage = MCPOAuthTokenStorage(path=oauth_store_path)
+
+    async def _seed() -> None:
+        await storage.put(
+            f"{url}/tokens",
+            {"access_token": "at-cached-7742"},
+            collection="mcp-oauth-token",
+        )
+
+    asyncio.run(_seed())
+
+    cfg = {"type": "http", "url": url, "auth": {"type": "oauth"}}
+    client = MCPClient(cfg, non_interactive=True)
+    transport = client._open_transport()  # must not raise
+    from fastmcp.client.auth import OAuth
+
+    assert isinstance(transport.auth, OAuth)
+
+
+def test_interactive_client_with_no_token_does_not_raise_preflight_error(
+    oauth_store_path,
+) -> None:
+    """Tier 1: an explicitly interactive client (non_interactive=False) is
+    allowed to proceed to FastMCP's own browser flow even with no cached
+    token — the headless guard only fires for non-interactive callers."""
+    cfg = {
+        "type": "http",
+        "url": "https://mcp.example.com/mcp",
+        "auth": {"type": "oauth"},
+    }
+    client = MCPClient(cfg, non_interactive=False)
+    transport = client._open_transport()  # must not raise
+    from fastmcp.client.auth import OAuth
+
+    assert isinstance(transport.auth, OAuth)
+
+
+# ── never write OAuth tokens into any rewind/recovery-core path ────────────
+
+
+def test_oauth_tokens_never_land_under_dot_reyn_recovery_core(
+    tmp_path, monkeypatch
+) -> None:
+    """Tier 2: OS invariant — OAuth tokens are OUTSIDE-bucket data (per
+    reyn-dir-layout.md), never written under a project's ``.reyn/state/`` or
+    ``.reyn/config/`` (the recovery-core, WAL/rewind-reconstructed subtrees).
+    This test asserts the NEGATIVE directly: after writing a token via the
+    real storage, no file appears anywhere under a project ``.reyn/`` tree,
+    because MCPOAuthTokenStorage never resolves its path there — the write
+    path is fully independent of any project root / WAL / config-generation
+    machinery. truncate-falsify N/A here (no recovery-core, hard-rule gate
+    only applies to reconstructable state; this is intentionally NOT
+    reconstructable — see the module docstring)."""
+    project_reyn_dir = tmp_path / "project" / ".reyn"
+    project_reyn_dir.mkdir(parents=True)
+    oauth_path = tmp_path / "outside-bucket" / "oauth_tokens.json"
+    storage = MCPOAuthTokenStorage(path=oauth_path)
+
+    async def _write() -> None:
+        await storage.put(
+            "https://mcp.example.com/tokens",
+            {"access_token": "at-isolation-check-1123"},
+            collection="mcp-oauth-token",
+        )
+
+    asyncio.run(_write())
+
+    assert oauth_path.exists()
+    # Nothing was written anywhere under the project's .reyn/ tree.
+    written_under_dot_reyn = list(project_reyn_dir.rglob("*"))
+    assert written_under_dot_reyn == []


### PR DESCRIPTION
**[lead-coder]** (shipping [per-PR-coder]'s completed implementation — the agent finished the code but stalled at a backgrounded pytest before committing; committed+pushed by lead so CI runs pytest, then lead hard-reviews the credential handling) — `part of #2597`, the FINAL slice of the MCP client redesign.

## What this adds
OAuth 2.1 (Auth-Code + PKCE via FastMCP) for hosted MCP servers + token storage. reyn `TokenStorage` persists to `oauth_tokens.json` in the **outside bucket** (0600, per-server, never logged/audited/rewound — verified against reyn-dir-layout.md). Headless + no stored token → clear error, no hang. Static bearer auth preserved.

## Doc
No docs/ in this PR — ④'s config/token-storage doc is folded into the docs-maintainer doc-completeness sweep already in flight (I'll route it there on merge).

## Gate status
Deferred pytest to CI (agent stalled at a backgrounded run — same pattern as H3/P1). Lead verifies CI green + hard-reviews the credential handling (0600, no token values logged, outside-bucket-not-rewound) before merge; will NOT merge if pytest is red beyond the known #2599.

## Test plan
- [ ] pytest — deferred to CI (lead verifies)
- [x] New `tests/test_mcp_oauth_2597_s4.py` (token-storage round-trip + wiring; full browser flow = manual/dogfood — lead confirms coverage on review)