### PR TITLE
docs(proposals): backfill README index for 0044, 0050-0060 + fix stale convention note

### DIFF
--- a/docs/deep-dives/proposals/README.ja.md
+++ b/docs/deep-dives/proposals/README.ja.md
@@ -93,7 +93,7 @@ SMALL / MEDIUM / LARGE（根拠付き）。
 | [0025](0025-planner-narration-and-sp-fixes.ja.md) | Planner — Router narration（スキルと同形、FP-0012 対称）+ plan step SP 修正 | proposed | SMALL |
 | [0026](0026-op-permission-cross-layer-coherence.ja.md) | Op/Permission クロスレイヤー整合性 — `reyn skill validate` + allowed_ops からの permission 要求自動導出 | proposed | SMALL |
 
-> **FP-0027 以降は GitHub Issues で管理。** [#28](https://github.com/tya5/reyn/issues/28)〜[#31](https://github.com/tya5/reyn/issues/31) 以降を参照。
+> **FP-0027〜0030 は GitHub Issues で直接管理**されていました(下記参照)。**FP-0044 以降はファイルベースの番号付き proposal に戻っています** — #44 以降の proposal は全てこのディレクトリ内のファイルであり、issue スタブではありません。上記の注記は 0027〜0030 の歴史的記録としてのみ残しています。
 
 | # | Issue | タイトル | Status | コスト |
 |---|---|---|---|---|
@@ -101,3 +101,18 @@ SMALL / MEDIUM / LARGE（根拠付き）。
 | 0028 | [#29](https://github.com/tya5/reyn/issues/29) | プラン進捗 UX | proposed | SMALL |
 | 0029 | [#30](https://github.com/tya5/reyn/issues/30) | プランステップのイテレーション予算 | proposed | SMALL |
 | 0030 | [#31](https://github.com/tya5/reyn/issues/31) | プランステップ結果品質 | proposed | SMALL |
+
+| # | タイトル | Status | コスト |
+|---|---|---|---|
+| [0044](0044-chat-package-decomposition.md) | `reyn.chat` 分解 — runtime namespace + cluster 分割 + god-file 分解 | proposed | MEDIUM |
+| [0050](0050-content-threat-scan.md) | Content-layer threat scan(prompt-injection / pre-exec command) | S1 merged(#1844); S2 lead 再レビュー待ち | MEDIUM |
+| [0051](0051-tool-result-viewer-registry-llm-template.md) | Tool-result viewer registry + LLM 生成 viewer テンプレート | superseded — 前提(Textual TUI 右パネル)が実装前に削除済み | SMALL |
+| [0052](0052-high-cost-model-preconfirm.md) | High-cost model 事前確認 | draft | SMALL |
+| [0053](0053-tool-result-schema-redesign.md) | Tool-result スキーマ再設計 | done(IMPLEMENTED 2026-07-08; 全 PR merged) | MEDIUM |
+| [0054](0054-present-layer.md) | Present layer — LLM トークン往復無しの user-facing 表示 | done(IMPLEMENTED 2026-07-08, v1 display-only) | LARGE |
+| [0055](0055-render-template-op-and-present-defaults.md) | `render_template` op + present defaults | done(IMPLEMENTED 2026-07-09) | SMALL |
+| [0056](0056-canonical-coverage-enforcement.md) | Canonical-mapping coverage enforcement | done(IMPLEMENTED 2026-07-09) | SMALL |
+| [0057](0057-rag-retrieval-redesign.md) | RAG / Retrieval 再設計 | owner-validated; 実装着手は GO 待ち | LARGE |
+| [0058](0058-web-surface-modularity.md) | Web surface modularity + Chainlit retire | owner-ratified; 複数 phase landed(#2837 auth-layer、#2850 chainlit retire) | LARGE |
+| [0059](0059-hook-event-redesign.md) | Hook-Event Redesign(Event Bus / reactivity substrate) | owner-ratified; Phase 1-5 landed(#2871–#2885) | LARGE |
+| [0060](0060-llm-wielding-foundation.md) | LLM-Wielding Foundation — agent が構築したものを実際に使うための基盤 | accepted(owner GO); Addendum A/B landed、C review 中 | LARGE |

--- a/docs/deep-dives/proposals/README.md
+++ b/docs/deep-dives/proposals/README.md
@@ -93,7 +93,11 @@ Links to related ADRs, PRs, and docs.
 | [0025](0025-planner-narration-and-sp-fixes.md) | Planner — router narration (align with skill/FP-0012) + plan step SP fixes | proposed | SMALL |
 | [0026](0026-op-permission-cross-layer-coherence.md) | Op/Permission cross-layer coherence — `reyn skill validate` + auto-derived permission requirements from allowed_ops | proposed | SMALL |
 
-> **FP-0027 onwards are managed in GitHub Issues.** See issues [#28](https://github.com/tya5/reyn/issues/28)–[#31](https://github.com/tya5/reyn/issues/31) and beyond.
+> **FP-0027–0030 were tracked directly in GitHub Issues** (see below) rather
+> than as files here. **FP-0044 onwards returned to file-based numbered
+> proposals** — every proposal since #44 is a file in this directory again,
+> not an issue stub; the note above is retained for the 0027–0030 historical
+> record only.
 
 | # | Issue | Title | Status | Cost |
 |---|---|---|---|---|
@@ -101,3 +105,18 @@ Links to related ADRs, PRs, and docs.
 | 0028 | [#29](https://github.com/tya5/reyn/issues/29) | Plan progress UX | proposed | SMALL |
 | 0029 | [#30](https://github.com/tya5/reyn/issues/30) | Plan step iteration budget | proposed | SMALL |
 | 0030 | [#31](https://github.com/tya5/reyn/issues/31) | Plan step result quality | proposed | SMALL |
+
+| # | Title | Status | Cost |
+|---|---|---|---|
+| [0044](0044-chat-package-decomposition.md) | `reyn.chat` decomposition — runtime namespace + cluster split + god-file seams | proposed | MEDIUM |
+| [0050](0050-content-threat-scan.md) | Content-layer threat scan (prompt-injection / pre-exec command) | S1 merged (#1844); awaiting S2 lead re-review | MEDIUM |
+| [0051](0051-tool-result-viewer-registry-llm-template.md) | Tool-result viewer registry + LLM-generated viewer templates | superseded — premise (Textual TUI right panel) deleted before implementation | SMALL |
+| [0052](0052-high-cost-model-preconfirm.md) | High-cost model pre-confirmation | draft | SMALL |
+| [0053](0053-tool-result-schema-redesign.md) | Tool-result schema redesign | done (IMPLEMENTED 2026-07-08; all PRs merged) | MEDIUM |
+| [0054](0054-present-layer.md) | Present layer — user-facing presentation without an LLM token round-trip | done (IMPLEMENTED 2026-07-08, v1 display-only) | LARGE |
+| [0055](0055-render-template-op-and-present-defaults.md) | `render_template` op + present defaults | done (IMPLEMENTED 2026-07-09) | SMALL |
+| [0056](0056-canonical-coverage-enforcement.md) | Canonical-mapping coverage enforcement | done (IMPLEMENTED 2026-07-09) | SMALL |
+| [0057](0057-rag-retrieval-redesign.md) | RAG / Retrieval redesign | owner-validated; implementation dispatch awaits GO | LARGE |
+| [0058](0058-web-surface-modularity.md) | Web surface modularity + Chainlit retire | owner-ratified; multiple phases landed (#2837 auth-layer, #2850 chainlit retire) | LARGE |
+| [0059](0059-hook-event-redesign.md) | Hook-Event Redesign (Event Bus / reactivity substrate) | owner-ratified; Phases 1-5 landed (#2871–#2885) | LARGE |
+| [0060](0060-llm-wielding-foundation.md) | LLM-Wielding Foundation — making the agent actually use what it can build | accepted (owner GO); Addenda A/B landed, C in review | LARGE |


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
Backfills a gap flagged during the FP-0058 arc and confirmed again by architect's 0059/0060 write notifications: `docs/deep-dives/proposals/README.md`/`.ja.md` say "FP-0027 onwards are managed in GitHub Issues," but 9 file-based proposals (0044, 0050-0058) already existed unindexed — plus the newly-landed 0059 (Hook-Event Redesign) and 0060 (LLM-Wielding Foundation).

- The convention note itself was stale (proposals returned to file-based tracking starting at 0044, but the note was never updated to say so, making the index self-contradictory if the 11 rows were just appended below it). Reworded to scope the "managed in GitHub Issues" note to 0027-0030 only, with an explicit statement that 0044+ are files again.
- Added all 11 missing rows. Each `Status`/`Cost` cell is pulled from that proposal's own status line or frontmatter (verified by reading each file), not invented — e.g. 0051 is marked `superseded` (its premise, the Textual TUI right panel, was deleted before implementation), 0053-0056 are marked `done (IMPLEMENTED ...)` per their own status lines, 0058/0059 note which phases have landed.
- `.ja.md` mirrored with the same 11 rows (none of these files have `.ja.md` siblings — both index versions link to the same source files).

No history refs beyond the existing convention (PR/issue numbers already appear in this table's other rows, e.g. 0053's "#2647"-style references — consistent, not new).

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no new warnings (proposals/ is excluded from the built site per `exclude_docs`, consistent with 0057/0058's prior placement)
- [x] Every linked file (`0044-chat-package-decomposition.md` through `0060-llm-wielding-foundation.md`) confirmed to exist via `ls` before linking
- [x] Every status claim read directly from that file's own status line/frontmatter, not inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)