### PR TITLE
fix: point offload read-back instructions at file__read, not retired read_tool_result

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -267,7 +267,7 @@ def _overflow_ref_text(ref: dict) -> str:
     return (
         f"[image not loaded — exceeds the per-turn media budget. "
         f"Stored at {ref['path']} ({ref.get('mime_type', 'image')}); "
-        f"load it with read_tool_result when the context has room.]"
+        f"load it with file__read(path={ref['path']!r}) when the context has room.]"
     )
 
 
@@ -302,8 +302,8 @@ def _build_media_tail_preview(
                 return {"type": "text", "text": (
                     f"[{n} more image(s) exceed the per-turn media budget and are "
                     f"not shown here. A lossless manifest of their on-disk paths is "
-                    f"stored at {saved['path']}; load it with read_tool_result to "
-                    f"access them.]"
+                    f"stored at {saved['path']}; load it with "
+                    f"file__read(path={saved['path']!r}) to access them.]"
                 )}
             except Exception:  # noqa: BLE001 — offload best-effort; degrade below
                 pass

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -184,7 +184,7 @@ def _build_preview(
         "_offload_total_chars": len(content_str),
         "_offload_note": (
             f"Tool result offloaded ({len(content_str)} chars); read the full "
-            f"body via read_tool_result({ref!r})."
+            f"body via file__read(path={ref!r})."
         ),
         "_offload_head": content_str[:head_chars] if head_chars > 0 else "",
         "_offload_tail": content_str[-tail_chars:] if tail_chars > 0 else "",


### PR DESCRIPTION
**[per-PR-coder]** — read_tool_result was retired as an LLM-callable tool in #1449 (verified: not registered anywhere as a callable action — only internal `MediaStore.read_tool_result*` Python methods remain). However, three LLM-facing instruction strings still told the model to call `read_tool_result` to read back an offloaded tool-result body. An LLM following those instructions calls a nonexistent tool and fails.

This PR points those instructions at `file__read(path=...)`, the tool that actually reads offloaded bodies back from `.reyn/tool-results/` (confirmed against `_READ_FILE_PARAMETERS` in `src/reyn/tools/file.py`, which requires a `path` argument).

## Sites changed
1. `src/reyn/runtime/services/tool_result_cap.py:187` — `_build_preview`'s `_offload_note`: `read_tool_result({ref!r})` → `file__read(path={ref!r})`.
2. `src/reyn/runtime/router_loop.py:270` — `_overflow_ref_text`: `load it with read_tool_result when the context has room.` → `load it with file__read(path={ref['path']!r}) when the context has room.`
3. `src/reyn/runtime/router_loop.py:305` — `_build_media_tail_preview`'s manifest follow-up: `load it with read_tool_result to access them.` → `load it with file__read(path={saved['path']!r}) to access them.`

Pure string/instruction fix — no logic changes. Remaining `read_tool_result` occurrences in `src/reyn/` (grepped exhaustively) are either the still-existing internal `MediaStore.read_tool_result*` Python methods, or comments/docstrings documenting internal implementation — out of scope per the task discriminator (LLM-visible output vs. internal doc/code).

No test asserts on the changed instruction strings' exact content, so no test changes were needed (and per the testing policy, new format-pinning tests would be a Tier-4 violation).

## Test plan
- [x] `ruff check src tests` — passes clean.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — skipped, no test files changed.
- [x] `pytest` from repo root — 7525 passed, 21 skipped, 5 failed. The 5 failures (`test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted`, `test_a2a.py::test_a2a_routes_mounted`, `test_mcp_sse.py::test_mcp_routes_mounted`, `test_plugin_loader.py::test_loader_disambiguates_via_package_field`, `test_resources_router.py::test_resources_route_is_mounted_on_app`) are pre-existing route-mounting failures on `main` unrelated to this diff — verified by `git stash` + rerunning the same 5 tests against unmodified `main`, which reproduces the identical failures.
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — passes clean.
- [x] Grepped `read_tool_result` across `src/reyn` and `tests/` to confirm no other LLM-facing site or test assertion was missed.