### PR TITLE
feat: P1 unify CUI onto a ClientTransport stream-consuming client (ADR-0039)

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -829,7 +829,7 @@ def _snapshot(registry, task_cache=None, config=None):
     }
 
 
-async def run_inline_input(registry, renderer, config=None) -> None:
+async def run_inline_input(registry, renderer, config=None, transport=None) -> None:
     """Run the interactive inline input Application until the user quits.
 
     Returns on quit (Ctrl-C/D/Q or /quit /exit) so run_repl can tear down (cost
@@ -839,6 +839,13 @@ async def run_inline_input(registry, renderer, config=None) -> None:
     ``_snapshot`` so the ``…`` overflow chip can list cron jobs / mcp servers /
     hooks. When None (--cui / non-inline path) the overflow panel shows empty
     sections — backward-compatible.
+
+    ``transport`` is the :class:`~reyn.interfaces.transport.client_transport.ClientTransport`
+    (ADR-0039 P1) this driver's WRITE side routes through — turn submit,
+    intervention answers, the user echo, cancel, and shutdown all go through the
+    transport's send seam rather than touching the session directly. (Status-bar
+    panel READS + the local command-UI plumbing still read the registry; a full
+    client-side read-model is P3.)
     """
     attached = registry.attached_session()
     if attached is None:
@@ -1100,7 +1107,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         # plain text, intervention answers, other slash — flows through
         # submit_user_text and routes inside the session unchanged.
         if stripped in ("/quit", "/exit"):
-            event.app.create_background_task(_quit(registry, event.app, quitting))
+            event.app.create_background_task(_quit(transport, event.app, quitting))
         else:
             # Echo the submitted line into the scrollback BEFORE the turn runs.
             # The live input field is cleared on submit (buf.reset above), so
@@ -1110,8 +1117,8 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             # it lands just above the agent reply — mirroring the PromptSession
             # path, where the typed line stays committed in the terminal.
             from reyn.runtime.outbox import OutboxMessage
-            registry.repl_outbox.put_nowait(OutboxMessage(kind="user", text=stripped))
-            event.app.create_background_task(_submit(registry, stripped))
+            transport.put_display(OutboxMessage(kind="user", text=stripped))
+            event.app.create_background_task(_submit(transport, stripped))
 
     # Owner spec: Enter=submit, Shift+Enter=newline. See the module-level
     # _SHIFT_ENTER_RAW_DATA / _is_shift_enter_escape / _down_arrow_action
@@ -1189,7 +1196,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             _cat_close()
         else:
             _menu_close()
-        app.create_background_task(_submit(registry, text))
+        app.create_background_task(_submit(transport, text))
 
     def _fill_menu_region(expansion, snap, *, live_task: bool = False) -> None:
         """Build one chip/category's element(s) fresh and host them in
@@ -1331,14 +1338,14 @@ async def run_inline_input(registry, renderer, config=None) -> None:
             rc = getattr(renderer, "request_cancel", None)
             if callable(rc):
                 rc()
-            event.app.create_background_task(_cancel_turn(registry))
+            event.app.create_background_task(_cancel_turn(transport))
         else:
-            event.app.create_background_task(_quit(registry, event.app, quitting))
+            event.app.create_background_task(_quit(transport, event.app, quitting))
 
     @kb.add("c-d")
     @kb.add("c-q")
     def _quit_key(event) -> None:
-        event.app.create_background_task(_quit(registry, event.app, quitting))
+        event.app.create_background_task(_quit(transport, event.app, quitting))
 
     # Above-region focus navigation (inert until a consumer registers an element,
     # since the region stays invisible + unfocusable while empty). ↑↓ move the
@@ -1382,7 +1389,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         s = registry.attached_session()
         if s is not None:
             s.set_pending_command_ui(None)  # consume the request
-        app.create_background_task(_submit(registry, text))
+        app.create_background_task(_submit(transport, text))
 
     def _sync_region() -> None:
         """Sync the above-region with the session's pending UI: the head closed-set
@@ -1398,7 +1405,7 @@ async def run_inline_input(registry, renderer, config=None) -> None:
                 _show(build_intervention_element(
                     head,
                     lambda cid, label: app.create_background_task(
-                        _deliver_intervention_choice(registry, cid, label)
+                        _deliver_intervention_choice(transport, cid, label)
                     ),
                 ), key)
             return
@@ -1478,20 +1485,18 @@ async def run_inline_input(registry, renderer, config=None) -> None:
         task_poll_task.cancel()
 
 
-async def _deliver_intervention_choice(registry, choice_id: str, label: str) -> None:
+async def _deliver_intervention_choice(transport, choice_id: str, label: str) -> None:
     """Deliver a region-selected intervention choice + echo it to scrollback.
 
-    The chosen choice id is delivered authoritatively (choice_id_override). On
-    success, a uniform ``answered: <label>`` line is put on the outbox so EVERY
-    resolved intervention leaves a trace in the conversation — not just the ones
-    (like permission) whose side effect happens to be visible. ask_user /
+    The chosen choice id is delivered authoritatively via the transport send
+    seam (``answer_intervention_choice``). On success, a uniform
+    ``answered: <label>`` line is put on the display stream so EVERY resolved
+    intervention leaves a trace in the conversation — not just the ones (like
+    permission) whose side effect happens to be visible. ask_user /
     safety-limit interventions otherwise vanish from scrollback on resolution.
     """
-    s = registry.attached_session()
-    if s is None:
-        return
     try:
-        delivered = await s.answer_oldest_intervention_choice(choice_id)
+        delivered = await transport.answer_intervention_choice(choice_id)
     except Exception:
         logger.exception("inline: delivering intervention choice failed")
         return
@@ -1503,29 +1508,26 @@ async def _deliver_intervention_choice(registry, choice_id: str, label: str) -> 
         # persist, but renders with the amber ◆ "needs-you" glyph — misleading for
         # a resolved-answer confirmation. "system" correctly signals historical
         # record (same visual weight as compaction / budget-warn markers).
-        registry.repl_outbox.put_nowait(
+        transport.put_display(
             OutboxMessage(kind="system", text=f"answered: {label}")
         )
 
 
-async def _submit(registry, text: str) -> None:
-    s = registry.attached_session()
-    if s is None:
-        return
+async def _submit(transport, text: str) -> None:
     # Launched as a background task, so an uncaught error here goes to asyncio's
     # exception handler (invisible above the live app) and the user sees the input
     # field clear with no response — a silent failure. Contain it: log + surface a
-    # visible error line via the outbox the output loop already drains.
+    # visible error line via the transport's display seam the output loop drains.
     try:
         # Route free-text input to any pending free-text intervention rather than
         # starting a new chat turn. Free-text = no choices (ask_user, mcp_install.secret,
         # etc.). Closed-set interventions (choices non-empty) are handled by the region
         # dropdown and never reach this path — matching build_intervention_element logic.
-        head = s.interventions.head()
+        head = transport.pending_intervention_head()
         if head is not None and not head.choices:
-            await s.answer_oldest_intervention_text(text)
+            await transport.answer_intervention_text(text)
             return
-        await s.submit_user_text(text)
+        await transport.submit_user_text(text)
     except Exception as e:
         logger.exception("inline submit failed")
         detail = f"{type(e).__name__}: {e}"
@@ -1533,27 +1535,22 @@ async def _submit(registry, text: str) -> None:
             detail = detail[:69] + "…"
         try:
             from reyn.runtime.outbox import OutboxMessage
-            registry.repl_outbox.put_nowait(
+            transport.put_display(
                 OutboxMessage(kind="error", text=f"input could not be submitted: {detail}")
             )
         except Exception:
             pass
 
 
-async def _cancel_turn(registry) -> None:
-    """Cancel the in-flight turn via session.cancel_inflight() — cooperative seam."""
-    s = registry.attached_session()
-    if s is None:
-        return
-    cancel_fn = getattr(s, "cancel_inflight", None)
-    if callable(cancel_fn):
-        try:
-            await cancel_fn()
-        except Exception:
-            logger.exception("cancel_inflight failed")
+async def _cancel_turn(transport) -> None:
+    """Cancel the in-flight turn via the transport's cancel seam — cooperative."""
+    try:
+        await transport.cancel_inflight()
+    except Exception:
+        logger.exception("cancel_inflight failed")
 
 
-async def _quit(registry, app, state: dict) -> None:
+async def _quit(transport, app, state: dict) -> None:
     # Idempotent: shutdown has a grace window, so a second quit (rapid Ctrl-C /
     # `/quit` then Ctrl-C) could race the first to app.exit() ("Return value
     # already set"). The check+set is synchronous (before the first await), so in
@@ -1562,7 +1559,7 @@ async def _quit(registry, app, state: dict) -> None:
         return
     state["quitting"] = True
     try:
-        await registry.shutdown()
+        await transport.shutdown()
     except Exception:
         # Log and suppress — a shutdown exception must not prevent app.exit()
         # from running (the PT app would hang with no escape path).

--- a/src/reyn/interfaces/repl/repl.py
+++ b/src/reyn/interfaces/repl/repl.py
@@ -1,241 +1,34 @@
 """prompt_toolkit-based REPL for AgentRegistry-managed multi-agent chat.
 
-The REPL drains the registry-owned `repl_outbox` (always present, regardless
-of which agent is attached) and forwards user input to whichever agent is
-currently attached. Agent switching (`/attach <name>`) flips the registry's
-attached pointer; the REPL doesn't need to re-bind anything because both
-the input and output sides funnel through the registry.
+``run_repl`` is the composition root of the chat client (ADR-0039 P1): it
+constructs the :class:`~reyn.interfaces.transport.in_process.InProcessTransport`
+from the registry and wires the stream-consuming client
+(:mod:`reyn.interfaces.repl.stream_client`) to it. The client then consumes ONE
+unified frame stream (display outbox + the renderer-relevant chat-event subset)
+and routes user input back through the transport's send side, so a local run
+exercises the same client path a remote client (P2) will.
+
+Agent switching (`/attach <name>`) flips the registry's attached pointer; the
+transport's focus binding re-wires the chat-event subscription across the
+switch, and both the input and output sides funnel through the registry-owned
+``repl_outbox`` the transport drains.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import sys
-from collections import deque
 
 from prompt_toolkit import PromptSession
-from prompt_toolkit.application import run_in_terminal
-from prompt_toolkit.application.current import get_app_or_none
 from prompt_toolkit.history import FileHistory
-from prompt_toolkit.patch_stdout import patch_stdout
 
+from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.runtime.registry import AgentRegistry  # #312 PR-A: registry stays in the runtime pkg
 
-from ._clipboard import copy_to_clipboard_async
 from .renderer import ChatRenderer
+from .stream_client import run_input_loop, run_output_loop
 
 logger = logging.getLogger(__name__)
-
-# How many recent agent replies `/copy` can target (1 = newest).
-_COPY_BUFFER_MAX = 20
-
-
-def _copy_target(recent_replies, arg: str) -> tuple[str | None, str]:
-    """Pure: resolve a ``/copy`` arg against the newest-first reply buffer.
-
-    Returns ``(text_to_copy, status)``. ``text_to_copy`` is None when there is
-    nothing to copy — ``status`` then explains why (list view / empty buffer /
-    bad arg / out of range). ``recent_replies[0]`` is the newest reply.
-    """
-    arg = (arg or "").strip()
-    n_buf = len(recent_replies)
-
-    def _plural(n: int) -> str:
-        return "reply" if n == 1 else "replies"
-
-    if arg == "list":
-        if not n_buf:
-            return None, "no replies buffered yet"
-        return None, f"{n_buf} {_plural(n_buf)} buffered (/copy N — 1 = newest)"
-    n = 1
-    if arg:
-        if not arg.isdigit() or int(arg) < 1:
-            return None, f"bad /copy arg {arg!r}; use a number (1 = newest) or 'list'"
-        n = int(arg)
-    if not n_buf:
-        return None, "no agent reply to copy yet"
-    if n > n_buf:
-        return None, f"only {n_buf} {_plural(n_buf)} buffered"
-    return recent_replies[n - 1], ""
-
-
-async def _handle_copy_sentinel(recent_replies, arg: str):
-    """Resolve a ``/copy`` request and return a status OutboxMessage to render.
-
-    Replaces the unhandled ``__copy_last_reply__`` sentinel (a silent no-op
-    before this) with a real clipboard copy + a visible result line.
-    """
-    text, status = _copy_target(recent_replies, arg)
-    if text is not None:
-        ok, tool = await copy_to_clipboard_async(text)
-        status = (
-            f"copied reply to clipboard ({tool})" if ok
-            else "no clipboard tool found — install pbcopy / xclip / wl-copy / xsel"
-        )
-    return _simple_status(status)
-
-
-async def _input_loop(
-    registry: AgentRegistry,
-    prompt_session: PromptSession,
-    renderer: ChatRenderer,
-    reply_seen: asyncio.Event | None = None,
-) -> None:
-    is_tty = sys.stdin.isatty()
-    while True:
-        # Piped / scripted mode: pace input by reply availability. Without
-        # this gate, readline pulls every buffered line before the output
-        # loop renders the first reply — the per-turn `reply_seen.clear()`
-        # races with `set()`, and any later `wait_for(reply_seen)` may be
-        # satisfied by an earlier turn's reply instead of the current one.
-        # The gate serialises turns: read line N+1 only after turn N's
-        # reply has been rendered (or there is no pending turn at all).
-        # TTY mode is unaffected — interactive users may type ahead.
-        if not is_tty and reply_seen is not None:
-            await reply_seen.wait()
-
-        try:
-            if is_tty:
-                with patch_stdout():
-                    text = await prompt_session.prompt_async(
-                        renderer.prompt_text(),
-                        # Animated working indicator while a turn runs. None when
-                        # idle (default base renderer) → no toolbar shown.
-                        bottom_toolbar=renderer.bottom_toolbar,
-                        refresh_interval=0.1,
-                        # #2786: prompt_toolkit's default (True) swaps the
-                        # loop's asyncio exception handler for its own for the
-                        # duration of this call (application.py's
-                        # set_exception_handler_ctx contextmanager) -- and the
-                        # prompt-wait is most of the REPL's wall-clock time, so
-                        # that window masks #2637's durable
-                        # install_asyncio_exception_handler capture almost
-                        # permanently. False leaves reyn's handler wired
-                        # (prompt_toolkit's own KeyboardInterrupt/EOF handling
-                        # lives in the key-binding layer, not this handler, so
-                        # nothing else regresses -- see asyncio_diagnostics.py).
-                        set_exception_handler=False,
-                    )
-            else:
-                # Piped / scripted stdin: skip prompt_toolkit entirely. It
-                # otherwise emits cursor-movement escapes (`\x1b[1A\x1b[K`)
-                # that clutter logs and confuse line-buffered drivers.
-                line = await asyncio.get_event_loop().run_in_executor(
-                    None, sys.stdin.readline,
-                )
-                if not line:
-                    raise EOFError
-                text = line
-        except (EOFError, KeyboardInterrupt):
-            # The pacing gate above guarantees any in-flight reply has
-            # already been rendered before we read the next line, so we
-            # can shut down immediately without a drain timeout.
-            await registry.shutdown()
-            return
-        text = (text or "").strip()
-        if not text:
-            continue
-        if text in {"/quit", "/exit"}:
-            await registry.shutdown()
-            return
-        attached = registry.attached_session()
-        if attached is None:
-            renderer.message(_simple_status("no agent attached; try :agents"))
-            continue
-        await _route_input_line(attached, text, reply_seen)
-
-
-async def _route_input_line(attached, text: str, reply_seen: "asyncio.Event | None") -> None:
-    """Route one non-quit REPL line to the attached session.
-
-    A pending intervention (permission prompt, ask_user, safety-limit) suspends
-    the router turn on the intervention's future — and that turn is the SOLE
-    consumer of the session inbox, so an answer routed the ordinary way
-    (``submit_user_text`` → inbox) can never be dequeued while the turn is
-    blocked: the future is never resolved and the session hangs indefinitely
-    (#2690 — the file-write approval prompt "never resumes after answering y").
-    A non-slash line is therefore delivered DIRECTLY to the pending intervention
-    via ``answer_oldest_intervention_text`` (the same session seam the inline
-    CUI's concurrent region poll uses), bypassing the inbox so the future
-    resolves and the blocked turn resumes.
-
-    Ordinary turns (no pending intervention) still flow through
-    ``submit_user_text``; a ``/``-prefixed line is never an intervention answer,
-    so it is left on the normal slash/inbox path. The direct-delivery result is
-    checked so a race where the intervention resolves between the head-check and
-    the deliver falls back to a normal turn instead of being dropped.
-    """
-    if not text.startswith("/") and attached.interventions.head() is not None:
-        if await attached.answer_oldest_intervention_text(text):
-            return
-    # Mark a reply as in flight before submit so the pacing gate on the next
-    # iteration blocks until the output loop signals it. `/`-prefixed slash
-    # commands (`/list`, `/attach`, `/answer`, ...) bypass the router and emit
-    # only `status` (no router reply), so clearing the gate for them would
-    # deadlock the next pipe iteration. `/quit` and `/exit` are handled by the
-    # caller and never reach here.
-    if reply_seen is not None and not text.startswith("/"):
-        reply_seen.clear()
-    await attached.submit_user_text(text)
-
-
-async def _output_loop(
-    registry: AgentRegistry,
-    renderer: ChatRenderer,
-    reply_seen: asyncio.Event | None = None,
-) -> None:
-    is_tty = sys.stdout.isatty()
-    # Newest-first ring of recent agent replies so `/copy [N]` can grab the
-    # latest (or an older) reply and pipe it to the system clipboard.
-    recent_replies: deque[str] = deque(maxlen=_COPY_BUFFER_MAX)
-    while True:
-        msg = await registry.repl_outbox.get()
-        if msg.kind == "__end__":
-            return
-        if msg.kind == "agent":
-            recent_replies.appendleft(msg.text)
-        elif msg.kind == "__copy_last_reply__":
-            # /copy sentinel: resolve + copy, then render the result as a status
-            # line instead of the (unhandled) sentinel — no more silent no-op.
-            msg = await _handle_copy_sentinel(recent_replies, msg.text)
-        elif msg.kind == "__rewind_list__":
-            # /rewind picker (F4): the inline path shows a ↑↓ region selector
-            # (driven by session.pending_command_ui), so skip the text list there;
-            # the plain --cui path renders it as the fallback.
-            if renderer.uses_app_input():
-                continue
-            from reyn.runtime.outbox import OutboxMessage
-            # persistent kind (not transient "status") so the list stays readable
-            msg = OutboxMessage(kind="intervention", text=msg.text)
-        # On a real terminal: wrap in run_in_terminal so the prompt is cleared
-        # before output and redrawn after — required for ANSI/Rich to render
-        # cleanly without corrupting the prompt.
-        # On a pipe: print plainly, no prompt redraw, no cursor escapes.
-        #
-        # Contain a single message's render failure: this loop is the sole
-        # consumer of repl_outbox, so an uncaught exception here would end the
-        # loop, trip run_repl's FIRST_COMPLETED wait, and tear down the whole
-        # REPL for one bad message. Log and continue instead (CancelledError is
-        # BaseException, so shutdown cancellation still propagates). reply_seen
-        # is still signalled below so the input pacing gate never hangs.
-        try:
-            if is_tty and get_app_or_none() is not None:
-                await run_in_terminal(lambda m=msg: renderer.message(m))
-            else:
-                renderer.message(msg)
-        except Exception:
-            logger.exception("output loop: render failed for message kind=%r", msg.kind)
-        # Signal end-of-turn for the input loop's pacing gate. "agent" is
-        # the canonical reply kind; "error" also counts as turn-terminal so
-        # a failed router round doesn't deadlock the next iteration.
-        if reply_seen is not None and msg.kind in {"agent", "error"}:
-            reply_seen.set()
-
-
-def _simple_status(text: str):
-    """Build a status OutboxMessage for inline rendering (no async needed)."""
-    from reyn.runtime.outbox import OutboxMessage
-    return OutboxMessage(kind="status", text=text)
 
 
 async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=None) -> None:
@@ -247,7 +40,7 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
     ``config`` is the loaded ReynConfig (or None). When supplied it is threaded
     read-only to ``run_inline_input`` so the ``…`` overflow chip can surface
     cron / mcp / hooks state. The --cui / non-TTY path is not affected (it uses
-    ``_input_loop`` and never receives ``config``).
+    ``run_input_loop`` and never receives ``config``).
     """
     attached = registry.attached_session()
     if attached is None:
@@ -255,22 +48,24 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
 
     history_path = attached.workspace_dir / ".input_history"
 
-    # Bind the front-end listeners that must follow the FOCUSED session across
-    # agent switches, via the registry (it re-wires them on every /attach):
-    #  - the renderer's working-indicator chat-event callback (turn_started →
-    #    spinner, turn_settled → idle), used by both input paths, and
-    #  - the intervention listener channel so ask_user / cost-warn confirm /
-    #    permission prompts surface and can be answered. The session is built with
-    #    enforce_listener_presence=True, so without a registered listener every
-    #    intervention short-circuits to an empty answer (a silent auto-refuse);
-    #    DEFAULT_CHAT_CHANNEL_ID ("tui") mirrors the Textual TUI / chainlit mount.
-    # Binding here (not a direct subscribe to `attached`) is what makes both
-    # follow a `/attach <other>` instead of stranding on the initial session.
+    # The transport is the client's sole seam to the session. It composes the
+    # two pre-existing render paths behind ONE unified frame stream:
+    #  - the display outbox (session.outbox → forwarder → repl_outbox), and
+    #  - the renderer's working-indicator chat-event subset (turn_started →
+    #    spinner, turn_settled → idle, tool_called → Running <tool>, …).
+    # `start()` binds the focus-following chat-event subscription + the
+    # intervention listener channel (so ask_user / cost-warn / permission
+    # prompts surface and can be answered — the session is built with
+    # enforce_listener_presence=True, so an unregistered listener silently
+    # auto-refuses; DEFAULT_CHAT_CHANNEL_ID ("tui") mirrors the chainlit mount),
+    # and starts the outbox → frame pump. The binding follows the FOCUSED
+    # session across `/attach` (re-wired by the registry), so neither the
+    # working indicator nor the intervention channel strands on the old session.
     from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
-    registry.bind_focus_listeners(
-        on_chat_event=renderer.on_chat_event,
-        intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+    transport = InProcessTransport(
+        registry, intervention_channel=DEFAULT_CHAT_CHANNEL_ID
     )
+    transport.start()
 
     renderer.banner(attached.agent_name)
 
@@ -281,12 +76,12 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
     reply_seen.set()
 
     # Interactive TTY inline renderer → its own rule-bar Application input
-    # driver. --cui / non-TTY (pipe / script) keep the PromptSession `_input_loop`
-    # (plain invariance + the piped reply_seen pacing). _output_loop is shared:
-    # run_in_terminal prints above whichever input is live.
+    # driver. --cui / non-TTY (pipe / script) keep the PromptSession input loop
+    # (plain invariance + the piped reply_seen pacing). The output loop is
+    # shared: run_in_terminal prints above whichever input is live.
     if renderer.uses_app_input() and sys.stdin.isatty():
         from reyn.interfaces.inline.app import run_inline_input
-        inputs = asyncio.create_task(run_inline_input(registry, renderer, config))
+        inputs = asyncio.create_task(run_inline_input(registry, renderer, config, transport))
     else:
         from prompt_toolkit.styles import Style
         prompt_session: PromptSession[str] = PromptSession(
@@ -296,10 +91,10 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
             style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
         )
         inputs = asyncio.create_task(
-            _input_loop(registry, prompt_session, renderer, reply_seen)
+            run_input_loop(transport, prompt_session, renderer, reply_seen)
         )
     outputs = asyncio.create_task(
-        _output_loop(registry, renderer, reply_seen)
+        run_output_loop(transport, renderer, reply_seen)
     )
 
     try:
@@ -308,9 +103,9 @@ async def run_repl(registry: AgentRegistry, renderer: ChatRenderer, *, config=No
             {inputs, outputs}, return_when=asyncio.FIRST_COMPLETED,
         )
     finally:
-        # Unwire from the LIVE attached session (handles a switch before quit),
-        # then clear the binding.
-        registry.unbind_focus_listeners()
+        # Unwire the transport from the LIVE attached session (handles a switch
+        # before quit) and stop the frame pump.
+        transport.close()
         inputs.cancel()
         outputs.cancel()
         await asyncio.gather(inputs, outputs, return_exceptions=True)

--- a/src/reyn/interfaces/repl/stream_client.py
+++ b/src/reyn/interfaces/repl/stream_client.py
@@ -1,0 +1,263 @@
+"""The stream-consuming chat client (ADR-0039 P1).
+
+This module is the CLIENT half of the transport seam: it consumes a
+:class:`~reyn.interfaces.transport.client_transport.ClientTransport`'s unified
+frame stream and drives the renderer, and it routes user input back through the
+transport's send side. It is the plain / ``--cui`` (PromptSession) driver and
+the shared output loop for the interactive inline driver.
+
+The defining property is **single-writer by construction**: this module touches
+the world ONLY through the ``ClientTransport`` it is handed — it imports no
+``Session`` / ``Workspace`` / tool / registry surface (enforced by
+``tests/test_stream_client_single_writer_boundary.py``). One stream comes in;
+the renderer's two entry points (``message`` for display frames,
+``on_chat_event`` for event frames) go out, dispatched by frame tag. This is
+what makes the future remote client (P2) single-writer-safe for free: it is the
+same client, a different transport.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from collections import deque
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.application import run_in_terminal
+from prompt_toolkit.application.current import get_app_or_none
+from prompt_toolkit.patch_stdout import patch_stdout
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import FrameTag
+from reyn.runtime.outbox import OutboxMessage
+
+from ._clipboard import copy_to_clipboard_async
+from .renderer import ChatRenderer
+
+logger = logging.getLogger(__name__)
+
+# How many recent agent replies `/copy` can target (1 = newest).
+_COPY_BUFFER_MAX = 20
+
+
+def _copy_target(recent_replies, arg: str) -> tuple[str | None, str]:
+    """Pure: resolve a ``/copy`` arg against the newest-first reply buffer.
+
+    Returns ``(text_to_copy, status)``. ``text_to_copy`` is None when there is
+    nothing to copy — ``status`` then explains why (list view / empty buffer /
+    bad arg / out of range). ``recent_replies[0]`` is the newest reply.
+    """
+    arg = (arg or "").strip()
+    n_buf = len(recent_replies)
+
+    def _plural(n: int) -> str:
+        return "reply" if n == 1 else "replies"
+
+    if arg == "list":
+        if not n_buf:
+            return None, "no replies buffered yet"
+        return None, f"{n_buf} {_plural(n_buf)} buffered (/copy N — 1 = newest)"
+    n = 1
+    if arg:
+        if not arg.isdigit() or int(arg) < 1:
+            return None, f"bad /copy arg {arg!r}; use a number (1 = newest) or 'list'"
+        n = int(arg)
+    if not n_buf:
+        return None, "no agent reply to copy yet"
+    if n > n_buf:
+        return None, f"only {n_buf} {_plural(n_buf)} buffered"
+    return recent_replies[n - 1], ""
+
+
+async def _handle_copy_sentinel(recent_replies, arg: str):
+    """Resolve a ``/copy`` request and return a status OutboxMessage to render.
+
+    Replaces the unhandled ``__copy_last_reply__`` sentinel (a silent no-op
+    before this) with a real clipboard copy + a visible result line.
+    """
+    text, status = _copy_target(recent_replies, arg)
+    if text is not None:
+        ok, tool = await copy_to_clipboard_async(text)
+        status = (
+            f"copied reply to clipboard ({tool})" if ok
+            else "no clipboard tool found — install pbcopy / xclip / wl-copy / xsel"
+        )
+    return _simple_status(status)
+
+
+def _simple_status(text: str) -> OutboxMessage:
+    """Build a status OutboxMessage for inline rendering (no async needed)."""
+    return OutboxMessage(kind="status", text=text)
+
+
+async def run_input_loop(
+    transport: ClientTransport,
+    prompt_session: PromptSession,
+    renderer: ChatRenderer,
+    reply_seen: "asyncio.Event | None" = None,
+) -> None:
+    is_tty = sys.stdin.isatty()
+    while True:
+        # Piped / scripted mode: pace input by reply availability. Without
+        # this gate, readline pulls every buffered line before the output
+        # loop renders the first reply — the per-turn `reply_seen.clear()`
+        # races with `set()`, and any later `wait_for(reply_seen)` may be
+        # satisfied by an earlier turn's reply instead of the current one.
+        # The gate serialises turns: read line N+1 only after turn N's
+        # reply has been rendered (or there is no pending turn at all).
+        # TTY mode is unaffected — interactive users may type ahead.
+        if not is_tty and reply_seen is not None:
+            await reply_seen.wait()
+
+        try:
+            if is_tty:
+                with patch_stdout():
+                    text = await prompt_session.prompt_async(
+                        renderer.prompt_text(),
+                        # Animated working indicator while a turn runs. None when
+                        # idle (default base renderer) → no toolbar shown.
+                        bottom_toolbar=renderer.bottom_toolbar,
+                        refresh_interval=0.1,
+                        # #2786: prompt_toolkit's default (True) swaps the
+                        # loop's asyncio exception handler for its own for the
+                        # duration of this call (application.py's
+                        # set_exception_handler_ctx contextmanager) -- and the
+                        # prompt-wait is most of the REPL's wall-clock time, so
+                        # that window masks #2637's durable
+                        # install_asyncio_exception_handler capture almost
+                        # permanently. False leaves reyn's handler wired
+                        # (prompt_toolkit's own KeyboardInterrupt/EOF handling
+                        # lives in the key-binding layer, not this handler, so
+                        # nothing else regresses -- see asyncio_diagnostics.py).
+                        set_exception_handler=False,
+                    )
+            else:
+                # Piped / scripted stdin: skip prompt_toolkit entirely. It
+                # otherwise emits cursor-movement escapes (`\x1b[1A\x1b[K`)
+                # that clutter logs and confuse line-buffered drivers.
+                line = await asyncio.get_event_loop().run_in_executor(
+                    None, sys.stdin.readline,
+                )
+                if not line:
+                    raise EOFError
+                text = line
+        except (EOFError, KeyboardInterrupt):
+            # The pacing gate above guarantees any in-flight reply has
+            # already been rendered before we read the next line, so we
+            # can shut down immediately without a drain timeout.
+            await transport.shutdown()
+            return
+        text = (text or "").strip()
+        if not text:
+            continue
+        if text in {"/quit", "/exit"}:
+            await transport.shutdown()
+            return
+        if not transport.has_session():
+            renderer.message(_simple_status("no agent attached; try :agents"))
+            continue
+        await route_input_line(transport, text, reply_seen)
+
+
+async def route_input_line(
+    transport: ClientTransport, text: str, reply_seen: "asyncio.Event | None"
+) -> None:
+    """Route one non-quit client line to the session via the transport.
+
+    A pending intervention (permission prompt, ask_user, safety-limit) suspends
+    the router turn on the intervention's future — and that turn is the SOLE
+    consumer of the session inbox, so an answer routed the ordinary way
+    (``submit_user_text`` → inbox) can never be dequeued while the turn is
+    blocked: the future is never resolved and the session hangs indefinitely
+    (#2690 — the file-write approval prompt "never resumes after answering y").
+    A non-slash line is therefore delivered DIRECTLY to the pending intervention
+    via the transport's ``answer_intervention_text`` seam (which wraps the same
+    session ``answer_oldest_intervention_text`` the inline CUI's concurrent
+    region poll uses), bypassing the inbox so the future resolves and the
+    blocked turn resumes.
+
+    Ordinary turns (no pending intervention) still flow through
+    ``submit_user_text``; a ``/``-prefixed line is never an intervention answer,
+    so it is left on the normal slash/inbox path. The direct-delivery result is
+    checked so a race where the intervention resolves between the head-check and
+    the deliver falls back to a normal turn instead of being dropped.
+    """
+    if not text.startswith("/") and transport.pending_intervention_head() is not None:
+        if await transport.answer_intervention_text(text):
+            return
+    # Mark a reply as in flight before submit so the pacing gate on the next
+    # iteration blocks until the output loop signals it. `/`-prefixed slash
+    # commands (`/list`, `/attach`, `/answer`, ...) bypass the router and emit
+    # only `status` (no router reply), so clearing the gate for them would
+    # deadlock the next pipe iteration. `/quit` and `/exit` are handled by the
+    # caller and never reach here.
+    if reply_seen is not None and not text.startswith("/"):
+        reply_seen.clear()
+    await transport.submit_user_text(text)
+
+
+async def run_output_loop(
+    transport: ClientTransport,
+    renderer: ChatRenderer,
+    reply_seen: "asyncio.Event | None" = None,
+) -> None:
+    is_tty = sys.stdout.isatty()
+    # Newest-first ring of recent agent replies so `/copy [N]` can grab the
+    # latest (or an older) reply and pipe it to the system clipboard.
+    recent_replies: deque[str] = deque(maxlen=_COPY_BUFFER_MAX)
+    async for frame in transport.frames():
+        # Event frame → the renderer's working-indicator entry point. The dual
+        # stream is dispatched by tag at the CONSUMING end so the renderer keeps
+        # its two entry points; an outbox-only stream would silently drop these
+        # (the A2 WaitingOn bug, designed out by the completeness gate).
+        if frame.tag is FrameTag.EVENT:
+            renderer.on_chat_event(frame.event)
+            continue
+        msg = frame.message
+        if msg.kind == "__end__":
+            return
+        if msg.kind == "agent":
+            recent_replies.appendleft(msg.text)
+        elif msg.kind == "__copy_last_reply__":
+            # /copy sentinel: resolve + copy, then render the result as a status
+            # line instead of the (unhandled) sentinel — no more silent no-op.
+            msg = await _handle_copy_sentinel(recent_replies, msg.text)
+        elif msg.kind == "__rewind_list__":
+            # /rewind picker (F4): the inline path shows a ↑↓ region selector
+            # (driven by session.pending_command_ui), so skip the text list there;
+            # the plain --cui path renders it as the fallback.
+            if renderer.uses_app_input():
+                continue
+            # persistent kind (not transient "status") so the list stays readable
+            msg = OutboxMessage(kind="intervention", text=msg.text)
+        # On a real terminal: wrap in run_in_terminal so the prompt is cleared
+        # before output and redrawn after — required for ANSI/Rich to render
+        # cleanly without corrupting the prompt.
+        # On a pipe: print plainly, no prompt redraw, no cursor escapes.
+        #
+        # Contain a single message's render failure: this loop is the sole
+        # consumer of the transport frame stream, so an uncaught exception here
+        # would end the loop, trip run_repl's FIRST_COMPLETED wait, and tear
+        # down the whole REPL for one bad message. Log and continue instead
+        # (CancelledError is BaseException, so shutdown cancellation still
+        # propagates). reply_seen is still signalled below so the input pacing
+        # gate never hangs.
+        try:
+            if is_tty and get_app_or_none() is not None:
+                await run_in_terminal(lambda m=msg: renderer.message(m))
+            else:
+                renderer.message(msg)
+        except Exception:
+            logger.exception("output loop: render failed for message kind=%r", msg.kind)
+        # Signal end-of-turn for the input loop's pacing gate. "agent" is
+        # the canonical reply kind; "error" also counts as turn-terminal so
+        # a failed router round doesn't deadlock the next iteration.
+        if reply_seen is not None and msg.kind in {"agent", "error"}:
+            reply_seen.set()
+
+
+__all__ = [
+    "route_input_line",
+    "run_input_loop",
+    "run_output_loop",
+]

--- a/src/reyn/interfaces/transport/__init__.py
+++ b/src/reyn/interfaces/transport/__init__.py
@@ -1,0 +1,31 @@
+"""Client-transport seam for the chat client (ADR-0039 P1).
+
+The inline CUI consumes its session through a single :class:`ClientTransport`
+seam — a unified, tagged frame stream (display + renderer-relevant chat-events)
+plus a send side — so a local run exercises the same client path a remote
+client (P2, AG-UI / SSE) will. :class:`InProcessTransport` is the local
+implementation composing the existing forwarder + chat-event subscription
+behind the seam; the frame vocabulary lives in
+:mod:`reyn.interfaces.transport.frames`.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import (
+    DisplayFrame,
+    EventFrame,
+    Frame,
+    FrameTag,
+    renderer_chat_events,
+)
+from reyn.interfaces.transport.in_process import InProcessTransport
+
+__all__ = [
+    "ClientTransport",
+    "DisplayFrame",
+    "EventFrame",
+    "Frame",
+    "FrameTag",
+    "InProcessTransport",
+    "renderer_chat_events",
+]

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -1,0 +1,85 @@
+"""``ClientTransport`` — the single seam between a chat client and its session.
+
+ADR-0039 P1 unifies the inline CUI's two direct render paths behind ONE
+transport seam so a local run exercises the same client path a remote client
+(P2, AG-UI / SSE) will. A ``ClientTransport`` presents the client with:
+
+- a unified, ordered, tagged frame stream (:meth:`frames`) merging the display
+  outbox and the renderer-relevant chat-event subset (see
+  :mod:`reyn.interfaces.transport.frames`); and
+- a send seam (:meth:`submit_user_text`, :meth:`answer_intervention_text`,
+  :meth:`answer_intervention_choice`, :meth:`put_display`,
+  :meth:`cancel_inflight`, :meth:`shutdown`) that wraps today's dispatch so the
+  client never touches ``Session`` / ``Workspace`` / tools directly.
+
+That last property is the **single-writer contract**: the client (renderer +
+input handling) writes to the world ONLY through the transport, which is what
+makes the future remote client single-writer-safe for free. The in-process
+implementation composes the existing forwarder + chat-event subscription behind
+this seam; a wire implementation (P2) is a second transport, not a second
+client codepath.
+
+This is an abstract base (not a bare Protocol) so a partial implementation
+fails at construction rather than silently at first use — the #1402
+completeness-by-construction discipline the ``PresentationConsumer`` seam uses.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, AsyncIterator
+
+if TYPE_CHECKING:
+    from reyn.interfaces.transport.frames import Frame
+    from reyn.runtime.outbox import OutboxMessage
+
+
+class ClientTransport(ABC):
+    """The client's sole seam to its session: a tagged frame stream + a send side."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Begin producing frames (wire up the display + chat-event sources)."""
+
+    @abstractmethod
+    def close(self) -> None:
+        """Stop producing frames and release the underlying subscriptions."""
+
+    @abstractmethod
+    def frames(self) -> "AsyncIterator[Frame]":
+        """Yield the unified, ordered, tagged frame stream (display + event)."""
+
+    @abstractmethod
+    async def submit_user_text(self, text: str) -> None:
+        """Submit a user turn (the ordinary new-turn path)."""
+
+    @abstractmethod
+    async def answer_intervention_text(self, text: str) -> bool:
+        """Deliver ``text`` to the oldest pending intervention; True iff delivered."""
+
+    @abstractmethod
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        """Deliver a chosen ``choice_id`` to the oldest intervention; True iff delivered."""
+
+    @abstractmethod
+    def has_session(self) -> bool:
+        """Whether a session is currently attached (client input guard)."""
+
+    @abstractmethod
+    def pending_intervention_head(self) -> "object | None":
+        """The oldest pending intervention handle, or None — client routing input."""
+
+    @abstractmethod
+    def put_display(self, msg: "OutboxMessage") -> None:
+        """Inject a client-authored display message (user echo, /copy result, …)
+        into the display stream, in order with the session's own output."""
+
+    @abstractmethod
+    async def cancel_inflight(self) -> None:
+        """Cooperatively cancel the in-flight turn (ctrl-c seam)."""
+
+    @abstractmethod
+    async def shutdown(self) -> None:
+        """Tear the session (and its registry) down — the /quit / EOF seam."""
+
+
+__all__ = ["ClientTransport"]

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -1,0 +1,111 @@
+"""Tagged frame vocabulary for the :mod:`reyn.interfaces.transport` client seam.
+
+The inline CUI historically consumed its session through **two independent
+source paths** (ADR-0039 P1): the display outbox (``session.outbox`` → the
+registry forwarder → ``repl_outbox`` → ``renderer.message``) and the
+chat-event subscription (``session.chat_events`` → ``renderer.on_chat_event``,
+which drives the Working / Running / Waiting-for-you indicator). A remote
+client, however, sees ONE ordered event stream (AG-UI / SSE, P2). This module
+defines the unified, tagged frame vocabulary that both the local
+``InProcessTransport`` and any future wire transport present to the client:
+
+- :class:`DisplayFrame` wraps a verbatim :class:`~reyn.runtime.outbox.OutboxMessage`
+  (the display path).
+- :class:`EventFrame` wraps the renderer-relevant *subset* of chat-events (the
+  working-indicator path).
+
+A frame carries its :class:`FrameTag` so the consuming client dispatches to the
+renderer's two entry points (``message`` for display, ``on_chat_event`` for
+event) at the consuming end — one stream in, two renderer entry points out.
+
+The forward-set (:func:`renderer_chat_events`) is **DERIVED** from the
+renderer's own vocabulary — ``_WAITING_ON_BY_EVENT`` (the tool-axis table) plus
+the turn / intervention-answer events ``on_chat_event`` handles — never
+hand-listed. The dual-stream completeness gate
+(``tests/test_transport_dual_stream_completeness.py``) binds the transport's
+coverage to that vocabulary so a renderer event the transport does not forward
+fails CI instead of silently vanishing on the wire (the A2 dual-stream bug,
+designed out).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.core.events.events import Event
+    from reyn.runtime.outbox import OutboxMessage
+
+
+class FrameTag(Enum):
+    """Which renderer entry point a frame dispatches to at the consuming end."""
+
+    DISPLAY = "display"  # → renderer.message(OutboxMessage)
+    EVENT = "event"      # → renderer.on_chat_event(Event)
+
+
+# The turn-lifecycle + intervention-answer chat-events the renderer's
+# ``on_chat_event`` consumes DIRECTLY (i.e. not via the ``_WAITING_ON_BY_EVENT``
+# tool-axis table). Kept here next to the derivation so the completeness gate
+# has a single, reviewable source for the non-tool half of the vocabulary.
+_TURN_AND_ANSWER_EVENTS = frozenset(
+    {
+        "turn_started",
+        "turn_settled",
+        "turn_completed",
+        "turn_cancelled",
+        "user_answered_intervention",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def renderer_chat_events() -> frozenset[str]:
+    """The exact set of chat-event types the renderer consumes — the transport's
+    forward-set, DERIVED from the renderer's vocabulary, never hand-listed.
+
+    Union of:
+
+    - ``_WAITING_ON_BY_EVENT.keys()`` (``interfaces/inline/app.py``) — the
+      tool-axis WaitingOn transition table (``tool_called`` / ``tool_returned``
+      / ``tool_failed``); extending WaitingOn to a new axis is one new entry
+      there and this set follows automatically.
+    - :data:`_TURN_AND_ANSWER_EVENTS` — the turn-lifecycle + intervention-answer
+      events ``renderer.on_chat_event`` branches on directly.
+
+    Deferred import avoids a module-load cycle (``app`` imports the renderer).
+    """
+    from reyn.interfaces.inline.app import _WAITING_ON_BY_EVENT
+
+    return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS
+
+
+@dataclass(frozen=True)
+class DisplayFrame:
+    """A display-path frame: one verbatim outbox message → ``renderer.message``."""
+
+    message: "OutboxMessage"
+    tag: FrameTag = FrameTag.DISPLAY
+
+
+@dataclass(frozen=True)
+class EventFrame:
+    """An event-path frame: one renderer-relevant chat-event → ``on_chat_event``."""
+
+    event: "Event"
+    tag: FrameTag = FrameTag.EVENT
+
+
+# A client consumes a stream of these; ``frame.tag`` selects the renderer entry.
+Frame = "DisplayFrame | EventFrame"
+
+
+__all__ = [
+    "DisplayFrame",
+    "EventFrame",
+    "Frame",
+    "FrameTag",
+    "renderer_chat_events",
+]

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -1,0 +1,166 @@
+"""``InProcessTransport`` — the local :class:`ClientTransport` (ADR-0039 P1).
+
+Composes the two EXISTING in-process delivery mechanisms behind the transport
+seam, changing *routing* only (delivery is unchanged, behavior byte-identical):
+
+- **Display path** — the registry's per-session outbox forwarder already pumps
+  ``session.outbox`` into ``registry.repl_outbox``. This transport drains that
+  queue in a background pump task and re-tags each message as a
+  :class:`~reyn.interfaces.transport.frames.DisplayFrame` on the unified stream.
+- **Event path** — a ``session.chat_events`` subscription (wired via the
+  registry's focus-listener binding, so it follows ``/attach``), *filtered to
+  the renderer's forward-set* (:func:`renderer_chat_events`), enqueues each
+  relevant event as an :class:`~reyn.interfaces.transport.frames.EventFrame` on
+  the SAME unified stream.
+
+The client drains one ordered stream (:meth:`frames`) and dispatches by tag —
+the local analogue of the single AG-UI/SSE event stream a remote client (P2)
+will consume. The send side wraps today's dispatch (``submit_user_text`` /
+``answer_oldest_intervention_*`` / ``repl_outbox`` echo / cancel / shutdown) so
+the client writes to the world ONLY through this seam (single-writer).
+
+The forward-set is injectable (``forward_events``, defaulting to the derived
+renderer vocabulary) purely so the P1 strip-falsify test can drop it and prove
+the event path is load-bearing; production always uses the derived default.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, AsyncIterator
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import (
+    DisplayFrame,
+    EventFrame,
+    Frame,
+    FrameTag,
+    renderer_chat_events,
+)
+
+if TYPE_CHECKING:
+    from reyn.core.events.events import Event
+    from reyn.runtime.outbox import OutboxMessage
+
+logger = logging.getLogger(__name__)
+
+
+class InProcessTransport(ClientTransport):
+    """The local transport: forwarder + filtered chat-events → one frame stream."""
+
+    def __init__(
+        self,
+        registry: "object",
+        *,
+        intervention_channel: str,
+        forward_events: "frozenset[str] | None" = None,
+    ) -> None:
+        # ``registry`` is the AgentRegistry (duck-typed here so the transport
+        # package carries no runtime import that the client would inherit). It
+        # owns ``repl_outbox``, the outbox forwarder, and the focus-listener
+        # binding this transport composes.
+        self._registry = registry
+        self._intervention_channel = intervention_channel
+        # DERIVED renderer vocabulary by default; injectable ONLY for the
+        # strip-falsify test (an empty set makes the event path vanish → RED).
+        self._forward_events = (
+            forward_events if forward_events is not None else renderer_chat_events()
+        )
+        self._frames: "asyncio.Queue[Frame]" = asyncio.Queue()
+        self._pump_task: "asyncio.Task | None" = None
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        # Event path: subscribe the FILTERED chat-event callback + the
+        # intervention channel via the registry's focus binding (follows
+        # /attach). Display path: pump repl_outbox into the unified stream.
+        self._registry.bind_focus_listeners(
+            on_chat_event=self._forward_chat_event,
+            intervention_channel=self._intervention_channel,
+        )
+        self._pump_task = asyncio.create_task(self._pump_outbox())
+
+    def close(self) -> None:
+        # Unwire from the LIVE attached session (handles a switch before quit).
+        self._registry.unbind_focus_listeners()
+        if self._pump_task is not None:
+            self._pump_task.cancel()
+            self._pump_task = None
+
+    # -- frame production ---------------------------------------------------
+
+    def _forward_chat_event(self, event: "Event") -> None:
+        # Synchronous subscriber (same mechanism as before): enqueue ONLY the
+        # renderer-relevant subset onto the unified stream. Non-renderer events
+        # are dropped here — the transport carries the renderer's vocabulary,
+        # not every chat-event.
+        etype = getattr(event, "type", None)
+        if etype in self._forward_events:
+            self._frames.put_nowait(EventFrame(event))
+
+    async def _pump_outbox(self) -> None:
+        # Re-tag the display outbox onto the unified stream, preserving order.
+        # Stops after forwarding the ``__end__`` control frame (session shutdown).
+        outbox = self._registry.repl_outbox
+        while True:
+            msg = await outbox.get()
+            self._frames.put_nowait(DisplayFrame(msg))
+            if msg.kind == "__end__":
+                return
+
+    async def frames(self) -> "AsyncIterator[Frame]":
+        while True:
+            frame = await self._frames.get()
+            yield frame
+            if frame.tag is FrameTag.DISPLAY and frame.message.kind == "__end__":
+                return
+
+    # -- send side ----------------------------------------------------------
+
+    def _attached(self) -> "object | None":
+        return self._registry.attached_session()
+
+    def has_session(self) -> bool:
+        return self._attached() is not None
+
+    def pending_intervention_head(self) -> "object | None":
+        s = self._attached()
+        return s.interventions.head() if s is not None else None
+
+    async def submit_user_text(self, text: str) -> None:
+        s = self._attached()
+        if s is not None:
+            await s.submit_user_text(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        s = self._attached()
+        if s is None:
+            return False
+        return bool(await s.answer_oldest_intervention_text(text))
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        s = self._attached()
+        if s is None:
+            return False
+        return bool(await s.answer_oldest_intervention_choice(choice_id))
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        # Client-authored display (user echo, /copy result, resolved-answer
+        # marker): route into the SAME outbox the forwarder drains so it lands
+        # in FIFO order with the session's own output, then re-tagged by the pump.
+        self._registry.repl_outbox.put_nowait(msg)
+
+    async def cancel_inflight(self) -> None:
+        s = self._attached()
+        if s is None:
+            return
+        cancel_fn = getattr(s, "cancel_inflight", None)
+        if callable(cancel_fn):
+            await cancel_fn()
+
+    async def shutdown(self) -> None:
+        await self._registry.shutdown()
+
+
+__all__ = ["InProcessTransport"]

--- a/tests/test_asyncio_diagnostics.py
+++ b/tests/test_asyncio_diagnostics.py
@@ -32,7 +32,7 @@ from prompt_toolkit.input import create_pipe_input
 from prompt_toolkit.output import DummyOutput
 
 import reyn.interfaces.inline.app as inline_app_mod
-import reyn.interfaces.repl.repl as repl_mod
+import reyn.interfaces.repl.stream_client as stream_client_mod
 from reyn.core.events.asyncio_diagnostics import install_asyncio_exception_handler
 
 
@@ -213,7 +213,7 @@ def test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler() -> No
     The durable-capture test above hardcodes the parameter in its own driver,
     so it would stay green even if a future edit dropped the argument from the
     production call sites -- i.e. it verifies the mechanism, not the wiring.
-    This pins the wiring itself: if ``interfaces/repl/repl.py``'s
+    This pins the wiring itself: if ``interfaces/repl/stream_client.py``'s
     ``prompt_session.prompt_async(...)`` (the ``--cui`` / non-TTY path) or
     ``interfaces/inline/app.py``'s ``app.run_async(...)`` (the default
     interactive ``reyn chat`` path) loses the argument, prompt_toolkit's
@@ -221,11 +221,11 @@ def test_repl_prompt_call_sites_disable_prompt_toolkit_exception_handler() -> No
     regression -- and this goes RED. Reads the real module source (AST), no
     mocks.
     """
-    repl_src = Path(repl_mod.__file__).read_text()
+    stream_client_src = Path(stream_client_mod.__file__).read_text()
     inline_src = Path(inline_app_mod.__file__).read_text()
 
-    assert _call_passes_set_exception_handler_false(repl_src, "prompt_async"), (
-        "repl.py's prompt_session.prompt_async(...) must pass "
+    assert _call_passes_set_exception_handler_false(stream_client_src, "prompt_async"), (
+        "stream_client.py's prompt_session.prompt_async(...) must pass "
         "set_exception_handler=False (else prompt_toolkit re-masks #2637 capture)"
     )
     assert _call_passes_set_exception_handler_false(inline_src, "run_async"), (

--- a/tests/test_copy_target_selection.py
+++ b/tests/test_copy_target_selection.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections import deque
 
-from reyn.interfaces.repl.repl import _copy_target
+from reyn.interfaces.repl.stream_client import _copy_target
 
 
 def test_default_selects_newest_reply() -> None:

--- a/tests/test_cui_permission_answer_resumes_2690.py
+++ b/tests/test_cui_permission_answer_resumes_2690.py
@@ -17,9 +17,12 @@ NOT hang because a default-zone (in-project) read is auto-allowed — it never
 raises an intervention. The out-of-zone WRITE is the first intervention-
 requiring permission, so it is the first to hit the dead answer-delivery path.
 
-The fix (``repl._route_input_line``) delivers a non-slash line directly to the
-pending intervention via ``answer_oldest_intervention_text``, bypassing the
-inbox so the future resolves.
+The fix (``stream_client.route_input_line``) delivers a non-slash line directly
+to the pending intervention via the transport's ``answer_intervention_text``
+seam (wrapping ``answer_oldest_intervention_text``), bypassing the inbox so the
+future resolves. Here the client's ``ClientTransport`` is the local
+``InProcessTransport`` over a single-session registry — the same seam production
+uses.
 
 Policy (docs/deep-dives/contributing/testing.md): real instances only — a real
 ``Session`` + real ``PermissionResolver`` + the real intervention/permission
@@ -36,17 +39,28 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from reyn.core.events.state_log import StateLog
-from reyn.interfaces.repl.repl import _route_input_line
+from reyn.interfaces.repl.stream_client import route_input_line
+from reyn.interfaces.transport.in_process import InProcessTransport
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.security.permissions.permissions import PermissionResolver
 
 _USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _transport_for(session) -> InProcessTransport:
+    """The local ClientTransport over a single-session registry — the production
+    send seam the ``--cui`` client routes input through."""
+    return InProcessTransport(
+        SimpleNamespace(attached_session=lambda: session),
+        intervention_channel=DEFAULT_CHAT_CHANNEL_ID,
+    )
 
 
 def _tool_call_result(name: str, args_json: str) -> LLMToolCallResult:
@@ -156,7 +170,7 @@ async def test_cui_write_approval_answer_resumes_blocked_turn(tmp_path, monkeypa
         # THE FIX under test: the --cui input loop delivers the typed answer to
         # the attached session. On the buggy tree this routes through
         # submit_user_text → inbox → never dequeued (deadlock).
-        await _route_input_line(session, "y", None)
+        await route_input_line(_transport_for(session), "y", None)
 
         assert await _poll(lambda: out.exists()), (
             "write never completed after answering y — the blocked turn did "
@@ -208,7 +222,7 @@ async def test_cui_read_approval_answer_resumes_identically(tmp_path, monkeypatc
         )
         assert session.interventions.head().kind == "permission.file.read"
 
-        await _route_input_line(session, "y", None)
+        await route_input_line(_transport_for(session), "y", None)
 
         assert await _poll(lambda: str(outside) in _granted_paths(session)), (
             "read never completed after answering y — the blocked turn did "

--- a/tests/test_inline_app_bgtask.py
+++ b/tests/test_inline_app_bgtask.py
@@ -13,9 +13,18 @@ from types import SimpleNamespace
 import pytest
 
 from reyn.interfaces.inline.app import _quit, _submit
+from reyn.interfaces.transport.in_process import InProcessTransport
+
+
+def _tx(registry):
+    """Wrap a fake registry in the real local transport — the send seam the
+    inline driver's helpers write through (no mocks)."""
+    return InProcessTransport(registry, intervention_channel="tui")
 
 
 class _RaisingSession:
+    interventions = SimpleNamespace(head=lambda: None)
+
     async def submit_user_text(self, text: str) -> None:
         raise RuntimeError("simulated submit failure")
 
@@ -28,7 +37,7 @@ async def test_submit_surfaces_error_instead_of_failing_silently() -> None:
         attached_session=lambda: _RaisingSession(),
         repl_outbox=asyncio.Queue(),
     )
-    await _submit(registry, "hello")  # must not raise out of the background task
+    await _submit(_tx(registry), "hello")  # must not raise out of the background task
     msg = registry.repl_outbox.get_nowait()
     assert msg.kind == "error"
     assert msg.text  # a non-empty, user-visible message
@@ -53,7 +62,7 @@ async def test_quit_is_idempotent_under_rapid_double_quit() -> None:
     app = _CountingApp()
     state: dict = {}
     await asyncio.gather(
-        _quit(registry, app, state),
-        _quit(registry, app, state),
+        _quit(_tx(registry), app, state),
+        _quit(_tx(registry), app, state),
     )
     assert app.exit_calls == 1

--- a/tests/test_inline_intervention_region.py
+++ b/tests/test_inline_intervention_region.py
@@ -15,6 +15,13 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.interfaces.inline.app import _deliver_intervention_choice, _submit
+from reyn.interfaces.transport.in_process import InProcessTransport
+
+
+def _tx(registry):
+    """Wrap a fake registry in the real local transport — the send seam the
+    inline driver's helpers write through (no mocks)."""
+    return InProcessTransport(registry, intervention_channel="tui")
 from reyn.interfaces.inline.intervention_region import (
     InterventionElement,
     build_intervention_element,
@@ -136,7 +143,7 @@ async def test_deliver_choice_echoes_answer_to_scrollback() -> None:
     queue: asyncio.Queue = asyncio.Queue()
     registry = SimpleNamespace(attached_session=lambda: session, repl_outbox=queue)
 
-    await _deliver_intervention_choice(registry, "just_path", "[j]ust this path always")
+    await _deliver_intervention_choice(_tx(registry), "just_path", "[j]ust this path always")
 
     assert session.delivered == ["just_path"]  # authoritative id delivered
     msg = queue.get_nowait()
@@ -155,7 +162,7 @@ async def test_deliver_choice_no_echo_when_nothing_delivered() -> None:
     registry = SimpleNamespace(
         attached_session=lambda: _AnsweringSession(ok=False), repl_outbox=queue
     )
-    await _deliver_intervention_choice(registry, "x", "lbl")
+    await _deliver_intervention_choice(_tx(registry), "x", "lbl")
     assert queue.empty()
 
 
@@ -232,7 +239,7 @@ async def test_submit_routes_to_intervention_bus_when_ask_user_pending() -> None
     build_intervention_element logic.
     """
     registry, answered, submitted = _stub_registry(choices=[])
-    await _submit(registry, "hello ask_user")
+    await _submit(_tx(registry), "hello ask_user")
 
     assert answered == ["hello ask_user"], "text must reach intervention bus"
     assert submitted == [], "submit_user_text must NOT be called while free-text iv pending"
@@ -248,7 +255,7 @@ async def test_submit_routes_to_intervention_bus_for_mcp_install_secret() -> Non
     secret that never arrives.
     """
     registry, answered, submitted = _stub_registry(choices=[])
-    await _submit(registry, "mysecretvalue")
+    await _submit(_tx(registry), "mysecretvalue")
 
     assert answered == ["mysecretvalue"], "secret must reach intervention bus"
     assert submitted == [], "submit_user_text must NOT be called for mcp_install.secret"

--- a/tests/test_repl_output_loop_containment.py
+++ b/tests/test_repl_output_loop_containment.py
@@ -1,20 +1,36 @@
-"""Tier 2: _output_loop contains a single message's render failure.
+"""Tier 2: run_output_loop contains a single message's render failure.
 
-The output loop is the sole consumer of the registry's repl_outbox, so an
-uncaught exception while rendering one message would end the loop and tear the
-whole REPL down. This drives the loop with a real queue and a recorder renderer
-that raises on one poison message, and asserts later messages still render (the
-loop survived) — before the fix the exception propagated out of _output_loop.
+The output loop is the sole consumer of the transport's unified frame stream,
+so an uncaught exception while rendering one display frame would end the loop
+and tear the whole REPL down. This drives the loop with a real frame stream and
+a recorder renderer that raises on one poison message, and asserts later
+messages still render (the loop survived) — before the fix the exception
+propagated out of the loop.
 """
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 
 import pytest
 
-from reyn.interfaces.repl.repl import _output_loop
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+
+
+class _FrameStreamTransport:
+    """A real ClientTransport double: yields a fixed sequence of display frames.
+
+    Only ``frames()`` is exercised by run_output_loop; the send side is unused
+    here, so this Fake implements just the consumed surface (no mocks).
+    """
+
+    def __init__(self, messages: list[OutboxMessage]) -> None:
+        self._messages = messages
+
+    async def frames(self):
+        for msg in self._messages:
+            yield DisplayFrame(msg)
 
 
 class _Recorder:
@@ -28,24 +44,28 @@ class _Recorder:
             raise RuntimeError("simulated render failure")
         self.seen.append(msg.text)
 
+    def on_chat_event(self, event) -> None:  # pragma: no cover - unused here
+        pass
+
+    def uses_app_input(self) -> bool:
+        return False
+
 
 @pytest.mark.asyncio
 async def test_output_loop_survives_a_render_exception() -> None:
     """Tier 2: a message whose render raises is skipped; the loop keeps
     draining and renders the messages after it."""
-    queue: asyncio.Queue = asyncio.Queue()
-    registry = SimpleNamespace(repl_outbox=queue)
+    messages = [
+        OutboxMessage(kind="agent", text="before"),
+        OutboxMessage(kind="agent", text="BOOM"),   # render raises here
+        OutboxMessage(kind="agent", text="after"),
+        OutboxMessage(kind="__end__", text=""),
+    ]
+    transport = _FrameStreamTransport(messages)
     renderer = _Recorder()
-    for text, kind in [
-        ("before", "agent"),
-        ("BOOM", "agent"),       # render raises here
-        ("after", "agent"),
-        ("", "__end__"),
-    ]:
-        await queue.put(OutboxMessage(kind=kind, text=text))
 
     # Before the fix this raises RuntimeError out of the loop; after, it returns.
-    await asyncio.wait_for(_output_loop(registry, renderer), timeout=2.0)
+    await asyncio.wait_for(run_output_loop(transport, renderer), timeout=2.0)
 
     assert "before" in renderer.seen
     assert "after" in renderer.seen      # the loop continued past the failure

--- a/tests/test_repl_simple_status.py
+++ b/tests/test_repl_simple_status.py
@@ -7,7 +7,7 @@ raise ModuleNotFoundError when the function runs, not at module load).
 """
 from __future__ import annotations
 
-from reyn.interfaces.repl.repl import _simple_status
+from reyn.interfaces.repl.stream_client import _simple_status
 from reyn.runtime.outbox import OutboxMessage
 
 

--- a/tests/test_stream_client_single_writer_boundary.py
+++ b/tests/test_stream_client_single_writer_boundary.py
@@ -1,0 +1,78 @@
+"""Tier 2: the stream-consuming client is single-writer by construction (P1).
+
+ADR-0039 P1's single-writer contract: the client (renderer + input handling)
+touches the world ONLY through its ``ClientTransport`` — never ``Session`` /
+``Workspace`` / tool / op-execution surface directly. This import-boundary AST
+guard (the scoped-factory / op-context single-source precedent) pins that the
+client modules import NONE of that writer surface, so the future remote client
+(P2) is single-writer-safe for free: it is the same client, a different
+transport.
+
+- ``stream_client`` is the fully-migrated reference client — it must import the
+  transport seam AND none of the writer surface.
+- ``inline/app`` is the interactive input driver — its send side routes through
+  the transport; it likewise imports none of the writer surface (its status-bar
+  READS reach the registry duck-typed, a P3 read-model concern, not an import).
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+# The writer surface the client must not import directly. ``runtime.outbox`` (the
+# display DTO) and ``interfaces.repl.renderer`` are display types, NOT this set.
+_FORBIDDEN_PREFIXES = (
+    "reyn.runtime.session",
+    "reyn.runtime.workspace",
+    "reyn.tools",
+    "reyn.core.op_runtime",
+)
+
+_CLIENT_MODULES = (
+    "interfaces/repl/stream_client.py",
+    "interfaces/inline/app.py",
+)
+
+
+def _imported_modules(rel: str) -> set[str]:
+    """Every module imported anywhere in the file (top-level or function-local)."""
+    tree = ast.parse((_SRC / rel).read_text(encoding="utf-8"))
+    mods: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            mods.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level == 0 and node.module:
+                mods.add(node.module)
+    return mods
+
+
+def _forbidden_hits(rel: str) -> list[str]:
+    return sorted(
+        mod
+        for mod in _imported_modules(rel)
+        if any(mod == p or mod.startswith(p + ".") for p in _FORBIDDEN_PREFIXES)
+    )
+
+
+def test_client_modules_do_not_import_writer_surface() -> None:
+    """Tier 2: neither client module imports Session / Workspace / tools /
+    op-execution — the single-writer import boundary. A new direct import of any
+    writer module fails here, naming module:file."""
+    offenders = {rel: _forbidden_hits(rel) for rel in _CLIENT_MODULES}
+    offenders = {rel: hits for rel, hits in offenders.items() if hits}
+    assert not offenders, (
+        "client module(s) import the writer surface directly — breaks the P1 "
+        f"single-writer boundary (route through the ClientTransport): {offenders}"
+    )
+
+
+def test_stream_client_uses_the_transport_seam() -> None:
+    """Tier 2: positive guard — the reference client imports the ClientTransport
+    seam, so the chokepoint is used, not bypassed."""
+    mods = _imported_modules("interfaces/repl/stream_client.py")
+    assert any(m.startswith("reyn.interfaces.transport") for m in mods), (
+        "stream_client must consume its session through reyn.interfaces.transport"
+    )

--- a/tests/test_transport_bit_identical.py
+++ b/tests/test_transport_bit_identical.py
@@ -1,0 +1,150 @@
+"""Tier 2: InProcessTransport is a behavior-preserving refactor (ADR-0039 P1).
+
+The P1 unification moves the inline CUI's two direct render paths (the display
+outbox and the renderer's chat-event subscription) behind ONE transport frame
+stream — routing only, delivery unchanged. This pins that byte-for-byte:
+
+- the DISPLAY sub-stream rendered THROUGH the transport (repl_outbox → pump →
+  frames → run_output_loop → renderer.message) is identical to the direct
+  ``renderer.message`` baseline; and
+- the EVENT sub-stream (chat_events → filtered subscription → frames →
+  renderer.on_chat_event) reproduces the identical WaitingOn / working-indicator
+  transition sequence as the direct ``renderer.on_chat_event`` baseline.
+
+The renderer is unchanged; only the source routing moved. Real instances only —
+a real ``InlineChatRenderer``, a real ``EventLog`` for chat_events, a real
+``repl_outbox`` queue behind a small registry double (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from io import StringIO
+
+import pytest
+
+from reyn.core.events.events import Event, EventLog
+from reyn.interfaces.repl.renderer import InlineChatRenderer
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+
+# A fixed monotonic clock makes the working-indicator fragments a deterministic
+# function of the WaitingOn STATE (elapsed = now - since = 0), so a frag-sequence
+# comparison IS a state-transition comparison — via the PUBLIC working_frags.
+_NOW = 10_000.0
+
+# Display frames spanning every renderer kind branch.
+_DISPLAY = [
+    OutboxMessage(kind="agent", text="hello [world] <ok>"),
+    OutboxMessage(kind="status", text="thinking about it"),
+    OutboxMessage(kind="error", text="something failed"),
+    OutboxMessage(kind="intervention", text="approve this? [y/N]"),
+    OutboxMessage(kind="trace", text="· ran a tool"),
+]
+
+# The event sub-stream: the full renderer vocabulary (turn lifecycle + the
+# tool-axis WaitingOn table + intervention-answer).
+_EVENTS = [
+    ("turn_started", {}),
+    ("tool_called", {"tool": "grep_files"}),
+    ("tool_returned", {}),
+    ("tool_failed", {}),
+    ("user_answered_intervention", {}),
+    ("turn_settled", {}),
+]
+
+
+class _RecordingInlineRenderer(InlineChatRenderer):
+    """A real InlineChatRenderer that records the working-indicator state after
+    each chat-event (public working_frags, fixed clock → deterministic)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.working_states: list = []
+
+    def on_chat_event(self, event) -> None:
+        super().on_chat_event(event)
+        self.working_states.append(self.working_frags(_NOW))
+
+
+class _FakeRegistry:
+    """Registry double: a real EventLog for chat_events + a real repl_outbox
+    queue + the focus-listener binding the transport composes. No mocks."""
+
+    def __init__(self) -> None:
+        self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        self.chat_events = EventLog()
+        self._cb = None
+
+    def bind_focus_listeners(self, *, on_chat_event=None, intervention_channel=None) -> None:
+        self._cb = on_chat_event
+        if on_chat_event is not None:
+            self.chat_events.add_subscriber(on_chat_event)
+
+    def unbind_focus_listeners(self) -> None:
+        if self._cb is not None:
+            self.chat_events.remove_subscriber(self._cb)
+            self._cb = None
+
+    def attached_session(self):
+        return None
+
+
+def _baseline(monkeypatch) -> tuple[str, list]:
+    """Direct-path baseline: renderer.on_chat_event + renderer.message directly."""
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    for etype, data in _EVENTS:
+        r.on_chat_event(Event(type=etype, data=data))
+    for msg in _DISPLAY:
+        r.message(msg)
+    return buf.getvalue(), r.working_states
+
+
+async def _via_transport(monkeypatch) -> tuple[str, list]:
+    """The same script routed THROUGH InProcessTransport + run_output_loop."""
+    fake = _FakeRegistry()
+    transport = InProcessTransport(fake, intervention_channel="tui")
+    transport.start()
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    try:
+        for etype, data in _EVENTS:
+            fake.chat_events.emit(etype, **data)
+        for msg in _DISPLAY:
+            fake.repl_outbox.put_nowait(msg)
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        await asyncio.wait_for(run_output_loop(transport, r), timeout=2.0)
+    finally:
+        transport.close()
+    return buf.getvalue(), r.working_states
+
+
+@pytest.mark.asyncio
+async def test_transport_render_and_status_bar_match_direct_path(monkeypatch) -> None:
+    """Tier 2: the display bytes AND the WaitingOn transition sequence produced
+    through the transport equal the direct-path baseline (behavior-preserving)."""
+    monkeypatch.setattr(time, "monotonic", lambda: _NOW)
+
+    base_stdout, base_states = _baseline(monkeypatch)
+    tx_stdout, tx_states = await _via_transport(monkeypatch)
+
+    # Display path: identical rendered bytes (renderer unchanged, frames verbatim).
+    assert tx_stdout == base_stdout
+    assert base_stdout  # sanity: the script actually rendered something
+
+    # Event path: identical WaitingOn / working-indicator transition sequence.
+    assert tx_states == base_states
+    # sanity: the sequence is non-trivial (Thinking → Running grep_files → …).
+    # working_line splits the label into per-character frags, so reconstruct it.
+    assert len(base_states) == len(_EVENTS)
+
+    def _label(frags) -> str:
+        return "".join(txt for _style, txt in frags)
+
+    running = [frags for frags in base_states if "grep_files" in _label(frags)]
+    assert running, "expected a 'Running grep_files' WaitingOn state from tool_called"

--- a/tests/test_transport_dual_stream_completeness.py
+++ b/tests/test_transport_dual_stream_completeness.py
@@ -1,0 +1,66 @@
+"""Tier 2: the transport forwards EVERY chat-event the renderer consumes (P1).
+
+FP-0056-isomorphic completeness gate — the structural form of the A2 dual-stream
+bug ("an outbox-only wire drops WaitingOn"). It enumerates the chat-event types
+the renderer's ``on_chat_event`` actually branches on — by AST-scanning the
+renderer source (the equality/membership literals) UNION the ``_WAITING_ON_BY_EVENT``
+tool-axis table — and asserts EACH is in the transport's forwarded set
+(``renderer_chat_events``). A renderer event the transport does not forward ⇒
+RED, so a future renderer event that isn't wired through the transport fails CI
+instead of silently vanishing on the wire.
+
+The enumeration reads the renderer's real code (not the transport's own
+derivation), so the two are bound independently — the gate is not circular.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from reyn.interfaces.inline.app import _WAITING_ON_BY_EVENT
+from reyn.interfaces.transport.frames import renderer_chat_events
+
+_RENDERER = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "reyn" / "interfaces" / "repl" / "renderer.py"
+)
+
+
+def _renderer_consumed_event_literals() -> set[str]:
+    """Every string literal the renderer's ``on_chat_event`` methods compare
+    ``etype`` against — the turn-lifecycle + intervention-answer half of the
+    vocabulary (the tool-axis half is the ``_WAITING_ON_BY_EVENT`` table).
+
+    Collecting only strings inside ``ast.Compare`` nodes excludes incidental
+    literals like ``getattr(event, "type")`` — those are Call args, not compares.
+    """
+    tree = ast.parse(_RENDERER.read_text(encoding="utf-8"))
+    consumed: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name == "on_chat_event"):
+            continue
+        for cmp_node in ast.walk(node):
+            if not isinstance(cmp_node, ast.Compare):
+                continue
+            for lit in ast.walk(cmp_node):
+                if isinstance(lit, ast.Constant) and isinstance(lit.value, str):
+                    consumed.add(lit.value)
+    return consumed
+
+
+def test_transport_forwards_every_renderer_consumed_chat_event() -> None:
+    """Tier 2: each chat-event the renderer consumes is in the transport's
+    forward-set. Un-forwarded ⇒ RED (the A2 dual-stream bug, designed out)."""
+    consumed = _renderer_consumed_event_literals() | set(_WAITING_ON_BY_EVENT.keys())
+    forwarded = renderer_chat_events()
+
+    # Sanity: the enumeration actually found the renderer's vocabulary (a broken
+    # scan that found nothing must not vacuously pass).
+    assert "turn_started" in consumed
+    assert {"tool_called", "tool_returned", "tool_failed"} <= consumed
+
+    missing = consumed - forwarded
+    assert not missing, (
+        "renderer consumes chat-events the transport does NOT forward — they "
+        f"would vanish on the wire (A2 dual-stream bug): {sorted(missing)}"
+    )

--- a/tests/test_transport_strip_falsify.py
+++ b/tests/test_transport_strip_falsify.py
@@ -1,0 +1,97 @@
+"""Tier 2: the transport's chat-event forward-set is LOAD-BEARING (ADR-0039 P1).
+
+Strip-falsify (the P1 analog of the strip-verification discipline): an
+``InProcessTransport`` whose forward-set is emptied delivers ZERO chat-events to
+the client, so the WaitingOn / Working / Running transitions vanish — RED. With
+the DERIVED forward-set (production default) the same chat-events reach the
+renderer. This proves the dual-stream event path is a real seam, not decorative
+— the structural counter-evidence for the A2 "outbox-only drops WaitingOn" bug.
+
+Real instances only — a real ``EventLog`` for chat_events + a real repl_outbox
+queue behind a small registry double; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.frames import renderer_chat_events
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+
+_EVENTS = [("turn_started", {}), ("tool_called", {"tool": "grep_files"}), ("turn_settled", {})]
+
+
+class _EventRecordingRenderer:
+    """Records the chat-event types the client actually delivers (real double)."""
+
+    def __init__(self) -> None:
+        self.events_seen: list[str] = []
+
+    def on_chat_event(self, event) -> None:
+        self.events_seen.append(getattr(event, "type", None))
+
+    def message(self, msg) -> None:  # pragma: no cover - display path unused here
+        pass
+
+    def uses_app_input(self) -> bool:
+        return False
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        self.chat_events = EventLog()
+        self._cb = None
+
+    def bind_focus_listeners(self, *, on_chat_event=None, intervention_channel=None) -> None:
+        self._cb = on_chat_event
+        if on_chat_event is not None:
+            self.chat_events.add_subscriber(on_chat_event)
+
+    def unbind_focus_listeners(self) -> None:
+        if self._cb is not None:
+            self.chat_events.remove_subscriber(self._cb)
+            self._cb = None
+
+    def attached_session(self):
+        return None
+
+
+async def _drive(forward_events) -> list[str]:
+    fake = _FakeRegistry()
+    transport = InProcessTransport(
+        fake, intervention_channel="tui", forward_events=forward_events
+    )
+    transport.start()
+    renderer = _EventRecordingRenderer()
+    try:
+        for etype, data in _EVENTS:
+            fake.chat_events.emit(etype, **data)
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        await asyncio.wait_for(run_output_loop(transport, renderer), timeout=2.0)
+    finally:
+        transport.close()
+    return renderer.events_seen
+
+
+@pytest.mark.asyncio
+async def test_derived_forward_set_delivers_chat_events() -> None:
+    """Tier 2: with the derived forward-set, the client receives the WaitingOn
+    chat-events (the event path is wired)."""
+    seen = await _drive(renderer_chat_events())
+    assert set(seen) == {"turn_started", "tool_called", "turn_settled"}
+
+
+@pytest.mark.asyncio
+async def test_stripped_forward_set_makes_waiting_on_vanish() -> None:
+    """Tier 2: strip-falsify — with the forward-set emptied, the client receives
+    NO chat-events → WaitingOn transitions vanish → RED for the event path."""
+    seen = await _drive(frozenset())
+    assert seen == [], (
+        "stripping the chat-event forward-set must drop ALL renderer chat-events; "
+        f"got {seen!r} — the event path is not actually gated by the forward-set"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — P1 of the thin-client / single-writer-server arc (ADR-0039 D2/D8, tracker #2805). P0 (server auth) merged; this is the `local ≡ remote` foundation. **Behavior-preserving refactor — routing only, no user-visible change.**

## The two paths unified (verified in-tree)
- **Path A (display):** `session.outbox` → per-session forwarder (`registry.py:_forwarder`) → `registry.repl_outbox` → the inline output loop → `renderer.message(OutboxMessage)`.
- **Path B (WaitingOn — load-bearing, easily missed):** `session.chat_events` → `subscribe_chat_events(renderer.on_chat_event)` wired via `registry.bind_focus_listeners` (was `repl.py:271`) → drives Working / Running / Waiting-for-you.

## The seam — `ClientTransport` (dual-stream → ONE tagged frame stream)
New package `src/reyn/interfaces/transport/`:
- `frames.py` — `FrameTag`, `DisplayFrame(OutboxMessage)`, `EventFrame(Event)`, and `renderer_chat_events()`.
- `client_transport.py` — the `ClientTransport` ABC (frames + send seam). An ABC, not a bare Protocol, so a partial impl fails at construction (#1402 completeness-by-construction, the `PresentationConsumer` discipline).
- `in_process.py` — `InProcessTransport(registry, *, intervention_channel, forward_events=None)`: composes the **existing** forwarder (`repl_outbox` → pump → `DisplayFrame`) + a **filtered** `chat_events` subscription (→ `EventFrame`) into ONE unified `asyncio.Queue`. **Delivery mechanism unchanged — only routing is abstracted.** The unified frame is exactly the P2 AG-UI/SSE mapping surface (one stream, not two channels that re-split on the wire).

The renderer keeps its **two entry points**; `run_output_loop` dispatches by `frame.tag` at the consuming end (display → `message`, event → `on_chat_event`).

## Derived forward-set (never hand-listed)
`renderer_chat_events()` = `_WAITING_ON_BY_EVENT.keys()` (`tool_called`/`tool_returned`/`tool_failed`) **∪** the turn/answer events (`turn_started`, `turn_settled`/`turn_completed`/`turn_cancelled`, `user_answered_intervention`) = **8 types**. Extending WaitingOn to a new axis is one entry in `_WAITING_ON_BY_EVENT` and this set follows automatically.

## Single-writer by construction
The stream-consuming client (`interfaces/repl/stream_client.py`, the plain/`--cui` reference client) imports **no** Session / Workspace / tool / op surface and touches the world ONLY through the transport (import-boundary AST guard). `run_repl` is the composition root that builds the transport from the registry. The interactive inline driver's **send side** (submit / answer / echo / cancel / quit) routes through the transport too; its status-panel **reads** remain on the registry — a P3 client-side read-model concern, explicitly deferred (documented in `run_inline_input`).

## Tests (4 — real instances, no mocks)
1. **bit-identical** (`test_transport_bit_identical.py`): drive the same script through `InProcessTransport` + `run_output_loop` vs the direct `renderer.message`/`on_chat_event` baseline; assert **display bytes** identical AND the **WaitingOn transition sequence** identical (fixed clock → `working_frags` is a deterministic function of the state, a public-surface comparison).
2. **dual-stream completeness gate** (`test_transport_dual_stream_completeness.py`, FP-0056-style): AST-enumerate the chat-event literals the renderer's `on_chat_event` compares against ∪ `_WAITING_ON_BY_EVENT.keys()`, assert **each ∈ forward-set**. Un-forwarded ⇒ RED. Non-circular (scans the renderer source, not the transport's own derivation) — kills the A2 "outbox-only drops WaitingOn" bug by design.
3. **single-writer import-boundary** (`test_stream_client_single_writer_boundary.py`): AST guard — `stream_client` + `inline/app` import none of `runtime.session`/`runtime.workspace`/`tools`/`core.op_runtime`; positive guard that `stream_client` imports the transport seam.
4. **strip-falsify** (`test_transport_strip_falsify.py`): default forward-set delivers the chat-events; `forward_events=frozenset()` ⇒ the client receives **zero** chat-events → WaitingOn transitions vanish → RED. Proves the event path is load-bearing.

## Out of scope (later phases)
Wire/AG-UI transport + present-on-wire (P2); seize/multi-client (P3+); network fail-close + grace (P3); the interactive driver's client-side read-model (P3).

## CI (all four gates green locally)
- `ruff check` — clean.
- `test_tier_audit.py --strict` (all changed test files) — 33/33 OK, 0 Tier-4.
- `pytest` — **8129 passed** against the worktree src. The only failures are 4 pre-existing `tests/web/` route-mounting/plugin-loader tests that **reproduce identically on pristine `origin/main`** (I touch nothing in `web/`).
- `verify_module_docstrings.py` — clean.

## Existing tests migrated to the seam (refactor-consequence)
`test_repl_output_loop_containment` (→ `run_output_loop` + frame-stream double), `test_cui_permission_answer_resumes_2690` (#2690 — `route_input_line` over `InProcessTransport`), `test_repl_simple_status` / `test_copy_target_selection` (moved helper import), `test_inline_intervention_region` / `test_inline_app_bgtask` (helpers now take a transport), `test_asyncio_diagnostics` (prompt call site moved to `stream_client`).

Do NOT merge — the architect co-vets against `P1_stream_client_spec.md`; lead merges on verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)