### PR TITLE
fix: offload full WAL write to close Windows event-loop-freeze gap (#1765 Step 1b)

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -23,17 +23,22 @@ like LLM calls live in the audit log under `.reyn/events/`):
 Per P7: this is OS-level generic infrastructure — `kind` strings and
 field names live here, not in any domain-specific code.
 
-Off-loop durability (#1765 Step 1a). The fsync runs OFF the event loop via the shared
-`DurabilityWorker` (so a slow disk no longer freezes the loop — TUI repaint + other
-sessions keep running DURING the fsync), yet `append` still returns only once durable: the
-per-append crash-recovery contract is UNCHANGED (no relaxed-durability window — that is the
-deferred Step 2). The off-loop fsync would reopen the #1751 surface (a lockless `iter_from`
-reading a written-but-not-yet-fsync'd entry) — closed structurally by `_inflight_seq`: the
-worker marks the seq it is fsyncing right now, and `iter_from` skips exactly that one entry
-(a single-entry exclusion, NOT a durable ceiling, so cross-instance reads of a process-shared
-WAL + recovery still see every durable entry). The seq is assigned + the worker write
-submitted under the lock, so seq order = file order, and `truncate_below` (also under the
-lock) never overlaps a write.
+Off-loop durability (#1765 Step 1a, extended by Step 1b). Step 1a moved the `fsync` OFF the
+event loop via the shared `DurabilityWorker` (so a slow disk no longer freezes the loop — TUI
+repaint + other sessions keep running DURING the fsync); Step 1b (`_do_wal_write`) extends this
+to the `open`/`write`/`flush` themselves + the defensive lead-newline `stat`/`read` check, since
+those are NOT free on every platform (Windows AV re-scan / cloud-sync rehydration / a stale
+file-lock can stall a plain `open()` after the file has sat idle — same loop-freezing failure
+mode Step 1a fixed for `fsync`, just for a different syscall). `append` still returns only once
+durable: the per-append crash-recovery contract is UNCHANGED (no relaxed-durability window for
+`append`; `append_nowait` is the separate, deliberately-relaxed fire-and-forget path). The
+off-loop write would reopen the #1751 surface (a lockless `iter_from` reading a
+written-but-not-yet-durable entry) — closed structurally by `_inflight_seq`: the worker marks
+the seq it is writing right now (for the WHOLE off-loop window, not just the fsync slice), and
+`iter_from` skips exactly that one entry (a single-entry exclusion, NOT a durable ceiling, so
+cross-instance reads of a process-shared WAL + recovery still see every durable entry). The seq
+is assigned + the worker write submitted under the lock, so seq order = file order, and
+`truncate_below` (also under the lock) never overlaps a write.
 """
 from __future__ import annotations
 
@@ -236,11 +241,13 @@ class StateLog:
         """The durable WAL-write job (run by the DurabilityWorker, serially — the single serial
         venue, so no lock). At drain it ASSIGNS the seq (``++_counter`` — serial, so monotonic =
         durability order, never racing) and sets ``_last_assigned_seq`` (the paired snapshot job,
-        FIFO-after, reads it to stamp ``applied_seq``); writes the line + fsyncs OFF the loop;
-        then advances ``_last_durable_seq`` strictly AFTER the fsync (the watermark never names a
-        non-durable entry). ``_inflight_seq`` (the one entry mid-fsync — the worker is serial, so
-        only ever one) keeps ``iter_from`` from exposing it. Post-append observers fire after the
-        durable write. A blocking ``append`` passes a per-call ``holder`` to receive the seq."""
+        FIFO-after, reads it to stamp ``applied_seq``); writes the line + fsyncs OFF the loop
+        (``_do_wal_write``, off-loop — see #1765-Step-1b below); then advances
+        ``_last_durable_seq`` strictly AFTER the write (the watermark never names a non-durable
+        entry). ``_inflight_seq`` (the one entry mid-write — the worker is serial, so only ever
+        one) keeps ``iter_from`` from exposing it for the WHOLE off-loop window. Post-append
+        observers fire after the durable write. A blocking ``append`` passes a per-call
+        ``holder`` to receive the seq."""
         async def _task() -> None:
             self._counter += 1
             seq = self._counter
@@ -250,26 +257,39 @@ class StateLog:
             entry = {"seq": seq, "ts": datetime.now().isoformat(), "kind": kind}
             entry.update(fields)
             # Mark this entry in-flight BEFORE it appears in the file, so a concurrent
-            # `iter_from` during the fsync skips it (written but not yet durable); cleared
-            # only AFTER the fsync, when it is durable + readable.
+            # `iter_from` during the write/fsync skips it (written but not yet durable);
+            # cleared only AFTER the write, when it is durable + readable.
             self._inflight_seq = seq
             try:
                 payload = json.dumps(entry, ensure_ascii=False) + "\n"
-                # Defensive lead-newline (a prior run may have crashed mid-write so the file
-                # ends without a newline): start on our own line; the torn fragment parses as
-                # garbage + is skipped on replay.
-                need_lead_newline = self._needs_lead_newline()
-                with self._path.open("a", encoding="utf-8") as f:
-                    if need_lead_newline:
-                        f.write("\n")
-                    f.write(payload)
-                    f.flush()
-                    await asyncio.to_thread(os.fsync, f.fileno())
+                await asyncio.to_thread(self._do_wal_write, payload)
             finally:
                 self._inflight_seq = None
             self._last_durable_seq = seq  # durable now → the watermark advances
             await self._fire_post_append(kind, seq, fields)
         return _task
+
+    def _do_wal_write(self, payload: str) -> None:
+        """#1765 Step 1b: the synchronous WAL-line write (run off-loop via ``asyncio.to_thread``,
+        mirroring ``_do_truncate``'s pattern). Step 1a moved ONLY ``os.fsync`` off the loop; the
+        preceding ``_needs_lead_newline`` check (a ``stat`` + tail-byte ``read``) and the
+        ``open``/``write``/``flush`` themselves stayed SYNCHRONOUS on the loop, on the (POSIX-
+        biased) assumption that appending to an already-resident file is effectively instant. On
+        Windows that assumption doesn't hold after the file has sat idle: a real-time antivirus
+        re-scan, a cloud-sync (OneDrive/Dropbox) placeholder needing to rehydrate, or a stale
+        file-lock retry can each stall an ``open``/``stat``/``read`` for seconds to minutes —
+        and because this job runs on the SAME event loop as the TUI repaint and the whole
+        turn-processing pipeline, that stall freezes everything (the "message echoes, but
+        Working… never appears" symptom), not just this WAL append. Folding the lead-newline
+        check + open/write/flush/fsync into ONE thread-hop keeps every synchronous file access
+        for this append off the loop, closing the gap Step 1a left open."""
+        need_lead_newline = self._needs_lead_newline()
+        with self._path.open("a", encoding="utf-8") as f:
+            if need_lead_newline:
+                f.write("\n")
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
 
     async def submit_durable(self, do_durable_write) -> None:
         """#1765 Step 1a: submit a durable write from ANOTHER substrate (e.g. a snapshot

--- a/tests/test_1765_state_log_durability.py
+++ b/tests/test_1765_state_log_durability.py
@@ -1,9 +1,9 @@
-"""Tier 2: #1765 Step 1a — StateLog routed through the DurabilityWorker (off-loop WAL fsync).
+"""Tier 2: #1765 Step 1a/1b — StateLog routed through the DurabilityWorker (off-loop WAL write).
 
-The refactor is BEHAVIOR-INVARIANT for durability + recovery (the off-loop fsync is the only
-change): an append returns only once durable, recovery replays every durable entry, and the
-`_durable_seq` watermark closes the #1751 lockless-read surface (a written-but-not-yet-fsync'd
-tail entry is structurally unreadable). Real instances (no mocks).
+The refactor is BEHAVIOR-INVARIANT for durability + recovery (moving the write/fsync off the
+loop is the only change): an append returns only once durable, recovery replays every durable
+entry, and the `_durable_seq` watermark closes the #1751 lockless-read surface (a
+written-but-not-yet-durable tail entry is structurally unreadable). Real instances (no mocks).
 """
 from __future__ import annotations
 
@@ -66,6 +66,57 @@ async def test_iter_from_excludes_inflight_entry_during_fsync(tmp_path, monkeypa
     await appending  # fsync completes → seq 2 is now durable
     after = [e["seq"] for e in sl.iter_from(1)]
     assert after == [1, 2], "after the fsync, the now-durable entry is readable"
+    await sl.aclose()
+
+
+@pytest.mark.asyncio
+async def test_slow_file_open_does_not_freeze_the_event_loop(tmp_path, monkeypatch):
+    """Tier 2: #1765 Step 1b. Step 1a moved only `fsync` off the loop; the preceding
+    `_needs_lead_newline` check + `open`/`write`/`flush` stayed synchronous on the loop. On a
+    stalled filesystem (Windows AV re-scan / cloud-sync rehydration / a stale lock — all far
+    more likely after the file has sat idle), those calls freeze the WHOLE event loop, not just
+    this append (the reported symptom: the user's message echoes, but the "Working…" indicator
+    never appears). RED against pre-Step-1b code: a concurrent counter task would NOT advance
+    during a slow `open()`, since the synchronous open call itself blocked the only thread
+    running the loop."""
+    import asyncio
+
+    p = tmp_path / "wal.jsonl"
+    sl = StateLog(p)
+
+    orig_do_wal_write = sl._do_wal_write
+
+    def _slow_do_wal_write(payload):
+        import time
+        time.sleep(0.2)  # simulates a stalled `open()`/`stat()` — runs off-loop in to_thread
+        return orig_do_wal_write(payload)
+
+    monkeypatch.setattr(sl, "_do_wal_write", _slow_do_wal_write)
+
+    ticks = 0
+
+    async def _counter() -> None:
+        nonlocal ticks
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    counter_task = asyncio.create_task(_counter())
+    await sl.append("inbox_put", text="slow-open")
+    # snapshot BEFORE draining counter_task to completion: if the loop had frozen for the
+    # 0.2s stall, ticks would still be near-zero here, only catching up afterward — awaiting
+    # counter_task first (as a prior version of this test did) makes the assertion pass
+    # unconditionally regardless of whether the loop froze.
+    ticks_during_append = ticks
+    await counter_task
+    # threshold kept low (5, not e.g. 20): on Windows — the platform this fix targets — the
+    # default ~15.6ms timer resolution makes each 5ms `asyncio.sleep` take ~15.6ms, so even a
+    # correct implementation only accumulates ~12 ticks in the 200ms stall. A frozen loop still
+    # produces ~0, so >= 5 keeps the discrimination margin without false-failing on Windows.
+    assert ticks_during_append >= 5, (
+        "the loop must keep making progress on OTHER coroutines DURING the stalled "
+        "open/write/flush (off-loop) — a near-zero count at this point means the loop froze"
+    )
     await sl.aclose()
 
 


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- Root cause of a reported Windows UX bug: after hitting Enter, the user's message echoed immediately but the "Working…" indicator sometimes took minutes to appear. Traced to `state_log.py`'s WAL append: #1765 Step 1a only moved `os.fsync` off the event loop, leaving `_needs_lead_newline` (stat + tail read) and `open`/`write`/`flush` synchronous on the loop. On Windows, a stalled filesystem (AV re-scan, cloud-sync rehydration, a stale lock — all more likely once the WAL file has sat idle) can block those calls for seconds to minutes, freezing the *entire* event loop, not just the append.
- Fix (Step 1b): folds the lead-newline check + open/write/flush/fsync into one `asyncio.to_thread` hop (`_do_wal_write`), mirroring the existing `_do_truncate` off-loop pattern in the same file. `_inflight_seq` now brackets the whole off-loop window (was: fsync slice only), preserving the #1751 lockless-read closure.
- Behavior-invariant for durability/recovery: append still returns only once durable; crash-mid-write torn-tail handling unchanged; seq order still equals file order under concurrency (`DurabilityWorker` remains strict serial-FIFO, so the two off-loop hops never overlap).

## Review history

This diff went through **two rounds of Fable-model review** (both dispatched at the owner's explicit request):

1. Round 1 flagged a vacuous test (`test_slow_file_open_does_not_freeze_the_event_loop` asserted only after fully draining a concurrent counter task, so it passed unconditionally regardless of whether the loop had frozen) — fixed by snapshotting the counter immediately after `append()` returns.
2. Round 2 empirically re-verified the fix by simulating the regression (confirmed the freeze test now goes RED) and found two more test issues, both applied:
   - Deleted `test_iter_from_excludes_inflight_entry_during_slow_open` — proven (by literally removing the `_inflight_seq` protection and rerunning) to pass even with no protection at all; the real #1751 leak window (write→fsync) is already covered by the pre-existing fsync test.
   - Lowered the freeze-test tick threshold from `>= 20` to `>= 5` — Windows' ~15.6ms timer resolution would make even a correct fix only accumulate ~12 ticks in the 200ms stall, risking a false failure on the very platform this fix targets.

Both rounds independently re-verified thread safety (only `self._path` and an immutable payload string cross the thread boundary), `DurabilityWorker` serialization, and the crash-recovery/torn-tail contract — concluding the source change is safe.

## Test plan

- [x] `pytest tests/test_1765_state_log_durability.py -v` — 4 passed (RED→GREEN verified via `git stash` against the pre-fix code)
- [x] `ruff check src tests` (changed files) — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_1765_state_log_durability.py` — 0 violations
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/events/state_log.py` — clean
- [x] Full `pytest` suite — 7859 passed, 9 failed (pre-existing/environmental, unrelated files: compaction resolver, LLM request error redaction, LLM router fallback, responses-API routing — none touch `state_log.py` or this diff), 17 skipped
- [x] Crash-recovery / rewind / time-travel test suites re-confirmed passing (owner explicitly required this be checked)

Tier self-check: both new/modified tests are Tier 2 (OS invariant), docstrings declare Tier first line, no MagicMock/patch of collaborators (own-method monkeypatch used as a seam, consistent with the existing `os.fsync` patch pattern in the same file), no private-state assertions, no format pins.