### PR TITLE
test+fix(#2608): hook run-loop-pickup coverage + fs_watch path normalization

### DIFF
--- a/src/reyn/runtime/fs_watcher.py
+++ b/src/reyn/runtime/fs_watcher.py
@@ -22,6 +22,24 @@ docs. That scheduled callable does the actual (loop-thread-only) bounded
 bound+drop+log discipline (``_QUEUE_MAXSIZE``, overflow drops the newest event
 + logs, never grows unboundedly, never blocks the watchdog thread).
 
+Path normalization (#2623): on macOS ``/tmp`` is a symlink to ``/private/tmp``
+(same class of footgun exists anywhere an operator's configured
+``fs_watch.paths`` entry traverses a symlink). ``watchdog``'s OS backend
+(fsevents on macOS) reports the RESOLVED path in every fired event regardless
+of which path string ``Observer.schedule`` was given — so a naive matcher
+written against the operator's CONFIGURED path (e.g. ``matcher: {path:
+'/tmp/x/**'}``) silently never matches an event path of
+``/private/tmp/x/...``. Fixed at registration (:meth:`FsWatcher.start`): for
+each configured path whose ``os.path.realpath`` differs from its own
+(normalized) form, a resolved-path -> configured-path REWRITE is recorded
+(:attr:`_path_rewrites`). Every fired event's path is rewritten back onto the
+operator's configured prefix (:meth:`_rewrite_path`) before it ever reaches
+``hook_trigger`` — so ``matcher: {path: <the path the operator wrote in
+fs_watch.paths>}`` Just Works, and the ``file_changed`` event's ``path``
+template var is exactly the configured path (not a resolved alias of it) for
+any file under it. A path with no symlink component is unaffected
+(rewrite is a no-op — ``resolved == configured`` and no entry is added).
+
 Debounce (F7-3): editors emit event BURSTS for one logical change (temp files,
 multiple writes, create-then-modify). Coalesced per-path on the watchdog
 thread with a simple leading-edge scheme: :meth:`_FsEventHandler._maybe_fire`
@@ -61,6 +79,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -126,6 +145,9 @@ class FsWatcher:
         self._queue: "asyncio.Queue[tuple[str, str]] | None" = None
         self._drain_task: "asyncio.Task | None" = None
         self._started = False
+        # #2623: resolved-symlink-path -> operator-configured-path rewrites,
+        # built in :meth:`start` — see module docstring "Path normalization".
+        self._path_rewrites: "list[tuple[str, str]]" = []
 
     def is_started(self) -> bool:
         """Read-only introspection for callers/tests — mirrors
@@ -162,6 +184,19 @@ class FsWatcher:
         self._queue = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
         self._drain_task = asyncio.create_task(self._drain_events())
 
+        # #2623: build the resolved->configured path rewrite table BEFORE
+        # scheduling — the OS backend (fsevents on macOS, symlink-transparent
+        # on Linux too) reports events at the REALPATH regardless of which
+        # path string we hand ``observer.schedule``, so every reported event
+        # path needs rewriting back onto what the operator actually wrote in
+        # ``fs_watch.paths`` for a ``matcher: {path: <configured>}`` to match.
+        self._path_rewrites = []
+        for configured in self._paths:
+            resolved = os.path.realpath(configured)
+            normalized_configured = os.path.normpath(configured)
+            if resolved != normalized_configured:
+                self._path_rewrites.append((resolved, normalized_configured))
+
         handler = _build_handler(FileSystemEventHandler, self)
         observer = Observer()
         for path in self._paths:
@@ -169,6 +204,20 @@ class FsWatcher:
         observer.start()
         self._observer = observer
         self._started = True
+
+    def _rewrite_path(self, path: str) -> str:
+        """#2623: rewrite a fired event's (possibly symlink-resolved) path back
+        onto the operator's configured ``fs_watch.paths`` prefix, so
+        ``matcher: {path: <configured>}`` matches regardless of a
+        macOS-``/tmp``-style symlink in the watched path. A path with no
+        matching resolved-prefix (no symlink was involved) passes through
+        unchanged."""
+        for resolved, configured in self._path_rewrites:
+            if path == resolved:
+                return configured
+            if path.startswith(resolved + os.sep):
+                return configured + path[len(resolved):]
+        return path
 
     # ── thread->async bridge (called from the watchdog OS thread) ──────────
 
@@ -181,6 +230,12 @@ class FsWatcher:
         loop = self._loop
         if loop is None:
             return  # stopped/never started — defensive, should not happen mid-callback
+        # #2623: rewrite the (possibly symlink-resolved) path back onto the
+        # operator's configured prefix BEFORE it ever reaches hook_trigger —
+        # _path_rewrites is built once in start() (loop thread) before the
+        # observer thread is started, so this read-only lookup from the
+        # watchdog thread is race-free (no further writes after start()).
+        path = self._rewrite_path(path)
         try:
             loop.call_soon_threadsafe(self._enqueue, event_type, path)
         except RuntimeError:

--- a/tests/test_2608_h4_fs_watcher.py
+++ b/tests/test_2608_h4_fs_watcher.py
@@ -18,7 +18,11 @@ Tier 2 (OS invariant): a REAL ``watchdog`` ``Observer`` + REAL file writes
   modify fires with correct path + event_type; a burst of writes to one path
   debounces to ONE fire; a path NOT under a watched dir never fires; empty
   ``paths`` config -> the watcher never starts (byte-identical to pre-H4);
-  ``watchdog`` not importable -> warn + no-op (never raises).
+  ``watchdog`` not importable -> warn + no-op (never raises); (#2623) a
+  ``fs_watch.paths`` entry given via a SYMLINK reports events with the path
+  rewritten back onto the operator's configured (symlink) prefix, so a
+  ``matcher: {path: <configured>}`` glob still matches — closing the macOS
+  ``/tmp`` -> ``/private/tmp`` footgun.
 
 Policy (docs/deep-dives/contributing/testing.md): real instances only — no
 ``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. ``pytest.importorskip``
@@ -27,6 +31,7 @@ guards every test that needs a real ``watchdog`` Observer.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from pathlib import Path
 
@@ -158,6 +163,49 @@ async def test_real_file_write_fires_hook_with_path_and_event_type(tmp_path):
         assert template_vars["point"] == "file_changed"
         assert Path(template_vars["path"]) == target
         assert template_vars["event_type"] in ("created", "modified")
+    finally:
+        await watcher.aclose()
+
+
+@pytest.mark.asyncio
+async def test_symlinked_watch_path_reports_events_under_the_configured_prefix(tmp_path):
+    """Tier 2: (#2623) the macOS ``/tmp`` -> ``/private/tmp`` footgun, reproduced
+    with a real symlink (not OS-specific — this works the same on Linux). A
+    ``fs_watch.paths`` entry given via a symlink (mirroring an operator writing
+    ``paths: ['/tmp/x']`` on macOS) must report the fired event's ``path`` under
+    the CONFIGURED (symlink) prefix, not the OS-resolved realpath — so a naive
+    ``matcher: {path: '<configured>/**'}`` glob (evaluated against the
+    configured prefix an operator actually wrote) matches, instead of silently
+    never firing because the reported path secretly points at the resolved
+    target directory."""
+    real_dir = tmp_path / "real_target"
+    real_dir.mkdir()
+    symlink_dir = tmp_path / "watched_via_symlink"
+    os.symlink(real_dir, symlink_dir)
+    configured_path = str(symlink_dir)
+
+    trigger = _Recorder()
+    watcher = FsWatcher(paths=[configured_path], hook_trigger=trigger, debounce_seconds=0.05)
+    try:
+        await watcher.start()
+        assert watcher.is_started()
+
+        target = symlink_dir / "a.txt"
+        target.write_text("hello")
+
+        await _wait_for(lambda: len(trigger.calls) >= 1)
+        (point, template_vars) = trigger.calls[0]
+        assert point == "file_changed"
+        # The reported path must be reachable under the OPERATOR'S configured
+        # (symlink) prefix — not silently swapped for the OS-resolved realpath.
+        reported_path = template_vars["path"]
+        assert reported_path.startswith(configured_path), (
+            f"expected {reported_path!r} to start with the configured prefix "
+            f"{configured_path!r} — the #2623 symlink-normalization contract"
+        )
+        # The load-bearing consumer-facing proof: a matcher glob written
+        # against the operator's CONFIGURED path actually matches the event.
+        assert matches({"path": f"{configured_path}/**"}, template_vars) is True
     finally:
         await watcher.aclose()
 

--- a/tests/test_2608_run_loop_pickup.py
+++ b/tests/test_2608_run_loop_pickup.py
@@ -1,0 +1,167 @@
+"""Tests for #2608 — closing the run-loop-pickup coverage gap.
+
+A live-dogfood + investigation of the external-event->hooks arc (#2608)
+confirmed BY REPRODUCTION that a background-fired external-event hook push
+(``wake=True``) wakes an IDLE ``session.run()`` loop and runs a
+hook-attributed turn. But the existing H1/H4 unit tests
+(``tests/test_2608_h1_mcp_resource_updated_hook.py``,
+``tests/test_2608_h4_fs_watcher.py``) call the producer/dispatch path
+directly and only assert the templated push LANDS in ``session.inbox`` —
+they never start ``session.run()``, so they cannot observe the run-loop
+actually picking the push up off the inbox and executing a turn. That is
+the "unit-green != live-works" hole this file closes.
+
+This test starts a REAL ``Session.run()`` as a background task, lets it go
+idle, fires a REAL ``dispatch_external_event`` call (the exact public entry
+point the FsWatcher drain task / MCP resources/updated bridge / cron+webhook
+ingress all use — see ``Session.dispatch_external_event``'s docstring) from a
+separate background task, and asserts a turn ACTUALLY RAN: a ``turn_started``
+event with ``kind == "hook"`` was emitted and the hook-attributed
+router-loop turn completed (``turn_settled``), via the session's public
+event log / inbox surface — never private state.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. The ONLY faked
+boundary is the LLM call itself (``reyn.runtime.router_loop.call_llm_tools``),
+replaced with a real async stub function — the same established idiom
+``tests/test_1800_wake_drain.py`` uses to drive ``session.run()`` end-to-end
+without a live model.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _text_result(text: str = "ok") -> LLMToolCallResult:
+    """Real LLMToolCallResult that makes RouterLoop emit a text reply."""
+    return LLMToolCallResult(
+        content=text,
+        tool_calls=[],
+        finish_reason="stop",
+        usage=_EMPTY_USAGE,
+    )
+
+
+def _make_llm_stub_fn(result: LLMToolCallResult):  # type: ignore[no-untyped-def]
+    """A real async callable mimicking ``call_llm_tools`` — the LLM boundary is
+    the only thing allowed to be faked (policy); the run-loop / dispatch /
+    hook machinery below it all run for real."""
+
+    async def _stub(**kwargs) -> LLMToolCallResult:  # noqa: ANN202
+        return result
+
+    return _stub
+
+
+async def _wait_for(predicate, *, attempts: int = 200, delay: float = 0.02) -> None:
+    """Poll ``predicate()`` until True or give up — the hook fire and the
+    run-loop's pickup of it both happen asynchronously off separate tasks."""
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+def _make_session(tmp_path: Path, *, hooks_config: list) -> Session:
+    return Session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_external_event_wakes_idle_run_loop_and_runs_hook_turn(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: THE run-loop-pickup proof the H1/H4 unit tests stop one step
+    short of. A REAL ``Session.run()`` idles on its inbox; a background-fired
+    ``dispatch_external_event`` (the exact call FsWatcher / the MCP bridge /
+    cron+webhook ingress all make) must not just land a message in the
+    inbox — it must WAKE the run-loop and RUN a hook-attributed turn:
+    ``turn_started`` with ``kind == "hook"`` is emitted, and the turn
+    completes (``turn_settled``) via the REAL router loop (LLM boundary
+    faked only)."""
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _make_llm_stub_fn(_text_result("hook turn ran")),
+    )
+
+    hooks_config = [
+        {
+            "on": "mcp_resource_updated",
+            "template_push": {
+                "message": "[{{ server }}] {{ uri }} updated",
+                "wake": True,
+            },
+        },
+    ]
+    session = _make_session(tmp_path, hooks_config=hooks_config)
+
+    run_task = asyncio.create_task(session.run())
+    try:
+        # Let the loop reach its idle blocking-get with nothing to do yet.
+        await asyncio.sleep(0.1)
+        assert session.inbox.empty()
+        hook_turns_before = [
+            e for e in session._chat_events.all()
+            if e.type == "turn_started" and e.data.get("kind") == "hook"
+        ]
+        assert hook_turns_before == []
+
+        # From a SEPARATE background task — the same shape a real external
+        # producer (FsWatcher's drain task, the MCP receive-loop task) uses:
+        # it never runs on the session's own run-loop task.
+        async def _fire() -> None:
+            await session.dispatch_external_event(
+                "mcp_resource_updated",
+                {"server": "srv", "uri": "resource://counter"},
+            )
+
+        fire_task = asyncio.create_task(_fire())
+        await fire_task
+
+        # The load-bearing assertion: a turn ACTUALLY RAN off the run-loop
+        # picking the push up — not just "the message sits in the inbox".
+        await _wait_for(
+            lambda: any(
+                e.type == "turn_started" and e.data.get("kind") == "hook"
+                for e in session._chat_events.all()
+            )
+        )
+        (hook_turn_started,) = [
+            e for e in session._chat_events.all()
+            if e.type == "turn_started" and e.data.get("kind") == "hook"
+        ]
+        assert hook_turn_started.data.get("kind") == "hook"
+
+        # And the turn actually completed (the router loop ran to settlement,
+        # not just got dispatched and stalled).
+        await _wait_for(
+            lambda: any(
+                e.type == "turn_settled" and e.data.get("kind") == "hook"
+                for e in session._chat_events.all()
+            )
+        )
+
+        # The templated hook push was consumed as the turn's trigger — the
+        # inbox drained it, it did not just sit there waiting to be read.
+        assert session.inbox.empty()
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)


### PR DESCRIPTION
**[lead-coder]** (shipping [per-PR-coder]'s completed implementation — agent stalled at a backgrounded pytest before committing; committed+pushed by lead) — `part of #2608`, `fixes #2623`.

## What this adds
1. **Run-loop-pickup coverage** — a Tier-2 test that starts `session.run()` and fires an external-event hook from a background task, asserting a turn ACTUALLY RUNS (`turn_started{kind:hook}` + the push processed), not just that it lands in the inbox. Closes the coverage hole the live dogfood exposed (the impl was confirmed correct by reproduction; this is the missing assertion).
2. **#2623 fs_watch path normalization** — watched paths are realpath-resolved so an operator's `matcher: {path: ...}` matches despite symlinks (macOS /tmp→/private/tmp).

## Gate status
Deferred pytest to CI (agent stalled). Lead verifies CI green + reviews before merge.

## Test plan
- [ ] pytest — CI (lead verifies)
- [x] New `tests/test_2608_run_loop_pickup.py` (real Session + real run() loop) + fs_watch symlink test