### PR TITLE
feat: status-text canonical mappers for 25 status producers — #2681 Bucket C

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -799,6 +799,288 @@ def memory_body_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
+# ── Status-text mappers — FP-0056 issue #2681 Bucket C burn-down ─────────────────────────────────
+#
+# The 26 (25 real mappers; ``topology_create`` triaged as a genuine RECORD — full config echo, not
+# an ack — and left in the ratchet ledger for Bucket B) write/ack/spawn-ack producers whose result
+# has NO readable body: a write confirmation, a spawn ack, an install ack. Before this burn-down each
+# took the ``CANONICAL_TODO`` whole-dict fallback (a raw ``structured`` blob); :func:`make_status_text_mapper`
+# is the ONE reusable factory every one of them declares through — a short human/LLM-readable status
+# line (the producer-specific phrasing) + the SAME structured fields carried as ``meta`` instead of an
+# opaque blob. Behavior-preserving: nothing the caller could read via the whole-dict fallback is lost,
+# only reshaped (canonical text+meta instead of a raw dict).
+
+
+def make_status_text_mapper(
+    render: "Callable[[dict], str]",
+    *,
+    meta_keys: "tuple[str, ...]" = (),
+    empty_marker: str = "(done)",
+) -> CanonicalMapper:
+    """Factory — build a canonical mapper for a SUCCESS-shaped status/ack result (issue #2681 Bucket
+    C: write/ack/spawn-ack producers with no readable body).
+
+    ``render(result)`` renders the short human/LLM-readable status line (the producer-specific
+    phrasing — "Saved '<slug>' to <path>.", "Spawned agent '<name>'.", "Removed N chunk(s).", …).
+    ``meta_keys`` names the top-level result fields that ride along as structured ``meta``
+    (frontmatter) — the SAME fields the pre-burn-down whole-dict fallback carried; a key absent from
+    a particular result shape is silently skipped (lets one factory call cover a producer with more
+    than one success sub-shape, e.g. ``mcp_install``'s ``ok`` vs ``needs_secrets``).
+
+    SUCCESS shape only — FP-0056 v2 piece #1 (the shared error seam) routes any
+    :func:`is_error_result` shape through ``error_to_canonical`` BEFORE a mapper runs, so ``render``
+    only ever sees a success/status dict."""
+
+    def _mapper(result: dict) -> CanonicalToolResult:
+        meta: dict[str, Any] = {}
+        for key in meta_keys:
+            value = result.get(key)
+            if value is not None:
+                meta[key] = value
+        text = _explicit_empty(render(result), empty_marker)
+        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+
+    return _mapper
+
+
+def _render_remember(result: dict) -> str:
+    return f"Saved '{result.get('saved', '')}' to {result.get('path', '')}."
+
+
+# ``remember_shared`` / ``remember_agent`` (tools/memory.py) — same success shape
+# ``{saved, layer, path}``, one shared mapper.
+remember_to_canonical = make_status_text_mapper(
+    render=_render_remember, meta_keys=("saved", "layer", "path"),
+)
+
+
+def _render_forget_memory(result: dict) -> str:
+    return f"Deleted memory '{result.get('deleted', '')}'."
+
+
+# ``forget_memory`` (tools/memory.py) — ``{deleted, layer}``.
+forget_memory_to_canonical = make_status_text_mapper(
+    render=_render_forget_memory, meta_keys=("deleted", "layer"),
+)
+
+
+def _render_cron_register(result: dict) -> str:
+    verb = "Replaced" if result.get("replaced") else "Registered"
+    return f"{verb} cron job '{result.get('name', '')}'."
+
+
+# ``cron_register`` (tools/cron.py) — ``{status, name, replaced, live_update_applied, path}``.
+cron_register_to_canonical = make_status_text_mapper(
+    render=_render_cron_register,
+    meta_keys=("name", "replaced", "live_update_applied", "path"),
+)
+
+
+def _render_cron_unregister(result: dict) -> str:
+    verb = "Removed" if result.get("removed") else "No matching job for"
+    return f"{verb} cron job '{result.get('name', '')}'."
+
+
+# ``cron_unregister`` (tools/cron.py) — ``{status, name, removed, live_update_applied, path}``.
+cron_unregister_to_canonical = make_status_text_mapper(
+    render=_render_cron_unregister,
+    meta_keys=("name", "removed", "live_update_applied", "path"),
+)
+
+
+def _render_cron_set_enabled(result: dict) -> str:
+    state = "enabled" if result.get("enabled") else "disabled"
+    return f"Cron job '{result.get('name', '')}' {state}."
+
+
+# ``cron_enable`` / ``cron_disable`` (tools/cron.py) — shared ``_set_enabled`` backbone, same shape
+# ``{status, name, enabled, found_in_dynamic, live_update_applied}``.
+cron_set_enabled_to_canonical = make_status_text_mapper(
+    render=_render_cron_set_enabled,
+    meta_keys=("name", "enabled", "found_in_dynamic", "live_update_applied"),
+)
+
+
+def _render_hooks_add(result: dict) -> str:
+    verb = "Added" if result.get("added") else "Already present:"
+    return f"{verb} hook at '{result.get('on', '')}'."
+
+
+# ``hooks_add`` (tools/hooks.py) — ``{status, on, added, reload_scheduled, path}``.
+hooks_add_to_canonical = make_status_text_mapper(
+    render=_render_hooks_add,
+    meta_keys=("on", "added", "reload_scheduled", "path"),
+)
+
+
+def _render_task_heartbeat(result: dict) -> str:
+    return f"Heartbeat recorded for task {result.get('task_id', '')} (state={result.get('state', '')})."
+
+
+# ``task.heartbeat`` (core/op_runtime/task.py) — ``{kind, status, task_id, state, unblocked}``.
+task_heartbeat_to_canonical = make_status_text_mapper(
+    render=_render_task_heartbeat, meta_keys=("task_id", "state", "unblocked"),
+)
+
+
+def _render_task_register_unblock_predicate(result: dict) -> str:
+    return f"Unblock predicate registered for task {result.get('task_id', '')}."
+
+
+# ``task.register_unblock_predicate`` (core/op_runtime/task.py) — ``{kind, status, task_id}``.
+task_register_unblock_predicate_to_canonical = make_status_text_mapper(
+    render=_render_task_register_unblock_predicate, meta_keys=("task_id",),
+)
+
+
+def _render_task_comment(result: dict) -> str:
+    return f"Comment {result.get('comment_id', '')} added to task {result.get('task_id', '')}."
+
+
+# ``task.comment`` (core/op_runtime/task.py) — ``{kind, status, task_id, comment_id}``.
+task_comment_to_canonical = make_status_text_mapper(
+    render=_render_task_comment, meta_keys=("task_id", "comment_id"),
+)
+
+
+def _render_agent_spawn(result: dict) -> str:
+    text = f"Spawned agent '{result.get('name', '')}' (parent={result.get('parent', '')})."
+    note = result.get("note")
+    return f"{text}\n{note}" if note else text
+
+
+# ``agent_spawn`` (tools/agent_spawn.py) — ``{status, name, parent, note}``.
+agent_spawn_to_canonical = make_status_text_mapper(
+    render=_render_agent_spawn, meta_keys=("name", "parent"),
+)
+
+
+def _render_session_spawn(result: dict) -> str:
+    text = f"Spawned session {result.get('sid', '')} (mode={result.get('mode', '')})."
+    note = result.get("note")
+    return f"{text}\n{note}" if note else text
+
+
+# ``session_spawn`` (tools/session_spawn.py) — ``{status, sid, mode, note}``.
+session_spawn_to_canonical = make_status_text_mapper(
+    render=_render_session_spawn, meta_keys=("sid", "mode"),
+)
+
+
+def _render_delegate_to_agent(result: dict) -> str:
+    text = f"Dispatched to '{result.get('to', '')}'."
+    note = result.get("note")
+    return f"{text}\n{note}" if note else text
+
+
+# ``delegate_to_agent`` (tools/delegate_to_agent.py) — ``{status, to, note}``.
+delegate_to_agent_to_canonical = make_status_text_mapper(
+    render=_render_delegate_to_agent, meta_keys=("to",),
+)
+
+
+def _render_index_drop(result: dict) -> str:
+    chunks = result.get("chunks_dropped", 0)
+    verb = "Removed" if result.get("removed") else "No source found; removed"
+    return f"{verb} {chunks} chunk(s)."
+
+
+# ``index_drop`` (core/op_runtime/index_drop.py) op kind AND its ``drop_source`` (tools/drop_source.py)
+# tool wrapper — both surface the same handler's ``{removed, chunks_dropped}`` result verbatim.
+index_drop_to_canonical = make_status_text_mapper(
+    render=_render_index_drop, meta_keys=("removed", "chunks_dropped"),
+)
+
+
+def _render_pipeline_install_verb(result: dict) -> str:
+    name = result.get("name", "")
+    registered = result.get("registered_names") or []
+    count = len(registered)
+    plural = "s" if count != 1 else ""
+    return f"Installed pipeline '{name}' ({count} pipeline{plural} registered)."
+
+
+# ``pipeline_install_local`` / ``pipeline_install_source`` (tools/pipeline_management_verbs.py) —
+# both delegate to ``op_runtime.pipeline_install.handle`` and surface its
+# ``{status:"installed", name, registered_names, path, description, config_path, source}`` verbatim
+# (the tool-level ``{status:"ok", data:...}`` envelope is peeled by ``unwrap_dispatch_envelope`` before
+# this mapper runs).
+pipeline_install_verb_to_canonical = make_status_text_mapper(
+    render=_render_pipeline_install_verb,
+    meta_keys=("name", "registered_names", "path", "description", "config_path", "source"),
+)
+
+
+def _render_skill_install_verb(result: dict) -> str:
+    return f"Installed skill '{result.get('name', '')}'."
+
+
+# ``skill_install_local`` / ``skill_install_source`` (tools/skill_verbs.py) — both delegate to
+# ``op_runtime.skill_install.handle`` and surface its
+# ``{status:"installed", name, path, description, config_path, source}`` verbatim (envelope peeled
+# the same way as the pipeline-install verbs).
+skill_install_verb_to_canonical = make_status_text_mapper(
+    render=_render_skill_install_verb,
+    meta_keys=("name", "path", "description", "config_path", "source"),
+)
+
+
+def _render_mcp_install_local_verb(result: dict) -> str:
+    return f"Installed local MCP server '{result.get('name', '')}'."
+
+
+# ``mcp_install_local`` (tools/mcp_verbs.py) — writes ``.reyn/config/mcp.yaml`` directly (does not
+# delegate to ``op_runtime.mcp_install``); its own result shape is
+# ``{kind:"mcp_install_local", name, config_path, entry}``.
+mcp_install_local_verb_to_canonical = make_status_text_mapper(
+    render=_render_mcp_install_local_verb, meta_keys=("name", "config_path", "entry"),
+)
+
+
+def _render_mcp_install_verb(result: dict) -> str:
+    if result.get("status") == "needs_secrets":
+        return result.get("guide") or "MCP install needs secrets set before it can proceed."
+    server_name = result.get("server_name") or result.get("server_id") or ""
+    return f"Installed MCP server '{server_name}'."
+
+
+# ``mcp_install_registry`` / ``mcp_install_package`` (tools/mcp_verbs.py) — both delegate to
+# ``op_runtime.mcp_install.handle`` and surface its result verbatim: either the ``status:"ok"``
+# install-complete shape (``server_id, server_name, scope, installed_path, runtime, env_keys_set,
+# source``) or the ``status:"needs_secrets"`` short-circuit (``server_id, missing_secret_keys,
+# guide`` — the ``guide`` text IS the actionable message, so it becomes ``text`` verbatim rather than
+# a synthesized line). Envelope peeled the same way as the pipeline/skill install verbs.
+mcp_install_verb_to_canonical = make_status_text_mapper(
+    render=_render_mcp_install_verb,
+    meta_keys=(
+        "status", "server_id", "server_name", "scope", "installed_path", "runtime",
+        "env_keys_set", "source", "missing_secret_keys",
+    ),
+)
+
+
+def _render_mcp_subscribe_resource_verb(result: dict) -> str:
+    return f"Subscribed to {result.get('uri', '')} on server '{result.get('server', '')}'."
+
+
+# ``subscribe_mcp_resource`` (tools/mcp.py) — surfaces the ``mcp_subscribe_resource`` op kind's
+# ``{kind, status:"ok", server, uri}`` result verbatim.
+mcp_subscribe_resource_verb_to_canonical = make_status_text_mapper(
+    render=_render_mcp_subscribe_resource_verb, meta_keys=("server", "uri"),
+)
+
+
+def _render_mcp_unsubscribe_resource_verb(result: dict) -> str:
+    return f"Unsubscribed from {result.get('uri', '')} on server '{result.get('server', '')}'."
+
+
+# ``unsubscribe_mcp_resource`` (tools/mcp.py) — surfaces the ``mcp_unsubscribe_resource`` op kind's
+# ``{kind, status:"ok", server, uri}`` result verbatim.
+mcp_unsubscribe_resource_verb_to_canonical = make_status_text_mapper(
+    render=_render_mcp_unsubscribe_resource_verb, meta_keys=("server", "uri"),
+)
+
+
 def ask_user_to_canonical(result: dict) -> CanonicalToolResult:
     """``ask_user`` op result → canonical (FP-0056 PR-F1 triage: text-shaped). The user's ``answer``
     (free text or the chosen option) IS what the LLM acts on → ``text`` — not a whole-dict blob hiding

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -107,6 +107,6 @@ class _DenyBus:
         return InterventionAnswer(choice_id="no", text="")
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import index_drop_to_canonical  # noqa: E402
 
-register("index_drop", handle, canonical=CANONICAL_TODO)
+register("index_drop", handle, canonical=index_drop_to_canonical)

--- a/src/reyn/core/op_runtime/task.py
+++ b/src/reyn/core/op_runtime/task.py
@@ -759,7 +759,12 @@ async def _assign(op, ctx: OpContext) -> dict:
     return _ok("task.assign", task=assigned.to_dict())
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import (  # noqa: E402
+    CANONICAL_TODO,
+    task_comment_to_canonical,
+    task_heartbeat_to_canonical,
+    task_register_unblock_predicate_to_canonical,
+)
 
 register("task.create", _create, canonical=CANONICAL_TODO)
 register("task.update_status", _update_status, canonical=CANONICAL_TODO)
@@ -769,7 +774,10 @@ register("task.add_dependency", _add_dependency, canonical=CANONICAL_TODO)
 register("task.remove_dependency", _remove_dependency, canonical=CANONICAL_TODO)
 register("task.repoint_dependency", _repoint_dependency, canonical=CANONICAL_TODO)
 register("task.abort", _abort, canonical=CANONICAL_TODO)
-register("task.heartbeat", _heartbeat, canonical=CANONICAL_TODO)
-register("task.register_unblock_predicate", _register_unblock_predicate, canonical=CANONICAL_TODO)
-register("task.comment", _comment, canonical=CANONICAL_TODO)
+register("task.heartbeat", _heartbeat, canonical=task_heartbeat_to_canonical)
+register(
+    "task.register_unblock_predicate", _register_unblock_predicate,
+    canonical=task_register_unblock_predicate_to_canonical,
+)
+register("task.comment", _comment, canonical=task_comment_to_canonical)
 register("task.assign", _assign, canonical=CANONICAL_TODO)

--- a/src/reyn/tools/agent_spawn.py
+++ b/src/reyn/tools/agent_spawn.py
@@ -64,10 +64,10 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     return await rs.spawn_agent_fn(name=name, role=args.get("role", "") or "")
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import agent_spawn_to_canonical  # noqa: E402
 
 AGENT_SPAWN = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=agent_spawn_to_canonical,
     name="agent_spawn",
     router_dispatched=True,
     description=_AGENT_SPAWN_DESCRIPTION,

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -442,10 +442,15 @@ async def _handle_cron_disable(
 # ── ToolDefinition instances ─────────────────────────────────────────
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import (  # noqa: E402
+    CANONICAL_TODO,
+    cron_register_to_canonical,
+    cron_set_enabled_to_canonical,
+    cron_unregister_to_canonical,
+)
 
 CRON_REGISTER = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=cron_register_to_canonical,
     name="cron_register",
     description=_CRON_REGISTER_DESCRIPTION,
     parameters=_CRON_REGISTER_PARAMETERS,
@@ -456,7 +461,7 @@ CRON_REGISTER = ToolDefinition(
 )
 
 CRON_UNREGISTER = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=cron_unregister_to_canonical,
     name="cron_unregister",
     description=_CRON_UNREGISTER_DESCRIPTION,
     parameters=_CRON_NAME_ONLY_PARAMETERS,
@@ -478,7 +483,7 @@ CRON_LIST = ToolDefinition(
 )
 
 CRON_ENABLE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=cron_set_enabled_to_canonical,
     name="cron_enable",
     description=_CRON_ENABLE_DESCRIPTION,
     parameters=_CRON_NAME_ONLY_PARAMETERS,
@@ -489,7 +494,7 @@ CRON_ENABLE = ToolDefinition(
 )
 
 CRON_DISABLE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=cron_set_enabled_to_canonical,
     name="cron_disable",
     description=_CRON_DISABLE_DESCRIPTION,
     parameters=_CRON_NAME_ONLY_PARAMETERS,

--- a/src/reyn/tools/delegate_to_agent.py
+++ b/src/reyn/tools/delegate_to_agent.py
@@ -138,10 +138,10 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     }
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import delegate_to_agent_to_canonical  # noqa: E402
 
 DELEGATE_TO_AGENT = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=delegate_to_agent_to_canonical,
     name="delegate_to_agent",
     router_dispatched=True,
     description=_DELEGATE_TO_AGENT_DESCRIPTION,

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -97,10 +97,10 @@ async def _handle_drop_source(
     return await execute_op(op, legacy_ctx)
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import index_drop_to_canonical  # noqa: E402
 
 DROP_SOURCE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=index_drop_to_canonical,
     name="drop_source",
     router_dispatched=True,
     description=_DROP_SOURCE_DESCRIPTION,

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -196,10 +196,10 @@ async def _handle_hooks_add(args: Mapping[str, Any], ctx: ToolContext) -> ToolRe
     }
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import hooks_add_to_canonical  # noqa: E402
 
 HOOKS_ADD = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=hooks_add_to_canonical,
     name="hooks_add",
     description=_HOOKS_ADD_DESCRIPTION,
     parameters=_HOOKS_ADD_PARAMETERS,

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -629,7 +629,9 @@ from reyn.core.offload.canonical import (  # noqa: E402
     CANONICAL_TODO,
     mcp_get_prompt_to_canonical,
     mcp_read_resource_to_canonical,
+    mcp_subscribe_resource_verb_to_canonical,
     mcp_to_canonical,
+    mcp_unsubscribe_resource_verb_to_canonical,
 )
 
 LIST_MCP_SERVERS = ToolDefinition(
@@ -739,7 +741,7 @@ READ_MCP_RESOURCE = ToolDefinition(
 # reuse (server enum only).
 
 SUBSCRIBE_MCP_RESOURCE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=mcp_subscribe_resource_verb_to_canonical,
     name="subscribe_mcp_resource",
     router_dispatched=True,
     description=_SUBSCRIBE_MCP_RESOURCE_DESCRIPTION,
@@ -752,7 +754,7 @@ SUBSCRIBE_MCP_RESOURCE = ToolDefinition(
 )
 
 UNSUBSCRIBE_MCP_RESOURCE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=mcp_unsubscribe_resource_verb_to_canonical,
     name="unsubscribe_mcp_resource",
     router_dispatched=True,
     description=_UNSUBSCRIBE_MCP_RESOURCE_DESCRIPTION,

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -586,7 +586,12 @@ async def _handle_mcp_call_tool(
 # ── ToolDefinitions ──────────────────────────────────────────────────────────
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO, mcp_to_canonical  # noqa: E402
+from reyn.core.offload.canonical import (  # noqa: E402
+    CANONICAL_TODO,
+    mcp_install_local_verb_to_canonical,
+    mcp_install_verb_to_canonical,
+    mcp_to_canonical,
+)
 
 MCP_SEARCH_REGISTRY = ToolDefinition(
     canonical=CANONICAL_TODO,
@@ -602,7 +607,7 @@ MCP_SEARCH_REGISTRY = ToolDefinition(
 
 
 MCP_INSTALL_REGISTRY = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=mcp_install_verb_to_canonical,
     name="mcp_install_registry",
     description=_MCP_INSTALL_REGISTRY_DESCRIPTION,
     parameters=_MCP_INSTALL_REGISTRY_PARAMETERS,
@@ -614,7 +619,7 @@ MCP_INSTALL_REGISTRY = ToolDefinition(
 
 
 MCP_INSTALL_PACKAGE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=mcp_install_verb_to_canonical,
     name="mcp_install_package",
     description=_MCP_INSTALL_PACKAGE_DESCRIPTION,
     parameters=_MCP_INSTALL_PACKAGE_PARAMETERS,
@@ -626,7 +631,7 @@ MCP_INSTALL_PACKAGE = ToolDefinition(
 
 
 MCP_INSTALL_LOCAL = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=mcp_install_local_verb_to_canonical,
     name="mcp_install_local",
     description=_MCP_INSTALL_LOCAL_DESCRIPTION,
     parameters=_MCP_INSTALL_LOCAL_PARAMETERS,

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -609,7 +609,12 @@ def _regenerate_index(ctx: ToolContext, mem_dir: Path, index_path: Path) -> None
 
 # ── ToolDefinition instances ─────────────────────────────────────────────────────
 
-from reyn.core.offload.canonical import CANONICAL_TODO, memory_body_to_canonical  # noqa: E402
+from reyn.core.offload.canonical import (  # noqa: E402
+    CANONICAL_TODO,
+    forget_memory_to_canonical,
+    memory_body_to_canonical,
+    remember_to_canonical,
+)
 
 LIST_MEMORY = ToolDefinition(
     canonical=CANONICAL_TODO,
@@ -638,7 +643,7 @@ READ_MEMORY_BODY = ToolDefinition(
 )
 
 REMEMBER_SHARED = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=remember_to_canonical,
     name="remember_shared",
     router_dispatched=True,
     description=_REMEMBER_SHARED_DESCRIPTION,
@@ -650,7 +655,7 @@ REMEMBER_SHARED = ToolDefinition(
 )
 
 REMEMBER_AGENT = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=remember_to_canonical,
     name="remember_agent",
     router_dispatched=True,
     description=_REMEMBER_AGENT_DESCRIPTION,
@@ -662,7 +667,7 @@ REMEMBER_AGENT = ToolDefinition(
 )
 
 FORGET_MEMORY = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=forget_memory_to_canonical,
     name="forget_memory",
     router_dispatched=True,
     description=_FORGET_MEMORY_DESCRIPTION,

--- a/src/reyn/tools/pipeline_management_verbs.py
+++ b/src/reyn/tools/pipeline_management_verbs.py
@@ -236,10 +236,10 @@ async def _handle_pipeline_install_source(
 
 # ── ToolDefinitions ───────────────────────────────────────────────────────────
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import pipeline_install_verb_to_canonical  # noqa: E402
 
 PIPELINE_INSTALL_LOCAL = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=pipeline_install_verb_to_canonical,
     name="pipeline_install_local",
     description=_PIPELINE_INSTALL_LOCAL_DESCRIPTION,
     parameters=_PIPELINE_INSTALL_LOCAL_PARAMETERS,
@@ -250,7 +250,7 @@ PIPELINE_INSTALL_LOCAL = ToolDefinition(
 )
 
 PIPELINE_INSTALL_SOURCE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=pipeline_install_verb_to_canonical,
     name="pipeline_install_source",
     description=_PIPELINE_INSTALL_SOURCE_DESCRIPTION,
     parameters=_PIPELINE_INSTALL_SOURCE_PARAMETERS,

--- a/src/reyn/tools/session_spawn.py
+++ b/src/reyn/tools/session_spawn.py
@@ -82,10 +82,10 @@ async def _handle(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     )
 
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import session_spawn_to_canonical  # noqa: E402
 
 SESSION_SPAWN = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=session_spawn_to_canonical,
     name="session_spawn",
     router_dispatched=True,
     description=_SESSION_SPAWN_DESCRIPTION,

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -210,10 +210,10 @@ async def _handle_skill_install_source(
 
 # ── ToolDefinitions ───────────────────────────────────────────────────────────
 
-from reyn.core.offload.canonical import CANONICAL_TODO  # noqa: E402
+from reyn.core.offload.canonical import skill_install_verb_to_canonical  # noqa: E402
 
 SKILL_INSTALL_LOCAL = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=skill_install_verb_to_canonical,
     name="skill_install_local",
     description=_SKILL_INSTALL_LOCAL_DESCRIPTION,
     parameters=_SKILL_INSTALL_LOCAL_PARAMETERS,
@@ -224,7 +224,7 @@ SKILL_INSTALL_LOCAL = ToolDefinition(
 )
 
 SKILL_INSTALL_SOURCE = ToolDefinition(
-    canonical=CANONICAL_TODO,
+    canonical=skill_install_verb_to_canonical,
     name="skill_install_source",
     description=_SKILL_INSTALL_SOURCE_DESCRIPTION,
     parameters=_SKILL_INSTALL_SOURCE_PARAMETERS,

--- a/src/reyn/tools/task_ops.py
+++ b/src/reyn/tools/task_ops.py
@@ -22,7 +22,12 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from reyn.core.offload.canonical import CANONICAL_TODO
+from reyn.core.offload.canonical import (
+    CANONICAL_TODO,
+    task_comment_to_canonical,
+    task_heartbeat_to_canonical,
+    task_register_unblock_predicate_to_canonical,
+)
 from reyn.schemas.models import (
     TaskAbortIROp,
     TaskAddDependencyIROp,
@@ -88,6 +93,19 @@ _TASK_OPS: tuple[tuple[str, type, str], ...] = (
 )
 
 
+# #2681 Bucket C burn-down: these three task ops' ToolDefinition MUST declare the same canonical
+# mapper as their op_runtime registration (core/op_runtime/task.py) — both seams share the ONE
+# ``"task.<verb>"`` source id, and ``declare_canonical`` rejects a conflicting re-declaration. The
+# other 9 task ops (create/update_status/get/list/add_dependency/remove_dependency/
+# repoint_dependency/abort/assign) return a full ``task=...to_dict()`` record — genuinely structured,
+# left on ``CANONICAL_TODO`` (Bucket B).
+_TASK_OP_CANONICAL: "dict[str, Any]" = {
+    "task.heartbeat": task_heartbeat_to_canonical,
+    "task.register_unblock_predicate": task_register_unblock_predicate_to_canonical,
+    "task.comment": task_comment_to_canonical,
+}
+
+
 def _parameters_for(model: type) -> dict[str, Any]:
     """JSON-schema ``parameters`` for a task IROp model, minus the ``kind``
     discriminator (set by the factory, never the LLM)."""
@@ -150,7 +168,7 @@ def build_task_tool_definitions() -> list[ToolDefinition]:
     defs: list[ToolDefinition] = []
     for op_kind, model, description in _TASK_OPS:
         defs.append(ToolDefinition(
-            canonical=CANONICAL_TODO,
+            canonical=_TASK_OP_CANONICAL.get(op_kind, CANONICAL_TODO),
             name=op_kind,  # e.g. "task.create" — registry-dispatch target name
             description=description,
             parameters=_parameters_for(model),

--- a/tests/test_2681_bucket_c_status_text_mappers.py
+++ b/tests/test_2681_bucket_c_status_text_mappers.py
@@ -1,0 +1,215 @@
+"""Tier 1: FP-0056 issue #2681 Bucket C — status-text canonical mappers for the 26 status-only
+producers (write/ack/spawn-ack results, no readable body).
+
+Before this burn-down each of these producers was ``CANONICAL_TODO`` — the provisional whole-dict
+fallback (``text=""``, the whole result as a ``structured`` attachment). ``make_status_text_mapper``
+(``core/offload/canonical.py``) is the ONE reusable factory every one of them now declares through: a
+short human/LLM-readable status line + the same structured fields carried as ``meta`` — behavior-
+preserving (nothing the caller could read via the whole-dict fallback is lost, only reshaped).
+
+Real result dicts (the shapes the producers actually emit — read from source, not invented), no
+mocks. Spot-checks a representative producer per family (memory / cron / spawn / install / drop) via
+the LIVE registered declaration (``to_canonical(result, source=<name>)``), not the bare mapper
+function — so the assertions exercise the real registration seam, not just the factory in isolation.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Importing op_runtime eagerly registers every op handler + its canonical declaration; building the
+# default tool registry declares every ToolDefinition's — both are needed for ``to_canonical``'s
+# ``source=`` resolution to find our new declarations (mirrors the coverage-gate test's setup).
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.offload.canonical import make_status_text_mapper, to_canonical
+from reyn.tools import get_default_registry
+
+get_default_registry()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Spot-checks — representative real result shapes, across memory / cron / spawn / install / drop
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_memory_remember_shared_renders_status_text_with_meta() -> None:
+    """Tier 1: ``remember_shared`` (tools/memory.py ``_handle_remember`` success shape) renders a
+    short status line naming what was saved + where, with ``layer``/``path`` carried as meta."""
+    result = {"saved": "user_role", "layer": "shared", "path": ".reyn/memory/user_role.md"}
+    canonical = to_canonical(result, source="remember_shared")
+    assert "user_role" in canonical["text"]
+    assert ".reyn/memory/user_role.md" in canonical["text"]
+    assert canonical["attachments"] == []
+    assert canonical["meta"]["layer"] == "shared"
+    assert canonical["meta"]["path"] == ".reyn/memory/user_role.md"
+
+
+def test_memory_forget_memory_renders_status_text() -> None:
+    """Tier 1: ``forget_memory`` success shape (``{deleted, layer}``) renders a short deletion line."""
+    result = {"deleted": "feedback_tone", "layer": "agent"}
+    canonical = to_canonical(result, source="forget_memory")
+    assert "feedback_tone" in canonical["text"]
+    assert canonical["meta"]["layer"] == "agent"
+
+
+def test_cron_register_renders_replaced_vs_registered() -> None:
+    """Tier 1: ``cron_register`` (tools/cron.py) distinguishes a fresh register from a replace, and
+    carries the live-update/path signal as meta."""
+    fresh = {
+        "status": "ok", "name": "morning_news", "replaced": False,
+        "live_update_applied": True, "path": ".reyn/config/cron.yaml",
+    }
+    canonical = to_canonical(fresh, source="cron_register")
+    assert "Registered" in canonical["text"]
+    assert "morning_news" in canonical["text"]
+    assert canonical["meta"]["live_update_applied"] is True
+
+    replaced = {**fresh, "replaced": True}
+    canonical_replaced = to_canonical(replaced, source="cron_register")
+    assert "Replaced" in canonical_replaced["text"]
+
+
+def test_agent_spawn_renders_status_text_with_note() -> None:
+    """Tier 1: ``agent_spawn`` (tools/agent_spawn.py ``spawn_agent`` success shape) names the new
+    agent + its parent, with the OS-authored ``note`` appended verbatim (lossless)."""
+    result = {
+        "status": "spawned", "name": "researcher", "parent": "lead",
+        "note": "New agent created; its capabilities are capped at ⊆ yours.",
+    }
+    canonical = to_canonical(result, source="agent_spawn")
+    assert "researcher" in canonical["text"]
+    assert "lead" in canonical["text"]
+    assert "capped at" in canonical["text"]  # the note rides along, not dropped
+    assert canonical["meta"]["parent"] == "lead"
+
+
+def test_session_spawn_renders_status_text() -> None:
+    """Tier 1: ``session_spawn`` (tools/session_spawn.py) success shape names the sid + mode."""
+    result = {
+        "status": "spawned", "sid": "sess-42", "mode": "ephemeral",
+        "note": "Fresh session spawned + task submitted; it runs in isolation.",
+    }
+    canonical = to_canonical(result, source="session_spawn")
+    assert "sess-42" in canonical["text"]
+    assert "ephemeral" in canonical["text"]
+    assert canonical["meta"]["sid"] == "sess-42"
+
+
+def test_delegate_to_agent_renders_status_text() -> None:
+    """Tier 1: ``delegate_to_agent`` (tools/delegate_to_agent.py) dispatch-ack shape."""
+    result = {"status": "dispatched", "to": "peer_agent", "note": "Peer's reply will arrive later."}
+    canonical = to_canonical(result, source="delegate_to_agent")
+    assert "peer_agent" in canonical["text"]
+    assert canonical["meta"]["to"] == "peer_agent"
+
+
+def test_index_drop_shared_by_op_kind_and_drop_source_tool() -> None:
+    """Tier 1: ``index_drop`` (op kind) and ``drop_source`` (its tool wrapper, tools/drop_source.py)
+    surface the SAME ``{removed, chunks_dropped}`` handler result — both declared through the same
+    mapper, so both render identically."""
+    result = {"removed": True, "chunks_dropped": 17}
+    for source in ("index_drop", "drop_source"):
+        canonical = to_canonical(result, source=source)
+        assert "17" in canonical["text"]
+        assert "chunk" in canonical["text"]
+        assert canonical["meta"]["chunks_dropped"] == 17
+        assert canonical["meta"]["removed"] is True
+
+
+def test_skill_install_local_renders_status_text() -> None:
+    """Tier 1: ``skill_install_local`` surfaces ``op_runtime.skill_install.handle``'s
+    ``{status:"installed", name, path, ...}`` result verbatim (post dispatch-envelope unwrap)."""
+    result = {
+        "status": "installed", "name": "code_review", "path": "/skills/code_review",
+        "description": "Reviews a diff.", "config_path": ".reyn/config/skills.yaml", "source": "",
+    }
+    canonical = to_canonical(result, source="skill_install_local")
+    assert "code_review" in canonical["text"]
+    assert canonical["meta"]["path"] == "/skills/code_review"
+    assert canonical["meta"]["config_path"] == ".reyn/config/skills.yaml"
+
+
+def test_mcp_install_registry_renders_ok_and_needs_secrets() -> None:
+    """Tier 1: ``mcp_install_registry`` surfaces ``op_runtime.mcp_install.handle``'s TWO success
+    sub-shapes — the install-complete ack and the ``needs_secrets`` short-circuit (whose ``guide`` IS
+    the actionable message, so it becomes ``text`` verbatim)."""
+    ok_result = {
+        "kind": "mcp_install", "status": "ok", "server_id": "io.example/server-time",
+        "server_name": "server-time", "scope": "local", "installed_path": "/mcp/server-time",
+        "runtime": "npx", "env_keys_set": [], "source": "",
+    }
+    canonical = to_canonical(ok_result, source="mcp_install_registry")
+    assert "server-time" in canonical["text"]
+    assert canonical["meta"]["scope"] == "local"
+
+    needs_secrets = {
+        "kind": "mcp_install", "status": "needs_secrets", "server_id": "io.example/server-time",
+        "missing_secret_keys": ["API_KEY"],
+        "guide": "Server requires secret env-vars not yet set: API_KEY.",
+    }
+    canonical_secrets = to_canonical(needs_secrets, source="mcp_install_registry")
+    assert canonical_secrets["text"] == needs_secrets["guide"]
+    assert canonical_secrets["meta"]["missing_secret_keys"] == ["API_KEY"]
+
+
+def test_mcp_subscribe_resource_renders_status_text() -> None:
+    """Tier 1: ``subscribe_mcp_resource`` surfaces the ``mcp_subscribe_resource`` op kind's
+    ``{kind, status:"ok", server, uri}`` result verbatim."""
+    result = {"kind": "mcp_subscribe_resource", "status": "ok", "server": "docs", "uri": "docs://readme"}
+    canonical = to_canonical(result, source="subscribe_mcp_resource")
+    assert "docs://readme" in canonical["text"]
+    assert "docs" in canonical["text"]
+    assert canonical["meta"]["server"] == "docs"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error shape still routes through the shared error seam (piece #1) — unaffected by the new mappers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_error_shape_bypasses_the_new_status_mapper() -> None:
+    """Tier 1: an error-shaped result (carries ``error``) is intercepted by the shared error seam
+    BEFORE any of the new status-text mappers run — the mapper only ever sees a success dict."""
+    error_result = {"status": "error", "kind": "agent_exists", "error": "agent 'x' already exists."}
+    canonical = to_canonical(error_result, source="agent_spawn")
+    assert canonical["meta"]["isError"] is True
+    assert "already exists" in canonical["text"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Falsify — the factory itself: without a declared mapper the result takes the lossless whole-dict
+# fallback (empty text, the whole dict as a structured attachment) — proving the assertions above
+# actually exercise the new mapper, not a vacuously-passing shape.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_falsify_undeclared_source_takes_whole_dict_fallback_not_status_text() -> None:
+    """Tier 1: (falsify) the SAME result shape through an UNDECLARED source name takes the whole-dict
+    fallback (empty ``text``, the dict in ``attachments``) — confirming the status-text rendering
+    above is actually produced by the declared mapper, not some source-independent default."""
+    result = {"saved": "user_role", "layer": "shared", "path": ".reyn/memory/user_role.md"}
+    fallback = to_canonical(result, source="_not_a_registered_producer_2681")
+    assert fallback["text"] == ""
+    assert fallback["attachments"] == [{"kind": "structured", "data": result}]
+
+
+def test_make_status_text_mapper_meta_keys_skip_absent_fields() -> None:
+    """Tier 1: a ``meta_keys`` entry absent from a given result shape is silently skipped (not set to
+    ``None``) — lets one factory call cover a producer with more than one success sub-shape (e.g.
+    ``mcp_install``'s ``ok`` vs ``needs_secrets``, exercised above)."""
+    mapper = make_status_text_mapper(render=lambda r: "did the thing", meta_keys=("a", "b"))
+    canonical = mapper({"a": 1})
+    assert canonical["meta"] == {"a": 1}
+    assert "b" not in canonical["meta"]
+
+
+def test_make_status_text_mapper_empty_render_gets_explicit_marker() -> None:
+    """Tier 1: a ``render`` that returns an empty/blank string is NOT surfaced as blank ``text`` (which
+    would spuriously fire the ``canonical_degraded`` invariant, FP-0056 v2 piece #2) — it gets the
+    factory's explicit marker instead."""
+    mapper = make_status_text_mapper(render=lambda r: "", empty_marker="(nothing happened)")
+    canonical = mapper({})
+    assert canonical["text"] == "(nothing happened)"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])

--- a/tests/test_fp0056_canonical_coverage_gate.py
+++ b/tests/test_fp0056_canonical_coverage_gate.py
@@ -55,34 +55,29 @@ _STRUCTURED_PASSTHROUGH_ADMIN_6 = frozenset({
 # Two of the migration's ~54 provisional producers were triaged as text-shaped and given REAL mappers
 # in F1 (``read_memory_body`` → the memory body text; ``ask_user`` → the user's answer), so they are
 # NOT here. See PR-F1 description for the full text-shaped / genuinely-structured / status-only triage.
+#
+# #2681 Bucket C burn-down: 25 status-only producers (write/ack/spawn-ack results, no readable body)
+# now ship a real ``make_status_text_mapper`` mapper (canonical.py) instead of the whole-dict
+# fallback — removed from the ledger. ``topology_create`` was triaged alongside them but its result
+# is a genuine RECORD (full topology config echo: kind/members/leader/profiles), not an ack, so it
+# stays here for Bucket B.
 _CANONICAL_TODO_GRANDFATHERED = frozenset({
-    "agent_spawn",
-    "cron_disable", "cron_enable", "cron_list", "cron_register", "cron_unregister",
-    "delegate_to_agent",
+    "cron_list",
     "describe_action", "describe_agent", "describe_mcp_tool",
-    "drop_source",
-    "forget_memory",
-    "hooks_add",
-    "index_drop",
     "invoke_action",
     "list_actions", "list_agents",
     "list_mcp_prompts", "list_mcp_resource_templates", "list_mcp_resources",
     "list_mcp_servers", "list_mcp_tools",
     "list_memory",
-    "mcp_install_local", "mcp_install_package", "mcp_install_registry", "mcp_search_registry",
-    "pipeline_install_local", "pipeline_install_source",
+    "mcp_search_registry",
     # #2692 burn-down: ``present`` now ships a real text mapper (its ack is an agent-facing
     # signal, not bulk content) — removed from the ledger (the ratchet set only shrinks).
-    "remember_agent", "remember_shared",
     "search_actions",
-    "session_spawn",
     # #2681 Bucket A burn-down: ``shell`` now ships a real text mapper (its stdout is the readable
     # LLM body, mirroring ``sandboxed_exec``'s stdout-is-text treatment) — removed from the ledger
     # (the ratchet set only shrinks).
-    "skill_install_local", "skill_install_source",
-    "subscribe_mcp_resource", "unsubscribe_mcp_resource",
-    "task.abort", "task.add_dependency", "task.assign", "task.comment", "task.create",
-    "task.get", "task.heartbeat", "task.list", "task.register_unblock_predicate",
+    "task.abort", "task.add_dependency", "task.assign", "task.create",
+    "task.get", "task.list",
     "task.remove_dependency", "task.repoint_dependency", "task.update_status",
     "topology_create",
 })

--- a/tests/test_fp0056_canonical_fallback_event.py
+++ b/tests/test_fp0056_canonical_fallback_event.py
@@ -43,7 +43,9 @@ get_default_registry()
 # A grandfathered ``CANONICAL_TODO`` producer (issue #2681 burn-down ledger). Used only to confirm the
 # classifier reports the ``canonical_todo`` reason for a real declared-debt producer; if this one is
 # later burned down to a real mapper it simply leaves the set — swap in any other ledger member.
-_A_CANONICAL_TODO_PRODUCER = "agent_spawn"
+# (#2681 Bucket C burned ``agent_spawn`` down to a real status-text mapper — swapped to
+# ``topology_create``, triaged as a genuine record and left on the ledger for Bucket B.)
+_A_CANONICAL_TODO_PRODUCER = "topology_create"
 # An admin/install producer declared STRUCTURED_PASSTHROUGH (owner decision #1 family).
 _A_PASSTHROUGH_PRODUCER = "mcp_install"
 # A producer with a REAL mapper — the falsify control.


### PR DESCRIPTION
**[per-PR-coder]** —

## Summary

FP-0056's canonical gate requires every LLM-invocable producer to declare a canonical mapper; unmapped ones carry `CANONICAL_TODO` (whole-dict fallback). A registry-enumeration scout triaged the 51 remaining producers into buckets; this PR is **Bucket C — the 26 status-only producers**: write/ack/spawn-ack results with no readable body (write confirmations, spawn acks, install acks).

part of #2681

### The centralized helper

`make_status_text_mapper` (`src/reyn/core/offload/canonical.py`) is the ONE reusable factory every one of these producers declares through:

- `render(result) -> str` — a short human/LLM-readable status line (producer-specific phrasing: `"Saved '<slug>' to <path>."`, `"Spawned agent '<name>'."`, `"Removed N chunk(s)."`, …)
- `meta_keys` — the top-level result fields that ride along as structured `meta` (frontmatter), same info the whole-dict fallback carried, just reshaped. A key absent from a given result shape is silently skipped, so one factory call can cover a producer with more than one success sub-shape (e.g. `mcp_install`'s `ok` vs `needs_secrets`).

Behavior-preserving throughout: nothing readable via the old whole-dict fallback is lost — text+meta instead of a raw dict blob. The shared error seam (FP-0056 v2 piece #1) still intercepts any `is_error_result` shape *before* these mappers run, so each `render` only ever sees a success/status dict.

### The 25 producers mapped (26 scouted, 1 flagged and left)

- **memory**: `remember_shared`, `remember_agent` (shared `remember_to_canonical`), `forget_memory`
- **cron**: `cron_register`, `cron_unregister`, `cron_enable`/`cron_disable` (shared `cron_set_enabled_to_canonical`)
- **hooks**: `hooks_add`
- **task**: `task.heartbeat`, `task.register_unblock_predicate`, `task.comment` (both the op-runtime registration in `core/op_runtime/task.py` AND the `task_ops.py` ToolDefinition share the same source id — both updated to keep `declare_canonical`'s conflict check happy)
- **spawn/delegation**: `agent_spawn`, `session_spawn`, `delegate_to_agent`
- **index/drop**: `drop_source` (tool) + `index_drop` (op kind) — share one mapper since `drop_source` just delegates to the `index_drop` handler and surfaces its `{removed, chunks_dropped}` result verbatim
- **install**: `pipeline_install_local`/`pipeline_install_source` (shared), `skill_install_local`/`skill_install_source` (shared), `mcp_install_local`, `mcp_install_package`/`mcp_install_registry` (shared — handles both the `status:"ok"` and `status:"needs_secrets"` sub-shapes)
- **mcp subscribe**: `subscribe_mcp_resource`, `unsubscribe_mcp_resource`

**`topology_create` flagged, left on `CANONICAL_TODO`**: read its handler (`RouterHostAdapter.create_topology`) — its success result is `{status:"created", name, kind, members, leader, profiles}`, a genuine RECORD (the full topology config echoed back), not a short ack. Forcing it through a status-text mapper would lose the `members`/`profiles` structure a reader needs. Left for Bucket B.

### Ledger edit

Removed the 25 burned-down entries from `_CANONICAL_TODO_GRANDFATHERED` in `tests/test_fp0056_canonical_coverage_gate.py` so the gate's `live_todo == ledger` ratchet assert still holds (monotonically shrinking set). `topology_create` stays. `shell` also stays — it's Bucket A's sibling PR's entry; this PR doesn't touch it, so a rebase against Bucket A landing first is a no-op on this ledger (different entries).

Also swapped `tests/test_fp0056_canonical_fallback_event.py`'s `_A_CANONICAL_TODO_PRODUCER` fixture from `agent_spawn` (now mapped) to `topology_create` (still on the ledger) — that test file's own comment anticipated this swap.

## Test plan

- [x] New `tests/test_2681_bucket_c_status_text_mappers.py` — spot-checks representative producers across memory / cron / spawn / install / drop (`remember_shared`, `forget_memory`, `cron_register` replaced-vs-registered, `agent_spawn`, `session_spawn`, `delegate_to_agent`, `index_drop` shared by both source ids, `skill_install_local`, `mcp_install_registry` both success sub-shapes, `subscribe_mcp_resource`) via the LIVE registered declaration (`to_canonical(result, source=...)`, not the bare mapper function) — exercises the real registration seam.
- [x] Falsify: an error-shaped result still routes through the shared error seam, not the new mapper (`test_error_shape_bypasses_the_new_status_mapper`).
- [x] Falsify: an undeclared source still takes the lossless whole-dict fallback (`test_falsify_undeclared_source_takes_whole_dict_fallback_not_status_text`) — proves the status-text assertions above are actually produced by the declared mapper.
- [x] Manual cp-falsify: reverted `remember_shared`'s declaration back to `CANONICAL_TODO`, confirmed BOTH the ledger ratchet gate test AND the new spot-check test go RED, then restored from a `cp` backup (never `git checkout` on uncommitted work) and confirmed green again.
- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 23 tests inspected, 0 errors, 0 warnings.
- [x] `pytest` (full suite, repo root) — 8071 passed, 21 skipped, 5 pre-existing failures (`test_fp0001_a2a_endpoints`, `test_a2a.py`, `test_mcp_sse.py`, `test_plugin_loader.py`, `test_resources_router.py` — all route-mounting assertions, independently confirmed to fail against a clean `origin/main` checkout with none of this PR's changes, unrelated to canonical mapping).
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)