### PR TITLE
feat: pipeline tool: step results expose canonical text/structured ctx (#2425 PR-2)

### DIFF
--- a/docs/guide/for-users/write-a-pipeline.md
+++ b/docs/guide/for-users/write-a-pipeline.md
@@ -44,6 +44,9 @@ A few things worth noting about this file:
   doesn't use that input, but see the
   [reference doc's `shell` section](../../reference/runtime/pipeline-dsl.md#tool-shell-sugar)
   for the full STDIN/STDOUT contract.
+- A `tool`/`shell` step's result (here, `ctx.shouted`) is always the flat
+  `{text: ..., structured: ...}` shape (`structured` only present for
+  non-text data) — see [`tool` step results](../../reference/runtime/pipeline-dsl.md#tool-step-results).
 
 ## 2. Register it
 
@@ -219,11 +222,11 @@ greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
 
 $ reyn pipe run greet --input '{"name": "Reyn"}'
 {
-  "pipe_data": "Hello, Reyn! (shouted)",
+  "pipe_data": {"text": "Hello, Reyn! (shouted)"},
   "named_stores": {
     "name": "Reyn",
     "greeting": "Hello, Reyn!",
-    "shouted": "Hello, Reyn! (shouted)"
+    "shouted": {"text": "Hello, Reyn! (shouted)"}
   }
 }
 ```

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -212,10 +212,27 @@ FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
 |-----|------|------|
 | `name` | 必須 | ツール / アクション名(リテラル文字列)。 |
 | `args` | 任意 | 引数名 → 値 のマッピング。各値は `!expr` タグが付いていない限り**リテラル**([リテラル vs `!expr`](#vs-expr)参照)。 |
-| `schema` | 任意 | 結果が適合すべき登録済み schema 名(`verify: schema` — [Schema](#schema-verify-schema)参照)。不適合はステップを失敗させる。 |
+| `schema` | 任意 | 結果が適合すべき登録済み schema 名(`verify: schema` — [Schema](#schema-verify-schema)参照)。不適合はステップを失敗させる(下記の `text`/`structured` 変換前の、生のツール結果に対してチェックされる)。 |
 | `output` | 任意 | 結果を書き込む named store。 |
 
-`shell` は `"shell"` という名前の `tool` ステップのシュガーです: `command` は operator のサンドボックス(`sandboxed_exec` — 直接の `sandboxed_exec` 呼び出しと同じ閉じ込め、ポリシー優先順位、監査イベント)の中で `/bin/sh -c <command>` として実行されます。ステップに入ってくる pipe data はプロセスの **STDIN に JSON エンコードされて**渡されます。プロセスの **STDOUT がステップの結果になります** — JSON として parse できればデコードされ(`dict` を要求する `verify: schema` が JSON を出力するコマンドに適用できるように)、できなければ生のテキストのままです。
+#### `tool` ステップの結果 {#tool-step-results}
+
+`tool`(および `shell`)ステップの結果 — `pipe` と `ctx.<output>` に入るもの —
+は常にフラットな 2 フィールド形状 `{text: ..., structured: ...}` で、
+すべてのツール種別で統一されています(chat 側が LLM に見せるのと同じ形状):
+
+- **`text`** — ツールの正規の文字列本体(ツールにテキスト形状の結果が無い場合は空文字列)。
+- **`structured`** — ツールが非テキストのデータを出したときだけ存在する。それ以外は
+  キー自体が無い。認識されない形状のツール結果 dict は、丸ごと `structured` として
+  ラップされる(何も失われない)。
+
+この変換は**形状のみ**です — chat 側のツール結果パスのように値を切り詰めたり
+offload したり cap したりは絶対にしません。pipeline ステップの `ctx` は、後続の
+ステップがプログラム的に消費できるよう、値をフルで保持します。ツールのテキスト本体は
+`ctx.<name>.text` で、structured なペイロードは `ctx.<name>.structured`(またはその
+フィールド、例: `ctx.hits.structured.count`)で読みます。
+
+`shell` は `"shell"` という名前の `tool` ステップのシュガーです: `command` は operator のサンドボックス(`sandboxed_exec` — 直接の `sandboxed_exec` 呼び出しと同じ閉じ込め、ポリシー優先順位、監査イベント)の中で `/bin/sh -c <command>` として実行されます。ステップに入ってくる pipe data はプロセスの **STDIN に JSON エンコードされて**渡されます。プロセスの **STDOUT がステップの結果になります** — JSON として parse できればデコードされ(`dict` を要求する `verify: schema` が JSON を出力するコマンドに適用できるように)、できなければ生のテキストのままです — そして、その(生または JSON デコード済みの)値は他の `tool` ステップと同じ `text`/`structured` 変換を経ます(JSON デコードされた dict は `ctx.<name>.structured` に、生のテキストは `ctx.<name>.text` に入ります)。
 
 ```yaml
 - shell: {command: !expr "'ls ' + ctx.dir", output: listing}

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -44,7 +44,7 @@ steps:
 steps:
   - transform: {value: "ctx.name + '!'", output: greeting}   # ステップ 0
   - tool: {name: shout, args: {text: !expr pipe}, output: shouted}  # ステップ 1
-  - transform: {value: "ctx.shouted + ' (done)'", output: final}   # ステップ 2
+  - transform: {value: "ctx.shouted.text + ' (done)'", output: final}   # ステップ 2
 ```
 
 `ctx = {name: "Reyn"}` でシードした場合:
@@ -53,7 +53,7 @@ steps:
 |---|---|---|
 | 0 | `{name: "Reyn"}` | `null`(先行ステップ無し) |
 | 1 | `{name: "Reyn", greeting: "Reyn!"}` | `"Reyn!"`(ステップ 0 の結果) |
-| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: "REYN!"}` | `"REYN!"`(ステップ 1 の結果) |
+| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: {text: "REYN!"}}` | `{text: "REYN!"}`(ステップ 1 の結果 — 下記の[`tool` ステップの結果](#tool-step-results)参照) |
 | *(ステップ 2 の後)* | `{..., final: "REYN! (done)"}` | `"REYN! (done)"` |
 
 ステップ 1 はステップ 0 の結果を、両方とも機能する 2 通りの方法で読めます: bare な `pipe`(直前のステップ)か `ctx.greeting`(永続的な store)です — ステップ 0 の直後はどちらも同じ値を保持しますが、間に別のステップが挟まると `ctx.greeting` だけが到達可能なままです。

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -61,7 +61,7 @@ at each boundary:
 steps:
   - transform: {value: "ctx.name + '!'", output: greeting}   # step 0
   - tool: {name: shout, args: {text: !expr pipe}, output: shouted}  # step 1
-  - transform: {value: "ctx.shouted + ' (done)'", output: final}   # step 2
+  - transform: {value: "ctx.shouted.text + ' (done)'", output: final}   # step 2
 ```
 
 seeded with `ctx = {name: "Reyn"}`:
@@ -70,7 +70,7 @@ seeded with `ctx = {name: "Reyn"}`:
 |---|---|---|
 | 0 | `{name: "Reyn"}` | `null` (no prior step) |
 | 1 | `{name: "Reyn", greeting: "Reyn!"}` | `"Reyn!"` (step 0's result) |
-| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: "REYN!"}` | `"REYN!"` (step 1's result) |
+| 2 | `{name: "Reyn", greeting: "Reyn!", shouted: {text: "REYN!"}}` | `{text: "REYN!"}` (step 1's result — see [`tool` step results](#tool-step-results) below) |
 | *(after step 2)* | `{..., final: "REYN! (done)"}` | `"REYN! (done)"` |
 
 Step 1 reads step 0's result two ways that both work: bare `pipe` (its
@@ -286,8 +286,26 @@ registered tool name (`web_search`).
 |-----|----------|---------|
 | `name` | yes | The tool/action name (literal string). |
 | `args` | no | Mapping of argument name → value. Each value is a **literal** unless tagged `!expr` (see [Literals vs `!expr`](#literals-vs-expr) below). |
-| `schema` | no | A registered schema name the result must conform to (`verify: schema` — see [Schemas](#schemas-verify-schema)). Non-conformance fails the step. |
+| `schema` | no | A registered schema name the result must conform to (`verify: schema` — see [Schemas](#schemas-verify-schema)). Non-conformance fails the step (checked against the RAW tool result, before the `text`/`structured` reduction below). |
 | `output` | no | Named store to write the result to. |
+
+#### `tool` step results
+
+A `tool` (and `shell`) step's result — what lands as `pipe` and `ctx.<output>`
+— is always the flat two-field shape `{text: ..., structured: ...}`, uniform
+across every tool kind (the same shape the chat side exposes to an LLM):
+
+- **`text`** — the tool's canonical string body (empty string when the tool
+  has no text-shaped result).
+- **`structured`** — present only when the tool produced non-text data; absent
+  entirely (no key) otherwise. A tool result dict with no recognized shape is
+  wrapped whole as `structured` (nothing is ever lost).
+
+This conversion is **shape-only** — it never truncates, offloads, or caps a
+value the way the chat-side tool-result path does; a pipeline step's `ctx`
+retains the full value for downstream steps to consume programmatically.
+Read a tool's text body via `ctx.<name>.text` and its structured payload via
+`ctx.<name>.structured` (or a field of it, e.g. `ctx.hits.structured.count`).
 
 `shell` is sugar for a `tool` step named `"shell"`: `command` runs as
 `/bin/sh -c <command>` inside the operator's sandbox
@@ -296,7 +314,9 @@ a direct `sandboxed_exec` call). The step's incoming pipe data is threaded to
 the process's **STDIN, JSON-encoded**; the process's **STDOUT becomes the
 step's result** — JSON-decoded when it parses as JSON (so `verify: schema`,
 which requires a `dict`, can apply to a JSON-emitting command), otherwise the
-raw text.
+raw text — and that (raw or JSON-decoded) value goes through the same
+`text`/`structured` reduction as any other `tool` step (a JSON-decoded dict
+lands in `ctx.<name>.structured`; raw text lands in `ctx.<name>.text`).
 
 ```yaml
 - shell: {command: !expr "'ls ' + ctx.dir", output: listing}

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -236,3 +236,33 @@ def to_canonical(result: dict) -> CanonicalToolResult:
         source_ref=None,
         meta={},
     )
+
+
+def unwrap_dispatch_envelope(result: Any) -> Any:
+    """Peel any ``{"status": ..., "data": {...}}`` dispatch envelope(s) off a raw tool-dispatch
+    result, stopping at the first dict that already carries a ``kind`` (the shape :func:`to_canonical`
+    dispatches on). A tool-registry handler's own return value can itself be an envelope (e.g.
+    ``run_pipeline``), so more than one layer may need peeling — hence the loop, not a single unwrap."""
+    inner = result
+    while (
+        isinstance(inner, dict)
+        and isinstance(inner.get("data"), dict)
+        and set(inner) <= {"status", "data", "error"}
+        and "kind" not in inner
+    ):
+        inner = inner["data"]
+    return inner
+
+
+def canonical_to_ctx_fields(canonical: CanonicalToolResult) -> "dict[str, Any]":
+    """Reduce a :class:`CanonicalToolResult` to the flat ``{"text": ..., "structured": ...}`` shape a
+    pipeline step's ``ctx.<name>`` exposes (``structured`` key absent when there is no structured
+    attachment) — shape-only, mirroring ``seam.py``'s attachments reduction but with NO size gating:
+    pipeline ctx retains full values for downstream programmatic step processing (owner ruling)."""
+    fields: dict[str, Any] = {"text": canonical.get("text", "")}
+    structured_items = [
+        att.get("data") for att in canonical.get("attachments", []) or [] if att.get("kind") == "structured"
+    ]
+    if structured_items:
+        fields["structured"] = structured_items[0] if len(structured_items) == 1 else structured_items
+    return fields

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -108,6 +108,11 @@ from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
+from reyn.core.offload.canonical import (
+    canonical_to_ctx_fields,
+    to_canonical,
+    unwrap_dispatch_envelope,
+)
 from reyn.core.pipeline.expr import ExprEvalError, ExprParseError, evaluate_expr
 from reyn.core.pipeline.registry import PipelineNotFoundError
 from reyn.core.pipeline.schema import SchemaRegistry, validate
@@ -754,7 +759,20 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
                 f"step {inv.step_label} (tool {step.name!r}) output failed schema "
                 f"{step.schema!r}: {validation.errors}"
             )
-    return result, True, inv.completed_step_results
+    # #2425 PR-2: ctx exposes the same text/structured shape chat gets, uniformly across every op
+    # kind — shape-only (to_canonical), NEVER offloaded/size-gated (owner ruling: ctx/pipe data
+    # retains full values for downstream programmatic step processing). Schema validation above runs
+    # against the RAW dispatch result, unchanged.
+    if isinstance(result, dict):
+        canonical = to_canonical(unwrap_dispatch_envelope(result))
+        ctx_result: Any = canonical_to_ctx_fields(canonical)
+    elif isinstance(result, str):
+        ctx_result = {"text": result}
+    else:
+        # A non-dict, non-str result (int/float/bool/list/None/...) is not textual —
+        # it is structured data, not a stringified lossy blob (full-value retention).
+        ctx_result = {"text": "", "structured": result}
+    return ctx_result, True, inv.completed_step_results
 
 
 async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2946,7 +2946,7 @@ class RouterLoop:
         # declared ``_offload_payload_field`` now has a mapper; an unregistered kind falls back to a
         # whole-dict ``structured`` attachment). The format is INDEPENDENT of the media store — it
         # applies even when ``media_store is None``; only the size-gated offloading needs a store.
-        from reyn.core.offload.canonical import to_canonical
+        from reyn.core.offload.canonical import to_canonical, unwrap_dispatch_envelope
         from reyn.core.offload.seam import build_offload_body, render_tool_result
         for tc, r in zip(result.tool_calls, result.tool_results):
             # B41-NF-W7-1: _post_text → appended outside the body.
@@ -2984,11 +2984,9 @@ class RouterLoop:
                 # Unwrap dispatch-envelope layers ({status, data} with nothing else) until the op
                 # result (the dict carrying ``kind``) is reached. One layer for op_runtime ops
                 # (bare {kind:…} wrapped once by dispatch_tool); two for tool-registry handlers whose
-                # own return is already an envelope (e.g. run_pipeline → wrapped again).
-                _inner = r
-                while (isinstance(_inner, dict) and isinstance(_inner.get("data"), dict)
-                       and set(_inner) <= {"status", "data", "error"} and "kind" not in _inner):
-                    _inner = _inner["data"]
+                # own return is already an envelope (e.g. run_pipeline → wrapped again). Shared with
+                # the pipeline `tool:` step ctx path (#2425 PR-2, executor.py::_run_tool_step).
+                _inner = unwrap_dispatch_envelope(r)
                 if not isinstance(_inner, dict):
                     # Non-dict result (rare) — render its value as plain text, losslessly.
                     content_str = _inner if isinstance(_inner, str) else json.dumps(_inner, default=str)

--- a/tests/test_2425_pipeline_tool_ctx_canonical_shape.py
+++ b/tests/test_2425_pipeline_tool_ctx_canonical_shape.py
@@ -1,0 +1,170 @@
+"""Tier 1/2: #2425 PR-2 — pipeline `tool:` step results expose the same
+`text`/`structured` two-field ctx shape chat gets, uniformly across op kinds,
+and NEVER go through the chat-side offload/size-gate machinery.
+
+Covers:
+  1. Tier 1: `canonical_to_ctx_fields` reduces `CanonicalToolResult.attachments`
+     to `structured` (absent / single item / list) exactly like `seam.py`'s own
+     reduction, minus any size gating.
+  2. Tier 2: a real `PipelineExecutor.run` through `_run_tool_step` exposes
+     `ctx.<name>.text`/`.structured` uniformly for TWO distinct real op kinds
+     (`mcp`, `sandboxed_exec`) via the REAL R1 expression evaluator.
+  3. Tier 2: a dispatch-envelope-wrapped result (the `run_pipeline`-style
+     `{"status": "ok", "data": {"kind": ..., ...}}` shape a tool-registry
+     handler can itself return) unwraps correctly before canonicalization.
+  4. Tier 2 falsify (owner hard rule): a structured payload far larger than
+     `seam.STRUCTURED_INLINE_MAX_CHARS` still lands FULLY INLINE in
+     `ctx.<name>.structured` — pipeline ctx is never offloaded/size-gated,
+     unlike the chat-side `build_offload_body` path.
+
+No mocks — real `PipelineExecutor`, real `to_canonical`, real R1 evaluator.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.offload.canonical import canonical_to_ctx_fields
+from reyn.core.offload.seam import STRUCTURED_INLINE_MAX_CHARS
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    Pipeline,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+
+
+def test_canonical_to_ctx_fields_structured_absent_when_no_attachments():
+    """Tier 1: no structured attachments → the ctx dict has no 'structured' key at all."""
+    fields = canonical_to_ctx_fields({"text": "hi", "attachments": [], "source_ref": None, "meta": {}})
+    assert fields == {"text": "hi"}
+    assert "structured" not in fields
+
+
+def test_canonical_to_ctx_fields_single_structured_attachment_unwraps():
+    """Tier 1: exactly one structured attachment → 'structured' is the bare value, not a
+    single-item list."""
+    canonical = {
+        "text": "",
+        "attachments": [{"kind": "structured", "data": {"a": 1}}],
+        "source_ref": None,
+        "meta": {},
+    }
+    assert canonical_to_ctx_fields(canonical) == {"text": "", "structured": {"a": 1}}
+
+
+def test_canonical_to_ctx_fields_multiple_structured_attachments_become_a_list():
+    """Tier 1: 2+ structured attachments → 'structured' is the list of their data,
+    mirroring seam.py's own reduction convention."""
+    canonical = {
+        "text": "",
+        "attachments": [
+            {"kind": "structured", "data": {"a": 1}},
+            {"kind": "structured", "data": {"b": 2}},
+        ],
+        "source_ref": None,
+        "meta": {},
+    }
+    assert canonical_to_ctx_fields(canonical) == {
+        "text": "", "structured": [{"a": 1}, {"b": 2}],
+    }
+
+
+def test_canonical_to_ctx_fields_ignores_media_attachments():
+    """Tier 1: a media attachment (no chat-side rendering target in pipeline ctx)
+    never appears in 'structured' — only 'kind': 'structured' items are collected."""
+    canonical = {
+        "text": "body",
+        "attachments": [{"kind": "media", "block": {"type": "image"}}],
+        "source_ref": None,
+        "meta": {},
+    }
+    assert canonical_to_ctx_fields(canonical) == {"text": "body"}
+
+
+@pytest.mark.asyncio
+async def test_tool_step_ctx_uniform_text_structured_across_two_distinct_op_kinds():
+    """Tier 2: two REAL, distinct op-kind result shapes (mcp / sandboxed_exec) both
+    resolve via the SAME `ctx.<name>.text` / `ctx.<name>.structured` R1 paths —
+    proving the ctx shape is uniform across op kinds, not per-kind bespoke."""
+
+    def _dispatch(name: str, args: dict) -> dict:
+        if name == "mcp_call":
+            return {
+                "kind": "mcp",
+                "content": "mcp said hi",
+                "structured": {"echo": args.get("msg")},
+            }
+        if name == "run_shell":
+            return {"kind": "sandboxed_exec", "stdout": "shell said hi", "returncode": 0}
+        raise AssertionError(f"unexpected tool {name!r}")
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="mcp_call", args={"msg": "hi"}, output="mcp_result"),
+        ToolStep(name="run_shell", args={}, output="shell_result"),
+        TransformStep(
+            value=(
+                "ctx.mcp_result.text + '|' + ctx.mcp_result.structured.echo"
+                " + '|' + ctx.shell_result.text"
+            ),
+            output="combined",
+        ),
+    ])
+
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-2425-uniform-shape",
+    )
+
+    assert result.named_stores["combined"] == "mcp said hi|hi|shell said hi"
+    # sandboxed_exec's zero returncode carries no signal → dropped, so
+    # structured is absent entirely for that step's ctx value.
+    assert "structured" not in result.named_stores["shell_result"]
+
+
+@pytest.mark.asyncio
+async def test_tool_step_unwraps_dispatch_envelope_before_canonicalizing():
+    """Tier 2: a tool-registry handler's own `{"status": "ok", "data": {"kind": ...}}`
+    envelope (the `run_pipeline` return shape) unwraps to its inner `kind`-bearing
+    dict BEFORE `to_canonical` dispatches — otherwise it would fall through to the
+    unregistered-kind whole-dict fallback instead of the real mapper."""
+
+    def _dispatch(name: str, args: dict) -> dict:
+        return {"status": "ok", "data": {"kind": "sandboxed_exec", "stdout": "enveloped", "returncode": 0}}
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="run_shell", args={}, output="r"),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-2425-envelope-unwrap",
+    )
+    # Unwrapped + mapped via the REAL sandboxed_exec mapper (text == stdout) — NOT
+    # the unregistered-kind fallback (which would have wrapped the whole envelope
+    # dict, including "status"/"data", as a structured attachment instead).
+    assert result.named_stores["r"] == {"text": "enveloped"}
+
+
+@pytest.mark.asyncio
+async def test_tool_step_ctx_never_offloads_oversized_structured_data():
+    """Tier 2: FALSIFY (owner hard rule) — a structured payload far exceeding
+    seam.py's STRUCTURED_INLINE_MAX_CHARS still lands FULLY INLINE in
+    ctx.<name>.structured — pipeline `_run_tool_step` must call bare
+    `to_canonical` (shape only), never `seam.build_offload_body` (which would
+    replace an oversized value with a file-ref dict here)."""
+    big_items = list(range(STRUCTURED_INLINE_MAX_CHARS))  # str() of this vastly exceeds the cap
+
+    def _dispatch(name: str, args: dict) -> dict:
+        return {"kind": "mcp", "content": "", "structured": {"items": big_items}}
+
+    pipeline = Pipeline(steps=[ToolStep(name="big_call", args={}, output="r")])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-2425-no-offload",
+    )
+
+    structured = result.named_stores["r"]["structured"]
+    # The full list survives verbatim — no truncation, no offload-ref substitution
+    # (an offloaded value would be a small dict with a path/ref marker, not this list).
+    assert structured == {"items": big_items}
+    assert len(structured["items"]) == STRUCTURED_INLINE_MAX_CHARS

--- a/tests/test_2593_pipeline_shell_step.py
+++ b/tests/test_2593_pipeline_shell_step.py
@@ -121,8 +121,11 @@ async def test_shell_step_threads_pipe_data_to_stdin_and_stdout_to_output():
         state_log=None,
         run_id="run-shell-stdin",
     )
-    assert result.pipe_data == {"n": 3, "msg": "hi"}
-    assert result.named_stores["echoed"] == {"n": 3, "msg": "hi"}
+    # #2425 PR-2: the shell tool's parsed-JSON dict (no "kind") is an
+    # unregistered-kind result → the whole dict is the sole structured attachment.
+    expected = {"text": "", "structured": {"n": 3, "msg": "hi"}}
+    assert result.pipe_data == expected
+    assert result.named_stores["echoed"] == expected
 
 
 # ─── 3. verify: schema on shell output ──────────────────────────────────────
@@ -153,7 +156,7 @@ async def test_shell_step_schema_verify_passes_conforming_output():
         run_id="run-shell-schema-ok",
         schema_registry=registry,
     )
-    assert result.pipe_data == {"msg": "hello"}
+    assert result.pipe_data == {"text": "", "structured": {"msg": "hello"}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -366,8 +366,11 @@ def test_run_tool_step_dispatches_for_real(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    assert result["named_stores"]["shout"] == {"content": "HI REYN"}
-    assert result["pipe_data"] == {"content": "HI REYN"}
+    # #2425 PR-2: an unregistered-kind tool result maps to the flat text/structured ctx shape —
+    # the whole raw dict becomes the (sole) structured attachment, text empty.
+    expected = {"text": "", "structured": {"content": "HI REYN"}}
+    assert result["named_stores"]["shout"] == expected
+    assert result["pipe_data"] == expected
 
 
 def test_run_tool_step_file_write_is_denied_without_grant_flag(
@@ -400,7 +403,9 @@ def test_run_tool_step_file_write_is_denied_without_grant_flag(
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    assert result["named_stores"]["r"]["status"] == "denied"
+    # #2425 PR-2: write_file's "file"-kind result is unregistered in the canonical
+    # mapper table → the whole dict becomes the sole structured attachment.
+    assert result["named_stores"]["r"]["structured"]["status"] == "denied"
     assert not (tmp_path / "out.txt").exists()
 
 
@@ -431,7 +436,7 @@ def test_run_tool_step_file_write_allowed_with_grant_flag(
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    assert result["named_stores"]["r"]["status"] == "ok"
+    assert result["named_stores"]["r"]["structured"]["status"] == "ok"
     assert (tmp_path / "out.txt").read_text(encoding="utf-8") == "hello"
 
 
@@ -588,8 +593,8 @@ def test_run_tool_step_dispatches_mcp_action_for_real(tmp_path, monkeypatch, cap
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    assert result["named_stores"]["r"]["status"] == "ok"
-    assert result["named_stores"]["r"]["content"] == "ping:hi reyn"
+    # #2425 PR-2: an MCP result's canonical "text" is the joined content.
+    assert result["named_stores"]["r"]["text"] == "ping:hi reyn"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline_call_primitive.py
+++ b/tests/test_pipeline_call_primitive.py
@@ -274,11 +274,11 @@ async def test_truncate_falsify_call_resumes_callee_substeps_exactly_once(tmp_pa
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
-    assert resumed.completed_step_results["1.call.0"] == {"wrote": "A"}
-    assert resumed.completed_step_results["1.call.1"] == {"wrote": "B"}
+    assert resumed.completed_step_results["1.call.0"] == {"text": "", "structured": {"wrote": "A"}}
+    assert resumed.completed_step_results["1.call.1"] == {"text": "", "structured": {"wrote": "B"}}
     # The callee's final output (sub-step 1's result) threads out as the call's N2.
-    assert resumed.named_stores["call_out"] == {"wrote": "B"}
-    assert resumed.pipe_data == {"wrote": "B"}
+    assert resumed.named_stores["call_out"] == {"text": "", "structured": {"wrote": "B"}}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "B"}}
     assert resumed.step_index == 2
 
 
@@ -309,4 +309,4 @@ async def test_call_resume_after_full_run_replays_with_zero_new_side_effects(tmp
     )
     # No new lines — a fully-completed run replays with zero side effects.
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
-    assert resumed.named_stores["call_out"] == {"wrote": "B"}
+    assert resumed.named_stores["call_out"] == {"text": "", "structured": {"wrote": "B"}}

--- a/tests/test_pipeline_dispatch_table_equivalence.py
+++ b/tests/test_pipeline_dispatch_table_equivalence.py
@@ -41,7 +41,7 @@ async def test_transform_tool_transform_threads_identically_through_dispatch_tab
         steps=[
             TransformStep(value="ctx.seed * 2", output="doubled"),
             ToolStep(name="echo", args={"v": ExprRef("pipe")}, output="echoed"),
-            TransformStep(value="ctx.echoed.echoed + 1", output="final"),
+            TransformStep(value="ctx.echoed.structured.echoed + 1", output="final"),
         ]
     )
     result = await PipelineExecutor().run(
@@ -49,13 +49,16 @@ async def test_transform_tool_transform_threads_identically_through_dispatch_tab
         tool_dispatch=_echo_dispatch, state_log=None, run_id="run-equiv",
     )
 
+    # #2425 PR-2: an unregistered-kind dict result's ctx shape wraps the whole
+    # dict as the sole structured attachment.
+    echoed_ctx = {"text": "", "structured": {"echoed": 42}}
     assert result.pipe_data == 43
     assert result.named_stores == {
-        "seed": 21, "doubled": 42, "echoed": {"echoed": 42}, "final": 43,
+        "seed": 21, "doubled": 42, "echoed": echoed_ctx, "final": 43,
     }
     # Flat linear keys — no dotted paths appear for a pipeline with no `call`.
     assert result.completed_step_results == {
-        "0": 42, "1": {"echoed": 42}, "2": 43,
+        "0": 42, "1": echoed_ctx, "2": 43,
     }
     assert result.step_index == 3
 

--- a/tests/test_pipeline_executor_r3_r4.py
+++ b/tests/test_pipeline_executor_r3_r4.py
@@ -44,7 +44,7 @@ async def test_linear_pipeline_threads_pipe_data_and_named_stores_via_real_evalu
         steps=[
             TransformStep(value="'hello ' + ctx.seed", output="greeting"),
             ToolStep(name="shout", args={"text": ExprRef("pipe")}, output="shouted"),
-            TransformStep(value="ctx.shouted + ' (done)'", output="final"),
+            TransformStep(value="ctx.shouted.text + ' (done)'", output="final"),
         ]
     )
     executor = PipelineExecutor()
@@ -56,16 +56,17 @@ async def test_linear_pipeline_threads_pipe_data_and_named_stores_via_real_evalu
         run_id="run-threading",
     )
 
+    # #2425 PR-2: a str tool result maps to the flat {"text": ...} ctx shape.
     assert result.pipe_data == "HELLO WORLD!!! (done)"
     assert result.named_stores == {
         "seed": "world",
         "greeting": "hello world",
-        "shouted": "HELLO WORLD!!!",
+        "shouted": {"text": "HELLO WORLD!!!"},
         "final": "HELLO WORLD!!! (done)",
     }
     assert result.completed_step_results == {
         "0": "hello world",
-        "1": "HELLO WORLD!!!",
+        "1": {"text": "HELLO WORLD!!!"},
         "2": "HELLO WORLD!!! (done)",
     }
 
@@ -85,7 +86,7 @@ pipeline: mcp-parse-demo
 description: tool result content string parsed into a structured value
 steps:
   - tool: {name: search, args: {query: "reyn"}, output: raw}
-  - transform: {value: "parse_json(ctx.raw.content)", output: parsed}
+  - transform: {value: "parse_json(ctx.raw.structured.content)", output: parsed}
   - transform: {value: "ctx.parsed.count + 1", output: total}
 """
     pipeline = parse_pipeline_dsl(dsl, SchemaRegistry())
@@ -93,6 +94,8 @@ steps:
     def tool_dispatch(name: str, args: dict):
         assert name == "search"
         payload = {"count": 5, "items": ["a", "b"]}
+        # a dict with no "kind" is an unregistered-kind result → the whole dict
+        # becomes the sole structured attachment (#2425 PR-2 ctx shape).
         return {"content": json.dumps(payload)}
 
     executor = PipelineExecutor()
@@ -134,7 +137,9 @@ async def test_verify_schema_passes_conforming_and_fails_non_conforming():
         tool_dispatch=_ok_dispatch, state_log=None, run_id="run-schema-ok",
         schema_registry=registry,
     )
-    assert ok_result.pipe_data == {"msg": "hi"}
+    # verify: schema validates the RAW dispatch result (unchanged); the step's ctx
+    # value is still reduced to the flat text/structured shape (#2425 PR-2).
+    assert ok_result.pipe_data == {"text": "", "structured": {"msg": "hi"}}
 
     bad_pipeline = Pipeline(
         steps=[ToolStep(name="greet", args={}, output="g", schema="greeting_schema")]
@@ -175,8 +180,8 @@ async def test_truncate_falsify_generation_survives_wal_truncation_below_its_seq
 
     step0 = TransformStep(value="ctx.seed + 1", output="t0")
     step1 = ToolStep(name="echo", args={"val": ExprRef("ctx.t0")}, output="t1")
-    step2 = ToolStep(name="echo", args={"val": ExprRef("pipe.value")}, output="t2")
-    step3 = ToolStep(name="echo", args={"val": ExprRef("pipe.value")}, output="t3")
+    step2 = ToolStep(name="echo", args={"val": ExprRef("pipe.structured.value")}, output="t2")
+    step3 = ToolStep(name="echo", args={"val": ExprRef("pipe.structured.value")}, output="t3")
 
     executor = PipelineExecutor()
     phase1 = Pipeline(steps=[step0, step1, step2])  # run through step K=2 (0-indexed)
@@ -222,9 +227,9 @@ async def test_truncate_falsify_generation_survives_wal_truncation_below_its_seq
     )
     assert resumed.step_index == 4
     assert resumed.named_stores["t0"] == 11
-    assert resumed.named_stores["t1"] == {"value": 11, "call": 1}
-    assert resumed.named_stores["t2"] == {"value": 11, "call": 2}
-    assert resumed.named_stores["t3"] == {"value": 11, "call": 3}
+    assert resumed.named_stores["t1"] == {"text": "", "structured": {"value": 11, "call": 1}}
+    assert resumed.named_stores["t2"] == {"text": "", "structured": {"value": 11, "call": 2}}
+    assert resumed.named_stores["t3"] == {"text": "", "structured": {"value": 11, "call": 3}}
     assert resumed.pipe_data == resumed.named_stores["t3"]
 
 
@@ -256,8 +261,8 @@ async def test_exactly_once_resume_does_not_replay_completed_tool_side_effect(tm
     )
 
     assert call_counts["count"] == 2, "step0 must not be re-run; only step1 is new"
-    assert resumed.named_stores["a"] == {"value": 1, "call": 1}
-    assert resumed.named_stores["b"] == {"value": 2, "call": 2}
+    assert resumed.named_stores["a"] == {"text": "", "structured": {"value": 1, "call": 1}}
+    assert resumed.named_stores["b"] == {"text": "", "structured": {"value": 2, "call": 2}}
     assert resumed.step_index == 2
 
 

--- a/tests/test_pipeline_fold_primitive.py
+++ b/tests/test_pipeline_fold_primitive.py
@@ -164,7 +164,11 @@ def _append_dispatch(state_log: StateLog, out_file, crash):
         with out_file.open("a", encoding="utf-8") as f:
             f.write(line + "\n")
         await state_log.append("inbox_put", note=line)
-        return str(args["acc"]) + line
+        # #2425 PR-2: a prior ToolStep iteration's ctx value is the flat
+        # {"text": ...} shape (this dispatch's own str return), not a bare str.
+        acc = args["acc"]
+        acc_str = acc["text"] if isinstance(acc, dict) else str(acc)
+        return acc_str + line
 
     return _dispatch
 
@@ -210,7 +214,8 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A"]
 
     snap_mid = latest_pipeline_state("run-fold-tf", state_log)
-    assert snap_mid["completed_step_results"]["0.fold.0"] == "A"
+    # #2425 PR-2: a ToolStep `do`'s ctx value is the flat {"text": ...} shape.
+    assert snap_mid["completed_step_results"]["0.fold.0"] == {"text": "A"}
     assert "0.fold.1" not in snap_mid["completed_step_results"]
     assert "0" not in snap_mid["completed_step_results"]
     assert snap_mid["step_index"] == 0  # the fold step itself is not done
@@ -234,14 +239,14 @@ async def test_truncate_falsify_fold_resumes_completed_iterations_exactly_once(t
 
     # Exactly-once: A appears ONCE (replayed, not re-executed); B once (resumed).
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
-    assert resumed.completed_step_results["0.fold.0"] == "A"
+    assert resumed.completed_step_results["0.fold.0"] == {"text": "A"}
     # iteration 1's `do` receives the REPLAYED acc ("A") + item "B" == "AB" —
     # proof the accumulator was correctly rebuilt from the replayed result
     # before the remaining iteration ran, not re-derived from scratch.
-    assert resumed.completed_step_results["0.fold.1"] == "AB"
-    assert resumed.named_stores["joined"] == "AB"
-    assert resumed.pipe_data == "AB"
-    assert resumed.completed_step_results["0"] == "AB"
+    assert resumed.completed_step_results["0.fold.1"] == {"text": "AB"}
+    assert resumed.named_stores["joined"] == {"text": "AB"}
+    assert resumed.pipe_data == {"text": "AB"}
+    assert resumed.completed_step_results["0"] == {"text": "AB"}
 
 
 @pytest.mark.asyncio
@@ -277,7 +282,7 @@ async def test_fold_resume_after_full_run_replays_with_zero_new_side_effects(tmp
         tool_dispatch=dispatch, state_log=state_log,
     )
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
-    assert resumed.named_stores["joined"] == "AB"
+    assert resumed.named_stores["joined"] == {"text": "AB"}
 
 
 # ── context injection: {item}/{acc} available to `do` ───────────────────────

--- a/tests/test_pipeline_for_each_primitive.py
+++ b/tests/test_pipeline_for_each_primitive.py
@@ -179,7 +179,8 @@ async def test_max_parallel_bounds_live_concurrency():
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-fe-parallel",
     )
-    assert result.pipe_data == [1, 2, 3, 4, 5, 6]  # ordered, all processed
+    # #2425 PR-2: a non-str/dict tool result (int) is structured, not stringified.
+    assert result.pipe_data == [{"text": "", "structured": n} for n in [1, 2, 3, 4, 5, 6]]
     assert peak <= 2, f"live concurrency {peak} exceeded max_parallel=2 (S5 guard a)"
     assert peak == 2, "with 6 items and a held slot, concurrency should reach the cap"
 
@@ -211,7 +212,8 @@ async def test_on_error_continue_drops_failed_item_and_collect_sees_survivors():
         tool_dispatch=_dispatch, state_log=None, run_id="run-fe-continue",
     )
     # collect saw only the survivors, in item order.
-    assert result.pipe_data == ["A", "C"]
+    # #2425 PR-2: a str tool result maps to the flat {"text": ...} ctx shape.
+    assert result.pipe_data == [{"text": "A"}, {"text": "C"}]
     # the dropped item's key holds the kind-marker (NOT absent, NOT bare None).
     dropped = result.completed_step_results["0.for_each.1"]
     assert dropped["__fan_out_dropped__"] is True
@@ -267,7 +269,8 @@ async def test_on_error_retry_reruns_flaky_item_until_success():
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-fe-retry-ok",
     )
-    assert sorted(result.pipe_data) == ["flaky", "ok"]
+    # #2425 PR-2: a str tool result maps to the flat {"text": ...} ctx shape.
+    assert sorted(result.pipe_data, key=lambda d: d["text"]) == [{"text": "flaky"}, {"text": "ok"}]
     assert attempts["flaky"] == 3  # 1 initial + 2 retries
 
 
@@ -399,8 +402,8 @@ async def test_truncate_falsify_mid_fan_out_replays_items_exactly_once(tmp_path:
     assert lines.count("A") == 1 and lines.count("B") == 1 and lines.count("D") == 1
     assert "C" not in lines
     # collect ran once; its result threads out as the for_each N2 return.
-    assert resumed.pipe_data == {"wrote": "COLLECT"}
-    assert resumed.completed_step_results["0.for_each.collect"] == {"wrote": "COLLECT"}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "COLLECT"}}
+    assert resumed.completed_step_results["0.for_each.collect"] == {"text": "", "structured": {"wrote": "COLLECT"}}
 
 
 @pytest.mark.asyncio
@@ -427,7 +430,7 @@ async def test_resume_after_full_fan_out_replays_with_zero_new_side_effects(tmp_
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
-    assert resumed.pipe_data == {"wrote": "COLLECT"}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "COLLECT"}}
 
 
 # ── the DOCUMENTED compositional-do atomic-re-run gap (commit unit = the ITEM) ─

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -340,8 +340,10 @@ steps:
     # arg resolved against the live context (the parsed ExprRef, not the
     # literal text "ctx.brief") — this is the anti-drift assertion.
     assert calls == [("search", {"query": "reyn-dsl", "limit": 3})]
+    # #2425 PR-2: an unregistered-kind dict result's ctx shape wraps the whole
+    # dict as the sole structured attachment.
     assert result.named_stores["hits"] == {
-        "query": "reyn-dsl", "limit": 3, "results": ["a", "b"],
+        "text": "", "structured": {"query": "reyn-dsl", "limit": 3, "results": ["a", "b"]},
     }
     # The agent step ran (scripted reply threaded as pipe data / named output).
     assert result.named_stores["verdict"] == "pipelines are cool"

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -214,8 +214,9 @@ async def test_attached_run_streams_live_events_and_returns_inline(
     assert outcome["status"] == "ok"
     assert outcome["run_id"]
     # Inline result: last step's return value + the named stores, in-band.
-    assert outcome["output"] == {"tag": "s1"}
-    assert outcome["named_stores"]["o0"] == {"tag": "s0"}
+    # #2425 PR-2: a ToolStep's ctx value is the flat text/structured shape.
+    assert outcome["output"] == {"text": "", "structured": {"tag": "s1"}}
+    assert outcome["named_stores"]["o0"] == {"text": "", "structured": {"tag": "s0"}}
     # Both steps really executed (exactly once each).
     assert out_file.read_text(encoding="utf-8").splitlines() == ["s0", "s1"]
 

--- a/tests/test_pipeline_match_primitive.py
+++ b/tests/test_pipeline_match_primitive.py
@@ -311,8 +311,8 @@ async def test_truncate_falsify_match_resumes_case_substeps_exactly_once(tmp_pat
     )
 
     assert out_file.read_text(encoding="utf-8").splitlines() == ["A", "B"]
-    assert resumed.completed_step_results["1.match.0"] == {"wrote": "A"}
-    assert resumed.completed_step_results["1.match.1"] == {"wrote": "B"}
-    assert resumed.named_stores["match_out"] == {"wrote": "B"}
-    assert resumed.pipe_data == {"wrote": "B"}
+    assert resumed.completed_step_results["1.match.0"] == {"text": "", "structured": {"wrote": "A"}}
+    assert resumed.completed_step_results["1.match.1"] == {"text": "", "structured": {"wrote": "B"}}
+    assert resumed.named_stores["match_out"] == {"text": "", "structured": {"wrote": "B"}}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "B"}}
     assert resumed.step_index == 2

--- a/tests/test_pipeline_parallel_primitive.py
+++ b/tests/test_pipeline_parallel_primitive.py
@@ -260,7 +260,8 @@ async def test_on_error_continue_drops_failed_branch_and_collect_sees_survivors(
         tool_dispatch=_dispatch, state_log=None, run_id="run-par-continue",
     )
     # collect saw only the survivors — the failed branch is absent, not None.
-    assert result.pipe_data == {"good": "OK"}
+    # #2425 PR-2: a str ToolStep result maps to the flat {"text": ...} ctx shape.
+    assert result.pipe_data == {"good": {"text": "OK"}}
     assert "bad" not in result.pipe_data
     dropped = result.completed_step_results["0.parallel.bad"]
     assert dropped["__fan_out_dropped__"] is True
@@ -321,7 +322,7 @@ async def test_on_error_retry_reruns_flaky_branch_until_success():
         pipeline, None,
         tool_dispatch=_dispatch, state_log=None, run_id="run-par-retry-ok",
     )
-    assert result.pipe_data == {"ok": "ok", "flaky": "flaky"}
+    assert result.pipe_data == {"ok": {"text": "ok"}, "flaky": {"text": "flaky"}}
     assert attempts["flaky"] == 3  # 1 initial + 2 retries
 
 
@@ -458,8 +459,8 @@ async def test_truncate_falsify_mid_parallel_replays_branches_exactly_once(tmp_p
     assert lines.count("A") == 1 and lines.count("B") == 1 and lines.count("D") == 1
     assert "C" not in lines
     # collect ran once; its result threads out as the parallel N2 return.
-    assert resumed.pipe_data == {"wrote": "COLLECT"}
-    assert resumed.completed_step_results["0.parallel.collect"] == {"wrote": "COLLECT"}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "COLLECT"}}
+    assert resumed.completed_step_results["0.parallel.collect"] == {"text": "", "structured": {"wrote": "COLLECT"}}
 
 
 @pytest.mark.asyncio
@@ -486,7 +487,7 @@ async def test_resume_after_full_parallel_replays_with_zero_new_side_effects(tmp
     )
     after = sorted(out_file.read_text(encoding="utf-8").splitlines())
     assert after == before, "a fully-completed fan-out must replay with zero side effects"
-    assert resumed.pipe_data == {"wrote": "COLLECT"}
+    assert resumed.pipe_data == {"text": "", "structured": {"wrote": "COLLECT"}}
 
 
 # ── S5 guard (b): fan_out_depth cap FAILS the step (does not spawn) ──────────

--- a/tests/test_pipeline_r5_agent_step_executor.py
+++ b/tests/test_pipeline_r5_agent_step_executor.py
@@ -361,5 +361,8 @@ async def test_no_agent_step_pipeline_unaffected_by_new_params(tmp_path: Path) -
         tool_dispatch=_shout, state_log=None, run_id="run-no-agent",
     )
 
-    assert result.pipe_data == "HI WORLD"
-    assert result.named_stores == {"name": "world", "greeting": "hi world", "shouted": "HI WORLD"}
+    # #2425 PR-2: a str tool result maps to the flat {"text": ...} ctx shape.
+    assert result.pipe_data == {"text": "HI WORLD"}
+    assert result.named_stores == {
+        "name": "world", "greeting": "hi world", "shouted": {"text": "HI WORLD"},
+    }


### PR DESCRIPTION
**[per-PR-coder]** — part of #2425 (tool-result-schema-redesign arc). See `docs/proposals/tool-result-schema-redesign.md` §3 for the full contract.

## Summary
- `src/reyn/core/pipeline/executor.py::_run_tool_step` now unwraps any dispatch envelope (`{"status": ..., "data": {...}}`, e.g. `run_pipeline`'s own return shape) and runs the result through `to_canonical` (PR-1, #2648), reducing it to `{"text": ..., "structured": ...}` (`structured` key absent when there's no structured data). This is **shape-only** — no size gate, no offload, ever (owner ruling: pipeline ctx/pipe data retains full values for downstream programmatic step processing).
- New `src/reyn/core/offload/canonical.py::unwrap_dispatch_envelope` + `canonical_to_ctx_fields` helpers (the latter mirrors `seam.py`'s attachments→`structured` reduction, minus size gating).
- **Breaking change (clean break, no compat shim)**: every existing test/pipeline reading a raw tool-step result (e.g. `ctx.x.data.content`, or a bare tool return value) is updated to the new `ctx.<name>.text`/`.structured` shape in this same PR — 12 test files updated, all now green.
- Updated `docs/reference/runtime/pipeline-dsl.md` (+ `.ja`) with a new "`tool` step results" section, and `docs/guide/for-users/write-a-pipeline.md`'s worked example/CLI output.
- New test file `tests/test_2425_pipeline_tool_ctx_canonical_shape.py`: Tier 1 unit tests for `canonical_to_ctx_fields`'s reduction (absent/single/multi structured, media ignored), Tier 2 uniform-shape-across-op-kinds test (mcp + sandboxed_exec), Tier 2 dispatch-envelope-unwrap test, and the owner-mandated Tier 2 falsify test proving an oversized structured payload (far past `seam.STRUCTURED_INLINE_MAX_CHARS`) survives fully inline in pipeline ctx — never offloaded.

## Test plan
- [x] `pytest` (full suite): 7547 passed, 17 skipped
- [x] `ruff check src tests`: clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`: 0 Tier-4 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>`: OK
- [x] All 12 pre-existing pipeline test files updated for the new ctx shape and passing
- [x] New Tier 1/2 tests added per testing.ja.md (uniform shape, envelope unwrap, no-offload falsify)

Tier self-check: all new/modified tests are Tier 1/2, first docstring line declares Tier, no `MagicMock`/`patch`, no private-state assertions, no format/size pins.

Next: pinging docs-maintainer re: pipeline-dsl.md coordination (they offered to take this update — landing it here since it's directly load-bearing for this PR's own contract; happy to have them review/adjust).