### PR TITLE
feat: Hook-Event Redesign Phase 4a — per-Session Async Bus (proposal 0059 §3.2/§3.3)

### DIFF
--- a/src/reyn/hooks/__init__.py
+++ b/src/reyn/hooks/__init__.py
@@ -45,7 +45,14 @@ Hook-Event Redesign Phase 3 (proposal 0059 §10 Q-reyn-4) additionally exposes:
     validate_event_pattern_against_schema — OPT-IN static validation: flag an
                      ``EventPattern`` payload field not in a kind's builtin
                      schema (typo-resistance).
+
+Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3) additionally exposes:
+    HookBus        — the per-Session pub/sub broadcast bus (``reyn.hooks.
+                     bus``); ``HookDispatcher.dispatch`` broadcasts to it
+                     independently of the Sync hook loop when injected.
+    HookBusSubscription — a subscriber's handle on a ``HookBus``.
 """
+from reyn.hooks.bus import HookBus, HookBusSubscription
 from reyn.hooks.event import HookEvent
 from reyn.hooks.event_pattern import EventPattern
 from reyn.hooks.event_pattern import from_legacy_matcher as event_pattern_from_legacy_matcher
@@ -63,6 +70,8 @@ from reyn.hooks.shell_runner import run_shell_hook
 
 __all__ = [
     "EventPattern",
+    "HookBus",
+    "HookBusSubscription",
     "HookDef",
     "HookEvent",
     "PushBlock",

--- a/src/reyn/hooks/bus.py
+++ b/src/reyn/hooks/bus.py
@@ -1,0 +1,162 @@
+"""reyn.hooks.bus — the per-Session ``HookBus`` (Hook-Event Redesign Phase 4a,
+proposal ``docs/deep-dives/proposals/0059-hook-event-redesign.md`` §3.2/§3.3).
+
+reyn's ``HookDispatcher`` (``reyn.hooks.dispatcher``) is the Sync path: an
+awaited, per-hook-isolated, registration-ordered dispatch invoked at each of
+the 10 builtin lifecycle/external points. Before this module reyn had no
+pub/sub broadcast layer at all (proposal §3.2 reconcile) — this is that layer,
+net-new, and the prerequisite substrate the Composer (Phase 4b) builds on.
+Phase 4a delivers ONLY the Bus; it does not build the Composer, the
+``emit_hook_event`` op (Phase 5), or ``QueuePolicy``/Backpressure.
+
+**pub/sub broadcast, not a queue** (§3.2): ``publish`` hands the SAME
+``HookEvent`` instance to every live subscriber. There is no "consume" —
+one subscriber observing an event never removes it for another. Each
+subscriber owns its OWN bounded queue so a slow subscriber cannot starve a
+fast one, and ``publish`` never blocks the publisher (mirrors the Ingress
+Adapter bridge's non-blocking, drop-newest-and-log overflow discipline,
+``reyn.hooks.ingress._BoundedEventBridge`` — the same shape, one layer up).
+
+**Independent of Sync dispatch** (§3.2): the same builtin kind (e.g.
+``builtin:external:mcp_resource_updated``) can be Sync-registered for a
+side-effect AND Bus-subscribed for observation — not mutually exclusive.
+``HookDispatcher.dispatch`` publishes to its (optional) bus unconditionally,
+regardless of whether any Sync hook is registered for the point, so a
+Bus-only subscriber observes every dispatched event even with zero Sync
+hooks configured.
+
+**Per-Session scope (§3.3, v1)**: a ``HookBus`` is constructed once per
+Session (mirroring ``HookDispatcher``'s own per-Session construction,
+``runtime/session.py``) and injected into that Session's ``HookDispatcher``.
+There is no cross-session Bus — a subscriber on one session's Bus can never
+observe another session's events (session isolation is structural, not a
+runtime check). Cross-session event correlation is an explicit v1 non-goal
+(proposal §3.3/§11 future list).
+
+**Band alignment (§3.2 reconcile)**: the Bus carries hook-events ONLY. It
+does NOT route through the P6 ``EventLog`` subscriber path (audit-event) and
+must never be confused with it (CLAUDE.md's 3-event rule — audit-event /
+WAL-event / hook-event are three distinct things). Naming: ``HookBus`` (never
+bare ``Bus`` or ``EventBus``) so it cannot collide with ``reyn.core.events``
+at the identifier level, same discipline as ``HookEvent`` (``reyn.hooks.event``).
+
+**No-subscriber happy path (byte-identical)**: ``publish`` with zero live
+subscribers iterates an empty list — no queue, no task, no allocation beyond
+the loop itself. Constructing a ``HookBus`` and never subscribing to it is
+indistinguishable in behavior from not having one; ``HookDispatcher.dispatch``
+without an injected bus (``bus=None``, the default) skips the publish call
+entirely, so every pre-Phase-4a call site (and every pre-Phase-4a test) is
+unaffected.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from reyn.hooks.event import HookEvent
+
+logger = logging.getLogger(__name__)
+
+# Default per-subscriber queue bound. A subscriber that falls this far behind
+# starts losing the OLDEST unread events it hasn't drained yet (drop-newest
+# would let a stuck subscriber silently wedge new events out of history
+# indefinitely; drop-oldest bounds staleness instead) — same trade documented
+# for the Ingress bridge's overflow path, adapted per-subscriber here since a
+# Bus subscriber (unlike a single Sync drain task) is expected to poll at its
+# own pace.
+_DEFAULT_SUBSCRIBER_MAXSIZE = 128
+
+
+class HookBusSubscription:
+    """A single subscriber's handle on a :class:`HookBus`. Each subscription
+    owns its own bounded queue (broadcast, not a shared consume-once queue —
+    every live subscription independently receives every published
+    :class:`HookEvent`). Use as an async context manager or call
+    :meth:`close` explicitly when done observing."""
+
+    def __init__(self, *, bus: "HookBus", queue: "asyncio.Queue[HookEvent]") -> None:
+        self._bus = bus
+        self._queue = queue
+        self._closed = False
+
+    async def get(self) -> HookEvent:
+        """Await the next broadcast HookEvent for this subscription."""
+        return await self._queue.get()
+
+    def get_nowait(self) -> HookEvent:
+        """Non-blocking variant of :meth:`get` — raises ``asyncio.QueueEmpty``
+        if nothing has been broadcast to this subscription yet."""
+        return self._queue.get_nowait()
+
+    def close(self) -> None:
+        """Detach from the bus. Idempotent — safe to call more than once."""
+        if self._closed:
+            return
+        self._closed = True
+        self._bus._unsubscribe(self._queue)
+
+    async def __aenter__(self) -> "HookBusSubscription":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        self.close()
+
+
+class HookBus:
+    """Per-Session pub/sub broadcast bus for :class:`HookEvent` (proposal
+    §3.2/§3.3). One instance per Session — construct alongside that Session's
+    ``HookDispatcher`` and inject it in (``HookDispatcher(..., bus=...)``);
+    never share an instance across sessions (§3.3 v1 = per-Session, no
+    cross-session correlation)."""
+
+    def __init__(self, *, subscriber_maxsize: int = _DEFAULT_SUBSCRIBER_MAXSIZE) -> None:
+        self._subscriber_maxsize = subscriber_maxsize
+        self._subscribers: "list[asyncio.Queue[HookEvent]]" = []
+
+    def subscribe(self) -> HookBusSubscription:
+        """Register a new subscriber. Returns a handle whose ``get()``
+        awaits the next broadcast event; call ``close()`` (or use as an
+        async context manager) to stop receiving."""
+        queue: "asyncio.Queue[HookEvent]" = asyncio.Queue(maxsize=self._subscriber_maxsize)
+        self._subscribers.append(queue)
+        return HookBusSubscription(bus=self, queue=queue)
+
+    def _unsubscribe(self, queue: "asyncio.Queue[HookEvent]") -> None:
+        try:
+            self._subscribers.remove(queue)
+        except ValueError:
+            pass  # already removed / never registered — close() is idempotent
+
+    def publish(self, event: HookEvent) -> None:
+        """Broadcast ``event`` to every live subscriber. SYNCHRONOUS,
+        non-blocking, never raises: each subscriber gets the SAME
+        :class:`HookEvent` instance (no copy — proposal §3.2's "same instance,
+        simultaneously" requirement), and a full subscriber queue drops its
+        OLDEST unread entry to make room rather than blocking the publisher
+        or dropping the newest broadcast (see module docstring). Zero
+        subscribers → the loop body never runs (the no-subscriber
+        byte-identical happy path)."""
+        for queue in list(self._subscribers):
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                try:
+                    queue.get_nowait()  # drop the oldest to make room
+                except asyncio.QueueEmpty:
+                    pass
+                try:
+                    queue.put_nowait(event)
+                except asyncio.QueueFull:  # pragma: no cover — racing consumer, best-effort
+                    logger.warning(
+                        "HookBus: subscriber queue still full after drop-oldest — "
+                        "broadcast of %r skipped for this subscriber", event.kind,
+                    )
+
+    @property
+    def subscriber_count(self) -> int:
+        """The number of currently-live subscriptions (public, non-private
+        surface for tests/observability — not an internal-state pin)."""
+        return len(self._subscribers)
+
+
+__all__ = ["HookBus", "HookBusSubscription"]

--- a/src/reyn/hooks/dispatcher.py
+++ b/src/reyn/hooks/dispatcher.py
@@ -30,6 +30,7 @@ import json
 import logging
 from typing import Any, Awaitable, Callable
 
+from reyn.hooks.bus import HookBus
 from reyn.hooks.event import HookEvent
 from reyn.hooks.event_pattern import from_legacy_matcher
 from reyn.hooks.event_pattern import matches as event_pattern_matches
@@ -81,8 +82,16 @@ class HookDispatcher:
         cross_session_put: "Callable[..., Any] | None" = None,
         current_session_id: "str | None" = None,
         is_hook_disabled: "Callable[[HookDef], bool] | None" = None,
+        bus: "HookBus | None" = None,
     ) -> None:
         self._registry = registry
+        # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): the optional
+        # per-Session Async Bus. None (the default — every pre-Phase-4a call
+        # site, including every pre-Phase-4a test) keeps dispatch() byte-
+        # identical to before this module existed; when set, dispatch()
+        # broadcasts a copy-free HookEvent to it INDEPENDENTLY of the Sync
+        # hooks_for() loop below (see dispatch()'s docstring).
+        self._bus = bus
         # #2285: per-session hook APPLICABILITY gate — consulted at dispatch time (live) so a hook
         # disabled for THIS session is skipped. Deferred (a callable, not a snapshot) so a toggle
         # applies to the next dispatch without rebuilding the dispatcher. ``None`` → no gate
@@ -168,11 +177,24 @@ class HookDispatcher:
         legitimately be dispatched with an arbitrary/partial dict (tests, and
         any future non-builtin point), and this per-hook-isolation boundary is
         about a HOOK's action failing, not about producer-schema drift.
+
+        Hook-Event Redesign Phase 4a (proposal 0059 §3.2): immediately after
+        constructing ``event``, it is broadcast to this dispatcher's (optional)
+        ``HookBus`` — UNCONDITIONALLY, before the Sync ``hooks_for()`` loop
+        below runs and regardless of whether that loop finds any registered
+        hook for ``point``. This is what makes Sync and Bus independent (§3.2):
+        a Bus-only subscriber observes every dispatched event even with zero
+        Sync hooks configured for ``point``, and a Sync hook's execution below
+        is entirely unaffected by whether any Bus subscriber exists. ``bus is
+        None`` (the default) skips this line — the no-bus happy path stays
+        byte-identical to pre-Phase-4a.
         """
         event = HookEvent(
             kind=canonical_kind(point), payload=template_vars,
             chain_id=template_vars.get("chain_id"),
         )
+        if self._bus is not None:
+            self._bus.publish(event)
         for hook in self._registry.hooks_for(point):
             if self._is_hook_disabled is not None and self._is_hook_disabled(hook):
                 continue  # #2285: hook disabled for THIS session (live applicability toggle)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1376,7 +1376,17 @@ class Session:
         # ``hooks:`` block; None/absent → empty registry → every dispatch() is a
         # no-op (run-loop byte-identical to a hooks-free build). Constructed
         # unconditionally so the 4 lifecycle dispatch() sites are uniform.
+        from reyn.hooks.bus import HookBus
         from reyn.hooks.dispatcher import HookDispatcher
+        # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): one HookBus
+        # PER SESSION, constructed here alongside the HookDispatcher it feeds
+        # and never shared across sessions (§3.3 v1 = per-Session scope — no
+        # cross-session event observation/correlation). No subscriber ever
+        # attaches unless something explicitly calls ``session._hook_bus.
+        # subscribe()`` (nothing does yet in Phase 4a — the Composer, Phase
+        # 4b, is the first consumer) — until then this is a no-op alongside
+        # every dispatch() call (see HookBus.publish's zero-subscriber path).
+        self._hook_bus = HookBus()
         # #2073 S2b: hooks are LAYERED — the reyn.yaml startup layer (OUT-set,
         # captured once here, NEVER re-read on a reload) ∪ the .reyn/hooks.yaml
         # runtime layer (IN-set, hot-reloadable; the LLM-op writes it in S3).
@@ -1425,6 +1435,9 @@ class Session:
             # Lambda defers ``self._chat_events`` (assigned below this point);
             # only called at dispatch time.
             emit_event=lambda et, **d: self._chat_events.emit(et, **d),
+            # Phase 4a: broadcast every dispatched HookEvent to this session's
+            # own bus, independently of the Sync hooks_for() loop above.
+            bus=self._hook_bus,
         )
         # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
         # reapply seam can unschedule jobs removed from the runtime file WITHOUT

--- a/tests/test_hook_event_bus_0059_phase4a.py
+++ b/tests/test_hook_event_bus_0059_phase4a.py
@@ -1,0 +1,264 @@
+"""Tests for the Hook-Event Redesign Phase 4a — the per-Session Async
+``HookBus`` (proposal ``docs/deep-dives/proposals/0059-hook-event-redesign.md``
+§3.2/§3.3).
+
+Coverage plan
+-------------
+Tier 1 (contract): ``HookBus`` — pub/sub broadcast, unit tested directly:
+  every live subscriber observes the SAME published ``HookEvent`` instance
+  (no consume-once semantics — N subscribers each get their own copy of the
+  observation), a closed subscription stops receiving, and zero subscribers
+  is a no-op (``publish`` never raises with none registered).
+Tier 2 (OS invariant, dispatcher-unit): ``HookDispatcher.dispatch`` — driving
+  the REAL dispatcher with an injected ``HookBus``:
+  - Sync happy-path byte-identical: with ``bus=None`` (the default, matching
+    every pre-Phase-4a call site), behavior is unchanged from the Phase 1-3
+    suites (no bus attribute observably touched).
+  - Independence: a Sync-registered hook's action AND the Bus broadcast both
+    fire for the same dispatch (additive, not exclusive); a Bus-only
+    subscriber (point with ZERO Sync hooks registered) still observes the
+    event via the bus.
+Tier 2 (OS invariant, Session-integration): a real ``Session``'s
+  ``_hook_bus`` is per-instance — two independently-constructed sessions get
+  two distinct ``HookBus`` objects, so a subscriber on session A's bus never
+  observes an event dispatched on session B (§3.3 per-Session scope,
+  structural isolation — no cross-session reference exists to observe
+  through).
+Strip-falsify: breaking ``HookBus.publish`` (skip the ``put_nowait`` — i.e.
+  drop the subscriber notification) flips the broadcast test RED; restoring
+  goes GREEN (documented inline in
+  ``test_broadcast_reaches_every_subscriber_same_instance``'s docstring, the
+  strip target for a reviewer to falsify against).
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+_GET_TIMEOUT = 1.0  # bounds every subscription.get() await so a broken/dropped
+# broadcast fails the assertion (RED) rather than hanging pytest forever.
+
+
+async def _get(sub) -> HookEvent:
+    return await asyncio.wait_for(sub.get(), timeout=_GET_TIMEOUT)
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.bus import HookBus
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.event import HookEvent
+from reyn.hooks.registry import HookRegistry
+from reyn.hooks.schema import HookDef, PushBlock
+from reyn.runtime.session import Session
+
+# ---------------------------------------------------------------------------
+# Recording seam (mirrors test_hook_dispatcher_1800_5b.py's _Recorder)
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """A real recording async callable. Captures (args, kwargs) per call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple, dict]] = []
+
+    async def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+    @property
+    def kinds(self) -> list:
+        """The first positional arg of each call (the inbox/stage kind)."""
+        return [a[0] for (a, _k) in self.calls]
+
+
+def _dispatcher(hooks: list[HookDef], *, bus: "HookBus | None" = None) -> tuple[HookDispatcher, dict]:
+    seams = {
+        "put_inbox": _Recorder(),
+        "stage_next_turn_context": _Recorder(),
+        "run_shell": _Recorder(),
+    }
+    disp = HookDispatcher(
+        HookRegistry(hooks),
+        put_inbox=seams["put_inbox"],
+        stage_next_turn_context=seams["stage_next_turn_context"],
+        run_shell=seams["run_shell"],
+        bus=bus,
+    )
+    return disp, seams
+
+
+# ---------------------------------------------------------------------------
+# Tier 1: HookBus pub/sub broadcast — pure unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broadcast_reaches_every_subscriber_same_instance():
+    """Tier 1: publish() delivers the SAME HookEvent instance to every live
+    subscriber, simultaneously — broadcast, not a consume-once queue.
+
+    Strip-falsify target: comment out the ``queue.put_nowait(event)`` line in
+    ``HookBus.publish`` (or replace it with a no-op) — this assertion goes
+    RED (``sub_a.get()``/``sub_b.get()`` never resolve); restoring the
+    put_nowait call goes GREEN again.
+    """
+    bus = HookBus()
+    sub_a = bus.subscribe()
+    sub_b = bus.subscribe()
+    event = HookEvent(kind="builtin:lifecycle:turn_end", payload={"chain_id": "c1"})
+
+    bus.publish(event)
+
+    got_a = await asyncio.wait_for(sub_a.get(), timeout=1.0)
+    got_b = await asyncio.wait_for(sub_b.get(), timeout=1.0)
+    assert got_a is event  # same instance, not a copy
+    assert got_b is event
+    assert got_a is got_b
+
+
+@pytest.mark.asyncio
+async def test_each_subscriber_independently_observes_every_event():
+    """Tier 1: subscriber A reading its event does not consume it for B — each
+    subscription owns its own queue (no shared consume-once state)."""
+    bus = HookBus()
+    sub_a = bus.subscribe()
+    sub_b = bus.subscribe()
+    e1 = HookEvent(kind="builtin:lifecycle:turn_start", payload={})
+    e2 = HookEvent(kind="builtin:lifecycle:turn_end", payload={})
+
+    bus.publish(e1)
+    bus.publish(e2)
+
+    # A drains both before B reads anything — B still sees both, in order.
+    assert await _get(sub_a) is e1
+    assert await _get(sub_a) is e2
+    assert await _get(sub_b) is e1
+    assert await _get(sub_b) is e2
+
+
+@pytest.mark.asyncio
+async def test_closed_subscription_stops_receiving():
+    """Tier 1: closing a subscription detaches it — a later publish() is not
+    delivered to it, and subscriber_count reflects the detach."""
+    bus = HookBus()
+    sub = bus.subscribe()
+    assert bus.subscriber_count == 1
+
+    sub.close()
+    assert bus.subscriber_count == 0
+
+    bus.publish(HookEvent(kind="builtin:lifecycle:turn_end", payload={}))
+    with pytest.raises(asyncio.QueueEmpty):
+        sub.get_nowait()
+
+
+def test_publish_with_no_subscribers_is_a_noop():
+    """Tier 1: publish() with zero live subscribers never raises and touches
+    nothing (the no-subscriber byte-identical happy path, §3.2)."""
+    bus = HookBus()
+    bus.publish(HookEvent(kind="builtin:lifecycle:turn_end", payload={}))  # must not raise
+    assert bus.subscriber_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: HookDispatcher + injected HookBus — Sync happy-path + independence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_bus_none_keeps_the_sync_hook_firing():
+    """Tier 2: the default ``bus=None`` (every pre-Phase-4a call site) drives
+    the exact same Sync behavior as the Phase 1-3 suites — a hook still fires,
+    and no bus-shaped side effect exists to observe."""
+    hook = HookDef(on="turn_end", template_push=PushBlock(message="continue", wake=True))
+    disp, seams = _dispatcher([hook], bus=None)
+
+    await disp.dispatch("turn_end", {})
+
+    assert seams["put_inbox"].kinds == ["hook"]
+
+
+@pytest.mark.asyncio
+async def test_sync_hook_and_bus_broadcast_both_fire_same_dispatch():
+    """Tier 2: independence (§3.2) — a Sync-registered hook's action AND the
+    Bus broadcast both happen for the SAME dispatch() call; neither
+    suppresses the other."""
+    bus = HookBus()
+    sub = bus.subscribe()
+    hook = HookDef(on="turn_end", template_push=PushBlock(message="continue", wake=True))
+    disp, seams = _dispatcher([hook], bus=bus)
+
+    await disp.dispatch("turn_end", {"chain_id": "c1"})
+
+    # Sync side: the hook's push fired.
+    assert seams["put_inbox"].kinds == ["hook"]
+    # Bus side: the SAME dispatch also broadcast a HookEvent.
+    event = await asyncio.wait_for(sub.get(), timeout=1.0)
+    assert event.kind == "builtin:lifecycle:turn_end"
+    assert event.payload["chain_id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_bus_only_subscriber_observes_event_with_zero_sync_hooks():
+    """Tier 2: independence (§3.2) — a point with NO Sync hook registered
+    still broadcasts to the Bus. Proves the Bus is not gated on
+    ``hooks_for(point)`` being non-empty."""
+    bus = HookBus()
+    sub = bus.subscribe()
+    disp, seams = _dispatcher([], bus=bus)  # empty registry — no Sync hook at all
+
+    await disp.dispatch("session_start", {"agent_name": "a"})
+
+    # No Sync side-effect (the no-hooks-equivalence property, unaffected).
+    assert seams["put_inbox"].calls == []
+    assert seams["stage_next_turn_context"].calls == []
+    # But the Bus still observed the dispatch.
+    event = await asyncio.wait_for(sub.get(), timeout=1.0)
+    assert event.kind == "builtin:lifecycle:session_start"
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: real Session — per-Session Bus scope (§3.3)
+# ---------------------------------------------------------------------------
+
+
+def _make_session(tmp_path: Path, *, name: str) -> Session:
+    return Session(
+        agent_name="test-agent",
+        state_log=StateLog(tmp_path / f"{name}.wal"),
+        snapshot_path=tmp_path / f"{name}.json",
+        hooks_config=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_per_session_bus_isolation(tmp_path):
+    """Tier 2: §3.3 per-Session scope — two independently-constructed Sessions
+    each get their OWN bus; a subscriber attached to session A's bus observes
+    only events dispatched on A, never on B. Proven behaviorally (dispatch on
+    A reaches A's subscriber but not B's, and vice versa) rather than by
+    asserting the private ``_hook_bus`` attributes' identity directly."""
+    session_a = _make_session(tmp_path, name="a")
+    session_b = _make_session(tmp_path, name="b")
+
+    sub_a = session_a._hook_bus.subscribe()
+    sub_b = session_b._hook_bus.subscribe()
+
+    await session_a._hook_dispatcher.dispatch("turn_end", {"chain_id": "from-a"})
+
+    event_a = await asyncio.wait_for(sub_a.get(), timeout=1.0)
+    assert event_a.payload["chain_id"] == "from-a"
+    # B's subscription saw nothing from A's dispatch.
+    with pytest.raises(asyncio.QueueEmpty):
+        sub_b.get_nowait()
+
+    await session_b._hook_dispatcher.dispatch("turn_end", {"chain_id": "from-b"})
+    event_b = await asyncio.wait_for(sub_b.get(), timeout=1.0)
+    assert event_b.payload["chain_id"] == "from-b"
+    # A's subscription still only ever saw its own session's event.
+    with pytest.raises(asyncio.QueueEmpty):
+        sub_a.get_nowait()


### PR DESCRIPTION
**[hook-event-coder]** — Hook-Event Redesign **Phase 4a — the per-Session Async Bus** (proposal `docs/deep-dives/proposals/0059-hook-event-redesign.md` §3.2 / §3.3). Phases 1–3 (typed `HookEvent`, Schema Registry, Ingress Adapter, `EventPattern`) already landed; this adds the net-new pub/sub broadcast layer the Composer (Phase 4b) will build on. **Phase 4a delivers the Bus alone** — no Composer, no `emit_hook_event` op, no QueuePolicy/Backpressure.

## Bus design (§3.2 / §3.3)

- **`HookBus` (`src/reyn/hooks/bus.py`)** — a per-Session pub/sub **broadcast** bus for `HookEvent`. `publish(event)` hands the **same** `HookEvent` instance to every live subscriber; **no consume concept** (every subscriber sees every event). `subscribe()` returns a `HookBusSubscription` handle (its own bounded queue; `get()`/`get_nowait()`/`close()`, usable as an async context manager). Naming avoids collision with `reyn.core.events` (P6 audit) at the identifier level — same discipline as `HookEvent`.
- **Non-blocking, bounded by construction** — `publish` is synchronous and never blocks the publisher; each subscriber owns its own bounded queue (drop-oldest on overflow) so a slow subscriber can't starve a fast one. Mirrors the Ingress bridge's non-blocking overflow discipline one layer up.
- **Per-Session ownership (§3.3 v1)** — one `HookBus` constructed in `Session.__init__` (`self._hook_bus`), injected into that Session's `HookDispatcher` (`bus=`). Never shared across sessions → cross-session observation is structurally impossible (a v1 non-goal).
- **Attach point — independent of Sync (§3.2)** — `HookDispatcher.dispatch()` publishes the constructed `HookEvent` to its (optional) bus **unconditionally**, *before* the Sync `hooks_for()` loop and *regardless* of whether any Sync hook is registered for the point. So the same `builtin:external:mcp_resource_updated` can be Sync-registered for a side-effect **and** Bus-subscribed for observation — additive, not mutually exclusive. A Bus-only subscriber observes every dispatched event even with zero Sync hooks.

## Sync happy-path byte-identical

- `HookDispatcher(bus=None)` is the default — every pre-Phase-4a call site and test constructs the dispatcher exactly as before; the publish line is skipped, so `dispatch()` is byte-identical to pre-Phase-4a.
- `HookBus.publish()` with **zero subscribers** iterates an empty list — a pure no-op (the no-subscriber byte-identical happy path). Constructing a bus and never subscribing is behaviorally indistinguishable from not having one.
- The existing hook suite + Phase 1–3 tests stay green **unmodified**: `pytest -k hook` → **350 passed, 3 skipped**.

## §0 scope boundary

The Bus carries **hook-events ONLY** — it does NOT route through the P6 `EventLog` subscriber path (audit-event) and is never confused with it (CLAUDE.md 3-event rule). Out of scope for 4a: Composer (4b), `emit_hook_event` op (Phase 5), QueuePolicy/Backpressure.

## Tests (`tests/test_hook_event_bus_0059_phase4a.py`, 8 tests, real instances — no mocks)

- **Broadcast** — a published `HookEvent` reaches all N subscribers as the **same instance** (`is`); each subscription independently observes every event (no consume-once).
- **Independence** — a Sync-registered hook's action AND the Bus broadcast both fire for the same `dispatch()`; a Bus-only subscriber observes an event on a point with **zero** Sync hooks registered.
- **Per-Session** — two independently-constructed real `Session`s: a subscriber on A's bus observes only A's dispatched events, never B's (proven behaviorally, not by private-attr identity).
- **No-subscriber no-op** + **closed-subscription-stops-receiving** + **`bus=None` keeps the Sync hook firing**.
- **Strip-falsify** — replacing `HookBus.publish`'s `queue.put_nowait(event)` with a no-op (drop the subscriber notification) turns the 5 broadcast/independence/per-Session tests **RED** (`TimeoutError` on `get()`); restoring goes **GREEN**. Verified both directions.

## CI gates (all 4, local)

- `ruff check src tests` → **All checks passed!**
- `python scripts/test_tier_audit.py --strict tests/test_hook_event_bus_0059_phase4a.py` → **8/8 OK, 0 warnings, 0 errors** (Tier declared per docstring; behavioral assertions only, no private-state pins).
- `python scripts/verify_module_docstrings.py <changed src>` → **OK**.
- `pytest` (full suite, local) → **8248 passed, 20 skipped, 0 failures** (216s). New bus file 8 passed; `pytest -k hook` 350 passed, 3 skipped.

## Test plan

- [x] `pytest -k hook` green (350 passed, 3 skipped) — Sync happy-path + Phase 1–3 unchanged.
- [x] Strip-falsify RED→GREEN verified both directions.
- [x] All 4 CI gates run locally (ruff / tier-audit / module-docstrings / full pytest — all green).

Part of the Hook-Event Redesign arc (proposal 0059). Composer (Phase 4b) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
