### PR TITLE
fix: schema-validate composed:* hook matchers at load — close the Phase-3 footgun for composed events (#2889)

### DIFF
--- a/src/reyn/hooks/event_pattern.py
+++ b/src/reyn/hooks/event_pattern.py
@@ -113,14 +113,30 @@ def matches(pattern: "EventPattern | None", event: HookEvent) -> bool:
     return _payload_matches(pattern.payload, event.payload)
 
 
-def validate_against_schema(pattern: EventPattern, kind: str) -> None:
+def validate_against_schema(
+    pattern: EventPattern,
+    kind: str,
+    composed_schemas: "dict[str, frozenset[str]] | None" = None,
+) -> None:
     """Raise ``HookSchemaError`` iff ``pattern.payload`` names a field that
-    ``kind``'s builtin schema (``schema_registry.BUILTIN_HOOK_SCHEMAS``) does
-    not carry — typo-resistance (e.g. ``payload.srever`` vs the real
-    ``server`` field). A ``kind`` with no builtin schema entry (a future /
-    non-builtin point — the schema-driven open set) is a silent no-op —
-    nothing to validate against, the same "open set" posture as
+    ``kind``'s schema does not carry — typo-resistance (e.g. ``payload.srever``
+    vs the real ``server`` field). A ``kind`` with no schema entry (a future /
+    non-builtin, non-composed point — the schema-driven open set) is a silent
+    no-op — nothing to validate against, the same "open set" posture as
     ``schema_registry.validate_payload``.
+
+    ``kind``'s schema resolves from TWO sources: ``composed_schemas`` (a
+    ``{emit_kind: frozenset(field_names)}`` map for every currently-configured
+    ``composed:*`` kind — #2889, closes the Phase-3 open-set gap ``composed:*``
+    was left in: every composed event, across all 7 Composer ops, is emitted
+    by the single ``_emit_composed`` producer with the FIXED payload shape
+    ``{"inputs": [...], "correlation_key": <key>}``, so this schema is knowable
+    and identical for every composer) checked FIRST, falling back to the
+    builtin ``schema_registry.BUILTIN_HOOK_SCHEMAS`` (the two namespaces never
+    collide — ``composed:*`` vs the 10 shipped builtin points). ``None``
+    (the default — no composer configuration known to the caller) skips the
+    composed lookup entirely, preserving the pre-#2889 open-set posture for
+    every caller that doesn't thread it.
 
     ENFORCED AT LOAD: ``reyn.hooks.loader.load_hooks`` calls this for every
     configured matcher (wrapping a ``HookSchemaError`` into a decision-enabling
@@ -128,7 +144,9 @@ def validate_against_schema(pattern: EventPattern, kind: str) -> None:
     load rather than silently never firing (see module docstring)."""
     if not pattern.payload:
         return
-    schema = BUILTIN_HOOK_SCHEMAS.get(canonical_kind(kind))
+    schema = composed_schemas.get(kind) if composed_schemas else None
+    if schema is None:
+        schema = BUILTIN_HOOK_SCHEMAS.get(canonical_kind(kind))
     if schema is None:
         return
     unknown = sorted(set(pattern.payload) - schema)

--- a/src/reyn/hooks/loader.py
+++ b/src/reyn/hooks/loader.py
@@ -178,7 +178,11 @@ def _parse_matcher(raw: object, entry_index: int) -> "dict[str, str] | None":
     return matcher
 
 
-def _parse_entry(raw: object, entry_index: int) -> HookDef:
+def _parse_entry(
+    raw: object,
+    entry_index: int,
+    composed_schemas: "dict[str, frozenset[str]] | None" = None,
+) -> HookDef:
     """Validate one raw hooks list entry and return a ``HookDef``."""
     if not isinstance(raw, dict):
         raise HookConfigError(
@@ -216,16 +220,37 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
     # namespace (one entry per ``composers:`` config's ``emit.kind``, not a
     # fixed enum), so it is accepted by PREFIX here rather than being added to
     # ``ALLOWED_HOOK_POINTS`` (a closed frozenset of the 10 builtin points).
-    # A composed-kind hook is NOT looked up via the builtin Schema Registry
-    # (``BUILTIN_HOOK_SCHEMAS`` has no ``composed:*`` entry, so a ``matcher``
-    # on one stays permissive/open-set below, same as any other non-builtin
-    # point) — its consumer is ``reyn.hooks.composed_consumer.
+    # Its consumer is ``reyn.hooks.composed_consumer.
     # ComposedEventConsumer``, not ``HookDispatcher.dispatch()``'s Sync loop.
+    # #2889: a composed-kind hook's ``matcher`` IS now schema-validated below,
+    # against ``composed_schemas`` (every composed event's payload shape is
+    # the fixed ``{"inputs", "correlation_key"}`` — see ``event_pattern.
+    # validate_against_schema``'s docstring) — closing the Phase-3 open-set
+    # gap this class of hook was left in.
     if on_key not in ALLOWED_HOOK_POINTS and not on_key.startswith(COMPOSED_KIND_PREFIX):
         sorted_points = ", ".join(sorted(ALLOWED_HOOK_POINTS))
         raise HookConfigError(
             f"hooks[{entry_index}].on={on_raw!r} is not a recognised hook-point. "
             f"Allowed: {sorted_points}, or a {COMPOSED_KIND_PREFIX}<name> composed-event kind."
+        )
+    # #2889 sub-decision (b), included: a dangling composed-kind subscription
+    # (``on: composed:X`` with NO configured composer producing ``composed:X``)
+    # can never fire — the SAME silent-never-fire class the matcher check
+    # below closes, and the reorder in ``Session.__init__`` (composer defs
+    # built before hooks) makes the FULL known composed-kind universe
+    # available here. ``composed_schemas is None`` (the default — a caller
+    # with no composer configuration to thread, e.g. a bare ``load_hooks(raw)``
+    # test call) skips this check entirely, preserving the pre-#2889
+    # permissive posture for every such caller.
+    if (
+        composed_schemas is not None
+        and on_key.startswith(COMPOSED_KIND_PREFIX)
+        and on_key not in composed_schemas
+    ):
+        raise HookConfigError(
+            f"hooks[{entry_index}].on={on_raw!r} names a composed kind no configured "
+            f"composer produces — it would never fire. Known composed kinds: "
+            f"{sorted(composed_schemas) or '(none configured)'}."
         )
 
     # ── scheme: exactly one of template_push / shell_exec / shell_push /
@@ -274,19 +299,24 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
     # ── matcher (optional, #2608 H2 — a field->pattern filter dict) ────────
     matcher: "dict[str, str] | None" = _parse_matcher(raw.get("matcher", None), entry_index)
 
-    # Hook-Event Redesign Phase 3 (proposal 0059 §10 Q-reyn-4): a matcher that
-    # names a payload field the hook-point's builtin schema does NOT carry is
+    # Hook-Event Redesign Phase 3 (proposal 0059 §10 Q-reyn-4) + #2889: a
+    # matcher that names a payload field the kind's schema does NOT carry is
     # a silent "never fire" footgun (a ``srever`` typo matches nothing, and the
     # operator gets no signal). ∴ fail-loud at load — validate the matcher (as
-    # a payload-only ``EventPattern``) against the point's ``BUILTIN_HOOK_SCHEMAS``
-    # entry. A point with NO builtin schema (a future/custom point — the
-    # schema-driven OPEN SET) stays permissive: ``validate_against_schema`` is a
-    # no-op there (proposal §4 open-set posture, preserved). This is additive
-    # correctness — a schema-VALID matcher still parses/evaluates byte-identically;
-    # only a schema-EXTERNAL (dead) matcher now surfaces as a HookConfigError.
+    # a payload-only ``EventPattern``) against the kind's schema: a builtin
+    # point's ``BUILTIN_HOOK_SCHEMAS`` entry, OR (#2889) a ``composed:*``
+    # kind's entry in ``composed_schemas`` (the fixed ``{"inputs",
+    # "correlation_key"}`` shape every Composer emits — closes the Phase-3
+    # open-set gap ``composed:*`` was left in). A kind with NO schema in
+    # either source (a future/custom point, or a composed kind when the
+    # caller passed no ``composed_schemas`` — the schema-driven OPEN SET)
+    # stays permissive: ``validate_against_schema`` is a no-op there (proposal
+    # §4 open-set posture, preserved). This is additive correctness — a
+    # schema-VALID matcher still parses/evaluates byte-identically; only a
+    # schema-EXTERNAL (dead) matcher now surfaces as a HookConfigError.
     if matcher is not None:
         try:
-            validate_event_pattern(from_legacy_matcher(matcher), on_key)
+            validate_event_pattern(from_legacy_matcher(matcher), on_key, composed_schemas)
         except HookSchemaError as exc:
             raise HookConfigError(f"hooks[{entry_index}].matcher: {exc}") from exc
 
@@ -316,7 +346,10 @@ def _parse_entry(raw: object, entry_index: int) -> HookDef:
 # ---------------------------------------------------------------------------
 
 
-def load_hooks(raw: object) -> HookRegistry:
+def load_hooks(
+    raw: object,
+    composed_schemas: "dict[str, frozenset[str]] | None" = None,
+) -> HookRegistry:
     """Parse and validate the ``hooks:`` value from a reyn.yaml dict.
 
     Parameters
@@ -325,6 +358,16 @@ def load_hooks(raw: object) -> HookRegistry:
         The value of the ``hooks:`` key from the config dict.  May be
         ``None`` (absent), an empty list, or a list of hook dicts.
         Any other type is logged as a warning and treated as empty.
+    composed_schemas:
+        #2889 — a ``{emit_kind: frozenset(field_names)}`` map for every
+        currently-configured ``composed:*`` kind (``reyn.runtime.session.
+        Session`` builds this from ``self._composer_defs`` and passes it
+        here). Used to (a) schema-validate a ``composed:*`` hook's
+        ``matcher`` (mirrors the Phase-3 builtin-point enforce-at-load path)
+        and (b) fail loud on a ``composed:*`` subscription with no producing
+        composer. ``None`` (the default) skips both checks — the pre-#2889
+        permissive posture, for callers with no composer configuration to
+        thread (most direct ``load_hooks(raw)`` test calls).
 
     Returns
     -------
@@ -350,6 +393,6 @@ def load_hooks(raw: object) -> HookRegistry:
 
     defs: list[HookDef] = []
     for idx, entry in enumerate(raw):
-        defs.append(_parse_entry(entry, idx))
+        defs.append(_parse_entry(entry, idx, composed_schemas))
 
     return HookRegistry(defs)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1415,6 +1415,25 @@ class Session:
         _boot_in_set = _load_in_set(
             getattr(self._registry, "_project_root", None) or Path.cwd()
         )
+        # Hook-Event Redesign — composed:* matcher schema-validation footgun
+        # close (#2889, mirrors the Phase-3 #2873 enforce-at-load fix for
+        # builtin points). ``_build_composer_defs`` is a pure/side-effect-free
+        # parse (confirmed — no hook-registry interaction), so it is SAFE to
+        # move ahead of ``_build_hook_registry`` here: knowing the full set of
+        # configured composers (all 4 layers) BEFORE hooks are validated lets
+        # a ``composed:*`` hook's ``matcher`` be schema-checked too, closing
+        # the open-set gap Phase 3 left for composed kinds (every composed
+        # event, across all 7 Composer ops, is emitted by the single
+        # ``_emit_composed`` producer with the FIXED payload shape
+        # ``{"inputs": [...], "correlation_key": <key>}`` — composer.py:336-338
+        # — so this schema is knowable and identical for every composer, keyed
+        # by its ``emit_kind``). Composers are v1 startup-only (no hot-reload
+        # seam), so this map is computed once and reused by the hooks reapply
+        # seam (``_reapply_hooks``) too — see ``self._composed_schemas`` below.
+        self._composer_defs = self._build_composer_defs(_boot_in_set)
+        self._composed_schemas: "dict[str, frozenset[str]]" = {
+            d.emit_kind: frozenset({"inputs", "correlation_key"}) for d in self._composer_defs
+        }
         self._hook_dispatcher = HookDispatcher(
             self._build_hook_registry(_boot_in_set),
             put_inbox=self._put_inbox,
@@ -1457,16 +1476,16 @@ class Session:
             bus=self._hook_bus,
         )
         # Hook-Event Redesign Phase 4b/5 (#2880/#2881): the Composer definitions
-        # (built from the same layered raw config `_build_composer_defs` reads)
-        # + the composed:*->Sync consumer bridge. Neither is STARTED here
-        # (starting means spawning background asyncio tasks, which belongs in
-        # ``run()``, this session's async entry point — construction here is
-        # synchronous); `run()` calls `self._composer_registry.start()` /
-        # `self._composed_consumer.start()` once. `stop()`ed in `run()`'s
-        # shutdown `finally` (mirrors the FsWatcher start/stop shape).
+        # (``self._composer_defs``, built above — ahead of the hook registry,
+        # #2889) + the composed:*->Sync consumer bridge. Neither is STARTED
+        # here (starting means spawning background asyncio tasks, which
+        # belongs in ``run()``, this session's async entry point —
+        # construction here is synchronous); `run()` calls
+        # `self._composer_registry.start()` / `self._composed_consumer.
+        # start()` once. `stop()`ed in `run()`'s shutdown `finally` (mirrors
+        # the FsWatcher start/stop shape).
         from reyn.hooks.composed_consumer import ComposedEventConsumer
         from reyn.hooks.composer import Composer, ComposerRegistry
-        self._composer_defs = self._build_composer_defs(_boot_in_set)
         self._composer_registry = ComposerRegistry(
             composers=[
                 Composer(
@@ -3772,6 +3791,13 @@ class Session:
         Rebuilding from scratch each call means a removed hook (runtime or per-agent)
         simply isn't in the new registry — removal handled by construction.
 
+        Threads ``self._composed_schemas`` (#2889 — computed once in
+        ``__init__`` from ``self._composer_defs``, BEFORE this is first
+        called; composers are startup-only, so the map never changes) into
+        every ``load_hooks`` call below, so a ``composed:*`` hook's
+        ``matcher`` is schema-validated exactly like a builtin point's,
+        closing the Phase-3 open-set gap ``composed:*`` was left in.
+
         **Per-LAYER boot resilience (the add-on refinement):** ``load_hooks`` raises
         ``HookConfigError`` on a malformed layer, and BOTH boot AND the reload path call
         this — a malformed persisted ``.reyn/hooks.yaml`` or per-agent file must NOT
@@ -3787,7 +3813,8 @@ class Session:
         per_agent_list = self._read_per_agent_hooks()
         per_session_list = self._read_per_session_hooks()  # #2285: the 4th, most-specific layer
         combined = list(self._startup_hooks_raw)
-        registry = load_hooks(combined)  # trusted startup must load — else fail loud
+        composed_schemas = getattr(self, "_composed_schemas", None)
+        registry = load_hooks(combined, composed_schemas)  # trusted startup must load — else fail loud
         for label, layer in (
             ("runtime", runtime_list),
             ("per-agent", per_agent_list),
@@ -3796,7 +3823,7 @@ class Session:
             if not layer:
                 continue
             try:
-                registry = load_hooks(combined + layer)  # validate the cumulative add
+                registry = load_hooks(combined + layer, composed_schemas)  # validate the cumulative add
                 combined = combined + layer
             except HookConfigError as exc:
                 logger.warning(

--- a/tests/test_hook_composed_matcher_schema_2889.py
+++ b/tests/test_hook_composed_matcher_schema_2889.py
@@ -1,0 +1,323 @@
+"""Tests for #2889 — schema-validate ``composed:*`` hook matchers at load,
+closing the Phase-3 (#2873) footgun the ``composed:*`` open namespace was
+left in.
+
+Root cause (see the architect's design comment on #2889): ``composed:*`` is
+an open namespace, so a ``matcher`` on a ``composed:*`` hook was NOT
+schema-checked at load — a typo'd field silently never matches at dispatch,
+exactly the footgun Phase 3 closed for the 10 builtin points. Fix: every
+composed event, across all 7 Composer ops, is emitted by the single
+``_emit_composed`` producer (``reyn.hooks.composer``) with the FIXED payload
+shape ``{"inputs": [...], "correlation_key": <key>}`` — so the schema is
+knowable and identical for every composer, keyed by its ``emit_kind``.
+``Session.__init__`` now builds the Composer defs BEFORE the hook registry
+(the reorder is side-effect-free — confirmed) and threads the derived
+``{emit_kind: frozenset({"inputs", "correlation_key"})}`` map into
+``load_hooks`` -> ``_parse_entry`` -> ``event_pattern.validate_against_schema``.
+
+Coverage plan
+-------------
+Tier 1 (contract): ``event_pattern.validate_against_schema`` — a
+  ``composed_schemas``-resolved schema flags an unknown field / passes a
+  known one, mirroring the Phase-3 builtin-point contract test.
+Tier 1 (contract): ``reyn.hooks.loader.load_hooks(raw, composed_schemas)`` —
+  reachability: a typo'd composed matcher fails loud at load; a valid one
+  loads clean; a ``composed:*`` subscription with NO producing composer
+  fails loud (sub-decision (b), included — the reorder makes the full known
+  composed-kind universe available at hook-load time); ``composed_schemas=
+  None`` (the default, no composer config threaded) stays permissive for
+  both checks — the pre-#2889 posture is unchanged for such callers.
+Tier 2 (OS invariant, Session-integration): a REAL ``Session`` constructed
+  with a ``composers_config`` + ``hooks_config`` whose composed matcher has a
+  schema-external field fails loud AT BOOT (``Session.__init__`` raises) —
+  proving the reorder + schema-map + threading actually reaches the
+  production wiring, not just the loader in isolation.
+Strip-falsify (both the matcher check and the dangling-producer check):
+  simulating "the schema-injection wiring never happened" flips each
+  enforced case back to a clean load — RED; restoring goes GREEN.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks import loader as loader_mod
+from reyn.hooks.event_pattern import EventPattern, validate_against_schema
+from reyn.hooks.loader import HookConfigError, load_hooks
+from reyn.hooks.schema_registry import HookSchemaError
+from reyn.runtime.session import Session
+
+_DEPLOY_APPROVED_SCHEMAS: "dict[str, frozenset[str]]" = {
+    "composed:deploy_approved": frozenset({"inputs", "correlation_key"}),
+}
+
+
+def _composer_config(*, name: str = "deploy_approved", emit_kind: str = "composed:deploy_approved") -> list:
+    return [
+        {
+            "name": name,
+            "op": "any",
+            "inputs": [{"kind": "builtin:external:file_changed"}],
+            "emit": {"kind": emit_kind},
+        },
+    ]
+
+
+# ===========================================================================
+# Tier 1 — Contract: validate_against_schema resolves a composed_schemas entry
+# ===========================================================================
+
+
+def test_validate_against_schema_flags_typo_composed_field() -> None:
+    """Tier 1: a payload field NOT in a composed kind's fixed
+    ``{"inputs", "correlation_key"}`` schema (a ``correlation_ky`` typo) is
+    flagged — the new capability #2889 adds for ``composed:*``."""
+    with pytest.raises(HookSchemaError, match="correlation_ky"):
+        validate_against_schema(
+            EventPattern(payload={"correlation_ky": "x"}),
+            "composed:deploy_approved",
+            _DEPLOY_APPROVED_SCHEMAS,
+        )
+
+
+def test_validate_against_schema_accepts_real_composed_fields() -> None:
+    """Tier 1: both real composed-payload fields pass silently."""
+    validate_against_schema(
+        EventPattern(payload={"inputs": [], "correlation_key": "x"}),
+        "composed:deploy_approved",
+        _DEPLOY_APPROVED_SCHEMAS,
+    )  # no raise
+
+
+def test_validate_against_schema_composed_kind_without_map_is_noop() -> None:
+    """Tier 1: ``composed_schemas=None`` (no composer config known to the
+    caller) preserves the pre-#2889 open-set posture — a composed kind stays
+    unvalidated, same as any other non-builtin point."""
+    validate_against_schema(
+        EventPattern(payload={"anything": "x"}), "composed:deploy_approved",
+    )  # no raise — composed_schemas defaults to None
+
+
+def test_validate_against_schema_composed_map_does_not_shadow_builtin() -> None:
+    """Tier 1: a non-empty ``composed_schemas`` map doesn't affect builtin-kind
+    validation — the two namespaces are disjoint and the builtin path is
+    unchanged."""
+    with pytest.raises(HookSchemaError, match="srever"):
+        validate_against_schema(
+            EventPattern(payload={"srever": "x"}),
+            "mcp_resource_updated",
+            _DEPLOY_APPROVED_SCHEMAS,
+        )
+
+
+# ===========================================================================
+# Tier 1 — Contract: enforced at load via reyn.hooks.loader.load_hooks
+# ===========================================================================
+
+
+def test_load_hooks_rejects_typo_composed_matcher_field() -> None:
+    """Tier 1: reachability — a ``composed:*`` hook's matcher naming a field
+    NOT in the fixed composed payload shape fails loud as ``HookConfigError``
+    at load, instead of silently never firing."""
+    raw = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"correlation_ky": "abc"},  # typo: should be "correlation_key"
+        },
+    ]
+    with pytest.raises(HookConfigError, match="correlation_ky"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+
+
+def test_load_hooks_accepts_valid_composed_matcher_fields() -> None:
+    """Tier 1: a composed matcher naming ``inputs``/``correlation_key`` (the
+    real fixed shape) loads fine — enforcement is additive."""
+    raw = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"correlation_key": "abc"},
+        },
+    ]
+    registry = load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+    (hook,) = registry.hooks_for("composed:deploy_approved")
+    assert hook.matcher == {"correlation_key": "abc"}
+
+
+def test_load_hooks_composed_matcher_stays_permissive_without_composed_schemas() -> None:
+    """Tier 1: ``composed_schemas=None`` (the default — most direct
+    ``load_hooks(raw)`` callers) skips composed-kind matcher validation
+    entirely, preserving the pre-#2889 posture."""
+    raw = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"anything_at_all": "x"},
+        },
+    ]
+    registry = load_hooks(raw)  # no composed_schemas passed
+    (hook,) = registry.hooks_for("composed:deploy_approved")
+    assert hook.matcher == {"anything_at_all": "x"}
+
+
+# ===========================================================================
+# Tier 1 — Contract: sub-decision (b), included — dangling-producer detection
+# ===========================================================================
+
+
+def test_load_hooks_rejects_dangling_composed_subscription() -> None:
+    """Tier 1: ``on: composed:X`` with NO configured composer producing
+    ``composed:X`` fails loud — it could never fire (the reorder makes the
+    full known composed-kind universe available at hook-load time)."""
+    raw = [{"on": "composed:no_such_producer", "template_push": {"message": "x"}}]
+    with pytest.raises(HookConfigError, match="no configured composer"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+
+
+def test_load_hooks_accepts_composed_subscription_with_real_producer() -> None:
+    """Tier 1: the dangling-producer check doesn't false-positive — a
+    composed kind that DOES appear in ``composed_schemas`` loads fine."""
+    raw = [{"on": "composed:deploy_approved", "template_push": {"message": "x"}}]
+    registry = load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+    (hook,) = registry.hooks_for("composed:deploy_approved")
+    assert hook.on == "composed:deploy_approved"
+
+
+def test_load_hooks_dangling_check_skipped_without_composed_schemas() -> None:
+    """Tier 1: ``composed_schemas=None`` also skips the dangling-producer
+    check — a caller with no composer configuration to thread gets the
+    pre-#2889 permissive posture for BOTH new checks, not just the matcher
+    one."""
+    raw = [{"on": "composed:no_such_producer", "template_push": {"message": "x"}}]
+    registry = load_hooks(raw)  # no composed_schemas
+    (hook,) = registry.hooks_for("composed:no_such_producer")
+    assert hook.on == "composed:no_such_producer"
+
+
+# ===========================================================================
+# Tier 2 — OS invariant: Session integration — the reorder + threading
+# actually reaches production construction, not just the loader in isolation.
+# ===========================================================================
+
+
+def test_session_boot_fails_loud_on_typo_composed_matcher(tmp_path: Path) -> None:
+    """Tier 2: a REAL ``Session`` constructed with a composer producing
+    ``composed:deploy_approved`` and a startup hook whose composed matcher
+    names a schema-external field raises ``HookConfigError`` AT BOOT
+    (``Session.__init__``) — the trusted startup layer fails loud, exactly
+    like the pre-existing Phase-3 builtin-point guarantee."""
+    hooks_config = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"correlation_ky": "abc"},  # typo
+        },
+    ]
+    with pytest.raises(HookConfigError, match="correlation_ky"):
+        Session(
+            agent_name="composed-matcher-2889-agent",
+            state_log=StateLog(tmp_path / "state.wal"),
+            snapshot_path=tmp_path / "snap.json",
+            hooks_config=hooks_config,
+            composers_config=_composer_config(),
+        )
+
+
+def test_session_boot_loads_clean_with_valid_composed_matcher(tmp_path: Path) -> None:
+    """Tier 2: the positive control — a schema-valid composed matcher boots
+    a REAL Session cleanly (no ``HookConfigError``) — additive correctness,
+    not a regression on the happy path."""
+    hooks_config = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"correlation_key": "abc"},
+        },
+    ]
+    Session(
+        agent_name="composed-matcher-2889-agent-ok",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        hooks_config=hooks_config,
+        composers_config=_composer_config(),
+    )  # no raise
+
+
+def test_session_boot_fails_loud_on_dangling_composed_subscription(tmp_path: Path) -> None:
+    """Tier 2: a REAL Session with a hook on a composed kind NO configured
+    composer produces raises ``HookConfigError`` at boot (sub-decision (b)
+    reaching production construction, not just the loader in isolation)."""
+    hooks_config = [{"on": "composed:no_such_producer", "template_push": {"message": "x"}}]
+    with pytest.raises(HookConfigError, match="no configured composer"):
+        Session(
+            agent_name="composed-dangling-2889-agent",
+            state_log=StateLog(tmp_path / "state.wal"),
+            snapshot_path=tmp_path / "snap.json",
+            hooks_config=hooks_config,
+            composers_config=_composer_config(),  # produces a DIFFERENT composed kind
+        )
+
+
+# ===========================================================================
+# Strip-falsify — proving the checks are load-bearing, not mechanism stubs
+# ===========================================================================
+
+
+def test_strip_falsify_composed_matcher_schema_validation(monkeypatch) -> None:
+    """Tier 1: strip-falsify — patch ``loader.validate_event_pattern`` so it
+    always drops ``composed_schemas`` (simulating the #2889 threading never
+    happened, e.g. the reorder didn't land), which flips the typo'd composed
+    matcher from fail-loud to a clean load — RED. Restoring goes GREEN."""
+    raw = [
+        {
+            "on": "composed:deploy_approved",
+            "template_push": {"message": "x"},
+            "matcher": {"correlation_ky": "abc"},  # typo
+        },
+    ]
+    # Real (fixed) behavior: raises.
+    with pytest.raises(HookConfigError, match="correlation_ky"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+
+    original = loader_mod.validate_event_pattern
+
+    def _stripped(pattern, kind, composed_schemas=None):
+        return original(pattern, kind, None)  # drop composed_schemas — simulate the pre-#2889 bug
+
+    monkeypatch.setattr(loader_mod, "validate_event_pattern", _stripped)
+    registry = load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)  # RED — no longer raises
+    (hook,) = registry.hooks_for("composed:deploy_approved")
+    assert hook.matcher == {"correlation_ky": "abc"}
+
+    monkeypatch.undo()
+    with pytest.raises(HookConfigError, match="correlation_ky"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)  # GREEN — restored
+
+
+def test_strip_falsify_dangling_producer_detection() -> None:
+    """Tier 1: strip-falsify — the dangling-producer check is gated entirely
+    on ``composed_schemas`` being threaded (the reorder's whole point: making
+    the full known composed-kind universe available before hooks load).
+    Passing ``None`` (as if the reorder never ran / the caller never threaded
+    composer info) flips the SAME dangling subscription from fail-loud to a
+    clean load — RED. Passing the real map restores fail-loud — GREEN."""
+    raw = [{"on": "composed:no_such_producer", "template_push": {"message": "x"}}]
+
+    # Real (fixed) behavior, with the schema map threaded: raises.
+    with pytest.raises(HookConfigError, match="no configured composer"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)
+
+    # Strip: composed_schemas=None — RED, the same dangling hook loads clean.
+    registry = load_hooks(raw, None)
+    (hook,) = registry.hooks_for("composed:no_such_producer")
+    assert hook.on == "composed:no_such_producer"
+
+    # Restore: GREEN.
+    with pytest.raises(HookConfigError, match="no configured composer"):
+        load_hooks(raw, _DEPLOY_APPROVED_SCHEMAS)


### PR DESCRIPTION
**[lead-coder]** — Closes #2889. Reintroduced Phase-3 footgun, closed for `composed:*` hooks.

## Defect
Phase 3 (#2873) made a `matcher` field not in a builtin hook-point's schema fail-loud-reject at load, so a typo can't silently never-match. But `composed:*` hooks were left an open-set — a `matcher` on a `composed:*` hook was NOT schema-validated, so a typo'd field silently never matched again. This closes that for composed events (per the architect's canonical design comment on #2889).

## Key fact making this trivial
Every composed event, across all 7 Composer ops, is emitted by the single `_emit_composed` producer (`composer.py:336-338`) with a FIXED payload shape `{"inputs": [...], "correlation_key": <key>}`. So the schema for any `composed:<name>` is `frozenset({"inputs", "correlation_key"})`, keyed by the composer's `emit.kind`.

## Fix (mirrors the Phase-3 enforce-at-load path exactly)
1. **Reorder** — `src/reyn/runtime/session.py:1418-1436`: `_build_composer_defs` now runs BEFORE `_build_hook_registry` (side-effect-free parse, confirmed), so the full composed-kind universe is known when hooks validate.
2. **Derive the composed-schema map** — `session.py:1434-1436`: `self._composed_schemas = {d.emit_kind: frozenset({"inputs","correlation_key"}) for d in self._composer_defs}`.
3. **Thread it** — `_build_hook_registry` (`session.py:3816,3826`) passes `self._composed_schemas` into every `load_hooks(...)` call → `load_hooks(raw, composed_schemas)` (`loader.py:349`) → `_parse_entry(..., composed_schemas)` (`loader.py:181`) → `validate_event_pattern(from_legacy_matcher(matcher), on_key, composed_schemas)` (`loader.py:~320`). In `event_pattern.validate_against_schema` (`event_pattern.py:116-155`) the schema resolves from `composed_schemas.get(kind)` FIRST (for `composed:*` kinds), falling back to `BUILTIN_HOOK_SCHEMAS` — the two namespaces never collide. Everything downstream (unknown-field diff → `HookSchemaError` → `HookConfigError`) is unchanged. `composed_schemas=None` (the default — bare `load_hooks(raw)` callers with no composer config to thread) preserves the pre-#2889 open-set posture.

## Sub-decision (b): dangling-producer detection — INCLUDED
A hook `on: composed:X` where NO configured composer produces `composed:X` now fails loud (`loader.py:~234-250`) — it would never fire, the same silent-never-fire class the matcher check closes. It's a small, clean addition given the reorder (which already makes the full known composed-kind universe available at hook-load time), so I included it in this PR. Also gated on `composed_schemas is not None`, so bare-loader callers stay permissive.

## Tests — `tests/test_hook_composed_matcher_schema_2889.py` (15 tests, Tier 1/2)
- Typo'd/schema-external composed matcher field → `HookConfigError` at load (loader + real `Session.__init__` boot).
- Valid `inputs`/`correlation_key` matcher → loads clean (loader + Session boot).
- Dangling `composed:X` with no producer → fail-loud (loader + Session boot).
- `composed_schemas=None` → both new checks skipped (pre-#2889 posture preserved).
- **Strip-falsify (schema-injection wiring)**: patch `loader.validate_event_pattern` to drop `composed_schemas` → typo'd composed matcher clean-loads = RED; restore → GREEN. Proves the validation is load-bearing, not a mechanism stub.
- **Strip-falsify (dangling-producer)**: pass `composed_schemas=None` (as if the reorder never ran) → dangling subscription clean-loads = RED; pass the real map → fail-loud = GREEN.

## Design fork
None. Followed the architect's canonical design comment on #2889 exactly (reorder + derived map + single `validate_against_schema` branch), and took the flagged-optional sub-decision (b) as INCLUDE per the "small, clean given the reorder" criterion. Sub-decision (a) (matcher depth) is a non-issue: the schema is the set of top-level payload keys, and `inputs`/`correlation_key` are exactly the top-level composed-payload keys.

## Gates
Local: ruff ✅, tier-audit `--strict` (15/15 OK) ✅, module-docstring verify ✅. Full local `pytest` ✅ **8315 passed, 20 skipped**. CI runs the full pytest suite on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)