### PR TITLE
docs: full-rewrite product-think.md (5th and last of 5, #2750 complete)

### DIFF
--- a/docs/concepts/agent-engineering/index.ja.md
+++ b/docs/concepts/agent-engineering/index.ja.md
@@ -78,7 +78,6 @@ run 内で rubric に対して出力をスコアリングする(`judge_output`: 
 - agent エンジニアリング一般が初めてですか? まず `CLAUDE.md` の Constitution 節と [charter.md](../architecture/charter.md) を読んでください — それらが現行の grounded なモデルです。このページにはレンズごとのナラティブな解説のために戻ってきてください。
 - 別のフレームワークから来ていますか? 最も興味のあるレンズにスキップしてください。クロスリンクが必要に応じて他のレンズに引き戻します。
 - 自分のシステムの自己評価をしていますか? 「まだ薄い部分」の記述 — 特に憲章の 2 つの honest thin area である Retrieval と Evaluation — が率直な箇所です。
-- **staleness についての注記**: この 8 つのレンズページのうち 1 つ(Product Think)は、以前の engine 削除 arc で削除された phase-graph skill engine を前提に書かれており、何が stale で何が現行かを明示する状態バナーをページ冒頭に持っています。Tool Contract Design、System Design、Retrieval Engineering、Reliability Engineering、Security はすでに完全な書き直しを経ています。Evaluation と Observability は現行モデルに対して新規に書かれました。残り 1 ページの完全な de-drift パスは follow-up として追跡されています — `charter.md` 自体が family ごとに構築された方法をなぞっています。
 
 ## 関連情報
 

--- a/docs/concepts/agent-engineering/index.md
+++ b/docs/concepts/agent-engineering/index.md
@@ -78,7 +78,6 @@ Three of the eight lenses name a *discipline* whose *universal mechanism* is one
 - New to agent engineering generally? Read `CLAUDE.md`'s Constitution section and [charter.md](../architecture/charter.md) first — they're the current, grounded model. Come back here for the narrative per-lens walkthrough.
 - Coming from another framework? Skip to the lens you care most about; cross-links will pull you back to the others as needed.
 - Doing self-assessment for your own system? The "where it's still thin" passages — especially on Retrieval and Evaluation, the constitution's two honest thin areas — are the candid bits.
-- **A note on staleness**: one of these eight lens pages (Product Think) was written against the phase-graph skill engine deleted in an earlier engine-deletion arc, and carries a status banner at the top naming exactly what's stale vs. still current. Tool Contract Design, System Design, Retrieval Engineering, Reliability Engineering, and Security have already gone through a full rewrite; Evaluation and Observability are newly written against the current model. A full de-drift pass on the remaining page is tracked as a follow-up — mirroring how `charter.md` itself was built family-by-family.
 
 ## See also
 

--- a/docs/concepts/agent-engineering/product-think.ja.md
+++ b/docs/concepts/agent-engineering/product-think.ja.md
@@ -6,70 +6,45 @@ audience: [human, agent]
 
 # Product Think
 
-> **状態: stale。** このページは削除済みの phase-graph skill engine を前提に書かれています —
-> 以下の CLI 表(`reyn run-once`、ワークフロー中心のサブコマンド)、
-> `limits.phase.max_visits`、「まだ薄い部分」の「ストリーミング出力なし」/
-> 「コストダッシュボードなし」という主張は、すべて現行の inline CUI(agents/cost/permissions
-> のライブ audit chip 付き — `docs/feature-map.md` の Inline CUI セクションで現行確認済み、
-> 以下の「ストリーミング出力なし」という主張と矛盾)より前のものです。
-> 書き直しは follow-up として追跡されています。現行の grounded なストーリーは
-> [`docs/concepts/architecture/charter.md`](../architecture/charter.md)
-> (Product Think 行、7 feature family 全体で populate 済み)を参照してください。
-
 製品としての agent の視点: 使用感、実行コスト、実環境での予測可能性。研究上の問題ではないため、投資が不足しがちですが、システムを長期間維持するかどうかを決めるのはこの部分です。
 
 ## Reyn の実装方法
 
 ### CLI の使い勝手
 
-Reyn CLI は 1 つのモノリシックなエントリーポイントではなく、小さく組み合わせ可能なサブコマンドとして構成されています:
+Reyn の CLI は 1 つのモノリシックなエントリーポイントではなく、小さく組み合わせ可能なサブコマンドとして構成されています — それぞれが自身のサブシステムの operator サーフェス(agent / topology / memory / permissions / events / mcp / config / …)だけを所有し、共有メガコマンドではなく同じ `reyn.yaml` と `.reyn/` 状態ディレクトリを共有します。重複したリストをここに載せる代わりに、完全で現行のコマンド一覧は [feature-map.md の CLI セクション](../../feature-map.md#cli) を参照してください。
 
-| コマンド | 目的 |
-|---------|---------|
-| `reyn run-once` | 汎用エージェントを stdin プロンプトで一度だけ実行 |
-| `reyn chat` | ルーター + Memory を持つインタラクティブ REPL |
-| `reyn agent` | 名前付き永続エージェントの作成/管理 |
-| `reyn init` | `reyn.yaml` と `.reyn/` をスキャフォールド |
-| `reyn permissions` | 保存された承認の確認/取り消し |
-| `reyn memory` | Memory の一覧/表示/編集/検索/エクスポート |
-| `reyn events` | 保存されたイベントログのリプレイ |
-| `reyn config` | 設定の表示/編集 |
+### ライブな legibility: inline CUI の audit chip
 
-各コマンドは独立して習得できます。同じ `reyn.yaml` と `.reyn/` 状態ディレクトリを共有することで組み合わせられます。
+inline CUI のステータス chip バー(Agents / Cost / Model / Tools / MCP / Skills / Hooks / Pipes / Cron / Tasks)は、P6 audit-event ログが記録するのと同じ operator に見える状態を、事後のリプレイでのみ利用可能なのではなく、ライブかつインラインで表面化します — これは Observability レンズが同じ chip をどう読むかの dual-facet な相方です([observability.md](observability.md) を参照)。
 
-### コスト規律
+### コストレポートと削減 — bounding とは別物
 
-フラグまたは設定として表示される 3 つのレバー:
+似ているがレンズとしては別物の 2 つ:
 
-- **モデルクラス(`light` / `standard` / `strong`)。** ワークフローは特定のモデルを指定せずに書かれます。リゾルバーがクラスを `reyn.yaml` の具体的な LiteLLM モデル文字列にマッピングします。プロジェクトごと(または `--model` でラン単位)のコスト tier を切り替えるのは 1 行の変更です。
-- **エージェントごとのコストレポート。** `reyn chat` の `/cost` スラッシュコマンドで現在のエージェントのトークン使用量 + USD コストをすぐ確認できます。
-- **`limits.phase.max_visits` と `limits.phase.max_wall_seconds`。** 暴走ループと Phase ごとの時間バジェットを制限します。どちらもコストの上限です(各訪問は少なくとも 1 回の LLM 呼び出しであり、時間制限のある Phase は低速 LLM による爆発的なコスト増を防ぎます)。
+- **コストの *レポート*(このレンズ)**: `/cost` は現在の agent のトークン + USD の簡易サマリーを、`/budget` は完全な内訳を表示します。`cost_warn` は、解決されたモデルの 100 万トークンあたりコストが閾値を超えたときにオペレーターへ事前選択の警告を出す仕組みで、モデル・セッションごとに重複排除されます — legibility と predictability であり、それ以上のものではありません。
+- **コストの *bounding*(cross-cutting band の `cost/budget` メンバーであり、このレンズではない)**: 超過すると以降の支出を拒否する、agent ごと/日次/月次のハードなトークン+USD キャップ。bounding cap を Product Think の exemplar として引用しないでください — それは band の仕事であり、このレンズの仕事ではありません(band↔lens の完全な区別は `CLAUDE.md` の Constitution 節を参照)。
+- **コストの *削減*** はこのレンズのもう1つの facet です: `present` はバルクデータを LLM 出力として再現する代わりに、ほぼ 0 出力トークンでサーフェスにルーティングします — 単なるレポート機構ではなく、本物のトークンコスト削減です。
 
 ### 予測可能な UX
 
-積み重なって効果を生む小さな選択がいくつかあります:
-
-- **`output_language`。** 1 つの設定キーがすべてのワークフローにわたってユーザー向け出力の言語を制御します。ワークフローごとのローカライゼーションコードは不要です。
+- **`output_language`。** 1 つの設定キーがユーザー向け出力の言語を制御します。agent ごとのローカライゼーションコードは不要です。
 - **`reyn events`。** ランが予期しないことをした場合、記録の artifact は 1 回の CLI 呼び出しで取得できます。
 - **状態はディスク上に存在する。** `.reyn/` にはイベント、チャット、承認、Memory が格納されます。重要なものはプロセスメモリだけに存在しません。
-
-### プログラミングなしの組み合わせ
-
-このシステムは関数ではなくワークフローで考えることを促します。`chat` はルーターワークフローであり、importer/improver/builder はそれ自体ワークフローです。新しい高レベルのケイパビリティは、新しい CLI サブコマンドではなく新しいワークフローになる傾向があります。
+- **On-limit mode。** `interactive` / `auto_extend` / `unattended` は、あらゆる loop/timeout/budget チェックポイントに対して、オペレーターに予測可能で config で選択可能な制御を一様に与えます — [reliability-engineering.md](reliability-engineering.md) を参照。
+- **`/tasks` view。** 実行中のタスク、タスクごとのステータス、kill を一覧表示 — skill run と dynamic task にまたがる、オーケストレーションされた作業への operator legibility。
 
 ## まだ薄い部分
 
-いくつかの UX/コストレバーが欠けているか、薄い状態です:
-
-- **ストリーミング出力なし。** 長時間実行される Phase は完了するまでコンソールに何も表示されません（イベントログはリアルタイムで満たされますが、レンダリング出力は Phase ごとです）。インタラクティブな作業ではこれで問題ありません。非常に長時間実行されるワークフローでは問題になります。
-- **コストダッシュボードや傾向ビューなし。** ランごとのコストは表示されます。ラン間の集計はユーザーの作業です（データは他のツールにフィードするのに十分な構造を持っています）。
-- **オンボーディングに粗い部分あり。** `reyn init` は設定をスキャフォールドしますが、チュートリアル 01 が実際のオリエンテーションです。単一の統合された `reyn quickstart` は存在しません。
+- **コストダッシュボードや傾向ビューなし。** ランごとのコストは表示されます(`/cost`、`/budget`)。ラン間の集計はオペレーター自身の作業です(データは他のツールにフィードするのに十分な構造を持っています)。
+- **オンボーディングに粗い部分あり。** `reyn init` は設定をスキャフォールドしますが、getting-started ガイドが実際のオリエンテーションです。単一の統合されたワンコマンドのクイックスタートは存在しません。
 
 これらはすべて OS を変更せずに対処できます。すでに安定したランタイム上のプロダクトポリッシュです。
 
 ## 関連情報
 
+- `CLAUDE.md`(§ Constitution)— Product Think レンズの pass-line と、このページが依拠する bounding≠削減/legibility の区別
+- [`docs/concepts/architecture/charter.md`](../architecture/charter.md) — 7 つの feature family すべてで grounded された Product Think 行
+- [observability.md](observability.md) — このページの「ライブな legibility」節と対をなす audit chip の dual-facet
 - [リファレンス: cli/chat](../../reference/cli/chat.md)
-- [リファレンス: cli/common-flags](../../reference/cli/common-flags.md)
-
-- [retrieval-engineering.md](retrieval-engineering.md) — chat Memory が UX に直接影響する
+- [リファレンス: config/budget](../../reference/config/budget.md)

--- a/docs/concepts/agent-engineering/product-think.md
+++ b/docs/concepts/agent-engineering/product-think.md
@@ -6,72 +6,45 @@ audience: [human, agent]
 
 # Product Think
 
-> **Status: stale.** This page was written against the deleted phase-graph
-> skill engine — the CLI table below (`reyn run-once`, workflow-centric
-> subcommands), `limits.phase.max_visits`, and the "no streaming output" /
-> "no cost dashboard" claims in "Where it's still thin" all predate the
-> current inline CUI (with live audit chips for agents/cost/permissions —
-> confirmed current via `docs/feature-map.md`'s Inline CUI section, which
-> contradicts the "no streaming output" claim below). A rewrite is tracked
-> as a follow-up; in the meantime see
-> [`docs/concepts/architecture/charter.md`](../architecture/charter.md)
-> (Product Think row, populated across all 7 feature families) for the
-> current, grounded story.
-
 The agent-as-a-product perspective: how it feels to use, what it costs to run, how predictable it is in the wild. Easy to under-invest in because it's not a research problem — but it's what determines whether anyone keeps the system around.
 
 ## How reyn handles it
 
 ### CLI affordances
 
-The reyn CLI is structured as small, composable subcommands rather than one monolithic entrypoint:
+reyn's CLI is structured as small, composable subcommands rather than one monolithic entrypoint — each owning exactly its own subsystem's operator surface (agent / topology / memory / permissions / events / mcp / config / …), sharing the same `reyn.yaml` and `.reyn/` state directory rather than a shared mega-command. See [feature-map.md's CLI section](../../feature-map.md#cli) for the full, current command inventory rather than a duplicated list here.
 
-| Command | Purpose |
-|---------|---------|
-| `reyn run-once` | Run the general agent once on a stdin prompt |
-| `reyn chat` | Interactive REPL with router + memory |
-| `reyn agent` | Create and manage named persistent agents |
-| `reyn init` | Scaffold `reyn.yaml` and `.reyn/` |
-| `reyn permissions` | Inspect / revoke saved approvals |
-| `reyn memory` | List / show / edit / search / export memory |
-| `reyn events` | Replay a saved event log |
-| `reyn config` | View / edit configuration |
+### Live legibility: the inline CUI's audit chips
 
-Each one can be learned in isolation; they compose by sharing the same `reyn.yaml` and `.reyn/` state directory.
+The inline CUI's status-chip bar (Agents / Cost / Model / Tools / MCP / Skills / Hooks / Pipes / Cron / Tasks) surfaces the same operator-visible state the P6 audit-event log records, live and inline rather than only available via after-the-fact replay — this is the dual-facet companion to the Observability lens's reading of the same chips (see [observability.md](observability.md)).
 
-### Cost discipline
+### Cost reporting and reduction — distinct from bounding
 
-Three levers, all surfaced as flags or config:
+Two things that look similar but are lens-distinct:
 
-- **Model classes (`light` / `standard` / `strong`).** A workflow is written without naming a specific model; the resolver maps the class to a concrete LiteLLM model string from `reyn.yaml`. Switching cost tiers per project (or per run with `--model`) is a one-line change.
-- **Per-agent cost reporting.** `reyn chat`'s `/cost` slash command gives a quick token + USD summary for the current agent.
-- **`limits.phase.max_visits` and `limits.phase.max_wall_seconds`.** Cap runaway loops and per-phase time budgets — both are cost ceilings (each visit is at least one LLM call, and time-bounded phases prevent slow-LLM blowups).
+- **Cost *reporting* (this lens)**: `/cost` gives a quick token + USD summary for the current agent; `/budget` gives a full breakdown. `cost_warn` is a pre-selection warning to the operator when the resolved model's cost-per-1M-tokens exceeds a threshold, de-duped once per model per session — legibility and predictability, nothing more.
+- **Cost *bounding* (the cross-cutting band's `cost/budget` member, not this lens)**: hard per-agent / daily / monthly token+USD caps that refuse further spend once exceeded. Don't cite the bounding caps as a Product Think exemplar — they're the band's job, not this lens's (see `CLAUDE.md`'s Constitution section for the full band↔lens distinction).
+- **Cost *reduction*** is this lens's other facet: `present` routes bulk data to the surface at ~0 output tokens instead of reproducing it as LLM output — a genuine token-cost reduction, not just a reporting mechanism.
 
 ### Predictable UX
 
-A few small choices that compound:
-
-- **`output_language`.** One config key controls the language of user-facing output across every workflow. No per-workflow localization code.
+- **`output_language`.** One config key controls the language of user-facing output. No per-agent localization code.
 - **`reyn events`.** When a run does something unexpected, the artifact-of-record is one CLI call away.
 - **State is on disk.** `.reyn/` holds events, chats, approvals, memory. Nothing important is in process memory only.
-
-### Composition without programming
-
-The system rewards thinking in workflows rather than functions. `chat` is a router workflow; importer/improver/builder are themselves workflows. New high-level capabilities tend to be new workflows rather than new CLI subcommands.
+- **On-limit modes.** `interactive` / `auto_extend` / `unattended` give the operator predictable, config-selectable control over every loop/timeout/budget checkpoint uniformly — see [reliability-engineering.md](reliability-engineering.md).
+- **`/tasks` view.** Lists running tasks, per-task status, and kill — operator legibility into orchestrated work, spanning skill runs and dynamic tasks.
 
 ## Where it's still thin
 
-A handful of UX/cost levers are missing or thin:
-
-- **No streaming output.** A long-running phase shows nothing on the console until it completes (the event log fills in real time, but the rendered output is per-phase). For interactive work this is OK; for very long-running workflows, it's not.
-- **No cost dashboard or trend view.** Per-run cost is shown; aggregating across runs is the user's job (the data is structured enough to feed into other tools).
-- **Onboarding has rough edges.** `reyn init` scaffolds config but tutorial 01 is the actual orientation; a single integrated `reyn quickstart` doesn't exist.
+- **No cost dashboard or trend view.** Per-run cost is shown (`/cost`, `/budget`); aggregating across runs is the operator's own job (the data is structured enough to feed into other tools).
+- **Onboarding has rough edges.** `reyn init` scaffolds config, but the getting-started guide is the actual orientation — a single integrated one-command quickstart doesn't exist.
 
 These are addressable without changing the OS — they're product polish on top of an already-stable runtime.
 
 ## See also
 
+- `CLAUDE.md` (§ Constitution) — the Product Think lens's pass-line, and the bounding≠reduction/legibility distinction this page depends on
+- [`docs/concepts/architecture/charter.md`](../architecture/charter.md) — the Product Think row, grounded across all 7 feature families
+- [observability.md](observability.md) — the audit-chips dual-facet companion to this page's "Live legibility" section
 - [Reference: cli/chat](../../reference/cli/chat.md)
-- [Reference: cli/common-flags](../../reference/cli/common-flags.md)
-
-- [retrieval-engineering.md](retrieval-engineering.md) — chat memory affects UX directly
+- [Reference: config/budget](../../reference/config/budget.md)


### PR DESCRIPTION
**[docs-maintainer]** — #2750, family-by-family rewrite, 5th and **last** of 5 pages (Product Think). This completes the agent-engineering full-rewrite arc.

## What changed
- **CLI affordances** now points at `feature-map.md`'s own CLI section as the single source of truth for the command inventory, instead of hand-duplicating a list that will re-drift (same anti-redrift lesson as `events.md`'s FP-0021 table and `llm-invocation-surfaces.md`'s tool list).
- **New "Live legibility" section**: the inline CUI's audit-chip bar, named as the dual-facet companion to `observability.md`'s reading of the same chips (one feature, two lens facets — the pattern established across the charter.md arc).
- **"Cost reporting and reduction"** explicitly separates three things that used to be conflated: reporting (`/cost`, `/budget`, `cost_warn`), reduction (`present`'s ~0-token routing), and bounding (the cross-cutting band's `cost/budget` member, **not** a Product Think exemplar) — the bounding≠lens distinction from charter.md's own template rules.
- Dropped the dead `limits.phase.max_visits`/`max_wall_seconds` cost-lever claim entirely (phase-graph-era, confirmed dead in an earlier pass) and the false "no streaming output" claim (contradicted by the inline CUI's live chips).
- **"Where it's still thin"** keeps only what's still true: no cross-run cost dashboard, onboarding rough edges.

## Also touched
Since this is the last of the 5 banner-de-drifted pages, removed the now-fully-obsolete "note on staleness" bullet from `agent-engineering/index.md`(`.ja.md`) entirely — all 8 lens pages are now fully current, nothing left to flag.

## Arc complete
This closes out the agent-engineering full-rewrite arc: all 5 pages (system-design / retrieval-engineering / reliability-engineering / security / product-think) rewritten family-by-family, matching `charter.md`'s own build pattern, plus the 2 brand-new pages (evaluation / observability) from the earlier #2749.

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `python3 -m pytest tests/test_fp0036_coverage.py -q` — 23 passed
- [x] `ruff check src tests` — all checks passed
- [x] `git diff | grep -oE "#[0-9]{3,4}"` — none found

Requesting architect anti-overclaim gate review.