### PR TITLE
docs: deliverable-4 #4 — llm-invocation-surfaces.md tool-inventory rewrite

### DIFF
--- a/docs/concepts/architecture/llm-invocation-surfaces.ja.md
+++ b/docs/concepts/architecture/llm-invocation-surfaces.ja.md
@@ -15,7 +15,14 @@ audience: [human, agent]
 > `control`/`artifact`/`control_ir` エンベロープが現行ソースに存在しないことを直接
 > grep で確認済みです。第4節(統合 `ToolRegistry` 実装ログ)は現行アーキテクチャを
 > 記述しており正確ですが、`gates(phase=...)` への言及は今や vestigial です(消費する
-> phase surface が無い)。
+> phase surface が無い)。**§2.1 のツール一覧(「常時存在13 tools + 条件付き、13–22
+> tools」という記述)も stale だったため訂正済み** — これは FP-0034 以前の per-kind
+> ツール surface を記述しており、Phase 6(2026-05-16)以降 production の唯一の挙動と
+> なっている universal action catalog wrapper モードではありません。
+> `docs/concepts/tools-integrations/universal-catalog.md` と
+> `src/reyn/runtime/router_tools.py` の `_LEGACY_TOOL_NAMES` strip list、および
+> `ActionRetrievalConfig.universal_wrappers_enabled: bool = True`(production
+> デフォルト)で確認済みです。
 
 ## 1. なぜこれが重要か
 
@@ -31,11 +38,12 @@ Reyn は `RouterLoop`(インタラクティブチャットセッション)経由
 
 **仕組み:** litellm 経由の `call_llm_tools` によるネイティブ LLM function calling。ツール定義は OpenAI `tools` 配列形式に従い、モデルはアシスタントメッセージ内の `tool_calls` で応答する。OS は各呼び出しをディスパッチし、`tool_result` を追記して、モデルが通常テキストを返すまで LLM を再呼び出しする。
 
-**ツール surface:** `src/reyn/runtime/router_tools.py` の `build_tools()` がツールリストを組み立てる。実際の数はオペレーター設定に依存する。
+**ツール surface:** `src/reyn/runtime/router_tools.py` の `build_tools()` がツールリストを組み立て、引き続き OpenAI `tools` 配列形式を返すが、そのリストの **production デフォルトの形状は、もはやフラットな per-kind ツールリストではなく universal action catalog** である — 完全なモデルは [Universal Action Catalog](../tools-integrations/universal-catalog.md) を参照。production デフォルト設定(`action_retrieval.universal_wrappers_enabled: true`、FP-0034 PR-3b-iv 以降のデフォルト)では:
 
-- **常時存在（13 tools）:** `list_skills`, `describe_skill`, `list_agents`, `describe_agent`, `list_memory`, `read_memory_body`, `delegate_to_agent`, `remember_shared`, `remember_agent`, `forget_memory`, `web_search`, `reyn_src_list`, `reyn_src_read`
-- **条件付き（+0〜+9 tools）:** `invoke_skill`（ワークフロー登録時）、`list_directory` + `read_file`（file read スコープ設定時）、`write_file` + `delete_file`（file write スコープ設定時）、`web_fetch`（オペレーターのオプトイン）、`list_mcp_servers` + `list_mcp_tools` + `call_mcp_tool`（MCP servers 設定時）
-- **実測レンジ: 13–22 tools**（`router_tools.py` のコメントに記載の「11–18」は `web_search`、`reyn_src_list`、`reyn_src_read` 追加前の記述であり、現在は stale）
+- **3〜4 個の universal wrapper**(`list_actions`、`describe_action`、`invoke_action`、加えて `action_retrieval.embedding_class` が設定され index が準備できている場合は `search_actions`)が、skill / peer agent / MCP / file / web / memory / RAG corpus / sandboxed exec を含むすべてのカテゴリを、種類ごとに別ツールを用意するのではなく単一の qualified-name dispatch パターン(`<category>__<entry>`)でカバーする。
+- **legacy な per-kind ツールはこのモードで `tools=` から除外される**(`router_tools.py` の `_LEGACY_TOOL_NAMES` セット)— `list_agents`、`describe_agent`、`delegate_to_agent`、`list_memory`、`read_memory_body`、`remember_shared`、`remember_agent`、`forget_memory`、`recall`、`read_file`、`write_file`、`delete_file`、`list_directory`、`web_search`、`web_fetch`、`list_mcp_servers`、`list_mcp_tools`、`call_mcp_tool` 等はもう LLM に見える tool list に現れない。それらのハンドラーは wrapper の backing implementation として registry に残り、`universal_dispatch.py` 経由で dispatch される。
+- **オプションの hot-list 直接エイリアス**(`hot_list_aliases`)を wrapper に加えて追加でき、頻用アクションについてのみ discover ステップを bypass できる。
+- **オペレーターの opt-out**: `action_retrieval.universal_wrappers_enabled: false` を設定すると FP-0034 以前のフラットな per-kind ツールリスト(このセクションがかつて無条件に記述していた形状)に戻る — これは config のエスケープハッチであり、デフォルトの operator 体験ではない。
 
 **役割:** オーケストレーション — 次のサブコンポーネント（ワークフロー、Agent、plan、メモリ操作、直接テキスト応答）を選択する。
 

--- a/docs/concepts/architecture/llm-invocation-surfaces.md
+++ b/docs/concepts/architecture/llm-invocation-surfaces.md
@@ -17,7 +17,15 @@ audience: [human, agent]
 > current source. Those sections have been removed. Section 4 (the unified
 > `ToolRegistry` implementation log) remains accurate — it documents the still-
 > current architecture — except that its `gates(phase=...)` references are now
-> vestigial (no phase surface consumes them).
+> vestigial (no phase surface consumes them). §2.1's tool-inventory list (the
+> "13 always-present + conditional, 13–22 tools" description) was **also stale
+> and has been corrected** — it described the pre-FP-0034 per-kind tool surface,
+> not the universal-action-catalog wrapper mode that has been the sole
+> production behaviour since Phase 6 (2026-05-16), confirmed via
+> `docs/concepts/tools-integrations/universal-catalog.md` and
+> `src/reyn/runtime/router_tools.py`'s `_LEGACY_TOOL_NAMES` strip list plus
+> `ActionRetrievalConfig.universal_wrappers_enabled: bool = True` (the
+> production default).
 
 ## 1. Why this matters
 
@@ -33,11 +41,12 @@ Reyn invokes the LLM via native function-calling tools over `RouterLoop` (intera
 
 **Mechanism:** native LLM function calling via `call_llm_tools` (backed by litellm). Tool definitions follow the OpenAI `tools` array shape; the model replies with `tool_calls` in the assistant message. The OS dispatches each call, appends the `tool_result`, and re-invokes the LLM until it produces a plain text reply.
 
-**Tool surface:** `build_tools()` in `src/reyn/runtime/router_tools.py` assembles the tool list. The actual count depends on operator configuration:
+**Tool surface:** `build_tools()` in `src/reyn/runtime/router_tools.py` assembles the tool list, still returning the OpenAI `tools` array shape, but the *production-default* shape of that list is now the universal action catalog, not a flat per-kind tool list — see [Universal Action Catalog](../tools-integrations/universal-catalog.md) for the full model. In production default config (`action_retrieval.universal_wrappers_enabled: true`, the default since FP-0034 PR-3b-iv):
 
-- **Always present (13 tools):** `list_skills`, `describe_skill`, `list_agents`, `describe_agent`, `list_memory`, `read_memory_body`, `delegate_to_agent`, `remember_shared`, `remember_agent`, `forget_memory`, `web_search`, `reyn_src_list`, `reyn_src_read`.
-- **Conditional (+0 to +9 tools):** `invoke_skill` (when workflows are registered), `list_directory` + `read_file` (when file read scope is configured), `write_file` + `delete_file` (when file write scope is configured), `web_fetch` (operator opt-in), `list_mcp_servers` + `list_mcp_tools` + `call_mcp_tool` (when MCP servers are configured).
-- **Verified range: 13–22 tools.** (The comment in `router_tools.py` that states "11–18" predates the addition of `web_search`, `reyn_src_list`, and `reyn_src_read` and is stale.)
+- **The 3–4 universal wrappers** (`list_actions`, `describe_action`, `invoke_action`, plus `search_actions` when `action_retrieval.embedding_class` is configured and its index is ready) address every category — skill, peer agent, MCP, file, web, memory, RAG corpus, sandboxed exec — through one qualified-name dispatch pattern (`<category>__<entry>`), rather than a separate tool per kind.
+- **Legacy per-kind tools are stripped** from `tools=` in this mode (`router_tools.py`'s `_LEGACY_TOOL_NAMES` set) — `list_agents`, `describe_agent`, `delegate_to_agent`, `list_memory`, `read_memory_body`, `remember_shared`, `remember_agent`, `forget_memory`, `recall`, `read_file`, `write_file`, `delete_file`, `list_directory`, `web_search`, `web_fetch`, `list_mcp_servers`, `list_mcp_tools`, `call_mcp_tool`, and more no longer appear in the LLM-visible tool list; their handlers remain registered as the wrappers' backing implementations, dispatched via `universal_dispatch.py`.
+- **Optional hot-list direct aliases** may be appended on top of the wrappers for frequently-used actions (`hot_list_aliases`), bypassing the discover step for those specific actions only.
+- **Operator opt-out**: setting `action_retrieval.universal_wrappers_enabled: false` restores the pre-FP-0034 flat per-kind tool list (the shape this section used to describe unconditionally) — this is a config escape hatch, not the default operator experience.
 
 **Role:** orchestration — pick the next sub-component (workflow, agent, plan, memory operation, direct text reply).
 


### PR DESCRIPTION
**[docs-maintainer]** — deliverable-4, the approved #4 (llm-invocation-surfaces.md §2.1 rewrite), for #2717.

## Primary-source verification (per lead-coder's ask, before rewriting)
- `src/reyn/runtime/router_tools.py`'s `_LEGACY_TOOL_NAMES` strip set: when universal wrappers are enabled, nearly every tool §2.1 named (`list_agents`, `delegate_to_agent`, `list_memory`, `web_search`, `read_file`, the MCP tools, etc.) is stripped from `tools=` entirely.
- `src/reyn/config/embedding.py`'s `ActionRetrievalConfig`: `universal_wrappers_enabled: bool = True` — confirmed production default (comment: "default since PR-3b-iv").
- `docs/concepts/tools-integrations/universal-catalog.md`'s own text: *"Since Phase 6 (2026-05-16), the wrapper-only path is the sole production behaviour: legacy per-kind tools no longer appear in the LLM-visible `tools=`."*

§2.1's old "13 always-present + conditional, 13–22 tools" description was the pre-FP-0034 flat per-kind tool surface — not what's actually visible to the LLM under production config.

## Fix
Rewrote §2.1's "Tool surface" bullet to describe the current default shape:
- 3–4 universal wrappers (`list_actions` / `describe_action` / `invoke_action` / `search_actions`) addressing every category via qualified-name dispatch (`<category>__<entry>`)
- Legacy per-kind tools stripped in this mode (named the strip set explicitly)
- Optional hot-list direct aliases
- The `universal_wrappers_enabled: false` opt-out (restores the old flat list — a config escape hatch, not the default)

Cross-linked to `universal-catalog.md` as the authoritative, already-maintained tool-inventory doc rather than hand-duplicating its content here — same anti-re-drift lesson as the FP-0021 table fix in `events.md` earlier in this arc (a second hardcoded copy of a fact that changes over time just re-drifts later).

Applied the same fix to `.ja.md`.

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `python3 -m pytest tests/test_fp0036_coverage.py -q` — 23 passed
- [x] `ruff check src tests` — all checks passed
- [x] `git diff | grep -oE "#[0-9]{3,4}"` — none found

This is a technical-accuracy fix (tool-surface description), not positioning copy, so architect gate isn't required per lead-coder's earlier framing — flagging for your review directly.