### PR TITLE
fix: multi-doc pipeline entry registration is intra-file atomic (#2775)

### DIFF
--- a/src/reyn/data/pipelines/registry.py
+++ b/src/reyn/data/pipelines/registry.py
@@ -279,6 +279,27 @@ def _load_one_entry(
     # Sibling-name set for dot-less `call`/`match` resolution (#2722).
     siblings = {p.name for p in pipelines}
 
+    # #2775: an entry's registration must be INTRA-FILE ATOMIC — a file with N
+    # `pipeline:` documents commits ALL N or NONE. Register-as-you-go left docs
+    # 1..N-1 live in the registry when doc N failed, while the per-entry
+    # isolation layer logged/recorded "the entry was skipped" (a silent partial
+    # success: `run_pipeline(name="{key}.doc1")` succeeded despite the skip
+    # event). So use a TWO-PASS commit:
+    #
+    #   Pass 1 (validate + resolve + collision pre-check — NO registry mutation):
+    #     namespace every pipeline (raises on an unresolved dot-less sibling) and
+    #     pre-check each resulting global name against both the already-populated
+    #     registry (a cross-entry collision) and the names staged so far. `siblings`
+    #     is known upfront and independent of registration order, so this pass
+    #     catches every failure the old per-doc loop could — with zero mutation.
+    #   Pass 2 (commit): every name is known-good + unique, so `register()` cannot
+    #     raise its duplicate guard — the whole file lands atomically.
+    #
+    # A failure in ANY doc raises PipelineLoadError out of pass 1 before pass 2
+    # begins, so the registry is untouched — exactly matching the "entry skipped"
+    # semantics the isolation layer reports.
+    staged: "list[object]" = []
+    seen: "set[str]" = set(registry.names())
     for pipeline in pipelines:
         if not pipeline.name:
             # parse_pipeline_docs requires a non-empty ``pipeline:`` name, so
@@ -290,17 +311,23 @@ def _load_one_entry(
         # Namespace: prefix the declared name AND every resolved dot-less sibling
         # ref with `{key}.` (raises PipelineLoadError for an unresolved sibling).
         namespaced = _namespace_pipeline(pipeline, key, siblings)
-        try:
-            registry.register(namespaced.name, namespaced, schema_registry)
-        except ValueError as exc:
-            # Duplicate GLOBAL name across entries — the registry's own
-            # re-registration guard. First-registered entry keeps the name; this
-            # (later) entry is the one that fails.
+        if namespaced.name in seen:
+            # A GLOBAL name collision — with an earlier ENTRY (first-registered
+            # wins) or (defensively) an earlier sibling in THIS file (R2 already
+            # prevents same declared names, so intra-file is unreachable, but the
+            # single check covers both). Raised in pass 1 → nothing from this file
+            # is committed.
             raise PipelineLoadError(
                 f"pipelines.entries.{key!r}: file {path} registers name "
                 f"{namespaced.name!r} which is already registered by an earlier "
-                f"entry: {exc}"
-            ) from exc
+                "entry."
+            )
+        seen.add(namespaced.name)
+        staged.append(namespaced)
+
+    # Pass 2: commit — names pre-validated absent + unique, so no register() raises.
+    for namespaced in staged:
+        registry.register(namespaced.name, namespaced, schema_registry)
 
 
 def build_pipeline_registry(

--- a/tests/test_2722_pipeline_multi_doc_namespacing.py
+++ b/tests/test_2722_pipeline_multi_doc_namespacing.py
@@ -215,6 +215,62 @@ def test_unresolved_sibling_fail_loud_no_silent_fallback_per_entry(
     assert "ghost" in event["data"]["error"]
 
 
+def test_multi_doc_entry_registration_is_intra_file_atomic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #2775 — a multi-``pipeline:``-doc entry commits ALL its documents
+    or NONE (intra-file atomicity). When a LATER document in the file fails to
+    resolve (doc 2's dot-less ``call`` targets a nonexistent sibling), an
+    EARLIER valid document in the SAME file (doc 1) must NOT be left registered:
+    the whole entry is skipped, matching the ``pipeline_load_failed`` event's
+    "skipped" semantics. A register-as-you-go loop left ``orders.alpha`` live +
+    callable while the event said the entry was skipped (a silent partial
+    success). Non-strict (session-factory) posture; a healthy OTHER entry still
+    loads (cross-entry isolation, #2641, is preserved — the entry is the atomic
+    unit)."""
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    # doc 1 (alpha) is valid + register-able; doc 2 (beta) has an unresolved
+    # dot-less sibling — the OLD per-doc loop registered alpha before beta failed.
+    _write(
+        tmp_path / "p", "multi.yaml",
+        "pipeline: alpha\nsteps:\n  - transform: {value: \"1\", output: o}\n"
+        "---\n"
+        "pipeline: beta\nsteps:\n  - call: {pipeline: ghost, output: r}\n",
+    )
+    _write(tmp_path / "p", "ok.yaml", "pipeline: fine\nsteps:\n  - transform: {value: \"1\", output: o}\n")
+
+    registry = build_pipeline_registry(
+        {"entries": {"orders": {"path": "p/multi.yaml"}, "b": {"path": "p/ok.yaml"}}},
+        tmp_path,  # strict=False (default)
+    )
+
+    # ZERO pipelines from the failed multi-doc file — not the leaked ``orders.alpha``.
+    assert "orders.alpha" not in registry.names()
+    assert "orders.beta" not in registry.names()
+    # the healthy OTHER entry is unaffected (per-entry isolation is the atomic unit).
+    assert set(registry.names()) == {"b.fine"}
+    # the failure is durably recorded, naming the entry.
+    events = _read_events_of_kind(reyn_dir / "events", "pipeline_load_failed")
+    [event] = events
+    assert event["data"]["key"] == "orders"
+
+
+def test_multi_doc_entry_atomic_under_strict_re_raise(tmp_path: Path) -> None:
+    """Tier 2: #2775 — under the STRICT hot-reload posture the same multi-doc
+    failure re-raises atomically (last-good registry preserved by the caller),
+    committing nothing from the file. Complements the non-strict per-entry case."""
+    _write(
+        tmp_path / "p", "multi.yaml",
+        "pipeline: alpha\nsteps:\n  - transform: {value: \"1\", output: o}\n"
+        "---\n"
+        "pipeline: beta\nsteps:\n  - call: {pipeline: ghost, output: r}\n",
+    )
+    with pytest.raises(PipelineLoadError, match="dot-less call/match target 'ghost'"):
+        build_pipeline_registry({"entries": {"orders": {"path": "p/multi.yaml"}}}, tmp_path, strict=True)
+
+
 def test_r1_dot_in_entry_key_is_load_error(tmp_path: Path) -> None:
     """Tier 2: R1 — a config entry key containing the reserved '.' is a load
     error (it would make the derived ``{key}.{name}`` global name ambiguous)."""


### PR DESCRIPTION
**[per-PR-coder]** — Follow-up fix for a real bug found by the sandbox_2 co-vet of #2774 (the #2722 impl). Straightforward atomicity fix; the #2722 design itself is unaffected.

Closes #2775
Follow-up to #2774 · part of the #2722 arc · preserves #2641 (per-entry isolation).

## The bug (co-vet, reproduced)
A multi-`pipeline:`-doc entry's registration was **not intra-file atomic** in non-strict mode. `_load_one_entry` namespaced + registered each document **one at a time**:

```python
for pipeline in pipelines:
    namespaced = _namespace_pipeline(pipeline, key, siblings)   # can raise (unresolved sibling)
    registry.register(namespaced.name, namespaced, schema_registry)  # mutates immediately
```

If doc N failed, docs `1..N-1` from the **same file** were already committed. `build_pipeline_registry`'s non-strict per-entry catch then logged/recorded *"the entry was skipped"* — but the returned registry still contained the earlier docs, **live and callable**. An operator/LLM sees `orders failed to load` in the event stream, reasonably concludes nothing under `orders.*` is usable, yet `run_pipeline(name="orders.alpha")` silently succeeds. A silent partial success at file-atomicity granularity — the exact "fail-loud, no silent success" property the design guarantees at the resolution granularity, missing one level up.

This was a genuinely new failure mode the multi-doc feature introduced (couldn't exist pre-#2722, when an entry was always exactly one pipeline), and the existing tests only covered cross-**entry** isolation, not within-**file** atomicity.

## The fix — 2-pass commit (sandbox_2's proposed shape)
- **Pass 1** (validate + resolve + collision pre-check, **zero registry mutation**): namespace every pipeline (raises on an unresolved dot-less sibling; `siblings` is known upfront and order-independent), and pre-check each resulting global name against both the already-populated registry (cross-entry collision) and the names staged so far. Catches every failure the old loop could.
- **Pass 2** (commit): all N names known-good + unique, so `register()` cannot raise its duplicate guard — the whole file lands atomically.

A failure in any doc raises out of pass 1 **before** pass 2 begins → the registry is untouched, matching the "entry skipped" semantics. Cross-entry isolation (#2641) is preserved: the **entry** stays the atomic unit, so a healthy sibling entry still loads; strict/hot-reload still re-raises atomically.

## Test plan
- [x] New regression `test_multi_doc_entry_registration_is_intra_file_atomic`: non-strict, 2-doc file, doc 2 fails → **zero** pipelines from that file registered (not the leaked `orders.alpha`), healthy other entry still loads, `pipeline_load_failed` names the entry.
- [x] New `test_multi_doc_entry_atomic_under_strict_re_raise`: strict posture re-raises atomically.
- [x] **cp-falsify**: reintroduced register-as-you-go → the atomicity test went RED → restored from scratch copy (never git).
- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_2722_pipeline_multi_doc_namespacing.py` — 0 Tier-4 violations.
- [x] `python scripts/verify_module_docstrings.py src/reyn/data/pipelines/registry.py` — clean.
- [x] Pipeline subset (`-k "pipe or pipeline"`): 482 passed, 3 skipped. Full `pytest` running to confirm no wider regression (baseline: only the 5 pre-existing `tests/web/` route-mount failures, unrelated).

sandbox_2 independently verified the same gap — requesting re-co-vet after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)