### PR TITLE
feat: render_template op — sandboxed Jinja2 text-templating producer (FP-0055 PR-2)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -20,6 +20,7 @@ Control IR is the list of side-effect operations the LLM may emit alongside its 
 | `grep_files` | Search file contents by regex | `file.read` |
 | `ask_user` | Pause the phase and ask the user a question | none (always allowed) |
 | `present` | Route bulk data + a declarative view to the user surface without the data passing through LLM output tokens (fire-and-continue) | Tier 0 (always allowed); `data_ref` read authority == `file.read` |
+| `render_template` | Render a Jinja2 template against structured data into a string (a sandboxed producer — no side effects, no sink) | `template_ref` / `data_ref` read authority == `file.read`; inline-only is pure computation (no gate) |
 | `sandboxed_exec` | Run argv under a `SandboxPolicy` via a `SandboxBackend` (replaces the removed `shell` op) | enforced by backend (`SandboxPolicy`) |
 | `web_search` | Search the public web via DuckDuckGo | Tier 1 — default allow; `web.search: deny` in `reyn.yaml` blocks |
 | `web_fetch` | Fetch a single URL and return extracted text | Tier 1 — default allow; `web.fetch: deny` in `reyn.yaml` blocks |
@@ -271,6 +272,72 @@ appear earlier in the session), never LLM-self-reported. The event carries **ref
 > display-only projection (no reconstructed state). See
 > [Concepts: Present layer](../../concepts/runtime/present.md) and the
 > [Present op & surface reference](present.md) for the full surface.
+
+## `render_template`
+
+Renders a Jinja2 template against structured data into a plain string. A general,
+sandboxed **producer**: `data + template → string`, with **no side effects and no
+sink** — the rendered string is returned as an ordinary op result (canonical `text`;
+large output auto-offloads on the chat path). The caller routes it to whatever sink it
+wants: `present`, a `write_file`, a message body, or a pipeline `ctx`.
+
+Prefer `present` (declarative) to show structured data to the user — it is
+token-economical and portable. Reach for `render_template` only when you need
+**computed text**: loops / conditionals / aggregation woven into prose, which
+declarative binding intentionally cannot express.
+
+```json
+{
+  "kind": "render_template",
+  "template": "{% for r in data.results %}- {{ r.title }}\n{% endfor %}",
+  "data_ref": "runs/summary.json",
+  "undefined": "strict"
+}
+```
+
+Fields:
+- `template` (XOR `template_ref`) — inline Jinja2 source string.
+- `template_ref` (XOR `template`) — a zone-readable template file path, read as **raw
+  text** under `file.read` authority (a template file is source text, never
+  JSON-rehydrated).
+- `data_ref` (XOR `data_inline`) — any zone-readable path, re-hydrated to its full
+  value under `file.read` semantics (the same seam `present` uses).
+- `data_inline` (XOR `data_ref`) — a small object already in the LLM's context.
+- `undefined` (optional, default `"strict"`) — `"strict"`: an undefined variable is a
+  **hard error naming the missing name** (loud-by-default, so a file sink never
+  silently writes a broken artifact); `"lenient"`: undefined renders empty and the
+  referenced-but-unbound names surface as `undefined_vars` in the result meta.
+
+The resolved data binds under **`data`** in the template context
+(`{{ data.results[0].title }}`).
+
+**Sandbox + neutrality.** The engine is always `jinja2.sandbox.SandboxedEnvironment`
+(via the one factory, `reyn.security.template_env.make_sandboxed_env`) — templates may
+be LLM-authored, and unsandboxed Jinja2 is arbitrary-code execution (SSTI). A blocked
+attribute traversal (`{{ ().__class__ }}`) raises a sandbox violation → a structured
+`error` result; nothing executes. `autoescape` is **OFF**: the op returns RAW rendered
+bytes. Neutralization is the **sink's** job (a terminal strips control bytes at its
+guard, a file is inert, a web surface HTML-escapes) — escaping in the producer would
+corrupt file / terminal artifacts.
+
+**Read-authority equivalence.** `template_ref` / `data_ref` resolve through exactly the
+`file.read` gate; a denied read → `status="denied"`. render_template can never read
+more than the agent's `file.read` can. An inline-only invocation (`template` +
+`data_inline`) is pure computation — no read gate.
+
+**Resource bounds.** `SandboxedEnvironment` stops SSTI but not resource exhaustion — a
+bounded loop like `{% for i in range(10**9) %}` still floods. The cap is applied
+**during** generation (streaming `template.generate(context)`), accumulating against a
+max-output-chars budget with a wall-clock backstop; the moment either is exceeded the
+render stops and the result is TRUNCATED with a `truncated: true` meta flag naming
+which bound fired (`truncate_reason`) — a bounded result, never an OOM / hang. Bounds
+default to safety-spirit constants (operator-tunable via `OpContext.render_template_bounds`).
+
+Result fields: `rendered` (the string), `truncated`, `truncate_reason` (when
+truncated), `undefined_vars` (lenient mode). An error result carries
+`status="error"` + `error_kind` (`template_error` | `security` | `undefined`) +
+`error`. No new event type — standard op events; a pure function of (template, data),
+so ordinary memo/replay applies.
 
 ## `sandboxed_exec`
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -364,6 +364,34 @@ def _reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
+def _render_template_to_canonical(result: dict) -> CanonicalToolResult:
+    """``render_template`` op result → canonical (FP-0055 PR-2). The rendered string
+    (``rendered``) IS the LLM-readable body → ``text`` (NOT a whole-dict ``structured``
+    blob — a render_template result without its own mapper would fall to the FP-0056
+    whole-dict fallback and hide the rendered text behind a JSON envelope). Signal
+    meta: ``truncated`` (+ which bound fired, ``truncate_reason``) tells the LLM the
+    output was capped mid-generate; ``undefined_vars`` (lenient mode) names the
+    referenced-but-unbound template variables so it can self-correct. An error
+    (``status="error"`` — syntax / SSTI-blocked / strict-undefined) surfaces the
+    message as ``text`` with ``meta.isError``."""
+    if _is_error(result):
+        return CanonicalToolResult(
+            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
+        )
+    meta: dict[str, Any] = {}
+    if result.get("truncated"):
+        meta["truncated"] = True
+        reason = result.get("truncate_reason")
+        if reason:
+            meta["truncate_reason"] = reason
+    undefined_vars = result.get("undefined_vars")
+    if undefined_vars:
+        meta["undefined_vars"] = undefined_vars
+    return CanonicalToolResult(
+        text=result.get("rendered", "") or "", attachments=[], source_ref=None, meta=meta,
+    )
+
+
 def _compact_to_canonical(result: dict) -> CanonicalToolResult:
     """``compact`` op result → canonical. On success the freed-token / free-window metrics (+ the chat-
     axis compression fields when present) render as a short ``text`` summary; on error the ``error``
@@ -421,6 +449,9 @@ _MAPPERS: dict[str, Any] = {
     "index_query": _chunks_to_canonical,
     "run_pipeline": _run_pipeline_to_canonical,
     "run_pipeline_async": _run_pipeline_async_to_canonical,
+    # FP-0055 PR-2: render_template producer — the rendered string → text (never the
+    # whole-dict fallback for its OWN result; truncated/undefined_vars as signal meta).
+    "render_template": _render_template_to_canonical,
     # FP-0056 PR-H hotfix: the file family + reyn_src dev-reads + compact/judge_output — the coverage
     # gap that offloaded a doc read as a whole-dict ``structured`` blob (dogfood 2026-07-09).
     "file": _file_to_canonical,

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -128,6 +128,9 @@ from . import pipeline_install as _pipeline_install  # noqa: F401, E402
 # FP-0054 PR-A: present op — user-facing presentation of bulk data (null renderer).
 from . import present as _present  # noqa: F401, E402
 from . import recall as _recall  # noqa: F401, E402
+
+# FP-0055 PR-2: render_template op — sandboxed Jinja2 text-templating producer.
+from . import render_template as _render_template  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402
 
 # #2548 PR-C: local skill install op (register a SKILL.md dir into skills.entries).

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from reyn.config import MultimodalConfig, SandboxConfig, WebConfig
     from reyn.core.events.events import EventLog
     from reyn.core.events.state_log import StateLog
+    from reyn.core.op_runtime.render_template import RenderTemplateBounds
     from reyn.core.present import PresentationRenderer
     from reyn.data.workspace.media_store import MediaStore
     from reyn.data.workspace.workspace import Workspace
@@ -96,6 +97,13 @@ class OpContext:
     # from the session/adapter's current registry, so a hot-reload swap is picked up
     # at the next turn boundary.
     presentation_registry: "object | None" = None
+
+    # FP-0055 PR-2: resource bounds for the `render_template` op (streaming
+    # output-size + wall-clock cap, applied DURING generation). None → the
+    # safety-spirit defaults (RenderTemplateBounds()). The override seam is used by
+    # operator config (future yaml wiring) and by tests that inject a tiny cap; a
+    # production-default None correctly applies the generous defaults in-handler.
+    render_template_bounds: "RenderTemplateBounds | None" = None
 
     # #272/#1128: voluntary-compaction capability for the `compact` op.
     # An awaitable zero-arg callable the caller (Session / phase runtime)

--- a/src/reyn/core/op_runtime/render_template.py
+++ b/src/reyn/core/op_runtime/render_template.py
@@ -1,0 +1,210 @@
+"""render_template kind handler — a sandboxed text-templating producer (FP-0055 PR-2).
+
+``render_template`` renders a Jinja2 template against structured data into a plain
+string. It is a **producer**, not a sink: it writes nothing and invokes no surface —
+the rendered string is returned as an ordinary op result (canonical ``text``) whose
+bulk auto-offloads on the chat path, and the caller routes it to whatever sink it
+wants (``present``, a ``write_file`` step, a message, or a pipeline ``ctx``).
+
+Trust + safety model
+--------------------
+- **Sandbox (producer-side, sink-independent).** The engine is always
+  ``jinja2.sandbox.SandboxedEnvironment`` (via the one factory,
+  ``reyn.security.template_env.make_sandboxed_env``): templates may be LLM-authored,
+  and unsandboxed Jinja2 is arbitrary-code execution (SSTI). A blocked attribute
+  traversal (``{{ ().__class__ }}``) raises ``SecurityError`` → a structured error
+  result; nothing executes.
+- **Producer-neutrality (no output escaping here).** ``autoescape`` is OFF and the
+  op returns RAW rendered bytes. Neutralization is the SINK's job — a terminal
+  strips control bytes at its guard, a file is inert, a web surface HTML-escapes.
+  Escaping in the producer would corrupt file / terminal artifacts.
+- **Read-authority equivalence.** ``template_ref`` / ``data_ref`` resolve through
+  exactly the ``file.read`` gate (``resolve_ref_text`` / ``resolve_present_source``);
+  a denied read → ``status="denied"``. render_template can never read more than the
+  agent's ``file.read`` can. An inline-only invocation is pure computation.
+
+Undefined policy
+----------------
+``strict`` (default) → an undefined variable is a HARD error naming the missing name
+(loud-by-default: a file sink must never silently write a broken artifact). ``lenient``
+→ undefined renders empty and the referenced-but-unbound names surface in the result
+meta as ``undefined_vars`` (a self-correction signal, not a crash).
+
+Resource bounds
+---------------
+``SandboxedEnvironment`` stops SSTI but NOT resource exhaustion — a bounded loop like
+``{% for i in range(10**9) %}`` still floods. The cap is applied **during** generation,
+not after: rendering streams through ``template.generate(context)`` (Jinja2's chunk
+generator), accumulating against a max-chars budget with a wall-clock backstop; the
+moment either is exceeded the loop stops and the result is TRUNCATED with a ``truncated``
+meta flag naming which bound fired — a bounded result, never an OOM / hang / crash.
+``.render()`` (materialize-then-cap) would be insufficient: the exhaustion happens
+during materialization. Bounds default to the safety-spirit constants below and are
+overridable per op-context via ``OpContext.render_template_bounds``.
+
+Determinism: a pure function of (template, data) — no clock / random in the render
+path; ordinary op-event / memo replay applies. No new event type, no reconstructed
+state (recovery-feature gate N/A).
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from jinja2 import TemplateError, UndefinedError
+from jinja2.meta import find_undeclared_variables
+from jinja2.sandbox import SecurityError
+
+from reyn.core.present import (
+    PresentSourceNotFound,
+    resolve_present_source,
+    resolve_ref_text,
+)
+from reyn.security.template_env import make_sandboxed_env
+
+from . import register
+from .context import OpContext
+
+_KIND = "render_template"
+
+# The template-context key the resolved data binds under (unambiguous, mirrors the
+# pipeline ``ctx`` style — ``{{ data.results[0].title }}``).
+_DATA_KEY = "data"
+
+
+@dataclass(frozen=True)
+class RenderTemplateBounds:
+    """Resource bounds for a single render, applied DURING generation.
+
+    ``max_output_chars`` — the streaming byte(char) budget; the render truncates the
+    moment cumulative output exceeds it. ``wall_clock_seconds`` — the elapsed-time
+    backstop (Jinja2 exposes no iteration count, so wall-clock bounds a runaway loop
+    that produces little text per step). Safety-spirit defaults: generous enough for
+    real reports / configs, tight enough that a runaway generator is stopped quickly.
+    """
+
+    max_output_chars: int = 256_000
+    wall_clock_seconds: float = 5.0
+
+
+def _error(error_kind: str, message: str) -> dict:
+    """A structured error result — a Jinja render / syntax error, an SSTI-blocked
+    access, or a strict-undefined variable. ``status="error"`` is the sole error-path
+    driver the canonical mapper reads (→ ``meta.isError``)."""
+    return {
+        "kind": _KIND,
+        "status": "error",
+        "ok": False,
+        "error_kind": error_kind,
+        "error": message,
+    }
+
+
+async def _resolve_template_text(op: Any, ctx: OpContext) -> str:
+    """The Jinja2 source text: an inline ``template`` verbatim, or a ``template_ref``
+    read as RAW text under ``file.read`` authority (never JSON-rehydrated — a template
+    file is source text even when it starts with ``{``)."""
+    if op.template_ref is not None:
+        text, _ingested = await resolve_ref_text(op.template_ref, ctx)
+        return text
+    return op.template
+
+
+async def _resolve_data(op: Any, ctx: OpContext) -> Any:
+    """The template-context data: a ``data_ref`` re-hydrated to its full value under
+    ``file.read`` authority (the same seam ``present`` uses), or ``data_inline``
+    verbatim (already in the LLM's context)."""
+    if op.data_ref is not None:
+        value, _ingested = await resolve_present_source(op.data_ref, ctx)
+        return value
+    return op.data_inline
+
+
+def _undefined_vars(env: Any, source: str, context: dict) -> list[str]:
+    """The referenced-but-unbound top-level names in ``source`` (lenient-mode signal).
+
+    A static over-approximation: the names the template references that are neither in
+    the bound ``context`` nor in the environment globals (``range``/``dict``/…). Sorted
+    for a stable, high-signal self-correction hint; it does not execute the template."""
+    referenced = find_undeclared_variables(env.parse(source))
+    bound = set(context) | set(env.globals)
+    return sorted(referenced - bound)
+
+
+async def handle(op: Any, ctx: OpContext) -> dict:
+    # 1. Resolve template + data under file.read authority. PermissionError
+    #    propagates → the dispatch layer returns status="denied" (read-authority
+    #    equivalence). A missing ref → not_found (mirrors present).
+    try:
+        source = await _resolve_template_text(op, ctx)
+        data = await _resolve_data(op, ctx)
+    except PresentSourceNotFound as exc:
+        return {"kind": _KIND, "status": "not_found", "ok": False, "error": str(exc)}
+
+    context = {_DATA_KEY: data}
+
+    # 2. Compile in the sandbox. autoescape OFF (producer-neutral). A syntax error
+    #    is a HARD error (never a silent fallback — malformed input must not be masked).
+    env = make_sandboxed_env(undefined=op.undefined)
+    try:
+        template = env.from_string(source)
+    except TemplateError as exc:
+        return _error("template_error", f"template syntax error: {exc}")
+
+    # 3. Lenient-mode undefined-var signal (static; strict mode raises at render
+    #    instead, so this stays empty there).
+    undefined_vars: list[str] = []
+    if op.undefined == "lenient":
+        undefined_vars = _undefined_vars(env, source, context)
+
+    # 4. Stream-render with a during-generation cap (size + wall-clock backstop). The
+    #    cap fires DURING generate() so a runaway loop is stopped before it floods
+    #    memory — .render() would materialize the whole string first.
+    bounds = ctx.render_template_bounds or RenderTemplateBounds()
+    chunks: list[str] = []
+    total = 0
+    truncated = False
+    truncate_reason: str | None = None
+    started = time.monotonic()
+    try:
+        for chunk in template.generate(context):
+            chunks.append(chunk)
+            total += len(chunk)
+            if total > bounds.max_output_chars:
+                truncated = True
+                truncate_reason = "max_output_chars"
+                break
+            if time.monotonic() - started > bounds.wall_clock_seconds:
+                truncated = True
+                truncate_reason = "wall_clock_seconds"
+                break
+    except UndefinedError as exc:
+        # strict-undefined → hard error naming the missing variable (Jinja's message
+        # names it), so the LLM self-corrects in one turn.
+        return _error("undefined", str(exc))
+    except SecurityError as exc:
+        # SSTI-blocked attribute traversal — nothing executed.
+        return _error("security", f"sandbox blocked template access: {exc}")
+    except TemplateError as exc:
+        return _error("template_error", str(exc))
+
+    rendered = "".join(chunks)
+    if truncated:
+        rendered = rendered[: bounds.max_output_chars]
+
+    result: dict = {
+        "kind": _KIND,
+        "status": "ok",
+        "ok": True,
+        "rendered": rendered,
+        "truncated": truncated,
+    }
+    if truncate_reason is not None:
+        result["truncate_reason"] = truncate_reason
+    if undefined_vars:
+        result["undefined_vars"] = undefined_vars
+    return result
+
+
+register(_KIND, handle)

--- a/src/reyn/core/present/__init__.py
+++ b/src/reyn/core/present/__init__.py
@@ -23,6 +23,7 @@ from reyn.core.present.source import (
     compute_ingested,
     rehydrate_ref_text,
     resolve_present_source,
+    resolve_ref_text,
 )
 
 __all__ = [
@@ -41,5 +42,6 @@ __all__ = [
     "resolve_bindings",
     "resolve_pointer",
     "resolve_present_source",
+    "resolve_ref_text",
     "validate_blueprint",
 ]

--- a/src/reyn/core/present/source.py
+++ b/src/reyn/core/present/source.py
@@ -31,19 +31,23 @@ class PresentSourceNotFound(FileNotFoundError):
     passed) — distinct from a permission denial."""
 
 
-async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, str]:
-    """Resolve ``data_ref`` to its full value under ``file.read`` authority.
+async def _gate_and_read_ref(ref: str, ctx: "OpContext") -> tuple[bytes, str]:
+    """The shared read-authority gate + workspace read for any ref-resolving op.
 
-    Returns ``(value, ingested)`` where ``value`` is the re-hydrated structured
-    object (when the ref's bytes parse as JSON) or the decoded text, and
-    ``ingested`` ∈ ``{none, partial, full}`` (OS-computed).
+    Runs the ``file.read`` gate (read-authority equivalence: a ref-read can never
+    read more than the agent's ``file.read`` can) then reads the bytes. Returns
+    ``(raw_bytes, ingested)`` where ``ingested`` ∈ ``{none, partial, full}``
+    (OS-computed from the events log).
 
     Raises ``PermissionError`` when the read is not authorized (identical gate to
-    ``file.read``); ``PresentSourceNotFound`` when the path is missing.
+    ``file.read``); ``PresentSourceNotFound`` when the path is missing. This is the
+    ONE seam both ``resolve_present_source`` (present's ``data_ref``) and
+    ``resolve_ref_text`` (``render_template``'s ``template_ref`` / ``data_ref``)
+    route through, so the equivalence is asserted in exactly one place.
     """
     from reyn.core.op_runtime.file import _resolve_for_gate
 
-    resolved = _resolve_for_gate(ctx, data_ref)
+    resolved = _resolve_for_gate(ctx, ref)
 
     # Read-authority equivalence: the SAME gate file.read uses. bus=None → the
     # non-interactive deny path; a wired bus → the same JIT prompt.
@@ -58,9 +62,25 @@ async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, 
             bus=ctx.intervention_bus,
         )
 
-    raw_bytes, found = ctx.workspace.read_file_bytes(data_ref)
+    raw_bytes, found = ctx.workspace.read_file_bytes(ref)
     if not found:
-        raise PresentSourceNotFound(f"present data_ref not found: {data_ref}")
+        raise PresentSourceNotFound(f"ref not found: {ref}")
+
+    ingested = compute_ingested(ctx, ref, resolved)
+    return raw_bytes, ingested
+
+
+async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, str]:
+    """Resolve ``data_ref`` to its full value under ``file.read`` authority.
+
+    Returns ``(value, ingested)`` where ``value`` is the re-hydrated structured
+    object (when the ref's bytes parse as JSON) or the decoded text, and
+    ``ingested`` ∈ ``{none, partial, full}`` (OS-computed).
+
+    Raises ``PermissionError`` when the read is not authorized (identical gate to
+    ``file.read``); ``PresentSourceNotFound`` when the path is missing.
+    """
+    raw_bytes, ingested = await _gate_and_read_ref(data_ref, ctx)
 
     text, _encoding = decode_text_or_none(raw_bytes)
     value: Any
@@ -71,8 +91,25 @@ async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, 
     else:
         value = rehydrate_ref_text(text)
 
-    ingested = compute_ingested(ctx, data_ref, resolved)
     return value, ingested
+
+
+async def resolve_ref_text(ref: str, ctx: "OpContext") -> tuple[str, str]:
+    """Resolve ``ref`` to its decoded **text** under ``file.read`` authority — the
+    ``render_template`` counterpart to :func:`resolve_present_source` that keeps the
+    bytes as raw text (NO JSON re-hydration), because a Jinja2 template file is
+    source text even when it happens to start with ``{`` / ``[``.
+
+    Returns ``(text, ingested)``. Raises ``PermissionError`` (identical gate to
+    ``file.read`` — same seam as present) when the read is not authorized, and
+    ``PresentSourceNotFound`` when the path is missing OR the bytes are not
+    decodable text (a binary blob is not a template / template-context source).
+    """
+    raw_bytes, ingested = await _gate_and_read_ref(ref, ctx)
+    text, _encoding = decode_text_or_none(raw_bytes)
+    if text is None:
+        raise PresentSourceNotFound(f"ref is not decodable text: {ref}")
+    return text, ingested
 
 
 def rehydrate_ref_text(text: str) -> Any:

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -218,6 +218,61 @@ class PresentIROp(BaseModel):
         return self
 
 
+class RenderTemplateIROp(BaseModel):
+    """render_template op — render a Jinja2 template against structured data into a
+    plain string (FP-0055 PR-2).
+
+    A general, sandboxed **producer**: ``data + template → string``. It has NO side
+    effects and invokes no sink — the rendered string is returned as an ordinary op
+    result whose bulk auto-offloads on the chat path; the caller routes it to any
+    sink (``present``, a ``write_file``, a message, or a pipeline ``ctx``).
+    Neutralization of the raw output is the SINK's job, never the producer's
+    (producer-neutrality: a file is inert bytes, a terminal strips control bytes at
+    its guard — different sinks disagree about what is dangerous).
+
+    Template source (exactly one): ``template`` — an inline Jinja2 source string —
+    XOR ``template_ref`` — a file path read as raw text under ``file.read``
+    authority (a template file is source text, never JSON-rehydrated).
+
+    Data source (exactly one): ``data_ref`` — any zone-readable path, re-hydrated to
+    its full value under ``file.read`` semantics (the same seam ``present`` uses) —
+    XOR ``data_inline`` — a small object already in the LLM's context. The resolved
+    value binds under ``data`` in the template context (``{{ data.results[0] }}``).
+
+    ``undefined``: ``strict`` (default) → an undefined variable is a HARD error
+    naming the missing name (loud-by-default so a file sink never silently writes a
+    broken artifact); ``lenient`` → undefined renders empty and the referenced-but-
+    unbound names are reported in the result meta (``undefined_vars``).
+
+    **Read-authority equivalence**: ``template_ref`` / ``data_ref`` resolve through
+    exactly the ``file.read`` gate (a denied read → ``status="denied"``);
+    render_template can never read more than the agent's ``file.read`` can. An
+    inline-only invocation is pure computation (no read gate). The engine is always
+    ``jinja2.sandbox.SandboxedEnvironment`` (SSTI-safe; templates may be
+    LLM-authored) with autoescape OFF (HTML-escaping is a sink concern).
+    """
+    kind: Literal["render_template"]
+    template: str | None = None            # XOR template_ref; inline Jinja2 source
+    template_ref: str | None = None        # XOR template; a zone-readable template file path
+    data_ref: str | None = None            # XOR data_inline; any zone-readable path (re-hydrated)
+    data_inline: Any | None = None         # XOR data_ref; small already-in-context data
+    undefined: Literal["strict", "lenient"] = "strict"
+
+    @model_validator(mode="after")
+    def _exactly_one_template_and_one_data(self) -> "RenderTemplateIROp":
+        # data_inline may legitimately be a falsy value ({} / [] / 0 / ""); the
+        # ``is None`` checks distinguish "absent" from "present-but-falsy".
+        if (self.template is None) == (self.template_ref is None):
+            raise ValueError(
+                "render_template requires exactly one of template / template_ref"
+            )
+        if (self.data_ref is None) == (self.data_inline is None):
+            raise ValueError(
+                "render_template requires exactly one of data_ref / data_inline"
+            )
+        return self
+
+
 class SandboxedExecIROp(BaseModel):
     """Execute a command under a SandboxPolicy (FP-0017).
 
@@ -681,6 +736,10 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # without the data passing through LLM output tokens. Tier 0 (ask_user's
     # sibling); the only gate is data_ref read authority == file.read.
     "present":     PresentIROp,
+    # FP-0055 PR-2: render a Jinja2 template against structured data → a string.
+    # A sandboxed producer (no side effects, no sink); template_ref/data_ref read
+    # authority == file.read.
+    "render_template": RenderTemplateIROp,
     "web_fetch":   WebFetchIROp,
     "web_search":  WebSearchIROp,
     "mcp_install": MCPInstallIROp,
@@ -736,6 +795,7 @@ if TYPE_CHECKING:
             MCPGetPromptIROp,
             AskUserIROp,
             PresentIROp,
+            RenderTemplateIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,
             IndexQueryIROp, RecallIROp, IndexDropIROp,

--- a/tests/test_render_template_op_fp0055_pr2.py
+++ b/tests/test_render_template_op_fp0055_pr2.py
@@ -1,0 +1,325 @@
+"""render_template op (FP-0055 PR-2) — sandboxed Jinja2 text-templating producer.
+
+Contract + OS-invariant coverage for the `render_template` op: happy-path render,
+strict/lenient undefined policy, SSTI sandbox containment (falsify), during-generate
+resource caps (falsify), read-authority equivalence (`file.read` gate, both
+directions), and the op's own canonical `_MAPPERS` entry (rendered string → `text`,
+never a whole-dict `structured` fallback). Real Workspace + PermissionResolver +
+EventLog — no collaborator mocks. Assertions are on the public op result, the
+sandbox/cap behavior, and the canonical shape (never private state, never an exact
+rendered-whitespace layout).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import to_canonical
+from reyn.core.op_runtime import execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.render_template import RenderTemplateBounds, handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import RenderTemplateIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _resolver(tmp_path: Path, config_permissions: dict | None = None) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config_permissions or {},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _ctx(
+    tmp_path: Path,
+    resolver: PermissionResolver,
+    bounds: RenderTemplateBounds | None = None,
+) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=resolver)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="render_template_test",
+        render_template_bounds=bounds,
+    )
+    return ctx, events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── Tier 1: render happy path ────────────────────────────────────────────────
+
+
+def test_render_happy_path_inline(tmp_path):
+    """Tier 1: inline template + inline data → the rendered string. Content-presence
+    assertion (the interpolated + looped values appear), not an exact-whitespace pin."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="Report: {{ data.title }}\n{% for r in data.rows %}- {{ r }}\n{% endfor %}",
+        data_inline={"title": "Q3", "rows": ["alpha", "beta"]},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    assert result["truncated"] is False
+    rendered = result["rendered"]
+    assert "Report: Q3" in rendered
+    assert "- alpha" in rendered
+    assert "- beta" in rendered
+
+
+def test_render_binds_data_ref_full_value(tmp_path, monkeypatch):
+    """Tier 1: a data_ref is re-hydrated to its full value (same seam present uses)
+    and bound under `data` — the template reaches nested fields of the on-disk JSON."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data.json").write_text(json.dumps({"results": [{"title": "hit-one"}]}))
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="{{ data.results[0].title }}",
+        data_ref="data.json",
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    assert "hit-one" in result["rendered"]
+
+
+# ── Tier 1: undefined policy ─────────────────────────────────────────────────
+
+
+def test_strict_undefined_is_hard_error_naming_var(tmp_path):
+    """Tier 1: strict (default) → an undefined variable is a hard error whose message
+    names the missing name, so the LLM self-corrects. No silent blank render."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="Hello {{ data.name }}, ref {{ missing_var }}",
+        data_inline={"name": "world"},
+        undefined="strict",
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "undefined"
+    assert "missing_var" in result["error"]
+
+
+def test_lenient_undefined_renders_empty_and_reports_meta(tmp_path):
+    """Tier 1: lenient → undefined renders empty (no crash) and the referenced-but-
+    unbound names surface in undefined_vars for self-correction."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="Hello {{ data.name }}[{{ missing_var }}]",
+        data_inline={"name": "world"},
+        undefined="lenient",
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    # undefined rendered empty → the bracket is empty, the bound value present.
+    assert "Hello world[]" in result["rendered"]
+    assert "missing_var" in result["undefined_vars"]
+
+
+# ── Tier 1: SSTI containment (falsify) ───────────────────────────────────────
+
+
+def test_ssti_attribute_traversal_is_blocked(tmp_path):
+    """Tier 1: falsify — a template attempting an SSTI attribute-traversal escape
+    (`().__class__.__bases__`) is stopped by the SandboxedEnvironment — it does NOT
+    execute; the op returns a structured security error and the class object never
+    reaches the output."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="{{ ().__class__.__bases__[0].__subclasses__() }}",
+        data_inline={},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "security"
+    # Falsify: the escape did not succeed — no rendered string of subclasses.
+    assert "rendered" not in result
+
+
+# ── Tier 1: resource bounds (falsify) ────────────────────────────────────────
+
+
+def test_output_size_cap_truncates_during_generate(tmp_path):
+    """Tier 1: falsify — a template that would generate huge output is capped DURING
+    generate — the result is truncated + flagged in meta, NOT an OOM/hang. The size
+    guard fires and the output is bounded by the injected budget."""
+    bounds = RenderTemplateBounds(max_output_chars=50, wall_clock_seconds=100.0)
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path), bounds=bounds)
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="{% for i in range(100000) %}X{% endfor %}",
+        data_inline={},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    assert result["truncated"] is True
+    assert result["truncate_reason"] == "max_output_chars"
+    # Bounded by the injected budget (compared to the budget var, not a format pin).
+    assert len(result["rendered"]) <= bounds.max_output_chars
+    # It is the runaway loop's output, cut short — nothing but the loop body char.
+    assert set(result["rendered"]) <= {"X"}
+
+
+def test_wall_clock_backstop_fires(tmp_path):
+    """Tier 1: falsify — the wall-clock backstop bounds a generator independently of
+    size — with a zero- /negative-time budget it truncates on the first streamed chunk
+    (deterministic: any elapsed time exceeds it), flagging the wall-clock reason."""
+    bounds = RenderTemplateBounds(max_output_chars=10_000_000, wall_clock_seconds=-1.0)
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path), bounds=bounds)
+    op = RenderTemplateIROp(
+        kind="render_template",
+        template="{% for i in range(100000) %}line{{ i }}\n{% endfor %}",
+        data_inline={},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    assert result["truncated"] is True
+    assert result["truncate_reason"] == "wall_clock_seconds"
+
+
+def test_small_render_is_not_truncated(tmp_path):
+    """Tier 1: falsify direction — a small render under the default bounds is NOT
+    flagged truncated — so the cap tests above are not a blanket 'always truncated'."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template", template="{{ data.x }}", data_inline={"x": "small"},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    assert result["truncated"] is False
+    assert "truncate_reason" not in result
+
+
+# ── Tier 1: template syntax error ────────────────────────────────────────────
+
+
+def test_template_syntax_error_is_hard_error(tmp_path):
+    """Tier 1: a malformed template is a hard error (never masked as a blank render)."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    op = RenderTemplateIROp(
+        kind="render_template", template="{% for x in %}", data_inline={},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "error"
+    assert result["error_kind"] == "template_error"
+
+
+# ── Tier 1: read-authority equivalence (denied ⇔ file.read denied) ───────────
+
+
+def test_template_ref_denied_iff_file_read_denied(tmp_path, monkeypatch):
+    """Tier 1: a template_ref read gate is identical to file.read — a config
+    file.read:deny denies BOTH. Real resolver (not None); falsify (allow) below."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tpl.j2").write_text("{{ data.x }}")
+    (tmp_path / "data.json").write_text(json.dumps({"x": 1}))
+    deny = _resolver(tmp_path, {"file": {"read": "deny"}})
+    ctx, _events = _ctx(tmp_path, deny)
+    op = RenderTemplateIROp(
+        kind="render_template", template_ref="tpl.j2", data_inline={"x": 1},
+    )
+    result = _run(execute_op(op, ctx))
+    assert result["status"] == "denied"
+    # file.read denied on the same path (equivalence).
+    with pytest.raises(PermissionError):
+        _run(deny.require_file_read(PermissionDecl(), str(tmp_path / "tpl.j2"), "t"))
+
+
+def test_data_ref_denied_iff_file_read_denied(tmp_path, monkeypatch):
+    """Tier 1: a data_ref read gate is identical to file.read (same equivalence as the
+    template_ref path — both route through the one gate seam)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data.json").write_text(json.dumps({"x": 1}))
+    deny = _resolver(tmp_path, {"file": {"read": "deny"}})
+    ctx, _events = _ctx(tmp_path, deny)
+    op = RenderTemplateIROp(
+        kind="render_template", template="{{ data.x }}", data_ref="data.json",
+    )
+    result = _run(execute_op(op, ctx))
+    assert result["status"] == "denied"
+
+
+def test_refs_allowed_when_file_read_allowed(tmp_path, monkeypatch):
+    """Tier 1: falsify direction — with read allowed (default CWD zone) the same
+    template_ref + data_ref render ok — so the denials above are not a blanket refusal."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tpl.j2").write_text("value={{ data.x }}")
+    (tmp_path / "data.json").write_text(json.dumps({"x": 42}))
+    allow = _resolver(tmp_path)
+    ctx, _events = _ctx(tmp_path, allow)
+    op = RenderTemplateIROp(
+        kind="render_template", template_ref="tpl.j2", data_ref="data.json",
+    )
+    result = _run(execute_op(op, ctx))
+    assert result["status"] == "ok"
+    assert "value=42" in result["rendered"]
+
+
+# ── Tier 1: render_template's own canonical mapper (guards the FP-0056 gap) ───
+
+
+def test_canonical_mapper_rendered_string_becomes_text():
+    """Tier 1: the op's own result → canonical `text` (the rendered string), NOT a
+    whole-dict `structured` attachment. Guards against re-introducing the FP-0056
+    whole-dict fallback for this new producer kind."""
+    result = {
+        "kind": "render_template", "status": "ok", "ok": True,
+        "rendered": "the rendered body", "truncated": False,
+    }
+    canonical = to_canonical(result)
+    assert canonical["text"] == "the rendered body"
+    # NOT the fallback: no structured attachment carrying the whole dict.
+    assert canonical.get("attachments") == []
+
+
+def test_canonical_mapper_surfaces_truncated_and_undefined_meta():
+    """Tier 1: truncated + undefined_vars are carried as signal meta (the LLM's
+    self-correction channel), and an error result surfaces its message with isError."""
+    truncated = to_canonical({
+        "kind": "render_template", "status": "ok", "ok": True,
+        "rendered": "XXX", "truncated": True, "truncate_reason": "max_output_chars",
+        "undefined_vars": ["missing_var"],
+    })
+    assert truncated["meta"]["truncated"] is True
+    assert truncated["meta"]["truncate_reason"] == "max_output_chars"
+    assert "missing_var" in truncated["meta"]["undefined_vars"]
+
+    errored = to_canonical({
+        "kind": "render_template", "status": "error", "ok": False,
+        "error_kind": "undefined", "error": "'missing_var' is undefined",
+    })
+    assert errored["meta"]["isError"] is True
+    assert "missing_var" in errored["text"]
+
+
+# ── Tier 1: producer-neutrality (raw output, no producer-side escaping) ──────
+
+
+def test_producer_returns_raw_unneutralized_output(tmp_path):
+    """Tier 1: the producer returns RAW rendered bytes — a control/ESC sequence in the
+    data survives in the result (neutralization is the SINK's job, not the producer's).
+    Falsify against producer-side stripping."""
+    ctx, _events = _ctx(tmp_path, _resolver(tmp_path))
+    esc = "\x1b[31mred\x1b[0m"
+    op = RenderTemplateIROp(
+        kind="render_template", template="{{ data.msg }}", data_inline={"msg": esc},
+    )
+    result = _run(handle(op, ctx))
+    assert result["status"] == "ok"
+    # Raw ESC bytes retained — the producer did not strip/escape them.
+    assert "\x1b[31m" in result["rendered"]


### PR DESCRIPTION
**[per-pr-coder]** — **PR-2 of the FP-0055 arc** (design doc: `docs/deep-dives/proposals/0055-render-template-op-and-present-defaults.md`, PR #2673). `part of #2673` — the arc doc gets its IMPLEMENTED stamp separately. Builds on PR-0 (`make_sandboxed_env`) and PR-1 (present `view` rename freeing the `template` name).

## What

A standalone `render_template` op: a general **sandboxed producer** — `data + Jinja2 template → string`. It has **no side effects and invokes no sink**; the rendered string is returned as an ordinary op result whose bulk auto-offloads on the chat path, and the caller routes it to any sink (`present` / `write_file` / message / pipeline `ctx`).

### Contract
- **Template source** (exactly one): `template` (inline Jinja2) XOR `template_ref` (file path, read as raw text).
- **Data source** (exactly one): `data_ref` (re-hydrated to full value) XOR `data_inline`. Binds under `data` in the template context.
- **`undefined`**: `strict` (default; hard error naming the missing var) | `lenient` (renders empty + `undefined_vars` meta).

### Sandbox + streaming cap
- Engine is always `jinja2.sandbox.SandboxedEnvironment` via `make_sandboxed_env` (PR-0); **autoescape OFF** (producer returns RAW bytes — neutralization is the sink's job).
- **Resource cap applied DURING generation**: renders via `template.generate(context)` (streaming, **not** `.render()`), accumulating against a max-output-chars budget with a **wall-clock backstop**. A cap hit → truncated result + `truncated`/`truncate_reason` meta (never OOM/hang). Bounds default to safety-spirit constants (`RenderTemplateBounds`), overridable via `OpContext.render_template_bounds`.
- SSTI attribute-traversal (`{{ ().__class__... }}`) → blocked by the sandbox → structured `security` error, nothing executed.

### Read-authority equivalence
`template_ref` / `data_ref` resolve through **exactly the `file.read` gate** — extracted `_gate_and_read_ref` in `present/source.py`, shared by `resolve_present_source` (unchanged behavior) and the new `resolve_ref_text` (raw text, no JSON rehydration). Denied read → `status="denied"`. Inline-only is pure computation (no gate).

### Feedback-chokepoint mapper (FP-0056 discipline)
`render_template` is a NEW op kind whose result reaches the offload chokepoint, so it has **its own `_MAPPERS` entry** in `offload/canonical.py` (rendered string → `text`; `truncated`/`undefined_vars` as signal meta) — it does NOT fall into the whole-dict fallback.

### #1983 same-PR sync
`OP_KIND_MODEL_MAP` (`schemas/models.py`) + a `render_template` section in `docs/reference/runtime/control-ir.md` both added here.

## Judgment calls (flagged for reviewer)
1. **Truncation = result+meta, not hard-error.** The dispatch brief says a cap hit → "a truncated result flagged in meta (not a crash)"; the design doc's prose says "hard error naming the cap." I followed the brief — and the doc's own canonical-mapper requirement (`truncated`/`undefined_vars` **in meta**) only makes sense if a result is returned, so the two doc requirements are internally consistent under result+meta.
2. **Inline-template arg named `template`** (per the brief + naming-partition rationale: the name is free now that present renamed to `view`). The doc's contract YAML block shows `template_inline`; I used `template` as the brief specifies. Data pair is `data_ref`/`data_inline` (both sources agree).
3. **No chat `ToolDefinition`.** The sibling op `present` exposes no universal-catalog `ToolDefinition` either — it dispatches via `execute_op` through the `Op` union. `render_template` mirrors that exactly (in the union + registered handler = wired to the same production dispatch path as present). The doc's "prefer present" steering lives in the control-ir.md section, matching present's treatment. No `available_control_ops` runtime producer exists to add a per-op description to.
4. **Operator-config tunability of bounds is a follow-up.** Bounds are overridable at the `OpContext` seam (used by tests) with safety-spirit defaults applied when `None` (= production today). Full yaml config-schema + loader + ctx-builder threading is a separate reviewable change; flagged, not silently dropped.

## Test plan
All Tier 1 / OS-invariant, real Workspace + PermissionResolver + EventLog (no mocks):
- [x] Render happy path (inline + `data_ref` full-value binding)
- [x] strict-undefined → error naming the var; lenient → renders empty + `undefined_vars` meta
- [x] SSTI blocked (falsify): `().__class__.__bases__...` → `security` error, no output
- [x] Output size cap (falsify): runaway loop capped during-generate → truncated + meta; + a not-truncated falsify direction
- [x] Wall-clock backstop fires (falsify): negative-time budget → truncated `wall_clock_seconds`
- [x] Template syntax error → `template_error`
- [x] Read-authority: `template_ref` + `data_ref` denied ⇔ `file.read` denied; allow direction renders
- [x] Canonical mapper: result → `text` (not whole-dict `structured`); truncated/undefined_vars/error → meta
- [x] Producer-neutrality: raw ESC bytes survive in the result (no producer-side stripping)

## Gates (all 4, local, green)
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_render_template_op_fp0055_pr2.py` — 15/15 OK, 0 violations
- [x] `pytest` — 7659 passed; the only 5 failures are the pre-existing route-mount/plugin-loader flakes (confirmed identical on the clean baseline via `git stash`, none touch changed files)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK