### PR TITLE
feat: reyn pipe CLI (list/install/run subcommands)

### DIFF
--- a/docs/guide/for-users/write-a-pipeline.ja.md
+++ b/docs/guide/for-users/write-a-pipeline.ja.md
@@ -125,3 +125,41 @@ run_pipeline(name="review", input={reviewers: ["reviewer_a", "reviewer_b"], doc:
 各レビュアーは隔離された並行 `agent` ステップとして実行され(最大 4 並行、失敗時は 1 回リトライ)、全員の結果が揃うと、R1 の `all()` コンビネータで `all_passed` という 1 つの boolean に畳み込まれます — これは bare な `reviews` ではなく、`for_each` ステップの `output` が書き込んだ永続的な named store である `ctx.reviews` から読みます — そして `match` がそれに応じて `report_pass` または `report_fail` の sub-pipeline にルーティングします(どちらも別途登録が必要です。単一ファイルで完結させたい場合は、素の `transform`/`tool` ステップに置き換えてください)。
 
 この 2 つ目の pipeline も、手順 2 と同様に独自の `pipelines.entries` 宣言(または `pipeline_management__install_local` 呼び出し)が必要です — エージェントがそれを起動できるようになる前に。
+
+## 5. CLI から直接 pipeline を管理・実行する
+
+ここまでは、すべてチャットセッション内のエージェントのツール呼び出しを通じて行われていました。`reyn pipe` は、list / install / run という同じ 3 つのことを、ライブセッションなしで pipeline を管理・実行したい場合のために、直接の CLI コマンドとして提供します:
+
+```console
+$ reyn pipe list
+No pipelines configured.
+Add one with: reyn pipe install --path <file.yaml>  or edit reyn.yaml manually.
+
+$ reyn pipe install --path pipelines/greet.yaml --non-interactive
+Installing pipeline from path: pipelines/greet.yaml
+
+Pipeline 'greet' installed successfully.
+Config written to: .reyn/config/pipelines.yaml
+...
+
+$ reyn pipe list
+NAME   PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
+────────────────────────────────────────────────────────────────────────────────
+greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
+
+$ reyn pipe run greet --input '{"name": "Reyn"}'
+{
+  "pipe_data": "Hello, Reyn! (shouted)",
+  "named_stores": {
+    "name": "Reyn",
+    "greeting": "Hello, Reyn!",
+    "shouted": "Hello, Reyn! (shouted)"
+  }
+}
+```
+
+`reyn pipe install` は `--source <git/GitHub URL>` (`reyn mcp install` と同じ `//subdir` 記法) と、インストールする pipeline の identity を事前に明示する `--name` も受け付けます — DSL 自身が宣言する `pipeline:` 名と食い違う場合は、両者を静かに乖離させるのではなく、明確なエラーで拒否されます。
+
+`reyn pipe list` の **LOAD STATUS** 列は、ログを掘らずに壊れたエントリを直接見る手段です: `enabled: true` なのにパースに失敗したエントリ(DSL の不備、ファイル欠如、宣言名の重複)は、どこにも現れず静かに消えるのではなく、その場で `FAILED` と表示されます。
+
+`reyn pipe run` は pipeline を **CLI プロセス自身の中で単独実行**します — `agent` ステップをアタッチできるライブなエージェントセッションも、`tool` ステップをディスパッチするための router / tool-catalog コンテキストも存在しません。`transform` / `call` / `match` / `fold` / `for_each` / `parallel` ステップだけで構成された pipeline はエンドツーエンドで実行されますが、(直接、または `call`/`match` のターゲット経由で) `tool:` や `agent:` ステップに到達する pipeline は、静かに何もしない・実行途中でわかりにくくクラッシュするのではなく、実行前に明確なメッセージとともに拒否されます — そのような pipeline はライブなエージェントセッション(`run_pipeline`)から実行してください。また `reyn pipe run` の呼び出しにはクラッシュリカバリもありません: これは one-shot のフォアグラウンドコマンドなので、途中で kill/中断された実行は、他の CLI ツールと同様、単に失敗したコマンドであり、再開可能な driver-session ではありません。

--- a/docs/guide/for-users/write-a-pipeline.md
+++ b/docs/guide/for-users/write-a-pipeline.md
@@ -192,3 +192,61 @@ version).
 This second pipeline would need its own `pipelines.entries` declaration (or
 `pipeline_management__install_local` call), same as step 2 above, before an
 agent can launch it.
+
+## 5. Manage and run pipelines from the CLI directly
+
+Everything above happens through an agent's tool calls inside a chat session.
+`reyn pipe` does the same three things — list, install, run — as a direct CLI
+command, for when you want to manage or execute a pipeline without a live
+session:
+
+```console
+$ reyn pipe list
+No pipelines configured.
+Add one with: reyn pipe install --path <file.yaml>  or edit reyn.yaml manually.
+
+$ reyn pipe install --path pipelines/greet.yaml --non-interactive
+Installing pipeline from path: pipelines/greet.yaml
+
+Pipeline 'greet' installed successfully.
+Config written to: .reyn/config/pipelines.yaml
+...
+
+$ reyn pipe list
+NAME   PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
+────────────────────────────────────────────────────────────────────────────────
+greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
+
+$ reyn pipe run greet --input '{"name": "Reyn"}'
+{
+  "pipe_data": "Hello, Reyn! (shouted)",
+  "named_stores": {
+    "name": "Reyn",
+    "greeting": "Hello, Reyn!",
+    "shouted": "Hello, Reyn! (shouted)"
+  }
+}
+```
+
+`reyn pipe install` also accepts `--source <git/GitHub URL>` (same `//subdir`
+convention as `reyn mcp install`), and `--name` to assert the installed
+pipeline's identity up front — a mismatch against the DSL's own declared
+`pipeline:` name is refused with a clear error rather than silently diverging
+the two.
+
+`reyn pipe list`'s **LOAD STATUS** column is the direct way to see a broken
+entry without digging through logs: an entry that is `enabled: true` but
+failed to parse (bad DSL, missing file, a duplicate declared name) shows
+`FAILED` right there, instead of just silently not appearing anywhere.
+
+`reyn pipe run` executes the pipeline **standalone, in the CLI process
+itself** — there is no live agent session to attach an `agent` step to, and
+no router/tool-catalog context to dispatch a `tool` step through. It runs
+pipelines built from `transform` / `call` / `match` / `fold` / `for_each` /
+`parallel` steps end-to-end; a pipeline that reaches a `tool:` or `agent:`
+step (directly, or through a `call`/`match` target) is refused up front with
+a clear message, rather than silently doing nothing or crashing mid-run —
+run that pipeline from a live agent session (`run_pipeline`) instead. There
+is also no crash-recovery for a `reyn pipe run` invocation: it is a one-shot
+foreground command, so a killed/interrupted run is simply a failed command,
+the same as any other CLI tool — not a resumable driver-session.

--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -20,6 +20,7 @@ from . import init as init
 from . import mcp as mcp
 from . import memory as memory
 from . import permissions as permissions
+from . import pipe as pipe
 from . import run_once as run_once
 from . import secret as secret
 from . import source as source
@@ -28,4 +29,4 @@ from . import topology as topology
 from . import web as web
 
 # Order is the order shown in `reyn --help`.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, chainlit, mcp, secret, source, cron, dogfood, embeddings, support_bundle, audit]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, chainlit, mcp, pipe, secret, source, cron, dogfood, embeddings, support_bundle, audit]

--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -1,0 +1,617 @@
+"""`reyn pipe` — manage and run registered pipelines directly, outside a live
+chat session.
+
+Subcommands
+-----------
+list       List configured pipelines (``pipelines.entries``) with LOAD STATUS.
+install    Install a pipeline (local *.yaml or git/URL source) into config.
+run        Execute a registered pipeline to completion, print the result.
+
+Mirrors ``reyn.interfaces.cli.commands.mcp``'s conventions closely: the same
+``register(sub)``/``run_*(args)`` shape, the same ``--project`` root
+resolution, and (for ``install``) the same PermissionResolver/EventLog/
+StdinInterventionBus OpContext-bridging pattern ``mcp install`` uses — just
+targeting ``pipeline_install.handle`` instead of ``mcp_install.handle`` and
+the canonical ``.reyn/config/pipelines.yaml`` path instead of
+``.reyn/config/mcp.yaml``.
+
+``run`` scope decision (see ``run_run``'s docstring for the full rationale):
+a CLI invocation is one-shot/foreground/single-process, so it uses
+``PipelineExecutor().run(...)`` directly rather than the live-session
+``run_pipeline`` tool's crash-recoverable driver-session/MessageBus-attach
+machinery (IS-6) — that machinery exists to let a run survive a PROCESS crash
+and resume from another turn; a CLI command that dies mid-run is just "the
+command failed", the same as any other CLI tool, with no recovery
+expectation. v1 supports pipelines built ONLY from ``transform``/``call``/
+``match``/``fold``/``for_each``/``parallel`` steps (real dispatch, real
+recursion into registered callees) — ``tool``/``agent`` steps are NOT
+dispatchable standalone (real tool dispatch needs a live ``ToolContext`` with
+a router_state / permission resolver / workspace bridge; a real ``agent``
+step needs a live ``AgentRegistry`` capable of spawning ephemeral sessions —
+both are substantially more than a CLI convenience wrapper should assemble).
+A pipeline that reaches either step kind (directly or through a ``call``/
+``match`` target) gets one clear, actionable error before anything runs —
+never a silent no-op, never a confusing crash.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_MAX_DESC = 50
+
+
+def _get_project_root() -> "Path | None":
+    from reyn.config import _find_project_root
+    return _find_project_root(Path.cwd())
+
+
+def _resolve_install_project_root(project_arg: "str | None") -> Path:
+    """Resolve the install target project root, fail loud.
+
+    Mirrors ``mcp.py``'s ``_resolve_install_project_root``: ``--project``
+    overrides; otherwise the closest ``reyn.yaml`` ancestor of cwd. Exits
+    with an actionable message when neither yields a project root, rather
+    than silently writing into a non-project cwd.
+    """
+    from reyn.config import _find_project_root
+
+    if project_arg:
+        project_root = Path(project_arg).resolve()
+    else:
+        found = _find_project_root(Path.cwd())
+        if found is None:
+            print(
+                "error: no reyn.yaml found from the current directory; pass "
+                "--project <path-to-project-root>. (pipe install writes the "
+                "pipeline config under the project's .reyn/ — it will not "
+                "guess a non-project cwd.)",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        project_root = found
+
+    if not (project_root / "reyn.yaml").exists():
+        print(
+            f"error: {project_root}/reyn.yaml not found. "
+            "Run `reyn init` there or pass a different --project path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return project_root
+
+
+def _trunc(s: str, n: int) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "pipe",
+        help="Manage and run registered pipelines directly (outside a live chat session)",
+    )
+    psub = p.add_subparsers(dest="pipe_command", metavar="<subcommand>")
+    psub.required = True
+
+    # ---- list ----
+    lst = psub.add_parser(
+        "list",
+        help="List configured pipelines and their load status",
+    )
+    lst.set_defaults(func=run_list)
+
+    # ---- install ----
+    install = psub.add_parser(
+        "install",
+        help="Install a pipeline into Reyn configuration",
+    )
+    install.add_argument(
+        "--path",
+        dest="path",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Local pipeline DSL *.yaml file. Required when --source is not "
+            "given; when --source IS given, selects the DSL file inside the "
+            "cloned repo (only needed if the repo/subdir has more than one "
+            "*.yaml candidate)."
+        ),
+    )
+    install.add_argument(
+        "--source",
+        dest="source",
+        default=None,
+        metavar="SOURCE",
+        help=(
+            "Install from a git/GitHub URL, cloned to .reyn/pipelines/<name>/. "
+            "Supports a '//' subdir suffix, e.g. "
+            "'https://github.com/user/repo//pipelines/my-pipeline'."
+        ),
+    )
+    install.add_argument(
+        "--name",
+        dest="name",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Optional override — must match the DSL's declared 'pipeline:' "
+            "name exactly, or the install is refused (the declared name is "
+            "always the identity a call/match step resolves against)."
+        ),
+    )
+    install.add_argument(
+        "--project", dest="project", default=None, metavar="PATH",
+        help=(
+            "Project root containing reyn.yaml. Defaults to the closest "
+            "ancestor with a reyn.yaml, or the current directory."
+        ),
+    )
+    install.add_argument(
+        "--non-interactive",
+        dest="non_interactive",
+        action="store_true",
+        help="Suppress interactive prompts (for CI use)",
+    )
+    install.set_defaults(func=run_install)
+
+    # ---- run ----
+    run_p = psub.add_parser(
+        "run",
+        help="Run a registered pipeline to completion and print its result",
+    )
+    run_p.add_argument(
+        "name",
+        metavar="NAME",
+        help="Registered pipeline name (its declared 'pipeline:' name)",
+    )
+    run_p.add_argument(
+        "--input",
+        dest="input",
+        default="{}",
+        metavar="JSON",
+        help="A JSON object string seeding the run's named stores (ctx.*). Default: {}",
+    )
+    run_p.add_argument(
+        "--project", dest="project", default=None, metavar="PATH",
+        help=(
+            "Project root containing reyn.yaml. Defaults to the closest "
+            "ancestor with a reyn.yaml, or the current directory."
+        ),
+    )
+    run_p.add_argument(
+        "--async",
+        dest="async_",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    run_p.set_defaults(func=run_run)
+
+
+# ---------------------------------------------------------------------------
+# run_list
+# ---------------------------------------------------------------------------
+
+
+def run_list(args: argparse.Namespace) -> None:
+    """List configured pipelines with a LOAD STATUS column.
+
+    Unlike ``mcp list`` there is no live-server handshake concept for
+    pipelines — loading IS the check, so this always does the "expensive"
+    thing: it builds a real ``PipelineRegistry`` from the SAME merged
+    ``pipelines.entries`` cascade every session uses
+    (``reyn.config.load_config`` already implements the identical
+    user-global/project/project-local/dynamic-``.reyn/config/pipelines.yaml``
+    union-merge invariant ``mcp.py``'s ``_all_servers_with_scope`` hand-rolls
+    for ``mcp.servers`` — see ``loader.py``'s ``pipelines`` merge branch —
+    so this reuses ``load_config()`` rather than re-deriving that cascade a
+    second time) and checks, per ENABLED entry, whether its declared name
+    landed in the registry. An entry that is ``enabled: true`` but did NOT
+    load (malformed DSL, unreadable path, config-key / declared-name
+    mismatch, or a duplicate declared name — #2641's per-entry-isolation
+    posture) shows FAILED here, so ``reyn pipe list`` is a first-class way
+    to SEE load failures without digging through dogfood_trace/logs.
+    """
+    from reyn.config import load_config
+    from reyn.data.pipelines.registry import build_pipeline_registry
+
+    project_root = _get_project_root()
+    if project_root is None:
+        print(
+            "No reyn.yaml found from the current directory — nothing to list. "
+            "Run from inside a Reyn project, or pass a project root via --project "
+            "to other 'reyn pipe' subcommands."
+        )
+        return
+
+    config = load_config()
+    raw_entries = (config.pipelines or {}).get("entries") or {}
+
+    if not raw_entries:
+        print("No pipelines configured.")
+        print(
+            "Add one with: reyn pipe install --path <file.yaml>  "
+            "or edit reyn.yaml manually."
+        )
+        return
+
+    registry = build_pipeline_registry(config.pipelines, project_root, strict=False)
+    loaded_names = set(registry.names())
+
+    rows: list[tuple[str, str, str, str, str]] = []
+    for key, raw in sorted(raw_entries.items()):
+        if not isinstance(raw, dict):
+            rows.append((key, "(malformed entry)", "", "?", "FAILED"))
+            continue
+        path = str(raw.get("path") or "")
+        description = str(raw.get("description") or "")
+        enabled = bool(raw.get("enabled", True))
+        if not enabled:
+            status = "disabled"
+        elif key in loaded_names:
+            status = "loaded"
+        else:
+            status = "FAILED"
+        rows.append((key, path, description, "yes" if enabled else "no", status))
+
+    _W_NAME = max((len(r[0]) for r in rows), default=4)
+    _W_NAME = max(_W_NAME, 4)
+    _W_PATH = max((len(r[1]) for r in rows), default=4)
+    _W_PATH = min(max(_W_PATH, 4), 60)
+    _W_ENABLED = 7
+    _W_STATUS = 12
+
+    header = (
+        f"{'NAME':<{_W_NAME}}  {'PATH':<{_W_PATH}}  "
+        f"{'DESCRIPTION':<{_MAX_DESC}}  {'ENABLED':<{_W_ENABLED}}  LOAD STATUS"
+    )
+    print(header)
+    print("─" * len(header))
+    for name, path, description, enabled, status in rows:
+        print(
+            f"{name:<{_W_NAME}}  {_trunc(path, _W_PATH):<{_W_PATH}}  "
+            f"{_trunc(description, _MAX_DESC):<{_MAX_DESC}}  "
+            f"{enabled:<{_W_ENABLED}}  {status}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# run_install
+# ---------------------------------------------------------------------------
+
+
+def run_install(args: argparse.Namespace) -> None:
+    """Install a pipeline from ``--path`` (local) or ``--source`` (git/URL).
+
+    Bridges into ``pipeline_install.handle`` via the exact same
+    PermissionResolver/PermissionDecl/EventLog/StdinInterventionBus/synthetic-
+    workspace OpContext pattern ``mcp.py``'s ``_run_install_from_source``
+    uses — the CLI is an operator-trusted entry point (a human explicitly
+    running a local command, not an LLM-driven turn), so it session-approves
+    the canonical config path up-front exactly like ``mcp install`` does for
+    ``.reyn/config/mcp.yaml``, just targeting ``.reyn/config/pipelines.yaml``.
+    """
+    path: "str | None" = getattr(args, "path", None)
+    source: "str | None" = getattr(args, "source", None)
+    name: "str | None" = getattr(args, "name", None)
+    non_interactive: bool = getattr(args, "non_interactive", False)
+
+    if not path and not source:
+        print(
+            "Error: provide --path <local pipeline DSL file> or "
+            "--source <git/URL specifier> (or both — --source clones a repo, "
+            "--path then selects the DSL file inside it).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    project_root = _resolve_install_project_root(getattr(args, "project", None))
+
+    import asyncio as _asyncio
+
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.core.op_runtime.pipeline_install import handle as _pipeline_install_handle
+    from reyn.core.op_runtime.skill_install import _parse_source_spec, _source_host
+    from reyn.schemas.models import PipelineInstallIROp
+    from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+    from reyn.user_intervention import StdinInterventionBus
+
+    perm_config: dict = {}
+    try:
+        from reyn.config import load_config
+        perm_config = getattr(load_config(), "permissions", {}) or {}
+    except Exception:
+        perm_config = {}
+
+    perm_resolver = PermissionResolver(
+        config_permissions=perm_config,
+        project_root=project_root,
+        interactive=not non_interactive and sys.stdin.isatty(),
+    )
+
+    events = EventLog()
+    workspace = type("Workspace", (), {"base_dir": str(project_root)})()
+    bus = StdinInterventionBus()
+
+    canonical_config = ".reyn/config/pipelines.yaml"
+    perm_resolver.session_approve_path(
+        canonical_config, "pipeline_install_cli", "file.write",
+    )
+
+    host: "str | None" = None
+    if source:
+        git_url, _subdir = _parse_source_spec(source)
+        host = _source_host(git_url)
+
+    decl = PermissionDecl(
+        file_write=[{"path": canonical_config, "scope": "just_path"}],
+        http_get=[{"host": host}] if host else [],
+    )
+
+    ctx = OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=decl,
+        permission_resolver=perm_resolver,
+        actor="pipeline_install_cli",
+        intervention_bus=bus,
+    )
+
+    op = PipelineInstallIROp(
+        kind="pipeline_install",
+        path=path or "",
+        name=name,
+        source=source,
+    )
+
+    print(f"Installing pipeline from {'source: ' + source if source else 'path: ' + str(path)}")
+    print()
+
+    try:
+        result = _asyncio.run(_pipeline_install_handle(op, ctx))
+    except PermissionError as exc:
+        print(f"\nPermission denied: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as exc:
+        print(f"\nError during pipeline_install: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    status = result.get("status")
+    if status != "installed":
+        err = result.get("error", "(unknown error)")
+        print(f"=== pipeline_install {status}: {err} ===", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Pipeline '{result.get('name')}' installed successfully.")
+    print(f"Config written to: {result.get('config_path')}")
+    print(
+        "Hot-reload requested: the installed pipeline will go live in any "
+        "running 'reyn chat'/'reyn web' session at its next turn boundary "
+        "(no restart required for a live session; a brand-new 'reyn chat' "
+        "or 'reyn pipe run' picks it up immediately)."
+    )
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+# ---------------------------------------------------------------------------
+# run_run
+# ---------------------------------------------------------------------------
+
+# The step kinds a standalone 'reyn pipe run' can execute end-to-end (real
+# recursion through call/match/fold/for_each/parallel; real dispatch for
+# transform). 'tool' and 'agent' are NOT supported standalone — see the
+# module docstring for why.
+_UNSUPPORTED_STEP_LABELS = {"tool", "agent"}
+
+
+def _find_unsupported_steps(pipeline, registry, *, _visited=None) -> "list[str]":
+    """Walk ``pipeline``'s steps (recursing into any ``call``/``match`` target
+    resolvable through ``registry``, and into ``fold``/``for_each``'s ``do``,
+    ``for_each``'s ``collect``, and ``parallel``'s ``branches``/``collect``)
+    and return the sorted set of unsupported step-kind labels reachable from
+    it (``"tool"`` / ``"agent"``), or ``[]`` if the whole reachable pipeline
+    is executable standalone. An unresolvable ``call``/``match`` target is
+    NOT flagged here — that surfaces as the executor's own clear
+    "not registered" error at run time instead."""
+    from reyn.core.pipeline.executor import (
+        AgentStep,
+        CallStep,
+        FoldStep,
+        ForEachStep,
+        MatchStep,
+        ParallelStep,
+        ToolStep,
+    )
+    from reyn.core.pipeline.registry import PipelineNotFoundError
+
+    if _visited is None:
+        _visited = set()
+    found: "set[str]" = set()
+
+    def _walk_callee(callee_name: str) -> None:
+        if callee_name in _visited:
+            return
+        _visited.add(callee_name)
+        try:
+            callee = registry.get(callee_name)
+        except PipelineNotFoundError:
+            return
+        for s in callee.steps:
+            _walk_step(s)
+
+    def _walk_step(step) -> None:
+        if isinstance(step, ToolStep):
+            found.add("tool")
+        elif isinstance(step, AgentStep):
+            found.add("agent")
+        elif isinstance(step, CallStep):
+            _walk_callee(step.pipeline)
+        elif isinstance(step, MatchStep):
+            for case in step.cases.values():
+                _walk_callee(case.pipeline)
+            if step.default is not None:
+                _walk_callee(step.default.pipeline)
+        elif isinstance(step, FoldStep):
+            _walk_step(step.do)
+        elif isinstance(step, ForEachStep):
+            _walk_step(step.do)
+            _walk_step(step.collect)
+        elif isinstance(step, ParallelStep):
+            for branch in step.branches.values():
+                _walk_step(branch)
+            _walk_step(step.collect)
+
+    for top_step in pipeline.steps:
+        _walk_step(top_step)
+    return sorted(found)
+
+
+def run_run(args: argparse.Namespace) -> None:
+    """Run a registered pipeline to completion via ``PipelineExecutor().run()``
+    directly, and print its final result as JSON.
+
+    This is deliberately NOT the live-session ``run_pipeline`` tool's
+    crash-recoverable driver-session/MessageBus-attach path (IS-6) — that
+    machinery exists so a pipeline run can survive a live multi-session
+    RUNTIME process crashing mid-run and be resumed/delivered on a later
+    turn. A ``reyn pipe run`` invocation is a one-shot, foreground, single
+    -process CLI command: if it dies mid-run, that is exactly like any other
+    CLI command dying mid-run — the user's terminal command failed, with
+    no "resume on the next chat turn" expectation to honor. So this loads
+    the config, builds a real ``PipelineRegistry``, and calls the executor
+    directly with ``state_log=None`` (an established, already-used pattern —
+    see e.g. ``tests/test_2575_pipeline_disk_registration.py`` — meaning no
+    R4 recovery snapshot is written; a killed ``reyn pipe run`` simply is not
+    resumable, matching the "just a CLI command" trust model).
+
+    ``--input`` (default ``"{}"``) is a JSON object string that seeds the
+    run's named stores (``PipelineExecutor.run``'s ``initial_context``
+    param) — the FIRST step's ``ctx.*`` sees these keys, exactly like
+    ``run_pipeline``'s ``input`` argument.
+
+    Scope: only pipelines reachable through ``transform``/``call``/``match``/
+    ``fold``/``for_each``/``parallel`` steps run standalone. A pipeline
+    containing (or reaching, through a ``call``/``match`` target) a
+    ``tool``/``agent`` step is refused BEFORE anything runs, with a clear
+    message pointing at running it from a live agent session instead — never
+    a silent no-op, never a confusing crash mid-run.
+    """
+    from reyn.core.pipeline.executor import PipelineExecutionError, PipelineExecutor
+    from reyn.core.pipeline.registry import PipelineNotFoundError
+    from reyn.data.pipelines.registry import build_pipeline_registry
+
+    if getattr(args, "async_", False):
+        print(
+            "error: --async is not supported for 'reyn pipe run' — a CLI "
+            "invocation is a one-shot foreground command with no "
+            "fire-and-forget semantics. Omit --async and wait for the run "
+            "to complete (use --input to seed it).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    name: str = args.name.strip()
+    if not name:
+        print("Error: NAME must not be empty.", file=sys.stderr)
+        sys.exit(1)
+
+    raw_input: str = getattr(args, "input", "{}") or "{}"
+    try:
+        seed_ctx = json.loads(raw_input)
+    except json.JSONDecodeError as exc:
+        print(f"Error: --input is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(seed_ctx, dict):
+        print("Error: --input must be a JSON object.", file=sys.stderr)
+        sys.exit(1)
+
+    project_arg = getattr(args, "project", None)
+    if project_arg:
+        project_root = Path(project_arg).resolve()
+    else:
+        project_root = _get_project_root()
+    if project_root is None:
+        print(
+            "error: no reyn.yaml found from the current directory; pass "
+            "--project <path-to-project-root>.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from reyn.config import load_config
+    config = load_config()
+    pipeline_registry = build_pipeline_registry(config.pipelines, project_root, strict=False)
+
+    try:
+        pipeline = pipeline_registry.get(name)
+        schema_registry = pipeline_registry.get_schema_registry(name)
+    except PipelineNotFoundError:
+        print(
+            f"error: pipeline '{name}' is not registered. "
+            "Run 'reyn pipe list' to see available pipelines.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    unsupported = _find_unsupported_steps(pipeline, pipeline_registry)
+    if unsupported:
+        labels = "/".join(f"{k}:" for k in unsupported)
+        print(
+            f"error: pipeline '{name}' contains a {labels} step (directly or "
+            "via a call/match target) — 'reyn pipe run' does not yet support "
+            "tool:/agent: steps standalone. Run this pipeline from a live "
+            "agent session instead (the 'run_pipeline' tool).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    def _tool_dispatch(tool_name: str, _resolved_args: dict):
+        # Defensive only: _find_unsupported_steps already refused any
+        # pipeline reaching a ToolStep before we got here.
+        raise PipelineExecutionError(
+            f"tool step {tool_name!r} cannot be dispatched standalone by "
+            "'reyn pipe run' — run this pipeline from a live agent session "
+            "instead."
+        )
+
+    run_id = f"cli-{uuid.uuid4().hex}"
+    executor = PipelineExecutor()
+    try:
+        result = asyncio.run(
+            executor.run(
+                pipeline,
+                seed_ctx or None,
+                tool_dispatch=_tool_dispatch,
+                state_log=None,
+                run_id=run_id,
+                schema_registry=schema_registry,
+                registry=None,
+                default_identity=None,
+                pipeline_registry=pipeline_registry,
+            )
+        )
+    except PipelineExecutionError as exc:
+        print(f"error: pipeline '{name}' failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        json.dumps(
+            {"pipe_data": result.pipe_data, "named_stores": result.named_stores},
+            indent=2,
+            ensure_ascii=False,
+            default=str,
+        )
+    )

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -1,0 +1,299 @@
+"""Tier 2: OS invariant — ``reyn pipe`` CLI subcommands (list/install/run).
+
+Covers:
+  - argparse registration (happy-path parse for list/install/run).
+  - ``reyn pipe list``: LOAD STATUS distinguishes a working entry from a
+    deliberately-broken one (real ``build_pipeline_registry``, real tmp_path
+    files, no mocks — #2641's per-entry-isolation posture surfaced visibly).
+  - ``reyn pipe install --path``: real local DSL file, driven through the
+    CLI's own ``run_install`` with a real ``argparse.Namespace`` (matching
+    ``test_mcp_source_install.py``'s own drive-through-run(args) shape) —
+    asserts ``.reyn/config/pipelines.yaml`` gets the correct entry.
+  - ``reyn pipe run NAME``: a real registered transform-only pipeline
+    executed end-to-end via ``run_run``, asserting the printed JSON result.
+  - the clear-error path for a pipeline reaching a ``tool:`` step (scoped out
+    of v1 standalone execution) — asserts a clean ``SystemExit(1)`` with an
+    actionable message, never a crash or silent no-op.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.interfaces.cli.commands.pipe import register, run_install, run_list, run_run
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    register(sub)
+    return parser
+
+
+def _write_reyn_yaml(project_root: Path, pipelines_entries: dict | None = None) -> None:
+    data: dict = {"model": "standard"}
+    if pipelines_entries is not None:
+        data["pipelines"] = {"entries": pipelines_entries}
+    (project_root / "reyn.yaml").write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8",
+    )
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Argparse registration
+# ---------------------------------------------------------------------------
+
+
+def test_pipe_list_parses():
+    """Tier 2: 'pipe list' parses with no extra args."""
+    parser = _make_parser()
+    args = parser.parse_args(["pipe", "list"])
+    assert args.pipe_command == "list"
+
+
+def test_pipe_install_parses_path():
+    """Tier 2: 'pipe install --path FILE' parses; --source/--name default None."""
+    parser = _make_parser()
+    args = parser.parse_args(["pipe", "install", "--path", "p.yaml", "--non-interactive"])
+    assert args.pipe_command == "install"
+    assert args.path == "p.yaml"
+    assert args.source is None
+    assert args.name is None
+    assert args.non_interactive is True
+
+
+def test_pipe_install_parses_source():
+    """Tier 2: 'pipe install --source URL' parses."""
+    parser = _make_parser()
+    args = parser.parse_args(["pipe", "install", "--source", "https://github.com/x/y"])
+    assert args.source == "https://github.com/x/y"
+
+
+def test_pipe_run_parses():
+    """Tier 2: 'pipe run NAME --input JSON' parses; --async is present but suppressed."""
+    parser = _make_parser()
+    args = parser.parse_args(["pipe", "run", "my_pipeline", "--input", '{"a": 1}'])
+    assert args.pipe_command == "run"
+    assert args.name == "my_pipeline"
+    assert args.input == '{"a": 1}'
+    assert args.async_ is False
+
+
+def test_pipe_run_async_flag_parses_but_is_rejected_at_runtime(capsys):
+    """Tier 2: '--async' parses (so argparse doesn't hard-reject it) but
+    run_run() refuses it with a clear message rather than silently accepting."""
+    parser = _make_parser()
+    args = parser.parse_args(["pipe", "run", "my_pipeline", "--async"])
+    assert args.async_ is True
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "--async" in err
+    assert "not supported" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# reyn pipe list
+# ---------------------------------------------------------------------------
+
+
+def test_list_shows_loaded_and_failed_entries(tmp_path, monkeypatch, capsys):
+    """Tier 2: a working entry shows 'loaded'; a broken one (missing file)
+    shows 'FAILED' — #2641's per-entry isolation surfaced visibly by the CLI."""
+    monkeypatch.chdir(tmp_path)
+
+    working_dsl = (
+        "pipeline: good_one\n"
+        "description: a working pipeline\n"
+        "steps:\n"
+        "  - transform: {value: \"ctx.x\", output: y}\n"
+    )
+    (tmp_path / "pipelines").mkdir()
+    (tmp_path / "pipelines" / "good.yaml").write_text(working_dsl, encoding="utf-8")
+
+    _write_reyn_yaml(
+        tmp_path,
+        {
+            "good_one": {"path": "pipelines/good.yaml", "description": "a working pipeline"},
+            "missing_one": {"path": "pipelines/does_not_exist.yaml"},
+        },
+    )
+
+    run_list(_ns())
+
+    out = capsys.readouterr().out
+    lines = {ln.split()[0]: ln for ln in out.splitlines() if ln and not ln.startswith("─")}
+    assert "loaded" in lines["good_one"]
+    assert "FAILED" in lines["missing_one"]
+
+
+def test_list_no_project_root_prints_message(tmp_path, monkeypatch, capsys):
+    """Tier 2: outside any project (no reyn.yaml reachable), list prints a
+    clear message instead of crashing."""
+    monkeypatch.chdir(tmp_path)
+    run_list(_ns())
+    out = capsys.readouterr().out
+    assert "no reyn.yaml" in out.lower()
+
+
+def test_list_no_pipelines_configured(tmp_path, monkeypatch, capsys):
+    """Tier 2: a project with reyn.yaml but no pipelines.entries reports zero
+    configured pipelines rather than an empty/confusing table."""
+    monkeypatch.chdir(tmp_path)
+    _write_reyn_yaml(tmp_path)
+    run_list(_ns())
+    out = capsys.readouterr().out
+    assert "no pipelines configured" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# reyn pipe install --path
+# ---------------------------------------------------------------------------
+
+
+def test_install_local_path_writes_config(tmp_path, capsys):
+    """Tier 2: 'pipe install --path FILE' registers the DSL's declared name
+    into .reyn/config/pipelines.yaml via the real pipeline_install op handler."""
+    _write_reyn_yaml(tmp_path)
+
+    dsl_path = tmp_path / "my_pipeline.yaml"
+    dsl_path.write_text(
+        "pipeline: my_pipeline\n"
+        "description: installed via CLI\n"
+        "steps:\n"
+        "  - transform: {value: \"ctx.x\", output: y}\n",
+        encoding="utf-8",
+    )
+
+    args = _ns(
+        path=str(dsl_path), source=None, name=None,
+        project=str(tmp_path), non_interactive=True,
+    )
+    run_install(args)
+
+    config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    assert config_path.exists()
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    entry = written["pipelines"]["entries"]["my_pipeline"]
+    assert entry["path"] == str(dsl_path.resolve())
+    assert entry["description"] == "installed via CLI"
+    assert entry["enabled"] is True
+
+    out = capsys.readouterr().out
+    assert "installed successfully" in out.lower()
+
+
+def test_install_name_mismatch_is_a_clean_error(tmp_path, capsys):
+    """Tier 2: a --name that disagrees with the DSL's declared 'pipeline:'
+    name is refused with a clear message (pipeline_install.py's own
+    validation), not a raw exception leaking to the CLI user."""
+    _write_reyn_yaml(tmp_path)
+
+    dsl_path = tmp_path / "p.yaml"
+    dsl_path.write_text(
+        "pipeline: real_name\nsteps:\n  - transform: {value: \"ctx.x\", output: y}\n",
+        encoding="utf-8",
+    )
+
+    args = _ns(
+        path=str(dsl_path), source=None, name="different_name",
+        project=str(tmp_path), non_interactive=True,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_install(args)
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "name mismatch" in err.lower() or "does not match" in err.lower()
+
+
+def test_install_neither_path_nor_source_rejects(tmp_path, capsys):
+    """Tier 2: no --path and no --source → sys.exit(1) with an actionable message."""
+    args = _ns(path=None, source=None, name=None, project=str(tmp_path), non_interactive=True)
+    with pytest.raises(SystemExit) as exc_info:
+        run_install(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "--path" in err and "--source" in err
+
+
+# ---------------------------------------------------------------------------
+# reyn pipe run
+# ---------------------------------------------------------------------------
+
+
+def test_run_transform_pipeline_end_to_end(tmp_path, monkeypatch, capsys):
+    """Tier 2: a real registered transform-only pipeline runs end-to-end via
+    run_run(), printing the correct final result as JSON."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl_path = tmp_path / "hello.yaml"
+    dsl_path.write_text(
+        "pipeline: hello_cli\n"
+        "description: greets ctx.name\n"
+        "steps:\n"
+        "  - transform: {value: \"'hello ' + ctx.name\", output: greeting}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"hello_cli": {"path": "hello.yaml"}})
+
+    args = _ns(
+        name="hello_cli", input=json.dumps({"name": "world"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert result["pipe_data"] == "hello world"
+    assert result["named_stores"]["greeting"] == "hello world"
+
+
+def test_run_unregistered_pipeline_is_clean_error(tmp_path, monkeypatch, capsys):
+    """Tier 2: running a NAME with no matching registered pipeline exits
+    cleanly with an actionable message, not a raw KeyError."""
+    monkeypatch.chdir(tmp_path)
+    _write_reyn_yaml(tmp_path)
+
+    args = _ns(name="nope", input="{}", project=str(tmp_path), async_=False)
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "not registered" in err.lower()
+
+
+def test_run_tool_step_is_refused_with_clear_error_not_a_crash(tmp_path, monkeypatch, capsys):
+    """Tier 2: a pipeline reaching a 'tool:' step is refused BEFORE anything
+    runs, with a clear, actionable message pointing at a live agent session —
+    never a silent no-op, never a confusing mid-run crash."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl_path = tmp_path / "uses_tool.yaml"
+    dsl_path.write_text(
+        "pipeline: uses_tool\n"
+        "steps:\n"
+        "  - tool: {name: search, args: {query: \"reyn\"}, output: hits}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"uses_tool": {"path": "uses_tool.yaml"}})
+
+    args = _ns(name="uses_tool", input="{}", project=str(tmp_path), async_=False)
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "tool:" in err
+    assert "does not yet support" in err.lower() or "live agent session" in err.lower()


### PR DESCRIPTION
**[per-PR-coder]** — New `reyn pipe` CLI command (`list`/`install`/`run`) so pipelines can be managed/executed directly, not just through a live chat session — mirrors `reyn mcp`'s conventions closely (same `register(sub)`/`run_*(args)` shape, same `--project` root resolution, same PermissionResolver/EventLog/StdinInterventionBus OpContext-bridging pattern for `install`).

## What's in

- **`reyn pipe list`** — reads the merged `pipelines.entries` config (reused `reyn.config.load_config()`, which already implements the identical union-merge cascade `mcp.py`'s `_all_servers_with_scope` hand-rolls for `mcp.servers` — see `loader.py`'s `pipelines` merge branch — rather than re-deriving that cascade a second time), builds a real `PipelineRegistry` via `build_pipeline_registry(..., strict=False)`, and prints NAME/PATH/DESCRIPTION/ENABLED/**LOAD STATUS**. An `enabled: true` entry that did NOT make it into the registry (malformed DSL, missing file, config-key/declared-name mismatch, duplicate declared name — #2641's per-entry-isolation posture) shows `FAILED` — this is now a first-class way to *see* a broken pipeline entry without digging through `dogfood_trace`/logs.
- **`reyn pipe install --path|--source [--name] [--non-interactive]`** — bridges into `pipeline_install.handle` (`src/reyn/core/op_runtime/pipeline_install.py`) via the **exact same** PermissionResolver/PermissionDecl/EventLog/StdinInterventionBus/synthetic-workspace OpContext pattern `mcp.py`'s `_run_install_from_source` uses, targeting the canonical `.reyn/config/pipelines.yaml` instead of `.reyn/config/mcp.yaml`. Same trust model as `mcp install`: the CLI is an operator-trusted entry point (a human running a local command), so it session-approves the canonical config path up front. A `--name` that disagrees with the DSL's declared `pipeline:` name surfaces `pipeline_install.py`'s own clear "name mismatch" error rather than a raw exception.
- **`reyn pipe run NAME [--input JSON]`** — uses `PipelineExecutor().run()` **directly** (not the live-session `run_pipeline` tool's crash-recoverable driver-session/MessageBus-attach machinery, IS-6) — a CLI invocation is one-shot/foreground/single-process; if it dies mid-run that's just "the command failed", same as any other CLI tool, with no resume-on-next-turn expectation to honor. `state_log=None` is an already-established pattern (e.g. `tests/test_2575_pipeline_disk_registration.py`).

## Scope decision on `tool:`/`agent:` steps (explicit, as requested)

`reyn pipe run` supports pipelines built from `transform`/`call`/`match`/`fold`/`for_each`/`parallel` steps end-to-end (real recursion into registered `call`/`match` callees, real dispatch). It does **NOT** support `tool:` or `agent:` steps standalone:

- A real `tool` step needs a live `ToolContext` (router_state, permission resolver, workspace bridge, tool catalog) — assembling that for a bare CLI command is substantially more than a page of code and would mean re-building session-adjacent machinery just for this convenience wrapper.
- A real `agent` step needs a live `AgentRegistry` capable of spawning ephemeral sessions under an identity — same story.

Before running anything, `reyn pipe run` walks the pipeline (recursing into any resolvable `call`/`match` target, `fold`/`for_each`'s `do`, `for_each`'s `collect`, `parallel`'s `branches`/`collect`) and refuses with a clear, actionable message if it reaches either step kind — pointing at running that pipeline from a live agent session (`run_pipeline`) instead. Never a silent no-op, never a confusing crash mid-run. One test (`test_run_tool_step_is_refused_with_clear_error_not_a_crash`) proves this fires cleanly.

`--async` is intentionally rejected (not silently accepted) — a one-shot foreground CLI command has no fire-and-forget semantics to honor.

## Verification

All three subcommands were driven live end-to-end against a real tmp project (not just via tests) — `reyn pipe list` (empty → configured → LOAD STATUS), `reyn pipe install --path` (writes `.reyn/config/pipelines.yaml`), `reyn pipe run NAME --input '{"name": "Reyn"}'` (correct JSON result), and the `tool:` step refusal path. The doc examples in `write-a-pipeline.md`/`.ja.md` are the literal verified output.

## Gates (all green locally)

- `ruff check src tests`
- `python scripts/test_tier_audit.py --strict tests/test_cli_pipe.py` — 14/14 OK, 0 Tier-4 violations
- `pytest` (full suite) — 7517 passed, 21 skipped, 4 pre-existing failures unrelated to this change (`tests/web/test_a2a.py::test_a2a_routes_mounted`, `tests/web/test_mcp_sse.py::test_mcp_routes_mounted`, `tests/web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `tests/web/test_resources_router.py::test_resources_route_is_mounted_on_app` — confirmed via `git stash` that they fail identically on `main` at `91cea6fc`, before this PR's changes)
- `python scripts/verify_module_docstrings.py <changed src files>`

## Test plan

- [x] `reyn pipe list` shows correct LOAD STATUS for a working entry vs a deliberately-broken one (real files, real `build_pipeline_registry`, no mocks)
- [x] `reyn pipe install --path` writes the correct `.reyn/config/pipelines.yaml` entry
- [x] `reyn pipe install` with a `--name` mismatch fails cleanly (not a raw exception)
- [x] `reyn pipe run NAME` executes a real transform-only pipeline end-to-end and prints the correct JSON result
- [x] `reyn pipe run NAME` on a pipeline containing a `tool:` step is refused with a clear, actionable error (not a crash, not a silent no-op)
- [x] `--async` is rejected with a clear message, not silently accepted
- [x] All CI gates run locally and pass (see above)