### PR TITLE
docs: fix pipeline install workflow + broken example + add canonical data-flow section

### DIFF
--- a/docs/guide/for-users/write-a-pipeline.ja.md
+++ b/docs/guide/for-users/write-a-pipeline.ja.md
@@ -1,10 +1,10 @@
 # pipeline を書いて実行する
 
-pipeline は、決定的なマルチステップ制御フローを記述する小さな YAML ファイルです。本ガイドでは、pipeline を書き、プロジェクトに配置し、起動するまでを扱います — さらに、エージェントがその場で生成する一回限りの手順向けに、登録不要な ad-hoc の代替手段も扱います。完全な文法と起動ツールのリファレンスは [Pipeline DSL リファレンス](../../reference/runtime/pipeline-dsl.ja.md) を、why / アーキテクチャは [Pipeline](../../concepts/runtime/pipelines.ja.md) を参照してください。
+pipeline は、決定的なマルチステップ制御フローを記述する小さな YAML ファイルです。本ガイドでは、pipeline を書き、登録し、起動するまでを扱います — さらに、エージェントがその場で生成する一回限りの手順向けに、登録不要な ad-hoc の代替手段も扱います。完全な文法と起動ツールのリファレンスは [Pipeline DSL リファレンス](../../reference/runtime/pipeline-dsl.ja.md) を、why / アーキテクチャは [Pipeline](../../concepts/runtime/pipelines.ja.md) を参照してください。
 
 ## 1. pipeline を書く
 
-プロジェクトルートに `pipelines/` ディレクトリ(デフォルトのスキャン対象ディレクトリ)を作成し、`*.yaml` ファイルを配置します。以下は `name` を受け取り、挨拶し、その結果を叫ぶ pipeline です:
+プロジェクト内の任意の場所に Appendix-B DSL ファイルを書きます(デフォルトのスキャン対象ディレクトリは無くなりました — 手順 2 参照)。以下は `name` を受け取り、挨拶し、その結果を叫ぶ pipeline です:
 
 ```yaml
 # pipelines/greet.yaml
@@ -12,22 +12,33 @@ pipeline: greet
 description: Greet a name and shout it.
 steps:
   - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
-  - shell: {command: !expr "'echo ' + greeting", output: shouted}
+  - shell: {command: !expr "'echo ' + ctx.greeting", output: shouted}
 ```
 
 このファイルについて注目すべき点がいくつかあります:
 
 - pipeline は `pipeline:` キーの名前(`greet`)の下に登録されます。ファイル名ではありません — `pipelines/greet.yaml` は何にリネームしても `greet` として登録され続けます。
 - 各ステップは、自身の種別(`transform`、`tool`、`agent`、または合成プリミティブ(Pipeline DSL リファレンス参照)のいずれか)を名前とする単一キーのマッピングです。
-- `ctx.name` はこの pipeline が期待する seed input です。`greeting` は最初のステップの `output` で書き込まれた後、後続のステップで `ctx.greeting` として利用可能になります — ここでは 2 番目のステップのコンテキストがそれを named store として公開しているため、`!expr` 文字列連結の中で bare な `greeting` として参照しています。
+- `ctx.name` はこの pipeline が期待する seed input です。`greeting` は最初のステップの `output` で書き込まれた後、それ以降のすべてのステップから `ctx.greeting` として利用可能になります。bare name のショートカットはありません — `ctx.greeting` の代わりに bare な `greeting` として読もうとするとステップが失敗します。すべての expression は `ctx`(すべての named store)と `pipe`(直前のステップ自身の結果)の 2 つだけをトップレベルキーとして持つコンテキストに対して評価されるためです。完全なルールと実例のトレースは [ステップ間のデータフロー](../../reference/runtime/pipeline-dsl.ja.md#data-flow-between-steps) を参照してください。
 - `!expr` は `command` をリテラル文字列ではなく評価すべき expression としてマークします — [リテラル vs `!expr`](../../reference/runtime/pipeline-dsl.ja.md#vs-expr) 参照。
 - `shell` は operator のサンドボックスの中でコマンドを実行し、前のステップの pipe data を JSON エンコードして STDIN に渡します — この pipeline はその入力を使いませんが、完全な STDIN/STDOUT の契約は[リファレンスの `shell` セクション](../../reference/runtime/pipeline-dsl.ja.md#tool-shell)を参照してください。
 
-## 2. セッションを開始(または再起動)する
+## 2. 登録する
 
-pipeline はセッション開始時にディスクから登録されます — 別途「インストール」ステップは無く、デフォルトの `pipelines/` ディレクトリには `reyn.yaml` へのエントリも不要です。セッションを再起動する(または新しく開始する)と `greet` が登録されます。
+pipeline は、config 内の明示的な `pipelines.entries` 宣言によってのみ登録されます — ディレクトリスキャンは無いため、ディスク上に置かれた `*.yaml` ファイルは登録されるまでどのセッションからも不可視です。`reyn.yaml` にエントリを追加します(エントリキーは DSL 自身が宣言する `pipeline:` 名と完全に一致しなければなりません):
 
-ファイルの parse に失敗した場合、または 2 つのファイルが同じ `pipeline:` 名を宣言した場合、セッション開始は問題のファイルを名指しして大きく失敗します — タイプミスが、出荷するつもりだった pipeline を静かに消すことはありません。詳細な表は [Pipeline registration § Failure behavior](../../concepts/runtime/pipeline-registration.md#failure-behavior-fail-loud) を参照してください。
+```yaml
+# reyn.yaml
+pipelines:
+  entries:
+    greet:
+      path: pipelines/greet.yaml
+      description: "Greet a name and shout it"
+```
+
+あるいは、同等の効果として、エージェントに `pipeline_management__install_local(path="pipelines/greet.yaml")` を呼んでもらうこともできます — これはファイルを parse し、名前を検証し、`.reyn/config/pipelines.yaml` に同種のエントリを書き込みます。どちらの方法でも、変更は次のターン境界で hot-reload によって反映されます — 新しく登録した pipeline を反映させるのに**セッションの再起動は不要**です。
+
+ファイルの parse に失敗した場合、または 2 つのエントリが同じ `pipeline:` 名を宣言した場合、読み込みは問題のエントリを名指しして大きく失敗します — タイプミスが、出荷するつもりだった pipeline を静かに消すことはありません。詳細な表は [Pipeline registration § Failure behavior](../../concepts/runtime/pipeline-registration.md#failure-behavior-fail-loud) を参照してください。
 
 ## 3. 起動する
 
@@ -91,9 +102,9 @@ steps:
           schema: Review
       collect: {transform: {value: "pipe"}}
       output: reviews
-  - transform: {value: "all(reviews, r -> r.passed)", output: all_passed}
+  - transform: {value: "all(ctx.reviews, r -> r.passed)", output: all_passed}
   - match:
-      on: all_passed
+      on: ctx.all_passed
       cases:
         "True": {pipeline: report_pass, pass: [reviews]}
         "False": {pipeline: report_fail, pass: [reviews]}
@@ -111,4 +122,6 @@ fields:
 run_pipeline(name="review", input={reviewers: ["reviewer_a", "reviewer_b"], doc: "..."})
 ```
 
-各レビュアーは隔離された並行 `agent` ステップとして実行され(最大 4 並行、失敗時は 1 回リトライ)、全員の結果が揃うと、R1 の `all()` コンビネータで `all_passed` という 1 つの boolean に畳み込まれ、`match` がそれに応じて `report_pass` または `report_fail` の sub-pipeline にルーティングします(どちらも別途登録が必要です。単一ファイルで完結させたい場合は、素の `transform`/`tool` ステップに置き換えてください)。
+各レビュアーは隔離された並行 `agent` ステップとして実行され(最大 4 並行、失敗時は 1 回リトライ)、全員の結果が揃うと、R1 の `all()` コンビネータで `all_passed` という 1 つの boolean に畳み込まれます — これは bare な `reviews` ではなく、`for_each` ステップの `output` が書き込んだ永続的な named store である `ctx.reviews` から読みます — そして `match` がそれに応じて `report_pass` または `report_fail` の sub-pipeline にルーティングします(どちらも別途登録が必要です。単一ファイルで完結させたい場合は、素の `transform`/`tool` ステップに置き換えてください)。
+
+この 2 つ目の pipeline も、手順 2 と同様に独自の `pipelines.entries` 宣言(または `pipeline_management__install_local` 呼び出し)が必要です — エージェントがそれを起動できるようになる前に。

--- a/docs/guide/for-users/write-a-pipeline.md
+++ b/docs/guide/for-users/write-a-pipeline.md
@@ -1,17 +1,17 @@
 # Write and run a pipeline
 
 A pipeline is a small YAML file describing a deterministic, multi-step
-control flow. This guide walks through writing one, dropping it into your
-project, and invoking it — plus the ad-hoc, no-registration alternative for a
-one-off procedure an agent generates on the fly. For the full grammar and
+control flow. This guide walks through writing one, registering it, and
+invoking it — plus the ad-hoc, no-registration alternative for a one-off
+procedure an agent generates on the fly. For the full grammar and
 invocation-tool reference, see the [Pipeline DSL reference](../../reference/runtime/pipeline-dsl.md);
 for the why/architecture, see [Pipelines](../../concepts/runtime/pipelines.md).
 
 ## 1. Write the pipeline
 
-Create a `pipelines/` directory at your project root (the default scan
-directory) and drop in a `*.yaml` file. This one takes a `name`, greets it,
-and shouts the result:
+Write an Appendix-B DSL file anywhere in your project (there is no default
+scan directory — see step 2). This one takes a `name`, greets it, and shouts
+the result:
 
 ```yaml
 # pipelines/greet.yaml
@@ -19,7 +19,7 @@ pipeline: greet
 description: Greet a name and shout it.
 steps:
   - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
-  - shell: {command: !expr "'echo ' + greeting", output: shouted}
+  - shell: {command: !expr "'echo ' + ctx.greeting", output: shouted}
 ```
 
 A few things worth noting about this file:
@@ -31,9 +31,12 @@ A few things worth noting about this file:
   `agent`, or one of the [compositional primitives](../../reference/runtime/pipeline-dsl.md#compositional-primitives)).
 - `ctx.name` is the seed input this pipeline expects; `greeting`, once
   written by the first step's `output`, becomes available as `ctx.greeting`
-  in later steps — here referenced bare as `greeting` inside the `!expr`
-  string-concat, since the second step's context still exposes it as a named
-  store.
+  in every later step. There is no bare-name shortcut — reading it as bare
+  `greeting` (instead of `ctx.greeting`) fails the step, since every
+  expression evaluates against a context whose only two top-level keys are
+  `ctx` (all named stores) and `pipe` (the immediately-preceding step's own
+  result). See [Data flow between steps](../../reference/runtime/pipeline-dsl.md#data-flow-between-steps)
+  for the full rule and a worked trace.
 - `!expr` marks `command` as an expression to evaluate, not a literal string
   — see [Literals vs `!expr`](../../reference/runtime/pipeline-dsl.md#literals-vs-expr).
 - `shell` runs the command in the operator's sandbox and threads the
@@ -42,16 +45,33 @@ A few things worth noting about this file:
   [reference doc's `shell` section](../../reference/runtime/pipeline-dsl.md#tool-shell-sugar)
   for the full STDIN/STDOUT contract.
 
-## 2. Start (or restart) the session
+## 2. Register it
 
-Pipelines are registered from disk at session start — there's no separate
-"install" step and no `reyn.yaml` entry required for the default `pipelines/`
-directory. Restart your session (or start a fresh one) and `greet` is
-registered.
+Pipelines are registered purely via an explicit `pipelines.entries`
+declaration in config — there is no directory scan, so a `*.yaml` file
+sitting on disk is invisible to every session until it is registered. Add an
+entry to `reyn.yaml` (the entry key must match the DSL's own declared
+`pipeline:` name exactly):
 
-If a file fails to parse, or two files declare the same `pipeline:` name,
-session start fails loudly, naming the offending file — a typo never
-silently drops a pipeline you meant to ship. See
+```yaml
+# reyn.yaml
+pipelines:
+  entries:
+    greet:
+      path: pipelines/greet.yaml
+      description: "Greet a name and shout it"
+```
+
+or, equivalently, ask an agent to call
+`pipeline_management__install_local(path="pipelines/greet.yaml")`, which
+parses the file, validates the name, and writes the same kind of entry to
+`.reyn/config/pipelines.yaml` for you. Either way the change takes effect at
+the next turn boundary via hot-reload — **no session restart needed** to pick
+up a newly-registered pipeline.
+
+If the file fails to parse, or two entries declare the same `pipeline:` name,
+loading fails loudly, naming the offending entry — a typo never silently
+drops a pipeline you meant to ship. See
 [Pipeline registration § Failure behavior](../../concepts/runtime/pipeline-registration.md#failure-behavior-fail-loud)
 for the full table.
 
@@ -140,9 +160,9 @@ steps:
           schema: Review
       collect: {transform: {value: "pipe"}}
       output: reviews
-  - transform: {value: "all(reviews, r -> r.passed)", output: all_passed}
+  - transform: {value: "all(ctx.reviews, r -> r.passed)", output: all_passed}
   - match:
-      on: all_passed
+      on: ctx.all_passed
       cases:
         "True": {pipeline: report_pass, pass: [reviews]}
         "False": {pipeline: report_fail, pass: [reviews]}
@@ -162,7 +182,13 @@ run_pipeline(name="review", input={reviewers: ["reviewer_a", "reviewer_b"], doc:
 
 Each reviewer runs as an isolated, concurrent `agent` step (up to 4 at once,
 each retried once on failure); once all have landed, `all_passed` folds them
-into one boolean via the R1 `all()` combinator, and `match` routes to a
-`report_pass` or `report_fail` sub-pipeline accordingly (both would need to
-be registered separately, or replaced with plain `transform`/`tool` steps for
-a self-contained single-file version).
+into one boolean via the R1 `all()` combinator — read from `ctx.reviews`,
+the durable named store the `for_each` step's `output` wrote, not a bare
+`reviews` — and `match` routes to a `report_pass` or `report_fail`
+sub-pipeline accordingly (both would need to be registered separately, or
+replaced with plain `transform`/`tool` steps for a self-contained single-file
+version).
+
+This second pipeline would need its own `pipelines.entries` declaration (or
+`pipeline_management__install_local` call), same as step 2 above, before an
+agent can launch it.

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -26,8 +26,43 @@ pipeline: review_and_report
 description: Review a document and summarize the verdict.
 steps:
   - agent: {prompt: "Review {ctx.doc}. Reply with passed/notes.", schema: Review, output: review}
-  - transform: {value: "review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
+  - transform: {value: "ctx.review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
 ```
+
+## ステップ間のデータフロー {#data-flow-between-steps}
+
+すべてのステップの expression / テンプレートは、常にこの 2 つに対してのみ評価されます — 第三の形は無く、bare name のショートカットもありません:
+
+- **`ctx`** — 現在のスコープでこれまでに蓄積された、すべての named store をフラットな namespace として持つもの。`output: X` を宣言したステップは、それ以降のスコープ内のすべてのステップから `ctx.X` として読めるようになります — bare な `X` としてではありません。
+- **`pipe`** — 現在のスコープで直前に実行されたステップ自身の結果。名前は無く、一時的です。bare な `pipe` として読みます(`ctx.pipe` ではありません — `pipe` は named store ではなく、コンテキストのトップレベルキーです)。`output:` を宣言しないステップも、次のステップのための `pipe` data は生成します。単に永続的な名前が付かないだけです。
+
+つまり `output: X` は同時に 2 つのことを行います: 同じシーケンスの次のステップの `pipe` になる、*かつ* `ctx.X` として永続的に書き込まれ、スコープが終わるまで(下記参照)それ以降のスコープ内のすべてのステップから見えるようになります(直後のステップだけではありません)。
+
+**実例のトレース** — 3 つのステップで、各境界で `ctx` と `pipe` が何を保持しているかを正確に示します:
+
+```yaml
+steps:
+  - transform: {value: "ctx.name + '!'", output: greeting}   # ステップ 0
+  - tool: {name: shout, args: {text: !expr pipe}, output: shouted}  # ステップ 1
+  - transform: {value: "ctx.shouted + ' (done)'", output: final}   # ステップ 2
+```
+
+`ctx = {name: "Reyn"}` でシードした場合:
+
+| ステップの前 | `ctx` | `pipe` |
+|---|---|---|
+| 0 | `{name: "Reyn"}` | `null`(先行ステップ無し) |
+| 1 | `{name: "Reyn", greeting: "Reyn!"}` | `"Reyn!"`(ステップ 0 の結果) |
+| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: "REYN!"}` | `"REYN!"`(ステップ 1 の結果) |
+| *(ステップ 2 の後)* | `{..., final: "REYN! (done)"}` | `"REYN! (done)"` |
+
+ステップ 1 はステップ 0 の結果を、両方とも機能する 2 通りの方法で読めます: bare な `pipe`(直前のステップ)か `ctx.greeting`(永続的な store)です — ステップ 0 の直後はどちらも同じ値を保持しますが、間に別のステップが挟まると `ctx.greeting` だけが到達可能なままです。
+
+**スコープの例外**(規範的な記述は下記の[形式文法 § 構造的な不変条件](#formal-grammar)参照):
+
+- `for_each`/`parallel` のブランチはそれぞれ、ブランチ開始時点での外側の `ctx` の**隔離されたコピー**に対して評価します — ブランチ内の書き込みが外側のスコープや sibling ブランチに漏れ出すことはありません。
+- `call`/`match` の callee の `ctx` は `pass:` に列挙された名前**のみ**から構築されます — そこに列挙されていない caller の named store は、`ctx` のショートカットであっても callee から不可視です。
+- `fold` の `do` と `for_each` の `do` は、それぞれ自身のコンテキストに `ctx`/`pipe` に加えて追加のトップレベルキー(`fold` は `item`/`acc`、`for_each` は `item`)を持ちます — 下記のそれぞれのセクション参照。
 
 ### `pipeline:` ドキュメントのキー
 
@@ -39,7 +74,7 @@ steps:
 
 `input` / `defaults` / `refine` は pipeline 設計のより完全な文法の一部ですが、まだランタイムがありません — これらを使ったドキュメントは、静かに無視されるのではなく、明示的な「まだサポートされていない」エラーで parse に失敗します。
 
-## 形式文法
+## 形式文法 {#formal-grammar}
 
 以下の EBNF は**規範的な、現行の**文法です — 初期の設計提案からではなく、`parse_pipeline_dsl`(`src/reyn/core/pipeline/parser.py`)から直接導出されています。今日パーサが受け付けるものを正確にカバーしています: これに適合する定義はクリーンに parse でき、違反は拒否されます。YAML のマッピングキーは無順序です — 以下の線形な並びは可読性のためであり、位置的な要求ではありません。`NAME` は識別子的な bare 文字列、`EXPR` は [R1 expression](#r1-expression) のソース文字列、`TPL` は `agent.prompt` のテンプレート文字列(`{ctx.dotted.path}` / `{pipe}` 補間、R1 ではない)です。
 
@@ -125,8 +160,8 @@ FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
 
 - `call`/`match`/`fold` の `do`、`for_each` の `do`/`collect`、`parallel` の branch/`collect` は**完全にネストされた `Step`** です — どのステップ種別でもよく、別の合成プリミティブでも構いません。
 - `call`、`match` の case/`default`、`parallel` の `branches` は、いずれも**静的リテラル**の pipeline / ステップターゲットを指定します — 実行時の expression では決してありません。実行時に評価されるのは `match.on` と `for_each`/`fold` の `over` だけです。
-- `pass:` は `call`/`match` の callee のコンテキストが構築される*唯一の*チャネルです — そこに列挙されていない caller の named store は callee から不可視です。
-- `for_each`/`parallel` のブランチはそれぞれ、外側の named store の**隔離されたコピー**を受け取ります — 並行なアイテム/ブランチ間の sibling 通信はありません。
+- `pass:` は `call`/`match` の callee のコンテキストが構築される*唯一の*チャネルです — そこに列挙されていない caller の named store は callee から不可視です([ステップ間のデータフロー](#data-flow-between-steps)参照)。
+- `for_each`/`parallel` のブランチはそれぞれ、外側の named store の**隔離されたコピー**を受け取ります — 並行なアイテム/ブランチ間の sibling 通信はありません([ステップ間のデータフロー](#data-flow-between-steps)参照)。
 - `!expr` は `tool`/`shell` の引数を解決すべき expression にする*唯一の*方法です — リスト / マッピングの中にネストすると静かな no-op ではなく parse エラーになります。
 
 ## ステップ種別
@@ -135,7 +170,7 @@ FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
 
 ### `transform`
 
-純粋なステップです: `value` は現在のコンテキストに対して [R1 expression](#r1-expression) として評価され、その結果がこのステップの pipe data になります(`output` が設定されていれば、その named store にも書き込まれます)。
+純粋なステップです: `value` は現在のコンテキスト(`ctx`/`pipe` — [ステップ間のデータフロー](#data-flow-between-steps)参照)に対して [R1 expression](#r1-expression) として評価され、その結果がこのステップの pipe data になります(`output` が設定されていれば、その named store にも書き込まれます)。
 
 ```yaml
 - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
@@ -184,7 +219,7 @@ FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
 args: {query: !expr ctx.brief, limit: !expr "ctx.n + 1", label: "a plain string"}
 ```
 
-`query` と `limit` は R1 expression のソースで、実行時にステップのコンテキストに対して解決されます。`label` はリテラル文字列 `"a plain string"` です。`!expr` は引数の**値全体**としてのみ有効です — ネストしたリスト / マッピングの中に隠れていると parse エラーになるため、「たまたま expression に見えるリテラル」と「expression」の間に曖昧さはありません。
+`query` と `limit` は R1 expression のソースで、実行時にステップの `ctx`/`pipe` コンテキストに対して解決されます([ステップ間のデータフロー](#data-flow-between-steps)参照)。`label` はリテラル文字列 `"a plain string"` です。`!expr` は引数の**値全体**としてのみ有効です — ネストしたリスト / マッピングの中に隠れていると parse エラーになるため、「たまたま expression に見えるリテラル」と「expression」の間に曖昧さはありません。
 
 `transform.value` は常に R1 expression です(`transform` ステップにリテラル形式は無いため `!expr` タグは不要)。`agent` ステップの `prompt` は決して R1 expression ではありません — 下記参照。
 
@@ -232,7 +267,7 @@ callee の最初のステップは call サイトでの caller の pipe data を
 
 ```yaml
 - match:
-    on: "review.passed"
+    on: "ctx.review.passed"
     cases:
       "True": {pipeline: report_pass, pass: [review]}
       "False": {pipeline: report_fail, pass: [review]}
@@ -251,7 +286,7 @@ callee の最初のステップは call サイトでの caller の pipe data を
 
 ### `fold` — 逐次アキュムレータ
 
-リストを順に走査し、繰り返される `do` ステップを通してアキュムレータを引き継ぎます。
+リストを順に走査し、繰り返される `do` ステップを通してアキュムレータを引き継ぎます。`do` のコンテキストは、通常の `ctx`/`pipe`([ステップ間のデータフロー](#data-flow-between-steps)参照)に加えて `item` と `acc` という 2 つの追加のトップレベルキーを持ちます — 詳細は下の表を参照。
 
 ```yaml
 - fold:
@@ -275,7 +310,7 @@ callee の最初のステップは call サイトでの caller の pipe data を
 
 ### `for_each` — 並行 fan-out
 
-各リストアイテムに対して `do` を隔離された並行サブスコープとして実行し、その後 `collect` を一度だけ結果に対して実行します。
+各リストアイテムに対して `do` を隔離された並行サブスコープとして実行し、その後 `collect` を一度だけ結果に対して実行します。このセクションの `do` コンテキストが依拠する隔離ルール(各アイテムが自身の `ctx` コピーを持ち、書き込みがアイテム間や外側のスコープに漏れ出すことはない)については[ステップ間のデータフロー](#data-flow-between-steps)参照。
 
 ```yaml
 - for_each:
@@ -301,7 +336,7 @@ callee の最初のステップは call サイトでの caller の pipe data を
 
 ### `parallel` — 異種・名前付きブランチの fan-out
 
-`for_each` の異種版の兄弟です: 実行時サイズのリストに対して単一の `do` を fan-out する代わりに、`parallel` は静的で有限な、*それぞれ異なる*名前付きブランチの集合を並行に fan-out し、その後 `collect` を一度だけそれらの結果の名前付きマップに対して実行します。
+`for_each` の異種版の兄弟です: 実行時サイズのリストに対して単一の `do` を fan-out する代わりに、`parallel` は静的で有限な、*それぞれ異なる*名前付きブランチの集合を並行に fan-out し、その後 `collect` を一度だけそれらの結果の名前付きマップに対して実行します。`for_each` と同じ隔離ルールです — [ステップ間のデータフロー](#data-flow-between-steps)参照: 各ブランチは自身の `ctx` コピーを持ち、`collect` の `pipe` はどれか 1 つのブランチの結果ではなく `{branch_name: result}` マップ全体です。
 
 ```yaml
 - parallel:
@@ -309,7 +344,7 @@ callee の最初のステップは call サイトでの caller の pipe data を
     branches:
       security: {agent: {prompt: "Security-review {ctx.doc}", schema: Review}}
       style: {agent: {prompt: "Style-review {ctx.doc}", schema: Review}}
-    collect: {transform: {value: "{'security': security, 'style': style}"}}
+    collect: {transform: {value: "{security: pipe.security, style: pipe.style}"}}
     output: reviews
 ```
 
@@ -521,9 +556,9 @@ steps:
       schema: Review
       output: review
   - transform:
-      value: "review.passed and 'OK' or 'NEEDS WORK'"
+      value: "ctx.review.passed and 'OK' or 'NEEDS WORK'"
       output: verdict
   - shell:
-      command: !expr "'echo ' + verdict"
+      command: !expr "'echo ' + ctx.verdict"
       output: shouted
 ```

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -32,8 +32,64 @@ pipeline: review_and_report
 description: Review a document and summarize the verdict.
 steps:
   - agent: {prompt: "Review {ctx.doc}. Reply with passed/notes.", schema: Review, output: review}
-  - transform: {value: "review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
+  - transform: {value: "ctx.review.passed and 'OK' or 'NEEDS WORK'", output: verdict}
 ```
+
+## Data flow between steps
+
+Every step's expression / template evaluates against exactly the same two
+top-level things — there is no third form and no bare-name shortcut:
+
+- **`ctx`** — every named store accumulated so far in the current scope, as a
+  flat namespace. A step that declared `output: X` makes it readable, from
+  every later step in scope, as `ctx.X` — never bare `X`.
+- **`pipe`** — the immediately preceding step's own result in the current
+  scope, unnamed and ephemeral. Read as bare `pipe` (not `ctx.pipe` — `pipe`
+  is a top-level context key, not a named store). A step with no `output:`
+  still produces `pipe` data for whichever step runs next; it just isn't
+  durably named.
+
+So `output: X` does two things at once: it becomes `pipe` for the very next
+step in the same sequence, *and* it is durably written to `ctx.X`, visible to
+every later step in scope (not only the immediate next one) until the scope
+ends.
+
+**A worked trace** — three steps, showing exactly what `ctx` and `pipe` hold
+at each boundary:
+
+```yaml
+steps:
+  - transform: {value: "ctx.name + '!'", output: greeting}   # step 0
+  - tool: {name: shout, args: {text: !expr pipe}, output: shouted}  # step 1
+  - transform: {value: "ctx.shouted + ' (done)'", output: final}   # step 2
+```
+
+seeded with `ctx = {name: "Reyn"}`:
+
+| Before step | `ctx` | `pipe` |
+|---|---|---|
+| 0 | `{name: "Reyn"}` | `null` (no prior step) |
+| 1 | `{name: "Reyn", greeting: "Reyn!"}` | `"Reyn!"` (step 0's result) |
+| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: "REYN!"}` | `"REYN!"` (step 1's result) |
+| *(after step 2)* | `{..., final: "REYN! (done)"}` | `"REYN! (done)"` |
+
+Step 1 reads step 0's result two ways that both work: bare `pipe` (its
+immediate predecessor) or `ctx.greeting` (the durable store) — they hold the
+same value right after step 0, but only `ctx.greeting` stays reachable once a
+step runs in between.
+
+**Scoping exceptions** (see [Formal grammar § Structural
+invariants](#formal-grammar) below for the normative statement):
+
+- `for_each`/`parallel` branches each evaluate against an **isolated copy**
+  of the outer `ctx` taken at branch-start — a write inside a branch never
+  leaks back to the outer scope or to a sibling branch.
+- A `call`/`match` callee's `ctx` is built **only** from the names listed in
+  `pass:` — a caller's named store not listed there is invisible to the
+  callee, `ctx` shortcut or not.
+- `fold`'s `do` and `for_each`'s `do` add extra top-level keys to their own
+  context (`item`/`acc` for `fold`, `item` for `for_each`) alongside `ctx`
+  and `pipe` — see their own sections below.
 
 ### `pipeline:` document keys
 
@@ -147,9 +203,11 @@ and executor, not just documented convention):
   **static literal** pipeline/step target — never a runtime expression. Only
   `match.on` and `for_each`/`fold`'s `over` are runtime-evaluated.
 - `pass:` is the *only* channel a `call`/`match` callee's context is built
-  from — a caller's named store not listed there is invisible to the callee.
+  from — a caller's named store not listed there is invisible to the callee
+  (see [Data flow between steps](#data-flow-between-steps)).
 - `for_each`/`parallel` branches each get an **isolated copy** of the outer
-  named stores — no sibling communication between concurrent items/branches.
+  named stores — no sibling communication between concurrent items/branches
+  (see [Data flow between steps](#data-flow-between-steps)).
 - `!expr` is the *only* way a `tool`/`shell` argument becomes a resolved
   expression instead of a literal — nesting it inside a list/mapping value is
   a parse error, not a silent no-op.
@@ -162,8 +220,10 @@ steps** — they read the context, do one piece of work, and produce a result:
 ### `transform`
 
 A pure step: `value` is evaluated as an [R1 expression](#the-r1-expression-language)
-against the current context; the result becomes this step's pipe data (and,
-if `output` is set, is also written to that named store).
+against the current context (`ctx`/`pipe` — see
+[Data flow between steps](#data-flow-between-steps)); the result becomes this
+step's pipe data (and, if `output` is set, is also written to that named
+store).
 
 ```yaml
 - transform: {value: "'Hello, ' + ctx.name + '!'", output: greeting}
@@ -227,7 +287,9 @@ args: {query: !expr ctx.brief, limit: !expr "ctx.n + 1", label: "a plain string"
 ```
 
 `query` and `limit` are R1 expression sources, resolved against the step's
-context at run time; `label` is the literal string `"a plain string"`.
+`ctx`/`pipe` context at run time (see
+[Data flow between steps](#data-flow-between-steps)); `label` is the literal
+string `"a plain string"`.
 `!expr` is only honored as the **whole value** of an argument — one hiding
 inside a nested list or mapping is a parse error, so there is no ambiguity
 between "a literal that happens to look like an expression" and "an
@@ -291,7 +353,7 @@ runs that case's target exactly like a `call` step.
 
 ```yaml
 - match:
-    on: "review.passed"
+    on: "ctx.review.passed"
     cases:
       "True": {pipeline: report_pass, pass: [review]}
       "False": {pipeline: report_fail, pass: [review]}
@@ -312,6 +374,9 @@ selects a *label*, never a target directly.
 ### `fold` — sequential accumulator
 
 Walks a list in order, threading an accumulator through a repeated `do` step.
+`do`'s context extends the usual `ctx`/`pipe` (see
+[Data flow between steps](#data-flow-between-steps)) with two extra top-level
+keys, `item` and `acc` — see the table below.
 
 ```yaml
 - fold:
@@ -340,7 +405,10 @@ collect independently.
 ### `for_each` — concurrent fan-out
 
 Runs `do` over each list item as an isolated concurrent sub-scope, then runs
-`collect` once over the ordered results.
+`collect` once over the ordered results. See
+[Data flow between steps](#data-flow-between-steps) for the isolation rule
+this section's `do` context relies on (each item gets its own `ctx` copy —
+writes never leak between items or back to the outer scope).
 
 ```yaml
 - for_each:
@@ -371,7 +439,10 @@ cannot see any other item's result.
 `for_each`'s heterogeneous sibling: instead of fanning one `do` step out over
 a runtime-sized list, `parallel` fans a static, finite set of *distinct*
 named branches out concurrently, then runs `collect` once over the named map
-of their results.
+of their results. Same isolation rule as `for_each` — see
+[Data flow between steps](#data-flow-between-steps): each branch gets its own
+`ctx` copy, and `collect`'s `pipe` is the whole `{branch_name: result}` map,
+not any one branch's result directly.
 
 ```yaml
 - parallel:
@@ -379,7 +450,7 @@ of their results.
     branches:
       security: {agent: {prompt: "Security-review {ctx.doc}", schema: Review}}
       style: {agent: {prompt: "Style-review {ctx.doc}", schema: Review}}
-    collect: {transform: {value: "{'security': security, 'style': style}"}}
+    collect: {transform: {value: "{security: pipe.security, style: pipe.style}"}}
     output: reviews
 ```
 
@@ -686,9 +757,9 @@ steps:
       schema: Review
       output: review
   - transform:
-      value: "review.passed and 'OK' or 'NEEDS WORK'"
+      value: "ctx.review.passed and 'OK' or 'NEEDS WORK'"
       output: verdict
   - shell:
-      command: !expr "'echo ' + verdict"
+      command: !expr "'echo ' + ctx.verdict"
       output: shouted
 ```

--- a/pipelines/hello.yaml
+++ b/pipelines/hello.yaml
@@ -1,9 +1,19 @@
-# Sample pipeline (#2575) — the minimal end-to-end example.
+# Sample pipeline — the minimal end-to-end example.
 #
-# Drop an Appendix-B DSL file into this directory (`pipelines/`, the default
-# scan dir) and it is loaded + registered at session start under its declared
-# `pipeline:` name. This one registers as `hello` (the file name is just a
-# container — the `pipeline:` key below is authoritative).
+# This file is NOT registered by merely sitting in this directory — pipelines
+# are registered only via an explicit `pipelines.entries.<name>` declaration
+# in config (see docs/concepts/runtime/pipeline-registration.md). To make
+# this one live, either add:
+#
+#     pipelines:
+#       entries:
+#         hello:
+#           path: pipelines/hello.yaml
+#
+#   to reyn.yaml, or call `pipeline_management__install_local` with this
+#   file's path. Either way it registers as `hello` — the `pipeline:` key
+#   below is authoritative, not the file name — and is live immediately via
+#   hot-reload (no session restart needed).
 #
 # An agent can then launch it:
 #     run_pipeline(name="hello", input={name: "Reyn"})


### PR DESCRIPTION
**[per-PR-coder]** — Docs-only fix for the owner-reported "step-to-step data flow is ambiguous, I don't understand it" complaint, plus a stale post-#2635 install-workflow description found in the same investigation.

## What was wrong

1. **Stale install workflow** — `write-a-pipeline.md`/`.ja.md` described the pre-existing directory-scan registration model ("drop a file in `pipelines/`, restart the session"). That model was removed entirely by the pipeline-install change that merged just before this PR — pipelines are now registered only via an explicit `pipelines.entries.<name>` config declaration (hand-edited or via `pipeline_management__install_local`/`install_source`), live via hot-reload with no restart needed. Rewrote both language versions' "1. Write" / "2. (register)" sections to the current flow, and fixed `pipelines/hello.yaml`'s header comment, which still claimed directory-scan registration.

2. **Broken flagship example** — the guide's `greet.yaml` had `shell: {command: !expr "'echo ' + greeting", ...}`, referencing the named store `greeting` bare instead of as `ctx.greeting`. I re-verified this myself (not just trusted the report) by reading `src/reyn/core/pipeline/executor.py` (module docstring: every step evaluates against `{"ctx": named_stores, "pipe": pipe_data}`) and `expr.py::_resolve_path` (walks from the full 2-key context — a bare name that isn't `ctx` or `pipe` itself is never resolvable). I then actually ran both the broken and corrected pipeline through `parse_pipeline_dsl` + `PipelineExecutor` in a scratch script: the broken form raises `ExprEvalError: path 'greeting' is absent: no field 'greeting' in context`; the corrected `ctx.greeting` form executes end-to-end and produces the expected output. Fixed the example and its accompanying (self-contradictory) prose.

   While auditing `pipeline-dsl.md`/`.ja.md` for the same anti-pattern I found (and fixed, also with scratch-verified expression evaluation) several sibling instances of the identical bug: `match.on: "review.passed"` → `"ctx.review.passed"`, the canonical grammar example's `transform`/`shell` steps, and a `parallel` `collect` step whose object-literal syntax was doubly broken (quoted keys are a parse error in R1's object-literal grammar, and its values were also bare instead of `pipe.<branch>`). Also fixed the guide's second worked example (`for_each`+`match`), which had the same bare-`reviews`/bare-`all_passed` bug.

3. **No canonical data-flow explanation** — added one "Data flow between steps" section to `pipeline-dsl.md`/`.ja.md` (positioned right after "Document shape"), covering the `ctx`/`pipe` two-key context rule, the `output:` dual-write semantics, the `for_each`/`parallel` isolation rule and `call`/`match`'s `pass:`-only channel (cross-referencing the existing "Structural invariants" list), and a worked 3-step trace showing exactly what `ctx`/`pipe` hold at each boundary. Cross-referenced from `transform`, `tool`, `fold`, `for_each`, and `parallel`.

Both `.md`/`.ja.md` pairs updated consistently.

## Verification

- Re-read the cited code myself (`executor.py`, `expr.py::_resolve_path`, `MatchStep`'s `evaluate_expr(step.on, inv.context)` call) rather than trusting the report at face value.
- Ran the corrected `greet` example end-to-end via `parse_pipeline_dsl` + `PipelineExecutor` (scratch script, not committed) — confirmed the broken form raises and the corrected form succeeds with the expected `named_stores`/`pipe_data`.
- Verified the additional bare-reference bugs (parallel collect, `all(reviews,...)`, `match.on`) directly against `reyn.core.pipeline.expr.evaluate_expr`, confirming each raises in its buggy form and succeeds in its corrected form.
- `ruff check src tests` — clean (no src/test changes, ran anyway per the gate instructions).
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no new anchor/link issues introduced by this change (added explicit `{#id}` anchors on the two new pure-Japanese headings in `pipeline-dsl.ja.md` since mkdocs' slugifier falls back to numbered IDs for headings with no ASCII characters — a pre-existing repo-wide pattern I did not otherwise touch).

## Scope note

This PR is docs-only (`docs/**` + one sample pipeline comment). No `src`/`tests` changes, so `python scripts/test_tier_audit.py` and `pytest` are trivially skippable — nothing for them to run against.

## Test plan

- [x] Re-verified the bare-name bug against real executor/expr code (not just trusted the report).
- [x] Ran the corrected `greet` example end-to-end (scratch script) — succeeds.
- [x] Ran the broken form to confirm it actually raises `ExprEvalError`.
- [x] Verified additional bare-reference bugs found while auditing (parallel collect, `all(reviews,...)`, `match.on`) against real `evaluate_expr`.
- [x] `ruff check src tests` clean.
- [x] `mkdocs build --strict` exits 0 with no anchor/link regressions from this change.
- [x] Both `.md`/`.ja.md` pairs updated consistently.