### PR TITLE
feat: M3 inner-dispatch fail-visible seam — the final canonical silent-loss piece (FP-0056 v2 #3)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -47,6 +47,14 @@ A genuinely unregistered ``source`` (dynamic/edge, or ``None``) keeps the lossle
 PR-F2 adds the ``canonical_fallback_used`` visibility event (degrade-with-audit) on the TODO + unknown
 paths.
 
+FP-0056 v2 closes the three canonical silent-loss modes structurally: piece #1 the shared error seam
+(M1, ``error_to_canonical`` before every mapper), piece #2 the runtime ``canonical_degraded`` invariant
+(M2, a success-mapper returning empty), and piece #3 (this) the inner-dispatch FAIL-VISIBLE seam (M3):
+a mapper whose inner discriminator is missing/unknown raises :class:`CanonicalDiscriminatorMiss` instead
+of emitting status-only garbage (the #2695 ``"None: ok"`` — non-empty so M2's empty-check misses it, not
+an error so M1's seam misses it); :func:`to_canonical` catches it and rides the EXISTING whole-dict
+fallback + ``canonical_fallback_used`` (reason ``"discriminator_miss"``).
+
 P7: the source → canonical mapping is OS-level (no domain-specific vocabulary). The deref / paging /
 offload store machinery is reused unchanged — 案B removes only the field-guessing.
 """
@@ -117,6 +125,22 @@ class _Undeclared:
 # canonical choice; the coverage gate rejects it (red CI naming the tool). It exists so a missing
 # declaration is a loud gate failure, not a silent fallback.
 UNDECLARED = _Undeclared()
+
+
+class CanonicalDiscriminatorMiss(Exception):
+    """Raised by an inner-dispatch mapper when its inner discriminator (the sub-field it switches on —
+    ``file``'s ``op``, ``reyn_src``'s ``content``/``entries``/``matches`` body key) is MISSING or an
+    UNKNOWN value, so the mapper cannot render a success view (FP-0056 v2 piece #3, mode M3).
+
+    The mapper raises this instead of falling through to a status-only catch-all that interpolates the
+    (often ``None``) discriminator into text — the ``"None: ok"`` garbage the #2695 file glob/list bug
+    emitted (non-empty, so piece #2's ``canonical_degraded`` empty-check does NOT catch it; not an
+    error, so piece #1's shared error seam does NOT catch it either). :func:`to_canonical` catches this
+    and takes the SAME lossless whole-dict fallback a genuine unknown source would (:func:`_fallback_structured`),
+    marking it so the caller emits the EXISTING ``canonical_fallback_used`` audit-event (reason
+    ``"discriminator_miss"``) — the discriminator-miss renders the full dict (recoverable) + emits the
+    audit signal, instead of silent garbage. No new mechanism: M3 rides the existing whole-dict-fallback
+    visibility (the path #2695 should have taken)."""
 
 
 # A canonical declaration: a mapper, the reviewed passthrough opt-in, or the provisional TODO marker.
@@ -470,7 +494,13 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
     SUCCESS shape only — FP-0056 v2 piece #1 routes any error (``status`` error/denied/not_found, which
     carry an ``error`` field) through the shared ``error_to_canonical`` seam before this mapper runs; the
     whole result dict (incl. ``op``/``status``/``path``) is preserved in that error view's lossless
-    structured attachment."""
+    structured attachment.
+
+    ``op`` is the inner discriminator: when it is MISSING or an UNKNOWN value (the #2695 glob/list
+    adapters that normalized ``op`` away), this raises :class:`CanonicalDiscriminatorMiss` — FAIL-VISIBLE
+    (mode M3) — so :func:`to_canonical` takes the lossless whole-dict fallback + fires
+    ``canonical_fallback_used``, INSTEAD of the old status-only ``f"{op}: {status}"`` = ``"None: ok"``
+    garbage."""
     op = result.get("op")
     meta = _file_signal_meta(result)
     if op == "read":
@@ -496,10 +526,13 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
         text = "\n".join(str(m) for m in matches) if matches else "(no matches)"
         return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
 
-    # write / edit / delete / mkdir / move / stat / regenerate_index → a short status text.
-    return CanonicalToolResult(
-        text=_render_file_status(op, result), attachments=[], source_ref=None, meta=meta,
-    )
+    # write / edit / delete / mkdir / move / stat / regenerate_index → a short status text. A missing/
+    # unknown ``op`` is a discriminator-miss → fail-visible (M3), NEVER the old ``"None: ok"`` garbage.
+    if op in _FILE_STATUS_OPS:
+        return CanonicalToolResult(
+            text=_render_file_status(op, result), attachments=[], source_ref=None, meta=meta,
+        )
+    raise CanonicalDiscriminatorMiss(f"file_to_canonical: missing/unknown op {op!r}")
 
 
 def _render_file_grep(result: dict) -> str:
@@ -520,10 +553,20 @@ def _render_file_grep(result: dict) -> str:
     return "\n".join(lines)
 
 
+# The mutating / metadata ``file`` ops whose success view is a short status line (read/grep/glob are
+# handled earlier in ``file_to_canonical`` by their own body). Any ``op`` outside read/grep/glob AND
+# this set is a discriminator-miss → :class:`CanonicalDiscriminatorMiss` (M3), never status garbage.
+_FILE_STATUS_OPS = frozenset(
+    {"write", "edit", "delete", "mkdir", "move", "stat", "regenerate_index"}
+)
+
+
 def _render_file_status(op: "str | None", result: dict) -> str:
     """A short, human-readable status line for a mutating / metadata ``file`` op (write/edit/delete/
     mkdir/move/stat/regenerate_index). Descriptive, not JSON — the LLM acts on the outcome, not the
-    envelope."""
+    envelope. Only ever called with an ``op`` in :data:`_FILE_STATUS_OPS` (``file_to_canonical`` raises
+    :class:`CanonicalDiscriminatorMiss` for a missing/unknown ``op`` before reaching here), so there is
+    no status-only ``f"{op}: {status}"`` catch-all — that was the #2695 ``"None: ok"`` garbage."""
     path = result.get("path", "")
     if op == "write":
         text = f"Wrote {result.get('bytes_written', 0)} bytes to {path}."
@@ -543,7 +586,9 @@ def _render_file_status(op: "str | None", result: dict) -> str:
         return f"Regenerated index at {result.get('output_path', '')}: {result.get('entries', 0)} entries."
     if op == "stat":
         return f"stat {path}: {result.get('info')}"
-    return f"{op}: {result.get('status', 'ok')}"
+    # Unreachable for a valid op (caller guards with ``_FILE_STATUS_OPS``); defensive fail-visible
+    # rather than the removed ``f"{op}: {status}"`` = ``"None: ok"`` garbage catch-all.
+    raise CanonicalDiscriminatorMiss(f"_render_file_status: unhandled op {op!r}")
 
 
 def reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
@@ -559,7 +604,11 @@ def reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
       rendered lines as ``text``.
 
     SUCCESS shape only — FP-0056 v2 piece #1 routes an ``{error}`` result through the shared
-    ``error_to_canonical`` seam before this mapper runs."""
+    ``error_to_canonical`` seam before this mapper runs. The body key (``content``/``entries``/
+    ``matches``) is the inner discriminator: a result carrying NONE of them raises
+    :class:`CanonicalDiscriminatorMiss` (mode M3) so :func:`to_canonical` takes the lossless whole-dict
+    fallback + fires ``canonical_fallback_used`` — the SAME recoverable output as the old inline
+    whole-dict return, now AUDITED (fail-visible) rather than silently unmapped."""
     if "content" in result:
         meta = {"path": result["path"]} if result.get("path") is not None else {}
         text = _explicit_empty(result.get("content", "") or "", "(empty file)")
@@ -583,10 +632,11 @@ def reyn_src_to_canonical(result: dict) -> CanonicalToolResult:
         return CanonicalToolResult(
             text=text or "(no matches)", attachments=[], source_ref=None, meta={},
         )
-    # A reyn_src shape with none of the known bodies — keep the whole dict lossless as structured.
-    return CanonicalToolResult(
-        text="", attachments=[{"kind": "structured", "data": result}], source_ref=None, meta={},
-    )
+    # A reyn_src shape with none of the known bodies (content/entries/matches) — discriminator-miss.
+    # Fail-visible (M3): raise so ``to_canonical`` takes the lossless whole-dict fallback AND fires
+    # ``canonical_fallback_used``, instead of an inline whole-dict return that was recoverable but
+    # SILENT (unaudited).
+    raise CanonicalDiscriminatorMiss("reyn_src_to_canonical: no content/entries/matches body key")
 
 
 def render_template_to_canonical(result: dict) -> CanonicalToolResult:
@@ -737,16 +787,30 @@ def ask_user_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
-def _fallback_structured(result: dict) -> CanonicalToolResult:
+# A private, NON-rendered marker key stamped on the whole-dict fallback canonical when it was taken
+# because an inner-dispatch mapper raised :class:`CanonicalDiscriminatorMiss` (FP-0056 v2 piece #3, M3).
+# It is a signal channel for :func:`canonical_fallback_reason` only — the renderer (``build_offload_body``
+# reads ``attachments``/``meta``) and the ctx reducer (``canonical_to_ctx_fields`` reads ``text``/
+# ``attachments``) never read it, so it never reaches the LLM body (unlike ``meta``, which renders as
+# frontmatter YAML).
+_DISCRIMINATOR_MISS_MARKER = "_discriminator_miss"
+
+
+def _fallback_structured(result: dict, *, discriminator_miss: bool = False) -> CanonicalToolResult:
     """The lossless whole-dict fallback: the entire result becomes a ``structured`` attachment
     (readable as frontmatter YAML, ``ctx.<name>.structured.<field>`` still programmatically reachable),
     ``text`` empty. Used for a declared ``STRUCTURED_PASSTHROUGH`` producer, a provisional
-    ``CANONICAL_TODO`` producer, AND a genuinely unregistered ``source`` (dynamic/edge). PR-F2 adds a
-    ``canonical_fallback_used`` event on the ``CANONICAL_TODO`` + unregistered paths (degrade-with-
-    audit) — but NOT on ``STRUCTURED_PASSTHROUGH`` (a reviewed, legitimate whole-dict view)."""
-    return CanonicalToolResult(
+    ``CANONICAL_TODO`` producer, a genuinely unregistered ``source`` (dynamic/edge), AND a mapped
+    producer whose inner discriminator missed (``discriminator_miss=True`` — FP-0056 v2 piece #3, M3).
+    PR-F2 emits ``canonical_fallback_used`` on the ``CANONICAL_TODO`` + unregistered paths, and piece #3
+    on the discriminator-miss path (degrade-with-audit) — but NOT on ``STRUCTURED_PASSTHROUGH`` (a
+    reviewed, legitimate whole-dict view)."""
+    canonical = CanonicalToolResult(
         text="", attachments=[{"kind": "structured", "data": result}], source_ref=None, meta={},
     )
+    if discriminator_miss:
+        canonical[_DISCRIMINATOR_MISS_MARKER] = True  # type: ignore[typeddict-unknown-key]
+    return canonical
 
 
 def to_canonical(result: dict, *, source: "str | None" = None) -> CanonicalToolResult:
@@ -774,7 +838,15 @@ def to_canonical(result: dict, *, source: "str | None" = None) -> CanonicalToolR
         return error_to_canonical(result)
     if declaration is CANONICAL_TODO:
         return _fallback_structured(result)
-    return declaration(result)
+    # FP-0056 v2 piece #3 — the M3 fail-visible seam. A mapper whose inner discriminator is missing/
+    # unknown raises ``CanonicalDiscriminatorMiss`` rather than emitting status-only garbage (#2695
+    # ``"None: ok"``). Route it to the SAME lossless whole-dict fallback a genuine unknown takes, marked
+    # so the caller emits ``canonical_fallback_used`` (reason ``"discriminator_miss"``) — full dict
+    # recoverable + audit signal, never silent garbage.
+    try:
+        return declaration(result)
+    except CanonicalDiscriminatorMiss:
+        return _fallback_structured(result, discriminator_miss=True)
 
 
 # The audit-event kind the two live ``to_canonical`` callers emit when a result took a VISIBLE
@@ -785,14 +857,23 @@ CANONICAL_FALLBACK_EVENT = "canonical_fallback_used"
 
 
 def canonical_fallback_reason(
-    source: "str | None", *, structured_offloaded: bool = False
+    source: "str | None",
+    *,
+    structured_offloaded: bool = False,
+    canonical: "CanonicalToolResult | None" = None,
 ) -> "str | None":
     """Return the audit reason a :data:`CANONICAL_FALLBACK_EVENT` should carry for ``source``'s
     canonicalization, or ``None`` when nothing should fire (FP-0056 PR-F2 — the visibility half).
 
-    A short category string is returned on each of the three fail-visible paths (owner decisions #2/#3
+    A short category string is returned on each of the four fail-visible paths (owner decisions #2/#3
     — degrade-with-audit, never silently):
 
+    - ``canonical`` carries the discriminator-miss marker — a MAPPED producer whose inner discriminator
+      was missing/unknown, so :func:`to_canonical` took the lossless whole-dict fallback instead of the
+      mapper's status-only garbage (FP-0056 v2 piece #3, mode M3) → ``"discriminator_miss"``. Checked
+      FIRST because it is the ONE fallback a real-mapper ``source`` can take; without it the declaration
+      lookup below would (wrongly) report ``None`` for a mapped producer that DID fall back. The #2695
+      ``"None: ok"`` class made runtime-visible.
     - ``source`` unregistered / ``None`` (a genuine unknown the registries can't enumerate → the
       lossless whole-dict fallback) → ``"unregistered"``.
     - ``source`` declared :data:`CANONICAL_TODO` (gate-satisfying debt, no real mapper yet → the same
@@ -803,9 +884,12 @@ def canonical_fallback_reason(
       this producer — make it visible). A SMALL (inline) passthrough is a reviewed, legitimate view →
       ``None`` (no event).
 
-    A real mapper always returns ``None`` — a mapped producer never took a fallback. Only a reason
-    CATEGORY is returned; NO result content is ever returned or logged (audit signal, not data — the
-    callers emit the ``source`` id + this reason, never the result body)."""
+    A real mapper that mapped cleanly always returns ``None`` — a mapped producer that did not fall back
+    never took a fallback. Only a reason CATEGORY is returned; NO result content is ever returned or
+    logged (audit signal, not data — the callers emit the ``source`` id + this reason, never the result
+    body)."""
+    if canonical is not None and canonical.get(_DISCRIMINATOR_MISS_MARKER):
+        return "discriminator_miss"
     declaration = canonical_declaration(source)
     if declaration is None:
         return "unregistered"

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -782,8 +782,10 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
         # genuinely-unregistered tool) emits a P6 audit event naming the source — degrade-with-audit,
         # never silently. The passthrough-oversized case (owner decision #2) can't arise here: the
         # pipeline ctx path is NEVER offloaded/size-gated (full-value retention), so it is not probed.
+        # FP-0056 v2 piece #3: passing ``canonical`` lets the classifier also fire on a mapped
+        # producer whose inner discriminator missed (reason ``"discriminator_miss"`` — M3, #2695).
         # Source id only; NEVER the result body.
-        _fallback_reason = canonical_fallback_reason(canonical_source)
+        _fallback_reason = canonical_fallback_reason(canonical_source, canonical=canonical)
         if _fallback_reason is not None and inv.deps.events is not None:
             inv.deps.events.emit(
                 CANONICAL_FALLBACK_EVENT, source=canonical_source, reason=_fallback_reason,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3047,9 +3047,13 @@ class RouterLoop:
                         # blob exceeded the offload gate) emits a P6 audit event naming the source —
                         # degrade-with-audit, never silently (the dogfood incident was one silent
                         # fallback). Source id only; NEVER the result body.
+                        # FP-0056 v2 piece #3: passing ``canonical`` lets the classifier also fire on a
+                        # mapped producer whose inner discriminator missed (reason
+                        # ``"discriminator_miss"`` — M3, #2695), riding the same fallback event.
                         _fallback_reason = canonical_fallback_reason(
                             canonical_source,
                             structured_offloaded=frontmatter.get("structured") == "offloaded",
+                            canonical=canonical,
                         )
                         if _fallback_reason is not None:
                             _events = getattr(host, "events", None)

--- a/tests/test_fp0056_m3_fail_visible.py
+++ b/tests/test_fp0056_m3_fail_visible.py
@@ -1,0 +1,235 @@
+"""Tier 1/2: FP-0056 v2 piece #3 — the M3 inner-dispatch FAIL-VISIBLE seam.
+
+M3 (the third canonical silent-loss mode, after M1 error-seam #2752 and M2
+``canonical_degraded`` #2748): a mapper that sub-dispatches on an inner discriminator
+(``file``'s ``op``, ``reyn_src``'s body key) used to fall through, on a missing/unknown
+discriminator, to a status-only catch-all that emitted ``f"{op}: {status}"`` = the literal
+``"None: ok"`` garbage (#2695). Non-empty, so M2's empty-check misses it; not an error, so
+M1's shared seam misses it — the user/LLM got meaningless text instead of the real result.
+
+Piece #3 makes such a discriminator-miss FAIL-VISIBLE: the mapper raises
+``CanonicalDiscriminatorMiss``; :func:`to_canonical` catches it and takes the SAME lossless
+whole-dict fallback a genuine unknown source takes, marked so the caller emits the EXISTING
+``canonical_fallback_used`` audit-event (reason ``"discriminator_miss"``). Full dict
+recoverable + audit signal, never silent garbage.
+
+``canonical_fallback_used`` is a P6 AUDIT-event (observability), NOT WAL-derived recovery
+state — the recovery-PR-gate (truncate-falsify) does not apply.
+
+Real instances only (no mocks): the real registration seams, a real ``PipelineExecutor``, a
+real ``EventLog``. Assertions are on the public canonical shape + the public classifier + the
+emitted audit-event, never on private state or exact formatting.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Eagerly register every op handler + its canonical declaration, and build the default tool
+# registry so every ToolDefinition's declaration is populated (the classifier resolves against these).
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import (
+    _DECLARATIONS,
+    CANONICAL_FALLBACK_EVENT,
+    CanonicalDiscriminatorMiss,
+    CanonicalToolResult,
+    canonical_fallback_reason,
+    file_to_canonical,
+    reyn_src_to_canonical,
+    to_canonical,
+)
+from reyn.core.pipeline.executor import Pipeline, PipelineExecutor, ToolStep
+from reyn.tools import get_default_registry
+
+get_default_registry()
+
+# A distinctive status value a correct mapper must never echo into its ``text`` body.
+_PROBE_STATUS = "__M3_PROBE_STATUS_SENTINEL__"
+
+
+def _structured_data(canonical: CanonicalToolResult) -> object | None:
+    """The whole-dict data of the sole ``structured`` attachment, or ``None``."""
+    for att in canonical.get("attachments", []) or []:
+        if att.get("kind") == "structured":
+            return att.get("data")
+    return None
+
+
+# --------------------------------------------------------------------------------------------------
+# #2695 acceptance — a ``file`` result with a missing/unknown ``op`` no longer renders "None: ok".
+# --------------------------------------------------------------------------------------------------
+
+def test_file_missing_op_is_fail_visible_not_none_ok_garbage() -> None:
+    """Tier 1: a ``file`` result with NO ``op`` renders the whole-dict fallback (recoverable) — never
+    the #2695 ``"None: ok"`` status-only garbage — and the classifier reports ``discriminator_miss``."""
+    result = {"kind": "file", "status": "ok", "matches": ["a.txt", "b.txt"]}
+    canonical = to_canonical(result, source="file")
+
+    assert canonical.get("text", "") != "None: ok"  # the #2695 symptom is gone
+    # The whole dict survives losslessly as a structured attachment (nothing dropped).
+    assert _structured_data(canonical) == result
+    # The mapped ``file`` source that fell back inside the mapper is classified fail-visible.
+    assert canonical_fallback_reason("file", canonical=canonical) == "discriminator_miss"
+
+
+def test_file_unknown_op_is_fail_visible() -> None:
+    """Tier 1: an UNKNOWN ``op`` value (not read/grep/glob/status-op) is also fail-visible."""
+    result = {"kind": "file", "op": "teleport", "status": "ok"}
+    canonical = to_canonical(result, source="file")
+    assert canonical.get("text", "") != "teleport: ok"
+    assert _structured_data(canonical) == result
+    assert canonical_fallback_reason("file", canonical=canonical) == "discriminator_miss"
+
+
+def test_file_mapper_raises_discriminator_miss_directly() -> None:
+    """Tier 1: the mapper itself raises ``CanonicalDiscriminatorMiss`` on a missing ``op`` (the
+    fail-visible signal), rather than returning status-only garbage."""
+    with pytest.raises(CanonicalDiscriminatorMiss):
+        file_to_canonical({"kind": "file", "status": "ok"})
+
+
+def test_valid_file_op_still_dispatches_no_fallback() -> None:
+    """Tier 1: NON-REGRESSION — a VALID ``op`` still dispatches to its per-op body and does NOT
+    trip the discriminator-miss path (the fix triggers only on a miss)."""
+    result = {"kind": "file", "op": "glob", "status": "ok", "matches": ["alpha.txt", "beta.txt"]}
+    canonical = to_canonical(result, source="file")
+    assert "alpha.txt" in canonical["text"] and "beta.txt" in canonical["text"]
+    assert not _structured_data(canonical)  # a mapped success is NOT a whole-dict fallback
+    assert canonical_fallback_reason("file", canonical=canonical) is None
+
+
+# --------------------------------------------------------------------------------------------------
+# The other inner-dispatch mapper — reyn_src (body-key discriminator).
+# --------------------------------------------------------------------------------------------------
+
+def test_reyn_src_no_body_key_is_fail_visible() -> None:
+    """Tier 1: a ``reyn_src`` result with none of content/entries/matches is fail-visible (whole-dict
+    fallback + ``discriminator_miss``), not a SILENT (unaudited) inline whole-dict return."""
+    result = {"status": "ok", "unexpected_shape": True}
+    canonical = to_canonical(result, source="reyn_src_read")
+    assert _structured_data(canonical) == result
+    assert canonical_fallback_reason("reyn_src_read", canonical=canonical) == "discriminator_miss"
+
+
+def test_reyn_src_no_body_key_raises_directly() -> None:
+    """Tier 1: the ``reyn_src`` mapper raises ``CanonicalDiscriminatorMiss`` on an unknown shape."""
+    with pytest.raises(CanonicalDiscriminatorMiss):
+        reyn_src_to_canonical({"status": "ok"})
+
+
+def test_valid_reyn_src_shape_still_dispatches() -> None:
+    """Tier 1: NON-REGRESSION — a ``reyn_src`` read (``content``) still renders its body as text."""
+    canonical = to_canonical(
+        {"path": "docs/x.md", "content": "hello body"}, source="reyn_src_read"
+    )
+    assert canonical["text"] == "hello body"
+    assert canonical_fallback_reason("reyn_src_read", canonical=canonical) is None
+
+
+# --------------------------------------------------------------------------------------------------
+# The registry-derived guard: NO registered mapper has a silent status-only catch-all.
+# --------------------------------------------------------------------------------------------------
+
+def _registered_mappers() -> set:
+    """Every distinct real canonical mapper function born at the two registration seams (the
+    sentinels STRUCTURED_PASSTHROUGH / CANONICAL_TODO are not callable → excluded)."""
+    return {d for d in _DECLARATIONS.values() if callable(d)}
+
+
+def _status_echo_offense(mapper) -> str | None:
+    """Drive ``mapper`` with a discriminator-less result carrying ONLY a distinctive status. Return
+    the offending text when the mapper ECHOES that status into its ``text`` body WITHOUT raising
+    ``CanonicalDiscriminatorMiss`` (the #2695 ``"None: ok"`` silent-catch-all pattern), else ``None``.
+
+    A fail-visible mapper raises (→ no offense); a mapper with no inner status-dispatch renders an
+    explicit-empty marker that does not contain the probe (→ no offense)."""
+    try:
+        canonical = mapper({"status": _PROBE_STATUS})
+    except CanonicalDiscriminatorMiss:
+        return None
+    text = canonical.get("text", "") or ""
+    return text if _PROBE_STATUS in text else None
+
+
+def test_no_registered_mapper_has_silent_status_only_catch_all() -> None:
+    """Tier 2: registry-derived guard — driven with a discriminator-less status-only probe, NO
+    registered canonical mapper echoes the status into its text without being fail-visible. This is
+    the general rule that prevents a NEW inner-dispatch mapper from re-introducing M3 (#2695)."""
+    mappers = _registered_mappers()
+    assert mappers, "no canonical mappers registered — the registration seams did not populate"
+    offenders = {
+        mapper.__name__: offense
+        for mapper in mappers
+        if (offense := _status_echo_offense(mapper)) is not None
+    }
+    assert not offenders, (
+        "these mappers emit status-only garbage on a discriminator-miss (the #2695 'None: ok' "
+        f"class) — raise CanonicalDiscriminatorMiss instead: {offenders}"
+    )
+
+
+def test_guard_catches_a_hypothetical_silent_catch_all_mapper() -> None:
+    """Tier 2: FALSIFY the guard — a hypothetical NEW inner-dispatch mapper with a silent status-only
+    catch-all (the #2695 anti-pattern) IS flagged by the guard's probe, and a fail-visible variant is
+    NOT (proving the guard discriminates real fail-visibility, not merely 'has a catch-all')."""
+
+    def _garbage_mapper(result: dict) -> CanonicalToolResult:
+        op = result.get("op")
+        if op == "read":
+            return CanonicalToolResult(
+                text=str(result.get("content", "")), attachments=[], source_ref=None, meta={},
+            )
+        # silent status-only catch-all — the exact #2695 shape
+        return CanonicalToolResult(
+            text=f"{op}: {result.get('status', 'ok')}", attachments=[], source_ref=None, meta={},
+        )
+
+    def _fail_visible_mapper(result: dict) -> CanonicalToolResult:
+        op = result.get("op")
+        if op == "read":
+            return CanonicalToolResult(
+                text=str(result.get("content", "")), attachments=[], source_ref=None, meta={},
+            )
+        raise CanonicalDiscriminatorMiss(f"unknown op {op!r}")
+
+    assert _status_echo_offense(_garbage_mapper) is not None  # caught
+    assert _status_echo_offense(_fail_visible_mapper) is None  # allowed
+
+
+# --------------------------------------------------------------------------------------------------
+# End-to-end: the live chokepoint fires canonical_fallback_used on the discriminator-miss path.
+# --------------------------------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_file_discriminator_miss_emits_fallback_event_end_to_end() -> None:
+    """Tier 2: a pipeline tool step whose ``file`` result dropped its ``op`` (the #2695 shape) emits
+    ``canonical_fallback_used`` with reason ``discriminator_miss`` naming the source — and NO result
+    content bytes leak into any audit-event payload (audit signal, not data)."""
+    secret_match = "SECRET-MATCH-PATH-should-never-reach-an-audit-event.txt"
+
+    def _dispatch(name: str, args: dict) -> dict:
+        # A ``file`` result MISSING ``op`` (the #2695 glob/list-adapter normalization) — pre-#3 this
+        # canonicalized to the "None: ok" garbage with NO event; post-#3 it is fail-visible.
+        return {
+            "kind": "file",
+            "status": "ok",
+            "matches": [secret_match],
+            "_canonical_source": "file",
+        }
+
+    events = EventLog()
+    pipeline = Pipeline(steps=[ToolStep(name="glob_files", args={}, output="r")])
+    await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-fp0056-m3", events=events,
+    )
+
+    [fallback_event] = [e for e in events.all() if e.type == CANONICAL_FALLBACK_EVENT]
+    assert fallback_event.data["source"] == "file"
+    assert fallback_event.data["reason"] == "discriminator_miss"
+
+    # No result content bytes in ANY event payload — the event carries the source identity only.
+    all_payloads = json.dumps([e.data for e in events.all()])
+    assert secret_match not in all_payloads


### PR DESCRIPTION
**[per-PR-coder]** — FP-0056 v2 **piece #3 (FINAL)**: the M3 inner-dispatch **fail-visible** seam. Closes the third and last canonical silent-loss mode. Pieces #1 (union error seam, #2752) and #2 (`canonical_degraded`, #2748) already landed; with this, all three modes (M1 seam / M2 `canonical_degraded` / M3 fail-visible) are structurally closed.

Design authority: architect's design pass in **#2698 comments** (piece #3 section).

## The class (M3)
An inner-dispatch mapper (`file`'s `op`; `reyn_src`'s `content`/`entries`/`matches` body key) whose discriminator was **missing/unknown** fell through to a status-only catch-all emitting `f"{op}: {status}"` = the literal **`"None: ok"`** garbage (#2695). NON-empty → piece #2's `canonical_degraded` empty-check misses it; NOT an error → piece #1's shared error seam misses it. The LLM got meaningless text instead of the real result.

## Fix — no new mechanism
A discriminator-miss now raises `CanonicalDiscriminatorMiss`; `to_canonical` catches it and takes the **same lossless whole-dict fallback** a genuine unknown source takes, marked so the caller emits the **existing `canonical_fallback_used`** audit-event with a new reason category `discriminator_miss`. Full dict recoverable + audit signal — the path #2695 should have taken. (Wiring: `canonical_fallback_reason(source, canonical=...)` reads a private, non-rendered marker on the fallback canonical; both live chokepoints — `executor.py`, `router_loop.py` — pass the canonical.)

### Inner-dispatch mappers enumerated (from `canonical.py` source, not a subset) + how each was made fail-visible
Of all 17 mappers, exactly **two** sub-dispatch on an inner discriminator that could produce status-only garbage:
- **`file_to_canonical`** (`op` discriminator) — missing/unknown `op` → **raise** (was `"None: ok"`). `_render_file_status`'s `f"{op}: {status}"` catch-all removed; new `_FILE_STATUS_OPS` frozenset guards the valid mutating ops.
- **`reyn_src_to_canonical`** (`content`/`entries`/`matches` body-key discriminator) — unknown shape → **raise** (was a **silent inline whole-dict** return — same recoverable output, but UNAUDITED; now fires the event).

The other 15 mappers either have no inner discriminator, or already render explicit-empty / lossless-structured on a missing field (no status-only garbage possible) — confirmed by the guard below driving all of them.

### Guard (registry-derived, proportionate — not a framework)
`test_no_registered_mapper_has_silent_status_only_catch_all`: drives **every** registered canonical mapper (enumerated from `_DECLARATIONS`) with a discriminator-less status-only probe and asserts none echoes the status into `text` without being fail-visible. Prevents a NEW inner-dispatch mapper from re-introducing M3. Falsified by `test_guard_catches_a_hypothetical_silent_catch_all_mapper` (a hypothetical `"None: ok"`-shaped mapper is caught; a fail-visible variant passes).

## Recovery-gate
`canonical_fallback_used` is a **P6 audit-event** (observability), NOT WAL-derived recovery state → the recovery-PR-gate (truncate-falsify) does **not** apply.

## Tests (Tier-declared, real instances, RED→GREEN)
`tests/test_fp0056_m3_fail_visible.py` (10 tests):
- **#2695 acceptance**: a `file` result with missing/unknown `op` → whole-dict fallback (not `"None: ok"`) + `discriminator_miss` reason; end-to-end via a real `PipelineExecutor` fires `canonical_fallback_used` with no result-body leak. cp-falsify confirmed RED on pre-#3 code (`file_to_canonical({"kind":"file","status":"ok"})["text"] == "None: ok"`).
- reyn_src discriminator-miss → fail-visible whole-dict fallback + reason.
- guard + guard-falsify (above).
- non-regression: valid `op`/valid reyn_src shape still dispatch cleanly, no fallback reason.

## Test plan
- [x] `ruff check src tests` — clean (incl. I001)
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0056_m3_fail_visible.py` — 10/10 OK, 0 Tier-4
- [x] `pytest` (repo root) — 7922 passed; 5 failures are **pre-existing** web-route-mount tests (`test_a2a`/`test_mcp_sse`/`test_plugin_loader`/`test_resources_router`/`test_fp0001_a2a_endpoints`), verified failing identically on the pristine baseline (they don't import any changed module)
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK
- [x] cp-falsify: pre-#3 code emits `"None: ok"` (RED); post-#3 renders whole-dict fallback + `canonical_fallback_used` (GREEN)

Prior pieces: #2752 (M1), #2748 (M2). Design: #2698.

Closes #2699
Closes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)