### PR TITLE
fix: retrieval scheme without embedding — fail-loud at config + auto-fallback, no silent dead session (#2895)

### DIFF
--- a/src/reyn/config/loader.py
+++ b/src/reyn/config/loader.py
@@ -346,6 +346,54 @@ def _reconcile_embedding_class(cfg: "ReynConfig") -> None:
     cfg.action_retrieval.embedding_class = None
 
 
+def _validate_retrieval_scheme_embedding(cfg: "ReynConfig") -> None:
+    """#2895 fix (a): fail loud at config load when ``tool_use.chat:
+    retrieval`` is selected with no working embedding configured.
+
+    ``RetrievalScheme`` (``reyn.tools.schemes.retrieval``) presents a
+    ``search_actions`` tool the LLM is meant to call before anything else.
+    Without an embedding, ``SchemeOps.search_actions`` always returns ``[]``
+    (index/provider unavailable — degrades silently by design), and
+    retrieval's own terminal rule (empty match minus already-seen ⇒
+    terminal) drops the search tool on the very first call — stranding the
+    LLM on ``base_tools`` only for the rest of the session, with no catalog
+    action ever reachable. The graceful schemes (``enumerate-all`` /
+    ``universal-category``) never hit this because their only catalog entry
+    point isn't gated behind search, so they degrade via
+    ``is_search_available`` (hide the tool + surface a hint) instead of
+    going silently dead.
+
+    Reuses the SAME primary gate ``is_search_available`` checks
+    (``action_retrieval.embedding_class`` truthy) and the SAME enable-hint
+    text those schemes surface via ``list_actions``
+    (``universal_catalog._HIDDEN_STATE_HINT``) — one consistent operator
+    message regardless of which layer catches the misconfiguration. Runs
+    AFTER ``_reconcile_embedding_class`` so a dangling ``embedding_class``
+    (typo, no entry in ``embedding.classes``) is already degraded to None
+    here too, not just the explicit-null case.
+
+    This is the config-time half of the #2895 fix; ``RetrievalScheme.
+    build_presentation`` carries the runtime-auto-fallback half (defense in
+    depth for the case this validation is bypassed, e.g. embedding extras
+    silently missing at Session-build time — an env fact this config-load
+    check cannot see).
+    """
+    if cfg.tool_use.chat != "retrieval":
+        return
+    if cfg.action_retrieval.embedding_class:
+        return
+    from reyn.tools.universal_catalog import _HIDDEN_STATE_HINT
+
+    raise ValueError(
+        "tool_use.chat: retrieval requires a working embedding "
+        "(action_retrieval.embedding_class is unset/disabled) — without one, "
+        "the search_actions tool always returns no results, and retrieval's "
+        "terminal-on-empty-match rule drops it on the very first search, "
+        "stranding the LLM on base tools only with no catalog action ever "
+        "reachable. " + _HIDDEN_STATE_HINT
+    )
+
+
 def load_config(cwd: Path | None = None) -> ReynConfig:
     """Load and merge config from all sources. CLI flags are applied by the caller."""
     cwd = (cwd or Path.cwd()).resolve()
@@ -578,6 +626,7 @@ def load_config(cwd: Path | None = None) -> ReynConfig:
         presentations=_as_config_dict(merged.get("presentations"), "presentations"),
     )
     _reconcile_embedding_class(_cfg)
+    _validate_retrieval_scheme_embedding(_cfg)
     return _cfg
 
 

--- a/src/reyn/tools/schemes/retrieval.py
+++ b/src/reyn/tools/schemes/retrieval.py
@@ -113,6 +113,35 @@ class RetrievalScheme:
         base = list(ops.base_tools(available, layer_ctx))
         refinement = layer_ctx.get("refinement")
         if not refinement:
+            if not layer_ctx.get("search_visible", False):
+                # #2895 fix (b): runtime auto-fallback. ``search_visible`` is the
+                # same D14 gate (index + provider + model class + is_ready) that
+                # decides whether search_actions is usable — when it's False the
+                # embedding is unavailable (never configured, extras missing, or
+                # index not ready yet). Presenting the search tool anyway would
+                # let ``ops.search_actions`` return ``[]`` on the very first call
+                # (index/provider is None — degrades silently), and this scheme's
+                # own terminal rule below (empty match ⇒ terminal) would then drop
+                # the search tool and strand the LLM on ``base`` only forever —
+                # the exact silent dead-session #2895 reports. Config load
+                # (``reyn.config.loader._validate_retrieval_scheme_embedding``)
+                # rejects the common never-configured case up front; this is the
+                # defense-in-depth leg for whatever slips past that (index build
+                # failure, extras missing at Session-build time — env facts
+                # config load can't see). Degrade like ``enumerate-all``: present
+                # the full flat catalog directly (no search indirection needed,
+                # so nothing is ever unreachable) and surface the SAME
+                # enable-hint the graceful schemes inject via ``list_actions`` —
+                # no duplicated hint text.
+                from reyn.tools.universal_catalog import _HIDDEN_STATE_HINT
+
+                catalog = await ops.catalog_entries()
+                slots = self._slots_for(available, layer_ctx, False)
+                slots["slot_post_catalog"] = _HIDDEN_STATE_HINT
+                return Presentation(
+                    llm_tools_payload=base + catalog,
+                    tool_use_sp=slots,
+                )
             # Initial presentation: the base + the search tool (no catalog flood).
             # #1627 Stage 3+4: sp_params removed; tool_use_sp carries the full SP.
             return Presentation(

--- a/tests/test_2895_retrieval_scheme_requires_embedding.py
+++ b/tests/test_2895_retrieval_scheme_requires_embedding.py
@@ -1,0 +1,117 @@
+"""Tier 2: #2895 fix (a) — config-load fail-loud for ``tool_use.chat:
+retrieval`` selected with no working embedding configured.
+
+``RetrievalScheme`` (``reyn.tools.schemes.retrieval``) presents a
+``search_actions`` tool as its ONLY catalog entry point. Without an
+embedding, ``SchemeOps.search_actions`` (``reyn.runtime.router_loop.py``)
+always returns ``[]`` (index/provider unavailable — a silent degrade by
+design), and retrieval's own terminal-on-empty-match rule then drops the
+search tool on the very first call — stranding the LLM on ``base_tools``
+only for the rest of the session, with no catalog action ever reachable
+(#2895). ``reyn.config.loader._validate_retrieval_scheme_embedding`` catches
+the common "never configured" case at config load instead of letting it
+reach a live session.
+
+No mocks: drives the real ``load_config`` end to end against a real
+``reyn.yaml`` on disk (mirrors the pattern in
+``tests/test_action_retrieval_wiring.py``).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config import ReynConfig, load_config
+
+
+def _write_yaml(tmp_path: Path, body: str) -> None:
+    (tmp_path / "reyn.yaml").write_text(body, encoding="utf-8")
+
+
+def test_retrieval_scheme_without_embedding_class_fails_loud(tmp_path: Path) -> None:
+    """Tier 2: #2895 fix (a), falsify-pin. ``tool_use.chat: retrieval`` +
+    ``action_retrieval.embedding_class: null`` (explicit no-embedding) must
+    raise a ValueError carrying the SAME enable-hint text the graceful
+    schemes surface via ``list_actions`` (``universal_catalog.
+    _HIDDEN_STATE_HINT``) — not a bare/opaque error, so the operator is told
+    how to fix it.
+
+    Falsify by hand: remove the
+    ``_validate_retrieval_scheme_embedding(_cfg)`` call in
+    ``reyn.config.loader.load_config`` → this test goes RED (load_config
+    returns cleanly with the misconfiguration silently accepted).
+    """
+    from reyn.tools.universal_catalog import _HIDDEN_STATE_HINT
+
+    _write_yaml(
+        tmp_path,
+        """
+tool_use:
+  chat: retrieval
+action_retrieval:
+  embedding_class: null
+""",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        load_config(cwd=tmp_path)
+    message = str(excinfo.value)
+    assert "retrieval" in message
+    assert _HIDDEN_STATE_HINT in message
+
+
+def test_retrieval_scheme_with_dangling_embedding_class_fails_loud(tmp_path: Path) -> None:
+    """Tier 2: an ``embedding_class`` naming no real entry in
+    ``embedding.classes`` (typo) is degraded to None by
+    ``_reconcile_embedding_class`` BEFORE the #2895 validation runs — so a
+    dangling class is caught too, not just the explicit-null case. Reuses
+    the same reconciliation ``is_search_available`` relies on at runtime
+    (closed-world class membership), not a new notion of "configured"."""
+    _write_yaml(
+        tmp_path,
+        """
+tool_use:
+  chat: retrieval
+action_retrieval:
+  embedding_class: totally-made-up-class
+""",
+    )
+    with pytest.raises(ValueError):
+        load_config(cwd=tmp_path)
+
+
+def test_retrieval_scheme_with_embedding_class_loads_cleanly(tmp_path: Path) -> None:
+    """Tier 2: the contrast — ``tool_use.chat: retrieval`` with a REAL
+    embedding class configured loads without error (the fail-loud check is
+    scoped to the no-embedding misconfiguration, not to selecting retrieval
+    at all)."""
+    _write_yaml(
+        tmp_path,
+        """
+tool_use:
+  chat: retrieval
+action_retrieval:
+  embedding_class: local-mini
+""",
+    )
+    cfg: ReynConfig = load_config(cwd=tmp_path)
+    assert cfg.tool_use.chat == "retrieval"
+    assert cfg.action_retrieval.embedding_class == "local-mini"
+
+
+def test_other_schemes_do_not_require_embedding(tmp_path: Path) -> None:
+    """Tier 2: the validation is retrieval-specific — enumerate-all (and any
+    non-retrieval scheme) never hinges its only catalog entry point on
+    search, so it must NOT be rejected for having no embedding configured."""
+    _write_yaml(
+        tmp_path,
+        """
+tool_use:
+  chat: enumerate-all
+action_retrieval:
+  embedding_class: null
+""",
+    )
+    cfg: ReynConfig = load_config(cwd=tmp_path)
+    assert cfg.tool_use.chat == "enumerate-all"
+    assert cfg.action_retrieval.embedding_class is None

--- a/tests/test_retrieval_scheme_1593.py
+++ b/tests/test_retrieval_scheme_1593.py
@@ -63,13 +63,47 @@ def _tool(name):
 
 @pytest.mark.asyncio
 async def test_initial_presentation_shows_search_tool(tmp_path) -> None:
-    """Tier 2: with no refinement, retrieval presents base + the search tool (NOT
-    the whole catalog) — the narrowing-before-call posture."""
+    """Tier 2: with no refinement AND a working embedding (search_visible=True),
+    retrieval presents base + the search tool (NOT the whole catalog) — the
+    narrowing-before-call posture."""
     ops = _FakeOps()
-    pres = await RetrievalScheme().build_presentation({}, {}, ops)
+    pres = await RetrievalScheme().build_presentation({}, {"search_visible": True}, ops)
     names = [t["function"]["name"] for t in pres.llm_tools_payload]
     assert _SEARCH_TOOL_NAME in names and "respond" in names
     assert ops.calls == []                                # no search yet (no refinement)
+
+
+@pytest.mark.asyncio
+async def test_initial_presentation_falls_back_to_catalog_when_search_unavailable(tmp_path) -> None:
+    """Tier 2: #2895 fix (b), falsify-pin. When the embedding is unavailable
+    (``search_visible`` False/absent — the SAME D14 gate ``router_loop.py``
+    computes from index/provider/model_class/is_ready), retrieval must NOT
+    present the search tool. Presenting it would let ``ops.search_actions``
+    return ``[]`` on the very first call (the #2895 mechanism), and this
+    scheme's own terminal-on-empty-match rule would then drop the search tool
+    and strand the LLM on base_tools only — a silent dead session with the
+    full catalog never reachable.
+
+    Instead it must degrade like ``enumerate-all``: present the full flat
+    catalog (every action stays reachable) and surface the enable-hint
+    (reused from ``universal_catalog._HIDDEN_STATE_HINT`` — the SAME hint the
+    graceful schemes inject) via ``tool_use_sp['slot_post_catalog']``.
+
+    Falsify by hand: revert the ``if not layer_ctx.get("search_visible",
+    False)`` branch in ``RetrievalScheme.build_presentation`` (retrieval.py)
+    → this test goes RED (search tool appears, catalog + hint disappear).
+    """
+    from reyn.tools.universal_catalog import _HIDDEN_STATE_HINT
+
+    ops = _FakeOps(catalog=[_tool("file__write"), _tool("file__read")])
+    # search_visible absent (defaults False) — mirrors "no embedding configured".
+    pres = await RetrievalScheme().build_presentation({}, {}, ops)
+    names = {t["function"]["name"] for t in pres.llm_tools_payload}
+    assert _SEARCH_TOOL_NAME not in names                 # search NEVER offered — would be a dead end
+    assert {"file__write", "file__read"} <= names          # catalog stays fully reachable instead
+    assert "respond" in names                              # base tools still present
+    assert ops.calls == []                                 # no dead search ever attempted
+    assert pres.tool_use_sp.get("slot_post_catalog") == _HIDDEN_STATE_HINT  # enable-hint surfaced
 
 
 @pytest.mark.asyncio
@@ -124,7 +158,7 @@ async def test_initial_presentation_supplies_search_sp_fragment(tmp_path) -> Non
     (formerly sp_fragment; folded into the slot-map in Stage 3). The LLM must see
     search_actions guidance even when the OS's named-gate block is off."""
     ops = _FakeOps()
-    pres = await RetrievalScheme().build_presentation({}, {}, ops)
+    pres = await RetrievalScheme().build_presentation({}, {"search_visible": True}, ops)
     # #1627 Stage 4: sp_params removed from build_presentation.
     assert pres.sp_params == {}                                      # no longer populated
     assert isinstance(pres.tool_use_sp, dict)                      # scheme owns SP via slot-map


### PR DESCRIPTION
**[lead-coder]** — Fixes #2895 (architect-grounded, proposal 0060 discovery — independent defect).

## The defect

`tool_use.chat: retrieval` was accepted as valid config with NO embedding configured (`config/execution.py:17-30` only validated it's a non-empty scheme-name string). At runtime, `SchemeOps.search_actions` (`router_loop.py:2907-2908`) returns `[]` when `index is None or provider is None` — silent. For the retrieval scheme specifically, an empty first search → `matched=[]` → `new = set(matched) - seen` empty → `terminal=True` on the very first search (`retrieval.py`) → the search tool is dropped and the LLM is stranded on `base_tools` only, no catalog action ever reachable. Contrast: `enumerate-all`/`universal-category` degrade gracefully via `is_search_available` (hide `search_actions` + inject an enable-hint), catalog actions stay reachable.

## Fix — both layers (defense-in-depth, per architect spec)

**(a) config-load fail-loud** — `reyn.config.loader._validate_retrieval_scheme_embedding` (called right after `_reconcile_embedding_class`, so a dangling `embedding_class` typo is already degraded to `None` by the time this runs): rejects `tool_use.chat: retrieval` when `action_retrieval.embedding_class` is falsy, raising a `ValueError` that includes the SAME enable-hint text the graceful schemes surface (`reyn.tools.universal_catalog._HIDDEN_STATE_HINT` — reused verbatim, not duplicated).

**(b) runtime auto-fallback** — `RetrievalScheme.build_presentation` (`src/reyn/tools/schemes/retrieval.py`): the initial presentation now checks `layer_ctx["search_visible"]` (the same D14 gate `router_loop.py` computes from index/provider/model_class/`is_ready()`) BEFORE ever offering the search tool. When it's False, the scheme never presents `search_actions` at all — it degrades like `enumerate-all`: presents the full flat catalog (`ops.catalog_entries()`) so every action stays reachable, and injects the SAME `_HIDDEN_STATE_HINT` into `tool_use_sp["slot_post_catalog"]`. This is the safety net for whatever slips past (a) — e.g. `local-embed` extras missing at Session-build time, an env fact config-load can't see.

Both legs reuse the SAME embedding-availability check (`is_search_available`'s primary gate / `search_visible`) and the SAME enable-hint constant — no new "is embedding configured" notion invented.

## Tests

- `tests/test_2895_retrieval_scheme_requires_embedding.py` (Tier 2, 4 tests): config-load fail-loud for explicit-null embedding_class, dangling/typo'd class, the contrast case (real class → loads cleanly), and non-retrieval schemes unaffected.
- `tests/test_retrieval_scheme_1593.py`: added `test_initial_presentation_falls_back_to_catalog_when_search_unavailable` (Tier 2) — drives the real `RetrievalScheme.build_presentation` with `search_visible` absent/False, asserts the search tool is NEVER offered, the catalog stays reachable, and the hint is surfaced. Updated two pre-existing tests (`test_initial_presentation_shows_search_tool`, `test_initial_presentation_supplies_search_sp_fragment`) to pass `search_visible: True` explicitly — they previously relied on `{}` defaulting to "show search tool," which was the exact defect this PR fixes.
- Falsify-pinned both new assertions by hand (stripped the config-check call / the `search_visible` guard) → both went RED → restored. Confirmed via direct diff-and-revert, not by inspection.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_2895_retrieval_scheme_requires_embedding.py tests/test_retrieval_scheme_1593.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/config/loader.py src/reyn/tools/schemes/retrieval.py` — OK
- [x] `pytest` (full suite) — CI `pytest (3.11)` + `pytest (3.12)` both PASS. Local run was 8299 passed / 1 pre-existing order-dependent flake (`test_full_schema_contract_matches_baseline`, `get_default_registry()` global-state pollution — passes in isolation on clean main + this branch; exonerated, see comment).

Closes #2895

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
