### PR TITLE
feat: present-layer PR-C — presentations.yaml registry + hot-reload + 4-stage fallback

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1252,6 +1252,34 @@ The entry **key must match the DSL file's own declared `pipeline:` name exactly*
 
 See [Concepts: Pipeline registration](../../concepts/runtime/pipeline-registration.md) for the full registration model and the install tools.
 
+## `presentations` block
+
+Registers **named presentation templates** for the `present` op — the same explicit-registration model as `skills.entries` / `pipelines.entries` / `mcp.servers`. A named template's value is a **blueprint**: the identical declarative, non-executable component tree an inline `present` blueprint is (catalog components + JSON-Pointer path bindings). The blueprint lives **inline** in the entry (no file indirection — a blueprint is small declarative data), and is structurally validated at load time.
+
+Registering a named template is an **operator/config action** — there is no install tool and no op the model can call to register one. The model authors *inline* blueprints only; a named `template:` in a `present` op is a read-only lookup against this registry. An unknown template name is not an error: the `present` op falls back through a content-type default viewer to a generic YAML/text view, so the data always reaches the user.
+
+```yaml
+presentations:
+  entries:
+    search_results:
+      blueprint:                              # required; inline component tree
+        - component: table
+          rows: {"$bind": "/results"}
+          columns:
+            - {header: Author, path: /author}
+            - {header: Title,  path: /title}
+      description: "Search results table"      # optional
+      enabled: true                            # optional, default true
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `blueprint` | list or object | required | The declarative component tree (same shape + catalog as an inline `present` blueprint). Validated at load; a malformed blueprint is skipped (logged), or on hot-reload rejects the whole reload (last-good kept). |
+| `description` | string | `""` | Optional one-line summary. |
+| `enabled` | bool | `true` | `false` removes the entry from the registry entirely. |
+
+`presentations.entries` merges across `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ the dynamic `<project>/.reyn/config/presentations.yaml`, later tiers winning on name collision — the same merge shape as `skills.entries` / `pipelines.entries` / `mcp.servers`. The `<project>/.reyn/config/presentations.yaml` layer hot-reloads at the turn boundary, so a newly-registered template becomes resolvable on the next turn without a restart.
+
 ## `embedding` block
 
 RAG embedding model classes and batch settings. Built-in defaults cover the OpenAI path — no `reyn.yaml` changes are required for a fresh install with `OPENAI_API_KEY`.

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -881,3 +881,23 @@
 #         messages:
 #           - type: text
 #             text: "${ROUTER_REPLY}"
+
+# -----------------------------------------------------------------------------
+# presentations: named presentation-template registry for the `present` op.
+# A template's value is a blueprint (the same declarative component tree an
+# inline `present` blueprint is). Registering one is an operator/config action
+# (there is no install tool — the model authors inline blueprints only). Merges
+# across config tiers like skills/pipelines; the dynamic
+# .reyn/config/presentations.yaml layer hot-reloads at the turn boundary.
+# -----------------------------------------------------------------------------
+# presentations:
+#   entries:
+#     search_results:
+#       blueprint:
+#         - component: table
+#           rows: {"$bind": "/results"}
+#           columns:
+#             - {header: Author, path: /author}
+#             - {header: Title,  path: /title}
+#       description: "Search results table"   # optional
+#       enabled: true                          # optional, default true

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -235,6 +235,21 @@ def _merge(base: dict, override: dict) -> dict:
                 **val,
                 "entries": {**existing_entries, **new_entries},
             }
+        elif key == "presentations" and isinstance(val, dict):
+            # FP-0054 PR-C: named-presentation-template registry entries union across
+            # config tiers — mirrors the ``skills`` / ``pipelines`` branches exactly
+            # (``entries`` is a per-name union with later tier winning on collision,
+            # not last-tier-wins-wholesale). Lets ~/.reyn/config.yaml declare global
+            # templates while reyn.yaml / .reyn/config/presentations.yaml add
+            # project-local ones.
+            existing = result.get("presentations", {})
+            existing_entries = existing.get("entries", {}) if isinstance(existing, dict) else {}
+            new_entries = val.get("entries", {}) if isinstance(val, dict) else {}
+            result["presentations"] = {
+                **existing,
+                **val,
+                "entries": {**existing_entries, **new_entries},
+            }
         else:
             result[key] = val
     return result
@@ -401,6 +416,18 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         dynamic_pipelines = _load_yaml(project_root / ".reyn" / "config" / "pipelines.yaml")
         merged = _merge(merged, dynamic_pipelines)
 
+        # FP-0054 PR-C: named-presentation-template registry separated from static
+        # config — same #470 invariant as skills/pipelines/MCP.
+        # .reyn/config/presentations.yaml carries project-local template
+        # declarations; merged LAST so it wins on name collision with
+        # operator-edited reyn.yaml presentation entries. Shape:
+        # {"presentations": {"entries": {<name>: {<entry>}}}} — same as the
+        # presentations section in reyn.yaml, handled by the _merge presentations
+        # branch above. Also in _HOT_RELOAD_FILES (the IN-set) so template
+        # declarations hot-reload at the turn boundary.
+        dynamic_presentations = _load_yaml(project_root / ".reyn" / "config" / "presentations.yaml")
+        merged = _merge(merged, dynamic_presentations)
+
         # ADR-0031: <project>/.reyn/config.yaml is DEPRECATED (removed from
         # the 3-layer cascade).  Emit a one-time warning if the file exists so
         # users know to migrate.  The file is intentionally NOT loaded.
@@ -519,6 +546,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         ),
         skills=_as_config_dict(merged.get("skills"), "skills"),
         pipelines=_as_config_dict(merged.get("pipelines"), "pipelines"),
+        presentations=_as_config_dict(merged.get("presentations"), "presentations"),
     )
     _reconcile_embedding_class(_cfg)
     return _cfg
@@ -537,6 +565,7 @@ _HOT_RELOAD_FILES: tuple[str, ...] = (
     "config/mcp.yaml", "config/cron.yaml", "config/hooks.yaml",
     "config/skills.yaml",  # #2548 PR-B: skills IN-set hot-reload
     "config/pipelines.yaml",  # pipelines IN-set hot-reload (mirrors skills.yaml)
+    "config/presentations.yaml",  # FP-0054 PR-C: presentation-template IN-set hot-reload
 )
 
 

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -306,6 +306,26 @@ class ReynConfig:
     # (explicit entries win on collision) — same union-merge shape as
     # ``skills`` (see ``_merge`` in loader.py).
     pipelines: dict = field(default_factory=dict)
+    # FP-0054 PR-C: named-presentation-template registry config. Raw dict passed to
+    # reyn.data.presentations.registry.build_presentation_registry at session-factory
+    # time (SessionFactoryConfig.from_config). A named template's value is a
+    # blueprint (the same declarative component tree an inline `present` blueprint
+    # is), validated at build time. Registering a named template is an
+    # OPERATOR/config action (write-gate culture — the LLM authors inline blueprints
+    # only, never registers named templates), so there is no install op. Shape:
+    #   presentations:
+    #     entries:
+    #       <name>:
+    #         blueprint:                              # required; inline component tree
+    #           - component: table
+    #             rows: {"$bind": "/results"}
+    #             columns:
+    #               - {header: Author, path: /author}
+    #         description: "One-line description"     # optional
+    #         enabled: true                            # optional, default true
+    # Merged across config tiers by name (explicit entries win on collision) — same
+    # union-merge shape as ``skills`` / ``pipelines`` (see ``_merge`` in loader.py).
+    presentations: dict = field(default_factory=dict)
 
     def model_class_for(self, purpose: str) -> str:
         """#1672: the model CLASS for a logical call *purpose*.

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -86,6 +86,16 @@ class OpContext:
     # its own `surface_name` (e.g. inline-CUI's OutboxPresentationRenderer = "inline-cui").
     presentation_renderer: "PresentationRenderer | None" = None
 
+    # FP-0054 PR-C: the operator's named-template registry (from
+    # `.reyn/config/presentations.yaml`) a `present` op resolves `op.template`
+    # against — the §3 fallback chain's stage 1. A `PresentationRegistry` (duck-typed
+    # `.get(name) -> validated nodes | None`). None = no registry wired (direct/test
+    # construction) → every named template is "unknown" and falls through to the
+    # generic fallback viewer (never a hard error). Sourced fresh per op-ctx build
+    # from the session/adapter's current registry, so a hot-reload swap is picked up
+    # at the next turn boundary.
+    presentation_registry: "object | None" = None
+
     # #272/#1128: voluntary-compaction capability for the `compact` op.
     # An awaitable zero-arg callable the caller (Session / phase runtime)
     # wires to its synchronous compaction (force_compact_now), returning

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -1,4 +1,4 @@
-"""present kind handler — route bulk data + a display template to the user (FP-0054 PR-A/PR-B).
+"""present kind handler — route bulk data + a display template to the user (FP-0054 PR-A/B/C).
 
 **Tier 0** (``ask_user``'s sibling) and **fire-and-continue**: unlike ``ask_user``
 this op does NOT pause the run — it produces a presentation ack and returns. The
@@ -12,6 +12,22 @@ PR-A's null-surface behavior (no UI reached, ``surface="null"``). The op returns
 compact, high-signal ack (``{ok, bindings_resolved, bindings_dropped, rows}``, drops as
 ``{path, reason}``) and emits the ``presented`` P6 event (refs + stats, never content
 bytes) regardless of whether a renderer is wired.
+
+**PR-C — named templates + the §3 4-stage fallback chain.** ``op.template`` is a
+registered name resolved against ``OpContext.presentation_registry`` (the operator's
+``presentations.yaml`` — a named template's value is a validated blueprint, the same
+downstream ``resolve_bindings`` → render path as an inline blueprint). The template
+source falls back through 4 stages (never a hard failure — the data always reaches
+the user): **(1)** a resolvable registered ``template`` → **(2)** an inline
+``blueprint`` → **(3)** a content-type default viewer synthesized from the data's
+shape → **(4)** a generic YAML/text dump of the whole value. The fallback fires when
+the requested rendering cannot produce a usable presentation — an UNKNOWN template
+name, or a template whose bindings ALL miss the data (``all_bindings_missed`` — don't
+show an empty shell). The ack + ``presented`` event carry the REQUESTED rendering's
+stats (so the LLM's self-correction loop still sees its template all-missed), plus a
+``note`` naming the fallback viewer that actually reached the user. A malformed INLINE
+blueprint stays a HARD error (``status="error"``) — that is a template bug, not a
+fallback trigger.
 """
 from __future__ import annotations
 
@@ -22,6 +38,9 @@ from typing import Any
 from reyn.core.present import (
     PresentBlueprintError,
     PresentSourceNotFound,
+    ResolvedPresentation,
+    default_viewer_blueprint,
+    generic_blueprint,
     resolve_bindings,
     resolve_present_source,
     validate_blueprint,
@@ -34,6 +53,11 @@ from .context import OpContext
 _NULL_SURFACE = "null"
 
 _INLINE_MARKER = "<inline-data>"
+
+# The §3 fallback-stage labels used in the ack ``note`` (never in the fixed
+# ``presented`` event shape).
+_STAGE_CONTENT_TYPE = "content_type_default"
+_STAGE_GENERIC = "generic"
 
 
 def _template_id(op: PresentIROp) -> str:
@@ -103,63 +127,151 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     template_id = _template_id(op)
     surface = _surface_name(ctx)
 
-    # 2. Named-template resolution (registry + fallback chain) lands in a later
-    #    PR; PR-A resolves inline blueprints only. A named template is recorded
-    #    (audit-first) but not yet renderable.
-    if op.template is not None:
-        _emit_presented(
-            ctx, data_ref=data_ref_field, template=template_id, surface=surface,
-            ingested=ingested, bindings_resolved=0, bindings_dropped=[], rows=0,
-        )
-        return {
-            "kind": "present", "status": "ok", "ok": False,
-            "bindings_resolved": 0, "bindings_dropped": [], "rows": 0,
-            "note": (
-                "named-template resolution is not available yet; author an inline "
-                "blueprint (catalog components + $bind path bindings) instead."
-            ),
-        }
-
-    # 3. Structural gate on the inline blueprint (catalog components + path
-    #    bindings only). A malformed blueprint is a hard error, NOT a soft drop.
+    # 2. Resolve the presentation through the §3 4-stage fallback chain. A
+    #    malformed INLINE blueprint is a HARD error (a template bug), NOT a
+    #    fallback trigger — unknown template names / all-miss templates fall
+    #    through instead.
     try:
-        nodes = validate_blueprint(op.blueprint)
+        requested, rendered, fallback_stage = _resolve_presentation(
+            op, data, surface=surface, registry=ctx.presentation_registry,
+        )
     except PresentBlueprintError as exc:
         return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
 
-    # 4. Bind + guard against the wired surface (or the PR-A null surface — both use the
-    #    terminal neutralizer strategy today; see guard.py's _STRATEGIES).
-    resolved = resolve_bindings(nodes, data, surface=surface)
-
-    # 5. Audit event (P6) — refs + stats, never content bytes.
+    # 3. Audit event (P6) — refs + REQUESTED-rendering stats, never content bytes.
+    #    (The fallback rendering is a deterministic display detail derivable from
+    #    the recorded data_ref; the event audits what the caller requested.)
+    stats = _requested_stats(requested)
     _emit_presented(
         ctx,
         data_ref=data_ref_field,
         template=template_id,
         surface=surface,
         ingested=ingested,
-        bindings_resolved=resolved.bindings_resolved,
-        bindings_dropped=resolved.bindings_dropped,
-        rows=resolved.rows,
+        bindings_resolved=stats["bindings_resolved"],
+        bindings_dropped=stats["bindings_dropped"],
+        rows=stats["rows"],
     )
 
-    # 6. Hand the render model to the wired surface (PR-B). Fire-and-continue: the op's
-    #    ack (below) is already fully derived from `resolved`'s stats, not from anything
-    #    the renderer does — a renderer failure must never be allowed to reach here (see
-    #    OutboxPresentationRenderer's own fire-and-forget contract).
+    # 4. Hand the actually-rendered model to the wired surface (PR-B). Fire-and-
+    #    continue: the op's ack (below) is already fully derived from the stats,
+    #    not from anything the renderer does — a renderer failure must never be
+    #    allowed to reach here (see OutboxPresentationRenderer's own fire-and-forget
+    #    contract).
     if ctx.presentation_renderer is not None:
-        ctx.presentation_renderer.render(resolved)
+        ctx.presentation_renderer.render(rendered)
 
-    # 7. The compact, high-signal ack (the LLM's only feedback).
-    return {
+    # 5. The compact, high-signal ack (the LLM's only feedback). ``ok`` is True
+    #    because SOME presentation reached the user; ``all_bindings_missed`` +
+    #    ``note`` carry the "your template did not match" self-correction signal
+    #    when a fallback fired.
+    ack = {
         "kind": "present",
         "status": "ok",
         "ok": True,
-        "bindings_resolved": resolved.bindings_resolved,
-        "bindings_dropped": resolved.bindings_dropped,
-        "rows": resolved.rows,
-        "all_bindings_missed": resolved.all_bindings_missed,
+        "bindings_resolved": stats["bindings_resolved"],
+        "bindings_dropped": stats["bindings_dropped"],
+        "rows": stats["rows"],
+        "all_bindings_missed": stats["all_bindings_missed"],
     }
+    note = _fallback_note(op, requested, fallback_stage)
+    if note is not None:
+        ack["note"] = note
+    return ack
+
+
+def _resolve_presentation(
+    op: PresentIROp, data: Any, *, surface: str, registry: Any,
+) -> "tuple[ResolvedPresentation | None, ResolvedPresentation, str | None]":
+    """Run the FP-0054 §3 4-stage template-source fallback chain.
+
+    Returns ``(requested, rendered, fallback_stage)``:
+
+    - ``requested`` — the ``ResolvedPresentation`` of the caller-requested rendering
+      (stage 1 registered ``template`` or stage 2 inline ``blueprint``), or ``None``
+      when the requested template name is UNKNOWN (nothing was bound). The ack +
+      event report these stats so the LLM's self-correction loop sees its own
+      template's outcome.
+    - ``rendered`` — the ``ResolvedPresentation`` actually handed to the surface: the
+      requested one when it produced a usable presentation (≥1 binding resolved, or a
+      literal-only template), else a synthesized fallback — stage 3 (content-type
+      default viewer), then stage 4 (generic YAML/text, which always renders).
+    - ``fallback_stage`` — ``None`` when the requested rendering was used, else the
+      fallback stage that rendered.
+
+    A malformed INLINE blueprint raises ``PresentBlueprintError`` (a hard error, not
+    a fallback trigger) — the caller surfaces ``status="error"``. A registered
+    template is already validated at registry-build time, so it never re-validates
+    here.
+    """
+    requested: "ResolvedPresentation | None" = None
+    if op.template is not None:
+        nodes = registry.get(op.template) if registry is not None else None
+        if nodes is not None:
+            requested = resolve_bindings(nodes, data, surface=surface)
+    else:
+        # Inline blueprint — the structural gate (hard error preserved), then bind.
+        nodes = validate_blueprint(op.blueprint)
+        requested = resolve_bindings(nodes, data, surface=surface)
+
+    # Requested rendering is usable → no fallback. ``all_bindings_missed`` is True
+    # only when the template had ≥1 binding and none resolved (a literal-only or a
+    # partially-hitting template is usable and renders as-is).
+    if requested is not None and not requested.all_bindings_missed:
+        return requested, requested, None
+
+    # Stage 3 — content-type default viewer (synthesized from the data's shape).
+    stage3 = resolve_bindings(
+        validate_blueprint(default_viewer_blueprint(data)), data, surface=surface,
+    )
+    if not stage3.all_bindings_missed:
+        return requested, stage3, _STAGE_CONTENT_TYPE
+
+    # Stage 4 — generic YAML/text (always renders — the final catch).
+    stage4 = resolve_bindings(
+        validate_blueprint(generic_blueprint(data)), data, surface=surface,
+    )
+    return requested, stage4, _STAGE_GENERIC
+
+
+def _requested_stats(requested: "ResolvedPresentation | None") -> dict:
+    """The ack + event binding-stats for the caller-requested rendering. An unknown
+    template name (``requested is None``) reports zeros — the LLM asked for a
+    template that resolved nothing; the ``note`` explains the fallback."""
+    if requested is None:
+        return {
+            "bindings_resolved": 0, "bindings_dropped": [], "rows": 0,
+            "all_bindings_missed": False,
+        }
+    return {
+        "bindings_resolved": requested.bindings_resolved,
+        "bindings_dropped": requested.bindings_dropped,
+        "rows": requested.rows,
+        "all_bindings_missed": requested.all_bindings_missed,
+    }
+
+
+def _fallback_note(
+    op: PresentIROp, requested: "ResolvedPresentation | None", fallback_stage: "str | None",
+) -> "str | None":
+    """The ack ``note`` naming the fallback viewer that reached the user, or ``None``
+    when the requested rendering was used directly."""
+    if fallback_stage is None:
+        return None
+    viewer = (
+        "content-type default viewer"
+        if fallback_stage == _STAGE_CONTENT_TYPE
+        else "generic YAML/text viewer"
+    )
+    if op.template is not None and requested is None:
+        return (
+            f"template {op.template!r} is not registered — presented via the "
+            f"{viewer} so the data still reached the user."
+        )
+    return (
+        f"all bindings missed — presented via the {viewer} so the data still "
+        "reached the user (re-check the template against the data shape)."
+    )
 
 
 register("present", handle)

--- a/src/reyn/core/present/__init__.py
+++ b/src/reyn/core/present/__init__.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from reyn.core.present.binding import ResolvedPresentation, resolve_bindings, resolve_pointer
 from reyn.core.present.catalog import CATALOG, PresentBlueprintError, validate_blueprint
+from reyn.core.present.fallback import default_viewer_blueprint, generic_blueprint
 from reyn.core.present.renderer import PresentationRenderer
 from reyn.core.present.source import (
     PresentSourceNotFound,
@@ -25,6 +26,8 @@ __all__ = [
     "PresentationRenderer",
     "ResolvedPresentation",
     "compute_ingested",
+    "default_viewer_blueprint",
+    "generic_blueprint",
     "resolve_bindings",
     "resolve_pointer",
     "resolve_present_source",

--- a/src/reyn/core/present/fallback.py
+++ b/src/reyn/core/present/fallback.py
@@ -1,0 +1,234 @@
+"""Default-viewer synthesizers for the present layer's 4-stage fallback (FP-0054 §3, PR-C).
+
+The FP-0054 §3 template-source fallback chain::
+
+    registered template (operator) → inline blueprint (LLM)
+        → content-type default viewer → generic YAML/text
+
+Stages 1-2 (registered / inline) are the *requested* rendering, driven in
+``op_runtime/present.py``. This module builds the two SYNTHESIZED fallback stages,
+each as a plain declarative blueprint so it runs the SAME
+``validate_blueprint`` → ``resolve_bindings`` → render path — reusing the guard,
+size caps and non-executable-by-construction shape, never a bespoke render path.
+FP-0051's viewer *registry* was deleted (design lineage only); these are built
+fresh here.
+
+- **Stage 3 — content-type default viewer** (:func:`default_viewer_blueprint`):
+  a minimal default chosen by a lightweight recognition ladder (architect-endorsed):
+  **declared content-type → diff-sniff (FP-0051 heuristic) → data shape**.
+
+  1. *Declared content-type* — an explicit ``text``/``markdown`` type → a
+     ``markdown`` component; a ``code`` type → a ``code`` component. This stage is
+     populated **only** from inline data / an explicit op arg: a `present` op has no
+     content-type field today, and — verified — an offloaded ``data_ref`` carries no
+     content-type in its frontmatter (the tool-result canonical mappers drop
+     ``content_type`` as transport). So for a ``data_ref`` source ``content_type`` is
+     ``None`` and we fall straight to diff-sniff → shape (an endorsed correct
+     degrade), never reading a content-type that is not there.
+  2. *Diff-sniff* — a string that looks like a unified diff defaults to the ``diff``
+     viewer (diff is common and should highlight).
+  3. *Shape* — a list of objects → a ``table`` over the union of the first rows'
+     keys; a list of scalars → a ``list``; an object → a ``keyvalue`` card of its
+     top-level keys; the opaque ``{"binary": ...}`` marker → a ``text`` placeholder
+     (byte count + ref, never markdown/code); any other scalar or plain string →
+     a **``text``** component (NOT ``markdown`` — markdown re-interprets ``#`` /
+     ``*`` / ``[]()`` and would mangle plain output, violating the fidelity
+     principle). Every binding is derived from the data itself, so it does not
+     "show an empty shell".
+- **Stage 4 — generic YAML/text** (:func:`generic_blueprint`): the whole value as
+  one text-family leaf — structured data dumped to YAML in a ``code`` component,
+  plain text in a ``text`` component. The terminal, always-renders catch: the
+  ref/data always reaches the user (design principle 4 — "degrade, don't fail").
+
+Both synthesizers emit blueprints in the *inline-blueprint* shape (catalog
+components + ``{"$bind": <pointer>}`` bindings / literals), so the caller validates
+and binds them identically to an LLM-authored blueprint. The value is bound (not
+inlined as a literal, where a pointer is natural) so the render model still carries
+the neutralized/capped data the surface renderer consumes.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Cap on how many columns a shape-derived table advertises — a wide object would
+# otherwise produce an unreadable table. The row values themselves are size-capped
+# at the guard; this bounds the *column* fan-out, a shape choice, not a leaf cap.
+_MAX_DEFAULT_COLUMNS = 20
+
+# How many leading rows to scan for the table-column key union. First-row-only
+# drops keys under sparse data (a later row with an extra key); scanning ALL rows
+# is unbounded work on a huge list. First-K is the bounded middle ground.
+_COLUMN_KEY_SCAN_ROWS = 50
+
+# Diff-sniff (stage-3 recognition ladder step 2, FP-0051 lineage). Only the first
+# _SNIFF_BYTES of a string are inspected — a strong, low-false-positive signal:
+# a ``diff --git`` header or a unified-diff ``@@ … @@`` hunk header.
+_SNIFF_BYTES = 4096
+_DIFF_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
+
+# Content-type prefixes that map to the markdown / code default components. Matched
+# case-insensitively against a *declared* content-type only (inline data / explicit
+# op arg) — never derived from an offloaded ``data_ref`` (no content-type there).
+_MARKDOWN_TYPES = ("text/markdown", "text/x-markdown")
+_CODE_TYPE_HINTS = ("application/json", "text/x-", "application/x-", "text/css", "text/html")
+
+
+def _is_markdown_type(content_type: "str | None") -> bool:
+    """True iff a DECLARED content-type marks the value as markdown."""
+    if not content_type:
+        return False
+    ct = content_type.lower()
+    return any(ct.startswith(p) for p in _MARKDOWN_TYPES)
+
+
+def _is_code_type(content_type: "str | None") -> bool:
+    """True iff a DECLARED content-type marks the value as source/code-like."""
+    if not content_type:
+        return False
+    ct = content_type.lower()
+    return any(ct.startswith(p) for p in _CODE_TYPE_HINTS)
+
+
+def _looks_like_diff(text: str) -> bool:
+    """FP-0051 diff-sniff — a conservative unified-diff detector over the head of
+    ``text`` (a ``diff --git`` line or a ``@@ … @@`` hunk header). Deliberately
+    strict to avoid mis-flagging prose as a diff."""
+    head = text[:_SNIFF_BYTES]
+    if head.startswith("diff --git ") or "\ndiff --git " in head:
+        return True
+    return bool(_DIFF_HUNK_RE.search(head))
+
+
+def _column_keys(rows: list) -> list[str]:
+    """The ordered union of string keys across the first :data:`_COLUMN_KEY_SCAN_ROWS`
+    row objects (column count capped at :data:`_MAX_DEFAULT_COLUMNS`). Used to derive
+    a default ``table``'s columns from a list-of-objects' actual shape."""
+    seen: dict[str, None] = {}
+    for row in rows[:_COLUMN_KEY_SCAN_ROWS]:
+        if isinstance(row, dict):
+            for k in row:
+                if isinstance(k, str) and k not in seen:
+                    seen[k] = None
+                    if len(seen) >= _MAX_DEFAULT_COLUMNS:
+                        return list(seen)
+    return list(seen)
+
+
+def _escape_token(key: str) -> str:
+    """Escape a dict key into a single RFC 6901 reference token (``~`` → ``~0``,
+    ``/`` → ``~1``) so a key containing those characters binds correctly."""
+    return key.replace("~", "~0").replace("/", "~1")
+
+
+def default_viewer_blueprint(data: Any, *, content_type: "str | None" = None) -> "list[dict]":
+    """Stage 3 — synthesize a content-type/shape default blueprint for ``data``.
+
+    The recognition ladder (architect-endorsed): **declared content-type →
+    diff-sniff → data shape**.
+
+    - ``content_type`` is a DECLARED type (from inline data / an explicit op arg
+      only — an offloaded ``data_ref`` has none, so callers pass ``None`` for a ref
+      source and the ladder degrades to diff-sniff → shape). A markdown type → a
+      ``markdown`` component; a code type → a ``code`` component.
+    - A string that sniffs as a unified diff → a ``diff`` component.
+    - ``list`` of objects → a ``table`` binding the whole list, columns = the union
+      of the first rows' keys (row-relative ``/<key>`` paths);
+    - ``list`` of scalars (or mixed / empty) → a ``list`` binding the whole list;
+    - ``dict`` → a ``keyvalue`` card, one row per top-level key; the opaque
+      ``{"binary": ...}`` marker → a ``text`` placeholder (byte count + ref);
+    - any other scalar / plain string → a ``text`` of the whole value (NOT
+      ``markdown`` — plain output must not be re-interpreted as markup).
+
+    Returns a blueprint (list of component nodes) in the inline-blueprint shape.
+    """
+    # 1. Declared content-type (populated only for inline/explicit-arg sources).
+    if isinstance(data, str):
+        if _is_markdown_type(content_type):
+            return [{"component": "markdown", "text": {"$bind": ""}}]
+        if _is_code_type(content_type):
+            return [{"component": "code", "text": {"$bind": ""}}]
+        # 2. Diff-sniff (FP-0051 heuristic) — a unified diff highlights by default.
+        if _looks_like_diff(data):
+            return [{"component": "diff", "text": {"$bind": ""}}]
+        # 3. Plain string → text (fidelity: never markdown for un-typed text).
+        return [{"component": "text", "text": {"$bind": ""}}]
+
+    # 3. Shape-based defaults for structured data.
+    if isinstance(data, list):
+        if any(isinstance(row, dict) for row in data):
+            keys = _column_keys(data)
+            if keys:
+                return [{
+                    "component": "table",
+                    "rows": {"$bind": ""},
+                    "columns": [
+                        {"header": k, "path": f"/{_escape_token(k)}"} for k in keys
+                    ],
+                }]
+        # Scalars, mixed, or empty → a plain list of the whole array.
+        return [{"component": "list", "items": {"$bind": ""}}]
+
+    if isinstance(data, dict):
+        # The opaque non-text binary marker from resolve_present_source → a text
+        # placeholder (never markdown/code — there is nothing to highlight).
+        if data.get("binary") is True:
+            size = data.get("byte_size")
+            size_txt = f"{size} bytes" if isinstance(size, int) else "unknown size"
+            return [{
+                "component": "text",
+                "text": f"[binary data — {size_txt}; full data in the ref]",
+            }]
+        keys = [k for k in data if isinstance(k, str)]
+        if keys:
+            return [{
+                "component": "keyvalue",
+                "rows": [
+                    {"label": k, "value": {"$bind": f"/{_escape_token(k)}"}}
+                    for k in keys
+                ],
+            }]
+        # An empty / non-string-keyed object → fall through to the whole-doc view.
+
+    # Any other scalar (number / bool / null) → a text of the whole value.
+    return [{"component": "text", "text": {"$bind": ""}}]
+
+
+def generic_blueprint(data: Any) -> "list[dict]":
+    """Stage 4 — the generic YAML/text terminal viewer for ``data``.
+
+    Structured data (dict / list) → a ``code`` component (``language: yaml``) whose
+    text is the whole value dumped to YAML; plain text / a scalar → a ``text``
+    component of the value. The text is a LITERAL (the value is already in hand),
+    so it still passes through the guard + the per-leaf size cap at the render seam.
+    Always renders — the final catch so the data never fails to reach the user.
+    """
+    if isinstance(data, (dict, list)):
+        return [{
+            "component": "code",
+            "language": "yaml",
+            "text": _to_yaml(data),
+        }]
+    if data is None:
+        return [{"component": "text", "text": ""}]
+    if isinstance(data, str):
+        return [{"component": "text", "text": data}]
+    return [{"component": "text", "text": str(data)}]
+
+
+def _to_yaml(data: Any) -> str:
+    """Dump ``data`` to a YAML string for the generic viewer, falling back to a
+    JSON dump if the value is not YAML-serializable (defensive — the resolved
+    value is JSON-origin, so ``safe_dump`` handles it, but a stray non-serializable
+    object must never crash the always-renders terminal stage)."""
+    import yaml
+
+    try:
+        return yaml.safe_dump(data, allow_unicode=True, sort_keys=False, default_flow_style=False)
+    except yaml.YAMLError:
+        import json
+
+        return json.dumps(data, ensure_ascii=False, indent=2, default=str)
+
+
+__all__ = ["default_viewer_blueprint", "generic_blueprint"]

--- a/src/reyn/data/presentations/__init__.py
+++ b/src/reyn/data/presentations/__init__.py
@@ -1,0 +1,27 @@
+"""reyn.data.presentations — the named-template registry for the present layer (FP-0054 PR-C).
+
+Named presentation templates live in ``.reyn/config/presentations.yaml`` and are
+registered the SAME way ``skills.entries`` / ``pipelines.entries`` are (config
+section → per-entry declaration → hot-reload seam at the turn boundary).
+
+A named template's value is a **blueprint** — the identical declarative,
+non-executable component tree an inline blueprint is — validated through
+``reyn.core.present.validate_blueprint`` at registry-build time (so a malformed
+template is caught at config load, per-entry isolated, never at render time).
+Registering a named template is an **operator/config action**: the write-gate
+culture means the LLM authors inline blueprints only and never registers a named
+template.
+"""
+from __future__ import annotations
+
+from reyn.data.presentations.registry import (
+    PresentationLoadError,
+    PresentationRegistry,
+    build_presentation_registry,
+)
+
+__all__ = [
+    "PresentationLoadError",
+    "PresentationRegistry",
+    "build_presentation_registry",
+]

--- a/src/reyn/data/presentations/registry.py
+++ b/src/reyn/data/presentations/registry.py
@@ -1,0 +1,198 @@
+"""reyn.data.presentations.registry — config-entries → PresentationRegistry loader (FP-0054 PR-C).
+
+The production population path for named presentation templates (the FP-0054 §3
+4-stage fallback's stage 1 — "registered template, operator-owned"). Templates
+are registered PURELY via explicit ``presentations.entries`` declarations in
+config — the same registration model as
+``reyn.data.pipelines.registry.build_pipeline_registry`` /
+``reyn.data.skills.registry.build_skill_registry`` / ``mcp.servers``.
+
+Unlike a skill (metadata only, the file is never parsed) and like a pipeline (the
+value must be PARSED/validated to be usable), a named template's value is a
+**blueprint** — the same declarative component tree an inline blueprint is —
+carried INLINE in the entry (a blueprint is small declarative data, not a
+file-backed artifact like a pipeline DSL or a ``SKILL.md``, so it needs no path
+indirection). Each entry's ``blueprint`` is validated through
+:func:`reyn.core.present.catalog.validate_blueprint` at build time, and the
+registry stores the NORMALIZED node list keyed by the entry name. So a registered
+template is already-valid nodes at render time — a malformed template is rejected
+at config load, never at ``present`` dispatch.
+
+**Operator/config action, not an LLM action.** There is deliberately NO install
+op: registering a named template is a write-gate operator action (the operator
+edits ``presentations.yaml``); the LLM authors inline blueprints only. This is why
+this loader has no ``op.name`` vs declared-name reconciliation (a blueprint has no
+self-declared name — the entry key IS the name) and no
+``request_reload``-from-an-op path.
+
+Failure posture is PER-ENTRY ISOLATED, not process-fatal (mirrors
+``build_pipeline_registry``): a malformed blueprint or a non-dict entry is caught
+INSIDE the ``entries`` loop — logged as a ``logging`` warning AND durably emitted
+as a ``presentation_load_failed`` P6 event (via ``emit_cli_event`` — this loader
+has no per-session ``ctx``/``EventLog`` handle and is called from multiple
+entrypoints, so the session-independent sink is the right fit), then SKIPPED — the
+remaining entries still load. This matters because
+``SessionFactoryConfig.from_config`` calls this at EVERY session construction with
+no enclosing try/except, so one broken template entry must not crash reyn startup.
+
+``strict=True`` (opt-in, default ``False``) restores the fail-loud posture — the
+first per-entry failure raises :class:`PresentationLoadError` straight out of
+:func:`build_presentation_registry` with NO logging/eventing. This exists for the
+``presentations`` hot-reload seam (``Session._reapply_presentations``): that seam
+needs ATOMIC last-good-registry semantics — reject the ENTIRE rebuild on any
+broken entry and keep serving the old registry unchanged, rather than silently
+dropping just the broken template from a live session mid-reload. Session-factory
+construction is the opposite case (a NEW session has no "old registry" to fall
+back to), so ``strict=False`` is right there: isolate the bad entry, keep the good
+ones, let the session start.
+
+``raw_presentations=None`` (the util/no-root path), an empty/absent
+``presentations:`` block, or an empty ``entries`` map → an empty registry (zero
+templates is a valid, non-error state — same as skills/pipelines). These return
+before the per-entry loop even starts, so nothing is logged.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from reyn.core.present import PresentBlueprintError, validate_blueprint
+
+logger = logging.getLogger(__name__)
+
+
+class PresentationLoadError(ValueError):
+    """A ``presentations.entries`` declaration could not be loaded (missing /
+    malformed ``blueprint``, or a blueprint that fails the structural
+    :func:`validate_blueprint` gate). Raised internally by :func:`_load_one_entry`
+    and caught PER-ENTRY by :func:`build_presentation_registry` (logged + durably
+    emitted as a ``presentation_load_failed`` event, then skipped — see the module
+    docstring), unless ``strict=True``."""
+
+
+class PresentationRegistry:
+    """An in-memory ``name -> validated blueprint nodes`` map for named templates.
+
+    A template's value is the NORMALIZED node list returned by
+    :func:`validate_blueprint` (structure only; leaf neutralization happens later
+    at the render seam, exactly as for an inline blueprint). Built fresh + swapped
+    on hot-reload (never mutated in place), so the reference the op resolves
+    against is always a consistent snapshot.
+    """
+
+    def __init__(self) -> None:
+        self._templates: dict[str, list[dict]] = {}
+
+    def register(self, name: str, nodes: list[dict]) -> None:
+        """Register a validated template under ``name``. Re-registration of an
+        already-present name raises :class:`ValueError` (the caller resolves
+        first-registered-wins by catching this — mirrors ``PipelineRegistry``)."""
+        if name in self._templates:
+            raise ValueError(f"presentation template {name!r} is already registered")
+        self._templates[name] = nodes
+
+    def get(self, name: str) -> "list[dict] | None":
+        """The validated node list for ``name``, or ``None`` when unregistered
+        (an unknown name is NOT an error — it falls through the present op's
+        fallback chain to the generic viewer)."""
+        return self._templates.get(name)
+
+    def has(self, name: str) -> bool:
+        """True iff ``name`` is a registered template."""
+        return name in self._templates
+
+    def names(self) -> list[str]:
+        """The registered template names (declaration order)."""
+        return list(self._templates)
+
+
+def _load_one_entry(key: str, raw: Any, registry: PresentationRegistry) -> None:
+    """Load + register ONE ``presentations.entries.<key>`` declaration.
+
+    Raises :class:`PresentationLoadError` for a missing ``blueprint``, a blueprint
+    that fails the structural gate, or a duplicate name across entries. This
+    function fails loud; :func:`build_presentation_registry` is the isolation
+    boundary that catches it per-entry.
+    """
+    if not isinstance(raw, dict):
+        raise PresentationLoadError(
+            f"presentations.entries.{key!r} must be a mapping, got {type(raw).__name__}"
+        )
+    if "blueprint" not in raw:
+        raise PresentationLoadError(
+            f"presentations.entries.{key!r} has no 'blueprint' — a named template's "
+            "value is a declarative component tree (the same shape as an inline "
+            "blueprint)."
+        )
+    try:
+        nodes = validate_blueprint(raw["blueprint"])
+    except PresentBlueprintError as exc:
+        raise PresentationLoadError(
+            f"presentations.entries.{key!r}: blueprint failed the structural gate: {exc}"
+        ) from exc
+
+    try:
+        registry.register(key, nodes)
+    except ValueError as exc:
+        # Duplicate name — first-registered wins; this (later) entry fails.
+        raise PresentationLoadError(
+            f"presentations.entries.{key!r}: {exc}"
+        ) from exc
+
+
+def build_presentation_registry(
+    raw_presentations: "dict[str, Any] | None", *, strict: bool = False,
+) -> PresentationRegistry:
+    """Build a populated :class:`PresentationRegistry` from the ``presentations:``
+    config dict.
+
+    For each ``presentations.entries.<key>`` declaration, the inline ``blueprint``
+    is validated via :func:`validate_blueprint` and registered under the entry key
+    (the authoritative name a ``present`` op's ``template`` resolves against).
+
+    ``raw_presentations=None`` / an empty-or-absent ``presentations:`` block / a
+    block with no ``entries`` → an empty registry (zero-config default, not a
+    failure — nothing logged). Otherwise each per-entry failure (missing / malformed
+    blueprint, duplicate name) is caught PER ENTRY, logged, durably emitted as a
+    ``presentation_load_failed`` P6 event, then skipped — unless ``strict=True``,
+    which re-raises the first failure (the hot-reload seam's atomic posture; see the
+    module docstring).
+    """
+    from reyn.core.events.events import emit_cli_event
+
+    registry = PresentationRegistry()
+    if not isinstance(raw_presentations, dict):
+        return registry
+
+    raw_entries = raw_presentations.get("entries")
+    if not isinstance(raw_entries, dict):
+        return registry
+
+    for key, raw in raw_entries.items():
+        key = str(key)
+        if isinstance(raw, dict) and not bool(raw.get("enabled", True)):
+            continue
+
+        try:
+            _load_one_entry(key, raw, registry)
+        except PresentationLoadError as exc:
+            if strict:
+                raise
+            logger.warning(
+                "presentations.entries.%r failed to load and was skipped: %s",
+                key, exc,
+            )
+            try:
+                emit_cli_event(
+                    "presentation_load_failed",
+                    key=key,
+                    error=str(exc),
+                )
+            except Exception:  # noqa: BLE001 -- durable-capture must never crash startup
+                pass
+            continue
+
+    return registry
+
+
+__all__ = ["PresentationRegistry", "build_presentation_registry", "PresentationLoadError"]

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -46,6 +46,12 @@ class SessionFactoryConfig:
     # available_skills snapshot. Empty registry when project_root is unknown
     # (direct/test from_config(config)) → byte-identical to pre-#2575.
     pipeline_registry: Any
+    # FP-0054 PR-C: the populated PresentationRegistry, built ONCE per frontend from
+    # config.presentations (validate each inline blueprint → register by name).
+    # Threaded to every Session (incl. spawns) so a named `present` template resolves
+    # — mirrors the build-once available_skills / pipeline_registry snapshots. Empty
+    # registry when config has no presentations (byte-identical to pre-PR-C).
+    presentation_registry: Any
     # ── AgentRegistry uniform config (3) ────────────────────────────────────
     delegation_capability_default: str
     # #2103 C3: operator spawn-tree bounds (safety.spawn.*) — the LLM spawn seams
@@ -72,6 +78,7 @@ class SessionFactoryConfig:
         from pathlib import Path
 
         from reyn.data.pipelines.registry import build_pipeline_registry
+        from reyn.data.presentations.registry import build_presentation_registry
         from reyn.data.skills.registry import build_skill_registry
         root = Path(project_root) if project_root is not None else None
         pipeline_registry = (
@@ -79,6 +86,10 @@ class SessionFactoryConfig:
             if root is not None
             else build_pipeline_registry(None, Path.cwd())
         )
+        # FP-0054 PR-C: inline blueprints — no filesystem locus, so no project_root
+        # dependency (unlike pipelines). Built here so every factory site threads the
+        # same validated snapshot.
+        presentation_registry = build_presentation_registry(config.presentations)
         return cls(
             sandbox_config=config.sandbox,
             multimodal_config=config.multimodal,
@@ -92,6 +103,8 @@ class SessionFactoryConfig:
             available_skills=build_skill_registry(config.skills),
             # #2575: built once here (empty when project_root is unknown).
             pipeline_registry=pipeline_registry,
+            # FP-0054 PR-C: built once here from config.presentations.
+            presentation_registry=presentation_registry,
             delegation_capability_default=config.delegation.capability_default,
             max_spawn_depth=config.safety.spawn.max_depth,
             max_spawn_children=config.safety.spawn.max_children,

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -65,6 +65,16 @@ def validate_in_set(in_set: "dict") -> "str | None":
         entries = skills.get("entries")
         if entries is not None and not isinstance(entries, dict):
             return "skills.entries must be a mapping"
+    presentations = in_set.get("presentations")
+    if presentations is not None:
+        # FP-0054 PR-C: structural shape check only (mirrors skills). A malformed
+        # individual blueprint is caught per-entry by build_presentation_registry
+        # (strict=True on the reload seam → the whole rebuild rejects, last-good kept).
+        if not isinstance(presentations, dict):
+            return "presentations section must be a mapping"
+        entries = presentations.get("entries")
+        if entries is not None and not isinstance(entries, dict):
+            return "presentations.entries must be a mapping"
     hooks = in_set.get("hooks")
     if hooks is not None:
         # #2073 S2b: validate the runtime hooks shape via the real loader so a

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -55,6 +55,7 @@ def build_router_op_context(
     agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
     intervention_bus: Any = None,  # Session wires post-hoc; RouterHostAdapter inline
     presentation_renderer: Any = None,  # FP-0054 PR-B: RouterHostAdapter wires inline (factory)
+    presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
     multimodal_config: Any = None,  # #364
     media_store: Any = None,  # #383
     compact_now: Any = None,  # #272/#1128
@@ -136,6 +137,7 @@ def build_router_op_context(
         agent_id=agent_id,
         intervention_bus=intervention_bus,
         presentation_renderer=presentation_renderer,
+        presentation_registry=presentation_registry,
         multimodal_config=multimodal_config,
         media_store=media_store,
         compact_now=compact_now,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -128,5 +128,6 @@ def build_scoped_chat_session(
         chat_tool_use_scheme=factory_config.chat_tool_use_scheme,
         available_skills=factory_config.available_skills,  # #2548 PR-A
         pipeline_registry=factory_config.pipeline_registry,  # #2575
+        presentation_registry=factory_config.presentation_registry,  # FP-0054 PR-C
         **base,
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -122,6 +122,7 @@ class RouterHostAdapter:
         state_log: Any = None,                  # StateLog | None — #2248 PR-A2 (config emit)
         agent_registry: Any,                    # AgentRegistry | None
         pipeline_registry: Any = None,          # PipelineRegistry | None — IS-5
+        presentation_registry: Any = None,      # PresentationRegistry | None — FP-0054 PR-C
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
         current_task_id_fn: "Callable[[], str | None] | None" = None,     # #1953 §16
@@ -364,6 +365,12 @@ class RouterHostAdapter:
         self._state_log = state_log  # #2259 PR-1: WAL head for config generation emit
         self._registry = agent_registry
         self._pipeline_registry = pipeline_registry  # IS-5: run_pipeline lookup source
+        # FP-0054 PR-C: operator named-template registry (presentations.yaml). Held on
+        # the adapter (like _pipeline_registry) so make_router_op_context threads the
+        # CURRENT snapshot into each OpContext; the pipelines/skills-style hot-reload
+        # seam (Session._reapply_presentations) SWAPS this reference (dual-write with
+        # the Session's copy) so a newly-registered template is visible next turn.
+        self._presentation_registry = presentation_registry
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
         self._current_task_id_fn = current_task_id_fn      # #1953 §16
@@ -665,6 +672,14 @@ class RouterHostAdapter:
         against the session's actual registered pipelines instead of the
         None landmine."""
         return self._pipeline_registry
+
+    def get_presentation_registry(self) -> Any:
+        """The adapter's captured PresentationRegistry (or None) — FP-0054 PR-C.
+        ``make_router_op_context`` reads it into each router OpContext's
+        ``presentation_registry`` so a `present` op resolves a named ``template``.
+        The public surface the hot-reload dual-write (``_reapply_presentations``)
+        swaps and tests observe (mirrors ``get_pipeline_registry``)."""
+        return self._presentation_registry
 
     def get_web_fetch_allowed(self) -> bool:
         """Always returns True — FP-0022: web_fetch is now always in the catalog.
@@ -1960,6 +1975,8 @@ class RouterHostAdapter:
             agent_id=None,
             intervention_bus=bus,
             presentation_renderer=presentation_renderer,
+            # FP-0054 PR-C: the adapter's CURRENT registry snapshot (hot-reload swaps it).
+            presentation_registry=self._presentation_registry,
             multimodal_config=self._multimodal_config,
             media_store=self._media_store,
             compact_now=self._compact_now,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -746,6 +746,11 @@ class Session:
         # session). None (direct/test construction) → an empty registry, byte-
         # identical to pre-#2575's own-constructed empty one.
         pipeline_registry: "PipelineRegistry | None" = None,
+        # FP-0054 PR-C: the pre-built PresentationRegistry (operator named templates
+        # from presentations.yaml, built once at the session factory). None
+        # (direct/test construction) → an empty registry (byte-identical to pre-PR-C:
+        # every named template is "unknown" → generic fallback viewer).
+        presentation_registry: "object | None" = None,
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -1149,6 +1154,17 @@ class Session:
         # registered pipeline as ``pipeline__<name>`` to the LLM (IS-5 D19).
         self._pipeline_registry = (
             pipeline_registry if pipeline_registry is not None else PipelineRegistry()
+        )
+        # FP-0054 PR-C: the session's named-presentation-template registry. Threaded
+        # to RouterHostAdapter below (mirrors pipeline_registry) → each router
+        # OpContext's presentation_registry → the `present` op's stage-1 template
+        # resolution. The hot-reload seam (_reapply_presentations) SWAPS this
+        # reference AND the adapter's captured copy so a newly-registered template is
+        # visible at the next turn boundary. None (direct/test) → empty registry.
+        from reyn.data.presentations import PresentationRegistry
+        self._presentation_registry = (
+            presentation_registry if presentation_registry is not None
+            else PresentationRegistry()
         )
         # PR11: max delegation hop depth (LangGraph-style). 0 = user input,
         # each `_send_to_agent` increments. Refuse send when depth > limit.
@@ -1576,6 +1592,10 @@ class Session:
             # RouterCallerState.pipeline_registry by
             # RouterLoop._build_router_caller_state.
             pipeline_registry=self._pipeline_registry,
+            # FP-0054 PR-C: the session's PresentationRegistry — mirrors
+            # pipeline_registry above; the adapter threads its CURRENT snapshot into
+            # each router OpContext, and _reapply_presentations swaps both copies.
+            presentation_registry=self._presentation_registry,
             # #2103 S1bc-exec: record a spawned session's sid→task (the trusted result
             # header source) + read this session's LIVE sid (the cached session_id above
             # is stale for spawned sessions, stamped post-construction) for the non-main
@@ -2167,6 +2187,15 @@ class Session:
         ``RouterCallerState`` by ``RouterLoop._build_router_caller_state``.
         """
         return self._pipeline_registry
+
+    @property
+    def presentation_registry(self):
+        """Read-only accessor for the session's owning PresentationRegistry
+        (FP-0054 PR-C — operator named templates from presentations.yaml). Mirrors
+        ``pipeline_registry`` above; threaded into ``RouterHostAdapter`` at
+        construction and swapped by ``_reapply_presentations`` on hot-reload. Tests
+        verify a registered template is live via this surface."""
+        return self._presentation_registry
 
     @property
     def interventions(self) -> "InterventionRegistry":
@@ -3471,6 +3500,7 @@ class Session:
         hr.register_seam("hooks", self._reapply_hooks)  # #2073 S2b (global hooks)
         hr.register_seam("skills", self._reapply_skills)  # #2548 PR-B: skills hot-reload
         hr.register_seam("pipelines", self._reapply_pipelines)  # #2581: pipeline hot-reload
+        hr.register_seam("presentations", self._reapply_presentations)  # FP-0054 PR-C
 
     def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
         """Build the LAYERED hook registry — the three-layer COMBINE (#2073 S2b + the
@@ -3687,6 +3717,45 @@ class Session:
         # after a fully successful build, so a failure above never half-applies.
         self._pipeline_registry = new_registry
         self._router_host._pipeline_registry = new_registry
+        return True
+
+    async def _reapply_presentations(self, in_set: dict) -> bool:
+        """Reapply the named-presentation-template registry (FP-0054 PR-C) — re-read
+        the full config cascade (``load_config(project_root).presentations``) and
+        rebuild via :func:`~reyn.data.presentations.registry.build_presentation_registry`,
+        mirroring ``_reapply_pipelines`` exactly (same disk-loader shape, same
+        dual-write need).
+
+        The registry is rebuilt fresh + the reference SWAPPED (never mutated), so an
+        added / changed / removed template is picked up. The swap is a dual-write:
+        ``self._presentation_registry`` AND ``self._router_host._presentation_registry``
+        (the adapter holds its own captured copy that ``make_router_op_context`` reads
+        into each OpContext) — both must be reassigned or the adapter keeps serving the
+        stale registry.
+
+        Fail-loud-but-non-fatal: ``build_presentation_registry(..., strict=True)`` raises
+        ``PresentationLoadError`` on the FIRST malformed template — ``strict=True``
+        opts INTO the atomic last-good posture (a live session keeps its old registry
+        rather than half-applying a broken reload). The raise is caught here (alongside
+        any other error) — the seam logs + returns False, leaving the OLD registry (on
+        both holders) intact. The new registry is only assigned after a fully successful
+        build, so a malformed file at reload-time can never half-apply.
+
+        ``in_set`` is ignored; the full cascade re-read is the correct source (same
+        pattern as ``_reapply_skills`` / ``_reapply_pipelines``). Returns True iff a new
+        registry was successfully built + swapped."""
+        from reyn.config.loader import load_config
+        from reyn.data.presentations.registry import build_presentation_registry
+        try:
+            fresh_cfg = load_config(self._hot_reload_project_root())
+            new_registry = build_presentation_registry(fresh_cfg.presentations, strict=True)
+        except Exception as exc:  # noqa: BLE001 — best-effort, last-good on failure (incl. PresentationLoadError)
+            logger.warning("_reapply_presentations: registry rebuild failed: %r", exc)
+            return False
+        # Dual-write swap (Session + the adapter's captured copy) — only reached after
+        # a fully successful build, so a failure above never half-applies.
+        self._presentation_registry = new_registry
+        self._router_host._presentation_registry = new_registry
         return True
 
     async def _reapply_per_agent_capability(self, in_set: dict) -> bool:

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -89,11 +89,12 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
 def test_seams_registered_on_the_reloader(tmp_path: Path) -> None:
     """Tier 2: the Session registers its reapply seams on the HotReloader (the 4 S2
     seams + the S2b hooks seam + the #2548 PR-B skills seam + the #2581 pipelines
-    seam)."""
+    seam + the FP-0054 PR-C presentations seam)."""
     session = _make_session(tmp_path)
     names = [name for (name, _fn) in session._hot_reloader._seams]
     assert names == [
-        "cron", "mcp", "per_agent_capability", "new_agent", "hooks", "skills", "pipelines",
+        "cron", "mcp", "per_agent_capability", "new_agent", "hooks", "skills",
+        "pipelines", "presentations",
     ]
 
 

--- a/tests/test_2103_C3_spawn_limits_1953.py
+++ b/tests/test_2103_C3_spawn_limits_1953.py
@@ -39,11 +39,12 @@ def test_safety_spawn_is_restart_only_not_self_raisable():
     from reyn.config.loader import _HOT_RELOAD_FILES
     assert "reyn.yaml" not in _HOT_RELOAD_FILES
     assert "reyn.local.yaml" not in _HOT_RELOAD_FILES
-    # the hot-reload set is the narrow IN-layer (mcp/cron/hooks/skills/pipelines) —
-    # none carry safety.*
+    # the hot-reload set is the narrow IN-layer (mcp/cron/hooks/skills/
+    # pipelines/presentations) — none carry safety.*
     assert set(_HOT_RELOAD_FILES) == {
         "config/mcp.yaml", "config/cron.yaml", "config/hooks.yaml",
         "config/skills.yaml", "config/pipelines.yaml",
+        "config/presentations.yaml",
     }
 
 

--- a/tests/test_present_registry_fp0054_prc.py
+++ b/tests/test_present_registry_fp0054_prc.py
@@ -1,0 +1,441 @@
+"""Present layer PR-C (FP-0054) — presentations.yaml registration + hot-reload + 4-stage fallback.
+
+Contract + OS-invariant coverage for the named-template registry and the §3
+template-source fallback chain (registered template → inline blueprint →
+content-type default viewer → generic YAML/text). Real Session /
+RouterHostAdapter / HotReloader / OpContext / EventLog — no collaborator mocks.
+Assertions are on the public op ack, the resolved render model reaching a
+recording renderer, the `presented` event payload, and the public registry
+surface (`names()` / `has()` / `get()` / `session.presentation_registry` /
+`router_host.get_presentation_registry()`) — never private state, never exact
+render layout.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.config.loader import load_config
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle
+from reyn.data.presentations.registry import (
+    PresentationLoadError,
+    PresentationRegistry,
+    build_presentation_registry,
+)
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.session import Session
+from reyn.schemas.models import ALL_OP_KINDS, PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# A named template (operator config) whose value is a blueprint — the same
+# declarative component tree an inline blueprint is.
+_AUTHORS_TEMPLATE = [
+    {
+        "component": "table",
+        "rows": {"$bind": "/results"},
+        "columns": [{"header": "Author", "path": "/author"}],
+    }
+]
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+
+
+class _RecordingRenderer:
+    """A real (non-mock) PresentationRenderer that records what reached the
+    surface. Fire-and-continue: ``render`` returns nothing the op awaits."""
+
+    surface_name = "test-surface"
+
+    def __init__(self) -> None:
+        self.rendered: list = []
+
+    def render(self, resolved) -> None:
+        self.rendered.append(resolved)
+
+
+def _ctx(
+    tmp_path: Path,
+    *,
+    registry: "PresentationRegistry | None" = None,
+    renderer: "_RecordingRenderer | None" = None,
+) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=_resolver(tmp_path))
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=_resolver(tmp_path),
+        actor="present_prc_test",
+        presentation_registry=registry,
+        presentation_renderer=renderer,
+    )
+    return ctx, events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _all_leaf_text(resolved) -> str:
+    """Every rendered string leaf in the render model (for a "did the data reach
+    the surface" content-presence assertion — not a layout pin)."""
+    parts: list[str] = []
+
+    def _walk(obj) -> None:
+        if isinstance(obj, str):
+            parts.append(obj)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                _walk(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                _walk(v)
+
+    _walk(resolved.nodes)
+    return "\n".join(parts)
+
+
+# ── Tier 1: config round-trip (non-default value reaches the registry) ────────
+
+
+def test_config_roundtrip_named_template_reaches_registry(tmp_path: Path) -> None:
+    """Tier 1: a real .reyn/config/presentations.yaml with a named template (a
+    NON-default blueprint value) is loaded through the full config cascade + built
+    into the registry under its entry name, with the blueprint structurally
+    validated (mirrors the skills/pipelines disk round-trip)."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    cfg_dir = tmp_path / ".reyn" / "config"
+    cfg_dir.mkdir(parents=True)
+    (cfg_dir / "presentations.yaml").write_text(
+        yaml.dump({"presentations": {"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}}}),
+        encoding="utf-8",
+    )
+
+    cfg = load_config(tmp_path)
+    # The presentations section reached ReynConfig (the entries union-merge).
+    assert cfg.presentations.get("entries", {}).get("authors", {}).get("blueprint") == _AUTHORS_TEMPLATE
+
+    registry = build_presentation_registry(cfg.presentations)
+    assert registry.has("authors")
+    assert registry.names() == ["authors"]
+    nodes = registry.get("authors")
+    # Stored as the NORMALIZED validated node list (structure preserved).
+    assert nodes[0]["component"] == "table"
+    assert nodes[0]["columns"][0]["header"] == "Author"
+
+
+def test_malformed_template_entry_skipped_not_fatal(tmp_path: Path) -> None:
+    """Tier 1: a malformed blueprint entry (non-catalog component) is per-entry
+    isolated — logged + skipped in lenient mode, the good sibling still loads;
+    strict mode (the hot-reload posture) re-raises."""
+    raw = {
+        "entries": {
+            "good": {"blueprint": _AUTHORS_TEMPLATE},
+            "bad": {"blueprint": {"component": "button", "text": "click"}},
+        }
+    }
+    registry = build_presentation_registry(raw)  # lenient default
+    assert registry.has("good")
+    assert not registry.has("bad")
+
+    with pytest.raises(PresentationLoadError):
+        build_presentation_registry(raw, strict=True)
+
+
+def test_disabled_template_entry_not_registered(tmp_path: Path) -> None:
+    """Tier 1: an entry with enabled: false is not registered (mirrors skills)."""
+    raw = {"entries": {"off": {"blueprint": _AUTHORS_TEMPLATE, "enabled": False}}}
+    registry = build_presentation_registry(raw)
+    assert not registry.has("off")
+
+
+# ── Tier 1: named-template resolution renders via the same binding path ───────
+
+
+def test_registered_template_renders_via_same_binding_path_as_inline(tmp_path: Path) -> None:
+    """Tier 1: a registered template resolves + renders via the SAME
+    validate→resolve_bindings→render path an equivalent inline blueprint uses —
+    the op ack reflects it identically and the render model reaches the surface."""
+    data = {"results": [{"author": "amy"}, {"author": "bob"}]}
+    registry = PresentationRegistry()
+    registry.register("authors", build_presentation_registry(
+        {"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}}).get("authors"))
+
+    # Named-template path.
+    r_named = _RecordingRenderer()
+    ctx_n, _ = _ctx(tmp_path, registry=registry, renderer=r_named)
+    ack_named = _run(handle(
+        PresentIROp(kind="present", data_inline=data, template="authors"), ctx_n))
+
+    # Equivalent inline-blueprint path over the same data.
+    r_inline = _RecordingRenderer()
+    ctx_i, _ = _ctx(tmp_path, registry=registry, renderer=r_inline)
+    ack_inline = _run(handle(
+        PresentIROp(kind="present", data_inline=data, blueprint=_AUTHORS_TEMPLATE), ctx_i))
+
+    assert ack_named["ok"] is True
+    assert ack_named["bindings_resolved"] == ack_inline["bindings_resolved"]
+    assert ack_named["rows"] == ack_inline["rows"] == 2
+    assert "note" not in ack_named  # no fallback — the template matched
+    # The data reached the surface via the registered template.
+    assert r_named.rendered, "the registered template must reach the wired renderer"
+    surfaced = _all_leaf_text(r_named.rendered[-1])
+    assert "amy" in surfaced and "bob" in surfaced
+
+
+def test_registered_template_records_name_in_presented_event(tmp_path: Path) -> None:
+    """Tier 1: the presented event records the REGISTERED NAME as its template
+    field (not an inline-blueprint hash)."""
+    data = {"results": [{"author": "amy"}]}
+    registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
+    ctx, events = _ctx(tmp_path, registry=registry, renderer=_RecordingRenderer())
+    _run(handle(PresentIROp(kind="present", data_inline=data, template="authors"), ctx))
+    ev = [e for e in events.all() if e.type == "presented"][-1]
+    assert ev.data["template"] == "authors"
+    assert ev.data["bindings_resolved"] >= 1
+
+
+# ── Tier 1: 4-stage fallback (never a hard error; data reaches the surface) ───
+
+
+def test_unknown_template_falls_to_generic_viewer_not_error(tmp_path: Path) -> None:
+    """Tier 1: an UNKNOWN template name is NOT a hard error — it falls through the
+    fallback chain to a generic viewer, the data still reaches the surface, and the
+    ack carries ok=True + a note naming the fallback."""
+    data = {"author": "amy", "title": "hello"}
+    registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
+    renderer = _RecordingRenderer()
+    ctx, events = _ctx(tmp_path, registry=registry, renderer=renderer)
+
+    ack = _run(handle(
+        PresentIROp(kind="present", data_inline=data, template="does_not_exist"), ctx))
+
+    assert ack["status"] == "ok"
+    assert ack["ok"] is True
+    assert "note" in ack and "not registered" in ack["note"]
+    # The data reached the surface via the fallback (content-type default viewer:
+    # a dict → keyvalue over its keys).
+    assert renderer.rendered
+    surfaced = _all_leaf_text(renderer.rendered[-1])
+    assert "amy" in surfaced and "hello" in surfaced
+    # And the presented event still fired (audit-first).
+    assert [e for e in events.all() if e.type == "presented"]
+
+
+def test_all_bindings_miss_template_falls_to_fallback_viewer(tmp_path: Path) -> None:
+    """Tier 1: a registered template whose bindings ALL miss the data does NOT show
+    an empty shell — it falls to the fallback viewer (data still reaches the user),
+    while the ack preserves the LLM self-correction signal (all_bindings_missed +
+    the drop list from the REQUESTED template) plus a fallback note."""
+    # Template expects /results[*]/author; the data has no /results at all.
+    registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
+    data = {"completely": "different", "shape": [1, 2, 3]}
+    renderer = _RecordingRenderer()
+    ctx, _ = _ctx(tmp_path, registry=registry, renderer=renderer)
+
+    ack = _run(handle(PresentIROp(kind="present", data_inline=data, template="authors"), ctx))
+
+    assert ack["ok"] is True
+    assert ack["all_bindings_missed"] is True  # the REQUESTED template's own outcome
+    assert ack["bindings_resolved"] == 0
+    assert "note" in ack and "all bindings missed" in ack["note"]
+    # The data still reached the surface (a fallback viewer rendered it).
+    assert renderer.rendered
+    surfaced = _all_leaf_text(renderer.rendered[-1])
+    assert "different" in surfaced
+
+
+def test_inline_blueprint_all_miss_also_falls_back(tmp_path: Path) -> None:
+    """Tier 1: the fallback applies to the stage-2 inline-blueprint path too — an
+    LLM blueprint whose bindings all miss degrades to the fallback viewer rather
+    than presenting an empty shell."""
+    data = {"real_key": "real_value"}
+    blueprint = [{"component": "text", "text": {"$bind": "/absent"}}]
+    renderer = _RecordingRenderer()
+    ctx, _ = _ctx(tmp_path, registry=None, renderer=renderer)
+
+    ack = _run(handle(PresentIROp(kind="present", data_inline=data, blueprint=blueprint), ctx))
+
+    assert ack["ok"] is True
+    assert ack["all_bindings_missed"] is True
+    assert "note" in ack
+    surfaced = _all_leaf_text(renderer.rendered[-1])
+    assert "real_value" in surfaced
+
+
+def test_malformed_inline_blueprint_stays_hard_error_not_fallback(tmp_path: Path) -> None:
+    """Tier 1: a malformed INLINE blueprint (non-catalog component) is a HARD error
+    (status="error") — a template BUG, not a fallback trigger. Only unknown-name /
+    all-miss route to the fallback chain."""
+    ctx, _ = _ctx(tmp_path, registry=None, renderer=_RecordingRenderer())
+    ack = _run(handle(PresentIROp(
+        kind="present", data_inline={"a": 1},
+        blueprint={"component": "button", "text": "click"}), ctx))
+    assert ack["status"] == "error"
+    assert ack["ok"] is False
+
+
+def test_no_registry_wired_treats_named_template_as_unknown(tmp_path: Path) -> None:
+    """Tier 1: with no registry wired (presentation_registry=None, direct/test
+    construction), a named template is 'unknown' and falls to the generic viewer —
+    never a crash on a None registry."""
+    data = {"x": 1}
+    renderer = _RecordingRenderer()
+    ctx, _ = _ctx(tmp_path, registry=None, renderer=renderer)
+    ack = _run(handle(PresentIROp(kind="present", data_inline=data, template="anything"), ctx))
+    assert ack["ok"] is True
+    assert "note" in ack
+    assert "1" in _all_leaf_text(renderer.rendered[-1])
+
+
+# ── Tier 1: operator/LLM boundary (registration is config, not an LLM action) ─
+
+
+def test_referencing_a_template_name_never_registers_it(tmp_path: Path) -> None:
+    """Tier 1: the write-gate boundary — the LLM authors inline blueprints only;
+    naming a template in a `present` op is a READ-ONLY lookup that never registers.
+    A present op referencing an unknown name leaves the registry unchanged (no
+    self-registration side effect) — registration is an operator/config action."""
+    registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
+    assert not registry.has("llm_authored")
+    ctx, _ = _ctx(tmp_path, registry=registry, renderer=_RecordingRenderer())
+
+    _run(handle(PresentIROp(kind="present", data_inline={"a": 1}, template="llm_authored"), ctx))
+
+    # The op did not register anything — the registry is exactly as the operator left it.
+    assert not registry.has("llm_authored")
+    assert registry.names() == ["authors"]
+
+
+def test_no_present_register_op_kind_exists() -> None:
+    """Tier 1: there is no op kind for the LLM to register a named template
+    (unlike skill_install / pipeline_install, presentations are operator-config
+    only — no install op). The only present-family op is `present` itself."""
+    present_family = {k for k in ALL_OP_KINDS if "present" in k}
+    assert present_family == {"present"}
+
+
+# ── Tier 2: hot-reload — a new template is visible at the next turn boundary ──
+
+
+def _make_session(tmp_path: Path) -> Session:
+    """Minimal real Session whose presentation registry is built from the current
+    config cascade (mirrors SessionFactoryConfig.from_config's build-once path)."""
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    cfg = load_config(tmp_path)
+    return Session(
+        agent_name="prc-test",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        presentation_registry=build_presentation_registry(cfg.presentations),
+    )
+
+
+def _write_dynamic_template(tmp_path: Path, name: str, blueprint) -> None:
+    path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump({"presentations": {"entries": {name: {"blueprint": blueprint}}}}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_hotreload_seam_registered(tmp_path: Path) -> None:
+    """Tier 2: the Session registers the presentations seam on the HotReloader."""
+    session = _make_session(tmp_path)
+    seam_names = [name for (name, _fn) in session._hot_reloader._seams]
+    assert "presentations" in seam_names
+
+
+@pytest.mark.asyncio
+async def test_hotreload_adds_template_to_live_registry_dual_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: adding a template to .reyn/config/presentations.yaml + applying the
+    presentations seam swaps the LIVE registry on BOTH session.presentation_registry
+    AND router_host.get_presentation_registry() (the dual-write the adapter needs,
+    since it holds its own captured copy) — the template is visible next turn."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    assert not session.presentation_registry.has("authors")
+
+    _write_dynamic_template(tmp_path, "authors", _AUTHORS_TEMPLATE)
+    changed = await session._reapply_presentations({})
+
+    assert changed is True
+    assert session.presentation_registry.has("authors")
+    assert session.router_host.get_presentation_registry().has("authors"), (
+        "the RouterHostAdapter's captured registry must reflect the swap (the "
+        "dual-write the adapter needs since it never re-reads Session)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hotreload_via_apply_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the template becomes visible through the SAME path /reload uses —
+    HotReloader.request_reload + apply_pending — at the turn boundary."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    _write_dynamic_template(tmp_path, "authors", _AUTHORS_TEMPLATE)
+
+    session._hot_reloader.request_reload(source="operator")
+    summary = await session._hot_reloader.apply_pending()
+
+    assert summary is not None
+    assert "presentations" in summary["applied"]
+    assert session.presentation_registry.has("authors")
+    assert session.router_host.get_presentation_registry().has("authors")
+
+
+@pytest.mark.asyncio
+async def test_hotreload_malformed_template_keeps_old_registry_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a malformed template at reload time makes the seam return False and
+    leaves the OLD registry (both holders) intact — atomic last-good (strict=True):
+    the broken reload never half-applies or clears the live registry."""
+    monkeypatch.chdir(tmp_path)
+    _write_dynamic_template(tmp_path, "authors", _AUTHORS_TEMPLATE)
+    session = _make_session(tmp_path)
+    assert session.presentation_registry.has("authors")
+    old_registry = session.presentation_registry
+
+    # Break it: a non-catalog component fails the structural gate.
+    _write_dynamic_template(tmp_path, "authors", {"component": "button", "text": "x"})
+    changed = await session._reapply_presentations({})
+
+    assert changed is False
+    assert session.presentation_registry is old_registry, (
+        "a failed rebuild must leave the Session's live registry object untouched"
+    )
+    assert session.router_host.get_presentation_registry() is old_registry
+    assert session.presentation_registry.has("authors"), "the last-good template survives"
+
+
+# ── Tier 2: no content bytes in the presented event on the fallback path ──────
+
+
+def test_fallback_event_carries_no_content_bytes(tmp_path: Path) -> None:
+    """Tier 2: even on the fallback path, the presented event payload carries refs
+    + stats only — the surfaced data values never appear in the audit event."""
+    secret = "UNIQUE_SENTINEL_PRC_7b21"
+    registry = build_presentation_registry({"entries": {"authors": {"blueprint": _AUTHORS_TEMPLATE}}})
+    ctx, events = _ctx(tmp_path, registry=registry, renderer=_RecordingRenderer())
+    _run(handle(PresentIROp(
+        kind="present", data_inline={"note": secret}, template="does_not_exist"), ctx))
+    ev = [e for e in events.all() if e.type == "presented"][-1]
+    assert secret not in json.dumps(ev.data)


### PR DESCRIPTION
**[per-pr-coder]** — **PR-C of the present-layer arc** (`docs/deep-dives/proposals/0054-present-layer.md`, RATIFIED). `part of` the present-layer arc — **not** `closes` (PR-D still pending: replay/rewind + concepts docs).

Builds §§3, 6: `presentations.yaml` registration + hot-reload seam + the 4-stage template-source fallback chain, and replaces PR-A's named-template `ok=False` stub. FP-0051's viewer registry is deleted — stage 3 is built fresh (architect-endorsed design; the architect will co-land a §3 doc refinement).

## What landed

**Registration — mirrors `skills.entries` / `pipelines.entries` exactly**
- `ReynConfig.presentations` (raw dict) + `_merge` entries-union branch + `.reyn/config/presentations.yaml` cascade load + `_HOT_RELOAD_FILES` member + `validate_in_set` shape check.
- New `reyn.data.presentations.registry`: `PresentationRegistry` + `build_presentation_registry` (per-entry isolation → `presentation_load_failed` event + skip; `strict=True` for the reload seam's atomic last-good posture). A named template's value is an **inline blueprint**, validated via `validate_blueprint` at build time (malformed → caught at load, never at render).
- **Operator/config action only — no install op.** Write-gate culture: the LLM authors inline blueprints and never registers named templates.
- `SessionFactoryConfig` bundle field + `Session._reapply_presentations` seam (dual-write Session + `RouterHostAdapter`), threaded through `OpContext.presentation_registry` via the same router-ctx seam PR-B wired the renderer through. Hot-reload swaps the reference → a newly-registered template is visible next turn.

**Named-template resolution + 4-stage fallback (`present.py::handle`)**
1. **registered template** (operator) → 2. **inline blueprint** (LLM) → 3. **content-type default viewer** → 4. **generic YAML/text**.
- Stage 3 synthesizes a default blueprint from the resolved data and runs it through the **same** `validate_blueprint → resolve_bindings → render` rails (guard + caps + non-executable apply uniformly). Recognition ladder: declared content-type → diff-sniff (FP-0051 heuristic) → shape. `str`/scalar → `text` (not `markdown` — fidelity); `list[dict]`→`table` (union of first-K rows' keys); `dict`→`keyvalue`; binary marker → `text` placeholder.
- Stage 4 dumps the whole value to YAML (`code`) / text — always renders (final catch; data always reaches the user).
- Fallback fires on an **unknown template name** OR `all_bindings_missed` (don't show an empty shell) — never a hard failure. A malformed **inline** blueprint stays a hard `status="error"` (a template bug, not a fallback trigger).
- ack + `presented` event carry the **requested** stage's stats (self-correction loop intact) + a `note` naming the fallback viewer. **`presented` event shape unchanged** (PR-A).

**Content-type-on-refs note:** an offloaded `data_ref` carries no content-type in its frontmatter (the canonical mappers drop it as transport), so for a ref source the declared-type stage is `None` and the ladder degrades to diff-sniff → shape (architect-confirmed correct degrade).

## Recovery gate
N/A — `presentations.yaml` is operator config (like skills/pipelines entries), not WAL-event-derived recovery state. No registry state is reconstructed from events.

## Test plan
- [x] Config round-trip: a real `.reyn/config/presentations.yaml` (non-default blueprint) reaches the registry through the full cascade.
- [x] Named-template resolution renders via the **same** binding path as an equivalent inline blueprint (ack + surfaced data identical); event records the registered name.
- [x] Fallback: unknown template name AND all-bindings-miss template each fall to the fallback viewer (ok=True, note, data reaches the surface); inline-blueprint all-miss also falls back; malformed inline blueprint stays a hard error.
- [x] Hot-reload: newly-registered template visible at the next turn boundary via `_reapply_presentations` + `apply_pending` (dual-write Session + adapter); malformed-on-reload keeps old registry intact (atomic last-good).
- [x] Operator/LLM boundary: referencing a template name never registers it; no `present`-family op kind beyond `present`.
- [x] `git stash` confirmed the 5 route-mount failures reproduce on clean main (pre-existing flakes, unrelated).

## CI gates (all four, local)
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` (3 changed test files, 31 tests) — 0 errors / 0 warnings
- [x] `pytest` — 7605 pass; only the 5 pre-existing route-mount flakes remain (reproduced on clean main via `git stash`). Two exact-set pins (`_HOT_RELOAD_FILES`, seam list) updated to include the new `presentations` member — the load-bearing "reyn.yaml not hot-reloadable" invariant still holds.
- [x] `verify_module_docstrings.py` (14 changed src files) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
