### PR TITLE
feat: canonical_degraded runtime invariant (FP-0056 v2 piece #2 — M2 safety net)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -169,6 +169,20 @@ def _is_error(result: dict) -> bool:
     return bool(result.get("isError")) or result.get("status") == "error"
 
 
+def _explicit_empty(text: str, marker: str) -> str:
+    """Render a legit-empty SUCCESS body (an empty file read, a no-output command, an empty
+    template render, …) as an EXPLICIT marker instead of a blank string.
+
+    Two reasons (FP-0056 v2 piece #2): (1) a blank ``text`` with no attachments on a non-error
+    result would spuriously fire the runtime ``canonical_degraded`` invariant, which exists to catch
+    a *success-mapper losing content it had* (M2) — a genuinely-empty success is not that loss;
+    (2) an explicit "(empty file)" / "(no output)" is better LLM UX than a blank tool result the
+    model has to guess about. Only mappers whose success path can legitimately produce no output
+    wrap their body here; a mapper that regresses to empty when it should always produce something
+    (or an unknown future mapper) still fires the invariant."""
+    return text if text.strip() else marker
+
+
 def mcp_to_canonical(result: dict) -> CanonicalToolResult:
     """MCP result → canonical. ``content`` (joined text) → ``text``; ``structured``
     (structuredContent) + ``media_blocks`` → typed ``attachments`` (a large ``structured`` is
@@ -184,8 +198,14 @@ def mcp_to_canonical(result: dict) -> CanonicalToolResult:
     for block in result.get("media_blocks") or []:
         attachments.append({"kind": "media", "block": block})
     meta = {"isError": True} if _is_error(result) else {}
+    text = result.get("content", "") or ""
+    # A successful MCP call with no content AND no attachments renders an explicit empty (else the
+    # canonical_degraded invariant fires on a legit no-output tool). An error keeps its (possibly
+    # terse) message untouched; an attachment-carrying result already has visible content.
+    if not attachments and not _is_error(result):
+        text = _explicit_empty(text, "(no content)")
     return CanonicalToolResult(
-        text=result.get("content", "") or "",
+        text=text,
         attachments=attachments,
         source_ref=None,
         meta=meta,
@@ -209,8 +229,11 @@ def mcp_read_resource_to_canonical(result: dict) -> CanonicalToolResult:
         elif "blob" in item:
             attachments.append({"kind": "structured", "data": item})
     meta = {"isError": True} if _is_error(result) else {}
+    text = "\n".join(text_parts)
+    if not attachments and not _is_error(result):
+        text = _explicit_empty(text, "(no content)")
     return CanonicalToolResult(
-        text="\n".join(text_parts),
+        text=text,
         attachments=attachments,
         source_ref=None,
         meta=meta,
@@ -234,8 +257,11 @@ def mcp_get_prompt_to_canonical(result: dict) -> CanonicalToolResult:
         elif content is not None:
             attachments.append({"kind": "structured", "data": content})
     meta = {"isError": True} if _is_error(result) else {}
+    text = "\n".join(text_parts)
+    if not attachments and not _is_error(result):
+        text = _explicit_empty(text, "(no content)")
     return CanonicalToolResult(
-        text="\n".join(text_parts),
+        text=text,
         attachments=attachments,
         source_ref=None,
         meta=meta,
@@ -249,6 +275,7 @@ def web_fetch_to_canonical(result: dict) -> CanonicalToolResult:
     is dropped."""
     content = result.get("content")
     text = content if content else str(result.get("preview") or "")
+    text = _explicit_empty(text, "(no content)")
     meta: dict[str, Any] = {}
     if result.get("truncated"):
         meta["truncated"] = True
@@ -281,6 +308,9 @@ def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
         text = f"{stdout}\n{stderr}" if stdout else stderr
     else:
         text = stdout
+    # A command that produced no stdout/stderr (e.g. mkdir/touch/mv) renders an explicit empty so the
+    # canonical_degraded invariant does not fire on a legit no-output exec (returncode carries signal).
+    text = _explicit_empty(text, "(no output)")
     meta: dict[str, Any] = {}
     returncode = result.get("returncode")
     if returncode:  # nonzero (or truthy) only — a 0 exit is not actionable signal
@@ -304,9 +334,16 @@ def run_pipeline_to_canonical(result: dict) -> CanonicalToolResult:
     ruling)."""
     output = result.get("output")
     if isinstance(output, str):
-        return CanonicalToolResult(text=output, attachments=[], source_ref=None, meta={})
-    attachments = [{"kind": "structured", "data": output}] if output is not None else []
-    return CanonicalToolResult(text="", attachments=attachments, source_ref=None, meta={})
+        return CanonicalToolResult(
+            text=_explicit_empty(output, "(no output)"), attachments=[], source_ref=None, meta={},
+        )
+    if output is None:
+        # A pipeline that completed with no final output: explicit empty text (no structured to carry
+        # it), so a legit no-output run does not fire the canonical_degraded invariant.
+        return CanonicalToolResult(text="(no output)", attachments=[], source_ref=None, meta={})
+    return CanonicalToolResult(
+        text="", attachments=[{"kind": "structured", "data": output}], source_ref=None, meta={},
+    )
 
 
 def run_pipeline_async_to_canonical(result: dict) -> CanonicalToolResult:
@@ -363,8 +400,13 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
         attachments = [
             {"kind": "media", "block": block} for block in (result.get("media_blocks") or [])
         ]
+        text = result.get("content", "") or ""
+        # An empty file read (no media blocks carrying an image body) renders an explicit empty so the
+        # canonical_degraded invariant does not fire on a legit read of a genuinely empty file.
+        if not attachments:
+            text = _explicit_empty(text, "(empty file)")
         return CanonicalToolResult(
-            text=result.get("content", "") or "", attachments=attachments, source_ref=None, meta=meta,
+            text=text, attachments=attachments, source_ref=None, meta=meta,
         )
 
     if op == "grep":
@@ -445,8 +487,9 @@ def reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
         )
     if "content" in result:
         meta = {"path": result["path"]} if result.get("path") is not None else {}
+        text = _explicit_empty(result.get("content", "") or "", "(empty file)")
         return CanonicalToolResult(
-            text=result.get("content", "") or "", attachments=[], source_ref=None, meta=meta,
+            text=text, attachments=[], source_ref=None, meta=meta,
         )
     if "entries" in result:
         entries = result.get("entries") or []
@@ -492,8 +535,9 @@ def render_template_to_canonical(result: dict) -> CanonicalToolResult:
     undefined_vars = result.get("undefined_vars")
     if undefined_vars:
         meta["undefined_vars"] = undefined_vars
+    text = _explicit_empty(result.get("rendered", "") or "", "(empty render)")
     return CanonicalToolResult(
-        text=result.get("rendered", "") or "", attachments=[], source_ref=None, meta=meta,
+        text=text, attachments=[], source_ref=None, meta=meta,
     )
 
 
@@ -571,8 +615,9 @@ def judge_output_to_canonical(result: dict) -> CanonicalToolResult:
         value = result.get(key)
         if value is not None:
             meta[key] = value
+    text = _explicit_empty(str(result.get("reason", "") or ""), "(no reason given)")
     return CanonicalToolResult(
-        text=str(result.get("reason", "") or ""), attachments=[], source_ref=None, meta=meta,
+        text=text, attachments=[], source_ref=None, meta=meta,
     )
 
 
@@ -593,8 +638,9 @@ def memory_body_to_canonical(result: dict) -> CanonicalToolResult:
         value = result.get(key)
         if value is not None:
             meta[key] = value
+    text = _explicit_empty(result.get("content", "") or "", "(empty)")
     return CanonicalToolResult(
-        text=result.get("content", "") or "", attachments=[], source_ref=None, meta=meta,
+        text=text, attachments=[], source_ref=None, meta=meta,
     )
 
 
@@ -603,8 +649,9 @@ def ask_user_to_canonical(result: dict) -> CanonicalToolResult:
     (free text or the chosen option) IS what the LLM acts on → ``text`` — not a whole-dict blob hiding
     it behind ``kind``/``question``/``status`` transport. Shape:
     ``{kind:"ask_user", question, answer, status:"ok"}``."""
+    text = _explicit_empty(str(result.get("answer", "") or ""), "(no answer)")
     return CanonicalToolResult(
-        text=str(result.get("answer", "") or ""), attachments=[], source_ref=None, meta={},
+        text=text, attachments=[], source_ref=None, meta={},
     )
 
 
@@ -673,6 +720,54 @@ def canonical_fallback_reason(
     if declaration is STRUCTURED_PASSTHROUGH and structured_offloaded:
         return "passthrough_oversized"
     return None
+
+
+# The audit-event kind the two live ``to_canonical`` callers emit when a NON-error result canonicalized
+# to a completely empty view — no text AND no attachments — i.e. a success-mapper silently lost the
+# content it should have surfaced (FP-0056 v2 piece #2, mode M2), or an unknown future mapper bug did.
+# Distinct from ``canonical_fallback_used`` (which fires on the *declared/unknown whole-dict fallback*
+# paths, never on a mapped producer): this one fires on a MAPPED producer that emitted nothing. It is
+# an audit / P6 event, NOT a WAL / recovery-core event (no truncate-falsify obligation).
+CANONICAL_DEGRADED_EVENT = "canonical_degraded"
+
+# The single reason category ``canonical_degraded_reason`` returns when it fires. A category string
+# (not result content) so the callers emit ``source`` id + this reason, never the result body.
+_CANONICAL_DEGRADED_REASON = "empty_canonical"
+
+
+def canonical_degraded_reason(
+    result: dict, canonical: CanonicalToolResult
+) -> "str | None":
+    """Return the audit reason a :data:`CANONICAL_DEGRADED_EVENT` should carry, or ``None`` when the
+    result canonicalized to a visible view (FP-0056 v2 piece #2 — the runtime M2 safety net).
+
+    Fires (non-``None``) iff ALL hold:
+
+    - the result is **not error-classified** — neither :func:`_is_error` (``isError`` / ``status ==
+      "error"``) nor the canonical's ``meta.isError`` (the broader per-mapper error checks — ``file``'s
+      ``denied``/``not_found``, an ``error`` field, …) flags it. An error result may legitimately carry
+      a terse message; it is not a silent SUCCESS loss (piece #1's shared error seam will further
+      guarantee non-empty error text);
+    - the canonical ``text`` is empty after ``.strip()``;
+    - the canonical ``attachments`` list is empty.
+
+    A ``data: []`` (or any) structured attachment is an EXPLICIT empty the LLM sees → does NOT fire
+    (the rule is purely text-empty AND attachments-empty; there is deliberately NO "trivial attachment"
+    check). A legit-empty success (empty file, no-output command, …) is rendered to an explicit marker
+    by its mapper (:func:`_explicit_empty`), so it too renders non-empty text and does NOT fire — only a
+    mapper that *lost* content it had, or a not-yet-fixed future mapper, produces the empty+empty shape.
+
+    The helper is PURE (a sibling of :func:`canonical_fallback_reason`): the event fires caller-side at
+    the two ``to_canonical`` call sites, never here."""
+    if not isinstance(result, dict):
+        return None
+    if _is_error(result) or (canonical.get("meta") or {}).get("isError"):
+        return None
+    if (canonical.get("text", "") or "").strip():
+        return None
+    if canonical.get("attachments"):
+        return None
+    return _CANONICAL_DEGRADED_REASON
 
 
 _CANONICAL_SOURCE_KEY = "_canonical_source"

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -109,7 +109,9 @@ from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
 from reyn.core.events.pipeline_recovery import latest_pipeline_state, record_pipeline_state
 from reyn.core.offload.canonical import (
+    CANONICAL_DEGRADED_EVENT,
     CANONICAL_FALLBACK_EVENT,
+    canonical_degraded_reason,
     canonical_fallback_reason,
     canonical_to_ctx_fields,
     extract_canonical_source,
@@ -773,7 +775,8 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
     # retains full values for downstream programmatic step processing). Schema validation above runs
     # against the RAW dispatch result, unchanged.
     if isinstance(result, dict):
-        canonical = to_canonical(unwrap_dispatch_envelope(result), source=canonical_source)
+        _inner = unwrap_dispatch_envelope(result)
+        canonical = to_canonical(_inner, source=canonical_source)
         ctx_result: Any = canonical_to_ctx_fields(canonical)
         # FP-0056 PR-F2: a VISIBLE fallback (a #2681 CANONICAL_TODO producer, or a
         # genuinely-unregistered tool) emits a P6 audit event naming the source — degrade-with-audit,
@@ -785,6 +788,24 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
             inv.deps.events.emit(
                 CANONICAL_FALLBACK_EVENT, source=canonical_source, reason=_fallback_reason,
             )
+        # FP-0056 v2 piece #2: a MAPPED producer that canonicalized to an empty view (no text + no
+        # attachments) on a non-error result silently lost its content (mode M2) — fire the
+        # ``canonical_degraded`` audit event + a warn log (degrade-with-audit). A legit-empty success
+        # renders an explicit marker in its mapper and does not reach here. Source id only; NEVER the
+        # result body.
+        _degraded_reason = canonical_degraded_reason(
+            _inner if isinstance(_inner, dict) else {}, canonical
+        )
+        if _degraded_reason is not None:
+            import logging
+            logging.getLogger(__name__).warning(
+                "canonical_degraded: source=%s reason=%s (a non-error tool result canonicalized to an "
+                "empty view — no text, no attachments)", canonical_source, _degraded_reason,
+            )
+            if inv.deps.events is not None:
+                inv.deps.events.emit(
+                    CANONICAL_DEGRADED_EVENT, source=canonical_source, reason=_degraded_reason,
+                )
     elif isinstance(result, str):
         ctx_result = {"text": result}
     else:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2971,7 +2971,9 @@ class RouterLoop:
         # ``structured`` attachment. The format is INDEPENDENT of the media store — it applies even
         # when ``media_store is None``; only the size-gated offloading needs a store.
         from reyn.core.offload.canonical import (
+            CANONICAL_DEGRADED_EVENT,
             CANONICAL_FALLBACK_EVENT,
+            canonical_degraded_reason,
             canonical_fallback_reason,
             extract_canonical_source,
             to_canonical,
@@ -3056,6 +3058,26 @@ class RouterLoop:
                                     CANONICAL_FALLBACK_EVENT,
                                     source=canonical_source,
                                     reason=_fallback_reason,
+                                )
+                        # FP-0056 v2 piece #2: a MAPPED producer that canonicalized to an empty view
+                        # (no text + no attachments) on a non-error result silently lost its content
+                        # (mode M2) — fire ``canonical_degraded`` (audit event + warn log,
+                        # degrade-with-audit). A legit-empty success renders an explicit marker in its
+                        # mapper and does not reach here. Source id only; NEVER the result body.
+                        _degraded_reason = canonical_degraded_reason(_inner, canonical)
+                        if _degraded_reason is not None:
+                            import logging
+                            logging.getLogger(__name__).warning(
+                                "canonical_degraded: source=%s reason=%s (a non-error tool result "
+                                "canonicalized to an empty view — no text, no attachments)",
+                                canonical_source, _degraded_reason,
+                            )
+                            _events = getattr(host, "events", None)
+                            if _events is not None:
+                                _events.emit(
+                                    CANONICAL_DEGRADED_EVENT,
+                                    source=canonical_source,
+                                    reason=_degraded_reason,
                                 )
                         if built_media:
                             # media lifted from INSIDE data (the top-level strip missed it)

--- a/tests/test_fp0056_canonical_degraded_invariant.py
+++ b/tests/test_fp0056_canonical_degraded_invariant.py
@@ -1,0 +1,220 @@
+"""Tier 1/2: the runtime ``canonical_degraded`` invariant (FP-0056 v2 piece #2).
+
+The tool-result canonical mapper has a silent-loss mode M2: a *success*-mapper treats a non-trivial
+result as success but emits an EMPTY canonical view — no text, no attachments — so the user/LLM sees
+nothing. Piece #2 is the cheapest runtime safety net for M2 + any unknown future mapper bug: a pure
+helper :func:`canonical_degraded_reason`, consulted at the two ``to_canonical`` call sites, fires a
+``canonical_degraded`` P6 audit event (+ a warn log) when a NON-error result canonicalizes to
+text-empty AND attachments-empty.
+
+The nuance is the false-positive guard: a *genuinely*-empty success (an empty file read, a no-output
+command, a 0-match grep/glob) must NOT fire. Those mappers were fixed to render an EXPLICIT empty
+marker (``(empty file)`` / ``(no output)`` / ``(no matches)`` …) — better LLM UX and non-empty text,
+so the invariant stays silent on them. A ``data: []`` structured attachment is likewise an explicit
+empty the LLM sees (attachments non-empty) → does NOT fire.
+
+The event is an AUDIT / P6 event — NOT a WAL / recovery-core event (no truncate-falsify obligation).
+
+Covered here with real instances (no mocks — a real ``PipelineExecutor``, a real ``EventLog``, the real
+registration seam, real mapper functions):
+
+- Tier 1: :func:`canonical_degraded_reason` fires on a non-error empty-empty view, stays ``None`` on a
+  normal non-empty result, on each legit-empty-now-explicit mapper, on a ``data: []`` attachment, and
+  on any error-classified result.
+- Tier 2: the pipeline tool-step chokepoint EMITS ``canonical_degraded`` (source id only, no body) and
+  logs a warn when a MAPPED producer canonicalizes to an empty view; a producer whose result carries
+  content does NOT emit it (falsify control).
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+# Importing the op-runtime package + building the default registry populates every canonical
+# declaration (identically to the coverage-gate / fallback-event tests).
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import (
+    CANONICAL_DEGRADED_EVENT,
+    CanonicalToolResult,
+    canonical_degraded_reason,
+    chunks_to_canonical,
+    declare_canonical,
+    file_to_canonical,
+    reyn_src_to_canonical,
+    sandboxed_exec_to_canonical,
+    web_search_to_canonical,
+)
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.tools import get_default_registry
+
+get_default_registry()
+
+
+# A module-level mapper that deliberately emits an EMPTY canonical view for a NON-error success — the
+# M2 shape the invariant exists to catch. Declared ONCE at import (stable identity → declare_canonical
+# is idempotent for the identical re-declaration a per-call lambda would violate). A real production
+# mapper never does this; this stands in for a buggy / not-yet-fixed one.
+def _deliberately_empty_mapper(result: dict) -> CanonicalToolResult:
+    return CanonicalToolResult(text="", attachments=[], source_ref=None, meta={})
+
+
+_EMPTY_PRODUCER_ID = "test_deliberately_empty_producer"
+declare_canonical(_EMPTY_PRODUCER_ID, _deliberately_empty_mapper)
+
+
+def test_degraded_reason_fires_on_nonerror_empty_view() -> None:
+    """Tier 1: a NON-error result whose canonical view is text-empty AND attachments-empty is the M2
+    silent-loss shape → :func:`canonical_degraded_reason` returns a reason (the event fires). Whitespace
+    is stripped, so a whitespace-only body counts as empty."""
+    result = {"kind": "some_mapped_op", "status": "ok"}
+    empty = CanonicalToolResult(text="", attachments=[], source_ref=None, meta={})
+    assert canonical_degraded_reason(result, empty) is not None
+
+    whitespace = CanonicalToolResult(text="   \n\t", attachments=[], source_ref=None, meta={})
+    assert canonical_degraded_reason(result, whitespace) is not None
+
+
+def test_degraded_reason_none_for_normal_nonempty_result() -> None:
+    """Tier 1: FALSIFY — a normal result with a non-empty text body does NOT fire (no false positive)."""
+    result = {"kind": "some_mapped_op", "status": "ok"}
+    canonical = CanonicalToolResult(text="the answer", attachments=[], source_ref=None, meta={})
+    assert canonical_degraded_reason(result, canonical) is None
+
+
+def test_degraded_reason_none_for_error_classified_result() -> None:
+    """Tier 1: an error-classified result never fires — neither via ``_is_error`` (``status==error`` /
+    ``isError``) nor via the canonical ``meta.isError`` a broader per-mapper error check set. An error
+    may legitimately carry a terse/empty message; it is not a silent SUCCESS loss."""
+    empty = CanonicalToolResult(text="", attachments=[], source_ref=None, meta={})
+    # status==error → _is_error True → exempt.
+    assert canonical_degraded_reason({"status": "error"}, empty) is None
+    # isError flag → _is_error True → exempt.
+    assert canonical_degraded_reason({"isError": True}, empty) is None
+    # meta.isError set by a broader per-mapper error check (file denied/not_found, error field) → exempt
+    # even when the raw result dict itself does not trip _is_error.
+    meta_err = CanonicalToolResult(text="", attachments=[], source_ref=None, meta={"isError": True})
+    assert canonical_degraded_reason({"kind": "file", "op": "read"}, meta_err) is None
+
+
+def test_degraded_reason_none_for_data_empty_attachment() -> None:
+    """Tier 1: a ``data: []`` structured attachment is an EXPLICIT empty the LLM sees → attachments is
+    non-empty → does NOT fire. There is deliberately NO 'trivial attachment' check. Verified through the
+    real ``web_search`` (empty results) and ``recall`` (empty chunks) mappers."""
+    ws = web_search_to_canonical({"kind": "web_search", "status": "ok", "results": []})
+    assert ws["text"] == "" and ws["attachments"] == [{"kind": "structured", "data": []}]
+    assert canonical_degraded_reason({"kind": "web_search", "status": "ok", "results": []}, ws) is None
+
+    chunks = chunks_to_canonical({"kind": "recall", "chunks": []})
+    assert chunks["attachments"] == [{"kind": "structured", "data": []}]
+    assert canonical_degraded_reason({"kind": "recall", "chunks": []}, chunks) is None
+
+
+def test_degraded_reason_none_for_legit_empty_now_explicit_mappers() -> None:
+    """Tier 1: the false-positive guard — each mapper that can legitimately produce no output now
+    renders an EXPLICIT empty marker (non-empty text), so a genuine empty-success does NOT fire.
+    Enumerated legit-empty cases fixed for piece #2:
+
+    - ``file`` read of an empty file → ``(empty file)``.
+    - ``file`` grep / glob with 0 matches → ``(no matches)``.
+    - ``sandboxed_exec`` with no stdout/stderr → ``(no output)``.
+    - ``reyn_src`` read of an empty file → ``(empty file)``."""
+    # file read, empty file (no media blocks) → explicit marker, non-empty text.
+    read_empty = {"kind": "file", "op": "read", "status": "ok", "path": "empty.txt", "content": ""}
+    c = file_to_canonical(read_empty)
+    assert c["text"] == "(empty file)"
+    assert canonical_degraded_reason(read_empty, c) is None
+
+    # file grep, 0 matches (content mode) → "(no matches)".
+    grep0 = {"kind": "file", "op": "grep", "status": "ok", "output_mode": "content", "matches": []}
+    cg = file_to_canonical(grep0)
+    assert cg["text"] == "(no matches)"
+    assert canonical_degraded_reason(grep0, cg) is None
+
+    # file glob, 0 matches → "(no matches)".
+    glob0 = {"kind": "file", "op": "glob", "status": "ok", "matches": []}
+    cgl = file_to_canonical(glob0)
+    assert cgl["text"] == "(no matches)"
+    assert canonical_degraded_reason(glob0, cgl) is None
+
+    # sandboxed_exec, no output (returncode 0) → "(no output)".
+    exec0 = {"kind": "sandboxed_exec", "status": "ok", "returncode": 0, "stdout": "", "stderr": ""}
+    ce = sandboxed_exec_to_canonical(exec0)
+    assert ce["text"] == "(no output)"
+    assert canonical_degraded_reason(exec0, ce) is None
+
+    # reyn_src read, empty file → "(empty file)".
+    rs_empty = {"content": "", "path": "docs/empty.md"}
+    cr = reyn_src_to_canonical(rs_empty)
+    assert cr["text"] == "(empty file)"
+    assert canonical_degraded_reason(rs_empty, cr) is None
+
+
+@pytest.mark.asyncio
+async def test_empty_mapper_at_call_site_emits_degraded_event_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: a pipeline tool step whose MAPPED producer canonicalizes to an empty view emits
+    ``canonical_degraded`` naming the source (source id only — no result body leaks) AND logs a warn.
+    Real ``PipelineExecutor`` + real ``EventLog`` + the real registration seam (no mocks)."""
+    secret_body = "SECRET-CONTENT-that-the-buggy-mapper-dropped-should-never-reach-an-audit-event"
+
+    def _dispatch(name: str, args: dict) -> dict:
+        # A result tagged with the deliberately-empty mapper's identity: the mapper drops the body,
+        # producing the empty-empty canonical view (the M2 shape). The distinctive string must never
+        # leak into any event payload.
+        return {
+            "kind": "some_kind",
+            "content": secret_body,
+            "_canonical_source": _EMPTY_PRODUCER_ID,
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="buggy_tool", args={}, output="r")])
+    with caplog.at_level(logging.WARNING, logger="reyn.core.pipeline.executor"):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-degraded", events=events,
+        )
+
+    # Exactly one degraded event for the one empty-mapping tool step (unpack asserts the count).
+    [degraded] = [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT]
+    assert degraded.data["source"] == _EMPTY_PRODUCER_ID
+    assert degraded.data["reason"]  # a non-empty reason category
+
+    # No result content bytes in ANY event payload — the event carries the source identity only.
+    all_payloads = json.dumps([e.data for e in events.all()])
+    assert secret_body not in all_payloads
+    assert "content" not in degraded.data
+
+    # A warn was logged naming the degrade (degrade-with-audit: audit event + operator-visible warn).
+    warn_records = [r for r in caplog.records if "canonical_degraded" in r.getMessage()]
+    assert warn_records, "a canonical_degraded warn must be logged"
+    assert secret_body not in "\n".join(r.getMessage() for r in warn_records)
+
+
+@pytest.mark.asyncio
+async def test_mapped_producer_with_content_does_not_emit_degraded_event() -> None:
+    """Tier 2: FALSIFY — a producer whose real mapper surfaces content (``sandboxed_exec`` with real
+    stdout) canonicalizes to a non-empty view → NO ``canonical_degraded`` event fires."""
+
+    def _dispatch(name: str, args: dict) -> dict:
+        return {
+            "kind": "sandboxed_exec",
+            "stdout": "real output",
+            "returncode": 0,
+            "_canonical_source": "sandboxed_exec",
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="run_shell", args={}, output="r")])
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-degraded-ok", events=events,
+    )
+
+    assert not [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT], (
+        "a producer that surfaced content must not emit the canonical_degraded audit event"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — part of #2699 (FP-0056 v2 piece #2 of 3 — do NOT close the umbrella; #1 union error seam + #3 M3 fail-visible land separately). Design authority: the architect design pass + tightening B in the **#2698 comments**.

## What
The runtime `canonical_degraded` invariant — the cheapest, immediate safety net for silent-loss **mode M2** (a success-mapper treats a non-trivial result as success but emits an EMPTY canonical view — no text, no attachments — so the user/LLM sees nothing) + any unknown future mapper bug.

A pure helper `canonical_degraded_reason(result, canonical) -> str | None` is consulted at the **two `to_canonical` call sites** (`executor.py`, `router_loop.py`) — exactly alongside the existing `canonical_fallback_reason`, same shape/placement. A non-None return fires a `canonical_degraded` **P6 audit-event + a warn log** (degrade-with-audit). `to_canonical` stays pure; the helper is a sibling of `canonical_fallback_reason`.

**Determination (architect tightening B):** fire iff the result is NOT error-classified (`_is_error` OR the canonical's `meta.isError`) AND `canonical.text.strip()` is empty AND `canonical.attachments` is empty. **No "trivial attachment" check** — a `data: []` structured attachment is an explicit empty the LLM sees and must NOT fire.

## The false-positive guard (the nuance)
A genuinely-empty *success* would spuriously fire, so I enumerated the legit-empty cases and fixed each mapper to render an EXPLICIT empty marker (also better LLM UX) via a shared `_explicit_empty(text, marker)` helper. A legit-empty success now renders non-empty text and does NOT fire — only a mapper that *lost* content it had, or a not-yet-fixed future mapper, produces the empty+empty shape.

| mapper | legit-empty case | fix |
|---|---|---|
| `file` read | empty file (no media blocks) | `(empty file)` |
| `file` grep / glob | 0 matches | already `(no matches)` (verified, non-firing fixture) |
| `sandboxed_exec` | no stdout/stderr (mkdir/touch/mv) | `(no output)` |
| `reyn_src` read | empty file | `(empty file)` (list/glob/grep already `(empty)`/`(no matches)`) |
| `read_memory_body` | empty body | `(empty)` |
| `render_template` | empty render | `(empty render)` |
| `ask_user` | empty answer | `(no answer)` |
| `judge_output` | empty reason (score in meta) | `(no reason given)` |
| `web_fetch` | empty content/preview | `(no content)` |
| `run_pipeline` (sync) | empty-string / None output | `(no output)` |
| `mcp` / `mcp_read_resource` / `mcp_get_prompt` | empty content + no attachments | `(no content)` (conditional on no attachments) |

**Left as-is (already correct):** `recall`/`index_query` `chunks: []` and `web_search` `results: []` both carry a `data: []` structured attachment → attachments non-empty → do not fire (the explicit-empty-attachment case the rule intentionally allows).

## Recovery-gate note
`canonical_degraded` is a **P6 audit-event** (observability trail), NOT WAL-derived recovery state, so the truncate-falsify recovery gate does not apply.

## Tests (`tests/test_fp0056_canonical_degraded_invariant.py`, Tier-declared, real instances — no mocks)
- **Tier 1** — fires on a non-error empty-empty view (incl. whitespace-only); returns None on a normal non-empty result; None on any error-classified result (`_is_error` and `meta.isError`); None on a `data: []` attachment (real `web_search`/`recall` mappers); None on each legit-empty-now-explicit mapper (`file` read/grep/glob, `sandboxed_exec`, `reyn_src` read).
- **Tier 2** (integration, real `PipelineExecutor` + real `EventLog` + real registration seam) — a MAPPED producer that canonicalizes to empty emits `canonical_degraded` (source id only, no body leak) **and** logs a warn; a producer with content does NOT emit it (falsify control).
- **RED→GREEN verified**: neutered the helper to always return None → the fire unit-test + the integration event-test both went RED → restored (via `cp` from scratch backup, never git).

## CI gates (all 4 green locally)
- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_fp0056_canonical_degraded_invariant.py` — 7/7 OK, 0 Tier-4.
- `pytest` (repo root) — 7902 passed; the 5 `tests/web/` failures (A2A/MCP-SSE/plugin-loader/resources route-mounting) are **pre-existing on clean `origin/main`** (verified in a temp worktree) and unrelated to this change (touches zero web/server code).
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan
- [x] `canonical_degraded_reason` unit contract (fire / no-false-fire / error-exempt / data:[] / legit-empty) — automated, passing.
- [x] Event fires at the call site with a warn log, source-id only, no body leak — automated integration test, passing.
- [x] RED→GREEN falsification performed and restored via `cp` scratch backup.
- [x] All 4 CI gates run locally (pytest failures confirmed pre-existing on origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
