### PR TITLE
fix: rewire MCP ingress through McpIngressAdapter.to_event, fix stale schema.py docstring

### DIFF
--- a/src/reyn/hooks/schema.py
+++ b/src/reyn/hooks/schema.py
@@ -22,12 +22,23 @@ event loop. ``HookDef.matcher`` stayed reserved/uninterpreted for this
 point in H1 (scoping was via which resources the user subscribed to).
 
 #2608 H2 interprets ``matcher``: a ``dict[str, str]`` of field -> pattern,
-evaluated against the event's ``template_vars`` BEFORE the hook's action runs
-(``reyn.hooks.matcher.matches``, called from ``HookDispatcher.dispatch``).
+evaluated against the event's ``template_vars`` BEFORE the hook's action runs.
 For ``mcp_resource_updated`` the two matchable fields are ``server`` (exact
 match) and ``uri`` (glob via ``fnmatch``) — e.g. ``{"server": "github", "uri":
 "file:///repo/**"}``. Absent/empty matcher -> fires always (unchanged for
 every pre-H2 hook, lifecycle or external-event).
+
+Hook-Event Redesign Phase 3 (proposal 0059 §10 Q-reyn-4): ``HookDispatcher.
+dispatch`` no longer calls ``reyn.hooks.matcher.matches`` on ``hook.matcher``
+directly — every ``matcher`` is wrapped into a payload-only ``EventPattern``
+(``reyn.hooks.event_pattern.from_legacy_matcher``) and evaluated through
+``reyn.hooks.event_pattern.matches`` (whose payload predicate still delegates
+to the unchanged ``reyn.hooks.matcher.matches``, so every existing
+``hooks.yaml`` entry's match semantics are byte-identical — this field's own
+dict-of-field->pattern shape and validation, below, are unaffected). Phase 3
+also makes an out-of-schema matcher field FAIL-LOUD at ``load_hooks`` time
+(``HookConfigError``, typo-resistance against the Phase-1 Schema Registry)
+rather than silently never matching at dispatch time.
 
 #2608 H3 adds the 4th action, ``pipeline_launch`` — a hook can launch a
 REGISTERED Pipeline (``reyn.core.pipeline.registry.PipelineRegistry.get``)

--- a/src/reyn/mcp/connection_service.py
+++ b/src/reyn/mcp/connection_service.py
@@ -152,6 +152,7 @@ update is not.
 from __future__ import annotations
 
 import asyncio
+import functools
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -324,11 +325,17 @@ class MCPConnectionService:
                 handler = ReynMCPMessageHandler(
                     self._emit_sink, server,
                     tools_cache_invalidate=self._tools_cache_invalidate,
-                    # #2608 H1: wired only when a hook_trigger was injected (this
-                    # service's enqueue_external_event is itself a no-op without one) —
-                    # so a session with no hook_trigger stays byte-identical to pre-H1.
+                    # #2608 H1 / Hook-Event Redesign #2875 F1: wired only when a
+                    # hook_trigger was injected (this service's ingress path is itself
+                    # a no-op without one) — so a session with no hook_trigger stays
+                    # byte-identical to pre-H1. Bound to THIS server name via
+                    # functools.partial — :meth:`_mcp_to_hook_event` is per-service
+                    # (one ``McpIngressAdapter``, shared across every held server),
+                    # but the raw signal the handler sees (``uri``, ``resync``) does
+                    # not itself carry which server produced it.
                     on_external_event=(
-                        self.enqueue_external_event if self._hook_trigger is not None else None
+                        functools.partial(self._mcp_to_hook_event, server)
+                        if self._hook_trigger is not None else None
                     ),
                     agent_name=self._agent_name,
                 )
@@ -450,21 +457,40 @@ class MCPConnectionService:
             return None
         return self._elicitation_bus
 
-    # ── #2608 H1 / Hook-Event Phase 2 §6.1: MCP Ingress Adapter delegate ───────────
+    # ── #2608 H1 / Hook-Event Phase 2 §6.1 / #2875 F1: MCP Ingress Adapter delegate ──
+
+    def _mcp_to_hook_event(self, server: str, uri: "str | None", resync: bool) -> None:
+        """The production ``ReynMCPMessageHandler.on_external_event`` callback for a
+        given ``server`` (bound via ``functools.partial`` in :meth:`_ensure_open`).
+        SYNCHRONOUS, non-blocking, never raises — called from the MCP receive-loop
+        task (see module docstring's H1 section for the full bridge design).
+
+        Hook-Event Redesign #2875 F1 (proposal 0059 §6 completion): converts the RAW
+        signal (``uri``, ``resync`` — ``server``/``agent_name`` close over this
+        service/handler) into a :class:`~reyn.hooks.event.HookEvent` via
+        ``self._mcp_ingress_adapter.to_event`` — the ONE place ``build_hook_payload``
+        now runs for MCP. Before #2875, ``ReynMCPMessageHandler.emit_resource_updated``
+        called ``build_hook_payload`` directly and handed the finished payload to
+        ``enqueue_external_event`` (below), so ``McpIngressAdapter.to_event`` — added
+        in Phase 2 (#2872) — was never actually reached for MCP in production, despite
+        ``FsIngressAdapter.to_event`` being reached for ``file_changed``: the §6 unify
+        was 3/4 wired, not 4/4. Delivery (the bounded queue+drain-task bridge) is
+        unchanged — same ``self._mcp_ingress_adapter.deliver`` this class always used."""
+        event = self._mcp_ingress_adapter.to_event(
+            uri, server=server, agent_name=self._agent_name, resync=resync,
+        )
+        self._mcp_ingress_adapter.deliver(event)
 
     def enqueue_external_event(self, point: str, template_vars: dict) -> None:
-        """SYNCHRONOUS, non-blocking entry point called from the MCP receive-loop task
-        (``ReynMCPMessageHandler.on_resource_updated``). Never awaits, never raises,
-        never blocks — see module docstring's H1 section for the full bridge design.
-
-        Hook-Event Redesign Phase 2 (proposal 0059 §6.1): delegates the bounded
-        queue+drain-task delivery mechanism to ``self._mcp_ingress_adapter``
-        (``reyn.hooks.ingress.McpIngressAdapter``) — the SAME bridge shape
-        ``FsIngressAdapter`` uses, no longer duplicated per-source. ``point`` +
-        ``template_vars`` (already schema-built by ``ReynMCPMessageHandler`` via
-        ``build_hook_payload``) are wrapped into a :class:`~reyn.hooks.event.HookEvent`
-        here — byte-identical values, now typed at the ingress boundary instead of
-        only inside ``HookDispatcher.dispatch``.
+        """Low-level entry point onto ``self._mcp_ingress_adapter``'s bounded
+        queue+drain-task delivery mechanism — takes an ALREADY-BUILT
+        ``(point, template_vars)`` pair and wraps it into a
+        :class:`~reyn.hooks.event.HookEvent` for delivery. Kept as a public
+        entry point for exercising the bridge's queue/overflow/drain behaviour
+        directly (see ``tests/test_2608_h1_mcp_resource_updated_hook.py``); the
+        production MCP call path itself goes through :meth:`_mcp_to_hook_event`
+        (which builds the event via ``McpIngressAdapter.to_event``, #2875 F1) —
+        this method is NOT what ``ReynMCPMessageHandler`` calls any more.
 
         No-op when ``hook_trigger`` is None (no hook wired for this session) —
         the adapter itself no-ops in that case."""

--- a/src/reyn/mcp/message_handler.py
+++ b/src/reyn/mcp/message_handler.py
@@ -61,8 +61,6 @@ from typing import Any, Callable
 from fastmcp.client.messages import MessageHandler
 from fastmcp.client.tasks import TaskNotificationHandler
 
-from reyn.hooks.schema_registry import build_hook_payload
-
 logger = logging.getLogger(__name__)
 
 # Matches EventLog.emit(type: str, **data) -> Event; a plain callable sink lets callers
@@ -70,14 +68,20 @@ logger = logging.getLogger(__name__)
 # MCPConnectionService's emit_sink wiring.
 EmitSink = Callable[..., Any]
 ToolsCacheInvalidate = Callable[[str], None]
-# #2608 H1: SYNCHRONOUS enqueue callable (never awaited here — the handler runs on the
-# receive-loop task, see module docstring's "synchronous hook bodies"). Matches
-# ``MCPConnectionService.enqueue_external_event(point, template_vars)`` — a bounded,
-# non-blocking hand-off to the session's async HookDispatcher, drained by a task on the
-# session's own event loop. None = no external-event hook bridge (byte-identical to
-# pre-H1 behaviour — the ephemeral MCPClientPool path and any session with no
-# ``mcp_resource_updated`` hook configured never wire this).
-OnExternalEvent = Callable[[str, dict], None]
+# #2608 H1 / Hook-Event Redesign #2875 F1 (proposal 0059 §6 completion): SYNCHRONOUS
+# raw-signal callable (never awaited here — the handler runs on the receive-loop task,
+# see module docstring's "synchronous hook bodies"). Carries the RAW MCP signal
+# (uri, resync) — NOT a pre-built payload — so the payload-construction step (Phase 1's
+# ``build_hook_payload``) happens exactly once, inside
+# ``reyn.hooks.ingress.McpIngressAdapter.to_event`` (the adapter this handler's caller,
+# ``MCPConnectionService``, binds this callback to per-server). Before #2875 this
+# handler built the payload itself via ``build_hook_payload`` directly, bypassing
+# ``McpIngressAdapter.to_event`` entirely — the 1 of 4 ingress sources (MCP/Fs/Cron/
+# Webhook) not actually funnelling through its own adapter's ``to_event``, per the §6
+# unify. None = no external-event hook bridge (byte-identical to pre-H1 behaviour — the
+# ephemeral MCPClientPool path and any session with no ``mcp_resource_updated`` hook
+# configured never wire this).
+OnExternalEvent = Callable[[str | None, bool], None]
 
 
 class ReynMCPMessageHandler(TaskNotificationHandler):
@@ -214,20 +218,24 @@ class ReynMCPMessageHandler(TaskNotificationHandler):
         only the added ``resync`` field distinguishes a synthetic re-signal
         from a real push for anyone inspecting the payload. Never raises: a
         fault in either downstream path must not break the receive loop (real
-        push) or the reconnect (synthetic path)."""
+        push) or the reconnect (synthetic path).
+
+        Hook-Event Redesign #2875 F1 (proposal 0059 §6 completion): this method
+        passes the RAW signal (``uri``, ``resync``) to ``_on_external_event`` —
+        it does NOT call ``build_hook_payload`` itself. Payload construction
+        happens exactly once, downstream, inside
+        ``reyn.hooks.ingress.McpIngressAdapter.to_event`` (bound per-server by
+        ``MCPConnectionService``, the sole production wirer of
+        ``_on_external_event`` — see its ``_ensure_open``). Before #2875 this
+        method built the payload inline via ``build_hook_payload`` directly,
+        which meant ``McpIngressAdapter.to_event`` — despite existing since
+        Phase 2 (#2872) — was never actually reached in production for MCP,
+        the 1 of 4 ingress sources (MCP/Fs/Cron/Webhook) not funnelling
+        through its own adapter's ``to_event``."""
         self._emit("mcp_resource_updated", server=self._server_name, uri=uri, resync=resync)
         if self._on_external_event is not None:
             try:
-                self._on_external_event(
-                    "mcp_resource_updated",
-                    build_hook_payload(
-                        "mcp_resource_updated",
-                        server=self._server_name,
-                        uri=uri,
-                        agent_name=self._agent_name,
-                        resync=resync,
-                    ),
-                )
+                self._on_external_event(uri, resync)
             except Exception:  # noqa: BLE001 — a trigger fault must not break the receive loop
                 logger.warning(
                     "ReynMCPMessageHandler: on_external_event failed for %r on server %r",

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -165,6 +165,59 @@ async def test_no_configured_hook_leaves_hook_side_a_pure_noop(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Tier 2: #2875 F1 — MCP production path actually reaches McpIngressAdapter.to_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_real_mcp_push_routes_through_mcp_ingress_adapter_to_event(tmp_path, monkeypatch):
+    """Tier 2: #2875 F1 — the production MCP ingress path
+    (``ReynMCPMessageHandler.emit_resource_updated`` ->
+    ``MCPConnectionService._mcp_to_hook_event``) actually reaches
+    ``reyn.hooks.ingress.McpIngressAdapter.to_event``. Phase 2 (#2872) added
+    ``to_event``, but the MCP call site kept building the payload inline via
+    ``build_hook_payload`` directly (bypassing the adapter), so ``to_event`` was
+    production-dead for MCP — the §6 Ingress-Adapter unify was 3/4 wired, not
+    4/4. Record-then-delegate around the REAL ``McpIngressAdapter.to_event``
+    (the same idiom ``test_hook_event_schema_registry_sync_0059.py`` uses for
+    ``HookDispatcher.dispatch`` — every side effect still runs for real, only
+    the observation is added) and drive the SAME real subprocess push as the
+    core H1 proof above.
+
+    Strip-falsify: if the rewire were undone (``message_handler.py`` reverted
+    to building the payload itself, bypassing ``to_event``), ``calls`` stays
+    empty, ``_wait_for`` times out, and the ``(call,) = calls`` unpack below
+    raises — RED."""
+    from reyn.hooks.ingress import McpIngressAdapter
+
+    calls: list[tuple[str | None, str, bool]] = []
+    original = McpIngressAdapter.to_event
+
+    def _recording_to_event(self, uri, *, server, agent_name, resync):
+        calls.append((uri, server, resync))
+        return original(self, uri, server=server, agent_name=agent_name, resync=resync)
+
+    monkeypatch.setattr(McpIngressAdapter, "to_event", _recording_to_event)
+
+    hooks_config = [
+        {"on": "mcp_resource_updated", "template_push": {"message": "{{ uri }}"}},
+    ]
+    session = _make_session(tmp_path, hooks_config=hooks_config)
+    try:
+        client = await session._mcp_connection_service.get("srv", _stdio_cfg(_SUBSCRIBABLE_SERVER))
+        await client.subscribe_resource(_URI)
+
+        result = await client.call_tool("bump_and_notify", {})
+        assert result["isError"] is False
+
+        await _wait_for(lambda: bool(calls))
+        (call,) = calls  # exactly one push -> exactly one to_event call
+        assert call == (_URI, "srv", False)
+    finally:
+        await session._mcp_connection_service.aclose()
+
+
+# ---------------------------------------------------------------------------
 # Tier 2: bounded sync->async bridge — overflow drops, never blocks
 # ---------------------------------------------------------------------------
 

--- a/tests/test_hook_event_schema_registry_sync_0059.py
+++ b/tests/test_hook_event_schema_registry_sync_0059.py
@@ -47,11 +47,13 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.core.op_runtime import task as taskmod
 from reyn.hooks import dispatcher as dispatcher_mod
+from reyn.hooks.ingress import McpIngressAdapter
 from reyn.hooks.loader import load_hooks
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.schema_registry import (
     BUILTIN_HOOK_SCHEMAS,
     HookSchemaError,
+    bare_point,
     build_hook_payload,
     canonical_kind,
 )
@@ -172,12 +174,20 @@ async def test_all_ten_builtin_points_dispatch_schema_matching_payloads(
     await _wait_for(lambda: sum(1 for p, _ in captured if p in ("cron_fired", "webhook_received")) >= 2)
 
     # ── mcp_resource_updated (in-process MCP bridge) ── ``on_external_event`` is
-    # called SYNCHRONOUSLY by ``emit_resource_updated`` (mirroring the real
-    # ``MCPConnectionService.enqueue_external_event`` bridge, itself sync/
-    # non-blocking — the actual ``await`` happens on its own drain task); this
-    # bridge schedules the real (capturing) dispatch the same way.
-    def _mcp_bridge(point: str, template_vars: dict) -> None:
-        asyncio.create_task(disp.dispatch(point, template_vars))
+    # called SYNCHRONOUSLY by ``emit_resource_updated`` with the RAW signal
+    # (``uri``, ``resync``) — #2875 F1: the payload build now happens via the REAL
+    # ``McpIngressAdapter.to_event`` (proposal 0059 §6), mirroring the production
+    # ``MCPConnectionService._mcp_to_hook_event`` wiring exactly, so this also
+    # proves ``to_event`` is production-reached, not dead. The resulting
+    # ``HookEvent`` is handed to the real (capturing) dispatch the same
+    # sync-enqueue-then-async-drain shape the production bridge uses.
+    mcp_adapter = McpIngressAdapter(hook_trigger=None)  # to_event is pure — no I/O, no Session
+
+    def _mcp_bridge(uri: "str | None", resync: bool) -> None:
+        event = mcp_adapter.to_event(
+            uri, server="github", agent_name="sync-gate-agent", resync=resync,
+        )
+        asyncio.create_task(disp.dispatch(bare_point(event.kind), event.payload))
 
     handler = ReynMCPMessageHandler(
         lambda *a, **k: None, "github", on_external_event=_mcp_bridge, agent_name="sync-gate-agent",


### PR DESCRIPTION
**[hook-event-coder]** — Small cleanup from the Hook-Event Phase 1-3 architect review, issue #2875.

## What this does

**F1 — Complete the §6 Ingress-Adapter unify for MCP.** Phase 2 (#2872) added `McpIngressAdapter.to_event` (`src/reyn/hooks/ingress.py`), but the MCP path was the 1 of 4 external-event ingress sources (MCP/Fs/Cron/Webhook) still constructing the `mcp_resource_updated` `HookEvent` payload INLINE — `ReynMCPMessageHandler.emit_resource_updated` (`src/reyn/mcp/message_handler.py`) called `build_hook_payload` directly, bypassing `McpIngressAdapter.to_event` entirely. So `to_event` was production-dead for MCP: the §6 unify was 3/4 wired, not 4/4.

Rewired the callback contract:
- `ReynMCPMessageHandler.emit_resource_updated` now passes the RAW signal (`uri`, `resync`) to `_on_external_event`, instead of a pre-built payload.
- `MCPConnectionService` binds a new `_mcp_to_hook_event(server, uri, resync)` method per-server (via `functools.partial`, since `McpIngressAdapter` is per-service not per-server) — it converts the raw signal into a `HookEvent` via `self._mcp_ingress_adapter.to_event(...)` and delivers it through the existing bounded queue+drain bridge, unchanged.
- `build_hook_payload` now runs in exactly ONE place for MCP: inside `McpIngressAdapter.to_event`.
- The old `enqueue_external_event(point, template_vars)` low-level entry stays on `MCPConnectionService` (still exercised directly by the bounded-queue overflow test) but is no longer what the production MCP call path invokes.

Byte-identical: same `build_hook_payload("mcp_resource_updated", server=..., uri=..., agent_name=..., resync=...)` call, same field set — just relocated from the handler into the adapter.

**F2 — Stale docstring.** `src/reyn/hooks/schema.py`'s matcher section claimed `HookDispatcher.dispatch` calls `reyn.hooks.matcher.matches` directly — Phase 3 (#2873) changed this: matching now routes through the generalized `EventPattern` grammar (`reyn.hooks.event_pattern.matches` + `from_legacy_matcher`), and `load_hooks` now fail-loud validates matcher fields against the Schema Registry (a schema-external field raises `HookConfigError` at load, not silently never-matches at dispatch). Updated the docstring to describe the Phase-3 reality.

## Verification

- Added `test_real_mcp_push_routes_through_mcp_ingress_adapter_to_event` (Tier 2, real subprocess MCP server + real Session) that record-then-delegates around the REAL `McpIngressAdapter.to_event` and asserts it's actually called with `(uri, server, resync)` — proving `to_event` is now production-reached for MCP, not dead.
- **Strip-falsify verified manually**: reverted the `on_external_event` wiring to `None` (simulating the pre-fix bypass) — the new test goes RED (`ValueError: not enough values to unpack (expected 1, got 0)`), confirming the test actually catches the regression. Restored before commit.
- Updated `test_hook_event_schema_registry_sync_0059.py`'s MCP bridge fixture to match the new raw-signal callback contract, now itself routing through a real `McpIngressAdapter.to_event` call — the Phase-1 schema sync-gate and Phase-2 ingress-adapter tests stay green.
- Existing MCP production-path tests (`test_2608_h1_mcp_resource_updated_hook.py`) all stay green, including the real end-to-end subprocess push -> hook -> inbox proof.
- §0 scope respected: hook-event layer only, no P6/WAL touch.

## CI gates (all local, all green)

- `ruff check src tests` → All checks passed!
- `python scripts/test_tier_audit.py --strict tests/test_2608_h1_mcp_resource_updated_hook.py tests/test_hook_event_schema_registry_sync_0059.py` → 14/14 OK, 0 Tier-4 violations
- `pytest` (repo root) → 8241 passed, 20 skipped in 223.29s
- `python scripts/verify_module_docstrings.py <changed src files>` → OK, no refactor-narrative docstrings

## Test plan

- [x] `pytest tests/test_2608_h1_mcp_resource_updated_hook.py tests/test_hook_event_schema_registry_sync_0059.py tests/test_hook_event_ingress_adapter_0059_phase2.py tests/test_hook_event_pattern_0059_phase3.py tests/test_2597_p1_reconnect_resync_read.py` → 59 passed
- [x] Full repo `pytest` → 8241 passed, 20 skipped
- [x] `ruff check src tests` → clean
- [x] `test_tier_audit.py --strict` on changed test files → 0 violations
- [x] `verify_module_docstrings.py` on changed src files → OK
- [x] Manual strip-falsify: reverted the rewire, confirmed the new to_event-reached test goes RED, restored

toward #2875

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>