### PR TITLE
fix: ConsoleChatRenderer renders present op output in --cui plain mode

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -145,6 +145,25 @@ class ConsoleChatRenderer(ChatRenderer):
 
     def message(self, msg: OutboxMessage) -> None:
         self._clear_transient()
+        if msg.kind == "presentation":
+            # FP-0054 PR-B gap (issue #2701): this plain (--cui) renderer never had
+            # `format_inline_message`'s presentation handling, so a `present` op's
+            # result was silently dropped here (rendered nowhere, the OS-level op
+            # itself succeeded). Render via a plain (no ANSI) Console so this
+            # renderer's existing no-color contract holds — same node→renderable
+            # conversion `InlineChatRenderer` uses, just captured as plain text.
+            from io import StringIO as _StringIO
+
+            from rich.console import Console
+
+            from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+            buf = _StringIO()
+            Console(file=buf, color_system=None, width=100).print(
+                render_presentation_nodes(msg.meta.get("nodes", []))
+            )
+            self._write(buf.getvalue())
+            self._transient_active = False
+            return
         kind_prefix = self._PREFIX.get(msg.kind, "")
         meta_prefix = _meta_prefix(msg.meta)
         # Inject meta prefix between kind tag and text so logs read

--- a/tests/test_present_renderer_fp0054_prb.py
+++ b/tests/test_present_renderer_fp0054_prb.py
@@ -190,6 +190,35 @@ def test_format_inline_message_dispatches_presentation_kind() -> None:
     assert "hello from present" in console.file.getvalue()
 
 
+def test_console_chat_renderer_renders_presentation_kind_issue_2701() -> None:
+    """Tier 2: RED→GREEN regression for issue #2701 — `--cui` (`reyn chat --cui`)
+    uses `ConsoleChatRenderer`, not `InlineChatRenderer`. PR-B originally wired
+    `kind="presentation"` only into `format_inline_message` (consumed by
+    `InlineChatRenderer`), so `ConsoleChatRenderer.message()` fell through to its
+    generic branch and printed nothing (`msg.text` is deliberately empty; the
+    render model lives in `msg.meta["nodes"]`) — a `present` op succeeded at the
+    OS level but showed the user nothing in `--cui` mode. RED against the
+    pre-fix code (empty output); GREEN once `ConsoleChatRenderer.message()` also
+    renders `meta["nodes"]`."""
+    import sys as _sys
+    from io import StringIO as _StringIO
+
+    from reyn.interfaces.repl.renderer import ConsoleChatRenderer
+
+    renderer = ConsoleChatRenderer()
+    msg = OutboxMessage(kind="presentation", text="", meta={"nodes": [
+        {"component": "text", "text": "hello from present cui"},
+    ]})
+    captured = _StringIO()
+    real_stdout = _sys.__stdout__
+    _sys.__stdout__ = captured
+    try:
+        renderer.message(msg)
+    finally:
+        _sys.__stdout__ = real_stdout
+    assert "hello from present cui" in captured.getvalue()
+
+
 # ── 5. op_runtime/present.py surface derivation + renderer call ─────────────
 
 


### PR DESCRIPTION
**[tui-coder]** — Closes #2701, part of #2688 (present-layer arc real-environment verification).

## Summary
While re-verifying the present/render_template invocation-surface fix (#2692/#2700) live via `reyn chat --cui`, found that a `present` op succeeds at the OS level (audit event confirms `bindings_resolved: 1`, ack `ok: true`) but shows the user **nothing** — a self-caught gap in my own PR-B (#2661) scope.

**Root cause**: `--cui` uses `ConsoleChatRenderer` (confirmed via `logger_factory.py::make_chat_renderer`), not `RichChatRenderer` (which is dead code — grepped, never instantiated anywhere in the codebase). PR-B wired `kind="presentation"` handling only into `format_inline_message()` (consumed by `InlineChatRenderer`, the default non-`--cui` renderer). `ConsoleChatRenderer.message()` had no such branch, so it fell to its generic `else` path — and since `OutboxPresentationRenderer` deliberately sets `msg.text=""` (the render model lives in `msg.meta["nodes"]`), this printed an empty line, silently dropping the presented content.

## Fix
`ConsoleChatRenderer.message()` now special-cases `kind == "presentation"`: renders `meta["nodes"]` via the existing `present_renderer.py::render_presentation_nodes()` (same conversion `format_inline_message` uses) through a plain (`color_system=None`) Rich `Console` captured to a string, consistent with this renderer's existing no-ANSI contract, then writes the plain text via the existing `_write()` path.

## Live verification (real `reyn chat --cui`, litellm proxy)
Before the fix: `present(data_ref=".../sample.txt")` → nothing rendered on screen.
After the fix:
```
[#ault] present
Line one of a readable sample file.
Line two with some numbers: 42, 7, 100.
Line three: the quick brown fox jumps.

[#ault] present
agent> I have presented the content of `sample.txt` to you.
```

## Test plan
- [x] New RED→GREEN regression test (`test_console_chat_renderer_renders_presentation_kind_issue_2701`) — confirmed RED via `git stash` on the pre-fix renderer.py, GREEN after.
- [x] Full pytest suite: 7837 passed, 17 skipped. **Note**: 9 pre-existing failures (`test_compaction_resolver_aware_1172.py`, `test_llm_request_error_1676.py`, `test_llm_router_s3b_1829.py`, `test_responses_api_routing_1678.py`) reproduce identically in full-suite runs with my change completely `git stash`-removed — confirmed unrelated to this diff (isolated runs of these 4 files pass cleanly, with or without my change; the 9-failure set is a pre-existing full-suite-only artifact on current main).
- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_present_renderer_fp0054_prb.py` — 0 errors.
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — OK.
- [x] Live tmux `reyn chat --cui` re-verification (above).

Tier self-check: new test is Tier 2, first docstring line declares Tier, no `MagicMock`/`patch`, no private-state assertions, no format/size pins.