### PR TITLE
docs: full-rewrite system-design.md (1st of 5, #2750)

### DIFF
--- a/docs/concepts/agent-engineering/index.ja.md
+++ b/docs/concepts/agent-engineering/index.ja.md
@@ -39,7 +39,7 @@ Reyn は 8 つのエンジニアリング視点を通じて読み解けます。
 
 ### 1. [System Design](system-design.md)
 
-マクロ構造: 制御フロー、状態、責任をレイヤーを横断してどのように分散させるか。現行の分割は LLM が決定し、OS が実行し、feature が自分のドメインを所有する、という形で、新しいレイヤー横断の結合はありません。*(このページ自体の本文は現在 stale です — 状態バナーを参照してください。)*
+マクロ構造: 制御フロー、状態、責任をレイヤーを横断してどのように分散させるか。現行の分割は LLM が決定し、OS が実行し、feature が自分のドメインを所有する、という形で、新しいレイヤー横断の結合はありません。
 
 ### 2. [Tool Contract Design](tool-contract-design.md)
 
@@ -78,7 +78,7 @@ run 内で rubric に対して出力をスコアリングする(`judge_output`: 
 - agent エンジニアリング一般が初めてですか? まず `CLAUDE.md` の Constitution 節と [charter.md](../architecture/charter.md) を読んでください — それらが現行の grounded なモデルです。このページにはレンズごとのナラティブな解説のために戻ってきてください。
 - 別のフレームワークから来ていますか? 最も興味のあるレンズにスキップしてください。クロスリンクが必要に応じて他のレンズに引き戻します。
 - 自分のシステムの自己評価をしていますか? 「まだ薄い部分」の記述 — 特に憲章の 2 つの honest thin area である Retrieval と Evaluation — が率直な箇所です。
-- **staleness についての注記**: この 8 つのレンズページのうち 5 つ(System Design、Retrieval、Reliability、Security、Product Think)は、以前の engine 削除 arc で削除された phase-graph skill engine を前提に書かれており、それぞれ何が stale で何が現行かを明示する状態バナーをページ冒頭に持っています。Tool Contract Design はすでにこの訂正を経ています。Evaluation と Observability は現行モデルに対して新規に書かれました。残り 5 ページの完全な de-drift パスは follow-up として、1 ページずつ追跡されています — `charter.md` 自体が family ごとに構築された方法をなぞっています。
+- **staleness についての注記**: この 8 つのレンズページのうち 4 つ(Retrieval、Reliability、Security、Product Think)は、以前の engine 削除 arc で削除された phase-graph skill engine を前提に書かれており、それぞれ何が stale で何が現行かを明示する状態バナーをページ冒頭に持っています。Tool Contract Design と System Design はすでに完全な書き直しを経ています。Evaluation と Observability は現行モデルに対して新規に書かれました。残り 4 ページの完全な de-drift パスは follow-up として、1 ページずつ追跡されています — `charter.md` 自体が family ごとに構築された方法をなぞっています。
 
 ## 関連情報
 

--- a/docs/concepts/agent-engineering/index.md
+++ b/docs/concepts/agent-engineering/index.md
@@ -39,7 +39,7 @@ Every layer has a corresponding engineering lens. The lenses don't partition the
 
 ### 1. [System Design](system-design.md)
 
-The macro shape: how control flow, state, and responsibility are distributed across layers. The current split is LLM-decides / OS-executes / feature-owns-its-domain — no new cross-layer coupling. *(This page's own body is currently stale; see its status banner.)*
+The macro shape: how control flow, state, and responsibility are distributed across layers. The current split is LLM-decides / OS-executes / feature-owns-its-domain — no new cross-layer coupling.
 
 ### 2. [Tool Contract Design](tool-contract-design.md)
 
@@ -78,7 +78,7 @@ Three of the eight lenses name a *discipline* whose *universal mechanism* is one
 - New to agent engineering generally? Read `CLAUDE.md`'s Constitution section and [charter.md](../architecture/charter.md) first — they're the current, grounded model. Come back here for the narrative per-lens walkthrough.
 - Coming from another framework? Skip to the lens you care most about; cross-links will pull you back to the others as needed.
 - Doing self-assessment for your own system? The "where it's still thin" passages — especially on Retrieval and Evaluation, the constitution's two honest thin areas — are the candid bits.
-- **A note on staleness**: five of these eight lens pages (System Design, Retrieval, Reliability, Security, Product Think) were written against the phase-graph skill engine deleted in an earlier engine-deletion arc, and each carries a status banner at the top naming exactly what's stale vs. still current. Tool Contract Design already went through this correction. Evaluation and Observability are newly written against the current model. A full de-drift pass on the remaining five is tracked as a follow-up, one page at a time — mirroring how `charter.md` itself was built family-by-family.
+- **A note on staleness**: four of these eight lens pages (Retrieval, Reliability, Security, Product Think) were written against the phase-graph skill engine deleted in an earlier engine-deletion arc, and each carries a status banner at the top naming exactly what's stale vs. still current. Tool Contract Design and System Design have already gone through a full rewrite; Evaluation and Observability are newly written against the current model. A full de-drift pass on the remaining four is tracked as a follow-up, one page at a time — mirroring how `charter.md` itself was built family-by-family.
 
 ## See also
 

--- a/docs/concepts/agent-engineering/system-design.ja.md
+++ b/docs/concepts/agent-engineering/system-design.ja.md
@@ -6,51 +6,47 @@ audience: [human, agent]
 
 # System Design
 
-> **状態: stale。** このページは phase-graph skill engine(Phase / Workflow / OS
-> のレイヤー分割、`candidate_outputs` エッジ)を前提に書かれていますが、
-> 後の engine 削除 arc で削除されました — 現行ソースにどちらの概念も存在しないことを
-> 直接 grep で確認済みです。現行モデル(permission gate を通す typed Control IR op
-> dispatch、phase graph ではなく Control IR op/pipeline/skill に dispatch する
-> router loop)をカバーする書き直しは follow-up として追跡されています。当面は
-> `CLAUDE.md` の Constitution 節と
-> [`docs/concepts/architecture/charter.md`](../architecture/charter.md)
-> (System Design 行)が、この lens の現行 grounded ソースです。
-
 agent システムのマクロ構造: 制御フロー、状態、責任をレイヤーを横断してどのように分散させるか、そしてランタイムが LLM が何をしても強制する不変条件は何か。
 
 ## Reyn の実装方法
 
-3 つのレイヤー、それぞれ単一の責任を持つ:
+### レイヤー分割: LLM が決定し、OS が実行し、feature が自身のドメインを所有する
+
+Reyn の現行の形には、辿るべき固定の phase グラフはもうありません。代わりに、3 つの責任が構造的に分離されています:
 
 | レイヤー | 所有するもの | 知っていること |
 |-------|------|-------------|
-| **OS** | ランタイムループ、検証、Events | ワークフローのドメインは何も知らない |
-| **ワークフロー** | グラフ、エントリー Phase、final output schema | 自身の Phase と artifact のみ |
-| **Phase** | 入力 artifact 型 + LLM への指示 | 自身の入力以外は何も知らない |
+| **LLM** | 次に何をするか、どの順番で、どんな引数で | 現在のターンのコンテキストフレームに含まれるものだけ — それ以外は何も知らない |
+| **OS** | op dispatch、スキーマ検証、permission gate、audit-event ログ、workspace | workflow/skill/pipeline 固有の文字列リテラルは一切知らない(今も有効な P7 不変条件) |
+| **Feature(skill / pipeline / agent)** | 自身の指示、自身の artifact、自身のスコープ | 与えられたもの以外は何も知らない — ある skill は他の skill の状態に踏み込めない |
 
-この分割から 2 つの不変条件が生まれます:
+LLM がどのサーフェス(chat router、A2A、MCP)経由で話していても、2 つの不変条件が成り立ちます:
 
-1. **グラフが LLM を制約する。** LLM は `candidate_outputs` からエッジを選択し、OS はそれ以外を拒否します。制御フローは有限状態機械であり、自由形式のプロンプトチェーンではありません。
-2. **OS はワークフローに依存しない。** 特定の Phase、artifact、またはフィールドを命名する文字列リテラルは OS コードに現れません（P7）。新しいワークフローは純粋なデータであり、OS コードは変わりません。
+1. **すべての副作用は typed で schema-validated な Control IR op であり、LLM が手作りする自由形式の文字列では決してない。** OS は不正な形式の op を実行前に拒否します。LLM の出力から op-schema 検証を経ずに直接副作用に至る経路は存在しません。
+2. **すべての op は、どの tool-use scheme が LLM に提示していようと(ネイティブ function-calling、universal action catalog wrapper、CodeAct、…)、同じ exclude → permission → dispatch ゲートを通ります。** 提示レイヤーは差し替え可能ですが、その下にあるゲートは差し替え不可能です。
 
-結果として、ワークフローの動作はワークフローファイルと各 Phase 内での LLM の選択の関数になります。どちらも小さく、検査可能です。
+### 構造的な有界性が今も存在する場所: Pipeline
 
-### LLM の制御フローを制限する理由
+旧 phase-graph engine の安全性の論拠は有限状態機械でした: LLM は閉じた候補集合からエッジを選ぶことしかできず、run 全体が証明可能に有界でした。その特定の機構は無くなりましたが、同じ*種類*の保証 — LLM が逃れられない、閉じた non-Turing-complete な control-plane — は、それを望むケースに対して今日も存在します: **Pipeline** です。pipeline は決定論的な DSL であり、その合成プリミティブは構造的に閉じています(ネストした `launch` なし、任意の再帰なし)。安全性とクラッシュリカバリは、無制限の実行グラフの上に重ねられたランタイムポリシーからではなく、DSL の形そのものから来ます。
 
-制限のない LLM オーケストレーションは、測定可能な 3 つの方法で不安定です:
+Chat(router loop)は意図的にこの同じ厳密な有界性を再導入**しません** — その安全性の論拠は異なります: typed-op 検証 + permission gate + force-close 付き bounded-loop + audit-event/WAL trail であり、LLM が踏み外せない閉じたグラフではありません。あるタスクに Pipeline と chat-router オーケストレーションのどちらを選ぶかは、この 2 つの安全性の論拠のどちらを望むかを選ぶことです。
 
-- **ドリフト。** 自由な選択のたびにタスクから逸脱するチャンスが生まれます。
-- **テスト不可能性。** 「このプロンプトは最終的に完了するか？」は自由な agent では決定不可能ですが、有限グラフでは自明に決定可能です。
-- **再入不可能。** 何かが失敗した場合、失敗した Phase を特定したいものです。自由形式のオーケストレーションには指し示す Phase がありません。
+### 現行の具体的な機構
 
-Reyn はワークフローグラフを明示的に書くコストを支払い、代わりに予測可能性を得ます。
+- **Chat session / router loop** — `RouterLoop` が LLM が選んだ各アクション(skill run、agent delegation、pipeline launch、MCP call、memory op、…)を、同じ permission-gated な dispatch パス経由で実行します。
+- **Skill** — 段階的開示の instructions(L1 system-prompt メニュー → L2 on-demand フル読み込み → L3 バンドル済み asset 読み込み)であり、OS が実行するプログラムではありません。モデルが読むかどうかを選びます。
+- **Environment backend 抽象化** — `EnvironmentBackend` が repo-FS の read/write/exec が *どこで* 行われるか(host か container か)を OS + permission レイヤーから完全に抽象化するため、実行場所によって governance レイヤーが変わることはありません。
+- **Workspace(P5)がシングルソースオブトゥルース** — agent が生成するすべての artifact は workspace チャンネルを通過します。LLM のコンテキストウィンドウにしか存在しない load-bearing なものはありません。
+- **P6 audit-event ログ** — OS が引き起こすすべての状態変化は audit-event を発行し、LLM が何をしたかに関係なく、すべての run に完全でリプレイ可能な記録を残します。
 
 ## まだ薄い部分
 
-グラフは自己ループのない DAG です。Phase は自身を次の Phase としてリストできません。修正ループは別の Phase を使います（`review → revise → review`）。実用上は問題ありませんが、一部のフレームワークが「同じステップをインラインでリトライ」できるのに対し、1 つのノードが追加されます。単一の Phase では不十分な場合のエスケープハッチは、サブスキルノード（グラフ内の `@subskill`）です。
+phase-graph の厳密な有限状態機械を手放したことによるトレードオフは、見かけだけのものではなく本物です: chat-router オーケストレーションはもはや、ある run が終了する、または固定された経路の集合にとどまるという*構造的*保証を与えません — その保証は今や、閉じたグラフの形(LLM が文字通り違反できない構造的性質)ではなく、force-close 付き bounded-loop(ランタイムポリシー)に存在します。Pipeline は、タスクが構造的保証を必要とするときに戻るためのエスケープハッチであり、chat オーケストレーションはより open-ended なデフォルトです。このトレードが見合うかどうかはタスクごとの判断であり、決着済みの問題ではありません — 現行の bounded-loop 機構がどう働くかは [reliability-engineering.md](reliability-engineering.md) を参照してください。
 
 ## 関連情報
 
-- [../architecture/llm-as-decision-engine.md](../architecture/llm-as-decision-engine.md)
-- [tool-contract-design.md](tool-contract-design.md) — LLM が選択をどのように表現するか
-- [reliability-engineering.md](reliability-engineering.md) — LLM が間違えたときに何が起こるか
+- `CLAUDE.md`(§ Constitution)— System Design レンズの pass-line、canonical
+- [`docs/concepts/architecture/charter.md`](../architecture/charter.md) — 7 つの feature family すべてで grounded された System Design 行
+- [tool-contract-design.md](tool-contract-design.md) — LLM がどのように選択を表現するか(このページの不変条件 #1 が依存する typed op contract)
+- [reliability-engineering.md](reliability-engineering.md) — LLM が間違えたときに何が起こるか、force-close 付き bounded-loop 機構がどう働くか
+- [`docs/concepts/runtime/pipelines.md`](../runtime/pipelines.md) — Pipeline の構造的な閉じ方の全体

--- a/docs/concepts/agent-engineering/system-design.md
+++ b/docs/concepts/agent-engineering/system-design.md
@@ -6,51 +6,47 @@ audience: [human, agent]
 
 # System Design
 
-> **Status: stale.** This page was written against the phase-graph skill engine
-> (Phase / Workflow / OS layering, `candidate_outputs` edges), deleted in a
-> later engine-deletion arc — confirmed via direct grep that neither concept
-> exists in current source. A rewrite covering the current model (typed
-> Control IR op dispatch through a permission gate; the router loop
-> dispatching to Control IR ops, pipelines, and skills rather than a phase
-> graph) is tracked as a follow-up. In the meantime, `CLAUDE.md`'s
-> Constitution section and [`docs/concepts/architecture/charter.md`](../architecture/charter.md)
-> (System Design row) are the current, grounded source for this lens.
-
 The macro shape of an agent system: how control flow, state, and responsibility are distributed across layers, and what invariants the runtime enforces no matter what the LLM does.
 
 ## How reyn handles it
 
-Three layers, each with a single responsibility:
+### The layer split: LLM decides, OS executes, feature owns its own domain
+
+reyn's current shape has no fixed graph of phases to walk. Instead, three responsibilities are kept structurally separate:
 
 | Layer | Owns | Knows about |
 |-------|------|-------------|
-| **OS** | The runtime loop, validation, events | None of the workflow's domain |
-| **Workflow** | The graph, entry phase, final output schema | Only its own phases and artifacts |
-| **Phase** | An input artifact type + LLM instructions | Nothing outside its own input |
+| **LLM** | Which action to take next, in what order, with what arguments | Whatever the current turn's context frame contains — nothing else |
+| **OS** | Op dispatch, schema validation, the permission gate, the audit-event log, the workspace | No workflow/skill/pipeline-specific string literal (the still-true P7 invariant) |
+| **Feature (skill / pipeline / agent)** | Its own instructions, its own artifacts, its own scope | Nothing outside what it's given — a skill can't reach into another skill's state |
 
-Two invariants follow from the split:
+Two invariants hold regardless of which surface the LLM is talking through (chat router, A2A, MCP):
 
-1. **The graph constrains the LLM.** The LLM picks an edge from `candidate_outputs`; the OS rejects anything else. Control flow is a finite state machine, not free-form prompt chaining.
-2. **The OS is workflow-agnostic.** No string literal naming a specific phase, artifact, or field appears in OS code (P7). New workflows are pure data; OS code never changes.
+1. **Every side effect is a typed, schema-validated Control IR op — never a free-form string the LLM constructs by hand.** The OS rejects malformed ops before they run; there is no path from LLM output straight to a side effect without passing through op-schema validation.
+2. **Every op routes through the same exclude → permission → dispatch gate, regardless of which tool-use scheme presents it to the LLM** (native function-calling, universal action catalog wrapper, CodeAct, …). The presentation layer is swappable; the gate underneath it is not.
 
-The result: a workflow's behavior is a function of its workflow files plus the LLM's choices within each phase — both small, both inspectable.
+### Where hard, structural boundedness still exists: Pipeline
 
-### Why bound the LLM's control flow
+The old phase-graph engine's safety argument was a finite-state-machine: the LLM could only pick an edge from a closed candidate set, so the whole run was provably bounded. That specific mechanism is gone, but the same *kind* of guarantee — a closed, non-Turing-complete control-plane the LLM cannot escape — still exists today for the case that wants it: **Pipeline**. A pipeline is a deterministic DSL whose composition primitives are structurally closed (no nested `launch`, no arbitrary recursion), so safety and crash-recovery come from the DSL's shape, not from a runtime policy layered on top of an unbounded execution graph.
 
-Unbounded LLM orchestration is unstable in three measurable ways:
+Chat (the router loop) deliberately does **not** re-impose that same hard boundedness — its safety argument is different: typed-op validation + the permission gate + bounded-loop-with-force-close + the audit-event/WAL trail, rather than a closed graph the LLM can't step outside of. Choosing Pipeline vs. chat-router orchestration for a given task is choosing which of these two safety arguments you want.
 
-- **Drift.** Each free choice is a chance to wander off-task.
-- **Untestability.** "Will this prompt eventually finish?" is undecidable for a free agent and trivially decidable on a finite graph.
-- **No clean re-entry.** When something fails, you want to point to the failing phase. Free-form orchestration has no phases to point at.
+### Concrete current mechanisms
 
-reyn pays the cost of writing workflow graphs explicitly and gets predictability in return.
+- **Chat session / router loop** — a `RouterLoop` dispatches each LLM-chosen action (skill run, agent delegation, pipeline launch, MCP call, memory op, …) through the same permission-gated dispatch path.
+- **Skills** — layered-disclosure instructions (an L1 system-prompt menu → L2 on-demand full read → L3 bundled-asset read), not programs the OS executes; the model chooses to read them.
+- **Environment backend abstraction** — `EnvironmentBackend` abstracts *where* repo-FS read/write/exec happens (host vs. container) away from the OS + permission layer entirely, so the governance layer doesn't change based on execution location.
+- **Workspace (P5) as the single source of truth** — every artifact an agent produces passes through the workspace channel; nothing load-bearing lives only in an LLM's context window.
+- **The P6 audit-event log** — every state change the OS causes emits an audit-event, giving every run a complete, replayable record independent of what the LLM chose to do.
 
 ## Where it's still thin
 
-The graph is a DAG with no self-loops — a phase cannot list itself as a next phase. Revision loops use a separate phase (`review → revise → review`). This is fine in practice but adds one node where some frameworks let you "retry the same step inline." Sub-skill nodes (`@subskill` in the graph) are the escape hatch when a single phase isn't enough.
+The trade-off from dropping the phase-graph's hard finite-state-machine is real, not just cosmetic: chat-router orchestration no longer gives a *structural* guarantee that a given run terminates or stays on a fixed set of paths — that guarantee now lives in bounded-loop-with-force-close (a runtime policy) rather than in the shape of a closed graph (a structural property the LLM literally cannot violate). Pipeline is the escape hatch back to a structural guarantee when a task needs one; chat orchestration is the more open-ended default. Whether that trade is worth it is a per-task judgment call, not a settled question — see [reliability-engineering.md](reliability-engineering.md) for how the current bounded-loop mechanism works.
 
 ## See also
 
-- [../architecture/llm-as-decision-engine.md](../architecture/llm-as-decision-engine.md)
-- [tool-contract-design.md](tool-contract-design.md) — how the LLM expresses its choices
-- [reliability-engineering.md](reliability-engineering.md) — what happens when the LLM gets it wrong
+- `CLAUDE.md` (§ Constitution) — the System Design lens's pass-line, canonical
+- [`docs/concepts/architecture/charter.md`](../architecture/charter.md) — the System Design row grounded across all 7 feature families
+- [tool-contract-design.md](tool-contract-design.md) — how the LLM expresses its choices (the typed op contract this page's invariant #1 depends on)
+- [reliability-engineering.md](reliability-engineering.md) — what happens when the LLM gets it wrong, and how bounded-loop-with-force-close works
+- [`docs/concepts/runtime/pipelines.md`](../runtime/pipelines.md) — Pipeline's structural closedness in full


### PR DESCRIPTION
**[docs-maintainer]** — #2750, family-by-family rewrite, 1st of 5 pages (System Design, the most structural — was fully dead, no salvageable content).

## What changed
Full rewrite replacing the banner-de-drifted stub:

- **Layer split table**: LLM decides / OS executes / feature owns its own domain (replacing the dead Phase/Workflow/OS split, `candidate_outputs` edges).
- **Two invariants** that hold regardless of tool-use scheme: typed Control IR op (never free-form), same `exclude → permission → dispatch` gate underneath every presentation surface.
- **Pipeline named as the current home of hard, structurally-closed boundedness** — the old phase-graph's finite-state-machine safety argument doesn't have a like-for-like replacement in chat orchestration; Pipeline is where that same *kind* of guarantee lives today for tasks that want it. Chat's own safety argument is different (bounded-loop + audit-trail, not a closed graph).
- **Concrete current mechanisms**: chat session/router loop, skills' layered disclosure, `EnvironmentBackend` host/container abstraction, workspace as SSoT, P6 audit-event log.
- **"Where it's still thin"** keeps this honest: dropping the phase-graph's structural termination guarantee is a real trade-off, not resolved drift papered over.

## Also touched
`index.md`(`.ja.md`): removed the "currently stale" parenthetical on the System Design entry (now rewritten); updated the staleness-note count from 5 remaining stale pages to 4 (Retrieval, Reliability, Security, Product Think).

Dropped the `architecture/llm-as-decision-engine.md` link from "See also" — that page is itself built entirely on the dead `candidate_outputs`/phase-transition model and is separately tracked as owner-gated for its whole-file fate; not citable as a current source.

## Template rules applied
No `history` refs (issue numbers) in the page body. Grounded every claim in a real current source (feature-map.md's OS Core differentiation blockquote, Pipeline's differentiation blockquote, EnvironmentBackend, P5/P6/P7).

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `python3 -m pytest tests/test_fp0036_coverage.py -q` — 23 passed
- [x] `ruff check src tests` — all checks passed
- [x] `git diff | grep -oE "#[0-9]{3,4}"` — none found

Requesting architect anti-overclaim gate review per the #2750 approach.