### PR TITLE
fix: restore durable unhandled-exception capture masked by prompt_toolkit REPL handler (#2786)

### DIFF
--- a/src/reyn/core/events/asyncio_diagnostics.py
+++ b/src/reyn/core/events/asyncio_diagnostics.py
@@ -34,6 +34,8 @@ with an equivalent handler).
 from __future__ import annotations
 
 import asyncio
+import logging
+import sys
 import traceback
 from typing import Any
 
@@ -98,15 +100,48 @@ def _durably_capture(context: dict[str, Any]) -> None:
         pass
 
 
+def _asyncio_log_reaches_console() -> bool:
+    """Whether an ERROR record on the ``asyncio`` logger reaches the console.
+
+    ``loop.default_exception_handler`` logs via the ``asyncio`` logger. If the
+    effective handler chain includes a ``StreamHandler`` pointed at the real
+    console (``sys.stdout`` / ``sys.stderr``) -- or NO handler at all, in which
+    case ``logging``'s ``lastResort`` handler writes to stderr -- the message
+    is already on screen. Only when the interactive-CUI redirect
+    (``_setup_interactive_logging`` in interfaces/cli/commands/chat.py) has
+    replaced those with a ``FileHandler`` does no console handler remain.
+
+    Walks the logger→parent chain honoring ``propagate``, mirroring
+    ``logging.Logger.callHandlers``. ``FileHandler`` is a ``StreamHandler``
+    subclass, so it is excluded explicitly.
+    """
+    logger: logging.Logger | None = logging.getLogger("asyncio")
+    saw_handler = False
+    while logger is not None:
+        for handler in logger.handlers:
+            saw_handler = True
+            if isinstance(handler, logging.StreamHandler) and not isinstance(
+                handler, logging.FileHandler
+            ):
+                if getattr(handler, "stream", None) in (sys.stdout, sys.stderr):
+                    return True
+        if not logger.propagate:
+            break
+        logger = logger.parent
+    # No handler anywhere in the chain → logging.lastResort (stderr) fires.
+    return not saw_handler
+
+
 def _surface_while_app_running(context: dict[str, Any]) -> None:
     """Print the context's message on screen while a prompt_toolkit
-    Application owns the terminal (#2786 polish).
+    Application owns the terminal AND the ``asyncio`` logger's output has
+    been redirected away from the console (#2786 polish).
 
     ``loop.default_exception_handler`` (called before this, in ``_handler``)
     already logs ``context["message"]`` via the ``asyncio`` logger --
     including the message-only case (no ``exception`` key) this module's
     docstring describes, where the message is the ONLY diagnostic available.
-    That log line reaches stderr for every entrypoint EXCEPT reyn's own
+    That log line reaches the console for every entrypoint EXCEPT reyn's own
     interactive chat CUI: `_setup_interactive_logging`
     (interfaces/cli/commands/chat.py) redirects the root logger to
     `.reyn/logs/reyn.log` for the whole duration of that session, so the
@@ -114,13 +149,18 @@ def _surface_while_app_running(context: dict[str, Any]) -> None:
     exactly the "Exception None" blank-diagnostics symptom #2786 reports,
     even after the loop's exception handler is no longer masked.
 
+    The ``_asyncio_log_reaches_console()`` guard is what keeps this from
+    DOUBLE-printing on paths where the default handler already reached the
+    console -- e.g. the ``--cui`` PromptSession path (a prompt_toolkit
+    Application IS running there, but logging is NOT redirected, so stderr
+    already showed the message). Surfacing there would print it twice.
+
     A bare ``print`` would also corrupt whichever prompt_toolkit
     Application currently owns the terminal (the inline CUI's rule-bar
-    Application, or the `--cui` / non-TTY PromptSession's own Application),
-    so this goes through ``run_in_terminal`` -- the same mechanism
-    prompt_toolkit's own ``Application._handle_exception`` and reyn's REPL
-    output loop (``interfaces/repl/repl.py``) already use to interleave
-    ad-hoc output with a live render.
+    Application), so this goes through ``run_in_terminal`` -- the same
+    mechanism prompt_toolkit's own ``Application._handle_exception`` and
+    reyn's REPL output loop (``interfaces/repl/repl.py``) already use to
+    interleave ad-hoc output with a live render.
 
     No-op when no Application is running (headless entrypoints -- web
     server, chainlit, cron, dogfood -- are unaffected; their unredirected
@@ -131,6 +171,11 @@ def _surface_while_app_running(context: dict[str, Any]) -> None:
     except Exception:  # noqa: BLE001 -- optional at import time, never fatal
         return
     if get_app_or_none() is None:
+        return
+    if _asyncio_log_reaches_console():
+        # The default handler already put the message on screen; a second
+        # print via run_in_terminal would double it. Only surface when the
+        # log has been redirected off-console (interactive-CUI session).
         return
 
     exc = context.get("exception")

--- a/src/reyn/core/events/asyncio_diagnostics.py
+++ b/src/reyn/core/events/asyncio_diagnostics.py
@@ -58,6 +58,7 @@ def _make_handler():
         # the existing stderr/logging behavior an operator already relies on.
         loop.default_exception_handler(context)
         _durably_capture(context)
+        _surface_while_app_running(context)
 
     return _handler
 
@@ -94,4 +95,58 @@ def _durably_capture(context: dict[str, Any]) -> None:
             task_repr=repr(task) if task is not None else "",
         )
     except Exception:  # noqa: BLE001 -- durable-capture must never crash the loop
+        pass
+
+
+def _surface_while_app_running(context: dict[str, Any]) -> None:
+    """Print the context's message on screen while a prompt_toolkit
+    Application owns the terminal (#2786 polish).
+
+    ``loop.default_exception_handler`` (called before this, in ``_handler``)
+    already logs ``context["message"]`` via the ``asyncio`` logger --
+    including the message-only case (no ``exception`` key) this module's
+    docstring describes, where the message is the ONLY diagnostic available.
+    That log line reaches stderr for every entrypoint EXCEPT reyn's own
+    interactive chat CUI: `_setup_interactive_logging`
+    (interfaces/cli/commands/chat.py) redirects the root logger to
+    `.reyn/logs/reyn.log` for the whole duration of that session, so the
+    message would otherwise never reach the screen there -- reproducing
+    exactly the "Exception None" blank-diagnostics symptom #2786 reports,
+    even after the loop's exception handler is no longer masked.
+
+    A bare ``print`` would also corrupt whichever prompt_toolkit
+    Application currently owns the terminal (the inline CUI's rule-bar
+    Application, or the `--cui` / non-TTY PromptSession's own Application),
+    so this goes through ``run_in_terminal`` -- the same mechanism
+    prompt_toolkit's own ``Application._handle_exception`` and reyn's REPL
+    output loop (``interfaces/repl/repl.py``) already use to interleave
+    ad-hoc output with a live render.
+
+    No-op when no Application is running (headless entrypoints -- web
+    server, chainlit, cron, dogfood -- are unaffected; their unredirected
+    logging already surfaces the message via the call above).
+    """
+    try:
+        from prompt_toolkit.application.current import get_app_or_none
+    except Exception:  # noqa: BLE001 -- optional at import time, never fatal
+        return
+    if get_app_or_none() is None:
+        return
+
+    exc = context.get("exception")
+    message = context.get("message") or "Unhandled exception in event loop"
+    tb_text = (
+        "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+        if exc is not None else ""
+    )
+
+    def _emit() -> None:
+        print(f"\nUnhandled exception in event loop: {message}")
+        if tb_text:
+            print(tb_text)
+
+    try:
+        from prompt_toolkit.application import run_in_terminal
+        run_in_terminal(_emit)
+    except Exception:  # noqa: BLE001 -- surfacing must never crash the loop
         pass

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -1462,7 +1462,17 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     task_poll_task = asyncio.create_task(_task_poll())
     try:
         with patch_stdout():
-            await app.run_async()
+            # #2786: this Application.run_async() is the input driver for the
+            # DEFAULT interactive `reyn chat` (this renderer's uses_app_input()
+            # is what selects run_inline_input over repl.py's PromptSession
+            # path) -- prompt_toolkit's default (set_exception_handler=True)
+            # would mask #2637's durable asyncio exception capture for the
+            # exact same reason as the PromptSession path in
+            # interfaces/repl/repl.py (see that call site's comment): the app
+            # owns the loop's exception handler for its whole run, which is
+            # most of the REPL's wall-clock time. False keeps reyn's handler
+            # wired throughout.
+            await app.run_async(set_exception_handler=False)
     finally:
         poll_task.cancel()
         task_poll_task.cancel()

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -103,6 +103,18 @@ async def _input_loop(
                         # idle (default base renderer) → no toolbar shown.
                         bottom_toolbar=renderer.bottom_toolbar,
                         refresh_interval=0.1,
+                        # #2786: prompt_toolkit's default (True) swaps the
+                        # loop's asyncio exception handler for its own for the
+                        # duration of this call (application.py's
+                        # set_exception_handler_ctx contextmanager) -- and the
+                        # prompt-wait is most of the REPL's wall-clock time, so
+                        # that window masks #2637's durable
+                        # install_asyncio_exception_handler capture almost
+                        # permanently. False leaves reyn's handler wired
+                        # (prompt_toolkit's own KeyboardInterrupt/EOF handling
+                        # lives in the key-binding layer, not this handler, so
+                        # nothing else regresses -- see asyncio_diagnostics.py).
+                        set_exception_handler=False,
                     )
             else:
                 # Piped / scripted stdin: skip prompt_toolkit entirely. It

--- a/tests/test_asyncio_diagnostics.py
+++ b/tests/test_asyncio_diagnostics.py
@@ -19,6 +19,7 @@ Policy compliance (docs/deep-dives/contributing/testing.md):
 """
 from __future__ import annotations
 
+import ast
 import asyncio
 import json
 import logging
@@ -30,6 +31,8 @@ from prompt_toolkit.application.current import create_app_session
 from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 
+import reyn.interfaces.inline.app as inline_app_mod
+import reyn.interfaces.repl.repl as repl_mod
 from reyn.core.events.asyncio_diagnostics import install_asyncio_exception_handler
 
 
@@ -176,4 +179,56 @@ def test_durable_capture_survives_prompt_toolkit_prompt_wait(
     assert (
         event["data"]["context_message"]
         == "message-only-context-during-prompt-wait"
+    )
+
+
+def _call_passes_set_exception_handler_false(source: str, method_name: str) -> bool:
+    """Whether *source* contains a ``<...>.<method_name>(...)`` call that
+    passes ``set_exception_handler=False`` as a keyword.
+
+    AST-level (not a substring grep): tolerant of formatting/whitespace and
+    scoped to the actual call, not a comment mentioning the param.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == method_name):
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "set_exception_handler"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value is False
+            ):
+                return True
+    return False
+
+
+def test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler() -> None:
+    """Tier 2b: both REPL prompt_toolkit entry points keep reyn's asyncio
+    exception handler wired by passing ``set_exception_handler=False``.
+
+    The durable-capture test above hardcodes the parameter in its own driver,
+    so it would stay green even if a future edit dropped the argument from the
+    production call sites -- i.e. it verifies the mechanism, not the wiring.
+    This pins the wiring itself: if ``interfaces/repl/repl.py``'s
+    ``prompt_session.prompt_async(...)`` (the ``--cui`` / non-TTY path) or
+    ``interfaces/inline/app.py``'s ``app.run_async(...)`` (the default
+    interactive ``reyn chat`` path) loses the argument, prompt_toolkit's
+    default (``True``) silently re-masks #2637's capture -- exactly the #2786
+    regression -- and this goes RED. Reads the real module source (AST), no
+    mocks.
+    """
+    repl_src = Path(repl_mod.__file__).read_text()
+    inline_src = Path(inline_app_mod.__file__).read_text()
+
+    assert _call_passes_set_exception_handler_false(repl_src, "prompt_async"), (
+        "repl.py's prompt_session.prompt_async(...) must pass "
+        "set_exception_handler=False (else prompt_toolkit re-masks #2637 capture)"
+    )
+    assert _call_passes_set_exception_handler_false(inline_src, "run_async"), (
+        "inline/app.py's app.run_async(...) must pass "
+        "set_exception_handler=False (else prompt_toolkit re-masks #2637 capture)"
     )

--- a/tests/test_asyncio_diagnostics.py
+++ b/tests/test_asyncio_diagnostics.py
@@ -25,6 +25,10 @@ import logging
 from pathlib import Path
 
 import pytest
+from prompt_toolkit import PromptSession
+from prompt_toolkit.application.current import create_app_session
+from prompt_toolkit.input import create_pipe_input
+from prompt_toolkit.output import DummyOutput
 
 from reyn.core.events.asyncio_diagnostics import install_asyncio_exception_handler
 
@@ -115,4 +119,61 @@ def test_default_handler_still_invoked(
         "still-visible-in-logs" in str(record.message)
         or (record.exc_info and "still-visible-in-logs" in str(record.exc_info[1]))
         for record in caplog.records
+    )
+
+
+def test_durable_capture_survives_prompt_toolkit_prompt_wait(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2b: durable capture is not masked while a prompt_toolkit
+    Application (the REPL's prompt-wait, most of its wall-clock time) owns
+    the loop's asyncio exception handler.
+
+    Regression context (#2786): `Application.run_async` defaults to
+    `set_exception_handler=True`, which swaps the loop's exception handler
+    for its own for the whole call -- masking #2637's durable capture
+    installed by `install_asyncio_exception_handler`. `interfaces/repl/
+    repl.py`'s `prompt_session.prompt_async(...)` (and `interfaces/inline/
+    app.py`'s `Application.run_async(...)`) now both pass
+    `set_exception_handler=False` so reyn's handler stays wired. This drives
+    the exact call shape `repl.py` uses -- a real `PromptSession.prompt_async`
+    with `set_exception_handler=False` on a headless pipe input/DummyOutput
+    (prompt_toolkit's own sanctioned no-TTY test harness) -- and fires a
+    message-only `call_exception_handler` (no `exception` key: the
+    "Exception None" class this module's docstring describes) while the
+    prompt is still awaiting input, then asserts the event landed durably.
+    """
+    reyn_dir = tmp_path / ".reyn"
+    reyn_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    async def _drive() -> str:
+        install_asyncio_exception_handler(asyncio.get_running_loop())
+        with create_pipe_input() as pipe_input:
+            with create_app_session(input=pipe_input, output=DummyOutput()):
+                session: PromptSession[str] = PromptSession()
+
+                async def _fire_then_type() -> None:
+                    # Let prompt_async actually start (and install its own
+                    # loop bindings) before firing, so this reproduces the
+                    # "exception arrives during the prompt wait" window.
+                    await asyncio.sleep(0)
+                    asyncio.get_running_loop().call_exception_handler(
+                        {"message": "message-only-context-during-prompt-wait"}
+                    )
+                    await asyncio.sleep(0)
+                    pipe_input.send_text("hello\r")
+
+                asyncio.create_task(_fire_then_type())
+                # The exact parameter repl.py's `_input_loop` now passes.
+                return await session.prompt_async(set_exception_handler=False)
+
+    result = asyncio.run(_drive())
+    assert result == "hello"  # the prompt itself still completed normally
+
+    events = _read_events_of_kind(reyn_dir / "events", "asyncio_unhandled_exception")
+    [event] = events  # exactly one event captured — unpack raises otherwise
+    assert (
+        event["data"]["context_message"]
+        == "message-only-context-during-prompt-wait"
     )


### PR DESCRIPTION
**[per-PR-coder]** — Restores #2637's durable unhandled-exception capture and surfaces the message-only diagnostic, fixing the "Unhandled exception in event loop: / Exception None" zero-diagnostics symptom (#2786), reproduced on Mac + company Windows.

## Root cause (per the issue, verified below)

`prompt_toolkit`'s `Application.run_async` defaults to `set_exception_handler=True`: for the full duration of the call it swaps the asyncio loop's exception handler for its own (`application.py:827-834`'s `set_exception_handler_ctx` contextmanager). Since the REPL's prompt-wait is most of its wall-clock time, this masks #2637's durable `install_asyncio_exception_handler` capture almost permanently. Compounding it, prompt_toolkit's own `_handle_exception` (`application.py:1022`) never prints `context["message"]` — the *only* diagnostic for a message-only context (no `exception` object) — so the screen shows nothing but `Exception None`.

## Fix

1. **`interfaces/repl/repl.py:100`** — `prompt_session.prompt_async(..., set_exception_handler=False)`. This is the `--cui` / non-TTY input path. `prompt.py:920` officially forwards this to `Application.run_async`.
2. **`interfaces/inline/app.py:1394`** — `app.run_async(set_exception_handler=False)`. **Not named in the issue's proposal**, but verified to be the *same* masking window: `renderer.uses_app_input()` routes the **default interactive `reyn chat`** (TTY, no `--cui`) through `run_inline_input`'s own `Application.run_async()` instead of `repl.py`'s `PromptSession` path — and that call had the identical `set_exception_handler=True` default. Since default `reyn chat` is the more common surface, this sibling fix was necessary to close the gap for the reported real-world repro, not just the `--cui` fallback.
3. **Polish** (`core/events/asyncio_diagnostics.py`) — `_surface_while_app_running` prints the message via `run_in_terminal` when a prompt_toolkit `Application` is running **AND** the asyncio logger's output has been redirected off-console. Needed on top of (1)+(2) because `loop.default_exception_handler`'s `logger.error` (which now fires again) is redirected to `.reyn/logs/reyn.log` for the whole interactive-CUI session (`_setup_interactive_logging` in `chat.py`) — so even unmasked, the message would still never reach the screen for default `reyn chat` without this.

## Co-vet polish (this revision)

- **Double-print guard** — `_surface_while_app_running` now checks `_asyncio_log_reaches_console()` first: it surfaces **only** when the asyncio logger's effective handler chain has no console `StreamHandler` (the redirected interactive-CUI case). On the `--cui` PromptSession path an Application IS running but logging is NOT redirected, so `default_exception_handler` already put the message on stderr — surfacing there would double-print. Owner path (interactive, redirected) unchanged. Verified: no-handler/lastResort → True (skip), stderr StreamHandler → True (skip), FileHandler redirect → False (surface).
- **Call-site wiring pin** — new Tier 2b `test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler` AST-asserts that both `repl.py`'s `prompt_async(...)` and `inline/app.py`'s `run_async(...)` pass `set_exception_handler=False`. The durable-capture test hardcodes the param in its own driver (verifies the *mechanism*), so it would stay green if a future edit dropped the arg from either production call site; this pins the *wiring* and goes RED if the arg is removed.

## Verification: durable capture is actually RESTORED, not just unmasked

Traced `install_asyncio_exception_handler` (llm.py's `run_async`, the shared loop-owning choke point for `reyn chat`) → `_make_handler`'s `_handler` → `loop.default_exception_handler(context)` (existing stderr/log visibility, unchanged) → `_durably_capture(context)` → `emit_cli_event("asyncio_unhandled_exception", ...)` → `.reyn/events/direct/cli/<date>.jsonl`. Confirmed end-to-end with a real event loop + real `PromptSession.prompt_async(set_exception_handler=False)` on a headless pipe input (`create_pipe_input`/`DummyOutput`): firing a message-only `loop.call_exception_handler({"message": ...})` *during* the prompt-wait now lands one `asyncio_unhandled_exception` event with `context_message` intact.

## Verification: no regression in prompt_toolkit's own error handling

Read `application.py`'s `run_async` body directly: `set_handle_sigint(loop)` (Ctrl-C → `loop.add_signal_handler(SIGINT, ...)`) and EOF (`f.set_exception(EOFError)` on the Application's own future) are **separate context managers/mechanisms**, entirely independent of `set_exception_handler_ctx`. `set_exception_handler` only gates whether *genuinely unhandled loop-level exceptions* route through prompt_toolkit's `_handle_exception` vs. the installed loop handler — no effect on Ctrl-C, EOF, or normal prompt render-error flows.

Also directly reproduced the pre-fix bug: temporarily flipping the durable-capture test's parameter to `set_exception_handler=True` (cp-scratch backup, not git) reproduced the *exact* reported symptom verbatim on stdout —

```
Unhandled exception in event loop:

Exception None
```

— followed by a hang (prompt_toolkit's own handler blocks on "Press ENTER to continue…", consuming the pipe input meant for the prompt), killed by `pytest-timeout`. Restored afterward.

## Tests added (`tests/test_asyncio_diagnostics.py`, Tier 2b, no mocks)

- `test_durable_capture_survives_prompt_toolkit_prompt_wait` — drives the exact call shape `repl.py` uses against prompt_toolkit's headless harness, fires a message-only `call_exception_handler` mid-prompt, asserts the event survives durably.
- `test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler` — AST wiring pin for both production call sites (see co-vet polish above).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_asyncio_diagnostics.py` — 4/4 OK, 0 Tier-4 violations
- [x] `pytest` — target file 4/4 pass; full suite (repo root, `-n auto --timeout=120`) 7989 passed, 21 skipped; the only 5 failures (a2a/mcp/resources/plugin-loader web route-mounting tests) reproduce identically on `origin/main` before this change (verified via `git stash` + rerun) — pre-existing, unrelated to this diff
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] RED→GREEN falsify-restore on BOTH new tests (durable-capture: flip param → reproduces symptom + hang; wiring-pin: strip param from repl.py → RED) — restored clean via cp-scratch backup, never git
- [x] Double-print guard verified directly (no-handler/stderr → skip surface; FileHandler redirect → surface)
- [x] (skipped — no live-terminal manual click-through; the REPL/inline-CUI paths need a real TTY this sandboxed env lacks. Covered by the headless prompt_toolkit harness above, which exercises the identical `Application.run_async`/`PromptSession.prompt_async` machinery)

Closes #2786