### PR TITLE
feat: multiline input for inline CUI (Enter=submit, Shift+Enter=newline)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -72,7 +72,11 @@ class _SlashCompleter(Completer):
 
     def get_completions(self, document, complete_event):
         text = document.text_before_cursor
-        if not text.startswith("/") or " " in text:
+        # Slash commands are inherently single-line; a "\n" means the input
+        # (now multiline-capable, see run_inline_input's Buffer) has moved past
+        # a bare command word, so stop suggesting — same intent as the
+        # existing " " in text check, just extended to the newline case.
+        if not text.startswith("/") or " " in text or "\n" in text:
             return
         prefix = text[1:]
         for name, summary in slash_command_completions(prefix):
@@ -95,6 +99,75 @@ _ABOVE_REGION_MAX_HEIGHT = 12
 # unbounded Dimension.exact(), which prompt_toolkit cannot satisfy past the
 # terminal's remaining rows and renders "Window too small" instead of the menu.
 _MENU_REGION_MAX_HEIGHT = 12
+
+# Same cap, for the multiline input box itself. A fixed height=1 (the
+# pre-multiline default) only ever showed the buffer's current line — once
+# Shift+Enter/Ctrl+J can insert real newlines, a fixed height=1 window hides
+# every line except the one the cursor is on (confirmed live via tmux: typing
+# "line one", Shift+Enter, "line two" showed only "line two", though the
+# newline itself DID insert correctly — a rendering gap, not a submit bug).
+# Capped (not unbounded) for the same "Window too small" reason as the two
+# constants above.
+_INPUT_MAX_HEIGHT = 8
+
+
+# Owner spec for the inline input: Enter=submit, Shift+Enter=newline — the
+# OPPOSITE of prompt_toolkit's own multiline default (Enter=newline,
+# Meta+Enter=submit; see run_inline_input's "enter" binding, which inverts it).
+#
+# Hard limit (confirmed via direct prompt_toolkit source read + an empirical
+# tmux byte-probe, not guesswork): most terminals send an IDENTICAL "\r" for
+# Enter and Shift+Enter — the classic VT100 protocol has no way to encode
+# "Enter + Shift" as a distinct byte sequence, so this is a terminal-layer
+# limit reyn's code cannot work around for those terminals (macOS
+# Terminal.app, GNOME Terminal, default Windows Terminal, PuTTY, conhost).
+#
+# Some terminals DO send a disambiguated escape sequence when an extended
+# keyboard protocol is active — critically, mintty (Windows Git Bash) sends
+# the legacy xterm modifyOtherKeys form below BY DEFAULT since 2009.
+# prompt_toolkit's OWN ansi_escape_sequences.py maps that sequence back to
+# plain Keys.ControlM (its own comment: "currently unsupported, so just
+# re-map... to the unmodified versions") — but the raw KeyPress.data still
+# carries the full original escape string, so the distinction survives and can
+# be recovered without any prompt_toolkit monkeypatch. Verified empirically: a
+# byte-probe app confirmed `\x1b[27;2;13~` parses as ONE Keys.ControlM event
+# whose .data is the full escape string, distinct from plain Enter's .data ==
+# "\r". Ctrl+J (LF, a byte distinct from Enter's CR on every VT100-compatible
+# terminal) is the guaranteed-always-works fallback for terminals where
+# Shift+Enter is genuinely undetectable — see the "c-j" binding.
+_SHIFT_ENTER_RAW_DATA = frozenset({
+    "\x1b[27;2;13~",  # xterm modifyOtherKeys (mintty default) — Shift+Enter
+})
+
+
+def _is_shift_enter_escape(data: str) -> bool:
+    """True if ``data`` (a KeyPress's raw ``.data``) is the disambiguated
+    Shift+Enter escape sequence prompt_toolkit's own key-name resolution
+    collapses to plain Enter. See ``_SHIFT_ENTER_RAW_DATA`` above for the full
+    investigation."""
+    return data in _SHIFT_ENTER_RAW_DATA
+
+
+def _down_arrow_action(has_text: bool, cursor_row: int, line_count: int) -> str:
+    """Pure decision for the multiline input buffer's ↓ key, mirroring
+    ``Buffer.auto_down``'s row-awareness (this custom binding replaces
+    prompt_toolkit's default auto_down entirely, so it must reproduce that
+    part) plus reyn's own empty-box "drop to status bar" affordance.
+
+    Returns one of ``"focus_status"`` / ``"cursor_down"`` / ``"history_forward"``.
+    """
+    if not has_text:
+        return "focus_status"
+    if cursor_row < line_count - 1:
+        return "cursor_down"
+    return "history_forward"
+
+
+def _input_window_height(line_count: int) -> int:
+    """Pure: how many rows the input Window should occupy for a buffer with
+    ``line_count`` lines — at least 1, capped at ``_INPUT_MAX_HEIGHT`` (see its
+    own docstring for why a fixed height=1 broke multiline display)."""
+    return min(max(1, line_count), _INPUT_MAX_HEIGHT)
 
 
 def _picker_hint(has_picker_focus: bool, key: str | None) -> str:
@@ -700,8 +773,13 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     if attached is None:
         raise RuntimeError("run_inline_input: no session attached (call registry.attach() first)")
     history = FileHistory(str(attached.workspace_dir / ".input_history"))
+    # multiline=True: Enter=submit / Shift+Enter=newline (owner spec) instead of
+    # prompt_toolkit's own multiline default (Enter=newline, Meta+Enter=submit) —
+    # see the "enter" binding below, which inverts it. FileHistory already
+    # round-trips multi-line entries natively ("+"-prefixed continuation lines,
+    # history.py:297-306) — no reyn-side change needed there.
     buf = Buffer(
-        multiline=False, history=history,
+        multiline=True, history=history,
         completer=_SLASH_COMPLETER, complete_while_typing=True,
     )
     # sel: which main chip; open: its detail/picker shown. The dropdown's
@@ -774,7 +852,10 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     prompt_sym = Window(
         FormattedTextControl([(f"fg:{_CC_ACCENT} bold", "❯ ")]), width=2, height=1
     )
-    input_win = Window(BufferControl(buffer=buf), height=1)
+    input_win = Window(
+        BufferControl(buffer=buf),
+        height=lambda: _input_window_height(buf.document.line_count),
+    )
     inputrow = VSplit([prompt_sym, input_win])
 
     def status_fragments() -> list:
@@ -938,8 +1019,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
 
     kb = KeyBindings()
 
-    @kb.add("enter", filter=has_focus(input_win))
-    def _accept(event) -> None:
+    def _do_submit(event) -> None:
         text = buf.text
         buf.reset(append_to_history=True)
         stripped = text.strip()
@@ -962,17 +1042,63 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             registry.repl_outbox.put_nowait(OutboxMessage(kind="user", text=stripped))
             event.app.create_background_task(_submit(registry, stripped))
 
+    # Owner spec: Enter=submit, Shift+Enter=newline. See the module-level
+    # _SHIFT_ENTER_RAW_DATA / _is_shift_enter_escape / _down_arrow_action
+    # docstrings (above _picker_hint) for the full cross-terminal investigation.
+    @kb.add("enter", filter=has_focus(input_win))
+    def _accept(event) -> None:
+        last = event.key_sequence[-1] if event.key_sequence else None
+        if last is not None and _is_shift_enter_escape(last.data):
+            buf.newline(copy_margin=False)
+            return
+        _do_submit(event)
+
+    # Kitty keyboard protocol form of Shift+Enter (`ESC [ 1 3 ; 2 u`) — enabled
+    # by DEFAULT on iTerm2/kitty/Ghostty/Alacritty/Rio/Warp/Contour (not on
+    # mintty, which uses the legacy form the "enter" binding above handles
+    # instead). Registered as a raw multi-key sequence since prompt_toolkit has
+    # no built-in "s-enter" name — confirmed via its own key-bindings docs,
+    # which list every other shift-combination (s-up/s-down/s-left/s-right/
+    # s-tab/etc.) but not s-enter. prompt_toolkit's KeyProcessor already
+    # buffers-and-matches multi-byte sequences this way for every other
+    # escape-coded key (arrows, F-keys, …), so this is the same mechanism, not
+    # a special case.
+    @kb.add("escape", "[", "1", "3", ";", "2", "u", filter=has_focus(input_win))
+    def _shift_enter_kitty(event) -> None:
+        buf.newline(copy_margin=False)
+
+    # Ctrl+J (raw LF, 0x0A) — a byte distinct from Enter's CR (0x0D) on EVERY
+    # VT100-compatible terminal, needing no protocol negotiation. The
+    # guaranteed-always-works newline binding for terminals where Shift+Enter
+    # is genuinely undetectable (see _SHIFT_ENTER_RAW_DATA's docstring) — the
+    # same fallback pattern used by other CLIs facing this exact cross-terminal
+    # gap (e.g. Claude Code's own tracking issue on this recommends Ctrl+J/
+    # Alt+Enter as the documented alternative). Overrides prompt_toolkit's own
+    # default c-j binding, which normally re-feeds it as if it were Enter (some
+    # terminals, e.g. WSL, send \n instead of \r for plain Enter) — reyn's
+    # input already only ever reaches here via an explicit Enter/Shift+Enter
+    # path, so that default's rationale doesn't apply and this rebinding is safe.
+    @kb.add("c-j", filter=has_focus(input_win))
+    def _ctrl_j_newline(event) -> None:
+        buf.newline(copy_margin=False)
+
     @kb.add("down", filter=has_focus(input_win) & ~has_completions)
     def _down(event) -> None:
-        # With text in the box, ↓ is history navigation (forward, shell-like) so
-        # it doesn't yank focus away mid-edit. With an empty box, ↓ drops into the
-        # status bar (its discoverable affordance). ↑ stays history either way.
-        # Gated on ~has_completions so that while the slash menu is open ↓ falls
-        # through to the default binding (navigate the completion list).
-        if buf.text:
-            buf.history_forward()
-        else:
+        # Gated on ~has_completions so that while the slash menu is open ↓
+        # falls through to the default binding (navigate the completion
+        # list). ↑ stays on prompt_toolkit's own default (auto_up), which
+        # already has the same row-aware behavior built in — only ↓ needed
+        # reyn's empty-box "drop to status bar" special case, see
+        # _down_arrow_action's docstring.
+        action = _down_arrow_action(
+            bool(buf.text), buf.document.cursor_position_row, buf.document.line_count,
+        )
+        if action == "focus_status":
             event.app.layout.focus(status_win)
+        elif action == "cursor_down":
+            buf.cursor_down()
+        else:
+            buf.history_forward()
 
     def _actionable_open() -> bool:
         # Dropdown showing AND the opened element is a selectable picker (a

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -787,7 +787,18 @@ class InlineChatRenderer(ChatRenderer):
             self._transient_active = False
 
     def banner(self, agent_name: str) -> None:
-        self._console.print(f"[{_CC_DIM}]· {agent_name} · /quit to exit ·[/]\n")
+        # Ctrl+J is the GUARANTEED-works newline binding (documented per the
+        # #1765-adjacent Shift+Enter investigation: most terminals can't
+        # distinguish Shift+Enter from plain Enter at all — Ctrl+J sends a
+        # distinct byte, LF vs CR, on every VT100-compatible terminal). Shift+
+        # Enter also works out of the box on terminals with an extended
+        # keyboard protocol (mintty/Git Bash default; iTerm2/kitty/Ghostty/
+        # Alacritty default) — worth advertising, but Ctrl+J is the one that
+        # never silently fails, so it leads.
+        self._console.print(
+            f"[{_CC_DIM}]· {agent_name} · Enter to send · "
+            f"ctrl+j / shift+enter for newline · /quit to exit ·[/]\n"
+        )
         self._flush()
 
     def message(self, msg: OutboxMessage) -> None:

--- a/tests/test_inline_multiline_input.py
+++ b/tests/test_inline_multiline_input.py
@@ -1,0 +1,116 @@
+"""Tier 2: multiline inline-input pure helpers (owner spec: Enter=submit,
+Shift+Enter=newline).
+
+``_is_shift_enter_escape`` and ``_down_arrow_action`` are extracted as pure
+functions so the terminal-escape-sequence detection and the row-aware ↓-key
+decision are unit-testable without a running prompt_toolkit Application —
+mirrors the existing ``_picker_hint`` extraction pattern in this module.
+
+The Shift+Enter detection is grounded in a real cross-terminal investigation
+(direct prompt_toolkit source read + an empirical tmux byte-probe sending the
+literal escape sequences into a live prompt_toolkit key processor): most
+terminals send an identical "\\r" for Enter and Shift+Enter (a hard VT100
+protocol limit), but mintty (Windows Git Bash) sends a disambiguated xterm
+modifyOtherKeys escape sequence by default, which prompt_toolkit's own
+``ansi_escape_sequences.py`` collapses back to plain Enter at the ``.key``
+level while still preserving the original bytes in ``.data``.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.inline.app import (
+    _INPUT_MAX_HEIGHT,
+    _SHIFT_ENTER_RAW_DATA,
+    _down_arrow_action,
+    _input_window_height,
+    _is_shift_enter_escape,
+)
+
+
+def test_is_shift_enter_escape_true_for_mintty_sequence():
+    """Tier 2: the mintty/xterm-modifyOtherKeys Shift+Enter escape sequence is
+    recognized as Shift+Enter."""
+    assert _is_shift_enter_escape("\x1b[27;2;13~") is True
+
+
+def test_is_shift_enter_escape_false_for_plain_enter():
+    """Tier 2: plain Enter's raw data ("\\r") is NOT mistaken for Shift+Enter —
+    the whole point of the detection is telling these two apart."""
+    assert _is_shift_enter_escape("\r") is False
+
+
+def test_is_shift_enter_escape_false_for_unrelated_data():
+    """Tier 2: arbitrary other key data (e.g. a normal character) is not
+    misclassified as Shift+Enter."""
+    assert _is_shift_enter_escape("a") is False
+    assert _is_shift_enter_escape("") is False
+
+
+def test_shift_enter_raw_data_set_is_nonempty():
+    """Tier 2: the recognized-sequences set actually has the mintty entry (a
+    regression guard against the constant being accidentally emptied)."""
+    assert "\x1b[27;2;13~" in _SHIFT_ENTER_RAW_DATA
+
+
+def test_down_arrow_action_empty_buffer_focuses_status():
+    """Tier 2: ↓ on an empty input box drops focus to the status bar (the
+    existing discoverable affordance, unchanged by multiline support)."""
+    assert _down_arrow_action(has_text=False, cursor_row=0, line_count=1) == "focus_status"
+
+
+def test_down_arrow_action_single_line_with_text_goes_to_history():
+    """Tier 2: single-line buffer (cursor_row == line_count - 1 == 0) with text
+    falls to history-forward — byte-identical to the pre-multiline behavior."""
+    action = _down_arrow_action(has_text=True, cursor_row=0, line_count=1)
+    assert action == "history_forward"
+
+
+def test_down_arrow_action_multiline_not_on_last_row_moves_cursor():
+    """Tier 2: multiline buffer, cursor NOT on the last line → move the cursor
+    down a line (in-buffer navigation), not history — this is the new
+    behavior multiline support requires (mirrors Buffer.auto_down's own
+    row-check, since the custom ↓ binding replaces auto_down entirely)."""
+    action = _down_arrow_action(has_text=True, cursor_row=0, line_count=3)
+    assert action == "cursor_down"
+
+
+def test_down_arrow_action_multiline_on_last_row_goes_to_history():
+    """Tier 2: multiline buffer, cursor ON the last line → falls through to
+    history-forward, same as the single-line case."""
+    action = _down_arrow_action(has_text=True, cursor_row=2, line_count=3)
+    assert action == "history_forward"
+
+
+def test_down_arrow_action_multiline_middle_row_moves_cursor():
+    """Tier 2: a middle row (neither first nor last) always moves the cursor,
+    never triggers history or status-bar focus."""
+    action = _down_arrow_action(has_text=True, cursor_row=1, line_count=5)
+    assert action == "cursor_down"
+
+
+def test_input_window_height_single_line_is_one():
+    """Tier 2: a single-line buffer (the pre-multiline common case) still gets
+    exactly height=1 — byte-identical to the old fixed height=1 default."""
+    assert _input_window_height(1) == 1
+
+
+def test_input_window_height_grows_with_line_count():
+    """Tier 2: the input window height grows with the buffer's line count —
+    this is the actual fix for the review-caught rendering gap: a fixed
+    height=1 window only ever showed the buffer's CURRENT line, hiding every
+    earlier line once Shift+Enter/Ctrl+J could insert real newlines (confirmed
+    live via tmux: "line one" + Shift+Enter + "line two" showed only "line
+    two" even though the newline itself inserted correctly)."""
+    assert _input_window_height(3) == 3
+
+
+def test_input_window_height_capped_at_max():
+    """Tier 2: height never exceeds _INPUT_MAX_HEIGHT, regardless of how many
+    lines the buffer holds — same "Window too small" guard rationale as the
+    existing _ABOVE_REGION_MAX_HEIGHT / _MENU_REGION_MAX_HEIGHT caps."""
+    assert _input_window_height(_INPUT_MAX_HEIGHT + 50) == _INPUT_MAX_HEIGHT
+
+
+def test_input_window_height_never_below_one():
+    """Tier 2: a defensive floor — line_count should never be < 1 in practice,
+    but the height must never go to 0 (an invisible input box) even so."""
+    assert _input_window_height(0) == 1

--- a/tests/test_inline_slash_completer_multiline.py
+++ b/tests/test_inline_slash_completer_multiline.py
@@ -1,0 +1,53 @@
+"""Tier 2: _SlashCompleter's newline guard (multiline input support).
+
+Slash commands are inherently single-line — once the input buffer (now
+multiline-capable, see run_inline_input's Buffer) has moved past a bare
+command word onto a second line, the completer must go quiet, same intent as
+its existing " " in text check, just extended to the "\\n" case. Real
+Document + real completer instance, no mocks.
+"""
+from __future__ import annotations
+
+from prompt_toolkit.document import Document
+
+from reyn.interfaces.inline.app import _SLASH_COMPLETER
+
+
+class _FakeCompleteEvent:
+    completion_requested = True
+
+
+def _completions_for(text: str) -> list:
+    doc = Document(text=text, cursor_position=len(text))
+    return list(_SLASH_COMPLETER.get_completions(doc, _FakeCompleteEvent()))
+
+
+def test_completes_bare_slash_prefix():
+    """Tier 2: a bare "/mo" still suggests matching commands (pre-existing
+    behavior, unaffected by the newline guard)."""
+    completions = _completions_for("/mo")
+    assert any(c.display[0][1] == "/model" for c in completions)
+
+
+def test_stops_after_space_unchanged():
+    """Tier 2: the pre-existing " " in text guard still stops suggestions once
+    args begin."""
+    assert _completions_for("/model standard") == []
+
+
+def test_stops_after_newline():
+    """Tier 2: a newline (Shift+Enter having inserted one) also stops
+    suggestions — the new guard this change adds."""
+    assert _completions_for("/mo\nsomething") == []
+
+
+def test_stops_after_bare_trailing_newline():
+    """Tier 2: even a lone trailing newline right after the command word
+    (nothing typed on the second line yet) stops suggestions."""
+    assert _completions_for("/mo\n") == []
+
+
+def test_non_slash_text_yields_nothing():
+    """Tier 2: text not starting with "/" never suggests (pre-existing guard,
+    unaffected)."""
+    assert _completions_for("hello") == []


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Owner spec: Enter submits the message, Shift+Enter inserts a newline — the opposite of prompt_toolkit's own multiline default (Enter=newline, Meta+Enter=submit). The input `Buffer` is now `multiline=True` with custom key bindings inverting the default.

## The Shift+Enter cross-terminal limit (design-judgment point, pre-cleared with lead-coder before implementing)

Confirmed via **direct prompt_toolkit source read + an empirical tmux byte-probe** (not guesswork — a minimal probe app was written to log raw `KeyPress` events for literal escape-sequence bytes sent through a live pane):

- Most terminals send an **identical `\r`** for Enter and Shift+Enter — a hard VT100 protocol limit with no software workaround (macOS Terminal.app, GNOME Terminal, default Windows Terminal, PuTTY, conhost).
- Some terminals send a **disambiguated escape sequence** when an extended keyboard protocol is active:
  - **mintty (Windows Git Bash)** sends the legacy xterm modifyOtherKeys form `\x1b[27;2;13~` **by default since 2009**. prompt_toolkit's own `ansi_escape_sequences.py` collapses this back to plain Enter at the `.key` level (its own comment: *"currently unsupported, so just re-map... to the unmodified versions"*) — but the raw `KeyPress.data` still carries the original escape string, so the distinction is recovered in the `"enter"` handler with **no prompt_toolkit monkeypatch needed**. Verified empirically via the byte-probe.
  - **iTerm2/kitty/Ghostty/Alacritty/Rio/Warp/Contour** send the Kitty keyboard protocol form (`ESC [ 13 ; 2 u`) by default — registered as a raw multi-key-sequence binding (prompt_toolkit has no built-in `"s-enter"` name; confirmed via its own key-bindings docs, which list every other shift-combination but not this one). This turned out to be low-risk to add (no conflicts, no unstable parsing), so base + stretch shipped together per lead-coder's scope call.
- **Ctrl+J** (raw LF, distinct from Enter's CR on every VT100-compatible terminal) is bound as the **guaranteed-always-works fallback** for terminals where Shift+Enter is genuinely undetectable — the same pattern other CLIs facing this exact gap use (e.g. Claude Code's own open tracking issue on this recommends Ctrl+J/Alt+Enter as the documented alternative). Advertised in the inline startup banner alongside Shift+Enter.

## Other integration points

- `FileHistory` already round-trips multi-line entries natively (`"+"`-prefixed continuation lines) — no change needed.
- `_SlashCompleter` gained a `"\n"` guard (slash commands are inherently single-line).
- The `↓` key binding is now row-aware (mirrors `Buffer.auto_down`, which it fully replaces): moves the cursor within multiline text, falls to history-forward on the last line, or focuses the status bar on an empty buffer (unchanged discoverability affordance).
- The input `Window`'s height now grows with the buffer's line count (capped at 8, same "Window too small" guard rationale as the existing above-region/menu-region caps) — the pre-existing fixed `height=1` only ever showed the buffer's *current* line, hiding earlier lines once real newlines could be inserted. **Caught live during tmux verification** (typing "line one", Shift+Enter, "line two" showed only "line two" even though the newline itself inserted correctly) and fixed in the same PR.

## Test plan

- [x] `pytest tests/test_inline_multiline_input.py tests/test_inline_slash_completer_multiline.py tests/test_inline_pr3b_status_bar.py` — 93 passed
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/verify_module_docstrings.py` (changed src files) — clean
- [x] Full `pytest` suite — 7915 passed, 9 failed (pre-existing/environmental, unrelated files — same known baseline as prior PRs this session), 17 skipped
- [x] **Live tmux verification, real byte sequences sent into a live pane** (not just unit tests):
  - mintty-style Shift+Enter (`\x1b[27;2;13~`) inserts a newline, does NOT submit — confirmed by absence of an echoed message in scrollback
  - Kitty-protocol Shift+Enter (`\x1b[13;2u`) inserts a newline — confirmed
  - Ctrl+J inserts a newline — confirmed
  - Plain Enter submits the full multiline buffer as ONE turn — confirmed via the agent receiving all lines in one tool call
  - Up/Down cursor navigation within multiline text does NOT trigger history — confirmed (buffer content unchanged after navigating)
  - History recall (`↑` on empty buffer) restores the full multi-line entry — confirmed
  - `↓` past the last history entry on an empty buffer focuses the status bar — confirmed via the status-bar-focus hint appearing
  - Slash completion (`/mo` → `/model` menu) still triggers — confirmed
  - Input window height grows to fit multi-line content and shows all lines — confirmed (this is the fix for the height bug caught above)

Tier self-check: all new/modified tests are Tier 2 (pure function extraction — `_is_shift_enter_escape`, `_down_arrow_action`, `_input_window_height`, `_SlashCompleter.get_completions`), docstrings declare Tier first line, no MagicMock/patch of collaborators, no private-state assertions, no format pins.