### PR TITLE
fix: an unloadable pipeline entry no longer crashes reyn startup (per-entry isolation + durable failure logging)

### DIFF
--- a/docs/concepts/runtime/pipeline-registration.md
+++ b/docs/concepts/runtime/pipeline-registration.md
@@ -84,17 +84,42 @@ Hand-editing any of the first three is a normal way to register a pipeline;
 the fourth is written automatically by the install tools below and reflects
 what a session installed for itself.
 
-## Failure behavior — fail loud
+## Failure behavior — per-entry isolated, visible but non-fatal
 
-Loading is strict, so a broken definition is never silently dropped:
+Loading is per-entry isolated: a broken declaration is never silently
+dropped, but it also never takes down the rest of the session's pipelines
+(or the session itself). At session-factory time (every `reyn chat` / `reyn
+web` startup), a broken entry is caught, logged as a warning, durably
+recorded as a `pipeline_load_failed` event (readable via
+`scripts/dogfood_trace.py` / the raw `.reyn/events/direct/cli/*.jsonl`
+files), and skipped — every other declared entry still loads and registers
+normally:
 
 | Condition | Behavior |
 |-----------|----------|
-| Malformed DSL file | Session start fails, naming the offending file. |
-| Entry key ≠ the DSL's declared `pipeline:` name | Session start fails, naming both the key and the declared name. |
-| Two entries declaring the same `pipeline:` name | Session start fails, naming the collision. |
-| An entry's `path` does not exist | Session start fails, naming the path. |
-| No `pipelines.entries` declared | No pipelines registered (empty registry). |
+| Malformed DSL file | That entry is skipped; logged + durably recorded, naming the offending file. Other entries still load. |
+| Entry key ≠ the DSL's declared `pipeline:` name | That entry is skipped; logged + durably recorded, naming both the key and the declared name. Other entries still load. |
+| Two entries declaring the same `pipeline:` name | The FIRST-registered entry (config declaration order) wins; the later, colliding entry is skipped and logged + durably recorded. |
+| An entry's `path` does not exist | That entry is skipped; logged + durably recorded, naming the path. Other entries still load. |
+| No `pipelines.entries` declared | No pipelines registered (empty registry) — not a failure, nothing logged. |
+
+This is a deliberate middle ground between two failure postures neither of
+which fit: fully silent (a typo could vanish a pipeline the operator meant to
+ship, with zero trace — the earlier design's own stated reason for
+fail-loud) and fully fatal (the original fail-loud design — the first
+broken entry anywhere in `pipelines.entries` used to crash the ENTIRE
+session, which meant one unrelated pipeline's typo could take down `reyn
+chat` / `reyn web` startup entirely). Per-entry isolation keeps a broken
+entry visible to the operator (warning + durable event) while letting every
+healthy entry — and the session itself — start normally.
+
+The hot-reload seam (`/reload`, `Session._reapply_pipelines`) is the one
+exception: it opts back into the OLD atomic, fail-loud posture (any broken
+entry aborts the WHOLE rebuild, leaving the previously-loaded registry
+fully intact) — a live session's already-running pipeline registry should
+never have an entry silently vanish out from under it mid-reload, so a
+broken edit at reload time is rejected wholesale rather than partially
+applied.
 
 ## Installing pipelines
 

--- a/docs/reference/dogfood-tracing.md
+++ b/docs/reference/dogfood-tracing.md
@@ -287,6 +287,39 @@ printer truncates long lines like it does for every event kind; read the
 
 ---
 
+# Pipeline Load Failures (`pipeline_load_failed` event)
+
+`reyn.data.pipelines.registry.build_pipeline_registry` (the
+`pipelines.entries` → `PipelineRegistry` loader called at every session-factory
+construction, see `docs/concepts/runtime/pipeline-registration.md` § "Failure
+behavior") isolates each `pipelines.entries.<key>` declaration: a broken entry
+(missing `path`, unreadable file, malformed DSL, a config-key / declared-name
+mismatch, or a duplicate declared name) no longer crashes the whole session
+start. It is durably emitted as a `pipeline_load_failed` P6 event via
+`emit_cli_event` (session-independent — routes to
+`.reyn/events/direct/cli/<date>.jsonl`, same sink as
+`asyncio_unhandled_exception` above) and skipped; every other declared entry
+still loads.
+
+```bash
+python scripts/dogfood_trace.py --mode full --filter pipeline_load_failed --root .reyn
+```
+
+Fields on the event: `key` (the `pipelines.entries.<key>` config key that
+failed), `path` (the entry's declared `path`, `""` if the entry had none),
+and `error` (the descriptive `PipelineLoadError` message, naming the file /
+mismatch / collision as appropriate).
+
+Note: the hot-reload seam (`Session._reapply_pipelines`, the `/reload`
+`pipelines` component) calls the loader with `strict=True` instead — it opts
+back into the OLD fail-loud, atomic posture (any broken entry aborts the
+WHOLE rebuild, previously-loaded registry left fully intact) rather than
+emitting `pipeline_load_failed`, since a live session's registry should never
+have an entry silently vanish mid-reload. That failure is only visible via
+the `_reapply_pipelines` warning log, not this event.
+
+---
+
 # LLM Replay (`scripts/llm_replay.py`)
 
 `llm_replay.py` takes a trace file, finds a specific request by `request_id`,

--- a/src/reyn/data/pipelines/registry.py
+++ b/src/reyn/data/pipelines/registry.py
@@ -18,31 +18,74 @@ authoritative because that is the identity a ``call``/``match`` step's
 ``pipeline: LIT`` resolves against, NOT the config entry's key. A config entry
 key that disagrees with its file's declared name is a footgun (the key you'd
 naturally look for is not the key a `call` step actually resolves against) —
-this loader FAILS LOUD on that mismatch rather than silently registering under
-one or the other (same posture as the install op's op.name vs declared-name
-check in ``op_runtime/pipeline_install.py``).
+this loader refuses that mismatch (same posture as the install op's op.name vs
+declared-name check in ``op_runtime/pipeline_install.py``).
 
-Failure posture is FAIL-LOUD (not silent-skip): a malformed DSL file raises with
-its path (a typo must not silently drop a pipeline the operator meant to ship),
-a duplicate declared name across entries surfaces the registry's own
-re-registration ``ValueError``, and a config-key / declared-name mismatch raises
-explicitly. ``raw_pipelines=None`` (the util/no-root path) → an empty registry;
-an empty/absent ``pipelines:`` block or an empty ``entries`` map → an empty
-registry (zero pipelines is a valid, non-error state — same as skills).
+Failure posture is PER-ENTRY ISOLATED, not process-fatal: a malformed DSL file,
+an unreadable path, a config-key / declared-name mismatch, or a duplicate
+declared name across entries are each caught INSIDE the ``entries`` loop —
+logged as a Python ``logging`` warning AND durably emitted as a
+``pipeline_load_failed`` P6 event (via ``emit_cli_event`` — see its own
+docstring; this loader has no per-session ``ctx``/``EventLog`` handle threaded
+in, and is called from multiple distinct entrypoints, so the session-independent
+sink is the right fit), then SKIPPED — the remaining entries still load. This
+was changed from an earlier fail-loud design (raise straight out of
+``build_pipeline_registry``) because ``SessionFactoryConfig.from_config``
+(``reyn/runtime/factory_config.py``) calls this with no enclosing try/except,
+at EVERY session construction — so one broken pipeline entry anywhere in
+``pipelines.entries`` crashed reyn's ENTIRE startup (`reyn chat` / `reyn web`),
+not just that one pipeline. Visibility is still preserved (the warning + event
+carry the exact same descriptive message the old raise would have) — this is
+NOT the fully-silent ``skills.registry`` pattern (a typo must not silently
+vanish with zero trace); it is "visible but non-fatal".
+
+Duplicate declared name across entries: the FIRST-registered entry with that
+name wins; a later entry that collides is the one skipped/logged (dict
+iteration order = config declaration order — the first entry an operator
+listed keeps its registration).
+
+``raw_pipelines=None`` (the util/no-root path) → an empty registry; an
+empty/absent ``pipelines:`` block or an empty ``entries`` map → an empty
+registry (zero pipelines is a valid, non-error state — same as skills). These
+are the only cases where ``build_pipeline_registry`` returns early WITHOUT
+even entering the per-entry loop — they are not "failures", just an absent
+config shape, so nothing is logged.
+
+``strict=True`` (opt-in, default ``False``) restores the ORIGINAL fail-loud
+posture — the first per-entry failure raises :class:`PipelineLoadError`
+straight out of ``build_pipeline_registry``, with NO logging/eventing (the
+raise itself is the signal). This exists for ``Session._reapply_pipelines``
+(``reyn/runtime/session.py``, the ``pipelines`` hot-reload seam): that seam
+needs ATOMIC last-good-registry semantics — reject the ENTIRE rebuild on any
+broken entry and keep serving the old registry unchanged, rather than
+silently dropping just the broken pipeline from a live session's registry
+graph mid-reload (a "the pipeline this operator was relying on just vanished
+from the running session" surprise). Session-factory construction
+(``SessionFactoryConfig.from_config``) is the opposite case — a NEW session
+about to start has no "old registry" to fall back to, so ``strict=False``
+(the default) is the right posture there: isolate the bad entry, keep the
+good ones, let the session start.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
 from reyn.core.pipeline.registry import PipelineRegistry
 
+logger = logging.getLogger(__name__)
+
 
 class PipelineLoadError(ValueError):
     """A ``pipelines.entries`` declaration could not be loaded (unreadable file,
     malformed DSL, a duplicate declared name, or a config-key / declared-name
-    mismatch). Carries enough detail for the operator to find the offending
-    entry — fail-loud, never silent-skip."""
+    mismatch). Raised internally by :func:`_load_one_entry` and caught PER-ENTRY
+    by :func:`build_pipeline_registry` (logged + durably emitted as a
+    ``pipeline_load_failed`` event, then the entry is skipped — see the module
+    docstring). Still importable/raisable directly by callers that want the
+    old fail-loud posture for a single entry (e.g. an install-time validation
+    path that should refuse a bad file rather than silently accept it)."""
 
 
 def _entry_path(project_root: Path, raw_path: str) -> Path:
@@ -52,8 +95,84 @@ def _entry_path(project_root: Path, raw_path: str) -> Path:
     return p if p.is_absolute() else (project_root / p)
 
 
+def _load_one_entry(
+    key: str, raw: dict, project_root: "Path", registry: PipelineRegistry,
+) -> None:
+    """Load + register ONE ``pipelines.entries.<key>`` declaration.
+
+    Raises :class:`PipelineLoadError` for:
+      - a missing ``path``,
+      - an unreadable / malformed DSL file (path included),
+      - a config entry key that disagrees with its file's declared
+        ``pipeline:`` name,
+      - a duplicate declared name across entries.
+
+    Callers (:func:`build_pipeline_registry`) catch this per-entry — see the
+    module docstring for the visible-but-non-fatal posture. This function
+    itself still fails loud; it is the isolation boundary that changed, not
+    the validation logic.
+    """
+    # Deferred import: parser pulls the pipeline executor/schema stack, which is
+    # heavier than this loader's own surface — keep module import cheap.
+    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+    from reyn.core.pipeline.schema import SchemaRegistry
+
+    raw_path = str(raw.get("path") or "").strip()
+    if not raw_path:
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r} has no 'path' — a pipeline entry "
+            "must declare the DSL file to load."
+        )
+    path = _entry_path(project_root, raw_path)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r}: could not read {path}: {exc}"
+        ) from exc
+
+    schema_registry = SchemaRegistry()
+    try:
+        pipeline = parse_pipeline_dsl(text, schema_registry)
+    except PipelineParseError as exc:
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r}: malformed pipeline file {path}: {exc}"
+        ) from exc
+
+    name = pipeline.name
+    if not name:
+        # parse_pipeline_dsl requires a non-empty ``pipeline:`` name, so
+        # this is defensive — a hand-built Pipeline with no name has no
+        # key to register under.
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r}: file {path} produced a pipeline "
+            "with no declared name — a 'pipeline:' name is required."
+        )
+    if name != key:
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r} declares path {path} whose DSL "
+            f"'pipeline:' name is {name!r} — the config entry key must "
+            "match the DSL's declared name exactly (the declared name is "
+            "the authoritative key a call/match step resolves against; a "
+            "divergent config key is a silent footgun, not a rename)."
+        )
+
+    try:
+        registry.register(name, pipeline, schema_registry)
+    except ValueError as exc:
+        # Duplicate declared name across entries — the registry's own
+        # re-registration guard. First-registered entry keeps the name; this
+        # (later) entry is the one that fails.
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r}: file {path} declares name {name!r} "
+            f"which is already registered by an earlier entry: {exc}"
+        ) from exc
+
+
 def build_pipeline_registry(
     raw_pipelines: "dict[str, Any] | None", project_root: "Path",
+    *, strict: bool = False,
 ) -> PipelineRegistry:
     """Build a populated :class:`PipelineRegistry` from the ``pipelines:`` config.
 
@@ -66,18 +185,21 @@ def build_pipeline_registry(
     ``raw_pipelines=None`` → an empty registry (the util/no-root path). An
     empty/absent ``pipelines:`` block, or a ``pipelines:`` block with no
     ``entries``, → an empty registry (zero-config default — no pipelines
-    registered until the operator or an install tool declares one).
+    registered until the operator or an install tool declares one). These two
+    cases return before the per-entry loop even starts — they describe an
+    absent config shape, not a failure, so nothing is logged.
 
-    Raises :class:`PipelineLoadError` for:
-      - an unreadable / malformed DSL file (path included),
-      - a duplicate declared name across entries,
-      - a config entry key that disagrees with its file's declared
-        ``pipeline:`` name (fail-loud rather than silently picking one).
+    This function itself never raises for a per-entry failure. A missing
+    ``path``, an unreadable / malformed DSL file, a config-key / declared-name
+    mismatch, or a duplicate declared name are each caught PER ENTRY (via
+    :func:`_load_one_entry` raising :class:`PipelineLoadError`), logged as a
+    ``logging`` warning, durably emitted as a ``pipeline_load_failed`` P6
+    event (``reyn.core.events.events.emit_cli_event`` — see the module
+    docstring for why this sink), and then skipped — the remaining entries
+    still load normally. A duplicate declared name resolves first-registered-
+    wins: the later entry is the one logged/skipped.
     """
-    # Deferred import: parser pulls the pipeline executor/schema stack, which is
-    # heavier than this loader's own surface — keep module import cheap.
-    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
-    from reyn.core.pipeline.schema import SchemaRegistry
+    from reyn.core.events.events import emit_cli_event
 
     registry = PipelineRegistry()
     # ``None`` = the util/no-root path (from_config without a project_root) →
@@ -96,56 +218,28 @@ def build_pipeline_registry(
         if not bool(raw.get("enabled", True)):
             continue
 
-        raw_path = str(raw.get("path") or "").strip()
-        if not raw_path:
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r} has no 'path' — a pipeline entry "
-                "must declare the DSL file to load."
-            )
-        path = _entry_path(project_root, raw_path)
-
         try:
-            text = path.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r}: could not read {path}: {exc}"
-            ) from exc
-
-        schema_registry = SchemaRegistry()
-        try:
-            pipeline = parse_pipeline_dsl(text, schema_registry)
-        except PipelineParseError as exc:
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r}: malformed pipeline file {path}: {exc}"
-            ) from exc
-
-        name = pipeline.name
-        if not name:
-            # parse_pipeline_dsl requires a non-empty ``pipeline:`` name, so
-            # this is defensive — a hand-built Pipeline with no name has no
-            # key to register under.
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r}: file {path} produced a pipeline "
-                "with no declared name — a 'pipeline:' name is required."
+            _load_one_entry(key, raw, project_root, registry)
+        except PipelineLoadError as exc:
+            if strict:
+                # Preserve the original fail-loud contract for callers that
+                # need atomic all-or-nothing semantics (Session._reapply_pipelines'
+                # hot-reload seam — see the docstring's ``strict`` paragraph).
+                raise
+            logger.warning(
+                "pipelines.entries.%r failed to load and was skipped: %s",
+                key, exc,
             )
-        if name != key:
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r} declares path {path} whose DSL "
-                f"'pipeline:' name is {name!r} — the config entry key must "
-                "match the DSL's declared name exactly (the declared name is "
-                "the authoritative key a call/match step resolves against; a "
-                "divergent config key is a silent footgun, not a rename)."
-            )
-
-        try:
-            registry.register(name, pipeline, schema_registry)
-        except ValueError as exc:
-            # Duplicate declared name across entries — surface loudly with the
-            # path (the registry's re-registration guard).
-            raise PipelineLoadError(
-                f"pipelines.entries.{key!r}: file {path} declares name {name!r} "
-                f"which is already registered by an earlier entry: {exc}"
-            ) from exc
+            try:
+                emit_cli_event(
+                    "pipeline_load_failed",
+                    key=key,
+                    path=str(raw.get("path") or ""),
+                    error=str(exc),
+                )
+            except Exception:  # noqa: BLE001 -- durable-capture must never crash startup
+                pass
+            continue
 
     return registry
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3630,13 +3630,19 @@ class Session:
         ``run_pipeline`` actually resolves against, via ``get_pipeline_registry()``)
         would silently keep serving the stale registry.
 
-        Fail-loud-but-non-fatal: ``build_pipeline_registry`` raises ``PipelineLoadError``
-        (malformed DSL / duplicate declared name) on a broken on-disk file. That is
-        caught here (alongside any other unexpected error) — the reload seam logs +
-        returns False, leaving the OLD registry (on both holders) fully intact. The new
-        registry object is only ever assigned after a fully successful build, so a
-        malformed file at reload-time can never half-apply or clear the live registry
-        (atomic-by-construction, same guarantee as skills).
+        Fail-loud-but-non-fatal: ``build_pipeline_registry(..., strict=True)`` raises
+        ``PipelineLoadError`` (malformed DSL / duplicate declared name / missing path /
+        name mismatch) on the FIRST broken on-disk entry — ``strict=True`` is passed
+        explicitly here to opt back INTO that atomic fail-loud posture (the default,
+        used by session-FACTORY construction, is lenient/per-entry-isolated instead —
+        see ``build_pipeline_registry``'s own docstring for why the two call sites
+        need opposite postures: a brand-new session has no "old registry" to protect,
+        a live hot-reload does). The raise is caught here (alongside any other
+        unexpected error) — the reload seam logs + returns False, leaving the OLD
+        registry (on both holders) fully intact. The new registry object is only ever
+        assigned after a fully successful build, so a malformed file at reload-time
+        can never half-apply or clear the live registry (atomic-by-construction, same
+        guarantee as skills).
 
         Note (R7): a pipeline run already in flight resolves its OWN definition from
         the snapshotted work order (``invocation.json``), never the live registry, so a
@@ -3651,6 +3657,7 @@ class Session:
             fresh_cfg = load_config(self._hot_reload_project_root())
             new_registry = build_pipeline_registry(
                 fresh_cfg.pipelines, self._hot_reload_project_root(),
+                strict=True,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort, last-good on failure (incl. PipelineLoadError)
             logger.warning("_reapply_pipelines: registry rebuild failed: %r", exc)

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -14,9 +14,11 @@ Coverage:
   1. Contract — the parser now carries the declared name on ``Pipeline.name``,
      and serde round-trips it (default-tolerant for pre-existing on-disk data).
   2. Loader — config entries → registry keyed by the declared name; a config
-     key that disagrees with the DSL's declared name FAILS LOUD (the
-     authoritative resolution key is the DSL's, never the config key);
-     malformed / duplicate → FAIL LOUD with the path; empty → empty.
+     key that disagrees with the DSL's declared name, a malformed file, a
+     missing path, or a duplicate declared name are each isolated PER ENTRY
+     (logged + durably emitted, the entry skipped, remaining entries still
+     load — see the follow-up bugfix in test_2639-style commit history: a
+     single broken entry must never crash session startup); empty → empty.
   3. Wiring — ``from_config(config, project_root)`` builds the registry once;
      ``Session(pipeline_registry=)`` adopts it.
   4. Surfacing + invoke — a config-loaded pipeline surfaces as ``pipeline__<name>``
@@ -40,12 +42,32 @@ from typing import Any
 
 import pytest
 
+
+def _read_events_of_kind(events_dir: Path, kind: str) -> list[dict]:
+    """Read every JSONL event of *kind* from anywhere under *events_dir*.
+
+    Mirrors tests/test_asyncio_diagnostics.py's helper of the same name — the
+    canonical way to read back an ``emit_cli_event``-durable-captured event
+    from a real ``.reyn/events/`` tree in a test.
+    """
+    found: list[dict] = []
+    if not events_dir.exists():
+        return found
+    for path in events_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            if rec.get("type") == kind:
+                found.append(rec)
+    return found
+
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, TransformStep
 from reyn.core.pipeline.registry import PipelineRegistry
 from reyn.core.pipeline.schema import SchemaRegistry
 from reyn.core.pipeline.serde import pipeline_from_dict, pipeline_to_dict
-from reyn.data.pipelines.registry import PipelineLoadError, build_pipeline_registry
+from reyn.data.pipelines.registry import build_pipeline_registry
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
@@ -160,57 +182,108 @@ def test_loader_entry_path_may_use_any_filename(tmp_path: Path) -> None:
     assert set(registry.names()) == {"hello"}  # declared name, not "greet"
 
 
-def test_loader_entry_key_declared_name_mismatch_fails_loudly(tmp_path: Path) -> None:
+def test_loader_entry_key_declared_name_mismatch_is_skipped_not_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: a config entry key that disagrees with the DSL's declared
     ``pipeline:`` name is a footgun (a ``call`` step resolves the DECLARED
-    name, not the config key you'd naturally look for) — FAILS LOUD rather
-    than silently registering under one or the other."""
+    name, not the config key you'd naturally look for) — the entry is
+    skipped (not registered) and the failure is durably logged, but
+    ``build_pipeline_registry`` itself does NOT raise (regression: this used
+    to crash the whole session at startup — see the module docstring)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)  # declares "hello"
 
-    with pytest.raises(PipelineLoadError) as exc:
-        build_pipeline_registry(_entries(("mismatched-key", "pipelines/hello.yaml")), tmp_path)
+    registry = build_pipeline_registry(
+        _entries(("mismatched-key", "pipelines/hello.yaml")), tmp_path,
+    )
 
-    assert "mismatched-key" in str(exc.value)
-    assert "hello" in str(exc.value)
+    assert registry.names() == ()
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "mismatched-key"
+    assert "hello" in event["data"]["error"]
 
 
-def test_loader_malformed_file_fails_loudly_with_path(tmp_path: Path) -> None:
-    """Tier 2: a malformed DSL file raises PipelineLoadError naming the file —
-    NOT a silent skip (a typo must not silently drop a pipeline the operator
-    meant to ship)."""
+def test_loader_malformed_file_is_skipped_and_durably_logged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a malformed DSL file is skipped (not registered), NOT a silent
+    vanish (a typo must not silently drop a pipeline with zero trace) — a
+    warning is logged and a ``pipeline_load_failed`` event is durably
+    captured naming the file. ``build_pipeline_registry`` itself does not
+    raise (regression: one broken entry used to crash reyn startup)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
     _write(tmp_path / "pipelines", "broken.yaml", "pipeline: broken\nsteps: not-a-list\n")
 
-    with pytest.raises(PipelineLoadError) as exc:
-        build_pipeline_registry(_entries(("broken", "pipelines/broken.yaml")), tmp_path)
+    registry = build_pipeline_registry(_entries(("broken", "pipelines/broken.yaml")), tmp_path)
 
-    assert "broken.yaml" in str(exc.value)
+    assert registry.names() == ()
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "broken"
+    assert "broken.yaml" in event["data"]["error"]
 
 
-def test_loader_duplicate_declared_name_fails_loudly(tmp_path: Path) -> None:
+def test_loader_broken_entry_does_not_prevent_valid_sibling_from_loading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the actual regression scenario — one malformed
+    ``pipelines.entries`` declaration must NOT prevent a second, VALID entry
+    in the SAME config from registering. Before the fix, the first entry's
+    ``PipelineLoadError`` propagated straight out of ``build_pipeline_registry``
+    and crashed session construction before the loop ever reached the second,
+    healthy entry."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path / "pipelines", "broken.yaml", "pipeline: broken\nsteps: not-a-list\n")
+    _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
+
+    registry = build_pipeline_registry(
+        _entries(("broken", "pipelines/broken.yaml"), ("hello", "pipelines/hello.yaml")),
+        tmp_path,
+    )
+
+    assert set(registry.names()) == {"hello"}
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events  # exactly one failure captured — unpack raises otherwise
+    assert event["data"]["key"] == "broken"
+
+
+def test_loader_duplicate_declared_name_first_wins_second_skipped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: two entries declaring the SAME ``pipeline:`` name (via distinct
-    files that both name themselves after their own key) surface the
-    registry's re-registration guard as a loud load error, never a silent
-    last-wins overwrite. Constructed via two distinct on-disk copies of the
-    same DSL, each entry-keyed to its own file's declared name — the collision
-    is forced by writing a THIRD entry that repeats an already-used key path
-    is not representable (entries is a dict = unique keys), so the realistic
-    collision path is two entries whose files coincidentally declare the same
-    name under two different keys."""
+    files that both name themselves after their own key) — the FIRST entry
+    (dict iteration = declaration order) wins the registration; the second
+    entry is logged + durably captured and skipped, never a silent
+    last-wins overwrite and never fatal to the whole load."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
     _write(tmp_path / "pipelines", "a.yaml", _HELLO_DSL)  # declares "hello"
     _write(tmp_path / "pipelines", "b.yaml", _HELLO_DSL)  # also declares "hello"
 
-    with pytest.raises(PipelineLoadError) as exc:
-        build_pipeline_registry(
-            {
-                "entries": {
-                    "hello": {"path": "pipelines/a.yaml"},
-                    "hello-again": {"path": "pipelines/b.yaml"},
-                }
-            },
-            tmp_path,
-        )
+    registry = build_pipeline_registry(
+        {
+            "entries": {
+                "hello": {"path": "pipelines/a.yaml"},
+                "hello-again": {"path": "pipelines/b.yaml"},
+            }
+        },
+        tmp_path,
+    )
 
-    assert "hello" in str(exc.value)
+    assert set(registry.names()) == {"hello"}
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "hello-again"
+    assert "hello" in event["data"]["error"]
 
 
 def test_loader_empty_config_yields_empty_registry(tmp_path: Path) -> None:
@@ -233,17 +306,27 @@ def test_loader_disabled_entry_is_not_registered(tmp_path: Path) -> None:
     assert registry.names() == ()
 
 
-def test_loader_missing_file_fails_loudly(tmp_path: Path) -> None:
-    """Tier 2: an entry whose ``path`` does not exist on disk fails loud with
-    the path — never a silent skip (an operator typo in ``path:`` must surface,
-    not vanish the pipeline silently)."""
-    with pytest.raises(PipelineLoadError) as exc:
-        build_pipeline_registry(
-            {"entries": {"hello": {"path": "pipelines/does_not_exist.yaml"}}},
-            tmp_path,
-        )
+def test_loader_missing_file_is_skipped_and_durably_logged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: an entry whose ``path`` does not exist on disk is skipped, but
+    never a SILENT skip (an operator typo in ``path:`` must surface via the
+    warning log + durable event, not vanish the pipeline with zero trace) —
+    and it does not crash ``build_pipeline_registry`` itself."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
 
-    assert "does_not_exist.yaml" in str(exc.value)
+    registry = build_pipeline_registry(
+        {"entries": {"hello": {"path": "pipelines/does_not_exist.yaml"}}},
+        tmp_path,
+    )
+
+    assert registry.names() == ()
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "hello"
+    assert "does_not_exist.yaml" in event["data"]["error"]
 
 
 # ── 3. Wiring: from_config build-once + Session adoption ──────────────────────


### PR DESCRIPTION
**[per-PR-coder]** — Fixes a startup crash where a single malformed `pipelines.entries` declaration took down all of reyn.

## The crash mechanism

`src/reyn/data/pipelines/registry.py::build_pipeline_registry` raised `PipelineLoadError` for ANY per-entry failure — missing `path`, unreadable file, malformed DSL, no declared `pipeline:` name, config-key/declared-name mismatch, or a duplicate declared name across entries. This was called with **no enclosing try/except anywhere up the chain**: `src/reyn/runtime/factory_config.py::SessionFactoryConfig.from_config` calls it directly at **every** session construction — i.e. every `reyn chat` / `reyn web` startup. So one broken pipeline entry anywhere in `pipelines.entries` crashed reyn's entire startup, not just that one pipeline.

## The fix

`build_pipeline_registry`'s per-entry body is extracted into `_load_one_entry(key, raw, project_root, registry)`, which still raises `PipelineLoadError` exactly as before (same validation, same messages — no change to what counts as a failure). The main loop now catches that per entry:

```python
try:
    _load_one_entry(key, raw, project_root, registry)
except PipelineLoadError as exc:
    if strict:
        raise
    logger.warning(...)
    emit_cli_event("pipeline_load_failed", key=key, path=..., error=str(exc))
    continue
```

- **Not silent**: the same descriptive message the old raise carried is now a `logging.WARNING` **and** a durably-captured `pipeline_load_failed` P6 event via `emit_cli_event` (the session-independent sink — mirrors the rationale in `reyn.core.events.asyncio_diagnostics`, since this loader has no per-session `ctx`/`EventLog` handle and is called from multiple distinct entrypoints). Inspectable via `scripts/dogfood_trace.py --mode full --filter pipeline_load_failed`.
- **Not fatal**: the remaining entries in `raw_pipelines.entries` still load and register normally — a broken `entry_a` no longer blocks a valid `entry_b`.
- **Duplicate-name ordering**: the FIRST-registered entry with a declared name wins; a later, colliding entry is the one skipped/logged (dict iteration order = config declaration order).

### Hot-reload needs the opposite posture

`Session._reapply_pipelines` (the `/reload` `pipelines` seam) already had two tests pinning **atomic** behavior: a broken file at reload time must leave the previously-loaded registry **fully intact**, not partially replaced. Silently making `build_pipeline_registry` lenient everywhere would have broken that guarantee — a live session's registry could lose a pipeline mid-reload with no rollback.

So `build_pipeline_registry` grew a `strict: bool = False` keyword:
- **Session-factory construction** (the crash site) uses the default `strict=False` — isolate the bad entry, keep the good ones, let a *new* session start (it has no "old registry" to protect).
- **`Session._reapply_pipelines`** explicitly passes `strict=True` — restores the exact original fail-loud, all-or-nothing posture, so the existing hot-reload atomicity tests pass **unchanged**.

## Tests

`tests/test_2575_pipeline_disk_registration.py`:
- Malformed/mismatched/missing-path/duplicate-name entries no longer raise out of `build_pipeline_registry` — each is durably captured as a `pipeline_load_failed` event (read back from a real `.reyn/events/**/*.jsonl` tree, mirroring `test_asyncio_diagnostics.py`'s helper).
- `test_loader_broken_entry_does_not_prevent_valid_sibling_from_loading` — the actual regression scenario: one broken entry + one valid entry in the same config → the valid one still registers.
- `test_loader_duplicate_declared_name_first_wins_second_skipped` — first entry wins, second is logged/skipped.
- `tests/test_2581_pipeline_hotreload.py` — unchanged, still green (verifies `strict=True` preserves hot-reload atomicity).

## Docs

`docs/concepts/runtime/pipeline-registration.md` § "Failure behavior" rewritten (was "fail loud" → now "per-entry isolated, visible but non-fatal", with the hot-reload exception called out). `docs/reference/dogfood-tracing.md` gets a new `pipeline_load_failed` event section mirroring the existing `asyncio_unhandled_exception` one. No `.ja.md` counterpart exists for either doc.

## Gates (all run locally, all green)

- `ruff check src tests` — pass
- `python scripts/test_tier_audit.py --strict <changed test files>` — 23/23 OK, 0 Tier-4 violations
- `pytest` from repo root — full suite green except 5 pre-existing failures (route-mounting / plugin-loader tests), confirmed identical on `main` via `git stash` before/after comparison — unrelated to this change
- `python scripts/verify_module_docstrings.py <changed src files>` — OK

## Test plan
- [x] `ruff check src tests` passes
- [x] `python scripts/test_tier_audit.py --strict tests/test_2575_pipeline_disk_registration.py` passes (23/23, 0 errors)
- [x] `pytest` from repo root — green (pre-existing unrelated failures confirmed via main-branch comparison)
- [x] `python scripts/verify_module_docstrings.py src/reyn/data/pipelines/registry.py src/reyn/runtime/session.py src/reyn/runtime/factory_config.py` passes
- [x] Manually verified: a broken `pipelines.entries` file no longer raises out of `build_pipeline_registry`, and a healthy sibling entry in the same config still registers (test_loader_broken_entry_does_not_prevent_valid_sibling_from_loading)