### PR TITLE
docs: present-layer proposal (present op + declarative tool-data presentation)

### DIFF
--- a/docs/deep-dives/proposals/0054-present-layer.md
+++ b/docs/deep-dives/proposals/0054-present-layer.md
@@ -319,6 +319,11 @@ differentiator is making blindness *auditable*, not forbidding it.)
 - **PR-C** — `presentations.yaml` registration + hot-reload seam + the 4-stage fallback
   chain (built fresh — FP-0051's registry is deleted; §§ 3, 6).
 - **PR-D** — replay/rewind placeholder rendering + docs (concepts page + reference).
+  **The PR-D description must restate the § 8 recovery-gate answer** (pure re-render /
+  placeholder, no authoritative state reconstructed from `presented` events ⇒
+  truncate-falsify gate N/A) so a future reviewer does not re-flag it — and must
+  re-trigger the gate in-arc if the implementation ever reconstructs state from
+  `presented` events.
 
 ## Test plan (per testing.ja.md tiers)
 

--- a/docs/deep-dives/proposals/0054-present-layer.md
+++ b/docs/deep-dives/proposals/0054-present-layer.md
@@ -10,7 +10,7 @@ always round-trips through LLM tokens. Splitting the cost into axes:
 
 | Axis | Cost | Status |
 |---|---|---|
-| **A. Ingestion (input)** | tool result entering LLM context | **Solved** by the offload mechanism + tool-result-schema-redesign arc (`docs/proposals/tool-result-schema-redesign.md`): data lands in a ref file, the LLM sees schema + preview, reads back on demand via `file__read` |
+| **A. Ingestion (input)** | tool result entering LLM context | **Solved** by the offload mechanism + tool-result-schema-redesign arc (`docs/deep-dives/proposals/0053-tool-result-schema-redesign.md`, IMPLEMENTED): data lands in a ref file, the LLM sees schema + preview, reads back on demand via `file__read` |
 | **B. Reproduction (output)** | the LLM re-types the data as output tokens to show the user | **Unsolved — target of this proposal** |
 | **C. Fidelity loss** | to fit output, the LLM summarizes/truncates; the user loses data | **Unsolved — same mechanism solves it** |
 
@@ -20,11 +20,13 @@ the bulk bytes never pass through LLM output.
 
 Two existing reyn mechanisms are each half of the answer, currently unconnected:
 
-1. **Offload** (redesign arc) — offloaded refs are the data handles: the
-   `structured_ref` frontmatter field for the structured stream, and the text-side ref
-   embedded inline in the truncation note (`file__read("<ref>")` — no dedicated
-   frontmatter field). Saves input tokens only; presentation still goes through output
-   tokens.
+1. **Offload** (redesign arc, landed) — the offload refs are the data handles.
+   Structured stream: an inline `structured` frontmatter field, or when offloaded
+   `structured: offloaded` + `structured_ref` (a `file__read`-able path) +
+   `structured_preview`. Text stream: the body text, or when offloaded a plain-text note
+   `...[truncated: <N> chars total — full body: file__read(path="<ref>")]...` (no
+   dedicated frontmatter field for the text ref). Saves input tokens only; presentation
+   still goes through output tokens.
 2. **Tool-result viewer registry + LLM template** (FP-0051,
    `docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md`) —
    content-type → viewer → Rich renderable, with a safety-fenced LLM-generated template
@@ -261,13 +263,15 @@ differentiator is making blindness *auditable*, not forbidding it.)
 ## Relationship to the tool-result-schema-redesign arc
 
 - **Consumer, not competitor**: `present` consumes the arc's offload refs — the
-  `structured_ref` frontmatter field, plus the text-side ref carried inline in the
-  truncation note — i.e. the text/structured stream split from the canonical mappers.
-- **Zero blocking asks — and the dependency is already met**: the arc is owner-approved,
-  and as of 2026-07-08 design doc (#2646), PR-0 (#2647), and PR-1 (#2648, canonical
-  mappers + legacy-path deletion) are **merged**. The interfaces this proposal consumes
-  are live; the arc's remaining PR-2 (pipeline ctx) / PR-3 (offload config) do not gate
-  this proposal.
+  `structured` / `structured_ref` / `structured_preview` frontmatter fields, plus the
+  text-side ref carried inline in the truncation note — i.e. the text/structured stream
+  split from the canonical mappers. Pipeline `ctx.<name>.text` / `ctx.<name>.structured`
+  (PR-2) expose the same split (no size gate, full value).
+- **Zero blocking asks — dependency fully met (arc CLOSED 2026-07-08)**: every arc PR is
+  merged — PR-0 #2647, PR-1 #2648 (canonical mappers + legacy deletion), PR-2 #2652
+  (pipeline ctx), PR-3 #2651 (`offload:` opt-out), PR-4 #2654 (design doc →
+  `docs/deep-dives/proposals/0053-tool-result-schema-redesign.md`, IMPLEMENTED stamp).
+  The offload output shape is landed and fixed; nothing gates this proposal.
 - **Follow-up (additive, post-arc)**: enrich offload frontmatter with a shape summary
   (key names / types / array lengths) instead of only a head-N-chars preview — improves
   blind template authoring. To be filed as an issue after the arc lands.
@@ -323,4 +327,4 @@ differentiator is making blindness *auditable*, not forbidding it.)
 - The New Stack: Agent UI Standards Multiply — https://thenewstack.io/agent-ui-standards-multiply-mcp-apps-and-googles-a2ui/
 - Vercel AI SDK 3.0 Generative UI — https://vercel.com/blog/ai-sdk-3-generative-ui
 - FP-0051 viewer registry (superseded — TUI + registry deleted 2026-07, design lineage only) — `docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md`
-- Tool-result schema redesign — `docs/proposals/tool-result-schema-redesign.md`
+- Tool-result schema redesign (IMPLEMENTED) — `docs/deep-dives/proposals/0053-tool-result-schema-redesign.md`

--- a/docs/deep-dives/proposals/0054-present-layer.md
+++ b/docs/deep-dives/proposals/0054-present-layer.md
@@ -124,16 +124,31 @@ present:
   resolved identically to `file.read`** — `present` can never read more than the agent's
   file ops can. Not limited to tool-result refs: artifacts, agent-written files, any
   zone-readable path qualifies (works even with `offload.enabled: false`).
+- **`data_ref` resolution seam (junction with the tool-result arc).** A `data_ref` may
+  be a plain workspace path *or* an offload ref (e.g. a `structured_ref` produced by the
+  arc). `present` resolves it by loading the **full value** through the same file-read /
+  offload-store access the arc established (`file__read(path=<ref>)` semantics), under
+  the `file.read` authority check above — i.e. present re-hydrates offloaded structured
+  data from `structured_ref` rather than from the LLM-visible preview. The resolver is a
+  single explicit seam (`resolve_present_source(data_ref) -> bytes|obj`), so the two arcs
+  meet at exactly one point and offloaded vs inline data is transparent to the renderer.
 - **Fire-and-continue**: unlike `ask_user`, does not pause the run.
-- **Op result (ack)** — the LLM's only feedback, deliberately compact:
+- **Op result (ack)** — the LLM's only feedback, deliberately compact **and high-signal**
+  (same principle as the tool-result arc): each drop carries a *reason category* so the
+  next-turn LLM can act, not just a bare path list.
   ```yaml
   ok: true
   bindings_resolved: 3
-  bindings_dropped: ["/results/0/author"]
   rows: 500
+  bindings_dropped:
+    - {path: "/results/0/author", reason: path_not_found}   # template/data shape mismatch
+    # reason ∈ {path_not_found, type_mismatch, guard_stripped}
   ```
-  This closes the self-correction loop for blind presentation: the LLM detects a
-  mismatched template for tens of tokens and can re-present with corrected paths.
+  This closes the self-correction loop for blind presentation: `path_not_found` across
+  many rows reads as "template doesn't match this data shape → re-check"; `type_mismatch`
+  as "right path, wrong component"; `guard_stripped` as "content neutralized by the
+  presentation-guard, not a template bug". The LLM corrects for tens of tokens without
+  ingesting the data.
 - New op kind ⇒ **`OP_KIND_MODEL_MAP` + `docs/reference/runtime/control-ir.md` section
   in the same PR** (CLAUDE.md hard rule #1983).
 
@@ -225,7 +240,7 @@ Mirror of the input-side content-guard, at the output boundary:
   latent bug already in `repl/renderer.py`'s two existing render sites, and more visible
   for `present` tables. The renderer must read `get_app().output.get_size().columns` and
   pass it explicitly to `Console(width=...)` per render. (Fixing the two existing sites
-  is a worthwhile fast-follow, tracked separately — not in this proposal's scope.)
+  is a worthwhile fast-follow, tracked as issue #2655 — not in this proposal's scope.)
 - **Remote surfaces (web/A2A)**: remote clients cannot read local refs. Data delivery is
   the surface adapter's responsibility: materialize via the gateway (size-capped inline
   embed or a served endpoint). v1 ships the terminal (inline-CUI) surface only; the hub
@@ -241,7 +256,7 @@ presented:
   surface: [inline-cui]
   ingested: none | partial | full   # OS-COMPUTED, not LLM-self-reported
   bindings_resolved: 3
-  bindings_dropped: ["/results/0/author"]
+  bindings_dropped: [{path: "/results/0/author", reason: path_not_found}]
 ```
 
 **Blind-routing is not a permission mode — it is an audit annotation.** Whether the LLM
@@ -256,8 +271,14 @@ differentiator is making blindness *auditable*, not forbidding it.)
   existing lifecycle class.
 - Replay/rewind re-renders best-effort from the `presented` event; a GC'd ref renders as
   an expiry placeholder pointing at the audit event. Presentation is a cache; the event
-  is the truth. (No WAL-derived recovery state is introduced ⇒ the recovery-feature PR
-  gate does not apply.)
+  is the truth.
+- **Recovery-feature PR gate — explicit answer (per lead-coder):** PR-D introduces **no
+  reconstructed state**. It re-renders a projection from a durable event + an
+  already-durable ref, or shows a placeholder; nothing derives recoverable state from
+  WAL events, and `present` never writes recovery-core state. ⇒ the CLAUDE.md
+  recovery-feature truncate-falsify gate **does not apply**. If a future revision ever
+  reconstructs state from `presented` events, that PR must carry the truncate-falsify
+  test in-arc.
 - Conversation history never contains the presented bytes ⇒ nothing new for compaction.
 
 ## Relationship to the tool-result-schema-redesign arc

--- a/docs/proposals/present-layer.md
+++ b/docs/proposals/present-layer.md
@@ -194,8 +194,11 @@ Mirror of the input-side content-guard, at the output boundary:
   terminal scrollback *uncapped*, because normal output is already bounded by LLM
   *output tokens*. `present` is unbounded by construction (that is the whole point), so
   it must carry its **own** default cap: render head-N rows/lines + a
-  `…N more — full data: <ref>` tail. There is no pager in the inline-CUI; the **ref is
-  the full-fidelity escape hatch** (re-present with a filter/higher cap, or `file__read`).
+  `…N more — full data: <ref>` tail. **Cap before render, not after** (tui-coder review) —
+  for `code`/`diff`, Rich syntax highlighting is costly, so truncate the source to the
+  row/line budget first and highlight only the survivors. There is no pager in the
+  inline-CUI; the **ref is the full-fidelity escape hatch** (re-present with a
+  filter/higher cap, or `file__read`).
   This bound is orthogonal to the inline-CUI's live-region caps
   (`_ABOVE_REGION_MAX_HEIGHT` / `_MENU_REGION_MAX_HEIGHT` = 12), which govern persistent
   UI regions, not one-shot conversation output.
@@ -215,6 +218,12 @@ Mirror of the input-side content-guard, at the output boundary:
   `Console` → `StringIO` → `prompt_toolkit.run_in_terminal()` print. This axis is
   separate from the live-region line caps; the present-specific default output cap (§ 5)
   applies instead.
+- **Explicit render width (tui-coder review).** Rich's `Console` cannot auto-detect
+  terminal width when writing to a `StringIO`; it silently falls back to 80 columns — a
+  latent bug already in `repl/renderer.py`'s two existing render sites, and more visible
+  for `present` tables. The renderer must read `get_app().output.get_size().columns` and
+  pass it explicitly to `Console(width=...)` per render. (Fixing the two existing sites
+  is a worthwhile fast-follow, tracked separately — not in this proposal's scope.)
 - **Remote surfaces (web/A2A)**: remote clients cannot read local refs. Data delivery is
   the surface adapter's responsibility: materialize via the gateway (size-capped inline
   embed or a served endpoint). v1 ships the terminal (inline-CUI) surface only; the hub
@@ -282,8 +291,8 @@ differentiator is making blindness *auditable*, not forbidding it.)
   + control-ir.md section (hard rule), `presented` event type.
 - **PR-B** — inline-CUI renderer: conversation inline block + `PresentationRenderer`
   protocol (FP-0051 design lineage), height caps + expand affordance.
-- **PR-C** — `presentations.yaml` registration + hot-reload seam + 4-stage fallback
-  integration with FP-0051 registry.
+- **PR-C** — `presentations.yaml` registration + hot-reload seam + the 4-stage fallback
+  chain (built fresh — FP-0051's registry is deleted; §§ 3, 6).
 - **PR-D** — replay/rewind placeholder rendering + docs (concepts page + reference).
 
 ## Test plan (per testing.ja.md tiers)

--- a/docs/proposals/present-layer.md
+++ b/docs/proposals/present-layer.md
@@ -189,23 +189,32 @@ Mirror of the input-side content-guard, at the output boundary:
   especially) for never-ingested data.
 - **Per-binding size caps** — prevents `/` (root) bound into a `text` component from
   dumping an entire file.
-- **Per-surface inline height caps** (terminal: e.g. ~20 rows inline + expand/pager
-  affordance, exact mechanics per tui-coder input) — a 10k-row present must not destroy
-  terminal scrollback. Fidelity is guaranteed by the ref (full data always reachable),
-  not by unbounded inline paint.
+- **Default output cap (present-specific — not a scrollback pager).** The inline-CUI
+  convention (confirmed with tui-coder) is that conversation output flows freely into
+  terminal scrollback *uncapped*, because normal output is already bounded by LLM
+  *output tokens*. `present` is unbounded by construction (that is the whole point), so
+  it must carry its **own** default cap: render head-N rows/lines + a
+  `…N more — full data: <ref>` tail. There is no pager in the inline-CUI; the **ref is
+  the full-fidelity escape hatch** (re-present with a filter/higher cap, or `file__read`).
+  This bound is orthogonal to the inline-CUI's live-region caps
+  (`_ABOVE_REGION_MAX_HEIGHT` / `_MENU_REGION_MAX_HEIGHT` = 12), which govern persistent
+  UI regions, not one-shot conversation output.
 
 ### 6. Renderers and surfaces
 
 - `PresentationRenderer` protocol — **built fresh** (the FP-0051 registry was deleted,
   not relocated; its design is the lineage, not a base to extend). Terminal (inline-CUI)
-  = Rich/ANSI (substrate to confirm with tui-coder); web = native components; A2A =
-  structured message part.
-- **Terminal note**: the current terminal UI is the inline-CUI
-  (`src/reyn/interfaces/inline/`) — no side panel, and its only tool-result rendering is
-  `summarize_tool_result` (a one-liner). `present` renders as an **inline block in the
-  conversation flow**, introducing rich rendering that does not exist today. Rendering
-  substrate and constraints (height caps, expand/pager affordances, scrollback behavior)
-  are being confirmed with tui-coder.
+  = **Rich** (confirmed with tui-coder); web = native components; A2A = structured
+  message part.
+- **Terminal note (confirmed with tui-coder 2026-07-08).** The terminal UI is the
+  inline-CUI (`src/reyn/interfaces/inline/`, prompt_toolkit + Rich) — the Textual TUI and
+  right panel were deleted in `eff08169`; there is no side panel (the model is elastic
+  Regions above / below the input bar). Its only tool-result rendering today is
+  `summarize_tool_result` (a one-liner). `present` renders as a **one-shot inline block
+  in the conversation scrollback**, riding the existing `repl/renderer.py` pattern: Rich
+  `Console` → `StringIO` → `prompt_toolkit.run_in_terminal()` print. This axis is
+  separate from the live-region line caps; the present-specific default output cap (§ 5)
+  applies instead.
 - **Remote surfaces (web/A2A)**: remote clients cannot read local refs. Data delivery is
   the surface adapter's responsibility: materialize via the gateway (size-capped inline
   embed or a served endpoint). v1 ships the terminal (inline-CUI) surface only; the hub

--- a/docs/proposals/present-layer.md
+++ b/docs/proposals/present-layer.md
@@ -1,0 +1,308 @@
+# Present layer — user-facing presentation of bulk data without LLM token round-trip
+
+**Author:** architect · **Status:** DRAFT (design proposal — awaiting owner review; no
+implementation dispatched) · **Date:** 2026-07-08
+
+## Problem
+
+When an agent obtains external data via a tool and shows it to the user, the data today
+always round-trips through LLM tokens. Splitting the cost into axes:
+
+| Axis | Cost | Status |
+|---|---|---|
+| **A. Ingestion (input)** | tool result entering LLM context | **Solved** by the offload mechanism + tool-result-schema-redesign arc (`docs/proposals/tool-result-schema-redesign.md`): data lands in a ref file, the LLM sees schema + preview, reads back on demand via `file__read` |
+| **B. Reproduction (output)** | the LLM re-types the data as output tokens to show the user | **Unsolved — target of this proposal** |
+| **C. Fidelity loss** | to fit output, the LLM summarizes/truncates; the user loses data | **Unsolved — same mechanism solves it** |
+
+The offloaded ref file is *already* "data file + handle". What is missing is a primitive
+that routes that handle plus a display template to the user-facing surface directly, so
+the bulk bytes never pass through LLM output.
+
+Two existing reyn mechanisms are each half of the answer, currently unconnected:
+
+1. **Offload** (redesign arc) — offloaded refs are the data handles: the
+   `structured_ref` frontmatter field for the structured stream, and the text-side ref
+   embedded inline in the truncation note (`file__read("<ref>")` — no dedicated
+   frontmatter field). Saves input tokens only; presentation still goes through output
+   tokens.
+2. **Tool-result viewer registry + LLM template** (FP-0051,
+   `docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md`) —
+   content-type → viewer → Rich renderable, with a safety-fenced LLM-generated template
+   fallback. **Status (confirmed 2026-07-08, docs-maintainer exhaustive grep):**
+   FP-0051 is **superseded** — the Textual TUI (right panel included) and the entire
+   viewer-registry module (`register_viewer` / `render_tool_result` / content-type
+   dispatch) were **deleted with no relocation**. The current terminal UI is the
+   **inline-CUI** (`src/reyn/interfaces/inline/`), whose only tool-result rendering is
+   `summarize_tool_result` — a **single-line summary with no content-type dispatch and
+   no rich rendering**. FP-0051's *design* (predicate registry, template fence, escape
+   idioms, fallback chain) remains the lineage this proposal draws on, but there is **no
+   live rendering surface to generalize — it is rebuilt fresh.**
+
+**This sharpens the problem.** Today bulk tool data reaches the user via exactly two
+paths: a `summarize_tool_result` one-liner (maximal fidelity loss) or full LLM output
+reproduction (maximal token cost). Axis B and C are not merely suboptimal — the rich
+middle ground does not currently exist at all.
+
+This proposal introduces that middle ground: a `present` op (Control IR) + a
+surface-agnostic presentation model, building rich, cross-surface presentation fresh on
+the inline-CUI, along the FP-0051 design lineage.
+
+## Standards landscape (2026) and the architectural choice
+
+The agent-UI presentation problem has crystallized into a protocol layer industry-wide.
+Two fundamental approaches:
+
+| | **MCP Apps** (Anthropic + OpenAI + MCP-UI, 2026-01) | **A2UI v1.0** (Google, Candidate) |
+|---|---|---|
+| Mechanism | tool declares `ui://` resource → host renders bundled HTML/JS in sandboxed iframe; tool-result data flows to the iframe directly, bypassing LLM tokens | agent emits a **declarative component blueprint** (no code); data bound by **JSON Pointer (RFC 6901)** paths; `updateComponents` (structure) and `updateDataModel` (data) are separate messages |
+| Security | executable-but-sandboxed (iframe + JSON-RPC audit) | **non-executable by construction** — catalog components + path bindings only |
+| Terminal-renderable | ❌ impossible (no iframe in a terminal) | ✅ abstract components map to any surface |
+
+Related: AG-UI (CopilotKit) is the transport pipe (typed SSE events), complementary to
+either. Vercel Generative UI routes `toolName → pre-built component`; the model never
+generates UI code.
+
+**Decision (owner-approved): approach = declarative blueprint, architecture = hub-and-spoke
+"option C".** The internal model is reyn-native but **structurally isomorphic to A2UI**
+(declarative component tree · path-based data binding · vetted non-executable catalog).
+Rationale:
+
+1. The terminal (inline-CUI) is reyn's first-class surface; the iframe-webapp approach
+   cannot reach it.
+2. "Non-executable by construction" is the same philosophy as reyn's structural
+   write-gate: safety from the primitive's *shape*, not from policy layered on top.
+   FP-0051's template fence (LLM picks labels + key names only, allowlist + double
+   escape) is already this shape.
+3. Isomorphism keeps future wire adapters thin — external A2UI / MCP Apps emit
+   (`reyn mcp serve` / A2A producer side) and ingest (reyn-as-MCP-host consumer side)
+   become boundary adapters — while keeping internal contracts sovereign and insulated
+   from a still-Candidate external spec.
+
+```
+   internal surfaces            hub                       boundary adapters (future)
+  inline-CUI / web / A2A ◀── present op + declarative ──▶  A2UI / MCP-Apps emit (producer)
+  (know nothing of A2UI)      model + renderers        ──▶  A2UI / MCP-UI ingest (consumer)
+```
+
+Wire-level protocol conformance is explicitly deferred until the standards stabilize;
+only the internal *shape* is aligned now.
+
+## Design principles (invariants)
+
+1. **LLM sees shape, not content; the user sees everything.** The LLM works from the
+   offload schema + preview and binds paths; the renderer joins the template against the
+   full data the LLM never ingested. This asymmetry is the designed contract, not a
+   defect.
+2. **Display is free; computation costs.** Presenting N rows costs ~0 LLM tokens. The
+   moment the agent must *transform* the data (sort, filter, answer questions about it),
+   it pays to read the ref. Documented so the asymmetry is never mistaken for a bug.
+3. **Declarative, never executable.** Templates are catalog components + path bindings.
+   No markup, no HTML, no code ever crosses from LLM to renderer.
+4. **Degrade, don't fail; degradation is audited.** Binding misses soft-skip per
+   binding; drops are recorded in the audit event; full miss falls back to the generic
+   viewer. A broken template can never lose the user's access to the data (the ref
+   remains readable).
+5. **Audit-first.** Every presentation emits a P6 event carrying refs and stats — never
+   content bytes (data is already durable in the ref file; events stay light).
+
+## Design
+
+### 1. `present` op (Control IR)
+
+```yaml
+present:
+  data_ref: <path>            # XOR data_inline; any zone-readable file
+  data_inline: <small dict>   # optional convenience for small already-in-context data
+  template: <registered name> # XOR blueprint
+  blueprint: <inline declarative component tree with path bindings>
+```
+
+- **Tier 0** (`ask_user`'s sibling): presenting to the user is not an exfiltration
+  channel — the user is the trust root. The only gate: **`data_ref` read authority is
+  resolved identically to `file.read`** — `present` can never read more than the agent's
+  file ops can. Not limited to tool-result refs: artifacts, agent-written files, any
+  zone-readable path qualifies (works even with `offload.enabled: false`).
+- **Fire-and-continue**: unlike `ask_user`, does not pause the run.
+- **Op result (ack)** — the LLM's only feedback, deliberately compact:
+  ```yaml
+  ok: true
+  bindings_resolved: 3
+  bindings_dropped: ["/results/0/author"]
+  rows: 500
+  ```
+  This closes the self-correction loop for blind presentation: the LLM detects a
+  mismatched template for tens of tokens and can re-present with corrected paths.
+- New op kind ⇒ **`OP_KIND_MODEL_MAP` + `docs/reference/runtime/control-ir.md` section
+  in the same PR** (CLAUDE.md hard rule #1983).
+
+### 2. Declarative UI model (v1 catalog — display-only)
+
+Component catalog, all read-only:
+
+| Component | Binding slots |
+|---|---|
+| `text` / `markdown` | `text` (bind or literal) |
+| `code` | `text`, `language?` |
+| `diff` | `text` |
+| `keyvalue` (card) | `rows: [{label, value: bind}]` |
+| `table` | `rows: <bind → array>`, `columns: [{header, path (row-relative)}]` |
+| `list` | `items: <bind → array>`, optional per-item template |
+| `image` | routes to the existing multimodal delivery path |
+
+- Bindings are **JSON Pointer (RFC 6901)**; table/list column paths resolve relative to
+  the iterated row. Structured refs → pointer bindings; plain-text refs → whole-body
+  binding into text-family components (`text`/`code`/`diff`/`markdown`) only.
+- **v1 is display-only: no interactive components** (no buttons, no forms). UI-spoofing
+  (fake consent dialogs etc.) only becomes harmful with interactivity; MCP Apps spends
+  its sandbox complexity there. reyn avoids the class structurally. Interactivity is v2,
+  and must route through the existing intervention bus (the consent path) when it comes.
+  **← the one headline owner decision this doc requests.**
+
+### 3. Template sources — 4-stage fallback
+
+```
+registered template (operator-owned) → inline blueprint (LLM-authored, catalog-constrained)
+  → content-type default viewer (FP-0051 registry) → generic YAML/text
+```
+
+- Named templates live in **`.reyn/config/presentations.yaml`** — same registration +
+  hot-reload-seam pattern as `skills.entries` / `pipelines.entries`. Registering named
+  templates is an **operator/config action**; the LLM authors inline blueprints only
+  (write-gate culture).
+- Inline blueprints are structurally gated at op validation: catalog components only,
+  bindings are path expressions only, labels escaped at parse (FP-0051's fence,
+  generalized).
+
+### 4. Binding semantics
+
+- Path hit → bind (escape at render, per surface).
+- Path miss → **soft-skip that binding/component**, record in `bindings_dropped`.
+- Type mismatch → renderer coercion rules (scalar into table binding → 1 row; etc.).
+- All bindings miss → fall back to generic viewer; never a hard failure.
+
+### 5. Presentation-guard (output seam)
+
+Mirror of the input-side content-guard, at the output boundary:
+
+- Threat scan + neutralization of rendered leaf strings: terminal escape sequences,
+  Rich markup, HTML — per target surface. Runs **unconditionally**, including (and
+  especially) for never-ingested data.
+- **Per-binding size caps** — prevents `/` (root) bound into a `text` component from
+  dumping an entire file.
+- **Per-surface inline height caps** (terminal: e.g. ~20 rows inline + expand/pager
+  affordance, exact mechanics per tui-coder input) — a 10k-row present must not destroy
+  terminal scrollback. Fidelity is guaranteed by the ref (full data always reachable),
+  not by unbounded inline paint.
+
+### 6. Renderers and surfaces
+
+- `PresentationRenderer` protocol — **built fresh** (the FP-0051 registry was deleted,
+  not relocated; its design is the lineage, not a base to extend). Terminal (inline-CUI)
+  = Rich/ANSI (substrate to confirm with tui-coder); web = native components; A2A =
+  structured message part.
+- **Terminal note**: the current terminal UI is the inline-CUI
+  (`src/reyn/interfaces/inline/`) — no side panel, and its only tool-result rendering is
+  `summarize_tool_result` (a one-liner). `present` renders as an **inline block in the
+  conversation flow**, introducing rich rendering that does not exist today. Rendering
+  substrate and constraints (height caps, expand/pager affordances, scrollback behavior)
+  are being confirmed with tui-coder.
+- **Remote surfaces (web/A2A)**: remote clients cannot read local refs. Data delivery is
+  the surface adapter's responsibility: materialize via the gateway (size-capped inline
+  embed or a served endpoint). v1 ships the terminal (inline-CUI) surface only; the hub
+  model records this contract
+  now so remote phases don't warp the core.
+
+### 7. Audit — `presented` event (P6)
+
+```yaml
+presented:
+  data_ref: <path>            # or inline-data marker
+  template: <name | inline blueprint hash>
+  surface: [inline-cui]
+  ingested: none | partial | full   # OS-COMPUTED, not LLM-self-reported
+  bindings_resolved: 3
+  bindings_dropped: ["/results/0/author"]
+```
+
+**Blind-routing is not a permission mode — it is an audit annotation.** Whether the LLM
+read the data before presenting is a fact the OS can compute (result was inline, or a
+`file__read(ref)` appears earlier in the session). No config gate in v1; the guard runs
+regardless; audit records the fact. (The standards world routes blind as the norm; reyn's
+differentiator is making blindness *auditable*, not forbidding it.)
+
+### 8. Lifetime, replay, rewind
+
+- `present` does **not** pin `data_ref` into any retention window. Refs keep their
+  existing lifecycle class.
+- Replay/rewind re-renders best-effort from the `presented` event; a GC'd ref renders as
+  an expiry placeholder pointing at the audit event. Presentation is a cache; the event
+  is the truth. (No WAL-derived recovery state is introduced ⇒ the recovery-feature PR
+  gate does not apply.)
+- Conversation history never contains the presented bytes ⇒ nothing new for compaction.
+
+## Relationship to the tool-result-schema-redesign arc
+
+- **Consumer, not competitor**: `present` consumes the arc's offload refs — the
+  `structured_ref` frontmatter field, plus the text-side ref carried inline in the
+  truncation note — i.e. the text/structured stream split from the canonical mappers.
+- **Zero blocking asks — and the dependency is already met**: the arc is owner-approved,
+  and as of 2026-07-08 design doc (#2646), PR-0 (#2647), and PR-1 (#2648, canonical
+  mappers + legacy-path deletion) are **merged**. The interfaces this proposal consumes
+  are live; the arc's remaining PR-2 (pipeline ctx) / PR-3 (offload config) do not gate
+  this proposal.
+- **Follow-up (additive, post-arc)**: enrich offload frontmatter with a shape summary
+  (key names / types / array lengths) instead of only a head-N-chars preview — improves
+  blind template authoring. To be filed as an issue after the arc lands.
+
+## Out of scope (v1)
+
+- Interactive components (v2; via intervention bus).
+- Live-updating presentations (A2UI `updateDataModel` diffs) — presentations are
+  immutable snapshots; revisit if dashboard-like demand appears (hooks/events could
+  drive it).
+- Pipelines (`tool:`/`agent:` step surfaces) and CodeAct observation path — same scoping
+  as the redesign arc.
+- Remote-surface materialization implementation (design contract recorded, § 6).
+- Wire-level A2UI / MCP Apps adapters (emit + ingest) — enabled by isomorphism, deferred
+  until the specs stabilize.
+
+## Suggested PR sequencing (post owner-GO, post arc PR-1)
+
+- **PR-A** — `present` op + declarative model + binding resolution + presentation-guard
+  core (no UI yet; op returns ack against a null renderer). Includes `OP_KIND_MODEL_MAP`
+  + control-ir.md section (hard rule), `presented` event type.
+- **PR-B** — inline-CUI renderer: conversation inline block + `PresentationRenderer`
+  protocol (FP-0051 design lineage), height caps + expand affordance.
+- **PR-C** — `presentations.yaml` registration + hot-reload seam + 4-stage fallback
+  integration with FP-0051 registry.
+- **PR-D** — replay/rewind placeholder rendering + docs (concepts page + reference).
+
+## Test plan (per testing.ja.md tiers)
+
+- **Tier 1 (contract)**: binding resolution (hit / miss soft-skip / coercion / row-relative
+  paths); ack shape (drops reported); blueprint structural gate (non-catalog component
+  rejected, non-path binding rejected); guard (escape survival asserted via literal
+  bracket, per FP-0051 test idiom); `presented` event field presence incl. OS-computed
+  `ingested`; read-authority equivalence (`present` denied ⇔ `file.read` denied).
+- **Tier 2 (OS invariant)**: fire-and-continue (run not paused); no content bytes in
+  event payloads; ref-expiry placeholder path.
+- **No Tier-4 pins**: no exact-render/whitespace assertions; assert content presence and
+  drop lists, not layout.
+
+## Open questions (owner)
+
+1. **Ratify: v1 catalog is display-only** (interactivity deferred to v2 via intervention
+   bus). This is the single structural decision the rest of the design leans on.
+2. Naming: `present` (op), `presentations.yaml` (registry) — bikeshed-level, defaults
+   proposed here stand unless overridden.
+
+## Sources
+
+- MCP Apps announcement (MCP blog, 2026-01-26) — https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/
+- A2UI v1.0 specification — https://a2ui.org/specification/v1.0-a2ui/
+- Google Developers: Introducing A2UI — https://developers.googleblog.com/introducing-a2ui-an-open-project-for-agent-driven-interfaces/
+- CopilotKit: The State of Agentic UI (AG-UI / MCP-UI / A2UI) — https://www.copilotkit.ai/blog/the-state-of-agentic-ui-comparing-ag-ui-mcp-ui-and-a2ui-protocols
+- The New Stack: Agent UI Standards Multiply — https://thenewstack.io/agent-ui-standards-multiply-mcp-apps-and-googles-a2ui/
+- Vercel AI SDK 3.0 Generative UI — https://vercel.com/blog/ai-sdk-3-generative-ui
+- FP-0051 viewer registry (superseded — TUI + registry deleted 2026-07, design lineage only) — `docs/deep-dives/proposals/0051-tool-result-viewer-registry-llm-template.md`
+- Tool-result schema redesign — `docs/proposals/tool-result-schema-redesign.md`


### PR DESCRIPTION
**[architect]** — DRAFT design proposal for a **present layer**: a `present` op (Control IR) plus a surface-agnostic, declarative presentation model that lets bulk tool-result data reach the user **without round-tripping through LLM output tokens**.

Doc: `docs/deep-dives/proposals/0054-present-layer.md` (sequential proposals home; `deep-dives/` is excluded from the public mkdocs site, matching `0053-tool-result-schema-redesign.md`).

## What & why
- **Problem**: showing tool data to the user costs LLM output tokens (reproduction) and loses fidelity (summarization). Today, bulk data reaches the user only via `summarize_tool_result` (1-line, max fidelity loss) or full LLM output reproduction (max token cost) — no rich middle ground exists.
- **Design**: hub-and-spoke, reyn-native declarative model **structurally isomorphic to A2UI** (JSON-Pointer bindings, vetted non-executable catalog); wire adapters (A2UI / MCP Apps) deferred to boundary. Consumes the tool-result-schema-redesign arc's landed offload refs (`structured` / `structured_ref` / `structured_preview` + text-side inline truncation-note ref). That arc is now **fully closed** (PR-0..PR-4 merged), so the dependency is met.
- **Security**: declarative-not-executable (structural write-gate parity); presentation-guard at the output seam; blind-routing recorded as an OS-computed audit annotation, not gated.

## Reviews incorporated
- **docs-maintainer**: field-name accuracy (`structured_ref` vs non-existent `text_ref`), arc-status facts, FP-0051 superseded.
- **tui-coder**: inline-CUI reality (Rich via `repl/renderer.py`; scrollback uncapped; present carries its own head-N cap); cap-before-render for code/diff; explicit `Console(width=...)`.
- **lead-coder**: design APPROVE; high-signal ack (`{path, reason}`), explicit `resolve_present_source` data_ref seam, recovery-gate N/A rationale in §8 + PR-D.

## Status
- **Owner RATIFIED 2026-07-08**: v1 display-only catalog approved. Owner also asked for markdown + templates — both already in v1 scope (markdown = §2 catalog; templates = §3 4-stage fallback; display-only means non-interactive, not content-limited).
- Implementation dispatch: lead-coder (review/merge owner) proceeds PR-A → PR-D.

## Test plan
- [x] (skipped — docs-only) No src/tests touched; ruff / tier-audit / docstring-verify are N/A.
- [x] Location: `docs/deep-dives/proposals/` — excluded from public mkdocs site (`exclude_docs: deep-dives/`), so no nav/strict-build concern; parity with `0053-tool-result-schema-redesign.md`.
- [x] Owner ratify: v1 display-only catalog — **ratified 2026-07-08** (markdown + templates confirmed in-scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
