### PR TITLE
fix: #2714 close held MCP connections on normal reyn exit (+ guaranteed subprocess terminate)

### DIFF
--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -94,7 +94,9 @@ bearer token):
 """
 from __future__ import annotations
 
+import logging
 import os
+import signal
 import sys
 import tempfile
 import warnings
@@ -107,6 +109,8 @@ from typing import Any, NoReturn
 # callers that import ``from reyn.mcp.client import expand_env`` continue to
 # work without change.
 from reyn.security.secrets.interpolation import expand_env as expand_env  # noqa: F401
+
+logger = logging.getLogger(__name__)
 
 # ── Errors ───────────────────────────────────────────────────────────────────
 
@@ -257,6 +261,82 @@ def _classify_and_raise(exc: Exception, message: str) -> NoReturn:
     raise MCPError(message) from exc
 
 
+def _extract_stdio_child_pid(fastmcp_client: "Any") -> int | None:
+    """#2714 best-effort: return the OS pid of the stdio subprocess backing
+    ``fastmcp_client``, or None if it can't be located.
+
+    fastmcp 3.4.2's ``StdioTransport`` deliberately keeps the spawned subprocess
+    handle OFF the transport object (its connect-task holds it in a task-local
+    ``AsyncExitStack`` so the task owns no back-reference), and neither fastmcp nor
+    the mcp SDK exposes the pid on any public surface. So we walk the connect-task's
+    coroutine / async-generator frame chain (through the mcp ``stdio_client``
+    generator's ``AsyncExitStack``) to find the ``anyio.abc.Process`` and read its
+    ``pid``.
+
+    Every step is defensive: any structural drift from a fastmcp/mcp upgrade returns
+    None, and the belt-and-suspenders reap then simply falls back to the async
+    graceful teardown — byte-identical to pre-#2714 behaviour. Captured ONCE at
+    connect (structure known-good) and only ever used as a terminate target, so a
+    stale/None value can never do worse than the pre-fix orphan."""
+    try:
+        from anyio.abc import Process as _AnyioProcess
+    except Exception:  # pragma: no cover — anyio ships with fastmcp
+        return None
+    transport = getattr(fastmcp_client, "transport", None)
+    connect_task = getattr(transport, "_connect_task", None)
+    get_coro = getattr(connect_task, "get_coro", None)
+    if get_coro is None:
+        return None
+    try:
+        return _walk_frames_for_process_pid(get_coro(), _AnyioProcess)
+    except Exception:  # noqa: BLE001 — pid capture is best-effort, never fatal
+        return None
+
+
+def _walk_frames_for_process_pid(root_coro: "Any", process_type: type) -> int | None:
+    """Breadth-first walk of a coroutine/async-generator/AsyncExitStack graph rooted
+    at ``root_coro``, returning the ``pid`` of the first ``process_type`` instance
+    found in any frame's locals. Bounded (``id``-deduped, step-capped) so a cyclic
+    or pathological graph can never loop forever. Helper for
+    :func:`_extract_stdio_child_pid` — see there for why the walk is necessary."""
+    pending: list[Any] = [root_coro]
+    seen: set[int] = set()
+    steps = 0
+    while pending and steps < 500:
+        steps += 1
+        node = pending.pop()
+        if node is None or id(node) in seen:
+            continue
+        seen.add(id(node))
+        # An AsyncExitStack node: descend into the context managers it will exit
+        # (the mcp stdio_client generator + the ClientSession live here).
+        callbacks = getattr(node, "_exit_callbacks", None)
+        if callbacks is not None:
+            for cb in callbacks:
+                callback = cb[1] if isinstance(cb, tuple) and len(cb) == 2 else None
+                target = getattr(callback, "__self__", None)
+                gen = getattr(target, "gen", None)  # _AsyncGeneratorContextManager.gen
+                if gen is not None:
+                    pending.append(gen)
+                inner_stack = getattr(target, "_exit_stack", None)  # ClientSession
+                if inner_stack is not None:
+                    pending.append(inner_stack)
+            continue
+        frame = getattr(node, "cr_frame", None) or getattr(node, "ag_frame", None)
+        if frame is not None:
+            for value in frame.f_locals.values():
+                if isinstance(value, process_type):
+                    pid = getattr(value, "pid", None)
+                    if isinstance(pid, int):
+                        return pid
+                if getattr(value, "_exit_callbacks", None) is not None:
+                    pending.append(value)
+        awaited = getattr(node, "cr_await", None) or getattr(node, "ag_await", None)
+        if awaited is not None:
+            pending.append(awaited)
+    return None
+
+
 # ── Client ───────────────────────────────────────────────────────────────────
 
 class MCPClient:
@@ -362,6 +442,14 @@ class MCPClient:
         # never raises).
         self._negotiated_version: str | None = None
         self._server_capabilities: Any = None  # mcp.types.ServerCapabilities | None
+        # #2714 belt-and-suspenders: the OS pid of the stdio subprocess this client
+        # spawned (stdio transport only; None for http/sse and until initialize()
+        # succeeds). Captured best-effort right after the connect handshake and used
+        # as the explicit-terminate target in ``_reap_child_process`` so a normal-exit
+        # teardown that is cut short by a swallowed Windows teardown fault (or a loop
+        # torn down before the async graceful close drains) still reaps the child
+        # rather than orphaning it in Task Manager. See ``_extract_stdio_child_pid``.
+        self._child_pid: int | None = None
 
     @property
     def server_name(self) -> str | None:
@@ -496,6 +584,13 @@ class MCPClient:
 
         self._client = client
         self._initialized = True
+        # #2714: capture the stdio subprocess pid now (structure known-good right
+        # after the handshake) for the belt-and-suspenders reap in close(). Best-
+        # effort and stdio-only — non-stdio transports own no subprocess, and any
+        # structural drift in a future fastmcp/mcp upgrade simply yields None (the
+        # reap then no-ops, falling back to the async graceful teardown).
+        if self._type == "stdio":
+            self._child_pid = _extract_stdio_child_pid(client)
         # #2597 capability/version gate: read the negotiated version + capabilities
         # right after the handshake completes. ``initialize_result`` is populated by
         # ``client.__aenter__()`` above (fastmcp 3.4.2: ``Client.initialize_result``
@@ -742,9 +837,22 @@ class MCPClient:
             _classify_and_raise(exc, f"MCP resources/unsubscribe error: {exc}")
 
     async def close(self) -> None:
-        """Tear down the transport and session. Safe to call repeatedly."""
+        """Tear down the transport and session. Safe to call repeatedly.
+
+        #2714: the graceful ``client.close()`` (fastmcp → mcp ``stdio_client``'s
+        SIGTERM→SIGKILL / Windows Job-Object tree-terminate) is the PRIMARY reaper.
+        But that teardown runs inside anyio cancel scopes that, on Windows, can raise
+        a ``BrokenResourceError`` / ``BaseExceptionGroup`` mid-teardown (the fault the
+        existing seams contain, see connection_service.py / pool.py) — and if that
+        fault (or the event loop tearing down before the async teardown drains) cuts
+        the terminate short, the stdio subprocess survives (Unix reaps orphans; Windows
+        does not). So after the graceful close — whether it succeeds OR raises — a
+        ``finally`` explicitly reaps the captured child pid, guaranteeing the OS
+        subprocess is terminated rather than trusting that a swallowed fault left it
+        dead. On a clean close the child is already gone and the reap is a no-op."""
         if self._client is None:
             self.close_stderr_capture()
+            self._reap_child_process()  # nothing opened, or already closed once — still idempotent
             return
         client = self._client
         self._client = None
@@ -758,9 +866,59 @@ class MCPClient:
         try:
             await client.close()
         except Exception:
-            # Best-effort cleanup; transport may already be down.
+            # Best-effort graceful cleanup; transport may already be down. The
+            # belt-and-suspenders reap in the finally still terminates the OS
+            # subprocess even when this graceful path raised (the #2714 guard).
             pass
-        self.close_stderr_capture()
+        finally:
+            # #2714: explicit terminate runs on BOTH the success and the fault path
+            # (finally, not just after — a BaseExceptionGroup from the anyio teardown
+            # would otherwise skip it), so a Windows teardown fault can never leave the
+            # child alive.
+            self._reap_child_process()
+            self.close_stderr_capture()
+
+    def _reap_child_process(self) -> None:
+        """#2714 belt-and-suspenders: synchronously terminate the captured stdio child
+        subprocess if it is still alive. Idempotent + best-effort — never raises.
+
+        The async graceful teardown normally leaves the child already dead, so the
+        common case is ``ProcessLookupError`` (already gone) → a no-op. This exists for
+        the path where the graceful teardown did NOT complete (a swallowed Windows
+        teardown fault, or a loop torn down before it drained): a plain synchronous
+        ``os.kill`` reaps the child without needing a live event loop.
+
+        Scope note (honest bound): this reaps the DIRECT child pid via stdlib
+        ``os.kill`` only (psutil is not a dependency), which is exactly the reported
+        leak (``python -m <server>`` / an ``execvp``-preserving sandbox wrapper, whose
+        direct child IS the server — verified). Full process-TREE termination (a server
+        that itself forks grandchildren) stays owned by the graceful path's
+        SIGTERM→SIGKILL / Windows Job-Object teardown."""
+        pid = self._child_pid
+        if pid is None:
+            return
+        self._child_pid = None
+        # SIGKILL is absent on Windows; os.kill(pid, SIGTERM) there maps to
+        # TerminateProcess — either way an unconditional, immediate terminate.
+        sig = getattr(signal, "SIGKILL", signal.SIGTERM)
+        try:
+            os.kill(pid, sig)
+        except (ProcessLookupError, ChildProcessError):
+            return  # already gone — the graceful path reaped it (the common no-op case)
+        except OSError as exc:  # e.g. EPERM — never fail teardown on the reap
+            logger.warning("MCP subprocess reap (pid=%s) failed: %r", pid, exc)
+            return
+        # POSIX: the child was spawned in-process (anyio.open_process) so it is OUR
+        # child — waitpid it so the freshly SIGKILL'd process doesn't linger as a
+        # zombie (itself a leftover process). Blocks only until the just-killed child
+        # is reaped (immediate); a concurrent reap by asyncio's child watcher surfaces
+        # as ChildProcessError, which is fine. Windows has no zombies and no waitpid
+        # for a non-os-spawned pid, so skip it there.
+        if os.name == "posix":
+            try:
+                os.waitpid(pid, 0)
+            except (ChildProcessError, OSError):
+                pass
 
     # ── stderr capture (stdio only) ─────────────────────────────────────────
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3004,15 +3004,35 @@ class AgentRegistry:
             if not t.done():
                 t.cancel()
         tasks = self.running_tasks()
-        if not tasks:
-            return
-        # Cooperative grace, then hard-cancel any straggler (cancelled forwarders
-        # finish immediately; a stuck session.run lands in `pending`).
-        _done, pending = await asyncio.wait(tasks, timeout=_SHUTDOWN_GRACE_S)
-        for t in pending:
-            t.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        if tasks:
+            # Cooperative grace, then hard-cancel any straggler (cancelled forwarders
+            # finish immediately; a stuck session.run lands in `pending`).
+            _done, pending = await asyncio.wait(tasks, timeout=_SHUTDOWN_GRACE_S)
+            for t in pending:
+                t.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+        # #2714: close held MCP connections (Option C) for EVERY loaded session on the
+        # NORMAL-exit path too — the REPL's /quit + Ctrl-C/EOF (interfaces/repl/repl.py)
+        # route through here, but pre-#2714 only ``remove_session`` (spawned-session
+        # drop) and ``archive_agent`` (DELETE) ran the MCP teardown, so the MAIN
+        # interactive session's held stdio subprocesses were orphaned on every ordinary
+        # exit (accumulating in Windows Task Manager — Unix reaps them, Windows does
+        # not). Run AFTER the run-loop tasks have drained/cancelled above so no in-flight
+        # MCP call races the close, and while this event loop is still alive (this async
+        # method is awaited before the loop tears down — an async close needs a live
+        # loop; MCPClient.close's synchronous belt-and-suspenders reap covers the case
+        # where a teardown fault or loop-teardown cuts the graceful close short). A
+        # no-op for ephemeral sessions (never populate the connection service) and
+        # sessions built without one (getattr guard) — mirrors remove_session/
+        # archive_agent's teardown seam.
+        for _name, session in self._iter_named_sessions():
+            aclose_mcp = getattr(session, "aclose_mcp_connections", None)
+            if callable(aclose_mcp):
+                try:
+                    await aclose_mcp()
+                except Exception as exc:
+                    logger.warning("MCP connection teardown failed for %r: %s", _name, exc)
 
     def loaded_names(self) -> list[str]:
         return list(self._sessions.keys())

--- a/tests/test_2714_mcp_shutdown_teardown.py
+++ b/tests/test_2714_mcp_shutdown_teardown.py
@@ -1,0 +1,102 @@
+"""#2714 — held MCP stdio subprocesses must be closed on the NORMAL-exit path.
+
+The bug: the main interactive session's held MCP connections (Option C, #2597 S2a)
+were closed only from ``registry.remove_session`` (spawned-session drop) and
+``archive_agent`` (DELETE) — never on ordinary ``reyn chat`` exit (REPL /quit +
+Ctrl-C/EOF → ``registry.shutdown()``). So every normal exit orphaned the held stdio
+subprocess (``python -m <server>`` / ``uvx``); Unix reaps orphans, Windows does not,
+so they accumulate in Task Manager.
+
+Real instances only, per the testing policy: no ``mock.patch`` / ``MagicMock``. Stdio
+round-trips spawn a REAL subprocess running ``tests/_support/mcp_fastmcp_echo_server.py``
+(a real FastMCP server); its ``pid`` tool returns the subprocess's own OS pid, so the
+tests observe actual process termination via ``os.kill`` rather than object identity.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.mcp.client import MCPClient
+
+_SUPPORT_DIR = Path(__file__).parent / "_support"
+_ECHO_SERVER = _SUPPORT_DIR / "mcp_fastmcp_echo_server.py"
+
+_CFG = {"type": "stdio", "command": sys.executable, "args": [str(_ECHO_SERVER)]}
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_main_session_held_mcp_connections(tmp_path: Path):
+    """Tier 2: ``registry.shutdown()`` (the REPL /quit + Ctrl-C/EOF normal-exit seam)
+    closes the MAIN session's held MCP connections, so a held stdio subprocess is not
+    orphaned on ordinary exit (#2714). RED on origin/main (shutdown omitted the MCP
+    teardown — held_servers stayed ``["srv"]`` after shutdown). Real AgentRegistry +
+    real MAIN (default-sid) session + real stdio echo server (no mocks)."""
+    from reyn.runtime.registry import AgentRegistry
+    from reyn.runtime.session import Session
+
+    def _factory(profile) -> Session:
+        return Session(agent_name=profile.name, mcp_servers={"srv": _CFG})
+
+    registry = AgentRegistry(project_root=tmp_path, session_factory=_factory)
+    registry.create("owner")
+    session = registry.get_or_load("owner")  # the MAIN (default-sid) session
+
+    await session._mcp_call_tool("srv", "echo", {"text": "hi"})
+    assert session.mcp_held_servers() == ["srv"]
+
+    await registry.shutdown()
+    assert session.mcp_held_servers() == [], (
+        "registry.shutdown() must close the main session's held MCP connections "
+        "on the normal-exit path (#2714)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_subprocess_even_when_graceful_close_raises():
+    """Tier 2: ``MCPClient.close()``'s belt-and-suspenders reap terminates the stdio
+    subprocess even when the graceful fastmcp/mcp teardown RAISES (#2714 #C — the
+    swallowed Windows teardown-fault path). The fix must GUARANTEE the OS subprocess
+    is terminated, not trust that a contained fault left the child dead. Real
+    subprocess (echo server); the graceful close is forced to raise by swapping in a
+    real fake fastmcp client (a plain object whose ``close`` raises — no mock.patch)."""
+
+    class _RaisingClose:
+        async def close(self) -> None:
+            raise RuntimeError("simulated Windows teardown fault")
+
+    client = MCPClient(_CFG, agent_id="reyn/test", server_name="echo")
+    await client.__aenter__()
+    real_fastmcp = client._client  # keep for cleanup — we orphan it below
+    try:
+        pid = int((await client.call_tool("pid", {}))["content"][0]["text"])
+        os.kill(pid, 0)  # process alive before close (no exception)
+
+        client._client = _RaisingClose()  # graceful close will now raise
+        await client.close()  # must NOT propagate the fault AND must still reap
+
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)  # the belt-and-suspenders reap terminated the child
+    finally:
+        with contextlib.suppress(Exception):
+            await real_fastmcp.close()
+
+
+@pytest.mark.asyncio
+async def test_graceful_close_alone_terminates_subprocess():
+    """Tier 2: the happy-path counterpart — a clean ``MCPClient.close()`` (no injected
+    fault) still terminates the stdio subprocess (the graceful fastmcp/mcp teardown is
+    the PRIMARY reaper; the #2714 belt-and-suspenders is a no-op here). Guards against
+    the reap wiring accidentally breaking the normal teardown."""
+    client = MCPClient(_CFG, agent_id="reyn/test", server_name="echo")
+    await client.__aenter__()
+    pid = int((await client.call_tool("pid", {}))["content"][0]["text"])
+    os.kill(pid, 0)  # alive
+
+    await client.close()
+    with pytest.raises(ProcessLookupError):
+        os.kill(pid, 0)  # terminated on a clean close


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2714

## The bug (code-verified, cross-platform logic gap)
The main interactive session's held MCP stdio connections (Option C, #2597 S2a) were closed only from `registry.remove_session` (spawned-session drop) and `archive_agent` (DELETE) — **never on ordinary `reyn chat` exit**. The REPL's `/quit` + Ctrl-C/EOF (`interfaces/repl/repl.py:121,127`) route through `registry.shutdown()`, which posted the agent shutdown sentinel + cancelled forwarders but **never ran the MCP teardown**. So the main session's held stdio subprocess (`python -m <server>` / `uvx`) was orphaned on every normal exit. Unix reaps orphans; Windows does not → accumulation in Task Manager.

This is a **logical** cleanup-correctness defect, fully determinable and fixable cross-platform.

## Fix — every exit path now closes + terminates

**1. Exit-path wiring (`runtime/registry.py::shutdown`)** — after draining the run-loop tasks (and no longer early-returning via `if not tasks: return` when a session has no running task — that early return is exactly what skipped the teardown for an idle main session), close held MCP connections for **every loaded session** via `aclose_mcp_connections` — the same teardown seam `remove_session` / `archive_agent` already use, now also on the normal-exit path (`/quit`, Ctrl-C, EOF/window-close all funnel through `shutdown()`). Runs **after** task drain (no in-flight MCP call races the close) and **while the event loop is still alive** (the async graceful close needs a live loop; `shutdown()` is awaited before the loop tears down).

**2. Terminate-guarantee for the #C fault-containment (`mcp/client.py::close`)** — the existing seams (`connection_service.py:518`, `pool.py:124`) **swallow** Windows teardown faults (BrokenResourceError / BaseExceptionGroup). If that swallowed fault cut the subprocess-terminate short, the child would survive. So instead of trusting the swallow, `MCPClient.close()` now, in a **`finally`** (runs on both the success and the fault path — a BaseExceptionGroup would otherwise skip an after-statement), **explicitly terminates** the captured stdio child pid with a synchronous `os.kill` (+ POSIX `waitpid` so the SIGKILL'd child doesn't linger as a zombie). Synchronous, so it reaps even if the loop is already tearing down. On a clean close the child is already gone → `ProcessLookupError` → no-op.

**What the graceful path does (traced against installed fastmcp 3.4.2 + mcp SDK):** `MCPClient.close` → fastmcp `Client.close` → `_disconnect(force=True)` → `StdioTransport.disconnect` → the mcp `stdio_client` teardown, which closes stdin, waits, then `_terminate_process_tree` (SIGTERM→SIGKILL / Windows Job-Object) — i.e. the graceful path DOES own process-tree termination and normally leaves the child dead before the stream-close faults. The belt-and-suspenders is the guarantee for the case where a swallowed fault or loop-teardown interrupts that graceful teardown.

**Child-pid capture:** fastmcp keeps the subprocess handle off the transport (task-local `AsyncExitStack`), and neither fastmcp nor mcp exposes the pid, so it's captured best-effort at connect by walking the connect-task frame chain. Fully defensive: any structural drift from a future fastmcp/mcp upgrade yields `None` → the reap no-ops and falls back to the async graceful teardown (byte-identical to pre-fix). Scope bound: this reaps the **direct child** pid via stdlib `os.kill` only (psutil is not a dependency) — which is exactly the reported leak (`python -m <server>`, and an `execvp`-preserving sandbox wrapper whose direct child IS the server — verified: under Seatbelt the captured pid == the server's own `os.getpid()`). Process-TREE reaping of a server that forks grandchildren stays owned by the graceful path.

**Also confirmed (no change needed):** ephemeral-session MCP calls already close per-call via the one-shot `MCPClientPool` (`session.py:6079-6082`, `async with … as pool`); per-reconnect teardown (`connection_service.py:409-420`) already closes the dead client before reopening — and now also benefits from the `MCPClient.close` terminate-guarantee.

## Tests (`tests/test_2714_mcp_shutdown_teardown.py`) — real subprocess, no mocks
- `test_shutdown_closes_main_session_held_mcp_connections` — real `AgentRegistry` + real MAIN session + real stdio echo server; asserts `registry.shutdown()` leaves `mcp_held_servers() == []`. **RED on origin/main** (stayed `["srv"]`), GREEN after.
- `test_close_reaps_subprocess_even_when_graceful_close_raises` — real subprocess; the graceful close is forced to raise via a **real fake** fastmcp client (a plain object whose `close` raises — no `mock.patch`); asserts the real subprocess is terminated (`os.kill(pid, 0)` → `ProcessLookupError`). **RED on origin/main.** Proves terminate fires even on the swallowed-fault path.
- `test_graceful_close_alone_terminates_subprocess` — happy-path guard: a clean close still terminates the child (graceful path is the primary reaper; the reap is a no-op).

Falsify done via `cp -r` scratch (never git stash/checkout): both new-behavior tests go RED on pristine `origin/main` sources, GREEN with the fix.

## CI gates (all run locally against the worktree src)
- `ruff check src tests` — **PASS**
- `python scripts/test_tier_audit.py --strict tests/test_2714_mcp_shutdown_teardown.py` — **PASS** (3/3, 0 Tier-4)
- `pytest` (repo root) — my 3 tests **PASS**; full suite **7850 passed, 5 failed**. All 5 failures (`tests/web/test_a2a.py`, `test_mcp_sse.py`, `test_plugin_loader.py`, `test_resources_router.py`, `tests/test_fp0001_a2a_endpoints.py` — all "routes_mounted"/plugin-loader) are **pre-existing and env-specific** (web route mounting): verified identical on pristine `origin/main` with my code swapped out. Unrelated to this change (MCP/registry).
- `python scripts/verify_module_docstrings.py src/reyn/mcp/client.py src/reyn/runtime/registry.py` — **PASS**

## Correctness claim
The correctness bar here is **logical completeness**, determinable off-Windows: every ordinary exit path (`/quit`, Ctrl-C, EOF/window-close) now calls the MCP teardown, and the OS subprocess terminate is guaranteed to complete (explicit synchronous `os.kill`, in a `finally`, not delegated to a swallowed fault). Both properties are proven cross-platform by the tests above. Owner's Windows Task-Manager check post-merge is a sanity pass for any platform-specific surprise — not a gate on whether the cleanup happens.

## Doc note
No doc change: `docs/concepts/tools-integrations/mcp.md` already documents held connections as session-lifetime; this fix makes the implementation honor that contract on the normal-exit path (a bug fix, not a contract change).

## Test plan
- [x] RED→GREEN falsified via `cp -r` scratch on pristine `origin/main`
- [x] All 4 CI gates run locally (results above)
- [x] Belt-and-suspenders terminate verified against a real spawned subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)