### PR TITLE
refactor: consolidate LITELLM_API_BASE to load_config single writer + AST guard (#2683)

### DIFF
--- a/src/reyn/interfaces/cli/invocation_context.py
+++ b/src/reyn/interfaces/cli/invocation_context.py
@@ -8,7 +8,6 @@ load/merge logic.
 from __future__ import annotations
 
 import argparse
-import os
 from dataclasses import dataclass
 
 from reyn.config import ReynConfig, SafetyConfig, load_config
@@ -22,9 +21,11 @@ class InvocationContext:
 
     @classmethod
     def from_args(cls, args: argparse.Namespace) -> "InvocationContext":
+        # #2683: ``LITELLM_API_BASE`` export folded into ``load_config()`` — the
+        # single canonical writer (universal chokepoint). The former inline copy
+        # here was purely redundant (``load_config`` above already exported it via
+        # idempotent ``setdefault``); a single-writer AST guard now enforces this.
         config = load_config()
-        if config.api_base:
-            os.environ.setdefault("LITELLM_API_BASE", config.api_base)
         return cls(config=config, resolver=ModelResolver(
             config.models,
             default_class=config.model,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -269,9 +269,12 @@ def _get_registry():
         perm_resolver = _get_perm_resolver()
         project_context = load_project_context(config, root)
 
+        # #2683: ``LITELLM_API_BASE`` export folded into ``load_config()`` — the
+        # single canonical writer (universal chokepoint). ``_load_config()`` above
+        # (line ~265) already ran ``load_config()`` before any session/LLM call on
+        # the web path, so the former inline copy here was purely redundant
+        # (idempotent ``setdefault``). ``os`` stays imported: read below at :~296.
         import os
-        if config.api_base:
-            os.environ.setdefault("LITELLM_API_BASE", config.api_base)
 
         from reyn.llm.model_resolver import ModelResolver
         resolver = ModelResolver(

--- a/tests/test_litellm_api_base_load_config_seam_2683.py
+++ b/tests/test_litellm_api_base_load_config_seam_2683.py
@@ -1,0 +1,78 @@
+"""Tier 2: OS invariant — #2683 removal-safety regression for the proxy seam.
+
+#2683 deleted the inline ``LITELLM_API_BASE`` exports from
+``InvocationContext.from_args`` (chat/run/mcp-serve/chainlit) and
+``web/deps._get_registry`` on the basis that ``load_config()`` — which both call
+before their first LLM call — is now the single canonical writer. This test
+falsifies the "the removal silently re-broke proxy routing" failure mode: it
+drives the real ``InvocationContext.from_args`` seam (no mock) and asserts that a
+configured ``api_base`` still lands in ``LITELLM_API_BASE`` purely via the
+``load_config()`` fold.
+
+The web path (``_get_registry`` → ``_load_config`` → ``load_config``) shares the
+exact same seam and is covered transitively by the loader-level guarantee; a full
+web-registry build pulls in process-singleton state (budget/state-log/registry)
+that does not fit a focused Tier-2 seam test, so it is asserted here only at the
+shared ``load_config()`` level, not by standing up the FastAPI registry.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from reyn.interfaces.cli.invocation_context import InvocationContext
+
+_KEY = "LITELLM_API_BASE"
+
+
+@contextmanager
+def _clean_env_and_cwd(project_dir: Path):
+    """Save/restore ``LITELLM_API_BASE`` and cwd; enter with the key unset.
+
+    Env-mutation tests are isolation-sensitive: ``setdefault`` is a no-op when
+    the key is already present, so the seam can only be observed from a clean
+    slate. Everything is restored in ``finally`` so parallel workers and later
+    tests see the pre-test environment.
+    """
+    prev_val = os.environ.get(_KEY)
+    prev_cwd = os.getcwd()
+    os.environ.pop(_KEY, None)
+    os.chdir(project_dir)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
+        if prev_val is None:
+            os.environ.pop(_KEY, None)
+        else:
+            os.environ[_KEY] = prev_val
+
+
+def test_invocation_context_seam_still_exports_api_base() -> None:
+    """Tier 2: chat/run path sets LITELLM_API_BASE via the load_config fold."""
+    api_base = "http://localhost:4000/reyn-2683-seam"
+    with TemporaryDirectory() as td:
+        project = Path(td)
+        (project / "reyn.yaml").write_text(f"api_base: {api_base}\n", encoding="utf-8")
+        with _clean_env_and_cwd(project):
+            # Real seam, no mock: from_args → load_config() → the single writer.
+            ctx = InvocationContext.from_args(argparse.Namespace())
+            # Config carries the value AND the env var was materialized — proving
+            # the removed inline copy's job is now done by load_config().
+            assert ctx.config.api_base == api_base
+            assert os.environ.get(_KEY) == api_base
+
+
+def test_absent_api_base_leaves_env_unset() -> None:
+    """Tier 2: no api_base configured → the seam leaves LITELLM_API_BASE unset."""
+    with TemporaryDirectory() as td:
+        project = Path(td)
+        (project / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+        with _clean_env_and_cwd(project):
+            ctx = InvocationContext.from_args(argparse.Namespace())
+            assert not ctx.config.api_base
+            # The ``if _api_base`` guard means no empty/spurious export.
+            assert _KEY not in os.environ

--- a/tests/test_litellm_api_base_single_writer_ast_guard_2683.py
+++ b/tests/test_litellm_api_base_single_writer_ast_guard_2683.py
@@ -1,0 +1,187 @@
+"""Tier 2: OS invariant — #2683 single-writer AST guard for LITELLM_API_BASE.
+
+The ``LITELLM_API_BASE`` env var routes every LLM/embedding request to the
+LiteLLM proxy (readers: ``reyn.llm.llm.proxy_kwargs`` and the embedding
+``data/embedding/litellm_provider._proxy_kwargs`` mirror). #2682 established
+``config/loader.py::load_config`` as the *single canonical writer* because it is
+the one universal chokepoint every LLM entry passes before its first LLM call.
+#2683 removed the two redundant per-entry inline copies
+(``interfaces/cli/invocation_context.py`` + ``interfaces/web/deps.py``) and adds
+this guard so the "per-entry hand-wiring" class that caused #2682 cannot recur:
+a NEW ``environ["LITELLM_API_BASE"] = ...`` (or ``setdefault`` / ``update`` /
+``os.putenv``) anywhere else in ``src/reyn/`` fails here at PR time.
+
+The guard classifies by *operation*, not string presence: it flags only WRITE
+positions and leaves reads (``.get`` / ``in`` / subscript-read) alone. It matches
+on the attribute name ``environ`` being written (plus module-level ``putenv``) and
+resolves ``from os import environ [as Y]`` aliases, so the canonical write —
+authored through the ``import os as _os_for_mcp`` alias
+(``_os_for_mcp.environ.setdefault(...)``) — is correctly attributed to
+``loader.py`` regardless of the alias.
+
+Static residual (accepted, not a silent gap): a dynamic-key write
+(``environ[var] = ...`` where ``var`` is a runtime string) is not statically
+catchable — same limitation as the #1190 cost-chokepoint guard's dynamic
+dispatch. Every current write uses a string-literal key, so the static guard is
+complete for the present tree.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_KEY = "LITELLM_API_BASE"
+_CANONICAL_REL = "src/reyn/config/loader.py"
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _environ_alias_names(tree: ast.AST) -> set[str]:
+    """Names bound to ``os.environ`` via ``from os import environ [as Y]``.
+
+    ``import os as X`` needs no entry here: ``X.environ`` is an ``Attribute``
+    whose ``attr`` is ``environ``, which ``_is_environ_expr`` matches directly.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                if alias.name == "environ":
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _putenv_names(tree: ast.AST) -> set[str]:
+    """Names bound to ``os.putenv`` via ``from os import putenv [as Z]``."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                if alias.name == "putenv":
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def _is_environ_expr(node: ast.AST, alias_names: set[str]) -> bool:
+    """True if ``node`` refers to an ``os.environ`` mapping.
+
+    - ``ast.Attribute`` with ``attr == "environ"`` — covers ``os.environ``,
+      ``_os_for_mcp.environ`` (the canonical alias), any ``import os as X``.
+    - ``ast.Name`` bound by ``from os import environ [as Y]``.
+    """
+    if isinstance(node, ast.Attribute) and node.attr == "environ":
+        return True
+    return isinstance(node, ast.Name) and node.id in alias_names
+
+
+def _slice_is_key(sl: ast.AST) -> bool:
+    return isinstance(sl, ast.Constant) and sl.value == _KEY
+
+
+def _arg0_is_key(args: list[ast.expr]) -> bool:
+    return bool(args) and isinstance(args[0], ast.Constant) and args[0].value == _KEY
+
+
+def _dict_or_kwargs_has_key(call: ast.Call) -> bool:
+    """True if an ``environ.update(...)`` call sets the literal key.
+
+    Covers ``update({"LITELLM_API_BASE": ...})`` (dict literal) and
+    ``update(LITELLM_API_BASE=...)`` (keyword — the string is a valid identifier).
+    """
+    for a in call.args:
+        if isinstance(a, ast.Dict):
+            for k in a.keys:
+                if isinstance(k, ast.Constant) and k.value == _KEY:
+                    return True
+    for kw in call.keywords:
+        if kw.arg == _KEY:
+            return True
+    return False
+
+
+def _is_putenv_call(call: ast.Call, putenv_names: set[str]) -> bool:
+    """True for ``os.putenv("LITELLM_API_BASE", ...)`` / aliased ``putenv(...)``.
+
+    ``putenv`` writes the real environment bypassing ``os.environ`` — flag it
+    belt-and-suspenders even though no current site uses it.
+    """
+    func = call.func
+    is_putenv = (isinstance(func, ast.Attribute) and func.attr == "putenv") or (
+        isinstance(func, ast.Name) and func.id in putenv_names
+    )
+    return is_putenv and _arg0_is_key(call.args)
+
+
+def _write_sites(py: Path, root: Path) -> list[str]:
+    """Return ``rel:lineno`` for every LITELLM_API_BASE *write* in ``py``."""
+    tree = ast.parse(py.read_text(encoding="utf-8"))
+    alias_names = _environ_alias_names(tree)
+    putenv_names = _putenv_names(tree)
+    rel = py.resolve().relative_to(root).as_posix()
+    sites: list[str] = []
+
+    for node in ast.walk(tree):
+        # 1) subscript-assign: <environ>["LITELLM_API_BASE"] = / += / : T =
+        targets: list[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            targets = list(node.targets)
+        elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+            targets = [node.target]
+        for t in targets:
+            if (
+                isinstance(t, ast.Subscript)
+                and _is_environ_expr(t.value, alias_names)
+                and _slice_is_key(t.slice)
+            ):
+                sites.append(f"{rel}:{node.lineno}")
+
+        # 2) mutating method call on environ: setdefault / pop / update
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            fn = node.func
+            if _is_environ_expr(fn.value, alias_names):
+                if fn.attr in ("setdefault", "pop") and _arg0_is_key(node.args):
+                    sites.append(f"{rel}:{node.lineno}")
+                elif fn.attr == "update" and _dict_or_kwargs_has_key(node):
+                    sites.append(f"{rel}:{node.lineno}")
+
+        # 3) module-level putenv with the literal key
+        if isinstance(node, ast.Call) and _is_putenv_call(node, putenv_names):
+            sites.append(f"{rel}:{node.lineno}")
+
+    return sites
+
+
+def test_litellm_api_base_has_exactly_one_writer() -> None:
+    """Tier 2: the only code writing LITELLM_API_BASE lives in loader.py."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+
+    all_sites: list[str] = []
+    for py in src.rglob("*.py"):
+        all_sites.extend(_write_sites(py, root))
+
+    write_files = {site.rsplit(":", 1)[0] for site in all_sites}
+
+    # The collector must find the canonical writer — else the guard is a
+    # false-green (an empty collector would trivially pass the set equality).
+    assert _CANONICAL_REL in write_files, (
+        "single-writer guard found NO LITELLM_API_BASE write in "
+        f"{_CANONICAL_REL} — the canonical writer moved or the write-detector "
+        f"regressed (its alias/operation classification). Collected: {all_sites}"
+    )
+
+    # And it must be the ONLY file writing it. A second writer anywhere else
+    # (the #2682 per-entry hand-wiring class) grows this set and fails here.
+    assert write_files == {_CANONICAL_REL}, (
+        "LITELLM_API_BASE written outside the single canonical writer "
+        f"({_CANONICAL_REL}::load_config). This re-opens the per-entry proxy "
+        "hand-wiring class (#2682): a per-entry copy silently drifts from the "
+        "chokepoint. Route the export through load_config() instead. "
+        f"Offending write sites: {sorted(all_sites)}"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2683. Prevention follow-up to #2682: consolidate `LITELLM_API_BASE` to a single canonical writer and add an AST/CI guard so the per-entry hand-wiring class that caused #2682 cannot recur.

## What
#2682 made `load_config()` (`config/loader.py:492`, via the `import os as _os_for_mcp` alias) the single canonical writer of `LITELLM_API_BASE` — it is the one universal chokepoint every LLM entry passes before its first LLM call. Two redundant inline copies remained (idempotent `setdefault`, harmless-but-duplicative). This PR removes both and adds a single-writer guard.

Final shape: **writer = 1 (loader.py) / reader-chokepoints = 2 (`llm.proxy_kwargs` + embedding `_proxy_kwargs`, both read-only) / write-invariant guard = 1**.

## Removal-safety traces (each removal is safe ⇒ load_config precedes the first LLM call on that path)
- **`interfaces/cli/invocation_context.py`** (chat/run/mcp-serve/chainlit): `from_args` calls `load_config()` on the line directly above the former copy. `load_config` now exports `LITELLM_API_BASE` itself ⇒ the inline copy was purely redundant (same `setdefault` value). **SAFE.** Removed the copy + the now-unused `import os`.
- **`interfaces/web/deps.py`** (`_get_registry`, web frontend): `_get_registry` calls `_load_config()` (→ `load_config()`) at the top of the function (~:265), *before* the session factory / any session is built and long before any LLM call. So the former copy (~:274) was purely redundant. **SAFE.** Removed the copy; **kept `import os`** because it is read again below (`os.environ.get("REYN_WEB_EAGER_EMBEDDING_BUILD")` ~:296).

Neither path is left uncovered — both reach `load_config()` before their first LLM call, so proxy routing is unchanged (idempotent `setdefault`).

## AST guard: write-vs-read classification + alias resolution
Invariant: the string literal `"LITELLM_API_BASE"` appears at a **write** position only in `config/loader.py`.

- **Flagged as writes:** subscript-assign (`environ["…"] = …`, incl. `+=` / annotated), `environ.setdefault(…)` / `.pop(…)`, `environ.update({…literal key…})` (dict-literal and keyword forms), and module-level `os.putenv(…)` / aliased `putenv(…)`.
- **Not flagged (reads, legitimate):** `.get(…)`, `… in environ`, subscript-read. The two readers (`llm.proxy_kwargs`, embedding `_proxy_kwargs`) stay unflagged — the guard classifies by **operation**, not string presence.
- **Alias gotcha (`_os_for_mcp`):** the canonical write is authored through `import os as _os_for_mcp` → `_os_for_mcp.environ.setdefault(...)`. The guard matches on the **attribute name `environ`** being written (so `os.environ`, `_os_for_mcp.environ`, any `import os as X` all match regardless of the base name) and additionally resolves `from os import environ [as Y]` / `from os import putenv [as Z]` name bindings. A naive `os.`-prefix match would both miss the aliased canonical write and misattribute it — this guard does not.
- **Static residual (documented, not a silent gap):** a dynamic-key write (`environ[var] = …` with a runtime `var`) is not statically catchable — same limitation as the #1190 cost-chokepoint guard. Every current write uses a string-literal key, so the static guard is complete for the present tree.

Falsify evidence: temporarily adding a second, **aliased** writer (`import os as _alias_os; _alias_os.environ["LITELLM_API_BASE"] = "x"`) turned the guard RED (offending site correctly reported via attribute-name matching, proving alias resolution); restored via scratch backup (never `git checkout`), guard GREEN again.

## Tests (both Tier 2)
- `tests/test_litellm_api_base_single_writer_ast_guard_2683.py` — the single-writer AST guard. Asserts the collector finds the canonical loader.py write (guards against a false-green empty collector) AND that it is the only writer.
- `tests/test_litellm_api_base_load_config_seam_2683.py` — removal-safety regression. Drives the real `InvocationContext.from_args` seam (no mock, save/restore env + cwd): a configured `api_base` still lands in `LITELLM_API_BASE` purely via the `load_config()` fold; and an absent `api_base` leaves the var unset (the `if _api_base` guard).

## 4 CI gates (run locally on this diff)
- `ruff check src tests` → **All checks passed!**
- `python scripts/test_tier_audit.py --strict <both test files>` → **3 OK, 0 warnings, 0 Tier-4 errors**
- `pytest -q -n auto --timeout=120` (repo root) → **7790 passed, 21 skipped**; my 3 new tests pass. 5 pre-existing web route-mount failures (`test_*_routes_mounted`, `test_resources_route_is_mounted_on_app`, `test_loader_disambiguates_via_package_field`) are **unrelated to this diff** — verified they fail identically on the clean tree (HEAD 11a8733f) with my src changes stashed (environmental: routers not mounted locally). Removing an env export cannot un-mount a router.
- `python scripts/verify_module_docstrings.py <both src files>` → **OK**.

## Test plan
- [x] AST guard passes on the post-removal tree (single writer = loader.py).
- [x] Guard falsified: a second (aliased) writer makes it RED; restored to GREEN.
- [x] Removal-safety: InvocationContext seam still sets `LITELLM_API_BASE` from configured `api_base` via `load_config()` (real, no mock).
- [x] (skipped — Tier-2 scope) Full web `_get_registry` build not stood up (pulls process-singleton budget/state-log/registry). Web path shares the identical `load_config()` seam; covered transitively at the loader level. Removal trace documents load_config precedes the first LLM call on the web path.
- [x] All 4 CI gates run locally (see above).

## Non-goal
Does not touch #2686 (deferred conditional-cred follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)