### PR TITLE
docs: reconcile chat.md slash-command table with the live REGISTRY

### DIFF
--- a/docs/reference/cli/chat.ja.md
+++ b/docs/reference/cli/chat.ja.md
@@ -61,19 +61,36 @@ reyn chat researcher
 
 | コマンド | 効果 |
 |---------|--------|
-| `/list` | 実行中の Skill スポーンと保留中の介入を表示 |
-| `/cancel <id>` | Skill スポーンをキャンセル（完全な id または最後の 4 文字） |
-| `/answer <id> <text>` | 保留中の `ask_user` / Permission プロンプトに回答 |
+| `/agent edit role <text>` | アタッチ中 agent のペルソナを書き換え |
+| `/agent new <name>` | 新規 agent を作成してアタッチ |
 | `/agents` | 読み込まれた agent と現在アタッチされているものを一覧表示 |
-| `/attach <name>` | REPL ポインターを別の agent に切り替える（前の agent はバックグラウンドで実行し続ける） |
-| `/session new \| switch <sid> \| list` | アタッチ中 agent の会話セッションを開く / 切り替える / 一覧表示（[Sessions](../../concepts/multi-agent/sessions.md) 参照） |
-| `/skill list` | 実行中の Skill 実行を表示（id / 名前 / current_phase + 親子関係） |
-| `/skill discard <run_id>` | 特定の Skill 実行を中止して cleanup を実行 |
-| `/tasks` | 動作中の Skill 実行の統合ビュー。`/tasks list` と同じ |
-| `/tasks status <prefix>` | 特定の Skill 実行の current phase + 経過時間を表示 |
-| `/tasks kill <prefix>` | 特定の Skill 実行を中止。prefix は Skill の run_id とマッチ |
+| `/answer <id-prefix> <text>` | 保留中の `ask_user` / Permission プロンプトに回答(id-prefix: intervention id の任意の一意な prefix) |
+| `/attach <name>` | REPL ポインターを別の agent に切り替える(前の agent はバックグラウンドで実行し続ける) |
+| `/budget [reset]` | 完全な budget 内訳; `/budget reset` はプロセス単位のカウンタをクリア([config/budget](../config/budget.md) 参照) |
+| `/clear-history`(alias `/clear`) | チャット履歴を消去(**破壊的**; メモリ内 + 永続履歴 + action-usage テーブルをクリア。events/run-state/profile は保持) |
+| `/compact` | コンテキストウィンドウを空けるため今すぐ会話履歴を圧縮する([chat-compaction](../../concepts/data-retrieval/chat-compaction.md) 参照) |
+| `/concept <term>` | 用語集のインライン参照 |
+| `/copy [N\|list]` | agent の返信をクリップボードにコピー(1 = 最新、2 = 1 ターン前、…) |
+| `/cost` | このagentのトークン + USD コスト概要 |
+| `/exit` | チャットを終了(alias: `/quit`、Ctrl+D) |
+| `/help [<cmd>]` | スラッシュコマンドのヘルプ — 全件一覧、または特定コマンドに絞る |
+| `/hook on\|off <name>` | このセッションでの hook の有効/無効を切り替え(次回 dispatch から有効; セッションスコープ — agent の他セッションでは引き続き発火。再起動後も持続) |
+| `/image <path>`(alias `/img`) | 次のユーザーメッセージに画像を添付(マルチモーダル入力; png/jpg/jpeg/gif/webp/svg) |
+| `/list` | 保留中の介入を一覧表示 |
+| `/memory [list\|view <name>]` | プロジェクトメモリのエントリを確認([concepts/memory](../../concepts/data-retrieval/memory.md) 参照) |
+| `/model [<class>]` | セッションのモデルクラスとオーバーライドを表示、または `/model <class>` でセッション単位のモデルクラスオーバーライドを設定(既知クラスに対して validate; 再起動でクリア) |
+| `/pending [list\|discard <id>\|claim <id>]` | 停滞したクロスチャネル操作を一覧表示 / 破棄 / claim |
+| `/quit` | チャットを終了(alias: `/exit`、Ctrl+D) |
+| `/reload` | 次のターン境界でランタイム設定(`.reyn/*.yaml`)をホットリロード |
+| `/reset confirm` | 進行中の run 状態をリセット(スナップショット + WAL; 監査ログは保持) |
+| `/rewind [seq]` | 以前のチェックポイントへタイムトラベル — 引数無しでピッカーメニューを開く、`seq` で直接ジャンプ([Time-travel](../../concepts/runtime/time-travel.md) · [How-to](../../guide/for-users/time-travel.md) 参照) |
+| `/session new \| switch <sid> \| list` | アタッチ中 agent の会話セッションを開く / 切り替える / 一覧表示([Sessions](../../concepts/multi-agent/sessions.md) 参照) |
+| `/tasks [list]` | LLM が `task__create` で作成した dynamic task を一覧表示 |
+| `/tasks status <task_id-prefix>` | 特定の task のステータス + 依存関係を表示 |
+| `/tasks kill <task_id-prefix>` | 特定の dynamic task を中止 |
+| `/visibility on\|off <tool\|mcp\|category> <name>` | このセッションでの capability の LLM 可視性を切り替え(次ターンで非表示 / agent の許可済 envelope の範囲内で復元 — envelope が拒否する capability は非表示のまま) |
 
-`/list` / `/cancel` / `/answer` は基盤となります。複数の Skill 実行と介入がプロンプトをブロックせずに共存できます。`/agents` / `/attach` はマルチエージェントワークフローのプリミティブです。`/skill` は crash recovery オペレーターコマンドで、per-skill-run のライフサイクルを surface します。`/tasks` は Skill 実行の統合エントリーポイントで、Skill が spawn された後に LLM が user に `/tasks` で進捗確認を案内します。
+`/list` / `/answer` は基盤となります。保留中の介入がプロンプトをブロックせずに共存できます。`/agents` / `/attach` / `/agent` はマルチエージェントワークフローのプリミティブです。`/tasks` は LLM が `task__create` で spawn する dynamic task のエントリーポイントです — 実行中のものを一覧表示、特定タスクのステータス/依存関係を確認、または kill します; task 作成後 LLM も user に `/tasks` を案内します。`/hook` / `/visibility` はセッションスコープの LLM カタログ制御で、ステータスバーの `hook`/`tool`/`mcp`/`category` チップと対応します。`/copy` は会話ペインのユーティリティ; `/image` はマルチモーダル入力を可能にします。
 
 ## マルチエージェントの動作
 

--- a/docs/reference/cli/chat.md
+++ b/docs/reference/cli/chat.md
@@ -67,31 +67,30 @@ While a session is active, lines starting with `/` are intercepted and never rou
 | `/answer <id-prefix> <text>` | Answer a pending `ask_user` / permission prompt (id-prefix: any unique prefix of the intervention id) |
 | `/attach <name>` | Switch the REPL pointer to another agent (the previous one keeps running in the background) |
 | `/budget [reset]` | Full budget breakdown; `/budget reset` clears per-process counters (see [config/budget](../config/budget.md)) |
-| `/cancel <id-prefix>` | Cancel a running skill (accepts any unique prefix of the run_id) |
-| `/clear-history` | Wipe chat history (**destructive**; clears in-memory + persistent history) |
+| `/clear-history` (alias `/clear`) | Wipe chat history (**destructive**; clears in-memory + persistent history and the action-usage table; events/run-state/profile preserved) |
 | `/compact` | Compact the conversation history now to free up the context window (see [chat-compaction](../../concepts/data-retrieval/chat-compaction.md)) |
-| `/concept <term>` | Inline glossary lookup (T1-3) |
+| `/concept <term>` | Inline glossary lookup |
 | `/copy [N\|list]` | Copy an agent reply to the clipboard (1 = newest, 2 = one turn back, …) |
 | `/cost` | Quick token + USD cost summary for this agent |
 | `/exit` | Exit the chat (alias: `/quit`, Ctrl+D) |
 | `/help [<cmd>]` | Slash command help — list all, or focus on one |
-| `/image <path>` | Attach an image to the next user message (multimodal input) |
-| `/list` | List running skills and pending interventions |
+| `/hook on\|off <name>` | Enable/disable a hook for this session (live at the next dispatch; session-scoped — the hook still fires in the agent's other sessions; persists across restart) |
+| `/image <path>` (alias `/img`) | Attach an image to the next user message (multimodal input; png/jpg/jpeg/gif/webp/svg) |
+| `/list` | List pending interventions |
 | `/memory [list\|view <name>]` | Inspect project memory entries (see [concepts/memory](../../concepts/data-retrieval/memory.md)) |
 | `/model [<class>]` | Show the session's model class and any override, or set a per-session model-class override with `/model <class>` (validated against known classes; clears on restart) |
 | `/pending [list\|discard <id>\|claim <id>]` | List / discard / claim stalled cross-channel ops |
 | `/quit` | Exit the chat (alias: `/exit`, Ctrl+D) |
-| `/reset confirm` | Reset in-flight skill state (snapshots + WAL; audit logs preserved) |
+| `/reload` | Hot-reload runtime config (`.reyn/*.yaml`) at the next turn boundary |
+| `/reset confirm` | Reset in-flight run state (snapshots + WAL; audit logs preserved) |
 | `/rewind [seq]` | Time-travel to an earlier checkpoint — no arg opens the picker menu; `seq` jumps directly (see [Time-travel](../../concepts/runtime/time-travel.md) · [How-to](../../guide/for-users/time-travel.md)) |
 | `/session new \| switch <sid> \| list` | Open / switch / list conversation sessions for the attached agent (see [Sessions](../../concepts/multi-agent/sessions.md)) |
-| `/skill list` | Show active skill runs (id, name, current phase + parent lineage) |
-| `/skill discard <run_id>` | Abort a specific skill run + cleanup |
-| `/skills` | List available skills (stdlib, project, local) |
-| `/tasks` | Unified view of active skill runs. Same as `/tasks list` |
-| `/tasks status <prefix>` | Show current phase + elapsed for a specific skill run |
-| `/tasks kill <prefix>` | Cancel a specific skill run; prefix matches against skill run_ids |
+| `/tasks [list]` | List dynamic tasks the LLM created via `task__create` |
+| `/tasks status <task_id-prefix>` | Show a task's status + dependencies |
+| `/tasks kill <task_id-prefix>` | Abort a specific dynamic task |
+| `/visibility on\|off <tool\|mcp\|category> <name>` | Toggle this session's LLM visibility of a capability (hidden next turn / restored up to the agent's authorized envelope — an envelope-denied capability stays hidden) |
 
-`/list` / `/cancel` / `/answer` are foundational — they let multiple skill runs and interventions coexist without blocking the prompt. `/agents` / `/attach` / `/agent` are the multi-agent workflow primitives. `/skill` is the crash-recovery operator command that surfaces the per-skill-run lifecycle: inspect what is running or abort a stuck run. `/tasks` is the unified entry point for skill runs — the LLM also points users at `/tasks` after a skill is spawned. `/copy` is a conversation-pane utility; `/image` enables multimodal input.
+`/list` / `/answer` are foundational — they let pending interventions coexist without blocking the prompt. `/agents` / `/attach` / `/agent` are the multi-agent workflow primitives. `/tasks` is the entry point for dynamic tasks the LLM spawns via `task__create` — list what's running, inspect a specific one's status/dependencies, or kill it; the LLM also points users at `/tasks` after creating one. `/hook` / `/visibility` are session-scoped LLM-catalog controls, mirroring the status bar's `hook`/`tool`/`mcp`/`category` chips. `/copy` is a conversation-pane utility; `/image` enables multimodal input.
 
 ## Multi-agent behavior
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -4621,9 +4621,9 @@ class Session:
         # in-flight task to drain at shutdown.
 
     async def _handle_user_message(self, text: str, *, chain_id: str) -> None:
-        # Slash commands (`/list`, `/cancel <id>`, `/answer <id> <text>`) take
-        # precedence over both the active-intervention router and a fresh
-        # router turn.
+        # Slash commands (`/list`, `/tasks kill <id>`, `/answer <id> <text>`)
+        # take precedence over both the active-intervention router and a
+        # fresh router turn.
         if text.startswith("/"):
             if await self._maybe_handle_slash(text):
                 return


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Follow-up to #2831/#2832/#2833 — reconciles `chat.md`'s "Slash commands" reference table against the actual live `SlashRegistry`, per lead-coder's request after I flagged `/cancel`/`/skill*`/`/skills` as suspiciously absent from the registry.

**Confirmed dead, not a grep false-negative**: traced the real runtime dispatch path — `src/reyn/runtime/session.py:_maybe_handle_slash` (the sole call site, from `_handle_user_message`) resolves commands via `REGISTRY.get(cmd)`, and `REGISTRY` is populated exclusively by the `@slash(...)`/`slash(...)` calls in `src/reyn/interfaces/slash/*.py` — there is no other registration path. `cancel`, `skill`, `skills` are not among them. Removed the four corresponding rows.

**Added the 3 registered commands that had zero row**: `/hook`, `/reload`, `/visibility` — verified against their handlers' `summary`/`usage` and behavior directly.

**Corrected stale "skill run" vocabulary**:
- `/list`'s description said "running skills and pending interventions" — the actual handler (`interfaces/slash/chat.py`) only lists pending interventions (the "running tasks: (none)" line it prints is a hardcoded placeholder, not a real query — not documented as if it worked).
- `/tasks`' three rows described "skill run" semantics; the actual command (`interfaces/slash/tasks.py`) is entirely about the dynamic-task system (`task__create`, `session.task_backend`) — this predates a skill-run → dynamic-task rename after the SkillRunner was removed. Rewrote all three rows in the current vocabulary.
- Rewrote the closing summary paragraph to match (removed the `/skill`/`/cancel` mentions, added `/tasks`/`/hook`/`/visibility`).

**`chat.ja.md`**: was missing most of the table already (a much larger pre-existing EN/JA gap than the 4 dead rows — it only had `list`/`cancel`/`answer`/`agents`/`attach`/`session`/`skill*`/`tasks*`). Brought it to full parity with the reconciled EN table.

**`src/reyn/runtime/session.py`**: fixed the stale `` `/cancel <id>` `` mention in `_handle_user_message`'s comment (→ `` `/tasks kill <id>` ``).

No history refs in doc bodies.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no new warnings/aborts
- [x] Every row's summary/usage verified directly against its handler's `@slash(...)` registration in `src/reyn/interfaces/slash/*.py` (not inferred from old docs)
- [x] `/list`'s and `/tasks`' actual behavior read from their handler bodies, not just the `summary=` string
- [x] Confirmed dead commands via the live dispatch path (`session.py` → `REGISTRY.get`), not static grep alone — same discipline requested after an earlier grep false-negative this session (`--connect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)