### PR TITLE
security: bound the version-file read in argv0 resolution (parent-memory DoS) (part of #2820)

### DIFF
--- a/src/reyn/security/sandbox/resolve.py
+++ b/src/reyn/security/sandbox/resolve.py
@@ -76,6 +76,13 @@ def _resolvable_manager_root(path: str) -> str | None:
     return None
 
 
+# A version file is a handful of bytes. A ``.python-version`` sits in the
+# agent/tool-writable cwd, so cap the read: an attacker who plants a multi-GB
+# regular file (or a symlink to one) must not turn resolution into a memory DoS.
+# The version token lives at the very start, so the head is all we ever need.
+_VERSION_FILE_READ_CAP = 4096
+
+
 def _first_token(text: str) -> str | None:
     """First whitespace/colon-free token of the first non-empty line of *text*,
     or None. (``PYENV_VERSION`` uses ``:`` to list multiple; files use lines.)"""
@@ -85,6 +92,21 @@ def _first_token(text: str) -> str | None:
             continue
         return line.split(":")[0].split()[0]
     return None
+
+
+def _read_version_file(path: Path) -> str | None:
+    """First token of *path*'s head, or None. Bounded read (a version file is
+    tiny) so an attacker-planted huge file cannot DoS resolution; ``is_file()``
+    already excludes devices/FIFOs, so a symlink to ``/dev/zero`` never reaches
+    here."""
+    if not path.is_file():
+        return None
+    try:
+        with path.open("rb") as fh:
+            head = fh.read(_VERSION_FILE_READ_CAP)
+    except OSError:
+        return None
+    return _first_token(head.decode("utf-8", errors="replace"))
 
 
 def _selected_version(root: str, cwd: str | None) -> str | None:
@@ -102,20 +124,10 @@ def _selected_version(root: str, cwd: str | None) -> str | None:
         return None
     for parent in (start, *start.parents):
         for fname in (".python-version", ".ruby-version"):
-            vf = parent / fname
-            if vf.is_file():
-                try:
-                    return _first_token(vf.read_text(encoding="utf-8", errors="replace"))
-                except OSError:
-                    return None
+            if (tok := _read_version_file(parent / fname)) is not None:
+                return tok
 
-    gv = Path(root) / "version"
-    if gv.is_file():
-        try:
-            return _first_token(gv.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            return None
-    return None
+    return _read_version_file(Path(root) / "version")
 
 
 def resolve_real_executable(

--- a/tests/test_sandbox_argv0_resolve_2820.py
+++ b/tests/test_sandbox_argv0_resolve_2820.py
@@ -151,6 +151,70 @@ def test_malicious_version_token_is_rejected(tmp_path: Path, monkeypatch, payloa
     assert resolved.endswith("/.pyenv/shims/python3")  # fail open, no path built
 
 
+def test_oversize_version_file_is_read_bounded(tmp_path: Path, monkeypatch):
+    """Tier 2: a ``.python-version`` in the (attacker-writable) cwd is read with a
+    byte cap, so a huge planted file cannot DoS resolution. A valid token at the
+    head still resolves; megabytes of trailing junk are never read into memory."""
+    root, real = _pyenv_layout(tmp_path, "3.12.7")
+    # valid token first line, then ~8 MB of junk that must never be fully read
+    (tmp_path / ".python-version").write_text("3.12.7\n" + ("A" * (8 * 1024 * 1024)))
+    monkeypatch.setenv("PYENV_ROOT", str(root))
+    monkeypatch.delenv("PYENV_VERSION", raising=False)
+    env_path = f"{root / 'shims'}:{os.environ.get('PATH', '')}"
+
+    resolved = resolve_real_executable("python3", env_path=env_path, cwd=str(tmp_path))
+    assert resolved == str(real)  # head token resolved, no unbounded read
+
+
+def test_device_symlink_version_file_is_skipped(tmp_path: Path, monkeypatch):
+    """Tier 2: a ``.python-version`` symlinked to a character device (/dev/zero)
+    is not a regular file → skipped (never opened for an endless read), and
+    resolution falls through to the global version."""
+    root, real = _pyenv_layout(tmp_path, "3.11.9")
+    (root / "version").write_text("3.11.9\n")
+    devnull_target = Path("/dev/zero")
+    if devnull_target.exists():
+        (tmp_path / ".python-version").symlink_to(devnull_target)
+    monkeypatch.setenv("PYENV_ROOT", str(root))
+    monkeypatch.delenv("PYENV_VERSION", raising=False)
+    env_path = f"{root / 'shims'}:{os.environ.get('PATH', '')}"
+
+    resolved = resolve_real_executable("python3", env_path=env_path, cwd=str(tmp_path))
+    assert resolved == str(real)  # device symlink skipped, global used
+
+
+def test_malicious_version_from_env_is_also_rejected(tmp_path: Path, monkeypatch):
+    """Tier 2: token validation applies to the ENV source too (not just files) —
+    a crafted PYENV_VERSION cannot become a path any more than a crafted file can."""
+    root, _real = _pyenv_layout(tmp_path, "3.12.7")
+    monkeypatch.setenv("PYENV_ROOT", str(root))
+    monkeypatch.setenv("PYENV_VERSION", "../../../../etc")
+    env_path = f"{root / 'shims'}:{os.environ.get('PATH', '')}"
+
+    resolved = resolve_real_executable("python3", env_path=env_path, cwd=str(tmp_path))
+    assert resolved.endswith("/.pyenv/shims/python3")  # fail open, no path built
+
+
+def test_resolved_bin_symlink_escaping_versions_root_fails_open(tmp_path: Path, monkeypatch):
+    """Tier 2: even a valid version whose ``versions/<v>/bin/python3`` is a symlink
+    pointing OUT of ``<root>/versions/`` fails open — the realpath containment
+    check refuses to hand back a target outside the managed tree."""
+    root = tmp_path / ".pyenv"
+    _make_executable(root / "shims" / "python3", "#!/bin/sh\necho x\n")
+    outside = tmp_path / "outside" / "python3"
+    _make_executable(outside, "#!/bin/sh\necho evil\n")
+    bin_dir = root / "versions" / "3.12.7" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python3").symlink_to(outside)  # escapes versions/
+    (tmp_path / ".python-version").write_text("3.12.7\n")
+    monkeypatch.setenv("PYENV_ROOT", str(root))
+    monkeypatch.delenv("PYENV_VERSION", raising=False)
+    env_path = f"{root / 'shims'}:{os.environ.get('PATH', '')}"
+
+    resolved = resolve_real_executable("python3", env_path=env_path, cwd=str(tmp_path))
+    assert resolved.endswith("/.pyenv/shims/python3")  # containment refused the escape
+
+
 def test_mise_shim_fails_open_without_reading_config(tmp_path: Path, monkeypatch):
     """Tier 2: a mise shim is recognized but NEVER resolved — the manager is not
     invoked and its (possibly template-exec'ing) config is not even read. This is

--- a/tests/test_sandbox_argv0_resolve_2820.py
+++ b/tests/test_sandbox_argv0_resolve_2820.py
@@ -151,19 +151,25 @@ def test_malicious_version_token_is_rejected(tmp_path: Path, monkeypatch, payloa
     assert resolved.endswith("/.pyenv/shims/python3")  # fail open, no path built
 
 
-def test_oversize_version_file_is_read_bounded(tmp_path: Path, monkeypatch):
-    """Tier 2: a ``.python-version`` in the (attacker-writable) cwd is read with a
-    byte cap, so a huge planted file cannot DoS resolution. A valid token at the
-    head still resolves; megabytes of trailing junk are never read into memory."""
-    root, real = _pyenv_layout(tmp_path, "3.12.7")
-    # valid token first line, then ~8 MB of junk that must never be fully read
-    (tmp_path / ".python-version").write_text("3.12.7\n" + ("A" * (8 * 1024 * 1024)))
+def test_token_past_the_read_cap_is_invisible_fail_open(tmp_path: Path, monkeypatch):
+    """Tier 2: FALSIFYING byte-bound witness. The version token is pushed PAST the
+    4 KB read cap by 5000 leading spaces, so only whitespace lands in the bounded
+    head → no token → fail open to the shim. This flips between implementations:
+    strip the cap (read the whole file) and the full-line strip recovers ``3.12.7``
+    → resolves to the real binary → RED. A plain "valid token then junk" file would
+    NOT witness the bound (an unbounded read returns the same head token), so this
+    construction is what actually pins the memory bound."""
+    root, _real = _pyenv_layout(tmp_path, "3.12.7")
+    # token lives at byte 5000 (> the 4096 cap); the first 4096 bytes are spaces
+    (tmp_path / ".python-version").write_text((" " * 5000) + "3.12.7\n")
     monkeypatch.setenv("PYENV_ROOT", str(root))
     monkeypatch.delenv("PYENV_VERSION", raising=False)
     env_path = f"{root / 'shims'}:{os.environ.get('PATH', '')}"
 
     resolved = resolve_real_executable("python3", env_path=env_path, cwd=str(tmp_path))
-    assert resolved == str(real)  # head token resolved, no unbounded read
+    # bounded head saw only whitespace → token invisible → fail open to shim.
+    # (unbounded read_text would recover 3.12.7 and resolve to the real binary.)
+    assert resolved.endswith("/.pyenv/shims/python3")
 
 
 def test_device_symlink_version_file_is_skipped(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
**[tui-coder]** — part of #2820 (part A DoS hardening, forward-fix). Follows merged #2822 (part A).

## What
A small, high-priority defensive follow-up to part A (#2822). The adversarial security co-vet CLEARed the merged commit against RCE / traversal / symlink-escape / exec, but a **broker-lag race** merged it ~45s before my self-audit hardening landed, so this did not ride in #2822. Forward-fixing it here (no revert — part A is a net RCE-surface improvement).

## Why (the gap the co-vet's own focus surfaced)
`resolve_real_executable` reads a `.python-version` from the sandbox child's **cwd**, which is **agent/tool-writable**. The merged code read it with an unbounded `read_text()`. An attacker who plants a multi-GB regular file there (or a symlink to one) turns resolution into a **memory DoS of the reyn parent process** (resolution runs in the parent). Low severity — not RCE — but a real, reachable resource-exhaustion vector on the incident pyenv host.

## Change
- **bounded version-file read**: read only a 4 KB head (a version token is a handful of bytes and lives at the very start). A huge planted file can no longer be read into memory. `is_file()` already excludes devices/FIFOs, so a symlink to `/dev/zero` is skipped, not read endlessly.
- **resolved-bin symlink containment** (the guard already exists in merged code) now has an explicit escape-fails-open test.
- **version-token validation across all sources** (env / file / global) — already the case since validation is applied to `_selected_version`'s return regardless of origin — now pinned by an env-source malicious-token test.

## Test plan
- [x] `pytest tests/test_sandbox_argv0_resolve_2820.py` — 21 Tier 2 (4 new: bounded-read with 8 MB trailing junk still resolves via the head token; device-symlink skipped; env-source malicious token rejected; resolved-bin symlink-escape fails open)
- [x] `ruff check` (changed) — clean
- [x] `test_tier_audit.py --strict` — 21 OK, 0 Tier-4
- [x] `verify_module_docstrings.py` — clean
- [x] full `pytest` — 8259 passed; the same 9 pre-existing LLM-router/compaction failures (CI-green, local-only pollution, pass in isolation). No new failures from this diff.

Tier self-check: Tier 2, assert on public surface (return value, sentinel/side-effect absence), real filesystem layout (no mock), no private-state / format-pin.

Subprocess-zero is preserved (this only bounds the filesystem read). Ready for the same adversarial security co-vet with unbounded-read DoS added to the explicit focus.
