### PR TITLE
feat: mid-turn immediate hot-reload for skill/pipeline install (additive path) (#2761 PR-2)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -147,6 +147,16 @@ class OpContext:
     # non-chat) → the op skips it (the opt-in contract, same as the step-event gate).
     state_log: "StateLog | None" = None
 
+    # #2761 PR-2: this SESSION's HotReloader (the #2073 S3 per-session route), so an
+    # install op (skill_install / pipeline_install) can apply its reload IMMEDIATELY
+    # (mid-turn) for a PURE ADDITION — making the just-installed NEW entry resolvable
+    # this turn. A same-name overwrite / no reloader keeps the deferred turn-boundary
+    # path. Per-session (never the process-global get_active_hot_reloader, which is the
+    # last-registered session — a multi-session footgun). None outside a live chat
+    # session (tests / CLI separate-process install) → the op falls back to the deferred
+    # path (unchanged behavior).
+    hot_reloader: "object | None" = None
+
     # FP-0022 follow-up: declarative SSL config for web_fetch and MCP registry.
     # Defaults to WebConfig() (= no override, falls through to env-var chain).
     # Callers that have a ReynConfig available should pass config.web here.

--- a/src/reyn/core/op_runtime/pipeline_install.py
+++ b/src/reyn/core/op_runtime/pipeline_install.py
@@ -31,9 +31,11 @@ Local-path install (``op.source is None``):
   7. ``record_config_generation`` on the pipelines.yaml path AFTER write —
      the truncation-surviving recovery base (#2259 / CLAUDE.md recovery gate).
   8. Emit ``pipeline_installed`` event (P6 audit trail).
-  9. Request hot-reload so the installed pipeline goes live in the current session
-     (the ``"pipelines"`` seam — ``Session._reapply_pipelines`` — rebuilds the
-     registry from the fresh config cascade).
+  9. Reload so the installed pipeline goes live (#2761 PR-2): a PURE ADDITION on a
+     live per-session reloader (``ctx.hot_reloader``) applies the ``"pipelines"`` seam
+     (``Session._reapply_pipelines`` — rebuilds the registry from the fresh config
+     cascade) IMMEDIATELY (mid-turn) — resolvable this same turn; a same-name overwrite
+     (clobber-update) or no per-session reloader keeps the deferred turn-boundary path.
 
 Source/git install (``op.source`` set):
   Same pipeline as local, but step 0 fetches the DSL file first:
@@ -410,6 +412,11 @@ async def handle(
     }
     if op.source:
         entry["source"] = op.source
+    # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
+    # so step 9 routes a NEW name to the immediate mid-turn apply and a same-name
+    # overwrite (clobber-update — pipeline's only update path) to the deferred path.
+    from reyn.runtime.hot_reload import is_pure_addition  # noqa: PLC0415
+    _is_addition = is_pure_addition(safe_name, existing["pipelines"]["entries"])
     existing["pipelines"]["entries"][safe_name] = entry
     _write_yaml(config_path, existing)
 
@@ -428,10 +435,18 @@ async def handle(
     )
 
     # ── 9. Hot-reload: surface the installed pipeline in the current session ──
-    from reyn.runtime.hot_reload import get_active_hot_reloader  # noqa: PLC0415
-    _reloader = get_active_hot_reloader()
-    if _reloader is not None:
-        _reloader.request_reload(source="pipeline_install")
+    # #2761 PR-2: a PURE ADDITION on a live per-session reloader (ctx.hot_reloader)
+    # applies IMMEDIATELY (mid-turn) so the just-installed NEW pipeline is resolvable
+    # this turn (a call/match step can target it same execution); a same-name overwrite
+    # (clobber-update) or no per-session reloader (CLI separate process) keeps the
+    # existing deferred turn-boundary behavior — which also confines the R7 pending-call
+    # target hazard to the deferred path it already lives on.
+    from reyn.runtime.hot_reload import dispatch_install_reload  # noqa: PLC0415
+    await dispatch_install_reload(
+        getattr(ctx, "hot_reloader", None),
+        source="pipeline_install",
+        is_addition=_is_addition,
+    )
 
     return {
         "status": "installed",

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -17,7 +17,10 @@ Local-path install (``op.source is None``):
   6. ``record_config_generation`` on the skills.yaml path AFTER write —
      the truncation-surviving recovery base (#2259 / CLAUDE.md recovery gate).
   7. Emit ``skill_installed`` event (P6 audit trail).
-  8. Request hot-reload so the installed skill goes live in the current session.
+  8. Reload so the installed skill goes live (#2761 PR-2): a PURE ADDITION on a
+     live per-session reloader (``ctx.hot_reloader``) applies IMMEDIATELY (mid-turn)
+     — the new skill is resolvable this same turn; a same-name overwrite
+     (clobber-update) or no per-session reloader keeps the deferred turn-boundary path.
 
 Source/git install (``op.source`` set — #2548 PR-D):
   Same pipeline as local, but step 0 fetches the skill first:
@@ -533,6 +536,11 @@ async def handle(
     }
     if op.source:
         entry["source"] = op.source
+    # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
+    # so step 8 can route a NEW name to the immediate mid-turn apply and a same-name
+    # overwrite (clobber-update — skill's only update path) to the deferred path.
+    from reyn.runtime.hot_reload import is_pure_addition  # noqa: PLC0415
+    _is_addition = is_pure_addition(name, existing["skills"]["entries"])
     existing["skills"]["entries"][name] = entry
     _write_yaml(config_path, existing)
 
@@ -551,10 +559,16 @@ async def handle(
     )
 
     # ── 8. Hot-reload: surface the installed skill in the current session ─────
-    from reyn.runtime.hot_reload import get_active_hot_reloader  # noqa: PLC0415
-    _reloader = get_active_hot_reloader()
-    if _reloader is not None:
-        _reloader.request_reload(source="skill_install")
+    # #2761 PR-2: a PURE ADDITION on a live per-session reloader (ctx.hot_reloader)
+    # applies IMMEDIATELY (mid-turn) so the just-installed NEW skill is resolvable this
+    # turn; a same-name overwrite (clobber-update) or no per-session reloader (CLI
+    # separate process) keeps the existing deferred turn-boundary behavior.
+    from reyn.runtime.hot_reload import dispatch_install_reload  # noqa: PLC0415
+    await dispatch_install_reload(
+        getattr(ctx, "hot_reloader", None),
+        source="skill_install",
+        is_addition=_is_addition,
+    )
 
     return {
         "status": "installed",

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -34,6 +34,30 @@ _log = logging.getLogger(__name__)
 # wires the per-component seams (mcp / cron / hooks / per-agent capability / …).
 ReapplySeam = tuple[str, Callable[[dict], Awaitable[bool]]]
 
+# #2761 PR-2: an install op's ``source`` → the seam name(s) its IMMEDIATE mid-turn
+# apply must run (and ONLY those — not the whole reload). Skill / pipeline are the
+# two pure-in-memory rebuild types; ``mcp_install`` is added in PR-3 (its seam does
+# an external re-probe with a probe-then-commit + cancel/timeout contract).
+_INSTALL_SOURCE_SEAMS: "dict[str, tuple[str, ...]]" = {
+    "skill_install": ("skills",),
+    "pipeline_install": ("pipelines",),
+}
+
+
+def is_pure_addition(name: str, existing_entries: "dict | None") -> bool:
+    """True iff ``name`` is NOT already registered — a pure addition (#2761 PR-2).
+
+    An install op gates its IMMEDIATE mid-turn reload on this: a brand-new name never
+    touches an in-USE entry, so applying it mid-turn cannot trigger the R7
+    in-use-replace hazard (``session._reapply_pipelines`` docstring note / issue
+    #2761). A same-name overwrite (``name`` already present) is NOT a pure addition —
+    it keeps the existing deferred turn-boundary path, preserving clobber-update
+    (skill/pipeline have no ``remove`` CLI, so re-install is their only update path)
+    and the documented mcp re-install fix, and confining R7 to the deferred path it
+    already lives on.
+    """
+    return name not in (existing_entries or {})
+
 
 def validate_in_set(in_set: "dict") -> "str | None":
     """Validate-before-apply (#2073 S2): a structural check of the re-read IN-set.
@@ -199,6 +223,74 @@ class HotReloader:
             )
         return {"source": source, "applied": applied, "failed": failed}
 
+    async def apply_now(self, *, source: str) -> "dict":
+        """#2761 PR-2: apply an install's reload IMMEDIATELY (mid-turn), running ONLY
+        the seam(s) that ``source`` affects — NOT the whole reload (that is
+        :meth:`apply_pending`'s turn-boundary job).
+
+        Used by an install op on the PURE-ADDITION path (the caller gates on
+        :func:`is_pure_addition` + a live per-session reloader), so the just-installed
+        NEW skill/pipeline is resolvable/usable in the SAME execution — the owner's
+        additive same-turn goal. Only *resolution* (looking a name up to run it) is
+        made immediate; *discovery* (the LLM's tool catalog / "## Skills" menu, built
+        once per turn) still updates next turn — so this does not over-claim mid-turn
+        LLM discovery.
+
+        Re-reads ONLY the IN-set (same safety boundary as :meth:`apply_pending` — the
+        OUT-set ``reyn.yaml`` is never opened) and runs validate-before-apply: a
+        malformed IN-set is REJECTED whole (no seam runs, live config unchanged). Never
+        raises out — a seam failure is isolated under ``failed`` so a misbehaving
+        reload can never break the turn. Does NOT touch the deferred ``pending`` flag
+        (the immediate path is independent of the operator ``/reload`` schedule).
+
+        Returns a ``{"source", "applied", "failed"}`` summary (or, on a rejected
+        IN-set, additionally ``"rejected"``). An unknown / unmapped ``source`` applies
+        nothing (defensive — callers pass a known install source)."""
+        target_seams = _INSTALL_SOURCE_SEAMS.get(source)
+        if not target_seams:
+            return {"source": source, "applied": [], "failed": []}
+
+        # Same IN-set safety boundary as apply_pending: the OUT-set is never opened.
+        in_set = load_hot_reload_config(self._project_root)
+
+        # Validate-before-apply (atomicity): a malformed IN-set is REJECTED whole — no
+        # seam runs, the live config is unchanged. Mirrors apply_pending exactly.
+        if self._validate is not None:
+            reason = self._validate(in_set)
+            if reason:
+                _log.warning(
+                    "hot-reload (immediate) REJECTED (invalid IN-set): %s — live config unchanged",
+                    reason,
+                )
+                if self._events is not None:
+                    self._events.emit(
+                        "config_reload_rejected",
+                        source=source or "unknown",
+                        reason=reason,
+                    )
+                return {"source": source, "rejected": reason, "applied": [], "failed": []}
+
+        applied: list[str] = []
+        failed: list[str] = []
+        for name, fn in self._seams:
+            if name not in target_seams:
+                continue  # immediate apply is scoped to the affected seam(s) only
+            try:
+                if await fn(in_set):
+                    applied.append(name)
+            except Exception as exc:  # noqa: BLE001 — a seam never breaks the turn
+                _log.warning("hot-reload (immediate) seam %r failed: %s", name, exc)
+                failed.append(name)
+
+        if self._events is not None:
+            self._events.emit(
+                "config_reloaded",
+                source=source or "unknown",
+                components=applied,
+                failed=failed,
+            )
+        return {"source": source, "applied": applied, "failed": failed}
+
 
 # ── process-wide active HotReloader (#2073 S3) ──────────────────────────────
 # The LLM-op hooks-write tool reaches the reloader to ``request_reload`` after
@@ -220,10 +312,43 @@ def get_active_hot_reloader() -> "HotReloader | None":
     return _active_hot_reloader
 
 
+async def dispatch_install_reload(
+    ctx_reloader: "HotReloader | None",
+    *,
+    source: str,
+    is_addition: bool,
+) -> None:
+    """#2761 PR-2: route an install op's post-write reload.
+
+    - **Pure addition + a live per-session reloader** (``ctx.hot_reloader``, the
+      #2073 S3 per-session route) → :meth:`HotReloader.apply_now` runs the affected
+      seam IMMEDIATELY so the just-installed NEW entry is resolvable this turn.
+    - **Otherwise** (a same-name overwrite, OR no per-session reloader — e.g. the CLI
+      ``reyn <kind> install`` running in a separate process) → the EXISTING deferred
+      turn-boundary behavior via the process-active reloader, UNCHANGED. This
+      preserves clobber-update (skill/pipeline's only update path) + the documented
+      mcp re-install fix, and confines the R7 in-use-replace hazard to the deferred
+      path it already lives on.
+
+    The per-session ``ctx_reloader`` is preferred over the process-global
+    :func:`get_active_hot_reloader` for the immediate path specifically, because the
+    process-global is the *last-registered* session's reloader (a multi-session
+    footgun the deferred path tolerates but the immediate path must not)."""
+    if is_addition and ctx_reloader is not None:
+        await ctx_reloader.apply_now(source=source)
+        return
+    # Deferred / clobber-update / no-per-session-reloader path — unchanged behavior.
+    reloader = get_active_hot_reloader()
+    if reloader is not None:
+        reloader.request_reload(source=source)
+
+
 __all__ = [
     "HotReloader",
     "ReapplySeam",
     "validate_in_set",
+    "is_pure_addition",
+    "dispatch_install_reload",
     "set_active_hot_reloader",
     "get_active_hot_reloader",
 ]

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -74,6 +74,7 @@ def build_router_op_context(
     task_subscription_writer: Any = None,  # #2187 backend-master: the Task subscription WAL writer
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
     current_task_id: str | None = None,  # #1953 §16: the task this turn is executing → task.create ownership
+    hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -159,4 +160,5 @@ def build_router_op_context(
         task_subscription_writer=task_subscription_writer,  # #2187 backend-master: the Task subscription WAL writer
         hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
         current_task_id=current_task_id,  # #1953 §16: ownership-derivation context
+        hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -2069,6 +2069,12 @@ class RouterHostAdapter:
             current_task_id=(
                 self._current_task_id_fn() if self._current_task_id_fn else None
             ),
+            # #2761 PR-2: the per-session HotReloader so an install op (skill/pipeline)
+            # can apply a pure-addition reload IMMEDIATELY (mid-turn) → the new entry is
+            # resolvable this turn. This is the router-dispatched install path
+            # (skill_management__install_* / pipeline ops → build_legacy_op_context →
+            # this factory), so it is the load-bearing wiring for PR-2.
+            hot_reloader=self.hot_reloader,
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5713,6 +5713,7 @@ class Session:
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
             current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)
+            hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/test_2761_pr2_hotreload_immediate_apply.py
@@ -1,0 +1,493 @@
+"""Tier 2: #2761 PR-2 — immediate mid-turn apply for a PURE-ADDITION install.
+
+The hot-reload arc drops the turn-boundary constraint so an install op can USE the
+skill/pipeline it just installed within the same execution. The mechanism is a PATH
+CONDITION (not a blanket guard — see the #2761 revised §2 contract): a pure addition
+(a brand-new name) on a live per-session reloader applies IMMEDIATELY via
+``HotReloader.apply_now`` (only the affected seam); a same-name overwrite
+(clobber-update — skill/pipeline have no ``remove`` CLI, so re-install is their only
+update path) OR no per-session reloader keeps the EXISTING deferred turn-boundary
+path. This confines the R7 in-use-replace hazard to the deferred path it already lives
+on, and preserves every update workflow.
+
+Three invariant clusters:
+  A. ``apply_now`` runs ONLY the seam(s) the install ``source`` affects (not the whole
+     reload), immediately, atomically (validate-before-apply), and independent of the
+     deferred ``pending`` schedule.
+  B. ``is_pure_addition`` + ``dispatch_install_reload`` route addition→immediate,
+     overwrite/no-reloader→deferred.
+  C. End-to-end through the REAL install handlers + a REAL Session's seams: a NEW name
+     is resolvable the SAME turn; a same-name overwrite is NOT applied mid-turn but
+     still lands (clobber-update preserved) at the next turn boundary.
+
+Honesty (discovery vs resolution): these assert *resolution* (the live registry /
+available-skills the op resolves against), never the LLM's mid-turn *discovery*
+catalog (rebuilt once per turn) — matching the contract's explicit scope.
+
+No mocks. Real EventLog / HotReloader / Session / RouterHostAdapter / install handlers.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.hot_reload import (
+    HotReloader,
+    dispatch_install_reload,
+    is_pure_addition,
+    set_active_hot_reloader,
+)
+from reyn.runtime.session import Session
+from reyn.security.permissions.permissions import PermissionDecl
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seam_recorder() -> "tuple[dict, callable]":
+    """Return (ran, make_seam): ``ran`` records which seam names executed; ``make_seam``
+    builds a real async seam fn that records its name and returns ``changed``."""
+    ran: dict[str, int] = {}
+
+    def make_seam(name: str, changed: bool = True):
+        async def _seam(in_set: dict) -> bool:
+            ran[name] = ran.get(name, 0) + 1
+            return changed
+        return _seam
+
+    return ran, make_seam
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "pr2-agent") -> Session:
+    """Minimal real Session rooted at *tmp_path* (chdir before calling). Builds
+    ``available_skills`` + ``pipeline_registry`` from ``load_config`` so entries already
+    written to ``.reyn/config/*.yaml`` are adopted — mirroring session-factory."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    from reyn.config.loader import load_config
+    from reyn.data.pipelines.registry import build_pipeline_registry
+    from reyn.data.skills.registry import build_skill_registry
+    cfg = load_config()
+    available_skills = build_skill_registry(cfg.skills) or None
+    pipeline_registry = build_pipeline_registry(cfg.pipelines, tmp_path)
+    return Session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        available_skills=available_skills,
+        pipeline_registry=pipeline_registry,
+    )
+
+
+def _op_ctx(tmp_path: Path, session: "Session | None") -> OpContext:
+    """A real OpContext wired to *session*'s HotReloader (or None) — permission_resolver
+    is None so the install handler skips the file-write gate (the gate is not under
+    test here; the reload path condition is)."""
+    return OpContext(
+        workspace=Workspace(events=EventLog(), base_dir=tmp_path),
+        events=EventLog(),
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        hot_reloader=(session._hot_reloader if session is not None else None),
+    )
+
+
+def _write_skill(tmp_path: Path, dirname: str, *, name: str, description: str) -> Path:
+    d = tmp_path / dirname
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\nbody\n", encoding="utf-8",
+    )
+    return d
+
+
+def _write_pipeline(tmp_path: Path, filename: str, *, name: str, description: str) -> Path:
+    p = tmp_path / filename
+    p.write_text(
+        f"pipeline: {name}\n"
+        f"description: {description}\n"
+        "steps:\n"
+        "  - transform: {value: \"'hi'\", output: g}\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _skill_names(session: Session) -> list[str]:
+    skills = session._router_host.get_available_skills()
+    return [s.name for s in skills] if skills else []
+
+
+def _skill_desc(session: Session, name: str) -> "str | None":
+    for s in session._router_host.get_available_skills() or []:
+        if s.name == name:
+            return s.description
+    return None
+
+
+def _pipeline_names(session: Session) -> tuple[str, ...]:
+    """Names in the LIVE pipeline registry (the one run_pipeline resolves against)."""
+    return session._router_host.get_pipeline_registry().names()
+
+
+def _pipeline_desc(session: Session, name: str) -> "str | None":
+    reg = session._router_host.get_pipeline_registry()
+    return reg.get(name).description if name in reg.names() else None
+
+
+# ===========================================================================
+# A. HotReloader.apply_now — affected-seam-only, immediate, atomic
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_apply_now_runs_only_the_affected_seam(tmp_path: Path) -> None:
+    """Tier 2: apply_now(source=skill_install) runs ONLY the "skills" seam — NOT the
+    whole reload — so a mid-turn install applies just its own component."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+    hr.register_seam("pipelines", make_seam("pipelines"))
+    hr.register_seam("mcp", make_seam("mcp"))
+
+    summary = await hr.apply_now(source="skill_install")
+
+    assert summary["applied"] == ["skills"]
+    assert ran == {"skills": 1}, "pipelines/mcp seams must NOT run for a skill_install apply_now"
+
+
+@pytest.mark.asyncio
+async def test_apply_now_pipeline_source_targets_pipelines_seam(tmp_path: Path) -> None:
+    """Tier 2: apply_now(source=pipeline_install) targets the "pipelines" seam only."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+    hr.register_seam("pipelines", make_seam("pipelines"))
+
+    summary = await hr.apply_now(source="pipeline_install")
+
+    assert summary["applied"] == ["pipelines"]
+    assert ran == {"pipelines": 1}
+
+
+@pytest.mark.asyncio
+async def test_apply_now_does_not_touch_the_deferred_pending_flag(tmp_path: Path) -> None:
+    """Tier 2: apply_now is the IMMEDIATE path — it never sets/clears the deferred
+    ``pending`` schedule (operator /reload stays independent)."""
+    _ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+    assert hr.pending is False
+
+    await hr.apply_now(source="skill_install")
+
+    assert hr.pending is False, "apply_now must not schedule a deferred reload"
+
+
+@pytest.mark.asyncio
+async def test_apply_now_unknown_source_is_noop(tmp_path: Path) -> None:
+    """Tier 2: an unmapped source (e.g. operator /reload, or a not-yet-wired install
+    type) applies nothing immediately — no seam runs, no crash (defensive)."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+
+    summary = await hr.apply_now(source="operator")
+
+    assert summary["applied"] == []
+    assert ran == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_now_rejects_malformed_in_set_atomically(tmp_path: Path) -> None:
+    """Tier 2: a malformed IN-set is REJECTED whole — the seam does NOT run (live config
+    unchanged), and a config_reload_rejected event is emitted (same atomicity as
+    apply_pending)."""
+    cfg = tmp_path / ".reyn" / "config"
+    cfg.mkdir(parents=True)
+    (cfg / "skills.yaml").write_text("skills: not-a-mapping\n", encoding="utf-8")
+    ran, make_seam = _seam_recorder()
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    hr.register_seam("skills", make_seam("skills"))
+
+    summary = await hr.apply_now(source="skill_install")
+
+    assert "rejected" in summary
+    assert ran == {}, "no seam may run when the IN-set is rejected"
+    assert any(e.type == "config_reload_rejected" for e in events.all())
+
+
+@pytest.mark.asyncio
+async def test_apply_now_emits_config_reloaded_with_source(tmp_path: Path) -> None:
+    """Tier 2: a successful immediate apply emits the config_reloaded P6 audit-event
+    carrying the install source (observability of a mid-turn config change)."""
+    _ran, make_seam = _seam_recorder()
+    events = EventLog()
+    hr = HotReloader(project_root=tmp_path, events=events)
+    hr.register_seam("skills", make_seam("skills"))
+
+    await hr.apply_now(source="skill_install")
+
+    sources = [e.data["source"] for e in events.all() if e.type == "config_reloaded"]
+    assert sources == ["skill_install"]
+
+
+@pytest.mark.asyncio
+async def test_operator_reload_still_runs_all_seams(tmp_path: Path) -> None:
+    """Tier 2: the deferred operator path (request_reload → apply_pending) is UNCHANGED
+    — it still runs ALL seams (the immediate apply_now scoping does not leak into it)."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+    hr.register_seam("pipelines", make_seam("pipelines"))
+    hr.request_reload(source="operator")
+
+    summary = await hr.apply_pending()
+
+    assert set(summary["applied"]) == {"skills", "pipelines"}
+    assert ran == {"skills": 1, "pipelines": 1}
+
+
+# ===========================================================================
+# B. is_pure_addition + dispatch_install_reload routing
+# ===========================================================================
+
+
+def test_is_pure_addition() -> None:
+    """Tier 2: is_pure_addition is True only for a name absent from the current entries
+    (None entries → absent → True); a present name is an overwrite (False)."""
+    assert is_pure_addition("new", {"old": {}}) is True
+    assert is_pure_addition("old", {"old": {}}) is False
+    assert is_pure_addition("anything", None) is True
+    assert is_pure_addition("x", {}) is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_addition_applies_immediately(tmp_path: Path) -> None:
+    """Tier 2: dispatch_install_reload with is_addition=True + a live ctx reloader runs
+    the affected seam IMMEDIATELY (apply_now) and does NOT schedule a deferred reload."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+
+    await dispatch_install_reload(hr, source="skill_install", is_addition=True)
+
+    assert ran == {"skills": 1}
+    assert hr.pending is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_overwrite_defers(tmp_path: Path) -> None:
+    """Tier 2: dispatch_install_reload with is_addition=False keeps the EXISTING deferred
+    behavior — the seam does NOT run mid-turn; a reload is scheduled for the turn
+    boundary (preserving clobber-update, confining R7 to the deferred path)."""
+    ran, make_seam = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make_seam("skills"))
+    set_active_hot_reloader(hr)
+    try:
+        await dispatch_install_reload(hr, source="skill_install", is_addition=False)
+    finally:
+        set_active_hot_reloader(None)
+
+    assert ran == {}, "an overwrite must not apply mid-turn"
+    assert hr.pending is True, "an overwrite schedules the deferred turn-boundary reload"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_no_reloader_defers_via_active(tmp_path: Path) -> None:
+    """Tier 2: no per-session reloader (ctx.hot_reloader=None — the CLI separate-process
+    install) → the deferred path via the process-active reloader, even for an addition
+    (the immediate path requires a live per-session reloader)."""
+    ran, make_seam = _seam_recorder()
+    active = HotReloader(project_root=tmp_path, events=EventLog())
+    active.register_seam("skills", make_seam("skills"))
+    set_active_hot_reloader(active)
+    try:
+        await dispatch_install_reload(None, source="skill_install", is_addition=True)
+    finally:
+        set_active_hot_reloader(None)
+
+    assert ran == {}
+    assert active.pending is True
+
+
+# ===========================================================================
+# C. End-to-end: real install handlers + real Session seams
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_skill_install_new_name_is_live_same_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: installing a NEW skill through the real handler makes it resolvable in the
+    SAME turn (present in the live get_available_skills()) WITHOUT any turn-boundary
+    apply — the pure-addition immediate path. pending stays False."""
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    assert "greet-skill" not in _skill_names(session)
+
+    skill_dir = _write_skill(tmp_path, "greet", name="greet-skill", description="v1")
+    op = SkillInstallIROp(kind="skill_install", path=str(skill_dir))
+    result = await skill_install_handle(op, _op_ctx(tmp_path, session))
+
+    assert result["status"] == "installed"
+    assert "greet-skill" in _skill_names(session), (
+        "a NEW skill must be resolvable the same turn (immediate mid-turn apply)"
+    )
+    # The immediate path fully handled it — nothing was left pending for the turn
+    # boundary (apply_pending is a no-op → None when nothing is scheduled).
+    residual = await session._hot_reloader.apply_pending()
+    assert residual is None, (
+        "the immediate addition path must not ALSO schedule a deferred reload"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_install_same_name_overwrite_defers_but_lands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: re-installing an EXISTING skill (clobber-update) is NOT applied mid-turn
+    (deferred, pending scheduled) but still lands at the next turn boundary — the
+    update workflow is preserved, not errored, just not same-turn (R7 avoidance)."""
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    # First install (addition) → immediately live, description v1.
+    skill_dir = _write_skill(tmp_path, "greet", name="greet-skill", description="v1")
+    await skill_install_handle(
+        SkillInstallIROp(kind="skill_install", path=str(skill_dir)),
+        _op_ctx(tmp_path, session),
+    )
+    assert _skill_desc(session, "greet-skill") == "v1"
+
+    # Re-install SAME name with a changed description (clobber-update).
+    _write_skill(tmp_path, "greet", name="greet-skill", description="v2")
+    result = await skill_install_handle(
+        SkillInstallIROp(kind="skill_install", path=str(skill_dir)),
+        _op_ctx(tmp_path, session),
+    )
+
+    assert result["status"] == "installed", "clobber-update must not be errored/refused"
+    assert _skill_desc(session, "greet-skill") == "v1", (
+        "a same-name overwrite must NOT be applied mid-turn (deferred)"
+    )
+
+    # It lands at the next turn boundary (the deferred turn-end apply) — proving the
+    # overwrite scheduled the deferred path, and clobber-update still works.
+    await session._hot_reloader.apply_pending()
+    assert _skill_desc(session, "greet-skill") == "v2", (
+        "the clobber-update must land at the turn boundary (applies next turn)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_install_new_name_is_resolvable_same_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: installing a NEW pipeline through the real handler makes it resolvable in
+    the SAME turn via the live registry get_pipeline_registry().get(name) — a call/match
+    step could target it this execution. pending stays False."""
+    from reyn.core.op_runtime.pipeline_install import handle as pipeline_install_handle
+    from reyn.schemas.models import PipelineInstallIROp
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    assert "greet" not in _pipeline_names(session)
+
+    dsl = _write_pipeline(tmp_path, "greet.yaml", name="greet", description="v1")
+    op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl))
+    result = await pipeline_install_handle(op, _op_ctx(tmp_path, session))
+
+    assert result["status"] == "installed"
+    assert "greet" in _pipeline_names(session), (
+        "a NEW pipeline must be resolvable the same turn (immediate mid-turn apply)"
+    )
+    residual = await session._hot_reloader.apply_pending()
+    assert residual is None, (
+        "the immediate addition path must not ALSO schedule a deferred reload"
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_install_same_name_overwrite_defers_but_lands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: re-installing an EXISTING pipeline (clobber-update) is NOT applied mid-turn
+    (deferred) but lands at the next turn boundary — update preserved, R7 avoided."""
+    from reyn.core.op_runtime.pipeline_install import handle as pipeline_install_handle
+    from reyn.schemas.models import PipelineInstallIROp
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+
+    dsl = _write_pipeline(tmp_path, "greet.yaml", name="greet", description="v1")
+    await pipeline_install_handle(
+        PipelineInstallIROp(kind="pipeline_install", path=str(dsl)),
+        _op_ctx(tmp_path, session),
+    )
+    assert _pipeline_desc(session, "greet") == "v1"
+
+    # Re-install SAME declared name with a changed description (clobber-update).
+    _write_pipeline(tmp_path, "greet.yaml", name="greet", description="v2")
+    result = await pipeline_install_handle(
+        PipelineInstallIROp(kind="pipeline_install", path=str(dsl)),
+        _op_ctx(tmp_path, session),
+    )
+
+    assert result["status"] == "installed", "clobber-update must not be errored/refused"
+    assert _pipeline_desc(session, "greet") == "v1", (
+        "a same-name overwrite must NOT be applied mid-turn (deferred)"
+    )
+
+    await session._hot_reloader.apply_pending()
+    assert _pipeline_desc(session, "greet") == "v2", (
+        "the clobber-update must land at the turn boundary (applies next turn)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skill_install_no_per_session_reloader_defers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: with no per-session reloader (ctx.hot_reloader=None — the CLI
+    separate-process install), a NEW skill install does NOT apply mid-turn; it takes the
+    deferred path (unchanged best-effort behavior)."""
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    set_active_hot_reloader(session._hot_reloader)
+    try:
+        skill_dir = _write_skill(tmp_path, "solo", name="solo-skill", description="v1")
+        result = await skill_install_handle(
+            SkillInstallIROp(kind="skill_install", path=str(skill_dir)),
+            _op_ctx(tmp_path, None),  # ctx.hot_reloader is None
+        )
+    finally:
+        set_active_hot_reloader(None)
+
+    assert result["status"] == "installed"
+    assert "solo-skill" not in _skill_names(session), (
+        "with no per-session reloader the install must NOT apply mid-turn"
+    )
+    # It fell back to the deferred path — applying at the turn boundary makes it live.
+    await session._hot_reloader.apply_pending()
+    assert "solo-skill" in _skill_names(session), (
+        "the deferred fallback lands the install at the turn boundary"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — **PR-2 of the mid-execution hot-reload arc** (`part of #2761`): `HotReloader.apply_now` + immediate mid-turn apply for `skill_install` / `pipeline_install`. Implements the architect's **revised §2 path-condition** contract (the latest architect comment on #2761 — the revision of the "P1 seam-call contract"). PR-3 (mcp probe-then-commit) follows separately, with architect co-vet.

## What & why
Drops the turn-boundary constraint so an install op can **use what it just installed within the same execution** — the owner's goal. The mechanism is a **PATH CONDITION**, not a blanket guard (PR-1's step-1 surfaced that a blanket same-name refuse would strand skill/pipeline updates — they have no `remove` CLI, so re-install/clobber is their only update path — and break the documented `reyn mcp install` re-install fix; the architect revised §2 accordingly):

```
if is_pure_addition(name) and ctx.hot_reloader is not None:
    <write config> ; await ctx.hot_reloader.apply_now(source=...)   # immediate mid-turn
else:
    <existing deferred turn-boundary behavior, UNCHANGED>            # overwrite / no reloader
```

- **Pure addition (new name) + live per-session reloader** → the affected seam (`skills` / `pipelines`) is rebuilt+swapped IMMEDIATELY, so the new entry is **resolvable this turn**.
- **Same-name overwrite (clobber-update)** → the **existing deferred path, unchanged** — preserves skill/pipeline clobber-update + the documented mcp re-install fix, and **confines the R7 in-use-replace hazard to the deferred path it already lives on** (a pure addition never touches an in-USE entry).
- **No per-session reloader (CLI `reyn <kind> install`, separate process)** → existing deferred/restart best-effort, unchanged.

**Discovery vs resolution honesty:** only *resolution* (looking a name up to run it) is made immediate; the LLM's *discovery* catalog (tool schemas + `## Skills` menu, built once per turn) still updates next turn. Tests assert resolution only — no over-claim of mid-turn LLM discovery.

## Changes
- `runtime/hot_reload.py`: `HotReloader.apply_now(source=)` (re-read IN-set → validate-before-apply → run **only** the source-mapped seam(s) → emit `config_reloaded`; never touches the deferred `pending` flag); `is_pure_addition(name, entries)`; `dispatch_install_reload(ctx_reloader, source, is_addition)` (the shared addition→immediate / else→deferred router, preferring the **per-session** `ctx.hot_reloader` over the process-global for the immediate path — multi-session correctness); `_INSTALL_SOURCE_SEAMS` map (skill/pipeline; mcp added in PR-3).
- `core/op_runtime/context.py`: `OpContext.hot_reloader` field (the #2073 S3 per-session route, now threaded to op handlers).
- `runtime/router_op_context.py` + `runtime/services/router_host_adapter.py` (`self.hot_reloader`) + `runtime/session.py` (`self._hot_reloader`): thread `hot_reloader` into the OpContext at **both** router builders (the router-dispatched install path — `skill_management__install_*` / pipeline install → `build_legacy_op_context` → adapter `make_router_op_context` — is the load-bearing one).
- `core/op_runtime/skill_install.py` / `pipeline_install.py`: capture `is_pure_addition` BEFORE the entries-dict write; replace the tail `get_active_hot_reloader().request_reload(...)` with `dispatch_install_reload(...)`.

## impl step-1 verification (architect's checklist)
- `apply_now` runs the affected seam **only** (skill_install→`skills`, pipeline_install→`pipelines`), not the whole reload — tested directly.
- Per-session `ctx.hot_reloader` (session.py:1611 → adapter `self.hot_reloader` / session `self._hot_reloader`) is used for the immediate path, never the process-global — wired at both builders; op-level tests drive it through the real session reloader.
- The addition-condition routes a same-name overwrite to the deferred path — tested (overwrite not applied mid-turn, lands after `apply_pending`).

## Tests — `tests/test_2761_pr2_hotreload_immediate_apply.py` (Tier 2, 16 tests, real instances, no mocks)
- **A. `apply_now`**: affected-seam-only (skill / pipeline); doesn't touch `pending`; unknown source no-op; malformed IN-set rejected atomically (no seam runs); emits `config_reloaded`; operator `/reload` deferred path still runs ALL seams (unchanged).
- **B. routing**: `is_pure_addition`; dispatch addition→immediate; overwrite→deferred; no-reloader→deferred-via-active.
- **C. e2e (real handlers + real Session seams)**: NEW skill/pipeline resolvable same turn; same-name overwrite NOT applied mid-turn but lands at the turn boundary (clobber-update preserved, not errored); no-per-session-reloader defers.
- **cp-falsify**: neutered `dispatch_install_reload`'s immediate branch → the 5 immediate-apply tests went RED → restored via `cp` backup (never git).

## Test plan
- [x] `ruff check src tests` — clean (incl. I001).
- [x] `python scripts/test_tier_audit.py --strict tests/test_2761_pr2_hotreload_immediate_apply.py` — 16/16 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK.
- [x] `pytest` (repo root) — 7956 passed; the only 5 failures (`tests/web/*` route-mounting + `test_fp0001_a2a_endpoints`) are **pre-existing on clean origin/main** (verified identical at base 3402bdf2; environment/optional-dep, untouched by this PR).
- [x] cp-falsify RED→GREEN confirmed (immediate-apply invariant).
- [x] (Visual/Manual) none — pure runtime path condition, no UI/CLI surface change (skipped — no visual affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
