### PR TITLE
test: retire 5 stale route-mount baseline tests (app.routes literal-path pins → behavioral)

### DIFF
--- a/tests/test_fp0001_a2a_endpoints.py
+++ b/tests/test_fp0001_a2a_endpoints.py
@@ -526,18 +526,16 @@ def test_async_mode_with_unknown_agent_returns_internal_error(tmp_path) -> None:
 # ---------------------------------------------------------------------------
 # 9. New routes are mounted
 # ---------------------------------------------------------------------------
-
-
-def test_fp0001_routes_mounted() -> None:
-    """Tier 2: the task lifecycle routes added by FP-0001 are present in
-    the FastAPI app's route table.
-
-    Pins that include_router wired them correctly without accidentally
-    shadowing or dropping any existing route.
-    """
-    from reyn.interfaces.web.server import app
-
-    paths = {getattr(r, "path", None) for r in app.routes}
-    assert "/a2a/tasks/{run_id}" in paths, "GET /a2a/tasks/{run_id} must be mounted"
-    assert "/a2a/tasks/{run_id}/cancel" in paths, "POST /a2a/tasks/{run_id}/cancel must be mounted"
-    assert "/a2a/tasks/{run_id}/events" in paths, "GET /a2a/tasks/{run_id}/events must be mounted"
+#
+# (A former "routes are mounted" test lived here, pinning literal
+# ``app.routes`` path strings for the three task-lifecycle routes.
+# FastAPI 0.139 changed ``include_router``'s internal representation
+# (routes now surface as a lazy ``_IncludedRouter`` wrapper, not a
+# flattened ``Route`` with a ``.path``), so the pin failed even though
+# all three routes remain reachable — the exact "NEVER pin internal
+# structure" trap the testing policy warns about. Deleted as a
+# redundant duplicate: each route is already hit with a real request
+# elsewhere in this module (``GET /a2a/tasks/{run_id}`` at line ~92,
+# ``POST /a2a/tasks/{run_id}/cancel`` at line ~141, ``GET
+# /a2a/tasks/{run_id}/events`` at line ~190 — each returns a real 200
+# body, which only a mounted route can produce).

--- a/tests/web/test_a2a.py
+++ b/tests/web/test_a2a.py
@@ -122,27 +122,22 @@ def _restore_overrides() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 1. Routes are mounted
-# ---------------------------------------------------------------------------
-
-
-def test_a2a_routes_mounted() -> None:
-    """Tier 2: the A2A router exposes the three documented routes.
-
-    Pins the wiring without exercising the protocol. A renamed router
-    or a missing ``include_router`` would trip this test.
-    """
-    from reyn.interfaces.web.server import app
-
-    paths = {getattr(r, "path", None) for r in app.routes}
-    assert "/a2a/agents" in paths
-    assert "/a2a/agents/{agent_name}/.well-known/agent-card.json" in paths
-    assert "/a2a/agents/{agent_name}" in paths
-
-
-# ---------------------------------------------------------------------------
 # 2. Agent Card discovery
 # ---------------------------------------------------------------------------
+#
+# (A former "routes are mounted" test lived here, pinning literal
+# ``app.routes`` path strings. FastAPI 0.139 changed how ``include_router``
+# is represented internally (routes now surface as a lazy ``_IncludedRouter``
+# wrapper rather than flattened ``Route`` objects with a ``.path``), which
+# made the introspection-based pin fail even though the routes remain fully
+# reachable — exactly the "NEVER pin internal structure" trap the testing
+# policy warns about. Deleted as a redundant duplicate: mount reachability
+# for these same three routes is already proven behaviorally below
+# (``test_agent_card_returns_canonical_shape`` / `..._unknown_agent_returns_404``
+# hit ``GET /a2a/agents/{name}/.well-known/agent-card.json``;
+# ``test_list_a2a_agents_enumerates_registered`` hits ``GET /a2a/agents``;
+# ``test_message_send_returns_a2a_message`` hits ``POST /a2a/agents/{name}``)
+# and by ``tests/web/test_surface_registry.py::test_enabling_a2a_makes_it_reachable``.)
 
 
 def test_agent_card_returns_canonical_shape(tmp_path):

--- a/tests/web/test_mcp_sse.py
+++ b/tests/web/test_mcp_sse.py
@@ -31,28 +31,27 @@ pytest.importorskip("mcp", reason="mcp not installed ([mcp] extra missing)")
 
 
 # ---------------------------------------------------------------------------
-# 1. Routes are mounted
-# ---------------------------------------------------------------------------
-
-
-def test_mcp_routes_mounted() -> None:
-    """Tier 2: the /mcp/sse GET route and the /mcp/messages mount are
-    both present on the FastAPI app.
-
-    Pins the wiring without exercising the SSE handshake: a missing
-    Mount is the most likely regression if the router file is renamed
-    or its include is reordered.
-    """
-    from reyn.interfaces.web.server import app
-
-    paths = {getattr(r, "path", None) for r in app.routes}
-    assert "/mcp/sse" in paths, f"/mcp/sse missing from {paths}"
-    assert "/mcp/messages" in paths, f"/mcp/messages missing from {paths}"
-
-
-# ---------------------------------------------------------------------------
 # 2. POST /mcp/messages without session_id → 4xx
 # ---------------------------------------------------------------------------
+#
+# (A former "routes are mounted" test lived here, pinning literal
+# ``app.routes`` path strings for ``/mcp/sse`` and ``/mcp/messages``.
+# FastAPI 0.139 changed ``include_router``'s internal representation
+# (routes now surface as a lazy ``_IncludedRouter`` wrapper, not a
+# flattened ``Route`` with a ``.path``), so the pin failed even though
+# both routes remain reachable — the exact "NEVER pin internal
+# structure" trap the testing policy warns about. Deleted as a
+# redundant duplicate: ``/mcp/messages`` reachability is already proven
+# behaviorally by the two tests below (a 4xx response means the SDK's
+# own mount handled the request — a 404 would mean unmounted) and by
+# ``tests/web/test_surface_registry.py``'s disabled/enabled surface
+# checks. ``/mcp/sse`` is appended to the app's route table in the
+# very same ``_mount_mcp`` call (``surfaces.py``) that appends
+# ``/mcp/messages``, guarded by the same enabled-check, so proving one
+# reachable is strong evidence for the other; opening a real
+# ``GET /mcp/sse`` stream from a sync ``TestClient`` was tried and
+# hangs (verified empirically) because the SSE handshake needs a
+# concurrent client, not just an app.routes membership check.)
 
 
 def test_mcp_messages_missing_session_id_returns_4xx() -> None:

--- a/tests/web/test_plugin_loader.py
+++ b/tests/web/test_plugin_loader.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
 
 from reyn.interfaces.web.plugin_loader import load_webhook_plugins, load_webhooks_yaml
 
@@ -260,22 +261,28 @@ def test_loader_continues_after_register_raises(_patch_entry_points):
 def test_loader_disambiguates_via_package_field(_patch_entry_points):
     """Tier 2: when two packages register the same plugin name, the
     ``package:`` field in webhooks.yaml selects which one is mounted.
-    Verified via the entry-point's distribution name reaching through
-    to ``register_router`` (= each fake builds a router with a marker
-    path so the test can identify which one mounted).
+
+    Verified behaviorally via a real ``TestClient`` request rather than
+    ``app.routes`` introspection (each fake builds a router with a
+    marker path so the test can tell which one mounted by which path
+    actually answers) — FastAPI 0.139 changed ``include_router``'s
+    internal representation (routes now surface as a lazy
+    ``_IncludedRouter`` wrapper, not a flattened ``Route`` with a
+    ``.path``), which made a literal-path ``app.routes`` pin here rot
+    even though the disambiguation still works correctly.
     """
     def _from_a(config):
         r = APIRouter()
         @r.get("/from-pkg-a")
         async def _h():
-            return {}
+            return {"pkg": "a"}
         return r
 
     def _from_b(config):
         r = APIRouter()
         @r.get("/from-pkg-b")
         async def _h():
-            return {}
+            return {"pkg": "b"}
         return r
 
     _patch_entry_points.append(_stub_entry_point("sample_slack", "pkg_a", _from_a))
@@ -287,7 +294,12 @@ def test_loader_disambiguates_via_package_field(_patch_entry_points):
         webhooks_config={"sample_slack": {"package": "pkg_b"}},
     )
     assert mounted == 1
-    # The pkg_b router (= /from-pkg-b path) should be the one mounted.
-    paths = {getattr(r, "path", "") for r in app.routes}
-    assert "/from-pkg-b" in paths
-    assert "/from-pkg-a" not in paths
+
+    client = TestClient(app, raise_server_exceptions=False)
+    # The pkg_b router should be the one mounted — its route answers...
+    resp_b = client.get("/from-pkg-b")
+    assert resp_b.status_code == 200, resp_b.text
+    assert resp_b.json() == {"pkg": "b"}
+    # ...while pkg_a's route was never mounted, so it 404s.
+    resp_a = client.get("/from-pkg-a")
+    assert resp_a.status_code == 404, resp_a.text

--- a/tests/web/test_resources_router.py
+++ b/tests/web/test_resources_router.py
@@ -187,19 +187,22 @@ def test_get_unknown_agent_returns_404(tmp_project: Path):
 
 
 # ── router registration ────────────────────────────────────────────────
-
-
-def test_resources_route_is_mounted_on_app():
-    """Tier 2: the resources router is registered on the gateway. Without
-    this, every other test in this module would still pass via 404 from
-    FastAPI's default-not-found, masking a route-mount regression.
-    """
-    from reyn.interfaces.web.server import app
-    paths = {getattr(r, "path", "") for r in app.routes}
-    assert any(
-        "/agents/" in p and "/tool-results/" in p
-        for p in paths
-    ), f"resources route not mounted; routes seen: {sorted(paths)}"
+#
+# (A former "router is registered" test lived here, pinning literal
+# ``app.routes`` path strings. FastAPI 0.139 changed how
+# ``include_router`` is represented internally (routes now surface as a
+# lazy ``_IncludedRouter`` wrapper, not a flattened ``Route`` with a
+# ``.path``), so the pin failed even though the route remains fully
+# reachable — the exact "NEVER pin internal structure" trap the testing
+# policy warns about. Deleted as a redundant duplicate: the mount is
+# already proven live by every 200/404 response above in THIS module
+# (``test_get_serves_minted_path_ref_body`` gets a real 200 body back —
+# only possible if the route is mounted; ``test_get_missing_file_returns_404``
+# / ``test_get_unknown_agent_returns_404`` distinguish a genuine "not
+# found" from FastAPI's blanket unmounted-path 404 precisely because the
+# happy-path test in the same module proves the route exists at all).
+# ``resources`` is also one of the owner-locked always-ON surfaces per
+# ``tests/web/test_surface_registry.py::test_fresh_install_default_on_set_excludes_a2a_and_mcp``.)
 
 
 # ── Browser hardening (#442) ───────────────────────────────────────────


### PR DESCRIPTION
**[test-hygiene-coder]** — Retire the 5-test red baseline: stale `app.routes` literal-path route-mount pins → behavioral / deleted-as-redundant.

## Problem

These 5 tests failed on `origin/main` **before** the current RAG/surface arc (verified failing at `e3e1aa5b` too — genuinely pre-existing, not a recent regression), and have been carried as "5 baseline failures" across several PRs. A red baseline hides future real regressions, so we clean it up.

Root cause (all 5): each asserted a **literal path string** against `{r.path for r in app.routes}`. FastAPI **0.139** changed how `include_router` is represented internally — routes now surface as a lazy `_IncludedRouter` wrapper rather than flattened `Route` objects with a `.path`, so `{r.path for r in app.routes}` no longer contains the route paths. The introspection pins rotted even though **every route remains fully reachable**. This is exactly the "NEVER pin internal structure" trap the testing policy calls out.

**None was a real mounting bug.** The mounts work — proven by the P2 behavioral reachability suite `tests/web/test_surface_registry.py::test_enabling_a2a_makes_it_reachable` (passes) and by each module's own request-based sibling tests.

## Per-test 3-branch classification + action

| # | Test | Branch | Action |
|---|------|--------|--------|
| 1 | `test_a2a.py::test_a2a_routes_mounted` | **1 — redundant w/ behavioral reachability** | **DELETED** |
| 2 | `test_mcp_sse.py::test_mcp_routes_mounted` | **1 — redundant** | **DELETED** |
| 3 | `test_resources_router.py::test_resources_route_is_mounted_on_app` | **1 — redundant** | **DELETED** |
| 4 | `test_fp0001_a2a_endpoints.py::test_fp0001_routes_mounted` | **1 — redundant** | **DELETED** |
| 5 | `test_plugin_loader.py::test_loader_disambiguates_via_package_field` | **2 — unique behavior, not covered by reachability** | **CONVERTED to behavioral** |

### Reasoning per test

1. **`test_a2a_routes_mounted`** — pinned `/a2a/agents`, `/a2a/agents/{agent_name}`, `/a2a/agents/{agent_name}/.well-known/agent-card.json`. All three are already hit with **real requests + real 200/404** in the same module: `test_agent_card_returns_canonical_shape` / `test_agent_card_unknown_agent_returns_404` (GET the card route), `test_list_a2a_agents_enumerates_registered` (GET `/a2a/agents`), `test_message_send_returns_a2a_message` (POST `/a2a/agents/{name}`). Also covered by P2 `test_enabling_a2a_makes_it_reachable`. → **DELETE** (weak brittle duplicate).

2. **`test_mcp_routes_mounted`** — pinned `/mcp/sse` + `/mcp/messages`. `/mcp/messages` reachability is already proven by the two sibling behavioral tests (`test_mcp_messages_missing_session_id_returns_4xx` / `..._invalid_session_id_returns_4xx` — a **4xx** from the SDK mount, not a 404, only happens if mounted). `/mcp/sse` is appended to the route table in the **same** `_mount_mcp` call, guarded by the same enabled-check, as `/mcp/messages`. I attempted a real behavioral `GET /mcp/sse` — it **hangs a sync `TestClient`** (the SSE handler blocks on `server.run` for the connection lifetime; needs a concurrent client, empirically verified: `EXIT=124` under `timeout`). No safe request-level witness beyond what the siblings + P2 already give. → **DELETE** (redundant; not worth a flaky concurrent-SSE harness).

3. **`test_resources_route_is_mounted_on_app`** — its own docstring admitted it existed only to guard against the sibling tests silently passing via a default-404. But the happy-path sibling `test_get_serves_minted_path_ref_body` returns a **real 200 body** (only possible if mounted), and `test_get_missing_file_returns_404` / `test_get_unknown_agent_returns_404` distinguish genuine not-found from unmounted precisely because the happy path proves the route exists. `resources` is an owner-locked always-ON surface per P2 `test_fresh_install_default_on_set_...`. → **DELETE** (redundant).

4. **`test_fp0001_routes_mounted`** — pinned `/a2a/tasks/{run_id}`, `/a2a/tasks/{run_id}/cancel`, `/a2a/tasks/{run_id}/events`. Each is hit with a **real request returning a real 200** elsewhere in the same module: `test_get_task_returns_a2a_envelope_from_task_backend` (GET), `test_cancel_task_aborts_task_in_backend` (POST cancel), `test_stream_task_events_returns_event_stream_content_type` (GET events). → **DELETE** (redundant).

5. **`test_loader_disambiguates_via_package_field`** — this is a **different concept** (plugin-loader `package:` disambiguation, not core route-mounting) and tests **unique behavior** no reachability test covers: when two packages register the same webhook plugin name, `package:` selects which mounts. The old assertion witnessed it via `app.routes` literal-path introspection (`/from-pkg-b` in paths). **CONVERTED** to behavioral: build the app via `load_webhook_plugins`, then a real `TestClient` — `GET /from-pkg-b` → **200 + body `{"pkg":"b"}"`**, `GET /from-pkg-a` → **404**. Witnesses behavior (which router answers), not route structure, so it won't rot on a path-representation refactor. Docstring Tier-declared `Tier 2`.

## Why convert/delete rather than re-pin

Updating a brittle literal-path pin to a *new* literal-path pin just resets the staleness clock — it would rot again on the next route-representation change. Deletions are only where the P2 behavioral reachability + same-module request tests genuinely cover the same mount (cited above per test). The one survivor (#5) tests unique behavior and is now request-based.

## Result

`pytest tests/web/test_a2a.py tests/web/test_mcp_sse.py tests/web/test_resources_router.py tests/test_fp0001_a2a_endpoints.py tests/web/test_plugin_loader.py` → **42 passed, 1 skipped, 0 failed** (was 5 failed / 41 passed). The web route red baseline is **GONE**.

## Gates

- `ruff check src tests` → clean.
- `python scripts/test_tier_audit.py --strict` on the 5 changed files → 43 inspected, 0 Tier-4 violations, 0 warnings.
- Full `pytest` → the 5 baseline failures gone, 0 new failures.
- No `src/` files touched → module-docstring gate N/A.

## Test plan

- [x] 5 target files green (42 passed / 1 skipped / 0 failed).
- [x] No surviving assertion introspects `app.routes` for a literal path (grep-verified — all remaining `app.routes` mentions are in explanatory comments).
- [x] ruff clean.
- [x] tier-audit --strict clean on the 5 files.
- [x] Converted test (#5) is behavioral (TestClient request → 200/404), Tier-declared.

@architect — please co-vet the delete-vs-convert branch calls (esp. #2 `/mcp/sse`, where I deleted rather than built a concurrent-SSE harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
