### PR TITLE
ci: add `uv lock --check` gate to close the manifest↔lock drift class (#2852)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,8 +97,19 @@ jobs:
       # No existing workflow installs uv (test/lint/docs jobs all use pip),
       # so this uses astral-sh's official setup-uv action — the canonical
       # install path for uv in GitHub Actions.
+      #
+      # version is pinned (not floating-latest): uv is pre-1.0 and has
+      # historically bumped the lockfile format across minor releases. This
+      # is a required, merge-blocking gate — an unpinned auto-upgrade of uv
+      # could make `uv lock --check` spuriously reject the committed
+      # (format-stable) uv.lock and block every unrelated PR. 0.11.28 is the
+      # version this gate is currently green against; bump deliberately,
+      # together with `[tool.uv].required-version` in pyproject.toml, if
+      # uv.lock is ever re-locked with a newer uv.
       - name: Install uv
         uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.11.28"
 
       # Fails if uv.lock has drifted from pyproject.toml (#2852: two silent
       # drifts merged with no gate catching them — a fastmcp promotion

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,26 @@ jobs:
       - name: Build docs (strict)
         run: mkdocs build --strict -f .mkdocs/mkdocs.yml
 
+  lock-check:
+    name: uv lock --check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # No existing workflow installs uv (test/lint/docs jobs all use pip),
+      # so this uses astral-sh's official setup-uv action — the canonical
+      # install path for uv in GitHub Actions.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      # Fails if uv.lock has drifted from pyproject.toml (#2852: two silent
+      # drifts merged with no gate catching them — a fastmcp promotion
+      # without re-lock, and a near-miss chainlit-extra removal).
+      - name: Check uv.lock is up to date
+        run: uv lock --check
+
   audit:
     name: test-tier audit
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,14 @@ sample_line = "reyn.gateway.sample_line:register_router"
 # When the SDK isn't installed, ``register_router`` returns ``None``
 # with a clear log message so reyn boots without crashing.
 
+[tool.uv]
+# Keep local `uv lock` runs compatible with the CI `lock-check` gate's pinned
+# uv version (see .github/workflows/test.yml). uv is pre-1.0 and has bumped
+# the lockfile format across minor releases; without this, a contributor
+# on a newer/older uv minor could re-lock uv.lock into a format the
+# CI-pinned uv rejects, making a locally-green `uv lock --check` fail in CI.
+required-version = ">=0.11,<0.12"
+
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]


### PR DESCRIPTION
**[lead-coder]** — Closes #2852.

Adds a `lock-check` job to `.github/workflows/test.yml` that runs `uv lock --check`, failing CI if `uv.lock` has drifted from `pyproject.toml`. This closes the manifest↔lock drift class that previously let two silent drifts merge with no gate catching them (a fastmcp core promotion without re-lock, and a near-miss chainlit-extra removal, per #2850).

## Details

- **Main was already in sync** — `uv lock --check` passes clean on `main` (#2850's re-lock holds). No `uv.lock` changes needed in this PR; the gate starts green.
- **uv install method**: no existing workflow in `.github/workflows/` installs `uv` (the `test` / `lint` / `docs` jobs all use `pip install -e ".[...]"` directly against the system Python). Since there was no existing in-repo pattern to reuse, this job uses the official `astral-sh/setup-uv@v5` action — the canonical GitHub Actions install path for `uv`.
- Job is a separate lightweight job (`lock-check`, name `uv lock --check`), mirroring how `ruff` / `test-tier audit` / `docs build` are each their own job in this workflow. `timeout-minutes: 5`. Only step is checkout → install uv → `uv lock --check`.
- No application code, tests, dependency declarations, or `uv.lock` touched — `.github/workflows/test.yml` and `pyproject.toml` (`[tool.uv]` only) touched.

## Determinism hardening (pre-merge review finding)

The initial version of this PR used `astral-sh/setup-uv@v5` with no `version:` pinned, so CI would install whatever uv is currently latest on every run. Because `lock-check` is a **required, merge-blocking** gate, and uv is pre-1.0 (has bumped the lockfile format across minor releases before), an unpinned auto-upgrade of uv could make `uv lock --check` spuriously reject the committed, format-stable `uv.lock` — blocking every unrelated PR until someone re-locks. A deterministic hygiene gate must not itself be non-deterministic. Fixed both sides:

1. **Pinned the gate's uv version** — `astral-sh/setup-uv@v5` now takes `version: "0.11.28"`, the exact version this gate's own CI run on this branch installed and passed against (`Successfully installed uv version 0.11.28`, confirmed from the job log). Bumping this pin is now a deliberate, reviewed action, not silent drift.
2. **Added `[tool.uv] required-version = ">=0.11,<0.12"` to `pyproject.toml`** — keeps a contributor's local `uv lock` on a uv minor compatible with the CI-pinned 0.11.28, so local and CI lock output stay in agreement (a contributor on uv 0.12+ locally would otherwise risk producing a lock format the CI-pinned uv rejects). Range rather than an exact pin so patch releases within 0.11.x don't force every contributor to match the CI patch version exactly. Verified this range doesn't break the current local dev environment (locally installed uv 0.11.15 satisfies it and `uv lock --check` still passes clean).

## Falsification check (gate actually bites)

Locally bumped `pydantic>=2.0` → `pydantic>=2.5` in `pyproject.toml` (no re-lock) and re-ran `uv lock --check`: it failed with exit 1 ("The lockfile at `uv.lock` needs to be updated"). Reverted the change and re-ran: exit 0. Confirms the check is a real gate, not a no-op.

## Test plan

- [x] `uv lock --check` passes locally on this branch (gate starts green — main was already in sync via #2850)
- [x] `uv lock --check` still passes after adding the version pin + `required-version` (verified with local uv 0.11.15, which satisfies the new `>=0.11,<0.12` range)
- [x] `ruff check src tests` passes (unaffected — no src/tests changes)
- [x] (skipped — CI-config-only change, no application logic) full `pytest` run
- [x] Verified the gate goes red on an intentional lock drift (see Falsification check above) and green again once reverted — strong witness the gate actually catches manifest↔lock drift, not just a passthrough
- [x] Verified in live CI: the `lock-check` job ran on this branch and passed, installing uv 0.11.28 (job log: "Successfully installed uv version 0.11.28") — confirms the pin resolves and the gate is green in the Actions runner, not just locally
