### PR TITLE
feat: agent-step intervention/present reaches the pipeline originator when attached (#2769)

### DIFF
--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -702,6 +702,19 @@ class _RunDeps:
     pipeline_registry: "PipelineRegistry | None"
     events: "EventLog | None"
     cancel_check: "Callable[[], bool] | None"
+    # #2769: the LIVE session that invoked this pipeline run (the
+    # ``PipelineExecutorDriver``'s own ``self._session``), or ``None`` if the run is
+    # detached / headless (a CLI ``reyn pipe`` run, or a direct executor call in a
+    # test). The executor NEVER uses it except to forward it, opaquely, to an
+    # ``agent`` step's ``run_agent_step`` (``_run_agent_step``) — where it becomes the
+    # ``BridgeToParent`` target so the worker's ``ask_user`` / permission / present
+    # reach the pipeline ORIGINATOR via the #2735 transitive bridge (agent-step →
+    # driver → operator). A live ``Session`` (NOT a snapshot) is threaded because the
+    # transitive bridge re-reads ``parent_session.intervention_bridge`` at ask-time to
+    # support live re-attachment, which a frozen snapshot could not. Threaded unchanged
+    # into every nested scope by ``replace(deps, ...)`` so a ``for_each`` / ``call``
+    # sub-scope's agent-steps reach the same originator.
+    invoker_session: "Any | None" = None
     # S5 fan-out spawn bounds. ``fan_out_depth`` is a PER-BRANCH frozen value:
     # entering a ``for_each`` threads a ``replace(deps, fan_out_depth=+1)`` copy
     # into its item/collect sub-scopes, so a nested for_each sees a deeper value
@@ -847,6 +860,10 @@ async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str,
             capabilities=step.capabilities,
             schema=step.schema,
             schema_registry=deps.schema_registry,
+            # #2769: forward the invoking pipeline's live session so this agent-step's
+            # ask_user / permission / present reach the ORIGINATOR (via BridgeToParent +
+            # the #2735 transitive bridge) when attached; None → AuditOnly fail-closed.
+            invoker_session=deps.invoker_session,
         )
     except AgentStepError as exc:
         raise PipelineExecutionError(
@@ -1483,6 +1500,7 @@ class PipelineExecutor:
         cancel_check: "Callable[[], bool] | None" = None,
         max_fan_out_depth: "int | None" = None,
         max_pipeline_spawns: "int | None" = None,
+        invoker_session: "Any | None" = None,
     ) -> PipelineResult:
         """Run `pipeline` from the first step. `initial_context` seeds the named
         stores (``ctx.*``) available to the first step; there is no incoming pipe
@@ -1501,7 +1519,13 @@ class PipelineExecutor:
         omitted (NEVER unbounded-by-omission); the operator wires reyn.yaml's
         ``safety.spawn.*`` values here via the driver. ``0`` = unlimited (opt-out).
         Deliberately decoupled from `registry`: a `for_each` needs its caps even
-        with no `AgentStep` (so no `registry`) in the pipeline."""
+        with no `AgentStep` (so no `registry`) in the pipeline.
+
+        `invoker_session` (#2769) is the live session that invoked this run (the
+        driver-session), forwarded opaquely to an `agent` step's `run_agent_step`
+        so its interventions + present reach the pipeline originator when attached;
+        `None` (CLI-headless / direct executor call) → the agent-step routes
+        AuditOnly (fail-closed)."""
         named_stores: "dict[str, Any]" = dict(initial_context) if initial_context else {}
         return await self._run_from(
             pipeline,
@@ -1520,6 +1544,7 @@ class PipelineExecutor:
             cancel_check=cancel_check,
             max_fan_out_depth=max_fan_out_depth,
             max_pipeline_spawns=max_pipeline_spawns,
+            invoker_session=invoker_session,
         )
 
     async def resume(
@@ -1537,6 +1562,7 @@ class PipelineExecutor:
         cancel_check: "Callable[[], bool] | None" = None,
         max_fan_out_depth: "int | None" = None,
         max_pipeline_spawns: "int | None" = None,
+        invoker_session: "Any | None" = None,
     ) -> PipelineResult:
         """Resume `run_id`: load the latest recorded generation (R4) and replay every
         step already in ``completed_step_results`` (no re-execution — exactly-once).
@@ -1565,6 +1591,7 @@ class PipelineExecutor:
                 cancel_check=cancel_check,
                 max_fan_out_depth=max_fan_out_depth,
                 max_pipeline_spawns=max_pipeline_spawns,
+                invoker_session=invoker_session,
             )
         return await self._run_from(
             pipeline,
@@ -1583,6 +1610,7 @@ class PipelineExecutor:
             cancel_check=cancel_check,
             max_fan_out_depth=max_fan_out_depth,
             max_pipeline_spawns=max_pipeline_spawns,
+            invoker_session=invoker_session,
         )
 
     async def _run_from(
@@ -1604,6 +1632,7 @@ class PipelineExecutor:
         cancel_check: "Callable[[], bool] | None" = None,
         max_fan_out_depth: "int | None" = None,
         max_pipeline_spawns: "int | None" = None,
+        invoker_session: "Any | None" = None,
     ) -> PipelineResult:
         # S5 caps: default to conservative finite constants when the caller omits
         # them (never unbounded-by-omission). ``0`` (an explicit operator opt-out)
@@ -1626,6 +1655,7 @@ class PipelineExecutor:
             pipeline_registry=pipeline_registry,
             events=events,
             cancel_check=cancel_check,
+            invoker_session=invoker_session,
             fan_out_depth=0,
             max_fan_out_depth=eff_max_depth,
             spawn_budget=SpawnBudget(eff_max_spawns),

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -216,6 +216,14 @@ class PipelineExecutorDriver:
                     schema_registry=schema_registry,
                     max_fan_out_depth=self._registry.max_pipeline_fan_out_depth,
                     max_pipeline_spawns=self._registry.max_pipeline_spawns,
+                    # #2769: thread THIS driver-session down to any agent-step's
+                    # run_agent_step so its ask_user / permission / present reach the
+                    # pipeline originator (via BridgeToParent + the #2735 transitive
+                    # bridge). When this driver is itself detached (async / headless
+                    # launch), its OWN intervention_bridge is AuditOnly, so the
+                    # transitive walk terminates in a fail-closed typed refusal at this
+                    # driver hop — the agent-step is never left able to self-allow.
+                    invoker_session=self._session,
                 )
             else:
                 result = await executor.resume(
@@ -231,6 +239,8 @@ class PipelineExecutorDriver:
                     schema_registry=schema_registry,
                     max_fan_out_depth=self._registry.max_pipeline_fan_out_depth,
                     max_pipeline_spawns=self._registry.max_pipeline_spawns,
+                    # #2769: same invoker threading on the resume path (see run above).
+                    invoker_session=self._session,
                 )
         except PipelineCancelled as exc:
             # IS-6: an intentional Ctrl-C stop at a step boundary. TERMINAL (so

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -91,7 +91,10 @@ prefix and differing only in how the caller drives + collects:
     spawn's user-reaching capabilities cannot silently self-bind. Each spawn site declares a
     ``runtime/spawn_routing`` decision: ``_spawn_pipeline_driver_session`` picks
     ``BridgeToParent`` (attached) or ``AuditOnlyNoSurface`` (detached); ``run_agent_step`` picks
-    ``AuditOnlyNoSurface`` (headless leaf worker — closing #2706).
+    ``BridgeToParent(invoker_session)`` when a live invoking pipeline session is threaded in
+    (#2769 — the agent-step's ask_user / permission / present reach the pipeline ORIGINATOR via
+    the #2735 transitive bridge) or ``AuditOnlyNoSurface`` when detached / headless (no invoker —
+    closing #2706, and fail-closed by construction).
 """
 from __future__ import annotations
 
@@ -195,6 +198,7 @@ async def run_agent_step(
     schema_registry: "SchemaRegistry | None" = None,
     chain_id: "str | None" = None,
     timeout: "float | None" = None,
+    invoker_session: "Any | None" = None,
 ) -> Any:
     """Spawn an ephemeral session, run one turn, collect + return its output.
 
@@ -215,17 +219,41 @@ async def run_agent_step(
     ``chain_id`` defaults to a fresh uuid4 hex (mirrors ``MessageBus``'s own
     ``_new_request_id``). ``timeout`` defaults to
     ``_DEFAULT_AGENT_STEP_TIMEOUT_S`` seconds.
+
+    ``invoker_session`` (#2769) is the LIVE session that invoked this pipeline run
+    — the pipeline driver-session, threaded down opaquely by ``PipelineExecutor``
+    from ``PipelineExecutorDriver`` (which holds ``self._session``). When present,
+    the ephemeral worker's user-reaching capabilities route ``BridgeToParent`` to
+    it, so an agent-step ``ask_user`` / permission JIT approval / ``safety.limit`` /
+    MCP elicitation AND ``present`` reach the pipeline ORIGINATOR (the operator) —
+    the #2735 compositional transitive bridge walks agent-step → driver → root
+    operator, resolving at the first attached ancestor. When the invoking pipeline
+    was itself launched DETACHED, the driver-session's own bridge is
+    ``AuditOnlyInterventionBridge`` and that same transitive walk terminates in a
+    typed refusal at the driver hop — so the fail-closed behavior is preserved by
+    the driver's own routing, not by this seam. ``None`` (a CLI-headless ``reyn
+    pipe`` run with no live session, or a direct executor call) routes
+    ``AuditOnlyNoSurface`` here directly.
     """
     from reyn.core.pipeline.schema import validate
     from reyn.runtime.message_bus import MessageBus
-    from reyn.runtime.spawn_routing import AuditOnlyNoSurface
+    from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
 
     narrowing = _build_agent_step_narrowing(capabilities)
-    # #2708 P3-item3 (#2706): a headless ephemeral leaf worker has no attachable surface, so its
-    # user-reaching capabilities route AuditOnlyNoSurface — a ``present`` step is audit-only (the
-    # durable ``presented`` P6 event fires; no orphan outbox message), and an ``ask_user`` step
-    # returns a typed refusal rather than silently self-binding to an undrained outbox / hanging.
-    routing = AuditOnlyNoSurface()
+    # #2769 (refines #2706/#2710 P3-item3): an agent-step's user-reaching capabilities route to the
+    # pipeline INVOKER when one is threaded in (``BridgeToParent(invoker_session)`` — the driver
+    # session), so ``ask_user`` / permission / ``safety.limit`` / elicitation AND ``present`` reach
+    # the originating operator via the #2735 transitive bridge (agent-step → driver → operator). With
+    # NO invoker (CLI-headless ``reyn pipe`` / a direct executor call), route ``AuditOnlyNoSurface`` —
+    # ``present`` is audit-only (durable ``presented`` P6 event; no orphan outbox) and ``ask_user``
+    # returns a typed refusal, never a silent self-bind/hang. When the invoker pipeline is DETACHED,
+    # the driver session's OWN bridge is AuditOnly, so the transitive walk still refuses fail-closed —
+    # the DENY is a consumer-side deny-by-default property, independent of this routing decision.
+    routing = (
+        BridgeToParent(invoker_session)
+        if invoker_session is not None
+        else AuditOnlyNoSurface()
+    )
     sid = await spawn_ephemeral_session(
         registry, identity=identity, narrowing=narrowing,
         presentation_consumer=routing.presentation_consumer,
@@ -248,12 +276,14 @@ async def run_agent_step(
         reply_to=SystemRef(),
         timeout=timeout if timeout is not None else _DEFAULT_AGENT_STEP_TIMEOUT_S,
     )
-    # #2708 P3-item3 (#2706 root-cause-ii): a ``present`` step's output is ROUTED per the worker's
-    # DECLARED consumer (AuditOnlyNoSurface above) — it renders at the worker's own sink (audit-only:
-    # the durable ``presented`` P6 event) at op time, so it never arrives here as a ``"presentation"``
-    # outbox reply to be silently dropped (the pre-fix self-bound worker put a ``"presentation"`` on
-    # its own outbox that this ``kind == "agent"`` filter discarded). The join is the agent-step's
-    # RETURN text; presentation is not lost, it is deliberately audit-only per the declaration.
+    # #2708 P3-item3 (#2706 root-cause-ii) + #2769: a ``present`` step's output is ROUTED per the
+    # worker's DECLARED consumer — under ``BridgeToParent`` (attached invoker) it renders onto the
+    # INVOKER's outbox (reaching the operator by construction); under ``AuditOnlyNoSurface`` (detached)
+    # it renders audit-only (the durable ``presented`` P6 event). In EITHER case it renders at op time
+    # at the worker's own sink and never arrives here as a ``"presentation"`` outbox reply for this
+    # ``kind == "agent"`` filter to see — so present symmetry falls out of the ROUTING decision above,
+    # NOT of this filter (do NOT special-case it for present). The join is the agent-step's RETURN
+    # text; presentation is delivered/audited per the declaration, never lost here.
     text = "\n\n".join(r.text for r in replies if r.kind == "agent")
 
     if schema is None:

--- a/tests/test_2769_agent_step_intervention_reaches_invoker.py
+++ b/tests/test_2769_agent_step_intervention_reaches_invoker.py
@@ -1,0 +1,324 @@
+"""#2769 — an agent-step's intervention (+ present) reaches the pipeline INVOKER when attached.
+
+Owner refinement of P3-item3 (#2706/#2710): ``run_agent_step`` used to hardcode
+``AuditOnlyNoSurface`` for its ephemeral leaf worker, so an agent-step launched inside a
+pipeline attached to a live chat ALWAYS refused ask_user / permission / present. #2769 threads
+the invoking pipeline's live driver-session down to ``run_agent_step`` and swaps the routing to
+``BridgeToParent(invoker_session)`` when attached (``AuditOnlyNoSurface`` when detached / headless).
+So an agent-step's ``ask_user`` / permission JIT approval / ``safety.limit`` / elicitation AND its
+``present`` reach the ORIGINATING operator via the #2735 compositional transitive bridge
+(agent-step → driver → root operator), while a detached run stays fail-closed.
+
+Real ``AgentRegistry`` / ``Session`` / ``RouterLoop`` / ``MessageBus`` / intervention +
+present machinery — no collaborator mocks. The ONLY faked collaborator is the leaf worker's
+LLM completion (a fixed plain-text reply via the ``_loop_observer`` seam), incidental to the
+routing claim under test (the spawn's DECLARED routing + its reachability). Asserts on public
+surfaces: the worker's routing accessors, the operator's active-intervention queue + outbox,
+the typed permission decision (``PermissionError`` = DENY). Follows the exact operator-reach
+pattern of ``test_spawn_routing_detached_fail_mode_2708`` /
+``test_2708_p32a_spawn_bridge_intervention``.
+
+Safety crux (#2769): the DETACHED permission fail-closed DENY is a consumer-side deny-by-default
+property, INDEPENDENT of the routing swap — an AuditOnly refusal (``choice_id=None``) falls
+through to DENY at every permission consumer. ``test_detached_agent_step_permission_fail_closed_deny``
+pins it: a detached agent-step worker's own AuditOnly bus, fed to the real permission consumer,
+yields DENY (``PermissionError``), never allow.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle as present_handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.intervention_choices import YES, generic_yn_choices
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.presentation_consumer import (
+    AuditOnlyPresentationConsumer,
+    SpawnBridgePresentationConsumer,
+)
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from reyn.runtime.session_api import run_agent_step
+from reyn.runtime.session_buses import (
+    AuditOnlyInterventionBridge,
+    SpawnBridgeInterventionListener,
+)
+from reyn.schemas.models import PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import UserIntervention
+
+
+class _ScriptedReply:
+    """A fixed plain-text LLM turn (no tool_calls) — the leaf worker's turn completes with
+    this content, so ``run_agent_step`` returns and its ephemeral worker vanishes; the routing
+    it was SPAWNED with (the #2769 claim) is captured by the recording factory before then. NOT
+    a MagicMock: a signature drift in ``call_llm_tools`` raises TypeError here as in production."""
+
+    def __init__(self, content: str = "leaf worker done") -> None:
+        self.content = content
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        return LLMToolCallResult(
+            content=self.content, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRegistry, list]":
+    """Real AgentRegistry whose factory RECORDS every Session it builds (so a spawned worker's
+    public routing is inspectable after it vanishes) and wires a scripted plain-text LLM onto each
+    session's real RouterLoopDriver via ``_loop_observer`` (post-construction observer, not a
+    factory-seam bypass)."""
+    built: list[Session] = []
+    holder: dict = {}
+    scripted = _ScriptedReply()
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            non_interactive=True, presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+        s._loop_driver._loop_observer = (  # noqa: SLF001 — designed Tier-2 LLM seam
+            lambda loop: setattr(loop, "_llm_caller", scripted)
+        )
+        built.append(s)
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg, built
+
+
+def _drain(queue: "asyncio.Queue") -> list:
+    out: list = []
+    while not queue.empty():
+        out.append(queue.get_nowait())
+    return out
+
+
+def _by_kind(msgs: list, kind: str) -> list:
+    return [m for m in msgs if getattr(m, "kind", None) == kind]
+
+
+def _cancel_tasks(reg: "AgentRegistry") -> None:
+    for task in list(reg._tasks.values()):  # noqa: SLF001 — teardown precedent (sibling tests)
+        if not task.done():
+            task.cancel()
+
+
+# ── Attached: agent-step ask_user reaches the invoker operator ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attached_agent_step_ask_user_reaches_invoker_operator(tmp_path: Path) -> None:
+    """Tier 2: an agent-step run with an ``invoker_session`` (attached pipeline) spawns its leaf
+    worker ``BridgeToParent(invoker)`` — the worker's ``ask_user`` reaches the INVOKER operator's
+    live listener and the operator's answer flows back. RED on main: ``run_agent_step`` hardcoded
+    ``AuditOnlyNoSurface``, so the worker's bridge refused locally and NEVER reached the invoker."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+    invoker = reg.get_or_load("worker")
+    # The live operator on the invoking (pipeline-originator) session.
+    invoker.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    await run_agent_step(reg, identity="worker", prompt="do a thing", invoker_session=invoker)
+
+    # The worker was spawned BridgeToParent(invoker) — the #2769 routing swap (RED on main: it
+    # would be an AuditOnlyInterventionBridge that refuses locally, never reaching the invoker).
+    workers = [s for s in built if isinstance(s.intervention_bridge, SpawnBridgeInterventionListener)]
+    assert workers, (
+        "the agent-step worker was NOT routed BridgeToParent(invoker) — it kept the pre-#2769 "
+        "AuditOnly bridge and its ask_user would refuse locally, never reaching the operator."
+    )
+    worker = workers[-1]
+    assert worker.intervention_bridge.parent_session is invoker
+
+    # Operator-reach proof: the worker's ask_user (via its DECLARED bridge — the exact bus its op
+    # builds) lands on the INVOKER operator's active queue and resolves with the operator's answer.
+    bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
+    iv = UserIntervention(kind="ask_user", prompt="which branch?")
+    deliver = asyncio.ensure_future(bus.deliver(iv))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not invoker.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert invoker.interventions.list_active(), (
+        "the agent-step ask_user never reached the invoker operator's active queue (it refused "
+        "locally instead of bridging to the originator)."
+    )
+    # The operator was prompted on the invoker's own surface (chat-native intervention announce).
+    assert _by_kind(_drain(invoker.outbox), "intervention"), (
+        "the operator was never prompted on the invoker surface — the bridged ask_user did not "
+        "announce on the invoker's outbox."
+    )
+    consumed = await invoker._maybe_answer_oldest_intervention("blue")  # noqa: SLF001 — operator sim
+    assert consumed is True
+    answer = await asyncio.wait_for(deliver, timeout=5.0)  # resolves via the operator, no hang
+    assert (answer.choice_id or answer.text) == "blue"
+    assert answer.refused is False
+
+    _cancel_tasks(reg)
+
+
+# ── Attached: agent-step permission (bus-wide) reaches the invoker operator ───────────────
+
+
+@pytest.mark.asyncio
+async def test_attached_agent_step_permission_reaches_invoker_operator(tmp_path: Path) -> None:
+    """Tier 2: bus-wide — the routing swap governs the WHOLE intervention bus, so an agent-step
+    ``permission.generic`` JIT-approval (the kind the owner specifically wants the operator to see)
+    reaches the invoker operator via the same bridge, not just ``ask_user``. Same DECLARED-bridge
+    reachability proof, with a permission intervention."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+    invoker = reg.get_or_load("worker")
+    invoker.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    await run_agent_step(reg, identity="worker", prompt="do a thing", invoker_session=invoker)
+
+    workers = [s for s in built if isinstance(s.intervention_bridge, SpawnBridgeInterventionListener)]
+    assert workers, "the agent-step worker was not routed BridgeToParent(invoker) (#2769)."
+    worker = workers[-1]
+
+    bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
+    iv = UserIntervention(
+        kind="permission.generic", prompt="Allow tool 'shell'?", choices=generic_yn_choices(),
+    )
+    deliver = asyncio.ensure_future(bus.deliver(iv))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not invoker.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert invoker.interventions.list_active(), (
+        "the agent-step PERMISSION prompt never reached the invoker operator — the routing swap "
+        "must be bus-wide (permission.* / safety.limit / elicitation), not ask_user-only."
+    )
+    # The operator picks the affirmative choice on the invoker surface (the authoritative
+    # closed-set choice path the inline selector uses — bypasses text/hotkey match_choice).
+    consumed = await invoker.answer_oldest_intervention_choice(YES)
+    assert consumed is True
+    answer = await asyncio.wait_for(deliver, timeout=5.0)
+    # The operator's affirmative reached the agent-step's permission op (a real grant, not a refusal).
+    assert answer.choice_id == YES
+    assert answer.refused is False
+
+    _cancel_tasks(reg)
+
+
+# ── Attached: agent-step present reaches the invoker outbox (routing, not filter) ─────────
+
+
+@pytest.mark.asyncio
+async def test_attached_agent_step_present_reaches_invoker_outbox(tmp_path: Path) -> None:
+    """Tier 2: present symmetry falls out of the ROUTING decision (NOT the ``kind=='agent'`` reply
+    filter). The attached worker is spawned ``SpawnBridgePresentationConsumer`` bound to the invoker,
+    so a ``present`` renders onto the INVOKER's outbox (reaching the operator) — RED on main: the
+    worker was AuditOnly, present was a no-op sink that reached no one."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+    invoker = reg.get_or_load("worker")
+
+    await run_agent_step(reg, identity="worker", prompt="do a thing", invoker_session=invoker)
+
+    workers = [
+        s for s in built if isinstance(s.presentation_consumer, SpawnBridgePresentationConsumer)
+    ]
+    assert workers, (
+        "the agent-step worker was NOT routed SpawnBridgePresentationConsumer(invoker) — its "
+        "present would hit the pre-#2769 AuditOnly no-op sink, reaching no operator surface."
+    )
+    worker = workers[-1]
+
+    # Drive a present op through the worker's DECLARED present sink (the exact renderer its op
+    # builds): SpawnBridge binds to the invoker, so the render lands on the INVOKER's outbox.
+    events = EventLog()
+    sink = worker.presentation_consumer.sink(worker)
+    ctx = OpContext(
+        workspace=Workspace(events=events), events=events, permission_decl=PermissionDecl(),
+        presentation_renderer=sink,
+    )
+    op = PresentIROp(
+        kind="present", data_inline={"v": "AGENTSTEP2769"},
+        blueprint={"component": "text", "text": {"$bind": "/v"}},
+    )
+    result = await present_handle(op, ctx)
+    assert result["ok"] is True
+    presented = _by_kind(_drain(invoker.outbox), "presentation")
+    assert presented, (
+        "the agent-step present did NOT land on the invoker's outbox — present symmetry must ride "
+        "the routing (BridgeToParent's SpawnBridgePresentationConsumer), reaching the operator."
+    )
+
+    _cancel_tasks(reg)
+
+
+# ── Detached: agent-step ask_user refuses (unchanged) ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detached_agent_step_ask_user_refuses(tmp_path: Path) -> None:
+    """Tier 2: a DETACHED agent-step (no ``invoker_session`` — a headless ``reyn pipe`` run or a
+    direct executor call) keeps the reviewed ``AuditOnlyNoSurface`` routing: its ``ask_user``
+    resolves to a typed refusal, never reaching (nor hanging on) any operator."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    await run_agent_step(reg, identity="worker", prompt="do a thing")  # no invoker_session
+
+    workers = [s for s in built if isinstance(s.intervention_bridge, AuditOnlyInterventionBridge)]
+    assert workers, (
+        "a detached agent-step worker was not routed AuditOnly — the fail-closed detached routing "
+        "must be preserved when no invoker_session is threaded in."
+    )
+    worker = workers[-1]
+    bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
+    iv = UserIntervention(kind="ask_user", prompt="which branch?")
+    answer = await asyncio.wait_for(bus.deliver(iv), timeout=3.0)  # MUST NOT hang
+    assert answer.refused is True
+
+    _cancel_tasks(reg)
+
+
+# ── Detached: agent-step permission → fail-closed DENY (the safety crux) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_detached_agent_step_permission_fail_closed_deny(tmp_path: Path) -> None:
+    """Tier 2: (safety crux) a DETACHED agent-step's AuditOnly permission refusal is interpreted as
+    DENY (fail-closed) by the real permission consumer — NOT allow. The detached worker's OWN
+    AuditOnly bus, fed to a real ``PermissionResolver.require_tool`` (the consumer an agent-step's
+    permission op reaches), yields a ``PermissionError`` (deny). This is the security-critical
+    invariant: the routing change cannot open a refuse→allow hole because DENY is a consumer-side
+    deny-by-default property (``choice_id=None`` falls through to deny), independent of routing."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    await run_agent_step(reg, identity="worker", prompt="do a thing")  # detached
+
+    workers = [s for s in built if isinstance(s.intervention_bridge, AuditOnlyInterventionBridge)]
+    assert workers, "the detached agent-step worker was not routed AuditOnly (#2769 fail-closed)."
+    worker = workers[-1]
+
+    # The EXACT bus the worker's permission op would dispatch on (its declared AuditOnly bridge).
+    bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
+    # A real permission consumer: the tool IS declared (passes the static-authority gate) and is
+    # NOT pre-approved, so it reaches the interactive prompt → the AuditOnly bus → a refusal.
+    resolver = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    decl = PermissionDecl(tool=["risky_tool"])
+
+    with pytest.raises(PermissionError):
+        # The AuditOnly refusal (choice_id=None) is consumed as DENY — require_tool raises. A
+        # refuse→allow hole would let this pass (the serious security regression this pins against).
+        await resolver.require_tool(decl, "risky_tool", bus)
+
+    _cancel_tasks(reg)

--- a/tests/test_2769_agent_step_intervention_reaches_invoker.py
+++ b/tests/test_2769_agent_step_intervention_reaches_invoker.py
@@ -46,7 +46,11 @@ from reyn.runtime.presentation_consumer import (
 )
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
-from reyn.runtime.session_api import run_agent_step
+from reyn.runtime.session_api import (
+    _build_agent_step_narrowing,
+    run_agent_step,
+    spawn_ephemeral_session,
+)
 from reyn.runtime.session_buses import (
     AuditOnlyInterventionBridge,
     SpawnBridgeInterventionListener,
@@ -294,16 +298,19 @@ async def test_detached_agent_step_ask_user_refuses(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_detached_agent_step_permission_fail_closed_deny(tmp_path: Path) -> None:
-    """Tier 2: (safety crux) a DETACHED agent-step's AuditOnly permission refusal is interpreted as
-    DENY (fail-closed) by the real permission consumer — NOT allow. The detached worker's OWN
-    AuditOnly bus, fed to a real ``PermissionResolver.require_tool`` (the consumer an agent-step's
-    permission op reaches), yields a ``PermissionError`` (deny). This is the security-critical
-    invariant: the routing change cannot open a refuse→allow hole because DENY is a consumer-side
-    deny-by-default property (``choice_id=None`` falls through to deny), independent of routing."""
+    """Tier 2: (safety crux, detached CASE i of ii) ``invoker_session=None`` → the agent-step routes
+    ``AuditOnlyNoSurface`` DIRECTLY, and its AuditOnly permission refusal is interpreted as DENY
+    (fail-closed) by the real permission consumer — NOT allow. The detached worker's OWN AuditOnly
+    bus, fed to a real ``PermissionResolver.require_tool`` (the consumer an agent-step's permission
+    op reaches), yields a ``PermissionError`` (deny). Security-critical invariant: the routing change
+    cannot open a refuse→allow hole because DENY is a consumer-side deny-by-default property
+    (``choice_id=None`` falls through to deny), independent of routing. Case ii (invoker IS a
+    detached-driver session → transitive fail-close) is pinned separately below — the two together
+    enumerate BOTH production-reachable detached fail-close cases (not a curated subset)."""
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     reg, built = _recording_registry(tmp_path, state_log)
 
-    await run_agent_step(reg, identity="worker", prompt="do a thing")  # detached
+    await run_agent_step(reg, identity="worker", prompt="do a thing")  # detached (invoker_session=None)
 
     workers = [s for s in built if isinstance(s.intervention_bridge, AuditOnlyInterventionBridge)]
     assert workers, "the detached agent-step worker was not routed AuditOnly (#2769 fail-closed)."
@@ -319,6 +326,68 @@ async def test_detached_agent_step_permission_fail_closed_deny(tmp_path: Path) -
     with pytest.raises(PermissionError):
         # The AuditOnly refusal (choice_id=None) is consumed as DENY — require_tool raises. A
         # refuse→allow hole would let this pass (the serious security regression this pins against).
+        await resolver.require_tool(decl, "risky_tool", bus)
+
+    _cancel_tasks(reg)
+
+
+@pytest.mark.asyncio
+async def test_detached_driver_invoker_agent_step_permission_fail_closed_deny_transitively(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: (safety crux, detached CASE ii of ii) the invoker IS a detached-driver session — a
+    headless async pipeline whose OWN driver session EXISTS but is ``AuditOnly``-spawned (the exact
+    production path ``_spawn_pipeline_driver_session`` takes on ``start_pipeline_run``, and the one
+    ``pipeline_executor_driver.py`` claims: "when this driver is itself detached ... its OWN
+    intervention_bridge is AuditOnly, so the transitive walk terminates in a fail-closed typed
+    refusal"). Here the agent-step routes ``BridgeToParent(detached-driver)`` (NOT direct AuditOnly),
+    and the #2735 transitive walk resolves at the DRIVER hop into the driver's own AuditOnly bridge →
+    refuse → the permission consumer DENIES. Pins that this SECOND detached case fail-closes via the
+    transitive hop, completing the enumeration with case i above (invoker=None → direct AuditOnly)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg, built = _recording_registry(tmp_path, state_log)
+
+    # A detached-driver session: spawned AuditOnly, exactly as the detached (start_pipeline_run)
+    # launch path spawns its pipeline driver. It EXISTS (a live session driving a headless async
+    # pipeline) but has no attachable operator surface — its own bridge is AuditOnly.
+    driver_sid = await spawn_ephemeral_session(
+        reg, identity="worker", narrowing=_build_agent_step_narrowing(None),
+        presentation_consumer=AuditOnlyPresentationConsumer(),
+        intervention_bridge=AuditOnlyInterventionBridge(),
+    )
+    detached_driver = reg.get_session("worker", driver_sid)
+    assert detached_driver is not None
+    assert isinstance(detached_driver.intervention_bridge, AuditOnlyInterventionBridge)
+
+    # The agent-step is invoked WITH this detached driver as its invoker → BridgeToParent(driver),
+    # NOT direct AuditOnly (that distinguishes case ii from case i above).
+    await run_agent_step(
+        reg, identity="worker", prompt="do a thing", invoker_session=detached_driver,
+    )
+
+    # The worker routed BridgeToParent(detached-driver): a SpawnBridge whose parent IS the driver
+    # (NOT a direct AuditOnly bridge). RED if run_agent_step ignored the invoker (case-i shape).
+    workers = [
+        s for s in built
+        if isinstance(s.intervention_bridge, SpawnBridgeInterventionListener)
+        and s.intervention_bridge.parent_session is detached_driver
+    ]
+    assert workers, (
+        "the agent-step worker was NOT routed BridgeToParent(detached-driver) — case ii requires "
+        "the invoker (the detached driver) to be the bridge parent, so the transitive walk can "
+        "fail-close at the driver hop rather than the worker routing AuditOnly directly (case i)."
+    )
+    worker = workers[-1]
+
+    # The transitive walk (worker → detached-driver's own AuditOnly bridge → refuse) is the EXACT
+    # bus the worker's permission op dispatches on. Fed to the real permission consumer → DENY,
+    # reached VIA the driver hop (not a worker-local AuditOnly). This is the production-reachable
+    # (ii) path proven fail-closed.
+    bus = worker.intervention_bridge.bus(run_id="r", actor="agent-step")
+    resolver = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    decl = PermissionDecl(tool=["risky_tool"])
+
+    with pytest.raises(PermissionError):
         await resolver.require_tool(decl, "risky_tool", bus)
 
     _cancel_tasks(reg)


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2769

Owner refinement of P3-item3 (#2706/#2710): an `agent` step launched inside a pipeline attached to a live chat should have its interventions + `present` reach the originating operator — the current always-refuse for agent-steps was unexpected. This mirrors the pipeline driver's attached/detached routing via the #2735 compositional transitive bridge (agent-step → driver → root operator). References #2735 (compositional bridge) and #2706/#2710 (the P3-item3 agent-step decisions this refines).

## The problem
`run_agent_step` (`session_api.py`) hardcoded `routing = AuditOnlyNoSurface()`, and had no handle to the driver session — so an agent-step's `ask_user` / permission JIT approval / `safety.limit` / MCP elicitation AND `present` ALWAYS refused / were audit-only, even when the pipeline was attached to a live operator.

## The fix — 5-layer threading + a leaf routing swap
Thread the invoking pipeline's **live driver-session** opaquely down to `run_agent_step`:

```
PipelineExecutorDriver.run_turn (self._session)
  → PipelineExecutor.run / .resume        (new invoker_session param)
    → _run_from                            (new param)
      → _RunDeps                           (new invoker_session field, preserved by replace(deps,...))
        → _run_agent_step                  (forwards deps.invoker_session)
          → run_agent_step                 (routing swap)
```

Routing swap at the leaf:
```python
routing = BridgeToParent(invoker_session) if invoker_session is not None else AuditOnlyNoSurface()
```
The executor **never uses** `invoker_session` except to forward it. A **live `Session`** is threaded (not a snapshot) because the #2735 transitive bridge re-reads `parent_session.intervention_bridge` at ask-time to support live re-attachment. The `reyn pipe` CLI (headless) and direct executor calls leave it `None` → `AuditOnlyNoSurface`.

## Present symmetry is covered by ROUTING, not the filter
Under `BridgeToParent` the worker is spawned with a `SpawnBridgePresentationConsumer` bound to the invoker, so `present` renders onto the invoker's outbox by construction; under `AuditOnlyNoSurface` it's an audit-only no-op sink. In **either** case present renders at op time at the worker's own sink and never arrives at the `kind=="agent"` reply filter. **The filter is untouched** (this corrects the earlier "fix the filter" framing).

## Bus-wide, automatically
`intervention_bridge` governs the whole intervention bus (ask_user + permission.* + safety.limit.* + elicitation), so the single routing swap covers all kinds — no per-kind work.

## Fail-closed DENY preserved by construction (safety crux)
A detached run routes `AuditOnlyNoSurface`; a driver that is itself detached carries an AuditOnly bridge, so the transitive walk terminates in a typed refusal at the driver hop. The refuse→DENY is a **consumer-side deny-by-default property, independent of the routing change** (an AuditOnly refusal has `choice_id=None`, which falls through to deny at every permission consumer). The routing change cannot open a refuse→allow hole because it never touches those branches. **Pinned by a dedicated test**: a detached agent-step worker's own AuditOnly bus, fed to a real `PermissionResolver.require_tool`, raises `PermissionError` (DENY) — never allow.

## Tests (Tier 2, real Session + real intervention bus, no mocks; RED→GREEN cp-falsified)
`tests/test_2769_agent_step_intervention_reaches_invoker.py`:
- Attached: agent-step `ask_user` reaches the invoker operator + answer flows back
- Attached: agent-step **permission** reaches the operator (bus-wide, not just ask_user)
- Attached: agent-step **present** lands on the invoker's outbox (via routing)
- Detached: agent-step `ask_user` → typed refusal (unchanged)
- Detached: agent-step **permission → fail-closed DENY** (the safety crux)

**cp-falsify**: reverting the routing swap turns the 3 attached tests RED while the 2 detached stay GREEN (verified via scratch backup, never git).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <new test>` — 5/5 OK
- [x] `python scripts/verify_module_docstrings.py <changed src>` — clean
- [x] `pytest` (repo root) — new + related pipeline/spawn suites pass; the only failures (5) are pre-existing web/a2a/mcp route-mounting tests confirmed failing on the clean base, unrelated to this change
- [x] cp-falsify the routing swap (attached RED, detached GREEN, restored)

Truncate/WAL falsify: N/A — no new WAL-derived recovery state (routing is live, not persisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)