### PR TITLE
feat: conditional LLM credential pre-check for `reyn pipe run` (#2686)

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -1434,6 +1434,141 @@ _STEP_KINDS: "dict[type, str]" = {
 
 
 # ---------------------------------------------------------------------------
+# LLM-usage classification (the credential-pre-check soundness seam, #2686)
+# ---------------------------------------------------------------------------
+#
+# ``pipeline_uses_llm`` is a SOUND UNDER-APPROXIMATION of "this pipeline drives
+# an LLM": it may return ``False`` for a pipeline that in fact reaches an LLM
+# (a false NEGATIVE — the caller degrades to today's mid-run error, ACCEPTABLE)
+# but it must NEVER return ``True`` for a pipeline that does not (a false
+# POSITIVE would let ``reyn pipe run`` re-introduce the reverted #2685 bug:
+# ``SystemExit``-ing a legitimate transform/tool-only pipeline whose provider
+# env var happens to be unset). False-positive-ZERO is the absolute contract.
+#
+# Every ``_STEP_KINDS`` type is classified into EXACTLY ONE bucket below —
+# LLM-leaf, non-LLM-leaf, or container (recurse into its nested steps / callee
+# sub-pipelines). The Tier-1 completeness gate (``test_2686_*``) enumerates
+# ``_STEP_KINDS`` and asserts full coverage, so a NEW step kind is RED until
+# explicitly classified here (never a silent non-LLM default — that would
+# disable the check for the new kind unsoundly). This is the same structure
+# seam FP-0056's canonical gate and #2683's single-writer guard use: the
+# classification lives in a registry keyed by dataclass type, not an inline
+# ``isinstance`` hand-list.
+
+# LLM-leaf: an ``AgentStep`` ALWAYS drives an LLM (``run_agent_step`` spawns an
+# ephemeral session and runs one turn). This is the only unconditional LLM leaf.
+_LLM_LEAF_KINDS: "frozenset[type]" = frozenset({AgentStep})
+
+# Non-LLM leaf: never drives an LLM by ITSELF.
+#   - ``TransformStep``: sandboxed R1 expression, no LLM.
+#   - ``ToolStep`` (incl. ``ToolStep(name="shell")`` — ``shell`` collapses to a
+#     ToolStep at the executor layer; there is no ShellStep type): a tool
+#     dispatch. RESIDUAL under-approximation: a ``tool`` step CAN reach an
+#     LLM-driving op — currently ``judge_output``, and the agent-spawn class
+#     exposed on the tool surface (``agent_spawn`` / ``delegate_to_agent`` /
+#     ``session_spawn``). Classifying ``tool`` as non-LLM here means those
+#     degrade to a mid-run error rather than an early credential check. A sound
+#     extension would derive the LLM-op set from a registration marker
+#     (FP-0056 pattern), NOT a hand-list of op names — out of scope for #2686.
+_NON_LLM_LEAF_KINDS: "frozenset[type]" = frozenset({TransformStep, ToolStep})
+
+
+def _fold_children(step: "FoldStep", registry, seen):  # type: ignore[no-untyped-def]
+    return (step.do,)
+
+
+def _for_each_children(step: "ForEachStep", registry, seen):  # type: ignore[no-untyped-def]
+    return (step.do, step.collect)
+
+
+def _parallel_children(step: "ParallelStep", registry, seen):  # type: ignore[no-untyped-def]
+    return (*step.branches.values(), step.collect)
+
+
+def _resolve_callee_steps(
+    name: str, registry: "PipelineRegistry | None", seen: "set[str]",
+) -> "tuple[Step, ...]":
+    """Resolve a ``call``/``match`` static sub-pipeline NAME through the
+    registry and return its steps for recursion. Cycle-guarded via ``seen``
+    (bounded by construction, but guard anyway). An UNRESOLVABLE name (no
+    registry, cycle, or not registered) yields NO children — the predicate
+    then does NOT fire for that branch, consistent with "let the executor
+    surface the resolution error first" (false-positive-zero over eager-True)."""
+    if registry is None or name in seen:
+        return ()
+    seen.add(name)
+    try:
+        callee = registry.get(name)
+    except PipelineNotFoundError:
+        return ()
+    return tuple(callee.steps)
+
+
+def _call_children(step: "CallStep", registry, seen):  # type: ignore[no-untyped-def]
+    return _resolve_callee_steps(step.pipeline, registry, seen)
+
+
+def _match_children(step: "MatchStep", registry, seen):  # type: ignore[no-untyped-def]
+    # Each case + default is a STATIC sub-pipeline name run "exactly like a
+    # call step's callee" (MatchCase docstring) — resolve EACH via the registry
+    # and OR the results. A MatchStep has NO direct ``Step`` field, so a naive
+    # "traverse Step attributes" would misclassify it as a leaf and silently
+    # disable the check for match-routed agent pipelines.
+    children: "list[Step]" = []
+    for case in step.cases.values():
+        children.extend(_resolve_callee_steps(case.pipeline, registry, seen))
+    if step.default is not None:
+        children.extend(_resolve_callee_steps(step.default.pipeline, registry, seen))
+    return tuple(children)
+
+
+# Container step type -> a function yielding the nested Steps to recurse into
+# (``call``/``match`` resolve their static sub-pipeline names via the registry;
+# ``fold``/``for_each``/``parallel`` return their in-line nested steps).
+_CONTAINER_CHILDREN: "dict[type, Callable[..., tuple[Step, ...]]]" = {
+    FoldStep: _fold_children,
+    ForEachStep: _for_each_children,
+    ParallelStep: _parallel_children,
+    CallStep: _call_children,
+    MatchStep: _match_children,
+}
+
+
+def pipeline_uses_llm(
+    pipeline: "Pipeline", registry: "PipelineRegistry | None" = None,
+) -> bool:
+    """Return ``True`` iff some REACHABLE step of ``pipeline`` drives an LLM.
+
+    A SOUND UNDER-APPROXIMATION (see the module-level classification comment):
+    false negatives degrade to a mid-run error (acceptable); false positives
+    are forbidden (they re-introduce the reverted #2685 "SystemExit a valid
+    non-LLM pipeline" bug). ``AgentStep`` is the only True leaf; ``transform``/
+    ``tool``/``shell`` are False leaves (the ``tool``-reaches-LLM class is a
+    documented residual); containers recurse — ``call``/``match`` resolve their
+    static sub-pipeline names through ``registry`` (cycle-guarded; unresolvable
+    ⇒ do not fire), ``fold``/``for_each``/``parallel`` recurse into their
+    in-line nested steps.
+    """
+    seen: "set[str]" = set()
+
+    def _step_uses_llm(step: Step) -> bool:
+        t = type(step)
+        if t in _LLM_LEAF_KINDS:
+            return True
+        if t in _NON_LLM_LEAF_KINDS:
+            return False
+        children_fn = _CONTAINER_CHILDREN.get(t)
+        if children_fn is None:
+            # Unclassified type: the sound default is False (under-approx). The
+            # Tier-1 completeness gate makes this unreachable for a registered
+            # ``_STEP_KINDS`` member — a new kind is RED until classified above.
+            return False
+        return any(_step_uses_llm(child) for child in children_fn(step, registry, seen))
+
+    return any(_step_uses_llm(step) for step in pipeline.steps)
+
+
+# ---------------------------------------------------------------------------
 # Executor
 # ---------------------------------------------------------------------------
 
@@ -1757,4 +1892,5 @@ __all__ = [
     "PipelineCancelled",
     "PipelineExecutor",
     "STEP_DISPATCH",
+    "pipeline_uses_llm",
 ]

--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -647,6 +647,32 @@ def run_run(args: argparse.Namespace) -> None:
         )
         sys.exit(1)
 
+    # #2686: credential pre-check, CONDITIONAL on the pipeline actually using an
+    # LLM. ``reyn pipe run`` builds NO InvocationContext, so we resolve
+    # ``config.model`` ourselves and call the config-level core directly. This
+    # runs AFTER pipeline resolution (so "not registered" / parse / validation
+    # errors surface first — the #2685 lesson) and fires ONLY for LLM-using
+    # pipelines (``pipeline_uses_llm``, a false-positive-zero under-approximation)
+    # so a legitimate transform/tool-only pipeline is NEVER SystemExit-ed when a
+    # provider env var happens to be unset (the reverted #2685 regression). The
+    # proxy path is already a no-op inside the core (``config.api_base`` short-
+    # circuit), so no new proxy/credential logic lives here.
+    from reyn.core.pipeline.executor import pipeline_uses_llm
+    from reyn.interfaces.cli.credentials_check import verify_model_credentials_or_exit
+
+    if pipeline_uses_llm(pipeline, pipeline_registry):
+        from reyn.llm.model_resolver import ModelResolver
+
+        try:
+            resolved_model: "str | None" = ModelResolver(
+                config.models,
+                default_class=config.model,
+                purpose_classes=config.model_class_by_purpose,
+            ).resolve(config.model).model
+        except Exception:
+            resolved_model = None  # resolver failure — let downstream surface it
+        verify_model_credentials_or_exit(config, resolved_model)
+
     grant_file_write = bool(getattr(args, "grant_file_write", False))
     # A real, standalone AgentRegistry (registry_bootstrap) so an
     # AgentStep can genuinely spawn+run an ephemeral session — see the module

--- a/src/reyn/interfaces/cli/credentials_check.py
+++ b/src/reyn/interfaces/cli/credentials_check.py
@@ -15,6 +15,7 @@ import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from reyn.config import ReynConfig
     from reyn.interfaces.cli.invocation_context import InvocationContext
 
 
@@ -31,27 +32,36 @@ _PROVIDER_ENV_VARS: dict[str, str] = {
 }
 
 
-def verify_credentials_or_exit(
-    session: "InvocationContext", args: argparse.Namespace,
+def verify_model_credentials_or_exit(
+    config: "ReynConfig", resolved: "str | None",
 ) -> None:
-    """Exit 1 with an actionable message if the model the command will use
-    has no credentials configured (no env var AND no api_base proxy).
-    """
-    config = session.config
+    """Config-level credential pre-check core (no ``InvocationContext`` needed).
 
+    Exit 1 with an actionable message iff the ALREADY-RESOLVED litellm model
+    string ``resolved`` needs a provider env var that is unset AND no ``api_base``
+    proxy is configured. This is the shared tail of the check: any caller that
+    can resolve its model string to litellm form (``reyn chat``/``mcp`` via the
+    :func:`verify_credentials_or_exit` wrapper below; ``reyn pipe run``, which
+    builds NO ``InvocationContext``, by resolving ``config.model`` itself and
+    passing it here) reuses IDENTICAL exit logic.
+
+    The ONLY exit case is "no ``api_base`` + known provider prefix + that
+    provider's env var unset" — every other input early-returns (proxy handles
+    auth; ``resolved`` is None/bare/unknown-provider ⇒ trust the resolver /
+    let litellm raise its own error). False positives (rejecting a setup that
+    would work) are worse than false negatives (a late litellm error for an
+    unusual provider), so the check stays deliberately narrow.
+    """
     # When a proxy api_base is configured the proxy handles auth — provider
     # env vars become optional (the proxy may accept any string or use its
     # own credential).  Skip the check entirely in that case.
     if config.api_base:
         return
 
-    # Resolve to the litellm model string the command will actually use
-    # (honours --model on the CLI).  Its provider prefix (everything before
-    # the first "/") tells us which env var is required.
-    try:
-        _, resolved = session.model_for(args)
-    except Exception:
-        return  # resolver failure — let downstream surface its own error
+    # ``None`` = the caller could not resolve a model string (resolver failure)
+    # — let downstream surface its own error rather than guess.
+    if resolved is None:
+        return
 
     if "/" not in resolved:
         return  # bare model name; trust the resolver
@@ -76,3 +86,33 @@ def verify_credentials_or_exit(
         f"See docs/guide/getting-started/01-installation.md for details.\n"
     )
     sys.exit(1)
+
+
+def verify_credentials_or_exit(
+    session: "InvocationContext", args: argparse.Namespace,
+) -> None:
+    """Exit 1 with an actionable message if the model the command will use
+    has no credentials configured (no env var AND no api_base proxy).
+
+    Thin ``InvocationContext`` wrapper over :func:`verify_model_credentials_or_exit`:
+    resolves the litellm model string the command will actually use (honours
+    ``--model`` on the CLI via ``session.model_for``), then delegates the
+    api_base / provider-prefix / env-var decision to the config-level core.
+    Behaviour is byte-identical to the pre-extraction inline check.
+    """
+    config = session.config
+
+    # Preserve the pre-extraction ordering: under a proxy we skip resolution
+    # entirely (``model_for`` is never called), exactly as before.
+    if config.api_base:
+        return
+
+    # Resolve to the litellm model string the command will actually use.  Its
+    # provider prefix (everything before the first "/") tells the core which
+    # env var is required.
+    try:
+        _, resolved = session.model_for(args)
+    except Exception:
+        return  # resolver failure — let downstream surface its own error
+
+    verify_model_credentials_or_exit(config, resolved)

--- a/tests/test_2686_pipe_llm_credential_precheck.py
+++ b/tests/test_2686_pipe_llm_credential_precheck.py
@@ -1,0 +1,413 @@
+"""Tier 1/2: #2686 — CONDITIONAL LLM credential pre-check for ``reyn pipe run``.
+
+``reyn pipe run`` gains ``reyn chat``'s early "no API key set" pre-check, but
+fires it ONLY when the resolved pipeline actually uses an LLM (``pipeline_uses_llm``)
+and only AFTER pipeline resolution. A PRIOR attempt (#2685) added the check
+UNCONDITIONALLY and regressed: it ``SystemExit``-ed legitimate transform/tool-only
+pipelines whose provider env var was merely unset, and preempted the "pipeline not
+registered" error. That was reverted; #2686 re-adds it conditionally.
+
+Structure of this file:
+
+- Tier 1 completeness gate: every ``_STEP_KINDS`` step type is classified into
+  exactly one LLM bucket (llm-leaf / non-llm-leaf / container). A new kind is RED
+  until classified — a silent non-LLM default would unsoundly disable the check.
+- Tier 1 per-kind behaviour falsify: the gate catches MISSING classification but
+  not WRONG classification, so each container kind (fold/for_each/parallel/call/
+  match) gets a minimal pipeline reaching an ``AgentStep`` ONLY through it →
+  predicate True; transform/tool/shell-only → False (false-positive-zero).
+- Tier 2 integration/core: the extracted config-level core
+  (``verify_model_credentials_or_exit``) exits/short-circuits correctly, and
+  ``run_run`` drives it — a non-LLM pipeline runs WITHOUT SystemExit even with
+  every provider key unset (the #2685 regression, pinned dead); an agent pipeline
+  with no key + no proxy exits early; "not registered" surfaces its own error.
+
+Real dataclasses / real ``PipelineRegistry`` / real ``load_config`` / real
+``run_run`` — no mocks. The credential pre-check for the agent-pipeline case
+exits BEFORE any LLM spawn, so no LLM replay is needed here.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.pipeline.executor import (
+    _CONTAINER_CHILDREN,
+    _LLM_LEAF_KINDS,
+    _NON_LLM_LEAF_KINDS,
+    _STEP_KINDS,
+    AgentStep,
+    CallStep,
+    FoldStep,
+    ForEachStep,
+    MatchCase,
+    MatchStep,
+    ParallelStep,
+    Pipeline,
+    ToolStep,
+    TransformStep,
+    pipeline_uses_llm,
+)
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.interfaces.cli.commands.pipe import register, run_run
+from reyn.interfaces.cli.credentials_check import verify_model_credentials_or_exit
+
+_PROVIDER_KEYS = ("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "AZURE_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _restore_litellm_api_base():
+    """Snapshot + restore LITELLM_API_BASE around every test in this file.
+
+    ``load_config()`` legitimately EXPORTS LITELLM_API_BASE process-wide when a
+    config carries ``api_base`` (#2683's single-writer chokepoint) — and the
+    ``api_base``-proxy fixtures here drive exactly that path. Without this owning
+    the real restore, the export would leak into the rest of the suite and
+    perturb litellm-routing tests (same guard as
+    ``test_pipe_proxy_bootstrap_2682.py``)."""
+    saved = os.environ.get("LITELLM_API_BASE")
+    try:
+        yield
+    finally:
+        if saved is None:
+            os.environ.pop("LITELLM_API_BASE", None)
+        else:
+            os.environ["LITELLM_API_BASE"] = saved
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — completeness gate (classification coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_every_step_kind_is_classified_into_exactly_one_llm_bucket() -> None:
+    """Tier 1: every executor step kind (``_STEP_KINDS``) is classified into
+    EXACTLY ONE of llm-leaf / non-llm-leaf / container. A new step kind added to
+    the union without a classification here → RED (forces a soundness decision;
+    a silent non-LLM default would disable the credential check for that kind)."""
+    llm_leaf = set(_LLM_LEAF_KINDS)
+    non_llm_leaf = set(_NON_LLM_LEAF_KINDS)
+    container = set(_CONTAINER_CHILDREN)
+
+    # Coverage: the three buckets exactly partition the executor step universe.
+    assert (llm_leaf | non_llm_leaf | container) == set(_STEP_KINDS)
+
+    # Disjointness: no kind lands in two buckets (a kind is a leaf XOR a container).
+    assert not (llm_leaf & non_llm_leaf)
+    assert not (llm_leaf & container)
+    assert not (non_llm_leaf & container)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — per-kind behaviour falsify (WRONG classification, not just missing)
+# ---------------------------------------------------------------------------
+
+
+def _agent() -> AgentStep:
+    return AgentStep(prompt="do the thing", identity="default")
+
+
+def _transform() -> TransformStep:
+    return TransformStep(value="pipe")
+
+
+def test_agent_leaf_uses_llm() -> None:
+    """Tier 1: a bare ``AgentStep`` is the True leaf — the predicate fires."""
+    assert pipeline_uses_llm(Pipeline(steps=[_agent()])) is True
+
+
+def test_transform_tool_shell_only_pipeline_does_not_use_llm() -> None:
+    """Tier 1: transform / tool / ``shell`` (a ``ToolStep(name='shell')``, NOT a
+    ShellStep) only → predicate is False. This is the false-positive-zero pin: a
+    legitimate non-LLM pipeline must NEVER be classified as LLM-using (the
+    reverted #2685 SystemExit-a-valid-pipeline regression)."""
+    non_llm = Pipeline(steps=[
+        _transform(),
+        ToolStep(name="write_file", args={}),
+        ToolStep(name="shell", args={}),
+    ])
+    assert pipeline_uses_llm(non_llm) is False
+
+
+def test_fold_over_agent_uses_llm() -> None:
+    """Tier 1: an ``AgentStep`` reachable ONLY through a ``fold`` container →
+    True (container recursion into ``fold.do``)."""
+    pl = Pipeline(steps=[FoldStep(init="0", do=_agent(), output="acc")])
+    assert pipeline_uses_llm(pl) is True
+
+
+def test_for_each_agent_in_do_and_in_collect_use_llm() -> None:
+    """Tier 1: ``for_each`` recurses into BOTH ``do`` and ``collect`` — an
+    ``AgentStep`` in either reaches the predicate."""
+    via_do = Pipeline(steps=[
+        ForEachStep(do=_agent(), collect=_transform(), on_error="abort"),
+    ])
+    via_collect = Pipeline(steps=[
+        ForEachStep(do=_transform(), collect=_agent(), on_error="abort"),
+    ])
+    assert pipeline_uses_llm(via_do) is True
+    assert pipeline_uses_llm(via_collect) is True
+
+
+def test_for_each_transform_only_does_not_use_llm() -> None:
+    """Tier 1: a ``for_each`` with non-LLM ``do`` AND ``collect`` → False."""
+    pl = Pipeline(steps=[
+        ForEachStep(do=_transform(), collect=_transform(), on_error="abort"),
+    ])
+    assert pipeline_uses_llm(pl) is False
+
+
+def test_parallel_over_agent_branch_uses_llm() -> None:
+    """Tier 1: an ``AgentStep`` in a ``parallel`` branch → True (recursion into
+    every ``branches`` value + ``collect``)."""
+    pl = Pipeline(steps=[
+        ParallelStep(
+            branches={"a": _transform(), "b": _agent()},
+            collect=_transform(),
+        ),
+    ])
+    assert pipeline_uses_llm(pl) is True
+
+
+def test_call_resolves_callee_via_registry_and_recurses() -> None:
+    """Tier 1: a ``call`` step's static sub-pipeline name is resolved through the
+    ``PipelineRegistry`` and recursed into — an agent-using callee → True, a
+    transform-only callee → False (registry resolution is REQUIRED for a
+    ``CallStep`` to be classifiable; it has no in-line ``Step`` field)."""
+    reg = PipelineRegistry()
+    reg.register("sub_agent", Pipeline(steps=[_agent()], name="sub_agent"))
+    reg.register("sub_plain", Pipeline(steps=[_transform()], name="sub_plain"))
+
+    caller_llm = Pipeline(steps=[CallStep(pipeline="sub_agent")])
+    caller_plain = Pipeline(steps=[CallStep(pipeline="sub_plain")])
+    assert pipeline_uses_llm(caller_llm, reg) is True
+    assert pipeline_uses_llm(caller_plain, reg) is False
+
+
+def test_match_resolves_each_case_and_default_via_registry() -> None:
+    """Tier 1: a ``match`` step resolves EACH case AND ``default`` via the
+    registry and ORs the results — an ``AgentStep`` reachable through any case OR
+    the default → True. A MatchStep has NO direct ``Step`` field, so without
+    per-case registry resolution it would be misclassified as a leaf (silently
+    disabling the check for match-routed agent pipelines)."""
+    reg = PipelineRegistry()
+    reg.register("sub_agent", Pipeline(steps=[_agent()], name="sub_agent"))
+    reg.register("sub_plain", Pipeline(steps=[_transform()], name="sub_plain"))
+
+    # Agent reachable only via a case.
+    via_case = Pipeline(steps=[MatchStep(
+        on="pipe",
+        cases={"x": MatchCase(pipeline="sub_plain"), "y": MatchCase(pipeline="sub_agent")},
+    )])
+    # Agent reachable only via default.
+    via_default = Pipeline(steps=[MatchStep(
+        on="pipe",
+        cases={"x": MatchCase(pipeline="sub_plain")},
+        default=MatchCase(pipeline="sub_agent"),
+    )])
+    # All targets non-LLM → False.
+    all_plain = Pipeline(steps=[MatchStep(
+        on="pipe",
+        cases={"x": MatchCase(pipeline="sub_plain")},
+        default=MatchCase(pipeline="sub_plain"),
+    )])
+    assert pipeline_uses_llm(via_case, reg) is True
+    assert pipeline_uses_llm(via_default, reg) is True
+    assert pipeline_uses_llm(all_plain, reg) is False
+
+
+def test_unresolvable_callee_does_not_fire() -> None:
+    """Tier 1: an unresolvable ``call`` target (no registry, or name not
+    registered) yields NO children → predicate does NOT fire (False) — consistent
+    with 'let the executor surface the resolution error first', and keeping
+    false-positive-zero (we never guess True for an unknown callee)."""
+    caller = Pipeline(steps=[CallStep(pipeline="does_not_exist")])
+    empty_reg = PipelineRegistry()
+    assert pipeline_uses_llm(caller, None) is False
+    assert pipeline_uses_llm(caller, empty_reg) is False
+
+
+def test_call_cycle_is_guarded() -> None:
+    """Tier 1: a self-referential ``call`` (or a mutual cycle) with no agent step
+    terminates and returns False — the cycle guard prevents infinite recursion."""
+    reg = PipelineRegistry()
+    reg.register("loop", Pipeline(steps=[CallStep(pipeline="loop")], name="loop"))
+    assert pipeline_uses_llm(Pipeline(steps=[CallStep(pipeline="loop")]), reg) is False
+
+
+def test_nested_container_over_call_to_agent_uses_llm() -> None:
+    """Tier 1: composition — a ``for_each`` whose ``do`` is a ``call`` to an
+    agent-using sub-pipeline reaches the LLM through two container layers."""
+    reg = PipelineRegistry()
+    reg.register("sub_agent", Pipeline(steps=[_agent()], name="sub_agent"))
+    pl = Pipeline(steps=[ForEachStep(
+        do=CallStep(pipeline="sub_agent"), collect=_transform(), on_error="abort",
+    )])
+    assert pipeline_uses_llm(pl, reg) is True
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — the extracted config-level credential core
+# ---------------------------------------------------------------------------
+
+
+def _load_config_at(tmp_path: Path, monkeypatch, *, api_base: str | None):
+    """Write a minimal reyn.yaml (optionally with api_base) and load it."""
+    from reyn.config import load_config
+    data: dict = {"model": "standard", "models": {"standard": "openai/gpt-4o-mini"}}
+    if api_base is not None:
+        data["api_base"] = api_base
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    return load_config()
+
+
+@pytest.fixture
+def _keys_unset(monkeypatch):
+    """Every provider env var (and the proxy switch) unset — reproduces the CI
+    environment the #2685 regression was masked away from locally.
+
+    LITELLM_API_BASE is cleared via direct ``os.environ.pop`` (the autouse
+    ``_restore_litellm_api_base`` fixture owns its restore) rather than
+    ``monkeypatch.delenv`` — mixing monkeypatch's undo with ``load_config()``'s
+    own set of the same var confuses monkeypatch's bookkeeping (the exact
+    hazard ``test_pipe_proxy_bootstrap_2682.py`` documents)."""
+    for key in _PROVIDER_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    os.environ.pop("LITELLM_API_BASE", None)
+
+
+def test_core_exits_when_key_unset_and_no_proxy(tmp_path, monkeypatch, _keys_unset) -> None:
+    """Tier 2: no api_base + known provider prefix + env var unset → SystemExit(1)
+    with an actionable message. This is the ONLY exit case."""
+    config = _load_config_at(tmp_path, monkeypatch, api_base=None)
+    with pytest.raises(SystemExit) as exc:
+        verify_model_credentials_or_exit(config, "openai/gpt-4o-mini")
+    assert exc.value.code == 1
+
+
+def test_core_no_exit_when_key_present(tmp_path, monkeypatch, _keys_unset) -> None:
+    """Tier 2: env var set → no exit (returns None)."""
+    config = _load_config_at(tmp_path, monkeypatch, api_base=None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert verify_model_credentials_or_exit(config, "openai/gpt-4o-mini") is None
+
+
+def test_core_proxy_api_base_is_a_no_op(tmp_path, monkeypatch, _keys_unset) -> None:
+    """Tier 2: api_base (proxy) set → no-op even with the provider key unset —
+    the proxy handles auth. This is the branch that makes an agent pipeline under
+    a proxy config proceed without an early exit (the user's real dogfood setup)."""
+    config = _load_config_at(tmp_path, monkeypatch, api_base="http://localhost:4000")
+    assert verify_model_credentials_or_exit(config, "openai/gpt-4o-mini") is None
+
+
+def test_core_none_bare_and_unknown_provider_are_no_ops(tmp_path, monkeypatch, _keys_unset) -> None:
+    """Tier 2: resolver-failure (None), a bare model name (no '/'), and an
+    unknown provider prefix all early-return — the check is deliberately narrow
+    (false positives are worse than a late litellm error)."""
+    config = _load_config_at(tmp_path, monkeypatch, api_base=None)
+    assert verify_model_credentials_or_exit(config, None) is None
+    assert verify_model_credentials_or_exit(config, "gpt-4o-mini") is None
+    assert verify_model_credentials_or_exit(config, "cohere/command-r") is None
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — run_run integration (the conditional gate, end to end)
+# ---------------------------------------------------------------------------
+
+
+def _write_reyn_yaml(root: Path, entries: dict) -> None:
+    data = {
+        "model": "standard",
+        "models": {"standard": "openai/gpt-4o-mini"},
+        "pipelines": {"entries": entries},
+    }
+    (root / "reyn.yaml").write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8",
+    )
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+def test_register_parses_run_subcommand() -> None:
+    """Tier 2: the ``pipe`` subparser registers (guards the import surface this
+    file's integration tests drive)."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    register(sub)
+    args = parser.parse_args(["pipe", "run", "somepipe"])
+    assert args.name == "somepipe"
+
+
+def test_run_non_llm_pipeline_does_not_exit_with_keys_unset(
+    tmp_path, monkeypatch, capsys, _keys_unset,
+) -> None:
+    """Tier 2: THE #2685 regression, pinned dead. A transform-only pipeline runs
+    to completion via ``run_run`` even with EVERY provider key unset and no proxy
+    — the conditional check must NOT fire for a non-LLM pipeline."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "hello.yaml").write_text(
+        "pipeline: hello_cli\n"
+        "steps:\n"
+        "  - transform: {value: \"'hello ' + ctx.name\", output: greeting}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"hello_cli": {"path": "hello.yaml"}})
+
+    args = _ns(
+        name="hello_cli", input=json.dumps({"name": "world"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)  # must NOT raise SystemExit
+
+    result = json.loads(capsys.readouterr().out)
+    assert result["pipe_data"] == "hello world"
+
+
+def test_run_agent_pipeline_exits_early_when_key_unset_no_proxy(
+    tmp_path, monkeypatch, capsys, _keys_unset,
+) -> None:
+    """Tier 2: an agent (LLM) pipeline with the provider key unset AND no proxy
+    exits early (code 1) with the credential message — AFTER pipeline resolution,
+    BEFORE any LLM spawn."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "agent.yaml").write_text(
+        "pipeline: agent_cli\n"
+        "steps:\n"
+        "  - agent: {prompt: \"summarize {pipe}\", identity: default}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"agent_cli": {"path": "agent.yaml"}})
+
+    args = _ns(name="agent_cli", input="{}", project=str(tmp_path), async_=False)
+    with pytest.raises(SystemExit) as exc:
+        run_run(args)
+    assert exc.value.code == 1
+    assert "no api key" in capsys.readouterr().err.lower()
+
+
+def test_run_unregistered_pipeline_surfaces_its_own_error_not_cred(
+    tmp_path, monkeypatch, capsys, _keys_unset,
+) -> None:
+    """Tier 2: a NAME with no matching pipeline exits with the 'not registered'
+    error, NOT the credential error — the check runs AFTER resolution, so
+    resolution failures win (the #2685 preemption lesson)."""
+    monkeypatch.chdir(tmp_path)
+    _write_reyn_yaml(tmp_path, {})
+
+    args = _ns(name="nope", input="{}", project=str(tmp_path), async_=False)
+    with pytest.raises(SystemExit) as exc:
+        run_run(args)
+    assert exc.value.code == 1
+    err = capsys.readouterr().err.lower()
+    assert "not registered" in err
+    assert "no api key" not in err

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -471,6 +471,12 @@ def test_run_agent_step_spawns_real_ephemeral_session(tmp_path, monkeypatch, cap
     monkeypatch.setattr(
         litellm, "acompletion", _fake_scripted_acompletion("the agent's answer"),
     )
+    # #2686: an agent (LLM) pipeline now trips ``reyn pipe run``'s conditional
+    # credential pre-check, which exits early when no provider key AND no proxy
+    # are configured (keys are UNSET in CI). The faked ``acompletion`` ignores
+    # the key value, so a dummy env var satisfies the pre-check and lets the run
+    # reach the replay seam — matching real "a credential must be configured".
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-2686-dummy")
 
     dsl_path = tmp_path / "uses_agent.yaml"
     dsl_path.write_text(


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2686. Re-adds the LLM credential pre-check to `reyn pipe run` that `reyn chat`/`mcp` have, CONDITIONALLY (the whole point — #2685 added it unconditionally, SystemExit-ed valid non-LLM pipelines + preempted the "not registered" error, and was reverted). Architect's design pass + self-review addendum on the issue are authoritative; this implements them.

## What changed

**1. Config-level extraction (`credentials_check.py`) — chat/mcp byte-identical.**
`verify_model_credentials_or_exit(config, resolved: str | None)` holds the tail (api_base guard → provider-prefix → env-var → exit). `verify_credentials_or_exit(session, args)` becomes a thin wrapper: keeps the pre-extraction ordering (api_base early-return *before* `model_for`, so `model_for` is never called under a proxy), resolves the model, delegates. `run_run` (which builds NO InvocationContext, deliberately) calls the core directly after resolving `config.model` via `ModelResolver` itself. No new proxy/credential logic — the proxy path was already a no-op (`config.api_base` short-circuit).

**2. `pipeline_uses_llm(pipeline, registry) -> bool` — false-positive-ZERO under-approximation.** Bound to a step-type classification registry (structure seam, not an inline hand-list), gated by a Tier-1 completeness test over `_STEP_KINDS`. Per-kind classification:

| kind | classification | recursion mechanic |
|---|---|---|
| `agent` (`AgentStep`) | **LLM leaf → True** | — always drives `run_agent_step` |
| `transform` (`TransformStep`) | non-LLM leaf → False | — |
| `tool` (`ToolStep`, incl. `ToolStep(name="shell")`) | non-LLM leaf → False | — (residual, see below) |
| `fold` (`FoldStep`) | container | traverse `do` |
| `for_each` (`ForEachStep`) | container | traverse `do` + `collect` |
| `parallel` (`ParallelStep`) | container | traverse all `branches.values()` + `collect` |
| `call` (`CallStep`) | container | **resolve `pipeline` (static name) via PipelineRegistry → recurse** |
| `match` (`MatchStep`) | container | **resolve EACH `cases[*].pipeline` + `default.pipeline` via PipelineRegistry → recurse, OR results** |

- **Cycle guard** on call/match resolution (`seen` set). **Unresolvable sub-pipeline name → do NOT fire** (return no children → False for that branch) — consistent with "let the executor surface the resolution error first".
- `shell` operated on as the executor type `ToolStep(name="shell")` — no `ShellStep` lookup (it's a parse-kind that collapses at the executor layer).
- **Documented `tool` residual (by name):** a `tool` step CAN reach an LLM-driving op — `judge_output`, and the agent-spawn class on the tool surface (`agent_spawn` / `delegate_to_agent` / `session_spawn`). Treating `tool` as non-LLM is a deliberate under-approximation → those degrade to today's mid-run error. A sound extension derives the LLM-op set from a registration marker (FP-0056 pattern), NOT a hand-list — out of scope here.

**3. Insertion point (`pipe.py::run_run`).** Immediately after `pipeline = pipeline_registry.get(name)` + its `PipelineNotFoundError` handling, BEFORE the AgentRegistry build and `executor.run(...)`. So parse / validation / "not registered" errors surface first (the #2685 lesson). run_run builds no InvocationContext.

## Container-field note
Every container field matched the design/addendum table exactly (`FoldStep.do`; `ForEachStep.do`+`.collect`; `ParallelStep.branches: dict[str,Step]`+`.collect`; `CallStep.pipeline: str`; `MatchStep.cases: dict[str,MatchCase]`+`.default`, each `MatchCase.pipeline: str`). Nothing papered over.

## Test plan
- [x] **Tier 1 completeness gate** — enumerate `_STEP_KINDS`, assert the three buckets exactly partition it + are disjoint (new kind → RED).
- [x] **Tier 1 per-kind behavior falsify** — fold/for_each/parallel/call/match fixtures each reaching an `AgentStep` ONLY through that container → True; transform/tool/shell-only → False; unresolvable callee → False; self-call cycle terminates → False; nested `for_each`→`call`→agent → True.
- [x] **Tier 2 core** — no-api_base+key-unset → exit(1); key-set → no-op; api_base proxy → no-op (agent-under-proxy proceeds); None/bare/unknown-provider → no-op.
- [x] **Tier 2 run_run integration (keys UNSET)** — (a) transform-only pipeline runs WITHOUT SystemExit (the #2685 regression, pinned dead); (b) agent pipeline, no key + no proxy → exit(1) after resolution; (d) unregistered → "not registered" error, NOT the cred error.
- [x] **Existing test updated** — `test_cli_pipe.py::test_run_agent_step_spawns_real_ephemeral_session` now sets a dummy `OPENAI_API_KEY` (faked `acompletion` ignores it) so the new pre-check passes and the run reaches the replay seam — this test would otherwise break in CI (keys unset).
- [x] **CI-parity: full suite run with `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`/`GEMINI_API_KEY`/`AZURE_API_KEY`/`LITELLM_API_BASE` all UNSET** → **5 failed, 7810 passed, 21 skipped**. The 5 failures are the pre-existing FastMCP web-route-mount env flakes (`test_fp0001_a2a_endpoints`, `web/test_a2a`, `web/test_mcp_sse`, `web/test_plugin_loader`, `web/test_resources_router`) — verified identical to the clean-tree (stashed) keys-unset baseline. Zero cred-related failures. (During development a `LITELLM_API_BASE` leak from a proxy-config `load_config()` in a new test perturbed 9 litellm-routing tests; fixed with the same autouse save/restore fixture `test_pipe_proxy_bootstrap_2682.py` uses — re-verified clean.)
- [x] **4 CI gates local** — `ruff check src tests` ✓ · `test_tier_audit.py --strict` (both changed test files) ✓ 40/40 · full `pytest` (above) ✓ · `verify_module_docstrings.py` (3 changed src files) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
