### PR TITLE
feat: P2 AG-UI transport — second ClientTransport over HTTP+SSE (ADR-0039)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -1,0 +1,120 @@
+# AG-UI transport — the thin-client wire protocol
+
+Reyn's chat client is a stream-consuming UI: it draws a session's output and
+routes user input, and it touches the session ONLY through a transport seam.
+There are two transports behind that one seam — a local in-process transport,
+and this **AG-UI transport** over HTTP + Server-Sent Events (SSE). Both feed the
+identical renderer, so a remote client draws byte-for-byte what a local one does.
+
+This page is the wire contract: the SSE endpoint, the reyn-frame ⇄ AG-UI-event
+mapping, and the `STATE_*` status read-model.
+
+## Surfaces
+
+The transport speaks **AG-UI only** — it is a UI, not an agent. (Agent↔agent is
+A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
+
+- `GET /agui/chat/{agent}/events` — the server→client SSE stream. Each SSE block
+  is `event: <TYPE>\ndata: <json>\n\n`.
+- `POST /agui/chat/{agent}` — the client→server channel. Body is a JSON object;
+  the current message type is `{"type": "user_message", "text": "..."}` (submit
+  a turn).
+
+Both are gated by the server's authentication context: a connection presents its
+token as `?token=` or an `Authorization: Bearer <token>` header (same-machine
+UDS connections are identified by OS peer credentials instead). An
+unauthenticated connection is refused with `401` before any session is attached.
+
+## Standard envelope, reyn-private richness
+
+Every event carries **both**:
+
+- a **standard AG-UI field shape**, so a generic AG-UI client renders the
+  interoperable core (text / tool / run / error / state); and
+- a reyn-private `_reyn` reconstruction block, from which the reyn client rebuilds
+  the exact render frame.
+
+A generic client ignores what it does not understand: an event with no `_reyn`
+block (or a reyn `CUSTOM` event a generic client does not model) is **skipped,
+not fatal** — reyn owns this ignore-unknown contract.
+
+## Event mapping
+
+The client consumes one ordered SSE stream and dispatches each event back to one
+of the renderer's two entry points (display vs working-indicator). The mapping:
+
+### Display path (agent output → the scrollback)
+
+| reyn display kind | AG-UI event        | Notes                                        |
+|-------------------|--------------------|----------------------------------------------|
+| `agent`           | `TEXT_MESSAGE_CONTENT` | the assistant reply text                  |
+| `status`          | `TEXT_MESSAGE_CONTENT` | transient status line (`role: status`)    |
+| `error`           | `RUN_ERROR`        | error text                                   |
+| `trace`           | `CUSTOM`           | reyn tool/step trace line                    |
+| `intervention`    | `CUSTOM`           | a prompt is displayed (answer round-trip is a later phase) |
+| `presentation`    | `CUSTOM`           | a `present` op's render-node model (see *present-on-wire*) |
+| control sentinels | `CUSTOM`           | `__end__` and client-local control kinds     |
+
+Any display kind not in this table still round-trips losslessly (it falls back to
+`CUSTOM` and is reconstructed from `_reyn`) — a new renderer kind can never
+silently vanish on the wire.
+
+### Working-indicator path (turn lifecycle + tool axis)
+
+| reyn chat-event               | AG-UI event      |
+|-------------------------------|------------------|
+| `turn_started`                | `RUN_STARTED`    |
+| `turn_settled` / `turn_completed` / `turn_cancelled` | `RUN_FINISHED` |
+| `tool_called`                 | `TOOL_CALL_START`|
+| `tool_returned` / `tool_failed` | `TOOL_CALL_END`|
+| `user_answered_intervention`  | `CUSTOM`         |
+
+These eight are the exact set the renderer's working / running / waiting-for-you
+indicator consumes; the transport forwards precisely this set.
+
+## present-on-wire
+
+A `present` op's render model is a `list[dict]` of render nodes, **neutralized at
+construction** (every leaf string stripped of terminal control / ESC sequences),
+so it is inert before it reaches any wire. It rides a `CUSTOM` event under the
+`presentation` display kind, carried in `meta.nodes`.
+
+The AG-UI client additionally re-runs the surface neutralizer over every node
+leaf **at the transport edge**, per connection — idempotent for a leaf the
+construction seam already neutralized, but load-bearing defense-in-depth for a
+heterogeneous-surface client whose upstream did not neutralize (or neutralized
+for a different surface).
+
+## STATE_* — the status read-model
+
+The status bar (attached agent, model, cost, tokens, context usage, and the
+current WaitingOn label) is a **read-model**, not a file mirror: it is derived
+from the session's live cost / token / context accessors and the working-indicator
+state, and only the render-relevant subset is streamed.
+
+- `STATE_SNAPSHOT` — emitted **on connect**, the full read-model. Fields:
+  `attached_name`, `model`, `cost_agent`, `cost_total`, `agent_tokens`,
+  `ctx_used`, `ctx_window`, `waiting_on`.
+- `STATE_DELTA` — emitted **on change**, carrying only the changed keys. An idle
+  stream emits no deltas.
+
+The client seeds its status view from the snapshot and merges each delta, so the
+remote status panel always reflects the server's values.
+
+## Reconnect
+
+On connect (or reconnect) the server replays, before any live event:
+
+1. `MESSAGES_SNAPSHOT` — the display backlog (the messages already produced), so
+   a reconnecting client rebuilds its scrollback; then
+2. `STATE_SNAPSHOT` — the status read-model above.
+
+Live events (and `STATE_DELTA`s) follow.
+
+## Local ≡ remote
+
+The server serializes the SAME unified frame stream the local in-process
+transport produces (display outbox + the renderer-relevant chat-event subset).
+The AG-UI transport adds only wire framing, never new render semantics — so the
+remote renderer's display bytes and working-indicator transitions are identical
+to the local ones.

--- a/src/reyn/interfaces/transport/agui/__init__.py
+++ b/src/reyn/interfaces/transport/agui/__init__.py
@@ -1,0 +1,59 @@
+"""AG-UI wire transport for the thin client (ADR-0039 P2).
+
+The SECOND :class:`~reyn.interfaces.transport.client_transport.ClientTransport`,
+over HTTP+SSE. P1 unified the CUI onto the transport seam with the local
+:class:`~reyn.interfaces.transport.in_process.InProcessTransport`; this package
+adds the remote sibling so ``reyn chat --connect`` drives the identical renderer,
+a different transport (D2). renderer and stream_client are unchanged.
+
+- :mod:`.protocol` — the reyn ``Frame`` ⇄ AG-UI-event codec (standard envelope +
+  reyn-private ``_reyn`` reconstruction; graceful-degrade for generic clients).
+- :mod:`.state` — the STATE_* status read-model (snapshot + delta) and the
+  present-on-wire per-connection re-guard hook.
+- :mod:`.emitter` — server side: a reyn ``Frame`` stream → AG-UI SSE text.
+- :mod:`.client` — :class:`AgUiTransport`, the client that decodes SSE back into
+  the renderer's ``Frame`` vocabulary.
+- :mod:`.endpoint` — the FastAPI SSE endpoint + turn-submit POST, behind the P0
+  auth gate.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    AgUiEvent,
+    MessagesSnapshot,
+    StateUpdate,
+    decode_event,
+    encode_frame,
+    encode_messages_snapshot,
+    encode_state_delta,
+    encode_state_snapshot,
+    parse_sse_blocks,
+    to_sse,
+)
+from reyn.interfaces.transport.agui.state import (
+    RemoteStatusView,
+    StatusModel,
+    project_status,
+    reguard_nodes,
+)
+
+__all__ = [
+    "AgUiTransport",
+    "AgUiEmitter",
+    "AgUiEvent",
+    "MessagesSnapshot",
+    "StateUpdate",
+    "decode_event",
+    "encode_frame",
+    "encode_messages_snapshot",
+    "encode_state_delta",
+    "encode_state_snapshot",
+    "parse_sse_blocks",
+    "to_sse",
+    "RemoteStatusView",
+    "StatusModel",
+    "project_status",
+    "reguard_nodes",
+]

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -1,0 +1,169 @@
+"""Client-side ``AgUiTransport`` — the SECOND ClientTransport, over the wire (P2).
+
+P1 proved the :class:`~reyn.interfaces.transport.client_transport.ClientTransport`
+seam with the local :class:`~reyn.interfaces.transport.in_process.InProcessTransport`.
+P2 adds this remote sibling: it decodes a server AG-UI SSE stream back into the
+SAME :class:`~reyn.interfaces.transport.frames.Frame` objects the renderer
+consumes — so ``reyn chat --connect`` drives the identical renderer, a different
+transport (D2). renderer and stream_client are UNCHANGED.
+
+The transport is decoupled from HTTP for testability and single-responsibility:
+it consumes an ``AsyncIterator[str]`` of raw SSE lines (production: an httpx
+``aiter_lines`` over the SSE endpoint) and calls an injected ``send`` coroutine
+to POST a client→server message (production: an httpx POST). :meth:`frames`
+demuxes the one SSE stream three ways — render frames to the renderer, STATE_*
+to the :class:`~reyn.interfaces.transport.agui.state.RemoteStatusView`
+side-channel, and the reconnect MESSAGES/STATE snapshots — while re-guarding
+presentation nodes at the edge (A5).
+
+Phase boundary: P2 is DISPLAY + basic turn submit only. The intervention-answer
+methods exist to satisfy the ABC but are the HITL answer round-trip = P3; here
+they best-effort POST and the client does not introspect the server's
+intervention queue (:meth:`pending_intervention_head` is ``None``), so
+``route_input_line`` always takes the ordinary turn-submit path.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator, Awaitable, Callable
+
+from reyn.interfaces.transport.agui.protocol import (
+    MessagesSnapshot,
+    StateUpdate,
+    decode_event,
+    parse_sse_blocks,
+)
+from reyn.interfaces.transport.agui.state import RemoteStatusView, reguard_nodes
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, Frame
+
+
+class AgUiTransport(ClientTransport):
+    """Decode a server AG-UI SSE stream into the renderer's ``Frame`` vocabulary."""
+
+    def __init__(
+        self,
+        sse_lines: "AsyncIterator[str]",
+        send: "Callable[[dict], Awaitable[None]]",
+        *,
+        status_view: "RemoteStatusView | None" = None,
+        reguard_surface: str = "terminal",
+        connected: bool = True,
+    ) -> None:
+        self._sse_lines = sse_lines
+        self._send = send
+        self._status = status_view if status_view is not None else RemoteStatusView()
+        self._reguard_surface = reguard_surface
+        self._connected = connected
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def start(self) -> None:
+        # The SSE line source is created and owned by the caller (the httpx
+        # connect happens before construction); nothing to wire up here.
+        return None
+
+    def close(self) -> None:
+        self._connected = False
+
+    # -- status side-channel ------------------------------------------------
+
+    @property
+    def status(self) -> RemoteStatusView:
+        """The remote status read-model view (reflects the server's STATE_*)."""
+        return self._status
+
+    # -- frame production ---------------------------------------------------
+
+    def _reguard_frame(self, frame: Frame) -> Frame:
+        # Per-connection edge re-guard for presentation render-nodes (A5): inert
+        # at construction already, re-neutralized here for a heterogeneous client.
+        if isinstance(frame, DisplayFrame) and frame.message.kind == "presentation":
+            nodes = frame.message.meta.get("nodes")
+            if isinstance(nodes, list):
+                meta = dict(frame.message.meta)
+                meta["nodes"] = reguard_nodes(nodes, surface=self._reguard_surface)
+                from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+                return DisplayFrame(
+                    OutboxMessage(kind="presentation", text=frame.message.text, meta=meta)
+                )
+        return frame
+
+    def _consume_block(self, block_lines: "list[str]") -> "list[Frame]":
+        # Decode one SSE block into zero or more render frames, routing STATE_*
+        # and MESSAGES_SNAPSHOT to their side-channels.
+        out: list[Frame] = []
+        for ev in parse_sse_blocks(block_lines + [""]):
+            decoded = decode_event(ev.type, ev.data)
+            if decoded is None:
+                continue  # foreign / unknown event — ignore-unknown (D6)
+            if isinstance(decoded, StateUpdate):
+                if decoded.snapshot is not None:
+                    self._status.apply_snapshot(decoded.snapshot)
+                if decoded.delta is not None:
+                    self._status.apply_delta(decoded.delta)
+            elif isinstance(decoded, MessagesSnapshot):
+                out.extend(self._reguard_frame(f) for f in decoded.frames)
+            else:  # a Frame
+                out.append(self._reguard_frame(decoded))
+        return out
+
+    async def frames(self) -> "AsyncIterator[Frame]":
+        block: list[str] = []
+        async for raw in self._sse_lines:
+            line = raw.rstrip("\n")
+            if line == "":
+                if block:
+                    for frame in self._consume_block(block):
+                        yield frame
+                        if (
+                            isinstance(frame, DisplayFrame)
+                            and frame.message.kind == "__end__"
+                        ):
+                            return
+                    block = []
+                continue
+            block.append(line)
+        # Flush a trailing block with no terminal blank line.
+        if block:
+            for frame in self._consume_block(block):
+                yield frame
+
+    # -- send side ----------------------------------------------------------
+
+    def has_session(self) -> bool:
+        return self._connected
+
+    def pending_intervention_head(self) -> "object | None":
+        # P2 is display-only for interventions; the client does not introspect
+        # the server's intervention queue (that is P3), so input always takes
+        # the ordinary turn-submit path in route_input_line.
+        return None
+
+    async def submit_user_text(self, text: str) -> None:
+        await self._send({"type": "user_message", "text": text})
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        # P3 (HITL answer round-trip). Best-effort POST for forward-wiring; P2
+        # never routes here because pending_intervention_head() is None.
+        await self._send({"type": "answer_intervention", "text": text})
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        await self._send({"type": "answer_intervention", "text": choice_id})
+        return False
+
+    def put_display(self, msg) -> None:
+        # A remote client cannot inject into the server's outbox; client-authored
+        # echoes render locally through the renderer, not this seam. No-op here.
+        return None
+
+    async def cancel_inflight(self) -> None:
+        await self._send({"type": "cancel_inflight"})
+
+    async def shutdown(self) -> None:
+        self._connected = False
+        await self._send({"type": "shutdown"})
+
+
+__all__ = ["AgUiTransport"]

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -1,0 +1,95 @@
+"""Server-side AG-UI emitter — a reyn ``Frame`` stream → SSE text (ADR-0039 P2).
+
+The single-writer server holds the session; a remote client attaches over
+HTTP+SSE. This emitter is the server half of that wire: it consumes the SAME
+unified ``Frame`` stream the local :class:`~reyn.interfaces.transport.in_process.InProcessTransport`
+produces (display outbox + renderer-relevant chat-events) and serializes it to
+AG-UI SSE via :mod:`reyn.interfaces.transport.agui.protocol`. Because both
+transports feed off the identical frame source, *local ≡ remote by construction*
+(D2) — the emitter adds only wire framing, never new render semantics.
+
+On connect it replays the reconnect snapshots (A4): ``MESSAGES_SNAPSHOT`` (the
+display backlog) then ``STATE_SNAPSHOT`` (the status read-model). It then streams
+one SSE event per frame, and after each frame emits a ``STATE_DELTA`` when the
+projected status changed — the current WaitingOn label is tracked off the
+chat-event stream so the remote status panel follows Thinking / Running /
+Waiting-for-you without a second source.
+"""
+from __future__ import annotations
+
+from typing import AsyncIterator, Callable
+
+from reyn.interfaces.transport.agui.protocol import (
+    encode_frame,
+    encode_messages_snapshot,
+    encode_state_delta,
+    encode_state_snapshot,
+    to_sse,
+)
+from reyn.interfaces.transport.agui.state import StatusModel, project_status
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
+
+# WaitingOn label derivation off the chat-event stream — a lightweight, local
+# mirror of the renderer's ``_WAITING_ON_BY_EVENT`` table + turn lifecycle, kept
+# here so the emitter need not import the inline app (which pulls the renderer).
+# turn_settled/completed/cancelled → idle (None); tool_called → Running <tool>.
+_IDLE_EVENTS = frozenset({"turn_settled", "turn_completed", "turn_cancelled"})
+
+
+def _waiting_on_after(etype: str, edata: dict, current: "str | None") -> "str | None":
+    if etype == "turn_started":
+        return "Thinking"
+    if etype == "tool_called":
+        tool = edata.get("tool")
+        return f"Running {tool}" if tool else "Running"
+    if etype in ("tool_returned", "tool_failed"):
+        return "Thinking"
+    if etype in _IDLE_EVENTS:
+        return None
+    return current
+
+
+class AgUiEmitter:
+    """Serialize a reyn ``Frame`` stream (+ status read-model) to AG-UI SSE text."""
+
+    def __init__(
+        self,
+        frames: "AsyncIterator[Frame]",
+        status_provider: "Callable[[], dict | None]",
+        *,
+        backlog: "list[Frame] | None" = None,
+    ) -> None:
+        # ``frames`` is the unified frame stream (e.g. an InProcessTransport's
+        # ``frames()``); ``status_provider`` returns the CUI status snapshot dict
+        # (or None when no session is attached); ``backlog`` is the display
+        # history replayed on connect for reconnect (A4).
+        self._frames = frames
+        self._status_provider = status_provider
+        self._backlog = list(backlog or [])
+        self._model = StatusModel()
+        self._waiting_on: str | None = None
+
+    def _project(self) -> dict:
+        return project_status(self._status_provider(), waiting_on=self._waiting_on)
+
+    async def stream(self) -> AsyncIterator[str]:
+        # Reconnect snapshots first (A4): backlog display, then full status.
+        yield to_sse(encode_messages_snapshot(self._backlog))
+        yield to_sse(encode_state_snapshot(self._model.snapshot(self._project())))
+
+        async for frame in self._frames:
+            yield to_sse(encode_frame(frame))
+            if isinstance(frame, EventFrame):
+                ev = frame.event
+                self._waiting_on = _waiting_on_after(
+                    getattr(ev, "type", "") or "", dict(getattr(ev, "data", {}) or {}),
+                    self._waiting_on,
+                )
+            delta = self._model.delta(self._project())
+            if delta:
+                yield to_sse(encode_state_delta(delta))
+            if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
+                return
+
+
+__all__ = ["AgUiEmitter"]

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -1,0 +1,189 @@
+"""FastAPI AG-UI transport endpoint — HTTP+SSE, behind the P0 auth gate (P2).
+
+The wire surface for the remote thin client (D2): a new SSE endpoint that streams
+the server session's :class:`~reyn.interfaces.transport.frames.Frame` stream as
+AG-UI events (via :class:`~reyn.interfaces.transport.agui.emitter.AgUiEmitter`),
+plus a POST for the client→server turn submit. It is modelled on the existing
+A2A SSE pattern (``StreamingResponse`` / ``text/event-stream``) — A2A is the
+internal spine (D1); this is the AG-UI UI surface, a distinct endpoint that does
+NOT touch ``ws/chat`` (that consolidation is P6).
+
+Every connection is gated by the **P0 auth context** (``app.state.auth``, merged
+already): the request identity is resolved through the SAME
+:meth:`~reyn.interfaces.web.auth.core.AuthContext.authenticate` seam the WS gate
+uses (no new auth is introduced) — an unauthenticated connection is refused
+before any session is attached. The per-connection frame source fans the
+session's own outbox + the renderer-relevant chat-event subset into one unified
+frame stream (the server analogue of :class:`InProcessTransport`), so the wire
+carries exactly what the local seam does.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import (
+    DisplayFrame,
+    EventFrame,
+    Frame,
+    renderer_chat_events,
+)
+from reyn.interfaces.web.auth import AuthContext, ConnectionIdentity
+from reyn.interfaces.web.deps import get_registry
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["agui"])
+
+
+def _auth_context(request: Request) -> "AuthContext | None":
+    """The process-wide AuthContext built by the server lifespan, if present."""
+    return getattr(getattr(request.app, "state", None), "auth", None)
+
+
+def _token_from_request(request: Request) -> "str | None":
+    tok = request.query_params.get("token")
+    if tok:
+        return tok
+    auth = request.headers.get("authorization")
+    if auth and auth.lower().startswith("bearer "):
+        return auth[7:].strip()
+    return None
+
+
+def authenticate_request(
+    request: Request, auth: AuthContext, *, connection_id: str = ""
+) -> ConnectionIdentity:
+    """Resolve a request's identity through the P0 ``authenticate`` seam.
+
+    Adapts a FastAPI ``Request`` (client host + presented token) to the existing
+    :meth:`AuthContext.authenticate` — no new auth logic, the WS gate's twin for
+    the HTTP surface.
+    """
+    client = getattr(request, "client", None)
+    client_host = getattr(client, "host", None) if client else None
+    return auth.authenticate(
+        client_host=client_host,
+        presented_token=_token_from_request(request),
+        connection_id=connection_id,
+    )
+
+
+class _SessionFrameSource:
+    """Per-connection unified frame stream off a session (server analogue of
+    :class:`InProcessTransport`): fan out ``session.outbox`` as DisplayFrames and
+    the renderer-relevant ``session.chat_events`` subset as EventFrames onto one
+    ordered queue."""
+
+    def __init__(self, session) -> None:
+        self._session = session
+        self._q: "asyncio.Queue[Frame]" = asyncio.Queue()
+        self._forward = renderer_chat_events()
+        self._events = getattr(session, "chat_events", None) or getattr(
+            session, "_chat_events", None
+        )
+        self._drain_task: "asyncio.Task | None" = None
+
+    def _on_chat_event(self, event) -> None:
+        if getattr(event, "type", None) in self._forward:
+            self._q.put_nowait(EventFrame(event))
+
+    def start(self) -> None:
+        if self._events is not None:
+            self._events.add_subscriber(self._on_chat_event)
+        self._drain_task = asyncio.create_task(self._drain_outbox())
+
+    def close(self) -> None:
+        if self._events is not None:
+            self._events.remove_subscriber(self._on_chat_event)
+        if self._drain_task is not None:
+            self._drain_task.cancel()
+
+    async def _drain_outbox(self) -> None:
+        outbox = self._session.outbox
+        while True:
+            msg = await outbox.get()
+            self._q.put_nowait(DisplayFrame(msg))
+            if msg.kind == "__end__":
+                return
+
+    async def frames(self):
+        while True:
+            frame = await self._q.get()
+            yield frame
+            if isinstance(frame, DisplayFrame) and frame.message.kind == "__end__":
+                return
+
+
+@router.get("/agui/chat/{agent_name}/events")
+async def agui_events(request: Request, agent_name: str):
+    """SSE stream of the session's frames as AG-UI events (server→client)."""
+    auth = _auth_context(request)
+    if auth is None:
+        return JSONResponse({"error": "authentication unavailable"}, status_code=401)
+    identity = authenticate_request(request, auth)
+    if not identity.authenticated:
+        return JSONResponse({"error": "authentication required"}, status_code=401)
+
+    registry = get_registry()
+    if not registry.exists(agent_name):
+        return JSONResponse({"error": f"agent {agent_name!r} not found"}, status_code=404)
+    session = await registry.attach(agent_name)
+
+    source = _SessionFrameSource(session)
+    source.start()
+
+    def _status_provider():
+        # Read-model source: the inline status snapshot for the attached session.
+        from reyn.interfaces.inline.app import _snapshot  # noqa: PLC0415
+
+        return _snapshot(registry)
+
+    emitter = AgUiEmitter(source.frames(), _status_provider)
+
+    async def gen():
+        try:
+            async for chunk in emitter.stream():
+                yield chunk
+        finally:
+            source.close()
+
+    return StreamingResponse(gen(), media_type="text/event-stream")
+
+
+@router.post("/agui/chat/{agent_name}")
+async def agui_submit(request: Request, agent_name: str):
+    """Client→server turn submit (P2 scope: basic turn submit only)."""
+    auth = _auth_context(request)
+    if auth is None:
+        return JSONResponse({"error": "authentication unavailable"}, status_code=401)
+    identity = authenticate_request(request, auth)
+    if not identity.authenticated:
+        return JSONResponse({"error": "authentication required"}, status_code=401)
+    if not auth.authorize_write(identity):
+        return JSONResponse({"error": "unauthorized"}, status_code=403)
+
+    registry = get_registry()
+    if not registry.exists(agent_name):
+        return JSONResponse({"error": f"agent {agent_name!r} not found"}, status_code=404)
+
+    try:
+        payload = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid JSON"}, status_code=400)
+    if not isinstance(payload, dict):
+        return JSONResponse({"error": "body must be a JSON object"}, status_code=400)
+
+    session = await registry.attach(agent_name)
+    if payload.get("type") == "user_message":
+        text = str(payload.get("text", "")).strip()
+        if text:
+            await session.submit_user_text(text)
+    return JSONResponse({"status": "ok"})
+
+
+__all__ = ["router", "authenticate_request"]

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -1,0 +1,296 @@
+"""AG-UI wire protocol — the reyn ``Frame`` ⇄ AG-UI-event codec (ADR-0039 P2).
+
+P1 unified the CUI onto a :class:`~reyn.interfaces.transport.client_transport.ClientTransport`
+seam whose vocabulary is the tagged :class:`~reyn.interfaces.transport.frames.Frame`
+(``DisplayFrame`` / ``EventFrame``). P2 adds a SECOND transport over the wire; this
+module is its **codec** — the one place a ``Frame`` is turned into an AG-UI event
+and back, so the remote renderer stays byte-identical to the local one.
+
+Design (the load-bearing invariants this module carries):
+
+- **One frame ⇄ one AG-UI event.** :func:`encode_frame` maps each ``Frame`` to a
+  single :class:`AgUiEvent` (``type`` + ``data``); :func:`decode_event` inverts
+  it. A 1:1 mapping keeps the decode unambiguous and the round-trip lossless for
+  the renderer-relevant fields (display bytes + WaitingOn sequence).
+
+- **Standard envelope, reyn-private richness (D6).** Every encoded event carries
+  BOTH a standard AG-UI field shape (so a generic AG-UI client renders the core:
+  text / tool / run / error / state) AND a reyn-private ``_reyn`` reconstruction
+  block. :func:`decode_event` reconstructs the exact ``Frame`` from ``_reyn``; a
+  foreign event with no ``_reyn`` block decodes to ``None`` (ignore-unknown /
+  graceful degrade — the generic-client contract).
+
+- **The mapping is a table, derived, not hand-listed at the call site.** The
+  ``kind``/``type`` → AG-UI-event-type tables (:data:`_DISPLAY_KIND_EVENT` /
+  :data:`_EVENT_TYPE_EVENT`) are the single source the completeness gate reads;
+  an unmapped kind falls back to :data:`CUSTOM` and still round-trips (lossless
+  by construction), so a new renderer kind can never silently vanish on the wire.
+
+STATE (the status read-model) and MESSAGES snapshots ride the same SSE stream but
+are not ``Frame``\\s — they decode to :class:`StateUpdate` / :class:`MessagesSnapshot`
+so the client demuxes render frames from the status side-channel.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
+from reyn.runtime.outbox import OutboxMessage
+
+# ── AG-UI event type names (hand-rolled; the SDK is not a dependency) ─────────
+TEXT_MESSAGE_CONTENT = "TEXT_MESSAGE_CONTENT"
+RUN_STARTED = "RUN_STARTED"
+RUN_FINISHED = "RUN_FINISHED"
+RUN_ERROR = "RUN_ERROR"
+TOOL_CALL_START = "TOOL_CALL_START"
+TOOL_CALL_END = "TOOL_CALL_END"
+STATE_SNAPSHOT = "STATE_SNAPSHOT"
+STATE_DELTA = "STATE_DELTA"
+MESSAGES_SNAPSHOT = "MESSAGES_SNAPSHOT"
+CUSTOM = "CUSTOM"
+
+# Namespaced reconstruction key. Its presence is the "this is a reyn frame"
+# marker a generic client ignores and the reyn client reconstructs from.
+_REYN = "_reyn"
+
+# DisplayFrame ``OutboxMessage.kind`` → AG-UI event type. Kinds not listed here
+# (control sentinels like ``__end__`` / ``__copy_last_reply__``, and any future
+# renderer kind) fall back to CUSTOM in :func:`_display_event_type` — they still
+# round-trip losslessly via ``_reyn``; the table only selects the generic-client
+# surface. ``presentation`` rides CUSTOM = present-on-wire (G2).
+_DISPLAY_KIND_EVENT: dict[str, str] = {
+    "agent": TEXT_MESSAGE_CONTENT,
+    "status": TEXT_MESSAGE_CONTENT,
+    "error": RUN_ERROR,
+    "intervention": CUSTOM,
+    "trace": CUSTOM,
+    "presentation": CUSTOM,
+}
+
+# EventFrame ``Event.type`` → AG-UI event type. turn_* → RUN_*; tool_* →
+# TOOL_CALL_*; ``user_answered_intervention`` is reyn-private → CUSTOM. Every
+# entry here is one of the eight ``renderer_chat_events()`` the transport
+# forwards; the completeness gate binds the two independently.
+_EVENT_TYPE_EVENT: dict[str, str] = {
+    "turn_started": RUN_STARTED,
+    "turn_settled": RUN_FINISHED,
+    "turn_completed": RUN_FINISHED,
+    "turn_cancelled": RUN_FINISHED,
+    "user_answered_intervention": CUSTOM,
+    "tool_called": TOOL_CALL_START,
+    "tool_returned": TOOL_CALL_END,
+    "tool_failed": TOOL_CALL_END,
+}
+
+
+@dataclass(frozen=True)
+class AgUiEvent:
+    """One AG-UI wire event: an SSE ``event:`` type plus its ``data:`` object."""
+
+    type: str
+    data: dict
+
+
+@dataclass(frozen=True)
+class StateUpdate:
+    """A decoded STATE_* event — the status read-model side-channel, not a frame.
+
+    Exactly one of ``snapshot`` (full, on connect) / ``delta`` (changed keys) is
+    set. Consumed by the client's remote-status view, never by the renderer.
+    """
+
+    snapshot: "dict | None" = None
+    delta: "dict | None" = None
+
+
+@dataclass(frozen=True)
+class MessagesSnapshot:
+    """A decoded MESSAGES_SNAPSHOT — the reconnect display backlog (A4)."""
+
+    frames: list = field(default_factory=list)
+
+
+def _display_event_type(kind: str) -> str:
+    return _DISPLAY_KIND_EVENT.get(kind, CUSTOM)
+
+
+def _event_event_type(etype: str) -> str:
+    return _EVENT_TYPE_EVENT.get(etype, CUSTOM)
+
+
+# ── encode: Frame → AgUiEvent ────────────────────────────────────────────────
+
+def encode_frame(frame: Frame) -> AgUiEvent:
+    """Encode one ``Frame`` to a single AG-UI event (standard fields + ``_reyn``)."""
+    if isinstance(frame, DisplayFrame):
+        return _encode_display(frame)
+    if isinstance(frame, EventFrame):
+        return _encode_event(frame)
+    raise TypeError(f"not a Frame: {type(frame).__name__}")
+
+
+def _encode_display(frame: DisplayFrame) -> AgUiEvent:
+    msg = frame.message
+    kind, text, meta = msg.kind, msg.text, dict(msg.meta or {})
+    ag_type = _display_event_type(kind)
+    reyn = {"frame": "display", "kind": kind, "text": text, "meta": meta}
+    # Standard AG-UI surface a generic client renders (best-effort).
+    if ag_type is TEXT_MESSAGE_CONTENT:
+        std = {"role": "assistant" if kind == "agent" else "status", "delta": text}
+    elif ag_type is RUN_ERROR:
+        std = {"message": text}
+    else:  # CUSTOM — reyn-private (presentation / trace / intervention / control)
+        std = {"name": f"reyn.display.{kind}", "value": {"text": text}}
+    return AgUiEvent(type=ag_type, data={**std, _REYN: reyn})
+
+
+def _encode_event(frame: EventFrame) -> AgUiEvent:
+    ev = frame.event
+    etype = getattr(ev, "type", None) or ""
+    edata = dict(getattr(ev, "data", {}) or {})
+    ag_type = _event_event_type(etype)
+    reyn = {"frame": "event", "type": etype, "data": edata}
+    if ag_type in (TOOL_CALL_START, TOOL_CALL_END):
+        std = {"toolName": edata.get("tool"), "step": edata.get("tool")}
+    elif ag_type in (RUN_STARTED, RUN_FINISHED):
+        std = {"phase": etype}
+    else:  # CUSTOM — user_answered_intervention et al.
+        std = {"name": f"reyn.event.{etype}", "value": edata}
+    return AgUiEvent(type=ag_type, data={**std, _REYN: reyn})
+
+
+def encode_state_snapshot(snapshot: dict) -> AgUiEvent:
+    """STATE_SNAPSHOT — the full status read-model, emitted on connect (A4)."""
+    return AgUiEvent(
+        type=STATE_SNAPSHOT,
+        data={"snapshot": dict(snapshot), _REYN: {"frame": "state", "snapshot": dict(snapshot)}},
+    )
+
+
+def encode_state_delta(delta: dict) -> AgUiEvent:
+    """STATE_DELTA — the changed status-read-model keys since the last emit."""
+    return AgUiEvent(
+        type=STATE_DELTA,
+        data={"delta": dict(delta), _REYN: {"frame": "state_delta", "delta": dict(delta)}},
+    )
+
+
+def encode_messages_snapshot(frames: "list[Frame]") -> AgUiEvent:
+    """MESSAGES_SNAPSHOT — the display backlog replayed on connect (A4)."""
+    payload = [_encode_display(f).data[_REYN] for f in frames if isinstance(f, DisplayFrame)]
+    return AgUiEvent(
+        type=MESSAGES_SNAPSHOT,
+        data={"messages": payload, _REYN: {"frame": "messages", "messages": payload}},
+    )
+
+
+# ── decode: AgUiEvent → Frame | StateUpdate | MessagesSnapshot | None ─────────
+
+def decode_event(
+    ag_type: str, data: dict
+) -> "Frame | StateUpdate | MessagesSnapshot | None":
+    """Invert :func:`encode_frame` (and the STATE / MESSAGES encoders).
+
+    Reconstructs the exact reyn object from the ``_reyn`` block. An event with no
+    ``_reyn`` block (a generic/foreign AG-UI event) decodes to ``None`` — the
+    ignore-unknown / graceful-degrade contract (D6).
+    """
+    reyn = data.get(_REYN) if isinstance(data, dict) else None
+    if not isinstance(reyn, dict):
+        return None
+    frame_tag = reyn.get("frame")
+    if frame_tag == "display":
+        return DisplayFrame(
+            OutboxMessage(
+                kind=reyn.get("kind", ""),
+                text=reyn.get("text", ""),
+                meta=dict(reyn.get("meta") or {}),
+            )
+        )
+    if frame_tag == "event":
+        return EventFrame(Event(type=reyn.get("type", ""), data=dict(reyn.get("data") or {})))
+    if frame_tag == "state":
+        return StateUpdate(snapshot=dict(reyn.get("snapshot") or {}))
+    if frame_tag == "state_delta":
+        return StateUpdate(delta=dict(reyn.get("delta") or {}))
+    if frame_tag == "messages":
+        frames = [
+            DisplayFrame(
+                OutboxMessage(
+                    kind=m.get("kind", ""),
+                    text=m.get("text", ""),
+                    meta=dict(m.get("meta") or {}),
+                )
+            )
+            for m in (reyn.get("messages") or [])
+        ]
+        return MessagesSnapshot(frames=frames)
+    return None
+
+
+# ── SSE framing ──────────────────────────────────────────────────────────────
+
+def to_sse(event: AgUiEvent) -> str:
+    """Serialize an AG-UI event to an SSE block: ``event: T\\ndata: {json}\\n\\n``."""
+    return f"event: {event.type}\ndata: {json.dumps(event.data, ensure_ascii=False)}\n\n"
+
+
+def parse_sse_blocks(lines: "list[str]") -> "list[AgUiEvent]":
+    """Parse SSE text (already split to lines) into AG-UI events.
+
+    Accumulates ``event:`` / ``data:`` fields until a blank separator line and
+    emits one :class:`AgUiEvent` per block. Malformed JSON in a ``data:`` line
+    is skipped (a robust wire never lets one bad block kill the stream).
+    """
+    events: list[AgUiEvent] = []
+    ev_type: str | None = None
+    data_buf: list[str] = []
+
+    def _flush() -> None:
+        nonlocal ev_type, data_buf
+        if ev_type is not None and data_buf:
+            try:
+                payload = json.loads("\n".join(data_buf))
+            except json.JSONDecodeError:
+                payload = None
+            if isinstance(payload, dict):
+                events.append(AgUiEvent(type=ev_type, data=payload))
+        ev_type, data_buf = None, []
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if line == "":
+            _flush()
+            continue
+        if line.startswith("event:"):
+            ev_type = line[len("event:"):].strip()
+        elif line.startswith("data:"):
+            data_buf.append(line[len("data:"):].strip())
+    _flush()
+    return events
+
+
+__all__ = [
+    "AgUiEvent",
+    "StateUpdate",
+    "MessagesSnapshot",
+    "TEXT_MESSAGE_CONTENT",
+    "RUN_STARTED",
+    "RUN_FINISHED",
+    "RUN_ERROR",
+    "TOOL_CALL_START",
+    "TOOL_CALL_END",
+    "STATE_SNAPSHOT",
+    "STATE_DELTA",
+    "MESSAGES_SNAPSHOT",
+    "CUSTOM",
+    "encode_frame",
+    "encode_state_snapshot",
+    "encode_state_delta",
+    "encode_messages_snapshot",
+    "decode_event",
+    "to_sse",
+    "parse_sse_blocks",
+]

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -1,0 +1,144 @@
+"""STATE_* status read-model + present-on-wire re-guard (ADR-0039 P2).
+
+P1 left the status bar (ctx / cost / token / WaitingOn) read straight off the
+registry by duck-typing — fine in-process, but a remote client has no registry
+to read. P2 streams the status view over the wire as ``STATE_SNAPSHOT`` (on
+connect) + ``STATE_DELTA`` (on change). This module owns three pieces:
+
+- :func:`project_status` — the **read-model projection**: the wire-relevant
+  subset of the existing inline status snapshot (the ``_snapshot`` dict the CUI
+  already builds). It is a *read-model*, NOT a file mirror — it derives from the
+  session's live cost / token / ctx accessors and the current WaitingOn label,
+  and carries only what a status panel renders.
+- :class:`StatusModel` — the server-side differ: holds the last projected view
+  and yields the changed keys (:meth:`delta`) so the emitter streams a compact
+  ``STATE_DELTA`` instead of a full snapshot on every tick.
+- :class:`RemoteStatusView` — the client-side reader: applies a snapshot then
+  deltas so the remote status panel reflects the SERVER's values.
+
+Plus :func:`reguard_nodes` — the **per-connection re-guard hook** (A5): render
+nodes are already neutralized at construction (inert-on-wire), but a
+heterogeneous-surface client re-runs the surface neutralizer over every leaf at
+the transport edge as defense in depth (idempotent for the terminal surface).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from reyn.core.present.guard import get_neutralizer
+
+# The status keys that ride the wire — the read-model's whole vocabulary. Kept
+# as an explicit projection so a private/expensive snapshot field (e.g. the
+# bound ``ctx_compaction_status_fn`` method) can never leak onto the wire.
+_WIRE_KEYS = (
+    "attached_name",
+    "model",
+    "cost_agent",
+    "cost_total",
+    "agent_tokens",
+    "ctx_used",
+    "ctx_window",
+    "waiting_on",
+)
+
+
+def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) -> dict:
+    """Project the inline status snapshot to the wire read-model subset.
+
+    ``snapshot`` is the CUI's ``_snapshot`` dict (or ``None`` when no session is
+    attached). ``waiting_on`` is the current WaitingOn label (from the
+    chat-event stream) folded in so the remote panel shows the same
+    Thinking / Running / Waiting-for-you state the local one does.
+    """
+    snap = snapshot or {}
+    out = {
+        "attached_name": snap.get("attached_name"),
+        "model": snap.get("model"),
+        "cost_agent": snap.get("cost_agent", 0.0),
+        "cost_total": snap.get("cost_total", 0.0),
+        "agent_tokens": snap.get("agent_tokens", 0),
+        "ctx_used": snap.get("ctx_used", 0),
+        "ctx_window": snap.get("ctx_window", 0),
+        "waiting_on": waiting_on,
+    }
+    return out
+
+
+@dataclass
+class StatusModel:
+    """Server-side status differ: last-projected view → changed-key deltas."""
+
+    _last: dict = field(default_factory=dict)
+
+    def snapshot(self, projected: dict) -> dict:
+        """Record ``projected`` as the baseline and return it (the full view)."""
+        self._last = dict(projected)
+        return dict(projected)
+
+    def delta(self, projected: dict) -> dict:
+        """Return only the keys whose value changed since the last snapshot/delta.
+
+        Empty dict when nothing changed — the emitter skips the STATE_DELTA emit
+        so an idle stream stays quiet.
+        """
+        changed = {k: v for k, v in projected.items() if self._last.get(k, _UNSET) != v}
+        if changed:
+            self._last.update(changed)
+        return changed
+
+
+@dataclass
+class RemoteStatusView:
+    """Client-side status reader: apply a snapshot, then deltas, and read back.
+
+    The remote status panel renders off :attr:`values`; :meth:`apply_snapshot`
+    replaces it wholesale (connect / reconnect) and :meth:`apply_delta` merges
+    changed keys — so the panel always reflects the SERVER's status values.
+    """
+
+    values: dict = field(default_factory=dict)
+
+    def apply_snapshot(self, snapshot: dict) -> None:
+        self.values = dict(snapshot)
+
+    def apply_delta(self, delta: dict) -> None:
+        self.values.update(delta)
+
+    def get(self, key: str, default=None):
+        return self.values.get(key, default)
+
+
+def reguard_nodes(nodes: "list[dict]", *, surface: str = "terminal") -> list[dict]:
+    """Re-run the surface neutralizer over every leaf string in render nodes (A5).
+
+    Nodes are already inert at construction; this is the per-connection edge
+    re-guard for a heterogeneous-surface client — idempotent for a leaf the
+    construction seam already neutralized, but load-bearing for a client whose
+    upstream did not (or neutralized for a different surface). Structure is
+    preserved; only leaf ``str`` values are passed through
+    ``get_neutralizer(surface).neutralize``.
+    """
+    neutralizer = get_neutralizer(surface)
+
+    def _walk(value):
+        if isinstance(value, str):
+            cleaned, _stripped = neutralizer.neutralize(value)
+            return cleaned
+        if isinstance(value, dict):
+            return {k: _walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(v) for v in value]
+        return value
+
+    return [_walk(node) for node in nodes]
+
+
+_UNSET = object()
+
+
+__all__ = [
+    "project_status",
+    "StatusModel",
+    "RemoteStatusView",
+    "reguard_nodes",
+]

--- a/src/reyn/interfaces/web/server.py
+++ b/src/reyn/interfaces/web/server.py
@@ -371,6 +371,14 @@ app.include_router(_a2a_router.router)
 # spec gap for resource fetch with the industry-standard pattern.
 app.include_router(_resources_router.router)
 
+# AG-UI thin-client transport (ADR-0039 P2): a new SSE endpoint that streams
+# the session's frame stream as AG-UI events (server→client) plus a turn-submit
+# POST, behind the P0 auth gate. Distinct from ws/chat (that consolidation is
+# P6); A2A is the internal spine (D1), this is the AG-UI UI surface.
+from reyn.interfaces.transport.agui.endpoint import router as _agui_router  # noqa: E402
+
+app.include_router(_agui_router)
+
 # ── WebSocket routes ────────────────────────────────────────────────────────
 
 from reyn.interfaces.web.ws import chat as _ws_chat  # noqa: E402

--- a/tests/test_agui_auth_reuse.py
+++ b/tests/test_agui_auth_reuse.py
@@ -1,0 +1,65 @@
+"""Tier 2: the AG-UI endpoint reuses the P0 auth gate — unauth refused (P2, D5a).
+
+The new SSE surface introduces no new auth: it resolves identity through the same
+:class:`~reyn.interfaces.web.auth.core.AuthContext.authenticate` seam the WS gate
+uses. This pins the security invariant: a connection with no / a wrong token is
+refused (401) BEFORE any session is attached; a connection presenting the
+configured token passes the gate (it is not refused for auth).
+
+Real instances only — a real FastAPI app mounting the real router with a real
+AuthContext; the Starlette TestClient drives real HTTP. No mocks.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from reyn.interfaces.transport.agui.endpoint import router
+from reyn.interfaces.web.auth import AuthContext
+
+
+def _app_with_token(token: str) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    # A network-tier (non-loopback) client must present the token; require_token
+    # forces the check even were the client loopback.
+    app.state.auth = AuthContext(token=token, require_token=True)
+    return app
+
+
+def test_submit_without_token_is_refused() -> None:
+    """Tier 2: POST with no token is refused (401) before any session work."""
+    client = TestClient(_app_with_token("s3cret"))
+    resp = client.post("/agui/chat/demo", json={"type": "user_message", "text": "hi"})
+    assert resp.status_code == 401
+
+
+def test_submit_with_wrong_token_is_refused() -> None:
+    """Tier 2: POST with a wrong token is refused (401)."""
+    client = TestClient(_app_with_token("s3cret"))
+    resp = client.post(
+        "/agui/chat/demo",
+        json={"type": "user_message", "text": "hi"},
+        headers={"authorization": "Bearer nope"},
+    )
+    assert resp.status_code == 401
+
+
+def test_events_without_token_is_refused() -> None:
+    """Tier 2: the SSE GET with no token is refused (401) before attach."""
+    client = TestClient(_app_with_token("s3cret"))
+    resp = client.get("/agui/chat/demo/events")
+    assert resp.status_code == 401
+
+
+def test_correct_token_passes_the_auth_gate() -> None:
+    """Tier 2: with the configured token the connection is NOT refused for auth
+    (it passes the gate; a missing agent is a 404, not a 401)."""
+    client = TestClient(_app_with_token("s3cret"))
+    resp = client.post(
+        "/agui/chat/demo?token=s3cret",
+        json={"type": "user_message", "text": "hi"},
+    )
+    assert resp.status_code != 401
+    # It got past auth into agent resolution (demo agent does not exist here).
+    assert resp.status_code in (403, 404)

--- a/tests/test_agui_generic_client_degrade.py
+++ b/tests/test_agui_generic_client_degrade.py
@@ -1,0 +1,61 @@
+"""Tier 2: a generic AG-UI client degrades gracefully on reyn Custom (P2, D6).
+
+AG-UI has no normative "ignore-unknown" clause, so reyn owns it: a foreign or
+unknown event (no reyn ``_reyn`` reconstruction block, or a reyn Custom a generic
+client does not understand) is SKIPPED, not fatal. This pins the decoder side of
+that contract:
+
+- an event with no ``_reyn`` block decodes to ``None`` (skipped); and
+- interleaving such foreign events in the SSE stream does not disturb the reyn
+  frames — the real frames still arrive in order, the unknown ones vanish.
+
+Real instances only — the real codec + AgUiTransport; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.protocol import decode_event, encode_frame, to_sse
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+def test_foreign_event_decodes_to_none() -> None:
+    """Tier 2: an event with no reyn reconstruction block is ignored (None)."""
+    # A standard AG-UI event a generic server might send that reyn did not encode.
+    assert decode_event("TEXT_MESSAGE_CONTENT", {"role": "assistant", "delta": "hi"}) is None
+    # A reyn-shaped Custom with a name but no _reyn block is likewise skipped.
+    assert decode_event("CUSTOM", {"name": "some.future.reyn.event", "value": {}}) is None
+
+
+@pytest.mark.asyncio
+async def test_foreign_events_interleaved_are_skipped() -> None:
+    """Tier 2: foreign events interleaved with reyn frames vanish; the reyn
+    frames still arrive in order (ignore-unknown, not fatal)."""
+    foreign = "event: CUSTOM\ndata: {\"name\": \"vendor.x\", \"value\": 1}\n\n"
+    sse = (
+        foreign
+        + to_sse(encode_frame(DisplayFrame(OutboxMessage(kind="agent", text="one"))))
+        + foreign
+        + to_sse(encode_frame(DisplayFrame(OutboxMessage(kind="agent", text="two"))))
+        + to_sse(encode_frame(DisplayFrame(OutboxMessage(kind="__end__", text=""))))
+    )
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    texts = []
+    async for f in transport.frames():
+        if isinstance(f, DisplayFrame) and f.message.kind == "agent":
+            texts.append(f.message.text)
+
+    assert texts == ["one", "two"]

--- a/tests/test_agui_mapping_completeness.py
+++ b/tests/test_agui_mapping_completeness.py
@@ -1,0 +1,105 @@
+"""Tier 2: every renderer Frame kind has an AG-UI encode→decode mapping (P2).
+
+The wire version of P1's dual-stream completeness gate. The Frame vocabulary the
+renderer consumes has two halves:
+
+- **DisplayFrame kinds** — the ``OutboxMessage.kind`` literals the renderer's
+  ``message`` / ``format_inline_message`` dispatch on (AST-scanned from the
+  renderer source, NOT from the codec's own table — non-circular).
+- **EventFrame types** — the eight ``renderer_chat_events()`` the transport
+  forwards (derived, not hand-listed).
+
+For EACH, the codec must round-trip it: ``encode_frame`` → SSE → ``decode_event``
+must reconstruct the SAME kind/type and payload. A kind the codec drops or
+mangles ⇒ the round-trip assertion fails ⇒ RED — so a new renderer kind that the
+wire cannot carry fails CI instead of silently vanishing on the wire.
+
+The enumeration reads the renderer's real code + the derived event set (two
+independent sources), never the codec's mapping tables, so the gate is not
+circular.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.protocol import (
+    decode_event,
+    encode_frame,
+    parse_sse_blocks,
+    to_sse,
+)
+from reyn.interfaces.transport.frames import (
+    DisplayFrame,
+    EventFrame,
+    renderer_chat_events,
+)
+from reyn.runtime.outbox import OutboxMessage
+
+_RENDERER = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "reyn" / "interfaces" / "repl" / "renderer.py"
+)
+
+# The renderer functions that dispatch on ``OutboxMessage.kind``. Scanning these
+# (not the whole file) keeps the vocabulary to actual display-kind branches.
+_DISPLAY_DISPATCH_FUNCS = {"message", "format_inline_message"}
+
+
+def _renderer_display_kinds() -> set[str]:
+    """Every ``kind`` string literal the renderer's display-dispatch functions
+    compare against — the DisplayFrame vocabulary, read from renderer source."""
+    tree = ast.parse(_RENDERER.read_text(encoding="utf-8"))
+    kinds: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name in _DISPLAY_DISPATCH_FUNCS):
+            continue
+        for cmp_node in ast.walk(node):
+            if not isinstance(cmp_node, ast.Compare):
+                continue
+            for lit in ast.walk(cmp_node):
+                if isinstance(lit, ast.Constant) and isinstance(lit.value, str):
+                    kinds.add(lit.value)
+    return kinds
+
+
+def _roundtrip(frame):
+    """encode → SSE → parse → decode, exactly as the wire does."""
+    sse = to_sse(encode_frame(frame))
+    (ev,) = parse_sse_blocks(sse.split("\n"))
+    return decode_event(ev.type, ev.data)
+
+
+def test_every_display_kind_round_trips_over_the_wire() -> None:
+    """Tier 2: each renderer display kind encodes→decodes back to the same kind
+    and text/meta. Unmapped / lossy ⇒ RED (the wire-drop bug, designed out)."""
+    kinds = _renderer_display_kinds()
+
+    # Sanity: the scan actually found the renderer's vocabulary (a broken scan
+    # that found nothing must not vacuously pass).
+    assert {"agent", "error", "presentation", "intervention"} <= kinds
+
+    for kind in kinds:
+        frame = DisplayFrame(OutboxMessage(kind=kind, text="body", meta={"k": "v"}))
+        decoded = _roundtrip(frame)
+        assert isinstance(decoded, DisplayFrame), f"{kind!r} did not decode to a DisplayFrame"
+        assert decoded.message.kind == kind, f"{kind!r} kind mangled → {decoded.message.kind!r}"
+        assert decoded.message.text == "body"
+        assert decoded.message.meta == {"k": "v"}
+
+
+def test_every_forwarded_chat_event_round_trips_over_the_wire() -> None:
+    """Tier 2: each of the eight renderer_chat_events encodes→decodes back to the
+    same event type and data. Unmapped / lossy ⇒ RED."""
+    events = renderer_chat_events()
+
+    # Sanity: the derived set is the expected non-trivial vocabulary.
+    assert {"tool_called", "tool_returned", "tool_failed", "turn_started"} <= events
+
+    for etype in events:
+        frame = EventFrame(Event(type=etype, data={"tool": "grep_files"}))
+        decoded = _roundtrip(frame)
+        assert isinstance(decoded, EventFrame), f"{etype!r} did not decode to an EventFrame"
+        assert decoded.event.type == etype, f"{etype!r} type mangled → {decoded.event.type!r}"
+        assert decoded.event.data == {"tool": "grep_files"}

--- a/tests/test_agui_present_on_wire.py
+++ b/tests/test_agui_present_on_wire.py
@@ -1,0 +1,75 @@
+"""Tier 2: present render-nodes ride the wire inert + edge re-guard (P2, G2/A5).
+
+A ``present`` op's render model is a ``list[dict]`` neutralized at construction
+(inert-on-wire). P2 carries it as a reyn Custom event (present-on-wire, G2) and
+adds a per-connection re-guard at the transport edge (A5) for a heterogeneous
+client whose upstream may not have neutralized (or neutralized for a different
+surface). This pins both:
+
+- a ``presentation`` frame round-trips over the wire as a DisplayFrame with its
+  nodes intact (rides Custom, decoded back to the same kind); and
+- a leaf carrying an ESC / control sequence is neutralized at the edge — the
+  decoded node no longer contains the raw control bytes (inert by construction,
+  re-asserted per connection).
+
+Real instances only — the real codec + AgUiTransport + the real presentation
+guard neutralizer; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.protocol import encode_frame, to_sse
+from reyn.interfaces.transport.agui.state import reguard_nodes
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+# An OSC-52 clipboard escape (a real terminal attack surface) embedded in a leaf.
+_ESC_LEAF = "safe\x1b]52;;ZXZpbA==\x07tail"
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+def test_reguard_neutralizes_control_sequences_in_leaves() -> None:
+    """Tier 2: the edge re-guard strips ESC/control bytes from every node leaf,
+    preserving structure (A5 defense-in-depth for heterogeneous clients)."""
+    nodes = [{"type": "text", "text": _ESC_LEAF}, {"type": "table", "rows": [[_ESC_LEAF]]}]
+    guarded = reguard_nodes(nodes)
+
+    # Structure preserved; ESC byte removed from every leaf.
+    assert "\x1b" not in guarded[0]["text"]
+    assert "\x1b" not in guarded[1]["rows"][0][0]
+    # The non-control content survives (neutralize strips control, not text).
+    assert "safe" in guarded[0]["text"] and "tail" in guarded[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_presentation_frame_rides_wire_inert() -> None:
+    """Tier 2: a presentation frame round-trips as a DisplayFrame(kind=presentation)
+    with nodes re-guarded at the transport edge (no raw control bytes)."""
+    frame = DisplayFrame(
+        OutboxMessage(kind="presentation", text="", meta={"nodes": [{"type": "text", "text": _ESC_LEAF}]})
+    )
+    sse = to_sse(encode_frame(frame)) + to_sse(
+        encode_frame(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+    )
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    decoded = []
+    async for f in transport.frames():
+        decoded.append(f)
+
+    pres = decoded[0]
+    assert isinstance(pres, DisplayFrame) and pres.message.kind == "presentation"
+    # present-on-wire is inert: the ESC byte is gone after the edge re-guard.
+    leaf = pres.message.meta["nodes"][0]["text"]
+    assert "\x1b" not in leaf and "safe" in leaf

--- a/tests/test_agui_reconnect_snapshot.py
+++ b/tests/test_agui_reconnect_snapshot.py
@@ -1,0 +1,69 @@
+"""Tier 2: on connect the server emits MESSAGES_SNAPSHOT + STATE_SNAPSHOT (P2, A4).
+
+The reconnect contract (A4): before any live frame, a connecting client receives
+a display backlog (``MESSAGES_SNAPSHOT``) then the full status read-model
+(``STATE_SNAPSHOT``); deltas follow. This pins the emit order and that the client
+replays the backlog frames + seeds its status view from the snapshot.
+
+Real instances only — the real emitter, codec, AgUiTransport; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    MESSAGES_SNAPSHOT,
+    STATE_SNAPSHOT,
+    parse_sse_blocks,
+)
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_connect_emits_messages_then_state_snapshot_then_frames() -> None:
+    """Tier 2: the first two SSE events are MESSAGES_SNAPSHOT then STATE_SNAPSHOT,
+    the backlog is replayed to the client, and the status view is seeded."""
+    backlog = [
+        DisplayFrame(OutboxMessage(kind="agent", text="earlier reply")),
+    ]
+
+    async def frames():
+        yield DisplayFrame(OutboxMessage(kind="agent", text="live reply"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(
+        frames(),
+        lambda: {"attached_name": "a", "cost_agent": 0.5, "ctx_window": 200},
+        backlog=backlog,
+    )
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    # Emit order: MESSAGES_SNAPSHOT then STATE_SNAPSHOT come first (A4).
+    events = parse_sse_blocks(sse.split("\n"))
+    assert events[0].type == MESSAGES_SNAPSHOT
+    assert events[1].type == STATE_SNAPSHOT
+
+    # Client replays the backlog (as a real frame) then the live frame, and
+    # seeds its status view from the snapshot.
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    texts = [
+        f.message.text
+        async for f in transport.frames()
+        if isinstance(f, DisplayFrame) and f.message.kind == "agent"
+    ]
+    assert texts == ["earlier reply", "live reply"]
+    assert transport.status.get("attached_name") == "a"
+    assert transport.status.get("ctx_window") == 200

--- a/tests/test_agui_state_read_model.py
+++ b/tests/test_agui_state_read_model.py
@@ -1,0 +1,73 @@
+"""Tier 2: the remote status panel reflects server STATE_* values (P2 hard gate).
+
+P1 left the status bar read registry-duck-typed — fine in-process, broken over
+the wire. P2 streams the session status view (ctx / cost / token / WaitingOn) as
+``STATE_SNAPSHOT`` on connect + ``STATE_DELTA`` on change. This pins the hard
+gate: after the server emits a snapshot and at least one delta, the CLIENT's
+remote status view reflects the SERVER's values — both the snapshot baseline and
+the delta-updated value.
+
+The status source is a read-model (the projected snapshot subset), NOT a file
+mirror. Real instances only — the real emitter, codec, AgUiTransport, and the
+RemoteStatusView; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_remote_status_view_reflects_snapshot_then_delta() -> None:
+    """Tier 2: the client status view carries the server's snapshot values, then
+    a delta updates them (WaitingOn from the chat-event stream + a cost change)."""
+    # A mutable server-side status source: cost rises between frames, so the
+    # emitter produces a STATE_DELTA. WaitingOn is derived from the event stream.
+    state = {"cost_agent": 1.0, "cost_total": 1.0, "ctx_used": 10, "ctx_window": 100,
+             "agent_tokens": 5, "attached_name": "a", "model": "m"}
+
+    def status_provider():
+        return dict(state)
+
+    async def frames():
+        # A tool_called event advances WaitingOn to "Running grep_files"; then a
+        # cost change drives a STATE_DELTA on the next frame.
+        yield EventFrame(Event(type="turn_started", data={}))
+        yield EventFrame(Event(type="tool_called", data={"tool": "grep_files"}))
+        state["cost_agent"] = 2.5  # server-side change → delta
+        yield DisplayFrame(OutboxMessage(kind="agent", text="done"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    # Sanity: the wire actually carried a snapshot AND a delta.
+    assert "STATE_SNAPSHOT" in sse
+    assert "STATE_DELTA" in sse
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # draining also applies STATE_* to transport.status
+
+    view = transport.status
+    # Snapshot baseline reached the client...
+    assert view.get("attached_name") == "a"
+    assert view.get("ctx_window") == 100
+    # ...and the delta updated the changed keys (cost + WaitingOn).
+    assert view.get("cost_agent") == 2.5
+    assert view.get("waiting_on") == "Running grep_files"

--- a/tests/test_agui_transport_bit_identical.py
+++ b/tests/test_agui_transport_bit_identical.py
@@ -1,0 +1,168 @@
+"""Tier 2: the reyn CUI is byte-identical across transports (ADR-0039 P2).
+
+P1 proved InProcessTransport == direct baseline. P2 extends the bit-identical
+invariant to the WIRE: the same session frame script routed session → server
+AG-UI SSE emit → client SSE decode → Frame → renderer produces the IDENTICAL
+display bytes AND WaitingOn / working-indicator transition sequence as the
+InProcess transport and the direct baseline. If any renderer-relevant field did
+not survive the wire round-trip, the bytes or the state sequence would diverge.
+
+Real instances only — a real InlineChatRenderer, a real AgUiEmitter + AgUiTransport
+over real SSE text, the real codec; no mocks. Fixed monotonic clock so the
+working-indicator fragments are a deterministic function of the WaitingOn state.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from io import StringIO
+
+import pytest
+
+from reyn.core.events.events import Event, EventLog
+from reyn.interfaces.repl.renderer import InlineChatRenderer
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.interfaces.transport.in_process import InProcessTransport
+from reyn.runtime.outbox import OutboxMessage
+
+_NOW = 10_000.0
+
+_DISPLAY = [
+    OutboxMessage(kind="agent", text="hello [world] <ok>"),
+    OutboxMessage(kind="status", text="thinking about it"),
+    OutboxMessage(kind="error", text="something failed"),
+    OutboxMessage(kind="intervention", text="approve this? [y/N]"),
+    OutboxMessage(kind="trace", text="· ran a tool"),
+]
+
+_EVENTS = [
+    ("turn_started", {}),
+    ("tool_called", {"tool": "grep_files"}),
+    ("tool_returned", {}),
+    ("tool_failed", {}),
+    ("user_answered_intervention", {}),
+    ("turn_settled", {}),
+]
+
+# The interleaved script (events then display then __end__) as Frames — the
+# common source both transports consume.
+def _script_frames() -> list:
+    frames: list = [EventFrame(Event(type=t, data=d)) for t, d in _EVENTS]
+    frames += [DisplayFrame(m) for m in _DISPLAY]
+    frames.append(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+    return frames
+
+
+class _RecordingInlineRenderer(InlineChatRenderer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.working_states: list = []
+
+    def on_chat_event(self, event) -> None:
+        super().on_chat_event(event)
+        self.working_states.append(self.working_frags(_NOW))
+
+
+class _FakeRegistry:
+    def __init__(self) -> None:
+        self.repl_outbox: asyncio.Queue = asyncio.Queue()
+        self.chat_events = EventLog()
+        self._cb = None
+
+    def bind_focus_listeners(self, *, on_chat_event=None, intervention_channel=None) -> None:
+        self._cb = on_chat_event
+        if on_chat_event is not None:
+            self.chat_events.add_subscriber(on_chat_event)
+
+    def unbind_focus_listeners(self) -> None:
+        if self._cb is not None:
+            self.chat_events.remove_subscriber(self._cb)
+            self._cb = None
+
+    def attached_session(self):
+        return None
+
+
+def _baseline(monkeypatch) -> tuple[str, list]:
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    for etype, data in _EVENTS:
+        r.on_chat_event(Event(type=etype, data=data))
+    for msg in _DISPLAY:
+        r.message(msg)
+    return buf.getvalue(), r.working_states
+
+
+async def _via_in_process(monkeypatch) -> tuple[str, list]:
+    fake = _FakeRegistry()
+    transport = InProcessTransport(fake, intervention_channel="tui")
+    transport.start()
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    try:
+        for etype, data in _EVENTS:
+            fake.chat_events.emit(etype, **data)
+        for msg in _DISPLAY:
+            fake.repl_outbox.put_nowait(msg)
+        fake.repl_outbox.put_nowait(OutboxMessage(kind="__end__", text=""))
+        await asyncio.wait_for(run_output_loop(transport, r), timeout=2.0)
+    finally:
+        transport.close()
+    return buf.getvalue(), r.working_states
+
+
+async def _frame_source(frames):
+    for f in frames:
+        yield f
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+async def _via_agui(monkeypatch) -> tuple[str, list]:
+    # Server side: emit the frame script to AG-UI SSE text.
+    emitter = AgUiEmitter(_frame_source(_script_frames()), lambda: None)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    # Client side: decode the SSE back into frames and drive the renderer.
+
+    async def _noop_send(_payload):  # no client→server traffic in this test
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    await asyncio.wait_for(run_output_loop(transport, r), timeout=2.0)
+    return buf.getvalue(), r.working_states
+
+
+@pytest.mark.asyncio
+async def test_agui_bytes_and_status_match_in_process_and_baseline(monkeypatch) -> None:
+    """Tier 2: display bytes AND WaitingOn sequence are byte-equal across
+    AgUi == InProcess == direct baseline (bit-identity extended to the wire)."""
+    monkeypatch.setattr(time, "monotonic", lambda: _NOW)
+
+    base_stdout, base_states = _baseline(monkeypatch)
+    ip_stdout, ip_states = await _via_in_process(monkeypatch)
+    ag_stdout, ag_states = await _via_agui(monkeypatch)
+
+    # sanity: the script actually rendered something non-trivial.
+    assert base_stdout
+    assert len(base_states) == len(_EVENTS)
+
+    # Display bytes: wire round-trip == in-process == baseline.
+    assert ip_stdout == base_stdout
+    assert ag_stdout == base_stdout
+
+    # WaitingOn / working-indicator transition sequence: identical across all.
+    assert ip_states == base_states
+    assert ag_states == base_states

--- a/tests/test_transport_dual_stream_completeness.py
+++ b/tests/test_transport_dual_stream_completeness.py
@@ -33,6 +33,12 @@ def _renderer_consumed_event_literals() -> set[str]:
 
     Collecting only strings inside ``ast.Compare`` nodes excludes incidental
     literals like ``getattr(event, "type")`` — those are Call args, not compares.
+
+    UNDER-CAPTURE GUARD: this scans compares *directly inside* ``on_chat_event``.
+    If a renderer moves its ``etype ==`` branch into a helper that
+    ``on_chat_event`` merely calls, the literal leaves this function body and is
+    silently dropped — widen the scan to follow the helper (or inline the branch)
+    before that refactor lands. (ADR-0039 P2 drive-by.)
     """
     tree = ast.parse(_RENDERER.read_text(encoding="utf-8"))
     consumed: set[str] = set()


### PR DESCRIPTION
**[per-PR-coder]** — P2 of the thin-client / single-writer-server arc (ADR-0039), toward #2805.

Adds a **second `ClientTransport` = `AgUiTransport`** over the wire (HTTP + SSE, hand-rolled AG-UI schema — the SDK is not a dep). renderer and stream_client are **unchanged** (P1 proved the seam). P2 = server-side AG-UI emitter + client-side decoder + `STATE_*` status read-model + SSE endpoint behind the P0 auth gate.

Co-vet against `P2_agui_transport_spec.md`. **Do NOT merge** — architect co-vets, lead-coder merges on verdict.

## What landed
- `transport/agui/protocol.py` — reyn `Frame` ⇄ AG-UI-event codec. Standard envelope (generic clients render text/tool/run/error/state) + reyn-private `_reyn` reconstruction block (lossless round-trip). Foreign event with no `_reyn` → `None` (ignore-unknown / graceful degrade, D6).
- `transport/agui/state.py` — `STATE_*` read-model (`project_status` / `StatusModel` server differ / `RemoteStatusView` client reader) + `reguard_nodes` per-connection edge re-guard (A5).
- `transport/agui/emitter.py` — server side: unified `Frame` stream → AG-UI SSE. `MESSAGES_SNAPSHOT` + `STATE_SNAPSHOT` on connect (A4), `STATE_DELTA` on change; WaitingOn tracked off the chat-event stream.
- `transport/agui/client.py` — `AgUiTransport(ClientTransport)`: SSE decode → `Frame` + POST send. Decoupled from HTTP (consumes an SSE-line iterator + a `send` coroutine) so prod is a thin httpx adapter and tests drive the real codec in-memory.
- `transport/agui/endpoint.py` — FastAPI SSE `GET /agui/chat/{agent}/events` + turn-submit `POST /agui/chat/{agent}`, gated by the **P0 auth context** (reused via the same `AuthContext.authenticate` seam — no new auth). Distinct from `ws/chat` (P6). Mounted in `web/server.py`.
- `docs/reference/runtime/agui-transport.md` — the wire protocol reference (event-mapping table + `STATE_*` snapshot/delta contract + present-on-wire + reconnect).

## Scoping decisions flagged for co-vet
- **1 frame ⇄ 1 AG-UI event** (not START/CONTENT/END streaming). reyn's outbox delivers whole messages, not token deltas, so a single content event per message keeps decode unambiguous and the round-trip lossless. The mapping table's role is the generic-client interop surface; fidelity rides `_reyn`. `STEP_*`/WaitingOn semantics are folded into `STATE_*` (the status read-model) rather than emitted as separate step events.
- **`P2_agui_transport_spec.md` was not present in the repo or my broker inbox** — I built to the dispatch brief (which is spec-detailed). Flagging so the co-vet reconciles against the canonical spec.
- **Intervention = DISPLAY only; input = basic turn submit only** (per phase boundary). The answer round-trip methods exist for the ABC but best-effort POST and `pending_intervention_head()` is `None` (HITL answer round-trip = P3).
- **Endpoint session fan-out** is a per-connection `_SessionFrameSource` (server analogue of InProcessTransport off `session.outbox` + filtered `chat_events`). Functional + auth-gated; the heavy N-client production hardening overlaps the ws-consolidation phase.
- **feature-map row deferred** — the feature is not yet actor-reachable (no `reyn chat --connect` wiring until a later phase); flagged rather than adding a premature inventory row.

## Test plan (7 items, Tier 2, real instances, no mocks)
- [x] 1. Bit-identical across transports — AgUi == InProcess == direct baseline, compared by display bytes + WaitingOn sequence (fixed clock). `tests/test_agui_transport_bit_identical.py`
- [x] 2. AG-UI mapping completeness gate — every display kind (AST-scanned from renderer source) + every `renderer_chat_events()` round-trips encode→decode; non-circular (enumerated from renderer vocabulary, not the codec table). `tests/test_agui_mapping_completeness.py`
- [x] 3. present-on-wire inert — presentation rides `CUSTOM`, edge re-guard strips ESC/control from every node leaf. `tests/test_agui_present_on_wire.py`
- [x] 4. `STATE_*` status read-model — snapshot + ≥1 delta → remote `RemoteStatusView` reflects server values (cost + WaitingOn). `tests/test_agui_state_read_model.py`
- [x] 5. Generic-client degrade — event with no `_reyn`, and interleaved foreign events, are skipped; reyn frames still arrive in order. `tests/test_agui_generic_client_degrade.py`
- [x] 6. Reconnect snapshot — first two SSE events are `MESSAGES_SNAPSHOT` then `STATE_SNAPSHOT`; client replays backlog + seeds status. `tests/test_agui_reconnect_snapshot.py`
- [x] 7. Auth reuse — unauthenticated GET/POST refused (401) before attach; correct token passes the gate. `tests/test_agui_auth_reuse.py`

## Strip-falsify RED evidence
Removed the `_reyn` reconstruction block from both codec encoders (cp-backup → edit in place → restore byte-identically; never `git stash`/`checkout`). Both the mapping-completeness gate AND the bit-identical test went **RED** (frames vanish → empty display bytes vs baseline):
```
FAILED tests/test_agui_mapping_completeness.py::test_every_display_kind_round_trips_over_the_wire
FAILED tests/test_agui_mapping_completeness.py::test_every_forwarded_chat_event_round_trips_over_the_wire
FAILED tests/test_agui_transport_bit_identical.py::test_agui_bytes_and_status_match_in_process_and_baseline
3 failed
```
Restored byte-identically (`git diff --stat` clean) → 3 passed.

## CI gates (all green locally)
- `ruff check src tests` — All checks passed (fixed one I001 in a test import block).
- `test_tier_audit.py --strict` (7 test files) — 13 tests, 0 Tier-4 violations.
- `pytest` (full, repo root) — **8145 passed**, 5 failed. All 5 failures are pre-existing route-mount/plugin-loader local-env artifacts (`test_fp0001_routes_mounted`, `test_a2a_routes_mounted`, `test_mcp_routes_mounted`, `test_plugin_loader...`, `test_resources_route_is_mounted_on_app`) — **verified reproducing identically on pristine `origin/main` (8a1b4b6a)**; my change adds zero new failures.
- `verify_module_docstrings.py` (all changed src) — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)