### PR TITLE
refactor: drop now-unused AgentRegistry(environment_backend=, workspace_state_dir=) params (#2255)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -462,8 +462,6 @@ def run(args: argparse.Namespace) -> None:
         # #2093: the uniform reyn.yaml-derived registry config bundle
         # (delegation_capability_default) — one source point.
         factory_config=SessionFactoryConfig.from_config(session_cfg.config, project_root),
-        environment_backend=env_backend,
-        workspace_state_dir=ws_state_dir,
     )
 
     name = args.agent_name or DEFAULT_AGENT_NAME

--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -545,8 +545,6 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
             state_log=None,
             # #2093: the uniform reyn.yaml-derived registry config bundle.
             factory_config=SessionFactoryConfig.from_config(config, project_root),
-            environment_backend=env_backend,   # #1544: container shadow-git
-            workspace_state_dir=ws_state_dir,  # #1557 gap-#1: shadow git-dir under --state-dir
         )
         _reg_cell.append(reg)
         return reg

--- a/src/reyn/interfaces/web/deps.py
+++ b/src/reyn/interfaces/web/deps.py
@@ -385,10 +385,6 @@ def _get_registry():
             # (delegation_capability_default) — one bundle, so a new one can't be
             # missed here (the delegation_capability_default #2081 drift).
             factory_config=SessionFactoryConfig.from_config(config, root),
-            # ``_scoped`` is local to the session factory above; fetch the overrides
-            # at this scope via the accessor.
-            environment_backend=get_cli_scoped_overrides().environment_backend,
-            workspace_state_dir=get_cli_scoped_overrides().workspace_state_dir,
         )
         registry_ref.append(registry)
         _registry = registry

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -149,8 +149,6 @@ class AgentRegistry:
         session_factory: Callable[[AgentProfile], "object"],
         state_log: StateLog | None = None,
         retention_policy: RetentionPolicy | None = None,
-        environment_backend: "object | None" = None,
-        workspace_state_dir: "Path | None" = None,
         delegation_capability_default: str = "inherit",
         max_spawn_depth: int = 0,
         max_spawn_children: int = 0,

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -227,7 +227,5 @@ def build_agent_registry_from_project(
         session_factory=_session_factory,
         state_log=state_log,
         factory_config=factory_config,
-        environment_backend=None,
-        workspace_state_dir=ws_state_dir,
     )
     return registry


### PR DESCRIPTION
**[per-PR-coder]** — mechanical cleanup for #2255 (D-follow-up from #2248 PR-D / git-layer deletion #2254).

## What

`AgentRegistry.__init__` accepted two params — `environment_backend` and `workspace_state_dir` — that were **only** consumed by the git-based workspace-durability layer deleted in #2254 (`_build_workspace_store()` / `op_content_log`). Since that deletion they were accepted-but-unused: never stored to an instance var, never read anywhere in the registry. Removed the params and the (now-dead) kwargs at the production call sites that passed them. Owner no-debt / no-dead-code principle (#2248).

## Verification (grep-first, per the issue)

- **`registry.py`**: before removal, `environment_backend` / `workspace_state_dir` appeared **only** on the two `__init__` signature lines — no assignment, no body read, no `_environment_backend`/`_workspace_state_dir` instance var. Confirmed dead.
- **Caller enumeration** (`grep -rn "AgentRegistry(" src/reyn tests`): 4 production sites passed these kwargs — `runtime/registry_bootstrap.py`, `interfaces/web/deps.py`, `interfaces/cli/commands/chat.py`, `interfaces/cli/commands/dogfood.py`. All 4 updated. (The other src sites — `mcp.py`, `agent.py`, `topology.py`, and the chainlit `AgentRegistry` — never passed them; unchanged.)
- **No test passes these to `AgentRegistry`**: the only test file mentioning the names is `test_scoped_session_factory_invariant_1402.py`, where they are in `_REQUIRED_SCOPED` — the required-params set for **`build_scoped_chat_session`** (the live Session FS-exec seam), NOT `AgentRegistry`. Untouched (verified: that invariant still passes). Every other `environment_backend=`/`workspace_state_dir=` kwarg in `tests/` targets `Session` / `Workspace` / `RouterOpContext` / `router_host_adapter` — all live, all unrelated.
- **No stranded locals** (ruff F841 clean): at each call site the removed value's source variable is still consumed by the site's own **Session factory** (which legitimately still takes `environment_backend` / `workspace_state_dir` — those Session params are live). `chat.py` `env_backend`/`ws_state_dir` → passed to `build_scoped_chat_session`; `dogfood.py` same; `registry_bootstrap.py` `ws_state_dir` → Session factory line; `web/deps.py` `get_cli_scoped_overrides()` → still used by the session factory + at two other scopes.

## Scope note

This removes only the **`AgentRegistry`** copies of these params. The identically-named params on `Session`, `Workspace`, `RouterOpContext`, `router_host_adapter`, and the `build_scoped_chat_session` factory are the **live** FS-exec-seam plumbing and are intentionally left alone.

## Test plan

- [x] `ruff check src tests` — clean (F841 unused-var + I001 import-sort both pass; no now-unused `Path` import in registry.py).
- [x] `python scripts/verify_module_docstrings.py <5 changed src files>` — OK.
- [x] `pytest` full suite (from repo root) — green (see PR checks). Targeted first: `test_scoped_session_factory_invariant_1402` (the AgentRegistry-gets-factory_config invariant + the build_scoped_chat_session required-params guard), `test_registry_multi_session_1726`, `test_registry_checkout_2a2`, `test_2248_prb_config_path_consistency`, `test_2248_pr_a2_emit_hooks`, `test_multi_agent_p7`, `test_multi_session_restore` — 22 passed.
- [x] No test changes required (no test constructed `AgentRegistry` with these kwargs) — n/a, not skipped.
- No new test added: this is a pure dead-param removal (no new behavior/invariant to pin). A regression here surfaces as a `TypeError: unexpected keyword argument` at any re-introduced call site — caught by the existing frontend/registry construction tests above, which all exercise the real constructor.

Closes #2255.
