### PR TITLE
fix: force non_interactive=True for ephemeral pipeline-spawned sessions (no user to ask)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2697,6 +2697,17 @@ class AgentRegistry:
             ephemeral_session = self._peek_session(name, sid)
             if ephemeral_session is not None:
                 ephemeral_session._ephemeral = True
+                # #2585 PR2: an ephemeral spawn is structurally headless — it
+                # receives exactly ONE prompt via MessageBus.request (see
+                # session_api.run_agent_step) and returns; there is no
+                # interactive user on the other end to answer a clarifying
+                # question, regardless of which frontend's session_factory
+                # spawned it. Force the override here (NOT in spawn_session
+                # itself, which persistent/A2A spawns also use and which MAY
+                # have a real user eventually) so the worker always lands on
+                # the "proceed with assumption" SP branch instead of wasting
+                # its one turn asking a question no one can answer.
+                ephemeral_session._non_interactive = True
         if narrowing:
             import yaml
             cfg_path = self._session_state_dir(name, sid) / "config.yaml"

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1937,6 +1937,16 @@ class Session:
         self._event_store = new_store
 
     @property
+    def non_interactive(self) -> bool:
+        """#2585 PR2: read-only public surface for ``_non_interactive`` (set at
+        construction from the frontend's session_factory, and force-overridden
+        to True for ephemeral spawns by ``AgentRegistry.spawn_session_recorded``
+        — see its ``mode == "ephemeral"`` branch). Lets callers/tests observe
+        the effective ask-vs-proceed SP branch without reaching into the
+        "private" attribute."""
+        return self._non_interactive
+
+    @property
     def total_usage(self):
         return self._budget.total_usage
 

--- a/tests/test_2585_pr2_ephemeral_non_interactive_force.py
+++ b/tests/test_2585_pr2_ephemeral_non_interactive_force.py
@@ -1,0 +1,91 @@
+"""Tier 2: #2585 PR2 — ephemeral pipeline-spawned sessions force non_interactive=True.
+
+``AgentRegistry.spawn_session_recorded(mode="ephemeral")`` is the primitive behind
+``run_agent_step`` (pipeline ``agent`` steps): the spawned worker receives exactly ONE
+prompt via ``MessageBus.request`` and returns — structurally headless, no interactive
+user on the other end. But the spawned session is constructed via the SAME shared
+``session_factory`` the registry was built with (captured from whichever frontend
+launched the pipeline — A2A/MCP/chainlit/dogfood all deliberately set
+``non_interactive=False``, "interactive byte-identical"). Without an override, an
+ephemeral worker could inherit ``non_interactive=False`` and land on the SP's "ask ONE
+clarifying question" branch with no one to answer it.
+
+This test builds a registry whose factory mirrors that interactive-frontend default
+(``non_interactive=False``) and asserts:
+  1. an ephemeral spawn is forced to ``non_interactive=True`` regardless of the
+     factory's default (the fix, in ``AgentRegistry.spawn_session_recorded``'s
+     ``mode == "ephemeral"`` branch);
+  2. a persistent spawn is NOT touched — it keeps whatever the factory set — because a
+     persistent spawn (e.g. agent-to-agent multi-session) may eventually have a real
+     user on the other end, so forcing it there would be wrong.
+
+Real AgentRegistry + real Session (no mocks); mirrors the ``holder`` deferred-registry-
+ref factory pattern used by ``test_2103_A_ephemeral_auto_vanish_1953.py`` /
+``test_pipeline_r5_run_agent_step.py``. Assertions read the PUBLIC ``session.
+non_interactive`` property (added alongside this fix), not the "private"
+``_non_interactive`` attribute directly.
+
+FALSIFY: drop the ``ephemeral_session._non_interactive = True`` line in
+``spawn_session_recorded`` → the ephemeral assertion goes RED (stays False, inherited
+from the factory).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """A registry whose factory mirrors an interactive frontend (chainlit/A2A/MCP/
+    dogfood): every constructed session gets ``non_interactive=False`` — the shared
+    default per ``scoped_session_factory.py``'s "interactive byte-identical" comment."""
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=False,
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_spawn_forces_non_interactive_true(tmp_path):
+    """Tier 2: #2585 PR2 — an ephemeral spawn is forced to non_interactive=True even
+    though the factory's default (mirroring an interactive frontend) is False. RED if
+    the override in spawn_session_recorded's ephemeral branch is dropped."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")  # the live main session (factory default: False)
+
+    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    eph = reg._peek_session("alice", eph_sid)
+
+    assert eph.non_interactive is True
+
+
+@pytest.mark.asyncio
+async def test_persistent_spawn_keeps_factory_default(tmp_path):
+    """Tier 2: #2585 PR2 — the fix is scoped to ephemeral spawns only: a persistent
+    spawn (e.g. agent-to-agent multi-session) keeps whatever the factory set
+    (False here), proving the override does NOT leak into spawn_session() itself.
+    RED if a future change moves the override into the shared spawn_session path."""
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+
+    per_sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    per = reg._peek_session("alice", per_sid)
+
+    assert per.non_interactive is False


### PR DESCRIPTION
**[per-PR-coder]** — PR2 of the sp-autonomy-revision arc (PR1, already merged, promoted the ambiguity/proceed-vs-ask + persistence SP rules to the OS frame, gated on `non_interactive`).

## The gap

`Session.non_interactive` (`src/reyn/runtime/session.py:724`) defaults to `False` and is threaded per-frontend via the shared `session_factory` captured at `AgentRegistry` construction (`registry.py:173`). Per `scoped_session_factory.py:59`, A2A/MCP/chainlit/dogfood frontends deliberately set `non_interactive=False` ("interactive byte-identical").

`AgentRegistry.spawn_session()` (used by `spawn_session_recorded(mode="ephemeral")` — the primitive behind pipeline `agent` steps via `session_api.run_agent_step`) constructs the spawned session through that SAME shared frontend factory. So an ephemeral, pipeline-spawned worker — which is structurally headless (it receives exactly ONE prompt via `MessageBus.request` and returns; see `run_agent_step`, no human round-trip anywhere in that path) — could inherit `non_interactive=False` from its frontend, landing it on the "ask ONE clarifying question" SP branch with literally no one to answer. This wastes the worker's turn.

## The fix

One line in `spawn_session_recorded`'s `mode == "ephemeral"` branch (`registry.py`, right next to the existing `ephemeral_session._ephemeral = True`):

```python
ephemeral_session._non_interactive = True
```

`_non_interactive` is a plain instance attribute set in `Session.__init__` (`session.py:847`, `self._non_interactive = bool(non_interactive)`) — not a property with side effects — so this is a safe direct override, mirroring the existing `_ephemeral = True` pattern at the same locus.

**Why NOT in `spawn_session()` itself:** `spawn_session()` is called by `spawn_session_recorded` for BOTH ephemeral and persistent modes. Persistent spawns (agent-to-agent multi-session, per the A2A comments in the file) may eventually have a real user on the other end of that session, so forcing `non_interactive=True` there would be wrong. The override is scoped to exactly the `mode == "ephemeral"` branch, where "one prompt in, one reply out, no human" is a structural guarantee, verified by reading `run_agent_step` (`session_api.py`) end to end — it spawns via `spawn_ephemeral_session`, sends one `MessageBus.request` "user" turn, and returns the joined reply; no path round-trips through an actual human.

Also adds a small read-only `Session.non_interactive` property (mirrors the existing `total_usage`/`total_cost_usd` public-delegation pattern) so tests and callers can observe the effective flag without reaching into the "private" `_non_interactive` attribute — keeps the new test on the public surface per the testing policy.

## Tests

New `tests/test_2585_pr2_ephemeral_non_interactive_force.py` (Tier 2, real `AgentRegistry` + real `Session`, no mocks — mirrors the `holder` deferred-registry-ref factory pattern from `test_2103_A_ephemeral_auto_vanish_1953.py` / `test_pipeline_r5_run_agent_step.py`):

1. `test_ephemeral_spawn_forces_non_interactive_true` — registry factory sets `non_interactive=False` (simulating an interactive frontend); `spawn_session_recorded(mode="ephemeral")`'s result has `.non_interactive is True` — the override fires regardless of the frontend factory's default.
2. `test_persistent_spawn_keeps_factory_default` — `spawn_session_recorded(mode="persistent")` keeps `.non_interactive is False` (the factory's value, untouched) — proving the fix is correctly scoped to ephemeral only.

## Gates (all green locally)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_2585_pr2_ephemeral_non_interactive_force.py` — 2/2 OK, 0 Tier-4 violations.
- `pytest` (full suite, repo root) — 7445 passed, 21 skipped, 5 pre-existing failures (route-mounting tests in `tests/web/` + `test_fp0001_a2a_endpoints.py` + `test_plugin_loader.py`) verified unrelated: reproduced identically via `git stash` against HEAD without this diff.
- `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py src/reyn/runtime/session.py` — clean.

## Out of scope (per brief)

No dogfood A3 verification (separate follow-up). No touch to OS-frame SP wording (PR1) or `_universal_sp.py`. No touch to `max_iterations`. No doc mirror added — grepped `docs/` for pipeline agent-step / ephemeral-session docs referencing `non_interactive`/clarifying-question behavior; none found.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_2585_pr2_ephemeral_non_interactive_force.py`
- [x] `pytest` (full suite; 5 failures confirmed pre-existing/unrelated)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py src/reyn/runtime/session.py`