### PR TITLE
fix: per-path in-process lock serializes concurrent same-path file writes (#2782)

### DIFF
--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -13,6 +13,7 @@ from reyn.schemas.models import FileIROp
 from . import register
 from .context import OpContext
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
+from .path_locks import get_path_lock, locked_paths
 
 _WRITE_OPS = frozenset({"write", "edit", "delete", "regenerate_index", "mkdir", "move"})
 _READ_OPS = frozenset({"read", "glob", "grep", "stat"})
@@ -237,15 +238,20 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         # changed. The pre-read is best-effort (skipped if read is denied).
         _prev_enc: str | None = None
         _prev_size: int | None = None  # #1466: bytes of the file before overwrite
-        try:
-            _prev_bytes, _existed = ctx.workspace.read_file_bytes(op.path)
-            if _existed:
-                _, _prev_enc = decode_text_or_none(_prev_bytes)
-                _prev_size = len(_prev_bytes)  # zero extra I/O — reuse the encoding pre-read
-        except PermissionError:
-            pass
-        _content = op.content or ""
-        ctx.workspace.write_file(op.path, _content)
+        # #2782 path-locking step: hold the SAME per-path lock `edit` holds, so
+        # a concurrent edit's read-modify-write can't interleave with this
+        # blind overwrite (either direction would silently discard the other
+        # op's change — a lost update).
+        async with get_path_lock(_resolve_for_gate(ctx, op.path)):
+            try:
+                _prev_bytes, _existed = ctx.workspace.read_file_bytes(op.path)
+                if _existed:
+                    _, _prev_enc = decode_text_or_none(_prev_bytes)
+                    _prev_size = len(_prev_bytes)  # zero extra I/O — reuse the encoding pre-read
+            except PermissionError:
+                pass
+            _content = op.content or ""
+            ctx.workspace.write_file(op.path, _content)
         ctx.events.emit("tool_executed", op="write_file", path=op.path)
         result: dict = {
             "kind": "file", "op": "write", "path": op.path, "status": "ok",
@@ -422,7 +428,11 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         }
 
     if op.op == "delete":
-        deleted = ctx.workspace.delete_file(op.path)
+        # #2782: same per-path lock as edit/write — otherwise a concurrent
+        # edit's read-modify-write can straddle this delete and "resurrect"
+        # the file (edit read before the delete, writes back after it).
+        async with get_path_lock(_resolve_for_gate(ctx, op.path)):
+            deleted = ctx.workspace.delete_file(op.path)
         ctx.events.emit("tool_executed", op="delete_file", path=op.path, deleted=deleted)
         return {"kind": "file", "op": "delete", "path": op.path, "status": "ok", "deleted": deleted}
 
@@ -433,6 +443,15 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         return await _execute_edit(op, ctx)
 
     if op.op == "regenerate_index":
+        # #2782: lock the SAME per-path key on the actually-written
+        # `output_path` (not the source `path`, which is a directory of
+        # *.md sources being read, not the file being mutated). The
+        # error branches (missing output_path/entry_template) never
+        # touch disk, so they run outside the lock.
+        if op.output_path:
+            resolved_output = _resolve_for_gate(ctx, op.output_path)
+            async with get_path_lock(resolved_output):
+                return _execute_regenerate_index(op, ctx)
         return _execute_regenerate_index(op, ctx)
 
     if op.op == "mkdir":
@@ -456,7 +475,14 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
                 "kind": "file", "op": "move", "path": op.path,
                 "status": "error", "error": "dest_path is required for move",
             }
-        moved = ctx.workspace.move_path(op.path, op.dest_path)
+        # #2782: move touches TWO paths (source is effectively deleted, dest is
+        # effectively written) — lock BOTH via `locked_paths`, which acquires
+        # them in a fixed sorted order (never src-then-dest vs dest-then-src)
+        # so a move and a reverse move can never deadlock against each other.
+        src_resolved = _resolve_for_gate(ctx, op.path)
+        dst_resolved = _resolve_for_gate(ctx, op.dest_path)
+        async with locked_paths(src_resolved, dst_resolved):
+            moved = ctx.workspace.move_path(op.path, op.dest_path)
         if not moved:
             ctx.events.emit("tool_executed", op="move", path=op.path, found=False)
             return {
@@ -692,7 +718,15 @@ def _execute_edit_sync(op: FileIROp, ctx: OpContext) -> tuple[dict, int | None, 
 
 
 async def _execute_edit(op: FileIROp, ctx: OpContext) -> dict:
-    result, replacements, written_path = await asyncio.to_thread(_execute_edit_sync, op, ctx)
+    # #2782 path-locking step: #2794 made the read-modify-write atomic WITHIN
+    # this one `to_thread` job, but two concurrent `edit_file` (or edit +
+    # write/delete/move) ops on the SAME path now run in different worker
+    # threads — both read, both write, one silently lost (the demonstrated
+    # race). The per-path lock is held across the ENTIRE `to_thread` call
+    # (the whole read-modify-write), so a second same-path writer blocks here
+    # until this one's write has landed.
+    async with get_path_lock(_resolve_for_gate(ctx, op.path)):
+        result, replacements, written_path = await asyncio.to_thread(_execute_edit_sync, op, ctx)
     if replacements is not None:
         # Order matches pre-#2782 behavior: write_file_bytes's workspace_updated
         # emit ran BEFORE the handler's tool_executed emit.

--- a/src/reyn/core/op_runtime/path_locks.py
+++ b/src/reyn/core/op_runtime/path_locks.py
@@ -1,0 +1,92 @@
+"""Per-path in-process serialization lock registry — `file.py`'s same-path
+cross-op race guard (#2782, the path-locking step).
+
+#2794 offloaded ``edit_file``'s read-modify-write into ONE ``asyncio.to_thread``
+job — atomic WITHIN a single op (no ``await`` between the read and the write;
+see ``_execute_edit_sync``'s docstring in ``file.py``). But it removed the
+implicit cross-op serialization that single-threaded, single-event-loop
+execution used to provide: TWO concurrent same-path writer ops (e.g. two
+``edit_file`` calls, or an ``edit_file``/``write_file`` pair) now each run
+their read-modify-write independently — both read, both compute, both write —
+and one write silently overwrites the other (a classic lost-update race).
+Concrete reachable paths: pipeline ``parallel``/``for_each`` fan-out (see
+``core/pipeline/executor.py``'s "read-modify-write race" docstring), concurrent
+sub-agents, concurrent A2A sessions sharing a ``base_dir``.
+
+The fix mirrors ``runtime/agent_locks.py``'s per-key, loop-aware
+``asyncio.Lock`` registry (same family, no new mechanism): an **in-process**
+(NOT flock/fcntl — deliberately single-process per ADR-0018; cross-process
+mutual exclusion is deferred to the A2A-server model, a separate initiative)
+``asyncio.Lock`` keyed by the RESOLVED absolute path, acquired by ``file.py``'s
+async op handlers across the whole read-modify-write / mutate call, released
+in ``finally`` (via ``async with``). Two concurrent ops on DIFFERENT paths
+never contend; two concurrent ops on the SAME path serialize.
+
+A dedicated registry (not a shared dict with ``agent_locks.py``) — paths and
+agent names are different key domains; sharing one dict risks an accidental
+collision and conflates two unrelated concerns. The MECHANISM is reused
+(identical loop-aware-keying pattern); the registry is not.
+
+Loop-aware keying (mirrors #1762's rationale in ``agent_locks.py``): an
+``asyncio.Lock`` binds to the event loop it is first awaited on; keying the
+registry by the running loop (not just the path) means each loop gets its own
+lock objects, so a lock created under one pytest-asyncio test's loop is never
+reused (and tripped) under a later test's loop. Production runs a single
+process-wide loop, so this is transparent there.
+"""
+from __future__ import annotations
+
+import asyncio
+import weakref
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import AsyncIterator
+
+# Per-running-loop registries of per-path locks. Keyed by the event loop so
+# each loop gets distinct lock objects (an asyncio.Lock is bound to the loop
+# it is awaited on). WeakKeyDictionary → a dead loop's locks are GC'd with it.
+# Callers must NOT mutate this directly; use ``get_path_lock`` /
+# ``locked_paths`` only.
+_LOCKS_BY_LOOP: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def get_path_lock(resolved_path: str) -> asyncio.Lock:
+    """Return the per-path ``asyncio.Lock`` for *resolved_path* on the running loop.
+
+    ``resolved_path`` MUST be the fully resolved absolute path (the same
+    string ``Workspace._resolve_write``/``_resolve_read`` would compute, e.g.
+    via ``file.py``'s ``_resolve_for_gate``) — two callers naming the same
+    file via different spellings (relative vs absolute, unresolved symlink)
+    would otherwise take out DIFFERENT locks and the guard would silently not
+    apply.
+
+    Identity guarantee: repeated calls with the same path **on the same loop**
+    return the **same** ``asyncio.Lock`` object; different paths yield
+    distinct objects. Different loops yield distinct objects by design
+    (mirrors ``agent_locks.get_agent_lock``, #1762).
+    """
+    loop = asyncio.get_running_loop()
+    per_loop = _LOCKS_BY_LOOP.get(loop)
+    if per_loop is None:
+        per_loop = {}
+        _LOCKS_BY_LOOP[loop] = per_loop
+    return per_loop.setdefault(resolved_path, asyncio.Lock())
+
+
+@asynccontextmanager
+async def locked_paths(*resolved_paths: str) -> AsyncIterator[None]:
+    """Acquire the per-path locks for every path in *resolved_paths*, held for
+    the duration of the ``async with`` block, released in reverse order on
+    exit (``AsyncExitStack``) — including on exception.
+
+    Multi-path callers (``move`` locks both source and destination) MUST go
+    through this helper rather than nesting ``async with get_path_lock(...)``
+    by hand: paths are deduplicated and then acquired in **sorted order**, a
+    fixed global ordering that prevents the classic two-lock deadlock (task A
+    locks src-then-dest while task B concurrently locks dest-then-src).
+    """
+    async with AsyncExitStack() as stack:
+        for path in sorted(set(resolved_paths)):
+            await stack.enter_async_context(get_path_lock(path))
+        yield

--- a/tests/test_file_path_lock_2782.py
+++ b/tests/test_file_path_lock_2782.py
@@ -1,0 +1,177 @@
+"""Tier 2: #2782 (path-locking step) — a per-path `asyncio.Lock`
+(`core.op_runtime.path_locks`) serializes concurrent same-path file writes.
+
+Background: #2794 offloaded `edit_file`'s read-modify-write into ONE
+`asyncio.to_thread` job — atomic WITHIN a single op, since no `await` appears
+between the read and the write (see `_execute_edit_sync`'s docstring in
+`file.py`). But it removed the implicit cross-op serialization that
+single-threaded, single-event-loop execution used to provide: TWO concurrent
+`edit_file` ops on the SAME path now run their read-modify-write in DIFFERENT
+worker threads — both read the pre-edit content, both compute independently,
+both write — and whichever writes last wins outright, silently discarding the
+other op's edit (a classic read-modify-write lost-update race). Concrete
+reachable paths: pipeline `parallel`/`for_each` fan-out, concurrent
+sub-agents, concurrent A2A sessions sharing a `base_dir`.
+
+`test_file_ops_offload_2782.py` (the #2794 PR) explicitly deferred this case:
+"Path-locking ... is explicitly DEFERRED ... not tested here." This module
+is that follow-up.
+
+Real `Workspace`/`EventLog`/`OpContext`/`file.handle`/`asyncio.gather`
+throughout — no mocks, no `unittest.mock`. `file.handle` is the actual
+production op-dispatch entry point (the same function every tool-catalog
+frontend — router `edit_file`/`write_file`, phase `file` op — ultimately
+calls; see `test_op_runtime_file_mkdir_move_stat.py` for the same direct-call
+convention). The only "fake" is a `threading.Barrier` wrapped around
+`Workspace.read_file_bytes` in the primary guard test, used purely to force a
+DETERMINISTIC race window (both threads' reads land before either write)
+instead of relying on OS thread-scheduling luck — this is standard practice
+for reproducing a race condition on demand, not a mock of a collaborator: the
+real `read_file_bytes` still runs, wrapped, not replaced.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={"file.read": "allow", "file.write": "allow"},
+        project_root=tmp_path,
+        interactive=False,
+    )
+
+
+def _ctx(tmp_path: Path) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events, permission_resolver=_resolver(tmp_path), base_dir=tmp_path)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=_resolver(tmp_path),
+        actor="test_skill",
+    )
+
+
+def test_concurrent_edit_file_same_path_both_edits_survive(tmp_path):
+    """Tier 2: #2782 — the load-bearing guard. Two concurrent `edit` ops on
+    the SAME path, making DIFFERENT edits, launched via `asyncio.gather`
+    through the real op-dispatch path (`file.handle` -> `_execute_edit` ->
+    `asyncio.to_thread(_execute_edit_sync, ...)`). Both edits must survive in
+    the final on-disk content — no lost update.
+
+    A `threading.Barrier(2, timeout=...)` wraps `Workspace.read_file_bytes`
+    so BOTH worker threads' reads are forced to land before either write
+    proceeds — this is the exact interleaving the lost-update race requires.
+    With the per-path lock in place, the second op's `to_thread` job cannot
+    even START until the first op's lock is released (after ITS write has
+    landed), so the barrier's second party never arrives in time; it times
+    out (`BrokenBarrierError`, caught) and each op proceeds having read
+    strictly AFTER the other's write — genuinely serialized, not merely
+    lucky timing.
+    """
+    (tmp_path / "shared.txt").write_text("AAA line\nBBB line\n")
+    ctx = _ctx(tmp_path)
+
+    barrier = threading.Barrier(2)
+    orig_read = ctx.workspace.read_file_bytes
+
+    def _synced_read(path_str):
+        data = orig_read(path_str)
+        try:
+            barrier.wait(timeout=0.5)
+        except threading.BrokenBarrierError:
+            pass
+        return data
+
+    ctx.workspace.read_file_bytes = _synced_read
+
+    op_a = FileIROp(kind="file", op="edit", path="shared.txt", old_string="AAA", new_string="aaa")
+    op_b = FileIROp(kind="file", op="edit", path="shared.txt", old_string="BBB", new_string="bbb")
+
+    async def _run():
+        return await asyncio.gather(handle(op_a, ctx), handle(op_b, ctx))
+
+    result_a, result_b = asyncio.run(_run())
+
+    assert result_a["status"] == "ok", result_a
+    assert result_b["status"] == "ok", result_b
+    final = (tmp_path / "shared.txt").read_text()
+    assert "aaa" in final, f"lost update: edit A's change is missing from final content {final!r}"
+    assert "bbb" in final, f"lost update: edit B's change is missing from final content {final!r}"
+    assert "AAA" not in final and "BBB" not in final, (
+        f"an edit target string survived unreplaced — a partial/corrupted merge: {final!r}"
+    )
+
+
+def test_concurrent_edit_and_write_same_path_no_lost_update(tmp_path):
+    """Tier 2: #2782 fix-class completeness — `write` is a DIFFERENT op kind
+    than `edit` but mutates the same path, so it must acquire the SAME
+    per-path lock. A concurrent `edit` (read-modify-write, offloaded to a
+    worker thread) and `write` (blind overwrite, on the event-loop thread) on
+    the SAME path must not interleave: whichever runs second must see a
+    coherent full result, never a torn merge of the two."""
+    (tmp_path / "shared2.txt").write_text("original\n")
+    ctx = _ctx(tmp_path)
+
+    op_edit = FileIROp(kind="file", op="edit", path="shared2.txt", old_string="original", new_string="edited")
+    op_write = FileIROp(kind="file", op="write", path="shared2.txt", content="replaced\n")
+
+    async def _run():
+        return await asyncio.gather(handle(op_edit, ctx), handle(op_write, ctx))
+
+    result_edit, result_write = asyncio.run(_run())
+
+    # Whichever op the runtime happens to serialize first, EACH op must see a
+    # coherent, fully-applied outcome: the write is unconditional
+    # (`status == "ok"`) and the edit either succeeds against "original" (it
+    # ran first) or fails cleanly with `old_string not found` (it ran second,
+    # against "replaced\n" — never a torn/partial read).
+    assert result_write["status"] == "ok", result_write
+    assert result_edit["status"] in ("ok", "error"), result_edit
+    final = (tmp_path / "shared2.txt").read_text()
+    assert final in ("edited\n", "replaced\n"), (
+        f"final content must be a CLEAN result of one full op, not a torn merge: {final!r}"
+    )
+
+
+def test_move_reversed_src_dest_does_not_deadlock(tmp_path):
+    """Tier 2: #2782 — `move` acquires locks on BOTH its source and dest path
+    via `path_locks.locked_paths`, which sorts paths (a FIXED global order)
+    before acquiring them. Two concurrent moves over the SAME two paths with
+    REVERSED src/dest (`a.txt`->`b.txt` concurrently with `b.txt`->`a.txt`)
+    are the classic two-lock deadlock shape: naive src-then-dest acquisition
+    would have op1 hold `a.txt` while waiting on `b.txt`, and op2 hold `b.txt`
+    while waiting on `a.txt` — neither can ever proceed. Sorting first means
+    BOTH ops always take `a.txt` before `b.txt` regardless of which is
+    "source" — no deadlock, whichever move lands first (the runtime makes no
+    ordering promise between two concurrent ops on overlapping paths, only
+    mutual exclusion). Bounded via `asyncio.wait_for` so a regression back to
+    unordered acquisition fails as a timeout, not a silent hang."""
+    (tmp_path / "a.txt").write_text("A\n")
+    (tmp_path / "b.txt").write_text("B\n")
+    ctx = _ctx(tmp_path)
+
+    op_1 = FileIROp(kind="file", op="move", path="a.txt", dest_path="b.txt")
+    op_2 = FileIROp(kind="file", op="move", path="b.txt", dest_path="a.txt")
+
+    async def _run():
+        return await asyncio.wait_for(asyncio.gather(handle(op_1, ctx), handle(op_2, ctx)), timeout=5.0)
+
+    result_1, result_2 = asyncio.run(_run())
+    # The point is completion without deadlock — whichever move the runtime
+    # happens to serialize first relocates its source out from under the
+    # other, so the second observes `not_found`; either outcome is a clean
+    # completion, not a hang.
+    assert result_1["status"] in ("ok", "not_found"), result_1
+    assert result_2["status"] in ("ok", "not_found"), result_2


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2782

## Problem
#2794 offloaded `edit_file`'s read-modify-write into ONE `asyncio.to_thread` job — atomic *within* a single op (no `await` between read and write). But it removed the implicit cross-op serialization that single-threaded, single-event-loop execution used to provide. **Demonstrated race**: two concurrent `edit_file` ops on the SAME path now run in different worker threads → both read the pre-edit content → both write → one edit is silently lost (classic read-modify-write lost update). Reachable paths: pipeline `parallel`/`for_each` fan-out (see `core/pipeline/executor.py`'s "read-modify-write race" docstring), concurrent sub-agents, concurrent A2A sessions sharing a `base_dir`.

## Fix (architect recommendation D — in-process, NOT flock)
New `src/reyn/core/op_runtime/path_locks.py`: a process-global, **loop-aware** registry of per-path `asyncio.Lock`s keyed by the **resolved absolute path**. This mirrors the existing `runtime/agent_locks.py` per-key lock family (same mechanism + the #1762 loop-aware-keying rationale — a lock is bound to the loop it's first awaited on; keying by running loop keeps each pytest-asyncio loop isolated). A **dedicated** registry (not shared with `agent_locks`) because paths and agent names are different key domains. Locks are acquired at the **async op layer** in `file.py`, held across the whole read-modify-write / mutate, released in `finally` via `async with`.

In-process by design (ADR-0018 single-process end-state; cross-process mutual exclusion is deferred to the A2A-server model, a separate initiative) — deliberately **not** flock/fcntl. The single-writer server model architecturally backs this choice.

### Op-scope enumeration (fix-class completeness sweep)
Every op in `file.py` that MUTATES a path now takes the SAME per-path lock, so a concurrent edit+write (or edit+delete) on one path also serializes:

| op | locks | why |
|----|-------|-----|
| `edit` | `path` (across the `to_thread` read-modify-write) | the demonstrated race |
| `write` | `path` (across the encoding pre-read + `write_file`) | a blind overwrite straddling a concurrent edit's read/write would discard the edit |
| `delete` | `path` | a concurrent edit reading before / writing after a delete would "resurrect" the file |
| `regenerate_index` | `output_path` (the file actually written — NOT the source dir it reads) | same-path writer completeness; error branches touch no disk, run outside the lock |
| `move` | **both** `src` + `dst` via `locked_paths(...)` | move is effectively delete(src)+write(dst) |

**Deadlock-ordering note (move):** `move` locks two paths. `locked_paths()` deduplicates and acquires in **sorted resolved-path order** (a fixed global ordering) so two concurrent moves over the same two paths with reversed src/dest (`a→b` ∥ `b→a`) — the classic two-lock deadlock shape — always take `a` before `b` regardless of role, and cannot deadlock.

Read-only ops (`read`/`glob`/`grep`/`stat`) and `mkdir` (dir creation, not a same-path file write) are unchanged.

## Guard test (load-bearing) + cp-falsify RED
`tests/test_file_path_lock_2782.py` (Tier 2, real `Workspace`/`EventLog`/`OpContext`/`file.handle`/`asyncio.gather` — no mocks):

1. **`test_concurrent_edit_file_same_path_both_edits_survive`** — 2 concurrent `edit` ops making DIFFERENT edits via `asyncio.gather` through the real op-dispatch path. A `threading.Barrier` wraps `read_file_bytes` to *deterministically* force both reads before either write (the exact lost-update interleaving), rather than relying on scheduling luck. With the lock, the 2nd op's `to_thread` can't start until the 1st's lock releases (post-write), the barrier times out (caught), and both edits survive.
2. **`test_concurrent_edit_and_write_same_path_no_lost_update`** — cross-op-kind completeness: concurrent `edit`+`write` on one path → final content is a clean full result of one op, never a torn merge.
3. **`test_move_reversed_src_dest_does_not_deadlock`** — `a→b` ∥ `b→a`, bounded by `asyncio.wait_for` so a regression to unordered acquisition fails as a timeout not a hang.

**cp-falsify:** backed up `file.py` to scratch, removed the `edit` lock acquisition, re-ran the guard test **5×** → RED every time, reproducing the exact lost update (`'aaa line\nBBB line\n'` / `'AAA line\nbbb line\n'` — one edit silently gone). Restored via `cp` (never git on uncommitted work), confirmed byte-identical, re-ran → green.

## Test plan
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_file_path_lock_2782.py` — 3/3 OK, 0 Tier-4 violations
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK
- [x] `pytest` (full suite) — 8060 passed; 4 pre-existing unrelated failures (`test_a2a_routes_mounted` / `test_mcp_routes_mounted` / `test_plugin_loader` / `test_resources_router` — FastAPI route-mounting in this local env; verified they fail identically on clean origin/main with my change stashed)
- [x] Guard test passes with the fix; cp-falsify goes RED (5/5) with the lock removed, restored byte-identical
- [x] Existing file-op suites (`test_file_ops_offload_2782`, `test_op_runtime_file_mkdir_move_stat`, `test_file_edit_registry`, `test_edit_file_preview_1418`, `test_file_read_encoding_1452`) — 52 passed, no regressions

Do NOT merge — architect co-vets (they hold the live repro); lead merges on verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)