### PR TITLE
feat: multiple pipeline: docs per file + uniform {key}.{name} namespacing (#2722)

### DIFF
--- a/docs/concepts/runtime/pipeline-registration.md
+++ b/docs/concepts/runtime/pipeline-registration.md
@@ -8,9 +8,16 @@ search_hints: [pipeline registration, pipelines entries, register pipeline, run_
 # Pipeline registration
 
 A **pipeline** is a deterministic, multi-step control flow written in the
-pipeline DSL (a single YAML document). Once registered, an agent can launch
-it by name with `run_pipeline` (or the catalog verb `pipeline__<name>`), and
-one pipeline can `call` another by name.
+pipeline DSL. A DSL file may hold one or more `pipeline:` documents (private
+helper pipelines co-located with an entry point). Once registered, an agent can
+launch a pipeline by its fully-qualified name with `run_pipeline` (or the
+catalog verb `pipeline__<name>`), and one pipeline can `call` another.
+
+**Namespacing is always on.** Every pipeline registers under a global name of
+the form `{entry-key}.{pipeline-name}` — where `{entry-key}` is the config
+entry key and `{pipeline-name}` is the document's declared `pipeline:` name.
+The entry key is a pure namespace label; it does not need to equal any declared
+name.
 
 ## Registration: explicit entries, no directory scan
 
@@ -23,7 +30,7 @@ disk with no config entry is invisible to every session.
 # reyn.yaml
 pipelines:
   entries:
-    hello:
+    greetings:                 # the entry KEY is the namespace label
       path: pipelines/hello.yaml
       description: "Minimal greeting pipeline"
       enabled: true
@@ -31,8 +38,8 @@ pipelines:
 
 ## Adding a pipeline
 
-1. Write one Appendix-B DSL document per `*.yaml` file. Each file declares its
-   name with a top-level `pipeline:` key:
+1. Write one or more Appendix-B DSL documents (`---`-separated) per `*.yaml`
+   file. Each declares its name with a top-level `pipeline:` key:
 
    ```yaml
    # pipelines/hello.yaml
@@ -43,31 +50,66 @@ pipelines:
    ```
 
 2. Declare a `pipelines.entries.<key>` entry pointing at the file (see above).
-   **The entry key must match the DSL's own declared `pipeline:` name
-   exactly** — see below.
+   The key is a **pure namespace label** — it can be anything (it need not
+   match any declared `pipeline:` name).
 
-3. Start (or restart) the session. The pipeline is now registered under its
-   declared name and an agent can launch it:
+3. Start (or restart) the session. The pipeline registers under its
+   fully-qualified `{key}.{name}` global name, and an agent can launch it:
 
    ```
-   run_pipeline(name="hello", input={name: "Reyn"})
+   run_pipeline(name="greetings.hello", input={name: "Reyn"})
    ```
 
    or via the qualified catalog verb the action catalog surfaces:
 
    ```
-   pipeline__hello({name: "Reyn"})
+   pipeline__greetings.hello({name: "Reyn"})
    ```
 
-## The declared name is authoritative
+## Namespacing: `{entry-key}.{pipeline-name}`
 
-A pipeline registers under the name in its `pipeline:` key. This is the
-identity a `call` (or `match`) step's `pipeline:` target resolves against, so
-it must be exact. Unlike `skills.entries` (where the config key freely names
-the skill), **the `pipelines.entries` key must match the DSL's declared name
-exactly** — a mismatch fails session start loudly, naming both the key and
-the declared name. A file's own filename is irrelevant either way; only the
-`path` it's referenced from and the `pipeline:` key inside it matter.
+Every pipeline registers under the global name `{entry-key}.{pipeline-name}` —
+uniformly, regardless of how many `pipeline:` documents the file holds. The
+`greetings` entry above pointing at a `pipeline: hello` document registers as
+`greetings.hello`. The config entry key is a **pure namespace label**; unlike
+the old model it does not need to equal any declared name (this brings pipelines
+in line with the looser `skills.entries` / `mcp.servers` precedent).
+
+### Multiple pipelines in one file
+
+A file may co-locate a helper pipeline with the entry point that uses it —
+each `---`-separated `pipeline:` document registers under the same namespace:
+
+```yaml
+# pipelines/order_flow.yaml
+pipeline: main
+steps:
+  - call: {pipeline: interrogate, output: verdict}   # dot-less → sibling
+---
+pipeline: interrogate
+steps:
+  - agent: {prompt: "Assess the suspect: {pipe}"}
+```
+
+Under `entries: {orders: {path: pipelines/order_flow.yaml}}` this registers
+`orders.main` and `orders.interrogate`.
+
+### `call`/`match` target resolution — the dot/no-dot rule
+
+A `call` (or `match`) step's `pipeline:` target resolves by whether it contains
+a `.`:
+
+- **No dot** (`call: {pipeline: interrogate}`) — a **same-file sibling**
+  reference; resolves to `{entry-key}.interrogate`. A dot-less target with no
+  matching sibling in the same file is a **load-time error** (fail-loud; there
+  is no silent fallback to some unrelated global pipeline).
+- **Has a dot** (`call: {pipeline: other.helper}`) — a **global** reference,
+  resolved against the whole registry (`other.helper`), unchanged.
+
+`.` is **reserved** as the namespace separator — it is forbidden in both a
+declared `pipeline:` name and a config entry key (a load-time error). This is
+what makes the dot/no-dot rule unambiguous: a local name has zero dots, a
+global name has exactly one.
 
 ## Config cascade
 
@@ -98,8 +140,11 @@ normally:
 | Condition | Behavior |
 |-----------|----------|
 | Malformed DSL file | That entry is skipped; logged + durably recorded, naming the offending file. Other entries still load. |
-| Entry key ≠ the DSL's declared `pipeline:` name | That entry is skipped; logged + durably recorded, naming both the key and the declared name. Other entries still load. |
-| Two entries declaring the same `pipeline:` name | The FIRST-registered entry (config declaration order) wins; the later, colliding entry is skipped and logged + durably recorded. |
+| Entry key contains a `.` | That entry is skipped; logged + durably recorded (`.` is the reserved namespace separator). Other entries still load. |
+| A declared `pipeline:` name contains a `.` | That entry is skipped (malformed file); logged + durably recorded. |
+| Two `pipeline:` documents in one file declaring the same name | That entry is skipped (malformed file); logged + durably recorded. |
+| A dot-less `call`/`match` target with no matching same-file sibling | That entry is skipped; logged + durably recorded, naming the unresolved target. Other entries still load. |
+| Two entries producing the same global `{key}.{name}` | The FIRST-registered (config declaration order) wins; the later, colliding entry is skipped and logged + durably recorded. |
 | An entry's `path` does not exist | That entry is skipped; logged + durably recorded, naming the path. Other entries still load. |
 | No `pipelines.entries` declared | No pipelines registered (empty registry) — not a failure, nothing logged. |
 
@@ -132,12 +177,15 @@ Two chat-callable tools under the `pipeline_management` category write
 
 Registers a local pipeline DSL file into `.reyn/config/pipelines.yaml`:
 
-1. Parses the DSL file at the given path (validation step — a malformed file
-   is refused).
-2. Resolves the registration name from the DSL's own declared `pipeline:` key;
-   an optional `name` argument must match it exactly or the install is refused.
-3. Threat-scans the description (strict scope) — blocks on a blocking-severity
-   match.
+1. Parses the DSL file at the given path (one or more `pipeline:` documents —
+   validation step; a malformed file is refused).
+2. Resolves the namespace **key** — the optional `name` argument, or the DSL
+   file stem when omitted. The key is a pure label (`.` reserved); every
+   `pipeline:` document in the file registers as `{key}.{declared-name}`, and
+   the full set of registered names is enumerated in the result and the audit
+   event.
+3. Threat-scans every pipeline's description (strict scope) — blocks on a
+   blocking-severity match.
 4. Gates the `pipelines.yaml` write through the standard `require_file_write`
    permission flow.
 5. Writes the entry, records a config generation (crash-recovery — survives
@@ -154,15 +202,15 @@ Fetches a pipeline from a git/GitHub URL and installs the clone:
    convention) selects a subdirectory of the clone instead of its root.
 3. Locates the DSL file in the clone — an explicit `path` argument selects it
    when the repo/subdir contains more than one `*.yaml` file — then proceeds
-   through the same parse → name-validate → threat-scan → gate → write →
+   through the same parse → namespace-key → threat-scan → gate → write →
    hot-reload pipeline as the local path, with the registered `path` pointing
    at the installed copy.
 
-**Path-safety hardening** (both tools, since the resolved name feeds a
-filesystem path under `.reyn/pipelines/`): the derived name — from the
-`name` argument or the DSL's declared `pipeline:` name — is rejected outright
-unless it is a single safe path component (`[A-Za-z0-9._-]+`, no `..`, no
-leading dot, no separators). A belt-and-suspenders containment check
+**Path-safety hardening** (both tools, since the namespace key feeds a
+filesystem path under `.reyn/pipelines/`): the key — from the `name` argument
+or the source/file basename — is rejected outright unless it is a single safe
+path component (`[A-Za-z0-9_-]+`, no `.`, no `..`, no separators; `.` is
+reserved as the namespace separator). A belt-and-suspenders containment check
 (`resolve()` + `relative_to()`) additionally refuses any install destination
 that would resolve outside `.reyn/pipelines/`, guarding against a gap in the
 name check itself. Neither check silently rewrites an unsafe name —

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1201,7 +1201,7 @@ Registers pipeline DSL files — the same explicit-registration model as `skills
 ```yaml
 pipelines:
   entries:
-    hello:
+    greetings:                       # entry KEY = the namespace label
       path: pipelines/hello.yaml   # project-root-relative or absolute
       description: "Minimal greeting pipeline"   # optional
       enabled: true                              # optional, default true
@@ -1209,11 +1209,11 @@ pipelines:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `path` | string | required | Path to the pipeline's `*.yaml` DSL file. |
+| `path` | string | required | Path to the pipeline's `*.yaml` DSL file (may hold multiple `---`-separated `pipeline:` documents). |
 | `description` | string | `""` | Optional one-line summary; if omitted, the DSL's own `description:` key is used. |
 | `enabled` | bool | `true` | `false` removes the entry from the registry entirely. |
 
-The entry **key must match the DSL file's own declared `pipeline:` name exactly** — the declared name is the authoritative identity a `call`/`match` step resolves against, not the config key. A mismatch fails session start loudly, naming both the key and the declared name.
+The entry **key is a pure namespace label** — it need not equal any declared `pipeline:` name. Every pipeline in the file registers under the global name `{key}.{declared-name}` (namespacing is always on). A `.` is reserved as the namespace separator, so it is forbidden in both an entry key and a declared `pipeline:` name. A dot-less `call`/`match` target resolves to a same-file sibling (`{key}.name`); a dotted target is a global reference (`other_key.name`).
 
 `pipelines.entries` merges across `~/.reyn/config.yaml` ⊕ `reyn.yaml` ⊕ `reyn.local.yaml` ⊕ the dynamic `<project>/.reyn/config/pipelines.yaml` (written by the `pipeline_management__install_local` / `pipeline_management__install_source` chat tools), later tiers winning on name collision — the same merge shape as `skills.entries` / `mcp.servers`.
 

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -119,7 +119,11 @@ steps:
       output: verdicts
 ```
 
-Here `interrogate` (a registered sub-pipeline) reads the current suspect as
+Here `interrogate` is a sibling pipeline co-located in the same file (a
+dot-less `call` target resolves to a same-file sibling; a cross-file target
+uses the qualified `other_key.name` form — see [Pipeline
+registration](../../concepts/runtime/pipeline-registration.md#callmatch-target-resolution--the-dotno-dot-rule)).
+It reads the current suspect as
 `ctx.suspect` — `pass: {suspect: item}` evaluated the bare-path expression
 `item` against the `for_each` scope's context (which carries `item`
 alongside `ctx`/`pipe`) and bound the result to `suspect` in the callee's
@@ -131,7 +135,7 @@ acc}`.
 
 | Key | Required | Meaning |
 |-----|----------|---------|
-| `pipeline` | yes | The declared name. Authoritative for registration and for a `call`/`match` step's target — see [Pipeline registration](../../concepts/runtime/pipeline-registration.md#the-declared-name-is-authoritative). |
+| `pipeline` | yes | The declared local name. Registered globally as `{entry-key}.{name}` (namespacing is always on) and referenced by a `call`/`match` step's target — see [Pipeline registration](../../concepts/runtime/pipeline-registration.md#namespacing-entry-keypipeline-name). Must not contain `.` (reserved separator). |
 | `description` | no | Human-readable summary; surfaced to the LLM alongside the name when a registered pipeline is listed as a `pipeline__<name>` catalog action. Defaults to empty. |
 | `steps` | yes | Non-empty list of steps, executed in order (see [Step kinds](#step-kinds) and [Primitives](#compositional-primitives)). |
 
@@ -400,7 +404,7 @@ its final output out as this step's result.
 
 | Key | Required | Meaning |
 |-----|----------|---------|
-| `pipeline` | yes | A static literal pipeline name — never a runtime expression. An unregistered target fails the step. |
+| `pipeline` | yes | A static literal pipeline name — never a runtime expression. Dot-less = a same-file sibling (`{entry-key}.name`); dotted = a global (`other_key.name`) — see [target resolution](../../concepts/runtime/pipeline-registration.md#callmatch-target-resolution--the-dotno-dot-rule). An unresolved/unregistered target fails at load or step time. |
 | `pass` | no | A flat `{NAME: EXPR}` mapping. The callee's context is built **fresh** from only these bindings — a `NAME` not bound by any entry is structurally invisible to the callee. Each entry's `EXPR` is an R1 expression evaluated against the caller's current context (`ctx`/`pipe`/`item`/`acc` — whatever is in scope, exactly like `transform.value`), and the result is bound to `NAME` in the callee's `ctx` (see [Data flow between steps](#data-flow-between-steps)). A failing expression fails the step, naming the entry. |
 | `output` | no | Named store to write the callee's final result to. |
 

--- a/pipelines/hello.yaml
+++ b/pipelines/hello.yaml
@@ -1,24 +1,26 @@
 # Sample pipeline — the minimal end-to-end example.
 #
 # This file is NOT registered by merely sitting in this directory — pipelines
-# are registered only via an explicit `pipelines.entries.<name>` declaration
+# are registered only via an explicit `pipelines.entries.<key>` declaration
 # in config (see docs/concepts/runtime/pipeline-registration.md). To make
 # this one live, either add:
 #
 #     pipelines:
 #       entries:
-#         hello:
+#         greetings:              # the entry KEY is a pure namespace label
 #           path: pipelines/hello.yaml
 #
 #   to reyn.yaml, or call `pipeline_management__install_local` with this
-#   file's path. Either way it registers as `hello` — the `pipeline:` key
-#   below is authoritative, not the file name — and is live immediately via
-#   hot-reload (no session restart needed).
+#   file's path. Namespacing is always on (#2722): every pipeline registers
+#   as `{entry-key}.{pipeline-name}`, so the `pipeline: hello` doc below
+#   registers as `greetings.hello`. The entry key does NOT need to equal the
+#   declared name — it is just the namespace. Live immediately via hot-reload
+#   (no session restart needed).
 #
-# An agent can then launch it:
-#     run_pipeline(name="hello", input={name: "Reyn"})
+# An agent can then launch it by its fully-qualified name:
+#     run_pipeline(name="greetings.hello", input={name: "Reyn"})
 # or via the qualified catalog verb the enumerator surfaces:
-#     pipeline__hello({name: "Reyn"})
+#     pipeline__greetings.hello({name: "Reyn"})
 #
 # It is a single pure `transform` step so it runs with no external tools —
 # safe to keep as a live smoke/dogfood pipeline.

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -294,14 +294,16 @@ class ReynConfig:
     # invisible to every session). Shape:
     #   pipelines:
     #     entries:
-    #       <name>:
+    #       <key>:
     #         path: "pipelines/hello.yaml"
     #         description: "One-line description"   # optional
     #         enabled: true                          # optional, default true
-    # Each entry's ``path`` is parsed via ``parse_pipeline_dsl``; the pipeline
-    # registers under its OWN declared ``pipeline:`` name (the authoritative
-    # resolution key a ``call``/``match`` step targets), not the config entry
-    # key — see ``build_pipeline_registry``'s name-mismatch validation.
+    # Each entry's ``path`` is parsed via ``parse_pipeline_docs`` (a file may
+    # hold multiple ``pipeline:`` documents — #2722). Namespacing is always on:
+    # every pipeline registers as ``{key}.{declared-name}``. The config entry
+    # key is a pure namespace label (it need NOT equal any declared name); a
+    # dot-less ``call``/``match`` target resolves to a same-file sibling, a
+    # dotted one to a global — see ``build_pipeline_registry``.
     # Absent/empty → no pipelines loaded. Merged across config tiers by name
     # (explicit entries win on collision) — same union-merge shape as
     # ``skills`` (see ``_merge`` in loader.py).

--- a/src/reyn/core/op_runtime/pipeline_install.py
+++ b/src/reyn/core/op_runtime/pipeline_install.py
@@ -13,16 +13,18 @@ Handler logic (one-shot, no sub-phases):
 Local-path install (``op.source is None``):
   1. Resolve the pipeline DSL file: ``op.path`` must point directly at a
      ``*.yaml`` file (unlike skill, there is no directory-or-file resolution —
-     a pipeline registration is always exactly one file).
-  2. Parse it via ``parse_pipeline_dsl`` into a ``Pipeline`` — this is the
-     validation step (a malformed DSL file is refused, never registered).
-  3. Resolve the registration name: the DSL's own declared ``pipeline:`` name
-     is ALWAYS the identity a ``call``/``match`` step resolves against. When
-     ``op.name`` is set it must match the DSL's declared name exactly — a
-     mismatch is refused (fail-loud) rather than letting the config key
-     silently diverge from the resolution key.
-  4. Threat-scan the pipeline description via ``content_guard.scan_for_threats``
-     (scope="strict") — block on blocking-severity match (same threat surface
+     a pipeline registration is always exactly one file, though that file may
+     hold MULTIPLE ``pipeline:`` documents — #2722).
+  2. Parse it via ``parse_pipeline_docs`` into one-or-more ``Pipeline``s — this
+     is the validation step (a malformed DSL file is refused, never registered).
+  3. Resolve the registration namespace KEY (#2722): the config entry key is a
+     pure namespace label (``op.name``, or the DSL file stem when omitted) — it
+     no longer must equal any declared ``pipeline:`` name (the old key==name
+     coupling is gone). ``.`` is reserved (R1) and rejected in the key. Every
+     ``pipeline:`` document registers as ``{key}.{declared-name}``; the FULL set
+     is enumerated in the result + audit event (H6 — no silent scope creep).
+  4. Threat-scan EVERY pipeline's description via ``content_guard.scan_for_threats``
+     (scope="strict") — block on any blocking-severity match (same threat surface
      as a skill's SKILL.md description: free-text authored by whoever wrote the
      DSL, which for a source install is untrusted third-party content).
   5. Gate via ``PermissionResolver.require_file_write`` for the pipelines.yaml path.
@@ -97,13 +99,15 @@ def _pipelines_config_path(project_root: Path) -> Path:
     return project_root / ".reyn" / "config" / "pipelines.yaml"
 
 
-def _parse_pipeline_file(path: Path) -> "tuple[object | None, str]":
-    """Read + parse a pipeline DSL file. Returns (Pipeline | None, error_message).
+def _parse_pipeline_file(path: Path) -> "tuple[list | None, str]":
+    """Read + parse a pipeline DSL file. Returns (list[Pipeline] | None, error).
 
-    On success, error_message is "". On failure (unreadable file or malformed
-    DSL), the Pipeline is None and error_message describes the failure.
-    """
-    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+    A file may hold MORE than one ``pipeline:`` document (#2722) — every one is
+    parsed and returned. On success, error_message is "". On failure (unreadable
+    file or malformed DSL), the list is None and error_message describes the
+    failure. R1 (a reserved ``.`` in a declared name) and R2 (an intra-file
+    duplicate declared name) surface here as a malformed-file error."""
+    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_docs
     from reyn.core.pipeline.schema import SchemaRegistry
 
     try:
@@ -111,10 +115,10 @@ def _parse_pipeline_file(path: Path) -> "tuple[object | None, str]":
     except OSError as exc:
         return None, f"could not read pipeline file {path}: {exc}"
     try:
-        pipeline = parse_pipeline_dsl(text, SchemaRegistry())
+        pipelines = parse_pipeline_docs(text, SchemaRegistry())
     except PipelineParseError as exc:
         return None, f"malformed pipeline file {path}: {exc}"
-    return pipeline, ""
+    return pipelines, ""
 
 
 def _find_sole_yaml(directory: Path) -> "Path | None":
@@ -136,11 +140,12 @@ async def handle(
 ) -> dict:
     """Execute a pipeline_install op — register a local or source-fetched pipeline.
 
-    Local path (``op.source is None``): parses the DSL at ``op.path``, resolves
-    + validates the registration name against the DSL's own declared
-    ``pipeline:`` name, threat-scans the description, gates the config write,
-    persists the entry, records a config generation for crash-recovery, emits
-    an audit event, and requests a hot-reload.
+    Local path (``op.source is None``): parses the DSL at ``op.path`` (one or
+    more ``pipeline:`` documents — #2722), resolves the namespace key (``op.name``
+    or the file stem; ``.`` reserved), threat-scans every description, gates the
+    config write, persists the entry, records a config generation for
+    crash-recovery, emits an audit event (enumerating all ``{key}.{name}`` global
+    names registered — H6), and requests a hot-reload.
 
     Source/git path (``op.source`` set): additionally gates the source host
     via ``require_http_get`` and shallow-clones the repo before the same
@@ -264,9 +269,9 @@ async def handle(
             }
         install_path = str(dsl_path.resolve())
 
-    # ── 2. Parse the DSL (validation step) ────────────────────────────────────
-    pipeline, parse_err = _parse_pipeline_file(dsl_path)
-    if pipeline is None:
+    # ── 2. Parse the DSL (validation step) — a file may hold N pipelines (#2722)
+    pipelines, parse_err = _parse_pipeline_file(dsl_path)
+    if pipelines is None:
         if op.source:
             shutil.rmtree(clone_dest, ignore_errors=True)
         return {
@@ -277,16 +282,25 @@ async def handle(
             "error": parse_err,
         }
 
-    declared_name = pipeline.name
-    description = pipeline.description or ""
+    # The config entry's description is metadata surfaced alongside the namespace
+    # in the catalog — use the first document's (the file's own summary).
+    description = pipelines[0].description or ""
 
-    # ── 3. Resolve + validate the registration name ───────────────────────────
-    # The DSL's own declared `pipeline:` name is ALWAYS the resolution key a
-    # call/match step resolves against — unlike skill, op.name cannot rename
-    # the registered identity. A caller-supplied op.name that disagrees with
-    # the DSL is a footgun (config key != resolution key) and is refused
-    # rather than silently allowed to diverge.
-    if op.name and op.name.strip() != declared_name:
+    # ── 3. Resolve the registration namespace KEY (#2722) ─────────────────────
+    # The config entry key IS the namespace label — every pipeline in the file
+    # registers as `{key}.{declared-name}`. The old `op.name == declared-name`
+    # coupling is GONE: the key no longer must equal any declared pipeline name.
+    # For a source install the key was derived pre-clone (`_candidate_name`); for
+    # a local install it is `op.name` or the DSL file stem.
+    if op.source:
+        name = _candidate_name
+    else:
+        name = (op.name or "").strip() or dsl_path.stem
+
+    # #2722 R1: '.' is RESERVED as the namespace separator — reject it in the key
+    # (stricter than _safe_name_component, which permits an interior '.'). A key
+    # with a '.' would make the derived global name '<key>.<doc>' ambiguous.
+    if "." in name:
         if op.source:
             shutil.rmtree(clone_dest, ignore_errors=True)
         return {
@@ -295,20 +309,16 @@ async def handle(
             "path": op.path,
             "source": op.source or "",
             "error": (
-                f"name mismatch: op.name={op.name!r} does not match the DSL's "
-                f"declared pipeline name {declared_name!r}. The declared 'pipeline:' "
-                "name is the authoritative identity a call/match step resolves "
-                "against, so the config key must match it exactly — pass no "
-                "'name' override, or fix the DSL's 'pipeline:' key."
+                f"invalid pipeline namespace key {name!r}: '.' is reserved as the "
+                "namespace separator (registered names are '<key>.<pipeline-name>'). "
+                "Choose a 'name' with no '.'."
             ),
         }
-    name = declared_name
 
-    # SECURITY: sanitize the resolved name BEFORE it is used as a config key OR
-    # (for source installs) a filesystem path component. The DSL's `pipeline:`
-    # name is third-party content for a source install — a malicious
-    # `pipeline: ../../../evil` would escape .reyn/pipelines/ at the rename step
-    # (path-traversal → arbitrary rmtree).
+    # SECURITY: sanitize the key BEFORE it is used as a config key OR (for source
+    # installs) a filesystem path component. For a source install the key derives
+    # from an attacker-influenced URL basename — a malicious name would escape
+    # .reyn/pipelines/ (path-traversal → arbitrary rmtree).
     safe_name = _safe_name_component(name)
     if safe_name is None:
         if op.source:
@@ -320,42 +330,29 @@ async def handle(
             "source": op.source or "",
             "error": (
                 f"invalid pipeline name {name!r}. The name must be a single path "
-                "component (letters, digits, '.', '_', '-'; no '/', '\\', '..', or "
-                "leading '.'). Fix the DSL's 'pipeline:' key."
+                "component (letters, digits, '_', '-'; no '.', '/', '\\', '..', or "
+                "leading '.'). Pass a safe 'name'."
             ),
         }
 
-    # For source installs: if the resolved name differs from the candidate we used
-    # for the clone destination, rename the clone dir to the resolved name.
-    if op.source and name != _candidate_name:
-        new_dest = _pipelines_root / name
-        # SECURITY: containment check BEFORE any rmtree/rename — refuse if new_dest
-        # escapes .reyn/pipelines/ even after sanitization (guards a sanitizer gap).
-        if not _contained_under(new_dest, _pipelines_root):
-            shutil.rmtree(clone_dest, ignore_errors=True)
-            return {
-                "kind": "pipeline_install",
-                "status": "error",
-                "source": op.source or "",
-                "error": (
-                    f"refused: install destination for {name!r} escapes .reyn/pipelines/. "
-                    "This is a path-containment violation."
-                ),
-            }
-        if new_dest.exists():
-            shutil.rmtree(new_dest)
-        # Preserve the relative position of the DSL file inside the clone.
-        rel_dsl = dsl_path.relative_to(clone_dest)
-        clone_dest.rename(new_dest)
-        clone_dest = new_dest
-        dsl_path = new_dest / rel_dsl
-        install_path = str(dsl_path.resolve())
+    # #2722 H6: the FULL set of global names this install registers — every
+    # `pipeline:` document in the file, namespaced under the key. Enumerated in
+    # the approval-visible result + the audit event so approving one op.name
+    # never silently registers extra pipelines behind the operator's back.
+    registered_names = [f"{safe_name}.{p.name}" for p in pipelines]
 
-    # ── 4. Threat-scan the description (scope="strict") ──────────────────────
+    # ── 4. Threat-scan EVERY pipeline's description (scope="strict") ──────────
+    # A multi-doc file has N author-written descriptions; each is untrusted
+    # free-text (esp. for a source install) — scan them all, block on any match.
     _ts = getattr(ctx, "threat_scan", None)
-    if _ts is not None and getattr(_ts, "enabled", False) and description:
-        _matches = scan_for_threats(description, _ts, scope="strict")
-        if _matches:
+    if _ts is not None and getattr(_ts, "enabled", False):
+        for _p in pipelines:
+            _desc = _p.description or ""
+            if not _desc:
+                continue
+            _matches = scan_for_threats(_desc, _ts, scope="strict")
+            if not _matches:
+                continue
             for _m in _matches:
                 ctx.events.emit(
                     "pipeline_install_threat_match",
@@ -383,8 +380,8 @@ async def handle(
                     "source": op.source or "",
                     "path": install_path,
                     "error": (
-                        f"install blocked: pipeline description matched threat "
-                        f"pattern '{_block.pattern_id}' "
+                        f"install blocked: pipeline {_p.name!r} description matched "
+                        f"threat pattern '{_block.pattern_id}' "
                         f"({_block.scope}/{_block.severity}). The description "
                         f"contains a prohibited pattern. Do not install this pipeline."
                     ),
@@ -428,6 +425,7 @@ async def handle(
     ctx.events.emit(
         "pipeline_installed",
         name=safe_name,
+        registered_names=registered_names,
         path=install_path,
         description=description,
         config_path=str(config_path),
@@ -451,6 +449,7 @@ async def handle(
     return {
         "status": "installed",
         "name": safe_name,
+        "registered_names": registered_names,
         "path": install_path,
         "description": description,
         "config_path": str(config_path),

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -70,11 +70,30 @@ parsed from another as long as the same registry is passed to both.
 A DSL text is one or more YAML documents (``---``-separated). Each document
 is classified as a ``schema:`` document or a ``pipeline:`` document by its
 top-level key; a text may mix both (schemas typically precede the pipeline
-that references them). Exactly one ``pipeline:`` document must be present in
-a call to :func:`parse_pipeline_dsl` — a file with zero or more than one is a
-parse error (unambiguous "what did I just parse" contract for the registry
-caller populating a :class:`~reyn.core.pipeline.registry.PipelineRegistry`
-from one file per pipeline).
+that references them). A text may hold **multiple** ``pipeline:`` documents
+(#2722 — a file's private helper pipelines co-located with the entry point):
+
+  - :func:`parse_pipeline_docs` returns **all** ``pipeline:`` documents in the
+    text as a ``list[Pipeline]`` (at least one — zero is still a parse error).
+    Two documents declaring the SAME ``pipeline:`` name is a parse error
+    (#2722 R2 — the intra-file duplicate-name check). This is the entry point
+    the config loader (:mod:`reyn.data.pipelines.registry`) and the
+    ``pipeline_install`` op use.
+  - :func:`parse_pipeline_dsl` is the **single-document** contract: it calls
+    :func:`parse_pipeline_docs` and requires exactly one ``pipeline:`` document,
+    returning that sole :class:`Pipeline`. Used where a text is inherently one
+    pipeline — ``run_pipeline_inline`` ("run THIS one now") and programmatic
+    single-pipeline parse.
+
+This parser is **config-agnostic**: it parses the declared ``pipeline:`` names
+and ``call``/``match`` targets VERBATIM (bare names as authored) and never sees
+the config entry key that a namespaced registration derives from. The
+``{entry-key}.{local-name}`` prefixing — and the "a dot-less ``call`` target
+must resolve to a same-file sibling" rule (#2722) — belong to the loader, which
+owns the entry key (H4). The parser's one naming rule is #2722 **R1**: a ``.``
+is reserved as the namespace separator, so a declared ``pipeline:`` name
+containing ``.`` is a parse error (the config entry key is R1-checked separately
+by the loader).
 """
 from __future__ import annotations
 
@@ -101,7 +120,7 @@ from reyn.core.pipeline.expr import ExprParseError
 from reyn.core.pipeline.expr import parse as parse_expr
 from reyn.core.pipeline.schema import SchemaRegistry
 
-__all__ = ["PipelineParseError", "parse_pipeline_dsl"]
+__all__ = ["PipelineParseError", "parse_pipeline_dsl", "parse_pipeline_docs"]
 
 
 class PipelineParseError(ValueError):
@@ -657,6 +676,17 @@ def _parse_pipeline_doc(doc: "dict[str, Any]") -> Pipeline:
     name = doc.get("pipeline")
     if not isinstance(name, str) or not name:
         _fail("pipeline document: 'pipeline' must be a non-empty name string")
+    if "." in name:
+        # #2722 R1: '.' is RESERVED as the namespace separator — a global
+        # registered name is '<entry-key>.<local-name>', so a declared name may
+        # never contain a '.' (it would alias a qualified cross-file reference
+        # and break the dot/no-dot resolution dichotomy). Fail loud at parse.
+        _fail(
+            f"pipeline name {name!r} contains a reserved '.' — '.' is the "
+            "namespace separator (a registered pipeline's global name is "
+            "'<entry-key>.<local-name>'); a declared 'pipeline:' name must not "
+            "contain it"
+        )
     description = doc.get("description", "")
     if not isinstance(description, str):
         _fail(f"pipeline {name!r}: 'description' must be a string, got {type(description).__name__}")
@@ -681,15 +711,29 @@ def _parse_schema_doc(doc: "dict[str, Any]", schema_registry: SchemaRegistry) ->
     schema_registry.register(name, {"fields": fields})
 
 
-def parse_pipeline_dsl(text: str, schema_registry: SchemaRegistry) -> Pipeline:
-    """Parse `text` (one or more `---`-separated YAML documents) into exactly
-    one `Pipeline`. Any `schema:`-keyed document found is registered into
-    `schema_registry` (mutated in place — the caller passes the SAME
-    registry to `PipelineExecutor.run`/`resume` so `schema: REF` references
-    resolve). Raises `PipelineParseError` for malformed YAML, a malformed R1
-    expression, any construct outside the linear executor's current scope
-    (see module docstring), or a text with zero or more than one `pipeline:`
-    document."""
+def parse_pipeline_docs(
+    text: str, schema_registry: SchemaRegistry
+) -> "list[Pipeline]":
+    """Parse `text` (one or more `---`-separated YAML documents) into a LIST of
+    `Pipeline`s — one per `pipeline:` document, in document order (#2722). Any
+    `schema:`-keyed document found is registered into `schema_registry` (mutated
+    in place — the caller passes the SAME registry to `PipelineExecutor.run`/
+    `resume` so `schema: REF` references resolve; every parsed pipeline shares
+    this one registry).
+
+    At least one `pipeline:` document must be present (zero is a parse error).
+    Two `pipeline:` documents declaring the SAME name is a parse error (#2722
+    R2 — the intra-file duplicate-name check; both would otherwise claim the
+    same `{entry-key}.{name}` global name). Raises `PipelineParseError` for
+    malformed YAML, a malformed R1 expression, a declared name containing the
+    reserved `.` (#2722 R1), any construct outside the linear executor's current
+    scope (see module docstring), a text with zero `pipeline:` documents, or an
+    intra-file duplicate declared name.
+
+    This function is CONFIG-AGNOSTIC (H4): it returns pipelines under their bare
+    declared names and leaves `call`/`match` targets verbatim. Namespacing
+    (`{entry-key}.{local-name}`) and the sibling-resolution of dot-less targets
+    are the loader's job (it owns the entry key)."""
     try:
         raw_docs = list(yaml.load_all(text, Loader=_PipelineLoader))
     except yaml.YAMLError as exc:
@@ -718,8 +762,37 @@ def parse_pipeline_dsl(text: str, schema_registry: SchemaRegistry) -> Pipeline:
                 f"key, got keys {sorted(doc)!r}"
             )
 
-    if len(pipeline_docs) != 1:
+    if not pipeline_docs:
+        _fail("expected at least one 'pipeline:' document, found 0")
+
+    pipelines = [_parse_pipeline_doc(d) for d in pipeline_docs]
+    # #2722 R2: intra-file duplicate declared-name check. Two docs claiming the
+    # same name would both map to `{entry-key}.{name}` — reject before the
+    # loader ever tries to register them.
+    seen: "set[str]" = set()
+    for pipeline in pipelines:
+        if pipeline.name in seen:
+            _fail(
+                f"duplicate 'pipeline:' name {pipeline.name!r} — two documents in "
+                "one DSL text may not declare the same name (each declared name "
+                "must be unique within the file)"
+            )
+        seen.add(pipeline.name)
+    return pipelines
+
+
+def parse_pipeline_dsl(text: str, schema_registry: SchemaRegistry) -> Pipeline:
+    """Parse `text` into exactly ONE `Pipeline` — the single-document contract.
+
+    A thin wrapper over :func:`parse_pipeline_docs` for the surfaces where a text
+    is inherently a single pipeline (``run_pipeline_inline`` — "run THIS one
+    now" — and programmatic single-pipeline parse). Raises `PipelineParseError`
+    (same failure set as :func:`parse_pipeline_docs`) plus a text with MORE than
+    one `pipeline:` document (this contract is single-doc; use
+    :func:`parse_pipeline_docs` for a multi-pipeline file)."""
+    pipelines = parse_pipeline_docs(text, schema_registry)
+    if len(pipelines) != 1:
         _fail(
-            f"expected exactly one 'pipeline:' document, found {len(pipeline_docs)}"
+            f"expected exactly one 'pipeline:' document, found {len(pipelines)}"
         )
-    return _parse_pipeline_doc(pipeline_docs[0])
+    return pipelines[0]

--- a/src/reyn/data/pipelines/registry.py
+++ b/src/reyn/data/pipelines/registry.py
@@ -12,20 +12,38 @@ Unlike skills (explicit ``entries`` config, metadata only, never parses the
 file), a pipeline must be PARSED to be usable — the ``PipelineRegistry`` stores
 live ``Pipeline`` objects and surfaces their name+description to the LLM (IS-5's
 D19 catalog enumerator). So this loader parses each entry's ``path`` via
-:func:`~reyn.core.pipeline.parser.parse_pipeline_dsl` and registers the result
-under the pipeline's OWN declared ``pipeline:`` name (``Pipeline.name``) —
-authoritative because that is the identity a ``call``/``match`` step's
-``pipeline: LIT`` resolves against, NOT the config entry's key. A config entry
-key that disagrees with its file's declared name is a footgun (the key you'd
-naturally look for is not the key a `call` step actually resolves against) —
-this loader refuses that mismatch (same posture as the install op's op.name vs
-declared-name check in ``op_runtime/pipeline_install.py``).
+:func:`~reyn.core.pipeline.parser.parse_pipeline_docs` (a file may hold MORE
+than one ``pipeline:`` document — #2722) and registers EVERY parsed pipeline.
+
+**Namespacing is ALWAYS ON (#2722).** A registered pipeline's global name is
+uniformly ``{entry-key}.{local-name}`` — for every pipeline, regardless of how
+many ``pipeline:`` documents the file holds. The config entry key is PURELY a
+namespace label; it no longer needs to equal any pipeline's declared name (the
+old ``key == declared-name`` coupling is gone). A single-``pipeline:`` file
+under ``entries: {orders: {path}}`` whose doc is ``pipeline: main`` registers as
+``orders.main`` — there is no bare-name registration anywhere.
+
+``call``/``match`` target resolution is a clean dot/no-dot dichotomy (#2722),
+applied HERE (the loader owns the entry key; the parser stays config-agnostic —
+H4):
+
+  - a **dot-less** target (``call: {pipeline: helper}``) is a same-file SIBLING
+    reference — it resolves to ``{entry-key}.helper``. An unresolved sibling (no
+    ``pipeline:`` doc named ``helper`` in the same file) is a load-time error
+    (fail-loud; NO silent fallback to some unrelated global).
+  - a **dotted** target (``call: {pipeline: other.helper}``) is a GLOBAL
+    reference — left unchanged, resolved against the whole registry at run time.
+
+Because ``.`` is reserved in both declared names and entry keys (#2722 R1 — a
+dot-less name has 0 dots, a global has exactly 1), dot-presence alone
+classifies a reference with no ambiguity.
 
 Failure posture is PER-ENTRY ISOLATED, not process-fatal: a malformed DSL file,
-an unreadable path, a config-key / declared-name mismatch, or a duplicate
-declared name across entries are each caught INSIDE the ``entries`` loop —
-logged as a Python ``logging`` warning AND durably emitted as a
-``pipeline_load_failed`` P6 event (via ``emit_cli_event`` — see its own
+an unreadable path, an entry key containing the reserved ``.`` (R1), an
+unresolved dot-less sibling reference, an intra-file duplicate declared name
+(R2), or a duplicate global name across entries are each caught INSIDE the
+``entries`` loop — logged as a Python ``logging`` warning AND durably emitted as
+a ``pipeline_load_failed`` P6 event (via ``emit_cli_event`` — see its own
 docstring; this loader has no per-session ``ctx``/``EventLog`` handle threaded
 in, and is called from multiple distinct entrypoints, so the session-independent
 sink is the right fit), then SKIPPED — the remaining entries still load. This
@@ -39,10 +57,11 @@ carry the exact same descriptive message the old raise would have) — this is
 NOT the fully-silent ``skills.registry`` pattern (a typo must not silently
 vanish with zero trace); it is "visible but non-fatal".
 
-Duplicate declared name across entries: the FIRST-registered entry with that
-name wins; a later entry that collides is the one skipped/logged (dict
-iteration order = config declaration order — the first entry an operator
-listed keeps its registration).
+Duplicate GLOBAL name across entries (``{entry-key}.{local-name}`` collision —
+possible only if two entries share the same key, or a namespaced name coincides
+with another): the FIRST-registered entry with that name wins; a later entry
+that collides is the one skipped/logged (dict iteration order = config
+declaration order — the first entry an operator listed keeps its registration).
 
 ``raw_pipelines=None`` (the util/no-root path) → an empty registry; an
 empty/absent ``pipelines:`` block or an empty ``entries`` map → an empty
@@ -79,8 +98,9 @@ logger = logging.getLogger(__name__)
 
 class PipelineLoadError(ValueError):
     """A ``pipelines.entries`` declaration could not be loaded (unreadable file,
-    malformed DSL, a duplicate declared name, or a config-key / declared-name
-    mismatch). Raised internally by :func:`_load_one_entry` and caught PER-ENTRY
+    malformed DSL, a reserved ``.`` in the entry key, an unresolved dot-less
+    sibling reference, or a duplicate global name). Raised internally by
+    :func:`_load_one_entry` and caught PER-ENTRY
     by :func:`build_pipeline_registry` (logged + durably emitted as a
     ``pipeline_load_failed`` event, then the entry is skipped — see the module
     docstring). Still importable/raisable directly by callers that want the
@@ -95,17 +115,119 @@ def _entry_path(project_root: Path, raw_path: str) -> Path:
     return p if p.is_absolute() else (project_root / p)
 
 
+def _resolve_ref(target: str, key: str, siblings: "set[str]", *, where: str) -> str:
+    """Resolve a single ``call``/``match`` target under the ``{key}.`` namespace
+    (#2722, the loader-side dot/no-dot dichotomy — H4).
+
+    - A **dotted** target (``other.helper``) is a GLOBAL reference — returned
+      unchanged (resolved against the whole registry at run time).
+    - A **dot-less** target (``helper``) is a same-file SIBLING reference — it
+      must match a sibling ``pipeline:`` doc name in ``siblings`` and is rewritten
+      to ``f"{key}.{helper}"``. An unresolved sibling raises
+      :class:`PipelineLoadError` (fail-loud; there is NO bare global to fall back
+      to under uniform namespacing)."""
+    if "." in target:
+        return target
+    if target not in siblings:
+        raise PipelineLoadError(
+            f"{where}: dot-less call/match target {target!r} does not match any "
+            f"sibling pipeline in the same file (siblings: {sorted(siblings)!r}) "
+            "— a dot-less target resolves to a same-file sibling only; use "
+            "'<entry-key>.<name>' to target a pipeline registered from another entry"
+        )
+    return f"{key}.{target}"
+
+
+def _namespace_step(step: object, key: str, siblings: "set[str]", *, where: str) -> object:
+    """Recursively rewrite every ``call``/``match`` target inside ``step`` under
+    the ``{key}.`` namespace (#2722). Walks the full step tree — a target can be
+    nested in a ``fold.do``, a ``for_each.do``/``collect``, or a
+    ``parallel`` branch/``collect``, arbitrarily deep. Frozen dataclasses are
+    rebuilt via :func:`dataclasses.replace`; linear steps (transform/tool/agent —
+    no pipeline reference) pass through unchanged."""
+    from dataclasses import replace
+
+    from reyn.core.pipeline.executor import (
+        CallStep,
+        FoldStep,
+        ForEachStep,
+        MatchStep,
+        ParallelStep,
+    )
+
+    if isinstance(step, CallStep):
+        return replace(step, pipeline=_resolve_ref(step.pipeline, key, siblings, where=where))
+    if isinstance(step, MatchStep):
+        new_cases = {
+            label: replace(
+                case,
+                pipeline=_resolve_ref(
+                    case.pipeline, key, siblings, where=f"{where} match case {label!r}"
+                ),
+            )
+            for label, case in step.cases.items()
+        }
+        new_default = (
+            replace(
+                step.default,
+                pipeline=_resolve_ref(
+                    step.default.pipeline, key, siblings, where=f"{where} match default"
+                ),
+            )
+            if step.default is not None
+            else None
+        )
+        return replace(step, cases=new_cases, default=new_default)
+    if isinstance(step, FoldStep):
+        return replace(step, do=_namespace_step(step.do, key, siblings, where=where))
+    if isinstance(step, ForEachStep):
+        return replace(
+            step,
+            do=_namespace_step(step.do, key, siblings, where=where),
+            collect=_namespace_step(step.collect, key, siblings, where=where),
+        )
+    if isinstance(step, ParallelStep):
+        return replace(
+            step,
+            branches={
+                name: _namespace_step(branch, key, siblings, where=where)
+                for name, branch in step.branches.items()
+            },
+            collect=_namespace_step(step.collect, key, siblings, where=where),
+        )
+    return step
+
+
+def _namespace_pipeline(pipeline: object, key: str, siblings: "set[str]") -> object:
+    """Return a copy of ``pipeline`` namespaced under ``key`` (#2722): its
+    declared name becomes ``f"{key}.{name}"`` and every ``call``/``match`` target
+    in its step tree is resolved via :func:`_namespace_step` (dot-less siblings
+    prefixed with ``{key}.``, dotted globals left as-is). Raises
+    :class:`PipelineLoadError` for an unresolved dot-less sibling reference."""
+    from dataclasses import replace
+
+    where = f"pipeline {pipeline.name!r}"  # type: ignore[attr-defined]
+    new_steps = [
+        _namespace_step(step, key, siblings, where=f"{where} step {i}")
+        for i, step in enumerate(pipeline.steps)  # type: ignore[attr-defined]
+    ]
+    return replace(pipeline, name=f"{key}.{pipeline.name}", steps=new_steps)  # type: ignore[attr-defined]
+
+
 def _load_one_entry(
     key: str, raw: dict, project_root: "Path", registry: PipelineRegistry,
 ) -> None:
-    """Load + register ONE ``pipelines.entries.<key>`` declaration.
+    """Load + register ONE ``pipelines.entries.<key>`` declaration (#2722:
+    a file may hold multiple ``pipeline:`` documents — ALL are registered,
+    each under the uniform ``{key}.{local-name}`` namespace).
 
     Raises :class:`PipelineLoadError` for:
+      - a config entry key containing the reserved ``.`` (#2722 R1),
       - a missing ``path``,
       - an unreadable / malformed DSL file (path included),
-      - a config entry key that disagrees with its file's declared
-        ``pipeline:`` name,
-      - a duplicate declared name across entries.
+      - an intra-file duplicate declared name (#2722 R2, surfaced by the parser),
+      - an unresolved dot-less sibling ``call``/``match`` reference (#2722),
+      - a duplicate GLOBAL name across entries.
 
     Callers (:func:`build_pipeline_registry`) catch this per-entry — see the
     module docstring for the visible-but-non-fatal posture. This function
@@ -114,8 +236,18 @@ def _load_one_entry(
     """
     # Deferred import: parser pulls the pipeline executor/schema stack, which is
     # heavier than this loader's own surface — keep module import cheap.
-    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+    from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_docs
     from reyn.core.pipeline.schema import SchemaRegistry
+
+    # #2722 R1: '.' is RESERVED as the namespace separator — a config entry key
+    # is the namespace label, so a key containing '.' would make the derived
+    # global name ambiguous ('a.b' + doc 'c' -> 'a.b.c', two dots). Fail loud.
+    if "." in key:
+        raise PipelineLoadError(
+            f"pipelines.entries.{key!r}: a config entry key must not contain "
+            "'.' — '.' is the namespace separator (a registered pipeline's "
+            "global name is '<entry-key>.<pipeline-name>')."
+        )
 
     raw_path = str(raw.get("path") or "").strip()
     if not raw_path:
@@ -132,42 +264,43 @@ def _load_one_entry(
             f"pipelines.entries.{key!r}: could not read {path}: {exc}"
         ) from exc
 
+    # One SchemaRegistry per FILE, shared by every pipeline parsed from it — a
+    # `schema:` document in the file serves every sibling pipeline (#2722).
     schema_registry = SchemaRegistry()
     try:
-        pipeline = parse_pipeline_dsl(text, schema_registry)
+        pipelines = parse_pipeline_docs(text, schema_registry)
     except PipelineParseError as exc:
+        # Covers malformed DSL, a declared name with a reserved '.' (R1), and an
+        # intra-file duplicate declared name (R2).
         raise PipelineLoadError(
             f"pipelines.entries.{key!r}: malformed pipeline file {path}: {exc}"
         ) from exc
 
-    name = pipeline.name
-    if not name:
-        # parse_pipeline_dsl requires a non-empty ``pipeline:`` name, so
-        # this is defensive — a hand-built Pipeline with no name has no
-        # key to register under.
-        raise PipelineLoadError(
-            f"pipelines.entries.{key!r}: file {path} produced a pipeline "
-            "with no declared name — a 'pipeline:' name is required."
-        )
-    if name != key:
-        raise PipelineLoadError(
-            f"pipelines.entries.{key!r} declares path {path} whose DSL "
-            f"'pipeline:' name is {name!r} — the config entry key must "
-            "match the DSL's declared name exactly (the declared name is "
-            "the authoritative key a call/match step resolves against; a "
-            "divergent config key is a silent footgun, not a rename)."
-        )
+    # Sibling-name set for dot-less `call`/`match` resolution (#2722).
+    siblings = {p.name for p in pipelines}
 
-    try:
-        registry.register(name, pipeline, schema_registry)
-    except ValueError as exc:
-        # Duplicate declared name across entries — the registry's own
-        # re-registration guard. First-registered entry keeps the name; this
-        # (later) entry is the one that fails.
-        raise PipelineLoadError(
-            f"pipelines.entries.{key!r}: file {path} declares name {name!r} "
-            f"which is already registered by an earlier entry: {exc}"
-        ) from exc
+    for pipeline in pipelines:
+        if not pipeline.name:
+            # parse_pipeline_docs requires a non-empty ``pipeline:`` name, so
+            # this is defensive — a nameless Pipeline has no key to register under.
+            raise PipelineLoadError(
+                f"pipelines.entries.{key!r}: file {path} produced a pipeline "
+                "with no declared name — a 'pipeline:' name is required."
+            )
+        # Namespace: prefix the declared name AND every resolved dot-less sibling
+        # ref with `{key}.` (raises PipelineLoadError for an unresolved sibling).
+        namespaced = _namespace_pipeline(pipeline, key, siblings)
+        try:
+            registry.register(namespaced.name, namespaced, schema_registry)
+        except ValueError as exc:
+            # Duplicate GLOBAL name across entries — the registry's own
+            # re-registration guard. First-registered entry keeps the name; this
+            # (later) entry is the one that fails.
+            raise PipelineLoadError(
+                f"pipelines.entries.{key!r}: file {path} registers name "
+                f"{namespaced.name!r} which is already registered by an earlier "
+                f"entry: {exc}"
+            ) from exc
 
 
 def build_pipeline_registry(
@@ -178,9 +311,10 @@ def build_pipeline_registry(
 
     For each ``pipelines.entries.<key>`` declaration, ``path`` is resolved
     (project-root-relative or absolute), read, and parsed via
-    ``parse_pipeline_dsl`` into a ``Pipeline`` + its own ``SchemaRegistry`` (so a
-    registered pipeline's ``verify: schema`` steps resolve), then registered
-    under the pipeline's declared ``pipeline:`` name.
+    ``parse_pipeline_docs`` into one-or-more ``Pipeline``s + a shared
+    ``SchemaRegistry`` (so a registered pipeline's ``verify: schema`` steps
+    resolve), then EVERY parsed pipeline is registered under the uniform
+    ``{key}.{local-name}`` namespace (#2722).
 
     ``raw_pipelines=None`` → an empty registry (the util/no-root path). An
     empty/absent ``pipelines:`` block, or a ``pipelines:`` block with no
@@ -189,14 +323,15 @@ def build_pipeline_registry(
     cases return before the per-entry loop even starts — they describe an
     absent config shape, not a failure, so nothing is logged.
 
-    This function itself never raises for a per-entry failure. A missing
-    ``path``, an unreadable / malformed DSL file, a config-key / declared-name
-    mismatch, or a duplicate declared name are each caught PER ENTRY (via
+    This function itself never raises for a per-entry failure. A reserved-``.``
+    entry key (R1), a missing ``path``, an unreadable / malformed DSL file, an
+    intra-file duplicate declared name (R2), an unresolved dot-less sibling
+    reference, or a duplicate global name are each caught PER ENTRY (via
     :func:`_load_one_entry` raising :class:`PipelineLoadError`), logged as a
     ``logging`` warning, durably emitted as a ``pipeline_load_failed`` P6
     event (``reyn.core.events.events.emit_cli_event`` — see the module
     docstring for why this sink), and then skipped — the remaining entries
-    still load normally. A duplicate declared name resolves first-registered-
+    still load normally. A duplicate global name resolves first-registered-
     wins: the later entry is the one logged/skipped.
     """
     from reyn.core.events.events import emit_cli_event

--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -175,9 +175,10 @@ def register(sub) -> None:
         default=None,
         metavar="NAME",
         help=(
-            "Optional override — must match the DSL's declared 'pipeline:' "
-            "name exactly, or the install is refused (the declared name is "
-            "always the identity a call/match step resolves against)."
+            "Optional namespace key for the entry (default: the DSL file "
+            "stem, or the source basename). Every pipeline in the file "
+            "registers as '<name>.<declared-pipeline-name>'. Must not "
+            "contain '.' (the reserved namespace separator)."
         ),
     )
     install.add_argument(
@@ -203,7 +204,10 @@ def register(sub) -> None:
     run_p.add_argument(
         "name",
         metavar="NAME",
-        help="Registered pipeline name (its declared 'pipeline:' name)",
+        help=(
+            "Registered pipeline's fully-qualified name "
+            "'<entry-key>.<declared-pipeline-name>' (see `reyn pipe list`)."
+        ),
     )
     run_p.add_argument(
         "--input",
@@ -261,12 +265,15 @@ def run_list(args: argparse.Namespace) -> None:
     union-merge invariant ``mcp.py``'s ``_all_servers_with_scope`` hand-rolls
     for ``mcp.servers`` — see ``loader.py``'s ``pipelines`` merge branch —
     so this reuses ``load_config()`` rather than re-deriving that cascade a
-    second time) and checks, per ENABLED entry, whether its declared name
-    landed in the registry. An entry that is ``enabled: true`` but did NOT
-    load (malformed DSL, unreadable path, config-key / declared-name
-    mismatch, or a duplicate declared name — #2641's per-entry-isolation
-    posture) shows FAILED here, so ``reyn pipe list`` is a first-class way
-    to SEE load failures without digging through dogfood_trace/logs.
+    second time) and checks, per ENABLED entry, whether any pipeline landed
+    in the registry under that entry's ``{key}.`` namespace (#2722 —
+    namespacing is always on, so a healthy entry registers one or more
+    ``{key}.{declared-name}`` globals). An entry that is ``enabled: true`` but
+    registered NOTHING (malformed DSL, unreadable path, a reserved ``.`` in the
+    key, or an unresolved dot-less sibling reference — #2641's
+    per-entry-isolation posture) shows FAILED here, so ``reyn pipe list`` is a
+    first-class way to SEE load failures without digging through
+    dogfood_trace/logs.
     """
     from reyn.config import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
@@ -304,7 +311,8 @@ def run_list(args: argparse.Namespace) -> None:
         enabled = bool(raw.get("enabled", True))
         if not enabled:
             status = "disabled"
-        elif key in loaded_names:
+        elif any(n == key or n.startswith(f"{key}.") for n in loaded_names):
+            # #2722: a healthy entry registers under the `{key}.` namespace.
             status = "loaded"
         else:
             status = "FAILED"

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -413,18 +413,16 @@ class PipelineInstallIROp(BaseModel):
       required when the repo root/subdir contains more than one candidate),
       and registers the installed copy's path.
 
-    ``name`` resolution: the pipeline DSL's own declared ``pipeline:`` name is
-    ALWAYS the registration identity (the key a ``call``/``match`` step
-    resolves against) — unlike skill, where the config key IS the identity.
-    When ``name`` is supplied it must match the DSL's declared ``pipeline:``
-    name; a mismatch is refused (``status="error"``) rather than silently
-    diverging the config key from the resolution key. When omitted, the
-    config key defaults to the DSL's declared name.
+    ``name`` resolution (#2722): ``name`` is a free NAMESPACE KEY (like skill),
+    NOT coupled to any declared ``pipeline:`` name. Every ``pipeline:`` document
+    in the file registers under ``{name}.{declared-name}``. ``.`` is reserved
+    (the namespace separator) and rejected in ``name``. When omitted, the key
+    defaults to the DSL file stem (or the source basename for a git install).
     """
     kind: Literal["pipeline_install"]
     path: str = ""                              # local DSL *.yaml file (ignored when source set; also selects the file inside a cloned source repo)
     scope: str = ".reyn/config/pipelines.yaml"   # target config file (no-op tier arg, forward-compat with mcp_install's `scope`)
-    name: str | None = None                      # must match the DSL's declared `pipeline:` name when set
+    name: str | None = None                      # free namespace key (#2722); no '.'; defaults to the DSL file stem
     # When set, the pipeline DSL is fetched from this git/GitHub URL (mirrors SkillInstallIROp.source).
     # Supports optional subdir via "//": "https://github.com/user/repo" (root) or
     # "https://github.com/user/repo//pipelines/my-pipeline" (pipelines/my-pipeline subdir).

--- a/src/reyn/tools/pipeline_management_verbs.py
+++ b/src/reyn/tools/pipeline_management_verbs.py
@@ -35,14 +35,14 @@ from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 _PIPELINE_INSTALL_LOCAL_DESCRIPTION = (
     "Register a local pipeline DSL file into the project config "
     "by writing an entry to .reyn/config/pipelines.yaml. The pipeline is "
-    "immediately available to sessions (as pipeline__<name> and run_pipeline) "
-    "after the next hot-reload. Pass the direct path to the pipeline's *.yaml "
-    "DSL file (unlike skill, a pipeline registration is always exactly one "
-    "file — there is no directory resolution). "
-    "Use 'name' to make the intended registration name explicit; it must "
-    "match the DSL's own declared 'pipeline:' name exactly (a mismatch is "
-    "refused rather than silently allowed to diverge — the declared name is "
-    "the identity a call/match step resolves against)."
+    "immediately available to sessions (as pipeline__<key>.<name> and "
+    "run_pipeline) after the next hot-reload. Pass the direct path to the "
+    "pipeline's *.yaml DSL file (which may hold multiple '---'-separated "
+    "'pipeline:' documents). "
+    "Use 'name' to set the NAMESPACE KEY for the file; every pipeline in it "
+    "registers as '<name>.<declared-pipeline-name>'. 'name' need not match any "
+    "declared name and must not contain '.' (the reserved separator); it "
+    "defaults to the DSL file stem when omitted."
 )
 
 _PIPELINE_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
@@ -58,10 +58,10 @@ _PIPELINE_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
         "name": {
             "type": "string",
             "description": (
-                "Optional: the expected registration name. Must match the "
-                "DSL's own declared 'pipeline:' name exactly, or the install "
-                "is refused. When omitted, the config key defaults to the "
-                "DSL's declared name."
+                "Optional namespace key for the file. Every pipeline in it "
+                "registers as '<name>.<declared-pipeline-name>'. Need not "
+                "match any declared name; must not contain '.'. Defaults to "
+                "the DSL file stem when omitted."
             ),
         },
     },
@@ -132,8 +132,9 @@ _PIPELINE_INSTALL_SOURCE_DESCRIPTION = (
     "'https://github.com/user/repo//path/to/pipelines' (subdir form). "
     "Use 'path' to select the DSL file inside the clone when the repo/subdir "
     "contains more than one *.yaml file. "
-    "Use 'name' to make the intended registration name explicit; it must "
-    "match the DSL's own declared 'pipeline:' name exactly."
+    "Use 'name' to set the NAMESPACE KEY; every pipeline in the file registers "
+    "as '<name>.<declared-pipeline-name>'. 'name' need not match any declared "
+    "name and must not contain '.'; it defaults to the source basename."
 )
 
 _PIPELINE_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
@@ -159,9 +160,10 @@ _PIPELINE_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
         "name": {
             "type": "string",
             "description": (
-                "Optional: the expected registration name. Must match the "
-                "DSL's own declared 'pipeline:' name exactly, or the install "
-                "is refused."
+                "Optional namespace key. Every pipeline in the file registers "
+                "as '<name>.<declared-pipeline-name>'. Need not match any "
+                "declared name; must not contain '.'. Defaults to the source "
+                "basename."
             ),
         },
     },
@@ -180,7 +182,8 @@ async def _handle_pipeline_install_source(
       2. Shallow-clones the repo to .reyn/pipelines/<name>/.
       3. Locates + parses the DSL file from the clone (root or subdir via //;
          'path' selects it when ambiguous).
-      4. Validates the registration name against the DSL's declared name.
+      4. Resolves the namespace key (#2722: 'name' or the source basename;
+         every pipeline registers as '<key>.<declared-name>').
       5. Threat-scans the description (scope=strict; block on blocking match).
       6. Gates require_file_write for .reyn/config/pipelines.yaml.
       7. Writes the pipelines.yaml entry with the installed clone path + source URL.

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -7,18 +7,18 @@ build_pipeline_registry``): an operator declares ``pipelines.entries.<key>:
 {path: ...}`` in config (the SAME explicit-registration model as
 ``skills.entries`` / ``mcp.servers`` — clean break from an earlier
 directory-scan design; there is no ``scan_dirs`` / blind glob) and each
-declared entry is parsed + registered under its OWN declared ``pipeline:``
-name at session-factory time.
+declared entry is parsed + registered under the uniform ``{key}.{name}``
+namespace (#2722) at session-factory time.
 
 Coverage:
   1. Contract — the parser now carries the declared name on ``Pipeline.name``,
      and serde round-trips it (default-tolerant for pre-existing on-disk data).
-  2. Loader — config entries → registry keyed by the declared name; a config
-     key that disagrees with the DSL's declared name, a malformed file, a
-     missing path, or a duplicate declared name are each isolated PER ENTRY
-     (logged + durably emitted, the entry skipped, remaining entries still
-     load — see the follow-up bugfix in test_2639-style commit history: a
-     single broken entry must never crash session startup); empty → empty.
+  2. Loader — config entries → registry keyed by ``{entry-key}.{declared-name}``
+     (#2722: namespacing always on, the key is a pure label); a malformed file,
+     a missing path, or an unresolved dot-less sibling reference are each
+     isolated PER ENTRY (logged + durably emitted, the entry skipped, remaining
+     entries still load — a single broken entry must never crash session
+     startup); empty → empty.
   3. Wiring — ``from_config(config, project_root)`` builds the registry once;
      ``Session(pipeline_registry=)`` adopts it.
   4. Surfacing + invoke — a config-loaded pipeline surfaces as ``pipeline__<name>``
@@ -136,17 +136,17 @@ def test_pipeline_from_dict_defaults_name_when_absent() -> None:
 # ── 2. Loader: config entries → registry, keyed by declared name; fail-loud ───
 
 
-def test_loader_registers_pipeline_from_entry_under_declared_name(tmp_path: Path) -> None:
+def test_loader_registers_pipeline_from_entry_under_namespaced_name(tmp_path: Path) -> None:
     """Tier 2: a ``pipelines.entries.<key>`` declaration is parsed + registered
-    under its declared ``pipeline:`` name, with its name + description surfaced
-    via ``entries()`` (what the catalog enumerator reads)."""
+    under the uniform ``{key}.{declared-name}`` namespace (#2722), with its name +
+    description surfaced via ``entries()`` (what the catalog enumerator reads)."""
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
 
-    registry = build_pipeline_registry(_entries(("hello", "pipelines/hello.yaml")), tmp_path)
+    registry = build_pipeline_registry(_entries(("greetings", "pipelines/hello.yaml")), tmp_path)
 
-    assert set(registry.names()) == {"hello"}
-    assert registry.entries() == (("hello", "greet the seed name"),)
-    assert registry.get("hello").name == "hello"
+    assert set(registry.names()) == {"greetings.hello"}
+    assert registry.entries() == (("greetings.hello", "greet the seed name"),)
+    assert registry.get("greetings.hello").name == "greetings.hello"
 
 
 def test_loader_no_entries_yields_empty_registry(tmp_path: Path) -> None:
@@ -172,39 +172,35 @@ def test_loader_scan_dirs_key_is_ignored(tmp_path: Path) -> None:
 
 
 def test_loader_entry_path_may_use_any_filename(tmp_path: Path) -> None:
-    """Tier 2: an entry's ``path`` may point at any filename — the declared
-    ``pipeline:`` name (not the filename) is the registration identity, and the
-    entry key must match it (see the mismatch test below)."""
+    """Tier 2: an entry's ``path`` may point at any filename — neither the
+    filename nor the declared name has to equal the entry key; the global name is
+    ``{key}.{declared-name}`` (#2722)."""
     _write(tmp_path / "pipelines", "greet.yaml", _HELLO_DSL)  # file stem = "greet"
 
     registry = build_pipeline_registry(_entries(("hello", "pipelines/greet.yaml")), tmp_path)
 
-    assert set(registry.names()) == {"hello"}  # declared name, not "greet"
+    assert set(registry.names()) == {"hello.hello"}  # {key}.{declared}, not "greet"
 
 
-def test_loader_entry_key_declared_name_mismatch_is_skipped_not_fatal(
+def test_loader_entry_key_need_not_equal_declared_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: a config entry key that disagrees with the DSL's declared
-    ``pipeline:`` name is a footgun (a ``call`` step resolves the DECLARED
-    name, not the config key you'd naturally look for) — the entry is
-    skipped (not registered) and the failure is durably logged, but
-    ``build_pipeline_registry`` itself does NOT raise (regression: this used
-    to crash the whole session at startup — see the module docstring)."""
+    """Tier 2: #2722 — the ``key == declared-name`` coupling is GONE. A config
+    entry key that differs from the DSL's declared ``pipeline:`` name is fine:
+    the key is a pure namespace label, and the pipeline registers under the
+    ``{key}.{declared-name}`` global name (no error, no skip)."""
     reyn_dir = tmp_path / ".reyn"
     reyn_dir.mkdir()
     monkeypatch.chdir(tmp_path)
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)  # declares "hello"
 
     registry = build_pipeline_registry(
-        _entries(("mismatched-key", "pipelines/hello.yaml")), tmp_path,
+        _entries(("some_namespace", "pipelines/hello.yaml")), tmp_path,
     )
 
-    assert registry.names() == ()
-    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
-    [event] = events
-    assert event["data"]["key"] == "mismatched-key"
-    assert "hello" in event["data"]["error"]
+    assert set(registry.names()) == {"some_namespace.hello"}
+    # no failure was logged — a divergent key is no longer an error.
+    assert _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed") == []
 
 
 def test_loader_malformed_file_is_skipped_and_durably_logged(
@@ -249,20 +245,19 @@ def test_loader_broken_entry_does_not_prevent_valid_sibling_from_loading(
         tmp_path,
     )
 
-    assert set(registry.names()) == {"hello"}
+    assert set(registry.names()) == {"hello.hello"}
     events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
     [event] = events  # exactly one failure captured — unpack raises otherwise
     assert event["data"]["key"] == "broken"
 
 
-def test_loader_duplicate_declared_name_first_wins_second_skipped(
+def test_loader_same_declared_name_different_keys_both_register(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: two entries declaring the SAME ``pipeline:`` name (via distinct
-    files that both name themselves after their own key) — the FIRST entry
-    (dict iteration = declaration order) wins the registration; the second
-    entry is logged + durably captured and skipped, never a silent
-    last-wins overwrite and never fatal to the whole load."""
+    """Tier 2: #2722 — two entries whose files declare the SAME ``pipeline:``
+    name but sit under DIFFERENT keys BOTH register, namespaced apart
+    (``key_a.hello`` / ``key_b.hello``). Namespacing decouples them: the same
+    declared name no longer collides across entries, so nothing is skipped."""
     reyn_dir = tmp_path / ".reyn"
     reyn_dir.mkdir()
     monkeypatch.chdir(tmp_path)
@@ -272,18 +267,15 @@ def test_loader_duplicate_declared_name_first_wins_second_skipped(
     registry = build_pipeline_registry(
         {
             "entries": {
-                "hello": {"path": "pipelines/a.yaml"},
-                "hello-again": {"path": "pipelines/b.yaml"},
+                "key_a": {"path": "pipelines/a.yaml"},
+                "key_b": {"path": "pipelines/b.yaml"},
             }
         },
         tmp_path,
     )
 
-    assert set(registry.names()) == {"hello"}
-    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
-    [event] = events
-    assert event["data"]["key"] == "hello-again"
-    assert "hello" in event["data"]["error"]
+    assert set(registry.names()) == {"key_a.hello", "key_b.hello"}
+    assert _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed") == []
 
 
 def test_loader_empty_config_yields_empty_registry(tmp_path: Path) -> None:
@@ -348,7 +340,7 @@ def test_from_config_builds_populated_registry_from_project_root(tmp_path: Path)
 
     fc = SessionFactoryConfig.from_config(config, tmp_path)
 
-    assert set(fc.pipeline_registry.names()) == {"hello"}
+    assert set(fc.pipeline_registry.names()) == {"hello.hello"}
 
 
 def test_from_config_without_project_root_is_empty(tmp_path: Path, monkeypatch) -> None:
@@ -462,8 +454,8 @@ async def test_disk_loaded_pipeline_surfaces_in_list_actions(tmp_path: Path) -> 
     result = await LIST_ACTIONS.handler({"category": ["pipeline"]}, ctx)
 
     items = {it["qualified_name"]: it for it in result["items"]}
-    assert "pipeline__hello" in items
-    assert items["pipeline__hello"]["short_description"] == "greet the seed name"
+    assert "pipeline__hello.hello" in items
+    assert items["pipeline__hello.hello"]["short_description"] == "greet the seed name"
 
 
 # ── 5. Cross-pipeline call: a loaded pipeline calls another loaded pipeline ────
@@ -471,11 +463,11 @@ async def test_disk_loaded_pipeline_surfaces_in_list_actions(tmp_path: Path) -> 
 
 @pytest.mark.asyncio
 async def test_disk_loaded_pipeline_call_resolves_and_runs_end_to_end(tmp_path: Path) -> None:
-    """Tier 2: two pipelines loaded FROM config entries — one whose ``call``
-    step targets the other by its declared name — resolve + run end-to-end.
-    This closes the foundation's deferred named-callee production
-    registration: a ``call`` against a config-registered pipeline now works
-    in production."""
+    """Tier 2: two pipelines loaded FROM separate config entries — one whose
+    ``call`` step targets the other by its FULLY-QUALIFIED cross-file name
+    (``inner.inner`` — a dotted global reference, #2722) — resolve + run
+    end-to-end. A cross-entry reference must be dotted (dot-less resolves to a
+    same-file sibling only)."""
     callee_dsl = """
 pipeline: inner
 description: inner callee
@@ -486,7 +478,7 @@ steps:
 pipeline: outer
 description: calls inner
 steps:
-  - call: {pipeline: inner, pass: {seed: ctx.seed}, output: called}
+  - call: {pipeline: inner.inner, pass: {seed: ctx.seed}, output: called}
   - transform: {value: "ctx.called + '-outer'", output: final}
 """
     _write(tmp_path / "pipelines", "inner.yaml", callee_dsl)
@@ -496,7 +488,7 @@ steps:
         _entries(("inner", "pipelines/inner.yaml"), ("outer", "pipelines/outer.yaml")),
         tmp_path,
     )
-    outer = registry.get("outer")
+    outer = registry.get("outer.outer")
 
     result = await PipelineExecutor().run(
         outer, {"seed": "x"},
@@ -551,7 +543,7 @@ def test_loading_a_pipeline_does_not_loosen_the_floor(tmp_path: Path) -> None:
 
     _write(tmp_path / "pipelines", "hello.yaml", _HELLO_DSL)
     registry = build_pipeline_registry(_entries(("hello", "pipelines/hello.yaml")), tmp_path)
-    assert "hello" in registry.names()  # a pipeline IS registered
+    assert "hello.hello" in registry.names()  # a pipeline IS registered
 
     contextual, _ = cp.resolve_profile(cp.builtin_untrusted_profile())
     layer = ContextualLayer(contextual)
@@ -618,7 +610,7 @@ async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
             "function": {
                 "name": "invoke_action",
                 "arguments": json.dumps({
-                    "action_name": "pipeline__hello",
+                    "action_name": "pipeline__hello.hello",
                     "args": {"input": {"name": "Reyn"}},
                 }),
             },

--- a/tests/test_2581_pipeline_hotreload.py
+++ b/tests/test_2581_pipeline_hotreload.py
@@ -121,7 +121,7 @@ async def test_hotreload_adds_pipeline_to_live_registry(
     ``session.router_host.get_pipeline_registry()`` — not a dead local copy."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    assert "hello" not in _names(session)
+    assert "hello.hello" not in _names(session)
 
     _write_pipeline(tmp_path, "hello.yaml", _HELLO_V1)
     _write_dynamic_entries(tmp_path, ("hello", "pipelines/hello.yaml"))
@@ -129,8 +129,8 @@ async def test_hotreload_adds_pipeline_to_live_registry(
     changed = await session._reapply_pipelines({})
 
     assert changed is True
-    assert "hello" in _names(session)
-    assert "hello" in set(session.router_host.get_pipeline_registry().names()), (
+    assert "hello.hello" in _names(session)
+    assert "hello.hello" in set(session.router_host.get_pipeline_registry().names()), (
         "the RouterHostAdapter's own captured registry must reflect the swap "
         "(the dual-write the adapter needs since it never re-reads Session)"
     )
@@ -147,15 +147,15 @@ async def test_hotreload_changes_pipeline_description_on_live_registry(
     _write_pipeline(tmp_path, "hello.yaml", _HELLO_V1)
     _write_dynamic_entries(tmp_path, ("hello", "pipelines/hello.yaml"))
     session = _make_session(tmp_path)
-    assert session.pipeline_registry.get("hello").steps[0].value.startswith("'v1-'")
+    assert session.pipeline_registry.get("hello.hello").steps[0].value.startswith("'v1-'")
 
     _write_pipeline(tmp_path, "hello.yaml", _HELLO_V2)
     changed = await session._reapply_pipelines({})
 
     assert changed is True
-    assert session.pipeline_registry.get("hello").steps[0].value.startswith("'v2-'")
+    assert session.pipeline_registry.get("hello.hello").steps[0].value.startswith("'v2-'")
     assert (
-        session.router_host.get_pipeline_registry().get("hello").steps[0].value.startswith("'v2-'")
+        session.router_host.get_pipeline_registry().get("hello.hello").steps[0].value.startswith("'v2-'")
     ), "router_host's own registry copy must also see the changed definition"
 
 
@@ -188,8 +188,8 @@ async def test_hotreload_via_apply_pending_dual_write(
 
     assert summary is not None
     assert "pipelines" in summary["applied"]
-    assert "hello" in _names(session)
-    assert "hello" in set(session.router_host.get_pipeline_registry().names())
+    assert "hello.hello" in _names(session)
+    assert "hello.hello" in set(session.router_host.get_pipeline_registry().names())
 
 
 # ---------------------------------------------------------------------------
@@ -208,7 +208,7 @@ async def test_hotreload_malformed_pipeline_keeps_old_registry_intact(
     _write_pipeline(tmp_path, "hello.yaml", _HELLO_V1)
     _write_dynamic_entries(tmp_path, ("hello", "pipelines/hello.yaml"))
     session = _make_session(tmp_path)
-    assert "hello" in _names(session)
+    assert "hello.hello" in _names(session)
     old_registry = session.pipeline_registry
 
     # Break the file: malformed steps.
@@ -223,7 +223,7 @@ async def test_hotreload_malformed_pipeline_keeps_old_registry_intact(
     assert session.router_host.get_pipeline_registry() is old_registry, (
         "a failed rebuild must leave the router_host's captured registry untouched"
     )
-    assert "hello" in _names(session), "the last-good pipeline must still be registered"
+    assert "hello.hello" in _names(session), "the last-good pipeline must still be registered"
 
 
 @pytest.mark.asyncio
@@ -253,7 +253,7 @@ async def test_hotreload_malformed_pipeline_observable_via_warning_and_noop_appl
         "_reapply_pipelines" in rec.message for rec in caplog.records
     ), "the malformed-file failure must be logged for operator visibility"
     # And the old registry is still intact after the no-op apply.
-    assert "hello" in _names(session)
+    assert "hello.hello" in _names(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_2686_pipe_llm_credential_precheck.py
+++ b/tests/test_2686_pipe_llm_credential_precheck.py
@@ -113,7 +113,7 @@ def test_run_non_llm_pipeline_does_not_exit_with_keys_unset(
     _write_reyn_yaml(tmp_path, {"hello_cli": {"path": "hello.yaml"}})
 
     args = _ns(
-        name="hello_cli", input=json.dumps({"name": "world"}),
+        name="hello_cli.hello_cli", input=json.dumps({"name": "world"}),
         project=str(tmp_path), async_=False,
     )
     run_run(args)  # must NOT raise SystemExit

--- a/tests/test_2702_present_pipe_run_stdout.py
+++ b/tests/test_2702_present_pipe_run_stdout.py
@@ -66,7 +66,7 @@ def test_pipe_run_present_step_renders_to_stdout(tmp_path, monkeypatch, capsys):
     _write_present_pipeline(tmp_path)
 
     args = argparse.Namespace(
-        name="shows", input="{}", project=str(tmp_path), async_=False,
+        name="shows.shows", input="{}", project=str(tmp_path), async_=False,
         grant_file_write=False,
     )
     run_run(args)

--- a/tests/test_2722_pipeline_multi_doc_namespacing.py
+++ b/tests/test_2722_pipeline_multi_doc_namespacing.py
@@ -1,0 +1,277 @@
+"""#2722 — multiple ``pipeline:`` documents per DSL file + uniform namespacing.
+
+Namespacing is ALWAYS ON: every registered pipeline's global name is
+``{entry-key}.{local-name}`` — no bare registration, regardless of doc count.
+The config entry key is a pure namespace label (the old ``key == declared-name``
+coupling is gone). ``call``/``match`` targets resolve by a dot/no-dot rule:
+dot-less = a same-file sibling (``{key}.name``), dotted = a global reference.
+
+Coverage:
+  1. Parser (``parse_pipeline_docs``) — N>=1 pipeline docs; R1 (a reserved '.'
+     in a declared name) and R2 (an intra-file duplicate declared name) are
+     parse errors; ``parse_pipeline_dsl`` keeps its single-document contract
+     (``run_pipeline_inline``'s surface — unchanged).
+  2. Loader (``build_pipeline_registry``) — uniform ``{key}.{name}`` for single-
+     AND multi-doc files; dot-less sibling resolution + unresolved-sibling
+     load error; dotted global left as-is; a reserved '.' in the entry key is a
+     load error.
+  3. ``pipeline_install`` op (H6) — a multi-doc file's approval-visible result
+     enumerates ALL N registered ``{key}.{name}`` global names.
+
+Real instances only (real parser / loader / registry / op handler) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.pipeline.executor import CallStep, MatchStep, PipelineExecutor
+from reyn.core.pipeline.parser import (
+    PipelineParseError,
+    parse_pipeline_docs,
+    parse_pipeline_dsl,
+)
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.data.pipelines.registry import PipelineLoadError, build_pipeline_registry
+from reyn.schemas.models import PipelineInstallIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _write(dir_: Path, filename: str, text: str) -> Path:
+    dir_.mkdir(parents=True, exist_ok=True)
+    path = dir_ / filename
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _entries(*names_and_paths: "tuple[str, str]") -> dict:
+    return {"entries": {name: {"path": path} for name, path in names_and_paths}}
+
+
+_MULTI_DOC = """
+pipeline: main
+description: entry point
+steps:
+  - call: {pipeline: helper, output: r}
+---
+pipeline: helper
+description: private helper
+steps:
+  - transform: {value: "'helped'", output: out}
+"""
+
+
+# ── 1. Parser ─────────────────────────────────────────────────────────────────
+
+
+def test_parse_pipeline_docs_returns_all_documents() -> None:
+    """Tier 1: parse_pipeline_docs returns EVERY ``pipeline:`` document under its
+    bare declared name (config-agnostic — no prefixing at the parser layer)."""
+    pipelines = parse_pipeline_docs(_MULTI_DOC, SchemaRegistry())
+
+    assert [p.name for p in pipelines] == ["main", "helper"]
+    # bare target verbatim — the parser does NOT prefix (that is the loader's job).
+    assert pipelines[0].steps[0].pipeline == "helper"
+
+
+def test_parse_pipeline_dsl_single_doc_contract_unchanged() -> None:
+    """Tier 1: parse_pipeline_dsl keeps its exactly-one-document contract
+    (``run_pipeline_inline``'s surface) — a single-doc text parses to one
+    Pipeline, a multi-doc text is rejected."""
+    single = "pipeline: solo\nsteps:\n  - transform: {value: \"1\", output: o}\n"
+    assert parse_pipeline_dsl(single, SchemaRegistry()).name == "solo"
+
+    with pytest.raises(PipelineParseError, match="exactly one"):
+        parse_pipeline_dsl(_MULTI_DOC, SchemaRegistry())
+
+
+def test_r1_dot_in_declared_name_is_parse_error() -> None:
+    """Tier 1: R1 — '.' is reserved as the namespace separator, so a declared
+    ``pipeline:`` name containing '.' is a parse error."""
+    dsl = "pipeline: a.b\nsteps:\n  - transform: {value: \"1\", output: o}\n"
+    with pytest.raises(PipelineParseError, match="reserved '.'|namespace separator"):
+        parse_pipeline_docs(dsl, SchemaRegistry())
+
+
+def test_r2_intra_file_duplicate_declared_name_is_parse_error() -> None:
+    """Tier 1: R2 — two ``pipeline:`` documents in one file declaring the same
+    name is a parse error (both would claim the same ``{key}.name`` global)."""
+    dup = (
+        "pipeline: same\nsteps:\n  - transform: {value: \"1\", output: o}\n"
+        "---\n"
+        "pipeline: same\nsteps:\n  - transform: {value: \"2\", output: p}\n"
+    )
+    with pytest.raises(PipelineParseError, match="duplicate 'pipeline:' name"):
+        parse_pipeline_docs(dup, SchemaRegistry())
+
+
+# ── 2. Loader: uniform namespacing + dot/no-dot resolution ────────────────────
+
+
+def test_multi_doc_file_registers_every_pipeline_namespaced(tmp_path: Path) -> None:
+    """Tier 2: a 2-``pipeline:``-doc file registers BOTH pipelines under the
+    uniform ``{key}.{name}`` namespace, and the dot-less sibling ``call`` target
+    is rewritten to the sibling's global name."""
+    _write(tmp_path / "p", "flow.yaml", _MULTI_DOC)
+
+    registry = build_pipeline_registry(_entries(("orders", "p/flow.yaml")), tmp_path, strict=True)
+
+    assert set(registry.names()) == {"orders.main", "orders.helper"}
+    main = registry.get("orders.main")
+    assert isinstance(main.steps[0], CallStep)
+    assert main.steps[0].pipeline == "orders.helper"  # sibling resolved + namespaced
+
+
+def test_single_doc_file_also_namespaced_no_bare_exception(tmp_path: Path) -> None:
+    """Tier 2: uniform namespacing — a SINGLE-``pipeline:``-doc file registers as
+    ``{key}.{name}`` too (no bare-name special case for the single-doc file)."""
+    _write(tmp_path / "p", "solo.yaml", "pipeline: solo\nsteps:\n  - transform: {value: \"1\", output: o}\n")
+
+    registry = build_pipeline_registry(_entries(("ns", "p/solo.yaml")), tmp_path, strict=True)
+
+    assert set(registry.names()) == {"ns.solo"}
+    assert "solo" not in registry.names()  # no bare registration
+
+
+def test_dotted_target_is_a_global_reference_left_unchanged(tmp_path: Path) -> None:
+    """Tier 2: a DOTTED ``call`` target is a global reference — the loader leaves
+    it verbatim (resolved against the whole registry at run time), never
+    prefixing it with the entry key."""
+    dsl = (
+        "pipeline: caller\nsteps:\n"
+        "  - call: {pipeline: other_ns.callee, output: r}\n"
+    )
+    _write(tmp_path / "p", "caller.yaml", dsl)
+
+    registry = build_pipeline_registry(_entries(("mine", "p/caller.yaml")), tmp_path, strict=True)
+
+    caller = registry.get("mine.caller")
+    assert caller.steps[0].pipeline == "other_ns.callee"  # global, unchanged
+
+
+def test_unresolved_dotless_sibling_is_load_error(tmp_path: Path) -> None:
+    """Tier 2: a dot-less ``call`` target with no matching same-file sibling is a
+    load-time error (fail-loud; NO silent fallback to an unrelated global)."""
+    dsl = (
+        "pipeline: caller\nsteps:\n"
+        "  - call: {pipeline: nonexistent, output: r}\n"
+    )
+    _write(tmp_path / "p", "caller.yaml", dsl)
+
+    with pytest.raises(PipelineLoadError, match="dot-less call/match target 'nonexistent'"):
+        build_pipeline_registry(_entries(("mine", "p/caller.yaml")), tmp_path, strict=True)
+
+
+def test_r1_dot_in_entry_key_is_load_error(tmp_path: Path) -> None:
+    """Tier 2: R1 — a config entry key containing the reserved '.' is a load
+    error (it would make the derived ``{key}.{name}`` global name ambiguous)."""
+    _write(tmp_path / "p", "solo.yaml", "pipeline: solo\nsteps:\n  - transform: {value: \"1\", output: o}\n")
+
+    with pytest.raises(PipelineLoadError, match="must not contain"):
+        build_pipeline_registry(_entries(("a.b", "p/solo.yaml")), tmp_path, strict=True)
+
+
+def test_match_targets_are_namespaced_recursively(tmp_path: Path) -> None:
+    """Tier 2: a ``match`` step's case + default targets follow the SAME dot/
+    no-dot rule (dot-less sibling → ``{key}.name``, dotted → global)."""
+    dsl = """
+pipeline: router
+steps:
+  - match:
+      on: ctx.kind
+      cases:
+        a: {pipeline: leg}
+        b: {pipeline: far_ns.remote}
+      default: {pipeline: leg}
+---
+pipeline: leg
+steps:
+  - transform: {value: "'leg'", output: o}
+"""
+    _write(tmp_path / "p", "router.yaml", dsl)
+
+    registry = build_pipeline_registry(_entries(("route", "p/router.yaml")), tmp_path, strict=True)
+
+    router = registry.get("route.router")
+    match = router.steps[0]
+    assert isinstance(match, MatchStep)
+    assert match.cases["a"].pipeline == "route.leg"       # sibling → namespaced
+    assert match.cases["b"].pipeline == "far_ns.remote"   # dotted global → unchanged
+    assert match.default.pipeline == "route.leg"
+
+
+@pytest.mark.asyncio
+async def test_multi_doc_sibling_call_runs_end_to_end(tmp_path: Path) -> None:
+    """Tier 2: the multi-doc file's ``main`` runs its co-located ``helper`` via
+    the namespaced sibling reference, end-to-end through the real executor."""
+    _write(tmp_path / "p", "flow.yaml", _MULTI_DOC)
+    registry = build_pipeline_registry(_entries(("orders", "p/flow.yaml")), tmp_path, strict=True)
+
+    result = await PipelineExecutor().run(
+        registry.get("orders.main"), {},
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-2722", pipeline_registry=registry,
+    )
+
+    assert result.named_stores["r"] == "helped"
+
+
+# ── 3. pipeline_install op — H6 enumerate-all-names ───────────────────────────
+
+
+class _Events:
+    def __init__(self) -> None:
+        self.emitted: "list[tuple[str, dict]]" = []
+
+    def emit(self, kind: str, **kwargs) -> None:
+        self.emitted.append((kind, kwargs))
+
+
+class _StubWorkspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+def _install_ctx(tmp_path: Path) -> "tuple[OpContext, _Events]":
+    config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+    decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
+    events = _Events()
+    ctx = OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=events,
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=None,
+    )
+    return ctx, events
+
+
+@pytest.mark.asyncio
+async def test_pipeline_install_multi_doc_enumerates_all_names(tmp_path: Path) -> None:
+    """Tier 2: H6 — installing a multi-``pipeline:``-doc file enumerates EVERY
+    registered ``{key}.{name}`` global name in the approval-visible result and
+    the audit event (no silent scope creep behind one approved op.name)."""
+    from reyn.core.op_runtime.pipeline_install import handle
+
+    dsl_path = _write(tmp_path / "src", "flow.yaml", _MULTI_DOC)
+    ctx, events = _install_ctx(tmp_path)
+
+    op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl_path), name="orders")
+    result = await handle(op=op, ctx=ctx)
+
+    assert result["status"] == "installed", result
+    assert result["name"] == "orders"  # the namespace key
+    assert set(result["registered_names"]) == {"orders.main", "orders.helper"}
+
+    installed = [kw for kind, kw in events.emitted if kind == "pipeline_installed"]
+    assert installed and set(installed[0]["registered_names"]) == {"orders.main", "orders.helper"}

--- a/tests/test_2722_pipeline_multi_doc_namespacing.py
+++ b/tests/test_2722_pipeline_multi_doc_namespacing.py
@@ -166,6 +166,55 @@ def test_unresolved_dotless_sibling_is_load_error(tmp_path: Path) -> None:
         build_pipeline_registry(_entries(("mine", "p/caller.yaml")), tmp_path, strict=True)
 
 
+def _read_events_of_kind(events_dir: Path, kind: str) -> "list[dict]":
+    """Read every JSONL event of *kind* from anywhere under *events_dir* (the
+    canonical way to read back an ``emit_cli_event``-durable-captured event)."""
+    import json
+
+    found: "list[dict]" = []
+    if not events_dir.exists():
+        return found
+    for path in events_dir.rglob("*.jsonl"):
+        for line in path.read_text().splitlines():
+            if line.strip() and (rec := json.loads(line)).get("type") == kind:
+                found.append(rec)
+    return found
+
+
+def test_unresolved_sibling_fail_loud_no_silent_fallback_per_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the settled design's *"fail-loud; NO silent fallback"* for an
+    unresolved dot-less sibling, in the DEFAULT (non-strict) session-factory
+    posture. The resolution NEVER silently binds the dot-less target to some
+    unrelated global (no fallback); instead it raises a ``PipelineLoadError``
+    that flows through the established #2641 per-entry-isolation seam: the bad
+    entry is SKIPPED and durably recorded as a ``pipeline_load_failed`` event
+    (loud), while a healthy sibling entry still loads. (The strict hot-reload
+    seam re-raises atomically — see test_unresolved_dotless_sibling_is_load_error.)"""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    # `ghost` is neither a same-file sibling nor a (would-be) global — pre-#2722
+    # this could have silently resolved to an unrelated bare `ghost`; now it fails.
+    _write(tmp_path / "p", "bad.yaml", "pipeline: caller\nsteps:\n  - call: {pipeline: ghost, output: r}\n")
+    _write(tmp_path / "p", "ok.yaml", "pipeline: fine\nsteps:\n  - transform: {value: \"1\", output: o}\n")
+
+    registry = build_pipeline_registry(
+        {"entries": {"a": {"path": "p/bad.yaml"}, "b": {"path": "p/ok.yaml"}}},
+        tmp_path,  # strict=False (default) — per-entry isolation
+    )
+
+    # the unresolved-sibling entry registered NOTHING (no silent misresolution);
+    # the healthy sibling entry still loaded.
+    assert set(registry.names()) == {"b.fine"}
+    # and the failure is LOUD — durably recorded, naming the entry + the target.
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "a"
+    assert "ghost" in event["data"]["error"]
+
+
 def test_r1_dot_in_entry_key_is_load_error(tmp_path: Path) -> None:
     """Tier 2: R1 — a config entry key containing the reserved '.' is a load
     error (it would make the derived ``{key}.{name}`` global name ambiguous)."""

--- a/tests/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/test_2761_pr2_hotreload_immediate_apply.py
@@ -407,14 +407,14 @@ async def test_pipeline_install_new_name_is_resolvable_same_turn(
 
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    assert "greet" not in _pipeline_names(session)
+    assert "greet.greet" not in _pipeline_names(session)
 
     dsl = _write_pipeline(tmp_path, "greet.yaml", name="greet", description="v1")
     op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl))
     result = await pipeline_install_handle(op, _op_ctx(tmp_path, session))
 
     assert result["status"] == "installed"
-    assert "greet" in _pipeline_names(session), (
+    assert "greet.greet" in _pipeline_names(session), (
         "a NEW pipeline must be resolvable the same turn (immediate mid-turn apply)"
     )
     residual = await session._hot_reloader.apply_pending()
@@ -440,7 +440,7 @@ async def test_pipeline_install_same_name_overwrite_defers_but_lands(
         PipelineInstallIROp(kind="pipeline_install", path=str(dsl)),
         _op_ctx(tmp_path, session),
     )
-    assert _pipeline_desc(session, "greet") == "v1"
+    assert _pipeline_desc(session, "greet.greet") == "v1"
 
     # Re-install SAME declared name with a changed description (clobber-update).
     _write_pipeline(tmp_path, "greet.yaml", name="greet", description="v2")
@@ -450,12 +450,12 @@ async def test_pipeline_install_same_name_overwrite_defers_but_lands(
     )
 
     assert result["status"] == "installed", "clobber-update must not be errored/refused"
-    assert _pipeline_desc(session, "greet") == "v1", (
+    assert _pipeline_desc(session, "greet.greet") == "v1", (
         "a same-name overwrite must NOT be applied mid-turn (deferred)"
     )
 
     await session._hot_reloader.apply_pending()
-    assert _pipeline_desc(session, "greet") == "v2", (
+    assert _pipeline_desc(session, "greet.greet") == "v2", (
         "the clobber-update must land at the turn boundary (applies next turn)"
     )
 

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -233,10 +233,11 @@ def test_install_local_path_writes_config(tmp_path, capsys):
     assert "installed successfully" in out.lower()
 
 
-def test_install_name_mismatch_is_a_clean_error(tmp_path, capsys):
-    """Tier 2: a --name that disagrees with the DSL's declared 'pipeline:'
-    name is refused with a clear message (pipeline_install.py's own
-    validation), not a raw exception leaking to the CLI user."""
+def test_install_name_becomes_the_namespace_key(tmp_path, capsys):
+    """Tier 2: #2722 — a --name that differs from the DSL's declared 'pipeline:'
+    name is NOT an error (the coupling is gone); --name is the namespace key, so
+    the pipeline registers as '<name>.<declared>' and the config entry is keyed
+    by --name."""
     _write_reyn_yaml(tmp_path)
 
     dsl_path = tmp_path / "p.yaml"
@@ -246,14 +247,17 @@ def test_install_name_mismatch_is_a_clean_error(tmp_path, capsys):
     )
 
     args = _ns(
-        path=str(dsl_path), source=None, name="different_name",
+        path=str(dsl_path), source=None, name="my_namespace",
         project=str(tmp_path), non_interactive=True,
     )
-    with pytest.raises(SystemExit) as exc_info:
-        run_install(args)
-    assert exc_info.value.code == 2
-    err = capsys.readouterr().err
-    assert "name mismatch" in err.lower() or "does not match" in err.lower()
+    run_install(args)  # no SystemExit — a divergent --name is fine now
+
+    out = capsys.readouterr().out
+    assert "installed successfully" in out.lower()
+    written = yaml.safe_load(
+        (tmp_path / ".reyn" / "config" / "pipelines.yaml").read_text(encoding="utf-8")
+    )
+    assert "my_namespace" in written["pipelines"]["entries"]  # entry keyed by --name
 
 
 def test_install_neither_path_nor_source_rejects(tmp_path, capsys):
@@ -287,7 +291,7 @@ def test_run_transform_pipeline_end_to_end(tmp_path, monkeypatch, capsys):
     _write_reyn_yaml(tmp_path, {"hello_cli": {"path": "hello.yaml"}})
 
     args = _ns(
-        name="hello_cli", input=json.dumps({"name": "world"}),
+        name="hello_cli.hello_cli", input=json.dumps({"name": "world"}),
         project=str(tmp_path), async_=False,
     )
     run_run(args)
@@ -359,7 +363,7 @@ def test_run_tool_step_dispatches_for_real(tmp_path, monkeypatch, capsys):
     _write_reyn_yaml(tmp_path, {"uses_tool": {"path": "uses_tool.yaml"}})
 
     args = _ns(
-        name="uses_tool", input=json.dumps({"msg": "hi reyn"}),
+        name="uses_tool.uses_tool", input=json.dumps({"msg": "hi reyn"}),
         project=str(tmp_path), async_=False,
     )
     run_run(args)
@@ -396,7 +400,7 @@ def test_run_tool_step_file_write_is_denied_without_grant_flag(
     _write_reyn_yaml(tmp_path, {"writer": {"path": "writer.yaml"}})
 
     args = _ns(
-        name="writer", input="{}", project=str(tmp_path), async_=False,
+        name="writer.writer", input="{}", project=str(tmp_path), async_=False,
         grant_file_write=False,
     )
     run_run(args)
@@ -430,7 +434,7 @@ def test_run_tool_step_file_write_allowed_with_grant_flag(
     _write_reyn_yaml(tmp_path, {"writer": {"path": "writer.yaml"}})
 
     args = _ns(
-        name="writer", input="{}", project=str(tmp_path), async_=False,
+        name="writer.writer", input="{}", project=str(tmp_path), async_=False,
         grant_file_write=True,
     )
     run_run(args)
@@ -500,7 +504,7 @@ def test_run_agent_step_spawns_real_ephemeral_session(tmp_path, monkeypatch, cap
         encoding="utf-8",
     )
 
-    args = _ns(name="uses_agent", input="{}", project=str(tmp_path), async_=False)
+    args = _ns(name="uses_agent.uses_agent", input="{}", project=str(tmp_path), async_=False)
     run_run(args)
 
     out = capsys.readouterr().out
@@ -594,7 +598,7 @@ def test_run_tool_step_dispatches_mcp_action_for_real(tmp_path, monkeypatch, cap
     )
 
     args = _ns(
-        name="uses_mcp", input=json.dumps({"msg": "hi reyn"}),
+        name="uses_mcp.uses_mcp", input=json.dumps({"msg": "hi reyn"}),
         project=str(tmp_path), async_=False,
     )
     run_run(args)

--- a/tests/test_pipeline_install.py
+++ b/tests/test_pipeline_install.py
@@ -163,7 +163,10 @@ async def test_pipeline_install_e2e_writes_config_and_registry_picks_up(tmp_path
     result = await handle(op=op, ctx=ctx)
 
     assert result["status"] == "installed", f"install failed: {result}"
+    # #2722: no op.name → the namespace key defaults to the DSL file stem ("hello").
     assert result["name"] == "hello"
+    # H6: the full set of global names registered is enumerated (namespaced).
+    assert result["registered_names"] == ["hello.hello"]
     assert result["description"] == "Does something useful"
 
     config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
@@ -175,8 +178,8 @@ async def test_pipeline_install_e2e_writes_config_and_registry_picks_up(tmp_path
     assert entry["description"] == "Does something useful"
 
     registry = build_pipeline_registry(raw["pipelines"], tmp_path)
-    assert "hello" in registry.names()
-    assert registry.get("hello").description == "Does something useful"
+    assert "hello.hello" in registry.names()  # {key}.{declared} (#2722)
+    assert registry.get("hello.hello").description == "Does something useful"
 
 
 # ── Test 2: truncate-falsify (MANDATORY CLAUDE.md recovery gate) ─────────────
@@ -209,7 +212,9 @@ async def test_pipeline_install_truncate_falsify_generation_survives_wal_truncat
 
     dsl_path = _make_pipeline_dsl(tmp_path / "pipelines", "recover.yaml", "recover-pipeline", "Recoverable pipeline")
     ctx, _events = _make_ctx(tmp_path, state_log=state_log)
-    op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl_path))
+    # op.name sets the namespace key explicitly (#2722), so the config entry key
+    # is "recover-pipeline" (this test tracks the ENTRY through rewind).
+    op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl_path), name="recover-pipeline")
     result = await handle(op=op, ctx=ctx)
     assert result["status"] == "installed", f"install failed: {result}"
 
@@ -343,11 +348,11 @@ def test_pipeline_install_source_is_denied_under_untrusted_floor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pipeline_install_op_name_mismatch_with_declared_name_refused(tmp_path):
-    """Tier 2: unlike skill_install (op.name freely renames the registered key),
-    a pipeline's declared 'pipeline:' name is ALWAYS the resolution key a
-    call/match step targets — op.name disagreeing with it is refused rather
-    than silently diverging the config key from the resolution key."""
+async def test_pipeline_install_op_name_is_free_namespace_key(tmp_path):
+    """Tier 2: #2722 — the op.name == declared-name coupling is GONE. op.name is a
+    free namespace key (like skill_install), independent of the DSL's declared
+    'pipeline:' name. Installing a `pipeline: hello` file with `name="not-hello"`
+    is ACCEPTED and registers the pipeline as `not-hello.hello`."""
     from reyn.core.op_runtime.pipeline_install import handle
 
     dsl_path = _make_pipeline_dsl(tmp_path / "pipelines", "hello.yaml", "hello", "desc")
@@ -356,14 +361,15 @@ async def test_pipeline_install_op_name_mismatch_with_declared_name_refused(tmp_
     op = PipelineInstallIROp(kind="pipeline_install", path=str(dsl_path), name="not-hello")
     result = await handle(op=op, ctx=ctx)
 
-    assert result["status"] == "error", f"expected error, got {result}"
-    assert "mismatch" in result["error"].lower()
+    assert result["status"] == "installed", f"expected installed, got {result}"
+    assert result["name"] == "not-hello"  # the namespace key
+    assert result["registered_names"] == ["not-hello.hello"]  # {key}.{declared}
 
     config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
-    assert not config_path.exists() or not (
-        yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-    ).get("pipelines", {}).get("entries", {}), \
-        "pipelines.yaml must not gain an entry when the name mismatch is refused"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert "not-hello" in raw["pipelines"]["entries"]  # config entry keyed by op.name
+    registry = build_pipeline_registry(raw["pipelines"], tmp_path)
+    assert "not-hello.hello" in registry.names()
 
 
 # ── Test 6: source install (mirrors PR-D) ─────────────────────────────────────
@@ -380,11 +386,13 @@ async def test_pipeline_install_source_e2e_clones_and_registers(tmp_path):
     source_url = repo.as_uri()
 
     ctx, events = _make_ctx(tmp_path)
-    op = PipelineInstallIROp(kind="pipeline_install", source=source_url)
+    # #2722: op.name is the namespace key (no longer coupled to the declared name).
+    op = PipelineInstallIROp(kind="pipeline_install", source=source_url, name="source-pipeline")
     result = await handle(op=op, ctx=ctx)
 
     assert result["status"] == "installed", f"expected installed, got {result}"
     assert result["name"] == "source-pipeline"
+    assert result["registered_names"] == ["source-pipeline.source-pipeline"]
     assert result["description"] == "A git-sourced pipeline"
     assert result["source"] == source_url
 
@@ -495,7 +503,7 @@ async def test_pipeline_install_source_subdir_convention(tmp_path):
     source_url = repo.as_uri() + "//pipelines"
 
     ctx, _events = _make_ctx(tmp_path)
-    op = PipelineInstallIROp(kind="pipeline_install", source=source_url)
+    op = PipelineInstallIROp(kind="pipeline_install", source=source_url, name="subdir-pipeline")
     result = await handle(op=op, ctx=ctx)
 
     assert result["status"] == "installed", f"expected installed, got {result}"

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -235,13 +235,14 @@ schema: only_a_schema
 fields:
   a: {type: string, required: true}
 """
-    with pytest.raises(PipelineParseError, match="exactly one"):
+    with pytest.raises(PipelineParseError, match="at least one"):
         parse_pipeline_dsl(dsl, SchemaRegistry())
 
 
 def test_two_pipeline_documents_raises() -> None:
     """Tier 1: a text with more than one `pipeline:` document is a
-    `PipelineParseError` (ambiguous "which pipeline did I just parse")."""
+    `PipelineParseError` under the SINGLE-document `parse_pipeline_dsl` contract
+    (multi-doc is `parse_pipeline_docs`, tested in test_2722_*)."""
     dsl = """
 pipeline: one
 steps:


### PR DESCRIPTION
**[per-PR-coder]** — Implements the settled #2722 design (authority: dogfood-coder's *\"final settled design, TL;DR\"* comment, endorsed by architect). Namespacing is **always on**, `key==declared-name` coupling is **gone**, no compat shim (owner no-debt directive).

Closes #2722

## What changed

**Uniform namespacing.** Every registered pipeline's global name is `{entry-key}.{local-name}` — for every pipeline, single- or multi-doc file alike. No bare registration anywhere. The config entry key is a pure namespace label (need not equal any declared name).

**Name resolution — dot/no-dot dichotomy** (loader-side):
- `call: {pipeline: X}` (no dot) → same-file sibling → `{key}.X`. Unresolved sibling = **load-time error** (fail-loud, no silent fallback).
- `call: {pipeline: X.Y}` (dot) → global, left verbatim.
- Same for `match:` case/default targets (rewritten recursively through `fold`/`for_each`/`parallel` nesting).

**R1** — `.` reserved in declared names (parse error) AND entry keys (load error). **R2** — intra-file duplicate declared name = parse error.

**Parser/loader split (H4).** `parse_pipeline_docs(text, reg) -> list[Pipeline]` is the new multi-doc entry point: parses N≥1 docs under **bare** names, enforces R1/R2, stays config-agnostic. The loader (`build_pipeline_registry` / `_load_one_entry`) owns the entry key and does all `{key}.` prefixing of doc names + resolved sibling refs via a recursive `_namespace_step`. `parse_pipeline_dsl` is kept as the **single-document** contract (thin wrapper enforcing exactly-one) for `run_pipeline_inline` and programmatic single-parse — a genuine distinct contract, not a shim.

**H6 — `pipeline_install`.** Parses multi-doc; `op.name` is now a free namespace key (coupling dropped; `.` rejected; defaults to the DSL file stem / source basename). The result + `pipeline_installed` event enumerate **all N** `{key}.{name}` registered names — no silent scope creep.

**`run_pipeline_inline` untouched** — single-doc, run-this-now (uses `parse_pipeline_dsl`).

## Migration (breaking, one-time — no shim)
Every pipeline's global name changes (`hello` → `{key}.hello`). Updated:
- `pipelines/hello.yaml` header comment; `src/reyn/config/root.py` `pipelines:` doc.
- Docs: `pipeline-registration.md` (namespacing + dot/no-dot section, failure table), `reyn-yaml.md`, `pipeline-dsl.md` (call-target + `pipeline:` field), install-tool descriptions in `pipeline_management_verbs.py`, `PipelineInstallIROp` schema doc.
- CLI (`reyn pipe`): `run_list` now detects a healthy entry by `{key}.` namespace prefix (not `key in names`); `run` help + `--name` help updated to the qualified form.
- All existing pipeline tests migrated to the namespaced contract (the two `key==name`-mismatch-refused tests repurposed to assert the now-allowed decoupling; the cross-entry duplicate test repurposed to assert same-name-different-keys both register).

## Test plan
- [x] `ruff check src tests` — clean (incl. I001).
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 110 tests, 0 Tier-4 violations.
- [x] `pytest` (repo root) — all pipeline/changed tests pass; the only 5 failures are pre-existing `tests/web/` route-mounting tests, **confirmed failing identically on pristine `origin/main`** (untouched by this PR — no web/a2a/mcp-sse/plugin-loader modules changed).
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean.
- [x] **cp-falsify** the resolution logic: broke `_resolve_ref`'s `{key}.` prefix → 3 resolution tests went RED → restored from scratch copy (never git).
- [x] New `tests/test_2722_pipeline_multi_doc_namespacing.py` (12 tests): multi-doc both-register, single-doc-also-namespaced (no bare exception), dot/no-dot resolution incl. unresolved-sibling error + dotted-global-unchanged + recursive `match`, R1 (name + key), R2, H6 enumerate-all-names, end-to-end sibling `call` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)