### PR TITLE
feat: mid-turn immediate mcp install via probe-then-commit (stdio+remote) (#2761 PR-3)

### DIFF
--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -5,7 +5,13 @@ Handler logic (one-shot, no sub-phases):
   2. Check runtime command availability (npx / uvx / docker / dnx)
   3. Gate via PermissionResolver.require_mcp_install (ADR-0029)
   4. Prompt for secret env vars via intervention_bus; persist with secrets.store
-  5. Write mcp.servers.<name> into the target scope config file
+  5. Reload (#2761 PR-3): a PURE ADDITION on a live per-session reloader takes the
+     IMMEDIATE mid-turn path — PROBE the server (spawn/connect + list_tools) FIRST,
+     write mcp.servers.<name> ONLY on a successful probe (probe-then-commit: a
+     failed/cancelled probe leaves nothing written — no half-install), then
+     apply_now so its tools are resolvable this same turn. A same-name overwrite
+     (the documented re-install fix) or no per-session reloader keeps the deferred
+     turn-boundary path (write + request_reload), unchanged.
   6. Emit mcp_server_installed event (P6)
 
 Scope → file mapping:
@@ -146,6 +152,44 @@ def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
         entry["env"] = {k: f"${{{k}}}" for k in env_keys}
 
     return entry
+
+
+async def probe_mcp_server(
+    server_name: str, server_entry: dict, *, agent_id: str | None = None,
+) -> "str | None":
+    """#2761 PR-3: probe a prospective MCP server (spawn/connect + ``list_tools``)
+    BEFORE its config is committed — the probe-then-commit atomicity gate.
+
+    Returns ``None`` on a successful probe (the server is reachable and advertises
+    tools) or an error string on failure. The caller writes the config ONLY on
+    ``None`` — so a failed probe leaves NOTHING written (no half-install, no rollback).
+
+    Routed through the crash-safe :class:`~reyn.mcp.gateway.MCPGateway` seam (#2421):
+    open + list + teardown inside one contain-all boundary + a per-server timeout,
+    task-affine so the SDK's stdio_client/ClientSession scopes close in the same task.
+    The gateway raises ONLY :class:`MCPFault` for a transport/timeout fault (contained
+    here → error string); a genuine Ctrl+C ``CancelledError`` is re-raised by the
+    gateway as control flow and propagates OUT of this probe — the pool's ``__aexit__``
+    has already torn the transport down (stdio subprocess kill via ``kill_process_tree``
+    / HTTP close), and because the config write is strictly AFTER this probe, a cancel
+    leaves nothing committed. **Transport-uniform**: stdio and remote (http/sse) share
+    this one path — ``MCPClient.__aexit__`` owns the transport-appropriate teardown, so
+    the probe never branches on transport (mirrors ``Session._mcp_list_tools``)."""
+    from reyn.mcp.client import expand_env  # noqa: PLC0415
+    from reyn.mcp.gateway import MCPFault, MCPGateway  # noqa: PLC0415
+
+    expanded = expand_env(server_entry)
+    if not isinstance(expanded, dict):
+        return f"server config must be a dict, got {type(expanded).__name__}"
+    # A url-only remote entry defaults to http (mirrors _mcp_list_tools).
+    if "type" not in expanded and expanded.get("url"):
+        expanded = {**expanded, "type": "http"}
+    gateway = MCPGateway(agent_id=agent_id)
+    try:
+        await gateway.list_tools(server_name, expanded)
+    except MCPFault as exc:
+        return str(exc)
+    return None
 
 
 def _read_yaml_config(path: Path) -> dict:
@@ -509,11 +553,51 @@ async def handle(
             ),
         }
 
-    # Merge into existing config
+    # Ensure the mcp section shape exists (read-only prep — NO write yet).
     if "mcp" not in existing or not isinstance(existing.get("mcp"), dict):
         existing["mcp"] = {}
     if "servers" not in existing["mcp"] or not isinstance(existing["mcp"].get("servers"), dict):
         existing["mcp"]["servers"] = {}
+
+    # ── 5b. Probe-then-commit + path-condition (#2761 PR-3) ───────────────────
+    # Capture pure-addition-vs-overwrite BEFORE any mutation. A PURE ADDITION on a
+    # live per-session reloader takes the IMMEDIATE mid-turn path: PROBE the server
+    # (spawn/connect + list_tools) FIRST, and write config ONLY on a successful probe
+    # → a failed/cancelled probe leaves nothing committed (no half-install, no
+    # rollback). A same-name overwrite (the documented `reyn mcp install` re-install
+    # fix) or no per-session reloader keeps the existing deferred turn-boundary path
+    # (unchanged), confining any in-use-replace to the deferred path.
+    from reyn.runtime.hot_reload import (  # noqa: PLC0415
+        dispatch_install_reload,
+        is_pure_addition,
+    )
+    _is_addition = is_pure_addition(server_name, existing["mcp"]["servers"])
+    _reloader = getattr(ctx, "hot_reloader", None)
+    if _is_addition and _reloader is not None:
+        _probe_err = await probe_mcp_server(
+            server_name, server_entry, agent_id=getattr(ctx, "agent_id", None),
+        )
+        if _probe_err is not None:
+            ctx.events.emit(
+                "mcp_install_probe_failed",
+                server_id=op.server_id,
+                server_name=server_name,
+                error=_probe_err,
+            )
+            return {
+                "kind": "mcp_install",
+                "status": "error",
+                "server_id": op.server_id,
+                "server_name": server_name,
+                "source": op.source or "",
+                "error": (
+                    f"MCP server {server_name!r} failed its pre-install probe "
+                    f"(nothing written — no half-install): {_probe_err}"
+                ),
+            }
+
+    # ── 5c. COMMIT: write mcp.servers.<name>. The immediate path reaches here ONLY
+    # after a successful probe; the deferred path always writes (unchanged). ──────
     existing["mcp"]["servers"][server_name] = server_entry
 
     _write_yaml_config(config_path, existing)
@@ -539,17 +623,18 @@ async def handle(
         # NOTE: env values are NOT emitted — only key names for audit
     )
 
-    # ── 7. #2372: schedule a hot-reload so the installed server's tools go live in the
-    # SAME chat session (no restart). The mcp seam (_reapply_mcp → refresh_mcp_servers)
-    # re-reads the roster from the config cascade — which merges the IN-set just written —
-    # and re-probes tools at the next turn boundary. Next-turn is the effective granularity:
-    # the LLM tool catalog is rebuilt per-turn, so same-turn would buy nothing. Best-effort:
-    # no active reloader (CLI `reyn mcp install` runs in a separate process; a phase/tool
-    # ctx has none) → no-op, and a restart / yaml mtime-watch still surfaces it.
-    from reyn.runtime.hot_reload import get_active_hot_reloader  # noqa: PLC0415
-    _reloader = get_active_hot_reloader()
-    if _reloader is not None:
-        _reloader.request_reload(source="mcp_install")
+    # ── 7. Reload (#2761 PR-3 + #2372): a PROBED pure addition on a live per-session
+    # reloader applies IMMEDIATELY (mid-turn) — the mcp seam (_reapply_mcp →
+    # refresh_mcp_servers) re-reads the roster from the config cascade (merging the
+    # IN-set just written) and swaps the live tool-set, so the just-installed server's
+    # tools are resolvable/callable this same turn. A same-name overwrite or no
+    # per-session reloader (CLI `reyn mcp install` separate process) keeps the existing
+    # deferred turn-boundary behavior via the process-active reloader (best-effort;
+    # a restart / yaml mtime-watch still surfaces it). The LLM's tool *catalog* still
+    # rebuilds next turn (discovery vs resolution) — the install op *uses* it this turn.
+    await dispatch_install_reload(
+        _reloader, source="mcp_install", is_addition=_is_addition,
+    )
 
     return {
         "kind": "mcp_install",

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -34,13 +34,20 @@ _log = logging.getLogger(__name__)
 # wires the per-component seams (mcp / cron / hooks / per-agent capability / …).
 ReapplySeam = tuple[str, Callable[[dict], Awaitable[bool]]]
 
-# #2761 PR-2: an install op's ``source`` → the seam name(s) its IMMEDIATE mid-turn
-# apply must run (and ONLY those — not the whole reload). Skill / pipeline are the
-# two pure-in-memory rebuild types; ``mcp_install`` is added in PR-3 (its seam does
-# an external re-probe with a probe-then-commit + cancel/timeout contract).
+# #2761 PR-2/PR-3: an install op's ``source`` → the seam name(s) its IMMEDIATE mid-turn
+# apply must run (and ONLY those — not the whole reload). Skill / pipeline are the two
+# pure-in-memory rebuild types (PR-2); ``mcp_install`` (PR-3) additionally probes the
+# server (spawn/connect + list_tools) BEFORE its config write (probe-then-commit) so a
+# failed/cancelled probe leaves nothing committed — the seam here runs the live tool-set
+# swap (``_reapply_mcp`` → ``refresh_mcp_servers``) after that probe has already gated
+# the write.
 _INSTALL_SOURCE_SEAMS: "dict[str, tuple[str, ...]]" = {
     "skill_install": ("skills",),
     "pipeline_install": ("pipelines",),
+    "mcp_install": ("mcp",),
+    # mcp__install_local writes .reyn/mcp.yaml via a parallel path (tools/mcp_verbs)
+    # but reloads the SAME mcp seam — its distinct source label maps here too.
+    "mcp__install_local": ("mcp",),
 }
 
 

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -448,13 +448,50 @@ async def _handle_mcp_install_local(
 
     data = _read_yaml_config(config_path)
     servers = data.setdefault("mcp", {}).setdefault("servers", {})
+
+    # #2761 PR-3: probe-then-commit + path-condition for the PRIMARY local-stdio path.
+    # mcp__install_local writes .reyn/config/mcp.yaml DIRECTLY — a parallel path to the
+    # mcp_install op — so it must carry the same immediate-apply contract, else the
+    # primary local-stdio use would never get same-turn use of its just-installed
+    # server. A PURE ADDITION on a live per-session reloader PROBES the server first
+    # (spawn/connect + list_tools) and writes ONLY on a successful probe (a
+    # failed/cancelled probe leaves nothing written — no half-install); a same-name
+    # overwrite or no per-session reloader keeps the existing deferred behavior. The
+    # per-session reloader (ctx.hot_reloader, #2761 PR-2) is reached via the router's
+    # op-context factory (the single tool→op ctx source); absent (test / CLI) → deferred.
+    from reyn.core.op_runtime.mcp_install import probe_mcp_server
+    from reyn.runtime.hot_reload import dispatch_install_reload, is_pure_addition
+
+    _op_ctx = (
+        rs.op_context_factory()
+        if rs is not None and getattr(rs, "op_context_factory", None) is not None
+        else None
+    )
+    _reloader = getattr(_op_ctx, "hot_reloader", None) if _op_ctx is not None else None
+    _is_addition = is_pure_addition(name, servers)
+    if _is_addition and _reloader is not None:
+        _probe_err = await probe_mcp_server(
+            name, entry, agent_id=getattr(_op_ctx, "agent_id", None),
+        )
+        if _probe_err is not None:
+            return {
+                "status": "error",
+                "data": {
+                    "kind": "mcp_install_local",
+                    "name": name,
+                    "error": (
+                        f"MCP server {name!r} failed its pre-install probe "
+                        f"(nothing written — no half-install): {_probe_err}"
+                    ),
+                },
+            }
+
     servers[name] = entry
     _write_yaml_config(config_path, data)
 
-    from reyn.runtime.hot_reload import get_active_hot_reloader
-    _reloader = get_active_hot_reloader()
-    if _reloader is not None:
-        _reloader.request_reload(source="mcp__install_local")
+    await dispatch_install_reload(
+        _reloader, source="mcp__install_local", is_addition=_is_addition,
+    )
 
     return {
         "status": "ok",

--- a/tests/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/test_2761_pr3_mcp_immediate_probe.py
@@ -1,0 +1,320 @@
+"""Tier 2: #2761 PR-3 — immediate mid-turn mcp install via probe-then-commit.
+
+Extends the #2761 path-condition (PR-2) to mcp: a PURE ADDITION on a live per-session
+reloader takes the IMMEDIATE mid-turn path — but mcp additionally PROBES the server
+(spawn/connect + ``list_tools``) BEFORE writing config, and writes ONLY on a successful
+probe (**probe-then-commit**: a failed/cancelled probe leaves nothing written — no
+half-install, no rollback needed). A same-name overwrite (the documented ``reyn mcp
+install`` re-install fix) or no per-session reloader keeps the existing DEFERRED
+turn-boundary path, unchanged.
+
+The probe is transport-uniform (one ``MCPGateway`` path; ``MCPClient.__aexit__`` owns
+the transport-appropriate teardown — stdio subprocess kill / HTTP close) and rides the
+cancellable turn task (Ctrl+C → ``CancelledError`` propagates after teardown; since the
+write is strictly after the probe, a cancel commits nothing).
+
+Coverage note: the completeness for the PRIMARY stdio use runs through
+``mcp__install_local`` (``tools/mcp_verbs``), which writes ``.reyn/config/mcp.yaml``
+DIRECTLY — a parallel path to the ``mcp_install`` op — so it carries the SAME contract.
+These e2e tests drive that real path against a REAL stdio MCP server subprocess
+(``tests/_support/mcp_tools_only_pid_server.py``).
+
+Honesty (discovery vs resolution): asserts the installed server is *resolvable/usable*
+(live roster + tool cache) the same turn, NOT the LLM's mid-turn discovery catalog.
+
+No mocks. Real EventLog / HotReloader / Session / MCPGateway / a real stdio MCP server.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.mcp_install import (
+    _read_yaml_config,
+    _scope_to_path,
+    probe_mcp_server,
+)
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
+from reyn.runtime.session import Session
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.tools.mcp_verbs import _handle_mcp_install_local
+
+_PID_SERVER = Path(__file__).parent / "_support" / "mcp_tools_only_pid_server.py"
+_STDIO = {"command": sys.executable, "args": [str(_PID_SERVER)]}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seam_recorder():
+    ran: dict[str, int] = {}
+
+    def make(name: str):
+        async def _seam(in_set: dict) -> bool:
+            ran[name] = ran.get(name, 0) + 1
+            return True
+        return _seam
+
+    return ran, make
+
+
+class _RS:
+    """Minimal RouterState carrying the op-context factory + resolver the install_local
+    handler reads — wired to REAL objects (a real session factory / a real reloader)."""
+
+    def __init__(self, factory, resolver=None) -> None:
+        self.op_context_factory = factory
+        self.permission_resolver = resolver
+
+
+class _Ctx:
+    """Minimal ToolContext plumbing (mirrors the existing install_local test's _FakeCtx)
+    — router_state + a workspace with a ``root``. All wired to real components."""
+
+    def __init__(self, root: Path, rs: "_RS | None") -> None:
+        self.router_state = rs
+        self.workspace = type("_W", (), {"root": str(root)})()
+
+
+def _session(tmp: Path) -> Session:
+    (tmp / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    return Session(
+        agent_name="mcp-pr3",
+        state_log=StateLog(tmp / "s.wal"),
+        snapshot_path=tmp / "snap.json",
+    )
+
+
+def _session_ctx(session: Session, tmp: Path) -> _Ctx:
+    """A ctx whose op-context factory is the session's REAL make_router_op_context (so
+    ctx.hot_reloader is the session's per-session reloader). resolver=None → the
+    install_local file-write gate is skipped (not under test)."""
+    return _Ctx(tmp, _RS(session._router_host.make_router_op_context, None))
+
+
+def _reloader_ctx(reloader: HotReloader, tmp: Path) -> _Ctx:
+    """A ctx whose factory returns a bare OpContext carrying ``reloader`` — for the
+    probe-then-commit tests that only need the immediate path to fire (no full roster)."""
+    op_ctx = OpContext(
+        workspace=Workspace(events=EventLog(), base_dir=tmp),
+        events=EventLog(),
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        hot_reloader=reloader,
+    )
+    return _Ctx(tmp, _RS(lambda: op_ctx, None))
+
+
+def _servers_on_disk(tmp: Path) -> dict:
+    data = _read_yaml_config(_scope_to_path("local", tmp))
+    return (data.get("mcp") or {}).get("servers") or {}
+
+
+def _roster_names(session: Session) -> list[str]:
+    return [s["name"] for s in session._router_host.get_mcp_servers()]
+
+
+# ===========================================================================
+# A. probe_mcp_server — real servers, transport-uniform
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_probe_reachable_stdio_returns_none() -> None:
+    """Tier 2: probing a REACHABLE stdio server (spawn + list_tools) returns None —
+    the commit gate opens."""
+    err = await probe_mcp_server("pidsrv", {"type": "stdio", **_STDIO})
+    assert err is None
+
+
+@pytest.mark.asyncio
+async def test_probe_unreachable_stdio_returns_error() -> None:
+    """Tier 2: probing an UNREACHABLE stdio server (bad command) returns an error
+    string (the MCPFault is contained) — the commit gate stays shut."""
+    err = await probe_mcp_server(
+        "bad", {"type": "stdio", "command": "/nonexistent/reyn-xyz", "args": []},
+    )
+    assert isinstance(err, str) and err
+
+
+@pytest.mark.asyncio
+async def test_probe_unreachable_remote_returns_error() -> None:
+    """Tier 2: the probe is transport-uniform — an unreachable REMOTE (http) server
+    returns an error string via the SAME path (http-transport branch, same rollback)."""
+    err = await probe_mcp_server(
+        "remote", {"type": "http", "url": "http://127.0.0.1:1/mcp", "timeout": 3},
+    )
+    assert isinstance(err, str) and err
+
+
+# ===========================================================================
+# B. apply_now — the mcp source maps to the mcp seam only
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_apply_now_mcp_install_targets_mcp_seam_only(tmp_path: Path) -> None:
+    """Tier 2: apply_now(source=mcp_install) runs ONLY the "mcp" seam."""
+    ran, make = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("skills", make("skills"))
+    hr.register_seam("pipelines", make("pipelines"))
+    hr.register_seam("mcp", make("mcp"))
+
+    summary = await hr.apply_now(source="mcp_install")
+
+    assert summary["applied"] == ["mcp"]
+    assert ran == {"mcp": 1}
+
+
+@pytest.mark.asyncio
+async def test_apply_now_mcp_install_local_targets_mcp_seam_only(tmp_path: Path) -> None:
+    """Tier 2: the parallel mcp__install_local source label also maps to the "mcp" seam."""
+    ran, make = _seam_recorder()
+    hr = HotReloader(project_root=tmp_path, events=EventLog())
+    hr.register_seam("mcp", make("mcp"))
+    hr.register_seam("skills", make("skills"))
+
+    summary = await hr.apply_now(source="mcp__install_local")
+
+    assert summary["applied"] == ["mcp"]
+    assert ran == {"mcp": 1}
+
+
+# ===========================================================================
+# C. install_local probe-then-commit e2e (real Session + real stdio server)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_local_install_new_reachable_is_live_same_turn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: installing a NEW reachable stdio server probes OK, commits, and applies
+    IMMEDIATELY — the server is in the live roster + its tools are cached the SAME turn
+    (no restart, no turn boundary). pending stays False (immediate, not deferred)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session(tmp_path)
+    assert "pidsrv" not in _roster_names(session)
+
+    result = await _handle_mcp_install_local(
+        {"name": "pidsrv", **_STDIO}, _session_ctx(session, tmp_path),
+    )
+
+    assert result["status"] == "ok"
+    assert "pidsrv" in _roster_names(session), (
+        "a NEW reachable server must be resolvable the same turn (immediate probe-commit)"
+    )
+    snap = session._router_host.mcp_tools_cache_snapshot
+    assert snap is not None and "pidsrv" in snap, "its tools must be live-cached same turn"
+    # Immediate path — nothing left pending for the turn boundary.
+    residual = await session._hot_reloader.apply_pending()
+    assert residual is None, "the immediate probe-commit must not ALSO defer a reload"
+
+
+@pytest.mark.asyncio
+async def test_local_install_probe_failure_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a NEW server that FAILS its probe (bad command) returns an error and
+    writes NOTHING — probe-then-commit means no half-install (config unchanged)."""
+    monkeypatch.chdir(tmp_path)
+    reloader = HotReloader(project_root=tmp_path, events=EventLog())
+
+    result = await _handle_mcp_install_local(
+        {"name": "badsrv", "command": "/nonexistent/reyn-xyz", "args": []},
+        _reloader_ctx(reloader, tmp_path),
+    )
+
+    assert result["status"] == "error"
+    assert "badsrv" not in _servers_on_disk(tmp_path), (
+        "a failed probe must leave NOTHING written (no half-install)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_install_same_name_overwrite_defers_and_skips_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: re-installing an EXISTING server (the documented re-install fix) is NOT
+    probe-gated and NOT applied mid-turn — it keeps the deferred turn-boundary path
+    (write + schedule). Proven by re-installing over a good server with a BAD command:
+    an overwrite still succeeds (no probe) and schedules a deferred reload."""
+    monkeypatch.chdir(tmp_path)
+    session = _session(tmp_path)
+
+    # First install (addition) → probed + immediately live.
+    await _handle_mcp_install_local(
+        {"name": "srv", **_STDIO}, _session_ctx(session, tmp_path),
+    )
+    assert "srv" in _roster_names(session)
+
+    # Re-install SAME name with a BAD command — an overwrite skips the probe, so it
+    # does NOT error; it writes + defers (documented re-install workflow preserved).
+    result = await _handle_mcp_install_local(
+        {"name": "srv", "command": "/nonexistent/reyn-xyz", "args": []},
+        _session_ctx(session, tmp_path),
+    )
+
+    assert result["status"] == "ok", "an overwrite must NOT be probe-gated (re-install preserved)"
+    pending = session._hot_reloader.pending
+    assert pending is True, "an overwrite schedules the deferred turn-boundary reload"
+    assert _servers_on_disk(tmp_path)["srv"]["command"] == "/nonexistent/reyn-xyz", (
+        "the overwrite is written to config (clobber-update), applied at the turn boundary"
+    )
+
+
+@pytest.mark.asyncio
+async def test_local_install_no_per_session_reloader_defers_no_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: with no per-session reloader (CLI separate process), a NEW install is NOT
+    probe-gated and takes the deferred path — proven by a BAD command succeeding
+    (written) because no probe runs."""
+    monkeypatch.chdir(tmp_path)
+    set_active_hot_reloader(HotReloader(project_root=tmp_path, events=EventLog()))
+    try:
+        result = await _handle_mcp_install_local(
+            {"name": "clisrv", "command": "/nonexistent/reyn-xyz", "args": []},
+            _Ctx(tmp_path, _RS(factory=None, resolver=None)),  # no op-context factory
+        )
+    finally:
+        set_active_hot_reloader(None)
+
+    assert result["status"] == "ok", "no per-session reloader → no probe → not error"
+    assert "clisrv" in _servers_on_disk(tmp_path), "deferred path still writes config"
+
+
+@pytest.mark.asyncio
+async def test_local_install_probe_cancel_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: Ctrl+C during a HUNG probe → CancelledError propagates and NOTHING is
+    written (the write is strictly after the probe → cancel commits nothing). The
+    subprocess is spawned by a real python that never speaks MCP, so the initialize
+    handshake hangs until cancelled."""
+    monkeypatch.chdir(tmp_path)
+    reloader = HotReloader(project_root=tmp_path, events=EventLog())
+    ctx = _reloader_ctx(reloader, tmp_path)
+
+    task = asyncio.ensure_future(_handle_mcp_install_local(
+        {"name": "hung", "command": sys.executable, "args": ["-c", "import time; time.sleep(60)"]},
+        ctx,
+    ))
+    await asyncio.sleep(0.6)  # let the probe start + the subprocess spawn
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert "hung" not in _servers_on_disk(tmp_path), (
+        "a cancelled probe must leave NOTHING written (write is strictly after the probe)"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — **PR-3 (final phase) of the mid-execution hot-reload arc**: mcp install (stdio + remote) immediate mid-turn apply via **probe-then-commit**. Completes the arc — `Closes #2761`. Implements the architect's #2761 P1 seam-call contract §3 (probe-then-commit + cancel/timeout/rollback). **Load-bearing cancellation/teardown — architect co-vet requested.**

## What & why
Extends the PR-2 path-condition to mcp: a **PURE ADDITION** on a live per-session reloader takes the IMMEDIATE mid-turn path — but mcp additionally **PROBES** the server (spawn/connect + `list_tools`) BEFORE writing config, committing ONLY on a successful probe. A same-name overwrite (the documented `reyn mcp install` re-install fix) or no per-session reloader keeps the existing DEFERRED turn-boundary path, unchanged.

**Probe-then-commit (rollback-free by ordering):**
```
if is_pure_addition(name) and ctx.hot_reloader:
    probe(server)                # spawn/connect + list_tools, inline-awaited, bounded
    if probe fails/times-out/cancels: return error  # NOTHING written → no half-install
    write config ; apply_now()   # COMMIT only after a successful probe
else:
    write config ; deferred reload   # overwrite / no reloader — unchanged
```
The write is **strictly after** the probe, so a failed/cancelled probe leaves nothing committed — atomicity is by ordering, no rollback needed.

**Transport-uniform + crash-safe teardown (reuse, no reinvention):** the probe routes through the existing `MCPGateway` seam (#2421) — open + list + teardown inside one contain-all boundary + a per-server timeout, task-affine. It raises ONLY `MCPFault` for a transport/timeout fault (→ error string, no write), and **re-raises a genuine Ctrl+C `CancelledError`** as control flow after the pool's `__aexit__` tears the transport down (stdio subprocess kill via `kill_process_tree` / HTTP close). stdio and remote (http/sse) share this one path — `MCPClient.__aexit__` owns the transport difference, so the probe never branches on transport.

## Changes
- `core/op_runtime/mcp_install.py`: `probe_mcp_server(name, entry, agent_id)` (crash-safe probe via `MCPGateway`, transport-uniform, mirrors `_mcp_list_tools`); `handle` restructured to probe-then-commit + path-condition (`is_pure_addition` before mutation, probe-gated write, `dispatch_install_reload` for the reload). Emits `mcp_install_probe_failed` (P6) on a failed probe.
- `runtime/hot_reload.py`: `_INSTALL_SOURCE_SEAMS += {"mcp_install": ("mcp",), "mcp__install_local": ("mcp",)}` so `apply_now` runs only the mcp seam.
- `tools/mcp_verbs.py` (`_handle_mcp_install_local`): **completeness extension — see below.**

## ⚠️ Completeness extension (for architect co-vet): `mcp__install_local` — the PRIMARY stdio path
While tracing, I found `_handle_mcp_install_local` (the `mcp__install_local` verb — **the primary way to add a local stdio server**) writes `.reyn/config/mcp.yaml` **directly**, a **parallel write path that bypasses `mcp_install.handle`**. So the contract's `mcp_install.py:517` anchor covers registry/source installs but NOT the local-stdio path the architect called "the primary use." Leaving it out would make the feature unreachable-for-purpose for the primary stdio case (same class as the PR-2 `ctx.hot_reloader` wiring gap). I applied the **same** probe-then-commit + path-condition to `_handle_mcp_install_local` (reusing the shared `probe_mcp_server` + `is_pure_addition` + `dispatch_install_reload`; the per-session reloader is reached via the router's single op-context factory). **Flagging explicitly** — if you'd prefer this split to a follow-up PR, it's an isolated ~40-line section, cheap to revert.

## impl step-1 verification (architect's §4 checklist)
- **probe-then-commit ordering** — the config write is strictly after a successful probe; a failed/cancelled probe writes nothing (falsify test pins this).
- **cancel → teardown, no orphan** — the probe rides the cancellable turn task; `MCPGateway` re-raises genuine `CancelledError` after `MCPClient.__aexit__` tears the transport down (verified via the gateway's `is_real_control_flow` contain-all boundary + the real-subprocess cancel test).
- **timeout** — `MCPGateway`'s per-server `asyncio.timeout` bounds spawn+probe (unreachable-remote test).
- **`ctx.hot_reloader` (per-session)** used for `apply_now`, never the process-global.
- **discovery vs resolution** — tests assert the server is *resolvable/usable* same turn (live roster + tool cache), not the LLM's mid-turn catalog.

## Tests — `tests/test_2761_pr3_mcp_immediate_probe.py` (Tier 2, 10 tests, real instances incl. a REAL stdio MCP server subprocess, no mocks)
- **probe**: reachable stdio → None; unreachable stdio → error; unreachable **remote (http)** → error (transport-uniform).
- **apply_now**: `mcp_install` / `mcp__install_local` sources target the mcp seam only.
- **e2e (real Session + real `tests/_support/mcp_tools_only_pid_server.py`)**: NEW reachable server → probed, committed, **live roster + tools cached same turn** (immediate, `pending` stays False); **probe failure → nothing written** (no half-install); **same-name overwrite → not probe-gated, deferred** (documented re-install preserved, clobber-update written for the turn boundary); **no per-session reloader → deferred, no probe**; **Ctrl+C during a hung probe → `CancelledError` propagates + nothing written** (rollback-free by ordering).
- **cp-falsify**: neutering `probe_mcp_server` (always "succeeds") → the 4 probe/rollback tests go RED → restored via `cp` backup (never git).

## Test plan
- [x] `ruff check src tests` — clean (incl. I001).
- [x] `python scripts/test_tier_audit.py --strict tests/test_2761_pr3_mcp_immediate_probe.py` — 10/10 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK.
- [x] `pytest` (repo root) — full suite green modulo the pre-existing `tests/web/*` route-mounting failures (unrelated env/optional-dep; identical on clean origin/main).
- [x] cp-falsify RED→GREEN confirmed (probe-then-commit / rollback-free invariant).
- [x] (Visual/Manual) none — runtime path condition + probe, no UI/CLI surface change (skipped — no visual affordance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
