### PR TITLE
feat: single-drain broadcast hub for session.outbox (ADR-0039 P6b-1)

### DIFF
--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -56,6 +56,8 @@ from reyn.interfaces.transport.frames import (
 )
 from reyn.interfaces.web.auth import AuthContext, ConnectionIdentity
 from reyn.interfaces.web.deps import get_registry
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.outbox_hub import DEFAULT_SURFACE_MAXSIZE
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID
 from reyn.runtime.session_buses import NO_SURFACE_REFUSAL_REASON
 
@@ -191,6 +193,7 @@ class _SessionFrameSource:
             session, "_chat_events", None
         )
         self._drain_task: "asyncio.Task | None" = None
+        self._sub = None
 
     def _on_chat_event(self, event) -> None:
         if getattr(event, "type", None) in self._forward:
@@ -204,13 +207,25 @@ class _SessionFrameSource:
     def close(self) -> None:
         if self._events is not None:
             self._events.remove_subscriber(self._on_chat_event)
+        if self._sub is not None:
+            self._sub.close()
         if self._drain_task is not None:
             self._drain_task.cancel()
 
     async def _drain_outbox(self) -> None:
-        outbox = self._session.outbox
+        # ADR-0039 P6b: subscribe to the session's outbox *hub* (a bounded
+        # per-surface queue) instead of draining ``session.outbox`` directly.
+        # This surface therefore receives the FULL stream even when other AG-UI
+        # / local surfaces are attached (asyncio.Queue's single-getter steal is
+        # resolved by the hub's single-drain fan-out). A stuck SSE reader is
+        # disconnect-slow'd by the hub — ``get()`` then returns ``None`` and we
+        # end this surface's stream with a synthetic terminal frame.
+        self._sub = self._session.outbox_hub.subscribe(maxsize=DEFAULT_SURFACE_MAXSIZE)
         while True:
-            msg = await outbox.get()
+            msg = await self._sub.get()
+            if msg is None:
+                self._q.put_nowait(DisplayFrame(OutboxMessage(kind="__end__", text="")))
+                return
             self._q.put_nowait(DisplayFrame(msg))
             if msg.kind == "__end__":
                 return

--- a/src/reyn/runtime/outbox_hub.py
+++ b/src/reyn/runtime/outbox_hub.py
@@ -1,0 +1,158 @@
+"""OutboxHub — single-drain broadcast fan-out for ``session.outbox`` (ADR-0039 P6b).
+
+`session.outbox` is a single-consumer :class:`asyncio.Queue`: every ``.get()``
+hands an item to exactly ONE getter. Before this hub, two code paths drained it
+directly — the registry's local ``_forwarder`` (→ ``repl_outbox``, the local REPL
+sink) and the AG-UI ``_SessionFrameSource`` (one drain per SSE connection). They
+were kept mutually exclusive (``ensure_running`` starts the forwarder;
+``ensure_session_running`` does not and lets the AG-UI caller drain) precisely
+because two concurrent getters on one Queue *steal* frames from each other, so N
+AG-UI surfaces would each see only a fraction of the stream.
+
+P6b makes AG-UI the sole UI transport for the browser AND the ``--connect`` thin
+client concurrently, so the mutual-exclusion no longer holds. This hub resolves
+it structurally:
+
+- **ONE** task drains ``session.outbox`` — the sole ``.get()`` consumer.
+- Each surface calls :meth:`OutboxHub.subscribe` to get its OWN
+  :class:`HubSubscription` queue; the hub fans every message out to every
+  subscription, so each surface receives the FULL stream in order.
+- The local ``_forwarder`` and the AG-UI ``_SessionFrameSource`` become hub
+  *subscribers* rather than direct outbox drainers — folding the two paths into
+  one non-stealing fan-out.
+
+**Slow / dead surface never blocks the writer.** Fan-out uses ``put_nowait``.
+A subscription may cap its queue (``maxsize``); when a bounded surface's queue is
+full (it stopped draining — a stuck SSE client) the hub *disconnects* it
+(disconnect-slow policy): it clears that one queue, pushes a close sentinel so the
+subscriber's :meth:`HubSubscription.get` returns ``None``, and drops it from the
+fan-out set. The single drain task therefore never awaits a full queue and other
+surfaces are unaffected. The local REPL subscription is created *unbounded*
+(``maxsize=0``) so its delivery is byte-identical to the pre-hub direct forwarder
+(a fast, unbounded local sink is never disconnected).
+
+``__end__`` (the session-shutdown terminal) fans out to all surfaces like any
+other message; each subscriber terminates its own loop on ``kind == "__end__"``.
+The drain task then returns; a later :meth:`subscribe` restarts it (session
+restart), since the underlying ``session.outbox`` Queue is reused.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.runtime.outbox import OutboxMessage
+
+logger = logging.getLogger(__name__)
+
+# Default per-surface queue cap for a *bounded* subscription (a remote SSE
+# surface). Generous — a surface this far behind is genuinely stuck, not merely
+# briefly slow — so disconnect-slow only fires on a truly dead reader.
+DEFAULT_SURFACE_MAXSIZE = 4096
+
+# Distinct from ``__end__`` (a real terminal OutboxMessage): this private
+# sentinel signals a subscription was force-closed by disconnect-slow, surfaced
+# to the consumer as ``get()`` returning ``None``.
+_CLOSED = object()
+
+
+class HubSubscription:
+    """One surface's view of the broadcast stream — a private queue fed by the hub.
+
+    Consumers loop on :meth:`get`, which yields each :class:`OutboxMessage` in
+    order and returns ``None`` once the subscription is force-closed
+    (disconnect-slow). ``__end__`` arrives as an ordinary message (``kind ==
+    "__end__"``); ``None`` is *only* the disconnected-surface signal.
+    """
+
+    __slots__ = ("_hub", "_queue")
+
+    def __init__(self, hub: "OutboxHub", maxsize: int) -> None:
+        self._hub = hub
+        # maxsize=0 → unbounded (the local REPL sink, byte-identical to the
+        # pre-hub direct forwarder). A positive cap arms disconnect-slow.
+        self._queue: "asyncio.Queue" = asyncio.Queue(maxsize=maxsize)
+
+    async def get(self) -> "OutboxMessage | None":
+        """Next message in order, or ``None`` if this surface was disconnected."""
+        item = await self._queue.get()
+        if item is _CLOSED:
+            return None
+        return item
+
+    def close(self) -> None:
+        """Detach this surface from the hub (graceful client teardown)."""
+        self._hub._remove(self)
+
+
+class OutboxHub:
+    """Single-drain broadcast hub over one source ``asyncio.Queue``."""
+
+    def __init__(self, source: "asyncio.Queue", *, name: str = "") -> None:
+        self._source = source
+        self._subs: "set[HubSubscription]" = set()
+        self._drain_task: "asyncio.Task | None" = None
+        self._name = name
+
+    def subscribe(self, *, maxsize: int = 0) -> HubSubscription:
+        """Register a new surface. ``maxsize=0`` is unbounded (local sink);
+        a positive cap arms the disconnect-slow policy for a remote surface.
+
+        Lazily (re)starts the single drain task, so the hub needs no running
+        loop at construction — only when the first surface attaches."""
+        sub = HubSubscription(self, maxsize)
+        self._subs.add(sub)
+        self._ensure_drain()
+        return sub
+
+    def _remove(self, sub: HubSubscription) -> None:
+        self._subs.discard(sub)
+
+    def _ensure_drain(self) -> None:
+        if self._drain_task is None or self._drain_task.done():
+            self._drain_task = asyncio.create_task(self._drain())
+
+    async def _drain(self) -> None:
+        """The SOLE ``source.get()`` consumer: drain and fan out forever, until
+        the ``__end__`` terminal (session shutdown)."""
+        while True:
+            msg = await self._source.get()
+            self._fanout(msg)
+            if getattr(msg, "kind", None) == "__end__":
+                return
+
+    def _fanout(self, msg: "OutboxMessage") -> None:
+        # Never awaits: put_nowait into each surface's queue; a full bounded
+        # queue triggers disconnect-slow rather than blocking the drain.
+        for sub in list(self._subs):
+            try:
+                sub._queue.put_nowait(msg)
+            except asyncio.QueueFull:
+                self._disconnect_slow(sub)
+
+    def _disconnect_slow(self, sub: HubSubscription) -> None:
+        """Drop a stuck surface without blocking the writer or other surfaces.
+
+        Runs synchronously (no ``await``) so it is atomic against the drain
+        loop and the subscriber's ``get()``: clear the surface's queue, push the
+        close sentinel (so its next ``get()`` returns ``None``), and remove it
+        from the fan-out set. A dead reader thus cannot back-pressure the hub."""
+        self._subs.discard(sub)
+        while True:
+            try:
+                sub._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        try:
+            sub._queue.put_nowait(_CLOSED)
+        except asyncio.QueueFull:  # pragma: no cover — just cleared above
+            pass
+        logger.warning(
+            "outbox_hub[%s]: disconnected a slow surface (queue full, %d remain)",
+            self._name, len(self._subs),
+        )
+
+
+__all__ = ["OutboxHub", "HubSubscription", "DEFAULT_SURFACE_MAXSIZE"]

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -3037,46 +3037,62 @@ class AgentRegistry:
         session is the attached one; otherwise drops the message (transient
         kinds were already dropped at source, durable narration is in history).
         Special kind `__attach_request__` is consumed here as a control signal.
+
+        ADR-0039 P6b: subscribes to the session's outbox *hub* (unbounded local
+        sink) instead of draining ``session.outbox`` directly — so this local
+        REPL forwarder and any concurrent AG-UI surface each receive the full
+        stream rather than stealing frames. Delivery is byte-identical to the
+        pre-hub direct drain (an unbounded subscription is a transparent 1:1
+        pipe and is never disconnected-slow).
         """
         key = (name, sid)
         agent = self._peek_session(name, sid)
-        while True:
-            msg = await agent.outbox.get()
-            if msg.kind == "__end__":
-                # Session shut down — propagate to REPL only if we're the
-                # attached one (otherwise REPL would terminate spuriously
-                # on a detached session's shutdown).
+        sub = agent.outbox_hub.subscribe()  # maxsize=0 → unbounded local sink
+        try:
+            while True:
+                msg = await sub.get()
+                if msg is None:
+                    # Subscription force-closed (disconnect-slow). An unbounded
+                    # local sink never reaches this, but end cleanly if it ever does.
+                    return
+                if msg.kind == "__end__":
+                    # Session shut down — propagate to REPL only if we're the
+                    # attached one (otherwise REPL would terminate spuriously
+                    # on a detached session's shutdown).
+                    if key == self._attached:
+                        await self.repl_outbox.put(msg)
+                    return
+                if msg.kind == "__attach_request__":
+                    # User typed `/attach <other>` while this agent was attached.
+                    if msg.text and self.exists(msg.text):
+                        await self.attach(msg.text)
+                        # (Issue #191 re-post removed: that forwarded msg to the
+                        # Textual TUI's _on_attach_request for header refresh.
+                        # TUI deleted — re-post is dead code; _output_loop never
+                        # handled this kind, so only effect was a bare-text leak.)
+                    continue
+                if msg.kind == "__session_switch_request__":
+                    # FP-0043 Stage 4a: `/session switch <sid>` — focus another
+                    # session of the CURRENT agent (msg.text = target sid). Routed
+                    # through the forwarder (mirroring __attach_request__) so the
+                    # focus flip + display re-wire are sequenced on the registry
+                    # side, not raced by a direct call from the slash handler.
+                    # Graceful on a bad sid: drop (the slash handler validated
+                    # existence + replied before posting).
+                    if msg.text:
+                        try:
+                            await self.attach_session(name, msg.text)
+                        except KeyError:
+                            pass  # session vanished between validate + switch — no-op
+                        # (re-post removed: was for Textual TUI header refresh —
+                        # dead code after TUI deletion; _output_loop never used it.)
+                    continue
                 if key == self._attached:
                     await self.repl_outbox.put(msg)
-                return
-            if msg.kind == "__attach_request__":
-                # User typed `/attach <other>` while this agent was attached.
-                if msg.text and self.exists(msg.text):
-                    await self.attach(msg.text)
-                    # (Issue #191 re-post removed: that forwarded msg to the
-                    # Textual TUI's _on_attach_request for header refresh.
-                    # TUI deleted — re-post is dead code; _output_loop never
-                    # handled this kind, so only effect was a bare-text leak.)
-                continue
-            if msg.kind == "__session_switch_request__":
-                # FP-0043 Stage 4a: `/session switch <sid>` — focus another session
-                # of the CURRENT agent (msg.text = target sid). Routed through the
-                # forwarder (mirroring __attach_request__) so the focus flip +
-                # display re-wire are sequenced on the registry side, not raced by a
-                # direct call from the slash handler. Graceful on a bad sid: drop
-                # (the slash handler validated existence + replied before posting).
-                if msg.text:
-                    try:
-                        await self.attach_session(name, msg.text)
-                    except KeyError:
-                        pass  # session vanished between validate + switch — no-op
-                    # (re-post removed: was for Textual TUI header refresh — dead
-                    # code after TUI deletion; _output_loop never consumed it.)
-                continue
-            if key == self._attached:
-                await self.repl_outbox.put(msg)
-            # else: drop — session is detached, transient kinds were already
-            # dropped at source, durable narration is in history.jsonl
+                # else: drop — session is detached, transient kinds were already
+                # dropped at source, durable narration is in history.jsonl
+        finally:
+            sub.close()
 
     def detach(self) -> None:
         """Mark the attached session as detached without stopping its task."""

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -58,6 +58,7 @@ from reyn.runtime.limits.limit_handler import (
     reset_run_extensions,
 )
 from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.outbox_hub import OutboxHub
 from reyn.runtime.pending_op_view import PendingOpView
 from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
 from reyn.runtime.services import (
@@ -1420,6 +1421,13 @@ class Session:
         self.history: list[ChatMessage] = []
         self.inbox: asyncio.Queue = asyncio.Queue()
         self.outbox: asyncio.Queue = asyncio.Queue()
+        # ADR-0039 P6b: the outbox is single-consumer (asyncio.Queue hands each
+        # item to exactly ONE getter). The hub is the SOLE ``outbox.get()``
+        # consumer and fans every message out to N per-surface subscriptions, so
+        # the local REPL forwarder and each AG-UI surface receive the FULL stream
+        # instead of stealing frames from one another. Drain starts lazily on the
+        # first ``subscribe`` (no running loop needed here at construction).
+        self.outbox_hub = OutboxHub(self.outbox, name=self.agent_name)
         # #2103 S1bc-exec: sid → original-task record for sessions THIS session spawned.
         # When a spawned session's result routes back, the result header renders
         # ``task=<the spawner's OWN request>`` from THIS trusted record (keyed by the

--- a/tests/test_attach_request_forwarded.py
+++ b/tests/test_attach_request_forwarded.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.outbox_hub import OutboxHub
 
 
 class _FakeInterventions:
@@ -32,6 +33,11 @@ class _FakeSession:
 
     def __init__(self) -> None:
         self.outbox: asyncio.Queue = asyncio.Queue()
+        # ADR-0039 P6b: the forwarder subscribes to the session's outbox hub
+        # (the sole outbox.get() consumer) rather than draining outbox directly.
+        # A real OutboxHub over this fake's real outbox preserves the test's
+        # producer→forwarder path (no mock).
+        self.outbox_hub = OutboxHub(self.outbox)
         self.is_attached: bool = False
         self._interventions = _FakeInterventions()
 

--- a/tests/test_outbox_hub_broadcast.py
+++ b/tests/test_outbox_hub_broadcast.py
@@ -1,0 +1,164 @@
+"""Tier 2: OutboxHub is a single-drain broadcast fan-out (ADR-0039 P6b).
+
+``session.outbox`` is a single-consumer ``asyncio.Queue`` — each ``.get()`` hands
+an item to exactly ONE getter, so two direct drainers (the local forwarder + an
+AG-UI surface, or two AG-UI surfaces) *steal* frames from each other. The hub is
+the sole ``.get()`` consumer and fans every message out to N per-surface
+subscriptions. Two invariants, both proven here with real instances (a real
+``asyncio.Queue`` source, a real ``OutboxHub``, real ``OutboxMessage``s — no
+mocks):
+
+1. **N>=2 (new capability):** two surfaces each receive the FULL stream in order.
+   The strip (revert to per-connection ``source.get()``) splits it ~K/2 — proven
+   directly by ``test_two_direct_getters_steal_*`` establishing the hazard the hub
+   removes.
+2. **N=1 (non-regression):** the hub is a transparent 1:1 pipe — delivery is
+   byte-identical to a direct drain of the same script, so the pre-hub local path
+   is preserved.
+
+Plus the slow-surface policy: a bounded surface that stops draining is
+disconnect-slow'd (its ``get()`` returns ``None``) while the writer never blocks
+and other surfaces still receive the full stream.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.outbox_hub import OutboxHub
+
+_K = 20
+
+
+def _script(k: int = _K) -> list[OutboxMessage]:
+    return [OutboxMessage(kind="agent", text=str(i)) for i in range(k)]
+
+
+async def _drain(sub) -> list[str]:
+    """Drain a hub subscription to its terminal (``__end__`` or disconnect)."""
+    got: list[str] = []
+    while True:
+        msg = await asyncio.wait_for(sub.get(), timeout=2.0)
+        if msg is None or msg.kind == "__end__":
+            return got
+        got.append(msg.text)
+
+
+@pytest.mark.asyncio
+async def test_two_surfaces_each_receive_full_stream_in_order() -> None:
+    """Tier 2: N>=2 — two hub surfaces BOTH receive every frame in order (no steal)."""
+    source: asyncio.Queue = asyncio.Queue()
+    hub = OutboxHub(source)
+    a = hub.subscribe()
+    b = hub.subscribe()
+    for msg in _script():
+        source.put_nowait(msg)
+    source.put_nowait(OutboxMessage(kind="__end__", text=""))
+
+    got_a, got_b = await asyncio.gather(_drain(a), _drain(b))
+
+    expected = [str(i) for i in range(_K)]
+    assert got_a == expected
+    assert got_b == expected
+
+
+@pytest.mark.asyncio
+async def test_two_direct_getters_steal_the_stream() -> None:
+    """Tier 2: the hazard the hub removes — two DIRECT ``source.get()`` drainers
+    (the pre-hub per-connection drain) split the stream, neither sees it whole.
+
+    This is the strip-falsify baseline made explicit: the hub's fan-out is what
+    turns this ~K/2 split into two full streams (the test above)."""
+    source: asyncio.Queue = asyncio.Queue()
+    for msg in _script():
+        source.put_nowait(msg)
+
+    async def direct_drain() -> list[str]:
+        got: list[str] = []
+        for _ in range(_K):  # bounded so the losers of the race don't hang
+            try:
+                msg = await asyncio.wait_for(source.get(), timeout=0.2)
+            except asyncio.TimeoutError:
+                break
+            got.append(msg.text)
+        return got
+
+    got_a, got_b = await asyncio.gather(direct_drain(), direct_drain())
+
+    # Each item went to exactly ONE getter: a disjoint partition whose union is
+    # the whole stream — so the two surfaces canNOT BOTH see it whole (the exact
+    # negation of the hub invariant proven in the N>=2 test above).
+    whole = [str(i) for i in range(_K)]
+    assert set(got_a + got_b) == set(whole)
+    assert set(got_a).isdisjoint(got_b)
+    assert not (got_a == whole and got_b == whole)
+
+
+@pytest.mark.asyncio
+async def test_single_surface_is_transparent_pipe() -> None:
+    """Tier 2: N=1 non-regression — the hub delivers exactly the source sequence,
+    byte-identical to a direct drain of the same script (pre-hub path preserved)."""
+    script = _script()
+
+    # Direct-drain baseline (the pre-hub path): one getter, the whole script.
+    direct_source: asyncio.Queue = asyncio.Queue()
+    for msg in script:
+        direct_source.put_nowait(msg)
+    direct_source.put_nowait(OutboxMessage(kind="__end__", text=""))
+    baseline: list[str] = []
+    while True:
+        msg = await asyncio.wait_for(direct_source.get(), timeout=2.0)
+        if msg.kind == "__end__":
+            break
+        baseline.append(msg.text)
+
+    # Same script through the hub at N=1.
+    hub_source: asyncio.Queue = asyncio.Queue()
+    hub = OutboxHub(hub_source)
+    sub = hub.subscribe()
+    for msg in script:
+        hub_source.put_nowait(msg)
+    hub_source.put_nowait(OutboxMessage(kind="__end__", text=""))
+    via_hub = await _drain(sub)
+
+    assert via_hub == baseline
+    assert baseline == [str(i) for i in range(_K)]  # sanity: non-trivial script
+
+
+@pytest.mark.asyncio
+async def test_slow_surface_disconnected_without_blocking_the_writer() -> None:
+    """Tier 2: a bounded surface that stops draining is disconnect-slow'd (its
+    ``get()`` returns ``None``) while a fast surface still receives the FULL
+    stream and the source fully drains — the writer is never blocked."""
+    source: asyncio.Queue = asyncio.Queue()
+    hub = OutboxHub(source)
+    fast = hub.subscribe()  # unbounded
+    slow = hub.subscribe(maxsize=2)  # tiny cap, never drained → disconnect-slow
+    k = 50
+    for i in range(k):
+        source.put_nowait(OutboxMessage(kind="agent", text=str(i)))
+    source.put_nowait(OutboxMessage(kind="__end__", text=""))
+
+    # Fast surface receives everything — proves the drain was never blocked by
+    # the stuck slow surface (if it had blocked, fast would hang / be short).
+    got_fast = await _drain(fast)
+    assert got_fast == [str(i) for i in range(k)]
+
+    # Slow surface was force-closed: its next read is the None disconnect signal.
+    assert await asyncio.wait_for(slow.get(), timeout=2.0) is None
+
+
+@pytest.mark.asyncio
+async def test_end_terminal_fans_out_to_all_surfaces() -> None:
+    """Tier 2: ``__end__`` reaches every attached surface (terminal fan-out)."""
+    source: asyncio.Queue = asyncio.Queue()
+    hub = OutboxHub(source)
+    subs = [hub.subscribe() for _ in range(3)]
+    source.put_nowait(OutboxMessage(kind="agent", text="only"))
+    source.put_nowait(OutboxMessage(kind="__end__", text=""))
+
+    results = await asyncio.gather(*(_drain(s) for s in subs))
+    for got in results:
+        assert got == ["only"]


### PR DESCRIPTION
**[per-PR-coder]** — Sub-PR 1 of 2-3 for **P6b ws-consolidation** (ADR-0039 final phase). `part of #2805`. This is the **load-bearing** hub; browser migration + delete + vocabulary land in the next sub-PR(s) after this co-vets.

## The bug (primary, verified)
`session.outbox` is a single-consumer `asyncio.Queue` (session.py:1422) — every `.get()` hands an item to exactly ONE getter. Two paths drained it directly:
- registry `_forwarder` (registry.py:3033) → `repl_outbox` (local REPL sink)
- AG-UI `_SessionFrameSource._drain_outbox` (endpoint.py:210) — **one drain per SSE connection**

They were kept mutually exclusive (`ensure_running` starts the forwarder; `ensure_session_running` does not, letting the AG-UI caller drain) *precisely because* two concurrent getters steal frames from each other (registry.py:2890-2900 documents the hazard). P6b makes AG-UI concurrent for browser + `--connect` thin client, dissolving the mutual-exclusion — so without this fix, multi-client display silently regresses to frame-stealing.

## Design — broadcast hub owned by Session
- `src/reyn/runtime/outbox_hub.py` — `OutboxHub` is the **SOLE** `outbox.get()` consumer; one drain task fans every message out to N per-surface `HubSubscription` queues. Owned by Session (`session.outbox_hub`), drain starts lazily on first `subscribe` (no running loop needed at construction).
- The local `_forwarder` folds in as a hub subscriber (**unbounded** `maxsize=0` → byte-identical to the pre-hub direct drain). Its control-kind handling (`__attach_request__` / `__session_switch_request__`) is preserved verbatim.
- The AG-UI `_SessionFrameSource` folds in as a **bounded** subscriber (`DEFAULT_SURFACE_MAXSIZE=4096`).
- **Slow-surface policy (explicit): disconnect-slow, writer never blocks.** Fan-out is `put_nowait`; a full bounded queue → the hub clears that one queue, pushes a close sentinel (subscriber `get()` → `None`), drops it from fan-out, and logs. The single drain never awaits a full queue; other surfaces unaffected. The unbounded local sink is never disconnected.
- `__end__` fans out to all surfaces (terminal); the drain restarts on a later `subscribe` (session restart, same reused Queue).

`chainlit`/`ws.chat` keep their own per-`web:<thread>`-session direct drains (single-surface-per-session → no steal → hub stays inert for them); `ws.chat` is deleted in the next sub-PR.

## Two-invariant proof (architect-requested)
`tests/test_outbox_hub_broadcast.py` (Tier 2, real `asyncio.Queue` + real `OutboxHub` + real `OutboxMessage`, no mocks):

1. **N≥2 (new capability):** `test_two_surfaces_each_receive_full_stream_in_order` — 2 surfaces both receive all K in order. `test_two_direct_getters_steal_the_stream` establishes the negation (disjoint partition, cannot both be whole).
2. **N=1 (non-regression):** `test_single_surface_is_transparent_pipe` — hub delivery is byte-identical to a direct drain of the same script.
3. **Slow policy:** `test_slow_surface_disconnected_without_blocking_the_writer` — bounded stuck surface → `get()` returns `None`; fast surface still gets the full stream (writer never blocked).
4. `test_end_terminal_fans_out_to_all_surfaces`.

### Strip-falsify evidence (production hub reverted to per-conn direct `.get()`)
- **N≥2 → RED**: `test_two_surfaces_each_receive_full_stream_in_order` → `TimeoutError` (one surface drains all + `__end__`, the other hangs on stolen frames).
- **N=1 → GREEN (unchanged)**: `test_single_surface_is_transparent_pipe` still passes — proving reverting the hub back to direct-drain is **harmless at a single surface** (the non-regression / bit-identical direction).

Composition for local-REPL bit-identity: hub transparent at N=1 (proof #2) ∘ unchanged downstream (existing `test_transport_bit_identical.py` + `test_agui_transport_bit_identical.py` stay green) = local single-surface delivery byte-identical.

## Test plan
- [x] N≥2 invariant: both surfaces full stream in order
- [x] N≥2 strip → RED (per-conn direct `.get()` → one surface hangs; captured)
- [x] N=1 non-regression: hub == direct drain byte-identical
- [x] N=1 strip other direction → still GREEN (hub harmless at single surface)
- [x] single AG-UI surface unchanged (`test_agui_transport_bit_identical.py` green)
- [x] local REPL bit-identical (`test_transport_bit_identical.py` green + hub-transparency composition)
- [x] slow surface disconnect-slow, writer never blocks
- [x] `__attach_request__` control path preserved (`test_attach_request_forwarded.py` green after `_FakeSession` gains a real `OutboxHub`)
- [x] 4 CI gates local: ruff (`src tests`) clean; tier audit `--strict` (7 tests OK); module-docstrings OK; full `pytest` = 8237 passed, 21 skipped
- [x] Baseline: the only failures (5) are the pre-existing `tests/web/` route-mount/plugin + `test_fp0001_routes_mounted` — verified reproduce **identically** on pristine `origin/main`; **zero new** failures from this PR

## Files
- `src/reyn/runtime/outbox_hub.py` (new) — `OutboxHub` + `HubSubscription`
- `src/reyn/runtime/session.py` — construct `self.outbox_hub`
- `src/reyn/runtime/registry.py` — `_forwarder` subscribes to the hub (unbounded), try/finally close
- `src/reyn/interfaces/transport/agui/endpoint.py` — `_SessionFrameSource` subscribes to the hub (bounded)
- `tests/test_outbox_hub_broadcast.py` (new), `tests/test_attach_request_forwarded.py` (fake gains real hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)