### PR TITLE
fix: make reyn web / chat --connect install + connect failures diagnosable

### DIFF
--- a/src/reyn/interfaces/cli/commands/web.py
+++ b/src/reyn/interfaces/cli/commands/web.py
@@ -4,7 +4,7 @@ FastAPI + AG-UI SSE ゲートウェイ (reyn.interfaces.web.server) を uvicorn 
 フロントエンドを http://localhost:<port> から利用できます。
 
 このコマンドは reyn の `[web]` オプション依存を必要とします:
-    pip install -e ".[web]"
+    python -m pip install -e '.[web]'
 """
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ def register(sub) -> None:
         help="Web UI ゲートウェイサーバを起動する",
         description=(
             "FastAPI + AG-UI SSE ゲートウェイを uvicorn で起動します。\n"
-            "インストール: pip install -e \".[web]\""
+            "インストール: python -m pip install -e '.[web]'"
         ),
     )
     p.add_argument(
@@ -168,24 +168,18 @@ def _apply_cli_scoped_overrides(args: argparse.Namespace) -> None:
 
 
 def run(args: argparse.Namespace) -> None:
+    from reyn.interfaces.install_guard import missing_dep_message
+
     try:
         import uvicorn
-    except ImportError:
-        print(
-            "Error: uvicorn is not installed. "
-            "Run `pip install -e \".[web]\"` to install the web gateway dependencies.",
-            file=sys.stderr,
-        )
+    except ImportError as e:
+        print(missing_dep_message(e, "uvicorn", "web"), file=sys.stderr)
         sys.exit(1)
 
     try:
         import fastapi  # noqa: F401
-    except ImportError:
-        print(
-            "Error: fastapi is not installed. "
-            "Run `pip install -e \".[web]\"` to install the web gateway dependencies.",
-            file=sys.stderr,
-        )
+    except ImportError as e:
+        print(missing_dep_message(e, "fastapi", "web"), file=sys.stderr)
         sys.exit(1)
 
     # --default-design flag: propagate via env so web_config router can read it.

--- a/src/reyn/interfaces/install_guard.py
+++ b/src/reyn/interfaces/install_guard.py
@@ -1,0 +1,65 @@
+"""Diagnosable install-guard messaging for optional-extra dependencies.
+
+Several entry points (``reyn web``, ``reyn chat --connect``) require optional
+dependency groups declared in ``pyproject.toml`` extras (e.g. ``[web]``). When
+the import of such a dependency fails, the guard must tell the operator *why* in
+a way that actually resolves the failure — two diagnosability traps motivate this
+module:
+
+1. A **bare** ``pip install -e ".[web]"`` recommendation is fragile: on setups
+   where ``pip`` resolves to a different interpreter than the active venv (pyenv
+   shims, global site-packages), the install lands in the wrong environment and
+   the guard keeps reporting "not installed". The robust form is
+   ``python -m pip install -e '.[web]'`` — ``python -m pip`` targets the *running*
+   interpreter, and single-quoting the extra stops zsh from globbing ``[web]``.
+2. Reporting **every** ``ImportError`` as "not installed" masks version-conflict
+   failures (the dependency IS installed, but an incompatible resolved version
+   breaks its import). :func:`missing_dep_message` distinguishes a genuinely
+   missing module (``ModuleNotFoundError`` whose ``name`` is the package) from an
+   installed-but-broken import, and surfaces the real exception text in both.
+
+This module is import-light (stdlib only) on purpose: it must be importable even
+when the optional extra it describes is absent.
+"""
+from __future__ import annotations
+
+
+def install_command(extra: str) -> str:
+    """Return the robust, interpreter-targeted install command for ``extra``.
+
+    ``python -m pip`` installs into the *active* interpreter (not whatever a bare
+    ``pip`` shim resolves to); the single quotes protect the ``[extra]`` token
+    from shell globbing (zsh).
+    """
+    return f"python -m pip install -e '.[{extra}]'"
+
+
+def missing_dep_message(exc: ImportError, package: str, extra: str) -> str:
+    """Build a diagnosable guard message for a failed optional-dependency import.
+
+    Distinguishes two failure modes and phrases each differently:
+
+    * genuinely missing (``ModuleNotFoundError`` whose ``name`` is ``package``)
+      → an "is not installed" message with the robust install command.
+    * installed-but-broken (any other ``ImportError``, e.g. a version conflict)
+      → an "is installed but failed to import" message.
+
+    The underlying exception text is included in *both* messages so the real
+    cause is visible instead of being masked as "not installed".
+    """
+    cmd = install_command(extra)
+    note = (
+        f"(`{cmd}` installs into the active interpreter; the quotes protect the "
+        "extra from shell globbing.)"
+    )
+    if isinstance(exc, ModuleNotFoundError) and exc.name == package:
+        return (
+            f"Error: {package} is not installed ({exc}). "
+            f"Run `{cmd}` to install the [{extra}] dependencies. {note}"
+        )
+    return (
+        f"Error: {package} is installed but failed to import: {exc} — "
+        f"likely a version conflict (the [{extra}] extra pins compatible versions, "
+        f"e.g. fastapi/starlette; check the installed versions). "
+        f"If it is genuinely missing, run `{cmd}`. {note}"
+    )

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -29,6 +29,28 @@ logger = logging.getLogger(__name__)
 _HEARTBEAT_INTERVAL = 10.0
 
 
+def connect_failure_message(status: int, agent_name: str, base_url: str) -> str:
+    """Map an SSE-connect HTTP status to an actionable, cause-naming message.
+
+    A bare "server refused the connection (404)" hides the real cause: a 404 on
+    ``reyn chat --connect`` almost always means the *agent* wasn't found (the
+    client defaults to agent ``"default"`` when none is passed), and a 401 is an
+    auth-token problem. Name the cause and give the next step for each.
+    """
+    if status == 404:
+        return (
+            f"Error: agent '{agent_name}' not found on the server (404). "
+            f"List available agents: curl {base_url}/a2a/agents . "
+            "(If you didn't pass an agent name, it defaults to 'default'.)"
+        )
+    if status == 401:
+        return (
+            "Error: authentication failed (401) — pass --token <secret> "
+            "(the token `reyn web` prints on launch), or set REYN_WEB_AUTH_TOKEN."
+        )
+    return f"Error: server refused the connection ({status}) at {base_url}."
+
+
 async def run_remote_repl(
     *,
     base_url: str,
@@ -46,12 +68,10 @@ async def run_remote_repl(
     """
     try:
         import httpx
-    except ImportError:
-        print(
-            "Error: httpx is not installed. `reyn chat --connect` needs the web "
-            'client deps: pip install -e ".[web]"',
-            file=sys.stderr,
-        )
+    except ImportError as e:
+        from reyn.interfaces.install_guard import missing_dep_message
+
+        print(missing_dep_message(e, "httpx", "web"), file=sys.stderr)
         sys.exit(1)
 
     from prompt_toolkit import PromptSession
@@ -88,16 +108,11 @@ async def run_remote_repl(
 
         try:
             async with client.stream("GET", events_url, params=params) as resp:
-                if resp.status_code == 401:
-                    print(
-                        "Error: authentication required / rejected by the server. "
-                        "Pass --token <secret> (or set REYN_WEB_AUTH_TOKEN).",
-                        file=sys.stderr,
-                    )
-                    sys.exit(1)
                 if resp.status_code >= 400:
                     print(
-                        f"Error: server refused the connection ({resp.status_code}).",
+                        connect_failure_message(
+                            resp.status_code, agent_name, base_url
+                        ),
                         file=sys.stderr,
                     )
                     sys.exit(1)

--- a/tests/test_install_guard_message.py
+++ b/tests/test_install_guard_message.py
@@ -1,0 +1,109 @@
+"""Tier 2: install-guard message distinguishes missing-vs-broken + robust install cmd.
+
+Two diagnosability defects motivated ``reyn.interfaces.install_guard``:
+
+1. A bare ``pip install -e ".[web]"`` recommendation can install into the wrong
+   interpreter (pip shim ≠ active venv). The guard must recommend the robust
+   ``python -m pip install -e '.[web]'`` form (interpreter-targeted + shell-glob
+   safe quotes).
+2. Reporting every ``ImportError`` as "not installed" masks version-conflict
+   failures. The guard must distinguish a genuinely missing module
+   (``ModuleNotFoundError`` whose ``name`` is the package) from an
+   installed-but-broken import, and surface the real exception text in both.
+
+A second, sibling defect in the same "unhelpful CLI error" class:
+``reyn chat --connect`` printed a bare "server refused the connection (404)" that
+gave no clue a 404 means the *agent* (defaulting to ``default``) wasn't found, or
+that a 401 is a token problem. ``connect_failure_message`` maps the status to a
+cause-naming, actionable message; those cases are tested below too.
+
+These are Tier-2 (OS/subsystem invariant: the operator-facing failure surface
+resolves the failure) tests of the pure message-selection helpers — no mocks; the
+real ``ImportError`` / ``ModuleNotFoundError`` instances drive the branch.
+"""
+from __future__ import annotations
+
+from reyn.interfaces.install_guard import install_command, missing_dep_message
+from reyn.interfaces.repl.remote_client import connect_failure_message
+
+
+def test_module_not_found_reports_not_installed_with_robust_command():
+    """Tier 2: ModuleNotFoundError(name=package) → 'not installed' + robust cmd."""
+    exc = ModuleNotFoundError("No module named 'fastapi'", name="fastapi")
+    msg = missing_dep_message(exc, "fastapi", "web")
+
+    assert "not installed" in msg
+    # Robust, interpreter-targeted install command with glob-safe quoting.
+    assert "python -m pip install -e '.[web]'" in msg
+    # Real exception text is surfaced (not masked).
+    assert "No module named 'fastapi'" in msg
+
+
+def test_generic_import_error_reports_installed_but_broken():
+    """Tier 2: non-ModuleNotFound ImportError → 'installed but failed to import'."""
+    exc = ImportError("cannot import name 'Foo' from 'fastapi'")
+    msg = missing_dep_message(exc, "fastapi", "web")
+
+    assert "installed but failed to import" in msg
+    # The distinct branch must NOT claim the package is absent.
+    assert "is not installed" not in msg
+    # The real exception text must be visible so a version conflict is diagnosable.
+    assert "cannot import name 'Foo' from 'fastapi'" in msg
+
+
+def test_module_not_found_for_other_module_is_treated_as_broken():
+    """Tier 2: package installed but its own dependency is missing → broken, not absent.
+
+    ``import fastapi`` can raise ModuleNotFoundError whose ``name`` is a
+    *transitive* dependency (fastapi is present but a dep it imports is not).
+    That is an installed-but-broken failure, not 'fastapi is not installed'.
+    """
+    exc = ModuleNotFoundError("No module named 'starlette'", name="starlette")
+    msg = missing_dep_message(exc, "fastapi", "web")
+
+    assert "installed but failed to import" in msg
+    assert "fastapi is not installed" not in msg
+    assert "No module named 'starlette'" in msg
+
+
+def test_install_command_is_interpreter_targeted_and_quoted():
+    """Tier 2: install_command uses `python -m pip` and single-quotes the extra."""
+    cmd = install_command("web")
+    assert cmd == "python -m pip install -e '.[web]'"
+
+
+# ---------------------------------------------------------------------------
+# reyn chat --connect SSE-connect failure message (status-aware)
+# ---------------------------------------------------------------------------
+# A bare "server refused the connection (404)" gave no clue that a 404 means the
+# agent (defaulting to 'default') wasn't found. connect_failure_message names the
+# real cause and the next step per status.
+
+
+def test_connect_404_names_agent_and_discovery_hint():
+    """Tier 2: 404 → names the agent + the /a2a/agents discovery hint."""
+    msg = connect_failure_message(404, "default", "http://127.0.0.1:8080")
+
+    assert "404" in msg
+    assert "default" in msg  # the agent name is surfaced
+    assert "not found" in msg
+    assert "http://127.0.0.1:8080/a2a/agents" in msg  # discovery hint
+
+
+def test_connect_401_mentions_token_auth():
+    """Tier 2: 401 → auth failure naming --token / REYN_WEB_AUTH_TOKEN."""
+    msg = connect_failure_message(401, "default", "http://127.0.0.1:8080")
+
+    assert "401" in msg
+    assert "--token" in msg
+    assert "REYN_WEB_AUTH_TOKEN" in msg
+    # Must not be misreported as an agent-not-found problem.
+    assert "not found" not in msg
+
+
+def test_connect_other_status_includes_code_and_url():
+    """Tier 2: other status → generic message carrying the code + failing URL."""
+    msg = connect_failure_message(503, "default", "http://127.0.0.1:8080")
+
+    assert "503" in msg
+    assert "http://127.0.0.1:8080" in msg


### PR DESCRIPTION
**[per-PR-coder]** — Two "unhelpful CLI error" diagnosability defects a real user hit (spent a long time debugging). Standalone fix, not part of an arc.

## Fix 1 — install-guard messaging (`reyn web`, `reyn chat --connect`)
Two defects in the `[web]`-extra import guards:

1. **Bare `pip install -e ".[web]"` recommendation is fragile.** On setups where `pip` resolves to a different interpreter than the active venv (pyenv shims → global site-packages), the install lands in the wrong environment and the guard keeps saying "not installed". The robust form is **`python -m pip install -e '.[web]'`** — `python -m pip` targets the *running* interpreter, and single-quoting `'.[web]'` stops zsh globbing the extra away.
2. **Every `ImportError` was reported as "not installed,"** masking version-conflict failures (the package IS installed but its import breaks — e.g. a resolved `fastapi`/`starlette` version outside the `[web]` extra's pins).

New pure helper `reyn.interfaces.install_guard.missing_dep_message(exc, package, extra)`:
- `ModuleNotFoundError` whose `.name` is the package → **"X is not installed"** + robust command.
- any other `ImportError` (incl. `ModuleNotFoundError` for a *transitive* dep) → **"X is installed but failed to import: {e}"** + version-conflict hint.
- surfaces the real exception text in **both** branches.

Applied to the `uvicorn` + `fastapi` guards in `cli/commands/web.py` and the `httpx` guard in `repl/remote_client.py`. Also updated the module docstring / argparse help in `web.py` to the robust command for consistency. (Out of scope, left untouched: `chainlit.py` — slated for retirement; `server.py` `[mcp]` / `reyn_src.py` `[dev]` messages — different extras; `tls.py` — no bare-pip pattern.)

## Fix 2 — status-aware `reyn chat --connect` SSE failure (sibling defect, same class)
`reyn chat --connect http://127.0.0.1:8080` (no agent name → client falls back to agent `default`) got a **404** and a bare `Error: server refused the connection (404).` — no clue it was an **agent-not-found** problem.

New pure helper `connect_failure_message(status, agent_name, base_url)`:
- **404** → names the agent + discovery hint: `agent '{agent}' not found on the server (404). List available agents: curl {base_url}/a2a/agents . (…defaults to 'default'.)`
- **401** → `authentication failed (401) — pass --token <secret> …, or set REYN_WEB_AUTH_TOKEN.`
- **other** → generic message carrying the code + failing URL.

**Message only — connect behavior unchanged** (no server-query for the default agent; that's a separate design item the lead is tracking).

## Tests
`tests/test_install_guard_message.py` (Tier 2, no mocks — real `ImportError`/`ModuleNotFoundError` instances):
- `ModuleNotFoundError(name='fastapi')` → message contains "not installed", `python -m pip install -e '.[web]'`, and the exception text.
- generic `ImportError("cannot import name …")` → "installed but failed to import" + exception text, and NOT "is not installed".
- `ModuleNotFoundError(name='starlette')` under package `fastapi` → treated as installed-but-broken (transitive-dep case).
- 404 message names the agent + `/a2a/agents` hint; 401 mentions `--token`/`REYN_WEB_AUTH_TOKEN`; other status carries code + URL.

## Gates (all four, local)
- `ruff check src tests` → clean
- `python scripts/test_tier_audit.py --strict tests/test_install_guard_message.py` → 7 inspected, 0 errors
- `python scripts/verify_module_docstrings.py <changed src>` → OK
- `pytest` (repo root) → new tests pass; the 5 pre-existing route-mount/plugin failures (`test_fp0001_routes_mounted`, `tests/web/{test_a2a,test_mcp_sse,test_plugin_loader,test_resources_router}`) reproduce **identically** on pristine `origin/main` (verified via throwaway worktrees) — zero new.

## Test plan
- [x] Verified helper messages via unit tests (both helpers, all branches).
- [x] Baseline: 5 pre-existing failures confirmed identical on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)