### PR TITLE
feat: snapshot-back the loop-valve counter (hook_driven_turns) — crash-durable, truncation-safe (#2884)

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -70,6 +70,15 @@ class AgentSnapshot:
     # Each entry is ``{"kind": str, "payload": dict}`` (no msg_id — already
     # consumed from the inbox before staging here).
     next_turn_context: list[dict] = field(default_factory=list)
+    # #2884: the hook-driven-turns loop-valve counter (Session._hook_driven_turns),
+    # snapshot-backed for crash-durability. A pure-WAL-derived count is NOT
+    # truncation-safe — the consumed `inbox_put{kind:"hook"}` events it would
+    # need are pruned by `truncate_below` (only REWIND_KIND is force-kept,
+    # retention.py) — exactly the #2259 config-loss class. The snapshot floor
+    # sits at/above the truncation floor, so this field survives truncation
+    # by construction. Kept current between snapshots by `apply_events`
+    # replaying `hook_driven_turns_set` WAL entries (see `_apply_one`).
+    hook_driven_turns: int = 0
 
     # ── persistence ─────────────────────────────────────────────────────
 
@@ -127,6 +136,7 @@ class AgentSnapshot:
             next_turn_context=list(
                 data.get("next_turn_context", []) or []
             ),
+            hook_driven_turns=_coerce_int(data.get("hook_driven_turns", 0)),
         )
 
     def to_payload(self) -> dict:
@@ -143,6 +153,7 @@ class AgentSnapshot:
             "outstanding_interventions": self.outstanding_interventions,
             "buffered_intervention_answers": self.buffered_intervention_answers,
             "next_turn_context": self.next_turn_context,
+            "hook_driven_turns": self.hook_driven_turns,
         }
 
     def serialize(self) -> str:
@@ -260,5 +271,11 @@ class AgentSnapshot:
                 self.next_turn_context.append(entry)
         elif kind == "next_turn_context_cleared":
             self.next_turn_context.clear()
+        # ── #2884: loop-valve counter (between-snapshot replay maintenance) ──
+        elif kind == "hook_driven_turns_set":
+            try:
+                self.hook_driven_turns = int(event.get("count", 0))
+            except (TypeError, ValueError):
+                self.hook_driven_turns = 0
         # step_started/completed/failed mutate per-task snapshot only — no agent-level state change here.
         # Unknown kinds: no-op (forward compatibility for future kinds)

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -111,6 +111,12 @@ WAL_EVENT_KINDS = (
     "task_rebound",
     # (#2248 PR-A added `config_changed` here; #2259 PR-1 removed it — config recovery is now
     # a truncation-surviving GENERATION, not a truncatable WAL event. See config_generations.py.)
+    # NEW (#2884) — the hook-driven-turns loop-valve counter's FULL current value (not a
+    # delta), recorded at every reset (kind="user") and increment (kind="hook") edge. This
+    # kind is a truncatable, between-snapshot replay-maintenance record ONLY — the
+    # reconstruction SOURCE-of-truth is the snapshot field (AgentSnapshot.hook_driven_turns),
+    # since consumed WAL entries are pruned by truncate_below (the #2259 config-loss class).
+    "hook_driven_turns_set",
 )
 
 

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -385,6 +385,28 @@ class SnapshotJournal:
         self._snapshot.next_turn_context.append(entry)
         self.save_nowait()
 
+    # ── loop-valve counter (#2884) ──────────────────────────────────────────
+
+    async def record_hook_driven_turns(self, *, count: int) -> None:
+        """Append ``hook_driven_turns_set`` to WAL + update the snapshot (#2884).
+
+        Mirrors ``record_intervention_answer_buffered``: Session's in-memory
+        ``_hook_driven_turns`` (the loop-valve counter bounding hook
+        self-continuation) is the runtime cache; ``AgentSnapshot.hook_driven_turns``
+        is its on-disk durable form. Records the FULL current value (not a
+        delta) at both the reset-to-0 (kind="user") and each increment
+        (kind="hook") edges, so replay (``AgentSnapshot._apply_one``) can
+        reconstruct the exact value between snapshots by replaying the same
+        WAL kind — no dependency on ``inbox_consume`` carrying the item kind.
+        """
+        if self._state_log is None:
+            return
+        self._wal_append_nowait(
+            "hook_driven_turns_set", target=self._agent_name, count=count,
+        )
+        self._snapshot.hook_driven_turns = count
+        self.save_nowait()
+
     async def record_next_turn_context_cleared(self) -> None:
         """Append ``next_turn_context_cleared`` to WAL + clear the buffer (#1800-4b).
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2476,6 +2476,17 @@ class Session:
         """
         return self._buffered_intervention_answers
 
+    @property
+    def hook_driven_turns(self) -> int:
+        """Read-only accessor for the hook-driven-turns loop-valve counter (#2884).
+
+        Snapshot-backed (``AgentSnapshot.hook_driven_turns`` — see
+        ``restore_state`` / ``SnapshotJournal.record_hook_driven_turns``) so
+        tests and observability can read the crash-durable value without
+        reaching into the private ``_hook_driven_turns`` field.
+        """
+        return self._hook_driven_turns
+
     def _is_turn_cancel_requested(self) -> bool:
         """Forwarding → RouterLoopDriver.is_cancel_requested (PR-3)."""
         return self._loop_driver.is_cancel_requested()
@@ -2997,6 +3008,9 @@ class Session:
                                              + self._restore_intervention_tasks
             buffered_intervention_answers  → self._buffered_intervention_answers
             next_turn_context              → self._next_turn_context
+            hook_driven_turns              → self._hook_driven_turns (#2884; restore_state's
+                                               plain assignment is unconditional, so no
+                                               separate clear step is needed here)
 
         The _inflight_wal_tasks task handles are already settled by
         await_quiescent; this drops the (now-done) handles so the rewound
@@ -3022,6 +3036,10 @@ class Session:
         self._buffered_intervention_answers.clear()
         # next_turn_context (#1800-4b)
         self._next_turn_context.clear()
+        # hook_driven_turns (#2884): reset the loop-valve counter mirror. restore_state
+        # re-assigns it wholesale from the reconstructed snapshot, but clearing here keeps
+        # the zero-residue guarantee robust independent of that assignment.
+        self._hook_driven_turns = 0
         self._inflight_wal_tasks.clear()
 
     @property
@@ -4384,6 +4402,10 @@ class Session:
         Callable from async context only — restoration schedules asyncio
         tasks."""
         self._journal.install(snapshot)
+        # #2884: restore the loop-valve counter from its snapshot-backed durable
+        # form — otherwise a crash+restart silently resets it to 0, handing a
+        # near-cap hook self-continuation chain a free fresh budget window.
+        self._hook_driven_turns = snapshot.hook_driven_turns
         for msg in snapshot.inbox:
             self.inbox.put_nowait((msg["kind"], msg["payload"]))
         self._chains.restore(on_fire=self._on_chain_timeout_fire)
@@ -4516,8 +4538,12 @@ class Session:
         # trigger. Monotonic counter + finite cap + reset-on-user-turn ⇒ finite.
         if kind == "user":
             self._hook_driven_turns = 0
+            # #2884: snapshot-back the counter so a crash+restart does not hand a
+            # near-cap self-wake loop a free fresh budget window (see restore_state).
+            await self._journal.record_hook_driven_turns(count=0)
         elif kind == "hook":
             self._hook_driven_turns += 1
+            await self._journal.record_hook_driven_turns(count=self._hook_driven_turns)
             _base_cap = self._safety.loop.max_hook_driven_turns
             if _base_cap > 0:
                 _cap = _base_cap + int(self._safety_extensions.get("hook_driven_turns", 0.0))

--- a/tests/test_2884_hook_driven_turns_truncation_falsify.py
+++ b/tests/test_2884_hook_driven_turns_truncation_falsify.py
@@ -1,0 +1,146 @@
+"""Tier 2: #2884 — the hook-driven-turns loop-valve counter TRUNCATION-falsify.
+
+``Session._hook_driven_turns`` (the #1800 slice 7 loop-valve, bounding hook
+self-continuation) was an in-memory-only int: a crash+restart reset it to 0,
+handing a near-cap self-wake loop a free fresh budget window (a
+defense-in-depth gap, not an acute exploit — the composer self-loop state
+that would actually re-arm the dangerous chain is separately non-durable;
+see architect's design comment on #2884).
+
+The fix snapshots the counter (``AgentSnapshot.hook_driven_turns``), mirroring
+``buffered_intervention_answers``. A pure-WAL-derived count is explicitly
+REJECTED by the design: consumed WAL entries are pruned by ``truncate_below``
+(only ``REWIND_KIND`` is force-kept) — exactly the #2259 config-loss class.
+This test proves the snapshot-backed value survives truncation of its OWN
+source WAL events (the CLAUDE.md recovery-feature PR gate), mirroring
+``tests/test_2259_config_truncation_bug.py``.
+
+Real Session / StateLog / AgentSnapshot (no mocks); only the LLM boundary
+(``_loop_driver.run_turn``) is replaced with a plain async recorder, exactly
+as ``tests/test_hook_loop_valve_1800_7.py`` does to isolate the valve.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.config.chat import LoopConfig, OnLimitConfig, SafetyConfig
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.session import Session
+
+AGENT = "valve-agent"
+
+
+def _make_session(wal: Path, snapshot_path: Path, *, cap: int = 100) -> tuple[Session, StateLog]:
+    safety = SafetyConfig(
+        loop=LoopConfig(max_hook_driven_turns=cap),
+        on_limit=OnLimitConfig(mode="unattended"),
+    )
+    state_log = StateLog(wal)
+    session = Session(
+        agent_name=AGENT, state_log=state_log, snapshot_path=snapshot_path, safety=safety,
+    )
+    return session, state_log
+
+
+def _fake_run_turn(session: Session) -> None:
+    """Replace the LLM boundary with a no-op recorder (isolates the valve)."""
+    async def _noop(user_text: str, chain_id: str) -> None:
+        return None
+    session._loop_driver.run_turn = _noop  # type: ignore[method-assign]
+
+
+async def _push_hook(session: Session, text: str) -> None:
+    await session._put_inbox("hook", {"name": "turn_end", "text": text, "wake": True})
+
+
+def _reconstruct(agent_name: str, snapshot_path: Path, state_log: StateLog) -> AgentSnapshot:
+    """Mirror ``AgentRegistry.restore_all``'s algorithm: load the durable snapshot,
+    tail the WAL from its ``applied_seq``, replay onto it."""
+    snap = AgentSnapshot.load(agent_name, snapshot_path)
+    events = list(state_log.iter_from(snap.applied_seq))
+    snap.apply_events(events)
+    return snap
+
+
+@pytest.mark.asyncio
+async def test_hook_driven_turns_survives_wal_truncation_below_its_source_events(tmp_path):
+    """Tier 2: #2884 truncate-falsify (CLAUDE.md recovery-feature PR gate). Drive N=3
+    hook-driven turns → their ``hook_driven_turns_set`` WAL source events + the durable
+    snapshot both land with count=3. Filler events push the truncation floor PAST those
+    source events; ``truncate_below`` drops them (asserted). Reconstructing (load snapshot
+    + replay the WAL tail) still yields 3 — because the value is baked into the durable
+    FULL-STATE snapshot, not derived solely from the (now-dropped) WAL events. RED if the
+    snapshot field / restore wiring were absent: reconstruction would see 0."""
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path, cap=100)
+    _fake_run_turn(session)
+
+    N = 3
+    for i in range(N):
+        await _push_hook(session, f"h{i}")
+        await session.run_one_iteration()
+    await session.journal.flush()  # drain the fire-and-forget WAL + snapshot writes
+
+    assert session.hook_driven_turns == N, "sanity: the live counter advanced to N"
+
+    # the source events (one hook_driven_turns_set per turn) are durable below this point.
+    pre_truncate_lines = [
+        line for line in wal.read_text().splitlines() if line.strip()
+    ]
+    assert any(
+        '"hook_driven_turns_set"' in line and f'"count": {N}' in line
+        for line in pre_truncate_lines
+    ), "sanity: the final hook_driven_turns_set@N source event must be durable pre-truncation"
+
+    # push filler events far past the counter's source events, then truncate below them.
+    for i in range(150):
+        await state_log.append("inbox_put", n=i)
+    floor = state_log.current_seq - 5
+    await state_log.truncate_below(floor)
+    await state_log.flush()
+    stats = state_log.last_truncate_stats
+    assert stats["dropped"] >= N, (
+        f"the {N} hook_driven_turns_set source events (and other early entries) must be "
+        f"truncated below the floor; dropped={stats['dropped']}"
+    )
+    post_truncate_lines = [line for line in wal.read_text().splitlines() if line.strip()]
+    assert not any('"hook_driven_turns_set"' in line for line in post_truncate_lines), (
+        "the source events must actually be gone from the WAL post-truncation (not just "
+        "counted) — otherwise this test would pass vacuously even for a WAL-derived design"
+    )
+
+    await state_log.aclose()  # simulate the crash: tear down run1's WAL worker
+
+    # reconstruct (simulates a restart): a FRESH StateLog + Session over the SAME wal/snapshot
+    # (mirrors AgentRegistry.restore_all: load snapshot, tail WAL from applied_seq, replay, restore).
+    session2, state_log2 = _make_session(wal, snapshot_path, cap=100)
+    reconstructed = _reconstruct(AGENT, snapshot_path, state_log2)
+    session2.restore_state(reconstructed)
+
+    assert session2.hook_driven_turns == N, (
+        f"the loop-valve counter must survive WAL truncation below its own source events "
+        f"(snapshot-backed, not WAL-derived); got {session2.hook_driven_turns}, expected {N}"
+    )
+
+    await state_log2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_agent_snapshot_hook_driven_turns_round_trip(tmp_path):
+    """Tier 1: a basic AgentSnapshot save/load round-trip preserves a non-zero
+    ``hook_driven_turns`` value (not the 0 default — proves the field is actually
+    threaded through serialize/save/load, not silently dropped)."""
+    path = tmp_path / "snapshot.json"
+    snap = AgentSnapshot(agent_name=AGENT, hook_driven_turns=7)
+    snap.save(path)
+
+    loaded = AgentSnapshot.load(AGENT, path)
+
+    assert loaded.hook_driven_turns == 7, (
+        f"hook_driven_turns must round-trip through save/load; got {loaded.hook_driven_turns}"
+    )

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -91,6 +91,9 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
         "outstanding_interventions": "session._interventions.clear() + restore tasks",
         "buffered_intervention_answers": "session._buffered_intervention_answers cleared",
         "next_turn_context": "session._next_turn_context cleared",
+        # #2884: the loop-valve counter mirror is reset to 0 (restore_state re-assigns
+        # it wholesale from the reconstructed snapshot; the reset keeps zero-residue robust).
+        "hook_driven_turns": "session._hook_driven_turns reset to 0",
     }
     assert set(disposition) == set(AgentSnapshot.__dataclass_fields__), (
         "AgentSnapshot fields changed — update reset_for_rewind (and this map) so "

--- a/tests/test_reset_for_rewind.py
+++ b/tests/test_reset_for_rewind.py
@@ -103,6 +103,38 @@ def test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields():
 
 
 @pytest.mark.asyncio
+async def test_reset_for_rewind_zeroes_hook_driven_turns_counter(tmp_path):
+    """Tier 2: #2884 — reset_for_rewind zeroes the loop-valve counter mirror.
+
+    Behavioral pin for the reset line (session.py reset_for_rewind → the
+    ``_hook_driven_turns = 0`` step). Populate a NONZERO counter pre-rewind,
+    call reset_for_rewind, assert the public counter is 0 post-reset. Stripping
+    the reset line makes this go RED — closing the green-on-strip vector the
+    field-coverage drift-guard alone leaves open.
+
+    Scope note: for THIS counter the reset is belt-and-suspenders (the sole
+    rewind call site, registry.py, runs ``restore_state`` on the immediately-
+    following unconditional line, overwriting the counter wholesale from the
+    reconstructed snapshot). This test pins the reset's own zero-residue
+    behaviour regardless, so a future change that silently drops it is caught.
+    """
+    log = StateLog(tmp_path / "wal")
+    session = _session(tmp_path, log)
+
+    # arrange: a nonzero loop-valve counter (the pre-rewind residue to clear).
+    session._hook_driven_turns = 5
+
+    await session.reset_for_rewind()
+
+    # assert via the public read-only accessor (no private-state assertion).
+    assert session.hook_driven_turns == 0, (
+        "reset_for_rewind must zero the hook-driven-turns loop-valve counter "
+        "(stale nonzero residue would hand the post-rewind session a wrong "
+        "max_hook_driven_turns valve budget)"
+    )
+
+
+@pytest.mark.asyncio
 async def test_reset_for_rewind_is_idempotent_on_clean_session(tmp_path):
     """Tier 2: reset_for_rewind on an already-empty session is a safe no-op."""
     log = StateLog(tmp_path / "wal")


### PR DESCRIPTION
**[lead-coder]** — Closes #2884.

## Problem
`Session._hook_driven_turns` (the #1800 slice 7 loop-valve counter that backstops hook self-continuation / composed→wake / emit→wake loops) was an **in-memory int, not snapshot/WAL-backed**. A crash+restart reset it to 0, so a near-cap self-wake loop could get a fresh free budget window after a crash.

## Honest threat model (per the architect's design comment on #2884)
This is a **defense-in-depth gap, not an acute exploit**. The dangerous composer self-loop correlation state is separately crash-non-durable (`InMemoryPendingStore` drops in-flight composed pendings on crash — fail-safe), so the self-stimulating chain cannot auto-re-arm from composer state. What survives is one WAL-logged in-flight hook-wake (redelivered post-restart) or an external re-stimulus — either re-enters the valve seam **with the counter freshly reset to 0**. Worth closing now that `emit_hook_event` makes a fully-autonomous LLM loop live and the valve is its only bound (and before 0060 Phase-4 leans on the valve to force-close auto-improvement loops).

## Fix — snapshot-backed (the load-bearing decision)
A pure-WAL-derived counter is **NOT truncation-safe** — consumed `inbox_put{kind:"hook"}` events are pruned by `truncate_below` (only `REWIND_KIND` is force-kept), exactly the #2259 config-loss class. So the counter is **snapshot-backed**, mirroring `buffered_intervention_answers`:

- **`AgentSnapshot.hook_driven_turns: int`** (new field) — `agent_snapshot.py`; wired into `to_payload` / `load` / `_apply_one` (replays a new `hook_driven_turns_set` WAL kind for between-snapshot correctness). Mirrors `buffered_intervention_answers` (the "in-memory dict is the runtime cache; this field is its on-disk durable form" pattern).
- **`SnapshotJournal.record_hook_driven_turns(count)`** — `snapshot_journal.py`; WAL-append (`hook_driven_turns_set`, registered in `WAL_EVENT_KINDS`) + snapshot update + `save_nowait`. Records the FULL value at both the reset (user turn) and each increment (hook turn) edge.
- **`Session.restore_state`** now sets `self._hook_driven_turns = snapshot.hook_driven_turns` — the restore wiring.
- **`Session.reset_for_rewind`** resets the mirror to 0 (zero-residue drift-guard) + `Session.hook_driven_turns` public read-only property.

A single int → one snapshot field; no generation-store (heavier than needed, per the architect).

## Truncate-falsify test — INCLUDED IN THIS PR (CLAUDE.md recovery-feature hard-rule gate)
`tests/test_2884_hook_driven_turns_truncation_falsify.py::test_hook_driven_turns_survives_wal_truncation_below_its_source_events` (mirrors `tests/test_2259_config_truncation_bug.py`):
1. Drive N=3 hook-driven turns → counter=3; flush the durable WAL+snapshot writes.
2. Assert the final `hook_driven_turns_set@3` source event is durable pre-truncation.
3. Push 150 filler WAL events; `truncate_below(floor)` past the source events; assert `dropped >= N` **and** that no `hook_driven_turns_set` line survives in the WAL (so it can't pass vacuously).
4. Reconstruct (load snapshot + replay WAL tail) into a fresh Session → **assert counter survives as 3**.

**Falsify (verified manually, then reverted):** stripping the `restore_state` wiring → the truncate-falsify test goes RED (reconstructs to 0); separately stripping the `AgentSnapshot.load` field wiring → both tests RED. Restored → GREEN. This proves the snapshot-backing is load-bearing and survives truncation.

Plus a basic round-trip test (`test_agent_snapshot_hook_driven_turns_round_trip`) preserving a non-default value (7, not 0).

## Design fork
None — followed the architect's canonical design comment exactly. The one confirm-item the architect flagged (whether `inbox_consume` carries the item kind for between-snapshot replay) is sidestepped: `record_hook_driven_turns` writes the FULL counter value at both edges via its own `hook_driven_turns_set` kind, so replay reconstructs the exact value without depending on `inbox_consume` carrying kind.

## Test / gates
- Local gates green: `ruff check src tests`, `test_tier_audit.py --strict` (both changed test files), `verify_module_docstrings.py` (4 changed src files).
- **Local full `pytest`: 6009 passed, 14 skipped** (the initial run surfaced one by-construction drift-guard failure — `test_reset_for_rewind_clear_scope_covers_all_agentsnapshot_fields` requires every new AgentSnapshot field get an explicit reset disposition — now fixed and re-run green).
- **CI runs the full pytest** on push (authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>