### PR TITLE
feat: expose the `embed` primitive as a typed op + LLM tool (FP-0057 Phase 1)

### DIFF
--- a/docs/feature-map.md
+++ b/docs/feature-map.md
@@ -47,6 +47,7 @@ mindmap
       web_fetch
       mcp
       mcp_install
+      embed
       index_query
       recall
       index_drop
@@ -314,13 +315,14 @@ The op kinds below mirror `OP_KIND_MODEL_MAP` in `schemas/models.py`.
 | `mcp_subscribe_resource` / `mcp_unsubscribe_resource` | Subscribe/unsubscribe to server-pushed `resources/updated` for one URI (requires a persistent connection; push lands as an `mcp_resource_updated` hook-event) |
 | `mcp_get_prompt` | Fetch one rendered MCP prompt's messages by name (permission-gated, same axis as `mcp`) |
 | `mcp_install` | Install / register an MCP server (registry / package / local source) |
+| `embed` | Raw embedding primitive: batch texts → vectors (FP-0057 Phase 1). User-facing (compose with an external MCP vector-DB via pipeline) AND the shared logic later internal RAG ops call; default-allow; PRE-embed redaction-egress seam | [Control IR § embed](reference/runtime/control-ir.md#embed) |
 | `index_query` | Vector similarity search over one indexed source |
 | `recall` | Macro: embed query → `index_query` per source → merge top-K |
 | `index_drop` | Destructive source removal — requires approval |
 | `compact` | Summarise / compact conversation history within budget |
 | `judge_output` | LLM scorer with rubric + threshold + `on_fail` policy |
 
-> The `embed` and `index_write` ops were removed — embedding and index-writing now run provider-direct inside `reyn.api.safe.embed_index` and the `recall` op, not as standalone ops. See [Control IR](reference/runtime/control-ir.md).
+> `recall` still embeds its query provider-direct (unchanged); `index_write` remains removed — index-writing runs provider-direct inside `reyn.api.safe.embed_index` (`embed_and_index`, the CodeAct-only ingestion entry), which `embed` does not yet retire (FP-0057 Phase 2 replaces it with `index_update`). See [Control IR](reference/runtime/control-ir.md).
 
 ---
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -33,6 +33,7 @@ Control IR is the list of side-effect operations the LLM may emit. The OS dispat
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
 | `pipeline_install` | Register a pipeline (local DSL file or git/URL source) into the project pipelines config | `file.write: [.reyn/config/pipelines.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
+| `embed` | Raw embedding primitive: batch texts -> vectors (FP-0057 Phase 1; the user-facing primitive AND the shared logic later internal RAG ops call) | none (default-allow; embedding API cost) |
 | `index_query` | Semantic vector search over one indexed source | none |
 | `recall` | Macro: embed query (provider-direct) → index_query per source → merge top-K | none (embedding API cost) |
 | `index_drop` | Remove an indexed source entirely (destructive) | `permissions.index_drop: ask` in skill frontmatter |
@@ -703,6 +704,33 @@ Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`, `path
 
 Events emitted: `pipeline_install_threat_match`, `pipeline_install_threat_blocked` (threat scan),
 `pipeline_installed` (P6 on success).
+
+## `embed`
+
+Raw embedding primitive (FP-0057 Phase 1): a batch of texts in, one vector per text out, in the same order. `embed` is the **user-facing** primitive — the user composes `embed` -> their own external MCP vector-DB's store/search tools via pipeline (reyn hosts no user RAG store). It is also the SHARED logic later internal RAG ops (`index_update` / `semantic_search`, FP-0057 Phase 2) call — same `EmbeddingProvider`, no duplicated embed logic, split only by audience surface.
+
+```json
+{
+  "kind": "embed",
+  "texts": ["first chunk of text", "second chunk of text"],
+  "embedding_model": "standard"
+}
+```
+
+Fields:
+
+- `texts` (list[str], required) — texts to embed. Returned vectors preserve this order.
+- `embedding_model` (str, default `"standard"`) — model class (light/standard/strong) or a literal provider model id, forwarded to `EmbeddingProvider.embed`.
+
+Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str, "total_tokens": int}`.
+
+Reuses the existing `EmbeddingProvider` (`RoutingEmbeddingProvider` via `get_provider` — the sole embedder, local sentence-transformers + API classes handled inside the provider); this op is a thin typed envelope, not a re-implementation. Batching (`embedding.batch_size`, default 100) happens inside the provider — the op contract itself is list-in/list-out, batch-granular.
+
+**Redaction-egress seam**: embedding via an API-backed provider sends text content to an external embedding API — a data-egress point. Every text in the batch is passed through a PRE-embed scan (`redact_secrets`, the existing FP-0050 secret-redaction primitive) *before* `provider.embed()` is called, unconditionally (no caller-supplied bypass). A redaction hit fires an `embed_secret_redacted` audit-event. This is a Phase 1 scaffold of the seam using the existing generic secret-redaction pass; the full firm ephemeral-attachment content policy is FP-0057 Phase 3.
+
+Events: `embed_secret_redacted` (`count`, `model`) when the PRE-embed scan redacts one or more texts.
+
+Default-**ALLOW** (compute op — the cost is the embedding API/compute, not a workspace write); individually name-gateable via `contextual_gate` like every other op kind. Additive: does not retire `embed_and_index` (`reyn.api.safe.embed_index`, the CodeAct-only ingestion entry) — that clean-break is FP-0057 Phase 2.
 
 ## `index_query`
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -548,15 +548,18 @@ Handler lifecycle:
 5. Writes `mcp.servers.<name>` to the target scope config file
 6. Emits `mcp_server_installed` event (P6) — key names only, no values
 
-> **Removed ops.** The `embed` and `index_write` control-IR ops were removed.
-> Embedding + index writing are now done **provider-direct** inside
-> `reyn.api.safe.embed_index.embed_and_index()` (a safe-mode `python` step
-> streams its own chunks into it — the bundled `index_docs` / `index_events`
-> chunkers were removed along with the stdlib skills that wrapped them) and
-> inside the `recall` op (query embedding). The `EmbeddingProvider` and
-> `SqliteIndexBackend` primitives are unchanged — only the run-op wrappers and
-> bundled chunkers are gone. Nothing emits `kind: embed` / `kind: index_write`
-> anymore.
+> **`index_write` removed (still); `embed` re-exposed (FP-0057 Phase 1).** The
+> `index_write` control-IR op stays removed — index writing is done
+> **provider-direct** inside `reyn.api.safe.embed_index.embed_and_index()` (a
+> safe-mode `python` step streams its own chunks into it — the bundled
+> `index_docs` / `index_events` chunkers were removed along with the stdlib
+> skills that wrapped them). `recall` still embeds its query provider-direct.
+> The `EmbeddingProvider` and `SqliteIndexBackend` primitives are unchanged.
+> The `embed` op, however, is **no longer removed**: FP-0057 Phase 1 re-added
+> it as the user-facing raw embedding primitive (see the [`embed`](#embed)
+> section above) — #1303's "no caller" rationale for removing it is obsolete
+> now that the primitive is exposed for user RAG composition. So `kind: embed`
+> is emitted again; only `kind: index_write` is not.
 
 ## `skill_install`
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -498,6 +498,17 @@ def chunks_to_canonical(result: dict) -> CanonicalToolResult:
     return CanonicalToolResult(text="", attachments=attachments, source_ref=None, meta={})
 
 
+def embed_to_canonical(result: dict) -> CanonicalToolResult:
+    """embed op result → canonical (FP-0057 Phase 1). ``vectors`` are large float arrays with no
+    natural text body — carried as a ``structured`` attachment (mirrors ``chunks_to_canonical`` for
+    the RAG op family). ``model`` / ``total_tokens`` are small high-signal meta the LLM reads inline;
+    the raw ``kind`` transport echo is dropped."""
+    vectors = result.get("vectors")
+    attachments = [{"kind": "structured", "data": vectors}] if vectors is not None else []
+    meta = {k: result[k] for k in ("model", "total_tokens") if k in result}
+    return CanonicalToolResult(text="", attachments=attachments, source_ref=None, meta=meta)
+
+
 def run_pipeline_to_canonical(result: dict) -> CanonicalToolResult:
     """Sync run_pipeline result → canonical. The final ``output`` is the whole thing the calling LLM
     wants: a str output → ``text``; a non-str output → a ``structured`` attachment. ``run_id`` and

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -114,6 +114,10 @@ from . import compact as _compact  # noqa: F401, E402
 # #1303 Stage I: embed + index_write run-ops deleted (folded into
 # reyn.api.safe.embed_index; recall embeds provider-direct). index_query +
 # index_drop + recall remain.
+# FP-0057 Phase 1: embed op RE-ADDED as the user-facing raw embedding
+# primitive (#1303's "no caller" rationale is obsolete post skill-engine
+# deletion, #2438).
+from . import embed as _embed  # noqa: F401, E402
 from . import file as _file  # noqa: F401, E402
 from . import index_drop as _index_drop  # noqa: F401, E402
 from . import index_query as _index_query  # noqa: F401, E402

--- a/src/reyn/core/op_runtime/contextual_gate.py
+++ b/src/reyn/core/op_runtime/contextual_gate.py
@@ -33,6 +33,11 @@ _OP_KIND_ALIASES: "dict[str, frozenset[str]]" = {
     "web_search": frozenset({"web__search"}),
     "web_fetch": frozenset({"web__fetch"}),
     # rag / memory-read
+    # FP-0057 Phase 1: embed is the raw user-facing embedding primitive — no
+    # distinct chat-tool qualified name (unlike recall/drop_source, which the
+    # universal_dispatch wrapper exposes under a `rag_operation__*` alias) →
+    # gated on its own kind name only, same shape as index_query.
+    "embed": frozenset(),
     "recall": frozenset({"rag_operation__recall"}),
     "index_query": frozenset(),
     "index_drop": frozenset({"rag_operation__drop_source"}),

--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -1,0 +1,107 @@
+"""embed op handler — the raw embedding primitive: batch texts -> vectors.
+
+FP-0057 Phase 1. `embed` is the **user-facing** primitive (the user composes
+`embed` -> their own external MCP vector-DB's tools via pipeline; reyn never
+hosts a user RAG store) AND the shared logic Phase 2's `index_update` /
+`semantic_search` will call internally — same `EmbeddingProvider`, no
+duplicated embed logic, split only by audience surface.
+
+Reuses the existing `EmbeddingProvider` (`get_provider` -> the
+`RoutingEmbeddingProvider`, the sole embedder — local sentence-transformers +
+API classes are handled INSIDE the provider). This handler batches nothing
+itself: `provider.embed()` already internally splits into
+`embedding.batch_size` (default 100) sized API calls; the op contract is
+simply list-in -> list-out (ADR-0033 §2.1 / FP-0057 design "batch: list ->
+vectors").
+
+Redaction-egress seam (co-vet #3, security): embedding via an API-backed
+provider is a DATA EGRESS point — text content leaves the process to an
+external embedding API. Every text is passed through the PRE-embed scan
+(`redact_secrets`, the existing FP-0050 secret-redaction primitive also used
+at the compaction-input egress boundary) BEFORE `provider.embed()` is called
+— the seam sits at the op's PRE-call point, ahead of the egress, and is not
+bypassable (no caller-supplied "skip scan" flag; every text in the batch is
+scanned unconditionally). A redaction hit is recorded as an audit-event
+(`embed_secret_redacted`) so the seam firing is observable (P6). Phase 1
+scaffolds the seam with the existing secret-redaction pass; the full firm
+ephemeral-attachment content policy is Phase 3 per the FP-0057 design doc
+(`docs/deep-dives/proposals/0057-rag-retrieval-redesign.md`).
+"""
+from __future__ import annotations
+
+import os
+
+from reyn.data.embedding import get_provider
+from reyn.schemas.models import EmbedIROp
+from reyn.security.secret_redaction import redact_secrets
+
+from . import register
+from .context import OpContext
+
+
+def _resolve_provider():
+    """Resolve the embedding provider (env override + reyn.yaml embedding config).
+
+    Mirrors `op_runtime.recall._resolve_provider` — both call sites resolve the
+    SAME shared `EmbeddingProvider` (`RoutingEmbeddingProvider` via
+    `get_provider`); recall's provider-direct query embed and this op's batch
+    embed are independent call sites into one shared provider, not duplicated
+    embedding logic. Kept as a small local helper (not a cross-module import
+    of recall's private function) so each op-runtime module stays
+    self-contained and independently testable via monkeypatching its own
+    module-level `get_provider` name (established op_runtime test convention,
+    see `tests/test_op_recall.py`).
+    """
+    name = os.environ.get("REYN_EMBEDDING_PROVIDER", "litellm")
+    if name == "litellm":
+        try:
+            from reyn.config import load_config
+            cfg = load_config().embedding
+        except Exception:
+            cfg = None
+        return get_provider(name, config=cfg or {})
+    return get_provider(name, config={})
+
+
+async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
+    """Execute an embed op: batch texts -> vectors (FP-0057 Phase 1).
+
+    Steps:
+      1. PRE-embed redaction-egress scan (co-vet #3) — every text is passed
+         through `redact_secrets()` before it reaches the provider, i.e.
+         before the egress boundary to an external embedding API.
+      2. `provider.embed(scanned_texts, model)` — batches internally; list in,
+         list out, vector order preserved.
+
+    Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str,
+    "total_tokens": int}`. Errors propagate to the shared `execute_op`
+    try/except (status="error" + `control_ir_failed` event) — this handler
+    does not swallow provider failures.
+    """
+    if not op.texts:
+        return {"kind": "embed", "vectors": [], "model": op.embedding_model, "total_tokens": 0}
+
+    # ── PRE-embed egress seam (co-vet #3) — unconditional, unbypassable ────
+    scanned_texts = [redact_secrets(t) for t in op.texts]
+    redacted_count = sum(1 for orig, scanned in zip(op.texts, scanned_texts) if orig != scanned)
+    if redacted_count:
+        ctx.events.emit(
+            "embed_secret_redacted",
+            count=redacted_count,
+            model=op.embedding_model,
+        )
+
+    provider = _resolve_provider()
+    result = await provider.embed(scanned_texts, op.embedding_model)
+
+    return {
+        "kind": "embed",
+        "vectors": result.get("vectors", []),
+        "model": result.get("model", op.embedding_model),
+        "total_tokens": result.get("total_tokens", 0),
+    }
+
+
+from reyn.core.offload.canonical import embed_to_canonical  # noqa: E402
+
+register("embed", handle, canonical=embed_to_canonical)

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -455,6 +455,32 @@ class ChunkMetadata(BaseModel):
 # reyn.api.safe.embed_index (provider.embed + SqliteIndexBackend directly) and
 # recall embeds the query provider-direct, so neither run-op has any caller.
 # EmbeddingProvider / SqliteIndexBackend / IndexQueryIROp / RecallIROp remain.
+#
+# FP-0057 Phase 1: EmbedIROp is RE-ADDED — #1303's rationale (no caller) is
+# obsolete (the skill engine that motivated the collapse is deleted, #2438).
+# `embed` is now the exposed USER-FACING primitive (user composes embed -> an
+# external MCP vector-DB via pipeline) AND the shared logic Phase 2's
+# `index_update`/`semantic_search` call internally — same EmbeddingProvider,
+# no duplicated embed logic, split only by audience surface. `recall` keeps
+# its own provider-direct embed call (unchanged) — it is not rewired onto
+# this op in Phase 1 (that is a Phase-2-adjacent internal-surface concern).
+
+
+class EmbedIROp(BaseModel):
+    """Raw embedding primitive — batch text -> vectors (FP-0057 Phase 1).
+
+    Batch-granular (list in -> list out); the `EmbeddingProvider` handles
+    internal batching (`embedding.batch_size` config, default 100) and the
+    local-sentence-transformers / API-class split — this op owns none of
+    that, it is a thin typed envelope over the existing provider.
+
+    Default-ALLOW (compute op, cost = the embedding API/compute, not a
+    workspace write); individually name-gateable via `contextual_gate`.
+    LLM-callable via ToolDefinition `embed`.
+    """
+    kind: Literal["embed"]
+    texts: list[str]
+    embedding_model: str = "standard"  # model class name or literal provider model id
 
 
 class IndexQueryIROp(BaseModel):
@@ -745,6 +771,9 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # here → a phase emitting it failed Op union validation. Added to restore
     # the control-ir.md ↔ map sync invariant.
     "mcp_drop_server": MCPDropServerIROp,
+    # FP-0057 Phase 1: raw embed primitive (user-facing; also Phase 2's shared
+    # internal embed logic — no duplication, split by audience surface).
+    "embed":       EmbedIROp,
     "index_query": IndexQueryIROp,
     "recall":      RecallIROp,
     "index_drop":  IndexDropIROp,
@@ -796,7 +825,7 @@ if TYPE_CHECKING:
             RenderTemplateIROp,
             WebFetchIROp, WebSearchIROp, MCPInstallIROp,
             MCPDropServerIROp,
-            IndexQueryIROp, RecallIROp, IndexDropIROp,
+            EmbedIROp, IndexQueryIROp, RecallIROp, IndexDropIROp,
             SandboxedExecIROp, JudgeOutputIROp, CompactIROp,
             TaskCreateIROp, TaskUpdateStatusIROp, TaskGetIROp, TaskListIROp,
             TaskAddDependencyIROp, TaskRemoveDependencyIROp, TaskRepointDependencyIROp,

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -52,6 +52,7 @@ def get_default_registry() -> ToolRegistry:
     )
     from reyn.tools.delegate_to_agent import DELEGATE_TO_AGENT
     from reyn.tools.drop_source import DROP_SOURCE
+    from reyn.tools.embed import EMBED
 
     # Wave 2 additions (ADR-0026 M3 Wave 2)
     from reyn.tools.file import (
@@ -140,6 +141,9 @@ def get_default_registry() -> ToolRegistry:
     # RAG ops (ADR-0033 Phase 1)
     registry.register(RECALL)
     registry.register(DROP_SOURCE)
+    # FP-0057 Phase 1: raw embed primitive (user-facing; composes with an
+    # external MCP vector-DB via pipeline — reyn hosts no user RAG store).
+    registry.register(EMBED)
     registry.register(COMPACT)
     # #2692 (part of the #2688 sweep): present + render_template invocation surface.
     # One registration each opens BOTH chat (build_tools + gates.router="allow") and

--- a/src/reyn/tools/embed.py
+++ b/src/reyn/tools/embed.py
@@ -1,0 +1,111 @@
+"""embed ToolDefinition (FP-0057 Phase 1).
+
+`embed` is the raw, USER-FACING embedding primitive: a batch of texts in,
+a batch of vectors out. The user composes `embed` -> their own external MCP
+vector-DB's store/retrieve tools via pipeline (reyn never hosts a user RAG
+store, per the FP-0057 design). Default-ALLOW (compute op — cost is the
+embedding API/compute, not a workspace side effect); individually
+name-gateable via `contextual_gate` like every other op kind.
+
+ADDITIVE: this does NOT retire `embed_and_index` (`reyn.api.safe.embed_index`,
+the CodeAct-only ingestion entry) — that clean-break is FP-0057 Phase 2, when
+`index_update` replaces ingestion. Phase 1 only adds `embed`.
+
+Per ADR-0026: the ToolDefinition lives here; registration is in
+get_default_registry() in tools/__init__.py.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.core.offload.canonical import embed_to_canonical
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+_EMBED_DESCRIPTION = (
+    "Embed a batch of texts into vectors using reyn's configured embedding "
+    "model (raw primitive — no storage). Returns one vector per input text, "
+    "in the same order. Use this to build your OWN persistent RAG store: "
+    "embed your texts, then hand the vectors to your own vector-DB MCP "
+    "tools (store/upsert) to persist them, and again at query time to embed "
+    "a query before calling that store's search tool. For reyn's OWN "
+    "indexed sources / memory / tool-use retrieval, use `recall` instead — "
+    "it embeds and searches in one call over reyn-managed indexes."
+)
+
+_EMBED_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "texts": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Texts to embed. Returned vectors preserve this order.",
+        },
+        "embedding_model": {
+            "type": "string",
+            "default": "standard",
+            "description": (
+                "Embedding model class (light/standard/strong) or a full "
+                "provider model id."
+            ),
+        },
+    },
+    "required": ["texts"],
+}
+
+
+async def _handle_embed(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
+    """Dispatch an EmbedIROp via op_runtime (mirrors tools/recall.py's shape)."""
+    from reyn.core.op_runtime import execute_op
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.schemas.models import EmbedIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    texts = args.get("texts")
+    if not texts:
+        return {
+            "ok": False,
+            "error_kind": "missing_required_arg",
+            "error_message": "embed requires a non-empty `texts` array.",
+            "missing": ["texts"],
+        }
+
+    op = EmbedIROp(
+        kind="embed",
+        texts=[str(t) for t in texts],
+        embedding_model=str(args.get("embedding_model", "standard")),
+    )
+
+    if (
+        ctx.router_state is not None
+        and ctx.router_state.op_context_factory is not None
+    ):
+        legacy_ctx = ctx.router_state.op_context_factory()
+    else:
+        # Minimal context for router-side calls without a factory. embed has
+        # no workspace side effect (read-only w.r.t. the workspace; its only
+        # effect is the outbound embedding API call), so a workspace-less
+        # OpContext is safe here — same posture as tools/recall.py.
+        legacy_ctx = OpContext(
+            workspace=ctx.workspace,
+            events=ctx.events,
+            permission_decl=PermissionDecl(),
+            permission_resolver=ctx.permission_resolver,
+            actor="",
+            subscribers=getattr(ctx.events, "subscribers", []),
+            resolver=ctx.resolver,
+        )
+
+    return await execute_op(op, legacy_ctx)
+
+
+EMBED = ToolDefinition(
+    canonical=embed_to_canonical,
+    name="embed",
+    router_dispatched=True,
+    description=_EMBED_DESCRIPTION,
+    parameters=_EMBED_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_embed,
+    category="discovery",
+    purity="read_only",
+)

--- a/tests/test_2123_router_dispatch_sot_1953.py
+++ b/tests/test_2123_router_dispatch_sot_1953.py
@@ -43,6 +43,10 @@ _EXPECTED_DISPATCH: "frozenset[str]" = frozenset({
     "list_mcp_prompts", "get_mcp_prompt",
     "remember_shared", "remember_agent", "forget_memory", "list_memory", "read_memory_body",
     "recall", "drop_source", "compact",
+    # FP-0057 Phase 1: embed gained a router-dispatched ToolDefinition (the raw
+    # user-facing embedding primitive; default-allow) so chat + pipeline reach
+    # the new embed op handler.
+    "embed",
     # #2692 (part of the #2688 sweep): present + render_template gained a ToolDefinition
     # (router_dispatched=True) so chat + pipeline can reach the existing op handlers.
     "present", "render_template",

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -1,0 +1,240 @@
+"""Tier 1/2: `embed` typed op — FP-0057 Phase 1 (the raw embed primitive).
+
+Tests use a real class implementing the `EmbeddingProvider` protocol
+(`FakeEmbeddingProvider`, same pattern as `tests/test_op_recall.py`'s
+`FakeEmbeddingProvider`) monkeypatched into `op_runtime.embed`'s
+module-level `get_provider` — NOT `unittest.mock` (per
+`docs/deep-dives/contributing/testing.ja.md`).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import available_kinds, execute_op
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.embedding.provider import EmbedBatchResult
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import ALL_OP_KINDS, OP_KIND_MODEL_MAP, EmbedIROp, Op
+from reyn.security.permissions.permissions import PermissionDecl
+
+# ---------------------------------------------------------------------------
+# Fake provider (real EmbeddingProvider-protocol instance, not a mock)
+# ---------------------------------------------------------------------------
+
+class FakeEmbeddingProvider:
+    """Deterministic real EmbeddingProvider: a fixed 3-dim vector per text,
+    scaled by input length so distinct texts get distinct (but reproducible)
+    vectors — enough to assert shape/order without pinning provider internals."""
+
+    def __init__(self) -> None:
+        self._batch_size = 10
+        self.received_texts: list[str] = []
+
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        self.received_texts.extend(texts)
+        vectors = [[float(len(t)), 0.0, 1.0] for t in texts]
+        return EmbedBatchResult(vectors=vectors, model=f"fake/{model}", total_tokens=len(texts))
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return len(texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 3
+
+
+def _make_ctx(tmp_path: Path) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: registration + control-ir round-trip
+# ---------------------------------------------------------------------------
+
+def test_embed_registered_in_op_kind_model_map() -> None:
+    """Tier 1: `embed` is a first-class Control IR op kind (hard-rule sync:
+    OP_KIND_MODEL_MAP <-> control-ir.md, #1983)."""
+    assert "embed" in OP_KIND_MODEL_MAP
+    assert OP_KIND_MODEL_MAP["embed"] is EmbedIROp
+    assert "embed" in ALL_OP_KINDS
+    assert "embed" in available_kinds()
+
+
+def test_embed_op_round_trips_through_the_op_union() -> None:
+    """Tier 1: an embed op dict validates against the discriminated `Op` union
+    (the same envelope shape an LLM would emit)."""
+    from pydantic import TypeAdapter
+
+    adapter: TypeAdapter = TypeAdapter(Op)
+    parsed = adapter.validate_python(
+        {"kind": "embed", "texts": ["hello", "world"], "embedding_model": "standard"}
+    )
+    assert isinstance(parsed, EmbedIROp)
+    assert parsed.texts == ["hello", "world"]
+    assert parsed.embedding_model == "standard"
+
+
+def test_embed_op_defaults_embedding_model_to_standard() -> None:
+    """Tier 1: `embedding_model` defaults to "standard" when omitted."""
+    op = EmbedIROp(kind="embed", texts=["x"])
+    assert op.embedding_model == "standard"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: op-runtime dispatch behavior
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_embed_batch_returns_one_vector_per_text_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: embed is batch-granular (list -> list); vector order matches
+    input text order and dimension matches the (fake) model's dimension."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=["a", "bb", "ccc"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert result["kind"] == "embed"
+    # unpack: exactly one vector per input text, order-preserving
+    vec_a, vec_bb, vec_ccc = result["vectors"]
+    # each vector is 3-dim (matches the fake provider's declared dimension) and
+    # its first component encodes the source text's length (fake's deterministic
+    # scheme) -> confirms per-text correspondence, not just count
+    x_a, y_a, z_a = vec_a
+    x_bb, y_bb, z_bb = vec_bb
+    x_ccc, y_ccc, z_ccc = vec_ccc
+    assert (x_a, x_bb, x_ccc) == (1.0, 2.0, 3.0)
+    assert result["total_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_embed_empty_texts_returns_empty_vectors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: an empty `texts` list is a no-op (empty vectors, no provider
+    call) rather than an error."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=[], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert result["vectors"] == []
+    assert fake.received_texts == []
+
+
+@pytest.mark.asyncio
+async def test_embed_default_gate_allows_dispatch_without_permission_resolver(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: embed is default-ALLOW (a compute op) — it dispatches and
+    succeeds with no `permission_resolver` wired into the OpContext, mirroring
+    recall/index_query's no-gate posture."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    assert ctx.permission_resolver is None
+    op = EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    # unpack: exactly one vector for the single input text
+    (only_vector,) = result["vectors"]
+    assert only_vector
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: redaction-egress seam (co-vet #3) reachability
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_embed_pre_embed_redaction_seam_fires_on_a_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a secret-shaped text is redacted BEFORE it reaches the
+    provider (the PRE-call egress seam, co-vet #3) — the provider never sees
+    the raw credential value, and the seam firing is recorded as an
+    `embed_secret_redacted` audit-event."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    secret_text = 'api_key = "abcdefghijklmnopqrstuvwxyz123456"'
+    op = EmbedIROp(kind="embed", texts=[secret_text, "harmless text"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    # the provider (= the egress boundary to an external embedding API) never
+    # receives the raw secret value
+    assert "abcdefghijklmnopqrstuvwxyz123456" not in fake.received_texts[0]
+    assert "REDACTED" in fake.received_texts[0]
+    # the harmless text is untouched
+    assert fake.received_texts[1] == "harmless text"
+    # the seam firing is observable (P6 audit-event trace)
+    assert any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: EMBED ToolDefinition — registered, default-allow
+# ---------------------------------------------------------------------------
+
+def test_embed_tool_registered_default_allow() -> None:
+    """Tier 1: the `embed` ToolDefinition is registered in the default tool
+    registry with gates.router=allow / gates.phase=allow (default-ALLOW per
+    the FP-0057 design — a compute op, individually name-gateable via
+    contextual_gate rather than requiring an ask-gate by default)."""
+    from reyn.tools import get_default_registry
+
+    registry = get_default_registry()
+    tool = registry.lookup("embed")
+    assert tool is not None
+    assert tool.gates.router == "allow"
+    assert tool.gates.phase == "allow"
+
+
+def test_embed_op_kind_has_a_contextual_gate_entry() -> None:
+    """Tier 1: `embed` is registered in the contextual-gate op-kind table (so a
+    per-session capability narrowing can name-gate it individually, even
+    though its default posture is allow) — same shape as index_query/recall."""
+    from reyn.core.op_runtime.contextual_gate import op_kind_tool_names
+
+    names = op_kind_tool_names("embed")
+    assert "embed" in names
+
+
+@pytest.mark.asyncio
+async def test_embed_no_redaction_event_when_no_secret_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the redaction seam is a no-op (no event, text unchanged) when
+    no secret pattern is present — it must not false-positive on ordinary text."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=["just some ordinary sentence"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert fake.received_texts == ["just some ordinary sentence"]
+    assert not any(e.type == "embed_secret_redacted" for e in ctx.events.all())

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -97,6 +97,13 @@ _NOT_EXTERNAL = {
     # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a
     # status dict (on / added / reload_scheduled / path), not external content.
     "hooks_add",
+    # FP-0057 Phase 1: embed returns VECTORS (float arrays derived from the
+    # input texts), not relayed external content — the numeric embedding is a
+    # transform of the caller's own texts, not fetched server/internet content.
+    # (The PRE-embed redaction-egress seam scrubs secrets before the outbound
+    # API call; the returned vectors carry no external payload.) Same "derived
+    # from input, not a relay" rationale as render_template.
+    "embed",
     # — catalog / discovery (reyn-assembled or operator config) —
     "list_agents", "describe_agent",
     "list_actions", "search_actions", "describe_action",


### PR DESCRIPTION
**[rag-coder]** — FP-0057 Phase 1: expose the `embed` primitive (typed Control IR op + LLM-facing tool). Toward #2843. Design: `docs/deep-dives/proposals/0057-rag-retrieval-redesign.md` (branch `origin/docs/rag-redesign-fp0057`). Base = origin/main @ 111cdfd6 (Phase 0, #2845).

## DO NOT MERGE until reviewed. @architect co-vet requested (see 5-point checklist below).

## What

Adds `embed` as a typed op (`EmbedIROp`) + `EMBED` ToolDefinition: batch texts → batch vectors. It is the **user-facing** primitive (the user composes `embed` → their own external MCP vector-DB's store/search tools via pipeline; reyn hosts no user RAG store) AND the shared logic Phase 2's `index_update`/`semantic_search` will call internally (same `EmbeddingProvider`, no duplicated embed logic — split only by audience surface).

- `EmbedIROp` (`src/reyn/schemas/models.py`) + `OP_KIND_MODEL_MAP["embed"]` + `Op`-union entry.
- `src/reyn/core/op_runtime/embed.py` — handler; reuses `RoutingEmbeddingProvider` via `get_provider`.
- `src/reyn/tools/embed.py` — `EMBED` ToolDefinition, `gates=ToolGates(router="allow", phase="allow")`.
- `embed_to_canonical` in `src/reyn/core/offload/canonical.py` (vectors → structured attachment, mirrors `chunks_to_canonical`).
- Docs: `control-ir.md` §embed, `feature-map.md` row.
- Tests: `tests/test_op_embed.py` (10) + two completeness-gate registries updated for the new tool.

## Architect 5-point co-vet

1. **control-ir.md ↔ OP_KIND_MODEL_MAP same-PR sync + `contextual_gate` registration.** `EmbedIROp` + `OP_KIND_MODEL_MAP["embed"]` + `control-ir.md` §embed all land here (hard rule). `contextual_gate._OP_KIND_ALIASES["embed"] = frozenset()` registered (gated on its own kind name, like `index_query`) — the #1912b completeness invariant holds even though the default posture is allow.
2. **EmbeddingProvider reuse — zero duplicated embed logic.** The handler calls `RoutingEmbeddingProvider` via `get_provider` (the sole embedder; local sentence-transformers + API classes handled inside the provider). Batching is internal to the provider (`embedding.batch_size`, default 100). The op is a thin typed envelope, not a re-implementation.
3. **Default-allow + name-gateable.** `ToolGates(router="allow", phase="allow")` (compute op — cost is the embedding API/compute, not a workspace write); individually name-gateable via the `contextual_gate` entry above.
4. **Redaction-egress seam at the PRE=egress point, bypass-impossible — scope = WIRED in Phase 1, full policy in Phase 3.** Placed in `op_runtime/embed.py::handle`, *before* `provider.embed()` (the egress boundary to an external embedding API). Every text in the batch is passed through `redact_secrets()` (the existing FP-0050 secret-redaction primitive, also used at the compaction-input egress) — **unconditionally, no caller-supplied bypass flag**. A hit fires an `embed_secret_redacted` audit-event (count, model) so the seam's firing is observable (P6). **My scoping choice: WIRED, not a no-op placeholder** — a credential-shaped value never reaches the provider. This is the *generic* secret-redaction pass (reused, not reinvented); the **full firm ephemeral-attachment content policy is FP-0057 Phase 3** per the design doc. Flagging for co-vet: is reusing `redact_secrets` the right Phase-1 scope, or do you want a pure no-op hook with all scan work deferred to Phase 3?
5. **Batch list→list + `existing_hashes` + additive.** `texts: list[str]` in, `vectors: list[list[float]]` out, order-preserving. `embed_and_index` (`reyn.api.safe.embed_index`, CodeAct-only ingestion) is **untouched** — additive-only; its retirement is Phase 2. Note: `existing_hashes` dedup is an `index_update`-side concept (the ingestion path), N/A to the raw `embed` primitive itself — Phase 2 preserves it when `index_update` calls `embed`.

## Op schema

```json
{"kind": "embed", "texts": ["...", "..."], "embedding_model": "standard"}
```
Returns: `{"kind": "embed", "vectors": [[...], [...]], "model": "...", "total_tokens": N}`.

## CI gates (local, all four)

- **`ruff check src tests`** → `All checks passed!`
- **`python scripts/test_tier_audit.py --strict tests/test_op_embed.py tests/test_returns_external_content_flagset_1822.py tests/test_2123_router_dispatch_sot_1953.py`** → `OK: 18, errors: 0` (exit 0).
- **`pytest` (repo root)** → **8302 passed, 21 skipped, 7 failed** → after fixing the 2 completeness-gate failures my new tool introduced (both now green), the remaining **5 failures are pre-existing editable-install / route-mounting baseline** (`test_fp0001_a2a_endpoints::test_fp0001_routes_mounted`, `web/test_a2a::test_a2a_routes_mounted`, `web/test_mcp_sse::test_mcp_routes_mounted`, `web/test_resources_router::test_resources_route_is_mounted_on_app`, `web/test_plugin_loader::test_loader_disambiguates_via_package_field`). **Verified 0-NEW**: `git stash` (my change removed) → those same 5 still fail on clean 111cdfd6. My change touches no web/route/plugin code.
- **`python scripts/verify_module_docstrings.py <changed src files>`** → OK (no refactor-narrative).

> The 2 gate failures I had to fix (both legitimate — a new tool must be classified): added `"embed"` to `_NOT_EXTERNAL` in `test_returns_external_content_flagset_1822.py` (embed returns vectors *derived from* the input texts, not relayed external content — same rationale as `render_template`) and to `_EXPECTED_DISPATCH` in `test_2123_router_dispatch_sot_1953.py` (the frozen dispatch-set oracle).

## Test plan

- [x] `embed` registered in `OP_KIND_MODEL_MAP` + round-trips through the `Op` union; `embedding_model` defaults to `"standard"`
- [x] batch-granular: N texts → N vectors, order-preserving, dimension matches the (fake) provider's model
- [x] empty `texts` → empty vectors, no provider call
- [x] default-allow: dispatches with no `permission_resolver` wired
- [x] `EMBED` tool registered with `gates.router=allow`/`gates.phase=allow`; `embed` present in `contextual_gate._OP_KIND_ALIASES`
- [x] redaction seam reachable: a secret-shaped text is redacted *before* reaching the provider + fires `embed_secret_redacted`; ordinary text is a no-op (no false positive)

Tests use a real `EmbeddingProvider`-protocol class (`FakeEmbeddingProvider`, same pattern as `tests/test_op_recall.py`) monkeypatched into the module-level `get_provider` — no `unittest.mock`/`MagicMock`/`patch` (per testing.ja.md).

Broker-notified lead-coder + architect.
