### PR TITLE
feat: FP-0057 #2856 Part A — tool-use embed rides the shared embed op (redaction bypass closed, event_sink preserved via ctx)

### DIFF
--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -278,6 +278,19 @@ class OpContext:
     # ``_create`` read-side stays fixed. None = not executing a task-as-request.
     current_task_id: "str | None" = None
 
+    # FP-0057 #2856 Part A: the TUI model-download status sink for the `embed`
+    # op's provider resolution. Carries ONLY the event_sink CALLABLE
+    # (``(kind, text, meta) -> None``, precedent: sentence_transformers_provider's
+    # ``EventSink``) — NOT a provider instance, so provider lifecycle/construction
+    # stays owned by the embed op handler (which still does its own redaction-egress
+    # scan before calling it). This is the seam that lets ``ActionEmbeddingIndex``
+    # route tool-use embeds through the shared `embed` op (inheriting the redaction
+    # seam) while preserving the session's TUI download-status rows, instead of
+    # calling `provider.embed()` provider-direct (the pre-#2856 redaction bypass).
+    # None = no TUI-observable download status (tests / non-chat construction) —
+    # the provider falls back to its own no-op default.
+    embedding_event_sink: "Callable[[str, str, dict], None] | None" = None
+
 
 def sandbox_policy_from_ctx(ctx: "OpContext") -> "SandboxPolicy | None":
     """Build the ``SandboxPolicy`` from ``ctx.default_sandbox_policy`` (the

--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -39,7 +39,7 @@ from . import register
 from .context import OpContext
 
 
-def _resolve_provider():
+def _resolve_provider(event_sink=None):
     """Resolve the embedding provider (env override + reyn.yaml embedding config).
 
     Mirrors `op_runtime.semantic_search._resolve_provider` — both call sites
@@ -51,6 +51,12 @@ def _resolve_provider():
     op-runtime module stays self-contained and independently testable via
     monkeypatching its own module-level `get_provider` name (established
     op_runtime test convention, see `tests/test_op_semantic_search.py`).
+
+    FP-0057 #2856 Part A: ``event_sink`` (from ``ctx.embedding_event_sink``) is
+    forwarded to ``get_provider`` so a session-scoped TUI model-download status
+    sink still fires even though this call resolves a FRESH provider per op call
+    (the caller — e.g. ``ActionEmbeddingIndex`` via the tool-use `embed` op path
+    — no longer holds its own long-lived provider instance).
     """
     name = os.environ.get("REYN_EMBEDDING_PROVIDER", "litellm")
     if name == "litellm":
@@ -59,8 +65,8 @@ def _resolve_provider():
             cfg = load_config().embedding
         except Exception:
             cfg = None
-        return get_provider(name, config=cfg or {})
-    return get_provider(name, config={})
+        return get_provider(name, config=cfg or {}, event_sink=event_sink)
+    return get_provider(name, config={}, event_sink=event_sink)
 
 
 async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
@@ -71,7 +77,13 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
          through `redact_secrets()` before it reaches the provider, i.e.
          before the egress boundary to an external embedding API.
       2. `provider.embed(scanned_texts, model)` — batches internally; list in,
-         list out, vector order preserved.
+         list out, vector order preserved. The provider is resolved fresh per
+         call via `_resolve_provider(event_sink=ctx.embedding_event_sink)`
+         (FP-0057 #2856 Part A) — `ctx.embedding_event_sink` forwards the
+         caller's TUI model-download status sink through WITHOUT the caller
+         holding its own provider instance, so a tool-use caller (e.g.
+         `ActionEmbeddingIndex`) routes through this op (inheriting the
+         redaction seam above) while keeping its download-status rows.
 
     Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str,
     "total_tokens": int}`. Errors propagate to the shared `execute_op`
@@ -91,7 +103,7 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
             model=op.embedding_model,
         )
 
-    provider = _resolve_provider()
+    provider = _resolve_provider(event_sink=ctx.embedding_event_sink)
     result = await provider.embed(scanned_texts, op.embedding_model)
 
     return {

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2900,7 +2900,11 @@ class RouterLoop:
         if index is None or provider is None:
             return []
         try:
-            results = await index.query(query, provider, model_class, top_k=top_k)
+            # FP-0057 #2856 Part A: idx.query() routes through the shared
+            # `embed` op (execute_op) instead of calling ``provider`` directly
+            # — needs an OpContext, not the provider instance itself.
+            op_ctx = self.host.make_router_op_context()
+            results = await index.query(query, op_ctx, model_class, top_k=top_k)
         except Exception as e:  # noqa: BLE001 — search is best-effort presentation aid
             import logging
             logging.getLogger(__name__).warning("search_actions failed: %s", e)
@@ -3345,6 +3349,15 @@ class RouterLoop:
         hash skipped) and serialised by the index's internal lock,
         so concurrent calls are safe.
 
+        ``provider`` is retained as the caller's pre-existing "embedding
+        configured" signal (callers gate on ``provider is not None`` before
+        spawning this background build) but is no longer passed to
+        ``idx.build()`` — FP-0057 #2856 Part A routes the actual embed call
+        through ``execute_op(EmbedIROp(...), op_ctx)`` (see
+        ``ActionEmbeddingIndex._embed_via_op``), so ``idx.build()`` now takes
+        an ``OpContext`` (built the same way as the other router op-ctx call
+        sites: ``self.host.make_router_op_context()``).
+
         Errors are swallowed, flagged on the RouterLoop instance, and surfaced
         as an operator-visible warning log so a misconfigured embedding provider
         does not crash the chat session — the next turn finds ``is_ready()``
@@ -3378,7 +3391,8 @@ class RouterLoop:
                 return
             result = await list_actions_def.handler({}, tool_ctx)
             items = result.get("items", []) if isinstance(result, dict) else []
-            await idx.build(items, provider, model_class)
+            op_ctx = self.host.make_router_op_context()
+            await idx.build(items, op_ctx, model_class)
         except Exception as exc:
             # #1458: memoize the failure so subsequent turns do not retry.
             self._action_index_build_failed = True

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -76,6 +76,7 @@ def build_router_op_context(
     current_task_id: str | None = None,  # #1953 §16: the task this turn is executing → task.create ownership
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
+    embedding_event_sink: Any = None,  # FP-0057 #2856 Part A: TUI model-download status sink for the `embed` op's provider resolution (ActionEmbeddingIndex build/query path). None → no TUI-observable download status.
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -163,4 +164,5 @@ def build_router_op_context(
         current_task_id=current_task_id,  # #1953 §16: ownership-derivation context
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
         render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
+        embedding_event_sink=embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
     )

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -184,6 +184,11 @@ class RouterHostAdapter:
         action_embedding_index: Any = None,
         embedding_provider: Any = None,
         embedding_model_class: str | None = None,
+        # FP-0057 #2856 Part A: the session's TUI model-download status sink
+        # CALLABLE (paired with ``embedding_provider`` above), threaded onto
+        # every router OpContext (``ctx.embedding_event_sink``) so the `embed`
+        # op forwards it into the fresh per-call provider it resolves.
+        embedding_event_sink: Any = None,
         # FP-0034 Phase 2: sandbox backend name for exec D14 visibility
         # gate. Passed from ``session._sandbox_config.backend`` so the
         # universal catalog ``_enumerate_category("exec")`` can decide
@@ -411,6 +416,8 @@ class RouterHostAdapter:
         self._action_embedding_index = action_embedding_index
         self._embedding_provider = embedding_provider
         self._embedding_model_class = embedding_model_class
+        # FP-0057 #2856 Part A
+        self._embedding_event_sink = embedding_event_sink
         # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
         self._available_skills = available_skills
         # FP-0034 Phase 2
@@ -2084,6 +2091,10 @@ class RouterHostAdapter:
             # (skill_management__install_* / pipeline ops → build_legacy_op_context →
             # this factory), so it is the load-bearing wiring for PR-2.
             hot_reloader=self.hot_reloader,
+            # FP-0057 #2856 Part A: forward the session's TUI model-download
+            # status sink so the `embed` op preserves it (ActionEmbeddingIndex
+            # build/query now routes through the op instead of provider-direct).
+            embedding_event_sink=self._embedding_event_sink,
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1048,6 +1048,14 @@ class Session:
         self._action_embedding_index: Any = None
         self._embedding_provider: Any = None
         self._embedding_model_class: str | None = None
+        # FP-0057 #2856 Part A: the TUI model-download status sink CALLABLE
+        # (set below, alongside ``_embedding_provider``), threaded onto every
+        # router OpContext as ``ctx.embedding_event_sink`` so the `embed` op
+        # (which ``ActionEmbeddingIndex`` now routes through instead of
+        # calling ``provider.embed()`` directly) can forward it into the
+        # FRESH per-call provider it resolves — preserving the download-status
+        # rows without the caller holding a long-lived provider instance.
+        self._embedding_event_sink: Any = None
         if (
             self._action_retrieval.universal_wrappers_enabled
             and self._action_retrieval.embedding_class
@@ -1098,6 +1106,12 @@ class Session:
                     embedding_config,
                     event_sink=_embedding_event_sink,
                 )
+                # FP-0057 #2856 Part A: keep the sink CALLABLE addressable on
+                # its own so it can be threaded onto router OpContexts
+                # (ctx.embedding_event_sink) independently of
+                # ``_embedding_provider`` (which stays for non-tool-use /
+                # legacy callers until they migrate).
+                self._embedding_event_sink = _embedding_event_sink
                 self._embedding_model_class = self._action_retrieval.embedding_class
                 # FP-0057 Phase 0: unified onto IndexBackend's cache
                 # convention (.reyn/cache/index/<source>/); the old
@@ -1114,6 +1128,7 @@ class Session:
                 self._embedding_provider = None
                 self._action_embedding_index = None
                 self._embedding_model_class = None
+                self._embedding_event_sink = None
         # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
         # Created when universal_wrappers_enabled=True and hot_list_n > 0.
         # Per-agent compacted table at
@@ -1752,6 +1767,7 @@ class Session:
             action_embedding_index=self._action_embedding_index,
             embedding_provider=self._embedding_provider,
             embedding_model_class=self._embedding_model_class,
+            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: forwarded to make_router_op_context
             # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list.
             action_usage_tracker=self._action_usage_tracker,
             uncompacted_tool_call_records_fn=(
@@ -5913,6 +5929,7 @@ class Session:
             current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
             render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
+            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -29,22 +29,35 @@ first build after upgrading rebuilds from scratch at the new path — no
 migration code, since the action index is cache (regenerable, not
 recovery-core). See ``docs/reference/runtime/reyn-dir-layout.md``.
 
-Lifecycle (unchanged from the caller's point of view):
+Lifecycle:
   1. Construction: empty index, ``is_ready() == False``.
-  2. ``await build(items, provider, model_class)`` — embeds each item's
-     ``"{qualified_name}: {short_description}"`` text via the
-     ``EmbeddingProvider``, stores the vectors via the backend, and
-     records a catalog snapshot hash. On completion ``is_ready()``
-     returns True.
+  2. ``await build(items, ctx, model_class)`` — embeds each item's
+     ``"{qualified_name}: {short_description}"`` text via
+     ``execute_op(EmbedIROp(...), ctx)`` (FP-0057 #2856 Part A — the shared
+     `embed` op, not a provider-direct call), stores the vectors via the
+     backend, and records a catalog snapshot hash. On completion
+     ``is_ready()`` returns True.
      Disk shortcut: when the on-disk backend state already carries the
      same catalog hash + model class, the embed call is skipped and the
      in-memory state is adopted from disk (= process-restart cache hit).
-  3. ``await query(text, provider, model_class, top_k=10)`` — embeds
-     the query once, asks the backend to rank all stored vectors by
-     cosine similarity, and returns the top-K items with their
-     ``score``. When the index is not ready, returns ``[]`` so callers
-     (= ``search_actions`` handler) gracefully degrade instead of
+  3. ``await query(text, ctx, model_class, top_k=10)`` — embeds
+     the query once (same `embed`-op route), asks the backend to rank all
+     stored vectors by cosine similarity, and returns the top-K items with
+     their ``score``. When the index is not ready, returns ``[]`` so
+     callers (= ``search_actions`` handler) gracefully degrade instead of
      crashing.
+
+FP-0057 #2856 Part A (redaction-bypass close-out): ``build()``/``query()``
+used to call ``provider.embed(...)`` PROVIDER-DIRECT, carrying a session-
+scoped provider whose only reason for living on this class was to also
+carry the TUI's model-download-status ``event_sink`` — a bypass of the
+shared `embed` op's PRE-embed redaction-egress scan (a secret in the tool
+catalog's ``short_description`` would previously leave the process
+unredacted). Both methods now take an ``OpContext`` instead of an
+``EmbeddingProvider`` and route through ``execute_op(EmbedIROp(...), ctx)``;
+the event_sink is preserved via ``ctx.embedding_event_sink`` (a callable,
+not a provider instance) forwarded to the op's own fresh provider
+resolution (see ``core/op_runtime/embed.py``).
 
 Catalog hash semantics:
   - Hash is over the SORTED tuple of qualified_names.
@@ -87,7 +100,7 @@ from reyn.data.index.backend import ChunkRecord, cache_dir_for_source
 from reyn.data.index.build_lock import try_acquire_build_lock
 
 if TYPE_CHECKING:
-    from reyn.data.embedding.provider import EmbeddingProvider
+    from reyn.core.op_runtime.context import OpContext
 
 import asyncio
 
@@ -291,10 +304,37 @@ class ActionEmbeddingIndex:
         self._size = stat["chunk_count"]
         return True
 
+    async def _embed_via_op(
+        self, texts: list[str], ctx: "OpContext", model_class: str,
+    ) -> list[list[float]]:
+        """Embed ``texts`` via the shared `embed` op (FP-0057 #2856 Part A).
+
+        Replaces the pre-#2856 ``provider.embed(...)`` provider-direct call —
+        routing through ``execute_op`` inherits the op's PRE-embed redaction-
+        egress scan (``embed.py``'s co-vet #3 seam) instead of bypassing it.
+        ``ctx.embedding_event_sink`` (forwarded by the caller) still reaches
+        the op's freshly-resolved provider, so the TUI model-download status
+        rows are unaffected by this routing change.
+
+        Raises ``RuntimeError`` on an op-level failure (mirrors the previous
+        provider-direct exception-propagation contract — ``build()``'s
+        all-or-nothing partial-build guard depends on this raising rather
+        than returning a partial/empty vector list silently).
+        """
+        from reyn.core.op_runtime import execute_op
+        from reyn.schemas.models import EmbedIROp
+
+        result = await execute_op(
+            EmbedIROp(kind="embed", texts=texts, embedding_model=model_class), ctx,
+        )
+        if result.get("status") == "error":
+            raise RuntimeError(f"embed op failed: {result.get('error')}")
+        return list(result.get("vectors", []))
+
     async def build(
         self,
         items: list[Mapping[str, Any]],
-        provider: "EmbeddingProvider",
+        ctx: "OpContext",
         model_class: str,
     ) -> None:
         """Embed each item and store the vector via the backend.
@@ -318,6 +358,12 @@ class ActionEmbeddingIndex:
         concurrent builds across OS processes. If another live process
         is mid-build, this call falls back to the disk state without
         invoking the embedding provider.
+
+        FP-0057 #2856 Part A: ``ctx`` (an ``OpContext``) replaces the prior
+        ``provider`` (``EmbeddingProvider``) argument — the embed call now
+        routes through ``execute_op(EmbedIROp(...), ctx)`` (see
+        ``_embed_via_op``) instead of calling a caller-held provider
+        directly.
         """
         async with self._build_lock:
             new_hash = compute_catalog_hash(list(items))
@@ -364,8 +410,7 @@ class ActionEmbeddingIndex:
                 self._building = True
                 _built_ok = False
                 try:
-                    result = await provider.embed(texts, model_class)
-                    vectors = list(result["vectors"])
+                    vectors = await self._embed_via_op(texts, ctx, model_class)
                     if len(vectors) != len(valid_items):
                         raise RuntimeError(
                             f"EmbeddingProvider returned {len(vectors)} "
@@ -393,7 +438,7 @@ class ActionEmbeddingIndex:
     async def query(
         self,
         query_text: str,
-        provider: "EmbeddingProvider",
+        ctx: "OpContext",
         model_class: str,
         top_k: int = 10,
     ) -> list[dict[str, Any]]:
@@ -407,6 +452,10 @@ class ActionEmbeddingIndex:
         gracefully degrades.
 
         Empty / whitespace-only query → empty result.
+
+        FP-0057 #2856 Part A: ``ctx`` (an ``OpContext``) replaces the prior
+        ``provider`` (``EmbeddingProvider``) argument — see ``build()``'s
+        docstring / ``_embed_via_op``.
         """
         if not self.is_ready():
             return []
@@ -415,8 +464,7 @@ class ActionEmbeddingIndex:
         if top_k <= 0:
             return []
 
-        query_result = await provider.embed([query_text], model_class)
-        query_vectors = list(query_result["vectors"])
+        query_vectors = await self._embed_via_op([query_text], ctx, model_class)
         if not query_vectors:
             return []
         query_vec = query_vectors[0]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -1066,6 +1066,16 @@ async def _handle_search_actions(
     if idx is None or provider is None or not model_class:
         return {"items": [], "total": 0}
 
+    # FP-0057 #2856 Part A: idx.query() now routes through the shared `embed`
+    # op (execute_op) rather than calling ``provider`` directly, so it needs
+    # an OpContext — built via the same factory (rs.op_context_factory =
+    # host.make_router_op_context) other tool-use ops already thread. The
+    # ``provider`` None-check above stays as the D14 configured-signal.
+    op_ctx_factory = rs.op_context_factory
+    if op_ctx_factory is None:
+        return {"items": [], "total": 0}
+    op_ctx = op_ctx_factory()
+
     # Optional category restriction (§D14 schema), default = all.
     # #934: validate up-front; stale-enum entries surface as an explicit
     # error envelope rather than silently dropping.
@@ -1084,7 +1094,7 @@ async def _handle_search_actions(
     # Over-fetch when filtering by category so we still return up to
     # ``limit`` after the post-filter cut.
     raw_top_k = limit * len(CATEGORIES) if category_set else limit
-    results = await idx.query(query, provider, model_class, top_k=raw_top_k)
+    results = await idx.query(query, op_ctx, model_class, top_k=raw_top_k)
 
     if category_set:
         from reyn.tools.universal_catalog import split_qualified_name

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Any
 
 from reyn.runtime.router_loop import RouterLoop
 
@@ -56,6 +57,18 @@ class _MinimalEvents:
 class _MinimalHost:
     def __init__(self) -> None:
         self.events = _MinimalEvents()
+        # FP-0057 #2856 Part A: _build_action_embedding_index_background now
+        # builds an OpContext via ``host.make_router_op_context()`` and passes
+        # THAT (not the raw provider) as idx.build()'s second positional arg
+        # (idx.build() itself now routes the embed call through the shared
+        # `embed` op). These tests' fake indexes still reach into that
+        # second arg expecting the fake provider (to trigger the SAME
+        # provider-raised exception the production embed op would surface),
+        # so this stub just returns whatever provider the test stashed here.
+        self.op_ctx_stub: Any = None
+
+    def make_router_op_context(self) -> Any:
+        return self.op_ctx_stub
 
 
 class _LoopWithFailingBuild(RouterLoop):
@@ -75,6 +88,7 @@ class _LoopWithFailingBuild(RouterLoop):
 def _run_build(loop: _LoopWithFailingBuild) -> None:
     idx = _FailingIndex()
     provider = _FailingProvider()
+    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
     asyncio.run(loop._build_action_embedding_index_background(idx, provider, "local-mini"))
 
 
@@ -113,6 +127,7 @@ def test_build_failure_search_stays_hidden() -> None:
     assert idx.is_ready() is False
     provider = _FailingProvider()
     loop = _LoopWithFailingBuild()
+    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
     asyncio.run(loop._build_action_embedding_index_background(idx, provider, "local-mini"))
     # is_ready() still False after failure — search stays hidden.
     assert idx.is_ready() is False
@@ -284,6 +299,7 @@ def test_build_failure_unsupported_param_warns_proxy_fix(caplog) -> None:
     loop = _LoopWithFailingBuild()
     idx = _UnsupportedParamIndex()
     provider = _UnsupportedParamProvider()
+    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
         asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
 

--- a/tests/test_action_embedding_index.py
+++ b/tests/test_action_embedding_index.py
@@ -26,10 +26,31 @@ from typing import Any
 
 import pytest
 
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.action_index import (
     ActionEmbeddingIndex,
     compute_catalog_hash,
 )
+
+
+def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Build a real OpContext whose `embed` op resolves to ``provider``.
+
+    FP-0057 #2856 Part A: ``ActionEmbeddingIndex.build()``/``query()`` now
+    route the embed call through ``execute_op(EmbedIROp(...), ctx)`` (the
+    shared `embed` op) instead of calling a caller-held provider directly —
+    tests monkeypatch the op-runtime module's ``get_provider`` (the
+    established convention, see ``tests/test_op_embed.py``) instead of
+    passing the fake provider as a positional argument.
+    """
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
 
 # ── Fake EmbeddingProvider ────────────────────────────────────────────────
 
@@ -83,12 +104,13 @@ def test_initial_state_not_ready() -> None:
     assert idx.catalog_hash() is None
 
 
-def test_build_then_ready() -> None:
+def test_build_then_ready(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: build() transitions index to ready."""
     idx = ActionEmbeddingIndex()
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     _run(idx.build(
         [{"qualified_name": "skill__a", "short_description": "A"}],
-        _FakeEmbeddingProvider(),
+        ctx,
         "standard",
     ))
     assert idx.is_ready() is True
@@ -122,30 +144,32 @@ def test_catalog_hash_changes_when_names_change() -> None:
     assert a != b
 
 
-def test_idempotent_rebuild_with_same_catalog() -> None:
+def test_idempotent_rebuild_with_same_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: second build() with same catalog is a no-op (no re-embed)."""
     items = [
         {"qualified_name": "skill__a", "short_description": "A"},
         {"qualified_name": "skill__b", "short_description": "B"},
     ]
     provider = _FakeEmbeddingProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex()
-    _run(idx.build(items, provider, "standard"))
+    _run(idx.build(items, ctx, "standard"))
     first_call_count = len(provider.calls)
-    _run(idx.build(items, provider, "standard"))
+    _run(idx.build(items, ctx, "standard"))
     assert len(provider.calls) == first_call_count, (
         "Second build with identical catalog must not re-embed; "
         f"provider.calls grew from {first_call_count} to {len(provider.calls)}"
     )
 
 
-def test_rebuild_when_catalog_changes() -> None:
+def test_rebuild_when_catalog_changes(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: changing the qualified_name set triggers a fresh build."""
     provider = _FakeEmbeddingProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex()
     _run(idx.build(
         [{"qualified_name": "skill__a", "short_description": "A"}],
-        provider, "standard",
+        ctx, "standard",
     ))
     first_call_count = len(provider.calls)
     _run(idx.build(
@@ -153,7 +177,7 @@ def test_rebuild_when_catalog_changes() -> None:
             {"qualified_name": "skill__a", "short_description": "A"},
             {"qualified_name": "skill__b", "short_description": "B"},
         ],
-        provider, "standard",
+        ctx, "standard",
     ))
     assert len(provider.calls) > first_call_count
     assert idx.size() == 2
@@ -162,16 +186,16 @@ def test_rebuild_when_catalog_changes() -> None:
 # ── 3. query() — top-K ranking ────────────────────────────────────────────
 
 
-def test_query_returns_top_k_items() -> None:
+def test_query_returns_top_k_items(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: query returns top_k results sorted by score descending."""
     items = [
         {"qualified_name": f"skill__item_{i}", "short_description": f"Item {i}"}
         for i in range(5)
     ]
     idx = ActionEmbeddingIndex()
-    _run(idx.build(items, _FakeEmbeddingProvider(), "standard"))
-    results = _run(idx.query("query for item 0", _FakeEmbeddingProvider(),
-                              "standard", top_k=3))
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx.build(items, ctx, "standard"))
+    results = _run(idx.query("query for item 0", ctx, "standard", top_k=3))
     (r0, r1, r2) = results
     # Scores must be monotonically non-increasing.
     scores = [r["score"] for r in (r0, r1, r2)]
@@ -184,92 +208,96 @@ def test_query_returns_top_k_items() -> None:
         assert -1.0 <= r["score"] <= 1.0
 
 
-def test_query_top_k_larger_than_catalog_returns_all() -> None:
+def test_query_top_k_larger_than_catalog_returns_all(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: top_k > catalog size returns the full catalog."""
     items = [
         {"qualified_name": "skill__only", "short_description": "Only one"},
     ]
     idx = ActionEmbeddingIndex()
-    _run(idx.build(items, _FakeEmbeddingProvider(), "standard"))
-    results = _run(idx.query("anything", _FakeEmbeddingProvider(),
-                              "standard", top_k=10))
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx.build(items, ctx, "standard"))
+    results = _run(idx.query("anything", ctx, "standard", top_k=10))
     (only,) = results
 
 
 # ── 4. Graceful degradation ───────────────────────────────────────────────
 
 
-def test_query_not_ready_returns_empty() -> None:
+def test_query_not_ready_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: querying before build() returns []."""
     idx = ActionEmbeddingIndex()
-    assert _run(idx.query("anything", _FakeEmbeddingProvider(), "standard")) == []
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    assert _run(idx.query("anything", ctx, "standard")) == []
 
 
-def test_query_empty_string_returns_empty() -> None:
+def test_query_empty_string_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: empty query returns [] (skip wasteful embedding call)."""
     idx = ActionEmbeddingIndex()
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     _run(idx.build(
         [{"qualified_name": "skill__a", "short_description": "A"}],
-        _FakeEmbeddingProvider(), "standard",
+        ctx, "standard",
     ))
-    assert _run(idx.query("", _FakeEmbeddingProvider(), "standard")) == []
-    assert _run(idx.query("   ", _FakeEmbeddingProvider(), "standard")) == []
+    assert _run(idx.query("", ctx, "standard")) == []
+    assert _run(idx.query("   ", ctx, "standard")) == []
 
 
-def test_query_zero_top_k_returns_empty() -> None:
+def test_query_zero_top_k_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: top_k <= 0 returns []."""
     idx = ActionEmbeddingIndex()
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     _run(idx.build(
         [{"qualified_name": "skill__a", "short_description": "A"}],
-        _FakeEmbeddingProvider(), "standard",
+        ctx, "standard",
     ))
-    assert _run(idx.query("q", _FakeEmbeddingProvider(),
-                           "standard", top_k=0)) == []
-    assert _run(idx.query("q", _FakeEmbeddingProvider(),
-                           "standard", top_k=-1)) == []
+    assert _run(idx.query("q", ctx, "standard", top_k=0)) == []
+    assert _run(idx.query("q", ctx, "standard", top_k=-1)) == []
 
 
 # ── 5. Edge cases ─────────────────────────────────────────────────────────
 
 
-def test_empty_catalog_records_hash_no_vectors() -> None:
+def test_empty_catalog_records_hash_no_vectors(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: build() with empty items still records the empty hash."""
     idx = ActionEmbeddingIndex()
-    _run(idx.build([], _FakeEmbeddingProvider(), "standard"))
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx.build([], ctx, "standard"))
     assert idx.is_ready() is True
     assert idx.size() == 0
     assert idx.catalog_hash() is not None
 
 
-def test_items_without_qualified_name_dropped() -> None:
+def test_items_without_qualified_name_dropped(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: items missing qualified_name are silently skipped."""
     idx = ActionEmbeddingIndex()
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     _run(idx.build(
         [
             {"qualified_name": "skill__valid", "short_description": "Valid"},
             {"short_description": "No qualified_name field"},  # dropped
             {"qualified_name": "", "short_description": "Empty name"},  # dropped
         ],
-        _FakeEmbeddingProvider(),
+        ctx,
         "standard",
     ))
     assert idx.size() == 1
 
 
-def test_mismatched_vector_count_refuses_partial_build() -> None:
+def test_mismatched_vector_count_refuses_partial_build(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: provider returning wrong vector count → RuntimeError, no state.
 
     Refuses partial state so we don't end up with a corrupt half-populated
     index.  The catalog hash stays None so the next build retries.
     """
     idx = ActionEmbeddingIndex()
+    ctx = _ctx_for(_DegenerateFakeProvider(), monkeypatch)
     with pytest.raises(RuntimeError, match="refusing partial build"):
         _run(idx.build(
             [
                 {"qualified_name": "skill__a"},
                 {"qualified_name": "skill__b"},  # 2 items but provider returns 1
             ],
-            _DegenerateFakeProvider(),
+            ctx,
             "standard",
         ))
     assert idx.is_ready() is False
@@ -287,11 +315,14 @@ def test_mismatched_vector_count_refuses_partial_build() -> None:
 # private-storage-format pin the testing policy forbids.
 
 
-def test_workspace_root_build_creates_db_file(tmp_path: "Path") -> None:
+def test_workspace_root_build_creates_db_file(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: build() with a workspace_root creates the unified index.db."""
     items = [{"qualified_name": "skill__a", "short_description": "A"}]
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(items, _FakeEmbeddingProvider(), "standard"))
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx.build(items, ctx, "standard"))
 
     assert idx.db_path is not None and idx.db_path.exists(), (
         "index.db must be created after build()"
@@ -300,14 +331,17 @@ def test_workspace_root_build_creates_db_file(tmp_path: "Path") -> None:
     assert idx.catalog_hash() is not None
 
 
-def test_unified_path_replaces_old_action_index_dir(tmp_path: "Path") -> None:
+def test_unified_path_replaces_old_action_index_dir(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: FP-0057 Phase 0 clean-break — storage lands under the unified
     ``.reyn/cache/index/<source>/`` convention, NOT the old private
     ``.reyn/cache/action_index/`` directory (which is no longer read or
     written; regenerable cache, no migration needed)."""
     items = [{"qualified_name": "skill__a", "short_description": "A"}]
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(items, _FakeEmbeddingProvider(), "standard"))
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx.build(items, ctx, "standard"))
 
     old_dir = tmp_path / ".reyn" / "cache" / "action_index"
     assert not old_dir.exists(), (
@@ -318,7 +352,9 @@ def test_unified_path_replaces_old_action_index_dir(tmp_path: "Path") -> None:
     assert idx.db_path.parent == tmp_path / ".reyn" / "cache" / "index" / "actions"
 
 
-def test_workspace_root_loads_from_disk_skips_embed(tmp_path: "Path") -> None:
+def test_workspace_root_loads_from_disk_skips_embed(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: second index with the same workspace_root loads from disk,
     skips embed.
 
@@ -334,13 +370,15 @@ def test_workspace_root_loads_from_disk_skips_embed(tmp_path: "Path") -> None:
     # First process — build + persist
     idx1 = ActionEmbeddingIndex(workspace_root=tmp_path)
     provider1 = _FakeEmbeddingProvider()
-    _run(idx1.build(items, provider1, "standard"))
+    ctx1 = _ctx_for(provider1, monkeypatch)
+    _run(idx1.build(items, ctx1, "standard"))
     (only_call,) = provider1.calls
 
     # Second process (simulated) — fresh index, same catalog
     idx2 = ActionEmbeddingIndex(workspace_root=tmp_path)
     provider2 = _FakeEmbeddingProvider()
-    _run(idx2.build(items, provider2, "standard"))
+    ctx2 = _ctx_for(provider2, monkeypatch)
+    _run(idx2.build(items, ctx2, "standard"))
 
     assert not provider2.calls, (
         "build() must load from disk and skip the embed call on cache hit"
@@ -350,7 +388,9 @@ def test_workspace_root_loads_from_disk_skips_embed(tmp_path: "Path") -> None:
     assert idx2.catalog_hash() == idx1.catalog_hash()
 
 
-def test_workspace_root_rebuilds_on_stale_disk_hash(tmp_path: "Path") -> None:
+def test_workspace_root_rebuilds_on_stale_disk_hash(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: changed catalog triggers re-embed and overwrites disk hash."""
     items_v1 = [{"qualified_name": "skill__a", "short_description": "A"}]
     items_v2 = [
@@ -359,13 +399,15 @@ def test_workspace_root_rebuilds_on_stale_disk_hash(tmp_path: "Path") -> None:
     ]
 
     idx1 = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx1.build(items_v1, _FakeEmbeddingProvider(), "standard"))
+    ctx1 = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    _run(idx1.build(items_v1, ctx1, "standard"))
     hash_v1 = idx1.catalog_hash()
 
     # Fresh index — different catalog → must re-embed, not load v1 from disk
     idx2 = ActionEmbeddingIndex(workspace_root=tmp_path)
     provider2 = _FakeEmbeddingProvider()
-    _run(idx2.build(items_v2, provider2, "standard"))
+    ctx2 = _ctx_for(provider2, monkeypatch)
+    _run(idx2.build(items_v2, ctx2, "standard"))
 
     (only_call,) = provider2.calls  # stale disk hash must trigger re-embed
     assert idx2.size() == 2
@@ -375,6 +417,44 @@ def test_workspace_root_rebuilds_on_stale_disk_hash(tmp_path: "Path") -> None:
     # the new hash (= the disk write-through actually took).
     idx3 = ActionEmbeddingIndex(workspace_root=tmp_path)
     provider3 = _FakeEmbeddingProvider()
-    _run(idx3.build(items_v2, provider3, "standard"))
+    ctx3 = _ctx_for(provider3, monkeypatch)
+    _run(idx3.build(items_v2, ctx3, "standard"))
     assert not provider3.calls
     assert idx3.catalog_hash() == idx2.catalog_hash()
+
+
+# ── 7. FP-0057 #2856 Part A — redaction-bypass closed ────────────────────
+#
+# Pre-#2856, build()/query() called `provider.embed(...)` PROVIDER-DIRECT,
+# bypassing the shared `embed` op's PRE-embed redaction-egress scan
+# (co-vet #3 in core/op_runtime/embed.py). Routing through
+# execute_op(EmbedIROp(...), ctx) (Part A) means a secret-shaped string
+# anywhere in the catalog (e.g. a tool's short_description) is redacted
+# BEFORE it reaches the (fake, in-test) embedding provider — the same
+# egress boundary an external embedding API would sit behind in production.
+
+
+def test_build_redacts_secret_in_short_description_before_embed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a secret-shaped short_description is redacted at the embed
+    egress BEFORE the (fake) provider ever sees it — the tool-use
+    provider-direct redaction bypass this Part A closes."""
+    provider = _FakeEmbeddingProvider()
+    ctx = _ctx_for(provider, monkeypatch)
+    idx = ActionEmbeddingIndex()
+    secret_desc = 'api_key = "abcdefghijklmnopqrstuvwxyz123456"'
+    _run(idx.build(
+        [{"qualified_name": "skill__leaky", "short_description": secret_desc}],
+        ctx,
+        "standard",
+    ))
+    ((embedded_texts, _model),) = provider.calls
+    (embedded_text,) = embedded_texts
+    assert "abcdefghijklmnopqrstuvwxyz123456" not in embedded_text, (
+        "the raw secret must never reach the embedding provider"
+    )
+    assert "REDACTED" in embedded_text
+    # The seam firing is observable (P6 audit-event trace) on the ctx used
+    # for the build.
+    assert any(e.type == "embed_secret_redacted" for e in ctx.events.all())

--- a/tests/test_action_embedding_index_concurrency.py
+++ b/tests/test_action_embedding_index_concurrency.py
@@ -35,14 +35,37 @@ import time
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
 from reyn.data.embedding.provider import EmbedBatchResult
 from reyn.data.index.backend import cache_dir_for_source
 from reyn.data.index.build_lock import pid_alive, try_acquire_build_lock
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.action_index import ActionEmbeddingIndex, compute_catalog_hash
 
 
 def _run(coro):
     return asyncio.run(coro)
+
+
+def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Build a real OpContext whose `embed` op resolves to ``provider``.
+
+    FP-0057 #2856 Part A: ``ActionEmbeddingIndex.build()``/``query()`` now
+    route the embed call through ``execute_op(EmbedIROp(...), ctx)`` (the
+    shared `embed` op) instead of calling a caller-held provider directly —
+    tests monkeypatch the op-runtime module's ``get_provider`` (the
+    established convention, see ``tests/test_op_embed.py``) instead of
+    passing the fake provider as a positional argument.
+    """
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
 
 
 def _lock_dir(workspace_root: Path) -> Path:
@@ -82,16 +105,19 @@ def _items() -> list[dict[str, Any]]:
 # ── 1. Class-swap detection ──────────────────────────────────────────────────
 
 
-def test_same_catalog_different_class_triggers_rebuild(tmp_path: Path) -> None:
+def test_same_catalog_different_class_triggers_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: identical items + new model_class → provider.embed called again."""
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
 
-    _run(idx.build(_items(), provider, "openai/text-embedding-3-small"))
+    _run(idx.build(_items(), ctx, "openai/text-embedding-3-small"))
     assert provider.embed_calls == ["openai/text-embedding-3-small"]
 
     # Same catalog, different class — must re-embed even though hash matches.
-    _run(idx.build(_items(), provider, "sentence-transformers/all-MiniLM-L6-v2"))
+    _run(idx.build(_items(), ctx, "sentence-transformers/all-MiniLM-L6-v2"))
     assert provider.embed_calls == [
         "openai/text-embedding-3-small",
         "sentence-transformers/all-MiniLM-L6-v2",
@@ -100,7 +126,9 @@ def test_same_catalog_different_class_triggers_rebuild(tmp_path: Path) -> None:
     assert idx.model_class == "sentence-transformers/all-MiniLM-L6-v2"
 
 
-def test_same_catalog_same_class_remains_idempotent(tmp_path: Path) -> None:
+def test_same_catalog_same_class_remains_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: regression guard — class match preserves Phase 2 step 2 idempotency.
 
     The class-swap check must not break the existing "same hash → no-op"
@@ -108,17 +136,20 @@ def test_same_catalog_same_class_remains_idempotent(tmp_path: Path) -> None:
     class must skip the embed call.
     """
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
 
-    _run(idx.build(_items(), provider, "standard"))
-    _run(idx.build(_items(), provider, "standard"))
+    _run(idx.build(_items(), ctx, "standard"))
+    _run(idx.build(_items(), ctx, "standard"))
     assert provider.embed_calls == ["standard"]  # second call short-circuited
 
 
 # ── 2. Disk persistence carries model_class ──────────────────────────────────
 
 
-def test_disk_load_rejects_model_class_mismatch(tmp_path: Path) -> None:
+def test_disk_load_rejects_model_class_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: cross-process cache reuse blocked when model class differs.
 
     Mirrors the scenario where two reyn processes share the unified
@@ -128,32 +159,38 @@ def test_disk_load_rejects_model_class_mismatch(tmp_path: Path) -> None:
     than serving foreign-model vectors.
     """
     provider_a = _FakeProvider()
+    ctx_a = _ctx_for(provider_a, monkeypatch)
     idx_a = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx_a.build(_items(), provider_a, "openai/text-embedding-3-small"))
+    _run(idx_a.build(_items(), ctx_a, "openai/text-embedding-3-small"))
     assert provider_a.embed_calls == ["openai/text-embedding-3-small"]
 
     # Fresh instance pointing at the same workspace_root but with a
     # different model class — must re-embed because the on-disk meta
     # records the other class.
     provider_b = _FakeProvider()
+    ctx_b = _ctx_for(provider_b, monkeypatch)
     idx_b = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx_b.build(_items(), provider_b, "sentence-transformers/all-MiniLM-L6-v2"))
+    _run(idx_b.build(_items(), ctx_b, "sentence-transformers/all-MiniLM-L6-v2"))
     assert provider_b.embed_calls == ["sentence-transformers/all-MiniLM-L6-v2"]
 
 
-def test_disk_load_accepts_matching_class_and_catalog(tmp_path: Path) -> None:
+def test_disk_load_accepts_matching_class_and_catalog(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: process restart with same class + catalog → disk-only path.
 
     The second instance does NOT invoke its provider; the vectors are
     loaded from the unified backend.
     """
     provider_a = _FakeProvider()
+    ctx_a = _ctx_for(provider_a, monkeypatch)
     idx_a = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx_a.build(_items(), provider_a, "standard"))
+    _run(idx_a.build(_items(), ctx_a, "standard"))
 
     provider_b = _FakeProvider()
+    ctx_b = _ctx_for(provider_b, monkeypatch)
     idx_b = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx_b.build(_items(), provider_b, "standard"))
+    _run(idx_b.build(_items(), ctx_b, "standard"))
     assert provider_b.embed_calls == []  # loaded from disk; embed not called
     assert idx_b.is_ready()
     assert idx_b.model_class == "standard"
@@ -162,7 +199,9 @@ def test_disk_load_accepts_matching_class_and_catalog(tmp_path: Path) -> None:
 # ── 3. Cross-process advisory lock ──────────────────────────────────────────
 
 
-def test_concurrent_build_skips_when_lock_held_by_live_pid(tmp_path: Path) -> None:
+def test_concurrent_build_skips_when_lock_held_by_live_pid(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: another live process holding .build.lock → embed call skipped.
 
     Simulates the multi-surface parallel-session race tui-coder
@@ -183,8 +222,9 @@ def test_concurrent_build_skips_when_lock_held_by_live_pid(tmp_path: Path) -> No
     )
 
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), provider, "standard"))
+    _run(idx.build(_items(), ctx, "standard"))
 
     # The lock was held → embed must NOT have been called.
     assert provider.embed_calls == []
@@ -195,7 +235,9 @@ def test_concurrent_build_skips_when_lock_held_by_live_pid(tmp_path: Path) -> No
     lock_path.unlink(missing_ok=True)
 
 
-def test_stale_lock_is_reaped(tmp_path: Path) -> None:
+def test_stale_lock_is_reaped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: a .build.lock whose PID is dead is taken over (no deadlock)."""
     lock_dir = _lock_dir(tmp_path)
     lock_path = lock_dir / ".build.lock"
@@ -213,8 +255,9 @@ def test_stale_lock_is_reaped(tmp_path: Path) -> None:
     )
 
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), provider, "standard"))
+    _run(idx.build(_items(), ctx, "standard"))
 
     # Stale lock reaped → embed called normally; build completed.
     assert provider.embed_calls == ["standard"]
@@ -223,7 +266,9 @@ def test_stale_lock_is_reaped(tmp_path: Path) -> None:
     assert not lock_path.exists()
 
 
-def test_corrupt_lock_file_is_treated_as_stale(tmp_path: Path) -> None:
+def test_corrupt_lock_file_is_treated_as_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: malformed .build.lock (= partial write, garbage) is recoverable.
 
     A crashed previous process may leave a half-written lock; the next
@@ -235,8 +280,9 @@ def test_corrupt_lock_file_is_treated_as_stale(tmp_path: Path) -> None:
     lock_path.write_text("not json at all }}}", encoding="utf-8")
 
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), provider, "standard"))
+    _run(idx.build(_items(), ctx, "standard"))
 
     assert provider.embed_calls == ["standard"]
 
@@ -279,7 +325,9 @@ def test_pid_alive_self_returns_true() -> None:
 # ── 5. Empty catalog records model_class too ────────────────────────────────
 
 
-def test_empty_catalog_records_class_for_subsequent_match(tmp_path: Path) -> None:
+def test_empty_catalog_records_class_for_subsequent_match(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: building over an empty catalog still imprints model_class.
 
     Otherwise the next call with the same empty catalog + same class
@@ -287,9 +335,10 @@ def test_empty_catalog_records_class_for_subsequent_match(tmp_path: Path) -> Non
     step 2 empty-catalog short-circuit).
     """
     provider = _FakeProvider()
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build([], provider, "standard"))
+    _run(idx.build([], ctx, "standard"))
     assert idx.model_class == "standard"
     # Same args → no-op (no second embed call).
-    _run(idx.build([], provider, "standard"))
+    _run(idx.build([], ctx, "standard"))
     assert provider.embed_calls == []  # empty catalog never calls embed

--- a/tests/test_fp0057_phase0_index_consolidation.py
+++ b/tests/test_fp0057_phase0_index_consolidation.py
@@ -39,7 +39,13 @@ import math
 from pathlib import Path
 from typing import Any
 
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
 from reyn.data.index.backends.sqlite import SqliteIndexBackend
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.action_index import ActionEmbeddingIndex
 
 MODEL_CLASS = "standard"
@@ -49,6 +55,23 @@ _DIM = 8
 
 def _run(coro: Any) -> Any:
     return asyncio.run(coro)
+
+
+def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Build a real OpContext whose `embed` op resolves to ``provider``.
+
+    FP-0057 #2856 Part A: ``ActionEmbeddingIndex.build()``/``query()`` now
+    route the embed call through ``execute_op(EmbedIROp(...), ctx)`` (the
+    shared `embed` op) instead of calling a caller-held provider directly —
+    tests monkeypatch the op-runtime module's ``get_provider`` (the
+    established convention, see ``tests/test_op_embed.py``) instead of
+    passing the fake provider as a positional argument.
+    """
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
 
 
 # ── 1. Capability seam ───────────────────────────────────────────────────
@@ -172,7 +195,7 @@ class _CraftedVectorProvider:
 
 
 def test_topk_ranking_identical_to_pre_consolidation_oracle(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Tier 2: co-vet #2 non-regression gate.
 
@@ -210,9 +233,10 @@ def test_topk_ranking_identical_to_pre_consolidation_oracle(
 
     # ── production: real ActionEmbeddingIndex riding SqliteIndexBackend ──
     provider = _CraftedVectorProvider(affinity_by_qn)
+    ctx = _ctx_for(provider, monkeypatch)
     idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(catalog_items, provider, MODEL_CLASS))
-    results = _run(idx.query(QUERY_TEXT, provider, MODEL_CLASS, top_k=top_k))
+    _run(idx.build(catalog_items, ctx, MODEL_CLASS))
+    results = _run(idx.query(QUERY_TEXT, ctx, MODEL_CLASS, top_k=top_k))
 
     production_qns = [r["qualified_name"] for r in results]
     production_scores = [r["score"] for r in results]

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -45,13 +45,14 @@ class FakeEmbeddingProvider:
         return 3
 
 
-def _make_ctx(tmp_path: Path) -> OpContext:
+def _make_ctx(tmp_path: Path, *, embedding_event_sink=None) -> OpContext:
     events = EventLog()
     ws = Workspace(events=events)
     return OpContext(
         workspace=ws,
         events=events,
         permission_decl=PermissionDecl(),
+        embedding_event_sink=embedding_event_sink,
     )
 
 
@@ -238,3 +239,82 @@ async def test_embed_no_redaction_event_when_no_secret_present(
     assert result.get("status") != "error", result
     assert fake.received_texts == ["just some ordinary sentence"]
     assert not any(e.type == "embed_secret_redacted" for e in ctx.events.all())
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: FP-0057 #2856 Part A — ctx.embedding_event_sink forwarding seam
+# ---------------------------------------------------------------------------
+#
+# ActionEmbeddingIndex used to call `provider.embed(...)` PROVIDER-DIRECT so
+# it could carry a session-scoped provider's TUI model-download-status
+# event_sink — bypassing this op's PRE-embed redaction-egress seam above.
+# Part A closes that bypass by having ActionEmbeddingIndex route through this
+# op instead; the seam that makes that possible WITHOUT losing the TUI
+# status rows is this op forwarding `ctx.embedding_event_sink` into its own
+# per-call `_resolve_provider(event_sink=...)` — verified here directly
+# (independent of ActionEmbeddingIndex, which has its own coverage in
+# tests/test_action_embedding_index.py).
+
+@pytest.mark.asyncio
+async def test_embed_forwards_ctx_embedding_event_sink_to_provider_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when ctx carries an embedding_event_sink, the op forwards THAT
+    exact callable into get_provider(event_sink=...) — the seam that keeps
+    the TUI model-download status rows alive for a caller (ActionEmbeddingIndex)
+    that no longer holds its own provider instance."""
+    fake = FakeEmbeddingProvider()
+    received_event_sinks: list[object] = []
+
+    def _spy_get_provider(*_args, event_sink=None, **_kwargs):
+        received_event_sinks.append(event_sink)
+        return fake
+
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", _spy_get_provider)
+
+    def _tui_sink(kind: str, text: str, meta: dict) -> None:
+        pass
+
+    ctx = _make_ctx(tmp_path, embedding_event_sink=_tui_sink)
+    op = EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    # unpack: exactly one get_provider() call was made for this single embed
+    (forwarded_sink,) = received_event_sinks
+    assert forwarded_sink is _tui_sink, (
+        "ctx.embedding_event_sink must reach get_provider(event_sink=...) "
+        "UNCHANGED (identity), not wrapped/dropped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_forwards_none_when_ctx_embedding_event_sink_stripped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: falsify — stripping ctx.embedding_event_sink (force None — the
+    OpContext default) means get_provider() receives event_sink=None — the
+    RED counterpart of the test above, confirming the forwarding is actually
+    load-bearing (not a no-op wiring that would "pass" either way)."""
+    fake = FakeEmbeddingProvider()
+    received_event_sinks: list[object] = []
+
+    def _spy_get_provider(*_args, event_sink=None, **_kwargs):
+        received_event_sinks.append(event_sink)
+        return fake
+
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", _spy_get_provider)
+
+    ctx = _make_ctx(tmp_path)  # embedding_event_sink defaults to None
+    assert ctx.embedding_event_sink is None
+    op = EmbedIROp(kind="embed", texts=["hello"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    (forwarded_sink,) = received_event_sinks
+    assert forwarded_sink is None, (
+        "with no sink on ctx, get_provider() must receive event_sink=None "
+        "(no TUI status forwarded) — the RED case for the test above"
+    )

--- a/tests/test_universal_handlers.py
+++ b/tests/test_universal_handlers.py
@@ -31,6 +31,10 @@ from typing import Any, Mapping
 
 import pytest
 
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools import get_default_registry
 from reyn.tools.types import (
     RouterCallerState,
@@ -246,10 +250,28 @@ class _StubProvider:
         }
 
 
-def _ready_index_with(items):
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Build a real OpContext whose `embed` op resolves to ``provider``.
+
+    FP-0057 #2856 Part A: ``ActionEmbeddingIndex.build()``/``query()`` and
+    the `search_actions` handler now route the embed call through
+    ``execute_op(EmbedIROp(...), ctx)`` (the shared `embed` op) instead of
+    calling a caller-held provider directly — tests monkeypatch the
+    op-runtime module's ``get_provider`` (the established convention, see
+    ``tests/test_op_embed.py``) instead of threading the fake provider
+    positionally.
+    """
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+def _ready_index_with(items, ctx: OpContext):
     from reyn.tools.action_index import ActionEmbeddingIndex
     idx = ActionEmbeddingIndex()
-    _run(idx.build(items, _StubProvider(), "standard"))
+    _run(idx.build(items, ctx, "standard"))
     return idx
 
 
@@ -288,18 +310,27 @@ def test_search_actions_no_index_returns_empty() -> None:
     assert result == {"items": [], "total": 0}
 
 
-def test_search_actions_returns_ranked_items() -> None:
+def test_search_actions_returns_ranked_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: handler returns ranked items with score from the index."""
     items = [
         {"qualified_name": "skill__alpha", "short_description": "Alpha skill"},
         {"qualified_name": "skill__beta", "short_description": "Beta skill"},
         {"qualified_name": "skill__gamma", "short_description": "Gamma skill"},
     ]
-    idx = _ready_index_with(items)
+    provider = _StubProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch)
+    idx = _ready_index_with(items, op_ctx)
     rs = RouterCallerState(
         action_embedding_index=idx,
-        embedding_provider=_StubProvider(),
+        embedding_provider=provider,
         embedding_model_class="standard",
+        # FP-0057 #2856 Part A: search_actions now needs an OpContext (built
+        # via this factory) to route the query embed through the shared
+        # `embed` op — same field production wires from
+        # host.make_router_op_context.
+        op_context_factory=lambda: op_ctx,
     )
     result = _run(SEARCH_ACTIONS.handler(
         {"query": "alpha", "limit": 2}, _make_ctx(rs),
@@ -311,7 +342,9 @@ def test_search_actions_returns_ranked_items() -> None:
         assert "score" in it
 
 
-def test_search_actions_filters_by_category() -> None:
+def test_search_actions_filters_by_category(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: category filter restricts to qualified_names in those categories."""
     items = [
         {"qualified_name": "memory_entry__alpha", "short_description": "Alpha"},
@@ -319,11 +352,14 @@ def test_search_actions_filters_by_category() -> None:
         {"qualified_name": "memory_entry__beta", "short_description": "Beta"},
         {"qualified_name": "file__write", "short_description": "Write"},
     ]
-    idx = _ready_index_with(items)
+    provider = _StubProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch)
+    idx = _ready_index_with(items, op_ctx)
     rs = RouterCallerState(
         action_embedding_index=idx,
-        embedding_provider=_StubProvider(),
+        embedding_provider=provider,
         embedding_model_class="standard",
+        op_context_factory=lambda: op_ctx,
     )
     result = _run(SEARCH_ACTIONS.handler(
         {"query": "x", "category": ["memory_entry"], "limit": 10}, _make_ctx(rs),


### PR DESCRIPTION
**[rag-coder]** — FP-0057 #2856 **Part A** — eliminate the tool-use provider-direct embed (redaction-egress bypass) while preserving the TUI model-download `event_sink`.

## Problem
`ActionEmbeddingIndex.build()/query()` embedded **provider-direct** (`provider.embed(...)`), carrying a session-scoped provider whose *only* reason for living on that class was to also carry the TUI's model-download-status `event_sink`. That path **bypassed the shared `embed` op's PRE-embed redaction-egress seam** (co-vet #3 in `core/op_runtime/embed.py`) — a secret in the tool catalog's `short_description` would leave the process to an external embedding API **unredacted**.

## Design (architect — carry the event_sink CALLABLE, not a provider instance)
1. **New `OpContext` field** `embedding_event_sink: Callable[[str, str, dict], None] | None = None` — mirrors the `presentation_renderer` `X | None` seam (None-fallback = existing behavior). Carries only the event_sink callable; the embed op keeps building its own provider + doing redaction, so provider lifecycle stays decoupled from the ctx.
2. **embed op forwards it**: `_resolve_provider(event_sink=ctx.embedding_event_sink)` → `get_provider(event_sink=...)` — the op's own fresh per-call provider still fires model-download status.
3. **ActionEmbeddingIndex rewired**: `build()`/`query()` now take an `OpContext` (was `EmbeddingProvider`) and embed via a new `_embed_via_op` → `execute_op(EmbedIROp(...), ctx)` — inheriting the redaction seam. No live `provider.embed(` remains.
4. **ctx-threading path (the main wiring effort)**: `session._embedding_event_sink` (captured next to the provider) → `build_router_op_context` / `RouterHostAdapter.make_router_op_context` → `ctx.embedding_event_sink`. Build/query call sites (`router_loop._build_action_embedding_index_background`, `router_loop.search_actions`, and the `search_actions` handler in `universal_catalog.py`) obtain the op-ctx via `host.make_router_op_context()` / `rs.op_context_factory()`.

## Outcome
Provider-direct embed eliminated in tool-use → redaction bypass closed (a secret in the tool catalog is now redacted at embed egress, `embed_secret_redacted` audit-event on the tool-use embed path) + the TUI download-status rows preserved via the forwarded event_sink.

## Falsify (RED-on-strip confirmed, then GREEN-restored)
- `tests/test_op_embed.py`:
  - `test_embed_forwards_ctx_embedding_event_sink_to_provider_resolution` — when ctx carries the sink, `get_provider(event_sink=...)` receives that **exact callable** (identity). GREEN.
  - `test_embed_forwards_none_when_ctx_embedding_event_sink_stripped` — **strip `ctx.embedding_event_sink` (force None)** → `get_provider` receives `event_sink=None` (no TUI status forwarded). This is the RED counterpart proving the forwarding is load-bearing.
- `tests/test_action_embedding_index.py::test_build_redacts_secret_in_short_description_before_embed` — a secret-shaped `short_description` is redacted BEFORE the (fake) provider sees it (raw secret absent, `REDACTED` present) + `embed_secret_redacted` emitted on the tool-use build path — the provider-direct-is-gone proof.

`grep -nE "await provider\.embed\(|provider\.embed\(texts|provider\.embed\(\[" src/reyn/tools/action_index.py` → no live call (only docstring prose mentions the retired path).

## CI gates (all 4 green, local)
- **ruff** `ruff check src tests` → `All checks passed!`
- **tier-audit** `--strict` on the 6 changed test files → `103 inspected, 103 OK, 0 Tier-4`
- **pytest** (full, from repo root) → `8170 passed, 20 skipped, 0 failures` (baseline clean post-#2853)
- **module-docstrings** on the 8 changed src files → `OK: no refactor narrative`

## Scope note
Part B (#2858, index-op cap-forwarding) is a separate parallel PR touching the index ops/backend — this PR stays in the embed op + `action_index` + the new context field; no overlap.

@architect co-vet requested.

part of #2856

🤖 Generated with [Claude Code](https://claude.com/claude-code)
