### PR TITLE
feat: classify sandbox launcher-fork denial + make it legible (part of #2820)

### DIFF
--- a/docs/reference/runtime/events.ja.md
+++ b/docs/reference/runtime/events.ja.md
@@ -42,7 +42,7 @@ Reyn はすべての状態変化に対して構造化イベントを発行しま
 | 種類 | タイミング |
 |------|------|
 | `read_file`、`write_file`、`edit_file`、`delete_file`、`glob_files`、`grep`、`regenerate_index` | `file` op のバリアント — すべて `tool_executed`（`op=<sub_op>`）経由 |
-| `sandboxed_exec_started`、`sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`、`backend`; `completed`: `argv`、`backend`、`returncode` |
+| `sandboxed_exec_started`、`sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`、`argv0_resolved`、`backend`; `completed`: `argv`、`argv0_resolved`、`backend`、`returncode`、`denial_class`。`argv0_resolved`（#2820）は `argv[0]` が解決される realpath（read-only。bare `python3` が `~/.pyenv/shims/python3` に解決されるのが launcher-fork denial の tell）。`denial_class` は `(deny process-fork)` 下で PATH 上の launcher/shim（pyenv/asdf/mise/npx/uvx）の内部 fork がブロックされたとき `"fork_denied"`、それ以外は `null` — ツール失敗ではなく環境/設定の問題 |
 | `mcp_called`、`mcp_completed`、`mcp_failed`、`mcp_cancelled` | MCP ツール op — `mcp_cancelled`（#2813）は Ctrl-C の `cancel_event` が実行中の呼び出しを完了前に中断したとき、`mcp_completed`/`mcp_failed` の代わりに発火 |
 | `mcp_server_installed` | `mcp_install` op — `name`、キー名のみ（値は含まない） |
 | `mcp_install_cancelled`、`mcp_prompt_get_cancelled`、`mcp_resource_read_cancelled`、`mcp_resource_subscribe_cancelled`、`mcp_resource_unsubscribe_cancelled` | #2813 — Ctrl-C の `cancel_event` が該当 op（install probe / get-prompt / read-resource / subscribe / unsubscribe）を完了前に中断。op は `status:"cancelled"` を返し、何もコミットされない |

--- a/docs/reference/runtime/events.md
+++ b/docs/reference/runtime/events.md
@@ -42,7 +42,7 @@ Each Control IR op kind emits its own event:
 | Kind | When |
 |------|------|
 | `read_file`, `write_file`, `edit_file`, `delete_file`, `glob_files`, `grep`, `regenerate_index` | `file` op variants — all via `tool_executed` with `op=<sub_op>` |
-| `sandboxed_exec_started`, `sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`, `backend`; `completed`: `argv`, `backend`, `returncode` |
+| `sandboxed_exec_started`, `sandboxed_exec_completed` | `sandboxed_exec` op — `started`: `argv`, `argv0_resolved`, `backend`; `completed`: `argv`, `argv0_resolved`, `backend`, `returncode`, `denial_class`. `argv0_resolved` (#2820) is the realpath `argv[0]` resolves to (read-only; a bare `python3` resolving to `~/.pyenv/shims/python3` is the tell for a launcher-fork denial). `denial_class` is `"fork_denied"` when the sandbox blocked `fork()` at a PATH launcher/shim (pyenv/asdf/mise/npx/uvx) under `(deny process-fork)`, else `null` — an environment/config condition, not a tool failure |
 | `mcp_called`, `mcp_completed`, `mcp_failed`, `mcp_cancelled` | MCP tool ops — `mcp_cancelled` (#2813) fires instead of `mcp_completed`/`mcp_failed` when a Ctrl-C `cancel_event` interrupts an in-flight call before it completes |
 | `mcp_server_installed` | `mcp_install` op — `name`, key names only (no values) |
 | `mcp_install_cancelled`, `mcp_prompt_get_cancelled`, `mcp_resource_read_cancelled`, `mcp_resource_subscribe_cancelled`, `mcp_resource_unsubscribe_cancelled` | #2813 — a Ctrl-C `cancel_event` interrupted the corresponding op (install probe / get-prompt / read-resource / subscribe / unsubscribe) before it completed; the op returns `status:"cancelled"` and nothing is committed |

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -407,9 +407,27 @@ def web_search_to_canonical(result: dict) -> CanonicalToolResult:
     return CanonicalToolResult(text="", attachments=[], source_ref=None, meta={})
 
 
+def _fork_denial_note(argv0_resolved: str | None) -> str:
+    """The operator/LLM-facing explanation prepended to a launcher-fork denial
+    (#2820). It exists to KILL the weak-model self-narrative ("I can't execute
+    tools") by stating plainly this is an environment/config condition, not a
+    tool-availability one, and that an identical retry will fail identically."""
+    where = f" '{argv0_resolved}'" if argv0_resolved else ""
+    return (
+        "[sandbox] Blocked at the launcher layer: the sandbox denies process "
+        f"fork(), and the command{where} resolves to a version-manager shim "
+        "(pyenv/asdf/mise) or a spawn-based launcher (npx/uvx) that forks "
+        "internally. This is an environment / sandbox-configuration problem — "
+        "NOT a missing tool and NOT a lack of tool-calling ability; retrying the "
+        "same command will fail identically. Fix: invoke the real binary by "
+        "absolute path, or allow subprocess for this command."
+    )
+
+
 def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
     """sandboxed_exec result → canonical. ``stdout`` (+ ``stderr`` when present) → ``text``; a NONZERO
     ``returncode`` → signal meta (it changes what the LLM does next — a zero code is not signal).
+    A ``denial_class`` (#2820) prepends an explicit environment-vs-tool note and surfaces as meta.
     Transport (backend/truncated) is dropped."""
     stdout = result.get("stdout") or ""
     stderr = result.get("stderr") or ""
@@ -424,6 +442,13 @@ def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
     returncode = result.get("returncode")
     if returncode:  # nonzero (or truthy) only — a 0 exit is not actionable signal
         meta["returncode"] = returncode
+    # #2820: a launcher-fork denial is opaque as raw stderr — name it and prepend the explanation so
+    # the LLM does not misread it as "I cannot execute tools" (the exact failure mode that motivated it).
+    denial_class = result.get("denial_class")
+    if denial_class:
+        meta["denial_class"] = denial_class
+        if denial_class == "fork_denied":
+            text = f"{_fork_denial_note(result.get('argv0_resolved'))}\n\n{text}"
     return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
 
 

--- a/src/reyn/core/op_runtime/sandboxed_exec.py
+++ b/src/reyn/core/op_runtime/sandboxed_exec.py
@@ -9,13 +9,28 @@ Emits `sandboxed_exec_started` / `sandboxed_exec_completed` events (P6).
 """
 from __future__ import annotations
 
+import os
+import shutil
 from typing import Literal
 
 from reyn.schemas.models import SandboxedExecIROp
 from reyn.security.sandbox import SandboxPolicy, get_default_backend
+from reyn.security.sandbox.denial import classify_denial
 
 from . import register
 from .context import OpContext
+
+
+def _resolve_argv0(argv0: str) -> str | None:
+    """Best-effort realpath of *argv0* as the sandbox child would resolve it —
+    READ-ONLY (no exec). Records what a bare command name actually points at so a
+    launcher-fork denial (#2820) is legible in the trace without re-deriving PATH:
+    a bare ``python3`` that resolves to ``~/.pyenv/shims/python3`` is the entire
+    tell. ``None`` when the name is not found on PATH."""
+    found = shutil.which(argv0)
+    if found is None:
+        return None
+    return os.path.realpath(found)
 
 
 async def handle(
@@ -78,9 +93,16 @@ async def handle(
     # not the op's request fields — the operator-or-default policy wins over op
     # fields, so the trace must show what was enforced (a network:true op under
     # a network:false policy ran WITHOUT network, and the event must say so).
+    # #2820: record what argv[0] actually resolves to. When a launcher-fork
+    # denial happens (bare command → pyenv/asdf/mise shim or npx/uvx that forks
+    # internally under (deny process-fork)), this field is the diagnostic that
+    # would otherwise take a live PATH re-derivation to recover.
+    argv0_resolved = _resolve_argv0(op.argv[0]) if op.argv else None
+
     ctx.events.emit(
         "sandboxed_exec_started",
         argv=list(op.argv),
+        argv0_resolved=argv0_resolved,
         backend=backend.name,
         timeout_seconds=policy.timeout_seconds,
         network=policy.network,
@@ -114,14 +136,22 @@ async def handle(
             "truncated": False,
         }
 
+    # #2820: classify a launcher-fork denial (pure fn of returncode+stderr). None
+    # for any normal (even nonzero) exit — only a genuine sandbox denial is named,
+    # so the canonical layer can tell the LLM "environment/config, not tool
+    # availability" and the audit trail records the class.
+    denial_class = classify_denial(result.returncode, result.stderr)
+
     ctx.events.emit(
         "sandboxed_exec_completed",
         argv=list(op.argv),
+        argv0_resolved=argv0_resolved,
         backend=backend.name,
         returncode=result.returncode,
         stdout_len=len(stdout_text),
         stderr_len=len(stderr_text),
         truncated=result.truncated,
+        denial_class=denial_class,
     )
 
     status = "ok" if result.returncode == 0 else ("timeout" if result.returncode == -1 else "error")
@@ -133,6 +163,8 @@ async def handle(
         "stdout": stdout_text,
         "stderr": stderr_text,
         "truncated": result.truncated,
+        "denial_class": denial_class,
+        "argv0_resolved": argv0_resolved,
     }
 
 

--- a/src/reyn/security/sandbox/denial.py
+++ b/src/reyn/security/sandbox/denial.py
@@ -1,0 +1,56 @@
+"""Pure classification of a sandbox denial from a finished result (#2820, part B).
+
+A sandbox that enforces ``(deny process-fork)`` (macOS seatbelt / Linux seccomp,
+whenever ``SandboxPolicy.allow_subprocess`` is False) makes a *bare-command* exec
+fail at the LAUNCHER layer rather than in the workload: a bare ``python3`` on
+PATH resolves to a version-manager shim (``~/.pyenv/shims/python3`` → ``pyenv
+exec ...``) or a spawn-based launcher (``npx`` / ``uvx``) whose own internal
+``fork()`` is blocked — even when the command itself never forks. The raw stderr
+is opaque::
+
+    /opt/homebrew/opt/pyenv/bin/pyenv: fork: Operation not permitted
+
+Two failure modes follow from that opacity: a weak model reads it as "I cannot
+execute tools" and entrenches a false self-narrative turn after turn, and an
+operator cannot tell an environment/PATH problem from a genuine tool failure.
+This module names the class so the canonical layer can say "environment/config
+problem, not tool-availability" and the audit-event can record it.
+
+Pure: no I/O, no process state — a function of ``(returncode, stderr)`` only, so
+it replays deterministically over a captured fixture (testing.md static-replay).
+"""
+from __future__ import annotations
+
+import re
+
+#: Denial class: the sandbox blocked ``fork()`` and a PATH launcher/shim (not the
+#: workload) hit it. See module docstring for the mechanism.
+DENIAL_FORK = "fork_denied"
+
+# The launcher-fork denial signature. A shell-based shim (pyenv/asdf/mise) or a
+# spawn-heavy launcher (npx/uvx) prints "<name>: fork: <reason>" when the sandbox
+# blocks fork(): "Operation not permitted" is the macOS sandbox-exec /
+# (deny process-fork) EPERM case; "Resource temporarily unavailable" (EAGAIN) is
+# the variant some Linux seccomp/rlimit configurations surface.
+_FORK_DENIED = re.compile(
+    r"fork:\s*(operation not permitted|resource temporarily unavailable)",
+    re.IGNORECASE,
+)
+
+
+def classify_denial(returncode: int, stderr: bytes | str) -> str | None:
+    """Return a denial-class string for a finished sandbox result, or ``None``.
+
+    Only a genuine failure (nonzero ``returncode``) is classified — a normal
+    exit is never a denial regardless of its output — and currently the only
+    class is the launcher-fork denial (:data:`DENIAL_FORK`, #2820). ``None``
+    means "not a recognized sandbox denial", so callers special-case only the
+    real thing.
+    """
+    if returncode == 0:
+        return None
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    if _FORK_DENIED.search(stderr):
+        return DENIAL_FORK
+    return None

--- a/tests/test_sandbox_denial_class_2820.py
+++ b/tests/test_sandbox_denial_class_2820.py
@@ -1,0 +1,149 @@
+"""Tier 2: sandbox launcher-fork denial classification + canonical note (#2820, B).
+
+The denial classifier is a pure function of ``(returncode, stderr)`` — these lock
+it down by static replay over the REAL captured stderr (``pyenv: fork: Operation
+not permitted``, the ../user incident's exact bytes), never by re-running a
+sandbox. The canonical tests prove the opaque raw stderr is turned into an
+explicit "environment/config, not tool-availability" note — the whole point of
+part B is to stop a weak model reading the raw line as "I cannot execute tools".
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.offload.canonical import sandboxed_exec_to_canonical
+from reyn.security.sandbox.backend import SandboxResult
+from reyn.security.sandbox.denial import DENIAL_FORK, classify_denial
+
+# The exact stderr the incident produced (bare ``python3`` → pyenv shim → pyenv
+# forks under (deny process-fork)). Captured, not synthesized.
+_REAL_FORK_STDERR = b"/opt/homebrew/opt/pyenv/bin/pyenv: fork: Operation not permitted\n"
+
+
+def test_classify_real_captured_fork_denial_stderr():
+    """Tier 2: the real ../user incident stderr classifies as fork_denied."""
+    assert classify_denial(128, _REAL_FORK_STDERR) == DENIAL_FORK
+
+
+def test_classify_eagain_variant():
+    """Tier 2: the Linux EAGAIN wording is the same class (a seccomp/rlimit
+    surface of the identical launcher-fork denial)."""
+    assert (
+        classify_denial(1, b"npx: fork: Resource temporarily unavailable")
+        == DENIAL_FORK
+    )
+
+
+def test_classify_is_case_insensitive():
+    """Tier 2: signature match must not hinge on exact casing of the OS message."""
+    assert classify_denial(128, b"sh: FORK: OPERATION NOT PERMITTED") == DENIAL_FORK
+
+
+def test_zero_returncode_is_never_a_denial():
+    """Tier 2: a success is never a denial even if output coincidentally matches —
+    the classifier gates on failure first."""
+    assert classify_denial(0, _REAL_FORK_STDERR) is None
+
+
+def test_ordinary_nonzero_failure_is_not_classified():
+    """Tier 2: a normal command failure (no fork-denial signature) → None, so the
+    canonical note only fires on the real thing."""
+    assert classify_denial(1, b"ls: nope: No such file or directory") is None
+    assert classify_denial(2, b"") is None
+
+
+def test_canonical_prepends_env_not_tool_note_on_fork_denial():
+    """Tier 2: a fork_denied result renders the explicit environment-vs-tool note
+    (naming the resolved shim) AND carries denial_class in meta — the LLM must see
+    "NOT a lack of tool-calling ability", not just the raw pyenv line."""
+    result = {
+        "kind": "sandboxed_exec",
+        "status": "error",
+        "returncode": 128,
+        "stdout": "",
+        "stderr": _REAL_FORK_STDERR.decode(),
+        "denial_class": DENIAL_FORK,
+        "argv0_resolved": "/Users/x/.pyenv/shims/python3",
+    }
+    canonical = sandboxed_exec_to_canonical(result)
+    text = canonical["text"]
+    assert "NOT a lack of tool-calling ability" in text
+    assert "environment" in text.lower()
+    assert "/Users/x/.pyenv/shims/python3" in text  # names the resolved shim
+    assert "pyenv" in text  # the raw stderr is still present below the note
+    assert canonical["meta"].get("denial_class") == DENIAL_FORK
+
+
+def test_canonical_note_absent_on_ordinary_failure():
+    """Tier 2: regression guard — a normal nonzero exit (denial_class None) gets
+    NO launcher note and NO denial_class meta; only returncode signal survives."""
+    result = {
+        "kind": "sandboxed_exec",
+        "status": "error",
+        "returncode": 2,
+        "stdout": "",
+        "stderr": "boom",
+        "denial_class": None,
+        "argv0_resolved": "/usr/bin/false",
+    }
+    canonical = sandboxed_exec_to_canonical(result)
+    assert "[sandbox]" not in canonical["text"]
+    assert "denial_class" not in canonical["meta"]
+    assert canonical["meta"].get("returncode") == 2
+
+
+class _ForkDenyingBackend:
+    """Real SandboxBackend test double (NOT a mock) that returns the captured
+    fork-denial result — proves the handler classifies + surfaces it end-to-end."""
+
+    name = "fake-forkdeny"
+
+    def available(self) -> bool:
+        return True
+
+    def wrap_command(self, argv, policy):  # pragma: no cover - unused here
+        from reyn.security.sandbox.backend import WrappedCommand
+
+        return WrappedCommand(argv=list(argv))
+
+    async def run(self, argv, policy, *, stdin=None, cwd=None, cancel_event=None):
+        return SandboxResult(returncode=128, stdout=b"", stderr=_REAL_FORK_STDERR)
+
+
+@pytest.mark.asyncio
+async def test_handler_surfaces_denial_class_and_argv0_end_to_end():
+    """Tier 2: the real handler, given a backend that reproduces the fork denial,
+    returns denial_class='fork_denied' in the P5 dict AND emits it (with
+    argv0_resolved) on the P6 sandboxed_exec_completed event — the production
+    wiring, not just the pure fn."""
+    from reyn.core.events.events import EventLog
+    from reyn.core.op_runtime import execute_op
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.schemas.models import SandboxedExecIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    workspace = Workspace(events=events)
+    ctx = OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=PermissionDecl(),
+        sandbox_backend=_ForkDenyingBackend(),
+    )
+    op = SandboxedExecIROp(
+        kind="sandboxed_exec",
+        argv=["python3", "-c", "print(2+2)"],
+        env_passthrough=["PATH"],
+        timeout_seconds=30,
+    )
+
+    result = await execute_op(op, ctx)
+
+    assert result["denial_class"] == DENIAL_FORK
+    assert "argv0_resolved" in result  # present (value may be None if python3 off PATH)
+
+    completed = [e for e in events.all() if e.type == "sandboxed_exec_completed"]
+    assert completed, "sandboxed_exec_completed not emitted"
+    assert completed[0].data.get("denial_class") == DENIAL_FORK
+    assert "argv0_resolved" in completed[0].data


### PR DESCRIPTION
**[tui-coder]** — part of #2820 (PR1 = part B: diagnostic infra)

## What
Names and explains the sandbox **launcher-fork denial** so it stops being an opaque, misattributed failure. This is the independent minimal slice of #2820 — it does **not** change the sandbox boundary; it makes the denial legible.

## Why
Root-caused from a live `../user` incident (reported as "gemini won't execute tools"). Under `(deny process-fork)` (the default when `allow_subprocess=False`), a **bare** command exec fails at the PATH launcher layer, not in the workload:

```
$ python3 -c "print(2+2)"                    → pyenv: fork: Operation not permitted  (rc=128)
$ /opt/homebrew/bin/python3 -c "print(2+2)"  → 4  ✅
```

`~/.pyenv/shims/python3` execs `pyenv exec ...`, and pyenv forks internally — blocked — even though `print(2+2)` never forks. The raw stderr is opaque, producing two failure modes:
1. A weak model reads `fork: Operation not permitted` as **"I cannot execute tools"** and entrenches a false self-narrative turn after turn (the actual `../user` symptom).
2. An operator cannot tell an environment/PATH problem from a genuine tool failure; the multi-day investigation chased herdr / `com.apple.provenance` / uv-vs-pyenv before the real cause surfaced.

## Change
- **`src/reyn/security/sandbox/denial.py`** (new) — `classify_denial(returncode, stderr)`: pure fn, captures the fork-denial signature (EPERM + the EAGAIN variant). Returns `"fork_denied"` or `None`.
- **`sandboxed_exec` handler** — read-only realpath of `argv[0]` (a bare `python3` resolving to `~/.pyenv/shims/python3` is the entire tell) + denial classification, surfaced on `sandboxed_exec_started`/`completed` events and the result dict.
- **canonical mapper** — on `fork_denied`, prepend an explicit **"environment/config, NOT tool-availability"** note (naming the resolved shim) so the LLM stops misreading it. This directly targets failure mode #1.
- **`events.md` / `events.ja.md`** — mirror synced with `argv0_resolved` + `denial_class`.

The `(deny process-fork)` boundary is **unchanged**. Part A (argv[0] pre-resolution — the actual fix) and part C (MCP stdio `_build_mcp_sandbox_policy` policy-fit) follow as separate sub-PRs.

## Test plan
- [x] `pytest tests/test_sandbox_denial_class_2820.py` — 8 Tier 2 (static replay over the **real captured** incident stderr + handler end-to-end wiring via a fake backend)
- [x] `ruff check` (changed files) — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_sandbox_denial_class_2820.py` — 8 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py` (changed src) — clean
- [x] full `pytest` — 8220 passed; **9 pre-existing failures** in `test_compaction_resolver_aware_1172` / `test_llm_request_error_1676` / `test_llm_router_s3b_1829` / `test_responses_api_routing_1678` (LLM-router/compaction area, unrelated to this diff). Confirmed pre-existing via stash A/B: the identical 9 fail on the clean branch with this diff stashed, and all pass in isolation (full-suite-only test pollution, not main breakage).

Tier self-check: all new tests are Tier 2 (pure-fn static replay + production-wiring), assert on public surface (`canonical["text"]`/`["meta"]`, event `.data`, result dict), no private-state / format-pin / mock.
