### PR TITLE
fix: pipe-run present renders to the operator's stdout (#2702)

### DIFF
--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -706,9 +706,30 @@ def run_run(args: argparse.Namespace) -> None:
                     # router turn's — NOT the hardcoded router_state=None gap
                     # documented as "caveat-1" in runtime/router_loop.py.
                     source_session = agent_registry.get_or_load(DEFAULT_AGENT_NAME)
-                    _router_state_cache["state"] = await build_resource_caller_state(
+                    state = await build_resource_caller_state(
                         source_session.router_host,
                     )
+                    # #2702: wire the pipe-run present RENDER surface. The op_context
+                    # _factory this state carries is the default-identity Session's
+                    # make_router_op_context, which wires an OutboxPresentationRenderer
+                    # routing to that Session's outbox — a sink NOTHING drains in a
+                    # headless `reyn pipe run`. So a `tool: present` step executed
+                    # ok:True but the operator saw nothing (silent purpose-failure).
+                    # Wrap the factory to override the OpContext's presentation_renderer
+                    # with a headless stdout Rich Console sink, so present from a
+                    # pipeline `tool:` step actually reaches the user's stdout. Additive
+                    # — the op handler / render / guard / binding logic is untouched.
+                    base_factory = state.op_context_factory
+                    if base_factory is not None:
+                        def _factory_with_stdout_present(_base=base_factory):
+                            from reyn.interfaces.repl.present_renderer import (
+                                StdoutPresentationRenderer,
+                            )
+                            op_ctx = _base()
+                            op_ctx.presentation_renderer = StdoutPresentationRenderer()
+                            return op_ctx
+                        state.op_context_factory = _factory_with_stdout_present
+                    _router_state_cache["state"] = state
                 return _router_state_cache["state"]
 
             tool_ctx = _build_run_tool_context(

--- a/src/reyn/interfaces/repl/present_renderer.py
+++ b/src/reyn/interfaces/repl/present_renderer.py
@@ -107,3 +107,42 @@ def render_presentation_nodes(nodes: list[dict]) -> "Any":
     from rich.console import Group
 
     return Group(*[_render_node(node) for node in nodes])
+
+
+class StdoutPresentationRenderer:
+    """`PresentationRenderer` (`core/present/renderer.py`) that prints a resolved
+    presentation directly to **stdout** via a Rich `Console` — the headless sink a
+    `present` op reaches from `reyn pipe run` (#2702), which has no live CUI outbox /
+    output loop to route through.
+
+    This is the SINK end of the same seam as the inline-CUI's `OutboxPresentationRenderer`
+    (`runtime/session_buses.py`): the CUI variant is deliberately thin (it hands the raw
+    render model to the outbox and lets the UI loop draining it own the Rich conversion),
+    but a headless CLI run has no such loop — so this renderer owns the
+    `render_presentation_nodes` conversion + the `Console.print` itself, reusing the SAME
+    markup-inert render model this module already builds for the CUI. The op_runtime layer
+    still never imports Rich; this interfaces-layer adapter is the seam where that boundary
+    is respected.
+
+    `surface_name = "terminal"`: the generic terminal-family surface (a registered
+    neutralizer strategy in `core/present/guard.py` — ESC/control strip), so the guard's
+    per-surface binding runs exactly as it does for the inline-CUI sink.
+
+    Fire-and-continue: `render` must never raise into the `present` op (the op's ack is
+    already derived from the resolved stats before this is called — see
+    `op_runtime/present.py`'s fire-and-forget contract), so a Rich/IO failure is swallowed;
+    a pipeline step must never crash on a display-only side effect.
+    """
+
+    surface_name = "terminal"
+
+    def render(self, resolved: "Any") -> None:
+        try:
+            from rich.console import Console
+
+            # Construct the Console per render so it binds the CURRENT sys.stdout
+            # (honors capture/redirect); no ANSI is forced — a headless CLI writes
+            # whatever the terminal (or a captured stream) supports.
+            Console().print(render_presentation_nodes(resolved.nodes))
+        except Exception:  # noqa: BLE001 — display-only fire-and-forget (see docstring)
+            pass

--- a/tests/test_2702_present_pipe_run_stdout.py
+++ b/tests/test_2702_present_pipe_run_stdout.py
@@ -1,0 +1,93 @@
+"""#2702 — a pipeline ``tool: present`` step renders to the operator's stdout (part of the #2688 sweep).
+
+#2692 opened the pipeline INVOCATION surface for ``present`` (a ``tool: present`` step resolves +
+reaches ``execute_op`` + returns ``ok:True``), but left the RENDER surface unwired outside chat: the
+pipe-run ``OpContext``'s ``presentation_renderer`` routed to the ``default``-identity Session's outbox,
+which nothing drains in a headless ``reyn pipe run`` — so present executed, returned ``ok:True``, and
+the user saw NOTHING (a silent purpose-failure; present's purpose is the user SEEING the data).
+
+This is the reachable-FOR-PURPOSE proof one layer deeper than #2692's ``execute_op``-reach test: it
+drives a REAL ``reyn pipe run`` (``run_run``) of a real registered pipeline whose ``tool: present``
+step carries a unique marker in its data, and asserts the marker text actually appears on stdout — the
+render reached the operator, not just an ``ok:True`` ack. Real project scaffold / config / registry /
+executor / present op — no collaborator mocks; asserts the presented CONTENT appears (a marker
+substring), never exact Rich formatting/whitespace (a Tier-4 pin).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from reyn.interfaces.cli.commands.pipe import run_run
+
+# A distinctive token that appears in the PRESENTED data but NOT in the present op's
+# compact ack (which is what the final `reyn pipe run` JSON prints). So its presence on
+# stdout proves the RENDER reached the operator, distinct from the ack round-trip.
+_MARKER = "REYNPRESENTMARKER42"
+
+
+def _write_reyn_yaml(project_root: Path, pipelines_entries: dict) -> None:
+    data: dict = {
+        "model": "standard",
+        "models": {"standard": "openai/gpt-4o-mini"},
+        "pipelines": {"entries": pipelines_entries},
+    }
+    (project_root / "reyn.yaml").write_text(
+        yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8",
+    )
+
+
+def _write_present_pipeline(project_root: Path) -> None:
+    """A one-step pipeline whose ``tool: present`` step shows inline data (marker
+    inside) via the stage-3 default viewer (no view authoring needed)."""
+    (project_root / "shows.yaml").write_text(
+        "pipeline: shows\n"
+        "steps:\n"
+        "  - tool:\n"
+        "      name: present\n"
+        "      args:\n"
+        "        data_inline: {label: " + _MARKER + "}\n"
+        "      output: ack\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(project_root, {"shows": {"path": "shows.yaml"}})
+
+
+def test_pipe_run_present_step_renders_to_stdout(tmp_path, monkeypatch, capsys):
+    """Tier 2: a real ``reyn pipe run`` of a ``tool: present`` step renders the presented
+    data to the operator's stdout — the reachable-FOR-PURPOSE bar (user SEES the data),
+    not merely ``execute_op`` reach / ``ok:True``. RED on origin/main (present routes to a
+    never-drained outbox → marker absent from stdout); GREEN once the pipe-run OpContext
+    wires a headless stdout presentation renderer."""
+    monkeypatch.chdir(tmp_path)
+    _write_present_pipeline(tmp_path)
+
+    args = argparse.Namespace(
+        name="shows", input="{}", project=str(tmp_path), async_=False,
+        grant_file_write=False,
+    )
+    run_run(args)
+
+    out = capsys.readouterr().out
+    # The presented marker reached the operator's stdout (the render fired), distinct
+    # from the final JSON ack (which carries only reached-user/bind STATS, not the data).
+    assert _MARKER in out, (
+        "present rendered nothing to stdout — the pipe-run OpContext's "
+        "presentation_renderer is unwired (or routes to a never-drained sink)."
+    )
+
+    # Sanity: the run still completed and printed its result JSON (the present ack is a
+    # compact stats blob, NOT the data — so the marker's presence above is the render, not
+    # the ack echoing the data back).
+    json_start = out.index("{", out.index(_MARKER))
+    result = json.loads(out[json_start:])
+    # The step output is the present op's compact canonical ack (a reached-user / bind-
+    # stats TEXT line — FP-0056), NOT the data; so the stdout marker above is the render.
+    assert "Presented to the user" in result["named_stores"]["ack"]["text"]
+    assert _MARKER not in json.dumps(result), (
+        "the present ack unexpectedly carried the data — the stdout marker match "
+        "must prove the RENDER, not an ack echo."
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2702. Part of the #2688 sweep.

## The bug (primary-verified)
#2692 opened the pipeline **invocation** surface for `present` (a `tool: present` step resolves + reaches `execute_op` + returns `ok:True`), but left the **render** surface unwired outside chat:

- The pipe-run `OpContext`'s `presentation_renderer` came from the `default`-identity Session's `make_router_op_context`, which wires an `OutboxPresentationRenderer` routing to **that Session's outbox** — a sink **nothing drains** in a headless `reyn pipe run`.
- `core/op_runtime/present.py` renders only `if ctx.presentation_renderer is not None`, but returns the `{ok:True,...}` ack regardless.
- Net: `reyn pipe run` with a `tool: present` step executed, returned `ok:True`, and the operator **saw nothing** — silent purpose-failure.

(Note: the OpContext's `presentation_renderer` was not literally `None` as first framed — Session.`__init__` unconditionally wires the outbox-renderer factory — but the effect is identical: the render lands in an outbox no one drains in a headless CLI run.)

## Fix (additive — op handler / render / guard / binding logic untouched)
1. **`StdoutPresentationRenderer`** added to `src/reyn/interfaces/repl/present_renderer.py` — a headless `PresentationRenderer` (the SINK end of the same seam as the inline-CUI's `OutboxPresentationRenderer`) that prints the resolved presentation to **stdout** via a Rich `Console`, reusing the SAME markup-inert `render_presentation_nodes` model. `surface_name="terminal"` (a registered guard neutralizer strategy, so the per-surface binding runs identically). Fire-and-continue (swallows display-only failures, honoring the op's fire-and-forget contract).
2. **Wiring point**: `src/reyn/interfaces/cli/commands/pipe.py` `run_run()` → `_resolve_router_state()`. After `build_resource_caller_state(...)`, the session-derived `op_context_factory` is wrapped so the returned `OpContext`'s `presentation_renderer` is overridden with the stdout sink. So `present` from a pipeline `tool:` step reaches the user's stdout.

## Agent-step audit (`agent:` step → `session_api.run_agent_step`)
An `agent:` step spawns an ephemeral session via `spawn_ephemeral_session` → `registry.spawn_session_recorded`, which builds a real Session whose `OutboxPresentationRenderer` routes to **that ephemeral session's outbox**. `run_agent_step` collects only `kind="agent"` reply text via `MessageBus.request`; the ephemeral session's outbox is **not drained to stdout** in a pipe-run. So a `present` inside an agent-step shares the **same null-surface-effect gap**.

**Flagged, not wired here** (out of scope): closing it requires plumbing the ephemeral session's presentation output to the operator's stdout at the `spawn_ephemeral_session`/`run_agent_step` seam (deep in the executor's agent-step, no clean seam in `pipe.py`), and raises a genuine design question (whether/how a nested agent-step's present should interleave with top-level pipeline stdout). @lead-coder — recommend a follow-up issue; trace above.

## RED → GREEN evidence (stdout capture)
`tests/test_2702_present_pipe_run_stdout.py` drives a **real** `reyn pipe run` (`run_run`) of a `tool: present` step carrying a unique marker in its inline data, and asserts the marker appears on **stdout** (the render reached the operator — distinct from the compact `ok:True` ack the final JSON prints).

- **RED** on origin/main: `AssertionError: present rendered nothing to stdout` — stdout carried only the ack (`"Presented to the user. mode=default rows=0 bindings_resolved=1"`), no marker.
- **GREEN** after: `1 passed`.

## Gate results (run locally to completion)
- **ruff** `ruff check src tests` → `All checks passed!`
- **tier audit** `--strict tests/test_2702_present_pipe_run_stdout.py` → `OK: 1, errors: 0` (Tier 2, first docstring line declares it)
- **pytest** (repo root) → **7835 passed, 21 skipped, 5 failed**. The 5 failures are **pre-existing and unrelated** — all web/a2a/mcp route-mounting tests (`test_fp0001_a2a_endpoints`, `web/test_a2a`, `web/test_mcp_sse`, `web/test_plugin_loader`, `web/test_resources_router`). My diff touches only `pipe.py` + `present_renderer.py` (+ the new test) and provably cannot affect web-server route registration.
- **module docstrings** `verify_module_docstrings.py <changed src>` → `OK`

## Test plan
- [x] RED confirmed on origin/main (marker absent from stdout)
- [x] GREEN after fix (marker present on stdout)
- [x] All 4 CI gates run locally (pytest failures pre-existing/unrelated, enumerated above)

## Coordination
Kept strictly to the **pipe-run** path. Did **not** touch the `--cui` chat renderer wiring (tui-coder's sibling #2701).

🤖 Generated with [Claude Code](https://claude.com/claude-code)