### PR TITLE
fix: close StateLog/EventStore/FsWatcher on every production teardown path

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -526,14 +526,23 @@ def run(args: argparse.Namespace) -> None:
         # A2A use (registry.get_or_load returns this attached scoped session, no
         # fresh unscoped build), then print the final reply and exit.
         if getattr(args, "once", False):
-            _once_result = await _run_once(registry, name)
-            sys.stdout.write((_once_result.get("reply", "") or "") + "\n")
-            # #1649: a limit-abort must propagate a non-zero exit so a
-            # non-TTY wrapper/CI detects the runaway-stop (vs a clean reply).
-            # The decision-enabling message is already in the reply above
-            # (never silent). exit(2) distinguishes it from arg/usage errors.
-            if _once_result.get("limit_stopped"):
-                sys.exit(2)
+            # #2783: this branch used to return (or sys.exit) with NO teardown of
+            # any kind — unlike run_repl (below), which always routes through
+            # registry.shutdown() on /quit/EOF. That left MCP connections,
+            # FsWatcher, StateLog and EventStore all unclosed on every
+            # `reyn run-once` invocation. try/finally so a limit-abort's
+            # sys.exit(2) still runs teardown before the process exits.
+            try:
+                _once_result = await _run_once(registry, name)
+                sys.stdout.write((_once_result.get("reply", "") or "") + "\n")
+                # #1649: a limit-abort must propagate a non-zero exit so a
+                # non-TTY wrapper/CI detects the runaway-stop (vs a clean reply).
+                # The decision-enabling message is already in the reply above
+                # (never silent). exit(2) distinguishes it from arg/usage errors.
+                if _once_result.get("limit_stopped"):
+                    sys.exit(2)
+            finally:
+                await registry.shutdown()
             return
         await run_repl(registry, renderer=renderer, config=session_cfg.config)
 

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -818,6 +818,15 @@ class AgentRegistry:
             aclose_mcp = getattr(session, "aclose_mcp_connections", None)
             if callable(aclose_mcp):
                 await aclose_mcp()
+            # #2783: same teardown-completeness gap as remove_session — close
+            # FsWatcher/EventStore here too, not just MCP, before ``self.remove``
+            # drops the session from the in-memory map.
+            aclose_fs_watcher = getattr(session, "aclose_fs_watcher", None)
+            if callable(aclose_fs_watcher):
+                await aclose_fs_watcher()
+            aclose_event_store = getattr(session, "aclose_event_store", None)
+            if callable(aclose_event_store):
+                await aclose_event_store()
         cascade_changes = self.remove(name, purge=purge)
         if self._state_log is not None:
             await self._state_log.append(
@@ -1982,6 +1991,21 @@ class AgentRegistry:
             aclose_mcp = getattr(session, "aclose_mcp_connections", None)
             if callable(aclose_mcp):
                 await aclose_mcp()
+            # #2783: close FsWatcher/EventStore SYNCHRONOUSLY here too, mirroring the
+            # MCP close above — do not rely on session.run()'s own `finally` (which
+            # also closes FsWatcher) to get there before this function returns. That
+            # `finally` only runs once the task.cancel() below is actually scheduled
+            # and unwound, which this function never awaits (bare `task.cancel()`,
+            # no `await task`) — a genuine race, not hypothetical. Both closes are
+            # idempotent (FsWatcher.aclose / EventStore.aclose, verified — see their
+            # docstrings), so `run()`'s later finally-close is a harmless no-op if it
+            # still fires after this.
+            aclose_fs_watcher = getattr(session, "aclose_fs_watcher", None)
+            if callable(aclose_fs_watcher):
+                await aclose_fs_watcher()
+            aclose_event_store = getattr(session, "aclose_event_store", None)
+            if callable(aclose_event_store):
+                await aclose_event_store()
         for task_dict in (self._tasks, self._forward_tasks):
             task = task_dict.pop((name, sid), None)
             if task is not None:
@@ -3143,6 +3167,26 @@ class AgentRegistry:
                     await aclose_mcp()
                 except Exception as exc:
                     logger.warning("MCP connection teardown failed for %r: %s", _name, exc)
+        # #2783: drain every loaded session's EventStore (per-session instance) so
+        # trailing audit events (fire-and-forget via submit_nowait) survive a normal
+        # exit instead of being silently dropped when asyncio.run cancels outstanding
+        # tasks at loop teardown. Same getattr-guarded, same-loop-as-MCP pattern above.
+        for _name, session in self._iter_named_sessions():
+            aclose_event_store = getattr(session, "aclose_event_store", None)
+            if callable(aclose_event_store):
+                try:
+                    await aclose_event_store()
+                except Exception as exc:
+                    logger.warning("EventStore teardown failed for %r: %s", _name, exc)
+        # #2783: drain the registry-wide StateLog (WAL) — the same gap #1765 left open
+        # for the exact same reason (fire-and-forget submit_nowait, cancelled at loop
+        # teardown). One shared instance, so this runs once per shutdown() call, not
+        # per session.
+        if self._state_log is not None:
+            try:
+                await self._state_log.aclose()
+            except Exception as exc:
+                logger.warning("StateLog teardown failed: %s", exc)
 
     def loaded_names(self) -> list[str]:
         return list(self._sessions.keys())

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6176,6 +6176,20 @@ class Session:
         """
         await self._mcp_connection_service.aclose()
 
+    async def aclose_event_store(self) -> None:
+        """#2783 teardown: drain this session's EventStore before the process exits.
+
+        Idempotent (``EventStore.aclose`` is idempotent — see #2780). Without this,
+        a normal ``/quit`` can drop the trailing audit events (e.g. the very
+        ``session_completed``/``turn_completed`` records describing the graceful
+        exit) because ``asyncio.run`` cancels outstanding tasks at loop teardown
+        and ``EventStore.write`` enqueues via ``submit_nowait`` (fire-and-forget).
+        Called from the registry's session-teardown seams alongside
+        ``aclose_mcp_connections``/``aclose_fs_watcher`` — same pattern, same
+        call sites.
+        """
+        await self._event_store.aclose()
+
     # --- RouterLoop orchestration ---
 
     def _cap_tool_result(self, content_str: str) -> str:

--- a/tests/test_teardown_completeness_2783.py
+++ b/tests/test_teardown_completeness_2783.py
@@ -1,0 +1,190 @@
+"""Tier 2: #2783 — StateLog/EventStore (and, for A2A remove_session, FsWatcher) must
+actually be torn down on every production exit path.
+
+Before this fix: `AgentRegistry.shutdown()` (the REPL /quit + Ctrl-C/EOF + dogfood +
+`reyn pipe run` normal-exit seam) closed held MCP connections (#2714) but never
+called `StateLog.aclose()` / `Session.aclose_event_store()` — both wrap a
+`DurabilityWorker` whose queued-but-not-yet-written tail entries are silently
+dropped when `asyncio.run()` cancels outstanding tasks at loop teardown (the same
+defect class as #1765's WAL fix and #2780's EventStore fix, one layer up: those
+fixed the WRITE path off-loop; this fixes the DRAIN-on-exit gap).
+
+Separately, `reyn chat --once` (`chat.py`'s `once=True` branch) reached NEITHER
+`registry.shutdown()` NOR any teardown of any kind — not just StateLog/EventStore,
+MCP/FsWatcher too.
+
+And `AgentRegistry.remove_session` (the A2A spawned-session drop seam) already
+closed MCP synchronously before cancelling the session's `run()` task, but relied
+on that same cancelled task's own `finally` to close FsWatcher/EventStore — a
+genuine race, since the cancelled task is never awaited before `remove_session`
+returns.
+
+Real `AgentRegistry` + real `Session` instances throughout, per the testing
+policy — no `mock.patch`/`MagicMock`. Observed via each seam's own public surface
+(`active_path`'s file content, `is_fs_watcher_active`) rather than private state.
+"""
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, registry=holder.get("reg"))
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("owner", role="").save(tmp_path / ".reyn" / "agents" / "owner")
+    return reg
+
+
+def _event_store_file_contains(session: Session, needle: str) -> bool:
+    path = session._event_store.active_path
+    if path is None or not path.exists():
+        return False
+    return needle in path.read_text()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_event_store(tmp_path, monkeypatch):
+    """Tier 2: `registry.shutdown()` drains the main session's EventStore so a
+    queued-but-unwritten event lands on disk before the process exits (#2783).
+    RED before the fix: `write()` enqueues via `submit_nowait` (fire-and-forget,
+    per #2780) and nothing drained it on shutdown, so the file could be missing the
+    trailing event immediately after `shutdown()` returned."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("owner")
+
+    session._chat_events.emit("budget_warn", dimension="daily_tokens")
+    await reg.shutdown()
+
+    assert _event_store_file_contains(session, "budget_warn"), (
+        "registry.shutdown() must drain the main session's EventStore (#2783)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_state_log(tmp_path, monkeypatch):
+    """Tier 2: `registry.shutdown()` drains the registry-wide StateLog (WAL) too —
+    the same gap #1765 originally fixed for the WRITE path, now closed for the
+    DRAIN-on-exit path. Uses `append_nowait` (fire-and-forget, per #1765) — the
+    awaited `append()` already blocks for durability regardless of this fix, so it
+    would pass even without it; `append_nowait` is the path that actually needs
+    `aclose()` to drain on exit. Observed via the WAL file's own content (public:
+    the file IS the durable surface), not private state."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("owner")
+
+    reg._state_log.append_nowait("agent_archived", entity_kind="agent", name="owner")
+    await reg.shutdown()
+
+    wal_path = tmp_path / "wal.jsonl"
+    assert wal_path.exists()
+    assert "agent_archived" in wal_path.read_text(), (
+        "registry.shutdown() must drain the shared StateLog (#2783)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shutdown_event_store_close_is_idempotent(tmp_path, monkeypatch):
+    """Tier 2: calling `aclose_event_store()` twice (once via `shutdown()`, once
+    directly) must not raise — `EventStore.aclose()` is documented idempotent
+    (#2780); the #2783 wiring relies on this so a second close from an overlapping
+    teardown seam is a harmless no-op, not a crash."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("owner")
+
+    await reg.shutdown()
+    await session.aclose_event_store()  # second close — must not raise
+
+
+def test_reyn_run_once_cli_reaches_registry_shutdown(tmp_path, monkeypatch):
+    """Tier 2: #2783 — `reyn chat --once` (`chat.py`'s `once=True` branch,
+    delegated to from `reyn run-once`) used to return/exit with ZERO teardown of
+    any kind — not just StateLog/EventStore, MCP/FsWatcher too, since it never
+    reached `registry.shutdown()` at all. Drives the REAL production entry point
+    (`run_once.register` → the real argparse defaults → the real `chat.run(args)`,
+    the exact code changed by this fix) end to end, with only the network-facing
+    LLM drive (`send_to_agent_impl`) substituted for a fast real async function (a
+    same-signature stand-in, not a MagicMock/AsyncMock) — the turn-driving
+    internals it replaces are already covered by #187's own tests; this test is
+    about whether the NEW try/finally wrapper around it reaches
+    `registry.shutdown()`. Observed via a call-through spy on the real
+    `AgentRegistry.shutdown` (wraps and still calls the original — a call-count
+    probe, not a mock that fakes the method's behavior), not private state."""
+    import argparse
+
+    from reyn.interfaces.cli.commands import run_once
+    from reyn.runtime.registry import AgentRegistry
+
+    monkeypatch.chdir(tmp_path)
+    top = argparse.ArgumentParser()
+    sub = top.add_subparsers()
+    run_once.register(sub)
+    args = top.parse_args(["run-once"])
+
+    async def _fake_send(registry, *, agent_name, message, timeout=0,
+                          intervention_override=None, sid=None) -> dict:
+        return {"reply": "ok", "limit_stopped": False}
+
+    monkeypatch.setattr("reyn.mcp.server.send_to_agent_impl", _fake_send)
+
+    orig_shutdown = AgentRegistry.shutdown
+    call_count = {"n": 0}
+
+    async def _counting_shutdown(self) -> None:
+        call_count["n"] += 1
+        await orig_shutdown(self)
+
+    monkeypatch.setattr(AgentRegistry, "shutdown", _counting_shutdown)
+    monkeypatch.setattr("sys.stdin", io.StringIO("hi"))
+
+    from reyn.interfaces.cli.commands import chat
+    chat.run(args)
+
+    assert call_count["n"] == 1, (
+        "reyn run-once / reyn chat --once must reach registry.shutdown() exactly "
+        "once so MCP/FsWatcher/StateLog/EventStore all get torn down (#2783) — "
+        "before this fix it reached zero times"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_session_closes_event_store_synchronously_before_cancel(tmp_path, monkeypatch):
+    """Tier 2: #2783 A2A race — `remove_session` must close the spawned session's
+    EventStore SYNCHRONOUSLY (before `task.cancel()`, mirroring the existing MCP
+    close), not rely on the cancelled `run()` task's own `finally` to get there.
+    RED before the fix: the event landed only if `run()`'s finally happened to
+    execute before this assertion — a genuine race, not guaranteed. Observed via
+    the file's content immediately after `remove_session` returns, no further
+    await needed if the fix is synchronous."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("owner")
+    spawned_sid = reg.spawn_session("owner", presentation_consumer=None, intervention_bridge=None)
+    spawned = reg.get_session("owner", spawned_sid)
+    spawned.register_intervention_listener("test")
+
+    spawned._chat_events.emit("budget_warn", dimension="daily_tokens")
+
+    await reg.remove_session("owner", spawned_sid, record=False)
+
+    assert _event_store_file_contains(spawned, "budget_warn"), (
+        "remove_session must close the spawned session's EventStore synchronously, "
+        "before task.cancel(), not rely on the cancelled run() task's own finally (#2783)"
+    )


### PR DESCRIPTION
**[tui-coder]** — Implements #2783 (full GO per owner, relayed by lead-coder). Design was settled and posted to the issue prior to implementation (see issue comments) — this PR follows that 5-step design verbatim.

## Problem

`AgentRegistry.shutdown()` (the REPL `/quit`/Ctrl-C/EOF normal-exit seam, plus dogfood/`reyn pipe run`, which already call it in a `finally`) already closed held MCP connections (#2714) but never called `StateLog.aclose()` or any per-session EventStore close. Both wrap a `DurabilityWorker` whose queued-but-not-yet-written tail entries (fire-and-forget via `submit_nowait`) are silently dropped when `asyncio.run()` cancels outstanding tasks at loop teardown — the same defect class as #1765 (WAL) / #2780 (EventStore), one layer up: those fixed the *write* path off-loop; this fixes the *drain-on-exit* gap.

Two further gaps found during design (both in-scope per the settled design):
- **`reyn chat --once` reached ZERO teardown of any kind** — not just StateLog/EventStore, MCP/FsWatcher too — since the `once=True` branch (`chat.py:528-537`) returned/`sys.exit`ed directly, never routing through `registry.shutdown()`.
- **A2A `remove_session`/`archive_agent`** already closed MCP synchronously before cancelling the session's `run()` task, but relied on that same cancelled task's own `finally` (which also closes FsWatcher) to get there — a genuine race, since the cancel is never awaited before the function returns.

## Changes

- `AgentRegistry.shutdown()` (`registry.py`): drains every loaded session's EventStore (per-session `getattr`-guarded loop, mirroring the existing MCP loop), then the shared `StateLog` (once per process).
- `Session.aclose_event_store()` (`session.py`): new wrapper mirroring `aclose_fs_watcher`/`aclose_mcp_connections`. Idempotent (`EventStore.aclose` is idempotent, verified in #2780).
- `chat.py`'s `once=True` branch: wrapped in `try/finally: await registry.shutdown()` — covers `reyn chat --once` and `reyn run-once` (which delegates to it) and the `sys.exit(2)` limit-abort path (#1649).
- `AgentRegistry.remove_session` / `archive_agent`: close FsWatcher and EventStore **synchronously**, in the same spot as the existing MCP close, before `task.cancel()`. Idempotence (both closes, verified) is what makes this safe — `run()`'s later finally-close firing anyway is a harmless no-op, not a double-close bug.

## Review-gate items addressed

- **Idempotence**: `test_shutdown_event_store_close_is_idempotent` calls `aclose_event_store()` twice (once via `shutdown()`, once directly) and asserts no exception.
- **Teardown reachability**: `test_reyn_run_once_cli_reaches_registry_shutdown` drives the REAL `reyn run-once` CLI entry point (`run_once.register` → real argparse defaults → real `chat.run(args)`) end to end, with only the network-facing LLM drive (`send_to_agent_impl`) substituted for a same-signature async stand-in (not a Mock) — verified via a call-through spy on the real `AgentRegistry.shutdown` that `shutdown()` is reached exactly once (was zero times before the fix).

## Verification

- RED→GREEN: all 5 new tests fail before the fix (stashed source, confirmed `AttributeError`/assertion failures), pass after.
- Broader teardown-adjacent sweep: `test_2714_mcp_shutdown_teardown.py` + `test_2103_s1bc_session_drop.py` + `test_shutdown_force_cancel.py` + `test_2597_s2a_mcp_connection_service.py` + `test_session_vanished_emit_2154.py` + `test_2103_A_ephemeral_auto_vanish_1953.py` + `test_multisession_history_isolation_2348.py` + `test_chat_exclude_tools_187.py` + this PR's own file — 41/41 passed.
- Full pytest suite: 9 failed / 8011 passed / 17 skipped — same pre-existing, unrelated baseline seen across every full-suite run this session (`test_compaction_resolver_aware_1172.py` x3, `test_llm_request_error_1676.py`, `test_llm_router_s3b_1829.py` x2, `test_responses_api_routing_1678.py` x3).
- 4 local CI gates green: `ruff check`, `python scripts/test_tier_audit.py --strict tests/test_teardown_completeness_2783.py`, full `pytest`, `python scripts/verify_module_docstrings.py <changed src files>`.

## Not in scope

Recovery-feature PR gate (truncate-falsify test) does not apply — per `anchor_store.py`'s own docstring, `EventStore`/`StateLog`'s `aclose()` drain is an audit/durability-on-exit concern, not a WAL-event-derived reconstruction source; nothing here changes crash-recovery semantics, only whether already-durable-bound writes actually land before process exit.

## Test plan

- [x] RED→GREEN confirmed for all 5 new tests
- [x] Teardown-adjacent test sweep (41/41)
- [x] Full pytest suite (baseline 9 pre-existing failures, no new regressions)
- [x] All 4 local CI gates green

**Tier self-check**: all 5 new tests are Tier 2 (real `AgentRegistry`/`Session` instances, no `MagicMock`/`patch` for collaborators — the one call-through spy on `AgentRegistry.shutdown` still calls the original implementation, it's a call-count probe not a behavior fake; observed via public file content / call counts, no private-state assertions).