### PR TITLE
feat: #2708 P3-item3 — spawn-axis user-reaching completeness gate (closes #2710, #2706)

### DIFF
--- a/src/reyn/core/op_runtime/ask_user.py
+++ b/src/reyn/core/op_runtime/ask_user.py
@@ -62,6 +62,26 @@ async def handle(op: AskUserIROp, ctx: OpContext) -> dict:
     )
 
     answer = await ctx.intervention_bus.request(iv)
+    # #2708 P3-item3: a DELIBERATE, reason'd refusal (a detached/headless spawn with no
+    # attachable operator surface — AuditOnlyInterventionBridge) surfaces as a TYPED outcome:
+    # status="refused" carrying the reason, NOT a fabricated empty "ok" answer and NOT a
+    # park/hang. Distinct from a legacy empty-string auto-refuse (refused=False) which stays
+    # the status="ok", answer="" path below (behaviour unchanged for existing callers).
+    if getattr(answer, "refused", False):
+        ctx.events.emit(
+            "user_intervention_received",
+            run_id=ctx.run_id,
+            actor=ctx.actor,
+            phase=ctx.current_phase,
+            answer="",
+            intervention_id=iv.id,
+            refused=True,
+            reason=answer.reason,
+        )
+        return {
+            "kind": "ask_user", "question": op.question, "answer": "",
+            "status": "refused", "reason": answer.reason,
+        }
     # A selected option resolves with choice_id (= the option text); free-text
     # resolves with text.
     text = answer.choice_id or answer.text or ""

--- a/src/reyn/interfaces/slash/session.py
+++ b/src/reyn/interfaces/slash/session.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from reyn.interfaces.slash import reply, reply_error, slash
 from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.spawn_routing import ReviewedNA
 
 if TYPE_CHECKING:
     from reyn.runtime.session import Session
@@ -53,7 +54,14 @@ async def session_cmd(session: "Session", args: str) -> None:
 
     if sub == "new":
         try:
-            sid = reg.spawn_session(name)
+            # #2708 P3-item3: /session new opens a real attachable conversation session — the user
+            # /session switches to focus + drain it; self-binding to the factory default is reviewed-NA.
+            _routing = ReviewedNA("interfaces/slash/session.py::session_cmd")
+            sid = reg.spawn_session(
+                name,
+                presentation_consumer=_routing.presentation_consumer,
+                intervention_bridge=_routing.intervention_bridge,
+            )
         except ValueError as exc:  # dup id (spawn_session guards)
             await reply_error(session, str(exc))
             return

--- a/src/reyn/runtime/presentation_consumer.py
+++ b/src/reyn/runtime/presentation_consumer.py
@@ -119,6 +119,53 @@ class SpawnBridgePresentationConsumer:
         return self._parent_consumer.sink(self._parent_session)
 
 
+class AuditOnlyPresentationConsumer:
+    """The DELIBERATE present routing for a spawn with NO attachable parent surface and no own
+    drain — a detached pipeline driver (``start_pipeline_run``) or a headless ephemeral
+    agent-step worker (``run_agent_step``). Its ``present`` is *audit-only*: the ``presented``
+    P6 event still fires upstream (``core/op_runtime/present.py`` emits it UNCONDITIONALLY,
+    before the sink is consulted), so the render is durable in the spawn's own audit log /
+    ``reyn events`` replay — NOT lost — while the visible draw is a documented no-op.
+
+    This is the structural replacement for today's self-bound default, whose
+    ``OutboxPresentationConsumer`` would enqueue a ``"presentation"`` message onto the spawn's
+    OWN outbox that nobody drains (the #2710 detached-present / #2706 agent-step-present
+    silent-loss class): the render returned ``ok:True`` while reaching no one.
+
+    Distinct from ``NullPresentationConsumer`` (gated to reviewed NA *frontends* — web / mcp /
+    dogfood): this is the reviewed routing decision for a *spawn* with no attachable surface,
+    chosen EXPLICITLY at the spawn site via ``runtime/spawn_routing.AuditOnlyNoSurface`` — so a
+    human frontend's detached spawn still lands here deliberately, not by an NA-surface dodge.
+    It constructs NO ``OutboxPresentationRenderer`` (it returns the no-op sink), so the #2708
+    present-sink AST guard is unaffected."""
+
+    def sink(self, session: "Session") -> "PresentationRenderer":
+        # The child ``session`` is intentionally ignored: there is no surface to bind. The
+        # no-op sink drops the visible draw; the durable audit trail is the upstream
+        # ``presented`` P6 event (fired regardless of the sink), so the present is recorded,
+        # not orphaned.
+        return AuditOnlyPresentationSink()
+
+
+class AuditOnlyPresentationSink:
+    """The no-op ``PresentationRenderer`` an :class:`AuditOnlyPresentationConsumer` yields. Its
+    ``surface_name`` is the REGISTERED ``"null"`` neutralizer surface (``core/present/guard.py``
+    ``_STRATEGIES``) — the terminal no-op family — so a ``present`` op resolves + neutralizes
+    bindings cleanly for EVERY blueprint shape (an explicit text blueprint, a default viewer,
+    a generic dump alike) and then draws nothing. (Deliberately NOT reusing ``NullPresentationSink``
+    whose ``surface_name="none"`` is unregistered and fails the fail-closed guard for a text-leaf
+    blueprint — a spawn's audit-only present must be robust across all shapes.) The visible draw is
+    dropped; the durable audit trail is the upstream ``presented`` P6 event (fired regardless)."""
+
+    surface_name = "null"
+
+    def render(self, resolved: "ResolvedPresentation") -> None:
+        # Documented no-op: a detached/headless spawn has no attachable surface, so the resolved
+        # render model is intentionally not drawn. The `present` op's ack + `presented` event
+        # already fired upstream; only the visible draw is a no-op.
+        return None
+
+
 class NullPresentationSink:
     """`PresentationRenderer` (`core/present/renderer.py`) for a surface with no human
     presentation drain: `render` is a documented no-op. Obtainable ONLY through
@@ -160,6 +207,8 @@ class NullPresentationConsumer:
 
 
 __all__ = [
+    "AuditOnlyPresentationConsumer",
+    "AuditOnlyPresentationSink",
     "NullPresentationConsumer",
     "NullPresentationSink",
     "OutboxPresentationConsumer",

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2649,8 +2649,8 @@ class AgentRegistry:
         #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
         no-default kwargs (the spawn-axis completeness gate) — every caller must declare an
         explicit spawn-time user-reaching routing decision (``runtime/spawn_routing``): a
-        ``BridgeToParent`` / ``SelfDeliveringWithDrain`` / ``AuditOnlyNoSurface`` value's
-        resolved pair, or ``None``/``None`` only at a reviewed ``ReviewedNA`` self-bound site.
+        ``BridgeToParent`` / ``AuditOnlyNoSurface`` value's resolved pair, or ``None``/``None``
+        only at a reviewed ``ReviewedNA`` self-bound site.
         A missing kwarg is a TypeError (pinned by ``inspect.signature``), so a new spawn site
         cannot silently self-bind into an orphan/hang.
 
@@ -2757,9 +2757,9 @@ class AgentRegistry:
         #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
         no-default kwargs — the spawn-time user-reaching routing decision, forwarded to the
         constructed session. A caller declares one of ``runtime/spawn_routing``'s decisions:
-        ``BridgeToParent`` (attached pipeline driver — present reaches the parent surface, ask_user
-        reaches the parent's live operator), ``AuditOnlyNoSurface`` (detached/headless — present
-        audit-only, ask_user a typed refusal), ``SelfDeliveringWithDrain``, or ``ReviewedNA``
+        ``BridgeToParent`` (attached pipeline driver / delegated sub-agent — present reaches the
+        parent surface, ask_user reaches the parent's live operator), ``AuditOnlyNoSurface``
+        (detached/headless — present audit-only, ask_user a typed refusal), or ``ReviewedNA``
         (``None``/``None`` self-bound, reviewed sites only). No silent default (#2708 P3-item3)."""
         sid = self.spawn_session(
             name,

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -56,6 +56,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.task.subscription import SubscriptionRegistry
 
 from .profile import PROFILE_FILENAME, AgentProfile
+from .spawn_routing import ReviewedNA
 from .topology import TOPOLOGY_DIRNAME, Topology, _validate_topology_name
 
 DEFAULT_AGENT_NAME = "default"
@@ -493,7 +494,14 @@ class AgentRegistry:
             return session
         sid = f"{transport}:{native_id}"
         if not self._has_session(agent_name, sid):
-            self.spawn_session(agent_name, sid=sid)
+            # #2708 P3-item3: a transport-native inbound session — the transport drains its OWN
+            # outbox, no parent to bridge to; self-binding to the factory default is reviewed-correct.
+            _routing = ReviewedNA("runtime/registry.py::resolve_session")
+            self.spawn_session(
+                agent_name, sid=sid,
+                presentation_consumer=_routing.presentation_consumer,
+                intervention_bridge=_routing.intervention_bridge,
+            )
         return self.get_session(agent_name, sid)
 
     def load_profile(self, name: str) -> AgentProfile:
@@ -1042,7 +1050,14 @@ class AgentRegistry:
                 await self.ensure_running(name)
             else:
                 if not self._has_session(name, sid):
-                    self.spawn_session(name, sid=sid)
+                    # #2708 P3-item3: crash-recovery re-creates a spawned session to re-adopt its
+                    # snapshot — a headless re-wake with no attached surface; self-bound reviewed-NA.
+                    _routing = ReviewedNA("runtime/registry.py::restore_all")
+                    self.spawn_session(
+                        name, sid=sid,
+                        presentation_consumer=_routing.presentation_consumer,
+                        intervention_bridge=_routing.intervention_bridge,
+                    )
                 session = self._peek_session(name, sid)
                 if session is not None:
                     session.restore_state(snap)
@@ -1130,7 +1145,14 @@ class AgentRegistry:
                 continue
             bump_resume_attempts(run_dir)
             if not self._has_session(name, sid):
-                self.spawn_session(name, sid=sid)
+                # #2708 P3-item3: pipeline driver crash-recovery re-wake — the originally-attached
+                # caller is gone, the result routes via the inbox reply address; self-bound reviewed-NA.
+                _routing = ReviewedNA("runtime/registry.py::_rewake_pipeline_runs")
+                self.spawn_session(
+                    name, sid=sid,
+                    presentation_consumer=_routing.presentation_consumer,
+                    intervention_bridge=_routing.intervention_bridge,
+                )
             session = self._peek_session(name, sid)
             if session is None:
                 continue
@@ -2618,11 +2640,19 @@ class AgentRegistry:
 
     def spawn_session(
         self, name: str, sid: "str | None" = None,
-        *, presentation_consumer: "object | None" = None,
-        intervention_bridge: "object | None" = None,
+        *, presentation_consumer: "object | None",
+        intervention_bridge: "object | None",
     ) -> str:
         """FP-0043 Stage 3: open a NEW conversation Session under an existing
         Agent, SHARING the agent's identity object. Returns the new session-id.
+
+        #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
+        no-default kwargs (the spawn-axis completeness gate) — every caller must declare an
+        explicit spawn-time user-reaching routing decision (``runtime/spawn_routing``): a
+        ``BridgeToParent`` / ``SelfDeliveringWithDrain`` / ``AuditOnlyNoSurface`` value's
+        resolved pair, or ``None``/``None`` only at a reviewed ``ReviewedNA`` self-bound site.
+        A missing kwarg is a TypeError (pinned by ``inspect.signature``), so a new spawn site
+        cannot silently self-bind into an orphan/hang.
 
         Structure-only (lead-confirmed): this lets the Registry hold N sessions
         per agent; INBOUND routing to a non-default session is Stage 4 — until
@@ -2710,8 +2740,8 @@ class AgentRegistry:
     async def spawn_session_recorded(
         self, name: str, *, mode: str = "persistent",
         narrowing: "dict | None" = None,
-        presentation_consumer: "object | None" = None,
-        intervention_bridge: "object | None" = None,
+        presentation_consumer: "object | None",
+        intervention_bridge: "object | None",
     ) -> str:
         """#2103 S1bc: the action-layer SESSION-SPAWN seam — spawn a fresh-context
         session under ``name`` (sync ``spawn_session``) + persist the spawner's
@@ -2724,12 +2754,13 @@ class AgentRegistry:
         Does NOT submit a task — that is the caller (the spawn op), separable from the
         record. Emit no-ops without a WAL.
 
-        #2708 P3.1/P3.2a: ``presentation_consumer`` + ``intervention_bridge`` (both default
-        None = today's self-bound outbox consumer + listener-less intervention registry) are
-        the spawn-time capability overrides forwarded to the constructed session — the
-        attached pipeline driver spawn passes a ``SpawnBridgePresentationConsumer`` (present
-        reaches the parent surface) and a ``SpawnBridgeInterventionListener`` (ask_user
-        reaches the parent's live operator) by construction."""
+        #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
+        no-default kwargs — the spawn-time user-reaching routing decision, forwarded to the
+        constructed session. A caller declares one of ``runtime/spawn_routing``'s decisions:
+        ``BridgeToParent`` (attached pipeline driver — present reaches the parent surface, ask_user
+        reaches the parent's live operator), ``AuditOnlyNoSurface`` (detached/headless — present
+        audit-only, ask_user a typed refusal), ``SelfDeliveringWithDrain``, or ``ReviewedNA``
+        (``None``/``None`` self-bound, reviewed sites only). No silent default (#2708 P3-item3)."""
         sid = self.spawn_session(
             name,
             presentation_consumer=presentation_consumer,

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1036,8 +1036,15 @@ class RouterHostAdapter:
         # non-main-spawn guard: a non-main session may now spawn — its result routes back
         # correctly by (agent, from_sid). (None / "main" → main-case, byte-identical.)
         from_sid = self.live_session_id
+        # #2708 P3-item3: the LLM session_spawn tool spawns a real attachable conversation session
+        # under this agent (async-dispatch; result routes back FP-0043 Stage-4) — like /session new,
+        # the user can attach to drain it; self-binding to the factory default is reviewed-NA.
+        from reyn.runtime.spawn_routing import ReviewedNA
+        _routing = ReviewedNA("runtime/services/router_host_adapter.py::spawn_session")
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
+            presentation_consumer=_routing.presentation_consumer,
+            intervention_bridge=_routing.intervention_bridge,
         )
         # #2103 S1bc-exec: record sid→task BEFORE submitting, so a fast result finds the
         # trusted task on return (else it falls back to the kind=agent rendering).

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1036,11 +1036,24 @@ class RouterHostAdapter:
         # non-main-spawn guard: a non-main session may now spawn — its result routes back
         # correctly by (agent, from_sid). (None / "main" → main-case, byte-identical.)
         from_sid = self.live_session_id
-        # #2708 P3-item3: the LLM session_spawn tool spawns a real attachable conversation session
-        # under this agent (async-dispatch; result routes back FP-0043 Stage-4) — like /session new,
-        # the user can attach to drain it; self-binding to the factory default is reviewed-NA.
-        from reyn.runtime.spawn_routing import ReviewedNA
-        _routing = ReviewedNA("runtime/services/router_host_adapter.py::spawn_session")
+        # #2708 P3-item3 (co-vet must-fix): the LLM session_spawn tool spawns a background sub-agent
+        # that is NOT self-attachable by a human — it is LLM-initiated, so no operator is guaranteed
+        # to know the child sid to attach + drain (unlike /session new, which a human starts + attaches
+        # to). A self-bound (ReviewedNA) child would hit the SAME origin-pin park/hang this PR closes:
+        # its ask_user stamps "tui", no listener → InterventionCoordinator.dispatch parks forever. So
+        # the child BRIDGES to its spawning PARENT (BridgeToParent): the spawner is a live session whose
+        # own routing already decides where user-reaching capabilities go — a delegated sub-agent's
+        # ask_user reaches the parent's operator (parent attached) by construction, exactly like the
+        # attached pipeline driver ("delegated-work-can-ask"). A parent that cannot be resolved (should
+        # not happen — this adapter runs FOR that session) falls back to AuditOnlyNoSurface (a typed
+        # refusal), never a hang.
+        from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
+        parent_session = self._registry.get_session(self._agent_name, from_sid)
+        _routing = (
+            BridgeToParent(parent_session)
+            if parent_session is not None
+            else AuditOnlyNoSurface()
+        )
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
             presentation_consumer=_routing.presentation_consumer,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2264,6 +2264,14 @@ class Session:
         return self._presentation_consumer
 
     @property
+    def intervention_bridge(self):
+        """Read-only accessor for this session's spawn-time intervention bridge (#2708 P3.2a /
+        P3-item3), or ``None`` for a self-bound session. An attached pipeline driver carries a
+        ``SpawnBridgeInterventionListener`` (ask_user reaches the parent operator); a detached /
+        headless spawn carries an ``AuditOnlyInterventionBridge`` (ask_user is a typed refusal)."""
+        return self._intervention_bridge
+
+    @property
     def interventions(self) -> "InterventionRegistry":
         """Read-only public accessor for the session's InterventionRegistry.
 

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -73,8 +73,8 @@ prefix and differing only in how the caller drives + collects:
     EventLog bridge as ``pipeline_step_*`` — extended (``lifecycle_forwarder``) to re-emit
     ``presented`` onto the PARENT's log with ``bridged_from=<driver_sid>`` provenance.
     Together: both the visible present and its audit trail reach the parent, closing the
-    driver-isolation split. (Detached/async present is out of P3.1 scope — no attached
-    parent surface exists; tracked as the P3 spawn-routing completeness gate.)
+    driver-isolation split. (Detached/async present has no attached parent surface — the
+    #2708 P3-item3 completeness gate routes it ``AuditOnlyNoSurface``: audit-only, no orphan.)
     #2708 P3.2a: the SAME attach seam bridges the driver's INTERVENTION delivery. The driver
     gets a fresh listener-less ``InterventionRegistry`` (fail-closed), so an ``ask_user`` step
     would silently auto-refuse even with a live operator blocked on the parent (#2721). The
@@ -82,8 +82,16 @@ prefix and differing only in how the caller drives + collects:
     (``runtime/session_buses.py``) bound to the PARENT, so its router intervention bus
     dispatches on the PARENT session's live-operator listener — the operator is prompted and
     their answer flows back to the driver's awaiting op by construction. (Detached/async
-    intervention keeps the fail-closed default — a tracked known-RED cell, same completeness
-    gate as present.)
+    intervention has no attachable operator — the #2708 P3-item3 gate routes it
+    ``AuditOnlyNoSurface``: a typed, reason'd refusal, replacing the pre-fix origin-pin park/hang.)
+
+    #2708 P3-item3 (the spawn-axis completeness gate): every spawn seam
+    (``spawn_session`` / ``spawn_session_recorded`` / ``spawn_ephemeral_session``) takes
+    ``presentation_consumer`` + ``intervention_bridge`` as REQUIRED, no-default kwargs, so a
+    spawn's user-reaching capabilities cannot silently self-bind. Each spawn site declares a
+    ``runtime/spawn_routing`` decision: ``_spawn_pipeline_driver_session`` picks
+    ``BridgeToParent`` (attached) or ``AuditOnlyNoSurface`` (detached); ``run_agent_step`` picks
+    ``AuditOnlyNoSurface`` (headless leaf worker — closing #2706).
 """
 from __future__ import annotations
 
@@ -131,6 +139,8 @@ _DEFAULT_AGENT_STEP_TIMEOUT_S: float = 120.0
 
 async def spawn_ephemeral_session(
     registry: "AgentRegistry", *, identity: str, narrowing: "dict | None" = None,
+    presentation_consumer: "object | None",
+    intervention_bridge: "object | None",
 ) -> str:
     """Spawn an ephemeral session under ``identity`` for a non-LLM caller.
 
@@ -143,9 +153,18 @@ async def spawn_ephemeral_session(
 
     No task is submitted here — that stays the caller's job (the Pipeline
     executor's ``agent`` step, in the eventual wiring), same as the S1bc
-    action-layer seam does not submit either."""
+    action-layer seam does not submit either.
+
+    #2708 P3-item3: ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED, no-default
+    kwargs (root-cause-i of #2706: this seam wholly lacked them, so an agent-step worker's
+    ``present`` silently self-bound to an undrained outbox). The caller declares a
+    ``runtime/spawn_routing`` decision — ``run_agent_step`` passes ``AuditOnlyNoSurface`` (a
+    headless leaf worker has no attachable surface) — and this forwards it to
+    ``spawn_session_recorded``."""
     return await registry.spawn_session_recorded(
         identity, mode="ephemeral", narrowing=narrowing,
+        presentation_consumer=presentation_consumer,
+        intervention_bridge=intervention_bridge,
     )
 
 
@@ -199,9 +218,19 @@ async def run_agent_step(
     """
     from reyn.core.pipeline.schema import validate
     from reyn.runtime.message_bus import MessageBus
+    from reyn.runtime.spawn_routing import AuditOnlyNoSurface
 
     narrowing = _build_agent_step_narrowing(capabilities)
-    sid = await spawn_ephemeral_session(registry, identity=identity, narrowing=narrowing)
+    # #2708 P3-item3 (#2706): a headless ephemeral leaf worker has no attachable surface, so its
+    # user-reaching capabilities route AuditOnlyNoSurface — a ``present`` step is audit-only (the
+    # durable ``presented`` P6 event fires; no orphan outbox message), and an ``ask_user`` step
+    # returns a typed refusal rather than silently self-binding to an undrained outbox / hanging.
+    routing = AuditOnlyNoSurface()
+    sid = await spawn_ephemeral_session(
+        registry, identity=identity, narrowing=narrowing,
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
     session = registry.get_session(identity, sid)
     if session is None:
         raise AgentStepError(
@@ -219,6 +248,12 @@ async def run_agent_step(
         reply_to=SystemRef(),
         timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,
     )
+    # #2708 P3-item3 (#2706 root-cause-ii): a ``present`` step's output is ROUTED per the worker's
+    # DECLARED consumer (AuditOnlyNoSurface above) — it renders at the worker's own sink (audit-only:
+    # the durable ``presented`` P6 event) at op time, so it never arrives here as a ``"presentation"``
+    # outbox reply to be silently dropped (the pre-fix self-bound worker put a ``"presentation"`` on
+    # its own outbox that this ``kind == "agent"`` filter discarded). The join is the agent-step's
+    # RETURN text; presentation is not lost, it is deliberately audit-only per the declaration.
     text = "\n\n".join(r.text for r in replies if r.kind == "agent")
 
     if schema is None:
@@ -290,14 +325,14 @@ async def _spawn_pipeline_driver_session(
     Returns ``(driver_session, run_id, driver_sid)``; the caller drives the run
     (nudge + detached pump, or attached ``MessageBus.request``).
 
-    #2708 P3.1 (Half-A, visible output): when ``attached_parent_session`` is given (the
-    ATTACHED path only — ``run_pipeline_attached`` passes the live caller session), the
-    driver-session is spawned with a ``SpawnBridgePresentationConsumer`` bound to that
-    parent, so a ``present`` step's render reaches the PARENT's surface by construction
-    (structurally replacing the #2707 interim outbox forward). The DETACHED path
-    (``start_pipeline_run``) passes ``None`` — there is no live attached surface, so the
-    driver keeps the default self-bound consumer (its present is audit-only in its own
-    log, correct with no attached parent)."""
+    #2708 P3-item3: the spawn-time routing is a typed decision. ATTACHED path (given
+    ``attached_parent_session`` — ``run_pipeline_attached`` passes the live caller):
+    ``BridgeToParent`` binds the driver's present sink + ask_user routing to the PARENT, so a
+    ``present``/``ask_user`` step reaches the parent surface/operator by construction. DETACHED
+    path (``start_pipeline_run``, ``attached_parent_session=None``): ``AuditOnlyNoSurface`` —
+    ``present`` is audit-only (durable ``presented`` P6 event; no orphan outbox, closing #2710)
+    and ``ask_user`` returns a typed refusal (closing the confirmed detached HANG), a DELIBERATE
+    reviewed fail-mode rather than the pre-fix incidental self-bound orphan/park."""
     from reyn.core.events.config_recovery import reyn_root
     from reyn.core.pipeline.serde import pipeline_to_dict
     from reyn.core.pipeline.work_order import (
@@ -317,34 +352,24 @@ async def _spawn_pipeline_driver_session(
     # so the embedded pipeline name is sanitized to one safe path component.
     safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", pipeline_name) or "pipeline"
     rid = run_id or f"pipeline-{safe_name}-{uuid.uuid4().hex}"
-    # #2708 P3.1 Half-A / P3.2a: on the attached path, bind the driver's present sink AND its
-    # ask_user/permission routing to the PARENT by construction — so a `present` step reaches
-    # the parent surface (P3.1) and an `ask_user` step reaches the parent's live operator
-    # listener instead of silently auto-refusing (P3.2a, #2721). Detached spawns pass None for
-    # both → the default self-bound outbox consumer + listener-less registry (byte-identical);
-    # the detached ask_user auto-refuse is a tracked known-RED cell (P3 completeness gate).
-    bridge_consumer: "Any | None" = None
-    bridge_intervention: "Any | None" = None
-    if attached_parent_session is not None:
-        from reyn.runtime.presentation_consumer import SpawnBridgePresentationConsumer
-        from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
-        from reyn.runtime.session_buses import SpawnBridgeInterventionListener
+    # #2708 P3-item3: the driver's spawn-time user-reaching routing is an explicit, typed decision
+    # (``runtime/spawn_routing``). ATTACHED path (``run_pipeline_attached`` passes the live caller):
+    # ``BridgeToParent`` — a ``present`` step reaches the parent surface (P3.1) and an ``ask_user``
+    # step reaches the parent's live operator listener (P3.2a, #2721), both by construction. DETACHED
+    # path (``start_pipeline_run``, no attached surface): ``AuditOnlyNoSurface`` — ``present`` is
+    # audit-only (durable ``presented`` P6 event; no orphan outbox — closes #2710) and ``ask_user``
+    # returns a typed refusal instead of parking forever (closes the confirmed detached HANG).
+    from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
 
-        bridge_consumer = SpawnBridgePresentationConsumer(
-            parent_consumer=attached_parent_session.presentation_consumer,
-            parent_session=attached_parent_session,
-        )
-        # The parent chat surface (CLI/CUI/chainlit) registers its operator listener under
-        # DEFAULT_CHAT_CHANNEL_ID ("tui") — the same id a parent-native ask_user stamps — so
-        # the bridged iv routes to the live listener, not the stalled queue.
-        bridge_intervention = SpawnBridgeInterventionListener(
-            parent_session=attached_parent_session,
-            parent_channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+    routing = (
+        BridgeToParent(attached_parent_session)
+        if attached_parent_session is not None
+        else AuditOnlyNoSurface()
+    )
     sid = await registry.spawn_session_recorded(
         reply_to_agent, mode="persistent",
-        presentation_consumer=bridge_consumer,
-        intervention_bridge=bridge_intervention,
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
     )
     work_order = PipelineWorkOrder(
         run_id=rid,

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -208,20 +208,37 @@ class SpawnBridgeInterventionListener:
 
     def bus(
         self, *, run_id: "str | None" = None, actor: "str | None" = None,
-    ) -> "ChatInterventionBus":
-        """Build the driver's router intervention bus bound to the PARENT session.
+    ):
+        """Build the child's router intervention bus, resolved COMPOSITIONALLY toward the
+        PARENT's OWN declared routing (not a raw dispatch on the parent's coordinator).
 
-        The child ignores its OWN session (the analog of
-        ``SpawnBridgePresentationConsumer.sink`` ignoring the child): the returned
-        bus delivers through ``parent_session._dispatch_intervention`` and stamps
-        ``parent_channel_id`` so the parent's live operator listener resolves it —
-        identical to a parent-native chat ask_user."""
-        return ChatInterventionBus(
-            self._parent_session,
-            run_id=run_id,
-            actor=actor,
-            channel_id=self._parent_channel_id,
-        )
+        The child ignores its OWN session (the analog of ``SpawnBridgePresentationConsumer.sink``
+        ignoring the child) and asks: how does the PARENT itself route ``ask_user``?
+
+        - The parent is ITSELF a bridged/audit-only spawn (it carries an
+          ``intervention_bridge``) → recurse into it. So a chain of spawns (a sub-agent that
+          ``session_spawn``s a grandchild) resolves TRANSITIVELY toward the first ancestor that
+          can actually serve an operator — a grandchild's ``ask_user`` reaches the human via an
+          attached ancestor, NOT the immediate (headless, listener-less) parent's registry where
+          it would origin-pin park (the #2708 co-vet recursive hang edge).
+        - The parent is a root/real session (no bridge) with a LIVE operator listener on
+          ``parent_channel_id`` → deliver there (identical to a parent-native chat ask_user).
+        - The parent is a root/real session with NO live listener (a fully-headless chain — no
+          operator anywhere) → a typed, reason'd refusal (``AuditOnlyInterventionBridge``), NEVER
+          an unbounded park. This is the terminal that makes BridgeToParent hang-safe by
+          construction at every depth."""
+        parent_bridge = getattr(self._parent_session, "intervention_bridge", None)
+        if parent_bridge is not None:
+            return parent_bridge.bus(run_id=run_id, actor=actor)
+        if self._parent_session.interventions.has_listener(self._parent_channel_id):
+            return ChatInterventionBus(
+                self._parent_session,
+                run_id=run_id,
+                actor=actor,
+                channel_id=self._parent_channel_id,
+            )
+        # Fully-headless chain: no reachable operator → deliberate typed refusal, not a park.
+        return AuditOnlyInterventionBridge().bus(run_id=run_id, actor=actor)
 
 
 # The reason a detached/headless spawn's ``ask_user`` is refused — carried on the typed

--- a/src/reyn/runtime/session_buses.py
+++ b/src/reyn/runtime/session_buses.py
@@ -224,6 +224,57 @@ class SpawnBridgeInterventionListener:
         )
 
 
+# The reason a detached/headless spawn's ``ask_user`` is refused — carried on the typed
+# ``InterventionAnswer.reason`` so the pipeline/agent-step sees a DELIBERATE outcome, never a
+# fabricated empty answer nor a park/hang.
+NO_SURFACE_REFUSAL_REASON = (
+    "no interactive surface attached to this detached/headless run — ask_user cannot reach an "
+    "operator; the run proceeds with a deliberate refusal rather than hanging or fabricating an "
+    "empty answer"
+)
+
+
+class _AuditOnlyInterventionChannel:
+    """The ``UserChannel`` / ``RequestBus`` a detached/headless spawn dispatches ``ask_user`` on:
+    it DELIBERATELY refuses every intervention with a reason, resolving IMMEDIATELY — it never
+    enqueues, never announces, never awaits a future. So there is no origin-pin park/hang (the
+    confirmed #2710 detached fail-mode: the self-bound ``ChatInterventionBus`` stamps
+    ``origin_channel_id='tui'``, and ``InterventionCoordinator.dispatch`` parks it stalled +
+    ``await iv.future`` forever) and no silent empty-string auto-refuse."""
+
+    async def deliver(self, iv: "UserIntervention") -> "InterventionAnswer":
+        from reyn.user_intervention import InterventionAnswer
+
+        return InterventionAnswer(refused=True, reason=NO_SURFACE_REFUSAL_REASON)
+
+    async def request(self, iv: "UserIntervention") -> "InterventionAnswer":
+        return await self.deliver(iv)
+
+
+class AuditOnlyInterventionBridge:
+    """The intervention analog of ``AuditOnlyPresentationConsumer`` (``runtime/
+    presentation_consumer.py``): the DELIBERATE ``ask_user`` routing for a spawn with NO
+    attachable operator surface — a detached pipeline driver (``start_pipeline_run``) or a
+    headless ephemeral agent-step worker (``run_agent_step``).
+
+    Where ``SpawnBridgeInterventionListener`` routes a child ``ask_user`` to a live PARENT
+    operator, this bridge has no parent to route to, so its ``bus()`` returns a channel that
+    resolves every ``ask_user`` with a typed, reason'd REFUSAL
+    (``InterventionAnswer(refused=True, reason=...)``). That is the reviewed replacement for the
+    two incidental fail-modes an unrouted detached spawn hit before: the origin-pin park/hang
+    (confirmed the live #2710 fail-mode) and, on other constructions, the silent empty-string
+    auto-refuse (``InterventionRegistry.dispatch``'s ``enforce_listener_presence`` short-circuit).
+    Chosen EXPLICITLY at the spawn site via ``runtime/spawn_routing.AuditOnlyNoSurface``."""
+
+    def bus(
+        self, *, run_id: "str | None" = None, actor: "str | None" = None,
+    ) -> "_AuditOnlyInterventionChannel":
+        """Build the spawn's router intervention channel — a refuse-with-reason sink. The
+        ``run_id`` / ``actor`` are accepted for signature-parity with
+        ``SpawnBridgeInterventionListener.bus`` but unused (a refusal carries no provenance)."""
+        return _AuditOnlyInterventionChannel()
+
+
 class OutboxPresentationRenderer:
     """``PresentationRenderer`` (``core/present/renderer.py``) that routes a resolved
     presentation's render model onto the Session's outbox as a ``"presentation"``

--- a/src/reyn/runtime/spawn_routing.py
+++ b/src/reyn/runtime/spawn_routing.py
@@ -13,18 +13,20 @@ three spawn seams (``AgentRegistry.spawn_session`` / ``.spawn_session_recorded``
 ``session_api.spawn_ephemeral_session``) takes ``presentation_consumer`` + ``intervention_bridge``
 as REQUIRED, no-default kwargs (pinned by ``inspect.signature`` — the #1402
 completeness-by-construction mechanism generalized to the spawn axis), so a spawn site cannot
-omit the decision. A ``SpawnRouting`` value names ONE of four decisions and resolves to the
+omit the decision. A ``SpawnRouting`` value names ONE of three decisions and resolves to the
 concrete pair a site forwards:
 
-- :class:`BridgeToParent` — an attached parent surface exists: the child's ``present`` renders
-  to the parent's sink and its ``ask_user`` reaches the parent's live operator listener (the
-  P3.1 / P3.2a ``SpawnBridge*`` seams). Used by the attached pipeline driver spawn.
+- :class:`BridgeToParent` — the child bridges its user-reaching capabilities to its spawning
+  PARENT: ``present`` renders to the parent's sink and ``ask_user`` reaches the parent's live
+  operator listener (the P3.1 / P3.2a ``SpawnBridge*`` seams). Used by the attached pipeline
+  driver spawn AND the LLM ``session_spawn`` tool (a delegated sub-agent's ask_user must reach
+  the operator, "delegated-work-can-ask") — since the parent is a live session with its own
+  declared routing, this is hang-safe by construction (parent attached → operator; a parent
+  that cannot serve degrades to that parent's own reviewed fail-mode, never an unbounded park).
 - :class:`AuditOnlyNoSurface` — no attachable surface (detached async pipeline, headless
   ephemeral agent-step): ``present`` is audit-only (the durable ``presented`` P6 event fires;
   the visible draw is a documented no-op — not an orphan) and ``ask_user`` returns a typed,
   reason'd refusal (never silent-empty, never a park/hang). The reviewed *deliberate* fail-mode.
-- :class:`SelfDeliveringWithDrain` — the spawn owns a surface that drains its own outbox
-  (passes an explicit real consumer); no parent bridge.
 - :class:`ReviewedNA` — a spawn where self-binding to the factory default is genuinely correct
   (a real user-attachable conversation session, or a crash-recovery re-wake). Its ``site`` MUST
   be a member of the reviewed :data:`_REVIEWED_SELF_BOUND_SPAWN_SITES` frozenset — constructing
@@ -58,16 +60,16 @@ if TYPE_CHECKING:
 #   - _rewake_pipeline_runs: pipeline driver crash-recovery re-wake; the originally-attached caller
 #                           is gone, the result routes via the inbox reply address.
 #   - session_cmd:          ``/session new`` opens a real attachable conversation session under the
-#                           agent — the user ``/session switch``es to focus + drain it.
-#   - spawn_session:        the LLM ``session_spawn`` tool spawns a real attachable conversation
-#                           session under the agent (async-dispatch; result routes back FP-0043
-#                           Stage-4) — like ``/session new``, drainable by attaching.
+#                           agent — a HUMAN starts it and ``/session switch``es to focus + drain it.
+# NB: the LLM ``session_spawn`` tool (``router_host_adapter.spawn_session``) is deliberately NOT
+# here — it is LLM-initiated + backgrounded, so no operator is guaranteed to know the child sid to
+# attach + drain, and a self-bound child would hit the very origin-pin ask_user hang this gate
+# closes. It routes ``BridgeToParent`` instead (delegated-work-can-ask), NOT self-bound.
 _REVIEWED_SELF_BOUND_SPAWN_SITES = frozenset({
     "runtime/registry.py::resolve_session",
     "runtime/registry.py::restore_all",
     "runtime/registry.py::_rewake_pipeline_runs",
     "interfaces/slash/session.py::session_cmd",
-    "runtime/services/router_host_adapter.py::spawn_session",
 })
 
 
@@ -141,26 +143,6 @@ class AuditOnlyNoSurface(SpawnRouting):
         return AuditOnlyInterventionBridge()
 
 
-class SelfDeliveringWithDrain(SpawnRouting):
-    """The spawn owns a surface that drains its OWN outbox — it passes an explicit, real present
-    consumer (e.g. a stdout self-delivering consumer). No parent bridge; ``ask_user`` keeps the
-    session's own listener wiring."""
-
-    def __init__(
-        self, consumer: "object", *, intervention_bridge: "object | None" = None,
-    ) -> None:
-        self._consumer = consumer
-        self._intervention_bridge = intervention_bridge
-
-    @property
-    def presentation_consumer(self) -> "object":
-        return self._consumer
-
-    @property
-    def intervention_bridge(self) -> "object | None":
-        return self._intervention_bridge
-
-
 class ReviewedNA(SpawnRouting):
     """Self-binding to the session factory's own default is genuinely correct here — a real
     user-attachable conversation session, or a crash-recovery re-wake. ``site`` MUST be a member
@@ -195,7 +177,6 @@ __all__ = [
     "AuditOnlyNoSurface",
     "BridgeToParent",
     "ReviewedNA",
-    "SelfDeliveringWithDrain",
     "SpawnRouting",
     "_REVIEWED_SELF_BOUND_SPAWN_SITES",
 ]

--- a/src/reyn/runtime/spawn_routing.py
+++ b/src/reyn/runtime/spawn_routing.py
@@ -1,0 +1,201 @@
+"""reyn.runtime.spawn_routing — the typed spawn-time user-reaching routing decision (#2708 P3-item3).
+
+A spawned session inherits two user-reaching capabilities from its spawn site: where its
+``present`` renders, and where its ``ask_user`` reaches an operator. When a spawn site
+declares NEITHER (the pre-P3-item3 ``None``/``None`` default), the child silently self-binds
+— its ``present`` writes to its own undrained outbox (the #2710 detached / #2706 agent-step
+orphan class) and its ``ask_user`` origin-pin-parks forever on a ``"tui"`` channel no listener
+serves (the confirmed #2710 detached HANG) or silently empty-auto-refuses. The failure was
+*incidental*, not chosen.
+
+This module makes the decision **explicit, typed, and reviewed by construction**. Each of the
+three spawn seams (``AgentRegistry.spawn_session`` / ``.spawn_session_recorded`` /
+``session_api.spawn_ephemeral_session``) takes ``presentation_consumer`` + ``intervention_bridge``
+as REQUIRED, no-default kwargs (pinned by ``inspect.signature`` — the #1402
+completeness-by-construction mechanism generalized to the spawn axis), so a spawn site cannot
+omit the decision. A ``SpawnRouting`` value names ONE of four decisions and resolves to the
+concrete pair a site forwards:
+
+- :class:`BridgeToParent` — an attached parent surface exists: the child's ``present`` renders
+  to the parent's sink and its ``ask_user`` reaches the parent's live operator listener (the
+  P3.1 / P3.2a ``SpawnBridge*`` seams). Used by the attached pipeline driver spawn.
+- :class:`AuditOnlyNoSurface` — no attachable surface (detached async pipeline, headless
+  ephemeral agent-step): ``present`` is audit-only (the durable ``presented`` P6 event fires;
+  the visible draw is a documented no-op — not an orphan) and ``ask_user`` returns a typed,
+  reason'd refusal (never silent-empty, never a park/hang). The reviewed *deliberate* fail-mode.
+- :class:`SelfDeliveringWithDrain` — the spawn owns a surface that drains its own outbox
+  (passes an explicit real consumer); no parent bridge.
+- :class:`ReviewedNA` — a spawn where self-binding to the factory default is genuinely correct
+  (a real user-attachable conversation session, or a crash-recovery re-wake). Its ``site`` MUST
+  be a member of the reviewed :data:`_REVIEWED_SELF_BOUND_SPAWN_SITES` frozenset — constructing
+  one for any other site raises, so a NEW spawn site cannot silently join the self-bound set
+  (the #2708 NA-ratchet generalized to the spawn axis).
+
+Enforcement is three-layered, mirroring the landed P1 present-sink gate:
+  1. required no-default kwargs (``inspect.signature`` pin) — a site cannot omit the decision;
+  2. the :class:`ReviewedNA` frozenset ratchet — a new self-bound site cannot silently join;
+  3. an AST guard (``tests/test_spawn_routing_gate_2708.py``) — every ``src/reyn`` call to a
+     spawn seam passes both routing kwargs explicitly, so a new gap is a PR-time CI failure.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+# The reviewed set of spawn sites where self-binding to the session factory's own default
+# (``presentation_consumer=None`` / ``intervention_bridge=None``) is genuinely correct — either
+# a real user-attachable conversation session (the user can drain its outbox / answer its
+# ask_user by attaching), or a crash-recovery re-wake with no attached caller. Membership is a
+# REVIEWED ratchet (the #2708 NA-ratchet model): a new spawn site cannot self-bind without being
+# added here in review. Keyed ``"<src-relpath>::<enclosing-function>"`` so the id is stable
+# under line moves and unambiguous across same-named functions. Each member states WHY it is NA:
+#   - resolve_session:      a transport-native inbound session (web:<thread> / a2a:<peer>); the
+#                           transport drains its OWN outbox — no parent to bridge to.
+#   - restore_all:          crash-recovery re-creates a spawned session to re-adopt its snapshot;
+#                           a headless re-wake with no attached surface (present → its own audit log).
+#   - _rewake_pipeline_runs: pipeline driver crash-recovery re-wake; the originally-attached caller
+#                           is gone, the result routes via the inbox reply address.
+#   - session_cmd:          ``/session new`` opens a real attachable conversation session under the
+#                           agent — the user ``/session switch``es to focus + drain it.
+#   - spawn_session:        the LLM ``session_spawn`` tool spawns a real attachable conversation
+#                           session under the agent (async-dispatch; result routes back FP-0043
+#                           Stage-4) — like ``/session new``, drainable by attaching.
+_REVIEWED_SELF_BOUND_SPAWN_SITES = frozenset({
+    "runtime/registry.py::resolve_session",
+    "runtime/registry.py::restore_all",
+    "runtime/registry.py::_rewake_pipeline_runs",
+    "interfaces/slash/session.py::session_cmd",
+    "runtime/services/router_host_adapter.py::spawn_session",
+})
+
+
+class SpawnRouting:
+    """Base of the typed spawn-time routing decision. A subclass resolves to the
+    ``(presentation_consumer, intervention_bridge)`` pair a spawn site forwards to the spawn seam
+    via the required ``presentation_consumer=`` / ``intervention_bridge=`` kwargs."""
+
+    @property
+    def presentation_consumer(self) -> "object | None":
+        """The present-sink consumer the spawned session is constructed with (or ``None`` to
+        inherit the session factory's own default — the self-bound case)."""
+        raise NotImplementedError
+
+    @property
+    def intervention_bridge(self) -> "object | None":
+        """The ask_user/permission bridge the spawned session is constructed with (or ``None``
+        to keep the self-bound, listener-enforced default)."""
+        raise NotImplementedError
+
+
+class BridgeToParent(SpawnRouting):
+    """An attached PARENT surface exists — bridge the child's user-reaching capabilities to it
+    (P3.1 present + P3.2a intervention). Used by the attached pipeline driver spawn: a ``present``
+    step reaches the parent's sink and an ``ask_user`` step reaches the parent's live operator
+    listener, both by construction."""
+
+    def __init__(self, parent_session: "Session") -> None:
+        self._parent_session = parent_session
+
+    @property
+    def presentation_consumer(self) -> "object":
+        from reyn.runtime.presentation_consumer import SpawnBridgePresentationConsumer
+
+        return SpawnBridgePresentationConsumer(
+            parent_consumer=self._parent_session.presentation_consumer,
+            parent_session=self._parent_session,
+        )
+
+    @property
+    def intervention_bridge(self) -> "object":
+        from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
+        from reyn.runtime.session_buses import SpawnBridgeInterventionListener
+
+        # The parent chat surface registers its operator listener under DEFAULT_CHAT_CHANNEL_ID
+        # ("tui") — the same id a parent-native ask_user stamps — so the bridged iv routes to the
+        # live listener, not the stalled queue.
+        return SpawnBridgeInterventionListener(
+            parent_session=self._parent_session,
+            parent_channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+
+
+class AuditOnlyNoSurface(SpawnRouting):
+    """No attachable surface (detached async pipeline / headless ephemeral agent-step): the
+    DELIBERATE, reviewed fail-mode. ``present`` is audit-only (the durable ``presented`` P6 event
+    fires; the visible draw is a documented no-op — not an orphan outbox message) and ``ask_user``
+    returns a typed, reason'd refusal (``InterventionAnswer.refused`` → the op returns
+    ``status="refused"``) — never a silent empty answer, never a park/hang."""
+
+    @property
+    def presentation_consumer(self) -> "object":
+        from reyn.runtime.presentation_consumer import AuditOnlyPresentationConsumer
+
+        return AuditOnlyPresentationConsumer()
+
+    @property
+    def intervention_bridge(self) -> "object":
+        from reyn.runtime.session_buses import AuditOnlyInterventionBridge
+
+        return AuditOnlyInterventionBridge()
+
+
+class SelfDeliveringWithDrain(SpawnRouting):
+    """The spawn owns a surface that drains its OWN outbox — it passes an explicit, real present
+    consumer (e.g. a stdout self-delivering consumer). No parent bridge; ``ask_user`` keeps the
+    session's own listener wiring."""
+
+    def __init__(
+        self, consumer: "object", *, intervention_bridge: "object | None" = None,
+    ) -> None:
+        self._consumer = consumer
+        self._intervention_bridge = intervention_bridge
+
+    @property
+    def presentation_consumer(self) -> "object":
+        return self._consumer
+
+    @property
+    def intervention_bridge(self) -> "object | None":
+        return self._intervention_bridge
+
+
+class ReviewedNA(SpawnRouting):
+    """Self-binding to the session factory's own default is genuinely correct here — a real
+    user-attachable conversation session, or a crash-recovery re-wake. ``site`` MUST be a member
+    of :data:`_REVIEWED_SELF_BOUND_SPAWN_SITES`; constructing one for any other site raises, so a
+    NEW spawn site cannot silently self-bind (the #2708 NA-ratchet, spawn axis)."""
+
+    def __init__(self, site: str) -> None:
+        if site not in _REVIEWED_SELF_BOUND_SPAWN_SITES:
+            raise ValueError(
+                f"ReviewedNA refused for spawn site {site!r}: not a reviewed self-bound site. A "
+                f"spawn that reaches the user must declare BridgeToParent / SelfDeliveringWithDrain "
+                f"/ AuditOnlyNoSurface; only {sorted(_REVIEWED_SELF_BOUND_SPAWN_SITES)} may self-bind "
+                f"to the factory default (add here ONLY via review — see the frozenset rationale)."
+            )
+        self._site = site
+
+    @property
+    def site(self) -> str:
+        """The reviewed self-bound spawn-site id this decision was constructed for."""
+        return self._site
+
+    @property
+    def presentation_consumer(self) -> None:
+        return None
+
+    @property
+    def intervention_bridge(self) -> None:
+        return None
+
+
+__all__ = [
+    "AuditOnlyNoSurface",
+    "BridgeToParent",
+    "ReviewedNA",
+    "SelfDeliveringWithDrain",
+    "SpawnRouting",
+    "_REVIEWED_SELF_BOUND_SPAWN_SITES",
+]

--- a/src/reyn/runtime/spawn_routing.py
+++ b/src/reyn/runtime/spawn_routing.py
@@ -153,9 +153,9 @@ class ReviewedNA(SpawnRouting):
         if site not in _REVIEWED_SELF_BOUND_SPAWN_SITES:
             raise ValueError(
                 f"ReviewedNA refused for spawn site {site!r}: not a reviewed self-bound site. A "
-                f"spawn that reaches the user must declare BridgeToParent / SelfDeliveringWithDrain "
-                f"/ AuditOnlyNoSurface; only {sorted(_REVIEWED_SELF_BOUND_SPAWN_SITES)} may self-bind "
-                f"to the factory default (add here ONLY via review — see the frozenset rationale)."
+                f"spawn that reaches the user must declare BridgeToParent or AuditOnlyNoSurface; "
+                f"only {sorted(_REVIEWED_SELF_BOUND_SPAWN_SITES)} may self-bind to the factory "
+                f"default (add here ONLY via review — see the frozenset rationale)."
             )
         self._site = site
 

--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -174,9 +174,20 @@ class InterventionAnswer:
     is the id of the selected `InterventionChoice` (or None when the user
     typed something that didn't match any hotkey — producer decides whether
     to re-issue the prompt).
+
+    #2708 P3-item3: `refused` marks a DELIBERATE, reason'd refusal (distinct from
+    an empty free-text answer `text=""`). A detached/headless spawn with no
+    attachable operator surface resolves `ask_user` this way (via
+    `runtime/session_buses.AuditOnlyInterventionBridge`), so the producer sees a
+    typed outcome — the `ask_user` op returns `status="refused"` carrying `reason`
+    — instead of a fabricated empty answer or a park/hang. Legacy empty-string
+    auto-refusals (`InterventionRegistry.dispatch`'s listener-enforce short-circuit)
+    keep `refused=False` — behaviour unchanged for existing callers.
     """
     text: str = ""
     choice_id: str | None = None
+    refused: bool = False
+    reason: str = ""
 
 
 @runtime_checkable

--- a/tests/test_2103_A_ephemeral_auto_vanish_1953.py
+++ b/tests/test_2103_A_ephemeral_auto_vanish_1953.py
@@ -58,8 +58,8 @@ async def test_ephemeral_spawn_auto_vanishes_persistent_survives(tmp_path):
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")  # the live main session
 
-    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
-    per_sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)
+    per_sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     live = reg.session_ids("alice")
     assert eph_sid in live and per_sid in live  # both live initially (public surface)
 
@@ -88,7 +88,7 @@ async def test_ephemeral_does_not_vanish_while_awaiting_delegation(tmp_path):
     if the awaited-work guard is dropped (it vanishes mid-await)."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)
     eph = reg._peek_session("alice", sid)
 
     # the spawned session delegated to a peer + awaits its response (pending chain;
@@ -114,7 +114,7 @@ async def test_ephemeral_vanish_scheduled_once(tmp_path):
     session)."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)
     eph = reg._peek_session("alice", sid)
 
     eph._maybe_schedule_ephemeral_vanish()

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -80,7 +80,7 @@ async def test_main_spawn_result_routes_back_correlated_as_spawned_session(tmp_p
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")  # the spawner (main session)
 
-    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     spawned = reg.ensure_session_running("worker", sid)
     assert spawned is not None
     # the spawner records the trusted sid→task (= what the adapter does at spawn time).
@@ -117,7 +117,7 @@ async def test_unrecorded_sid_falls_back_to_kind_agent(tmp_path, monkeypatch):
     monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", _scripted_llm())
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")
-    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     spawned = reg.ensure_session_running("worker", sid)
     # NO record_spawned_task → the lookup misses.
     await spawned._send_agent_response(
@@ -136,7 +136,7 @@ async def test_response_routes_to_non_main_spawner_sid_not_main(tmp_path):
     (get_or_load(to) → main): main would get it + the spawner would not."""
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")  # the agent's main (must NOT receive a non-main reply)
-    x_sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    x_sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     spawner_x = reg.ensure_session_running("worker", x_sid)  # the non-main spawner, loaded
     assert spawner_x is not None and x_sid != "main"
 
@@ -180,7 +180,7 @@ async def test_non_main_delegation_reply_routes_to_delegating_sid_not_main(tmp_p
     reg = _registry(tmp_path)
     reg.create("peer")
     main = reg.get_or_load("worker")  # the delegator agent's main (must NOT get the reply)
-    x_sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    x_sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     x = reg.ensure_session_running("worker", x_sid)  # the NON-MAIN delegating session
     assert x is not None and x_sid != "main"
 

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -34,12 +34,13 @@ def _registry(tmp_path: Path) -> AgentRegistry:
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 
-    def _factory(profile: AgentProfile) -> Session:
+    def _factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         # wire the registry back-reference (= what production frontends pass) so the
         # A2A response callback (_a2a_send_response) can route — without it the
         # response is silently dropped (registry is None).
         return Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge,
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2103_s1bc_session_spawn_tool.py
+++ b/tests/test_2103_s1bc_session_spawn_tool.py
@@ -46,7 +46,7 @@ async def test_spawn_session_recorded_emits_config_complete_event(tmp_path: Path
     reg = _registry(tmp_path)
     sid = await reg.spawn_session_recorded(
         "worker", mode="ephemeral", narrowing={"tool_deny": ["sandboxed_exec"]},
-    )
+    presentation_consumer=None, intervention_bridge=None)
     ev = next(
         e for e in reg.state_log.iter_from(0)
         if e.get("kind") == "session_spawned" and e.get("sid") == sid
@@ -71,7 +71,7 @@ async def test_spawn_session_recorded_enforces_narrowing_on_live_session(tmp_pat
     reg = _registry(tmp_path)
     sid = await reg.spawn_session_recorded(
         "worker", mode="persistent", narrowing={"tool_deny": ["delete_file"]},
-    )
+    presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("worker", sid)
     # the live tool gate reads _effective_contextual_for_turn(); a fresh spawned session
     # has no untrusted-content history → it returns the injected _contextual_permission.
@@ -92,7 +92,7 @@ async def test_spawn_session_recorded_no_narrowing_is_inert(tmp_path: Path) -> N
     is (None, ∅), the public surface), but session_spawned is still emitted
     (rewind-tracking is unconditional)."""
     reg = _registry(tmp_path)
-    sid = await reg.spawn_session_recorded("worker", mode="persistent", narrowing=None)
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", narrowing=None, presentation_consumer=None, intervention_bridge=None)
     assert reg.resolved_profile_for("worker", sid=sid) == (None, frozenset())  # inert
     assert any(e.get("kind") == "session_spawned" for e in reg.state_log.iter_from(0))
 

--- a/tests/test_2581_pipeline_hotreload.py
+++ b/tests/test_2581_pipeline_hotreload.py
@@ -265,8 +265,10 @@ async def test_hotreload_malformed_pipeline_observable_via_warning_and_noop_appl
 def _worker_registry(tmp_path: Path, state_log: StateLog, pipeline_registry: PipelineRegistry) -> AgentRegistry:
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             pipeline_registry=pipeline_registry,

--- a/tests/test_2585_pr2_ephemeral_non_interactive_force.py
+++ b/tests/test_2585_pr2_ephemeral_non_interactive_force.py
@@ -70,7 +70,7 @@ async def test_ephemeral_spawn_forces_non_interactive_true(tmp_path):
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")  # the live main session (factory default: False)
 
-    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    eph_sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)
     eph = reg._peek_session("alice", eph_sid)
 
     assert eph.non_interactive is True
@@ -85,7 +85,7 @@ async def test_persistent_spawn_keeps_factory_default(tmp_path):
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
 
-    per_sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    per_sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     per = reg._peek_session("alice", per_sid)
 
     assert per.non_interactive is False

--- a/tests/test_2597_s2a_mcp_connection_service.py
+++ b/tests/test_2597_s2a_mcp_connection_service.py
@@ -193,12 +193,12 @@ async def test_remove_session_teardown_closes_held_connections(tmp_path: Path):
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(agent_name=profile.name, mcp_servers={"srv": _CFG})
 
     registry = AgentRegistry(project_root=tmp_path, session_factory=_factory)
     registry.create("s2a-owner")
-    sid = await registry.spawn_session_recorded("s2a-owner", mode="persistent")
+    sid = await registry.spawn_session_recorded("s2a-owner", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     session = registry._peek_session("s2a-owner", sid)
 
     await session._mcp_call_tool("srv", "echo", {"text": "hi"})

--- a/tests/test_2608_h3_pipeline_launch_hook.py
+++ b/tests/test_2608_h3_pipeline_launch_hook.py
@@ -340,8 +340,10 @@ def _agent_registry_with_hooks(
 ) -> AgentRegistry:
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             hooks_config=hooks_config, pipeline_registry=pipeline_registry,

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -176,8 +176,11 @@ async def test_detached_present_not_bridged_to_caller(tmp_path: Path) -> None:
     """Tier 2: scope guard — a DETACHED (``start_pipeline_run``) pipeline's present is NOT
     bridged to the (non-attached) invoker: no ``pipeline_run_attached`` marker is emitted,
     so the caller's forwarder never bridge-subscribes → no bridged ``presented`` on the
-    caller log and no presentation on the caller outbox. This pins the attached-only scope
-    (detached/async present is the tracked P3-item3 known-RED cell, not addressed here)."""
+    caller log and no presentation on the caller outbox. This pins the attached-only scope of
+    P3.1's PARENT-bridge. (Detached present is now a DELIBERATE ``AuditOnlyNoSurface`` decision
+    — audit-only, no orphan — landed in P3-item3; see
+    ``test_spawn_routing_detached_fail_mode_2708``. It still, correctly, does not reach this
+    non-attached caller.)"""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")

--- a/tests/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/test_2708_p32a_spawn_bridge_intervention.py
@@ -222,15 +222,14 @@ async def test_attached_ask_user_not_stalled_uses_live_parent_listener(
 
 
 @pytest.mark.asyncio
-async def test_detached_ask_user_does_not_reach_invoker_known_red(tmp_path: Path) -> None:
-    """Tier 2: scope guard (known-RED cell) — a DETACHED (``start_pipeline_run``) pipeline's
-    ``ask_user`` has NO attached parent surface, so the driver keeps its self-bound,
-    listener-less intervention registry: the ask does NOT reach the (non-attached) invoker's
-    live operator listener (over a bounded window the invoker is never prompted). This pins
-    the attached-only scope of P3.2a — detached/async intervention is the tracked P3-item3
-    completeness-gate cell, NOT addressed here and NOT silently blessed as correct (the
-    detached ask does not resolve against the invoker; whether it fail-closes or stalls in
-    the driver's own registry is the known-RED behavior tracked for the completeness gate)."""
+async def test_detached_ask_user_does_not_reach_invoker(tmp_path: Path) -> None:
+    """Tier 2: scope guard — a DETACHED (``start_pipeline_run``) pipeline's ``ask_user`` does
+    NOT reach the (non-attached) invoker's live operator listener (over a bounded window the
+    invoker is never prompted). This pins the attached-only scope of P3.2a's PARENT-bridge.
+    (Detached ask_user is now a DELIBERATE ``AuditOnlyNoSurface`` decision — a typed refusal
+    resolved locally, NOT the pre-fix origin-pin park/hang — landed in P3-item3; see
+    ``test_spawn_routing_detached_fail_mode_2708``. It correctly resolves without ever touching
+    this non-attached invoker's registry.)"""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg = _agent_registry(tmp_path, state_log)
     caller = reg.get_or_load("worker")
@@ -258,9 +257,9 @@ async def test_detached_ask_user_does_not_reach_invoker_known_red(tmp_path: Path
             )
             await asyncio.sleep(0.1)
     finally:
-        # Teardown: the detached driver's ask_user may still be pending in its own registry
-        # (known-RED), so cancel the registry's live session run tasks to avoid a lingering
-        # coroutine at loop close.
+        # Teardown: cancel the registry's live session run tasks to avoid a lingering coroutine
+        # at loop close. (Post-P3-item3 the detached ask_user resolves immediately via the
+        # AuditOnly refusal — no longer parked — but the driver pump task may still be live.)
         for task in list(reg._tasks.values()):
             if not task.done():
                 task.cancel()

--- a/tests/test_2714_mcp_shutdown_teardown.py
+++ b/tests/test_2714_mcp_shutdown_teardown.py
@@ -39,7 +39,7 @@ async def test_shutdown_closes_main_session_held_mcp_connections(tmp_path: Path)
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(agent_name=profile.name, mcp_servers={"srv": _CFG})
 
     registry = AgentRegistry(project_root=tmp_path, session_factory=_factory)

--- a/tests/test_hook_applicability_2285.py
+++ b/tests/test_hook_applicability_2285.py
@@ -54,8 +54,8 @@ async def test_hook_disable_is_per_session(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     _write_agent_hook(tmp_path, "myhook")  # shared per-agent hook, before the sessions build registries
     reg.get_or_load("alice")
-    s1 = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
-    s2 = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s1 = reg.get_session("alice", await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None))
+    s2 = reg.get_session("alice", await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None))
 
     s1.set_hook_enabled("myhook", False)  # disable in S1 only
 
@@ -73,7 +73,7 @@ async def test_hook_toggle_off_then_on(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     _write_agent_hook(tmp_path, "myhook")
     reg.get_or_load("alice")
-    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None))
 
     s.set_hook_enabled("myhook", False)
     await s._hook_dispatcher.dispatch("turn_end", {})
@@ -91,7 +91,7 @@ async def test_per_session_hooks_yaml_is_a_4th_layer(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None))
 
     # write a per-session hook at this session's state dir, then re-build the registry
     per_session = Path(s._snapshot_path).parent / "hooks.yaml"
@@ -125,7 +125,7 @@ async def test_hook_slash_disables_via_public_state(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     _write_agent_hook(tmp_path, "myhook")
     reg.get_or_load("alice")
-    s = reg.get_session("alice", await reg.spawn_session_recorded("alice"))
+    s = reg.get_session("alice", await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None))
     s.is_attached = True
 
     await hook_cmd(s, "off myhook")

--- a/tests/test_mcp_list_tools_finally_close.py
+++ b/tests/test_mcp_list_tools_finally_close.py
@@ -44,7 +44,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 async def _session(tmp_path) -> Session:
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     sess = reg.get_session("alice", sid)
     # #2597 S2a: only an EPHEMERAL session still routes _mcp_list_tools through the
     # one-shot MCPClientPool this test exercises — a persistent session now holds its

--- a/tests/test_multi_session_restore.py
+++ b/tests/test_multi_session_restore.py
@@ -90,7 +90,7 @@ async def test_multi_session_restore_is_per_session_independent(tmp_path, monkey
     # ── pre-crash: open main + a spawned session, assign distinct state ──
     reg1 = _make_registry(tmp_path, wal)
     main1 = reg1.get_or_load("alpha")                 # the implicit "main" session
-    sid = reg1.spawn_session("alpha")                 # a second session under the same agent
+    sid = reg1.spawn_session("alpha", presentation_consumer=None, intervention_bridge=None)                 # a second session under the same agent
     spawned1 = reg1.get_session("alpha", sid)
     assert spawned1 is not None
 

--- a/tests/test_multisession_history_isolation_2348.py
+++ b/tests/test_multisession_history_isolation_2348.py
@@ -52,8 +52,8 @@ async def test_spawned_sessions_have_isolated_history(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    a = reg.get_session("alice", reg.spawn_session("alice"))
-    b = reg.get_session("alice", reg.spawn_session("alice"))
+    a = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
+    b = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
 
     assert a.history_path != b.history_path, "spawned sessions must have isolated history paths"
     a._append_history(ChatMessage(role="user", content="secret from A"))
@@ -71,7 +71,7 @@ async def test_spawned_events_isolated_and_forwarder_survives_rewire(tmp_path, m
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     main = reg.get_or_load("alice")
-    a = reg.get_session("alice", reg.spawn_session("alice"))
+    a = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
 
     assert a.events_dir != main.events_dir, "spawned session must have an isolated events dir"
 
@@ -97,8 +97,8 @@ async def test_crash_recovery_restores_each_session_own_history(tmp_path, monkey
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    a = reg.get_session("alice", reg.spawn_session("alice"))
-    b = reg.get_session("alice", reg.spawn_session("alice"))
+    a = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
+    b = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
     a._append_history(ChatMessage(role="user", content="A-only"))
     b._append_history(ChatMessage(role="user", content="B-only"))
 
@@ -125,8 +125,8 @@ async def test_rewind_reset_does_not_touch_other_sessions_transcript(tmp_path, m
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    a = reg.get_session("alice", reg.spawn_session("alice"))
-    b = reg.get_session("alice", reg.spawn_session("alice"))
+    a = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
+    b = reg.get_session("alice", reg.spawn_session("alice", presentation_consumer=None, intervention_bridge=None))
     a._append_history(ChatMessage(role="user", content="A-msg"))
     b._append_history(ChatMessage(role="user", content="B-msg"))
     b_before = b.history_path.read_text()

--- a/tests/test_pipeline_a2_spawn_ephemeral_session.py
+++ b/tests/test_pipeline_a2_spawn_ephemeral_session.py
@@ -26,8 +26,12 @@ from reyn.runtime.session_api import spawn_ephemeral_session
 def _registry(tmp_path: Path) -> AgentRegistry:
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
-    def _factory(profile) -> Session:
-        return Session(agent_name=profile.name, state_log=state_log)
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     reg.create("worker")
@@ -43,7 +47,7 @@ async def test_spawn_ephemeral_session_emits_config_complete_event(tmp_path: Pat
     event (entity_kind/name/sid/mode="ephemeral") — the identical event shape
     ``reg.spawn_session_recorded`` emits for the LLM tool path."""
     reg = _registry(tmp_path)
-    sid = await spawn_ephemeral_session(reg, identity="worker")
+    sid = await spawn_ephemeral_session(reg, identity="worker", presentation_consumer=None, intervention_bridge=None)
     ev = next(
         e for e in reg.state_log.iter_from(0)
         if e.get("kind") == "session_spawned" and e.get("sid") == sid
@@ -66,7 +70,7 @@ async def test_spawn_ephemeral_session_works_with_no_router_state(tmp_path: Path
     ToolContext is constructed anywhere in this test, and session_api.py imports
     neither at module scope (grep-checked below)."""
     reg = _registry(tmp_path)
-    sid = await spawn_ephemeral_session(reg, identity="worker")
+    sid = await spawn_ephemeral_session(reg, identity="worker", presentation_consumer=None, intervention_bridge=None)
     assert isinstance(sid, str) and sid
 
 
@@ -104,7 +108,7 @@ async def test_spawn_ephemeral_session_narrowing_applied(tmp_path: Path) -> None
     reg = _registry(tmp_path)
     sid = await spawn_ephemeral_session(
         reg, identity="worker", narrowing={"tool_deny": ["delete_file"]},
-    )
+    presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("worker", sid)
     effective = session._effective_contextual_for_turn()
     assert effective is not None, (
@@ -119,5 +123,5 @@ async def test_spawn_ephemeral_session_no_narrowing_is_inert(tmp_path: Path) -> 
     """Tier 2: no narrowing → the per-session capability layer stays inert
     (byte-identical to the no-narrowing tool-path case)."""
     reg = _registry(tmp_path)
-    sid = await spawn_ephemeral_session(reg, identity="worker")
+    sid = await spawn_ephemeral_session(reg, identity="worker", presentation_consumer=None, intervention_bridge=None)
     assert reg.resolved_profile_for("worker", sid=sid) == (None, frozenset())

--- a/tests/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/test_pipeline_driver_resource_caller_state_2567.py
@@ -170,8 +170,10 @@ def _worker_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     helper, extended with ``mcp_servers=``."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             mcp_servers={"servers": {"brave": {"command": "true"}}},

--- a/tests/test_pipeline_for_each_primitive.py
+++ b/tests/test_pipeline_for_each_primitive.py
@@ -586,8 +586,10 @@ class _ScriptedAgentReply:
 def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgentReply) -> AgentRegistry:
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -280,8 +280,10 @@ def _agent_registry(
 ) -> AgentRegistry:
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -288,7 +288,7 @@ async def test_notify_reply_true_driver_DOES_deliver_positive_control(
     scripted = _ScriptedAgentReply("ack")
     reg = _agent_registry(tmp_path, state_log, scripted)
 
-    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("worker", sid)
     pipeline = _steps(1)
     from reyn.core.pipeline.serde import pipeline_to_dict
@@ -383,7 +383,7 @@ async def test_driver_cancel_writes_terminal_marker_recovery_skips(
     out_file = tmp_path / "out.txt"
     reg = _agent_registry(tmp_path, state_log, None)
 
-    sid = await reg.spawn_session_recorded("worker", mode="persistent")
+    sid = await reg.spawn_session_recorded("worker", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("worker", sid)
     # Late-bind the driver so the step handler can close over it to request cancel.
     from reyn.core.pipeline.serde import pipeline_to_dict

--- a/tests/test_pipeline_parallel_primitive.py
+++ b/tests/test_pipeline_parallel_primitive.py
@@ -573,8 +573,10 @@ class _ScriptedAgentReply:
 def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgentReply) -> AgentRegistry:
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_r5_agent_step_executor.py
+++ b/tests/test_pipeline_r5_agent_step_executor.py
@@ -63,8 +63,10 @@ def _registry(
     real ``RouterLoopDriver`` via ``_loop_observer``, before the driver's first turn."""
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -80,10 +80,12 @@ def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRe
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
 
-    def _factory(profile) -> Session:
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (
@@ -204,7 +206,7 @@ async def test_agent_step_narrowing_denies_delegation_when_spawned(tmp_path: Pat
         ["delegate_to_agent", "run_pipeline", "file__read"]
     )
 
-    sid = await spawn_ephemeral_session(reg, identity="worker", narrowing=narrowing)
+    sid = await spawn_ephemeral_session(reg, identity="worker", narrowing=narrowing, presentation_consumer=None, intervention_bridge=None)
     contextual, _excluded = reg.resolved_profile_for("worker", sid=sid)
 
     assert contextual is not None

--- a/tests/test_registry_multi_session_1726.py
+++ b/tests/test_registry_multi_session_1726.py
@@ -59,7 +59,7 @@ def test_spawn_session_creates_distinct_session_sharing_agent(tmp_path) -> None:
     surface, so the test pins the public identity-equivalence contract.)"""
     reg = _registry(tmp_path)
     main = reg.get_or_load("default")
-    sid = reg.spawn_session("default")
+    sid = reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)
     spawned = reg.get_session("default", sid)
 
     assert sid != _DEFAULT_SID
@@ -77,7 +77,7 @@ def test_default_session_unaffected_by_spawn(tmp_path) -> None:
     one (get_or_load still returns the original "main" instance)."""
     reg = _registry(tmp_path)
     main = reg.get_or_load("default")
-    reg.spawn_session("default")
+    reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)
     assert reg.get_or_load("default") is main
     assert reg.get_session("default") is main
 
@@ -90,7 +90,7 @@ async def test_attach_session_focuses_existing_and_rejects_unknown(tmp_path) -> 
     handler + forwarder rely on). No build — the session must already exist."""
     reg = _registry(tmp_path)
     reg.get_or_load("default")
-    sid = reg.spawn_session("default")
+    sid = reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)
     try:
         focused = await reg.attach_session("default", sid)
         assert reg.attached_name == "default"
@@ -131,7 +131,7 @@ def test_agent_cost_usd_reads_durable_per_agent_total(tmp_path):
 
     reg = _registry(tmp_path, tracker=tracker)
     reg.get_or_load("default")
-    reg.spawn_session("default")  # a 2nd session — must NOT double the reported per-agent cost
+    reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)  # a 2nd session — must NOT double the reported per-agent cost
 
     assert reg.agent_cost_usd("default") == pytest.approx(0.15), (
         "durable per-agent total (all sessions, one counter) — not reset to 0, not N×-summed"
@@ -162,8 +162,8 @@ def test_agent_cost_usd_survives_restart_and_byte_aligns_no_ntimes(tmp_path):
 
     reg = _registry(tmp_path, tracker=restarted)
     reg.get_or_load("default")
-    reg.spawn_session("default")
-    reg.spawn_session("default")  # 3 sessions total — must not multiply the per-agent cost
+    reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)
+    reg.spawn_session("default", presentation_consumer=None, intervention_bridge=None)  # 3 sessions total — must not multiply the per-agent cost
 
     assert reg.agent_cost_usd("default") == pytest.approx(0.42), "survives restart (not 0), no N×"
     assert reg.agent_cost_usd("default") == restarted.agent_cost_usd("default"), (

--- a/tests/test_registry_session_tree.py
+++ b/tests/test_registry_session_tree.py
@@ -83,7 +83,7 @@ def test_session_tree_lists_spawned_sessions(tmp_path: Path) -> None:
     """Tier 2: a spawned session shows up alongside 'main' under the same agent."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("default")
-    sid = reg.spawn_session("default", "sub1")
+    sid = reg.spawn_session("default", "sub1", presentation_consumer=None, intervention_bridge=None)
 
     sids = {s["sid"] for s in reg.session_tree()[0]["sessions"]}
     assert {"main", sid} <= sids
@@ -93,8 +93,8 @@ def test_session_tree_sids_sorted(tmp_path: Path) -> None:
     """Tier 2: sessions within an agent are sorted by sid regardless of spawn order."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("default")
-    reg.spawn_session("default", "zz")
-    reg.spawn_session("default", "aa")
+    reg.spawn_session("default", "zz", presentation_consumer=None, intervention_bridge=None)
+    reg.spawn_session("default", "aa", presentation_consumer=None, intervention_bridge=None)
 
     sids = [s["sid"] for s in reg.session_tree()[0]["sessions"]]
     assert sids == sorted(sids)
@@ -105,7 +105,7 @@ def test_session_tree_all_false_when_nothing_attached(tmp_path: Path) -> None:
     the agent and session level."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("default")
-    reg.spawn_session("default", "sub1")
+    reg.spawn_session("default", "sub1", presentation_consumer=None, intervention_bridge=None)
     assert reg.attached_name is None           # public-surface precondition
 
     entry = reg.session_tree()[0]

--- a/tests/test_router_ctx_media_store_2409.py
+++ b/tests/test_router_ctx_media_store_2409.py
@@ -36,7 +36,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
 async def _session(tmp_path) -> Session:
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     return reg.get_session("alice", sid)
 
 

--- a/tests/test_session_vanished_emit_2154.py
+++ b/tests/test_session_vanished_emit_2154.py
@@ -63,7 +63,7 @@ async def test_genuine_ephemeral_vanish_emits_session_vanished(tmp_path):
     emitted defect."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)
 
     eph = reg._peek_session("alice", sid)
     eph._maybe_schedule_ephemeral_vanish()
@@ -84,7 +84,7 @@ async def test_reconstruction_drop_does_not_emit_session_vanished(tmp_path):
     corrupt as-of-cut reconstruction (the cause-separation, record=False)."""
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     assert sid not in _vanished_sids(reg.state_log, "alice")  # spawn alone: none
 
     await reg._drop_session("alice", sid)
@@ -101,7 +101,7 @@ async def test_session_vanished_before_cut_reconstructs_gone(tmp_path):
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
     log = reg.state_log
-    sid = await reg.spawn_session_recorded("alice", mode="ephemeral")  # spawn ≤ cut, live
+    sid = await reg.spawn_session_recorded("alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None)  # spawn ≤ cut, live
     assert sid in reg.session_ids("alice")                    # present (public surface)
     # the vanish was RECORDED but the session survives (teardown didn't finish).
     await log.append("session_vanished", entity_kind="session", name="alice", sid=sid)
@@ -126,7 +126,7 @@ async def test_session_vanished_after_cut_survives_reconstruction(tmp_path):
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
     log = reg.state_log
-    sid = await reg.spawn_session_recorded("alice", mode="persistent")
+    sid = await reg.spawn_session_recorded("alice", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     cut = log.current_seq                                          # cut = N (after spawn)
     await log.append("session_vanished", entity_kind="session",
                      name="alice", sid=sid)                        # V = cut+1 (abandoned)

--- a/tests/test_slash_budget_session_reload_cmds.py
+++ b/tests/test_slash_budget_session_reload_cmds.py
@@ -83,7 +83,9 @@ class _FakeRegistry:
         self._spawn_raises = spawn_raises
         self._get_session_result = get_session_result
 
-    def spawn_session(self, name: str) -> str:
+    def spawn_session(
+        self, name: str, *, presentation_consumer=None, intervention_bridge=None,
+    ) -> str:
         if self._spawn_raises is not None:
             raise self._spawn_raises
         return self._spawn_result  # type: ignore[return-value]

--- a/tests/test_slash_session_1726.py
+++ b/tests/test_slash_session_1726.py
@@ -31,7 +31,7 @@ class _StubRegistry:
     def attached_name(self):
         return self._attached_name
 
-    def spawn_session(self, name):
+    def spawn_session(self, name, *, presentation_consumer=None, intervention_bridge=None):
         sid = f"s{len(self._sids)}"
         self._sids.append(sid)
         self.spawned.append(name)

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -34,12 +34,14 @@ from reyn.runtime.presentation_consumer import (
     AuditOnlyPresentationSink,
 )
 from reyn.runtime.registry import AgentRegistry
-from reyn.runtime.session import Session
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import run_agent_step, start_pipeline_run
 from reyn.runtime.session_buses import (
     NO_SURFACE_REFUSAL_REASON,
     AuditOnlyInterventionBridge,
+    SpawnBridgeInterventionListener,
 )
+from reyn.user_intervention import UserIntervention
 
 
 def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRegistry, list]":
@@ -297,6 +299,61 @@ async def test_agent_step_worker_spawned_audit_only(tmp_path: Path) -> None:
         "run_agent_step did not spawn its ephemeral worker AuditOnly (#2706 root-cause-i) — its "
         "present would self-bind to an undrained outbox, dropped by the kind=='agent' filter."
     )
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()
+
+
+# ── co-vet must-fix: LLM session_spawn child bridges to the parent operator (no hang) ────
+
+
+@pytest.mark.asyncio
+async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(tmp_path: Path) -> None:
+    """Tier 2: co-vet must-fix — the LLM ``session_spawn`` tool's BACKGROUND child routes
+    ``BridgeToParent`` (not self-bound ReviewedNA), so its ``ask_user`` reaches the spawning
+    PARENT's live operator and RESOLVES — it does NOT hit the origin-pin park/hang a self-bound
+    child would (its "tui"-stamped iv on a listener-less own registry parks forever). RED before
+    fix (child ``intervention_bridge`` is None → ask_user parks on the child's own registry);
+    GREEN after (BridgeToParent → the parent operator resolves it)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+    parent = reg.get_or_load("worker")
+    # A live operator attached to the PARENT (the "tui" listener a mounted CUI registers).
+    parent.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+    host = parent._router_host
+    host._live_session_id_fn = lambda: "main"  # from_sid = the parent's real sid (resolvable)
+
+    result = await host.spawn_session(
+        request="help me", mode="persistent", narrowing=None, chain_id="c1",
+    )
+    assert result["status"] == "spawned"
+    child = reg.get_session("worker", result["sid"])
+    assert child is not None
+
+    # Routing proof: the child bridges its user-reaching capabilities to the PARENT (not self-bound).
+    assert isinstance(child.intervention_bridge, SpawnBridgeInterventionListener), (
+        "session_spawn's child was self-bound (ReviewedNA) — its ask_user would origin-pin-park; "
+        "it must route BridgeToParent so a delegated sub-agent's ask_user reaches the operator."
+    )
+    assert child.intervention_bridge.parent_session is parent
+
+    # Operator-reach proof: the child's ask_user (via its DECLARED bridge — the exact bus its router
+    # op builds) lands on the PARENT's live listener and resolves with the operator's answer — no hang.
+    bus = child.intervention_bridge.bus(run_id="r", actor="child")
+    iv = UserIntervention(kind="ask_user", prompt="which branch?")
+    deliver = asyncio.ensure_future(bus.deliver(iv))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not parent.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert parent.interventions.list_active(), (
+        "the child's ask_user never reached the parent operator's active queue (parked/hung)."
+    )
+    consumed = await parent._maybe_answer_oldest_intervention("blue")
+    assert consumed is True
+    answer = await asyncio.wait_for(deliver, timeout=5.0)  # resolves (no hang)
+    assert (answer.choice_id or answer.text) == "blue"
 
     for task in list(reg._tasks.values()):
         if not task.done():

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -358,3 +358,81 @@ async def test_session_spawn_child_ask_user_reaches_parent_operator_no_hang(tmp_
     for task in list(reg._tasks.values()):
         if not task.done():
             task.cancel()
+
+
+async def _spawn_from(
+    reg: "AgentRegistry", spawner: "Session", spawner_sid: str,
+) -> "tuple[Session, str]":
+    """Spawn a child session from ``spawner`` via the LLM session_spawn adapter path (so the child
+    gets the adapter's BridgeToParent routing), returning ``(child_session, child_sid)``."""
+    host = spawner._router_host
+    host._live_session_id_fn = lambda: spawner_sid
+    r = await host.spawn_session(request="x", mode="persistent", narrowing=None, chain_id="c")
+    child = reg.get_session("worker", r["sid"])
+    assert child is not None
+    return child, r["sid"]
+
+
+@pytest.mark.asyncio
+async def test_session_spawn_grandchild_ask_user_reaches_root_operator_transitively(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: co-vet recursive-edge closure — a GRANDCHILD (session_spawn from a HEADLESS spawned
+    child) routes its ask_user TRANSITIVELY to the first attached ancestor (the ROOT operator), NOT
+    the immediate headless parent's listener-less registry where it would origin-pin park. Proves
+    BridgeToParent is hang-safe at EVERY depth (session_spawn has no depth cap + a spawned child's
+    router loop re-exposes session_spawn → grandchildren are reachable). RED if the bridge dispatches
+    on the immediate parent's coordinator (the grandchild never reaches the root queue → hang)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, _built = _recording_registry(tmp_path, state_log)
+    root = reg.get_or_load("worker")
+    root.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)  # the human operator (attached root)
+
+    child, child_sid = await _spawn_from(reg, root, "main")  # headless spawned child (no listener)
+    assert not child.interventions.has_listener(DEFAULT_CHAT_CHANNEL_ID)
+    grandchild, _ = await _spawn_from(reg, child, child_sid)
+
+    # The grandchild's ask_user (via its declared bridge) must land on the ROOT operator's queue.
+    bus = grandchild.intervention_bridge.bus(run_id="r", actor="gc")
+    iv = UserIntervention(kind="ask_user", prompt="which branch?")
+    deliver = asyncio.ensure_future(bus.deliver(iv))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not root.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert root.interventions.list_active(), (
+        "the grandchild's ask_user did NOT reach the ROOT operator — it parked on the immediate "
+        "headless parent's listener-less registry (the recursive hang edge)."
+    )
+    answered = await root._maybe_answer_oldest_intervention("blue")
+    assert answered is True
+    answer = await asyncio.wait_for(deliver, timeout=5.0)  # resolves via root operator, no hang
+    assert (answer.choice_id or answer.text) == "blue"
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_fully_headless_spawn_chain_ask_user_refuses_not_hang(tmp_path: Path) -> None:
+    """Tier 2: co-vet recursive-edge terminal — a FULLY-headless spawn chain (no operator listener
+    anywhere in the ancestry) resolves ask_user with a typed refusal, NEVER an unbounded park. This
+    is the terminal that makes BridgeToParent hang-safe by construction even with no reachable
+    operator at the root."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, _built = _recording_registry(tmp_path, state_log)
+    root = reg.get_or_load("worker")  # NO listener registered — a headless root (cron/background)
+
+    child, child_sid = await _spawn_from(reg, root, "main")
+    grandchild, _ = await _spawn_from(reg, child, child_sid)
+
+    bus = grandchild.intervention_bridge.bus(run_id="r", actor="gc")
+    iv = UserIntervention(kind="ask_user", prompt="which branch?")
+    answer = await asyncio.wait_for(bus.deliver(iv), timeout=3.0)  # MUST NOT hang
+    assert answer.refused is True
+    assert answer.reason == NO_SURFACE_REFUSAL_REASON
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -1,0 +1,303 @@
+"""#2708 P3-item3 — the DELIBERATE detached/headless fail-mode (no orphan present, no ask hang).
+
+The spawn-axis completeness gate turns the pre-fix INCIDENTAL detached fail-modes into a
+reviewed, deliberate ``AuditOnlyNoSurface`` decision:
+
+  * detached ``present`` (#2710) — no longer orphans a ``"presentation"`` message on the driver's
+    own undrained outbox; the render is audit-only (the durable ``presented`` P6 event fires).
+  * detached ``ask_user`` — no longer HANGS. Step-1 primary-data resolution: the self-bound
+    ``ChatInterventionBus`` stamps ``origin_channel_id="tui"`` and
+    ``InterventionCoordinator.dispatch`` parks it stalled + ``await iv.future`` forever (verified:
+    a detached ask_user pipeline never reached terminal in >6s). ``AuditOnlyInterventionBridge``
+    resolves it IMMEDIATELY with a typed, reason'd refusal — terminal in well under a second.
+  * agent-step ``present`` (#2706) — the ephemeral leaf worker is spawned AuditOnly, so its
+    present is audit-only, not silently self-bound then dropped by the ``kind=="agent"`` filter.
+
+Real ``AgentRegistry`` / ``Session`` / ``StateLog`` / ``PipelineExecutor`` / present + ask_user
+ops + intervention machinery — no collaborator mocks. Asserts on public surfaces (outbox,
+EventLog, the typed ``InterventionAnswer`` / ask_user ack, the session's public routing
+accessors), never Rich formatting.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.config_recovery import reyn_root
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import Pipeline, ToolStep
+from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.runtime.presentation_consumer import (
+    AuditOnlyPresentationConsumer,
+    AuditOnlyPresentationSink,
+)
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import run_agent_step, start_pipeline_run
+from reyn.runtime.session_buses import (
+    NO_SURFACE_REFUSAL_REASON,
+    AuditOnlyInterventionBridge,
+)
+
+
+def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRegistry, list]":
+    """Real AgentRegistry whose factory RECORDS every Session it builds — so a test can inspect a
+    spawned driver/worker session's public routing even after the ephemeral session vanishes from
+    the registry map (the Python ref + its in-memory EventLog survive)."""
+    built: list[Session] = []
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            non_interactive=True, presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+        built.append(s)
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg, built
+
+
+def _drain(queue: "asyncio.Queue") -> list:
+    out: list = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+def _by_kind(msgs: list, kind: str) -> list:
+    return [m for m in msgs if getattr(m, "kind", None) == kind]
+
+
+# ── Unit: the AuditOnly routing primitives ──────────────────────────────────────────────
+
+
+def test_audit_only_presentation_consumer_sink_is_noop() -> None:
+    """Tier 2: AuditOnlyPresentationConsumer yields an AuditOnlyPresentationSink — a no-op visible
+    draw (the durable audit trail is the upstream ``presented`` event), never an orphan outbox sink."""
+    sink = AuditOnlyPresentationConsumer().sink(object())
+    assert isinstance(sink, AuditOnlyPresentationSink)
+    # The sink's surface is the REGISTERED "null" no-op neutralizer — robust across all present
+    # blueprint shapes (an "none"-surface sink fails the fail-closed guard for a text-leaf blueprint).
+    assert sink.surface_name == "null"
+    sink.render(object())  # no-op, must not raise (fire-and-continue)
+
+
+@pytest.mark.asyncio
+async def test_present_op_via_audit_only_sink_fires_audit_event_and_no_orphan() -> None:
+    """Tier 1: present-op contract through the AuditOnly sink — the ``presented`` P6 audit event
+    STILL fires (the render is durable / replay-visible, not lost) and the visible draw is a
+    documented no-op (no orphan outbox message). This is the audit-only-not-lost guarantee the
+    detached/agent-step routing relies on, pinned at the op layer (deterministic, no LLM)."""
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.core.op_runtime.present import handle
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.schemas.models import PresentIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    sink = AuditOnlyPresentationConsumer().sink(object())
+    ctx = OpContext(
+        workspace=Workspace(events=events), events=events, permission_decl=PermissionDecl(),
+        presentation_renderer=sink,
+    )
+    op = PresentIROp(
+        kind="present", data_inline={"v": "AUDITONLYMARK"},
+        blueprint={"component": "text", "text": {"$bind": "/v"}},
+    )
+    result = await handle(op, ctx)
+    assert result["ok"] is True  # present succeeded (not errored/lost)
+    presented = [e for e in events.all() if e.type == "presented"]
+    assert presented, "the AuditOnly present did NOT emit a 'presented' audit event — trail lost"
+    # The sink's own surface is the null/no-op surface — the visible draw reached no orphan queue.
+    assert presented[0].data.get("surface") == [sink.surface_name]
+
+
+@pytest.mark.asyncio
+async def test_audit_only_intervention_bridge_refuses_with_reason_immediately() -> None:
+    """Tier 2: AuditOnlyInterventionBridge.bus().deliver returns a TYPED, reason'd refusal
+    IMMEDIATELY (refused=True) — never enqueues/awaits (no park/hang), never a silent empty."""
+    from reyn.user_intervention import UserIntervention
+
+    bus = AuditOnlyInterventionBridge().bus(run_id="r", actor="a")
+    iv = UserIntervention(kind="ask_user", prompt="which?")
+    answer = await asyncio.wait_for(bus.deliver(iv), timeout=2.0)
+    assert answer.refused is True
+    assert answer.reason == NO_SURFACE_REFUSAL_REASON
+    assert answer.text == ""
+
+
+@pytest.mark.asyncio
+async def test_ask_user_op_via_audit_only_bridge_returns_typed_refusal() -> None:
+    """Tier 1: ask_user-op contract through the AuditOnly bridge — the op returns a TYPED refusal
+    (``status="refused"`` carrying the reason), NOT a fabricated empty ``status="ok"`` answer, and
+    emits a ``user_intervention_received`` event with ``refused=True``. Deterministic (no LLM), and
+    completes immediately (no park/hang)."""
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime.ask_user import handle
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.schemas.models import AskUserIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    ctx = OpContext(
+        workspace=Workspace(events=events), events=events, permission_decl=PermissionDecl(),
+        intervention_bus=AuditOnlyInterventionBridge().bus(),
+    )
+    op = AskUserIROp(kind="ask_user", question="which branch?", required=True)
+    result = await asyncio.wait_for(handle(op, ctx), timeout=2.0)
+    assert result["status"] == "refused", "ask_user did not surface the typed refusal"
+    assert result["reason"] == NO_SURFACE_REFUSAL_REASON
+    assert result["answer"] == ""  # never a fabricated non-empty answer
+    received = [e for e in events.all() if e.type == "user_intervention_received"]
+    assert any(e.data.get("refused") is True for e in received), (
+        "the refusal was not recorded as refused=True — it looked like a normal empty answer"
+    )
+
+
+# ── #2710: detached present is audit-only (no orphan) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detached_present_is_audit_only_no_orphan_outbox(tmp_path: Path) -> None:
+    """Tier 2: a DETACHED pipeline's ``present`` no longer orphans a ``"presentation"`` message on
+    the driver's own undrained outbox (the pre-fix #2710 silent-loss); it is audit-only — the
+    driver's ``presented`` P6 event still fires (audit trail preserved), zero outbox presentation."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    rid = await start_pipeline_run(
+        reg, pipeline=Pipeline(steps=[
+            ToolStep(name="present", args={"data_inline": {"label": "AUDITONLYMARK"}}, output="a"),
+        ]),
+        pipeline_name="shows", input=None,
+        reply_to_agent="worker", reply_to_sid="main", state_log=state_log,
+    )
+    run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
+    deadline = asyncio.get_event_loop().time() + 10.0
+    while asyncio.get_event_loop().time() < deadline:
+        if read_result(run_dir) is not None:
+            break
+        await asyncio.sleep(0.05)
+    assert read_result(run_dir) is not None, "detached present pipeline did not reach terminal"
+
+    # The detached driver was spawned AuditOnly (its present sink is the no-op) — identify it as
+    # the built session carrying that routing decision. RED if the detached spawn self-bound
+    # instead (#2710 orphan class): no AuditOnly-routed session would exist.
+    audit_drivers = [
+        s for s in built if isinstance(s.presentation_consumer, AuditOnlyPresentationConsumer)
+    ]
+    assert audit_drivers, (
+        "no AuditOnly-routed driver was built — the detached spawn did not route AuditOnly "
+        "(its present would self-bind to an undrained outbox, the #2710 orphan class)."
+    )
+    driver = audit_drivers[-1]
+    assert read_result(run_dir).get("status") == "ok", "detached present pipeline did not succeed"
+    assert _by_kind(_drain(driver.outbox), "presentation") == [], (
+        "the detached driver orphaned a presentation on its own outbox (the #2710 silent-loss) — "
+        "AuditOnly makes present a no-op visible draw (the audit trail is the upstream "
+        "'presented' event; see test_present_op_via_audit_only_sink_fires_audit_event_and_no_orphan)."
+    )
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()
+
+
+# ── detached ask_user: deliberate typed refusal, NO hang ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detached_ask_user_refuses_deliberately_no_hang(tmp_path: Path) -> None:
+    """Tier 2: step-1 resolution pinned. A DETACHED pipeline's ``ask_user`` now RESOLVES (terminal
+    reached quickly — NOT the pre-fix origin-pin park/hang that never reached terminal in >6s) via
+    a DELIBERATE typed refusal: the driver's ``user_intervention_received`` event carries
+    ``refused=True`` + the reason, not a fabricated empty auto-refuse."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    rid = await start_pipeline_run(
+        reg, pipeline=Pipeline(steps=[
+            ToolStep(name="ask_user", args={"question": "which branch?", "required": True}, output="a"),
+        ]),
+        pipeline_name="asks", input=None,
+        reply_to_agent="worker", reply_to_sid="main", state_log=state_log,
+    )
+    run_dir = pipeline_run_dir(reyn_root(state_log.path), rid)
+
+    # NO HANG: terminal within a tight window (the pre-fix hang never reached it in >6s).
+    deadline = asyncio.get_event_loop().time() + 5.0
+    while asyncio.get_event_loop().time() < deadline:
+        if read_result(run_dir) is not None:
+            break
+        await asyncio.sleep(0.02)
+    assert read_result(run_dir) is not None, (
+        "detached ask_user did NOT reach terminal within 5s — the origin-pin park/hang was not "
+        "closed by the AuditOnly refusal."
+    )
+
+    # The driver was spawned AuditOnly (the routing that turns the pre-fix hang into a deliberate
+    # refusal) — identify it as the built session carrying an AuditOnly intervention bridge. The
+    # refusal SEMANTICS (status="refused" + reason, not silent-empty) are pinned deterministically
+    # at the op layer in test_ask_user_op_via_audit_only_bridge_returns_typed_refusal.
+    audit_drivers = [
+        s for s in built if isinstance(s.intervention_bridge, AuditOnlyInterventionBridge)
+    ]
+    assert audit_drivers, (
+        "no AuditOnly-routed driver was built — the detached ask_user would origin-pin-park/hang."
+    )
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()
+
+
+# ── #2706: agent-step worker is spawned AuditOnly ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_step_worker_spawned_audit_only(tmp_path: Path) -> None:
+    """Tier 2: #2706 root-cause-i — ``run_agent_step`` spawns its ephemeral leaf worker with an
+    AuditOnly routing (present audit-only, ask_user typed-refusal), NOT the pre-fix self-bound
+    consumer that orphaned a present onto the worker's own outbox for the ``kind=="agent"`` filter
+    to silently drop. Pinned on the worker's PUBLIC routing accessors."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    # The worker's one router turn has no live LLM here (returns empty agent text); the spawn +
+    # its declared routing is what #2706 root-cause-i fixes — captured via the recording factory.
+    try:
+        await asyncio.wait_for(
+            run_agent_step(reg, identity="worker", prompt="do a thing", timeout=5.0),
+            timeout=20.0,
+        )
+    except Exception:
+        # A router/LLM failure in the worker turn is irrelevant to this test's claim (the spawn's
+        # DECLARED routing) — the worker Session was already built + recorded before the turn ran.
+        pass
+
+    # The ephemeral worker was spawned AuditOnly (#2706 root-cause-i) — identify it as the built
+    # session carrying that routing. RED if run_agent_step self-bound the worker instead (its
+    # present would orphan on an undrained outbox and be dropped by the kind=='agent' filter).
+    audit_workers = [
+        s for s in built
+        if isinstance(s.presentation_consumer, AuditOnlyPresentationConsumer)
+        and isinstance(s.intervention_bridge, AuditOnlyInterventionBridge)
+    ]
+    assert audit_workers, (
+        "run_agent_step did not spawn its ephemeral worker AuditOnly (#2706 root-cause-i) — its "
+        "present would self-bind to an undrained outbox, dropped by the kind=='agent' filter."
+    )
+
+    for task in list(reg._tasks.values()):
+        if not task.done():
+            task.cancel()

--- a/tests/test_spawn_routing_gate_2708.py
+++ b/tests/test_spawn_routing_gate_2708.py
@@ -145,14 +145,15 @@ def test_all_three_spawn_seams_require_routing_kwargs_no_default() -> None:
 
 def test_reviewed_self_bound_spawn_sites_is_the_reviewed_frozenset() -> None:
     """Tier 2: the reviewed self-bound spawn sites are EXACTLY the reviewed set (transport-native
-    reuse, two crash-recovery re-wakes, /session new, LLM session_spawn). A new self-bound spawn
-    site must be added here deliberately — the equality ratchet blocks a silent self-bind."""
+    reuse, two crash-recovery re-wakes, /session new). A new self-bound spawn site must be added
+    here deliberately — the equality ratchet blocks a silent self-bind. The LLM ``session_spawn``
+    tool is deliberately NOT a member (co-vet must-fix): it is LLM-initiated + backgrounded, so a
+    self-bound child would hit the origin-pin ask_user hang — it routes ``BridgeToParent`` instead."""
     assert _REVIEWED_SELF_BOUND_SPAWN_SITES == frozenset({
         "runtime/registry.py::resolve_session",
         "runtime/registry.py::restore_all",
         "runtime/registry.py::_rewake_pipeline_runs",
         "interfaces/slash/session.py::session_cmd",
-        "runtime/services/router_host_adapter.py::spawn_session",
     })
 
 
@@ -163,6 +164,10 @@ def test_reviewed_na_refuses_non_reviewed_site() -> None:
         ReviewedNA("runtime/session_api.py::run_agent_step")
     with pytest.raises(ValueError):
         ReviewedNA("some/new/site.py::brand_new_spawn")
+    # The LLM session_spawn tool is NOT reviewed-self-bound (co-vet must-fix: it routes
+    # BridgeToParent, not ReviewedNA) — constructing ReviewedNA for it must be refused.
+    with pytest.raises(ValueError):
+        ReviewedNA("runtime/services/router_host_adapter.py::spawn_session")
 
 
 def test_reviewed_na_yields_self_bound_pair_for_reviewed_site() -> None:

--- a/tests/test_spawn_routing_gate_2708.py
+++ b/tests/test_spawn_routing_gate_2708.py
@@ -1,0 +1,175 @@
+"""Tier 2: OS invariant — #2708 P3-item3 spawn-axis user-reaching completeness gate.
+
+The construction-axis gate (#1402 / #2708 P1) made a Session un-buildable without a declared
+present sink. This is the SAME three mechanisms generalized to the SPAWN axis, so a spawn whose
+child reaches the user (``present`` / ``ask_user``) cannot silently fail to route to the parent:
+
+1. **Required-kwarg forcing** — ``presentation_consumer`` + ``intervention_bridge`` are REQUIRED,
+   no-default keyword-only params of the three spawn seams (``AgentRegistry.spawn_session`` /
+   ``.spawn_session_recorded`` / ``session_api.spawn_ephemeral_session``). Pinned by
+   ``inspect.signature`` (the #1402 ``_REQUIRED_SCOPED`` mechanism) — a default re-opens
+   silent-omission drift.
+2. **AST guard** — every ``src/reyn`` call to a spawn seam passes BOTH routing kwargs
+   explicitly, and never a bare literal ``None`` (which would bypass the ``ReviewedNA`` ratchet).
+   A new spawn site that omits the decision is a PR-time CI failure, naming file:line — the same
+   orphan-impossible-by-construction model as ``test_present_sink_ast_guard_2708``.
+3. **NA-ratchet** — ``_REVIEWED_SELF_BOUND_SPAWN_SITES`` is the reviewed frozenset of sites where
+   self-binding to the factory default (``None``/``None``) is genuinely correct; ``ReviewedNA``
+   refuses any other site, so a new spawn site cannot silently join the self-bound set (the
+   FP-0056 admin-6 equality model, spawn axis).
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+from pathlib import Path
+
+import pytest
+
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session_api import spawn_ephemeral_session
+from reyn.runtime.spawn_routing import (
+    _REVIEWED_SELF_BOUND_SPAWN_SITES,
+    ReviewedNA,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+# The three spawn seams whose calls must declare a routing decision. ``spawn_session_recorded`` /
+# ``spawn_ephemeral_session`` are unambiguous names; ``spawn_session`` collides with
+# ``RouterHostAdapter.spawn_session`` (a forwarding method reached as ``self.host.spawn_session``),
+# excluded below.
+_SEAM_NAMES = frozenset({
+    "spawn_session", "spawn_session_recorded", "spawn_ephemeral_session",
+})
+_REQUIRED_ROUTING_KWARGS = ("presentation_consumer", "intervention_bridge")
+
+
+def _is_host_adapter_spawn_session(func: ast.AST) -> bool:
+    """True for ``<x>.host.spawn_session`` — the RouterHostAdapter forwarding method (NOT a
+    registry spawn seam), which has no routing kwargs and forwards to ``spawn_session_recorded``
+    (itself guarded). Excluded so the guard does not false-positive on it."""
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == "spawn_session"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "host"
+    )
+
+
+def _spawn_seam_calls() -> list[tuple[str, ast.Call]]:
+    """Every ``src/reyn`` Call to one of the three spawn seams (host-adapter forward excluded)."""
+    out: list[tuple[str, ast.Call]] = []
+    for py in sorted(_SRC.rglob("*.py")):
+        rel = str(py.relative_to(_SRC))
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute)
+                else None
+            )
+            if name not in _SEAM_NAMES:
+                continue
+            if _is_host_adapter_spawn_session(func):
+                continue
+            out.append((f"{rel}:{node.lineno}", node))
+    return out
+
+
+def test_spawn_seam_calls_declare_both_routing_kwargs() -> None:
+    """Tier 2: every spawn-seam call in src/reyn passes BOTH presentation_consumer= and
+    intervention_bridge= explicitly (completeness-by-construction). A new spawn site that omits
+    the routing decision fails here, naming file:line — the orphan/hang-impossible guard."""
+    calls = _spawn_seam_calls()
+    assert calls, "no spawn-seam calls found in src/reyn — the guard's target moved?"
+    offenders: list[str] = []
+    for loc, call in calls:
+        passed = {k.arg for k in call.keywords if k.arg is not None}
+        # A ``**kwargs`` splat (k.arg is None) forwards everything — treat as compliant.
+        has_splat = any(k.arg is None for k in call.keywords)
+        missing = [k for k in _REQUIRED_ROUTING_KWARGS if k not in passed]
+        if missing and not has_splat:
+            offenders.append(f"{loc} (missing {missing})")
+    assert not offenders, (
+        "spawn-seam call(s) omit a required routing kwarg — a child's present/ask_user would "
+        "silently self-bind (orphan outbox / origin-pin hang). Declare a runtime/spawn_routing "
+        f"decision (BridgeToParent / SelfDeliveringWithDrain / AuditOnlyNoSurface / ReviewedNA): "
+        f"{offenders}"
+    )
+
+
+def test_spawn_seam_calls_never_pass_bare_literal_none() -> None:
+    """Tier 2: no spawn-seam call passes a bare literal ``None`` for a routing kwarg — self-binding
+    must go through ``ReviewedNA(site)`` (whose ratchet validates the site), never a raw None that
+    dodges the reviewed frozenset. Forwarded variables / routing-decision attributes are fine."""
+    offenders: list[str] = []
+    for loc, call in _spawn_seam_calls():
+        for kw in call.keywords:
+            if kw.arg in _REQUIRED_ROUTING_KWARGS and (
+                isinstance(kw.value, ast.Constant) and kw.value.value is None
+            ):
+                offenders.append(f"{loc} ({kw.arg}=None)")
+    assert not offenders, (
+        "spawn-seam call(s) pass a bare literal None routing kwarg — this bypasses the ReviewedNA "
+        "ratchet. Use ReviewedNA(<reviewed-site>).presentation_consumer / .intervention_bridge (or a "
+        f"real routing decision) so a new self-bound site can't silently join the reviewed set: {offenders}"
+    )
+
+
+def test_all_three_spawn_seams_require_routing_kwargs_no_default() -> None:
+    """Tier 2: the #1402 mechanism on the spawn axis — presentation_consumer + intervention_bridge
+    are REQUIRED, keyword-only, no-default on all three spawn seams. A default re-opens
+    silent-omission drift (a spawn site could omit the decision)."""
+    seams = [
+        AgentRegistry.spawn_session,
+        AgentRegistry.spawn_session_recorded,
+        spawn_ephemeral_session,
+    ]
+    for fn in seams:
+        sig = inspect.signature(fn)
+        for pname in _REQUIRED_ROUTING_KWARGS:
+            assert pname in sig.parameters, f"{fn.__qualname__} missing {pname}"
+            p = sig.parameters[pname]
+            assert p.kind is inspect.Parameter.KEYWORD_ONLY, (
+                f"{fn.__qualname__}.{pname} must be keyword-only"
+            )
+            assert p.default is inspect.Parameter.empty, (
+                f"{fn.__qualname__}.{pname} must be REQUIRED (no default) — a default re-opens "
+                "silent-omission drift (#2708 P3-item3 completeness-by-construction)"
+            )
+
+
+def test_reviewed_self_bound_spawn_sites_is_the_reviewed_frozenset() -> None:
+    """Tier 2: the reviewed self-bound spawn sites are EXACTLY the reviewed set (transport-native
+    reuse, two crash-recovery re-wakes, /session new, LLM session_spawn). A new self-bound spawn
+    site must be added here deliberately — the equality ratchet blocks a silent self-bind."""
+    assert _REVIEWED_SELF_BOUND_SPAWN_SITES == frozenset({
+        "runtime/registry.py::resolve_session",
+        "runtime/registry.py::restore_all",
+        "runtime/registry.py::_rewake_pipeline_runs",
+        "interfaces/slash/session.py::session_cmd",
+        "runtime/services/router_host_adapter.py::spawn_session",
+    })
+
+
+def test_reviewed_na_refuses_non_reviewed_site() -> None:
+    """Tier 2: ReviewedNA is refused for a spawn site NOT in the reviewed frozenset (a new site
+    trying to self-bind without review) — the spawn-axis NA-ratchet."""
+    with pytest.raises(ValueError):
+        ReviewedNA("runtime/session_api.py::run_agent_step")
+    with pytest.raises(ValueError):
+        ReviewedNA("some/new/site.py::brand_new_spawn")
+
+
+def test_reviewed_na_yields_self_bound_pair_for_reviewed_site() -> None:
+    """Tier 2: each reviewed site constructs a ReviewedNA whose resolved routing is the self-bound
+    (None/None) pair — the factory default, genuinely correct for that reviewed site."""
+    for site in _REVIEWED_SELF_BOUND_SPAWN_SITES:
+        routing = ReviewedNA(site)
+        assert routing.site == site
+        assert routing.presentation_consumer is None
+        assert routing.intervention_bridge is None

--- a/tests/test_spawn_routing_gate_2708.py
+++ b/tests/test_spawn_routing_gate_2708.py
@@ -97,7 +97,7 @@ def test_spawn_seam_calls_declare_both_routing_kwargs() -> None:
     assert not offenders, (
         "spawn-seam call(s) omit a required routing kwarg — a child's present/ask_user would "
         "silently self-bind (orphan outbox / origin-pin hang). Declare a runtime/spawn_routing "
-        f"decision (BridgeToParent / SelfDeliveringWithDrain / AuditOnlyNoSurface / ReviewedNA): "
+        f"decision (BridgeToParent / AuditOnlyNoSurface / ReviewedNA): "
         f"{offenders}"
     )
 

--- a/tests/test_visibility_persist_2285.py
+++ b/tests/test_visibility_persist_2285.py
@@ -63,7 +63,7 @@ def _reload_spawned(tmp_path: Path, sid: str) -> Session:
     floor + visibility.yaml override both persist on disk, so the reload re-derives them."""
     reg2 = _make_registry(tmp_path)
     reg2.get_or_load("alice")
-    reg2.spawn_session("alice", sid=sid)
+    reg2.spawn_session("alice", sid=sid, presentation_consumer=None, intervention_bridge=None)
     return reg2.get_session("alice", sid)
 
 
@@ -77,7 +77,7 @@ async def test_persisted_override_cannot_rewiden_spawner_floor_after_reload(tmp_
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]}, presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     assert _allows_tool(session, "delete_file") is False  # spawner floor denies it
 
@@ -103,7 +103,7 @@ async def test_visibility_override_round_trips_across_reload(tmp_path, monkeypat
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")  # no narrowing → envelope allows all tools
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)  # no narrowing → envelope allows all tools
     session = reg.get_session("alice", sid)
     assert _allows_tool(session, "read_file") is True
 
@@ -123,7 +123,7 @@ async def test_hidden_set_round_trips_exact_value(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     session.set_capability_visible("tool", "read_file", False)
     session.set_capability_visible("tool", "ask_user", False)
@@ -148,7 +148,7 @@ async def test_hook_disabled_set_survives_reload(tmp_path, monkeypatch):
     reg = _make_registry(tmp_path)
     _write_agent_hook(tmp_path, "myhook")  # shared per-agent hook (built into every session registry)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     assert any(h["name"] == "myhook" and h["enabled"] for h in session.hook_state())
 
@@ -167,7 +167,7 @@ async def test_clearing_override_removes_persisted_store(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     session.set_capability_visible("tool", "read_file", False)
     session.set_capability_visible("tool", "read_file", True)  # back to default → store pruned

--- a/tests/test_visibility_slash_2285.py
+++ b/tests/test_visibility_slash_2285.py
@@ -41,7 +41,7 @@ def _allows(session: Session, name: str) -> bool:
 async def _session(tmp_path) -> Session:
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     session.is_attached = True
     return session

--- a/tests/test_visibility_toggle_2285.py
+++ b/tests/test_visibility_toggle_2285.py
@@ -48,7 +48,7 @@ async def test_toggle_on_cannot_revive_envelope_denied_tool(tmp_path, monkeypatc
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]}, presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
 
     assert _allows_tool(session, "delete_file") is False  # envelope denies it
@@ -66,7 +66,7 @@ async def test_toggle_hides_then_restores_within_envelope(tmp_path, monkeypatch)
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice")  # no narrowing → envelope allows all tools
+    sid = await reg.spawn_session_recorded("alice", presentation_consumer=None, intervention_bridge=None)  # no narrowing → envelope allows all tools
     session = reg.get_session("alice", sid)
     assert _allows_tool(session, "delete_file") is True  # allowed by the envelope
 
@@ -84,7 +84,7 @@ async def test_visibility_state_reflects_envelope_and_override(tmp_path, monkeyp
     monkeypatch.chdir(tmp_path)
     reg = _make_registry(tmp_path)
     reg.get_or_load("alice")
-    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]})
+    sid = await reg.spawn_session_recorded("alice", narrowing={"tool_deny": ["delete_file"]}, presentation_consumer=None, intervention_bridge=None)
     session = reg.get_session("alice", sid)
     session.set_capability_visible("tool", "ask_user", False)
 


### PR DESCRIPTION
**[per-PR-coder]** — #2708 P3-item3: the spawn-axis user-reaching **completeness gate**.

`part of #2708`. `Closes #2710` `Closes #2706`.

Generalizes the landed construction-axis gate (#1402 required-kwarg pin + #2708-P1 AST guard + NA-ratchet) to the **spawn axis**, so a spawn whose child reaches the user (`present` / `ask_user`) can no longer silently fail to route — a new gap is now **compile/CI-impossible**. Subsumes #2710 (detached present), #2706 (agent-step present), and the disputed detached-`ask_user` fail-mode.

## Step-1 empirical resolution (the disputed fail-mode): **HANG**, not auto-refuse
Primary data (probe, real registry/pipeline, no mocks): a detached `ask_user` pipeline **never reached terminal in >6s** — it parks forever. Mechanism confirmed by source-trace: the detached driver's self-bound `ChatInterventionBus` stamps `origin_channel_id="tui"`; `InterventionCoordinator.dispatch` sees no `"tui"` listener → `park_stalled(iv)` + `await iv.future` (never resolved). The `enforce_listener_presence` short-circuit is **bypassed** — the coordinator's origin-pin stall branch returns before `registry.dispatch`'s enforce check. So the source-trace ("auto-refuse") and the coder observation ("hang") were both partially right: the enforce short-circuit is real but unreachable on this construction. After the fix the same pipeline reaches terminal in **0.05s**.

## The 8 spawn call sites + declared routing (enumerated from source, not a marker subset)
Direct callers of the 3 seams (`spawn_session` ×5, `spawn_session_recorded` ×3, `spawn_ephemeral_session` ×1):

| # | site | routing decision |
|---|------|------------------|
| 1 | `session_api._spawn_pipeline_driver_session` | `BridgeToParent` (attached) / **`AuditOnlyNoSurface`** (detached — #2710) |
| 2 | `session_api.run_agent_step` → `spawn_ephemeral_session` | **`AuditOnlyNoSurface`** (#2706) |
| 3 | `router_host_adapter.spawn_session` (LLM `session_spawn`) | **`BridgeToParent`** (delegated-work-can-ask — reaches the spawner's operator; co-vet must-fix) |
| 4 | `registry.resolve_session` (transport reuse) | `ReviewedNA` (inherits frontend default consumer) |
| 5 | `registry.restore_all` (crash-recovery) | `ReviewedNA` |
| 6 | `registry._rewake_pipeline_runs` (pipeline crash-recovery) | `ReviewedNA` |
| 7 | `interfaces/slash/session.session_cmd` (`/session new`) | `ReviewedNA` |
| 8 | `registry.spawn_session_recorded` → `spawn_session` / `spawn_ephemeral_session` → `spawn_session_recorded` | **forward** the caller's decision (variables) |

The gate is **atomic**: the two kwargs are required no-default on all 3 seams, so CI breaks unless every site declares — all declare in this PR.

## The three enforcement mechanisms (spawn axis)
1. **Required-kwarg forcing** — `presentation_consumer` + `intervention_bridge` are required, keyword-only, no-default on `spawn_session` / `spawn_session_recorded` / `spawn_ephemeral_session` (`spawn_ephemeral_session` gains them — #2706 root-cause-i). Pinned by `inspect.signature`.
2. **Typed routing decision** — new `runtime/spawn_routing.py`: `BridgeToParent` / `AuditOnlyNoSurface` / `ReviewedNA(site)`.
3. **AST guard** (`test_spawn_routing_gate_2708.py`) — every `src/reyn` spawn-seam call passes both kwargs explicitly and never a bare literal `None` (which would dodge the ratchet). Falsified: injecting a bare `spawn_session('x')` → RED naming file:line → restored → GREEN.
4. **NA-ratchet** — `_REVIEWED_SELF_BOUND_SPAWN_SITES` frozenset of **4** sites (equality-pinned); `ReviewedNA(site)` refuses a non-member, so a new self-bound site can't silently join.

## Co-vet revisions (architect flow-trace)
- **MUST-FIX**: `session_spawn` was `ReviewedNA` (self-bound) — but it's LLM-initiated + backgrounded, so no operator is guaranteed to know the child sid to attach+drain; a self-bound child hits the very origin-pin `ask_user` hang this PR closes. Changed to **`BridgeToParent`** (the spawner is a live session whose declared routing already decides where user-reaching capabilities go — a delegated sub-agent's `ask_user` reaches the parent operator, "delegated-work-can-ask"; parent unresolvable → `AuditOnlyNoSurface` fallback, never a hang). Frozenset 5→4. New RED test `test_session_spawn_child_ask_user_reaches_parent_operator_no_hang` (cp-falsify: self-bound → RED, BridgeToParent → GREEN).
- **SOFT cleanup**: inspected `resolve_session` — it inherits the frontend default consumer (the "drains own outbox" comment is the web thread draining `kind=agent`, not a self-delivering present consumer at the spawn seam) → confirmed `ReviewedNA`. Removed the unused speculative `SelfDeliveringWithDrain` type (no caller/test; true self-delivering lives at the P1 construction gate, no home at the spawn seam) — no-debt.
- **RECURSIVE-EDGE closure** (re-vet, verified not assumed): `session_spawn` has no depth cap, a spawned child's router loop re-exposes `session_spawn`, and a headless child is a listener-less parent — so a **grandchild** bridging to it would origin-pin park (BridgeToParent alone didn't close the hang at depth ≥ 2). Fix: `SpawnBridgeInterventionListener.bus()` now resolves **compositionally** toward the parent's *declared* routing — a bridged parent → recurse (transitive to the first attached ancestor / root operator); a root with a live listener → deliver there; a fully-headless chain → typed refusal, never a park. **Hang-safe by construction at every depth.** Two RED tests (grandchild reaches root operator; fully-headless → refusal), cp-falsified RED→GREEN.

## The deliberate detached fail-mode (`AuditOnlyNoSurface`)
- `present` → `AuditOnlyPresentationConsumer` → `AuditOnlyPresentationSink` (surface `"null"`, the **registered** no-op neutralizer — deliberately not `NullPresentationSink`'s unregistered `"none"`, which fails the fail-closed guard for a text-leaf blueprint). The visible draw is a no-op; the durable `presented` P6 event still fires (audit-only, not lost, replay-visible). No orphan outbox message (#2710).
- `ask_user` → `AuditOnlyInterventionBridge` → immediate `InterventionAnswer(refused=True, reason=…)`; the `ask_user` op returns `status="refused"` with the reason (new `InterventionAnswer.refused`/`reason` fields; `refused=False` legacy path unchanged). Never silent-empty, never park/hang.

## Tests (Tier-declared, real instances, no mocks)
- `test_spawn_routing_gate_2708.py` — inspect.signature pin, AST guard (+ no-bare-None), NA-ratchet equality + refusal.
- `test_spawn_routing_detached_fail_mode_2708.py` — op-level present-via-AuditOnly (presented fires + no orphan), op-level ask_user-via-AuditOnly (`status="refused"` + reason), detached present pipeline (audit-only, no orphan), detached ask_user pipeline (terminal in <5s = no hang, driver routed AuditOnly), agent-step worker spawned AuditOnly (#2706).
- Existing p31/p32a detached scope-guards updated (were "known-RED", now assert the deliberate AuditOnly cell); ~63 spawn-seam call sites + affected test factories threaded the required kwargs.

## Test plan
- [x] `ruff check src tests` (incl. I001) — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] `pytest` — green (excluding pre-existing LLM-provider env failures unrelated to this change)
- [x] Step-1 empirically pinned (hang → 0.05s terminal); AST guard falsified RED→GREEN via cp-backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
