### PR TITLE
cleanup: remove dead skill/phase/workflow event-render vocab from dogfood_trace (#2512)

### DIFF
--- a/scripts/dogfood_trace.py
+++ b/scripts/dogfood_trace.py
@@ -277,32 +277,14 @@ def mode_chain(root: Path) -> None:
     if not evs:
         print("no events found"); return
     base_ts = evs[0].get("timestamp")
-    indent = 0
-    print("=== Skill / Tool Chain ===")
+    print("=== Tool Chain ===")
     for ev in evs:
         kind, data, ts = ev.get("type", ""), ev.get("data", {}), ev.get("timestamp")
-        pad = "  " * indent
         t = _ts_offset(base_ts, ts)
-        if kind == "workflow_started":
-            print(f"{pad}[{t}] workflow_started: {data.get('skill','?')}  run_id={data.get('run_id','')}")
-            indent = min(indent + 1, 6)
-        elif kind == "phase_started":
-            print(f"{pad}[{t}] phase_started: {data.get('phase','?')}")
-        elif kind == "tool_called":
-            print(f"{pad}[{t}] tool: {data.get('tool','?')}({_exc(data.get('args',{}))})")
-        elif kind == "run_skill_started":
-            print(f"{pad}[{t}] run_skill_started: {data.get('skill','?')}")
-            indent = min(indent + 1, 6)
-        elif kind == "run_skill_completed":
-            indent = max(indent - 1, 0); pad = "  " * indent
-            print(f"{pad}[{t}] run_skill_completed: {data.get('skill','?')}  status={data.get('status','?')}")
-        elif kind == "workflow_finished":
-            indent = max(indent - 1, 0); pad = "  " * indent
-            print(f"{pad}[{t}] workflow_finished  status={data.get('status','?')}")
-        elif kind == "phase_completed":
-            print(f"{pad}[{t}] phase_completed: {data.get('phase','?')}  decision={data.get('decision','?')}")
-        elif kind in ("control_ir_failed", "phase_retry"):
-            print(f"{pad}[{t}] {kind}: {json.dumps(data, ensure_ascii=False)[:80]}")
+        if kind == "tool_called":
+            print(f"[{t}] tool: {data.get('tool','?')}({_exc(data.get('args',{}))})")
+        elif kind == "control_ir_failed":
+            print(f"[{t}] {kind}: {json.dumps(data, ensure_ascii=False)[:80]}")
 
 
 def mode_summary(root: Path) -> None:
@@ -310,31 +292,11 @@ def mode_summary(root: Path) -> None:
     if not evs:
         print("no events found"); return
 
-    workflows: list[dict] = []
-    wf_map: dict[str, dict] = {}
     tool_calls, peer_failures, iv_dispatch, iv_resolve, agent_msgs = [], [], [], [], []
 
     for ev in evs:
         kind, data, ts = ev.get("type", ""), ev.get("data", {}), ev.get("timestamp", "")
-        if kind == "workflow_started":
-            wf = {"run_id": data.get("run_id",""), "skill": data.get("skill",""),
-                  "entry_phase": data.get("entry_phase",""), "ts": ts, "status": "active", "phases": []}
-            workflows.append(wf); wf_map[wf["run_id"]] = wf
-        elif kind == "workflow_finished":
-            run_id = data.get("run_id", "")
-            if run_id in wf_map:
-                wf_map[run_id]["status"] = data.get("status", "finished")
-            else:
-                for wf in reversed(workflows):
-                    if wf["status"] == "active":
-                        wf["status"] = data.get("status", "finished"); break
-        elif kind == "phase_started":
-            phase = data.get("phase", "")
-            for wf in reversed(workflows):
-                if wf["status"] == "active":
-                    if phase not in wf["phases"]: wf["phases"].append(phase)
-                    break
-        elif kind == "tool_called" and data.get("tool") in IMPORTANT_TOOLS:
+        if kind == "tool_called" and data.get("tool") in IMPORTANT_TOOLS:
             tool_calls.append({"tool": data.get("tool"), "args": data.get("args", {}),
                                 "caller": data.get("caller_id", data.get("caller_kind", "")), "ts": ts})
         elif kind == "peer_reply_failed_surfaced":
@@ -351,13 +313,6 @@ def mode_summary(root: Path) -> None:
     print("=" * 60)
     print("DOGFOOD TRACE SUMMARY")
     print("=" * 60)
-
-    print(f"\n[Skill Chain]  ({len(workflows)} workflow(s))")
-    for wf in workflows:
-        phases_str = " -> ".join(wf["phases"]) or "(no phases recorded)"
-        print(f"  [{wf['ts'][:19]}] {wf['skill']} (entry={wf['entry_phase']})  status={wf['status']}")
-        print(f"    phases: {phases_str}")
-        print(f"    run_id: {wf['run_id']}")
 
     print(f"\n[Tool Calls]  ({len(tool_calls)} important tool call(s))")
     for i, tc in enumerate(tool_calls, 1):
@@ -379,15 +334,6 @@ def mode_summary(root: Path) -> None:
         src = d.get("from", d.get("agent", "?"))
         text = str(d.get("text", d.get("content", "")))
         print(f"  {src}: {text[:40]}")
-
-    skill_runs_dir = root / "state" / "skill_runs"
-    if skill_runs_dir.exists():
-        runs = list(skill_runs_dir.iterdir())
-        print(f"\n[Skill Run State]  {skill_runs_dir}  ({len(runs)} entr(ies))")
-        for r in sorted(runs)[:10]:
-            print(f"  {r.name}")
-    else:
-        print(f"\n[Skill Run State]  {skill_runs_dir} (not found)")
 
     print()
     mode_cost(root)

--- a/tests/test_dogfood_trace_tool.py
+++ b/tests/test_dogfood_trace_tool.py
@@ -39,19 +39,23 @@ def _run(args: list[str]) -> tuple[str, int]:
     return result.stdout + result.stderr, result.returncode
 
 
+# Surviving, still-produced event vocab (#2512): the skill-era
+# workflow_*/phase_*/run_skill_* kinds have 0 producers after the skill-machinery
+# removal, so the live-mode renderers no longer branch on them. ``tool_called``
+# (emitted by ``core/dispatch/dispatcher.py``) + ``session_started`` /
+# ``session_completed`` are current producers, so they exercise the real
+# chain/summary/full rendering paths.
 MINIMAL_EVENTS = [
-    {"type": "workflow_started", "timestamp": "2026-05-04T10:00:00+09:00",
-     "data": {"run_id": "run_001", "skill": "my_skill", "entry_phase": "do_it"}},
-    {"type": "phase_started", "timestamp": "2026-05-04T10:00:01+09:00",
-     "data": {"phase": "do_it", "visit_count": 1}},
+    {"type": "session_started", "timestamp": "2026-05-04T10:00:00+09:00",
+     "data": {"run_id": "run_001", "agent": "default"}},
     {"type": "tool_called", "timestamp": "2026-05-04T10:00:02+09:00",
-     "data": {"caller_kind": "skill_phase", "caller_id": "my_skill.do_it",
-              "tool": "invoke_skill", "args": {"skill": "sub"}}},
+     "data": {"caller_kind": "agent", "caller_id": "default",
+              "tool": "file", "args": {"op": "read", "path": "src/x.py"}}},
     {"type": "tool_called", "timestamp": "2026-05-04T10:00:03+09:00",
-     "data": {"caller_kind": "skill_phase", "caller_id": "my_skill.do_it",
-              "tool": "describe_skill", "args": {"name": "sub"}}},
-    {"type": "workflow_finished", "timestamp": "2026-05-04T10:00:05+09:00",
-     "data": {"run_id": "run_001", "status": "finished"}},
+     "data": {"caller_kind": "agent", "caller_id": "default",
+              "tool": "ask_user", "args": {"prompt": "proceed?"}}},
+    {"type": "session_completed", "timestamp": "2026-05-04T10:00:05+09:00",
+     "data": {"run_id": "run_001", "status": "completed"}},
 ]
 
 
@@ -62,14 +66,15 @@ MINIMAL_EVENTS = [
 class TestSummaryMode:
     """Tier 2: summary mode emits expected sections."""
 
-    def test_summary_includes_skill_chain(self, tmp_path: Path) -> None:
-        """Tier 2: summary output contains skill_started and tool_called data."""
+    def test_summary_includes_tool_calls(self, tmp_path: Path) -> None:
+        """Tier 2: summary output renders the [Tool Calls] section from live
+        ``tool_called`` events (surviving vocab, #2512)."""
         reyn = tmp_path / ".reyn"
         _write_events(reyn, MINIMAL_EVENTS)
         out, rc = _run(["--root", str(reyn), "--mode", "summary"])
         assert rc == 0
-        assert "my_skill" in out
-        assert "invoke_skill" in out or "describe_skill" in out
+        assert "Tool Calls" in out
+        assert "file" in out or "ask_user" in out
 
     def test_summary_no_events_message(self, tmp_path: Path) -> None:
         """Tier 2: empty .reyn/events dir prints 'no events found'."""
@@ -119,8 +124,8 @@ class TestFullMode:
         out, rc = _run(["--root", str(reyn), "--mode", "full", "--filter", "tool_called"])
         assert rc == 0
         assert "tool_called" in out
-        # workflow_started events should NOT appear in the header section
-        assert "workflow_started" not in out
+        # a non-filtered kind (session_started) should NOT appear in the grouped output
+        assert "session_started" not in out
 
     def test_full_corrupt_line_skipped(self, tmp_path: Path) -> None:
         """Tier 2: a corrupt JSONL line is silently skipped; valid lines parsed."""
@@ -128,25 +133,26 @@ class TestFullMode:
         target = reyn / "events" / "agents" / "default" / "chat" / "s.jsonl"
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(
-            '{"type":"workflow_started","timestamp":"2026-05-04T10:00:00+09:00","data":{"run_id":"r1","skill":"x","entry_phase":"p"}}\n'
+            '{"type":"session_started","timestamp":"2026-05-04T10:00:00+09:00","data":{"run_id":"r1","agent":"default"}}\n'
             'NOT VALID JSON\n'
-            '{"type":"workflow_finished","timestamp":"2026-05-04T10:00:01+09:00","data":{"run_id":"r1","status":"finished"}}\n',
+            '{"type":"session_completed","timestamp":"2026-05-04T10:00:01+09:00","data":{"run_id":"r1","status":"completed"}}\n',
             encoding="utf-8",
         )
         out, rc = _run(["--root", str(reyn), "--mode", "full"])
         assert rc == 0
-        assert "workflow_started" in out
-        assert "workflow_finished" in out
+        assert "session_started" in out
+        assert "session_completed" in out
 
 
 class TestChainMode:
-    """Tier 2: chain mode shows workflow/phase/tool timeline."""
+    """Tier 2: chain mode shows the live tool-call timeline."""
 
-    def test_chain_shows_phases(self, tmp_path: Path) -> None:
-        """Tier 2: chain mode prints phase_started events in order."""
+    def test_chain_shows_tool_calls(self, tmp_path: Path) -> None:
+        """Tier 2: chain mode prints live ``tool_called`` events in order
+        (surviving vocab, #2512)."""
         reyn = tmp_path / ".reyn"
         _write_events(reyn, MINIMAL_EVENTS)
         out, rc = _run(["--root", str(reyn), "--mode", "chain"])
         assert rc == 0
-        assert "workflow_started" in out
-        assert "do_it" in out
+        assert "tool:" in out
+        assert "file" in out


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2512

## What

`dogfood_trace`'s `mode_chain` / `mode_summary` still branched on seven skill-era event kinds that have **0 producers** after the skill-machinery + eval-export removals. Rendering branches for kinds nothing emits are dead code; the entanglement was that the `--mode summary/full/chain` live-mode tests used `workflow_*` as their fixture vocabulary, so removing the vocab forced a fixture rewrite (why this was split out of the item1 arc into its own issue).

## 0-producer verification (primary evidence)

For each of `workflow_started`, `workflow_finished`, `phase_started`, `phase_completed`, `phase_retry`, `run_skill_started`, `run_skill_completed`:
- **Multi-line-aware `.emit()` scan** over all of `src/`: none of the seven is ever the first string-literal argument to an `.emit(...)` call. (An initial single-line grep was insufficient — `tool_called` itself is emitted via a multi-line `emit(\n "tool_called",` in `core/dispatch/dispatcher.py`, so I re-ran a multi-line-aware AST-style match to be sure.)
- **Full-occurrence grep**: the only remaining references to these kinds in `src/` are **consumer** watch-sets (`mcp/server.py` / `web/routers/a2a.py` `TRACKED_EVENTS`, `openui` dispatch) and the `reporters` `on_<type>` handlers — never a producer. `phase_started` specifically appears only in those consumer filters (dead-but-harmless; out of scope here).
- No direct `Event(type=...)` construction with any of the seven.

## Changes

- **`mode_chain`**: removed the six dead render branches + `phase_retry`; kept the live `tool_called` + `control_ir_failed` branches. The workflow/skill `indent` nesting logic went with them. Header `Skill / Tool Chain` -> `Tool Chain`.
- **`mode_summary`**: removed the workflow tracking (`workflows`/`wf_map` + `workflow_started`/`workflow_finished`/`phase_started` branches) and its now-orphaned `[Skill Chain]` output section, plus the dead `[Skill Run State]` dir listing (`state/skill_runs` has no writer in `src/` post-skill-deletion). Tool-call / peer-failure / intervention / agent-message / cost sections unchanged.
- **Tests** (`test_dogfood_trace_tool.py`): rewrote the `--mode chain/summary/full` fixtures off the dead `workflow_*` vocab onto surviving produced kinds — `tool_called` (from `core/dispatch/dispatcher.py`) + `session_started`/`session_completed` — keeping the live rendering coverage intact.

`--mode llm-payloads` (CLAUDE.md-canonical) **untouched**.

## Scope notes (for co-vet)

- **`IMPORTANT_TOOLS`** still lists dead skill tool names (`invoke_skill` / `describe_skill` / `list_skills` / `run_skill`). Left as-is: it is a filter allowlist, not event-**rendering** vocab, so it's outside this issue's stated scope (harmless — those never match). Flagging in case you want it folded in.
- **Historical dogfood journal/findings** under `docs/deep-dives/journal/dogfood/**` contain `[Skill Chain]` / `workflow_*` in archived point-in-time run captures. Left untouched — editing timestamped run archives would falsify the record.
- `test_dogfood_fresh_mode.py` uses `{"type":"workflow_started"}` only as arbitrary filler to assert a reset script preserves the events log (kind is semantically irrelevant there; different subsystem) — left untouched.

## Test plan

- [x] `ruff check src tests scripts/dogfood_trace.py` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_dogfood_trace_tool.py` — 8/8 OK, 0 Tier-4 violations.
- [x] `python scripts/verify_module_docstrings.py scripts/dogfood_trace.py` — clean.
- [x] `pytest` (full suite) — 8034 passed / 21 skipped / 5 pre-existing failures unrelated to this change (identical web/plugin-loader route-mount set — `test_fp0001_a2a_endpoints`, `web/test_a2a`, `web/test_mcp_sse`, `web/test_plugin_loader`, `web/test_resources_router` — verified failing identically on an unmodified worktree; this PR touches only `scripts/dogfood_trace.py` + its test).
- [x] Falsified: neutering the surviving `tool_called` render branch in `mode_chain`/`mode_summary` turns `test_chain_shows_tool_calls` + `test_summary_includes_tool_calls` RED; restoring -> GREEN. Confirms the rewritten tests guard the live rendering path, not a vacuous one.
- [x] Manual smoke: ran `--mode chain`, `--mode summary`, `--mode full --filter tool_called` against a surviving-vocab fixture — all render the live tool-call output correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)