### PR TITLE
refactor: relocate per-parameter tool descriptions (Phase 4, byte-identical)

### DIFF
--- a/src/reyn/tools/agent_spawn.py
+++ b/src/reyn/tools/agent_spawn.py
@@ -31,11 +31,11 @@ _AGENT_SPAWN_PARAMETERS: dict[str, Any] = {
     "properties": {
         "name": {
             "type": "string",
-            "description": "The new agent's identity (a unique agent name).",
+            "description": _delegation_descriptions.PARAMS["agent_spawn"]["name"].text,
         },
         "role": {
             "type": "string",
-            "description": "The new agent's role/purpose (free text).",
+            "description": _delegation_descriptions.PARAMS["agent_spawn"]["role"].text,
         },
     },
     "required": ["name"],

--- a/src/reyn/tools/compact.py
+++ b/src/reyn/tools/compact.py
@@ -26,10 +26,7 @@ _COMPACT_PARAMETERS: dict[str, Any] = {
     "properties": {
         "reason": {
             "type": "string",
-            "description": (
-                "Optional short rationale for the audit trail (e.g. 'window "
-                "low before reading large file'). Not interpreted by the OS."
-            ),
+            "description": _context_descriptions.PARAMS["compact"]["reason"].text,
         },
     },
     "required": [],

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -60,11 +60,7 @@ _CRON_DISABLE_DESCRIPTION = _cron_descriptions.cron_disable.text
 _CRON_NAME_PARAM = {
     "name": {
         "type": "string",
-        "description": (
-            "Unique job identifier within the project (e.g. "
-            "'morning_news', 'weekly_report'). Reused across "
-            "register/unregister/enable/disable."
-        ),
+        "description": _cron_descriptions.PARAMS["cron_register"]["name"].text,
     },
 }
 
@@ -74,34 +70,19 @@ _CRON_REGISTER_PARAMETERS: dict[str, Any] = {
         **_CRON_NAME_PARAM,
         "to": {
             "type": "string",
-            "description": (
-                "Target Reyn agent name. The scheduled message is "
-                "delivered to this agent's inbox; the agent must "
-                "exist in the project."
-            ),
+            "description": _cron_descriptions.PARAMS["cron_register"]["to"].text,
         },
         "message": {
             "type": "string",
-            "description": (
-                "Free-form text dispatched to the agent. Treated as a "
-                "user-turn-shaped message with sender='cron:<name>'."
-            ),
+            "description": _cron_descriptions.PARAMS["cron_register"]["message"].text,
         },
         "schedule": {
             "type": "string",
-            "description": (
-                "5-field cron expression (e.g. '0 9 * * *' = daily 9am, "
-                "'0 */6 * * *' = every 6 hours, '0 9 * * MON' = Mondays "
-                "9am)."
-            ),
+            "description": _cron_descriptions.PARAMS["cron_register"]["schedule"].text,
         },
         "enabled": {
             "type": "boolean",
-            "description": (
-                "Whether the schedule fires immediately. Defaults to "
-                "true. Set false to register a paused job and enable "
-                "later via cron__enable."
-            ),
+            "description": _cron_descriptions.PARAMS["cron_register"]["enabled"].text,
         },
     },
     "required": ["name", "to", "message", "schedule"],

--- a/src/reyn/tools/delegate_to_agent.py
+++ b/src/reyn/tools/delegate_to_agent.py
@@ -53,16 +53,11 @@ _DELEGATE_TO_AGENT_PARAMETERS: dict[str, Any] = {
     "properties": {
         "to": {
             "type": "string",
-            "description": (
-                "Target agent name as listed by list_agents."
-            ),
+            "description": _delegation_descriptions.PARAMS["delegate_to_agent"]["to"].text,
         },
         "request": {
             "type": "string",
-            "description": (
-                "Natural-language request paraphrased "
-                "for the peer's context."
-            ),
+            "description": _delegation_descriptions.PARAMS["delegate_to_agent"]["request"].text,
         },
     },
     "required": ["to", "request"],

--- a/src/reyn/tools/descriptions/__init__.py
+++ b/src/reyn/tools/descriptions/__init__.py
@@ -54,7 +54,7 @@ from reyn.tools.descriptions import (
     skill,
     task,
 )
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 ALL: dict[str, ToolDescription] = {
     **discovery.ALL,
@@ -76,7 +76,33 @@ ALL: dict[str, ToolDescription] = {
     **task.ALL,
 }
 
+# Phase 4 (param-level relocation): each bucket that has at least one
+# per-parameter description exposes a ``PARAMS: dict[str, dict[str,
+# ParamDescription]]`` — keyed by the SAME entry name as that bucket's
+# ``ALL`` (tool_name for nearly every bucket; the ``task`` bucket has no
+# PARAMS module yet — its 12 op-kind entries carry no per-param text in
+# their origin schemas). ``interactive`` (ask_user) also has none. Buckets
+# without a PARAMS module are simply omitted from this merge.
+ALL_PARAMS: dict[str, dict[str, ParamDescription]] = {
+    **discovery.PARAMS,
+    **io.PARAMS,
+    **memory.PARAMS,
+    **mcp.PARAMS,
+    **execution.PARAMS,
+    **delegation.PARAMS,
+    **cron.PARAMS,
+    **hooks.PARAMS,
+    **presentation.PARAMS,
+    **catalog.PARAMS,
+    **context.PARAMS,
+    **pipeline.PARAMS,
+    **pipeline_management.PARAMS,
+    **skill.PARAMS,
+    **dev.PARAMS,
+}
+
 __all__ = [
+    "ParamDescription",
     "ToolDescription",
     "discovery",
     "io",
@@ -96,4 +122,5 @@ __all__ = [
     "dev",
     "task",
     "ALL",
+    "ALL_PARAMS",
 ]

--- a/src/reyn/tools/descriptions/_types.py
+++ b/src/reyn/tools/descriptions/_types.py
@@ -40,3 +40,29 @@ class ToolDescription:
     purpose: str
     text: str
     ja: str
+
+
+@dataclass(frozen=True)
+class ParamDescription:
+    """One JSON-schema parameter's LLM-facing ``description`` plus a Japanese gloss.
+
+    Phase 4 of the tool-description package refactor extends the reviewable
+    package below tool-LEVEL text to PARAM-level text: the per-field
+    ``"description": "..."`` strings inside a ``ToolDefinition.parameters``
+    JSON-schema (``properties.<field>.description``). Not every tool has
+    param-level descriptions — many params are self-evident from their name
+    + type alone, so a bucket's ``PARAMS`` dict only carries entries for
+    fields that actually declare one in the origin schema.
+
+    Attributes:
+        text: The EXACT string sent to the LLM as
+            ``parameters["properties"][field]["description"]``. Must be
+            byte-identical to the pre-migration string.
+        ja: Purpose-based Japanese gloss of what the field is / why it
+            matters — NOT a literal translation of ``text`` — for a
+            reviewer who reads Japanese faster than English prose. Never
+            sent to the LLM.
+    """
+
+    text: str
+    ja: str

--- a/src/reyn/tools/descriptions/catalog.py
+++ b/src/reyn/tools/descriptions/catalog.py
@@ -19,7 +19,7 @@ conceptual, not a literal mirror of the ``category`` field).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 list_agents = ToolDescription(
     tool_name="list_agents",
@@ -124,4 +124,38 @@ ALL: dict[str, ToolDescription] = {
     "list_agents": list_agents,
     "describe_agent": describe_agent,
     "invoke_action": invoke_action,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# list_agents / describe_agent have no param-level descriptions (bare-typed
+# `path` / `name`) — no entries needed.
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "invoke_action": {
+        "action_name": ParamDescription(
+            text=(
+                "Qualified name of the action/resource to invoke "
+                "(e.g. 'mcp__brave__search', 'multi_agent__delegate')."
+            ),
+            ja=(
+                "呼び出すアクション/リソースの修飾名（例 "
+                "'mcp__brave__search', 'multi_agent__delegate'）。"
+            ),
+        ),
+        "args": ParamDescription(
+            text=(
+                "Arguments for the action; shape comes from "
+                "describe_action.input_schema. May be omitted for "
+                "resources whose canonical invoke takes no args "
+                "(e.g. memory_entry__foo)."
+            ),
+            ja=(
+                "アクションへの引数。形は describe_action.input_schema から"
+                "得る。正規の呼び出しが引数を取らないリソース（例 "
+                "memory_entry__foo）では省略可。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/context.py
+++ b/src/reyn/tools/descriptions/context.py
@@ -8,7 +8,7 @@ to ``context.compact.text``.
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 compact = ToolDescription(
     tool_name="compact",
@@ -37,4 +37,22 @@ compact = ToolDescription(
 
 ALL: dict[str, ToolDescription] = {
     "compact": compact,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "compact": {
+        "reason": ParamDescription(
+            text=(
+                "Optional short rationale for the audit trail (e.g. 'window "
+                "low before reading large file'). Not interpreted by the OS."
+            ),
+            ja=(
+                "監査証跡向けの任意の短い理由（例：'大きなファイルを読む前に"
+                "空きが少ない'）。OS はこの値を解釈しない。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/cron.py
+++ b/src/reyn/tools/descriptions/cron.py
@@ -9,7 +9,7 @@ module now aliases its ``_CRON_*_DESCRIPTION`` module constants to
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 cron_register = ToolDescription(
     tool_name="cron_register",
@@ -102,4 +102,76 @@ ALL: dict[str, ToolDescription] = {
     "cron_list": cron_list,
     "cron_enable": cron_enable,
     "cron_disable": cron_disable,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# ``name`` is shared across register/unregister/enable/disable (the origin
+# module builds ``_CRON_NAME_PARAM`` once and reuses it) — kept as one entry
+# reused below rather than duplicated per tool, matching that structure.
+
+_name_param = ParamDescription(
+    text=(
+        "Unique job identifier within the project (e.g. "
+        "'morning_news', 'weekly_report'). Reused across "
+        "register/unregister/enable/disable."
+    ),
+    ja=(
+        "プロジェクト内で一意なジョブ識別子（例 'morning_news', "
+        "'weekly_report'）。register/unregister/enable/disable で共通に使う。"
+    ),
+)
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "cron_register": {
+        "name": _name_param,
+        "to": ParamDescription(
+            text=(
+                "Target Reyn agent name. The scheduled message is "
+                "delivered to this agent's inbox; the agent must "
+                "exist in the project."
+            ),
+            ja=(
+                "送信先の Reyn エージェント名。スケジュールされたメッセージは"
+                "このエージェントの inbox に届く。プロジェクト内に実在する"
+                "必要がある。"
+            ),
+        ),
+        "message": ParamDescription(
+            text=(
+                "Free-form text dispatched to the agent. Treated as a "
+                "user-turn-shaped message with sender='cron:<name>'."
+            ),
+            ja=(
+                "エージェントに送る自由記述テキスト。sender='cron:<name>' の"
+                "ユーザーターン形式のメッセージとして扱われる。"
+            ),
+        ),
+        "schedule": ParamDescription(
+            text=(
+                "5-field cron expression (e.g. '0 9 * * *' = daily 9am, "
+                "'0 */6 * * *' = every 6 hours, '0 9 * * MON' = Mondays "
+                "9am)."
+            ),
+            ja=(
+                "5フィールドの cron 式（例 '0 9 * * *' = 毎日9時、"
+                "'0 */6 * * *' = 6時間毎、'0 9 * * MON' = 毎週月曜9時）。"
+            ),
+        ),
+        "enabled": ParamDescription(
+            text=(
+                "Whether the schedule fires immediately. Defaults to "
+                "true. Set false to register a paused job and enable "
+                "later via cron__enable."
+            ),
+            ja=(
+                "スケジュールを即座に有効化するか。デフォルト true。false に"
+                "すると一時停止状態で登録し、後で cron__enable で有効化できる。"
+            ),
+        ),
+    },
+    "cron_unregister": {"name": _name_param},
+    "cron_enable": {"name": _name_param},
+    "cron_disable": {"name": _name_param},
 }

--- a/src/reyn/tools/descriptions/delegation.py
+++ b/src/reyn/tools/descriptions/delegation.py
@@ -15,7 +15,7 @@ LLM drives directly, never a phase-authored Control IR op.
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 agent_spawn = ToolDescription(
     tool_name="agent_spawn",
@@ -113,4 +113,107 @@ ALL: dict[str, ToolDescription] = {
     "delegate_to_agent": delegate_to_agent,
     "session_spawn": session_spawn,
     "topology_create": topology_create,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "agent_spawn": {
+        "name": ParamDescription(
+            text="The new agent's identity (a unique agent name).",
+            ja="新しいエージェントの識別子（一意なエージェント名）。",
+        ),
+        "role": ParamDescription(
+            text="The new agent's role/purpose (free text).",
+            ja="新しいエージェントの役割・目的（自由記述）。",
+        ),
+    },
+    "delegate_to_agent": {
+        "to": ParamDescription(
+            text="Target agent name as listed by list_agents.",
+            ja="list_agents に列挙される委任先エージェント名。",
+        ),
+        "request": ParamDescription(
+            text=(
+                "Natural-language request paraphrased "
+                "for the peer's context."
+            ),
+            ja="相手エージェントの文脈向けに言い換えた自然言語のリクエスト。",
+        ),
+    },
+    "session_spawn": {
+        "request": ParamDescription(
+            text="The task for the fresh-context session to run.",
+            ja="新規コンテキストのセッションに実行させるタスク。",
+        ),
+        "mode": ParamDescription(
+            text=(
+                "ephemeral = the session auto-vanishes after its task; "
+                "persistent = it stays. Chosen at spawn time."
+            ),
+            ja=(
+                "ephemeral はタスク後にセッションが自動消滅、persistent は"
+                "残る。スポーン時に選択する。"
+            ),
+        ),
+        "narrowing": ParamDescription(
+            text=(
+                "Optional per-session capability narrowing (restrict-only, cannot "
+                "widen your envelope): a capability_profile subset, e.g. "
+                "{\"tool_deny\": [\"sandboxed_exec\"]}."
+            ),
+            ja=(
+                "任意のセッション単位の権限絞り込み（restrict-only、自分の"
+                "権限範囲を広げることはできない）: capability_profile の"
+                "サブセット、例 {\"tool_deny\": [\"sandboxed_exec\"]}。"
+            ),
+        ),
+    },
+    "topology_create": {
+        "name": ParamDescription(
+            text="The new topology's name (unique; 1-32 chars [a-z0-9_-]).",
+            ja="新しいトポロジー名（一意、1〜32文字 [a-z0-9_-]）。",
+        ),
+        "kind": ParamDescription(
+            text=(
+                "network = every member ↔ every member; team = star around a leader "
+                "(requires 'leader'); pipeline = ordered chain (members[i] → members[i+1])."
+            ),
+            ja=(
+                "network=全メンバー相互接続、team=leader中心のスター"
+                "（'leader'必須）、pipeline=順序付きチェーン"
+                "（members[i] → members[i+1]）。"
+            ),
+        ),
+        "members": ParamDescription(
+            text=(
+                "Agent names to wire — each must be in your spawn subtree (yourself or "
+                "an agent you spawned)."
+            ),
+            ja=(
+                "接続するエージェント名 — それぞれ自分のスポーンサブツリー内"
+                "（自分自身か自分がスポーンしたエージェント）である必要がある。"
+            ),
+        ),
+        "leader": ParamDescription(
+            text="For kind=team only: the member at the centre of the star.",
+            ja="kind=team のときのみ: スターの中心となるメンバー。",
+        ),
+        "profiles": ParamDescription(
+            text=(
+                "Optional JSON object mapping a member name to a capability_profile name "
+                "(both strings). A bound member's session is narrowed by that profile (it "
+                "can only narrow within its ⊆-you envelope, never widen). Each key must be "
+                "one of 'members'."
+            ),
+            ja=(
+                "任意: メンバー名を capability_profile 名にマッピングする JSON "
+                "オブジェクト（両方とも文字列）。束縛されたメンバーのセッションは"
+                "そのプロファイルで絞り込まれる（⊆自分の範囲内でのみ絞り込め、"
+                "広げることはできない）。各キーは 'members' のいずれかである"
+                "必要がある。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/dev.py
+++ b/src/reyn/tools/descriptions/dev.py
@@ -10,7 +10,7 @@ repository — ``reyn_src_list`` / ``reyn_src_read`` / ``reyn_src_glob`` /
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 reyn_src_list = ToolDescription(
     tool_name="reyn_src_list",
@@ -120,4 +120,69 @@ ALL: dict[str, ToolDescription] = {
     "reyn_src_read": reyn_src_read,
     "reyn_src_glob": reyn_src_glob,
     "reyn_src_grep": reyn_src_grep,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# reyn_src_list has no param-level description (path is bare-typed) — no
+# entry needed.
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "reyn_src_read": {
+        "offset": ParamDescription(
+            text=(
+                "Line number to start reading from (0-indexed). "
+                "Omit to start at the beginning of the file. When set "
+                "(with or without limit), the 256-KB byte cap is "
+                "bypassed by line-streaming only the requested slice."
+            ),
+            ja=(
+                "読み取り開始行（0始まり）。省略時はファイル先頭から。"
+                "設定時（limit有無に関わらず）は256KBのバイト上限を"
+                "回避し、要求された範囲のみを行単位でストリームする。"
+            ),
+        ),
+        "limit": ParamDescription(
+            text=(
+                "Number of lines to read from `offset`. "
+                "Omit to read through end of file."
+            ),
+            ja="`offset` から読む行数。省略時はファイル末尾まで読む。",
+        ),
+    },
+    "reyn_src_glob": {
+        "pattern": ParamDescription(
+            text="Glob pattern (e.g. '**/*.py', 'docs/**/*.md').",
+            ja="glob パターン（例 '**/*.py', 'docs/**/*.md'）。",
+        ),
+    },
+    "reyn_src_grep": {
+        "pattern": ParamDescription(
+            text="Regex pattern (Python `re` syntax).",
+            ja="正規表現パターン（Python `re` 構文）。",
+        ),
+        "path": ParamDescription(
+            text=(
+                "Repo-relative directory or file to scope the search. "
+                "Default = repo root. Use '' for repo root."
+            ),
+            ja="検索範囲をリポジトリ相対のディレクトリ/ファイルに絞る。デフォルトはリポジトリルート。",
+        ),
+        "glob": ParamDescription(
+            text=(
+                "Optional filename glob filter (e.g. '**/*.py'). "
+                "When omitted, all text files under `path` are searched."
+            ),
+            ja="任意のファイル名 glob フィルタ（例 '**/*.py'）。省略時は `path` 配下の全テキストファイルを検索。",
+        ),
+        "case_sensitive": ParamDescription(
+            text="Default false (= case-insensitive).",
+            ja="デフォルト false（大文字小文字を区別しない）。",
+        ),
+        "max_results": ParamDescription(
+            text="Cap on match count. Default 50.",
+            ja="一致件数の上限。デフォルト 50。",
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/discovery.py
+++ b/src/reyn/tools/descriptions/discovery.py
@@ -15,7 +15,7 @@ search_actions / describe_action.
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 embed = ToolDescription(
     tool_name="embed",
@@ -320,4 +320,128 @@ ALL: dict[str, ToolDescription] = {
     "list_actions": list_actions,
     "search_actions": search_actions,
     "describe_action": describe_action,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# web_fetch / web_search have no param-level descriptions in their origin
+# schemas (url/max_length/query are bare-typed) — no entries needed here.
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "embed": {
+        "texts": ParamDescription(
+            text="Texts to embed. Returned vectors preserve this order.",
+            ja="埋め込み対象のテキスト群。返るベクトルはこの順序を保持する。",
+        ),
+        "embedding_model": ParamDescription(
+            text=(
+                "Embedding model class (light/standard/strong) or a full "
+                "provider model id."
+            ),
+            ja="埋め込みモデルクラス（light/standard/strong）またはプロバイダのフルモデルID。",
+        ),
+    },
+    "semantic_search": {
+        "query": ParamDescription(
+            text="Natural language query to search for.",
+            ja="検索する自然言語クエリ。",
+        ),
+        "sources": ParamDescription(
+            text="Logical source names to search (from Indexed sources list).",
+            ja="検索対象の論理ソース名（Indexed sources 一覧から）。",
+        ),
+        "top_k": ParamDescription(
+            text="Number of top chunks to return.",
+            ja="返す上位チャンク数。",
+        ),
+        "filters": ParamDescription(
+            text="ChunkMetadata field equality filters (e.g. source_path).",
+            ja="ChunkMetadata フィールドの等価フィルタ（例 source_path）。",
+        ),
+        "embedding_model": ParamDescription(
+            text=(
+                "Fallback embedding model class (light/standard/strong) or "
+                "full model id, used ONLY for a source with no recorded "
+                "model yet — every already-indexed source auto-adopts its "
+                "OWN recorded model regardless of this value (multi-model "
+                "correctness, FP-0057 Phase 2a)."
+            ),
+            ja=(
+                "フォールバックの埋め込みモデルクラス（light/standard/strong）"
+                "またはフルモデルID。まだ記録済みモデルがないソースにのみ使わ"
+                "れる — 既にインデックス済みのソースはこの値に関係なく自身の"
+                "記録済みモデルを自動採用する（マルチモデル正当性、FP-0057 "
+                "Phase 2a）。"
+            ),
+        ),
+    },
+    "mcp_search_registry": {
+        "text": ParamDescription(
+            text=(
+                "Natural-language capability request (e.g. \"github "
+                "related\", \"image generation\", \"PDF handling\") — "
+                "the query may be in any language, including Japanese "
+                "and other non-English input."
+            ),
+            ja=(
+                "自然言語での能力リクエスト（例「github関連」「画像生成」"
+                "「PDF処理」） — 日本語を含むどの言語でもよい。"
+            ),
+        ),
+    },
+    "list_actions": {
+        # NOTE: the origin schema appends ``", ".join(CATEGORIES) + "."`` to
+        # this text at import time (the live category list, not a literal) —
+        # ``.text`` here is the STATIC prefix only; the origin module still
+        # does the concatenation so the byte-identical rendered string is
+        # unchanged.
+        "category": ParamDescription(
+            text=(
+                "Filter by category. Pass an array of category names "
+                "(e.g. category=['exec'], category=['web', 'file']). "
+                "Omit or pass [] to include all categories. "
+                "Categories: "
+            ),
+            ja=(
+                "カテゴリで絞り込む。カテゴリ名の配列を渡す（例 "
+                "category=['exec']）。省略または [] で全カテゴリを含む。"
+                "（末尾に実際のカテゴリ一覧が動的に付加される）"
+            ),
+        ),
+        "offset": ParamDescription(
+            text="Pagination offset (default 0).",
+            ja="ページングオフセット（デフォルト 0）。",
+        ),
+        "limit": ParamDescription(
+            text="Page size (default 10).",
+            ja="1ページのサイズ（デフォルト 10）。",
+        ),
+    },
+    "search_actions": {
+        "query": ParamDescription(
+            text="Natural-language query in any language.",
+            ja="任意の言語での自然言語クエリ。",
+        ),
+        "category": ParamDescription(
+            text="Optional category restriction.",
+            ja="任意のカテゴリ制限。",
+        ),
+        "limit": ParamDescription(
+            text="Top-K results to return (default 10).",
+            ja="返す上位K件の結果数（デフォルト 10）。",
+        ),
+    },
+    "describe_action": {
+        "action_name": ParamDescription(
+            text=(
+                "Qualified name of the action/resource to describe "
+                "(e.g. 'mcp__brave__search', 'rag_corpus__meetings')."
+            ),
+            ja=(
+                "説明対象のアクション/リソースの修飾名（例 "
+                "'mcp__brave__search', 'rag_corpus__meetings'）。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/execution.py
+++ b/src/reyn/tools/descriptions/execution.py
@@ -13,7 +13,7 @@ pipeline DSL sugar over sandboxed_exec, #2593).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 sandboxed_exec = ToolDescription(
     tool_name="sandboxed_exec",
@@ -74,4 +74,33 @@ shell = ToolDescription(
 ALL: dict[str, ToolDescription] = {
     "sandboxed_exec": sandboxed_exec,
     "shell": shell,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+_timeout_seconds_desc = ParamDescription(
+    text="Wall-clock time limit in seconds (default 60).",
+    ja="実時間タイムアウト秒数（デフォルト 60）。",
+)
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "sandboxed_exec": {
+        "argv": ParamDescription(
+            text="Command and arguments; argv[0] is the executable.",
+            ja="コマンドと引数。argv[0] が実行ファイル。",
+        ),
+        "timeout_seconds": _timeout_seconds_desc,
+    },
+    "shell": {
+        "command": ParamDescription(
+            text="Shell command line, run as `/bin/sh -c <command>`.",
+            ja="`/bin/sh -c <command>` として実行されるシェルコマンド行。",
+        ),
+        "stdin_pipe": ParamDescription(
+            text="The previous pipeline step's pipe-data (JSON-encoded onto stdin).",
+            ja="直前のパイプラインステップのパイプデータ（JSON エンコードして stdin に渡す）。",
+        ),
+        "timeout": _timeout_seconds_desc,
+    },
 }

--- a/src/reyn/tools/descriptions/hooks.py
+++ b/src/reyn/tools/descriptions/hooks.py
@@ -9,7 +9,7 @@ agent-self-reload trigger that writes to the runtime hooks layer
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 hooks_add = ToolDescription(
     tool_name="hooks_add",
@@ -38,4 +38,39 @@ hooks_add = ToolDescription(
 
 ALL: dict[str, ToolDescription] = {
     "hooks_add": hooks_add,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "hooks_add": {
+        "on": ParamDescription(
+            text="The lifecycle point the hook fires at.",
+            ja="フックが発火するライフサイクルポイント。",
+        ),
+        "message": ParamDescription(
+            text="The message pushed when the hook fires (a Jinja2 template is allowed).",
+            ja="フック発火時にプッシュされるメッセージ（Jinja2 テンプレート可）。",
+        ),
+        "wake": ParamDescription(
+            text=(
+                "true → the push starts a new turn (self-continuation, capability E); "
+                "false → it rides along with the next turn as context (capability C). "
+                "Default true."
+            ),
+            ja=(
+                "true なら新しいターンを開始（自己継続、capability E）、false なら"
+                "次のターンにコンテキストとして相乗り（capability C）。デフォルト true。"
+            ),
+        ),
+        "push_when": ParamDescription(
+            text="Optional Jinja2 → bool; when it renders false the push is skipped. Default 'true'.",
+            ja="任意の Jinja2 → bool 条件。false になるとプッシュはスキップされる。デフォルト 'true'。",
+        ),
+        "name": ParamDescription(
+            text="Optional label surfaced as the [hook:<name>] attribution prefix.",
+            ja="[hook:<name>] という帰属プレフィックスとして表示される任意ラベル。",
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/io.py
+++ b/src/reyn/tools/descriptions/io.py
@@ -18,7 +18,7 @@ I/O), matching the Phase 2 dispatch brief, not by its literal
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 read_file = ToolDescription(
     tool_name="read_file",
@@ -223,4 +223,147 @@ ALL: dict[str, ToolDescription] = {
     "list_directory": list_directory,
     "drop_source": drop_source,
     "index_update": index_update,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# Only fields that actually declare a "description" in the origin
+# ``parameters`` JSON-schema get an entry here — many params (e.g. `path`
+# on read_file) are bare `{"type": "string"}` with no description.
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "read_file": {
+        "offset": ParamDescription(
+            text=(
+                "Line number to start reading from (0-indexed). "
+                "Omit to start at the beginning of the file."
+            ),
+            ja="読み取り開始行（0始まり）。省略時はファイル先頭から。",
+        ),
+        "limit": ParamDescription(
+            text=(
+                "Number of lines to read from `offset`. "
+                "Omit to read through end of file."
+            ),
+            ja="`offset` から読む行数。省略時はファイル末尾まで読む。",
+        ),
+    },
+    "edit_file": {
+        "old_string": ParamDescription(
+            text=(
+                "Exact text to replace. Must appear exactly once unless "
+                "replace_all is true; include surrounding context to "
+                "make it unique."
+            ),
+            ja=(
+                "置換対象の完全一致テキスト。replace_all=true でない限り"
+                "ファイル内に1回だけ出現する必要があるので、周辺文脈を含めて"
+                "一意にする。"
+            ),
+        ),
+        "new_string": ParamDescription(
+            text="Replacement text.",
+            ja="置換後のテキスト。",
+        ),
+        "replace_all": ParamDescription(
+            text=(
+                "When true, every occurrence of old_string is replaced. "
+                "Default false (= require uniqueness)."
+            ),
+            ja="true なら old_string の全出現を置換。デフォルト false（一意性を要求）。",
+        ),
+    },
+    "grep_files": {
+        "pattern": ParamDescription(
+            text="Regex pattern to search for.",
+            ja="検索する正規表現パターン。",
+        ),
+        "path": ParamDescription(
+            text="Directory or file to search. Defaults to '.' (workspace root).",
+            ja="検索対象のディレクトリまたはファイル。デフォルトは '.'（ワークスペースルート）。",
+        ),
+        "glob": ParamDescription(
+            text="File-glob filter (e.g. '**/*.py'). Searches all files when omitted.",
+            ja="ファイル glob フィルタ（例 '**/*.py'）。省略時は全ファイルを検索。",
+        ),
+        "case_sensitive": ParamDescription(
+            text="When true, search is case-sensitive. Defaults to false.",
+            ja="true なら大文字小文字を区別。デフォルト false。",
+        ),
+        "max_results": ParamDescription(
+            text="Maximum number of matches to return. Defaults to 50.",
+            ja="返す一致件数の上限。デフォルト 50。",
+        ),
+    },
+    "glob_files": {
+        "pattern": ParamDescription(
+            text=(
+                "Glob pattern. To match by name anywhere under a directory, "
+                "always include `**` (e.g. '**/*.py' or 'src/**/*.md'). "
+                "A bare name without `**` matches only at the exact root "
+                "level, not recursively."
+            ),
+            ja=(
+                "glob パターン。ディレクトリ配下のどこでも名前一致させたいなら"
+                "必ず `**` を含める（例 '**/*.py'）。`**` のない裸の名前は"
+                "ルート直下のみ一致し再帰しない。"
+            ),
+        ),
+        "path": ParamDescription(
+            text="Root directory for the glob. Defaults to '.' (workspace root).",
+            ja="glob 検索の起点ディレクトリ。デフォルトは '.'（ワークスペースルート）。",
+        ),
+    },
+    "drop_source": {
+        "source": ParamDescription(
+            text="Logical source name to remove (from Indexed sources list).",
+            ja="削除する論理ソース名（Indexed sources 一覧から）。",
+        ),
+    },
+    "index_update": {
+        "source": ParamDescription(
+            text="Logical source name to ingest into.",
+            ja="投入先の論理ソース名。",
+        ),
+        "chunks": ParamDescription(
+            text="Chunks to reconcile into the index.",
+            ja="インデックスに反映するチャンク群。",
+        ),
+        "chunks.metadata": ParamDescription(
+            text=(
+                "content_hash (required, change-detection key), "
+                "source_path (required, reconciliation-scope "
+                "key), plus optional source_type / chunk_index "
+                "/ size_tokens / parent_context / extra."
+            ),
+            ja=(
+                "content_hash（必須、変更検知キー）、source_path（必須、"
+                "reconcile 範囲キー）、任意で source_type / chunk_index / "
+                "size_tokens / parent_context / extra。"
+            ),
+        ),
+        "embedding_model": ParamDescription(
+            text=(
+                "Embedding model class, used ONLY when this source has no "
+                "recorded model yet (first index_update for a new source) "
+                "— an already-indexed source's recorded model always wins "
+                "(a source is one embedding space)."
+            ),
+            ja=(
+                "埋め込みモデルクラス。このソースに記録済みモデルがまだない"
+                "場合（新規ソースの最初の index_update）のみ使用される — "
+                "既にインデックス済みのソースは記録済みモデルが常に優先"
+                "（1ソース=1埋め込み空間）。"
+            ),
+        ),
+        "description": ParamDescription(
+            text="SourceManifest description (first-index or override).",
+            ja="SourceManifest の説明文（初回インデックス時または上書き）。",
+        ),
+        "path": ParamDescription(
+            text="SourceManifest path label (first-index or override).",
+            ja="SourceManifest のパスラベル（初回インデックス時または上書き）。",
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/mcp.py
+++ b/src/reyn/tools/descriptions/mcp.py
@@ -26,7 +26,7 @@ Covers, by origin module:
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 list_mcp_servers = ToolDescription(
     tool_name="list_mcp_servers",
@@ -383,4 +383,276 @@ ALL: dict[str, ToolDescription] = {
     "mcp_call_tool": mcp_call_tool,
     "mcp_install": mcp_install,
     "mcp_drop_server": mcp_drop_server,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# ``server_mcp_name_param`` / ``server_uri_param`` are re-used across
+# several entries below wherever the origin schema repeats the exact same
+# literal string (mirrors the origin file's own repetition, not a new
+# dedup).
+
+_server_param = ParamDescription(
+    text="MCP server name — choose from the enum (verbatim).",
+    ja="MCP サーバー名 — enum からそのまま選ぶ。",
+)
+_resource_uri_param = ParamDescription(
+    text="Resource URI, verbatim from list_mcp_resources.",
+    ja="list_mcp_resources から得たリソース URI（そのまま）。",
+)
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "call_mcp_tool": {
+        "server": _server_param,
+        "mcp_tool_name": ParamDescription(
+            text=(
+                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
+                "the enum. Use describe_mcp_tool for the full input schema."
+            ),
+            ja=(
+                "ドット区切りの mcp_tool 識別子: <server>.<tool> — enum から"
+                "選ぶ。完全な入力スキーマは describe_mcp_tool で取得。"
+            ),
+        ),
+        "tool_args": ParamDescription(
+            text=(
+                "The target MCP tool's OWN parameters (the shape from "
+                "describe_mcp_tool), as a nested object here — NOT flat alongside "
+                "server / mcp_tool_name."
+            ),
+            ja=(
+                "対象 MCP ツール自体のパラメータ（describe_mcp_tool の形）。"
+                "ここではネストされたオブジェクトとして渡す — server / "
+                "mcp_tool_name と同じ階層に平らに置かない。"
+            ),
+        ),
+    },
+    "describe_mcp_tool": {
+        "server": _server_param,
+        "mcp_tool_name": ParamDescription(
+            text=(
+                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
+                "the enum."
+            ),
+            ja="ドット区切りの mcp_tool 識別子: <server>.<tool> — enum から選ぶ。",
+        ),
+    },
+    "list_mcp_resources": {"server": _server_param},
+    "list_mcp_resource_templates": {"server": _server_param},
+    "read_mcp_resource": {
+        "server": _server_param,
+        "uri": _resource_uri_param,
+    },
+    "subscribe_mcp_resource": {
+        "server": _server_param,
+        "uri": _resource_uri_param,
+    },
+    "unsubscribe_mcp_resource": {
+        "server": _server_param,
+        "uri": _resource_uri_param,
+    },
+    "list_mcp_prompts": {"server": _server_param},
+    "get_mcp_prompt": {
+        "server": _server_param,
+        "name": ParamDescription(
+            text="Prompt name, verbatim from list_mcp_prompts.",
+            ja="list_mcp_prompts から得たプロンプト名（そのまま）。",
+        ),
+        "arguments": ParamDescription(
+            text=(
+                "Arguments to render the prompt with, matching the shape "
+                "from list_mcp_prompts' arguments field. Optional — omit "
+                "for a prompt that takes none."
+            ),
+            ja=(
+                "プロンプトをレンダリングする引数。list_mcp_prompts の "
+                "arguments フィールドの形に一致させる。任意 — 引数を取らな"
+                "いプロンプトなら省略可。"
+            ),
+        ),
+    },
+    "mcp_install": {
+        "server_id": ParamDescription(
+            text=(
+                "Registry identifier, e.g. "
+                "'io.github.modelcontextprotocol/server-filesystem'."
+            ),
+            ja="レジストリ識別子（例 'io.github.modelcontextprotocol/server-filesystem'）。",
+        ),
+        "scope": ParamDescription(
+            text=(
+                "Config tier to write the server entry to. "
+                "'local' → reyn.local.yaml (default), "
+                "'project' → reyn.yaml, "
+                "'user' → ~/.reyn/config.yaml."
+            ),
+            ja=(
+                "サーバーエントリを書き込む設定階層。'local' → "
+                "reyn.local.yaml（デフォルト）、'project' → reyn.yaml、"
+                "'user' → ~/.reyn/config.yaml。"
+            ),
+        ),
+        "env_overrides": ParamDescription(
+            text=(
+                "Pre-supplied env values for secret vars required by the server. "
+                "Keys are env var names; values are the secrets. "
+                "Values not provided here will be prompted interactively."
+            ),
+            ja=(
+                "サーバーが必要とするシークレット変数への事前供給値。キーは"
+                "環境変数名、値はシークレット。ここで与えられない値は対話的"
+                "に確認される。"
+            ),
+        ),
+    },
+    "mcp_drop_server": {
+        "server": ParamDescription(
+            text=(
+                "Short server name as it appears under mcp.servers in "
+                "configuration (e.g. 'filesystem', 'brave')."
+            ),
+            ja="設定の mcp.servers に現れる短いサーバー名（例 'filesystem', 'brave'）。",
+        ),
+        "scope": ParamDescription(
+            text=(
+                "Config tier to remove from. Omit to auto-detect by "
+                "walking local → project → user and removing from the "
+                "first match."
+            ),
+            ja=(
+                "削除元の設定階層。省略すると local → project → user の順に"
+                "探索し最初に一致した階層から削除する。"
+            ),
+        ),
+        "clear_secrets": ParamDescription(
+            text=(
+                "When true (default), also remove the corresponding "
+                "${KEY} entries from ~/.reyn/secrets.env. Set false to "
+                "keep the secrets for reinstall."
+            ),
+            ja=(
+                "true（デフォルト）なら ~/.reyn/secrets.env の対応する "
+                "${KEY} エントリも削除する。再インストール用に残すなら "
+                "false にする。"
+            ),
+        ),
+    },
+    "mcp_install_registry": {
+        "server_id": ParamDescription(
+            text=(
+                "Registry identifier from mcp__search_registry "
+                "(= candidates[].name, "
+                "e.g. 'io.github.modelcontextprotocol/server-time')."
+            ),
+            ja=(
+                "mcp__search_registry から得たレジストリ識別子"
+                "（= candidates[].name、例 'io.github.modelcontextprotocol/server-time'）。"
+            ),
+        ),
+        "env_overrides": ParamDescription(
+            text=(
+                "Inline env values. Usually NOT needed — the first call "
+                "returns status='needs_secrets' listing which keys to "
+                "set via `reyn secret set <KEY>`; only pass this dict "
+                "when the operator supplied values inline."
+            ),
+            ja=(
+                "インラインの環境変数値。通常は不要 — 最初の呼び出しは "
+                "status='needs_secrets' を返し `reyn secret set <KEY>` で"
+                "設定すべきキーを列挙する。オペレーターが値をインラインで"
+                "供給した場合のみこの辞書を渡す。"
+            ),
+        ),
+    },
+    "mcp_install_package": {
+        "kind": ParamDescription(
+            text="Package channel.",
+            ja="パッケージのチャネル種別。",
+        ),
+        "identifier": ParamDescription(
+            text=(
+                "npm: package name (e.g. '@scope/server-foo')\n"
+                "pypi: distribution name (e.g. 'my-mcp-server')\n"
+                "docker: image with optional tag "
+                "(e.g. 'org/img:v1')\n"
+                "github: full URL "
+                "(e.g. 'https://github.com/owner/repo' or "
+                "'https://github.com/owner/repo/tree/<ref>/src/<sub>')"
+            ),
+            ja=(
+                "npm: パッケージ名（例 '@scope/server-foo'）／pypi: 配布名"
+                "（例 'my-mcp-server'）／docker: タグ付きイメージ（例 "
+                "'org/img:v1'）／github: フル URL。"
+            ),
+        ),
+        "version": ParamDescription(
+            text=(
+                "Version constraint. npm/pypi/docker only — "
+                "ignored for github."
+            ),
+            ja="バージョン制約。npm/pypi/docker のみ有効 — github では無視される。",
+        ),
+        "env_overrides": ParamDescription(
+            text=(
+                "Inline env values when the operator provides them; "
+                "otherwise expect status='needs_secrets' on the "
+                "first call (npm/pypi/docker only)."
+            ),
+            ja=(
+                "オペレーターが値を提供する場合のインライン環境変数値。"
+                "それ以外は最初の呼び出しで status='needs_secrets' を"
+                "想定する（npm/pypi/docker のみ）。"
+            ),
+        ),
+    },
+    "mcp_install_local": {
+        "name": ParamDescription(
+            text=(
+                "Short config key written under mcp.servers.<name> "
+                "(e.g. 'weather'). Used as the server prefix in "
+                "mcp__call_tool's '<server>__<tool>' identifier."
+            ),
+            ja=(
+                "mcp.servers.<name> に書き込まれる短い設定キー（例 "
+                "'weather'）。mcp__call_tool の '<server>__<tool>' 識別子の"
+                "サーバー部分として使われる。"
+            ),
+        ),
+        "command": ParamDescription(
+            text=(
+                "Executable to spawn (e.g. 'python', 'node', 'uvx', "
+                "or an absolute path)."
+            ),
+            ja="起動する実行ファイル（例 'python', 'node', 'uvx'、または絶対パス）。",
+        ),
+        "args": ParamDescription(
+            text=(
+                "Command-line arguments. Typically the script path "
+                "(e.g. ['/tmp/weather_mcp.py']) plus flags the server "
+                "expects."
+            ),
+            ja=(
+                "コマンドライン引数。通常はスクリプトパス（例 "
+                "['/tmp/weather_mcp.py']）とサーバーが要求するフラグ。"
+            ),
+        ),
+        "env_overrides": ParamDescription(
+            text="Inline env values for the spawned process.",
+            ja="起動するプロセスへのインライン環境変数値。",
+        ),
+    },
+    "mcp_call_tool": {
+        "tool": ParamDescription(
+            text=(
+                "<server>__<tool> identifier from mcp__list_tools "
+                "(e.g. 'time__get_current_time')."
+            ),
+            ja="mcp__list_tools から得た <server>__<tool> 識別子（例 'time__get_current_time'）。",
+        ),
+        "tool_args": ParamDescription(
+            text="Per-tool args dict (consult mcp__list_tools).",
+            ja="ツール毎の引数辞書（mcp__list_tools を参照）。",
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/memory.py
+++ b/src/reyn/tools/descriptions/memory.py
@@ -13,7 +13,7 @@ forget_memory.
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 list_memory = ToolDescription(
     tool_name="list_memory",
@@ -131,4 +131,64 @@ ALL: dict[str, ToolDescription] = {
     "remember_shared": remember_shared,
     "remember_agent": remember_agent,
     "forget_memory": forget_memory,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# list_memory / forget_memory have no param-level descriptions in their
+# origin schemas (path/layer/slug are bare-typed) — no entries needed.
+
+_description_desc = ParamDescription(
+    text="One-line summary; appears in memory listings",
+    ja="1行の要約。メモリ一覧に表示される。",
+)
+_body_desc = ParamDescription(
+    text="Full body markdown, typically <5 lines",
+    ja="本文の markdown。通常5行未満。",
+)
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "read_memory_body": {
+        "offset": ParamDescription(
+            text=(
+                "Line number to start reading from (0-indexed), counted "
+                "against the body after the YAML frontmatter is stripped. "
+                "Omit to start at the beginning."
+            ),
+            ja=(
+                "読み取り開始行（0始まり）。YAML フロントマターを除いた本文"
+                "に対してカウントする。省略時は先頭から。"
+            ),
+        ),
+        "limit": ParamDescription(
+            text=(
+                "Number of lines to read from `offset`. "
+                "Omit to read through end of body."
+            ),
+            ja="`offset` から読む行数。省略時は本文末尾まで読む。",
+        ),
+    },
+    "remember_shared": {
+        "slug": ParamDescription(
+            text=(
+                "Filename stem, format <type>_<topic>, "
+                "e.g. user_role"
+            ),
+            ja="ファイル名の幹（<type>_<topic> 形式、例 user_role）。",
+        ),
+        "description": _description_desc,
+        "body": _body_desc,
+    },
+    "remember_agent": {
+        "slug": ParamDescription(
+            text=(
+                "Filename stem, format <type>_<topic>, "
+                "e.g. feedback_tone"
+            ),
+            ja="ファイル名の幹（<type>_<topic> 形式、例 feedback_tone）。",
+        ),
+        "description": _description_desc,
+        "body": _body_desc,
+    },
 }

--- a/src/reyn/tools/descriptions/pipeline.py
+++ b/src/reyn/tools/descriptions/pipeline.py
@@ -16,7 +16,7 @@ mirror of the ``category`` field).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 run_pipeline = ToolDescription(
     tool_name="run_pipeline",
@@ -120,4 +120,59 @@ ALL: dict[str, ToolDescription] = {
     "run_pipeline_async": run_pipeline_async,
     "run_pipeline_inline": run_pipeline_inline,
     "run_pipeline_inline_async": run_pipeline_inline_async,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+#
+# run_pipeline / run_pipeline_async share ONE parameters schema in the origin
+# module (``_RUN_PIPELINE_PARAMETERS``); run_pipeline_inline /
+# run_pipeline_inline_async likewise share ``_RUN_PIPELINE_INLINE_PARAMETERS``.
+# Keyed here by the base verb name; the origin module reuses the same dict
+# object for both the sync and async ToolDefinition.
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "run_pipeline": {
+        "name": ParamDescription(
+            text="The registered pipeline's name.",
+            ja="登録済みパイプラインの名前。",
+        ),
+        "input": ParamDescription(
+            text=(
+                "Initial named context (ctx.*) for the pipeline's first "
+                "step. Omit for a pipeline that needs no seed input."
+            ),
+            ja=(
+                "パイプライン最初のステップ向けの初期名前付きコンテキスト"
+                "（ctx.*）。シード入力が不要なパイプラインなら省略可。"
+            ),
+        ),
+    },
+    "run_pipeline_inline": {
+        "definition": ParamDescription(
+            text=(
+                "The pipeline as a DSL string (Appendix B grammar): one or "
+                "more '---'-separated YAML documents — exactly one 'pipeline:' "
+                "document plus any 'schema:' documents its steps reference. "
+                "Generated at call time; parsed + statically validated before "
+                "anything runs."
+            ),
+            ja=(
+                "DSL文字列としてのパイプライン（Appendix B 文法）。1つ以上の "
+                "'---' 区切り YAML ドキュメント — 'pipeline:' ドキュメントが"
+                "1つ必須、ステップが参照する 'schema:' ドキュメントは任意。"
+                "呼び出し時に生成され、実行前にパースと静的検証を受ける。"
+            ),
+        ),
+        "input": ParamDescription(
+            text=(
+                "Initial named context (ctx.*) for the pipeline's first step. "
+                "Omit for a pipeline that needs no seed input."
+            ),
+            ja=(
+                "パイプライン最初のステップ向けの初期名前付きコンテキスト"
+                "（ctx.*）。シード入力が不要なパイプラインなら省略可。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/pipeline_management.py
+++ b/src/reyn/tools/descriptions/pipeline_management.py
@@ -16,7 +16,7 @@ mirror of the ``category`` field).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 pipeline_install_local = ToolDescription(
     tool_name="pipeline_install_local",
@@ -80,4 +80,74 @@ pipeline_install_source = ToolDescription(
 ALL: dict[str, ToolDescription] = {
     "pipeline_install_local": pipeline_install_local,
     "pipeline_install_source": pipeline_install_source,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "pipeline_install_local": {
+        "path": ParamDescription(
+            text=(
+                "Direct path to the pipeline's *.yaml DSL file. May be "
+                "absolute or project-root-relative."
+            ),
+            ja="パイプラインの *.yaml DSL ファイルへの直接パス。絶対パスまたはプロジェクトルート相対。",
+        ),
+        "name": ParamDescription(
+            text=(
+                "Optional namespace key for the file. Every pipeline in it "
+                "registers as '<name>.<declared-pipeline-name>'. Need not "
+                "match any declared name; must not contain '.'. Defaults to "
+                "the DSL file stem when omitted."
+            ),
+            ja=(
+                "ファイルの任意の名前空間キー。ファイル内の各パイプラインは "
+                "'<name>.<declared-pipeline-name>' として登録される。宣言名"
+                "と一致する必要はなく '.' を含んではならない。省略時は DSL "
+                "ファイルの stem を使う。"
+            ),
+        ),
+    },
+    "pipeline_install_source": {
+        "source": ParamDescription(
+            text=(
+                "Git or GitHub URL of the pipeline repo. Examples: "
+                "'https://github.com/user/pipeline-repo' or "
+                "'https://github.com/user/monorepo//pipelines/my-pipeline'."
+            ),
+            ja=(
+                "パイプラインリポジトリの Git/GitHub URL。例 "
+                "'https://github.com/user/pipeline-repo' や "
+                "'https://github.com/user/monorepo//pipelines/my-pipeline'。"
+            ),
+        ),
+        "path": ParamDescription(
+            text=(
+                "Optional: path (relative to the repo root, or the subdir "
+                "when the source URL uses the '//' convention) to the DSL "
+                "*.yaml file. Required when the repo/subdir contains more "
+                "than one *.yaml file."
+            ),
+            ja=(
+                "任意: DSL *.yaml ファイルへのパス（リポジトリルート相対、"
+                "または source URL が '//' 規約を使う場合はサブディレクトリ"
+                "相対）。repo/subdir に *.yaml が複数ある場合は必須。"
+            ),
+        ),
+        "name": ParamDescription(
+            text=(
+                "Optional namespace key. Every pipeline in the file registers "
+                "as '<name>.<declared-pipeline-name>'. Need not match any "
+                "declared name; must not contain '.'. Defaults to the source "
+                "basename."
+            ),
+            ja=(
+                "任意の名前空間キー。ファイル内の各パイプラインは "
+                "'<name>.<declared-pipeline-name>' として登録される。宣言名"
+                "と一致する必要はなく '.' を含んではならない。省略時は "
+                "source のベース名を使う。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/presentation.py
+++ b/src/reyn/tools/descriptions/presentation.py
@@ -10,7 +10,7 @@ origin module now aliases its ``_X_DESCRIPTION`` constant to
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 present = ToolDescription(
     tool_name="present",
@@ -71,4 +71,111 @@ render_template = ToolDescription(
 ALL: dict[str, ToolDescription] = {
     "present": present,
     "render_template": render_template,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "present": {
+        "data_ref": ParamDescription(
+            text=(
+                "What to show: a zone-readable path or an offloaded-result reference. Read under the "
+                "same authority as file.read. Provide exactly one of data_ref / data_inline."
+            ),
+            ja=(
+                "表示するもの: ゾーン読み取り可能なパス、またはオフロードされた"
+                "結果への参照。file.read と同じ権限で読む。data_ref / "
+                "data_inline のどちらか一方のみ指定する。"
+            ),
+        ),
+        "data_inline": ParamDescription(
+            text=(
+                "Small data already in your context, passed directly instead of a ref. Provide "
+                "exactly one of data_ref / data_inline."
+            ),
+            ja=(
+                "既にコンテキストにある小さなデータを参照の代わりに直接渡す。"
+                "data_ref / data_inline のどちらか一方のみ指定する。"
+            ),
+        ),
+        "view": ParamDescription(
+            text=(
+                "Optional: the name of a registered presentation (presentations.yaml) to render "
+                "with. Omit for the default view. At most one of view / blueprint."
+            ),
+            ja=(
+                "任意: レンダリングに使う登録済みプレゼンテーション名"
+                "（presentations.yaml）。省略時はデフォルトビュー。view / "
+                "blueprint はどちらか一方のみ。"
+            ),
+        ),
+        "blueprint": ParamDescription(
+            text=(
+                "Optional (advanced): an inline declarative component tree with JSON-Pointer "
+                "bindings for full control over the layout. Prefer the simple default (omit both "
+                "view and blueprint) unless you specifically need a custom layout. At most one of "
+                "view / blueprint."
+            ),
+            ja=(
+                "任意（上級者向け）: レイアウトを完全制御するインラインの"
+                "宣言的コンポーネントツリー（JSON-Pointer バインディング付き）。"
+                "カスタムレイアウトが特に必要でない限り、view/blueprint 両方"
+                "省略のシンプルなデフォルトを推奨。view / blueprint はどちらか"
+                "一方のみ。"
+            ),
+        ),
+    },
+    "render_template": {
+        "template": ParamDescription(
+            text=(
+                "Inline Jinja2 source text. Provide exactly one of template / template_ref."
+            ),
+            ja="インラインの Jinja2 ソーステキスト。template / template_ref のどちらか一方のみ指定する。",
+        ),
+        "template_ref": ParamDescription(
+            text=(
+                "A zone-readable path to a template file (read as raw source text under file.read "
+                "authority). Provide exactly one of template / template_ref."
+            ),
+            ja=(
+                "テンプレートファイルへのゾーン読み取り可能なパス（file.read "
+                "権限で生テキストとして読む）。template / template_ref の"
+                "どちらか一方のみ指定する。"
+            ),
+        ),
+        "data_ref": ParamDescription(
+            text=(
+                "A zone-readable path whose value binds under 'data' in the template. Read under the "
+                "same authority as file.read. Provide exactly one of data_ref / data_inline."
+            ),
+            ja=(
+                "値がテンプレート内の 'data' にバインドされるゾーン読み取り"
+                "可能なパス。file.read と同じ権限で読む。data_ref / "
+                "data_inline のどちらか一方のみ指定する。"
+            ),
+        ),
+        "data_inline": ParamDescription(
+            text=(
+                "Small data already in your context, bound under 'data' in the template. Provide "
+                "exactly one of data_ref / data_inline."
+            ),
+            ja=(
+                "既にコンテキストにある小さなデータをテンプレート内の 'data' "
+                "にバインドする。data_ref / data_inline のどちらか一方のみ"
+                "指定する。"
+            ),
+        ),
+        "undefined": ParamDescription(
+            text=(
+                "Undefined-variable policy. 'strict' (default) errors naming the missing variable; "
+                "'lenient' renders undefined as empty and reports the unbound names."
+            ),
+            ja=(
+                "未定義変数のポリシー。'strict'（デフォルト）は不足変数名を"
+                "示すエラーを出す。'lenient' は未定義を空としてレンダリングし"
+                "未束縛の名前を報告する。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/descriptions/skill.py
+++ b/src/reyn/tools/descriptions/skill.py
@@ -15,7 +15,7 @@ mirror of the ``category`` field).
 """
 from __future__ import annotations
 
-from reyn.tools.descriptions._types import ToolDescription
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
 
 skill_install_local = ToolDescription(
     tool_name="skill_install_local",
@@ -71,4 +71,65 @@ skill_install_source = ToolDescription(
 ALL: dict[str, ToolDescription] = {
     "skill_install_local": skill_install_local,
     "skill_install_source": skill_install_source,
+}
+
+
+# ── Phase 4: per-parameter descriptions (byte-identical relocation) ──────────
+
+_name_key_desc = ParamDescription(
+    text=(
+        "Config key written under skills.entries.<name>. "
+        "When omitted, the frontmatter 'name:' field is used; "
+        "if that is also absent, the directory basename is used."
+    ),
+    ja=(
+        "skills.entries.<name> に書き込まれる設定キー。省略時は"
+        "フロントマターの 'name:' フィールドを使い、それも無ければ"
+        "ディレクトリのベース名を使う。"
+    ),
+)
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "skill_install_local": {
+        "path": ParamDescription(
+            text=(
+                "Path to the skill directory (containing SKILL.md) or "
+                "the direct path to the SKILL.md file. May be absolute "
+                "or project-root-relative."
+            ),
+            ja=(
+                "SKILL.md を含むスキルディレクトリへのパス、または SKILL.md "
+                "ファイルへの直接パス。絶対パスまたはプロジェクトルート相対。"
+            ),
+        ),
+        "name": _name_key_desc,
+    },
+    "skill_install_source": {
+        "source": ParamDescription(
+            text=(
+                "Git or GitHub URL of the skill repo. The root (or subdir "
+                "specified via '//' separator) must contain a SKILL.md file. "
+                "Examples: 'https://github.com/user/skill-repo' or "
+                "'https://github.com/user/monorepo//skills/my-skill'."
+            ),
+            ja=(
+                "スキルリポジトリの Git/GitHub URL。ルート（または '//' "
+                "区切りで指定したサブディレクトリ）に SKILL.md が必要。例 "
+                "'https://github.com/user/skill-repo' や "
+                "'https://github.com/user/monorepo//skills/my-skill'。"
+            ),
+        ),
+        "name": ParamDescription(
+            text=(
+                "Config key written under skills.entries.<name>. "
+                "When omitted, the frontmatter 'name:' field is used; "
+                "if that is also absent, the repo/subdir basename is used."
+            ),
+            ja=(
+                "skills.entries.<name> に書き込まれる設定キー。省略時は"
+                "フロントマターの 'name:' フィールドを使い、それも無ければ"
+                "repo/subdir のベース名を使う。"
+            ),
+        ),
+    },
 }

--- a/src/reyn/tools/drop_source.py
+++ b/src/reyn/tools/drop_source.py
@@ -30,9 +30,7 @@ _DROP_SOURCE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "source": {
             "type": "string",
-            "description": (
-                "Logical source name to remove (from Indexed sources list)."
-            ),
+            "description": _io_descriptions.PARAMS["drop_source"]["source"].text,
         },
     },
     "required": ["source"],

--- a/src/reyn/tools/embed.py
+++ b/src/reyn/tools/embed.py
@@ -34,15 +34,12 @@ _EMBED_PARAMETERS: dict[str, Any] = {
         "texts": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Texts to embed. Returned vectors preserve this order.",
+            "description": discovery.PARAMS["embed"]["texts"].text,
         },
         "embedding_model": {
             "type": "string",
             "default": "standard",
-            "description": (
-                "Embedding model class (light/standard/strong) or a full "
-                "provider model id."
-            ),
+            "description": discovery.PARAMS["embed"]["embedding_model"].text,
         },
     },
     "required": ["texts"],

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -64,17 +64,11 @@ _READ_FILE_PARAMETERS: dict[str, Any] = {
         "path": {"type": "string"},
         "offset": {
             "type": "integer",
-            "description": (
-                "Line number to start reading from (0-indexed). "
-                "Omit to start at the beginning of the file."
-            ),
+            "description": _io_descriptions.PARAMS["read_file"]["offset"].text,
         },
         "limit": {
             "type": "integer",
-            "description": (
-                "Number of lines to read from `offset`. "
-                "Omit to read through end of file."
-            ),
+            "description": _io_descriptions.PARAMS["read_file"]["limit"].text,
         },
     },
     "required": ["path"],
@@ -103,22 +97,15 @@ _EDIT_FILE_PARAMETERS: dict[str, Any] = {
         "path": {"type": "string"},
         "old_string": {
             "type": "string",
-            "description": (
-                "Exact text to replace. Must appear exactly once unless "
-                "replace_all is true; include surrounding context to "
-                "make it unique."
-            ),
+            "description": _io_descriptions.PARAMS["edit_file"]["old_string"].text,
         },
         "new_string": {
             "type": "string",
-            "description": "Replacement text.",
+            "description": _io_descriptions.PARAMS["edit_file"]["new_string"].text,
         },
         "replace_all": {
             "type": "boolean",
-            "description": (
-                "When true, every occurrence of old_string is replaced. "
-                "Default false (= require uniqueness)."
-            ),
+            "description": _io_descriptions.PARAMS["edit_file"]["replace_all"].text,
         },
     },
     "required": ["path", "old_string", "new_string"],
@@ -129,23 +116,23 @@ _GREP_FILES_PARAMETERS: dict[str, Any] = {
     "properties": {
         "pattern": {
             "type": "string",
-            "description": "Regex pattern to search for.",
+            "description": _io_descriptions.PARAMS["grep_files"]["pattern"].text,
         },
         "path": {
             "type": "string",
-            "description": "Directory or file to search. Defaults to '.' (workspace root).",
+            "description": _io_descriptions.PARAMS["grep_files"]["path"].text,
         },
         "glob": {
             "type": "string",
-            "description": "File-glob filter (e.g. '**/*.py'). Searches all files when omitted.",
+            "description": _io_descriptions.PARAMS["grep_files"]["glob"].text,
         },
         "case_sensitive": {
             "type": "boolean",
-            "description": "When true, search is case-sensitive. Defaults to false.",
+            "description": _io_descriptions.PARAMS["grep_files"]["case_sensitive"].text,
         },
         "max_results": {
             "type": "integer",
-            "description": "Maximum number of matches to return. Defaults to 50.",
+            "description": _io_descriptions.PARAMS["grep_files"]["max_results"].text,
         },
     },
     "required": ["pattern"],
@@ -156,16 +143,11 @@ _GLOB_FILES_PARAMETERS: dict[str, Any] = {
     "properties": {
         "pattern": {
             "type": "string",
-            "description": (
-                "Glob pattern. To match by name anywhere under a directory, "
-                "always include `**` (e.g. '**/*.py' or 'src/**/*.md'). "
-                "A bare name without `**` matches only at the exact root "
-                "level, not recursively."
-            ),
+            "description": _io_descriptions.PARAMS["glob_files"]["pattern"].text,
         },
         "path": {
             "type": "string",
-            "description": "Root directory for the glob. Defaults to '.' (workspace root).",
+            "description": _io_descriptions.PARAMS["glob_files"]["path"].text,
         },
     },
     "required": ["pattern"],

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -40,27 +40,23 @@ _HOOKS_ADD_PARAMETERS: dict[str, Any] = {
     "properties": {
         "on": {
             "type": "string", "enum": _HOOK_POINTS,
-            "description": "The lifecycle point the hook fires at.",
+            "description": _hooks_descriptions.PARAMS["hooks_add"]["on"].text,
         },
         "message": {
             "type": "string",
-            "description": "The message pushed when the hook fires (a Jinja2 template is allowed).",
+            "description": _hooks_descriptions.PARAMS["hooks_add"]["message"].text,
         },
         "wake": {
             "type": "boolean",
-            "description": (
-                "true → the push starts a new turn (self-continuation, capability E); "
-                "false → it rides along with the next turn as context (capability C). "
-                "Default true."
-            ),
+            "description": _hooks_descriptions.PARAMS["hooks_add"]["wake"].text,
         },
         "push_when": {
             "type": "string",
-            "description": "Optional Jinja2 → bool; when it renders false the push is skipped. Default 'true'.",
+            "description": _hooks_descriptions.PARAMS["hooks_add"]["push_when"].text,
         },
         "name": {
             "type": "string",
-            "description": "Optional label surfaced as the [hook:<name>] attribution prefix.",
+            "description": _hooks_descriptions.PARAMS["hooks_add"]["name"].text,
         },
     },
     "required": ["on", "message"],

--- a/src/reyn/tools/index_update.py
+++ b/src/reyn/tools/index_update.py
@@ -33,7 +33,7 @@ _INDEX_UPDATE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "source": {
             "type": "string",
-            "description": "Logical source name to ingest into.",
+            "description": _io_descriptions.PARAMS["index_update"]["source"].text,
         },
         "chunks": {
             "type": "array",
@@ -43,35 +43,27 @@ _INDEX_UPDATE_PARAMETERS: dict[str, Any] = {
                     "text": {"type": "string"},
                     "metadata": {
                         "type": "object",
-                        "description": (
-                            "content_hash (required, change-detection key), "
-                            "source_path (required, reconciliation-scope "
-                            "key), plus optional source_type / chunk_index "
-                            "/ size_tokens / parent_context / extra."
-                        ),
+                        "description": _io_descriptions.PARAMS["index_update"][
+                            "chunks.metadata"
+                        ].text,
                     },
                 },
                 "required": ["text", "metadata"],
             },
-            "description": "Chunks to reconcile into the index.",
+            "description": _io_descriptions.PARAMS["index_update"]["chunks"].text,
         },
         "embedding_model": {
             "type": "string",
             "default": "standard",
-            "description": (
-                "Embedding model class, used ONLY when this source has no "
-                "recorded model yet (first index_update for a new source) "
-                "— an already-indexed source's recorded model always wins "
-                "(a source is one embedding space)."
-            ),
+            "description": _io_descriptions.PARAMS["index_update"]["embedding_model"].text,
         },
         "description": {
             "type": "string",
-            "description": "SourceManifest description (first-index or override).",
+            "description": _io_descriptions.PARAMS["index_update"]["description"].text,
         },
         "path": {
             "type": "string",
-            "description": "SourceManifest path label (first-index or override).",
+            "description": _io_descriptions.PARAMS["index_update"]["path"].text,
         },
     },
     "required": ["source", "chunks"],

--- a/src/reyn/tools/mcp.py
+++ b/src/reyn/tools/mcp.py
@@ -112,22 +112,15 @@ _CALL_MCP_TOOL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["call_mcp_tool"]["server"].text,
         },
         "mcp_tool_name": {
             "type": "string",
-            "description": (
-                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
-                "the enum. Use describe_mcp_tool for the full input schema."
-            ),
+            "description": _mcp_descriptions.PARAMS["call_mcp_tool"]["mcp_tool_name"].text,
         },
         _MCP_TOOL_ARGS_KEY: {
             "type": "object",
-            "description": (
-                "The target MCP tool's OWN parameters (the shape from "
-                "describe_mcp_tool), as a nested object here — NOT flat alongside "
-                "server / mcp_tool_name."
-            ),
+            "description": _mcp_descriptions.PARAMS["call_mcp_tool"]["tool_args"].text,
         },
     },
     "required": ["server", "mcp_tool_name", _MCP_TOOL_ARGS_KEY],
@@ -138,14 +131,11 @@ _DESCRIBE_MCP_TOOL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["describe_mcp_tool"]["server"].text,
         },
         "mcp_tool_name": {
             "type": "string",
-            "description": (
-                "Dotted mcp_tool identifier: <server>.<tool> — choose from "
-                "the enum."
-            ),
+            "description": _mcp_descriptions.PARAMS["describe_mcp_tool"]["mcp_tool_name"].text,
         },
     },
     "required": ["server", "mcp_tool_name"],
@@ -161,7 +151,7 @@ _LIST_MCP_RESOURCES_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["list_mcp_resources"]["server"].text,
         },
     },
     "required": ["server"],
@@ -174,7 +164,7 @@ _LIST_MCP_RESOURCE_TEMPLATES_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["list_mcp_resource_templates"]["server"].text,
         },
     },
     "required": ["server"],
@@ -187,11 +177,11 @@ _READ_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["read_mcp_resource"]["server"].text,
         },
         "uri": {
             "type": "string",
-            "description": "Resource URI, verbatim from list_mcp_resources.",
+            "description": _mcp_descriptions.PARAMS["read_mcp_resource"]["uri"].text,
         },
     },
     "required": ["server", "uri"],
@@ -207,11 +197,11 @@ _SUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["subscribe_mcp_resource"]["server"].text,
         },
         "uri": {
             "type": "string",
-            "description": "Resource URI, verbatim from list_mcp_resources.",
+            "description": _mcp_descriptions.PARAMS["subscribe_mcp_resource"]["uri"].text,
         },
     },
     "required": ["server", "uri"],
@@ -224,11 +214,11 @@ _UNSUBSCRIBE_MCP_RESOURCE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["unsubscribe_mcp_resource"]["server"].text,
         },
         "uri": {
             "type": "string",
-            "description": "Resource URI, verbatim from list_mcp_resources.",
+            "description": _mcp_descriptions.PARAMS["unsubscribe_mcp_resource"]["uri"].text,
         },
     },
     "required": ["server", "uri"],
@@ -244,7 +234,7 @@ _LIST_MCP_PROMPTS_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["list_mcp_prompts"]["server"].text,
         },
     },
     "required": ["server"],
@@ -257,19 +247,15 @@ _GET_MCP_PROMPT_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": "MCP server name — choose from the enum (verbatim).",
+            "description": _mcp_descriptions.PARAMS["get_mcp_prompt"]["server"].text,
         },
         "name": {
             "type": "string",
-            "description": "Prompt name, verbatim from list_mcp_prompts.",
+            "description": _mcp_descriptions.PARAMS["get_mcp_prompt"]["name"].text,
         },
         "arguments": {
             "type": "object",
-            "description": (
-                "Arguments to render the prompt with, matching the shape "
-                "from list_mcp_prompts' arguments field. Optional — omit "
-                "for a prompt that takes none."
-            ),
+            "description": _mcp_descriptions.PARAMS["get_mcp_prompt"]["arguments"].text,
         },
     },
     "required": ["server", "name"],

--- a/src/reyn/tools/mcp_drop.py
+++ b/src/reyn/tools/mcp_drop.py
@@ -40,28 +40,17 @@ _MCP_DROP_SERVER_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server": {
             "type": "string",
-            "description": (
-                "Short server name as it appears under mcp.servers in "
-                "configuration (e.g. 'filesystem', 'brave')."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_drop_server"]["server"].text,
         },
         "scope": {
             "type": "string",
             "enum": ["local", "project", "user"],
-            "description": (
-                "Config tier to remove from. Omit to auto-detect by "
-                "walking local → project → user and removing from the "
-                "first match."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_drop_server"]["scope"].text,
         },
         "clear_secrets": {
             "type": "boolean",
             "default": True,
-            "description": (
-                "When true (default), also remove the corresponding "
-                "${KEY} entries from ~/.reyn/secrets.env. Set false to "
-                "keep the secrets for reinstall."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_drop_server"]["clear_secrets"].text,
         },
     },
     "required": ["server"],

--- a/src/reyn/tools/mcp_install.py
+++ b/src/reyn/tools/mcp_install.py
@@ -30,28 +30,16 @@ _MCP_INSTALL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server_id": {
             "type": "string",
-            "description": (
-                "Registry identifier, e.g. "
-                "'io.github.modelcontextprotocol/server-filesystem'."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install"]["server_id"].text,
         },
         "scope": {
             "type": "string",
             "enum": ["local", "project", "user"],
-            "description": (
-                "Config tier to write the server entry to. "
-                "'local' → reyn.local.yaml (default), "
-                "'project' → reyn.yaml, "
-                "'user' → ~/.reyn/config.yaml."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install"]["scope"].text,
         },
         "env_overrides": {
             "type": "object",
-            "description": (
-                "Pre-supplied env values for secret vars required by the server. "
-                "Keys are env var names; values are the secrets. "
-                "Values not provided here will be prompted interactively."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install"]["env_overrides"].text,
             "additionalProperties": {"type": "string"},
         },
     },

--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -57,12 +57,7 @@ _MCP_SEARCH_REGISTRY_PARAMETERS: dict[str, Any] = {
     "properties": {
         "text": {
             "type": "string",
-            "description": (
-                "Natural-language capability request (e.g. \"github "
-                "related\", \"image generation\", \"PDF handling\") — "
-                "the query may be in any language, including Japanese "
-                "and other non-English input."
-            ),
+            "description": discovery.PARAMS["mcp_search_registry"]["text"].text,
         },
     },
     "required": ["text"],
@@ -125,20 +120,11 @@ _MCP_INSTALL_REGISTRY_PARAMETERS: dict[str, Any] = {
     "properties": {
         "server_id": {
             "type": "string",
-            "description": (
-                "Registry identifier from mcp__search_registry "
-                "(= candidates[].name, "
-                "e.g. 'io.github.modelcontextprotocol/server-time')."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_registry"]["server_id"].text,
         },
         "env_overrides": {
             "type": "object",
-            "description": (
-                "Inline env values. Usually NOT needed — the first call "
-                "returns status='needs_secrets' listing which keys to "
-                "set via `reyn secret set <KEY>`; only pass this dict "
-                "when the operator supplied values inline."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_registry"]["env_overrides"].text,
             "additionalProperties": {"type": "string"},
         },
     },
@@ -221,34 +207,19 @@ _MCP_INSTALL_PACKAGE_PARAMETERS: dict[str, Any] = {
         "kind": {
             "type": "string",
             "enum": ["npm", "pypi", "docker", "github"],
-            "description": "Package channel.",
+            "description": _mcp_descriptions.PARAMS["mcp_install_package"]["kind"].text,
         },
         "identifier": {
             "type": "string",
-            "description": (
-                "npm: package name (e.g. '@scope/server-foo')\n"
-                "pypi: distribution name (e.g. 'my-mcp-server')\n"
-                "docker: image with optional tag "
-                "(e.g. 'org/img:v1')\n"
-                "github: full URL "
-                "(e.g. 'https://github.com/owner/repo' or "
-                "'https://github.com/owner/repo/tree/<ref>/src/<sub>')"
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_package"]["identifier"].text,
         },
         "version": {
             "type": "string",
-            "description": (
-                "Version constraint. npm/pypi/docker only — "
-                "ignored for github."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_package"]["version"].text,
         },
         "env_overrides": {
             "type": "object",
-            "description": (
-                "Inline env values when the operator provides them; "
-                "otherwise expect status='needs_secrets' on the "
-                "first call (npm/pypi/docker only)."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_package"]["env_overrides"].text,
             "additionalProperties": {"type": "string"},
         },
     },
@@ -346,31 +317,20 @@ _MCP_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "name": {
             "type": "string",
-            "description": (
-                "Short config key written under mcp.servers.<name> "
-                "(e.g. 'weather'). Used as the server prefix in "
-                "mcp__call_tool's '<server>__<tool>' identifier."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_local"]["name"].text,
         },
         "command": {
             "type": "string",
-            "description": (
-                "Executable to spawn (e.g. 'python', 'node', 'uvx', "
-                "or an absolute path)."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_local"]["command"].text,
         },
         "args": {
             "type": "array",
             "items": {"type": "string"},
-            "description": (
-                "Command-line arguments. Typically the script path "
-                "(e.g. ['/tmp/weather_mcp.py']) plus flags the server "
-                "expects."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_install_local"]["args"].text,
         },
         "env_overrides": {
             "type": "object",
-            "description": "Inline env values for the spawned process.",
+            "description": _mcp_descriptions.PARAMS["mcp_install_local"]["env_overrides"].text,
             "additionalProperties": {"type": "string"},
         },
     },
@@ -535,10 +495,7 @@ _MCP_CALL_TOOL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "tool": {
             "type": "string",
-            "description": (
-                "<server>__<tool> identifier from mcp__list_tools "
-                "(e.g. 'time__get_current_time')."
-            ),
+            "description": _mcp_descriptions.PARAMS["mcp_call_tool"]["tool"].text,
         },
         # #1646: the target tool's params nest under "tool_args", NOT "args" — the
         # universal-scheme live path is invoke_action(action_name="mcp__call_tool",
@@ -546,7 +503,7 @@ _MCP_CALL_TOOL_PARAMETERS: dict[str, Any] = {
         # invoke_action's own "args" (the LLM collapsed it → empty at the MCP call).
         _MCP_TOOL_ARGS_KEY: {
             "type": "object",
-            "description": "Per-tool args dict (consult mcp__list_tools).",
+            "description": _mcp_descriptions.PARAMS["mcp_call_tool"]["tool_args"].text,
         },
     },
     "required": ["tool"],

--- a/src/reyn/tools/memory.py
+++ b/src/reyn/tools/memory.py
@@ -83,18 +83,11 @@ _READ_MEMORY_BODY_PARAMETERS: dict[str, Any] = {
         "slug": {"type": "string"},
         "offset": {
             "type": "integer",
-            "description": (
-                "Line number to start reading from (0-indexed), counted "
-                "against the body after the YAML frontmatter is stripped. "
-                "Omit to start at the beginning."
-            ),
+            "description": _memory_descriptions.PARAMS["read_memory_body"]["offset"].text,
         },
         "limit": {
             "type": "integer",
-            "description": (
-                "Number of lines to read from `offset`. "
-                "Omit to read through end of body."
-            ),
+            "description": _memory_descriptions.PARAMS["read_memory_body"]["limit"].text,
         },
     },
     "required": ["layer", "slug"],
@@ -105,17 +98,12 @@ _REMEMBER_SHARED_PARAMETERS: dict[str, Any] = {
     "properties": {
         "slug": {
             "type": "string",
-            "description": (
-                "Filename stem, format <type>_<topic>, "
-                "e.g. user_role"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_shared"]["slug"].text,
         },
         "name": {"type": "string"},
         "description": {
             "type": "string",
-            "description": (
-                "One-line summary; appears in memory listings"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_shared"]["description"].text,
         },
         "type": {
             "type": "string",
@@ -123,9 +111,7 @@ _REMEMBER_SHARED_PARAMETERS: dict[str, Any] = {
         },
         "body": {
             "type": "string",
-            "description": (
-                "Full body markdown, typically <5 lines"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_shared"]["body"].text,
         },
     },
     "required": ["slug", "name", "description", "type", "body"],
@@ -136,17 +122,12 @@ _REMEMBER_AGENT_PARAMETERS: dict[str, Any] = {
     "properties": {
         "slug": {
             "type": "string",
-            "description": (
-                "Filename stem, format <type>_<topic>, "
-                "e.g. feedback_tone"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_agent"]["slug"].text,
         },
         "name": {"type": "string"},
         "description": {
             "type": "string",
-            "description": (
-                "One-line summary; appears in memory listings"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_agent"]["description"].text,
         },
         "type": {
             "type": "string",
@@ -154,9 +135,7 @@ _REMEMBER_AGENT_PARAMETERS: dict[str, Any] = {
         },
         "body": {
             "type": "string",
-            "description": (
-                "Full body markdown, typically <5 lines"
-            ),
+            "description": _memory_descriptions.PARAMS["remember_agent"]["body"].text,
         },
     },
     "required": ["slug", "name", "description", "type", "body"],

--- a/src/reyn/tools/pipeline_management_verbs.py
+++ b/src/reyn/tools/pipeline_management_verbs.py
@@ -46,17 +46,13 @@ _PIPELINE_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
         "path": {
             "type": "string",
             "description": (
-                "Direct path to the pipeline's *.yaml DSL file. May be "
-                "absolute or project-root-relative."
+                _pipeline_management_descriptions.PARAMS["pipeline_install_local"]["path"].text
             ),
         },
         "name": {
             "type": "string",
             "description": (
-                "Optional namespace key for the file. Every pipeline in it "
-                "registers as '<name>.<declared-pipeline-name>'. Need not "
-                "match any declared name; must not contain '.'. Defaults to "
-                "the DSL file stem when omitted."
+                _pipeline_management_descriptions.PARAMS["pipeline_install_local"]["name"].text
             ),
         },
     },
@@ -129,27 +125,19 @@ _PIPELINE_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
         "source": {
             "type": "string",
             "description": (
-                "Git or GitHub URL of the pipeline repo. Examples: "
-                "'https://github.com/user/pipeline-repo' or "
-                "'https://github.com/user/monorepo//pipelines/my-pipeline'."
+                _pipeline_management_descriptions.PARAMS["pipeline_install_source"]["source"].text
             ),
         },
         "path": {
             "type": "string",
             "description": (
-                "Optional: path (relative to the repo root, or the subdir "
-                "when the source URL uses the '//' convention) to the DSL "
-                "*.yaml file. Required when the repo/subdir contains more "
-                "than one *.yaml file."
+                _pipeline_management_descriptions.PARAMS["pipeline_install_source"]["path"].text
             ),
         },
         "name": {
             "type": "string",
             "description": (
-                "Optional namespace key. Every pipeline in the file registers "
-                "as '<name>.<declared-pipeline-name>'. Need not match any "
-                "declared name; must not contain '.'. Defaults to the source "
-                "basename."
+                _pipeline_management_descriptions.PARAMS["pipeline_install_source"]["name"].text
             ),
         },
     },

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -159,14 +159,11 @@ _RUN_PIPELINE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "name": {
             "type": "string",
-            "description": "The registered pipeline's name.",
+            "description": _pipeline_descriptions.PARAMS["run_pipeline"]["name"].text,
         },
         "input": {
             "type": "object",
-            "description": (
-                "Initial named context (ctx.*) for the pipeline's first "
-                "step. Omit for a pipeline that needs no seed input."
-            ),
+            "description": _pipeline_descriptions.PARAMS["run_pipeline"]["input"].text,
         },
     },
     "required": ["name"],
@@ -502,20 +499,11 @@ _RUN_PIPELINE_INLINE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "definition": {
             "type": "string",
-            "description": (
-                "The pipeline as a DSL string (Appendix B grammar): one or "
-                "more '---'-separated YAML documents — exactly one 'pipeline:' "
-                "document plus any 'schema:' documents its steps reference. "
-                "Generated at call time; parsed + statically validated before "
-                "anything runs."
-            ),
+            "description": _pipeline_descriptions.PARAMS["run_pipeline_inline"]["definition"].text,
         },
         "input": {
             "type": "object",
-            "description": (
-                "Initial named context (ctx.*) for the pipeline's first step. "
-                "Omit for a pipeline that needs no seed input."
-            ),
+            "description": _pipeline_descriptions.PARAMS["run_pipeline_inline"]["input"].text,
         },
     },
     "required": ["definition"],

--- a/src/reyn/tools/present.py
+++ b/src/reyn/tools/present.py
@@ -41,33 +41,19 @@ _PRESENT_PARAMETERS: dict[str, Any] = {
     "properties": {
         "data_ref": {
             "type": "string",
-            "description": (
-                "What to show: a zone-readable path or an offloaded-result reference. Read under the "
-                "same authority as file.read. Provide exactly one of data_ref / data_inline."
-            ),
+            "description": _presentation_descriptions.PARAMS["present"]["data_ref"].text,
         },
         "data_inline": {
             "type": "object",
-            "description": (
-                "Small data already in your context, passed directly instead of a ref. Provide "
-                "exactly one of data_ref / data_inline."
-            ),
+            "description": _presentation_descriptions.PARAMS["present"]["data_inline"].text,
         },
         "view": {
             "type": "string",
-            "description": (
-                "Optional: the name of a registered presentation (presentations.yaml) to render "
-                "with. Omit for the default view. At most one of view / blueprint."
-            ),
+            "description": _presentation_descriptions.PARAMS["present"]["view"].text,
         },
         "blueprint": {
             "type": "object",
-            "description": (
-                "Optional (advanced): an inline declarative component tree with JSON-Pointer "
-                "bindings for full control over the layout. Prefer the simple default (omit both "
-                "view and blueprint) unless you specifically need a custom layout. At most one of "
-                "view / blueprint."
-            ),
+            "description": _presentation_descriptions.PARAMS["present"]["blueprint"].text,
         },
     },
     "required": [],

--- a/src/reyn/tools/render_template.py
+++ b/src/reyn/tools/render_template.py
@@ -40,38 +40,28 @@ _RENDER_TEMPLATE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "template": {
             "type": "string",
-            "description": (
-                "Inline Jinja2 source text. Provide exactly one of template / template_ref."
-            ),
+            "description": _presentation_descriptions.PARAMS["render_template"]["template"].text,
         },
         "template_ref": {
             "type": "string",
             "description": (
-                "A zone-readable path to a template file (read as raw source text under file.read "
-                "authority). Provide exactly one of template / template_ref."
+                _presentation_descriptions.PARAMS["render_template"]["template_ref"].text
             ),
         },
         "data_ref": {
             "type": "string",
-            "description": (
-                "A zone-readable path whose value binds under 'data' in the template. Read under the "
-                "same authority as file.read. Provide exactly one of data_ref / data_inline."
-            ),
+            "description": _presentation_descriptions.PARAMS["render_template"]["data_ref"].text,
         },
         "data_inline": {
             "type": "object",
             "description": (
-                "Small data already in your context, bound under 'data' in the template. Provide "
-                "exactly one of data_ref / data_inline."
+                _presentation_descriptions.PARAMS["render_template"]["data_inline"].text
             ),
         },
         "undefined": {
             "type": "string",
             "enum": ["strict", "lenient"],
-            "description": (
-                "Undefined-variable policy. 'strict' (default) errors naming the missing variable; "
-                "'lenient' renders undefined as empty and reports the unbound names."
-            ),
+            "description": _presentation_descriptions.PARAMS["render_template"]["undefined"].text,
         },
     },
     "required": [],

--- a/src/reyn/tools/reyn_src.py
+++ b/src/reyn/tools/reyn_src.py
@@ -79,19 +79,11 @@ _REYN_SRC_READ_PARAMETERS: dict[str, Any] = {
         "path": {"type": "string"},
         "offset": {
             "type": "integer",
-            "description": (
-                "Line number to start reading from (0-indexed). "
-                "Omit to start at the beginning of the file. When set "
-                "(with or without limit), the 256-KB byte cap is "
-                "bypassed by line-streaming only the requested slice."
-            ),
+            "description": _dev_descriptions.PARAMS["reyn_src_read"]["offset"].text,
         },
         "limit": {
             "type": "integer",
-            "description": (
-                "Number of lines to read from `offset`. "
-                "Omit to read through end of file."
-            ),
+            "description": _dev_descriptions.PARAMS["reyn_src_read"]["limit"].text,
         },
     },
     "required": ["path"],
@@ -166,7 +158,7 @@ _REYN_SRC_GLOB_PARAMETERS: dict[str, Any] = {
     "properties": {
         "pattern": {
             "type": "string",
-            "description": "Glob pattern (e.g. '**/*.py', 'docs/**/*.md').",
+            "description": _dev_descriptions.PARAMS["reyn_src_glob"]["pattern"].text,
         },
     },
     "required": ["pattern"],
@@ -181,29 +173,23 @@ _REYN_SRC_GREP_PARAMETERS: dict[str, Any] = {
     "properties": {
         "pattern": {
             "type": "string",
-            "description": "Regex pattern (Python `re` syntax).",
+            "description": _dev_descriptions.PARAMS["reyn_src_grep"]["pattern"].text,
         },
         "path": {
             "type": "string",
-            "description": (
-                "Repo-relative directory or file to scope the search. "
-                "Default = repo root. Use '' for repo root."
-            ),
+            "description": _dev_descriptions.PARAMS["reyn_src_grep"]["path"].text,
         },
         "glob": {
             "type": "string",
-            "description": (
-                "Optional filename glob filter (e.g. '**/*.py'). "
-                "When omitted, all text files under `path` are searched."
-            ),
+            "description": _dev_descriptions.PARAMS["reyn_src_grep"]["glob"].text,
         },
         "case_sensitive": {
             "type": "boolean",
-            "description": "Default false (= case-insensitive).",
+            "description": _dev_descriptions.PARAMS["reyn_src_grep"]["case_sensitive"].text,
         },
         "max_results": {
             "type": "integer",
-            "description": "Cap on match count. Default 50.",
+            "description": _dev_descriptions.PARAMS["reyn_src_grep"]["max_results"].text,
         },
     },
     "required": ["pattern"],

--- a/src/reyn/tools/sandboxed_exec.py
+++ b/src/reyn/tools/sandboxed_exec.py
@@ -35,11 +35,11 @@ _SANDBOXED_EXEC_PARAMETERS: dict[str, Any] = {
         "argv": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Command and arguments; argv[0] is the executable.",
+            "description": _execution_descriptions.PARAMS["sandboxed_exec"]["argv"].text,
         },
         "timeout_seconds": {
             "type": "integer",
-            "description": "Wall-clock time limit in seconds (default 60).",
+            "description": _execution_descriptions.PARAMS["sandboxed_exec"]["timeout_seconds"].text,
         },
     },
     "required": ["argv"],

--- a/src/reyn/tools/semantic_search.py
+++ b/src/reyn/tools/semantic_search.py
@@ -54,39 +54,29 @@ _SEMANTIC_SEARCH_PARAMETERS: dict[str, Any] = {
     "properties": {
         "query": {
             "type": "string",
-            "description": "Natural language query to search for.",
+            "description": discovery.PARAMS["semantic_search"]["query"].text,
         },
         "sources": {
             "type": "array",
             "items": {"type": "string"},
-            "description": (
-                "Logical source names to search (from Indexed sources list)."
-            ),
+            "description": discovery.PARAMS["semantic_search"]["sources"].text,
         },
         "top_k": {
             "type": "integer",
             "default": 5,
             "minimum": 1,
             "maximum": 50,
-            "description": "Number of top chunks to return.",
+            "description": discovery.PARAMS["semantic_search"]["top_k"].text,
         },
         "filters": {
             "type": "object",
             "default": {},
-            "description": (
-                "ChunkMetadata field equality filters (e.g. source_path)."
-            ),
+            "description": discovery.PARAMS["semantic_search"]["filters"].text,
         },
         "embedding_model": {
             "type": "string",
             "default": "standard",
-            "description": (
-                "Fallback embedding model class (light/standard/strong) or "
-                "full model id, used ONLY for a source with no recorded "
-                "model yet — every already-indexed source auto-adopts its "
-                "OWN recorded model regardless of this value (multi-model "
-                "correctness, FP-0057 Phase 2a)."
-            ),
+            "description": discovery.PARAMS["semantic_search"]["embedding_model"].text,
         },
     },
     "required": ["query", "sources"],

--- a/src/reyn/tools/session_spawn.py
+++ b/src/reyn/tools/session_spawn.py
@@ -33,24 +33,17 @@ _SESSION_SPAWN_PARAMETERS: dict[str, Any] = {
     "properties": {
         "request": {
             "type": "string",
-            "description": "The task for the fresh-context session to run.",
+            "description": _delegation_descriptions.PARAMS["session_spawn"]["request"].text,
         },
         "mode": {
             "type": "string",
             "enum": ["ephemeral", "persistent"],
             "default": "persistent",
-            "description": (
-                "ephemeral = the session auto-vanishes after its task; "
-                "persistent = it stays. Chosen at spawn time."
-            ),
+            "description": _delegation_descriptions.PARAMS["session_spawn"]["mode"].text,
         },
         "narrowing": {
             "type": "object",
-            "description": (
-                "Optional per-session capability narrowing (restrict-only, cannot "
-                "widen your envelope): a capability_profile subset, e.g. "
-                "{\"tool_deny\": [\"sandboxed_exec\"]}."
-            ),
+            "description": _delegation_descriptions.PARAMS["session_spawn"]["narrowing"].text,
         },
     },
     "required": ["request"],

--- a/src/reyn/tools/shell.py
+++ b/src/reyn/tools/shell.py
@@ -43,14 +43,14 @@ _SHELL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "command": {
             "type": "string",
-            "description": "Shell command line, run as `/bin/sh -c <command>`.",
+            "description": _execution_descriptions.PARAMS["shell"]["command"].text,
         },
         "stdin_pipe": {
-            "description": "The previous pipeline step's pipe-data (JSON-encoded onto stdin).",
+            "description": _execution_descriptions.PARAMS["shell"]["stdin_pipe"].text,
         },
         "timeout": {
             "type": "integer",
-            "description": "Wall-clock time limit in seconds (default 60).",
+            "description": _execution_descriptions.PARAMS["shell"]["timeout"].text,
         },
     },
     "required": ["command"],

--- a/src/reyn/tools/skill_verbs.py
+++ b/src/reyn/tools/skill_verbs.py
@@ -39,19 +39,11 @@ _SKILL_INSTALL_LOCAL_PARAMETERS: dict[str, Any] = {
     "properties": {
         "path": {
             "type": "string",
-            "description": (
-                "Path to the skill directory (containing SKILL.md) or "
-                "the direct path to the SKILL.md file. May be absolute "
-                "or project-root-relative."
-            ),
+            "description": _skill_descriptions.PARAMS["skill_install_local"]["path"].text,
         },
         "name": {
             "type": "string",
-            "description": (
-                "Config key written under skills.entries.<name>. "
-                "When omitted, the frontmatter 'name:' field is used; "
-                "if that is also absent, the directory basename is used."
-            ),
+            "description": _skill_descriptions.PARAMS["skill_install_local"]["name"].text,
         },
     },
     "required": ["path"],
@@ -118,20 +110,11 @@ _SKILL_INSTALL_SOURCE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "source": {
             "type": "string",
-            "description": (
-                "Git or GitHub URL of the skill repo. The root (or subdir "
-                "specified via '//' separator) must contain a SKILL.md file. "
-                "Examples: 'https://github.com/user/skill-repo' or "
-                "'https://github.com/user/monorepo//skills/my-skill'."
-            ),
+            "description": _skill_descriptions.PARAMS["skill_install_source"]["source"].text,
         },
         "name": {
             "type": "string",
-            "description": (
-                "Config key written under skills.entries.<name>. "
-                "When omitted, the frontmatter 'name:' field is used; "
-                "if that is also absent, the repo/subdir basename is used."
-            ),
+            "description": _skill_descriptions.PARAMS["skill_install_source"]["name"].text,
         },
     },
     "required": ["source"],

--- a/src/reyn/tools/topology_create.py
+++ b/src/reyn/tools/topology_create.py
@@ -34,36 +34,25 @@ _TOPOLOGY_CREATE_PARAMETERS: dict[str, Any] = {
     "properties": {
         "name": {
             "type": "string",
-            "description": "The new topology's name (unique; 1-32 chars [a-z0-9_-]).",
+            "description": _delegation_descriptions.PARAMS["topology_create"]["name"].text,
         },
         "kind": {
             "type": "string",
             "enum": ["network", "team", "pipeline"],
-            "description": (
-                "network = every member ↔ every member; team = star around a leader "
-                "(requires 'leader'); pipeline = ordered chain (members[i] → members[i+1])."
-            ),
+            "description": _delegation_descriptions.PARAMS["topology_create"]["kind"].text,
         },
         "members": {
             "type": "array",
             "items": {"type": "string"},
-            "description": (
-                "Agent names to wire — each must be in your spawn subtree (yourself or "
-                "an agent you spawned)."
-            ),
+            "description": _delegation_descriptions.PARAMS["topology_create"]["members"].text,
         },
         "leader": {
             "type": "string",
-            "description": "For kind=team only: the member at the centre of the star.",
+            "description": _delegation_descriptions.PARAMS["topology_create"]["leader"].text,
         },
         "profiles": {
             "type": "object",
-            "description": (
-                "Optional JSON object mapping a member name to a capability_profile name "
-                "(both strings). A bound member's session is narrowed by that profile (it "
-                "can only narrow within its ⊆-you envelope, never widen). Each key must be "
-                "one of 'members'."
-            ),
+            "description": _delegation_descriptions.PARAMS["topology_create"]["profiles"].text,
         },
     },
     "required": ["name", "kind", "members"],

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -292,24 +292,26 @@ _LIST_ACTIONS_PARAMETERS: dict[str, Any] = {
         "category": {
             "type": "array",
             "items": {"type": "string", "enum": list(CATEGORIES)},
+            # The reviewable ``.text`` is the STATIC prefix ending in
+            # "Categories: "; the live CATEGORIES list is appended here so
+            # the rendered string stays byte-identical to the pre-migration
+            # literal (see discovery.PARAMS's docstring note on this entry).
             "description": (
-                "Filter by category. Pass an array of category names "
-                "(e.g. category=['exec'], category=['web', 'file']). "
-                "Omit or pass [] to include all categories. "
-                "Categories: " + ", ".join(CATEGORIES) + "."
+                discovery.PARAMS["list_actions"]["category"].text
+                + ", ".join(CATEGORIES) + "."
             ),
         },
         "offset": {
             "type": "integer",
             "minimum": 0,
             "default": 0,
-            "description": "Pagination offset (default 0).",
+            "description": discovery.PARAMS["list_actions"]["offset"].text,
         },
         "limit": {
             "type": "integer",
             "minimum": 1,
             "default": 10,
-            "description": "Page size (default 10).",
+            "description": discovery.PARAMS["list_actions"]["limit"].text,
         },
     },
 }
@@ -326,18 +328,18 @@ _SEARCH_ACTIONS_PARAMETERS: dict[str, Any] = {
     "properties": {
         "query": {
             "type": "string",
-            "description": "Natural-language query in any language.",
+            "description": discovery.PARAMS["search_actions"]["query"].text,
         },
         "category": {
             "type": "array",
             "items": {"type": "string", "enum": list(CATEGORIES)},
-            "description": "Optional category restriction.",
+            "description": discovery.PARAMS["search_actions"]["category"].text,
         },
         "limit": {
             "type": "integer",
             "minimum": 1,
             "default": 10,
-            "description": "Top-K results to return (default 10).",
+            "description": discovery.PARAMS["search_actions"]["limit"].text,
         },
     },
     "required": ["query"],
@@ -355,10 +357,7 @@ _DESCRIBE_ACTION_PARAMETERS: dict[str, Any] = {
     "properties": {
         "action_name": {
             "type": "string",
-            "description": (
-                "Qualified name of the action/resource to describe "
-                "(e.g. 'mcp__brave__search', 'rag_corpus__meetings')."
-            ),
+            "description": discovery.PARAMS["describe_action"]["action_name"].text,
         },
     },
     "required": ["action_name"],
@@ -375,19 +374,11 @@ _INVOKE_ACTION_PARAMETERS: dict[str, Any] = {
     "properties": {
         "action_name": {
             "type": "string",
-            "description": (
-                "Qualified name of the action/resource to invoke "
-                "(e.g. 'mcp__brave__search', 'multi_agent__delegate')."
-            ),
+            "description": _catalog_descriptions.PARAMS["invoke_action"]["action_name"].text,
         },
         "args": {
             "type": "object",
-            "description": (
-                "Arguments for the action; shape comes from "
-                "describe_action.input_schema. May be omitted for "
-                "resources whose canonical invoke takes no args "
-                "(e.g. memory_entry__foo)."
-            ),
+            "description": _catalog_descriptions.PARAMS["invoke_action"]["args"].text,
         },
     },
     "required": ["action_name"],


### PR DESCRIPTION
**[tooldesc-coder]** — Final Phase 4 (param-level) of the tool-description package refactor. Phases 1-3 (tool-LEVEL descriptions) landed in #2862/#2864/#2866. This PR moves the remaining LLM-facing surface — per-argument `"description"` strings inside `ToolDefinition.parameters` JSON-schemas — into the same reviewable `src/reyn/tools/descriptions/` package, per owner request ("引数説明も llm に見えるなら分離したい").

## Discovery (posted before bulk-relocating)

Grepped every `src/reyn/tools/*.py` for per-field `"description":` inside a `parameters` schema (excluding runtime code paths like `t.get("description", "")` and `types.py`'s render helpers). Inventory:

- **26 origin tool files** carry at least one param-level description; several files (web_fetch, web_search, ask_user, catalog.py's list_agents/describe_agent) have **none** (params are self-evident bare-typed fields) — confirming the owner's expectation that this surface is smaller than the tool-level one.
- **~54 tools** end up with a `PARAMS` entry; **~100 individual param-description strings** relocated in total.
- One non-literal case found: `list_actions`'s `category` field description is dynamically composed (`"...Categories: " + ", ".join(CATEGORIES) + "."` — `CATEGORIES` is a live tuple, not a literal). Kept the STATIC prefix as the reviewable `.text` and left the origin module doing the same runtime concatenation, so the rendered string stays byte-identical (documented in `discovery.py`).

## Convention

Added `ParamDescription` (frozen dataclass: `text` + `ja`) as a sibling to `ToolDescription` in `descriptions/_types.py`. Each bucket module that has at least one param-level description now also exports `PARAMS: dict[str, dict[str, ParamDescription]]`, keyed by tool name then field name (mirrors `ALL`'s keying). `descriptions/__init__.py` aggregates every bucket's `PARAMS` into `ALL_PARAMS`. Origin tool modules reference `<bucket>.PARAMS[tool_name][field].text` inline in their `parameters` dict literals — pure relocation, no LLM-facing text change, no call-site behavior change.

## Verification

- **Full-schema baseline test** (`tests/tools/test_tool_description_relocation.py`, pre-existing, NOT modified) — compares the full `render_for_router()` output (description AND parameters) against the committed pre-migration baseline. Stayed **GREEN** after the full relocation (byte-identical).
- **Strip-falsify**: changed one relocated param `.text` by 1 char (`edit_file`'s `new_string` description) — the baseline test went **RED** as expected, proving the param path is actually guarded by that test. Reverted before commit.
- **CJK-free gate** (#2860): scanned every `ParamDescription.text` in `ALL_PARAMS` for CJK characters — **zero leaks** into LLM-facing param text.

## CI gates (run locally)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict` — no test files changed by this PR; 7485 tests inspected, 0 errors
- `pytest` (repo root) — 8189 passed, 20 skipped, 0 failures
- `python scripts/verify_module_docstrings.py <changed files>` — OK, no refactor-narrative violations

## Test plan

- [x] Full-schema baseline test green post-relocation
- [x] Strip-falsify red (proves param path guarded), then reverted
- [x] No CJK in any relocated param `.text`
- [x] All 4 CI gates green locally

Tool-description relocation (tool-level + param-level) is now **fully complete**.