### PR TITLE
fix: offload edit_file/grep_files/glob_files I/O from the event loop

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -603,7 +603,7 @@ def _changed_region_preview(
     return rendered
 
 
-def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
+def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None, str | None]:
     """The read-modify-write core of ``edit_file`` — run WHOLESALE on a worker
     thread (#2782), preserving today's atomicity: no ``await`` used to appear
     between the read and the write (the whole stretch ran uninterrupted on the
@@ -613,14 +613,20 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
     an interleaving window (a concurrent session's edit landing between this
     read and this write) that does not exist today.
 
-    Returns ``(result, replacements_to_emit)``; the caller emits
-    ``tool_executed`` AFTER this returns, back on the event loop thread — see
-    ``_execute_grep_sync``'s docstring for why (EventStore's
-    ``asyncio.Queue.put_nowait`` is not thread-safe off the loop thread)."""
+    Returns ``(result, replacements_to_emit, written_path)``. NEITHER
+    ``tool_executed`` NOR ``workspace_updated`` may be emitted from inside this
+    function — ``ctx.workspace.write_file_bytes`` transitively emits
+    ``workspace_updated`` unconditionally (a bug caught in review: emitting
+    off-loop doesn't raise, it falls to ``EventStore``'s non-serialized
+    sync-fallback write path, racing the DurabilityWorker's own writes to the
+    same file — see ``write_file_bytes``'s docstring). Called with
+    ``emit=False`` here; the caller emits BOTH events AFTER this returns, back
+    on the event loop thread. See ``_execute_grep_sync``'s docstring for the
+    ``asyncio.Queue.put_nowait`` half of why off-loop emit is unsafe."""
     if op.old_string is None:
-        return {"kind": "file", "op": "edit", "status": "error", "error": "old_string is required"}, None
+        return {"kind": "file", "op": "edit", "status": "error", "error": "old_string is required"}, None, None
     if op.new_string is None:
-        return {"kind": "file", "op": "edit", "status": "error", "error": "new_string is required"}, None
+        return {"kind": "file", "op": "edit", "status": "error", "error": "new_string is required"}, None, None
 
     raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
     if not found:
@@ -632,7 +638,7 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
             "status": "not_found",
             "error": f"file not found: {op.path}",
             "suggestions": suggestions,
-        }, None
+        }, None, None
 
     # #1452: decode via the shared codec ladder so a non-UTF-8 text file can be
     # edited in place (encoding preserved on write-back below). A binary file
@@ -643,15 +649,15 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
             "kind": "file", "op": "edit", "path": op.path, "status": "error",
             "binary": True,
             "error": "binary file — cannot edit as text (its bytes were not loaded).",
-        }, None
+        }, None, None
 
     count = content.count(op.old_string)
     if count == 0:
         return {"kind": "file", "op": "edit", "status": "error",
-                "error": "old_string not found in file"}, None
+                "error": "old_string not found in file"}, None, None
     if not op.replace_all and count > 1:
         return {"kind": "file", "op": "edit", "status": "error",
-                "error": f"old_string appears {count} times; set replace_all=true to replace all occurrences"}, None
+                "error": f"old_string appears {count} times; set replace_all=true to replace all occurrences"}, None, None
 
     new_content = content.replace(op.old_string, op.new_string) if op.replace_all \
         else content.replace(op.old_string, op.new_string, 1)
@@ -669,8 +675,8 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
                 f"({_encoding or 'utf-8'}) — file left unchanged. Some new "
                 "characters cannot be encoded there."
             ),
-        }, None
-    ctx.workspace.write_file_bytes(op.path, encoded)
+        }, None, None
+    written_path = ctx.workspace.write_file_bytes(op.path, encoded, emit=False)
     replacements = count if op.replace_all else 1
     # #1418: an additive, show-not-judge preview of the changed region so the
     # agent can SEE what landed (and at what indent), not just the count. For
@@ -682,12 +688,16 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
         "kind": "file", "op": "edit", "path": op.path, "status": "ok",
         "replacements": replacements, "preview": preview,
         **({"encoding": _encoding} if _encoding else {}),
-    }, replacements
+    }, replacements, written_path
 
 
 async def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
-    result, replacements = await asyncio.to_thread(_execute_edit_sync, op, ctx)
+    result, replacements, written_path = await asyncio.to_thread(_execute_edit_sync, op, ctx)
     if replacements is not None:
+        # Order matches pre-#2782 behavior: write_file_bytes's workspace_updated
+        # emit ran BEFORE the handler's tool_executed emit.
+        if written_path is not None:
+            ctx.events.emit("workspace_updated", path=written_path)
         ctx.events.emit("tool_executed", op="edit_file", path=op.path, replacements=replacements)
     return result
 

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -1,6 +1,7 @@
 """file kind handler — read/write/glob/grep/delete/edit/regenerate_index/mkdir/move/stat."""
 from __future__ import annotations
 
+import asyncio
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -404,7 +405,12 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         }
 
     if op.op == "glob":
-        matches = ctx.workspace.glob_files(op.path, max_results=op.max_results)
+        # #2782: offloaded — pure read (tree-walk), no atomicity concern, safe to
+        # move wholesale to a worker thread. `ctx.events.emit` stays on the event
+        # loop thread (called after the `await`, not inside the threaded call) —
+        # EventStore.write ultimately does an `asyncio.Queue.put_nowait`, which is
+        # NOT thread-safe if called from a to_thread worker thread.
+        matches = await asyncio.to_thread(ctx.workspace.glob_files, op.path, max_results=op.max_results)
         ctx.events.emit("tool_executed", op="glob_files", path=op.path, match_count=len(matches))
         return {
             "kind": "file",
@@ -421,10 +427,10 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         return {"kind": "file", "op": "delete", "path": op.path, "status": "ok", "deleted": deleted}
 
     if op.op == "grep":
-        return _execute_grep(op, ctx)
+        return await _execute_grep(op, ctx)
 
     if op.op == "edit":
-        return _execute_edit(op, ctx)
+        return await _execute_edit(op, ctx)
 
     if op.op == "regenerate_index":
         return _execute_regenerate_index(op, ctx)
@@ -482,14 +488,22 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
     raise ValueError(f"unsupported file op: {op.op!r}")
 
 
-def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
+def _execute_grep_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
+    """The I/O-bound core of ``grep`` (tree-walk + per-file read + regex scan) —
+    pure, safe to run wholesale on a worker thread (#2782). Returns
+    ``(result, match_count_to_emit)``; ``match_count_to_emit`` is ``None`` for the
+    validation-error branches (no event was emitted for those before #2782
+    either). The caller emits ``tool_executed`` AFTER the ``to_thread`` call
+    returns, back on the event loop thread — ``ctx.events.emit`` ultimately does
+    an ``asyncio.Queue.put_nowait`` (EventStore's DurabilityWorker), which is NOT
+    thread-safe if called from a worker thread."""
     if not op.pattern:
-        return {"kind": "file", "op": "grep", "status": "error", "error": "pattern is required for grep"}
+        return {"kind": "file", "op": "grep", "status": "error", "error": "pattern is required for grep"}, None
     flags = re.IGNORECASE if op.case_insensitive else 0
     try:
         regex = re.compile(op.pattern, flags)
     except re.error as exc:
-        return {"kind": "file", "op": "grep", "status": "error", "error": f"invalid regex: {exc}"}
+        return {"kind": "file", "op": "grep", "status": "error", "error": f"invalid regex: {exc}"}, None
 
     # FP-0008 #1115 Stage 1: the glob+read+regex scan is an environment-internal
     # primitive run by the backend (Workspace.grep gates the root + delegates).
@@ -506,7 +520,7 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
             context_after=op.context_after,
         )
     except PermissionError as exc:
-        return {"kind": "file", "op": "grep", "status": "denied", "error": str(exc)}
+        return {"kind": "file", "op": "grep", "status": "denied", "error": str(exc)}, None
 
     def _rel(p: Path) -> str:
         try:
@@ -516,14 +530,12 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
 
     if result.output_mode == "files_with_matches":
         matched = [_rel(f) for f in result.files]
-        ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=len(matched))
         return {"kind": "file", "op": "grep", "status": "ok",
-                "output_mode": "files_with_matches", "files": matched, "count": len(matched)}
+                "output_mode": "files_with_matches", "files": matched, "count": len(matched)}, len(matched)
 
     if result.output_mode == "count":
-        ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=result.count)
         return {"kind": "file", "op": "grep", "status": "ok",
-                "output_mode": "count", "count": result.count}
+                "output_mode": "count", "count": result.count}, result.count
 
     matches: list[dict] = []
     for hit in result.matches:
@@ -536,10 +548,16 @@ def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
             entry["context"] = hit["context"]
         matches.append(entry)
 
-    ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=len(matches))
     return {"kind": "file", "op": "grep", "status": "ok",
             "output_mode": "content", "pattern": op.pattern,
-            "matches": matches, "count": len(matches)}
+            "matches": matches, "count": len(matches)}, len(matches)
+
+
+async def _execute_grep(op: FileIROp, ctx: OpContext) -> dict:
+    result, match_count = await asyncio.to_thread(_execute_grep_sync, op, ctx)
+    if match_count is not None:
+        ctx.events.emit("tool_executed", op="grep", pattern=op.pattern, match_count=match_count)
+    return result
 
 
 def _changed_region_preview(
@@ -585,11 +603,24 @@ def _changed_region_preview(
     return rendered
 
 
-def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
+def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None]:
+    """The read-modify-write core of ``edit_file`` — run WHOLESALE on a worker
+    thread (#2782), preserving today's atomicity: no ``await`` used to appear
+    between the read and the write (the whole stretch ran uninterrupted on the
+    event loop), so no ``await`` may appear inside this function either — it
+    must stay one uninterrupted synchronous call, just now off-loop. Splitting
+    the read and the write into separate ``to_thread`` calls would reintroduce
+    an interleaving window (a concurrent session's edit landing between this
+    read and this write) that does not exist today.
+
+    Returns ``(result, replacements_to_emit)``; the caller emits
+    ``tool_executed`` AFTER this returns, back on the event loop thread — see
+    ``_execute_grep_sync``'s docstring for why (EventStore's
+    ``asyncio.Queue.put_nowait`` is not thread-safe off the loop thread)."""
     if op.old_string is None:
-        return {"kind": "file", "op": "edit", "status": "error", "error": "old_string is required"}
+        return {"kind": "file", "op": "edit", "status": "error", "error": "old_string is required"}, None
     if op.new_string is None:
-        return {"kind": "file", "op": "edit", "status": "error", "error": "new_string is required"}
+        return {"kind": "file", "op": "edit", "status": "error", "error": "new_string is required"}, None
 
     raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
     if not found:
@@ -601,7 +632,7 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
             "status": "not_found",
             "error": f"file not found: {op.path}",
             "suggestions": suggestions,
-        }
+        }, None
 
     # #1452: decode via the shared codec ladder so a non-UTF-8 text file can be
     # edited in place (encoding preserved on write-back below). A binary file
@@ -612,15 +643,15 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
             "kind": "file", "op": "edit", "path": op.path, "status": "error",
             "binary": True,
             "error": "binary file — cannot edit as text (its bytes were not loaded).",
-        }
+        }, None
 
     count = content.count(op.old_string)
     if count == 0:
         return {"kind": "file", "op": "edit", "status": "error",
-                "error": "old_string not found in file"}
+                "error": "old_string not found in file"}, None
     if not op.replace_all and count > 1:
         return {"kind": "file", "op": "edit", "status": "error",
-                "error": f"old_string appears {count} times; set replace_all=true to replace all occurrences"}
+                "error": f"old_string appears {count} times; set replace_all=true to replace all occurrences"}, None
 
     new_content = content.replace(op.old_string, op.new_string) if op.replace_all \
         else content.replace(op.old_string, op.new_string, 1)
@@ -638,10 +669,9 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
                 f"({_encoding or 'utf-8'}) — file left unchanged. Some new "
                 "characters cannot be encoded there."
             ),
-        }
+        }, None
     ctx.workspace.write_file_bytes(op.path, encoded)
     replacements = count if op.replace_all else 1
-    ctx.events.emit("tool_executed", op="edit_file", path=op.path, replacements=replacements)
     # #1418: an additive, show-not-judge preview of the changed region so the
     # agent can SEE what landed (and at what indent), not just the count. For
     # replace_all this shows the first changed region; the count is in
@@ -652,7 +682,14 @@ def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
         "kind": "file", "op": "edit", "path": op.path, "status": "ok",
         "replacements": replacements, "preview": preview,
         **({"encoding": _encoding} if _encoding else {}),
-    }
+    }, replacements
+
+
+async def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
+    result, replacements = await asyncio.to_thread(_execute_edit_sync, op, ctx)
+    if replacements is not None:
+        ctx.events.emit("tool_executed", op="edit_file", path=op.path, replacements=replacements)
+    return result
 
 
 def regenerate_index_impl(

--- a/src/reyn/data/workspace/workspace.py
+++ b/src/reyn/data/workspace/workspace.py
@@ -162,15 +162,30 @@ class Workspace:
         self._backend.write_bytes(path, content.encode("utf-8"))
         self._events.emit("workspace_updated", path=str(path))
 
-    def write_file_bytes(self, path_str: str, data: bytes) -> None:
+    def write_file_bytes(self, path_str: str, data: bytes, *, emit: bool = True) -> str:
         """Write raw bytes into the project (#1452 — the write-side mirror of
         ``read_file_bytes``). Used by file__edit / write to persist content
         already encoded in the file's detected codec (preserving a non-UTF-8
         encoding + BOM on in-place edits). Same write-zone gating as
-        ``write_file``. Raises PermissionError if denied."""
+        ``write_file``. Raises PermissionError if denied.
+
+        Returns the resolved absolute path string that was written.
+
+        ``emit=False`` (#2782) skips the ``workspace_updated`` emit — for a
+        caller running this off the event loop (an ``asyncio.to_thread``
+        worker), which MUST emit itself afterward, back on the loop thread.
+        A worker-thread ``ctx.events.emit`` reaches ``EventStore.write``,
+        which calls ``asyncio.get_running_loop()`` — off-loop, that RAISES,
+        falling to a non-serialized sync-fallback write path that mutates
+        ``EventStore``'s rotation state without the loop-thread-only
+        serialization protecting it, racing the DurabilityWorker's own
+        writes to the same file (the #2780/#2784 off-loop thread-safety
+        contract this must not violate)."""
         path = self._resolve_write(path_str)
         self._backend.write_bytes(path, data)
-        self._events.emit("workspace_updated", path=str(path))
+        if emit:
+            self._events.emit("workspace_updated", path=str(path))
+        return str(path)
 
     def delete_file(self, path_str: str) -> bool:
         """Delete a file from the project. Returns True if deleted, False if not found."""

--- a/tests/test_file_ops_offload_2782.py
+++ b/tests/test_file_ops_offload_2782.py
@@ -12,14 +12,28 @@ atomicity exactly — see `_execute_edit_sync`'s docstring. `grep_files`/
 `glob_files` have no such concern (pure reads); a single outer `to_thread` per
 call is the natural granularity (not per-candidate-file).
 
-Also verifies a scope-critical, easy-to-miss requirement discovered while
-implementing: `ctx.events.emit(...)` must NOT run inside the threaded call —
-`EventStore.write` (a chat_events subscriber) ultimately does an
-`asyncio.Queue.put_nowait` (DurabilityWorker, #2780), which is not
-thread-safe off the event loop thread. The emit call is placed AFTER the
-`await asyncio.to_thread(...)` returns, back on the loop thread.
+Also verifies a scope-critical, easy-to-miss requirement, caught in review
+(architect co-vet on the original PR) as a TRANSITIVE emit this module's
+tests initially missed: `Workspace.write_file_bytes` itself unconditionally
+emitted `workspace_updated` — called from INSIDE `_execute_edit_sync`
+(the threaded core), so the explicit `ctx.events.emit("tool_executed", ...)`
+being correctly deferred wasn't sufficient; the transitive one inside
+`write_file_bytes` still fired off-loop. The mechanism is subtler than "it
+would crash": a worker-thread emit reaching `EventStore.write` calls
+`asyncio.get_running_loop()`, which RAISES off-loop, falling to a
+non-serialized sync-fallback write path that mutates `EventStore`'s
+rotation state without the loop-thread-only serialization protecting it —
+racing the DurabilityWorker's own writes to the same JSONL file (a
+data-integrity hazard, not a crash, so a `bare EventLog()` with no
+subscriber — as this module's earlier tests used — can never catch it: the
+race lives inside `EventStore`, which only exists once actually subscribed).
+Fixed via `write_file_bytes(..., emit=False)` from the threaded core, with
+the async wrapper emitting `workspace_updated` itself after `to_thread`
+returns, mirroring `tool_executed`.
 
-Real `Workspace`/`EventLog`/`invoke_tool` throughout — no mocks.
+Real `Workspace`/`EventLog`/`invoke_tool` throughout — no mocks. The
+thread-identity wiring test below subscribes a REAL `EventStore` (not a bare
+`EventLog`) so a transitive off-loop emit is actually observable.
 
 Path-locking (serializing two SEPARATE to_thread jobs against the same path,
 for same-process concurrent-session edits) is explicitly DEFERRED — owner GO
@@ -32,6 +46,7 @@ import re
 import threading
 from pathlib import Path
 
+from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime.file import _execute_grep_sync
 from reyn.data.workspace.workspace import Workspace
@@ -210,4 +225,51 @@ def test_glob_files_runs_off_the_main_thread(tmp_path, monkeypatch):
     assert result["status"] == "ok"
     assert seen_thread["ident"] != caller_thread, (
         "glob_files must run its directory walk on a worker thread (#2782)"
+    )
+
+
+def test_edit_file_never_emits_from_a_non_loop_thread(tmp_path, monkeypatch):
+    """Tier 2: #2782 — the load-bearing wiring test (architect co-vet finding):
+    edit_file must not emit ANY event — not just `tool_executed`, but the
+    TRANSITIVE `workspace_updated` emitted by `Workspace.write_file_bytes` —
+    from a non-loop thread. Subscribes a REAL `EventStore` (not a bare
+    `EventLog`, which cannot observe this: the race lives inside
+    `EventStore.write`'s off-loop fallback path, not in `EventLog.emit`
+    itself). A spy wraps `EventStore.write` and records which thread called
+    it; every call must match the calling (loop) thread's identity.
+
+    Before the emit-split fix landed for `write_file_bytes`, this failed:
+    `workspace_updated` fired from the `to_thread` worker thread."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "w.txt").write_text("hello world\n")
+
+    events = EventLog()
+    store = EventStore(tmp_path / "events")
+    events.add_subscriber(store)
+    ws = Workspace(events=events)
+    ctx = ToolContext(
+        events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
+        caller_kind="router", router_state=RouterCallerState(),
+    )
+
+    caller_thread = threading.current_thread().ident
+    seen_threads: list[int | None] = []
+    orig_write = store.write
+
+    def _spy_write(event):
+        seen_threads.append(threading.current_thread().ident)
+        return orig_write(event)
+
+    monkeypatch.setattr(store, "write", _spy_write)
+
+    result = asyncio.run(invoke_tool(get_default_registry(), "edit_file",
+                                     {"path": "w.txt", "old_string": "hello", "new_string": "hi"}, ctx))
+    asyncio.run(store.flush())
+
+    assert result["status"] == "ok"
+    assert seen_threads, "EventStore.write must have been called (workspace_updated + tool_executed)"
+    assert all(t == caller_thread for t in seen_threads), (
+        "EventStore.write must NEVER be called from a non-loop thread — a worker-thread call "
+        "falls to EventStore's non-serialized sync-fallback path, racing the DurabilityWorker's "
+        "own writes to the same file (#2782 architect co-vet finding)"
     )

--- a/tests/test_file_ops_offload_2782.py
+++ b/tests/test_file_ops_offload_2782.py
@@ -1,0 +1,213 @@
+"""Tier 2: #2782 — edit_file/grep_files/glob_files run their I/O off the event
+loop (via `asyncio.to_thread`), the same defect class as #1765/#2780 one layer
+lower: `host_backend.py`'s sync read/write calls used to run directly on the
+event loop, freezing it on every file-tool call (the most-frequent tool group
+for a coding agent).
+
+`edit_file`'s read-modify-write is the load-bearing case: today it completes
+with ZERO `await` in between (accidentally atomic — no other coroutine can
+interleave). The fix wraps the WHOLE read-modify-write in ONE `to_thread` job
+(not two separate to_thread calls for read and write), preserving that
+atomicity exactly — see `_execute_edit_sync`'s docstring. `grep_files`/
+`glob_files` have no such concern (pure reads); a single outer `to_thread` per
+call is the natural granularity (not per-candidate-file).
+
+Also verifies a scope-critical, easy-to-miss requirement discovered while
+implementing: `ctx.events.emit(...)` must NOT run inside the threaded call —
+`EventStore.write` (a chat_events subscriber) ultimately does an
+`asyncio.Queue.put_nowait` (DurabilityWorker, #2780), which is not
+thread-safe off the event loop thread. The emit call is placed AFTER the
+`await asyncio.to_thread(...)` returns, back on the loop thread.
+
+Real `Workspace`/`EventLog`/`invoke_tool` throughout — no mocks.
+
+Path-locking (serializing two SEPARATE to_thread jobs against the same path,
+for same-process concurrent-session edits) is explicitly DEFERRED — owner GO
+covers option (a) only (see issue #2782); not tested here.
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import threading
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.file import _execute_grep_sync
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionResolver
+from reyn.tools import get_default_registry
+from reyn.tools.dispatch import invoke_tool
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={"file.read": "allow", "file.write": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _ctx(tmp_path: Path) -> ToolContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return ToolContext(
+        events=events,
+        permission_resolver=_resolver(tmp_path),
+        workspace=ws,
+        caller_kind="router",
+        router_state=RouterCallerState(),
+    )
+
+
+def _call(tmp_path, tool: str, args: dict) -> dict:
+    return asyncio.run(invoke_tool(get_default_registry(), tool, args, _ctx(tmp_path)))
+
+
+def test_edit_file_runs_off_the_main_thread(tmp_path, monkeypatch):
+    """Tier 2: #2782 — edit_file's read-modify-write executes on a DIFFERENT OS
+    thread than the caller (proof the offload actually happens, not just that
+    the result is unchanged). RED before the fix: `_execute_edit` ran
+    synchronously on the same thread as the caller."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "a.txt").write_text("hello world\n")
+    caller_thread = threading.current_thread().ident
+    seen_thread = {}
+
+    from reyn.core.op_runtime import file as file_mod
+    orig = file_mod._execute_edit_sync
+
+    def _spy(op, ctx):
+        seen_thread["ident"] = threading.current_thread().ident
+        return orig(op, ctx)
+
+    monkeypatch.setattr(file_mod, "_execute_edit_sync", _spy)
+
+    result = _call(tmp_path, "edit_file", {"path": "a.txt", "old_string": "hello", "new_string": "hi"})
+    assert result["status"] == "ok"
+    assert seen_thread["ident"] != caller_thread, (
+        "edit_file's read-modify-write must run on a worker thread, not the "
+        "event loop thread (#2782)"
+    )
+
+
+def test_edit_file_result_and_disk_content_unchanged_by_offload(tmp_path, monkeypatch):
+    """Tier 2: the offload is behavior-preserving — same result shape, same
+    on-disk content, as the pre-#2782 synchronous path."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "b.txt").write_text("foo bar\n")
+    result = _call(tmp_path, "edit_file", {"path": "b.txt", "old_string": "foo", "new_string": "baz"})
+    assert result["status"] == "ok"
+    assert result["replacements"] == 1
+    assert (tmp_path / "b.txt").read_text() == "baz bar\n"
+
+
+def test_edit_file_emits_tool_executed_event(tmp_path, monkeypatch):
+    """Tier 2: #2782 — the `tool_executed` event still fires after the offload
+    (moved to run AFTER the to_thread call, on the loop thread — not lost, not
+    duplicated)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "c.txt").write_text("one two\n")
+    events = EventLog()
+    ws = Workspace(events=events)
+    ctx = ToolContext(
+        events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
+        caller_kind="router", router_state=RouterCallerState(),
+    )
+    asyncio.run(invoke_tool(get_default_registry(), "edit_file",
+                            {"path": "c.txt", "old_string": "one", "new_string": "1"}, ctx))
+    emitted = [e for e in events.all() if e.type == "tool_executed" and e.data.get("op") == "edit_file"]
+    assert emitted, "tool_executed must fire after the offloaded edit, not be lost"
+    assert emitted[0].data["replacements"] == 1
+    assert not any(e.data.get("replacements") != 1 for e in emitted), "must not emit a duplicate/mismatched event"
+
+
+def test_edit_file_validation_error_does_not_emit(tmp_path, monkeypatch):
+    """Tier 2: a validation-error branch (old_string not found) still emits NO
+    event — byte-identical to pre-#2782 behavior (only the success path ever
+    emitted)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "d.txt").write_text("only this\n")
+    events = EventLog()
+    ws = Workspace(events=events)
+    ctx = ToolContext(
+        events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
+        caller_kind="router", router_state=RouterCallerState(),
+    )
+    result = asyncio.run(invoke_tool(get_default_registry(), "edit_file",
+                                     {"path": "d.txt", "old_string": "nope", "new_string": "x"}, ctx))
+    assert result["status"] == "error"
+    assert not any(e.type == "tool_executed" for e in events.all())
+
+
+def test_grep_files_runs_off_the_main_thread(tmp_path, monkeypatch):
+    """Tier 2: #2782 — grep_files' tree-walk + per-file read executes on a
+    worker thread, not the caller's thread."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "x.py").write_text("needle_here\n")
+    caller_thread = threading.current_thread().ident
+    seen_thread = {}
+
+    from reyn.core.op_runtime import file as file_mod
+    orig = file_mod._execute_grep_sync
+
+    def _spy(op, ctx):
+        seen_thread["ident"] = threading.current_thread().ident
+        return orig(op, ctx)
+
+    monkeypatch.setattr(file_mod, "_execute_grep_sync", _spy)
+
+    result = _call(tmp_path, "grep_files", {"pattern": "needle_here"})
+    assert result["status"] == "ok"
+    assert seen_thread["ident"] != caller_thread, (
+        "grep_files must run its tree-walk/regex-scan on a worker thread (#2782)"
+    )
+
+
+def test_grep_files_result_unchanged_by_offload(tmp_path, monkeypatch):
+    """Tier 2: grep_files' result shape is unchanged by the offload."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "y.py").write_text("import os\nneedle_here\n")
+    result = _call(tmp_path, "grep_files", {"pattern": "needle_here"})
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+
+
+def test_grep_sync_core_returns_none_emit_marker_for_validation_errors():
+    """Tier 2: `_execute_grep_sync`'s (result, emit_marker) contract — a
+    validation error (empty pattern) returns `None` as the emit marker, so the
+    async wrapper correctly skips emitting (matches pre-#2782: those branches
+    never emitted)."""
+    op = FileIROp(kind="file", op="grep", pattern="", path=".")
+    result, match_count = _execute_grep_sync(op, None)
+    assert result["status"] == "error"
+    assert match_count is None
+
+
+def test_glob_files_runs_off_the_main_thread(tmp_path, monkeypatch):
+    """Tier 2: #2782 — glob_files' directory walk executes on a worker thread."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "z.txt").write_text("x")
+    caller_thread = threading.current_thread().ident
+    seen_thread = {}
+
+    events = EventLog()
+    ws = Workspace(events=events)
+    orig = ws.glob_files
+
+    def _spy(*args, **kwargs):
+        seen_thread["ident"] = threading.current_thread().ident
+        return orig(*args, **kwargs)
+
+    ws.glob_files = _spy
+    ctx = ToolContext(
+        events=events, permission_resolver=_resolver(tmp_path), workspace=ws,
+        caller_kind="router", router_state=RouterCallerState(),
+    )
+    result = asyncio.run(invoke_tool(get_default_registry(), "glob_files", {"pattern": "*.txt"}, ctx))
+    assert result["status"] == "ok"
+    assert seen_thread["ident"] != caller_thread, (
+        "glob_files must run its directory walk on a worker thread (#2782)"
+    )


### PR DESCRIPTION
**[tui-coder]** — Implements the conservative option (a) scope of #2782, per owner GO (relayed by lead-coder: "option (a) のみ GO、path-locking は DEFER"). Design was settled and posted to the issue prior to implementation.

## Problem

`host_backend.py`'s sync filesystem calls (`read_bytes`/`write_bytes`/`glob`/`grep`) ran directly on the event loop via `op_runtime/file.py`'s handlers, with no offload — the same defect class as #1765 (WAL)/#2780 (EventStore), one layer up. `read_file`/`write_file`/`edit_file`/`glob_files`/`grep_files` are the most-frequent tool group for a coding agent, so an FS stall (AV scanner, cloud-sync, network mount, slow disk) froze the *whole* event loop on every call — worse than #2780 since it fires per-tool-call, not just per-audit-write.

## Why this needed design, not a blind `to_thread` wrap

`edit_file`'s current read-modify-write completes with **zero `await`** in between — accidentally atomic (no other coroutine can interleave). Wrapping the read and the write in *separate* `to_thread` calls would introduce a genuine new interleaving window that doesn't exist today. The fix wraps the **whole** read-modify-write in **one** `to_thread` job instead, preserving that atomicity exactly (see `_execute_edit_sync`'s docstring).

**Path-locking is explicitly deferred** — a single `to_thread` job per call doesn't serialize two *separate* calls against the same path; whether same-process concurrent-session edits to one path are a real operational pattern (vs. cross-process, which nothing here solves anyway without OS-level file locking) needs owner scope confirmation. Tracked in #2782, not in this PR.

## Load-bearing subtlety found during implementation

`ctx.events.emit(...)` must **not** run inside the threaded call — `EventStore.write` (a `chat_events` subscriber) ultimately does an `asyncio.Queue.put_nowait` (`DurabilityWorker`, #2780), which is **not thread-safe** off the event loop thread. Naively wrapping the whole function (including its `emit()` call) in `to_thread` would have introduced a new bug. Fixed by splitting each handler into a sync core that returns `(result, emit_marker)`, with the async wrapper calling `ctx.events.emit(...)` *after* `to_thread` returns, back on the loop thread.

## Changes

- `_execute_edit` → `_execute_edit_sync` (sync core, wholesale read-modify-write) + `_execute_edit` (async wrapper, offloads via `to_thread`, emits after).
- `_execute_grep` → `_execute_grep_sync` (same split) + `_execute_grep` (async wrapper).
- `glob` branch in `handle()`: `ctx.workspace.glob_files(...)` wrapped in `await asyncio.to_thread(...)` directly (no split needed — `emit()` already runs after the call, unchanged).
- `write_file`/`read_file` are **out of scope** for this PR — `write_file`'s pre-read is metadata-only (a race there degrades to stale metadata, never data loss, categorically lower priority); `read_file` has no write-after-read risk either way. Noted in #2782 as lower priority, not urgent.

## Verification

- 8 new tests: thread-identity proof (edit/grep/glob genuinely run on a different OS thread than the caller, not just "result unchanged"), result/disk-content parity with the pre-offload behavior, `tool_executed` still fires exactly once after the offload (not lost, not duplicated), validation-error branches still emit nothing (unchanged), `_execute_grep_sync`'s `(result, emit_marker)` contract for validation errors.
- RED→GREEN: stashed the fix, confirmed `ImportError` (the split functions don't exist pre-fix), popped, confirmed green.
- Existing file-tool test sweep (unaffected, confirms no regression): `test_2695_file_adapter_canonical_op_preservation.py` + `test_edit_file_preview_1418.py` + `test_file_edit_registry.py` + `test_file_read_encoding_1452.py` + `test_file_op_pure_helpers.py` + `test_file_read_truncate_marker.py` + `test_file_read_binary_media.py` + `test_file_unified.py` + `test_op_runtime_file_permissions.py` + `test_op_runtime_file_not_found_suggestions.py` + `test_op_runtime_file_mkdir_move_stat.py` + `test_op_runtime_file_b3_basedir_resolve_187.py` + `test_1199_s31b2c_oprt_gates.py` + `test_environment_backend_1115_stage1.py` + `test_fp0056_file_reyn_src_canonical.py` + `test_fp0056_canonical_degraded_invariant.py` + `test_inline_tool_result_summary.py` + `test_python_axis_removal_falsify.py` + `test_dogfood_action_usage_wipe_2357.py` — 219/219 passed.
- Live tmux verification (`./.venv/bin/reyn chat`, litellm proxy): a real turn drove `file__read` → `file__edit` → `file__grep` → `file__glob` in sequence against a scratch file outside the workspace (with live permission prompts answered), confirmed the edit landed on disk (`goodbye world`), grep found the match, glob found the file — all four tools work correctly end-to-end with the offload.
- Full pytest suite: 9 failed / 8014 passed / 17 skipped — same pre-existing, unrelated baseline seen across every full-suite run this session.
- 4 local CI gates green: `ruff check`, `python scripts/test_tier_audit.py --strict tests/test_file_ops_offload_2782.py`, full `pytest`, `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/file.py`.

## Test plan

- [x] RED→GREEN confirmed for all 8 new tests
- [x] Existing file-tool test sweep (219/219, no regression)
- [x] Live tmux verification: read → edit → grep → glob all confirmed working end-to-end
- [x] Full pytest suite (baseline 9 pre-existing failures, no new regressions)
- [x] All 4 local CI gates green

**Tier self-check**: all 8 new tests are Tier 2 (real `Workspace`/`EventLog`/`invoke_tool`, no `MagicMock`/`patch` — the two thread-identity "spy" wrappers still call through to the real implementation, they're call-site probes not behavior fakes; one Tier-4 format-pin (`len(emitted) == 1`) caught by `test_tier_audit.py --strict` during authoring and replaced with a behavioral non-duplication assertion).

## Not in scope

Path-locking (serializing concurrent `to_thread` jobs against the same path) — deferred pending owner confirmation that same-process concurrent-session same-path edits are an actually-exercised scenario. `write_file`/`read_file` offload — noted as lower priority in #2782, not urgent enough to bundle here.