### PR TITLE
feat: stdio MCP server sandbox policy defaults to allow-subprocess (operator-owned) (part of #2820)

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -733,6 +733,8 @@ mcp:
 | `command` | string | stdio | 起動する実行ファイル。 |
 | `args` | list[string] | stdio（任意） | `command` に渡す引数ベクター。 |
 | `env` | map[string,string] | stdio（任意） | 起動プロセスへの追加環境変数。値は `${VAR}` 展開に対応。 |
+| `network` | bool | stdio（任意） | サンドボックス化されたサーバーがネットワークを使用できるか。`sandboxed_exec` と同じ single-source デフォルトに従う。ネットワークに到達すべきでないサーバーを隔離するには `false`。オペレーター所有 — モデルは設定不可。 |
+| `subprocess` | bool | stdio（任意） | サンドボックス化されたサーバーが子プロセスを spawn（fork）できるか。デフォルト `true` — ほとんどの stdio サーバーは fork ベースの launcher（`npx` → node、`uvx` → tool）で起動し、起動に fork を要する。真に fork 不要なサーバーを hardening するには `false`。オペレーター所有 — モデルは設定不可。 |
 | `url` | string | http, sse | エンドポイント URL。 |
 | `headers` | map[string,string] | http, sse（任意） | 静的リクエストヘッダー。値は `${VAR}` 展開に対応。 |
 | `call_timeout_seconds` | float | すべて（任意） | MCP SDK の `read_timeout_seconds` に渡される per-call リクエストタイムアウト。 未設定の場合は SDK デフォルトが適用される（= Reyn 側で override しない、 transport-specific の SDK timeout が支配）。 特定 server が遅いと分かっている場合、 あるいは速い + fail-fast したい場合に設定する。 `timeout` (= `type: http` の HTTP transport connect timeout) とは独立。 |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1202,6 +1202,8 @@ mcp:
 | `command` | string | stdio | Executable to spawn. |
 | `args` | list[string] | stdio (optional) | Argument vector passed to `command`. |
 | `env` | map[string,string] | stdio (optional) | Extra environment variables for the spawned process. Values support `${VAR}` expansion. |
+| `network` | bool | stdio (optional) | Whether the sandboxed server may use the network. Defaults to the same single-source default as `sandboxed_exec`. Set `false` to isolate a server that should never reach the network. Operator-owned — the model cannot set it. |
+| `subprocess` | bool | stdio (optional) | Whether the sandboxed server may spawn child processes (fork). Defaults to `true` — most stdio servers launch via a fork-based launcher (`npx` → node, `uvx` → the tool) and must fork to start. Set `false` to harden a genuinely fork-free server. Operator-owned — the model cannot set it. |
 | `url` | string | http, sse | Endpoint URL. |
 | `headers` | map[string,string] | http, sse (optional) | Static request headers. Values support `${VAR}` expansion. |
 | `call_timeout_seconds` | float | all (optional) | Per-call request timeout passed to the MCP SDK's `read_timeout_seconds`. Unset → SDK default applies (= no Reyn-level override; the SDK's transport-specific timeout governs). Set when a specific server is known to be slow or known to be quick + you want `fail-fast`. Independent of `timeout` (which is the HTTP transport's connect timeout for `type: http`). |

--- a/src/reyn/mcp/client.py
+++ b/src/reyn/mcp/client.py
@@ -1012,6 +1012,22 @@ class MCPClient:
         operator-ownership (the policy is the operator's, not the LLM's — the LLM
         cannot set it), not default-off; an operator who wants an isolated server
         sets ``network: false`` (see the migration hint surfaced on init failure).
+
+        ``subprocess`` is likewise OPERATOR-declared per server (``subprocess:
+        false`` to harden) and defaults to ``True`` (#2820 part C). A stdio MCP
+        server is, in the overwhelming common case, launched via a fork-based
+        launcher (``npx`` → node, ``uvx`` → the tool, a ``python`` wrapper) — it
+        forks to exist. The pre-#2820 default of ``False`` (SandboxPolicy's own
+        default, since this builder never set the field) emitted ``(deny
+        process-fork)`` and so silently killed the very launch it was wrapping,
+        with an opaque ``fork: Operation not permitted`` — the same launcher-fork
+        denial class as #2820. ``False`` here hardened nothing (the server never
+        started); it only hid the knob behind an unexplained failure. Default
+        ``True`` is the honest default per the operator-customizability posture;
+        the remaining boundaries (network gate, write scoping, read deny-list)
+        still bound the server and its children. An operator who runs a
+        genuinely fork-free server sets ``subprocess: false`` to harden it —
+        same operator-ownership model as ``network``.
         """
         from reyn.security.sandbox import SandboxPolicy
         from reyn.security.sandbox.policy import DEFAULT_SANDBOX_NETWORK
@@ -1019,6 +1035,7 @@ class MCPClient:
         cwd = self._config.get("cwd") or os.getcwd()
         return SandboxPolicy(
             network=bool(self._config.get("network", DEFAULT_SANDBOX_NETWORK)),
+            allow_subprocess=bool(self._config.get("subprocess", True)),
             write_paths=[cwd],
         )
 

--- a/tests/test_mcp_client_sandbox_wrap.py
+++ b/tests/test_mcp_client_sandbox_wrap.py
@@ -94,6 +94,45 @@ def test_seatbelt_wrap_network_opt_out(monkeypatch):
     client.close_stderr_capture()
 
 
+def test_seatbelt_wrap_subprocess_default_allows_fork(monkeypatch):
+    """Tier 2: #2820-C — with no `subprocess` override a stdio MCP server defaults
+    to allow-subprocess, so the Seatbelt profile grants `(allow process-fork)`. A
+    fork-based launcher (npx/uvx/python) is the common case and must be able to
+    fork to exist. FAILS on the pre-#2820 default (SandboxPolicy default False →
+    (deny process-fork), which silently killed the launch)."""
+    _patch_backend(monkeypatch, SeatbeltBackend())
+    client = _stdio_client()  # no `subprocess` key
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert "(allow process-fork)" in profile
+    assert "(deny process-fork)" not in profile
+    client.close_stderr_capture()
+
+
+def test_seatbelt_wrap_subprocess_opt_out_denies_fork(monkeypatch):
+    """Tier 2: #2820-C — an operator-declared `subprocess: false` HARDENS the
+    server: the profile emits `(deny process-fork)` (the opt-OUT knob, for a
+    genuinely fork-free server). Operator-owned, same model as `network`."""
+    _patch_backend(monkeypatch, SeatbeltBackend())
+    client = _stdio_client(subprocess=False)
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert "(deny process-fork)" in profile
+    assert "(allow process-fork)" not in profile
+    client.close_stderr_capture()
+
+
+def test_seatbelt_wrap_subprocess_opt_in_explicit(monkeypatch):
+    """Tier 2: #2820-C — an explicit `subprocess: true` is honored (allow fork),
+    same observable outcome as the default but operator-pinned."""
+    _patch_backend(monkeypatch, SeatbeltBackend())
+    client = _stdio_client(subprocess=True)
+    _cmd, args = client._sandbox_wrap_stdio("my-mcp", [])
+    profile = Path(args[1]).read_text()
+    assert "(allow process-fork)" in profile
+    client.close_stderr_capture()
+
+
 def test_landlock_wrap_uses_reexec_shim(monkeypatch):
     """Tier 2: under Landlock (#1344 follow-up E), wrap_command wraps the command
     as the reyn.security.sandbox.landlock_exec re-exec shim (python -m ... --policy


### PR DESCRIPTION
**[tui-coder]** — part of #2820 (PR3 = part C: MCP stdio policy-fit). Follows merged #2821 (part B) and #2822 (part A).

## What
Fixes the policy-fit for the stdio MCP server workload class: `_build_mcp_sandbox_policy` never set `allow_subprocess`, so it took `SandboxPolicy`'s default `False` and wrapped every stdio server with `(deny process-fork)`.

## Why
A stdio MCP server is, in the common case, launched by a **fork-based launcher** (`npx` → node, `uvx` → the tool, a `python` wrapper) — it forks to exist. So the pre-#2820 default of `False` **silently killed the very launch it was wrapping**, with the same opaque `fork: Operation not permitted` as the #2820 incident. `False` hardened nothing (the server never started) — it only hid the knob behind an unexplained failure.

## How (operator-customizability posture — don't hide the knob)
- add a per-server **`subprocess:`** key (operator-declared, exactly like `network:`; the **LLM cannot set it**), defaulting to **`True`**.
- the remaining boundaries still bound the server and its children: **network gate**, **write scoping** (server cwd), **read deny-list** — none are touched.
- an operator running a genuinely fork-free server sets `subprocess: false` to harden it — same operator-ownership model as `network`.
- documents both `network:` and `subprocess:` per-server sandbox keys in the reyn-yaml MCP-servers reference (they were previously undocumented).

## Review focus (per @lead-coder)
1. **Boundary not weakened**: the only policy change is adding `allow_subprocess=bool(self._config.get("subprocess", True))`. `network`, `write_paths`, and the read deny-list are unchanged — the SBPL profile gains `(allow process-fork)` and nothing else. Pinned by `test_seatbelt_wrap_subprocess_default_allows_fork` (asserts `(allow process-fork)` present, and nothing about network changes) and the retained network tests.
2. **Default True, per-site rationale**: operator-declared, LLM-untouchable; `True` is the honest default because a fork-denied stdio server never starts (see the docstring). Opt-out via `subprocess: false` is pinned by `test_seatbelt_wrap_subprocess_opt_out_denies_fork` (`(deny process-fork)`).
3. **Key-unset behavior**: default `True` → existing stdio MCP servers launch; an operator can still explicitly harden with `subprocess: false`.

## Per-site audit (parity discipline — validated per-site, not derived from a proxy set)
All `SandboxPolicy` construction sites were enumerated. `skill_install` (git clone) already correctly sets `allow_subprocess=True`. `hooks/shell_runner.py` defaults `False` and is **flagged as a separate per-site judgment** (a hook shell's fork need depends on the operator's command) — **not** bulk-changed under this rule; recorded as a tracked candidate. Part C changes **only** the MCP stdio class.

## Test plan
- [x] `pytest tests/test_mcp_client_sandbox_wrap.py` — 11 Tier 2 (3 new: default-allows-fork, opt-out-denies-fork, explicit-opt-in), asserting on the observable SBPL wrap output (no mock; real SeatbeltBackend)
- [x] `ruff check` (changed) — clean
- [x] `test_tier_audit.py --strict` — 11 OK, 0 Tier-4
- [x] `verify_module_docstrings.py` (changed src) — clean
- [x] full `pytest` — 8253 passed; the same 9 pre-existing LLM-router/compaction failures (CI-green, local-only full-suite pollution, pass in isolation). No new failures from this diff.

Tier self-check: Tier 2, assert on observable wrap output (the SBPL profile text), no private-state / format-pin / mock.

asdf/mise argv0 resolution + a bounded-read DoS hardening are tracked follow-ups on #2820 (from part A's co-vet).
