### PR TITLE
fix: shell gets a real text canonical mapper — #2681 Bucket A (latent file-class bug)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -60,6 +60,7 @@ offload store machinery is reused unchanged — 案B removes only the field-gues
 """
 from __future__ import annotations
 
+import json
 from typing import Any, Callable, TypedDict
 
 
@@ -424,6 +425,43 @@ def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
     if returncode:  # nonzero (or truthy) only — a 0 exit is not actionable signal
         meta["returncode"] = returncode
     return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+
+
+# The exact dispatch-envelope key set ``unwrap_dispatch_envelope`` also tests for (#2681 Bucket A) —
+# ``shell_to_canonical`` uses the SAME shape heuristic to find the enveloped payload.
+_DISPATCH_ENVELOPE_KEYS = frozenset({"status", "data", "error"})
+
+
+def shell_to_canonical(result: dict) -> CanonicalToolResult:
+    """``shell`` tool result → canonical (#2681 Bucket A — the scout-flagged latent file-class bug:
+    PR-F1's ``CANONICAL_TODO`` triage missed that ``shell`` is a TEXT producer, so its readable STDOUT
+    was shown to the LLM as a whole-dict ``structured`` blob instead of clean text).
+
+    ``shell`` is #2593 thin pipeline-DSL sugar over ``sandboxed_exec`` whose ``_handle`` (locked design)
+    returns ONLY the command's STDOUT — JSON-decoded when it parses (so ``verify: schema`` can apply to
+    a JSON-emitting command), else the raw text. ``stderr``/``returncode`` never reach this seam (they
+    are dropped one layer up, by that same locked design) — the one respect this mapper CANNOT mirror
+    ``sandboxed_exec_to_canonical`` (whose ``returncode`` signal meta this would carry, were it visible
+    here); ``meta`` is therefore always empty for ``shell``.
+
+    The shape THIS mapper actually receives (post ``unwrap_dispatch_envelope``) is one of:
+
+    - the dispatch envelope ``{"status": ..., "data": <value>}`` — the common case (a plain-text
+      command, or JSON stdout that decoded to a non-``dict`` such as a list/number/bool/``None``: the
+      envelope could not be peeled because peeling requires a ``dict`` ``data``);
+    - ``<value>`` directly when stdout decoded to a ``dict`` (already peeled one envelope layer).
+
+    Either way, mirroring ``sandboxed_exec``'s "stdout IS the text" treatment: ``value`` renders as the
+    readable ``text`` body — verbatim when it is already a ``str``, else ``json.dumps``'d so a
+    JSON-emitting command's output stays fully legible — and there is NO ``structured`` attachment (the
+    whole-dict blob this mapper replaces)."""
+    if "data" in result and set(result) <= _DISPATCH_ENVELOPE_KEYS:
+        value = result["data"]
+    else:
+        value = result
+    text = value if isinstance(value, str) else json.dumps(value, default=str)
+    text = _explicit_empty(text, "(no output)")
+    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
 
 
 def chunks_to_canonical(result: dict) -> CanonicalToolResult:

--- a/src/reyn/tools/shell.py
+++ b/src/reyn/tools/shell.py
@@ -95,10 +95,10 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> Any:
         return stdout
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import shell_to_canonical  # noqa: E402
 
 SHELL = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=shell_to_canonical,
     name="shell",
     description=_SHELL_DESCRIPTION,
     parameters=_SHELL_PARAMETERS,

--- a/tests/test_2593_pipeline_shell_step.py
+++ b/tests/test_2593_pipeline_shell_step.py
@@ -121,9 +121,10 @@ async def test_shell_step_threads_pipe_data_to_stdin_and_stdout_to_output():
         state_log=None,
         run_id="run-shell-stdin",
     )
-    # #2425 PR-2: the shell tool's parsed-JSON dict (no "kind") is an
-    # unregistered-kind result → the whole dict is the sole structured attachment.
-    expected = {"text": "", "structured": {"n": 3, "msg": "hi"}}
+    # #2681 Bucket A: ``shell`` now ships a real text canonical mapper (mirroring
+    # ``sandboxed_exec``'s stdout-is-text treatment) — the parsed-JSON dict renders as
+    # readable ``text`` (json.dumps'd), NOT a whole-dict ``structured`` blob.
+    expected = {"text": '{"n": 3, "msg": "hi"}'}
     assert result.pipe_data == expected
     assert result.named_stores["echoed"] == expected
 
@@ -156,7 +157,9 @@ async def test_shell_step_schema_verify_passes_conforming_output():
         run_id="run-shell-schema-ok",
         schema_registry=registry,
     )
-    assert result.pipe_data == {"text": "", "structured": {"msg": "hello"}}
+    # #2681 Bucket A: real text mapper — the parsed-JSON dict renders as readable
+    # ``text``, not a whole-dict ``structured`` blob (see test 2's comment).
+    assert result.pipe_data == {"text": '{"msg": "hello"}'}
 
 
 @pytest.mark.asyncio

--- a/tests/test_2681_shell_canonical.py
+++ b/tests/test_2681_shell_canonical.py
@@ -1,0 +1,78 @@
+"""Tier 1: #2681 Bucket A — the ``shell`` tool ships a real text canonical mapper.
+
+The scout enumeration for FP-0056's CANONICAL_TODO burn-down (#2681) flagged that PR-F1's triage
+missed ``shell`` (``reyn.tools.shell._handle``) as a TEXT-content producer: it returns bare subprocess
+STDOUT (``json.loads(stdout)`` when it parses, else the raw text), which under the provisional
+``CANONICAL_TODO`` whole-dict fallback the LLM saw as an opaque ``structured`` blob instead of clean
+text — the same file-class latent bug the ``file``/``reyn_src`` 2026-07-09 dogfood incident produced.
+
+``shell_to_canonical`` mirrors ``sandboxed_exec_to_canonical``'s "stdout IS the text" treatment.
+``shell``'s own ``_handle`` (locked #2593 design) surfaces ONLY stdout — ``stderr``/``returncode``
+never reach this canonical seam (dropped one layer up), so unlike ``sandboxed_exec`` this mapper's
+``meta`` is always empty; that gap is a structural, documented consequence of the #2593 contract, not
+an oversight here.
+
+Mirrors the tool-result arc (#2425) / FP-0056 PR-H mapper-contract test style: real result shapes (the
+two envelope shapes ``to_canonical(source="shell")`` actually receives — see
+``reyn.core.offload.canonical.shell_to_canonical``'s docstring), no mocks, presence/absence +
+substring assertions (no Tier-4 formatting pins).
+"""
+from __future__ import annotations
+
+from reyn.core.offload.canonical import CANONICAL_TODO, canonical_declaration, to_canonical
+from reyn.tools import get_default_registry
+from reyn.tools.shell import SHELL
+
+
+def test_shell_declares_a_real_mapper_not_canonical_todo():
+    """Tier 1: the burn-down itself — ``shell``'s ToolDefinition no longer declares the provisional
+    ``CANONICAL_TODO`` marker; it is registered as a real callable mapper."""
+    assert SHELL.canonical is not CANONICAL_TODO
+    assert callable(SHELL.canonical)
+    registered = get_default_registry().lookup("shell")
+    assert registered is not None
+    assert registered.canonical is not CANONICAL_TODO
+    assert canonical_declaration("shell") is SHELL.canonical
+
+
+def test_plain_text_stdout_is_clean_text_not_a_whole_dict_blob():
+    """Tier 1: INCIDENT — a plain (non-JSON) shell command's STDOUT, reaching this seam wrapped in the
+    dispatch envelope ``{"status": ..., "data": <stdout>}`` (the shape ``to_canonical`` sees for the
+    router/chat tool-call path — ``unwrap_dispatch_envelope`` cannot peel a non-dict ``data``), renders
+    as the readable ``text`` verbatim. RED pre-fix: with ``CANONICAL_TODO`` the whole envelope dict
+    (``{"status": "ok", "data": "hello world"}``) became a ``structured`` attachment and ``text`` was
+    empty — exactly the "readable output shown as an opaque blob" bug the #2681 scout flagged."""
+    result = {"status": "ok", "data": "hello world"}
+    canonical = to_canonical(result, source="shell")
+    assert canonical["text"] == "hello world"
+    assert not any(a.get("kind") == "structured" for a in canonical["attachments"]), (
+        "no whole-dict structured attachment — the incident's blob is gone"
+    )
+
+
+def test_json_dict_stdout_renders_as_readable_json_text_not_structured():
+    """Tier 1: a JSON-emitting shell command's STDOUT decodes to a ``dict`` — the pipeline ``tool:``
+    step path (``core.pipeline.executor._run_tool_step``) already peels the dispatch envelope one
+    layer for a ``dict`` ``data`` (``unwrap_dispatch_envelope``), so this mapper receives the parsed
+    dict DIRECTLY (no ``status``/``data`` wrapper). It still renders as legible ``text`` (json-dumped),
+    never a ``structured`` attachment — mirroring sandboxed_exec's stdout-is-text treatment even though
+    the stdout happens to parse as JSON."""
+    result = {"n": 3, "msg": "hi"}
+    canonical = to_canonical(result, source="shell")
+    assert canonical["text"] == '{"n": 3, "msg": "hi"}'
+    assert canonical["attachments"] == []
+
+
+def test_empty_output_renders_an_explicit_marker_not_blank_text():
+    """Tier 1: a no-output command (empty stdout) renders an explicit ``(no output)`` marker rather
+    than a blank ``text`` — the same M2 (``canonical_degraded``) guard every other mapper applies to a
+    legitimately-empty success."""
+    canonical = to_canonical({"status": "ok", "data": ""}, source="shell")
+    assert canonical["text"] == "(no output)"
+
+
+def test_shell_removed_from_the_canonical_todo_grandfathered_ledger():
+    """Tier 1: the ratchet — ``shell`` no longer takes the ``CANONICAL_TODO`` fallback, so it must not
+    appear in the gate's grandfathered ledger (``tests/test_fp0056_canonical_coverage_gate.py``); the
+    full ``live == ledger`` equality is asserted there, this just pins the direct declaration check."""
+    assert canonical_declaration("shell") is not CANONICAL_TODO

--- a/tests/test_fp0056_canonical_coverage_gate.py
+++ b/tests/test_fp0056_canonical_coverage_gate.py
@@ -76,7 +76,9 @@ _CANONICAL_TODO_GRANDFATHERED = frozenset({
     "remember_agent", "remember_shared",
     "search_actions",
     "session_spawn",
-    "shell",
+    # #2681 Bucket A burn-down: ``shell`` now ships a real text mapper (its stdout is the readable
+    # LLM body, mirroring ``sandboxed_exec``'s stdout-is-text treatment) — removed from the ledger
+    # (the ratchet set only shrinks).
     "skill_install_local", "skill_install_source",
     "subscribe_mcp_resource", "unsubscribe_mcp_resource",
     "task.abort", "task.add_dependency", "task.assign", "task.comment", "task.create",

--- a/tests/test_fp0056_m3_fail_visible.py
+++ b/tests/test_fp0056_m3_fail_visible.py
@@ -132,10 +132,27 @@ def test_valid_reyn_src_shape_still_dispatches() -> None:
 # The registry-derived guard: NO registered mapper has a silent status-only catch-all.
 # --------------------------------------------------------------------------------------------------
 
+# Mappers with NO inner discriminator — they render the ENTIRE input value as ``text`` verbatim (no
+# per-field selection, so there is no sub-view to silently drop on a "miss"). The probe's heuristic
+# ("does the rendered text contain the bare status echoed back") cannot distinguish "the WHOLE input
+# legitimately IS ``{status: ...}``" from a discriminator-miss catch-all for such a mapper — narrowly
+# exempted by name, not blanket-skipped:
+# - ``shell_to_canonical`` (#2681 Bucket A): ``shell``'s stdout can be ANY JSON shape (including one
+#   whose only key happens to be ``status`` — a health-check-style command's own output), and the
+#   mapper's whole job is to render that value faithfully — never select/drop a sub-field the way
+#   ``file``/``reyn_src`` dispatch on ``op``/body-key. Nothing is ever dropped, so M3 cannot recur.
+_NO_INNER_DISCRIMINATOR_MAPPERS = frozenset({"shell_to_canonical"})
+
+
 def _registered_mappers() -> set:
     """Every distinct real canonical mapper function born at the two registration seams (the
-    sentinels STRUCTURED_PASSTHROUGH / CANONICAL_TODO are not callable → excluded)."""
-    return {d for d in _DECLARATIONS.values() if callable(d)}
+    sentinels STRUCTURED_PASSTHROUGH / CANONICAL_TODO are not callable → excluded), minus the
+    non-discriminating mappers this probe structurally cannot evaluate
+    (:data:`_NO_INNER_DISCRIMINATOR_MAPPERS`)."""
+    return {
+        d for d in _DECLARATIONS.values()
+        if callable(d) and d.__name__ not in _NO_INNER_DISCRIMINATOR_MAPPERS
+    }
 
 
 def _status_echo_offense(mapper) -> str | None:


### PR DESCRIPTION
**[per-PR-coder]** — part of #2681

## Context

FP-0056's registry-derived scout enumeration (issue #2681) triaged all 51 `CANONICAL_TODO` producers and flagged **Bucket A: `shell`** as the single highest-priority fix — a TEXT-content producer PR-F1's original triage missed. `shell` (`src/reyn/tools/shell.py:_handle`, #2593 pipeline-DSL sugar over `sandboxed_exec`) returns bare subprocess STDOUT (`json.loads(stdout)` when it parses, else the raw text). Under the provisional `CANONICAL_TODO` whole-dict fallback, this readable command output was shown to the LLM as an opaque `structured` blob instead of clean text — the same file-class latent bug the `file`/`reyn_src` 2026-07-09 dogfood incident produced.

## Fix

Added `shell_to_canonical` (`src/reyn/core/offload/canonical.py`), mirroring the EXISTING `sandboxed_exec_to_canonical`'s "stdout IS the text" treatment:

- The shape this mapper receives (post `unwrap_dispatch_envelope`) is one of: the dispatch envelope `{"status": ..., "data": <value>}` (the common router/chat-path case — a plain-text command, or JSON stdout that decoded to a non-`dict`), or `<value>` directly when stdout decoded to a `dict` (already peeled one envelope layer — the pipeline `tool:` step path).
- Either way, `value` renders as the readable `text` body — verbatim when already a `str`, else `json.dumps`'d so a JSON-emitting command's output stays legible — with NO `structured` attachment (the whole-dict blob this replaces).
- `meta` is always empty for `shell`: unlike `sandboxed_exec`, `shell`'s own `_handle` (locked #2593 design) surfaces ONLY stdout — `stderr`/`returncode` never reach this canonical seam (they're dropped one layer up, by that same locked contract). This is a structural, documented consequence of #2593, not an oversight in this mapper.
- `shell`'s `ToolDefinition.canonical` now declares `shell_to_canonical` instead of `CANONICAL_TODO`.
- Removed `"shell"` from `_CANONICAL_TODO_GRANDFATHERED` (`tests/test_fp0056_canonical_coverage_gate.py`) — the ratchet set only shrinks; the gate's `live == ledger` equality assert still passes.
- `tests/test_fp0056_m3_fail_visible.py`'s registry-wide "no silent status-only catch-all" probe drives every registered mapper with a bare `{"status": ...}` dict. `shell_to_canonical` has NO inner discriminator (it renders the whole value verbatim, never selects/drops a sub-field the way `file`/`reyn_src` dispatch on `op`/body-key), so it structurally cannot re-introduce the M3 class — narrowly exempted by name (`_NO_INNER_DISCRIMINATOR_MAPPERS`) with a documented rationale, not blanket-skipped.
- Updated the two `test_2593_pipeline_shell_step.py` assertions that pinned the OLD `CANONICAL_TODO` fallback shape (`{"text": "", "structured": {...}}`) to the new real-mapper shape (`{"text": '<json-dumped dict>'}`) — this is the intended, expected behavior change the fix makes (not a regression).

## Falsify evidence

Manually reverted `shell.py`'s `canonical=` back to `CANONICAL_TODO` and reran the new/updated tests — 6 failures (the new `tests/test_2681_shell_canonical.py` mapper tests + the two updated `test_2593_pipeline_shell_step.py` assertions), each showing the whole-envelope-dict / whole-JSON-dict `structured` blob with empty `text` — confirming RED pre-fix. Restored the real mapper — GREEN.

## Test plan

- [x] `tests/test_2681_shell_canonical.py` (new) — Tier 1: `shell` declares a real mapper (not `CANONICAL_TODO`); plain-text stdout (envelope shape) renders as clean `text`, no `structured` attachment; JSON-dict stdout (pipeline-unwrapped shape) renders as readable json-dumped `text`, no `structured` attachment; empty output renders the explicit `(no output)` marker; `shell` is off the grandfathered ledger.
- [x] `tests/test_2593_pipeline_shell_step.py` — updated the two assertions pinning the old fallback shape to the new real-mapper shape; the other 7 tests (registry wiring, stdin threading, schema verify pass/fail, timeout, security floors, DSL round-trip) pass unchanged.
- [x] `tests/test_fp0056_canonical_coverage_gate.py` — the ratchet `live == ledger` equality assert passes with `shell` removed; the admin-6 `STRUCTURED_PASSTHROUGH` assert is unaffected.
- [x] `tests/test_fp0056_m3_fail_visible.py` — added a narrow, documented exemption so the registry-wide status-echo probe doesn't false-positive on `shell_to_canonical`'s no-discriminator design; all 10 tests in the module pass.
- [x] Falsify: reverted the mapper → RED (6 failures) → restored → GREEN.
- [x] `ruff check src tests` — clean (verified in an isolated `git worktree` checkout of this branch's commit).
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 30/30 OK, 0 Tier-4 violations.
- [x] `pytest` (full suite from repo root, isolated worktree) — 8062 passed, 21 skipped; the only 5 failures are pre-existing route-mounting/plugin-loader tests unrelated to this change (confirmed to fail identically on a clean `origin/main` checkout with no changes applied).
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Note for reviewers

This PR edits the `_CANONICAL_TODO_GRANDFATHERED` frozenset in `tests/test_fp0056_canonical_coverage_gate.py` (removing `"shell"`). A Bucket C PR (status-only producers, #2681) independently edits this same frozenset, removing different entries — expect a trivial rebase on whichever lands second (no semantic conflict, just adjacent lines in the same set literal).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>