### PR TITLE
fix: canonical mappers for file/reyn_src/compact/judge_output (FP-0056 PR-H hotfix)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -31,6 +31,16 @@ control_ir/phase offloader, pending its separate removal.)
 
 P7: the op-kind → canonical mapping is OS-level (no domain-specific vocabulary). The deref / paging / offload
 store machinery is reused unchanged — 案B removes only the field-guessing.
+
+FP-0056 PR-H (hotfix): the original 案B mapper table scoped migration to the ops that once declared
+``_offload_payload_field`` (+ mcp/pipeline) — so the ``file`` family (``kind:"file"``, unmapped), the
+``reyn_src_*`` dev-reads (kind-less), and ``compact`` / ``judge_output`` all took the whole-dict fallback.
+In dogfood a doc read via ``reyn_source__read`` was therefore offloaded as a 600-char JSON-dict preview
+instead of the readable text body. This module now registers a ``file`` mapper (op-dispatched: read →
+``content`` as ``text``, grep/glob → rendered lines, mutations → a status line), a ``reyn_src`` mapper
+(the tool-handler seam tags its kind-less result ``kind:"reyn_src"`` so it routes here, not to the
+fallback), and ``compact`` / ``judge_output`` mappers. The registry-enforcement framework, identity-keyed
+dispatch, and the ``canonical_fallback_used`` event are follow-ups (PR-F1/PR-F2), not this hotfix.
 """
 from __future__ import annotations
 
@@ -203,6 +213,201 @@ def _run_pipeline_async_to_canonical(result: dict) -> CanonicalToolResult:
     return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
 
 
+def _file_signal_meta(result: dict) -> "dict[str, Any]":
+    """High-signal meta for a ``file`` op result: ``op`` + ``status`` (a ``truncated`` read tells the
+    LLM there is more; a ``not_found`` tells it to retry another path) + ``path`` (which file). Transport
+    noise beyond these is dropped, per the module's high-signal-only rule. ``isError`` is added on the
+    error path by the caller."""
+    meta: dict[str, Any] = {}
+    for key in ("op", "status", "path"):
+        value = result.get(key)
+        if value is not None:
+            meta[key] = value
+    return meta
+
+
+def _file_to_canonical(result: dict) -> CanonicalToolResult:
+    """``file`` op result (read/write/glob/grep/edit/delete/mkdir/move/stat/regenerate_index) → canonical.
+
+    Dispatch is on the result's ``op`` field (NOT ``kind``, which is the coarse ``"file"`` for the whole
+    family). The LLM-readable body per op:
+
+    - ``read`` → the file ``content`` as ``text`` (an image read surfaces its ``media_blocks`` as media
+      attachments, matching the MCP mapper); ``path``/``op``/``status`` are signal meta, never the body.
+    - ``grep`` / ``glob`` → the rendered match / path lines as ``text`` (``content`` mode → ``path:line:
+      text``; ``files_with_matches`` / glob → the paths; ``count`` mode → a one-line total).
+    - ``write`` / ``edit`` / ``delete`` / ``mkdir`` / ``move`` / ``stat`` / ``regenerate_index`` → a short
+      status ``text``.
+
+    Any op whose result is an error (``status`` error/denied/not_found, or an ``error`` field) surfaces
+    the ``error`` message as ``text`` with ``meta.isError`` — the sole error-path driver."""
+    op = result.get("op")
+    status = result.get("status")
+    meta = _file_signal_meta(result)
+    if _is_error(result) or status in ("error", "denied", "not_found") or (
+        "error" in result and result.get("error")
+    ):
+        meta["isError"] = True
+        return CanonicalToolResult(
+            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta=meta,
+        )
+
+    if op == "read":
+        attachments = [
+            {"kind": "media", "block": block} for block in (result.get("media_blocks") or [])
+        ]
+        return CanonicalToolResult(
+            text=result.get("content", "") or "", attachments=attachments, source_ref=None, meta=meta,
+        )
+
+    if op == "grep":
+        return CanonicalToolResult(
+            text=_render_file_grep(result), attachments=[], source_ref=None, meta=meta,
+        )
+
+    if op == "glob":
+        matches = result.get("matches") or []
+        text = "\n".join(str(m) for m in matches) if matches else "(no matches)"
+        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+
+    # write / edit / delete / mkdir / move / stat / regenerate_index → a short status text.
+    return CanonicalToolResult(
+        text=_render_file_status(op, result), attachments=[], source_ref=None, meta=meta,
+    )
+
+
+def _render_file_grep(result: dict) -> str:
+    """Render a ``file`` grep result's matches as text lines. ``content`` mode → ``path:line: text``;
+    ``files_with_matches`` → one path per line; ``count`` mode → a one-line total."""
+    output_mode = result.get("output_mode")
+    if output_mode == "count":
+        return f"{result.get('count', 0)} match(es)"
+    if output_mode == "files_with_matches":
+        files = result.get("files") or []
+        return "\n".join(str(f) for f in files) if files else "(no matches)"
+    matches = result.get("matches") or []
+    if not matches:
+        return "(no matches)"
+    lines = [
+        f"{m.get('path', '')}:{m.get('line_number', '')}: {m.get('content', '')}" for m in matches
+    ]
+    return "\n".join(lines)
+
+
+def _render_file_status(op: "str | None", result: dict) -> str:
+    """A short, human-readable status line for a mutating / metadata ``file`` op (write/edit/delete/
+    mkdir/move/stat/regenerate_index). Descriptive, not JSON — the LLM acts on the outcome, not the
+    envelope."""
+    path = result.get("path", "")
+    if op == "write":
+        text = f"Wrote {result.get('bytes_written', 0)} bytes to {path}."
+        note = result.get("encoding_note")
+        return f"{text} {note}" if note else text
+    if op == "edit":
+        text = f"Edited {path}: {result.get('replacements', 0)} replacement(s)."
+        preview = result.get("preview")
+        return f"{text}\n{preview}" if preview else text
+    if op == "delete":
+        return f"Deleted {path} (deleted={result.get('deleted')})."
+    if op == "mkdir":
+        return f"Created directory {path} (created={result.get('created')})."
+    if op == "move":
+        return f"Moved {path} -> {result.get('dest_path', '')}."
+    if op == "regenerate_index":
+        return f"Regenerated index at {result.get('output_path', '')}: {result.get('entries', 0)} entries."
+    if op == "stat":
+        return f"stat {path}: {result.get('info')}"
+    return f"{op}: {result.get('status', 'ok')}"
+
+
+def _reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
+    """``reyn_src_*`` handler result (read/list/glob/grep) → canonical. These handlers return a
+    kind-less ``{path, content}`` / ``{entries}`` / ``{matches}`` dict tagged with ``kind:"reyn_src"``
+    at the tool-handler seam so this mapper (not the whole-dict fallback) shapes them — the dogfood
+    incident root: a doc read via ``reyn_source__read`` was offloaded as a whole-dict ``structured``
+    blob instead of the readable body.
+
+    - ``read`` (``content``) → the file body as ``text`` (``path`` is signal meta).
+    - ``list`` (``entries``) → ``type: name`` lines as ``text``.
+    - ``glob`` (``matches`` of paths) / ``grep`` (``matches`` of ``{path, line, snippet}``) → the
+      rendered lines as ``text``.
+    - an ``error`` → the message as ``text`` with ``meta.isError``."""
+    if result.get("error"):
+        return CanonicalToolResult(
+            text=str(result["error"]), attachments=[], source_ref=None, meta={"isError": True},
+        )
+    if "content" in result:
+        meta = {"path": result["path"]} if result.get("path") is not None else {}
+        return CanonicalToolResult(
+            text=result.get("content", "") or "", attachments=[], source_ref=None, meta=meta,
+        )
+    if "entries" in result:
+        entries = result.get("entries") or []
+        text = "\n".join(f"{e.get('type', '')}: {e.get('name', '')}" for e in entries) or "(empty)"
+        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
+    if "matches" in result:
+        matches = result.get("matches") or []
+        if matches and isinstance(matches[0], dict):
+            # grep: {path, line, snippet}
+            text = "\n".join(
+                f"{m.get('path', '')}:{m.get('line', '')}: {m.get('snippet', '')}" for m in matches
+            )
+        else:
+            # glob: a list of repo-relative path strings.
+            text = "\n".join(str(m) for m in matches)
+        return CanonicalToolResult(
+            text=text or "(no matches)", attachments=[], source_ref=None, meta={},
+        )
+    # A reyn_src shape with none of the known bodies — keep the whole dict lossless as structured.
+    return CanonicalToolResult(
+        text="", attachments=[{"kind": "structured", "data": result}], source_ref=None, meta={},
+    )
+
+
+def _compact_to_canonical(result: dict) -> CanonicalToolResult:
+    """``compact`` op result → canonical. On success the freed-token / free-window metrics (+ the chat-
+    axis compression fields when present) render as a short ``text`` summary; on error the ``error``
+    message surfaces as ``text`` with ``meta.isError``. Result shape:
+    ``{kind:"compact", status:"ok", freed_tokens?, free_window_after?, summarized_turns?,
+    compressed_tokens?, bridge_tokens?}`` (ok) or ``{status:"error", error_kind, error}`` (error)."""
+    if _is_error(result):
+        return CanonicalToolResult(
+            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
+        )
+    parts: list[str] = ["Compaction complete."]
+    for label, key in (
+        ("freed_tokens", "freed_tokens"),
+        ("free_window_after", "free_window_after"),
+        ("summarized_turns", "summarized_turns"),
+        ("compressed_tokens", "compressed_tokens"),
+        ("bridge_tokens", "bridge_tokens"),
+    ):
+        value = result.get(key)
+        if value is not None:
+            parts.append(f"{label}={value}")
+    return CanonicalToolResult(text=" ".join(parts), attachments=[], source_ref=None, meta={})
+
+
+def _judge_output_to_canonical(result: dict) -> CanonicalToolResult:
+    """``judge_output`` op result → canonical. The scorer's ``reason`` (its LLM-readable explanation) is
+    the ``text``; ``score`` / ``passed`` / ``threshold`` / ``on_fail`` are signal meta (they drive the
+    caller's next move — a failed judgment triggers ``on_fail``). An error surfaces the message as
+    ``text`` with ``meta.isError``. Shape: ``{kind:"judge_output", score, passed, reason, threshold,
+    on_fail}`` (ok) or ``{status:"error", error}`` (error)."""
+    if _is_error(result) or (result.get("status") == "error"):
+        return CanonicalToolResult(
+            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
+        )
+    meta: dict[str, Any] = {}
+    for key in ("score", "passed", "threshold", "on_fail"):
+        value = result.get(key)
+        if value is not None:
+            meta[key] = value
+    return CanonicalToolResult(
+        text=str(result.get("reason", "") or ""), attachments=[], source_ref=None, meta=meta,
+    )
+
+
 # op-kind → canonical mapper. Every op that once declared ``_offload_payload_field`` is registered
 # here; an unregistered kind falls back to a whole-dict ``structured`` attachment (see ``to_canonical``).
 _MAPPERS: dict[str, Any] = {
@@ -216,6 +421,12 @@ _MAPPERS: dict[str, Any] = {
     "index_query": _chunks_to_canonical,
     "run_pipeline": _run_pipeline_to_canonical,
     "run_pipeline_async": _run_pipeline_async_to_canonical,
+    # FP-0056 PR-H hotfix: the file family + reyn_src dev-reads + compact/judge_output — the coverage
+    # gap that offloaded a doc read as a whole-dict ``structured`` blob (dogfood 2026-07-09).
+    "file": _file_to_canonical,
+    "reyn_src": _reyn_src_to_canonical,
+    "compact": _compact_to_canonical,
+    "judge_output": _judge_output_to_canonical,
 }
 
 

--- a/src/reyn/tools/reyn_src.py
+++ b/src/reyn/tools/reyn_src.py
@@ -14,6 +14,17 @@ from typing import Any, Mapping
 
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
+
+def _as_reyn_src(result: dict) -> dict:
+    """Tag a ``reyn.runtime.reyn_src`` helper result with ``kind:"reyn_src"`` so the offload seam
+    (``core/offload/canonical.py``) routes it through the dedicated ``reyn_src`` mapper — the file body
+    / listing / match lines become the LLM-readable ``text`` — instead of the whole-dict ``structured``
+    fallback that confused the agent in the FP-0056 dogfood incident (a doc read surfaced as a 600-char
+    JSON-dict preview). The runtime helpers stay pure (no ``kind``); tagging lives at this tool seam,
+    which is the only consumer of their results."""
+    result["kind"] = "reyn_src"
+    return result
+
 # Description must be byte-identical to the current router_tools.py
 # ToolSpec.description for reyn_src_list (lines 776-783). Copied verbatim.
 _REYN_SRC_LIST_DESCRIPTION = (
@@ -108,12 +119,12 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     try:
         root = resolve_reyn_root()
     except RuntimeError as exc:
-        return {"error": str(exc)}
+        return _as_reyn_src({"error": str(exc)})
     try:
         target = safe_resolve_inside(root, path)
     except ValueError as exc:
-        return {"error": str(exc)}
-    return list_entries(root, target, path)
+        return _as_reyn_src({"error": str(exc)})
+    return _as_reyn_src(list_entries(root, target, path))
 
 
 async def _handle_read(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
@@ -134,19 +145,19 @@ async def _handle_read(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     try:
         root = resolve_reyn_root()
     except RuntimeError as exc:
-        return {"error": str(exc)}
+        return _as_reyn_src({"error": str(exc)})
     try:
         target = safe_resolve_inside(root, path)
     except ValueError as exc:
-        return {"error": str(exc)}
+        return _as_reyn_src({"error": str(exc)})
     offset_raw = args.get("offset")
     limit_raw = args.get("limit")
-    return read_text(
+    return _as_reyn_src(read_text(
         target,
         path,
         offset=int(offset_raw) if offset_raw is not None else None,
         limit=int(limit_raw) if limit_raw is not None else None,
-    )
+    ))
 
 
 _REYN_SRC_GLOB_DESCRIPTION = (
@@ -220,8 +231,8 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     try:
         root = resolve_reyn_root()
     except RuntimeError as exc:
-        return {"error": str(exc)}
-    return glob_entries(root, pattern)
+        return _as_reyn_src({"error": str(exc)})
+    return _as_reyn_src(glob_entries(root, pattern))
 
 
 async def _handle_grep(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
@@ -232,15 +243,15 @@ async def _handle_grep(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     try:
         root = resolve_reyn_root()
     except RuntimeError as exc:
-        return {"error": str(exc)}
-    return grep_entries(
+        return _as_reyn_src({"error": str(exc)})
+    return _as_reyn_src(grep_entries(
         root,
         pattern=pattern,
         path=args.get("path", ""),
         glob=args.get("glob"),
         case_sensitive=bool(args.get("case_sensitive", False)),
         max_results=int(args.get("max_results", 50) or 50),
-    )
+    ))
 
 
 REYN_SRC_LIST = ToolDefinition(

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -403,9 +403,10 @@ def test_run_tool_step_file_write_is_denied_without_grant_flag(
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    # #2425 PR-2: write_file's "file"-kind result is unregistered in the canonical
-    # mapper table → the whole dict becomes the sole structured attachment.
-    assert result["named_stores"]["r"]["structured"]["status"] == "denied"
+    # FP-0056 PR-H: write_file's "file"-kind result now has a canonical mapper → a mutating
+    # op surfaces a short status ``text`` (not a whole-dict structured blob). A denial surfaces
+    # the not-approved message as the text body; the write does not land.
+    assert "not approved" in result["named_stores"]["r"]["text"]
     assert not (tmp_path / "out.txt").exists()
 
 
@@ -436,7 +437,8 @@ def test_run_tool_step_file_write_allowed_with_grant_flag(
 
     out = capsys.readouterr().out
     result = json.loads(out)
-    assert result["named_stores"]["r"]["structured"]["status"] == "ok"
+    # FP-0056 PR-H: file write → a short status ``text`` (mapped), not a structured whole-dict blob.
+    assert "Wrote" in result["named_stores"]["r"]["text"]
     assert (tmp_path / "out.txt").read_text(encoding="utf-8") == "hello"
 
 

--- a/tests/test_format_feedback_golden_1608.py
+++ b/tests/test_format_feedback_golden_1608.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-import yaml
 
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
@@ -87,11 +86,12 @@ async def test_execute_round_message_sequence_golden(monkeypatch):
     assert write_msg["tool_call_id"] == "call_write"
     assert write_msg["content"].startswith("Error (tool_excluded): ")
 
-    # (4) the dispatched call's result is its own message at index 0. #2425 案B: an unmapped op
-    # result renders as a frontmatter YAML block (whole dict → ``structured``), not a JSON envelope
-    # — the exact dispatch outcome is harness-dependent, but it must round-trip at its own id.
+    # (4) the dispatched call's result is its own message at index 0. FP-0056 PR-H: the ``file`` kind
+    # now has a canonical mapper (no longer the whole-dict frontmatter fallback), so the read renders
+    # via that mapper — the exact dispatch outcome is harness-dependent (this fixtureless host has no
+    # workspace, so the read surfaces as an error string), but it must round-trip at its own id with a
+    # non-empty body and must NOT carry the excluded-call error.
     read_msg = tool_msgs[0]
     assert read_msg["tool_call_id"] == "call_read"
-    assert read_msg["content"].startswith("---\n"), "unmapped op result → frontmatter YAML"
-    _head = read_msg["content"][4:].split("\n---\n")[0]
-    assert yaml.safe_load(_head)["structured"]["kind"] == "file"
+    assert isinstance(read_msg["content"], str) and read_msg["content"], "read result round-trips at its id"
+    assert not read_msg["content"].startswith("Error (tool_excluded): "), "read is dispatched, not excluded"

--- a/tests/test_fp0056_file_reyn_src_canonical.py
+++ b/tests/test_fp0056_file_reyn_src_canonical.py
@@ -1,0 +1,228 @@
+"""Tier 1: FP-0056 PR-H — canonical mappers for the file family, reyn_src dev-reads, compact, judge_output.
+
+The dogfood incident (2026-07-09): a doc read via ``reyn_source__read`` was offloaded as a whole-dict
+``structured`` attachment (a 600-char JSON-dict preview) instead of the readable text body, because
+``_MAPPERS`` had no mapper for ``kind:"file"`` (unmapped) or the kind-less ``reyn_src_*`` results — both
+took the whole-dict fallback. These tests pin the fix: the readable body is the ``text`` stream, never a
+whole-dict structured blob. The incident regression test is RED against pre-hotfix code (with the mappers
+removed, ``to_canonical`` falls back to a whole-dict structured attachment and ``text`` is empty).
+
+Mirrors the tool-result arc (#2425) mapper-contract style: real result dicts (the shapes the producers
+actually emit), no mocks, presence/absence + substring assertions (no Tier-4 formatting pins).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.offload.canonical import to_canonical
+from reyn.core.offload.seam import build_offload_body
+from reyn.tools.reyn_src import _handle_read
+from reyn.tools.types import ToolContext
+
+
+def _fake_save(value, **_kw) -> dict:
+    """Records what was stored; returns a path-ref block like the real offload store (a plain stand-in
+    store, not a mock of a collaborator — mirrors ``test_2425_offload_seam._fake_save``)."""
+    _fake_save.stored.append(value)
+    return {"path": f".reyn/tool-results/{len(_fake_save.stored):04d}.txt", "content_hash": "h"}
+
+
+_fake_save.stored = []
+
+# A document large enough (> the seam's STRUCTURED_INLINE_MAX_CHARS = 2000) that a whole-dict structured
+# fallback WOULD be size-gated to its own ref — the exact shape the incident produced.
+_BIG_DOC = "# Present layer\n\n" + ("The present layer renders tool results. " * 200)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Incident regression — RED against pre-hotfix code
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_incident_file_read_offloads_clean_text_not_whole_dict_blob():
+    """Tier 1: INCIDENT — a large doc read via ``file`` read normalizes so the readable body is the
+    ``text`` stream and NO whole-dict structured attachment is produced. RED pre-hotfix: with no ``file``
+    mapper the whole result dict fell to the structured fallback (``text=""``, structured offloaded)."""
+    result = {
+        "kind": "file", "op": "read", "path": "docs/reference/runtime/present.ja.md",
+        "status": "ok", "content": _BIG_DOC, "_self_bounded": True,
+    }
+    canonical = to_canonical(result)
+    assert canonical["text"] == _BIG_DOC, "the doc body is the text payload (not offloaded as a dict)"
+    assert not any(a.get("kind") == "structured" for a in canonical["attachments"]), \
+        "no whole-dict structured attachment — the incident's blob is gone"
+
+    _fake_save.stored = []
+    frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+    assert text == _BIG_DOC, "the readable body is the text stream the LLM reads"
+    assert "structured" not in frontmatter and "structured_ref" not in frontmatter, \
+        "no structured ref/preview — the 600-char JSON-dict preview the agent saw is gone"
+
+
+def test_incident_reyn_src_read_offloads_clean_text_not_whole_dict_blob():
+    """Tier 1: INCIDENT (the exact dogfood path) — a large doc read via ``reyn_src_read`` (tagged
+    ``kind:"reyn_src"`` at the tool seam) normalizes to a clean ``text`` body, no whole-dict blob.
+    RED pre-hotfix: the kind-less result took the fallback and offloaded the whole dict."""
+    result = {"kind": "reyn_src", "path": "docs/reference/runtime/present.ja.md", "content": _BIG_DOC}
+    canonical = to_canonical(result)
+    assert canonical["text"] == _BIG_DOC
+    assert not any(a.get("kind") == "structured" for a in canonical["attachments"])
+
+    _fake_save.stored = []
+    frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+    assert text == _BIG_DOC
+    assert "structured" not in frontmatter and "structured_ref" not in frontmatter
+
+
+@pytest.mark.asyncio
+async def test_incident_end_to_end_real_reyn_src_read_handler_tags_kind_and_maps_clean():
+    """Tier 1: INTEGRATION — the REAL ``reyn_src_read`` handler reads a real repo file, its result is
+    tagged ``kind:"reyn_src"`` at the tool seam, and ``to_canonical`` yields the file body as ``text``
+    (not a structured blob). Proves the tag→mapper wiring end-to-end, not just the mapper in isolation."""
+    ctx = ToolContext(events=None, permission_resolver=None, workspace=None, caller_kind="router")
+    result = await _handle_read({"path": "pyproject.toml"}, ctx)
+    assert result["kind"] == "reyn_src", "the tool seam tags the kind so the mapper (not fallback) runs"
+
+    canonical = to_canonical(result)
+    assert canonical["text"] == result["content"], "the file body is the text payload"
+    assert 'name = "reyn"' in canonical["text"], "the real file content is present as readable text"
+    assert not any(a.get("kind") == "structured" for a in canonical["attachments"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# file mapper — per-op contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_file_read_content_is_text_path_op_status_are_signal_meta():
+    """Tier 1: file read → ``content`` is ``text``; ``path``/``op``/``status`` are signal meta (which
+    file, what happened), never the body."""
+    c = to_canonical({"kind": "file", "op": "read", "path": "a/b.md", "status": "ok",
+                      "content": "hello world", "_self_bounded": True})
+    assert c["text"] == "hello world"
+    assert c["meta"].get("path") == "a/b.md"
+    assert c["meta"].get("op") == "read" and c["meta"].get("status") == "ok"
+    assert not any(a.get("kind") == "structured" for a in c["attachments"])
+
+
+def test_file_read_not_found_surfaces_error_text_and_iserror():
+    """Tier 1: a not_found read surfaces the error message as ``text`` with ``meta.isError`` — the sole
+    error-path driver (so the seam renders ``Error: ...`` and the LLM retries a different path)."""
+    c = to_canonical({"kind": "file", "op": "read", "path": "missing.md",
+                      "status": "not_found", "error": "file not found: missing.md", "content": ""})
+    assert c["meta"].get("isError") is True
+    assert "file not found" in c["text"]
+
+
+def test_file_read_image_media_blocks_become_media_attachments():
+    """Tier 1: an image read (content empty, media_blocks present) surfaces the blocks as MEDIA
+    attachments (matching the MCP mapper), never a structured blob."""
+    c = to_canonical({"kind": "file", "op": "read", "path": "x.png", "status": "ok",
+                      "content": "", "media_blocks": [{"type": "image", "data": "..."}]})
+    assert [a["kind"] for a in c["attachments"]] == ["media"]
+
+
+def test_file_grep_content_mode_renders_match_lines_as_text():
+    """Tier 1: grep content mode → ``path:line: text`` lines as ``text`` (readable, not a dict blob)."""
+    c = to_canonical({"kind": "file", "op": "grep", "status": "ok", "output_mode": "content",
+                      "pattern": "foo", "matches": [
+                          {"path": "a.py", "line_number": 3, "content": "foo = 1"},
+                          {"path": "b.py", "line_number": 9, "content": "foo()"}],
+                      "count": 2})
+    assert "a.py:3: foo = 1" in c["text"] and "b.py:9: foo()" in c["text"]
+    assert not any(a.get("kind") == "structured" for a in c["attachments"])
+
+
+def test_file_glob_matches_render_as_path_lines():
+    """Tier 1: glob → the matched paths as newline-joined ``text``."""
+    c = to_canonical({"kind": "file", "op": "glob", "pattern": "*.py", "status": "ok",
+                      "matches": ["a.py", "b.py"], "count": 2})
+    assert c["text"] == "a.py\nb.py"
+
+
+def test_file_write_is_short_status_text():
+    """Tier 1: write → a short human-readable status ``text`` (bytes + path), not a JSON envelope."""
+    c = to_canonical({"kind": "file", "op": "write", "path": "out.txt", "status": "ok",
+                      "bytes_written": 42})
+    assert "42" in c["text"] and "out.txt" in c["text"]
+    assert not any(a.get("kind") == "structured" for a in c["attachments"])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# reyn_src mapper — per-shape contract
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_reyn_src_read_content_is_text_path_is_meta():
+    """Tier 1: reyn_src read → ``content`` is the ``text`` body; ``path`` is signal meta."""
+    c = to_canonical({"kind": "reyn_src", "path": "README.md", "content": "# Reyn"})
+    assert c["text"] == "# Reyn"
+    assert c["meta"].get("path") == "README.md"
+
+
+def test_reyn_src_error_surfaces_iserror():
+    """Tier 1: a reyn_src error (e.g. path outside repo) surfaces the message as ``text`` + isError."""
+    c = to_canonical({"kind": "reyn_src", "error": "reyn_src: path '..' resolves outside repo"})
+    assert c["meta"].get("isError") is True
+    assert "outside" in c["text"]
+
+
+def test_reyn_src_list_entries_render_as_text_lines():
+    """Tier 1: reyn_src list → ``type: name`` lines as ``text`` (a browsable listing, not a dict)."""
+    c = to_canonical({"kind": "reyn_src", "path": "docs", "entries": [
+        {"name": "concepts", "type": "dir"}, {"name": "README.md", "type": "file"}]})
+    assert "dir: concepts" in c["text"] and "file: README.md" in c["text"]
+
+
+def test_reyn_src_grep_matches_render_as_text_lines():
+    """Tier 1: reyn_src grep → ``path:line: snippet`` lines as ``text``."""
+    c = to_canonical({"kind": "reyn_src", "pattern": "def", "count": 1, "truncated": False,
+                      "matches": [{"path": "x.py", "line": 5, "snippet": "def foo():"}]})
+    assert "x.py:5: def foo():" in c["text"]
+    assert not any(a.get("kind") == "structured" for a in c["attachments"])
+
+
+def test_reyn_src_glob_matches_render_as_path_lines():
+    """Tier 1: reyn_src glob → the matched path strings as newline-joined ``text``."""
+    c = to_canonical({"kind": "reyn_src", "pattern": "**/*.md", "count": 2,
+                      "matches": ["docs/a.md", "docs/b.md"]})
+    assert c["text"] == "docs/a.md\ndocs/b.md"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# compact / judge_output mappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_compact_ok_summarizes_metrics_as_text():
+    """Tier 1: compact ok → a short ``text`` summary of the freed-token / free-window metrics (no blob)."""
+    c = to_canonical({"kind": "compact", "status": "ok", "freed_tokens": 1200,
+                      "free_window_after": 90000, "summarized_turns": 8})
+    assert "freed_tokens=1200" in c["text"] and "free_window_after=90000" in c["text"]
+    assert not any(a.get("kind") == "structured" for a in c["attachments"])
+
+
+def test_compact_error_surfaces_iserror():
+    """Tier 1: compact error → the message as ``text`` with ``meta.isError``."""
+    c = to_canonical({"kind": "compact", "status": "error", "error_kind": "compaction_unavailable",
+                      "error": "no compaction context is wired here"})
+    assert c["meta"].get("isError") is True
+    assert "no compaction context" in c["text"]
+
+
+def test_judge_output_reason_is_text_score_is_signal_meta():
+    """Tier 1: judge_output → ``reason`` is the ``text``; score/passed/threshold/on_fail are signal
+    meta (they drive the caller's next move — a failed judgment triggers on_fail)."""
+    c = to_canonical({"kind": "judge_output", "score": 0.4, "passed": False, "reason": "too terse",
+                      "threshold": 0.7, "on_fail": "retry"})
+    assert c["text"] == "too terse"
+    assert c["meta"].get("passed") is False and c["meta"].get("score") == 0.4
+    assert c["meta"].get("threshold") == 0.7 and c["meta"].get("on_fail") == "retry"
+
+
+def test_judge_output_error_surfaces_iserror():
+    """Tier 1: judge_output error (target resolution failed) → the message as ``text`` + isError."""
+    c = to_canonical({"kind": "judge_output", "status": "error",
+                      "error": "target resolution failed: 'summary'"})
+    assert c["meta"].get("isError") is True
+    assert "target resolution failed" in c["text"]


### PR DESCRIPTION
**[per-pr-coder]** — **PR-H of FP-0056** (URGENT dogfood hotfix). Reference: `docs/deep-dives/proposals/0056-canonical-coverage-enforcement.md` (#2675), § "Immediate hotfix (PR-H)". `part of #2675` (PR-F1/PR-F2 follow — NOT closes).

## Incident
In dogfood, reading a doc via `reyn_source__read` (and `file read`) hit `to_canonical`'s whole-dict `structured` fallback: `_MAPPERS` had 10 kinds, and neither `file` (kind:"file", unmapped) nor `reyn_src_*` (kind-less) had a mapper. The LLM got a 600-char JSON-dict preview instead of the readable text body (6 offloads in 3 min). Inherited coverage gap from the FP-0053 tool-result arc, not a regression.

## Change — add the missing mappers ONLY (not the framework)
- **`file` mapper** (`src/reyn/core/offload/canonical.py`), dispatched on the result's `op`:

  | op | canonical `text` | notes |
  |---|---|---|
  | `read` | file `content` | `path`/`op`/`status` → signal meta; image `media_blocks` → media attachments |
  | `grep` | rendered match lines | `content` mode → `path:line: text`; `files_with_matches` → paths; `count` → total |
  | `glob` | matched paths (newline-joined) | |
  | `write`/`edit`/`delete`/`mkdir`/`move`/`stat`/`regenerate_index` | short status line | |
  | any error (`status` error/denied/not_found, or `error` field) | the error message | `meta.isError` set |

- **`reyn_src` mapper**: **dedicated mapper** (kind:`reyn_src`), NOT `kind:"file"` reuse. Rationale: reyn_src result shapes diverge from the file op's (no `op` field; grep uses `snippet`/`line` vs `content`/`line_number`; list uses `entries`) — forcing them through the op-dispatched file mapper would mean fabricating an `op` and reshaping fields (invasive, risks the reyn_src contract). The tool-handler seam (`src/reyn/tools/reyn_src.py`) tags the kind-less runtime-helper result `kind:"reyn_src"` via `_as_reyn_src(...)` so it routes to this mapper (read→content text, list→`type: name` lines, glob→paths, grep→`path:line: snippet` lines, error→text+isError). Verified safe: the only consumers of the reyn_src helper results are these tool handlers → the router chokepoint; existing reyn_src tests assert key presence, not exact dict/key-set equality.
- **`compact` mapper**: ok → short text summary of freed-token / free-window (+ chat-axis compression) metrics; error → text + isError. Shape: `{kind:"compact", status:"ok", freed_tokens?, free_window_after?, summarized_turns?, compressed_tokens?, bridge_tokens?}` | `{status:"error", error_kind, error}`.
- **`judge_output` mapper**: `reason` → text; `score`/`passed`/`threshold`/`on_fail` → signal meta (they drive the caller's next move); error → text + isError. Shape: `{kind:"judge_output", score, passed, reason, threshold, on_fail}` | `{status:"error", error}`.

**Not built** (PR-F1/PR-F2): registry-enforcement framework, CI completeness gate, `STRUCTURED_PASSTHROUGH`, identity-keyed `to_canonical(result, source=...)`, `canonical_fallback_used` event.

## Not #1983
`file`/`compact`/`judge_output` already exist as op kinds (`file` intentionally out of `OP_KIND_MODEL_MAP`; the other two are in it). `reyn_src` is a canonical-mapper key, not an op-runtime kind. **No new op-runtime kind → no `OP_KIND_MODEL_MAP` / control-ir.md change.**

## Cross-consumer impact (reviewer attention)
The canonical mapper also feeds the **pipeline tool-step ctx** via `canonical_to_ctx_fields` (`core/pipeline/executor.py`). With `file` now mapped, a file-op step's `ctx.<step>` exposes a text status instead of the pre-hotfix whole-dict `structured` (consistent with existing text-only ops like web_fetch/exec, which already have no `.structured`). Two `test_cli_pipe` tests + one format-feedback golden that explicitly pinned the pre-hotfix unmapped-fallback shape are updated to the mapped (text) shape, per the proposal's explicit "write/edit/delete → short status text". If a follow-up needs programmatic file-op status in pipeline ctx, PR-F1 is the place.

## Regression test = the incident (RED against pre-hotfix)
`tests/test_fp0056_file_reyn_src_canonical.py` (18 tests). Verified RED against pre-hotfix by removing the 4 mapper registrations: the 3 incident tests fail (whole-dict fallback → empty `text` / structured blob), GREEN after. Includes an end-to-end integration test through the REAL `reyn_src_read` handler (real repo file → kind tagged → clean text). Real instances, no mocks, no Tier-4 pins.

## CI gates (all 4, local, to completion)
- `ruff check src tests` — **PASS**
- `python scripts/test_tier_audit.py --strict <changed test files>` — **PASS** (39 inspected, 0 errors)
- `pytest` (repo root) — **PASS**: 7637 passed, 21 skipped, 5 failed. The 5 failures are pre-existing route-mount flakes (`test_fp0001_a2a_endpoints`, `web/test_a2a`, `web/test_mcp_sse`, `web/test_plugin_loader`, `web/test_resources_router`) — confirmed via `git stash` that they fail identically on clean origin/main (unrelated to this change).
- `python scripts/verify_module_docstrings.py <changed src files>` — **PASS**

## Test plan
- [x] New incident regression test is RED against pre-hotfix code (mappers removed → whole-dict fallback), GREEN with the fix.
- [x] Per-mapper contract tests: file read/grep/glob/write, reyn_src read/list/glob/grep + error, compact ok/error, judge_output ok/error.
- [x] End-to-end integration through the real `reyn_src_read` handler (kind tagging → clean text).
- [x] All 4 CI gates run locally to completion.
- [x] Full-suite residual failures confirmed pre-existing on clean origin/main (git stash).
- [x] No new op-runtime kind; `OP_KIND_MODEL_MAP` / control-ir.md untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)