### PR TITLE
fix: reyn pipe run resolves MCP (and other resource-backed) tool categories via build_resource_caller_state

### DIFF
--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -47,6 +47,18 @@ blanket-granted (see ``_build_run_tool_context``'s docstring). This matters
 because a pipeline may be installed from an untrusted source (``reyn pipe
 install --source``) — it must not silently gain broad file/network access
 merely by being RUN.
+
+Bug fix (was: ``router_state=None`` unconditionally): a bare ``ToolContext``
+with no ``router_state`` silently drops every resource-backed universal-
+catalog category — ``mcp``, ``agents``, ``available_skills``, ``rag_corpus``,
+``sandbox_backend`` (documented as "caveat-1" in ``runtime/router_loop.py``'s
+``UniversalCategoryScheme.catalog_entries``) — so a ``tool:`` step calling
+``mcp__<server>__<tool>`` could never resolve. ``run_run`` now builds
+``router_state`` via ``reyn.tools.types.build_resource_caller_state``, fed
+the ``default`` identity's own Session's ``RouterHostAdapter`` (every real
+``Session`` builds one unconditionally in ``__init__``, live chat loop or
+not) — the exact same machinery the async pipeline driver-session's tool-step
+dispatch already uses (``runtime/services/pipeline_executor_driver.py``).
 """
 from __future__ import annotations
 
@@ -443,7 +455,9 @@ def run_install(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_run_tool_context(project_root: Path, *, grant_file_write: bool = False):
+def _build_run_tool_context(
+    project_root: Path, router_state: "Any | None", *, grant_file_write: bool = False,
+):
     """Build a real, standalone ``ToolContext`` for ``reyn pipe run``'s
     ``tool:`` step dispatch — routed through the SAME seam a live agent
     session's ``ToolStep`` uses (``_make_tool_dispatch`` /
@@ -476,11 +490,16 @@ def _build_run_tool_context(project_root: Path, *, grant_file_write: bool = Fals
         caller (including the non-interactive pipeline driver-session,
         ``services/pipeline_executor_driver.py``) already sets this same
         literal.
-      - ``router_state=None``: no live router/host context exists standalone.
-        A tool handler that specifically needs ``ctx.router_state`` (e.g.
-        ``run_pipeline``'s own tool, structurally denied inside a pipeline
-        step anyway — R6 S3) raises its own clear "no router context"
-        error — an honest, narrow limitation, not a silent gap.
+      - ``router_state``: the caller-supplied ``RouterCallerState`` (built via
+        ``reyn.tools.types.build_resource_caller_state`` from a real Session's
+        ``RouterHostAdapter`` — see ``run_run``) so ``mcp``/``agents``/
+        ``available_skills``/``rag_corpus``/``sandbox_backend`` catalog
+        categories resolve exactly like a live ``reyn chat`` turn's. A tool
+        handler that specifically needs loop-local fields this state does NOT
+        carry (chain_id, budget, dispatch callbacks — e.g. ``run_pipeline``'s
+        own tool, structurally denied inside a pipeline step anyway — R6 S3)
+        raises its own clear error — an honest, narrow limitation, not a
+        silent gap.
       - ``resolver``/``hot_reloader``/``state_log``: ``None`` — each is
         documented (``tools/types.py``) to gracefully degrade when absent.
     """
@@ -516,7 +535,7 @@ def _build_run_tool_context(project_root: Path, *, grant_file_write: bool = Fals
         permission_resolver=perm_resolver,
         workspace=workspace,
         caller_kind="router",
-        router_state=None,
+        router_state=router_state,
         resolver=None,
         hot_reloader=None,
         state_log=None,
@@ -553,13 +572,19 @@ def run_run(args: argparse.Namespace) -> None:
     (:func:`_build_run_tool_context`); an ``agent:`` step spawns a real
     ephemeral session under the ``default`` agent identity via a real,
     standalone ``AgentRegistry`` (``registry_bootstrap.
-    build_agent_registry_from_project``). The one remaining narrow gap: a
-    ``tool:`` step that specifically needs ``ctx.router_state`` (e.g. a
-    hand-authored tool reading ``router_state.pipeline_registry`` directly)
-    still fails — with that tool's own clear error — since no live router
-    context exists standalone; nothing in the shipped tool catalog needs
-    ``router_state`` outside of ``run_pipeline`` itself, which is already
-    structurally denied inside a pipeline step (R6 S3, nesting is call-only).
+    build_agent_registry_from_project``).
+
+    ``router_state`` (fixed — was a hardcoded ``None`` landmine, see
+    ``runtime/router_loop.py``'s "caveat-1" comment): the resource-backed
+    catalog categories (``mcp``, ``agents``, ``available_skills``,
+    ``rag_corpus``, ``sandbox_backend``) are populated via
+    ``reyn.tools.types.build_resource_caller_state``, fed the ``default``
+    identity's own ``RouterHostAdapter`` (``AgentRegistry.get_or_load(
+    DEFAULT_AGENT_NAME).router_host`` — every real ``Session`` builds one
+    unconditionally in ``__init__``). This is the SAME machinery the async
+    pipeline driver-session's tool-step dispatch already uses
+    (``runtime/services/pipeline_executor_driver.py::_make_dispatch``) —
+    not a new mechanism, just reused for this standalone caller too.
     """
     from reyn.core.pipeline.executor import PipelineExecutionError, PipelineExecutor
     from reyn.core.pipeline.registry import PipelineNotFoundError
@@ -567,6 +592,7 @@ def run_run(args: argparse.Namespace) -> None:
     from reyn.runtime.registry import DEFAULT_AGENT_NAME
     from reyn.runtime.registry_bootstrap import build_agent_registry_from_project
     from reyn.tools.pipeline_verbs import _make_tool_dispatch
+    from reyn.tools.types import build_resource_caller_state
 
     if getattr(args, "async_", False):
         print(
@@ -622,11 +648,12 @@ def run_run(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     grant_file_write = bool(getattr(args, "grant_file_write", False))
-    tool_ctx = _build_run_tool_context(project_root, grant_file_write=grant_file_write)
-    tool_dispatch = _make_tool_dispatch(tool_ctx)
     # A real, standalone AgentRegistry (registry_bootstrap) so an
     # AgentStep can genuinely spawn+run an ephemeral session — see the module
-    # docstring for the corrected tool:/agent: scope decision.
+    # docstring for the corrected tool:/agent: scope decision. It also doubles
+    # as the source of a real Session (the `default` identity's own) whose
+    # RouterHostAdapter feeds the tool-step ToolContext's router_state below —
+    # every real Session builds one unconditionally, live chat session or not.
     agent_registry = build_agent_registry_from_project(
         project_root, config, non_interactive=True, grant_file_write=grant_file_write,
     )
@@ -636,6 +663,38 @@ def run_run(args: argparse.Namespace) -> None:
 
     async def _run() -> Any:
         try:
+            # A pipeline that never reaches a 'tool:' step should not pay the
+            # cost of constructing a real Session (LLM client / resolver
+            # setup) just to source a router_state nobody will read — so the
+            # `default` identity's Session (and the #2567 build_resource_
+            # caller_state call it feeds) is resolved LAZILY, on the FIRST
+            # actual tool dispatch, not unconditionally up front.
+            _router_state_cache: "dict[str, Any]" = {}
+
+            async def _resolve_router_state() -> Any:
+                if "state" not in _router_state_cache:
+                    # #2567's pattern, reused: build the host-derived
+                    # RouterCallerState subset from a real Session's
+                    # RouterHostAdapter, so mcp/agents/available_skills/
+                    # rag_corpus/sandbox_backend resolve exactly like a live
+                    # router turn's — NOT the hardcoded router_state=None gap
+                    # documented as "caveat-1" in runtime/router_loop.py.
+                    source_session = agent_registry.get_or_load(DEFAULT_AGENT_NAME)
+                    _router_state_cache["state"] = await build_resource_caller_state(
+                        source_session.router_host,
+                    )
+                return _router_state_cache["state"]
+
+            tool_ctx = _build_run_tool_context(
+                project_root, None, grant_file_write=grant_file_write,
+            )
+            base_dispatch = _make_tool_dispatch(tool_ctx)
+
+            async def tool_dispatch(tool_name: str, resolved_args: dict) -> Any:
+                if tool_ctx.router_state is None:
+                    tool_ctx.router_state = await _resolve_router_state()
+                return await base_dispatch(tool_name, resolved_args)
+
             return await executor.run(
                 pipeline,
                 seed_ctx or None,

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -26,12 +26,21 @@ Covers:
     default write zone via the real, shipped ``write_file`` tool is DENIED
     without ``--grant-file-write``, and succeeds with it — byte-identical to
     ``reyn chat``'s own no-flag/``--grant-file-write`` posture.
+  - regression (bug fix): a ``tool:`` step calling a first-class
+    ``mcp__<server>__<tool>`` action now genuinely resolves and dispatches —
+    the ``router_state=None`` gap ("caveat-1" in ``runtime/router_loop.py``)
+    silently dropped every resource-backed catalog category (mcp/agents/
+    available_skills/rag_corpus/sandbox_backend). Only the MCP CLIENT's
+    transport is faked (``reyn.mcp.pool.MCPClient``, mirroring
+    ``test_2421_gateway_acceptance.py``'s existing fixture convention) — the
+    resolution/dispatch/permission-gate machinery all runs for real.
 """
 from __future__ import annotations
 
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 import litellm
 import pytest
@@ -52,7 +61,12 @@ def _make_parser() -> argparse.ArgumentParser:
 
 
 def _write_reyn_yaml(project_root: Path, pipelines_entries: dict | None = None) -> None:
-    data: dict = {"model": "standard"}
+    # A real litellm-recognizable model string for 'standard' (mirrors a real
+    # project's reyn.yaml) — avoids litellm's own unrecognized-provider banner
+    # printing to stdout, which would otherwise corrupt 'reyn pipe run's JSON
+    # output the moment a 'tool:' step lazily constructs a real Session (the
+    # router_state fix's source of a RouterHostAdapter — see run_run).
+    data: dict = {"model": "standard", "models": {"standard": "openai/gpt-4o-mini"}}
     if pipelines_entries is not None:
         data["pipelines"] = {"entries": pipelines_entries}
     (project_root / "reyn.yaml").write_text(
@@ -479,4 +493,140 @@ def test_run_agent_step_spawns_real_ephemeral_session(tmp_path, monkeypatch, cap
     out = capsys.readouterr().out
     result = json.loads(out)
     assert result["named_stores"]["reply"] == "the agent's answer"
-    assert result["pipe_data"] == "the agent's answer"
+
+
+# ---------------------------------------------------------------------------
+# reyn pipe run — MCP (and other resource-backed) tool-category dispatch fix
+# ---------------------------------------------------------------------------
+
+
+class _FakeMCPClient:
+    """Fakes the transport ONLY — every layer above (resolve_invoke_action,
+    mcp_call_tool, MCPGateway/MCPConnectionService, the OpContext / permission
+    gate) runs for real. Mirrors ``MCPClient``'s real construction signature
+    (``config`` positional, ``agent_id``/``server_name``/``message_handler``/
+    ``elicitation_handler`` kwargs — the ``default`` identity's main Session
+    is non-ephemeral, so it holds its MCP connection open via
+    ``MCPConnectionService`` rather than the ephemeral-session
+    ``MCPClientPool`` path — both construct a bare ``MCPClient`` the same way,
+    mirroring ``test_2421_gateway_acceptance.py``'s existing fixture
+    convention of patching the constructor at its import site) and the
+    async-CM + ``call_tool`` surface + the negotiated-version/capabilities
+    read ``MCPConnectionService`` does once per (re)connect."""
+
+    def __init__(self, config: dict, *, agent_id: "str | None" = None,
+                 server_name: "str | None" = None, **_kwargs: Any) -> None:
+        self._config = config
+        self.server_name = server_name
+        self.negotiated_version = "2024-11-05"
+
+    async def __aenter__(self) -> "_FakeMCPClient":
+        return self
+
+    async def __aexit__(self, *exc_info) -> None:
+        return None
+
+    def advertised_capabilities(self) -> dict:
+        return {}
+
+    def is_initialized(self) -> bool:
+        return True
+
+    async def call_tool(
+        self, name: str, args: dict, *, progress_callback=None, timeout_seconds=None,
+    ) -> dict:
+        return {
+            "content": [{"type": "text", "text": f"{name}:{args.get('msg', '')}"}],
+            "isError": False,
+        }
+
+
+def test_run_tool_step_dispatches_mcp_action_for_real(tmp_path, monkeypatch, capsys):
+    """Tier 2: regression pin for the router_state=None bug — a 'tool:' step
+    calling the first-class 'mcp__<server>__<tool>' action now genuinely
+    resolves and dispatches through the real MCP call path (permission gate,
+    MCPGateway/MCPConnectionService, the op_runtime mcp handler all real; only
+    the MCP CLIENT's transport is faked, mirroring
+    test_2421_gateway_acceptance.py's own fixture convention of patching
+    MCPClient at its import site)."""
+    monkeypatch.chdir(tmp_path)
+    import reyn.mcp.connection_service as connection_service_mod
+    import reyn.mcp.pool as pool_mod
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(connection_service_mod, "MCPClient", _FakeMCPClient)
+
+    dsl_path = tmp_path / "uses_mcp.yaml"
+    dsl_path.write_text(
+        "pipeline: uses_mcp\n"
+        "steps:\n"
+        "  - tool: {name: mcp__echo__ping, args: {msg: !expr ctx.msg}, output: r}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "models": {"standard": "openai/gpt-4o-mini"},
+                "mcp": {"servers": {"echo": {"type": "stdio", "command": "x"}}},
+                # Non-interactive caller (no one to answer the JIT approval
+                # prompt) needs the MCP runtime-approval gate pre-granted in
+                # config — mirrors what an operator running 'reyn pipe run'
+                # non-interactively against a trusted server would configure.
+                "permissions": {"mcp": {"echo": "allow"}},
+                "pipelines": {"entries": {"uses_mcp": {"path": "uses_mcp.yaml"}}},
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    args = _ns(
+        name="uses_mcp", input=json.dumps({"msg": "hi reyn"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert result["named_stores"]["r"]["status"] == "ok"
+    assert result["named_stores"]["r"]["content"] == "ping:hi reyn"
+
+
+@pytest.mark.asyncio
+async def test_router_state_resource_categories_populated_from_real_session(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: a more direct regression-pin than the end-to-end MCP case above
+    — the SAME real Session (default identity) run_run sources router_state
+    from has its RouterHostAdapter report the project's configured MCP
+    servers, confirming build_resource_caller_state saw a REAL host (not the
+    router_state=None gap this bug fix closes)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "mcp": {"servers": {"echo": {"type": "stdio", "command": "x"}}},
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    from reyn.config import load_config
+    from reyn.runtime.registry import DEFAULT_AGENT_NAME
+    from reyn.runtime.registry_bootstrap import build_agent_registry_from_project
+    from reyn.tools.types import build_resource_caller_state
+
+    config = load_config()
+    agent_registry = build_agent_registry_from_project(
+        tmp_path, config, non_interactive=True,
+    )
+    try:
+        session = agent_registry.get_or_load(DEFAULT_AGENT_NAME)
+        router_state = await build_resource_caller_state(session.router_host)
+    finally:
+        await agent_registry.shutdown()
+
+    servers = {s["name"] for s in (router_state.mcp_servers or [])}
+    assert "echo" in servers


### PR DESCRIPTION
**[per-PR-coder]** — Fixes a bug in the just-merged `reyn pipe` CLI (#2643/#2644): `reyn pipe run` could not dispatch MCP (or any other resource-backed) tool categories from a `tool:` pipeline step.

## Root cause

`reyn pipe run`'s `_build_run_tool_context` (`src/reyn/interfaces/cli/commands/pipe.py`) built its `ToolContext` with `router_state=None` unconditionally. Every resource-backed universal-catalog category — `mcp`, `agents`, `available_skills`, `rag_corpus`, `sandbox_backend` — is gated on `ctx.router_state` (documented as **"caveat-1"** in `runtime/router_loop.py`'s `UniversalCategoryScheme.catalog_entries`: *"a ToolContext WITHOUT router_state drops the resource categories — agents/mcp"*). Concretely, `mcp__<server>__<tool>` dispatch went through `_require_host` (`reyn/tools/mcp.py`), which raises `"MCP tool handlers require ctx.router_state.host ... this is a dispatcher wiring bug"` whenever `router_state` is `None` — so an MCP `tool:` step failed every time, silently (from the pipeline author's perspective) rather than obviously.

## The fix — reuses existing machinery, invents nothing new

- `reyn.tools.types.build_resource_caller_state(host) -> RouterCallerState` already exists and is already documented for exactly this situation: its docstring says `host` is a `RouterLoopHost`-compatible object (typically a `RouterHostAdapter`), and that loop-local fields are unpopulated for "callers without a RouterLoop turn (e.g. a pipeline driver-session)".
- The **async** pipeline driver-session's own tool-step dispatch (`runtime/services/pipeline_executor_driver.py::_make_dispatch`) already calls `await build_resource_caller_state(host)` with `host = self._router_host` (a `RouterHostAdapter`) — this PR makes `reyn pipe run` do the exact same thing, for the exact same reason.
- Every real `Session` builds a `RouterHostAdapter` (`self._router_host`) **unconditionally** in `__init__` — not just when a chat/router loop is live — and exposes it via the existing public `Session.router_host` property. So any real `Session` (e.g. one obtained via `AgentRegistry.get_or_load`) already has a usable adapter to hand to `build_resource_caller_state`.

`run_run` now sources `router_state` from the `default` identity's own Session — `agent_registry.get_or_load(DEFAULT_AGENT_NAME).router_host` — the same `AgentRegistry` `reyn pipe run` already builds for `agent:` step support (#2644). Resolution is **lazy**, on the first actual `tool:` dispatch, so a pipeline that never reaches a `tool:` step (the common case — pure `transform`/`call`/`match`/`fold`/`for_each`/`parallel` pipelines) never pays the cost of constructing a real Session (LLM resolver / model-budget setup) just to source a `router_state` nobody reads.

## Verified populated after the fix

- **`mcp_servers`**: an end-to-end test (`test_run_tool_step_dispatches_mcp_action_for_real`) runs a real `reyn pipe run` of a pipeline with a `tool: {name: mcp__echo__ping, ...}` step, dispatching through the REAL permission gate / `MCPGateway` / `MCPConnectionService` / op_runtime `mcp` handler — only the MCP **client's transport** is faked (`reyn.mcp.pool.MCPClient` / `reyn.mcp.connection_service.MCPClient`, mirroring `test_2421_gateway_acceptance.py`'s existing fixture convention for patching that constructor). Asserts the tool call actually resolves and returns the (faked) result — not just that resolution doesn't crash.
- A direct regression-pin (`test_router_state_resource_categories_populated_from_real_session`) confirms `RouterCallerState.mcp_servers` reflects the project's configured `mcp.servers` when sourced this way.
- `agents` / `available_skills` / `rag_corpus` / `sandbox_backend` are populated by the SAME `build_resource_caller_state(host)` call (same host, same field-by-field accessor set already exercised by the driver-session's identical usage) — structurally the same fix, not independently re-verified per category in a dedicated new test here.

## Docs

Checked `docs/guide/for-users/write-a-pipeline.md`/`.ja.md` §"Manage and run from the CLI" — it already says "every step kind runs, including tool: and agent:" without singling out MCP as broken, so no correction was needed (the general claim is simply now actually true).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_cli_pipe.py` — 20/20 OK, 0 Tier-4 violations
- [x] `pytest` from repo root — full suite green modulo 4 pre-existing failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `tests/web/test_a2a.py::test_a2a_routes_mounted`, `tests/web/test_mcp_sse.py::test_mcp_routes_mounted`, `tests/web/test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `tests/web/test_resources_router.py::test_resources_route_is_mounted_on_app`) — confirmed by running each in isolation against clean `origin/main` (`142b2037`) with this branch's changes stashed; identical failures, unrelated to this change.
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/pipe.py tests/test_cli_pipe.py` — OK