### PR TITLE
fix: reorder status-bar chips — cost between task and ctx

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -414,12 +414,12 @@ _MORE_SUB_CHIP_SPECS = [
 _CHIP_SPECS = [
     ChipSpec("model", "model", lambda s: str(s["model"]), _model_expansion,
              value_color=_CC_ACCENT),
-    ChipSpec("cost",  "cost",  lambda s: f"${s['cost_agent']:.4f}", _cost_expansion,
-             value_color=_CC_DONE),
     ChipSpec("agent", "agent", lambda s: str(s["attached_name"] or "—"), _agent_expansion,
              value_color=_CC_COOL),
     ChipSpec("task",  "task",  lambda s: str(s.get("task_count", 0)), _task_expansion,
              value_color=_CC_WARN),
+    ChipSpec("cost",  "cost",  lambda s: f"${s['cost_agent']:.4f}", _cost_expansion,
+             value_color=_CC_DONE),
     ChipSpec("ctx",   "ctx",   _ctx_pct, _ctx_expansion,
              value_color=_CC_COOL),
     # "more" has no `expansion` — Enter on it opens the level-2 sub-bar

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -82,9 +82,10 @@ def _snap(**over):
 
 
 def test_chip_specs_has_required_keys_in_order() -> None:
-    """Tier 2: the registry exposes model/cost/agent/task/ctx/more in that order."""
+    """Tier 2: the registry exposes model/agent/task/cost/ctx/more in that order
+    (owner: cost moved between task and ctx)."""
     keys = [s.key for s in _CHIP_SPECS]
-    assert keys == ["model", "cost", "agent", "task", "ctx", "more"]
+    assert keys == ["model", "agent", "task", "cost", "ctx", "more"]
 
 
 def test_chips_carry_per_item_value_colours() -> None:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Owner requested reordering the inline CUI status-bar chips: `cost` moved from its old position (right after `model`) to between `task` and `ctx`.

- Was: `model / cost / agent / task / ctx / more`
- Now: `model / agent / task / cost / ctx / more`

Pure `_CHIP_SPECS` list reorder — no behavior change to any individual chip's value/expansion logic.

## Test plan

- [x] `pytest tests/test_inline_pr3b_status_bar.py` — 75 passed (order-assertion test updated)
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/app.py` — clean
- [x] Live tmux verification: status bar renders `model │ agent │ task │ cost │ ctx │ …` in the new order

Tier self-check: the one modified test is Tier 2 (pure list-order assertion), docstring declares Tier first line, no mocks/private-state/format pins beyond the intended chip-order contract.