### PR TITLE
fix: task-sqlite-lock CI flake — isolate web-lifespan test cwd (root fix, not busy_timeout bump)

### DIFF
--- a/tests/web/test_auth_gate_middleware.py
+++ b/tests/web/test_auth_gate_middleware.py
@@ -71,6 +71,22 @@ def gated(tmp_project: Path, monkeypatch: pytest.MonkeyPatch):
     """
     _reset_singletons()
     monkeypatch.setattr("reyn.config._find_project_root", lambda _: tmp_project)
+    # #2845/#2860 (task-sqlite-lock flake): the lifespan resolves its sqlite Task
+    # backend at ``.reyn/state/tasks.db`` relative to the process CWD, NOT the
+    # (monkeypatched) project root above — so without this chdir every test in
+    # this module opens/closes a real connection against the ACTUAL repo's
+    # ``<repo>/.reyn/state/tasks.db``, shared with every other test file that
+    # also forgets to isolate cwd (e.g. test_surface_registry.py) and, under
+    # ``pytest -n auto``, with concurrent xdist worker PROCESSES hitting the
+    # same on-disk file at the same time. ``busy_timeout=0`` (deliberate
+    # fail-fast) then raises ``sqlite3.OperationalError: database is locked``
+    # instead of waiting — an order/schedule-dependent flake, reproducible via
+    # ``pytest tests/web/test_auth_gate_middleware.py tests/web/test_surface_registry.py
+    # -n 4`` without this chdir. Isolating cwd to the per-test ``tmp_project``
+    # mirrors the sibling lifespan-driving tests (``test_lifespan_task_backend_close.py``,
+    # ``test_web_auth_lifespan_wiring.py``, ``test_fp0009_b_web_lifespan.py``), all of
+    # which already chdir for exactly this reason.
+    monkeypatch.chdir(tmp_project)
     from reyn.interfaces.web.server import app
 
     app.dependency_overrides.clear()

--- a/tests/web/test_surface_registry.py
+++ b/tests/web/test_surface_registry.py
@@ -110,6 +110,16 @@ def _fresh_app(
     monkeypatch.setenv(_ENABLE_ENV, enable)
     monkeypatch.setenv(_DISABLE_ENV, disable)
 
+    # #2845/#2860 (task-sqlite-lock flake): the lifespan resolves its sqlite Task
+    # backend at ``.reyn/state/tasks.db`` relative to the process CWD, not the
+    # ``project_root`` patched above — without this chdir every test here opens a
+    # real connection against the actual repo's shared ``<repo>/.reyn/state/tasks.db``,
+    # colliding (``busy_timeout=0`` → ``database is locked``) with any other test
+    # file that also drives the real lifespan without isolating cwd (e.g.
+    # test_auth_gate_middleware.py), including concurrent ``pytest -n auto`` xdist
+    # workers. Mirrors the sibling lifespan tests, which already chdir.
+    monkeypatch.chdir(project_root)
+
     # Also steer reyn.interfaces.web.deps' own project-root/config lookups
     # (a separate lazy-import call site) so any handler that reads them
     # (e.g. /api/agents) resolves against the same tmp project.


### PR DESCRIPTION
**[test-isolation-coder]** — Root-causes the recurring `sqlite3.OperationalError: database is locked` flake (#2845 on Python 3.11, #2860 on 3.12) in `tests/web/test_auth_gate_middleware.py::test_patch_budget_caps_requires_token` and siblings.

## Root cause (not "an orphaned connection from one leaking test" — a shared un-isolated path)

`_lifespan` in `src/reyn/interfaces/web/server.py` opens its sqlite Task backend at a **CWD-relative** path:

```python
task_db_path = Path(".reyn") / "state" / "tasks.db"
```

Two test files drive the *real* production lifespan (`with TestClient(app) as client:` / manual `__enter__`/`__exit__`) but only monkeypatch `_find_project_root` (used for config/agent resolution) — they never `monkeypatch.chdir()` into their per-test `tmp_project`:

- `tests/web/test_auth_gate_middleware.py`'s `gated` fixture
- `tests/web/test_surface_registry.py`'s `_fresh_app` (+ `_client_with_token`)

Because the task-db path is CWD-relative, both files (and the real repo checkout itself) share **one physical file**: `<cwd>/.reyn/state/tasks.db`. Each test opens/closes its own connection correctly on `with`/`__exit__` — no per-test leak — but under CI's `pytest -n auto` (`.github/workflows/test.yml`), pytest-xdist schedules individual test *items* (not whole files) across worker **processes**. Two workers can end up driving these fixtures concurrently, each a genuinely separate OS process opening a connection to the same on-disk file at the same instant. The backend's `PRAGMA busy_timeout=0` (intentional prod fail-fast, `sqlite_backend.py:206`) then raises immediately instead of waiting — collection-order/schedule-dependent, which is exactly why a new test file shifting collection shifted which tests land on which worker and exposed it twice.

The 3 other tests that already drive this lifespan (`test_lifespan_task_backend_close.py`, `test_web_auth_lifespan_wiring.py`, `test_fp0009_b_web_lifespan.py`) all already `monkeypatch.chdir(tmp_path)` for exactly this reason — the two flaky files were simply missing it.

## Fix (root, per the no-bandaid directive)

Add `monkeypatch.chdir(tmp_project)` / `monkeypatch.chdir(project_root)` to the two fixtures, so each test's lifespan opens its task-sqlite db under its own isolated `tmp_path`, never touching (or racing on) the shared repo-root path. `busy_timeout=0` is untouched — it stays the intentional fail-fast; the fix removes the shared-resource contention that made fail-fast observable as a flake.

## Falsify

Reproducible without any code change to `src/`, purely via test scheduling:

```
rm -rf .reyn
python -m pytest tests/web/test_auth_gate_middleware.py tests/web/test_surface_registry.py -n 4 -p no:randomly -q
```

- **Strip** (git stash this PR's diff): 6/8 repeated runs errored with `sqlite3.OperationalError: database is locked` at `sqlite_backend.py:206`, hitting `test_patch_budget_caps_requires_token` (the exact test named in #2845/#2860) among others — RED reproduced.
- **Restore** (this PR's diff applied): 6/6 repeated runs green, and no `.reyn/state/tasks.db` is created at the repo root anymore (confirming the isolation, not just luck).

## CI gates (all green locally)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/web/test_auth_gate_middleware.py tests/web/test_surface_registry.py` — 14/14 OK, 0 Tier-4
- `pytest -q -n auto --timeout=120` (full suite, matches CI) — **8182 passed, 20 skipped, 0 failed** in 125s
- `python scripts/verify_module_docstrings.py <changed src files>` — no `src/` files changed; n/a (verified as no-op)

## Test plan

- [x] Reproduced the order/schedule-dependent RED via the parallel repro command above (strip → RED, restore → GREEN)
- [x] Full local suite green under `-n auto` (matches CI's `test.yml` invocation)
- [x] Confirmed no shared `.reyn/state/tasks.db` is created at the repo root by these two files anymore