### PR TITLE
feat: add ctx status-bar chip (current context size vs model window)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -178,7 +178,7 @@ mindmap
       /tasks view
     🖥️ Inline CUI
       Conversation view
-      Status chips (Agents/Cost/Model/Tools/MCP/Skills/Hooks/Pipes/Cron/Tasks)
+      Status chips (Agents/Cost/Model/Ctx/Tools/MCP/Skills/Hooks/Pipes/Cron/Tasks)
       Tool-result one-line summaries
       Above-input region (interventions, command UIs)
       Input + slash-command completion
@@ -595,7 +595,7 @@ still use the plain `ConsoleChatRenderer`.
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
 | Conversation view | Streaming conversation in scrollback with terracotta-accented `⏺`/`⎿` markers per message kind (agent/status/error/intervention/trace) | — |
-| Status chips | Live one-line chip bar above the input: Agents / Cost / Model / Tools / MCP / Skills / Hooks / Pipes / Cron / Tasks, each expandable in place | — |
+| Status chips | Live one-line chip bar above the input: Agents / Cost / Model / Ctx / Tools / MCP / Skills / Hooks / Pipes / Cron / Tasks, each expandable in place — Ctx shows current context size vs the model's context window as a Claude Code-style %, with a dropdown for window source (litellm catalog vs fallback), cache-hit rate, and the compaction subsystem's own separate estimate | — |
 | Tool-result summaries | `summarize_tool_result` renders a best-effort one-line, per-tool summary (e.g. `Read 42 lines`, `3 matches`); always degrades gracefully to a truncated repr, never a full content preview | — |
 | Above-input region | Closed-set interventions (confirm/select/grant-deny) and command UIs (e.g. the `/rewind` checkpoint picker) render as a selectable row list above the input, rather than a modal | [Permission model](concepts/runtime/permission-model.md) |
 | Input + slash-command completion | Input bar with `/`-prefixed command autocomplete (`/plan`, `/compact`, `/find`, `/help`, `/clear`, …) | — |

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -143,16 +143,74 @@ def _model_expansion(snap, dispatch):
     return CommandUIElement(rows, [f"/model {c}" for c in classes], dispatch)
 
 
+def _cache_hit_line(label: str, cached: int, prompt: int, *, note: str = "") -> str:
+    """One "cache X% hit (a / b prompt tokens)" line, label padded to the same
+    9-char column every other cost/ctx dropdown line uses (was misaligned
+    when the label itself carried the qualifier, e.g. "cache (cumulative)")."""
+    pct = round(100 * cached / prompt) if prompt > 0 else 0
+    tail = f", {note}" if note else ""
+    return f"{label:<9}{pct}% hit ({cached:,} / {prompt:,} prompt tokens{tail})"
+
+
 def _cost_expansion(snap, dispatch):
     def lines():
         p, c, t = snap["usage"]
         session = snap["cost_usd"]
         agent_t = snap.get("agent_tokens", t)
+        cached = snap.get("session_cached_tokens", 0)
         return [
             f"total    ${snap.get('cost_total', session):.4f}",
             f"agent    ${snap.get('cost_agent', session):.4f}",
             f"session  ${session:.4f}",
             f"tokens   prompt {p} · completion {c} · total {agent_t}",
+            _cache_hit_line("cache", cached, p, note="cumulative"),
+        ]
+    return DetailElement(lines)
+
+
+def _ctx_pct(snap) -> str:
+    window = snap.get("ctx_window", 0)
+    used = snap.get("ctx_used", 0)
+    # used <= 0 means no LLM call has completed yet this session — show "—"
+    # rather than a misleading "0%" (a real completed call's prompt_tokens is
+    # never actually 0; the system prompt alone is nonzero).
+    if window <= 0 or used <= 0:
+        return "—"
+    return f"{round(100 * used / window)}%"
+
+
+def _ctx_expansion(snap, dispatch):
+    # Current-state only (this is the ctx chip's whole reason to exist —
+    # cumulative figures live in the cost chip instead, see _cost_expansion).
+    #
+    # Two DISTINCT figures, kept visually separated so they don't collapse
+    # back into one ambiguous number:
+    #   - prompt/window/free/cache: the REAL last-call size against the
+    #     model's REAL context limit — "how close to the hard limit".
+    #   - compaction: the compaction subsystem's OWN lightweight estimate
+    #     (history only, excl. system prompt/tools) against ITS internal
+    #     trigger threshold — "when will auto-compaction fire". A smaller,
+    #     already-adjusted number; not comparable to the block above.
+    def lines():
+        window = snap.get("ctx_window", 0)
+        prompt_tokens = snap.get("ctx_used", 0)
+        free = max(0, window - prompt_tokens)
+        pct = round(100 * prompt_tokens / window) if window > 0 else 0
+        recent_prompt, recent_cached = snap.get("ctx_recent_usage", (0, 0))
+        # Lazy: only computed while this dropdown is actually open (see
+        # _snapshot's comment on why context_window_status() must not run on
+        # every render frame).
+        status_fn = snap.get("ctx_compaction_status_fn")
+        status = status_fn() if status_fn is not None else {}
+        comp_trigger = status.get("effective_trigger", 0)
+        comp_est = max(0, comp_trigger - status.get("free_window", 0))
+        comp_pct = round(100 * comp_est / comp_trigger) if comp_trigger > 0 else 0
+        return [
+            f"window       {window:,} tokens  ({snap.get('ctx_source', 'unknown')})",
+            f"prompt       {prompt_tokens:,} tokens  ({pct}% of window)",
+            f"free         {free:,} tokens",
+            _cache_hit_line("cache", recent_cached, recent_prompt),
+            f"compaction   {comp_est:,} / {comp_trigger:,} tokens est.  ({comp_pct}% to trigger)",
         ]
     return DetailElement(lines)
 
@@ -362,6 +420,8 @@ _CHIP_SPECS = [
              value_color=_CC_COOL),
     ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion,
              value_color=_CC_WARN),
+    ChipSpec("ctx",   "ctx",   _ctx_pct, _ctx_expansion,
+             value_color=_CC_COOL),
     # "more" has no `expansion` — Enter on it opens the level-2 sub-bar
     # (_MORE_SUB_CHIP_SPECS) instead of a menu_region dropdown directly; see
     # _is_more()/_sub_bar_visible() in run_inline_input.
@@ -563,6 +623,34 @@ def _snapshot(registry, task_cache=None, config=None):
         registry.agent_tokens(registry.attached_name)
         if registry.attached_name else u.total_tokens
     )
+    # Headline figure: the single most recent LLM call's prompt_tokens against
+    # the model's REAL context window (get_max_input_tokens) — "how close to
+    # the model's hard limit am I", matching the Claude Code-style % owners
+    # expect. last_call_usage (NOT total_usage or a turn-summed figure) — a
+    # turn can make several LLM calls via tool-loop iterations, each re-
+    # sending nearly the same growing context, so summing them would wildly
+    # overstate current occupancy. raw_context_window() is a cheap dict
+    # lookup, safe to call every render frame (_snapshot runs on every frame).
+    raw_window = s.raw_context_window()
+    ctx_window = raw_window["window"]
+    ctx_source = raw_window["source"]
+    recent = s.last_call_usage
+    ctx_used = recent.prompt_tokens
+    # Supplementary figure: the compaction subsystem's OWN lightweight estimate
+    # (history only, excl. system prompt/tools) against ITS internal trigger
+    # threshold (already SP/head/tail-adjusted, not the model's real window) —
+    # answers "when will auto-compaction fire", a different question from the
+    # headline one above. Keeping both avoids collapsing two distinct
+    # measurements into one ambiguous number (the original "used" bug).
+    #
+    # UNLIKE raw_context_window, Session.context_window_status() is NOT cheap
+    # (json.dumps + token-estimate of the full router-view history) — do not
+    # call it eagerly here, since _snapshot() runs on every render frame
+    # regardless of whether the ctx dropdown is even open. Store the bound
+    # method itself; _ctx_expansion's lines() calls it lazily, only while the
+    # dropdown is actually open (and only once per redraw of THAT dropdown,
+    # not the whole app).
+    ctx_compaction_status_fn = s.context_window_status
     return {
         "model": s.model,
         "model_active_class": s.active_model_class(),
@@ -575,6 +663,12 @@ def _snapshot(registry, task_cache=None, config=None):
         "cost_total": cost_total,
         "cost_agent": cost_agent,
         "agent_tokens": agent_tokens,
+        "ctx_used": ctx_used,
+        "ctx_window": ctx_window,
+        "ctx_source": ctx_source,
+        "session_cached_tokens": u.cached_tokens,
+        "ctx_recent_usage": (recent.prompt_tokens, recent.cached_tokens),
+        "ctx_compaction_status_fn": ctx_compaction_status_fn,
         "task_count": task_cache["count"] if task_cache else 0,
         "task_tree": task_cache["tree"] if task_cache else [],
         "cron_jobs": _extract_cron_jobs(config) if config is not None else [],

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -53,6 +53,38 @@ def _lookup_max_input(model: str) -> "int | None":
     return None
 
 
+def _resolve_max_input(model: str) -> "tuple[int, str, bool]":
+    """Resolve (value, source, is_fallback) exactly once — the single place
+    ``get_max_input_tokens`` and ``get_max_input_tokens_source`` both delegate
+    to, so the #1162 prefix-strip-retry resolution order exists in ONE spot
+    (previously duplicated across the two functions, a silent-drift risk if
+    the order ever changed in only one place)."""
+    max_input = _lookup_max_input(model)
+    if max_input is not None:
+        return max_input, f"litellm catalog: {model}", False
+
+    # #1162: provider-prefixed proxy models miss the catalog under the prefix
+    # but resolve under the bare model name. e.g. ``openai/gemini-2.5-flash-lite``
+    # (routing Gemini through an openai-compat proxy) is not in litellm's openai
+    # catalog → exception → would fall to the 128K default, over-compacting a
+    # real 1M window by ~87%. Strip the FIRST provider segment and retry before
+    # falling back. This only IMPROVES resolution: a still-unknown bare name
+    # falls through to the same conservative fallback as before (safe even if a
+    # proxy aliases the prefixed name to something else — the bare lookup just
+    # misses → 128K).
+    if "/" in model:
+        bare = model.split("/", 1)[1]
+        max_input = _lookup_max_input(bare)
+        if max_input is not None:
+            return max_input, f"litellm catalog: {bare}", False
+
+    return (
+        _FALLBACK_MAX_INPUT_TOKENS,
+        f"reyn fallback default: {_FALLBACK_MAX_INPUT_TOKENS:,} tokens (model not cataloged)",
+        True,
+    )
+
+
 def get_max_input_tokens(
     model: str,
     *,
@@ -83,27 +115,8 @@ def get_max_input_tokens(
     int
         Positive integer token count. Always > 0.
     """
-    max_input = _lookup_max_input(model)
-    if max_input is not None:
-        return max_input
-
-    # #1162: provider-prefixed proxy models miss the catalog under the prefix
-    # but resolve under the bare model name. e.g. ``openai/gemini-2.5-flash-lite``
-    # (routing Gemini through an openai-compat proxy) is not in litellm's openai
-    # catalog → exception → would fall to the 128K default, over-compacting a
-    # real 1M window by ~87%. Strip the FIRST provider segment and retry before
-    # falling back. This only IMPROVES resolution: a still-unknown bare name
-    # falls through to the same conservative fallback as before (safe even if a
-    # proxy aliases the prefixed name to something else — the bare lookup just
-    # misses → 128K).
-    if "/" in model:
-        bare = model.split("/", 1)[1]
-        max_input = _lookup_max_input(bare)
-        if max_input is not None:
-            return max_input
-
-    # Fallback path: emit warning once per model.
-    if model not in _warned_models:
+    value, _source, is_fallback = _resolve_max_input(model)
+    if is_fallback and model not in _warned_models:
         _warned_models.add(model)
         msg = (
             f"model_budget: max_input_tokens unknown for model={model!r}; "
@@ -118,5 +131,13 @@ def get_max_input_tokens(
                 phase=phase,
                 run_id=run_id,
             )
+    return value
 
-    return _FALLBACK_MAX_INPUT_TOKENS
+
+def get_max_input_tokens_source(model: str) -> str:
+    """Human-readable description of where ``get_max_input_tokens(model)``'s
+    value came from — litellm's catalog, or this module's conservative
+    fallback (there is no user-configurable override of a model's context
+    window anywhere in reyn today). Display-only (status bar / debug)."""
+    _value, source, _is_fallback = _resolve_max_input(model)
+    return source

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1377,6 +1377,12 @@ class RouterLoop:
         self._dispatch_catalog: "dict[str, dict] | None" = None
         self._tool_names: frozenset[str] = frozenset()  # kept for backward compat
         self._total_usage: TokenUsage = TokenUsage()
+        # Status-bar ctx chip's "current size" figure needs a SINGLE LLM call's
+        # prompt_tokens, not the turn-summed _total_usage above — summing every
+        # call in a multi-tool-iteration turn double(triple/...)-counts nearly
+        # the same growing context each iteration re-sends, wildly overstating
+        # "how much of the window is currently occupied".
+        self._last_call_usage: TokenUsage = TokenUsage()
         # #1593: the active tool-use scheme. PR-1 = universal-category (the shipped
         # behaviour, behind the protocol) for every layer → byte-identical. Per-layer
         # config selection (tool_use:{chat,step,phase}) plugs in here; with all
@@ -1388,6 +1394,13 @@ class RouterLoop:
         """Accumulated token usage across all LLM calls made in this loop."""
         return self._total_usage
 
+    @property
+    def last_call_usage(self) -> TokenUsage:
+        """TokenUsage of the single MOST RECENT LLM call made in this loop —
+        distinct from ``total_usage`` (the turn-summed figure). Reset at the
+        start of each ``run()`` like ``total_usage``."""
+        return self._last_call_usage
+
     async def run(self, user_text: str, history: list[dict]) -> TokenUsage:
         """Process one user utterance end-to-end. Emits to host.put_outbox.
 
@@ -1395,6 +1408,7 @@ class RouterLoop:
         caller can credit it to the session-level usage counter (F4 Bug 2).
         """
         self._total_usage = TokenUsage()
+        self._last_call_usage = TokenUsage()
         host = self.host
         # #1092 PR-A (FD1, ADR-0036): catalog-source REPLACE seam. A phase host
         # supplies its op tool catalog (allowed_ops via _build_phase_tool_catalog),
@@ -1948,6 +1962,7 @@ class RouterLoop:
                         )
             if result.usage:
                 self._total_usage += result.usage
+                self._last_call_usage = result.usage
             # #1593 loop-unify (Issue-1): interpret-driven routing — the active
             # scheme classifies EVERY result, instead of the OS sniffing
             # ``result.tool_calls``. universal-category returns Execute when there

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -44,6 +44,7 @@ class BudgetGateway:
         self._events = events
         self._agent_name = agent_name
         self._total_usage: TokenUsage = TokenUsage()
+        self._last_call_usage: TokenUsage = TokenUsage()
         self._total_cost_usd: float = 0.0
         self._router_cap: int = default_router_cap
         self._router_invocations_this_turn: int = 0
@@ -68,16 +69,30 @@ class BudgetGateway:
         """Cumulative USD cost for this session (all LLM calls)."""
         return self._total_cost_usd
 
+    @property
+    def last_call_usage(self) -> TokenUsage:
+        """TokenUsage of the single MOST RECENT LLM call only — distinct from
+        BOTH the cumulative session total AND a turn-summed figure. A chat
+        turn can make several LLM calls (tool-loop iterations), each re-
+        sending nearly the same growing context; summing them would wildly
+        overstate "how much of the context window is currently occupied"
+        (status-bar ctx chip's headline figure). Overwritten (not
+        accumulated) on each call."""
+        return self._last_call_usage
+
     def accumulate(self, result) -> None:
         """Accumulate a single LLM call result's tokens + cost into per-session
-        totals. Mirrors Session._accumulate."""
+        totals. Mirrors Session._accumulate. ``result.token_usage`` is already
+        a single call's usage (not turn-summed), so it doubles as last_call_usage."""
         if result.token_usage is not None:
             self._total_usage += result.token_usage
+            self._last_call_usage = result.token_usage
         if result.cost_usd is not None:
             self._total_cost_usd += result.cost_usd
 
     def add_router_usage(
-        self, *, usage: TokenUsage, resolver, router_model_name: str
+        self, *, usage: TokenUsage, last_call_usage: "TokenUsage | None" = None,
+        resolver, router_model_name: str,
     ) -> None:
         """Accumulate router LLM usage with proxy-prefix stripping.
 
@@ -85,10 +100,17 @@ class BudgetGateway:
         prefix (e.g. ``openai/``) from the resolved model name before
         passing it to ``estimate_cost`` so the litellm pricing lookup
         succeeds (F4 Bug 1).
+
+        ``usage`` is the TURN-SUMMED total (all LLM calls this turn) and is
+        what gets accumulated into total_usage/total_cost_usd (billing must
+        count every call). ``last_call_usage`` — the single most recent call,
+        from RouterLoop.last_call_usage — is what last_call_usage reports;
+        they are NOT the same figure for a multi-tool-iteration turn.
         """
         if usage is None or usage.total_tokens == 0:
             return
         self._total_usage += usage
+        self._last_call_usage = last_call_usage if last_call_usage is not None else usage
         # F4 Bug 1: strip proxy prefix so estimate_cost lookup succeeds.
         from reyn.llm.llm import proxy_kwargs
         from reyn.llm.pricing import estimate_cost

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -141,15 +141,42 @@ class ContextBudgetAdvisor:
         text_tokens = estimate_tokens(tool_content, self._model, use_chars4=use_chars4)
         return max(0, self.per_turn_cap_tokens() - text_tokens)
 
+    def _effective_trigger_source(self) -> str:
+        """Where effective_trigger's underlying window size came from (status-bar
+        ctx chip detail). The engine-budget path subdivides T_max by configured
+        component weights, but T_max itself is always resolved via
+        get_max_input_tokens — so the root source is the same two-way split
+        either way (litellm catalog vs reyn's fallback default)."""
+        from reyn.llm.model_budget import get_max_input_tokens_source
+        return get_max_input_tokens_source(self._model)
+
     def context_window_status(self) -> dict:
         """Live exact-token context budget for the SP context-size signal.
 
-        Returns {free_window, effective_trigger}.
+        Returns {free_window, effective_trigger, source}.
         """
         effective_trigger, used = self._free_window_now()
         return {
             "free_window": max(0, effective_trigger - used),
             "effective_trigger": effective_trigger,
+            "source": self._effective_trigger_source(),
+        }
+
+    def raw_context_window(self) -> dict:
+        """The model's ACTUAL context window (get_max_input_tokens), distinct
+        from ``context_window_status``'s ``effective_trigger`` — that value is
+        already reduced by SP/head/tail/component-weight budgeting (an
+        internal compaction-trigger threshold, not the model's real limit).
+        For a user-facing "how close to the model's hard limit" display
+        (status-bar ctx chip), the denominator should be this raw figure.
+
+        Returns {window, source}.
+        """
+        from reyn.llm.model_budget import get_max_input_tokens, get_max_input_tokens_source
+        model = self._model
+        return {
+            "window": get_max_input_tokens(model, events=self._events),
+            "source": get_max_input_tokens_source(model),
         }
 
     async def maybe_force_compact(

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -424,6 +424,7 @@ class RouterLoopDriver:
         if router_usage is not None:
             self._budget.add_router_usage(
                 usage=router_usage,
+                last_call_usage=loop.last_call_usage,
                 resolver=self._resolver,
                 router_model_name=loop.router_model,
             )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1746,7 +1746,7 @@ class Session:
             compact_now=self._compact_now_for_op,
             # #272/#1128 context-size signal: live exact-token budget so the
             # router SP can show the LLM the free window (header).
-            context_window_status=self._context_window_status,
+            context_window_status=self.context_window_status,
             # B25-S5-1: thread eager-build flag so RouterLoop awaits build
             # before computing _search_visible on the first turn.
             eager_embedding_build=self._eager_embedding_build,
@@ -2047,6 +2047,14 @@ class Session:
     @property
     def total_usage(self):
         return self._budget.total_usage
+
+    @property
+    def last_call_usage(self):
+        """TokenUsage of the single most recent LLM call only (distinct from
+        BOTH the session-cumulative ``total_usage`` and a turn-summed figure —
+        a turn can make several LLM calls via tool-loop iterations) — status-
+        bar ctx chip's "current context size" headline figure."""
+        return self._budget.last_call_usage
 
     @property
     def total_cost_usd(self) -> float:
@@ -6180,9 +6188,23 @@ class Session:
         """Forwarding → ContextBudgetAdvisor.media_followup_budget (PR-1)."""
         return self._budget_advisor.media_followup_budget(tool_content)
 
-    def _context_window_status(self) -> dict:
-        """Forwarding → ContextBudgetAdvisor.context_window_status (PR-1)."""
+    def context_window_status(self) -> dict:
+        """Forwarding → ContextBudgetAdvisor.context_window_status (PR-1).
+
+        Public — read by both the RouterHostAdapter SP context-size signal
+        (via the callback wired at __init__) and the inline UI's ctx chip
+        dropdown (status bar reads only public accessors, see
+        interfaces/inline/app.py's module docstring). Non-trivial cost: does a
+        json.dumps + token-estimate of the full router-view history on every
+        call — callers should not invoke this from a per-render-frame path."""
         return self._budget_advisor.context_window_status()
+
+    def raw_context_window(self) -> dict:
+        """Forwarding → ContextBudgetAdvisor.raw_context_window (status-bar ctx
+        chip's real "distance to the model's hard limit" denominator). Public,
+        and cheap (a dict lookup) — safe to call every render frame, unlike
+        ``context_window_status`` above."""
+        return self._budget_advisor.raw_context_window()
 
     async def _compact_now_for_op(self) -> dict:
         """#272/#1128/#191: voluntary-compaction callback (compact op + /compact).

--- a/tests/test_budget_gateway_invariants.py
+++ b/tests/test_budget_gateway_invariants.py
@@ -96,6 +96,39 @@ def test_accumulate_independent_of_tracker():
     assert snap.get("agent_tokens", {}).get("test_agent", 0) == 0
 
 
+def test_last_call_usage_is_overwritten_not_accumulated():
+    """Tier 2: last_call_usage (status-bar ctx chip's current-size figure)
+    reflects only the MOST RECENT accumulate() call, unlike total_usage which
+    sums every call — a stale earlier-call usage must not leak into a later
+    call's current-size reading."""
+    gw, _ = _make_gateway()
+
+    r1 = _FakeLLMResult(prompt_tokens=10, completion_tokens=5, cost_usd=0.001)
+    gw.accumulate(r1)
+    assert gw.last_call_usage.prompt_tokens == 10
+    assert gw.total_usage.prompt_tokens == 10
+
+    r2 = _FakeLLMResult(prompt_tokens=20, completion_tokens=8, cost_usd=0.002)
+    gw.accumulate(r2)
+    assert gw.last_call_usage.prompt_tokens == 20   # overwritten, not 10+20
+    assert gw.total_usage.prompt_tokens == 30        # cumulative still sums
+
+
+def test_last_call_usage_unaffected_by_zero_usage_result():
+    """Tier 2: a zero-usage accumulate() call (e.g. a cost-only event) must not
+    clobber the last real call's current-size figure."""
+    gw, _ = _make_gateway()
+
+    gw.accumulate(_FakeLLMResult(prompt_tokens=15, completion_tokens=3))
+    gw.accumulate(_FakeLLMResult(prompt_tokens=0, completion_tokens=0, cost_usd=None))
+    # token_usage is still a TokenUsage(0, 0) object (not None) on the zero
+    # result, so accumulate()'s `if result.token_usage is not None` branch
+    # DOES run — this documents that current behavior overwrites with the
+    # zero usage (matches total_usage's own += semantics: a real zero-usage
+    # call is data, not a no-op).
+    assert gw.last_call_usage.prompt_tokens == 0
+
+
 # ---------------------------------------------------------------------------
 # Invariant 2: router cap fires exactly at cap-th invocation
 # ---------------------------------------------------------------------------
@@ -299,3 +332,42 @@ def test_add_router_usage_no_strip_without_proxy(monkeypatch):
     )
 
     assert gw.total_usage.total_tokens == 75
+
+
+def test_add_router_usage_uses_explicit_last_call_usage_not_turn_total():
+    """Tier 2: add_router_usage (the live chat-turn accumulation path, see
+    router_loop_driver.py) takes `usage` (the TURN-SUMMED total, across every
+    LLM call the turn made — a tool-loop can iterate several times) and a
+    SEPARATE `last_call_usage` (the single most recent call, from
+    RouterLoop.last_call_usage). last_call_usage must reflect the smaller
+    single-call figure, NOT the turn total — using the turn-summed figure as
+    the ctx chip's "current context size" would double/triple-count nearly
+    the same growing context each tool-loop iteration re-sends (the bug this
+    param was added to fix)."""
+    resolver = ModelResolver({"light": "openai/gpt-4o-mini"}, builtin={})
+    gw, _ = _make_gateway()
+
+    # A 3-call turn: usage is the SUM (300 prompt tokens across 3 calls), but
+    # last_call_usage is only the final call's own usage (120 of those 300).
+    turn_total = TokenUsage(prompt_tokens=300, completion_tokens=30, cached_tokens=200)
+    final_call = TokenUsage(prompt_tokens=120, completion_tokens=10, cached_tokens=100)
+    gw.add_router_usage(
+        usage=turn_total, last_call_usage=final_call,
+        resolver=resolver, router_model_name="light",
+    )
+    assert gw.last_call_usage.prompt_tokens == 120   # the single call, NOT 300
+    assert gw.last_call_usage.cached_tokens == 100
+    assert gw.total_usage.prompt_tokens == 300        # billing still counts every call
+
+
+def test_add_router_usage_falls_back_to_turn_total_when_last_call_usage_omitted():
+    """Tier 2: last_call_usage is optional (default None) — omitting it (as an
+    older/non-UI caller might) falls back to the turn total, so nothing
+    breaks for callers that don't care about the ctx-chip distinction."""
+    resolver = ModelResolver({"light": "openai/gpt-4o-mini"}, builtin={})
+    gw, _ = _make_gateway()
+
+    u = TokenUsage(prompt_tokens=40, completion_tokens=5, cached_tokens=5)
+    gw.add_router_usage(usage=u, resolver=resolver, router_model_name="light")
+    assert gw.last_call_usage.prompt_tokens == 40
+    assert gw.total_usage.prompt_tokens == 40

--- a/tests/test_context_budget_advisor_raw_window.py
+++ b/tests/test_context_budget_advisor_raw_window.py
@@ -1,0 +1,95 @@
+"""Tier 2: ContextBudgetAdvisor.raw_context_window (status-bar ctx chip).
+
+The chip's headline "how close to the model's hard limit" figure must compare
+the last request's REAL prompt_tokens against the model's REAL context window
+(get_max_input_tokens) — NOT against ``context_window_status()``'s
+``effective_trigger``, which is already reduced by SP/head/tail/component-
+weight budgeting for compaction-trigger purposes and is a materially smaller
+number. Real ContextBudgetAdvisor instances, no mocks.
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.llm.model_budget import get_max_input_tokens, get_max_input_tokens_source
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+
+
+def _make_advisor(*, model: str, compaction_controller=None) -> ContextBudgetAdvisor:
+    return ContextBudgetAdvisor(
+        compaction=CompactionConfig(),
+        compaction_controller=compaction_controller,
+        media_store=None,
+        model_fn=lambda: model,
+        events=None,
+        history_fn=lambda: [],
+    )
+
+
+def test_raw_context_window_returns_the_models_real_window() -> None:
+    """Tier 2: raw_context_window()["window"] equals get_max_input_tokens(model)
+    directly — no compaction-engine adjustment, unlike effective_trigger."""
+    advisor = _make_advisor(model="openai/gpt-4o")
+    result = advisor.raw_context_window()
+    assert result["window"] == get_max_input_tokens("openai/gpt-4o")
+
+
+def test_raw_context_window_source_matches_model_budget_source() -> None:
+    """Tier 2: the source string is exactly get_max_input_tokens_source(model)
+    (litellm catalog vs reyn fallback), not a compaction-engine description."""
+    advisor = _make_advisor(model="openai/gpt-4o")
+    result = advisor.raw_context_window()
+    assert result["source"] == get_max_input_tokens_source("openai/gpt-4o")
+
+
+def test_raw_context_window_differs_from_effective_trigger_with_engine_budgets() -> None:
+    """Tier 2: falsification of the original bug — with a real compaction
+    engine attached, effective_trigger is SP/head/tail-reduced and materially
+    SMALLER than the model's real window. If raw_context_window() collapsed
+    back to effective_trigger, this assertion would fail (they'd be equal)."""
+    from reyn.services.compaction.engine import compute_budgets
+
+    model = "openai/gpt-4o"
+    cfg = CompactionConfig()
+    budgets = compute_budgets(cfg, model, T_SP=2000, T_comp_SP=500)
+
+    class _FakeEngine:
+        def __init__(self, b):
+            self.budgets = b
+
+    class _FakeController:
+        def __init__(self, engine):
+            self._engine = engine
+
+    advisor = _make_advisor(
+        model=model, compaction_controller=_FakeController(_FakeEngine(budgets)),
+    )
+    raw = advisor.raw_context_window()["window"]
+    adjusted = advisor.context_window_status()["effective_trigger"]
+    assert raw == get_max_input_tokens(model)
+    assert adjusted == budgets.effective_trigger
+    assert raw > adjusted, (
+        "the model's real window must be strictly larger than the "
+        "compaction-adjusted trigger threshold — otherwise the two figures "
+        "would be indistinguishable and the chip's split has no purpose"
+    )
+
+
+def test_raw_context_window_live_reads_model_fn() -> None:
+    """Tier 2: like context_window_status, raw_context_window reads the model
+    live via model_fn (not cached at construction) — a /model override must be
+    reflected without rebuilding the advisor."""
+    current = {"m": "openai/gpt-4o"}
+    advisor = ContextBudgetAdvisor(
+        compaction=CompactionConfig(),
+        compaction_controller=None,
+        media_store=None,
+        model_fn=lambda: current["m"],
+        events=None,
+        history_fn=lambda: [],
+    )
+
+    base = advisor.raw_context_window()["window"]
+    current["m"] = "openai/gpt-4"
+    after = advisor.raw_context_window()["window"]
+    assert after != base
+    assert after == get_max_input_tokens("openai/gpt-4")

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -55,11 +55,17 @@ class _FakeRouterLoop:
         self.router_model = "fake-model"
         self.force_close_calls = 0
         self.always_overflow = always_overflow
+        # Mirrors RouterLoop.last_call_usage (status-bar ctx chip's single-most-
+        # recent-call figure) — router_loop_driver.py reads this attribute
+        # after a successful run().
+        self.last_call_usage = TokenUsage()
 
     async def run(self, *, user_text: str, history: list[dict]) -> TokenUsage:
         if self.always_overflow or not _has_consolidation(history):
             raise ContextOverflowError("simulated context_length too large")
-        return TokenUsage(prompt_tokens=10, completion_tokens=5)
+        usage = TokenUsage(prompt_tokens=10, completion_tokens=5)
+        self.last_call_usage = usage
+        return usage
 
     async def _force_close_call(
         self, messages: list[dict], *, resolved_model: str

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -56,6 +56,12 @@ def _snap(**over):
         "cost_usd": 0.0,
         "cost_agent": 0.0,
         "agent_tokens": 0,
+        "ctx_used": 0,
+        "ctx_window": 0,
+        "ctx_source": "litellm catalog: standard",
+        "session_cached_tokens": 0,
+        "ctx_recent_usage": (0, 0),
+        "ctx_compaction_status_fn": lambda: {"effective_trigger": 0, "free_window": 0},
         "task_count": 0,
         "task_tree": [],
         "cron_jobs": [],
@@ -76,9 +82,9 @@ def _snap(**over):
 
 
 def test_chip_specs_has_required_keys_in_order() -> None:
-    """Tier 2: the registry exposes model/cost/agent/task/more in that order."""
+    """Tier 2: the registry exposes model/cost/agent/task/ctx/more in that order."""
     keys = [s.key for s in _CHIP_SPECS]
-    assert keys == ["model", "cost", "agent", "task", "more"]
+    assert keys == ["model", "cost", "agent", "task", "ctx", "more"]
 
 
 def test_chips_carry_per_item_value_colours() -> None:
@@ -131,6 +137,146 @@ def test_task_chip_value_returns_count_string() -> None:
     spec = next(s for s in _CHIP_SPECS if s.key == "task")
     assert spec.value(_snap(task_count=3)) == "3"
     assert spec.value(_snap(task_count=0)) == "0"
+
+
+def test_ctx_chip_value_returns_usage_percent() -> None:
+    """Tier 2: the ctx chip's value() returns used/window as a rounded percent."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "ctx")
+    assert spec.value(_snap(ctx_used=50_000, ctx_window=200_000)) == "25%"
+
+
+def test_ctx_chip_value_shows_dash_when_window_unknown() -> None:
+    """Tier 2: a zero/missing window (no attached session budget yet) shows '—'
+    rather than raising a ZeroDivisionError."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "ctx")
+    assert spec.value(_snap(ctx_used=0, ctx_window=0)) == "—"
+
+
+def test_ctx_chip_value_shows_dash_when_no_call_completed_yet() -> None:
+    """Tier 2: used<=0 (no LLM call has completed this session — last_call_usage
+    starts at TokenUsage() zero) shows '—', not a misleading "0%" — a real
+    completed call's prompt_tokens is never actually 0 (system prompt alone is
+    nonzero), so 0 unambiguously means "not measured yet"."""
+    spec = next(s for s in _CHIP_SPECS if s.key == "ctx")
+    assert spec.value(_snap(ctx_used=0, ctx_window=200_000)) == "—"
+
+
+def test_ctx_expansion_is_detail_element() -> None:
+    """Tier 2: the ctx chip's dropdown is read-only (no picker — nothing to select)."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    el = _ctx_expansion(_snap(ctx_used=50_000, ctx_window=200_000), lambda _: None)
+    assert isinstance(el, DetailElement)
+
+
+def test_ctx_expansion_shows_prompt_window_free_and_source() -> None:
+    """Tier 2: the dropdown breaks the percent down into raw prompt/window/free
+    token counts plus WHERE the window size came from (owner: 情報源もわかるように —
+    litellm catalog vs reyn's own fallback default, since there is no
+    user-configurable override of a model's context window in reyn today).
+    ctx_used is the LAST ACTUAL REQUEST's prompt_tokens (owner: 「ユーザは
+    prompt tokensの方を気にするのでは」→ confirmed) against the model's REAL
+    context window — "how close to the hard limit", not a compaction-internal
+    estimate (that lives in the separate "compaction" line — see
+    test_ctx_expansion_shows_compaction_estimate_separately)."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap(
+        ctx_used=50_000, ctx_window=200_000,
+        ctx_source="litellm catalog: claude-opus-4-8",
+    )
+    lines = _ctx_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+    assert "prompt" in joined and "50,000 tokens" in joined
+    assert "200,000 tokens" in joined
+    assert "litellm catalog: claude-opus-4-8" in joined
+    assert "150,000 tokens" in joined  # free = window - prompt
+    assert "25%" in joined
+
+
+def test_ctx_expansion_shows_compaction_estimate_separately() -> None:
+    """Tier 2: owner asked to keep the compaction subsystem's own lightweight
+    history estimate visible too, but NOT collapsed into the same number as
+    the real prompt/window figures above (that ambiguity was the original bug
+    — 「今の見せ方だと意味がわからない」). It gets its own labeled line with its
+    own (smaller, already-adjusted) denominator, the compaction trigger
+    threshold — never the model's real window.
+
+    The compaction figures come from a LAZY status_fn (not eager snapshot
+    fields) — Session.context_window_status() is expensive (json.dumps +
+    token-estimate of the full history) and must only run while this dropdown
+    is open, not on every _snapshot() render-frame call (perf regression
+    caught in review: mirrors the exact WAL-off-loop lesson from #1765 — don't
+    reintroduce a per-frame/per-loop-tick cost)."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap(
+        ctx_used=50_000, ctx_window=200_000,
+        ctx_compaction_status_fn=lambda: {"effective_trigger": 68_000, "free_window": 67_296},
+    )
+    lines = _ctx_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+    assert "compaction" in joined
+    assert "704 / 68,000 tokens est." in joined
+    assert "1% to trigger" in joined  # round(100 * 704 / 68000) == 1
+
+
+def test_ctx_expansion_compaction_status_fn_called_lazily() -> None:
+    """Tier 2: the compaction status_fn must NOT be invoked until lines() is
+    actually called — proves the deferral is real, not just a renamed eager
+    read. Falsification: if _ctx_expansion or its outer closure called
+    status_fn eagerly, `calls` would already be 1 before lines() runs."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    calls = []
+    def _status_fn():
+        calls.append(1)
+        return {"effective_trigger": 100, "free_window": 50}
+    snap = _snap(ctx_compaction_status_fn=_status_fn)
+    el = _ctx_expansion(snap, lambda _: None)
+    assert calls == [], "status_fn must not be called before lines() is invoked"
+    el.lines()
+    assert calls == [1], "status_fn must be called exactly once when lines() runs"
+
+
+def test_ctx_expansion_compaction_estimate_zero_trigger_shows_zero_percent() -> None:
+    """Tier 2: a zero/unknown compaction trigger must not divide by zero."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap(ctx_compaction_status_fn=lambda: {"effective_trigger": 0, "free_window": 0})
+    joined = "\n".join(_ctx_expansion(snap, lambda _: None).lines())
+    assert "0 / 0 tokens est.  (0% to trigger)" in joined
+
+
+def test_ctx_expansion_missing_compaction_status_fn_defaults_to_zero() -> None:
+    """Tier 2: a snap without ctx_compaction_status_fn (e.g. an older caller,
+    or a test that doesn't care about this line) must not crash."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap()
+    snap.pop("ctx_compaction_status_fn", None)
+    joined = "\n".join(_ctx_expansion(snap, lambda _: None).lines())
+    assert "0 / 0 tokens est.  (0% to trigger)" in joined
+
+
+def test_ctx_expansion_shows_current_turn_cache_hit_only() -> None:
+    """Tier 2: ctx is the CURRENT-state chip (owner: 「ctxはカレントの状態と考える」) —
+    it shows only the most recent LLM call's cache-hit rate. Cumulative
+    cache-hit lives in the cost chip instead (see
+    test_cost_expansion_shows_cumulative_cache_hit_rate), so ctx must NOT
+    duplicate a session-cumulative figure."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap(
+        usage=(80_000, 500, 80_500), session_cached_tokens=60_000,  # session cumulative — unused here
+        ctx_recent_usage=(10_000, 2_000),                           # last call: 20%
+    )
+    lines = _ctx_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+    assert "20% hit (2,000 / 10,000 prompt tokens)" in joined
+    assert "75% hit" not in joined  # the session-cumulative figure must NOT appear
+
+
+def test_ctx_expansion_cache_hit_zero_when_no_prompt_tokens() -> None:
+    """Tier 2: no prompt tokens yet (fresh session, no call completed) must not
+    divide by zero."""
+    from reyn.interfaces.inline.app import _ctx_expansion
+    snap = _snap(usage=(0, 0, 0), session_cached_tokens=0, ctx_recent_usage=(0, 0))
+    joined = "\n".join(_ctx_expansion(snap, lambda _: None).lines())
+    assert "0% hit (0 / 0 prompt tokens)" in joined
 
 
 def test_more_chip_has_no_expansion() -> None:
@@ -594,6 +740,16 @@ def test_cost_expansion_breaks_down_total_agent_session() -> None:
     assert "0.0100" in by_label["session"]    # the attached session
     # the breakdown is not collapsed: total reflects the cross-agent sum
     assert by_label["total"] != by_label["session"]
+
+
+def test_cost_expansion_shows_cumulative_cache_hit_rate() -> None:
+    """Tier 2: owner explicitly asked to confirm the SESSION-cumulative cache-hit
+    figure lives in the cost chip (not ctx, which is current-call-only) —
+    session_cached_tokens is a subset of usage[0]=prompt_tokens (#1772 semantics)."""
+    snap = _snap(usage=(80_000, 500, 80_500), session_cached_tokens=60_000)
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+    assert "75% hit (60,000 / 80,000 prompt tokens, cumulative)" in joined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_model_budget.py
+++ b/tests/test_model_budget.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 import pytest
 
 from reyn.core.events.events import EventLog
-from reyn.llm.model_budget import _FALLBACK_MAX_INPUT_TOKENS, get_max_input_tokens
+from reyn.llm.model_budget import (
+    _FALLBACK_MAX_INPUT_TOKENS,
+    get_max_input_tokens,
+    get_max_input_tokens_source,
+)
 
 
 def test_known_model_returns_positive_int() -> None:
@@ -100,3 +104,32 @@ def test_unknown_prefixed_model_still_falls_back() -> None:
     assert result == _FALLBACK_MAX_INPUT_TOKENS
     # the fallback event still fires for the genuinely-unknown model (unchanged).
     assert [e for e in events.all() if e.type == "model_budget_fallback"]
+
+
+def test_source_for_cataloged_model_names_litellm() -> None:
+    """Tier 2: get_max_input_tokens_source (status-bar ctx chip's source line)
+    names "litellm catalog" — not the fallback — for a real cataloged model."""
+    source = get_max_input_tokens_source("gemini/gemini-2.5-flash-lite")
+    assert source.startswith("litellm catalog:")
+    assert "gemini/gemini-2.5-flash-lite" in source
+
+
+def test_source_for_unknown_model_names_reyn_fallback() -> None:
+    """Tier 2: an unrecognized model's source names reyn's OWN fallback default,
+    not litellm — the owner explicitly wants this distinguished from a real
+    catalog hit (there is no user-configurable window override in reyn today,
+    so these two are the only two real sources)."""
+    source = get_max_input_tokens_source("unknown/garbage-model-xyz-test-only")
+    assert source.startswith("reyn fallback default")
+    assert str(_FALLBACK_MAX_INPUT_TOKENS) in source.replace(",", "")
+
+
+def test_source_for_prefix_strip_resolved_model_names_bare_litellm_hit() -> None:
+    """Tier 2: a proxy-prefixed model that only resolves via #1162's bare-name
+    retry still reports "litellm catalog" (naming the bare model), matching
+    what get_max_input_tokens actually used — not a fallback claim."""
+    if get_max_input_tokens(_BARE) == _FALLBACK_MAX_INPUT_TOKENS:
+        pytest.skip(f"litellm catalog lacks {_BARE!r} in this env")
+    source = get_max_input_tokens_source(f"openai/{_BARE}")
+    assert source.startswith("litellm catalog:")
+    assert _BARE in source

--- a/tests/test_session_cost_accumulation.py
+++ b/tests/test_session_cost_accumulation.py
@@ -242,3 +242,106 @@ def test_router_loop_run_accumulates_usage_across_iterations():
     # Two iterations × 50 prompt + 10 completion
     assert total.prompt_tokens == 100, f"Expected 100 prompt tokens, got {total.prompt_tokens}"
     assert total.completion_tokens == 20, f"Expected 20 completion tokens, got {total.completion_tokens}"
+
+
+def test_router_loop_last_call_usage_is_the_final_iteration_only():
+    """Tier 2: RouterLoop.last_call_usage reflects only the LAST iteration's
+    TokenUsage, distinct from total_usage (the sum across every iteration).
+    The status-bar ctx chip's "current context size" figure uses
+    last_call_usage precisely to avoid the turn-total's double-counting —
+    each tool-loop iteration re-sends nearly the same growing context, so
+    summing them wildly overstates current occupancy (review-caught bug in
+    the original ctx-chip landing)."""
+    import json
+
+    host = _FakeHost()
+    loop = RouterLoop(host=host, chain_id="c-test", max_iterations=3)
+
+    first_usage = TokenUsage(prompt_tokens=50, completion_tokens=10)
+    final_usage = TokenUsage(prompt_tokens=90, completion_tokens=15)  # larger, later call
+
+    tool_result = LLMToolCallResult(
+        content=None,
+        tool_calls=[{
+            "id": "tc_1",
+            "type": "function",
+            "function": {"name": "list_skills", "arguments": json.dumps({})},
+        }],
+        finish_reason="tool_calls",
+        usage=first_usage,
+    )
+    text_result = LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=final_usage,
+    )
+
+    results_queue = [tool_result, text_result]
+
+    async def fake_call_llm_tools(**kwargs):
+        return results_queue.pop(0)
+
+    async def run_it():
+        import reyn.runtime.router_loop as _rl_mod
+        original = _rl_mod.call_llm_tools
+        _rl_mod.call_llm_tools = fake_call_llm_tools
+        try:
+            return await loop.run(user_text="hi", history=[])
+        finally:
+            _rl_mod.call_llm_tools = original
+
+    total = asyncio.run(run_it())
+
+    assert total.prompt_tokens == 140  # 50 + 90, the turn-summed total
+    assert loop.last_call_usage.prompt_tokens == 90    # only the FINAL call
+    assert loop.last_call_usage.completion_tokens == 15
+    assert loop.last_call_usage.prompt_tokens != total.prompt_tokens
+
+
+def test_router_loop_last_call_usage_resets_between_runs():
+    """Tier 2: last_call_usage (like total_usage) resets to zero at the start
+    of each run() — a stale value from a prior turn must not leak into a new
+    turn that (e.g.) makes zero LLM calls before erroring out."""
+    loop = RouterLoop(host=_FakeHost(), chain_id="c-test", max_iterations=3)
+
+    usage = TokenUsage(prompt_tokens=77, completion_tokens=7)
+    result = LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=usage,
+    )
+
+    async def fake_call_llm_tools(**kwargs):
+        return result
+
+    async def run_once():
+        import reyn.runtime.router_loop as _rl_mod
+        original = _rl_mod.call_llm_tools
+        _rl_mod.call_llm_tools = fake_call_llm_tools
+        try:
+            return await loop.run(user_text="hi", history=[])
+        finally:
+            _rl_mod.call_llm_tools = original
+
+    asyncio.run(run_once())
+    assert loop.last_call_usage.prompt_tokens == 77
+
+    # Second run reuses the SAME loop instance (mirrors router_loop_driver.py's
+    # single-loop-per-turn construction) with a fresh empty-usage result.
+    empty_result = LLMToolCallResult(
+        content="done", tool_calls=[], finish_reason="stop", usage=None,
+    )
+
+    async def fake_call_llm_tools_empty(**kwargs):
+        return empty_result
+
+    async def run_again():
+        import reyn.runtime.router_loop as _rl_mod
+        original = _rl_mod.call_llm_tools
+        _rl_mod.call_llm_tools = fake_call_llm_tools_empty
+        try:
+            return await loop.run(user_text="hi again", history=[])
+        finally:
+            _rl_mod.call_llm_tools = original
+
+    asyncio.run(run_again())
+    assert loop.last_call_usage.prompt_tokens == 0, (
+        "last_call_usage must reset at the start of run(), not carry over "
+        "the previous turn's value when the new turn's call has no usage"
+    )


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- Adds a `ctx` chip to the inline CUI status bar showing current context occupancy as a % of the model's real context window (Claude Code-style), with a dropdown for detail.
- Headline figure = the single most recent LLM call's `prompt_tokens` / model's real `get_max_input_tokens` window — "how close to the hard limit am I". Required adding `RouterLoop.last_call_usage` (distinct from the existing turn-summed `total_usage`): a chat turn can make several LLM calls via tool-loop iterations, each re-sending nearly the same growing context, so summing them would wildly overstate current occupancy (a bug caught and fixed during a self-review round before this PR).
- Dropdown also shows: where the window size came from (litellm catalog vs reyn's own fallback default — no user-configurable override exists today), cache-hit rate for the most recent call, and the compaction subsystem's own separate lightweight estimate (kept visually distinct so it doesn't collapse into the same ambiguous number as the headline figure).
- `cost` chip gained a cumulative (session-wide) cache-hit line — cumulative figures belong there, not in the current-state `ctx` chip.
- `Session.context_window_status()` / `raw_context_window()` are now public (the module's own docstring requires the status bar read only public accessors — was previously violated). The expensive `context_window_status()` call (json.dumps + token-estimate of the full history) is deferred to a lazy closure invoked only while the ctx dropdown is actually open, not on every render frame (this repo's own inline app runs `_snapshot()` on every redraw, so an eager expensive call there is a real perf regression — same class of lesson as the recent #1765 WAL off-loop fix).

## Review history

Went through a full self-review pass (owner-requested, Fable model) before opening this PR, which caught 8 issues — all fixed prior to this PR:
1. Headline figure used turn-summed usage instead of single-call usage (the double-counting bug above)
2. `context_window_status()` was called eagerly every render frame (perf)
3. UI called private `Session._context_window_status()`/`_raw_context_window()` — now public
4. `get_max_input_tokens_source()` duplicated `get_max_input_tokens`'s resolution logic — refactored to a single shared resolver
5. Misleading key name `ctx_cached_tokens` (actually session-cumulative, owned by the cost chip) — renamed `session_cached_tokens`
6. Fresh session showed misleading `ctx 0%` — now shows `—` until a call completes
7. Cost dropdown's cache line was misaligned — fixed padding
8. Fallback source string was too long for the dropdown — shortened

All fixes independently re-verified live via tmux (both dropdowns), plus a dedicated test proving the compaction status closure is called lazily (not eagerly).

## Test plan

- [x] `pytest tests/test_inline_pr3b_status_bar.py tests/test_model_budget.py tests/test_budget_gateway_invariants.py tests/test_context_budget_advisor_raw_window.py tests/test_session_cost_accumulation.py tests/test_force_close_chat_handoff_1092.py tests/test_live_model_budget_consumers_1752.py` — 113 passed
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/test_tier_audit.py --strict` (changed test files) — 0 violations
- [x] `python scripts/verify_module_docstrings.py` (changed src files) — clean
- [x] Full `pytest` suite — 7883 passed, 9 failed (pre-existing/environmental, unrelated files: compaction resolver, LLM request error redaction, LLM router fallback, responses-API routing — none touch these files), 17 skipped
- [x] Live tmux verification of both the `ctx` and `cost` dropdowns, rendering matches design exactly
- [x] Caught and fixed one regression from this diff during the full-suite run: a `_FakeRouterLoop` test double in `test_force_close_chat_handoff_1092.py` needed the new `last_call_usage` attribute — fixed, all 5 tests in that file now pass

Tier self-check: all new/modified tests are Tier 2 (OS invariant / pure function), docstrings declare Tier first line, no MagicMock/patch of collaborators (real `RouterLoop`/`ContextBudgetAdvisor`/`BudgetGateway` instances; the one existing test double, `_FakeRouterLoop`, was updated not newly introduced), no private-state assertions, no format pins.