### PR TITLE
fix: cap session_spawn nesting depth at parity with agent_spawn (#2737)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -630,6 +630,40 @@ class AgentRegistry:
                 n += 1
         return n
 
+    def session_nesting_depth(self, name: str, sid: "str | None" = None) -> int:
+        """#2737: the LLM ``session_spawn`` NESTING depth of session ``(name, sid)`` — a
+        root/main session = 0, each ``session_spawn`` edge +1. Walks the
+        ``SpawnBridgeInterventionListener`` parent-linkage chain — the SAME parent linkage
+        ``SpawnBridgeInterventionListener.bus()`` recurses over to resolve an ``ask_user``
+        toward the root operator (#2735) — so the depth this returns is exactly that
+        ``bus()`` recursion depth. Capping it at the ``session_spawn`` seam therefore bounds
+        BOTH unbounded session nesting (resource) AND the compositional ``bus()`` recursion
+        (a deep-chain ``RecursionError``) by construction — the #2708 P3-item3 co-vet edge.
+
+        This is a LIVE-runtime property (the in-memory bridge chain), matching the live risk
+        it bounds: a crash tears the chain down (restore re-creates a spawned session
+        self-bound via ``ReviewedNA`` — no ``SpawnBridge*`` bridge), so there is no persisted
+        depth to survive WAL truncation and no recovery-gate surface. A non-spawned session
+        (no ``SpawnBridgeInterventionListener`` bridge) terminates the walk at depth 0."""
+        from reyn.runtime.session_buses import SpawnBridgeInterventionListener
+
+        session = self._peek_session(
+            name, sid if sid is not None else _DEFAULT_SID,
+        )
+        depth = 0
+        seen: "set[int]" = set()
+        while session is not None:
+            bridge = getattr(session, "intervention_bridge", None)
+            if not isinstance(bridge, SpawnBridgeInterventionListener):
+                break
+            parent = bridge.parent_session
+            if parent is None or id(parent) in seen:
+                break
+            seen.add(id(parent))
+            depth += 1
+            session = parent
+        return depth
+
     # #2175: the BASE operator spawn bounds (safety.spawn.*, config-set restart-only).
     # Exposed so the LLM spawn SEAM (host adapter) can compute the EFFECTIVE limit
     # (base + the on_limit per-operation extension) and route an exceed through the

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1077,9 +1077,9 @@ class RouterHostAdapter:
                 decision = await self._spawn_limit_checkpoint(
                     kind=f"max_session_depth:{self._agent_name}",
                     prompt=(
-                        f"Session-spawn nesting depth {cur_depth + 1} would exceed "
-                        f"max_spawn_depth ({eff_depth}). Allow agent {self._agent_name!r} "
-                        "to nest spawned sessions deeper?"
+                        f"Session-spawn nesting depth {cur_depth + 1} would exceed the "
+                        f"session-nesting cap ({eff_depth}). Allow agent "
+                        f"{self._agent_name!r} to nest spawned sessions deeper?"
                     ),
                     detail=(
                         f"agent={self._agent_name} sid={from_sid} depth={cur_depth + 1} "
@@ -1092,10 +1092,13 @@ class RouterHostAdapter:
                     return {
                         "status": "error", "kind": "spawn_limit_exceeded",
                         "error": (
-                            f"spawn-limit: max_spawn_depth={eff_depth} would be exceeded "
-                            f"(agent {self._agent_name!r} at session-nesting depth "
-                            f"{cur_depth}). → Raise safety.spawn.max_depth to allow deeper "
-                            "session nesting."
+                            f"spawn-limit: session-nesting depth {cur_depth + 1} would "
+                            f"exceed the session-nesting cap ({eff_depth}) (agent "
+                            f"{self._agent_name!r} at session-nesting depth {cur_depth}). "
+                            "→ Extend just this axis via the operator spawn-limit "
+                            "checkpoint (raises max_session_depth for this agent), or "
+                            "raise the shared base safety.spawn.max_depth (which lifts "
+                            "BOTH the agent-tree and session-nesting caps)."
                         ),
                     }
         sid = await self._registry.spawn_session_recorded(

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1054,6 +1054,50 @@ class RouterHostAdapter:
             if parent_session is not None
             else AuditOnlyNoSurface()
         )
+        # #2737: session_spawn NESTING depth cap — PARITY with agent_spawn's max_spawn_depth
+        # gate (this method's sibling ``spawn_agent`` below). The LLM session_spawn path
+        # re-exposes spawn_session on EVERY spawned child's router host, so unbounded
+        # grandchildren/great-grandchildren are reachable; and the compositional
+        # ``SpawnBridgeInterventionListener.bus()`` walk (#2735) recurses once per nesting
+        # level to resolve ask_user toward the root operator, so a deep chain risks a
+        # ``RecursionError`` during ask_user resolution. The SAME operator base cap
+        # (``safety.spawn.max_depth`` = ``registry.max_spawn_depth``) bounds BOTH by
+        # construction (capped nesting depth ⇒ bounded bus() recursion, since the depth is
+        # exactly that walk's length). Routed through the SAME on_limit checkpoint and the
+        # SAME typed ``spawn_limit_exceeded`` error as agent_spawn (uniform sibling), with a
+        # SEPARATE extension key — session nesting ≠ agent-tree depth, so an approved widen of
+        # one must not silently widen the other (the #2175 approval-scoping principle).
+        base_depth = self._registry.max_spawn_depth
+        if base_depth:
+            cur_depth = self._registry.session_nesting_depth(self._agent_name, from_sid)
+            eff_depth = base_depth + int(
+                self._safety_extensions.get(f"max_session_depth:{self._agent_name}", 0.0)
+            )
+            if cur_depth + 1 > eff_depth:
+                decision = await self._spawn_limit_checkpoint(
+                    kind=f"max_session_depth:{self._agent_name}",
+                    prompt=(
+                        f"Session-spawn nesting depth {cur_depth + 1} would exceed "
+                        f"max_spawn_depth ({eff_depth}). Allow agent {self._agent_name!r} "
+                        "to nest spawned sessions deeper?"
+                    ),
+                    detail=(
+                        f"agent={self._agent_name} sid={from_sid} depth={cur_depth + 1} "
+                        f"cap={eff_depth}"
+                    ),
+                    extension_amount=1.0,
+                    run_id=self._agent_name,
+                )
+                if not decision.allow_continue:
+                    return {
+                        "status": "error", "kind": "spawn_limit_exceeded",
+                        "error": (
+                            f"spawn-limit: max_spawn_depth={eff_depth} would be exceeded "
+                            f"(agent {self._agent_name!r} at session-nesting depth "
+                            f"{cur_depth}). → Raise safety.spawn.max_depth to allow deeper "
+                            "session nesting."
+                        ),
+                    }
         sid = await self._registry.spawn_session_recorded(
             self._agent_name, mode=mode, narrowing=narrowing,
             presentation_consumer=_routing.presentation_consumer,

--- a/tests/test_2737_session_spawn_depth_cap.py
+++ b/tests/test_2737_session_spawn_depth_cap.py
@@ -1,0 +1,179 @@
+"""Tier 2: #2737 — session_spawn NESTING depth cap at PARITY with agent_spawn.
+
+``max_spawn_depth`` (``safety.spawn.max_depth``) gated the ``agent_spawn`` path only —
+the LLM ``session_spawn`` path was uncapped, so a spawned child's router host re-exposes
+``spawn_session`` and grandchildren/great-grandchildren nest without limit (#2708
+P3-item3 co-vet edge). Two consequences the cap bounds by construction:
+  1. resource — unbounded session nesting;
+  2. recursion — the compositional ``SpawnBridgeInterventionListener.bus()`` walk (#2735)
+     recurses once per nesting level to resolve ask_user toward the root operator, so a
+     deep chain risks a ``RecursionError``. The nesting depth this cap counts is EXACTLY
+     that walk's length (both walk the same ``SpawnBridge*`` parent chain), so a capped
+     depth ⇒ a bounded ``bus()`` recursion.
+
+The fix reuses the SAME operator base cap + on_limit checkpoint + typed
+``spawn_limit_exceeded`` error as ``agent_spawn`` (uniform sibling), enforced at the
+``router_host_adapter.spawn_session`` seam.
+
+Real ``AgentRegistry`` + real ``Session`` (factory forwards the spawn bridges) + real
+``RouterHostAdapter`` + real on_limit framework — no collaborator mocks. Assertions use
+the public spawn surface (adapter ack) + the public ``session_nesting_depth`` read.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import OnLimitConfig
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_buses import SpawnBridgeInterventionListener
+from reyn.runtime.spawn_routing import BridgeToParent
+from tests._support.router_host_adapter import make_adapter
+
+
+def _registry(tmp_path: Path, state_log: StateLog, *, max_depth: int = 0) -> AgentRegistry:
+    """Real AgentRegistry whose Session factory forwards BOTH spawn overrides (the
+    widened factory protocol), so a spawned child carries the parent-bound
+    ``SpawnBridgeInterventionListener`` bridge the nesting-depth walk counts."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+
+    reg = AgentRegistry(
+        project_root=tmp_path, session_factory=_factory, state_log=state_log,
+        max_spawn_depth=max_depth,
+    )
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+async def _nest_once(reg: AgentRegistry, parent: Session) -> str:
+    """Spawn one child SESSION under ``worker`` bridged to ``parent`` via the raw recorded
+    seam (bypasses the cap — used only to BUILD a chain the cap is then tested against)."""
+    routing = BridgeToParent(parent)
+    return await reg.spawn_session_recorded(
+        "worker",
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+
+
+def _teardown_tasks(reg: AgentRegistry) -> None:
+    for task in list(getattr(reg, "_tasks", {}).values()):
+        if not task.done():
+            task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_session_nesting_depth_counts_the_bridge_chain(tmp_path: Path) -> None:
+    """Tier 2: ``session_nesting_depth`` returns the LLM-spawn nesting depth — main = 0,
+    each ``session_spawn`` edge +1 — by walking the ``SpawnBridgeInterventionListener``
+    parent chain. This is the SAME chain ``bus()`` recurses over, so this quantity is the
+    recursion depth the cap bounds. (Grounds the parity + recursion-bound claim.)"""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log)
+    main = reg.get_or_load("worker")
+    assert reg.session_nesting_depth("worker") == 0  # a root/main session
+
+    child_sid = await _nest_once(reg, main)
+    assert reg.session_nesting_depth("worker", child_sid) == 1
+
+    child = reg.get_session("worker", child_sid)
+    gc_sid = await _nest_once(reg, child)
+    assert reg.session_nesting_depth("worker", gc_sid) == 2
+
+    # The counted chain IS the bus() recursion chain: each level carries a
+    # SpawnBridgeInterventionListener whose bus() resolves toward the root in bounded hops.
+    gc = reg.get_session("worker", gc_sid)
+    assert isinstance(gc.intervention_bridge, SpawnBridgeInterventionListener)
+    assert gc.intervention_bridge.bus() is not None  # terminates (bounded recursion)
+
+
+@pytest.mark.asyncio
+async def test_session_spawn_beyond_cap_is_rejected(tmp_path: Path) -> None:
+    """Tier 2: (RED on main = session_spawn is uncapped) a ``session_spawn`` that would
+    nest past ``max_spawn_depth`` is rejected with the SAME typed ``spawn_limit_exceeded``
+    error ``agent_spawn`` returns. cp-falsify: removing the adapter cap → this spawns
+    instead of rejecting (RED). unattended on_limit = the C3 hard-deny posture."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log, max_depth=1)
+    main = reg.get_or_load("worker")
+    child_sid = await _nest_once(reg, main)  # nesting depth 1 == max
+
+    adapter = make_adapter(
+        agent_name="worker", agent_registry=reg, session_id=child_sid,
+        on_limit=OnLimitConfig(mode="unattended"),
+    )
+    try:
+        res = await adapter.spawn_session(
+            request="do a thing", mode="persistent", narrowing=None, chain_id="c1",
+        )
+    finally:
+        _teardown_tasks(reg)
+    # PARITY: same error shape as agent_spawn's spawn-limit reject (status + kind).
+    assert res["status"] == "error" and res["kind"] == "spawn_limit_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_session_spawn_within_cap_still_works(tmp_path: Path) -> None:
+    """Tier 2: the bound is at PARITY, NOT stricter — a ``session_spawn`` that stays WITHIN
+    ``max_spawn_depth`` proceeds and spawns. Guards against an off-by-one that would reject
+    a legal nesting depth."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log, max_depth=2)
+    main = reg.get_or_load("worker")
+    child_sid = await _nest_once(reg, main)  # nesting depth 1; cap 2 ⇒ one more allowed
+
+    adapter = make_adapter(
+        agent_name="worker", agent_registry=reg, session_id=child_sid,
+        on_limit=OnLimitConfig(mode="unattended"),
+    )
+    try:
+        res = await adapter.spawn_session(
+            request="do a thing", mode="persistent", narrowing=None, chain_id="c1",
+        )
+    finally:
+        _teardown_tasks(reg)
+    assert res["status"] == "spawned"
+
+
+@pytest.mark.asyncio
+async def test_session_spawn_interactive_approve_extends_and_proceeds(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: PARITY with agent_spawn's interactive path — on_limit=interactive + operator
+    approves → the over-cap ``session_spawn`` PROCEEDS, and its SEPARATE per-agent extension
+    key is bumped (session nesting ≠ agent-tree depth: approving one must not silently widen
+    the other, the #2175 approval-scoping principle)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log, max_depth=1)
+    main = reg.get_or_load("worker")
+    child_sid = await _nest_once(reg, main)  # depth 1 == max
+
+    ext: dict = {}
+    adapter = make_adapter(
+        agent_name="worker", agent_registry=reg, session_id=child_sid,
+        on_limit=OnLimitConfig(mode="interactive", ask_timeout_seconds=0.0),
+        safety_extensions=ext, intervention_answer="yes",
+    )
+    try:
+        res = await adapter.spawn_session(
+            request="do a thing", mode="persistent", narrowing=None, chain_id="c1",
+        )
+    finally:
+        _teardown_tasks(reg)
+    assert res["status"] == "spawned"
+    # SEPARATE key from agent_spawn's max_spawn_depth:<agent> (approval-scoping).
+    assert ext.get("max_session_depth:worker", 0) >= 1
+    assert ext.get("max_spawn_depth:worker", 0) == 0


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2737 · part of #2708 (P3-item3 arc — NOT closing the umbrella)

## What
`max_spawn_depth` (`safety.spawn.max_depth`) gated the **`agent_spawn`** path only; the LLM **`session_spawn`** path was uncapped. This closes the last flagged edge of the #2708 P3-item3 co-vet.

Two consequences the cap bounds **by construction**:
1. **Resource** — a spawned child's router host re-exposes `spawn_session`, so grandchildren/great-grandchildren nest with no limit.
2. **Recursion** — the compositional `SpawnBridgeInterventionListener.bus()` walk (#2735) recurses once per nesting level to resolve `ask_user` toward the root operator, so a deep chain risks a `RecursionError` during ask_user resolution.

## How (parity with `agent_spawn`)
- **How `agent_spawn`'s cap works** (`router_host_adapter.spawn_agent`): reads `registry.max_spawn_depth` (base) + `registry.spawn_depth(parent)` (current agent-lineage depth); if `cur_depth + 1 > eff_depth` it routes through `_spawn_limit_checkpoint` (mode-driven: unattended reject / interactive ask / auto_extend) and, on non-allow, returns the typed `{"status":"error","kind":"spawn_limit_exceeded", ...}` ack.
- **Parity applied** at the `router_host_adapter.spawn_session` seam: same base cap, same checkpoint, **same typed `spawn_limit_exceeded` error shape** (no new failure shape invented). Depth is measured by a new `registry.session_nesting_depth(name, sid)` that walks the **exact `SpawnBridge*` parent chain `bus()` recurses over** (main = 0, each `session_spawn` edge +1).
- **Distinct extension key** `max_session_depth:<agent>` (not `max_spawn_depth:<agent>`) — session nesting ≠ agent-tree depth, so an approved widen of one does not silently widen the other (the #2175 approval-scoping principle).

## Both concerns bounded by one cap
Because `session_nesting_depth` counts the **same chain** `SpawnBridgeInterventionListener.bus()` recurses over, a capped nesting depth ⇒ a bounded `bus()` recursion. So the single depth cap is the clean root fix for **both** the resource (nesting) and recursion (`bus()` walk) concerns — the `bus()` walk is left compositional as-is (the architect's noted iterative rewrite would not address the resource concern).

## Recovery-gate note (not applicable)
The bounded quantity is a **live-runtime** property (the in-memory bridge chain), matching the live risk it bounds. A crash tears the chain down — restore re-wakes a spawned session self-bound (`ReviewedNA`, no `SpawnBridge*` bridge) — so there is **no persisted depth** to survive WAL truncation and **no recovery-gate surface**.

## Tests (`tests/test_2737_session_spawn_depth_cap.py`, Tier 2, real instances)
- `session_nesting_depth` counts the bridge chain (main=0 / child=1 / grandchild=2) and the counted chain **is** the `bus()` recursion chain (grandchild's `bus()` terminates in bounded hops).
- `session_spawn` beyond the cap → rejected with the **same** `spawn_limit_exceeded` error as `agent_spawn` (RED on main = uncapped).
- `session_spawn` within the cap still works (bound at parity, not stricter).
- interactive approve extends + proceeds, bumping the **separate** `max_session_depth:<agent>` key (agent-depth key untouched — approval-scoping).

**cp-falsify**: `cp -r` backup → removed the adapter cap block → 2 cap tests RED, 2 non-cap tests stay GREEN → restored from backup → 4/4 GREEN.

## CI gates (all 4 run locally)
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_2737_session_spawn_depth_cap.py` — 4 OK, 0 errors
- [x] `pytest` (repo root) — 7882 passed; 5 pre-existing failures (web/a2a/mcp/plugin route-mounting, optional-dep env; reproduced on clean HEAD with my changes stashed, zero overlap with this diff)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK

## Test plan
- [x] Depth cap rejects over-limit `session_spawn` with the sibling's typed error (automated)
- [x] Within-cap `session_spawn` still proceeds (automated)
- [x] Interactive approve extends via the separate key (automated)
- [x] cp-falsify RED→GREEN confirmed (manual, above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)