### PR TITLE
refactor: tool-description package Phase 3 — remaining categories + task data-tuple (byte-identical)

### DIFF
--- a/src/reyn/tools/ask_user.py
+++ b/src/reyn/tools/ask_user.py
@@ -15,17 +15,12 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import interactive as _interactive_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_ASK_USER_DESCRIPTION = (
-    "Pause the current phase and ask the user a clarifying question. "
-    "The OS suspends execution, presents the question (and optional "
-    "suggestions) to the user, waits for a free-text answer, and "
-    "resumes the phase with the answer available as a control IR result. "
-    "question: the question to display to the user. "
-    "suggestions: optional list of suggested responses. "
-    "required: if true (default), an empty answer is rejected."
-)
+# Relocated to reyn.tools.descriptions.interactive (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_ASK_USER_DESCRIPTION = _interactive_descriptions.ask_user.text
 
 _ASK_USER_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/catalog.py
+++ b/src/reyn/tools/catalog.py
@@ -24,17 +24,14 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import catalog as _catalog_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # ── list_agents ───────────────────────────────────────────────────────────────
 
-# Byte-identical to router_tools.py ToolSpec description for list_agents
-# (lines 297–301). Copied verbatim.
-_LIST_AGENTS_DESCRIPTION = (
-    "Browse peer agents reachable via topology. "
-    "Pass empty path for clusters; "
-    "pass a cluster name for agents in it."
-)
+# Relocated to reyn.tools.descriptions.catalog (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_LIST_AGENTS_DESCRIPTION = _catalog_descriptions.list_agents.text
 
 # Byte-identical to router_tools.py ToolSpec parameters for list_agents
 # (lines 302–308). Copied verbatim.
@@ -88,12 +85,9 @@ LIST_AGENTS = ToolDefinition(
 
 # ── describe_agent ────────────────────────────────────────────────────────────
 
-# Byte-identical to router_tools.py ToolSpec description for describe_agent
-# (lines 313–316). Copied verbatim.
-_DESCRIBE_AGENT_DESCRIPTION = (
-    "Fetch full role / capabilities profile for one agent. "
-    "Call before delegate_to_agent if uncertain."
-)
+# Relocated to reyn.tools.descriptions.catalog (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_DESCRIBE_AGENT_DESCRIPTION = _catalog_descriptions.describe_agent.text
 
 # Byte-identical to router_tools.py ToolSpec parameters for describe_agent
 # (lines 317–323). Copied verbatim.

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -14,16 +14,12 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import context as _context_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_COMPACT_DESCRIPTION = (
-    "Compact the conversation history now: summarise older turns to free up "
-    "context window. Use this when the 'Context window' status shows the free "
-    "window getting low and you still have work to do — compacting first frees "
-    "room so subsequent steps and large tool results fit. Returns the freed "
-    "tokens and the free window afterwards (exact tokens). The system also "
-    "compacts automatically as a backstop; this lets you do it proactively."
-)
+# Relocated to reyn.tools.descriptions.context (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_COMPACT_DESCRIPTION = _context_descriptions.compact.text
 
 _COMPACT_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -41,38 +41,18 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import cron as _cron_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-# ── Description literals ──────────────────────────────────────────────
+# ── Description literals (relocated to reyn.tools.descriptions.cron;
+# Phase 3 tool-description package refactor — byte-identical, no
+# LLM-facing text change) ──────────────────────────────────────────────
 
-_CRON_REGISTER_DESCRIPTION = (
-    "Schedule a recurring message to a Reyn agent. The cron scheduler "
-    "delivers the message to the target agent's inbox at each cron "
-    "fire — the agent processes it as a normal attributed turn from "
-    "a scheduled trigger. Idempotent on `name` (= replaces existing). "
-    "Use for periodic checks, reminders, automated summaries."
-)
-
-_CRON_UNREGISTER_DESCRIPTION = (
-    "Remove a previously-registered cron job by name. The schedule "
-    "stops firing immediately. No-op if the job doesn't exist."
-)
-
-_CRON_LIST_DESCRIPTION = (
-    "List all currently-registered cron jobs (= both reyn.yaml legacy "
-    "and .reyn/config/cron.yaml dynamic entries, unioned). Returns job name, "
-    "target, message/action, schedule, enabled state, and next-run time."
-)
-
-_CRON_ENABLE_DESCRIPTION = (
-    "Enable a previously-disabled cron job. The scheduler resumes "
-    "firing it on its schedule. No-op if already enabled."
-)
-
-_CRON_DISABLE_DESCRIPTION = (
-    "Disable a cron job without removing it. The schedule stops firing "
-    "until re-enabled via `cron__enable`. Use to pause a job temporarily."
-)
+_CRON_REGISTER_DESCRIPTION = _cron_descriptions.cron_register.text
+_CRON_UNREGISTER_DESCRIPTION = _cron_descriptions.cron_unregister.text
+_CRON_LIST_DESCRIPTION = _cron_descriptions.cron_list.text
+_CRON_ENABLE_DESCRIPTION = _cron_descriptions.cron_enable.text
+_CRON_DISABLE_DESCRIPTION = _cron_descriptions.cron_disable.text
 
 
 # ── Parameter schemas ─────────────────────────────────────────────────

--- a/src/reyn/tools/descriptions/__init__.py
+++ b/src/reyn/tools/descriptions/__init__.py
@@ -7,28 +7,52 @@ record — the exact LLM-facing ``text`` plus review-aid metadata (``surfaced``,
 grepping across ``src/reyn/tools/*.py``.
 
 Phase 1 covered the ``discovery`` category (see ``descriptions.discovery``).
-Phase 2 adds ``io``, ``memory``, ``mcp``, ``execution``, and ``delegation``
-(see the matching modules below) — the bulk categories, mechanical repeats
-of the Phase 1 pattern. Each origin tool module keeps a
-``_X_DESCRIPTION = descriptions.<category>.<name>.text`` alias so no call
+Phase 2 added ``io``, ``memory``, ``mcp``, ``execution``, and ``delegation``
+— the bulk categories, mechanical repeats of the Phase 1 pattern. Phase 3
+completes tool-LEVEL relocation with the remaining feature-area buckets:
+``cron``, ``hooks``, ``presentation``, ``catalog`` (peer-agent browse +
+``invoke_action``), ``interactive``, ``context``, ``pipeline`` (launch
+verbs), ``pipeline_management`` (install verbs), ``skill`` (install
+verbs), ``dev`` (``reyn_src_*``), and ``task`` (the 12 ``task.*``
+control-IR ops — the one module lifted out of a data-tuple rather than
+``_X_DESCRIPTION`` constants; see ``descriptions.task``'s docstring).
+Each origin tool module keeps a
+``_X_DESCRIPTION = descriptions.<bucket>.<name>.text`` alias so no call
 site changes — this package is purely a relocation of the string literal,
-never a behavior change.
+never a behavior change. Module grouping is CONCEPTUAL (feature area),
+not always a literal mirror of ``ToolDefinition.category`` — e.g.
+``catalog`` holds ``invoke_action`` (``category="invocation"``) alongside
+``list_agents`` / ``describe_agent`` (``category="discovery"``), matching
+the ``mcp`` module precedent from Phase 2 (mixed ``category`` values,
+grouped by feature).
 
-``ALL`` aggregates every category's descriptions into one
+``ALL`` aggregates every bucket's descriptions into one
 ``dict[str, ToolDescription]`` keyed by a package-unique entry name (NOT
 always the bare tool name — e.g. ``semantic_search_hide_legacy`` shares
 ``tool_name="semantic_search"`` with the ``semantic_search`` entry, since it
-is an alternate, currently-unwired description variant for that same tool).
+is an alternate, currently-unwired description variant for that same tool;
+the 12 ``task`` entries are keyed by their op_kind, e.g. ``"task.create"``).
 """
 from __future__ import annotations
 
 from reyn.tools.descriptions import (
+    catalog,
+    context,
+    cron,
     delegation,
+    dev,
     discovery,
     execution,
+    hooks,
+    interactive,
     io,
     mcp,
     memory,
+    pipeline,
+    pipeline_management,
+    presentation,
+    skill,
+    task,
 )
 from reyn.tools.descriptions._types import ToolDescription
 
@@ -39,6 +63,17 @@ ALL: dict[str, ToolDescription] = {
     **mcp.ALL,
     **execution.ALL,
     **delegation.ALL,
+    **cron.ALL,
+    **hooks.ALL,
+    **presentation.ALL,
+    **catalog.ALL,
+    **interactive.ALL,
+    **context.ALL,
+    **pipeline.ALL,
+    **pipeline_management.ALL,
+    **skill.ALL,
+    **dev.ALL,
+    **task.ALL,
 }
 
 __all__ = [
@@ -49,5 +84,16 @@ __all__ = [
     "mcp",
     "execution",
     "delegation",
+    "cron",
+    "hooks",
+    "presentation",
+    "catalog",
+    "interactive",
+    "context",
+    "pipeline",
+    "pipeline_management",
+    "skill",
+    "dev",
+    "task",
     "ALL",
 ]

--- a/src/reyn/tools/descriptions/catalog.py
+++ b/src/reyn/tools/descriptions/catalog.py
@@ -1,0 +1,127 @@
+"""Tool descriptions for the ``catalog`` bucket.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the peer-agent catalog browse
+tools (``list_agents`` / ``describe_agent``, ADR-0026 M3 Wave 2, from
+``tools/catalog.py``) plus ``invoke_action`` (the universal catalog's
+single dispatch entry point, from ``tools/universal_catalog.py`` — its
+sibling discovery entries ``list_actions`` / ``search_actions`` /
+``describe_action`` were already relocated into ``descriptions.discovery``
+in Phase 1). Each ``.text`` value is copied verbatim from its origin tool
+module; the origin module now aliases its ``_X_DESCRIPTION`` constant to
+``catalog.NAME.text``.
+
+Note: ``list_agents`` / ``describe_agent`` carry ``ToolDefinition.category
+="discovery"`` and ``invoke_action`` carries ``category="invocation"`` — this
+module groups them by feature-area (catalog browse + dispatch), matching
+the ``mcp`` / ``io`` precedent set in Phase 2 (module grouping is
+conceptual, not a literal mirror of the ``category`` field).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+list_agents = ToolDescription(
+    tool_name="list_agents",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Browse peer agents reachable via topology (clusters, then agents "
+        "in a cluster) before delegating."
+    ),
+    text=(
+        "Browse peer agents reachable via topology. "
+        "Pass empty path for clusters; "
+        "pass a cluster name for agents in it."
+    ),
+    ja=(
+        "トポロジー経由で到達可能なピアエージェントを閲覧する。空の path "
+        "でクラスタ一覧、クラスタ名を渡すとそのクラスタ内のエージェント"
+        "一覧を返す。"
+    ),
+)
+
+describe_agent = ToolDescription(
+    tool_name="describe_agent",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Fetch one peer agent's full role/capabilities profile before "
+        "delegating to it, when uncertain it fits the task."
+    ),
+    text=(
+        "Fetch full role / capabilities profile for one agent. "
+        "Call before delegate_to_agent if uncertain."
+    ),
+    ja=(
+        "1つのエージェントの完全な役割・能力プロファイルを取得する。"
+        "delegate_to_agent の前に、そのエージェントが適任か不確かな場合"
+        "に呼ぶ。"
+    ),
+)
+
+invoke_action = ToolDescription(
+    tool_name="invoke_action",
+    surfaced=(
+        "router-only (gates.router=allow, gates.phase=deny) — the universal "
+        "catalog's single dispatch entry point for all 13 action categories"
+    ),
+    purpose=(
+        "Execute any catalog action by qualified name — the ONE dispatch "
+        "surface every action category (MCP tool, file op, web search, "
+        "memory write, semantic search, agent delegation, etc.) routes "
+        "through, so the LLM never needs a per-kind legacy tool."
+    ),
+    text=(
+        "WHAT: Execute an action by qualified name (<category>__<entry>). "
+        "Executes the action's default semantic operation. "
+        "WHEN: Call this whenever you intend to run any action — MCP tool, "
+        "file operation, web search, memory write, semantic search, etc. All catalog actions "
+        "are invoked through this single entry point. "
+        "WHEN NOT: For chitchat or self-questions, reply without tools. "
+        "PREFERRED OVER: Legacy per-kind tools (call_mcp_tool, etc.) — "
+        "invoke_action covers all 13 action categories uniformly. "
+        "On unknown action_name, returns an error with similar-name suggestions. "
+        ""
+        "SPAWN-ACK HANDLING: when an action result is {status:'spawned', ...}, the "
+        "router exits the current turn before this tool description applies; the OS "
+        "emits the user-visible acknowledgment directly. You will not be asked to "
+        "compose a reply for the spawn-ack turn. "
+        ""
+        "TASK_SPAWNED: an agent-role message starting with [task_spawned] is "
+        "OS-emitted when an async task is launched (kind=agent, paired "
+        "with chain_id). The structured header "
+        "lets you correlate the spawn with the later [task_completed] message "
+        "carrying the same identifier. The trailing human-readable line is "
+        "what the user sees; the header is your correlation record. "
+        ""
+        "TASK_COMPLETED: a user-role message starting with [task_completed] is "
+        "OS-injected when a previously-spawned async task finishes (kind=agent) "
+        "or a spawned session completes (kind=spawned_session). The message "
+        "carries the task's status + result "
+        "fields. status='finished' means normal completion; other values "
+        "('loop_limit_exceeded', 'phase_budget_exceeded', 'budget_exceeded', "
+        "'error', or any non-'finished' value with result.error present) "
+        "indicate the task did not complete normally. "
+        ""
+        "AGENT DELEGATION: For peer agent delegation, use "
+        "action_name='multi_agent__delegate' with args {to: '<agent_name>', "
+        "request: ...}; get its canonical args via "
+        "describe_action(action_name='multi_agent__delegate'). "
+        "Use when task is outside available actions but matches a peer agent's role, "
+        "or when user explicitly addresses a named agent. "
+        "Acknowledge delegation in 1 sentence."
+    ),
+    ja=(
+        "修飾名（<category>__<entry>）でアクションを実行する。MCP ツー"
+        "ル・ファイル操作・ウェブ検索・メモリ書き込み・意味検索など、"
+        "あらゆるカテゴリのアクションはこの単一のディスパッチ入口を通"
+        "して実行される。未知の action_name にはエラーと類似名の提案が"
+        "返る。ピアエージェントへの委任は "
+        "action_name='multi_agent__delegate' を使う。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "list_agents": list_agents,
+    "describe_agent": describe_agent,
+    "invoke_action": invoke_action,
+}

--- a/src/reyn/tools/descriptions/context.py
+++ b/src/reyn/tools/descriptions/context.py
@@ -1,0 +1,40 @@
+"""Tool descriptions for the ``context`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): ``compact`` (#272 / #1128), the
+voluntary history-compaction tool. ``.text`` is copied verbatim from
+``tools/compact.py``; the origin module now aliases ``_COMPACT_DESCRIPTION``
+to ``context.compact.text``.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+compact = ToolDescription(
+    tool_name="compact",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Let the model voluntarily free context-window room ahead of the "
+        "mandatory retry_loop backstop compaction, when it still has work "
+        "to do and the window is filling."
+    ),
+    text=(
+        "Compact the conversation history now: summarise older turns to free up "
+        "context window. Use this when the 'Context window' status shows the free "
+        "window getting low and you still have work to do — compacting first frees "
+        "room so subsequent steps and large tool results fit. Returns the freed "
+        "tokens and the free window afterwards (exact tokens). The system also "
+        "compacts automatically as a backstop; this lets you do it proactively."
+    ),
+    ja=(
+        "会話履歴を今すぐ圧縮する: 古いターンを要約してコンテキストウィ"
+        "ンドウを空ける。'Context window' の空き表示が少なくなり、まだ"
+        "作業が残っている場合に使う。解放されたトークン数とその後の空き"
+        "ウィンドウ（正確なトークン数）を返す。システムはバックストップ"
+        "として自動でも圧縮するが、これを使えば能動的に行える。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "compact": compact,
+}

--- a/src/reyn/tools/descriptions/cron.py
+++ b/src/reyn/tools/descriptions/cron.py
@@ -1,0 +1,105 @@
+"""Tool descriptions for the ``cron`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical relocation
+— no LLM-facing text change): the 5 cron verbs (register / unregister /
+list / enable / disable), FP-0041 #489 PR-B2's message-based cron shape.
+Each ``.text`` value is copied verbatim from ``tools/cron.py``; the origin
+module now aliases its ``_CRON_*_DESCRIPTION`` module constants to
+``cron.NAME.text`` so every call site is unchanged.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+cron_register = ToolDescription(
+    tool_name="cron_register",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose=(
+        "Schedule a recurring message-to-agent job so periodic checks / "
+        "reminders / summaries run without a live turn keeping them alive."
+    ),
+    text=(
+        "Schedule a recurring message to a Reyn agent. The cron scheduler "
+        "delivers the message to the target agent's inbox at each cron "
+        "fire — the agent processes it as a normal attributed turn from "
+        "a scheduled trigger. Idempotent on `name` (= replaces existing). "
+        "Use for periodic checks, reminders, automated summaries."
+    ),
+    ja=(
+        "Reyn エージェントへの定期メッセージをスケジュールする。cron 発火"
+        "ごとに対象エージェントの受信箱にメッセージが配送され、通常のター"
+        "ンとして処理される。`name` について冪等（既存を置き換える）。"
+        "定期チェックやリマインダー、自動サマリーに使う。"
+    ),
+)
+
+cron_unregister = ToolDescription(
+    tool_name="cron_unregister",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose="Remove a previously-registered cron job so it stops firing.",
+    text=(
+        "Remove a previously-registered cron job by name. The schedule "
+        "stops firing immediately. No-op if the job doesn't exist."
+    ),
+    ja=(
+        "名前を指定して既存の cron ジョブを削除する。スケジュールは即座"
+        "に停止する。ジョブが存在しない場合は何もしない。"
+    ),
+)
+
+cron_list = ToolDescription(
+    tool_name="cron_list",
+    surfaced="router-only (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Enumerate current cron jobs (legacy reyn.yaml + dynamic "
+        ".reyn/config/cron.yaml, unioned) so the agent can inspect schedule "
+        "state before mutating it."
+    ),
+    text=(
+        "List all currently-registered cron jobs (= both reyn.yaml legacy "
+        "and .reyn/config/cron.yaml dynamic entries, unioned). Returns job name, "
+        "target, message/action, schedule, enabled state, and next-run time."
+    ),
+    ja=(
+        "現在登録されている cron ジョブを全て一覧する（reyn.yaml のレガ"
+        "シー分と .reyn/config/cron.yaml の動的分を統合）。ジョブ名・対象・"
+        "メッセージ/アクション・スケジュール・有効状態・次回実行時刻を返す。"
+    ),
+)
+
+cron_enable = ToolDescription(
+    tool_name="cron_enable",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose="Resume firing a previously-disabled cron job.",
+    text=(
+        "Enable a previously-disabled cron job. The scheduler resumes "
+        "firing it on its schedule. No-op if already enabled."
+    ),
+    ja=(
+        "無効化されていた cron ジョブを有効化する。スケジューラは元の"
+        "スケジュールで発火を再開する。既に有効な場合は何もしない。"
+    ),
+)
+
+cron_disable = ToolDescription(
+    tool_name="cron_disable",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose="Pause a cron job without deleting it, for later re-enable.",
+    text=(
+        "Disable a cron job without removing it. The schedule stops firing "
+        "until re-enabled via `cron__enable`. Use to pause a job temporarily."
+    ),
+    ja=(
+        "cron ジョブを削除せずに無効化する。`cron__enable` で再度有効化"
+        "するまでスケジュールは停止する。一時的にジョブを止めたい場合に"
+        "使う。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "cron_register": cron_register,
+    "cron_unregister": cron_unregister,
+    "cron_list": cron_list,
+    "cron_enable": cron_enable,
+    "cron_disable": cron_disable,
+}

--- a/src/reyn/tools/descriptions/dev.py
+++ b/src/reyn/tools/descriptions/dev.py
@@ -1,0 +1,123 @@
+"""Tool descriptions for the ``dev`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the four ``reyn_src_*``
+router-only dev-mode tools (ADR-0026 M3 Wave 1) that browse Reyn's own
+repository — ``reyn_src_list`` / ``reyn_src_read`` / ``reyn_src_glob`` /
+``reyn_src_grep``. Each ``.text`` value is copied verbatim from
+``tools/reyn_src.py``; the origin module now aliases its
+``_REYN_SRC_*_DESCRIPTION`` constants to ``dev.NAME.text``.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+reyn_src_list = ToolDescription(
+    tool_name="reyn_src_list",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose=(
+        "Discover Reyn's own source/doc layout (repo root or a "
+        "subdirectory) before reading specific files."
+    ),
+    text=(
+        "List entries under a path inside Reyn's own repository "
+        "(= the project that built this agent). Pass \"\" for "
+        "the repo root. Returns names + types (file/dir). Use "
+        "this to discover Reyn's source/doc layout before "
+        "reading specific files. Examples: list \"\" for the "
+        "top-level layout, \"docs/concepts\" for concept docs "
+        "(English; Japanese translations are the same path with a "
+        "\".ja.md\" filename suffix, not a separate directory), or "
+        "any subdirectory path for its contents."
+    ),
+    ja=(
+        "Reyn 自身のリポジトリ（このエージェントを構築したプロジェクト）"
+        "内のパス配下のエントリを一覧する。\"\" でリポジトリルート。"
+        "名前とタイプ（file/dir）を返す。特定ファイルを読む前にレイアウ"
+        "トを把握するために使う。"
+    ),
+)
+
+reyn_src_read = ToolDescription(
+    tool_name="reyn_src_read",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose=(
+        "Read one named file from Reyn's own repository by exact path, "
+        "when no indexed source covers the topic (else prefer "
+        "semantic_search)."
+    ),
+    text=(
+        "Read a text file from Reyn's own repository by an exact "
+        "repo-root-relative path. Use for: (a) reading a specific file the "
+        "user named (e.g. README.md), or (b) navigating "
+        "Reyn's source / docs when NO indexed source covers the topic. "
+        "If an indexed source description mentions concepts / design / "
+        "docs / Reyn, use `semantic_search` instead — guessing a file path is "
+        "unreliable; semantic search over indexed chunks is not. Fallback "
+        "entry point: reyn_src_read(\"README.md\") for the overview + "
+        "curated map of deep-dive paths."
+    ),
+    ja=(
+        "Reyn 自身のリポジトリ内のテキストファイルを、リポジトリルート"
+        "からの正確な相対パスで読む。ユーザーが名指ししたファイル（例: "
+        "README.md）を読む場合、またはインデックス済みソースがそのト"
+        "ピックをカバーしていない場合のナビゲーションに使う。"
+    ),
+)
+
+reyn_src_glob = ToolDescription(
+    tool_name="reyn_src_glob",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose=(
+        "Enumerate files in Reyn's own repository by structural glob "
+        "pattern, distinct from content search (reyn_src_grep) and "
+        "single-file read (reyn_src_read)."
+    ),
+    text=(
+        "Find files in Reyn's own repository by glob pattern (e.g. "
+        "'docs/**/*.md', 'src/**/router*.py'). Returns up to 200 "
+        "repo-root-relative paths, alphabetically sorted. Use this when "
+        "you need to enumerate files matching a structural pattern; for "
+        "content search use reyn_src_grep, for a single named file use "
+        "reyn_src_read."
+    ),
+    ja=(
+        "Reyn 自身のリポジトリ内のファイルを glob パターン（例: "
+        "'docs/**/*.md'）で検索する。最大200件のリポジトリルート相対パ"
+        "スをアルファベット順に返す。構造的パターンでファイルを列挙し"
+        "たい場合に使う。内容検索には reyn_src_grep、単一ファイルの読"
+        "み込みには reyn_src_read を使う。"
+    ),
+)
+
+reyn_src_grep = ToolDescription(
+    tool_name="reyn_src_grep",
+    surfaced="router-only (gates.router=allow, gates.phase=deny)",
+    purpose=(
+        "Search Reyn's own repository contents by regex, for 'where is X "
+        "handled in the source' style questions, distinct from structural "
+        "enumeration (reyn_src_glob) and single-file read (reyn_src_read)."
+    ),
+    text=(
+        "Search file contents in Reyn's own repository by regex. Returns "
+        "up to 50 matches as {path, line, snippet}. `path` scopes the "
+        "search (default = whole repo); `glob` further narrows by filename "
+        "(e.g. '**/*.py'). Use this for 'where in the Reyn source is X "
+        "handled' style questions; for structural enumeration use "
+        "reyn_src_glob, for reading one known file use reyn_src_read."
+    ),
+    ja=(
+        "Reyn 自身のリポジトリ内のファイル内容を正規表現で検索する。最"
+        "大50件の一致を {path, line, snippet} として返す。'X はソース"
+        "のどこで処理されているか' 式の質問に使う。構造的な列挙には "
+        "reyn_src_glob、既知の1ファイルの読み込みには reyn_src_read を"
+        "使う。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "reyn_src_list": reyn_src_list,
+    "reyn_src_read": reyn_src_read,
+    "reyn_src_glob": reyn_src_glob,
+    "reyn_src_grep": reyn_src_grep,
+}

--- a/src/reyn/tools/descriptions/hooks.py
+++ b/src/reyn/tools/descriptions/hooks.py
@@ -1,0 +1,41 @@
+"""Tool descriptions for the ``hooks`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): ``hooks_add`` (#2073 S3), the
+agent-self-reload trigger that writes to the runtime hooks layer
+(``.reyn/config/hooks.yaml``). ``.text`` is copied verbatim from
+``tools/hooks.py``; the origin module now aliases
+``_HOOKS_ADD_DESCRIPTION`` to ``hooks.hooks_add.text``.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+hooks_add = ToolDescription(
+    tool_name="hooks_add",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Let the agent expand its own hooks (self-directed continuation or "
+        "recurring injected context), bounded by the write-gate + "
+        "validate-before-apply + permission safety trifecta."
+    ),
+    text=(
+        "Add a push hook at an agent-lifecycle point (e.g. a turn_end self-continuation, "
+        "or a context-inject). The hook is written to your runtime hooks layer "
+        "(.reyn/config/hooks.yaml) and applied at the next turn boundary — it joins your existing "
+        "hooks additively. Use for self-directed continuation or recurring injected "
+        "context. Cannot touch startup config (reyn.yaml is restart-only)."
+    ),
+    ja=(
+        "エージェントのライフサイクルポイント（turn_end の自己継続や"
+        "コンテキスト注入など）にプッシュフックを追加する。フックは"
+        "ランタイムの hooks レイヤー（.reyn/config/hooks.yaml）に書き込まれ、"
+        "次のターン境界で適用される（既存フックに追加される）。自己主導"
+        "の継続や定期的なコンテキスト注入に使う。起動時設定"
+        "（reyn.yaml、再起動時のみ反映）には触れられない。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "hooks_add": hooks_add,
+}

--- a/src/reyn/tools/descriptions/interactive.py
+++ b/src/reyn/tools/descriptions/interactive.py
@@ -1,0 +1,39 @@
+"""Tool descriptions for the ``interactive`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): ``ask_user`` (ADR-0026 M3 Wave 1),
+the phase-only user-intervention tool. ``.text`` is copied verbatim from
+``tools/ask_user.py``; the origin module now aliases
+``_ASK_USER_DESCRIPTION`` to ``interactive.ask_user.text``.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+ask_user = ToolDescription(
+    tool_name="ask_user",
+    surfaced="phase-only (gates.router=deny, gates.phase=allow)",
+    purpose=(
+        "Pause phase execution to ask the user a clarifying question, "
+        "resuming with the free-text answer as a control IR result."
+    ),
+    text=(
+        "Pause the current phase and ask the user a clarifying question. "
+        "The OS suspends execution, presents the question (and optional "
+        "suggestions) to the user, waits for a free-text answer, and "
+        "resumes the phase with the answer available as a control IR result. "
+        "question: the question to display to the user. "
+        "suggestions: optional list of suggested responses. "
+        "required: if true (default), an empty answer is rejected."
+    ),
+    ja=(
+        "現在のフェーズを一時停止し、ユーザーに確認質問をする。OS が実行"
+        "を中断し、質問（と任意の提案）をユーザーに提示、自由記述の回答"
+        "を待ってから、その回答を control IR の結果として使えるようにフ"
+        "ェーズを再開する。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "ask_user": ask_user,
+}

--- a/src/reyn/tools/descriptions/pipeline.py
+++ b/src/reyn/tools/descriptions/pipeline.py
@@ -1,0 +1,123 @@
+"""Tool descriptions for the ``pipeline`` bucket (pipeline launch verbs).
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the four pipeline-launch verbs
+from ``tools/pipeline_verbs.py`` — ``run_pipeline`` / ``run_pipeline_async``
+(a REGISTERED pipeline by name) and ``run_pipeline_inline`` /
+``run_pipeline_inline_async`` (an agent-GENERATED ad-hoc DSL string,
+statically validated before spawn). Each ``.text`` value is copied verbatim
+from its origin constant; the origin module now aliases its
+``_RUN_PIPELINE*_DESCRIPTION`` constants to ``pipeline.NAME.text``.
+
+Note: all four carry ``ToolDefinition.category="io"`` — this module groups
+them by feature-area (pipeline launch), matching the ``mcp`` / ``io``
+precedent set in Phase 2 (module grouping is conceptual, not a literal
+mirror of the ``category`` field).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+run_pipeline = ToolDescription(
+    tool_name="run_pipeline",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Launch a REGISTERED pipeline by name and block for its final "
+        "output — the sync entry point for a pre-built multi-step "
+        "workflow."
+    ),
+    text=(
+        "Run a REGISTERED pipeline by name to completion and return its final "
+        "output. Blocks until the pipeline finishes (sync). 'input' seeds the "
+        "pipeline's initial named context (ctx.*) for its first step. Fails "
+        "clearly if 'name' is not a registered pipeline, or if any step fails."
+    ),
+    ja=(
+        "登録済みパイプラインを名前で実行し、完了まで待って最終出力を返"
+        "す（同期）。'input' はパイプライン最初のステップの初期名前付き"
+        "コンテキスト（ctx.*）を与える。'name' が未登録、またはいずれか"
+        "のステップが失敗した場合は明確に失敗する。"
+    ),
+)
+
+run_pipeline_async = ToolDescription(
+    tool_name="run_pipeline_async",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Launch a REGISTERED pipeline in the background and return "
+        "immediately, for a long-running workflow whose result arrives "
+        "later as a [pipeline] message."
+    ),
+    text=(
+        "Launch a REGISTERED pipeline by name in the background and return "
+        "immediately with {status: started, run_id}. The pipeline runs in a "
+        "dedicated crash-recoverable driver session; its final result arrives "
+        "later as a [pipeline] message on your conversation. 'input' seeds the "
+        "pipeline's initial named context (ctx.*) for its first step."
+    ),
+    ja=(
+        "登録済みパイプラインを名前でバックグラウンド起動し、即座に "
+        "{status: started, run_id} を返す。パイプラインは専用のクラッシ"
+        "ュ復旧可能なドライバーセッションで実行され、最終結果は後で "
+        "[pipeline] メッセージとして会話に届く。"
+    ),
+)
+
+run_pipeline_inline = ToolDescription(
+    tool_name="run_pipeline_inline",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Run an ad-hoc, agent-GENERATED DSL-string pipeline to completion, "
+        "statically validated (parse / schema refs / tool names / no "
+        "nested launch / identity==invoker) before anything spawns."
+    ),
+    text=(
+        "Run an ad-hoc pipeline you DEFINE inline (no pre-registration) to "
+        "completion and return its final output. Blocks until it finishes (sync). "
+        "'definition' is a pipeline DSL string (Appendix B); 'input' seeds the "
+        "first step's ctx.*. The definition is statically validated (parse, schema "
+        "refs, tool names, no nested pipeline launch, agent steps run as you) "
+        "BEFORE anything is spawned — a bad definition fails clearly and runs "
+        "nothing."
+    ),
+    ja=(
+        "事前登録なしでインラインに定義したアドホックなパイプラインを完"
+        "了まで実行し、最終出力を返す（同期）。'definition' はパイプラ"
+        "イン DSL 文字列。何かが起動される前に静的検証（パース、スキー"
+        "マ参照、ツール名、パイプラインのネスト起動禁止、agent ステップ"
+        "は呼び出し元として実行）が行われる — 不正な定義は明確に失敗し"
+        "何も実行しない。"
+    ),
+)
+
+run_pipeline_inline_async = ToolDescription(
+    tool_name="run_pipeline_inline_async",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Launch an ad-hoc, agent-GENERATED DSL-string pipeline in the "
+        "background, statically validated before spawn, result arriving "
+        "later as a [pipeline] message."
+    ),
+    text=(
+        "Launch an ad-hoc pipeline you DEFINE inline in the background and return "
+        "immediately with {status: started, run_id}. It runs in a dedicated "
+        "crash-recoverable driver session; its final result arrives later as a "
+        "[pipeline] message on your conversation. 'definition' is a pipeline DSL "
+        "string (Appendix B), statically validated before spawn; 'input' seeds the "
+        "first step's ctx.*."
+    ),
+    ja=(
+        "インラインに定義したアドホックなパイプラインをバックグラウンド"
+        "起動し、即座に {status: started, run_id} を返す。専用のクラッ"
+        "シュ復旧可能なドライバーセッションで実行され、最終結果は後で "
+        "[pipeline] メッセージとして届く。'definition' は起動前に静的検"
+        "証されるパイプライン DSL 文字列。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "run_pipeline": run_pipeline,
+    "run_pipeline_async": run_pipeline_async,
+    "run_pipeline_inline": run_pipeline_inline,
+    "run_pipeline_inline_async": run_pipeline_inline_async,
+}

--- a/src/reyn/tools/descriptions/pipeline_management.py
+++ b/src/reyn/tools/descriptions/pipeline_management.py
@@ -1,0 +1,83 @@
+"""Tool descriptions for the ``pipeline_management`` bucket.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the two pipeline install verbs
+from ``tools/pipeline_management_verbs.py`` — ``pipeline_install_local``
+(register a local DSL file) and ``pipeline_install_source`` (fetch +
+install from a git/GitHub URL). Each ``.text`` value is copied verbatim
+from its origin constant; the origin module now aliases its
+``_PIPELINE_INSTALL_*_DESCRIPTION`` constants to
+``pipeline_management.NAME.text``.
+
+Note: both carry ``ToolDefinition.category="io"`` — this module groups
+them by feature-area (pipeline management), matching the ``mcp`` / ``io``
+precedent set in Phase 2 (module grouping is conceptual, not a literal
+mirror of the ``category`` field).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+pipeline_install_local = ToolDescription(
+    tool_name="pipeline_install_local",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Register a local pipeline DSL file into the project config so "
+        "sessions can launch it (via pipeline__<key>.<name> or "
+        "run_pipeline) after the next hot-reload."
+    ),
+    text=(
+        "Register a local pipeline DSL file into the project config "
+        "by writing an entry to .reyn/config/pipelines.yaml. The pipeline is "
+        "immediately available to sessions (as pipeline__<key>.<name> and "
+        "run_pipeline) after the next hot-reload. Pass the direct path to the "
+        "pipeline's *.yaml DSL file (which may hold multiple '---'-separated "
+        "'pipeline:' documents). "
+        "Use 'name' to set the NAMESPACE KEY for the file; every pipeline in it "
+        "registers as '<name>.<declared-pipeline-name>'. 'name' need not match any "
+        "declared name and must not contain '.' (the reserved separator); it "
+        "defaults to the DSL file stem when omitted."
+    ),
+    ja=(
+        "ローカルのパイプライン DSL ファイルをプロジェクト設定に登録す"
+        "る（.reyn/config/pipelines.yaml へのエントリ書き込み）。次の"
+        "ホットリロード後、pipeline__<key>.<name> および run_pipeline "
+        "としてセッションから即座に利用可能になる。"
+    ),
+)
+
+pipeline_install_source = ToolDescription(
+    tool_name="pipeline_install_source",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Fetch a pipeline from a git/GitHub URL, shallow-clone + "
+        "threat-scan it, and install it into the project config."
+    ),
+    text=(
+        "Fetch a pipeline from a git/GitHub URL and install it into the project. "
+        "The repo is shallow-cloned to .reyn/pipelines/<name>/, the DSL is parsed "
+        "+ threat-scanned, and an entry is written to .reyn/config/pipelines.yaml. "
+        "The pipeline is immediately available to sessions after the next "
+        "hot-reload. Requires http.get permission for the source host. "
+        "Source format: 'https://github.com/user/repo' (repo root must contain "
+        "exactly one *.yaml DSL file, or 'path' selects it) or "
+        "'https://github.com/user/repo//path/to/pipelines' (subdir form). "
+        "Use 'path' to select the DSL file inside the clone when the repo/subdir "
+        "contains more than one *.yaml file. "
+        "Use 'name' to set the NAMESPACE KEY; every pipeline in the file registers "
+        "as '<name>.<declared-pipeline-name>'. 'name' need not match any declared "
+        "name and must not contain '.'; it defaults to the source basename."
+    ),
+    ja=(
+        "git/GitHub の URL からパイプラインを取得しプロジェクトにインス"
+        "トールする。リポジトリは .reyn/pipelines/<name>/ に浅くクロー"
+        "ンされ、DSL はパース + 脅威スキャンされた上で "
+        ".reyn/config/pipelines.yaml にエントリが書き込まれる。ソースホ"
+        "ストへの http.get 権限が必要。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "pipeline_install_local": pipeline_install_local,
+    "pipeline_install_source": pipeline_install_source,
+}

--- a/src/reyn/tools/descriptions/presentation.py
+++ b/src/reyn/tools/descriptions/presentation.py
@@ -1,0 +1,74 @@
+"""Tool descriptions for the ``presentation`` category.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): ``present`` (the present-layer
+arc, #2692 / FP-0054 / FP-0055) and ``render_template`` (#2692 / FP-0055),
+both chat + pipeline invocation surfaces onto pre-existing op handlers.
+Each ``.text`` value is copied verbatim from its origin tool module; the
+origin module now aliases its ``_X_DESCRIPTION`` constant to
+``presentation.NAME.text``.
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+present = ToolDescription(
+    tool_name="present",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Show bulk tool-result data to the user directly (zero-token "
+        "offload) instead of the LLM re-typing it through its own output "
+        "tokens — the present-layer arc's chat + pipeline entry point."
+    ),
+    text=(
+        "Show bulk data to the user directly, WITHOUT re-typing it through your own output tokens. "
+        "Use this after a tool returns a large result (a file, a query result, a list) that the user "
+        "should see: pass a reference to it and the presentation layer renders it for them. "
+        "Simple path — just pass 'data_ref' (a zone-readable path or an offloaded result ref) and it is "
+        "shown with a sensible default view; you do not need to design anything. Optionally pass 'view' "
+        "(a registered presentation name) to use a named layout, or 'blueprint' (advanced: a declarative "
+        "component tree) for full control — at most one of the two. Pass 'data_inline' INSTEAD of "
+        "'data_ref' only for small data already in your context (exactly one of data_ref / data_inline). "
+        "Reading a 'data_ref' requires the same file-read permission as reading the file. Returns a "
+        "compact acknowledgement (what reached the user and whether the view bound), not the data itself."
+    ),
+    ja=(
+        "大量データを、自分の出力トークンで再入力することなく直接ユーザ"
+        "ーに表示する。ツールが大きな結果（ファイル、クエリ結果、リスト"
+        "など）を返した後、参照を渡すだけでプレゼンテーション層が表示"
+        "してくれる。'data_ref' を渡すだけの簡易パスがデフォルト。"
+    ),
+)
+
+render_template = ToolDescription(
+    tool_name="render_template",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Render a Jinja2 template against structured data into a plain "
+        "string, as a sandboxed producer with no sink of its own — the "
+        "caller routes the result wherever it wants (present / write / "
+        "downstream pipeline step)."
+    ),
+    text=(
+        "Render a Jinja2 template against structured data into a plain string. A sandboxed producer: it "
+        "writes nothing and shows nothing — it returns the rendered text, which you then route wherever "
+        "you want (show it with 'present', write it with a file step, or pass it downstream in a "
+        "pipeline). Provide exactly one template source (inline 'template' text, or 'template_ref' — a "
+        "zone-readable template file path) and exactly one data source ('data_inline' — small data in "
+        "your context, or 'data_ref' — a zone-readable path). The data binds under 'data' in the template "
+        "(e.g. {{ data.results[0].title }}). 'undefined' controls unbound variables: 'strict' (default) "
+        "errors naming the missing name; 'lenient' renders them empty and reports them. Reading a "
+        "template_ref / data_ref requires the same permission as reading the file."
+    ),
+    ja=(
+        "Jinja2 テンプレートを構造化データに対してレンダリングし、プレー"
+        "ンな文字列を返す。書き込みも表示もしないサンドボックス化された"
+        "プロデューサー — レンダリング結果は present / ファイル書き込み / "
+        "パイプラインの後段など、呼び出し側が自由にルーティングする。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "present": present,
+    "render_template": render_template,
+}

--- a/src/reyn/tools/descriptions/skill.py
+++ b/src/reyn/tools/descriptions/skill.py
@@ -1,0 +1,74 @@
+"""Tool descriptions for the ``skill`` bucket.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the two skill install verbs from
+``tools/skill_verbs.py`` (#2548 PR-C / PR-D) — ``skill_install_local``
+(register a local ``SKILL.md`` directory) and ``skill_install_source``
+(fetch + install from a git/GitHub URL). Each ``.text`` value is copied
+verbatim from its origin constant; the origin module now aliases its
+``_SKILL_INSTALL_*_DESCRIPTION`` constants to ``skill.NAME.text``.
+
+Note: both carry ``ToolDefinition.category="io"`` — this module groups
+them by feature-area (skill management), matching the ``mcp`` / ``io``
+precedent set in Phase 2 (module grouping is conceptual, not a literal
+mirror of the ``category`` field).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+skill_install_local = ToolDescription(
+    tool_name="skill_install_local",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Register a local skill directory (SKILL.md) into the project "
+        "config so it becomes available to sessions after the next "
+        "hot-reload."
+    ),
+    text=(
+        "Register a local skill directory into the project config "
+        "by reading its SKILL.md frontmatter and writing an entry to "
+        ".reyn/config/skills.yaml. The skill is immediately available "
+        "to sessions after the next hot-reload. Pass the path to the "
+        "directory containing SKILL.md (or the SKILL.md file directly). "
+        "Use 'name' to override the config key when the directory name "
+        "differs from the desired skill identifier."
+    ),
+    ja=(
+        "ローカルのスキルディレクトリをプロジェクト設定に登録する"
+        "（SKILL.md のフロントマターを読み、.reyn/config/skills.yaml に"
+        "エントリを書き込む）。次のホットリロード後、セッションから即座"
+        "に利用可能になる。"
+    ),
+)
+
+skill_install_source = ToolDescription(
+    tool_name="skill_install_source",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Fetch a skill from a git/GitHub URL, shallow-clone + "
+        "threat-scan its SKILL.md, and install it into the project config."
+    ),
+    text=(
+        "Fetch a skill from a git/GitHub URL and install it into the project. "
+        "The repo is shallow-cloned to .reyn/skills/<name>/, the SKILL.md is "
+        "threat-scanned, and an entry is written to .reyn/config/skills.yaml. "
+        "The skill is immediately available to sessions after the next hot-reload. "
+        "Requires http.get permission for the source host in the skill's frontmatter. "
+        "Source format: 'https://github.com/user/repo' (repo root must contain SKILL.md) "
+        "or 'https://github.com/user/repo//path/to/skill' (subdir with SKILL.md). "
+        "Use 'name' to override the config key when the default (from SKILL.md frontmatter "
+        "or repo/subdir basename) differs from the desired skill identifier."
+    ),
+    ja=(
+        "git/GitHub の URL からスキルを取得しプロジェクトにインストール"
+        "する。リポジトリは .reyn/skills/<name>/ に浅くクローンされ、"
+        "SKILL.md は脅威スキャンされた上で .reyn/config/skills.yaml にエ"
+        "ントリが書き込まれる。ソースホストへの http.get 権限が必要。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "skill_install_local": skill_install_local,
+    "skill_install_source": skill_install_source,
+}

--- a/src/reyn/tools/descriptions/task.py
+++ b/src/reyn/tools/descriptions/task.py
@@ -1,0 +1,247 @@
+"""Tool descriptions for the ``task`` category — the data-tuple special case.
+
+Phase 3 of the tool-description package refactor (byte-identical
+relocation — no LLM-facing text change): the 12 ``task.*`` control-IR ops
+(#1953 dynamic-wire item-1) exposed as ``invoke_action`` targets
+(``task__create``, ``task__update_status``, …). Unlike every other tool
+module, these 12 descriptions previously lived INLINE as the third element
+of each ``(op_kind, IROp, description)`` tuple in ``tools/task_ops.py``'s
+``_TASK_OPS`` module constant, rather than as standalone ``_X_DESCRIPTION``
+constants — this module lifts them out to named ``ToolDescription``
+records (matching the convention every other tool file follows), and
+``_TASK_OPS`` now references ``TASK_CREATE.text`` etc. in place of the
+inline string literal.
+
+``tool_name`` for each entry is the op_kind (e.g. ``"task.create"``) —
+this doubles as ``ToolDefinition.name`` for these dynamically-built
+definitions (``build_task_tool_definitions`` sets ``name=op_kind``).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ToolDescription
+
+TASK_CREATE = ToolDescription(
+    tool_name="task.create",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Decompose a complex request into trackable sub-units — a task "
+        "created while executing a task is auto-owned by it, and "
+        "auto-assigned to the creator unless delegated."
+    ),
+    text=(
+        "Create a task. While you are EXECUTING a task, a task you create is automatically "
+        "owned by it (a sub-task) and — if you omit `assignee` — assigned to you to execute. "
+        "For a TOP-LEVEL task: omitting `assignee` leaves it UNASSIGNED (it waits in the "
+        "pending-assignment queue until a session claims it via task.assign); to execute it "
+        "YOURSELF, set `assignee` to your own session; set it to another session to delegate. "
+        "`deps` are depends-on task ids (born blocked until they complete). Use to decompose a "
+        "complex request into trackable units."
+    ),
+    ja=(
+        "タスクを作成する。タスク実行中に作成したタスクは自動的にその"
+        "サブタスクとして所有され、`assignee` を省略すれば自分に割り当"
+        "てられる。トップレベルタスクの場合、`assignee` を省略すると未"
+        "割り当てのまま保留キューで待機する。複雑な依頼を追跡可能な単位"
+        "に分解する際に使う。"
+    ),
+)
+
+TASK_UPDATE_STATUS = ToolDescription(
+    tool_name="task.update_status",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Declare a status transition as the single writer (the assignee); "
+        "terminal tasks reject further writes."
+    ),
+    text=(
+        "Declare a status transition on a task you are the ASSIGNEE of (the single "
+        "writer). Terminal tasks reject writes."
+    ),
+    ja=(
+        "自分が ASSIGNEE（唯一の書き込み者）であるタスクのステータス遷"
+        "移を宣言する。終端状態のタスクは書き込みを拒否する。"
+    ),
+)
+
+TASK_GET = ToolDescription(
+    tool_name="task.get",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose="Read one task record by id.",
+    text="Read one task record by id.",
+    ja="id を指定して1つのタスクレコードを読む。",
+)
+
+TASK_LIST = ToolDescription(
+    tool_name="task.list",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "List tasks narrowed by assignee/requester/status; narrowing by "
+        "requester lists the sub-tasks that task owns."
+    ),
+    text=(
+        "List tasks, optionally narrowed by assignee / requester / status. Narrowing "
+        "by `requester` (a task id) lists the sub-tasks that task owns."
+    ),
+    ja=(
+        "タスクを一覧する。assignee / requester / status で絞り込み可"
+        "能。`requester`（タスク id）で絞り込むと、そのタスクが所有す"
+        "るサブタスクを一覧する。"
+    ),
+)
+
+TASK_ADD_DEPENDENCY = ToolDescription(
+    tool_name="task.add_dependency",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Add a depends-on edge as the requester/topology owner, with "
+        "existence + cycle checks."
+    ),
+    text=(
+        "Add a depends-on edge (you must be the requester/topology owner). "
+        "Existence + cycle checked."
+    ),
+    ja=(
+        "依存関係エッジを追加する（requester/トポロジー所有者である必要"
+        "がある）。存在チェックと循環チェックが行われる。"
+    ),
+)
+
+TASK_REMOVE_DEPENDENCY = ToolDescription(
+    tool_name="task.remove_dependency",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Drop a depends-on edge (idempotent); may promote a now-ready "
+        "dependent."
+    ),
+    text=(
+        "Drop a depends-on edge (idempotent). Relaxing the graph may promote a "
+        "now-ready dependent."
+    ),
+    ja=(
+        "依存関係エッジを削除する（冪等）。グラフを緩めることで、条件が"
+        "揃った依存先タスクが実行可能に昇格することがある。"
+    ),
+)
+
+TASK_REPOINT_DEPENDENCY = ToolDescription(
+    tool_name="task.repoint_dependency",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Atomically repoint a dependency edge to a substitute task — the "
+        "primary recovery move, cycle-checked before any mutation."
+    ),
+    text=(
+        "Atomically repoint a dependency edge from one task to a substitute (the "
+        "primary recovery move). The new edge is cycle-checked before any mutation."
+    ),
+    ja=(
+        "依存関係エッジを別のタスクへアトミックに付け替える（主要な復"
+        "旧手段）。新しいエッジは変更前に循環チェックされる。"
+    ),
+)
+
+TASK_ABORT = ToolDescription(
+    tool_name="task.abort",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Abort (delete) a requested task + its sub-tree; cooperative-"
+        "terminal, rejecting the assignee's next status-write."
+    ),
+    text=(
+        "Abort (delete) a task you requested + its sub-tree. Cooperative-terminal: "
+        "the assignee's in-flight work is rejected at its next status-write."
+    ),
+    ja=(
+        "自分が requester であるタスクとそのサブツリーを中断（削除）す"
+        "る。協調的終端: assignee の進行中の作業は次のステータス書き込"
+        "み時に拒否される。"
+    ),
+)
+
+TASK_HEARTBEAT = ToolDescription(
+    tool_name="task.heartbeat",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Liveness ping for a blocked task, triggering unblock-predicate "
+        "evaluation and returning current state."
+    ),
+    text=(
+        "Liveness ping for a blocked task; triggers unblock-predicate evaluation. "
+        "Returns the current state."
+    ),
+    ja=(
+        "ブロック中のタスクへの生存確認。unblock-predicate の評価をトリ"
+        "ガーし、現在の状態を返す。"
+    ),
+)
+
+TASK_REGISTER_UNBLOCK_PREDICATE = ToolDescription(
+    tool_name="task.register_unblock_predicate",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Register a deterministic (code, no-LLM) unblock predicate "
+        "evaluated at heartbeat time."
+    ),
+    text=(
+        "Register a deterministic (code, no-LLM) unblock predicate evaluated at "
+        "heartbeat; true → unblock."
+    ),
+    ja=(
+        "heartbeat 時に評価される決定的（コード、LLM 不使用）な "
+        "unblock predicate を登録する。true でブロック解除。"
+    ),
+)
+
+TASK_COMMENT = ToolDescription(
+    tool_name="task.comment",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Append a comment to a task's thread — the durable inter-agent / "
+        "human-in-the-loop protocol."
+    ),
+    text=(
+        "Append a comment to a task's thread (durable inter-agent / human-in-the-loop "
+        "protocol)."
+    ),
+    ja=(
+        "タスクのスレッドにコメントを追記する（永続的なエージェント間 / "
+        "human-in-the-loop プロトコル）。"
+    ),
+)
+
+TASK_ASSIGN = ToolDescription(
+    tool_name="task.assign",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Claim an UNASSIGNED task, or hand off an already-assigned one "
+        "(owner-initiated only) — the new assignee is woken to execute it."
+    ),
+    text=(
+        "Assign a session to a task. An UNASSIGNED task (in the pending-assignment queue) "
+        "may be CLAIMED by anyone — set `assignee` to the session that will execute it. An "
+        "already-assigned task may be reassigned ONLY by its current assignee (owner-initiated "
+        "hand-off; others must request it via conversation). The new assignee is woken to "
+        "execute it."
+    ),
+    ja=(
+        "セッションをタスクに割り当てる。未割り当てタスク（保留キュー"
+        "内）は誰でも claim 可能。既に割り当て済みのタスクは現在の "
+        "assignee のみが再割り当てできる（オーナー主導のハンドオフ）。"
+        "新しい assignee は実行のために起こされる。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "task.create": TASK_CREATE,
+    "task.update_status": TASK_UPDATE_STATUS,
+    "task.get": TASK_GET,
+    "task.list": TASK_LIST,
+    "task.add_dependency": TASK_ADD_DEPENDENCY,
+    "task.remove_dependency": TASK_REMOVE_DEPENDENCY,
+    "task.repoint_dependency": TASK_REPOINT_DEPENDENCY,
+    "task.abort": TASK_ABORT,
+    "task.heartbeat": TASK_HEARTBEAT,
+    "task.register_unblock_predicate": TASK_REGISTER_UNBLOCK_PREDICATE,
+    "task.comment": TASK_COMMENT,
+    "task.assign": TASK_ASSIGN,
+}

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import hooks as _hooks_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 _HOOK_POINTS = [
@@ -30,13 +31,9 @@ _HOOK_POINTS = [
     "task_start", "task_end",
 ]
 
-_HOOKS_ADD_DESCRIPTION = (
-    "Add a push hook at an agent-lifecycle point (e.g. a turn_end self-continuation, "
-    "or a context-inject). The hook is written to your runtime hooks layer "
-    "(.reyn/config/hooks.yaml) and applied at the next turn boundary — it joins your existing "
-    "hooks additively. Use for self-directed continuation or recurring injected "
-    "context. Cannot touch startup config (reyn.yaml is restart-only)."
-)
+# Relocated to reyn.tools.descriptions.hooks (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_HOOKS_ADD_DESCRIPTION = _hooks_descriptions.hooks_add.text
 
 _HOOKS_ADD_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/pipeline_management_verbs.py
+++ b/src/reyn/tools/pipeline_management_verbs.py
@@ -28,21 +28,16 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import pipeline_management as _pipeline_management_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # ── pipeline_management__install_local ───────────────────────────────────────
 
+# Relocated to reyn.tools.descriptions.pipeline_management (Phase 3
+# tool-description package refactor — byte-identical, no LLM-facing text
+# change).
 _PIPELINE_INSTALL_LOCAL_DESCRIPTION = (
-    "Register a local pipeline DSL file into the project config "
-    "by writing an entry to .reyn/config/pipelines.yaml. The pipeline is "
-    "immediately available to sessions (as pipeline__<key>.<name> and "
-    "run_pipeline) after the next hot-reload. Pass the direct path to the "
-    "pipeline's *.yaml DSL file (which may hold multiple '---'-separated "
-    "'pipeline:' documents). "
-    "Use 'name' to set the NAMESPACE KEY for the file; every pipeline in it "
-    "registers as '<name>.<declared-pipeline-name>'. 'name' need not match any "
-    "declared name and must not contain '.' (the reserved separator); it "
-    "defaults to the DSL file stem when omitted."
+    _pipeline_management_descriptions.pipeline_install_local.text
 )
 
 _PIPELINE_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
@@ -121,20 +116,11 @@ async def _handle_pipeline_install_local(
 
 # ── pipeline_management__install_source ──────────────────────────────────────
 
+# Relocated to reyn.tools.descriptions.pipeline_management (Phase 3
+# tool-description package refactor — byte-identical, no LLM-facing text
+# change).
 _PIPELINE_INSTALL_SOURCE_DESCRIPTION = (
-    "Fetch a pipeline from a git/GitHub URL and install it into the project. "
-    "The repo is shallow-cloned to .reyn/pipelines/<name>/, the DSL is parsed "
-    "+ threat-scanned, and an entry is written to .reyn/config/pipelines.yaml. "
-    "The pipeline is immediately available to sessions after the next "
-    "hot-reload. Requires http.get permission for the source host. "
-    "Source format: 'https://github.com/user/repo' (repo root must contain "
-    "exactly one *.yaml DSL file, or 'path' selects it) or "
-    "'https://github.com/user/repo//path/to/pipelines' (subdir form). "
-    "Use 'path' to select the DSL file inside the clone when the repo/subdir "
-    "contains more than one *.yaml file. "
-    "Use 'name' to set the NAMESPACE KEY; every pipeline in the file registers "
-    "as '<name>.<declared-pipeline-name>'. 'name' need not match any declared "
-    "name and must not contain '.'; it defaults to the source basename."
+    _pipeline_management_descriptions.pipeline_install_source.text
 )
 
 _PIPELINE_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -144,17 +144,15 @@ from reyn.core.pipeline.executor import (
     ToolStep,
 )
 from reyn.core.pipeline.registry import PipelineNotFoundError
+from reyn.tools.descriptions import pipeline as _pipeline_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 if TYPE_CHECKING:
     from reyn.core.pipeline.schema import SchemaRegistry
 
-_RUN_PIPELINE_DESCRIPTION = (
-    "Run a REGISTERED pipeline by name to completion and return its final "
-    "output. Blocks until the pipeline finishes (sync). 'input' seeds the "
-    "pipeline's initial named context (ctx.*) for its first step. Fails "
-    "clearly if 'name' is not a registered pipeline, or if any step fails."
-)
+# Relocated to reyn.tools.descriptions.pipeline (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_RUN_PIPELINE_DESCRIPTION = _pipeline_descriptions.run_pipeline.text
 
 _RUN_PIPELINE_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -401,13 +399,9 @@ RUN_PIPELINE = ToolDefinition(
 )
 
 
-_RUN_PIPELINE_ASYNC_DESCRIPTION = (
-    "Launch a REGISTERED pipeline by name in the background and return "
-    "immediately with {status: started, run_id}. The pipeline runs in a "
-    "dedicated crash-recoverable driver session; its final result arrives "
-    "later as a [pipeline] message on your conversation. 'input' seeds the "
-    "pipeline's initial named context (ctx.*) for its first step."
-)
+# Relocated to reyn.tools.descriptions.pipeline (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_RUN_PIPELINE_ASYNC_DESCRIPTION = _pipeline_descriptions.run_pipeline_async.text
 
 
 async def _handle_run_pipeline_async(
@@ -527,23 +521,12 @@ _RUN_PIPELINE_INLINE_PARAMETERS: dict[str, Any] = {
     "required": ["definition"],
 }
 
-_RUN_PIPELINE_INLINE_DESCRIPTION = (
-    "Run an ad-hoc pipeline you DEFINE inline (no pre-registration) to "
-    "completion and return its final output. Blocks until it finishes (sync). "
-    "'definition' is a pipeline DSL string (Appendix B); 'input' seeds the "
-    "first step's ctx.*. The definition is statically validated (parse, schema "
-    "refs, tool names, no nested pipeline launch, agent steps run as you) "
-    "BEFORE anything is spawned — a bad definition fails clearly and runs "
-    "nothing."
-)
+# Relocated to reyn.tools.descriptions.pipeline (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_RUN_PIPELINE_INLINE_DESCRIPTION = _pipeline_descriptions.run_pipeline_inline.text
 
 _RUN_PIPELINE_INLINE_ASYNC_DESCRIPTION = (
-    "Launch an ad-hoc pipeline you DEFINE inline in the background and return "
-    "immediately with {status: started, run_id}. It runs in a dedicated "
-    "crash-recoverable driver session; its final result arrives later as a "
-    "[pipeline] message on your conversation. 'definition' is a pipeline DSL "
-    "string (Appendix B), statically validated before spawn; 'input' seeds the "
-    "first step's ctx.*."
+    _pipeline_descriptions.run_pipeline_inline_async.text
 )
 
 

--- a/src/reyn/tools/present.py
+++ b/src/reyn/tools/present.py
@@ -29,20 +29,12 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from reyn.core.offload.canonical import present_to_canonical
+from reyn.tools.descriptions import presentation as _presentation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_PRESENT_DESCRIPTION = (
-    "Show bulk data to the user directly, WITHOUT re-typing it through your own output tokens. "
-    "Use this after a tool returns a large result (a file, a query result, a list) that the user "
-    "should see: pass a reference to it and the presentation layer renders it for them. "
-    "Simple path — just pass 'data_ref' (a zone-readable path or an offloaded result ref) and it is "
-    "shown with a sensible default view; you do not need to design anything. Optionally pass 'view' "
-    "(a registered presentation name) to use a named layout, or 'blueprint' (advanced: a declarative "
-    "component tree) for full control — at most one of the two. Pass 'data_inline' INSTEAD of "
-    "'data_ref' only for small data already in your context (exactly one of data_ref / data_inline). "
-    "Reading a 'data_ref' requires the same file-read permission as reading the file. Returns a "
-    "compact acknowledgement (what reached the user and whether the view bound), not the data itself."
-)
+# Relocated to reyn.tools.descriptions.presentation (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_PRESENT_DESCRIPTION = _presentation_descriptions.present.text
 
 _PRESENT_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/render_template.py
+++ b/src/reyn/tools/render_template.py
@@ -28,19 +28,12 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from reyn.core.offload.canonical import render_template_to_canonical
+from reyn.tools.descriptions import presentation as _presentation_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
-_RENDER_TEMPLATE_DESCRIPTION = (
-    "Render a Jinja2 template against structured data into a plain string. A sandboxed producer: it "
-    "writes nothing and shows nothing — it returns the rendered text, which you then route wherever "
-    "you want (show it with 'present', write it with a file step, or pass it downstream in a "
-    "pipeline). Provide exactly one template source (inline 'template' text, or 'template_ref' — a "
-    "zone-readable template file path) and exactly one data source ('data_inline' — small data in "
-    "your context, or 'data_ref' — a zone-readable path). The data binds under 'data' in the template "
-    "(e.g. {{ data.results[0].title }}). 'undefined' controls unbound variables: 'strict' (default) "
-    "errors naming the missing name; 'lenient' renders them empty and reports them. Reading a "
-    "template_ref / data_ref requires the same permission as reading the file."
-)
+# Relocated to reyn.tools.descriptions.presentation (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_RENDER_TEMPLATE_DESCRIPTION = _presentation_descriptions.render_template.text
 
 _RENDER_TEMPLATE_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/reyn_src.py
+++ b/src/reyn/tools/reyn_src.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import dev as _dev_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 
@@ -37,17 +38,9 @@ def _as_reyn_src(result: dict) -> dict:
 # generic LLM hallucination — confirmed by grep across dogfood journal
 # findings hitting this exact wrong path repeatedly). Kept in sync with
 # ``docs/concepts`` actually existing at the repo root.
-_REYN_SRC_LIST_DESCRIPTION = (
-    "List entries under a path inside Reyn's own repository "
-    "(= the project that built this agent). Pass \"\" for "
-    "the repo root. Returns names + types (file/dir). Use "
-    "this to discover Reyn's source/doc layout before "
-    "reading specific files. Examples: list \"\" for the "
-    "top-level layout, \"docs/concepts\" for concept docs "
-    "(English; Japanese translations are the same path with a "
-    "\".ja.md\" filename suffix, not a separate directory), or "
-    "any subdirectory path for its contents."
-)
+# Relocated to reyn.tools.descriptions.dev (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_REYN_SRC_LIST_DESCRIPTION = _dev_descriptions.reyn_src_list.text
 
 # Parameters JSON schema must be byte-identical to the current
 # router_tools.py ToolSpec.parameters for reyn_src_list.
@@ -71,17 +64,9 @@ _REYN_SRC_LIST_PARAMETERS: dict[str, Any] = {
 #  - C1: file-read vs semantic-search distinction must be explicit
 #  - C2: README curated navigation entry point retained as fallback
 #  - web_search avoidance retained (= original HN first-touch motivation)
-_REYN_SRC_READ_DESCRIPTION = (
-    "Read a text file from Reyn's own repository by an exact "
-    "repo-root-relative path. Use for: (a) reading a specific file the "
-    "user named (e.g. README.md), or (b) navigating "
-    "Reyn's source / docs when NO indexed source covers the topic. "
-    "If an indexed source description mentions concepts / design / "
-    "docs / Reyn, use `semantic_search` instead — guessing a file path is "
-    "unreliable; semantic search over indexed chunks is not. Fallback "
-    "entry point: reyn_src_read(\"README.md\") for the overview + "
-    "curated map of deep-dive paths."
-)
+# Relocated to reyn.tools.descriptions.dev (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_REYN_SRC_READ_DESCRIPTION = _dev_descriptions.reyn_src_read.text
 
 # Parameters JSON schema for reyn_src_read. Mirrors ``read_file`` /
 # ``read_memory_body`` shape (= line-based ``offset`` / ``limit``) so the
@@ -172,14 +157,9 @@ async def _handle_read(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     ))
 
 
-_REYN_SRC_GLOB_DESCRIPTION = (
-    "Find files in Reyn's own repository by glob pattern (e.g. "
-    "'docs/**/*.md', 'src/**/router*.py'). Returns up to 200 "
-    "repo-root-relative paths, alphabetically sorted. Use this when "
-    "you need to enumerate files matching a structural pattern; for "
-    "content search use reyn_src_grep, for a single named file use "
-    "reyn_src_read."
-)
+# Relocated to reyn.tools.descriptions.dev (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_REYN_SRC_GLOB_DESCRIPTION = _dev_descriptions.reyn_src_glob.text
 
 _REYN_SRC_GLOB_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -192,14 +172,9 @@ _REYN_SRC_GLOB_PARAMETERS: dict[str, Any] = {
     "required": ["pattern"],
 }
 
-_REYN_SRC_GREP_DESCRIPTION = (
-    "Search file contents in Reyn's own repository by regex. Returns "
-    "up to 50 matches as {path, line, snippet}. `path` scopes the "
-    "search (default = whole repo); `glob` further narrows by filename "
-    "(e.g. '**/*.py'). Use this for 'where in the Reyn source is X "
-    "handled' style questions; for structural enumeration use "
-    "reyn_src_glob, for reading one known file use reyn_src_read."
-)
+# Relocated to reyn.tools.descriptions.dev (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_REYN_SRC_GREP_DESCRIPTION = _dev_descriptions.reyn_src_grep.text
 
 _REYN_SRC_GREP_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -25,19 +25,14 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from reyn.tools.descriptions import skill as _skill_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # ── skill_management__install_local ──────────────────────────────────────────
 
-_SKILL_INSTALL_LOCAL_DESCRIPTION = (
-    "Register a local skill directory into the project config "
-    "by reading its SKILL.md frontmatter and writing an entry to "
-    ".reyn/config/skills.yaml. The skill is immediately available "
-    "to sessions after the next hot-reload. Pass the path to the "
-    "directory containing SKILL.md (or the SKILL.md file directly). "
-    "Use 'name' to override the config key when the directory name "
-    "differs from the desired skill identifier."
-)
+# Relocated to reyn.tools.descriptions.skill (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_SKILL_INSTALL_LOCAL_DESCRIPTION = _skill_descriptions.skill_install_local.text
 
 _SKILL_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
     "type": "object",
@@ -114,17 +109,9 @@ async def _handle_skill_install_local(
 
 # ── skill_management__install_source ─────────────────────────────────────────
 
-_SKILL_INSTALL_SOURCE_DESCRIPTION = (
-    "Fetch a skill from a git/GitHub URL and install it into the project. "
-    "The repo is shallow-cloned to .reyn/skills/<name>/, the SKILL.md is "
-    "threat-scanned, and an entry is written to .reyn/config/skills.yaml. "
-    "The skill is immediately available to sessions after the next hot-reload. "
-    "Requires http.get permission for the source host in the skill's frontmatter. "
-    "Source format: 'https://github.com/user/repo' (repo root must contain SKILL.md) "
-    "or 'https://github.com/user/repo//path/to/skill' (subdir with SKILL.md). "
-    "Use 'name' to override the config key when the default (from SKILL.md frontmatter "
-    "or repo/subdir basename) differs from the desired skill identifier."
-)
+# Relocated to reyn.tools.descriptions.skill (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_SKILL_INSTALL_SOURCE_DESCRIPTION = _skill_descriptions.skill_install_source.text
 
 _SKILL_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
     "type": "object",

--- a/src/reyn/tools/task_ops.py
+++ b/src/reyn/tools/task_ops.py
@@ -43,54 +43,33 @@ from reyn.schemas.models import (
     TaskRepointDependencyIROp,
     TaskUpdateStatusIROp,
 )
+from reyn.tools.descriptions import task as _task_descriptions
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
 # (op_kind, IROp model, LLM-facing description). op_kind == the IROp's ``kind``
 # Literal; the exposed action name is the universal ``task__<verb>`` qualified
 # form (set in universal_dispatch._OPERATION_RULES → this ToolDefinition).
+#
+# Descriptions relocated to reyn.tools.descriptions.task (Phase 3
+# tool-description package refactor): each ``description`` string below now
+# references a named ``ToolDescription.text`` there instead of an inline
+# literal — the one data-tuple special case in the package (every other
+# tool file uses a standalone ``_X_DESCRIPTION`` module constant instead).
+# Byte-identical — no LLM-facing text change.
 _TASK_OPS: tuple[tuple[str, type, str], ...] = (
-    ("task.create", TaskCreateIROp,
-     "Create a task. While you are EXECUTING a task, a task you create is automatically "
-     "owned by it (a sub-task) and — if you omit `assignee` — assigned to you to execute. "
-     "For a TOP-LEVEL task: omitting `assignee` leaves it UNASSIGNED (it waits in the "
-     "pending-assignment queue until a session claims it via task.assign); to execute it "
-     "YOURSELF, set `assignee` to your own session; set it to another session to delegate. "
-     "`deps` are depends-on task ids (born blocked until they complete). Use to decompose a "
-     "complex request into trackable units."),
-    ("task.update_status", TaskUpdateStatusIROp,
-     "Declare a status transition on a task you are the ASSIGNEE of (the single "
-     "writer). Terminal tasks reject writes."),
-    ("task.get", TaskGetIROp, "Read one task record by id."),
-    ("task.list", TaskListIROp,
-     "List tasks, optionally narrowed by assignee / requester / status. Narrowing "
-     "by `requester` (a task id) lists the sub-tasks that task owns."),
-    ("task.add_dependency", TaskAddDependencyIROp,
-     "Add a depends-on edge (you must be the requester/topology owner). "
-     "Existence + cycle checked."),
-    ("task.remove_dependency", TaskRemoveDependencyIROp,
-     "Drop a depends-on edge (idempotent). Relaxing the graph may promote a "
-     "now-ready dependent."),
-    ("task.repoint_dependency", TaskRepointDependencyIROp,
-     "Atomically repoint a dependency edge from one task to a substitute (the "
-     "primary recovery move). The new edge is cycle-checked before any mutation."),
-    ("task.abort", TaskAbortIROp,
-     "Abort (delete) a task you requested + its sub-tree. Cooperative-terminal: "
-     "the assignee's in-flight work is rejected at its next status-write."),
-    ("task.heartbeat", TaskHeartbeatIROp,
-     "Liveness ping for a blocked task; triggers unblock-predicate evaluation. "
-     "Returns the current state."),
+    ("task.create", TaskCreateIROp, _task_descriptions.TASK_CREATE.text),
+    ("task.update_status", TaskUpdateStatusIROp, _task_descriptions.TASK_UPDATE_STATUS.text),
+    ("task.get", TaskGetIROp, _task_descriptions.TASK_GET.text),
+    ("task.list", TaskListIROp, _task_descriptions.TASK_LIST.text),
+    ("task.add_dependency", TaskAddDependencyIROp, _task_descriptions.TASK_ADD_DEPENDENCY.text),
+    ("task.remove_dependency", TaskRemoveDependencyIROp, _task_descriptions.TASK_REMOVE_DEPENDENCY.text),
+    ("task.repoint_dependency", TaskRepointDependencyIROp, _task_descriptions.TASK_REPOINT_DEPENDENCY.text),
+    ("task.abort", TaskAbortIROp, _task_descriptions.TASK_ABORT.text),
+    ("task.heartbeat", TaskHeartbeatIROp, _task_descriptions.TASK_HEARTBEAT.text),
     ("task.register_unblock_predicate", TaskRegisterUnblockPredicateIROp,
-     "Register a deterministic (code, no-LLM) unblock predicate evaluated at "
-     "heartbeat; true → unblock."),
-    ("task.comment", TaskCommentIROp,
-     "Append a comment to a task's thread (durable inter-agent / human-in-the-loop "
-     "protocol)."),
-    ("task.assign", TaskAssignIROp,
-     "Assign a session to a task. An UNASSIGNED task (in the pending-assignment queue) "
-     "may be CLAIMED by anyone — set `assignee` to the session that will execute it. An "
-     "already-assigned task may be reassigned ONLY by its current assignee (owner-initiated "
-     "hand-off; others must request it via conversation). The new assignee is woken to "
-     "execute it."),
+     _task_descriptions.TASK_REGISTER_UNBLOCK_PREDICATE.text),
+    ("task.comment", TaskCommentIROp, _task_descriptions.TASK_COMMENT.text),
+    ("task.assign", TaskAssignIROp, _task_descriptions.TASK_ASSIGN.text),
 )
 
 

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Collection, Final, Mapping
 
+from reyn.tools.descriptions import catalog as _catalog_descriptions
 from reyn.tools.descriptions import discovery
 from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
 
@@ -364,46 +365,9 @@ _DESCRIBE_ACTION_PARAMETERS: dict[str, Any] = {
 }
 
 
-_INVOKE_ACTION_DESCRIPTION = (
-    "WHAT: Execute an action by qualified name (<category>__<entry>). "
-    "Executes the action's default semantic operation. "
-    "WHEN: Call this whenever you intend to run any action — MCP tool, "
-    "file operation, web search, memory write, semantic search, etc. All catalog actions "
-    "are invoked through this single entry point. "
-    "WHEN NOT: For chitchat or self-questions, reply without tools. "
-    "PREFERRED OVER: Legacy per-kind tools (call_mcp_tool, etc.) — "
-    "invoke_action covers all 13 action categories uniformly. "
-    "On unknown action_name, returns an error with similar-name suggestions. "
-    ""
-    "SPAWN-ACK HANDLING: when an action result is {status:'spawned', ...}, the "
-    "router exits the current turn before this tool description applies; the OS "
-    "emits the user-visible acknowledgment directly. You will not be asked to "
-    "compose a reply for the spawn-ack turn. "
-    ""
-    "TASK_SPAWNED: an agent-role message starting with [task_spawned] is "
-    "OS-emitted when an async task is launched (kind=agent, paired "
-    "with chain_id). The structured header "
-    "lets you correlate the spawn with the later [task_completed] message "
-    "carrying the same identifier. The trailing human-readable line is "
-    "what the user sees; the header is your correlation record. "
-    ""
-    "TASK_COMPLETED: a user-role message starting with [task_completed] is "
-    "OS-injected when a previously-spawned async task finishes (kind=agent) "
-    "or a spawned session completes (kind=spawned_session). The message "
-    "carries the task's status + result "
-    "fields. status='finished' means normal completion; other values "
-    "('loop_limit_exceeded', 'phase_budget_exceeded', 'budget_exceeded', "
-    "'error', or any non-'finished' value with result.error present) "
-    "indicate the task did not complete normally. "
-    ""
-    "AGENT DELEGATION: For peer agent delegation, use "
-    "action_name='multi_agent__delegate' with args {to: '<agent_name>', "
-    "request: ...}; get its canonical args via "
-    "describe_action(action_name='multi_agent__delegate'). "
-    "Use when task is outside available actions but matches a peer agent's role, "
-    "or when user explicitly addresses a named agent. "
-    "Acknowledge delegation in 1 sentence."
-)
+# Relocated to reyn.tools.descriptions.catalog (Phase 3 tool-description
+# package refactor — byte-identical, no LLM-facing text change).
+_INVOKE_ACTION_DESCRIPTION = _catalog_descriptions.invoke_action.text
 
 
 _INVOKE_ACTION_PARAMETERS: dict[str, Any] = {


### PR DESCRIPTION
**[tooldesc-coder]** — Phase 3 of the tool-description package refactor (#2862/#2864 landed Phases 1-2). This completes tool-LEVEL description relocation: every `ToolDefinition.description` string now lives in `src/reyn/tools/descriptions/`.

## Scope

New `descriptions/<bucket>.py` modules (module grouping is conceptual/feature-area, matching the `mcp`/`io` precedent from Phase 2 — not always a literal mirror of `ToolDefinition.category`):

- `cron.py` — cron_register/unregister/list/enable/disable (5)
- `hooks.py` — hooks_add (1)
- `presentation.py` — present, render_template (2)
- `catalog.py` — list_agents, describe_agent, invoke_action (3)
- `interactive.py` — ask_user (1)
- `context.py` — compact (1)
- `pipeline.py` — run_pipeline / run_pipeline_async / run_pipeline_inline / run_pipeline_inline_async (4)
- `pipeline_management.py` — pipeline_install_local, pipeline_install_source (2)
- `skill.py` — skill_install_local, skill_install_source (2)
- `dev.py` — reyn_src_list/read/glob/grep (4)
- `task.py` — the 12 `task.*` control-IR ops (**data-tuple special case**, see below)

Each origin tool module keeps its `_X_DESCRIPTION = descriptions.<bucket>.<name>.text` alias so no call site changes — this is purely a relocation of the string literal, never a behavior change.

## task_ops.py data-tuple special case

`_TASK_OPS` previously carried each description as the third element of an inline `(op_kind, IROp, "...")` tuple — the one tool file that didn't follow the `_X_DESCRIPTION` module-constant convention. This PR lifts all 12 descriptions into named `ToolDescription` constants (`TASK_CREATE`, `TASK_UPDATE_STATUS`, …) in `descriptions/task.py`, and `_TASK_OPS` now references `TASK_CREATE.text` etc. — bringing `task_ops.py` in line with every other tool file. Larger diff in that one file, as flagged in the brief.

## Verification

- `test_tool_description_relocation.py` (the existing full-schema baseline test covering all 82 tools) stays **GREEN** — byte-identical render, no baseline regeneration.
- Strip-falsify: 1-char change to a relocated `text` (`cron_register`) → the baseline test goes **RED** (confirmed locally, then reverted).
- Liveness + completeness checks extend automatically to the new `ALL` entries (tool_name resolves to a registered tool; every field non-empty).
- **Tool-level relocation is now COMPLETE**: every `ToolDefinition.description` in the registry is sourced from `reyn.tools.descriptions`. Param-level (per-argument JSON-schema `description`) relocation remains Phase 4, out of scope here.

## CI gates (all run locally, all green)

- `ruff check src tests` → All checks passed!
- `python scripts/test_tier_audit.py --strict` (no test files touched this PR) → 7485 inspected, 0 errors
- `pytest` (repo root) → 8189 passed, 20 skipped, 0 failures
- `python scripts/verify_module_docstrings.py <changed files>` → OK, no refactor-narrative violations

## Test plan

- [x] `pytest tests/tools/test_tool_description_relocation.py` green (byte-identical baseline)
- [x] Strip-falsify manually verified RED then reverted
- [x] Full `pytest` suite green (8189 passed)
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean (no test files changed)
- [x] `verify_module_docstrings.py` clean