### PR TITLE
docs: refine present-layer §5 to per-surface neutralizer strategy (PR-A review adjudication)

### DIFF
--- a/docs/deep-dives/proposals/0054-present-layer.md
+++ b/docs/deep-dives/proposals/0054-present-layer.md
@@ -202,9 +202,27 @@ registered template (operator-owned) → inline blueprint (LLM-authored, catalog
 
 Mirror of the input-side content-guard, at the output boundary:
 
-- Threat scan + neutralization of rendered leaf strings: terminal escape sequences,
-  Rich markup, HTML — per target surface. Runs **unconditionally**, including (and
-  especially) for never-ingested data.
+- **Per-surface neutralizer strategy.** Neutralization of rendered leaf strings is a
+  strategy *selected by the target surface*, not a single uniform strip — what is
+  dangerous depends on the sink. Runs **unconditionally**, including (and especially) for
+  never-ingested data. Applied to **every** render-leaf string (label, literal, and
+  bound value) at one seam — never split "escape labels at parse / neutralize bound
+  values at bind", which leaves literal strings unguarded.
+  - **Terminal (v1, inline-CUI / Rich):** *strip* control / ESC sequences (always
+    dangerous — OSC / CSI, notably OSC-52 clipboard) and *escape* Rich console markup
+    (escape, not strip — `[red]` survives as literal text, preserving fidelity;
+    FP-0051 idiom). **No HTML-escaping** on this surface: `<div>` is inert literal text
+    in a terminal, and HTML-escaping would corrupt `<`/`>`/`&` in `code`/`diff` (core
+    v1 catalog) — a category error (neutralizing a threat that does not exist at this
+    sink).
+  - **Web (future):** HTML/JS escaping is *this* surface's neutralizer, shipped with the
+    web renderer — not applied on the terminal path. Structuring neutralization
+    per-surface (even with one surface in v1) lets the web strategy plug in without
+    touching the core (§ 6 per-surface boundary; structural write-gate).
+  - **Renderer note (PR-B):** Rich `Syntax` (code/diff) and `Text` are markup-inert, so
+    content routed to them must **not** be double-handled — the Rich-markup escape is for
+    markup-interpreting paths (`Markdown`), while `Syntax`/`Text` receive the raw
+    (control-stripped) string. Resolved in the PR-B renderer, not the guard core.
 - **Per-binding size caps** — prevents `/` (root) bound into a `text` component from
   dumping an entire file.
 - **Default output cap (present-specific — not a scrollback pager).** The inline-CUI


### PR DESCRIPTION
**[architect]** — Design-record refinement of §5 (presentation-guard), resolving the per-surface escape boundary raised during PR-A (#2658) review.

## Decision (adjudicated)
Neutralization is a **per-surface strategy** selected by the target sink, applied at **one seam** to every render-leaf string (label, literal, and bound value) — closing the class of bug where literal text-slot strings bypassed the guard while only bound values were neutralized.

- **Terminal (v1)**: strip control/ESC sequences (OSC-52 clipboard etc.) + escape Rich console markup (preserve `[red]` as literal). **No HTML-escape** — it would corrupt `<`/`>`/`&` in `code`/`diff` (core v1 catalog) while neutralizing a threat that does not exist at a terminal sink (category error).
- **Web (future)**: HTML/JS escaping is that surface's strategy, shipped with the web renderer — structured per-surface so it plugs in without touching the core (§6 boundary; structural write-gate).
- **PR-B renderer note**: Rich `Syntax`/`Text` are markup-inert; content routed to them must not be double-handled.

Pairs with the PR-A source fix (unify leaf neutralization; add literal-escape test). Docs-only; `deep-dives/` excluded from public mkdocs.

## Test plan
- [x] (skipped — docs-only) No src/tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
