### PR TITLE
feat: durably log unhandled asyncio exceptions for post-hoc diagnosis

### DIFF
--- a/docs/reference/dogfood-tracing.md
+++ b/docs/reference/dogfood-tracing.md
@@ -255,6 +255,38 @@ found` — the mode never crashes on missing files.
 
 ---
 
+# Asyncio Unhandled Exceptions (`asyncio_unhandled_exception` event)
+
+reyn installs a durable-capture `asyncio` exception handler
+(`reyn.core.events.asyncio_diagnostics.install_asyncio_exception_handler`) on
+every real loop-owning entrypoint (`reyn chat`, `reyn web`, `reyn cron run`,
+`reyn dogfood`, the chainlit server). Before this existed, a fire-and-forget
+background task (`asyncio.create_task(...)` whose result nobody awaits or
+checks) that raised was caught only by Python's own
+`asyncio.BaseEventLoop.default_exception_handler` — logged to stderr and then
+gone, the exact "Unhandled exception in event loop" / "exception: None"
+signature an operator cannot investigate after the fact.
+
+The handler always defers to the loop's own default handler first (no change
+to existing stderr/log visibility), then durably emits an
+`asyncio_unhandled_exception` P6 event via `emit_cli_event` (session-
+independent — routes to `.reyn/events/direct/cli/<date>.jsonl`, found the
+same way regardless of which entrypoint hit it).
+
+```bash
+python scripts/dogfood_trace.py --mode full --filter asyncio_unhandled_exception --root .reyn
+```
+
+Fields on the event: `exception_type` (str, `""` when asyncio reported a
+message-only context with no exception object), `exception_message`,
+`traceback` (full, untruncated in the stored JSONL — `--mode full`'s console
+printer truncates long lines like it does for every event kind; read the
+`.reyn/events/direct/cli/*.jsonl` file directly for the complete traceback),
+`context_message` (asyncio's raw `context["message"]`, always present), and
+`task_repr` (best-effort `repr()` of the task/future, `""` if undeterminable).
+
+---
+
 # LLM Replay (`scripts/llm_replay.py`)
 
 `llm_replay.py` takes a trace file, finds a specific request by `request_id`,

--- a/src/reyn/core/events/asyncio_diagnostics.py
+++ b/src/reyn/core/events/asyncio_diagnostics.py
@@ -1,0 +1,97 @@
+"""Global asyncio unhandled-exception -> durable P6 event capture.
+
+reyn installs no custom asyncio exception handler anywhere by default. That
+means a fire-and-forget background task (``asyncio.create_task(...)`` /
+``asyncio.ensure_future(...)`` whose result nobody awaits or checks) that
+raises is caught ONLY by Python's own
+``asyncio.BaseEventLoop.default_exception_handler`` -- which logs
+"Unhandled exception in event loop" (sometimes with ``exception: None`` when
+asyncio only has a *message*, no exception object) to stderr/logging and is
+then GONE. Nothing durable survives past that point, so an operator who
+notices the message days later has no way to investigate after the fact.
+
+``install_asyncio_exception_handler`` closes that gap: it installs a handler
+on the given (already-running) loop that ALWAYS defers to the loop's own
+default handler first (byte-identical existing stderr/log visibility), then
+durably emits an ``asyncio_unhandled_exception`` P6 event via
+``emit_cli_event`` -- the existing session-independent "no active Session in
+this process" durable-emit path (routes to
+``.reyn/events/direct/cli/<date>.jsonl``, found by walking up from
+``Path.cwd()``). Using ``emit_cli_event`` rather than a per-session
+``EventLog`` is a deliberate choice: reyn has several distinct loop-owning
+entrypoints (`reyn chat`, `reyn web`, `reyn cron run`, `reyn dogfood`, the
+chainlit server) and not all of them have a single active session at the
+point an unhandled exception surfaces (the web server and chainlit app can
+have zero-to-many concurrently attached sessions sharing one loop) -- a
+uniform, session-independent sink avoids having to special-case each
+entrypoint's session lifecycle just to find "the" EventLog to write to.
+
+Call this once per real loop-owning entrypoint, right after the loop is
+obtained/created and before the main work starts. Calling it more than once
+on the same loop is harmless (``loop.set_exception_handler`` just overwrites
+with an equivalent handler).
+"""
+from __future__ import annotations
+
+import asyncio
+import traceback
+from typing import Any
+
+_EVENT_KIND = "asyncio_unhandled_exception"
+
+
+def install_asyncio_exception_handler(loop: asyncio.AbstractEventLoop) -> None:
+    """Install the durable-capture asyncio exception handler on *loop*.
+
+    *loop* must already be the running loop of the entrypoint that owns it
+    (e.g. obtained via ``asyncio.get_running_loop()`` from inside the
+    entrypoint's top-level coroutine, or the loop just created by
+    ``asyncio.new_event_loop()``).
+    """
+    loop.set_exception_handler(_make_handler())
+
+
+def _make_handler():
+    def _handler(loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        # ALWAYS defer to the loop's own default handler first -- this
+        # handler only ADDS durable capture, it never replaces or suppresses
+        # the existing stderr/logging behavior an operator already relies on.
+        loop.default_exception_handler(context)
+        _durably_capture(context)
+
+    return _handler
+
+
+def _durably_capture(context: dict[str, Any]) -> None:
+    # Local import: keeps this module import-cheap for entrypoints that
+    # install the handler before the rest of reyn's config/event machinery
+    # is set up, and avoids import-cycle risk (events.py is a low-level
+    # module several higher layers import).
+    from reyn.core.events.events import emit_cli_event
+
+    exc = context.get("exception")
+    if exc is not None:
+        tb = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        exception_type = type(exc).__name__
+        exception_message = str(exc)
+    else:
+        # asyncio sometimes reports a message-only context (no exception
+        # object) -- this is the exact class an operator sees as
+        # "exception: None" and cannot investigate after the fact. Still
+        # durably captured: context_message is always present.
+        tb = ""
+        exception_type = ""
+        exception_message = ""
+    task = context.get("task") or context.get("future")
+
+    try:
+        emit_cli_event(
+            _EVENT_KIND,
+            exception_type=exception_type,
+            exception_message=exception_message,
+            traceback=tb,
+            context_message=context.get("message", ""),
+            task_repr=repr(task) if task is not None else "",
+        )
+    except Exception:  # noqa: BLE001 -- durable-capture must never crash the loop
+        pass

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -136,6 +136,17 @@ async def _get_or_build_registry() -> "AgentRegistry":
         if _REGISTRY is not None:
             return _REGISTRY
 
+        # This runs exactly once per process (guarded by _REGISTRY is None
+        # above), on the shared loop chainlit's ASGI server owns — the
+        # equivalent choke point to the FastAPI `_lifespan` startup hook in
+        # reyn.interfaces.web.server, since chainlit (like `reyn web`) has
+        # no asyncio.run()-call-site of its own for this process to hook.
+        # See reyn.core.events.asyncio_diagnostics.
+        from reyn.core.events.asyncio_diagnostics import (
+            install_asyncio_exception_handler,
+        )
+        install_asyncio_exception_handler(asyncio.get_running_loop())
+
         import argparse
 
         from reyn.config import _find_project_root, load_project_context

--- a/src/reyn/interfaces/cli/commands/cron.py
+++ b/src/reyn/interfaces/cli/commands/cron.py
@@ -227,6 +227,15 @@ def run_run(args: argparse.Namespace) -> None:
 
 async def _run_scheduler() -> None:
     """Build scheduler, start jobs, block until Ctrl-C."""
+    from reyn.core.events.asyncio_diagnostics import (
+        install_asyncio_exception_handler,
+    )
+    # `reyn cron run` is a real long-running foreground process (blocks until
+    # Ctrl-C) that starts one background asyncio task per enabled job — a
+    # durable capture point for a job task that raises unnoticed. See
+    # reyn.core.events.asyncio_diagnostics.
+    install_asyncio_exception_handler(asyncio.get_running_loop())
+
     from reyn.runtime.cron import CronJob, CronScheduler
 
     job_configs = _load_jobs()

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -342,8 +342,16 @@ def run_run(args: argparse.Namespace) -> None:
     if replay_dir:
         print(f"  replay mode: {replay_dir}")
 
-    result = asyncio.run(
-        run_scenario_set(
+    async def _drive() -> object:
+        # Batch driver: spins up N real agent Sessions (each with its own
+        # background tasks — hot-reload, fs-watch) on this one loop. Durable
+        # capture point for a background task that outlives its scenario.
+        # See reyn.core.events.asyncio_diagnostics.
+        from reyn.core.events.asyncio_diagnostics import (
+            install_asyncio_exception_handler,
+        )
+        install_asyncio_exception_handler(asyncio.get_running_loop())
+        return await run_scenario_set(
             scenario_set,
             run_id=getattr(args, "run_id", None),
             storage_dir=storage_dir,
@@ -354,7 +362,8 @@ def run_run(args: argparse.Namespace) -> None:
             with_interpretation=getattr(args, "with_interpretation", False),
             interpretation_model=getattr(args, "interpretation_model", None),
         )
-    )
+
+    result = asyncio.run(_drive())
 
     agg = result.aggregate()
     run_dir = storage_dir or (_runs_dir() / result.run_id)

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -117,6 +117,21 @@ _DISPOSITION_SWEEP_INTERVAL_SECONDS = 30.0
 async def _lifespan(app: FastAPI):
     # ── Startup ──
 
+    # Durable asyncio unhandled-exception capture (see
+    # reyn.core.events.asyncio_diagnostics). `reyn web` is uvicorn-owned —
+    # uvicorn.run() creates and owns the loop, so there is no
+    # asyncio.run()-call-site choke point to hook (unlike `run_async` for
+    # the CLI chat path). The lifespan startup hook is the first point this
+    # process has a *running* loop to install the handler on, and it runs
+    # exactly once per server process regardless of how many browser/API
+    # clients subsequently attach.
+    import asyncio  # noqa: PLC0415
+
+    from reyn.core.events.asyncio_diagnostics import (  # noqa: PLC0415
+        install_asyncio_exception_handler,
+    )
+    install_asyncio_exception_handler(asyncio.get_running_loop())
+
     # FP-0001 + issue #267 Gap 5: RunRegistry singleton — process-wide
     # task lifecycle tracking with snapshot persistence so a process
     # restart preserves A2A async-task state (= the structural gap that

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -463,8 +463,20 @@ async def shutdown_logging() -> None:
 
 
 def run_async(coro: Coroutine[object, object, T]) -> T:
-    """`asyncio.run` plus LiteLLM logging-worker drain. See `shutdown_logging`."""
+    """`asyncio.run` plus LiteLLM logging-worker drain. See `shutdown_logging`.
+
+    This is the shared loop-owning choke point for `reyn chat` (the
+    interactive REPL / `--once` one-shot drive) and the mcp.py CLI commands
+    that build their own event loop -- installing the durable asyncio
+    unhandled-exception capture here (rather than at each call site)
+    covers all of them from one place. See
+    ``reyn.core.events.asyncio_diagnostics`` for why.
+    """
     async def _wrapped() -> T:
+        from reyn.core.events.asyncio_diagnostics import (
+            install_asyncio_exception_handler,
+        )
+        install_asyncio_exception_handler(asyncio.get_running_loop())
         try:
             return await coro
         finally:

--- a/tests/test_asyncio_diagnostics.py
+++ b/tests/test_asyncio_diagnostics.py
@@ -1,0 +1,118 @@
+"""Tier 2b: an unhandled exception in a fire-and-forget asyncio task is
+durably captured as an `asyncio_unhandled_exception` P6 event, without
+losing the event loop's own default exception handling.
+
+Regression context: reyn installed no `asyncio.set_exception_handler`
+anywhere, so a background `asyncio.create_task(...)` whose result nobody
+awaits/checks would raise into Python's own
+`asyncio.BaseEventLoop.default_exception_handler` (stderr/logging only) and
+be gone — the exact "Unhandled exception in event loop" / "exception: None"
+class an operator cannot investigate after the fact. This test exercises the
+real `install_asyncio_exception_handler` + `emit_cli_event` path (no mocks)
+end to end: schedule a raising task on a real loop, let the loop process it,
+and assert the event landed durably under `.reyn/events/`.
+
+Policy compliance (docs/deep-dives/contributing/testing.md):
+- No unittest.mock / MagicMock / AsyncMock / patch.
+- Real event loop, real filesystem (pytest tmp_path), real EventStore reader.
+- Test docstring first line declares Tier.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.asyncio_diagnostics import install_asyncio_exception_handler
+
+
+def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
+    """Read every JSONL event of *kind* from anywhere under *events_dir*."""
+    found: list[dict] = []
+    if not events_dir.exists():
+        return found
+    for path in events_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            if rec.get("type") == kind:
+                found.append(rec)
+    return found
+
+
+def test_unhandled_task_exception_is_durably_captured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2b: a raising fire-and-forget task's exception survives as a P6 event.
+
+    Steps:
+    1. Real ``.reyn/`` dir under tmp_path (the durable-emit anchor
+       ``emit_cli_event`` walks up from cwd to find).
+    2. Real event loop; install the handler; schedule a task that raises
+       with NO one awaiting/checking its result (the fire-and-forget class).
+    3. Yield control (``asyncio.sleep(0)`` twice) so the loop's own
+       call_exception_handler path actually fires for the failed task.
+    4. Read back ``.reyn/events/**/*.jsonl`` and assert one
+       ``asyncio_unhandled_exception`` event exists with the right fields.
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    async def _boom() -> None:
+        raise ValueError("kaboom-from-background-task")
+
+    async def _drive() -> None:
+        install_asyncio_exception_handler(asyncio.get_running_loop())
+        asyncio.create_task(_boom())  # fire-and-forget: nobody awaits this
+        # Give the loop two ticks: one to run _boom() to its raise, one more
+        # for the loop to notice the task's exception was never retrieved
+        # and invoke the exception handler.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    asyncio.run(_drive())
+
+    events = _read_events_of_kind(reyn_dir / "events", "asyncio_unhandled_exception")
+    [event] = events  # exactly one event captured — unpack raises otherwise
+    data = event["data"]
+    assert data["exception_type"] == "ValueError"
+    assert "kaboom-from-background-task" in data["exception_message"]
+    assert "ValueError: kaboom-from-background-task" in data["traceback"]
+    assert "Task exception was never retrieved" in data["context_message"]
+
+
+def test_default_handler_still_invoked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2b: installing our handler does not regress existing stderr/log visibility.
+
+    asyncio's own default_exception_handler logs the failure via the
+    ``asyncio`` logger at ERROR level. This asserts that log record still
+    fires (our handler wraps, never replaces, the default one).
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    async def _boom() -> None:
+        raise RuntimeError("still-visible-in-logs")
+
+    async def _drive() -> None:
+        install_asyncio_exception_handler(asyncio.get_running_loop())
+        asyncio.create_task(_boom())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    with caplog.at_level(logging.ERROR, logger="asyncio"):
+        asyncio.run(_drive())
+
+    assert any(
+        "still-visible-in-logs" in str(record.message)
+        or (record.exc_info and "still-visible-in-logs" in str(record.exc_info[1]))
+        for record in caplog.records
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Fixes the observability gap the owner hit ("Unhandled exception in event loop" / "exception: None" while using reyn interactively, with no durable trace): `grep -rn "set_exception_handler" src/` confirmed reyn installs no custom `asyncio` exception handler anywhere, so a fire-and-forget background task (`asyncio.create_task(...)` whose result nobody awaits/checks) that raises is caught only by Python's own `asyncio.BaseEventLoop.default_exception_handler` — logged to stderr and then gone.

This PR is purely the OBSERVABILITY fix; it does not attempt to reproduce or fix any specific unhandled exception (unknown/unreproducible right now).

## What was wired, and where

New module `src/reyn/core/events/asyncio_diagnostics.py`: `install_asyncio_exception_handler(loop)` installs a handler that (1) **always** defers to the loop's own `default_exception_handler` first — zero regression to existing stderr/log visibility — then (2) durably emits an `asyncio_unhandled_exception` P6 event via the existing session-independent `emit_cli_event` helper (`reyn.core.events.events`), which routes to `.reyn/events/direct/cli/<date>.jsonl` by walking up from `Path.cwd()`.

**Why `emit_cli_event` and not a per-session `EventLog`**: reyn has several distinct loop-owning entrypoints, and not all of them have exactly one active session at the point an exception surfaces — `reyn web` and the chainlit server can have zero-to-many concurrently attached sessions sharing one loop. A single session-independent sink avoids special-casing each entrypoint's session lifecycle just to pick "the" `EventLog` to write to.

**Wired at 5 real loop-owning entrypoints** (not one-shot CLI utilities like `reyn agent create`):

1. **`reyn.llm.llm.run_async`** — the shared choke point for `reyn chat` (interactive REPL + `--once` one-shot drive) and the `mcp.py` CLI commands that build their own loop through it. Single wiring point covers all of them.
2. **`reyn.interfaces.web.server._lifespan`** (FastAPI startup) — `reyn web` is uvicorn-owned (`uvicorn.run()` creates/owns the loop), so there's no `asyncio.run()` call site to hook; the lifespan startup hook is the first point this process has a *running* loop, and it fires exactly once per server process.
3. **`reyn.interfaces.cli.commands.cron._run_scheduler`** — `reyn cron run` blocks in the foreground and starts one background task per enabled job.
4. **`reyn.interfaces.cli.commands.dogfood`** (batch driver) — wrapped the existing `asyncio.run(run_scenario_set(...))` call so the handler installs before the batch's per-scenario Sessions (each with their own background hot-reload/fs-watch tasks) spin up.
5. **`reyn.interfaces.chainlit_app.app._get_or_build_registry`** — process-singleton, built lazily on first chat start (guarded by `_REGISTRY is not None`), the chainlit-side equivalent of the FastAPI lifespan hook since chainlit also has no `asyncio.run()` call site of its own to intercept.

## Event shape

`asyncio_unhandled_exception`: `exception_type` (str, `""` when asyncio reports a message-only context with no exception object — the exact "exception: None" class the owner saw), `exception_message`, `traceback` (full, untruncated in the stored JSONL), `context_message` (asyncio's raw `context["message"]`, always present), `task_repr` (best-effort `repr()` of the task/future, `""` if undeterminable).

Query it post-hoc with:
```
python scripts/dogfood_trace.py --mode full --filter asyncio_unhandled_exception --root .reyn
```
(`--mode full`'s console printer truncates long lines for every event kind, same as today — read the JSONL file directly for the complete traceback.)

## Verification

- New Tier 2b test `tests/test_asyncio_diagnostics.py` (real event loop, real filesystem, no mocks): schedules a fire-and-forget task that raises, lets the loop process it, and asserts the event lands durably with the right fields (`test_unhandled_task_exception_is_durably_captured`), plus a second test asserting the loop's own `default_exception_handler` logging still fires unchanged (`test_default_handler_still_invoked`).
- All 4 CI gates run locally:
  - `ruff check src tests` — clean.
  - `python scripts/test_tier_audit.py --strict tests/test_asyncio_diagnostics.py` — clean (fixed one Tier-4 `len(...) == N` pin via unpack-assert idiom).
  - `pytest` from repo root — 7491 passed, 21 skipped, 5 pre-existing failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `web/test_a2a.py::test_a2a_routes_mounted`, `web/test_mcp_sse.py::test_mcp_routes_mounted`, `web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `web/test_resources_router.py::test_resources_route_is_mounted_on_app`) — confirmed identical on `main` with this diff stashed (route-mount test-isolation issue on the shared FastAPI `app` singleton, unrelated to this PR).
  - `python scripts/verify_module_docstrings.py <changed src files>` — clean.

## Docs

Added an "Asyncio Unhandled Exceptions" section to `docs/reference/dogfood-tracing.md` (mirrors the `hook_push_fired`/hook-liveness section's structure) documenting the event kind, fields, and the `--filter` invocation.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_asyncio_diagnostics.py`
- [x] `pytest` from repo root (pre-existing failures confirmed unrelated)
- [x] `python scripts/verify_module_docstrings.py <changed files>`
- [x] New test verifies durable capture end-to-end with a real event loop
- [x] New test verifies the default handler's existing behavior is preserved