### PR TITLE
fix: G12 empty-stop signal no longer leaks a bare "resume" prefix onto canonical tool results (#2689)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -389,6 +389,15 @@ def _apply_g12_signal(messages: list[dict]) -> list[dict]:
         top-level `_g12_signal` field after the opening brace, with
         trailing-comma elision for empty-object shapes (= `"{}"`,
         `"{ }"`) so the output is always parse-valid.
+      - Canonical frontmatter+text tool content (= `---\\n<yaml>---\\n<text>`,
+        the #2425 案B dominant shape): inject the signal as a LABELED
+        `_g12_signal` frontmatter field right after the opening delimiter —
+        mirroring the JSON `_g12_signal` field. This is the #2689 fix: the
+        prior code hit the plain-text branch below and glued a bare
+        `resume\\n\\n` prefix onto the actual tool result, which the model
+        read as corrupted tool output (a foreign, unlabeled token on the
+        front of the op result). A labeled frontmatter field is structured
+        metadata the model can attribute correctly, same as the JSON path.
       - Plain-text or non-JSON tool content: prefix with the signal text
         + a blank line for visual separation.
       - Non-string content (= list of content parts or None): leave
@@ -424,6 +433,15 @@ def _apply_g12_signal(messages: list[dict]) -> list[dict]:
             new_last["content"] = (
                 f'{{"_g12_signal": "{signal}", {inner}'
             )
+    elif content.startswith("---\n") and "\n---\n" in content:
+        # #2689: #2425 案B canonical tool-result format `---\n<yaml>---\n<text>`.
+        # Embed the signal as a LABELED frontmatter field (mirroring the JSON
+        # `_g12_signal` field) instead of the bare `resume\n\n` prefix the plain-
+        # text branch below would produce — that prefix read to the model as a
+        # foreign token glued to the front of the op result (corrupted tool
+        # output). Inject after the opening `---\n` delimiter (content[4:] drops
+        # it); the block stays valid YAML frontmatter with `_g12_signal` first.
+        new_last["content"] = f"---\n_g12_signal: {signal}\n{content[4:]}"
     else:
         new_last["content"] = f"{signal}\n\n{content}"
     return messages[:-1] + [new_last]

--- a/tests/test_g12_signal_contract.py
+++ b/tests/test_g12_signal_contract.py
@@ -133,6 +133,74 @@ def test_plain_text_tool_content_gets_prefix() -> None:
     assert new_content.endswith("plain text result")
 
 
+# ── 3b. Canonical frontmatter+text tool content (#2689) ─────────────────────
+# #2425 案B made `---\n<yaml>---\n<text>` the DOMINANT tool-result shape (no
+# JSON envelope). That content does not start with `{`, so it used to fall to
+# the plain-text branch and got a bare `resume\n\n` prefix glued onto the front
+# of the real op result — the model read it as corrupted tool output (#2689).
+# The signal must instead be a LABELED `_g12_signal` frontmatter field, mirroring
+# the JSON `_g12_signal` field.
+
+
+def _canonical_tool_content() -> str:
+    """Real canonical `---\\n<yaml>---\\n<text>` tool content via the production
+    renderer (no mock) — the shape feedback() builds for every tool result."""
+    from reyn.core.offload.seam import render_tool_result
+
+    return render_tool_result(
+        {"op": "read", "status": "ok", "path": "sample.txt"},
+        "Line one of a readable sample file.\nLine two.",
+    )
+
+
+def test_canonical_frontmatter_tool_content_has_no_bare_resume_prefix() -> None:
+    """Tier 2: #2689 regression guard — a canonical frontmatter+text tool result
+    must NOT be sent with a foreign `resume\\n\\n` prefix glued to its front.
+
+    RED before the fix: `_apply_g12_signal` hit the plain-text `else` branch and
+    produced `resume\\n\\n---\\nop: read...` (the exact corrupted payload the
+    reporter captured from REYN_LLM_TRACE_DUMP). GREEN after: the signal is a
+    labeled frontmatter field, so the op result the model reads is untouched.
+    """
+    import yaml
+
+    canonical = _canonical_tool_content()
+    msgs = [
+        {"role": "assistant", "tool_calls": [{"id": "call_1"}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": canonical},
+    ]
+    result = _apply_g12_signal(msgs)
+    sent = result[-1]["content"]
+
+    # Core #2689 guard: no foreign token glued to the front of the op result.
+    assert not sent.startswith("resume"), (
+        "canonical tool content must not carry a bare 'resume' prefix (#2689)"
+    )
+    # The signal is still present — the workaround must not be silently dropped.
+    assert "_g12_signal" in sent
+    # Still a valid frontmatter block, and the signal is a labeled field.
+    assert sent.startswith("---\n")
+    fm_block, body = sent[4:].split("\n---\n", 1)
+    parsed = yaml.safe_load(fm_block)
+    assert parsed["_g12_signal"] == "resume"
+    # Original op metadata + body survive intact (the tool result the model
+    # reads is the real result, not a mangled one).
+    assert parsed["op"] == "read"
+    assert parsed["status"] == "ok"
+    assert body == "Line one of a readable sample file.\nLine two."
+
+
+def test_canonical_frontmatter_does_not_mutate_input() -> None:
+    """Tier 2: #2689 — embedding the signal into canonical content returns a new
+    list + message and leaves the caller's persistent messages untouched (the
+    self-heal property: history/older-context copies stay clean)."""
+    canonical = _canonical_tool_content()
+    msgs = [{"role": "tool", "tool_call_id": "c", "content": canonical}]
+    result = _apply_g12_signal(msgs)
+    assert result is not msgs
+    assert msgs[-1]["content"] == canonical, "must not mutate the input message"
+
+
 # ── 4. Non-string content (= future content-parts API) ──────────────────────
 
 


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2689. Part of #2688 (does NOT close it).

## TL;DR
The visible `resume\n\n` prefix corrupting tool-result `content` is fixed at its **actual** root — which turned out to be **different from the reported hypothesis**. Flagging that divergence prominently for @lead-coder.

## Exact leak mechanism (the reporter's hypothesis was a coincidence)
The reporter attributed the `resume\n\n` prefix to `EMPTY_STOP_RETRY_DIRECTIVE = "resume"` (`router_loop.py:129`) leaking through message assembly. **It is not.** The empty-stop retry directive correctly stays its own standalone `{"role":"user","content":"resume"}` entry — I traced the assembly and confirmed it never merges.

The real source is the **G12 empty-stop-attractor workaround** `_apply_g12_signal` (`src/reyn/llm/llm.py:375`), applied inside `call_llm_tools` at the LLM-call boundary. It embeds `_G12_SIGNAL_TEXT` into the **trailing** `role=tool` message. And `_G12_SIGNAL_TEXT = "resume"` (`llm.py:303`) — the **same string** as the retry directive, *by design* (the comment at `llm.py:300-302` deliberately reuses the "uniform resume" token). That coincidence is why the reporter linked it to the wrong "resume".

**Why it surfaced now:** #2425 案B changed canonical tool-result rendering from a JSON envelope (`{...}`) to frontmatter+text (`---\n<yaml>---\n<text>`). `_apply_g12_signal` had two branches:
- JSON `{...}` → inject an invisible top-level `_g12_signal` field (labeled, structured).
- everything else → **`f"{signal}\n\n{content}"`** — a bare prefix.

Canonical content starts with `---`, not `{`, so it now hits the bare-prefix branch → `resume\n\n---\nop: read\n...` — the exact payload in the issue's raw trace. The model reads a foreign, unlabeled token glued to the front of the op result.

**Scope is broader than reported:** this fires on **every** tool call whose result is the trailing message (G12 on by default), not only after an empty-stop retry. The empty-stop retry in the repro was a coincidental correlation.

**Transient / self-heal (matches the issue):** `_apply_g12_signal` returns `messages[:-1] + [new_last]` — a new list, never mutating the persistent `messages` or `history.jsonl`, and only ever touches `messages[-1]`. So the prefix exists only in the one request where the tool result is trailing; older-context copies stay clean. Exactly the "in-memory only, missed by history review" behavior the reporter observed.

## The fix (root, not a downstream strip)
Add a canonical-frontmatter branch to `_apply_g12_signal`: embed the signal as a **labeled `_g12_signal` frontmatter field** (mirroring the JSON `_g12_signal` field) instead of a bare prefix:

```
---
_g12_signal: resume
op: read
status: ok
path: sample.txt
---
Line one of a readable sample file.
```

This is the root fix, not a band-aid: it does **not** string-strip "resume" downstream. It corrects *why* the token was foreign — the workaround's whole design is "embed a labeled signal field in the trailing tool message" (JSON path already did exactly this); the bare-prefix `else` was only ever a fallback for genuinely unstructured content, and that fallback is unchanged.

**Empty-stop retry behavior preserved:** untouched — the retry still fires and its directive stays a standalone `role=user` message. **G12 workaround preserved:** still fires; only the embedding *format* for the canonical shape changes (labeled field vs bare prefix). Injection is after the opening `---\n` delimiter, so the block stays valid YAML frontmatter with the original op metadata + body intact.

## RED → GREEN evidence
New Tier-2 regression tests in `tests/test_g12_signal_contract.py` drive the **real** `_apply_g12_signal` pure function (no mocks) with a **real** canonical result from the production `render_tool_result`:
- **RED** on unfixed tree (elif branch reverted): `test_canonical_frontmatter_tool_content_has_no_bare_resume_prefix` fails with `content='resume\n\n---\nop: read\nstatus: ok\npath: sample.txt\n---\nLine one...'` — byte-for-byte the reporter's payload.
- **GREEN** after fix: signal is a labeled frontmatter field, frontmatter parses, op metadata + body intact, no bare prefix, input not mutated.

Falsify done via a scratch copy of the fix (never `git checkout` on uncommitted work).

> Note on test surface: the task suggested an LLMReplay-through-`router_loop` test, but `_apply_g12_signal` runs *inside* `call_llm_tools`, which is the exact seam LLMReplay replaces (`_llm_caller`). LLMReplay therefore never observes this signal and structurally cannot catch the bug. The correct surface is the real `_apply_g12_signal` pure function directly — real instance, no mock, fully policy-compliant.

## 4 CI gates (all green locally)
- `ruff check src tests` → **All checks passed!**
- `python scripts/test_tier_audit.py --strict tests/test_g12_signal_contract.py` → **24 inspected, 0 Tier-4 violations**
- `pytest` (repo root) → **7792 passed, 21 skipped**; the 5 failures (`*_routes_mounted` / plugin loader in `tests/web/*`, `tests/test_fp0001_a2a_endpoints.py`) are **pre-existing on clean base 846ff536** (verified by stashing my diff and re-running — same 5 fail), environmental route-mounting, untouched by this change.
- `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` → **OK**

## @lead-coder — heads-up
Root cause diverges from the dispatch brief's hypothesis (G12 signal in `llm.py`, not empty-stop-retry assembly in `router_loop.py`). The fix embeds a labeled signal into the #2425 canonical frontmatter — a small, intent-preserving extension of the existing JSON `_g12_signal` design, not a refactor and not a change to the workaround's firing policy. If you'd prefer a different treatment for the canonical shape (e.g. suppress the G12 signal entirely for canonical content pending re-measurement, given the docstring's caveat that its protective effect is unverified in current contexts), say so and I'll adjust.

## Test plan
- [x] RED confirmed on unfixed tree (exact reporter payload reproduced)
- [x] GREEN after fix (labeled frontmatter field, body intact)
- [x] All 4 CI gates green locally (pytest failures pre-existing, verified)
- [x] Empty-stop retry behavior unchanged (directive stays standalone role=user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)