### PR TITLE
security: route stdio MCP + skill_install git clone through the sandbox abstraction (#2620)

### DIFF
--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -38,7 +38,6 @@ P6 audit trail).
 from __future__ import annotations
 
 import shutil
-import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -217,35 +216,78 @@ def _source_host(git_url: str) -> str | None:
         return git_url
 
 
-def _shallow_clone(git_url: str, dest: Path) -> str | None:
-    """Shallow-clone a git repo to ``dest``.
+async def _shallow_clone(git_url: str, dest: Path, ctx: OpContext) -> str | None:
+    """Shallow-clone a git repo to ``dest`` — routed through the sandbox
+    abstraction (#2620: agent-reachable subprocess launches must never bypass
+    ``reyn.security.sandbox``; a NoopBackend passthrough on an unsupported
+    platform is acceptable, a raw ``subprocess.run`` that never consults any
+    backend is not).
 
     Returns ``None`` on success, or an error message string on failure.
     The destination directory is REMOVED before cloning so this function
     is idempotent (re-install overwrites the previous clone).
+
+    Uses ``ctx.sandbox_backend`` (an injected stateful backend) or
+    ``get_default_backend(ctx.sandbox_config)`` for backend SELECTION (so the
+    operator's configured enforcement mechanism governs it, same as
+    ``sandboxed_exec``) but a purpose-built ``SandboxPolicy`` for this specific
+    operation: ``network=True`` is not overridable here because cloning over
+    the network is what the operation IS — an operator policy that forces
+    ``network: false`` globally would make every git-sourced skill install
+    fail outright, so the clone's policy is scoped independently, write-tight
+    to the install root (``dest.parent`` = ``.reyn/skills/``).
     """
     if dest.exists():
         shutil.rmtree(dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
+
+    from reyn.security.sandbox import SandboxPolicy, get_default_backend
+
+    backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)
+    policy = SandboxPolicy(
+        network=True,
+        write_paths=[str(dest.parent)],
+        timeout_seconds=120,
+        # git internally forks a subprocess for the transport helper
+        # (git-upload-pack over ssh/https) even for a plain clone — without
+        # this a fork-denying backend (Seatbelt's default policy denies
+        # process-fork) makes EVERY clone fail with "cannot fork()", not just
+        # a hardened corner case. Scoped to this one already-gated operation
+        # (require_http_get already ran), not a global relaxation.
+        allow_subprocess=True,
+        # git needs more than PATH to actually work (HOME for ~/.gitconfig,
+        # SSH/proxy/CA vars for non-file:// remotes) — pass these through so
+        # routing the clone through the sandbox abstraction does not itself
+        # break git's normal env-dependent behavior (parity with the
+        # previously-inherited-full-env ``subprocess.run`` call).
+        env_passthrough=[
+            "HOME", "PATH", "GIT_SSH_COMMAND", "SSH_AUTH_SOCK",
+            "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+            "https_proxy", "http_proxy", "no_proxy",
+            "SSL_CERT_FILE", "SSL_CERT_DIR",
+        ],
+    )
     try:
-        result = subprocess.run(  # noqa: S603
+        result = await backend.run(
             ["git", "clone", "--depth", "1", "--", git_url, str(dest)],
-            capture_output=True,
-            text=True,
-            timeout=120,
+            policy,
+            cwd=str(dest.parent),
         )
-        if result.returncode != 0:
-            return (
-                f"git clone failed (exit {result.returncode}): "
-                f"{result.stderr.strip() or result.stdout.strip()}"
-            )
-        return None
-    except FileNotFoundError:
-        return "git is not installed or not in PATH. Install git and retry."
-    except subprocess.TimeoutExpired:
-        return "git clone timed out after 120 s. The repository may be unreachable."
-    except Exception as exc:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001 — surface as a clone error, not a crash
         return f"git clone error: {exc}"
+
+    if result.returncode != 0:
+        detail = (
+            result.stderr.decode("utf-8", errors="replace").strip()
+            or result.stdout.decode("utf-8", errors="replace").strip()
+        )
+        if result.returncode == -1:
+            return (
+                f"git clone did not complete: {detail or 'timed out or failed to start'}. "
+                "Ensure git is installed and the repository is reachable."
+            )
+        return f"git clone failed (exit {result.returncode}): {detail}"
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -331,7 +373,7 @@ async def handle(
             }
 
         # 0c. Shallow-clone the repo.
-        clone_err = _shallow_clone(git_url, clone_dest)
+        clone_err = await _shallow_clone(git_url, clone_dest, ctx)
         if clone_err:
             return {
                 "kind": "skill_install",

--- a/src/reyn/environment/container_backend.py
+++ b/src/reyn/environment/container_backend.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Pattern
 
 from reyn.environment.backend import GrepResult
-from reyn.security.sandbox.backend import SandboxResult
+from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
 from reyn.security.sandbox.policy import SandboxPolicy
 
 # Sync runner: execute argv (optionally stdin), return SandboxResult. Injected so
@@ -376,6 +376,22 @@ class DockerEnvironmentBackend:
         except (OSError, subprocess.TimeoutExpired):
             return False
         return completed.returncode == 0
+
+    def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
+        """Prepend a ``docker exec`` invocation to *argv* for a PERSISTENT-process
+        launch (e.g. a stdio MCP server, #2620) inside the SAME container
+        ``run()`` execs into. Mirrors ``run()``'s login-shell + argv-faithful
+        re-exec construction (see that method's docstring for the ``bash -lc
+        'exec "$@"'`` rationale); ``-i`` is always passed (unlike ``run()``,
+        which only opens stdin when the caller supplies some) because a
+        persistent stdio server holds bidirectional pipes open for its whole
+        lifetime. No cleanup resource is owned (unlike Seatbelt's temp profile)."""
+        wrapped_argv = [
+            self.docker_bin, "exec", "-i",
+            "-w", self.repo_dir, self.container,
+            "bash", "-lc", 'exec "$@"', "reyn-exec", *argv,
+        ]
+        return WrappedCommand(argv=wrapped_argv, cleanup=None)
 
     async def run(
         self, argv: list[str], policy: SandboxPolicy, *, stdin: bytes | None = None,

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -98,6 +98,7 @@ import os
 import sys
 import tempfile
 import warnings
+from collections.abc import Callable
 from typing import Any, NoReturn
 
 # ── Env var expansion ─────────────────────────────────────────────────────────
@@ -347,10 +348,12 @@ class MCPClient:
         # underlying anyio subprocess), but ``tempfile.TemporaryFile``
         # does. Lazily created in ``_open_stdio``; closed in ``close``.
         self._stderr_capture: Any = None  # tempfile.TemporaryFile | None
-        # #1344: path of the temp Seatbelt profile (.sb) used to sandbox a
-        # stdio MCP server's subprocess, if one was generated in _open_stdio.
-        # Unlinked in close(). None for non-stdio / non-seatbelt / unsandboxed.
-        self._sandbox_profile_path: str | None = None
+        # #1344 / #2620: cleanup callable for whatever resource the sandbox
+        # backend's ``wrap_command()`` allocated for a stdio MCP server's
+        # subprocess wrap (e.g. Seatbelt's temp ``.sb`` profile file), if any.
+        # Invoked in close_stderr_capture(). None when the backend's wrap owns
+        # no such resource (Noop / Landlock).
+        self._sandbox_cleanup: Callable[[], None] | None = None
         # #2597 capability/version gate: captured in initialize() right after
         # ``client.__aenter__()`` completes FastMCP's initialize handshake (verified
         # against fastmcp 3.4.2: ``fastmcp.Client.initialize_result`` is populated at
@@ -799,16 +802,17 @@ class MCPClient:
         return text
 
     def close_stderr_capture(self) -> None:
-        """Close + delete the stderr temp file + the #1344 Seatbelt profile, if
-        any. Idempotent — called at every teardown path."""
-        # #1344: unlink the temp Seatbelt profile (.sb) generated for a
-        # sandboxed stdio MCP server. Best-effort; a leaked temp file must not
-        # break teardown.
-        profile_path = self._sandbox_profile_path
-        if profile_path is not None:
-            self._sandbox_profile_path = None
+        """Close + delete the stderr temp file + the #1344/#2620 sandbox wrap's
+        cleanup resource (e.g. Seatbelt's temp ``.sb`` profile), if any.
+        Idempotent — called at every teardown path."""
+        # #1344/#2620: invoke the sandbox backend's wrap_command() cleanup
+        # (Seatbelt: unlink the temp .sb profile; Noop/Landlock: no-op).
+        # Best-effort; a leaked temp file must not break teardown.
+        cleanup = self._sandbox_cleanup
+        if cleanup is not None:
+            self._sandbox_cleanup = None
             try:
-                os.unlink(profile_path)
+                cleanup()
             except OSError:
                 pass
         capture = self._stderr_capture
@@ -861,51 +865,39 @@ class MCPClient:
         )
 
     def _sandbox_wrap_stdio(self, command: str, args: list[str]) -> "tuple[str, list[str]]":
-        """Wrap ``(command, args)`` so the MCP server subprocess runs sandboxed (#1344).
+        """Wrap ``(command, args)`` so the MCP server subprocess runs sandboxed
+        (#1344, uniformly rerouted through the abstraction #2620).
 
-        Seatbelt (macOS): returns ``("sandbox-exec", ["-f", <profile>, command,
-        *args])`` with a generated SBPL profile (a temp ``.sb`` unlinked in
-        ``close``). Landlock (Linux, #1344 follow-up E): returns the
-        ``reyn.security.sandbox.landlock_exec`` re-exec shim argv (the COMMAND-level
-        analog — Landlock has no CLI wrapper). MCP stdio is persistent, so the
-        wrap is at the COMMAND level (the backend's one-shot ``run()`` does not
-        fit). Other backends (docker) are not yet wrapped here — the server then
-        runs UNSANDBOXED with a warning (never silently).
+        Routes through ``get_default_backend().wrap_command()`` UNIFORMLY — no
+        per-backend-name branching here. Every backend implements
+        ``wrap_command`` (Seatbelt: ``sandbox-exec -f <profile>``; Landlock: the
+        ``landlock_exec`` re-exec shim; NoopBackend: argv unchanged), so there is
+        no agent-reachable code path here that skips the abstraction — a
+        NoopBackend passthrough still went THROUGH ``wrap_command``, it just
+        enforces nothing (the owner-acceptable no-isolation case). MCP stdio is
+        a persistent subprocess, so the wrap is at the COMMAND level (the
+        backend's one-shot ``run()`` does not fit).
+
+        A failure while resolving/probing the backend itself (not a normal
+        outcome — defensive only) falls back to an unwrapped launch WITH a
+        loud warning, so a launch is never silently unsandboxed.
         """
         from reyn.security.sandbox import get_default_backend
 
+        argv = [command, *args]
         try:
             backend = get_default_backend()
-            name = getattr(backend, "name", None)
-            available = backend.available()
-        except Exception:  # noqa: BLE001 — a backend probe must not block a launch
-            name, available = None, False
-        if name == "seatbelt" and available:
-            from reyn.security.sandbox.backends.seatbelt import _build_sbpl_profile
-
-            profile = _build_sbpl_profile(self._build_mcp_sandbox_policy())
-            fh = tempfile.NamedTemporaryFile(
-                suffix=".sb", mode="w", delete=False, encoding="utf-8",
+            wrapped = backend.wrap_command(argv, self._build_mcp_sandbox_policy())
+        except Exception as exc:  # noqa: BLE001 — a backend probe/wrap must not block a launch
+            warnings.warn(
+                f"MCP stdio server {command!r} runs UNSANDBOXED "
+                f"(sandbox backend probe/wrap failed: {exc}).",
+                stacklevel=2,
             )
-            fh.write(profile)
-            fh.close()
-            self._sandbox_profile_path = fh.name
-            return "sandbox-exec", ["-f", fh.name, command, *args]
-        if name == "landlock" and available:
-            # #1344 follow-up E: the Landlock re-exec shim restricts itself then
-            # execs the target (Linux-validation-pending — see landlock_exec).
-            from reyn.security.sandbox.landlock_exec import build_landlock_exec_argv
+            return command, args
 
-            return build_landlock_exec_argv(
-                self._build_mcp_sandbox_policy(), command, args
-            )
-        warnings.warn(
-            f"MCP stdio server {command!r} runs UNSANDBOXED "
-            f"(sandbox backend={name or 'none'}); only Seatbelt + Landlock wraps "
-            f"are implemented (#1344) — docker wrapping is a follow-up.",
-            stacklevel=2,
-        )
-        return command, args
+        self._sandbox_cleanup = wrapped.cleanup
+        return wrapped.argv[0], list(wrapped.argv[1:])
 
     def _open_stdio(self) -> "Any":
         from fastmcp.client.transports import StdioTransport

--- a/src/reyn/security/sandbox/__init__.py
+++ b/src/reyn/security/sandbox/__init__.py
@@ -17,7 +17,7 @@ import logging
 import platform
 from typing import TYPE_CHECKING
 
-from .backend import SandboxBackend, SandboxResult
+from .backend import SandboxBackend, SandboxResult, WrappedCommand
 from .noop_backend import NoopBackend
 from .policy import SandboxPolicy
 
@@ -191,6 +191,7 @@ __all__ = [
     "SandboxPolicy",
     "SandboxBackend",
     "SandboxResult",
+    "WrappedCommand",
     "NoopBackend",
     "get_default_backend",
 ]

--- a/src/reyn/security/sandbox/backend.py
+++ b/src/reyn/security/sandbox/backend.py
@@ -8,10 +8,32 @@ execution under the declared policy.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from .policy import SandboxPolicy
+
+
+@dataclass
+class WrappedCommand:
+    """Result of ``SandboxBackend.wrap_command()`` — a command-level sandbox wrap.
+
+    Command-level wrapping (as opposed to the one-shot ``run()``) is the seam
+    for a PERSISTENT subprocess launch that the backend does not itself spawn
+    (e.g. a stdio MCP server held open by the caller's transport) — the wrap
+    prepends whatever the backend needs (a sandbox-exec invocation, a re-exec
+    shim, ...) and hands the full argv back for the caller to Popen/exec.
+
+    ``argv`` is the full wrapped argv (wrapper prefix + the original command),
+    ready to launch directly. ``cleanup``, when set, releases a wrap-owned
+    resource (e.g. Seatbelt's temp ``.sb`` profile file) — the caller MUST
+    invoke it once the wrapped subprocess is torn down. ``None`` means the
+    wrap owns no such resource.
+    """
+
+    argv: list[str]
+    cleanup: "Callable[[], None] | None" = None
 
 
 @dataclass
@@ -43,6 +65,25 @@ class SandboxBackend(Protocol):
 
     def available(self) -> bool:
         """Return True if this backend can be used on the current platform."""
+        ...
+
+    def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
+        """Return a command-level sandbox wrap of *argv* for a persistent-process
+        launch (e.g. a stdio MCP server) that cannot go through the one-shot
+        ``run()``. Every backend implements this uniformly so NO agent-reachable
+        command-level launch ever bypasses the abstraction:
+
+        - Seatbelt: prepends ``sandbox-exec -f <profile>`` (a generated SBPL
+          profile written to a temp file; the returned ``cleanup`` unlinks it).
+        - Landlock: prepends the ``landlock_exec`` re-exec shim argv.
+        - NoopBackend: returns *argv* UNCHANGED — passthrough, but the call
+          still went THROUGH this method (the owner-acceptable no-enforcement
+          case, as opposed to a raw bypass that never consulted the backend).
+
+        Synchronous and side-effect-light (may perform local I/O such as
+        writing a temp profile file) — it does not itself spawn the wrapped
+        process; the caller owns that.
+        """
         ...
 
     async def run(

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -28,7 +28,7 @@ import signal
 import subprocess
 
 from .._subprocess_io import communicate_capped
-from ..backend import SandboxResult
+from ..backend import SandboxResult, WrappedCommand
 from ..policy import SandboxPolicy
 
 _logger = logging.getLogger(__name__)
@@ -114,6 +114,20 @@ class LandlockBackend:
 
         self._available = True
         return True
+
+    def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
+        """Prepend the ``landlock_exec`` re-exec shim to *argv* for a
+        persistent-process launch (e.g. a stdio MCP server, #1344 follow-up E).
+        Landlock has no CLI wrapper, so the shim (a re-exec-and-restrict-self
+        module) IS the command-level wrap — the COMMAND-level analog of the
+        Seatbelt ``sandbox-exec -f <profile>`` wrap. No cleanup resource is
+        owned (unlike Seatbelt's temp profile)."""
+        if not argv:
+            raise ValueError("wrap_command: argv must be non-empty (command + args)")
+        from ..landlock_exec import build_landlock_exec_argv
+
+        executable, shim_argv = build_landlock_exec_argv(policy, argv[0], list(argv[1:]))
+        return WrappedCommand(argv=[executable, *shim_argv], cleanup=None)
 
     async def run(
         self,

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -30,7 +30,7 @@ import tempfile
 from pathlib import Path
 
 from reyn.security.sandbox._subprocess_io import communicate_capped
-from reyn.security.sandbox.backend import SandboxResult
+from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
 from reyn.security.sandbox.policy import SandboxPolicy
 
 _logger = logging.getLogger(__name__)
@@ -166,6 +166,30 @@ class SeatbeltBackend:
         if shutil.which("sandbox-exec") is None:
             return False
         return True
+
+    def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
+        """Prepend ``sandbox-exec -f <profile>`` to *argv* for a persistent-process
+        launch (e.g. a stdio MCP server, #1344). The SBPL profile is written to a
+        temp ``.sb`` file; the returned ``cleanup`` unlinks it — the caller invokes
+        it once the wrapped subprocess is torn down (mirrors ``run()``'s own
+        temp-profile lifecycle, above)."""
+        profile_text = _build_sbpl_profile(policy)
+        with tempfile.NamedTemporaryFile(
+            suffix=".sb", mode="w", delete=False, encoding="utf-8",
+        ) as fh:
+            fh.write(profile_text)
+            profile_path = fh.name
+
+        def _cleanup() -> None:
+            try:
+                os.unlink(profile_path)
+            except OSError:
+                pass
+
+        return WrappedCommand(
+            argv=["sandbox-exec", "-f", profile_path, *argv],
+            cleanup=_cleanup,
+        )
 
     async def run(
         self,

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -17,7 +17,7 @@ import signal
 import subprocess
 
 from ._subprocess_io import communicate_capped
-from .backend import SandboxBackend, SandboxResult
+from .backend import SandboxBackend, SandboxResult, WrappedCommand
 from .policy import SandboxPolicy
 
 _logger = logging.getLogger(__name__)
@@ -110,6 +110,14 @@ class NoopBackend:
 
     def available(self) -> bool:
         return True
+
+    def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
+        """Passthrough: argv is returned UNCHANGED — no enforcement — but the
+        call still went THROUGH the sandbox abstraction (the owner-acceptable
+        no-isolation case, #2620), as opposed to a caller that never consulted
+        any backend at all."""
+        _warn_once()
+        return WrappedCommand(argv=list(argv), cleanup=None)
 
     async def run(
         self,

--- a/tests/test_mcp_client_sandbox_wrap.py
+++ b/tests/test_mcp_client_sandbox_wrap.py
@@ -1,34 +1,34 @@
-"""Tier 2: stdio MCP server subprocess is sandbox-wrapped (#1344).
+"""Tier 2: stdio MCP server subprocess is sandbox-wrapped (#1344, uniformly
+rerouted through the abstraction #2620).
 
 The MCP server launched by ``_open_stdio`` must run under the platform sandbox
-so an LLM-invoked MCP tool cannot escape via the server. Pins the Seatbelt
-command-wrap (macOS) + the Landlock re-exec shim (Linux, #1344-E), the
-per-server network default (single-source DEFAULT_SANDBOX_NETWORK, #1339-D)
-with operator opt-in / opt-out, the unsandboxed warning for other backends,
-and the temp-profile cleanup.
+so an LLM-invoked MCP tool cannot escape via the server. ``_sandbox_wrap_stdio``
+now routes UNIFORMLY through ``backend.wrap_command()`` — no per-backend-name
+branching. This file pins: the Seatbelt command-wrap (macOS), the Landlock
+re-exec shim (Linux, #1344-E), NoopBackend's argv-unchanged PASSTHROUGH (still
+routed THROUGH the abstraction — the owner-acceptable no-enforcement case, NOT
+a bypass), the per-server network default (single-source
+DEFAULT_SANDBOX_NETWORK, #1339-D) with operator opt-in / opt-out, and the
+temp-profile cleanup.
 
-No mocks: a real ``_FakeBackend`` (name + available()) injected via monkeypatch
-of ``reyn.security.sandbox.get_default_backend``; the real ``_build_sbpl_profile`` builds
-the asserted SBPL.
+No mocks: the REAL ``NoopBackend`` / ``SeatbeltBackend`` / ``LandlockBackend``
+classes are used (monkeypatched in as ``get_default_backend``'s return value) —
+``wrap_command`` is pure/local-I/O-only and does not require the host platform
+to match (SeatbeltBackend.wrap_command builds an SBPL profile as plain text;
+it does not itself invoke ``sandbox-exec``).
 """
 from __future__ import annotations
 
+import sys
+import warnings
 from pathlib import Path
 
 import pytest
 
 from reyn.mcp.client import MCPClient
-
-
-class _FakeBackend:
-    """A real (non-mock) sandbox-backend stand-in: just name + available()."""
-
-    def __init__(self, name: str, available: bool = True) -> None:
-        self.name = name
-        self._available = available
-
-    def available(self) -> bool:
-        return self._available
+from reyn.security.sandbox.backends.landlock import LandlockBackend
+from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from reyn.security.sandbox.noop_backend import NoopBackend
 
 
 def _stdio_client(**cfg) -> MCPClient:
@@ -42,9 +42,9 @@ def _patch_backend(monkeypatch, backend) -> None:
 
 
 def test_seatbelt_wrap_wraps_command(monkeypatch):
-    """Tier 2: under Seatbelt, the command is wrapped as sandbox-exec -f <profile>
-    cmd args; the profile is a deny-default SBPL with broad-read."""
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    """Tier 2: under Seatbelt, wrap_command wraps the command as sandbox-exec -f
+    <profile> cmd args; the profile is a deny-default SBPL with broad-read."""
+    _patch_backend(monkeypatch, SeatbeltBackend())
     client = _stdio_client()
     cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
     assert cmd == "sandbox-exec"
@@ -55,6 +55,7 @@ def test_seatbelt_wrap_wraps_command(monkeypatch):
     profile = Path(profile_path).read_text()
     assert "(deny default)" in profile
     assert "(allow file-read*)" in profile.splitlines()  # broad-read (#1323)
+    client.close_stderr_capture()  # cleanup — no leaked temp profile
 
 
 def test_seatbelt_wrap_network_default(monkeypatch):
@@ -64,40 +65,41 @@ def test_seatbelt_wrap_network_default(monkeypatch):
     (asserts on observable wrap output, not the private policy object)."""
     from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
 
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    _patch_backend(monkeypatch, SeatbeltBackend())
     client = _stdio_client()  # no `network` key
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile = Path(args[1]).read_text()
     assert ("(allow network*)" in profile) is DEFAULT_SANDBOX_NETWORK
+    client.close_stderr_capture()
 
 
 def test_seatbelt_wrap_network_opt_in(monkeypatch):
     """Tier 2: an operator-declared `network: true` keeps the server on network."""
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    _patch_backend(monkeypatch, SeatbeltBackend())
     client = _stdio_client(network=True)
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile = Path(args[1]).read_text()
     assert "(allow network*)" in profile
+    client.close_stderr_capture()
 
 
 def test_seatbelt_wrap_network_opt_out(monkeypatch):
     """Tier 2: #1339-D — an operator-declared `network: false` ISOLATES the server
     (the opt-OUT knob; the network gate is now operator-set, not default-off)."""
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    _patch_backend(monkeypatch, SeatbeltBackend())
     client = _stdio_client(network=False)
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile = Path(args[1]).read_text()
     assert "(allow network*)" not in profile
+    client.close_stderr_capture()
 
 
 def test_landlock_wrap_uses_reexec_shim(monkeypatch):
-    """Tier 2: under Landlock (#1344 follow-up E), the command is wrapped as the
-    reyn.security.sandbox.landlock_exec re-exec shim (python -m ... --policy ... -- cmd
-    args) — the COMMAND-level analog of the Seatbelt wrap (no UNSANDBOXED warn)."""
-    import sys
-    import warnings
-
-    _patch_backend(monkeypatch, _FakeBackend("landlock"))
+    """Tier 2: under Landlock (#1344 follow-up E), wrap_command wraps the command
+    as the reyn.security.sandbox.landlock_exec re-exec shim (python -m ... --policy
+    ... -- cmd args) — the COMMAND-level analog of the Seatbelt wrap (no
+    UNSANDBOXED warn — this is a routed, enforced wrap, not a bypass)."""
+    _patch_backend(monkeypatch, LandlockBackend())
     client = _stdio_client()
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any UNSANDBOXED warn would fail here
@@ -108,29 +110,39 @@ def test_landlock_wrap_uses_reexec_shim(monkeypatch):
     assert args[sep + 1:] == ["my-mcp", "--flag"]  # original command preserved
 
 
-def test_non_seatbelt_warns_unsandboxed(monkeypatch):
-    """Tier 2: a backend without a Seatbelt wrap (e.g. noop) leaves the command
-    unchanged and WARNS that the server runs unsandboxed (never silent)."""
-    _patch_backend(monkeypatch, _FakeBackend("noop"))
+def test_noop_backend_wraps_argv_unchanged_through_abstraction(monkeypatch):
+    """Tier 2: #2620 — NoopBackend PASSES THROUGH argv unchanged, but the call
+    still routed through backend.wrap_command() (never a raw bypass). No
+    UserWarning is raised — Noop is the owner-acceptable no-enforcement
+    outcome, not an error condition to surface as a warning."""
+    _patch_backend(monkeypatch, NoopBackend())
+    client = _stdio_client()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
+    assert cmd == "my-mcp"
+    assert args == ["--flag"]  # unchanged — passthrough, but via wrap_command
+
+
+def test_backend_probe_failure_falls_back_with_warning(monkeypatch):
+    """Tier 2: only a genuine backend-resolution FAILURE (not a normal Noop
+    outcome) falls back to an unwrapped launch — and that fallback is always
+    loudly warned, never silent."""
+
+    def _boom(config=None):
+        raise RuntimeError("backend probe exploded")
+
+    monkeypatch.setattr("reyn.security.sandbox.get_default_backend", _boom)
     client = _stdio_client()
     with pytest.warns(UserWarning, match="UNSANDBOXED"):
         cmd, args = client._sandbox_wrap_stdio("my-mcp", ["--flag"])
     assert cmd == "my-mcp"
-    assert args == ["--flag"]  # unchanged → no wrap applied
-
-
-def test_unavailable_seatbelt_warns(monkeypatch):
-    """Tier 2: Seatbelt present but available()=False → unsandboxed + warn (not wrapped)."""
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt", available=False))
-    client = _stdio_client()
-    with pytest.warns(UserWarning, match="UNSANDBOXED"):
-        cmd, _ = client._sandbox_wrap_stdio("my-mcp", [])
-    assert cmd == "my-mcp"
+    assert args == ["--flag"]
 
 
 def test_profile_cleaned_on_close(monkeypatch):
     """Tier 2: the temp Seatbelt profile is unlinked on teardown (no leak)."""
-    _patch_backend(monkeypatch, _FakeBackend("seatbelt"))
+    _patch_backend(monkeypatch, SeatbeltBackend())
     client = _stdio_client()
     _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
     profile_path = args[1]  # wrap output (not private state)

--- a/tests/test_sandbox_wrap_command_2620.py
+++ b/tests/test_sandbox_wrap_command_2620.py
@@ -1,0 +1,92 @@
+"""Tier 2: OS invariant — SandboxBackend.wrap_command() uniformity (#2620).
+
+Every sandbox backend must implement ``wrap_command(argv, policy) ->
+WrappedCommand`` so a PERSISTENT-subprocess launch (stdio MCP) can be
+command-level wrapped without any agent-reachable caller bypassing the
+abstraction. This pins the per-backend contract directly (independent of the
+MCPClient caller, covered separately in test_mcp_client_sandbox_wrap.py):
+
+- NoopBackend: argv unchanged, no cleanup — passthrough THROUGH the
+  abstraction, not a bypass.
+- SeatbeltBackend: prepends sandbox-exec -f <profile>; cleanup unlinks the
+  temp profile.
+- LandlockBackend: prepends the landlock_exec re-exec shim; no cleanup
+  resource owned.
+
+No mocks — real backend instances throughout.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from reyn.security.sandbox.backend import WrappedCommand
+from reyn.security.sandbox.backends.landlock import LandlockBackend
+from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+from reyn.security.sandbox.noop_backend import NoopBackend
+from reyn.security.sandbox.policy import SandboxPolicy
+
+
+def test_noop_wrap_command_returns_argv_unchanged():
+    """Tier 2: NoopBackend.wrap_command is a passthrough — argv comes back
+    byte-identical and no cleanup resource is allocated. This is the
+    owner-acceptable no-enforcement outcome (#2620): the call went THROUGH
+    wrap_command, it just enforces nothing."""
+    backend = NoopBackend()
+    argv = ["my-server", "--flag", "value"]
+    wrapped = backend.wrap_command(argv, SandboxPolicy())
+    assert isinstance(wrapped, WrappedCommand)
+    assert wrapped.argv == argv
+    assert wrapped.argv is not argv  # defensive copy, not aliasing the input
+    assert wrapped.cleanup is None
+
+
+def test_noop_wrap_command_does_not_mutate_input_argv():
+    """Tier 2: mutating the returned argv must not alias the caller's list."""
+    backend = NoopBackend()
+    argv = ["cmd", "a"]
+    wrapped = backend.wrap_command(argv, SandboxPolicy())
+    wrapped.argv.append("b")
+    assert argv == ["cmd", "a"]  # caller's list untouched
+
+
+def test_seatbelt_wrap_command_prepends_sandbox_exec(tmp_path):
+    """Tier 2: SeatbeltBackend.wrap_command prepends sandbox-exec -f <profile>,
+    the profile is a real deny-default SBPL, and the trailing argv is the
+    original command unchanged."""
+    backend = SeatbeltBackend()
+    wrapped = backend.wrap_command(["my-server", "--flag"], SandboxPolicy())
+    assert wrapped.argv[0] == "sandbox-exec"
+    assert wrapped.argv[1] == "-f"
+    profile_path = Path(wrapped.argv[2])
+    assert profile_path.suffix == ".sb"
+    assert wrapped.argv[3:] == ["my-server", "--flag"]
+    profile = profile_path.read_text()
+    assert "(deny default)" in profile
+
+    assert wrapped.cleanup is not None
+    assert profile_path.exists()
+    wrapped.cleanup()
+    assert not profile_path.exists()  # cleanup unlinks the temp profile
+
+
+def test_seatbelt_wrap_command_cleanup_idempotent():
+    """Tier 2: calling cleanup twice must not raise (best-effort unlink)."""
+    backend = SeatbeltBackend()
+    wrapped = backend.wrap_command(["cmd"], SandboxPolicy())
+    wrapped.cleanup()
+    wrapped.cleanup()  # must not raise on a missing file
+
+
+def test_landlock_wrap_command_uses_reexec_shim():
+    """Tier 2: LandlockBackend.wrap_command wraps as the landlock_exec re-exec
+    shim (python -m reyn.security.sandbox.landlock_exec --policy ... -- cmd
+    args) — the COMMAND-level analog of the Seatbelt wrap. No cleanup
+    resource is owned."""
+    backend = LandlockBackend()
+    wrapped = backend.wrap_command(["my-server", "--flag"], SandboxPolicy())
+    assert wrapped.argv[0] == sys.executable
+    assert wrapped.argv[1:3] == ["-m", "reyn.security.sandbox.landlock_exec"]
+    sep = wrapped.argv.index("--")
+    assert wrapped.argv[sep + 1:] == ["my-server", "--flag"]
+    assert wrapped.cleanup is None

--- a/tests/test_skill_install_pr_d.py
+++ b/tests/test_skill_install_pr_d.py
@@ -250,7 +250,7 @@ async def test_skill_install_source_gates_http_get(tmp_path, monkeypatch):
 
     # Monkeypatch _shallow_clone to succeed (would only be reached on allow; on deny
     # the gate raises before clone). This avoids real network calls for https sources.
-    def _fake_clone(git_url, dest):
+    async def _fake_clone(git_url, dest, ctx):
         dest.mkdir(parents=True, exist_ok=True)
         (dest / "SKILL.md").write_text(
             "---\nname: gated-skill\ndescription: Gated\n---\nBody.\n",
@@ -419,6 +419,51 @@ async def test_skill_install_source_op_name_traversal_refused(tmp_path):
     assert sentinel.exists(), "SECURITY: sentinel2 directory was deleted (arbitrary rmtree)"
     assert (sentinel / "keep.txt").exists(), \
         "SECURITY: sentinel2 file was deleted (path-traversal via op.name succeeded)"
+
+
+# ── Test 9: SECURITY — clone routes through the sandbox abstraction (#2620) ──
+
+
+@pytest.mark.asyncio
+async def test_skill_install_clone_routes_through_sandbox_abstraction(tmp_path):
+    """Tier 2: SECURITY (#2620) — _shallow_clone's git clone subprocess must go
+    THROUGH the sandbox abstraction (``backend.run()``), not a raw
+    ``subprocess.run`` that never consults any backend. Verified via a REAL
+    ``NoopBackend`` subclass that records each ``run()`` invocation (not a
+    mock) injected on ``ctx.sandbox_backend`` — RED if the clone bypasses the
+    injected backend (e.g. reverts to a bare subprocess.run call)."""
+    from reyn.core.op_runtime.skill_install import handle
+    from reyn.security.sandbox.noop_backend import NoopBackend
+
+    class _RecordingBackend(NoopBackend):
+        """A real NoopBackend subclass that records each run() call's argv."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls: list[list[str]] = []
+
+        async def run(self, argv, policy, **kwargs):
+            self.calls.append(list(argv))
+            return await super().run(argv, policy, **kwargs)
+
+    repo = _make_git_skill_repo(tmp_path / "repos", "routed-skill", "Routed through sandbox")
+    source_url = repo.as_uri()
+
+    ctx, _events = _make_ctx(tmp_path)
+    recording_backend = _RecordingBackend()
+    ctx.sandbox_backend = recording_backend
+
+    op = SkillInstallIROp(kind="skill_install", source=source_url)
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed", f"expected installed, got {result}"
+    assert recording_backend.calls, (
+        "git clone did not route through the injected sandbox backend's run() — "
+        "the abstraction was bypassed"
+    )
+    clone_call = recording_backend.calls[0]
+    assert clone_call[:2] == ["git", "clone"], f"unexpected clone argv: {clone_call}"
+    assert source_url in clone_call
 
 
 def test_safe_skill_name_rejects_traversal_and_separators():


### PR DESCRIPTION
**[per-PR-coder]** — Owner-directed security fix: every agent-reachable subprocess/shell launch must route through `reyn.security.sandbox`, resolving to `NoopBackend` (unsandboxed) on an unsupported platform is acceptable, but a spawn that never consults the abstraction is not. Two paths did that; both are fixed here.

## Problem

1. **stdio MCP server launch** — `MCPClient._sandbox_wrap_stdio` (`src/reyn/mcp/client.py`) called `get_default_backend()` only for *selection*, then hardcoded `if name=="seatbelt": wrap` / `if name=="landlock": wrap`, else `warnings.warn(...)` + `return command, args` — raw argv, unsandboxed, for docker/noop/unavailable/probe-error.
2. **skill_install git clone** — `_shallow_clone` (`src/reyn/core/op_runtime/skill_install.py`) called `subprocess.run(["git","clone",...])` directly, never consulting any backend at all. Agent-reachable via the `skill_install_source` tool.

## Fix — `wrap_command` as a first-class abstraction op

`backend.run()` is one-shot (run argv, capture output) — it doesn't fit a stdio MCP server, which is a **persistent** subprocess held open by `StdioTransport`. So command-wrapping is now promoted to a first-class `SandboxBackend` method, alongside `run()`:

```python
def wrap_command(self, argv: list[str], policy: SandboxPolicy) -> WrappedCommand:
    """argv in, wrapped argv (+ optional cleanup callable) out."""
```

Implemented uniformly by every backend (`src/reyn/security/sandbox/backend.py` Protocol + `WrappedCommand` dataclass):
- **Seatbelt** (`backends/seatbelt.py`): prepends `sandbox-exec -f <profile>` (reuses `_build_sbpl_profile`); `cleanup` unlinks the temp `.sb` file.
- **Landlock** (`backends/landlock.py`): prepends the `landlock_exec` re-exec shim (reuses `build_landlock_exec_argv`); no cleanup resource.
- **NoopBackend** (`noop_backend.py`): returns argv **unchanged** — passthrough, but the call still went *through* the abstraction (the owner-acceptable no-enforcement case, not a bypass).
- **DockerEnvironmentBackend** (`environment/container_backend.py`) — discovered mid-fix via the container-backend Protocol-conformance tests (`test_container_backend_1115_stage2.py`, `test_run_container_backend_flags_1115.py`), which structurally assert `isinstance(backend, SandboxBackend)`. Adding `wrap_command` to the Protocol broke that conformance until implemented here too: prepends `docker exec -i -w <repo_dir> <container> bash -lc 'exec "$@"' reyn-exec <argv>`, mirroring `run()`'s own login-shell exec construction into the same container.

### Reroute 1 — `MCPClient._sandbox_wrap_stdio`
Deleted the hardcoded name-check + `warnings.warn` + raw-return. Now: `get_default_backend().wrap_command([command, *args], policy)` unconditionally. The `#1344` temp-`.sb`-profile cleanup lifecycle is preserved — `WrappedCommand.cleanup` is stashed on `self._sandbox_cleanup` (renamed from `self._sandbox_profile_path`) and invoked from `close_stderr_capture()`. A genuine backend-resolution *failure* (not a normal Noop outcome) still falls back to an unwrapped launch with a loud `UserWarning` — never silent.

### Reroute 2 — `skill_install._shallow_clone`
Now `async`, routes the `git clone` subprocess through `backend.run()` (one-shot fits — git clone is not persistent). Backend selection: `ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)` (operator's configured mechanism governs it, same as `sandboxed_exec`). Policy is purpose-built for this operation rather than inherited from `ctx.default_sandbox_policy`, because:
- `network=True` is not overridable here — cloning over the network is what the operation *is*; an operator's global `network: false` would break every git-sourced skill install outright.
- `allow_subprocess=True` — discovered via a real test failure: git internally forks a subprocess for the transport helper (`git-upload-pack`) even for a plain clone, and Seatbelt's default policy denies `process-fork`, so without this **every** clone failed with `cannot fork()`. Scoped to this one already-gated operation (the git-clone flow runs after `require_http_get` has already approved the source host), not a global relaxation.
- `write_paths=[dest.parent]` — scoped to `.reyn/skills/`.
- `env_passthrough` widened from bare `PATH` to include `HOME`/SSH/proxy/CA vars — otherwise routing through `NoopBackend.run()` (which only passes through `policy.env_passthrough` + `PATH`) silently starved git of env it needs, a regression vs. the previous full-env-inherited `subprocess.run`.

## By-design, NOT touched (for the owner)

- `api/unsafe/shell.py` — the operator-opt-in `mode: unsafe` escape hatch. Its entire purpose is to bypass the sandbox; routing it through the abstraction would defeat the escape hatch.
- Operator CLI/REPL spawns (`cli/commands/chainlit.py`, `$EDITOR`, clipboard, dogfood git) — operator-invoked, fixed argv, not agent-driven.
- `router_tools.py` — explicitly out of scope; a separate fix is in flight there.

## Test plan

- [x] `NoopBackend.wrap_command(argv, policy)` returns argv unchanged (passthrough through the abstraction) — `tests/test_sandbox_wrap_command_2620.py`.
- [x] `_sandbox_wrap_stdio` routes through `backend.wrap_command` for Seatbelt / Landlock / **Noop** (no per-name branching; Noop asserted to reach `wrap_command`, not an early raw-return) — `tests/test_mcp_client_sandbox_wrap.py`.
- [x] A genuine backend-probe/wrap *failure* still falls back with a loud `UserWarning` — `test_backend_probe_failure_falls_back_with_warning`.
- [x] skill_install clone routes through the sandbox abstraction — verified via a **real** `NoopBackend` subclass injected on `ctx.sandbox_backend` that records `run()` calls (not a mock) — `test_skill_install_clone_routes_through_sandbox_abstraction` in `tests/test_skill_install_pr_d.py`.
- [x] Seatbelt still prepends `sandbox-exec` (regression guard) + temp-profile cleanup unlinked on `close_stderr_capture()` (#1344 lifecycle preserved) — `test_profile_cleaned_on_close`, `test_seatbelt_wrap_command_prepends_sandbox_exec`.
- [x] Container-backend dual-Protocol conformance (`isinstance(backend, SandboxBackend)`) still holds after adding `wrap_command` to the Protocol — `test_container_backend_1115_stage2.py::test_satisfies_both_protocols`, `test_run_container_backend_flags_1115.py::test_docker_attach_satisfies_both_protocols`.
- [x] All existing skill_install PR-D e2e tests (real `file://` git clones, threat-scan block, subdir convention, config-generation recovery, path-traversal refusal) pass unchanged in behavior.

## Gates (all local, macOS, real SeatbeltBackend auto-selected — this machine has `sandbox-exec`)

```
$ ruff check src tests
All checks passed!

$ python scripts/test_tier_audit.py --strict tests/test_mcp_client_sandbox_wrap.py tests/test_skill_install_pr_d.py tests/test_sandbox_wrap_command_2620.py
Summary: 22 tests inspected
  OK: 22 / warnings: 0 / errors: 0
Exit code: 0

$ pytest -q
5 failed, 7442 passed, 21 skipped, 11 warnings in 158.15s
```

The 5 failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `web/test_a2a.py::test_a2a_routes_mounted`, `web/test_mcp_sse.py::test_mcp_routes_mounted`, `web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `web/test_resources_router.py::test_resources_route_is_mounted_on_app`) reproduce byte-identically on a clean `main` checkout with this PR's changes stashed — confirmed pre-existing / unrelated (route-mount test-isolation issue, #2599), **zero NEW failures** introduced by this change.

```
$ python scripts/verify_module_docstrings.py <all changed src files>
OK: no module-docstring refactor narrative.
```