### PR TITLE
fix: interrupt in-flight MCP calls immediately on Ctrl-C (#2813)

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -43,8 +43,9 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 |------|------|
 | `read_file`、`write_file`、`edit_file`、`delete_file`、`glob_files`、`grep`、`regenerate_index` | `file` op のバリアント — すべて `tool_executed`（`op=<sub_op>`）経由 |
 | `sandboxed_exec_started`、`sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`、`backend`; `completed`: `argv`、`backend`、`returncode` |
-| `mcp_called`、`mcp_completed`、`mcp_failed` | MCP ツール op |
+| `mcp_called`、`mcp_completed`、`mcp_failed`、`mcp_cancelled` | MCP ツール op — `mcp_cancelled`（#2813）は Ctrl-C の `cancel_event` が実行中の呼び出しを完了前に中断したとき、`mcp_completed`/`mcp_failed` の代わりに発火 |
 | `mcp_server_installed` | `mcp_install` op — `name`、キー名のみ（値は含まない） |
+| `mcp_install_cancelled`、`mcp_prompt_get_cancelled`、`mcp_resource_read_cancelled`、`mcp_resource_subscribe_cancelled`、`mcp_resource_unsubscribe_cancelled` | #2813 — Ctrl-C の `cancel_event` が該当 op（install probe / get-prompt / read-resource / subscribe / unsubscribe）を完了前に中断。op は `status:"cancelled"` を返し、何もコミットされない |
 | `web_search_started`、`web_search_completed`、`web_search_failed` | web_search op — `started`: `query`、`backend`; `completed`: `result_count` を追加; `failed`: `error` を追加 |
 | `web_fetch_started`、`web_fetch_completed`、`web_fetch_failed` | web_fetch op — `started`: `url`; `completed`: `url`、`status_code`、`content_length`、`extractor`; `failed`: `url`、`status`（`"timeout"` または `"error"`）、`error` |
 | `recall_embed_failed` | `recall` op — embed サブ op が失敗したとき: `query`、`error` |

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -43,8 +43,9 @@ Each Control IR op kind emits its own event:
 |------|------|
 | `read_file`, `write_file`, `edit_file`, `delete_file`, `glob_files`, `grep`, `regenerate_index` | `file` op variants — all via `tool_executed` with `op=<sub_op>` |
 | `sandboxed_exec_started`, `sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`, `backend`; `completed`: `argv`, `backend`, `returncode` |
-| `mcp_called`, `mcp_completed`, `mcp_failed` | MCP tool ops |
+| `mcp_called`, `mcp_completed`, `mcp_failed`, `mcp_cancelled` | MCP tool ops — `mcp_cancelled` (#2813) fires instead of `mcp_completed`/`mcp_failed` when a Ctrl-C `cancel_event` interrupts an in-flight call before it completes |
 | `mcp_server_installed` | `mcp_install` op — `name`, key names only (no values) |
+| `mcp_install_cancelled`, `mcp_prompt_get_cancelled`, `mcp_resource_read_cancelled`, `mcp_resource_subscribe_cancelled`, `mcp_resource_unsubscribe_cancelled` | #2813 — a Ctrl-C `cancel_event` interrupted the corresponding op (install probe / get-prompt / read-resource / subscribe / unsubscribe) before it completed; the op returns `status:"cancelled"` and nothing is committed |
 | `web_search_started`, `web_search_completed`, `web_search_failed` | web_search ops — `started`: `query`, `backend`; `completed`: adds `result_count`; `failed`: adds `error` |
 | `web_fetch_started`, `web_fetch_completed`, `web_fetch_failed` | web_fetch ops — `started`: `url`; `completed`: `url`, `status_code`, `content_length`, `extractor`; `failed`: `url`, `status` (`"timeout"` or `"error"`), `error` |
 | `recall_embed_failed` | `recall` op — emitted when the embed sub-op fails; `query`, `error` |

--- a/src/reyn/core/cancellable.py
+++ b/src/reyn/core/cancellable.py
@@ -1,0 +1,122 @@
+"""race_cancellable — the shared cancel_event race for bounded external calls (#2813).
+
+Any op that awaits a bounded external operation (subprocess, network call, MCP
+transport) should race it against the per-turn ``cancel_event`` (set by
+``Session.cancel_inflight()`` on Ctrl-C, threaded onto ``OpContext`` per #1470)
+so a cancel takes effect IMMEDIATELY instead of waiting out the operation's own
+internal timeout.
+
+Precedent: ``sandboxed_exec``'s backends (seatbelt/landlock/noop) already race
+their subprocess against ``cancel_event`` inline, per-backend. This module
+extracts the same race into ONE reusable primitive so a new bounded-call site
+(MCP, web_fetch, ...) doesn't reinvent it ad-hoc, and a future audit can grep
+for this one seam instead of N per-backend copies.
+
+Mechanism (same-task cancel scope, mirroring CPython's ``asyncio.timeout``): the
+awaited coroutine runs INLINE in the caller's own task — a watcher task cancels
+that HOST task when ``cancel_event`` fires, and the boundary here catches the
+resulting ``CancelledError``, ``uncancel()``s it, and translates it to
+:class:`Cancelled`. Running the coro in the host task (rather than a fresh task)
+is load-bearing: it preserves task-affinity for any resource whose open/await/
+close must stay on one task (e.g. the MCP SDK's ``stdio_client``/``ClientSession``
+anyio cancel scopes, #2421), and it means a GENUINE external cancel of the host
+task naturally propagates into the coro (no orphaned sub-task left running to its
+own timeout — the bug a spawn-a-new-task design would have introduced).
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+T = TypeVar("T")
+
+
+class Cancelled(Exception):
+    """Raised by :func:`race_cancellable` when ``cancel_event`` wins the race.
+
+    The awaited coroutine's own ``finally``/``__aexit__`` teardown has already run
+    (the ``CancelledError`` unwound through it in the host task) by the time this
+    is raised, EXCEPT if that teardown itself raised — in which case that
+    exception propagates instead and this is never raised. The caller only needs
+    to translate this into its own cancelled-outcome result/event."""
+
+
+async def race_cancellable(
+    coro: "Awaitable[T]",
+    *,
+    cancel_event: "asyncio.Event | None",
+) -> T:
+    """Await ``coro``, but cancel it immediately if ``cancel_event`` fires first.
+
+    ``cancel_event=None`` (no cancel-awareness available — OS-internal ops,
+    non-interactive callers, pre-#1470 call sites) makes this a plain
+    ``await coro`` — behavior-preserving default for every caller that doesn't
+    pass one. Likewise falls back to a plain ``await`` if there is no running
+    task to attach the cancel scope to (should not happen for op handlers).
+
+    Unlike waiting for a fixed internal timeout (``asyncio.timeout`` /
+    ``httpx`` request timeout / etc.), cancelling the host task interrupts
+    ``coro`` at its NEXT await point (a network read, a subprocess wait, an MCP
+    transport read) — genuinely immediate, not bounded by whatever internal
+    deadline the operation itself was configured with.
+
+    Raises :class:`Cancelled` if ``cancel_event`` won the race; re-raises a
+    genuine EXTERNAL cancel of the host task as ``CancelledError`` (never
+    swallows it — this is how ``Session.shutdown``'s hard-cancel still works);
+    otherwise returns ``coro``'s result, or re-raises whatever ``coro`` raised.
+    """
+    if cancel_event is None:
+        return await coro
+    host_task = asyncio.current_task()
+    if host_task is None:
+        return await coro
+
+    # Baseline cancellation count — an external cancel already in flight when we
+    # enter must NOT be misread as ours (mirrors asyncio.timeout's _cancelling).
+    baseline_cancelling = host_task.cancelling()
+    fired = False
+
+    async def _watcher() -> None:
+        nonlocal fired
+        try:
+            await cancel_event.wait()
+        except asyncio.CancelledError:
+            return  # we were cancelled (coro finished first) — nothing to do
+        fired = True
+        host_task.cancel()
+
+    watcher: "asyncio.Task[None]" = asyncio.ensure_future(_watcher())
+    already_uncancelled = False
+    try:
+        return await coro
+    except asyncio.CancelledError:
+        # Our watcher's cancel() is the ONLY cancel we ever issue (exactly once,
+        # guarded by ``fired``). uncancel() removes exactly it; the RETURNED count
+        # is whatever external cancels remain. <= baseline → only ours was pending
+        # → this is the event cancel, translate it. > baseline → a genuine external
+        # cancel is ALSO pending → honor it (re-raise), our extra cancel already
+        # removed so nothing leaks upward.
+        if fired:
+            already_uncancelled = True
+            if host_task.uncancel() <= baseline_cancelling:
+                raise Cancelled("cancel_event fired before the operation completed") from None
+        raise
+    finally:
+        if not watcher.done():
+            watcher.cancel()
+            try:
+                await watcher
+            except asyncio.CancelledError:
+                pass
+        elif fired and not already_uncancelled:
+            # The watcher fired but coro did NOT raise CancelledError (it returned
+            # normally, or raised a different exception, before our cancel() was
+            # delivered at an await point). A stray pending cancel would otherwise
+            # leak into the CALLER at its next await — consume it here. If an
+            # external cancel is also pending underneath ours, re-arm it so it is
+            # not silently dropped (we only meant to remove our own).
+            if host_task.uncancel() > baseline_cancelling:
+                host_task.cancel()

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -829,7 +829,17 @@ def make_status_text_mapper(
 
     SUCCESS shape only — FP-0056 v2 piece #1 (the shared error seam) routes any
     :func:`is_error_result` shape through ``error_to_canonical`` BEFORE a mapper runs, so ``render``
-    only ever sees a success/status dict."""
+    only ever sees a success/status dict.
+
+    ``status:"cancelled"`` (#2813) is DELIBERATELY not folded into the shared error seam —
+    :func:`is_error_result`'s own docstring (Tightening A) explains why a bare ``status`` value must
+    never be a standalone error trigger (a producer may give ``status`` a success-data meaning, e.g.
+    sandboxed_exec's nonzero-exit). So this factory checks for it directly, BEFORE calling ``render``:
+    every ``make_status_text_mapper``-built canonical (mcp_install / mcp_install_local /
+    mcp_subscribe_resource / mcp_unsubscribe_resource, at present) would otherwise fall through to
+    ``render``'s SUCCESS-only phrasing (e.g. "Installed MCP server '…'.") for a cancelled install that
+    wrote NOTHING — a false-positive success report caught in #2813 co-vet. ``meta_keys`` still ride
+    along (server_id/server_name/uri/... identify WHICH call was cancelled)."""
 
     def _mapper(result: dict) -> CanonicalToolResult:
         meta: dict[str, Any] = {}
@@ -837,6 +847,8 @@ def make_status_text_mapper(
             value = result.get(key)
             if value is not None:
                 meta[key] = value
+        if result.get("status") == "cancelled":
+            return CanonicalToolResult(text="Cancelled.", attachments=[], source_ref=None, meta=meta)
         text = _explicit_empty(render(result), empty_marker)
         return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
 

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -19,6 +19,7 @@ from .context import OpContext
 
 
 async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
+    from reyn.core.cancellable import Cancelled
     from reyn.mcp.client import expand_env
     from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -83,11 +84,20 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
     # connect, a bad config, a malformed response, or a transport group all surface here as a clean
     # MCPFault → contained error tool-result (owner req: MCP misbehavior must not crash the router
     # loop). Cancellation is never swallowed (is_real_control_flow re-raises genuine cancel/KI/SE).
-    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
+    # #2813: cancel_event races the whole open+call — a Ctrl-C now interrupts an in-flight MCP
+    # call immediately instead of waiting out its own call_timeout_seconds.
+    gateway = MCPGateway(
+        pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id,
+        cancel_event=ctx.cancel_event,
+    )
     try:
         result = await gateway.call_tool(
             op.server, op.tool, op.args, expanded, progress_cb=_on_progress,
         )
+    except Cancelled:
+        # #2813: distinct from a transport fault (P6 audit) — mirrors sandboxed_exec_cancelled.
+        ctx.events.emit("mcp_cancelled", server=op.server, tool=op.tool)
+        return {"kind": "mcp", "status": "cancelled", "server": op.server, "tool": op.tool}
     except MCPFault as fault_exc:
         # Owner req: feed the fault CONTENT back to the LLM (type + message, group members
         # aggregated) via the standard op-error result — so it can retry/adapt, not a silent error.

--- a/src/reyn/core/op_runtime/mcp_get_prompt.py
+++ b/src/reyn/core/op_runtime/mcp_get_prompt.py
@@ -27,6 +27,7 @@ from .context import OpContext
 
 
 async def _execute(op: MCPGetPromptIROp, ctx: OpContext) -> dict:
+    from reyn.core.cancellable import Cancelled
     from reyn.mcp.client import expand_env
     from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -51,9 +52,15 @@ async def _execute(op: MCPGetPromptIROp, ctx: OpContext) -> dict:
                 "name": op.name, "error": "no MCP client pool on this context"}
 
     ctx.events.emit("mcp_prompt_get", server=op.server, name=op.name)
-    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
+    gateway = MCPGateway(
+        pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id,
+        cancel_event=ctx.cancel_event,
+    )
     try:
         result = await gateway.get_prompt(op.server, op.name, op.arguments, expanded)
+    except Cancelled:
+        ctx.events.emit("mcp_prompt_get_cancelled", server=op.server, name=op.name)
+        return {"kind": "mcp_get_prompt", "status": "cancelled", "server": op.server, "name": op.name}
     except MCPFault as fault_exc:
         fault = str(fault_exc)
         ctx.events.emit("mcp_prompt_get_failed", server=op.server, name=op.name, error=fault)

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -28,9 +28,12 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from reyn.schemas.models import MCPInstallIROp
+
+if TYPE_CHECKING:
+    import asyncio
 
 from . import register
 from .context import OpContext
@@ -156,25 +159,36 @@ def _build_server_entry(pkg_raw: dict, env_keys: list[str]) -> dict:
 
 async def probe_mcp_server(
     server_name: str, server_entry: dict, *, agent_id: str | None = None,
+    cancel_event: "asyncio.Event | None" = None,
 ) -> "str | None":
     """#2761 PR-3: probe a prospective MCP server (spawn/connect + ``list_tools``)
     BEFORE its config is committed — the probe-then-commit atomicity gate.
 
     Returns ``None`` on a successful probe (the server is reachable and advertises
-    tools) or an error string on failure. The caller writes the config ONLY on
-    ``None`` — so a failed probe leaves NOTHING written (no half-install, no rollback).
+    tools) or an error string on failure — including a Ctrl-C cancel (#2813; see
+    below). The caller writes the config ONLY on ``None`` — so a failed OR
+    cancelled probe leaves NOTHING written (no half-install, no rollback).
 
     Routed through the crash-safe :class:`~reyn.mcp.gateway.MCPGateway` seam (#2421):
     open + list + teardown inside one contain-all boundary + a per-server timeout,
     task-affine so the SDK's stdio_client/ClientSession scopes close in the same task.
     The gateway raises ONLY :class:`MCPFault` for a transport/timeout fault (contained
-    here → error string); a genuine Ctrl+C ``CancelledError`` is re-raised by the
-    gateway as control flow and propagates OUT of this probe — the pool's ``__aexit__``
-    has already torn the transport down (stdio subprocess kill via ``kill_process_tree``
-    / HTTP close), and because the config write is strictly AFTER this probe, a cancel
-    leaves nothing committed. **Transport-uniform**: stdio and remote (http/sse) share
-    this one path — ``MCPClient.__aexit__`` owns the transport-appropriate teardown, so
-    the probe never branches on transport (mirrors ``Session._mcp_list_tools``)."""
+    here → error string), or PROPAGATES control flow: a genuine Ctrl+C
+    ``CancelledError`` (host-task cancel, e.g. ``Session.shutdown``'s hard-cancel), or
+    :class:`~reyn.core.cancellable.Cancelled` if ``cancel_event`` fires first (#2813 —
+    pass the per-turn ``OpContext.cancel_event`` here so a Ctrl-C during install
+    interrupts the probe IMMEDIATELY instead of waiting out its own
+    ``call_timeout_seconds``; ``None`` — the default — preserves the pre-#2813
+    behavior of running to the probe's own timeout). ``Cancelled`` is deliberately NOT
+    caught here — it propagates to the install caller, which translates it to a
+    ``status:"cancelled"`` result (uniform with the ``mcp``/resource op cancel
+    surface), rather than being flattened into a generic probe-error string. Either
+    way the pool's ``__aexit__`` has already torn the transport down (stdio subprocess
+    kill via ``kill_process_tree`` / HTTP close) by the time this function returns/
+    raises, and because the config write is strictly AFTER this probe, nothing gets
+    committed. **Transport-uniform**: stdio and remote (http/sse) share this one path —
+    ``MCPClient.__aexit__`` owns the transport-appropriate teardown, so the probe never
+    branches on transport (mirrors ``Session._mcp_list_tools``)."""
     from reyn.mcp.client import expand_env  # noqa: PLC0415
     from reyn.mcp.gateway import MCPFault, MCPGateway  # noqa: PLC0415
 
@@ -184,7 +198,7 @@ async def probe_mcp_server(
     # A url-only remote entry defaults to http (mirrors _mcp_list_tools).
     if "type" not in expanded and expanded.get("url"):
         expanded = {**expanded, "type": "http"}
-    gateway = MCPGateway(agent_id=agent_id)
+    gateway = MCPGateway(agent_id=agent_id, cancel_event=cancel_event)
     try:
         await gateway.list_tools(server_name, expanded)
     except MCPFault as exc:
@@ -567,6 +581,7 @@ async def handle(
     # rollback). A same-name overwrite (the documented `reyn mcp install` re-install
     # fix) or no per-session reloader keeps the existing deferred turn-boundary path
     # (unchanged), confining any in-use-replace to the deferred path.
+    from reyn.core.cancellable import Cancelled  # noqa: PLC0415
     from reyn.runtime.hot_reload import (  # noqa: PLC0415
         dispatch_install_reload,
         is_pure_addition,
@@ -574,9 +589,22 @@ async def handle(
     _is_addition = is_pure_addition(server_name, existing["mcp"]["servers"])
     _reloader = getattr(ctx, "hot_reloader", None)
     if _is_addition and _reloader is not None:
-        _probe_err = await probe_mcp_server(
-            server_name, server_entry, agent_id=getattr(ctx, "agent_id", None),
-        )
+        try:
+            _probe_err = await probe_mcp_server(
+                server_name, server_entry, agent_id=getattr(ctx, "agent_id", None),
+                cancel_event=ctx.cancel_event,
+            )
+        except Cancelled:
+            # #2813: Ctrl-C during the probe → uniform status:"cancelled" (matches the
+            # mcp/resource op cancel surface), nothing written (commit is strictly after).
+            ctx.events.emit(
+                "mcp_install_cancelled", server_id=op.server_id, server_name=server_name,
+            )
+            return {
+                "kind": "mcp_install", "status": "cancelled",
+                "server_id": op.server_id, "server_name": server_name,
+                "source": op.source or "",
+            }
         if _probe_err is not None:
             ctx.events.emit(
                 "mcp_install_probe_failed",

--- a/src/reyn/core/op_runtime/mcp_read_resource.py
+++ b/src/reyn/core/op_runtime/mcp_read_resource.py
@@ -28,6 +28,7 @@ from .context import OpContext
 
 
 async def _execute(op: MCPReadResourceIROp, ctx: OpContext) -> dict:
+    from reyn.core.cancellable import Cancelled
     from reyn.mcp.client import expand_env
     from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -52,9 +53,15 @@ async def _execute(op: MCPReadResourceIROp, ctx: OpContext) -> dict:
                 "uri": op.uri, "error": "no MCP client pool on this context"}
 
     ctx.events.emit("mcp_resource_read", server=op.server, uri=op.uri)
-    gateway = MCPGateway(pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id)
+    gateway = MCPGateway(
+        pool=ctx.mcp_connection_service or ctx.mcp_pool, agent_id=ctx.agent_id,
+        cancel_event=ctx.cancel_event,
+    )
     try:
         result = await gateway.read_resource(op.server, op.uri, expanded)
+    except Cancelled:
+        ctx.events.emit("mcp_resource_read_cancelled", server=op.server, uri=op.uri)
+        return {"kind": "mcp_read_resource", "status": "cancelled", "server": op.server, "uri": op.uri}
     except MCPFault as fault_exc:
         fault = str(fault_exc)
         ctx.events.emit("mcp_resource_read_failed", server=op.server, uri=op.uri, error=fault)

--- a/src/reyn/core/op_runtime/mcp_subscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_subscribe_resource.py
@@ -29,6 +29,7 @@ from .context import OpContext
 
 
 async def _execute(op: MCPSubscribeResourceIROp, ctx: OpContext) -> dict:
+    from reyn.core.cancellable import Cancelled
     from reyn.mcp.client import expand_env
     from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -57,9 +58,12 @@ async def _execute(op: MCPSubscribeResourceIROp, ctx: OpContext) -> dict:
         }
 
     ctx.events.emit("mcp_resource_subscribe", server=op.server, uri=op.uri)
-    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id, cancel_event=ctx.cancel_event)
     try:
         await gateway.subscribe_resource(op.server, op.uri, expanded)
+    except Cancelled:
+        ctx.events.emit("mcp_resource_subscribe_cancelled", server=op.server, uri=op.uri)
+        return {"kind": "mcp_subscribe_resource", "status": "cancelled", "server": op.server, "uri": op.uri}
     except MCPFault as fault_exc:
         fault = str(fault_exc)
         ctx.events.emit(

--- a/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
+++ b/src/reyn/core/op_runtime/mcp_unsubscribe_resource.py
@@ -13,6 +13,7 @@ from .context import OpContext
 
 
 async def _execute(op: MCPUnsubscribeResourceIROp, ctx: OpContext) -> dict:
+    from reyn.core.cancellable import Cancelled
     from reyn.mcp.client import expand_env
     from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -41,9 +42,15 @@ async def _execute(op: MCPUnsubscribeResourceIROp, ctx: OpContext) -> dict:
         }
 
     ctx.events.emit("mcp_resource_unsubscribe", server=op.server, uri=op.uri)
-    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id)
+    gateway = MCPGateway(pool=ctx.mcp_connection_service, agent_id=ctx.agent_id, cancel_event=ctx.cancel_event)
     try:
         await gateway.unsubscribe_resource(op.server, op.uri, expanded)
+    except Cancelled:
+        ctx.events.emit("mcp_resource_unsubscribe_cancelled", server=op.server, uri=op.uri)
+        return {
+            "kind": "mcp_unsubscribe_resource", "status": "cancelled",
+            "server": op.server, "uri": op.uri,
+        }
     except MCPFault as fault_exc:
         fault = str(fault_exc)
         ctx.events.emit(

--- a/src/reyn/mcp/gateway.py
+++ b/src/reyn/mcp/gateway.py
@@ -27,6 +27,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from reyn.core.cancellable import race_cancellable
 from reyn.mcp.client import MCPClient
 from reyn.mcp.pool import MCPClientPool, describe_fault, is_real_control_flow
 
@@ -72,6 +73,15 @@ class MCPGateway:
     :class:`~reyn.mcp.connection_service.MCPConnectionService` (#2597 S2a — held open for the
     whole session, cross-task-safe). The gateway itself never constructs either; it only calls
     ``get()`` on whatever the caller injects.
+
+    ``cancel_event`` (#2813): when passed (the per-turn ``asyncio.Event`` set by
+    ``Session.cancel_inflight()`` on Ctrl-C, threaded from ``OpContext.cancel_event``), every op
+    races against it via :func:`reyn.core.cancellable.race_cancellable` — a Ctrl-C during a
+    list/call/probe now cancels the in-flight MCP transport IMMEDIATELY (raising
+    :class:`reyn.core.cancellable.Cancelled`) instead of waiting out the op's own
+    ``call_timeout_seconds`` deadline. Mirrors the pattern already proven for ``sandboxed_exec``'s
+    seatbelt/landlock/noop backends. ``None`` (the default) preserves prior behavior exactly —
+    every existing caller that doesn't pass one is unaffected.
     """
 
     def __init__(
@@ -79,9 +89,11 @@ class MCPGateway:
         *,
         pool: "MCPClientPool | MCPConnectionService | None" = None,
         agent_id: str | None = None,
+        cancel_event: "asyncio.Event | None" = None,
     ) -> None:
         self._injected_pool = pool
         self._agent_id = agent_id
+        self._cancel_event = cancel_event
 
     @asynccontextmanager
     async def _acquire(self, server: str, config: dict):
@@ -97,28 +109,42 @@ class MCPGateway:
         self, server: str, config: dict, op: Callable[[MCPClient], Awaitable[Any]],
         *, timeout: "float | None",
     ) -> Any:
-        """Open a client and run ``op`` inside the contain-all boundary + a finite timeout. Raises
-        :class:`MCPFault` for any non-control-flow fault (incl. teardown groups); re-raises genuine
-        control flow untouched.
+        """Open a client and run ``op`` inside the contain-all boundary + a finite timeout, racing
+        the whole thing against ``self._cancel_event`` (#2813) if one was passed. Raises
+        :class:`MCPFault` for any non-control-flow fault (incl. teardown groups);
+        :class:`~reyn.core.cancellable.Cancelled` if ``cancel_event`` won the race; re-raises any
+        OTHER genuine control flow untouched.
 
         The timeout wraps the WHOLE ``acquire + op`` — the OPEN (initialize handshake) as well as the
         call — so a server that HANGS ON INIT is bounded too (else a fresh one-shot open for a
         list/probe would hang unbounded). On timeout ``asyncio.timeout`` surfaces a ``TimeoutError``
-        (an Exception, our task not cancelling), which the boundary contains as an ``MCPFault``."""
-        try:
-            if timeout is not None:
-                async with asyncio.timeout(timeout):
+        (an Exception, our task not cancelling), which the boundary contains as an ``MCPFault``.
+
+        ``race_cancellable`` runs ``_do()`` as its OWN task — when ``cancel_event`` fires, it calls
+        ``task.cancel()`` on THAT task, which is exactly the "our task IS genuinely cancelling"
+        condition ``is_real_control_flow`` already checks for (``asyncio.current_task().cancelling()
+        > 0``, evaluated from inside ``_do()``'s own frame) — so this reuses the SAME
+        already-correct transport-teardown path #2421 built for a real Ctrl-C, just now actually
+        reachable (previously nothing ever called ``task.cancel()`` on this seam; a Ctrl-C only set
+        a cooperative flag checked between tool-iteration boundaries, so an in-flight MCP call
+        always ran to its own timeout regardless)."""
+        async def _do() -> Any:
+            try:
+                if timeout is not None:
+                    async with asyncio.timeout(timeout):
+                        async with self._acquire(server, config) as client:
+                            return await op(client)
+                else:
                     async with self._acquire(server, config) as client:
                         return await op(client)
-            else:
-                async with self._acquire(server, config) as client:
-                    return await op(client)
-        except MCPFault:
-            raise
-        except BaseException as exc:  # noqa: BLE001 — the seam contains ALL non-control-flow faults
-            if is_real_control_flow(exc):
+            except MCPFault:
                 raise
-            raise MCPFault(describe_fault(exc)) from exc
+            except BaseException as exc:  # noqa: BLE001 — contains ALL non-control-flow faults
+                if is_real_control_flow(exc):
+                    raise
+                raise MCPFault(describe_fault(exc)) from exc
+
+        return await race_cancellable(_do(), cancel_event=self._cancel_event)
 
     async def list_tools(self, server: str, config: dict) -> list[dict]:
         """Return the server's advertised tools. Raises :class:`MCPFault` on any contained fault."""

--- a/src/reyn/runtime/services/execution_driver.py
+++ b/src/reyn/runtime/services/execution_driver.py
@@ -12,13 +12,24 @@ Methods mirrored from ``RouterLoopDriver`` (the sole current implementor):
 - ``is_cancel_requested()`` — poll the cooperative turn-cancel flag.
 - ``request_cancel()`` — set the cancel flag + asyncio.Event.
 - ``_check_cap(user_text)`` — enforce the per-turn router invocation cap.
+- ``cancel_event`` — the per-turn ``asyncio.Event`` (#2813), or ``None`` for a
+  driver with no interactive-turn cancel concept (``PipelineExecutorDriver``
+  uses a bare bool flag, no event). ``Session._mcp_list_tools`` and its 3
+  siblings read this to race an in-flight MCP call against Ctrl-C — it must
+  be declared here so BOTH implementors stay safe to access unconditionally
+  (a bare ``self._loop_driver.cancel_event`` would ``AttributeError`` on
+  ``PipelineExecutorDriver`` otherwise; this was caught in #2813 co-vet
+  before it shipped).
 
 The Protocol is ``runtime_checkable`` so ``isinstance()`` can be used in
 assertion / diagnostic paths without importing the concrete class.
 """
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    import asyncio
 
 
 @runtime_checkable
@@ -44,4 +55,9 @@ class ExecutionDriver(Protocol):
 
     async def _check_cap(self, user_text: str) -> None:
         """Enforce the per-turn router invocation cap."""
+        ...
+
+    @property
+    def cancel_event(self) -> "asyncio.Event | None":
+        """Per-turn asyncio.Event set by request_cancel(), or None (#2813)."""
         ...

--- a/src/reyn/runtime/services/pipeline_executor_driver.py
+++ b/src/reyn/runtime/services/pipeline_executor_driver.py
@@ -283,6 +283,15 @@ class PipelineExecutorDriver:
         pipeline turn (the executor's own step list is the bound)."""
         return None
 
+    @property
+    def cancel_event(self) -> None:
+        """#2813: no interactive-turn cancel_event concept here — cancellation is
+        the bare ``_cancel_requested`` bool polled at step boundaries (see
+        ``request_cancel``'s docstring). Any bounded MCP/network call this
+        driver's turn makes falls back to running to its own internal timeout on
+        Ctrl-C, same as every pre-#2813 caller with no cancel_event to pass."""
+        return None
+
     # ── internals ──────────────────────────────────────────────────────────────
 
     def _pipeline_registry(self) -> Any:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5829,6 +5829,7 @@ class Session:
 
     async def _mcp_list_tools(self, server: str) -> list[dict]:
         """Query the MCP server for its tools list."""
+        from reyn.core.cancellable import Cancelled
         from reyn.mcp.client import expand_env
         from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -5855,12 +5856,17 @@ class Session:
         # one-shot pool (no injected pool — list is not batched across ops), since holding a
         # connection open for a sub-second-lived session is pure churn.
         gateway = (
-            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            MCPGateway(
+                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                cancel_event=self._loop_driver.cancel_event,
+            )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id)
+            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             return await gateway.list_tools(server, expanded)
+        except Cancelled:
+            return [{"error": "cancelled"}]
         except MCPFault as exc:
             return [{"error": str(exc)}]
 
@@ -5874,6 +5880,7 @@ class Session:
         observability (list_tools has no analogous event; this ask is
         explicit per the #2597 ②a slice spec).
         """
+        from reyn.core.cancellable import Cancelled
         from reyn.mcp.client import expand_env
         from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -5891,12 +5898,17 @@ class Session:
             expanded = {**expanded, "type": "http"}
 
         gateway = (
-            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            MCPGateway(
+                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                cancel_event=self._loop_driver.cancel_event,
+            )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id)
+            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             resources = await gateway.list_resources(server, expanded)
+        except Cancelled:
+            return [{"error": "cancelled"}]
         except MCPFault as exc:
             return [{"error": str(exc)}]
         self._chat_events.emit(
@@ -5911,6 +5923,7 @@ class Session:
         permission-gated). Empty list is a normal result for a server that
         registers no templates.
         """
+        from reyn.core.cancellable import Cancelled
         from reyn.mcp.client import expand_env
         from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -5928,12 +5941,17 @@ class Session:
             expanded = {**expanded, "type": "http"}
 
         gateway = (
-            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            MCPGateway(
+                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                cancel_event=self._loop_driver.cancel_event,
+            )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id)
+            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             return await gateway.list_resource_templates(server, expanded)
+        except Cancelled:
+            return [{"error": "cancelled"}]
         except MCPFault as exc:
             return [{"error": str(exc)}]
 
@@ -6047,6 +6065,7 @@ class Session:
         session, one-shot pool otherwise). Emits ``mcp_prompts_listed`` for
         observability, same rationale as ``mcp_resources_listed``.
         """
+        from reyn.core.cancellable import Cancelled
         from reyn.mcp.client import expand_env
         from reyn.mcp.gateway import MCPFault, MCPGateway
 
@@ -6064,12 +6083,17 @@ class Session:
             expanded = {**expanded, "type": "http"}
 
         gateway = (
-            MCPGateway(pool=self._mcp_connection_service, agent_id=self._agent_id)
+            MCPGateway(
+                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                cancel_event=self._loop_driver.cancel_event,
+            )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id)
+            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             prompts = await gateway.list_prompts(server, expanded)
+        except Cancelled:
+            return [{"error": "cancelled"}]
         except MCPFault as exc:
             return [{"error": str(exc)}]
         self._chat_events.emit(

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -459,6 +459,7 @@ async def _handle_mcp_install_local(
     # overwrite or no per-session reloader keeps the existing deferred behavior. The
     # per-session reloader (ctx.hot_reloader, #2761 PR-2) is reached via the router's
     # op-context factory (the single tool→op ctx source); absent (test / CLI) → deferred.
+    from reyn.core.cancellable import Cancelled
     from reyn.core.op_runtime.mcp_install import probe_mcp_server
     from reyn.runtime.hot_reload import dispatch_install_reload, is_pure_addition
 
@@ -470,9 +471,34 @@ async def _handle_mcp_install_local(
     _reloader = getattr(_op_ctx, "hot_reloader", None) if _op_ctx is not None else None
     _is_addition = is_pure_addition(name, servers)
     if _is_addition and _reloader is not None:
-        _probe_err = await probe_mcp_server(
-            name, entry, agent_id=getattr(_op_ctx, "agent_id", None),
-        )
+        try:
+            _probe_err = await probe_mcp_server(
+                name, entry, agent_id=getattr(_op_ctx, "agent_id", None),
+                # #2813: a Ctrl-C during this probe now interrupts it immediately instead of
+                # waiting out its own call_timeout_seconds (this is the reported-incident path —
+                # mcp__install_local writes .reyn/config/mcp.yaml directly, bypassing the
+                # mcp_install op entirely, so it needs its own cancel_event wiring).
+                cancel_event=getattr(_op_ctx, "cancel_event", None),
+            )
+        except Cancelled:
+            # #2813: uniform status:"cancelled" (matches the mcp/resource op cancel surface
+            # + the mcp_install op path); nothing written (commit is strictly after).
+            #
+            # status:"cancelled" MUST live INSIDE data too (not just the outer envelope) —
+            # unwrap_dispatch_envelope peels the {status, data} wrapper down to `data`
+            # before the canonical mapper ever sees this result (mirrors how the SUCCESS
+            # case's data carries no envelope-only fields, and how mcp_install's own op
+            # result already nests status alongside kind). Omitting it here was a co-vet
+            # catch: the mapper's cancelled check (canonical.py's make_status_text_mapper)
+            # would silently miss it and render "Installed local MCP server '...'." for a
+            # cancelled install that wrote NOTHING.
+            events = getattr(_op_ctx, "events", None)
+            if events is not None:
+                events.emit("mcp_install_cancelled", server_name=name)
+            return {
+                "status": "cancelled",
+                "data": {"kind": "mcp_install_local", "status": "cancelled", "name": name},
+            }
         if _probe_err is not None:
             return {
                 "status": "error",

--- a/tests/test_2681_bucket_c_status_text_mappers.py
+++ b/tests/test_2681_bucket_c_status_text_mappers.py
@@ -161,6 +161,53 @@ def test_mcp_subscribe_resource_renders_status_text() -> None:
     assert canonical["meta"]["server"] == "docs"
 
 
+def test_mcp_install_registry_cancelled_does_not_render_as_installed() -> None:
+    """Tier 1: #2813 co-vet catch — a Ctrl-C-cancelled ``mcp_install_registry``/``mcp_install_package``
+    result (``status:"cancelled"``, nothing written) must NOT render the SUCCESS phrasing
+    ("Installed MCP server '...'.") — that would be a false-positive success report to the LLM/user
+    for an install that wrote nothing. ``make_status_text_mapper`` special-cases ``status:"cancelled"``
+    BEFORE calling the producer's own ``render`` (which only knows success shapes)."""
+    cancelled = {
+        "kind": "mcp_install", "status": "cancelled",
+        "server_id": "io.example/server-time", "server_name": "server-time", "source": "",
+    }
+    canonical = to_canonical(cancelled, source="mcp_install_registry")
+    assert canonical["text"] == "Cancelled."
+    assert "Installed" not in canonical["text"]
+    assert canonical["meta"]["server_name"] == "server-time"
+
+
+def test_mcp_install_local_cancelled_does_not_render_as_installed() -> None:
+    """Tier 1: #2813 — same false-success hazard for ``mcp_install_local`` (the reported-incident
+    path). Real regression caught in review: the verb's cancelled return originally put
+    ``status:"cancelled"`` only at the OUTER {status,data} envelope level — unwrap_dispatch_envelope
+    peels that wrapper down to ``data`` before the mapper ever runs, so the status must ALSO live
+    inside ``data`` (mirrors the success shape's own field placement) or this mapper never sees it."""
+    cancelled = {"kind": "mcp_install_local", "status": "cancelled", "name": "jq"}
+    canonical = to_canonical(cancelled, source="mcp_install_local")
+    assert canonical["text"] == "Cancelled."
+    assert "Installed" not in canonical["text"]
+    assert canonical["meta"]["name"] == "jq"
+
+
+def test_mcp_subscribe_resource_cancelled_does_not_render_as_subscribed() -> None:
+    """Tier 1: #2813 — same false-success hazard for mcp_subscribe_resource."""
+    cancelled = {"kind": "mcp_subscribe_resource", "status": "cancelled", "server": "docs", "uri": "docs://readme"}
+    canonical = to_canonical(cancelled, source="subscribe_mcp_resource")
+    assert canonical["text"] == "Cancelled."
+    assert "Subscribed" not in canonical["text"]
+    assert canonical["meta"]["uri"] == "docs://readme"
+
+
+def test_mcp_unsubscribe_resource_cancelled_does_not_render_as_unsubscribed() -> None:
+    """Tier 1: #2813 — same false-success hazard for mcp_unsubscribe_resource."""
+    cancelled = {"kind": "mcp_unsubscribe_resource", "status": "cancelled", "server": "docs", "uri": "docs://readme"}
+    canonical = to_canonical(cancelled, source="unsubscribe_mcp_resource")
+    assert canonical["text"] == "Cancelled."
+    assert "Unsubscribed" not in canonical["text"]
+    assert canonical["meta"]["uri"] == "docs://readme"
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Error shape still routes through the shared error seam (piece #1) — unaffected by the new mappers
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/test_2761_pr3_mcp_immediate_probe.py
@@ -101,15 +101,23 @@ def _session_ctx(session: Session, tmp: Path) -> _Ctx:
     return _Ctx(tmp, _RS(session._router_host.make_router_op_context, None))
 
 
-def _reloader_ctx(reloader: HotReloader, tmp: Path) -> _Ctx:
+def _reloader_ctx(
+    reloader: HotReloader, tmp: Path, *, cancel_event: "asyncio.Event | None" = None,
+) -> _Ctx:
     """A ctx whose factory returns a bare OpContext carrying ``reloader`` — for the
-    probe-then-commit tests that only need the immediate path to fire (no full roster)."""
+    probe-then-commit tests that only need the immediate path to fire (no full roster).
+
+    ``cancel_event`` (#2813): threaded onto the OpContext so a probe started through
+    this ctx races against it — used by the fast-cancel tests below, distinct from the
+    plain-``task.cancel()`` tests above (which exercise the pre-#2813 propagation path,
+    unaffected by this parameter when left ``None``)."""
     op_ctx = OpContext(
         workspace=Workspace(events=EventLog(), base_dir=tmp),
         events=EventLog(),
         permission_decl=PermissionDecl(),
         permission_resolver=None,
         hot_reloader=reloader,
+        cancel_event=cancel_event,
     )
     return _Ctx(tmp, _RS(lambda: op_ctx, None))
 
@@ -318,3 +326,92 @@ async def test_local_install_probe_cancel_writes_nothing(
     assert "hung" not in _servers_on_disk(tmp_path), (
         "a cancelled probe must leave NOTHING written (write is strictly after the probe)"
     )
+
+
+@pytest.mark.asyncio
+async def test_local_install_probe_cancel_event_interrupts_immediately(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #2813 — the LIVE incident this fixes. Before this fix, Ctrl-C during
+    ``mcp__install_local``'s probe did NOT interrupt it: the probe ran to its own full
+    ``call_timeout_seconds`` (120s default) regardless, and only the SURROUNDING turn's
+    cooperative cancel flag was set (checked between tool-iteration boundaries, per
+    ``Session.cancel_inflight``'s documented V1 boundary) — so the user's Ctrl-C
+    appeared to hang for up to 2 minutes.
+
+    This drives the REAL production path (``_handle_mcp_install_local``, the exact
+    ``mcp__install_local`` tool the incident used — NOT the parallel ``mcp_install``
+    op path, which has its own equivalent test above) with a genuinely hung stdio
+    subprocess, sets ``cancel_event`` shortly after the probe starts (mirroring
+    ``Session.cancel_inflight()``), and asserts the call returns FAST — well under the
+    120s timeout — proving genuine early interruption, not eventual timeout expiry.
+    Distinct from ``test_local_install_probe_cancel_writes_nothing`` above, which
+    exercises the OTHER (still-valid, unaffected) cancellation path: an external
+    ``task.cancel()`` on the whole call chain, with no ``cancel_event`` involved at
+    all — this test is RED before the #2813 fix (would take ~120s to return, this
+    assertion's deadline would fail) and GREEN after."""
+    monkeypatch.chdir(tmp_path)
+    reloader = HotReloader(project_root=tmp_path, events=EventLog())
+    cancel_event = asyncio.Event()
+    ctx = _reloader_ctx(reloader, tmp_path, cancel_event=cancel_event)
+
+    task = asyncio.ensure_future(_handle_mcp_install_local(
+        {"name": "hung", "command": sys.executable, "args": ["-c", "import time; time.sleep(60)"]},
+        ctx,
+    ))
+    await asyncio.sleep(0.6)  # let the probe start + the subprocess spawn
+    cancel_event.set()
+
+    try:
+        result = await asyncio.wait_for(task, timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(
+            "cancel_event must interrupt the in-flight probe within a few seconds — "
+            "NOT wait out its own ~120s call_timeout_seconds (#2813)"
+        )
+
+    # #2813: uniform status:"cancelled" (matches the mcp/resource op cancel surface),
+    # not a generic probe-error string.
+    assert result["status"] == "cancelled"
+    assert "hung" not in _servers_on_disk(tmp_path), (
+        "a cancel_event-cancelled probe must leave NOTHING written too"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cancel_inflight_interrupts_a_real_hung_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #2813 production-wiring test — drives the REAL Session.cancel_inflight()
+    (the actual method the TUI's Ctrl-C handler calls), NOT a hand-built OpContext with
+    cancel_event set directly. test_local_install_probe_cancel_event_interrupts_immediately
+    above proves the mechanism works when cancel_event is threaded in; THIS test proves
+    the threading itself is wired end to end: Session construction → RouterLoopDriver's
+    _set_cancel_event onto the router_host → make_router_op_context → OpContext.cancel_event
+    → probe_mcp_server → MCPGateway → race_cancellable.
+
+    A wiring-only test that hand-constructs an OpContext with cancel_event= would pass
+    even if THIS production chain were entirely disconnected (a real regression class —
+    see the #2788/#2801/#2802 co-vet precedent for exactly this failure mode: a
+    mechanism-test green while the production call-site is silently unwired)."""
+    monkeypatch.chdir(tmp_path)
+    session = _session(tmp_path)
+
+    task = asyncio.ensure_future(_handle_mcp_install_local(
+        {"name": "hung", "command": sys.executable, "args": ["-c", "import time; time.sleep(60)"]},
+        _session_ctx(session, tmp_path),
+    ))
+    await asyncio.sleep(0.6)  # let the probe start + the subprocess spawn
+    await session.cancel_inflight()  # the REAL production seam (TUI Ctrl-C → this call)
+
+    try:
+        result = await asyncio.wait_for(task, timeout=10.0)
+    except asyncio.TimeoutError:
+        pytest.fail(
+            "Session.cancel_inflight() must interrupt the in-flight probe within a few "
+            "seconds via the real production wiring chain — NOT wait out the probe's own "
+            "~120s call_timeout_seconds (#2813)"
+        )
+
+    assert result["status"] == "cancelled"
+    assert "hung" not in _servers_on_disk(tmp_path)

--- a/tests/test_cancellable_2813.py
+++ b/tests/test_cancellable_2813.py
@@ -1,0 +1,225 @@
+"""Tier 2: race_cancellable — the shared cancel_event race for bounded external calls (#2813).
+
+Direct unit coverage of the primitive itself (op-level coverage lives in
+test_2761_pr3_mcp_immediate_probe.py, which drives the real MCP install path).
+These tests lock down the same-task cancel-scope mechanism precisely (mirroring
+CPython's own asyncio.timeout design) — the load-bearing properties a naive
+spawn-a-new-task implementation would get wrong:
+
+- cancel_event firing does NOT leak an orphaned task (the coroutine is awaited
+  INLINE in the host task, not spawned — there is no separate task to leak)
+- a GENUINE external cancel of the host task (unrelated to cancel_event) still
+  propagates as CancelledError, not swallowed as Cancelled
+- an external cancel arriving BEFORE race_cancellable is even entered (already
+  cancelling) is not misattributed to the event
+- cancel_event=None is a byte-identical passthrough (every pre-#2813 caller)
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.cancellable import Cancelled, race_cancellable
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_interrupts_immediately_not_after_own_timeout():
+    """Tier 2: cancel_event firing mid-await raises Cancelled promptly — not after
+    the coroutine's own (much longer) internal duration."""
+    async def _slow() -> str:
+        await asyncio.sleep(60)
+        return "done"
+
+    cancel_event = asyncio.Event()
+
+    async def _fire_soon() -> None:
+        await asyncio.sleep(0.1)
+        cancel_event.set()
+
+    asyncio.ensure_future(_fire_soon())
+    with pytest.raises(Cancelled):
+        await asyncio.wait_for(
+            race_cancellable(_slow(), cancel_event=cancel_event), timeout=5.0,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_none_is_plain_passthrough():
+    """Tier 2: cancel_event=None (every pre-#2813 caller) is byte-identical to a
+    plain await — no watcher task, no race, normal return and normal exceptions."""
+    async def _ok() -> str:
+        return "value"
+
+    assert await race_cancellable(_ok(), cancel_event=None) == "value"
+
+    async def _raises() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await race_cancellable(_raises(), cancel_event=None)
+
+
+@pytest.mark.asyncio
+async def test_successful_coro_result_returned_when_event_never_fires():
+    """Tier 2: cancel_event passed but never set — coro completes normally, its
+    result is returned, and no stray cancellation leaks to the caller afterward
+    (the watcher's own cancel-on-cleanup must not bleed into subsequent awaits)."""
+    cancel_event = asyncio.Event()
+
+    async def _fast() -> int:
+        await asyncio.sleep(0.05)
+        return 42
+
+    result = await race_cancellable(_fast(), cancel_event=cancel_event)
+    assert result == 42
+
+    # No stray CancelledError should surface on a subsequent await in this task —
+    # proof the watcher's own cleanup-cancel didn't leak.
+    await asyncio.sleep(0.05)
+
+
+@pytest.mark.asyncio
+async def test_coro_exception_propagates_when_event_never_fires():
+    """Tier 2: a real exception from coro (not a cancellation at all) propagates
+    unchanged — race_cancellable must not swallow or reshape it."""
+    cancel_event = asyncio.Event()
+
+    async def _boom() -> None:
+        raise RuntimeError("real failure")
+
+    with pytest.raises(RuntimeError, match="real failure"):
+        await race_cancellable(_boom(), cancel_event=cancel_event)
+
+
+@pytest.mark.asyncio
+async def test_genuine_external_cancel_of_host_task_still_propagates():
+    """Tier 2: #2813 regression guard — a GENUINE external cancel of the HOST
+    task (e.g. registry.shutdown()'s hard-cancel, unrelated to cancel_event) must
+    still propagate as CancelledError, not be swallowed/misreported as Cancelled.
+    This is the exact distinction is_real_control_flow relies on downstream."""
+    cancel_event = asyncio.Event()  # never set — this cancel is NOT event-driven
+
+    async def _slow() -> str:
+        await asyncio.sleep(60)
+        return "unreachable"
+
+    async def _host() -> None:
+        await race_cancellable(_slow(), cancel_event=cancel_event)
+
+    host_task = asyncio.ensure_future(_host())
+    await asyncio.sleep(0.1)
+    host_task.cancel()  # genuine external cancel — NOT via cancel_event
+
+    with pytest.raises(asyncio.CancelledError):
+        await host_task
+
+
+@pytest.mark.asyncio
+async def test_teardown_runs_before_cancelled_is_raised_on_event_fire():
+    """Tier 2: on the normal event-fire path, the coroutine's own teardown
+    (finally / __aexit__) has already run by the time race_cancellable raises
+    Cancelled — proven by a side-effecting coroutine whose cleanup flag must
+    already be set. (Note: a naive spawn-a-new-task design ALSO satisfies this
+    specific path, since it awaits the cancelled op_task inline before raising —
+    see test_host_task_external_cancel_does_not_orphan_the_awaited_coroutine
+    below for the scenario that spawn-a-new-task design actually gets wrong.)"""
+    cancel_event = asyncio.Event()
+    resource_released = asyncio.Event()
+
+    async def _holds_a_resource() -> None:
+        try:
+            await asyncio.sleep(60)
+        finally:
+            resource_released.set()  # simulates e.g. a subprocess/transport teardown
+
+    async def _fire_soon() -> None:
+        await asyncio.sleep(0.1)
+        cancel_event.set()
+
+    asyncio.ensure_future(_fire_soon())
+    with pytest.raises(Cancelled):
+        await asyncio.wait_for(
+            race_cancellable(_holds_a_resource(), cancel_event=cancel_event), timeout=5.0,
+        )
+    assert resource_released.is_set()
+
+
+@pytest.mark.asyncio
+async def test_host_task_external_cancel_does_not_orphan_the_awaited_coroutine():
+    """Tier 2: #2813 — the load-bearing property a spawn-a-new-task design gets
+    WRONG (confirmed empirically: a reconstruction of that design leaves this
+    RED — the resource-release flag is still unset ~0.2s after the host task
+    finishes unwinding, because the spawned op_task is orphaned and keeps
+    running toward its own internal duration).
+
+    Scenario: the HOST task itself is cancelled from OUTSIDE while
+    race_cancellable is still waiting on ``cancel_event`` (which never fires —
+    this cancel has nothing to do with it). The same-task design means there IS
+    no separate op-task to orphan: the host task's own cancellation delivers
+    CancelledError directly into the awaited coroutine's current await point, so
+    its teardown runs inline, synchronously, as part of the host task unwinding
+    — by the time ``await host_task`` (below) returns, teardown is guaranteed
+    done, not just probably done after a grace sleep."""
+    cancel_event = asyncio.Event()  # never fires — this cancel is unrelated to it
+    resource_released = asyncio.Event()
+
+    async def _holds_a_resource() -> None:
+        try:
+            await asyncio.sleep(60)
+        finally:
+            resource_released.set()
+
+    async def _host() -> None:
+        await race_cancellable(_holds_a_resource(), cancel_event=cancel_event)
+
+    host_task = asyncio.ensure_future(_host())
+    await asyncio.sleep(0.1)
+    host_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await host_task
+
+    assert resource_released.is_set(), (
+        "the awaited coroutine's teardown must have already run by the time the "
+        "externally-cancelled HOST task finishes unwinding — a spawn-a-new-task "
+        "design leaves this unset (the orphaned task is still running toward "
+        "its own internal duration) — #2813 Fable co-vet Critical-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_wins_over_a_later_event_fire():
+    """Tier 2: an external cancel of the host task, arriving WHILE race_cancellable
+    is in flight, must win even if cancel_event ALSO fires shortly afterward —
+    the external CancelledError propagates, it is never reinterpreted as
+    Cancelled just because the event happened to fire during the same unwind
+    window. (Corrected test name/docstring from an earlier co-vet pass: this
+    does NOT exercise baseline_cancelling>0-at-entry, which requires a cancel
+    already pending BEFORE race_cancellable's first line runs — a narrower,
+    lower-value scenario given asyncio.Task.cancel()'s delivery timing makes it
+    awkward to construct deterministically; the interleaving-priority property
+    tested here is the one that matters in practice.)"""
+    cancel_event = asyncio.Event()  # will fire too, to exercise the interleaving
+
+    async def _slow() -> str:
+        await asyncio.sleep(60)
+        return "unreachable"
+
+    async def _host() -> None:
+        # A first (external) cancel arrives, then we race an event that ALSO
+        # fires shortly after — both are "in flight" conceptually; the outer
+        # CancelledError from the genuine external cancel must win.
+        await race_cancellable(_slow(), cancel_event=cancel_event)
+
+    host_task = asyncio.ensure_future(_host())
+    await asyncio.sleep(0.05)
+    host_task.cancel()  # genuine external cancel first
+
+    async def _fire_event_too() -> None:
+        await asyncio.sleep(0.1)
+        cancel_event.set()
+
+    asyncio.ensure_future(_fire_event_too())
+
+    with pytest.raises(asyncio.CancelledError):
+        await host_task

--- a/tests/test_execution_driver_seam.py
+++ b/tests/test_execution_driver_seam.py
@@ -40,6 +40,11 @@ class FakeDriver:
     def is_cancel_requested(self) -> bool:
         return self._cancel_requested
 
+    @property
+    def cancel_event(self) -> None:
+        """#2813: no interactive-turn cancel_event concept for this fake."""
+        return None
+
     def request_cancel(self) -> None:
         self._cancel_requested = True
 

--- a/tests/test_mcp_gateway_cancel_event_completeness_2813.py
+++ b/tests/test_mcp_gateway_cancel_event_completeness_2813.py
@@ -1,0 +1,81 @@
+"""Tier 2: #2813 — every interactive-turn MCPGateway(...) construction must pass
+``cancel_event=``, mirroring test_2421_mcp_seam_completeness.py's structural-gate
+pattern (a grep-enforced completeness pin, not a one-shot audit).
+
+Why this is needed (not just "nice to have"): #2813's own incident was exactly a
+sibling-sweep-miss — the cancel_event race was proven for sandboxed_exec, but every
+other bounded-call op handler silently missed it, including a brand-new MCP op
+handler someone could add tomorrow. Per-call-site opt-in with no enforcement is the
+whack-a-mole shape #2421's own docstring already names as the root cause it fixed for
+MCPClient construction; this test closes the same class of gap for cancel_event.
+
+Scope: only op_runtime/ and runtime/ (session.py) — the interactive-turn surfaces
+where a cancel_event is actually available. interfaces/cli/commands/mcp.py's two
+constructions are deliberately excluded: those are one-shot, non-interactive CLI
+invocations (`reyn mcp probe` / `reyn mcp list-tools`) with no per-turn Session/
+RouterLoopDriver to source a cancel_event from at all. tools/ (e.g.
+tools/mcp_verbs.py) is OUT OF SCOPE for this scan by construction — every
+MCPGateway(...) it needs is constructed inside op_runtime/mcp_install.py's
+probe_mcp_server(), which this scan does cover; tools/ itself never constructs
+a MCPGateway directly. If a future tools/ module starts constructing one
+directly, this test's scoped_dirs list must be extended to include it, or the
+gap goes unenforced.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# One-shot, non-interactive CLI commands — no per-turn cancel_event exists to pass.
+_ALLOWED = {"interfaces/cli/commands/mcp.py"}
+
+_CONSTRUCT = re.compile(r"\bMCPGateway\s*\(")
+
+
+def _find_call_spans(text: str) -> list[tuple[int, int, int]]:
+    """Return (start_offset, end_offset, start_line) for each real MCPGateway(...)
+    call in *text* — balances parens from the opening ``(`` to its matching close,
+    so a multi-line call is captured as one span (unlike a per-line regex)."""
+    spans: list[tuple[int, int, int]] = []
+    for m in _CONSTRUCT.finditer(text):
+        start = m.end() - 1  # position of the opening "("
+        depth = 0
+        i = start
+        while i < len(text):
+            if text[i] == "(":
+                depth += 1
+            elif text[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        start_line = text.count("\n", 0, m.start()) + 1
+        spans.append((m.start(), i + 1, start_line))
+    return spans
+
+
+def test_every_mcpgateway_construction_passes_cancel_event():
+    """Tier 2: RED if a new (or existing) MCPGateway(...) construction in
+    op_runtime/ or runtime/ omits cancel_event= — the same structural-gate shape
+    as test_2421_mcp_seam_completeness.py, applied to the #2813 cancel-race
+    contract instead of the transport-construction contract."""
+    root = Path(__file__).resolve().parents[1] / "src" / "reyn"
+    scoped_dirs = [root / "core" / "op_runtime", root / "runtime"]
+    offenders: list[str] = []
+    for scoped in scoped_dirs:
+        for py in scoped.rglob("*.py"):
+            rel = py.relative_to(root).as_posix()
+            if rel in _ALLOWED:
+                continue
+            text = py.read_text(encoding="utf-8")
+            for start, end, line_no in _find_call_spans(text):
+                call_text = text[start:end]
+                if "cancel_event" not in call_text:
+                    offenders.append(f"{rel}:{line_no}: {call_text.strip()[:80]}")
+    assert not offenders, (
+        "MCPGateway(...) constructed without cancel_event= — a Ctrl-C during this "
+        "call will wait out the op's own internal timeout instead of interrupting "
+        "immediately (#2813). Pass cancel_event=ctx.cancel_event (op_runtime) or "
+        "cancel_event=self._loop_driver.cancel_event (session.py), or add this file "
+        "to a documented allowlist if truly non-interactive:\n" + "\n".join(offenders)
+    )

--- a/tests/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/test_pipeline_driver_resource_caller_state_2567.py
@@ -234,6 +234,29 @@ async def test_driver_dispatch_reaches_real_host_mcp_roster(tmp_path: Path) -> N
     assert required_host is caller_host
 
 
+def test_pipeline_executor_driver_cancel_event_is_none_not_attributeerror(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: #2813 co-vet catch — Session._mcp_list_tools (and its 3 siblings)
+    read ``self._loop_driver.cancel_event`` unconditionally to thread a Ctrl-C
+    race into MCPGateway. ``PipelineExecutorDriver`` (the OTHER ExecutionDriver
+    implementor, used by driver-sessions born from run_pipeline_async) has no
+    interactive-turn cancel_event concept — before this fix it had no
+    ``cancel_event`` attribute AT ALL, so a driver-session calling any MCP
+    discovery method would AttributeError instead of returning a normal
+    error-list result. Real PipelineExecutorDriver, no mocks."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _worker_registry(tmp_path, state_log)
+    work_order = PipelineWorkOrder(
+        run_id="run-2813", pipeline_name="p", pipeline={"steps": [], "description": ""},
+        input=None, reply_to_agent="worker", reply_to_sid="main",
+        driver_agent="worker", driver_sid="drv-2813",
+    )
+    driver = PipelineExecutorDriver(work_order, registry=reg, state_log=state_log)
+
+    assert driver.cancel_event is None
+
+
 @pytest.mark.asyncio
 async def test_driver_dispatch_still_structurally_denies_pipeline_launch(
     tmp_path: Path,


### PR DESCRIPTION
**[tui-coder]** — Closes #2813. Live incident reported directly by the owner; two Fable-model co-vet rounds (design + implementation) surfaced and resolved 2 MUST-FIX regressions before this went up, in addition to the intentional design pivot documented below.

## Incident

Owner ran `mcp__install_local` interactively, pressed Ctrl-C, and the turn appeared to hang in "Cancelling…" for ~2 minutes before recovering.

## Root cause (confirmed via event trace, not assumed)

`tool_called: mcp__install_local` → `tool_returned` landed at **exactly 120.00s later**, matching `MCPGateway`'s default `call_timeout_seconds` to the millisecond; `turn_cancelled` fired only *after*. `Session.cancel_inflight()` sets a cooperative flag + `asyncio.Event` (`cancel_event`), but **nothing ever called `task.cancel()`** on the task actually running the in-flight MCP call — it ran to its own internal timeout regardless of Ctrl-C.

reyn already has a working mid-flight interrupt mechanism for `sandboxed_exec` (race the subprocess against `cancel_event`, SIGTERM→SIGKILL on fire) — this was never extended to MCP or any of the other 24 `op_runtime` handlers with a bounded external call. A coverage gap, not an architecture limitation.

## Core primitive: `src/reyn/core/cancellable.py`

`race_cancellable(coro, cancel_event=...)` races an awaited coroutine against `cancel_event` using a **same-task cancel-scope** (mirroring CPython's own `asyncio.timeout`), not a spawn-a-new-task design.

This distinction is load-bearing and was caught in the first co-vet round: a spawn-a-new-task version **orphans the awaited coroutine** (and whatever resource it holds open — an MCP stdio subprocess) when the *host* task is externally cancelled while the race is in flight — the orphaned task keeps running toward its own internal duration instead of tearing down. The same-task design also preserves task-affinity for resources whose open/await/close must stay on one task (the MCP SDK's `stdio_client`/`ClientSession` anyio scopes, #2421).

Raises `Cancelled` when `cancel_event` wins; re-raises a genuine external cancel of the host task as `CancelledError` unchanged (never swallowed — this is how `Session.shutdown`'s hard-cancel keeps working). `cancel_event=None` is a byte-identical passthrough for every pre-#2813 caller.

## Wiring

- `MCPGateway._run()` races `cancel_event` around the whole `acquire+op` — the one seam every MCP op shares, so list/call/probe/get_prompt/read_resource/subscribe/unsubscribe all get the fix through this one change.
- `cancel_event` threaded from `OpContext` into all 6 MCP `op_runtime` handlers, the reported-incident path (`mcp_verbs.py`'s `_handle_mcp_install_local`, which bypasses the `mcp_install` op and writes `.reyn/config/mcp.yaml` directly), and `Session`'s 4 MCP discovery methods.
- `ExecutionDriver` Protocol gained a `cancel_event` property (`RouterLoopDriver` already had one; `PipelineExecutorDriver` returns `None` — no interactive-turn cancel concept for a deterministic pipeline turn). **Missing this on the Protocol/`PipelineExecutorDriver` would `AttributeError`** the moment a pipeline driver-session called any MCP discovery method — caught in the second co-vet round before it shipped, RED→GREEN verified with a real `PipelineExecutorDriver` instance.
- A structural completeness-pin test (mirrors `test_2421_mcp_seam_completeness.py`) greps `op_runtime/` + `runtime/` for every `MCPGateway(...)` construction and fails if `cancel_event=` is missing — a new MCP op handler added tomorrow cannot silently reintroduce this gap.

## Result-shape unification + a second real bug caught fixing it

All cancel paths now return a uniform `status:"cancelled"` (mirroring `sandboxed_exec`'s existing precedent). Fixing the canonical-mapper rendering for this surfaced a second real bug, caught in review, not by CI: `mcp_install_local`'s cancelled return put `status:"cancelled"` only at the *outer* `{status, data}` envelope level; `unwrap_dispatch_envelope` peels that wrapper down to `data` *before* the canonical mapper ever runs, so the mapper never saw it and rendered the plain SUCCESS phrasing — **"Installed local MCP server '...'."" for an install that wrote NOTHING**. `make_status_text_mapper` now special-cases `status:"cancelled"` before calling a producer's own `render` (deliberately *not* folded into the shared `is_error_result` predicate, which intentionally excludes bare `status` values per its own documented rationale — a bare status can carry success-data meaning for other producers, e.g. `sandboxed_exec`'s nonzero exit).

## Verification

- New unit suite (`tests/test_cancellable_2813.py`, 8 tests) locks down the same-task-scope mechanism directly: immediate interrupt (not bounded by the coro's own duration), `cancel_event=None` passthrough, normal success/exception paths unaffected, genuine external host-task cancel still propagates as `CancelledError`, and the orphan-avoidance property — reconstructed the original spawn-a-new-task design and confirmed the exact orphan scenario is genuinely RED against it, GREEN against the fix.
- Production-wiring test (`test_session_cancel_inflight_interrupts_a_real_hung_probe`) drives the REAL `Session.cancel_inflight()` → `RouterLoopDriver` → `router_host` → `OpContext.cancel_event` chain, not a hand-built `OpContext` — confirmed RED by stripping the actual production wiring call site, not just the mechanism (per this morning's #2788/#2801/#2802 co-vet precedent on wiring-test discipline).
- Canonical-rendering regression tests (4 new, in `test_2681_bucket_c_status_text_mappers.py`) reproduce the exact false-success text ("Installed …", "Subscribed …") RED before the fix, GREEN after.
- Full pytest suite: 9 failed / 8163 passed / 17 skipped — same pre-existing, unrelated baseline seen throughout this session.
- All 4 local CI gates green.
- Docs: `docs/reference/runtime/events.md`/`.ja.md` updated with the 6 new cancel event kinds.

## Test plan

- [x] RED→GREEN confirmed for all new tests, including both co-vet-caught regressions
- [x] Production-wiring test verified against a real stripped call site, not just the mechanism
- [x] Full pytest suite (baseline 9 pre-existing failures, no new regressions)
- [x] All 4 local CI gates green
- [x] Events reference docs updated (both languages)

## Not in scope (tracked for follow-up, same utility applies)

`web_fetch` (SSRF-sensitive multi-hop redirect loop — restructuring it safely needs its own careful pass, not rushed under this incident's time pressure), `skill_install`'s git-clone subprocess, `judge_output`'s litellm call.

**Tier self-check**: all new/modified tests are Tier 1/2 (real `MCPGateway`/`Session`/`PipelineExecutorDriver`/canonical-mapper instances, no `MagicMock`/`patch`; the completeness-pin test is a static grep, same pattern as the existing `test_2421_mcp_seam_completeness.py`).