### PR TITLE
fix: swap assistant reply marker from U+23FA to U+25CF (Windows emoji fallback)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -594,7 +594,7 @@ still use the plain `ConsoleChatRenderer`.
 
 | Feature | Description | Documentation |
 |---------|-------------|---------------|
-| Conversation view | Streaming conversation in scrollback with terracotta-accented `⏺`/`⎿` markers per message kind (agent/status/error/intervention/trace) | — |
+| Conversation view | Streaming conversation in scrollback with terracotta-accented `●`/`⎿` markers per message kind (agent/status/error/intervention/trace) | — |
 | Status chips | Live one-line chip bar above the input: Agents / Cost / Model / Ctx / Tools / MCP / Skills / Hooks / Pipes / Cron / Tasks, each expandable in place — Ctx shows current context size vs the model's context window as a Claude Code-style %, with a dropdown for window source (litellm catalog vs fallback), cache-hit rate, and the compaction subsystem's own separate estimate | — |
 | Tool-result summaries | `summarize_tool_result` renders a best-effort one-line, per-tool summary (e.g. `Read 42 lines`, `3 matches`); always degrades gracefully to a truncated repr, never a full content preview | — |
 | Above-input region | Closed-set interventions (confirm/select/grant-deny) and command UIs (e.g. the `/rewind` checkpoint picker) render as a selectable row list above the input, rather than a modal | [Permission model](concepts/runtime/permission-model.md) |

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -302,11 +302,11 @@ _SPINNER = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 # Glyphs are distinct per kind so the eye separates them; colour is reserved for
 # STATE — default terminal fg (_CC_TEXT), then amber=needs-you, red=error,
 # green=done, dim=ambient/low — so a coloured glyph always signals something to
-# notice. Distinct glyphs: ⏺ assistant · ❯ you · ▸ tool · ◆ needs-you · ✗ error ·
+# notice. Distinct glyphs: ● assistant · ❯ you · ▸ tool · ◆ needs-you · ✗ error ·
 # ✓ done · · status · ⎿ detail.
 _KIND_LINE = {
     "user":         ("❯ ",   _CC_TEXT,   _CC_DIM),   # your input  (default fg, + bg block)
-    "agent":        ("⏺ ",   _CC_TEXT,   _CC_TEXT),  # normal reply — terminal default fg
+    "agent":        ("● ",   _CC_TEXT,   _CC_TEXT),  # normal reply — terminal default fg
     "reasoning":    ("· ",   _CC_DIM,    _CC_DIM),   # model thinking (dim; only shown when chat.reasoning.display=true)
     "intervention": ("◆ ",   _CC_WARN,   "bold"),    # needs you   — amber
     "error":        ("✗ ",   _CC_ERR,    _CC_ERR),   # error       — red
@@ -616,7 +616,7 @@ def _body_renderable(kind: str, text: str, body_style: str):
     if kind == "agent":
         # rich.Markdown centers H1 by default (LEVEL_ALIGN = {"h1": "center"}).
         # In a gutter-grid chat context that produces heavy leading whitespace —
-        # "⏺                          My Heading". Override to left for all levels.
+        # "●                          My Heading". Override to left for all levels.
         class _LeftHeading(Heading):
             LEVEL_ALIGN = {tag: "left" for tag in Heading.LEVEL_ALIGN}
 
@@ -651,7 +651,7 @@ def format_inline_message(msg: OutboxMessage):
         from reyn.interfaces.repl.present_renderer import render_presentation_nodes
         return render_presentation_nodes(meta.get("nodes", []))
 
-    # Tool-call rows. ▸ marks an invocation (distinct from the ⏺ assistant reply);
+    # Tool-call rows. ▸ marks an invocation (distinct from the ● assistant reply);
     # the ⎿ result / failure rows nest one level under it (2-space indent).
     if kind == "tool_call_started":
         tool = str(meta.get("tool", msg.text))
@@ -704,7 +704,7 @@ class InlineChatRenderer(ChatRenderer):
     reaches the terminal without corrupting the prompt). Conversation history
     stays in the terminal's own scrollback; only the prompt is live below.
 
-    PR1 (cutover) scope: `⏺`/`⎿` symbols + terracotta accent + per-kind
+    PR1 (cutover) scope: `●`/`⎿` symbols + terracotta accent + per-kind
     formatting. The rule-sandwiched input bar, navigable status bar, and
     in-conversation animations land in follow-up PRs (a custom prompt_toolkit
     Application that replaces the PromptSession input).

--- a/tests/test_inline_pr2_tool_rows.py
+++ b/tests/test_inline_pr2_tool_rows.py
@@ -1,6 +1,6 @@
 """Tier 2: inline CC-style tool rows + working-indicator contract.
 
-Tool-call OutboxMessages render as ⏺ Tool(args) / ⎿ result / ⎿ ✗ error, and the
+Tool-call OutboxMessages render as ● Tool(args) / ⎿ result / ⎿ ✗ error, and the
 working indicator turns on/off with the turn lifecycle. Assertions are on the
 public surfaces (`.plain`, `bottom_toolbar()`), not whitespace or private state.
 """
@@ -29,7 +29,7 @@ def _plain(kind: str, text: str, meta: dict) -> str:
 
 
 def test_tool_started_shows_invoke_marker_tool_and_args() -> None:
-    """Tier 2: tool_call_started → ▸ invocation marker (distinct from the ⏺
+    """Tier 2: tool_call_started → ▸ invocation marker (distinct from the ●
     assistant reply) + tool name + arg summary."""
     out = _plain("tool_call_started", "read_file",
                  {"tool": "read_file", "args": {"path": "docs/x.md"}})

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -60,13 +60,13 @@ def test_agent_heading_renders_left_not_centered() -> None:
 
     rich.Markdown centers H1 by default (LEVEL_ALIGN = {"h1": "center"}) which
     produces many leading spaces inside the gutter-grid body column:
-    "⏺                          My Heading". The _ChatMarkdown override makes all
+    "●                          My Heading". The _ChatMarkdown override makes all
     heading levels left-aligned so headings sit at the left edge of the body column,
     matching the CC chat aesthetic."""
     out = _plain("agent", "# Heading Title\nsome text", width=80)
     heading_line = next((ln for ln in out.split("\n") if "Heading Title" in ln), None)
     assert heading_line is not None, "heading line not found in output"
-    # Left-aligned: the heading text follows the gutter marker (⏺) with at most
+    # Left-aligned: the heading text follows the gutter marker (●) with at most
     # a small indent. Centered: ~30+ spaces precede the text in an 80-wide render.
     leading = len(heading_line) - len(heading_line.lstrip())
     assert leading < 10, (
@@ -81,10 +81,10 @@ def test_wrapped_agent_body_hang_indents_clear_of_the_gutter() -> None:
     lines = [ln for ln in out.split("\n") if ln.strip()]
     # a wrapped continuation line exists, indented into the body column with no
     # marker → the long body did wrap AND hang-indented clear of the gutter
-    assert any(c.startswith("  ") and "⏺" not in c for c in lines)
+    assert any(c.startswith("  ") and "●" not in c for c in lines)
     # the marker only ever LEADS a line (it never appears inside the body / in the
     # gutter of a continuation line)
-    assert all(("⏺" not in c) or c.startswith("⏺") for c in lines)
+    assert all(("●" not in c) or c.startswith("●") for c in lines)
 
 
 def test_long_unbreakable_token_folds_instead_of_truncating() -> None:
@@ -116,9 +116,9 @@ def test_user_echo_leads_with_input_marker_and_keeps_text() -> None:
 
 
 def test_agent_line_leads_with_dot_marker_and_keeps_text() -> None:
-    """Tier 2: an agent message renders with the ⏺ marker and its text."""
+    """Tier 2: an agent message renders with the ● marker and its text."""
     out = _plain("agent", "hello world")
-    assert "⏺" in out
+    assert "●" in out
     assert "hello world" in out
 
 
@@ -164,13 +164,13 @@ def test_intervention_keeps_actor_prefix_when_present() -> None:
 
 def test_kinds_use_distinct_markers() -> None:
     """Tier 2: message kinds carry distinct glyphs so the eye separates them — the
-    assistant ⏺ is not reused for an intervention (◆) or a tool invocation (▸)."""
+    assistant ● is not reused for an intervention (◆) or a tool invocation (▸)."""
     agent = _plain("agent", "x")
     interv = _plain("intervention", "x")
     tool = _plain("tool_call_started", "", {"tool": "Bash", "args": {}})
-    assert "⏺" in agent
-    assert "◆" in interv and "⏺" not in interv
-    assert "▸" in tool and "⏺" not in tool
+    assert "●" in agent
+    assert "◆" in interv and "●" not in interv
+    assert "▸" in tool and "●" not in tool
 
 
 def test_tool_call_completed_renders_corner_marker_and_summary() -> None:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

- The assistant-reply gutter marker (`⏺`) used **U+23FA** (BLACK CIRCLE FOR RECORD, Miscellaneous Technical block) — the same codepoint Claude Code uses (owner confirmed by pasting the literal character copied from Claude Code — identical codepoint).
- On Windows, several terminal/font configurations fall back to a colored emoji-style glyph for this Unicode block, rendering the marker completely differently from its intended plain monochrome appearance (owner-reported symptom: turns into a colored/emoji-style icon on Windows).
- Swapped to **U+25CF** (`●`, BLACK CIRCLE, Geometric Shapes block), which has far more consistent plain-glyph coverage across monospace fonts on all platforms including Windows, avoiding the color-fallback issue while keeping the same visual weight/size. Diverges from Claude Code's literal codepoint by one character, but is visually near-identical and fixes the cross-platform rendering bug.
- Scope: only the `"agent"` kind's gutter glyph in `_KIND_LINE` (`src/reyn/interfaces/repl/renderer.py`) — every other kind (user/reasoning/intervention/error/status/system/trace) already used a distinct glyph, unaffected.

## Test plan

- [x] `pytest tests/test_inline_pr2_tool_rows.py tests/test_inline_renderer_cutover.py` — 41 passed
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/repl/renderer.py` — clean
- [x] Repo-wide grep confirms no stray `⏺` (U+23FA) references remain anywhere in src/tests/docs
- [x] Live tmux verification: sent a real turn, confirmed the rendered reply marker is exactly U+25CF (`●`) by inspecting the captured pane's codepoints programmatically

Tier self-check: both modified test files' assertions are Tier 2 (pure rendering function output), asserting on the intentional glyph choice (a real product decision, not incidental formatting) — updated to the new literal character, no format pins beyond the intended contract.