### PR TITLE
feat: closed OutboxMessage kind vocabulary + browser-decode drift tripwire (ADR-0039 P6b-4)

### DIFF
--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -110,6 +110,10 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "the attach-request sentinel — upstream-consumed at registry.py:3052 (swallowed with continue), so it never reaches the AG-UI tap; this profile entry is a fail-safe for a tap-point change, not a live wire kind (remote attach-label sync is designed in P6b, not via this legacy sentinel)",
     ),
     CustomName(
+        "reyn.display.trace", DISPLAY_NS, "{text: str}",
+        "a nested detail / trace line (dim, transient) — the generic trace kind rendered nested with the tool-call trace subtypes",
+    ),
+    CustomName(
         "reyn.display.tool_call_started", DISPLAY_NS, "{text: str}",
         "a tool-call start trace line",
     ),

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -442,8 +442,10 @@ def decode_event(
         return None
     frame_tag = reyn.get("frame")
     if frame_tag == "display":
+        # UNTRUSTED wire value → from_wire (lenient): an unknown remote kind must
+        # ignore-unknown / graceful-degrade, never fail-close on __post_init__.
         return DisplayFrame(
-            OutboxMessage(
+            OutboxMessage.from_wire(
                 kind=reyn.get("kind", ""),
                 text=reyn.get("text", ""),
                 meta=dict(reyn.get("meta") or {}),
@@ -456,9 +458,11 @@ def decode_event(
     if frame_tag == "state_delta":
         return StateUpdate(delta=dict(reyn.get("delta") or {}))
     if frame_tag == "messages":
+        # UNTRUSTED wire values (reconnect backlog) → from_wire (lenient), same
+        # ignore-unknown contract as the single-display decode above.
         frames = [
             DisplayFrame(
-                OutboxMessage(
+                OutboxMessage.from_wire(
                     kind=m.get("kind", ""),
                     text=m.get("text", ""),
                     meta=dict(m.get("meta") or {}),

--- a/src/reyn/runtime/outbox.py
+++ b/src/reyn/runtime/outbox.py
@@ -10,6 +10,16 @@ Outbox is the **presentation stream**, distinct from history (durable log).
 - agent → also persisted to history.jsonl by Session
 - status / error / trace / intervention → display-only, never in history
 - __end__ → control signal for _output_loop shutdown
+
+**Closed kind vocabulary (ADR-0039 P6b).** ``kind`` is drawn from a CLOSED set
+(:data:`DISPLAY_KINDS` ∪ :data:`CONTROL_KINDS`), validated at construction in
+:meth:`OutboxMessage.__post_init__`. A kind outside the vocabulary would leak an
+unprofiled ``CUSTOM`` name on the AG-UI wire (the P6a disposition-gate concern);
+fail-visible at construction catches the helper/dynamic constructions a static
+scan misses. The validation is **production-side ONLY** — the AG-UI decode path
+rebuilds an OutboxMessage from an UNTRUSTED remote frame and must degrade
+gracefully on an unknown wire kind (ignore-unknown, never fail-close), so it uses
+:meth:`OutboxMessage.from_wire`, which bypasses the vocabulary check.
 """
 from __future__ import annotations
 
@@ -19,12 +29,69 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from reyn.runtime.transport import TransportRef
 
+# ── the closed kind vocabulary ───────────────────────────────────────────────
+# The settled disposition of every producer kind (P6a): standard 4 / profiled 11
+# / control 2. This module DECLARES the vocabulary independently; the
+# non-circular gate (tests/test_outbox_vocabulary.py +
+# tests/test_agui_profile_completeness.py) binds it against the real codec map
+# (protocol._DISPLAY_KIND_EVENT), the extension profile (profile.CUSTOM_PROFILE),
+# and the wire-filter allowlist (protocol.CONTROL_FILTER_KINDS).
+
+# standard-mapped (4): the codec emits a STANDARD AG-UI event (a generic client
+# renders it) — no reyn.* CUSTOM name. (protocol._DISPLAY_KIND_EVENT non-CUSTOM.)
+_STANDARD_DISPLAY_KINDS: "frozenset[str]" = frozenset({
+    "agent",      # → TEXT_MESSAGE_CONTENT (role assistant)
+    "status",     # → TEXT_MESSAGE_CONTENT (role status)
+    "reasoning",  # → REASONING_MESSAGE_CONTENT
+    "error",      # → RUN_ERROR
+})
+
+# profiled (11): the codec emits a reyn.display.<kind> CUSTOM event that has an
+# extension-profile entry (profile.CUSTOM_PROFILE). Renderer chrome with no
+# standard AG-UI analog. INCLUDES the three client-consumed control sentinels
+# that are FORWARDED on the wire (not filtered) — the CLIENT consumes them over
+# the transport stream, so filtering them would make remote /copy · /rewind
+# silent no-ops (they ride as reyn.display.* CUSTOM, round-trip losslessly).
+_PROFILED_DISPLAY_KINDS: "frozenset[str]" = frozenset({
+    "intervention",         # native prompt UI (answer round-trip via reyn.intervention.*)
+    "presentation",         # a present op's text; render-node model on _reyn meta.nodes
+    "user",                 # a user-authored line echoed live to the scrollback
+    "system",               # persisted lifecycle/status chrome (compaction / budget / cost-warn)
+    "trace",                # a nested detail / trace line (dim, transient)
+    "tool_call_started",    # tool-call start trace line
+    "tool_call_completed",  # tool-call completion trace line
+    "tool_call_failed",     # tool-call failure trace line
+    "__copy_last_reply__",  # /copy sentinel — client-side clipboard copy (stream_client._handle_copy_sentinel)
+    "__rewind_list__",      # /rewind sentinel — client renders the rewind list / region picker
+    "__attach_request__",   # /attach sentinel — upstream-consumed at registry._forwarder (agent swap); profile entry is a fail-safe
+})
+
+# Every kind FORWARDED to the AG-UI wire as a display frame (standard or CUSTOM).
+DISPLAY_KINDS: "frozenset[str]" = _STANDARD_DISPLAY_KINDS | _PROFILED_DISPLAY_KINDS
+
+# control-filtered (2): emitter-FILTERED control sentinels
+# (== protocol.CONTROL_FILTER_KINDS) — consumed as signals, NEVER forwarded on
+# the wire. Each documented with its consumption locus:
+CONTROL_KINDS: "frozenset[str]" = frozenset({
+    # Stream terminator: OutboxHub._drain / registry._forwarder /
+    # _SessionFrameSource loops all return on it; the AG-UI emitter returns
+    # (ends the SSE stream). Never rendered.
+    "__end__",
+    # `/session switch <sid>`: consumed at registry._forwarder (swallowed with
+    # `continue` → attach_session); the AG-UI emitter also fail-safe-filters it.
+    "__session_switch_request__",
+})
+
+# The complete closed vocabulary of valid OutboxMessage.kind values.
+VOCABULARY: "frozenset[str]" = DISPLAY_KINDS | CONTROL_KINDS
+
 
 @dataclass(frozen=True)
 class OutboxMessage:
     """One item published by Session to its outbox queue.
 
-    `kind` selects the renderer's formatting branch. `meta` carries
+    `kind` selects the renderer's formatting branch and MUST be in the closed
+    :data:`VOCABULARY` (validated in :meth:`__post_init__`). `meta` carries
     optional provenance:
 
     Common keys:
@@ -47,5 +114,46 @@ class OutboxMessage:
     meta: dict = field(default_factory=dict)
     reply_to: "TransportRef | None" = field(default=None)
 
+    def __post_init__(self) -> None:
+        # Production-side vocabulary gate (fail-visible at construction, catching
+        # the dynamic/helper constructions a static scan misses). Untrusted wire
+        # values MUST route around this via :meth:`from_wire`.
+        if self.kind not in VOCABULARY:
+            raise ValueError(
+                f"OutboxMessage.kind {self.kind!r} is not in the closed vocabulary. "
+                "Add it to DISPLAY_KINDS or CONTROL_KINDS (with its codec mapping / "
+                "profile entry) — an un-dispositioned kind would leak an unprofiled "
+                "CUSTOM name on the AG-UI wire. Untrusted wire values must use "
+                "OutboxMessage.from_wire (lenient)."
+            )
 
-__all__ = ["OutboxMessage"]
+    @classmethod
+    def from_wire(
+        cls,
+        kind: str,
+        text: str,
+        meta: "dict | None" = None,
+        reply_to: "TransportRef | None" = None,
+    ) -> "OutboxMessage":
+        """Reconstruct from UNTRUSTED wire values, BYPASSING vocabulary validation.
+
+        The AG-UI decode path (``protocol.decode_event``) rebuilds an
+        OutboxMessage from a remote peer's frame; an unknown wire kind MUST
+        degrade gracefully (ignore-unknown), never fail-close — so decode routes
+        around :meth:`__post_init__` here. All PRODUCTION construction uses the
+        validating ``__init__``. Bypasses ``__init__`` via ``object.__new__`` +
+        ``object.__setattr__`` (the dataclass is frozen)."""
+        obj = object.__new__(cls)
+        object.__setattr__(obj, "kind", kind)
+        object.__setattr__(obj, "text", text)
+        object.__setattr__(obj, "meta", dict(meta) if meta is not None else {})
+        object.__setattr__(obj, "reply_to", reply_to)
+        return obj
+
+
+__all__ = [
+    "OutboxMessage",
+    "DISPLAY_KINDS",
+    "CONTROL_KINDS",
+    "VOCABULARY",
+]

--- a/tests/cli/test_chainlit_adapter.py
+++ b/tests/cli/test_chainlit_adapter.py
@@ -70,16 +70,25 @@ def test_end_sentinel_returns_end_role():
     ["__stream_user__", "__stream_agent__", "__stream_partial__", "trace"],
 )
 def test_dropped_kinds_return_none(kind: str):
-    """Tier 1: incremental / trace kinds are dropped (= return None)."""
-    msg = OutboxMessage(kind=kind, text="incremental")
+    """Tier 1: incremental / trace kinds are dropped (= return None).
+
+    ``__stream_*__`` are legacy TUI-only incremental kinds with no producer (the
+    adapter drops them defensively); they are not in the closed vocabulary, so
+    they are built via ``from_wire`` — the same lenient path a wire-decoded
+    unknown kind would take."""
+    msg = OutboxMessage.from_wire(kind=kind, text="incremental")
     assert outbox_to_chainlit(msg) is None
 
 
 def test_unknown_kind_falls_back_to_system_author():
     """Tier 1: unrecognised kind renders as a system message (not dropped),
     so a future kind addition surfaces in the browser instead of being silently
-    eaten."""
-    msg = OutboxMessage(kind="some_future_kind", text="future text")
+    eaten.
+
+    An unknown kind can only reach the adapter as a wire-decoded frame (the
+    producer vocabulary gate rejects it at construction), so build it via
+    ``from_wire`` — the lenient decode path."""
+    msg = OutboxMessage.from_wire(kind="some_future_kind", text="future text")
     payload = outbox_to_chainlit(msg)
     assert payload is not None
     assert payload.role == "message"

--- a/tests/test_agui_mapping_completeness.py
+++ b/tests/test_agui_mapping_completeness.py
@@ -123,7 +123,11 @@ def test_every_display_kind_round_trips_over_the_wire() -> None:
     assert "heading_open" not in kinds
 
     for kind in kinds:
-        frame = DisplayFrame(OutboxMessage(kind=kind, text="body", meta={"k": "v"}))
+        # from_wire: this is a CODEC round-trip test over the renderer-scanned
+        # kind set, which over-reports phantom strings (e.g. ``nodes``) that are
+        # not producer kinds — the codec must round-trip any kind, so bypass the
+        # producer vocabulary gate on the test input.
+        frame = DisplayFrame(OutboxMessage.from_wire(kind=kind, text="body", meta={"k": "v"}))
         decoded = _roundtrip(frame)
         assert isinstance(decoded, DisplayFrame), f"{kind!r} did not decode to a DisplayFrame"
         assert decoded.message.kind == kind, f"{kind!r} kind mangled → {decoded.message.kind!r}"

--- a/tests/test_agui_profile_completeness.py
+++ b/tests/test_agui_profile_completeness.py
@@ -1,24 +1,14 @@
-"""Tier 2: every producer display kind is dispositioned on the AG-UI wire (P4/P6a).
+"""Tier 2: every display kind is dispositioned on the AG-UI wire (P4/P6a/P6b).
 
-This gate keeps the reyn AG-UI surface honest against the AUTHORITATIVE source of
-display kinds — the producer ``OutboxMessage(kind=...)`` set across ``src`` — NOT
-a renderer-file proxy. (The renderer under-reports: producer-only control
-sentinels — ``__attach_request__`` / ``__copy_last_reply__`` / ``__rewind_list__``
-/ ``__session_switch_request__`` — never appear in ``renderer.py`` yet ARE emitted;
-one of them, ``__attach_request__``, is genuinely wire-forwarded. It also
-over-reports phantom kinds like ``nodes`` that no producer emits.)
+This gate keeps the reyn AG-UI surface honest against the SETTLED closed vocabulary
+(:data:`reyn.runtime.outbox.VOCABULARY` — declared in ``outbox.py``, enforced at
+construction by ``OutboxMessage.__post_init__``). P6b retired the earlier AST
+producer-scan: the vocabulary IS now the authoritative producer domain (a kind
+outside it cannot be constructed), so the gate derives from it directly — and
+binds it, non-circularly, against the REAL codec + profile registry (never the
+vocabulary against itself).
 
-The enumeration reads the codec-input domain directly:
-
-- **(a)** every ``OutboxMessage(kind="literal")`` construction; and
-- **(b)** the call sites of *kind-forwarder* functions — a function whose body
-  builds ``OutboxMessage(kind=<its own param>)`` is a forwarder (``put_outbox`` /
-  ``reply`` / ``_enqueue_tool_call``), so its callers' literal ``kind=`` values
-  (and the param's string default) also enter the domain. Forwarders are
-  discovered structurally, not hand-listed — so a wrapper-only kind (the
-  ``tool_call_*`` trio) can never hide.
-
-Every producer kind must be **dispositioned** as exactly one of:
+Every vocabulary kind must be **dispositioned** as exactly one of:
 
 - **standard-mapped** — the codec emits a standard AG-UI event (``agent`` /
   ``status`` / ``reasoning`` / ``error``); or
@@ -28,17 +18,19 @@ Every producer kind must be **dispositioned** as exactly one of:
   :data:`~reyn.interfaces.transport.agui.protocol.CONTROL_FILTER_KINDS` allowlist,
   so the emitter never puts it on the wire (a local-control sentinel).
 
-A producer kind outside all three ⇒ RED — an unprofiled Custom name would leak on
-the wire, exactly the doc-drift this gate exists to catch. Real instances only —
-the real codec + the real profile registry; no mocks.
+A vocabulary kind outside all three ⇒ RED — an unprofiled Custom name would leak
+on the wire, exactly the doc-drift this gate exists to catch. Real instances only
+— the real codec + the real profile registry; no mocks.
 """
 from __future__ import annotations
 
-import ast
-from pathlib import Path
-
 from reyn.core.events.events import Event
-from reyn.interfaces.transport.agui.profile import is_profiled, profiled_names
+from reyn.interfaces.transport.agui.profile import (
+    CUSTOM_PROFILE,
+    DISPLAY_NS,
+    is_profiled,
+    profiled_names,
+)
 from reyn.interfaces.transport.agui.protocol import (
     CONTROL_FILTER_KINDS,
     CUSTOM,
@@ -52,113 +44,14 @@ from reyn.interfaces.transport.frames import (
     EventFrame,
     renderer_chat_events,
 )
-from reyn.runtime.outbox import OutboxMessage
-
-_SRC = Path(__file__).resolve().parents[1] / "src"
-
-
-def _callee_name(func: ast.AST) -> "str | None":
-    if isinstance(func, ast.Name):
-        return func.id
-    if isinstance(func, ast.Attribute):
-        return func.attr
-    return None
-
-
-def _is_str(node: ast.AST) -> bool:
-    return isinstance(node, ast.Constant) and isinstance(node.value, str)
-
-
-def _kind_kwonly_default(fn: ast.AST) -> "str | None":
-    """The string default of a keyword-only ``kind`` param, if any."""
-    for arg, default in zip(fn.args.kwonlyargs, fn.args.kw_defaults):
-        if arg.arg == "kind" and default is not None and _is_str(default):
-            return default.value
-    return None
-
-
-def _src_trees() -> "list[ast.AST]":
-    trees: list[ast.AST] = []
-    for path in _SRC.rglob("*.py"):
-        try:
-            trees.append(ast.parse(path.read_text(encoding="utf-8")))
-        except SyntaxError:
-            continue
-    return trees
-
-
-def _producer_display_kinds() -> set[str]:
-    """Every ``kind`` literal that flows into ``OutboxMessage.kind`` across ``src``
-    — the AUTHORITATIVE codec-input domain (not the renderer proxy).
-
-    Two literal sources, both followed:
-
-    - **(a)** direct ``OutboxMessage(kind="literal")`` constructions (keyword or
-      first positional); and
-    - **(b)** call sites of *kind-forwarder* functions — a function that
-      constructs ``OutboxMessage(kind=<its param>)`` is a forwarder; its callers'
-      literal ``kind=`` values (and the param's string default when ``kind`` is
-      omitted) enter the domain. Forwarders are discovered structurally, so a
-      wrapper-only kind (``tool_call_*``) cannot hide.
-
-    Kinds passed as a non-literal (a variable) cannot be enumerated and are out of
-    scope for a static gate."""
-    trees = _src_trees()
-
-    # Pass 1 — discover forwarders (function name → its ``kind`` str default).
-    forwarders: dict[str, "str | None"] = {}
-    for tree in trees:
-        for fn in ast.walk(tree):
-            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            params = {
-                a.arg
-                for a in (*fn.args.args, *fn.args.kwonlyargs, *fn.args.posonlyargs)
-            }
-            forwards = any(
-                isinstance(call, ast.Call)
-                and _callee_name(call.func) == "OutboxMessage"
-                and any(
-                    kw.arg == "kind"
-                    and isinstance(kw.value, ast.Name)
-                    and kw.value.id in params
-                    for kw in call.keywords
-                )
-                for call in ast.walk(fn)
-            )
-            if forwards:
-                forwarders[fn.name] = _kind_kwonly_default(fn)
-
-    # Pass 2 — collect literal kinds from direct constructions + forwarder calls.
-    kinds: set[str] = set()
-    for tree in trees:
-        for call in ast.walk(tree):
-            if not isinstance(call, ast.Call):
-                continue
-            name = _callee_name(call.func)
-            if name == "OutboxMessage":
-                for kw in call.keywords:
-                    if kw.arg == "kind" and _is_str(kw.value):
-                        kinds.add(kw.value.value)
-                if call.args and _is_str(call.args[0]):
-                    kinds.add(call.args[0].value)
-            elif name in forwarders:
-                had_kind = False
-                for kw in call.keywords:
-                    if kw.arg == "kind":
-                        had_kind = True
-                        if _is_str(kw.value):
-                            kinds.add(kw.value.value)
-                if not had_kind and forwarders[name]:
-                    kinds.add(forwarders[name])
-    return kinds
+from reyn.runtime.outbox import CONTROL_KINDS, DISPLAY_KINDS, VOCABULARY, OutboxMessage
 
 
 def _disposition(kind: str) -> str:
-    """Classify a producer kind: 'standard' | 'profiled' | 'control' | 'LEAK'."""
+    """Classify a vocabulary kind: 'standard' | 'profiled' | 'control' | 'LEAK'."""
     if kind in CONTROL_FILTER_KINDS:
         return "control"
-    ev = encode_frame(DisplayFrame(OutboxMessage(kind=kind, text="x")))
+    ev = encode_frame(DisplayFrame(OutboxMessage.from_wire(kind=kind, text="x")))
     if ev.type != CUSTOM:
         return "standard"
     if is_profiled(ev.data.get("name", "")):
@@ -167,13 +60,12 @@ def _disposition(kind: str) -> str:
 
 
 def _emitted_custom_names() -> set[str]:
-    """The ``reyn.*`` Custom names the codec puts on the wire for the producer
-    display-kind domain + the derived chat-event vocabulary — never the profile."""
+    """The ``reyn.*`` Custom names the codec puts on the wire for the FORWARDED
+    display vocabulary (:data:`DISPLAY_KINDS`) + the derived chat-event
+    vocabulary. Reads the codec's output, never the profile."""
     names: set[str] = set()
-    for kind in _producer_display_kinds():
-        if kind in CONTROL_FILTER_KINDS:
-            continue  # not forwarded — no wire event to profile
-        ev = encode_frame(DisplayFrame(OutboxMessage(kind=kind, text="x")))
+    for kind in DISPLAY_KINDS:  # every wire-forwarded kind (control-filtered excluded)
+        ev = encode_frame(DisplayFrame(OutboxMessage.from_wire(kind=kind, text="x")))
         if ev.type == CUSTOM:
             names.add(ev.data["name"])
     for etype in renderer_chat_events():
@@ -183,32 +75,33 @@ def _emitted_custom_names() -> set[str]:
     return names
 
 
-def test_every_producer_kind_is_dispositioned() -> None:
-    """Tier 2: every ``OutboxMessage(kind=...)`` producer kind is standard-mapped
-    OR profiled OR in the explicit control-filter allowlist. Anything else is an
-    unprofiled Custom name that would leak on the wire ⇒ RED.
+def test_every_vocabulary_kind_is_dispositioned() -> None:
+    """Tier 2: every closed-vocabulary kind is dispositioned (converted from the P6a AST scan);
+    standard-mapped OR profiled OR in the explicit control-filter allowlist.
+    Anything else is an unprofiled Custom name that would leak on the wire ⇒ RED.
 
-    Strip-falsify (recorded in the PR): dropping the ``__attach_request__`` profile
-    entry, or removing any kind from ``CONTROL_FILTER_KINDS``, makes that kind a
-    LEAK ⇒ RED."""
-    kinds = _producer_display_kinds()
+    Strip-falsify (recorded in the PR): dropping the ``reyn.display.trace`` (or any
+    profiled) entry, or removing a kind from ``CONTROL_FILTER_KINDS``, makes that
+    kind a LEAK ⇒ RED."""
+    # Sanity: the vocabulary spans all three dispositions (a broken/empty
+    # vocabulary must not vacuously pass).
+    assert {"agent", "status", "reasoning", "error"} <= VOCABULARY   # standard
+    assert {"system", "user", "trace", "__attach_request__",
+            "tool_call_started"} <= VOCABULARY                       # profiled CUSTOM
+    assert {"__end__", "__session_switch_request__"} <= VOCABULARY   # control-filtered
 
-    # Sanity: the producer scan found the real domain — including the
-    # producer-ONLY control sentinels (invisible to any renderer scan) and the
-    # wrapper-forwarded ``tool_call_*`` trio (invisible to a direct-constructor
-    # scan). A broken scan that found nothing must not vacuously pass.
-    assert {
-        "agent", "status", "reasoning", "error",          # standard-mapped
-        "system", "user", "__attach_request__",           # profiled CUSTOM
-        "tool_call_started",                              # wrapper-forwarded
-        "__end__", "__copy_last_reply__",                 # control-filtered
-    } <= kinds
-
-    leaks = {k for k in kinds if _disposition(k) == "LEAK"}
+    leaks = {k for k in VOCABULARY if _disposition(k) == "LEAK"}
     assert not leaks, (
-        "producer kinds with no disposition (standard-map, profile, or add to "
+        "vocabulary kinds with no disposition (standard-map, profile, or add to "
         f"CONTROL_FILTER_KINDS): {sorted(leaks)}"
     )
+
+
+def test_control_kinds_match_the_wire_filter_allowlist() -> None:
+    """Tier 2: the outbox ``CONTROL_KINDS`` (emitter-filtered sentinels) are
+    EXACTLY the codec's ``CONTROL_FILTER_KINDS`` — the two independent declarations
+    of "never forwarded on the wire" stay bound. Drift either way ⇒ RED."""
+    assert CONTROL_KINDS == CONTROL_FILTER_KINDS
 
 
 def test_control_sentinel_dispositions_client_consumed_forward_upstream_consumed_filter() -> None:
@@ -216,14 +109,13 @@ def test_control_sentinel_dispositions_client_consumed_forward_upstream_consumed
 
     - ``__copy_last_reply__`` / ``__rewind_list__`` are **client-consumed** over the
       transport stream (real client-side clipboard copy / rewind picker), so they
-      are FORWARDED (profiled CUSTOM) and round-trip losslessly — filtering them
-      would make remote ``/copy`` / ``/rewind`` silent no-ops.
-    - ``__end__`` (terminal) and ``__session_switch_request__`` (upstream-consumed
-      at registry.py:3061) are control-filtered.
-    - ``__attach_request__`` is upstream-consumed at registry.py:3052; its profile
-      entry is a fail-safe (not a live wire kind)."""
+      are FORWARDED (profiled CUSTOM display kinds) and round-trip losslessly.
+    - ``__end__`` (terminal) and ``__session_switch_request__`` (upstream-consumed)
+      are control-filtered.
+    - ``__attach_request__`` is upstream-consumed; its profile entry is a fail-safe."""
     # Client-consumed → forwarded + profiled + lossless round-trip.
     for client_kind in ("__copy_last_reply__", "__rewind_list__"):
+        assert client_kind in DISPLAY_KINDS, client_kind
         assert client_kind not in CONTROL_FILTER_KINDS, client_kind
         assert _disposition(client_kind) == "profiled", client_kind
         ev = encode_frame(DisplayFrame(OutboxMessage(kind=client_kind, text="x")))
@@ -243,15 +135,14 @@ def test_control_sentinel_dispositions_client_consumed_forward_upstream_consumed
 
 
 def test_every_custom_mapped_frame_is_profiled() -> None:
-    """Tier 2: each reyn.* Custom name the codec emits (for a forwarded producer
+    """Tier 2: each reyn.* Custom name the codec emits (for a forwarded display
     kind) has an extension-profile entry. An unprofiled Custom name ⇒ RED."""
     emitted = _emitted_custom_names()
 
-    # Sanity: the enumeration found the real emitted Custom vocabulary, including
-    # the producer-only ``__attach_request__`` (invisible to a renderer scan) and
-    # the wrapper-forwarded ``tool_call_started`` (invisible to a direct-ctor scan).
+    # Sanity: the enumeration found the real emitted Custom vocabulary.
     assert {
         "reyn.display.system",
+        "reyn.display.trace",
         "reyn.display.__attach_request__",
         "reyn.display.tool_call_started",
         "reyn.event.user_answered_intervention",
@@ -261,12 +152,25 @@ def test_every_custom_mapped_frame_is_profiled() -> None:
     assert not missing, f"unprofiled reyn.* Custom names (add to profile): {sorted(missing)}"
 
 
+def test_no_dead_display_profile_entry() -> None:
+    """Tier 2: every ``reyn.display.<kind>`` profile (reverse dead-entry catch)
+    entry names a kind that is in the closed vocabulary — no profile entry for a
+    kind no producer can construct. Drift (a stale profile member) ⇒ RED."""
+    prefix = f"{DISPLAY_NS}."
+    for name in CUSTOM_PROFILE:
+        if not name.startswith(prefix):
+            continue
+        kind = name[len(prefix):]
+        assert kind in VOCABULARY, (
+            f"profile entry {name!r} names kind {kind!r} which is not in the closed "
+            "vocabulary (dead profile entry — remove it or add the kind)"
+        )
+
+
 def test_intervention_frontend_tool_toolname_is_profiled() -> None:
     """Tier 2: the HITL frontend-tool ``toolName`` the emitter really produces
     falls under a profiled reyn.intervention.* namespace — for every intervention
-    kind (open namespace). Unprofiled ⇒ RED (the P3 members were the stale-base gap)."""
-    # Real emitter output for representative intervention kinds (ask_user free-text
-    # + a permission.* prompt) — enumerated from the codec, not the profile.
+    kind (open namespace). Unprofiled ⇒ RED."""
     for kind in ("ask_user", "permission.grant_deny"):
         ev = encode_intervention_tool_start(
             {"intervention_id": "iv-1", "intervention_kind": kind, "prompt": "?"}
@@ -275,30 +179,22 @@ def test_intervention_frontend_tool_toolname_is_profiled() -> None:
         assert toolname.startswith("reyn.intervention."), toolname
         assert is_profiled(toolname), f"unprofiled intervention frontend-tool: {toolname}"
 
-    # The empty-kind fallback (``reyn.intervention.ask_user``) is also profiled.
     ev = encode_intervention_tool_start({"intervention_id": "iv-2", "intervention_kind": ""})
     assert is_profiled(ev.data["toolName"])
 
 
 def test_reasoning_is_standard_mapped_not_a_custom_profile_entry() -> None:
     """Tier 2: P6a — the reasoning frame is STANDARD-mapped (a Reasoning* event),
-    so it needs NO reyn.* Custom profile entry. The completeness gate must expect
-    reasoning as standard-mapped, not demand a ``reyn.display.reasoning`` Custom
-    entry for a now-standard signal.
+    so it needs NO reyn.* Custom profile entry.
 
     Strip-falsify: remove ``"reasoning"`` from ``_DISPLAY_KIND_EVENT`` → the frame
     reverts to CUSTOM (``reyn.display.reasoning``) → the standard-mapped assertion
-    below goes RED (and the general completeness gate would then demand a Custom
-    entry that no longer exists)."""
+    below goes RED."""
     ev = encode_frame(DisplayFrame(OutboxMessage(kind="reasoning", text="thinking")))
 
-    # Standard-mapped, not CUSTOM: no reyn.* Custom name is emitted for reasoning.
     assert ev.type == REASONING_MESSAGE_CONTENT
     assert ev.type != CUSTOM
     assert "name" not in ev.data, "a standard Reasoning* event carries no CUSTOM name"
 
-    # The move's consequence: there is NO Custom profile entry for reasoning, and
-    # the completeness gate does not require one (a standard event needs no
-    # extension-profile entry).
     assert "reyn.display.reasoning" not in profiled_names()
     assert "reyn.display.reasoning" not in _emitted_custom_names()

--- a/tests/test_browser_reyn_decode_tripwire.py
+++ b/tests/test_browser_reyn_decode_tripwire.py
@@ -1,0 +1,76 @@
+"""Tier 2: the openui browser's _reyn decode stays in lockstep with the encoder.
+
+The browser (``openui/static/index.html``) is a reyn-aware AG-UI client: it reads
+the ``_reyn`` reconstruction block off each SSE event and rebuilds the
+``{kind, text, meta}`` the design's ``agent.message`` channel consumes. That
+decode is JavaScript, so a Python-side rename of an ``_encode_display`` ``_reyn``
+field (``frame`` / ``kind`` / ``text`` / ``meta``) would update the Python decode
++ keep the Python tests green while the browser's ``reyn.<field>`` reads break
+SILENTLY (no Python test exercises the JS).
+
+This is the drift tripwire (ADR-0039 P6b): it regex-extracts the ``reyn.<field>``
+names the browser's decode function reads and asserts each is a key the real
+``_encode_display`` puts on its ``_reyn`` block. Rename a field on ONE side only
+⇒ RED. Real encoder output; no mocks.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from reyn.interfaces.transport.agui.protocol import _encode_display
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_INDEX_HTML = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "reyn" / "interfaces" / "web" / "openui" / "static" / "index.html"
+)
+
+
+def _encoder_reyn_keys() -> set[str]:
+    """The exact keys ``_encode_display`` writes into its ``_reyn`` block — the
+    authoritative wire contract the browser decodes."""
+    ev = _encode_display(DisplayFrame(OutboxMessage(kind="agent", text="x", meta={})))
+    return set(ev.data["_reyn"].keys())
+
+
+def _browser_decode_fn() -> str:
+    """The body of the browser's ``_onReynDisplayEvent`` decode function."""
+    html = _INDEX_HTML.read_text(encoding="utf-8")
+    m = re.search(r"function _onReynDisplayEvent\(ev\) \{(.*?)\n  \}", html, re.DOTALL)
+    assert m, "could not locate _onReynDisplayEvent in index.html (decode moved?)"
+    return m.group(1)
+
+
+def test_browser_reads_only_reyn_fields_the_encoder_emits() -> None:
+    """Tier 2: every ``reyn.<field>`` the browser decode reads is a key
+    ``_encode_display`` emits. A one-sided rename ⇒ RED (the silent-JS-drift the
+    cross-language D6 check found manually, now committed)."""
+    fn = _browser_decode_fn()
+    # The decode binds ``const reyn = data._reyn`` then reads ``reyn.<field>``.
+    read_fields = set(re.findall(r"\breyn\.(\w+)", fn))
+    emitted = _encoder_reyn_keys()
+
+    assert read_fields, "tripwire found no reyn.<field> reads — decode shape changed"
+    missing = read_fields - emitted
+    assert not missing, (
+        "browser index.html reads _reyn fields the Python encoder no longer emits "
+        f"(rename drift): {sorted(missing)}; encoder emits {sorted(emitted)}"
+    )
+
+
+def test_browser_reads_the_reyn_block_and_display_frame_tag() -> None:
+    """Tier 2: the browser reads the ``_reyn`` block off the event and gates on
+    ``frame === "display"`` — the two structural anchors of the decode. If either
+    the block key or the display frame-tag value changes on the wire, this RED's."""
+    html = _INDEX_HTML.read_text(encoding="utf-8")
+    assert "data._reyn" in html, "browser must read the _reyn reconstruction block"
+
+    ev = _encode_display(DisplayFrame(OutboxMessage(kind="agent", text="x", meta={})))
+    assert ev.data["_reyn"]["frame"] == "display"  # the value the browser gates on
+    fn = _browser_decode_fn()
+    assert 'reyn.frame !== "display"' in fn or 'reyn.frame === "display"' in fn, (
+        "browser must gate on the display frame-tag; if _encode_display's frame "
+        "value changed from 'display', update index.html in lockstep"
+    )

--- a/tests/test_inline_renderer_cutover.py
+++ b/tests/test_inline_renderer_cutover.py
@@ -32,7 +32,11 @@ def _plain(kind: str, text: str, meta: dict | None = None, *, width: int = 80) -
     bare Text), so we render it through a Console to assert the marker/body
     contract on the visible output."""
     console = Console(width=width, file=io.StringIO(), color_system=None)
-    console.print(format_inline_message(OutboxMessage(kind=kind, text=text, meta=meta or {})))
+    # from_wire: these render tests exercise arbitrary kinds (incl. a wire-decoded
+    # unknown kind the renderer must degrade on) — the render path serves both
+    # local (validated) and remote-wire (lenient) frames, so bypass the producer
+    # vocabulary gate here.
+    console.print(format_inline_message(OutboxMessage.from_wire(kind=kind, text=text, meta=meta or {})))
     return console.file.getvalue()
 
 
@@ -41,7 +45,7 @@ def _render_ansi(kind: str, text: str, *, width: int = 30) -> str:
     background block emits a ``48;2;`` background SGR)."""
     console = Console(width=width, file=io.StringIO(), force_terminal=True,
                       color_system="truecolor")
-    console.print(format_inline_message(OutboxMessage(kind=kind, text=text)))
+    console.print(format_inline_message(OutboxMessage.from_wire(kind=kind, text=text)))
     return console.file.getvalue()
 
 

--- a/tests/test_outbox_vocabulary.py
+++ b/tests/test_outbox_vocabulary.py
@@ -1,0 +1,95 @@
+"""Tier 2: OutboxMessage.kind is a closed vocabulary, validated at construction
+but lenient on the untrusted wire (ADR-0039 P6b).
+
+Two directions plus a dead-entry catch:
+
+- **Production-side gate:** ``OutboxMessage(kind=<not in VOCABULARY>)`` raises at
+  construction (fail-visible — catches the dynamic/helper constructions a static
+  scan misses). Strip the ``__post_init__`` check → an un-vocabularied producer
+  slips through → the disposition gate can no longer guarantee no wire leak.
+- **Wire-side leniency:** ``OutboxMessage.from_wire(kind=<unknown>)`` does NOT
+  raise — the AG-UI decode path rebuilds frames from an untrusted remote peer and
+  must ignore-unknown / graceful-degrade, never fail-close.
+- **No dead vocabulary entry:** every VOCABULARY kind is referenced in ``src`` (a
+  producer construction, a renderer branch, a codec map, or a profile entry).
+
+Real instances only — the real dataclass, the real decode path; no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.interfaces.transport.agui.protocol import decode_event, encode_frame
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import (
+    CONTROL_KINDS,
+    DISPLAY_KINDS,
+    VOCABULARY,
+    OutboxMessage,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "reyn"
+
+
+def test_construction_accepts_every_vocabulary_kind() -> None:
+    """Tier 2: each of the closed-vocabulary kinds constructs (validated __init__)."""
+    for kind in VOCABULARY:
+        msg = OutboxMessage(kind=kind, text="x")
+        assert msg.kind == kind
+    # The vocabulary is the disjoint union of DISPLAY_KINDS and CONTROL_KINDS.
+    assert DISPLAY_KINDS.isdisjoint(CONTROL_KINDS)
+    assert VOCABULARY == DISPLAY_KINDS | CONTROL_KINDS
+
+
+def test_construction_rejects_an_unvocabularied_kind() -> None:
+    """Tier 2: a producer constructing an un-vocabularied kind (strip target)
+    raises at construction. Strip the ``__post_init__`` gate → no raise → RED."""
+    with pytest.raises(ValueError):
+        OutboxMessage(kind="not_a_real_kind", text="x")
+    # A near-miss (control-sentinel-shaped but unknown) is still rejected.
+    with pytest.raises(ValueError):
+        OutboxMessage(kind="__not_a_sentinel__", text="x")
+
+
+def test_from_wire_is_lenient_on_an_unknown_kind() -> None:
+    """Tier 2: the untrusted wire path tolerates an unknown kind (strip target)
+    (ignore-unknown), NEVER fail-close. Route from_wire through __post_init__ →
+    this RAISES → RED (the graceful-degrade contract broken)."""
+    msg = OutboxMessage.from_wire(kind="some_future_kind", text="body", meta={"k": "v"})
+    assert msg.kind == "some_future_kind"
+    assert msg.text == "body"
+    assert msg.meta == {"k": "v"}
+    assert isinstance(msg, OutboxMessage)
+
+
+def test_decode_of_an_unknown_wire_kind_is_graceful_not_a_raise() -> None:
+    """Tier 2: an unknown display kind arriving over the AG-UI wire decodes to a
+    DisplayFrame (graceful), not an exception — the end-to-end leniency contract.
+
+    Build a real wire event whose ``_reyn`` block carries an unknown kind (via
+    from_wire so encode itself doesn't fail-close), then decode it."""
+    wire = encode_frame(
+        DisplayFrame(OutboxMessage.from_wire(kind="a_kind_this_client_never_heard_of", text="hi"))
+    )
+    decoded = decode_event(wire.type, wire.data)  # must NOT raise
+    assert isinstance(decoded, DisplayFrame)
+    assert decoded.message.kind == "a_kind_this_client_never_heard_of"
+    assert decoded.message.text == "hi"
+
+
+def test_no_dead_vocabulary_entry() -> None:
+    """Tier 2: every VOCABULARY kind is referenced (reverse dead-entry catch) as a
+    ``"kind"`` string literal somewhere in ``src`` — a producer construction, a
+    renderer branch, a codec map, or a profile entry. A vocabulary member with no
+    live reference is dead ⇒ RED (remove it)."""
+    blob = "\n".join(
+        p.read_text(encoding="utf-8")
+        for p in _SRC.rglob("*.py")
+        if "__pycache__" not in p.parts
+    )
+    dead = {kind for kind in VOCABULARY if f'"{kind}"' not in blob}
+    assert not dead, (
+        f"vocabulary kinds with no live reference in src (dead entries): {sorted(dead)}"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Sub-PR 3 (FINAL) of the **P6b ws-consolidation** arc (ADR-0039). `part of #2805`. Lands on the merged P6b-1 hub (#2823) + P6b-2/3 browser migration (#2826). **Merging this closes the ADR-0039 buildable arc.** **NOT merged** — architect co-vets against `P6b_ws_consolidation_spec.md` §4 + the two folded follow-ups.

## Closed kind vocabulary (P6b-4)
`OutboxMessage.kind` becomes a CLOSED vocabulary, validated at construction but lenient on the untrusted wire.

- **`outbox.py`** declares `DISPLAY_KINDS` (standard 4 + profiled 11, wire-forwarded) + `CONTROL_KINDS` (2, emitter-filtered), `VOCABULARY` = their union (17). Each control kind documented with its consumption locus. Split aligns with the existing `reyn.display.*` namespace (the 3 client-consumed forwarded sentinels `__copy_last_reply__`/`__rewind_list__`/`__attach_request__` are profiled DISPLAY kinds) and `CONTROL_KINDS == protocol.CONTROL_FILTER_KINDS`.
- **`__post_init__`** validates `kind ∈ VOCABULARY` — production-side, fail-visible, catching the **dynamic/helper constructions a static scan misses** (`put_outbox` / `reply` / `_enqueue_tool_call`, all traced).
- **HARD CONSTRAINT — decode stays lenient**: `OutboxMessage.from_wire` reconstructs from UNTRUSTED wire values **bypassing `__post_init__`** (`object.__new__` + `object.__setattr__`), so an unknown remote kind ignore-unknown / graceful-degrades, never fail-close. `protocol.decode_event` (display + messages backlog) routes through `from_wire`. **Mechanism stated: `from_wire` classmethod.**
- **`profile.py`**: added `reyn.display.trace` — `trace` is a rendered, wire-encodable display kind (renderer branch + 4 tests emit it) that lacked a profile entry; the vocabulary made the gap visible and closes it. Vocabulary = 17 = standard 4 / profiled 11 / control 2.

### Vocabulary completeness (exhaustively enumerated from source, not guessed)
16 literal `OutboxMessage(kind="…")` + 3 dynamic sites traced (`_enqueue_tool_call`→tool_call_*, `put_outbox`→agent/system/error/reasoning, `reply`→system/status/error) + the renderer's 12 accepted display kinds. `trace` (renderer-legacy, no producer) folded in; `__stream_*__` confirmed dead (no producer).

### Gate (converted from the P6a AST producer-scan → vocabulary-derived; static scan retired)
- **(i) disposition**: every `VOCABULARY` kind is standard-mapped OR profiled OR control-filtered — binds the vocabulary against the REAL codec + profile (non-circular).
- **(ii) reverse dead-entry**: every vocabulary kind is referenced in `src`; every `reyn.display.<kind>` profile entry names a vocabulary kind.

### Strip-falsify (all RED, restored green; cp-backup, never git-stash)
- strip `__post_init__` → `test_construction_rejects_an_unvocabularied_kind` **RED**.
- route `from_wire` through `__init__` → `test_from_wire_is_lenient…` + `test_decode_of_an_unknown_wire_kind_is_graceful…` **RED** (ValueError).
- drop `reyn.display.trace` profile entry → `test_every_vocabulary_kind_is_dispositioned` **RED** (LEAK).

## Folded follow-ups (from the co-vet of #2826)
1. **Browser-JS-decode drift tripwire** (`test_browser_reyn_decode_tripwire.py`): regex-extracts the `reyn.<field>` names `index.html` reads and asserts each is a key `_encode_display` emits (+ the `_reyn` block key and the `frame==="display"` tag). A one-sided rename of a wire field (Python decode updates, JS breaks silently) ⇒ **RED**. Commits the manual cross-language D6 check from #2826.

## Test sweep
6 unknown-kind tests migrated to `from_wire` (chainlit adapter `__stream_*__`/`some_future_kind`, inline renderer `totally_new_kind`, mapping-completeness round-trip's phantom `nodes`) — an unknown kind now only reaches a consumer as a wire-decoded frame, so the tests build it via the lenient path.

## Test plan
- [x] construction rejects un-vocab kind (strip → RED)
- [x] `from_wire` lenient on unknown kind (strip → RED)
- [x] decode of unknown wire kind graceful, no raise (strip → RED)
- [x] disposition gate derives from vocabulary; drop trace profile → LEAK RED
- [x] reverse dead-entry: no dead vocab / profile entry
- [x] `CONTROL_KINDS == CONTROL_FILTER_KINDS`
- [x] browser-decode drift tripwire (one-sided field rename → RED)
- [x] 4 CI gates: ruff clean; tier-audit `--strict` 62 OK; module-docstrings OK; full `pytest` 8254 passed
- [x] Baseline: only 5 failures (tests/web route-mount/plugin + test_fp0001) — this PR touches ZERO web/server/route code (only outbox/protocol/profile + tests); same set verified identical on pristine `origin/main` in #2823/#2826; **zero new**

## Items 2-3 (routed / noted, per coordinator — not built here)
- **Stale module docstrings** (`server.py:3`, `cli/commands/web.py:3,22` "FastAPI + WebSocket gateway") → routed to docs-maintainer's WebSocket-positioning PR (same drift class).
- **`web.ws_max_size` config — CONFIRMED ORPHANED**: after the ws/chat deletion there are **0 in-app WebSocket routes** (verified at runtime: `[r for r in app.routes if WebSocketRoute]` == `[]`). uvicorn's `ws_max_size` only bounds WebSocket frames, so with no WS routes the config (reyn-yaml + `media.py` + `cli/commands/web.py`→uvicorn) is inert. **Tracked follow-up** (a config-schema change is its own scope — not removed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)