### PR TITLE
docs(tools): point hooks_add at the full hook syntax reference

### DIFF
--- a/src/reyn/tools/descriptions/hooks.py
+++ b/src/reyn/tools/descriptions/hooks.py
@@ -29,7 +29,9 @@ hooks_add = ToolDescription(
         "or a context-inject). The hook is written to your runtime hooks layer "
         "(.reyn/config/hooks.yaml) and applied at the next turn boundary — it joins your existing "
         "hooks additively. Use for self-directed continuation or recurring injected "
-        "context. Cannot touch startup config (reyn.yaml is restart-only)."
+        "context. Cannot touch startup config (reyn.yaml is restart-only). "
+        "For the full on: vocabulary, matcher, composers:, emit_hook_event, and every "
+        "scheme's fields, see the hooks concept doc at docs/concepts/runtime/hooks.md."
     ),
     ja=(
         "エージェントのライフサイクルポイント（turn_end の自己継続や"
@@ -38,6 +40,9 @@ hooks_add = ToolDescription(
         "次のターン境界で適用される（既存フックに追加される）。自己主導"
         "の継続や定期的なコンテキスト注入に使う。起動時設定"
         "（reyn.yaml、再起動時のみ反映）には触れられない。"
+        "on: の全語彙・matcher・composers:・emit_hook_event・各スキームの"
+        "全フィールドの完全な構文は docs/concepts/runtime/hooks.md（hooks コンセプト"
+        "ドキュメント）を参照。"
     ),
 )
 

--- a/tests/tools/_pre_migration_tool_schemas_baseline.json
+++ b/tests/tools/_pre_migration_tool_schemas_baseline.json
@@ -519,7 +519,7 @@
   },
   "hooks_add": {
     "function": {
-      "description": "Add a push hook at an agent-lifecycle point (e.g. a turn_end self-continuation, or a context-inject). The hook is written to your runtime hooks layer (.reyn/config/hooks.yaml) and applied at the next turn boundary — it joins your existing hooks additively. Use for self-directed continuation or recurring injected context. Cannot touch startup config (reyn.yaml is restart-only).",
+      "description": "Add a push hook at an agent-lifecycle point (e.g. a turn_end self-continuation, or a context-inject). The hook is written to your runtime hooks layer (.reyn/config/hooks.yaml) and applied at the next turn boundary — it joins your existing hooks additively. Use for self-directed continuation or recurring injected context. Cannot touch startup config (reyn.yaml is restart-only). For the full on: vocabulary, matcher, composers:, emit_hook_event, and every scheme's fields, see the hooks concept doc at docs/concepts/runtime/hooks.md.",
       "name": "hooks_add",
       "parameters": {
         "properties": {


### PR DESCRIPTION
**[lead-coder]** — Small discoverability follow-up to the hooks-event redesign work: `hooks_add`'s LLM-facing description now points an agent at the full hook syntax reference.

## Change
`src/reyn/tools/descriptions/hooks.py` — append ONE sentence to `hooks_add`'s `.text` (English, LLM-facing) and `.ja` (human-facing translation) directing to the hooks concept doc.

**EN** (appended to `.text`):
> For the full on: vocabulary, matcher, composers:, emit_hook_event, and every scheme's fields, see the hooks concept doc at docs/concepts/runtime/hooks.md.

**JA** (appended to `.ja`):
> on: の全語彙・matcher・composers:・emit_hook_event・各スキームの全フィールドの完全な構文は docs/concepts/runtime/hooks.md（hooks コンセプトドキュメント）を参照。

Cites the doc path directly (agents read a repo file with their normal file-read capability — no doc-reading tool name asserted).

## Baseline update
Editing the LLM-facing `.text` changes the rendered tool schema, so `tests/tools/test_tool_description_relocation.py::test_full_schema_contract_matches_baseline` would fail against the frozen baseline. Updated `tests/tools/_pre_migration_tool_schemas_baseline.json` the same minimal way #2885 did: a single targeted textual edit to ONLY the `hooks_add` entry's `description` string — no full regen, no reformatting. The diff is a one-line change; every other tool's frozen schema stays byte-identical.

## Gates (local)
- `ruff check src tests` — pass
- `python scripts/verify_module_docstrings.py src/reyn/tools/descriptions/hooks.py` — pass
- `test_tool_description_relocation.py` — 3 passed
- registry flagset / external-content tests (`-k flagset`) — 84 passed, 2 skipped
- Full `pytest` — **CI runs the full suite on push**; this change only edits `hooks_add`'s LLM-facing text + its baseline entry (no logic change), so risk is contained to the tool-description tests, which pass locally.

## Test plan
- [x] `test_full_schema_contract_matches_baseline` passes with updated baseline
- [x] baseline diff is hooks_add-only (verified via `git diff`)
- [x] EN `.text` is English; JA is the translation
- [x] (skipped — CI-delegated) full local pytest; CI runs the full suite on push

No `Closes` — discoverability follow-up to the hooks doc work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)