### PR TITLE
fix: neutralize LLM-derived intervention content in StdinInterventionBus prompt render (#2779)

### DIFF
--- a/src/reyn/user_intervention.py
+++ b/src/reyn/user_intervention.py
@@ -245,6 +245,21 @@ class UserChannel(Protocol):
 InterventionBus = RequestBus
 
 
+def _neutralize_terminal(value: str) -> str:
+    """Strip ESC / control sequences from an LLM-derived intervention leaf
+    before it reaches the ``StdinInterventionBus`` prompt_toolkit prompt
+    string (#2779). Mirrors ``runtime/services/intervention_handler
+    ._neutralize_terminal`` (#2776) exactly — same
+    ``core/present/guard.get_neutralizer("terminal")`` strategy (ESC/control
+    strip, FP-0054) — applied at this bus's own render seam so the
+    `reyn run` / cron / scripted-stdin surface gets the same guard the
+    inline-CUI surface already has.
+    """
+    from reyn.core.present.guard import get_neutralizer
+
+    return get_neutralizer("terminal").neutralize(value)[0]
+
+
 def match_choice(text: str, choices: list[InterventionChoice]) -> InterventionChoice | None:
     """Return the choice whose hotkey matches `text` exactly (case-sensitive),
     or None when no hotkey matches. Whitespace is stripped.
@@ -296,15 +311,30 @@ class StdinInterventionBus:
 
     @staticmethod
     def _render_prompt(iv: UserIntervention) -> str:
+        """Build the prompt_toolkit prompt string for this intervention.
+
+        ``iv.prompt`` / ``iv.detail`` / ``iv.suggestions`` / choice ``label``s
+        are LLM-derived (untrusted) — ``ask_user`` args come straight from a
+        model tool-call, and permission prompts interpolate a model-controlled
+        path. Each is passed through the SAME terminal neutralizer (#2776,
+        ``core/present/guard.get_neutralizer("terminal")`` — ESC/control
+        strip) the inline-CUI intervention paths use, so a control/ESC
+        sequence embedded in that content cannot drive this stdin-bus
+        terminal (#2779, the sibling surface #2776 left unguarded). The
+        ``[actor]`` prefix and the ``> `` affordance are OS-controlled and
+        need no guard; ``choice.hotkey``/``id`` (match keys) are never
+        rendered here and stay untouched.
+        """
         lines: list[str] = []
         prefix = f"[{iv.actor}] " if iv.actor else ""
-        lines.append(f"{prefix}{iv.prompt}")
+        lines.append(f"{prefix}{_neutralize_terminal(iv.prompt)}")
         if iv.detail:
-            lines.append(f"  {iv.detail}")
+            lines.append(f"  {_neutralize_terminal(iv.detail)}")
         if iv.suggestions:
-            lines.append(f"  options: {' / '.join(iv.suggestions)}")
+            options = " / ".join(_neutralize_terminal(s) for s in iv.suggestions)
+            lines.append(f"  options: {options}")
         if iv.choices:
-            labels = " / ".join(c.label for c in iv.choices)
+            labels = " / ".join(_neutralize_terminal(c.label) for c in iv.choices)
             lines.append(f"  {labels}")
         lines.append("  > ")
         return "\n".join(lines)

--- a/tests/test_2779_stdin_intervention_neutralize.py
+++ b/tests/test_2779_stdin_intervention_neutralize.py
@@ -1,0 +1,97 @@
+"""Tier 2a: #2779 — StdinInterventionBus prompt render neutralizes LLM-derived content.
+
+Sibling follow-up to #2776 (which unified the inline-CUI intervention display
+with the ``present`` renderer discipline / FP-0054 terminal neutralizer, but
+was scoped to the inline-CUI surface only). ``StdinInterventionBus`` is the
+`reyn run` / cron / scripted-stdin surface — a DIFFERENT entry point with a
+DIFFERENT rendering path (a prompt_toolkit prompt string, not the Rich
+Console scrollback) — so it needed its own wiring of the same neutralizer.
+
+Intervention content is LLM-derived / untrusted: ``ask_user`` ``prompt`` /
+``suggestions`` come straight from a model tool-call, and permission prompts
+interpolate a model-controlled ``path``. This suite pins the Security
+invariant: a terminal control/ESC/BEL/NUL sequence embedded in ``iv.prompt``
+/ ``iv.detail`` / ``iv.suggestions`` / a choice ``label`` must not reach the
+``_render_prompt`` output (the string handed to prompt_toolkit's
+``_read_line``) — the payload text around the control bytes must still be
+present, only the control bytes stripped. Falsify: drop the neutralizer call
+in ``StdinInterventionBus._render_prompt`` → these go RED (verified below by
+cp-scratch removal, restored via cp — never ``git checkout``).
+
+Real ``UserIntervention`` / ``InterventionChoice`` instances throughout; no
+mocks. Behavioral asserts only (control bytes absent / payload substring
+present) — no whitespace/format pins on the rest of the rendered string.
+"""
+from __future__ import annotations
+
+from reyn.user_intervention import (
+    InterventionChoice,
+    StdinInterventionBus,
+    UserIntervention,
+)
+
+# A terminal control/ESC injection payload: ESC + CSI red SGR, a bell, and a NUL.
+ESC = "\x1b[31mINJECT\x1b[0m\x07\x00"
+CONTROL_BYTES = ("\x1b", "\x07", "\x00")
+
+
+def test_render_prompt_neutralizes_prompt_and_detail() -> None:
+    """Tier 2a: iv.prompt / iv.detail control bytes are stripped; payload text survives."""
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt=f"question {ESC} here",
+        detail=f"detail {ESC} context",
+    )
+    rendered = StdinInterventionBus._render_prompt(iv)
+
+    for byte in CONTROL_BYTES:
+        assert byte not in rendered
+    assert "question" in rendered and "here" in rendered
+    assert "detail" in rendered and "context" in rendered
+    assert "INJECT" in rendered  # payload text (non-control) survives
+
+
+def test_render_prompt_neutralizes_suggestions() -> None:
+    """Tier 2a: iv.suggestions entries are neutralized individually."""
+    iv = UserIntervention(
+        kind="ask_user",
+        prompt="pick one",
+        suggestions=[f"opt-a {ESC}", "opt-b"],
+    )
+    rendered = StdinInterventionBus._render_prompt(iv)
+
+    for byte in CONTROL_BYTES:
+        assert byte not in rendered
+    assert "opt-a" in rendered
+    assert "opt-b" in rendered
+
+
+def test_render_prompt_neutralizes_choice_labels() -> None:
+    """Tier 2a: Choice ``label`` text is neutralized; ``hotkey``/``id`` (match
+    keys, never rendered) are untouched by the neutralizer — only the
+    displayed label is."""
+    choices = [
+        InterventionChoice(id="yes", label=f"[Y]es {ESC}", hotkey="Y"),
+        InterventionChoice(id="no", label="[N]o", hotkey="N"),
+    ]
+    iv = UserIntervention(kind="permission.file_write", prompt="allow?", choices=choices)
+    rendered = StdinInterventionBus._render_prompt(iv)
+
+    for byte in CONTROL_BYTES:
+        assert byte not in rendered
+    assert "[Y]es" in rendered
+    assert "[N]o" in rendered
+    # match keys are untouched (not part of the rendered guard's concern)
+    assert choices[0].hotkey == "Y"
+    assert choices[0].id == "yes"
+
+
+def test_render_prompt_actor_prefix_and_affordance_unchanged() -> None:
+    """Tier 2a: The OS-controlled ``[actor]`` prefix and ``> `` affordance need
+    no guard and are not corrupted by the neutralization of the untrusted
+    leaves."""
+    iv = UserIntervention(kind="ask_user", prompt=f"q {ESC}", actor="agent-1")
+    rendered = StdinInterventionBus._render_prompt(iv)
+
+    assert rendered.startswith("[agent-1] q ")
+    assert rendered.rstrip("\n").endswith("> ")


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2779

Sibling follow-up to #2776 (merged): #2776 unified the intervention DISPLAY with the `present`-layer renderer discipline (FP-0054 terminal neutralizer), but was scoped to the **inline-CUI** surface (`reyn chat`) only. This PR extends the SAME neutralizer to the **remaining unguarded surface** #2779 identified: `StdinInterventionBus` — the `reyn run` / cron / scripted-CLI stdin bus, a genuine terminal surface with its own rendering path (a prompt_toolkit prompt string, not the Rich Console scrollback #2776 already covers).

## Render-seam evidence (the raw path, before this fix)

`StdinInterventionBus._render_prompt` (`src/reyn/user_intervention.py:298`, static method) built the prompt string by directly interpolating `iv.prompt` / `iv.detail` / `iv.suggestions` / choice `label`s — no ESC/control-strip guard anywhere on the path:

```python
lines.append(f"{prefix}{iv.prompt}")
if iv.detail:
    lines.append(f"  {iv.detail}")
...
labels = " / ".join(c.label for c in iv.choices)
```

`deliver()` (`user_intervention.py:276`) then hands this string straight to `prompt_toolkit`'s `_read_line` (`session.prompt_async(prompt_text)`), a genuine terminal-writing sink. `iv.prompt`/`iv.detail`/`iv.suggestions` are LLM-derived — `ask_user` args come straight from a model tool-call, and permission prompts interpolate a model-controlled `path` — so an ESC/control sequence embedded there could drive this terminal (OSC-52 clipboard, cursor tricks, etc.) with zero neutralization. Confirmed by cp-falsify below: removing the neutralize calls reproduces the raw (un-neutralized) render immediately.

## Fix

Applied the exact same neutralizer #2776 wired into `runtime/services/intervention_handler.py` — `core/present/guard.get_neutralizer("terminal").neutralize(value)[0]` — mirrored as a local module helper `_neutralize_terminal` in `user_intervention.py` (same discipline: one small wrapper, called at every leaf that reaches this bus's render seam). Applied to `iv.prompt`, `iv.detail`, each `iv.suggestions` entry, and each choice `label`, inside `_render_prompt`. The OS-controlled `[actor]` prefix and `> ` affordance need no guard; `choice.hotkey`/`id` (match keys, never displayed) stay untouched — no change to pause/answer/selection flow, this is display-layer-only, same as #2776.

## Test (`tests/test_2779_stdin_intervention_neutralize.py`, Tier 2a, real instances)

- `iv.prompt` / `iv.detail` containing ESC/BEL/NUL → stripped from the rendered prompt string; payload text (`"question"`, `"INJECT"`, etc.) survives.
- `iv.suggestions` entries neutralized individually.
- Choice `label`s neutralized; `hotkey`/`id` untouched (still usable as match keys).
- `[actor]` prefix and `> ` affordance unaffected by neutralization of the untrusted leaves.
- **cp-falsify done**: removed the 4 `_neutralize_terminal(...)` call-sites in `_render_prompt` (cp-scratch backup, never `git checkout`) → 3 of 4 tests went RED (control bytes present in the rendered string); restored from the scratch backup → all 4 GREEN again.

Real `UserIntervention`/`InterventionChoice` instances throughout; no mocks. Behavioral asserts only (control bytes absent / payload substrings present) — no whitespace/format pins on the rest of the string.

## CI gates (all local)
- `ruff check src/reyn/user_intervention.py tests/test_2779_stdin_intervention_neutralize.py` — clean
- `python scripts/test_tier_audit.py --strict tests/test_2779_stdin_intervention_neutralize.py` — 4/4 OK, 0 Tier-4
- `pytest` (repo root) — 8008 passed, 21 skipped; 5 failed are **pre-existing** web/a2a/mcp route-mount + plugin-loader failures (same 5 test names #2776 already flagged as pre-existing on clean HEAD), unrelated to `user_intervention.py`
- `python scripts/verify_module_docstrings.py src/reyn/user_intervention.py` — OK

## Test plan
- [x] `iv.prompt`/`iv.detail` ESC/BEL/NUL stripped from `_render_prompt` output, payload survives — automated
- [x] `iv.suggestions` entries neutralized — automated
- [x] Choice `label`s neutralized; `hotkey`/`id` untouched — automated
- [x] `[actor]` prefix / `> ` affordance unaffected — automated
- [x] cp-falsify: dropping the neutralize calls → RED; restored → GREEN — done manually, verified above

🤖 Generated with [Claude Code](https://claude.com/claude-code)