### PR TITLE
docs: fix mkdocs site_description — 5th location of the dead tagline

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Reyn
-site_description: LLM workflow OS — phase transitions as a constrained decision graph
+site_description: An operating system for LLM agents — they decide, organize, and orchestrate; the OS makes every action typed, permissioned, audited, and recoverable by construction
 site_url: https://tya5.github.io/reyn/
 docs_dir: ../docs
 # Build output to repo-root site/ (config now lives in .mkdocs/, so make the


### PR DESCRIPTION
**[docs-maintainer]** — small follow-up to #2720, part of #2717.

`.mkdocs/mkdocs.yml`'s `site_description` (feeds the HTML `<meta name="description">` tag on every docs page — SEO/link-preview visible) still had the dead "LLM workflow OS — phase transitions as a constrained decision graph" tagline. #2720 fixed `docs/index.md` and `docs/start.md` (both languages) but missed this config field. Replaced with the constitution's T1 hero, matching #2720.

## Test plan
- [x] `mkdocs build --strict` clean