### PR TITLE
docs(adr-0039): add restrained "session multiplexer" client-side framing

### DIFF
--- a/docs/deep-dives/decisions/0039-thin-client-single-writer-server.md
+++ b/docs/deep-dives/decisions/0039-thin-client-single-writer-server.md
@@ -276,6 +276,19 @@ synthesis. (And since no tool locks a workspace across processes — all
 isolate or run single-process-async — the single-writer choice is
 industry-aligned, not exotic.)
 
+Read from the client side rather than the server side, the same design is a
+**session multiplexer** — the same shape as a terminal multiplexer (tmux) or
+Jupyter's shared kernel, applied to an agent runtime: one server multiplexes N
+agent sessions across M attached client surfaces (attach/detach, broadcast via
+`OutboxHub`, seize). Single-writer and multiplexer are two faces of one
+design, not two designs — "single-writer" names the server-side property,
+"multiplexer" names the client-side experience it produces. Multiplexing
+itself is not new (tmux, Jupyter, LSP all do it); what's new here is applying
+it to a **typed, permissioned, auditable** agent runtime rather than a plain
+shell or kernel process — the multiplexed unit is a governed runtime, attach
+works identically local or over the network, and any standard AG-UI client can
+attach, not just reyn's own.
+
 ---
 
 ## Consequences / honest ceiling


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Owner-ratified, kept deliberately restrained (per explicit brief: "控えめに" / not a reframe) — adds one paragraph to ADR-0039's "Positioning (proven-halves synthesis)" section, right next to the existing Jupyter shared-kernel analog.

Framing: read from the client side rather than the server side, the same single-writer design is a **session multiplexer** — the same shape as a terminal multiplexer (tmux) or Jupyter's shared kernel, applied to an agent runtime (one server multiplexing N sessions across M attached client surfaces: attach/detach, broadcast via `OutboxHub`, seize). Single-writer and multiplexer are named as two faces of one design, not two designs.

Honest line kept explicit per the brief: multiplexing itself is not a new pattern (tmux/Jupyter/LSP all do it) — the novelty is applying it to a typed/permissioned/auditable agent runtime, not a new category. No over-claim.

`docs/deep-dives/decisions/0039-thin-client-single-writer-server.md` has no `.ja` sibling, so no `.ja` sync is applicable here. No history refs added.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no new warnings/aborts
- [x] `OutboxHub` / seize / active-driver concepts verified live in `src/reyn/runtime/outbox_hub.py` and `src/reyn/interfaces/transport/agui/{surface,client,endpoint}.py` before citing them
- [x] No src/test files changed — other gates not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)