### PR TITLE
fix: cap the status-bar '…' overflow dropdown height (Window too small)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -89,6 +89,13 @@ _SLASH_COMPLETER = _SlashCompleter()
 # than the terminal height minus the fixed chrome (rules + input + status).
 _ABOVE_REGION_MAX_HEIGHT = 12
 
+# Same cap, for the below-input status-bar dropdown (menu_region). The "…"
+# overflow chip's panel can list one row per tool-visibility toggle (dozens of
+# entries in a real session) — without this cap dropdown_height() requests an
+# unbounded Dimension.exact(), which prompt_toolkit cannot satisfy past the
+# terminal's remaining rows and renders "Window too small" instead of the menu.
+_MENU_REGION_MAX_HEIGHT = 12
+
 
 def _picker_hint(has_picker_focus: bool, key: str | None) -> str:
     """Return the status-bar hint for the above-region picker state.
@@ -547,6 +554,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     # a CommandUIElement model picker (selectable) or a read-only DetailElement
     # (live detail, no cursor). Empty (cleared) while the menu is closed.
     menu_region = Region()
+    menu_region.set_max_visible(_MENU_REGION_MAX_HEIGHT)
     # Guards against a second quit (rapid Ctrl-C / `/quit` then Ctrl-C) racing the
     # first: shutdown has a grace window, so two _quit tasks could both reach
     # app.exit() — the second raises "Return value already set". _quit checks+sets
@@ -625,20 +633,37 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         # The focus cursor is drawn only on a selectable row (the model picker) —
         # a read-only DetailElement reports cursor_on_selectable False, so its
         # detail panel shows no highlight, exactly as before.
+        # Windowed like above_region_frags: the "…" overflow chip can list one
+        # row per tool-visibility toggle (dozens in a real session), so this
+        # slices to _MENU_REGION_MAX_HEIGHT rows + a "↓ N more" hint instead of
+        # requesting an unbounded height (prompt_toolkit "Window too small").
         draw_cursor = menu_region.cursor_on_selectable
+        scroll = menu_region.scroll
+        lines = menu_region.lines()
+        visible = lines[scroll : scroll + _MENU_REGION_MAX_HEIGHT]
+        cursor_local = menu_region.cursor - scroll
         out: list = []
-        for i, ln in enumerate(menu_region.lines()):
+        for i, ln in enumerate(visible):
             if i:
                 out.append(("", "\n"))
-            if draw_cursor and i == menu_region.cursor:
+            if draw_cursor and i == cursor_local:
                 out.append((f"fg:#0d0f12 bg:{_CC_ACCENT} bold", f" {ln} "))
             else:
                 style = _CC_DONE if ln.startswith("▸") else _CC_DIM
                 out.append((f"fg:{style}", f"   {ln}"))
+        items_below = len(lines) - scroll - _MENU_REGION_MAX_HEIGHT
+        if items_below > 0:
+            out.append(("", "\n"))
+            out.append((f"fg:{_CC_DIM}", f"   ↓ {items_below} more"))
         return out
 
     def dropdown_height() -> Dimension:
-        return Dimension.exact(len(menu_region.lines()))
+        lines = menu_region.lines()
+        n = len(lines)
+        scroll = menu_region.scroll
+        visible = min(n, _MENU_REGION_MAX_HEIGHT)
+        hint = 1 if n > scroll + _MENU_REGION_MAX_HEIGHT else 0
+        return Dimension.exact(visible + hint)
 
     dropdown = ConditionalContainer(
         Window(FormattedTextControl(dropdown_frags), height=dropdown_height),

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from reyn.interfaces.inline.app import (
     _CHIP_SPECS,
+    _MENU_REGION_MAX_HEIGHT,
     _agent_expansion,
     _build_task_tree,
     _cost_expansion,
@@ -684,3 +685,29 @@ def test_task_rows_empty_tree_replacement_shows_fallback() -> None:
 
     tc["tree"] = []
     assert el.lines() == ["(no active tasks)"]
+
+
+# ---------------------------------------------------------------------------
+# _more_expansion overflow (the "…" chip dropdown "Window too small" bug)
+# ---------------------------------------------------------------------------
+
+
+def test_more_expansion_many_tools_exceeds_menu_region_cap() -> None:
+    """Tier 2: a real session's per-tool visibility list (one row per registered
+    tool, dozens in production — 76 observed live) produces MORE total lines than
+    _MENU_REGION_MAX_HEIGHT. Pins the exact scenario that made app.py's
+    dropdown_height() (unbounded Dimension.exact(len(menu_region.lines()))) crash
+    prompt_toolkit with "Window too small" for the "…" chip specifically — the
+    model/cost/agent/task chips' expansions never approach this size, so the bug
+    was invisible until a session with many registered tools opened "…". The fix
+    (menu_region.set_max_visible + windowed dropdown_frags/height, mirroring
+    above_region) lives in local closures inside run_inline_input and isn't
+    unit-testable directly; this pins the upstream content-volume precondition.
+    """
+    many_tools = [
+        {"kind": "tool", "name": f"tool_{i}", "on": True} for i in range(76)
+    ]
+    snap = _snap(visibility_items=many_tools)
+    result = _more_expansion(snap, lambda _: None)
+    total_lines = sum(len(el.lines()) for el in result)
+    assert total_lines > _MENU_REGION_MAX_HEIGHT


### PR DESCRIPTION
**[tui-coder]** Owner-reported bug fix

## Problem

Selecting the status-bar "…" (overflow) chip and pressing Enter showed prompt_toolkit's `"Window too small..."` message instead of the dropdown menu, on a completely fresh session — reproduced live via tmux (mandatory per this repo's live-verify discipline).

## Root cause

Traced via a temporary debug log in `dropdown_height()`: the below-input dropdown region (`menu_region`) had **no height cap**. `dropdown_height()` requested an unbounded `Dimension.exact(len(menu_region.lines()))`.

The "…" chip's `_more_expansion()` lists one row per **registered tool** for the visibility-toggle section — my live test session had 76 tools registered, producing **95 total lines** (tool header + 76 rows, hooks header + row, cron header + row). prompt_toolkit's `HSplit` cannot satisfy a fixed-height request that exceeds the terminal's remaining rows, so it renders "Window too small" instead.

The other four chips (model/cost/agent/task) never produce enough rows to hit this — model's max content is ~12 rows (model classes) — so the bug stayed invisible until a session with many registered tools opened "…".

The ABOVE-input region (`above_region`, used for interventions / the `/rewind` picker) already solved this exact failure class: `_ABOVE_REGION_MAX_HEIGHT` + windowed rendering (`lines[scroll:scroll+N]`) + a `"↓ N more"` hint. That treatment was simply never extended to the below-input status-bar dropdown when it was built.

## Fix

Mirrors the existing `above_region` pattern exactly (no new mechanism):

- `menu_region.set_max_visible(_MENU_REGION_MAX_HEIGHT)` (new constant, `=12`, same value as `_ABOVE_REGION_MAX_HEIGHT`)
- `dropdown_frags()` / `dropdown_height()` now slice to the visible window (`scroll` offset) + append a `"↓ N more"` hint line, exactly like `above_region_frags()` / `above_region_height()`.

## Live verification

- Fresh `reyn chat` session, navigated to "…" chip, pressed Enter → dropdown now renders correctly (12 rows + `"↓ 83 more"`) instead of crashing.
- ↓ scrolling advances the visible window and the "N more" count correctly.
- Enter still toggles a tool's visibility and dispatches `/visibility on|off tool <name>` correctly.
- Esc still closes the dropdown cleanly.
- Model/cost/agent/task chip dropdowns unaffected (verified model chip still opens correctly, unchanged).

## Files changed

- `src/reyn/interfaces/inline/app.py` — new `_MENU_REGION_MAX_HEIGHT` constant, `menu_region.set_max_visible()` call, windowed `dropdown_frags()`/`dropdown_height()`
- `tests/test_inline_pr3b_status_bar.py` — 1 new regression test pinning the 76-tool overflow precondition

## Test plan

- [x] Reproduced live via tmux before any code change (mandatory discipline)
- [x] `pytest tests/test_inline_pr3b_status_bar.py tests/test_inline_region_framework.py` — 65 passed
- [x] `ruff check` changed files — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_inline_pr3b_status_bar.py` — 54 OK, 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — OK
- [x] Full `pytest` — 7458 passed, 17 skipped
- [x] Fix re-verified live via tmux after the code change (dropdown renders, scrolls, toggles, closes correctly)

## Tier self-check

No mocks, no private-state asserts, no format/size pins, no snapshots. New test is Tier 2.