### PR TITLE
feat: shared canonical error seam — eliminate the M1 silent-loss class (FP-0056 v2 piece #1)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -165,8 +165,92 @@ def canonical_declaration(
 
 def _is_error(result: dict) -> bool:
     """A result is an error when it explicitly flags one (MCP ``isError``) or its op-level
-    ``status`` is ``error`` (the sole error-path driver kept after meta-tightening)."""
+    ``status`` is ``error`` (the sole error-path driver kept after meta-tightening).
+
+    Retained after FP-0056 v2 piece #1 for the TWO producers whose ``status:"error"`` carries its
+    payload in a non-``error`` field (so the shared error seam intentionally does NOT intercept them,
+    and they keep their own ``meta.isError`` handling): ``mcp`` (message in ``content``) and
+    ``sandboxed_exec`` (a nonzero exit — output in ``stdout``/``stderr``, ``returncode`` as signal).
+    Also consulted by :func:`canonical_degraded_reason` (piece #2)."""
     return bool(result.get("isError")) or result.get("status") == "error"
+
+
+# FP-0056 v2 piece #1 — the shared error seam (the M1-class linchpin).
+#
+# The dedicated error-MESSAGE fields, in extractor priority order. This IS the true union of the
+# per-mapper error branches removed in piece #1 (``file``/``reyn_src``/``render_template``/``compact``/
+# ``present``/``judge_output``/``memory_body``/``web_search`` — and the recall/task_ops ``{ok:False,
+# error_message}`` that had NO branch, the #2698 gap). Every one of those producers surfaces its error
+# through one of these fields, so keying the predicate on them (not on the ambiguous ``status``/``ok``
+# values) makes removing the branches regression-free by construction.
+_ERROR_MESSAGE_FIELDS = ("error_message", "error", "error_kind")
+
+
+def is_error_result(result: object) -> bool:
+    """The union error predicate the shared error seam runs BEFORE a mapper's success-only logic
+    (FP-0056 v2 piece #1). True for the FIXED SET of known error shapes:
+
+    - ``{isError}`` (MCP-style explicit flag);
+    - a truthy dedicated error-message field — ``{error}`` / ``{error_message}`` / ``{error_kind}`` —
+      which subsumes the recall/task_ops ``{ok:False, error_message}`` + ``{error_kind}`` shapes, the
+      ``file`` ``denied``/``not_found`` (which carry ``error``), and every other per-mapper branch.
+
+    **Tightening A (the misclassification safety).** The seam runs on ALL mapper-path results, so the
+    predicate must NOT over-match a SUCCESS payload that happens to carry a data-meaning ``ok``/``status``
+    key. Two concrete hazards this predicate is designed around:
+
+    - a health-check-style ``{ok: False, service: "db"}`` (``ok:False`` MEANS "DB is down" — success
+      data) → NOT matched (no error-message field; a bare ``ok is False`` is never a trigger);
+    - ``sandboxed_exec``'s ``{status: "error", returncode: 2, stdout, stderr}`` (a nonzero exit is a
+      SUCCESSFUL execution whose output is ``stdout``/``stderr``) → NOT matched (no error-message
+      field). This is a REAL in-repo instance of the ``status`` data-meaning hazard: routing it through
+      :func:`error_to_canonical` would drop ``stdout``/``stderr`` on the router error path (which renders
+      ``text`` only, dropping attachments, when ``meta.isError``). So a bare ``status`` value is NOT a
+      standalone trigger — every real error producer pairs its status with an error-message field, and
+      the two producers that don't (``mcp`` content / ``sandboxed_exec`` stdout) keep their in-mapper
+      ``meta.isError`` handling (:func:`_is_error`) precisely because their payload is NOT a message.
+
+    Even were a misclassification to slip through, :func:`error_to_canonical` is LOSSLESS (whole dict →
+    structured attachment), so it only ever MIS-LABELS, never loses data."""
+    if not isinstance(result, dict):
+        return False
+    if result.get("isError"):
+        return True
+    return any(result.get(field) for field in _ERROR_MESSAGE_FIELDS)
+
+
+def _extract_error_message(result: dict) -> str:
+    """The union message extractor: read the first present error-message field in priority order,
+    ALWAYS returning a non-empty string (so an error never renders to empty ``text`` — the M1 fix).
+    A shape with an error signal but no readable message (e.g. a bare ``{error_kind}``) still yields a
+    non-empty line; the full dict is preserved in the structured attachment by :func:`error_to_canonical`."""
+    for field in ("error_message", "error"):
+        value = result.get(field)
+        if value:
+            return str(value)
+    error_kind = result.get("error_kind")
+    if error_kind:
+        return f"error: {error_kind}"
+    return "error"
+
+
+def error_to_canonical(result: dict) -> CanonicalToolResult:
+    """Render ANY :func:`is_error_result`-classified result to a LOSSLESS canonical error view
+    (FP-0056 v2 piece #1). Two guarantees:
+
+    - a NON-EMPTY ``text`` (the extracted union message) — eliminating the M1 silent-loss class where a
+      mapper with no error branch rendered an error to empty text (recall #2698 et al.);
+    - the WHOLE result dict as a ``structured`` attachment, plus ``meta.isError``. This losslessness is
+      what makes the fixed-set union predicate safe to run before every mapper (tightening A): even a
+      hypothetical misclassification of a success payload only MIS-LABELS it (``isError`` on a success)
+      — it NEVER loses data (the full payload survives in the attachment; the existing offload gate
+      handles it if large)."""
+    return CanonicalToolResult(
+        text=_extract_error_message(result),
+        attachments=[{"kind": "structured", "data": result}],
+        source_ref=None,
+        meta={"isError": True},
+    )
 
 
 def _explicit_empty(text: str, marker: str) -> str:
@@ -286,16 +370,16 @@ def web_fetch_to_canonical(result: dict) -> CanonicalToolResult:
 
 
 def web_search_to_canonical(result: dict) -> CanonicalToolResult:
-    """web_search result → canonical. The ``results`` list → a ``structured`` attachment (rendered as
-    frontmatter YAML, or offloaded to its own ref when large). An op-level failure (no ``results``,
-    ``status: error``) surfaces its message as ``text``. Transport (query/backend) is dropped."""
+    """web_search result → canonical (SUCCESS shape only — FP-0056 v2 piece #1 routes an error
+    ``{status:"error", error}`` through the shared ``error_to_canonical`` seam before this mapper runs).
+    The ``results`` list → a ``structured`` attachment (rendered as frontmatter YAML, or offloaded to
+    its own ref when large). Transport (query/backend) is dropped."""
     results = result.get("results")
     if results is not None:
         return CanonicalToolResult(
             text="", attachments=[{"kind": "structured", "data": results}], source_ref=None, meta={},
         )
-    text = str(result.get("error") or "") if result.get("status") == "error" else ""
-    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
+    return CanonicalToolResult(text="", attachments=[], source_ref=None, meta={})
 
 
 def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
@@ -383,19 +467,12 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
     - ``write`` / ``edit`` / ``delete`` / ``mkdir`` / ``move`` / ``stat`` / ``regenerate_index`` → a short
       status ``text``.
 
-    Any op whose result is an error (``status`` error/denied/not_found, or an ``error`` field) surfaces
-    the ``error`` message as ``text`` with ``meta.isError`` — the sole error-path driver."""
+    SUCCESS shape only — FP-0056 v2 piece #1 routes any error (``status`` error/denied/not_found, which
+    carry an ``error`` field) through the shared ``error_to_canonical`` seam before this mapper runs; the
+    whole result dict (incl. ``op``/``status``/``path``) is preserved in that error view's lossless
+    structured attachment."""
     op = result.get("op")
-    status = result.get("status")
     meta = _file_signal_meta(result)
-    if _is_error(result) or status in ("error", "denied", "not_found") or (
-        "error" in result and result.get("error")
-    ):
-        meta["isError"] = True
-        return CanonicalToolResult(
-            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta=meta,
-        )
-
     if op == "read":
         attachments = [
             {"kind": "media", "block": block} for block in (result.get("media_blocks") or [])
@@ -480,11 +557,9 @@ def reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
     - ``list`` (``entries``) → ``type: name`` lines as ``text``.
     - ``glob`` (``matches`` of paths) / ``grep`` (``matches`` of ``{path, line, snippet}``) → the
       rendered lines as ``text``.
-    - an ``error`` → the message as ``text`` with ``meta.isError``."""
-    if result.get("error"):
-        return CanonicalToolResult(
-            text=str(result["error"]), attachments=[], source_ref=None, meta={"isError": True},
-        )
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes an ``{error}`` result through the shared
+    ``error_to_canonical`` seam before this mapper runs."""
     if "content" in result:
         meta = {"path": result["path"]} if result.get("path") is not None else {}
         text = _explicit_empty(result.get("content", "") or "", "(empty file)")
@@ -519,13 +594,11 @@ def render_template_to_canonical(result: dict) -> CanonicalToolResult:
     (``rendered``) IS the LLM-readable body → ``text`` (NOT a whole-dict ``structured``
     blob). Signal meta: ``truncated`` (+ which bound fired, ``truncate_reason``) tells the LLM the
     output was capped mid-generate; ``undefined_vars`` (lenient mode) names the
-    referenced-but-unbound template variables so it can self-correct. An error
-    (``status="error"`` — syntax / SSTI-blocked / strict-undefined) surfaces the
-    message as ``text`` with ``meta.isError``."""
-    if _is_error(result):
-        return CanonicalToolResult(
-            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
-        )
+    referenced-but-unbound template variables so it can self-correct.
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes an error (``status="error"``/``not_found`` — syntax /
+    SSTI-blocked / strict-undefined, which carry an ``error`` field) through the shared
+    ``error_to_canonical`` seam before this mapper runs."""
     meta: dict[str, Any] = {}
     if result.get("truncated"):
         meta["truncated"] = True
@@ -546,11 +619,10 @@ def compact_to_canonical(result: dict) -> CanonicalToolResult:
     axis compression fields when present) render as a short ``text`` summary; on error the ``error``
     message surfaces as ``text`` with ``meta.isError``. Result shape:
     ``{kind:"compact", status:"ok", freed_tokens?, free_window_after?, summarized_turns?,
-    compressed_tokens?, bridge_tokens?}`` (ok) or ``{status:"error", error_kind, error}`` (error)."""
-    if _is_error(result):
-        return CanonicalToolResult(
-            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
-        )
+    compressed_tokens?, bridge_tokens?}`` (ok) or ``{status:"error", error_kind, error}`` (error).
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes the error shape through the shared
+    ``error_to_canonical`` seam before this mapper runs."""
     parts: list[str] = ["Compaction complete."]
     for label, key in (
         ("freed_tokens", "freed_tokens"),
@@ -571,15 +643,12 @@ def present_to_canonical(result: dict) -> CanonicalToolResult:
     AGENT-facing signal (did the presentation reach the user? did the view bind? which fallback fired?),
     NOT bulk content — so it renders as a short ``text`` line, not a whole-dict ``structured`` blob (the
     incident class). Success shape: ``{kind:"present", status:"ok", ok:True, mode, bindings_resolved,
-    bindings_dropped, rows, all_bindings_missed, note?}``. Any non-``ok`` status (``error`` — malformed
-    inline blueprint / XOR violation; ``not_found`` — missing ``data_ref``; ``denied`` — read-authority)
-    surfaces the ``error`` message as ``text`` with ``meta.isError`` so the LLM self-corrects."""
-    status = result.get("status")
-    if status not in (None, "ok"):
-        return CanonicalToolResult(
-            text=str(result.get("error") or f"present {status}"),
-            attachments=[], source_ref=None, meta={"isError": True},
-        )
+    bindings_dropped, rows, all_bindings_missed, note?}``.
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes any non-``ok`` status (``error`` — malformed inline
+    blueprint / XOR violation; ``not_found`` — missing ``data_ref``; ``denied`` — read-authority; each
+    carries an ``error`` field) through the shared ``error_to_canonical`` seam before this mapper runs,
+    so the LLM still self-corrects from a non-empty error message."""
     parts: list[str] = ["Presented to the user."]
     mode = result.get("mode")
     if mode is not None:
@@ -605,11 +674,10 @@ def judge_output_to_canonical(result: dict) -> CanonicalToolResult:
     the ``text``; ``score`` / ``passed`` / ``threshold`` / ``on_fail`` are signal meta (they drive the
     caller's next move — a failed judgment triggers ``on_fail``). An error surfaces the message as
     ``text`` with ``meta.isError``. Shape: ``{kind:"judge_output", score, passed, reason, threshold,
-    on_fail}`` (ok) or ``{status:"error", error}`` (error)."""
-    if _is_error(result) or (result.get("status") == "error"):
-        return CanonicalToolResult(
-            text=str(result.get("error") or ""), attachments=[], source_ref=None, meta={"isError": True},
-        )
+    on_fail}`` (ok) or ``{status:"error", error}`` (error).
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes the ``{status:"error", error}`` shape through the
+    shared ``error_to_canonical`` seam before this mapper runs."""
     meta: dict[str, Any] = {}
     for key in ("score", "passed", "threshold", "on_fail"):
         value = result.get(key)
@@ -628,11 +696,10 @@ def memory_body_to_canonical(result: dict) -> CanonicalToolResult:
     documented G12 empty-stop attractor (an LLM handed non-clean memory text stopped with an empty
     reply — router_loop._read_memory_body). ``layer`` / ``slug`` are signal meta (which entry). An
     error (``error`` field) surfaces the message as ``text`` with ``meta.isError``. Shape:
-    ``{content, layer?, slug?}`` (ok) or ``{error, layer?, slug?}`` (error)."""
-    if result.get("error"):
-        return CanonicalToolResult(
-            text=str(result["error"]), attachments=[], source_ref=None, meta={"isError": True},
-        )
+    ``{content, layer?, slug?}`` (ok) or ``{error, layer?, slug?}`` (error).
+
+    SUCCESS shape only — FP-0056 v2 piece #1 routes the ``{error, layer?, slug?}`` shape through the
+    shared ``error_to_canonical`` seam before this mapper runs."""
     meta: dict[str, Any] = {}
     for key in ("layer", "slug"):
         value = result.get(key)
@@ -678,7 +745,19 @@ def to_canonical(result: dict, *, source: "str | None" = None) -> CanonicalToolR
     - ``source`` ``None`` or unregistered (genuine unknown) → the same lossless whole-dict fallback
       (PR-F2 will emit ``canonical_fallback_used`` on the TODO + unknown paths). Nothing is ever lost."""
     declaration = canonical_declaration(source)
-    if declaration is None or declaration is STRUCTURED_PASSTHROUGH or declaration is CANONICAL_TODO:
+    # FP-0056 v2 piece #1 — the shared error seam, scope-limited to the MAPPER + CANONICAL_TODO paths
+    # (tightening A #3). A known error shape routes to the single lossless ``error_to_canonical`` BEFORE
+    # the mapper's (now success-only) logic OR the TODO whole-dict fallback — structurally eliminating
+    # the M1 class (a mapper with no error branch rendering an error to empty text). STRUCTURED_PASSTHROUGH
+    # (a reviewed "the whole dict IS the view") and unregistered/``None`` (a genuine unknown) are
+    # deliberately OUT of scope: they are already lossless whole-dict, M1 loss only occurs where a mapper
+    # would interpret the result, and keeping them on ``_fallback_structured`` preserves their
+    # ``canonical_fallback_used`` (PR-F2) visibility semantics.
+    if declaration is STRUCTURED_PASSTHROUGH or declaration is None:
+        return _fallback_structured(result)
+    if is_error_result(result):
+        return error_to_canonical(result)
+    if declaration is CANONICAL_TODO:
         return _fallback_structured(result)
     return declaration(result)
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -714,8 +714,23 @@ def memory_body_to_canonical(result: dict) -> CanonicalToolResult:
 def ask_user_to_canonical(result: dict) -> CanonicalToolResult:
     """``ask_user`` op result → canonical (FP-0056 PR-F1 triage: text-shaped). The user's ``answer``
     (free text or the chosen option) IS what the LLM acts on → ``text`` — not a whole-dict blob hiding
-    it behind ``kind``/``question``/``status`` transport. Shape:
-    ``{kind:"ask_user", question, answer, status:"ok"}``."""
+    it behind ``kind``/``question``/``status`` transport. Shapes:
+    ``{kind:"ask_user", question, answer, status:"ok"}`` (answered) or
+    ``{kind:"ask_user", question, answer:"", status:"refused", reason}`` (a #2708 P3-item3 refusal).
+
+    The ``refused`` shape is the THIRD in-mapper hybrid boundary (with ``mcp`` content / ``sandboxed_exec``
+    stdout — FP-0056 v2 piece #1): a DELIBERATE, reason'd refusal is a typed NON-error outcome, NOT a tool
+    error and NOT an empty answer. It carries no error-message field, so the shared error seam correctly
+    does not intercept it (it is not an error). But it MUST be handled here BEFORE the answer/explicit-empty
+    logic — otherwise ``_explicit_empty`` sees the empty ``answer`` and renders ``(no answer)``, silently
+    DROPPING the ``reason`` and re-introducing the very empty-answer the P3-item3 refusal design removed
+    (the LLM could then not tell a refusal from a blank answer). The reason is surfaced as ``text``; NO
+    ``meta.isError`` is set — framing a deliberate refusal as an error would contradict its
+    typed-non-error design."""
+    if result.get("status") == "refused":
+        reason = str(result.get("reason", "") or "")
+        text = f"(no answer — refused: {reason})" if reason else "(no answer — refused)"
+        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
     text = _explicit_empty(str(result.get("answer", "") or ""), "(no answer)")
     return CanonicalToolResult(
         text=text, attachments=[], source_ref=None, meta={},

--- a/tests/test_fp0056_error_seam.py
+++ b/tests/test_fp0056_error_seam.py
@@ -1,0 +1,249 @@
+"""Tier 1/2: the shared canonical error seam (FP-0056 v2 piece #1 — the M1-class linchpin).
+
+The tool-result canonical mapper hand-wrote error handling per-mapper, so a mapper with NO error branch
+(recall/task_ops ``{ok:False, error_message}`` — #2698; ``file`` ``denied``/``not_found``; ``memory_body``/
+``reyn_src`` ``{error}``; ``web_fetch`` errors) rendered an error to EMPTY text — the M1 silent-loss
+class. Piece #1 eliminates the class STRUCTURALLY: :func:`to_canonical` applies a union error predicate
+(:func:`is_error_result`) BEFORE per-mapper dispatch and routes any known error shape to a single
+:func:`error_to_canonical`; the per-mapper error branches are removed (mappers become success-only).
+
+Two contracts these tests pin:
+
+- **the fixed-set union predicate** — :func:`is_error_result` recognizes the fixed set of known error
+  shapes and, per tightening A, does NOT over-match a SUCCESS payload carrying a data-meaning ``ok`` /
+  ``status`` key (a health-check ``{ok:False, service}``; ``sandboxed_exec``'s nonzero-exit
+  ``{status:"error", stdout, returncode}``).
+- **losslessness** — :func:`error_to_canonical` renders a non-empty ``text`` AND the whole result dict
+  as a structured attachment (+ ``meta.isError``). This is what makes the predicate safe to run before
+  every mapper: even a hypothetical misclassification only MIS-LABELS, it never loses data.
+
+Real instances only (no mocks): the real registration seam (op-runtime import + default registry), the
+real mapper functions, a real ``PipelineExecutor`` + ``EventLog`` at the chokepoint.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Importing the op-runtime package + building the default registry populates every canonical
+# declaration (identically to the coverage-gate / degraded / fallback-event tests).
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import (
+    error_to_canonical,
+    is_error_result,
+    to_canonical,
+)
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.tools import get_default_registry
+
+get_default_registry()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_error_result — the fixed-set union predicate (Tier 1 contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_is_error_result_true_for_every_fixed_error_shape() -> None:
+    """Tier 1: :func:`is_error_result` returns True for the fixed set of known error shapes — the
+    ``{isError}`` flag, and the dedicated error-message fields ``error`` / ``error_message`` /
+    ``error_kind`` (which subsume the recall/task_ops ``{ok:False, error_message}`` + ``{error_kind}``,
+    the ``file`` ``denied``/``not_found`` which carry ``error``, and every other removed per-mapper
+    branch). The status-bearing shapes are the SHAPES REAL PRODUCERS EMIT — a status:error/denied/
+    not_found always co-carries an ``error`` field."""
+    for shape in (
+        {"isError": True},                                              # MCP-style explicit flag
+        {"ok": False, "error": "boom"},                                # present/render_template/file
+        {"ok": False, "error_message": "recall requires [query]"},     # recall / task_ops (#2698)
+        {"status": "error", "error": "syntax error"},                  # render_template/judge/web
+        {"status": "denied", "error": "read-authority denied"},        # file / present
+        {"status": "not_found", "error": "file not found: x.md"},      # file / render_template
+        {"error_kind": "missing_required_arg", "error_message": "..."},  # recall's kind+message
+        {"error_kind": "x"},                                           # bare error_kind
+        {"error": "reyn_src: path resolves outside repo"},             # memory_body / reyn_src bare error
+    ):
+        assert is_error_result(shape) is True, shape
+
+
+def test_is_error_result_false_for_success_and_data_meaning_payloads() -> None:
+    """Tier 1: FALSIFY (tightening A — the misclassification safety). :func:`is_error_result` does NOT
+    over-match a SUCCESS payload that carries a data-meaning ``ok`` / ``status`` key:
+
+    - a health-check-style ``{ok: False, service: "db"}`` (``ok:False`` MEANS "DB is down" — success
+      data, NOT a tool error) → False (a bare ``ok is False`` is never a trigger);
+    - ``sandboxed_exec``'s ``{status:"error", returncode:2, stdout, stderr}`` (a nonzero exit is a
+      SUCCESSFUL execution whose output is stdout/stderr) → False (a bare ``status`` value is never a
+      trigger; there is no error-message field). Routing it through the error seam would drop
+      stdout/stderr on the router error path — the concrete in-repo instance of the ``status`` hazard.
+
+    Plus ordinary success shapes and a non-dict."""
+    for shape in (
+        {"ok": False, "service": "db", "region": "us"},                # health-check data-meaning
+        {"status": "error", "returncode": 2, "stdout": "out", "stderr": "boom"},  # sandboxed_exec
+        {"status": "cancelled", "returncode": -1, "stdout": "partial"},  # sandboxed_exec cancel
+        {"status": "ok", "content": "hi"},                             # ordinary success
+        {"chunks": [{"id": 1}]},                                       # recall success
+        {"results": [{"url": "u"}]},                                   # web_search success
+        {"content": "hello world"},                                    # reyn_src / file read success
+    ):
+        assert is_error_result(shape) is False, shape
+    assert is_error_result("not a dict") is False
+    assert is_error_result(None) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# error_to_canonical — losslessness (Tier 1 contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_error_to_canonical_is_lossless_non_empty_text_plus_whole_dict_attachment() -> None:
+    """Tier 1: :func:`error_to_canonical` is LOSSLESS — a NON-EMPTY ``text`` (the extracted union
+    message) AND the WHOLE result dict as a structured attachment, plus ``meta.isError``. Proven with a
+    data-meaning-key payload (the hypothetical misclassification): even if such a success were mislabeled
+    an error, NO data is lost — every field survives in the attachment."""
+    payload = {"ok": False, "service": "db", "region": "us-east", "latency_ms": 4200}
+    canonical = error_to_canonical(payload)
+    assert canonical["text"].strip(), "error text must be non-empty (the M1 fix)"
+    assert canonical["meta"].get("isError") is True
+    # The WHOLE dict is preserved (lossless) — no field dropped even on a (hypothetical) misclassification.
+    assert canonical["attachments"] == [{"kind": "structured", "data": payload}]
+    assert canonical["attachments"][0]["data"]["service"] == "db"
+    assert canonical["attachments"][0]["data"]["latency_ms"] == 4200
+
+
+def test_error_to_canonical_extracts_message_in_priority_order() -> None:
+    """Tier 1: the union message extractor reads the first present error field (error_message → error →
+    error_kind), always non-empty; a shape with only an error signal and no readable message still
+    yields a non-empty line (the full dict remains in the attachment)."""
+    assert error_to_canonical({"error_message": "msg-a", "error": "msg-b"})["text"] == "msg-a"
+    assert error_to_canonical({"error": "msg-b"})["text"] == "msg-b"
+    assert "kind-only" in error_to_canonical({"error_kind": "kind-only"})["text"]
+    assert error_to_canonical({"isError": True})["text"].strip()  # non-empty even with no message field
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# #2698 subsumed — recall's {ok:False, error_message} renders NON-EMPTY (the acceptance test)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_recall_missing_arg_error_renders_non_empty_via_seam() -> None:
+    """Tier 1: #2698 SUBSUMED — recall's missing-arg error ``{ok:False, error_kind, error_message}``
+    (which ``chunks_to_canonical`` has NO branch for → rendered EMPTY on pre-#1 main, the M1 bug) now
+    routes through the shared seam to a NON-EMPTY ``text`` with ``meta.isError``. This is the RED→GREEN
+    acceptance test the #2698 issue asks for (RED against pre-#1 main / a neutered predicate)."""
+    recall_error = {
+        "ok": False,
+        "error_kind": "missing_required_arg",
+        "error_message": "recall requires ['query', 'sources']. Available sources are listed under "
+        "'Indexed sources' in the system prompt.",
+        "missing": ["query", "sources"],
+    }
+    canonical = to_canonical(recall_error, source="recall")
+    assert canonical["text"].strip(), "recall error must render NON-EMPTY (the #2698 fix)"
+    assert "recall requires" in canonical["text"]
+    assert canonical["meta"].get("isError") is True
+    # Lossless: the whole error dict (incl. ``missing``) survives in the attachment.
+    assert canonical["attachments"] == [{"kind": "structured", "data": recall_error}]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-mapper spot-checks — each removed error branch still routes correctly through the seam
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_removed_branch_mappers_still_route_errors_through_the_seam() -> None:
+    """Tier 1: each mapper whose per-mapper error branch was removed (success-only now) still surfaces
+    its error as NON-EMPTY ``text`` + ``meta.isError`` via the shared seam — spot-checking ``file``
+    (denied + not_found), ``reyn_src``, ``memory_body``, ``compact``, ``judge_output``, ``present``,
+    ``render_template``, and a ``task`` op (CANONICAL_TODO, also in seam scope)."""
+    cases = [
+        # (result, source, a substring expected in the rendered text)
+        ({"kind": "file", "op": "read", "path": "missing.md", "status": "not_found",
+          "error": "file not found: missing.md", "content": ""}, "file", "file not found"),
+        ({"kind": "file", "op": "write", "path": "/etc/x", "status": "denied",
+          "error": "write denied: outside workspace"}, "file", "denied"),
+        ({"kind": "reyn_src", "error": "reyn_src: path '..' resolves outside repo"},
+         "reyn_src_read", "outside"),
+        ({"error": "memory entry not clean", "layer": "user", "slug": "x"},
+         "read_memory_body", "not clean"),
+        ({"kind": "compact", "status": "error", "error_kind": "compaction_unavailable",
+          "error": "no compaction context is wired here"}, "compact", "no compaction context"),
+        ({"kind": "judge_output", "status": "error", "error": "target resolution failed: 'summary'"},
+         "judge_output", "target resolution failed"),
+        ({"kind": "present", "status": "not_found", "ok": False, "error": "data_ref not found: r1"},
+         "present", "data_ref not found"),
+        ({"kind": "render_template", "status": "error", "ok": False,
+          "error": "template syntax error at line 3"}, "render_template", "syntax error"),
+        ({"kind": "task", "ok": False, "error_message": "task.create args invalid: missing title"},
+         "task.create", "args invalid"),
+    ]
+    for result, source, expected_substr in cases:
+        canonical = to_canonical(result, source=source)
+        assert canonical["meta"].get("isError") is True, (source, canonical)
+        assert canonical["text"].strip(), f"{source} error must render non-empty"
+        assert expected_substr in canonical["text"], (source, canonical["text"])
+        # Losslessness holds uniformly: the whole result dict is preserved in the attachment.
+        assert canonical["attachments"] == [{"kind": "structured", "data": result}], source
+
+
+def test_sandboxed_exec_and_mcp_status_error_keep_in_mapper_handling() -> None:
+    """Tier 1: the two producers whose ``status:"error"`` carries a NON-message payload are correctly
+    NOT intercepted by the seam (their status is data-meaning) — they keep their in-mapper handling:
+
+    - ``sandboxed_exec`` nonzero exit → ``stdout``/``stderr`` in ``text``, ``returncode`` as signal meta;
+    - ``mcp`` tool-error → the description (in ``content``) as ``text`` + ``meta.isError``.
+
+    Routing either through ``error_to_canonical`` would drop that payload on the router error path (which
+    renders ``text`` only when ``meta.isError``) — the tightening-A hazard this scoping avoids."""
+    se = to_canonical(
+        {"kind": "sandboxed_exec", "status": "error", "returncode": 2, "stdout": "out", "stderr": "boom"},
+        source="sandboxed_exec",
+    )
+    assert "out" in se["text"] and "boom" in se["text"], se["text"]
+    assert se["meta"].get("returncode") == 2
+
+    mc = to_canonical(
+        {"kind": "mcp", "status": "error", "content": "boom: tool failed", "media_blocks": []},
+        source="mcp",
+    )
+    assert mc["text"] == "boom: tool failed"
+    assert mc["meta"].get("isError") is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tier 2 — the seam at the live pipeline chokepoint (real PipelineExecutor + EventLog)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_recall_error_at_pipeline_chokepoint_renders_non_empty_no_degraded() -> None:
+    """Tier 2: a recall missing-arg error flowing through a real pipeline tool step renders a non-empty
+    canonical error view — and, because piece #1 guarantees an error is non-empty + error-classified, it
+    does NOT trip the piece #2 ``canonical_degraded`` invariant (which now unambiguously means "a SUCCESS
+    result was lost"). Real ``PipelineExecutor`` + real ``EventLog`` (no mocks)."""
+    from reyn.core.offload.canonical import CANONICAL_DEGRADED_EVENT
+
+    def _dispatch(name: str, args: dict) -> dict:
+        return {
+            "ok": False,
+            "error_kind": "missing_required_arg",
+            "error_message": "recall requires ['query', 'sources'].",
+            "missing": ["query", "sources"],
+            "_canonical_source": "recall",
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="recall", args={}, output="r")])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-p1-recall", events=events,
+    )
+
+    # The recall error surfaced into the step's ctx as non-empty text (the M1 fix, end-to-end).
+    ctx_value = result.named_stores["r"]
+    assert ctx_value["text"].strip(), "recall error must reach ctx as non-empty text"
+    assert "recall requires" in ctx_value["text"]
+    # An error is error-classified → it does NOT masquerade as a lost success → no degraded event.
+    assert not [e for e in events.all() if e.type == CANONICAL_DEGRADED_EVENT], (
+        "an error result (non-empty, error-classified) must not trip canonical_degraded"
+    )

--- a/tests/test_fp0056_error_seam.py
+++ b/tests/test_fp0056_error_seam.py
@@ -186,6 +186,63 @@ def test_removed_branch_mappers_still_route_errors_through_the_seam() -> None:
         assert canonical["attachments"] == [{"kind": "structured", "data": result}], source
 
 
+def test_ask_user_refused_surfaces_reason_not_empty_and_is_not_error() -> None:
+    """Tier 1: the THIRD in-mapper hybrid boundary — ``ask_user``'s deliberate P3-item3 refusal
+    ``{status:"refused", reason, answer:""}`` is a typed NON-error outcome carrying no error-message
+    field (so the seam correctly does not intercept it). It MUST render the ``reason`` as NON-EMPTY
+    ``text`` and must NOT be error-framed (``meta.isError`` unset):
+
+    - RED against the pre-fix mapper, which saw the empty ``answer`` and rendered ``(no answer)``,
+      silently dropping the reason (an M1 loss + a cross-arc regression that re-introduced the very
+      empty-answer the #2708 P3-item3 refusal design removed — the LLM could not tell a refusal from a
+      blank answer)."""
+    refused = {
+        "kind": "ask_user", "question": "proceed?", "answer": "",
+        "status": "refused", "reason": "detached/headless spawn — no user attached",
+    }
+    # A refusal is a deliberate outcome, NOT a tool error.
+    assert is_error_result(refused) is False
+    canonical = to_canonical(refused, source="ask_user")
+    # The reason is surfaced (non-empty, NOT the silent "(no answer)").
+    assert canonical["text"].strip()
+    assert canonical["text"] != "(no answer)", "the refusal reason must not be silently dropped"
+    assert "detached/headless spawn" in canonical["text"]
+    # The text is distinguishable as a refusal (the LLM can tell refusal from a blank answer).
+    assert "refused" in canonical["text"].lower()
+    # NOT error-framed — a deliberate refusal is a typed non-error outcome.
+    assert not canonical["meta"].get("isError")
+
+    # A refusal with no reason string still renders a non-empty, refusal-distinguishable text.
+    no_reason = to_canonical(
+        {"kind": "ask_user", "answer": "", "status": "refused"}, source="ask_user"
+    )
+    assert no_reason["text"].strip() and "refused" in no_reason["text"].lower()
+    assert not no_reason["meta"].get("isError")
+
+
+def test_ask_user_legacy_empty_and_answered_paths_unchanged() -> None:
+    """Tier 1: NON-REGRESSION guard — the in-mapper refused branch keys STRICTLY on ``status=="refused"``
+    (the #2708 P3-item3 deliberate refusal) and must NOT alter the two neighbouring shapes the producer
+    distinguishes (ask_user.py):
+
+    - a legacy empty-string auto-refuse (``refused:False`` → ``{status:"ok", answer:""}``) still renders
+      the existing ``(no answer)`` marker (NOT the refusal wording, NOT dropped);
+    - a normal answered result (``{status:"ok", answer:<text>}``) still renders the answer as ``text``.
+
+    Neither is error-classified. This pins that the refused branch does not swallow a success shape."""
+    legacy_empty = to_canonical(
+        {"kind": "ask_user", "question": "q", "answer": "", "status": "ok"}, source="ask_user"
+    )
+    assert legacy_empty["text"] == "(no answer)"
+    assert not legacy_empty["meta"].get("isError")
+
+    answered = to_canonical(
+        {"kind": "ask_user", "question": "q", "answer": "yes", "status": "ok"}, source="ask_user"
+    )
+    assert answered["text"] == "yes"
+    assert not answered["meta"].get("isError")
+
+
 def test_sandboxed_exec_and_mcp_status_error_keep_in_mapper_handling() -> None:
     """Tier 1: the two producers whose ``status:"error"`` carries a NON-message payload are correctly
     NOT intercepted by the seam (their status is data-meaning) — they keep their in-mapper handling:


### PR DESCRIPTION
**[per-PR-coder]** — part of #2699 · Closes #2698

## What & why

The tool-result canonical mapper (`src/reyn/core/offload/canonical.py`) hand-wrote error handling per-mapper, so a mapper with **no error branch** rendered an error to **empty text** — the M1 silent-loss class. Piece #1 (the linchpin) eliminates the class **structurally**: `to_canonical` applies a union error predicate **before** per-mapper dispatch and routes any known error shape to a single lossless `error_to_canonical`; the per-mapper error branches are removed (mappers become success-only).

Design authority: the architect's design pass + **tightening A** in the [#2698 architect comment](https://github.com/tya5/reyn/issues/2698).

## The seam

- **`is_error_result(result) -> bool`** — the fixed-set union predicate: `{isError}` **OR** a truthy dedicated error-message field (`error` / `error_message` / `error_kind`). This is the true union of every removed per-mapper branch (recall/task_ops `{ok:False, error_message}` + `{error_kind}`; `file` denied/not_found which carry `error`; `memory_body`/`reyn_src` `{error}`; …), so removal is regression-free by construction.
- **`error_to_canonical(result) -> CanonicalToolResult`** — **LOSSLESS**: a non-empty `text` (extracted union message) **AND the whole result dict as a structured attachment**, + `meta.isError`.
- **`to_canonical`** runs the seam on the **mapper + CANONICAL_TODO** paths before dispatch; `STRUCTURED_PASSTHROUGH` / unregistered stay on the lossless whole-dict fallback (tightening A #3 — blast-radius; preserves their `canonical_fallback_used` semantics).

## ⚠️ Tightening A — the misclassification safety (please co-vet)

The predicate must not over-match a SUCCESS payload carrying a **data-meaning** `ok`/`status` key. Two concrete hazards, both handled:

1. a health-check `{ok:False, service:"db"}` (`ok:False` means "DB is down" — success data) → **not matched** (a bare `ok is False` is never a trigger).
2. **`sandboxed_exec`'s `{status:"error", returncode:2, stdout, stderr}`** — a nonzero exit is a *successful execution* whose output lives in stdout/stderr, not an `error` field. This is a **real in-repo instance** of the `status` hazard: routing it through `error_to_canonical` would **drop stdout/stderr on the router error path** (which renders `text` only, dropping attachments, when `meta.isError`). → **not matched** (a bare `status` value is never a standalone trigger).

**Design refinement flagged for the co-vet:** the architect's sketch kept `status=="error"` as a *standalone* clause. Primary evidence (`sandboxed_exec.py` sets `status:"error"` for nonzero exit; `test_sandboxed_exec_...` asserts stdout+returncode rendering; router `router_loop.py` drops attachments when `meta.isError`) shows that clause would misclassify `sandboxed_exec` and lose stdout/stderr. I refined the predicate to key on **error-message fields** (the true union of the removed branches) instead of the ambiguous `status` value. `mcp` (message in `content`) and `sandboxed_exec` (output in stdout/stderr) keep their in-mapper `meta.isError` handling precisely because their payload is not a message. **Net effect on M1 elimination is unchanged** — every real error producer carries a message field. Even so, losslessness means any residual misclassification only *mislabels*, never loses data.

## Per-mapper error branches removed (success-only now)

`web_search`, `file`, `reyn_src`, `render_template`, `compact`, `present`, `judge_output`, `memory_body`. (`recall`/`chunks_to_canonical` never had a branch — the #2698 gap; the seam now covers it. The seam also fixes a **latent M1 in `web_fetch`**, whose errors previously rendered `(no content)` with no isError.)

## Interaction with piece #2 (#2748)

After #1, an error is guaranteed non-empty + error-classified, so it never trips `canonical_degraded`; a `canonical_degraded` fire now **unambiguously means "a success result was lost."** Piece #2's tests stay green.

## Tests (`tests/test_fp0056_error_seam.py`, Tier-declared, real instances)

- Tier 1: `is_error_result` True for all fixed error shapes; **False** for data-meaning `{ok:False, service}` and `sandboxed_exec` `{status:error, stdout, returncode}` (tightening A).
- Tier 1: `error_to_canonical` LOSSLESS — proven with a data-meaning payload (no data lost on a hypothetical misclassification).
- Tier 1 (**#2698 acceptance**): recall's `{ok:False, error_message}` renders NON-EMPTY via the seam.
- Tier 1: per-mapper spot-checks (file denied/not_found, reyn_src, memory_body, compact, judge_output, present, render_template, a task_op) all route errors correctly; `sandboxed_exec`/`mcp` keep in-mapper handling.
- Tier 2: recall error at the live pipeline chokepoint renders non-empty and does NOT fire `canonical_degraded`.
- **cp-falsify done**: neutered `is_error_result` → the recall-non-empty acceptance test (+ 3 others) go RED (the `canonical_degraded` warn even fires on the neutered recall) → restored.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0056_error_seam.py` — 8 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/offload/canonical.py` — clean
- [x] `pytest` (repo root) — 7910 passed; 5 pre-existing failures (web route-mounting / plugin-loader) confirmed identical on unmodified canonical.py, unrelated to this change
- [x] cp-falsify RED→GREEN on the #2698 acceptance test

🤖 Generated with [Claude Code](https://claude.com/claude-code)