### PR TITLE
feat: inline-CUI present renderer + guard/renderer Rich-markup re-layering (FP-0054 PR-B)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -205,13 +205,20 @@ never-ingested data. Every render-leaf string — labels, literal slot values, A
 bound data values — passes through ONE neutralizer, selected by the target
 **surface** (a per-surface strategy, so a future web surface slots in without
 touching the binding layer). The v1 **terminal** strategy strips ESC / control
-sequences (OSC / CSI) and **escapes** (not strips) Rich console markup so `[red]`
-renders literally; it does **not** HTML-escape — in a terminal `<div>` is a
-harmless literal, and entity-escaping would corrupt `code` / `diff` content (HTML
-neutralization is a future web renderer's concern). **Per-binding size caps**
-prevent a `/` (root) pointer bound into a `text` component from dumping a whole
-file. Neutralization is a transform (the value still renders, inert) — the ref
-remains the full-fidelity source.
+sequences (OSC / CSI) only; it does **not** escape Rich console markup and does
+**not** HTML-escape. Rich-markup safety is deliberately NOT this seam's job (PR-B
+revision): Rich console-markup injection is reachable only through
+`console.print(str, markup=True)` — a choice the *renderer* makes per Rich
+object, not a property of the terminal sink. The inline-CUI renderer routes
+every leaf into a markup-inert Rich object (`Text` / `Syntax` / `Markdown`) and
+never calls `console.print` with markup interpretation on presented content, so
+Rich injection is structurally impossible regardless of what the guard does — the
+same "safety from shape, not policy" discipline as the guard's own ESC-strip.
+HTML neutralization stays a future web renderer's own concern (in a terminal
+`<div>` is a harmless literal, and entity-escaping would corrupt `code` / `diff`
+content). **Per-binding size caps** prevent a `/` (root) pointer bound into a
+`text` component from dumping a whole file. Neutralization is a transform (the
+value still renders, inert) — the ref remains the full-fidelity source.
 
 **Ack (op result)** — the LLM's only feedback, deliberately compact + high-signal:
 
@@ -235,10 +242,15 @@ bindings_resolved, bindings_dropped, rows}`. `ingested` (`none` | `partial` |
 appear earlier in the session), never LLM-self-reported. The event carries **refs
 + stats only, never content bytes** (the data is already durable in the ref).
 
-> PR-A scope: the model + binding + guard run against a **null renderer**
-> (`surface: ["null"]`) — there is no UI surface yet. The inline-CUI renderer,
-> `presentations.yaml` registry + fallback chain, and replay/rewind rendering land
-> in later PRs.
+> PR-B: the inline-CUI renderer is wired (`surface: ["inline-cui"]` when a chat
+> session's `OpContext.presentation_renderer` is set; `["null"]` otherwise — e.g.
+> a bare `OpContext` built without one, PR-A's original behavior). It renders
+> `ResolvedPresentation.nodes` as a one-shot inline block in the conversation
+> scrollback (`interfaces/repl/present_renderer.py`, riding the existing Rich
+> `Console` → `StringIO` → `run_in_terminal()` pattern), with an explicit
+> per-render terminal width (Rich cannot auto-detect width writing to a
+> `StringIO`). `presentations.yaml` registry + fallback chain, and replay/rewind
+> rendering land in later PRs.
 
 ## `sandboxed_exec`
 

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from reyn.config import MultimodalConfig, SandboxConfig, WebConfig
     from reyn.core.events.events import EventLog
     from reyn.core.events.state_log import StateLog
+    from reyn.core.present import PresentationRenderer
     from reyn.data.workspace.media_store import MediaStore
     from reyn.data.workspace.workspace import Workspace
     from reyn.llm.model_resolver import ModelResolver
@@ -79,6 +80,11 @@ class OpContext:
     # User interventions (ask_user, permission prompts in PR7)
     intervention_bus: "RequestBus | None" = None
     current_phase: str = ""
+
+    # FP-0054 PR-B: the surface a `present` op renders to. None = PR-A's null-surface
+    # behavior (no UI reached, resolve_bindings(surface="null")). A wired renderer names
+    # its own `surface_name` (e.g. inline-CUI's OutboxPresentationRenderer = "inline-cui").
+    presentation_renderer: "PresentationRenderer | None" = None
 
     # #272/#1128: voluntary-compaction capability for the `compact` op.
     # An awaitable zero-arg callable the caller (Session / phase runtime)

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -1,4 +1,4 @@
-"""present kind handler — route bulk data + a display template to the user (FP-0054 PR-A).
+"""present kind handler — route bulk data + a display template to the user (FP-0054 PR-A/PR-B).
 
 **Tier 0** (``ask_user``'s sibling) and **fire-and-continue**: unlike ``ask_user``
 this op does NOT pause the run — it produces a presentation ack and returns. The
@@ -6,12 +6,12 @@ only gate is that ``data_ref`` read authority resolves identically to
 ``file.read`` (in ``resolve_present_source``); a denied read raises
 ``PermissionError`` and the dispatch layer returns ``status="denied"``.
 
-PR-A scope: the declarative model + binding resolution + presentation-guard run
-against a **null renderer** — there is no UI surface yet (the inline-CUI renderer
-is a later PR). The op returns the compact, high-signal ack
-(``{ok, bindings_resolved, bindings_dropped, rows}``, drops as
-``{path, reason}``) and emits the ``presented`` P6 event (refs + stats, never
-content bytes).
+The surface is whichever ``OpContext.presentation_renderer`` the caller wired (PR-B: the
+inline-CUI's ``OutboxPresentationRenderer``, ``runtime/session_buses.py``) — ``None`` keeps
+PR-A's null-surface behavior (no UI reached, ``surface="null"``). The op returns the
+compact, high-signal ack (``{ok, bindings_resolved, bindings_dropped, rows}``, drops as
+``{path, reason}``) and emits the ``presented`` P6 event (refs + stats, never content
+bytes) regardless of whether a renderer is wired.
 """
 from __future__ import annotations
 
@@ -31,9 +31,7 @@ from reyn.schemas.models import PresentIROp
 from . import register
 from .context import OpContext
 
-# The PR-A surface: there is no UI renderer yet, so present renders against a
-# null renderer (no bytes reach any surface). Later PRs add "inline-cui" etc.
-_NULL_SURFACE = ["null"]
+_NULL_SURFACE = "null"
 
 _INLINE_MARKER = "<inline-data>"
 
@@ -49,11 +47,19 @@ def _template_id(op: PresentIROp) -> str:
     return f"blueprint:{digest[:16]}"
 
 
+def _surface_name(ctx: OpContext) -> str:
+    """The surface a resolved presentation reaches: the wired renderer's own name, or
+    the PR-A null surface when none is wired."""
+    renderer = ctx.presentation_renderer
+    return renderer.surface_name if renderer is not None else _NULL_SURFACE
+
+
 def _emit_presented(
     ctx: OpContext,
     *,
     data_ref: str,
     template: str,
+    surface: str,
     ingested: str,
     bindings_resolved: int,
     bindings_dropped: list[dict],
@@ -68,7 +74,7 @@ def _emit_presented(
         phase=ctx.current_phase,
         data_ref=data_ref,
         template=template,
-        surface=list(_NULL_SURFACE),
+        surface=[surface],
         ingested=ingested,
         bindings_resolved=bindings_resolved,
         bindings_dropped=bindings_dropped,
@@ -95,14 +101,15 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
         data_ref_field = _INLINE_MARKER
 
     template_id = _template_id(op)
+    surface = _surface_name(ctx)
 
     # 2. Named-template resolution (registry + fallback chain) lands in a later
     #    PR; PR-A resolves inline blueprints only. A named template is recorded
     #    (audit-first) but not yet renderable.
     if op.template is not None:
         _emit_presented(
-            ctx, data_ref=data_ref_field, template=template_id, ingested=ingested,
-            bindings_resolved=0, bindings_dropped=[], rows=0,
+            ctx, data_ref=data_ref_field, template=template_id, surface=surface,
+            ingested=ingested, bindings_resolved=0, bindings_dropped=[], rows=0,
         )
         return {
             "kind": "present", "status": "ok", "ok": False,
@@ -120,22 +127,30 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     except PresentBlueprintError as exc:
         return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
 
-    # 4. Bind + guard against the null renderer. The guard applies the surface's
-    #    neutralizer strategy (PR-A's null surface uses the terminal strategy).
-    resolved = resolve_bindings(nodes, data, surface=_NULL_SURFACE[0])
+    # 4. Bind + guard against the wired surface (or the PR-A null surface — both use the
+    #    terminal neutralizer strategy today; see guard.py's _STRATEGIES).
+    resolved = resolve_bindings(nodes, data, surface=surface)
 
     # 5. Audit event (P6) — refs + stats, never content bytes.
     _emit_presented(
         ctx,
         data_ref=data_ref_field,
         template=template_id,
+        surface=surface,
         ingested=ingested,
         bindings_resolved=resolved.bindings_resolved,
         bindings_dropped=resolved.bindings_dropped,
         rows=resolved.rows,
     )
 
-    # 6. The compact, high-signal ack (the LLM's only feedback).
+    # 6. Hand the render model to the wired surface (PR-B). Fire-and-continue: the op's
+    #    ack (below) is already fully derived from `resolved`'s stats, not from anything
+    #    the renderer does — a renderer failure must never be allowed to reach here (see
+    #    OutboxPresentationRenderer's own fire-and-forget contract).
+    if ctx.presentation_renderer is not None:
+        ctx.presentation_renderer.render(resolved)
+
+    # 7. The compact, high-signal ack (the LLM's only feedback).
     return {
         "kind": "present",
         "status": "ok",

--- a/src/reyn/core/present/__init__.py
+++ b/src/reyn/core/present/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from reyn.core.present.binding import ResolvedPresentation, resolve_bindings, resolve_pointer
 from reyn.core.present.catalog import CATALOG, PresentBlueprintError, validate_blueprint
+from reyn.core.present.renderer import PresentationRenderer
 from reyn.core.present.source import (
     PresentSourceNotFound,
     compute_ingested,
@@ -21,6 +22,7 @@ __all__ = [
     "CATALOG",
     "PresentBlueprintError",
     "PresentSourceNotFound",
+    "PresentationRenderer",
     "ResolvedPresentation",
     "compute_ingested",
     "resolve_bindings",

--- a/src/reyn/core/present/guard.py
+++ b/src/reyn/core/present/guard.py
@@ -8,22 +8,39 @@ un-neutralized. Two concerns:
 
 - **Neutralize rendered leaf strings** per surface so bound data cannot drive the
   surface it displays on. Neutralization is surface-specific: what is dangerous
-  on a terminal (ESC / control sequences, Rich markup) is not what is dangerous
-  in a browser (HTML). The neutralizer is a **per-surface strategy** (dispatch by
-  surface name), so §6's per-surface boundary is structural, not a conditional —
-  a future ``web`` strategy (HTML-escape) registers here without touching the
+  on a terminal (ESC / control sequences) is not what is dangerous in a browser
+  (HTML). The neutralizer is a **per-surface strategy** (dispatch by surface
+  name), so §6's per-surface boundary is structural, not a conditional — a
+  future ``web`` strategy (HTML-escape) registers here without touching the
   binding seam.
 - **Per-binding size caps** (surface-agnostic) so a ``/`` (root) pointer bound
   into a ``text`` component cannot dump a whole file, and a huge array cannot
   flood scrollback. Leaf strings cap by characters; arrays cap by row count.
 
-The v1 **terminal** strategy does exactly two things: strip ESC / control
-sequences (OSC / CSI — notably OSC-52 clipboard — is a real attack surface on
-every terminal), and **escape** (not strip) Rich console markup so ``[red]``
-renders literally (fidelity-preserving, FP-0051 idiom). It does **not**
-HTML-escape: in a terminal sink ``<div>`` is a harmless literal, and
-entity-escaping would corrupt ``code`` / ``diff`` content (the v1 catalog core).
-HTML neutralization is a future web renderer's concern.
+The v1 **terminal** strategy strips ESC / control sequences (OSC / CSI — notably
+OSC-52 clipboard — is a real attack surface on every terminal) and nothing else.
+It does **not** escape Rich console markup, and does **not** HTML-escape.
+
+**Rich-markup safety is NOT this module's responsibility (PR-B revision — see
+FP-0054 §5).** An earlier PR-A revision escaped ``[tag]``-shaped substrings here
+(the FP-0051 idiom), on the premise that Rich console markup is a surface-level
+threat like ESC sequences. It is not: Rich markup injection is possible ONLY
+through ``console.print(str, markup=True)`` — a choice the RENDERER makes per
+Rich object, not a property of the terminal sink itself. ``rich.text.Text`` and
+``rich.syntax.Syntax`` never interpret ``[tag]`` at all (markup-inert);
+``rich.markdown.Markdown`` interprets CommonMark's OWN backslash-escape, not
+Rich markup. Escaping here unconditionally corrupted Text/Syntax output with
+visible literal backslashes (a real bug caught by empirical testing across all
+three Rich paths, PR-B review) — the guard was neutralizing a threat that,
+for two of the three render paths it feeds, does not exist at that sink.
+
+The fix is structural, not a runtime escape/unescape pair: the inline-CUI
+renderer (``interfaces/repl/present_renderer.py``) routes every leaf into a
+markup-inert Rich object (``Text``/``Syntax``/``Markdown``) and never calls
+``console.print(str)`` with markup interpretation on presented content — Rich
+injection becomes impossible by construction, the same "safety from shape, not
+policy" philosophy as reyn's structural write-gate. HTML neutralization
+(HTML-escape) remains a future web renderer's own concern, for the same reason.
 
 Pure: no I/O, no events, no config — the caller wires telemetry and decides the
 drop-reason (``guard_stripped``) from the returned ``stripped`` flag.
@@ -47,11 +64,6 @@ MAX_ROWS: int = 500
 # the trailing sequence bytes so no partial escape survives.
 _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
 
-# Rich console markup tags: ``[tag]`` / ``[/tag]`` / ``[/]``. Rich's own escape
-# convention is a leading backslash on the ``[`` — we apply exactly that so the
-# tag renders as literal text instead of styling the surface.
-_RICH_TAG_RE = re.compile(r"\[(/?[a-zA-Z#][^\[\]]*|/)\]")
-
 
 class LeafNeutralizer(Protocol):
     """A per-surface leaf-string neutralizer. ``neutralize`` returns
@@ -63,24 +75,25 @@ class LeafNeutralizer(Protocol):
 
 
 class TerminalNeutralizer:
-    """Terminal-surface strategy: strip ESC / control sequences + escape Rich
-    markup. Does NOT HTML-escape (a terminal renders ``<div>`` as a literal, and
-    entity-escaping would corrupt ``code`` / ``diff`` content)."""
+    """Terminal-surface strategy: strip ESC / control sequences. Does NOT escape
+    Rich console markup (the renderer's job — see module docstring) and does NOT
+    HTML-escape (a terminal renders ``<div>`` as a literal, and entity-escaping
+    would corrupt ``code`` / ``diff`` content)."""
 
     def neutralize(self, value: str) -> tuple[str, bool]:
         out = _CONTROL_RE.sub("", value)
-        out = _RICH_TAG_RE.sub(lambda m: "\\" + m.group(0), out)
         return out, out != value
 
 
 _TERMINAL = TerminalNeutralizer()
 
-# Surface name → neutralizer strategy. v1 ships the terminal strategy; the null
-# renderer (no UI surface yet) uses it too, so the guard runs unconditionally even
-# with no real surface. A future ``web`` strategy (HTML-escape) is added here
-# WITHOUT touching the core seam or the binding layer.
+# Surface name → neutralizer strategy. v1 ships the terminal strategy for every
+# terminal-family surface (the null renderer uses it too, so the guard runs
+# unconditionally even with no real surface). A future ``web`` strategy
+# (HTML-escape) is added here WITHOUT touching the core seam or the binding layer.
 _STRATEGIES: dict[str, LeafNeutralizer] = {
     "terminal": _TERMINAL,
+    "inline-cui": _TERMINAL,
     "null": _TERMINAL,
 }
 _DEFAULT_STRATEGY: LeafNeutralizer = _TERMINAL

--- a/src/reyn/core/present/renderer.py
+++ b/src/reyn/core/present/renderer.py
@@ -1,0 +1,31 @@
+"""PresentationRenderer protocol — the surface seam a `present` op result reaches (FP-0054 PR-B).
+
+`op_runtime/present.py::handle` computes a `ResolvedPresentation` (bound, neutralized,
+capped render model) and hands it to `OpContext.presentation_renderer` when one is wired —
+`None` means the PR-A null-surface behavior (no UI reached, `surface="null"`). A wired
+renderer names its own `surface_name` (fed to `resolve_bindings(..., surface=...)` so the
+guard's per-surface neutralizer strategy matches the actual sink — see `core/present/guard.py`).
+
+`op_runtime` never imports a UI toolkit (Rich, prompt_toolkit): a concrete renderer (e.g. the
+inline-CUI's `OutboxPresentationRenderer` in `runtime/session_buses.py`) only needs to get the
+render model to its surface — the actual Rich-conversion happens downstream in the UI layer
+(`interfaces/repl/renderer.py`), the same layering every other outbox-carried message already
+uses.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from reyn.core.present.binding import ResolvedPresentation
+
+
+@runtime_checkable
+class PresentationRenderer(Protocol):
+    """A surface that can receive a resolved presentation. Fire-and-continue: `render`
+    does not return a value the caller awaits on — the `present` op has already produced
+    its ack from `resolved`'s stats before calling this."""
+
+    surface_name: str
+
+    def render(self, resolved: "ResolvedPresentation") -> None: ...

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -1,0 +1,109 @@
+"""present renderer — `ResolvedPresentation.nodes` → Rich renderables (FP-0054 PR-B).
+
+**Invariant (do not violate — FP-0054 §5 Option B, PR-B review).** Every leaf string
+here reaches a MARKUP-INERT Rich object — `Text` / `Syntax` / `Markdown` — and this
+module never calls `console.print(str)` (or hands a bare `str` to a Rich API that
+itself defaults to markup interpretation, e.g. `Table.add_column`/`add_row`). Rich
+console-markup injection becomes structurally impossible: `guard.py`'s terminal
+strategy strips ESC/control sequences only (the surface-universal threat) and
+deliberately does NOT escape `[tag]`-shaped text — see its module docstring for why
+that used to be here and was wrong (Rich markup is reachable ONLY through
+`console.print(str, markup=True)`, a renderer choice, not a sink property).
+`rich.markdown.Markdown` is the one exception: it interprets CommonMark, not Rich
+console markup, so a `markdown` component's raw (control-stripped) text goes to it
+directly — no wrapping needed, no injection vector either way.
+
+Pure: takes the already bound/neutralized/capped render model and a target width;
+produces a Rich renderable. No I/O — the caller (`interfaces/repl/renderer.py`'s
+`InlineChatRenderer`) owns the `Console` + `run_in_terminal` print.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def _cell(value: Any) -> "Any":
+    """Wrap a leaf value as a markup-inert `Text` — the ONE conversion every string
+    destined for a Rich renderable goes through in this module."""
+    from rich.text import Text
+
+    return Text(str(value))
+
+
+def _render_keyvalue(node: dict) -> "Any":
+    from rich.table import Table
+
+    grid = Table.grid(padding=(0, 1))
+    grid.add_column(style="bold")
+    grid.add_column()
+    for row in node.get("rows", []):
+        grid.add_row(_cell(row.get("label", "")), _cell(row.get("value", "")))
+    return grid
+
+
+def _render_table(node: dict) -> "Any":
+    from rich.table import Table
+
+    columns = node.get("columns", [])
+    table = Table(show_lines=False)
+    for col in columns:
+        table.add_column(_cell(col.get("header", "")))
+    n_rows = max((len(col.get("cells", [])) for col in columns), default=0)
+    for i in range(n_rows):
+        table.add_row(*[
+            _cell(col["cells"][i]) if i < len(col.get("cells", [])) else _cell("")
+            for col in columns
+        ])
+    return table
+
+
+def _render_list(node: dict) -> "Any":
+    from rich.console import Group
+
+    return Group(*[_cell(f"• {item}") for item in node.get("items", [])])
+
+
+def _render_code_or_diff(node: dict, *, lexer: str) -> "Any":
+    from rich.syntax import Syntax
+
+    # §5 "cap before render": the text is already head-N-capped by guard.cap_leaf
+    # (binding.py) before it ever reaches this render model — Syntax highlights only
+    # the survivors, never the full pre-cap source.
+    return Syntax(node.get("text", ""), lexer, word_wrap=True, background_color="default")
+
+
+def _render_node(node: dict) -> "Any":
+    from rich.markdown import Markdown
+    from rich.text import Text
+
+    component = node.get("component")
+    if component == "text":
+        return Text(node.get("text", ""))
+    if component == "markdown":
+        # CommonMark, not Rich console markup — no injection vector, no wrapping needed.
+        return Markdown(node.get("text", ""))
+    if component == "code":
+        return _render_code_or_diff(node, lexer=node.get("language") or "text")
+    if component == "diff":
+        return _render_code_or_diff(node, lexer="diff")
+    if component == "keyvalue":
+        return _render_keyvalue(node)
+    if component == "table":
+        return _render_table(node)
+    if component == "list":
+        return _render_list(node)
+    if component == "image":
+        alt = node.get("alt") or node.get("src") or ""
+        return Text(f"[image: {alt}]", style="dim")
+    # Unregistered/future component — never crash the render loop over one bad node.
+    return Text(f"<unsupported present component {component!r}>", style="dim")
+
+
+def render_presentation_nodes(nodes: list[dict]) -> "Any":
+    """Convert a `ResolvedPresentation.nodes` render model into ONE Rich renderable
+    (a `Group` of per-node renderables) — the one-shot inline block `present` prints
+    to the conversation scrollback. See module docstring for the markup-inert
+    invariant every branch here must preserve."""
+    from rich.console import Group
+
+    return Group(*[_render_node(node) for node in nodes])

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -324,6 +324,17 @@ def _short(v, n: int = 60) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _live_terminal_width(default: int = 80) -> int:
+    """The live prompt_toolkit app's terminal width in columns, re-read per call (the
+    terminal can resize between turns). Falls back to `default` (Rich's own fallback)
+    when no app is running — e.g. a headless test importing this module directly."""
+    try:
+        from prompt_toolkit.application import get_app
+        return get_app().output.get_size().columns
+    except Exception:
+        return default
+
+
 def _summarize_args(args) -> str:
     """Compact ``k=v`` summary of a tool's args dict (or a bare value)."""
     if not args:
@@ -609,6 +620,13 @@ def format_inline_message(msg: OutboxMessage):
     kind = msg.kind
     meta = msg.meta or {}
 
+    # FP-0054 PR-B: a `present` op's resolved render model — a one-shot inline block,
+    # not a gutter-marked conversation line (it is a whole rendered document, not a
+    # single reply). See `present_renderer.py` for the markup-inert render invariant.
+    if kind == "presentation":
+        from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+        return render_presentation_nodes(meta.get("nodes", []))
+
     # Tool-call rows. ▸ marks an invocation (distinct from the ⏺ assistant reply);
     # the ⎿ result / failure rows nest one level under it (2-space indent).
     if kind == "tool_call_started":
@@ -752,6 +770,15 @@ class InlineChatRenderer(ChatRenderer):
         self._clear_transient()
         if wants_separator(msg.kind, self._seen_message):
             self._console.print()  # blank line between message blocks
+        if msg.kind == "presentation":
+            # FP-0054 §6 (tui-coder review): Rich's Console cannot auto-detect terminal
+            # width writing to a StringIO — it silently falls back to 80 columns. Read
+            # the LIVE terminal width per render (the terminal can resize between
+            # turns) rather than inheriting that fallback, which matters far more for
+            # `present`'s tables than for the plain-text/one-liner kinds this renderer
+            # otherwise prints (a pre-existing latent gap there — issue #2655 fast-follow,
+            # out of this PR's scope).
+            self._console.width = _live_terminal_width()
         self._console.print(format_inline_message(msg))
         self._seen_message = True
         self._flush()

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -54,6 +54,7 @@ def build_router_op_context(
     # ── per-host fields (caller-supplied; behavior-preserving) ─────────────
     agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
     intervention_bus: Any = None,  # Session wires post-hoc; RouterHostAdapter inline
+    presentation_renderer: Any = None,  # FP-0054 PR-B: RouterHostAdapter wires inline (factory)
     multimodal_config: Any = None,  # #364
     media_store: Any = None,  # #383
     compact_now: Any = None,  # #272/#1128
@@ -134,6 +135,7 @@ def build_router_op_context(
         run_id=run_id,
         agent_id=agent_id,
         intervention_bus=intervention_bus,
+        presentation_renderer=presentation_renderer,
         multimodal_config=multimodal_config,
         media_store=media_store,
         compact_now=compact_now,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -244,6 +244,12 @@ class RouterHostAdapter:
         # config-deny path still raises, interactive prompt path raises
         # the documented RuntimeError telling the caller a bus is needed).
         intervention_bus_factory: Callable[[], Any] | None = None,
+        # FP-0054 PR-B: callable that yields a PresentationRenderer for router-initiated
+        # `present` ops. Session passes a factory wrapping
+        # ``OutboxPresentationRenderer(session)``; None (tests / headless) keeps
+        # ``OpContext.presentation_renderer=None`` — the `present` op's PR-A null-surface
+        # behavior (ack + audit event still fire; no UI is reached).
+        presentation_renderer_factory: Callable[[], Any] | None = None,
         # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
         # injected from Session (mirror the inter_agent_messaging injection) so the spawn SEAM can
         # route a spawn-limit exceed through the same mode-driven on_limit framework as
@@ -416,6 +422,10 @@ class RouterHostAdapter:
         # interactive (Layer 4) approval flow without crashing on
         # ``intervention_bus is None`` defensive guards.
         self._intervention_bus_factory = intervention_bus_factory
+        # FP-0054 PR-B: presentation-renderer factory used by make_router_op_context to
+        # populate ``ctx.presentation_renderer`` so a router-initiated `present` op
+        # reaches the live UI surface instead of PR-A's null surface.
+        self._presentation_renderer_factory = presentation_renderer_factory
         # #2175: spawn-limit on_limit checkpoint + the shared extension dict.
         self._handle_chat_limit_checkpoint = handle_chat_limit_checkpoint
         self._safety_extensions: "dict[str, float]" = (
@@ -1930,6 +1940,11 @@ class RouterHostAdapter:
             if self._intervention_bus_factory is not None
             else None
         )
+        presentation_renderer = (
+            self._presentation_renderer_factory()
+            if self._presentation_renderer_factory is not None
+            else None
+        )
         return build_router_op_context(
             events=self._events,
             permission_resolver=self._perm,
@@ -1944,6 +1959,7 @@ class RouterHostAdapter:
             sandbox_policy=self._sandbox_policy,
             agent_id=None,
             intervention_bus=bus,
+            presentation_renderer=presentation_renderer,
             multimodal_config=self._multimodal_config,
             media_store=self._media_store,
             compact_now=self._compact_now,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -73,7 +73,11 @@ from reyn.runtime.services.chain_manager import _PendingChain
 from reyn.runtime.services.execution_driver import ExecutionDriver
 from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
 from reyn.runtime.services.task_wake import WAKE_READY_KIND, WAKE_REQUESTER_KIND
-from reyn.runtime.session_buses import AgentRequestBus, ChatInterventionBus
+from reyn.runtime.session_buses import (
+    AgentRequestBus,
+    ChatInterventionBus,
+    OutboxPresentationRenderer,
+)
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
 from reyn.task.subscription import SubscriptionWriter
@@ -1693,6 +1697,11 @@ class Session:
                 self, run_id=None, actor="chat_router",
                 channel_id=DEFAULT_CHAT_CHANNEL_ID,
             ),
+            # FP-0054 PR-B: give the router OpContext a real PresentationRenderer so a
+            # `present` op reaches the live outbox (→ inline-CUI) instead of PR-A's null
+            # surface. Built per make_router_op_context() call, mirroring the
+            # intervention_bus_factory above.
+            presentation_renderer_factory=lambda: OutboxPresentationRenderer(self),
             # FP-0037 S2: yaml mtime watch needs the project root to resolve
             # the 3 yaml scope tier paths. None falls back to user-global only.
             project_root=getattr(self._registry, "_project_root", None),

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -1,6 +1,6 @@
-"""reyn.runtime.session_buses — Session-backed intervention bus adapters.
+"""reyn.runtime.session_buses — Session-backed intervention + presentation adapters.
 
-The intervention-routing adapters that bind to a ``Session``:
+The routing adapters that bind to a ``Session``:
 
 - ``AgentRequestBus`` — a ``RequestBus`` adapter that forwards an
   intervention to the Session's ``handle_intervention`` so the Agent owns the
@@ -8,8 +8,13 @@ The intervention-routing adapters that bind to a ``Session``:
 - ``ChatInterventionBus`` — a ``UserChannel`` implementation that routes a
   prompt through the Session's outbox/inbox to the attached listener, stamping
   origin-channel provenance for cross-channel routing.
+- ``OutboxPresentationRenderer`` (FP-0054 PR-B) — a ``PresentationRenderer`` that
+  routes a resolved presentation's render model through the SAME outbox the other
+  two use, as a new ``"presentation"`` ``OutboxMessage`` kind. Fire-and-forget: it
+  never awaits anything (the `present` op's ack is already complete before this
+  runs), mirroring the op's own fire-and-continue contract.
 
-Both hold a ``Session`` and delegate to it; the ``Session`` type is referenced
+All three hold a ``Session`` and delegate to it; the ``Session`` type is referenced
 only under ``TYPE_CHECKING`` so importing this module never imports
 ``session`` (one-directional ``session`` -> ``session_buses`` at runtime).
 """
@@ -17,7 +22,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from reyn.runtime.outbox import OutboxMessage
+
 if TYPE_CHECKING:
+    from reyn.core.present.binding import ResolvedPresentation
     from reyn.runtime.session import Session
     from reyn.user_intervention import InterventionAnswer, UserIntervention
 
@@ -147,3 +155,28 @@ class ChatInterventionBus:
     # Note: _dispatch_intervention on session.py is now a thin wrapper around
     # InterventionRegistry.dispatch (wave 2 of PR-refactor-session-1). Kept
     # method-level call so the bus signature stays stable.
+
+
+class OutboxPresentationRenderer:
+    """``PresentationRenderer`` (``core/present/renderer.py``) that routes a resolved
+    presentation's render model onto the Session's outbox as a ``"presentation"``
+    ``OutboxMessage`` — the SAME queue every other display kind (agent/status/error/
+    trace/intervention) already flows through.
+
+    Deliberately thin: this class does NOT convert ``nodes`` to Rich renderables — that
+    conversion is a UI-layer concern (``interfaces/repl/renderer.py``'s
+    ``format_inline_message``), consistent with how every other outbox kind carries raw
+    data in ``meta`` and lets the UI layer decide how to draw it. ``op_runtime`` (which
+    constructs the ``ResolvedPresentation`` this class receives) never imports Rich or
+    prompt_toolkit; this adapter is the seam where that boundary is respected.
+    """
+
+    surface_name = "inline-cui"
+
+    def __init__(self, session: "Session") -> None:
+        self._session = session
+
+    def render(self, resolved: "ResolvedPresentation") -> None:
+        self._session.outbox.put_nowait(
+            OutboxMessage(kind="presentation", text="", meta={"nodes": resolved.nodes})
+        )

--- a/tests/test_present_op_fp0054_pra.py
+++ b/tests/test_present_op_fp0054_pra.py
@@ -223,17 +223,19 @@ def test_terminal_escape_in_data_is_neutralized_not_rendered():
     assert {"path": "/v", "reason": "guard_stripped"} in out.bindings_dropped
 
 
-def test_rich_markup_in_data_is_escaped_literal():
-    """Tier 1: Rich markup in bound data is escaped so it renders literally (the
-    bracket survives as text, the styling does not drive the surface)."""
+def test_rich_markup_in_data_passes_the_guard_unescaped():
+    """Tier 1: PR-B revision (FP-0054 §5 Option B) — Rich console markup is NOT a
+    guard-level (surface-universal) threat like ESC sequences — it is reachable
+    ONLY through ``console.print(str, markup=True)``, a choice the RENDERER makes
+    per Rich object. The guard passes ``[tag]``-shaped text through byte-for-byte
+    (no escape, no strip, no drop); Rich-injection safety is the renderer's job
+    (it never feeds presented content through a markup-interpreting print call —
+    see ``interfaces/repl/present_renderer.py`` + its invariant-lock test)."""
     nodes = validate_blueprint({"component": "text", "text": {"$bind": "/v"}})
     out = resolve_bindings(nodes, {"v": "[bold red]owned[/bold red]"})
     rendered = out.nodes[0]["text"]
-    # The literal bracket text is preserved but escaped (backslash-guarded), so
-    # Rich will not interpret it as a style tag.
-    assert "bold red" in rendered
-    assert "\\[" in rendered
-    assert {"path": "/v", "reason": "guard_stripped"} in out.bindings_dropped
+    assert rendered == "[bold red]owned[/bold red]"
+    assert all(d["reason"] != "guard_stripped" for d in out.bindings_dropped)
 
 
 def test_root_pointer_into_text_is_size_capped():
@@ -265,10 +267,11 @@ def test_labels_neutralized_at_render_seam():
 
 
 def test_literal_text_slot_value_is_neutralized_via_single_seam():
-    """Tier 1: an LLM-authored LITERAL (non-$bind) escape / Rich-markup in a
-    text-family slot is neutralized + reported guard_stripped — the same standard
-    as a bound value (single-seam: no literal bypasses the guard). RED against the
-    pre-unification code where text-slot literals were only size-capped."""
+    """Tier 1: an LLM-authored LITERAL (non-$bind) escape in a text-family slot is
+    neutralized (ESC/control stripped) + reported guard_stripped — the same
+    standard as a bound value (single-seam: no literal bypasses the guard).
+    Rich-markup-shaped text in the SAME literal passes through unescaped (PR-B
+    Option B — see test_rich_markup_in_data_passes_the_guard_unescaped)."""
     nodes = validate_blueprint(
         {"component": "text", "text": "safe\x1b[31mINJECT\x1b[0m [bold]owned[/bold]"}
     )
@@ -276,7 +279,7 @@ def test_literal_text_slot_value_is_neutralized_via_single_seam():
     rendered = out.nodes[0]["text"]
     assert "\x1b" not in rendered          # ESC control byte gone
     assert "INJECT" in rendered            # readable text survives (inert)
-    assert "\\[" in rendered               # Rich markup escaped literal
+    assert "[bold]owned[/bold]" in rendered  # Rich-markup-shaped text passes through raw
     assert any(d["reason"] == "guard_stripped" for d in out.bindings_dropped)
 
 

--- a/tests/test_present_renderer_fp0054_prb.py
+++ b/tests/test_present_renderer_fp0054_prb.py
@@ -1,0 +1,271 @@
+"""Tier 1/2: FP-0054 PR-B — the inline-CUI `present` renderer + the guard/renderer
+Rich-markup-safety re-layering (Option B).
+
+Covers:
+  1. Tier 1: per-component render presence (each catalog component produces SOME
+     Rich renderable containing its content — not layout/exact-whitespace pins).
+  2. Tier 2 INVARIANT-LOCK (lead-coder review): Rich-markup-shaped leaf data
+     (``[bold]INJECT[/bold]``) survives the FULL real pipeline (guard →
+     resolve_bindings → render_presentation_nodes → an actual Rich Console print)
+     as LITERAL text, never interpreted as styling — the structural guarantee
+     Option B replaces the old escape/unescape pair with.
+  3. Tier 2: the terminal ESC/control-strip behavioral guarantee still holds
+     through the same full pipeline (guard's actual security responsibility,
+     unchanged by the Option B revision).
+  4. Tier 2: `OutboxPresentationRenderer.render` puts a `"presentation"`
+     `OutboxMessage` carrying the render model onto the real Session outbox (no
+     mock Session — a minimal real one), and `format_inline_message` dispatches
+     `kind="presentation"` to `render_presentation_nodes`.
+  5. Tier 1: `op_runtime/present.py` derives its `surface` string from the wired
+     `OpContext.presentation_renderer` (None → "null"; a renderer → its own
+     `surface_name`) and calls `.render()` on it exactly once when present.
+
+Real `PipelineExecutor`-adjacent objects throughout: real `Console`, real
+`resolve_bindings`, real `OpContext`; no `MagicMock`/`patch`. No exact-render /
+whitespace pins — asserts content presence and structural facts only.
+"""
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.present import resolve_bindings, validate_blueprint
+from reyn.data.workspace.workspace import Workspace
+from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+from reyn.interfaces.repl.renderer import format_inline_message
+from reyn.runtime.outbox import OutboxMessage
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+def _render_to_text(nodes: list[dict], *, width: int = 60) -> str:
+    console = Console(width=width, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(render_presentation_nodes(nodes))
+    return console.file.getvalue()
+
+
+# ── 1. per-component render presence ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("blueprint", "data", "expect_substr"),
+    [
+        ({"component": "text", "text": {"$bind": "/v"}}, {"v": "hello world"}, "hello world"),
+        ({"component": "markdown", "text": "**bold**"}, {}, "bold"),
+        ({"component": "code", "text": "x = 1", "language": "python"}, {}, "x"),
+        ({"component": "diff", "text": "+added\n-removed"}, {}, "added"),
+        (
+            {"component": "keyvalue", "rows": [{"label": "k", "value": {"$bind": "/v"}}]},
+            {"v": "val1"},
+            "val1",
+        ),
+        (
+            {
+                "component": "table",
+                "rows": {"$bind": "/items"},
+                "columns": [{"header": "name", "path": "/n"}],
+            },
+            {"items": [{"n": "row-one"}]},
+            "row-one",
+        ),
+        ({"component": "list", "items": ["alpha", "beta"]}, {}, "alpha"),
+        ({"component": "image", "alt": "a photo"}, {}, "a photo"),
+    ],
+)
+def test_each_catalog_component_renders_its_content(blueprint, data, expect_substr) -> None:
+    """Tier 1: every v1 catalog component produces a renderable whose printed
+    output contains its bound/literal content — presence, not exact layout."""
+    nodes = validate_blueprint(blueprint)
+    resolved = resolve_bindings(nodes, data, surface="inline-cui")
+    out = _render_to_text(resolved.nodes)
+    assert expect_substr in out
+
+
+def test_unsupported_component_does_not_crash_the_render_loop() -> None:
+    """Tier 1: a node with an unrecognized component name renders a placeholder
+    instead of raising — the render loop never crashes over one bad node."""
+    out = _render_to_text([{"component": "not-a-real-component"}])
+    assert "not-a-real-component" in out
+
+
+# ── 2. INVARIANT-LOCK: Rich markup never interpreted, full real pipeline ────
+
+
+def test_rich_markup_leaf_survives_literal_through_the_full_real_pipeline() -> None:
+    """Tier 2: INVARIANT-LOCK — `[bold]INJECT[/bold]` in bound data reaches the
+    printed terminal output as LITERAL text — never interpreted as Rich styling
+    (no ANSI SGR bytes around it) — through the REAL guard → bindings →
+    render_presentation_nodes → Console.print pipeline. This is the structural
+    guarantee Option B relies on in place of the old guard-level escape/unescape
+    pair (see guard.py's module docstring)."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/v"}})
+    resolved = resolve_bindings(nodes, {"v": "safe [bold]INJECT[/bold] text"}, surface="inline-cui")
+    # The guard passed the markup-shaped text through unescaped (Option B).
+    assert resolved.nodes[0]["text"] == "safe [bold]INJECT[/bold] text"
+
+    out = _render_to_text(resolved.nodes)
+    assert "[bold]INJECT[/bold]" in out       # literal brackets survive verbatim
+    assert "\x1b[1m" not in out               # never interpreted as a Rich bold SGR
+
+
+def test_rich_markup_in_code_and_table_cells_also_stays_literal() -> None:
+    """Tier 2: INVARIANT-LOCK — the same guarantee holds for the `code`/`table`
+    render paths specifically (the two paths the old escape/unescape approach
+    would have corrupted with visible backslashes — see guard.py docstring)."""
+    code_nodes = validate_blueprint({"component": "code", "text": "x = '[red]y[/red]'"})
+    code_resolved = resolve_bindings(code_nodes, {}, surface="inline-cui")
+    code_out = _render_to_text(code_resolved.nodes)
+    assert "[red]y[/red]" in code_out
+    assert "\\[red]" not in code_out          # no leftover escape backslash either
+
+    table_nodes = validate_blueprint({
+        "component": "table",
+        "rows": {"$bind": "/items"},
+        "columns": [{"header": "col [i]", "path": "/v"}],
+    })
+    table_resolved = resolve_bindings(
+        table_nodes, {"items": [{"v": "[bold]cell[/bold]"}]}, surface="inline-cui",
+    )
+    table_out = _render_to_text(table_resolved.nodes)
+    assert "[bold]cell[/bold]" in table_out
+    assert "col [i]" in table_out
+    assert "\\[bold]" not in table_out
+
+
+# ── 3. control/ESC-strip guarantee, unchanged ────────────────────────────────
+
+
+def test_control_and_esc_sequences_still_stripped_through_the_full_pipeline() -> None:
+    """Tier 2: the guard's actual security responsibility (ESC/control-sequence
+    stripping) is unchanged by the Option B revision — verified through the same
+    real render pipeline as the invariant-lock tests above."""
+    nodes = validate_blueprint({"component": "text", "text": {"$bind": "/v"}})
+    resolved = resolve_bindings(nodes, {"v": "safe\x1b[31mINJECT\x1b[0m text"}, surface="inline-cui")
+    assert "\x1b" not in resolved.nodes[0]["text"]
+    out = _render_to_text(resolved.nodes)
+    assert "\x1b[31m" not in out
+    assert "INJECT" in out
+
+
+# ── 4. OutboxPresentationRenderer + format_inline_message dispatch ──────────
+
+
+def test_outbox_presentation_renderer_puts_presentation_message() -> None:
+    """Tier 2: OutboxPresentationRenderer.render puts a real `OutboxMessage(kind=
+    "presentation")` carrying `resolved.nodes` onto the session's outbox — the
+    same queue every other display kind flows through."""
+    import asyncio
+
+    from reyn.core.present.binding import ResolvedPresentation
+    from reyn.runtime.session_buses import OutboxPresentationRenderer
+
+    class _Session:
+        def __init__(self) -> None:
+            self.outbox: asyncio.Queue = asyncio.Queue()
+
+    session = _Session()
+    renderer = OutboxPresentationRenderer(session)
+    assert renderer.surface_name == "inline-cui"
+
+    resolved = ResolvedPresentation(nodes=[{"component": "text", "text": "hi"}])
+    renderer.render(resolved)
+
+    msg = session.outbox.get_nowait()
+    assert isinstance(msg, OutboxMessage)
+    assert msg.kind == "presentation"
+    assert msg.meta["nodes"] == [{"component": "text", "text": "hi"}]
+
+
+def test_format_inline_message_dispatches_presentation_kind() -> None:
+    """Tier 2: format_inline_message routes kind="presentation" to
+    render_presentation_nodes (not the generic _KIND_LINE fallback)."""
+    msg = OutboxMessage(kind="presentation", text="", meta={"nodes": [
+        {"component": "text", "text": "hello from present"},
+    ]})
+    console = Console(width=60, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(format_inline_message(msg))
+    assert "hello from present" in console.file.getvalue()
+
+
+# ── 5. op_runtime/present.py surface derivation + renderer call ─────────────
+
+
+class _RecordingRenderer:
+    surface_name = "inline-cui"
+
+    def __init__(self) -> None:
+        self.calls = []
+        self.call_count = 0
+
+    def render(self, resolved) -> None:
+        self.calls.append(resolved)
+        self.call_count += 1
+
+
+def _ctx(*, presentation_renderer=None) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        presentation_renderer=presentation_renderer,
+    )
+
+
+@pytest.mark.asyncio
+async def test_present_op_uses_null_surface_when_no_renderer_wired() -> None:
+    """Tier 1: OpContext.presentation_renderer=None (PR-A behavior, unchanged) →
+    surface="null" in both the ack path's binding resolution and the presented
+    event, and no renderer is called."""
+    from reyn.core.op_runtime.present import handle
+    from reyn.schemas.models import PresentIROp
+
+    op = PresentIROp(
+        kind="present", data_inline={"v": "x"},
+        blueprint={"component": "text", "text": {"$bind": "/v"}},
+    )
+    result = await handle(op, _ctx())
+    assert result["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_present_op_calls_the_wired_renderer_exactly_once() -> None:
+    """Tier 1: a wired OpContext.presentation_renderer receives exactly one
+    `.render(resolved)` call carrying the SAME stats the ack reports."""
+    from reyn.core.op_runtime.present import handle
+    from reyn.schemas.models import PresentIROp
+
+    renderer = _RecordingRenderer()
+    op = PresentIROp(
+        kind="present", data_inline={"v": "x"},
+        blueprint={"component": "text", "text": {"$bind": "/v"}},
+    )
+    result = await handle(op, _ctx(presentation_renderer=renderer))
+    assert renderer.call_count == 1
+    assert renderer.calls[0].bindings_resolved == result["bindings_resolved"]
+
+
+@pytest.mark.asyncio
+async def test_presented_event_surface_reflects_the_wired_renderers_name() -> None:
+    """Tier 1: the `presented` audit event's `surface` field is the wired
+    renderer's own `surface_name`, not a hardcoded "null"/"inline-cui" literal."""
+    from reyn.core.op_runtime.present import handle
+    from reyn.schemas.models import PresentIROp
+
+    events = EventLog()
+    captured: list = []
+    events.add_subscriber(lambda e: captured.append(e) if e.type == "presented" else None)
+    ws = Workspace(events=events)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        presentation_renderer=_RecordingRenderer(),
+    )
+    op = PresentIROp(
+        kind="present", data_inline={"v": "x"},
+        blueprint={"component": "text", "text": {"$bind": "/v"}},
+    )
+    await handle(op, ctx)
+    assert captured
+    assert captured[0].data["surface"] == ["inline-cui"]


### PR DESCRIPTION
**[per-PR-coder]** — part of FP-0054 present-layer arc (PR-B). Contract: `docs/deep-dives/proposals/0054-present-layer.md` §5/§6 + "Suggested PR sequencing" (PR-B), and `docs/reference/runtime/control-ir.md`'s `present` section (updated in this PR).

## Summary

**Renderer wiring** (PR-B's core scope):
- `OpContext.presentation_renderer: PresentationRenderer | None` (new field, `core/present/renderer.py`'s new Protocol) — wired through `build_router_op_context` → `RouterHostAdapter`/`Session`, mirroring `intervention_bus`'s exact wiring pattern (factory-per-call, `None` in tests/headless).
- `OutboxPresentationRenderer` (`runtime/session_buses.py`) — pushes a `"presentation"` `OutboxMessage` carrying `ResolvedPresentation.nodes` onto the session outbox, the same queue every other display kind (agent/status/error/trace/intervention) already flows through. `op_runtime/present.py` never imports Rich — that stays a UI-layer concern.
- `present_renderer.py` (`interfaces/repl/`) — converts `nodes` to Rich renderables (`Text`/`Markdown`/`Syntax`/`Table`/`Group`) for a one-shot inline block in the conversation scrollback, wired into `format_inline_message`'s `kind="presentation"` branch.
- `op_runtime/present.py`'s `surface` string now derives from the wired renderer's own `surface_name` (`"inline-cui"`) instead of the PR-A-hardcoded `"null"`.
- Explicit per-render terminal width (`InlineChatRenderer.message()` reads `get_app().output.get_size().columns` for `kind="presentation"`) — Rich's `Console` silently falls back to 80 columns writing to a `StringIO`; the two pre-existing render call sites have the same latent gap, tracked separately as issue #2655 (out of this PR's scope, PR-B gets it right from the start per the design doc).

**Guard/renderer Rich-markup re-layering (Option B — folded in per lead-coder ruling, design consult with architect)**: empirical testing (`console.print(str)` w/ default markup=True vs `rich.text.Text` vs `rich.syntax.Syntax` vs `rich.markdown.Markdown`) showed PR-A's guard-level Rich-markup escape corrupted `Text`/`Syntax` output with visible literal backslashes, since those Rich types never interpret `[tag]` markup at all — the escape was solving a threat that doesn't exist at that sink. Fix is structural, not a runtime escape/unescape pair:
- `guard.py`'s `TerminalNeutralizer` now strips ESC/control sequences only (unchanged security responsibility) — Rich-markup escaping removed.
- `present_renderer.py` routes every leaf into a markup-inert Rich object and never calls `console.print` with markup interpretation on presented content — Rich injection becomes structurally impossible regardless of guard behavior (same "safety from shape, not policy" discipline as the guard's own ESC-strip).
- PR-A's two Rich-escape-survival tests updated to assert the new (correct) unescaped-passthrough + unchanged ESC/control-strip behavior.
- New invariant-lock tests (`test_present_renderer_fp0054_prb.py`) verify `[bold]INJECT[/bold]`-shaped data survives literally through the FULL real pipeline (guard → binding → render → actual `Console.print`) for `text`, `code`, and `table` — never interpreted as styling.

`docs/reference/runtime/control-ir.md`'s `present` section updated to match (guard behavior + PR-B surface wiring, replacing the PR-A null-surface note).

## Test plan
- [x] Full pytest suite: 7599 passed, 17 skipped
- [x] `ruff check src tests`: clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>`: 0 Tier-4 errors
- [x] `python scripts/verify_module_docstrings.py <changed src files>`: OK
- [x] New tests: per-component render presence (Tier 1, parametrized over all 8 catalog components), Rich-markup invariant-lock through the full real pipeline (Tier 2, text/code/table), ESC/control-strip unchanged (Tier 2), `OutboxPresentationRenderer` outbox wiring (Tier 2), `format_inline_message` dispatch (Tier 2), `present` op surface derivation + renderer call (Tier 1)
- [x] PR-A's existing 25 tests still pass unmodified except the 2 Rich-escape-survival tests updated for Option B

Tier self-check: all new/modified tests are Tier 1/2, first docstring line declares Tier, no `MagicMock`/`patch`, no private-state assertions, no format/size pins (verified via `test_tier_audit.py --strict`).