### PR TITLE
docs: sync CLAUDE.md constitution's Retrieval lens with charter.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Every new feature is read through **eight engineering lenses** and must stand on
 ### The eight lenses — each line is the pass-line (a gate for new work)
 1. **System Design** — responsibility sits at the right layer (LLM decides / OS executes / feature owns its domain); no new cross-layer coupling.
 2. **Tool Contract** — every side effect rides a typed, validated envelope (Control IR / a typed op), never an untyped string the LLM free-forms.
-3. **Retrieval** — the right context is delivered deterministically at the right time (`recall` + the preprocessor step), not stuffed unconditionally into the prompt.
+3. **Retrieval** — the right context is delivered deterministically at the right time (`recall` + a pluggable `IndexBackend` a safe-mode Python step can call directly), not stuffed unconditionally into the prompt.
 4. **Reliability** — it recovers from failure (schema-validate + re-prompt, bounded loops with graceful force-close, timeout + opt-in provider-retry); any derived state survives WAL truncation.
 5. **Security** — it is permission-gated and sandbox-scoped; no capability reaches the world without passing the gatekeeper.
 6. **Evaluation** — its output can be scored against a rubric in-run (`judge_output`: LLM scorer + threshold + `on_fail` policy).


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Flagged by lead-coder during a RAG-redesign proposal investigation (independent of the proposal itself, an existing drift): CLAUDE.md's constitution quote for the Retrieval lens still says "`recall` + the preprocessor step" — that machinery was removed in the skill/phase engine bulk-delete (#2438, `d3c8c7a1`). Verified independently: `preprocessor_executor.py` no longer exists anywhere in `src/` (only stale `.pyc` caches remain), and `docs/concepts/architecture/charter.md:64`'s Retrieval row already reflects the current mechanism — `recall` + a pluggable `IndexBackend` a safe-mode Python step calls directly (`embed_and_index()`).

Syncs CLAUDE.md's one-liner to match charter.md's already-current wording. No other "preprocessor" mentions remain in CLAUDE.md.

## Test plan
- [x] Verified `preprocessor_executor.py` absent from `src/` (only `__pycache__/*.pyc` remnants)
- [x] Verified `d3c8c7a1` / #2438 is the removal commit
- [x] Verified `charter.md:64`'s current wording before copying it
- [x] `grep -n "preprocessor" CLAUDE.md` — no other stale mentions

🤖 Generated with [Claude Code](https://claude.com/claude-code)