### PR TITLE
docs: add missing OTEL exporter row to feature-map.md

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -400,6 +400,7 @@ Main reference: **[`reyn.yaml`](reference/config/reyn-yaml.md)**
 | `permissions` | Project-wide default capability policy | [Permissions config](reference/config/permissions.md) |
 | `multi-agent` | Agent and topology defaults | [Multi-agent config](reference/config/multi-agent.md) |
 | `state_dir` | Runtime state directory (default `.reyn/`) | [State dir](reference/config/state-dir.md) |
+| `observability` | OTLP endpoint / headers / service name / content-capture toggle for the opt-in OpenTelemetry exporter | [reyn-yaml § observability](reference/config/reyn-yaml.md#observability-block) · [Observability reference](reference/runtime/observability.md) |
 | `auth` | OAuth provider definitions for `reyn auth login` (RFC 8628 device grant) | [reyn-yaml](reference/config/reyn-yaml.md) |
 | `mcp` | Configured external MCP server connections (transport + env) | [Concepts: MCP](concepts/tools-integrations/mcp.md) |
 | `multimodal` | Media handling caps (`max_bytes`, per-part token cost) | [reyn-yaml](reference/config/reyn-yaml.md) |
@@ -578,6 +579,7 @@ logic. Design: [content-threat scan proposal](deep-dives/proposals/0050-content-
 | Webhook push | Status-transition POSTs to `params.webhook_url` for async tasks (`reyn.web.notifications`) | [A2A concepts](concepts/multi-agent/a2a.md) |
 | MCP-over-SSE | `/mcp/sse` + `/mcp/messages` for MCP client connections | [reyn web CLI](reference/cli/web.md) · [reyn mcp CLI](reference/cli/mcp.md) |
 | REST API | `/api/*` for agents / skills / runs / topologies / budget / permissions | [reyn web CLI](reference/cli/web.md) |
+| OpenTelemetry (OTLP) export | Opt-in, fail-open subscriber on the P6 audit-event log — maps events to OTLP spans/metrics/log records (GenAI semantic conventions, pinned version), off unless an endpoint is configured, content-capture off by default. Never a recovery source: `.reyn/events` + the WAL are unaffected and unchanged whether or not it is attached | [Reference: Observability](reference/runtime/observability.md) |
 
 > **Differentiation vs general agents:** competitors specialise in broad, deep connectivity to the messaging apps you already use. Reyn keeps connectivity to standard protocols — MCP (client + server), A2A (sync + async tasks with webhook push), and a REST / AG-UI SSE gateway — rather than per-app integrations.
 


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
`docs/feature-map.md` had zero mention of the P5 OTEL exporter (`src/reyn/observability/otel_exporter.py`, already documented in `docs/reference/runtime/observability.md`) — a confirmed gap (grep 0) surfaced by the ADR-0039 arc's doc-surface completeness audit.

- Added a "Web & Protocol" row (parallel framing to the other export/transport rows already there: AG-UI browser chat, AG-UI remote chat, A2A, MCP-over-SSE), grounded in the observability reference doc: opt-in / fail-open / GenAI-convention-mapped / never a recovery source.
- Added the missing `observability` row to the "Config" section's block table, linking to `reyn-yaml.md#observability-block`.

Per lead-coder's scope correction: AG-UI is already covered by the two existing rows (`:572`/`:573`), so this PR does **not** add or duplicate any AG-UI/hub-related row — OTEL was the only confirmed gap. The separate sandbox launcher-fork feature-map rows (item ② of the original completeness request) were already closed by tui-coder in #2830.

No history refs in the doc body.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — passes clean, no new "Aborted"; the one new INFO line is the same pre-existing EN/JA cross-anchor-check pattern already present for ~15 other files in this repo (not a regression)
- [x] `ruff check src tests` — clean (docs-only change)
- [x] No src/test files changed — docstring gate and pytest not applicable
- [x] Verified `#observability-block` anchor exists in `docs/reference/config/reyn-yaml.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)