### PR TITLE
fix: dogfood 'fresh' reset wipes spawn-arc-created agents in single-run mode (#2169)

### DIFF
--- a/src/reyn/interfaces/cli/commands/dogfood.py
+++ b/src/reyn/interfaces/cli/commands/dogfood.py
@@ -269,6 +269,39 @@ def _scenario_state_targets(project_root: Path, agent_name: str) -> "dict[str, P
     }
 
 
+def _leaked_agent_dirs(project_root: Path, keep_agent: str) -> "list[Path]":
+    """#2169: the spawn-arc-created SIBLING agent dirs under ``.reyn/agents/`` that a
+    fresh per-scenario reset must remove — every agent dir EXCEPT the dogfood target.
+
+    Agent-creating scenarios (spawn-arc #2103 B/C) write ``.reyn/agents/<name>/profile.yaml``
+    for each agent they spawn (``researcher``/``alice``/``A``/``B``/``C``/``child``/…).
+    In single-run mode the project ``.reyn/`` is REUSED across runs, so those created
+    agents leak: a re-run of an agent-creating scenario hits ``agent already exists``
+    (``AgentRegistry.create`` raises when ``profile.yaml`` is present) → ``refuted``.
+
+    The dogfood TARGET agent (``keep_agent``, default ``"default"``) is deliberately
+    spared: its ``profile.yaml`` is a precondition — ``AgentRegistry.get_or_load`` raises
+    ``FileNotFoundError`` without it, so wiping it would block EVERY scenario — and its
+    ephemeral ledger/history are already wiped by ``_scenario_state_targets``. Per-agent
+    event logs live under ``.reyn/events/agents/<name>/`` (PR20), NOT under the removed
+    ``.reyn/agents/<name>/`` dir, so this removes no event log (no running-web constraint,
+    the reason ``dogfood_fresh_reset.sh`` — which has no agent name — defers this)."""
+    agents_root = project_root / ".reyn" / "agents"
+    if not agents_root.is_dir():
+        return []
+    return [d for d in sorted(agents_root.iterdir()) if d.is_dir() and d.name != keep_agent]
+
+
+def _wipe_leaked_agents(project_root: Path, keep_agent: str) -> None:
+    """Remove the spawn-arc-created sibling agent dirs (#2169) so agent-creating
+    scenarios are reproducible in single-run mode. Spares ``keep_agent`` (see
+    :func:`_leaked_agent_dirs`). Idempotent: a no-op when none have leaked."""
+    import shutil
+
+    for d in _leaked_agent_dirs(project_root, keep_agent):
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def _baselines_dir() -> Path:
     return _dogfood_base_dir() / "baselines"
 
@@ -401,6 +434,11 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
       context — defeating the "fresh per scenario" guarantee. The
       dogfood_fresh_reset.sh script explicitly defers per-agent history
       wipe to callers (= the runner is the caller); this is that wipe.
+    - Wipes agents CREATED by spawn-arc scenarios (sibling .reyn/agents/<other>/
+      dirs) before each scenario so an agent-creating scenario is reproducible
+      in single-run mode — otherwise created agents leak across runs and a
+      re-run hits "agent already exists" (#2169). The dogfood target agent is
+      spared (its profile.yaml is a load precondition).
     - Drops the cached Session from the registry between scenarios so
       the session's in-memory EventLog starts empty each time.
 
@@ -562,6 +600,11 @@ def _build_live_runner(agent_name: str, *, env_backend=None, ws_base_dir=None, w
         # wipe to the runner because it needs the agent name (which the script doesn't have).
         targets["action_usage"].unlink(missing_ok=True)
         targets["history"].unlink(missing_ok=True)
+        # #2169: remove agents CREATED by spawn-arc scenarios (siblings under .reyn/agents/),
+        # which otherwise leak across single-runs → "agent already exists" on re-run. The target
+        # agent is spared (its profile.yaml is a precondition). Same "needs the agent name" reason
+        # dogfood_fresh_reset.sh can't do this — the runner has the name, so it does it here.
+        _wipe_leaked_agents(project_root, agent_name)
 
     def _collect_events(registry: AgentRegistry) -> list[dict]:
         """Harvest events emitted during the scenario from the EventStore."""

--- a/tests/test_dogfood_leaked_agents_wipe_2169.py
+++ b/tests/test_dogfood_leaked_agents_wipe_2169.py
@@ -1,0 +1,73 @@
+"""Tier 2: #2169 — the dogfood per-scenario reset wipes spawn-arc-created agents.
+
+Spawn-arc scenarios (#2103 B/C) are the first dogfood scenarios that CREATE agents:
+each writes ``.reyn/agents/<name>/profile.yaml`` (``researcher``/``alice``/``A``/…).
+In single-run mode the project ``.reyn/`` is REUSED across runs, so those created
+agents previously leaked — a re-run of an agent-creating scenario hit ``agent already
+exists`` (``AgentRegistry.create`` raises when ``profile.yaml`` is present) → ``refuted``.
+The fresh per-scenario reset now removes every created SIBLING agent dir while sparing
+the dogfood TARGET agent (whose ``profile.yaml`` is a load precondition —
+``get_or_load`` raises ``FileNotFoundError`` without it, which would block every
+scenario). Real ``AgentProfile.save`` / ``PROFILE_FILENAME`` — the exact marker
+``AgentRegistry.exists`` keys off — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.interfaces.cli.commands.dogfood import (
+    _leaked_agent_dirs,
+    _wipe_leaked_agents,
+)
+from reyn.runtime.profile import PROFILE_FILENAME, AgentProfile
+
+
+def _seed_agent(agents_root: Path, name: str) -> Path:
+    """Write a real profile.yaml for ``name`` the way AgentRegistry.create does."""
+    agent_dir = agents_root / name
+    AgentProfile.new(name).save(agent_dir)
+    assert (agent_dir / PROFILE_FILENAME).is_file()  # precondition: it exists now
+    return agent_dir
+
+
+def test_leaked_agent_dirs_selects_siblings_spares_target(tmp_path):
+    """Tier 2: #2169 — the reset targets every created SIBLING agent dir and never
+    the dogfood target (order-agnostic membership, so no sort-order pin)."""
+    agents_root = tmp_path / ".reyn" / "agents"
+    for name in ("default", "researcher", "alice", "child"):
+        _seed_agent(agents_root, name)
+
+    leaked = _leaked_agent_dirs(tmp_path, "default")
+
+    assert {d.name for d in leaked} == {"researcher", "alice", "child"}
+    assert all(d.parent == agents_root for d in leaked)
+    # the target is never selected for removal
+    assert agents_root / "default" not in leaked
+
+
+def test_wipe_removes_created_agents_preserves_target(tmp_path):
+    """Tier 2: #2169 — after the wipe, created siblings' profile.yaml is gone (so a
+    re-run no longer hits "agent already exists") while the target's profile.yaml
+    survives (so get_or_load does not raise FileNotFoundError). RED before the fix:
+    the sibling profiles were never removed and leaked across single-runs."""
+    agents_root = tmp_path / ".reyn" / "agents"
+    _seed_agent(agents_root, "default")
+    _seed_agent(agents_root, "researcher")
+    _seed_agent(agents_root, "alice")
+
+    _wipe_leaked_agents(tmp_path, "default")
+
+    # created agents are gone — the "already exists" marker no longer present
+    assert not (agents_root / "researcher" / PROFILE_FILENAME).is_file()
+    assert not (agents_root / "researcher").exists()
+    assert not (agents_root / "alice").exists()
+    # the dogfood target is spared — its profile (a load precondition) still loads
+    assert (agents_root / "default" / PROFILE_FILENAME).is_file()
+    assert AgentProfile.load(agents_root / "default").name == "default"
+
+
+def test_wipe_is_idempotent_with_no_agents_dir(tmp_path):
+    """Tier 2: #2169 — the reset is a no-op (never raises) when nothing has leaked,
+    including when the .reyn/agents/ dir does not exist yet."""
+    _wipe_leaked_agents(tmp_path, "default")  # no .reyn/agents/ at all
+    assert _leaked_agent_dirs(tmp_path, "default") == []

--- a/tests/test_fp0036_live_runner.py
+++ b/tests/test_fp0036_live_runner.py
@@ -35,7 +35,7 @@ from reyn.dev.dogfood.scenarios import Scenario
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
-from reyn.runtime.profile import AgentProfile
+from reyn.runtime.profile import PROFILE_FILENAME, AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 
@@ -379,3 +379,61 @@ async def test_history_jsonl_wiped_before_scenario(tmp_path, monkeypatch):
                 )
 
     assert result.scenario_id == "hist-s1"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: created-agent isolation — spawn-arc sibling agents are wiped per
+# scenario through the REAL runner_fn -> _wipe_scenario_state wiring (#2169).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_created_sibling_agents_wiped_before_scenario(tmp_path, monkeypatch):
+    """Tier 2: #2169 — agents CREATED by a prior spawn-arc scenario do not leak
+    into the next single-run scenario.
+
+    Regression guard for the PRODUCTION WIRING (not just the mechanism): the
+    runner's ``runner_fn`` calls ``_wipe_scenario_state`` first, which calls
+    ``_wipe_leaked_agents`` — so a leaked sibling ``.reyn/agents/<other>/`` must
+    be gone after a scenario runs. Drives the real runner_fn path end-to-end so
+    that DELETING the ``_wipe_leaked_agents`` call (dogfood.py) makes this RED —
+    the direct-call mechanism tests in test_dogfood_leaked_agents_wipe_2169.py
+    would stay green if that wiring were stripped, so this closes the gap.
+
+    Strategy:
+    1. Seed a created sibling agent (``researcher``) with a real profile.yaml on
+       disk before running any scenario (mirrors a prior spawn-arc scenario).
+    2. Run a scenario for the dogfood target ``default`` via the runner_fn.
+    3. Assert the sibling's profile.yaml (the ``AgentRegistry.exists`` marker
+       that triggers "agent already exists") is gone, while the target
+       ``default`` agent survives (its profile is a load precondition) — the
+       latter is also a self-check that the runner rooted on ``tmp_path``.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    # A leaked created sibling from a prior spawn-arc scenario.
+    agents_root = tmp_path / ".reyn" / "agents"
+    researcher_dir = agents_root / "researcher"
+    AgentProfile.new("researcher", role="spawned").save(researcher_dir)
+    assert (researcher_dir / PROFILE_FILENAME).is_file(), (
+        "Precondition: leaked sibling agent seeded on disk."
+    )
+
+    async def fake_llm(**kw):
+        return _text_result("Fresh reply.")
+
+    runner_fn = _make_live_runner_fn(tmp_path, agent_name="default")
+    assert runner_fn is not None
+
+    scenario = _make_scenario("created-s1", input_text="hello")
+    monkeypatch.setattr("reyn.runtime.router_loop.call_llm_tools", fake_llm)
+    result = await runner_fn(scenario)
+
+    # The leaked sibling is gone — a re-run would no longer hit "already exists".
+    assert not (researcher_dir / PROFILE_FILENAME).is_file(), (
+        "the created sibling agent must be wiped by the runner's per-scenario reset"
+    )
+    assert not researcher_dir.exists()
+    # The dogfood target is spared (and this confirms the runner rooted on tmp_path).
+    assert (agents_root / "default" / PROFILE_FILENAME).is_file()
+    assert result.scenario_id == "created-s1"


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2169

Spawn-arc scenarios (#2103 B/C) are the first dogfood scenarios that **create** agents — each writes `.reyn/agents/<name>/profile.yaml` (`researcher`/`alice`/`A`/`B`/`C`/`child`/…). In **single-run** mode the project `.reyn/` is REUSED across runs, so those created agents leaked: a re-run of an agent-creating scenario hit `agent already exists` (`AgentRegistry.create` raises when `profile.yaml` is present) → `reply_outcome=refuted`, until a manual workspace reset.

## Root cause (primary evidence)

The single-run per-scenario reset is `_wipe_scenario_state` in `_build_live_runner` (`src/reyn/interfaces/cli/commands/dogfood.py`), invoked before every scenario by `runner_fn`. It wiped only the **target** agent's ephemeral files (`_scenario_state_targets`: `action_usage.json` + `history.jsonl` + the events chat dir) — **not** the sibling agent dirs the spawn-arc creates. So created agents accumulated under the shared `.reyn/agents/`.

Traced the existence check to the real mechanism: `AgentRegistry.exists(name)` → `(.reyn/agents/<name>/profile.yaml).is_file()`; `create()` raises `FileExistsError` when it's present (`registry.py:510-516`).

## Fix

`_wipe_scenario_state` now also removes every **created sibling** agent dir under `.reyn/agents/`, via two small pure helpers (`_leaked_agent_dirs` / `_wipe_leaked_agents`) mirroring the #2357 testable-helper pattern.

The dogfood **target** agent (`--agent`, default `default`) is deliberately **spared**, because:
- Its `profile.yaml` is a **load precondition** — `AgentRegistry.get_or_load` raises `FileNotFoundError` without it, so wiping it would block **every** scenario (`ensure_running` → blocked).
- Its ephemeral ledger/history are already wiped by `_scenario_state_targets`.

Safe by construction: per-agent **event logs** live under `.reyn/events/agents/<name>/` (PR20), **not** under the removed `.reyn/agents/<name>/` dir — so this removes **no event log** (no running-web constraint). This is the runner's job because it knows the target agent name; `dogfood_fresh_reset.sh` deliberately can't (it has no agent name — the same reason it already defers the `history` / `action_usage` wipe to the runner).

**Batch mode is unaffected** — each worker runs in its own fresh-`.reyn` worktree (`/tmp/reyn-worktrees/...`), so nothing leaks there. The gap was specific to single-run mode.

## Tests (`tests/test_dogfood_leaked_agents_wipe_2169.py`, Tier 2, real `AgentProfile`/`PROFILE_FILENAME`)

- `test_leaked_agent_dirs_selects_siblings_spares_target` — the reset selects every created sibling and never the target (order-agnostic set membership, no sort-order pin).
- `test_wipe_removes_created_agents_preserves_target` — after the real `_wipe_leaked_agents`, the siblings' `profile.yaml` is gone (so a re-run no longer hits "already exists") while the target's `profile.yaml` survives and still `AgentProfile.load`s (so `get_or_load` won't `FileNotFoundError`). Uses real `AgentProfile.save` — the exact marker `exists()` keys off, no mocks.
- `test_wipe_is_idempotent_with_no_agents_dir` — no-op / never raises when nothing has leaked.
- **cp-falsify done**: neutering `_wipe_leaked_agents` (cp-scratch backup, never `git checkout`) → the removal test goes RED (`researcher/profile.yaml` still present); restored → all green.

## CI gates (all local, green)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_dogfood_leaked_agents_wipe_2169.py` — 3/3 OK, 0 Tier-4
- `pytest` — 8035 passed, 21 skipped; the 5 failures are the **pre-existing** web/a2a/mcp route-mount + plugin-loader env failures (identical set to #2792/#2799's runs on clean HEAD), none reference dogfood
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/dogfood.py` — OK

> Local note: the venv's editable `reyn` resolves to the primary worktree's `src`, so all local runs used `PYTHONPATH=<this-worktree>/src` (verified the import resolves into this worktree). CI installs the branch checkout, so it's unaffected.

## Test plan
- [x] created sibling agents removed by the fresh reset — automated
- [x] target agent's profile spared (still loads) — automated
- [x] idempotent when nothing leaked / no `.reyn/agents/` dir — automated
- [x] cp-falsify: neuter wipe → RED; restore → green — done manually, verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)