### PR TITLE
fix: file_* glob/list adapters preserve op dispatch field (canonical "None: ok" data loss) (#2695)

### DIFF
--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -301,9 +301,20 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     legacy_ctx = _build_legacy_op_context(ctx)
     result = await execute_op(op, legacy_ctx)
 
-    # Normalise to {path, entries} shape (= same as session._file_list_directory)
+    # Normalise to {path, entries} shape (= same as session._file_list_directory).
+    # Preserve op="glob" + status + matches so file_to_canonical's glob branch
+    # fires (#2695: dropping op made the mapper fall through to "None: ok",
+    # silently losing the listing). entries is the caller-ergonomic alias;
+    # matches is the field the canonical glob branch renders.
     if result.get("status") == "ok":
-        return {"path": path, "entries": result.get("matches", [])}
+        matches = result.get("matches", [])
+        return {
+            "op": "glob",
+            "status": "ok",
+            "path": path,
+            "entries": matches,
+            "matches": matches,
+        }
     return {"error": result.get("error", "list_directory failed")}
 
 
@@ -351,8 +362,13 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     result = await execute_op(op, legacy_ctx)
 
     # Normalise: surface as {pattern, matches, count} for caller ergonomics.
+    # Preserve op="glob" + status so file_to_canonical's glob branch fires
+    # (#2695: dropping op made the mapper fall through to "None: ok", silently
+    # losing every match). pattern/matches/count stay as the ergonomic fields.
     if result.get("status") == "ok":
         return {
+            "op": "glob",
+            "status": "ok",
             "pattern": combined,
             "matches": result.get("matches", []),
             "count": result.get("count", 0),

--- a/tests/test_2695_file_adapter_canonical_op_preservation.py
+++ b/tests/test_2695_file_adapter_canonical_op_preservation.py
@@ -1,0 +1,120 @@
+"""Tier 2b: #2695 — file_* tool adapters preserve the ``op`` dispatch field.
+
+``file_to_canonical`` (the FP-0056 canonical mapper the file_* ToolDefinitions
+declare) sub-dispatches on the result's ``op`` field to pick a per-op rendering
+(glob → the match paths, read → the content, …). The ``glob_files`` and
+``list_directory`` adapters used to "normalize" their ok result to a
+caller-ergonomic ``{pattern, matches, count}`` / ``{path, entries}`` dict that
+DROPPED ``op`` (and ``status``). With ``op`` absent every branch was skipped and
+the mapper fell through to ``f"{op}: {status}"`` = the literal ``"None: ok"`` —
+silent total loss of the match list to the LLM (#2695, part of the #2688 sweep).
+
+This is a shape-preservation contract at the tool-adapter → canonical-mapper
+boundary: every file_* adapter's ok result must carry the ``op`` the mapper
+dispatches on, so the matches/entries actually render.
+
+Real registry / Workspace / op_runtime — no mocks. Assertions are on the public
+canonical text and the public result ``op`` field (the dispatch contract), never
+on formatting or private state.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import file_to_canonical
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionResolver
+from reyn.tools import get_default_registry
+from reyn.tools.dispatch import invoke_tool
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    events = EventLog()
+    return ToolContext(
+        events=events,
+        permission_resolver=PermissionResolver(
+            config_permissions={"file.read": "allow", "file.write": "allow"},
+            project_root=tmp_path,
+            interactive=False,
+        ),
+        workspace=Workspace(events=events, base_dir=tmp_path),
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _invoke(tmp_path: Path, name: str, args: dict) -> dict:
+    return asyncio.run(invoke_tool(get_default_registry(), name, args, _ctx(tmp_path)))
+
+
+def test_glob_result_renders_matches_not_none_ok(tmp_path, monkeypatch):
+    """Tier 2b: glob_files' canonical text lists the matched paths, not "None: ok"."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "alpha.txt").write_text("a\n")
+    (tmp_path / "beta.txt").write_text("b\n")
+
+    result = _invoke(tmp_path, "glob_files", {"pattern": "*.txt"})
+    # The dispatch field the canonical mapper needs must survive normalization.
+    assert result.get("op") == "glob"
+
+    text = file_to_canonical(result)["text"]
+    assert "alpha.txt" in text and "beta.txt" in text
+    assert text != "None: ok"  # the #2695 silent-loss symptom
+    assert "None" not in text
+
+
+def test_glob_empty_renders_no_matches_not_none_ok(tmp_path, monkeypatch):
+    """Tier 2b: an empty glob renders a readable no-match body, not "None: ok"."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "only.md").write_text("x\n")
+
+    result = _invoke(tmp_path, "glob_files", {"pattern": "*.txt"})
+    assert result.get("op") == "glob"
+    text = file_to_canonical(result)["text"]
+    assert text != "None: ok"
+    assert "no matches" in text.lower()
+
+
+def test_list_directory_renders_entries_not_none_ok(tmp_path, monkeypatch):
+    """Tier 2b: list_directory's canonical text lists the entries, not "None: ok"."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "one.txt").write_text("1\n")
+    (tmp_path / "two.txt").write_text("2\n")
+
+    result = _invoke(tmp_path, "list_directory", {"path": "."})
+    assert result.get("op") == "glob"  # list_directory delegates to the glob op
+
+    text = file_to_canonical(result)["text"]
+    assert "one.txt" in text and "two.txt" in text
+    assert text != "None: ok"
+    assert "None" not in text
+
+
+def test_every_file_adapter_ok_result_carries_op(tmp_path, monkeypatch):
+    """Tier 2b: guard — every file_* adapter's ok result carries a non-None ``op``.
+
+    ``file_to_canonical`` dispatches on ``op``; an adapter that drops it silently
+    routes to the ``"None: ok"`` fallback (the #2695 class). This drives all seven
+    real adapters and asserts the dispatch field is present, so the class cannot
+    silently regress via a new/edited adapter that re-normalizes ``op`` away."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "src.txt").write_text("hello world\n")
+    (tmp_path / "gone.txt").write_text("bye\n")
+
+    ok_calls = [
+        ("read_file", {"path": "src.txt"}),
+        ("grep_files", {"pattern": "hello"}),
+        ("glob_files", {"pattern": "*.txt"}),
+        ("list_directory", {"path": "."}),
+        ("write_file", {"path": "new.txt", "content": "x"}),
+        ("edit_file", {"path": "src.txt", "old_string": "hello", "new_string": "hi"}),
+        ("delete_file", {"path": "gone.txt"}),
+    ]
+    for name, args in ok_calls:
+        result = _invoke(tmp_path, name, args)
+        assert result.get("op") is not None, f"{name} ok-result dropped the op dispatch field"
+        # And the canonical rendering never degrades to the None-dispatch fallback.
+        assert file_to_canonical(result)["text"] != "None: ok", name


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2695. Part of the #2688 sweep (do NOT auto-part of the #2688 sweep).

## Bug
`file__glob` / `glob_files` (and `list_directory`) results reached the LLM as the literal string `"None: ok"` — the matched paths were silently, totally lost. HIGH severity: silent total data loss on a common tool.

## Root cause (tui-coder located precisely)
`file_to_canonical` sub-dispatches on `result["op"]`. `_handle_glob` / `_handle_list` "normalized" their `execute_op` result to a caller-ergonomic dict (`{pattern,matches,count}` / `{path,entries}`) that **dropped `op` and `status`**. With `op` absent, every mapper branch is skipped and it falls through to `f"{op}: {result.get('status','ok')}"` = `"None: ok"`. The mapper's `glob` branch was already correct — it just never got reached.

## Fix
Shape-preservation at the tool-adapter boundary (canonical mapper unchanged): additively re-add `op="glob"` + `status="ok"` to the ok-result of both adapters, preserving the ergonomic fields. `list_directory` also carries a `matches` alias (the field the glob branch renders) alongside `entries`. Error branches (`{error}`) already rendered correctly (the mapper's error check is op-independent) — untouched.

## Per-adapter audit (all 7 file_* adapters)

| adapter | op carried before? | shape | broken? | fixed? |
|---|---|---|---|---|
| `_handle_read` | yes (`op="read"`) | raw `execute_op` | no | n/a |
| `_handle_write` | yes (`op="write"`) | raw `execute_op` | no | n/a |
| `_handle_delete` | yes (`op="delete"`) | raw `execute_op` | no | n/a |
| `_handle_edit` | yes (`op="edit"`) | raw `execute_op` | no | n/a |
| `_handle_grep` | yes (`op="grep"`) | raw `execute_op` | no | n/a |
| `_handle_glob` | **NO** | normalized `{pattern,matches,count}` | **YES** | **YES** |
| `_handle_list` | **NO** | normalized `{path,entries}` | **YES** | **YES** |

Only the two adapters that re-normalize the op-result (glob, list) dropped the dispatch field; the five that return the raw `execute_op` result carry `op` intact. (Verified by driving all seven real adapters — see guard test.)

## Render verification (real adapter → `file_to_canonical`)
- `glob_files *.txt` (2 matches) → `"alpha.txt\nbeta.txt"` (was `"None: ok"`)
- `glob_files` empty → `"(no matches)"` (was `"None: ok"`)
- `list_directory .` → the entry paths (was `"None: ok"`)

## Broader-class audit — CONTAINED to file.py (one sibling flagged, not fixed)
`file_to_canonical` is the **only** canonical mapper that sub-dispatches on a **result field** (`result["op"]`); every other mapper dispatches on the FP-0056 invoked-identity `source` or on body-key presence, so the "adapter drops the dispatch field" class is contained to file.py's glob/list.

**Flag for [lead-coder]** (sibling, out of scope here — your call on a structural guard): `recall`'s defensive missing-arg early-return `{ok:False, error_kind, error_message, missing}` routes through `chunks_to_canonical`, which has **no error branch** (only `result.get("chunks")`), so the `error_message` renders to empty `text` — a different mechanism (mapper-has-no-error-branch, not op-drop) but the same net class (adapter returns a shape its mapper can't render → data loss). Candidate for the FP-0056 coverage gate extension (assert dispatch-field / error-path presence, not just mapper existence). Not fixed in this PR to keep it scoped to #2695.

## RED → GREEN
- RED on original `origin/main` file.py: all 4 tests fail (`glob_files ok-result dropped the op dispatch field`, canonical text `"None: ok"`). Falsified via scratch copy of origin/main's `file.py`, then restored — no `git checkout` of uncommitted work.
- GREEN after fix: `4 passed`.

## Gates (all run locally; PYTHONPATH pinned to this worktree — reyn is editable-installed against the main checkout)
- `ruff check src tests` → **All checks passed**
- `python scripts/test_tier_audit.py --strict <test>` → **4 OK, 0 warnings, 0 errors** (exit 0)
- `pytest` (repo root) → **7818 passed, 21 skipped, 5 failed**. The 5 failures are all web/a2a/mcp-sse/plugin **route-mounting** tests (`test_*_routes_mounted`, `test_loader_disambiguates_via_package_field`) — pre-existing environment failures unrelated to this change (my diff touches only `src/reyn/tools/file.py` + a new test; neither imports web/route code; the 5 fail identically with origin/main's `file.py`).
- `python scripts/verify_module_docstrings.py src/reyn/tools/file.py` → **OK**

## Test plan
- [x] RED reproduced on origin/main (`"None: ok"` / dropped op)
- [x] GREEN after fix (4 passed)
- [x] Render verification for glob / empty-glob / list
- [x] All 4 CI gates run locally (5 unrelated pre-existing web failures noted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)