### PR TITLE
docs: deliverable-4 #2 — dead tagline sweep, website/copy.yaml

### DIFF
--- a/website/copy.yaml
+++ b/website/copy.yaml
@@ -24,9 +24,8 @@ PAGE_TITLE: "Reyn — predictable LLM workflows"
 # no per-platform override is provided. Aim for 120–160 chars; match the LP
 # hero lede tone without repeating it word-for-word.
 META_DESCRIPTION: >-
-  LLM agent workflow OS with a Markdown DSL. Phase transitions are
-  constrained, validated, and replayable — predictability for production
-  agents, not just experiments.
+  Reyn is an operating system for LLM agents. Every action is typed,
+  permissioned, audited, and recoverable by construction.
 
 # Canonical URL: the production landing-page URL. Update this together with
 # `site_url` in mkdocs.yml when the project moves to a custom domain
@@ -40,7 +39,7 @@ CANONICAL_URL: "https://tya5.github.io/reyn/"
 # custom domain once that lands.
 OG_TITLE: "Reyn — gives you the reins"
 OG_IMAGE: "https://tya5.github.io/reyn/assets/banner-hero-reyn-main.png"
-OG_IMAGE_ALT: "Reyn — LLM agent workflow OS, on a clay-coloured banner"
+OG_IMAGE_ALT: "Reyn — an operating system for LLM agents, on a clay-coloured banner"
 
 # ── header / nav ────────────────────────────────────────────────────────────
 NAV_ARCH: "Architecture"
@@ -50,11 +49,12 @@ NAV_GITHUB: "GitHub"
 NAV_GITHUB_HREF: "https://github.com/tya5/reyn"
 
 # ── hero ────────────────────────────────────────────────────────────────────
-HERO_EYEBROW: "Open-source LLM workflow OS"
+HERO_EYEBROW: "Open-source agent OS"
 HERO_H1_HTML: "Many agents.<br/>One pair of <em>reins.</em>"
 HERO_LEDE: >-
-  Reyn is an LLM workflow OS. Phase transitions are constrained, validated,
-  and replayable — predictability for production agents, not just experiments.
+  Reyn is an operating system for LLM agents — they decide, organize, and
+  orchestrate; the OS makes every action typed, permissioned, audited, and
+  recoverable by construction.
 HERO_CTA_PRIMARY: "Get Started"
 HERO_CTA_SECONDARY: "Read the docs"
 


### PR DESCRIPTION
**[docs-maintainer]** — deliverable-4 (charter de-drift), task #2 (dead tagline sweep), for #2717.

## Scope
The dead "LLM workflow OS — phase transitions as a constrained decision graph" tagline was fixed in 5 locations by #2720/#2724 (docs/index.md, docs/index.ja.md, docs/start.md, docs/start.ja.md, `.mkdocs/mkdocs.yml` `site_description`). Swept the rest of the repo and found `website/copy.yaml` — the landing-page copy source of truth — still carrying the same pattern:

- `META_DESCRIPTION` → T1-aligned wording, trimmed to the file's own noted 120–160 char budget (122 chars)
- `HERO_EYEBROW`: "Open-source LLM workflow OS" → "Open-source agent OS"
- `HERO_LEDE` → the constitution's T1 hero line verbatim
- `OG_IMAGE_ALT` → matching wording

Verified `python website/build.py` still substitutes cleanly (`wrote website/dist/index.html; 42 new tokens`, `wrote website/dist/architecture.html; 33 new tokens`). `dist/` output is gitignored, not committed.

## Not in scope for this PR — flagging separately
Found deeper drift that's a bigger job than a tagline swap, so it's not touched here:

- `S02_HEADING_HTML`/`S02_BODY_P1`/`S02_BODY_P2` ("How it works") and `S03_*` ("Key concepts") describe the product as "A Skill is a directed graph of Phases" / "OS routes work between Phases" — the deleted phase-graph engine, described as current architecture.
- `ARCH_S01_BODY` ("Skills describe directed phase graphs. Phases loop the LLM through one task at a time...") — same pattern on the architecture page.
- `website/architecture.html:389` — a hardcoded mermaid diagram (`I05["05 · Skill"]` → `PG["Phase Graph + Transitions"]`, `I06["06 · Phase"]` → `PRE/LO/LP`) laying out the entire deleted 7-stage phase-graph pipeline as "how Reyn works."

These require a genuine content/diagram rewrite reflecting the current inline-CUI + Control-IR-op + unified-ToolRegistry architecture — a product/design-copy decision, not a mechanical docs fix. Recommend scoping as its own follow-up (possibly with architect/owner input on the replacement narrative) rather than folding into this sweep.

## Test plan
- [x] `python website/build.py` — clean substitution, no missing/unused-token warnings beyond baseline
- [x] `mkdocs build --strict` (from `.mkdocs/`) — clean (unaffected file, sanity-checked anyway)
- [x] `git diff | grep -oE "#[0-9]{3,4}"` sweep for stray issue-number refs — none found