### PR TITLE
fix: --cui permission-approval answer resolves the pending intervention (closes #2690)

### DIFF
--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -130,19 +130,41 @@ async def _input_loop(
         if attached is None:
             renderer.message(_simple_status("no agent attached; try :agents"))
             continue
-        # Mark a reply as in flight before submit so the pacing gate on
-        # the next iteration blocks until the output loop signals it.
-        # `/`-prefixed slash commands (`/list`, `/attach`, `/answer`, ...)
-        # bypass the router and emit only `status` (no router reply),
-        # so clearing the gate for them would deadlock the next pipe
-        # iteration. `/quit` and `/exit` are handled above and never
-        # reach this branch. Intervention answers (plain text that
-        # happens to answer a pending ask_user) can still deadlock the
-        # pipe; that path is rare in scripted use and tracked as a
-        # known limitation.
-        if reply_seen is not None and not text.startswith("/"):
-            reply_seen.clear()
-        await attached.submit_user_text(text)
+        await _route_input_line(attached, text, reply_seen)
+
+
+async def _route_input_line(attached, text: str, reply_seen: "asyncio.Event | None") -> None:
+    """Route one non-quit REPL line to the attached session.
+
+    A pending intervention (permission prompt, ask_user, safety-limit) suspends
+    the router turn on the intervention's future — and that turn is the SOLE
+    consumer of the session inbox, so an answer routed the ordinary way
+    (``submit_user_text`` → inbox) can never be dequeued while the turn is
+    blocked: the future is never resolved and the session hangs indefinitely
+    (#2690 — the file-write approval prompt "never resumes after answering y").
+    A non-slash line is therefore delivered DIRECTLY to the pending intervention
+    via ``answer_oldest_intervention_text`` (the same session seam the inline
+    CUI's concurrent region poll uses), bypassing the inbox so the future
+    resolves and the blocked turn resumes.
+
+    Ordinary turns (no pending intervention) still flow through
+    ``submit_user_text``; a ``/``-prefixed line is never an intervention answer,
+    so it is left on the normal slash/inbox path. The direct-delivery result is
+    checked so a race where the intervention resolves between the head-check and
+    the deliver falls back to a normal turn instead of being dropped.
+    """
+    if not text.startswith("/") and attached.interventions.head() is not None:
+        if await attached.answer_oldest_intervention_text(text):
+            return
+    # Mark a reply as in flight before submit so the pacing gate on the next
+    # iteration blocks until the output loop signals it. `/`-prefixed slash
+    # commands (`/list`, `/attach`, `/answer`, ...) bypass the router and emit
+    # only `status` (no router reply), so clearing the gate for them would
+    # deadlock the next pipe iteration. `/quit` and `/exit` are handled by the
+    # caller and never reach here.
+    if reply_seen is not None and not text.startswith("/"):
+        reply_seen.clear()
+    await attached.submit_user_text(text)
 
 
 async def _output_loop(

--- a/tests/test_cui_permission_answer_resumes_2690.py
+++ b/tests/test_cui_permission_answer_resumes_2690.py
@@ -1,0 +1,224 @@
+"""#2690 — the ``reyn chat --cui`` plain REPL input loop must resolve a pending
+permission intervention so the blocked router turn resumes.
+
+Bug reproduced (tui-coder, during #2688 real-env verification): an interactive
+file-write approval prompt (``[y]es / [j]ust this path / [r]ecursive / [N]o``)
+shown in ``--cui`` never resumed after the user answered ``y`` — indefinite
+hang, ``file__write`` never completed, no ``permission_granted`` event.
+
+Root cause: the ``--cui`` plain input loop routed EVERY typed line through
+``submit_user_text`` → the session inbox. But a pending permission intervention
+suspends the router turn on the intervention future, and that same turn is the
+SOLE inbox consumer — so the ``y`` answer sits in the inbox forever, the future
+is never resolved, and the turn hangs. (The inline CUI already answers
+interventions directly via a concurrent region poll; the plain loop lacked the
+equivalent.) The read-approval grants earlier in the reporter's session did
+NOT hang because a default-zone (in-project) read is auto-allowed — it never
+raises an intervention. The out-of-zone WRITE is the first intervention-
+requiring permission, so it is the first to hit the dead answer-delivery path.
+
+The fix (``repl._route_input_line``) delivers a non-slash line directly to the
+pending intervention via ``answer_oldest_intervention_text``, bypassing the
+inbox so the future resolves.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — a real
+``Session`` + real ``PermissionResolver`` + the real intervention/permission
+machinery + the real production ``_route_input_line``. The ONLY faked boundary
+is the LLM call (``reyn.runtime.router_loop.call_llm_tools``), replaced with a
+real async stub — the established idiom for driving ``session.run()`` end-to-end
+without a live model. No MagicMock / AsyncMock / patch.
+
+Both scenarios are bounded: a hang trips the poll budget and the assertion
+fails (RED); the fix resolves the future so the op completes well within the
+budget (GREEN).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.repl.repl import _route_input_line
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from reyn.security.permissions.permissions import PermissionResolver
+
+_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _tool_call_result(name: str, args_json: str) -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": name, "arguments": args_json},
+        }],
+        finish_reason="tool_calls",
+        usage=_USAGE,
+    )
+
+
+def _text_result() -> LLMToolCallResult:
+    return LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=_USAGE,
+    )
+
+
+def _sequenced_llm_stub(results: list[LLMToolCallResult]):
+    """Real async callable mimicking ``call_llm_tools`` — returns each result in
+    turn (the last repeats), the only faked boundary permitted by policy."""
+    state = {"n": 0}
+
+    async def _stub(**_kwargs) -> LLMToolCallResult:
+        i = state["n"]
+        state["n"] += 1
+        return results[min(i, len(results) - 1)]
+
+    return _stub
+
+
+async def _poll(pred, *, attempts: int = 150, delay: float = 0.02) -> bool:
+    """Bounded poll — a hang exhausts the budget and returns False (RED)."""
+    for _ in range(attempts):
+        if pred():
+            return True
+        await asyncio.sleep(delay)
+    return False
+
+
+def _make_session(project_root: Path, *, wal: Path, snap: Path) -> Session:
+    perm = PermissionResolver({}, project_root=project_root, interactive=True)
+    session = Session(
+        agent_name="test-agent",
+        permission_resolver=perm,
+        state_log=StateLog(wal),
+        snapshot_path=snap,
+        workspace_base_dir=project_root,
+    )
+    # run_repl registers this listener on the attached session (see
+    # tests/test_repl_intervention_listener.py) — without it the
+    # listener-presence guard auto-refuses every intervention.
+    session.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    return session
+
+
+def _granted_paths(session: Session) -> list[str]:
+    """Paths for which a ``permission_granted`` event fired — the event the
+    reporter found MISSING for the hung write."""
+    return [
+        e.data.get("path")
+        for e in session._chat_events.all()
+        if e.type == "permission_granted"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypatch):
+    """Tier 2: a ``y`` answered through the ``--cui`` input loop resolves the
+    pending file-write permission so the blocked router turn resumes — the write
+    completes and ``permission_granted`` (kind=file.write) is emitted. RED before
+    the fix (the inbox-routed answer never reaches the suspended future → the
+    write never lands → the bounded poll times out)."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    out = proj / "out.txt"  # under project root but OUTSIDE the .reyn/ write zone
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _sequenced_llm_stub([
+            _tool_call_result(
+                "file__write",
+                f'{{"path": "{out}", "content": "written ok"}}',
+            ),
+            _text_result(),
+        ]),
+    )
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await session.submit_user_text("write the file")
+        # The router turn reaches the out-of-zone write gate and dispatches the
+        # approval prompt — the turn is now suspended awaiting the answer.
+        assert await _poll(lambda: session.interventions.head() is not None), (
+            "the file-write approval prompt never appeared"
+        )
+        head = session.interventions.head()
+        assert head.kind == "permission.file.write"
+        assert {c.hotkey for c in head.choices} == {"y", "j", "r", "N"}
+
+        # THE FIX under test: the --cui input loop delivers the typed answer to
+        # the attached session. On the buggy tree this routes through
+        # submit_user_text → inbox → never dequeued (deadlock).
+        await _route_input_line(session, "y", None)
+
+        assert await _poll(lambda: out.exists()), (
+            "write never completed after answering y — the blocked turn did "
+            "not resume (#2690 hang)"
+        )
+        assert out.read_text() == "written ok"
+        # The intervention future resolved: nothing pending, and the
+        # permission_granted event the reporter found MISSING is now emitted.
+        assert session.interventions.head() is None
+        assert await _poll(lambda: str(out) in _granted_paths(session)), (
+            "no permission_granted event was emitted for the write path"
+        )
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatch):
+    """Tier 2: the mirror of the working read path — an OUT-of-zone read
+    approval (the read case only auto-allows when in-zone) is resolved by the
+    SAME ``--cui`` input-loop seam as the write, proving write now behaves
+    identically to read once both actually require a prompt."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    outside = tmp_path / "outside.txt"  # OUTSIDE the project read zone
+    outside.write_text("secret payload")
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _sequenced_llm_stub([
+            _tool_call_result("file__read", f'{{"path": "{outside}"}}'),
+            _text_result(),
+        ]),
+    )
+
+    session = _make_session(
+        proj, wal=tmp_path / "state.wal", snap=tmp_path / "snap.json",
+    )
+    run_task = asyncio.create_task(session.run())
+    try:
+        await session.submit_user_text("read the outside file")
+        assert await _poll(lambda: session.interventions.head() is not None), (
+            "the file-read approval prompt never appeared"
+        )
+        assert session.interventions.head().kind == "permission.file.read"
+
+        await _route_input_line(session, "y", None)
+
+        assert await _poll(lambda: str(outside) in _granted_paths(session)), (
+            "read never completed after answering y — the blocked turn did "
+            "not resume"
+        )
+        assert session.interventions.head() is None
+    finally:
+        await session.shutdown()
+        try:
+            await asyncio.wait_for(run_task, timeout=2.0)
+        except asyncio.TimeoutError:
+            run_task.cancel()
+            await asyncio.gather(run_task, return_exceptions=True)


### PR DESCRIPTION
**[per-PR-coder]** — Fixes the #2690 file-write approval hang in `reyn chat --cui`. Part of #2688 (verification sweep) — this PR is part of the #2688 sweep and does NOT close it.

## Root-cause trace (the exact never-resolved future + why write diverged from read)

`reyn chat --cui` uses the **plain** REPL (`repl._input_loop`), not the inline CUI. That loop routed **every** typed line through `attached.submit_user_text(text)` → the session **inbox**.

When a `file__write` to a path outside the default `.reyn/` write zone is executed inside a router turn, `require_file_write` dispatches a `permission.file.write` intervention and the router turn **suspends on `iv.future`** (`InterventionRegistry.dispatch` → `await iv.future`). That router turn is running inside `run_one_iteration`, and `Session.run()`'s `while await self.run_one_iteration()` loop is the **sole consumer of the inbox**.

So the answer path deadlocks:
- turn suspended on `iv.future` ⇒ `run_one_iteration` never returns ⇒ inbox never drained;
- the `y` typed by the user is routed via `submit_user_text` → inbox ⇒ it can never reach `_maybe_answer_oldest_intervention` (only called from `_handle_user_message`, which only runs when the inbox is drained);
- `iv.future` is never resolved ⇒ the awaited future the reporter's `lsof`/`ps` evidence pointed at (`~0.9% CPU`, `S+`, zero TCP) hangs forever; `file__write` never returns, no `permission_granted` event.

**Why write diverged from read**: the read grants earlier in the reporter's session were **default-zone (in-project) reads → auto-allowed**, which never raise an intervention (immediate `permission_granted`). The out-of-zone **write is the first intervention-requiring permission**, so it is the first to hit the dead answer-delivery path. Not a write-specific bug — the first blocking intervention of any kind would hang in `--cui`.

The **inline CUI** does not hang because it has a concurrent `_intervention_poll` task (`interfaces/inline/app.py`) that delivers closed-set answers **directly** to the session (`answer_oldest_intervention_choice` / `_text`), bypassing the inbox. The plain `--cui` loop had no equivalent.

## The fix (structural, not a workaround)

Extract `repl._route_input_line`. When a head intervention is pending, a **non-slash** line is delivered **directly** to it via the existing session seam `answer_oldest_intervention_text` (bypassing the inbox), so `iv.future` resolves and the blocked turn resumes — exactly what the inline CUI already does. Ordinary turns (no pending intervention) and slash lines are unchanged; the direct-delivery result is checked so a resolve-between-check-and-deliver race falls back to a normal turn.

No timeout/poll hack, no arbitrary "unstick". The answer now reaches the pending permission the same way the inline path does.

## Confound check (#2689 ruled out)

The regression test reproduces the hang in a **fresh session with no preceding empty-stop/retry turn** — the deadlock is purely permission-flow-level (inbox starvation) and independent of model input. #2689 is not a cause.

## RED → GREEN evidence

New `tests/test_cui_permission_answer_resumes_2690.py` (Tier 2) drives the **real** `_route_input_line` against a **real** `Session` + **real** `PermissionResolver` + the real intervention/permission machinery (only the LLM boundary `router_loop.call_llm_tools` is faked — the sanctioned idiom; no MagicMock/AsyncMock/patch). Bounded: a hang trips the poll budget = RED.
- **RED** (falsified by disabling the fix's direct-delivery branch): both cases time out — the write/read never completes after `y`.
- **GREEN** (with fix): `2 passed in ~2.6s`. Asserts the write lands, the intervention resolves (`interventions.head() is None`), and the previously-missing `permission_granted` event fires for the path. A mirror **read-approval** case (out-of-zone read) proves write now behaves identically to read once both require a prompt.

## Gate results (run locally)

- `ruff check src tests` — **All checks passed**
- `python scripts/test_tier_audit.py --strict tests/test_cui_permission_answer_resumes_2690.py` — **OK: 2, errors: 0**
- `pytest` (repo root) — **7792 passed, 21 skipped, 5 failed**. The 5 failures (`test_fp0001_a2a_endpoints`, `web/test_a2a`, `web/test_mcp_sse`, `web/test_plugin_loader`, `web/test_resources_router` — all "routes mounted" assertions) are **pre-existing and unrelated**: confirmed by `git stash` (they fail identically on clean `origin/main` without this change; a REPL fix cannot affect route mounting).
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/repl.py` — **OK**

## Test plan

- [x] Regression test RED before fix (falsified by reverting the fix branch), GREEN after.
- [x] Mirror read-approval case proves read/write parity through the same seam.
- [x] Existing REPL tests pass (`test_repl_intervention_listener`, `test_inline_pr3a_app`, `test_registry_focus_listener_rewire`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)