### PR TITLE
fix: close litellm async clients on shutdown to stop aiohttp session leak (#2787)

### DIFF
--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -481,6 +481,58 @@ async def shutdown_logging() -> None:
         pass
 
 
+async def _close_litellm_async_clients() -> None:
+    """Close LiteLLM's cached aiohttp-backed async HTTP clients before the
+    event loop closes (issue #2787).
+
+    Background:
+      LiteLLM's default async transport (`litellm/llms/custom_httpx/
+      aiohttp_transport.py`) is a real `aiohttp.ClientSession` cached in
+      the process-wide `litellm.in_memory_llm_clients_cache`.
+      `ClientSession.__del__` / `BaseConnector.__del__` fire a
+      "message"-only (no ``exception`` key) `loop.call_exception_handler`
+      context plus a `ResourceWarning` when a session/connector is
+      garbage-collected still open -- this is exactly the "Unhandled
+      exception in event loop: / Exception None" noise reported in #2787.
+
+      LiteLLM ships the fix as an explicit opt-in util rather than an
+      automatic close, because its cache intentionally does NOT close
+      evicted/cached clients itself (an in-flight request may still be
+      using one) — see `litellm.caching.llm_caching_handler.
+      LLMClientCache`'s docstring: "For explicit shutdown cleanup, use
+      close_litellm_async_clients()". LiteLLM also self-registers an
+      atexit hook for this (`register_async_client_cleanup`, lazy-loaded
+      on first `litellm.<attr>` access) but that hook recreates a brand
+      new event loop *after* ours has already closed — fragile,
+      especially cross-platform (matches the "recurs on both Mac and
+      Windows" note in #2787). Calling the same util explicitly here,
+      on the still-alive loop, is the deterministic version of that same
+      cleanup, and it is where `shutdown_logging` already lives (same
+      finally, same choke point for `reyn chat` / `--once` / the mcp.py
+      CLI commands that route through `run_async`).
+
+      Must run *after* `shutdown_logging`: `clear_queue()` awaits
+      queued LiteLLM `async_success_handler` coroutines, which may still
+      need the cached async client to complete (e.g. a logging
+      integration's own HTTP call) -- closing the client first could
+      break that drain.
+
+      Idempotent / safe to call when no client was ever created: the
+      function iterates `litellm.in_memory_llm_clients_cache.cache_dict`
+      (empty cache → no-op) and each handler's own `close()` checks
+      `.closed` before acting, so calling it twice (or on a fully cold
+      cache) never raises or double-closes.
+    """
+    try:
+        from litellm.llms.custom_httpx.async_client_cleanup import (
+            close_litellm_async_clients,
+        )
+        await close_litellm_async_clients()
+    except Exception:
+        # Best-effort: never raise from shutdown.
+        pass
+
+
 def run_async(coro: Coroutine[object, object, T]) -> T:
     """`asyncio.run` plus LiteLLM logging-worker drain. See `shutdown_logging`.
 
@@ -500,6 +552,7 @@ def run_async(coro: Coroutine[object, object, T]) -> T:
             return await coro
         finally:
             await shutdown_logging()
+            await _close_litellm_async_clients()
 
     return asyncio.run(_wrapped())
 

--- a/tests/test_llm_run_async_shutdown_litellm_clients_2787.py
+++ b/tests/test_llm_run_async_shutdown_litellm_clients_2787.py
@@ -1,0 +1,49 @@
+"""Tier 2b: run_async's shutdown path closes litellm's cached async HTTP
+client(s), preventing the "Unclosed client session" / "Unclosed connector"
+GC-time warnings (surfaced as "Unhandled exception in event loop: /
+Exception None") reported in #2787.
+
+Uses litellm's real async-client cache + real aiohttp objects (no mocks —
+`unittest.mock` is forbidden by testing policy). Asserts on the client
+session's own public `closed` attribute (aiohttp's documented public
+surface for this exact check), not any reyn-private state.
+"""
+from reyn.llm.llm import run_async
+
+
+def test_run_async_closes_cached_litellm_async_client() -> None:
+    """Tier 2b: a litellm async client created during a `run_async` call is
+    closed by the time `run_async` returns, not left for `__del__`/GC.
+
+    Regression guard for #2787 (aiohttp `Unclosed client session` /
+    `Unclosed connector` warnings firing from `__del__` at shutdown,
+    surfacing as "Unhandled exception in event loop: Exception None").
+    """
+    async def _create_litellm_async_client():
+        # Exercises litellm's real cache + real aiohttp-backed transport —
+        # the same call shape `litellm.acompletion(...)` makes internally
+        # for the aiohttp-transport providers (issue #2787's leak class).
+        from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+
+        handler = get_async_httpx_client(llm_provider="vertex_ai")
+        session = handler.client._transport._get_valid_client_session()
+        return session
+
+    session = run_async(_create_litellm_async_client())
+
+    # Public attribute of aiohttp.ClientSession — not reyn-private state.
+    assert session.closed is True
+
+
+def test_run_async_shutdown_is_idempotent_with_no_litellm_client_created() -> None:
+    """Tier 2b: `run_async`'s litellm-client-close step is a no-op (does not
+    raise) when no litellm async client was ever created during the run —
+    the common case for LLM-free `run_async` callers (e.g. mcp.py CLI
+    commands that never call an LLM).
+    """
+    async def _no_llm_call() -> str:
+        return "done"
+
+    # Must not raise even though no litellm async client cache entry exists
+    # for this call.
+    assert run_async(_no_llm_call()) == "done"


### PR DESCRIPTION
**[per-PR-coder]** — fix for #2787 (litellm aiohttp async-client leak → "Unclosed client session/connector" GC-time warnings surfacing as "Unhandled exception in event loop: / Exception None").

## Fix

`run_async`'s shutdown `finally` (`src/reyn/llm/llm.py`) — the same choke point where `shutdown_logging()` already drains LiteLLM's async logging worker — now also calls litellm's own `close_litellm_async_clients()` (`litellm.llms.custom_httpx.async_client_cleanup`) immediately afterward, on the still-alive event loop, before `asyncio.run()` closes it.

```python
finally:
    await shutdown_logging()
    await _close_litellm_async_clients()
```

Ordering is deliberate: `shutdown_logging`'s `clear_queue()` awaits queued `async_success_handler` coroutines, which may still need the cached async client (e.g. a logging integration's own HTTP call) — closing the client first could break that drain.

## Symbol-existence verification (pinned litellm 1.89.3)

```
>>> from litellm.llms.custom_httpx.async_client_cleanup import close_litellm_async_clients
```
exists, is `async`, and iterates `litellm.in_memory_llm_clients_cache.cache_dict`, calling each cached handler's own `close()` (or `.aclose()`). Confirmed live against the installed package (not from memory).

litellm *also* self-registers an atexit hook for the same cleanup (`register_async_client_cleanup`, lazy-triggered on first `litellm.<attr>` access — which every `litellm.acompletion()` call causes). That hook works by **creating a brand-new event loop after ours has already closed** (`asyncio.new_event_loop()` + `loop.run_until_complete(...)`) — explicitly to work around the main loop being gone by atexit time. This is more fragile than closing on the *original*, still-running loop, especially cross-platform — plausibly why #2787 recurred on both Mac and (the reporter's) Windows.

## Idempotence / lifecycle-placement verification

- **Safe with no client ever created**: the function iterates a `cache_dict` that's empty if no LLM call happened; no-op, no exception. Verified via `test_run_async_shutdown_is_idempotent_with_no_litellm_client_created`.
- **Safe to call twice / no double-close error**: each handler's own `close()` checks `.closed`/`is_closed()` before acting (verified by reading `BaseLLMAIOHTTPHandler.close()` and `LiteLLMAiohttpTransport`), and `close_litellm_async_clients()` itself wraps each handler's close in a `try/except: pass`.
- **Placement**: inside `run_async`'s `finally`, after `await coro` completes and after `shutdown_logging()` drains any pending logging-callback coroutines that might still need the client — i.e. after all LLM calls (and their logging tail) are done, before `asyncio.run()` tears down the loop. This is the single choke point for `reyn chat` (interactive REPL), `reyn run-once` (`--once`), and the mcp.py CLI commands that route through `run_async`.

## Leak-gone evidence (live, real objects, no mocks)

Live repro against the actual wired `run_async()`:
```
session.closed immediately after run_async() returns: True
ResourceWarnings captured post-gc: []
loop.call_exception_handler contexts captured: []
```
(created a real `litellm` async client via `get_async_httpx_client(llm_provider="vertex_ai")` — the same call litellm's Gemini/Vertex AI async-completion path makes internally — inside a `run_async(...)` call; before the fix, `session.closed` was `False` on return and a later `gc.collect()` fired the `__del__`-based `ResourceWarning` + a no-`exception` `loop.call_exception_handler` context, i.e. exactly the reported "Exception None" shape; after the fix, `session.closed` is `True` immediately on return and no warning/handler-call ever fires).

## Root-cause / leak-class investigation (honest scoping — please read before merging)

The issue's own report describes the warning firing **mid-session** (during a chat turn, right after a large tool result — a GC trigger point), not at process exit. I dug into whether the `run_async`-shutdown fix above actually addresses *that* symptom, or only a distinct end-of-run leak. Traced two candidate mechanisms against real litellm 1.89.3 source (no mocks):

- **(A) TTL-based cache eviction** — `litellm.caching.llm_caching_handler.LLMClientCache`'s own docstring: *"intentionally does NOT close clients on eviction... rely on GC... For explicit shutdown cleanup, use close_litellm_async_clients()."* (TTL = 3600s.) Tested and **found not reproducible** on reyn's actual Gemini/vertex_ai provider path: the same cached client is *also* pinned by an unrelated, process-lifetime singleton (`litellm.llms.vertex_ai.files.handler.VertexAIFilesHandler`) that holds its own persistent reference — clearing the cache dict (simulating TTL eviction) does not orphan the object (confirmed via `gc.get_referrers()`).
- **(B) Per-call transient client created/discarded on error or a different event loop** — `aiohttp_transport.py`'s `_get_valid_client_session()` has a documented `# Different event loop - can't schedule task, rely on GC` fallback. Traced but **not confirmed reachable**: reyn's `run_async` holds one stable event loop for an entire chat/REPL session or `--once` invocation; the cache key already embeds the loop's `id()`; the two `get_async_httpx_client()` call sites in `vertex_and_google_ai_studio_gemini.py` use stable (not call-unique) cache-key params; `user_intervention.py`'s only `asyncio.new_event_loop()` fallback fires solely when no loop is running in the calling context (a sync-only path), not mid-turn.

**Net, stated plainly**: this PR's fix is a genuine structural improvement (deterministic close on the still-alive loop, replacing a fragile atexit-based fresh-loop workaround) and closes the leak window it targets (verified above). It does **not** conclusively reproduce or rule out the specific mid-session mechanism the issue reports on reyn's actual call path — I found negative evidence against both candidate explanations, not a positive identification of a third one, and "not found" is not the same as "proven absent." Settling that would need a live dogfood session run continuously for >1hr (to clear the TTL window) with `PYTHONWARNINGS=always::ResourceWarning`, watching for warnings firing *during* the session. Filed as a narrow, roi:low follow-up: #2789 (carries the negative evidence so a future investigator doesn't re-derive it from scratch).

Given this, **#2787 stays open** — this PR is `part of #2787`, not `Closes #2787`.

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_llm_run_async_shutdown_litellm_clients_2787.py` — 2/2 OK, 0 errors, 0 warnings.
- [x] `pytest` (full suite, from repo root) — green (see CI / this PR's checks).
- [x] `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py` — OK.
- [x] Added test: `tests/test_llm_run_async_shutdown_litellm_clients_2787.py` — Tier 2b (OS invariant: "run_async's shutdown closes litellm's cached async HTTP client"). Real litellm/aiohttp objects throughout, no `MagicMock`/`patch`; asserts on the public `aiohttp.ClientSession.closed` attribute (not reyn-private state). Falsified: reverted the `finally` wiring locally, confirmed `test_run_async_closes_cached_litellm_async_client` goes RED (`assert False is True`), restored the fix, confirmed GREEN.
- [x] Considered a Tier test for the mid-session mechanism and deliberately did **not** write one — no honest Tier test can pin a mechanism that wasn't reproducible in the first place; doing so would be an implementation-detail test asserting a mechanism-that-may-not-exist. The negative-evidence writeup above + follow-up issue #2789 carry that instead.
- [x] Manual: ran `reyn run-once` against real providers (Gemini, OpenAI) with `PYTHONWARNINGS=always::ResourceWarning` while iterating on the repro — no leak-related warnings observed in the (short, single-turn) runs that got far enough to hit a real completion call before hitting unrelated model-config issues in this environment (stale Gemini model ids / a `functools.partial` bug in the reasoning-effort→responses-API transform path, unrelated to this fix).

## Follow-up

- #2789 — litellm mid-session transient-client leak: unreproduced on reyn's Gemini path, needs >1hr dogfood observation (roi:low).
