### PR TITLE
fix(#2628): codeact_runner delegates sandbox wrap to SandboxBackend.wrap_command

### DIFF
--- a/src/reyn/core/kernel/codeact_runner.py
+++ b/src/reyn/core/kernel/codeact_runner.py
@@ -11,14 +11,16 @@ Why a dedicated runner (not ``SandboxBackend.run``): ``run`` is single-shot
 (``subprocess.run`` capture — stdout read only after exit), but CodeAct needs a
 duplex channel **live during execution**. The runner does its own
 ``Popen(pass_fds=...)`` so the socketpair fd is inherited, and services the channel
-concurrently with the child. The OS sandbox is applied by reusing the backend's
-profile builder (S2b: Seatbelt ``_build_sbpl_profile`` + ``sandbox-exec`` wrapper;
-S2c: Landlock preexec ruleset) — the inherited socketpair fd survives both (an
-AF_UNIX socketpair is not a ``network*`` socket; verified on Seatbelt under
-``(deny default)+(deny network*)``).
+concurrently with the child. The OS sandbox is applied via the SAME
+``SandboxBackend.wrap_command(argv, policy)`` abstraction every other
+command-level launch route uses (#2626, #2628) — Seatbelt's ``sandbox-exec -f
+<profile>`` wrap or Landlock's re-exec shim, whichever backend is available —
+so the inherited socketpair fd survives both (an AF_UNIX socketpair is not a
+``network*`` socket; verified on Seatbelt under ``(deny default)+(deny
+network*)``).
 
 This module is the S2a core: the protocol + service loop + the direct (no-sandbox)
-spawn. The sandbox-wrapping spawn lands in S2b/S2c.
+spawn, plus the ``wrap_command``-delegated sandboxed spawn.
 """
 from __future__ import annotations
 
@@ -106,8 +108,8 @@ class CodeActRunner:
         for exercising the transport/proxy core without a sandbox; production callers
         (the CodeAct scheme) never set it.
 
-        S2b wires the Seatbelt wrap (reusing ``_build_sbpl_profile``); S2c wires
-        Landlock.
+        The wrap (Seatbelt or Landlock, whichever the backend is) is resolved via
+        ``sandbox_backend.wrap_command(...)`` — see ``_resolve_sandbox_spawn``.
         """
         base_argv = [self.python_executable, "-m", "reyn.core.kernel._codeact_harness"]
         argv, cleanup, spawn_error = self._resolve_sandbox_spawn(
@@ -226,12 +228,16 @@ class CodeActRunner:
         error string (fail-closed). Returns ``(argv, cleanup, error)``; exactly one
         of ``argv`` / ``error`` is non-None.
 
-        - Seatbelt (available): wrap ``base_argv`` with ``sandbox-exec -f <profile>``
-          using the REUSED ``_build_sbpl_profile`` (the inherited socketpair fd
-          survives — an AF_UNIX socketpair is not a ``network*`` socket).
-        - Landlock (available): S2c (preexec ruleset) — not yet wired → fail-closed.
+        - Any AVAILABLE real backend (Seatbelt / Landlock): delegate to the
+          backend's own ``wrap_command(base_argv, policy)`` (#2626's
+          ``SandboxBackend`` abstraction) — the SAME wrap logic every other
+          command-level launch route uses (single-abstraction, #2628). The
+          inherited socketpair fd survives both backends' wraps (an AF_UNIX
+          socketpair is not a ``network*`` socket).
         - noop / None / unavailable: fail-closed unless ``allow_unsandboxed`` (a
-          test-only escape for the transport/proxy core).
+          test-only escape for the transport/proxy core). NoopBackend's
+          ``wrap_command`` is a passthrough (no isolation), so it is deliberately
+          excluded here — CodeAct must never silently run unsandboxed.
         """
         name = getattr(sandbox_backend, "name", None)
         available = bool(sandbox_backend is not None and sandbox_backend.available())
@@ -250,40 +256,12 @@ class CodeActRunner:
         policy_dict["timeout_seconds"] = timeout
         policy = SandboxPolicy(**policy_dict)
 
-        if name == "seatbelt":
-            import tempfile  # noqa: PLC0415
+        try:
+            wrapped = sandbox_backend.wrap_command(base_argv, policy)
+        except Exception as exc:  # noqa: BLE001 — fail-closed on any wrap failure
+            return None, None, f"CodeAct: sandbox_backend.wrap_command failed: {exc}"
 
-            from reyn.security.sandbox.backends.seatbelt import (  # noqa: PLC0415
-                _build_sbpl_profile,
-            )
-
-            profile_text = _build_sbpl_profile(policy)
-            try:
-                fh = tempfile.NamedTemporaryFile(
-                    suffix=".sb", mode="w", delete=False, encoding="utf-8",
-                )
-                fh.write(profile_text)
-                fh.close()
-            except OSError as exc:
-                return None, None, f"CodeAct: failed to write Seatbelt profile: {exc}"
-
-            def _cleanup() -> None:
-                try:
-                    os.unlink(fh.name)
-                except OSError:
-                    pass
-
-            return ["sandbox-exec", "-f", fh.name, *base_argv], _cleanup, None
-
-        if name == "landlock":
-            return None, None, (
-                "CodeAct Landlock wrap is S2c (pending Linux+Landlock env "
-                "verification) — not yet available (fail-closed)."
-            )
-
-        return None, None, (
-            f"CodeAct does not support sandbox backend {name!r} yet (fail-closed)."
-        )
+        return wrapped.argv, wrapped.cleanup, None
 
     async def _service(
         self, sock: socket.socket, dispatch: DispatchFn, loop: asyncio.AbstractEventLoop,

--- a/tests/test_codeact_runner_1593.py
+++ b/tests/test_codeact_runner_1593.py
@@ -195,6 +195,90 @@ async def test_seatbelt_real_runner_round_trip() -> None:
     assert seen == [("m", {"n": 41})]
 
 
+# ── #2628: single-abstraction — codeact delegates to SandboxBackend.wrap_command ──
+
+
+def test_seatbelt_resolve_spawn_delegates_to_wrap_command(monkeypatch) -> None:
+    """Tier 2: #2628 — CodeActRunner._resolve_sandbox_spawn no longer hand-rolls
+    the Seatbelt wrap (importing ``_build_sbpl_profile`` + writing its own temp
+    ``.sb`` directly); it now calls ``SandboxBackend.wrap_command(argv, policy)``
+    — the SAME abstraction every other command-level launch route uses (#2626).
+    The wrapped argv's shape (``sandbox-exec -f <profile> <base_argv>``) matches
+    a direct ``backend.wrap_command()`` call on an equivalent policy, and the
+    returned cleanup actually unlinks the temp profile (no leak).
+
+    ``wrap_command`` builds a plain-text SBPL profile with local I/O only — it
+    does not itself invoke ``sandbox-exec`` — so this pins the delegation on
+    any host (the real ``SeatbeltBackend.available()`` platform gate is
+    exercised separately by ``test_seatbelt_real_runner_round_trip`` above);
+    only ``available()`` is monkeypatched here (a real instance's method, not a
+    mock collaborator) so the delegation itself is tested off-macOS too."""
+    import os
+
+    from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    backend = SeatbeltBackend()
+    monkeypatch.setattr(backend, "available", lambda: True)
+    runner = CodeActRunner()
+    base_argv = [runner.python_executable, "-m", "reyn.core.kernel._codeact_harness"]
+    sandbox_policy = {"network": False, "env_passthrough": ["PATH"]}
+
+    argv, cleanup, error = runner._resolve_sandbox_spawn(
+        base_argv, backend, sandbox_policy, 30.0, False,
+    )
+    assert error is None
+    assert argv is not None
+    assert cleanup is not None
+
+    # Same shape as a direct wrap_command() call: sandbox-exec -f <profile> <base_argv>.
+    # The profile PATH differs (each call gets its own fresh temp file), so compare
+    # everything else — the exact same code path codeact now runs.
+    direct = backend.wrap_command(base_argv, SandboxPolicy(network=False, env_passthrough=["PATH"], timeout_seconds=30.0))
+    assert argv[0] == direct.argv[0] == "sandbox-exec"
+    assert argv[1] == direct.argv[1] == "-f"
+    assert argv[3:] == direct.argv[3:] == base_argv
+
+    profile_path = argv[2]
+    assert os.path.exists(profile_path)
+    cleanup()
+    assert not os.path.exists(profile_path)  # cleanup unlinks the temp profile
+    direct.cleanup()  # tidy up the independently-created profile too
+
+
+def test_landlock_resolve_spawn_now_wraps_via_abstraction(monkeypatch) -> None:
+    """Tier 2: #2628 — Landlock is no longer a "S2c pending" stub that refuses
+    to run. ``LandlockBackend.wrap_command`` builds the re-exec shim argv
+    deterministically (no temp file, no randomness), so codeact's resolved argv
+    is BYTE-IDENTICAL to a direct ``backend.wrap_command()`` call — this is the
+    safety-preserving case: Landlock's wrap_command applies REAL isolation (the
+    re-exec shim restricts itself via Landlock then execs the target), so
+    delegating to it correctly ENABLES Landlock rather than weakening the prior
+    fail-closed refusal. ``available()`` is monkeypatched on the real instance
+    (its genuine platform/kernel-ABI gate is exercised separately by
+    ``tests/test_sandbox_landlock.py``) so this delegation is pinned on any host,
+    including this macOS dev box."""
+    from reyn.security.sandbox.backends.landlock import LandlockBackend
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    backend = LandlockBackend()
+    monkeypatch.setattr(backend, "available", lambda: True)
+    runner = CodeActRunner()
+    base_argv = [runner.python_executable, "-m", "reyn.core.kernel._codeact_harness"]
+    sandbox_policy = {"network": False, "env_passthrough": ["PATH"]}
+
+    argv, cleanup, error = runner._resolve_sandbox_spawn(
+        base_argv, backend, sandbox_policy, 30.0, False,
+    )
+    assert error is None
+    assert cleanup is None  # Landlock owns no cleanup resource (no temp file)
+
+    direct = backend.wrap_command(
+        base_argv, SandboxPolicy(network=False, env_passthrough=["PATH"], timeout_seconds=30.0),
+    )
+    assert argv == direct.argv  # byte-identical — same deterministic build
+
+
 # ── #1609: harness subprocess PYTHONPATH propagation (multi-worktree drift) ───
 
 


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2628.

## Summary

`CodeActRunner._resolve_sandbox_spawn` (~L217-286 pre-change) hand-rolled the Seatbelt sandbox wrap itself: it imported `_build_sbpl_profile` directly from the seatbelt backend, wrote its own temp `.sb` file, and returned `["sandbox-exec", "-f", <profile>, *base_argv]` + a local `_cleanup`. It also carried a `landlock → "S2c pending"` stub branch that unconditionally refused to run. This duplicated, character-for-character, what `SandboxBackend.wrap_command(argv, policy) -> WrappedCommand(argv, cleanup)` already provides (added in #2626).

Replaced the per-backend branching with a single call:

```python
try:
    wrapped = sandbox_backend.wrap_command(base_argv, policy)
except Exception as exc:
    return None, None, f"CodeAct: sandbox_backend.wrap_command failed: {exc}"
return wrapped.argv, wrapped.cleanup, None
```

The availability gate above this call is unchanged: `sandbox_backend is None or name in (None, "noop") or not available` still fails closed (`sandbox_unavailable`) unless `allow_unsandboxed=True` (test-only escape). `wrap_command` is only reached once the backend is confirmed real + available.

## Landlock safety determination (req 3)

Read `src/reyn/security/sandbox/backends/landlock.py`'s `wrap_command`: it builds the `landlock_exec` re-exec shim argv (`python -m reyn.security.sandbox.landlock_exec --policy <json> -- <cmd> <args>`), which — when actually invoked — restricts the process itself via `landlock.Ruleset(...).restrict_self()` **before** `execvp`-ing the target. This is real, irrevocable isolation, not a passthrough/noop (unlike `NoopBackend.wrap_command`, which is a documented passthrough).

Since `_resolve_sandbox_spawn`'s availability gate (`sandbox_backend.available()`) is unchanged and still runs *before* `wrap_command` is ever called, removing the old `"S2c pending"` stub does not weaken safety — it correctly **enables** Landlock (the backend genuinely enforces isolation once `available()` is True), matching the "no silent unsandboxed exec" requirement: unavailable/noop/None backends are exactly as fail-closed as before.

## Test (Tier 2, no mocks)

Added two tests to `tests/test_codeact_runner_1593.py`:
- `test_seatbelt_resolve_spawn_delegates_to_wrap_command` — real `SeatbeltBackend`; asserts codeact's resolved argv matches the shape of a direct `backend.wrap_command()` call (`sandbox-exec -f <profile> <base_argv>`), and that the returned `cleanup` actually unlinks the temp profile.
- `test_landlock_resolve_spawn_now_wraps_via_abstraction` — real `LandlockBackend`; since `wrap_command` builds the shim argv deterministically (no temp file), asserts codeact's resolved argv is **byte-identical** to a direct `backend.wrap_command()` call, proving Landlock delegation now works end-to-end instead of the old stub refusal.

Both monkeypatch only `backend.available()` (a real instance's method, not a mock collaborator) so the delegation is pinned cross-platform (this dev box is macOS, so Landlock's genuine platform gate is exercised separately by `tests/test_sandbox_landlock.py`).

Also updated the module docstring and `run()`'s docstring in `codeact_runner.py` to drop stale references to `_build_sbpl_profile` / "S2b/S2c wiring" now that both backends route through the single abstraction.

## Gates (all run locally, green)

- `ruff check src tests` — pass
- `python scripts/test_tier_audit.py --strict tests/test_codeact_runner_1593.py` — 15/15 OK, 0 Tier-4
- `pytest` (full suite) — 7456 passed, 21 skipped, **5 pre-existing failures unrelated to this change** (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`, `test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `test_resources_router.py::test_resources_route_is_mounted_on_app`) — verified these fail identically with this branch's changes stashed (web-routing/plugin-loader issues, not touched by this PR)
- `python scripts/verify_module_docstrings.py src/reyn/core/kernel/codeact_runner.py` — OK

## Test plan

- [x] Ran full pytest suite locally — only pre-existing, unrelated failures present
- [x] Verified Landlock's `wrap_command` applies real isolation (not a passthrough) before concluding the stub removal is safe
- [x] Confirmed the availability gate (`sandbox_backend.available()`) is unchanged, so unavailable backends still fail closed