### PR TITLE
fix: reyn pipe run bootstraps LiteLLM proxy via load_config chokepoint (#2682)

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -473,6 +473,24 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         if _ap is True or (isinstance(_ap, str) and _ap.strip().lower() in ("1", "true", "yes", "on")):
             _os_for_mcp.environ["REYN_FETCH_ALLOW_PRIVATE_IPS"] = "1"
 
+    # #2682: propagate ``api_base`` into the ``LITELLM_API_BASE`` env var — the
+    # single switch litellm reads (``reyn.llm.llm.proxy_kwargs`` / the embedding
+    # ``_proxy_kwargs`` mirror) to route a request to the LiteLLM proxy instead
+    # of the real upstream endpoint. ``load_config()`` is the one universal
+    # chokepoint EVERY LLM entry point passes before its first LLM call
+    # (``reyn pipe run`` / dogfood / embeddings call it directly; chat/run/mcp
+    # reach it via ``InvocationContext.from_args``; web via ``_get_registry``),
+    # so folding the export here closes the whole class at once — including the
+    # embeddings path the per-entry inline copies never covered. Mirrors the
+    # REYN_* exports above: explicit operator-set env var wins (idempotent
+    # ``setdefault``); an absent/empty ``api_base`` is a no-op. The pre-existing
+    # inline copies (``invocation_context.py`` / ``web/deps.py``) are now
+    # redundant but harmless (same ``setdefault`` value); their removal + a
+    # single-writer AST/CI guard is #2683.
+    _api_base = str(merged.get("api_base") or "")
+    if _api_base:
+        _os_for_mcp.environ.setdefault("LITELLM_API_BASE", _api_base)
+
     raw_ol = merged.get("output_language")
     output_language: str | None
     if isinstance(raw_ol, str) and raw_ol.strip():

--- a/tests/test_config_schema_enforcement_1056.py
+++ b/tests/test_config_schema_enforcement_1056.py
@@ -132,6 +132,13 @@ def test_every_scalar_leaf_takes_effect_on_nondefault_set(tmp_path: Path) -> Non
     noops: list[str] = []
     checked = 0
     old_cwd = os.getcwd()
+    # load_config() materializes some config keys into process env
+    # (LITELLM_API_BASE from api_base, REYN_MCP_REGISTRY_URLS, REYN_FETCH_
+    # ALLOW_PRIVATE_IPS). This test loads a synthetic config per leaf — snapshot
+    # + restore os.environ so those exports don't leak across the loop OR past
+    # this test into the rest of the suite (the same per-field isolation the
+    # per-leaf project root already gives on disk).
+    old_environ = dict(os.environ)
     try:
         for i, node in enumerate(nodes):
             if node.default is MISSING:
@@ -157,6 +164,8 @@ def test_every_scalar_leaf_takes_effect_on_nondefault_set(tmp_path: Path) -> Non
                 noops.append(f"{node.key}: set {cand!r} → reload {got!r} (set ignored)")
     finally:
         os.chdir(old_cwd)
+        os.environ.clear()
+        os.environ.update(old_environ)
 
     assert checked > 0, "no scalar leaf exercised — candidate generator returned None for all"
     assert not noops, (

--- a/tests/test_pipe_proxy_bootstrap_2682.py
+++ b/tests/test_pipe_proxy_bootstrap_2682.py
@@ -1,0 +1,128 @@
+"""Tier 2: #2682 — load_config() bootstraps the LiteLLM proxy switch.
+
+Root cause: the LiteLLM proxy switch env var ``LITELLM_API_BASE`` was exported
+only from ``InvocationContext.from_args`` (chat/run) and ``web/deps.py`` (web).
+``reyn pipe run`` reaches its ``AgentRegistry`` without building an
+``InvocationContext`` — so with a LiteLLM-proxy config (``api_base`` + pseudo
+``openai/<model>`` + only a proxy ``OPENAI_API_KEY``) the pseudo-model + proxy
+key were sent to the REAL upstream endpoint and rejected.
+
+The fix folds the export into ``load_config()`` itself — the one universal
+chokepoint every LLM entry point passes before its first LLM call (pipe /
+dogfood / embeddings direct; chat/run/mcp via ``InvocationContext``; web via
+``_get_registry``).
+
+No mocks: real ``load_config`` over a real on-disk ``reyn.yaml``. The autouse
+fixture handles LITELLM_API_BASE save/restore so the process env is never
+leaked into the rest of the suite.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reyn.config import load_config
+
+_PROXY = "http://localhost:4000"
+_PSEUDO_MODEL = "openai/gemini-2.5-flash-lite"
+
+
+@pytest.fixture(autouse=True)
+def _restore_litellm_api_base():
+    """Snapshot + restore LITELLM_API_BASE around every test in this file.
+
+    load_config() legitimately EXPORTS LITELLM_API_BASE process-wide (that IS
+    the fix under test), and ``monkeypatch.delenv(raising=False)`` records no
+    undo entry when the var starts absent — so the code-under-test's own set
+    would leak into the rest of the suite and perturb litellm-routing tests.
+    This fixture owns the real restore; the tests use monkeypatch only to set
+    up the pre-condition.
+    """
+    saved = os.environ.get("LITELLM_API_BASE")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("LITELLM_API_BASE", None)
+        else:
+            os.environ["LITELLM_API_BASE"] = saved
+
+
+def _write_project(root, *, api_base: str | None) -> None:
+    lines = ["model: standard", "models:", f"  standard: {_PSEUDO_MODEL}"]
+    if api_base is not None:
+        lines.insert(0, f"api_base: {api_base}")
+    (root / "reyn.yaml").write_text("\n".join(lines) + "\n")
+
+
+# ── the load_config() chokepoint (the pipe-run path passes here) ─────────────
+
+
+def test_load_config_exports_litellm_api_base(tmp_path, monkeypatch) -> None:
+    """Tier 2: load_config() with api_base exports LITELLM_API_BASE.
+
+    Every LLM entry point (incl. ``reyn pipe run``, which builds NO
+    InvocationContext) passes through load_config() before its first LLM call,
+    so this is the universal seam the proxy switch must be wired at.
+
+    LITELLM_API_BASE is manipulated via direct os.environ (the autouse fixture
+    owns restore); mixing monkeypatch.delenv with load_config()'s own set of
+    the same var confuses monkeypatch's undo bookkeeping.
+    """
+    os.environ.pop("LITELLM_API_BASE", None)
+    monkeypatch.chdir(tmp_path)
+    _write_project(tmp_path, api_base=_PROXY)
+
+    config = load_config()
+
+    assert config.api_base == _PROXY
+    assert os.environ.get("LITELLM_API_BASE") == _PROXY
+
+
+def test_load_config_no_api_base_leaves_env_unset(tmp_path, monkeypatch) -> None:
+    """Tier 2: falsify — no api_base → LITELLM_API_BASE stays unset (no-op)."""
+    os.environ.pop("LITELLM_API_BASE", None)
+    monkeypatch.chdir(tmp_path)
+    _write_project(tmp_path, api_base=None)
+
+    config = load_config()
+
+    assert config.api_base == ""
+    assert "LITELLM_API_BASE" not in os.environ
+
+
+def test_load_config_setdefault_does_not_clobber(tmp_path, monkeypatch) -> None:
+    """Tier 2: idempotent setdefault — a pre-existing value is preserved.
+
+    Explicit operator-set LITELLM_API_BASE wins over config (same principle as
+    the sibling REYN_* env exports load_config() already performs).
+    """
+    os.environ["LITELLM_API_BASE"] = "http://preset:9999"
+    monkeypatch.chdir(tmp_path)
+    _write_project(tmp_path, api_base=_PROXY)
+
+    load_config()
+
+    assert os.environ["LITELLM_API_BASE"] == "http://preset:9999"
+
+
+def test_load_config_export_does_not_leak_across_isolation(tmp_path, monkeypatch) -> None:
+    """Tier 2: the export is confined to the process env under test control.
+
+    Drives the api_base export, then (simulating the next isolated invocation)
+    clears the env and re-loads a NON-proxy config — the stale proxy value must
+    not survive. The autouse fixture owns the real restore; this asserts the
+    export has no hidden global stickiness beyond os.environ.
+    """
+    os.environ.pop("LITELLM_API_BASE", None)
+    monkeypatch.chdir(tmp_path)
+    _write_project(tmp_path, api_base=_PROXY)
+    load_config()
+    assert os.environ.get("LITELLM_API_BASE") == _PROXY
+
+    # Next isolated invocation: env cleared, non-proxy config → no re-export.
+    os.environ.pop("LITELLM_API_BASE", None)
+    _write_project(tmp_path, api_base=None)
+    load_config()
+    assert "LITELLM_API_BASE" not in os.environ


### PR DESCRIPTION
**[per-PR-coder]** — Fixes the `reyn pipe run` LiteLLM-proxy bootstrap gap. Minimal scope: proxy export folded into `load_config()`.

## Problem (#2682)
`reyn pipe run` reaches its `AgentRegistry` without building an `InvocationContext`, so it never exported `LITELLM_API_BASE`. With a LiteLLM-proxy config (`api_base: http://localhost:4000`, pseudo `openai/<model>` tiers, only a proxy `OPENAI_API_KEY`), litellm sent the pseudo-model + proxy key to the **real** upstream endpoint → rejected. `reyn chat` worked (exports via `InvocationContext.from_args`); `reyn pipe run` did not.

## Fix: fold the export into `load_config()`
`src/reyn/config/loader.py`, in the same config→env materialization block that already exports `REYN_MCP_REGISTRY_URLS` / `REYN_FETCH_ALLOW_PRIVATE_IPS`:
```python
_api_base = str(merged.get("api_base") or "")
if _api_base:
    _os_for_mcp.environ.setdefault("LITELLM_API_BASE", _api_base)
```
`load_config()` is the one universal chokepoint **every** LLM entry passes before its first LLM call (pipe/dogfood/embeddings direct; chat/run/mcp via `InvocationContext`; web via `_get_registry`), so this closes the whole class at once — including the embeddings `_proxy_kwargs` mirror a per-entry fix would miss. Idempotent `setdefault` (operator-set env wins); empty/absent `api_base` → no-op.

**Out of scope → #2683:** the pre-existing inline copies (`invocation_context.py`, `web/deps.py`) stay (redundant but harmless). Their removal + a single-writer AST/CI guard is #2683 (untouched here).

## Revision note (was RED on CI, now fixed)
The prior revision added an early `verify_credentials_or_exit` to `run_run`. That was a **regression**: a pipeline may have no LLM step (transform-only/tool-only), so a key-absent `SystemExit(1)` wrongly failed valid runs (7 `test_cli_pipe.py` failures under CI's keyless env — a `pytest-local ≠ CI` miss on my side) and preempted the pipeline-not-found error. **Fully reverted** (`pipe.py` cred block + the extracted `verify_model_credentials_or_exit` in `credentials_check.py` + its tests). `run_run` does no cred pre-check. Fail-fast cred UX gated on a real LLM/agent step (post-resolution) is a separate follow-up.

## run_run scope preserved
`run_run` builds NO `InvocationContext` (unchanged); standalone `PipelineExecutor().run(...)` + `ToolContext`/`AgentRegistry` path and fail-closed permission posture unchanged.

## Test-isolation note
`load_config()` now mutates process env by design, which surfaced a pre-existing gap: `test_config_schema_enforcement_1056` drives `load_config()` over every config leaf (incl. `api_base`) without restoring env → snapshot/restore `os.environ` around its loop (companion to its existing cwd restore).

## Final change set (3 files)
- `src/reyn/config/loader.py` — the fold.
- `tests/test_config_schema_enforcement_1056.py` — env snapshot/restore.
- `tests/test_pipe_proxy_bootstrap_2682.py` — new: load_config export (Tier 2) + falsify + idempotent setdefault + no-leak isolation.

## Test plan (all gates run with `OPENAI_API_KEY` UNSET — CI parity)
- [x] `pytest tests/test_cli_pipe.py` (keys unset) — 20 passed (the 7 CI failures resolved).
- [x] Tier 2: `load_config()` with `api_base` sets `LITELLM_API_BASE`; falsify (no api_base → unset); idempotent setdefault; no cross-invocation leak.
- [x] `ruff check src tests` — clean.
- [x] `test_tier_audit.py --strict` (both changed test files) — 0 errors.
- [x] `pytest` full suite (keys unset) — **7787 passed, 5 pre-existing baseline failures** (FastMCP web-route-mounting; verified identical on pristine origin/main). No cred-related failures.
- [x] `verify_module_docstrings.py src/reyn/config/loader.py` — OK.

Closes #2682
