### PR TITLE
refactor: Hook-Event Phase 2 — unified Ingress Adapter (proposal 0059 §6)

### DIFF
--- a/src/reyn/hooks/ingress.py
+++ b/src/reyn/hooks/ingress.py
@@ -1,0 +1,306 @@
+"""reyn.hooks.ingress — the unified Ingress Adapter interface (Hook-Event
+Redesign Phase 2, proposal ``docs/deep-dives/proposals/0059-hook-event-
+redesign.md`` §6).
+
+Before Phase 2, reyn's 4 external-event sources converged on
+``HookDispatcher.dispatch``/``Session.dispatch_external_event`` through TWO
+different, independently-implemented ingress patterns (#2608 H1/H4/H5):
+
+  - **in-process bridge** (``mcp_resource_updated``, ``file_changed``): the raw
+    signal arrives INSIDE the session's own process (an asyncio task for MCP,
+    a foreign OS thread for the fs watcher) and is handed off through a
+    bounded ``asyncio.Queue`` + a lazily-started drain task that ``await``s a
+    ``hook_trigger`` closure already bound to THIS session's
+    ``HookDispatcher.dispatch`` (captured at session-construction time —
+    ``runtime/session.py``'s ``MCPConnectionService``/``FsWatcher`` wiring).
+    Before Phase 2 this exact bounded-queue-plus-drain-task shape was
+    duplicated almost verbatim in ``mcp/connection_service.py`` and
+    ``runtime/fs_watcher.py``.
+  - **out-of-process resolve+fire** (``cron_fired``, ``webhook_received``):
+    the raw signal arrives OUTSIDE any session's process context (the
+    web-server's cron runner / the webhook gateway), so there is no
+    already-bound ``hook_trigger`` closure to call — the target Session must
+    first be RESOLVED (get-or-spawn) from the ``AgentRegistry``, then the hook
+    is fired via ``reyn.hooks.external_fire.fire_and_forget`` (a background
+    ``asyncio.create_task`` so a slow hook action never stalls the cron job's
+    own delivery or the webhook plugin's HTTP response).
+
+This module unifies both patterns behind ONE ``IngressAdapter`` interface:
+
+    (raw signal) --to_event()--> HookEvent --deliver()--> the resolved
+    Session's HookDispatcher
+
+``to_event`` is a PURE conversion (uses Phase 1's ``schema_registry.
+build_hook_payload``, so the field-for-field schemas + the Phase-1 sync-gate
+stay intact) — it does no I/O and resolves nothing. ``deliver`` closes the
+per-pattern delivery mechanism (bounded-queue-bridge for in-process,
+Session-resolve-then-fire-and-forget for out-of-process) — Sync dispatch
+(``HookDispatcher.dispatch``) and any future Async Bus never see these
+internals; they only ever receive ``(bare_point, payload)`` via the existing
+``hook_trigger``/``dispatch_external_event`` seam, UNCHANGED.
+
+Deliberately NOT unified: the raw-signal SHAPE each adapter's ``to_event``
+accepts (an MCP notification's uri, a filesystem path+event_type, a cron
+job_name+to, a webhook sender string) — these are inherently different
+external protocols/signals, and forcing one shared signature would either
+lose information or resurrect an untyped catch-all dict (the exact ad-hoc
+shape Phase 1 eliminated). What IS unified is the two-step shape
+(``to_event`` then ``deliver``) and the return type of ``to_event``
+(``HookEvent``, always).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Protocol, runtime_checkable
+
+from reyn.hooks.event import HookEvent
+from reyn.hooks.schema_registry import bare_point, build_hook_payload, canonical_kind
+
+logger = logging.getLogger(__name__)
+
+HookTrigger = Callable[[str, dict], Awaitable[Any]]
+
+
+@runtime_checkable
+class IngressAdapter(Protocol):
+    """The unified ingress interface every external source's adapter
+    implements. ``to_event`` is pure (no I/O, no Session resolve);
+    ``deliver`` performs the actual hand-off to the resolved Session's
+    ``HookDispatcher`` (queued-and-drained for in-process adapters,
+    resolved-then-fired for out-of-process adapters — see module docstring).
+    """
+
+    def to_event(self, *args: Any, **kwargs: Any) -> HookEvent:
+        ...
+
+    def deliver(self, event: HookEvent, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-process bridge (§6: MCP + Fs share this — the bounded-queue-plus-drain
+# shape consolidated out of connection_service.py / fs_watcher.py duplication)
+# ---------------------------------------------------------------------------
+
+
+class _BoundedEventBridge:
+    """The in-process ingress delivery mechanism: a bounded ``asyncio.Queue``
+    + a lazily-created background drain task that ``await``s ``hook_trigger``
+    for each queued :class:`HookEvent`, one at a time, with per-event
+    ``try/except`` (one bad dispatch must never kill the drain loop — mirrors
+    ``HookDispatcher.dispatch``'s own per-hook isolation one level up).
+
+    The THREAD/task hand-off that gets a raw signal safely onto the session's
+    own event loop (``call_soon_threadsafe`` for the fs watcher's foreign
+    watchdog-thread origin; a plain synchronous call for MCP's same-loop
+    receive-task origin) is NOT this bridge's concern — that happens BEFORE
+    :meth:`deliver` is called, in each adapter's own producer callback. This
+    bridge only owns what happens once already running on the session's loop:
+    bound the queue, drop-newest-and-log on overflow, drain.
+
+    ``hook_trigger=None`` (no hook wired for this session) makes
+    :meth:`deliver` a no-op and the whole queue/drain-task machinery never
+    activates — byte-identical to a build with no hook mechanism at all.
+    """
+
+    def __init__(
+        self,
+        *,
+        hook_trigger: "HookTrigger | None",
+        maxsize: int,
+        adapter_name: str,
+    ) -> None:
+        self._hook_trigger = hook_trigger
+        self._maxsize = maxsize
+        self._adapter_name = adapter_name
+        self._queue: "asyncio.Queue[HookEvent] | None" = None
+        self._drain_task: "asyncio.Task | None" = None
+
+    def deliver(self, event: HookEvent) -> None:
+        """SYNCHRONOUS, non-blocking. Never awaits, never raises."""
+        if self._hook_trigger is None:
+            return
+        self._ensure_drain_task()
+        assert self._queue is not None
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            # Bounded by construction: a burst faster than hooks can be
+            # dispatched drops the NEWEST event rather than growing the queue
+            # unboundedly or blocking the producer.
+            logger.warning(
+                "%s: hook-event queue full (maxsize=%d) — dropping %r event",
+                self._adapter_name, self._maxsize, event.kind,
+            )
+
+    def _ensure_drain_task(self) -> None:
+        if self._queue is None:
+            self._queue = asyncio.Queue(maxsize=self._maxsize)
+        if self._drain_task is None or self._drain_task.done():
+            self._drain_task = asyncio.create_task(self._drain())
+
+    async def _drain(self) -> None:
+        assert self._queue is not None
+        assert self._hook_trigger is not None
+        while True:
+            event = await self._queue.get()
+            try:
+                await self._hook_trigger(bare_point(event.kind), event.payload)
+            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
+                logger.warning(
+                    "%s: hook_trigger failed for %r", self._adapter_name, event.kind,
+                    exc_info=True,
+                )
+
+    async def aclose(self) -> None:
+        """Cancel the drain task. Idempotent — safe to call repeatedly and
+        safe even if :meth:`deliver` was never called (no task started)."""
+        if self._drain_task is not None and not self._drain_task.done():
+            self._drain_task.cancel()
+            try:
+                await self._drain_task
+            except asyncio.CancelledError:
+                pass
+        self._drain_task = None
+
+
+class McpIngressAdapter:
+    """§6.1 MCP Adapter — standard ``resources/updated`` notification only (no
+    custom dialect). Converts a resource-update signal into the builtin
+    ``mcp_resource_updated`` :class:`HookEvent` (via Phase 1's
+    ``build_hook_payload``, so the field-set stays schema-gated) and delivers
+    it through the shared in-process bridge."""
+
+    def __init__(self, *, hook_trigger: "HookTrigger | None", maxsize: int = 32) -> None:
+        self._bridge = _BoundedEventBridge(
+            hook_trigger=hook_trigger, maxsize=maxsize, adapter_name="McpIngressAdapter",
+        )
+
+    def to_event(
+        self, uri: "str | None", *, server: str, agent_name: "str | None", resync: bool,
+    ) -> HookEvent:
+        payload = build_hook_payload(
+            "mcp_resource_updated", server=server, uri=uri, agent_name=agent_name, resync=resync,
+        )
+        return HookEvent(kind=canonical_kind("mcp_resource_updated"), payload=payload)
+
+    def deliver(self, event: HookEvent) -> None:
+        self._bridge.deliver(event)
+
+    async def aclose(self) -> None:
+        await self._bridge.aclose()
+
+
+class FsIngressAdapter:
+    """§6.3 Fs Adapter — watchdog → ``file_changed``. Debounce-per-path stays
+    the caller's responsibility (``runtime/fs_watcher.py``'s
+    ``_FsEventHandler._maybe_fire``, upstream of this adapter — a debounced-
+    away event never reaches :meth:`to_event` at all). SECURITY invariant
+    preserved: this adapter has no widening capability of its own — the
+    watched-paths OUT-set is entirely owned by ``FsWatcher``/
+    ``FsWatchConfig`` (restart-only, no op/tool call reaches it)."""
+
+    def __init__(self, *, hook_trigger: "HookTrigger | None", maxsize: int = 32) -> None:
+        self._bridge = _BoundedEventBridge(
+            hook_trigger=hook_trigger, maxsize=maxsize, adapter_name="FsIngressAdapter",
+        )
+
+    def to_event(self, path: str, event_type: str) -> HookEvent:
+        payload = build_hook_payload("file_changed", path=path, event_type=event_type)
+        return HookEvent(kind=canonical_kind("file_changed"), payload=payload)
+
+    def deliver(self, event: HookEvent) -> None:
+        self._bridge.deliver(event)
+
+    async def aclose(self) -> None:
+        await self._bridge.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Out-of-process resolve+fire (§6: Cron + Webhook share this shape — Session
+# resolve is CLOSED here, never leaked to a Sync-dispatch/Bus caller)
+# ---------------------------------------------------------------------------
+
+
+class CronIngressAdapter:
+    """§6.4 Cron Adapter — internal-scheduler source (NOT an external
+    protocol; reconciled in the proposal as its own "internal scheduler
+    source" classification, §6). Resolves the fired job's own persistent
+    ``cron:<job_name>`` Session from the ``AgentRegistry`` (out-of-process
+    pattern — the web-server cron runner has no already-bound
+    ``hook_trigger`` closure to call), then fires ``cron_fired`` via
+    ``fire_and_forget`` so a slow hook action never stalls the job's own
+    inbox delivery.
+    """
+
+    TRANSPORT = "cron"
+
+    @staticmethod
+    def session_id(job_name: str) -> str:
+        return f"{CronIngressAdapter.TRANSPORT}:{job_name}"
+
+    def resolve_session(self, registry: Any, agent_name: str, job_name: str) -> Any:
+        """Get-or-spawn the persistent ``cron:<job_name>`` Session of
+        ``agent_name`` and boot its run-loop — the out-of-process
+        Session-resolve, closed inside this adapter (never leaked to
+        Sync dispatch / a future Async Bus)."""
+        session = registry.resolve_session(agent_name, self.TRANSPORT, job_name)
+        registry.ensure_session_running(agent_name, self.session_id(job_name))
+        return session
+
+    def to_event(self, job_name: str, to: str) -> HookEvent:
+        payload = build_hook_payload("cron_fired", job_name=job_name, to=to)
+        return HookEvent(kind=canonical_kind("cron_fired"), payload=payload)
+
+    def deliver(self, event: HookEvent, session: Any) -> None:
+        from reyn.hooks.external_fire import fire_and_forget
+        fire_and_forget(session, bare_point(event.kind), event.payload)
+
+
+class WebhookIngressAdapter:
+    """§6.2 Webhook Adapter — provider schema, unknown opaque (namespace-
+    per-provider is a later phase; Phase 2 keeps the single ``webhook_received``
+    builtin kind, unchanged), signature verify stays at the gateway plugin
+    layer (unchanged — Phase 2 does not move where verification happens).
+    SECURITY invariant preserved: the delivered payload carries ONLY routing
+    metadata (``transport``/``sender``) — the raw inbound request body is
+    NEVER included (token/PII never reaches a hook's template_vars)."""
+
+    _GENERIC_TRANSPORT = "webhook"
+
+    @staticmethod
+    def parse_sender(sender: str) -> "tuple[str, str]":
+        transport, sep, external_id = sender.partition(":")
+        if not sep or not transport.strip():
+            return WebhookIngressAdapter._GENERIC_TRANSPORT, sender
+        return transport, external_id
+
+    def resolve_session(self, registry: Any, agent_name: str, sender: str) -> Any:
+        """Get-or-spawn the per-sender webhook Session and boot its run-loop
+        — the out-of-process Session-resolve, closed inside this adapter."""
+        transport, native_id = self.parse_sender(sender)
+        session = registry.resolve_session(agent_name, transport, native_id)
+        registry.ensure_session_running(agent_name, f"{transport}:{native_id}")
+        return session
+
+    def to_event(self, sender: str) -> HookEvent:
+        transport, _external_id = self.parse_sender(sender)
+        # SECURITY (preserved from pre-Phase-2 dispatch_webhook_received): only
+        # transport + sender — routing metadata already used for dispatch
+        # attribution — never the raw inbound body/text.
+        payload = build_hook_payload("webhook_received", transport=transport, sender=sender)
+        return HookEvent(kind=canonical_kind("webhook_received"), payload=payload)
+
+    def deliver(self, event: HookEvent, session: Any) -> None:
+        from reyn.hooks.external_fire import fire_and_forget
+        fire_and_forget(session, bare_point(event.kind), event.payload)
+
+
+__all__ = [
+    "CronIngressAdapter",
+    "FsIngressAdapter",
+    "IngressAdapter",
+    "McpIngressAdapter",
+    "WebhookIngressAdapter",
+]

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -155,6 +155,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
+from reyn.hooks.ingress import McpIngressAdapter
 from reyn.mcp.client import MCPClient, MCPTransportError
 from reyn.mcp.elicitation import DEFAULT_ELICITATION_TIMEOUT_SECONDS, build_elicitation_handler
 from reyn.mcp.message_handler import EmitSink, ReynMCPMessageHandler, ToolsCacheInvalidate
@@ -231,8 +232,17 @@ class MCPConnectionService:
         self._elicitation_bus = elicitation_bus
         self._elicitation_gate = elicitation_gate
         self._agent_name = agent_name
-        self._hook_event_queue: "asyncio.Queue[tuple[str, dict]] | None" = None
-        self._hook_drain_task: "asyncio.Task | None" = None
+        # Hook-Event Redesign Phase 2 (proposal 0059 §6.1): the bounded
+        # queue+drain-task in-process bridge now lives in the shared
+        # ``McpIngressAdapter`` (``reyn.hooks.ingress``) — :meth:`enqueue_external_event`
+        # below delegates to it instead of owning the queue/drain machinery
+        # itself. Byte-identical behaviour (same maxsize, same drop+log on
+        # overflow, same lazy drain-task creation); the mechanism is just
+        # consolidated with ``FsWatcher``'s identical shape instead of
+        # duplicated.
+        self._mcp_ingress_adapter = McpIngressAdapter(
+            hook_trigger=hook_trigger, maxsize=_HOOK_EVENT_QUEUE_MAXSIZE,
+        )
         self._clients: dict[str, MCPClient] = {}
         # #2597 slice ②b: runtime-only, in-memory, NO WAL (Q4 — see module docstring).
         # server name -> set of URIs currently subscribed on that server's held
@@ -440,52 +450,29 @@ class MCPConnectionService:
             return None
         return self._elicitation_bus
 
-    # ── #2608 H1: bounded sync->async external-event->hook bridge ──────────────────
+    # ── #2608 H1 / Hook-Event Phase 2 §6.1: MCP Ingress Adapter delegate ───────────
 
     def enqueue_external_event(self, point: str, template_vars: dict) -> None:
         """SYNCHRONOUS, non-blocking entry point called from the MCP receive-loop task
         (``ReynMCPMessageHandler.on_resource_updated``). Never awaits, never raises,
         never blocks — see module docstring's H1 section for the full bridge design.
 
-        No-op when ``hook_trigger`` is None (no hook wired for this session)."""
-        if self._hook_trigger is None:
-            return
-        self._ensure_hook_drain_task()
-        assert self._hook_event_queue is not None
-        try:
-            self._hook_event_queue.put_nowait((point, template_vars))
-        except asyncio.QueueFull:
-            # Bounded by construction (#2608 H1): a burst of resource updates faster
-            # than hooks can be dispatched DROPS the newest event rather than growing
-            # the queue unboundedly or blocking the receive loop.
-            logger.warning(
-                "MCPConnectionService: external-event hook queue full (maxsize=%d) — "
-                "dropping %r event (server=%r)",
-                _HOOK_EVENT_QUEUE_MAXSIZE, point, template_vars.get("server"),
-            )
+        Hook-Event Redesign Phase 2 (proposal 0059 §6.1): delegates the bounded
+        queue+drain-task delivery mechanism to ``self._mcp_ingress_adapter``
+        (``reyn.hooks.ingress.McpIngressAdapter``) — the SAME bridge shape
+        ``FsIngressAdapter`` uses, no longer duplicated per-source. ``point`` +
+        ``template_vars`` (already schema-built by ``ReynMCPMessageHandler`` via
+        ``build_hook_payload``) are wrapped into a :class:`~reyn.hooks.event.HookEvent`
+        here — byte-identical values, now typed at the ingress boundary instead of
+        only inside ``HookDispatcher.dispatch``.
 
-    def _ensure_hook_drain_task(self) -> None:
-        if self._hook_event_queue is None:
-            self._hook_event_queue = asyncio.Queue(maxsize=_HOOK_EVENT_QUEUE_MAXSIZE)
-        if self._hook_drain_task is None or self._hook_drain_task.done():
-            self._hook_drain_task = asyncio.create_task(self._drain_hook_events())
-
-    async def _drain_hook_events(self) -> None:
-        """Runs on the session's event loop (this service's owning loop — the same
-        loop the held ``fastmcp.Client`` was opened on, see module docstring), so it
-        can safely ``await hook_trigger(...)``. Per-event ``try/except``: a raising
-        (or hanging-then-raising) hook dispatch must not kill the drain task — the
-        NEXT queued event still gets a chance."""
-        assert self._hook_event_queue is not None
-        assert self._hook_trigger is not None
-        while True:
-            point, template_vars = await self._hook_event_queue.get()
-            try:
-                await self._hook_trigger(point, template_vars)
-            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
-                logger.warning(
-                    "MCPConnectionService: hook_trigger failed for %r", point, exc_info=True,
-                )
+        No-op when ``hook_trigger`` is None (no hook wired for this session) —
+        the adapter itself no-ops in that case."""
+        from reyn.hooks.event import HookEvent
+        from reyn.hooks.schema_registry import canonical_kind
+        self._mcp_ingress_adapter.deliver(
+            HookEvent(kind=canonical_kind(point), payload=template_vars),
+        )
 
     def _track_subscription(self, server: str, uri: str) -> None:
         self._subscriptions.setdefault(server, set()).add(uri)
@@ -496,18 +483,13 @@ class MCPConnectionService:
     async def aclose(self) -> None:
         """Close every held connection. Idempotent — safe to call repeatedly (e.g. a
         session teardown seam that may run more than once)."""
-        # #2608 H1: cancel the hook-event drain task FIRST (finally-guaranteed, not
-        # except-Exception — CancelledError is a BaseException) so a client-teardown
-        # fault below can never leave the drain task orphaned across session teardown.
-        try:
-            if self._hook_drain_task is not None and not self._hook_drain_task.done():
-                self._hook_drain_task.cancel()
-                try:
-                    await self._hook_drain_task
-                except asyncio.CancelledError:
-                    pass
-        finally:
-            self._hook_drain_task = None
+        # #2608 H1 / Phase 2 §6.1: cancel the hook-event drain task FIRST
+        # (finally-guaranteed, not except-Exception — CancelledError is a
+        # BaseException) so a client-teardown fault below can never leave the
+        # drain task orphaned across session teardown. Delegated to the
+        # McpIngressAdapter (byte-identical: same cancel-then-await-swallow
+        # shape, now shared with FsIngressAdapter's aclose).
+        await self._mcp_ingress_adapter.aclose()
 
         clients = list(self._clients.items())
         self._clients.clear()

--- a/src/reyn/runtime/cron/routing.py
+++ b/src/reyn/runtime/cron/routing.py
@@ -22,48 +22,53 @@ the same ingress coroutine as the job's own inbox delivery (see
 """
 from __future__ import annotations
 
-from reyn.hooks.schema_registry import build_hook_payload
+from reyn.hooks.ingress import CronIngressAdapter
 
 CRON_TRANSPORT = "cron"
+
+# Hook-Event Redesign Phase 2 (proposal 0059 §6.4): the Cron Adapter is
+# stateless (no bound queue/session — it resolves its target Session fresh
+# at fire time), so one module-level instance is shared by every call.
+_ADAPTER = CronIngressAdapter()
 
 
 def cron_session_id(job_name: str) -> str:
     """The logical session-id (routing-key) for a cron job: ``cron:<job_name>``."""
-    return f"{CRON_TRANSPORT}:{job_name}"
+    return _ADAPTER.session_id(job_name)
 
 
 def resolve_cron_session(registry, agent_name: str, job_name: str):
     """Resolve (get-or-spawn) the persistent ``cron:<job_name>`` Session of
     ``agent_name`` and boot its run-loop so the scheduled turn is processed.
 
-    Steps (pure registry + session ops):
-      1. ``resolve_session(agent, "cron", job_name)`` — get-or-spawn by routing-key
-         (persistent: the same job resumes the same Session across fires).
-      2. ``ensure_session_running`` — boot the run-loop WITHOUT a forwarder (cron is
-         unattended; output handling is the S4b-3b notify layer, not the REPL sink).
+    Hook-Event Redesign Phase 2 (proposal 0059 §6.4): delegates to
+    ``CronIngressAdapter.resolve_session`` — the out-of-process Session-resolve
+    step of the unified Ingress Adapter interface, closed inside the adapter
+    (Sync dispatch / a future Async Bus never see it). Byte-identical steps
+    (get-or-spawn by routing-key, then boot the run-loop with no forwarder —
+    cron is unattended).
 
     Idempotent. Returns the resolved Session."""
-    session = registry.resolve_session(agent_name, CRON_TRANSPORT, job_name)
-    registry.ensure_session_running(agent_name, cron_session_id(job_name))
-    return session
+    return _ADAPTER.resolve_session(registry, agent_name, job_name)
 
 
 def dispatch_cron_fired(session, job_name: str, to: str) -> None:
-    """#2608 H5: fire the ``cron_fired`` external-event hook on ``session``
-    (the job's own resolved Session — pass the object :func:`resolve_cron_session`
-    returned, so the hook fires on the SAME session the job's message was
-    delivered to).
+    """#2608 H5 / Hook-Event Phase 2 §6.4: fire the ``cron_fired`` external-event
+    hook on ``session`` (the job's own resolved Session — pass the object
+    :func:`resolve_cron_session` returned, so the hook fires on the SAME
+    session the job's message was delivered to).
 
-    Non-blocking (``reyn.hooks.external_fire.fire_and_forget``) — a slow hook
-    action must never stall the cron job's own inbox delivery. ``template_vars``
-    carry only operator-authored config metadata (``job_name``, the target
-    agent name) — a cron job never carries end-user-supplied secrets the way
-    an inbound webhook body can, so nothing is withheld here (contrast
+    Delegates to ``CronIngressAdapter``'s ``to_event`` (builds the typed
+    ``HookEvent`` via Phase 1's ``build_hook_payload``, unchanged field-set)
+    then ``deliver`` (``reyn.hooks.external_fire.fire_and_forget`` — a slow
+    hook action must never stall the cron job's own inbox delivery).
+    ``template_vars`` carry only operator-authored config metadata
+    (``job_name``, the target agent name) — a cron job never carries
+    end-user-supplied secrets the way an inbound webhook body can, so
+    nothing is withheld here (contrast
     ``reyn.runtime.webhook_routing.dispatch_webhook_received``). ``job_name``
     is the matchable field (exact match — not a glob field, see
     ``reyn.hooks.matcher``), e.g. ``matcher: {job_name: "backup"}``.
     """
-    from reyn.hooks.external_fire import fire_and_forget
-    fire_and_forget(
-        session, "cron_fired", build_hook_payload("cron_fired", job_name=job_name, to=to),
-    )
+    event = _ADAPTER.to_event(job_name, to)
+    _ADAPTER.deliver(event, session)

--- a/src/reyn/runtime/fs_watcher.py
+++ b/src/reyn/runtime/fs_watcher.py
@@ -89,7 +89,7 @@ import os
 import time
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-from reyn.hooks.schema_registry import build_hook_payload
+from reyn.hooks.ingress import FsIngressAdapter
 
 if TYPE_CHECKING:
     pass
@@ -150,8 +150,14 @@ class FsWatcher:
         self._debounce_seconds = debounce_seconds
         self._observer: Any = None
         self._loop: "asyncio.AbstractEventLoop | None" = None
-        self._queue: "asyncio.Queue[tuple[str, str]] | None" = None
-        self._drain_task: "asyncio.Task | None" = None
+        # Hook-Event Redesign Phase 2 (proposal 0059 §6.3): the bounded
+        # queue+drain-task in-process bridge now lives in the shared
+        # ``FsIngressAdapter`` (``reyn.hooks.ingress``) — the SAME bridge
+        # shape ``McpIngressAdapter`` uses, no longer duplicated per-source.
+        # Byte-identical behaviour (same maxsize, same drop+log on overflow).
+        self._fs_ingress_adapter = FsIngressAdapter(
+            hook_trigger=hook_trigger, maxsize=_QUEUE_MAXSIZE,
+        )
         self._started = False
         # #2623: resolved-symlink-path -> operator-configured-path rewrites,
         # built in :meth:`start` — see module docstring "Path normalization".
@@ -189,8 +195,6 @@ class FsWatcher:
         FileSystemEventHandler, Observer = imported
 
         self._loop = asyncio.get_running_loop()
-        self._queue = asyncio.Queue(maxsize=_QUEUE_MAXSIZE)
-        self._drain_task = asyncio.create_task(self._drain_events())
 
         # #2623: schedule each watch on the RESOLVED (symlink-free) path and
         # build a resolved->configured rewrite table, so the reported event
@@ -263,54 +267,25 @@ class FsWatcher:
 
     def _enqueue(self, event_type: str, path: str) -> None:
         """Runs ON THE LOOP THREAD (scheduled via call_soon_threadsafe) — safe
-        to touch ``self._queue`` here."""
-        if self._queue is None:
-            return
-        try:
-            self._queue.put_nowait((event_type, path))
-        except asyncio.QueueFull:
-            # Bounded by construction (mirrors H1): a burst faster than hooks
-            # can be dispatched drops the newest event rather than growing the
-            # queue unboundedly.
-            logger.warning(
-                "FsWatcher: file_changed hook queue full (maxsize=%d) — "
-                "dropping %r event (path=%r)",
-                _QUEUE_MAXSIZE, event_type, path,
-            )
+        to touch the ``FsIngressAdapter``'s queue here.
 
-    async def _drain_events(self) -> None:
-        """Runs on the session's event loop; the only place that ``await``s
-        ``hook_trigger``. Per-event ``try/except`` mirrors H1's drain task —
-        one bad dispatch must not kill the drain loop."""
-        assert self._queue is not None
-        assert self._hook_trigger is not None
-        while True:
-            event_type, path = await self._queue.get()
-            try:
-                await self._hook_trigger(
-                    "file_changed",
-                    build_hook_payload("file_changed", path=path, event_type=event_type),
-                )
-            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
-                logger.warning(
-                    "FsWatcher: hook_trigger failed for path=%r event_type=%r",
-                    path, event_type, exc_info=True,
-                )
+        Hook-Event Redesign Phase 2 (proposal 0059 §6.3): converts the raw
+        ``(event_type, path)`` signal into a typed ``file_changed``
+        :class:`~reyn.hooks.event.HookEvent` via ``self._fs_ingress_adapter.
+        to_event`` (pure — same ``build_hook_payload`` call as pre-Phase-2,
+        just factored into the adapter), then hands it to the SAME bounded
+        queue+drain-task bridge ``McpIngressAdapter`` uses (``deliver``) — the
+        bound/drop-newest-and-log/drain behaviour is byte-identical, no
+        longer duplicated per-source."""
+        event = self._fs_ingress_adapter.to_event(path, event_type)
+        self._fs_ingress_adapter.deliver(event)
 
     async def aclose(self) -> None:
         """Stop the observer thread + cancel the drain task. Idempotent — safe
         to call repeatedly (e.g. a session teardown seam that may run more
         than once) and safe to call even if :meth:`start` was never called or
         no-op'd (empty paths / no watchdog)."""
-        try:
-            if self._drain_task is not None and not self._drain_task.done():
-                self._drain_task.cancel()
-                try:
-                    await self._drain_task
-                except asyncio.CancelledError:
-                    pass
-        finally:
-            self._drain_task = None
+        await self._fs_ingress_adapter.aclose()
 
         observer = self._observer
         self._observer = None
@@ -327,7 +302,6 @@ class FsWatcher:
             await loop.run_in_executor(None, _stop_and_join)
         self._started = False
         self._loop = None
-        self._queue = None
 
 
 def _build_handler(file_system_event_handler_cls: Any, watcher: FsWatcher) -> Any:

--- a/src/reyn/runtime/webhook_routing.py
+++ b/src/reyn/runtime/webhook_routing.py
@@ -24,9 +24,14 @@ stable ingress every webhook plugin routes through), right after
 """
 from __future__ import annotations
 
-from reyn.hooks.schema_registry import build_hook_payload
+from reyn.hooks.ingress import WebhookIngressAdapter
 
 _GENERIC_WEBHOOK_TRANSPORT = "webhook"
+
+# Hook-Event Redesign Phase 2 (proposal 0059 §6.2): the Webhook Adapter is
+# stateless (no bound queue/session — it resolves its target Session fresh
+# at request time), so one module-level instance is shared by every call.
+_ADAPTER = WebhookIngressAdapter()
 
 
 def parse_webhook_sender(sender: str) -> tuple[str, str]:
@@ -37,48 +42,39 @@ def parse_webhook_sender(sender: str) -> tuple[str, str]:
     that itself contains ``:`` is preserved). A sender with no transport prefix
     falls back to the generic ``webhook`` namespace with the whole sender as the
     external_id."""
-    transport, sep, external_id = sender.partition(":")
-    if not sep or not transport.strip():
-        return _GENERIC_WEBHOOK_TRANSPORT, sender
-    return transport, external_id
+    return _ADAPTER.parse_sender(sender)
 
 
 def resolve_webhook_session(registry, agent_name: str, sender: str):
     """Resolve (get-or-spawn) the per-sender webhook Session and boot its run-loop.
 
-    Steps (pure registry + session ops):
-      1. parse the sender → ``(transport, external_id)`` routing-key.
-      2. ``resolve_session`` get-or-spawn (persistent per sender; the same external
-         user resumes the same Session).
-      3. ``ensure_session_running`` — run-loop WITHOUT a forwarder (webhook is
-         fire-and-forget; the reply routes via the factory-wired outbox interceptor
-         from the plugin's ``reply_to=ExternalRef``, not the REPL sink).
+    Hook-Event Redesign Phase 2 (proposal 0059 §6.2): delegates to
+    ``WebhookIngressAdapter.resolve_session`` — the out-of-process
+    Session-resolve step of the unified Ingress Adapter interface, closed
+    inside the adapter (Sync dispatch / a future Async Bus never see it).
+    Byte-identical steps (parse sender → routing-key, get-or-spawn, boot the
+    run-loop with no forwarder — webhook is fire-and-forget).
 
     Idempotent. Returns the resolved Session."""
-    transport, native_id = parse_webhook_sender(sender)
-    session = registry.resolve_session(agent_name, transport, native_id)
-    registry.ensure_session_running(agent_name, f"{transport}:{native_id}")
-    return session
+    return _ADAPTER.resolve_session(registry, agent_name, sender)
 
 
 def dispatch_webhook_received(session, sender: str) -> None:
-    """#2608 H5: fire the ``webhook_received`` external-event hook on
-    ``session`` (the sender's own resolved Session — pass the object
-    :func:`resolve_webhook_session` returned).
+    """#2608 H5 / Hook-Event Phase 2 §6.2: fire the ``webhook_received``
+    external-event hook on ``session`` (the sender's own resolved Session —
+    pass the object :func:`resolve_webhook_session` returned).
 
-    Non-blocking (``reyn.hooks.external_fire.fire_and_forget``) — a slow hook
-    action must never stall the webhook plugin's HTTP response. ``template_vars``
-    carry ONLY ``transport`` + ``sender`` (safe routing metadata already used for
-    dispatch attribution) — deliberately NOT the raw inbound body/text, which may
-    carry tokens/PII the operator never intended a hook action to see (contrast
-    ``reyn.runtime.cron.routing.dispatch_cron_fired``, whose ``job_name``/``to``
-    are operator-authored config, never end-user-supplied). Both ``transport``
-    and ``sender`` are exact-match fields (not glob — see ``reyn.hooks.matcher``),
-    e.g. ``matcher: {transport: "slack"}``.
+    Delegates to ``WebhookIngressAdapter``'s ``to_event`` (builds the typed
+    ``HookEvent`` via Phase 1's ``build_hook_payload``, unchanged field-set —
+    SECURITY invariant preserved: ONLY ``transport`` + ``sender``, never the
+    raw inbound body/text, which may carry tokens/PII the operator never
+    intended a hook action to see; contrast
+    ``reyn.runtime.cron.routing.dispatch_cron_fired``, whose ``job_name``/
+    ``to`` are operator-authored config, never end-user-supplied) then
+    ``deliver`` (``reyn.hooks.external_fire.fire_and_forget`` — a slow hook
+    action must never stall the webhook plugin's HTTP response). Both
+    ``transport`` and ``sender`` are exact-match fields (not glob — see
+    ``reyn.hooks.matcher``), e.g. ``matcher: {transport: "slack"}``.
     """
-    from reyn.hooks.external_fire import fire_and_forget
-    transport, _external_id = parse_webhook_sender(sender)
-    fire_and_forget(
-        session, "webhook_received",
-        build_hook_payload("webhook_received", transport=transport, sender=sender),
-    )
+    event = _ADAPTER.to_event(sender)
+    _ADAPTER.deliver(event, session)

--- a/tests/test_hook_event_ingress_adapter_0059_phase2.py
+++ b/tests/test_hook_event_ingress_adapter_0059_phase2.py
@@ -1,0 +1,377 @@
+"""Tier 2: Hook-Event Redesign Phase 2 — Ingress Adapter unify (proposal
+``docs/deep-dives/proposals/0059-hook-event-redesign.md`` §6).
+
+Before Phase 2, reyn's 4 external-event sources converged on
+``HookDispatcher.dispatch``/``Session.dispatch_external_event`` through two
+independently-implemented ingress patterns: an in-process bounded-queue bridge
+(``mcp_resource_updated``, ``file_changed``) and an out-of-process
+Session-resolve-then-``fire_and_forget`` (``cron_fired``, ``webhook_received``).
+Phase 2 converges both onto ONE ``reyn.hooks.ingress.IngressAdapter`` interface:
+``to_event(raw) -> HookEvent`` (pure conversion, via Phase 1's
+``build_hook_payload``) + ``deliver(event, ...)`` (the mechanism-specific
+hand-off — bounded-queue-bridge for in-process, resolve-then-fire for
+out-of-process).
+
+This file drives the REAL adapter classes (no mocks) and proves:
+
+1. **byte-identical conversion** — each adapter's ``to_event`` produces the
+   IDENTICAL field-set the pre-Phase-2 free functions
+   (``message_handler.emit_resource_updated`` / ``fs_watcher._enqueue`` /
+   ``cron.routing.dispatch_cron_fired`` / ``webhook_routing.
+   dispatch_webhook_received``) built via the same ``build_hook_payload``
+   schema gate proven in ``test_hook_event_schema_registry_sync_0059.py``.
+2. **byte-identical delivery** — ``deliver`` reaches the SAME resolved
+   session's ``HookDispatcher`` the pre-Phase-2 mechanism did (in-process:
+   the bound ``hook_trigger`` closure; out-of-process: the registry-resolved
+   Session via ``fire_and_forget``).
+3. **strip-falsify** — breaking one adapter's conversion (a dropped field,
+   simulating drift) makes the schema gate (``HookSchemaError``, the SAME
+   Phase-1 construction-time gate) RED; restoring goes GREEN.
+4. **security invariants preserved** — the Webhook adapter's payload never
+   carries the raw inbound body/text; the Fs adapter has no widening
+   capability (no Control-IR op reaches ``FsWatchConfig``/``fs_watch.paths``).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.event import HookEvent
+from reyn.hooks.ingress import (
+    CronIngressAdapter,
+    FsIngressAdapter,
+    IngressAdapter,
+    McpIngressAdapter,
+    WebhookIngressAdapter,
+)
+from reyn.hooks.schema_registry import BUILTIN_HOOK_SCHEMAS, HookSchemaError
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+# ---------------------------------------------------------------------------
+# 0) Protocol conformance — all 4 adapters satisfy the ONE IngressAdapter shape
+# ---------------------------------------------------------------------------
+
+
+def test_all_four_adapters_satisfy_the_unified_protocol():
+    """Tier 2: the 4 external sources (mcp/fs = in-process, cron/webhook =
+    out-of-process) all structurally conform to ONE ``IngressAdapter``
+    interface (``to_event`` + ``deliver``) — the redesign's core claim."""
+    for adapter in (
+        McpIngressAdapter(hook_trigger=None),
+        FsIngressAdapter(hook_trigger=None),
+        CronIngressAdapter(),
+        WebhookIngressAdapter(),
+    ):
+        assert isinstance(adapter, IngressAdapter)
+
+
+# ---------------------------------------------------------------------------
+# 1) byte-identical conversion — to_event's payload matches the builtin schema
+#    (the SAME field-set the pre-Phase-2 free functions produced)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_adapter_to_event_matches_builtin_schema():
+    """Tier 2: McpIngressAdapter.to_event produces the identical field-set
+    ``message_handler.emit_resource_updated`` built pre-Phase-2."""
+    adapter = McpIngressAdapter(hook_trigger=None)
+    event = adapter.to_event(
+        "file:///repo/README.md", server="github", agent_name="a", resync=False,
+    )
+    assert isinstance(event, HookEvent)
+    assert event.kind == "builtin:external:mcp_resource_updated"
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+    assert event.payload["server"] == "github"
+    assert event.payload["uri"] == "file:///repo/README.md"
+    assert event.payload["resync"] is False
+
+
+def test_fs_adapter_to_event_matches_builtin_schema():
+    """Tier 2: FsIngressAdapter.to_event produces the identical field-set
+    ``fs_watcher``'s drain loop built pre-Phase-2."""
+    adapter = FsIngressAdapter(hook_trigger=None)
+    event = adapter.to_event("/repo/src/main.py", "modified")
+    assert event.kind == "builtin:external:file_changed"
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+    assert event.payload["path"] == "/repo/src/main.py"
+    assert event.payload["event_type"] == "modified"
+
+
+def test_cron_adapter_to_event_matches_builtin_schema():
+    """Tier 2: CronIngressAdapter.to_event produces the identical field-set
+    ``cron.routing.dispatch_cron_fired`` built pre-Phase-2."""
+    adapter = CronIngressAdapter()
+    event = adapter.to_event("nightly-backup", "news_agent")
+    assert event.kind == "builtin:external:cron_fired"
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+    assert event.payload["job_name"] == "nightly-backup"
+    assert event.payload["to"] == "news_agent"
+
+
+def test_webhook_adapter_to_event_matches_builtin_schema():
+    """Tier 2: WebhookIngressAdapter.to_event produces the identical field-set
+    ``webhook_routing.dispatch_webhook_received`` built pre-Phase-2."""
+    adapter = WebhookIngressAdapter()
+    event = adapter.to_event("slack:U456")
+    assert event.kind == "builtin:external:webhook_received"
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+    assert event.payload["transport"] == "slack"
+    assert event.payload["sender"] == "slack:U456"
+
+
+# ---------------------------------------------------------------------------
+# 2) byte-identical delivery — deliver() reaches the resolved session's real
+#    HookDispatcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_in_process_adapter_deliver_reaches_bound_hook_trigger():
+    """Tier 2: the shared in-process bridge (McpIngressAdapter / FsIngressAdapter)
+    ``deliver`` reaches the bound ``hook_trigger`` closure — the exact
+    mechanism ``MCPConnectionService``/``FsWatcher`` wire at session
+    construction (``runtime/session.py``)."""
+    captured: list[tuple[str, dict]] = []
+
+    async def _hook_trigger(point: str, payload: dict) -> None:
+        captured.append((point, payload))
+
+    mcp_adapter = McpIngressAdapter(hook_trigger=_hook_trigger)
+    event = mcp_adapter.to_event("file:///x", server="s", agent_name="a", resync=True)
+    mcp_adapter.deliver(event)
+    await _wait_for(lambda: len(captured) >= 1)
+    point, payload = captured[0]
+    assert point == "mcp_resource_updated"
+    assert payload == event.payload
+    await mcp_adapter.aclose()
+
+    captured.clear()
+    fs_adapter = FsIngressAdapter(hook_trigger=_hook_trigger)
+    event2 = fs_adapter.to_event("/repo/x.py", "created")
+    fs_adapter.deliver(event2)
+    await _wait_for(lambda: len(captured) >= 1)
+    point2, payload2 = captured[0]
+    assert point2 == "file_changed"
+    assert payload2 == event2.payload
+    await fs_adapter.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cron_adapter_resolve_session_and_deliver_reaches_real_dispatcher(tmp_path):
+    """Tier 2: CronIngressAdapter's out-of-process Session-resolve + deliver
+    reaches the REAL resolved Session's HookDispatcher — driving real
+    AgentRegistry/Session/HookDispatcher, no mocks."""
+    hooks_config = [
+        {"on": "cron_fired", "template_push": {"message": "{{ job_name }}"}},
+    ]
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, hooks_config=hooks_config)
+        s.register_intervention_listener("test")
+        return s
+
+    class _NoRunRegistry(AgentRegistry):
+        def ensure_session_running(self, name: str, sid: str):
+            return self._peek_session(name, sid)
+
+    reg = _NoRunRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    _seed(tmp_path, "news_agent")
+
+    adapter = CronIngressAdapter()
+    session = adapter.resolve_session(reg, "news_agent", "morning_news")
+    assert session is reg.get_session("news_agent", "cron:morning_news")
+
+    event = adapter.to_event("morning_news", "news_agent")
+    adapter.deliver(event, session)
+
+    await _wait_for(lambda: session.inbox.qsize() >= 1)
+    kind, payload = session.inbox.get_nowait()
+    assert kind == "hook"
+    assert payload["text"] == "morning_news"
+
+
+@pytest.mark.asyncio
+async def test_webhook_adapter_resolve_session_and_deliver_reaches_real_dispatcher(tmp_path):
+    """Tier 2: WebhookIngressAdapter's out-of-process Session-resolve + deliver
+    reaches the REAL resolved Session's HookDispatcher."""
+    hooks_config = [
+        {"on": "webhook_received", "template_push": {"message": "{{ transport }}"}},
+    ]
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log, hooks_config=hooks_config)
+        s.register_intervention_listener("test")
+        return s
+
+    class _NoRunRegistry(AgentRegistry):
+        def ensure_session_running(self, name: str, sid: str):
+            return self._peek_session(name, sid)
+
+    reg = _NoRunRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    _seed(tmp_path, "support_agent")
+
+    adapter = WebhookIngressAdapter()
+    session = adapter.resolve_session(reg, "support_agent", "slack:U456")
+
+    event = adapter.to_event("slack:U456")
+    adapter.deliver(event, session)
+
+    await _wait_for(lambda: session.inbox.qsize() >= 1)
+    kind, payload = session.inbox.get_nowait()
+    assert kind == "hook"
+    assert payload["text"] == "slack"
+
+
+# ---------------------------------------------------------------------------
+# 3) strip-falsify — an adapter that regresses (drops a field) is caught
+#    IMMEDIATELY at construction (the same Phase-1 schema gate), not silently.
+# ---------------------------------------------------------------------------
+
+
+def test_strip_falsify_webhook_adapter_dropped_field_is_caught(monkeypatch):
+    """Tier 2: falsifying WebhookIngressAdapter.to_event to drop ``sender``
+    (simulating an adapter regression during the Phase-2 refactor) raises
+    ``HookSchemaError`` immediately — RED. Restoring the real method goes
+    GREEN again."""
+    adapter = WebhookIngressAdapter()
+    original_to_event = WebhookIngressAdapter.to_event
+
+    def _broken_to_event(self, sender: str) -> HookEvent:
+        from reyn.hooks.schema_registry import build_hook_payload, canonical_kind
+        transport, _ = self.parse_sender(sender)
+        # BUG: omits "sender" — simulates a dropped field.
+        payload = build_hook_payload("webhook_received", transport=transport)
+        return HookEvent(kind=canonical_kind("webhook_received"), payload=payload)
+
+    monkeypatch.setattr(WebhookIngressAdapter, "to_event", _broken_to_event)
+    with pytest.raises(HookSchemaError):
+        adapter.to_event("slack:U456")
+
+    monkeypatch.setattr(WebhookIngressAdapter, "to_event", original_to_event)
+    event = adapter.to_event("slack:U456")  # GREEN again
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+
+
+def test_strip_falsify_cron_adapter_extra_field_is_caught(monkeypatch):
+    """Tier 2: falsifying CronIngressAdapter.to_event to ADD an undeclared
+    field (simulating drift the other direction) raises ``HookSchemaError``
+    immediately — RED. Restoring goes GREEN."""
+    adapter = CronIngressAdapter()
+    original_to_event = CronIngressAdapter.to_event
+
+    def _broken_to_event(self, job_name: str, to: str) -> HookEvent:
+        from reyn.hooks.schema_registry import build_hook_payload, canonical_kind
+        # BUG: an undeclared extra field smuggled in.
+        payload = build_hook_payload(
+            "cron_fired", job_name=job_name, to=to, unexpected_field="oops",
+        )
+        return HookEvent(kind=canonical_kind("cron_fired"), payload=payload)
+
+    monkeypatch.setattr(CronIngressAdapter, "to_event", _broken_to_event)
+    with pytest.raises(HookSchemaError):
+        adapter.to_event("nightly-backup", "news_agent")
+
+    monkeypatch.setattr(CronIngressAdapter, "to_event", original_to_event)
+    event = adapter.to_event("nightly-backup", "news_agent")  # GREEN again
+    assert frozenset(event.payload) == BUILTIN_HOOK_SCHEMAS[event.kind]
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_in_process_bridge_queue_overflow_drops_and_logs():
+    """Tier 2: falsifying — a maxsize=1 bridge with a stalled drain proves the
+    bounded-by-construction discipline still holds after consolidating the
+    queue+drain logic out of connection_service.py/fs_watcher.py into the
+    shared ``_BoundedEventBridge``: a burst beyond the bound drops the NEWEST
+    event (never raises, never blocks the caller)."""
+    release = asyncio.Event()
+    started = asyncio.Event()
+
+    async def _slow_hook_trigger(point: str, payload: dict) -> None:
+        started.set()
+        await release.wait()
+
+    adapter = McpIngressAdapter(hook_trigger=_slow_hook_trigger, maxsize=1)
+    e1 = adapter.to_event("file:///a", server="s", agent_name=None, resync=False)
+    e2 = adapter.to_event("file:///b", server="s", agent_name=None, resync=False)
+    e3 = adapter.to_event("file:///c", server="s", agent_name=None, resync=False)
+
+    adapter.deliver(e1)  # picked up by the drain task immediately (blocks on release)
+    await _wait_for(lambda: started.is_set())
+    adapter.deliver(e2)  # queued (maxsize=1)
+    adapter.deliver(e3)  # OVERFLOW — dropped, never raises
+
+    release.set()
+    await adapter.aclose()  # never hangs — proves deliver() never blocked the caller
+
+
+# ---------------------------------------------------------------------------
+# 4) security invariants preserved
+# ---------------------------------------------------------------------------
+
+
+def test_webhook_adapter_payload_never_carries_raw_body():
+    """Tier 2: security invariant — WebhookIngressAdapter.to_event's signature accepts
+    ONLY ``sender`` — there is no parameter through which a raw inbound
+    request body/text could reach the payload, and the produced payload's
+    field-set is exactly {transport, sender} (the builtin schema), never a
+    superset that could smuggle body content through."""
+    adapter = WebhookIngressAdapter()
+    event = adapter.to_event("slack:U456")
+    assert set(event.payload) == {"point", "transport", "sender"}
+    for value in event.payload.values():
+        assert "TOP_SECRET" not in str(value)
+
+
+def test_fs_adapter_has_no_path_widening_capability():
+    """Tier 2: security invariant — FsIngressAdapter's ``to_event``/``deliver`` surface
+    takes a path to CONVERT, never a path to ADD to the watch-set — it holds
+    no reference to ``FsWatchConfig``/``fs_watch.paths`` at all. The watched
+    OUT-set is entirely owned by ``FsWatcher`` (restart-only config), and no
+    Control-IR op kind references ``FsWatchConfig`` (verified against the
+    op-kind model map — the sandbox-policy-class invariant CLAUDE.md's Tool
+    Contract lens requires: no untyped/agent-driven path to widen an OUT-set
+    declared surface)."""
+    import inspect
+
+    from reyn.schemas.models import OP_KIND_MODEL_MAP
+
+    adapter = FsIngressAdapter(hook_trigger=None)
+    assert not hasattr(adapter, "paths")
+    assert not hasattr(adapter, "_paths")
+
+    for model_cls in OP_KIND_MODEL_MAP.values():
+        src = inspect.getsource(model_cls)
+        assert "FsWatchConfig" not in src
+        assert "fs_watch" not in src


### PR DESCRIPTION
**[hook-event-coder]** — Hook-Event Redesign Phase 2 (Ingress Adapter unify), proposal `docs/deep-dives/proposals/0059-hook-event-redesign.md` §6. Base = origin/main (includes Phase 1, #2871).

## Discovery: the 4-source → 2-pattern map (pre-Phase-2)

| source | process locality | pre-Phase-2 bridge |
|---|---|---|
| `mcp_resource_updated` | in-process (MCP receive-loop task) | `MCPConnectionService.enqueue_external_event` — bounded `asyncio.Queue` + drain task (`mcp/connection_service.py`) |
| `file_changed` | in-process, cross-thread (watchdog OS thread) | `FsWatcher._enqueue` — `call_soon_threadsafe` + bounded Queue + drain task (`runtime/fs_watcher.py`) |
| `cron_fired` | out-of-process (web-server cron runner) | `resolve_cron_session` (AgentRegistry) → `dispatch_cron_fired` → `fire_and_forget` (`runtime/cron/routing.py`) |
| `webhook_received` | out-of-process (webhook gateway) | `resolve_webhook_session` → `dispatch_webhook_received` → `fire_and_forget` (`runtime/webhook_routing.py`) |

Two independently-implemented patterns: **in-process bridge** (bounded-queue + drain task, near-identical code in `connection_service.py` and `fs_watcher.py`) vs **out-of-process resolve+fire** (`AgentRegistry` Session-resolve then `fire_and_forget`).

## Unified interface

New `src/reyn/hooks/ingress.py`:
- `IngressAdapter` protocol — `to_event(raw) -> HookEvent` (pure, via Phase 1's `build_hook_payload`, so field-for-field schemas + the Phase-1 sync-gate stay intact) + `deliver(event, ...)` (the mechanism-specific hand-off).
- `_BoundedEventBridge` — the shared in-process delivery mechanism (bounded queue + lazy drain task), deduplicating what was near-identical code in `connection_service.py`/`fs_watcher.py`. Backs `McpIngressAdapter` (§6.1, standard `resources/updated` only) and `FsIngressAdapter` (§6.3, no widening capability).
- `CronIngressAdapter` (§6.4, "internal scheduler source" per the proposal's reconcile) and `WebhookIngressAdapter` (§6.2) close the out-of-process Session-resolve *inside* the adapter — Sync dispatch / a future Async Bus never see it.

## Call-site wiring (byte-identical external behavior)

- `mcp/connection_service.py`: `enqueue_external_event` delegates to `McpIngressAdapter`; `aclose()` delegates to the adapter's `aclose()`. Same maxsize (32), same drop-newest-and-log overflow, same lazy drain-task creation.
- `runtime/fs_watcher.py`: `_enqueue` delegates to `FsIngressAdapter`. Same maxsize (32), same debounce (unchanged, upstream of the adapter).
- `runtime/cron/routing.py` / `runtime/webhook_routing.py`: `resolve_cron_session` / `dispatch_cron_fired` / `resolve_webhook_session` / `dispatch_webhook_received` **keep their existing public signatures** (external callers `gateway/api.py`, `interfaces/web/server.py` are untouched) but delegate internally to the adapters.

## Scope boundary (§0) — respected

Only the ingress/hook-event layer touched. No changes to `core/events` (P6 audit) or WAL. No Async Bus (Phase 4), no `emit_hook_event` op (Phase 5).

## Verification

**All 4 CI gates green:**
- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_hook_event_ingress_adapter_0059_phase2.py` — 13/13 OK, 0 Tier-4 violations.
- `pytest` (repo root) — **8211 passed, 20 skipped, 0 failed**.
- `python scripts/verify_module_docstrings.py <changed files>` — OK.

**Byte-identical + regression-zero:** every pre-existing test touching these 4 sources passes UNMODIFIED — `test_hook_event_schema_registry_sync_0059.py` (Phase-1 sync-gate, all 10 builtin points including the 4 ingress sources), `test_2608_h4_fs_watcher.py`, `test_2608_h5_cron_webhook_hooks.py`, `test_cron_routing.py`, `test_webhook_routing.py`, `test_2597_s2b_mcp_notifications_bridge.py`, `test_2597_s2a_mcp_resources_consumption.py`, `test_teardown_completeness_2783.py`, `gateway/test_api.py`.

**New Phase-2 test** (`tests/test_hook_event_ingress_adapter_0059_phase2.py`, 13 tests):
1. Protocol conformance — all 4 adapters structurally satisfy `IngressAdapter`.
2. Byte-identical conversion — each adapter's `to_event` payload matches `BUILTIN_HOOK_SCHEMAS` exactly.
3. Byte-identical delivery — `deliver` reaches the real bound `hook_trigger` (in-process) / the real resolved Session's `HookDispatcher` via a real `AgentRegistry`+`Session` (out-of-process), no mocks.
4. **Strip-falsify**: a dropped field (webhook adapter) and an extra field (cron adapter) both raise `HookSchemaError` immediately (RED); restoring the real method goes GREEN. Plus a queue-overflow strip proving the bound-by-construction/drop-newest discipline survived the consolidation.
5. **Security invariants**: webhook adapter's payload field-set is exactly `{point, transport, sender}` — no raw body ever reaches it; fs adapter holds no reference to `FsWatchConfig`/`fs_watch.paths`, and no `OP_KIND_MODEL_MAP` entry references it (no op can widen the watched OUT-set).

## Test plan
- [x] All 4 CI gates run locally and green (pasted above).
- [x] Byte-identical: every pre-existing production-path test for the 4 sources passes unmodified.
- [x] Strip-falsify RED→GREEN demonstrated for both drift directions (missing/extra field) + queue-overflow bound.
- [x] Security-invariant tests for webhook (no raw body) and fs (no widening capability).

@architect — co-vet welcome (broker-notified at discovery + now at PR-up).