### PR TITLE
feat: #2708 P3.1 — driver spawn-bridge (present reaches parent by construction) + audit bridge; remove #2707 interim

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -203,7 +203,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
 
         registry_ref: list = []
 
-        def _session_factory(profile: AgentProfile) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
             _ctx_perm, _profile_excluded = registry_ref[0].resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
@@ -213,7 +213,8 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # now renders the "presentation" nodes to the chainlit UI (the forced
                 # #2688 silent-drop fix); before #2708 it fell through to text="" and the
                 # present output was invisible.
-                presentation_consumer=OutboxPresentationConsumer(),
+                # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
+                presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
                 agent_name=profile.name,
                 model=model,
                 resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -364,7 +364,7 @@ def run(args: argparse.Namespace) -> None:
         interactive=sys.stdin.isatty(),
     )
 
-    def _session_factory(profile: AgentProfile):
+    def _session_factory(profile: AgentProfile, *, presentation_consumer=None):
         # Captured CLI defaults — registry doesn't need to know them.
         # #1827 S3: resolve the agent's topology capability_profile → contextual
         # narrowing (enforcement) + view exclusion. (None, ∅) when unbound = byte-identical.
@@ -373,7 +373,9 @@ def run(args: argparse.Namespace) -> None:
             # #2708 P1: chat-CLI (inline/plain --cui / run-once) — the InlineChatRenderer
             # drains the outbox "presentation" message and renders it (renderer.py:148),
             # so the outbox-backed consumer is byte-identical to the pre-#2708 default.
-            presentation_consumer=OutboxPresentationConsumer(),
+            # #2708 P3.1: a spawn override (the attached pipeline driver's parent-bound
+            # SpawnBridgePresentationConsumer) wins when supplied; None = this default.
+            presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -471,7 +471,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         # cell so the factory can reference it before assignment completes.
         _reg_cell: list = []
 
-        def _session_factory(profile: AgentProfile) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
             # #1827 S3: resolve the agent's topology capability_profile. The registry
             # cell may be empty during bootstrap → (None, ∅) = byte-identical.
             _reg = _reg_cell[0] if _reg_cell else None
@@ -482,7 +482,8 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # #2708 P1: the dogfood eval harness is headless with no outbox/present
                 # drain at all — a reviewed NA surface. Null is byte-identical (present
                 # was never rendered by the harness before #2708).
-                presentation_consumer=NullPresentationConsumer("dogfood"),
+                # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
+                presentation_consumer=presentation_consumer or NullPresentationConsumer("dogfood"),
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -395,13 +395,14 @@ def run_serve(args: argparse.Namespace) -> None:
 
     project_context = load_project_context(session_cfg.config, project_root)
 
-    def _session_factory(profile: AgentProfile):
+    def _session_factory(profile: AgentProfile, *, presentation_consumer=None):
         # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
             # #2708 P1: stdio-MCP is a history-harvest surface with no live present drain
             # — a reviewed NA surface. Null is byte-identical (present was invisible before).
-            presentation_consumer=NullPresentationConsumer("mcp"),
+            # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
+            presentation_consumer=presentation_consumer or NullPresentationConsumer("mcp"),
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -300,7 +300,7 @@ def _get_registry():
             os.environ.get("REYN_WEB_EAGER_EMBEDDING_BUILD", "").strip() == "1"
         )
 
-        def _session_factory(profile: AgentProfile) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
             registry = registry_ref[0]
             _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
@@ -310,7 +310,8 @@ def _get_registry():
                 # (its external outbox interceptor routes only kind="agent",
                 # external_routing.py:333) — a reviewed NA surface. Null is byte-identical
                 # (present was invisible + not externally routed before #2708).
-                presentation_consumer=NullPresentationConsumer("web"),
+                # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
+                presentation_consumer=presentation_consumer or NullPresentationConsumer("web"),
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/runtime/lifecycle_forwarder.py
+++ b/src/reyn/runtime/lifecycle_forwarder.py
@@ -29,9 +29,21 @@ from reyn.schemas.models import Event
 class ChatLifecycleForwarder:
     """Callable subscriber that bridges session-level events into the outbox."""
 
-    def __init__(self, outbox: asyncio.Queue, registry: "Any | None" = None) -> None:
+    def __init__(
+        self,
+        outbox: asyncio.Queue,
+        registry: "Any | None" = None,
+        events: "Any | None" = None,
+    ) -> None:
         self.outbox = outbox
         self._registry = registry
+        # #2708 P3.1 Half-B: this forwarder's OWN session EventLog (the parent/caller
+        # audit log). Used by the driver→parent bridge to re-emit a driver-session's
+        # ``presented`` event onto the parent's log with ``bridged_from=<driver_sid>``,
+        # so the present audit trail is not split across the driver and parent sessions.
+        # None (pre-P3.1 callers / tests) simply skips the audit-forward (visible-output
+        # bridge is independent, established by consumer inheritance, not here).
+        self._events = events
         # #2570: run_id -> (driver EventLog, listener fn, invoking tool name).
         # Tracks bridge-subscriptions to a pipeline driver-session's own
         # EventLog for the duration of one sync-attached run_pipeline call.
@@ -331,6 +343,29 @@ class ChatLifecycleForwarder:
             return
 
         def _on_driver_event(event: Event) -> None:
+            if event.type == "presented":
+                # #2708 P3.1 Half-B: bridge the driver's ``presented`` P6 audit event
+                # onto the PARENT's EventLog. Deliberately NOT run_id-filtered (unlike
+                # the pipeline_step_* path below), and this is SAFE — not the mis-fix of
+                # dropping a shared filter that guards concurrency:
+                #   (a) a pipeline-step present's ``run_id`` is structurally None, never
+                #       the pipeline rid — present.py:116 builds its OpContext via
+                #       ``ctx.router_state.op_context_factory()`` (the driver session's
+                #       ``make_router_op_context``, session.py:1739, run_id=None), and
+                #       op_runtime/present.py:132 emits ``presented`` with that run_id.
+                #       A run_id-equality filter would therefore SILENTLY DROP every
+                #       bridged present (the architect's flagged failure mode).
+                #   (b) there is no cross-run leak to guard against here: each pipeline
+                #       run spawns its OWN driver session (session_api._spawn_pipeline_
+                #       driver_session → a fresh spawn_session_recorded), so this
+                #       per-driver-EventLog subscription — added on attach, removed on
+                #       tool completion — sees exactly ONE run's presents. The driver
+                #       session runs only the pipeline (a PipelineExecutorDriver loop, no
+                #       interactive chat), so no unrelated present rides this log.
+                # (Making ``presented.run_id`` carry the rid = a larger present-op change,
+                # architect Q1-deferred; this mechanism-level bridge is the P3.1 scope.)
+                self._forward_presented_event(event, driver_sid=driver_sid, run_id=run_id)
+                return
             if event.type not in ("pipeline_step_started", "pipeline_step_completed"):
                 return
             if event.data.get("run_id") != run_id:
@@ -357,6 +392,28 @@ class ChatLifecycleForwarder:
             self.outbox.put_nowait(OutboxMessage(kind="status", text=text, meta=meta))
         except asyncio.QueueFull:
             pass
+
+    def _forward_presented_event(
+        self, event: Event, *, driver_sid: str, run_id: str
+    ) -> None:
+        """#2708 P3.1 Half-B: re-emit a driver-session's ``presented`` P6 event onto the
+        PARENT's EventLog so the present audit trail is not split across sessions.
+
+        The driver's OWN log legitimately keeps its native copy; this ADDS a copy to the
+        parent's log (which previously had none) annotated with provenance so replay/audit
+        tooling can tell a bridged present from a native one and not double-count:
+        ``bridged_from`` = the driver sid, ``pipeline_run_id`` = the attached run's id
+        (distinct from the event's own ``run_id``, which is the chat-router ``None``).
+
+        No-op when the forwarder was built without an ``events`` handle (pre-P3.1 callers
+        / tests). The parent forwarder defines no ``on_presented`` handler, so re-emitting
+        here does not recurse."""
+        if self._events is None:
+            return
+        payload = dict(event.data)
+        payload["bridged_from"] = driver_sid
+        payload.setdefault("pipeline_run_id", run_id)
+        self._events.emit("presented", **payload)
 
     def _maybe_unsubscribe_pipeline(self, tool: "str | None", run_id: "str | None") -> None:
         if not self._pipeline_subs:

--- a/src/reyn/runtime/presentation_consumer.py
+++ b/src/reyn/runtime/presentation_consumer.py
@@ -84,6 +84,41 @@ class OutboxPresentationConsumer:
         return OutboxPresentationRenderer(session)
 
 
+class SpawnBridgePresentationConsumer:
+    """A spawned/driver session's presentation consumer that DELEGATES to the PARENT's
+    consumer bound to the PARENT session — the child's `present` output reaches the
+    parent's surface *by construction* (#2708 P3.1).
+
+    A chat-invoked pipeline runs in a spawned driver-session; a `present` step in it
+    would otherwise render through the driver's OWN outbox sink, isolated from the parent
+    chat (the #2688 orphan class). This consumer, wired ONLY on the attached driver-spawn
+    path (`session_api._spawn_pipeline_driver_session`), makes the driver's present sink
+    resolve to the PARENT session's sink instead: `sink(child)` ignores the child and
+    returns `parent_consumer.sink(parent_session)`, so the render lands on the parent's
+    outbox exactly as a chat-native present would.
+
+    It STRUCTURALLY REPLACES the #2707 interim per-message outbox forward
+    (`session_api.py::run_pipeline_attached`): with the sink inherited, the parent receives
+    the present by construction (single delivery), not by a post-hoc copy of the driver's
+    drained outbox. It constructs NO `OutboxPresentationRenderer` itself (it delegates), so
+    the #2708 AST guard (`tests/test_present_sink_ast_guard_2708.py`) — which pins
+    `OutboxPresentationConsumer.sink` as the SOLE renderer construction site — is
+    unaffected."""
+
+    def __init__(
+        self, parent_consumer: "PresentationConsumer", parent_session: "Session"
+    ) -> None:
+        self._parent_consumer = parent_consumer
+        self._parent_session = parent_session
+
+    def sink(self, session: "Session") -> "PresentationRenderer":
+        # The child `session` is intentionally ignored: bind to the PARENT so render()
+        # writes to the parent's outbox (or, if the parent is itself a driver, recursively
+        # up; or a NullPresentationSink if the parent is an NA surface — inherited for
+        # free by delegating to the parent's own consumer).
+        return self._parent_consumer.sink(self._parent_session)
+
+
 class NullPresentationSink:
     """`PresentationRenderer` (`core/present/renderer.py`) for a surface with no human
     presentation drain: `render` is a documented no-op. Obtainable ONLY through
@@ -129,5 +164,6 @@ __all__ = [
     "NullPresentationSink",
     "OutboxPresentationConsumer",
     "PresentationConsumer",
+    "SpawnBridgePresentationConsumer",
     "_NA_PRESENTATION_SURFACES",
 ]

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2572,7 +2572,11 @@ class AgentRegistry:
         return session
 
     def _construct_session(
-        self, profile: AgentProfile, *, is_delegate: bool = False
+        self,
+        profile: AgentProfile,
+        *,
+        is_delegate: bool = False,
+        presentation_consumer: "object | None" = None,
     ) -> "object":
         """Build a configured Session from a profile (factory + shared-store
         attach), WITHOUT inserting it into the session map. Shared by get_or_load
@@ -2582,11 +2586,22 @@ class AgentRegistry:
         ``_constructing_as_delegate`` for the duration of the (synchronous) factory
         call, so the factory's ``resolved_profile_for(profile.name)`` sees it
         without a factory-signature change. Save/restore (not set-False) so it is
-        correct under nesting too — non-re-entrant today, but free future-proofing."""
+        correct under nesting too — non-re-entrant today, but free future-proofing.
+
+        #2708 P3.1: ``presentation_consumer`` is the spawn-time present-sink OVERRIDE (the
+        reusable capability-bundle inheritance seam — P3.2 threads cred/permission through
+        the SAME param). ``None`` (every non-spawn / default-spawn caller) keeps the
+        factory call byte-identical (``self._factory(profile)``); only when a spawn site
+        opts in (the attached pipeline driver, ``session_api._spawn_pipeline_driver_session``)
+        is the override forwarded, so the widened-factory contract only binds spawn sites
+        that actually pass one — bare test factories stay callable."""
         _prev_delegate = self._constructing_as_delegate
         self._constructing_as_delegate = is_delegate
         try:
-            session = self._factory(profile)
+            if presentation_consumer is not None:
+                session = self._factory(profile, presentation_consumer=presentation_consumer)
+            else:
+                session = self._factory(profile)
         finally:
             self._constructing_as_delegate = _prev_delegate
         # #1547: hand the session the shared anchor store so cut_generation
@@ -2597,7 +2612,10 @@ class AgentRegistry:
             attach_anchor(anchors)
         return session
 
-    def spawn_session(self, name: str, sid: "str | None" = None) -> str:
+    def spawn_session(
+        self, name: str, sid: "str | None" = None,
+        *, presentation_consumer: "object | None" = None,
+    ) -> str:
         """FP-0043 Stage 3: open a NEW conversation Session under an existing
         Agent, SHARING the agent's identity object. Returns the new session-id.
 
@@ -2611,7 +2629,12 @@ class AgentRegistry:
         new_sid = sid or uuid4().hex[:8]
         if self._has_session(name, new_sid):
             raise ValueError(f"session {new_sid!r} already exists for agent {name!r}")
-        session = self._construct_session(self.load_profile(name))
+        # #2708 P3.1: forward the optional present-sink override to the factory (None keeps
+        # today's default self-bound outbox consumer; the attached driver spawn passes a
+        # SpawnBridgePresentationConsumer so the driver's present reaches the parent).
+        session = self._construct_session(
+            self.load_profile(name), presentation_consumer=presentation_consumer,
+        )
         if shared is not None:
             # Share the SAME identity object (not the fresh one the factory built),
             # so a future identity change propagates to all of the agent's sessions.
@@ -2678,6 +2701,7 @@ class AgentRegistry:
     async def spawn_session_recorded(
         self, name: str, *, mode: str = "persistent",
         narrowing: "dict | None" = None,
+        presentation_consumer: "object | None" = None,
     ) -> str:
         """#2103 S1bc: the action-layer SESSION-SPAWN seam — spawn a fresh-context
         session under ``name`` (sync ``spawn_session``) + persist the spawner's
@@ -2688,8 +2712,13 @@ class AgentRegistry:
         (mode + narrowing) for symmetric re-materialise. Returns the new sid.
 
         Does NOT submit a task — that is the caller (the spawn op), separable from the
-        record. Emit no-ops without a WAL."""
-        sid = self.spawn_session(name)
+        record. Emit no-ops without a WAL.
+
+        #2708 P3.1: ``presentation_consumer`` (default None = today's self-bound outbox
+        consumer) is the present-sink override forwarded to the constructed session — the
+        attached pipeline driver spawn passes a ``SpawnBridgePresentationConsumer`` so the
+        driver's present reaches the parent surface by construction."""
+        sid = self.spawn_session(name, presentation_consumer=presentation_consumer)
         if mode == "ephemeral":
             # #2103: mark the live session so it auto-vanishes once its task is done
             # (Session._maybe_schedule_ephemeral_vanish, via this registry's

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -169,16 +169,17 @@ def build_agent_registry_from_project(
     ws_base_dir = project_root
     ws_state_dir = project_root / ".reyn"
 
-    def _session_factory(profile: "AgentProfile"):
+    def _session_factory(profile: "AgentProfile", *, presentation_consumer=None):
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
             # #2708 P1: the reusable registry base session (reyn pipe run's default
             # identity + driver spawns). Outbox-backed, byte-identical to the pre-#2708
             # uniform default: pipe run OVERRIDES the OpContext sink post-hoc with a
-            # self-delivering stdout renderer (pipe.py), and a driver spawn's outbox is
-            # bridged to the parent (#2707 forward) — neither is an orphan. P3 replaces
-            # the #2707 interim with a proper spawn-bridge sink.
-            presentation_consumer=OutboxPresentationConsumer(),
+            # self-delivering stdout renderer (pipe.py). #2708 P3.1: an ATTACHED pipeline
+            # driver spawn now passes a parent-bound SpawnBridgePresentationConsumer
+            # override (present reaches the parent by construction, replacing the removed
+            # #2707 forward); None (default / non-spawn) keeps the outbox-backed consumer.
+            presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
             agent_name=profile.name,
             model=config.model,
             resolver=resolver,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1459,7 +1459,13 @@ class Session:
         # conv pane via OutboxMessage(kind="system").
         from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
         self._chat_events.add_subscriber(
-            ChatLifecycleForwarder(self.outbox, registry=self._registry)
+            # #2708 P3.1 Half-B: give the forwarder THIS session's own EventLog so its
+            # driver→parent bridge (on_pipeline_run_attached) can re-emit a driver
+            # ``presented`` audit event onto the PARENT's log (bridged_from=<driver_sid>),
+            # closing the split audit trail that the visible-output bridge (Half-A) leaves.
+            ChatLifecycleForwarder(
+                self.outbox, registry=self._registry, events=self._chat_events
+            )
         )
         # #398 v4 emitter family — generic events-log subscriber that
         # converts known op-emitted events (= mcp_server_installed,
@@ -2220,6 +2226,15 @@ class Session:
         construction and swapped by ``_reapply_presentations`` on hot-reload. Tests
         verify a registered template is live via this surface."""
         return self._presentation_registry
+
+    @property
+    def presentation_consumer(self):
+        """Read-only accessor for this session's present-sink ``PresentationConsumer``
+        (#2708 P1 stores it; P3.1 reads it here). The spawn-bridge uses this to bind a
+        driver-session's present output to the PARENT: an attached pipeline driver spawn
+        wraps ``parent.presentation_consumer`` in a ``SpawnBridgePresentationConsumer`` so
+        the driver's present reaches the parent surface by construction."""
+        return self._presentation_consumer
 
     @property
     def interventions(self) -> "InterventionRegistry":

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -63,15 +63,18 @@ prefix and differing only in how the caller drives + collects:
     ``EventLog`` (see the function docstring) — the driver-session's live
     events are on a DIFFERENT EventLog than the one the human-attached caller
     (the TUI) watches, so this marker is the signal that bridges the two.
-    #2707: a ``present`` step renders through the driver-session's OWN
-    ``OutboxPresentationRenderer`` onto the DRIVER's outbox — a user-reaching
-    ``"presentation"`` message that is NOT an event, so it does not ride the
-    #2570 eventlog bridge. Parallel to that bridge, ``run_pipeline_attached``
-    forwards the driver's drained ``"presentation"`` outbox messages onto the
-    CALLER's own outbox (the same queue+kind a chat-native present reaches), so
-    a chat-invoked pipeline's present actually shows in the parent chat. This
-    forward is a Phase0 interim (removed/subsumed by P3 spawn-bundle inheritance,
-    #2708 Surface Capability Contract).
+    #2708 P3.1: a ``present`` step's OUTPUT (Half-A) reaches the parent chat surface
+    BY CONSTRUCTION — the attached driver-session is spawned with a
+    ``SpawnBridgePresentationConsumer`` (``runtime/presentation_consumer.py``) bound to the
+    PARENT session, so its present sink IS the parent's sink (structurally replacing the
+    #2707 interim outbox forward, which is removed — keeping both would double-deliver). Its
+    AUDIT event (Half-B) is bridged separately: ``presented`` is a driver-EventLog P6 event
+    (not a ``"presentation"`` outbox message), so it rides the same #2570 driver→parent
+    EventLog bridge as ``pipeline_step_*`` — extended (``lifecycle_forwarder``) to re-emit
+    ``presented`` onto the PARENT's log with ``bridged_from=<driver_sid>`` provenance.
+    Together: both the visible present and its audit trail reach the parent, closing the
+    driver-isolation split. (Detached/async present is out of P3.1 scope — no attached
+    parent surface exists; tracked as the P3 spawn-routing completeness gate.)
 """
 from __future__ import annotations
 
@@ -246,6 +249,7 @@ async def _spawn_pipeline_driver_session(
     notify_reply: bool,
     run_id: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
+    attached_parent_session: "Any | None" = None,
 ) -> "tuple[Any, str, str]":
     """Spawn + arm a pipeline driver-session, up to (but NOT including) the
     run/resume nudge — the shared launch prefix of the async (``start_pipeline_run``)
@@ -275,7 +279,16 @@ async def _spawn_pipeline_driver_session(
          caller collects the result in-band via ``read_result``).
 
     Returns ``(driver_session, run_id, driver_sid)``; the caller drives the run
-    (nudge + detached pump, or attached ``MessageBus.request``)."""
+    (nudge + detached pump, or attached ``MessageBus.request``).
+
+    #2708 P3.1 (Half-A, visible output): when ``attached_parent_session`` is given (the
+    ATTACHED path only — ``run_pipeline_attached`` passes the live caller session), the
+    driver-session is spawned with a ``SpawnBridgePresentationConsumer`` bound to that
+    parent, so a ``present`` step's render reaches the PARENT's surface by construction
+    (structurally replacing the #2707 interim outbox forward). The DETACHED path
+    (``start_pipeline_run``) passes ``None`` — there is no live attached surface, so the
+    driver keeps the default self-bound consumer (its present is audit-only in its own
+    log, correct with no attached parent)."""
     from reyn.core.events.config_recovery import reyn_root
     from reyn.core.pipeline.serde import pipeline_to_dict
     from reyn.core.pipeline.work_order import (
@@ -295,7 +308,20 @@ async def _spawn_pipeline_driver_session(
     # so the embedded pipeline name is sanitized to one safe path component.
     safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", pipeline_name) or "pipeline"
     rid = run_id or f"pipeline-{safe_name}-{uuid.uuid4().hex}"
-    sid = await registry.spawn_session_recorded(reply_to_agent, mode="persistent")
+    # #2708 P3.1 Half-A: on the attached path, bind the driver's present sink to the
+    # PARENT's consumer so its render reaches the parent surface by construction. Detached
+    # spawns pass None → the default self-bound outbox consumer (byte-identical).
+    bridge_consumer: "Any | None" = None
+    if attached_parent_session is not None:
+        from reyn.runtime.presentation_consumer import SpawnBridgePresentationConsumer
+
+        bridge_consumer = SpawnBridgePresentationConsumer(
+            parent_consumer=attached_parent_session.presentation_consumer,
+            parent_session=attached_parent_session,
+        )
+    sid = await registry.spawn_session_recorded(
+        reply_to_agent, mode="persistent", presentation_consumer=bridge_consumer,
+    )
     work_order = PipelineWorkOrder(
         run_id=rid,
         pipeline_name=pipeline_name,
@@ -452,6 +478,15 @@ async def run_pipeline_attached(
     from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
     from reyn.runtime.message_bus import MessageBus
 
+    # #2708 P3.1 Half-A: resolve the live caller (parent) session BEFORE the spawn so the
+    # driver inherits its present sink by construction (the ``SpawnBridgePresentationConsumer``
+    # is built inside ``_spawn_pipeline_driver_session`` from this parent). This is the SAME
+    # (agent, sid) live Session the #2588 cancel-bridge resolves below — resolve it once and
+    # reuse. None (should not happen on the attached path — the caller is live) → no bridge:
+    # the driver keeps its default self-bound consumer (degrades to pre-fix isolation, never
+    # blocks the run).
+    caller_session = registry.get_session(reply_to_agent, reply_to_sid)
+
     session, rid, sid = await _spawn_pipeline_driver_session(
         registry,
         pipeline=pipeline,
@@ -463,6 +498,7 @@ async def run_pipeline_attached(
         notify_reply=False,
         run_id=run_id,
         schema_registry=schema_registry,
+        attached_parent_session=caller_session,
     )
     if caller_events is not None:
         caller_events.emit(
@@ -487,7 +523,6 @@ async def run_pipeline_attached(
     # caller is live), skip the bridge (degrades to the pre-fix behavior, never
     # blocks the run).
     driver = getattr(session, "_loop_driver", None)
-    caller_session = registry.get_session(reply_to_agent, reply_to_sid)
     unregister_cancel: "Any | None" = None
     if caller_session is not None and driver is not None:
         register = getattr(caller_session, "register_cancel_forward", None)
@@ -496,7 +531,11 @@ async def run_pipeline_attached(
 
     bus = MessageBus()
     try:
-        drained = await bus.request(
+        # #2708 P3.1: the drained outbox is no longer inspected for a ``"presentation"``
+        # message to forward (that #2707 interim is removed — present now rides the
+        # inherited parent sink, see below). The request is still awaited for pump
+        # quiescence; its return value is intentionally unused.
+        await bus.request(
             session,
             kind="user",
             payload={"text": "", "chain_id": uuid.uuid4().hex},  # the D案 run nudge
@@ -507,36 +546,13 @@ async def run_pipeline_attached(
         if unregister_cancel is not None:
             unregister_cancel()
 
-    # Phase0 interim for #2707; removed/subsumed by P3 spawn-bundle inheritance
-    # (#2708 Surface Capability Contract). Kept as a LOCALIZED bridge — a plain
-    # "the driver-session's presentation reaches the parent's presentation
-    # consumer" forward, not entangled with any permanent machinery — so P3 can
-    # remove it wholesale once spawn inherits the caller's capability bundle
-    # (presentation sink included).
-    #
-    # #2707 (part of the #2688 present-sink sweep): a `present` step inside the
-    # driver-session renders through the driver's OWN
-    # ``OutboxPresentationRenderer`` (session_buses.py) → the DRIVER session's
-    # outbox as a ``"presentation"`` ``OutboxMessage``. ``MessageBus.request``
-    # above DRAINS that outbox (``drained``) as part of quiescence, but the
-    # sync-attached result contract only reads the terminal ``read_result``
-    # marker — so the drained presentation would be silently discarded and the
-    # attached caller's chat surface never shows it (present's ack is ``ok:True``
-    # regardless). #2570's driver→caller bridge carries pipeline_step_* EVENTS
-    # via the caller's EventLog; present is NOT an event, so it does not ride
-    # that bridge. Parallel to it, forward the driver's user-reaching outbox
-    # messages (the ``"presentation"`` kind) onto the CALLER's own outbox — the
-    # SAME queue+kind a chat-native present reaches (``OutboxPresentationRenderer``
-    # → ``session.outbox`` → the REPL/CUI presentation renderer), so the parent
-    # chat renders it identically. Additive: the present op / renderer / guard
-    # are untouched. Best-effort: an unresolvable caller session (should not
-    # happen on the attached path) skips the forward, degrading to the pre-fix
-    # behavior rather than blocking the run.
-    if caller_session is not None:
-        for msg in drained:
-            if msg.kind == "presentation":
-                caller_session.outbox.put_nowait(msg)
-
+    # #2707 interim REMOVED here (#2708 P3.1): the driver-session's ``present`` no longer
+    # renders to the driver's OWN outbox to be forwarded post-hoc. Half-A binds the driver's
+    # present sink to the PARENT's consumer at spawn (``SpawnBridgePresentationConsumer``,
+    # via ``attached_parent_session`` above), so a ``present`` step reaches the parent chat
+    # surface BY CONSTRUCTION — exactly once. Keeping the old drain-and-copy forward here
+    # alongside the bridge would DOUBLE-deliver the presentation, so it is deleted, not
+    # migrated.
     marker = read_result(run_dir)
     if marker is not None:
         return {

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -594,12 +594,14 @@ async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
     state_log = StateLog(tmp_path / ".reyn" / "state.wal")
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             chat_tool_use_scheme="universal-category",
             pipeline_registry=loaded,  # the config-loaded registry, threaded as the factory would
+            presentation_consumer=presentation_consumer,
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2707_pipeline_present_forwards_to_caller.py
+++ b/tests/test_2707_pipeline_present_forwards_to_caller.py
@@ -21,10 +21,14 @@ NOT merely on the driver-session's isolated outbox. Real
 collaborator mocks; asserts the presented CONTENT (a marker substring) on the
 public outbox surface, never exact Rich formatting/whitespace (a Tier-4 pin).
 
-# Phase0 interim for #2707; removed/subsumed by P3 spawn-bundle inheritance
-(#2708 Surface Capability Contract) — when spawn inherits the caller's
-capability bundle (presentation sink included), the outbox-forward this pins is
-gone and this test moves with it.
+# #2708 P3.1 UPDATE — the #2707 interim outbox-forward is now REMOVED; the driver's
+present reaches the caller by CONSTRUCTION (the driver spawns with a parent-bound
+``SpawnBridgePresentationConsumer`` — its present sink IS the caller's sink). This test
+stays GREEN via that new mechanism and, because it asserts EXACTLY ONE ``"presentation"``
+on the caller outbox, now doubles as the single-delivery guard: the forward + the bridge
+together would double-deliver, so a resurrected forward makes the ``(presented,) = ...``
+unpack fail. The mechanism changed (forward → inherited sink); the reachable-for-purpose
+outcome asserted here did not.
 """
 from __future__ import annotations
 
@@ -70,10 +74,15 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     own outbox), so a driver-session present renders exactly as in production."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: the attached driver spawn threads a parent-bound
+        # SpawnBridgePresentationConsumer through the factory; accept + forward it so the
+        # driver's present renders to the PARENT's outbox by construction (None on the
+        # non-driver caller session = Session's default self-bound outbox consumer).
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
@@ -103,13 +112,13 @@ async def test_attached_pipeline_present_reaches_parent_caller_outbox(
     tmp_path: Path,
 ) -> None:
     """Tier 2: a sync-attached ``run_pipeline_attached`` of a ``tool: present``
-    step forwards the driver-session's ``"presentation"`` render onto the CALLER
+    step lands the driver-session's ``"presentation"`` render on the CALLER
     session's own outbox (the parent chat surface the REPL/CUI drains), carrying
-    the presented marker. RED on origin/main — the driver's presentation is
-    drained by the attached pump and then discarded (only the terminal marker is
-    read back), so the caller outbox has no ``"presentation"`` message and the
-    marker never reaches the parent chat. GREEN once the attached pump forwards
-    the driver's user-reaching outbox messages to the caller."""
+    the presented marker — EXACTLY ONCE. #2708 P3.1: this now holds by construction
+    (the driver inherits the parent's present sink via ``SpawnBridgePresentationConsumer``),
+    not by the removed #2707 drain-and-copy forward. The single ``"presentation"``
+    (``(presented,) = ...`` unpack) is the single-delivery guard: bridge + a resurrected
+    forward would double-deliver."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")  # (worker, main) = the reply/parent-chat address

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -1,0 +1,210 @@
+"""#2708 P3.1 — a chat-invoked pipeline's ``present`` reaches the PARENT by construction.
+
+P3.1 replaces the #2707 interim outbox-forward with a STRUCTURAL fix: the attached
+pipeline driver-session is spawned with a ``SpawnBridgePresentationConsumer`` bound to the
+PARENT (caller) session, so the driver's present sink IS the parent's sink. Two halves:
+
+  * Half-A (visible output, type-level by-construction): a ``present`` step's render
+    reaches the parent chat surface EXACTLY ONCE, and NOT via the driver's own outbox
+    (the driver never renders to itself — its sink is the parent's). The removed #2707
+    forward + the bridge would double-deliver, so single-delivery is the guard.
+  * Half-B (audit, mechanism-level): the driver's ``presented`` P6 audit event is bridged
+    onto the PARENT's EventLog with ``bridged_from=<driver_sid>`` provenance — the #2570
+    driver→parent EventLog bridge extended to carry ``presented`` (it previously carried
+    only ``pipeline_step_*``, leaving the present audit trail split in the driver log).
+
+Scope (P3-item3 completeness gate, NOT P3.1): the DETACHED/async path
+(``start_pipeline_run``) has no attached parent surface, so its present is intentionally
+NOT bridged in P3.1 — a latent known-RED cell tracked separately, asserted here so it is
+explicit, not silently broken.
+
+Real ``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor``/present op — no
+collaborator mocks. Asserts on the public outbox + EventLog surfaces, never Rich
+formatting/whitespace (a Tier-4 pin).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.config_recovery import reyn_root
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, ToolStep
+from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
+
+_MARKER = "REYN2708P31BRIDGEMARKER"
+
+
+def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Real AgentRegistry + real Session factory that ACCEPTS the P3.1 present-sink
+    override (the widened factory protocol): the attached driver spawn threads a
+    parent-bound consumer through ``presentation_consumer=`` and the factory forwards it,
+    so the driver's present renders to the parent's outbox by construction."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _present_pipeline() -> Pipeline:
+    return Pipeline(steps=[
+        ToolStep(name="present", args={"data_inline": {"label": _MARKER}}, output="ack"),
+    ])
+
+
+def _drain(queue: "asyncio.Queue") -> list:
+    out: list = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+def _presentations(msgs: list) -> list:
+    return [m for m in msgs if getattr(m, "kind", None) == "presentation"]
+
+
+def _driver_sid_from(events) -> "str | None":
+    for e in events.all():
+        if e.type == "pipeline_run_attached":
+            return e.data.get("driver_sid")
+    return None
+
+
+@pytest.mark.asyncio
+async def test_attached_present_reaches_parent_by_construction_single_delivery(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: Half-A — a sync-attached ``run_pipeline_attached`` present lands on the
+    CALLER (parent) outbox EXACTLY ONCE via the inherited sink, and the DRIVER's own
+    outbox holds ZERO presentation (proves the sink is parent-bound, not a
+    self-render-then-forward). RED if the #2707 forward is resurrected alongside the
+    bridge (double delivery → the single-presentation unpack fails)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+
+    outcome = await run_pipeline_attached(
+        reg,
+        pipeline=_present_pipeline(),
+        pipeline_name="shows",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        tool="run_pipeline",
+        caller_events=caller.router_host.events,
+    )
+    assert outcome["status"] == "ok"
+
+    driver_sid = _driver_sid_from(caller.router_host.events)
+    assert driver_sid is not None
+
+    # Parent surface: exactly one presentation, carrying the marker.
+    caller_pres = _presentations(_drain(caller.outbox))
+    (presented,) = caller_pres  # fails RED on 0 (orphan) or >1 (double delivery)
+    assert _MARKER in json.dumps(presented.meta)
+
+    # The driver session did NOT render to its own outbox (its sink is the parent's).
+    driver = reg.get_session("worker", driver_sid)
+    assert driver is not None
+    assert _presentations(_drain(driver.outbox)) == [], (
+        "the driver-session rendered a presentation to its OWN outbox — the spawn-bridge "
+        "sink should have routed it to the parent (a self-render would be the #2707 "
+        "forward-era shape, an orphan without the removed forward)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_attached_present_audit_event_bridged_to_parent_log(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: Half-B — the driver's ``presented`` P6 audit event is re-emitted onto the
+    PARENT's EventLog with ``bridged_from=<driver_sid>`` provenance. RED on origin/main:
+    ``presented`` lands only on the driver's own log (the #2570 bridge carried only
+    ``pipeline_step_*``), so the parent audit trail is split."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+
+    await run_pipeline_attached(
+        reg,
+        pipeline=_present_pipeline(),
+        pipeline_name="shows",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        tool="run_pipeline",
+        caller_events=caller.router_host.events,
+    )
+    driver_sid = _driver_sid_from(caller.router_host.events)
+    assert driver_sid is not None
+
+    bridged = [
+        e for e in caller.router_host.events.all()
+        if e.type == "presented" and e.data.get("bridged_from")
+    ]
+    assert bridged, (
+        "no bridged 'presented' event on the parent EventLog — the present audit trail "
+        "is isolated in the driver-session's own log (the split-trail the bridge closes)."
+    )
+    (event,) = bridged  # exactly one bridged copy
+    assert event.data["bridged_from"] == driver_sid
+    assert event.data.get("pipeline_run_id"), "bridged present missing pipeline_run_id provenance"
+
+
+@pytest.mark.asyncio
+async def test_detached_present_not_bridged_to_caller(tmp_path: Path) -> None:
+    """Tier 2: scope guard — a DETACHED (``start_pipeline_run``) pipeline's present is NOT
+    bridged to the (non-attached) invoker: no ``pipeline_run_attached`` marker is emitted,
+    so the caller's forwarder never bridge-subscribes → no bridged ``presented`` on the
+    caller log and no presentation on the caller outbox. This pins the attached-only scope
+    (detached/async present is the tracked P3-item3 known-RED cell, not addressed here)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+
+    rid = await start_pipeline_run(
+        reg,
+        pipeline=_present_pipeline(),
+        pipeline_name="shows",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+    )
+    run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
+
+    # Drive the detached pump to terminal (result marker written).
+    deadline = asyncio.get_event_loop().time() + 15.0
+    while asyncio.get_event_loop().time() < deadline:
+        if read_result(run_dir) is not None:
+            break
+        await asyncio.sleep(0.05)
+    assert read_result(run_dir) is not None, "detached pipeline run did not reach terminal"
+
+    bridged = [
+        e for e in caller.router_host.events.all()
+        if e.type == "presented" and e.data.get("bridged_from")
+    ]
+    assert bridged == [], "a detached present was unexpectedly bridged to the caller log"
+    assert _presentations(_drain(caller.outbox)) == [], (
+        "a detached present unexpectedly reached the caller outbox"
+    )

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -88,10 +88,12 @@ def _agent_registry(
     """Real AgentRegistry + real Session factory (mirrors the IS-1 test)."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is4_inline.py
+++ b/tests/test_pipeline_is4_inline.py
@@ -80,10 +80,12 @@ def _agent_registry(
     """Real AgentRegistry + real Session factory (mirrors the IS-1/IS-2 tests)."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -63,11 +63,13 @@ def _registry_backed_session(tmp_path: Path):
     state_log = StateLog(tmp_path / ".reyn" / "state.wal")
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             chat_tool_use_scheme="universal-category",
+            presentation_consumer=presentation_consumer,
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -96,10 +96,13 @@ def _agent_registry(
     subscribe seam) so a test can observe the driver-session's live events."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: the attached driver spawn threads a present-sink override through the
+        # factory; accept + forward it (None = Session's default self-bound consumer).
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_tui_bridge_2570.py
+++ b/tests/test_pipeline_tui_bridge_2570.py
@@ -53,10 +53,12 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     """Real AgentRegistry + real Session factory (mirrors the IS-2/IS-4 tests)."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_run_pipeline_tool_is1.py
+++ b/tests/test_run_pipeline_tool_is1.py
@@ -63,10 +63,12 @@ def _agent_registry(
     test_pipeline_r5_agent_step_executor.py's ``_registry`` helper)."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None) -> Session:
+        # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (


### PR DESCRIPTION
**[per-PR-coder]** — P3.1 driver spawn-bridge. `part of #2708` (does NOT close it).

## Step-1 topology (re-grounded at file:line on live main, HEAD `89a9ad28`; verify-don't-infer)

| Concern | live location |
|---|---|
| sink → OpContext path | `session.py:1748` `presentation_renderer_factory=lambda: self._presentation_consumer.sink(self)` → per-turn OpContext; present op reads it at `op_runtime/present.py` `ctx.presentation_renderer` |
| driver spawn chokepoint | `session_api._spawn_pipeline_driver_session` → `registry.spawn_session_recorded(mode="persistent")` → `spawn_session` → `_construct_session` → `self._factory(profile)` — **no main-vs-spawn branch** on main (driver got the frontend factory's baked-in consumer bound to its OWN outbox) |
| attached vs detached branch | attached = `run_pipeline_attached` (inline `MessageBus.request`); detached = `start_pipeline_run` (`ensure_session_running` pump). Shared prefix = `_spawn_pipeline_driver_session`. Confirmed the caller session is resolvable via `registry.get_session(reply_to_agent, reply_to_sid)` at the spawn site |
| `Session` consumer accessor | **did not exist** on main → added read `@property presentation_consumer` (`session.py`) |
| #2707 forward site | `session_api.py` (was ~:535, the drain-and-copy `if msg.kind == "presentation": caller_session.outbox.put_nowait(msg)`) — **removed** |
| #2570 audit bridge | `lifecycle_forwarder.py` `_on_driver_event` (was pipeline_step_* only, filtered by `run_id`) |

**Architect verify-point (run_id filter) — checked, confirmed the flagged failure mode:** a pipeline-step `present` builds its OpContext at `tools/present.py:116` via `ctx.router_state.op_context_factory()` = the driver session's `make_router_op_context` (`session.py:1739`, **`run_id=None`**), and `op_runtime/present.py:132` emits `presented` with that run_id. So `presented.run_id` is **None, never the pipeline rid** — reusing the #2570 `run_id`-equality filter would **silently drop every bridged present**. I did **not** "remove a shared filter": each pipeline run spawns its OWN driver session, so the per-driver-EventLog subscription (added on attach, removed on tool completion) is inherently one-run-scoped — there is no concurrent-run leak to guard. Type-only matching within that window is correct and leak-free (documented inline). Making `presented.run_id` carry the rid = a larger present-op change (architect Q1-deferred).

## The fix

**Half-A (visible output, type-level by-construction):**
- New `SpawnBridgePresentationConsumer` (`presentation_consumer.py`): binds the PARENT's consumer to the PARENT session and delegates — `sink(child)` ignores child, returns `parent_consumer.sink(parent_session)`. **Constructs no `OutboxPresentationRenderer`** (delegates), so the P1 AST guard stays green with zero edits.
- Spawn override seam: optional `presentation_consumer` param threaded `spawn_session_recorded` → `spawn_session` → `_construct_session` (`override or default`; generic for P3.2 C/D). `_construct_session` forwards to the factory **only when non-None** → every non-spawn/default call stays `self._factory(profile)` byte-identical. Frontend closures widened (`presentation_consumer or <default>`).
- Opt-in **only on the attached path** (`_spawn_pipeline_driver_session(attached_parent_session=...)`); detached unchanged (#2710 scope).
- **#2707 forward removed** — bridge + forward would double-deliver.

**Half-B (audit, mechanism-level):** extend `lifecycle_forwarder._on_driver_event` to re-emit the driver's `presented` onto the PARENT's EventLog with `bridged_from=<driver_sid>` + `pipeline_run_id`. Forwarder ctor gains `events=self._chat_events`.

## AST guard: untouched & green
`test_present_sink_ast_guard_2708.py` passes with **no edits** — the bridge delegates, never constructs `OutboxPresentationRenderer`. (delegate-not-construct.)

## Single-delivery proof
`test_2707_...` asserts EXACTLY ONE `"presentation"` on the caller outbox (`(presented,) = presentations` unpacks). New `test_2708_p31...::test_attached_present_reaches_parent_by_construction_single_delivery` additionally asserts the **driver's own outbox holds ZERO** presentations (sink is parent-bound, not self-render-then-forward). Bridge + a resurrected forward → double-delivery → both fail. Verified GREEN.

## RED→GREEN evidence (falsify via `cp` scratch, never git checkout)
- Reverted `session_api.py` + `lifecycle_forwarder.py` to origin/main → the 3 new P3.1 tests fail (bridge/audit absent) → restored → GREEN.
- New tests: Half-A single-delivery+no-orphan, Half-B audit-`bridged_from`, detached-not-bridged scope guard. First docstring line declares Tier (all Tier 2). No Tier-4 pins.

## 4 CI gates (all green locally)
- `ruff check src tests` → **All checks passed**
- `test_tier_audit.py --strict <9 changed test files>` → **85 inspected, 0 Tier-4**
- `pytest` (repo root) → **7855 passed, 5 failed, 21 skipped**. The 5 failures are **pre-existing web route-mounting** assertions (`/a2a/agents`, `/from-pkg-b`, mcp-sse, resources-router not mounted) — **primary-verified pre-existing**: reverting ALL my src to origin/main, they still fail identically (0 overlap with pipeline/present/spawn code paths).
- `verify_module_docstrings.py <11 changed src files>` → **OK**

## Scope flags (surfaced, not dropped)
- Detached/async present is a **latent known-RED cell**, not "correct" — explicitly pinned by the detached scope-guard test; tracked as the P3 spawn-routing completeness gate (#2710 / P3-item3), out of P3.1.
- Recovery-gate check: the bridged `presented` is a forward-derived event bridge, **not** WAL-derived snapshot-backed recovery state → CLAUDE.md truncate-falsify gate does not apply (consistent with #2570).
- Other spawn sites (`spawn_ephemeral_session` agent-step) remain self-bound by default — same latent orphan class, P3 completeness-gate scope.

## Test plan
- [x] Half-A single-delivery + no-orphan (parent outbox exactly once, driver outbox zero)
- [x] Half-B `presented` on parent EventLog with `bridged_from`
- [x] Detached present NOT bridged (scope guard)
- [x] AST guard + #1402 invariant unchanged
- [x] 9 sync-pipeline test factories widened; full suite delta = only the 3 new tests + 9 restored (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
