### PR TITLE
fix: forward sandbox write_paths cap to all 4 index ops, retire safe-mode pre-flight duplication (FP-0057 #2856 Part B)

### DIFF
--- a/src/reyn/api/safe/index_update.py
+++ b/src/reyn/api/safe/index_update.py
@@ -51,23 +51,28 @@ self-loading, so the python harness needs no extra wiring:
   ``REYN_EMBEDDING_PROVIDER`` env var for the duration of the override (test
   hook only — production callers never override this).
 
-Sandbox self-gate (#1199 S3.4 Part1 parity)
---------------------------------------------
-The retired module forwarded the phase's `default_sandbox_policy.write_paths`
-cap straight into `SqliteIndexBackend(sandbox_write_paths=...)` so a
-subprocess-side self-gate applied even with no `ctx.permission_resolver`
-(the subprocess has none). The `index_update` op's own `SqliteIndexBackend`
-construction does not accept that cap, so this module performs the
-EQUIVALENT pre-flight check itself (same `_within_paths` primitive the
-backend uses) before dispatching the op — preserving the prior safety
-property without needing an op-layer change. The pre-flight gates BOTH
-writes the op performs: the source's own `index.db` (via
-`cache_dir_for_source`) AND the source manifest `sources.yaml` (via
-`sources_manifest_path`) — mirroring the LLM-tool path's own permission
-gate (`core/op_runtime/index_update.py`, resolver != None), which declares
-`file.write` authority over both paths. Before this parity fix, only the DB
-path was self-gated here, so a `write_paths` cap that excluded
-`.reyn/config/` still let a safe-mode call mutate the manifest.
+Sandbox self-gate (#2856 Part B — real-write-site, no wrapper pre-flight)
+--------------------------------------------------------------------------
+This module used to carry its OWN pre-flight `_within_paths` check (the
+#2851 db-path gate, later widened to the manifest path by the F3 fix) —
+a hand-duplicated re-derivation of the SAME gate `SqliteIndexBackend`/
+`SourceManifest` apply at their real write sites. #2856 Part B closes the
+gap that made the duplication necessary: `index_update`'s op handler
+(`core/op_runtime/index_update.py`) now forwards
+`sandbox_policy_from_ctx(ctx).write_paths` into BOTH the
+`SqliteIndexBackend` construction and the `SourceManifest.upsert` call,
+unconditionally (not just when `ctx.permission_resolver is not None`) — so
+setting `default_sandbox_policy={"write_paths": ...}` on the `OpContext`
+built below is now sufficient; the backend/manifest self-gate at the real
+write site enforces the SAME cap this module used to pre-flight-check by
+hand. The pre-flight block is retired — one gate, at the write, no
+reconstructed path-check to drift out of sync with the actual write path.
+
+Note: `execute_op` catches `PermissionError` and returns
+`{"status": "denied", ...}` (it never raises for op-level failures) — so a
+denied call here returns that dict rather than raising, unlike the retired
+pre-flight (which raised before `execute_op` was ever called). Callers that
+need to detect a sandbox denial should check `result["status"] == "denied"`.
 
 Internal layering
 ------------------
@@ -170,46 +175,10 @@ async def index_update_async(
     from reyn.core.events.events import EventLog
     from reyn.core.op_runtime import execute_op
     from reyn.core.op_runtime.context import OpContext
-    from reyn.data.index.backend import cache_dir_for_source, sources_manifest_path
-    from reyn.data.index.backends.sqlite import _within_paths
     from reyn.schemas.models import IndexUpdateIROp
     from reyn.security.permissions.permissions import PermissionDecl
 
     workspace_root = _resolve_workspace_root()
-
-    # #1199 S3.4 Part1 parity: self-gate the index DB path against the
-    # phase sandbox write_paths cap (the op has no ctx.permission_resolver
-    # here to gate through, mirroring the retired embed_and_index's direct
-    # SqliteIndexBackend(sandbox_write_paths=...) construction). The DB path
-    # is derived via the SAME `cache_dir_for_source` helper `SqliteIndexBackend.
-    # _db_path` uses for the actual write — so the gate checks exactly the path
-    # the backend writes, guaranteed-equal by construction (not by two
-    # hand-agreeing hardcoded formulas).
-    #
-    # F3 (RAG FP-0057 post-merge sweep): the op ALSO upserts the source
-    # manifest (`sources.yaml`) on every call (see
-    # `core/op_runtime/index_update.py`'s `SourceManifest.upsert`) — a write
-    # this self-gate previously did not constrain, unlike the LLM-tool path
-    # (resolver != None), which gates both the DB path AND the manifest path.
-    # Gate the manifest path too, via the SAME `sources_manifest_path` SSoT
-    # helper `SourceManifest.__init__` and the op's own permission-check path
-    # use for the actual write, so the gated path is guaranteed-equal to the
-    # write path by construction (not a third hand-agreed literal).
-    if _sandbox_write_paths is not None:
-        db_path = cache_dir_for_source(workspace_root, source) / "index.db"
-        if not _within_paths(db_path, _sandbox_write_paths):
-            raise PermissionError(
-                f"index_update: source {source!r} index path is outside the "
-                f"phase sandbox write_paths policy "
-                f"(write_paths={_sandbox_write_paths!r})."
-            )
-        sources_yaml = sources_manifest_path(workspace_root)
-        if not _within_paths(sources_yaml, _sandbox_write_paths):
-            raise PermissionError(
-                f"index_update: source {source!r} manifest path "
-                f"({sources_yaml}) is outside the phase sandbox write_paths "
-                f"policy (write_paths={_sandbox_write_paths!r})."
-            )
 
     events = EventLog()
     ctx = OpContext(
@@ -223,6 +192,19 @@ async def index_update_async(
         # decision the LLM already makes before the step runs.
         permission_resolver=None,
         actor="safe_mode_index_update",
+        # #2856 Part B: promote the harness-set sandbox_write_paths onto the
+        # ctx's `default_sandbox_policy` — the `index_update` op reads it via
+        # `sandbox_policy_from_ctx(ctx)` and forwards it into the
+        # `SqliteIndexBackend`/`SourceManifest` construction UNCONDITIONALLY
+        # (not gated on `permission_resolver is not None`), so the backend's
+        # own write self-gate (sqlite.py) and the manifest's own write
+        # self-gate (source_manifest.py) now enforce this cap at the REAL
+        # write site — no wrapper-side pre-flight re-derivation needed.
+        default_sandbox_policy=(
+            {"write_paths": _sandbox_write_paths}
+            if _sandbox_write_paths is not None
+            else None
+        ),
     )
 
     op = IndexUpdateIROp(

--- a/src/reyn/api/safe/index_update.py
+++ b/src/reyn/api/safe/index_update.py
@@ -74,6 +74,20 @@ denied call here returns that dict rather than raising, unlike the retired
 pre-flight (which raised before `execute_op` was ever called). Callers that
 need to detect a sandbox denial should check `result["status"] == "denied"`.
 
+Intentional consequence (cost-before-denial, ACCEPTED — not an oversight):
+cap enforcement is at the REAL write site (post-embed), not a caller
+pre-check. So an out-of-`write_paths` safe-mode write incurs the embed cost
+BEFORE the denial fires (unlike the retired pre-flight, which denied before
+any cost). This is intentional and accepted: (1) it affects ONLY the
+safe-mode path — the LLM-tool path's `require_file_write` (inside
+`if ctx.permission_resolver is not None`) already fails fast before embed;
+(2) it is a rare anomaly path (a python step attempting a write outside its
+sandbox = misconfiguration/malice, not happy-path); (3) it is
+security-neutral (`write_paths` gates only local writes; embed egress is
+orthogonal, protected by redaction; the out-of-cap write is still denied);
+(4) keeping a single authoritative gate at the write site is the point of
+#2856 Part B — a second op-level pre-check would split the authority.
+
 Internal layering
 ------------------
 This module is reyn-package internal code (= not subject to the safe-mode

--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -49,8 +49,14 @@ async def handle(
     # per-source granularity is not preserved (= drop is destructive
     # and the per-source distinction was operator-UX rather than
     # security).
+    # #2856 Part B: resolve unconditionally — forwarded into the backend
+    # below regardless of whether a permission_resolver is present, so the
+    # destructive drop self-gates at the real write site on every
+    # caller/surface (mirrors index_update).
+    sandbox_policy = sandbox_policy_from_ctx(ctx)
+    sandbox_write_paths = sandbox_policy.write_paths if sandbox_policy is not None else None
+
     if ctx.permission_resolver is not None:
-        sandbox_policy = sandbox_policy_from_ctx(ctx)
         sources_yaml = workspace_root / ".reyn" / "config" / "index" / "sources.yaml"
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(sources_yaml), ctx.actor,
@@ -66,11 +72,19 @@ async def handle(
             sandbox_policy=sandbox_policy,
         )
 
-    backend = SqliteIndexBackend(workspace_root=workspace_root)
+    # #2856 Part B: forward the cap into the backend — `drop` now self-gates
+    # the source dir at the real deletion site (sqlite.py), not just via the
+    # require_file_write above (which is skipped entirely when
+    # permission_resolver is None, e.g. a future safe-mode drop entry point).
+    backend = SqliteIndexBackend(
+        workspace_root=workspace_root, sandbox_write_paths=sandbox_write_paths,
+    )
     manifest = get_source_manifest(workspace_root)
 
     drop_result = await backend.drop(op.source)
-    removed_from_manifest = await manifest.remove(op.source)
+    removed_from_manifest = await manifest.remove(
+        op.source, sandbox_write_paths=sandbox_write_paths,
+    )
 
     # #2259 PR-1: record the FULL post-drop sources registry as a truncation-surviving config
     # generation so it recovers (the yaml is a derived projection). The helper guards

--- a/src/reyn/core/op_runtime/index_query.py
+++ b/src/reyn/core/op_runtime/index_query.py
@@ -72,6 +72,8 @@ async def handle(
 
     workspace_root = ctx.workspace.base_dir
 
+    sandbox_policy = sandbox_policy_from_ctx(ctx)
+
     # #1199 S3.4 Part1: route the index FS-op through the permission gate (the
     # SQLite I/O itself stays host-direct — random-access/lock can't go on the
     # read_file abstraction — so we gate the DB path BEFORE the backend opens
@@ -81,10 +83,19 @@ async def handle(
         db_path = workspace_root / ".reyn" / "cache" / "index" / op.source / "index.db"
         await ctx.permission_resolver.require_file_read(
             ctx.permission_decl, str(db_path), ctx.actor,
-            sandbox_policy=sandbox_policy_from_ctx(ctx),
+            sandbox_policy=sandbox_policy,
         )
 
-    backend = SqliteIndexBackend(workspace_root=workspace_root)
+    # #2856 Part B: forward the same cap-resolution seam into the backend as
+    # the other 3 index ops (uniform construction site — even though `query`
+    # is read-only and the backend has no write self-gate to trip here, this
+    # keeps `SqliteIndexBackend(...)` construction identical in shape across
+    # all 4 ops, so a future read-path self-gate has one seam to land on, not
+    # three-out-of-four).
+    backend = SqliteIndexBackend(
+        workspace_root=workspace_root,
+        sandbox_write_paths=sandbox_policy.write_paths if sandbox_policy is not None else None,
+    )
 
     try:
         chunks = await backend.query(

--- a/src/reyn/core/op_runtime/index_update.py
+++ b/src/reyn/core/op_runtime/index_update.py
@@ -87,6 +87,16 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
 
     workspace_root = ctx.workspace.base_dir
 
+    # #2856 Part B: resolve the sandbox cap ONCE, unconditionally (not just
+    # inside the `permission_resolver is not None` branch below) — it is
+    # forwarded into the backend/manifest regardless of whether a
+    # permission_resolver is present, so the safe-mode path (resolver=None,
+    # e.g. `reyn.api.safe.index_update`) gets the SAME real-write-site
+    # self-gate as the LLM-tool path, closing the asymmetry the wrapper's
+    # retired pre-flight used to paper over.
+    sandbox_policy = sandbox_policy_from_ctx(ctx)
+    sandbox_write_paths = sandbox_policy.write_paths if sandbox_policy is not None else None
+
     # Permission gate — own-write (not destructive), same shape as
     # index_query's read gate / index_drop's write gate: declares
     # file.write authority over this source's own index + the sources.yaml
@@ -94,7 +104,6 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
     # posture (no ask-gate) comes from the ToolGates on the `index_update`
     # ToolDefinition, not from this call.
     if ctx.permission_resolver is not None:
-        sandbox_policy = sandbox_policy_from_ctx(ctx)
         # Derive the DB path via the SAME `cache_dir_for_source` helper
         # `SqliteIndexBackend._db_path` uses for the actual write, so the gate
         # checks exactly the path the backend writes (guaranteed-equal by
@@ -110,7 +119,13 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
             sandbox_policy=sandbox_policy,
         )
 
-    backend = SqliteIndexBackend(workspace_root=workspace_root)
+    # #2856 Part B: forward the cap into the backend — its own self-gate on
+    # `db_file` (sqlite.py `write`/`delete`) now fires at the REAL write site
+    # for every caller/surface, not just the LLM-tool path's pre-embed
+    # require_file_write above.
+    backend = SqliteIndexBackend(
+        workspace_root=workspace_root, sandbox_write_paths=sandbox_write_paths,
+    )
     manifest = get_source_manifest(workspace_root)
 
     # ── Source-model-bound: resolve the model to embed with ────────────────
@@ -233,15 +248,18 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
         pth = existing_entry.path
     else:
         pth = "(unknown)"
-    await manifest.upsert(SourceEntry(
-        name=op.source,
-        description=desc,
-        path=pth,
-        backend="sqlite",
-        last_indexed=datetime.now(timezone.utc).isoformat(),
-        chunk_count=stat["chunk_count"],
-        embedding_model=stat["embedding_model"] or model,
-    ))
+    await manifest.upsert(
+        SourceEntry(
+            name=op.source,
+            description=desc,
+            path=pth,
+            backend="sqlite",
+            last_indexed=datetime.now(timezone.utc).isoformat(),
+            chunk_count=stat["chunk_count"],
+            embedding_model=stat["embedding_model"] or model,
+        ),
+        sandbox_write_paths=sandbox_write_paths,
+    )
 
     # P6 audit trail
     ctx.events.emit(

--- a/src/reyn/core/op_runtime/semantic_search.py
+++ b/src/reyn/core/op_runtime/semantic_search.py
@@ -56,11 +56,15 @@ from reyn.data.index.source_manifest import get_source_manifest
 from reyn.schemas.models import EmbedIROp, IndexQueryIROp, SemanticSearchIROp
 
 from . import execute_op, register
-from .context import OpContext
+from .context import OpContext, sandbox_policy_from_ctx
 
 
 async def _resolve_source_model(
-    source: str, workspace_root, fallback_model: str,
+    source: str,
+    workspace_root,
+    fallback_model: str,
+    *,
+    sandbox_write_paths: "list[str] | None" = None,
 ) -> str:
     """AUTO-ADOPT the embedding model for *source* (co-vet #1) — never
     caller-supplied. Preference order: `SourceManifest.embedding_model`
@@ -68,12 +72,20 @@ async def _resolve_source_model(
     recorded model (populated straight from index writes even when no
     manifest entry exists, e.g. in tests that seed the backend directly) ->
     `fallback_model` (an empty/unindexed source, where `index_query` falls
-    back to enumeration anyway — the model choice there is moot)."""
+    back to enumeration anyway — the model choice there is moot).
+
+    ``sandbox_write_paths`` (#2856 Part B): forwarded into the
+    `SqliteIndexBackend` construction for the same uniform-seam reason as
+    `index_query` — this call only reads (`stat`), so it does not trip the
+    backend's write self-gate, but the construction site now takes the SAME
+    cap-resolution shape as the other 3 index ops."""
     manifest = get_source_manifest(workspace_root)
     entry = await manifest.get(source)
     if entry is not None and entry.embedding_model:
         return entry.embedding_model
-    backend = SqliteIndexBackend(workspace_root=workspace_root)
+    backend = SqliteIndexBackend(
+        workspace_root=workspace_root, sandbox_write_paths=sandbox_write_paths,
+    )
     stat = await backend.stat(source)
     if stat.get("embedding_model"):
         return stat["embedding_model"]
@@ -101,6 +113,11 @@ async def handle(
 
     workspace_root = ctx.workspace.base_dir if ctx.workspace is not None else None
 
+    # #2856 Part B: resolved unconditionally, forwarded into `_resolve_source_model`'s
+    # backend construction below.
+    sandbox_policy = sandbox_policy_from_ctx(ctx)
+    sandbox_write_paths = sandbox_policy.write_paths if sandbox_policy is not None else None
+
     # ── 1. Resolve each source's model + group sources by distinct model ───
     source_models: dict[str, str] = {}
     for source in op.sources:
@@ -109,6 +126,7 @@ async def handle(
         else:
             source_models[source] = await _resolve_source_model(
                 source, workspace_root, op.embedding_model,
+                sandbox_write_paths=sandbox_write_paths,
             )
 
     # Group order = first-appearance order in op.sources (deterministic,

--- a/src/reyn/data/index/backends/sqlite.py
+++ b/src/reyn/data/index/backends/sqlite.py
@@ -423,6 +423,19 @@ class SqliteIndexBackend:
 
     async def drop(self, source: str) -> DropResult:
         source_dir = self._root / ".reyn" / "cache" / "index" / source
+        # #2856 Part B: same sandbox write-path gate as `write`/`delete` —
+        # drop is a destructive write, and (unlike write/delete) this method
+        # previously had NO self-gate at all, so a cap-forward with no op-layer
+        # `require_file_write` in front of it (e.g. a future safe-mode drop
+        # entry, or a direct `handle()` call with `permission_resolver=None`)
+        # would silently pass through. Gate BEFORE the exists()/rmtree side effect.
+        if self._sandbox_write_paths is not None and not _within_paths(
+            source_dir, self._sandbox_write_paths
+        ):
+            raise PermissionError(
+                f"index drop on {str(source_dir)!r} denied by the active sandbox "
+                f"policy (path outside write_paths={self._sandbox_write_paths!r})."
+            )
         if not source_dir.exists():
             return DropResult(removed=False, chunks_dropped=0)
 

--- a/src/reyn/data/index/source_manifest.py
+++ b/src/reyn/data/index/source_manifest.py
@@ -18,6 +18,7 @@ from typing import Any, AsyncIterator
 import yaml
 
 from reyn.data.index.backend import sources_manifest_path
+from reyn.data.index.backends.sqlite import _within_paths
 from reyn.data.index.build_lock import pid_alive as _pid_alive
 
 # ── Data model ────────────────────────────────────────────────────────────────
@@ -163,13 +164,36 @@ class SourceManifest:
             self._cache = {}
             self._loaded_mtime = None
 
-    async def _atomic_write(self) -> None:
+    async def _atomic_write(
+        self, *, sandbox_write_paths: "list[str] | None" = None,
+    ) -> None:
         """Write current mem cache to disk atomically (write → fsync → rename).
 
         Caller MUST hold ``self._lock``.  Updates ``_loaded_mtime`` to the
         newly written file so the next ``get_all`` does not trigger an
         unnecessary reload.
+
+        #2856 Part B: ``sandbox_write_paths``, when set (the phase sandbox
+        policy's ``write_paths``, forwarded by the op — mirrors
+        ``SqliteIndexBackend``'s own ``write``/``delete``/``drop`` self-gate),
+        self-gates ``sources.yaml`` against the cap BEFORE the write — this is
+        the manifest's OWN write site (the backend's ``db_file`` self-gate
+        does not cover it — F3). Taken as a per-call arg (not stored on
+        ``__init__``/the instance) because ``SourceManifest`` is a
+        per-workspace SINGLETON (``get_source_manifest``); storing the cap on
+        the instance would let one caller's cap leak into (or be clobbered
+        by) a concurrent caller's request on the same workspace. ``None`` =
+        no cap (current behavior, in-process callers already gated at the op
+        layer).
         """
+        if sandbox_write_paths is not None and not _within_paths(
+            self._path, sandbox_write_paths
+        ):
+            raise PermissionError(
+                f"source manifest write to {str(self._path)!r} denied by the "
+                f"active sandbox policy (path outside "
+                f"write_paths={sandbox_write_paths!r})."
+            )
         self._path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self._path.with_suffix(".yaml.tmp")
         payload = {
@@ -213,19 +237,29 @@ class SourceManifest:
         entries = await self.get_all()
         return entries.get(name)
 
-    async def upsert(self, entry: SourceEntry) -> None:
-        """Add or update entry. Atomic file write + mem cache update."""
+    async def upsert(
+        self, entry: SourceEntry, *, sandbox_write_paths: "list[str] | None" = None,
+    ) -> None:
+        """Add or update entry. Atomic file write + mem cache update.
+
+        ``sandbox_write_paths``: #2856 Part B — the phase sandbox cap,
+        forwarded by the caller (op) at the real write site. See
+        ``_atomic_write``.
+        """
         async with self._lock:
             if self._cache is None:
                 await self._reload_from_file()
             assert self._cache is not None
             self._cache[entry.name] = entry
-            await self._atomic_write()
+            await self._atomic_write(sandbox_write_paths=sandbox_write_paths)
 
-    async def remove(self, name: str) -> bool:
+    async def remove(
+        self, name: str, *, sandbox_write_paths: "list[str] | None" = None,
+    ) -> bool:
         """Remove entry. Returns True if removed, False if it didn't exist.
 
-        Atomic file write + mem cache update.
+        Atomic file write + mem cache update. ``sandbox_write_paths``: see
+        ``upsert``/``_atomic_write`` (#2856 Part B).
         """
         async with self._lock:
             if self._cache is None:
@@ -234,7 +268,7 @@ class SourceManifest:
             if name not in self._cache:
                 return False
             del self._cache[name]
-            await self._atomic_write()
+            await self._atomic_write(sandbox_write_paths=sandbox_write_paths)
             return True
 
     async def format_for_prompt(self) -> str:

--- a/tests/test_1199_s34_part1_fs_op_gate.py
+++ b/tests/test_1199_s34_part1_fs_op_gate.py
@@ -5,10 +5,12 @@
   - OS-side op handlers (index_query / index_drop) call require_file_read/write
     with the phase sandbox_policy ∩ BEFORE invoking the backend.
   - the WRITE path runs in the safe subprocess (no ctx): the sandbox write_paths
-    cap is forwarded into the subprocess (harness → reyn.api.safe.index_update,
-    FP-0057 Phase 2b successor to the retired embed_index) which performs the
-    equivalent pre-flight self-gate on the DB path before dispatching the
-    index_update op (co-signed B).
+    cap is forwarded onto the `OpContext.default_sandbox_policy` the subprocess
+    builds (harness → reyn.api.safe.index_update, FP-0057 Phase 2b successor to
+    the retired embed_index), and the `index_update` op forwards it into the
+    `SqliteIndexBackend`/`SourceManifest` construction, which self-gate at
+    their OWN real write sites (#2856 Part B — this superseded the #2851/F3
+    wrapper pre-flight, which duplicated the same path-check by hand).
 """
 from __future__ import annotations
 
@@ -85,9 +87,10 @@ def test_write_sandbox_falsification(tmp_path: Path) -> None:
 #
 # FP-0057 Phase 2b: the retired `reyn.api.safe.embed_index.embed_and_index`
 # (which forwarded the cap straight into `SqliteIndexBackend(sandbox_write_
-# paths=...)`) was replaced by `reyn.api.safe.index_update`, which performs
-# the equivalent pre-flight self-gate BEFORE dispatching the `index_update`
-# op (see that module's docstring) — this test now pins the new module.
+# paths=...)`) was replaced by `reyn.api.safe.index_update`. #2856 Part B then
+# retired that module's OWN pre-flight duplicate — it now promotes the cap
+# onto `OpContext.default_sandbox_policy`, and the `index_update` op forwards
+# it into the backend construction, which self-gates at the real write site.
 
 
 class _FakeProvider:
@@ -107,8 +110,12 @@ class _FakeProvider:
 
 def test_safe_index_update_forwards_cap_to_backend(tmp_path: Path) -> None:
     """Tier 2: the harness-set sandbox_write_paths context flows from
-    reyn.api.safe.index_update's pre-flight self-gate → a restrictive cap
-    DENIES the index write before the op (and thus any embed call) runs."""
+    reyn.api.safe.index_update → OpContext.default_sandbox_policy → the
+    `index_update` op's `SqliteIndexBackend` construction → the backend's own
+    real-write-site self-gate. `execute_op` catches the resulting
+    `PermissionError` and returns `status="denied"` (never raises for
+    op-level failures) — so a restrictive cap denies the write with a denied
+    envelope, and nothing lands on disk."""
     from reyn.api.safe import index_update as iu
     from reyn.data.embedding import register_provider
 
@@ -120,8 +127,9 @@ def test_safe_index_update_forwards_cap_to_backend(tmp_path: Path) -> None:
     )
     chunk = {"text": "hello", "metadata": {"content_hash": "h1", "source_path": "src.md"}}
     try:
-        with pytest.raises(PermissionError, match="sandbox"):
-            asyncio.run(iu.index_update_async([chunk], "src", "standard"))
+        result = asyncio.run(iu.index_update_async([chunk], "src", "standard"))
+        assert result["status"] == "denied"
+        assert not (tmp_path / ".reyn" / "cache" / "index" / "src" / "index.db").exists()
     finally:
         iu._reset_context()
 
@@ -177,3 +185,117 @@ def test_index_drop_gates_source_dir_by_sandbox_cap(tmp_path: Path, monkeypatch)
     op = IndexDropIROp(kind="index_drop", source="src")
     with pytest.raises(PermissionError):
         asyncio.run(handle(op, ctx))
+
+
+# ── #2856 Part B: cap-forwarding ALL 4 index ops → backend/manifest
+#    real-write-site self-gate (not just the require_file_write gate above,
+#    which is skipped entirely when permission_resolver is None) ────────────
+
+
+def _no_resolver_ctx(tmp_path: Path, *, sandbox_policy: dict | None) -> OpContext:
+    """An OpContext with NO permission_resolver (mirrors the safe-mode
+    wrapper's ctx shape) — isolates the backend/manifest self-gate from the
+    require_file_write gate, which only fires when resolver is not None."""
+    events = EventLog()
+    ws = Workspace(events, base_dir=tmp_path)
+    return OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=None, actor="s",
+        default_sandbox_policy=sandbox_policy,
+    )
+
+
+def test_index_drop_backend_self_gate_fires_with_no_resolver(tmp_path: Path) -> None:
+    """Tier 2: #2856 Part B falsify — with NO permission_resolver (the
+    require_file_write gate above is skipped entirely), a write_paths cap
+    excluding the source dir still DENIES `index_drop`, because the op now
+    forwards the cap into `SqliteIndexBackend(sandbox_write_paths=...)`,
+    which self-gates `drop()` at the real deletion site."""
+    from reyn.core.op_runtime.index_drop import handle
+
+    asyncio.run(_write(SqliteIndexBackend(workspace_root=tmp_path)))
+    source_dir = tmp_path / ".reyn" / "cache" / "index" / "s"
+    ctx = _no_resolver_ctx(tmp_path, sandbox_policy={"write_paths": ["/sandboxed"]})
+    op = IndexDropIROp(kind="index_drop", source="s")
+    with pytest.raises(PermissionError):
+        asyncio.run(handle(op, ctx))
+    assert source_dir.exists()  # denied BEFORE the rmtree side effect
+
+
+def test_index_drop_backend_self_gate_strip_falsify(tmp_path: Path) -> None:
+    """Tier 2: ★∩-falsification — the SAME drop the cap denies succeeds once
+    the cap is dropped (None), proving the self-gate (not something else) is
+    load-bearing."""
+    from reyn.core.op_runtime.index_drop import handle
+
+    asyncio.run(_write(SqliteIndexBackend(workspace_root=tmp_path)))
+    source_dir = tmp_path / ".reyn" / "cache" / "index" / "s"
+    assert source_dir.exists()
+    ctx = _no_resolver_ctx(tmp_path, sandbox_policy=None)
+    op = IndexDropIROp(kind="index_drop", source="s")
+    result = asyncio.run(handle(op, ctx))
+    assert result["removed"] is True
+    assert not source_dir.exists()
+
+
+def test_index_update_backend_self_gate_fires_with_no_resolver(tmp_path: Path) -> None:
+    """Tier 2: #2856 Part B falsify — with NO permission_resolver, a
+    write_paths cap excluding the source's index dir still DENIES
+    `index_update`'s write, because the op forwards the cap into
+    `SqliteIndexBackend(sandbox_write_paths=...)`, which self-gates `write()`
+    at the real write site. Symmetric with the safe-mode-path assertion in
+    test_2b_safe_index_update.py (same op, same cap, same real site)."""
+    from reyn.core.op_runtime.index_update import handle
+    from reyn.data.embedding import register_provider
+    from reyn.schemas.models import IndexUpdateIROp
+
+    register_provider("fake_2856", _FakeProvider)
+    ctx = _no_resolver_ctx(tmp_path, sandbox_policy={"write_paths": ["/sandboxed"]})
+    op = IndexUpdateIROp(
+        kind="index_update",
+        source="src",
+        chunks=[{"text": "hello", "metadata": {"content_hash": "h1", "source_path": "s.md"}}],
+        embedding_model="fake_2856",
+    )
+    import os
+    os.environ["REYN_EMBEDDING_PROVIDER"] = "fake_2856"
+    try:
+        with pytest.raises(PermissionError):
+            asyncio.run(handle(op, ctx))
+    finally:
+        os.environ.pop("REYN_EMBEDDING_PROVIDER", None)
+    assert not (tmp_path / ".reyn" / "cache" / "index" / "src" / "index.db").exists()
+
+
+# ── SourceManifest's OWN real-write-site self-gate (F3 root — the manifest
+#    write is NOT covered by the backend's db_file self-gate) ────────────────
+
+
+def test_source_manifest_upsert_self_gate_denies_outside_config_dir(tmp_path: Path) -> None:
+    """Tier 2: #2856 Part B — `SourceManifest.upsert`'s own real write site
+    (`_atomic_write`) denies when the forwarded cap excludes
+    `.reyn/config/index/sources.yaml`, closing F3 (the manifest write is a
+    SEPARATE write from the backend's `db_file`, so the backend self-gate
+    alone does not cover it)."""
+    from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+
+    manifest = get_source_manifest(tmp_path)
+    entry = SourceEntry(name="src", description="d", path="p")
+    with pytest.raises(PermissionError):
+        asyncio.run(
+            manifest.upsert(
+                entry, sandbox_write_paths=[str(tmp_path / ".reyn" / "cache")],
+            )
+        )
+    assert not (tmp_path / ".reyn" / "config" / "index" / "sources.yaml").exists()
+
+
+def test_source_manifest_upsert_self_gate_strip_falsify(tmp_path: Path) -> None:
+    """Tier 2: ★∩-falsification — the SAME upsert the cap denies succeeds
+    once the cap is dropped (None)."""
+    from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+
+    manifest = get_source_manifest(tmp_path)
+    entry = SourceEntry(name="src", description="d", path="p")
+    asyncio.run(manifest.upsert(entry, sandbox_write_paths=None))
+    assert (tmp_path / ".reyn" / "config" / "index" / "sources.yaml").exists()

--- a/tests/test_2b_safe_index_update.py
+++ b/tests/test_2b_safe_index_update.py
@@ -185,17 +185,24 @@ async def test_set_context_overrides_cwd(tmp_path: Path, monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_sandbox_write_paths_self_gate_denies_outside_path(tmp_path: Path) -> None:
-    """Tier 2: #1199 S3.4 Part1 parity — a phase sandbox write_paths cap
-    that excludes this source's index path raises PermissionError BEFORE
-    the op (and thus the embed call) ever runs (no partial embed cost)."""
+    """Tier 2: #2856 Part B — a phase sandbox write_paths cap that excludes
+    this source's index path denies the call. The cap now self-gates at the
+    REAL write site (`SqliteIndexBackend.write`, forwarded via the op's
+    `default_sandbox_policy`), not a wrapper pre-flight — so unlike the
+    retired #2851 pre-flight, the embed call already ran (cost incurred)
+    before the write-site denial; `execute_op` catches the `PermissionError`
+    and returns a `status="denied"` envelope (it never raises for op-level
+    failures — `core/op_runtime/__init__.py`)."""
     other_root = tmp_path / "elsewhere_entirely"
     other_root.mkdir()
     iu._set_context(sandbox_write_paths=[str(other_root)])
-    with pytest.raises(PermissionError):
-        await iu.index_update_async(
-            [_chunk("should not embed", "d.md")], source="d", model="standard",
-        )
-    assert CountingFakeProvider.embedded_texts == 0
+    result = await iu.index_update_async(
+        [_chunk("should not write", "d.md")], source="d", model="standard",
+    )
+    assert result["status"] == "denied"
+    backend = SqliteIndexBackend(workspace_root=tmp_path)
+    stat = await backend.stat("d")
+    assert stat["chunk_count"] == 0  # denied before the write landed
 
 
 @pytest.mark.asyncio
@@ -217,26 +224,23 @@ async def test_sandbox_write_paths_self_gate_allows_within_path(tmp_path: Path) 
 async def test_sandbox_write_paths_manifest_gate_denies_outside_config_dir(
     tmp_path: Path,
 ) -> None:
-    """Tier 2: F3 falsify — `index_update` also upserts the source manifest
-    (`.reyn/config/index/sources.yaml`) on every call, not just the source's
-    own `.reyn/cache/index/<source>/index.db`. A write_paths cap that covers
-    the index cache dir but EXCLUDES `.reyn/config/` must still deny the call
-    (manifest write is gated), matching the LLM-tool path's own permission
-    gate (`core/op_runtime/index_update.py`), which declares file.write
-    authority over both paths. Before the F3 fix, only the DB path was
-    self-gated here, so this cap would have silently let the manifest write
-    through — a source-description poisoning vector under a python-step
-    write_paths cap."""
+    """Tier 2: F3 (#2856 Part B) falsify — `index_update` also upserts the
+    source manifest (`.reyn/config/index/sources.yaml`) on every call, not
+    just the source's own `.reyn/cache/index/<source>/index.db`. A
+    write_paths cap that covers the index cache dir but EXCLUDES
+    `.reyn/config/` must still deny the call (manifest write is gated),
+    matching the LLM-tool path's own permission gate
+    (`core/op_runtime/index_update.py`), which declares file.write authority
+    over both paths. The gate now fires at `SourceManifest`'s own real write
+    site (`_atomic_write`) — the DB write (embed + backend.write) has
+    already succeeded by the time the manifest upsert is attempted and
+    denied (real-write-site ordering, not a pre-flight before either write)."""
     iu._set_context(
         sandbox_write_paths=[str(tmp_path / ".reyn" / "cache" / "index")],
     )
-    with pytest.raises(PermissionError):
-        await iu.index_update_async(
-            [_chunk("manifest write should be denied", "d.md")],
-            source="d", model="standard",
-        )
-    # The DB write happens (embed + backend.write) BEFORE the manifest
-    # upsert in the op's own handler, but the pre-flight self-gate here runs
-    # BEFORE either write is dispatched — so no chunk was embedded either.
-    assert CountingFakeProvider.embedded_texts == 0
+    result = await iu.index_update_async(
+        [_chunk("manifest write should be denied", "d.md")],
+        source="d", model="standard",
+    )
+    assert result["status"] == "denied"
     assert not (tmp_path / ".reyn" / "config" / "index" / "sources.yaml").exists()


### PR DESCRIPTION
**[rag-coder]** — FP-0057 #2856 Part B: forward the sandbox `write_paths` cap to all 4 index ops (`index_update`/`index_query`/`index_drop`/`semantic_search`) + retire the safe-mode wrapper's pre-flight duplication.

Design: architect spec (`opcontext_forwarding_seam_spec.md` §Part B). Base: origin/main (includes #2857's F3 manifest pre-flight, which this PR retires and replaces with the real-write-site gate).

## Problem
None of the 4 index ops forwarded `sandbox_policy_from_ctx(ctx).write_paths` into their `SqliteIndexBackend(...)` construction — so the backend's own `#1199` self-gate (`write`/`delete` in `sqlite.py`) was **inert on the op path**. The safe-mode wrapper (`api/safe/index_update.py`) compensated with a hand-written pre-flight (`#2851` db path + `#2857`'s F3 manifest path) — a duplicated re-derivation of the same path-check logic, with real SSoT-drift risk.

## Fix
1. **All 4 index ops** now resolve `sandbox_policy_from_ctx(ctx)` **unconditionally** (not just inside the `permission_resolver is not None` branch) and forward `.write_paths` into `SqliteIndexBackend(..., sandbox_write_paths=...)`:
   - `index_update.py` — forwards into both the backend AND `manifest.upsert(..., sandbox_write_paths=...)`.
   - `index_query.py` — forwarded for construction-site uniformity (read-only; no write self-gate to trip, but the 4 ops now build the backend identically).
   - `index_drop.py` — forwards into the backend AND `manifest.remove(..., sandbox_write_paths=...)`. **`SqliteIndexBackend.drop()` had NO self-gate at all before this PR** (unlike `write`/`delete`) — added one, gated before the `rmtree` side effect.
   - `semantic_search.py` — forwarded into `_resolve_source_model`'s backend construction (its `.stat()` read, same uniformity rationale as index_query).
2. **`SourceManifest`** gets its own real-write-site self-gate for `sources.yaml` (F3 root — the backend's `db_file` gate never covered the manifest, a separate file). Implemented as a **per-call `sandbox_write_paths` kwarg on `upsert`/`remove`** (threaded to `_atomic_write`), **not** a `__init__`/constructor field — `SourceManifest` is a per-workspace **singleton** (`get_source_manifest`), so storing the cap on the instance would let one caller's cap leak into or be clobbered by a concurrent caller on the same workspace. This deviates from the spec's literal "mirror the backend param" (backend is NOT a singleton — a fresh instance per op call, so construction-time is safe there) while preserving the intent (self-gate at the real write site, same cap). Flagging for architect co-vet.
3. **Safe-mode wrapper** (`api/safe/index_update.py`) now sets `default_sandbox_policy={"write_paths": _sandbox_write_paths}` on the `OpContext` it builds, and the **hand-written `_within_paths` pre-flight block is deleted** (both the #2851 db check and the F3 manifest check) — the op's own forward (step 1) now enforces the same cap at the real write site.

## Known, intentional trade-off (flagging for co-vet)
`execute_op` catches `PermissionError` and returns `{"status": "denied", ...}` — it **never raises** for op-level failures (`core/op_runtime/__init__.py`). So:
- The safe-mode wrapper's `index_update_async`/`index_update()` no longer **raise** `PermissionError` on denial (the retired pre-flight did) — callers must check `result["status"] == "denied"`. Updated the 3 affected tests in `test_2b_safe_index_update.py` + 1 in `test_1199_s34_part1_fs_op_gate.py` accordingly (behavioral: `status == "denied"` + no residual write on disk, not a private-state assertion).
- Real-write-site enforcement means the embed call (and, for the manifest-path-excluded case, the DB write) may have **already happened** before the denial fires, unlike the retired pre-flight's "deny before any cost." This is the explicit trade the spec calls for ("the safety property now lives at the real write-sites... the duplication debt is gone") — no cost-avoidance regression is silently introduced; it's a known, spec-directed consequence of moving the gate to the real write site. Test docstrings say so explicitly.

## Falsify (per spec)
- `index_drop` backend self-gate, no resolver: cap excluding source dir → `handle()` raises `PermissionError`; strip cap (None) → succeeds and removes the dir (`test_index_drop_backend_self_gate_fires_with_no_resolver` / `..._strip_falsify`).
- `index_update` backend self-gate, no resolver: cap excluding index dir → `handle()` raises `PermissionError`, nothing written (`test_index_update_backend_self_gate_fires_with_no_resolver`).
- `SourceManifest.upsert` self-gate: cap excluding `.reyn/config/` → `PermissionError`, `sources.yaml` never created; strip cap → succeeds (`test_source_manifest_upsert_self_gate_denies_outside_config_dir` / `..._strip_falsify`).
- Safe-mode path symmetry: `iu.index_update_async` with an excluding cap → `result["status"] == "denied"`, nothing written, for BOTH the db-path-excluded case and the manifest-path-excluded case (`test_2b_safe_index_update.py`, updated).
- LLM-tool path (`permission_resolver != None`, pre-existing `require_file_write` gate) and safe-mode path (`permission_resolver == None`, new backend/manifest self-gate) now both deny the SAME cap at the SAME logical write site — no asymmetry.

All confirmed RED-on-strip → GREEN-on-restore (ran with/without the forwarding change before finalizing).

## Test plan (CI gates run locally)
- [x] `ruff check src tests` — All checks passed!
- [x] `python scripts/test_tier_audit.py --strict tests/test_1199_s34_part1_fs_op_gate.py tests/test_2b_safe_index_update.py` — 23 tests inspected, 0 errors, 0 warnings.
- [x] `pytest` (repo root) — **8172 passed, 20 skipped, 0 failures** (213s).
- [x] `python scripts/verify_module_docstrings.py <7 changed src files>` — OK, no refactor-narrative violation.

## Files touched
- `src/reyn/core/op_runtime/index_update.py`, `index_query.py`, `index_drop.py`, `semantic_search.py`
- `src/reyn/data/index/backends/sqlite.py` (new `drop()` self-gate)
- `src/reyn/data/index/source_manifest.py` (`upsert`/`remove`/`_atomic_write` gain `sandbox_write_paths`)
- `src/reyn/api/safe/index_update.py` (cap → `default_sandbox_policy`, pre-flight block deleted)
- `tests/test_1199_s34_part1_fs_op_gate.py`, `tests/test_2b_safe_index_update.py` (updated + new falsify coverage)

part of #2856 (Part A — embed op event_sink/redaction — is a separate parallel PR; not touched here).
