### PR TITLE
feat: canonical_fallback_used audit event — visible whole-dict fallback (FP-0056 PR-F2)

### DIFF
--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -130,6 +130,14 @@ Events emitted by the task Control IR ops (`task.py`).
 | `workspace_updated` | Any artifact is written |
 | `tool_executed` | Generic tool dispatch |
 
+## Tool-result canonicalization
+
+Every tool/op result is normalized to one canonical shape before it reaches the LLM. A producer with a real mapper is shaped cleanly; one that has no mapper (declared debt, or a genuinely unregistered source) takes a lossless whole-dict fallback instead — and that fallback is made visible here rather than silent, so unmapped-producer debt is one `grep` away.
+
+| Kind | When | Key payload |
+|------|------|-------------|
+| `canonical_fallback_used` | A tool/op result took the whole-dict canonical fallback: a producer with declared-but-unwritten mapper debt, a genuinely unregistered / unknown source, or a passthrough producer whose whole-dict blob exceeded the structured offload gate. | `source` — the invoked producer id (op kind / tool name; `null` for a genuine unknown); `reason` — `unregistered` \| `canonical_todo` \| `passthrough_oversized`. Carries the source identity only — never the result body. |
+
 ## Memory
 
 | Kind | When | Key payload |

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -601,6 +601,45 @@ def to_canonical(result: dict, *, source: "str | None" = None) -> CanonicalToolR
     return declaration(result)
 
 
+# The audit-event kind the two live ``to_canonical`` callers emit when a result took a VISIBLE
+# fallback path — the observability half of FP-0056 (the static coverage gate is PR-F1; this makes
+# the runtime debt + genuine-unknown fallbacks visible instead of silent). It is an audit / P6 event,
+# NOT a WAL / recovery-core event.
+CANONICAL_FALLBACK_EVENT = "canonical_fallback_used"
+
+
+def canonical_fallback_reason(
+    source: "str | None", *, structured_offloaded: bool = False
+) -> "str | None":
+    """Return the audit reason a :data:`CANONICAL_FALLBACK_EVENT` should carry for ``source``'s
+    canonicalization, or ``None`` when nothing should fire (FP-0056 PR-F2 — the visibility half).
+
+    A short category string is returned on each of the three fail-visible paths (owner decisions #2/#3
+    — degrade-with-audit, never silently):
+
+    - ``source`` unregistered / ``None`` (a genuine unknown the registries can't enumerate → the
+      lossless whole-dict fallback) → ``"unregistered"``.
+    - ``source`` declared :data:`CANONICAL_TODO` (gate-satisfying debt, no real mapper yet → the same
+      whole-dict fallback) → ``"canonical_todo"``. This is the #2681 burn-down debt made runtime-visible.
+    - ``source`` declared :data:`STRUCTURED_PASSTHROUGH` whose whole-dict serialization exceeded the
+      structured offload gate (caller passes ``structured_offloaded=True``) → ``"passthrough_oversized"``
+      (owner decision #2: an oversized passthrough blob signals passthrough was the wrong choice for
+      this producer — make it visible). A SMALL (inline) passthrough is a reviewed, legitimate view →
+      ``None`` (no event).
+
+    A real mapper always returns ``None`` — a mapped producer never took a fallback. Only a reason
+    CATEGORY is returned; NO result content is ever returned or logged (audit signal, not data — the
+    callers emit the ``source`` id + this reason, never the result body)."""
+    declaration = canonical_declaration(source)
+    if declaration is None:
+        return "unregistered"
+    if declaration is CANONICAL_TODO:
+        return "canonical_todo"
+    if declaration is STRUCTURED_PASSTHROUGH and structured_offloaded:
+        return "passthrough_oversized"
+    return None
+
+
 _CANONICAL_SOURCE_KEY = "_canonical_source"
 
 

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -109,6 +109,8 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
 from reyn.core.offload.canonical import (
+    CANONICAL_FALLBACK_EVENT,
+    canonical_fallback_reason,
     canonical_to_ctx_fields,
     extract_canonical_source,
     to_canonical,
@@ -773,6 +775,16 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
     if isinstance(result, dict):
         canonical = to_canonical(unwrap_dispatch_envelope(result), source=canonical_source)
         ctx_result: Any = canonical_to_ctx_fields(canonical)
+        # FP-0056 PR-F2: a VISIBLE fallback (a #2681 CANONICAL_TODO producer, or a
+        # genuinely-unregistered tool) emits a P6 audit event naming the source — degrade-with-audit,
+        # never silently. The passthrough-oversized case (owner decision #2) can't arise here: the
+        # pipeline ctx path is NEVER offloaded/size-gated (full-value retention), so it is not probed.
+        # Source id only; NEVER the result body.
+        _fallback_reason = canonical_fallback_reason(canonical_source)
+        if _fallback_reason is not None and inv.deps.events is not None:
+            inv.deps.events.emit(
+                CANONICAL_FALLBACK_EVENT, source=canonical_source, reason=_fallback_reason,
+            )
     elif isinstance(result, str):
         ctx_result = {"text": result}
     else:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2956,6 +2956,8 @@ class RouterLoop:
         # ``structured`` attachment. The format is INDEPENDENT of the media store — it applies even
         # when ``media_store is None``; only the size-gated offloading needs a store.
         from reyn.core.offload.canonical import (
+            CANONICAL_FALLBACK_EVENT,
+            canonical_fallback_reason,
             extract_canonical_source,
             to_canonical,
             unwrap_dispatch_envelope,
@@ -3023,6 +3025,23 @@ class RouterLoop:
                             canonical, save_fn=_save_fn,
                             enabled=getattr(host, "offload_enabled", True),
                         )
+                        # FP-0056 PR-F2: a VISIBLE fallback (a #2681 CANONICAL_TODO producer, a
+                        # genuinely-unregistered source, or a STRUCTURED_PASSTHROUGH whose whole-dict
+                        # blob exceeded the offload gate) emits a P6 audit event naming the source —
+                        # degrade-with-audit, never silently (the dogfood incident was one silent
+                        # fallback). Source id only; NEVER the result body.
+                        _fallback_reason = canonical_fallback_reason(
+                            canonical_source,
+                            structured_offloaded=frontmatter.get("structured") == "offloaded",
+                        )
+                        if _fallback_reason is not None:
+                            _events = getattr(host, "events", None)
+                            if _events is not None:
+                                _events.emit(
+                                    CANONICAL_FALLBACK_EVENT,
+                                    source=canonical_source,
+                                    reason=_fallback_reason,
+                                )
                         if built_media:
                             # media lifted from INSIDE data (the top-level strip missed it)
                             media_blocks.extend(built_media)

--- a/tests/test_fp0056_canonical_fallback_event.py
+++ b/tests/test_fp0056_canonical_fallback_event.py
@@ -1,0 +1,130 @@
+"""Tier 1/2: the ``canonical_fallback_used`` audit event (FP-0056 PR-F2).
+
+PR-F1 made canonical coverage a *static* CI gate; PR-F2 makes the runtime fallback *visible* instead of
+silent — the observability half of the same contract. When a tool/op result takes the whole-dict
+canonical fallback (a #2681 ``CANONICAL_TODO`` producer, a genuinely-unregistered source, or a
+``STRUCTURED_PASSTHROUGH`` producer whose whole-dict blob overflows the offload gate), the live
+``to_canonical`` callers emit a P6 audit event naming the source. Degrade-with-audit, never silently:
+the 2026-07-09 dogfood incident (a doc read offloaded as a whole-dict blob) would have been one
+trace-grep instead of a human noticing the agent "being confused".
+
+The event is an AUDIT / P6 event — NOT a WAL / recovery-core event (no truncate-falsify obligation).
+
+Covered here with real instances (no mocks — a real ``PipelineExecutor``, a real ``EventLog``, the real
+registration seams):
+
+- Tier 1: :func:`canonical_fallback_reason` maps each of the three fire-conditions to its reason
+  category, and returns ``None`` for a real mapper and for a small (inline) passthrough.
+- Tier 2: the pipeline tool-step chokepoint EMITS ``canonical_fallback_used`` carrying the source id on
+  the fallback path, and NO result content bytes appear in any event payload.
+- Tier 2 falsify: a producer WITH a real mapper (``sandboxed_exec``) does NOT emit the event.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Importing the op-runtime package eagerly registers every op handler + its canonical declaration, and
+# building the default tool registry declares every ToolDefinition's — so the declarations the
+# classifier resolves against are populated (identically to the coverage-gate test's setup).
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import (
+    CANONICAL_FALLBACK_EVENT,
+    canonical_fallback_reason,
+)
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.tools import get_default_registry
+
+get_default_registry()
+
+
+# A grandfathered ``CANONICAL_TODO`` producer (issue #2681 burn-down ledger). Used only to confirm the
+# classifier reports the ``canonical_todo`` reason for a real declared-debt producer; if this one is
+# later burned down to a real mapper it simply leaves the set — swap in any other ledger member.
+_A_CANONICAL_TODO_PRODUCER = "agent_spawn"
+# An admin/install producer declared STRUCTURED_PASSTHROUGH (owner decision #1 family).
+_A_PASSTHROUGH_PRODUCER = "mcp_install"
+# A producer with a REAL mapper — the falsify control.
+_A_MAPPED_PRODUCER = "sandboxed_exec"
+
+
+def test_fallback_reason_maps_each_fire_condition_to_its_category() -> None:
+    """Tier 1: the three fail-visible fire-conditions each yield their reason category, and a real
+    mapper / a small passthrough yield ``None`` (no event) — the classifier the two chokepoints share."""
+    # 1. genuinely unregistered / unknown source (+ None) → the lossless whole-dict fallback.
+    assert canonical_fallback_reason("a_totally_unregistered_producer") == "unregistered"
+    assert canonical_fallback_reason(None) == "unregistered"
+    # 2. a declared-but-unmapped CANONICAL_TODO producer (the #2681 debt) → visible.
+    assert canonical_fallback_reason(_A_CANONICAL_TODO_PRODUCER) == "canonical_todo"
+    # 3. a STRUCTURED_PASSTHROUGH producer whose whole-dict blob overflowed the offload gate.
+    assert (
+        canonical_fallback_reason(_A_PASSTHROUGH_PRODUCER, structured_offloaded=True)
+        == "passthrough_oversized"
+    )
+    # A SMALL (inline) passthrough is the reviewed, legitimate whole-dict view → no event.
+    assert canonical_fallback_reason(_A_PASSTHROUGH_PRODUCER, structured_offloaded=False) is None
+    # A producer with a real mapper never took a fallback → no event (even if oversized somewhere).
+    assert canonical_fallback_reason(_A_MAPPED_PRODUCER) is None
+    assert canonical_fallback_reason(_A_MAPPED_PRODUCER, structured_offloaded=True) is None
+
+
+@pytest.mark.asyncio
+async def test_unregistered_fallback_emits_event_with_source_id_and_no_body() -> None:
+    """Tier 2: a pipeline tool step whose result took the whole-dict fallback (an unregistered source)
+    emits ``canonical_fallback_used`` naming the source — and NO result content bytes leak into any
+    event payload (audit signal, not data)."""
+    secret_body = "SECRET-DOCUMENT-BODY-should-never-reach-an-audit-event"
+
+    def _dispatch(name: str, args: dict) -> dict:
+        # A kind-bearing but UNREGISTERED producer, tagged with its invoked identity — the genuine-
+        # unknown fallback class. The body carries a distinctive string we assert never leaks.
+        return {
+            "kind": "mystery_kind",
+            "content": secret_body,
+            "_canonical_source": "an_unregistered_producer_id",
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="mystery_tool", args={}, output="r")])
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-f2-fallback", events=events,
+    )
+
+    # Exactly one fallback event for the one unregistered tool step (unpack asserts the count).
+    [fallback_event] = [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT]
+    payload = fallback_event.data
+    assert payload["source"] == "an_unregistered_producer_id"
+    assert payload["reason"] == "unregistered"
+
+    # No result content bytes in ANY event payload — the event carries the source identity only.
+    all_payloads = json.dumps([e.data for e in events.all()])
+    assert secret_body not in all_payloads
+    assert "content" not in payload  # the raw result field name is not forwarded either
+
+
+@pytest.mark.asyncio
+async def test_real_mapper_producer_does_not_emit_fallback_event() -> None:
+    """Tier 2: FALSIFY — a producer WITH a real canonical mapper (``sandboxed_exec``) is shaped cleanly —
+    it never took a fallback, so NO ``canonical_fallback_used`` event fires."""
+
+    def _dispatch(name: str, args: dict) -> dict:
+        return {
+            "kind": "sandboxed_exec",
+            "stdout": "clean output",
+            "returncode": 0,
+            "_canonical_source": _A_MAPPED_PRODUCER,
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="run_shell", args={}, output="r")])
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-f2-mapped", events=events,
+    )
+
+    assert not [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT], (
+        "a mapped producer must not emit the fallback audit event"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — FP-0056 PR-F2: the `canonical_fallback_used` audit event. The observability follow-up to PR-F1's static coverage gate — makes the runtime whole-dict fallback (the #2681 `CANONICAL_TODO` burn-down debt, and any genuinely-unknown source) **visible** instead of silent. Degrade-with-audit: the 2026-07-09 dogfood incident (a doc read offloaded as a whole-dict blob) would have been one trace-grep instead of a human noticing the agent "being confused". `part of #2675` (arc umbrella); the burn-down tracker is #2681.

Audit / P6 event — **NOT** a WAL / recovery-core event (no truncate-falsify obligation).

## Emit seam (the one real design nuance) — and why

`to_canonical(result, *, source)` stays a **pure, event-free function**. Instead of plumbing a raw emit callback into it, I added a pure classifier `canonical_fallback_reason(source, *, structured_offloaded)` that returns the reason category (or `None`), and had the **two live caller chokepoints emit** — both already have event access:

- **chat feedback chokepoint** — `router_loop.py::SchemeOps.feedback` (`host.events.emit`), after `build_offload_body` (so the passthrough-oversized signal `frontmatter["structured"] == "offloaded"` is known).
- **pipeline tool step** — `executor.py::_run_tool_step` (`inv.deps.events.emit`).

Rationale: the return-signal keeps the pure function pure and the payload clean (the reason must NOT go in `meta`, which is LLM-visible frontmatter). The classifier mirrors `to_canonical`'s own identity dispatch, so there's no second source-of-truth for "which sources fall back". No seam ambiguity was hit — the two callers were the only live `to_canonical` invokers (the other two references are docstrings).

## Three fire-conditions (owner decisions #2 / #3 in 0056)

| Condition | reason | Where |
|---|---|---|
| unregistered / `None` source (genuine unknown) | `unregistered` | both chokepoints |
| `CANONICAL_TODO` producer (declared #2681 debt) | `canonical_todo` | both chokepoints |
| `STRUCTURED_PASSTHROUGH` whose whole-dict blob **exceeds the structured offload gate** | `passthrough_oversized` | **chat chokepoint only** — the pipeline ctx path is never offload/size-gated (full-value retention, owner ruling), so the oversized case cannot arise there and is deliberately not probed |

**Payload = the source id + reason category ONLY** — never the result body (audit signal, not data).

## Docs

`docs/reference/runtime/events.md` (the full event taxonomy the concepts doc points to) gains a "Tool-result canonicalization" section documenting `canonical_fallback_used`. No history refs in the prose.

## Test plan (per testing.ja.md)

- [x] **Tier 2** — pipeline tool-step fallback path emits `canonical_fallback_used` carrying the source id; distinctive result-body string asserted absent from every event payload (no content bytes). Real `PipelineExecutor` + real `EventLog`, no mocks.
- [x] **Tier 2 FALSIFY** — a producer WITH a real mapper (`sandboxed_exec`) does NOT emit the event.
- [x] **Tier 1** — `canonical_fallback_reason` maps each of the three fire-conditions to its category and returns `None` for a real mapper and for a small (inline) passthrough (covers `passthrough_oversized`, the chat-only case, at the classifier contract level).
- [x] No Tier-4 pins (presence/absence + substrings; count asserted by unpack `[event] = ...`, not `len(...) == N`).

## 4 CI gates (run locally to completion)

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0056_canonical_fallback_event.py` — 3 OK, 0 errors
- [x] `pytest` — my 3 new tests pass; full suite **7783 passed, 5 failed**. The 5 failures (`tests/web/*` route-mounting + `test_fp0001_a2a_endpoints`) are **pre-existing on the clean base** (verified by stashing my changes and re-running: same 5 fail) and touch none of my files.
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
