### PR TITLE
feat: add parse_json combinator to the R1 pipeline expression language

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -2,7 +2,7 @@
 type: reference
 topic: runtime
 audience: [human, agent]
-search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns, parse_json]
 ---
 
 # Pipeline DSL リファレンス
@@ -385,6 +385,7 @@ combinator     ::= "map" "(" expr "," lambda ")"
                   | "sum" "(" expr ")"
                   | "join" "(" expr "," expr ")"
                   | "get" "(" expr "," STRING ("," expr)? ")"
+                  | "parse_json" "(" expr ")"
 lambda         ::= IDENT "->" expr        (* コンビネータ自身の引数としてのみ有効 *)
 path           ::= IDENT ("." IDENT)*
 cmp_op         ::= "==" | "!=" | "<" | ">" | "<=" | ">="
@@ -409,6 +410,7 @@ cmp_op         ::= "==" | "!=" | "<" | ">" | "<=" | ">="
 | `sum` | `sum(list)` | 数値の合計。 |
 | `join` | `join(list, sep)` | 文字列 join。 |
 | `get` | `get(base, "dotted.path", default?)` | **安全な**ナビゲーション — bare な `Path` と異なり、パスが存在しなくても例外を送出せず、`default`(無ければ `null`)を返す。 |
+| `parse_json` | `parse_json(string)` | JSON 文字列をその値(object/array/string/number/bool/null)にデコードする。引数が文字列でないか、有効な JSON でなければ例外を送出する — 安全なデフォルト返却バリアントは存在しない。 |
 
 `lambda`(`item -> expr`)は `map`/`filter`/`all`/`any`/`find` の直接の引数としてのみ有効です — 代入したり受け渡したりできる値ではありません。この固定コンビネータ集合の外にある名前を関数呼び出しとして書くと parse エラーになります。
 

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -2,7 +2,7 @@
 type: reference
 topic: runtime
 audience: [human, agent]
-search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns]
+search_hints: [pipeline DSL, pipeline grammar, EBNF, formal grammar, agent generation grammar, transform step, tool step, agent step, call step, match step, fold step, for_each step, parallel step, expr, R1 expression, verify schema, run_pipeline, run_pipeline_async, run_pipeline_inline, safety.spawn.max_pipeline_fan_out_depth, safety.spawn.max_pipeline_spawns, parse_json]
 ---
 
 # Pipeline DSL reference
@@ -499,6 +499,7 @@ combinator     ::= "map" "(" expr "," lambda ")"
                   | "sum" "(" expr ")"
                   | "join" "(" expr "," expr ")"
                   | "get" "(" expr "," STRING ("," expr)? ")"
+                  | "parse_json" "(" expr ")"
 lambda         ::= IDENT "->" expr        (* only valid as a combinator's own argument *)
 path           ::= IDENT ("." IDENT)*
 cmp_op         ::= "==" | "!=" | "<" | ">" | "<=" | ">="
@@ -530,6 +531,7 @@ set:
 | `sum` | `sum(list)` | Numeric sum. |
 | `join` | `join(list, sep)` | String-join. |
 | `get` | `get(base, "dotted.path", default?)` | **Safe** navigation — unlike a bare `Path`, never raises on a missing path; returns `default` (or `null`) instead. |
+| `parse_json` | `parse_json(string)` | Decode a JSON string into its value (object/array/string/number/bool/null). Raises if the argument is not a string or is not valid JSON — there is no safe/default-returning variant. |
 
 A `lambda` (`item -> expr`) is only ever valid as the direct argument of
 `map`/`filter`/`all`/`any`/`find` — it is not a value that can be assigned or

--- a/src/reyn/core/pipeline/expr.py
+++ b/src/reyn/core/pipeline/expr.py
@@ -11,7 +11,8 @@ trust context. This module is total by construction instead:
 
 - No recursion and no user-defined functions: the grammar has no call syntax
   beyond a fixed, closed set of combinators (``map``/``filter``/``all``/
-  ``any``/``count``/``sum``/``find``/``join``/``get``), and a ``Lambda`` node
+  ``any``/``count``/``sum``/``find``/``join``/``get``/``parse_json``), and a
+  ``Lambda`` node
   can only be produced as the direct argument of one of those combinators —
   it is never a value, so it can't be stored, named, returned, or invoked
   more than once per element.
@@ -28,6 +29,7 @@ path an expression reads (feeds the future data-flow analyzer).
 """
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -129,7 +131,7 @@ class Combinator:
 ExprNode = Union[Literal, Path, ListLit, ObjectLit, Unary, Binary, Lambda, Combinator]
 
 COMBINATOR_NAMES = frozenset(
-    {"map", "filter", "all", "any", "count", "sum", "find", "join", "get"}
+    {"map", "filter", "all", "any", "count", "sum", "find", "join", "get", "parse_json"}
 )
 _LAMBDA_COMBINATORS = frozenset({"map", "filter", "all", "any", "find"})
 
@@ -403,7 +405,7 @@ class _Parser:
             self._expect("COMMA")
             lam = self._parse_lambda()
             args = [list_expr, lam]
-        elif name in ("count", "sum"):
+        elif name in ("count", "sum", "parse_json"):
             args = [self._parse_or()]
         elif name == "join":
             list_expr = self._parse_or()
@@ -704,5 +706,14 @@ def _eval_combinator(node: Combinator, context: Mapping[str, Any]) -> Any:
         parts = path_literal.value.split(".")
         default = evaluate(node.args[2], context) if len(node.args) > 2 else None
         return _resolve_path_safe(parts, base, default)
+
+    if name == "parse_json":
+        value = evaluate(node.args[0], context)
+        if not isinstance(value, str):
+            raise ExprEvalError(f"parse_json() requires a string, got {type(value).__name__}")
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ExprEvalError(f"parse_json() failed to decode: {exc}") from exc
 
     raise ExprEvalError(f"unknown combinator {name!r}")  # pragma: no cover

--- a/tests/test_pipeline_executor_r3_r4.py
+++ b/tests/test_pipeline_executor_r3_r4.py
@@ -13,6 +13,8 @@ Real `StateLog` + `SchemaRegistry` throughout — no mocks, no private-state ass
 """
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from reyn.core.events.state_log import StateLog
@@ -24,6 +26,7 @@ from reyn.core.pipeline.executor import (
     ToolStep,
     TransformStep,
 )
+from reyn.core.pipeline.parser import parse_pipeline_dsl
 from reyn.core.pipeline.schema import SchemaRegistry
 
 
@@ -65,6 +68,44 @@ async def test_linear_pipeline_threads_pipe_data_and_named_stores_via_real_evalu
         "1": "HELLO WORLD!!!",
         "2": "HELLO WORLD!!! (done)",
     }
+
+
+@pytest.mark.asyncio
+async def test_parse_json_decodes_a_tool_result_string_field_end_to_end():
+    """Tier 2: the owner use case — an MCP-style `tool` step returns a payload
+    whose `content` field is a plain TEXT string that is itself JSON-encoded
+    (see `op_runtime/mcp.py`'s `_execute` handler). A DSL string is parsed via
+    the REAL `parse_pipeline_dsl` (not `evaluate_expr` in isolation) and run
+    through the REAL `PipelineExecutor`: a `transform` step decodes that
+    string with `parse_json`, and a later step reads a field off the decoded
+    object via `ctx.<name>.<field>` — proving the full round-trip, not just
+    the isolated combinator call."""
+    dsl = """
+pipeline: mcp-parse-demo
+description: tool result content string parsed into a structured value
+steps:
+  - tool: {name: search, args: {query: "reyn"}, output: raw}
+  - transform: {value: "parse_json(ctx.raw.content)", output: parsed}
+  - transform: {value: "ctx.parsed.count + 1", output: total}
+"""
+    pipeline = parse_pipeline_dsl(dsl, SchemaRegistry())
+
+    def tool_dispatch(name: str, args: dict):
+        assert name == "search"
+        payload = {"count": 5, "items": ["a", "b"]}
+        return {"content": json.dumps(payload)}
+
+    executor = PipelineExecutor()
+    result = await executor.run(
+        pipeline,
+        {},
+        tool_dispatch=tool_dispatch,
+        state_log=None,
+        run_id="run-parse-json-e2e",
+    )
+
+    assert result.named_stores["parsed"] == {"count": 5, "items": ["a", "b"]}
+    assert result.pipe_data == 6
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_expr_evaluator.py
+++ b/tests/test_pipeline_expr_evaluator.py
@@ -7,8 +7,10 @@ a pure, total, tree-walking evaluator for the expression language used by
 pin the public surface (``parse`` / ``evaluate`` / ``evaluate_expr`` /
 ``ExprEvalError`` / ``ExprParseError``): the spec's own example expressions
 must evaluate correctly, the combinator set must cover the reshape needs
-appendix A/C call out, and the totality/safety properties (no recursion, no
-calls, no IO) must hold structurally — not just as an untested claim.
+appendix A/C call out (plus ``parse_json`` for decoding a string payload — e.g.
+an MCP tool result's ``content`` field — into a structured value), and the
+totality/safety properties (no recursion, no calls, no IO) must hold
+structurally — not just as an untested claim.
 """
 from __future__ import annotations
 
@@ -132,6 +134,39 @@ def test_get_with_default_on_absent_path() -> None:
     assert evaluate_expr('get(review, "passed")', ctx) is True
     assert evaluate_expr('get(review, "missing.nested", "fallback")', ctx) == "fallback"
     assert evaluate_expr('get(review, "missing.nested")', ctx) is None
+
+
+def test_parse_json_decodes_object() -> None:
+    """Tier 1: `parse_json(string)` decodes a JSON object into a dict, including
+    nested arrays/bools/null (the R1 grammar's own literal shapes)."""
+    ctx = {"raw": '{"a": 1, "b": [true, null]}'}
+    assert evaluate_expr("parse_json(raw)", ctx) == {"a": 1, "b": [True, None]}
+
+
+def test_parse_json_decodes_array() -> None:
+    """Tier 1: `parse_json(string)` decodes a top-level JSON array into a list."""
+    assert evaluate_expr("parse_json(raw)", {"raw": "[1,2,3]"}) == [1, 2, 3]
+
+
+def test_parse_json_decodes_plain_string() -> None:
+    """Tier 1: `parse_json(string)` on JSON that is itself just a quoted string
+    decodes to that plain string (a valid, if degenerate, JSON document)."""
+    assert evaluate_expr("parse_json(raw)", {"raw": '"just a string"'}) == "just a string"
+
+
+def test_parse_json_invalid_json_raises_eval_error() -> None:
+    """Tier 1: `parse_json(string)` on malformed JSON raises `ExprEvalError` — R1's
+    only combinator error variant is raise, there is no safe/default-returning form
+    (unlike `get()`'s explicit safe-navigation design)."""
+    with pytest.raises(ExprEvalError):
+        evaluate_expr("parse_json(raw)", {"raw": "{not valid"})
+
+
+def test_parse_json_non_string_argument_raises_eval_error() -> None:
+    """Tier 1: `parse_json(expr)` on a non-string value raises `ExprEvalError`
+    rather than silently stringifying or passing the value through."""
+    with pytest.raises(ExprEvalError):
+        evaluate_expr("parse_json(n)", {"n": 42})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[per-PR-coder]** — Adds a tenth R1 combinator, `parse_json(string)`, so a pipeline `transform`/`tool`/`shell` step can decode a JSON-encoded TEXT string at runtime.

## Motivation

MCP tool results surfaced in a pipeline `tool` step often carry their payload as a plain TEXT string (the `content` field — see `src/reyn/core/op_runtime/mcp.py`'s `_execute` handler), which may itself be JSON-encoded. R1 (`src/reyn/core/pipeline/expr.py`) had no combinator to turn that string into a structured value usable by later steps.

## Design decision (owner-approved)

`parse_json(string)` **raises `ExprEvalError`** on a non-string argument or invalid JSON — there is no safe/default-returning variant. This is consistent with R1's existing "bare path resolution raises on a missing field" precedent, and deliberately does **not** mirror `get()`'s explicit safe-navigation design (YAGNI until a real need shows up).

## Changes

- `src/reyn/core/pipeline/expr.py` — `COMBINATOR_NAMES` gains `"parse_json"`; `_parse_combinator` extends the existing `count`/`sum` single-expression-argument shape to include `parse_json`; `_eval_combinator` gains a `parse_json` branch (type-checks the argument is `str`, then `json.loads`, wrapping `JSONDecodeError` into `ExprEvalError`). Module docstring's combinator list updated.
- `docs/reference/runtime/pipeline-dsl.md` and `.ja.md` — EBNF `combinator` production, the Combinators reference table, and `search_hints` frontmatter all updated in both languages.
- `tests/test_pipeline_expr_evaluator.py` — 5 new Tier 1 tests: object/array/plain-string decode, invalid-JSON raise, non-string-argument raise.
- `tests/test_pipeline_executor_r3_r4.py` — 1 new Tier 2 end-to-end test that parses a DSL string via the real `parse_pipeline_dsl` and runs it through the real `PipelineExecutor`: a `tool` step returns an MCP-shaped `{"content": "<json>"}` payload, a `transform` step decodes it with `parse_json`, and a later step reads a field off the decoded object via `ctx.parsed.<field>` — proving the full owner use-case round-trip, not just the isolated combinator call.

## Guide doc — deliberately not touched

Checked `docs/guide/for-users/write-a-pipeline.md`/`.ja.md` per the brief. That guide currently has **no** `tool` step example at all (only `transform`/`shell`/`agent`/compositional primitives), so there was no existing MCP-adjacent example to extend, and adding a free-standing `tool`-step example just to showcase `parse_json` would be out of scope for this PR. Left both guide files untouched.

## Gates run locally

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_expr_evaluator.py tests/test_pipeline_executor_r3_r4.py` — 35/35 OK, 0 Tier-4 violations
- `pytest` (repo root) — 7495 passed, 5 failed, 21 skipped. The 5 failures (`test_fp0001_a2a_endpoints.py`, `test_a2a.py`, `test_mcp_sse.py`, `test_plugin_loader.py`, `test_resources_router.py` — all route-mounting assertions) are **pre-existing on `main`/HEAD**, confirmed by re-running the same 5 tests with this branch's changes stashed (same failures, same assertions).
- `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/expr.py` — OK

## Test plan

- [x] `parse_json` decodes object/array/plain-string JSON correctly (Tier 1)
- [x] Invalid JSON and non-string argument raise `ExprEvalError` (Tier 1)
- [x] Full DSL-parse + real-executor round-trip: MCP-shaped tool `content` string → `parse_json` → later step reads decoded fields (Tier 2)
- [x] Both `pipeline-dsl.md` and `.ja.md` grammar/table/search_hints updated in sync