### PR TITLE
docs: note multi-line paste behavior + rare-terminal caveat in inline banner

### DIFF
--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -799,6 +799,18 @@ class InlineChatRenderer(ChatRenderer):
             f"[{_CC_DIM}]· {agent_name} · Enter to send · "
             f"ctrl+j / shift+enter for newline · /quit to exit ·[/]\n"
         )
+        # Multi-line paste is verified working (tmux round-trip: literal
+        # insert, no premature submit, single-turn send) on any terminal that
+        # respects prompt_toolkit's auto-enabled bracketed-paste mode — true
+        # for virtually every terminal in current use. The rare-terminal
+        # caveat (same hard-limit class as Shift+Enter): a terminal/input path
+        # that ignores bracketed paste entirely sends each embedded newline as
+        # a plain Enter, submitting one line at a time instead of one paste.
+        self._console.print(
+            f"[{_CC_DIM}]  paste: multi-line pastes work as one block on "
+            f"bracketed-paste-aware terminals (virtually all modern ones); "
+            f"without that, each line may submit separately.[/]\n"
+        )
         self._flush()
 
     def message(self, msg: OutboxMessage) -> None:


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Small doc-only follow-up to #2762 (merged), per lead-coder's request after an owner follow-up question ("does multiline input support multi-line paste?").

Verified via tmux with a real bracketed-paste envelope (`\x1b[200~...\x1b[201~`): multi-line paste works as one block, no premature submit, single-turn send — because prompt_toolkit auto-enables bracketed-paste mode on every Application and virtually all modern terminals respect it. Also honestly verified the rare-terminal edge case: a terminal/input path that ignores bracketed paste entirely sends each embedded newline as a plain Enter, causing one submit per line — same hard-limit class as the Shift+Enter investigation. Per lead-coder's call, not worth adding Enter-burst-debounce complexity for (risk of mis-debouncing an intentional fast double-Enter outweighs covering an already-rare gap) — documenting it is the right level of effort.

This adds one line to the inline CUI's startup banner (same location as the existing Shift+Enter/Ctrl+J note) describing both the working case and the caveat.

## Test plan

- [x] `ruff check` (changed file) — clean
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] Live tmux verification: banner renders both lines correctly on startup
- [x] (Already verified in the prior investigation, not re-run here) real bracketed-paste multi-line insert/submit + the unwrapped-paste edge case, both via tmux

No behavior change — doc-only (a startup banner string).