### PR TITLE
feat: #2708 P3.2a — intervention (ask_user) spawn-bridge (driver ask reaches parent operator by construction)

### DIFF
--- a/src/reyn/interfaces/chainlit_app/app.py
+++ b/src/reyn/interfaces/chainlit_app/app.py
@@ -203,7 +203,7 @@ async def _get_or_build_registry() -> "AgentRegistry":
 
         registry_ref: list = []
 
-        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
             _ctx_perm, _profile_excluded = registry_ref[0].resolved_profile_for(profile.name)
             s = build_scoped_chat_session(
@@ -215,6 +215,9 @@ async def _get_or_build_registry() -> "AgentRegistry":
                 # present output was invisible.
                 # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
                 presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
+                # #2708 P3.2a: forward the attached pipeline driver's intervention bridge so a
+                # driver ask_user reaches this chainlit operator; None = self-bound default.
+                intervention_bridge=intervention_bridge,
                 agent_name=profile.name,
                 model=model,
                 resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -364,7 +364,7 @@ def run(args: argparse.Namespace) -> None:
         interactive=sys.stdin.isatty(),
     )
 
-    def _session_factory(profile: AgentProfile, *, presentation_consumer=None):
+    def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None):
         # Captured CLI defaults — registry doesn't need to know them.
         # #1827 S3: resolve the agent's topology capability_profile → contextual
         # narrowing (enforcement) + view exclusion. (None, ∅) when unbound = byte-identical.
@@ -376,6 +376,10 @@ def run(args: argparse.Namespace) -> None:
             # #2708 P3.1: a spawn override (the attached pipeline driver's parent-bound
             # SpawnBridgePresentationConsumer) wins when supplied; None = this default.
             presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
+            # #2708 P3.2a: forward the attached pipeline driver's intervention bridge
+            # (SpawnBridgeInterventionListener) so a driver ask_user reaches this live
+            # operator; None (default / non-spawn) = self-bound fail-closed, byte-identical.
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -471,7 +471,7 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         # cell so the factory can reference it before assignment completes.
         _reg_cell: list = []
 
-        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
             # #1827 S3: resolve the agent's topology capability_profile. The registry
             # cell may be empty during bootstrap → (None, ∅) = byte-identical.
             _reg = _reg_cell[0] if _reg_cell else None
@@ -484,6 +484,10 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
                 # was never rendered by the harness before #2708).
                 # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
                 presentation_consumer=presentation_consumer or NullPresentationConsumer("dogfood"),
+                # #2708 P3.2a: forward the spawn-time intervention bridge (None = self-bound
+                # default). The dogfood harness is headless (_non_interactive) — a driver
+                # spawn keeps the fail-closed default; the seam is threaded uniformly.
+                intervention_bridge=intervention_bridge,
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -395,7 +395,7 @@ def run_serve(args: argparse.Namespace) -> None:
 
     project_context = load_project_context(session_cfg.config, project_root)
 
-    def _session_factory(profile: AgentProfile, *, presentation_consumer=None):
+    def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None):
         # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
@@ -403,6 +403,9 @@ def run_serve(args: argparse.Namespace) -> None:
             # — a reviewed NA surface. Null is byte-identical (present was invisible before).
             # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
             presentation_consumer=presentation_consumer or NullPresentationConsumer("mcp"),
+            # #2708 P3.2a: forward the spawn-time intervention bridge (None = self-bound
+            # default). stdio-MCP is a machine surface; the seam is threaded uniformly.
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name,
             model=model,
             resolver=session_cfg.resolver,

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -300,7 +300,7 @@ def _get_registry():
             os.environ.get("REYN_WEB_EAGER_EMBEDDING_BUILD", "").strip() == "1"
         )
 
-        def _session_factory(profile: AgentProfile, *, presentation_consumer=None) -> Session:
+        def _session_factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
             registry = registry_ref[0]
             _scoped = get_cli_scoped_overrides()  # #1401 CLI-scoped capabilities
             # #1827 S3: resolve the agent's topology capability_profile (None/∅ unbound).
@@ -312,6 +312,10 @@ def _get_registry():
                 # (present was invisible + not externally routed before #2708).
                 # #2708 P3.1: a spawn override (attached pipeline driver) wins when given.
                 presentation_consumer=presentation_consumer or NullPresentationConsumer("web"),
+                # #2708 P3.2a: forward the spawn-time intervention bridge (None = self-bound
+                # default). Web is a machine surface; a driver spawn from it keeps the fail-
+                # closed default, but the seam is threaded uniformly with the other frontends.
+                intervention_bridge=intervention_bridge,
                 agent_name=profile.name,
                 model=model,
                 resolver=resolver,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2577,6 +2577,7 @@ class AgentRegistry:
         *,
         is_delegate: bool = False,
         presentation_consumer: "object | None" = None,
+        intervention_bridge: "object | None" = None,
     ) -> "object":
         """Build a configured Session from a profile (factory + shared-store
         attach), WITHOUT inserting it into the session map. Shared by get_or_load
@@ -2588,20 +2589,23 @@ class AgentRegistry:
         without a factory-signature change. Save/restore (not set-False) so it is
         correct under nesting too — non-re-entrant today, but free future-proofing.
 
-        #2708 P3.1: ``presentation_consumer`` is the spawn-time present-sink OVERRIDE (the
-        reusable capability-bundle inheritance seam — P3.2 threads cred/permission through
-        the SAME param). ``None`` (every non-spawn / default-spawn caller) keeps the
-        factory call byte-identical (``self._factory(profile)``); only when a spawn site
-        opts in (the attached pipeline driver, ``session_api._spawn_pipeline_driver_session``)
-        is the override forwarded, so the widened-factory contract only binds spawn sites
-        that actually pass one — bare test factories stay callable."""
+        #2708 P3.1/P3.2a: ``presentation_consumer`` (present-sink) and
+        ``intervention_bridge`` (ask_user/permission routing) are the spawn-time
+        capability OVERRIDES — the reusable capability-bundle inheritance seam. ``None``
+        for both (every non-spawn / default-spawn caller) keeps the factory call
+        byte-identical (``self._factory(profile)``); only a spawn site that opts in (the
+        attached pipeline driver, ``session_api._spawn_pipeline_driver_session``) forwards
+        an override, so the widened-factory contract only binds spawn sites that actually
+        pass one — bare test factories stay callable."""
         _prev_delegate = self._constructing_as_delegate
         self._constructing_as_delegate = is_delegate
         try:
+            factory_kwargs: dict = {}
             if presentation_consumer is not None:
-                session = self._factory(profile, presentation_consumer=presentation_consumer)
-            else:
-                session = self._factory(profile)
+                factory_kwargs["presentation_consumer"] = presentation_consumer
+            if intervention_bridge is not None:
+                factory_kwargs["intervention_bridge"] = intervention_bridge
+            session = self._factory(profile, **factory_kwargs)
         finally:
             self._constructing_as_delegate = _prev_delegate
         # #1547: hand the session the shared anchor store so cut_generation
@@ -2615,6 +2619,7 @@ class AgentRegistry:
     def spawn_session(
         self, name: str, sid: "str | None" = None,
         *, presentation_consumer: "object | None" = None,
+        intervention_bridge: "object | None" = None,
     ) -> str:
         """FP-0043 Stage 3: open a NEW conversation Session under an existing
         Agent, SHARING the agent's identity object. Returns the new session-id.
@@ -2629,11 +2634,15 @@ class AgentRegistry:
         new_sid = sid or uuid4().hex[:8]
         if self._has_session(name, new_sid):
             raise ValueError(f"session {new_sid!r} already exists for agent {name!r}")
-        # #2708 P3.1: forward the optional present-sink override to the factory (None keeps
-        # today's default self-bound outbox consumer; the attached driver spawn passes a
-        # SpawnBridgePresentationConsumer so the driver's present reaches the parent).
+        # #2708 P3.1/P3.2a: forward the optional present-sink + intervention overrides to the
+        # factory (None keeps today's default self-bound outbox consumer + listener-less
+        # intervention registry; the attached driver spawn passes a
+        # SpawnBridgePresentationConsumer so the driver's present reaches the parent, and a
+        # SpawnBridgeInterventionListener so its ask_user reaches the parent's live operator).
         session = self._construct_session(
-            self.load_profile(name), presentation_consumer=presentation_consumer,
+            self.load_profile(name),
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
         )
         if shared is not None:
             # Share the SAME identity object (not the fresh one the factory built),
@@ -2702,6 +2711,7 @@ class AgentRegistry:
         self, name: str, *, mode: str = "persistent",
         narrowing: "dict | None" = None,
         presentation_consumer: "object | None" = None,
+        intervention_bridge: "object | None" = None,
     ) -> str:
         """#2103 S1bc: the action-layer SESSION-SPAWN seam — spawn a fresh-context
         session under ``name`` (sync ``spawn_session``) + persist the spawner's
@@ -2714,11 +2724,17 @@ class AgentRegistry:
         Does NOT submit a task — that is the caller (the spawn op), separable from the
         record. Emit no-ops without a WAL.
 
-        #2708 P3.1: ``presentation_consumer`` (default None = today's self-bound outbox
-        consumer) is the present-sink override forwarded to the constructed session — the
-        attached pipeline driver spawn passes a ``SpawnBridgePresentationConsumer`` so the
-        driver's present reaches the parent surface by construction."""
-        sid = self.spawn_session(name, presentation_consumer=presentation_consumer)
+        #2708 P3.1/P3.2a: ``presentation_consumer`` + ``intervention_bridge`` (both default
+        None = today's self-bound outbox consumer + listener-less intervention registry) are
+        the spawn-time capability overrides forwarded to the constructed session — the
+        attached pipeline driver spawn passes a ``SpawnBridgePresentationConsumer`` (present
+        reaches the parent surface) and a ``SpawnBridgeInterventionListener`` (ask_user
+        reaches the parent's live operator) by construction."""
+        sid = self.spawn_session(
+            name,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
         if mode == "ephemeral":
             # #2103: mark the live session so it auto-vanishes once its task is done
             # (Session._maybe_schedule_ephemeral_vanish, via this registry's

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -169,7 +169,7 @@ def build_agent_registry_from_project(
     ws_base_dir = project_root
     ws_state_dir = project_root / ".reyn"
 
-    def _session_factory(profile: "AgentProfile", *, presentation_consumer=None):
+    def _session_factory(profile: "AgentProfile", *, presentation_consumer=None, intervention_bridge=None):
         _ctx_perm, _profile_excluded = registry.resolved_profile_for(profile.name)
         s = build_scoped_chat_session(
             # #2708 P1: the reusable registry base session (reyn pipe run's default
@@ -180,6 +180,10 @@ def build_agent_registry_from_project(
             # override (present reaches the parent by construction, replacing the removed
             # #2707 forward); None (default / non-spawn) keeps the outbox-backed consumer.
             presentation_consumer=presentation_consumer or OutboxPresentationConsumer(),
+            # #2708 P3.2a: forward the attached pipeline driver's intervention bridge
+            # (SpawnBridgeInterventionListener) so a driver ask_user reaches the parent's live
+            # operator; None (default / non-spawn / detached) = self-bound fail-closed.
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name,
             model=config.model,
             resolver=resolver,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -760,6 +760,16 @@ class Session:
         # lazily via ``consumer.sink(self)`` (deferred so the outbox sink can bind this
         # Session, which does not exist when the factory kwarg is passed).
         presentation_consumer: "object | None" = None,
+        # #2708 P3.2a: the spawn-time intervention BRIDGE (a
+        # ``SpawnBridgeInterventionListener``). None (every non-spawn / detached /
+        # ephemeral construction) keeps today's self-bound fail-closed behavior — the
+        # driver's ``ask_user`` routes through its own listener-less registry. Only the
+        # ATTACHED pipeline driver spawn (``session_api._spawn_pipeline_driver_session``)
+        # passes one, so the driver's router intervention bus dispatches on the PARENT
+        # session's live-operator listener instead of silently auto-refusing (#2721). The
+        # reusable capability-bundle inheritance seam — same threading as
+        # ``presentation_consumer`` (P3.1).
+        intervention_bridge: "object | None" = None,
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file
@@ -834,6 +844,11 @@ class Session:
             if presentation_consumer is not None
             else OutboxPresentationConsumer()
         )
+        # #2708 P3.2a: the spawn-time intervention bridge (None = self-bound default).
+        # When set (attached pipeline driver), the router intervention_bus_factory below
+        # builds a bus bound to the PARENT session so the driver's ``ask_user`` reaches the
+        # parent's live operator listener by construction (mirror of _presentation_consumer).
+        self._intervention_bridge = intervention_bridge
         # #1953 §16 (recursive-request): the task_id this session is currently
         # EXECUTING as a task-as-request, set per-turn from an execute-wake's meta
         # (run_one_iteration). Read by the router op-ctx builders so task.create
@@ -1741,9 +1756,21 @@ class Session:
             # flow. The bus is built per make_router_op_context() call
             # — short-lived, scoped to the chat_router turn, identical
             # to what session._mcp_call_tool wires manually today.
-            intervention_bus_factory=lambda: ChatInterventionBus(
-                self, run_id=None, actor="chat_router",
-                channel_id=DEFAULT_CHAT_CHANNEL_ID,
+            # #2708 P3.2a: when this session is an ATTACHED pipeline driver (it carries a
+            # SpawnBridgeInterventionListener), the router intervention bus dispatches on the
+            # PARENT session's live-operator listener instead of the driver's own
+            # listener-less registry — so a pipeline-step ``ask_user`` reaches the operator
+            # blocked on the parent by construction (#2721), instead of silently auto-
+            # refusing. Non-driver / detached / ephemeral sessions (bridge is None) keep the
+            # self-bound bus, byte-identical. Mirror of the presentation_renderer_factory
+            # spawn-bridge below.
+            intervention_bus_factory=lambda: (
+                self._intervention_bridge.bus(run_id=None, actor="chat_router")
+                if self._intervention_bridge is not None
+                else ChatInterventionBus(
+                    self, run_id=None, actor="chat_router",
+                    channel_id=DEFAULT_CHAT_CHANNEL_ID,
+                )
             ),
             # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
             # so a `present` op reaches the surface's sink instead of PR-A's null surface.

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -75,6 +75,15 @@ prefix and differing only in how the caller drives + collects:
     Together: both the visible present and its audit trail reach the parent, closing the
     driver-isolation split. (Detached/async present is out of P3.1 scope — no attached
     parent surface exists; tracked as the P3 spawn-routing completeness gate.)
+    #2708 P3.2a: the SAME attach seam bridges the driver's INTERVENTION delivery. The driver
+    gets a fresh listener-less ``InterventionRegistry`` (fail-closed), so an ``ask_user`` step
+    would silently auto-refuse even with a live operator blocked on the parent (#2721). The
+    attached driver-session is spawned with a ``SpawnBridgeInterventionListener``
+    (``runtime/session_buses.py``) bound to the PARENT, so its router intervention bus
+    dispatches on the PARENT session's live-operator listener — the operator is prompted and
+    their answer flows back to the driver's awaiting op by construction. (Detached/async
+    intervention keeps the fail-closed default — a tracked known-RED cell, same completeness
+    gate as present.)
 """
 from __future__ import annotations
 
@@ -308,19 +317,34 @@ async def _spawn_pipeline_driver_session(
     # so the embedded pipeline name is sanitized to one safe path component.
     safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", pipeline_name) or "pipeline"
     rid = run_id or f"pipeline-{safe_name}-{uuid.uuid4().hex}"
-    # #2708 P3.1 Half-A: on the attached path, bind the driver's present sink to the
-    # PARENT's consumer so its render reaches the parent surface by construction. Detached
-    # spawns pass None → the default self-bound outbox consumer (byte-identical).
+    # #2708 P3.1 Half-A / P3.2a: on the attached path, bind the driver's present sink AND its
+    # ask_user/permission routing to the PARENT by construction — so a `present` step reaches
+    # the parent surface (P3.1) and an `ask_user` step reaches the parent's live operator
+    # listener instead of silently auto-refusing (P3.2a, #2721). Detached spawns pass None for
+    # both → the default self-bound outbox consumer + listener-less registry (byte-identical);
+    # the detached ask_user auto-refuse is a tracked known-RED cell (P3 completeness gate).
     bridge_consumer: "Any | None" = None
+    bridge_intervention: "Any | None" = None
     if attached_parent_session is not None:
         from reyn.runtime.presentation_consumer import SpawnBridgePresentationConsumer
+        from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+        from reyn.runtime.session_buses import SpawnBridgeInterventionListener
 
         bridge_consumer = SpawnBridgePresentationConsumer(
             parent_consumer=attached_parent_session.presentation_consumer,
             parent_session=attached_parent_session,
         )
+        # The parent chat surface (CLI/CUI/chainlit) registers its operator listener under
+        # DEFAULT_CHAT_CHANNEL_ID ("tui") — the same id a parent-native ask_user stamps — so
+        # the bridged iv routes to the live listener, not the stalled queue.
+        bridge_intervention = SpawnBridgeInterventionListener(
+            parent_session=attached_parent_session,
+            parent_channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
     sid = await registry.spawn_session_recorded(
-        reply_to_agent, mode="persistent", presentation_consumer=bridge_consumer,
+        reply_to_agent, mode="persistent",
+        presentation_consumer=bridge_consumer,
+        intervention_bridge=bridge_intervention,
     )
     work_order = PipelineWorkOrder(
         run_id=rid,

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -157,6 +157,73 @@ class ChatInterventionBus:
     # method-level call so the bus signature stays stable.
 
 
+class SpawnBridgeInterventionListener:
+    """A spawned/driver session's intervention bridge that routes the child's
+    ``ask_user`` / permission interventions to the PARENT session's live-operator
+    listener *by construction* (#2708 P3.2a). The intervention analog of
+    ``SpawnBridgePresentationConsumer`` (``runtime/presentation_consumer.py``).
+
+    A chat-invoked pipeline runs in a spawned driver-session that gets a fresh
+    ``InterventionRegistry(enforce_listener_presence=True)`` with **no** listener
+    registered (no ``bind_focus_listeners`` / ``register_intervention_listener`` for
+    the driver). So a driver ``ask_user`` would hit the no-listener short-circuit
+    (``services/intervention_registry.py`` — ``dispatch`` returns an empty
+    ``InterventionAnswer(text="")``) and **silently auto-refuse** — even under
+    ``run_pipeline_attached`` where a live operator is synchronously blocked on the
+    parent (#2721, the intervention-delivery sibling of the #2707 present gap).
+
+    This bridge, wired ONLY on the attached driver-spawn path
+    (``session_api._spawn_pipeline_driver_session``), makes the driver's router
+    intervention bus dispatch on the PARENT session instead of the child:
+    ``bus()`` returns a ``ChatInterventionBus`` bound to ``parent_session``, so the
+    child's ``ask_user`` routes into the parent's ``InterventionRegistry`` — which
+    HAS the live operator's listener — announces on the PARENT's outbox (the
+    operator sees it exactly as a chat-native ask_user), and the operator's answer
+    resolves the SAME ``iv.future`` the driver's op awaits. The delivery is
+    byte-identical to a parent-native ask_user (same channel-id stamping), and no
+    reverse answer path is needed (the future lives on the shared
+    ``UserIntervention``).
+
+    Detached (``start_pipeline_run``) and ephemeral-headless spawns pass no bridge
+    and keep the fail-closed default (no live operator) — the detached case is a
+    tracked known-RED cell (P3 spawn-routing completeness gate), NOT blessed-correct.
+    """
+
+    def __init__(self, parent_session: "Session", parent_channel_id: str) -> None:
+        self._parent_session = parent_session
+        self._parent_channel_id = parent_channel_id
+
+    @property
+    def parent_session(self) -> "Session":
+        """Read-only accessor for the bridged-to parent session (tests / audit)."""
+        return self._parent_session
+
+    @property
+    def parent_channel_id(self) -> str:
+        """The parent's intervention channel the bridged iv is stamped with — the
+        SAME id the parent operator registered its listener under, so the parent
+        coordinator routes the bridged iv to the live listener (not the stalled
+        queue)."""
+        return self._parent_channel_id
+
+    def bus(
+        self, *, run_id: "str | None" = None, actor: "str | None" = None,
+    ) -> "ChatInterventionBus":
+        """Build the driver's router intervention bus bound to the PARENT session.
+
+        The child ignores its OWN session (the analog of
+        ``SpawnBridgePresentationConsumer.sink`` ignoring the child): the returned
+        bus delivers through ``parent_session._dispatch_intervention`` and stamps
+        ``parent_channel_id`` so the parent's live operator listener resolves it —
+        identical to a parent-native chat ask_user."""
+        return ChatInterventionBus(
+            self._parent_session,
+            run_id=run_id,
+            actor=actor,
+            channel_id=self._parent_channel_id,
+        )
+
+
 class OutboxPresentationRenderer:
     """``PresentationRenderer`` (``core/present/renderer.py``) that routes a resolved
     presentation's render model onto the Session's outbox as a ``"presentation"``

--- a/src/reyn/tools/ask_user.py
+++ b/src/reyn/tools/ask_user.py
@@ -4,6 +4,12 @@ Phase-only capability: gates.router="deny", gates.phase="allow".
 The existing handler in src/reyn/op_runtime/ask_user.py is preserved
 and wrapped via a thin adapter that translates between the old
 (op, ctx) signature and the new (args, ctx) signature.
+
+#2708 P3.2a: the adapter now rebuilds the real OpContext from
+``ctx.router_state.op_context_factory()`` (the ``tools/present.py`` precedent) so a
+pipeline ``tool: ask_user`` step reaches the session-wired ``intervention_bus`` — and,
+for a chat-invoked pipeline's attached driver-session, the parent-bound bridge that
+delivers the ask to the live operator (the fix for #2721's silent auto-refuse).
 """
 from __future__ import annotations
 
@@ -36,20 +42,25 @@ _ASK_USER_PARAMETERS: dict[str, Any] = {
 
 
 async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
-    """Adapter wrapping op_runtime.ask_user.handle.
+    """Dispatch the ask_user op via op_runtime, through the REAL OpContext.
 
-    Bridges between the unified (args, ctx) signature and the
-    existing (op, ctx) signature.
+    Builds an ``AskUserIROp`` from the tool args and calls the registered ask_user
+    handler with the real ``OpContext`` from ``ctx.router_state``'s factory — the
+    ``present.py`` precedent (the present-layer arc's ``tool: present`` enabler). The
+    real OpContext carries the session-wired ``intervention_bus`` (built by the
+    session's ``make_router_op_context``), so a pipeline ``tool: ask_user`` step reaches
+    the live user-intervention machinery instead of raising.
 
-    ask_user is gated router="deny". With the phase-dispatch path removed
-    (#2542), no live dispatcher reaches this ToolDefinition handler — the
-    live user-intervention feature runs through OpContext.intervention_bus
-    (InterventionHandler / InterventionBus), not through this tool. This
-    handler is retained but formally unreachable; if it is ever invoked, it
-    passes ctx=None to the op handler, which raises the documented
-    RuntimeError (ask_user requires an intervention_bus on OpContext).
+    #2708 P3.2a: for a chat-invoked pipeline's ATTACHED driver-session, that
+    ``intervention_bus`` is bound (by the ``SpawnBridgeInterventionListener`` spawn
+    override) to the PARENT session's live-operator listener — so the driver's ask_user
+    reaches the operator blocked on the parent, instead of silently auto-refusing (#2721).
+    When there is no router_state factory (a bare/test ToolContext), we fall back to
+    ctx=None, whose op handler raises the documented "requires an intervention_bus"
+    RuntimeError — the same fail-fast as before this rebuild, never a silent wrong answer.
     """
     # Lazy import to avoid circular dependency at registry-init time.
+    from reyn.core.op_runtime import execute_op
     from reyn.core.op_runtime.ask_user import handle
     from reyn.schemas.models import AskUserIROp
 
@@ -62,6 +73,15 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         required=bool(args.get("required", True)),
     )
 
+    if (
+        ctx.router_state is not None
+        and ctx.router_state.op_context_factory is not None
+    ):
+        legacy_ctx = ctx.router_state.op_context_factory()
+        return await execute_op(op, legacy_ctx)
+
+    # No router-state OpContext factory (bare/test ToolContext): ctx=None → the op
+    # handler raises its documented "ask_user requires an intervention_bus" error.
     return await handle(op=op, ctx=None)
 
 

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -594,7 +594,7 @@ async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
     state_log = StateLog(tmp_path / ".reyn" / "state.wal")
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
@@ -602,6 +602,7 @@ async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
             chat_tool_use_scheme="universal-category",
             pipeline_registry=loaded,  # the config-loaded registry, threaded as the factory would
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2707_pipeline_present_forwards_to_caller.py
+++ b/tests/test_2707_pipeline_present_forwards_to_caller.py
@@ -74,7 +74,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     own outbox), so a driver-session present renders exactly as in production."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: the attached driver spawn threads a parent-bound
         # SpawnBridgePresentationConsumer through the factory; accept + forward it so the
         # driver's present renders to the PARENT's outbox by construction (None on the
@@ -83,6 +83,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -49,11 +49,12 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     so the driver's present renders to the parent's outbox by construction."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/test_2708_p32a_spawn_bridge_intervention.py
@@ -1,0 +1,266 @@
+"""#2708 P3.2a — a chat-invoked pipeline's ``ask_user`` reaches the PARENT operator.
+
+A pipeline run from within a chat session runs in a spawned DRIVER session, which gets
+a fresh, listener-less ``InterventionRegistry(enforce_listener_presence=True)``. So a
+``tool: ask_user`` step would hit the no-listener short-circuit
+(``services/intervention_registry.py`` — ``dispatch`` returns ``InterventionAnswer(text="")``)
+and **silently auto-refuse** — even under ``run_pipeline_attached`` where a live operator
+is blocked on the parent (#2721, the intervention-delivery sibling of the #2707 present
+gap fixed by P3.1).
+
+P3.2a fixes this by construction: the attached driver-session is spawned with a
+``SpawnBridgeInterventionListener`` bound to the PARENT (caller) session, so the driver's
+router intervention bus dispatches on the PARENT's ``InterventionRegistry`` — which HAS
+the live operator's listener. The operator is prompted on the parent surface and their
+answer flows back to the driver's awaiting ``ask_user`` op (the future lives on the shared
+``UserIntervention``). Reuses the P3.1 spawn-override seam (``intervention_bridge`` threaded
+through ``spawn_session_recorded`` / ``spawn_session`` / ``_construct_session``).
+
+Scope (P3-item3 completeness gate, NOT P3.2a): the DETACHED path (``start_pipeline_run``)
+has no attached parent surface, so its ask_user keeps the fail-closed auto-refuse — a
+tracked known-RED cell asserted here so it is explicit, not silently "correct".
+
+Real ``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor``/intervention
+machinery — no collaborator mocks. Asserts on the public outbox + intervention-registry
++ EventLog surfaces (the same operator-simulation pattern as the intervention e2e tests:
+register a real listener, drive ``_maybe_answer_oldest_intervention``).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper
+
+from reyn.core.events.state_log import StateLog  # noqa: E402
+from reyn.core.pipeline.executor import Pipeline, ToolStep  # noqa: E402
+from reyn.runtime.registry import AgentRegistry  # noqa: E402
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session  # noqa: E402
+from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run  # noqa: E402
+
+_QUESTION = "REYN2708P32A which branch?"
+_ANSWER = "REYN2708P32A-the-blue-branch"
+
+
+def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Real AgentRegistry + Session factory that accepts BOTH spawn overrides (the
+    widened factory protocol): the attached driver spawn threads a parent-bound
+    ``intervention_bridge`` and the factory forwards it, so the driver's ask_user
+    dispatches on the parent's live-operator registry by construction."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _ask_pipeline() -> Pipeline:
+    return Pipeline(steps=[
+        ToolStep(
+            name="ask_user",
+            args={"question": _QUESTION, "required": True},
+            output="ans",
+        ),
+    ])
+
+
+def _drain(queue: "asyncio.Queue") -> list:
+    out: list = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+def _interventions(msgs: list) -> list:
+    return [m for m in msgs if getattr(m, "kind", None) == "intervention"]
+
+
+def _driver_sid_from(events) -> "str | None":
+    for e in events.all():
+        if e.type == "pipeline_run_attached":
+            return e.data.get("driver_sid")
+    return None
+
+
+@pytest.mark.asyncio
+async def test_attached_ask_user_reaches_parent_operator_and_answer_flows_back(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: a sync-attached ``run_pipeline_attached`` ``ask_user`` step is delivered to
+    the PARENT (caller) operator's intervention channel — the operator is prompted and
+    their answer flows back into the driver's awaiting op. RED on origin/main: the driver's
+    listener-less registry auto-refuses (``text=""``), so the operator is never prompted and
+    the run proceeds on a fabricated empty answer."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+    # The live operator: register a listener on the parent under the chat channel the
+    # bridge routes to (the same id repl.py binds via bind_focus_listeners).
+    caller.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    async def _drive() -> dict:
+        return await run_pipeline_attached(
+            reg,
+            pipeline=_ask_pipeline(),
+            pipeline_name="asks",
+            input=None,
+            reply_to_agent="worker",
+            reply_to_sid="main",
+            state_log=state_log,
+            tool="run_pipeline",
+            caller_events=caller.router_host.events,
+        )
+
+    run_task = asyncio.ensure_future(_drive())
+    driver = None
+    try:
+        # The bridged ask_user dispatches on the PARENT: its iv lands in the PARENT's
+        # active-intervention queue (proof the ask reached the parent, not the driver's
+        # own listener-less registry which would have auto-refused instantly).
+        await wait_until(lambda: bool(caller.interventions.list_active()), timeout=15.0)
+        # Capture the driver session while it is still live (the persistent driver is
+        # removed from the registry once the attached run completes).
+        driver_sid = _driver_sid_from(caller.router_host.events)
+        assert driver_sid is not None
+        driver = reg.get_session("worker", driver_sid)
+        assert driver is not None
+        # The operator was prompted on the parent surface (an "intervention" announce on
+        # the parent's own outbox — the same queue+kind a chat-native ask_user reaches).
+        assert _interventions(_drain(caller.outbox)), (
+            "the operator was never prompted on the parent surface — the bridged ask_user "
+            "did not announce on the parent's outbox."
+        )
+        # The operator answers on the parent (drives the same deliver path repl input does).
+        consumed = await caller._maybe_answer_oldest_intervention(_ANSWER)
+        assert consumed is True
+        outcome = await asyncio.wait_for(run_task, timeout=15.0)
+    finally:
+        if not run_task.done():
+            run_task.cancel()
+
+    assert outcome["status"] == "ok"
+
+    # The operator's answer was DELIVERED for the bridged iv — its resolution fired
+    # ``user_answered_intervention`` on the PARENT's log (dispatch ran on the parent), with
+    # the real answer text, not the empty auto-refuse.
+    answered = [
+        e for e in caller.router_host.events.all()
+        if e.type == "user_answered_intervention"
+    ]
+    assert any(e.data.get("answer_text") == _ANSWER for e in answered), (
+        "the operator's answer was not delivered for the bridged ask_user on the parent log."
+    )
+    # And it flowed back INTO the driver's ask_user op (its P6 ``user_intervention_received``
+    # carries the real answer, not the fabricated empty auto-refuse text).
+    received = [
+        e for e in driver.router_host.events.all()
+        if e.type == "user_intervention_received"
+    ]
+    assert received, "no user_intervention_received on the driver log (ask never resolved)"
+    assert any(e.data.get("answer") == _ANSWER for e in received), (
+        "the driver's ask_user did not receive the operator's answer — it resolved on a "
+        "fabricated/empty answer (the silent auto-refuse this bridge fixes)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_attached_ask_user_not_stalled_uses_live_parent_listener(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the bridged iv is routed to the parent's LIVE listener, not parked in the
+    parent's stalled queue — the bridge stamps the parent's registered channel id, so the
+    origin-pin routing (``InterventionCoordinator``) delivers rather than stalls. Guards
+    that the bridge picks a channel the parent actually listens on."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+    caller.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    async def _drive() -> dict:
+        return await run_pipeline_attached(
+            reg,
+            pipeline=_ask_pipeline(),
+            pipeline_name="asks",
+            input=None,
+            reply_to_agent="worker",
+            reply_to_sid="main",
+            state_log=state_log,
+            tool="run_pipeline",
+            caller_events=caller.router_host.events,
+        )
+
+    run_task = asyncio.ensure_future(_drive())
+    try:
+        await wait_until(lambda: bool(caller.interventions.list_active()), timeout=15.0)
+        # Delivered (active), NOT stalled — the parent's live listener owns it.
+        assert caller.list_stalled_interventions() == [], (
+            "the bridged ask_user was parked in the parent's stalled queue instead of "
+            "reaching its live listener — the bridge stamped a channel the parent does "
+            "not listen on."
+        )
+        delivered = await caller._maybe_answer_oldest_intervention(_ANSWER)
+        assert delivered is True
+        outcome = await asyncio.wait_for(run_task, timeout=15.0)
+    finally:
+        if not run_task.done():
+            run_task.cancel()
+    assert outcome["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_detached_ask_user_does_not_reach_invoker_known_red(tmp_path: Path) -> None:
+    """Tier 2: scope guard (known-RED cell) — a DETACHED (``start_pipeline_run``) pipeline's
+    ``ask_user`` has NO attached parent surface, so the driver keeps its self-bound,
+    listener-less intervention registry: the ask does NOT reach the (non-attached) invoker's
+    live operator listener (over a bounded window the invoker is never prompted). This pins
+    the attached-only scope of P3.2a — detached/async intervention is the tracked P3-item3
+    completeness-gate cell, NOT addressed here and NOT silently blessed as correct (the
+    detached ask does not resolve against the invoker; whether it fail-closes or stalls in
+    the driver's own registry is the known-RED behavior tracked for the completeness gate)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _agent_registry(tmp_path, state_log)
+    caller = reg.get_or_load("worker")
+    caller.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    try:
+        await start_pipeline_run(
+            reg,
+            pipeline=_ask_pipeline(),
+            pipeline_name="asks",
+            input=None,
+            reply_to_agent="worker",
+            reply_to_sid="main",
+            state_log=state_log,
+        )
+        # Over a bounded window (the detached driver spawns + pumps + reaches its ask_user),
+        # the invoker's live operator listener is NEVER consulted — no intervention parks on
+        # the caller's active queue. (An attached bridge WOULD park one there; see the
+        # attached test. This is the not-bridged scope.)
+        deadline = asyncio.get_event_loop().time() + 4.0
+        while asyncio.get_event_loop().time() < deadline:
+            assert caller.interventions.list_active() == [], (
+                "a detached ask_user unexpectedly reached the invoker's live listener — "
+                "detached is out of P3.2a scope (known-RED)."
+            )
+            await asyncio.sleep(0.1)
+    finally:
+        # Teardown: the detached driver's ask_user may still be pending in its own registry
+        # (known-RED), so cancel the registry's live session run tasks to avoid a lingering
+        # coroutine at loop close.
+        for task in list(reg._tasks.values()):
+            if not task.done():
+                task.cancel()

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -88,12 +88,13 @@ def _agent_registry(
     """Real AgentRegistry + real Session factory (mirrors the IS-1 test)."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is4_inline.py
+++ b/tests/test_pipeline_is4_inline.py
@@ -80,12 +80,13 @@ def _agent_registry(
     """Real AgentRegistry + real Session factory (mirrors the IS-1/IS-2 tests)."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -63,13 +63,14 @@ def _registry_backed_session(tmp_path: Path):
     state_log = StateLog(tmp_path / ".reyn" / "state.wal")
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             chat_tool_use_scheme="universal-category",
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -96,13 +96,14 @@ def _agent_registry(
     subscribe seam) so a test can observe the driver-session's live events."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: the attached driver spawn threads a present-sink override through the
         # factory; accept + forward it (None = Session's default self-bound consumer).
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_tui_bridge_2570.py
+++ b/tests/test_pipeline_tui_bridge_2570.py
@@ -53,12 +53,13 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     """Real AgentRegistry + real Session factory (mirrors the IS-2/IS-4 tests)."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_run_pipeline_tool_is1.py
+++ b/tests/test_run_pipeline_tool_is1.py
@@ -63,12 +63,13 @@ def _agent_registry(
     test_pipeline_r5_agent_step_executor.py's ``_registry`` helper)."""
     holder: dict = {}
 
-    def _factory(profile, *, presentation_consumer=None) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # #2708 P3.1: accept + forward the attached driver spawn's present-sink override.
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (


### PR DESCRIPTION
**[per-PR-coder]** — #2708 **P3.2a** — the intervention (ask_user) spawn-bridge. Closes #2721 · `part of #2708`.

The D-capability (permission/ask_user delivery) analog of P3.1's present-render spawn gap: a chat-invoked pipeline's `ask_user` now reaches the **parent's live operator by construction**, instead of silently auto-refusing. Reuses the P3.1 spawn-override seam landed in #2719.

## Step-1 intervention topology (re-grounded at file:line on live main, HEAD `2738d9ea`; verify-don't-infer)

| Concern | live location |
|---|---|
| **listener registration for a normal chat session** | `repl.py:257-260` `bind_focus_listeners(intervention_channel=DEFAULT_CHAT_CHANNEL_ID)` -> `registry.py:2832 _wire_focus_listeners` -> `registry.py:2839 session.register_intervention_listener("tui")` -> `InterventionRegistry.register_listener` (adds to `_listeners`); re-wired on every `attach`. (chainlit `app.py:646`; MCP `server.py:235`; A2A `a2a_intervention.py`.) `DEFAULT_CHAT_CHANNEL_ID = "tui"` (`session.py:254`). |
| **no-listener silent-refuse site** | `services/intervention_registry.py:281-284` -- `if self._enforce_listener_presence and not self._listeners: return InterventionAnswer(text="")`. Confirmed: caller treats the empty answer as a refusal. Session builds its registry with `enforce_listener_presence=True` (`session.py:1520`). |
| **how the driver session differs** | `session_api._spawn_pipeline_driver_session` -> `spawn_session_recorded` -> factory -> a Session with its OWN fresh `InterventionRegistry(enforce_listener_presence=True)` and **NO listener registered** (no `bind_focus_listeners`/`register_intervention_listener` for the driver). So a driver `ask_user` -> `ChatInterventionBus(driver).deliver` -> `driver._dispatch_intervention` -> coordinator -> registry.dispatch -> **no listener -> auto-refuse `text=""`**, even under `run_pipeline_attached` with a live operator blocked on the parent. |
| **attached vs detached branch** | attached = `run_pipeline_attached` (resolves the live `caller_session`, passes `attached_parent_session`); detached = `start_pipeline_run` (passes None). Shared prefix `_spawn_pipeline_driver_session`. |
| **router intervention bus seam** | `session.py:1744 intervention_bus_factory` (consumed by `router_host_adapter.make_router_op_context`, `ctx.intervention_bus`), symmetric with P3.1's `presentation_renderer_factory` at `:1754`. |

This **matches** the architect's P3.2a spec (no contradiction).

## The fix (reuses the P3.1 spawn-override seam)

**`SpawnBridgeInterventionListener`** (`runtime/session_buses.py`, the intervention analog of `SpawnBridgePresentationConsumer`): holds `(parent_session, parent_channel_id)`; its `.bus()` builds a `ChatInterventionBus` bound to the **PARENT** session. So the driver's router intervention bus dispatches on the parent's `InterventionRegistry` (which HAS the live operator's listener) -- the child's `ask_user` announces on the **parent's** outbox (operator prompted), and the operator's answer resolves the **same** `iv.future` the driver's op awaits (the future lives on the shared `UserIntervention` -- no reverse answer path). Delivery is byte-identical to a parent-native ask_user (same `"tui"` channel-id stamping -> routed to the live listener, not the stalled queue).

**Spawn override seam (reused, not rebuilt):** an optional `intervention_bridge` param threaded through the SAME three functions P3.1 added `presentation_consumer` to -- `spawn_session_recorded` -> `spawn_session` -> `_construct_session` (`_construct_session` now builds a `factory_kwargs` dict; both-None keeps `self._factory(profile)` byte-identical). The frontend factory closures (chat/pipe/chainlit/mcp/web/dogfood) + `registry_bootstrap` widened to accept + forward `intervention_bridge` (flows via `**base` into `Session` -- **no `build_scoped_chat_session` signature change**, per the architect's "lighter than A" note).

**Wired ONLY on the attached path** (`_spawn_pipeline_driver_session`, when `attached_parent_session` is set -- the same condition P3.1's present bridge uses). Detached (`start_pipeline_run`) and ephemeral-headless spawns pass `None` -> fail-closed default.

**Enabler (symmetric with P3.1):** the `ask_user` tool handler (`tools/ask_user.py`) previously passed `ctx=None` (formally unreachable -> `RuntimeError`), so a pipeline `tool: ask_user` step could not reach the intervention machinery at all. It now **rebuilds the real OpContext** via `ctx.router_state.op_context_factory()` -- the exact `tools/present.py` precedent the present-layer arc established for `tool: present`. This makes `tool: ask_user` functional in a pipeline AND, combined with the bridge, reach the parent. (A bare/test ToolContext with no router_state factory still falls back to `ctx=None` -> the documented fail-fast, never a silent wrong answer.)

## Detached/async = known-RED scope-guard (NOT "correct")

The detached path keeps the driver's self-bound, listener-less registry -- its `ask_user` does **not** reach the invoker's operator. Pinned by `test_detached_ask_user_does_not_reach_invoker_known_red` (bounded-window: the invoker is never prompted). Tracked as the P3-item3 spawn-routing completeness gate, same as P3.1's detached present cell -- surfaced, not silently blessed.

## Tests (RED->GREEN, real intervention machinery, no mocks)

`tests/test_2708_p32a_spawn_bridge_intervention.py` (Tier 2, real `AgentRegistry`/`Session`/`PipelineExecutor` + the intervention-e2e operator-simulation pattern: register a real listener, drive `_maybe_answer_oldest_intervention`):
- **`test_attached_ask_user_reaches_parent_operator_and_answer_flows_back`** -- a chat->`run_pipeline_attached` with a `tool: ask_user` step: the ask parks on the **PARENT's** active-intervention queue, the operator is prompted on the parent outbox, and the answer flows back into the driver's op (parent log `user_answered_intervention` with the real answer + driver log `user_intervention_received` with the real answer). RED on origin/main = silent auto-refuse (operator never prompted).
- **`test_attached_ask_user_not_stalled_uses_live_parent_listener`** -- the bridged iv reaches the parent's LIVE listener (not the stalled queue) -- guards the channel-id choice.
- **`test_detached_ask_user_does_not_reach_invoker_known_red`** -- the known-RED scope guard.

Byte-identical for non-driver paths (all frontends default `intervention_bridge=None`; the 9 sync-pipeline test factories widened; existing P3.1 present + #2707 + attached tests stay GREEN).

**RED->GREEN evidence (falsify via `cp` scratch, never git):** saved the GREEN `session_api.py` to scratch, nulled the intervention bridge at its single wiring seam (`bridge_intervention = None`), re-ran the two attached tests -> **RED** (operator never prompted; the driver's self-bound ask stalls/refuses in its listener-less registry), then restored `session_api.py` from the scratch copy -> **GREEN** (all 3 pass).

## Recovery-gate check
The bridge routes runtime interventions to the parent's registry; it adds **no** WAL-derived / snapshot-backed recovery state (the parent-side dispatch persists exactly as a parent-native ask_user already does). CLAUDE.md's truncate-falsify gate does not apply (consistent with the architect's P3.2a note).

## 4 CI gates (all green locally)
- `ruff check src tests` -> **All checks passed**
- `test_tier_audit.py --strict <changed test files>` -> **88 inspected, 0 Tier-4**
- `pytest` (repo root) -> **7858 passed, 5 failed, 21 skipped** (0:03:45). The 5 failures are the **same pre-existing web route-mounting / plugin-loader** assertions #2719 (P3.1) documented -- `test_fp0001_routes_mounted`, `test_a2a_routes_mounted`, `test_mcp_routes_mounted`, `test_resources_route_is_mounted_on_app`, `test_loader_disambiguates_via_package_field` -- **0 overlap** with the intervention/spawn/pipeline code paths this PR touches.
- `verify_module_docstrings.py <11 changed src files>` -> **OK**

## Test plan
- [x] Attached ask_user reaches parent operator + answer flows back (RED->GREEN falsify-confirmed)
- [x] Bridged iv uses the live parent listener, not the stalled queue
- [x] Detached ask_user does NOT reach the invoker (known-RED scope guard)
- [x] Byte-identical: P3.1 present / #2707 / attached-pipeline tests unchanged & green
- [x] 9 sync-pipeline test factories widened for the new spawn override

🤖 Generated with [Claude Code](https://claude.com/claude-code)
