### PR TITLE
feat: proposal 0060 Phase 1 — Layer A (turn_origin seam + present-install op + uniform provenance)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -33,6 +33,7 @@ Control IR is the list of side-effect operations the LLM may emit. The OS dispat
 | `mcp_drop_server` | Remove an MCP server from project/local/user config (inverse of `mcp_install`) | `permissions.mcp_drop_server: true` in skill frontmatter |
 | `skill_install` | Register a skill (local dir or git/URL source) into the project skills config | `file.write: [.reyn/config/skills.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
 | `pipeline_install` | Register a pipeline (local DSL file or git/URL source) into the project pipelines config | `file.write: [.reyn/config/pipelines.yaml]` in skill frontmatter; `http.get: [{host: <source_host>}]` when `source` is set |
+| `presentation_install` | Register a named presentation template (inline blueprint) into the project presentations config | `file.write: [.reyn/config/presentations.yaml]` |
 | `embed` | Raw embedding primitive: batch texts -> vectors (FP-0057 Phase 1; the user-facing primitive AND the shared logic later internal RAG ops call) | none (default-allow; embedding API cost) |
 | `index_query` | Semantic vector search over one indexed source | none |
 | `semantic_search` | Macro (FP-0057 Phase 2a; renamed from `recall`): per-source-model embed query → index_query per source → merge top-K (multi-model correct) | none (embedding API cost) |
@@ -719,6 +720,69 @@ Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`, `path
 
 Events emitted: `pipeline_install_threat_match`, `pipeline_install_threat_blocked` (threat scan),
 `pipeline_installed` (P6 on success).
+
+## `presentation_install`
+
+Registers a named presentation template (a declarative component tree) into the
+project's `presentations.entries` config (proposal 0060 Phase 1 Layer A, A8).
+One tool surface verb: `presentation_management__install`, handled by
+`op_runtime/presentation_install.py`. Mirrors `skill_install` /
+`pipeline_install`'s STRUCTURE (permission gate → config write →
+`record_config_generation` → emit event → hot-reload), but there is **no**
+source/git-fetch path (a blueprint is small declarative data carried inline,
+never a file-backed artifact) and **no** `scan_for_threats` call — a present
+blueprint is structurally non-executable by construction
+(`reyn.core.present.catalog`: 8 fixed components, every non-literal value is a
+`$bind` RFC-6901 JSON-Pointer, no template-ref/eval/exec surface, `image.src`
+renders as a label — no fetch/SSRF); `validate_blueprint` (the SAME gate an
+inline `present(blueprint=...)` op already passes through) fills the role
+`scan_for_threats` fills for skill/pipeline free-text `description`.
+
+Example:
+```json
+{
+  "kind": "presentation_install",
+  "name": "status_card",
+  "blueprint": {
+    "component": "keyvalue",
+    "rows": [{"label": "status", "value": {"$bind": "/status"}}]
+  }
+}
+```
+
+Fields:
+- `name` (required) — the `presentations.entries` config key; the value a
+  `present(view=<name>)` op resolves against.
+- `blueprint` (required) — the declarative component tree, identical shape to
+  an inline `present(blueprint=...)`'s `blueprint` field.
+
+Handler lifecycle:
+1. Structural threat gate: `validate_blueprint(op.blueprint)` — refuses
+   (`status="blocked"`) BEFORE any config mutation on a malformed / non-catalog
+   blueprint.
+2. Gate via `PermissionResolver.require_file_write` (= `.reyn/config/presentations.yaml`)
+3. Write `presentations.entries.<name>` to `.reyn/config/presentations.yaml`
+   with `{blueprint, enabled: true, provenance: <ctx.turn_origin>}` —
+   `provenance` is OS-stamped from `ctx.turn_origin` alone (A7/A9), never from
+   an op field
+4. Call `record_config_generation` (inherits the existing config crash-recovery;
+   no new recovery-gated obligation — no truncate-falsify test owed for this op)
+5. Emit `presentation_installed` event (P6 audit trail)
+6. Request hot-reload via `dispatch_install_reload(source="presentation_install")`
+   (the existing `"presentations"` seam — `Session._reapply_presentations`,
+   FP-0054 PR-C — rebuilds the registry; the SAME seam operator edits to
+   `presentations.yaml` already reload through)
+
+Ships inert-by-construction: a presentation is invoke-by-name — it renders
+only when a `present(view=<name>)` op names it, so a freshly-installed
+template is discoverable but dormant until referenced (no new state needed,
+mirrors builtin-inert for skills/pipelines).
+
+Result fields: `status` (`"installed"` / `"blocked"` / `"error"`), `name`,
+`config_path`.
+
+Events emitted: `presentation_install_blocked` (structural gate),
+`presentation_installed` (P6 on success).
 
 ## `embed`
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1111,6 +1111,21 @@ skill_install_verb_to_canonical = make_status_text_mapper(
 )
 
 
+def _render_presentation_install_verb(result: dict) -> str:
+    return f"Installed presentation '{result.get('name', '')}'."
+
+
+# ``presentation_management__install_local`` (tools/presentation_management_verbs.py,
+# proposal 0060 Phase 1 Layer A / A8) — delegates to
+# ``op_runtime.presentation_install.handle`` and surfaces its
+# ``{status:"installed", name, config_path}`` verbatim (envelope peeled the same
+# way as the pipeline/skill install verbs).
+presentation_install_verb_to_canonical = make_status_text_mapper(
+    render=_render_presentation_install_verb,
+    meta_keys=("name", "config_path"),
+)
+
+
 def _render_mcp_install_local_verb(result: dict) -> str:
     return f"Installed local MCP server '{result.get('name', '')}'."
 

--- a/src/reyn/core/op_runtime/__init__.py
+++ b/src/reyn/core/op_runtime/__init__.py
@@ -156,6 +156,11 @@ from . import pipeline_install as _pipeline_install  # noqa: F401, E402
 # FP-0054 PR-A: present op — user-facing presentation of bulk data (null renderer).
 from . import present as _present  # noqa: F401, E402
 
+# proposal 0060 Phase 1 Layer A (A8): present-view install op (register a named
+# presentation template into presentations.entries — mirrors skill_install/
+# pipeline_install; lower threat, validate_blueprint is the structural gate).
+from . import presentation_install as _presentation_install  # noqa: F401, E402
+
 # FP-0055 PR-2: render_template op — sandboxed Jinja2 text-templating producer.
 from . import render_template as _render_template  # noqa: F401, E402
 from . import sandboxed_exec as _sandboxed_exec  # noqa: F401, E402

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -290,6 +290,22 @@ class OpContext:
     # ``_create`` read-side stays fixed. None = not executing a task-as-request.
     current_task_id: "str | None" = None
 
+    # proposal 0060 Phase 1 Layer A (A7): the OS-authoritative provenance
+    # classification of THIS turn, mirroring current_task_id's threading exactly
+    # (same _stamp_execution_context seam, same two ctx-build sites). Derived
+    # session-side from the turn ``kind`` (session.py `_stamp_execution_context`)
+    # — NEVER LLM-supplied. ``"user_directed"`` only for an explicit ``kind ==
+    # "user"`` turn; every other kind (hook / pipeline_result / wake-family /
+    # sub-agent agent_request|agent_response / any future unmapped kind)
+    # resolves to the strictER ``"auto_improvement"`` — the fail-safe default
+    # (0060 §2.7: silently falling to "user_directed" would let an unmapped
+    # turn bypass the Phase-4 auto-improvement gate). Install-op handlers
+    # (skill/pipeline/present, A9) stamp `entry["provenance"]` from this field
+    # alone; the op schemas carry no provenance field for the LLM to spoof
+    # (isomorphic to emit_hook_event's ②B ctx-side kind construction, 0059).
+    # None = a non-turn OpContext (direct/test construction, CLI/preprocessor).
+    turn_origin: "str | None" = None
+
     # FP-0057 #2856 Part A: the TUI model-download status sink for the `embed`
     # op's provider resolution. Carries ONLY the event_sink CALLABLE
     # (``(kind, text, meta) -> None``, precedent: sentence_transformers_provider's

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -335,3 +335,27 @@ def sandbox_policy_from_ctx(ctx: "OpContext") -> "SandboxPolicy | None":
     from reyn.security.sandbox.policy import SandboxPolicy
 
     return SandboxPolicy(**ctx.default_sandbox_policy)
+
+
+def provenance_from_ctx(ctx: "OpContext") -> str:
+    """The OS-set turn provenance to stamp on an install (proposal 0060 A7/A9).
+
+    **LOAD-BEARING fail-safe (closes a gate-bypass, not merely a default).**
+    Returns ``ctx.turn_origin`` when set (``"user_directed"`` / ``"auto_improvement"``,
+    classified OS-side in ``Session._stamp_execution_context`` — A7), but when
+    ``ctx.turn_origin`` is ``None``/unset it returns the STRICTER
+    ``"auto_improvement"`` — NEVER ``None``, NEVER ``"user_directed"``.
+
+    Why this is load-bearing, not cosmetic: the production router-tool path threads
+    ``turn_origin`` through ``make_router_op_context`` (the ``op_context_factory``
+    bound at ``tools/types.py`` build_router_caller_state), but the
+    ``build_legacy_op_context`` bridge's FALLBACK synthesis path (no bound
+    ``router_state.op_context_factory`` — phase / direct / future bridge callers)
+    constructs an ``OpContext`` with ``turn_origin`` left at its ``None`` default.
+    An install stamped ``provenance=None`` would be UNGATED — it escapes the
+    Phase-4 auto-improvement gate (whose foundation is this provenance value). This
+    helper collapses any such unset path to the stricter ``auto_improvement``, so a
+    provenance-unset install can never bypass the gate by construction (the same
+    fail-safe direction as A7's unmapped-kind → ``auto_improvement`` rule)."""
+    origin = getattr(ctx, "turn_origin", None)
+    return origin if origin is not None else "auto_improvement"

--- a/src/reyn/core/op_runtime/pipeline_install.py
+++ b/src/reyn/core/op_runtime/pipeline_install.py
@@ -71,6 +71,7 @@ from reyn.security.content_guard import first_blocking_match, scan_for_threats
 
 from . import register
 from .context import OpContext
+from .context import provenance_from_ctx as _provenance_from_ctx
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 # Reuse skill_install's generic (skill-agnostic) helpers verbatim rather than
@@ -414,8 +415,11 @@ async def handle(
     # — A7) — never from an op field, so an auto-improvement turn cannot self-declare
     # "user_directed" to bypass the Phase-4 gate. The `builtin` value is stamped on a
     # DIFFERENT seam (the future builtin-tier registry-build loader, not this install
-    # path) — never written here.
-    entry["provenance"] = ctx.turn_origin
+    # path) — never written here. LOAD-BEARING fail-safe: provenance_from_ctx
+    # collapses an unset ctx.turn_origin (a bridge-fallback path that didn't thread
+    # it) to the stricter "auto_improvement" — a provenance=None install would be
+    # UNGATED (escape the Phase-4 gate), so this closes that gate-bypass.
+    entry["provenance"] = _provenance_from_ctx(ctx)
     # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
     # so step 9 routes a NEW name to the immediate mid-turn apply and a same-name
     # overwrite (clobber-update — pipeline's only update path) to the deferred path.

--- a/src/reyn/core/op_runtime/pipeline_install.py
+++ b/src/reyn/core/op_runtime/pipeline_install.py
@@ -409,6 +409,13 @@ async def handle(
     }
     if op.source:
         entry["source"] = op.source
+    # proposal 0060 Phase 1 Layer A (A9): provenance is stamped from the single
+    # OS-authoritative source (ctx.turn_origin, set by Session._stamp_execution_context
+    # — A7) — never from an op field, so an auto-improvement turn cannot self-declare
+    # "user_directed" to bypass the Phase-4 gate. The `builtin` value is stamped on a
+    # DIFFERENT seam (the future builtin-tier registry-build loader, not this install
+    # path) — never written here.
+    entry["provenance"] = ctx.turn_origin
     # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
     # so step 9 routes a NEW name to the immediate mid-turn apply and a same-name
     # overwrite (clobber-update — pipeline's only update path) to the deferred path.

--- a/src/reyn/core/op_runtime/presentation_install.py
+++ b/src/reyn/core/op_runtime/presentation_install.py
@@ -1,0 +1,184 @@
+"""presentation_install kind handler — register a named presentation template into
+the project config (proposal 0060 Phase 1 Layer A, A8).
+
+Handler logic (one-shot, no sub-phases, no source/git-fetch path — a blueprint is
+small declarative data carried inline, never a file-backed artifact):
+
+  1. Structural threat gate: :func:`reyn.core.present.catalog.validate_blueprint`
+     on ``op.blueprint``. This IS the threat gate for this op (no
+     ``scan_for_threats`` call — there is no free-text field to scan). A present
+     blueprint is structurally non-executable by construction (8 fixed
+     components, every non-literal value is a ``$bind`` RFC-6901 JSON-Pointer, no
+     template-ref / eval / exec surface, ``image.src`` renders as a label — no
+     fetch/SSRF) — the SAME gate an inline ``present(blueprint=...)`` op already
+     passes through. A malformed / non-catalog blueprint is refused BEFORE any
+     config mutation.
+  2. Gate via ``PermissionResolver.require_file_write`` for the presentations.yaml
+     path.
+  3. Read ``.reyn/config/presentations.yaml`` (or empty dict), set
+     ``presentations.entries.<name>`` = ``{blueprint, enabled, provenance}``,
+     write back. ``provenance`` is stamped from ``ctx.turn_origin`` alone (A9,
+     A7) — the op schema carries no provenance field for the LLM to supply.
+  4. ``record_config_generation`` on the presentations.yaml path AFTER write —
+     inherits the existing config crash-recovery (no new recovery-gated
+     obligation; mirrors skill_install/pipeline_install).
+  5. Emit ``presentation_installed`` event (P6 audit trail).
+  6. Reload so the installed template goes live: a PURE ADDITION on a live
+     per-session reloader (``ctx.hot_reloader``) applies IMMEDIATELY (mid-turn)
+     via the "presentations" seam (the SAME seam FP-0054 PR-C registers for
+     operator edits to presentations.yaml); a same-name overwrite or no
+     per-session reloader keeps the deferred turn-boundary path.
+
+Ships inert-by-construction (A3, no new state needed): a present-view is
+invoke-by-name — it renders only when a ``present(view=<name>)`` op names it, so
+a freshly-installed template is discoverable but dormant until referenced,
+exactly like a builtin skill (``auto_invoke=False``) or pipeline (invoke-by-name).
+
+This mirrors ``skill_install.py`` / ``pipeline_install.py``'s STRUCTURE
+(permission gate → config write → record_config_generation → emit event →
+hot-reload) but the threat is LOWER than either (no source/git-fetch surface,
+no free-text description, ``validate_blueprint`` already fills the
+``scan_for_threats`` role).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.present import PresentBlueprintError, validate_blueprint
+from reyn.schemas.models import PresentationInstallIROp
+
+from . import register
+from .context import OpContext
+from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
+from .skill_install import _read_yaml, _resolve_project_root, _write_yaml
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _presentations_config_path(project_root: Path) -> Path:
+    """Canonical path for the dynamic presentations registry config."""
+    return project_root / ".reyn" / "config" / "presentations.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Main handler
+# ---------------------------------------------------------------------------
+
+
+async def handle(
+    op: PresentationInstallIROp,
+    ctx: OpContext,
+) -> dict:
+    """Execute a presentation_install op — register a named presentation template.
+
+    Validates ``op.blueprint`` structurally (the threat gate, A8), gates the
+    config write, persists the entry with an OS-stamped ``provenance`` (A9),
+    records a config generation for crash-recovery, emits an audit event, and
+    requests a hot-reload of the "presentations" seam.
+    """
+    project_root = _resolve_project_root(ctx.workspace)
+    name = (op.name or "").strip()
+    if not name:
+        return {
+            "kind": "presentation_install",
+            "status": "error",
+            "error": "name must be a non-empty string (the presentations.entries key).",
+        }
+
+    # ── 1. Structural threat gate: validate_blueprint (A8) ────────────────────
+    # This IS the threat gate for present-install — no free-text field, so no
+    # scan_for_threats call. Refuses BEFORE any config mutation.
+    try:
+        validate_blueprint(op.blueprint)
+    except PresentBlueprintError as exc:
+        ctx.events.emit(
+            "presentation_install_blocked",
+            name=name,
+            error=str(exc),
+        )
+        return {
+            "kind": "presentation_install",
+            "status": "blocked",
+            "name": name,
+            "error": (
+                f"install blocked: blueprint failed the structural gate: {exc}. "
+                "A presentation blueprint must use only the catalog components "
+                "(text/markdown/code/diff/keyvalue/table/list/image) with "
+                "$bind JSON-Pointer values."
+            ),
+        }
+
+    # ── 2. Permission gate: presentations.yaml write ──────────────────────────
+    config_path = _presentations_config_path(project_root)
+    if ctx.permission_resolver is not None:
+        _sandbox = _sandbox_policy_from_ctx(ctx)
+        await ctx.permission_resolver.require_file_write(
+            ctx.permission_decl, str(config_path), ctx.actor,
+            sandbox_policy=_sandbox,
+        )
+
+    # ── 3. Write presentations.entries.<name> to .reyn/config/presentations.yaml ─
+    existing = _read_yaml(config_path)
+    if "presentations" not in existing or not isinstance(existing.get("presentations"), dict):
+        existing["presentations"] = {}
+    if (
+        "entries" not in existing["presentations"]
+        or not isinstance(existing["presentations"].get("entries"), dict)
+    ):
+        existing["presentations"]["entries"] = {}
+    entry: dict = {
+        "blueprint": op.blueprint,
+        "enabled": True,
+    }
+    # proposal 0060 Phase 1 Layer A (A9): provenance is stamped from the single
+    # OS-authoritative source (ctx.turn_origin, set by
+    # Session._stamp_execution_context — A7) — never from an op field, so an
+    # auto-improvement turn cannot self-declare "user_directed" to bypass the
+    # Phase-4 gate. The `builtin` value is stamped on a DIFFERENT seam (the
+    # future builtin-tier registry-build loader, not this install path) — never
+    # written here.
+    entry["provenance"] = ctx.turn_origin
+    # #2761-style PR-2 mirror: capture pure-addition-vs-overwrite BEFORE the
+    # write mutates entries, so step 6 routes a NEW name to the immediate
+    # mid-turn apply and a same-name overwrite (clobber-update — presentation's
+    # only update path) to the deferred path.
+    from reyn.runtime.hot_reload import is_pure_addition  # noqa: PLC0415
+    _is_addition = is_pure_addition(name, existing["presentations"]["entries"])
+    existing["presentations"]["entries"][name] = entry
+    _write_yaml(config_path, existing)
+
+    # ── 4. Record config generation for crash-recovery (#2259 / CLAUDE.md gate) ─
+    # No new recovery-gated obligation (A8): this inherits the EXISTING config
+    # crash-recovery record_config_generation already provides — no
+    # truncate-falsify test owed for this op (config-generation recovery is
+    # already covered where record_config_generation is exercised).
+    from reyn.core.events.config_recovery import record_config_generation  # noqa: PLC0415
+    await record_config_generation(getattr(ctx, "state_log", None), config_path, existing)
+
+    # ── 5. Emit presentation_installed event (P6) ─────────────────────────────
+    ctx.events.emit(
+        "presentation_installed",
+        name=name,
+        config_path=str(config_path),
+    )
+
+    # ── 6. Hot-reload: surface the installed template in the current session ──
+    from reyn.runtime.hot_reload import dispatch_install_reload  # noqa: PLC0415
+    await dispatch_install_reload(
+        getattr(ctx, "hot_reloader", None),
+        source="presentation_install",
+        is_addition=_is_addition,
+    )
+
+    return {
+        "status": "installed",
+        "name": name,
+        "config_path": str(config_path),
+    }
+
+
+from reyn.core.offload.canonical import STRUCTURED_PASSTHROUGH  # noqa: E402
+
+register("presentation_install", handle, canonical=STRUCTURED_PASSTHROUGH)

--- a/src/reyn/core/op_runtime/presentation_install.py
+++ b/src/reyn/core/op_runtime/presentation_install.py
@@ -49,6 +49,7 @@ from reyn.schemas.models import PresentationInstallIROp
 
 from . import register
 from .context import OpContext
+from .context import provenance_from_ctx as _provenance_from_ctx
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 from .skill_install import _read_yaml, _resolve_project_root, _write_yaml
 
@@ -138,8 +139,11 @@ async def handle(
     # auto-improvement turn cannot self-declare "user_directed" to bypass the
     # Phase-4 gate. The `builtin` value is stamped on a DIFFERENT seam (the
     # future builtin-tier registry-build loader, not this install path) — never
-    # written here.
-    entry["provenance"] = ctx.turn_origin
+    # written here. LOAD-BEARING fail-safe: provenance_from_ctx collapses an
+    # unset ctx.turn_origin (a bridge-fallback path that didn't thread it) to the
+    # stricter "auto_improvement" — a provenance=None install would be UNGATED
+    # (escape the Phase-4 gate), so this closes that gate-bypass by construction.
+    entry["provenance"] = _provenance_from_ctx(ctx)
     # #2761-style PR-2 mirror: capture pure-addition-vs-overwrite BEFORE the
     # write mutates entries, so step 6 routes a NEW name to the immediate
     # mid-turn apply and a same-name overwrite (clobber-update — presentation's

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -536,6 +536,13 @@ async def handle(
     }
     if op.source:
         entry["source"] = op.source
+    # proposal 0060 Phase 1 Layer A (A9): provenance is stamped from the single
+    # OS-authoritative source (ctx.turn_origin, set by Session._stamp_execution_context
+    # — A7) — never from an op field, so an auto-improvement turn cannot self-declare
+    # "user_directed" to bypass the Phase-4 gate. The `builtin` value is stamped on a
+    # DIFFERENT seam (the future builtin-tier registry-build loader, not this install
+    # path) — never written here.
+    entry["provenance"] = ctx.turn_origin
     # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
     # so step 8 can route a NEW name to the immediate mid-turn apply and a same-name
     # overwrite (clobber-update — skill's only update path) to the deferred path.

--- a/src/reyn/core/op_runtime/skill_install.py
+++ b/src/reyn/core/op_runtime/skill_install.py
@@ -52,6 +52,7 @@ from reyn.security.content_guard import first_blocking_match, scan_for_threats
 
 from . import register
 from .context import OpContext
+from .context import provenance_from_ctx as _provenance_from_ctx
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 
 # ---------------------------------------------------------------------------
@@ -541,8 +542,11 @@ async def handle(
     # — A7) — never from an op field, so an auto-improvement turn cannot self-declare
     # "user_directed" to bypass the Phase-4 gate. The `builtin` value is stamped on a
     # DIFFERENT seam (the future builtin-tier registry-build loader, not this install
-    # path) — never written here.
-    entry["provenance"] = ctx.turn_origin
+    # path) — never written here. LOAD-BEARING fail-safe: provenance_from_ctx
+    # collapses an unset ctx.turn_origin (a bridge-fallback path that didn't thread
+    # it) to the stricter "auto_improvement" — a provenance=None install would be
+    # UNGATED (escape the Phase-4 gate), so this closes that gate-bypass.
+    entry["provenance"] = _provenance_from_ctx(ctx)
     # #2761 PR-2: capture pure-addition-vs-overwrite BEFORE the write mutates entries,
     # so step 8 can route a NEW name to the immediate mid-turn apply and a same-name
     # overwrite (clobber-update — skill's only update path) to the deferred path.

--- a/src/reyn/prompt/universal_slots.py
+++ b/src/reyn/prompt/universal_slots.py
@@ -245,6 +245,13 @@ ACTION_CATEGORIES_LINES = [
         "pipeline from a git/GitHub URL (shallow-clones to "
         ".reyn/pipelines/<name>/)."
     ),
+    (
+        "- **presentation_management** — manage named presentation templates: "
+        "`presentation_management__install` to register a named presentation "
+        "blueprint (a declarative component tree) into "
+        ".reyn/config/presentations.yaml, so a later `present(view=<name>)` "
+        "op can render it (proposal 0060 Phase 1 Layer A)."
+    ),
 ]
 
 HOT_LIST_ALIASES_HINT = (

--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -44,6 +44,10 @@ ReapplySeam = tuple[str, Callable[[dict], Awaitable[bool]]]
 _INSTALL_SOURCE_SEAMS: "dict[str, tuple[str, ...]]" = {
     "skill_install": ("skills",),
     "pipeline_install": ("pipelines",),
+    # proposal 0060 Phase 1 Layer A (A8): the presentation_install op writes
+    # .reyn/config/presentations.yaml — reload the SAME "presentations" seam
+    # FP-0054 PR-C already registers for operator edits to that file.
+    "presentation_install": ("presentations",),
     "mcp_install": ("mcp",),
     # mcp__install_local writes .reyn/mcp.yaml via a parallel path (tools/mcp_verbs)
     # but reloads the SAME mcp seam — its distinct source label maps here too.

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -75,6 +75,7 @@ def build_router_op_context(
     hook_dispatcher: Any = None,  # #1800 slice 5c: the Session's HookDispatcher
     hook_bus: Any = None,  # Hook-Event Redesign Phase 5 part 2: the Session's HookBus → emit_hook_event
     current_task_id: str | None = None,  # #1953 §16: the task this turn is executing → task.create ownership
+    turn_origin: str | None = None,  # proposal 0060 Phase 1 (A7): OS-derived turn provenance → install-op stamping (A9)
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
     embedding_event_sink: Any = None,  # FP-0057 #2856 Part A: TUI model-download status sink for the `embed` op's provider resolution (ActionEmbeddingIndex build/query path). None → no TUI-observable download status.
@@ -164,6 +165,7 @@ def build_router_op_context(
         hook_dispatcher=hook_dispatcher,  # #1800 slice 5c: task_start/end dispatch
         hook_bus=hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
         current_task_id=current_task_id,  # #1953 §16: ownership-derivation context
+        turn_origin=turn_origin,  # proposal 0060 Phase 1 (A7): OS-authoritative provenance source (A9)
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
         render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
         embedding_event_sink=embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -126,6 +126,7 @@ class RouterHostAdapter:
         record_spawned_task: "Callable[[str, str], None] | None" = None,  # #2103 S1bc-exec
         live_session_id_fn: "Callable[[], str | None] | None" = None,     # #2103 S1bc-exec
         current_task_id_fn: "Callable[[], str | None] | None" = None,     # #1953 §16
+        turn_origin_fn: "Callable[[], str | None] | None" = None,  # proposal 0060 Phase 1 (A7)
         agent_workspace_dir: Path,
         # File op callbacks
         file_read: Callable[..., Awaitable[dict]],
@@ -385,6 +386,7 @@ class RouterHostAdapter:
         self._record_spawned_task = record_spawned_task   # #2103 S1bc-exec
         self._live_session_id_fn = live_session_id_fn      # #2103 S1bc-exec
         self._current_task_id_fn = current_task_id_fn      # #1953 §16
+        self._turn_origin_fn = turn_origin_fn      # proposal 0060 Phase 1 (A7)
         self._workspace_dir = Path(agent_workspace_dir)
         # File callbacks
         self._file_read_cb = file_read
@@ -2087,6 +2089,14 @@ class RouterHostAdapter:
             # session-owned (the original model).
             current_task_id=(
                 self._current_task_id_fn() if self._current_task_id_fn else None
+            ),
+            # proposal 0060 Phase 1 (A7): mirrors current_task_id's live-callback
+            # read exactly (varies per turn, so the fixed init value would be stale).
+            # This is the router-dispatched install path (skill_management__install_*
+            # / pipeline / presentation_management__install_* → this factory), so it
+            # is the load-bearing wiring for A9's per-handler provenance stamp.
+            turn_origin=(
+                self._turn_origin_fn() if self._turn_origin_fn else None
             ),
             # #2761 PR-2: the per-session HotReloader so an install op (skill/pipeline)
             # can apply a pure-addition reload IMMEDIATELY (mid-turn) → the new entry is

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -901,6 +901,15 @@ class Session:
         # task (a user / hook / recovery turn). Slice B extends the lifetime to a
         # persistent assignment spanning continuation + recovery turns.
         self._current_task_id: "str | None" = None
+        # proposal 0060 Phase 1 Layer A (A7): the OS-authoritative provenance
+        # classification of the turn currently being processed, mirroring
+        # ``_current_task_id`` exactly (same seam, same threading). Set per-turn
+        # in ``_stamp_execution_context``; read by the router op-ctx builders so
+        # install-op handlers (skill/pipeline/present, A9) stamp
+        # ``entry["provenance"]`` from a single OS-set source the LLM cannot
+        # spoof. Initialized to the STRICTER value (fail-safe: never default to
+        # "user_directed" before the first turn is classified).
+        self._current_turn_origin: str = "auto_improvement"
         # #2103: a spawned EPHEMERAL session (spawn-time mode="ephemeral") auto-vanishes
         # once its task is done. Set post-construction by the registry on an ephemeral
         # spawn; the main session + persistent spawns leave it False. ``_vanish_scheduled``
@@ -1794,6 +1803,9 @@ class Session:
             # #1953 §16: the per-turn execution context (set in run_one_iteration),
             # read at op-ctx-build time so a router task.create derives ownership.
             current_task_id_fn=lambda: self._current_task_id,
+            # proposal 0060 Phase 1 (A7): mirrors current_task_id_fn exactly — a live
+            # callback (not a fixed init value) because turn_origin varies per turn.
+            turn_origin_fn=lambda: self._current_turn_origin,
             agent_workspace_dir=self.workspace_dir,
             file_read=self._file_read,
             file_write=self._file_write,
@@ -4690,7 +4702,21 @@ class Session:
         ownership-cascade fires on ABORT (a COMPLETED T is skipped), and a
         linger-owned sub-task's own recovery still routes to T's assignee. The
         clear-on-terminal alternative adds op→session coupling for no functional gain,
-        so it is intentionally NOT done."""
+        so it is intentionally NOT done.
+
+        proposal 0060 Phase 1 Layer A (A7): also derives ``self._current_turn_origin``
+        — the OS-authoritative provenance classification of this turn, threaded into
+        ``OpContext.turn_origin`` at both ctx-build sites exactly like
+        ``current_task_id`` above. Only an explicit ``kind == "user"`` turn grants
+        ``"user_directed"``; EVERY other kind — hook, pipeline_result, the wake family,
+        sub-agent ``agent_request``/``agent_response``, or any future kind this method
+        does not yet know about — resolves to the strictER ``"auto_improvement"``. This
+        is an if/else fail-safe, not a lookup table: there is no path by which an
+        unmapped kind can silently fall through to ``"user_directed"`` (0060 §2.7 —
+        that would let an autonomous turn bypass the Phase-4 auto-improvement gate).
+        Sub-agent turns are deliberately `"auto_improvement"` (lead-adjudicated,
+        Addendum B A7): a human directed the PARENT task, not necessarily this
+        install action."""
         meta = payload.get("meta", {})
         if kind == WAKE_READY_KIND:
             self._current_task_id = meta.get("task_id")
@@ -4700,6 +4726,8 @@ class Session:
             pass  # PRESERVE: self-continuation / response to the agent's own action
         else:
             self._current_task_id = None  # user / agent_request / unknown → new context
+        # A7: fail-safe if/else — "user" is the ONLY kind granting user_directed.
+        self._current_turn_origin = "user_directed" if kind == "user" else "auto_improvement"
 
     async def _handle_task_wake(self, payload: dict) -> None:
         """#1953 slice 7: surface a Task dep-graph wake (``task_ready`` /
@@ -6087,6 +6115,7 @@ class Session:
             hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: complete-by-construction (both router callers)
             hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target (both router op-ctx builders complete-by-construction)
             current_task_id=self._current_task_id,  # #1953 §16: ownership-derivation for task.create (enumerate ALL op-ctx builders)
+            turn_origin=self._current_turn_origin,  # proposal 0060 Phase 1 (A7): OS-authoritative provenance source (enumerate ALL op-ctx builders)
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
             render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
             embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -429,6 +429,38 @@ class PipelineInstallIROp(BaseModel):
     source: str | None = None                   # git/GitHub URL (installs to .reyn/pipelines/<name>/)
 
 
+class PresentationInstallIROp(BaseModel):
+    """Register a named presentation template into the project presentations
+    config (proposal 0060 Phase 1 Layer A, A8). Mirrors ``SkillInstallIROp`` /
+    ``PipelineInstallIROp``'s STRUCTURE (permission gate → config write →
+    ``record_config_generation`` → emit event → hot-reload), but the threat is
+    LOWER than either — a present ``blueprint`` is structurally non-executable
+    by construction (``reyn.core.present.catalog``: 8 fixed components, every
+    non-literal value is a ``$bind`` RFC-6901 JSON-Pointer, no template-ref /
+    eval / exec surface, ``image.src`` renders as a label — no fetch/SSRF).
+    ``validate_blueprint`` (the SAME structural gate an inline ``present``
+    blueprint already passes through) already fills the role
+    ``scan_for_threats`` fills for skill/pipeline free-text ``description`` —
+    so this op has no free-text field and therefore no ``scan_for_threats``
+    call in its handler.
+
+    Unlike skill/pipeline, there is no source/git-fetch path — a blueprint is
+    small declarative data carried inline (mirrors
+    ``reyn.data.presentations.registry``'s inline-blueprint-in-entry model),
+    never a file-backed artifact.
+
+    ``name`` is the registry key a ``present(view=...)`` op resolves against
+    (mirrors the config-entries key). ``blueprint`` is the same declarative
+    component tree an inline ``present(blueprint=...)`` accepts — it is
+    validated through the identical :func:`validate_blueprint` gate before the
+    entry is written, so a malformed / non-catalog blueprint is refused BEFORE
+    any config mutation.
+    """
+    kind: Literal["presentation_install"]
+    name: str                                    # registry key (present(view=<name>) resolves against this)
+    blueprint: "dict[str, Any] | list[Any]"       # the declarative component tree (same shape as inline present)
+
+
 class EmitHookEventIROp(BaseModel):
     """Emit an LLM-authored hook-event onto this session's ``HookBus`` (Hook-Event
     Redesign Phase 5 part 2, proposal ``docs/deep-dives/proposals/
@@ -911,6 +943,10 @@ OP_KIND_MODEL_MAP: dict[str, type[BaseModel]] = {
     # pipeline install — register a pipeline DSL file into pipelines.entries
     # (mirrors skill_install writing skills.entries; parallel install mechanism).
     "pipeline_install": PipelineInstallIROp,
+    # proposal 0060 Phase 1 Layer A (A8): register a named presentation template
+    # into presentations.entries (mirrors skill_install/pipeline_install's
+    # structure; lower threat — validate_blueprint IS the structural gate).
+    "presentation_install": PresentationInstallIROp,
     # Hook-Event Redesign Phase 5 part 2 (proposal 0059 §8): LLM-authored
     # hook-event emission onto the caller's own HookBus. See EmitHookEventIROp's
     # docstring for the structural session-binding + kind-whitelist security
@@ -953,6 +989,7 @@ if TYPE_CHECKING:
             TaskCommentIROp,
             SkillInstallIROp,
             PipelineInstallIROp,
+            PresentationInstallIROp,
             EmitHookEventIROp,
         ],
         Field(discriminator="kind"),

--- a/src/reyn/tools/__init__.py
+++ b/src/reyn/tools/__init__.py
@@ -107,6 +107,7 @@ def get_default_registry() -> ToolRegistry:
         RUN_PIPELINE_INLINE_ASYNC,
     )
     from reyn.tools.present import PRESENT
+    from reyn.tools.presentation_management_verbs import PRESENTATION_INSTALL
     from reyn.tools.render_template import RENDER_TEMPLATE
     from reyn.tools.reyn_src import (
         REYN_SRC_GLOB,
@@ -264,6 +265,9 @@ def get_default_registry() -> ToolRegistry:
     # source fetch) — mirrors SKILL_INSTALL_LOCAL / SKILL_INSTALL_SOURCE.
     registry.register(PIPELINE_INSTALL_LOCAL)
     registry.register(PIPELINE_INSTALL_SOURCE)
+    # proposal 0060 Phase 1 Layer A (A8): present-view install verb (register a
+    # named presentation template) — mirrors SKILL_INSTALL_LOCAL / PIPELINE_INSTALL_LOCAL.
+    registry.register(PRESENTATION_INSTALL)
     # IS-1 (pipeline v0.9 R6): run_pipeline — sync launch of a REGISTERED
     # pipeline. Router+phase allow. IS-5: surfaced to the live LLM catalog
     # via the ``pipeline`` universal-catalog category enumerator (lists

--- a/src/reyn/tools/descriptions/presentation_management.py
+++ b/src/reyn/tools/descriptions/presentation_management.py
@@ -1,0 +1,77 @@
+"""Tool descriptions for the ``presentation_management`` bucket (proposal 0060
+Phase 1 Layer A, A8).
+
+The single install verb from ``tools/presentation_management_verbs.py`` —
+``presentation_management__install`` (register a named presentation template
+into the project config). Mirrors the ``skill`` / ``pipeline_management``
+description-package precedent (Phase 3 tool-description package refactor
+pattern), applied fresh here since present-install is a new op (no
+byte-identical-relocation constraint applies to a first-time description).
+"""
+from __future__ import annotations
+
+from reyn.tools.descriptions._types import ParamDescription, ToolDescription
+
+presentation_install = ToolDescription(
+    tool_name="presentation_install_local",
+    surfaced="router + phase (gates.router=allow, gates.phase=allow)",
+    purpose=(
+        "Register a named presentation template (a declarative component "
+        "tree) into the project config so a present(view=<name>) op can "
+        "resolve it, becoming available to sessions after the next "
+        "hot-reload."
+    ),
+    text=(
+        "Register a named presentation template into the project config by "
+        "writing an entry to .reyn/config/presentations.yaml. The blueprint "
+        "must use only the catalog components (text/markdown/code/diff/"
+        "keyvalue/table/list/image) with $bind JSON-Pointer bindings — the "
+        "same structural gate an inline present(blueprint=...) already "
+        "passes through, so a malformed blueprint is refused before any "
+        "config mutation. The template is immediately available to "
+        "sessions after the next hot-reload, and renders only when a "
+        "present(view=<name>) op names it — installing it never renders "
+        "anything on its own."
+    ),
+    ja=(
+        "宣言的なコンポーネントツリー（プレゼンテーションテンプレート）を"
+        "名前付きでプロジェクト設定に登録する（.reyn/config/presentations.yaml "
+        "にエントリを書き込む）。次のホットリロード後、present(view=<name>) "
+        "から即座に解決可能になる。"
+    ),
+)
+
+ALL: dict[str, ToolDescription] = {
+    "presentation_install_local": presentation_install,
+}
+
+
+# ── per-parameter descriptions ────────────────────────────────────────────
+
+PARAMS: dict[str, dict[str, ParamDescription]] = {
+    "presentation_install_local": {
+        "name": ParamDescription(
+            text=(
+                "Config key written under presentations.entries.<name> — "
+                "the value a present(view=<name>) op resolves against."
+            ),
+            ja=(
+                "presentations.entries.<name> に書き込まれる設定キー。"
+                "present(view=<name>) が解決する値。"
+            ),
+        ),
+        "blueprint": ParamDescription(
+            text=(
+                "The declarative component tree (same shape as an inline "
+                "present(blueprint=...) — object or list of catalog "
+                "component nodes with $bind JSON-Pointer bindings)."
+            ),
+            ja=(
+                "宣言的なコンポーネントツリー（インラインの "
+                "present(blueprint=...) と同じ形— カタログコンポーネント"
+                "ノードのオブジェクトまたはリスト、$bind JSON-Pointer "
+                "バインディング付き）。"
+            ),
+        ),
+    },
+}

--- a/src/reyn/tools/presentation_management_verbs.py
+++ b/src/reyn/tools/presentation_management_verbs.py
@@ -1,0 +1,137 @@
+"""Presentation verb-object handler — install (proposal 0060 Phase 1 Layer A, A8).
+
+Router-callable presentation management verb under the ``presentation_management``
+category:
+
+  - ``presentation_management__install`` — register a named presentation
+    template (a declarative component tree) into the project
+    ``.reyn/config/presentations.yaml``, making it available to sessions that
+    load the config cascade.
+
+Mirrors ``skill_verbs.py`` / ``pipeline_management_verbs.py`` STRUCTURE (a
+single delegating handler + ``ToolDefinition``), but there is only ONE verb —
+unlike skill/pipeline, a presentation blueprint is small declarative data
+carried inline (never a file-backed artifact), so there is no
+``install_source`` git-fetch counterpart.
+
+NOTE: there is no ``presentation__`` resource-category prefix today (present
+templates are resolved via ``present(view=<name>)``, not a per-template
+dynamic-dispatch verb) — so ``presentation_management__`` is namespaced purely
+for consistency with ``skill_management__`` / ``pipeline_management__``, not to
+avoid an actual collision.
+
+Delegates to ``op_runtime/presentation_install.py`` via the
+``build_legacy_op_context`` bridge (same pattern as the skill/pipeline/mcp
+install verbs).
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from reyn.tools.descriptions import presentation_management as _presentation_descriptions
+from reyn.tools.types import ToolContext, ToolDefinition, ToolGates, ToolResult
+
+# ── presentation_management__install ─────────────────────────────────────────
+
+_PRESENTATION_INSTALL_DESCRIPTION = _presentation_descriptions.presentation_install.text
+
+_PRESENTATION_INSTALL_PARAMETERS: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": (
+                _presentation_descriptions.PARAMS["presentation_install_local"]["name"].text
+            ),
+        },
+        "blueprint": {
+            "description": (
+                _presentation_descriptions.PARAMS["presentation_install_local"]["blueprint"].text
+            ),
+        },
+    },
+    "required": ["name", "blueprint"],
+}
+
+
+async def _handle_presentation_install(
+    args: Mapping[str, Any], ctx: ToolContext,
+) -> ToolResult:
+    """Register a named presentation template by writing .reyn/config/presentations.yaml.
+
+    Delegates to op_runtime/presentation_install.handle via
+    build_legacy_op_context (same bridge pattern as skill/pipeline/mcp-install
+    verbs). The handler structurally validates the blueprint
+    (validate_blueprint — the threat gate, A8), gates the config write,
+    writes the entry with an OS-stamped provenance (A9), records a config
+    generation for crash-recovery, emits a presentation_installed event, and
+    requests a hot-reload.
+    """
+    from reyn.core.op_runtime.presentation_install import (
+        handle as presentation_install_handle,
+    )
+    from reyn.schemas.models import PresentationInstallIROp
+    from reyn.security.permissions.permissions import PermissionDecl
+    from reyn.tools.op_context_bridge import build_legacy_op_context
+
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return {
+            "status": "error",
+            "data": {"error": "name is required"},
+        }
+
+    blueprint = args.get("blueprint")
+    if blueprint is None:
+        return {
+            "status": "error",
+            "data": {"error": "blueprint is required"},
+        }
+
+    try:
+        op = PresentationInstallIROp(
+            kind="presentation_install",
+            name=name,
+            blueprint=blueprint,
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "data": {"error": f"invalid args: {exc}"},
+        }
+
+    decl = PermissionDecl()
+    decl.file_write = [{"path": ".reyn/config/presentations.yaml"}]
+
+    op_ctx = build_legacy_op_context(ctx)
+    op_ctx.permission_decl = decl
+    op_ctx.actor = "presentation_management__install"
+
+    result = await presentation_install_handle(op, op_ctx)
+    return {"status": "ok", "data": result}
+
+
+# ── ToolDefinition ────────────────────────────────────────────────────────────
+
+from reyn.core.offload.canonical import (  # noqa: E402
+    presentation_install_verb_to_canonical,
+)
+
+PRESENTATION_INSTALL = ToolDefinition(
+    canonical=presentation_install_verb_to_canonical,
+    # NOTE: named "presentation_install_local" (not the bare "presentation_install"
+    # op kind) — the tool-name and op-kind identities are separate
+    # declare_canonical source_ids (mirrors skill_install_local/skill_install vs
+    # pipeline_install_local/pipeline_install); reusing the op-kind's bare name
+    # here collides its STRUCTURED_PASSTHROUGH op-runtime declaration with this
+    # tool's own mapper declaration under the SAME source_id.
+    name="presentation_install_local",
+    description=_PRESENTATION_INSTALL_DESCRIPTION,
+    parameters=_PRESENTATION_INSTALL_PARAMETERS,
+    gates=ToolGates(router="allow", phase="allow"),
+    handler=_handle_presentation_install,
+    category="io",
+    purity="side_effect",
+)
+
+__all__ = ["PRESENTATION_INSTALL"]

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -98,6 +98,11 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # ``pipeline__`` resource category (per-registered-pipeline dynamic
     # dispatch); this is the management plane — mirrors ``skill_management``.
     "pipeline_management",
+    # proposal 0060 Phase 1 Layer A (A8): presentation management ops (install).
+    # Single verb (no source/git-fetch counterpart — a blueprint is inline
+    # declarative data). Management plane — mirrors ``skill_management`` /
+    # ``pipeline_management``.
+    "presentation_management",
 )
 
 
@@ -580,6 +585,11 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
         # repeat the same gap.
         "skill_management",
         "pipeline_management",
+        # proposal 0060 Phase 1 Layer A (A8): same enumeration wiring as
+        # skill_management / pipeline_management so
+        # list_actions(category=["presentation_management"]) surfaces the
+        # install verb (not just dispatchable-but-invisible).
+        "presentation_management",
     ):
         return _enumerate_static_category(category)
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -348,6 +348,11 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     "pipeline_management__install_local":  ("pipeline_install_local",  _passthrough_args),
     "pipeline_management__install_source": ("pipeline_install_source", _passthrough_args),
 
+    # presentation_management category (proposal 0060 Phase 1 Layer A / A8):
+    # register a named presentation template. Single verb (no source/git-fetch
+    # counterpart — a blueprint is inline declarative data, never file-backed).
+    "presentation_management__install": ("presentation_install_local", _passthrough_args),
+
     # pipeline category (IS-1: sync + REGISTERED-only run_pipeline;
     # IS-2: async launch in a crash-recoverable driver-session;
     # IS-4: ad-hoc INLINE launches — agent-GENERATED DSL + a static-analysis

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -72,6 +72,7 @@ def make_adapter(
     session_id: "str | None" = None,
     current_task_id_fn: "object | None" = None,  # #1953 §16: per-turn execution context
     turn_origin_fn: "object | None" = None,  # proposal 0060 Phase 1 (A7): per-turn provenance source
+    workspace_base_dir: "object | None" = None,  # router-op-ctx Workspace root (else cwd)
     agent_registry: object = None,  # #2103: real AgentRegistry for spawn/topology seams
     pipeline_registry: object = None,  # IS-5: real PipelineRegistry for run_pipeline lookup
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
@@ -160,4 +161,5 @@ def make_adapter(
         session_id=session_id,
         current_task_id_fn=current_task_id_fn,
         turn_origin_fn=turn_origin_fn,
+        workspace_base_dir=workspace_base_dir,
     )

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -71,6 +71,7 @@ def make_adapter(
     task_waker: object = None,    # #2107: OS TaskWaker (router task.* terminal → requester wake)
     session_id: "str | None" = None,
     current_task_id_fn: "object | None" = None,  # #1953 §16: per-turn execution context
+    turn_origin_fn: "object | None" = None,  # proposal 0060 Phase 1 (A7): per-turn provenance source
     agent_registry: object = None,  # #2103: real AgentRegistry for spawn/topology seams
     pipeline_registry: object = None,  # IS-5: real PipelineRegistry for run_pipeline lookup
     on_limit: object = None,  # #2175: OnLimitConfig for the spawn-limit checkpoint (None → no checkpoint = unattended reject)
@@ -158,4 +159,5 @@ def make_adapter(
         task_waker=task_waker,
         session_id=session_id,
         current_task_id_fn=current_task_id_fn,
+        turn_origin_fn=turn_origin_fn,
     )

--- a/tests/test_0060_phase1_layer_a.py
+++ b/tests/test_0060_phase1_layer_a.py
@@ -1,0 +1,239 @@
+"""Tier 2: OS invariant — proposal 0060 Phase 1 Layer A (A7 turn_origin seam,
+A9 uniform provenance stamp, A8 presentation_install op).
+
+Co-vet pins (docs/deep-dives/proposals/0060-llm-wielding-foundation.md,
+Addendum B — settled design record):
+
+  1. **Provenance is (2)B-structural** (mirrors emit_hook_event's ctx-side
+     kind-construction falsify): the presentation_install op schema has NO
+     provenance field; the handler stamps ONLY from ctx.turn_origin. Falsify:
+     an auto_improvement-provenance ctx + a handler reading a spoofed op-level
+     value would let the LLM self-declare user_directed — the REAL handler
+     must not do this (asserted directly: PresentationInstallIROp has no
+     provenance field to spoof, AND the written entry always equals
+     ctx.turn_origin regardless of anything on the op).
+  2. **turn_origin completeness is fail-safe**: every turn kind
+     Session.run_one_iteration dispatches maps through
+     _stamp_execution_context; an unmapped/new kind resolves to
+     "auto_improvement", NEVER "user_directed". Falsify: introduce a brand-new
+     kind with no dedicated mapping entry → if it resolved to "user_directed"
+     this test goes RED (fail-safe broken).
+  3. **present-install threat gate is validate_blueprint**: a malformed /
+     non-catalog blueprint is refused before any config mutation. Falsify:
+     strip the validate_blueprint call from the install path → a malformed
+     blueprint installs → RED.
+
+Real PermissionResolver + StateLog + OpContext + a real Session throughout
+(no mocks) — mirrors test_skill_install_pr_c.py / test_pipeline_install.py.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.presentation_install import handle as presentation_install_handle
+from reyn.core.present import PresentBlueprintError, validate_blueprint
+from reyn.runtime.session import Session
+from reyn.schemas.models import PresentationInstallIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from tests._support.router_host_adapter import make_adapter
+
+# ── shared stubs (real API surface, no mocks) ─────────────────────────────────
+
+
+class _StubWorkspace:
+    def __init__(self, base_dir: Path) -> None:
+        self.base_dir = base_dir
+
+
+class _Events:
+    """Minimal real-callable event log stub — passes emit calls through without side effects."""
+    subscribers: list = []
+
+    def emit(self, *_a, **_k) -> None:
+        pass
+
+
+def _make_ctx(
+    tmp_path: Path, *, turn_origin: "str | None", state_log: StateLog | None = None,
+) -> OpContext:
+    """A real OpContext with a PermissionResolver that allows presentations.yaml
+    writes, and a caller-chosen turn_origin (the field under test — mirrors the
+    OS-set value ``_stamp_execution_context`` would have produced for the turn)."""
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+
+    decl = PermissionDecl(
+        file_write=[{"path": str(config_path), "scope": "just_path"}],
+    )
+    return OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=state_log,
+        turn_origin=turn_origin,
+    )
+
+
+_VALID_BLUEPRINT = {"component": "text", "text": "hello"}
+
+
+# ── Test 1: (2)B-structural — no op-level provenance field to spoof ───────────
+
+
+def test_presentation_install_op_schema_has_no_provenance_field():
+    """Tier 2: (2)B-structural — PresentationInstallIROp carries NO provenance
+    field. Falsify: if a future edit adds ``provenance`` to the schema, an LLM
+    could set it directly and this assertion goes RED (the schema must stay
+    provenance-field-free; the value's authority lives ONLY in ctx.turn_origin,
+    A9)."""
+    op = PresentationInstallIROp(
+        kind="presentation_install", name="x", blueprint=_VALID_BLUEPRINT,
+    )
+    assert "provenance" not in type(op).model_fields
+
+
+@pytest.mark.asyncio
+async def test_presentation_install_stamps_provenance_from_ctx_only_not_op(tmp_path):
+    """Tier 2: (2)B-structural falsify — the handler stamps entry["provenance"]
+    from ctx.turn_origin ALONE. Simulates the spoof attempt: an op instance
+    carries no provenance field at all (confirmed above), so even a
+    maximally-adversarial op construction cannot influence the written value —
+    only ctx does. Two ctx values (one per provenance) → two installs → the
+    written entries differ ONLY by ctx.turn_origin, proving the value's sole
+    source. RED if the handler ever reads anything but ctx.turn_origin (e.g. a
+    stray op.provenance / op.extra kwarg smuggled through)."""
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+
+    ctx_auto = _make_ctx(tmp_path, turn_origin="auto_improvement")
+    op = PresentationInstallIROp(
+        kind="presentation_install", name="card_a", blueprint=_VALID_BLUEPRINT,
+    )
+    result_auto = await presentation_install_handle(op, ctx_auto)
+    assert result_auto["status"] == "installed"
+
+    ctx_user = _make_ctx(tmp_path, turn_origin="user_directed")
+    op2 = PresentationInstallIROp(
+        kind="presentation_install", name="card_b", blueprint=_VALID_BLUEPRINT,
+    )
+    result_user = await presentation_install_handle(op2, ctx_user)
+    assert result_user["status"] == "installed"
+
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    entries = written["presentations"]["entries"]
+    assert entries["card_a"]["provenance"] == "auto_improvement"
+    assert entries["card_b"]["provenance"] == "user_directed"
+
+
+# ── Test 2: turn_origin completeness fail-safe ────────────────────────────────
+
+
+def test_turn_origin_maps_every_known_kind_and_fails_safe_on_unmapped(tmp_path):
+    """Tier 2: A7 fail-safe — ONLY an explicit kind=="user" turn grants
+    "user_directed"; every other known kind (hook / pipeline_result / the wake
+    family / agent_request / agent_response) AND a brand-new, never-registered
+    kind all resolve to "auto_improvement". Asserts on the PUBLIC op-ctx output
+    (current adapter's turn_origin), not private state — mirrors the sibling
+    _stamp_execution_context / current_task_id completeness test
+    (test_2107_B15_preserve_self_continuation_1953.py). FALSIFY: if an unmapped
+    kind fell through to "user_directed", this test goes RED (a Phase-4-gate
+    bypass — 0060 SS2.7)."""
+    s = Session(agent_name="alice", state_log=StateLog(tmp_path / "wal.jsonl"))
+    adapter = make_adapter(
+        agent_name="alice", turn_origin_fn=lambda: s._current_turn_origin,
+    )
+
+    def current() -> "str | None":
+        return adapter.make_router_op_context().turn_origin
+
+    # The ONLY kind granting user_directed.
+    s._stamp_execution_context("user", {})
+    assert current() == "user_directed"
+
+    # Every other DISPATCHED kind (hook self-continuation, sub-agent turns, the
+    # wake family, an async pipeline's terminal result) resolves to the
+    # stricter auto_improvement — including kinds that PRESERVE current_task_id
+    # (hook/agent_response): turn_origin has its OWN (simpler) fail-safe rule,
+    # not derived from the task-ownership PRESERVE/RESET bands.
+    for kind in (
+        "hook", "agent_response", "agent_request", "pipeline_result",
+        "task_ready", "task_dependency_aborted",
+        # a brand-new kind this method has never seen before.
+        "some_unknown_future_kind_0060",
+    ):
+        s._stamp_execution_context(kind, {"meta": {}})
+        assert current() == "auto_improvement", (
+            f"kind={kind!r} must fail-safe to auto_improvement, never silently "
+            "default to user_directed"
+        )
+
+    # Re-arming with "user" and then a fresh unmapped kind still fails safe
+    # (not "sticky user" — every turn is reclassified from scratch).
+    s._stamp_execution_context("user", {})
+    assert current() == "user_directed"
+    s._stamp_execution_context("brand_new_kind_never_seen", {})
+    assert current() == "auto_improvement"
+
+
+# ── Test 3: present-install threat gate is validate_blueprint ────────────────
+
+
+@pytest.mark.asyncio
+async def test_malformed_blueprint_is_blocked_before_any_config_write(tmp_path):
+    """Tier 2: A8 — validate_blueprint IS the structural threat gate for
+    presentation_install (no scan_for_threats call — there is no free-text
+    field). A non-catalog component is refused BEFORE any config mutation:
+    status="blocked", no presentations.yaml written at all. FALSIFY: if the
+    handler's validate_blueprint call were stripped, the malformed blueprint
+    below would install successfully → RED."""
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    ctx = _make_ctx(tmp_path, turn_origin="user_directed")
+
+    # Sanity: this blueprint really is rejected by the structural gate itself
+    # (confirms the fixture is a true negative, not an accidentally-valid one).
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint({"component": "not_in_catalog", "text": "hi"})
+
+    op = PresentationInstallIROp(
+        kind="presentation_install",
+        name="evil",
+        blueprint={"component": "not_in_catalog", "text": "hi"},
+    )
+    result = await presentation_install_handle(op, ctx)
+    assert result["status"] == "blocked"
+    assert not config_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_valid_blueprint_installs_and_registry_accepts_it(tmp_path):
+    """Tier 2: positive control for test 3 — a catalog-valid blueprint installs
+    (status="installed") and the written presentations.yaml entry is itself
+    accepted by build_presentation_registry (the same structural gate the
+    op-install path and the config-load path both run through)."""
+    from reyn.data.presentations.registry import build_presentation_registry
+
+    ctx = _make_ctx(tmp_path, turn_origin="user_directed")
+    op = PresentationInstallIROp(
+        kind="presentation_install", name="hello_card", blueprint=_VALID_BLUEPRINT,
+    )
+    result = await presentation_install_handle(op, ctx)
+    assert result["status"] == "installed"
+    assert result["name"] == "hello_card"
+
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    registry = build_presentation_registry(raw["presentations"], strict=True)
+    assert registry.has("hello_card")

--- a/tests/test_0060_phase1_layer_a.py
+++ b/tests/test_0060_phase1_layer_a.py
@@ -23,8 +23,29 @@ Addendum B — settled design record):
      strip the validate_blueprint call from the install path → a malformed
      blueprint installs → RED.
 
-Real PermissionResolver + StateLog + OpContext + a real Session throughout
-(no mocks) — mirrors test_skill_install_pr_c.py / test_pipeline_install.py.
+Wiring-seam witnesses (architect co-vet on #2903, the emit_hook_event #2887
+class — a production tool path bypassing the ctx-factory that threads
+turn_origin). TWO DISTINCT witnesses:
+
+  4. **End-to-end wiring witness**: a REAL autonomous (hook-driven) turn driven
+     through the REAL presentation_management__install tool-invocation path
+     (PRESENTATION_INSTALL.handler → build_legacy_op_context →
+     router_state.op_context_factory = the adapter's make_router_op_context,
+     which threads turn_origin) → the written entry's provenance ==
+     "auto_improvement". Proves the production tool path carries the OS-set
+     provenance END-TO-END, not just the factory in isolation.
+  5. **Fail-safe strip-witness (independent, LOAD-BEARING)**: an OpContext whose
+     turn_origin is None/unset (a bridge-fallback synthesis path) reaching the
+     handler stamps provenance="auto_improvement", never None. Falsify: strip
+     the handler's provenance_from_ctx None→auto_improvement default (stamp
+     ctx.turn_origin directly) → the entry lands provenance=None (ungated,
+     escapes the Phase-4 gate) → RED. Proves the fail-safe closes the
+     gate-bypass by construction, not merely a default that happens to exist.
+
+Real PermissionResolver + StateLog + OpContext + a real Session + the real
+RouterHostAdapter op-ctx factory throughout (no mocks) — mirrors
+test_skill_install_pr_c.py / test_pipeline_install.py /
+test_emit_hook_event_0059_phase5_part2.py's production-path test.
 """
 from __future__ import annotations
 
@@ -237,3 +258,102 @@ async def test_valid_blueprint_installs_and_registry_accepts_it(tmp_path):
     raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     registry = build_presentation_registry(raw["presentations"], strict=True)
     assert registry.has("hello_card")
+
+
+# ── Test 4: end-to-end wiring witness (real hook turn → real tool path) ───────
+
+
+@pytest.mark.asyncio
+async def test_hook_turn_through_real_tool_path_stamps_auto_improvement(tmp_path):
+    """Tier 2: end-to-end wiring witness (#2903 architect co-vet, the #2887
+    class) — a REAL autonomous (hook-driven) turn driven through the REAL
+    presentation_management__install tool-invocation path stamps
+    provenance="auto_improvement" on the written entry.
+
+    Path exercised (production, no mocks): a real Session is stamped with a
+    ``hook`` self-continuation turn (autonomous, NOT a user turn) →
+    ``_current_turn_origin == "auto_improvement"``. A REAL RouterHostAdapter's
+    ``make_router_op_context`` (the exact ``op_context_factory`` production binds
+    at tools/types.py) is wired as ``router_state.op_context_factory``, reading
+    the session's turn_origin. The REAL ``PRESENTATION_INSTALL.handler`` verb
+    runs → ``build_legacy_op_context`` calls that factory → the OpContext
+    carries turn_origin → the handler writes the entry. Asserts the written
+    provenance is "auto_improvement".
+
+    FALSIFY: if ``make_router_op_context`` stopped threading turn_origin AND the
+    handler fail-safe were stripped, the written entry would be None → RED. This
+    is the witness the emit #2887 gap needed: the PRODUCTION tool path carries
+    the OS-set provenance end-to-end, not just the factory in isolation."""
+    from reyn.tools.presentation_management_verbs import PRESENTATION_INSTALL
+    from reyn.tools.types import RouterCallerState, ToolContext
+
+    s = Session(agent_name="alice", state_log=StateLog(tmp_path / "wal.jsonl"))
+    # a REAL autonomous turn: a hook self-continuation (NOT a user turn).
+    s._stamp_execution_context("hook", {"text": "autonomous continuation"})
+
+    adapter = make_adapter(
+        agent_name="alice",
+        turn_origin_fn=lambda: s._current_turn_origin,
+        workspace_base_dir=tmp_path,
+    )
+    # Precondition on the PUBLIC op-ctx output (not private state): the real
+    # production factory already classifies this hook turn as auto_improvement.
+    assert adapter.make_router_op_context().turn_origin == "auto_improvement"
+
+    router_state = RouterCallerState(
+        op_context_factory=adapter.make_router_op_context,
+    )
+    tool_ctx = ToolContext(
+        events=_Events(),
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=router_state,
+    )
+
+    result = await PRESENTATION_INSTALL.handler(
+        {"name": "auto_card", "blueprint": _VALID_BLUEPRINT}, tool_ctx,
+    )
+    assert result["status"] == "ok"
+    assert result["data"]["status"] == "installed"
+
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    prov = written["presentations"]["entries"]["auto_card"]["provenance"]
+    assert prov == "auto_improvement"
+
+
+# ── Test 5: fail-safe strip-witness (LOAD-BEARING, independent) ──────────────
+
+
+@pytest.mark.asyncio
+async def test_unset_turn_origin_fails_safe_to_auto_improvement(tmp_path):
+    """Tier 2: LOAD-BEARING fail-safe strip-witness (#2903 architect co-vet) —
+    an OpContext whose ``turn_origin`` is None/unset (the ``build_legacy_op_context``
+    bridge-FALLBACK synthesis path — a phase/direct/future bridge caller that did
+    NOT thread turn_origin) reaching the handler stamps
+    provenance="auto_improvement", NEVER None, NEVER user_directed.
+
+    This closes a gate-bypass: a ``provenance=None`` install is UNGATED — it
+    escapes the Phase-4 auto-improvement gate whose foundation is this value.
+
+    FALSIFY: strip the handler's ``provenance_from_ctx`` None→auto_improvement
+    default (stamp ``ctx.turn_origin`` directly instead) → the written entry
+    lands ``provenance: null`` → the equality assertion below goes RED. Proves
+    the fail-safe is load-bearing (closes the bypass by construction), not a
+    cosmetic default. Independent of the end-to-end witness above: this
+    exercises the UNSET input directly, not the wired production path."""
+    ctx = _make_ctx(tmp_path, turn_origin=None)  # the bridge-fallback shape: unset
+    assert ctx.turn_origin is None  # precondition: the risky input really is unset
+
+    op = PresentationInstallIROp(
+        kind="presentation_install", name="bridged", blueprint=_VALID_BLUEPRINT,
+    )
+    result = await presentation_install_handle(op, ctx)
+    assert result["status"] == "installed"
+
+    config_path = tmp_path / ".reyn" / "config" / "presentations.yaml"
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    prov = written["presentations"]["entries"]["bridged"]["provenance"]
+    assert prov == "auto_improvement"  # RED if the None→auto default is stripped
+    assert prov is not None

--- a/tests/test_0060_phase1_layer_a.py
+++ b/tests/test_0060_phase1_layer_a.py
@@ -357,3 +357,125 @@ async def test_unset_turn_origin_fails_safe_to_auto_improvement(tmp_path):
     prov = written["presentations"]["entries"]["bridged"]["provenance"]
     assert prov == "auto_improvement"  # RED if the None→auto default is stripped
     assert prov is not None
+
+
+# ── Test 6 + 7: per-stamper fail-safe strip-witnesses (skill + pipeline) ─────
+#
+# The present-install strip-witness (test 5) only pins ONE of the three install
+# stampers. The skill and pipeline stampers use the SAME provenance_from_ctx
+# fail-safe, but without their OWN strip-witness a future revert of either to
+# raw ``entry["provenance"] = ctx.turn_origin`` would silent-ship (green-on-
+# strip) — re-opening the gate-bypass on those 2 paths. These two witnesses pin
+# each independently (architect co-vet on #2903, the #2900 STEP-4 green-on-strip
+# class).
+
+
+def _skill_ctx(tmp_path: Path) -> OpContext:
+    """A real OpContext approving skills.yaml writes, turn_origin UNSET (None) —
+    the bridge-fallback shape (mirrors test_skill_install_pr_c.py's _make_ctx)."""
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+    decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
+    return OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=None,
+    )  # turn_origin defaults to None — the unset/bridge-fallback shape
+
+
+def _pipeline_ctx(tmp_path: Path) -> OpContext:
+    """A real OpContext approving pipelines.yaml writes, turn_origin UNSET (None)."""
+    config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=tmp_path, interactive=False,
+    )
+    resolver.session_approve_path(str(config_path), "test", "file.write")
+    decl = PermissionDecl(file_write=[{"path": str(config_path), "scope": "just_path"}])
+    return OpContext(
+        workspace=_StubWorkspace(base_dir=tmp_path),
+        events=_Events(),
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+        subscribers=[],
+        state_log=None,
+    )  # turn_origin defaults to None
+
+
+@pytest.mark.asyncio
+async def test_skill_install_unset_turn_origin_fails_safe_to_auto_improvement(tmp_path):
+    """Tier 2: LOAD-BEARING fail-safe strip-witness for the SKILL stamper
+    (#2903 co-vet). A real skill_install with ctx.turn_origin=None/unset (the
+    bridge-fallback shape) writes provenance="auto_improvement", never None.
+    FALSIFY: revert skill_install's ``entry["provenance"] = _provenance_from_ctx(ctx)``
+    to raw ``ctx.turn_origin`` (or strip provenance_from_ctx's None→auto for its
+    path) → the entry lands provenance=None → RED. Pins the skill path's
+    gate-bypass guard independently of present's (test 5)."""
+    from reyn.core.op_runtime.skill_install import handle as skill_install_handle
+    from reyn.schemas.models import SkillInstallIROp
+
+    skill_dir = tmp_path / "skills" / "my-skill"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: my-skill\ndescription: A test skill\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    ctx = _skill_ctx(tmp_path)
+    assert ctx.turn_origin is None  # precondition: the risky input really is unset
+
+    result = await skill_install_handle(
+        SkillInstallIROp(kind="skill_install", path=str(skill_dir)), ctx,
+    )
+    assert result["status"] == "installed"
+
+    config_path = tmp_path / ".reyn" / "config" / "skills.yaml"
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    prov = written["skills"]["entries"]["my-skill"]["provenance"]
+    assert prov == "auto_improvement"  # RED if the skill stamper's fail-safe is stripped
+    assert prov is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_install_unset_turn_origin_fails_safe_to_auto_improvement(tmp_path):
+    """Tier 2: LOAD-BEARING fail-safe strip-witness for the PIPELINE stamper
+    (#2903 co-vet). A real pipeline_install with ctx.turn_origin=None/unset
+    writes provenance="auto_improvement", never None. FALSIFY: revert
+    pipeline_install's ``entry["provenance"] = _provenance_from_ctx(ctx)`` to raw
+    ``ctx.turn_origin`` → the entry lands provenance=None → RED. Pins the
+    pipeline path's gate-bypass guard independently of present's (test 5)."""
+    from reyn.core.op_runtime.pipeline_install import handle as pipeline_install_handle
+    from reyn.schemas.models import PipelineInstallIROp
+
+    dsl_path = tmp_path / "pipelines" / "hello.yaml"
+    dsl_path.parent.mkdir(parents=True, exist_ok=True)
+    dsl_path.write_text(
+        "pipeline: hello\n"
+        "description: A test pipeline\n"
+        "steps:\n"
+        "  - transform: {value: \"1 + 1\", output: two}\n",
+        encoding="utf-8",
+    )
+    ctx = _pipeline_ctx(tmp_path)
+    assert ctx.turn_origin is None  # precondition: the risky input really is unset
+
+    result = await pipeline_install_handle(
+        PipelineInstallIROp(kind="pipeline_install", path=str(dsl_path)), ctx,
+    )
+    assert result["status"] == "installed"
+
+    config_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    written = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    prov = written["pipelines"]["entries"]["hello"]["provenance"]
+    assert prov == "auto_improvement"  # RED if the pipeline stamper's fail-safe is stripped
+    assert prov is not None

--- a/tests/test_fp0056_canonical_coverage_gate.py
+++ b/tests/test_fp0056_canonical_coverage_gate.py
@@ -36,11 +36,15 @@ from reyn.tools.types import ToolDefinition, ToolGates
 
 # The admin/install family whose whole-dict result IS the reviewed, legitimate LLM view
 # (FP-0056 owner decision #1). STRUCTURED_PASSTHROUGH membership is EXACTLY this set — no more.
+# proposal 0060 Phase 1 Layer A (A8) added ``presentation_install`` — another
+# install-manifest producer (same admin class as skill_install/pipeline_install),
+# so the reviewed set is now the admin-7.
 _STRUCTURED_PASSTHROUGH_ADMIN_6 = frozenset({
     "mcp_install",
     "mcp_drop_server",
     "skill_install",
     "pipeline_install",
+    "presentation_install",
     "mcp_subscribe_resource",
     "mcp_unsubscribe_resource",
 })
@@ -140,7 +144,7 @@ def test_structured_passthrough_membership_is_exactly_the_admin_6() -> None:
         sid for sid in _all_source_ids() if canonical_declaration(sid) is STRUCTURED_PASSTHROUGH
     }
     assert live_passthrough == set(_STRUCTURED_PASSTHROUGH_ADMIN_6), (
-        f"STRUCTURED_PASSTHROUGH must be exactly the admin-6; got {sorted(live_passthrough)}"
+        f"STRUCTURED_PASSTHROUGH must be exactly the admin/install family; got {sorted(live_passthrough)}"
     )
 
 

--- a/tests/test_present_registry_fp0054_prc.py
+++ b/tests/test_present_registry_fp0054_prc.py
@@ -323,12 +323,19 @@ def test_referencing_a_template_name_never_registers_it(tmp_path: Path) -> None:
     assert registry.names() == ["authors"]
 
 
-def test_no_present_register_op_kind_exists() -> None:
-    """Tier 1: there is no op kind for the LLM to register a named template
-    (unlike skill_install / pipeline_install, presentations are operator-config
-    only — no install op). The only present-family op is `present` itself."""
+def test_present_family_op_kinds_are_exactly_present_and_install() -> None:
+    """Tier 1: the present-family op kinds are EXACTLY ``present`` (render) and
+    ``presentation_install`` (register a named template — proposal 0060 Phase 1
+    Layer A / A8). No other present op exists. Registration happens ONLY via the
+    dedicated, permission-gated install op — never as a side effect of a
+    ``present`` render (that read-only boundary is pinned by
+    ``test_referencing_a_template_name_never_registers_it`` above).
+
+    Prior to 0060 A8 presentations were operator-config only; A8 adds the
+    LLM-authorable install op (mirroring skill_install / pipeline_install,
+    gated by ``validate_blueprint`` — the structural threat gate)."""
     present_family = {k for k in ALL_OP_KINDS if "present" in k}
-    assert present_family == {"present"}
+    assert present_family == {"present", "presentation_install"}
 
 
 # ── Tier 2: hot-reload — a new template is visible at the next turn boundary ──

--- a/tests/test_returns_external_content_flagset_1822.py
+++ b/tests/test_returns_external_content_flagset_1822.py
@@ -93,6 +93,12 @@ _NOT_EXTERNAL = {
     # registration; the scan result is internal OS state, not forwarded
     # external content. Same rationale as skill_install_source.
     "pipeline_install_source",
+    # proposal 0060 Phase 1 Layer A (A8): presentation_install_local writes
+    # .reyn/config/presentations.yaml — returns an install status dict
+    # (name / config_path / status), not fetched external content. No git/source
+    # fetch path at all (a blueprint is inline declarative data). Same
+    # classification rationale as skill_install_local / pipeline_install_local.
+    "presentation_install_local",
     "cron_register", "cron_unregister", "cron_enable", "cron_disable",
     # #2073 S3: hooks_add writes .reyn/hooks.yaml + schedules a reload — returns a
     # status dict (on / added / reload_scheduled / path), not external content.

--- a/tests/test_router_sp_universal_categories.py
+++ b/tests/test_router_sp_universal_categories.py
@@ -8,7 +8,7 @@ directly and pass the result as ``tool_use_sp``.
 Coverage:
   - No tool_use_sp (None): SP excludes the section (bare OS frame)
   - universal_wrappers_enabled=False via slot-map: SP excludes the section
-  - universal_wrappers_enabled=True via slot-map: SP includes section + all 13 cats
+  - universal_wrappers_enabled=True via slot-map: SP includes section + all categories (== CATEGORIES)
   - Section placement relative to other sections
   - Section content notes qualified-name format + dispatch path
 
@@ -70,7 +70,7 @@ def test_default_matches_explicit_false() -> None:
     assert "## Action categories" not in explicit
 
 
-# ── 2. Flag on adds the section with all 13 categories ───────────────────
+# ── 2. Flag on adds the section with all categories (== CATEGORIES) ──────
 
 
 def test_flag_on_adds_action_categories_section() -> None:

--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -74,6 +74,11 @@ def test_categories_master_table_order() -> None:
         # ``pipeline__`` resource category; management plane (mirrors
         # ``skill_management``).
         "pipeline_management",
+        # proposal 0060 Phase 1 Layer A (A8): presentation management ops
+        # (install). Management plane (mirrors skill_management /
+        # pipeline_management); required for presentation_management__install to
+        # dispatch.
+        "presentation_management",
     )
 
 

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -593,6 +593,10 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
     ("pipeline_management__install_local",  {"path": "/tmp/my-pipeline.yaml"}),
     # pipeline_management category — install_source requires source URL.
     ("pipeline_management__install_source", {"source": "https://github.com/user/pipeline-repo"}),
+    # presentation_management category (proposal 0060 Phase 1 Layer A / A8) —
+    # install requires name + blueprint (no source/git-fetch counterpart).
+    ("presentation_management__install",
+     {"name": "status_card", "blueprint": {"component": "text", "text": "hi"}}),
     # pipeline category (IS-1) — run_pipeline requires name; input is optional.
     ("pipeline__run", {"name": "my_pipeline", "input": {"topic": "x"}}),
     # pipeline category (IS-2) — async launch, same surface as the sync verb.

--- a/tests/tools/_pre_migration_tool_schemas_baseline.json
+++ b/tests/tools/_pre_migration_tool_schemas_baseline.json
@@ -386,13 +386,13 @@
     "type": "function",
     "function": {
       "name": "emit_hook_event",
-      "description": "Emit a hook-event named event_name, scoped to YOUR OWN session (the actual kind is llm:<your-session-id>:<event_name> \u2014 you cannot target another session or another namespace like builtin:*/composed:*/webhook:*). Use this to signal completion of something a Composer or a hooks_add-registered hook is watching for. payload is an optional dict carried on the event for a matcher/Composer to inspect.",
+      "description": "Emit a hook-event named event_name, scoped to YOUR OWN session (the actual kind is llm:<your-session-id>:<event_name> — you cannot target another session or another namespace like builtin:*/composed:*/webhook:*). Use this to signal completion of something a Composer or a hooks_add-registered hook is watching for. payload is an optional dict carried on the event for a matcher/Composer to inspect.",
       "parameters": {
         "type": "object",
         "properties": {
           "event_name": {
             "type": "string",
-            "description": "The event's name (becomes the llm:<your-session-id>:<event_name> kind \u2014 you supply only this suffix, never the session component)."
+            "description": "The event's name (becomes the llm:<your-session-id>:<event_name> kind — you supply only this suffix, never the session component)."
           },
           "payload": {
             "type": "object",
@@ -638,14 +638,17 @@
     "type": "function"
   },
   "list_actions": {
+    "type": "function",
     "function": {
-      "description": "WHAT: Discover actions in the FULL catalog (= a superset of the hot-list function entries you can see directly). The hot-list shown in your function list is a curated subset; this tool reveals the rest. Filter by category: `category=[...]` array (enum-restricted, exact category match). Omit or pass [] to enumerate everything visible. Returns {items: [{qualified_name, short_description}, ...], total: int}. An empty items array means no actions match — report this honestly. WHEN: PREFERRED FIRST for known-category enumeration (e.g. 'show me all memory_entry actions', 'what exec actions are available?') or exact-name lookup when you already know the category but not the exact entry. ALWAYS call list_actions BEFORE refusing a category-listable capability request. Refusing without a list_actions check is a FAILURE MODE (= the action you assumed missing may exist behind the hot-list). For known-category enumeration pass `category=['exec']` to narrow. WHEN NOT: For semantic / natural-language / free-text discovery (e.g. 'find an action that can ...', 'related to X', 'something for X' — the request may be phrased in any language, including Japanese and other non-English input) use search_actions instead — it returns relevance-ranked matches across categories rather than a flat enumeration. If you already know the exact action name, skip both and call invoke_action directly. PREFERRED OVER: Guessing action names + refusing capability requests — list_actions returns the canonical qualified names (e.g. mcp__call_tool, multi_agent__delegate) that invoke_action and describe_action expect. POST_CALL: After list_actions reveals at least one matching action, you MUST follow with describe_action or invoke_action. Do NOT reply directly — silent stop after enumeration is a failure mode. When items is empty, honestly tell the user no matching actions are available.",
       "name": "list_actions",
+      "description": "WHAT: Discover actions in the FULL catalog (= a superset of the hot-list function entries you can see directly). The hot-list shown in your function list is a curated subset; this tool reveals the rest. Filter by category: `category=[...]` array (enum-restricted, exact category match). Omit or pass [] to enumerate everything visible. Returns {items: [{qualified_name, short_description}, ...], total: int}. An empty items array means no actions match — report this honestly. WHEN: PREFERRED FIRST for known-category enumeration (e.g. 'show me all memory_entry actions', 'what exec actions are available?') or exact-name lookup when you already know the category but not the exact entry. ALWAYS call list_actions BEFORE refusing a category-listable capability request. Refusing without a list_actions check is a FAILURE MODE (= the action you assumed missing may exist behind the hot-list). For known-category enumeration pass `category=['exec']` to narrow. WHEN NOT: For semantic / natural-language / free-text discovery (e.g. 'find an action that can ...', 'related to X', 'something for X' — the request may be phrased in any language, including Japanese and other non-English input) use search_actions instead — it returns relevance-ranked matches across categories rather than a flat enumeration. If you already know the exact action name, skip both and call invoke_action directly. PREFERRED OVER: Guessing action names + refusing capability requests — list_actions returns the canonical qualified names (e.g. mcp__call_tool, multi_agent__delegate) that invoke_action and describe_action expect. POST_CALL: After list_actions reveals at least one matching action, you MUST follow with describe_action or invoke_action. Do NOT reply directly — silent stop after enumeration is a failure mode. When items is empty, honestly tell the user no matching actions are available.",
       "parameters": {
+        "type": "object",
         "properties": {
           "category": {
-            "description": "Filter by category. Pass an array of category names (e.g. category=['exec'], category=['web', 'file']). Omit or pass [] to include all categories. Categories: multi_agent, mcp, file, web, memory_entry, memory_operation, reyn_source, rag_corpus, rag_operation, exec, task, skill_management, pipeline, pipeline_management.",
+            "type": "array",
             "items": {
+              "type": "string",
               "enum": [
                 "multi_agent",
                 "mcp",
@@ -660,29 +663,27 @@
                 "task",
                 "skill_management",
                 "pipeline",
-                "pipeline_management"
-              ],
-              "type": "string"
+                "pipeline_management",
+                "presentation_management"
+              ]
             },
-            "type": "array"
-          },
-          "limit": {
-            "default": 10,
-            "description": "Page size (default 10).",
-            "minimum": 1,
-            "type": "integer"
+            "description": "Filter by category. Pass an array of category names (e.g. category=['exec'], category=['web', 'file']). Omit or pass [] to include all categories. Categories: multi_agent, mcp, file, web, memory_entry, memory_operation, reyn_source, rag_corpus, rag_operation, exec, task, skill_management, pipeline, pipeline_management, presentation_management."
           },
           "offset": {
-            "default": 0,
-            "description": "Pagination offset (default 0).",
+            "type": "integer",
             "minimum": 0,
-            "type": "integer"
+            "default": 0,
+            "description": "Pagination offset (default 0)."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 10,
+            "description": "Page size (default 10)."
           }
-        },
-        "type": "object"
+        }
       }
-    },
-    "type": "function"
+    }
   },
   "list_agents": {
     "function": {
@@ -1544,14 +1545,21 @@
     "type": "function"
   },
   "search_actions": {
+    "type": "function",
     "function": {
-      "description": "WHAT: Semantic search across available actions — multilingual, embedding-based, relevance-ranked. Returns {items: [{qualified_name, short_description, score}, ...]}. WHEN: PREFERRED FIRST for semantic / natural-language / free-text queries — when the user asks to find / search for / something related to / similar to / something for X / actions about Y / find ... related to Z (the request may be phrased in any language, including Japanese and other non-English input), or describes an intent without naming a specific category. ALWAYS call search_actions BEFORE refusing a semantic-intent capability request. Refusing without a search_actions check is a FAILURE MODE (= relevance ranking may surface the action across categories that a flat enumeration would miss). Multilingual — works in any language (Japanese, English, etc.). Handles both semantic descriptions AND free-text keyword lookup (e.g. an action containing 'http'). WHEN NOT: For known-category enumeration (e.g. 'show me all exec actions', 'list of memory_entry actions' — again, phrasable in any language) use list_actions(category=[...]) instead — it returns the flat catalogue slice rather than relevance-ranked hits. If you already know the exact action name, skip both and call invoke_action directly. Available only when an embedding class is configured (reyn.yaml action_retrieval.embedding_class). POST_CALL: After search_actions reveals at least one matching action, you MUST follow with describe_action or invoke_action. Do NOT reply directly — silent stop after semantic search is a failure mode.",
       "name": "search_actions",
+      "description": "WHAT: Semantic search across available actions — multilingual, embedding-based, relevance-ranked. Returns {items: [{qualified_name, short_description, score}, ...]}. WHEN: PREFERRED FIRST for semantic / natural-language / free-text queries — when the user asks to find / search for / something related to / similar to / something for X / actions about Y / find ... related to Z (the request may be phrased in any language, including Japanese and other non-English input), or describes an intent without naming a specific category. ALWAYS call search_actions BEFORE refusing a semantic-intent capability request. Refusing without a search_actions check is a FAILURE MODE (= relevance ranking may surface the action across categories that a flat enumeration would miss). Multilingual — works in any language (Japanese, English, etc.). Handles both semantic descriptions AND free-text keyword lookup (e.g. an action containing 'http'). WHEN NOT: For known-category enumeration (e.g. 'show me all exec actions', 'list of memory_entry actions' — again, phrasable in any language) use list_actions(category=[...]) instead — it returns the flat catalogue slice rather than relevance-ranked hits. If you already know the exact action name, skip both and call invoke_action directly. Available only when an embedding class is configured (reyn.yaml action_retrieval.embedding_class). POST_CALL: After search_actions reveals at least one matching action, you MUST follow with describe_action or invoke_action. Do NOT reply directly — silent stop after semantic search is a failure mode.",
       "parameters": {
+        "type": "object",
         "properties": {
+          "query": {
+            "type": "string",
+            "description": "Natural-language query in any language."
+          },
           "category": {
-            "description": "Optional category restriction.",
+            "type": "array",
             "items": {
+              "type": "string",
               "enum": [
                 "multi_agent",
                 "mcp",
@@ -1566,30 +1574,24 @@
                 "task",
                 "skill_management",
                 "pipeline",
-                "pipeline_management"
-              ],
-              "type": "string"
+                "pipeline_management",
+                "presentation_management"
+              ]
             },
-            "type": "array"
+            "description": "Optional category restriction."
           },
           "limit": {
-            "default": 10,
-            "description": "Top-K results to return (default 10).",
+            "type": "integer",
             "minimum": 1,
-            "type": "integer"
-          },
-          "query": {
-            "description": "Natural-language query in any language.",
-            "type": "string"
+            "default": 10,
+            "description": "Top-K results to return (default 10)."
           }
         },
         "required": [
           "query"
-        ],
-        "type": "object"
+        ]
       }
-    },
-    "type": "function"
+    }
   },
   "semantic_search": {
     "function": {
@@ -2261,5 +2263,28 @@
       }
     },
     "type": "function"
+  },
+  "presentation_install_local": {
+    "type": "function",
+    "function": {
+      "name": "presentation_install_local",
+      "description": "Register a named presentation template into the project config by writing an entry to .reyn/config/presentations.yaml. The blueprint must use only the catalog components (text/markdown/code/diff/keyvalue/table/list/image) with $bind JSON-Pointer bindings — the same structural gate an inline present(blueprint=...) already passes through, so a malformed blueprint is refused before any config mutation. The template is immediately available to sessions after the next hot-reload, and renders only when a present(view=<name>) op names it — installing it never renders anything on its own.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Config key written under presentations.entries.<name> — the value a present(view=<name>) op resolves against."
+          },
+          "blueprint": {
+            "description": "The declarative component tree (same shape as an inline present(blueprint=...) — object or list of catalog component nodes with $bind JSON-Pointer bindings)."
+          }
+        },
+        "required": [
+          "name",
+          "blueprint"
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
**[lead-coder]** — Layer A of proposal 0060 (`docs/deep-dives/proposals/0060-llm-wielding-foundation.md`, **Addendum B**): the provenance plumbing + the present-view install op, making the §2.7 provenance split **structural** (the foundation the Phase-4 auto-improvement gate rests on). `part of` / `toward` proposal 0060 Phase 1 — **not** Closes.

Layer C (the SP part×role routing frame) is a **separate PR** (SP prose, different change class) — not here.

## A7 — `OpContext.turn_origin` seam (mirrors `_current_task_id`)
- New field `OpContext.turn_origin` (`src/reyn/core/op_runtime/context.py`).
- **OS-side binding (anti-spoof site):** derived in `Session._stamp_execution_context` (`src/reyn/runtime/session.py`) into `self._current_turn_origin`, exactly where `_current_task_id` is set — the single seam that classifies the turn kind. Threaded through **both** ctx-build sites (`session.py` `_make_router_op_context` + `router_host_adapter.py` `make_router_op_context` via a live `turn_origin_fn` callback, mirroring `current_task_id_fn`). Never an op field → the LLM cannot supply it (isomorphic to `emit_hook_event`'s ②B ctx-side kind construction).
- **kind→origin map (load-bearing):** `user` → `user_directed`; **everything else** — hook / pipeline_result / wake-family / sub-agent `agent_request`|`agent_response` / **any unmapped/future kind** → `auto_improvement`. Only an explicit `user` turn grants `user_directed`; the default is the stricter value. Silent-default-to-`user_directed` is forbidden (would bypass the Phase-4 gate). Sub-agent turns = `auto_improvement` (lead-adjudicated, Addendum B A7).

## A9 — uniform provenance SOURCE
Each install handler stamps `entry["provenance"] = ctx.turn_origin` at entry construction (`skill_install.py`, `pipeline_install.py`) — a per-handler write whose **value is single-sourced** from the OS-set `ctx.turn_origin`, right beside the existing `if op.source: entry["source"] = ...` idiom. The `builtin` value is a **separate seam** (registry-build loader, F3) — not touched here.

## A8 — `presentation_install` op (present-view install)
New op kind `presentation_install` + handler `src/reyn/core/op_runtime/presentation_install.py`, mirroring skill-install's **structure**: `file_write` gate on `.reyn/config/presentations.yaml` → write `presentations.entries.<name>` (with OS-stamped `provenance`) → `record_config_generation` → `presentation_installed` event → hot-reload of the existing `"presentations"` seam.
- **`validate_blueprint` IS the structural threat gate** (reused from `reyn.core.present.catalog` — the same gate an inline `present(blueprint=...)` passes). A blueprint is non-executable by construction (8 fixed components, `$bind` JSON-Pointer only, no template-ref/eval/exec, `image.src` = label). **No** `scan_for_threats` (no free-text field), **no** source/git-fetch path, **no** new recovery obligation (inherits `record_config_generation`).
- Full tool surface: `presentation_management__install` verb (`presentation_management_verbs.py` + `descriptions/presentation_management.py`) → universal-dispatch route + `presentation_management` category + canonical mapper. Ships inert-by-construction (invoke-by-name).

## Co-vet pins (`tests/test_0060_phase1_layer_a.py`)
1. **provenance ②B-structural** — `PresentationInstallIROp` has **no** `provenance` field; the handler stamps from `ctx.turn_origin` alone. *Falsify:* two ctx values (auto/user) with an op that carries no provenance field → the two written entries differ ONLY by `ctx.turn_origin`; if a handler ever read an op-level value, a spoofed `user_directed` would survive on an auto turn → RED.
2. **turn_origin completeness fail-safe** — every kind maps; an unmapped kind → `auto_improvement`. *Falsify:* `some_unknown_future_kind_0060` + `brand_new_kind_never_seen` asserted → `auto_improvement`; if either resolved to `user_directed` → RED (asserted on public op-ctx output, not private state).
3. **present-install threat = `validate_blueprint`** — a non-catalog blueprint → `status="blocked"`, no config write. *Falsify:* strip the `validate_blueprint` call → the malformed blueprint installs → RED.

## Design forks flagged
- **Tool name `presentation_install_local` (not bare `presentation_install`).** The op-kind and tool-name are separate `declare_canonical` source_ids (STRUCTURED_PASSTHROUGH for the op-kind vs the status-text mapper for the tool). Reusing the bare op-kind name collides them. Mirrors `skill_install`/`skill_install_local`. The `_local` suffix has no `_source` sibling (no git-fetch for blueprints) — a naming asymmetry, kept for source-id consistency.
- **`presentation_install` added to the STRUCTURED_PASSTHROUGH admin set** (was "admin-6", now the admin/install family + 1). It is an install-manifest producer, same class as skill/pipeline install — a legitimate expansion, not a bypass.

## Scope boundary honored
No Phase-4 gate logic (what auto_improvement installs are restricted to). No builtin loader-stamp (F3). Phase-1 just carries + stamps provenance from an unspoofable source.

## Gates (all four, local)
- `ruff check src tests` — clean.
- `test_tier_audit.py --strict` (all changed test files) — 75/75 OK, 0 Tier-4.
- `verify_module_docstrings.py` (all changed src) — clean.
- **Full `pytest`: 8311 passed** on the first run; the 5 failures were registry-completeness gates that a new op-kind + tool legitimately updates (STRUCTURED_PASSTHROUGH admin set, external-content classification, route contract sample, tool-schema baseline, present-family op-kind set — one design-superseded test `test_no_present_register_op_kind_exists` rewritten to pin the new `{present, presentation_install}` invariant). All 5 now green; **CI runs the authoritative full pytest.**

## Test plan
- [x] `pytest tests/test_0060_phase1_layer_a.py` — 5/5 (co-vet pins).
- [x] The 5 registry-gate suites re-run green (358 passed together).
- [x] `docs/reference/runtime/control-ir.md` synced with `OP_KIND_MODEL_MAP` (new `presentation_install` section + table row) — CLAUDE.md hard rule.
- [ ] (CI) full `pytest` from repo root — authoritative.


---

## Co-vet update — wiring-seam closed (#2887 class, architect)
- **Production-path finding:** `presentation_management__install` → verb handler → `build_legacy_op_context` → `router_state.op_context_factory` = `RouterHostAdapter.make_router_op_context` (`tools/types.py:264`), which **threads `turn_origin`** (A7). Production path carries provenance end-to-end — no bypass. Residual vector: the bridge's **fallback** synthesis (`op_context_bridge.py:45-63`) leaves `turn_origin=None`.
- **Load-bearing fail-safe:** new `provenance_from_ctx(ctx)` (`op_runtime/context.py`) collapses `None`/unset → stricter `"auto_improvement"` (never None/user_directed); applied to all three stampers. Closes the `provenance=None` → ungated-install gate-bypass by construction.
- **Two distinct witnesses** (both falsify-verified): `test_hook_turn_through_real_tool_path_stamps_auto_improvement` (real hook turn through the real tool path → `auto_improvement`; RED when threading+fail-safe stripped) and `test_unset_turn_origin_fails_safe_to_auto_improvement` (unset ctx → `auto_improvement`; RED when the None→auto default stripped — proves the fail-safe is load-bearing).
- Gates re-run green (ruff, tier-audit --strict 7/7, docstrings, 59 affected tests).


## Co-vet update 2 — all 3 fail-safes individually strip-pinned
The `provenance_from_ctx` fail-safe was code-present in skill/pipeline/present, but only present had a strip-witness (skill/pipeline were green-on-strip — #2900 STEP-4 class). Added per-stamper strip-witnesses: `test_skill_install_unset_turn_origin_fails_safe_to_auto_improvement` + `test_pipeline_install_unset_turn_origin_fails_safe_to_auto_improvement` (each drives the real handler with `ctx.turn_origin=None`, asserts written `provenance == "auto_improvement"`; both hand-falsified RED→GREEN by reverting that stamper to raw `ctx.turn_origin`). All 3 gate-bypass guards now go RED on strip — no silent-ship.


## CI fix — CATEGORIES pins track the new presentation_management category
Two remote-CI failures (real divergence, #2885 registry-completeness class, fail-in-isolation — NOT the #2898 flake): the `presentation_management` category (required for the install verb to dispatch, added in fix-1) diverged the live `CATEGORIES` tuple from two pinning tests + the SP bullets. Fixed by tracking the real tuple: added the `presentation_management` SP bullet (`prompt/universal_slots.py`, in CATEGORIES order) + the master-table pin (`test_universal_catalog.py`); the SP-bullet test derives from CATEGORIES so it tracks automatically. **Full pytest run to completion: 8322 passed, 20 skipped, 0 failures.**
