### PR TITLE
fix(#2597): wire D5-D11 MCP resources/prompts/subscribe verbs into build_tools()

### DIFF
--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -3,7 +3,7 @@
 Public API
 ----------
 build_tools(available_agents, *, file_permissions, mcp_servers)
-    Returns 14–23 tools in fixed order for litellm.acompletion.
+    Returns 14–30 tools in fixed order for litellm.acompletion.
 
 Gemini-safe schema rules enforced throughout:
 - No oneOf / anyOf / additionalProperties / format keys
@@ -212,7 +212,7 @@ def build_tools(
 ) -> list[dict]:
     """Build the tools= argument for litellm.acompletion.
 
-    Returns 14–23 tools in fixed order (Anthropic prompt cache compatibility).
+    Returns 14–30 tools in fixed order (Anthropic prompt cache compatibility).
     Tool order matches the plan's canonical ordering:
       A1 list_agents, A2 describe_agent,
       A3 list_memory, A4 read_memory_body,
@@ -220,7 +220,11 @@ def build_tools(
       B2 remember_shared, B3 remember_agent, B4 forget_memory,
       C1 list_directory, C2 read_file (when any file scope),
       C3 write_file, C4 delete_file (only when write scope),
-      D1 list_mcp_servers, D2 list_mcp_tools, D3 call_mcp_tool, D4 describe_mcp_tool (when mcp configured).
+      D1 list_mcp_servers, D2 list_mcp_tools, D3 call_mcp_tool, D4 describe_mcp_tool,
+      D5 list_mcp_resources, D6 list_mcp_resource_templates, D7 read_mcp_resource,
+      D8 subscribe_mcp_resource, D9 unsubscribe_mcp_resource,
+      D10 list_mcp_prompts, D11 get_mcp_prompt (all D1–D11 when mcp configured,
+      #2597 slices ②a/②b/②c).
 
     Internally collects ToolSpec objects (= single source of truth for name,
     description, parameters, dispatch_kind) and returns the OpenAI dict shape
@@ -714,6 +718,113 @@ def build_tools(
                     description=_describe_mcp_tool_rendered["function"]["description"],
                     parameters=_describe_mcp_tool_rendered["function"]["parameters"],
                     dispatch_kind=_describe_mcp_tool_def.dispatch_kind,
+                ))
+
+            # ── #2597 slice ②a/②b/②c fix: D5–D11 resources/prompts/subscribe ──
+            #
+            # BUG: list_mcp_resources, list_mcp_resource_templates,
+            # read_mcp_resource, subscribe_mcp_resource,
+            # unsubscribe_mcp_resource, list_mcp_prompts, get_mcp_prompt were
+            # registered in get_default_registry() with gates.router="allow"
+            # and fully dispatchable, but had ZERO entries in build_tools() —
+            # the same "registered + dispatchable but never advertised" class
+            # of bug as #2589 (pipelines) and the #2120 session_spawn drift
+            # (see the B2b comment above). A real chat agent could never
+            # discover or call these seven verbs. All seven take a `server`
+            # arg (per tools/mcp.py's *_PARAMETERS dicts) and declare
+            # schema_enricher=_enrich_router_schema, so — exactly like D3/D4
+            # — they are rendered with the shared `_mcp_state` for the
+            # per-call `server` enum injection.
+
+            # ── D5: list_mcp_resources ───────────────────────────────────────
+            _list_mcp_resources_def = _registry.lookup("list_mcp_resources")
+            if _list_mcp_resources_def is not None and _list_mcp_resources_def.gates.router == "allow":
+                _list_mcp_resources_rendered = _list_mcp_resources_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_list_mcp_resources_rendered["function"]["name"],
+                    description=_list_mcp_resources_rendered["function"]["description"],
+                    parameters=_list_mcp_resources_rendered["function"]["parameters"],
+                    dispatch_kind=_list_mcp_resources_def.dispatch_kind,
+                ))
+
+            # ── D6: list_mcp_resource_templates ──────────────────────────────
+            _list_mcp_resource_templates_def = _registry.lookup("list_mcp_resource_templates")
+            if _list_mcp_resource_templates_def is not None and _list_mcp_resource_templates_def.gates.router == "allow":
+                _list_mcp_resource_templates_rendered = _list_mcp_resource_templates_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_list_mcp_resource_templates_rendered["function"]["name"],
+                    description=_list_mcp_resource_templates_rendered["function"]["description"],
+                    parameters=_list_mcp_resource_templates_rendered["function"]["parameters"],
+                    dispatch_kind=_list_mcp_resource_templates_def.dispatch_kind,
+                ))
+
+            # ── D7: read_mcp_resource ─────────────────────────────────────────
+            _read_mcp_resource_def = _registry.lookup("read_mcp_resource")
+            if _read_mcp_resource_def is not None and _read_mcp_resource_def.gates.router == "allow":
+                _read_mcp_resource_rendered = _read_mcp_resource_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_read_mcp_resource_rendered["function"]["name"],
+                    description=_read_mcp_resource_rendered["function"]["description"],
+                    parameters=_read_mcp_resource_rendered["function"]["parameters"],
+                    dispatch_kind=_read_mcp_resource_def.dispatch_kind,
+                ))
+
+            # ── D8: subscribe_mcp_resource ────────────────────────────────────
+            _subscribe_mcp_resource_def = _registry.lookup("subscribe_mcp_resource")
+            if _subscribe_mcp_resource_def is not None and _subscribe_mcp_resource_def.gates.router == "allow":
+                _subscribe_mcp_resource_rendered = _subscribe_mcp_resource_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_subscribe_mcp_resource_rendered["function"]["name"],
+                    description=_subscribe_mcp_resource_rendered["function"]["description"],
+                    parameters=_subscribe_mcp_resource_rendered["function"]["parameters"],
+                    dispatch_kind=_subscribe_mcp_resource_def.dispatch_kind,
+                ))
+
+            # ── D9: unsubscribe_mcp_resource ──────────────────────────────────
+            _unsubscribe_mcp_resource_def = _registry.lookup("unsubscribe_mcp_resource")
+            if _unsubscribe_mcp_resource_def is not None and _unsubscribe_mcp_resource_def.gates.router == "allow":
+                _unsubscribe_mcp_resource_rendered = _unsubscribe_mcp_resource_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_unsubscribe_mcp_resource_rendered["function"]["name"],
+                    description=_unsubscribe_mcp_resource_rendered["function"]["description"],
+                    parameters=_unsubscribe_mcp_resource_rendered["function"]["parameters"],
+                    dispatch_kind=_unsubscribe_mcp_resource_def.dispatch_kind,
+                ))
+
+            # ── D10: list_mcp_prompts ─────────────────────────────────────────
+            _list_mcp_prompts_def = _registry.lookup("list_mcp_prompts")
+            if _list_mcp_prompts_def is not None and _list_mcp_prompts_def.gates.router == "allow":
+                _list_mcp_prompts_rendered = _list_mcp_prompts_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_list_mcp_prompts_rendered["function"]["name"],
+                    description=_list_mcp_prompts_rendered["function"]["description"],
+                    parameters=_list_mcp_prompts_rendered["function"]["parameters"],
+                    dispatch_kind=_list_mcp_prompts_def.dispatch_kind,
+                ))
+
+            # ── D11: get_mcp_prompt ───────────────────────────────────────────
+            _get_mcp_prompt_def = _registry.lookup("get_mcp_prompt")
+            if _get_mcp_prompt_def is not None and _get_mcp_prompt_def.gates.router == "allow":
+                _get_mcp_prompt_rendered = _get_mcp_prompt_def.render_for_router(
+                    state=_mcp_state
+                )
+                specs.append(ToolSpec(
+                    name=_get_mcp_prompt_rendered["function"]["name"],
+                    description=_get_mcp_prompt_rendered["function"]["description"],
+                    parameters=_get_mcp_prompt_rendered["function"]["parameters"],
+                    dispatch_kind=_get_mcp_prompt_def.dispatch_kind,
                 ))
     else:
         _mcp_search_tool_raw = []

--- a/tests/test_router_tools_invariants.py
+++ b/tests/test_router_tools_invariants.py
@@ -1,9 +1,12 @@
 """Tier 2: ToolSpec dataclass invariants (ToolSpec refactor, PR-next).
 
-Three contract tests:
+Four contract tests:
   1. ToolSpec.to_openai_dict() round-trip produces a valid OpenAI tool shape.
   2. build_tools() specs are consistent with get_dispatch_kind().
   3. Unknown tool name defaults to "sync" from get_dispatch_kind().
+  4. build_tools() advertises every router=allow MCP verb (#2597 regression
+     guard — resources/subscribe/prompts verbs were registered + dispatchable
+     but not wired into the live tool schema).
 
 No mocks. No private-state assertions.
 """
@@ -146,6 +149,57 @@ def test_get_dispatch_kind_unknown_defaults_to_sync() -> None:
     unregistered tool will not cause RouterLoop to exit prematurely."""
     assert get_dispatch_kind("no_such_tool") == "sync"
     assert get_dispatch_kind("") == "sync"
+
+
+# ── 4. All MCP verbs actually reach the live tool schema ──────────────────────
+#
+# #2597 regression guard: list_mcp_resources, list_mcp_resource_templates,
+# read_mcp_resource, subscribe_mcp_resource, unsubscribe_mcp_resource,
+# list_mcp_prompts, get_mcp_prompt were registered in get_default_registry()
+# with gates.router="allow" and were fully dispatchable, but build_tools()
+# had ZERO wiring for them (grep-confirmed) — a real chat agent could never
+# see or call them (same advertising-gap class as #2589/#2555/#2120). This
+# test builds the live tool schema via build_tools() with an MCP server
+# configured and asserts every MCP verb (the existing D1-D4 plus the new
+# D5-D11 seven) is present by name. It fails on pre-fix code (7 missing
+# names) and passes post-fix. Uses the real ToolRegistry — no mocks.
+
+
+def test_build_tools_advertises_all_mcp_verbs() -> None:
+    """Tier 2: build_tools() must advertise every router=allow MCP verb.
+
+    Regression guard for the #2597 advertising gap: resources / resource
+    templates / subscribe / unsubscribe / prompts verbs were registered +
+    dispatchable but never wired into build_tools(), so a real chat agent
+    could not discover or call them even though the handlers worked.
+    """
+    tools = build_tools(
+        _SAMPLE_AGENTS,
+        mcp_servers=[{"name": "fs", "description": "FS"}],
+    )
+    tool_names = {t["function"]["name"] for t in tools}
+
+    expected_mcp_verbs = {
+        # D1-D4: pre-existing MCP tool-consumption verbs.
+        "list_mcp_servers",
+        "list_mcp_tools",
+        "call_mcp_tool",
+        "describe_mcp_tool",
+        # D5-D11: #2597 slices ②a/②b/②c resources/subscribe/prompts verbs.
+        "list_mcp_resources",
+        "list_mcp_resource_templates",
+        "read_mcp_resource",
+        "subscribe_mcp_resource",
+        "unsubscribe_mcp_resource",
+        "list_mcp_prompts",
+        "get_mcp_prompt",
+    }
+    missing = expected_mcp_verbs - tool_names
+    assert not missing, (
+        f"MCP verbs registered as gates.router='allow' but absent from the "
+        f"live build_tools() schema (undiscoverable by a real chat agent): "
+        f"{sorted(missing)}"
+    )
     assert get_dispatch_kind("list_skills") == "sync"
     assert get_dispatch_kind("invoke_skill") == "sync"
     assert get_dispatch_kind("web_search") == "sync"


### PR DESCRIPTION
**[per-PR-coder]** — part of #2597

## Bug

`build_tools()` in `src/reyn/runtime/router_tools.py` wires MCP tools into the live LLM tool-schema via an explicit allowlist — each verb needs its own `if <name>_def is not None and gates.router=="allow": specs.append(ToolSpec(...))` block (D1-D4). The 7 verbs added by slices ②a/②b/②c (`list_mcp_resources`, `list_mcp_resource_templates`, `read_mcp_resource`, `subscribe_mcp_resource`, `unsubscribe_mcp_resource`, `list_mcp_prompts`, `get_mcp_prompt`) were registered in `get_default_registry()` with `gates.router="allow"` and fully dispatchable (handlers unit-tested), but had **zero** entries in `build_tools()` — grep-confirmed 0 hits, not even imports. A real chat agent could discover/call `list_mcp_servers` / `list_mcp_tools` / `call_mcp_tool` / `describe_mcp_tool` but never the resources/prompts/subscribe verbs, even with an MCP server configured.

This is the same advertising-gap class as **#2589** (pipelines) and the earlier **#2120** `session_spawn` drift (registered + dispatchable, never wired into the live schema builder).

## Fix

Added D5-D11 blocks in `build_tools()` immediately after D4, following the exact D1-D4 pattern:
- `_registry.lookup(name)` → check `gates.router == "allow"` → `render_for_router(...)` → append `ToolSpec`.
- All 7 verbs take a `server` arg and declare `schema_enricher=_enrich_router_schema` in `tools/mcp.py` (confirmed by reading each `*_PARAMETERS` dict), so — exactly like D3 `call_mcp_tool` / D4 `describe_mcp_tool` — they're rendered with the shared `_mcp_state` (`RouterCallerState(mcp_servers=...)`) for per-call `server` enum injection.
- Updated the module + `build_tools()` docstrings (tool-count range, canonical ordering list) to include D5-D11.

## Coverage — the gap in test coverage that let this ship

The handlers were unit-tested (dispatch works), but nothing tested *live advertising* — the actual `build_tools()` output sent to the LLM. Added `test_build_tools_advertises_all_mcp_verbs` in `tests/test_router_tools_invariants.py`: builds the live tool schema via `build_tools()` with a configured MCP server (real registry, no mocks) and asserts **all 11** MCP verb names (D1-D4 existing + D5-D11 new) appear in the result. This is the test that would have caught the bug and now guards the whole class against silent non-advertisement going forward.

- Pre-fix (verified by stashing the `router_tools.py` change): **RED** — fails with `AssertionError: ... {'get_mcp_prompt', 'list_mcp_prompts', 'list_mcp_resource_templates', 'list_mcp_resources', 'read_mcp_resource', 'subscribe_mcp_resource', 'unsubscribe_mcp_resource'}` (all 7 missing).
- Post-fix: **GREEN**.

## Test plan

- [x] `ruff check src tests` — all checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_router_tools_invariants.py` — 7/7 OK, 0 errors
- [x] `pytest` (foreground, full suite) — 7437 passed, 21 skipped, 5 failed (all 5 pre-existing `*_routes_mounted` / plugin-loader failures on `main` HEAD, confirmed unrelated by re-running against unmodified `router_tools.py` — same 5 fail identically on main; #2599 web-route-mount known issue). Zero new failures.
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_tools.py tests/test_router_tools_invariants.py` — OK
- [x] Manually confirmed via `test_build_tools_advertises_all_mcp_verbs`: pre-fix RED (7 verbs missing) / post-fix GREEN.

## Gate output (summary)

```
ruff check src tests         → All checks passed!
test_tier_audit.py --strict  → 7 tests inspected, 0 errors, exit 0
pytest -q                    → 7437 passed, 21 skipped, 5 failed (pre-existing, unrelated)
verify_module_docstrings.py  → OK: no module-docstring refactor narrative
```