### PR TITLE
fix: isolate ActionEmbeddingIndex cwd-default cache in tests (2nd of #2861 CWD-relative-shared-state flake class)

### DIFF
--- a/tests/test_action_embedding_index.py
+++ b/tests/test_action_embedding_index.py
@@ -22,6 +22,7 @@ implementing the EmbeddingProvider Protocol's ``embed`` method.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -34,6 +35,32 @@ from reyn.tools.action_index import (
     ActionEmbeddingIndex,
     compute_catalog_hash,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """chdir to a per-test tmp dir (root-fix, same class as #2861).
+
+    Most tests in this file construct ``ActionEmbeddingIndex()`` with no
+    ``workspace_root`` override, so the index's on-disk cache defaults to
+    ``Path.cwd() / .reyn/cache/index/actions/`` (``action_index.py``'s
+    ``__init__``) — CWD-relative, not per-test. Without isolation every
+    such test in this file (and ``tests/test_universal_handlers.py``'s
+    ``test_search_actions_*`` tests) shares ONE physical
+    ``index.db``/``catalog_meta.json`` at the real repo root. Under
+    ``pytest -n auto`` this is a genuinely concurrent OS-process race: a
+    sibling xdist worker mid-``build()`` holds the shared cross-process
+    advisory build lock (``reyn.data.index.build_lock``), so this
+    process's own ``build()`` observes ``got_lock=False``, returns
+    without indexing, and ``is_ready()``/``query()`` degrade to
+    False/``[]`` — surfacing as ``search_actions`` returning an empty
+    result set (confirmed via a foreign-live-PID lock-holder repro).
+    ``monkeypatch.chdir`` isolates every test's default ``Path.cwd()``
+    to its own ``tmp_path``, mirroring the sibling lifespan tests that
+    already isolate cwd for the analogous CWD-relative ``tasks.db``
+    (#2861).
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:

--- a/tests/test_universal_handlers.py
+++ b/tests/test_universal_handlers.py
@@ -27,6 +27,7 @@ real custom registry by substituting the registry-lookup target.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import Any, Mapping
 
 import pytest
@@ -268,9 +269,9 @@ def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
     return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
 
 
-def _ready_index_with(items, ctx: OpContext):
+def _ready_index_with(items, ctx: OpContext, workspace_root: Path):
     from reyn.tools.action_index import ActionEmbeddingIndex
-    idx = ActionEmbeddingIndex()
+    idx = ActionEmbeddingIndex(workspace_root=workspace_root)
     _run(idx.build(items, ctx, "standard"))
     return idx
 
@@ -311,7 +312,7 @@ def test_search_actions_no_index_returns_empty() -> None:
 
 
 def test_search_actions_returns_ranked_items(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
     """Tier 2: handler returns ranked items with score from the index."""
     items = [
@@ -321,7 +322,15 @@ def test_search_actions_returns_ranked_items(
     ]
     provider = _StubProvider()
     op_ctx = _op_ctx_for(provider, monkeypatch)
-    idx = _ready_index_with(items, op_ctx)
+    # #2861-class root fix: pin this index's on-disk cache to a per-test
+    # tmp dir. ``ActionEmbeddingIndex()`` with no ``workspace_root``
+    # defaults to ``Path.cwd()`` (shared across the whole pytest process) —
+    # under `pytest -n auto` a sibling xdist worker mid-build on the SAME
+    # shared cross-process build lock causes THIS build to observe
+    # got_lock=False and skip indexing, so search_actions degrades to an
+    # empty result (see test_search_actions_filters_by_category's
+    # docstring / this file's flake history for the confirmed repro).
+    idx = _ready_index_with(items, op_ctx, tmp_path)
     rs = RouterCallerState(
         action_embedding_index=idx,
         embedding_provider=provider,
@@ -343,9 +352,26 @@ def test_search_actions_returns_ranked_items(
 
 
 def test_search_actions_filters_by_category(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    """Tier 2: category filter restricts to qualified_names in those categories."""
+    """Tier 2: category filter restricts to qualified_names in those categories.
+
+    #2861-class root fix (CI flake, confirmed via a foreign-live-PID
+    lock-holder repro): ``ActionEmbeddingIndex()`` with no
+    ``workspace_root`` defaults to ``Path.cwd() / .reyn/cache/index/actions/``
+    (``action_index.py``'s ``__init__``) — CWD-relative and shared by the
+    whole pytest process, same class as #2861's CWD-relative ``tasks.db``.
+    Under `pytest -n auto`, a sibling xdist worker concurrently mid-``build()``
+    on that SAME shared path holds the cross-process advisory build lock
+    (``reyn.data.index.build_lock``); this test's own ``build()`` then
+    observes ``got_lock=False``, returns without indexing, and
+    ``is_ready()``/``query()`` degrade to False/``[]`` — surfacing as
+    ``search_actions`` returning an empty item set (the reported
+    ``assert set() == {...}`` flake). Passing an explicit per-test
+    ``tmp_path`` as ``workspace_root`` (this index's own designed override
+    point) isolates the on-disk cache per test, closing the race
+    structurally rather than retrying/timing-out.
+    """
     items = [
         {"qualified_name": "memory_entry__alpha", "short_description": "Alpha"},
         {"qualified_name": "file__read", "short_description": "Read"},
@@ -354,7 +380,7 @@ def test_search_actions_filters_by_category(
     ]
     provider = _StubProvider()
     op_ctx = _op_ctx_for(provider, monkeypatch)
-    idx = _ready_index_with(items, op_ctx)
+    idx = _ready_index_with(items, op_ctx, tmp_path)
     rs = RouterCallerState(
         action_embedding_index=idx,
         embedding_provider=provider,


### PR DESCRIPTION
**[test-isolation-coder]** — Root fix for a RECURRING CI-flake class (2nd occurrence), not a bandaid.

## The flake
`tests/test_universal_handlers.py::test_search_actions_filters_by_category` intermittently fails under `pytest -n auto` (xdist) with `AssertionError: assert set() == {'memory_entry...'}` — `search_actions` returns EMPTY. It passes in isolation (3/3). This is the **2nd flake of one class**; the 1st was #2861 (CWD-relative shared `tasks.db` leaking across xdist workers).

## Root cause (primary-evidence; corrects the dispatch hypothesis)
The dispatch hypothesized a `_action_index_build_failed` **module-global memoization** leak. That is **falsified**: `_action_index_build_failed` is an **instance** attribute (`self._action_index_build_failed` on `RouterLoop`, `router_loop.py:3400`), created fresh per session/test — it **cannot** leak across tests.

The real root is **identical in class to #2861 — a CWD-relative shared filesystem artifact**:
- `ActionEmbeddingIndex()` with no `workspace_root` defaults to `Path.cwd()` (`action_index.py.__init__`), so its on-disk cache lands at `<cwd>/.reyn/cache/index/actions/` (`index.db` + `catalog_meta.json` + `.build.lock`) — **shared across the entire pytest process**, not per-test.
- Under `-n auto`, a sibling xdist worker mid-`build()` holds the **cross-process advisory build lock** (`reyn.data.index.build_lock`). This worker's own `build()` then observes `got_lock=False`, returns **without indexing**, so `is_ready()` stays False and `query()` returns `[]` → `search_actions` reports an empty item set = the reported `assert set() == {...}`.

Reproduced deterministically with a foreign live-PID `.build.lock` holder — reproduces the exact assertion message.

## Class enumeration (cover-all: all session-scoped mutable MODULE state, by xdist-leak risk)

**Filesystem / CWD-relative shared state — THIS flake's class:**
| State | Verdict |
|---|---|
| `ActionEmbeddingIndex` cwd-default cache | **THE leak** — was unisolated in 2 test files → **fixed here** |
| `_MANIFESTS` (`source_manifest`, keyed by `Path`) | Safe — all test + prod consumers (`build_resource_caller_state`) already `chdir`/`tmp_path` isolate (grep-verified) |
| `resolve_reyn_root` / `_get_project_root` / `_load_config` (`@lru_cache`, cwd/config-derived) | Safe — consumers already call `.cache_clear()` |
| task-sqlite `tasks.db` | Already fixed by #2861 |

**Module dict/set globals — NOT this class (no cwd/correctness leak):**
| State | Verdict |
|---|---|
| `_warned_models` (set) | Benign — dedupe for a one-time warn event; tests use unique model names |
| `_auto_extend_used` | Benign — keyed by unique `run_id`, reset at run entry |
| `_token_cache` | Benign — pure fn of `(model, text)` key → deterministic, no wrong-value leak |
| `_HANDLERS` / `_DECLARATIONS` / `_SCHEMES` / `_BUILTIN_HINTS` | Benign — populated at import, stable, never per-test mutated |
| `renderer_chat_events` (`@lru_cache`) | Benign — pure fn of static renderer vocab; no cwd/env dependence |

## Decision: (a) individual per-file isolation — NOT a shared-conftest reset

Justification: the leaking state is a **filesystem path**, not a Python module global — there is nothing to "reset between tests". The structural fix is **cwd / `workspace_root` isolation**, which is exactly #2861's fix pattern (#2861 also `chdir`'d per-fixture; it did **not** add a global reset). The enumeration shows no other leak-prone session-scoped state is unisolated, so a class-wide reset fixture would fix nothing new — and a global autouse `chdir` in the root conftest would be over-engineering with high blast radius (many tests deliberately rely on the repo cwd: reyn_src resolver, relative-path fixtures, surface tests).

Coverage is complete (no 3rd flake from this state): `grep` proves only **4** test files construct `ActionEmbeddingIndex`; the other 2 (`test_action_embedding_index_concurrency.py`, `test_fp0057_phase0_index_consolidation.py`) already pass `workspace_root=tmp_path`. This PR fixes the **2 outliers**:
- `test_action_embedding_index.py`: autouse `_isolate_cwd` fixture (`monkeypatch.chdir(tmp_path)`) covering its 14 bare `ActionEmbeddingIndex()` constructions.
- `test_universal_handlers.py`: thread an explicit `workspace_root=tmp_path` through the `_ready_index_with` helper (the file's single index-construction seam).

## Falsify (both fixtures load-bearing — RED on strip, GREEN on restore)

With a foreign **live-PID** holder written to the shared lock:
```
mkdir -p .reyn/cache/index/actions
sleep 30 & HOLDER=$!
python -c "import json,time,sys;open('.reyn/cache/index/actions/.build.lock','w').write(json.dumps({'pid':int(sys.argv[1]),'ts':time.time()}))" "$HOLDER"
# STRIP the fix, then:
python -m pytest tests/test_universal_handlers.py::test_search_actions_filters_by_category -q      # RED: assert set() == {'memory_entry__alpha','memory_entry__beta'}
python -m pytest tests/test_action_embedding_index.py::test_build_then_ready -q                     # RED: assert False is True
# RESTORE the fix, same forced lock:
python -m pytest tests/test_universal_handlers.py::test_search_actions_filters_by_category tests/test_action_embedding_index.py::test_build_then_ready -q  # GREEN
kill "$HOLDER"; rm -rf .reyn/cache/index/actions
```
- Stripped `test_universal_handlers.py` fix → RED with the **exact** reported message `assert set() == {'memory_entry__alpha','memory_entry__beta'}`.
- Stripped the `test_action_embedding_index.py` autouse fixture → RED `assert False is True` (build under contention leaves `is_ready()` False).
- Restored both → GREEN under identical contention.

## CI gates (all 4, green)
- `ruff check tests/test_universal_handlers.py tests/test_action_embedding_index.py` → All checks passed
- `python scripts/test_tier_audit.py --strict <both files>` → 65 inspected, 0 Tier-4 violations
- `pytest` (full, from repo root) → **8191 passed, 20 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py` → OK (no src files changed)

## Test plan
- [x] Reproduce the flake deterministically (foreign live-PID lock-holder) — reproduces exact assertion
- [x] Falsify both fixtures (RED-on-strip / GREEN-on-restore under identical forced lock)
- [x] Full `pytest` 0 failures
- [x] ruff / tier-audit / module-docstring gates green
- [x] Enumerate all `ActionEmbeddingIndex(` construction sites — all 4 files covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)