### PR TITLE
test: cover archive_agent's FsWatcher/EventStore teardown (#2783 follow-up)

### DIFF
--- a/tests/test_teardown_completeness_2783.py
+++ b/tests/test_teardown_completeness_2783.py
@@ -188,3 +188,47 @@ async def test_remove_session_closes_event_store_synchronously_before_cancel(tmp
         "remove_session must close the spawned session's EventStore synchronously, "
         "before task.cancel(), not rely on the cancelled run() task's own finally (#2783)"
     )
+
+
+@pytest.mark.asyncio
+async def test_archive_agent_closes_event_store_and_fs_watcher(tmp_path, monkeypatch):
+    """Tier 2: #2783 — `archive_agent` (the DELETE seam for the MAIN session,
+    `registry.py:805-834`) got the SAME FsWatcher/EventStore synchronous-close
+    fix as `remove_session` (`registry.py:1968-1990`), added in the SAME PR — a
+    separate call site with its own risk of being missed. Per the co-vet
+    discipline of falsifying every call site a multi-site fix touches, not just
+    one sibling path: this test targets `archive_agent` specifically, distinct
+    from `test_remove_session_closes_event_store_synchronously_before_cancel`
+    above (which only drives `remove_session`).
+
+    Uses a call-through spy on `Session.aclose_event_store`/`aclose_fs_watcher`
+    rather than an on-disk content check: `archive_agent` awaits
+    `self._state_log.append(...)` AFTER the close block, and that await gives
+    the EventStore's background drainer a chance to flush the queued write
+    anyway — even WITHOUT this fix — so an on-disk assertion here would pass
+    whether or not `archive_agent` actually called the close methods (a
+    timing coincidence, not a real green). A call-count spy is deterministic
+    regardless of drainer timing."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    session = reg.get_or_load("owner")
+
+    calls: dict[str, int] = {"event_store": 0, "fs_watcher": 0}
+    orig_aclose_event_store = session.aclose_event_store
+    orig_aclose_fs_watcher = session.aclose_fs_watcher
+
+    async def _spy_event_store() -> None:
+        calls["event_store"] += 1
+        await orig_aclose_event_store()
+
+    async def _spy_fs_watcher() -> None:
+        calls["fs_watcher"] += 1
+        await orig_aclose_fs_watcher()
+
+    monkeypatch.setattr(session, "aclose_event_store", _spy_event_store)
+    monkeypatch.setattr(session, "aclose_fs_watcher", _spy_fs_watcher)
+
+    await reg.archive_agent("owner", purge=False)
+
+    assert calls["event_store"] == 1, "archive_agent must call session.aclose_event_store() (#2783)"
+    assert calls["fs_watcher"] == 1, "archive_agent must call session.aclose_fs_watcher() (#2783)"


### PR DESCRIPTION
**[tui-coder]** — Small test-only follow-up to merged #2783 (PR #2791), applying the #2788/#2786 co-vet discipline (memory-curator pin: falsify every call site a multi-site fix touches, not just one sibling path) to this session's own prior work.

## Gap

#2783's fix added the same synchronous FsWatcher/EventStore close to BOTH `remove_session` and `archive_agent` (`registry.py:816-829` and `registry.py:1968-1990`), but only `remove_session` had a dedicated test. `archive_agent` was untested for this specific behavior.

## A note on getting it right the second time

My first attempt at closing this gap used an on-disk content check (mirroring the existing `remove_session` test) and it **passed even without the fix** — a false green. `archive_agent` awaits `self._state_log.append(...)` *after* the close block, and that await gives EventStore's background drainer a chance to flush the queued write anyway, regardless of whether `archive_agent` actually calls the close methods. Caught this by hand-verifying RED before pushing (stashed the fix, test still passed) — rewrote using a call-through spy on `Session.aclose_event_store`/`aclose_fs_watcher` instead, which is deterministic regardless of drainer timing. RED→GREEN reconfirmed with the spy-based version.

## Verification

- RED→GREEN: reverted the `archive_agent` fix block, confirmed the spy-based test fails (`0 == 1`), restored, confirmed green.
- Full test file (6 tests, all passing).
- Full pytest suite: 9 failed / 8033 passed / 17 skipped — same pre-existing baseline.
- `ruff check` + `test_tier_audit.py --strict` both green.

## Test plan

- [x] RED→GREEN confirmed
- [x] Full pytest suite (baseline 9 pre-existing failures, no new regressions)
- [x] ruff + tier-audit gates green

**Tier self-check**: Tier 2, real `AgentRegistry`/`Session`, no `MagicMock` — the call-through spy still invokes the real implementation, it's a call-count probe not a behavior fake.