### PR TITLE
fix: offload EventStore.write() from the event loop (#2780)

### DIFF
--- a/src/reyn/core/events/event_store.py
+++ b/src/reyn/core/events/event_store.py
@@ -249,8 +249,10 @@ class EventStore:
         `max_bytes` defaults to a nonzero 10MB, so `.stat()` used to fire a
         blocking syscall on literally EVERY `write()` call, not a rare path.
         The counter drifts (harmlessly) if an external process appends to the
-        same file, or after a FileNotFoundError recovery re-creates it — both
-        only shift the rotation point by a bounded amount, never break
+        same file, after a FileNotFoundError recovery re-creates it, or on
+        Windows where text-mode `\n` -> `\r\n` translation makes bytes-on-disk
+        exceed the counted `len(line.encode("utf-8")) + 1` — all three only
+        shift the rotation point by a bounded amount, never break
         correctness."""
         if self._active is None or self._active_started_at is None:
             return False

--- a/src/reyn/core/events/event_store.py
+++ b/src/reyn/core/events/event_store.py
@@ -13,14 +13,62 @@ that rename-based schemes have.
 
 Per P7: this is OS-level generic infrastructure — it never references
 specific event types or domain strings.
+
+Off-loop write (owner dogfood finding, 2026-07-10): ``write()`` used to
+``open()``/``write()`` synchronously, directly on the event loop — the SAME
+class of bug as #1765's WAL append (a filesystem stall freezes the WHOLE
+event loop), except unmitigated (not even fsync was offloaded) and far more
+exposed (fires on every chat event — at least once per turn via
+``turn_completed``, plus once per tool call, per hook, etc., vs. #1765's
+WAL-append-only exposure). Fixed by routing the write through a
+``DurabilityWorker`` (the SAME off-loop primitive #1765 introduced — reused,
+not reinvented; substrate-agnostic by that class's own design) via
+``submit_nowait``. ``write()`` stays a plain synchronous method — no API
+change, no caller updates anywhere ``emit()``/``write()`` is called: only the
+actual file I/O is deferred off-loop. Rotation decision + line serialization
+still happen synchronously at ``write()``-call time, so enqueue order still
+equals emission order; the worker's FIFO guarantee (enqueue order == write
+order) then keeps on-disk order matching emission order too — this log's
+ordering relative to other synchronous code (WAL appends included) is
+unchanged from before this fix, only the blocking part moved off the loop.
+Cross-log disk-durability ordering between this store and the WAL is NOT
+guaranteed (separate workers/queues) — but nothing depends on that; event
+timestamps are stamped synchronously at ``emit()`` time, so a consumer that
+correlates the two logs (dogfood_trace, support_bundle) orders by timestamp,
+not by which file landed first.
+
+Durability discipline mirrors #1765's WAL fix, per review: the single
+off-loop unit (``_write_line_sync``) does open + write + flush + fsync
+TOGETHER, so there is no "written but not yet fsynced" exposure window
+within one queued job — a line is either not-yet-durable (still queued) or
+fully durable (opened, written, and fsynced). ``submit_nowait`` (not
+``submit``) means ``write()`` itself does not await that durability — a
+RELAXED-durability window between ``write()`` returning and the line
+actually landing durably, same accepted trade-off the WAL's own
+``append_nowait``/``submit_nowait`` fire-and-forget path already carries
+elsewhere in this codebase — not a new risk class.
+
+This is an AUDIT log, not a recovery source: ``anchor_store.py`` explicitly
+documents that EventStore has no WAL seq and is deliberately not used for
+rewind/reconstruction ("mining the audit EventStore... would need a
+cross-log join" — see #1547). So this fix carries no crash-recovery
+truncate-falsify obligation (CLAUDE.md's recovery-feature PR gate governs
+WAL-event-derived reconstruction state; this isn't that) — but per review,
+the audit log's at-least-once durability still matters for the
+`events.md` audit-truth contract, hence ``aclose()`` below (drains every
+queued write before process/session teardown, so a graceful ``/quit``
+doesn't silently drop the tail of the audit trail — see its docstring).
 """
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import Iterator
 
+from reyn.core.events.durability_worker import DurabilityWorker
 from reyn.schemas.models import Event
 
 
@@ -46,6 +94,15 @@ class EventStore:
         self._suffix = suffix
         self._active: Path | None = None
         self._active_started_at: datetime | None = None
+        # Running byte count of the active file — avoids a `.stat()` syscall
+        # on every write() (max_bytes defaults to 10MB, i.e. nonzero, so the
+        # old `_should_rotate()` stat() fired on literally every call, not a
+        # rare path). Reset to 0 on rotation.
+        self._active_size = 0
+        # Off-loop write worker (see module docstring). Lazily binds to
+        # whichever loop is running on first write() — a store constructed
+        # before any loop exists is fine; only submit_nowait touches the loop.
+        self._worker = DurabilityWorker()
 
     # ── public API ──────────────────────────────────────────────────────
 
@@ -54,25 +111,91 @@ class EventStore:
         self.write(event)
 
     def write(self, event: Event) -> None:
+        """Serialize + enqueue one line for off-loop writing.
+
+        Synchronous (unchanged signature — every ``EventLog.emit()`` caller
+        across the codebase stays untouched). Rotation decision + JSON
+        serialization happen here, still on the caller's tick, so enqueue
+        order == emission order; only the actual ``open``/``write``/``fsync``
+        moves off-loop via the worker's FIFO (enqueue order == write order).
+
+        Falls back to a fully synchronous write when no event loop is
+        running (e.g. a CLI entry point that never starts one — see
+        ``events.py``'s CLI-mode EventStore construction) — ``submit_nowait``
+        requires a running loop and would otherwise raise, a regression this
+        fix must not introduce for synchronous callers.
+        """
         if self._active is None or self._should_rotate():
             self._open_new_file(now=datetime.now())
         line = json.dumps(event.model_dump(mode="json"), ensure_ascii=False)
+        self._active_size += len(line.encode("utf-8")) + 1  # +1 for the trailing "\n"
+        path = self._active
+        assert path is not None
         try:
-            with self._active.open("a", encoding="utf-8") as f:  # type: ignore[union-attr]
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._write_line_sync(path, line)
+            return
+        self._worker.submit_nowait(lambda p=path, ln=line: self._do_write(p, ln))
+
+    async def aclose(self) -> None:
+        """Drain every enqueued write before the caller tears down.
+
+        Without this, a normal ``/quit`` can drop the trailing audit events
+        (e.g. ``session_completed`` — the very event recording the graceful
+        exit) because ``asyncio.run`` cancels outstanding tasks at loop
+        teardown. Mirrors ``StateLog.aclose`` — call from the same teardown
+        path. A no-op if the worker was never used (nothing queued) or if
+        called on a different loop than the one bound at first ``write()``.
+        """
+        await self._worker.aclose()
+
+    async def flush(self) -> None:
+        """Wait until every currently-enqueued write has landed on disk,
+        WITHOUT closing the store (it stays usable afterward).
+
+        For any caller that needs to observe this store's on-disk state
+        synchronized with its own emit() calls before doing something that
+        reads the file from OUTSIDE this process (e.g. a test spawning a
+        subprocess that reads the events file fresh) — since ``write()`` is
+        fire-and-forget, nothing else guarantees that ordering. A no-op if
+        nothing is queued or if called on a different loop than the one
+        bound at first ``write()``."""
+        await self._worker.flush()
+
+    async def _do_write(self, path: Path, line: str) -> None:
+        await asyncio.to_thread(self._write_line_sync, path, line)
+
+    @staticmethod
+    def _write_line_sync(path: Path, line: str) -> None:
+        """The actual blocking append — open + write + fsync TOGETHER (no
+        written-but-not-fsynced exposure window; see module docstring).
+
+        FileNotFoundError recovery (the active file/parent dir was deleted by
+        an external process — e.g. dogfood scripts that wipe .reyn/events/
+        between scenarios while the server is still live) recreates the SAME
+        path rather than a new timestamped one (that decision belongs to the
+        synchronous ``write()``/``_open_new_file`` path, not here — this may
+        run off-loop, on a worker thread, with no access to instance state
+        beyond the path/line it was given). If the second attempt also fails,
+        the exception propagates as a persistent-failure health signal via
+        the worker (mirrors #1765's durable-write retry escalation) instead
+        of a synchronous raise to the ``emit()`` caller — an accepted
+        trade-off for a non-durability-critical audit log (see module
+        docstring's crash-recovery note).
+        """
+        try:
+            with path.open("a", encoding="utf-8") as f:
                 f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
         except FileNotFoundError:
-            # The active file (or its parent directory) was deleted by an
-            # external process (e.g. dogfood scripts that wipe .reyn/events/
-            # between scenarios while the server is still live).
-            # Recovery: reset _active and open a fresh file, then retry once.
-            # If the second attempt also fails (e.g. the directory is truly
-            # gone and cannot be recreated), re-raise so the caller sees the
-            # error rather than silently dropping events.
-            self._active = None
-            self._active_started_at = None
-            self._open_new_file(now=datetime.now())
-            with self._active.open("a", encoding="utf-8") as f:  # type: ignore[union-attr]
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+            with path.open("a", encoding="utf-8") as f:
                 f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
 
     def iter_all(self) -> Iterator[Event]:
         """Yield every event in this store in chronological order.
@@ -122,16 +245,19 @@ class EventStore:
     # ── internals ───────────────────────────────────────────────────────
 
     def _should_rotate(self) -> bool:
+        """Size check reads the in-memory running counter, not `.stat()` —
+        `max_bytes` defaults to a nonzero 10MB, so `.stat()` used to fire a
+        blocking syscall on literally EVERY `write()` call, not a rare path.
+        The counter drifts (harmlessly) if an external process appends to the
+        same file, or after a FileNotFoundError recovery re-creates it — both
+        only shift the rotation point by a bounded amount, never break
+        correctness."""
         if self._active is None or self._active_started_at is None:
             return False
         if self._max_bytes <= 0 and self._max_age_seconds <= 0:
             return False
-        if self._max_bytes > 0:
-            try:
-                if self._active.stat().st_size >= self._max_bytes:
-                    return True
-            except OSError:
-                pass
+        if self._max_bytes > 0 and self._active_size >= self._max_bytes:
+            return True
         now = datetime.now()
         if self._max_age_seconds > 0:
             elapsed = (now - self._active_started_at).total_seconds()
@@ -151,6 +277,7 @@ class EventStore:
         self._active = self._unique(candidate)
         self._active.touch()
         self._active_started_at = now
+        self._active_size = 0
 
     @staticmethod
     def _unique(path: Path) -> Path:

--- a/tests/test_2608_dogfood_hook_liveness.py
+++ b/tests/test_2608_dogfood_hook_liveness.py
@@ -37,9 +37,14 @@ def _run(args: list[str]) -> tuple[str, int]:
     return result.stdout + result.stderr, result.returncode
 
 
-def _event_log(reyn_dir: Path) -> EventLog:
+def _event_log(reyn_dir: Path) -> tuple[EventLog, EventStore]:
+    """Returns (log, store) — the caller must ``await store.flush()`` after
+    the last ``log.emit(...)`` and before spawning the subprocess below,
+    since EventStore.write() is fire-and-forget (off-loop write, #2780) and
+    the subprocess reads the events file fresh from an external process —
+    nothing else synchronizes that ordering."""
     store = EventStore(reyn_dir / "events" / "agents" / "default" / "chat")
-    return EventLog(subscribers=[store])
+    return EventLog(subscribers=[store]), store
 
 
 @pytest.mark.asyncio
@@ -48,7 +53,7 @@ async def test_hook_push_that_ran_is_not_flagged_inert(tmp_path: Path):
     is reported as ran — the healthy pairing, not flagged INERT."""
     reyn_dir = tmp_path / ".reyn"
     wal = StateLog(reyn_dir / "state" / "wal.jsonl")
-    log = _event_log(reyn_dir)
+    log, store = _event_log(reyn_dir)
 
     await wal.append(
         "inbox_put", target="test-agent", session_id="main",
@@ -58,6 +63,7 @@ async def test_hook_push_that_ran_is_not_flagged_inert(tmp_path: Path):
     # The run-loop actually picks the push up and runs a turn (real EventLog.emit,
     # the same call site as Session._handle_inbox_message's turn_started emit).
     log.emit("turn_started", kind="hook", chain_id=None)
+    await store.flush()  # ensure the write lands before the subprocess reads it
 
     out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
     assert rc == 0
@@ -73,7 +79,7 @@ async def test_inert_hook_push_is_flagged(tmp_path: Path):
     wal = StateLog(reyn_dir / "state" / "wal.jsonl")
     # An unrelated user-turn event exists (proves the mode doesn't just count
     # "any turn_started" — it specifically requires kind="hook").
-    log = _event_log(reyn_dir)
+    log, store = _event_log(reyn_dir)
     log.emit("turn_started", kind="user", chain_id=None)
 
     await wal.append(
@@ -82,6 +88,7 @@ async def test_inert_hook_push_is_flagged(tmp_path: Path):
         payload={"name": "cron_fired", "text": "tick", "wake": True, "_msg_id": "m2"},
     )
     # No turn_started(kind=hook) ever follows — the push sat in the inbox forever.
+    await store.flush()  # ensure the "user" event lands before the subprocess reads it
 
     out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
     assert rc == 0
@@ -107,7 +114,7 @@ async def test_mixed_healthy_and_inert_pushes_both_counted(tmp_path: Path):
     reported, and the summary counts split correctly (not just a boolean)."""
     reyn_dir = tmp_path / ".reyn"
     wal = StateLog(reyn_dir / "state" / "wal.jsonl")
-    log = _event_log(reyn_dir)
+    log, store = _event_log(reyn_dir)
 
     await wal.append(
         "inbox_put", target="test-agent", session_id="main",
@@ -122,6 +129,7 @@ async def test_mixed_healthy_and_inert_pushes_both_counted(tmp_path: Path):
         payload={"name": "file_changed", "text": "b", "wake": True, "_msg_id": "inert1"},
     )
     # no turn_started follows for inert1
+    await store.flush()  # ensure the written event lands before the subprocess reads it
 
     out, rc = _run(["--root", str(reyn_dir), "--mode", "hook-liveness"])
     assert rc == 0

--- a/tests/test_event_store_off_loop_write.py
+++ b/tests/test_event_store_off_loop_write.py
@@ -1,0 +1,179 @@
+"""Tier 2: EventStore off-loop write (#2780).
+
+``EventStore.write()`` used to ``open()``/``write()`` synchronously, directly
+on the event loop — the same class of bug as #1765's WAL append, except
+unmitigated (not even fsync was offloaded) and far more exposed (fires on
+every chat event, not just WAL appends). This suite verifies:
+
+- the event loop keeps making progress during a slow write (the actual bug
+  being fixed) — RED against a hypothetical synchronous write, verified via
+  the same "snapshot before draining the counter" discipline the #1765 PR's
+  own review caught (a counter drained BEFORE the snapshot passes
+  unconditionally regardless of whether the loop froze);
+- write order is preserved (enqueue order == emission order == on-disk
+  order), the "WAL-event ordering" property the owner asked about directly;
+- rotation now uses an in-memory byte counter, never ``Path.stat()`` (the
+  old code's `.stat()` fired on literally every write() call once max_bytes
+  is nonzero — the actual default — not a rare path);
+- ``aclose()``/``flush()`` drain pending writes, since ``write()`` is
+  fire-and-forget;
+- a caller with no running event loop (e.g. a synchronous CLI path) still
+  gets an immediate, synchronous write — no regression for that case.
+
+Real ``EventStore``/``DurabilityWorker`` instances, real filesystem
+(``tmp_path``), no mocks of collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.event_store import EventStore
+from reyn.schemas.models import Event
+
+
+def _ev(kind: str = "test_event", **data) -> Event:
+    return Event(type=kind, data=data)
+
+
+def _lines(path: Path) -> list[dict]:
+    return [json.loads(ln) for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+@pytest.mark.asyncio
+async def test_slow_write_does_not_freeze_the_event_loop(tmp_path, monkeypatch):
+    """Tier 2: the loop keeps advancing DURING a stalled write — the actual bug.
+
+    Snapshot BEFORE draining the counter task to completion (the #2739/#1765
+    review lesson): awaiting the counter first would make this pass
+    unconditionally regardless of whether the loop actually froze.
+    """
+    store = EventStore(tmp_path / "events")
+    orig_write_sync = store._write_line_sync
+
+    def _slow_write_sync(path, line):
+        import time
+        time.sleep(0.2)
+        return orig_write_sync(path, line)
+
+    monkeypatch.setattr(store, "_write_line_sync", _slow_write_sync)
+
+    ticks = 0
+
+    async def _counter() -> None:
+        nonlocal ticks
+        for _ in range(50):
+            await asyncio.sleep(0.005)
+            ticks += 1
+
+    counter_task = asyncio.create_task(_counter())
+    store.write(_ev("slow"))
+    await asyncio.sleep(0.21)  # let the stalled write's window pass
+    ticks_during_write = ticks
+    await counter_task
+    await store.aclose()
+    assert ticks_during_write >= 5, (
+        "the loop must keep making progress on OTHER coroutines during the "
+        "stalled write — a near-zero count means it froze"
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_order_preserved_across_concurrent_emits(tmp_path):
+    """Tier 2: enqueue order == emission order == on-disk order (the "WAL-event
+    ordering" property) — write() is synchronous and enqueues in call order,
+    and the worker's FIFO guarantee keeps that order on disk."""
+    store = EventStore(tmp_path / "events")
+    for i in range(20):
+        store.write(_ev("seq", i=i))
+    await store.aclose()
+
+    on_disk = [e["data"]["i"] for e in _lines(store.active_path)]
+    assert on_disk == list(range(20))
+
+
+@pytest.mark.asyncio
+async def test_rotation_never_calls_path_stat(tmp_path, monkeypatch):
+    """Tier 2: `_should_rotate()` uses the in-memory byte counter, not
+    `Path.stat()` — the old code's stat() fired on EVERY write() call once
+    max_bytes is nonzero (the actual default, 10MB), not a rare path.
+
+    Records calls to the ACTIVE store path specifically (rather than raising
+    from a global Path.stat monkeypatch, which corrupts pytest's own internal
+    traceback formatting — that also calls Path.stat/exists on unrelated
+    paths)."""
+    orig_stat = Path.stat
+    stat_calls: list[Path] = []
+    store = EventStore(tmp_path / "events", max_bytes=1000)
+
+    def _tracking_stat(self, *a, **kw):
+        if store.active_path is not None and self == store.active_path:
+            stat_calls.append(self)
+        return orig_stat(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "stat", _tracking_stat)
+    for i in range(10):
+        store.write(_ev("no_stat", i=i))
+    await store.aclose()
+    assert stat_calls == [], (
+        f"_should_rotate() must not stat() the active file — got {len(stat_calls)} calls"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rotation_fires_via_in_memory_counter(tmp_path):
+    """Tier 2: a write that pushes the running byte count past max_bytes
+    triggers rotation — a NEW active file is opened, proving the counter
+    (not a removed stat() call) still drives rotation correctly."""
+    store = EventStore(tmp_path / "events", max_bytes=50)
+    store.write(_ev("a", text="x" * 60))  # first write always fits (no rotation check yet)
+    first_path = store.active_path
+    store.write(_ev("b", text="y"))  # now over max_bytes → should rotate
+    second_path = store.active_path
+    await store.aclose()
+    assert second_path != first_path, "expected rotation to a new file once max_bytes is exceeded"
+
+
+@pytest.mark.asyncio
+async def test_aclose_drains_pending_writes(tmp_path):
+    """Tier 2: aclose() waits for every enqueued write to land — without it,
+    a write queued right before teardown could be silently lost (the actual
+    /quit-drops-trailing-events bug this fix addresses)."""
+    store = EventStore(tmp_path / "events")
+    store.write(_ev("before_close"))
+    await store.aclose()
+    on_disk = _lines(store.active_path)
+    assert any(e["type"] == "before_close" for e in on_disk)
+
+
+@pytest.mark.asyncio
+async def test_flush_drains_without_closing_the_store(tmp_path):
+    """Tier 2: flush() drains pending writes but the store stays usable
+    afterward (unlike aclose(), which shuts the worker down)."""
+    store = EventStore(tmp_path / "events")
+    store.write(_ev("first"))
+    await store.flush()
+    on_disk_after_flush = _lines(store.active_path)
+    assert any(e["type"] == "first" for e in on_disk_after_flush)
+
+    # Store still works after flush — not torn down.
+    store.write(_ev("second"))
+    await store.aclose()
+    on_disk_final = _lines(store.active_path)
+    assert {e["type"] for e in on_disk_final} == {"first", "second"}
+
+
+def test_write_without_running_loop_falls_back_to_synchronous(tmp_path):
+    """Tier 2: a caller with no running event loop (e.g. a synchronous CLI
+    entry point) still gets an immediate write — submit_nowait requires a
+    running loop and would otherwise raise, a regression this fix must not
+    introduce. This test is deliberately a plain `def`, not `async def`, so
+    there is no running loop."""
+    store = EventStore(tmp_path / "events")
+    store.write(_ev("sync_fallback"))
+    # No await/aclose needed — the write already happened synchronously.
+    on_disk = _lines(store.active_path)
+    assert any(e["type"] == "sync_fallback" for e in on_disk)

--- a/tests/test_multisession_history_isolation_2348.py
+++ b/tests/test_multisession_history_isolation_2348.py
@@ -81,6 +81,10 @@ async def test_spawned_events_isolated_and_forwarder_survives_rewire(tmp_path, m
     msg = a.outbox.get_nowait()
     assert "budget warn" in msg.text, "ChatLifecycleForwarder must survive set_events_dir (no drop)"
 
+    # EventStore.write() is fire-and-forget off-loop (#2780) — flush before reading
+    # the file from outside the EventLog/EventStore's own machinery.
+    await a._event_store.flush()
+
     # the event reached A's NEW per-session store, and did NOT leak into main's shared tree.
     a_blob = "".join(p.read_text() for p in a.events_dir.rglob("*.jsonl"))
     assert "budget_warn" in a_blob, "event must be written to A's per-session events store"


### PR DESCRIPTION
**[tui-coder]** —

## Summary

`EventStore.write()` did synchronous `open()`/`write()` directly on the event loop — the same class of bug as #1765's WAL append (a filesystem stall freezes the WHOLE event loop), except **unmitigated** (not even fsync was offloaded) and **far more exposed**: fires on every chat event (at least once per turn via `turn_completed`, plus once per tool call, per hook, etc.), not just WAL appends.

Owner-driven investigation (sync-API audit of the turn hot path, following the #1765 precedent) traced the root cause and designed the fix (Fable-reviewed, lead-coder review-gate items folded in — see below). Owner GO to implement.

## Fix

- Reuses `DurabilityWorker` (the same off-loop primitive #1765 introduced — substrate-agnostic by that class's own design, no reinvention) via `submit_nowait`. `write()` stays a plain synchronous method — **no API change, no caller updates** anywhere `emit()`/`write()` is called across the codebase.
- Rotation decision + JSON serialization still happen synchronously at `write()`-call time, so enqueue order == emission order; the worker's FIFO guarantee then keeps on-disk order matching emission order too — this log's ordering relative to other synchronous code (WAL appends included) is unchanged from before this fix.
- **Durability discipline mirrors the WAL fix** (lead-coder review-gate item): the single off-loop unit (`_write_line_sync`) does open + write + flush + **fsync together**, so there is no "written but not yet fsynced" exposure window within one queued job. `submit_nowait` (not `submit`) means `write()` itself doesn't await that durability — a relaxed-durability window, the same accepted trade-off the WAL's own `append_nowait`/`submit_nowait` fire-and-forget path already carries elsewhere in this codebase, not a new risk class.
- Falls back to a fully synchronous write when no event loop is running (e.g. a CLI entry point) — `submit_nowait` requires a running loop and would otherwise raise, a regression this fix must not introduce.
- **Second bug found and fixed during this work**: `_should_rotate()`'s size check called `Path.stat()` on **literally every `write()` call** (`max_bytes` defaults to a nonzero 10MB — not a rare rotation-time-only path as originally assumed). Replaced with an in-memory running byte counter — eliminates the syscall entirely rather than just deferring it.
- Added `EventStore.aclose()`/`flush()` (mirroring `StateLog`'s) so a normal `/quit` doesn't silently drop the trailing audit events (e.g. `session_completed` — the event recording the graceful exit itself) when `asyncio.run()` cancels outstanding tasks at teardown.

## Crash-recovery / doc-mirror gate (explicit per lead-coder's review-gate ask)

- **Recovery-feature truncate-falsify gate: does NOT apply.** `anchor_store.py` explicitly documents EventStore has no WAL seq and is deliberately not used for rewind/reconstruction ("mining the audit EventStore... would need a cross-log join" — #1547). This fix touches only the audit log, never WAL-event-derived reconstruction state.
- **`events.md` doc-mirror: not needed.** Checked both `docs/concepts/runtime/events.md` and `docs/reference/runtime/events.md` — neither makes an implementation-level claim (synchronous write, fsync timing) that this fix would contradict. The documented contract ("records what happened, in order") is unchanged; only the blocking-vs-non-blocking write mechanism changed.
- **Follow-up tracked separately**: while wiring `aclose()`, discovered `StateLog.aclose()` (from #1765) is *also* never called from production teardown (only from tests) — filed as #2783, out of scope here (needs its own investigation across multiple process-teardown entry points).

## Test plan

- [x] `pytest tests/test_event_store_off_loop_write.py` (new, 7 tests) — RED→GREEN verified via `git stash` (6/7 failed with `AttributeError` on the new seams pre-fix; the 7th, the sync-fallback test, correctly passes both before and after since it exercises unchanged behavior)
- [x] Loop-freeze regression test uses the snapshot-before-drain discipline (the #2739/#1765 review lesson — a counter drained to completion first would pass unconditionally regardless of whether the loop froze)
- [x] `pytest tests/test_event_store_stale_path_recovery.py tests/test_2608_dogfood_hook_liveness.py tests/test_multisession_history_isolation_2348.py` (existing EventStore-adjacent suites) — all pass; two tests needed a `await store.flush()` added (they read the events file from an async context immediately after `emit()`, an assumption `write()` being fire-and-forget now breaks — both were genuine regressions caught by the full suite run, not pre-existing)
- [x] `ruff check` / `python scripts/test_tier_audit.py --strict` / `python scripts/verify_module_docstrings.py` (all changed files) — clean
- [x] Full `pytest` suite — 8006 passed, 9 failed (pre-existing/environmental, unrelated files — same known baseline as prior PRs this session), 17 skipped