### PR TITLE
fix: apply live terminal width to remaining repl renderer Console sites (#2655)

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -218,6 +218,11 @@ class RichChatRenderer(ChatRenderer):
         # the bracketed token).
         self._clear_transient()
         c = self._console
+        # Rich's Console can't auto-detect terminal width writing to a StringIO —
+        # it silently falls back to 80 columns. Read the LIVE terminal width per
+        # render (the terminal can resize between turns) instead of inheriting
+        # that fallback (issue #2655).
+        c.width = _live_terminal_width()
         kind = msg.kind
         text = f"{_meta_prefix(msg.meta)}{msg.text}"
         if kind == "agent":
@@ -770,15 +775,12 @@ class InlineChatRenderer(ChatRenderer):
         self._clear_transient()
         if wants_separator(msg.kind, self._seen_message):
             self._console.print()  # blank line between message blocks
-        if msg.kind == "presentation":
-            # FP-0054 §6 (tui-coder review): Rich's Console cannot auto-detect terminal
-            # width writing to a StringIO — it silently falls back to 80 columns. Read
-            # the LIVE terminal width per render (the terminal can resize between
-            # turns) rather than inheriting that fallback, which matters far more for
-            # `present`'s tables than for the plain-text/one-liner kinds this renderer
-            # otherwise prints (a pre-existing latent gap there — issue #2655 fast-follow,
-            # out of this PR's scope).
-            self._console.width = _live_terminal_width()
+        # Rich's Console cannot auto-detect terminal width writing to a StringIO —
+        # it silently falls back to 80 columns. Read the LIVE terminal width per
+        # render (the terminal can resize between turns) rather than inheriting
+        # that fallback. Applies to every kind, not just `presentation`'s tables —
+        # plain agent replies can carry wide code/diff blocks too (issue #2655).
+        self._console.width = _live_terminal_width()
         self._console.print(format_inline_message(msg))
         self._seen_message = True
         self._flush()

--- a/tests/test_renderer_console_width_2655.py
+++ b/tests/test_renderer_console_width_2655.py
@@ -1,0 +1,93 @@
+"""Tier 2: repl renderer Console width tracks the live terminal (issue #2655).
+
+`RichChatRenderer` and `InlineChatRenderer` both render via a Rich `Console`
+writing to an in-memory `StringIO` buffer (so ANSI can be relayed to the real
+terminal outside prompt_toolkit's patched stdout — see each class's
+docstring). A Rich `Console` backed by a `StringIO` can't auto-detect a real
+terminal's column count and silently falls back to 80 columns, which wraps/
+truncates wide content (tables, diffs, code) regardless of the actual
+terminal width.
+
+Both classes' `message()` now re-read `_live_terminal_width()` immediately
+before every render (the terminal can resize between turns, so this can't be
+a construction-time-only fix). These tests exercise the render path
+behaviorally: a short label followed by a long unbreakable token wraps onto a
+new line when the live width is narrow, and stays on the SAME line as the
+label when the live width is wide — proving the render actually consults the
+live-width helper's return value (not a hardcoded/construction-time width),
+rather than asserting on the renderer's private Console attribute directly.
+"""
+from __future__ import annotations
+
+import io
+
+from reyn.interfaces.repl import renderer as renderer_module
+from reyn.interfaces.repl.renderer import InlineChatRenderer, RichChatRenderer
+from reyn.runtime.outbox import OutboxMessage
+
+# A long unbreakable token (no internal spaces): at a narrow width it can't
+# share a line with the "Path:" label; at a wide (>= label+token length)
+# width it fits alongside the label on one line.
+_TOKEN = "segment_" * 12 + "TOKENTAIL"
+_LABEL = "Path:"
+
+
+def _patch_live_width(monkeypatch, width: int) -> None:
+    """Monkeypatch the module's own `_live_terminal_width` free function — not a
+    collaborator object — so the render path can be exercised without a real
+    running prompt_toolkit `Application` (which `get_app()` otherwise requires)."""
+    monkeypatch.setattr(renderer_module, "_live_terminal_width", lambda default=80: width)
+
+
+def _rendered_output(monkeypatch, renderer, kind: str, text: str) -> str:
+    """Capture what message() flushes to sys.__stdout__ (the class's own
+    documented write target — see RichChatRenderer/InlineChatRenderer
+    docstrings), rather than reading renderer-private buffer state."""
+    captured = io.StringIO()
+    monkeypatch.setattr(renderer_module.sys, "__stdout__", captured)
+    renderer.message(OutboxMessage(kind=kind, text=text))
+    return captured.getvalue()
+
+
+def _label_and_token_share_a_line(out: str) -> bool:
+    return any(_LABEL in ln and _TOKEN in ln for ln in out.splitlines())
+
+
+def test_rich_chat_renderer_wide_live_width_keeps_label_and_token_on_one_line(monkeypatch) -> None:
+    """Tier 2: RichChatRenderer.message() applies a wide live terminal width, so
+    the label and the long unbreakable token stay on the SAME rendered line —
+    proving the Console width came from the live-width helper, not Rich's 80-col
+    StringIO fallback (issue #2655)."""
+    _patch_live_width(monkeypatch, width=200)
+    out = _rendered_output(monkeypatch, RichChatRenderer(), "agent", f"{_LABEL} {_TOKEN}")
+    assert _label_and_token_share_a_line(out)
+
+
+def test_rich_chat_renderer_narrow_live_width_wraps_token_onto_new_line(monkeypatch) -> None:
+    """Tier 2: the same render path, given a narrow live width, wraps the token
+    onto its own line — confirming the width is actually read per render rather
+    than a fixed wide value."""
+    _patch_live_width(monkeypatch, width=20)
+    out = _rendered_output(monkeypatch, RichChatRenderer(), "agent", f"{_LABEL} {_TOKEN}")
+    assert not _label_and_token_share_a_line(out)
+    assert _TOKEN in out.replace("\n", "")  # token content still present, just wrapped (no hang-indent here)
+
+
+def test_inline_chat_renderer_wide_live_width_keeps_label_and_token_on_one_line(monkeypatch) -> None:
+    """Tier 2: InlineChatRenderer.message() applies the live width for ordinary
+    ("agent") kinds too — the fix widens the earlier presentation-only gate
+    (FP-0054 §6) to every render, since plain agent replies can also carry wide
+    code/diff content."""
+    _patch_live_width(monkeypatch, width=200)
+    out = _rendered_output(monkeypatch, InlineChatRenderer(), "agent", f"{_LABEL} {_TOKEN}")
+    assert _label_and_token_share_a_line(out)
+
+
+def test_inline_chat_renderer_narrow_live_width_wraps_token_onto_new_line(monkeypatch) -> None:
+    """Tier 2: the same InlineChatRenderer render path, given a narrow live width,
+    wraps the token onto its own line — confirming per-render (not
+    construction-time-only) width."""
+    _patch_live_width(monkeypatch, width=20)
+    out = _rendered_output(monkeypatch, InlineChatRenderer(), "agent", f"{_LABEL} {_TOKEN}")
+    assert not _label_and_token_share_a_line(out)
+    assert "segment" in out  # token content still present, just wrapped onto new line(s)


### PR DESCRIPTION
**[per-pr-coder]** — Fixes the latent 80-column truncation bug in `src/reyn/interfaces/repl/renderer.py` (issue #2655, architect-filed, credit tui-coder).

## Summary

A Rich `Console` writing to a `StringIO` (not a real terminal) can't auto-detect terminal width and silently falls back to 80 columns. PR-B (#2661) added a `_live_terminal_width()` helper and applied it correctly at one render site (`InlineChatRenderer.message()`, gated to `kind == "presentation"` only), explicitly flagging the remaining gap as this issue's fast-follow.

This PR closes that gap at the two remaining sites, reusing the existing helper (no new width-detection logic):

1. **`RichChatRenderer.message()`** (~line 215) — never read the live width at all. Now sets `c.width = _live_terminal_width()` before rendering, for every message kind.
2. **`InlineChatRenderer.message()`** (~line 769) — previously only set the width when `msg.kind == "presentation"`. Widened to apply unconditionally, since plain agent replies can also carry wide code/diff content, not just `present`'s tables.

Both sites re-read the width on every render (not just at construction), since the terminal can resize between turns — matching the pattern the already-fixed site uses.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_renderer_console_width_2655.py` — 4/4 OK, 0 Tier-4 violations
- [x] `pytest` (repo root) — 7613 passed, 21 skipped, 5 pre-existing failures (route-mount flakes, confirmed via `git stash` to exist identically on `main` — unrelated to this change)
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK
- [x] New tests in `tests/test_renderer_console_width_2655.py` behaviorally verify: a long unbreakable token stays on the same line as its label when the live width is wide, and wraps onto a new line when narrow — for both `RichChatRenderer` and `InlineChatRenderer`. Falsified against pre-fix code via `git stash`: the two "wide" tests correctly fail without the fix (the "narrow" tests still pass either way, since 80-col default already wraps — expected).

Closes #2655