### PR TITLE
refactor: extract make_sandboxed_env into reyn.security.template_env (FP-0055 PR-0)

### DIFF
--- a/src/reyn/hooks/render.py
+++ b/src/reyn/hooks/render.py
@@ -55,10 +55,11 @@ import json
 import logging
 from dataclasses import dataclass
 
-from jinja2 import StrictUndefined, TemplateError, Undefined
+from jinja2 import TemplateError
 from jinja2.sandbox import SandboxedEnvironment
 
 from reyn.hooks.schema import PushBlock
+from reyn.security.template_env import make_sandboxed_env
 
 _log = logging.getLogger(__name__)
 
@@ -119,21 +120,6 @@ class ResolvedPush:
 
 
 # ---------------------------------------------------------------------------
-# Jinja2 environment factories
-# ---------------------------------------------------------------------------
-
-
-def _make_env_strict() -> SandboxedEnvironment:
-    """SandboxedEnvironment with StrictUndefined — for ``message``."""
-    return SandboxedEnvironment(undefined=StrictUndefined)
-
-
-def _make_env_silent() -> SandboxedEnvironment:
-    """SandboxedEnvironment with silent Undefined — for bool / session fields."""
-    return SandboxedEnvironment(undefined=Undefined)
-
-
-# ---------------------------------------------------------------------------
 # Core renderer
 # ---------------------------------------------------------------------------
 
@@ -173,8 +159,8 @@ def render_push(push: PushBlock, context: dict) -> ResolvedPush:
 
 def _render_push_inner(push: PushBlock, context: dict) -> ResolvedPush:
     """Inner renderer — may raise; callers should use ``render_push`` instead."""
-    env_strict = _make_env_strict()
-    env_silent = _make_env_silent()
+    env_strict = make_sandboxed_env(undefined="strict")
+    env_silent = make_sandboxed_env(undefined="lenient")
 
     # ── message (StrictUndefined — a blank message due to a typo is misleading) ──
     message = env_strict.from_string(push.message).render(context)
@@ -244,7 +230,7 @@ def render_pipeline_input(input_template: "dict | str | None", context: dict) ->
     """
     if input_template is None:
         return None
-    env = _make_env_silent()
+    env = make_sandboxed_env(undefined="lenient")
     if isinstance(input_template, str):
         rendered = env.from_string(input_template).render(context)
         obj = json.loads(rendered)

--- a/src/reyn/security/template_env.py
+++ b/src/reyn/security/template_env.py
@@ -1,0 +1,62 @@
+"""reyn.security.template_env — the one Jinja2 environment factory.
+
+``make_sandboxed_env`` is the **only** place in the codebase that constructs a
+Jinja2 environment. It always returns a ``jinja2.sandbox.SandboxedEnvironment``
+— never a plain ``jinja2.Environment`` — because templates in this codebase
+may be LLM-authored or operator-supplied-but-untrusted, and an unsandboxed
+Jinja2 environment allows attribute-traversal escapes (e.g.
+``{{ ().__class__.__bases__ }}`` or ``{{ cycler.__init__.__globals__ }}``)
+that amount to arbitrary code execution (SSTI). The sandbox is
+non-negotiable; this module exists so that invariant lives in exactly one
+place rather than being re-derived at every call site.
+
+Sits beside ``reyn.security.content_fence`` / ``reyn.security.content_guard``
+as the security-primitives home: those guard untrusted *input*; this guards
+untrusted *template execution*.
+
+Undefined policy
+-----------------
+The caller chooses how an undefined template variable behaves via the
+``undefined`` parameter:
+
+- ``"strict"`` — ``jinja2.StrictUndefined``: any undefined variable raises
+  ``jinja2.UndefinedError`` at render time. Use this where a silently blank
+  render would be misleading (e.g. a rendered message).
+- ``"lenient"`` — ``jinja2.Undefined``: an undefined variable renders as the
+  empty string rather than raising. Use this where a fail-safe empty result
+  is preferable to a crash (e.g. a boolean condition field).
+
+No other policy (autoescape, filters, extensions) is set here; callers that
+need more should extend the environment this factory returns rather than
+constructing their own.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from jinja2 import StrictUndefined, Undefined
+from jinja2.sandbox import SandboxedEnvironment
+
+UndefinedPolicy = Literal["strict", "lenient"]
+
+
+def make_sandboxed_env(undefined: UndefinedPolicy) -> SandboxedEnvironment:
+    """Return a ``SandboxedEnvironment`` configured per ``undefined``.
+
+    Parameters
+    ----------
+    undefined:
+        ``"strict"`` → ``StrictUndefined`` (raise on undefined variables);
+        ``"lenient"`` → ``Undefined`` (silent, renders as empty string).
+
+    Always returns ``jinja2.sandbox.SandboxedEnvironment`` — never a plain
+    ``jinja2.Environment`` — regardless of ``undefined``. See the module
+    docstring for why the sandbox is non-negotiable.
+    """
+    if undefined == "strict":
+        return SandboxedEnvironment(undefined=StrictUndefined)
+    if undefined == "lenient":
+        return SandboxedEnvironment(undefined=Undefined)
+    raise ValueError(
+        f"undefined must be 'strict' or 'lenient', got {undefined!r}."
+    )

--- a/tests/test_template_env_2673.py
+++ b/tests/test_template_env_2673.py
@@ -1,0 +1,58 @@
+"""Tier 1: shared sandboxed Jinja2 env factory (FP-0055 PR-0 / #2673).
+
+``make_sandboxed_env`` is the single Jinja2 environment constructor for the
+codebase (extracted from ``reyn.hooks.render``'s private helpers). These
+tests are a contract check on the factory itself: it always returns a
+``SandboxedEnvironment`` (never a plain ``Environment``), and the
+``undefined`` policy switches between raising on an undefined variable
+(``"strict"``) and rendering it as an empty string (``"lenient"``). Real
+Jinja2 instances, no mocks.
+"""
+from __future__ import annotations
+
+import jinja2
+import pytest
+from jinja2.sandbox import SandboxedEnvironment
+
+from reyn.security.template_env import make_sandboxed_env
+
+
+def test_strict_env_is_sandboxed():
+    """Tier 1: undefined='strict' returns a SandboxedEnvironment, not a plain Environment."""
+    env = make_sandboxed_env(undefined="strict")
+    assert isinstance(env, SandboxedEnvironment)
+    assert not (type(env) is jinja2.Environment)
+
+
+def test_lenient_env_is_sandboxed():
+    """Tier 1: undefined='lenient' returns a SandboxedEnvironment, not a plain Environment."""
+    env = make_sandboxed_env(undefined="lenient")
+    assert isinstance(env, SandboxedEnvironment)
+    assert not (type(env) is jinja2.Environment)
+
+
+def test_strict_undefined_raises_on_undefined_var():
+    """Tier 1: undefined='strict' raises when a template references an undefined variable."""
+    env = make_sandboxed_env(undefined="strict")
+    with pytest.raises(jinja2.UndefinedError):
+        env.from_string("{{ missing_var }}").render({})
+
+
+def test_lenient_undefined_renders_empty_string():
+    """Tier 1: undefined='lenient' renders an undefined variable as an empty string."""
+    env = make_sandboxed_env(undefined="lenient")
+    result = env.from_string("[{{ missing_var }}]").render({})
+    assert result == "[]"
+
+
+def test_sandbox_blocks_class_escape():
+    """Tier 1: sandbox proof — attribute-traversal SSTI escape is blocked, regardless of policy."""
+    env = make_sandboxed_env(undefined="lenient")
+    with pytest.raises(jinja2.exceptions.SecurityError):
+        env.from_string("{{ ().__class__.__bases__ }}").render({})
+
+
+def test_invalid_undefined_policy_rejected():
+    """Tier 1: an undefined policy outside {'strict', 'lenient'} raises ValueError."""
+    with pytest.raises(ValueError):
+        make_sandboxed_env(undefined="bogus")  # type: ignore[arg-type]


### PR DESCRIPTION
**[per-pr-coder]** — This is **PR-0** of the FP-0055 arc (design doc: `docs/deep-dives/proposals/0055-render-template-op-and-present-defaults.md`, PR-0 section). `part of` #2673 — multi-PR arc, does NOT close it.

## What this does (behavior-preserving extraction)
Extracts `hooks/render.py`'s private `_make_env_strict()` / `_make_env_silent()` Jinja2 environment constructors into a new shared security primitive **`src/reyn/security/template_env.py`** as a public **`make_sandboxed_env(undefined: "strict" | "lenient") -> SandboxedEnvironment`**. It sits beside the existing `content_fence` / `content_guard` input-side guards — a coherent security-primitives home (those guard untrusted *input*; this guards untrusted *template execution*).

- **`make_sandboxed_env` is now the ONLY Jinja2 env constructor** in the codebase and always returns `jinja2.sandbox.SandboxedEnvironment`, never a plain `jinja2.Environment` (verified by grep — no plain `Environment` exists). LLM/operator-authored templates without a sandbox are an SSTI vector, so the invariant lives in exactly one place.
- **`hooks/render.py` imports and consumes the helper**; the two undefined modes map to the parameter (`message` = `strict`, bool/session/pipeline-input fields = `lenient`). Behavior is IDENTICAL.
- Strictly behavior-preserving: no functional change to hook rendering. Hook tests pass unchanged.

**Out of scope** (later PRs): the `render_template` op (PR-2), present `view` rename (PR-1), streaming/output caps/wall-clock backstop (PR-2). This PR ONLY relocates the env constructor and repoints the hooks caller.

## Signature settled
```python
def make_sandboxed_env(undefined: Literal["strict", "lenient"]) -> SandboxedEnvironment
```
- `"strict"` → `StrictUndefined` (raise on undefined variable)
- `"lenient"` → `Undefined` (silent, renders empty string)
- invalid policy → `ValueError`

## Tests
- Existing hook-render tests are the behavior-preservation guard: `tests/test_1800_hook_render.py` + `tests/test_hook_shell_push_2069.py` pass **unmodified** (they exercise `render_push` / `render_pipeline_input`, incl. the sandbox-escape and strict/silent-undefined tests).
- New Tier-1 contract test `tests/test_template_env_2673.py`: factory returns `SandboxedEnvironment` (not a plain `Environment`); strict raises `UndefinedError` on an undefined var while lenient renders empty; sandbox blocks the `__class__` traversal escape; invalid policy rejected. Real instances, no mocks, no Tier-4 pins.

## Gates (all 4, repo root, green)
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_template_env_2673.py` — 6/6 OK, 0 Tier-4 violations
- [x] `pytest` — 7619 passed, 21 skipped; 5 failures are the **pre-existing route-mount flakes** (`test_fp0001_routes_mounted`, `test_a2a_routes_mounted`, `test_mcp_routes_mounted`, `test_loader_disambiguates_via_package_field`, `test_resources_route_is_mounted_on_app`) — confirmed identical on clean `main` via `git stash`; none touch files in this PR
- [x] `python scripts/verify_module_docstrings.py src/reyn/security/template_env.py src/reyn/hooks/render.py` — OK

## Test plan
- [x] Behavior preservation: `hooks/render.py` tests pass unchanged (verified — 64 passed incl. shell-push)
- [x] New factory contract test passes and audits clean
- [x] `make_sandboxed_env` is the only env constructor; no plain `jinja2.Environment` anywhere (grep-verified)
- [x] All 4 CI gates run locally to completion (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)