### PR TITLE
feat: present op (PR-A) — declarative model + binding + presentation-guard core (null renderer)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -19,6 +19,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `glob_files` | List files matching a glob pattern | `file.read` |
 | `grep_files` | Search file contents by regex | `file.read` |
 | `ask_user` | Pause the phase and ask the user a question | none (always allowed) |
+| `present` | Route bulk data + a display template to the user surface without the data passing through LLM output tokens (fire-and-continue) | Tier 0 (always allowed); `data_ref` read authority == `file.read` |
 | `sandboxed_exec` | Run argv under a `SandboxPolicy` via a `SandboxBackend` (replaces the removed `shell` op) | enforced by backend (`SandboxPolicy`) |
 | `web_search` | Search the public web via DuckDuckGo | Tier 1 — default allow; `web.search: deny` in `reyn.yaml` blocks |
 | `web_fetch` | Fetch a single URL and return extracted text | Tier 1 — default allow; `web.fetch: deny` in `reyn.yaml` blocks |
@@ -139,6 +140,98 @@ Pauses the phase and asks the user. The OS prints the question, reads stdin, and
 ```
 
 `suggestions` are free-text hints (the user may still type anything). `options` (PR-F3, #2233) is a **closed selectable set** — when non-empty, the frontend renders a **selector** over exactly those answers (empty → free-text input). `required` (default `true`) — when `false`, the user may dismiss without answering.
+
+## `present`
+
+Routes bulk data plus a declarative display template to the user-facing surface
+**without the data round-tripping through LLM output tokens**. The offloaded ref
+file is already "data file + handle"; `present` joins that handle to a display
+template so the bulk bytes reach the user directly. Presenting N rows costs ~0
+output tokens; the moment the agent must *transform* the data it pays to read the
+ref instead.
+
+**Tier 0** (`ask_user`'s sibling): presenting to the user — the trust root — is
+not an exfiltration channel, so there is no output permission gate. The one gate:
+`data_ref` read authority resolves **identically to `file.read`** — `present` can
+never read more than the agent's file ops can. Unlike `ask_user`, `present` is
+**fire-and-continue** — it does NOT pause the run.
+
+```json
+{
+  "kind": "present",
+  "data_ref": ".reyn/cache/tool-results/2026-.../structured.json",
+  "blueprint": {
+    "component": "table",
+    "rows": {"$bind": "/results"},
+    "columns": [
+      {"header": "Title", "path": "/title"},
+      {"header": "Author", "path": "/author"}
+    ]
+  }
+}
+```
+
+Fields (exactly one source, exactly one template):
+
+- `data_ref` (str) **XOR** `data_inline` (any) — the data source. `data_ref` is
+  any zone-readable path; an offloaded `structured_ref` is **re-hydrated to its
+  full value** (not read from the LLM-visible preview) via `file.read` semantics.
+  `data_inline` is small data already in the LLM's context.
+- `template` (str) **XOR** `blueprint` (object | array) — the display template.
+  `template` is a registered presentation name (the registry + fallback chain
+  land in a later PR); `blueprint` is an inline declarative component tree.
+
+**Declarative model (v1 catalog — display-only, non-executable by construction).**
+A blueprint is a single component node or a list of them (rendered top to bottom).
+Catalog components (all read-only): `text` / `markdown` / `code` / `diff` /
+`keyvalue` / `table` / `list` / `image`. There are **no interactive components**
+(no buttons / forms) in v1. Bindings are expressed structurally as
+`{"$bind": "<json-pointer>"}` — an RFC 6901 JSON Pointer **string** (`""` = whole
+document); everything else is a literal. `table` / `list` column paths resolve
+**row-relative** (relative to each iterated row). The structural gate at op
+validation rejects a non-catalog component or a non-path binding (a hard error,
+not a soft drop), and escapes literal labels at parse.
+
+**Binding semantics.** Path hit → bind. Path miss → **soft-skip** that binding +
+record it in `bindings_dropped` (never a hard failure). Type mismatch → coerce (a
+scalar into a `table` `rows` slot → a 1-row table) + record. Guard-stripped → a
+bound leaf neutralized or size-capped by the presentation-guard is recorded. When
+**all** bindings miss, the op reports `all_bindings_missed` (the generic-viewer
+fallback signal; the fallback wiring itself lands in a later PR).
+
+**Presentation-guard (output seam).** Runs **unconditionally**, including for
+never-ingested data: every rendered leaf string is neutralized (terminal escape /
+control sequences, Rich markup, HTML) so bound bulk data cannot drive the surface
+it displays on, and **per-binding size caps** prevent a `/` (root) pointer bound
+into a `text` component from dumping a whole file. Neutralization is a transform
+(the value still renders, inert) — the ref remains the full-fidelity source.
+
+**Ack (op result)** — the LLM's only feedback, deliberately compact + high-signal:
+
+```yaml
+ok: true
+bindings_resolved: 3
+rows: 500
+bindings_dropped:
+  - {path: "/results/0/author", reason: path_not_found}
+  # reason ∈ {path_not_found, type_mismatch, guard_stripped}
+```
+
+`path_not_found` across many rows reads as "template doesn't match this data
+shape"; `type_mismatch` as "right path, wrong component"; `guard_stripped` as
+"content neutralized by the guard, not a template bug". The LLM self-corrects a
+blind presentation for tens of tokens without ingesting the data.
+
+Event emitted: `presented` (P6 audit) — `{data_ref, template, surface, ingested,
+bindings_resolved, bindings_dropped, rows}`. `ingested` (`none` | `partial` |
+`full`) is **OS-computed** (was the data inline, or does a `read_file` on the ref
+appear earlier in the session), never LLM-self-reported. The event carries **refs
++ stats only, never content bytes** (the data is already durable in the ref).
+
+> PR-A scope: the model + binding + guard run against a **null renderer**
+> (`surface: ["null"]`) — there is no UI surface yet. The inline-CUI renderer,
+> `presentations.yaml` registry + fallback chain, and replay/rewind rendering land
+> in later PRs.
 
 ## `sandboxed_exec`
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -190,7 +190,8 @@ Catalog components (all read-only): `text` / `markdown` / `code` / `diff` /
 document); everything else is a literal. `table` / `list` column paths resolve
 **row-relative** (relative to each iterated row). The structural gate at op
 validation rejects a non-catalog component or a non-path binding (a hard error,
-not a soft drop), and escapes literal labels at parse.
+not a soft drop); it is purely structural — leaf-string neutralization is a single
+seam in the render layer (below), not at parse.
 
 **Binding semantics.** Path hit → bind. Path miss → **soft-skip** that binding +
 record it in `bindings_dropped` (never a hard failure). Type mismatch → coerce (a
@@ -200,11 +201,17 @@ bound leaf neutralized or size-capped by the presentation-guard is recorded. Whe
 fallback signal; the fallback wiring itself lands in a later PR).
 
 **Presentation-guard (output seam).** Runs **unconditionally**, including for
-never-ingested data: every rendered leaf string is neutralized (terminal escape /
-control sequences, Rich markup, HTML) so bound bulk data cannot drive the surface
-it displays on, and **per-binding size caps** prevent a `/` (root) pointer bound
-into a `text` component from dumping a whole file. Neutralization is a transform
-(the value still renders, inert) — the ref remains the full-fidelity source.
+never-ingested data. Every render-leaf string — labels, literal slot values, AND
+bound data values — passes through ONE neutralizer, selected by the target
+**surface** (a per-surface strategy, so a future web surface slots in without
+touching the binding layer). The v1 **terminal** strategy strips ESC / control
+sequences (OSC / CSI) and **escapes** (not strips) Rich console markup so `[red]`
+renders literally; it does **not** HTML-escape — in a terminal `<div>` is a
+harmless literal, and entity-escaping would corrupt `code` / `diff` content (HTML
+neutralization is a future web renderer's concern). **Per-binding size caps**
+prevent a `/` (root) pointer bound into a `text` component from dumping a whole
+file. Neutralization is a transform (the value still renders, inert) — the ref
+remains the full-fidelity source.
 
 **Ack (op result)** — the LLM's only feedback, deliberately compact + high-signal:
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -124,6 +124,9 @@ from . import mcp_unsubscribe_resource as _mcp_unsubscribe_resource  # noqa: F40
 
 # pipeline install op (register a pipeline DSL file into pipelines.entries — mirrors skill_install).
 from . import pipeline_install as _pipeline_install  # noqa: F401, E402
+
+# FP-0054 PR-A: present op — user-facing presentation of bulk data (null renderer).
+from . import present as _present  # noqa: F401, E402
 from . import recall as _recall  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -50,6 +50,10 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "judge_output": frozenset(),
     "compact": frozenset(),
     "ask_user": frozenset(),
+    # FP-0054 PR-A: present is Tier 0 (no output gate) but still gates on its own
+    # kind name under a per-session contextual narrowing (no distinct chat-tool
+    # qualified name → kind only; no silent bypass).
+    "present": frozenset(),
     # #1953 slice 1: Task ops have no distinct chat-tool qualified name → each
     # is gated on its own kind name (no silent bypass).
     "task.create": frozenset(),

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -120,8 +120,9 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     except PresentBlueprintError as exc:
         return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
 
-    # 4. Bind + guard against the null renderer.
-    resolved = resolve_bindings(nodes, data)
+    # 4. Bind + guard against the null renderer. The guard applies the surface's
+    #    neutralizer strategy (PR-A's null surface uses the terminal strategy).
+    resolved = resolve_bindings(nodes, data, surface=_NULL_SURFACE[0])
 
     # 5. Audit event (P6) — refs + stats, never content bytes.
     _emit_presented(

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -1,0 +1,149 @@
+"""present kind handler — route bulk data + a display template to the user (FP-0054 PR-A).
+
+**Tier 0** (``ask_user``'s sibling) and **fire-and-continue**: unlike ``ask_user``
+this op does NOT pause the run — it produces a presentation ack and returns. The
+only gate is that ``data_ref`` read authority resolves identically to
+``file.read`` (in ``resolve_present_source``); a denied read raises
+``PermissionError`` and the dispatch layer returns ``status="denied"``.
+
+PR-A scope: the declarative model + binding resolution + presentation-guard run
+against a **null renderer** — there is no UI surface yet (the inline-CUI renderer
+is a later PR). The op returns the compact, high-signal ack
+(``{ok, bindings_resolved, bindings_dropped, rows}``, drops as
+``{path, reason}``) and emits the ``presented`` P6 event (refs + stats, never
+content bytes).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from reyn.core.present import (
+    PresentBlueprintError,
+    PresentSourceNotFound,
+    resolve_bindings,
+    resolve_present_source,
+    validate_blueprint,
+)
+from reyn.schemas.models import PresentIROp
+
+from . import register
+from .context import OpContext
+
+# The PR-A surface: there is no UI renderer yet, so present renders against a
+# null renderer (no bytes reach any surface). Later PRs add "inline-cui" etc.
+_NULL_SURFACE = ["null"]
+
+_INLINE_MARKER = "<inline-data>"
+
+
+def _template_id(op: PresentIROp) -> str:
+    """The ``presented`` event's ``template`` field: the registered name, or a
+    stable short hash of the inline blueprint (no blueprint bytes in the event)."""
+    if op.template is not None:
+        return op.template
+    digest = hashlib.sha256(
+        json.dumps(op.blueprint, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+    return f"blueprint:{digest[:16]}"
+
+
+def _emit_presented(
+    ctx: OpContext,
+    *,
+    data_ref: str,
+    template: str,
+    ingested: str,
+    bindings_resolved: int,
+    bindings_dropped: list[dict],
+    rows: int,
+) -> None:
+    """Emit the P6 ``presented`` audit event — refs + stats only, never content
+    bytes (the data is already durable in the ref; the event stays light)."""
+    ctx.events.emit(
+        "presented",
+        run_id=ctx.run_id,
+        actor=ctx.actor,
+        phase=ctx.current_phase,
+        data_ref=data_ref,
+        template=template,
+        surface=list(_NULL_SURFACE),
+        ingested=ingested,
+        bindings_resolved=bindings_resolved,
+        bindings_dropped=bindings_dropped,
+        rows=rows,
+    )
+
+
+async def handle(op: PresentIROp, ctx: OpContext) -> dict:
+    # 1. Resolve the source under file.read authority (PermissionError propagates
+    #    → status="denied"; the read-authority-equivalence invariant).
+    if op.data_ref is not None:
+        try:
+            data, ingested = await resolve_present_source(op.data_ref, ctx)
+        except PresentSourceNotFound as exc:
+            return {
+                "kind": "present", "status": "not_found",
+                "ok": False, "error": str(exc),
+            }
+        data_ref_field: str = op.data_ref
+    else:
+        # Inline data is in the LLM's context by construction → ingested "full".
+        data = op.data_inline
+        ingested = "full"
+        data_ref_field = _INLINE_MARKER
+
+    template_id = _template_id(op)
+
+    # 2. Named-template resolution (registry + fallback chain) lands in a later
+    #    PR; PR-A resolves inline blueprints only. A named template is recorded
+    #    (audit-first) but not yet renderable.
+    if op.template is not None:
+        _emit_presented(
+            ctx, data_ref=data_ref_field, template=template_id, ingested=ingested,
+            bindings_resolved=0, bindings_dropped=[], rows=0,
+        )
+        return {
+            "kind": "present", "status": "ok", "ok": False,
+            "bindings_resolved": 0, "bindings_dropped": [], "rows": 0,
+            "note": (
+                "named-template resolution is not available yet; author an inline "
+                "blueprint (catalog components + $bind path bindings) instead."
+            ),
+        }
+
+    # 3. Structural gate on the inline blueprint (catalog components + path
+    #    bindings only). A malformed blueprint is a hard error, NOT a soft drop.
+    try:
+        nodes = validate_blueprint(op.blueprint)
+    except PresentBlueprintError as exc:
+        return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
+
+    # 4. Bind + guard against the null renderer.
+    resolved = resolve_bindings(nodes, data)
+
+    # 5. Audit event (P6) — refs + stats, never content bytes.
+    _emit_presented(
+        ctx,
+        data_ref=data_ref_field,
+        template=template_id,
+        ingested=ingested,
+        bindings_resolved=resolved.bindings_resolved,
+        bindings_dropped=resolved.bindings_dropped,
+        rows=resolved.rows,
+    )
+
+    # 6. The compact, high-signal ack (the LLM's only feedback).
+    return {
+        "kind": "present",
+        "status": "ok",
+        "ok": True,
+        "bindings_resolved": resolved.bindings_resolved,
+        "bindings_dropped": resolved.bindings_dropped,
+        "rows": resolved.rows,
+        "all_bindings_missed": resolved.all_bindings_missed,
+    }
+
+
+register("present", handle)

--- a/src/reyn/core/present/__init__.py
+++ b/src/reyn/core/present/__init__.py
@@ -1,0 +1,30 @@
+"""Present layer core — declarative, non-executable user-facing presentation (FP-0054).
+
+The building blocks the ``present`` op composes: a display-only component
+``catalog`` + structural blueprint gate, JSON-Pointer ``binding`` resolution
+against a null renderer, the output-side presentation ``guard``, and the
+``resolve_present_source`` seam that re-hydrates a ``data_ref`` under ``file.read``
+authority. Surface renderers (inline-CUI, web, A2A) consume this model in later
+PRs; this package produces the model + audit stats only.
+"""
+from __future__ import annotations
+
+from reyn.core.present.binding import ResolvedPresentation, resolve_bindings, resolve_pointer
+from reyn.core.present.catalog import CATALOG, PresentBlueprintError, validate_blueprint
+from reyn.core.present.source import (
+    PresentSourceNotFound,
+    compute_ingested,
+    resolve_present_source,
+)
+
+__all__ = [
+    "CATALOG",
+    "PresentBlueprintError",
+    "PresentSourceNotFound",
+    "ResolvedPresentation",
+    "compute_ingested",
+    "resolve_bindings",
+    "resolve_pointer",
+    "resolve_present_source",
+    "validate_blueprint",
+]

--- a/src/reyn/core/present/binding.py
+++ b/src/reyn/core/present/binding.py
@@ -4,6 +4,12 @@ The LLM works from an offload schema + preview and binds JSON-Pointer paths; thi
 module joins those bindings against the *full* data the LLM never ingested. The
 asymmetry (LLM sees shape, user sees content) is the designed contract.
 
+This layer is also the **single leaf-neutralization seam**: every render-leaf
+string — labels, literal slot values, AND bound data values — passes through the
+surface-selected neutralizer here (`guard.get_neutralizer(surface)`) as the render
+model is assembled. There is no parse-time neutralization path; nothing reaches a
+renderer un-neutralized.
+
 Semantics (§4):
 
 - **Path hit** → bind the value.
@@ -12,15 +18,16 @@ Semantics (§4):
 - **Type mismatch** → coerce (a scalar bound into a ``table`` ``rows`` slot → a
   1-row table; a container bound into a text slot → its JSON form) and record
   ``{path, reason: type_mismatch}``.
-- **Guard-stripped** → a bound leaf neutralized or size-capped by the
-  presentation-guard is recorded ``{path, reason: guard_stripped}``.
+- **Guard-stripped** → any render-leaf (bound value, literal, or label)
+  neutralized or size-capped by the presentation-guard is recorded
+  ``{path, reason: guard_stripped}``.
 - **All bindings miss** → the ``all_bindings_missed`` outcome is exposed so the
   caller can route to the generic viewer (the fallback wiring itself is a later
   PR); never a hard failure here.
 
 Table / list column paths resolve **row-relative** (RFC 6901 relative to each
-iterated row). Bindings are resolved against a **null renderer** in this layer —
-the returned model is data (bound values + drop stats), never surface bytes.
+iterated row). Only ``$bind`` paths count toward ``bindings_resolved``; a
+literal/label is neutralized but is not a binding.
 """
 from __future__ import annotations
 
@@ -29,7 +36,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from reyn.core.present.catalog import binding_pointer, is_binding
-from reyn.core.present.guard import cap_leaf, cap_rows, neutralize_leaf
+from reyn.core.present.guard import LeafNeutralizer, cap_leaf, cap_rows, get_neutralizer
 
 # Drop reason categories (§1 refined ack shape).
 PATH_NOT_FOUND = "path_not_found"
@@ -41,7 +48,7 @@ _MISSING = object()
 
 @dataclass
 class ResolvedPresentation:
-    """The outcome of joining a blueprint to data against a null renderer.
+    """The outcome of joining a blueprint to data.
 
     ``nodes`` is the render model (bound values, neutralized + capped) a surface
     renderer (later PR) consumes. The remaining fields are the compact,
@@ -129,34 +136,52 @@ def _coerce_rows(value: Any) -> tuple[list, bool]:
     return [value], True
 
 
-def _bind_text_slot(slot: Any, doc: Any, out: ResolvedPresentation) -> Any:
-    """Resolve a text-family slot (literal or ``$bind``). Returns the rendered
-    (neutralized, capped) string, or ``_MISSING`` when the binding missed."""
-    if not is_binding(slot):
-        # A literal — already escaped at parse; render as-is (still cap defensively).
-        if isinstance(slot, str):
-            capped, _ = cap_leaf(slot)
-            return capped
-        return slot
-    ptr = binding_pointer(slot)
-    value, found = resolve_pointer(doc, ptr)
-    if not found:
-        out._drop(ptr, PATH_NOT_FOUND)
-        return _MISSING
-    text, mismatch = _coerce_text(value)
-    clean, stripped = neutralize_leaf(text)
+def _guard(text: str, neut: LeafNeutralizer, out: ResolvedPresentation, *, path: str) -> str:
+    """Route a render-leaf string through the surface's single neutralizer seam +
+    the size cap; record ``guard_stripped`` (at ``path``) when it changes. Returns
+    the rendered value. Does NOT count toward ``bindings_resolved`` — that is the
+    binding layer's decision (a literal/label is neutralized but is not a
+    binding)."""
+    clean, stripped = neut.neutralize(text)
     capped, was_capped = cap_leaf(clean)
-    out._resolve()
-    if mismatch:
-        out._drop(ptr, TYPE_MISMATCH)
     if stripped or was_capped:
-        out._drop(ptr, GUARD_STRIPPED)
+        out._drop(path, GUARD_STRIPPED)
     return capped
+
+
+def _guard_maybe(value: Any, neut: LeafNeutralizer, out: ResolvedPresentation, *, path: str) -> Any:
+    """Neutralize a literal/label leaf when it is a string; non-strings pass
+    through unchanged (the seam only transforms strings)."""
+    if isinstance(value, str):
+        return _guard(value, neut, out, path=path)
+    return value
+
+
+def _render_text_slot(
+    slot: Any, doc: Any, out: ResolvedPresentation, neut: LeafNeutralizer, *, loc: str,
+) -> Any:
+    """Resolve + guard a text-family slot (literal or ``$bind``). Returns the
+    rendered (neutralized, capped) string, or ``_MISSING`` when the binding
+    missed."""
+    if is_binding(slot):
+        ptr = binding_pointer(slot)
+        value, found = resolve_pointer(doc, ptr)
+        if not found:
+            out._drop(ptr, PATH_NOT_FOUND)
+            return _MISSING
+        text, mismatch = _coerce_text(value)
+        out._resolve()
+        if mismatch:
+            out._drop(ptr, TYPE_MISMATCH)
+        return _guard(text, neut, out, path=ptr)
+    # A literal slot value — not a binding, but still a render-leaf → neutralize.
+    return _guard_maybe(slot, neut, out, path=loc)
 
 
 def _bind_rows_slot(slot: Any, doc: Any, out: ResolvedPresentation) -> tuple[list, bool]:
     """Resolve a ``rows`` / ``items`` array slot. Returns ``(rows, found)`` — an
-    empty list + ``found=False`` on a miss."""
+    empty list + ``found=False`` on a miss. (The array itself is not a leaf; its
+    cells are neutralized where they are rendered.)"""
     if not is_binding(slot):
         return (slot if isinstance(slot, list) else []), True
     ptr = binding_pointer(slot)
@@ -175,11 +200,13 @@ def _bind_rows_slot(slot: Any, doc: Any, out: ResolvedPresentation) -> tuple[lis
     return capped_rows, True
 
 
-def _bind_row_relative(rows: list, path: str, out: ResolvedPresentation) -> list:
-    """Resolve a row-relative column / item path across every row. Records a
-    single ``path_not_found`` when the path misses on ALL rows; a single
-    ``guard_stripped`` when any cell was neutralized. Returns the rendered cell
-    values (missing cells → empty string, sparse data is normal)."""
+def _bind_row_relative(
+    rows: list, path: str, out: ResolvedPresentation, neut: LeafNeutralizer,
+) -> list:
+    """Resolve a row-relative column / item path across every row (cells routed
+    through the neutralizer seam). Records a single ``path_not_found`` when the
+    path misses on ALL rows; a single ``guard_stripped`` when any cell was
+    neutralized. Missing cells → empty string (sparse data is normal)."""
     cells: list[str] = []
     any_hit = False
     any_stripped = False
@@ -190,7 +217,7 @@ def _bind_row_relative(rows: list, path: str, out: ResolvedPresentation) -> list
             continue
         any_hit = True
         text, _ = _coerce_text(value)
-        clean, stripped = neutralize_leaf(text)
+        clean, stripped = neut.neutralize(text)
         capped, was_capped = cap_leaf(clean)
         any_stripped = any_stripped or stripped or was_capped
         cells.append(capped)
@@ -203,51 +230,77 @@ def _bind_row_relative(rows: list, path: str, out: ResolvedPresentation) -> list
     return cells
 
 
-def resolve_bindings(nodes: list[dict], doc: Any) -> ResolvedPresentation:
-    """Join a validated (normalized) blueprint to ``doc`` against a null renderer.
+def _guard_list_items(
+    rows: list, out: ResolvedPresentation, neut: LeafNeutralizer, *, loc: str,
+) -> list:
+    """Neutralize the raw row values of a ``list`` with no per-item path (each is
+    a render-leaf). Aggregates one ``guard_stripped`` for the slot when any item
+    was neutralized."""
+    result: list[str] = []
+    any_stripped = False
+    for row in rows:
+        text, _ = _coerce_text(row)
+        clean, stripped = neut.neutralize(text)
+        capped, was_capped = cap_leaf(clean)
+        any_stripped = any_stripped or stripped or was_capped
+        result.append(capped)
+    if any_stripped:
+        out._drop(loc, GUARD_STRIPPED)
+    return result
+
+
+def resolve_bindings(nodes: list[dict], doc: Any, *, surface: str = "null") -> ResolvedPresentation:
+    """Join a validated (normalized) blueprint to ``doc``, neutralizing every
+    render-leaf through the ``surface``-selected seam.
 
     Returns a :class:`ResolvedPresentation` — the render model plus the compact
     binding stats (``bindings_resolved`` / ``bindings_dropped`` / ``rows`` /
     ``all_bindings_missed``) the op ack + ``presented`` event carry.
     """
+    neut = get_neutralizer(surface)
     out = ResolvedPresentation()
-    for node in nodes:
+    for i, node in enumerate(nodes):
+        loc = f"blueprint[{i}]"
         component = node["component"]
         rendered: dict[str, Any] = {"component": component}
         if component in {"text", "markdown", "code", "diff"}:
             if "text" in node:
-                val = _bind_text_slot(node["text"], doc, out)
+                val = _render_text_slot(node["text"], doc, out, neut, loc=f"{loc}.text")
                 if val is not _MISSING:
                     rendered["text"] = val
             if component == "code" and "language" in node:
-                rendered["language"] = node["language"]
+                rendered["language"] = _guard_maybe(
+                    node["language"], neut, out, path=f"{loc}.language"
+                )
         elif component == "keyvalue":
             rows_out = []
-            for row in node["rows"]:
-                val = _bind_text_slot(row["value"], doc, out)
+            for j, row in enumerate(node["rows"]):
+                val = _render_text_slot(row["value"], doc, out, neut, loc=f"{loc}.rows[{j}].value")
                 if val is not _MISSING:
-                    rows_out.append({"label": row["label"], "value": val})
+                    label = _guard_maybe(row["label"], neut, out, path=f"{loc}.rows[{j}].label")
+                    rows_out.append({"label": label, "value": val})
             rendered["rows"] = rows_out
         elif component == "table":
             rows, _found = _bind_rows_slot(node.get("rows"), doc, out)
             columns_out = []
-            for col in node.get("columns", []):
-                cells = _bind_row_relative(rows, col["path"], out)
-                columns_out.append({"header": col["header"], "cells": cells})
+            for j, col in enumerate(node.get("columns", [])):
+                cells = _bind_row_relative(rows, col["path"], out, neut)
+                header = _guard_maybe(col["header"], neut, out, path=f"{loc}.columns[{j}].header")
+                columns_out.append({"header": header, "cells": cells})
             rendered["columns"] = columns_out
             rendered["row_count"] = len(rows)
         elif component == "list":
             rows, _found = _bind_rows_slot(node.get("items"), doc, out)
             if "item_path" in node:
-                rendered["items"] = _bind_row_relative(rows, node["item_path"], out)
+                rendered["items"] = _bind_row_relative(rows, node["item_path"], out, neut)
             else:
-                rendered["items"] = [_coerce_text(r)[0] for r in rows]
+                rendered["items"] = _guard_list_items(rows, out, neut, loc=f"{loc}.items")
         elif component == "image":
             if "src" in node:
-                val = _bind_text_slot(node["src"], doc, out)
+                val = _render_text_slot(node["src"], doc, out, neut, loc=f"{loc}.src")
                 if val is not _MISSING:
                     rendered["src"] = val
             if "alt" in node:
-                rendered["alt"] = node["alt"]
+                rendered["alt"] = _guard_maybe(node["alt"], neut, out, path=f"{loc}.alt")
         out.nodes.append(rendered)
     return out

--- a/src/reyn/core/present/binding.py
+++ b/src/reyn/core/present/binding.py
@@ -1,0 +1,253 @@
+"""Binding resolution for present — join a validated blueprint to data (FP-0054).
+
+The LLM works from an offload schema + preview and binds JSON-Pointer paths; this
+module joins those bindings against the *full* data the LLM never ingested. The
+asymmetry (LLM sees shape, user sees content) is the designed contract.
+
+Semantics (§4):
+
+- **Path hit** → bind the value.
+- **Path miss** → soft-skip that binding and record ``{path, reason:
+  path_not_found}``; never a hard failure.
+- **Type mismatch** → coerce (a scalar bound into a ``table`` ``rows`` slot → a
+  1-row table; a container bound into a text slot → its JSON form) and record
+  ``{path, reason: type_mismatch}``.
+- **Guard-stripped** → a bound leaf neutralized or size-capped by the
+  presentation-guard is recorded ``{path, reason: guard_stripped}``.
+- **All bindings miss** → the ``all_bindings_missed`` outcome is exposed so the
+  caller can route to the generic viewer (the fallback wiring itself is a later
+  PR); never a hard failure here.
+
+Table / list column paths resolve **row-relative** (RFC 6901 relative to each
+iterated row). Bindings are resolved against a **null renderer** in this layer —
+the returned model is data (bound values + drop stats), never surface bytes.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from reyn.core.present.catalog import binding_pointer, is_binding
+from reyn.core.present.guard import cap_leaf, cap_rows, neutralize_leaf
+
+# Drop reason categories (§1 refined ack shape).
+PATH_NOT_FOUND = "path_not_found"
+TYPE_MISMATCH = "type_mismatch"
+GUARD_STRIPPED = "guard_stripped"
+
+_MISSING = object()
+
+
+@dataclass
+class ResolvedPresentation:
+    """The outcome of joining a blueprint to data against a null renderer.
+
+    ``nodes`` is the render model (bound values, neutralized + capped) a surface
+    renderer (later PR) consumes. The remaining fields are the compact,
+    high-signal stats the op ack + the ``presented`` event carry.
+    """
+
+    nodes: list[dict] = field(default_factory=list)
+    bindings_resolved: int = 0
+    bindings_dropped: list[dict] = field(default_factory=list)
+    rows: int = 0
+    _missed: int = 0
+
+    @property
+    def all_bindings_missed(self) -> bool:
+        """True iff the blueprint had ≥1 binding and none resolved (§4 full-miss
+        → generic-viewer fallback signal)."""
+        return self.bindings_resolved == 0 and self._missed > 0
+
+    def _resolve(self) -> None:
+        self.bindings_resolved += 1
+
+    def _drop(self, path: str, reason: str) -> None:
+        self.bindings_dropped.append({"path": path, "reason": reason})
+        if reason == PATH_NOT_FOUND:
+            self._missed += 1
+
+
+def resolve_pointer(doc: Any, pointer: str) -> tuple[Any, bool]:
+    """Resolve an RFC 6901 JSON Pointer against ``doc``. Returns ``(value, found)``.
+
+    ``""`` → the whole document. Array tokens index by integer; object tokens by
+    key. A miss (bad key / out-of-range index / scalar-with-remaining-tokens)
+    returns ``(None, False)`` — never raises.
+    """
+    if pointer == "":
+        return doc, True
+    if not pointer.startswith("/"):
+        return None, False
+    cur = doc
+    for raw in pointer.split("/")[1:]:
+        token = raw.replace("~1", "/").replace("~0", "~")
+        if isinstance(cur, dict):
+            if token not in cur:
+                return None, False
+            cur = cur[token]
+        elif isinstance(cur, list):
+            try:
+                idx = int(token)
+            except ValueError:
+                return None, False
+            if idx < 0 or idx >= len(cur):
+                return None, False
+            cur = cur[idx]
+        else:
+            return None, False
+    return cur, True
+
+
+def _coerce_text(value: Any) -> tuple[str, bool]:
+    """Coerce a bound value into a text-slot string. Returns ``(text, mismatch)``.
+
+    Scalars (str / number / bool / null) are natural text — not a mismatch. A
+    container (dict / list) into a text slot is a real type mismatch → its JSON
+    form + ``mismatch=True``.
+    """
+    if isinstance(value, str):
+        return value, False
+    if isinstance(value, bool):
+        return ("true" if value else "false"), False
+    if value is None:
+        return "", False
+    if isinstance(value, (int, float)):
+        return str(value), False
+    return json.dumps(value, ensure_ascii=False, default=str), True
+
+
+def _coerce_rows(value: Any) -> tuple[list, bool]:
+    """Coerce a bound value into an array of rows. Returns ``(rows, mismatch)``.
+
+    A scalar / object bound into a ``rows`` / ``items`` slot → a 1-row array
+    (§4 coercion rule) + ``mismatch=True``.
+    """
+    if isinstance(value, list):
+        return value, False
+    return [value], True
+
+
+def _bind_text_slot(slot: Any, doc: Any, out: ResolvedPresentation) -> Any:
+    """Resolve a text-family slot (literal or ``$bind``). Returns the rendered
+    (neutralized, capped) string, or ``_MISSING`` when the binding missed."""
+    if not is_binding(slot):
+        # A literal — already escaped at parse; render as-is (still cap defensively).
+        if isinstance(slot, str):
+            capped, _ = cap_leaf(slot)
+            return capped
+        return slot
+    ptr = binding_pointer(slot)
+    value, found = resolve_pointer(doc, ptr)
+    if not found:
+        out._drop(ptr, PATH_NOT_FOUND)
+        return _MISSING
+    text, mismatch = _coerce_text(value)
+    clean, stripped = neutralize_leaf(text)
+    capped, was_capped = cap_leaf(clean)
+    out._resolve()
+    if mismatch:
+        out._drop(ptr, TYPE_MISMATCH)
+    if stripped or was_capped:
+        out._drop(ptr, GUARD_STRIPPED)
+    return capped
+
+
+def _bind_rows_slot(slot: Any, doc: Any, out: ResolvedPresentation) -> tuple[list, bool]:
+    """Resolve a ``rows`` / ``items`` array slot. Returns ``(rows, found)`` — an
+    empty list + ``found=False`` on a miss."""
+    if not is_binding(slot):
+        return (slot if isinstance(slot, list) else []), True
+    ptr = binding_pointer(slot)
+    value, found = resolve_pointer(doc, ptr)
+    if not found:
+        out._drop(ptr, PATH_NOT_FOUND)
+        return [], False
+    rows, mismatch = _coerce_rows(value)
+    out.rows += len(rows)
+    out._resolve()
+    if mismatch:
+        out._drop(ptr, TYPE_MISMATCH)
+    capped_rows, was_capped = cap_rows(rows)
+    if was_capped:
+        out._drop(ptr, GUARD_STRIPPED)
+    return capped_rows, True
+
+
+def _bind_row_relative(rows: list, path: str, out: ResolvedPresentation) -> list:
+    """Resolve a row-relative column / item path across every row. Records a
+    single ``path_not_found`` when the path misses on ALL rows; a single
+    ``guard_stripped`` when any cell was neutralized. Returns the rendered cell
+    values (missing cells → empty string, sparse data is normal)."""
+    cells: list[str] = []
+    any_hit = False
+    any_stripped = False
+    for row in rows:
+        value, found = resolve_pointer(row, path)
+        if not found:
+            cells.append("")
+            continue
+        any_hit = True
+        text, _ = _coerce_text(value)
+        clean, stripped = neutralize_leaf(text)
+        capped, was_capped = cap_leaf(clean)
+        any_stripped = any_stripped or stripped or was_capped
+        cells.append(capped)
+    if not any_hit and rows:
+        out._drop(path, PATH_NOT_FOUND)
+    elif any_hit:
+        out._resolve()
+        if any_stripped:
+            out._drop(path, GUARD_STRIPPED)
+    return cells
+
+
+def resolve_bindings(nodes: list[dict], doc: Any) -> ResolvedPresentation:
+    """Join a validated (normalized) blueprint to ``doc`` against a null renderer.
+
+    Returns a :class:`ResolvedPresentation` — the render model plus the compact
+    binding stats (``bindings_resolved`` / ``bindings_dropped`` / ``rows`` /
+    ``all_bindings_missed``) the op ack + ``presented`` event carry.
+    """
+    out = ResolvedPresentation()
+    for node in nodes:
+        component = node["component"]
+        rendered: dict[str, Any] = {"component": component}
+        if component in {"text", "markdown", "code", "diff"}:
+            if "text" in node:
+                val = _bind_text_slot(node["text"], doc, out)
+                if val is not _MISSING:
+                    rendered["text"] = val
+            if component == "code" and "language" in node:
+                rendered["language"] = node["language"]
+        elif component == "keyvalue":
+            rows_out = []
+            for row in node["rows"]:
+                val = _bind_text_slot(row["value"], doc, out)
+                if val is not _MISSING:
+                    rows_out.append({"label": row["label"], "value": val})
+            rendered["rows"] = rows_out
+        elif component == "table":
+            rows, _found = _bind_rows_slot(node.get("rows"), doc, out)
+            columns_out = []
+            for col in node.get("columns", []):
+                cells = _bind_row_relative(rows, col["path"], out)
+                columns_out.append({"header": col["header"], "cells": cells})
+            rendered["columns"] = columns_out
+            rendered["row_count"] = len(rows)
+        elif component == "list":
+            rows, _found = _bind_rows_slot(node.get("items"), doc, out)
+            if "item_path" in node:
+                rendered["items"] = _bind_row_relative(rows, node["item_path"], out)
+            else:
+                rendered["items"] = [_coerce_text(r)[0] for r in rows]
+        elif component == "image":
+            if "src" in node:
+                val = _bind_text_slot(node["src"], doc, out)
+                if val is not _MISSING:
+                    rendered["src"] = val
+            if "alt" in node:
+                rendered["alt"] = node["alt"]
+        out.nodes.append(rendered)
+    return out

--- a/src/reyn/core/present/catalog.py
+++ b/src/reyn/core/present/catalog.py
@@ -16,13 +16,13 @@ at parse. Everything that is not a ``$bind`` object is a literal.
 
 The structural gate runs at op validation: a non-catalog component or a non-path
 binding is a hard rejection (``PresentBlueprintError``), not a soft drop —
-soft-skip is for *runtime* binding misses, not for a malformed template.
+soft-skip is for *runtime* binding misses, not for a malformed template. This gate
+is purely structural; leaf-string neutralization (labels, literals, bound values)
+is a single seam in the render layer (``binding.resolve_bindings``), not here.
 """
 from __future__ import annotations
 
 from typing import Any
-
-from reyn.core.present.guard import neutralize_leaf
 
 # Component name → the set of slot keys it accepts. Slots not listed are rejected
 # (keeps the surface tight + the gate exhaustive). ``rows`` / ``columns`` /
@@ -92,18 +92,9 @@ def _validate_slot_value(value: Any, *, where: str, allow_bind: bool = True) -> 
         )
 
 
-def _escape_label(label: Any) -> Any:
-    """Neutralize a literal label at parse (FP-0051's fence, generalized): the LLM
-    authors labels, so they are escaped the moment the blueprint is ingested, not
-    only at render. Non-string labels pass through."""
-    if isinstance(label, str):
-        clean, _ = neutralize_leaf(label)
-        return clean
-    return label
-
-
 def _validate_node(node: Any, *, path: str) -> dict:
-    """Validate one component node; return a normalized copy (labels escaped)."""
+    """Validate one component node; return a normalized copy (structure only —
+    leaf strings are neutralized later at the render seam, not here)."""
     if not isinstance(node, dict):
         raise PresentBlueprintError(f"{path}: component node must be an object, got {type(node).__name__}")
     component = node.get("component")
@@ -127,8 +118,6 @@ def _validate_node(node: Any, *, path: str) -> dict:
     if component in TEXT_FAMILY:
         if "text" in normalized:
             _validate_slot_value(normalized["text"], where=f"{path}.text")
-        if component == "code" and "language" in normalized:
-            normalized["language"] = _escape_label(normalized["language"])
     elif component == "keyvalue":
         normalized["rows"] = _validate_kv_rows(normalized.get("rows"), path=f"{path}.rows")
     elif component == "table":
@@ -141,8 +130,6 @@ def _validate_node(node: Any, *, path: str) -> dict:
     elif component == "image":
         if "src" in normalized:
             _validate_slot_value(normalized["src"], where=f"{path}.src")
-        if "alt" in normalized:
-            normalized["alt"] = _escape_label(normalized["alt"])
     return normalized
 
 
@@ -154,7 +141,7 @@ def _validate_kv_rows(rows: Any, *, path: str) -> list:
         if not isinstance(row, dict) or "label" not in row or "value" not in row:
             raise PresentBlueprintError(f"{path}[{i}]: each keyvalue row needs a label + value")
         _validate_slot_value(row["value"], where=f"{path}[{i}].value")
-        out.append({"label": _escape_label(row["label"]), "value": row["value"]})
+        out.append({"label": row["label"], "value": row["value"]})
     return out
 
 
@@ -167,13 +154,13 @@ def _validate_columns(columns: Any, *, path: str) -> list:
             raise PresentBlueprintError(f"{path}[{i}]: each column needs a header + path")
         # A column path is a row-relative JSON Pointer string (not a $bind object).
         _validate_pointer(col["path"], where=f"{path}[{i}].path")
-        out.append({"header": _escape_label(col["header"]), "path": col["path"]})
+        out.append({"header": col["header"], "path": col["path"]})
     return out
 
 
 def validate_blueprint(blueprint: Any) -> list[dict]:
     """Structurally gate an inline blueprint → a normalized list of component
-    nodes (labels escaped at parse).
+    nodes (structure only; leaf-string neutralization happens at the render seam).
 
     A blueprint is a single component node OR a list of nodes (a top-to-bottom
     sequence — the v1 catalog is display-only with no container component).

--- a/src/reyn/core/present/catalog.py
+++ b/src/reyn/core/present/catalog.py
@@ -1,0 +1,193 @@
+"""Declarative UI catalog + blueprint structural gate for present (FP-0054).
+
+The v1 catalog is **display-only / non-executable by construction** — the same
+philosophy as reyn's structural write-gate: safety from the primitive's *shape*,
+not from policy layered on top. A blueprint is data (a component tree), never
+code; the LLM authors *labels + path bindings* only.
+
+Catalog (all read-only): ``text`` / ``markdown`` / ``code`` / ``diff`` /
+``keyvalue`` / ``table`` / ``list`` / ``image``.
+
+Bindings are expressed structurally as ``{"$bind": "<json-pointer>"}`` — a
+single-key object whose value is an RFC 6901 JSON Pointer **string**. This makes
+"bindings are path expressions only" enforceable by shape: a ``$bind`` value
+that is not a pointer string (an expression, a nested object, a list) is rejected
+at parse. Everything that is not a ``$bind`` object is a literal.
+
+The structural gate runs at op validation: a non-catalog component or a non-path
+binding is a hard rejection (``PresentBlueprintError``), not a soft drop —
+soft-skip is for *runtime* binding misses, not for a malformed template.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from reyn.core.present.guard import neutralize_leaf
+
+# Component name → the set of slot keys it accepts. Slots not listed are rejected
+# (keeps the surface tight + the gate exhaustive). ``rows`` / ``columns`` /
+# ``items`` carry nested structure validated specially below.
+CATALOG: dict[str, frozenset[str]] = {
+    "text":     frozenset({"text"}),
+    "markdown": frozenset({"text"}),
+    "code":     frozenset({"text", "language"}),
+    "diff":     frozenset({"text"}),
+    "keyvalue": frozenset({"rows"}),
+    "table":    frozenset({"rows", "columns"}),
+    "list":     frozenset({"items", "item_path"}),
+    "image":    frozenset({"src", "alt"}),
+}
+
+# The text-family components — a whole-body (plain-text ref) binding may only bind
+# into these (§2: structured refs → pointer bindings; plain-text refs → whole-body
+# into text-family only).
+TEXT_FAMILY: frozenset[str] = frozenset({"text", "markdown", "code", "diff"})
+
+_BIND_KEY = "$bind"
+
+
+class PresentBlueprintError(ValueError):
+    """A blueprint failed the structural gate (non-catalog component / non-path
+    binding / malformed slot). A hard rejection — distinct from a runtime binding
+    miss, which soft-skips."""
+
+
+def is_binding(node: Any) -> bool:
+    """True iff ``node`` is a binding object ``{"$bind": "<pointer>"}``."""
+    return isinstance(node, dict) and set(node.keys()) == {_BIND_KEY}
+
+
+def binding_pointer(node: dict) -> str:
+    """The JSON Pointer string of a binding object (assumes ``is_binding``)."""
+    return node[_BIND_KEY]
+
+
+def _validate_pointer(ptr: Any, *, where: str) -> None:
+    """A JSON Pointer (RFC 6901) is a string that is empty (whole-doc) or begins
+    with ``/``. Anything else is a non-path binding → hard reject."""
+    if not isinstance(ptr, str):
+        raise PresentBlueprintError(
+            f"{where}: binding must be a JSON-Pointer string, got {type(ptr).__name__}"
+        )
+    if ptr != "" and not ptr.startswith("/"):
+        raise PresentBlueprintError(
+            f"{where}: binding {ptr!r} is not a JSON Pointer (must be '' or start with '/')"
+        )
+
+
+def _validate_slot_value(value: Any, *, where: str, allow_bind: bool = True) -> None:
+    """A slot value is either a binding object or a literal. A binding is
+    validated as a pointer; a literal must be a JSON scalar/str (no nested
+    component objects smuggling markup)."""
+    if is_binding(value):
+        if not allow_bind:
+            raise PresentBlueprintError(f"{where}: binding not allowed here")
+        _validate_pointer(binding_pointer(value), where=where)
+        return
+    if isinstance(value, dict):
+        # A bare dict that is not a binding is a non-path binding attempt (or an
+        # attempt to nest a component where a value belongs) → reject.
+        raise PresentBlueprintError(
+            f"{where}: expected a literal or a {{'$bind': <pointer>}} binding, got an object"
+        )
+
+
+def _escape_label(label: Any) -> Any:
+    """Neutralize a literal label at parse (FP-0051's fence, generalized): the LLM
+    authors labels, so they are escaped the moment the blueprint is ingested, not
+    only at render. Non-string labels pass through."""
+    if isinstance(label, str):
+        clean, _ = neutralize_leaf(label)
+        return clean
+    return label
+
+
+def _validate_node(node: Any, *, path: str) -> dict:
+    """Validate one component node; return a normalized copy (labels escaped)."""
+    if not isinstance(node, dict):
+        raise PresentBlueprintError(f"{path}: component node must be an object, got {type(node).__name__}")
+    component = node.get("component")
+    if component not in CATALOG:
+        raise PresentBlueprintError(
+            f"{path}: unknown component {component!r} — not in the display-only catalog "
+            f"{sorted(CATALOG)}"
+        )
+    allowed = CATALOG[component]
+    normalized: dict[str, Any] = {"component": component}
+    for key, value in node.items():
+        if key == "component":
+            continue
+        if key not in allowed:
+            raise PresentBlueprintError(
+                f"{path}.{key}: slot {key!r} is not valid for component {component!r} "
+                f"(allowed: {sorted(allowed)})"
+            )
+        normalized[key] = value
+
+    if component in TEXT_FAMILY:
+        if "text" in normalized:
+            _validate_slot_value(normalized["text"], where=f"{path}.text")
+        if component == "code" and "language" in normalized:
+            normalized["language"] = _escape_label(normalized["language"])
+    elif component == "keyvalue":
+        normalized["rows"] = _validate_kv_rows(normalized.get("rows"), path=f"{path}.rows")
+    elif component == "table":
+        _validate_slot_value(normalized.get("rows"), where=f"{path}.rows")
+        normalized["columns"] = _validate_columns(normalized.get("columns"), path=f"{path}.columns")
+    elif component == "list":
+        _validate_slot_value(normalized.get("items"), where=f"{path}.items")
+        if "item_path" in normalized:
+            _validate_pointer(normalized["item_path"], where=f"{path}.item_path")
+    elif component == "image":
+        if "src" in normalized:
+            _validate_slot_value(normalized["src"], where=f"{path}.src")
+        if "alt" in normalized:
+            normalized["alt"] = _escape_label(normalized["alt"])
+    return normalized
+
+
+def _validate_kv_rows(rows: Any, *, path: str) -> list:
+    if not isinstance(rows, list):
+        raise PresentBlueprintError(f"{path}: keyvalue rows must be a list of {{label, value}}")
+    out = []
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or "label" not in row or "value" not in row:
+            raise PresentBlueprintError(f"{path}[{i}]: each keyvalue row needs a label + value")
+        _validate_slot_value(row["value"], where=f"{path}[{i}].value")
+        out.append({"label": _escape_label(row["label"]), "value": row["value"]})
+    return out
+
+
+def _validate_columns(columns: Any, *, path: str) -> list:
+    if not isinstance(columns, list):
+        raise PresentBlueprintError(f"{path}: table columns must be a list of {{header, path}}")
+    out = []
+    for i, col in enumerate(columns):
+        if not isinstance(col, dict) or "header" not in col or "path" not in col:
+            raise PresentBlueprintError(f"{path}[{i}]: each column needs a header + path")
+        # A column path is a row-relative JSON Pointer string (not a $bind object).
+        _validate_pointer(col["path"], where=f"{path}[{i}].path")
+        out.append({"header": _escape_label(col["header"]), "path": col["path"]})
+    return out
+
+
+def validate_blueprint(blueprint: Any) -> list[dict]:
+    """Structurally gate an inline blueprint → a normalized list of component
+    nodes (labels escaped at parse).
+
+    A blueprint is a single component node OR a list of nodes (a top-to-bottom
+    sequence — the v1 catalog is display-only with no container component).
+    Raises ``PresentBlueprintError`` on any non-catalog component or non-path
+    binding.
+    """
+    if isinstance(blueprint, dict):
+        nodes = [blueprint]
+    elif isinstance(blueprint, list):
+        nodes = blueprint
+    else:
+        raise PresentBlueprintError(
+            f"blueprint must be a component object or a list of them, got {type(blueprint).__name__}"
+        )
+    if not nodes:
+        raise PresentBlueprintError("blueprint is empty — nothing to present")
+    return [_validate_node(node, path=f"blueprint[{i}]") for i, node in enumerate(nodes)]

--- a/src/reyn/core/present/guard.py
+++ b/src/reyn/core/present/guard.py
@@ -1,0 +1,91 @@
+"""Presentation-guard — the output-side neutralization boundary for present (FP-0054).
+
+Mirror of the input-side content-guard, applied at the output seam: every leaf
+string that reaches a renderer is threat-scanned and **neutralized** —
+regardless of whether the data was ever ingested by the LLM (the whole point of
+present is blind routing). Two concerns:
+
+- **Neutralize rendered leaf strings** so bound bulk data cannot drive the
+  surface it is displayed on: terminal escape / control sequences (a raw ``ESC``
+  can rewrite / spoof the user's terminal), Rich console markup (``[bold]`` …),
+  and HTML (``<script>`` …). Neutralization is a *transform* — the value still
+  renders, just inert — so no user data is lost; the ref remains the
+  full-fidelity source.
+- **Per-binding size caps** so a ``/`` (root) pointer bound into a ``text``
+  component cannot dump a whole file, and a huge array cannot flood scrollback.
+  Leaf strings cap by characters; arrays cap by row count (head-N + a remainder
+  note the caller composes from the ref).
+
+Pure: no I/O, no events, no config — the caller wires telemetry and decides the
+drop-reason (``guard_stripped``) from the returned ``stripped`` flag.
+"""
+from __future__ import annotations
+
+import re
+
+# Per-binding default caps. A leaf string longer than this is truncated (the
+# ``/`` root-into-text dump guard); an array longer than MAX_ROWS is capped to
+# head-N rows. Both are present-specific defaults — present is unbounded by
+# construction, so it carries its own cap rather than relying on LLM output
+# tokens (which bound ordinary conversation output).
+MAX_LEAF_CHARS: int = 10_000
+MAX_ROWS: int = 500
+
+# C0 control characters except tab / newline / carriage-return, plus the DEL
+# (0x7f) and the C1 range (0x80-0x9f). ``\x1b`` (ESC) — the lead byte of every
+# CSI / OSC terminal escape — is the headline threat; stripping the whole class
+# also removes the trailing sequence bytes so no partial escape survives.
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+# Rich console markup tags: ``[tag]`` / ``[/tag]`` / ``[/]``. Rich's own escape
+# convention is a leading backslash on the ``[`` — we apply exactly that so the
+# tag renders as literal text instead of styling the surface.
+_RICH_TAG_RE = re.compile(r"\[(/?[a-zA-Z#][^\[\]]*|/)\]")
+
+
+def neutralize_leaf(value: str) -> tuple[str, bool]:
+    """Neutralize a single rendered leaf string. Returns ``(clean, stripped)``.
+
+    ``stripped`` is True when the guard materially changed the value — a
+    terminal-escape / control sequence was removed, Rich markup was escaped, or
+    HTML angle brackets were entity-escaped. The caller reports a stripped
+    binding with drop-reason ``guard_stripped``.
+
+    The neutralized value still renders (inert) — this is a transform, not a
+    drop, so the user never loses data (the ref remains authoritative).
+    """
+    out = value
+    # 1. Strip terminal escape / control sequences.
+    out = _CONTROL_RE.sub("", out)
+    # 2. Escape Rich markup tags so they render literally (Rich unescapes a
+    #    leading backslash, so ``\[bold]`` prints as ``[bold]``).
+    out = _RICH_TAG_RE.sub(lambda m: "\\" + m.group(0), out)
+    # 3. Neutralize HTML: entity-escape the structural characters. ``&`` first so
+    #    the entities we introduce below are not themselves re-escaped.
+    if "<" in out or ">" in out or "&" in out:
+        out = out.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return out, out != value
+
+
+def cap_leaf(value: str, *, max_chars: int = MAX_LEAF_CHARS) -> tuple[str, bool]:
+    """Cap a leaf string to ``max_chars``. Returns ``(capped, was_capped)``.
+
+    A capped leaf carries a compact ``… (+N chars)`` tail so the reader knows
+    the value was truncated; the ref remains the full-fidelity escape hatch.
+    A capped binding is reported with drop-reason ``guard_stripped``.
+    """
+    if len(value) <= max_chars:
+        return value, False
+    remainder = len(value) - max_chars
+    return value[:max_chars] + f"… (+{remainder} chars — full data in the ref)", True
+
+
+def cap_rows(rows: list, *, max_rows: int = MAX_ROWS) -> tuple[list, bool]:
+    """Cap an array to ``max_rows`` head rows. Returns ``(capped, was_capped)``.
+
+    Caps BEFORE render (the caller renders only the survivors), so a costly
+    per-row render (syntax highlight etc.) never runs on the truncated tail.
+    """
+    if len(rows) <= max_rows:
+        return rows, False
+    return rows[:max_rows], True

--- a/src/reyn/core/present/guard.py
+++ b/src/reyn/core/present/guard.py
@@ -1,20 +1,29 @@
-"""Presentation-guard — the output-side neutralization boundary for present (FP-0054).
+"""Presentation-guard — the per-surface output neutralization boundary (FP-0054).
 
 Mirror of the input-side content-guard, applied at the output seam: every leaf
-string that reaches a renderer is threat-scanned and **neutralized** —
-regardless of whether the data was ever ingested by the LLM (the whole point of
-present is blind routing). Two concerns:
+string that reaches a renderer — labels, literal slot values, AND bound data
+values alike — passes through ONE neutralizer, selected by the target surface.
+There is no second neutralization path, so no render-leaf can reach a renderer
+un-neutralized. Two concerns:
 
-- **Neutralize rendered leaf strings** so bound bulk data cannot drive the
-  surface it is displayed on: terminal escape / control sequences (a raw ``ESC``
-  can rewrite / spoof the user's terminal), Rich console markup (``[bold]`` …),
-  and HTML (``<script>`` …). Neutralization is a *transform* — the value still
-  renders, just inert — so no user data is lost; the ref remains the
-  full-fidelity source.
-- **Per-binding size caps** so a ``/`` (root) pointer bound into a ``text``
-  component cannot dump a whole file, and a huge array cannot flood scrollback.
-  Leaf strings cap by characters; arrays cap by row count (head-N + a remainder
-  note the caller composes from the ref).
+- **Neutralize rendered leaf strings** per surface so bound data cannot drive the
+  surface it displays on. Neutralization is surface-specific: what is dangerous
+  on a terminal (ESC / control sequences, Rich markup) is not what is dangerous
+  in a browser (HTML). The neutralizer is a **per-surface strategy** (dispatch by
+  surface name), so §6's per-surface boundary is structural, not a conditional —
+  a future ``web`` strategy (HTML-escape) registers here without touching the
+  binding seam.
+- **Per-binding size caps** (surface-agnostic) so a ``/`` (root) pointer bound
+  into a ``text`` component cannot dump a whole file, and a huge array cannot
+  flood scrollback. Leaf strings cap by characters; arrays cap by row count.
+
+The v1 **terminal** strategy does exactly two things: strip ESC / control
+sequences (OSC / CSI — notably OSC-52 clipboard — is a real attack surface on
+every terminal), and **escape** (not strip) Rich console markup so ``[red]``
+renders literally (fidelity-preserving, FP-0051 idiom). It does **not**
+HTML-escape: in a terminal sink ``<div>`` is a harmless literal, and
+entity-escaping would corrupt ``code`` / ``diff`` content (the v1 catalog core).
+HTML neutralization is a future web renderer's concern.
 
 Pure: no I/O, no events, no config — the caller wires telemetry and decides the
 drop-reason (``guard_stripped``) from the returned ``stripped`` flag.
@@ -22,6 +31,7 @@ drop-reason (``guard_stripped``) from the returned ``stripped`` flag.
 from __future__ import annotations
 
 import re
+from typing import Protocol
 
 # Per-binding default caps. A leaf string longer than this is truncated (the
 # ``/`` root-into-text dump guard); an array longer than MAX_ROWS is capped to
@@ -31,10 +41,10 @@ import re
 MAX_LEAF_CHARS: int = 10_000
 MAX_ROWS: int = 500
 
-# C0 control characters except tab / newline / carriage-return, plus the DEL
-# (0x7f) and the C1 range (0x80-0x9f). ``\x1b`` (ESC) — the lead byte of every
-# CSI / OSC terminal escape — is the headline threat; stripping the whole class
-# also removes the trailing sequence bytes so no partial escape survives.
+# C0 control characters except tab / newline / carriage-return, plus DEL (0x7f)
+# and the C1 range (0x80-0x9f). ``\x1b`` (ESC) — the lead byte of every CSI / OSC
+# terminal escape — is the headline threat; stripping the whole class also removes
+# the trailing sequence bytes so no partial escape survives.
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
 # Rich console markup tags: ``[tag]`` / ``[/tag]`` / ``[/]``. Rich's own escape
@@ -43,28 +53,45 @@ _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 _RICH_TAG_RE = re.compile(r"\[(/?[a-zA-Z#][^\[\]]*|/)\]")
 
 
-def neutralize_leaf(value: str) -> tuple[str, bool]:
-    """Neutralize a single rendered leaf string. Returns ``(clean, stripped)``.
+class LeafNeutralizer(Protocol):
+    """A per-surface leaf-string neutralizer. ``neutralize`` returns
+    ``(clean, stripped)`` — ``stripped`` True when the value was materially
+    changed (the caller then reports the binding ``guard_stripped``)."""
 
-    ``stripped`` is True when the guard materially changed the value — a
-    terminal-escape / control sequence was removed, Rich markup was escaped, or
-    HTML angle brackets were entity-escaped. The caller reports a stripped
-    binding with drop-reason ``guard_stripped``.
+    def neutralize(self, value: str) -> tuple[str, bool]:
+        ...
 
-    The neutralized value still renders (inert) — this is a transform, not a
-    drop, so the user never loses data (the ref remains authoritative).
-    """
-    out = value
-    # 1. Strip terminal escape / control sequences.
-    out = _CONTROL_RE.sub("", out)
-    # 2. Escape Rich markup tags so they render literally (Rich unescapes a
-    #    leading backslash, so ``\[bold]`` prints as ``[bold]``).
-    out = _RICH_TAG_RE.sub(lambda m: "\\" + m.group(0), out)
-    # 3. Neutralize HTML: entity-escape the structural characters. ``&`` first so
-    #    the entities we introduce below are not themselves re-escaped.
-    if "<" in out or ">" in out or "&" in out:
-        out = out.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-    return out, out != value
+
+class TerminalNeutralizer:
+    """Terminal-surface strategy: strip ESC / control sequences + escape Rich
+    markup. Does NOT HTML-escape (a terminal renders ``<div>`` as a literal, and
+    entity-escaping would corrupt ``code`` / ``diff`` content)."""
+
+    def neutralize(self, value: str) -> tuple[str, bool]:
+        out = _CONTROL_RE.sub("", value)
+        out = _RICH_TAG_RE.sub(lambda m: "\\" + m.group(0), out)
+        return out, out != value
+
+
+_TERMINAL = TerminalNeutralizer()
+
+# Surface name → neutralizer strategy. v1 ships the terminal strategy; the null
+# renderer (no UI surface yet) uses it too, so the guard runs unconditionally even
+# with no real surface. A future ``web`` strategy (HTML-escape) is added here
+# WITHOUT touching the core seam or the binding layer.
+_STRATEGIES: dict[str, LeafNeutralizer] = {
+    "terminal": _TERMINAL,
+    "null": _TERMINAL,
+}
+_DEFAULT_STRATEGY: LeafNeutralizer = _TERMINAL
+
+
+def get_neutralizer(surface: str) -> LeafNeutralizer:
+    """Select the leaf neutralizer for ``surface`` (defaults to the terminal
+    strategy). The single dispatch point per-surface neutralization flows
+    through — the binding seam asks for a neutralizer by surface, never branches
+    on surface itself."""
+    return _STRATEGIES.get(surface, _DEFAULT_STRATEGY)
 
 
 def cap_leaf(value: str, *, max_chars: int = MAX_LEAF_CHARS) -> tuple[str, bool]:

--- a/src/reyn/core/present/source.py
+++ b/src/reyn/core/present/source.py
@@ -1,0 +1,120 @@
+"""`resolve_present_source` — the single data_ref resolution seam for present (FP-0054).
+
+This is the one point where the present arc meets the tool-result / offload arc. A
+``data_ref`` may be a plain workspace path OR an offload ref (e.g. a
+``structured_ref``). present resolves it by loading the **full value** through the
+same ``file.read`` authority + workspace access the file ops use — so an offloaded
+structured payload is re-hydrated from its ref rather than read from the
+LLM-visible preview, and inline-vs-offloaded is transparent to the renderer.
+
+**Read-authority equivalence (hard invariant).** The gate here is exactly
+``require_file_read`` against the resolved path: present can never read more than
+the agent's ``file.read`` can (present denied ⇔ file.read denied). A denied read
+raises ``PermissionError`` — propagated so the op-dispatch layer returns
+``status="denied"`` (the same channel a denied file op uses).
+
+``ingested`` is **OS-computed** from the events log (was there a prior
+``read_file`` on this ref this session?), never LLM-self-reported.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from reyn.data.workspace.text_codec import decode_text_or_none
+
+if TYPE_CHECKING:
+    from reyn.core.op_runtime.context import OpContext
+
+
+class PresentSourceNotFound(FileNotFoundError):
+    """The ``data_ref`` does not resolve to a readable file (after the read gate
+    passed) — distinct from a permission denial."""
+
+
+async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, str]:
+    """Resolve ``data_ref`` to its full value under ``file.read`` authority.
+
+    Returns ``(value, ingested)`` where ``value`` is the re-hydrated structured
+    object (when the ref's bytes parse as JSON) or the decoded text, and
+    ``ingested`` ∈ ``{none, partial, full}`` (OS-computed).
+
+    Raises ``PermissionError`` when the read is not authorized (identical gate to
+    ``file.read``); ``PresentSourceNotFound`` when the path is missing.
+    """
+    from reyn.core.op_runtime.file import _resolve_for_gate
+
+    resolved = _resolve_for_gate(ctx, data_ref)
+
+    # Read-authority equivalence: the SAME gate file.read uses. bus=None → the
+    # non-interactive deny path; a wired bus → the same JIT prompt.
+    if ctx.permission_resolver is not None:
+        from reyn.core.op_runtime.context import sandbox_policy_from_ctx
+
+        await ctx.permission_resolver.require_file_read(
+            ctx.permission_decl,
+            resolved,
+            ctx.actor,
+            sandbox_policy=sandbox_policy_from_ctx(ctx),
+            bus=ctx.intervention_bus,
+        )
+
+    raw_bytes, found = ctx.workspace.read_file_bytes(data_ref)
+    if not found:
+        raise PresentSourceNotFound(f"present data_ref not found: {data_ref}")
+
+    text, _encoding = decode_text_or_none(raw_bytes)
+    value: Any
+    if text is None:
+        # Non-text binary — present it as an opaque marker (image routing is the
+        # renderer's concern in a later PR); the value is the byte count.
+        value = {"binary": True, "byte_size": len(raw_bytes)}
+    else:
+        value = _rehydrate(text)
+
+    ingested = compute_ingested(ctx, data_ref, resolved)
+    return value, ingested
+
+
+def _rehydrate(text: str) -> Any:
+    """Re-hydrate an offloaded structured ref (JSON bytes) to its object, else
+    keep the plain text. The offload store writes ``json.dumps(...)`` for a
+    ``structured_ref``; a plain-text ref is returned as its string."""
+    import json
+
+    stripped = text.strip()
+    if stripped and stripped[0] in "{[":
+        try:
+            return json.loads(stripped)
+        except (ValueError, TypeError):
+            return text
+    return text
+
+
+def compute_ingested(ctx: "OpContext", data_ref: str, resolved: str) -> str:
+    """Compute ``ingested`` ∈ ``{none, partial, full}`` from the events log.
+
+    Blindness is an audit annotation, not a permission mode: this reports whether
+    a prior ``read_file`` on this ref appears earlier in the session — a full
+    (untruncated) read → ``full``; only truncated reads → ``partial``; no read →
+    ``none``. Never LLM-self-reported.
+    """
+    saw_full = False
+    saw_partial = False
+    for event in ctx.events.all():
+        if event.type != "tool_executed":
+            continue
+        d = event.data
+        if d.get("op") not in ("read_file", "read"):
+            continue
+        path = d.get("path")
+        if path != data_ref and path != resolved:
+            continue
+        if d.get("truncated"):
+            saw_partial = True
+        else:
+            saw_full = True
+    if saw_full:
+        return "full"
+    if saw_partial:
+        return "partial"
+    return "none"

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -171,6 +171,49 @@ class AskUserIROp(BaseModel):
     required: bool = True
 
 
+class PresentIROp(BaseModel):
+    """present op — route bulk data + a display template to the user-facing
+    surface without the data round-tripping through LLM output tokens (FP-0054).
+
+    **Tier 0** (``ask_user``'s sibling): presenting to the user — the trust root —
+    is not an exfiltration channel, so there is no output permission gate. The one
+    gate is that ``data_ref`` read authority resolves **identically to
+    ``file.read``**: present can never read more than the agent's file ops can.
+    Unlike ``ask_user``, present is **fire-and-continue** — it does NOT pause the
+    run.
+
+    Source (exactly one): ``data_ref`` — any zone-readable path; an offloaded
+    ``structured_ref`` is re-hydrated to its full value via ``file.read``
+    semantics — XOR ``data_inline`` — small data already in the LLM's context.
+
+    Template (exactly one): ``template`` — a registered presentation name (the
+    registry + fallback chain land in a later PR) — XOR ``blueprint`` — an inline
+    declarative component tree with JSON-Pointer (RFC 6901) path bindings,
+    structurally gated to the display-only catalog (catalog components only,
+    bindings are path expressions only). No markup / HTML / code ever crosses from
+    the LLM to the renderer.
+    """
+    kind: Literal["present"]
+    data_ref: str | None = None            # XOR data_inline; any zone-readable path
+    data_inline: Any | None = None         # XOR data_ref; small already-in-context data
+    template: str | None = None            # XOR blueprint; a registered presentation name
+    blueprint: dict[str, Any] | list[Any] | None = None  # XOR template; inline component tree
+
+    @model_validator(mode="after")
+    def _exactly_one_source_and_template(self) -> "PresentIROp":
+        # data_inline may legitimately be a falsy value ({} / [] / 0); the
+        # ``is None`` checks distinguish "absent" from "present-but-falsy".
+        if (self.data_ref is None) == (self.data_inline is None):
+            raise ValueError(
+                "present requires exactly one of data_ref / data_inline"
+            )
+        if (self.template is None) == (self.blueprint is None):
+            raise ValueError(
+                "present requires exactly one of template / blueprint"
+            )
+        return self
+
+
 class SandboxedExecIROp(BaseModel):
     """Execute a command under a SandboxPolicy (FP-0017).
 
@@ -630,6 +673,10 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # op_runtime/mcp_get_prompt.py + session.py's _mcp_list_prompts).
     "mcp_get_prompt": MCPGetPromptIROp,
     "ask_user":    AskUserIROp,
+    # FP-0054 PR-A: present bulk data + a display template to the user surface
+    # without the data passing through LLM output tokens. Tier 0 (ask_user's
+    # sibling); the only gate is data_ref read authority == file.read.
+    "present":     PresentIROp,
     "web_fetch":   WebFetchIROp,
     "web_search":  WebSearchIROp,
     "mcp_install": MCPInstallIROp,
@@ -684,6 +731,7 @@ if TYPE_CHECKING:
             MCPSubscribeResourceIROp, MCPUnsubscribeResourceIROp,
             MCPGetPromptIROp,
             AskUserIROp,
+            PresentIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,
             IndexQueryIROp, RecallIROp, IndexDropIROp,

--- a/tests/test_present_op_fp0054_pra.py
+++ b/tests/test_present_op_fp0054_pra.py
@@ -1,0 +1,397 @@
+"""Present op (FP-0054 PR-A) — declarative model + binding + guard + read-authority.
+
+Contract + OS-invariant coverage for the `present` op against a null renderer
+(no UI surface in PR-A). Real Workspace + PermissionResolver + EventLog — no
+collaborator mocks. Assertions are on the public op ack, the resolved-binding
+model, and the `presented` event payload (never private state, never exact
+render layout — there is no renderer yet).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle
+from reyn.core.present import (
+    PresentBlueprintError,
+    resolve_bindings,
+    resolve_pointer,
+    validate_blueprint,
+)
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _resolver(tmp_path: Path, config_permissions: dict | None = None) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config_permissions or {},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _ctx(tmp_path: Path, resolver: PermissionResolver) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=resolver)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="present_test",
+    )
+    return ctx, events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Tier 1: binding resolution ───────────────────────────────────────────────
+
+
+def test_binding_hit_binds_value():
+    """Tier 1: a path hit binds the value into the rendered leaf."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/title"}})
+    out = resolve_bindings(nodes, {"title": "hello world"})
+    assert out.bindings_resolved == 1
+    assert out.bindings_dropped == []
+    assert out.nodes[0]["text"] == "hello world"
+
+
+def test_binding_miss_soft_skips_and_records_path_not_found():
+    """Tier 1: a path miss soft-skips the binding + records path_not_found — never
+    a hard failure."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/absent"}})
+    out = resolve_bindings(nodes, {"title": "x"})
+    assert out.bindings_resolved == 0
+    assert {"path": "/absent", "reason": "path_not_found"} in out.bindings_dropped
+    # soft-skip: the leaf is simply absent, no exception, other structure intact.
+    assert out.nodes[0]["component"] == "text"
+
+
+def test_scalar_into_table_coerces_to_one_row_type_mismatch():
+    """Tier 1: a scalar bound into a table rows slot coerces to a 1-row table +
+    records type_mismatch (the §4 coercion rule)."""
+    nodes = validate_blueprint({
+        "component": "table",
+        "rows": {"$bind": "/x"},
+        "columns": [],
+    })
+    out = resolve_bindings(nodes, {"x": "just-a-scalar"})
+    assert out.rows == 1
+    assert {"path": "/x", "reason": "type_mismatch"} in out.bindings_dropped
+
+
+def test_row_relative_column_paths_resolve_per_row():
+    """Tier 1: table column paths resolve row-relative (RFC 6901 relative to each
+    iterated row); a column that misses on ALL rows records one path_not_found."""
+    nodes = validate_blueprint({
+        "component": "table",
+        "rows": {"$bind": "/results"},
+        "columns": [
+            {"header": "Title", "path": "/title"},
+            {"header": "Author", "path": "/author"},
+        ],
+    })
+    data = {"results": [{"title": "A", "author": "amy"}, {"title": "B", "author": "bob"}]}
+    out = resolve_bindings(nodes, data)
+    cols = {c["header"]: c["cells"] for c in out.nodes[0]["columns"]}
+    assert cols["Title"] == ["A", "B"]
+    assert cols["Author"] == ["amy", "bob"]
+    # No column missed → no path_not_found drops.
+    assert all(d["reason"] != "path_not_found" for d in out.bindings_dropped)
+
+
+def test_column_missing_on_all_rows_records_path_not_found():
+    """Tier 1: a column path absent from every row records exactly one
+    path_not_found (template/data shape mismatch), not one-per-row noise."""
+    nodes = validate_blueprint({
+        "component": "table",
+        "rows": {"$bind": "/results"},
+        "columns": [{"header": "Author", "path": "/author"}],
+    })
+    data = {"results": [{"title": "A"}, {"title": "B"}]}
+    out = resolve_bindings(nodes, data)
+    drops = [d for d in out.bindings_dropped if d["reason"] == "path_not_found"]
+    assert drops == [{"path": "/author", "reason": "path_not_found"}]
+
+
+def test_all_bindings_missed_outcome_exposed():
+    """Tier 1: when every binding misses, all_bindings_missed is True (the
+    generic-viewer fallback signal); still no hard failure."""
+    nodes = validate_blueprint([
+        {"component": "text", "text": {"$bind": "/nope1"}},
+        {"component": "text", "text": {"$bind": "/nope2"}},
+    ])
+    out = resolve_bindings(nodes, {"real": 1})
+    assert out.bindings_resolved == 0
+    assert out.all_bindings_missed is True
+
+
+def test_literal_only_blueprint_is_not_all_missed():
+    """Tier 1: a blueprint with no bindings (literals only) never reports
+    all_bindings_missed (there were no bindings to miss)."""
+    nodes = validate_blueprint({"component": "text", "text": "a literal heading"})
+    out = resolve_bindings(nodes, {})
+    assert out.all_bindings_missed is False
+
+
+def test_resolve_pointer_rfc6901_whole_doc_and_escapes():
+    """Tier 1: JSON Pointer resolution — '' is the whole document; '~1'/'~0'
+    decode to '/'/'~'; out-of-range/absent → not found."""
+    doc = {"a/b": {"c~d": 7}, "arr": [10, 20]}
+    assert resolve_pointer(doc, "") == (doc, True)
+    assert resolve_pointer(doc, "/a~1b/c~0d") == (7, True)
+    assert resolve_pointer(doc, "/arr/1") == (20, True)
+    assert resolve_pointer(doc, "/arr/9")[1] is False
+    assert resolve_pointer(doc, "/missing")[1] is False
+
+
+# ── Tier 1: ack shape (drop reason categories) ───────────────────────────────
+
+
+def test_ack_shape_reports_drops_with_reason_categories(tmp_path):
+    """Tier 1: the op ack carries {ok, bindings_resolved, bindings_dropped, rows}
+    with each drop as {path, reason} in the three reason categories."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = PresentIROp(
+        kind="present",
+        data_inline={"results": [{"title": "A"}], "big": {"nested": "obj"}},
+        blueprint=[
+            {"component": "table", "rows": {"$bind": "/results"},
+             "columns": [{"header": "Missing", "path": "/author"}]},
+            {"component": "text", "text": {"$bind": "/big"}},  # dict into text → type_mismatch
+        ],
+    )
+    ack = _run(handle(op, ctx))
+    assert ack["ok"] is True
+    assert set(ack.keys()) >= {"ok", "bindings_resolved", "bindings_dropped", "rows"}
+    reasons = {d["reason"] for d in ack["bindings_dropped"]}
+    assert "path_not_found" in reasons
+    assert "type_mismatch" in reasons
+    for drop in ack["bindings_dropped"]:
+        assert set(drop.keys()) == {"path", "reason"}
+        assert drop["reason"] in {"path_not_found", "type_mismatch", "guard_stripped"}
+
+
+# ── Tier 1: blueprint structural gate ────────────────────────────────────────
+
+
+def test_non_catalog_component_rejected():
+    """Tier 1: a component outside the display-only catalog is a hard rejection."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "button", "text": "click me"})
+
+
+def test_non_path_binding_rejected():
+    """Tier 1: a binding whose value is not a JSON-Pointer string is rejected
+    (bindings are path expressions only — no smuggled objects/expressions)."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "text", "text": {"$bind": {"expr": "1+1"}}})
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "text", "text": {"$bind": "not-a-pointer"}})
+
+
+def test_unknown_slot_rejected():
+    """Tier 1: a slot not in a component's allowed set is rejected (tight surface)."""
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "text", "onclick": "evil()"})
+
+
+# ── Tier 1: presentation-guard (escape survival, FP-0051 idiom) ──────────────
+
+
+def test_terminal_escape_in_data_is_neutralized_not_rendered():
+    """Tier 1: a terminal escape sequence in bound data is neutralized (never
+    reaches the rendered leaf) + the binding is recorded guard_stripped.
+
+    FP-0051 idiom: the literal control byte in the data must not survive into the
+    surface-bound value."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/v"}})
+    out = resolve_bindings(nodes, {"v": "safe\x1b[31mINJECT\x1b[0m"})
+    rendered = out.nodes[0]["text"]
+    assert "\x1b" not in rendered           # the ESC control byte is gone
+    assert "INJECT" in rendered             # the human-readable text survives (inert)
+    assert {"path": "/v", "reason": "guard_stripped"} in out.bindings_dropped
+
+
+def test_rich_markup_in_data_is_escaped_literal():
+    """Tier 1: Rich markup in bound data is escaped so it renders literally (the
+    bracket survives as text, the styling does not drive the surface)."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/v"}})
+    out = resolve_bindings(nodes, {"v": "[bold red]owned[/bold red]"})
+    rendered = out.nodes[0]["text"]
+    # The literal bracket text is preserved but escaped (backslash-guarded), so
+    # Rich will not interpret it as a style tag.
+    assert "bold red" in rendered
+    assert "\\[" in rendered
+    assert {"path": "/v", "reason": "guard_stripped"} in out.bindings_dropped
+
+
+def test_root_pointer_into_text_is_size_capped():
+    """Tier 1: a `/` (root) pointer bound into a text component is size-capped
+    (the whole-file-dump guard) + recorded guard_stripped."""
+    from reyn.core.present.guard import MAX_LEAF_CHARS
+
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": ""}})
+    huge = "x" * (MAX_LEAF_CHARS + 5000)
+    out = resolve_bindings(nodes, huge)
+    assert len(out.nodes[0]["text"]) < len(huge)
+    assert {"path": "", "reason": "guard_stripped"} in out.bindings_dropped
+
+
+def test_labels_escaped_at_parse():
+    """Tier 1: literal labels (column headers / kv labels) are neutralized at
+    parse (FP-0051 fence generalized), before any data binding."""
+    nodes = validate_blueprint({
+        "component": "keyvalue",
+        "rows": [{"label": "name\x1b[31m", "value": "v"}],
+    })
+    assert "\x1b" not in nodes[0]["rows"][0]["label"]
+
+
+# ── Tier 1: presented event field presence + OS-computed ingested ────────────
+
+
+def test_presented_event_carries_required_fields(tmp_path):
+    """Tier 1: the presented (P6) event carries the required audit fields incl.
+    surface + OS-computed ingested + the drop list."""
+    ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    op = PresentIROp(
+        kind="present", data_inline={"a": 1},
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    _run(handle(op, ctx))
+    ev = [e for e in events.all() if e.type == "presented"]
+    assert ev, "present emitted no presented event"
+    d = ev[-1].data
+    for field in ("data_ref", "template", "surface", "ingested",
+                  "bindings_resolved", "bindings_dropped", "rows"):
+        assert field in d
+    assert d["ingested"] in {"none", "partial", "full"}
+
+
+def test_ingested_is_os_computed_from_prior_read(tmp_path, monkeypatch):
+    """Tier 1: ingested is OS-computed from the events log — a prior full read_file
+    on the ref → 'full'; no prior read → 'none'. Never LLM-self-reported."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "ref.json").write_text(json.dumps({"a": 1}))
+    ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+
+    op = PresentIROp(
+        kind="present", data_ref="ref.json",
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    _run(handle(op, ctx))
+    first = [e for e in events.all() if e.type == "presented"][-1]
+    assert first.data["ingested"] == "none"
+
+    # Simulate a prior full read of the ref, then present again → 'full'.
+    events.emit("tool_executed", op="read_file", path="ref.json")
+    _run(handle(op, ctx))
+    second = [e for e in events.all() if e.type == "presented"][-1]
+    assert second.data["ingested"] == "full"
+
+
+def test_ingested_partial_on_truncated_read(tmp_path, monkeypatch):
+    """Tier 1: only a truncated prior read on the ref → 'partial'."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "ref.json").write_text(json.dumps({"a": 1}))
+    ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    events.emit("tool_executed", op="read_file", path="ref.json", truncated=True)
+    op = PresentIROp(
+        kind="present", data_ref="ref.json",
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    _run(handle(op, ctx))
+    ev = [e for e in events.all() if e.type == "presented"][-1]
+    assert ev.data["ingested"] == "partial"
+
+
+# ── Tier 1: read-authority equivalence (present denied ⇔ file.read denied) ────
+
+
+def test_present_denied_iff_file_read_denied(tmp_path, monkeypatch):
+    """Tier 1: present's data_ref read gate is identical to file.read — a config
+    file.read:deny denies BOTH. Real resolver (not None); falsify direction below."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "ref.json").write_text(json.dumps({"a": 1}))
+    deny = _resolver(tmp_path, {"file": {"read": "deny"}})
+    ctx, _events = _ctx(tmp_path, deny)
+
+    op = PresentIROp(
+        kind="present", data_ref="ref.json",
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    # present denied
+    ack = _run(execute_op(op, ctx))
+    assert ack["status"] == "denied"
+    # file.read denied on the same path (equivalence)
+    with pytest.raises(PermissionError):
+        _run(deny.require_file_read(PermissionDecl(), str(tmp_path / "ref.json"), "present_test"))
+
+
+def test_present_allowed_when_file_read_allowed(tmp_path, monkeypatch):
+    """Tier 1: falsify direction — with read allowed (default CWD zone), present
+    resolves the ref and returns ok, so the deny above is not a blanket refusal."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "ref.json").write_text(json.dumps({"a": 42}))
+    allow = _resolver(tmp_path)
+    ctx, _events = _ctx(tmp_path, allow)
+
+    op = PresentIROp(
+        kind="present", data_ref="ref.json",
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    # file.read allowed on the same path
+    _run(allow.require_file_read(PermissionDecl(), str(tmp_path / "ref.json"), "present_test"))
+    ack = _run(execute_op(op, ctx))
+    assert ack["status"] == "ok"
+    assert ack["ok"] is True
+    assert ack["bindings_resolved"] == 1
+
+
+# ── Tier 2: fire-and-continue + no content bytes in the event ────────────────
+
+
+def test_fire_and_continue_does_not_pause_the_run(tmp_path):
+    """Tier 2: present is fire-and-continue — unlike ask_user it needs NO
+    intervention_bus and returns a result without pausing (a pausing op would
+    raise without a bus)."""
+    resolver = _resolver(tmp_path)
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=resolver)
+    # intervention_bus deliberately left None (the ask_user pause dependency).
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="present_test", intervention_bus=None,
+    )
+    op = PresentIROp(
+        kind="present", data_inline={"a": 1},
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    ack = _run(handle(op, ctx))
+    assert ack["status"] == "ok"
+
+
+def test_event_carries_no_content_bytes(tmp_path):
+    """Tier 2: the presented event payload carries refs + stats only — the bound
+    data values never appear in the audit event (data is durable in the ref)."""
+    ctx, events = _ctx(tmp_path, _resolver(tmp_path))
+    secret_value = "UNIQUE_SENTINEL_CONTENT_9f3a"
+    op = PresentIROp(
+        kind="present", data_inline={"a": secret_value},
+        blueprint={"component": "text", "text": {"$bind": "/a"}},
+    )
+    _run(handle(op, ctx))
+    ev = [e for e in events.all() if e.type == "presented"][-1]
+    serialized = json.dumps(ev.data)
+    assert secret_value not in serialized

--- a/tests/test_present_op_fp0054_pra.py
+++ b/tests/test_present_op_fp0054_pra.py
@@ -248,14 +248,55 @@ def test_root_pointer_into_text_is_size_capped():
     assert {"path": "", "reason": "guard_stripped"} in out.bindings_dropped
 
 
-def test_labels_escaped_at_parse():
-    """Tier 1: literal labels (column headers / kv labels) are neutralized at
-    parse (FP-0051 fence generalized), before any data binding."""
+def test_labels_neutralized_at_render_seam():
+    """Tier 1: literal labels (kv labels / column headers) are neutralized through
+    the single render seam (not at parse). The structural gate keeps them raw;
+    resolve_bindings neutralizes every render-leaf including labels."""
+    raw = "name\x1b[31m"
     nodes = validate_blueprint({
         "component": "keyvalue",
-        "rows": [{"label": "name\x1b[31m", "value": "v"}],
+        "rows": [{"label": raw, "value": "v"}],
     })
-    assert "\x1b" not in nodes[0]["rows"][0]["label"]
+    # Structural gate is purely structural — the label is still raw here.
+    assert nodes[0]["rows"][0]["label"] == raw
+    # The single seam neutralizes it in the render model.
+    out = resolve_bindings(nodes, {})
+    assert "\x1b" not in out.nodes[0]["rows"][0]["label"]
+
+
+def test_literal_text_slot_value_is_neutralized_via_single_seam():
+    """Tier 1: an LLM-authored LITERAL (non-$bind) escape / Rich-markup in a
+    text-family slot is neutralized + reported guard_stripped — the same standard
+    as a bound value (single-seam: no literal bypasses the guard). RED against the
+    pre-unification code where text-slot literals were only size-capped."""
+    nodes = validate_blueprint(
+        {"component": "text", "text": "safe\x1b[31mINJECT\x1b[0m [bold]owned[/bold]"}
+    )
+    out = resolve_bindings(nodes, {})
+    rendered = out.nodes[0]["text"]
+    assert "\x1b" not in rendered          # ESC control byte gone
+    assert "INJECT" in rendered            # readable text survives (inert)
+    assert "\\[" in rendered               # Rich markup escaped literal
+    assert any(d["reason"] == "guard_stripped" for d in out.bindings_dropped)
+
+
+def test_terminal_neutralizer_does_not_html_escape_code_content():
+    """Tier 1: the terminal neutralizer does NOT HTML-escape — a `<div>` in a
+    `code`/`diff` slot survives literally (no entity-escape corruption). HTML
+    neutralization is a future web renderer's job, not the terminal's."""
+    # Bound value into a code slot.
+    nodes = validate_blueprint({"component": "code", "text": {"$bind": "/src"}})
+    out = resolve_bindings(nodes, {"src": "<div class='x'>y & z</div>"})
+    rendered = out.nodes[0]["text"]
+    assert rendered == "<div class='x'>y & z</div>"   # byte-for-byte survival
+    assert "&lt;" not in rendered and "&amp;" not in rendered
+    # No terminal-dangerous content → not stripped.
+    assert all(d["reason"] != "guard_stripped" for d in out.bindings_dropped)
+
+    # Same for a literal in a code slot.
+    nodes2 = validate_blueprint({"component": "code", "text": "<p>&nbsp;</p>"})
+    out2 = resolve_bindings(nodes2, {})
+    assert out2.nodes[0]["text"] == "<p>&nbsp;</p>"
 
 
 # ── Tier 1: presented event field presence + OS-computed ingested ────────────


### PR DESCRIPTION
**[per-PR-coder]** — This is **PR-A** of the present-layer arc. Design doc (owner-ratified, on main): `docs/deep-dives/proposals/0054-present-layer.md`. Part of the present-layer arc; PR-B (inline-CUI renderer), PR-C (presentations.yaml registry + fallback chain), PR-D (replay/rewind + docs) follow. Uses `part of`/`toward` phrasing — no closing keyword (sub-PR).

## Scope (exactly the doc's "PR-A")

`present` op + declarative model + binding resolution + presentation-guard core. **No UI yet** — the op returns its ack against a **null renderer** (`surface: ["null"]`).

### Op contract
- **Tier 0** (`ask_user`'s sibling), **fire-and-continue** — does NOT pause the run.
- **Arg validation** (pydantic `model_validator`): `data_ref` **XOR** `data_inline`; `template` **XOR** `blueprint`. `is None` checks distinguish absent from present-but-falsy (so `data_inline: {}` is valid).
- **Ack** (the LLM's only feedback): `{ok, bindings_resolved, bindings_dropped, rows}` where `bindings_dropped` is a list of `{path, reason}`, `reason ∈ {path_not_found, type_mismatch, guard_stripped}` (the refined d24d72e shape). Plus `all_bindings_missed` (generic-viewer fallback signal; the actual fallback wiring is PR-C).

### Declarative model (display-only, non-executable by construction)
Catalog: `text`/`markdown`/`code`/`diff`/`keyvalue`/`table`/`list`/`image`. Bindings expressed structurally as `{"$bind": "<json-pointer>"}` — an RFC 6901 pointer **string**; everything else is a literal. Structural gate at op validation rejects non-catalog components and non-path bindings (hard error, not a soft drop); labels escaped at parse (FP-0051 fence generalized).

### Binding resolution
JSON Pointer (RFC 6901); table/list column paths resolve **row-relative**. Hit → bind; miss → soft-skip + `path_not_found`; type mismatch → coercion (scalar into table `rows` → 1 row) + `type_mismatch`; all-miss → `all_bindings_missed` exposed.

### `resolve_present_source` + read-authority equivalence
`resolve_present_source(data_ref, ctx)` is the single 2-arc junction: it gates via the **same `require_file_read`** call the file ops use (resolved through `_resolve_for_gate`), then reads the ref and re-hydrates an offloaded `structured_ref` (JSON bytes → object) to its full value — offloaded-vs-inline transparent to the caller. A denied read raises `PermissionError` → dispatch returns `status="denied"`. **Invariant: present denied ⇔ file.read denied** (tested both directions with a REAL `PermissionResolver`, config `file.read: deny` + falsify allow).

### Presentation-guard
Runs **unconditionally** (incl. never-ingested data): neutralizes terminal escape/control sequences (`\x1b…`), Rich markup (`[tag]` → `\[tag]`), HTML (entity-escape) on every rendered leaf; **per-binding size caps** (leaf chars + row count) prevent a `/` root pointer dumping a whole file. A neutralized/capped binding is reported `guard_stripped`.

### `presented` event (P6)
`{data_ref, template, surface, ingested, bindings_resolved, bindings_dropped, rows}`. **No content bytes** (refs + stats only). `ingested` (none|partial|full) is **OS-computed** from the events log (prior `read_file` on the ref?), never LLM-self-reported.

### #1983 hard rule
`OP_KIND_MODEL_MAP` (`src/reyn/schemas/models.py`) ↔ `docs/reference/runtime/control-ir.md` sync is **in this PR**: `present` added to the map (+ TYPE_CHECKING union mirror) AND a full `## present` section + table row in control-ir.md.

### Recovery gate
**N/A** (per doc §8): `present` writes no WAL-event-derived reconstruction state; the `presented` event is durable audit, not recovery-core state. The truncate-falsify gate does not apply.

## Judgment calls (flagged for review)
1. **Binding marker `{"$bind": "<pointer>"}`.** The doc mandates "bindings are path expressions only" / JSON Pointer but doesn't fix the literal-vs-binding syntax. I chose a single-key `$bind` object so the "path-only" rule is enforceable by shape (a `$bind` value that isn't a pointer string is rejected). Alternative (a `$`-prefixed string convention) is more terse but harder to gate cleanly.
2. **Blueprint top-level = node | list[node].** The v1 catalog has no container component, so I made a blueprint either a single node or a flat sequence (rendered top-to-bottom). No nesting/children.
3. **`surface: ["null"]` in PR-A.** The doc's event example shows `surface: [inline-cui]`, but PR-A has no renderer — I emit `["null"]` (honest; PR-B swaps in the real surface).
4. **Named `template` deferred to PR-C.** PR-A resolves inline blueprints only; a `template` arg is accepted at the schema level but the handler returns `ok=False` + a `note` (audit event still emitted). The registry + 4-stage fallback are explicitly PR-C.
5. **`guard_stripped`/`type_mismatch` count as resolved AND flagged.** They render (coerced/neutralized), so they increment `bindings_resolved` and appear in `bindings_dropped` as issues; only `path_not_found` is a true non-render. `bindings_dropped` is thus an "issues" list keyed by reason (matches the doc's ack example carrying all three reasons together).
6. **`ingested` for `data_inline` = `full`** (data is in the LLM's context by construction).

## Gates (all four, from repo root — pytest-green ≠ CI-green)
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_present_op_fp0054_pra.py` — Exit 0 (0 Tier-4 violations)
- [x] `pytest` — 7569 passed; the only 5 failures (`test_fp0001_a2a_endpoints`, `test_a2a`, `test_mcp_sse`, `test_plugin_loader`, `test_resources_router`) are the known pre-existing route-mount failures — confirmed via `git stash` that they reproduce identically on clean main; none in files this PR touches.
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK (no refactor narrative)

## Test plan
- [x] Tier 1: binding hit / miss→soft-skip / scalar-into-table coercion / row-relative column paths / column-missing-on-all-rows / all-miss / JSON-Pointer RFC 6901 (whole-doc + `~0`/`~1` escapes)
- [x] Tier 1: ack shape — drops as `{path, reason}` across all three reason categories
- [x] Tier 1: blueprint structural gate — non-catalog component rejected, non-path binding rejected, unknown slot rejected
- [x] Tier 1: guard — terminal escape neutralized (not rendered) via literal-bracket FP-0051 idiom; Rich markup escaped literal; `/` root size-capped; labels escaped at parse
- [x] Tier 1: `presented` event field presence incl. OS-computed `ingested` (none/partial/full from prior read)
- [x] Tier 1: read-authority equivalence — present denied ⇔ file.read denied (real resolver) + falsify (allowed) direction
- [x] Tier 2: fire-and-continue (no intervention_bus needed, run not paused); no content bytes in the event payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)