### PR TITLE
docs: note the immediate-vs-CLI mcp-install persistence asymmetry

### DIFF
--- a/docs/reference/cli/mcp.ja.md
+++ b/docs/reference/cli/mcp.ja.md
@@ -45,6 +45,13 @@ reyn mcp clear-secret <SERVER> [<KEY>]
 
 CLI とチャットは末端で `op_runtime/mcp_install.py` に合流するため、 permission gate、 シークレット検出、 audit event は同一です。
 
+**永続化の非対称性。** 2 つのパスは、サーバーに到達できない場合に新しい設定を書き込むかどうかという 1 点で異なります。
+
+- **チャット駆動の install、ターン途中、live な per-session reloader あり** — probe-then-commit: 何かを書き込む*前に*サーバーを probe します(spawn/connect + `list_tools`)。probe が失敗またはキャンセルされた場合、`.reyn/mcp.yaml` は変更されません(half-install なし)— LLM が同じターンでそのサーバーを使いたかったという immediate なユースケースに合っています。
+- **`reyn mcp install`(CLI)、または live reloader が attach されていない install** — probe せずに設定を書き込みます。サーバーが現在到達不能でも構いません — 後で立ち上がることを見込んで今のうちに設定しておく、という deferred なユースケースに合っています。
+
+書き込み(または非書き込み)の後は両パスとも再び合流します: permission gate、シークレット検出、audit event はどちらのパスが走ったかに影響されません。
+
 ---
 
 ## サブコマンド: `search`

--- a/docs/reference/cli/mcp.md
+++ b/docs/reference/cli/mcp.md
@@ -65,6 +65,13 @@ The chat router exposes the same install surface as four `mcp` verbs split along
 
 The CLI and chat paths converge at `op_runtime/mcp_install.py`, so permission gates, secret detection, and audit events are identical.
 
+**Persistence asymmetry.** The two paths differ in one respect: whether the new server config is written when the server can't be reached.
+
+- **Chat-driven install, mid-turn, with a live per-session reloader** — probe-then-commit: the server is probed (spawn/connect + `list_tools`) *before* anything is written. A failed or cancelled probe leaves `.reyn/mcp.yaml` unchanged (no half-install) — this fits the immediate use case, since the LLM wanted to use the server this same turn.
+- **`reyn mcp install` (CLI) or any install with no live reloader attached** — writes the config without probing first. The server may currently be unreachable; this fits the deferred use case of configuring a server to come up later.
+
+Both paths converge again after the write (or non-write): permission gates, secret detection, and audit events are unaffected by which path ran.
+
 ---
 
 ## Subcommand: `search`


### PR DESCRIPTION
**[docs-maintainer]** — doc-only do-now, closes #2767 (roi:low, blocker-free per owner directive).

## What changed
Added a "Persistence asymmetry" section to `docs/reference/cli/mcp.md`(`.ja.md`), right after the existing CLI/chat-path convergence note, explaining the probe-then-commit vs write-without-probing behavior:

- **Chat-driven install, mid-turn, live per-session reloader attached** — probe-then-commit: the server is probed before anything is written; a failed/cancelled probe leaves `.reyn/mcp.yaml` unchanged (no half-install). Fits the immediate use-now case.
- **`reyn mcp install` (CLI) or any install with no live reloader** — writes without probing first. Fits the deferred configure-to-use-later case.

## Verification
Read `src/reyn/core/op_runtime/mcp_install.py` directly (the `_reloader`/`_is_addition` branch at the commit point, and `probe_mcp_server`'s own docstring) before writing — matches the described behavior exactly.

Closes #2767

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `python3 -m pytest tests/test_fp0036_coverage.py -q` — 23 passed
- [x] `ruff check src tests` — all checks passed
- [x] `git diff | grep -oE "#[0-9]{3,4}"` — none found in doc body (issue number only in commit trailer per convention)