### PR TITLE
feat: promote agent-autonomy Behaviour policy to OS frame (reaches all schemes incl CodeAct)

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1704,6 +1704,7 @@ class RouterLoop:
                 reasoning_continuity_section=getattr(
                     host, "reasoning_continuity_section", lambda: ""
                 )(),
+                non_interactive=self._non_interactive,
             )
         # Session._handle_user_message appends the user turn to history
         # BEFORE invoking _run_router_loop, so by the time we get here the

--- a/src/reyn/runtime/router_system_prompt.py
+++ b/src/reyn/runtime/router_system_prompt.py
@@ -39,6 +39,7 @@ def build_system_prompt(
     environment_info: "dict | None" = None,  # #1479: date/platform/shell/git from get_environment_info()
     scheme_sp_fragment: str = "",  # kept for backward compat; prefer tool_use_sp slot_post_catalog
     reasoning_continuity_section: str = "",  # #1652: pre-rendered prior-reasoning text section ("" = omit, byte-identical)
+    non_interactive: bool = False,  # sp-autonomy-revision: gates the OS-frame ambiguity/proceed-vs-ask Behaviour rule
 ) -> str:
     """Render the system prompt for the tool_use router loop.
 
@@ -90,6 +91,11 @@ def build_system_prompt(
         environment_info: system info dict (date/platform/shell/git).
         scheme_sp_fragment: backward-compat legacy free-form SP fragment
             (prefer ``tool_use_sp["slot_post_catalog"]`` for new schemes).
+        non_interactive: True for non-interactive (ephemeral/headless) sessions
+            with no user to ask. Gates the wording of the OS-frame ambiguity/
+            proceed-vs-ask Behaviour rule (scheme-agnostic — reaches every
+            tool-use scheme, including CodeAct, unlike the old scheme-owned
+            fork this superseded).
     """
     parts: list[str] = []
 
@@ -210,13 +216,38 @@ def build_system_prompt(
         " deliverable is a working result backed by REAL tool output — not a"
         " description of one. Do not stop after a stub, a plan, or a single command;"
         " keep working until you have actually produced the requested result, then"
-        " report what real execution returned.",
+        " report what real execution returned. Only end your turn when the request"
+        " is fully resolved or genuinely blocked: never yield half-done to ask"
+        " whether to continue, and when an approach fails, try an alternative"
+        " before stopping. If a real blocker remains, report it honestly.",
         "  - NEVER substitute fabricated output (invented data, file contents, or"
         " tool/command results) for results you could not actually produce. If a tool"
         " or call fails and blocks the real path, say so directly and try an"
         " alternative — reporting a blocker honestly is always better than inventing"
         " a result.",
     ])
+    # sp-autonomy-revision: ambiguity/proceed-vs-ask Behaviour rule, promoted to
+    # the OS frame (was scheme-owned in _universal_sp.py, which only reached the
+    # universal/enumerate/retrieval schemes — CodeAct's tool_use_sp REPLACES that
+    # scheme's SP region entirely, so it never got the rule). Living here in the
+    # static core makes it scheme-agnostic and reaches every scheme, incl CodeAct.
+    parts.append(
+        "  - Ambiguous or missing information: default to proceeding — make the"
+        " most reasonable assumption, state it explicitly, and continue. Ask ONE"
+        " targeted clarifying question ONLY when the ambiguity is BOTH"
+        " consequential (a wrong guess causes real, hard-to-undo work) AND cannot"
+        " be resolved from context or by inspecting the workspace. When the user"
+        " asks HOW to approach something, or whether to do it, answer first — do"
+        " not jump into actions they haven't asked for."
+        if non_interactive else
+        "  - Ambiguous or missing information: prefer proceeding with a stated,"
+        " reasonable assumption over asking. Ask ONE targeted clarifying question"
+        " ONLY when the ambiguity is BOTH consequential (a wrong guess causes"
+        " real, hard-to-undo work) AND cannot be resolved from context or by"
+        " inspecting the workspace. When the user asks HOW to approach something,"
+        " or whether to do it, answer first — do not jump into actions they"
+        " haven't asked for."
+    )
 
     # #1791 #3 (adopted by design judgment, GATED): memory-quality guidance, rendered
     # ONLY when the memory tool is active (memory_index present) — mirrors Hermes

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -500,4 +500,5 @@ class RouterHistoryBuffer:
             reasoning_continuity_section=getattr(
                 rh, "reasoning_continuity_section", lambda: ""
             )(),
+            non_interactive=self._non_interactive,
         )

--- a/src/reyn/tools/schemes/_universal_sp.py
+++ b/src/reyn/tools/schemes/_universal_sp.py
@@ -22,7 +22,10 @@ def build_universal_tool_use_slots(
     search_actions_enabled: bool,
     discovery_mandate: bool,
     has_hot_list_aliases: bool,
-    non_interactive: bool = False,
+    non_interactive: bool = False,  # sp-autonomy-revision: accepted for backward compat only —
+    # the ambiguity/proceed-vs-ask fork this used to gate moved to the OS-frame
+    # ``build_system_prompt(non_interactive=...)`` Behaviour rule (scheme-
+    # agnostic, reaches CodeAct too); no longer read in this function's body.
     non_claude: bool = False,  # #1791 A2: non-Claude operational-steering hygiene in slot_in_behaviour
     available_skills: "list | None" = None,  # #2548 PR-A: SkillEntry list for ## Skills block
 ) -> "dict[str, str]":
@@ -140,15 +143,6 @@ def build_universal_tool_use_slots(
         " via `task__create`'s `assignee`. Do NOT invoke a per-target"
         " action directly without decomposition — it loses the iteration"
         " shape and gets stuck on the first item.",
-        "",
-        (
-            "**Ambiguous or missing essential information** → there is no"
-            " interactive user to ask; state your best assumption and proceed"
-            " (do NOT stop to ask a clarifying question)."
-            if non_interactive else
-            "**Ambiguous or missing essential information** → ask ONE"
-            " clarifying question instead of guessing."
-        ),
         "",
     ])
     slots["slot_pre_environment"] = "\n".join(_r1)

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -24,6 +24,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.tools.scheme import CodeBlock, ExecContext, ExecutionResult, PlainText
 from reyn.tools.schemes.codeact import CodeActScheme
 
@@ -197,6 +198,39 @@ async def test_build_presentation_omits_excluded_actions() -> None:
     )
     assert "file__read" in pres.tool_use_sp   # kept
     assert "web__fetch" not in pres.tool_use_sp  # excluded → omitted
+
+
+@pytest.mark.asyncio
+async def test_full_sp_for_codeact_session_carries_os_frame_autonomy_rule() -> None:
+    """Tier 2: sp-autonomy-revision — the ambiguity/proceed-vs-ask and
+    finish-the-job/persistence Behaviour rules were promoted from the
+    scheme-owned `_universal_sp.py` fork to the OS-frame
+    `build_system_prompt` static core specifically because CodeAct's
+    `tool_use_sp` (a bare string) REPLACES the universal scheme's whole
+    `slot_pre_environment` region — so a rule living only in that region
+    (the old location) never reached a CodeAct-scheme agent. This builds a
+    full CodeAct session's tool_use_sp via the real `build_presentation` and
+    feeds it through the real `build_system_prompt`, proving the rule now
+    reaches CodeAct too."""
+    pres = await CodeActScheme().build_presentation({}, {}, _CatalogOps())
+    # CodeAct's tool_use_sp is a bare str (the REPLACE channel) — sanity-check
+    # it still normalises into slot_pre_environment (no dict/list slots leak).
+    assert isinstance(pres.tool_use_sp, str)
+
+    sp = build_system_prompt(
+        agent_name="chat",
+        agent_role="general agent",
+        available_agents=[],
+        memory_index={},
+        tool_use_sp=pres.tool_use_sp,
+    )
+    # The CodeAct code-API is present (REPLACE channel reached the OS frame).
+    assert "def file__read(" in sp
+    # The promoted ambiguity/proceed-vs-ask Behaviour rule reaches CodeAct.
+    assert "Ask ONE targeted clarifying question ONLY when the ambiguity is BOTH" in sp
+    assert "prefer proceeding with a stated," in sp  # interactive default wording
+    # The promoted persistence/anti-premature-yield clause reaches CodeAct.
+    assert "never yield" in sp and "half-done" in sp
 
 
 # ── S4: registration + selectability ─────────────────────────────────────────

--- a/tests/test_router_loop_non_interactive_live_1443.py
+++ b/tests/test_router_loop_non_interactive_live_1443.py
@@ -4,9 +4,15 @@
 session-side `_build_router_system_prompt` (override/budget path) — but the LIVE
 chat-router SP that `reyn run-once` actually renders is built separately inside
 `RouterLoop.run()` (router_loop.py), which omitted the flag → run-once still
-rendered the "ask ONE clarifying question" directive and dead-stopped (13398).
-The original #1440 test called `build_system_prompt` directly, so it unit-passed
-while the live path stayed broken.
+rendered the ask-first directive and dead-stopped (13398). The original #1440
+test called `build_system_prompt` directly, so it unit-passed while the live
+path stayed broken.
+
+sp-autonomy-revision (2026-07): the ambiguity/proceed-vs-ask directive was
+promoted from the scheme-owned `_universal_sp.py` fork to the OS-frame
+`build_system_prompt(non_interactive=...)` Behaviour rule (reaches every
+scheme, incl. CodeAct). `RouterLoop.run()`'s wiring of `self._non_interactive`
+into `build_system_prompt` is exactly this test's live-path assertion.
 
 This test drives `RouterLoop.run()` with a recording `call_llm_tools` and asserts
 on the system message the loop ACTUALLY builds — exercising the live path the
@@ -28,8 +34,10 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.router_loop import RouterLoop
 
 _EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=2)
-_CLARIFY = "ask ONE"
-_PROCEED = "no interactive user to ask"
+# Substrings unique to each branch's wording (behavior-pinned, not a full-text
+# snapshot) — see test_router_sp_non_interactive_1439.py for the same pair.
+_NON_INTERACTIVE_ONLY = "make the most reasonable assumption, state it explicitly"
+_INTERACTIVE_ONLY = "prefer proceeding with a stated,"
 
 
 class _FakeEventLog:
@@ -124,18 +132,19 @@ def _live_system_prompt(*, non_interactive: bool, monkeypatch: pytest.MonkeyPatc
 
 
 def test_run_once_live_router_sp_proceeds_not_clarifies(monkeypatch):
-    """Tier 3a: #1443 — a non_interactive RouterLoop's LIVE rendered SP omits the
-    clarifying-question directive and carries the proceed directive. This is the
+    """Tier 3a: #1443 — a non_interactive RouterLoop's LIVE rendered SP carries the
+    unconditional proceed directive, not the interactive one. This is the
     path `reyn run-once` renders; the #1440 unit test never exercised it."""
     sp = _live_system_prompt(non_interactive=True, monkeypatch=monkeypatch)
-    assert _CLARIFY not in sp, "live run-once SP must not tell the agent to ask a clarifying question"
-    assert _PROCEED in sp
+    assert _NON_INTERACTIVE_ONLY in sp
+    assert _INTERACTIVE_ONLY not in sp
 
 
 def test_interactive_live_router_sp_keeps_clarifying(monkeypatch):
-    """Tier 3a: #1443 — the interactive default LIVE SP keeps the clarifying
-    directive (byte-compatible). The differential proves the flag threads through
-    RouterLoop into the live build_system_prompt call, not just the session path."""
+    """Tier 3a: #1443 — the interactive default LIVE SP keeps the "prefer
+    proceeding" wording (byte-compatible). The differential proves the flag
+    threads through RouterLoop into the live build_system_prompt call, not just
+    the session path."""
     sp = _live_system_prompt(non_interactive=False, monkeypatch=monkeypatch)
-    assert _CLARIFY in sp
-    assert _PROCEED not in sp
+    assert _INTERACTIVE_ONLY in sp
+    assert _NON_INTERACTIVE_ONLY not in sp

--- a/tests/test_router_sp_non_interactive_1439.py
+++ b/tests/test_router_sp_non_interactive_1439.py
@@ -1,60 +1,60 @@
 """Tier 2: #1439 Fix #1 — autonomy-mode router SP signal (run-once path).
 
-#1627 Stage 4: ``build_system_prompt`` is now a pure slot-injector. The
-``non_interactive`` parameter has been REMOVED from ``build_system_prompt``.
-Tests now call ``build_universal_tool_use_slots`` directly (with
-``non_interactive=True/False``) and pass the result as ``tool_use_sp``.
+sp-autonomy-revision (2026-07): the ambiguity/proceed-vs-ask directive was
+promoted from the scheme-owned ``_universal_sp.py`` fork to the OS-frame
+``build_system_prompt(non_interactive=...)`` Behaviour rule, so it reaches
+every tool-use scheme (universal / enumerate / retrieval / CodeAct), not just
+the universal-category path. ``build_universal_tool_use_slots`` still accepts
+``non_interactive`` for backward compat, but no longer branches on it — the
+fork now lives solely in ``build_system_prompt``.
 
-In run-once (piped stdin, no TTY) there is no user to answer, so the
-"ask ONE clarifying question" directive is a structural dead-end (stalls
-the agent, #13398). The ``non_interactive`` flag in
-``build_universal_tool_use_slots`` swaps that one directive for a
-proceed-with-assumption directive; everything else is unchanged.
+In run-once (piped stdin, no TTY) there is no user to answer, so an ask-first
+directive is a structural dead-end (stalls the agent, #13398).
+``build_system_prompt(non_interactive=True)`` swaps in a proceed-with-
+assumption directive; everything else is unchanged.
 
-Real ``build_system_prompt`` + real ``build_universal_tool_use_slots``,
-no mocks.
+Real ``build_system_prompt``, no mocks.
 """
 from __future__ import annotations
 
 from reyn.runtime.router_system_prompt import build_system_prompt
-from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
 
-_CLARIFY = "ask ONE"
-_PROCEED = "no interactive user to ask"
+# Substrings unique to each branch's wording (behavior-pinned, not a full-text
+# snapshot): the non_interactive branch leads with an unconditional "default
+# to proceeding" framing; the interactive branch leads with a softer
+# "prefer proceeding" framing that still allows asking.
+_NON_INTERACTIVE_ONLY = "make the most reasonable assumption, state it explicitly"
+_INTERACTIVE_ONLY = "prefer proceeding with a stated,"
+_ASK_ONE_COMMON = "Ask ONE targeted clarifying question ONLY when the ambiguity is BOTH"
 
 
 def _sp(*, non_interactive: bool) -> str:
-    slots = build_universal_tool_use_slots(
-        universal_wrappers_enabled=False,
-        search_actions_enabled=True,
-        discovery_mandate=False,
-        has_hot_list_aliases=False,
-        non_interactive=non_interactive,
-    )
     return build_system_prompt(
         agent_name="chat",
         agent_role="general agent",
         available_agents=[],
         memory_index={},
-        tool_use_sp=slots,
+        non_interactive=non_interactive,
     )
 
 
-def test_interactive_default_keeps_clarifying_question() -> None:
-    """Tier 2: #1439 Fix #1 — non_interactive=False keeps the "ask ONE
-    clarifying question" directive."""
+def test_interactive_default_keeps_prefer_proceeding_wording() -> None:
+    """Tier 2: #1439 Fix #1 — non_interactive=False keeps the interactive
+    "prefer proceeding" wording, and the shared one-question cap."""
     sp = _sp(non_interactive=False)
-    assert _CLARIFY in sp
-    assert _PROCEED not in sp
+    assert _INTERACTIVE_ONLY in sp
+    assert _NON_INTERACTIVE_ONLY not in sp
+    assert _ASK_ONE_COMMON in sp
 
 
-def test_non_interactive_replaces_clarifying_with_proceed() -> None:
-    """Tier 2: #1439 Fix #1 — non_interactive=True omits the clarifying-
-    question directive and instead tells the agent to proceed with an assumption
-    (no user to ask). This is the 13398 dead-stop fix."""
+def test_non_interactive_uses_unconditional_proceed_wording() -> None:
+    """Tier 2: #1439 Fix #1 — non_interactive=True swaps in the unconditional
+    "default to proceeding" wording (no user to ask). This is the 13398
+    dead-stop fix, now living in the OS frame."""
     sp = _sp(non_interactive=True)
-    assert _CLARIFY not in sp, "run-once SP must not tell the agent to ask a clarifying question"
-    assert _PROCEED in sp
+    assert _NON_INTERACTIVE_ONLY in sp
+    assert _INTERACTIVE_ONLY not in sp
+    assert _ASK_ONE_COMMON in sp
     assert "proceed" in sp.lower()
 
 
@@ -66,12 +66,5 @@ def test_default_param_is_interactive() -> None:
         agent_role="general agent",
         available_agents=[],
         memory_index={},
-        tool_use_sp=build_universal_tool_use_slots(
-            universal_wrappers_enabled=False,
-            search_actions_enabled=True,
-            discovery_mandate=False,
-            has_hot_list_aliases=False,
-            non_interactive=False,
-        ),
     )
     assert default_sp == _sp(non_interactive=False)


### PR DESCRIPTION
**[per-PR-coder]** — Promotes the ambiguity/proceed-vs-ask autonomy directive from a scheme-owned fork to the OS frame, so every tool-use scheme (including CodeAct) gets it.

## Background
`docs/proposals/sp-autonomy-revision.md` (Fable5-reviewed, authoritative wording) originally scoped the ambiguity-fork edit to `src/reyn/tools/schemes/_universal_sp.py` (the universal-category scheme's tool-use SP builder). Since that doc was written, the scope changed: **two SP layers exist** —

- the **OS frame** (`router_system_prompt.py::build_system_prompt`) — scheme-agnostic, rendered for every agent regardless of tool-use dialect.
- the **scheme SP** (pluggable per tool-use dialect: universal / enumerate / retrieval / CodeAct).

`CodeActScheme.build_presentation` returns `tool_use_sp` as a bare string, which `build_system_prompt` normalises into `slot_pre_environment` — **replacing** the universal scheme's entire routing-guide region (where the old ambiguity fork lived). So a CodeAct-scheme agent never saw the old fork at all. Landing the directive in the OS frame's static `## Behaviour` core reaches all four schemes from one place.

## Changes

**Edit A** — `build_system_prompt` gains `non_interactive: bool = False`. Threaded from the two existing production call sites, both of which already hold the flag:
- `RouterHistoryBuffer.build_system_prompt()` → `non_interactive=self._non_interactive`
- `RouterLoop.run()`'s live SP build (~L1676) → `non_interactive=self._non_interactive`

No other production call site exists (grepped `build_system_prompt(` across `src/`).

**Edit B** — the ambiguity/proceed-vs-ask Behaviour rule moves into the OS frame's static `## Behaviour` block (cached prefix), gated on the new param:
- `non_interactive=True` (no user to ask): *"default to proceeding — make the most reasonable assumption, state it explicitly, and continue. Ask ONE targeted clarifying question ONLY when the ambiguity is BOTH consequential ... AND cannot be resolved..."*
- `non_interactive=False` (interactive default): *"prefer proceeding with a stated, reasonable assumption over asking. Ask ONE targeted clarifying question ONLY when..."*

Both branches keep the "answer HOW/whether-questions first" carve-out (Fable5 amendment A2) and the "ask ONE, never a questionnaire" cap (amendment A1).

Also appended the persistence/anti-premature-yield clause to the existing "Finishing the job" rule: *"Only end your turn when the request is fully resolved or genuinely blocked: never yield half-done to ask whether to continue, and when an approach fails, try an alternative before stopping. If a real blocker remains, report it honestly."*

The now-redundant fork in `_universal_sp.py` (~L144-151) is removed. `build_universal_tool_use_slots` keeps its `non_interactive` parameter for backward compat (many existing callers pass it) but no longer branches on it — a comment on the parameter documents where the behavior moved.

## Tests changed and why
- `tests/test_router_sp_non_interactive_1439.py` — rewritten. It previously asserted the OLD fork's behavior via `build_universal_tool_use_slots(non_interactive=...)` fed into `build_system_prompt`. Now calls `build_system_prompt(non_interactive=...)` directly and asserts substantive presence/absence of the two branch-specific phrasings (not full-string snapshots) — Tier 2.
- `tests/test_router_loop_non_interactive_live_1443.py` — updated assertions only (same live-path exercise via a real `RouterLoop.run()` + recording `call_llm_tools`, which was already the right seam for this promotion — no structural change needed since `RouterLoop._non_interactive` already existed and now threads straight into `build_system_prompt`). Old markers (`"ask ONE"` / `"no interactive user to ask"`) replaced with the new branch-distinguishing substrings — Tier 3a.
- `tests/test_codeact_scheme_1593.py` — **new test** `test_full_sp_for_codeact_session_carries_os_frame_autonomy_rule`: builds a real CodeAct `Presentation` via `build_presentation`, feeds its `tool_use_sp` into the real `build_system_prompt`, and asserts the promoted ambiguity + persistence Behaviour text is present in the rendered SP — proving CodeAct-scheme agents now get the policy (the whole point of this promotion). Tier 2.

All four gates pass locally: `ruff check src tests`, `python scripts/test_tier_audit.py --strict <changed test files>` (17/17 OK, 0 Tier-4), `pytest` (7444 passed / 5 pre-existing failures unrelated to this change — verified by reproducing the same 5 failures with these changes stashed, on unmodified HEAD: `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`, `test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `test_resources_router.py::test_resources_route_is_mounted_on_app` — a FastAPI-app-singleton test-order issue, unrelated to SP code), `python scripts/verify_module_docstrings.py <changed src files>`.

## Docs
Grepped `docs/concepts`, `docs/reference`, `docs/feature-map.md` for any user-facing description of "the agent asks a clarifying question" as current behavior — none found (hits were only in historical `docs/deep-dives/journal/dogfood/...` batch records, which are not current-behavior docs and are left untouched per repo policy on not rewriting history).

## Not in this PR
- No dogfood A3 verification (separate follow-up, budget-gated) — `docs/proposals/sp-autonomy-revision.md` amendment A3 calls for a before/after dogfood measurement; tracked separately.
- No changes to `session_api.py` / `registry.py` / ephemeral-session `non_interactive` forcing — tracked as a separate follow-up PR (PR2).
- `max_iterations` untouched — out of scope (noted in the proposal doc as a separate future lever).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_router_sp_non_interactive_1439.py tests/test_router_loop_non_interactive_live_1443.py tests/test_codeact_scheme_1593.py` — 17/17 OK, 0 Tier-4
- [x] `pytest` from repo root — 7444 passed, 5 pre-existing failures (verified unrelated via stash-and-rerun on HEAD)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_system_prompt.py src/reyn/runtime/router_loop.py src/reyn/runtime/services/router_history_buffer.py src/reyn/tools/schemes/_universal_sp.py` — OK