### PR TITLE
feat(#2608): hook-liveness observability — hook_push_fired event + dogfood_trace hook-liveness mode

### DIFF
--- a/docs/reference/dogfood-tracing.md
+++ b/docs/reference/dogfood-tracing.md
@@ -199,6 +199,62 @@ development only.
 
 ---
 
+# Hook Liveness (`--mode hook-liveness`)
+
+External-event hooks (`mcp_resource_updated` / `file_changed` / `cron_fired` /
+`webhook_received`, plus in-session `template_push`/`shell_push` hooks) can
+fail silently in one specific way: the push lands in a session's inbox but the
+run-loop never drains it into a turn. Before this mode existed, that failure
+left no trace an operator could find — the packaged `dogfood_trace.py` modes
+(`summary`/`full`/`chain`/`cost`) read only the EventLog
+(`.reyn/events/**/*.jsonl`); the WAL (`.reyn/state/wal.jsonl`), where the push
+landing is actually recorded (`inbox_put`), was never cross-checked against it.
+
+```bash
+python scripts/dogfood_trace.py --mode hook-liveness --root .reyn
+```
+
+## What it does
+
+1. Reads every WAL `inbox_put` entry with `msg_kind == "hook"` — each one is a
+   hook's E (wake=true) push landing in a session's inbox.
+2. Reads the EventLog for `turn_started` events carrying `kind == "hook"` —
+   the run-loop actually picking up the trigger and running a turn.
+3. Pairs each push against the earliest not-yet-claimed `turn_started(kind=hook)`
+   timestamped after it (FIFO — exact for the common single-session case).
+4. Any push with **no match** is flagged `INERT` — pushed into the inbox, but
+   the run-loop never ran a turn for it. This is the direct detector for the
+   "hook fired but never drained/ran" failure signature.
+
+The `point` column (the lifecycle point / external-event source that
+triggered the push) is cross-referenced from the `hook_push_fired` P6 event
+(emitted at fire-time by `HookDispatcher._push_resolved` for every push path —
+`template_push`, `shell_push`, E and C, cross-session or local). Its absence
+(an older WAL, or a session with no `emit_event` sink configured) only
+degrades the `point` column to `?`; it never changes the INERT verdict, which
+depends solely on the WAL/EventLog pairing.
+
+## Example output
+
+```
+============================================================
+HOOK LIVENESS  (WAL inbox_put(kind=hook)  <->  EventLog turn_started(kind=hook))
+============================================================
+fired-at                   point            name             ran?   INERT?
+2026-07-05T18:48:25.406416 turn_end         turn_end         yes
+2026-07-05T18:48:25.408589 cron_fired       cron_fired       no      <-- INERT (pushed, never ran)
+
+2 hook push(es): 1 ran, 1 INERT (pushed but never drained into a turn)
+INERT = the inert-hook failure signature: a push landed in the inbox (WAL
+inbox_put) with no subsequent turn_started(kind=hook) — the run-loop never
+picked it up.
+```
+
+A `.reyn/` with no WAL and no hook pushes prints a clean `no hook pushes
+found` — the mode never crashes on missing files.
+
+---
+
 # LLM Replay (`scripts/llm_replay.py`)
 
 `llm_replay.py` takes a trace file, finds a specific request by `request_id`,

--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -1,7 +1,7 @@
 """dogfood_trace.py — consolidate batch observation greps into one tool.
 
 Usage:
-    python scripts/dogfood_trace.py [--root .reyn] [--mode summary|full|chain|cost]
+    python scripts/dogfood_trace.py [--root .reyn] [--mode summary|full|chain|cost|hook-liveness]
                                     [--filter <event_kind>]
 
     # LLM payload trace modes (requires REYN_LLM_TRACE_DUMP to have been set during dogfood):
@@ -116,6 +116,141 @@ def mode_cost(root: Path) -> None:
         print(f"  LLM-call memoizations:     {llm_memo_hits} events  (= sub-loop LLM memo replay)")
         print(f"  estimated saved cost:      ${saved_usd:.4f}   (= {llm_memo_hits} LLM-call hits × ${avg_usd:.5f} avg)")
         print(f"  estimated saved tokens:    ~{int(saved_tokens):,}    (= {llm_memo_hits} hits × {int(avg_tokens):,} avg per call)")
+
+
+def _load_wal(root: Path) -> list[dict]:
+    """Load the WAL (``<root>/state/wal.jsonl``), oldest-first (by ``seq``).
+
+    Reuses ``_load_jsonl`` (the same tolerant-parse reader every other mode
+    uses) — no hand-rolled WAL parser. Returns ``[]`` when the file doesn't
+    exist (e.g. a non-persistent/no-WAL run): callers report a clean "no hook
+    pushes found" rather than crashing.
+    """
+    entries = _load_jsonl(root / "state" / "wal.jsonl")
+    entries.sort(key=lambda e: e.get("seq", 0))
+    return entries
+
+
+def _parse_ts_naive(ts: "str | None") -> "datetime | None":
+    """Best-effort ISO-8601 parse, normalised to a NAIVE (tzinfo-stripped) wall-clock
+    value so a WAL entry's naive ``ts`` (``datetime.now().isoformat()``) and an
+    EventLog event's tz-aware ``timestamp`` (``datetime.now().astimezone()``) — both
+    stamped from the SAME machine's local clock — can be ordered against each other.
+    Returns ``None`` on any parse failure (caller falls back to string comparison)."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=None) if dt.tzinfo is not None else dt
+
+
+def _is_after(candidate_ts: "str | None", reference_ts: "str | None") -> bool:
+    """True iff *candidate_ts* is chronologically after *reference_ts*.
+
+    Parses both as naive wall-clock datetimes when possible; falls back to a
+    plain string comparison (works for same-format ISO strings, the common
+    case) when either fails to parse.
+    """
+    a, b = _parse_ts_naive(reference_ts), _parse_ts_naive(candidate_ts)
+    if a is not None and b is not None:
+        return b > a
+    return (candidate_ts or "") > (reference_ts or "")
+
+
+def mode_hook_liveness(root: Path) -> None:
+    """--mode hook-liveness: the direct detector for the "hook fired but never
+    drained/ran" failure class (#2608 observability gap).
+
+    Previously invisible: the packaged dogfood_trace modes read ONLY the
+    EventLog (``<root>/events/**/*.jsonl``), never the WAL
+    (``<root>/state/wal.jsonl``) — so a ``template_push`` hook that landed in a
+    session's inbox (WAL ``inbox_put(msg_kind="hook")``) but was never drained
+    by the run-loop (no ``turn_started(kind="hook")`` ever followed) left NO
+    trace in the artifact the tooling actually read.
+
+    This mode reads BOTH: every WAL ``inbox_put`` entry with ``msg_kind ==
+    "hook"`` is an E-push (wake=true) landing in the inbox; it is paired
+    against the earliest not-yet-claimed EventLog ``turn_started(kind="hook")``
+    event timestamped after it (FIFO — the inbox drains in order, one turn per
+    push; exact for the common single-session case, a documented best-effort
+    approximation when many hook pushes race across sessions, since neither
+    artifact carries a shared correlation id back to `turn_started`). A push
+    with NO such match is flagged **INERT** — pushed, never ran.
+
+    The new ``hook_push_fired`` P6 event (emitted at fire-time by every push
+    path, #2608 part A) is cross-referenced ONLY for display (the lifecycle
+    ``point`` that triggered the push, absent from the WAL entry itself) — it
+    does not change the INERT verdict, so an OLDER WAL (pre-#2608 build, no
+    ``hook_push_fired`` events) still gets a correct liveness read.
+    """
+    wal_entries = _load_wal(root)
+    hook_pushes = [
+        e for e in wal_entries
+        if e.get("kind") == "inbox_put" and e.get("msg_kind") == "hook"
+    ]
+    if not hook_pushes:
+        print("no hook pushes found (no WAL inbox_put(msg_kind=hook) entries under "
+              f"{root / 'state' / 'wal.jsonl'})")
+        return
+
+    events = _all_events(root)
+    turn_started_hook = [
+        e for e in events
+        if e.get("type") == "turn_started" and (e.get("data") or {}).get("kind") == "hook"
+    ]
+    # hook_push_fired (part A) fires at the SAME call site as the WAL inbox_put
+    # for an E-push (wake=True), back-to-back with no await between — so the
+    # wake=True subset is in the same relative order as `hook_pushes`. Zipped
+    # positionally for DISPLAY (the `point` field) only; a length mismatch
+    # (older WAL / no emit_event sink configured for that run) just leaves
+    # `point` as "?" past the shorter list — never affects the INERT verdict.
+    push_fired_e = [
+        e for e in events
+        if e.get("type") == "hook_push_fired" and (e.get("data") or {}).get("wake") is True
+    ]
+
+    claimed = [False] * len(turn_started_hook)
+    rows: list[dict] = []
+    inert_count = 0
+    for i, push in enumerate(hook_pushes):
+        push_ts = push.get("ts", "")
+        payload = push.get("payload") or {}
+        name = payload.get("name", "?")
+        fired = push_fired_e[i] if i < len(push_fired_e) else None
+        point = (fired.get("data") or {}).get("point", "?") if fired else "?"
+
+        ran_at = None
+        for j, ts_ev in enumerate(turn_started_hook):
+            if claimed[j]:
+                continue
+            if _is_after(ts_ev.get("timestamp"), push_ts):
+                claimed[j] = True
+                ran_at = ts_ev.get("timestamp")
+                break
+        if ran_at is None:
+            inert_count += 1
+        rows.append({
+            "fired_at": push_ts, "name": name, "point": point,
+            "ran": ran_at is not None, "ran_at": ran_at,
+        })
+
+    print("=" * 60)
+    print("HOOK LIVENESS  (WAL inbox_put(kind=hook)  <->  EventLog turn_started(kind=hook))")
+    print("=" * 60)
+    print(f"{'fired-at':<26} {'point':<16} {'name':<16} {'ran?':<6} INERT?")
+    for r in rows:
+        ran_str = "yes" if r["ran"] else "no"
+        inert_str = "" if r["ran"] else "  <-- INERT (pushed, never ran)"
+        print(f"{r['fired_at']:<26} {r['point']:<16} {r['name']:<16} {ran_str:<6}{inert_str}")
+
+    print(f"\n{len(rows)} hook push(es): {len(rows) - inert_count} ran, {inert_count} INERT "
+          "(pushed but never drained into a turn)")
+    if inert_count:
+        print("INERT = the inert-hook failure signature: a push landed in the inbox "
+              "(WAL inbox_put) with no subsequent turn_started(kind=hook) — the run-loop "
+              "never picked it up.")
 
 
 def mode_full(root: Path, filter_kind: str | None) -> None:
@@ -977,7 +1112,7 @@ def main() -> None:
     parser.add_argument(
         "--mode",
         choices=[
-            "summary", "full", "chain", "cost",
+            "summary", "full", "chain", "cost", "hook-liveness",
             "llm-payloads", "llm-detail", "llm-tools-schema",
             "llm-context", "llm-advertised-ops", "llm-emitted-ops",
         ],
@@ -1054,7 +1189,10 @@ def main() -> None:
         print(f"no events found (root not found: {root})")
         sys.exit(0)
 
-    {"summary": mode_summary, "full": mode_full, "chain": mode_chain, "cost": mode_cost}[args.mode](
+    {
+        "summary": mode_summary, "full": mode_full, "chain": mode_chain, "cost": mode_cost,
+        "hook-liveness": mode_hook_liveness,
+    }[args.mode](
         *([root, args.filter_kind] if args.mode == "full" else [root])
     )
 

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -239,6 +239,30 @@ class HookDispatcher:
         the only difference between the two is where ``resolved`` comes from."""
         if not resolved.push_when:
             return  # conditional push guard (or a render/parse failure — fail-safe)
+        # #2608 observability: every push FIRE (template_push's Jinja2 render or
+        # shell_push's stdout JSON, both funnel through here) is surfaced as a P6
+        # event — previously ONLY shell_exec/shell_push emitted `hook_shell_executed`
+        # on the RUN side; a push's only artifact was the WAL `inbox_put`/staged
+        # context, so a push that fired but never drained (sat in the inbox forever)
+        # left no EventLog trace at all. `hook_push_fired` closes that gap: metadata
+        # only (hook_name/point/wake/target_session) — NEVER the rendered message
+        # body, which may carry secrets from template_vars. Best-effort: a sink
+        # error must never break the push (mirrors shell_runner's emit_event guard).
+        if self._emit_event is not None:
+            try:
+                self._emit_event(
+                    "hook_push_fired",
+                    hook_name=hook.name,
+                    point=point,
+                    wake=resolved.wake,
+                    target_session=(
+                        resolved.session.strip()
+                        if resolved.session and resolved.session.strip()
+                        else self._current_session_id
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001 — telemetry is best-effort
+                _log.debug("hook push_fired emit_event failed for %r: %s", hook.name, exc)
         # Attribution name (#1800 slice 6): the hook's operator label when set,
         # else the lifecycle point (slice-5b default) — the ``[hook:<name>]``
         # system-role prefix (shared E + C renderer).

--- a/tests/test_2608_dogfood_hook_liveness.py
+++ b/tests/test_2608_dogfood_hook_liveness.py
@@ -1,0 +1,128 @@
+"""Tier 2: #2608 observability — `dogfood_trace.py --mode hook-liveness`.
+
+The investigation-confirmed gap: dogfood_trace's existing aggregate modes
+read ONLY the EventLog (`.reyn/events/**/*.jsonl`) — never the WAL
+(`.reyn/state/wal.jsonl`) — so a hook push that landed in a session's inbox
+(WAL `inbox_put(msg_kind="hook")`) but was never drained by the run-loop (no
+subsequent `turn_started(kind="hook")`) left NO trace the tooling could read.
+`--mode hook-liveness` pairs the two artifacts and flags exactly that failure
+signature (INERT).
+
+Policy (docs/deep-dives/contributing/testing.md): fixtures are REAL artifacts
+written by the real producer components (``StateLog`` for the WAL,
+``EventLog`` + ``EventStore`` for the EventLog) — not hand-authored JSON
+guessing at the on-disk shape, so a producer-format drift would break this
+test rather than silently going unnoticed.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "dogfood_trace.py"
+
+
+def _run(args: list[str]) -> tuple[str, int]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)] + args,
+        capture_output=True, text=True,
+    )
+    return result.stdout + result.stderr, result.returncode
+
+
+def _event_log(reyn_dir: Path) -> EventLog:
+    store = EventStore(reyn_dir / "events" / "agents" / "default" / "chat")
+    return EventLog(subscribers=[store])
+
+
+@pytest.mark.asyncio
+async def test_hook_push_that_ran_is_not_flagged_inert(tmp_path: Path):
+    """Tier 2: a WAL inbox_put(kind=hook) followed by a real turn_started(kind=hook)
+    is reported as ran — the healthy pairing, not flagged INERT."""
+    reyn_dir = tmp_path / ".reyn"
+    wal = StateLog(reyn_dir / "state" / "wal.jsonl")
+    log = _event_log(reyn_dir)
+
+    await wal.append(
+        "inbox_put", target="test-agent", session_id="main",
+        msg_id="m1", msg_kind="hook",
+        payload={"name": "turn_end", "text": "continue", "wake": True, "_msg_id": "m1"},
+    )
+    # The run-loop actually picks the push up and runs a turn (real EventLog.emit,
+    # the same call site as Session._handle_inbox_message's turn_started emit).
+    log.emit("turn_started", kind="hook", chain_id=None)
+
+    out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
+    assert rc == 0
+    assert "1 hook push(es): 1 ran, 0 INERT" in out
+
+
+@pytest.mark.asyncio
+async def test_inert_hook_push_is_flagged(tmp_path: Path):
+    """Tier 2: a WAL inbox_put(kind=hook) with NO subsequent turn_started(kind=hook)
+    — the inert-hook failure signature — is flagged INERT. This is the exact bug
+    class the investigation found invisible to the packaged trace tooling."""
+    reyn_dir = tmp_path / ".reyn"
+    wal = StateLog(reyn_dir / "state" / "wal.jsonl")
+    # An unrelated user-turn event exists (proves the mode doesn't just count
+    # "any turn_started" — it specifically requires kind="hook").
+    log = _event_log(reyn_dir)
+    log.emit("turn_started", kind="user", chain_id=None)
+
+    await wal.append(
+        "inbox_put", target="test-agent", session_id="main",
+        msg_id="m2", msg_kind="hook",
+        payload={"name": "cron_fired", "text": "tick", "wake": True, "_msg_id": "m2"},
+    )
+    # No turn_started(kind=hook) ever follows — the push sat in the inbox forever.
+
+    out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
+    assert rc == 0
+    assert "INERT" in out
+    assert "1 hook push(es): 0 ran, 1 INERT" in out
+
+
+def test_no_wal_and_no_events_reports_clean_no_hooks(tmp_path: Path):
+    """Tier 2: an empty .reyn/ (no WAL, no events) is a clean 'no hook pushes
+    found' — robust to a missing WAL, never a crash/traceback."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+
+    out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
+    assert rc == 0
+    assert "no hook pushes found" in out
+    assert "Traceback" not in out
+
+
+@pytest.mark.asyncio
+async def test_mixed_healthy_and_inert_pushes_both_counted(tmp_path: Path):
+    """Tier 2: two hook pushes, one that ran and one that didn't — both are
+    reported, and the summary counts split correctly (not just a boolean)."""
+    reyn_dir = tmp_path / ".reyn"
+    wal = StateLog(reyn_dir / "state" / "wal.jsonl")
+    log = _event_log(reyn_dir)
+
+    await wal.append(
+        "inbox_put", target="test-agent", session_id="main",
+        msg_id="ok1", msg_kind="hook",
+        payload={"name": "turn_end", "text": "a", "wake": True, "_msg_id": "ok1"},
+    )
+    log.emit("turn_started", kind="hook", chain_id=None)  # pairs with ok1
+
+    await wal.append(
+        "inbox_put", target="test-agent", session_id="main",
+        msg_id="inert1", msg_kind="hook",
+        payload={"name": "file_changed", "text": "b", "wake": True, "_msg_id": "inert1"},
+    )
+    # no turn_started follows for inert1
+
+    out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
+    assert rc == 0
+    assert "2 hook push(es): 1 ran, 1 INERT" in out

--- a/tests/test_2608_hook_push_fired_event.py
+++ b/tests/test_2608_hook_push_fired_event.py
@@ -1,0 +1,128 @@
+"""Tier 2: #2608 observability — a hook push FIRE emits a P6 `hook_push_fired`
+EventLog event.
+
+Investigation-confirmed gap: only `shell_exec`/`shell_push` runs emitted a P6
+event (`hook_shell_executed`); a `template_push`/`shell_push` PUSH's only
+artifact was the WAL `inbox_put`/staged-context entry — so a push that landed
+in the inbox but was never drained (the "sits in inbox forever" failure) left
+NO EventLog trace. `hook_push_fired` (emitted at fire-time, in
+``HookDispatcher._push_resolved``) closes that gap for every push path (E
+wake=true, C wake=false, and cross-session).
+
+Policy (docs/deep-dives/contributing/testing.md): real ``HookRegistry`` /
+``HookDef`` / ``EventLog`` — no mocks. The dispatcher's Session seams
+(put_inbox / stage_next_turn_context) are recording real async callables.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef, PushBlock
+
+
+class _Recorder:
+    """A real recording async callable (not a mock) for the injected Session seams."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def _dispatcher(hooks: list[HookDef], event_log: EventLog, **seams) -> HookDispatcher:
+    seams.setdefault("put_inbox", _Recorder())
+    seams.setdefault("stage_next_turn_context", _Recorder())
+    return HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage_next_turn_context"],
+        emit_event=lambda et, **d: event_log.emit(et, **d),
+    )
+
+
+@pytest.mark.asyncio
+async def test_template_push_wake_true_emits_hook_push_fired():
+    """Tier 2: an E (wake=true) template_push fire emits `hook_push_fired` with
+    hook_name/point/wake/target_session metadata — NO message body (secrets-safe)."""
+    log = EventLog()
+    hook = HookDef(name="my-hook", on="turn_end",
+                    template_push=PushBlock(message="secret payload text", wake=True))
+    disp = _dispatcher([hook], log)
+
+    await disp.dispatch("turn_end", {})
+
+    (fired_event,) = [e for e in log.all() if e.type == "hook_push_fired"]
+    data = fired_event.data
+    assert data["hook_name"] == "my-hook"
+    assert data["point"] == "turn_end"
+    assert data["wake"] is True
+    assert "secret payload text" not in str(data)   # no message body leaked
+    assert "text" not in data and "message" not in data
+
+
+@pytest.mark.asyncio
+async def test_template_push_wake_false_also_emits_hook_push_fired():
+    """Tier 2: a C (wake=false) ride-along push ALSO fires the event — every push
+    path (not just E) is now observable, closing the gap for BOTH."""
+    log = EventLog()
+    hook = HookDef(name="ctx-hook", on="turn_start",
+                    template_push=PushBlock(message="note", wake=False))
+    disp = _dispatcher([hook], log)
+
+    await disp.dispatch("turn_start", {})
+
+    (fired_event,) = [e for e in log.all() if e.type == "hook_push_fired"]
+    assert fired_event.data["wake"] is False
+
+
+@pytest.mark.asyncio
+async def test_push_when_false_does_not_emit():
+    """Tier 2: a conditional push that resolves to push_when=False never fires —
+    no event either (mirrors: nothing was pushed, so nothing to report as fired)."""
+    log = EventLog()
+    hook = HookDef(name="skipped", on="turn_end",
+                    template_push=PushBlock(message="x", push_when="false"))
+    disp = _dispatcher([hook], log)
+
+    await disp.dispatch("turn_end", {})
+
+    assert [e for e in log.all() if e.type == "hook_push_fired"] == []
+
+
+@pytest.mark.asyncio
+async def test_no_emit_sink_stays_a_noop():
+    """Tier 2: emit_event=None (the default — e.g. a unit test / no-sink session)
+    stays byte-identical to pre-#2608: dispatch never raises and no event exists
+    because there's no EventLog to hold one."""
+    hook = HookDef(name="h", on="turn_end", template_push=PushBlock(message="x", wake=True))
+    disp = HookDispatcher(
+        HookRegistry([hook]),
+        put_inbox=_Recorder(),
+        stage_next_turn_context=_Recorder(),
+    )
+
+    await disp.dispatch("turn_end", {})  # must not raise with no emit_event sink
+
+
+@pytest.mark.asyncio
+async def test_shell_exec_hook_still_emits_hook_shell_executed_not_push_fired():
+    """Tier 2: a shell_exec hook (no push at all) does NOT emit hook_push_fired —
+    that event is a PUSH-fire signal only, distinct from the pre-existing
+    hook_shell_executed (run-side) signal."""
+    log = EventLog()
+    hook = HookDef(name="shell-h", on="session_start", shell_exec="true")
+    disp = HookDispatcher(
+        HookRegistry([hook]),
+        put_inbox=_Recorder(),
+        stage_next_turn_context=_Recorder(),
+        run_shell=_Recorder(),  # real recording callable — no real sandbox/subprocess
+        emit_event=lambda et, **d: log.emit(et, **d),
+    )
+
+    await disp.dispatch("session_start", {})
+
+    assert [e for e in log.all() if e.type == "hook_push_fired"] == []


### PR DESCRIPTION
**[per-PR-coder]** — part of #2608

## Summary

Investigation confirmed a hook-fire observability gap: a `template_push`/`shell_push` hook FIRE emitted no EventLog event (only `shell_exec`/`shell_push` RUNS emitted `hook_shell_executed`), and no packaged tool cross-checked the WAL against the EventLog — so a hook push that landed in a session's inbox but was **never drained into a turn** (the "sits in inbox forever" failure) left zero trace an operator could find via `dogfood_trace.py`.

This PR builds the two pieces of analysis tooling to close that gap.

### A. `hook_push_fired` P6 event (`src/reyn/hooks/dispatcher.py`)

`HookDispatcher._push_resolved` now emits `hook_push_fired` (via the same injected `emit_event` seam `hook_shell_executed` already uses) at fire-time, for **every** push path — `template_push` and `shell_push`, both E (wake=true) and C (wake=false), local or cross-session. Payload is metadata-only: `hook_name`, `point`, `wake`, `target_session` — **never the rendered message body** (which may carry secrets from `template_vars`). A push that resolves `push_when=False` (the conditional-push guard) does not fire, so it does not emit either — consistent with "nothing was pushed."

No-hooks equivalence preserved: an empty registry never enters the dispatch loop body, so `emit_event` is never touched — byte-identical to pre-#2608 when no hooks are configured. `emit_event=None` (e.g. a session/test with no EventLog sink) is also a no-op, same as the existing `hook_shell_executed` guard.

### B. `dogfood_trace.py --mode hook-liveness` (`scripts/dogfood_trace.py`)

Reads BOTH:
- the WAL (`.reyn/state/wal.jsonl`, via the same tolerant `_load_jsonl` reader every other mode uses) — every `inbox_put(msg_kind="hook")` entry is an E-push landing in the inbox;
- the EventLog (`.reyn/events/**/*.jsonl`, via the existing `_all_events`) — every `turn_started(kind="hook")` is the run-loop actually draining it into a turn.

Each push is paired against the earliest not-yet-claimed `turn_started(kind=hook)` timestamped after it (FIFO — exact for the common single-session case; a documented best-effort approximation when many hook pushes race, since neither artifact carries a shared correlation id back to `turn_started`). An unpaired push is flagged **INERT** — the direct detector for "pushed, never ran." The new `hook_push_fired` event (part A) is cross-referenced only for the `point` display column — an older WAL without it just shows `?`, never changes the INERT verdict. Robust to a missing WAL/events dir (prints a clean `no hook pushes found`, never crashes).

```
============================================================
HOOK LIVENESS  (WAL inbox_put(kind=hook)  <->  EventLog turn_started(kind=hook))
============================================================
fired-at                   point            name             ran?   INERT?
2026-07-05T18:48:25.406416 turn_end         turn_end         yes
2026-07-05T18:48:25.408589 cron_fired       cron_fired       no      <-- INERT (pushed, never ran)

2 hook push(es): 1 ran, 1 INERT (pushed but never drained into a turn)
```

### Doc: `docs/reference/dogfood-tracing.md`

New "Hook Liveness" section documenting the mode, what it reads, the pairing heuristic, and example output.

## Confinement

Touched only: `src/reyn/hooks/dispatcher.py`, `scripts/dogfood_trace.py`, `docs/reference/dogfood-tracing.md`, plus two new test files. Did not touch `fs_watcher.py` / `mcp/` / `router_tools.py` / `security/sandbox/` (other fixes in flight, per dispatch instructions).

## Testing (Tier 2, real components — no MagicMock/AsyncMock/patch)

- `tests/test_2608_hook_push_fired_event.py`: real `HookDispatcher` + real `HookRegistry`/`HookDef` + real `EventLog`. Asserts the event fires for E and C pushes, carries no message body, does NOT fire on `push_when=False` or a `shell_exec`-only hook, and stays a no-op with `emit_event=None`.
- `tests/test_2608_dogfood_hook_liveness.py`: real `StateLog` (WAL) + real `EventLog`/`EventStore` fixtures (not hand-authored JSON) driving the actual CLI subprocess. Covers: a healthy paired push, an INERT unpaired push (the target bug signature), a mix of both with correct counts, and the empty-`.reyn/` clean path.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_2608_hook_push_fired_event.py tests/test_2608_dogfood_hook_liveness.py` — 9/9 OK, 0 errors
- [x] `pytest` (repo root) — 7446 passed, 21 skipped, **5 failed** (all pre-existing/unrelated — `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `tests/web/test_a2a.py::test_a2a_routes_mounted`, `tests/web/test_mcp_sse.py::test_mcp_routes_mounted`, `tests/web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `tests/web/test_resources_router.py::test_resources_route_is_mounted_on_app` — all web/A2A route-mount tests, #2599 known-unrelated, zero overlap with hooks/dogfood_trace changes). **Zero NEW failures.**
- [x] `python scripts/verify_module_docstrings.py src/reyn/hooks/dispatcher.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)