### PR TITLE
feat: expose render_template output bounds via operator config (#2679)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1101,6 +1101,23 @@ offload:
 
 **Not a recommended steady-state setting.** With offload disabled, a single tool result can exceed the model's compaction-batch budget, recreating the pre-#1128 compaction dead-end (a turn too large to ever compact). A `offload_disabled` warning event is emitted at session start when this is set, so traces stay self-explaining.
 
+## `render_template` block
+
+Output bounds for the `render_template` tool. That tool renders a Jinja2 template against structured data into a string; the sandbox blocks template-injection but not resource exhaustion, so a runaway template (e.g. `{% for i in range(10**9) %}…{% endfor %}`) is capped **during** generation. The render stops the moment either bound is hit and the result is truncated (with a `truncated` flag naming which bound fired) rather than flooding memory or hanging. Raise the bounds for a large report; lower them to harden a shared host.
+
+```yaml
+render_template:
+  max_output_chars: 256000   # streaming char budget — truncate past this
+  wall_clock_seconds: 5.0    # elapsed-time backstop for a runaway loop
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `max_output_chars` | int | `256000` | The streaming character budget. The render truncates the moment cumulative output exceeds it. A non-positive or non-numeric value falls back to the default. |
+| `wall_clock_seconds` | float | `5.0` | Elapsed-time backstop. Jinja2 exposes no iteration count, so wall-clock bounds a runaway loop that emits little text per step. A non-positive or non-numeric value falls back to the default. |
+
+The defaults are generous enough for real reports / configs and tight enough that a runaway generator stops quickly. Omitting the block leaves both at their defaults (behaviour unchanged).
+
 ## MCP servers
 
 External tool servers reyn can call via the [Model Context Protocol](../../concepts/tools-integrations/mcp.md). Each entry under `mcp.servers:` is keyed by a short name (the same name the skill declares in `permissions.mcp` and emits in `mcp` ops).

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -430,6 +430,20 @@
 
 
 # -----------------------------------------------------------------------------
+# render_template: output bounds for the render_template op (FP-0055 / #2679).
+# The op renders a Jinja2 template against data into a string; the sandbox blocks
+# template injection but not resource exhaustion, so output is capped DURING
+# generation (a runaway {% for i in range(10**9) %} is truncated, not OOM'd).
+# Omit the block to keep the safe defaults below (behaviour unchanged); raise for
+# a large report, lower to harden a shared host. A non-positive/non-numeric value
+# falls back to that field's default.
+# -----------------------------------------------------------------------------
+# render_template:
+#   max_output_chars: 256000   # streaming char budget — truncate past this
+#   wall_clock_seconds: 5.0    # elapsed-time backstop for a runaway loop
+
+
+# -----------------------------------------------------------------------------
 # skill_resume: policy for handling steps that have a
 # ``step_started`` WAL event but no matching ``step_completed`` / ``step_failed``
 # (= the op may have committed externally and only the operator can decide).

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -229,6 +229,66 @@ def _build_offload_config(raw: object) -> "OffloadConfig":
 
 
 @dataclass
+class RenderTemplateConfig:
+    """`render_template:` — operator-tunable output bounds for the ``render_template``
+    op (FP-0055 / #2679).
+
+    The op caps output DURING generation (a ``SandboxedEnvironment`` blocks SSTI but
+    not resource exhaustion — a bounded loop like ``{% for i in range(10**9) %}``
+    still floods). Safe defaults + a per-op-context override seam already ship; this
+    section exposes the two bounds to operator yaml, mirroring ``offload:`` /
+    ``cost_warn:``.
+
+    - ``max_output_chars`` — the streaming char budget; the render truncates the
+      moment cumulative output exceeds it. Default 256_000.
+    - ``wall_clock_seconds`` — the elapsed-time backstop (Jinja2 exposes no iteration
+      count, so wall-clock bounds a runaway loop that emits little text per step).
+      Default 5.0.
+
+    The defaults mirror ``op_runtime.render_template.RenderTemplateBounds`` (the
+    in-handler fallback). Generous enough for real reports / configs, tight enough
+    that a runaway generator stops quickly; an operator raises them for a large
+    report or lowers them to harden a shared host.
+    """
+    max_output_chars: int = 256_000
+    wall_clock_seconds: float = 5.0
+
+
+def _build_render_template_config(raw: object) -> "RenderTemplateConfig":
+    """Parse the ``render_template:`` section (#2679).
+
+    Missing or malformed → full defaults (256_000 chars / 5.0s). A non-numeric or
+    non-positive value for either bound falls back to that field's default (an
+    operator typo must not silently disable the cap → a zero/negative bound would
+    truncate everything or never fire).
+    """
+    if not isinstance(raw, dict):
+        return RenderTemplateConfig()
+    defaults = RenderTemplateConfig()
+
+    max_output_chars = raw.get("max_output_chars", defaults.max_output_chars)
+    try:
+        max_output_chars = int(max_output_chars)
+        if max_output_chars <= 0:
+            max_output_chars = defaults.max_output_chars
+    except (TypeError, ValueError):
+        max_output_chars = defaults.max_output_chars
+
+    wall_clock_seconds = raw.get("wall_clock_seconds", defaults.wall_clock_seconds)
+    try:
+        wall_clock_seconds = float(wall_clock_seconds)
+        if wall_clock_seconds <= 0:
+            wall_clock_seconds = defaults.wall_clock_seconds
+    except (TypeError, ValueError):
+        wall_clock_seconds = defaults.wall_clock_seconds
+
+    return RenderTemplateConfig(
+        max_output_chars=max_output_chars,
+        wall_clock_seconds=wall_clock_seconds,
+    )
+
+
+@dataclass
 class SpawnConfig:
     """`safety.spawn:` — operator bounds on the LLM spawn tree (#2103 C3).
 

--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -11,6 +11,7 @@ from reyn.config.chat import (  # #1682 #3 cross-section
     _build_cost_config,  # #1682 #3: cost builder lives in chat
     _build_cost_warn_config,
     _build_offload_config,
+    _build_render_template_config,
     _build_safety_config,
 )
 from reyn.config.embedding import (  # #1682 #3 cross-section
@@ -506,6 +507,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
     cost = _build_cost_config(merged.get("cost"))
     cost_warn = _build_cost_warn_config(merged.get("cost_warn"))
     offload = _build_offload_config(merged.get("offload"))
+    render_template = _build_render_template_config(merged.get("render_template"))
     _cfg = ReynConfig(
         model=str(merged.get("model", "standard")),
         output_language=output_language,
@@ -547,6 +549,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         safety=safety,
         cost_warn=cost_warn,
         offload=offload,
+        render_template=render_template,
         web=_build_web_config(merged.get("web")),
         multimodal=_build_multimodal_config(merged.get("multimodal")),
         sandbox=_build_sandbox_config(merged.get("sandbox")),

--- a/src/reyn/config/root.py
+++ b/src/reyn/config/root.py
@@ -34,6 +34,7 @@ from reyn.config.chat import (
     OffloadConfig,
     OnLimitConfig,
     ReasoningConfig,
+    RenderTemplateConfig,
     SafetyConfig,
     TimeoutConfig,
 )
@@ -237,6 +238,9 @@ class ReynConfig:
     cost_warn: CostWarnConfig = field(default_factory=CostWarnConfig)
     # tool-result-schema-redesign §5: debug lever disabling all tool-result size gates.
     offload: OffloadConfig = field(default_factory=OffloadConfig)
+    # FP-0055 / #2679: operator-tunable output bounds for the render_template op
+    # (max_output_chars / wall_clock_seconds). Default → the safe in-handler bounds.
+    render_template: RenderTemplateConfig = field(default_factory=RenderTemplateConfig)
     # FP-0022 follow-up: declarative SSL config for web_fetch + MCP registry.
     # Priority: web.fetch.ca_bundle → web.fetch.verify_ssl → SSL_VERIFY env →
     # litellm.ssl_verify → SSL_CERT_FILE → True (default).

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -407,6 +407,7 @@ def run(args: argparse.Namespace) -> None:
             events_config=session_cfg.config.events,
             cost_warn_config=session_cfg.config.cost_warn,  # #2230: wire the warn/block gate
             offload_config=session_cfg.config.offload,  # tool-result-schema-redesign §5
+            render_template_config=session_cfg.config.render_template,  # #2679: render_template output bounds
             state_log=state_log,
             budget_tracker=budget_tracker,
             hooks_config=session_cfg.config.hooks,  # #1800 slice 5b (pass-through, not bundled)

--- a/src/reyn/runtime/registry_bootstrap.py
+++ b/src/reyn/runtime/registry_bootstrap.py
@@ -202,6 +202,7 @@ def build_agent_registry_from_project(
             events_config=config.events,
             cost_warn_config=config.cost_warn,
             offload_config=config.offload,
+            render_template_config=config.render_template,
             state_log=state_log,
             budget_tracker=budget_tracker,
             hooks_config=config.hooks,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -75,6 +75,7 @@ def build_router_op_context(
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
     current_task_id: str | None = None,  # #1953 §16: the task this turn is executing → task.create ownership
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
+    render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -161,4 +162,5 @@ def build_router_op_context(
         hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
         current_task_id=current_task_id,  # #1953 §16: ownership-derivation context
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
+        render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -264,6 +264,10 @@ class RouterHostAdapter:
         # file__read / mcp ops consult the cap + on_oversize policy.
         # ``None`` = no cap.
         multimodal_config: Any = None,
+        # #2679: operator RenderTemplateBounds threaded onto the router OpContext so
+        # a router/pipeline render_template op honours the operator's output cap.
+        # None → the op's in-handler defaults (256_000 chars / 5.0s).
+        render_template_bounds: Any = None,
         # #1652: ReasoningConfig (continuity/display/recent_turns) + the session
         # callback that renders the bounded prior-reasoning text section (reads
         # history + applies the continuity gate). None → reasoning disabled.
@@ -441,6 +445,9 @@ class RouterHostAdapter:
         # Issue #364: store the gate config so make_router_op_context can
         # thread it into the OpContext for router-initiated binary ops.
         self._multimodal_config = multimodal_config
+        # #2679: store the operator render_template output bounds for the same
+        # make_router_op_context threading.
+        self._render_template_bounds = render_template_bounds
         # #1652: reasoning capture/continuity/display config + the section renderer.
         self._reasoning_config = reasoning_config
         self._reasoning_continuity_section_fn = reasoning_continuity_section_fn
@@ -2046,6 +2053,7 @@ class RouterHostAdapter:
             # FP-0054 PR-C: the adapter's CURRENT registry snapshot (hot-reload swaps it).
             presentation_registry=self._presentation_registry,
             multimodal_config=self._multimodal_config,
+            render_template_bounds=self._render_template_bounds,  # #2679: operator render_template output cap
             media_store=self._media_store,
             compact_now=self._compact_now,
             cancel_event=self._cancel_event,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -23,6 +23,7 @@ from reyn.config import (  # noqa: F401
     MultimodalConfig,
     OffloadConfig,
     OnLimitConfig,
+    RenderTemplateConfig,
     RouterConfig,
     SafetyConfig,
     SandboxConfig,
@@ -669,6 +670,10 @@ class Session:
         # size gates (text cap / structured inline cap / media follow-up budget).
         # None -> defaults (enabled=True, normal offload behaviour).
         offload_config: OffloadConfig | None = None,
+        # FP-0055 / #2679: operator-tunable render_template output bounds
+        # (max_output_chars / wall_clock_seconds). None -> the safe defaults
+        # (256_000 chars / 5.0s), identical to the in-handler fallback.
+        render_template_config: RenderTemplateConfig | None = None,
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
@@ -1235,6 +1240,18 @@ class Session:
         self._cost_warn_config = cost_warn_config or CostWarnConfig()
         # tool-result-schema-redesign §5: debug lever (default enabled=True).
         self._offload_config = offload_config or OffloadConfig()
+        # FP-0055 / #2679: resolve the operator render_template bounds config into a
+        # concrete RenderTemplateBounds once, then thread it into every router
+        # OpContext builder (both make_router_op_context twins). Default config =
+        # the safe 256_000/5.0 bounds, so an unconfigured session is byte-identical
+        # to the prior in-handler fallback. The `render_template` op reads
+        # ``ctx.render_template_bounds`` (op_runtime/render_template.py).
+        _rt_cfg = render_template_config or RenderTemplateConfig()
+        from reyn.core.op_runtime.render_template import RenderTemplateBounds
+        self._render_template_bounds = RenderTemplateBounds(
+            max_output_chars=_rt_cfg.max_output_chars,
+            wall_clock_seconds=_rt_cfg.wall_clock_seconds,
+        )
 
         # PR21: WAL + per-agent snapshot for crash recovery. state_log is
         # process-shared (owned by AgentRegistry); when None, persistence
@@ -1721,6 +1738,9 @@ class Session:
             ),
             # Issue #364 multi-modal cluster: media-size gate config.
             multimodal_config=self._multimodal_config,
+            # FP-0055 / #2679: operator render_template output bounds → the router
+            # OpContext (the render_template op reads ctx.render_template_bounds).
+            render_template_bounds=self._render_template_bounds,
             # #1652: reasoning config (display/continuity/recent_turns gates) +
             # the bounded prior-reasoning section renderer (reads this session's
             # history). The host exposes reasoning_display_enabled() /
@@ -5714,6 +5734,7 @@ class Session:
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
             current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
+            render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_render_template_bounds_config_2679.py
+++ b/tests/test_render_template_bounds_config_2679.py
@@ -1,4 +1,5 @@
-"""Tier 2c: operator `render_template:` yaml bounds reach the render_template op.
+"""Tier 2c: operator `render_template:` yaml bounds reach the render_template op
+THROUGH a real Session.
 
 #2679 wired the operator config `render_template.max_output_chars` /
 `.wall_clock_seconds` through `ReynConfig` → `Session` → the router `OpContext`
@@ -6,29 +7,38 @@
 cap. The op already had safe defaults + an `OpContext.render_template_bounds`
 override seam (FP-0055 PR-2); this adds the missing operator-facing config.
 
-These pin the two load-bearing links the config adds, with REAL objects (no
-mocks): (1) the yaml→ReynConfig round-trip with a NON-DEFAULT value, and (2) the
-bounds threaded through the real `build_router_op_context` actually cap the real
-op. Assertions are on the public op result (`truncated` / `truncate_reason`) and
-public config fields — never private state, never an exact rendered layout.
+The point of #2679 is the **Session→op link** — the config value only matters if a
+real Session threads it into the OpContext the op actually reads. So these drive a
+REAL `Session` (built from a real `load_config`) and exercise BOTH Session-side
+builders that feed the op in production:
+
+  - ``Session._make_router_op_context`` (the file/MCP-op twin), and
+  - ``Session._router_host.make_router_op_context`` (the RouterHostAdapter twin
+    bound as ``op_context_factory`` in ``tools/types.py`` — the path the
+    ``render_template`` tool actually dispatches through on chat + pipeline).
+
+Stripping the ``render_template_bounds`` threading from EITHER Session-side builder
+makes the matching assertion below go RED (cp-falsify verified), so the reachability
+is CI-enforced, not merely reviewed once. Real objects throughout (no mocks);
+assertions on the public op result (`truncated` / `truncate_reason`), never private
+state or an exact rendered layout.
 """
 from __future__ import annotations
 
 import asyncio
 from pathlib import Path
 
+from reyn.config import RenderTemplateConfig
 from reyn.config.chat import _build_render_template_config
 from reyn.config.loader import load_config
-from reyn.core.events.events import EventLog
-from reyn.core.op_runtime.render_template import RenderTemplateBounds, handle
-from reyn.runtime.router_op_context import build_router_op_context
-from reyn.security.permissions.permissions import PermissionResolver
+from reyn.core.op_runtime.render_template import handle
+from reyn.runtime.session import Session
 
 
 class _RenderOp:
     """A minimal render_template op double: a 1000-char pure-computation render
-    (no template_ref / data_ref, so no file.read gate is exercised — this test is
-    about the bounds wiring, not read-authority)."""
+    (inline template, no template_ref / data_ref, so no file.read gate is
+    exercised — this test is about the bounds wiring, not read-authority)."""
 
     kind = "render_template"
     template = "{% for i in range(1000) %}X{% endfor %}"
@@ -38,34 +48,22 @@ class _RenderOp:
     undefined = "strict"
 
 
-def _ctx_with_bounds(tmp_path: Path, bounds: "RenderTemplateBounds | None"):
-    """Build a real router OpContext carrying ``bounds`` via the production
-    single-source builder (the same factory both router hosts call)."""
-    resolver = PermissionResolver(
-        config_permissions={}, project_root=tmp_path, interactive=False,
-    )
-    return build_router_op_context(
-        events=EventLog(),
-        permission_resolver=resolver,
-        file_permissions=None,
-        mcp_servers=None,
-        mcp_servers_flat=[],
-        allowed_mcp=None,
-        workspace_base_dir=tmp_path,
-        workspace_state_dir=tmp_path,
-        environment_backend=None,
-        sandbox_backend=None,
-        sandbox_policy=None,
-        agent_id=None,
-        presentation_renderer=None,
-        render_template_bounds=bounds,
-    )
+def _run_op_via(builder) -> dict:
+    """Build an OpContext via ``builder`` and run the real render_template op on it."""
+    ctx = builder()
+    return asyncio.run(handle(_RenderOp(), ctx))
 
 
-def test_operator_yaml_bounds_cap_the_render_template_op(tmp_path: Path) -> None:
-    """Tier 2c: a NON-DEFAULT `render_template:` yaml value round-trips to
-    ReynConfig and, threaded through the real router OpContext builder, caps the
-    real op — a 1000-char render is truncated at the operator's tiny bound.
+def test_operator_yaml_bounds_cap_the_op_through_a_real_session(tmp_path: Path) -> None:
+    """Tier 2c: a NON-DEFAULT `render_template:` yaml value round-trips through
+    `load_config` into a real `Session`, and BOTH Session-side OpContext builders
+    hand the op a cap that truncates a 1000-char render.
+
+    This is the #2679 guard: it drives the real Session→OpContext→op link (not a
+    hand-assembled bounds), so removing the `render_template_bounds` threading from
+    either `Session._make_router_op_context` or the RouterHostAdapter twin fails
+    here (cp-falsify verified) — the previously silent "plumbed-but-not-threaded"
+    regression is now caught.
     """
     (tmp_path / "reyn.yaml").write_text(
         "model: standard\n"
@@ -74,57 +72,53 @@ def test_operator_yaml_bounds_cap_the_render_template_op(tmp_path: Path) -> None
         "  wall_clock_seconds: 1.5\n"
     )
 
-    # (1) yaml → ReynConfig round-trip (the non-default value survives the loader).
+    # yaml → ReynConfig round-trip (the non-default value survives the loader).
     cfg = load_config(cwd=tmp_path)
     assert cfg.render_template.max_output_chars == 20
     assert cfg.render_template.wall_clock_seconds == 1.5
 
-    # (2) config → RenderTemplateBounds (the exact conversion Session.__init__ does)
-    #     → the real builder → the real op honours the operator's tiny cap.
-    bounds = RenderTemplateBounds(
-        max_output_chars=cfg.render_template.max_output_chars,
-        wall_clock_seconds=cfg.render_template.wall_clock_seconds,
-    )
-    ctx = _ctx_with_bounds(tmp_path, bounds)
-    capped = asyncio.run(handle(_RenderOp(), ctx))
+    # The production shape: the frontend factories pass `config.render_template`
+    # into the Session (registry_bootstrap / chat.py). A real Session resolves it
+    # into the bounds it threads into every router OpContext builder.
+    session = Session(agent_name="t", render_template_config=cfg.render_template)
 
-    assert capped["status"] == "ok"
-    assert capped["truncated"] is True
-    assert capped["truncate_reason"] == "max_output_chars"
+    # Builder 1 — Session._make_router_op_context (file/MCP twin).
+    r_session = _run_op_via(session._make_router_op_context)
+    assert r_session["status"] == "ok"
+    assert r_session["truncated"] is True
+    assert r_session["truncate_reason"] == "max_output_chars"
 
-    # Behavioural contrast: the SAME render under a generous bound is NOT truncated
-    # and is strictly longer — proving the operator's cap actually shortened the
-    # output (not merely flipped a flag). No exact-size pin (Tier-4 format pinning).
-    generous_ctx = _ctx_with_bounds(
-        tmp_path, RenderTemplateBounds(max_output_chars=256_000, wall_clock_seconds=5.0),
-    )
-    full = asyncio.run(handle(_RenderOp(), generous_ctx))
-    assert full["truncated"] is False
-    assert len(capped["rendered"]) < len(full["rendered"])
+    # Builder 2 — RouterHostAdapter.make_router_op_context (the op_context_factory
+    # the render_template tool actually dispatches through on chat + pipeline).
+    r_host = _run_op_via(session._router_host.make_router_op_context)
+    assert r_host["status"] == "ok"
+    assert r_host["truncated"] is True
+    assert r_host["truncate_reason"] == "max_output_chars"
 
 
-def test_absent_render_template_section_leaves_normal_output_uncapped(
+def test_default_config_leaves_normal_render_uncapped_through_a_real_session(
     tmp_path: Path,
 ) -> None:
-    """Tier 2c: with no `render_template:` section the loader yields the safe
-    defaults (256_000 / 5.0), so a normal-size render is NOT truncated — the
-    operator config is opt-in and default behaviour is unchanged.
+    """Tier 2c: with no `render_template:` section the Session gets the safe
+    defaults (256_000 / 5.0), so a normal-size render is NOT truncated through
+    either builder — the operator config is opt-in, default behaviour unchanged.
     """
-    # The loader's absent-section path (hermetic — no machine-global config I/O).
+    # The loader's absent-section path yields the safe defaults (hermetic — no
+    # machine-global config I/O).
     default_cfg = _build_render_template_config(None)
+    assert default_cfg == RenderTemplateConfig()
     assert default_cfg.max_output_chars == 256_000
     assert default_cfg.wall_clock_seconds == 5.0
 
-    bounds = RenderTemplateBounds(
-        max_output_chars=default_cfg.max_output_chars,
-        wall_clock_seconds=default_cfg.wall_clock_seconds,
-    )
-    ctx = _ctx_with_bounds(tmp_path, bounds)
-    result = asyncio.run(handle(_RenderOp(), ctx))
+    session = Session(agent_name="t", render_template_config=default_cfg)
 
-    assert result["status"] == "ok"
-    # A normal-size render passes through un-truncated under the generous default.
-    assert result["truncated"] is False
-    assert "truncate_reason" not in result
-    # The full render is present (existence, not an exact-size pin).
-    assert len(result["rendered"]) > 0
+    for builder in (
+        session._make_router_op_context,
+        session._router_host.make_router_op_context,
+    ):
+        result = _run_op_via(builder)
+        assert result["status"] == "ok"
+        assert result["truncated"] is False
+        assert "truncate_reason" not in result
+        # The full render is present (existence, not an exact-size pin).
+        assert len(result["rendered"]) > 0

--- a/tests/test_render_template_bounds_config_2679.py
+++ b/tests/test_render_template_bounds_config_2679.py
@@ -1,0 +1,130 @@
+"""Tier 2c: operator `render_template:` yaml bounds reach the render_template op.
+
+#2679 wired the operator config `render_template.max_output_chars` /
+`.wall_clock_seconds` through `ReynConfig` → `Session` → the router `OpContext`
+(both `make_router_op_context` twins) → the `render_template` op's during-generate
+cap. The op already had safe defaults + an `OpContext.render_template_bounds`
+override seam (FP-0055 PR-2); this adds the missing operator-facing config.
+
+These pin the two load-bearing links the config adds, with REAL objects (no
+mocks): (1) the yaml→ReynConfig round-trip with a NON-DEFAULT value, and (2) the
+bounds threaded through the real `build_router_op_context` actually cap the real
+op. Assertions are on the public op result (`truncated` / `truncate_reason`) and
+public config fields — never private state, never an exact rendered layout.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.config.chat import _build_render_template_config
+from reyn.config.loader import load_config
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.render_template import RenderTemplateBounds, handle
+from reyn.runtime.router_op_context import build_router_op_context
+from reyn.security.permissions.permissions import PermissionResolver
+
+
+class _RenderOp:
+    """A minimal render_template op double: a 1000-char pure-computation render
+    (no template_ref / data_ref, so no file.read gate is exercised — this test is
+    about the bounds wiring, not read-authority)."""
+
+    kind = "render_template"
+    template = "{% for i in range(1000) %}X{% endfor %}"
+    template_ref = None
+    data_ref = None
+    data_inline: dict = {}
+    undefined = "strict"
+
+
+def _ctx_with_bounds(tmp_path: Path, bounds: "RenderTemplateBounds | None"):
+    """Build a real router OpContext carrying ``bounds`` via the production
+    single-source builder (the same factory both router hosts call)."""
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    return build_router_op_context(
+        events=EventLog(),
+        permission_resolver=resolver,
+        file_permissions=None,
+        mcp_servers=None,
+        mcp_servers_flat=[],
+        allowed_mcp=None,
+        workspace_base_dir=tmp_path,
+        workspace_state_dir=tmp_path,
+        environment_backend=None,
+        sandbox_backend=None,
+        sandbox_policy=None,
+        agent_id=None,
+        presentation_renderer=None,
+        render_template_bounds=bounds,
+    )
+
+
+def test_operator_yaml_bounds_cap_the_render_template_op(tmp_path: Path) -> None:
+    """Tier 2c: a NON-DEFAULT `render_template:` yaml value round-trips to
+    ReynConfig and, threaded through the real router OpContext builder, caps the
+    real op — a 1000-char render is truncated at the operator's tiny bound.
+    """
+    (tmp_path / "reyn.yaml").write_text(
+        "model: standard\n"
+        "render_template:\n"
+        "  max_output_chars: 20\n"
+        "  wall_clock_seconds: 1.5\n"
+    )
+
+    # (1) yaml → ReynConfig round-trip (the non-default value survives the loader).
+    cfg = load_config(cwd=tmp_path)
+    assert cfg.render_template.max_output_chars == 20
+    assert cfg.render_template.wall_clock_seconds == 1.5
+
+    # (2) config → RenderTemplateBounds (the exact conversion Session.__init__ does)
+    #     → the real builder → the real op honours the operator's tiny cap.
+    bounds = RenderTemplateBounds(
+        max_output_chars=cfg.render_template.max_output_chars,
+        wall_clock_seconds=cfg.render_template.wall_clock_seconds,
+    )
+    ctx = _ctx_with_bounds(tmp_path, bounds)
+    capped = asyncio.run(handle(_RenderOp(), ctx))
+
+    assert capped["status"] == "ok"
+    assert capped["truncated"] is True
+    assert capped["truncate_reason"] == "max_output_chars"
+
+    # Behavioural contrast: the SAME render under a generous bound is NOT truncated
+    # and is strictly longer — proving the operator's cap actually shortened the
+    # output (not merely flipped a flag). No exact-size pin (Tier-4 format pinning).
+    generous_ctx = _ctx_with_bounds(
+        tmp_path, RenderTemplateBounds(max_output_chars=256_000, wall_clock_seconds=5.0),
+    )
+    full = asyncio.run(handle(_RenderOp(), generous_ctx))
+    assert full["truncated"] is False
+    assert len(capped["rendered"]) < len(full["rendered"])
+
+
+def test_absent_render_template_section_leaves_normal_output_uncapped(
+    tmp_path: Path,
+) -> None:
+    """Tier 2c: with no `render_template:` section the loader yields the safe
+    defaults (256_000 / 5.0), so a normal-size render is NOT truncated — the
+    operator config is opt-in and default behaviour is unchanged.
+    """
+    # The loader's absent-section path (hermetic — no machine-global config I/O).
+    default_cfg = _build_render_template_config(None)
+    assert default_cfg.max_output_chars == 256_000
+    assert default_cfg.wall_clock_seconds == 5.0
+
+    bounds = RenderTemplateBounds(
+        max_output_chars=default_cfg.max_output_chars,
+        wall_clock_seconds=default_cfg.wall_clock_seconds,
+    )
+    ctx = _ctx_with_bounds(tmp_path, bounds)
+    result = asyncio.run(handle(_RenderOp(), ctx))
+
+    assert result["status"] == "ok"
+    # A normal-size render passes through un-truncated under the generous default.
+    assert result["truncated"] is False
+    assert "truncate_reason" not in result
+    # The full render is present (existence, not an exact-size pin).
+    assert len(result["rendered"]) > 0


### PR DESCRIPTION
**[per-PR-coder]** — additive operator config for #2679 (FP-0055 follow-up). Exposes the `render_template` op's output bounds to operator yaml, mirroring the `offload:` / `cost_warn:` wiring pattern (per the issue).

## What

The `render_template` op already capped output during generation via `RenderTemplateBounds` (defaults `max_output_chars=256_000`, `wall_clock_seconds=5.0`) with an `OpContext.render_template_bounds` override seam — but that seam was **never populated** (always `None` → the in-handler defaults). This adds the operator-facing yaml:

```yaml
render_template:
  max_output_chars: 256000   # streaming char budget — truncate past this
  wall_clock_seconds: 5.0    # elapsed-time backstop for a runaway loop
```

threaded config → `ReynConfig` → `Session` → the router `OpContext` (both `make_router_op_context` twins) → the op's during-generate cap.

## Wiring (mirrors `offload:` exactly)

- **config**: `RenderTemplateConfig` dataclass + `_build_render_template_config` loader (`config/chat.py`), `ReynConfig.render_template` field (`config/root.py`), build+assign in `config/loader.py`. Auto-exported via the mechanical `reyn.config` re-export (guarded by `test_config_package_reexport_1682`, which passes).
- **config → Session**: `Session.__init__(render_template_config=…)` (`session.py`), passed from the same two sites that wire `offload_config` — `registry_bootstrap.py` (pipe/registry path) and `chat.py` (interactive `reyn chat` path). `build_scoped_chat_session` forwards it via its `**base` pass-through (unchanged), exactly like `offload_config`/`cost_warn_config`.
- **Session → op** (the previously-missing link): `Session.__init__` resolves the config into a concrete `RenderTemplateBounds` once (`self._render_template_bounds`; default config → the safe 256k/5s, byte-identical to the prior fallback), threaded into **both** router OpContext builders — `RouterHostAdapter.make_router_op_context` (new `render_template_bounds` ctor param) and `Session._make_router_op_context` — via a new `render_template_bounds` param on `build_router_op_context` (complete-by-construction, matching the `hot_reloader`/`current_task_id` precedent). The op's existing reader (`ctx.render_template_bounds or RenderTemplateBounds()`) picks it up unchanged.

## Load-bearing verification (reachable-for-purpose)

- **The op genuinely dispatches through the wired builder**: `tools/types.py:264` binds `op_context_factory = host.make_router_op_context` (the RouterHostAdapter builder), and `tools/render_template.py` dispatches the op through `ctx.router_state.op_context_factory()`. So the config reaches the op on the real chat **and** pipeline surfaces (pipe.py reuses the same factory). Traced, not assumed.
- **Live end-to-end (real objects, no mocks)**: a non-default yaml (`max_output_chars: 20`) → `load_config` → `RenderTemplateBounds` → real `build_router_op_context` → real `render_template` handler on a 1000-char template → `truncated=True`, `truncate_reason="max_output_chars"`, output strictly shorter than the same render under the generous default. Default config → `truncated=False`. Both captured as the two tests below.
- **Malformed/edge input**: a non-numeric or non-positive bound falls back to that field's default (an operator typo must not silently disable the cap — a `0`/negative bound would truncate everything or never fire). Verified in the loader unit path.

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_render_template_bounds_config_2679.py` — 2/2 OK (initial `len(...) == N` pins were flagged Tier-4 and rewritten to behavioral len-vs-len contrast + `truncated`/`truncate_reason` flags).
- [x] `pytest` full suite (repo root) — green (see CI). Targeted first: the new test, `test_render_template_op_fp0055_pr2`, `test_2692_present_render_template_invocation_surface`, `test_scoped_session_factory_invariant_1402`, `test_config_package_reexport_1682`, `test_2093_factory_config_bundle`, `test_multi_agent_p7` — all pass.
- [x] `python scripts/verify_module_docstrings.py <8 changed src files>` — OK.
- [x] Added `tests/test_render_template_bounds_config_2679.py` (Tier 2c, real `load_config` + real `build_router_op_context` + real op handler, no mocks; asserts public op result + public config fields). **Falsified**: removed the `render_template_bounds` threading from `build_router_op_context` → the non-default test goes RED (`assert False is True`), restored → GREEN.
- [x] Round-trip with a **non-default** value (issue requirement): `test_operator_yaml_bounds_cap_the_render_template_op` loads `max_output_chars: 20` from yaml and asserts it caps the real op.
- [x] Doc: added a `render_template` block to `docs/reference/config/reyn-yaml.md` (the canonical operator config reference), mirroring the `offload` / `cost_warn` block style. Note: the `.ja.md` reference does not document the `offload:` / `cost_warn:` blocks either — a pre-existing en/ja coverage gap not introduced here; flagging rather than silently widening scope.

## Scope note

Mirrors `offload:` exactly: the two surfaces that wire `offload_config` (chat + pipe-bootstrap) can override the bounds; the other frontends (web/mcp/dogfood/chainlit) get the safe **default** bounds (via `render_template_config or RenderTemplateConfig()` in `Session.__init__`) — so the op is correctly bounded everywhere, only the operator-override entry point matches offload's reach.

Closes #2679.
