### PR TITLE
feat: proposal 0060 Phase 1 — F1 backbone (part-type meta-registry SSoT + OS-authoritative provenance + OS-frame routing)

### DIFF
--- a/src/reyn/core/part_type_registry.py
+++ b/src/reyn/core/part_type_registry.py
@@ -1,0 +1,140 @@
+"""reyn.core.part_type_registry — the part-type meta-registry (proposal
+``docs/deep-dives/proposals/0060-llm-wielding-foundation.md`` §2.4/§3 F1).
+
+Today skills / pipelines / MCP servers / hooks / presentations each have their
+own separate registry (``reyn.data.skills.registry``,
+``reyn.data.pipelines.registry``, the MCP server roster on
+``RouterHostAdapter.get_mcp_servers``, ``reyn.hooks.loader.load_hooks``,
+``reyn.data.presentations.registry``) with no unified enumeration — there is
+no single place that lists "every kind of part reyn has" alongside the
+input/workflow/output role(s) it plays (proposal §2.1) or the catalog
+category it belongs to. This module is that single place.
+
+Mirrors the ``OP_KIND_MODEL_MAP`` (``reyn.schemas.models``) /
+``BUILTIN_HOOK_SCHEMAS`` (``reyn.hooks.schema_registry``) pattern: a plain
+code-shipped ``dict`` literal that other things DERIVE from, never a
+hand-curated duplicate list kept in sync by hand. ``PART_TYPE_REGISTRY``
+below is that dict; ``registry_ref`` on each entry POINTS AT the real
+per-part-type registry (a dotted ``module:qualname`` string) rather than
+importing/calling it eagerly — every real registry needs different
+construction arguments (a config dict, a project root, ...), so the
+meta-registry stays a lightweight index of WHERE the real registry lives, not
+a re-implementation of it.
+
+Three declared consumers (proposal §3 F1, none built here — this module only
+has to make them possible):
+
+1. the taxonomy CI gate (``tests/test_part_type_registry_taxonomy_0060.py``)
+   walks this dict and fails if any entry lacks a non-empty ``category`` —
+   registry-derived completeness, so a new part-type with no assigned
+   category turns the gate red instead of silently shipping uncatalogued.
+2. a future builtin-tier (proposal F3, NOT built in this phase) populates
+   catalog content per part-type using this as its part-type index.
+3. the live action catalog (``reyn.tools.universal_catalog``) can eventually
+   read this to keep its category set in sync with the part-type set — NOT
+   done in this phase (this module does not touch ``CATEGORIES``; see the
+   module-level note in that file). Wiring the two together is a follow-up
+   fork, not part of the meta-registry's own shape.
+
+``task`` is deliberately excluded (proposal §2.1: "task is excluded —
+deprecating").
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# The three roles a part can play (proposal §2.1 — not exclusive bins; a part
+# may play more than one, e.g. ``mcp`` plays all three).
+PART_ROLES: tuple[str, ...] = ("input", "workflow", "output")
+
+
+@dataclass(frozen=True)
+class PartTypeSpec:
+    """One row of the part-type meta-registry.
+
+    ``roles`` — subset of ``PART_ROLES`` this part-type plays (§2.1).
+    ``category`` — the catalog/taxonomy category label this part-type is
+        filed under. Required non-empty (the taxonomy gate's invariant).
+    ``registry_ref`` — ``"module:qualname"`` pointing at the REAL
+        per-part-type registry/loader this part-type's live instances are
+        enumerated from. Documentation + gate-walk target only; the
+        meta-registry never imports or calls it, so adding a part-type here
+        never requires that its real registry be import-safe at meta-registry
+        import time.
+    ``description`` — one-line human-facing summary of what this part-type is.
+    """
+
+    name: str
+    roles: frozenset[str]
+    category: str
+    registry_ref: str
+    description: str
+
+
+def _spec(
+    name: str, roles: tuple[str, ...], category: str, registry_ref: str, description: str
+) -> PartTypeSpec:
+    unknown = set(roles) - set(PART_ROLES)
+    if unknown:
+        raise ValueError(f"part-type {name!r} declares unknown role(s) {sorted(unknown)}")
+    return PartTypeSpec(
+        name=name,
+        roles=frozenset(roles),
+        category=category,
+        registry_ref=registry_ref,
+        description=description,
+    )
+
+
+# ── The meta-registry itself ────────────────────────────────────────────────
+PART_TYPE_REGISTRY: dict[str, PartTypeSpec] = {
+    "skill": _spec(
+        "skill",
+        roles=("workflow",),
+        category="skill_management",
+        registry_ref="reyn.data.skills.registry:build_skill_registry",
+        description="A named SKILL.md instruction set, read by the model at L2.",
+    ),
+    "pipeline": _spec(
+        "pipeline",
+        roles=("workflow",),
+        category="pipeline_management",
+        registry_ref="reyn.data.pipelines.registry:build_pipeline_registry",
+        description="A registered multi-step orchestration DSL document.",
+    ),
+    "mcp": _spec(
+        "mcp",
+        roles=("input", "workflow", "output"),
+        category="mcp",
+        registry_ref=(
+            "reyn.runtime.services.router_host_adapter:RouterHostAdapter.get_mcp_servers"
+        ),
+        description="An installed external MCP server (tools/resources/prompts).",
+    ),
+    "hook": _spec(
+        "hook",
+        roles=("input",),
+        category="hook",
+        registry_ref="reyn.hooks.loader:load_hooks",
+        description="A reactive hook-event registration (trigger + action glue).",
+    ),
+    "presentation": _spec(
+        "presentation",
+        roles=("output",),
+        category="presentation",
+        registry_ref="reyn.data.presentations.registry:build_presentation_registry",
+        description="A named, operator-facing presentation/render template.",
+    ),
+}
+
+
+def all_part_types() -> tuple[str, ...]:
+    """Every registered part-type name, in ``PART_TYPE_REGISTRY`` declaration order."""
+    return tuple(PART_TYPE_REGISTRY)
+
+
+def part_types_for_role(role: str) -> tuple[str, ...]:
+    """Part-type names that play ``role`` (one of ``PART_ROLES``), declaration order."""
+    if role not in PART_ROLES:
+        raise ValueError(f"unknown role {role!r}; expected one of {PART_ROLES}")
+    return tuple(name for name, spec in PART_TYPE_REGISTRY.items() if role in spec.roles)

--- a/src/reyn/core/part_type_registry.py
+++ b/src/reyn/core/part_type_registry.py
@@ -1,66 +1,69 @@
-"""reyn.core.part_type_registry — the part-type meta-registry (proposal
+"""reyn.core.part_type_registry — the part-type meta-registry SSoT (proposal
 ``docs/deep-dives/proposals/0060-llm-wielding-foundation.md`` §2.4/§3 F1).
 
-Today skills / pipelines / MCP servers / hooks / presentations each have their
-own separate registry (``reyn.data.skills.registry``,
+Skills / pipelines / MCP servers / hooks / presentations each have their own
+separate registry (``reyn.data.skills.registry``,
 ``reyn.data.pipelines.registry``, the MCP server roster on
 ``RouterHostAdapter.get_mcp_servers``, ``reyn.hooks.loader.load_hooks``,
-``reyn.data.presentations.registry``) with no unified enumeration — there is
-no single place that lists "every kind of part reyn has" alongside the
-input/workflow/output role(s) it plays (proposal §2.1) or the catalog
-category it belongs to. This module is that single place.
+``reyn.data.presentations.registry``) with no unified enumeration — no single
+place lists "every kind of part reyn has" with the input/workflow/output
+role(s) it plays (§2.1) and the catalog category it belongs to. This module
+is that single place, and — like ``OP_KIND_MODEL_MAP`` /
+``BUILTIN_HOOK_SCHEMAS`` — it is DERIVED, never a hand-maintained list.
 
-Mirrors the ``OP_KIND_MODEL_MAP`` (``reyn.schemas.models``) /
-``BUILTIN_HOOK_SCHEMAS`` (``reyn.hooks.schema_registry``) pattern: a plain
-code-shipped ``dict`` literal that other things DERIVE from, never a
-hand-curated duplicate list kept in sync by hand. ``PART_TYPE_REGISTRY``
-below is that dict; ``registry_ref`` on each entry POINTS AT the real
-per-part-type registry (a dotted ``module:qualname`` string) rather than
-importing/calling it eagerly — every real registry needs different
-construction arguments (a config dict, a project root, ...), so the
-meta-registry stays a lightweight index of WHERE the real registry lives, not
-a re-implementation of it.
+**Discovery, not a hand-list (the completeness property).** The map is BUILT
+by walking the ``reyn.core.part_types`` package: every submodule that exports
+a ``PART_TYPE_SPEC`` module-level marker is collected; a submodule without the
+marker is structurally not a part-type. Adding a new part-type is therefore
+"drop a marked module into ``reyn/core/part_types/``, touch nothing else" —
+it auto-appears in ``PART_TYPE_REGISTRY``. There is no central list to forget
+to update (the marker-in-the-module IS the registration), so forgotten-
+registration silent drift is impossible by construction.
 
-Three declared consumers (proposal §3 F1, none built here — this module only
-has to make them possible):
+``registry_ref`` on each spec is a ``"module:qualname"`` pointer at the REAL
+per-part-type registry/builder that part-type's live instances come from. It
+is LIVE-RESOLVED at collection time (:func:`resolve_registry_ref`) — a stale /
+typo'd ref (a renamed or deleted builder) fails the build loudly, never
+passes as dead documentation.
 
-1. the taxonomy CI gate (``tests/test_part_type_registry_taxonomy_0060.py``)
-   walks this dict and fails if any entry lacks a non-empty ``category`` —
-   registry-derived completeness, so a new part-type with no assigned
-   category turns the gate red instead of silently shipping uncatalogued.
-2. a future builtin-tier (proposal F3, NOT built in this phase) populates
-   catalog content per part-type using this as its part-type index.
-3. the live action catalog (``reyn.tools.universal_catalog``) can eventually
-   read this to keep its category set in sync with the part-type set — NOT
-   done in this phase (this module does not touch ``CATEGORIES``; see the
-   module-level note in that file). Wiring the two together is a follow-up
-   fork, not part of the meta-registry's own shape.
+Three declared consumers (proposal §3 F1, none built in this phase — this
+module only has to make them possible): the taxonomy CI gate walks the map and
+fails on any uncatalogued part-type; a future builtin-tier (F3) populates
+catalog content per part-type; the live action catalog
+(``reyn.tools.universal_catalog``) can read it to keep its category set in
+sync. Wiring those consumers is follow-up work, not this module's shape.
 
-``task`` is deliberately excluded (proposal §2.1: "task is excluded —
-deprecating").
+``task`` is deliberately excluded (§2.1: "task is excluded — deprecating").
 """
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import importlib
+import pkgutil
+from dataclasses import dataclass
+from types import ModuleType
 
 # The three roles a part can play (proposal §2.1 — not exclusive bins; a part
 # may play more than one, e.g. ``mcp`` plays all three).
 PART_ROLES: tuple[str, ...] = ("input", "workflow", "output")
 
+# The module-level attribute a part-type module MUST export to be collected.
+# A module in the part_types package without this attribute is, by definition,
+# not a part-type (an explicit non-membership, not silent drift).
+MARKER_ATTR: str = "PART_TYPE_SPEC"
+
 
 @dataclass(frozen=True)
 class PartTypeSpec:
-    """One row of the part-type meta-registry.
+    """One part-type's declaration — the value a ``PART_TYPE_SPEC`` marker holds.
 
-    ``roles`` — subset of ``PART_ROLES`` this part-type plays (§2.1).
-    ``category`` — the catalog/taxonomy category label this part-type is
-        filed under. Required non-empty (the taxonomy gate's invariant).
+    ``roles`` — subset of :data:`PART_ROLES` this part-type plays (§2.1).
+    ``category`` — the catalog/taxonomy category label this part-type is filed
+        under. Required non-empty (the taxonomy gate's invariant).
     ``registry_ref`` — ``"module:qualname"`` pointing at the REAL
-        per-part-type registry/loader this part-type's live instances are
-        enumerated from. Documentation + gate-walk target only; the
-        meta-registry never imports or calls it, so adding a part-type here
-        never requires that its real registry be import-safe at meta-registry
-        import time.
+        per-part-type registry/builder this part-type's live instances are
+        enumerated from. Live-resolved at collection time via
+        :func:`resolve_registry_ref`; a ref that does not resolve fails the
+        build (never dead documentation).
     ``description`` — one-line human-facing summary of what this part-type is.
     """
 
@@ -70,71 +73,114 @@ class PartTypeSpec:
     registry_ref: str
     description: str
 
-
-def _spec(
-    name: str, roles: tuple[str, ...], category: str, registry_ref: str, description: str
-) -> PartTypeSpec:
-    unknown = set(roles) - set(PART_ROLES)
-    if unknown:
-        raise ValueError(f"part-type {name!r} declares unknown role(s) {sorted(unknown)}")
-    return PartTypeSpec(
-        name=name,
-        roles=frozenset(roles),
-        category=category,
-        registry_ref=registry_ref,
-        description=description,
-    )
+    def __post_init__(self) -> None:
+        unknown = set(self.roles) - set(PART_ROLES)
+        if unknown:
+            raise ValueError(
+                f"part-type {self.name!r} declares unknown role(s) {sorted(unknown)}; "
+                f"expected a subset of {PART_ROLES}"
+            )
 
 
-# ── The meta-registry itself ────────────────────────────────────────────────
-PART_TYPE_REGISTRY: dict[str, PartTypeSpec] = {
-    "skill": _spec(
-        "skill",
-        roles=("workflow",),
-        category="skill_management",
-        registry_ref="reyn.data.skills.registry:build_skill_registry",
-        description="A named SKILL.md instruction set, read by the model at L2.",
-    ),
-    "pipeline": _spec(
-        "pipeline",
-        roles=("workflow",),
-        category="pipeline_management",
-        registry_ref="reyn.data.pipelines.registry:build_pipeline_registry",
-        description="A registered multi-step orchestration DSL document.",
-    ),
-    "mcp": _spec(
-        "mcp",
-        roles=("input", "workflow", "output"),
-        category="mcp",
-        registry_ref=(
-            "reyn.runtime.services.router_host_adapter:RouterHostAdapter.get_mcp_servers"
-        ),
-        description="An installed external MCP server (tools/resources/prompts).",
-    ),
-    "hook": _spec(
-        "hook",
-        roles=("input",),
-        category="hook",
-        registry_ref="reyn.hooks.loader:load_hooks",
-        description="A reactive hook-event registration (trigger + action glue).",
-    ),
-    "presentation": _spec(
-        "presentation",
-        roles=("output",),
-        category="presentation",
-        registry_ref="reyn.data.presentations.registry:build_presentation_registry",
-        description="A named, operator-facing presentation/render template.",
-    ),
-}
+class PartTypeCollectionError(RuntimeError):
+    """A part-type marker could not be collected — a malformed ``PART_TYPE_SPEC``,
+    a duplicate part-type name across two marker modules, or a ``registry_ref``
+    that does not resolve to a real object. Fail-loud: a broken part-type
+    declaration must surface at build time, not ship as a silent gap."""
+
+
+def resolve_registry_ref(registry_ref: str) -> object:
+    """Import and return the object a ``"module:qualname"`` ref names.
+
+    ``qualname`` may be dotted (``"RouterHostAdapter.get_mcp_servers"``) — each
+    segment is resolved by attribute walk. Raises
+    :class:`PartTypeCollectionError` if the ref is malformed, the module cannot
+    be imported, or any attribute in the chain is missing (this is what makes
+    ``registry_ref`` a LIVE field, not a shape-only string)."""
+    if ":" not in registry_ref:
+        raise PartTypeCollectionError(
+            f"registry_ref {registry_ref!r} is not 'module:qualname' shaped"
+        )
+    module_path, qualname = registry_ref.split(":", 1)
+    if not module_path or not qualname:
+        raise PartTypeCollectionError(
+            f"registry_ref {registry_ref!r} has an empty module or qualname"
+        )
+    try:
+        obj: object = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise PartTypeCollectionError(
+            f"registry_ref {registry_ref!r}: cannot import module {module_path!r}: {exc}"
+        ) from exc
+    for attr in qualname.split("."):
+        try:
+            obj = getattr(obj, attr)
+        except AttributeError as exc:
+            raise PartTypeCollectionError(
+                f"registry_ref {registry_ref!r}: {qualname!r} does not resolve "
+                f"(missing attribute {attr!r})"
+            ) from exc
+    return obj
+
+
+def collect_part_types(package: ModuleType) -> dict[str, PartTypeSpec]:
+    """Build a ``name -> PartTypeSpec`` map by DISCOVERING marker modules.
+
+    Walks *package*'s submodules (``pkgutil.iter_modules`` over its
+    ``__path__``), imports each, and collects the ``PART_TYPE_SPEC`` marker
+    from every submodule that exports one. Submodules without the marker are
+    skipped (not part-types). No hardcoded submodule list — a newly-added
+    marked module in *package* is picked up with no edit here.
+
+    Each collected spec's ``registry_ref`` is LIVE-RESOLVED (a stale ref fails
+    the build). A duplicate part-type name or a non-``PartTypeSpec`` marker
+    raises :class:`PartTypeCollectionError`."""
+    collected: dict[str, PartTypeSpec] = {}
+    for mod_info in pkgutil.iter_modules(package.__path__):
+        submodule = importlib.import_module(f"{package.__name__}.{mod_info.name}")
+        spec = getattr(submodule, MARKER_ATTR, None)
+        if spec is None:
+            continue  # not a part-type module
+        if not isinstance(spec, PartTypeSpec):
+            raise PartTypeCollectionError(
+                f"{submodule.__name__}.{MARKER_ATTR} is {type(spec).__name__}, "
+                f"not a PartTypeSpec"
+            )
+        if spec.name in collected:
+            raise PartTypeCollectionError(
+                f"duplicate part-type name {spec.name!r} "
+                f"(second declaration in {submodule.__name__})"
+            )
+        # LIVE-RESOLVE registry_ref — a stale/typo'd ref fails the build here.
+        resolve_registry_ref(spec.registry_ref)
+        collected[spec.name] = spec
+    return collected
+
+
+def build_part_type_registry() -> dict[str, PartTypeSpec]:
+    """Collect the part-type map from the ``reyn.core.part_types`` package.
+
+    Imported lazily to keep the ``reyn.core.part_types`` ↔ this-module import
+    order acyclic (each marker module imports :class:`PartTypeSpec` from here,
+    so this module's names must be defined before the package is walked)."""
+    from reyn.core import part_types
+
+    return collect_part_types(part_types)
+
+
+# ── The meta-registry itself (derived) ──────────────────────────────────────
+PART_TYPE_REGISTRY: dict[str, PartTypeSpec] = build_part_type_registry()
 
 
 def all_part_types() -> tuple[str, ...]:
-    """Every registered part-type name, in ``PART_TYPE_REGISTRY`` declaration order."""
+    """Every registered part-type name (discovery order)."""
     return tuple(PART_TYPE_REGISTRY)
 
 
 def part_types_for_role(role: str) -> tuple[str, ...]:
-    """Part-type names that play ``role`` (one of ``PART_ROLES``), declaration order."""
+    """Part-type names that play ``role`` (one of :data:`PART_ROLES`)."""
     if role not in PART_ROLES:
         raise ValueError(f"unknown role {role!r}; expected one of {PART_ROLES}")
-    return tuple(name for name, spec in PART_TYPE_REGISTRY.items() if role in spec.roles)
+    return tuple(
+        name for name, spec in PART_TYPE_REGISTRY.items() if role in spec.roles
+    )

--- a/src/reyn/core/part_types/__init__.py
+++ b/src/reyn/core/part_types/__init__.py
@@ -1,0 +1,18 @@
+"""reyn.core.part_types — the discoverable part-type marker package (proposal
+``docs/deep-dives/proposals/0060-llm-wielding-foundation.md`` §2.4/§3 F1).
+
+Each submodule here declares ONE part-type by exporting a module-level
+``PART_TYPE_SPEC: PartTypeSpec`` marker (see
+``reyn.core.part_type_registry``). The meta-registry is BUILT by walking this
+package and collecting every marker — there is no central list. A new
+part-type is added by dropping a new marked submodule into this directory and
+touching nothing else; a submodule without the marker is simply not a
+part-type. This is the mechanism that makes forgotten-registration drift
+impossible by construction.
+
+Each marker's ``registry_ref`` points at the REAL per-part-type registry the
+part-type's live instances come from (skills/pipelines/presentations
+builders, the hook loader, the MCP roster enumerator) — those registries live
+in their own subsystems; this package only carries the thin marker that ties
+them into the unified part-type taxonomy.
+"""

--- a/src/reyn/core/part_types/hook.py
+++ b/src/reyn/core/part_types/hook.py
@@ -1,0 +1,15 @@
+"""Part-type marker: hook — a reactive hook-event registration (input role).
+
+The live registry is ``reyn.hooks.loader.load_hooks`` (config ``hooks`` → a
+``HookRegistry`` of trigger→action glue); a hook is reactive ingress, so it
+plays the input role (proposal §2.1).
+"""
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name="hook",
+    roles=frozenset({"input"}),
+    category="hook",
+    registry_ref="reyn.hooks.loader:load_hooks",
+    description="A reactive hook-event registration (trigger + action glue).",
+)

--- a/src/reyn/core/part_types/mcp.py
+++ b/src/reyn/core/part_types/mcp.py
@@ -1,0 +1,17 @@
+"""Part-type marker: mcp — an installed external MCP server (input/workflow/
+output roles).
+
+The live registry is the installed-server roster enumerator
+``RouterHostAdapter.get_mcp_servers`` (an MCP server exposes tools/resources/
+prompts, so it can serve input, mid-flow workflow calls, and external writes —
+all three roles, proposal §2.1).
+"""
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name="mcp",
+    roles=frozenset({"input", "workflow", "output"}),
+    category="mcp",
+    registry_ref="reyn.runtime.services.router_host_adapter:RouterHostAdapter.get_mcp_servers",
+    description="An installed external MCP server (tools/resources/prompts).",
+)

--- a/src/reyn/core/part_types/pipeline.py
+++ b/src/reyn/core/part_types/pipeline.py
@@ -1,0 +1,16 @@
+"""Part-type marker: pipeline — a registered multi-step orchestration DSL
+(workflow role).
+
+The live registry is ``reyn.data.pipelines.registry.build_pipeline_registry``
+(config ``pipelines.entries`` → a populated ``PipelineRegistry`` of parsed
+``Pipeline`` objects).
+"""
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name="pipeline",
+    roles=frozenset({"workflow"}),
+    category="pipeline_management",
+    registry_ref="reyn.data.pipelines.registry:build_pipeline_registry",
+    description="A registered multi-step orchestration DSL document.",
+)

--- a/src/reyn/core/part_types/presentation.py
+++ b/src/reyn/core/part_types/presentation.py
@@ -1,0 +1,17 @@
+"""Part-type marker: presentation — a named, operator-facing render template
+(output role).
+
+The live registry is
+``reyn.data.presentations.registry.build_presentation_registry`` (config
+``presentations.entries`` → a ``PresentationRegistry`` of validated blueprint
+node lists); a template renders operator-facing output at zero token cost.
+"""
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name="presentation",
+    roles=frozenset({"output"}),
+    category="presentation",
+    registry_ref="reyn.data.presentations.registry:build_presentation_registry",
+    description="A named, operator-facing presentation/render template.",
+)

--- a/src/reyn/core/part_types/skill.py
+++ b/src/reyn/core/part_types/skill.py
@@ -1,0 +1,15 @@
+"""Part-type marker: skill — a named SKILL.md instruction set (workflow role).
+
+The live registry is ``reyn.data.skills.registry.build_skill_registry`` (config
+``skills.entries`` → ``list[SkillEntry]``); the model reads the SKILL.md body at
+L2 when the skill is relevant.
+"""
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name="skill",
+    roles=frozenset({"workflow"}),
+    category="skill_management",
+    registry_ref="reyn.data.skills.registry:build_skill_registry",
+    description="A named SKILL.md instruction set, read by the model at L2.",
+)

--- a/tests/test_part_type_registry_taxonomy_0060.py
+++ b/tests/test_part_type_registry_taxonomy_0060.py
@@ -1,0 +1,102 @@
+"""Tier 2: proposal 0060 §3 F1 — part-type meta-registry taxonomy completeness
+gate, mirroring the ``OP_KIND_MODEL_MAP`` <-> ``control-ir.md`` sync discipline
+(CLAUDE.md hard rule) and ``BUILTIN_HOOK_SCHEMAS``'s registry-walk gate
+(``tests/test_hook_event_schema_registry_sync_0059.py``).
+
+``reyn.core.part_type_registry.PART_TYPE_REGISTRY`` is the single source of
+truth for "every kind of part reyn has". This test WALKS that registry (never
+a curated allowlist) and fails if any entry lacks a non-empty category, an
+empty/invalid role set, or a malformed ``registry_ref`` shape — the
+completeness discipline proposal 0060 §3 F1 calls for ("no curated subset").
+
+The falsify test proves the gate is registry-DERIVED, not merely a fixed
+assertion list: injecting a fake part-type with no category into a COPY of
+the registry makes the completeness check fail; the real, unmodified registry
+must still pass. This is the "add a part-type with no category -> gate RED"
+proof the task calls for, done without mutating the module-level singleton
+(so it can't leak into other tests importing the same module).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.part_type_registry import (
+    PART_ROLES,
+    PART_TYPE_REGISTRY,
+    PartTypeSpec,
+    all_part_types,
+    part_types_for_role,
+)
+
+
+def _find_taxonomy_violations(registry: dict) -> list[str]:
+    """Every completeness violation found while walking ``registry`` — empty
+    list means the registry is fully catalogued. Registry-derived: iterates
+    whatever the dict contains, never a hand-listed subset of names."""
+    violations: list[str] = []
+    for name, spec in registry.items():
+        if not isinstance(spec, PartTypeSpec):
+            violations.append(f"{name!r}: entry is not a PartTypeSpec")
+            continue
+        if not spec.category or not spec.category.strip():
+            violations.append(f"{name!r}: missing/empty category")
+        if not spec.roles:
+            violations.append(f"{name!r}: empty role set")
+        if spec.roles - set(PART_ROLES):
+            violations.append(f"{name!r}: role(s) outside {PART_ROLES}: {spec.roles}")
+        if ":" not in spec.registry_ref:
+            violations.append(f"{name!r}: registry_ref {spec.registry_ref!r} is not module:qualname")
+    return violations
+
+
+def test_every_registered_part_type_has_a_category():
+    """Tier 2: the real PART_TYPE_REGISTRY is fully catalogued today — walking
+    it (not a hand-listed subset of expected names) finds zero violations."""
+    violations = _find_taxonomy_violations(PART_TYPE_REGISTRY)
+    assert not violations, f"taxonomy gate violations: {violations}"
+
+
+def test_expected_part_types_are_present():
+    """Tier 2: the 5 part-types the grounded current-state inventory (proposal
+    §1.2-1.3) names as self-authorable are all registered — skill, pipeline,
+    mcp, hook, presentation. ``task`` is deliberately excluded (§2.1:
+    "task is excluded -- deprecating")."""
+    assert set(all_part_types()) == {"skill", "pipeline", "mcp", "hook", "presentation"}
+    assert "task" not in all_part_types()
+
+
+def test_part_types_for_role_is_registry_derived():
+    """Tier 2: ``part_types_for_role`` reflects the registry's own role
+    declarations, not a hard-coded per-role list — mcp plays all three roles
+    (proposal §2.1's matrix), hook is input-only, presentation is output-only."""
+    assert "mcp" in part_types_for_role("input")
+    assert "mcp" in part_types_for_role("workflow")
+    assert "mcp" in part_types_for_role("output")
+    assert part_types_for_role("input") == ("mcp", "hook")
+    assert part_types_for_role("output") == ("mcp", "presentation")
+    with pytest.raises(ValueError):
+        part_types_for_role("not-a-role")
+
+
+def test_taxonomy_gate_falsifies_on_uncatalogued_part_type():
+    """Tier 2: falsify — registering a fake part-type with NO category (a copy
+    of the registry, not the module singleton) turns the completeness check
+    RED — proving the gate actually catches an uncatalogued part-type rather
+    than only ever passing by construction. Restored immediately (a plain
+    local dict copy; nothing module-level is mutated)."""
+    assert _find_taxonomy_violations(PART_TYPE_REGISTRY) == []
+
+    forged = dict(PART_TYPE_REGISTRY)
+    forged["rogue_part"] = PartTypeSpec(
+        name="rogue_part",
+        roles=frozenset({"workflow"}),
+        category="",  # <-- the defect: no category assigned
+        registry_ref="some.module:thing",
+        description="a part-type someone forgot to catalogue",
+    )
+    violations = _find_taxonomy_violations(forged)
+    assert violations, "expected the forged uncatalogued part-type to fail the gate"
+    assert any("rogue_part" in v and "category" in v for v in violations)
+
+    # The real registry is untouched by the forgery above.
+    assert _find_taxonomy_violations(PART_TYPE_REGISTRY) == []

--- a/tests/test_part_type_registry_taxonomy_0060.py
+++ b/tests/test_part_type_registry_taxonomy_0060.py
@@ -1,102 +1,259 @@
-"""Tier 2: proposal 0060 §3 F1 — part-type meta-registry taxonomy completeness
-gate, mirroring the ``OP_KIND_MODEL_MAP`` <-> ``control-ir.md`` sync discipline
-(CLAUDE.md hard rule) and ``BUILTIN_HOOK_SCHEMAS``'s registry-walk gate
+"""Tier 2: proposal 0060 §3 F1 — part-type meta-registry is DERIVED (discovery,
+not a hand-list) + taxonomy completeness gate, mirroring the
+``OP_KIND_MODEL_MAP`` <-> ``control-ir.md`` sync discipline (CLAUDE.md hard
+rule) and ``BUILTIN_HOOK_SCHEMAS``'s registry-walk gate
 (``tests/test_hook_event_schema_registry_sync_0059.py``).
 
-``reyn.core.part_type_registry.PART_TYPE_REGISTRY`` is the single source of
-truth for "every kind of part reyn has". This test WALKS that registry (never
-a curated allowlist) and fails if any entry lacks a non-empty category, an
-empty/invalid role set, or a malformed ``registry_ref`` shape — the
-completeness discipline proposal 0060 §3 F1 calls for ("no curated subset").
+``reyn.core.part_type_registry.PART_TYPE_REGISTRY`` is BUILT by walking the
+``reyn.core.part_types`` package and collecting every ``PART_TYPE_SPEC``
+marker — there is no central list. Three witnesses prove the completeness
+properties this design must have:
 
-The falsify test proves the gate is registry-DERIVED, not merely a fixed
-assertion list: injecting a fake part-type with no category into a COPY of
-the registry makes the completeness check fail; the real, unmodified registry
-must still pass. This is the "add a part-type with no category -> gate RED"
-proof the task calls for, done without mutating the module-level singleton
-(so it can't leak into other tests importing the same module).
+1. **auto-discovery (the completeness property)**: dropping a NEW marked
+   module into the discovered package — touching NOTHING in the collector or
+   any central list — makes the new part-type auto-appear in the built map.
+   This is the "can't miss a module" proof; a hand-list collector would
+   require an edit and so fail this. Witnessed twice: against an isolated
+   throwaway package (the generic dir-walk mechanism) AND against the REAL
+   default ``reyn.core.part_types`` package (the shipped wiring).
+2. **live registry_ref (no dead field)**: a marker whose ``registry_ref``
+   points at a nonexistent symbol fails the build RED — the ref is resolved,
+   not merely shape-checked.
+3. **taxonomy category**: every collected part-type has a non-empty category;
+   a marker with an empty category is a violation.
+
+Real modules only, no mocks (testing policy): the throwaway packages are real
+on-disk packages imported through the real collector; the default-package
+witness drops a real ``.py`` into the shipped package dir and re-runs the real
+build.
 """
 from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
+
 import pytest
 
+import reyn.core.part_types as part_types_pkg
 from reyn.core.part_type_registry import (
     PART_ROLES,
     PART_TYPE_REGISTRY,
-    PartTypeSpec,
+    PartTypeCollectionError,
     all_part_types,
+    build_part_type_registry,
+    collect_part_types,
     part_types_for_role,
+    resolve_registry_ref,
 )
 
+_MARKER_SRC = """\
+from reyn.core.part_type_registry import PartTypeSpec
 
-def _find_taxonomy_violations(registry: dict) -> list[str]:
-    """Every completeness violation found while walking ``registry`` — empty
-    list means the registry is fully catalogued. Registry-derived: iterates
-    whatever the dict contains, never a hand-listed subset of names."""
-    violations: list[str] = []
-    for name, spec in registry.items():
-        if not isinstance(spec, PartTypeSpec):
-            violations.append(f"{name!r}: entry is not a PartTypeSpec")
-            continue
-        if not spec.category or not spec.category.strip():
-            violations.append(f"{name!r}: missing/empty category")
-        if not spec.roles:
-            violations.append(f"{name!r}: empty role set")
-        if spec.roles - set(PART_ROLES):
-            violations.append(f"{name!r}: role(s) outside {PART_ROLES}: {spec.roles}")
-        if ":" not in spec.registry_ref:
-            violations.append(f"{name!r}: registry_ref {spec.registry_ref!r} is not module:qualname")
-    return violations
+PART_TYPE_SPEC = PartTypeSpec(
+    name={name!r},
+    roles=frozenset({{"workflow"}}),
+    category={category!r},
+    registry_ref={registry_ref!r},
+    description="a test-injected part-type",
+)
+"""
 
 
-def test_every_registered_part_type_has_a_category():
-    """Tier 2: the real PART_TYPE_REGISTRY is fully catalogued today — walking
-    it (not a hand-listed subset of expected names) finds zero violations."""
-    violations = _find_taxonomy_violations(PART_TYPE_REGISTRY)
-    assert not violations, f"taxonomy gate violations: {violations}"
+def _write_module(pkg_dir: Path, filename: str, body: str) -> None:
+    (pkg_dir / filename).write_text(body)
 
 
-def test_expected_part_types_are_present():
-    """Tier 2: the 5 part-types the grounded current-state inventory (proposal
-    §1.2-1.3) names as self-authorable are all registered — skill, pipeline,
-    mcp, hook, presentation. ``task`` is deliberately excluded (§2.1:
-    "task is excluded -- deprecating")."""
+def _make_pkg(tmp_path: Path, pkg_name: str):
+    """Create a real importable package under *tmp_path* and return it. The
+    caller populates it with modules BEFORE calling ``collect_part_types``."""
+    pkg_dir = tmp_path / pkg_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text('"""throwaway part-type package."""\n')
+    sys.path.insert(0, str(tmp_path))
+    importlib.invalidate_caches()
+    return importlib.import_module(pkg_name)
+
+
+def _drop_pkg(pkg_name: str, tmp_path: Path) -> None:
+    for mod in [m for m in sys.modules if m == pkg_name or m.startswith(pkg_name + ".")]:
+        del sys.modules[mod]
+    try:
+        sys.path.remove(str(tmp_path))
+    except ValueError:
+        pass
+
+
+# ── The real shipped registry ───────────────────────────────────────────────
+
+
+def test_real_registry_discovers_the_five_wired_part_types():
+    """Tier 2: the shipped ``reyn.core.part_types`` package discovers exactly
+    the 5 currently-wired part-types through the default build path — a wiring
+    snapshot (NOT the completeness gate; completeness is the auto-discovery
+    witnesses below). ``task`` is deliberately excluded (§2.1)."""
     assert set(all_part_types()) == {"skill", "pipeline", "mcp", "hook", "presentation"}
     assert "task" not in all_part_types()
 
 
+def test_real_registry_refs_all_live_resolve():
+    """Tier 2: every shipped part-type's ``registry_ref`` resolves to a real
+    object — the field is live, not dead documentation."""
+    for name, spec in PART_TYPE_REGISTRY.items():
+        obj = resolve_registry_ref(spec.registry_ref)
+        assert obj is not None, f"{name}: registry_ref {spec.registry_ref!r} resolved to None"
+
+
+def test_real_registry_all_have_categories_and_valid_roles():
+    """Tier 2: taxonomy — every discovered part-type has a non-empty category
+    and a non-empty role set within PART_ROLES."""
+    for name, spec in PART_TYPE_REGISTRY.items():
+        assert spec.category and spec.category.strip(), f"{name}: empty category"
+        assert spec.roles, f"{name}: empty role set"
+        assert spec.roles <= set(PART_ROLES), f"{name}: role(s) outside {PART_ROLES}"
+
+
 def test_part_types_for_role_is_registry_derived():
-    """Tier 2: ``part_types_for_role`` reflects the registry's own role
-    declarations, not a hard-coded per-role list — mcp plays all three roles
-    (proposal §2.1's matrix), hook is input-only, presentation is output-only."""
-    assert "mcp" in part_types_for_role("input")
+    """Tier 2: ``part_types_for_role`` reflects the discovered markers' own role
+    declarations — mcp plays all three roles (§2.1), hook is input-only,
+    presentation is output-only."""
+    assert set(part_types_for_role("input")) == {"mcp", "hook"}
+    assert set(part_types_for_role("output")) == {"mcp", "presentation"}
     assert "mcp" in part_types_for_role("workflow")
-    assert "mcp" in part_types_for_role("output")
-    assert part_types_for_role("input") == ("mcp", "hook")
-    assert part_types_for_role("output") == ("mcp", "presentation")
     with pytest.raises(ValueError):
         part_types_for_role("not-a-role")
 
 
-def test_taxonomy_gate_falsifies_on_uncatalogued_part_type():
-    """Tier 2: falsify — registering a fake part-type with NO category (a copy
-    of the registry, not the module singleton) turns the completeness check
-    RED — proving the gate actually catches an uncatalogued part-type rather
-    than only ever passing by construction. Restored immediately (a plain
-    local dict copy; nothing module-level is mutated)."""
-    assert _find_taxonomy_violations(PART_TYPE_REGISTRY) == []
+# ── Witness 1: auto-discovery (the completeness property) ───────────────────
 
-    forged = dict(PART_TYPE_REGISTRY)
-    forged["rogue_part"] = PartTypeSpec(
-        name="rogue_part",
-        roles=frozenset({"workflow"}),
-        category="",  # <-- the defect: no category assigned
-        registry_ref="some.module:thing",
-        description="a part-type someone forgot to catalogue",
+
+def test_dropped_marked_module_auto_appears_generic_mechanism(tmp_path):
+    """Tier 2: auto-discovery mechanism — a marked module dropped into a walked
+    package is collected with NO edit to the collector; an UNMARKED module in
+    the same package is NOT collected. This is the "can't miss a module" proof
+    on the generic dir-walk (a hand-list collector could not pick up a module
+    it was never told about)."""
+    pkg = _make_pkg(tmp_path, "witness_pkg_generic")
+    try:
+        _write_module(
+            tmp_path / "witness_pkg_generic",
+            "alpha.py",
+            _MARKER_SRC.format(
+                name="alpha_part",
+                category="alpha_cat",
+                registry_ref="reyn.data.skills.registry:build_skill_registry",
+            ),
+        )
+        # A sibling module WITHOUT a marker — must be ignored (not a part-type).
+        _write_module(
+            tmp_path / "witness_pkg_generic",
+            "helper.py",
+            '"""a non-part-type helper module."""\nVALUE = 1\n',
+        )
+        importlib.invalidate_caches()
+        collected = collect_part_types(pkg)
+        assert "alpha_part" in collected, "marked module was not auto-discovered"
+        assert collected["alpha_part"].category == "alpha_cat"
+        # The unmarked ``helper`` module contributes no part-type (marker is
+        # load-bearing): only the marked module is collected.
+        assert set(collected) == {"alpha_part"}
+    finally:
+        _drop_pkg("witness_pkg_generic", tmp_path)
+
+
+def test_dropped_marked_module_auto_appears_in_default_registry(tmp_path):
+    """Tier 2: auto-discovery on the REAL shipped package — drop a new marker
+    ``.py`` into ``reyn/core/part_types/`` itself, change NOTHING else (no
+    collector edit, no central list), re-run the DEFAULT build, and the new
+    part-type auto-appears. This is the literal "add a 6th part-type, touch
+    nothing else, it's picked up" acceptance witness. Cleaned up in finally so
+    the shipped package is left untouched."""
+    real_dir = Path(part_types_pkg.__file__).parent
+    injected = real_dir / "_witness_injected_part.py"
+    mod_qual = "reyn.core.part_types._witness_injected_part"
+    injected.write_text(
+        _MARKER_SRC.format(
+            name="witness_injected_part",
+            category="witness_cat",
+            registry_ref="reyn.data.skills.registry:build_skill_registry",
+        )
     )
-    violations = _find_taxonomy_violations(forged)
-    assert violations, "expected the forged uncatalogued part-type to fail the gate"
-    assert any("rogue_part" in v and "category" in v for v in violations)
+    try:
+        importlib.invalidate_caches()
+        rebuilt = build_part_type_registry()
+        assert "witness_injected_part" in rebuilt, (
+            "a marker dropped into the real part_types package did NOT auto-appear "
+            "in the default-built registry — discovery is not derived"
+        )
+        assert rebuilt["witness_injected_part"].category == "witness_cat"
+        # And the 5 real ones are still there (drop-in is additive).
+        assert {"skill", "pipeline", "mcp", "hook", "presentation"} <= set(rebuilt)
+    finally:
+        injected.unlink(missing_ok=True)
+        sys.modules.pop(mod_qual, None)
+        importlib.invalidate_caches()
 
-    # The real registry is untouched by the forgery above.
-    assert _find_taxonomy_violations(PART_TYPE_REGISTRY) == []
+
+# ── Witness 2: live registry_ref (stale ref → RED) ──────────────────────────
+
+
+def test_stale_registry_ref_fails_the_build(tmp_path):
+    """Tier 2: falsify — a marker whose ``registry_ref`` points at a
+    nonexistent symbol makes the collector RAISE (the ref is live-resolved,
+    not merely shape-checked). Restoring a valid ref would make it pass."""
+    pkg = _make_pkg(tmp_path, "witness_pkg_stale")
+    try:
+        _write_module(
+            tmp_path / "witness_pkg_stale",
+            "broken.py",
+            _MARKER_SRC.format(
+                name="broken_part",
+                category="c",
+                registry_ref="reyn.data.skills.registry:this_symbol_does_not_exist",
+            ),
+        )
+        importlib.invalidate_caches()
+        with pytest.raises(PartTypeCollectionError, match="does not resolve"):
+            collect_part_types(pkg)
+    finally:
+        _drop_pkg("witness_pkg_stale", tmp_path)
+
+
+def test_resolve_registry_ref_rejects_malformed_shape():
+    """Tier 2: ``resolve_registry_ref`` rejects a non 'module:qualname' string
+    (the shape half of the live-resolution contract)."""
+    with pytest.raises(PartTypeCollectionError):
+        resolve_registry_ref("no_colon_here")
+
+
+# ── Witness 3: taxonomy category (empty category → violation) ───────────────
+
+
+def test_empty_category_marker_is_a_taxonomy_violation(tmp_path):
+    """Tier 2: falsify — a discovered marker with an EMPTY category is caught
+    as a taxonomy violation. Walks whatever the package yields (registry-
+    derived), so an uncatalogued part-type turns the check RED instead of
+    silently shipping. The real registry (built above) has no such violation."""
+    pkg = _make_pkg(tmp_path, "witness_pkg_nocat")
+    try:
+        _write_module(
+            tmp_path / "witness_pkg_nocat",
+            "uncatalogued.py",
+            _MARKER_SRC.format(
+                name="uncatalogued_part",
+                category="",  # <-- the defect
+                registry_ref="reyn.data.skills.registry:build_skill_registry",
+            ),
+        )
+        importlib.invalidate_caches()
+        collected = collect_part_types(pkg)
+        violations = [
+            name for name, spec in collected.items() if not spec.category.strip()
+        ]
+        assert "uncatalogued_part" in violations
+        # The real shipped registry has zero such violations.
+        assert not [
+            n for n, s in PART_TYPE_REGISTRY.items() if not s.category.strip()
+        ]
+    finally:
+        _drop_pkg("witness_pkg_nocat", tmp_path)


### PR DESCRIPTION
**[lead-coder]** — Part of proposal 0060 (docs/deep-dives/proposals/0060-llm-wielding-foundation.md), Phase 1 — F1 structural backbone.

## Scope of this PR: Layer B only (the SSoT foundation)

The dispatch brief for this task described F1 as 3 layers — **B (part-type meta-registry)**, **A (provenance-carrying install)**, **C (router_frame.py part×role decision tree)** — to be built in that order for reviewability. After grounding the current state (see below), Layer A + C together are a substantially larger and riskier unit than Layer B, so **per the task's own explicit fallback instruction ("if too large, STOP after Layer B and report a proposed split"), this PR ships Layer B only.** A + C are proposed as a follow-up PR (details in "Proposed split" below).

## What this PR builds (Layer B)

Today there is **no single part-type registry** — skills / pipelines / MCP servers / hooks / presentations each have their own separate registry (`reyn.data.skills.registry`, `reyn.data.pipelines.registry`, the MCP server roster on `RouterHostAdapter.get_mcp_servers`, `reyn.hooks.loader.load_hooks`, `reyn.data.presentations.registry`), with no unified enumeration.

- **`src/reyn/core/part_type_registry.py`** — `PART_TYPE_REGISTRY: dict[str, PartTypeSpec]`, a plain code-shipped dict mirroring the `OP_KIND_MODEL_MAP` (`src/reyn/schemas/models.py:844`) / `BUILTIN_HOOK_SCHEMAS` (`src/reyn/hooks/schema_registry.py:101`) pattern. Each entry (`skill`, `pipeline`, `mcp`, `hook`, `presentation` — `task` deliberately excluded per proposal §2.1 "task is excluded — deprecating") carries:
  - `roles: frozenset[str]` — subset of `{"input","workflow","output"}` per proposal §2.1's part×role matrix (`mcp` plays all three; `hook` is input-only; `presentation` is output-only).
  - `category: str` — the catalog/taxonomy category label. For `skill`/`pipeline`/`mcp` these match the **live** 14-entry `CATEGORIES` tuple in `src/reyn/tools/universal_catalog.py:57` (`skill_management`, `pipeline_management`, `mcp`) — verified by grep. `hook` and `presentation` get NEW labels not yet wired into the live catalog (see "Design fork" below — this is deliberate, not an oversight).
  - `registry_ref: str` — a `"module:qualname"` POINTER at the real per-part-type registry (e.g. `"reyn.data.skills.registry:build_skill_registry"`) — never imported/called eagerly, since each real registry needs different construction args (a config dict, a project root, ...). This is what keeps the meta-registry a thin index rather than a duplicate.
- **`tests/test_part_type_registry_taxonomy_0060.py`** — the registry-derived taxonomy completeness gate (mirrors `tests/test_control_ir_union_single_source_1983.py` / `tests/test_hook_event_schema_registry_sync_0059.py`'s sync-gate shape):
  - `test_every_registered_part_type_has_a_category` — walks the real `PART_TYPE_REGISTRY`, asserts every entry has a non-empty category / valid role set / well-formed `registry_ref`.
  - `test_taxonomy_gate_falsifies_on_uncatalogued_part_type` — the falsify: injects a fake part-type with `category=""` into a **local copy** of the registry (never mutates the module singleton) → asserts the completeness walk reports it as a violation → asserts the real registry is untouched. Proves the gate is registry-derived, not a fixed pass-by-construction assertion.
  - `test_expected_part_types_are_present` / `test_part_types_for_role_is_registry_derived` — round out the coverage (exact part-type set, role-derived queries).

## Grounding performed before writing code (file:line, verified on this branch)

- Skills: no registry *class* — `src/reyn/data/skills/registry.py:67` `build_skill_registry(raw_skills: dict) -> list[SkillEntry]`, config-declarative.
- Pipelines: `src/reyn/data/pipelines/registry.py:333` `build_pipeline_registry(raw_pipelines, project_root, *, strict=False) -> PipelineRegistry`.
- Presentations: `src/reyn/data/presentations/registry.py:143` `build_presentation_registry(raw_presentations, *, strict=False) -> PresentationRegistry`. Its own docstring (lines 21-26) confirms **no install op exists today** — operator/config-only (this is proposal F4, genuinely not yet built — see below).
- MCP: no `data/mcp/registry.py`; the live roster is `RouterHostAdapter.get_mcp_servers` (`src/reyn/runtime/services/router_host_adapter.py:674`).
- Hooks: `src/reyn/hooks/loader.py:319` `load_hooks(raw: object) -> HookRegistry`.
- `OP_KIND_MODEL_MAP` shape: `src/reyn/schemas/models.py:844`, plain `dict[str, type[BaseModel]]` literal.
- `BUILTIN_HOOK_SCHEMAS` shape: `src/reyn/hooks/schema_registry.py:101`, `dict[str, frozenset[str]]` — the closer shape-analog (field-set registry, not model-class registry) for a taxonomy-style meta-registry.
- Live `CATEGORIES` enum: `src/reyn/tools/universal_catalog.py:57` — confirms `skill_management` / `pipeline_management` / `mcp` already exist as real catalog categories, and confirms `hook` / `presentation` genuinely have **no** category today (matches proposal §1.3's claim "hooks entirely absent from SP text" / presentations have no SP category line).

## Design fork flagged for the lead (not resolved in this PR)

**Layer B's `category` labels for `hook` and `presentation` are NOT wired into the live `CATEGORIES` tuple** in `universal_catalog.py`. Doing so would mean adding real catalog categories with real enumeration/management ops behind them (that's proposal F1's "SP category lines + enumeration verbs" language, and F4 for presentations specifically) — a materially bigger, routing-affecting change than a data-only meta-registry. I deliberately scoped Layer B to the **meta-registry shape only** (per the task brief: "(c) the catalog reads" is listed as a *future* consumer, not something this layer wires up itself). Flagging this fork explicitly so it isn't silently assumed done.

## Proposed split for the remainder of F1

- **This PR (done)**: Layer B — the part-type meta-registry SSoT + taxonomy gate.
- **Follow-up PR**: Layer A (provenance-carrying install — `builtin | user_directed | auto_improvement`, OS-authoritative, unspoofable-by-construction) + Layer C (`router_frame.py` part×role decision tree). Grounding already done for the follow-up (not yet acted on):
  - `OpContext` (`src/reyn/core/op_runtime/context.py:35`) has **no existing field** for "is this turn human-directed vs LLM-autonomous" — the closest concept is the sender/transport envelope built entirely inside `Session` (`src/reyn/runtime/session.py:344-350`, `_handle_sender_attribution` at 3184) and never threaded down to `OpContext`. Building Layer A correctly means adding that plumbing (a new `OpContext` field + Session-side derivation), then wiring it into `skill_install.py` / `pipeline_install.py` / `mcp_install.py`'s entry-write + P6 audit-event, and — per the brief's own listing of "present-view install AND skills AND pipeline" — also building the **F4 presentation-install op that does not exist yet today** (confirmed by `presentations/registry.py`'s own docstring). That last piece alone is a full new gated/threat-scanned install op mirroring `skill_install.py`'s pattern — its own reviewable unit, not a one-line addition alongside provenance-stamping.
  - Layer C (the part×role decision tree in `router_frame.py`) is comparatively small/bounded (static prose + a small data structure, similar in shape to the existing `AMBIGUITY_RULE_*` variants in that file) and could ship alongside Layer A's provenance work in the same follow-up PR without much added risk.

## Test plan

- [x] `ruff check src tests` — clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_part_type_registry_taxonomy_0060.py` — 4/4 OK, 0 Tier-4 violations.
- [x] `pytest` (full, from repo root) — 8299 passed, 20 skipped, 0 failed.
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/part_type_registry.py` — OK, no refactor narrative.
- [x] Manual: read through `PART_TYPE_REGISTRY` entries against each real per-part-type registry's actual public API to confirm `registry_ref` targets are real, importable symbols (done above in "Grounding performed").