### PR TITLE
fix: present + render_template chat + pipeline invocation surface (#2692)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -521,6 +521,41 @@ def compact_to_canonical(result: dict) -> CanonicalToolResult:
     return CanonicalToolResult(text=" ".join(parts), attachments=[], source_ref=None, meta={})
 
 
+def present_to_canonical(result: dict) -> CanonicalToolResult:
+    """``present`` op/tool result → canonical (FP-0054 / FP-0056). ``present`` is fire-and-continue: it
+    routes the bulk data to the user surface itself and returns a compact ACK. That ack is an
+    AGENT-facing signal (did the presentation reach the user? did the view bind? which fallback fired?),
+    NOT bulk content — so it renders as a short ``text`` line, not a whole-dict ``structured`` blob (the
+    incident class). Success shape: ``{kind:"present", status:"ok", ok:True, mode, bindings_resolved,
+    bindings_dropped, rows, all_bindings_missed, note?}``. Any non-``ok`` status (``error`` — malformed
+    inline blueprint / XOR violation; ``not_found`` — missing ``data_ref``; ``denied`` — read-authority)
+    surfaces the ``error`` message as ``text`` with ``meta.isError`` so the LLM self-corrects."""
+    status = result.get("status")
+    if status not in (None, "ok"):
+        return CanonicalToolResult(
+            text=str(result.get("error") or f"present {status}"),
+            attachments=[], source_ref=None, meta={"isError": True},
+        )
+    parts: list[str] = ["Presented to the user."]
+    mode = result.get("mode")
+    if mode is not None:
+        parts.append(f"mode={mode}")
+    for key in ("rows", "bindings_resolved"):
+        value = result.get(key)
+        if value is not None:
+            parts.append(f"{key}={value}")
+    dropped = result.get("bindings_dropped")
+    if dropped:
+        parts.append(f"bindings_dropped={len(dropped)}")
+    if result.get("all_bindings_missed"):
+        parts.append("all_bindings_missed=True")
+    text = " ".join(parts)
+    note = result.get("note")
+    if note:
+        text = f"{text}\n{note}"
+    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
+
+
 def judge_output_to_canonical(result: dict) -> CanonicalToolResult:
     """``judge_output`` op result → canonical. The scorer's ``reason`` (its LLM-readable explanation) is
     the ``text``; ``score`` / ``passed`` / ``threshold`` / ``on_fail`` are signal meta (they drive the

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -347,6 +347,10 @@ def _fallback_note(
     )
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import present_to_canonical  # noqa: E402
 
-register("present", handle, canonical=CANONICAL_TODO)
+# FP-0056 burn-down (#2681): the ack is an agent-facing signal (reached-user / view-bind stats),
+# not bulk content, so it maps to a short text line via ``present_to_canonical`` — no longer the
+# provisional ``CANONICAL_TODO``. The tool ToolDefinition (tools/present.py) declares the SAME mapper
+# so identity dispatch (source == "present") resolves it across chat + pipeline + the op path.
+register("present", handle, canonical=present_to_canonical)

--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -619,6 +619,34 @@ def build_tools(
             dispatch_kind=_compact_def.dispatch_kind,
         ))
 
+    # ── #2692: present + render_template (presentation surface) ─────────────────
+    # part of the #2688 sweep. Unconditional (like recall/drop_source §H): present
+    # has no natural window-fill visibility gate — the agent may want to display
+    # bulk data on any turn, and read-authority is enforced at op-exec (data_ref ==
+    # file.read), not by catalog exclusion (the web_fetch posture). Registering one
+    # ToolDefinition each also opens the pipeline surface (bare-name lookup, gate-
+    # ignoring); this section is what surfaces them to the default enumerate-all
+    # chat LLM. Op handler + IR op model unchanged.
+    _present_def = _registry.lookup("present")
+    if _present_def is not None and _present_def.gates.router == "allow":
+        _present_rendered = _present_def.render_for_router()
+        specs.append(ToolSpec(
+            name=_present_rendered["function"]["name"],
+            description=_present_rendered["function"]["description"],
+            parameters=_present_rendered["function"]["parameters"],
+            dispatch_kind=_present_def.dispatch_kind,
+        ))
+
+    _render_template_def = _registry.lookup("render_template")
+    if _render_template_def is not None and _render_template_def.gates.router == "allow":
+        _render_template_rendered = _render_template_def.render_for_router()
+        specs.append(ToolSpec(
+            name=_render_template_rendered["function"]["name"],
+            description=_render_template_rendered["function"]["description"],
+            parameters=_render_template_rendered["function"]["parameters"],
+            dispatch_kind=_render_template_def.dispatch_kind,
+        ))
+
     # ── D. MCP tools (permission-gated) ──────────────────────────────────────
     #
     # FP-0024 Component D: threshold-based switch.

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -103,7 +103,9 @@ def get_default_registry() -> ToolRegistry:
         RUN_PIPELINE_INLINE,
         RUN_PIPELINE_INLINE_ASYNC,
     )
+    from reyn.tools.present import PRESENT
     from reyn.tools.recall import RECALL
+    from reyn.tools.render_template import RENDER_TEMPLATE
     from reyn.tools.reyn_src import (
         REYN_SRC_GLOB,
         REYN_SRC_GREP,
@@ -139,6 +141,12 @@ def get_default_registry() -> ToolRegistry:
     registry.register(RECALL)
     registry.register(DROP_SOURCE)
     registry.register(COMPACT)
+    # #2692 (part of the #2688 sweep): present + render_template invocation surface.
+    # One registration each opens BOTH chat (build_tools + gates.router="allow") and
+    # pipeline (bare-name lookup) from the single unified registry — the op handlers
+    # already existed; only the ToolDefinition was missing.
+    registry.register(PRESENT)
+    registry.register(RENDER_TEMPLATE)
     # Task ops (#1953 dynamic-wire): the 12 task.* ToolDefinitions, derived
     # single-source from the IROp models (tools/task_ops.py).
     from reyn.tools.task_ops import TASK_TOOL_DEFINITIONS

--- a/src/reyn/tools/present.py
+++ b/src/reyn/tools/present.py
@@ -1,0 +1,145 @@
+"""present ToolDefinition (#2692 / FP-0054 / FP-0055) — chat + pipeline invocation surface.
+
+The ``present`` op handler (``op_runtime/present.py``) and IR op model (``PresentIROp``) already
+existed and worked, but had NO invocation surface: no ``ToolDefinition`` meant the default chat JSON
+tool catalog never offered it AND ``registry.lookup("present")`` returned ``None`` so a pipeline
+``tool: present`` step raised a "not a registered tool" error. The headline present-layer arc was
+reachable from nowhere (#2688 sweep).
+
+This module is the additive fix: a single ``ToolDefinition`` registered in ``get_default_registry()``
+opens BOTH surfaces from one lever (they draw the same unified registry) — pipeline via bare-name
+lookup, chat via ``gates.router="allow"`` + the ``build_tools`` section. The handler builds the real
+``PresentIROp`` and dispatches through ``execute_op`` with the real ``OpContext`` (the ``compact``
+precedent, ``tools/compact.py``), so the existing op handler enforces ``present``'s ``data_ref``
+read-authority (identical to ``file.read``) — the tool adds no permission bypass. Op handler + IR op
+model are UNCHANGED. Tool name == op kind (``"present"``) so FP-0056 identity dispatch resolves the
+same canonical declaration across every surface.
+
+Tiered schema (minimise LLM burden — "display is free"): the minimal call is ``present(data_ref=...)``,
+which routes straight to the stage-3 default-viewer synthesis (no view authoring). ``view`` names a
+registered presentation; ``blueprint`` is the advanced declarative component tree. The XOR constraints
+(exactly one of ``data_ref`` / ``data_inline``; at most one of ``view`` / ``blueprint``) are enforced
+by the ``PresentIROp`` validator — surfaced here in the description, not re-implemented.
+
+Per ADR-0026: the ToolDefinition lives here; registration is in get_default_registry() in
+tools/__init__.py.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.core.offload.canonical import present_to_canonical
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_PRESENT_DESCRIPTION = (
+    "Show bulk data to the user directly, WITHOUT re-typing it through your own output tokens. "
+    "Use this after a tool returns a large result (a file, a query result, a list) that the user "
+    "should see: pass a reference to it and the presentation layer renders it for them. "
+    "Simple path — just pass 'data_ref' (a zone-readable path or an offloaded result ref) and it is "
+    "shown with a sensible default view; you do not need to design anything. Optionally pass 'view' "
+    "(a registered presentation name) to use a named layout, or 'blueprint' (advanced: a declarative "
+    "component tree) for full control — at most one of the two. Pass 'data_inline' INSTEAD of "
+    "'data_ref' only for small data already in your context (exactly one of data_ref / data_inline). "
+    "Reading a 'data_ref' requires the same file-read permission as reading the file. Returns a "
+    "compact acknowledgement (what reached the user and whether the view bound), not the data itself."
+)
+
+_PRESENT_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "data_ref": {
+            "type": "string",
+            "description": (
+                "What to show: a zone-readable path or an offloaded-result reference. Read under the "
+                "same authority as file.read. Provide exactly one of data_ref / data_inline."
+            ),
+        },
+        "data_inline": {
+            "type": "object",
+            "description": (
+                "Small data already in your context, passed directly instead of a ref. Provide "
+                "exactly one of data_ref / data_inline."
+            ),
+        },
+        "view": {
+            "type": "string",
+            "description": (
+                "Optional: the name of a registered presentation (presentations.yaml) to render "
+                "with. Omit for the default view. At most one of view / blueprint."
+            ),
+        },
+        "blueprint": {
+            "type": "object",
+            "description": (
+                "Optional (advanced): an inline declarative component tree with JSON-Pointer "
+                "bindings for full control over the layout. Prefer the simple default (omit both "
+                "view and blueprint) unless you specifically need a custom layout. At most one of "
+                "view / blueprint."
+            ),
+        },
+    },
+    "required": [],
+}
+
+
+async def _handle_present(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Dispatch the present op via op_runtime.
+
+    Builds a PresentIROp from the tool args and calls the registered present handler with the real
+    OpContext from ctx.router_state's factory (the compact.py precedent), or a minimal context
+    otherwise. The real OpContext carries the caller's permission_decl so the op handler enforces
+    data_ref read-authority == file.read — the tool never bypasses it. An arg-level XOR violation
+    (both/neither source, both view+blueprint) is caught as a clean error, not a crash.
+    """
+    from pydantic import ValidationError
+
+    from reyn.core.op_runtime import execute_op
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.schemas.models import PresentIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    try:
+        op = PresentIROp(
+            kind="present",
+            data_ref=args.get("data_ref"),
+            data_inline=args.get("data_inline"),
+            view=args.get("view"),
+            blueprint=args.get("blueprint"),
+        )
+    except ValidationError as exc:
+        return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
+
+    if (
+        ctx.router_state is not None
+        and ctx.router_state.op_context_factory is not None
+    ):
+        legacy_ctx = ctx.router_state.op_context_factory()
+    else:
+        # Minimal context: no presentation surface wired and an empty permission_decl
+        # (deny-by-default read-authority). The op still runs — data_ref reads resolve
+        # through the same file.read gate, so an unauthorized ref is denied, never
+        # bypassed. #1673: never resolver=None (the bug-class invariant).
+        legacy_ctx = OpContext(
+            workspace=ctx.workspace,
+            events=ctx.events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=ctx.permission_resolver,
+            actor="",
+            subscribers=getattr(ctx.events, "subscribers", []),
+            resolver=ctx.resolver,
+        )
+
+    return await execute_op(op, legacy_ctx)
+
+
+PRESENT = ToolDefinition(
+    canonical=present_to_canonical,
+    name="present",
+    router_dispatched=True,
+    description=_PRESENT_DESCRIPTION,
+    parameters=_PRESENT_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_present,
+    category="presentation",
+    purity="side_effect",
+)

--- a/src/reyn/tools/render_template.py
+++ b/src/reyn/tools/render_template.py
@@ -1,0 +1,150 @@
+"""render_template ToolDefinition (#2692 / FP-0055) — chat + pipeline invocation surface.
+
+The ``render_template`` op handler (``op_runtime/render_template.py``) and IR op model
+(``RenderTemplateIROp``) already existed, but had NO ``ToolDefinition`` — so the default chat catalog
+never offered it and ``registry.lookup("render_template")`` returned ``None``, making a pipeline
+``tool: render_template`` step raise "not a registered tool". This module adds the single
+``ToolDefinition`` that opens BOTH surfaces from the one unified registry (pipeline via bare-name
+lookup, chat via ``gates.router="allow"`` + the ``build_tools`` section), mirroring ``tools/compact.py``.
+
+``render_template`` is a sandboxed producer: ``data + Jinja2 template → string``. It has no sink — the
+rendered string comes back as an ordinary op result (canonical ``text``) the caller routes wherever it
+wants (a ``present``, a ``write_file`` step, a pipeline ``ctx.<name>``). The handler builds the real
+``RenderTemplateIROp`` and dispatches through ``execute_op`` with the real ``OpContext``, so
+``template_ref`` / ``data_ref`` reads go through the same ``file.read`` gate the op already enforces —
+no permission bypass. Op handler + IR op model UNCHANGED. Tool name == op kind
+(``"render_template"``) so FP-0056 identity dispatch reuses the existing op canonical mapper
+(``render_template_to_canonical``) across every surface.
+
+The XOR constraints (exactly one of ``template`` / ``template_ref``; exactly one of ``data_ref`` /
+``data_inline``) are enforced by the ``RenderTemplateIROp`` validator — surfaced in the description,
+not re-implemented.
+
+Per ADR-0026: the ToolDefinition lives here; registration is in get_default_registry() in
+tools/__init__.py.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.core.offload.canonical import render_template_to_canonical
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_RENDER_TEMPLATE_DESCRIPTION = (
+    "Render a Jinja2 template against structured data into a plain string. A sandboxed producer: it "
+    "writes nothing and shows nothing — it returns the rendered text, which you then route wherever "
+    "you want (show it with 'present', write it with a file step, or pass it downstream in a "
+    "pipeline). Provide exactly one template source (inline 'template' text, or 'template_ref' — a "
+    "zone-readable template file path) and exactly one data source ('data_inline' — small data in "
+    "your context, or 'data_ref' — a zone-readable path). The data binds under 'data' in the template "
+    "(e.g. {{ data.results[0].title }}). 'undefined' controls unbound variables: 'strict' (default) "
+    "errors naming the missing name; 'lenient' renders them empty and reports them. Reading a "
+    "template_ref / data_ref requires the same permission as reading the file."
+)
+
+_RENDER_TEMPLATE_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "template": {
+            "type": "string",
+            "description": (
+                "Inline Jinja2 source text. Provide exactly one of template / template_ref."
+            ),
+        },
+        "template_ref": {
+            "type": "string",
+            "description": (
+                "A zone-readable path to a template file (read as raw source text under file.read "
+                "authority). Provide exactly one of template / template_ref."
+            ),
+        },
+        "data_ref": {
+            "type": "string",
+            "description": (
+                "A zone-readable path whose value binds under 'data' in the template. Read under the "
+                "same authority as file.read. Provide exactly one of data_ref / data_inline."
+            ),
+        },
+        "data_inline": {
+            "type": "object",
+            "description": (
+                "Small data already in your context, bound under 'data' in the template. Provide "
+                "exactly one of data_ref / data_inline."
+            ),
+        },
+        "undefined": {
+            "type": "string",
+            "enum": ["strict", "lenient"],
+            "description": (
+                "Undefined-variable policy. 'strict' (default) errors naming the missing variable; "
+                "'lenient' renders undefined as empty and reports the unbound names."
+            ),
+        },
+    },
+    "required": [],
+}
+
+
+async def _handle_render_template(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Dispatch the render_template op via op_runtime.
+
+    Builds a RenderTemplateIROp from the tool args and calls the registered handler with the real
+    OpContext from ctx.router_state's factory (the compact.py precedent), or a minimal context
+    otherwise. The real OpContext carries the caller's permission_decl so template_ref / data_ref
+    reads go through the file.read gate — the tool never bypasses it. An arg-level XOR violation is
+    caught as a clean error, not a crash.
+    """
+    from pydantic import ValidationError
+
+    from reyn.core.op_runtime import execute_op
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.schemas.models import RenderTemplateIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    undefined = args.get("undefined")
+    try:
+        op = RenderTemplateIROp(
+            kind="render_template",
+            template=args.get("template"),
+            template_ref=args.get("template_ref"),
+            data_ref=args.get("data_ref"),
+            data_inline=args.get("data_inline"),
+            undefined=undefined if undefined is not None else "strict",
+        )
+    except ValidationError as exc:
+        return {"kind": "render_template", "status": "error", "ok": False, "error": str(exc)}
+
+    if (
+        ctx.router_state is not None
+        and ctx.router_state.op_context_factory is not None
+    ):
+        legacy_ctx = ctx.router_state.op_context_factory()
+    else:
+        # Minimal context: an empty permission_decl (deny-by-default read-authority).
+        # An inline-only render is pure computation; a ref-read is denied unless the
+        # real OpContext (with the caller's grants) is threaded in. #1673: never
+        # resolver=None (the bug-class invariant).
+        legacy_ctx = OpContext(
+            workspace=ctx.workspace,
+            events=ctx.events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=ctx.permission_resolver,
+            actor="",
+            subscribers=getattr(ctx.events, "subscribers", []),
+            resolver=ctx.resolver,
+        )
+
+    return await execute_op(op, legacy_ctx)
+
+
+RENDER_TEMPLATE = ToolDefinition(
+    canonical=render_template_to_canonical,
+    name="render_template",
+    router_dispatched=True,
+    description=_RENDER_TEMPLATE_DESCRIPTION,
+    parameters=_RENDER_TEMPLATE_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_render_template,
+    category="presentation",
+    purity="read_only",
+)

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -43,6 +43,9 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "list_mcp_prompts", "get_mcp_prompt",
     "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
     "recall", "drop_source", "compact",
+    # #2692 (part of the #2688 sweep): present + render_template gained a ToolDefinition
+    # (router_dispatched=True) so chat + pipeline can reach the existing op handlers.
+    "present", "render_template",
     "list_actions", "search_actions", "describe_action", "invoke_action",
 })
 

--- a/tests/test_2692_present_render_template_invocation_surface.py
+++ b/tests/test_2692_present_render_template_invocation_surface.py
@@ -1,0 +1,257 @@
+"""#2692 — present + render_template are reachable from chat AND pipeline (part of the #2688 sweep).
+
+The bug: the ``present`` / ``render_template`` op handlers existed and worked, but neither had a
+``ToolDefinition``. So the default chat JSON tool catalog never offered them (0/69) AND
+``registry.lookup("present")`` returned ``None`` → a pipeline ``tool: present`` step raised a
+PipelineExecutionError ("not a registered tool"). The headline present-layer arc was reachable from
+nowhere.
+
+The fix registers one ``ToolDefinition`` per op in the single unified registry, which opens BOTH
+surfaces (chat via build_tools + gates.router="allow"; pipeline via bare-name lookup). These are the
+anti-regression proofs on both surfaces + the read-authority-preservation, tool→op bridge, tiered
+schema, and FP-0056 canonical-declaration invariants. Real Workspace / PermissionResolver / EventLog /
+PipelineExecutor — no collaborator mocks; assertions on the public op result and the built catalog,
+never private state or exact rendered whitespace.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import canonical_declaration, to_canonical
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.router_tools import build_tools
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.tools import RouterCallerState, ToolContext, get_default_registry
+from reyn.tools.pipeline_verbs import _make_tool_dispatch
+from reyn.tools.present import _handle_present
+from reyn.tools.render_template import _handle_render_template
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _resolver(tmp_path: Path, config_permissions: dict | None = None) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions=config_permissions or {},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _tool_ctx(
+    tmp_path: Path,
+    resolver: PermissionResolver | None,
+    *,
+    with_factory: bool = False,
+) -> ToolContext:
+    """A real ToolContext. ``with_factory=False`` exercises the minimal-OpContext path
+    (deny-by-default read-authority); ``with_factory=True`` threads a real OpContext via
+    ``router_state.op_context_factory`` (the chat precedent)."""
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=resolver)
+    router_state = None
+    if with_factory:
+        def _factory() -> OpContext:
+            return OpContext(
+                workspace=ws,
+                events=events,
+                permission_decl=PermissionDecl(),
+                permission_resolver=resolver,
+                actor="t2692",
+            )
+        router_state = RouterCallerState(op_context_factory=_factory)
+    return ToolContext(
+        events=events,
+        permission_resolver=resolver,
+        workspace=ws,
+        caller_kind="router",
+        router_state=router_state,
+    )
+
+
+# ── registry wiring (the root cause) ─────────────────────────────────────────
+
+
+def test_present_and_render_template_resolve_in_the_default_registry():
+    """Tier 2: registry.lookup resolves both — the #2692 bug was exactly that these
+    returned None (no ToolDefinition), so pipeline + chat could not reach the ops."""
+    registry = get_default_registry()
+    assert registry.lookup("present") is not None
+    assert registry.lookup("render_template") is not None
+
+
+# ── anti-regression: chat surface (reverses build_tools 0/69) ────────────────
+
+
+def test_build_tools_contains_present_and_render_template():
+    """Tier 2: the default chat catalog (build_tools output) now advertises present +
+    render_template — directly reversing the observed 0/69 (unreachable from chat)."""
+    tools = build_tools([{"name": "a1", "description": "d"}])
+    names = {t["function"]["name"] for t in tools}
+    assert "present" in names
+    assert "render_template" in names
+
+
+# ── anti-regression: pipeline surface (reverses PipelineExecutionError) ──────
+
+
+@pytest.mark.asyncio
+async def test_pipeline_present_step_reaches_the_op():
+    """Tier 2: a real pipeline `tool: present` step resolves via registry.lookup and
+    reaches execute_op — returning the present ack, NOT the prior 'not a registered
+    tool' PipelineExecutionError. data_inline avoids the read-authority gate so this
+    isolates the dispatch-resolution reversal."""
+    ctx = _tool_ctx(Path("/tmp"), None, with_factory=True)
+    pipeline = Pipeline(
+        steps=[
+            ToolStep(
+                name="present",
+                args={"data_inline": {"title": "Q3", "rows": [1, 2, 3]}},
+                output="ack",
+            ),
+        ]
+    )
+    result = await PipelineExecutor().run(
+        pipeline, {}, tool_dispatch=_make_tool_dispatch(ctx), state_log=None,
+        run_id="run-2692-present",
+    )
+    # The step's output carries the present op ack — proof the op ran (not an error).
+    store = result.named_stores["ack"]
+    assert store is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_render_template_step_reaches_the_op():
+    """Tier 2: a real pipeline `tool: render_template` step resolves + reaches
+    execute_op, returning the rendered string — reversing the prior PipelineExecutionError."""
+    ctx = _tool_ctx(Path("/tmp"), None, with_factory=True)
+    pipeline = Pipeline(
+        steps=[
+            ToolStep(
+                name="render_template",
+                args={"template": "hi {{ data.name }}", "data_inline": {"name": "reyn"}},
+                output="rendered",
+            ),
+        ]
+    )
+    result = await PipelineExecutor().run(
+        pipeline, {}, tool_dispatch=_make_tool_dispatch(ctx), state_log=None,
+        run_id="run-2692-render",
+    )
+    # The rendered string reached the step store (canonical text of the producer).
+    store = result.named_stores["rendered"]
+    assert "hi reyn" in json.dumps(store)
+
+
+# ── tool → op bridge builds the correct IR op ────────────────────────────────
+
+
+def test_present_tool_builds_present_op_and_reaches_handler():
+    """Tier 1: the present tool handler builds a real PresentIROp from its args and
+    dispatches through execute_op — the minimal data_inline call routes to the stage-3
+    default viewer (mode='default') and acks ok."""
+    ctx = _tool_ctx(Path("/tmp"), None)
+    result = _run(_handle_present({"data_inline": {"rows": [{"a": 1}]}}, ctx))
+    assert result["kind"] == "present"
+    assert result["status"] == "ok"
+    assert result["mode"] == "default"
+
+
+def test_render_template_tool_builds_op_and_renders():
+    """Tier 1: the render_template tool handler builds a real RenderTemplateIROp and the
+    op renders the inline template against the inline data (round-trips the args)."""
+    ctx = _tool_ctx(Path("/tmp"), None)
+    result = _run(_handle_render_template(
+        {"template": "value={{ data.x }}", "data_inline": {"x": 42}}, ctx,
+    ))
+    assert result["kind"] == "render_template"
+    assert result["status"] == "ok"
+    assert "value=42" in result["rendered"]
+
+
+# ── read-authority equivalence: present tool denial ⇔ file.read denial ───────
+
+
+def test_present_tool_data_ref_denied_iff_file_read_denied(tmp_path, monkeypatch):
+    """Tier 1: a present tool data_ref read goes through the SAME gate as file.read — a
+    config file.read:deny denies BOTH. Proves the tool adds no read-authority bypass
+    (real resolver, not None). Falsify (allow) below."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data.json").write_text(json.dumps({"x": 1}))
+    deny = _resolver(tmp_path, {"file": {"read": "deny"}})
+    ctx = _tool_ctx(tmp_path, deny)
+    result = _run(_handle_present({"data_ref": "data.json"}, ctx))
+    assert result["status"] == "denied"
+    # file.read denied on the same path (the equivalence, both directions).
+    with pytest.raises(PermissionError):
+        _run(deny.require_file_read(PermissionDecl(), str(tmp_path / "data.json"), "t"))
+
+
+def test_present_tool_data_ref_allowed_when_file_read_allowed(tmp_path, monkeypatch):
+    """Tier 1: falsify direction — with read allowed (default CWD zone) the same
+    present(data_ref) presents ok, so the denial above is a real gate, not a blanket
+    refusal. Also the 'minimal call = present(data_ref)' tiered-schema path."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data.json").write_text(json.dumps({"rows": [1, 2]}))
+    allow = _resolver(tmp_path)
+    ctx = _tool_ctx(tmp_path, allow)
+    result = _run(_handle_present({"data_ref": "data.json"}, ctx))
+    assert result["status"] == "ok"
+    assert result["mode"] == "default"
+
+
+# ── tiered schema: both view AND blueprint → reject ──────────────────────────
+
+
+def test_present_tool_rejects_both_view_and_blueprint():
+    """Tier 1: the IR op validator's 'at most one of view / blueprint' XOR is surfaced
+    (not re-implemented) — passing both is a clean error, not a crash."""
+    ctx = _tool_ctx(Path("/tmp"), None)
+    result = _run(_handle_present(
+        {"data_inline": {"x": 1}, "view": "some_view", "blueprint": {"kind": "table"}},
+        ctx,
+    ))
+    assert result["status"] == "error"
+
+
+def test_render_template_tool_rejects_both_template_and_template_ref():
+    """Tier 1: render_template's 'exactly one of template / template_ref' XOR is surfaced
+    from the IR op validator — passing both is a clean error."""
+    ctx = _tool_ctx(Path("/tmp"), None)
+    result = _run(_handle_render_template(
+        {"template": "x", "template_ref": "t.j2", "data_inline": {"x": 1}}, ctx,
+    ))
+    assert result["status"] == "error"
+
+
+# ── FP-0056: both new tools carry a canonical declaration ────────────────────
+
+
+def test_present_and_render_template_have_canonical_declarations():
+    """Tier 1: both tool names resolve to a real (callable) canonical mapper by invoked
+    identity (tool name == op kind), keeping the FP-0056 coverage gate green — present
+    ships a real text mapper (no longer CANONICAL_TODO)."""
+    assert callable(canonical_declaration("present"))
+    assert callable(canonical_declaration("render_template"))
+
+
+def test_present_ack_canonicalizes_to_text_not_structured():
+    """Tier 1: a present ack normalizes to a short canonical `text` (agent-facing signal),
+    NOT a whole-dict `structured` attachment — guards against the FP-0056 whole-dict gap
+    for this producer."""
+    ack = {
+        "kind": "present", "status": "ok", "ok": True, "mode": "default",
+        "bindings_resolved": 2, "bindings_dropped": [], "rows": 3,
+        "all_bindings_missed": False,
+    }
+    canonical = to_canonical(ack, source="present")
+    assert canonical["text"]
+    assert not canonical["attachments"]

--- a/tests/test_fp0056_canonical_coverage_gate.py
+++ b/tests/test_fp0056_canonical_coverage_gate.py
@@ -71,7 +71,8 @@ _CANONICAL_TODO_GRANDFATHERED = frozenset({
     "list_memory",
     "mcp_install_local", "mcp_install_package", "mcp_install_registry", "mcp_search_registry",
     "pipeline_install_local", "pipeline_install_source",
-    "present",
+    # #2692 burn-down: ``present`` now ships a real text mapper (its ack is an agent-facing
+    # signal, not bulk content) — removed from the ledger (the ratchet set only shrinks).
     "remember_agent", "remember_shared",
     "search_actions",
     "session_spawn",

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -101,6 +101,16 @@ _NOT_EXTERNAL = {
     "list_agents", "describe_agent",
     "list_actions", "search_actions", "describe_action",
     "list_mcp_servers", "cron_list",
+    # — presentation (#2692, part of the #2688 sweep) —
+    # present: fire-and-continue → returns a compact ACK (reached-user + view-bind
+    # stats), NOT the presented data itself → no external content forwarded (same
+    # "status ACK, not content" rationale as topology_create / the installers).
+    "present",
+    # render_template: returns the rendered string, derived from a template + data.
+    # A data_ref/template_ref reads file content — the same agent-work-product /
+    # file-content class as read_file (the deferred fast-follow, scan-only), not a
+    # relay of server/internet content.
+    "render_template",
     # — control / orchestration —
     "compact",
     # invoke_action: generic dispatcher — trust resolved by the EFFECTIVE inner

--- a/tests/test_router_tools.py
+++ b/tests/test_router_tools.py
@@ -42,6 +42,12 @@ EXPECTED_TOOL_NAMES = [
     # when the ToolRegistry contains them (B17-S6-1 / B17-S8-2 fix).
     "recall",
     "drop_source",
+    # present + render_template (#2692, part of the #2688 sweep) — always exposed
+    # so chat can reach the existing present-layer ops (read-authority is enforced
+    # at op-exec, not by catalog exclusion; the pipeline surface opens from the same
+    # single registration).
+    "present",
+    "render_template",
     # compact (#272/#1128) is NOT in the baseline — it is visibility-gated
     # (compact_visible) and only appears when the window is filling, paired
     # with the context-size signal (see test_compact_visible_gates_tool).
@@ -294,7 +300,8 @@ def test_total_tool_count_with_full_permissions():
     + 2 web E1+E2 (web_search + web_fetch always on since FP-0022; #1449
     retired read_tool_result E3) + 4 MCP D1-D4
     + 2 reyn_src F1-F2 + 1 plan G1
-    + 2 RAG H1-H2 (recall + drop_source) = 26 tools total.
+    + 2 RAG H1-H2 (recall + drop_source)
+    + 2 presentation (present + render_template, #2692) = 28 tools total.
     FP-0032: D4 describe_mcp_tool added alongside D1-D3.
     web_fetch_allowed param is kept for backward compat but now a no-op.
     """


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2692. Part of the #2688 sweep.

## The bug
The `present` and `render_template` **op handlers** (`core/op_runtime/present.py`, `render_template.py`) and **IR op models** (`PresentIROp`, `RenderTemplateIROp`) existed and worked — but neither op had a **`ToolDefinition`**. So:
- **chat**: the default JSON tool catalog never offered them (0/69) — the owner ran `reyn` and was told "no present tool".
- **pipeline**: `registry.lookup("present")` returned `None`, so a `tool: present` step raised `PipelineExecutionError` ("not a registered tool").

The headline present-layer arc (FP-0054/FP-0055) delivered zero value because it was reachable from **nowhere**.

## The fix — additive, one lever, two surfaces
`build_tools` (`runtime/router_tools.py`) and pipeline tool-step dispatch (`tools/pipeline_verbs.py`) **both draw from the same `get_default_registry()`**. So registering **one `ToolDefinition` per op** opens both surfaces:

| surface | reach mechanism (after fix) |
|---|---|
| **pipeline `tool:` step** | registry registration alone (bare-name lookup, gate-ignoring) |
| **default chat (JSON tool)** | registration + `gates.router="allow"` + a `build_tools` section (unconditional, like `recall`/`drop_source`) |

Op handlers + IR op models are **UNCHANGED**. New: `tools/present.py`, `tools/render_template.py` (modeled on the `tools/compact.py` op-backed-tool precedent), their registration in `get_default_registry()`, and the two `build_tools` sections.

- **Handler builds the real IR op** and calls `execute_op` with a **real `OpContext`** (via `ctx.router_state.op_context_factory()`, the compact pattern). This makes the existing op handler enforce **`present`'s `data_ref` read-authority == `file.read`** — the tool adds no permission bypass. Both surfaces converge on the same shared execution core (resolve_present_source / binding / guard / renderer / 4-stage fallback; render_template = Jinja producer) — no surface-dependent branching.
- **Tool name == op kind** (`"present"` / `"render_template"`) so FP-0056 identity dispatch resolves the same canonical declaration across chat + pipeline + the op path.
- **Tiered schema** (minimize LLM burden): `present` minimal call = `present(data_ref=...)` → stage-3 default-viewer synthesis (no view authoring); `view` (registered name, optional) / `blueprint` (advanced). `render_template` = `template` XOR `template_ref` / `data_ref` XOR `data_inline` / `undefined`. The XOR constraints are enforced by the existing IR op validators — surfaced in the tool schema/description, not re-implemented (an arg-level violation is caught as a clean error, not a crash).

## FP-0056 canonical declaration
- **`render_template`**: reuses the existing op canonical mapper `render_template_to_canonical`.
- **`present`**: the op previously carried `CANONICAL_TODO`. Since the ack is an agent-facing signal (reached-user / view-bind stats), not bulk content, this ships a **real text mapper `present_to_canonical`** and **burns down** `present` from `_CANONICAL_TODO_GRANDFATHERED` (the ratchet set only shrinks). Both the op registration and the ToolDefinition declare the SAME mapper (idempotent identity dispatch).

## "phase" NOT built
Per the architect's **final** #2692 comment: invocation surface = **chat + pipeline only**. "phase" is a deprecated internal execution-layer concept, not a surface — the earlier "chat+pipeline+phase" framing was superseded and is not built for.

## Both-surface anti-regression (RED → GREEN)
`tests/test_2692_present_render_template_invocation_surface.py`:
- **chat**: `build_tools(...)` output **contains** `present` + `render_template` (reverses 0/69).
- **pipeline**: real `ToolStep(name="present")` / `render_template` through `PipelineExecutor` + `_make_tool_dispatch` **resolves via registry.lookup and reaches `execute_op`** (reverses the `PipelineExecutionError`).
- tool→op bridge builds the correct IR op (real args round-trip); **read-authority equivalence** (present tool `data_ref` denied ⇔ `file.read` denied, real resolver, both directions); FP-0056 canonical declaration exists for both; tiered schema (`present(data_ref)` alone → stage-3; both view+blueprint → reject).

**Falsified RED on `origin/main`** (src stashed): `present`/`render_template` absent from build_tools AND `registry.lookup` returns `None` — GREEN with the fix.

## Deliberate golden-list updates (the gates working, not breaks)
- `test_2123_router_dispatch_sot_1953.py`: added `present`, `render_template` to `_EXPECTED_DISPATCH` (they carry `router_dispatched=True`).
- `test_router_tools.py`: added both to `EXPECTED_TOOL_NAMES`.
- `test_returns_external_content_flagset_1822.py`: classified both in `_NOT_EXTERNAL` (present = compact ACK, no content forwarded; render_template = same file-content-derived class as read_file).
- `test_fp0056_canonical_coverage_gate.py`: removed `present` from the CANONICAL_TODO ledger (burn-down).

## Gate results (local, all 4 CI gates)
- `ruff check src tests` — **pass**.
- `python scripts/test_tier_audit.py --strict <5 changed test files>` — **47 OK, 0 warnings, 0 Tier-4**.
- `pytest` (repo root) — **7830 passed, 21 skipped; 5 failed** — all 5 are **pre-existing** route-mounting tests (`test_a2a`, `test_mcp_sse`, `test_resources_router`, `test_plugin_loader`, `test_fp0001_a2a_endpoints` — optional web deps not enabled in this env; **verified failing identically on clean HEAD** without this change).
- `python scripts/verify_module_docstrings.py <6 changed src files>` — **pass**.

## Test plan
- [x] Both-surface anti-regression falsified RED on origin/main, GREEN with fix.
- [x] read-authority equivalence proven with the real PermissionResolver (no mock).
- [x] All 4 CI gates run to completion locally.
- [x] Confirmed the 5 remaining pytest failures pre-exist on clean HEAD (route-mounting / optional web deps, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
