### PR TITLE
feat: P4 AG-UI generic-client conformance + reyn extension profile (ADR-0039)

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -1,103 +1,332 @@
-# AG-UI transport — thin-client wire protocol
+# AG-UI transport — シンクライアントのワイヤープロトコル
 
-Reyn の chat client は stream-consuming な UI です: セッションの出力を描画し、ユーザー入力をルーティングし、セッションには **transport seam を通じてのみ**触れます。この 1 つの seam の背後に 2 つの transport があります — ローカルの in-process transport と、この **AG-UI transport**(HTTP + Server-Sent Events / SSE 経由)です。両方とも同一のレンダラーにフィードするため、remote client はローカルと byte-for-byte 同じものを描画します。
+Reyn のチャットクライアントはストリームを消費する UI である — セッションの出力を描画し、
+ユーザー入力をルーティングし、セッションには**transport seam を通じてのみ**接触する。この
+1 つの seam の背後には 2 つの transport がある — ローカルの in-process transport と、この
+**AG-UI transport**(HTTP + Server-Sent Events / SSE 経由)だ。両方とも同一のレンダラーへ
+フィードするため、リモートクライアントはローカルのものと byte-for-byte 同一の描画を行う。
 
-このページは wire contract です: SSE エンドポイント、reyn-frame ⇄ AG-UI-event マッピング、`STATE_*` ステータス read-model。
+このページは wire contract そのものである。SSE エンドポイント、reyn-frame ⇄ AG-UI-event の
+マッピング、そして `STATE_*` ステータス read-model を扱う。
 
 ## Surfaces
 
-この transport は **AG-UI のみ** を話します — それは UI であり、agent ではありません。(agent↔agent は A2A、tool は MCP、observability export は OTEL — それぞれ別の surface です。)
+この transport が話すのは **AG-UI のみ**である — これは UI であり、agent ではない
+(agent↔agent は A2A、tool は MCP、observability export は OTEL — それぞれ別の surface で
+ある)。
 
-- `GET /agui/chat/{agent}/events` — server→client の SSE ストリーム。各 SSE ブロックは `event: <TYPE>\ndata: <json>\n\n`。
-- `POST /agui/chat/{agent}` — client→server のチャンネル。Body は JSON object で、現在のメッセージ type は `{"type": "user_message", "text": "..."}`(ターンの submit)。
+- `GET /agui/chat/{agent}/events` — server→client の SSE ストリーム。各 SSE ブロックは
+  `event: <TYPE>\ndata: <json>\n\n` である。
+- `POST /agui/chat/{agent}` — client→server のチャンネル。Body は JSON object で、サポート
+  されるメッセージ type は以下の通り:
+  - `{"type": "user_message", "text": "..."}` — ターンを submit する。
+  - `{"type": "TOOL_CALL_RESULT", "toolCallId": "<intervention-id>", "text": "..."}` または
+    `{..., "choiceId": "<id>"}` — pending 中の intervention に回答する(HITL の round-trip;
+    下記「Human-in-the-loop answering」参照)。
+  - `{"type": "cancel_inflight"}` — in-flight なターンを協調的にキャンセルする(Ctrl-C
+    seam)。
+  - `{"type": "heartbeat"}` — liveness の keepalive。
 
-両方とも server の authentication context でゲートされます: 接続は token を `?token=` または `Authorization: Bearer <token>` ヘッダーとして提示します(同一マシン上の UDS 接続は代わりに OS peer credential で識別されます)。未認証の接続は、どのセッションにも attach される前に `401` で拒否されます。
+  server がモデル化していない入力 type は**グレースフルな no-op**(`200` の ack)であり、
+  `500` にはならない — これが server 側の ignore-unknown である。
+- `POST /agui/chat/{agent}/seize` — active-driver トークンを取得する(「Active driver and
+  seize」参照)。
+
+client が server をシャットダウンすることは決してできない — shutdown メッセージは存在せず、
+client の `/quit` はローカルな切断にすぎない。server が唯一の writer である。
+
+connection は `connection_id` クエリパラメータ(または `X-Reyn-Connection` ヘッダー)で自身を
+識別し、その値は SSE ストリームと POST を通じて安定している。
+
+両方とも server の authentication context によってゲートされる: connection は token を
+`?token=` または `Authorization: Bearer <token>` ヘッダーとして提示する(同一マシン上の UDS
+connection は代わりに OS の peer credential で識別される)。未認証の connection は、どの
+session にも attach される前に `401` で拒否される。この transport を開く operator 向けの
+コマンドは `reyn chat --connect <url>`(bearer token 用の `--token <secret>`、フォールバック
+として `REYN_WEB_AUTH_TOKEN` 環境変数)である。
 
 ## Standard envelope, reyn-private richness
 
-すべての event は **両方**を持ちます:
+すべての event は**両方**を運ぶ:
 
-- **標準 AG-UI field shape** — 汎用の AG-UI client が相互運用可能なコア(text / tool / run / error / state)を描画できるようにするため。そして
-- reyn-private な `_reyn` 再構築ブロック — reyn client がこれから正確な render frame を再構築します。
+- **標準的な AG-UI field shape** — 汎用の AG-UI client が相互運用可能なコア(text / tool /
+  run / error / state)を描画できるようにするため。そして
+- reyn-private な `_reyn` 再構成ブロック — reyn client がこれから正確な render frame を
+  再構築する。
 
-汎用 client は理解できないものを無視します: `_reyn` ブロックを持たない event(または汎用 client がモデル化しない reyn の `CUSTOM` event)は **スキップされる、致命的ではない** — reyn がこの ignore-unknown contract を所有します。
+汎用 client は理解できないものを無視する: `_reyn` ブロックを持たない event(または汎用
+client がモデル化しない reyn の `CUSTOM` event)は**スキップされる、致命的ではない** —
+reyn がこの ignore-unknown contract を所有する。
 
 ## Event mapping
 
-client は 1 つの順序付き SSE ストリームを消費し、各 event をレンダラーの 2 つのエントリーポイント(display か working-indicator か)のいずれかにディスパッチします。マッピング:
+client は 1 つの順序付き SSE ストリームを消費し、各 event をレンダラーの 2 つのエントリー
+ポイント(display か working-indicator か)のいずれかにディスパッチする。マッピングは
+以下の通り。
 
 ### Display path(agent 出力 → scrollback)
 
-| reyn display kind | AG-UI event        | 備考                                        |
+| reyn display kind | AG-UI event        | Notes                                        |
 |-------------------|--------------------|----------------------------------------------|
-| `agent`           | `TEXT_MESSAGE_CONTENT` | assistant の返信テキスト                  |
-| `status`          | `TEXT_MESSAGE_CONTENT` | 一時的なステータス行(`role: status`)    |
-| `error`           | `RUN_ERROR`        | エラーテキスト                                   |
+| `agent`           | text triplet       | assistant の返信テキスト(*text lifecycle* 参照) |
+| `status`          | text triplet       | 一時的なステータス行(`role: status`)        |
+| `error`           | `RUN_ERROR`        | エラーテキスト                                |
 | `trace`           | `CUSTOM`           | reyn の tool/step トレース行                    |
-| `intervention`    | `CUSTOM`           | プロンプトが表示される(回答の round-trip は後のフェーズ) |
+| `intervention`    | `CUSTOM`           | プロンプトが表示される。reyn client はそれをネイティブに描画し、id で回答する(「Human-in-the-loop answering」参照) |
 | `presentation`    | `CUSTOM`           | `present` op の render-node モデル(*present-on-wire* 参照) |
-| control sentinel  | `CUSTOM`           | `__end__` と client-local な control kind     |
+| control sentinels | `CUSTOM`           | `__end__` と client-local な control kind     |
 
-この表にない display kind もすべて losslessly round-trip します(`CUSTOM` にフォールバックし `_reyn` から再構築される)— 新しいレンダラー kind が wire 上で黙って消えることはありません。
+この表にない display kind もすべて損失なく round-trip する(`CUSTOM` にフォールバックし
+`_reyn` から再構成される)— 新しい renderer kind がワイヤー上で静かに消えることは決してない。
 
-### Working-indicator path(ターンライフサイクル + tool 軸)
+#### Text lifecycle(適合する triplet)
+
+AG-UI 仕様は、text lifecycle として**`TEXT_MESSAGE_START` → 1 つ以上の
+`TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`、すべて `messageId` で相関付けられる**ことを
+必須としている。裸の `TEXT_MESSAGE_CONTENT` は不正である(厳格な汎用クライアントはそれを
+破棄する)。したがって reyn のテキストメッセージ 1 件はこの triplet としてワイヤーに乗り、
+メッセージごとに生成される id を伴い(reyn の outbox には安定した message id がない)、
+CONTENT の `delta` がメッセージ全文を運ぶ(reyn は whole-message であり、トークン
+ストリーミングは scope 外である)。
+
+`_reyn` 再構成ブロックを運ぶのは **CONTENT** イベントのみである。START と END イベントは
+汎用のスキャフォールドであり、reyn client はそれらを `None` にデコードして無視する。その
+ため再構成の invariant は**1 フレーム ⇄ 1 つの `_reyn` 保持イベント**のままであり、reyn
+client はメッセージごとにちょうど 1 つの display frame を再構築する。
+
+### Working-indicator path(turn lifecycle + tool 軸)
 
 | reyn chat-event               | AG-UI event      |
 |-------------------------------|------------------|
 | `turn_started`                | `RUN_STARTED`    |
 | `turn_settled` / `turn_completed` / `turn_cancelled` | `RUN_FINISHED` |
 | `tool_called`                 | `TOOL_CALL_START`|
-| `tool_returned` / `tool_failed` | `TOOL_CALL_END`|
+| `tool_returned` / `tool_failed` | `TOOL_CALL_END` (with `status`) |
 | `user_answered_intervention`  | `CUSTOM`         |
 
-この 8 つが、レンダラーの working / running / waiting-for-you インジケーターが消費する正確なセットです — transport はこのセットをそのまま転送します。
+これらの 8 つが、レンダラーの working / running / waiting-for-you インジケーターが消費する
+正確なセットである — transport はこのセットをそのまま転送する。
+
+`TOOL_CALL_END` は etype から導出された標準の `status` フィールド(`"ok"` / `"error"`)を
+運ぶ — `tool_failed` → `"error"`、`tool_returned` → `"ok"` — これにより汎用クライアントも
+ツールの失敗を認識できる。reyn client は依然として `_reyn` から正確な etype を
+exact-recover する。
+
+### Intervention frontend-tool
+
+display frame と並行して、server は `toolName` が `reyn.intervention.<kind>`、`toolCallId`
+が intervention id であるような、対になる `TOOL_CALL_START` **frontend-tool** を発行する。
+汎用 AG-UI client はこれを通常の tool call として描画・回答できる。reyn client はこれを、
+どの intervention が pending かを知るためだけに使う — プロンプト自体は display frame から
+自ら描画するため、二重描画は発生しない。intervention が解決(回答または拒否)されると、
+server は終端の `TOOL_CALL_RESULT` を発行するため、pending の frontend-tool が宙に浮くこと
+はない。
+
+## Human-in-the-loop answering
+
+intervention への回答は permission grant **そのもの**であり、すべての回答は配信時に認証
+**かつ**認可される。client は信頼されない: server は identity を再認可し、回答を
+intervention 自身の**自前のコピー**(id、および choice id があればそれ)に照らして検証する
+— client がエコーする prompt / choices は信頼されない。
+
+回答は**id によって**配信される: `TOOL_CALL_RESULT` の `toolCallId` は operator に提示され
+た正確な intervention を指定するため、grant はその prompt に着地し、別のキュー中の
+intervention に着地することは決してない。未知の id、または既に回答済みの id は拒否される
+(client は通常のターンにフォールバックする)— 最も古いものに回答するというフォールバック
+は存在しない。
+
+認証済みの人間の operator による回答は unfenced である(信頼された operator 入力として
+扱われる)。internal な agent-to-agent path 経由で外部の agent peer から届く回答は fenced
+のままである(異なる、信頼されない trust class)。
+
+Attribution: 回答済みの各 grant は、認証済みの user id とその発信元 connection とともに
+audit trail に記録される。attach / seize / detach も同様に監査される。
+
+## Active driver and seize
+
+複数の terminal が 1 つの session に attach でき、すべてが同じ出力を見る。ある時点で厳密に
+1 つの connection だけが **active-driver token**(回答/操作する権限)を保持する。これは
+UX 上の調整トークンであり、security control ではない。
+
+認可された任意の connection は、handshake なしにトークンを**seize**(`POST
+/agui/chat/{agent}/seize`)できる — 想定されるケースは、1 人の operator がノート PC と
+デスクトップを行き来する場合である。以前の保持者は保持しない対等な peer となり、seize し
+返すこともできる。
+
+seize は、未認証 / 未認可の connection、または attach された surface を持たない connection
+に対しては拒否される。地位を追われた保持者の in-flight な回答は配信時に拒否される(もはや
+active driver ではないため)。
+
+## Fail-close and the grace window
+
+pending の intervention が、いなくなった operator を待って永遠にハングすることは決してあっ
+てはならない。ある intervention に対する最後の回答可能な operator surface が失われたとき
+— in-process な detach、または network の切断 / heartbeat タイムアウトのいずれか — その
+intervention は型付けされた拒否(run がそこから継続する fail-closed な回答)で解決され、
+放置されることはない。
+
+これが起きるのは**grace window**を経過した後のみである: window 内での短い切断と再接続は
+intervention を pending のまま保ち、正常に再開する。surface がゼロのまま grace window を
+丸ごと経過した場合にのみ拒否がトリガーされる。
+
+liveness signal(定期的な heartbeat)により、half-open な connection が死んだ surface を
+隠すことはできない: liveness タイムアウトを超えて heartbeat を止めた surface は失われたと
+検出される。
+
+拒否は**intervention ごと**に scope される: 別の live な surface(例えば外部の agent peer
+が回答しているもの)がまだ回答可能な intervention は、operator の terminal がすべていなく
+なっても pending のまま残される。
 
 ## present-on-wire
 
-`present` op の render モデルは render node の `list[dict]` であり、**構築時に neutralize** されています(すべての leaf string からターミナル制御 / ESC シーケンスが除去済み)— そのため wire に到達する前に inert です。これは `presentation` display kind の下で `CUSTOM` event に乗り、`meta.nodes` に格納されます。
+`present` op の render モデルは render node の `list[dict]` であり、**構築時に neutralize**
+されている(すべての leaf 文字列からターミナル制御 / ESC シーケンスが除去済み)ため、どの
+wire に到達する前にも inert である。これは `presentation` display kind の下で `CUSTOM`
+event に乗り、`meta.nodes` に格納される。
 
-AG-UI client はさらに、**transport edge で**、接続ごとに、すべての node leaf に対して surface neutralizer を再実行します — 構築 seam が既に neutralize した leaf に対しては冪等ですが、upstream が neutralize しなかった(または別の surface 用に neutralize した)heterogeneous-surface client にとっては load-bearing な defense-in-depth です。
+AG-UI client はさらに、**transport edge で**、接続ごとに、すべての node leaf に対して
+surface neutralizer を再実行する — 構築 seam が既に neutralize した leaf に対しては冪等だ
+が、upstream が neutralize しなかった(あるいは別の surface 用に neutralize した)
+heterogeneous-surface client にとっては load-bearing な defense-in-depth である。
 
 ## STATE_* — ステータス read-model
 
-ステータスバー(attached agent、model、cost、token、context 使用量、現在の WaitingOn ラベル)は **read-model** であり、ファイルミラーではありません: セッションの live な cost / token / context アクセサと working-indicator の状態から導出され、render に関連するサブセットのみがストリームされます。
+ステータスバー(attached agent、model、cost、tokens、context usage、そして現在の
+WaitingOn ラベル)は**read-model**であり、ファイルミラーではない: これはセッションの生き
+た cost / token / context アクセサと working-indicator の状態から導出され、render に関連
+する部分集合のみがストリームされる。
 
-- `STATE_SNAPSHOT` — **接続時**に発行される、完全な read-model。フィールド: `attached_name`、`model`、`cost_agent`、`cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、`waiting_on`。
-- `STATE_DELTA` — **変更時**に発行される、変更されたキーのみを運ぶ。アイドルなストリームは delta を発行しません。
+- `STATE_SNAPSHOT` — **接続時**に発行される、read-model 全体。フィールド: `attached_name`、
+  `model`、`cost_agent`、`cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、
+  `waiting_on`。
+- `STATE_DELTA` — **変更時**に発行され、変更されたキーのみを運ぶ。アイドルなストリームは
+  delta を発行しない。
 
-client はスナップショットから自身のステータスビューを seed し、各 delta をマージするため、remote のステータスパネルは常に server の値を反映します。
+client は snapshot から自身のステータスビューを seed し、各 delta をマージするため、
+remote のステータスパネルは常に server の値を反映する。
 
 ## Reconnect
 
-接続(または再接続)時、server は以下を、どのライブ event よりも前に再生します:
+接続(または再接続)時、server はどのライブ event よりも前に、以下を replay する:
 
-1. `MESSAGES_SNAPSHOT` — display のバックログ(既に生成されたメッセージ)。再接続する client が自身の scrollback を再構築できるようにする。それから
+1. `MESSAGES_SNAPSHOT` — display のバックログ(既に生成されたメッセージ)。再接続する
+   client が自身の scrollback を再構築できるようにする。続いて
 2. `STATE_SNAPSHOT` — 上記のステータス read-model。
 
-ライブ event(と `STATE_DELTA`)がそれに続きます。
+その後にライブ event(および `STATE_DELTA`)が続く。
+
+`MESSAGES_SNAPSHOT` の `messages` フィールドは、会話ターンのみからなる標準的な
+`[{role, content}]` **配列**である — `agent` → `assistant`、`user` → `user` — これは汎用
+client が期待する形状である。reyn の chrome(status / error / present / intervention /
+trace)は会話ターンではないため、この標準配列からは除外される。reyn client は `_reyn`
+ブロックからバックログ全体(chrome を含む)を再構築するため、その scrollback は変わらない。
+
+## The reyn extension profile
+
+相互運用可能なコアを超えて、reyn は reyn 所有の namespace の下に自分自身の語彙を名付ける
+— 標準的な対応物を持たない chrome のための `CUSTOM`-event `name`、そして intervention の
+ための frontend-tool `toolName` である。この namespace は**文書化され、テストされた拡張
+プロファイル**である: reyn が発行するすべての `reyn.*` name はレジストリエントリを持つ。
+completeness gate が、レンダラーのソース語彙(および intervention frontend-tool エンコー
+ダー)から reyn-mapped な語彙を列挙し、発行される各 name がプロファイル済みであることを
+assert するため、このプロファイルは codec がワイヤーに乗せるものから静かにドリフトする
+ことがない。
+
+3 つの namespace がある:
+
+### `reyn.display.<kind>`
+
+標準的な AG-UI 対応物を持たない reyn の display frame。`value` は `{"text": <string>}` —
+display 行のテキストである。
+
+| Custom `name`                     | Meaning                                              |
+|-----------------------------------|------------------------------------------------------|
+| `reyn.display.trace`              | reyn の tool/step トレース行                           |
+| `reyn.display.intervention`       | intervention プロンプトが表示される                     |
+| `reyn.display.presentation`       | `present` op のテキスト。render-node モデルは `_reyn` ブロックの `meta.nodes` に乗る(ワイヤー上は inert — *present-on-wire* 参照) |
+| `reyn.display.nodes`              | 生の render-node display 行                            |
+| `reyn.display.user`               | scrollback にライブでエコーされる user-authored な行(backlog の user ターンは代わりに標準の `messages` 配列に乗る) |
+| `reyn.display.tool_call_started`  | tool-call 開始のトレース行                              |
+| `reyn.display.tool_call_completed`| tool-call 完了のトレース行                              |
+| `reyn.display.tool_call_failed`   | tool-call 失敗のトレース行                              |
+
+### `reyn.event.<etype>`
+
+標準的な AG-UI 対応物を持たない reyn の chat-event(working-indicator 軸)。`value` は
+そのイベントのデータオブジェクトである。
+
+| Custom `name`                        | Meaning                                          |
+|--------------------------------------|--------------------------------------------------|
+| `reyn.event.user_answered_intervention` | ユーザーが intervention に回答した              |
+
+### `reyn.intervention.<kind>`
+
+上記の 2 つとは異なる形で運ばれる**open namespace**である: これは HITL **frontend-tool**
+の `TOOL_CALL_START`(`CUSTOM` ではなく標準 event — *Intervention frontend-tool* 参照)の
+`toolName` であり、そのため汎用 client は intervention を通常の tool call として描画・
+回答できる。`<kind>` は intervention の種類(`ask_user`、`permission.*`、…)であり、呼び
+出し元が与えるものであるため、これは閉じたメンバー集合としてではなく、**namespace** レベル
+(固定された値 schema)でプロファイルされる。
+
+- **`toolCallId`** — intervention id(client が `TOOL_CALL_RESULT` でそのまま echo し返す、
+  回答の相関アンカー)。
+- **`args`** — `{prompt, detail, choices, suggestions}`、汎用 client が質問を提示するため
+  に描画するもの。
+
+上記の `reyn.display.*` と `reyn.event.*` の namespace は、汎用 client が無視する
+`CUSTOM`-event name である(スキップされ、致命的エラーにはならない); reyn client は
+`_reyn` ブロックから正確な frame を再構成する。client がまだ知らない未知の `reyn.*` name
+も同様にスキップされ、致命的エラーにはならない。
 
 ## Local ≡ remote
 
-server はローカルの in-process transport が生成するのと**同じ**統一 frame stream(display outbox + レンダラーに関連する chat-event のサブセット)をシリアライズします。AG-UI transport が加えるのは wire framing のみで、新しい render semantics は一切加えません — そのため remote レンダラーの display バイトと working-indicator の遷移は、ローカルのものと同一です。
+server は、ローカルの in-process transport が生成するのと**同一の**統一 frame stream
+(display outbox + レンダラーに関連する chat-event の部分集合)をシリアライズする。AG-UI
+transport が加えるのは wire framing のみであり、新しい render semantics は一切加えない —
+そのため remote レンダラーの display バイト列と working-indicator の遷移は、ローカルの
+ものと同一である。
 
 ## AG-UI event coverage — 数字を正直に読む
 
-**以下の数字にかかわらず、frame loss はゼロ、reyn-client の fidelity は 100% です。** すべての event は reyn-private な `_reyn` 再構築ブロックを運びます(上記の *Standard envelope, reyn-private richness* 参照)。reyn client は常にこれから正確な元の frame を復元します。このセクションの coverage の数字が記述しているのは別のことです: **AG-UI の *標準*イベント語彙のうちどれだけを reyn がネイティブに発行しているか**(= reyn の知識なしに描画できる、汎用の非-reyn AG-UI client が見る信号)であり、`CUSTOM` event に折りたたまれ汎用 client がスキップせざるを得ないものとの対比です。ここでの低い数字は、汎用-client の richness についての記述であり、data loss についての記述ではありません。
+**以下の数字にかかわらず、frame loss はゼロであり、reyn-client の fidelity は 100% で
+ある。** すべての event は reyn-private な `_reyn` 再構成ブロックを運ぶ(上記の
+*Standard envelope, reyn-private richness* 参照)。reyn client は常にこれから正確な元の
+frame を復元する。このセクションの coverage の数字が記述しているのは別のことである:
+**AG-UI の *標準* event 語彙のうちどれだけを** — reyn 固有の知識なしに描画できる、汎用の
+非-reyn AG-UI client が見る信号を — reyn が現在ネイティブに発行しているか、対して汎用
+client がスキップせざるを得ない `CUSTOM` event に折りたたんでいるか、である。ここでの
+低い数字は、汎用-client の richness についての記述であり、data loss についての記述では
+ない。
 
-| Category   | 標準 event 数 | reyn-mapped | Disposition |
+| Category   | Standard events | reyn-mapped | Disposition |
 |------------|-----------------|-------------|--------------|
 | State      | 3                | 3           | **complete** |
-| Lifecycle  | 5                | 3           | **intentional-scope** — 2 つの Step event は独立した標準 event としてではなく `STATE_*` read-model の `waiting_on` フィールドに fold される(上記 *STATE_\* — ステータス read-model* 参照) |
-| Tool       | 5                | 2(→3 予定) | `TOOL_CALL_RESULT` は **next-phase**(後のフェーズの HITL frontend-tool 回答 round-trip で追加される); `TOOL_CALL_ARGS`/`_CHUNK` のペアは **intentional-scope**(reyn が発行する時点で tool call は既に完了しており、chunk 化すべき in-flight な args ストリームが存在しない) |
-| Text       | 4                | 1           | **intentional-scope** — reyn の outbox はトークン差分ではなく whole message を配信するため、メッセージごとに 1 つの `TEXT_MESSAGE_CONTENT` が正直なマッピングです。マップすべき `_START`/`_END`/streaming-chunk フェーズは存在しません |
-| Special    | 2                | 1           | **intentional-scope** — reyn-private なペイロードは常に構造化されている(`CUSTOM`)。標準の `RAW` passthrough event に reyn の use case はありません |
-| Activity   | 2                | 0           | **intentional-scope** — reyn に直接の analog がありません。同じ情報は既に frame stream + `STATE_*` が運んでいます |
+| Lifecycle  | 5                | 3           | **intentional-scope** — 2 つの Step event は、独立した標準 event としてではなく `STATE_*` read-model の `waiting_on` フィールドに fold される(上記 *STATE_\* — the status read-model* 参照) |
+| Tool       | 5                | 3           | **complete for the HITL round-trip** — `TOOL_CALL_START` + `TOOL_CALL_END`(標準の `status` フィールド付き)+ `TOOL_CALL_RESULT`(intervention frontend-tool の回答 round-trip); `TOOL_CALL_ARGS`/`_CHUNK` のペアは **intentional-scope** である(reyn が発行する時点で tool call は既に完了しており、chunk 化すべき in-flight な args ストリームは存在しない) |
+| Text       | 4                | 3           | **conforming triplet** — メッセージ 1 件全体が `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END` に乗り、`messageId` で相関付けられる。マップされていないのはストリーミング用の `TEXT_MESSAGE_CHUNK` のみである(**intentional-scope** — reyn の outbox はトークン差分ではなく whole message を配信する) |
+| Special    | 2                | 1           | **intentional-scope** — reyn-private なペイロードは常に構造化されている(`CUSTOM`)。標準の `RAW` passthrough event に reyn の use case はない |
+| Activity   | 2                | 0           | **intentional-scope** — reyn に直接の analog はない。同じ情報は既に frame stream + `STATE_*` が運んでいる |
 | Reasoning  | 7                | 0           | **future-candidate** — 最も価値の高いギャップ(下記参照) |
 
-**合計**: reyn は active-roster の標準 event **28 件中 9 件**をネイティブに発行しています(`CUSTOM` catch-all 自体を 1 件と数えると 10/28)。この 28 件の roster は Lifecycle(5)+ Text(4)+ Tool(5)+ State(3)+ Activity(2)+ Reasoning(7)+ Special(2)で、canonical な AG-UI event reference(<https://docs.ag-ui.com/concepts/events>)から集計しています。この reference は、active roster 外の meta/deprecated/draft entry を含めると最大で ~34 件の event 名を自称しています — 正確な数字は spec version に依存するため、このページは(より大きい数字ではなく)28 件の active roster を追跡対象としています。
+**合計**: reyn は active-roster の標準 event **28 件中 12 件**をネイティブに発行している
+(`CUSTOM` catch-all 自体を 1 件と数えると 13/28)。この 28 件の roster は、Lifecycle
+(5)+ Text(4)+ Tool(5)+ State(3)+ Activity(2)+ Reasoning(7)+ Special(2)であり、
+canonical な AG-UI event reference(<https://docs.ag-ui.com/concepts/events>)から集計
+している。この reference は、active roster 外の meta/deprecated/draft entry を含めると
+最大で ~34 件の event 名を自称している — 正確な数字は spec version に依存するため、この
+ページは(より大きい数字ではなく)28 件の active roster を追跡対象とする。
 
 ### なぜこのようにギャップが disposition されているか
 
-- **Reasoning(future-candidate、最高価値)。** reyn は既に reasoning を first-class な概念として扱っています。現在、reasoning トレースは `trace` display kind に乗り `CUSTOM` になるため、汎用 client には見えません。これを標準の `Reasoning*` event にマッピングすれば、汎用 AG-UI client がそれを直接描画できるようになります。この機能を出荷する前に尊重しなければならないゲート: reyn の **reasoning-display トグル** — operator が reasoning display を off にしている場合、wire 上にも何も発行されるべきではありません。マッピングがそのトグルを迂回する chain-of-thought 露出経路になってはいけません。
-- **Tool result の fidelity(non-blocking、低コスト)。** 汎用 client は現在、`tool_failed` と `tool_returned` を区別できません — どちらも標準の `TOOL_CALL_END` event に collapse し、失敗の事実は `_reyn`(汎用 client がスキップする)からしか復元できません。reyn-client の fidelity には影響しません。将来のパスで、汎用-client の可視性のために標準の `TOOL_CALL_END` ペイロード自体に error/status フィールドを表面化させることができ、実装コストは低いです。
-- **intentional-scope とマークされたものはすべて**、見落としではなく本物のアーキテクチャ上の違い(reyn の whole-message outbox、構造化のみの private ペイロード、in-flight な tool-args フェーズが無いこと、直接の "activity" 概念が無いこと)を反映しています — これらのギャップを埋めることは、バグを直すことではなく、reyn の設計が意図的に持っていない streaming/chunking の機構を発明することを意味します。
+- **Reasoning(future-candidate、最高価値)。** reyn は既に reasoning を first-class な
+  概念として扱っている。現在、reasoning トレースは `trace` display kind に乗り `CUSTOM`
+  になるため、汎用 client には見えない。これを標準の `Reasoning*` event にマッピングすれ
+  ば、汎用 AG-UI client がそれを直接描画できるようになる。これを出荷する前に尊重しなけれ
+  ばならないゲート: reyn の **reasoning-display トグル** — operator が reasoning display
+  を off にしている場合、wire 上にも何も発行されるべきではない。マッピングが、そのトグル
+  を迂回する chain-of-thought 露出経路になってはならない。
+- **intentional-scope とマークされたものはすべて**、見落としではなく本物のアーキテクチャ
+  上の違い(reyn の whole-message outbox、構造化のみの private ペイロード、in-flight な
+  tool-args フェーズが無いこと、直接の "activity" 概念が無いこと)を反映している —
+  これらのギャップを埋めることは、バグを直すことではなく、reyn の設計が意図的に持ってい
+  ない streaming/chunking の機構を発明することを意味する。

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -25,6 +25,9 @@ A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
   - `{"type": "cancel_inflight"}` — cooperatively cancel the in-flight turn (the
     Ctrl-C seam).
   - `{"type": "heartbeat"}` — a liveness keepalive.
+
+  An input type the server does not model is a **graceful no-op** (a `200` ack),
+  never a `500` — the server half of ignore-unknown.
 - `POST /agui/chat/{agent}/seize` — take the active-driver token (see "Active
   driver and seize").
 
@@ -64,8 +67,8 @@ of the renderer's two entry points (display vs working-indicator). The mapping:
 
 | reyn display kind | AG-UI event        | Notes                                        |
 |-------------------|--------------------|----------------------------------------------|
-| `agent`           | `TEXT_MESSAGE_CONTENT` | the assistant reply text                  |
-| `status`          | `TEXT_MESSAGE_CONTENT` | transient status line (`role: status`)    |
+| `agent`           | text triplet       | the assistant reply text (see *text lifecycle*) |
+| `status`          | text triplet       | transient status line (`role: status`)       |
 | `error`           | `RUN_ERROR`        | error text                                   |
 | `trace`           | `CUSTOM`           | reyn tool/step trace line                    |
 | `intervention`    | `CUSTOM`           | a prompt is displayed; the reyn client draws it natively and answers it by id (see "Human-in-the-loop answering") |
@@ -76,6 +79,21 @@ Any display kind not in this table still round-trips losslessly (it falls back t
 `CUSTOM` and is reconstructed from `_reyn`) — a new renderer kind can never
 silently vanish on the wire.
 
+#### Text lifecycle (the conforming triplet)
+
+The AG-UI spec mandates the text lifecycle **`TEXT_MESSAGE_START` → one or more
+`TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`, all correlated by a `messageId`**; a
+bare `TEXT_MESSAGE_CONTENT` is invalid (a strict generic client drops it). A whole
+reyn text message therefore rides the wire as that triplet, with a generated
+per-message id (reyn's outbox has no stable message id) and the CONTENT `delta`
+carrying the full message text (reyn is whole-message; token-streaming is out of
+scope).
+
+Only the **CONTENT** event carries the `_reyn` reconstruction block; the START and
+END events are generic scaffold that the reyn client decodes to `None` and
+ignores. So the reconstruction invariant stays **one frame ⇄ one `_reyn`-bearing
+event**, and the reyn client rebuilds exactly one display frame per message.
+
 ### Working-indicator path (turn lifecycle + tool axis)
 
 | reyn chat-event               | AG-UI event      |
@@ -83,11 +101,16 @@ silently vanish on the wire.
 | `turn_started`                | `RUN_STARTED`    |
 | `turn_settled` / `turn_completed` / `turn_cancelled` | `RUN_FINISHED` |
 | `tool_called`                 | `TOOL_CALL_START`|
-| `tool_returned` / `tool_failed` | `TOOL_CALL_END`|
+| `tool_returned` / `tool_failed` | `TOOL_CALL_END` (with `status`) |
 | `user_answered_intervention`  | `CUSTOM`         |
 
 These eight are the exact set the renderer's working / running / waiting-for-you
 indicator consumes; the transport forwards precisely this set.
+
+`TOOL_CALL_END` carries a standard `status` field (`"ok"` / `"error"`) derived
+from the etype — `tool_failed` → `"error"`, `tool_returned` → `"ok"` — so a
+generic client sees a tool failure. The reyn client still exact-recovers the
+precise etype from `_reyn`.
 
 ### Intervention frontend-tool
 
@@ -198,6 +221,70 @@ On connect (or reconnect) the server replays, before any live event:
 
 Live events (and `STATE_DELTA`s) follow.
 
+The `MESSAGES_SNAPSHOT` `messages` field is a **standard `[{role, content}]`
+array of conversation turns only** — `agent` → `assistant`, `user` → `user` — the
+shape a generic client expects. reyn chrome (status / error / present /
+intervention / trace) is not a conversation turn and is excluded from the standard
+array; the reyn client rebuilds the full backlog (chrome included) from the
+`_reyn` block, so its scrollback is unchanged.
+
+## The reyn extension profile
+
+Beyond the interoperable core, reyn names its own vocabulary under a reyn-owned
+namespace — the `CUSTOM`-event `name` for chrome with no standard analog, and the
+frontend-tool `toolName` for interventions. This namespace is a **documented,
+tested extension profile**: every `reyn.*` name reyn emits has a registry entry. A
+completeness gate enumerates the reyn-mapped vocabulary from the renderer's source
+vocabulary (plus the intervention frontend-tool encoder) and asserts each emitted
+name is profiled, so the profile cannot silently drift from what the codec puts on
+the wire.
+
+Three namespaces:
+
+### `reyn.display.<kind>`
+
+A reyn display frame with no standard AG-UI analog. `value` is `{"text": <string>}`
+— the display line text.
+
+| Custom `name`                     | Meaning                                              |
+|-----------------------------------|------------------------------------------------------|
+| `reyn.display.trace`              | a reyn tool/step trace line                           |
+| `reyn.display.intervention`       | an intervention prompt is displayed                   |
+| `reyn.display.presentation`       | a `present` op's text; the render-node model rides the `_reyn` block's `meta.nodes` (inert on the wire — see *present-on-wire*) |
+| `reyn.display.nodes`              | a raw render-node display line                         |
+| `reyn.display.user`               | a user-authored line echoed live to the scrollback (backlog user turns ride the standard `messages` array instead) |
+| `reyn.display.tool_call_started`  | a tool-call start trace line                           |
+| `reyn.display.tool_call_completed`| a tool-call completion trace line                     |
+| `reyn.display.tool_call_failed`   | a tool-call failure trace line                        |
+
+### `reyn.event.<etype>`
+
+A reyn chat-event (working-indicator axis) with no standard AG-UI analog. `value`
+is the event's data object.
+
+| Custom `name`                        | Meaning                                          |
+|--------------------------------------|--------------------------------------------------|
+| `reyn.event.user_answered_intervention` | the user answered an intervention             |
+
+### `reyn.intervention.<kind>`
+
+An **open namespace** carried differently from the two above: it is the `toolName`
+of the HITL **frontend-tool** `TOOL_CALL_START` (a standard event, not a `CUSTOM`
+one — see *Intervention frontend-tool*), so a generic client can render and answer
+an intervention as an ordinary tool call. `<kind>` is the intervention kind
+(`ask_user`, `permission.*`, …) — caller-supplied, so this is profiled at the
+**namespace** level (fixed value schema), not as a closed member set.
+
+- **`toolCallId`** — the intervention id (the answer-correlation anchor a client
+  echoes back verbatim in a `TOOL_CALL_RESULT`).
+- **`args`** — `{prompt, detail, choices, suggestions}`, what a generic client
+  renders to pose the question.
+
+The `reyn.display.*` and `reyn.event.*` namespaces above are `CUSTOM`-event names a
+generic client ignores (skipped, not fatal); the reyn client reconstructs the exact
+frame from the `_reyn` block. An unknown `reyn.*` name a client predates is likewise
+skipped, not fatal.
+
 ## Local ≡ remote
 
 The server serializes the SAME unified frame stream the local in-process
@@ -223,14 +310,14 @@ loss.
 |------------|-----------------|-------------|--------------|
 | State      | 3                | 3           | **complete** |
 | Lifecycle  | 5                | 3           | **intentional-scope** — the 2 Step events fold into the `STATE_*` read-model's `waiting_on` field instead of a separate standard event (see *STATE_\* — the status read-model* above) |
-| Tool       | 5                | 2 (→3 planned) | **next-phase** for `TOOL_CALL_RESULT` (lands with a later phase's HITL frontend-tool answer round-trip); the `TOOL_CALL_ARGS`/`_CHUNK` pair is **intentional-scope** (a tool call is already complete by the time reyn emits it — there is no in-flight args stream to chunk) |
-| Text       | 4                | 1           | **intentional-scope** — reyn's outbox delivers whole messages, not token deltas, so a single `TEXT_MESSAGE_CONTENT` per message is the honest mapping; there is no `_START`/`_END`/streaming-chunk phase to map |
+| Tool       | 5                | 3           | **complete for the HITL round-trip** — `TOOL_CALL_START` + `TOOL_CALL_END` (with a standard `status` field) + `TOOL_CALL_RESULT` (the intervention frontend-tool answer round-trip); the `TOOL_CALL_ARGS`/`_CHUNK` pair is **intentional-scope** (a tool call is already complete by the time reyn emits it — there is no in-flight args stream to chunk) |
+| Text       | 4                | 3           | **conforming triplet** — a whole message rides `TEXT_MESSAGE_START` → `TEXT_MESSAGE_CONTENT` → `TEXT_MESSAGE_END`, correlated by `messageId`; only the streaming `TEXT_MESSAGE_CHUNK` is unmapped (**intentional-scope** — reyn's outbox delivers whole messages, not token deltas) |
 | Special    | 2                | 1           | **intentional-scope** — reyn-private payloads are always structured (`CUSTOM`); the standard `RAW` passthrough event has no reyn use case |
 | Activity   | 2                | 0           | **intentional-scope** — reyn has no direct analog; the same information is already carried by the frame stream + `STATE_*` |
 | Reasoning  | 7                | 0           | **future-candidate** — the highest-value gap (see below) |
 
-**Totals**: reyn natively emits **9 of the 28** active-roster standard events
-(10/28 counting the `CUSTOM` catch-all itself as one). The 28-event roster is
+**Totals**: reyn natively emits **12 of the 28** active-roster standard events
+(13/28 counting the `CUSTOM` catch-all itself as one). The 28-event roster is
 Lifecycle (5) + Text (4) + Tool (5) + State (3) + Activity (2) + Reasoning (7)
 + Special (2), tallied from the canonical AG-UI event reference
 (<https://docs.ag-ui.com/concepts/events>). That reference self-reports up to
@@ -248,13 +335,6 @@ this page tracks the 28-event active roster, not the larger number.
   **reasoning-display toggle** — when the operator has reasoning display
   turned off, nothing should be emitted on the wire either, so a mapping must
   not become a chain-of-thought exposure path that bypasses that toggle.
-- **Tool result fidelity (non-blocking, low cost).** A generic client cannot
-  currently distinguish `tool_failed` from `tool_returned` — both collapse to
-  the standard `TOOL_CALL_END` event, with the failure fact recoverable only
-  from `_reyn` (which a generic client skips). reyn-client fidelity is
-  unaffected; a future pass could surface an error/status field on the
-  standard `TOOL_CALL_END` payload itself for generic-client visibility, at
-  low implementation cost.
 - **Everything marked intentional-scope** reflects a real architectural
   difference (reyn's whole-message outbox, structured-only private payloads,
   no in-flight tool-args phase, no direct "activity" concept) rather than an

--- a/src/reyn/interfaces/transport/agui/__init__.py
+++ b/src/reyn/interfaces/transport/agui/__init__.py
@@ -20,6 +20,12 @@ from __future__ import annotations
 
 from reyn.interfaces.transport.agui.client import AgUiTransport
 from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.profile import (
+    CUSTOM_PROFILE,
+    CustomName,
+    is_profiled,
+    profiled_names,
+)
 from reyn.interfaces.transport.agui.protocol import (
     AgUiEvent,
     InterventionTool,
@@ -28,6 +34,7 @@ from reyn.interfaces.transport.agui.protocol import (
     StateUpdate,
     decode_event,
     encode_frame,
+    encode_frame_wire,
     encode_intervention_tool_result,
     encode_intervention_tool_start,
     encode_messages_snapshot,
@@ -59,6 +66,7 @@ __all__ = [
     "StateUpdate",
     "decode_event",
     "encode_frame",
+    "encode_frame_wire",
     "encode_intervention_tool_result",
     "encode_intervention_tool_start",
     "encode_messages_snapshot",
@@ -74,4 +82,8 @@ __all__ = [
     "SurfaceManager",
     "SurfaceRegistry",
     "surface_registry",
+    "CUSTOM_PROFILE",
+    "CustomName",
+    "is_profiled",
+    "profiled_names",
 ]

--- a/src/reyn/interfaces/transport/agui/emitter.py
+++ b/src/reyn/interfaces/transport/agui/emitter.py
@@ -10,17 +10,19 @@ transports feed off the identical frame source, *local ≡ remote by constructio
 
 On connect it replays the reconnect snapshots (A4): ``MESSAGES_SNAPSHOT`` (the
 display backlog) then ``STATE_SNAPSHOT`` (the status read-model). It then streams
-one SSE event per frame, and after each frame emits a ``STATE_DELTA`` when the
-projected status changed — the current WaitingOn label is tracked off the
-chat-event stream so the remote status panel follows Thinking / Running /
-Waiting-for-you without a second source.
+each frame as its AG-UI **wire sequence** (:func:`encode_frame_wire` — a whole
+text message is the canonical ``TEXT_MESSAGE_START`` → ``…_CONTENT`` →
+``…_END`` triplet, P4; every other frame is a single event), and after each frame
+emits a ``STATE_DELTA`` when the projected status changed — the current WaitingOn
+label is tracked off the chat-event stream so the remote status panel follows
+Thinking / Running / Waiting-for-you without a second source.
 """
 from __future__ import annotations
 
 from typing import AsyncIterator, Callable
 
 from reyn.interfaces.transport.agui.protocol import (
-    encode_frame,
+    encode_frame_wire,
     encode_intervention_tool_result,
     encode_intervention_tool_start,
     encode_messages_snapshot,
@@ -80,7 +82,13 @@ class AgUiEmitter:
         yield to_sse(encode_state_snapshot(self._model.snapshot(self._project())))
 
         async for frame in self._frames:
-            yield to_sse(encode_frame(frame))
+            # A whole text message expands to the AG-UI START→CONTENT→END triplet
+            # (conformance); every other frame is a single event. Only the
+            # _reyn-bearing event round-trips to the reyn client — START/END are
+            # generic scaffold. An ``intervention`` kind is CUSTOM (a single
+            # event), so the triplet never disturbs the frontend-tool path below.
+            for event in encode_frame_wire(frame):
+                yield to_sse(event)
             # HITL frontend-tool lifecycle (ADR-0039 P3, R4). An intervention
             # rides the wire in TWO representations: the DisplayFrame above (the
             # reyn client's native prompt UI) AND a companion frontend-tool

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -1,0 +1,143 @@
+"""reyn AG-UI extension profile — the ``reyn.*`` namespace registry.
+
+The AG-UI standard surface renders the interoperable core (text / tool / run /
+error / state) for any generic client. Beyond that core, reyn names its own
+vocabulary under a **reyn-owned namespace** in two ways:
+
+- as the ``name`` of a ``CUSTOM`` event (chrome with no standard analog — trace
+  lines, the ``present`` render model, the intervention-answer axis); and
+- as the ``toolName`` of the HITL intervention **frontend-tool**
+  ``TOOL_CALL_START`` (a standard event, not a ``CUSTOM`` one).
+
+This module is the single registry that formalizes that namespace into a
+documented, tested **extension profile**: every ``reyn.*`` name reyn emits, its
+value schema, and what it means.
+
+Three namespaces:
+
+- ``reyn.display.<kind>`` — a reyn display frame with no standard AG-UI analog.
+  A ``CUSTOM`` ``name``; ``value`` is ``{"text": <the display line text>}``.
+  (``presentation`` also carries its render-node model on the ``_reyn`` block's
+  ``meta.nodes``, inert on the wire.) Closed member set (below).
+- ``reyn.event.<etype>`` — a reyn chat-event (working-indicator axis) with no
+  standard AG-UI analog. A ``CUSTOM`` ``name``; ``value`` is the event's data
+  object. Closed member set (below).
+- ``reyn.intervention.<kind>`` — the HITL frontend-tool ``toolName``. ``<kind>``
+  is the intervention kind (``ask_user`` / ``permission.*`` / …), caller-supplied,
+  so this is an **open namespace** profiled at the prefix level with a fixed value
+  schema (:data:`OPEN_NAMESPACES`), not a closed member set.
+
+**Non-circular completeness gate.** ``tests/test_agui_profile_completeness.py``
+enumerates the reyn-mapped vocabulary *from the source vocabulary* — display kinds
++ ``renderer_chat_events`` (encoded through the codec, ``CUSTOM`` names collected)
+AND the intervention frontend-tool encoder's real ``toolName`` — and asserts each
+emitted ``reyn.*`` name is profiled (a closed-member entry or an open-namespace
+prefix). An unprofiled name is RED — doc-drift is designed out, the same discipline
+as the P1/P2 completeness gates. The gate reads the codec's output, never this
+registry, so it is not comparing the profile to itself.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Namespace prefixes (the ``name`` before the terminal ``.<kind>`` / ``.<etype>``).
+DISPLAY_NS = "reyn.display"
+EVENT_NS = "reyn.event"
+INTERVENTION_NS = "reyn.intervention"
+
+# Human-readable namespace summaries — enumerated in the profile doc section.
+NAMESPACES: dict[str, str] = {
+    DISPLAY_NS: "a reyn display frame with no standard AG-UI analog (CUSTOM name; value: {text})",
+    EVENT_NS: "a reyn chat-event with no standard AG-UI analog (CUSTOM name; value: the event data object)",
+    INTERVENTION_NS: "the HITL intervention frontend-tool toolName (open namespace; args: {prompt, detail, choices, suggestions})",
+}
+
+# Open namespaces profiled at the PREFIX level (the terminal segment is
+# caller-supplied, so there is no closed member set). Maps the ``<prefix>.`` a
+# name must start with → its fixed value schema. ``reyn.intervention.`` is the
+# HITL frontend-tool ``toolName`` (``reyn.intervention.<kind>``); the trailing dot
+# is part of the key so a bare ``reyn.intervention`` does not spuriously match.
+OPEN_NAMESPACES: dict[str, str] = {
+    f"{INTERVENTION_NS}.": "args: {prompt, detail, choices, suggestions}; toolCallId = intervention id",
+}
+
+
+@dataclass(frozen=True)
+class CustomName:
+    """One profiled ``reyn.*`` Custom name: its namespace + ``value`` schema."""
+
+    name: str
+    namespace: str
+    value_schema: str
+    summary: str
+
+
+def _entries(*entries: CustomName) -> "dict[str, CustomName]":
+    return {e.name: e for e in entries}
+
+
+# The concrete, emitted Custom names. Keyed by the exact ``name`` the codec puts
+# on the wire; the completeness gate binds this set to the codec's emitted
+# vocabulary (a new Custom-mapped kind/etype with no entry here fails CI).
+CUSTOM_PROFILE: dict[str, CustomName] = _entries(
+    # ── reyn.display.<kind> — display frames with no standard AG-UI analog ──
+    CustomName("reyn.display.trace", DISPLAY_NS, "{text: str}", "a reyn tool/step trace line"),
+    CustomName(
+        "reyn.display.intervention", DISPLAY_NS, "{text: str}",
+        "an intervention prompt is displayed (the reyn client draws it natively; the answer round-trip rides the reyn.intervention.* frontend-tool)",
+    ),
+    CustomName(
+        "reyn.display.presentation", DISPLAY_NS, "{text: str}",
+        "a present op's text; the render-node model rides the _reyn block's meta.nodes, inert on the wire",
+    ),
+    CustomName("reyn.display.nodes", DISPLAY_NS, "{text: str}", "a raw render-node display line"),
+    CustomName(
+        "reyn.display.user", DISPLAY_NS, "{text: str}",
+        "a user-authored line echoed live to the scrollback (backlog user turns ride the standard messages array)",
+    ),
+    CustomName(
+        "reyn.display.tool_call_started", DISPLAY_NS, "{text: str}",
+        "a tool-call start trace line",
+    ),
+    CustomName(
+        "reyn.display.tool_call_completed", DISPLAY_NS, "{text: str}",
+        "a tool-call completion trace line",
+    ),
+    CustomName(
+        "reyn.display.tool_call_failed", DISPLAY_NS, "{text: str}",
+        "a tool-call failure trace line",
+    ),
+    # ── reyn.event.<etype> — chat-events with no standard AG-UI analog ──
+    CustomName(
+        "reyn.event.user_answered_intervention", EVENT_NS, "the event data object",
+        "the user answered an intervention (working-indicator axis)",
+    ),
+)
+
+
+def profiled_names() -> "frozenset[str]":
+    """The set of ``reyn.*`` Custom names the extension profile documents."""
+    return frozenset(CUSTOM_PROFILE)
+
+
+def is_profiled(name: str) -> bool:
+    """True iff *name* is profiled — a closed :data:`CUSTOM_PROFILE` member OR a
+    name under a profiled :data:`OPEN_NAMESPACES` prefix (the intervention
+    frontend-tool). An unprofiled name is skipped by a reyn client, so ``False``
+    is the generic ignore-unknown case, not fatal."""
+    if name in CUSTOM_PROFILE:
+        return True
+    return any(name.startswith(prefix) for prefix in OPEN_NAMESPACES)
+
+
+__all__ = [
+    "DISPLAY_NS",
+    "EVENT_NS",
+    "INTERVENTION_NS",
+    "NAMESPACES",
+    "OPEN_NAMESPACES",
+    "CustomName",
+    "CUSTOM_PROFILE",
+    "profiled_names",
+    "is_profiled",
+]

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -29,10 +29,35 @@ Design (the load-bearing invariants this module carries):
 STATE (the status read-model) and MESSAGES snapshots ride the same SSE stream but
 are not ``Frame``\\s — they decode to :class:`StateUpdate` / :class:`MessagesSnapshot`
 so the client demuxes render frames from the status side-channel.
+
+**Generic-client conformance (ADR-0039 P4).** The standard surface is widened so a
+stock AG-UI client with zero reyn knowledge renders a functional chat:
+
+- **Text triplet.** A bare ``TEXT_MESSAGE_CONTENT`` is invalid per the AG-UI spec,
+  which mandates ``TEXT_MESSAGE_START`` → one-or-more ``TEXT_MESSAGE_CONTENT`` →
+  ``TEXT_MESSAGE_END``, correlated by ``messageId``. :func:`encode_frame_wire`
+  expands a whole text message into that triplet with a shared generated id
+  (reyn's outbox has no stable message id). Only the CONTENT event carries the
+  ``_reyn`` reconstruction block — START/END are generic scaffold the reyn client
+  decodes to ``None`` — so the invariant stays **1 frame ⇄ 1 ``_reyn``-bearing
+  event** and reyn bit-identity is unchanged. (Token-streaming is out of scope;
+  reyn is whole-message.)
+- **Standard ``messages`` array.** ``MESSAGES_SNAPSHOT`` carries a standard
+  ``[{role, content}]`` array of **conversation turns only** (``agent`` →
+  ``assistant``, ``user`` → ``user``); reyn chrome (status / error / present /
+  intervention / trace) replays to the reyn client via ``_reyn`` and is NOT in the
+  standard array.
+- **Standard tool status.** ``TOOL_CALL_END`` carries a standard ``status``
+  (``"ok"`` / ``"error"``, derived from the frame etype) so a generic client sees
+  a tool failure; the reyn client still exact-recovers from ``_reyn``.
+
+The ``reyn.*`` Custom namespace is a documented, tested extension profile — see
+:mod:`reyn.interfaces.transport.agui.profile`.
 """
 from __future__ import annotations
 
 import json
+import uuid
 from dataclasses import dataclass, field
 
 from reyn.core.events.events import Event
@@ -40,7 +65,9 @@ from reyn.interfaces.transport.frames import DisplayFrame, EventFrame, Frame
 from reyn.runtime.outbox import OutboxMessage
 
 # ── AG-UI event type names (hand-rolled; the SDK is not a dependency) ─────────
+TEXT_MESSAGE_START = "TEXT_MESSAGE_START"
 TEXT_MESSAGE_CONTENT = "TEXT_MESSAGE_CONTENT"
+TEXT_MESSAGE_END = "TEXT_MESSAGE_END"
 RUN_STARTED = "RUN_STARTED"
 RUN_FINISHED = "RUN_FINISHED"
 RUN_ERROR = "RUN_ERROR"
@@ -154,12 +181,23 @@ class InterventionToolResult:
     status: str = "answered"
 
 
+# Display kinds that are conversation TURNS (vs reyn chrome) — the only kinds
+# that go into the standard MESSAGES_SNAPSHOT ``[{role, content}]`` array. Their
+# standard AG-UI ``role``: agent → assistant, user → user.
+_CONVERSATION_KINDS: dict[str, str] = {"agent": "assistant", "user": "user"}
+
+
 def _display_event_type(kind: str) -> str:
     return _DISPLAY_KIND_EVENT.get(kind, CUSTOM)
 
 
 def _event_event_type(etype: str) -> str:
     return _EVENT_TYPE_EVENT.get(etype, CUSTOM)
+
+
+def _new_message_id() -> str:
+    """A per-message id for the text triplet (reyn's outbox has no stable id)."""
+    return uuid.uuid4().hex
 
 
 # ── encode: Frame → AgUiEvent ────────────────────────────────────────────────
@@ -180,7 +218,13 @@ def _encode_display(frame: DisplayFrame) -> AgUiEvent:
     reyn = {"frame": "display", "kind": kind, "text": text, "meta": meta}
     # Standard AG-UI surface a generic client renders (best-effort).
     if ag_type is TEXT_MESSAGE_CONTENT:
-        std = {"role": "assistant" if kind == "agent" else "status", "delta": text}
+        # ``messageId`` correlates the START/CONTENT/END triplet
+        # (:func:`encode_frame_wire`); ``delta`` is the whole message text.
+        std = {
+            "messageId": _new_message_id(),
+            "role": "assistant" if kind == "agent" else "status",
+            "delta": text,
+        }
     elif ag_type is RUN_ERROR:
         std = {"message": text}
     else:  # CUSTOM — reyn-private (presentation / trace / intervention / control)
@@ -194,13 +238,45 @@ def _encode_event(frame: EventFrame) -> AgUiEvent:
     edata = dict(getattr(ev, "data", {}) or {})
     ag_type = _event_event_type(etype)
     reyn = {"frame": "event", "type": etype, "data": edata}
-    if ag_type in (TOOL_CALL_START, TOOL_CALL_END):
+    if ag_type is TOOL_CALL_START:
         std = {"toolName": edata.get("tool"), "step": edata.get("tool")}
+    elif ag_type is TOOL_CALL_END:
+        # Standard failure field: a generic client sees the failure; the reyn
+        # client still exact-recovers the etype from ``_reyn``.
+        std = {
+            "toolName": edata.get("tool"),
+            "step": edata.get("tool"),
+            "status": "error" if etype == "tool_failed" else "ok",
+        }
     elif ag_type in (RUN_STARTED, RUN_FINISHED):
         std = {"phase": etype}
     else:  # CUSTOM — user_answered_intervention et al.
         std = {"name": f"reyn.event.{etype}", "value": edata}
     return AgUiEvent(type=ag_type, data={**std, _REYN: reyn})
+
+
+def encode_frame_wire(frame: Frame) -> "list[AgUiEvent]":
+    """Encode one ``Frame`` to its full AG-UI **wire sequence** (P4).
+
+    Most frames are a single event. A whole text message expands to the canonical
+    AG-UI lifecycle triplet — ``TEXT_MESSAGE_START`` → ``TEXT_MESSAGE_CONTENT`` →
+    ``TEXT_MESSAGE_END``, correlated by a shared ``messageId`` — because a bare
+    ``TEXT_MESSAGE_CONTENT`` is invalid per the spec (a strict generic client
+    drops it). Only the CONTENT event carries the ``_reyn`` reconstruction block;
+    START/END are generic scaffold that :func:`decode_event` returns ``None`` for,
+    so the invariant stays **1 frame ⇄ 1 ``_reyn``-bearing event** and the reyn
+    client's render is unchanged.
+    """
+    event = encode_frame(frame)
+    if event.type != TEXT_MESSAGE_CONTENT:
+        return [event]
+    message_id = event.data.get("messageId")
+    start = AgUiEvent(
+        type=TEXT_MESSAGE_START,
+        data={"messageId": message_id, "role": event.data.get("role")},
+    )
+    end = AgUiEvent(type=TEXT_MESSAGE_END, data={"messageId": message_id})
+    return [start, event, end]
 
 
 def encode_state_snapshot(snapshot: dict) -> AgUiEvent:
@@ -220,11 +296,25 @@ def encode_state_delta(delta: dict) -> AgUiEvent:
 
 
 def encode_messages_snapshot(frames: "list[Frame]") -> AgUiEvent:
-    """MESSAGES_SNAPSHOT — the display backlog replayed on connect (A4)."""
-    payload = [_encode_display(f).data[_REYN] for f in frames if isinstance(f, DisplayFrame)]
+    """MESSAGES_SNAPSHOT — the display backlog replayed on connect (A4).
+
+    The standard ``messages`` field is a ``[{role, content}]`` array of
+    **conversation turns only** (P4) — the shape a generic AG-UI client expects;
+    reyn chrome (status / error / present / intervention / trace) is NOT a
+    conversation turn and is excluded. The reyn client rebuilds the FULL backlog
+    (all display frames) from the ``_reyn`` block, so its scrollback is unchanged.
+    """
+    reyn_payload = [
+        _encode_display(f).data[_REYN] for f in frames if isinstance(f, DisplayFrame)
+    ]
+    standard = [
+        {"role": _CONVERSATION_KINDS[f.message.kind], "content": f.message.text}
+        for f in frames
+        if isinstance(f, DisplayFrame) and f.message.kind in _CONVERSATION_KINDS
+    ]
     return AgUiEvent(
         type=MESSAGES_SNAPSHOT,
-        data={"messages": payload, _REYN: {"frame": "messages", "messages": payload}},
+        data={"messages": standard, _REYN: {"frame": "messages", "messages": reyn_payload}},
     )
 
 
@@ -373,7 +463,9 @@ __all__ = [
     "MessagesSnapshot",
     "InterventionTool",
     "InterventionToolResult",
+    "TEXT_MESSAGE_START",
     "TEXT_MESSAGE_CONTENT",
+    "TEXT_MESSAGE_END",
     "RUN_STARTED",
     "RUN_FINISHED",
     "RUN_ERROR",
@@ -385,6 +477,7 @@ __all__ = [
     "MESSAGES_SNAPSHOT",
     "CUSTOM",
     "encode_frame",
+    "encode_frame_wire",
     "encode_state_snapshot",
     "encode_state_delta",
     "encode_messages_snapshot",

--- a/tests/test_agui_generic_client_e2e.py
+++ b/tests/test_agui_generic_client_e2e.py
@@ -1,0 +1,187 @@
+"""Tier 2: a stock AG-UI client renders a functional chat off reyn (ADR-0039 P4).
+
+The phase proof. A **standard-only consumer** — zero reyn knowledge, reads ONLY
+standard AG-UI fields, ignores every ``CUSTOM`` / ``reyn.*`` event and never
+touches the private ``_reyn`` block — is pointed at the reyn server emitter and
+must reconstruct a functional chat:
+
+- **text** via the canonical ``TEXT_MESSAGE_START`` → ``…_CONTENT`` → ``…_END``
+  triplet (and NO bare CONTENT — the strict-client validity condition);
+- **tool** calls with a standard ``status`` (a failure is visible);
+- **run lifecycle** via ``RUN_STARTED`` / ``RUN_FINISHED``;
+- **status** via ``STATE_SNAPSHOT`` / ``STATE_DELTA``;
+- **backlog** via the standard ``MESSAGES_SNAPSHOT`` ``[{role, content}]`` array;
+- and reyn chrome (a ``trace`` → ``CUSTOM``) is silently ignored, not fatal.
+
+Real instances only — the real AgUiEmitter over the real codec; the generic
+client below is a plain standard-field consumer written for the test (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    MESSAGES_SNAPSHOT,
+    RUN_FINISHED,
+    RUN_STARTED,
+    STATE_DELTA,
+    STATE_SNAPSHOT,
+    TEXT_MESSAGE_CONTENT,
+    TEXT_MESSAGE_END,
+    TEXT_MESSAGE_START,
+    TOOL_CALL_END,
+    TOOL_CALL_RESULT,
+    TOOL_CALL_START,
+    parse_sse_blocks,
+)
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_REYN = "_reyn"
+
+
+class _GenericAgUiClient:
+    """A stock AG-UI consumer with ZERO reyn knowledge — standard fields only."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []          # finalized text messages
+        self.tool_events: list[tuple] = []      # ("start"|"end"|"result", tool/id, status)
+        self.runs: list[str] = []               # "started" / "finished"
+        self.status: dict = {}                  # merged STATE_* read-model
+        self.backlog: list[dict] = []           # standard MESSAGES_SNAPSHOT array
+        self.ignored: int = 0                   # CUSTOM / reyn.* / unknown skipped
+        self.bare_content: int = 0              # CONTENT with no prior START (invalid)
+        self._open: dict[str, dict] = {}
+        self._started: set[str] = set()
+
+    def consume(self, ag_type: str, data: dict) -> None:
+        # A generic client never reads reyn's private reconstruction block.
+        data = {k: v for k, v in data.items() if k != _REYN}
+        if ag_type == TEXT_MESSAGE_START:
+            mid = data.get("messageId")
+            self._started.add(mid)
+            self._open[mid] = {"role": data.get("role"), "content": ""}
+        elif ag_type == TEXT_MESSAGE_CONTENT:
+            mid = data.get("messageId")
+            if mid not in self._started:
+                self.bare_content += 1
+            buf = self._open.setdefault(mid, {"role": data.get("role"), "content": ""})
+            buf["content"] += data.get("delta", "")
+        elif ag_type == TEXT_MESSAGE_END:
+            mid = data.get("messageId")
+            if mid in self._open:
+                self.messages.append(self._open.pop(mid))
+        elif ag_type == TOOL_CALL_START:
+            self.tool_events.append(("start", data.get("toolName"), None))
+        elif ag_type == TOOL_CALL_END:
+            self.tool_events.append(("end", data.get("toolName"), data.get("status")))
+        elif ag_type == TOOL_CALL_RESULT:
+            # The terminal result of a (frontend-)tool call, keyed by toolCallId.
+            self.tool_events.append(("result", data.get("toolCallId"), None))
+        elif ag_type == RUN_STARTED:
+            self.runs.append("started")
+        elif ag_type == RUN_FINISHED:
+            self.runs.append("finished")
+        elif ag_type == STATE_SNAPSHOT:
+            self.status.update(data.get("snapshot") or {})
+        elif ag_type == STATE_DELTA:
+            self.status.update(data.get("delta") or {})
+        elif ag_type == MESSAGES_SNAPSHOT:
+            self.backlog = list(data.get("messages") or [])
+        else:
+            # CUSTOM / reyn.* / any event a stock client does not model → ignore.
+            self.ignored += 1
+
+
+_BACKLOG = [
+    DisplayFrame(OutboxMessage(kind="user", text="earlier question")),
+    DisplayFrame(OutboxMessage(kind="agent", text="earlier answer")),
+]
+
+
+def _script_frames() -> list:
+    return [
+        EventFrame(Event(type="turn_started", data={})),
+        DisplayFrame(OutboxMessage(kind="agent", text="the answer text")),
+        EventFrame(Event(type="tool_called", data={"tool": "grep_files"})),
+        EventFrame(Event(type="tool_failed", data={"tool": "grep_files"})),
+        DisplayFrame(OutboxMessage(kind="trace", text="· internal trace")),  # reyn chrome
+        # HITL: an intervention rides as a display frame (reyn-native, CUSTOM →
+        # ignored by the generic client) PLUS a companion frontend-tool the
+        # generic client CAN render + answer.
+        DisplayFrame(
+            OutboxMessage(
+                kind="intervention",
+                text="Approve deploy?",
+                meta={
+                    "intervention_id": "iv-9",
+                    "intervention_kind": "ask_user",
+                    "prompt": "Approve deploy?",
+                },
+            )
+        ),
+        EventFrame(Event(type="user_answered_intervention", data={"intervention_id": "iv-9"})),
+        EventFrame(Event(type="turn_settled", data={})),
+        DisplayFrame(OutboxMessage(kind="__end__", text="")),
+    ]
+
+
+async def _frame_source(frames):
+    for f in frames:
+        yield f
+
+
+@pytest.mark.asyncio
+async def test_generic_client_renders_functional_chat_from_standard_fields() -> None:
+    """Tier 2: the standard-only client reconstructs text (valid triplet) + tool
+    (+status) + run + status + backlog, and ignores reyn chrome — off standard
+    fields alone (the private _reyn block is stripped before it ever sees it)."""
+    emitter = AgUiEmitter(
+        _frame_source(_script_frames()),
+        lambda: {"attached_name": "demo", "model": "m", "ctx_window": 200},
+        backlog=_BACKLOG,
+    )
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    client = _GenericAgUiClient()
+    for ev in parse_sse_blocks(sse.split("\n")):
+        client.consume(ev.type, ev.data)
+
+    # Text: the live agent reply is assembled from a VALID triplet (START before
+    # CONTENT before END) — no bare CONTENT, the strict-client validity floor.
+    assert client.bare_content == 0
+    assert client.messages == [{"role": "assistant", "content": "the answer text"}]
+
+    # Tool: the failure is visible via the standard status field.
+    assert ("start", "grep_files", None) in client.tool_events
+    assert ("end", "grep_files", "error") in client.tool_events
+
+    # HITL coexists with the triplet: the generic client sees the intervention as
+    # a frontend-tool (TOOL_CALL_START, toolName reyn.intervention.<kind>) and its
+    # terminal TOOL_CALL_RESULT — the triplet synthesis did not disturb this path.
+    assert ("start", "reyn.intervention.ask_user", None) in client.tool_events
+    assert ("result", "iv-9", None) in client.tool_events
+    # ...and the text triplet is still valid alongside it.
+    assert client.bare_content == 0
+
+    # Run lifecycle: started then finished.
+    assert client.runs == ["started", "finished"]
+
+    # Status read-model: seeded from the snapshot (+ deltas merged).
+    assert client.status.get("attached_name") == "demo"
+    assert client.status.get("ctx_window") == 200
+
+    # Backlog: the standard conversation-turns array rebuilds the prior turns.
+    assert client.backlog == [
+        {"role": "user", "content": "earlier question"},
+        {"role": "assistant", "content": "earlier answer"},
+    ]
+
+    # reyn chrome (the trace frame → CUSTOM) is silently ignored, not fatal, and
+    # never leaks into the conversation.
+    assert client.ignored >= 1
+    assert all("trace" not in m["content"] for m in client.messages)

--- a/tests/test_agui_ignore_unknown_both_directions.py
+++ b/tests/test_agui_ignore_unknown_both_directions.py
@@ -1,0 +1,137 @@
+"""Tier 2: ignore-unknown holds in BOTH directions (ADR-0039 P4, D6).
+
+D6's honest ceiling becomes a stated + tested floor: an unknown input is skipped,
+never fatal, on both sides of the wire.
+
+Client (decode):
+  (a) a foreign standard event with no ``_reyn`` block → ``None``;
+  (b) an event whose ``_reyn`` block carries an unknown ``frame`` tag → ``None``;
+  (c) SR3: an unknown ``reyn.*`` Custom NAME → skip (``None``), not crash.
+
+Server (POST dispatch):
+  an unknown input type graceful-degrades — no ``KeyError`` / 500 — and does not
+  swallow or break the REAL dispatch surface: after an unknown verb, a turn
+  (``user_message``) and an answer (``TOOL_CALL_RESULT``, BY-ID) still route to
+  their handlers and the ``/seize`` route degrades cleanly.
+
+Real instances only — the real codec, a real FastAPI app mounting the real
+router with a real AuthContext + a hand-written real registry Fake; no mocks.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from reyn.interfaces.transport.agui import endpoint as endpoint_mod
+from reyn.interfaces.transport.agui.endpoint import router
+from reyn.interfaces.transport.agui.protocol import decode_event
+from reyn.interfaces.web.auth import AuthContext
+
+# ── client side: decode ignore-unknown (a) / (b) / (c) ──────────────────────
+
+def test_client_skips_foreign_event_without_reyn_block() -> None:
+    """Tier 2: (a) a standard event with no _reyn reconstruction block → None."""
+    assert decode_event("TEXT_MESSAGE_START", {"messageId": "m1", "role": "assistant"}) is None
+    assert decode_event("TOOL_CALL_END", {"toolName": "x", "status": "ok"}) is None
+
+
+def test_client_skips_unknown_reyn_frame_tag() -> None:
+    """Tier 2: (b) a _reyn block with a frame tag this client predates → None."""
+    assert decode_event("CUSTOM", {"_reyn": {"frame": "some_future_frame_kind"}}) is None
+
+
+def test_client_skips_unknown_reyn_custom_name() -> None:
+    """Tier 2: (c/SR3) an unknown reyn.* Custom NAME is skipped, not a crash."""
+    # No _reyn block (a future Custom a generic-shaped reyn event might carry).
+    assert decode_event("CUSTOM", {"name": "reyn.future.widget", "value": {"a": 1}}) is None
+    # A _reyn block whose frame tag is unknown is likewise skipped, not fatal.
+    assert decode_event("CUSTOM", {"name": "reyn.future.widget", "_reyn": {"frame": "widget"}}) is None
+
+
+# ── server side: POST dispatch graceful-degrade against the REAL dispatch ────
+# The endpoint dispatches several verbs (user_message / TOOL_CALL_RESULT answer /
+# cancel / heartbeat) plus a separate /seize route. An unknown verb must
+# graceful-degrade WITHOUT swallowing or breaking any of the real ones.
+
+class _FakeSession:
+    """A minimal real session Fake: records the turn/answer verbs it receives."""
+
+    def __init__(self) -> None:
+        self.submitted: list[str] = []
+        self.answers: list[str] = []
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_by_id(self, iv_id: str, text: str, **kw) -> bool:
+        self.answers.append(iv_id)
+        return True  # the id matched a pending intervention
+
+
+class _FakeRegistry:
+    """A minimal real registry Fake exposing the endpoint's touch-points."""
+
+    def __init__(self) -> None:
+        self.session = _FakeSession()
+
+    def exists(self, name: str) -> bool:
+        return True
+
+    async def attach(self, name: str):
+        return self.session
+
+
+def _app(monkeypatch, registry: _FakeRegistry) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.auth = AuthContext(token="s3cret", require_token=True)
+    # Swap the module-level registry accessor for a real hand-written Fake.
+    monkeypatch.setattr(endpoint_mod, "get_registry", lambda: registry)
+    return app
+
+
+def test_server_unknown_input_type_graceful_degrades(monkeypatch) -> None:
+    """Tier 2: an unknown POST input type does NOT 500 / KeyError — it falls
+    through to a clean 200 ack (server-side ignore-unknown), driving nothing."""
+    registry = _FakeRegistry()
+    client = TestClient(_app(monkeypatch, registry))
+
+    resp = client.post(
+        "/agui/chat/demo?token=s3cret",
+        json={"type": "some_future_input_type", "payload": {"k": "v"}},
+    )
+    assert resp.status_code == 200
+    # Graceful no-op: neither a turn nor an answer was driven.
+    assert registry.session.submitted == []
+    assert registry.session.answers == []
+
+
+def test_server_real_dispatch_surface_intact_around_unknown(monkeypatch) -> None:
+    """Tier 2: ignore-unknown does not swallow or break the real dispatch — after
+    an unknown verb, both a turn (user_message) and an answer (TOOL_CALL_RESULT)
+    still route to their handlers, and the /seize route degrades without a 500."""
+    registry = _FakeRegistry()
+    client = TestClient(_app(monkeypatch, registry))
+
+    # Unknown verb first (graceful), then the real verbs must still land.
+    assert client.post("/agui/chat/demo?token=s3cret", json={"type": "nope"}).status_code == 200
+
+    turn = client.post(
+        "/agui/chat/demo?token=s3cret", json={"type": "user_message", "text": "hello"}
+    )
+    assert turn.status_code == 200
+    assert registry.session.submitted == ["hello"]
+
+    # TOOL_CALL_RESULT routes to the answer path (BY-ID), not treated as unknown.
+    answer = client.post(
+        "/agui/chat/demo?token=s3cret",
+        json={"type": "TOOL_CALL_RESULT", "toolCallId": "iv-7", "text": "yes"},
+    )
+    assert answer.status_code == 200
+    assert answer.json()["answered"] is True
+    assert registry.session.answers == ["iv-7"]
+
+    # The seize route exists and degrades cleanly (no surface attached → 409
+    # "seize refused"), never a 500.
+    seize = client.post("/agui/chat/demo/seize?token=s3cret")
+    assert seize.status_code != 500

--- a/tests/test_agui_messages_standard_shape.py
+++ b/tests/test_agui_messages_standard_shape.py
@@ -1,0 +1,83 @@
+"""Tier 2: MESSAGES_SNAPSHOT is a standard conversation-turns array (ADR-0039 P4).
+
+Canonical AG-UI's ``messages`` is an array of message objects; a generic client
+reads it to rebuild the conversation. P4 emits a standard ``[{role, content}]``
+array of **conversation turns only** — ``agent`` → ``assistant``, ``user`` →
+``user`` — while reyn chrome (status / error / present / intervention / trace) is
+NOT a conversation turn and is excluded from the standard array (SR2). The reyn
+client still rebuilds the FULL backlog from the ``_reyn`` block (SR2 preserved),
+so its scrollback is unchanged.
+
+Real instances only — the real codec + AgUiTransport; no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.protocol import (
+    MESSAGES_SNAPSHOT,
+    encode_frame,
+    encode_messages_snapshot,
+    to_sse,
+)
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+# A backlog mixing conversation turns (agent / user) with reyn chrome kinds.
+_BACKLOG = [
+    DisplayFrame(OutboxMessage(kind="user", text="what's the weather")),
+    DisplayFrame(OutboxMessage(kind="agent", text="sunny")),
+    DisplayFrame(OutboxMessage(kind="status", text="thinking…")),
+    DisplayFrame(OutboxMessage(kind="error", text="a warning")),
+    DisplayFrame(OutboxMessage(kind="trace", text="· ran a tool")),
+]
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+def test_standard_messages_are_conversation_turns_only() -> None:
+    """Tier 2: the standard ``messages`` array is ``[{role, content}]`` of only
+    the agent/user turns; status/error/trace chrome is excluded (SR2)."""
+    ev = encode_messages_snapshot(_BACKLOG)
+    assert ev.type == MESSAGES_SNAPSHOT
+
+    standard = ev.data["messages"]
+    assert standard == [
+        {"role": "user", "content": "what's the weather"},
+        {"role": "assistant", "content": "sunny"},
+    ]
+    # Every entry is the standard convention object — nothing else leaks in.
+    assert all(set(m) == {"role", "content"} for m in standard)
+
+
+@pytest.mark.asyncio
+async def test_reyn_client_rebuilds_full_backlog_from_reyn_block() -> None:
+    """Tier 2: the reyn client replays the FULL backlog (chrome included) from the
+    _reyn block — the standard-array narrowing does not touch reyn reconstruction."""
+    # A __end__ sentinel terminates the client's frames() loop after the backlog.
+    sse = to_sse(encode_messages_snapshot(_BACKLOG)) + to_sse(
+        encode_frame(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+    )
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    kinds_texts = [
+        (f.message.kind, f.message.text)
+        async for f in transport.frames()
+        if isinstance(f, DisplayFrame) and f.message.kind != "__end__"
+    ]
+    assert kinds_texts == [
+        ("user", "what's the weather"),
+        ("agent", "sunny"),
+        ("status", "thinking…"),
+        ("error", "a warning"),
+        ("trace", "· ran a tool"),
+    ]

--- a/tests/test_agui_profile_completeness.py
+++ b/tests/test_agui_profile_completeness.py
@@ -1,0 +1,105 @@
+"""Tier 2: every Custom-mapped reyn frame has an extension-profile entry (P4, SR4).
+
+The reyn ``reyn.*`` Custom namespace is a documented, tested extension profile
+(:mod:`reyn.interfaces.transport.agui.profile`). This gate keeps it honest and
+non-circular: it enumerates the Custom-mapped frame vocabulary *from the
+renderer's source vocabulary* — the display kinds the renderer dispatches on
+(AST-scanned) plus the derived ``renderer_chat_events`` — encodes each through
+the codec, collects the ``reyn.*`` ``name`` of every event that lands on
+``CUSTOM``, and asserts each such name has a profile entry. It reads the codec's
+output, never the profile itself, so it is not comparing the profile to itself.
+
+An emitted Custom name with no profile entry is RED — doc-drift is designed out,
+the same discipline as the P1/P2 completeness gates.
+
+Real instances only — the real codec + the real profile registry; no mocks.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.profile import is_profiled
+from reyn.interfaces.transport.agui.protocol import (
+    CUSTOM,
+    encode_frame,
+    encode_intervention_tool_start,
+)
+from reyn.interfaces.transport.frames import (
+    DisplayFrame,
+    EventFrame,
+    renderer_chat_events,
+)
+from reyn.runtime.outbox import OutboxMessage
+
+_RENDERER = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "reyn" / "interfaces" / "repl" / "renderer.py"
+)
+_DISPLAY_DISPATCH_FUNCS = {"message", "format_inline_message"}
+
+
+def _renderer_display_kinds() -> set[str]:
+    """Every ``kind`` literal the renderer's display-dispatch functions compare
+    against — the DisplayFrame vocabulary, read from renderer source (not the
+    codec's tables), so the enumeration is independent of the profile."""
+    tree = ast.parse(_RENDERER.read_text(encoding="utf-8"))
+    kinds: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name in _DISPLAY_DISPATCH_FUNCS):
+            continue
+        for cmp_node in ast.walk(node):
+            if not isinstance(cmp_node, ast.Compare):
+                continue
+            for lit in ast.walk(cmp_node):
+                if isinstance(lit, ast.Constant) and isinstance(lit.value, str):
+                    kinds.add(lit.value)
+    return kinds
+
+
+def _emitted_custom_names() -> set[str]:
+    """The ``reyn.*`` Custom names the codec puts on the wire for the source
+    vocabulary — derived from the renderer's kinds/events, not from the profile."""
+    names: set[str] = set()
+    for kind in _renderer_display_kinds():
+        ev = encode_frame(DisplayFrame(OutboxMessage(kind=kind, text="x")))
+        if ev.type == CUSTOM:
+            names.add(ev.data["name"])
+    for etype in renderer_chat_events():
+        ev = encode_frame(EventFrame(Event(type=etype, data={})))
+        if ev.type == CUSTOM:
+            names.add(ev.data["name"])
+    return names
+
+
+def test_every_custom_mapped_frame_is_profiled() -> None:
+    """Tier 2: each reyn.* Custom name the codec emits has an extension-profile
+    entry. An unprofiled Custom name ⇒ RED (doc-drift, designed out)."""
+    emitted = _emitted_custom_names()
+
+    # Sanity: the enumeration found the real Custom vocabulary (a broken scan
+    # that found nothing must not vacuously pass).
+    assert {"reyn.display.trace", "reyn.event.user_answered_intervention"} <= emitted
+
+    missing = {name for name in emitted if not is_profiled(name)}
+    assert not missing, f"unprofiled reyn.* Custom names (add to profile): {sorted(missing)}"
+
+
+def test_intervention_frontend_tool_toolname_is_profiled() -> None:
+    """Tier 2: the HITL frontend-tool ``toolName`` the emitter really produces
+    falls under a profiled reyn.intervention.* namespace — for every intervention
+    kind (open namespace). Unprofiled ⇒ RED (the P3 members were the stale-base gap)."""
+    # Real emitter output for representative intervention kinds (ask_user free-text
+    # + a permission.* prompt) — enumerated from the codec, not the profile.
+    for kind in ("ask_user", "permission.grant_deny"):
+        ev = encode_intervention_tool_start(
+            {"intervention_id": "iv-1", "intervention_kind": kind, "prompt": "?"}
+        )
+        toolname = ev.data["toolName"]
+        assert toolname.startswith("reyn.intervention."), toolname
+        assert is_profiled(toolname), f"unprofiled intervention frontend-tool: {toolname}"
+
+    # The empty-kind fallback (``reyn.intervention.ask_user``) is also profiled.
+    ev = encode_intervention_tool_start({"intervention_id": "iv-2", "intervention_kind": ""})
+    assert is_profiled(ev.data["toolName"])

--- a/tests/test_agui_sr5_bit_identical_p4.py
+++ b/tests/test_agui_sr5_bit_identical_p4.py
@@ -1,0 +1,135 @@
+"""Tier 2: SR5 — the reyn client render is byte-identical across the P4 change.
+
+P4 widens the STANDARD surface (the text triplet, the standard messages array,
+the tool status field) so a generic client renders a functional chat. SR5 is the
+standing gate: every P4 change is ADDITIVE to the standard surface, ``_reyn``
+stays byte-unchanged, and the reyn client's render is unaffected.
+
+This pins both sides of that gate in one run:
+
+- the P4 wire genuinely carries the new generic scaffold — the
+  ``TEXT_MESSAGE_START`` / ``TEXT_MESSAGE_END`` events are present; yet
+- the reyn client, decoding the SAME wire, renders **byte-identical** display
+  output and an identical WaitingOn / working-indicator sequence to the direct
+  baseline (the renderer driven with no transport at all).
+
+If ``_reyn`` byte-equality broke, the decoded frames would differ and these
+byte-equalities would go RED. (The broader P2/P3 bit-identical suite stays green
+alongside — it is the InProcess == AgUi == baseline invariant.)
+
+Real instances only — a real InlineChatRenderer, a real AgUiEmitter + AgUiTransport
+over real SSE text; no mocks. Fixed monotonic clock so the working-indicator
+fragments are a deterministic function of the WaitingOn state.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from io import StringIO
+
+import pytest
+
+from reyn.core.events.events import Event
+from reyn.interfaces.repl.renderer import InlineChatRenderer
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.protocol import (
+    TEXT_MESSAGE_END,
+    TEXT_MESSAGE_START,
+    parse_sse_blocks,
+)
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_NOW = 10_000.0
+
+_DISPLAY = [
+    OutboxMessage(kind="agent", text="hello [world] <ok>"),
+    OutboxMessage(kind="status", text="thinking about it"),
+    OutboxMessage(kind="error", text="something failed"),
+]
+
+_EVENTS = [
+    ("turn_started", {}),
+    ("tool_called", {"tool": "grep_files"}),
+    ("tool_failed", {}),
+    ("turn_settled", {}),
+]
+
+
+def _script_frames() -> list:
+    frames: list = [EventFrame(Event(type=t, data=d)) for t, d in _EVENTS]
+    frames += [DisplayFrame(m) for m in _DISPLAY]
+    frames.append(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+    return frames
+
+
+class _RecordingInlineRenderer(InlineChatRenderer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.working_states: list = []
+
+    def on_chat_event(self, event) -> None:
+        super().on_chat_event(event)
+        self.working_states.append(self.working_frags(_NOW))
+
+
+def _baseline(monkeypatch) -> tuple[str, list]:
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    for etype, data in _EVENTS:
+        r.on_chat_event(Event(type=etype, data=data))
+    for msg in _DISPLAY:
+        r.message(msg)
+    return buf.getvalue(), r.working_states
+
+
+async def _frame_source(frames):
+    for f in frames:
+        yield f
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+@pytest.mark.asyncio
+async def test_sr5_wire_has_triplet_yet_reyn_render_matches_baseline(monkeypatch) -> None:
+    """Tier 2: SR5 — the P4 wire carries the text triplet scaffold, yet the reyn
+    client's render (display bytes + WaitingOn sequence) is byte-identical to the
+    direct baseline — the standard-surface widening did not perturb reyn."""
+    monkeypatch.setattr(time, "monotonic", lambda: _NOW)
+
+    base_stdout, base_states = _baseline(monkeypatch)
+
+    # Server side: emit the frame script to AG-UI SSE text (P4 emitter).
+    emitter = AgUiEmitter(_frame_source(_script_frames()), lambda: None)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    # The generic scaffold is genuinely present on the wire (else the SR5
+    # byte-equality below would be vacuous — the triplet must exist).
+    wire_types = {ev.type for ev in parse_sse_blocks(sse.split("\n"))}
+    assert TEXT_MESSAGE_START in wire_types
+    assert TEXT_MESSAGE_END in wire_types
+
+    # Client side: decode the SAME wire and drive the reyn renderer.
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    r = _RecordingInlineRenderer()
+    buf = StringIO()
+    monkeypatch.setattr(sys, "__stdout__", buf)
+    await asyncio.wait_for(run_output_loop(transport, r), timeout=2.0)
+    ag_stdout, ag_states = buf.getvalue(), r.working_states
+
+    # Sanity: the script rendered something non-trivial.
+    assert base_stdout
+
+    # SR5: byte-identical display + identical WaitingOn sequence, triplet notwithstanding.
+    assert ag_stdout == base_stdout
+    assert ag_states == base_states

--- a/tests/test_agui_text_triplet.py
+++ b/tests/test_agui_text_triplet.py
@@ -1,0 +1,72 @@
+"""Tier 2: a whole text message rides the canonical AG-UI triplet (ADR-0039 P4).
+
+Canonical AG-UI mandates the text lifecycle ``TEXT_MESSAGE_START`` → one-or-more
+``TEXT_MESSAGE_CONTENT`` → ``TEXT_MESSAGE_END``, all correlated by ``messageId``;
+a bare ``TEXT_MESSAGE_CONTENT`` is invalid (a strict generic client drops it). P4
+synthesizes the triplet for each whole message. This pins both halves of the P4
+contract:
+
+- **Generic surface valid**: the wire sequence for a text frame is exactly
+  START → CONTENT → END, one shared ``messageId``, CONTENT ``delta`` = full text.
+- **reyn invariant preserved (SR6)**: only the CONTENT event carries ``_reyn``
+  (START/END decode to ``None``), so the invariant stays 1 frame ⇄ 1
+  ``_reyn``-bearing event and the reyn client reconstructs the SAME single frame.
+
+Real instances only — the real codec; no mocks.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.transport.agui.protocol import (
+    TEXT_MESSAGE_CONTENT,
+    TEXT_MESSAGE_END,
+    TEXT_MESSAGE_START,
+    decode_event,
+    encode_frame_wire,
+)
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+def test_text_frame_expands_to_correlated_triplet() -> None:
+    """Tier 2: a text frame's wire sequence is START→CONTENT→END, one messageId,
+    CONTENT delta = the whole message text (the canonical lifecycle a generic
+    client requires)."""
+    start, content, end = encode_frame_wire(
+        DisplayFrame(OutboxMessage(kind="agent", text="hello world"))
+    )
+
+    assert [start.type, content.type, end.type] == [
+        TEXT_MESSAGE_START,
+        TEXT_MESSAGE_CONTENT,
+        TEXT_MESSAGE_END,
+    ]
+    mid = content.data.get("messageId")
+    assert mid, "the CONTENT event carries a non-empty messageId"
+    # START/CONTENT/END all share that one id (the correlation the spec requires).
+    assert {start.data.get("messageId"), end.data.get("messageId")} == {mid}
+    assert content.data["delta"] == "hello world"
+
+
+def test_only_content_carries_reyn_start_and_end_decode_to_none() -> None:
+    """Tier 2: SR6 — START/END are generic scaffold (no _reyn → decode None); only
+    CONTENT reconstructs the reyn frame — the 1 frame ⇄ 1 _reyn-event invariant."""
+    seq = encode_frame_wire(DisplayFrame(OutboxMessage(kind="agent", text="hi")))
+    start, content, end = seq
+
+    # START and END are standard-only scaffold: the reyn client ignores them.
+    assert decode_event(start.type, start.data) is None
+    assert decode_event(end.type, end.data) is None
+
+    # Exactly ONE event bears the reconstruction block, and it rebuilds the frame.
+    (reyn_bearing,) = [e for e in seq if "_reyn" in e.data]
+    assert reyn_bearing is content
+    decoded = decode_event(content.type, content.data)
+    assert isinstance(decoded, DisplayFrame)
+    assert decoded.message.kind == "agent" and decoded.message.text == "hi"
+
+
+def test_non_text_frame_is_a_single_event() -> None:
+    """Tier 2: a non-text frame (e.g. error → RUN_ERROR) is a single wire event,
+    not a triplet — the triplet is text-only."""
+    (only,) = encode_frame_wire(DisplayFrame(OutboxMessage(kind="error", text="boom")))
+    assert only.type != TEXT_MESSAGE_CONTENT

--- a/tests/test_agui_tool_call_status.py
+++ b/tests/test_agui_tool_call_status.py
@@ -1,0 +1,47 @@
+"""Tier 2: TOOL_CALL_END carries a standard status field (ADR-0039 P4).
+
+A generic AG-UI client needs to see a tool failure. P4 adds a standard
+``status`` (``"ok"`` / ``"error"``) to ``TOOL_CALL_END``, derived from the frame
+etype (``tool_failed`` → ``error``, ``tool_returned`` → ``ok``). The reyn client
+is unaffected — it still exact-recovers the precise etype from ``_reyn``.
+
+Real instances only — the real codec; no mocks.
+"""
+from __future__ import annotations
+
+from reyn.core.events.events import Event
+from reyn.interfaces.transport.agui.protocol import (
+    TOOL_CALL_END,
+    decode_event,
+    encode_frame,
+)
+from reyn.interfaces.transport.frames import EventFrame
+
+
+def _encode(etype: str):
+    return encode_frame(EventFrame(Event(type=etype, data={"tool": "grep_files"})))
+
+
+def test_tool_failed_maps_to_status_error() -> None:
+    """Tier 2: a tool_failed frame's standard TOOL_CALL_END status is 'error'."""
+    ev = _encode("tool_failed")
+    assert ev.type == TOOL_CALL_END
+    assert ev.data["status"] == "error"
+
+
+def test_tool_returned_maps_to_status_ok() -> None:
+    """Tier 2: a tool_returned frame's standard TOOL_CALL_END status is 'ok'."""
+    ev = _encode("tool_returned")
+    assert ev.type == TOOL_CALL_END
+    assert ev.data["status"] == "ok"
+
+
+def test_reyn_client_recovers_exact_etype_regardless_of_status() -> None:
+    """Tier 2: the reyn client reconstructs the precise etype from _reyn — the
+    standard status is a generic-surface addition, not the reyn recovery source."""
+    for etype in ("tool_failed", "tool_returned"):
+        ev = _encode(etype)
+        decoded = decode_event(ev.type, ev.data)
+        assert isinstance(decoded, EventFrame)
+        assert decoded.event.type == etype
+        assert decoded.event.data == {"tool": "grep_files"}


### PR DESCRIPTION
**[per-PR-coder]** — P4 of the thin-client / single-writer-server arc (ADR-0039), part of #2805. Generic-client conformance + reyn extension-profile formalization. **Do not merge** — awaiting architect co-vet against `P4_conformance_spec.md`, then lead-coder merges on verdict. **Rebased onto current `origin/main` (P3-inclusive) and reconciled** — extends P2+P3, nothing dropped.

## What P4 does
Turns D6's "honest ceiling" into a stated + tested **floor**: a stock AG-UI client (zero reyn knowledge, standard fields only) renders a functional chat, and the `reyn.*` namespace becomes a documented, tested profile. The reyn CUI stays **bit-identical** via `_reyn` (SR5, the standing gate).

### Three conformance gaps closed (additive to the standard surface)
- **(i) TEXT triplet.** `encode_frame_wire` synthesizes the canonical `TEXT_MESSAGE_START → CONTENT → END` with a shared generated `messageId`. Only CONTENT carries `_reyn`; START/END decode to `None` — so the invariant stays **1 frame ⇄ 1 `_reyn`-bearing event** and reyn bit-identity is unchanged (SR1/SR6).
- **(ii) MESSAGES_SNAPSHOT** emits a standard `[{role, content}]` conversation-turns-only array (`agent`→`assistant`, `user`→`user`); chrome stays reyn-private via `_reyn` (SR2/SR2b).
- **(iii) TOOL_CALL_END** carries a standard `status` (`"ok"`/`"error"`) from the etype; reyn exact-recovers from `_reyn`.

### reyn extension profile
New `profile.py` single registry over `reyn.display.<kind>` / `reyn.event.<etype>` (closed CUSTOM members) **and `reyn.intervention.<kind>` (open namespace)**. SR4 non-circular completeness gate: enumerate the reyn-mapped vocabulary from source (renderer kinds + `renderer_chat_events` + the intervention frontend-tool encoder) → assert each emitted name is profiled; unprofiled → RED.

### ignore-unknown, both directions
- **client**: (a) foreign event no `_reyn` → None; (b) unknown `_reyn` frame tag → None; (c) **SR3** unknown `reyn.*` name → skip.
- **server**: an unmodeled POST input type graceful-degrades (200 no-op, no `KeyError`/500) **without swallowing P3's real dispatch** — turn / answer (`TOOL_CALL_RESULT` by-id) / `/seize` all still route.

## Reconciliation with P3 (#2815) — the corrected diagnosis
The earlier "P3 not on main" note was a **stale-base artifact** (my worktree branched at P2); P3 is on `main`. Rebased and union-reconciled the four P3∩P4 files. Corrections applied to the P4 scoping that had assumed P3 absent:
- **`reyn.intervention.<kind>` is emitted, not reserved.** P3 emits it as the HITL frontend-tool `toolName` (`TOOL_CALL_START`, frame tag `intervention_tool`) + terminal `TOOL_CALL_RESULT`. It is now a **profiled open namespace** (kind is `ask_user`/`permission.*`, caller-supplied), and the SR4 gate covers it (`test_intervention_frontend_tool_toolname_is_profiled`).
- **HITL coexists with the triplet.** The emitter reconciliation layers the triplet loop (`encode_frame_wire`) then P3's frontend-tool emission; `intervention` is CUSTOM (single event), so the triplet never disturbs the `TOOL_CALL_START`/`RESULT` path. Verified in the generic-client e2e (frontend-tool + RESULT seen alongside a valid triplet).
- **endpoint.py**: took P3's handler wholesale (it already graceful-degrades unknown types); my earlier redundant edit dropped — no P3 lines lost.
- **Coverage matrix updated** in `agui-transport.md` (the authoritative "reading the numbers honestly" matrix): **Tool 2→3** (`TOOL_CALL_RESULT` landed + `status` field), **Text 1→3** (conforming triplet), totals **9→12 of 28**; the now-resolved "tool result fidelity" gap bullet removed. My duplicate coverage table was consolidated into it.

## RED evidence (strip-falsify, cp-backup/restore — never git stash)
- **Profile gate, closed member**: removed `reyn.display.trace` → `test_every_custom_mapped_frame_is_profiled` RED → restored PASS.
- **Profile gate, open namespace**: removed the `reyn.intervention.` `OPEN_NAMESPACES` entry → `test_intervention_frontend_tool_toolname_is_profiled` RED (`is_profiled('reyn.intervention.ask_user') = False`) → restored PASS.
- **SR5 bit-identical**: corrupted the CONTENT `_reyn.text` → SR5 RED (rendered bytes diverged from the P3-inclusive baseline) → restored PASS.

## Test plan (Tier-2, real instances, NO mocks — all pass)
- [x] 1. TEXT triplet — `test_agui_text_triplet.py`
- [x] 2. MESSAGES standard shape — `test_agui_messages_standard_shape.py`
- [x] 3. TOOL_CALL_END status — `test_agui_tool_call_status.py`
- [x] 4. profile completeness gate (closed members + open intervention namespace) — `test_agui_profile_completeness.py` (both strip-falsify RED verified)
- [x] 5. ignore-unknown both directions (client a/b/c + server unknown-type against P3's real turn/answer/seize dispatch) — `test_agui_ignore_unknown_both_directions.py`
- [x] 6. **generic-client e2e** — `test_agui_generic_client_e2e.py` (standard-only consumer, `_reyn` stripped: text triplet + tool+status + run + STATE + backlog + **HITL frontend-tool + RESULT**; reyn chrome ignored)
- [x] 7. **SR5 bit-identical** — `test_agui_sr5_bit_identical_p4.py` (triplet on wire, reyn render byte-equal to the P3-inclusive baseline; strip-falsify RED verified)

**P3's tests stay green** (HITL round-trip, answer-auth, fail-close grace, liveness, reachability-connect, seize, attribution) — the rebase regressed none. 51 agui tests pass (P2+P3+P4).

## CI gates (all 4 green locally, post-rebase)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict <7 test files>` — 17/17 OK, 0 Tier-4
- `pytest` (repo root) — **8199 passed**, 5 failed. The 5 (`tests/web/` route-mount a2a/mcp_sse/resources, `test_plugin_loader`, `test_fp0001_routes_mounted`) reproduce **identically on pristine `origin/main`** (verified) — pre-existing baseline, **zero NEW**, all in files P4 never touches.
- `python scripts/verify_module_docstrings.py <5 changed src files>` — clean

## Docs
`agui-transport.md`: text-lifecycle triplet, standard `messages`, `TOOL_CALL_END` status, the reyn **extension-profile** section (all three namespaces incl. the corrected `reyn.intervention.*`), and the updated coverage matrix. `.ja.md` regenerated as a 1:1 mirror of the reconciled English (verbatim identifiers, no history refs). No PR/ADR/issue refs in user docs.

## Carry-forward
Reasoning\* mapping = a later phase (highest-value future coverage; respect the reasoning-display toggle gate).

toward #2805