### PR TITLE
refactor: relocate io/memory/mcp/execution/delegation tool descriptions into the reviewable descriptions package (Phase 2, byte-identical)

### DIFF
--- a/src/reyn/tools/agent_spawn.py
+++ b/src/reyn/tools/agent_spawn.py
@@ -18,14 +18,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import delegation as _delegation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_AGENT_SPAWN_DESCRIPTION = (
-    "Create a new agent under your authority (org-design): give it a name + role. The "
-    "new agent's capabilities are automatically capped at a SUBSET of your own (it can "
-    "never do anything you can't). Use to design a team/org of agents; to narrow a "
-    "member's capabilities further or wire who-can-message-whom, use topology_create."
-)
+# Reviewable in src/reyn/tools/descriptions/delegation.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_AGENT_SPAWN_DESCRIPTION = _delegation_descriptions.agent_spawn.text
 
 _AGENT_SPAWN_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/delegate_to_agent.py
+++ b/src/reyn/tools/delegate_to_agent.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Mapping
 
+from reyn.tools.descriptions import delegation as _delegation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 if TYPE_CHECKING:
@@ -38,8 +39,10 @@ if TYPE_CHECKING:
 
 
 # Description must be byte-identical to router_tools.py line 403 ToolSpec.
-# Copied verbatim from the ToolSpec literal at commit-time.
-_DELEGATE_TO_AGENT_DESCRIPTION = "Forward the request to a peer agent."
+# Reviewable in src/reyn/tools/descriptions/delegation.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_DELEGATE_TO_AGENT_DESCRIPTION = _delegation_descriptions.delegate_to_agent.text
 
 # Parameters JSON schema must be byte-identical to router_tools.py ToolSpec
 # for delegate_to_agent. The "to" property omits the dynamic enum (which is

--- a/src/reyn/tools/descriptions/__init__.py
+++ b/src/reyn/tools/descriptions/__init__.py
@@ -6,8 +6,10 @@ record — the exact LLM-facing ``text`` plus review-aid metadata (``surfaced``,
 ``purpose``, ``ja``) that a reviewer can audit in one place instead of
 grepping across ``src/reyn/tools/*.py``.
 
-Phase 1 covers the ``discovery`` category (see ``descriptions.discovery``).
-Later phases add the remaining categories; each origin tool module keeps a
+Phase 1 covered the ``discovery`` category (see ``descriptions.discovery``).
+Phase 2 adds ``io``, ``memory``, ``mcp``, ``execution``, and ``delegation``
+(see the matching modules below) — the bulk categories, mechanical repeats
+of the Phase 1 pattern. Each origin tool module keeps a
 ``_X_DESCRIPTION = descriptions.<category>.<name>.text`` alias so no call
 site changes — this package is purely a relocation of the string literal,
 never a behavior change.
@@ -20,15 +22,32 @@ is an alternate, currently-unwired description variant for that same tool).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions import discovery
+from reyn.tools.descriptions import (
+    delegation,
+    discovery,
+    execution,
+    io,
+    mcp,
+    memory,
+)
 from reyn.tools.descriptions._types import ToolDescription
 
 ALL: dict[str, ToolDescription] = {
     **discovery.ALL,
+    **io.ALL,
+    **memory.ALL,
+    **mcp.ALL,
+    **execution.ALL,
+    **delegation.ALL,
 }
 
 __all__ = [
     "ToolDescription",
     "discovery",
+    "io",
+    "memory",
+    "mcp",
+    "execution",
+    "delegation",
     "ALL",
 ]

--- a/src/reyn/tools/descriptions/delegation.py
+++ b/src/reyn/tools/descriptions/delegation.py
@@ -1,0 +1,116 @@
+"""Tool descriptions for the ``delegation`` category.
+
+Phase 2 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): every ``delegation``-category
+ToolDefinition's description string lives here as a reviewable
+``ToolDescription`` record. Each ``.text`` value is copied verbatim from
+its origin tool module; the origin module now aliases its
+``_X_DESCRIPTION`` module constant to ``delegation.NAME.text`` so every
+call site is unchanged.
+
+Covers: agent_spawn (#2103 B-tool), delegate_to_agent (ADR-0026 M4),
+session_spawn (#2103 S1bc), topology_create (#2103 C1). All four are
+router-only (gates.phase=deny) — org-design / delegation primitives the
+LLM drives directly, never a phase-authored Control IR op.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+agent_spawn = ToolDescription(
+    tool_name="agent_spawn",
+    surfaced="router-only (gates.router=allow, gates.phase=deny) — #2103 B-tool",
+    purpose=(
+        "Create a new agent (org-design: WHO) under the caller's own "
+        "authority, with capability automatically capped at a subset of "
+        "the spawner's (⊆-parent by construction)."
+    ),
+    text=(
+        "Create a new agent under your authority (org-design): give it a name + role. The "
+        "new agent's capabilities are automatically capped at a SUBSET of your own (it can "
+        "never do anything you can't). Use to design a team/org of agents; to narrow a "
+        "member's capabilities further or wire who-can-message-whom, use topology_create."
+    ),
+    ja=(
+        "自分の権限の下で新しいエージェントを作成する（組織設計: WHO）。"
+        "名前とロールを与える。新エージェントの権限は自動的に自分のサブ"
+        "セットに制限される（自分にできないことはできない）。エージェント"
+        "チーム/組織を設計する用途。メンバーの権限をさらに絞ったり、誰が"
+        "誰にメッセージできるかを配線するには topology_create を使う。"
+    ),
+)
+
+delegate_to_agent = ToolDescription(
+    tool_name="delegate_to_agent",
+    surfaced=(
+        "router-only (gates.router=allow, gates.phase=deny) — async-dispatch "
+        "(ADR-0026 §6): reply arrives in a future RouterLoop turn via "
+        "PR14 pending_chain"
+    ),
+    purpose=(
+        "Forward the current request to a peer agent for it to handle, "
+        "without waiting inline for the reply."
+    ),
+    text="Forward the request to a peer agent.",
+    ja=(
+        "現在のリクエストをピアエージェントに転送する。応答はこの場では"
+        "待たず、将来の RouterLoop ターンで届く（非同期ディスパッチ）。"
+    ),
+)
+
+session_spawn = ToolDescription(
+    tool_name="session_spawn",
+    surfaced="router-only (gates.router=allow, gates.phase=deny) — #2103 S1bc",
+    purpose=(
+        "Spawn a fresh-context session under the caller's agent to run a "
+        "task in isolation (ephemeral or persistent), optionally with "
+        "narrowed capabilities."
+    ),
+    text=(
+        "Spawn a fresh-context session under your agent to run a task in isolation. "
+        "Choose mode='ephemeral' (auto-vanishes after the task) or 'persistent'. "
+        "Optionally narrow the sub-session's capabilities (restrict-only). The session "
+        "runs the task; its result stays in that session."
+    ),
+    ja=(
+        "自分のエージェントの下に、タスクを隔離環境で実行するための新規"
+        "コンテキストセッションを生成する。mode='ephemeral'（タスク後に"
+        "自動消滅）または 'persistent' を選ぶ。サブセッションの権限を"
+        "（制限のみ）狭めることもできる。セッションはタスクを実行し、結果"
+        "はそのセッション内に留まる。"
+    ),
+)
+
+topology_create = ToolDescription(
+    tool_name="topology_create",
+    surfaced="router-only (gates.router=allow, gates.phase=deny) — #2103 C1",
+    purpose=(
+        "Wire the caller's spawned agents into a topology (org-design: "
+        "WIRING) controlling who-can-message-whom, and optionally bind "
+        "members to a capability_profile to narrow them further."
+    ),
+    text=(
+        "Wire agents you spawned into a topology (org-design): group them by kind "
+        "(network = all-to-all, team = star around a leader, pipeline = ordered chain) to "
+        "control who-can-message-whom, and optionally bind each member to a "
+        "capability_profile to narrow it further. You may only include agents in your own "
+        "spawn subtree (yourself or agents you created via agent_spawn) — a member's "
+        "capabilities stay capped at a SUBSET of yours."
+    ),
+    ja=(
+        "自分が生成したエージェントをトポロジーに配線する（組織設計: "
+        "WIRING）。kind（network=全対全、team=リーダー中心のスター、"
+        "pipeline=順序付きチェーン）でグループ化し、誰が誰にメッセージ"
+        "できるかを制御する。任意でメンバーを capability_profile に束縛"
+        "してさらに絞ることもできる。含められるのは自分のスポーン"
+        "サブツリー内のエージェントのみで、権限は常に自分のサブセットに"
+        "制限される。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "agent_spawn": agent_spawn,
+    "delegate_to_agent": delegate_to_agent,
+    "session_spawn": session_spawn,
+    "topology_create": topology_create,
+}

--- a/src/reyn/tools/descriptions/execution.py
+++ b/src/reyn/tools/descriptions/execution.py
@@ -1,0 +1,77 @@
+"""Tool descriptions for the ``execution`` category.
+
+Phase 2 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): every ``execution``-category
+ToolDefinition's description string lives here as a reviewable
+``ToolDescription`` record. Each ``.text`` value is copied verbatim from
+its origin tool module; the origin module now aliases its
+``_X_DESCRIPTION`` module constant to ``execution.NAME.text`` so every
+call site is unchanged.
+
+Covers: sandboxed_exec (``sandboxed_exec.py``), shell (``shell.py`` —
+pipeline DSL sugar over sandboxed_exec, #2593).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+sandboxed_exec = ToolDescription(
+    tool_name="sandboxed_exec",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — FP-0034 "
+        "exec category, visibility-gated on a configured sandbox backend"
+    ),
+    purpose=(
+        "Execute a command in a sandboxed environment (FP-0017), with the "
+        "sandbox policy (network + filesystem scope) resolved by the OS, "
+        "not chosen by the LLM."
+    ),
+    text=(
+        "Execute a command in a sandboxed environment (FP-0017). The sandbox "
+        "policy (network access + filesystem scope) is the OPERATOR's, resolved "
+        "by the OS — it is not chosen here. "
+        "argv: command and arguments (argv[0] is the executable). "
+        "timeout_seconds: wall-clock time limit in seconds (default 60)."
+    ),
+    ja=(
+        "サンドボックス環境内でコマンドを実行する（FP-0017）。サンドボックス"
+        "ポリシー（ネットワークアクセス・ファイルシステムスコープ）は"
+        "オペレーターのものとして OS が解決する（ここで選択するものでは"
+        "ない）。argv: コマンドと引数、timeout_seconds: 秒単位のタイムアウト"
+        "（デフォルト60）。"
+    ),
+)
+
+shell = ToolDescription(
+    tool_name="shell",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — pipeline "
+        "DSL ``shell`` step sugar over sandboxed_exec (#2593)"
+    ),
+    purpose=(
+        "Run a shell command as pipeline-DSL sugar: STDIN carries the "
+        "previous step's pipe-data, STDOUT becomes this step's output, "
+        "same sandbox confinement as sandboxed_exec."
+    ),
+    text=(
+        "Run a shell command (via sandboxed_exec) whose STDIN receives the "
+        "previous pipeline step's pipe-data JSON-encoded, and whose STDOUT "
+        "becomes this step's output. command: the shell command line "
+        "(argv[0]='/bin/sh', argv[1]='-c'). timeout: wall-clock time limit in "
+        "seconds (default 60). The sandbox policy (network access + filesystem "
+        "scope) is the OPERATOR's, resolved by the OS — it is not chosen here."
+    ),
+    ja=(
+        "シェルコマンドを実行する（sandboxed_exec 経由）。STDIN には前段の"
+        "パイプラインステップの pipe-data が JSON エンコードされて渡り、"
+        "STDOUT がこのステップの出力になる。command: シェルコマンドライン"
+        "（argv[0]='/bin/sh', argv[1]='-c'）。timeout: 秒単位のタイムアウト"
+        "（デフォルト60）。サンドボックスポリシーはオペレーターのものとして"
+        "OS が解決する。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "sandboxed_exec": sandboxed_exec,
+    "shell": shell,
+}

--- a/src/reyn/tools/descriptions/io.py
+++ b/src/reyn/tools/descriptions/io.py
@@ -1,0 +1,226 @@
+"""Tool descriptions for the ``io`` category.
+
+Phase 2 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): every ``io``-category
+ToolDefinition's description string lives here as a reviewable
+``ToolDescription`` record. Each ``.text`` value is copied verbatim from
+its origin tool module; the origin module now aliases its
+``_X_DESCRIPTION`` module constant to ``io.NAME.text`` so every call
+site is unchanged.
+
+Covers: file.py's 6 verbs (read_file / write_file / delete_file /
+edit_file / list_directory / grep_files / glob_files), drop_source, and
+index_update. ``index_update``'s ``ToolDefinition.category`` field is
+``"discovery"`` in code (it shares the FP-0057 index lifecycle with
+``drop_source``) — it is grouped here by feature (index/file-adjacent
+I/O), matching the Phase 2 dispatch brief, not by its literal
+``category=`` value.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+read_file = ToolDescription(
+    tool_name="read_file",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Read a file's contents under the agent's read scope, with "
+        "guidance toward conventional project-root file locations."
+    ),
+    text=(
+        "Read a file's contents under the agent's read scope. "
+        "Common conventions: README is at project root as "
+        "`README.md`. CLAUDE.md, CHANGELOG.md, and "
+        "configuration files (e.g. `reyn.yaml`, "
+        "`pyproject.toml`) are at project root. Try these "
+        "conventional paths directly instead of asking the "
+        "user where the file lives."
+    ),
+    ja=(
+        "エージェントの読み取りスコープ内のファイル内容を読む。README は "
+        "プロジェクトルートの README.md、CLAUDE.md / CHANGELOG.md / 設定"
+        "ファイル（reyn.yaml、pyproject.toml 等）もプロジェクトルートにある"
+        "という慣習を踏まえ、ユーザーに場所を尋ねる前にこれらの慣習パスを"
+        "直接試す。"
+    ),
+)
+
+write_file = ToolDescription(
+    tool_name="write_file",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Create or overwrite a whole file under the agent's write scope; "
+        "steers the LLM toward edit_file for partial changes."
+    ),
+    text=(
+        "Write content to a file under the agent's write scope. "
+        "Creates or overwrites the WHOLE file. For a partial or surgical "
+        "change to an existing file, prefer the `file__edit` action instead of "
+        "rewriting the whole file."
+    ),
+    ja=(
+        "エージェントの書き込みスコープ内のファイルにコンテンツを書き込む。"
+        "ファイル全体を新規作成または上書きする。既存ファイルへの部分的な"
+        "変更には、ファイル全体を書き直すのではなく file__edit を使うことを"
+        "推奨する。"
+    ),
+)
+
+delete_file = ToolDescription(
+    tool_name="delete_file",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose="Delete a file under the agent's write scope.",
+    text="Delete a file under the agent's write scope.",
+    ja="エージェントの書き込みスコープ内のファイルを削除する。",
+)
+
+edit_file = ToolDescription(
+    tool_name="edit_file",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Replace a unique string in an existing file for a partial/surgical "
+        "edit, avoiding a whole-file read+write round-trip."
+    ),
+    text=(
+        "Replace a unique string in a file under the agent's write scope. "
+        "`old_string` MUST appear exactly once in the file; if it appears "
+        "multiple times, the call fails with a count — re-call with a longer "
+        "context-including snippet, or pass `replace_all=true` to replace "
+        "every occurrence. Use this for partial edits instead of read+write "
+        "for the whole file."
+    ),
+    ja=(
+        "エージェントの書き込みスコープ内のファイルで、一意な文字列を置換"
+        "する。old_string はファイル内にちょうど1回だけ出現する必要があり、"
+        "複数回出現する場合はエラーになる（より長い文脈を含めて再指定する"
+        "か、replace_all=true を渡す）。ファイル全体の読み書きではなく部分"
+        "編集に使う。"
+    ),
+)
+
+grep_files = ToolDescription(
+    tool_name="grep_files",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Search for a regex pattern across files under the agent's read "
+        "scope, distinct from list_directory's name-only enumeration."
+    ),
+    text=(
+        "Search for a regex pattern across files under the agent's read scope. "
+        "Use this when you need to find text or code patterns in files — "
+        "do NOT use list_directory for grep/glob intent. "
+        "Returns matching lines with file paths and line numbers."
+    ),
+    ja=(
+        "エージェントの読み取りスコープ内のファイルに対して正規表現パター"
+        "ンで検索する。テキストやコードパターンを探す際に使う（list_"
+        "directory はグレップ/グロブ用途には使わない）。マッチした行を"
+        "ファイルパスと行番号付きで返す。"
+    ),
+)
+
+glob_files = ToolDescription(
+    tool_name="glob_files",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Enumerate files by name/glob pattern under the agent's read scope, "
+        "distinct from list_directory's flat single-level listing."
+    ),
+    text=(
+        "Find files matching a glob pattern (e.g. '**/*.py') under the agent's "
+        "read scope. Use `**` to recurse into subdirectories. Use this when you "
+        "need to enumerate files by name pattern — do NOT use list_directory "
+        "for glob intent. Returns a list of matching file paths."
+    ),
+    ja=(
+        "エージェントの読み取りスコープ内で glob パターン（例: '**/*.py'）"
+        "に一致するファイルを探す。`**` でサブディレクトリを再帰する。"
+        "ファイル名パターンでの列挙に使う（list_directory はグロブ用途には"
+        "使わない）。一致したファイルパスのリストを返す。"
+    ),
+)
+
+list_directory = ToolDescription(
+    tool_name="list_directory",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "List a single directory's immediate contents (names + types) "
+        "under the agent's read scope — the flat, non-recursive counterpart "
+        "to grep_files / glob_files."
+    ),
+    text=(
+        "List contents of a directory under the agent's read scope. "
+        "Returns names + types (file/dir)."
+    ),
+    ja=(
+        "エージェントの読み取りスコープ内のディレクトリの内容を一覧表示"
+        "する。名前と種別（file/dir）を返す。"
+    ),
+)
+
+drop_source = ToolDescription(
+    tool_name="drop_source",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Remove an indexed source entirely (SQLite backend + manifest "
+        "entry) — the destructive counterpart to index_update, e.g. when "
+        "retiring a trial source or rebuilding from scratch."
+    ),
+    text=(
+        "Remove an indexed source entirely (= delete its SQLite + manifest entry). "
+        "Use when retiring trial sources or replacing with a different strategy. "
+        "Permission-gated; user is prompted to confirm."
+    ),
+    ja=(
+        "インデックス済みソースを完全に削除する（SQLite バックエンド＋"
+        "マニフェストエントリを削除）。試験的なソースの廃止や別の戦略への"
+        "切り替え時に使う。パーミッションゲート付きで、ユーザーに確認を"
+        "求める。"
+    ),
+)
+
+index_update = ToolDescription(
+    tool_name="index_update",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — own-write, "
+        "default-ALLOW op (FP-0057 Phase 2a)"
+    ),
+    purpose=(
+        "Incrementally reconcile chunks into an indexed source's in-core "
+        "IndexBackend (add/update/remove/skip by content_hash), the "
+        "constructive counterpart to drop_source — NO full-rebuild mode."
+    ),
+    text=(
+        "Incrementally ingest chunks into an indexed source, reconciling "
+        "against its current content: NEW content_hash values are embedded and "
+        "added; a source_path whose chunks changed (new hash under a path "
+        "already indexed) is updated (old chunks for that path replaced); a "
+        "source_path this call re-supplies chunks for but whose old chunk "
+        "hashes are absent from this call are removed; unchanged content_hash "
+        "values are skipped (no re-embed). NO full-rebuild mode — to rebuild a "
+        "source from scratch, call `drop_source` then `index_update` on the "
+        "fresh (empty) source. The caller supplies pre-chunked text (chunking "
+        "is the caller's responsibility, not this tool's)."
+    ),
+    ja=(
+        "インデックス済みソースに対してチャンクを差分投入し、現在の内容と"
+        "照合する（reconcile）: 新しい content_hash は埋め込んで追加、既存"
+        "パスのハッシュが変わっていれば更新、今回再提示されなかった旧"
+        "ハッシュは削除、変化のない content_hash は再埋め込みせずスキップ"
+        "する。フルリビルドモードはない（ゼロから作り直すには drop_source "
+        "してから空のソースに index_update する）。チャンク分割は呼び出し"
+        "側の責任。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "read_file": read_file,
+    "write_file": write_file,
+    "delete_file": delete_file,
+    "edit_file": edit_file,
+    "grep_files": grep_files,
+    "glob_files": glob_files,
+    "list_directory": list_directory,
+    "drop_source": drop_source,
+    "index_update": index_update,
+}

--- a/src/reyn/tools/descriptions/mcp.py
+++ b/src/reyn/tools/descriptions/mcp.py
@@ -1,0 +1,386 @@
+"""Tool descriptions for the ``mcp`` category.
+
+Every MCP-consumption / MCP-lifecycle ToolDefinition's description string
+lives here as a reviewable ``ToolDescription`` record. Each ``.text``
+value is byte-identical to its origin tool module's ``_X_DESCRIPTION``
+constant, which now aliases to ``mcp.NAME.text`` so every call site is
+unchanged.
+
+Grouped here by feature (MCP), not by each entry's literal
+``ToolDefinition.category=`` value: 11 entries carry ``category="discovery"``
+in code (predating the ``mcp`` category) and 6 install/drop entries carry
+``category="io"`` — but all 17 are MCP-specific verbs a reviewer wants
+audited in one place. Excludes ``mcp_search_registry``, which lives in
+``descriptions.discovery`` — its own ``ToolDefinition.category`` IS
+``"discovery"`` and it is discovery-shaped, not install-shaped.
+
+Covers, by origin module:
+  ``mcp.py``: list_mcp_servers, list_mcp_tools, call_mcp_tool,
+    describe_mcp_tool, list_mcp_resources, list_mcp_resource_templates,
+    read_mcp_resource, subscribe_mcp_resource, unsubscribe_mcp_resource,
+    list_mcp_prompts, get_mcp_prompt.
+  ``mcp_verbs.py``: mcp_install_registry, mcp_install_package,
+    mcp_install_local, mcp_call_tool.
+  ``mcp_install.py``: mcp_install (phase-only legacy install op).
+  ``mcp_drop.py``: mcp_drop_server.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+list_mcp_servers = ToolDescription(
+    tool_name="list_mcp_servers",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — Type C closure",
+    purpose="Enumerate configured MCP servers (name + description) for this agent.",
+    text=(
+        "List available MCP servers configured for this agent. "
+        "Returns name + description per server."
+    ),
+    ja="このエージェント用に設定された MCP サーバーを列挙する。サーバーごとに name + description を返す。",
+)
+
+list_mcp_tools = ToolDescription(
+    tool_name="list_mcp_tools",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — Type C closure",
+    purpose=(
+        "List the tools exposed by one MCP server, including inputSchema, "
+        "so the LLM can construct call_mcp_tool args without an extra "
+        "describe round-trip (#879)."
+    ),
+    text=(
+        "List tools exposed by one MCP server "
+        "(with description per tool)."
+    ),
+    ja="1つの MCP サーバーが公開するツールを一覧表示する（ツールごとに説明付き）。",
+)
+
+call_mcp_tool = ToolDescription(
+    tool_name="call_mcp_tool",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Invoke a named tool on an MCP server with args matching its "
+        "declared input schema."
+    ),
+    text=(
+        "Invoke a mcp_tool on an MCP server. Construct args matching "
+        "the mcp_tool's input schema (see describe_mcp_tool)."
+    ),
+    ja=(
+        "MCP サーバー上の mcp_tool を呼び出す。mcp_tool の入力スキーマに"
+        "合わせて引数を構築する（describe_mcp_tool 参照）。"
+    ),
+)
+
+describe_mcp_tool = ToolDescription(
+    tool_name="describe_mcp_tool",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — FP-0032 D4",
+    purpose=(
+        "Fetch one MCP tool's input schema when unsure how to construct "
+        "call_mcp_tool's args."
+    ),
+    text=(
+        "Get the input schema for one mcp_tool registered on an MCP server. "
+        "Call this before call_mcp_tool if you're unsure how to "
+        "construct the args."
+    ),
+    ja=(
+        "MCP サーバーに登録された1つの mcp_tool の入力スキーマを取得する。"
+        "call_mcp_tool の引数の組み立て方が分からない場合、事前に呼ぶ。"
+    ),
+)
+
+list_mcp_resources = ToolDescription(
+    tool_name="list_mcp_resources",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②a",
+    purpose="Enumerate one MCP server's resources (uri + description per resource).",
+    text=(
+        "List resources exposed by one MCP server "
+        "(with uri + description per resource)."
+    ),
+    ja="1つの MCP サーバーが公開するリソースを一覧表示する（uri + 説明付き）。",
+)
+
+list_mcp_resource_templates = ToolDescription(
+    tool_name="list_mcp_resource_templates",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②a",
+    purpose=(
+        "Enumerate one MCP server's parameterized resource-URI templates, "
+        "distinct from list_mcp_resources' concrete resource list."
+    ),
+    text=(
+        "List resource templates (parameterized URI patterns) exposed by one "
+        "MCP server. Use list_mcp_resources for concrete resources."
+    ),
+    ja=(
+        "1つの MCP サーバーが公開するリソーステンプレート（パラメータ化"
+        "された URI パターン）を一覧表示する。具体的なリソースには "
+        "list_mcp_resources を使う。"
+    ),
+)
+
+read_mcp_resource = ToolDescription(
+    tool_name="read_mcp_resource",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②a",
+    purpose=(
+        "Read one MCP resource's content by URI, resolved from "
+        "list_mcp_resources or a list_mcp_resource_templates template."
+    ),
+    text=(
+        "Read the contents of one MCP resource by URI. Get the uri from "
+        "list_mcp_resources (or by resolving a list_mcp_resource_templates "
+        "template)."
+    ),
+    ja=(
+        "URI で指定した1つの MCP リソースの内容を読む。uri は "
+        "list_mcp_resources から取得する（または list_mcp_resource_"
+        "templates のテンプレートを解決して得る）。"
+    ),
+)
+
+subscribe_mcp_resource = ToolDescription(
+    tool_name="subscribe_mcp_resource",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②b",
+    purpose=(
+        "Subscribe to server-pushed change notifications for one MCP "
+        "resource; the notification itself carries no content — "
+        "read_mcp_resource must be re-called to see it."
+    ),
+    text=(
+        "Subscribe to server-pushed updates for one MCP resource by URI. When the "
+        "server-side content changes, a mcp_resource_updated event is recorded — "
+        "call read_mcp_resource again to see the new content (the push notification "
+        "itself carries no content, just a signal that something changed)."
+    ),
+    ja=(
+        "URI で指定した1つの MCP リソースについて、サーバー側からのプッシュ"
+        "更新を購読する。サーバー側のコンテンツが変わると mcp_resource_"
+        "updated イベントが記録される — 新しい内容を見るには read_mcp_"
+        "resource を再度呼ぶ（プッシュ通知自体はコンテンツを持たず、変化の"
+        "シグナルのみ）。"
+    ),
+)
+
+unsubscribe_mcp_resource = ToolDescription(
+    tool_name="unsubscribe_mcp_resource",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②b",
+    purpose="Cancel a previously-established subscribe_mcp_resource subscription.",
+    text=(
+        "Unsubscribe from server-pushed updates for one MCP resource by URI "
+        "(previously subscribed via subscribe_mcp_resource)."
+    ),
+    ja=(
+        "URI で指定した1つの MCP リソースについて、以前 subscribe_mcp_"
+        "resource で購読したサーバープッシュ更新を解除する。"
+    ),
+)
+
+list_mcp_prompts = ToolDescription(
+    tool_name="list_mcp_prompts",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②c",
+    purpose="Enumerate one MCP server's prompts (name + description + arguments).",
+    text=(
+        "List prompts exposed by one MCP server "
+        "(with name + description + arguments per prompt)."
+    ),
+    ja=(
+        "1つの MCP サーバーが公開するプロンプトを一覧表示する（プロンプト"
+        "ごとに name + description + arguments 付き）。"
+    ),
+)
+
+get_mcp_prompt = ToolDescription(
+    tool_name="get_mcp_prompt",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — #2597 slice ②c",
+    purpose=(
+        "Fetch one MCP prompt's rendered messages by name, using the "
+        "argument schema from list_mcp_prompts."
+    ),
+    text=(
+        "Fetch one rendered MCP prompt's messages by name. Get the name (and its "
+        "argument schema) from list_mcp_prompts."
+    ),
+    ja=(
+        "名前で指定した1つの MCP プロンプトのレンダリング済みメッセージを"
+        "取得する。name（と引数スキーマ）は list_mcp_prompts から取得する。"
+    ),
+)
+
+mcp_install_registry = ToolDescription(
+    tool_name="mcp_install_registry",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — install source-axis split",
+    purpose=(
+        "Install an MCP server from the official registry by server_id "
+        "(paired with mcp_search_registry candidates), handling the "
+        "needs_secrets round-trip when secret env-vars are required."
+    ),
+    text=(
+        "Install an MCP server from the official MCP registry by its "
+        "registry name (server_id from mcp__search_registry candidates[].name). "
+        "When the server requires secret environment variables that the "
+        "operator has not yet set, the call returns status='needs_secrets' "
+        "with a guide explaining the `reyn secret set <KEY>` command; relay "
+        "that to the user and retry after they confirm secrets are set."
+    ),
+    ja=(
+        "公式 MCP レジストリから server_id を指定してサーバーをインストール"
+        "する（server_id は mcp__search_registry の candidates[].name から"
+        "得る）。サーバーがシークレット環境変数を要求し未設定の場合、"
+        "status='needs_secrets' と `reyn secret set <KEY>` の案内を返す — "
+        "ユーザーに伝え、設定確認後に再試行する。"
+    ),
+)
+
+mcp_install_package = ToolDescription(
+    tool_name="mcp_install_package",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — install source-axis split",
+    purpose=(
+        "Install an MCP server from a third-party package channel "
+        "(npm/pypi/docker) or a GitHub repo URL, for servers not in the "
+        "official registry."
+    ),
+    text=(
+        "Install an MCP server from a third-party package channel "
+        "(npm / pypi / docker) or a GitHub repo URL. Use when the server "
+        "isn't in the official registry (= mcp__search_registry returned "
+        "no match). Secret detection works the same as install_registry "
+        "for npm/pypi/docker; github URLs cannot pre-declare secrets."
+    ),
+    ja=(
+        "サードパーティのパッケージチャネル（npm/pypi/docker）または "
+        "GitHub リポジトリ URL から MCP サーバーをインストールする。公式"
+        "レジストリにない場合（mcp__search_registry が一致なしを返した"
+        "場合）に使う。npm/pypi/docker はシークレット検出が install_"
+        "registry と同様に働くが、github URL は事前宣言できない。"
+    ),
+)
+
+mcp_install_local = ToolDescription(
+    tool_name="mcp_install_local",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — install source-axis split",
+    purpose=(
+        "Register a local MCP server ({command, args} pair) directly, for "
+        "LLM-authored scripts or local dev servers, bypassing package "
+        "registries."
+    ),
+    text=(
+        "Install a local MCP server by registering a {command, args} pair "
+        "directly. Use for LLM-authored scripts or local development "
+        "servers. Bypasses package registries — cannot auto-detect required "
+        "secrets, so pass env_overrides inline when the server needs env-vars."
+    ),
+    ja=(
+        "{command, args} のペアを直接登録してローカル MCP サーバーを"
+        "インストールする。LLM が作成したスクリプトやローカル開発サーバー"
+        "向け。パッケージレジストリを経由しないため必要なシークレットを"
+        "自動検出できない — env-var が必要な場合は env_overrides を"
+        "インラインで渡す。"
+    ),
+)
+
+mcp_call_tool = ToolDescription(
+    tool_name="mcp_call_tool",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — generic "
+        "fallback beneath per-tool universal-catalog actions"
+    ),
+    purpose=(
+        "Generic fallback to call any installed MCP server's tool by "
+        "<server>__<tool> identifier when no per-tool universal-catalog "
+        "action is available."
+    ),
+    text=(
+        "Call a tool on an installed MCP server — GENERIC FALLBACK. "
+        "PREFER the per-tool 'mcp__<server>__<tool>' actions (e.g. "
+        "'mcp__time__get_current_time') when one is listed: they take the target "
+        "tool's own parameters directly (authoritative input_schema via "
+        "describe_action), with no generic envelope. Use this generic verb only as "
+        "a fallback when no per-tool action is available. Pass the tool identifier "
+        "in <server>__<tool> form (e.g. 'time__get_current_time') as returned by "
+        "mcp__list_tools, plus the tool's own args dict."
+    ),
+    ja=(
+        "インストール済み MCP サーバーのツールを呼び出す（汎用フォール"
+        "バック）。個別ツール専用の 'mcp__<server>__<tool>' アクションが"
+        "リストにある場合はそちらを優先する（describe_action で権威ある"
+        "入力スキーマを持つ、汎用エンベロープなし）。個別アクションが"
+        "ない場合のみこの汎用verbを使う。ツール識別子は <server>__<tool> "
+        "形式（mcp__list_tools が返す形）＋そのツール自身の引数dictを渡す。"
+    ),
+)
+
+mcp_install = ToolDescription(
+    tool_name="mcp_install",
+    surfaced=(
+        "phase-only (gates.router=deny, gates.phase=allow) — legacy Control "
+        "IR install op, ADR-0026 + ADR-0029"
+    ),
+    purpose=(
+        "Phase-authored install of an MCP server from the registry into a "
+        "chosen scope config file, with permission gate + secret prompting "
+        "owned by op_runtime.mcp_install."
+    ),
+    text=(
+        "Install an MCP server from the registry. "
+        "Fetches server.json, gates via permission resolver, "
+        "prompts for secrets, and writes the server entry to the "
+        "appropriate scope config file (local / project / user). "
+        "Status: enabled — this tool's presence in your tool list means "
+        "the required `file.write` and `http.get` permissions are verified. "
+        "Call mcp_install directly; do not abort on permission concerns."
+    ),
+    ja=(
+        "レジストリから MCP サーバーをインストールする（フェーズ専用の "
+        "Control IR オペレーション）。server.json を取得し、パーミッション"
+        "リゾルバでゲートし、シークレットを尋ね、適切なスコープの設定"
+        "ファイル（local/project/user）にサーバーエントリを書き込む。"
+        "このツールがツールリストに存在すること自体が file.write / "
+        "http.get 権限確認済みを意味する — 権限懸念で中断せず直接呼ぶ。"
+    ),
+)
+
+mcp_drop_server = ToolDescription(
+    tool_name="mcp_drop_server",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow) — FP-0034 §D23",
+    purpose=(
+        "Remove a configured MCP server entry (the destructor counterpart "
+        "to mcp_install), optionally clearing its secrets, gated by a "
+        "distinct mcp_drop_server permission."
+    ),
+    text=(
+        "Remove a configured MCP server. "
+        "Counter-op to mcp_install — deletes the server entry from "
+        "reyn.local.yaml / reyn.yaml / ~/.reyn/config.yaml (scope is "
+        "auto-detected when omitted). Optionally cleans the matching "
+        "${KEY} env entries from ~/.reyn/secrets.env. "
+        "Permission-gated via mcp_drop_server (= distinct from "
+        "mcp_install; install intent alone is insufficient)."
+    ),
+    ja=(
+        "設定済みの MCP サーバーを削除する（mcp_install の対になる破壊的"
+        "操作）。reyn.local.yaml / reyn.yaml / ~/.reyn/config.yaml から"
+        "サーバーエントリを削除する（scope 省略時は自動検出）。任意で "
+        "~/.reyn/secrets.env の対応する ${KEY} エントリも削除する。"
+        "mcp_drop_server という別個のパーミッションでゲートされる"
+        "（mcp_install とは別）。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "list_mcp_servers": list_mcp_servers,
+    "list_mcp_tools": list_mcp_tools,
+    "call_mcp_tool": call_mcp_tool,
+    "describe_mcp_tool": describe_mcp_tool,
+    "list_mcp_resources": list_mcp_resources,
+    "list_mcp_resource_templates": list_mcp_resource_templates,
+    "read_mcp_resource": read_mcp_resource,
+    "subscribe_mcp_resource": subscribe_mcp_resource,
+    "unsubscribe_mcp_resource": unsubscribe_mcp_resource,
+    "list_mcp_prompts": list_mcp_prompts,
+    "get_mcp_prompt": get_mcp_prompt,
+    "mcp_install_registry": mcp_install_registry,
+    "mcp_install_package": mcp_install_package,
+    "mcp_install_local": mcp_install_local,
+    "mcp_call_tool": mcp_call_tool,
+    "mcp_install": mcp_install,
+    "mcp_drop_server": mcp_drop_server,
+}

--- a/src/reyn/tools/descriptions/memory.py
+++ b/src/reyn/tools/descriptions/memory.py
@@ -1,0 +1,134 @@
+"""Tool descriptions for the ``memory`` category.
+
+Phase 2 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): every ``memory``-category
+ToolDefinition's description string lives here as a reviewable
+``ToolDescription`` record. Each ``.text`` value is copied verbatim from
+its origin tool module (``memory.py``); the origin module now aliases
+its ``_X_DESCRIPTION`` module constant to ``memory.NAME.text`` so every
+call site is unchanged.
+
+Covers: list_memory, read_memory_body, remember_shared, remember_agent,
+forget_memory.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+list_memory = ToolDescription(
+    tool_name="list_memory",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — Type C "
+        "closure per ADR-0026"
+    ),
+    purpose=(
+        "Browse persisted memory hierarchically (shared/agent layers) to "
+        "find a relevant entry before deciding whether read_memory_body is "
+        "needed."
+    ),
+    text=(
+        'Browse persisted memory hierarchically. Path = "" (roots) '
+        '| "shared" | "shared/user" | "agent/feedback" etc. '
+        "Returns child categories or item entries "
+        "(slug + name + one-line description)."
+    ),
+    ja=(
+        "永続化されたメモリを階層的に閲覧する。path は \"\"（ルート）/ "
+        "\"shared\" / \"shared/user\" / \"agent/feedback\" 等。子カテゴリ"
+        "または項目（slug + name + 一行説明）を返す。"
+    ),
+)
+
+read_memory_body = ToolDescription(
+    tool_name="read_memory_body",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — Type C "
+        "closure per ADR-0026"
+    ),
+    purpose=(
+        "Fetch the full body of one memory entry when list_memory's "
+        "one-line description isn't enough to answer the user."
+    ),
+    text=(
+        "Fetch the full body of one memory entry. "
+        "Use only when list_memory's description is too vague "
+        "to answer the user."
+    ),
+    ja=(
+        "1つのメモリエントリの本文全体を取得する。list_memory の説明では"
+        "ユーザーへの回答に不十分な場合にのみ使う。"
+    ),
+)
+
+remember_shared = ToolDescription(
+    tool_name="remember_shared",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — Type C "
+        "closure per ADR-0026"
+    ),
+    purpose=(
+        "Persist a durable, project-wide fact (user role / project decision "
+        "/ external reference) that should benefit every agent."
+    ),
+    text=(
+        "Persist a durable fact to project-wide (shared) memory. "
+        "Use for user role / project decisions / external references "
+        "that benefit all agents."
+    ),
+    ja=(
+        "プロジェクト全体（共有）メモリに永続的な事実を記録する。ユーザー"
+        "の役割・プロジェクトの決定事項・外部参照など、全エージェントに"
+        "有益な情報に使う。"
+    ),
+)
+
+remember_agent = ToolDescription(
+    tool_name="remember_agent",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — Type C "
+        "closure per ADR-0026"
+    ),
+    purpose=(
+        "Persist a durable fact to this agent's own private memory (a "
+        "preference/feedback/context that should not propagate to other "
+        "agents)."
+    ),
+    text=(
+        "Persist a durable fact to this agent's private memory. "
+        "Use for agent-specific preferences, feedback, or context "
+        "that should not propagate to all agents."
+    ),
+    ja=(
+        "このエージェント自身の個人メモリに永続的な事実を記録する。他の"
+        "エージェントに広めるべきでない、エージェント固有の好み・"
+        "フィードバック・文脈に使う。"
+    ),
+)
+
+forget_memory = ToolDescription(
+    tool_name="forget_memory",
+    surfaced=(
+        "router + phase (gates.router=allow, gates.phase=allow) — Type C "
+        "closure per ADR-0026"
+    ),
+    purpose=(
+        "Delete a memory entry, restricted to explicit user intent (the "
+        "user says 'forget') or a discovered-wrong memory."
+    ),
+    text=(
+        "Delete a memory entry. Only when the user explicitly says "
+        "'forget' or the memory turned out wrong."
+    ),
+    ja=(
+        "メモリエントリを削除する。ユーザーが明示的に「忘れて」と言った"
+        "場合、またはそのメモリが誤りだったと判明した場合にのみ使う。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "list_memory": list_memory,
+    "read_memory_body": read_memory_body,
+    "remember_shared": remember_shared,
+    "remember_agent": remember_agent,
+    "forget_memory": forget_memory,
+}

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import io as _io_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_DROP_SOURCE_DESCRIPTION = (
-    "Remove an indexed source entirely (= delete its SQLite + manifest entry). "
-    "Use when retiring trial sources or replacing with a different strategy. "
-    "Permission-gated; user is prompted to confirm."
-)
+# Reviewable in src/reyn/tools/descriptions/io.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_DROP_SOURCE_DESCRIPTION = _io_descriptions.drop_source.text
 
 _DROP_SOURCE_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import io as _io_descriptions
 from reyn.tools.op_context_bridge import (
     build_legacy_op_context as _build_legacy_op_context,
 )
@@ -27,55 +28,24 @@ from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # Descriptions must be byte-identical to the ToolSpec.description literals in
 # router_tools.py lines ~546-614 (C1-C4 block). Copied verbatim.
+#
+# Reviewable in src/reyn/tools/descriptions/io.py (Phase 2 of the
+# tool-description package refactor) — these aliases keep the call sites
+# unchanged (byte-identical relocation, no LLM-facing text change).
 
-_LIST_DIRECTORY_DESCRIPTION = (
-    "List contents of a directory under the agent's read scope. "
-    "Returns names + types (file/dir)."
-)
+_LIST_DIRECTORY_DESCRIPTION = _io_descriptions.list_directory.text
 
-_READ_FILE_DESCRIPTION = (
-    "Read a file's contents under the agent's read scope. "
-    "Common conventions: README is at project root as "
-    "`README.md`. CLAUDE.md, CHANGELOG.md, and "
-    "configuration files (e.g. `reyn.yaml`, "
-    "`pyproject.toml`) are at project root. Try these "
-    "conventional paths directly instead of asking the "
-    "user where the file lives."
-)
+_READ_FILE_DESCRIPTION = _io_descriptions.read_file.text
 
-_WRITE_FILE_DESCRIPTION = (
-    "Write content to a file under the agent's write scope. "
-    "Creates or overwrites the WHOLE file. For a partial or surgical "
-    "change to an existing file, prefer the `file__edit` action instead of "
-    "rewriting the whole file."
-)
+_WRITE_FILE_DESCRIPTION = _io_descriptions.write_file.text
 
-_DELETE_FILE_DESCRIPTION = (
-    "Delete a file under the agent's write scope."
-)
+_DELETE_FILE_DESCRIPTION = _io_descriptions.delete_file.text
 
-_EDIT_FILE_DESCRIPTION = (
-    "Replace a unique string in a file under the agent's write scope. "
-    "`old_string` MUST appear exactly once in the file; if it appears "
-    "multiple times, the call fails with a count — re-call with a longer "
-    "context-including snippet, or pass `replace_all=true` to replace "
-    "every occurrence. Use this for partial edits instead of read+write "
-    "for the whole file."
-)
+_EDIT_FILE_DESCRIPTION = _io_descriptions.edit_file.text
 
-_GREP_FILES_DESCRIPTION = (
-    "Search for a regex pattern across files under the agent's read scope. "
-    "Use this when you need to find text or code patterns in files — "
-    "do NOT use list_directory for grep/glob intent. "
-    "Returns matching lines with file paths and line numbers."
-)
+_GREP_FILES_DESCRIPTION = _io_descriptions.grep_files.text
 
-_GLOB_FILES_DESCRIPTION = (
-    "Find files matching a glob pattern (e.g. '**/*.py') under the agent's "
-    "read scope. Use `**` to recurse into subdirectories. Use this when you "
-    "need to enumerate files by name pattern — do NOT use list_directory "
-    "for glob intent. Returns a list of matching file paths."
-)
+_GLOB_FILES_DESCRIPTION = _io_descriptions.glob_files.text
 
 # Parameters JSON schemas must be byte-identical to the ToolSpec.parameters
 # literals in router_tools.py lines ~546-614 (C1-C4 block). Copied verbatim.

--- a/src/reyn/tools/index_update.py
+++ b/src/reyn/tools/index_update.py
@@ -20,20 +20,13 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from reyn.core.offload.canonical import index_update_to_canonical
+from reyn.tools.descriptions import io as _io_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_INDEX_UPDATE_DESCRIPTION = (
-    "Incrementally ingest chunks into an indexed source, reconciling "
-    "against its current content: NEW content_hash values are embedded and "
-    "added; a source_path whose chunks changed (new hash under a path "
-    "already indexed) is updated (old chunks for that path replaced); a "
-    "source_path this call re-supplies chunks for but whose old chunk "
-    "hashes are absent from this call are removed; unchanged content_hash "
-    "values are skipped (no re-embed). NO full-rebuild mode — to rebuild a "
-    "source from scratch, call `drop_source` then `index_update` on the "
-    "fresh (empty) source. The caller supplies pre-chunked text (chunking "
-    "is the caller's responsibility, not this tool's)."
-)
+# Reviewable in src/reyn/tools/descriptions/io.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_INDEX_UPDATE_DESCRIPTION = _io_descriptions.index_update.text
 
 _INDEX_UPDATE_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -61,33 +61,25 @@ from __future__ import annotations
 import copy
 from typing import TYPE_CHECKING, Any, Final, Mapping
 
+from reyn.tools.descriptions import mcp as _mcp_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 if TYPE_CHECKING:
     from reyn.tools.types import RouterCallerState
 
 # ── Description constants (byte-identical to router_tools.py D1/D2/D3) ────────
+#
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — these aliases keep the call sites
+# unchanged (byte-identical relocation, no LLM-facing text change).
 
-_LIST_MCP_SERVERS_DESCRIPTION = (
-    "List available MCP servers configured for this agent. "
-    "Returns name + description per server."
-)
+_LIST_MCP_SERVERS_DESCRIPTION = _mcp_descriptions.list_mcp_servers.text
 
-_LIST_MCP_TOOLS_DESCRIPTION = (
-    "List tools exposed by one MCP server "
-    "(with description per tool)."
-)
+_LIST_MCP_TOOLS_DESCRIPTION = _mcp_descriptions.list_mcp_tools.text
 
-_CALL_MCP_TOOL_DESCRIPTION = (
-    "Invoke a mcp_tool on an MCP server. Construct args matching "
-    "the mcp_tool's input schema (see describe_mcp_tool)."
-)
+_CALL_MCP_TOOL_DESCRIPTION = _mcp_descriptions.call_mcp_tool.text
 
-_DESCRIBE_MCP_TOOL_DESCRIPTION = (
-    "Get the input schema for one mcp_tool registered on an MCP server. "
-    "Call this before call_mcp_tool if you're unsure how to "
-    "construct the args."
-)
+_DESCRIBE_MCP_TOOL_DESCRIPTION = _mcp_descriptions.describe_mcp_tool.text
 
 
 # ── Parameters JSON schemas (byte-identical to router_tools.py D1/D2/D3) ──────
@@ -162,10 +154,7 @@ _DESCRIBE_MCP_TOOL_PARAMETERS: dict[str, Any] = {
 
 # ── #2597 slice ②a: resources consumption parameters ──────────────────────────
 
-_LIST_MCP_RESOURCES_DESCRIPTION = (
-    "List resources exposed by one MCP server "
-    "(with uri + description per resource)."
-)
+_LIST_MCP_RESOURCES_DESCRIPTION = _mcp_descriptions.list_mcp_resources.text
 
 _LIST_MCP_RESOURCES_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -178,10 +167,7 @@ _LIST_MCP_RESOURCES_PARAMETERS: dict[str, Any] = {
     "required": ["server"],
 }
 
-_LIST_MCP_RESOURCE_TEMPLATES_DESCRIPTION = (
-    "List resource templates (parameterized URI patterns) exposed by one "
-    "MCP server. Use list_mcp_resources for concrete resources."
-)
+_LIST_MCP_RESOURCE_TEMPLATES_DESCRIPTION = _mcp_descriptions.list_mcp_resource_templates.text
 
 _LIST_MCP_RESOURCE_TEMPLATES_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -194,11 +180,7 @@ _LIST_MCP_RESOURCE_TEMPLATES_PARAMETERS: dict[str, Any] = {
     "required": ["server"],
 }
 
-_READ_MCP_RESOURCE_DESCRIPTION = (
-    "Read the contents of one MCP resource by URI. Get the uri from "
-    "list_mcp_resources (or by resolving a list_mcp_resource_templates "
-    "template)."
-)
+_READ_MCP_RESOURCE_DESCRIPTION = _mcp_descriptions.read_mcp_resource.text
 
 _READ_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -218,12 +200,7 @@ _READ_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
 
 # ── #2597 slice ②b: resource subscriptions parameters ─────────────────────────
 
-_SUBSCRIBE_MCP_RESOURCE_DESCRIPTION = (
-    "Subscribe to server-pushed updates for one MCP resource by URI. When the "
-    "server-side content changes, a mcp_resource_updated event is recorded — "
-    "call read_mcp_resource again to see the new content (the push notification "
-    "itself carries no content, just a signal that something changed)."
-)
+_SUBSCRIBE_MCP_RESOURCE_DESCRIPTION = _mcp_descriptions.subscribe_mcp_resource.text
 
 _SUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -240,10 +217,7 @@ _SUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "required": ["server", "uri"],
 }
 
-_UNSUBSCRIBE_MCP_RESOURCE_DESCRIPTION = (
-    "Unsubscribe from server-pushed updates for one MCP resource by URI "
-    "(previously subscribed via subscribe_mcp_resource)."
-)
+_UNSUBSCRIBE_MCP_RESOURCE_DESCRIPTION = _mcp_descriptions.unsubscribe_mcp_resource.text
 
 _UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -263,10 +237,7 @@ _UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
 
 # ── #2597 slice ②c: prompts consumption parameters ────────────────────────────
 
-_LIST_MCP_PROMPTS_DESCRIPTION = (
-    "List prompts exposed by one MCP server "
-    "(with name + description + arguments per prompt)."
-)
+_LIST_MCP_PROMPTS_DESCRIPTION = _mcp_descriptions.list_mcp_prompts.text
 
 _LIST_MCP_PROMPTS_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -279,10 +250,7 @@ _LIST_MCP_PROMPTS_PARAMETERS: dict[str, Any] = {
     "required": ["server"],
 }
 
-_GET_MCP_PROMPT_DESCRIPTION = (
-    "Fetch one rendered MCP prompt's messages by name. Get the name (and its "
-    "argument schema) from list_mcp_prompts."
-)
+_GET_MCP_PROMPT_DESCRIPTION = _mcp_descriptions.get_mcp_prompt.text
 
 _GET_MCP_PROMPT_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -26,17 +26,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import mcp as _mcp_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_MCP_DROP_SERVER_DESCRIPTION = (
-    "Remove a configured MCP server. "
-    "Counter-op to mcp_install — deletes the server entry from "
-    "reyn.local.yaml / reyn.yaml / ~/.reyn/config.yaml (scope is "
-    "auto-detected when omitted). Optionally cleans the matching "
-    "${KEY} env entries from ~/.reyn/secrets.env. "
-    "Permission-gated via mcp_drop_server (= distinct from "
-    "mcp_install; install intent alone is insufficient)."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_DROP_SERVER_DESCRIPTION = _mcp_descriptions.mcp_drop_server.text
 
 
 _MCP_DROP_SERVER_PARAMETERS: dict[str, Any] = {

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -17,17 +17,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import mcp as _mcp_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_MCP_INSTALL_DESCRIPTION = (
-    "Install an MCP server from the registry. "
-    "Fetches server.json, gates via permission resolver, "
-    "prompts for secrets, and writes the server entry to the "
-    "appropriate scope config file (local / project / user). "
-    "Status: enabled — this tool's presence in your tool list means "
-    "the required `file.write` and `http.get` permissions are verified. "
-    "Call mcp_install directly; do not abort on permission concerns."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_INSTALL_DESCRIPTION = _mcp_descriptions.mcp_install.text
 
 _MCP_INSTALL_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -41,6 +41,7 @@ from dataclasses import asdict
 from typing import Any, Mapping
 
 from reyn.tools.descriptions import discovery
+from reyn.tools.descriptions import mcp as _mcp_descriptions
 from reyn.tools.mcp import _MCP_TOOL_ARGS_KEY  # #1646: single-source the inner-args key
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
@@ -114,14 +115,10 @@ async def _handle_mcp_search_registry(
 # ── mcp__install_registry ─────────────────────────────────────────────────────
 
 
-_MCP_INSTALL_REGISTRY_DESCRIPTION = (
-    "Install an MCP server from the official MCP registry by its "
-    "registry name (server_id from mcp__search_registry candidates[].name). "
-    "When the server requires secret environment variables that the "
-    "operator has not yet set, the call returns status='needs_secrets' "
-    "with a guide explaining the `reyn secret set <KEY>` command; relay "
-    "that to the user and retry after they confirm secrets are set."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_INSTALL_REGISTRY_DESCRIPTION = _mcp_descriptions.mcp_install_registry.text
 
 _MCP_INSTALL_REGISTRY_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -213,13 +210,10 @@ async def _handle_mcp_install_registry(
 # ── mcp__install_package ──────────────────────────────────────────────────────
 
 
-_MCP_INSTALL_PACKAGE_DESCRIPTION = (
-    "Install an MCP server from a third-party package channel "
-    "(npm / pypi / docker) or a GitHub repo URL. Use when the server "
-    "isn't in the official registry (= mcp__search_registry returned "
-    "no match). Secret detection works the same as install_registry "
-    "for npm/pypi/docker; github URLs cannot pre-declare secrets."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_INSTALL_PACKAGE_DESCRIPTION = _mcp_descriptions.mcp_install_package.text
 
 _MCP_INSTALL_PACKAGE_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -342,12 +336,10 @@ async def _handle_mcp_install_package(
 # ── mcp__install_local ────────────────────────────────────────────────────────
 
 
-_MCP_INSTALL_LOCAL_DESCRIPTION = (
-    "Install a local MCP server by registering a {command, args} pair "
-    "directly. Use for LLM-authored scripts or local development "
-    "servers. Bypasses package registries — cannot auto-detect required "
-    "secrets, so pass env_overrides inline when the server needs env-vars."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_INSTALL_LOCAL_DESCRIPTION = _mcp_descriptions.mcp_install_local.text
 
 _MCP_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -533,16 +525,10 @@ async def _handle_mcp_install_local(
 # ── mcp__call_tool ────────────────────────────────────────────────────────────
 
 
-_MCP_CALL_TOOL_DESCRIPTION = (
-    "Call a tool on an installed MCP server — GENERIC FALLBACK. "
-    "PREFER the per-tool 'mcp__<server>__<tool>' actions (e.g. "
-    "'mcp__time__get_current_time') when one is listed: they take the target "
-    "tool's own parameters directly (authoritative input_schema via "
-    "describe_action), with no generic envelope. Use this generic verb only as "
-    "a fallback when no per-tool action is available. Pass the tool identifier "
-    "in <server>__<tool> form (e.g. 'time__get_current_time') as returned by "
-    "mcp__list_tools, plus the tool's own args dict."
-)
+# Reviewable in src/reyn/tools/descriptions/mcp.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_MCP_CALL_TOOL_DESCRIPTION = _mcp_descriptions.mcp_call_tool.text
 
 _MCP_CALL_TOOL_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -42,39 +42,24 @@ import re
 from pathlib import Path
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import memory as _memory_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # ── Description literals — byte-identical to router_tools.py ToolSpec literals ─
+#
+# Reviewable in src/reyn/tools/descriptions/memory.py (Phase 2 of the
+# tool-description package refactor) — these aliases keep the call sites
+# unchanged (byte-identical relocation, no LLM-facing text change).
 
-_LIST_MEMORY_DESCRIPTION = (
-    'Browse persisted memory hierarchically. Path = "" (roots) '
-    '| "shared" | "shared/user" | "agent/feedback" etc. '
-    "Returns child categories or item entries "
-    "(slug + name + one-line description)."
-)
+_LIST_MEMORY_DESCRIPTION = _memory_descriptions.list_memory.text
 
-_READ_MEMORY_BODY_DESCRIPTION = (
-    "Fetch the full body of one memory entry. "
-    "Use only when list_memory's description is too vague "
-    "to answer the user."
-)
+_READ_MEMORY_BODY_DESCRIPTION = _memory_descriptions.read_memory_body.text
 
-_REMEMBER_SHARED_DESCRIPTION = (
-    "Persist a durable fact to project-wide (shared) memory. "
-    "Use for user role / project decisions / external references "
-    "that benefit all agents."
-)
+_REMEMBER_SHARED_DESCRIPTION = _memory_descriptions.remember_shared.text
 
-_REMEMBER_AGENT_DESCRIPTION = (
-    "Persist a durable fact to this agent's private memory. "
-    "Use for agent-specific preferences, feedback, or context "
-    "that should not propagate to all agents."
-)
+_REMEMBER_AGENT_DESCRIPTION = _memory_descriptions.remember_agent.text
 
-_FORGET_MEMORY_DESCRIPTION = (
-    "Delete a memory entry. Only when the user explicitly says "
-    "'forget' or the memory turned out wrong."
-)
+_FORGET_MEMORY_DESCRIPTION = _memory_descriptions.forget_memory.text
 
 
 

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -15,15 +15,13 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from reyn.llm.model_resolver import resolve_purpose_class  # #1673
+from reyn.tools.descriptions import execution as _execution_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_SANDBOXED_EXEC_DESCRIPTION = (
-    "Execute a command in a sandboxed environment (FP-0017). The sandbox "
-    "policy (network access + filesystem scope) is the OPERATOR's, resolved "
-    "by the OS — it is not chosen here. "
-    "argv: command and arguments (argv[0] is the executable). "
-    "timeout_seconds: wall-clock time limit in seconds (default 60)."
-)
+# Reviewable in src/reyn/tools/descriptions/execution.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_SANDBOXED_EXEC_DESCRIPTION = _execution_descriptions.sandboxed_exec.text
 
 
 # #1339 / sandbox-model completion: the tool exposes ONLY argv (+ timeout). The

--- a/src/reyn/tools/session_spawn.py
+++ b/src/reyn/tools/session_spawn.py
@@ -20,14 +20,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import delegation as _delegation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_SESSION_SPAWN_DESCRIPTION = (
-    "Spawn a fresh-context session under your agent to run a task in isolation. "
-    "Choose mode='ephemeral' (auto-vanishes after the task) or 'persistent'. "
-    "Optionally narrow the sub-session's capabilities (restrict-only). The session "
-    "runs the task; its result stays in that session."
-)
+# Reviewable in src/reyn/tools/descriptions/delegation.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_SESSION_SPAWN_DESCRIPTION = _delegation_descriptions.session_spawn.text
 
 _SESSION_SPAWN_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/shell.py
+++ b/src/reyn/tools/shell.py
@@ -30,16 +30,13 @@ from __future__ import annotations
 import json
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import execution as _execution_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates
 
-_SHELL_DESCRIPTION = (
-    "Run a shell command (via sandboxed_exec) whose STDIN receives the "
-    "previous pipeline step's pipe-data JSON-encoded, and whose STDOUT "
-    "becomes this step's output. command: the shell command line "
-    "(argv[0]='/bin/sh', argv[1]='-c'). timeout: wall-clock time limit in "
-    "seconds (default 60). The sandbox policy (network access + filesystem "
-    "scope) is the OPERATOR's, resolved by the OS — it is not chosen here."
-)
+# Reviewable in src/reyn/tools/descriptions/execution.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_SHELL_DESCRIPTION = _execution_descriptions.shell.text
 
 _SHELL_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/topology_create.py
+++ b/src/reyn/tools/topology_create.py
@@ -21,16 +21,13 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import delegation as _delegation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_TOPOLOGY_CREATE_DESCRIPTION = (
-    "Wire agents you spawned into a topology (org-design): group them by kind "
-    "(network = all-to-all, team = star around a leader, pipeline = ordered chain) to "
-    "control who-can-message-whom, and optionally bind each member to a "
-    "capability_profile to narrow it further. You may only include agents in your own "
-    "spawn subtree (yourself or agents you created via agent_spawn) — a member's "
-    "capabilities stay capped at a SUBSET of yours."
-)
+# Reviewable in src/reyn/tools/descriptions/delegation.py (Phase 2 of the
+# tool-description package refactor) — this alias keeps the call site
+# unchanged (byte-identical relocation, no LLM-facing text change).
+_TOPOLOGY_CREATE_DESCRIPTION = _delegation_descriptions.topology_create.text
 
 _TOPOLOGY_CREATE_PARAMETERS: dict[str, Any] = {
     "type": "object",


### PR DESCRIPTION
**[tooldesc-coder]** — Phase 2 of the tool-description package refactor (Phase 1 = #2862, which proved the pattern). Relocates the bulk-category `ToolDefinition.description` constants into new `src/reyn/tools/descriptions/<category>.py` modules so a reviewer audits LLM-facing tool text in one place instead of grepping across `src/reyn/tools/*.py`.

**Byte-identical relocation — NO LLM-facing text change.** Each origin tool module now aliases `_X_DESCRIPTION = descriptions.<category>.NAME.text`, so **every call site is unchanged** (the alias pattern from #2862). Each `ToolDescription.text` is copy-pasted verbatim; `surfaced`/`purpose` are review-aid metadata; `ja` is purpose-based Japanese (decision B), never a literal translation, never LLM-facing.

## Relocated categories + constants

- **io.py** (9): `read_file`, `write_file`, `delete_file`, `edit_file`, `grep_files`, `glob_files`, `list_directory` (← `file.py`), `drop_source` (← `drop_source.py`), `index_update` (← `index_update.py`, grouped by feature; its `category=` is `"discovery"` in code).
- **memory.py** (5): `list_memory`, `read_memory_body`, `remember_shared`, `remember_agent`, `forget_memory` (← `memory.py`).
- **mcp.py** (17): `list_mcp_servers`, `list_mcp_tools`, `call_mcp_tool`, `describe_mcp_tool`, `list_mcp_resources`, `list_mcp_resource_templates`, `read_mcp_resource`, `subscribe_mcp_resource`, `unsubscribe_mcp_resource`, `list_mcp_prompts`, `get_mcp_prompt` (← `mcp.py`); `mcp_install_registry`, `mcp_install_package`, `mcp_install_local`, `mcp_call_tool` (← `mcp_verbs.py`); `mcp_install` (← `mcp_install.py`); `mcp_drop_server` (← `mcp_drop.py`). **`mcp_search_registry` NOT double-moved** — it stays in `descriptions.discovery` from Phase 1.
- **execution.py** (2): `sandboxed_exec` (← `sandboxed_exec.py`), `shell` (← `shell.py`).
- **delegation.py** (4): `agent_spawn`, `delegate_to_agent`, `session_spawn`, `topology_create`.

Out of scope (per brief): discovery category (done, Phase 1), param-level descriptions (Phase 3), `task_ops.py` (Phase 3, data-tuple special case), the SP/prompt package (sibling owns it).

## Contract guard

The **existing** `tests/tools/test_tool_description_relocation.py` full-schema byte-identical baseline test (all 82 tools' `render_for_router()` — description AND parameters — vs `_pre_migration_tool_schemas_baseline.json`) **stays GREEN against the UNCHANGED baseline** — the relocation is byte-identical, so current render == the pre-migration baseline. **Baseline NOT regenerated** (regenerating would defeat the guard). Liveness + completeness gates extend automatically to the new `ALL` entries.

**Strip-falsify verified**: changed one relocated `text` (`io.list_directory`) by 1 char → the full-schema contract test went **RED** (`tool 'list_directory' render_for_router() output diverged from the pre-migration baseline`); restored → GREEN.

## CI gates (all 4, local)

- `ruff check src tests` → **All checks passed!**
- `python scripts/test_tier_audit.py --strict tests/tools/test_tool_description_relocation.py` → **3 inspected, 0 Tier-4 violations, exit 0** (no test files changed in Phase 2 — pure source relocation).
- `pytest` (repo root) → **8185 passed, 20 skipped, 9 warnings** (0 failures; warnings are pre-existing).
- `python scripts/verify_module_docstrings.py <20 changed src files>` → **OK: no module-docstring refactor narrative.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)