### PR TITLE
docs: add AG-UI event coverage matrix + ja sync + mkdocs nav entry

### DIFF
--- a/.mkdocs/mkdocs.yml
+++ b/.mkdocs/mkdocs.yml
@@ -139,6 +139,7 @@ nav:
           - reference/runtime/control-ir.md
           - reference/runtime/events.md
           - reference/runtime/pipeline-dsl.md
+          - reference/runtime/agui-transport.md
       - Config:
           - Core:
               - reference/config/reyn-yaml.md

--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -1,0 +1,103 @@
+# AG-UI transport — thin-client wire protocol
+
+Reyn の chat client は stream-consuming な UI です: セッションの出力を描画し、ユーザー入力をルーティングし、セッションには **transport seam を通じてのみ**触れます。この 1 つの seam の背後に 2 つの transport があります — ローカルの in-process transport と、この **AG-UI transport**(HTTP + Server-Sent Events / SSE 経由)です。両方とも同一のレンダラーにフィードするため、remote client はローカルと byte-for-byte 同じものを描画します。
+
+このページは wire contract です: SSE エンドポイント、reyn-frame ⇄ AG-UI-event マッピング、`STATE_*` ステータス read-model。
+
+## Surfaces
+
+この transport は **AG-UI のみ** を話します — それは UI であり、agent ではありません。(agent↔agent は A2A、tool は MCP、observability export は OTEL — それぞれ別の surface です。)
+
+- `GET /agui/chat/{agent}/events` — server→client の SSE ストリーム。各 SSE ブロックは `event: <TYPE>\ndata: <json>\n\n`。
+- `POST /agui/chat/{agent}` — client→server のチャンネル。Body は JSON object で、現在のメッセージ type は `{"type": "user_message", "text": "..."}`(ターンの submit)。
+
+両方とも server の authentication context でゲートされます: 接続は token を `?token=` または `Authorization: Bearer <token>` ヘッダーとして提示します(同一マシン上の UDS 接続は代わりに OS peer credential で識別されます)。未認証の接続は、どのセッションにも attach される前に `401` で拒否されます。
+
+## Standard envelope, reyn-private richness
+
+すべての event は **両方**を持ちます:
+
+- **標準 AG-UI field shape** — 汎用の AG-UI client が相互運用可能なコア(text / tool / run / error / state)を描画できるようにするため。そして
+- reyn-private な `_reyn` 再構築ブロック — reyn client がこれから正確な render frame を再構築します。
+
+汎用 client は理解できないものを無視します: `_reyn` ブロックを持たない event(または汎用 client がモデル化しない reyn の `CUSTOM` event)は **スキップされる、致命的ではない** — reyn がこの ignore-unknown contract を所有します。
+
+## Event mapping
+
+client は 1 つの順序付き SSE ストリームを消費し、各 event をレンダラーの 2 つのエントリーポイント(display か working-indicator か)のいずれかにディスパッチします。マッピング:
+
+### Display path(agent 出力 → scrollback)
+
+| reyn display kind | AG-UI event        | 備考                                        |
+|-------------------|--------------------|----------------------------------------------|
+| `agent`           | `TEXT_MESSAGE_CONTENT` | assistant の返信テキスト                  |
+| `status`          | `TEXT_MESSAGE_CONTENT` | 一時的なステータス行(`role: status`)    |
+| `error`           | `RUN_ERROR`        | エラーテキスト                                   |
+| `trace`           | `CUSTOM`           | reyn の tool/step トレース行                    |
+| `intervention`    | `CUSTOM`           | プロンプトが表示される(回答の round-trip は後のフェーズ) |
+| `presentation`    | `CUSTOM`           | `present` op の render-node モデル(*present-on-wire* 参照) |
+| control sentinel  | `CUSTOM`           | `__end__` と client-local な control kind     |
+
+この表にない display kind もすべて losslessly round-trip します(`CUSTOM` にフォールバックし `_reyn` から再構築される)— 新しいレンダラー kind が wire 上で黙って消えることはありません。
+
+### Working-indicator path(ターンライフサイクル + tool 軸)
+
+| reyn chat-event               | AG-UI event      |
+|-------------------------------|------------------|
+| `turn_started`                | `RUN_STARTED`    |
+| `turn_settled` / `turn_completed` / `turn_cancelled` | `RUN_FINISHED` |
+| `tool_called`                 | `TOOL_CALL_START`|
+| `tool_returned` / `tool_failed` | `TOOL_CALL_END`|
+| `user_answered_intervention`  | `CUSTOM`         |
+
+この 8 つが、レンダラーの working / running / waiting-for-you インジケーターが消費する正確なセットです — transport はこのセットをそのまま転送します。
+
+## present-on-wire
+
+`present` op の render モデルは render node の `list[dict]` であり、**構築時に neutralize** されています(すべての leaf string からターミナル制御 / ESC シーケンスが除去済み)— そのため wire に到達する前に inert です。これは `presentation` display kind の下で `CUSTOM` event に乗り、`meta.nodes` に格納されます。
+
+AG-UI client はさらに、**transport edge で**、接続ごとに、すべての node leaf に対して surface neutralizer を再実行します — 構築 seam が既に neutralize した leaf に対しては冪等ですが、upstream が neutralize しなかった(または別の surface 用に neutralize した)heterogeneous-surface client にとっては load-bearing な defense-in-depth です。
+
+## STATE_* — ステータス read-model
+
+ステータスバー(attached agent、model、cost、token、context 使用量、現在の WaitingOn ラベル)は **read-model** であり、ファイルミラーではありません: セッションの live な cost / token / context アクセサと working-indicator の状態から導出され、render に関連するサブセットのみがストリームされます。
+
+- `STATE_SNAPSHOT` — **接続時**に発行される、完全な read-model。フィールド: `attached_name`、`model`、`cost_agent`、`cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、`waiting_on`。
+- `STATE_DELTA` — **変更時**に発行される、変更されたキーのみを運ぶ。アイドルなストリームは delta を発行しません。
+
+client はスナップショットから自身のステータスビューを seed し、各 delta をマージするため、remote のステータスパネルは常に server の値を反映します。
+
+## Reconnect
+
+接続(または再接続)時、server は以下を、どのライブ event よりも前に再生します:
+
+1. `MESSAGES_SNAPSHOT` — display のバックログ(既に生成されたメッセージ)。再接続する client が自身の scrollback を再構築できるようにする。それから
+2. `STATE_SNAPSHOT` — 上記のステータス read-model。
+
+ライブ event(と `STATE_DELTA`)がそれに続きます。
+
+## Local ≡ remote
+
+server はローカルの in-process transport が生成するのと**同じ**統一 frame stream(display outbox + レンダラーに関連する chat-event のサブセット)をシリアライズします。AG-UI transport が加えるのは wire framing のみで、新しい render semantics は一切加えません — そのため remote レンダラーの display バイトと working-indicator の遷移は、ローカルのものと同一です。
+
+## AG-UI event coverage — 数字を正直に読む
+
+**以下の数字にかかわらず、frame loss はゼロ、reyn-client の fidelity は 100% です。** すべての event は reyn-private な `_reyn` 再構築ブロックを運びます(上記の *Standard envelope, reyn-private richness* 参照)。reyn client は常にこれから正確な元の frame を復元します。このセクションの coverage の数字が記述しているのは別のことです: **AG-UI の *標準*イベント語彙のうちどれだけを reyn がネイティブに発行しているか**(= reyn の知識なしに描画できる、汎用の非-reyn AG-UI client が見る信号)であり、`CUSTOM` event に折りたたまれ汎用 client がスキップせざるを得ないものとの対比です。ここでの低い数字は、汎用-client の richness についての記述であり、data loss についての記述ではありません。
+
+| Category   | 標準 event 数 | reyn-mapped | Disposition |
+|------------|-----------------|-------------|--------------|
+| State      | 3                | 3           | **complete** |
+| Lifecycle  | 5                | 3           | **intentional-scope** — 2 つの Step event は独立した標準 event としてではなく `STATE_*` read-model の `waiting_on` フィールドに fold される(上記 *STATE_\* — ステータス read-model* 参照) |
+| Tool       | 5                | 2(→3 予定) | `TOOL_CALL_RESULT` は **next-phase**(後のフェーズの HITL frontend-tool 回答 round-trip で追加される); `TOOL_CALL_ARGS`/`_CHUNK` のペアは **intentional-scope**(reyn が発行する時点で tool call は既に完了しており、chunk 化すべき in-flight な args ストリームが存在しない) |
+| Text       | 4                | 1           | **intentional-scope** — reyn の outbox はトークン差分ではなく whole message を配信するため、メッセージごとに 1 つの `TEXT_MESSAGE_CONTENT` が正直なマッピングです。マップすべき `_START`/`_END`/streaming-chunk フェーズは存在しません |
+| Special    | 2                | 1           | **intentional-scope** — reyn-private なペイロードは常に構造化されている(`CUSTOM`)。標準の `RAW` passthrough event に reyn の use case はありません |
+| Activity   | 2                | 0           | **intentional-scope** — reyn に直接の analog がありません。同じ情報は既に frame stream + `STATE_*` が運んでいます |
+| Reasoning  | 7                | 0           | **future-candidate** — 最も価値の高いギャップ(下記参照) |
+
+**合計**: reyn は active-roster の標準 event **28 件中 9 件**をネイティブに発行しています(`CUSTOM` catch-all 自体を 1 件と数えると 10/28)。この 28 件の roster は Lifecycle(5)+ Text(4)+ Tool(5)+ State(3)+ Activity(2)+ Reasoning(7)+ Special(2)で、canonical な AG-UI event reference(<https://docs.ag-ui.com/concepts/events>)から集計しています。この reference は、active roster 外の meta/deprecated/draft entry を含めると最大で ~34 件の event 名を自称しています — 正確な数字は spec version に依存するため、このページは(より大きい数字ではなく)28 件の active roster を追跡対象としています。
+
+### なぜこのようにギャップが disposition されているか
+
+- **Reasoning(future-candidate、最高価値)。** reyn は既に reasoning を first-class な概念として扱っています。現在、reasoning トレースは `trace` display kind に乗り `CUSTOM` になるため、汎用 client には見えません。これを標準の `Reasoning*` event にマッピングすれば、汎用 AG-UI client がそれを直接描画できるようになります。この機能を出荷する前に尊重しなければならないゲート: reyn の **reasoning-display トグル** — operator が reasoning display を off にしている場合、wire 上にも何も発行されるべきではありません。マッピングがそのトグルを迂回する chain-of-thought 露出経路になってはいけません。
+- **Tool result の fidelity(non-blocking、低コスト)。** 汎用 client は現在、`tool_failed` と `tool_returned` を区別できません — どちらも標準の `TOOL_CALL_END` event に collapse し、失敗の事実は `_reyn`(汎用 client がスキップする)からしか復元できません。reyn-client の fidelity には影響しません。将来のパスで、汎用-client の可視性のために標準の `TOOL_CALL_END` ペイロード自体に error/status フィールドを表面化させることができ、実装コストは低いです。
+- **intentional-scope とマークされたものはすべて**、見落としではなく本物のアーキテクチャ上の違い(reyn の whole-message outbox、構造化のみの private ペイロード、in-flight な tool-args フェーズが無いこと、直接の "activity" 概念が無いこと)を反映しています — これらのギャップを埋めることは、バグを直すことではなく、reyn の設計が意図的に持っていない streaming/chunking の機構を発明することを意味します。

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -118,3 +118,58 @@ transport produces (display outbox + the renderer-relevant chat-event subset).
 The AG-UI transport adds only wire framing, never new render semantics — so the
 remote renderer's display bytes and working-indicator transitions are identical
 to the local ones.
+
+## AG-UI event coverage — reading the numbers honestly
+
+**Frame loss is zero and reyn-client fidelity is 100%, regardless of the
+numbers below.** Every event carries the reyn-private `_reyn` reconstruction
+block (see *Standard envelope, reyn-private richness* above); the reyn client
+always recovers the exact original frame from it. The coverage figures in this
+section describe something different: **how much of the AG-UI *standard*
+event vocabulary** — the signal a *generic*, non-reyn AG-UI client can render
+without any reyn-specific knowledge — reyn currently emits natively, as
+opposed to folding into a `CUSTOM` event a generic client has to skip. A low
+number here is a statement about generic-client richness, not about data
+loss.
+
+| Category   | Standard events | reyn-mapped | Disposition |
+|------------|-----------------|-------------|--------------|
+| State      | 3                | 3           | **complete** |
+| Lifecycle  | 5                | 3           | **intentional-scope** — the 2 Step events fold into the `STATE_*` read-model's `waiting_on` field instead of a separate standard event (see *STATE_\* — the status read-model* above) |
+| Tool       | 5                | 2 (→3 planned) | **next-phase** for `TOOL_CALL_RESULT` (lands with a later phase's HITL frontend-tool answer round-trip); the `TOOL_CALL_ARGS`/`_CHUNK` pair is **intentional-scope** (a tool call is already complete by the time reyn emits it — there is no in-flight args stream to chunk) |
+| Text       | 4                | 1           | **intentional-scope** — reyn's outbox delivers whole messages, not token deltas, so a single `TEXT_MESSAGE_CONTENT` per message is the honest mapping; there is no `_START`/`_END`/streaming-chunk phase to map |
+| Special    | 2                | 1           | **intentional-scope** — reyn-private payloads are always structured (`CUSTOM`); the standard `RAW` passthrough event has no reyn use case |
+| Activity   | 2                | 0           | **intentional-scope** — reyn has no direct analog; the same information is already carried by the frame stream + `STATE_*` |
+| Reasoning  | 7                | 0           | **future-candidate** — the highest-value gap (see below) |
+
+**Totals**: reyn natively emits **9 of the 28** active-roster standard events
+(10/28 counting the `CUSTOM` catch-all itself as one). The 28-event roster is
+Lifecycle (5) + Text (4) + Tool (5) + State (3) + Activity (2) + Reasoning (7)
++ Special (2), tallied from the canonical AG-UI event reference
+(<https://docs.ag-ui.com/concepts/events>). That reference self-reports up to
+~34 event names in total when meta/deprecated/draft entries outside the
+active roster are counted — the exact figure is spec-version dependent, so
+this page tracks the 28-event active roster, not the larger number.
+
+### Why the gaps are dispositioned the way they are
+
+- **Reasoning (future-candidate, highest value).** reyn already treats
+  reasoning as a first-class concept; today a reasoning trace rides the
+  `trace` display kind → `CUSTOM`, invisible to a generic client. Mapping it
+  to the standard `Reasoning*` events would let a generic AG-UI client render
+  it directly. The gate that must be respected before shipping this: reyn's
+  **reasoning-display toggle** — when the operator has reasoning display
+  turned off, nothing should be emitted on the wire either, so a mapping must
+  not become a chain-of-thought exposure path that bypasses that toggle.
+- **Tool result fidelity (non-blocking, low cost).** A generic client cannot
+  currently distinguish `tool_failed` from `tool_returned` — both collapse to
+  the standard `TOOL_CALL_END` event, with the failure fact recoverable only
+  from `_reyn` (which a generic client skips). reyn-client fidelity is
+  unaffected; a future pass could surface an error/status field on the
+  standard `TOOL_CALL_END` payload itself for generic-client visibility, at
+  low implementation cost.
+- **Everything marked intentional-scope** reflects a real architectural
+  difference (reyn's whole-message outbox, structured-only private payloads,
+  no in-flight tool-args phase, no direct "activity" concept) rather than an
+  oversight — closing these gaps would mean inventing streaming/chunking
+  machinery reyn's design deliberately does not have, not fixing a bug.


### PR DESCRIPTION
**[docs-maintainer]** — architect-recommended docs task (lead-coder dispatch), for the AG-UI transport doc landed in #2812.

## What changed
Added the "AG-UI event coverage" section to `agui-transport.md`, framed per architect's guidance to durably prevent a bare "~30% coverage" misreading:

- **Leads with the load-bearing fact before any numbers**: the `_reyn` reconstruction block means frame loss is zero and reyn-client fidelity is 100%, regardless of the coverage figures — the numbers describe *generic-client standard-signal richness*, not data loss.
- **Category matrix** (State/Lifecycle/Tool/Text/Special/Activity/Reasoning) with standard-event count, reyn-mapped count, and disposition (complete / intentional-scope / next-phase / future-candidate) — numerator sourced from `src/reyn/interfaces/transport/agui/protocol.py`'s mapping dicts, denominator from the canonical AG-UI event reference at <https://docs.ag-ui.com/concepts/events> (external-standard citation, not a history ref).
- **28 vs 34 explained**: 28 = the active-category roster tallied here; ~34 = the reference's self-reported total including meta/deprecated/draft entries outside the active roster — not one unexplained number.
- **Per-gap rationale**: Reasoning is the highest-value future-candidate (with the reasoning-display-toggle gate that must be respected before mapping it, so it can't become a silent CoT-exposure path); the `tool_failed`/`tool_returned` collapse is a low-cost, non-blocking generic-client fidelity gap; everything else marked intentional-scope reflects a real architectural difference (whole-message outbox, structured-only private payloads), not an oversight.

## Also
- Added `docs/reference/runtime/agui-transport.ja.md` (full translation, including the new coverage section) — the page had no `.ja.md` sibling yet.
- Added both EN/JA to `.mkdocs/mkdocs.yml`'s Runtime reference nav (the page landed in #2812 without a nav entry).
- `feature-map.md` row remains deferred per #2812's own co-vet verdict ("not actor-reachable until `--connect` wiring" — correct discipline, not silence) — revisit once client-side wiring lands.

## Notes
No PR/ADR/issue-number references in either doc body — the AG-UI reference URL is an external standard citation, not a history ref.

## Test plan
- [x] `mkdocs build --strict` — clean
- [x] `python3 -m pytest tests/test_fp0036_coverage.py -q` — 23 passed
- [x] `ruff check src tests` — all checks passed
- [x] `git diff | grep -oE "#[0-9]{3,4}"` — none found