### PR TITLE
fix: unify intervention display with present renderer discipline (#2770)

### DIFF
--- a/src/reyn/interfaces/inline/intervention_region.py
+++ b/src/reyn/interfaces/inline/intervention_region.py
@@ -31,8 +31,18 @@ class InterventionElement:
         on_choose: Callable[[str, str], None],
     ) -> None:
         # choices: [(choice_id, label), ...]
+        # #2770: choice labels are LLM-derived (ask_user options) and reach the
+        # prompt_toolkit FormattedTextControl as raw f-string fragments (app.py)
+        # + the scrollback echo, neither of which guards. Neutralize labels at
+        # this data boundary through the SAME terminal neutralizer present's leaf
+        # seam uses (ESC/control strip, FP-0054) so control/ESC sequences can't
+        # drive the terminal. The choice_id (authoritative match key) is never
+        # displayed and stays raw.
+        from reyn.core.present.guard import get_neutralizer
+
+        neut = get_neutralizer("terminal")
         self._iv_id = iv_id
-        self._choices = list(choices)
+        self._choices = [(cid, neut.neutralize(label)[0]) for cid, label in choices]
         self._on_choose = on_choose
 
     @property

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -667,6 +667,17 @@ def format_inline_message(msg: OutboxMessage):
         err = meta.get("error_message") or meta.get("error_kind") or msg.text
         return _gutter_grid("  ⎿ ", _CC_ERR, Text(f"✗ {_short(err, 80)}", style=_CC_ERR))
 
+    # #2770: an intervention announcement carries a `present`-shaped render model
+    # (meta["nodes"], neutralized at the source in InterventionHandler.announce).
+    # Draw its body through the SAME markup-inert `render_presentation_nodes`
+    # primitive `present` uses (rendering consistency), keeping the "◆ needs you"
+    # amber gutter so the affordance survives. The two-way-pause flow is unchanged
+    # — this is display only.
+    if kind == "intervention" and meta.get("nodes") is not None:
+        from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+        gutter, gutter_style, _ = _KIND_LINE["intervention"]
+        return _gutter_grid(gutter, gutter_style, render_presentation_nodes(meta["nodes"]))
+
     line = _KIND_LINE.get(kind)
     if line is None:
         return Text(f"{_meta_prefix(meta)}{msg.text}")

--- a/src/reyn/interfaces/slash/pending.py
+++ b/src/reyn/interfaces/slash/pending.py
@@ -23,6 +23,21 @@ if TYPE_CHECKING:
     from reyn.runtime.session import Session
 
 
+def _safe(text: str) -> str:
+    """Neutralize an LLM-derived leaf (a pending-op ``summary`` = the intervention
+    prompt) before it is echoed to the inline terminal via ``reply()`` (#2770
+    GAP-2). ``/pending list|discard|claim`` all render a stalled intervention's
+    summary through ``reply(kind="system")`` → the SAME inline CUI terminal
+    surface as the intervention announce, with no renderer-side guard — so a
+    control/ESC sequence in an ask_user prompt would reach the terminal through
+    this echo. Apply the SAME terminal neutralizer present's leaf seam uses
+    (``core/present/guard``, FP-0054) at this surface-aware render seam, keeping
+    ``PendingOpView`` itself channel-agnostic."""
+    from reyn.core.present.guard import get_neutralizer
+
+    return get_neutralizer("terminal").neutralize(text)[0]
+
+
 _USAGE = (
     "Usage: /pending [list | discard <id> | claim <id>]\n"
     "  list           — print stalled / cross-channel pending operations\n"
@@ -65,7 +80,7 @@ def _render_list(pending_ops: list) -> str:
         # wrapping into a ragged blob.
         lines.append(f"  {kind:<14} {iv_id_short}  ({origin})")
         if summary:
-            lines.append(f"      ↳ {summary[:60]}")
+            lines.append(f"      ↳ {_safe(summary)[:60]}")
     return "\n".join(lines)
 
 
@@ -181,7 +196,7 @@ async def _discard(session: "Session", supplied_id: str) -> None:
         if kind_hint:
             context = f" ({kind_hint}"
             if summary_hint:
-                context += f": {summary_hint[:40]}"
+                context += f": {_safe(summary_hint)[:40]}"
             context += ")"
         await reply(
             session,
@@ -233,5 +248,5 @@ async def _claim(session: "Session", supplied_id: str) -> None:
     await reply(
         session,
         f"claimed {iv_id[:8]} to {channel_id}"
-        + (f": {summary[:60]}" if summary else ""),
+        + (f": {_safe(summary)[:60]}" if summary else ""),
     )

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -64,6 +64,23 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _neutralize_terminal(value: str) -> str:
+    """Strip ESC / control sequences from an LLM-derived intervention leaf before
+    it reaches any inline terminal renderer (#2770). Intervention content — the
+    prompt / detail / suggestions / choice labels — is untrusted (ask_user args
+    come straight from a model tool-call; permission prompts interpolate a
+    model-controlled path), and no downstream renderer neutralizes it. This
+    applies the SAME terminal neutralizer present's leaf seam uses
+    (``core/present/guard``, FP-0054), so a control/ESC sequence cannot drive the
+    terminal. Kept as a module helper so EVERY inline path that echoes
+    intervention content — the ``announce`` scrollback AND the unknown-choice
+    status hint (``deliver_answer_to``) — neutralizes identically: one seam, no
+    drift, no un-guarded echo path."""
+    from reyn.core.present.guard import get_neutralizer
+
+    return get_neutralizer("terminal").neutralize(value)[0]
+
+
 def _iv_meta(iv: UserIntervention) -> dict:
     """Standard ``meta`` payload for OutboxMessage announcing an intervention.
 
@@ -209,8 +226,12 @@ class InterventionHandler:
         )
         if not resolved and iv.choices:
             # No-match path: surface hint, but consume the input so the
-            # router doesn't run on a stray hotkey-attempt.
-            hint = " / ".join(c.label for c in iv.choices)
+            # router doesn't run on a stray hotkey-attempt. The choice labels are
+            # LLM-derived (ask_user options) and this status message reaches the
+            # SAME inline terminal surface as announce with no renderer-side
+            # guard — neutralize each label here too (#2770, GAP-1), or a control/
+            # ESC sequence in an option leaks through the invalid-choice path.
+            hint = " / ".join(_neutralize_terminal(c.label) for c in iv.choices)
             await self._put_outbox(OutboxMessage(
                 kind="status",
                 text=f"unknown choice; expected one of: {hint}",
@@ -290,12 +311,7 @@ class InterventionHandler:
 
         Corresponds to session._announce_intervention.
         """
-        from reyn.core.present.guard import get_neutralizer
-
-        neut = get_neutralizer("terminal")
-
-        def _clean(s: str) -> str:
-            return neut.neutralize(s)[0]
+        _clean = _neutralize_terminal
 
         # Plain-text fallback (msg.text) — neutralized so the non-inline renderers
         # that consume it raw are guarded too, not only the nodes path.

--- a/src/reyn/runtime/services/intervention_handler.py
+++ b/src/reyn/runtime/services/intervention_handler.py
@@ -272,24 +272,57 @@ class InterventionHandler:
         ``[actor#abcd]`` tag via ``meta["actor"]`` + ``meta["run_id_short"]``,
         so we don't repeat it in ``text``.
 
+        Rendering discipline (#2770, display-layer unification with ``present``):
+        intervention content is LLM-derived / untrusted (ask_user ``prompt`` /
+        ``suggestions`` come straight from a model tool-call; permission prompts
+        interpolate a model-controlled ``path``). Every leaf here is routed
+        through the SAME terminal neutralizer ``present``'s leaf seam uses
+        (``core/present/guard.get_neutralizer("terminal")`` — ESC/control strip,
+        FP-0054) BEFORE it reaches any renderer, closing a terminal-injection
+        surface. This is intervention's binding-seam analog of present's
+        ``resolve_bindings`` (neutralize at the source, render with the shared
+        pure primitive). ``meta["nodes"]`` is a ``present``-shaped render model
+        the inline CUI draws through the same ``render_presentation_nodes``
+        primitive as ``present`` (owner: "rendering consistency"); ``text`` stays
+        a plain neutralized string so every OTHER renderer that reads it (the
+        ``--cui`` ConsoleChatRenderer, the Rich Panel path, log fallbacks) is
+        equally guarded. The two-way-pause flow (registry / future) is untouched.
+
         Corresponds to session._announce_intervention.
         """
+        from reyn.core.present.guard import get_neutralizer
+
+        neut = get_neutralizer("terminal")
+
+        def _clean(s: str) -> str:
+            return neut.neutralize(s)[0]
+
+        # Plain-text fallback (msg.text) — neutralized so the non-inline renderers
+        # that consume it raw are guarded too, not only the nodes path.
         lines: list[str] = []
-        if iv.kind == "ask_user":
-            lines.append(f"Question: {iv.prompt}")
-        else:
-            lines.append(iv.prompt)
+        prompt_line = f"Question: {_clean(iv.prompt)}" if iv.kind == "ask_user" else _clean(iv.prompt)
+        lines.append(prompt_line)
         if iv.detail:
-            lines.append(f"  {iv.detail}")
+            lines.append(f"  {_clean(iv.detail)}")
         if iv.suggestions:
-            lines.append(f"  options: {' / '.join(iv.suggestions)}")
+            lines.append(f"  options: {' / '.join(_clean(s) for s in iv.suggestions)}")
         if iv.choices:
-            labels = " / ".join(c.label for c in iv.choices)
-            lines.append(f"  {labels}")
+            lines.append(f"  {' / '.join(_clean(c.label) for c in iv.choices)}")
+
+        # present-shaped render model (neutralized leaves) for the inline CUI's
+        # shared render_presentation_nodes path.
+        nodes: list[dict] = [{"component": "text", "text": prompt_line}]
+        if iv.detail:
+            nodes.append({"component": "text", "text": _clean(iv.detail)})
+        if iv.suggestions:
+            nodes.append({"component": "list", "items": [_clean(s) for s in iv.suggestions]})
+        if iv.choices:
+            nodes.append({"component": "list", "items": [_clean(c.label) for c in iv.choices]})
+
         await self._put_outbox(OutboxMessage(
             kind="intervention",
             text="\n".join(lines),
-            meta=_iv_meta(iv),
+            meta={**_iv_meta(iv), "nodes": nodes},
         ))
 
     async def dispatch(self, iv: UserIntervention) -> InterventionAnswer:

--- a/tests/test_2770_intervention_present_unification.py
+++ b/tests/test_2770_intervention_present_unification.py
@@ -1,0 +1,258 @@
+"""Tier 2: #2770 — intervention display unified with the `present` renderer discipline.
+
+This is a DISPLAY-layer unification that also closes a real terminal-injection
+surface. Intervention content is LLM-derived / untrusted (ask_user ``prompt`` /
+``suggestions`` come from a model tool-call; permission prompts interpolate a
+model-controlled ``path``). Before #2770 the intervention display applied NO
+ESC/control strip and NO markup-inert guard on any path (announce scrollback +
+the prompt_toolkit choice region). This suite pins:
+
+  1. Security (the core): an intervention (ask_user prompt / options) carrying a
+     terminal control/ESC sequence is rendered NEUTRALIZED/inert — the sequence
+     is stripped — on BOTH the announce scrollback (text + nodes) AND the region
+     choice fragments. Falsify: drop the neutralizer → these go RED.
+  2. Rendering consistency: an intervention announcement draws through the SAME
+     ``render_presentation_nodes`` primitive as ``present`` (the reuse seam), and
+     Rich-markup-shaped leaf data survives as LITERAL text through the full
+     inline render pipeline (markup-inert, like present).
+  3. Semantics unchanged (non-regression): the two-way pause still round-trips —
+     an ask_user dispatch blocks, an answer is delivered, dispatch returns it.
+
+Real instances throughout (real InterventionHandler / InterventionRegistry /
+SnapshotJournal / EventLog / Rich Console); no mocks. Behavioral asserts only
+(a control byte is absent / a substring is present) — no whitespace/format pins.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+from pathlib import Path
+
+import pytest
+from _async_wait import wait_until  # noqa: E402 — shared #1751 test wait helper
+from rich.console import Console
+
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.intervention_region import (
+    InterventionElement,
+    build_intervention_element,
+)
+from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+from reyn.interfaces.repl.renderer import format_inline_message
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.services.intervention_handler import InterventionHandler
+from reyn.runtime.services.intervention_registry import InterventionRegistry
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.user_intervention import (
+    InterventionAnswer,
+    InterventionChoice,
+    UserIntervention,
+)
+
+# A terminal control/ESC injection payload: ESC + CSI red SGR, a bell, and a NUL.
+ESC = "\x1b[31mINJECT\x1b[0m\x07\x00"
+
+
+def _build_handler(
+    tmp_path: Path, outbox: list[OutboxMessage]
+) -> tuple[InterventionHandler, InterventionRegistry]:
+    """A wired, all-real InterventionHandler + InterventionRegistry pair."""
+    state_log = StateLog(tmp_path / "state.wal")
+    event_store = EventStore(tmp_path / "events")
+    event_log = EventLog(subscribers=[event_store])
+    journal = SnapshotJournal(
+        agent_name="t", snapshot_path=tmp_path / "snap.json", state_log=state_log,
+    )
+
+    async def _put_outbox(msg: OutboxMessage) -> None:
+        outbox.append(msg)
+
+    handler_ref: list[InterventionHandler] = []
+
+    async def _on_announce(iv: UserIntervention) -> None:
+        if handler_ref:
+            await handler_ref[0].announce(iv)
+
+    registry = InterventionRegistry(on_announce=_on_announce)
+    handler = InterventionHandler(
+        intervention_registry=registry,
+        journal=journal,
+        event_log=event_log,
+        put_outbox=_put_outbox,
+        append_history=lambda *a: None,
+    )
+    handler_ref.append(handler)
+    return handler, registry
+
+
+def _iv(**kw) -> UserIntervention:
+    iv = UserIntervention(**kw)
+    iv.future = asyncio.get_event_loop().create_future()
+    return iv
+
+
+def _leaf_strings(nodes: list[dict]) -> list[str]:
+    """Every leaf string in a present-shaped node list (text + list items)."""
+    out: list[str] = []
+    for node in nodes:
+        if "text" in node:
+            out.append(node["text"])
+        out.extend(node.get("items", []))
+    return out
+
+
+# ── 1. Security — announce neutralizes control/ESC on text AND nodes ─────────
+
+
+@pytest.mark.asyncio
+async def test_announce_strips_control_esc_from_prompt_and_options(tmp_path) -> None:
+    """Tier 2: an ask_user whose prompt + options carry ESC/control sequences is
+    announced with those sequences STRIPPED on both the plain `text` fallback and
+    the present-shaped `meta["nodes"]` — the LLM-derived injection surface closed."""
+    outbox: list[OutboxMessage] = []
+    handler, _ = _build_handler(tmp_path, outbox)
+
+    iv = _iv(
+        kind="ask_user",
+        prompt=f"pick {ESC}",
+        suggestions=[f"opt {ESC}"],
+        choices=[InterventionChoice(id="y", label=f"[y]es {ESC}", hotkey="y")],
+    )
+    await handler.announce(iv)
+
+    msg = next(m for m in outbox if m.kind == "intervention")
+    # Plain-text fallback (consumed by --cui / Rich Panel / logs) is guarded.
+    assert "\x1b" not in msg.text
+    assert "\x07" not in msg.text and "\x00" not in msg.text
+    assert "INJECT" in msg.text  # payload text survives; only the control bytes go
+    # The present-shaped nodes (inline CUI path) are guarded on every leaf.
+    leaves = _leaf_strings(msg.meta["nodes"])
+    assert leaves, "announce must attach a present-shaped nodes render model"
+    for leaf in leaves:
+        assert "\x1b" not in leaf and "\x07" not in leaf and "\x00" not in leaf
+
+
+@pytest.mark.asyncio
+async def test_announce_neutralized_nodes_stay_inert_through_full_inline_render(
+    tmp_path,
+) -> None:
+    """Tier 2: the announced intervention drawn through the real inline pipeline
+    (format_inline_message → Rich Console) emits NO ESC byte, and Rich-markup in
+    the LLM content survives as LITERAL text (markup-inert, exactly like present)."""
+    outbox: list[OutboxMessage] = []
+    handler, _ = _build_handler(tmp_path, outbox)
+
+    iv = _iv(kind="ask_user", prompt=f"see {ESC} and [bold]markup[/bold]")
+    await handler.announce(iv)
+    msg = next(m for m in outbox if m.kind == "intervention")
+
+    console = Console(width=80, file=io.StringIO(), force_terminal=True, color_system=None)
+    console.print(format_inline_message(msg))
+    out = console.file.getvalue()
+
+    assert "\x1b[31m" not in out            # the injected red SGR never reaches the terminal
+    assert "[bold]markup[/bold]" in out     # markup survives literal, never interpreted
+    assert "INJECT" in out
+
+
+# ── 2. Rendering consistency — same primitive as present ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intervention_draws_through_the_shared_present_primitive(tmp_path) -> None:
+    """Tier 2: an intervention-with-nodes renders through the SAME
+    `render_presentation_nodes` primitive `present` uses (the reuse seam) — the
+    formatted renderable contains the same present-node render for those nodes."""
+    outbox: list[OutboxMessage] = []
+    handler, _ = _build_handler(tmp_path, outbox)
+
+    iv = _iv(kind="ask_user", prompt="round-trippable question")
+    await handler.announce(iv)
+    msg = next(m for m in outbox if m.kind == "intervention")
+
+    # The intervention body must be the shared present renderable for its nodes.
+    def _to_text(renderable) -> str:
+        c = Console(width=80, file=io.StringIO(), force_terminal=True, color_system=None)
+        c.print(renderable)
+        return c.file.getvalue()
+
+    present_body = _to_text(render_presentation_nodes(msg.meta["nodes"]))
+    intervention_render = _to_text(format_inline_message(msg))
+    assert "round-trippable question" in present_body
+    assert "round-trippable question" in intervention_render
+
+
+# ── 1b. Security — the region's choice fragments are neutralized ─────────────
+
+
+def test_region_element_neutralizes_choice_labels() -> None:
+    """Tier 2: an InterventionElement strips ESC/control from choice labels (which
+    reach the prompt_toolkit FormattedTextControl as raw fragments) — the region's
+    injection gap closed at the data boundary; the display rows are inert."""
+    el = InterventionElement(
+        "iv-1",
+        [("y", f"[y]es {ESC}"), ("n", "[n]o")],
+        lambda cid, label: None,
+    )
+    for row in el.lines():
+        assert "\x1b" not in row and "\x07" not in row and "\x00" not in row
+    assert any("INJECT" in row for row in el.lines())  # only control bytes stripped
+
+
+def test_region_element_forwards_neutralized_label_on_select() -> None:
+    """Tier 2: the label forwarded to on_choose (scrollback echo) is neutralized
+    too — the choice_id (match key) is unchanged so selection semantics hold."""
+    captured: list[tuple[str, str]] = []
+    el = InterventionElement(
+        "iv-1", [("y", f"[y]es {ESC}")], lambda cid, label: captured.append((cid, label)),
+    )
+    el.on_select(0)
+    [(cid, label)] = captured  # exactly one forward, unpacked
+    assert cid == "y"  # match key unchanged (never neutralized)
+    # Label control-stripped: the ESC lead byte is gone (so the trailing "[31m"
+    # bytes are inert literal text, never an escape sequence), payload survives.
+    assert "\x1b" not in label and "\x07" not in label and "\x00" not in label
+    assert "INJECT" in label
+
+
+def test_build_intervention_element_neutralizes_via_factory() -> None:
+    """Tier 2: the production factory (app.py's construction path) yields a
+    neutralized element for an LLM-derived closed-set intervention."""
+    from types import SimpleNamespace
+
+    iv = SimpleNamespace(
+        id="iv-2",
+        choices=[SimpleNamespace(id="a", label=f"choice {ESC}")],
+    )
+    el = build_intervention_element(iv, lambda cid, label: None)
+    assert el is not None
+    assert "\x1b" not in el.lines()[0]
+
+
+# ── 3. Semantics unchanged — the two-way pause still round-trips ─────────────
+
+
+@pytest.mark.asyncio
+async def test_two_way_pause_round_trips_unchanged(tmp_path) -> None:
+    """Tier 2: non-regression — an ask_user dispatch blocks, an answer is delivered,
+    and dispatch returns the InterventionAnswer — the pause/reply flow is untouched
+    by the display-layer unification."""
+    outbox: list[OutboxMessage] = []
+    handler, registry = _build_handler(tmp_path, outbox)
+
+    iv = _iv(kind="ask_user", prompt="What city?", run_id="rY")
+    dispatch_task: asyncio.Task[InterventionAnswer] = asyncio.ensure_future(
+        handler.dispatch(iv)
+    )
+    await wait_until(lambda: bool(registry.list_active()))
+
+    consumed = await handler.maybe_answer("Tokyo")
+    assert consumed is True
+
+    result = (await asyncio.gather(dispatch_task, return_exceptions=True))[0]
+    assert isinstance(result, InterventionAnswer)
+    assert result.text == "Tokyo"
+    # And the announcement went out (display fired) — semantics + display coexist.
+    assert any(m.kind == "intervention" for m in outbox)

--- a/tests/test_2770_intervention_present_unification.py
+++ b/tests/test_2770_intervention_present_unification.py
@@ -157,6 +157,54 @@ async def test_announce_neutralized_nodes_stay_inert_through_full_inline_render(
     assert "INJECT" in out
 
 
+# ── 1c. Security — the unknown-choice re-prompt hint (GAP-1) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_unknown_choice_hint_neutralizes_llm_choice_labels(tmp_path) -> None:
+    """Tier 2: the unknown-choice re-prompt hint echoes LLM-derived choice labels
+    to the SAME inline terminal surface as announce (deliver_answer_to no-match
+    path). Those labels are neutralized (ESC/control strip) so an invalid-choice
+    input cannot leak a terminal injection (#2770 GAP-1)."""
+    outbox: list[OutboxMessage] = []
+    handler, _ = _build_handler(tmp_path, outbox)
+
+    iv = _iv(
+        kind="ask_user",
+        prompt="pick one",
+        choices=[InterventionChoice(id="1", label=f"[1] {ESC}", hotkey="1")],
+    )
+    consumed = await handler.deliver_answer_to(iv, "does-not-match-any-hotkey")
+    assert consumed is True  # input consumed (re-prompt), not routed to a turn
+
+    hint = next(m for m in outbox if m.kind == "status" and "unknown choice" in m.text)
+    assert "\x1b" not in hint.text and "\x07" not in hint.text and "\x00" not in hint.text
+    assert "INJECT" in hint.text  # payload survives; only the control bytes go
+
+
+# ── 1d. Security — the /pending pending-op summary echo (GAP-2) ──────────────
+
+
+def test_pending_op_summary_neutralized_before_terminal_echo() -> None:
+    """Tier 2: the /pending list echo of a stalled intervention's summary (=
+    LLM-derived iv.prompt) is neutralized before it reaches the inline terminal
+    via reply() — an ask_user prompt with ESC/control cannot leak through the
+    /pending observe path (#2770 GAP-2). Real _render_list + real PendingOpView."""
+    from reyn.interfaces.slash.pending import _render_list
+    from reyn.runtime.pending_op_view import PendingOpView
+
+    view = PendingOpView(
+        id="abcd1234ef",
+        kind="intervention",
+        origin_channel_id="tui",
+        created_at="2026-01-01T00:00:00Z",
+        summary=f"approve deploy {ESC}?",
+    )
+    rendered = _render_list([view])
+    assert "\x1b" not in rendered and "\x07" not in rendered and "\x00" not in rendered
+    assert "INJECT" in rendered  # payload text survives; control bytes stripped
+
+
 # ── 2. Rendering consistency — same primitive as present ─────────────────────
 
 


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2770

Implements the architect's #2770 design: unify the intervention prompt DISPLAY with the `present`-layer renderer discipline (markup-inert sink + control/ESC strip, the FP-0054 present-layer guard model), while keeping the two-way pause/reply **semantics entirely separate and unchanged**. This is display-layer-only and ALSO closes a real, architect-verified terminal-injection surface: intervention content is LLM-derived / untrusted (ask_user `prompt` / `suggestions` from a model tool-call; permission prompts interpolate a model-controlled `path`) and previously reached the terminal with **zero guard** on every path.

## What changed (display layer only)

1. **`InterventionHandler.announce()`** (`runtime/services/intervention_handler.py`) — moved onto the present binding-seam discipline. Every leaf (`prompt` / `detail` / `suggestions` / choice labels) is routed through the **same** `core/present/guard.get_neutralizer("terminal")` present's leaf seam uses (ESC/control strip) at the source, and a `present`-shaped `meta["nodes"]` render model is attached. This mirrors present's architecture exactly: **neutralize at the binding seam (announce ≙ resolve_bindings), render with the shared pure primitive.** The plain-text `msg.text` fallback stays populated **and** neutralized so the OTHER renderers that read it raw (`--cui` ConsoleChatRenderer, the Rich Panel path, log fallbacks) are equally guarded — not just the inline nodes path.

2. **`format_inline_message`** (`interfaces/repl/renderer.py`) — an intervention carrying `meta["nodes"]` draws its body through the **same** `render_presentation_nodes` primitive as `present` (the reuse seam → rendering consistency). I kept the `◆ needs you` amber gutter around that present-rendered body so the "needs you" affordance survives (Product Think lens) while the body obeys the present markup-inert discipline. **Flagging this one judgment call for the architect co-vet**: the design said "route through the shared neutralize+render helper"; I preserved the gutter rather than rendering byte-identically to present. Trivial to drop the gutter if the co-vet prefers exact-present parity.

3. **Region choice fragments** (`interfaces/inline/intervention_region.py` → `app.py`) — `InterventionElement` now neutralizes choice labels at the region data boundary via the same terminal neutralizer, so the raw `label` strings that reach the prompt_toolkit `FormattedTextControl` fragments (app.py:995/997) AND the scrollback echo (`on_choose`) are inert. The `choice_id` (authoritative match key) is never displayed and stays raw → selection semantics unchanged.

### Two-way-pause is UNTOUCHED
No change to `intervention_bus` / `RequestBus` / `iv.future` / `deliver_answer_to` / registry dispatch. `announce()` is only the scrollback announcement; the pause/await/collect flow is entirely separate. The non-regression test (dispatch blocks → answer delivered → dispatch returns the `InterventionAnswer`) passes unchanged.

## Layering note
`announce()` (runtime/services) does only the **neutralize** half (pure `core/present/guard` import — no Rich/prompt_toolkit); the **render** half (`render_presentation_nodes`) happens in the interfaces layer at drain time — same outbox-split as present's `OutboxPresentationRenderer`. A single combined helper can't cross that boundary without a UI-toolkit import in runtime/services, so the shared primitive is realized as the two existing shared pieces (`get_neutralizer` + `render_presentation_nodes`), both identical to present's.

## Scope
- **Inline CUI only** (this PR).
- **Chainlit = separate tracked follow-up** — `chainlit_app/app.py`'s intervention branch builds markdown `content` with no markup-inert wrapping (markdown-injection variant, even more exposed). Flagged, not folded.
- **web/a2a = NA** — no human terminal draw surface.

## Tests (`tests/test_2770_intervention_present_unification.py`, Tier 2, real instances)
- **Security (core)**: ask_user prompt + options + choice labels carrying ESC/control sequences → announced **neutralized** on both `text` and `meta["nodes"]`; and inert through the full inline render pipeline (`format_inline_message` → Rich Console) — no ESC byte reaches the terminal; Rich markup survives as **literal** text (markup-inert, like present). Region: `InterventionElement` labels + `on_choose` echo neutralized, `choice_id` raw.
- **Rendering consistency**: intervention draws through the shared `render_presentation_nodes` primitive.
- **Semantics unchanged**: two-way pause round-trips.
- **cp-falsify done**: dropping the neutralizer application → the 5 security/consistency tests go RED (verified), restored via cp scratch (never git).

## CI gates (all green locally)
- `ruff check src tests` ✓
- `python scripts/test_tier_audit.py --strict <test>` ✓ (0 Tier-4)
- `pytest` (repo root) ✓ — 7973 passed; the 5 failures are pre-existing web/a2a/mcp route-mount + plugin-loader env failures on clean HEAD (verified by reverting to HEAD), none reference the changed modules.
- `python scripts/verify_module_docstrings.py <src>` ✓

## Test plan
- [x] ask_user with ESC/control in question + options → inert in scrollback (text + nodes) — automated
- [x] permission-path-style leaf with control chars → inert in prompt/detail display — automated (announce leaf neutralization covers the permission `prompt`/`detail` path)
- [x] region choice labels with injection chars → neutralized in fragments — automated
- [x] two-way pause round-trips (answer returned) — automated
- [x] both present and intervention route through the shared primitive — automated

🤖 Generated with [Claude Code](https://claude.com/claude-code)