### PR TITLE
fix: stale docs/en/ path example in reyn_src_list tool description

### DIFF
--- a/src/reyn/tools/reyn_src.py
+++ b/src/reyn/tools/reyn_src.py
@@ -25,16 +25,28 @@ def _as_reyn_src(result: dict) -> dict:
     result["kind"] = "reyn_src"
     return result
 
-# Description must be byte-identical to the current router_tools.py
-# ToolSpec.description for reyn_src_list (lines 776-783). Copied verbatim.
+# router_tools.py derives its rendered description from this ToolDefinition
+# via render_for_router() (registry lookup), not a separate literal — keep
+# this the single source of truth for the LLM-facing text.
+#
+# The example path was "docs/en/concepts" until the docs i18n restructure
+# (suffix-based: English lives at the repo-root path, Japanese is the same
+# path with a ".ja.md" filename suffix — no "/en/" or "/ja/" directory
+# prefix). That stale example reliably steered agents into guessing
+# nonexistent "docs/en/..." paths (a tool-description-caused attractor, not
+# generic LLM hallucination — confirmed by grep across dogfood journal
+# findings hitting this exact wrong path repeatedly). Kept in sync with
+# ``docs/concepts`` actually existing at the repo root.
 _REYN_SRC_LIST_DESCRIPTION = (
     "List entries under a path inside Reyn's own repository "
     "(= the project that built this agent). Pass \"\" for "
     "the repo root. Returns names + types (file/dir). Use "
     "this to discover Reyn's source/doc layout before "
     "reading specific files. Examples: list \"\" for the "
-    "top-level layout, \"docs/en/concepts\" for concept "
-    "docs, or any subdirectory path for its contents."
+    "top-level layout, \"docs/concepts\" for concept docs "
+    "(English; Japanese translations are the same path with a "
+    "\".ja.md\" filename suffix, not a separate directory), or "
+    "any subdirectory path for its contents."
 )
 
 # Parameters JSON schema must be byte-identical to the current

--- a/tests/test_reyn_src_unified.py
+++ b/tests/test_reyn_src_unified.py
@@ -27,20 +27,18 @@ from reyn.tools.reyn_src import (
 # ── 1. REYN_SRC_LIST render_for_router byte-identity ────────────────────────
 
 def test_reyn_src_list_router_render_exact_description():
-    """Tier 2: REYN_SRC_LIST description is byte-identical to the legacy ToolSpec
-    description in router_tools.py. Any whitespace or punctuation diff is a stop
-    signal that would drift LLMReplay fixtures."""
+    """Tier 2: render_for_router() passes the ToolDefinition's own description
+    through unchanged (no router-side transformation/truncation).
+
+    Asserts against the imported ``_REYN_SRC_LIST_DESCRIPTION`` constant
+    (the single source of truth in reyn_src.py) rather than a second,
+    independently-typed literal copy — a duplicated-literal pin is exactly
+    what let the description drift stale in the first place (it referenced
+    a "docs/en/concepts" path from before the docs i18n restructure,
+    reliably steering agents into guessing nonexistent paths, caught via a
+    real dogfood-journal grep sweep). One string, one place to update."""
     rendered = REYN_SRC_LIST.render_for_router()
-    legacy_description = (
-        "List entries under a path inside Reyn's own repository "
-        "(= the project that built this agent). Pass \"\" for "
-        "the repo root. Returns names + types (file/dir). Use "
-        "this to discover Reyn's source/doc layout before "
-        "reading specific files. Examples: list \"\" for the "
-        "top-level layout, \"docs/en/concepts\" for concept "
-        "docs, or any subdirectory path for its contents."
-    )
-    assert rendered["function"]["description"] == legacy_description
+    assert rendered["function"]["description"] == _REYN_SRC_LIST_DESCRIPTION
 
 
 def test_reyn_src_list_router_render_exact_parameters():


### PR DESCRIPTION
**[tui-coder]** —

## Summary

Owner-reported: dispatching a pipeline in a separate `../user` worktree reliably made the agent try to read/list paths under `docs/en/` — a path that hasn't existed since the docs i18n restructure (suffix-based: English at the repo-root path, Japanese is the same path with a `.ja.md` filename suffix, no `/en/`/`/ja/` directory prefix — see `CHANGELOG.md`). Owner also reported the same recurring at their company deployment.

## Root cause

Not generic LLM hallucination. The `reyn_src_list` tool's own `description` string (`src/reyn/tools/reyn_src.py`) used `"docs/en/concepts"` as its worked example — every agent that has this tool advertised sees that exact string in its tool schema and reliably reproduces the wrong path.

Confirmed via a grep sweep of `docs/deep-dives/journal/dogfood/`: this exact miss recurs across multiple unrelated dogfood batches (2026-05-04 through 2026-05-19), previously attributed to "generic LLM prior (mkdocs i18n pattern)" rather than traced back to the tool description itself.

## Fix

- Updated `_REYN_SRC_LIST_DESCRIPTION` to use `"docs/concepts"` (the actual current path) and note the `.ja.md` suffix convention for Japanese translations.
- Fixed the accompanying test, which hardcoded a **second, independently-typed copy** of the (stale) description string as a "byte-identical to legacy" pin — that duplicated-literal pattern is exactly what let the two copies drift apart in the first place. Now asserts against the imported `_REYN_SRC_LIST_DESCRIPTION` constant instead, so there's only one string to keep current going forward.

## Test plan

- [x] `pytest tests/test_reyn_src_unified.py` — 12 passed
- [x] `pytest tests/test_reyn_src_glob_grep.py tests/test_reyn_src_resolver.py tests/test_router_tools.py tests/test_router_tools_universal_wrappers.py tests/test_fp0056_*.py` (broader reyn_src-adjacent sweep) — 130 passed
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/verify_module_docstrings.py` — clean
- [x] Repo-wide grep confirms no other functional (non-historical-journal) source contains a stale `docs/en` reference
- [x] Directly rendered `REYN_SRC_LIST.render_for_router()` and confirmed the live description text no longer contains `docs/en`

Note: `docs/deep-dives/journal/` entries that historically documented this exact bug being observed (dated 2026-05-04 through 2026-05-19) are left untouched — they're a dogfood journal record of past investigation, not a place to retroactively rewrite.