### PR TITLE
feat: #2708 P1 — orphan-impossible present sink (required PresentationConsumer + AST guard)

### DIFF
--- a/src/reyn/interfaces/chainlit_app/adapter.py
+++ b/src/reyn/interfaces/chainlit_app/adapter.py
@@ -18,6 +18,10 @@ Kind coverage:
 - ``tool_call_failed``     → author "🔧 tool", type "system_message",
                               text "✗ <name>: <err>"
 - ``trace``                → dropped (debug noise)
+- ``presentation``         → author "📊 present", type "system_message";
+                              the ``present`` op render model in ``meta["nodes"]``
+                              serialized to Markdown (#2708 P1 — the #2688 fix; the
+                              generic fall-through dropped it as empty ``text``)
 - ``system``               → author "ℹ system", type "system_message"
 - ``__stream_*__``         → dropped (TUI-only incremental render kinds)
 - ``__end__``              → sentinel, signals drain to stop (returns None)
@@ -148,6 +152,63 @@ def _format_tool_call(msg: OutboxMessage) -> str:
     return f"✗ {name}{err}"
 
 
+_AUTHOR_PRESENT = "📊 present"
+
+
+def _present_node_to_markdown(node: dict) -> str:
+    """Render ONE `ResolvedPresentation` node (the FP-0054 render model — see
+    `interfaces/repl/present_renderer.py` for the terminal twin) to a Markdown
+    fragment for the chainlit browser UI. The render model is already bound /
+    neutralized / capped upstream; this is a display-only serialization."""
+    component = node.get("component")
+    text = node.get("text", "")
+    if component in ("text", "markdown"):
+        return text
+    if component == "code":
+        lang = node.get("language") or ""
+        return f"```{lang}\n{text}\n```"
+    if component == "diff":
+        return f"```diff\n{text}\n```"
+    if component == "keyvalue":
+        return "\n".join(
+            f"**{row.get('label', '')}**: {row.get('value', '')}"
+            for row in node.get("rows", [])
+        )
+    if component == "list":
+        return "\n".join(f"- {item}" for item in node.get("items", []))
+    if component == "table":
+        columns = node.get("columns", [])
+        if not columns:
+            return ""
+        headers = [str(c.get("header", "")) for c in columns]
+        n_rows = max((len(c.get("cells", [])) for c in columns), default=0)
+        lines = ["| " + " | ".join(headers) + " |",
+                 "| " + " | ".join("---" for _ in headers) + " |"]
+        for i in range(n_rows):
+            cells = [
+                str(c["cells"][i]) if i < len(c.get("cells", [])) else ""
+                for c in columns
+            ]
+            lines.append("| " + " | ".join(cells) + " |")
+        return "\n".join(lines)
+    if component == "image":
+        alt = node.get("alt") or node.get("src") or ""
+        return f"_[image: {alt}]_"
+    # Unregistered/future component — never crash the drain over one bad node.
+    return f"_<unsupported present component {component!r}>_"
+
+
+def _presentation_nodes_to_markdown(nodes: list) -> str:
+    """Serialize a `ResolvedPresentation.nodes` render model to a single Markdown
+    block for chainlit. #2708 P1: this is the chainlit side of the forced #2688
+    present fix — before it, kind="presentation" fell through to the generic branch,
+    which used the (empty) `text` field and dropped the render model in `meta["nodes"]`,
+    so a `present` op was invisible in chainlit despite ok:True."""
+    return "\n\n".join(
+        _present_node_to_markdown(n) for n in nodes if isinstance(n, dict)
+    )
+
+
 def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
     """Map one OutboxMessage to a Chainlit payload, or None to drop."""
     kind = msg.kind
@@ -173,6 +234,18 @@ def outbox_to_chainlit(msg: OutboxMessage) -> ChainlitPayload | None:
             role="message",
             author=_AUTHOR_TOOL,
             content=_format_tool_call(msg),
+            message_type=MSG_TYPE_SYSTEM,
+        )
+
+    # #2708 P1: a `present` op's render model rides on ``meta["nodes"]`` (the outbox
+    # message's ``text`` is ""), so it MUST be rendered from nodes — the generic
+    # fall-through below would emit empty content (the #2688 chainlit silent-drop bug).
+    if kind == "presentation":
+        meta = msg.meta if isinstance(msg.meta, dict) else {}
+        return ChainlitPayload(
+            role="message",
+            author=_AUTHOR_PRESENT,
+            content=_presentation_nodes_to_markdown(meta.get("nodes", [])),
             message_type=MSG_TYPE_SYSTEM,
         )
 

--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -154,6 +154,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
         from reyn.interfaces.cli.invocation_context import InvocationContext
         from reyn.runtime.budget.budget import BudgetTracker
         from reyn.runtime.factory_config import SessionFactoryConfig
+        from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
         from reyn.runtime.profile import AgentProfile
         from reyn.runtime.registry import AgentRegistry
         from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -206,6 +207,13 @@ async def _get_or_build_registry() -> "AgentRegistry":
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
             _ctx_perm, _profile_excluded = registry_ref[0].resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
+                # #2708 P1: chainlit is a HUMAN surface — it cannot NA-dodge (a Null sink
+                # is refused for a non-reviewed surface), so it MUST provide a real
+                # outbox-backed consumer. Its outbox drain (adapter.py::outbox_to_chainlit)
+                # now renders the "presentation" nodes to the chainlit UI (the forced
+                # #2688 silent-drop fix); before #2708 it fell through to text="" and the
+                # present output was invisible.
+                presentation_consumer=OutboxPresentationConsumer(),
                 agent_name=profile.name,
                 model=model,
                 resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -248,6 +248,7 @@ def run(args: argparse.Namespace) -> None:
     from reyn.config import _find_project_root, load_project_context
     from reyn.interfaces.repl.repl import run_repl
     from reyn.runtime.factory_config import SessionFactoryConfig
+    from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import DEFAULT_AGENT_NAME, AgentRegistry
     from reyn.runtime.registry_bootstrap import build_budget_tracker, build_state_log
@@ -369,6 +370,10 @@ def run(args: argparse.Namespace) -> None:
         # narrowing (enforcement) + view exclusion. (None, ∅) when unbound = byte-identical.
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
+            # #2708 P1: chat-CLI (inline/plain --cui / run-once) — the InlineChatRenderer
+            # drains the outbox "presentation" message and renders it (renderer.py:148),
+            # so the outbox-backed consumer is byte-identical to the pre-#2708 default.
+            presentation_consumer=OutboxPresentationConsumer(),
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -434,6 +434,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
     from reyn.mcp.server import send_to_agent_impl
     from reyn.runtime.budget.budget import BudgetTracker
     from reyn.runtime.factory_config import SessionFactoryConfig
+    from reyn.runtime.presentation_consumer import NullPresentationConsumer
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -478,6 +479,10 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 _reg.resolved_profile_for(profile.name) if _reg else (None, frozenset())
             )
             s = build_scoped_chat_session(
+                # #2708 P1: the dogfood eval harness is headless with no outbox/present
+                # drain at all — a reviewed NA surface. Null is byte-identical (present
+                # was never rendered by the harness before #2708).
+                presentation_consumer=NullPresentationConsumer("dogfood"),
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -326,6 +326,7 @@ def run_serve(args: argparse.Namespace) -> None:
     from reyn.mcp.server import serve_stdio
     from reyn.runtime.budget.budget import BudgetTracker
     from reyn.runtime.factory_config import SessionFactoryConfig
+    from reyn.runtime.presentation_consumer import NullPresentationConsumer
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -398,6 +399,9 @@ def run_serve(args: argparse.Namespace) -> None:
         # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
+            # #2708 P1: stdio-MCP is a history-harvest surface with no live present drain
+            # — a reviewed NA surface. Null is byte-identical (present was invisible before).
+            presentation_consumer=NullPresentationConsumer("mcp"),
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -258,6 +258,7 @@ def _get_registry():
     if _registry is None:
         from reyn.config import load_project_context
         from reyn.runtime.factory_config import SessionFactoryConfig
+        from reyn.runtime.presentation_consumer import NullPresentationConsumer
         from reyn.runtime.profile import AgentProfile
         from reyn.runtime.registry import AgentRegistry
         from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -305,6 +306,11 @@ def _get_registry():
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
             _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
+                # #2708 P1: web/A2A is a machine JSON surface with no human present drain
+                # (its external outbox interceptor routes only kind="agent",
+                # external_routing.py:333) — a reviewed NA surface. Null is byte-identical
+                # (present was invisible + not externally routed before #2708).
+                presentation_consumer=NullPresentationConsumer("web"),
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/runtime/presentation_consumer.py
+++ b/src/reyn/runtime/presentation_consumer.py
@@ -1,0 +1,133 @@
+"""reyn.runtime.presentation_consumer — the orphan-impossible present-sink seam (#2708 P1).
+
+A `present` op writes its resolved render model to a `PresentationRenderer` sink
+(`core/present/renderer.py`). Two sink shapes exist: a **self-delivering** one that
+draws directly to a surface (e.g. `StdoutPresentationRenderer` for `reyn pipe run`),
+and an **outbox-backed** one (`OutboxPresentationRenderer`, `runtime/session_buses.py`)
+that only puts a `"presentation"` message on the Session's outbox — it reaches the user
+ONLY if some per-surface drain loop consumes and renders that message. The historical
+bug class (#2688 / #2707) was an *orphan* outbox sink: a surface wired the outbox
+producer but had no consumer draining it, so a `present` op returned `ok:True` while the
+user saw nothing.
+
+This module makes that orphan **impossible by construction**:
+
+- `PresentationConsumer` is the ONLY public way to obtain a sink for a Session — its
+  `.sink(session)` returns a `PresentationRenderer`. `build_scoped_chat_session` takes a
+  `PresentationConsumer` as a REQUIRED, no-default kwarg (#1402 completeness-by-
+  construction), so a surface that declares no consumer cannot construct a Session at all
+  (compile/type error, not a silent null). The consumer — not a bare renderer — is the
+  required input because the outbox-backed renderer needs the Session, which does not yet
+  exist when `build_scoped_chat_session` is called; `.sink(session)` defers its
+  construction to Session init.
+- `OutboxPresentationConsumer.sink()` is the SOLE construction site for
+  `OutboxPresentationRenderer` (enforced by the AST guard in
+  `tests/test_present_sink_ast_guard_2708.py`, the #1190/#2683 single-writer model), so a
+  bare/orphan outbox sink cannot be instantiated anywhere in `src/reyn`.
+- A `NullPresentationSink` (documented no-op) is available ONLY through
+  `NullPresentationConsumer`, whose surface name must be a member of the reviewed
+  `_NA_PRESENTATION_SURFACES` frozenset — a machine surface with no human presentation
+  drain (web / mcp / dogfood). A new human surface cannot silently NA-dodge (the ratchet
+  test `tests/test_present_sink_na_ratchet_2708.py` pins the frozenset by equality, the
+  FP-0056 admin-6 model).
+
+P1 is present-sink-specific and byte-identical: it moves WHERE the sink is provided (from
+the uniform `session.py` default to each frontend's explicit consumer) without changing
+any render behavior, except the forced chainlit fix (its incomplete outbox drain dropped
+the render model — now repaired, since chainlit is a human surface that cannot NA-dodge).
+The canonical user-reaching kind enum + full kind-complete typed consumer contract is P3.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from reyn.core.present.binding import ResolvedPresentation
+    from reyn.core.present.renderer import PresentationRenderer
+    from reyn.runtime.session import Session
+
+# The reviewed set of surfaces that legitimately have NO human presentation drain, so a
+# `present` op reaching them is a documented no-op (machine/headless surface). Membership
+# is a REVIEWED ratchet (FP-0056 admin-6 equality model): a new human surface cannot add
+# itself here to dodge providing a real sink. Each member states WHY it is NA:
+#   - "web":     the A2A/web transport has no human web-UI present drain; its external
+#                outbox interceptor routes only kind="agent" (external_routing.py:333),
+#                so a "presentation" message reaches no surface.
+#   - "mcp":     the stdio-MCP server is a history-harvest surface — no live present drain.
+#   - "dogfood": the headless dogfood eval harness has no outbox/present drain at all.
+_NA_PRESENTATION_SURFACES = frozenset({"web", "mcp", "dogfood"})
+
+
+@runtime_checkable
+class PresentationConsumer(Protocol):
+    """A surface's declared ability to consume a `present` op's render model. `.sink(session)`
+    yields the `PresentationRenderer` the Session wires into its per-turn OpContext — the ONLY
+    supported way to obtain a sink. A surface with no `PresentationConsumer` cannot build a
+    Session (the required-kwarg forcing), so an orphan sink is structurally impossible."""
+
+    def sink(self, session: "Session") -> "PresentationRenderer": ...
+
+
+class OutboxPresentationConsumer:
+    """Consumer for surfaces whose Session outbox is drained by a live loop that renders the
+    `"presentation"` message — the inline/plain CUI (`interfaces/repl/renderer.py`), chainlit
+    (`chainlit_app/adapter.py::outbox_to_chainlit`), and the registry base session whose outbox
+    is either drained by the REPL, overridden by `reyn pipe run` (self-delivering stdout), or
+    bridged to a parent (#2707 driver forward).
+
+    `.sink()` is the SOLE `OutboxPresentationRenderer` construction site in `src/reyn` (AST
+    guard-enforced) — that single seam is what makes a bare orphan outbox sink impossible."""
+
+    def sink(self, session: "Session") -> "PresentationRenderer":
+        from reyn.runtime.session_buses import OutboxPresentationRenderer
+
+        return OutboxPresentationRenderer(session)
+
+
+class NullPresentationSink:
+    """`PresentationRenderer` (`core/present/renderer.py`) for a surface with no human
+    presentation drain: `render` is a documented no-op. Obtainable ONLY through
+    `NullPresentationConsumer` (whose surface is a reviewed `_NA_PRESENTATION_SURFACES`
+    member), so a human surface cannot silently reach this NA behavior."""
+
+    surface_name = "none"
+
+    def render(self, resolved: "ResolvedPresentation") -> None:
+        # Documented no-op: this surface (web JSON / mcp harvest / dogfood eval) has no
+        # human presentation drain, so the resolved render model is intentionally dropped.
+        # The `present` op's ack + audit event still fire upstream (PR-A null-surface
+        # semantics); only the visible draw is a no-op.
+        return None
+
+
+class NullPresentationConsumer:
+    """Consumer for a reviewed NA surface (web / mcp / dogfood). Its `surface` MUST be a
+    member of `_NA_PRESENTATION_SURFACES` — constructing one for any other (e.g. a human)
+    surface raises, so a human surface cannot NA-dodge by passing a Null sink."""
+
+    def __init__(self, surface: str) -> None:
+        if surface not in _NA_PRESENTATION_SURFACES:
+            raise ValueError(
+                f"NullPresentationConsumer refused for surface {surface!r}: not a reviewed "
+                f"NA surface. A human/visible surface must provide a real presentation "
+                f"consumer; only {sorted(_NA_PRESENTATION_SURFACES)} may use a Null sink "
+                f"(add here ONLY via review — see _NA_PRESENTATION_SURFACES rationale)."
+            )
+        self._surface = surface
+
+    @property
+    def surface(self) -> str:
+        """The reviewed NA surface name this consumer was constructed for."""
+        return self._surface
+
+    def sink(self, session: "Session") -> "PresentationRenderer":
+        return NullPresentationSink()
+
+
+__all__ = [
+    "NullPresentationConsumer",
+    "NullPresentationSink",
+    "OutboxPresentationConsumer",
+    "PresentationConsumer",
+    "_NA_PRESENTATION_SURFACES",
+]

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -135,6 +135,7 @@ def build_agent_registry_from_project(
     from reyn.config import load_project_context
     from reyn.llm.model_resolver import ModelResolver
     from reyn.runtime.factory_config import SessionFactoryConfig
+    from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
     from reyn.runtime.profile import AgentProfile
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.scoped_session_factory import build_scoped_chat_session
@@ -171,6 +172,13 @@ def build_agent_registry_from_project(
     def _session_factory(profile: "AgentProfile"):
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
+            # #2708 P1: the reusable registry base session (reyn pipe run's default
+            # identity + driver spawns). Outbox-backed, byte-identical to the pre-#2708
+            # uniform default: pipe run OVERRIDES the OpContext sink post-hoc with a
+            # self-delivering stdout renderer (pipe.py), and a driver spawn's outbox is
+            # bridged to the parent (#2707 forward) — neither is an orphan. P3 replaces
+            # the #2707 interim with a proper spawn-bridge sink.
+            presentation_consumer=OutboxPresentationConsumer(),
             agent_name=profile.name,
             model=config.model,
             resolver=resolver,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -54,7 +54,7 @@ def build_router_op_context(
     # ── per-host fields (caller-supplied; behavior-preserving) ─────────────
     agent_id: str | None,  # FP-0016 memory scope (RouterHostAdapter: None — gap candidate)
     intervention_bus: Any = None,  # Session wires post-hoc; RouterHostAdapter inline
-    presentation_renderer: Any = None,  # FP-0054 PR-B: RouterHostAdapter wires inline (factory)
+    presentation_renderer: Any,  # #2708 P1: REQUIRED (no default) — every OpContext builder must EXPLICITLY decide the present sink (a PresentationRenderer or None for the file/MCP-op path that no present op reaches). Silent-omission drift removed. RouterHostAdapter wires the surface consumer's sink (factory); Session._make_router_op_context passes None.
     presentation_registry: Any = None,  # FP-0054 PR-C: operator named-template registry (hot-reloadable)
     multimodal_config: Any = None,  # #364
     media_store: Any = None,  # #383

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -40,6 +40,8 @@ from reyn.runtime.session import Session
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from reyn.runtime.presentation_consumer import PresentationConsumer
+
 
 def build_scoped_chat_session(
     *,
@@ -57,6 +59,7 @@ def build_scoped_chat_session(
     agent_id: str | None,  # FP-0016 agent-id-scoped memory
     router_max_iterations: int,  # #187 per-message tool-call budget
     non_interactive: bool,  # #1439 Fix #1: run-once (no TTY) → SP proceeds instead of asking a clarifying question. Per-frontend: chat-CLI = not isatty(); A2A/MCP/chainlit/dogfood = False (interactive byte-identical)
+    presentation_consumer: "PresentationConsumer",  # #2708 P1: the surface's present-sink CONSUMER (orphan-impossible). Its .sink(session) yields the PresentationRenderer wired per-turn. REQUIRED (no default) so a surface cannot silently omit a present sink; a bare renderer can't be the kwarg because the outbox sink needs the not-yet-built Session (.sink defers it). Per-frontend: CUI=OutboxPresentationConsumer / chainlit=OutboxPresentationConsumer(+fixed drain) / web/mcp/dogfood=NullPresentationConsumer(reviewed NA)
     eager_embedding_build: bool,  # build the action embedding index up-front
     allowed_mcp: list[str] | None,  # per-profile MCP allow-list
     task_backend: Any,  # #1953 slice R — session-scoped Task backend instance. I-5=(A): cli/chat + MCP pass a per-session sqlite (rewind-participating); A2A/web passes None (the process-singleton A2A surface is read directly, NOT threaded here, so A2A tasks stay durable but un-rewound). None → op-runtime in-memory fallback (_BACKEND)
@@ -119,6 +122,7 @@ def build_scoped_chat_session(
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
         task_backend=task_backend,  # #1953 slice R
+        presentation_consumer=presentation_consumer,  # #2708 P1: present-sink consumer (.sink deferred to Session init)
         sandbox_config=factory_config.sandbox_config,
         multimodal_config=factory_config.multimodal_config,
         action_retrieval_config=factory_config.action_retrieval_config,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -58,6 +58,7 @@ from reyn.runtime.limits.limit_handler import (
 )
 from reyn.runtime.outbox import OutboxMessage
 from reyn.runtime.pending_op_view import PendingOpView
+from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
 from reyn.runtime.services import (
     BudgetGateway,
     ChainManager,
@@ -76,7 +77,6 @@ from reyn.runtime.services.task_wake import WAKE_READY_KIND, WAKE_REQUESTER_KIND
 from reyn.runtime.session_buses import (
     AgentRequestBus,
     ChatInterventionBus,
-    OutboxPresentationRenderer,
 )
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
@@ -751,6 +751,15 @@ class Session:
         # (direct/test construction) → an empty registry (byte-identical to pre-PR-C:
         # every named template is "unknown" → generic fallback viewer).
         presentation_registry: "object | None" = None,
+        # #2708 P1: the surface's present-sink CONSUMER. In production every Session is
+        # built via build_scoped_chat_session, which REQUIRES this (no default) — a
+        # frontend cannot silently omit a present sink. None is reachable ONLY by
+        # direct/test construction (forbidden in src/reyn by the #1402 invariant), where
+        # it falls back to the outbox-backed consumer (byte-identical to the pre-#2708
+        # uniform ``OutboxPresentationRenderer(self)`` default). The renderer is obtained
+        # lazily via ``consumer.sink(self)`` (deferred so the outbox sink can bind this
+        # Session, which does not exist when the factory kwarg is passed).
+        presentation_consumer: "object | None" = None,
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -812,6 +821,19 @@ class Session:
         # falls back to its in-memory backend (tests / direct construction).
         self._task_backend = task_backend
         self._task_waker = task_waker  # #1953 slice 7
+        # #2708 P1: the present-sink consumer. In production it is always supplied by
+        # build_scoped_chat_session (required kwarg); a direct/test construction (None)
+        # falls back to the outbox-backed consumer so the per-turn OpContext still wires
+        # an OutboxPresentationRenderer (byte-identical to the removed uniform default).
+        # The renderer is obtained lazily below (``sink(self)``) so it can bind this
+        # Session. No OutboxPresentationRenderer is instantiated here — the AST guard
+        # (test_present_sink_ast_guard_2708) requires the sole construction site to be
+        # OutboxPresentationConsumer.sink().
+        self._presentation_consumer = (
+            presentation_consumer
+            if presentation_consumer is not None
+            else OutboxPresentationConsumer()
+        )
         # #1953 §16 (recursive-request): the task_id this session is currently
         # EXECUTING as a task-as-request, set per-turn from an execute-wake's meta
         # (run_one_iteration). Read by the router op-ctx builders so task.create
@@ -1717,11 +1739,13 @@ class Session:
                 self, run_id=None, actor="chat_router",
                 channel_id=DEFAULT_CHAT_CHANNEL_ID,
             ),
-            # FP-0054 PR-B: give the router OpContext a real PresentationRenderer so a
-            # `present` op reaches the live outbox (→ inline-CUI) instead of PR-A's null
-            # surface. Built per make_router_op_context() call, mirroring the
-            # intervention_bus_factory above.
-            presentation_renderer_factory=lambda: OutboxPresentationRenderer(self),
+            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
+            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
+            # Built per make_router_op_context() call, mirroring the intervention_bus_factory
+            # above. The sink is obtained from the surface's declared PresentationConsumer
+            # (orphan-impossible: OutboxPresentationRenderer is constructible ONLY inside
+            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
+            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
             # FP-0037 S2: yaml mtime watch needs the project root to resolve
             # the 3 yaml scope tier paths. None falls back to user-global only.
             project_root=getattr(self._registry, "_project_root", None),
@@ -5617,6 +5641,11 @@ class Session:
                 else None
             ),
             agent_id=self._agent_id,
+            # #2708 P1: this builder serves file/MCP ops (_file_op / MCP), which no
+            # `present` op reaches — so the present sink is EXPLICITLY None (the required
+            # kwarg forces the decision, no silent omission). The visible present path is
+            # RouterHostAdapter.make_router_op_context, which wires the surface consumer's sink.
+            presentation_renderer=None,
             # #2409: forward the media store (the public twin RouterHostAdapter.make_router_op_context
             # already does — session.py:1826). Without it the chat-router MCP path got media_store=None
             # → MCP ImageContent couldn't be saved as a path-ref → a large image was inlined as

--- a/tests/test_present_consumer_2708.py
+++ b/tests/test_present_consumer_2708.py
@@ -1,0 +1,122 @@
+"""Tier 2: OS invariant — #2708 P1 present-sink consumer wiring + forced chainlit fix.
+
+Covers the #2708 P1 seam:
+- ``build_scoped_chat_session`` REQUIRES ``presentation_consumer`` (no default) — a
+  frontend that omits it fails to construct (compile-time forcing; A1/A2 orphan
+  impossible).
+- ``OutboxPresentationConsumer.sink(session)`` yields an ``OutboxPresentationRenderer``
+  that puts the SAME ``"presentation"`` outbox message as the pre-#2708 uniform default
+  (byte-identical).
+- chainlit's ``outbox_to_chainlit`` now renders the ``present`` render model from
+  ``meta["nodes"]`` (was an empty ``text`` fall-through = the #2688 silent-drop bug).
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+import pytest
+
+from reyn.interfaces.chainlit_app.adapter import outbox_to_chainlit
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
+from reyn.runtime.scoped_session_factory import build_scoped_chat_session
+
+
+class _Session:
+    """A minimal real Session stand-in exposing only the ``outbox`` an
+    OutboxPresentationRenderer writes to (mirrors test_present_renderer_fp0054_prb)."""
+
+    def __init__(self) -> None:
+        self.outbox: asyncio.Queue = asyncio.Queue()
+
+
+# ── forcing: presentation_consumer is a required no-default kwarg ─────────────
+
+
+def test_presentation_consumer_is_required_no_default() -> None:
+    """Tier 2: build_scoped_chat_session's ``presentation_consumer`` is a REQUIRED
+    keyword-only arg (no default) — a frontend cannot silently omit the present sink
+    (orphan-impossible by construction, #2708 A1)."""
+    sig = inspect.signature(build_scoped_chat_session)
+    p = sig.parameters["presentation_consumer"]
+    assert p.kind is inspect.Parameter.KEYWORD_ONLY
+    assert p.default is inspect.Parameter.empty
+
+
+def test_build_session_without_consumer_is_a_construction_error() -> None:
+    """Tier 2: omitting ``presentation_consumer`` raises at call time (the compile/
+    construction-time forcing the required kwarg guarantees). We assert the specific
+    missing arg so the failure is the forcing, not an unrelated one."""
+    with pytest.raises(TypeError) as ei:
+        # Deliberately omit presentation_consumer (and everything else) — the FIRST
+        # thing Python reports for a no-default kwarg-only call is the missing arg set.
+        build_scoped_chat_session()  # type: ignore[call-arg]
+    assert "presentation_consumer" in str(ei.value)
+
+
+# ── byte-identical: consumer.sink round-trips the outbox present message ──────
+
+
+def test_outbox_consumer_sink_puts_presentation_message() -> None:
+    """Tier 2: OutboxPresentationConsumer.sink(session).render(resolved) puts a
+    ``kind="presentation"`` OutboxMessage carrying resolved.nodes onto the session's
+    outbox — byte-identical to the pre-#2708 uniform ``OutboxPresentationRenderer(self)``
+    default (the sink is now obtained via the consumer instead of hardcoded)."""
+    from reyn.core.present.binding import ResolvedPresentation
+
+    session = _Session()
+    sink = OutboxPresentationConsumer().sink(session)
+    assert sink.surface_name == "inline-cui"  # byte-identical surface
+
+    sink.render(ResolvedPresentation(nodes=[{"component": "text", "text": "hi"}]))
+    msg = session.outbox.get_nowait()
+    assert msg.kind == "presentation"
+    assert msg.meta["nodes"] == [{"component": "text", "text": "hi"}]
+
+
+# ── forced chainlit fix (#2688): presentation renders instead of dropping ─────
+
+
+def test_chainlit_renders_presentation_nodes_not_empty() -> None:
+    """Tier 2: RED→GREEN for the #2688 chainlit silent-drop. A ``kind="presentation"``
+    OutboxMessage (text="", render model in meta["nodes"]) now maps to a chainlit
+    payload whose content contains the rendered node text — before #2708 it fell
+    through to the generic branch and emitted the empty ``text``."""
+    msg = OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [
+            {"component": "text", "text": "hello from present"},
+            {"component": "code", "language": "python", "text": "x = 1"},
+        ]},
+    )
+    payload = outbox_to_chainlit(msg)
+    assert payload is not None
+    assert payload.role == "message"
+    assert "hello from present" in payload.content
+    assert "x = 1" in payload.content
+    assert "```python" in payload.content
+    # The bug was empty content despite a non-empty render model:
+    assert payload.content.strip() != ""
+
+
+def test_chainlit_present_table_and_list_render() -> None:
+    """Tier 2: the chainlit present serializer covers the structured components
+    (table / keyvalue / list) so a structured present isn't silently blanked."""
+    msg = OutboxMessage(
+        kind="presentation",
+        text="",
+        meta={"nodes": [
+            {"component": "list", "items": ["a", "b"]},
+            {"component": "keyvalue", "rows": [{"label": "k", "value": "v"}]},
+            {"component": "table", "columns": [
+                {"header": "H1", "cells": ["r1"]},
+                {"header": "H2", "cells": ["r2"]},
+            ]},
+        ]},
+    )
+    content = outbox_to_chainlit(msg).content
+    assert "- a" in content and "- b" in content
+    assert "**k**: v" in content
+    assert "| H1 | H2 |" in content

--- a/tests/test_present_sink_ast_guard_2708.py
+++ b/tests/test_present_sink_ast_guard_2708.py
@@ -1,0 +1,99 @@
+"""Tier 2: OS invariant — #2708 P1 present-sink single-writer AST guard.
+
+``OutboxPresentationRenderer(...)`` (the outbox-backed present sink, whose output
+reaches the user ONLY if a per-surface drain consumes it) may be instantiated in
+``src/reyn`` ONLY inside ``OutboxPresentationConsumer.sink`` (in
+``runtime/presentation_consumer.py``). Any other construction site is an *orphan*
+sink — a renderer with no consumer draining its outbox — the exact #2688/#2707 bug
+class. This guard makes that orphan *impossible by construction* (the #1190
+``litellm.acompletion`` / #2683 single-writer model): a new
+``OutboxPresentationRenderer(...)`` anywhere else in ``src/reyn`` fails here at PR
+time, naming file:line. Tests are exempt (the guard scopes to ``src/reyn``), so
+fixtures may construct the renderer directly.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _is_outbox_renderer_construction(node: ast.AST) -> bool:
+    """True for an ``OutboxPresentationRenderer(...)`` CALL (construction).
+
+    Only a call constructs the sink; a bare ``Name`` reference / import is not a
+    construction (excluded), matching the #1190 guard's call-vs-reference split.
+    """
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "OutboxPresentationRenderer"
+    )
+
+
+def _sink_method_span(consumer_py: Path) -> tuple[int, int]:
+    """Return the (start, end) line span of ``OutboxPresentationConsumer.sink``."""
+    tree = ast.parse(consumer_py.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "OutboxPresentationConsumer":
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and (
+                    item.name == "sink"
+                ):
+                    return item.lineno, (item.end_lineno or item.lineno)
+    raise AssertionError(
+        "OutboxPresentationConsumer.sink not found in presentation_consumer.py — "
+        "the present-sink chokepoint moved?"
+    )
+
+
+def test_outbox_present_renderer_constructed_only_in_consumer_sink() -> None:
+    """Tier 2: the outbox present sink's sole construction site is
+    OutboxPresentationConsumer.sink (orphan sinks structurally impossible)."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    consumer_py = (src / "runtime" / "presentation_consumer.py").resolve()
+    start, end = _sink_method_span(consumer_py)
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not _is_outbox_renderer_construction(node):
+                continue
+            inside = py.resolve() == consumer_py and start <= node.lineno <= end
+            if not inside:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno}")
+
+    assert not offenders, (
+        "OutboxPresentationRenderer(...) constructed outside "
+        "OutboxPresentationConsumer.sink — an orphan present sink (renderer with no "
+        "consumer draining its outbox = the #2688/#2707 silent-invisible-present bug). "
+        "Obtain the sink via a PresentationConsumer.sink(session) instead. "
+        f"Offending sites: {offenders}"
+    )
+
+
+def test_sink_chokepoint_actually_constructs_it() -> None:
+    """Tier 2: positive guard — OutboxPresentationConsumer.sink DOES construct the
+    renderer (the chokepoint exists and is used, not merely asserted-empty)."""
+    root = _repo_root()
+    consumer_py = (root / "src" / "reyn" / "runtime" / "presentation_consumer.py").resolve()
+    start, end = _sink_method_span(consumer_py)
+    tree = ast.parse(consumer_py.read_text(encoding="utf-8"))
+    constructions = [
+        node.lineno
+        for node in ast.walk(tree)
+        if _is_outbox_renderer_construction(node) and start <= node.lineno <= end
+    ]
+    assert constructions, (
+        "OutboxPresentationConsumer.sink must construct OutboxPresentationRenderer "
+        "(the single allowed present-sink chokepoint) — none found"
+    )

--- a/tests/test_present_sink_na_ratchet_2708.py
+++ b/tests/test_present_sink_na_ratchet_2708.py
@@ -1,0 +1,51 @@
+"""Tier 2: OS invariant — #2708 P1 NA-present-surface reviewed ratchet.
+
+A surface with NO human presentation drain may use a ``NullPresentationSink``
+(documented no-op) — but ONLY through ``NullPresentationConsumer``, and ONLY for a
+surface named in the reviewed ``_NA_PRESENTATION_SURFACES`` frozenset. This ratchet
+(the FP-0056 admin-6 equality model) prevents a NEW human/visible surface from
+silently NA-dodging (passing a Null sink instead of implementing a real present
+consumer): adding a member forces this equality assertion to be updated in the same
+review, and constructing a Null consumer for a non-member raises.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.presentation_consumer import (
+    _NA_PRESENTATION_SURFACES,
+    NullPresentationConsumer,
+    NullPresentationSink,
+)
+
+
+def test_na_surface_set_is_the_reviewed_frozenset() -> None:
+    """Tier 2: the NA-present surfaces are EXACTLY the reviewed set (web / mcp /
+    dogfood). A new member (esp. a human surface) must be added here deliberately —
+    the equality ratchet blocks a silent NA-dodge."""
+    assert _NA_PRESENTATION_SURFACES == frozenset({"web", "mcp", "dogfood"})
+
+
+def test_null_consumer_refuses_non_reviewed_surface() -> None:
+    """Tier 2: a Null present sink is refused for a surface NOT in the reviewed NA
+    set (e.g. a human surface trying to dodge providing a real consumer)."""
+    with pytest.raises(ValueError):
+        NullPresentationConsumer("chat")
+    with pytest.raises(ValueError):
+        NullPresentationConsumer("chainlit")
+
+
+def test_null_consumer_yields_noop_sink_for_reviewed_surface() -> None:
+    """Tier 2: each reviewed NA surface constructs a NullPresentationConsumer whose
+    sink is a NullPresentationSink (render is a no-op that never raises)."""
+
+    class _StubSession:
+        pass
+
+    for surface in ("web", "mcp", "dogfood"):
+        consumer = NullPresentationConsumer(surface)
+        assert consumer.surface == surface
+        sink = consumer.sink(_StubSession())
+        assert isinstance(sink, NullPresentationSink)
+        # no-op render must not raise (fire-and-continue display contract)
+        sink.render(object())

--- a/tests/test_scoped_session_factory_invariant_1402.py
+++ b/tests/test_scoped_session_factory_invariant_1402.py
@@ -62,6 +62,7 @@ _REQUIRED_SCOPED = frozenset({
     "eager_embedding_build",
     "allowed_mcp",
     "task_backend",  # #1953 slice R: per-session Task backend (per-frontend scoped — I-5=(A))
+    "presentation_consumer",  # #2708 P1: per-frontend present-sink consumer (orphan-impossible — a surface cannot silently omit a present sink)
     "factory_config",  # #2093: the uniform config bundle — required, can't be omitted
 })
 


### PR DESCRIPTION
**[per-PR-coder]** — Phase 1 of #2708 (Surface Capability Contract). Makes the present render **sink** a required, orphan-impossible construction input so no surface can build a Session that returns \`ok:True\` while the user sees nothing (the #2688/#2707 silent-invisible-present class). Part of #2708 — does NOT close it.

## Step 1 — consumer topology (re-grounded at file:line, #2707 discipline)
Who drains the outbox \`"presentation"\` message and renders it, per surface:

| surface | outbox present consumer (drain) today | verified at | P1 sink |
|---|---|---|---|
| inline-CUI | `InlineChatRenderer` drains + `render_presentation_nodes` | `interfaces/repl/renderer.py:148`, `:650`, `:803` | `OutboxPresentationConsumer` (byte-identical) |
| plain `--cui` | same InlineChatRenderer path | `interfaces/repl/renderer.py:148` | `OutboxPresentationConsumer` |
| pipe-run | self-delivering stdout override (post-hoc on op_ctx) | `interfaces/cli/commands/pipe.py:729` | unchanged (registry base = `OutboxPresentationConsumer`; stdout override kept) |
| chainlit | **incomplete fall-through — `meta["nodes"]` dropped, `text=""`** | `chainlit_app/adapter.py` generic branch | **complete consumer + FORCED drain fix** |
| web / A2A | none (external outbox interceptor routes only `kind="agent"`) | `runtime/external_routing.py:333`, `web/deps.py:185` | `NullPresentationConsumer("web")` (reviewed NA) |
| mcp | none (stdio history-harvest) | `interfaces/cli/commands/mcp.py` (no present drain) | `NullPresentationConsumer("mcp")` (reviewed NA) |
| dogfood | none (headless eval harness, zero outbox/present drain) | `interfaces/cli/commands/dogfood.py` | `NullPresentationConsumer("dogfood")` (reviewed NA) |
| driver-session | orphan → #2707 interim forwards to parent | `runtime/session_api.py:535` | KEEP #2707 interim (P3 replaces with spawn-bridge) |

**Every `OutboxPresentationRenderer(...)` instantiation site in `src/reyn` (for the AST guard):** before P1 there were two — `runtime/session.py:1724` (uniform default, REMOVED) and the class def `runtime/session_buses.py:160`. After P1 the sole construction Call site is `OutboxPresentationConsumer.sink()`. (Non-instantiation refs are docstrings/comments in `session_api.py`, `op_runtime/present.py`, etc.)

## Crux resolution (producer≠consumer; required-kwarg alone = false-fix)
The gap was never the producer (`session.py:1724` was uniform). Promoting the producer would let a surface pass a bare `OutboxPresentationRenderer` with no consumer = explicit orphan that still compiles. Resolution (lead + architect confirmed): the required kwarg is the **`PresentationConsumer`**, not a bare renderer — the outbox renderer needs the not-yet-built Session, so `.sink(session)` defers construction (exactly the architect's `PresentationConsumer.sink(session)->OutboxPresentationRenderer` mechanism; "type = PresentationRenderer" = the `.sink()` return type).

## The interface landed
- `runtime/presentation_consumer.py`: `PresentationConsumer` protocol (`.sink(session)->PresentationRenderer`); `OutboxPresentationConsumer` (sole outbox-renderer construction site); `NullPresentationSink` + `NullPresentationConsumer` (NA, gated by a **reviewed `_NA_PRESENTATION_SURFACES` frozenset** = `{web, mcp, dogfood}`, each with a why-NA rationale comment).
- `build_scoped_chat_session` gains a **REQUIRED no-default `presentation_consumer` kwarg** (added to `_REQUIRED_SCOPED` in the #1402 invariant test). Session stores it; the per-turn factory calls `self._presentation_consumer.sink(self)` — the removed `session.py:1724` uniform `OutboxPresentationRenderer(self)` default. `router_op_context.py` `presentation_renderer =None` silent default removed (now required-explicit; `Session._make_router_op_context` passes `None` explicitly — the file/MCP-op path no present op reaches).

## AST guard (single-writer, #1190 model)
`tests/test_present_sink_ast_guard_2708.py`: `OutboxPresentationRenderer(...)` may be constructed **only inside `OutboxPresentationConsumer.sink`** (`runtime/presentation_consumer.py`); any other `src/reyn` site → RED. **Allowed site:** the `sink` method span in `presentation_consumer.py`. Enumerated + asserted from the full grep above.

## Forced chainlit fix (#2688)
chainlit is a human surface → cannot NA-dodge (Null refused for non-reviewed surface). `outbox_to_chainlit` now renders the `present` render model from `meta["nodes"]` to Markdown (text/code/diff/keyvalue/table/list/image) instead of the empty-`text` fall-through.

## RED→GREEN + byte-identical evidence (falsify via cp-backup, never git checkout)
- **AST guard**: injected an orphan `OutboxPresentationRenderer(session)` into `session_buses.py` → guard RED naming `session_buses.py:161`; restored → GREEN.
- **chainlit fix**: removed the new presentation branch → `content=''` (the exact #2688 bug: `ChainlitPayload(..., content='')`); restored → GREEN.
- **Forcing**: `build_scoped_chat_session()` without `presentation_consumer` → `TypeError` naming the missing arg; invariant test pins it required-no-default.
- **byte-identical**: `OutboxPresentationConsumer().sink(session).render(...)` puts the same `kind="presentation"` message (`surface_name="inline-cui"`) as before; existing `test_present_renderer_fp0054_prb` / `test_2707_pipeline_present_forwards_to_caller` still green.

## 4 CI gates (all local, PYTHONPATH=src — editable install points at the main checkout)
- `ruff check src tests` — **All checks passed** (I001 autofixed on new imports).
- `python scripts/test_tier_audit.py --strict <4 changed test files>` — **15 inspected, 0 errors**.
- `pytest` (repo root) — **7847 passed, 21 skipped**; 5 failures are **pre-existing** web/A2A route-mounting + plugin-loader tests, reproduced on a **pristine origin/main worktree** (unrelated to presentation; consistent with the in-flight MCP/FastMCP arc): `test_fp0001_routes_mounted`, `web/test_a2a::test_a2a_routes_mounted`, `web/test_mcp_sse::test_mcp_routes_mounted`, `web/test_plugin_loader::test_loader_disambiguates_via_package_field`, `web/test_resources_router::test_resources_route_is_mounted_on_app`.
- `python scripts/verify_module_docstrings.py <11 changed src files>` — **OK**.

## Scope (per architect)
P1 = present-sink-specific + byte-identical. NOT building the canonical user-reaching kind enum / kind-complete typed contract — that's P3. Driver #2707 interim kept (P3 spawn-bridge replaces it).

## Test plan
- [x] AST guard RED→GREEN (falsify + restore)
- [x] chainlit present RED→GREEN (falsify + restore)
- [x] forcing: missing kwarg → TypeError; invariant pins required-no-default
- [x] byte-identical present render (inline outbox + pipe-run interim)
- [x] NA ratchet equality + non-NA refusal
- [x] all 4 CI gates run locally to completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)