### PR TITLE
feat: proposal 0060 Phase 1 — Layer C (part×role routing frame, derived from the meta-registry)

### DIFF
--- a/src/reyn/prompt/router_frame.py
+++ b/src/reyn/prompt/router_frame.py
@@ -234,3 +234,100 @@ def output_language_directive(output_language: str) -> str:
         f"  - Always reply in language: {output_language}."
         "  Do NOT switch language even for error messages or clarifying questions."
     )
+
+
+# ── Mechanism routing (part x role) — 0060 Addendum C, Layer C ─────────────
+# WHEN: always, scheme-independent, static cache-prefix section.
+# WHERE: build_system_prompt() -> a dedicated "## Mechanism routing" section,
+#        placed in the STATIC block (before "## Behaviour") -- NOT a
+#        scheme-owned tool_use_sp slot. It therefore holds across all four
+#        tool-use schemes (universal / enumerate / retrieval / codeact): they
+#        all funnel through this one OS-frame builder, and none of them can
+#        omit or overwrite this section the way a scheme-owned slot could.
+# WHY: proposal 0060 Addendum C (C1/C2) -- the model needs a standing map of
+#      WHICH mechanism to reach for by role (input / workflow / output), not
+#      just a flat action catalog, and hooks (today entirely absent from the
+#      SP) need to become visible. C3 (load-bearing): the part x role rows
+#      are DERIVED from reyn.core.part_type_registry.PART_TYPE_REGISTRY's
+#      ``roles`` frozensets -- NEVER a hand-written parallel table (the
+#      #2899 completeness discipline applied at the SP layer). A new marked
+#      part-type dropped into reyn.core.part_types auto-appears here with
+#      zero edits to this module.
+# 日本語訳: 常に描画される、scheme非依存の静的節。「入力/処理/出力」の各役割に
+#      どの機構を使うべきかの地図を提示し、これまでSPに一切現れなかった hook を
+#      可視化する。表の各行は PART_TYPE_REGISTRY の roles frozenset から導出され、
+#      手書きの並行テーブルは禁止（#2899 の完全性規律をSP層に適用）。
+MECHANISM_ROUTING_HEADER = "## Mechanism routing (part x role)"
+
+MECHANISM_DECISION_TREE = (
+    "Pick the mechanism by what you need, not by habit:\n"
+    "  - need INPUT (new data or a reactive trigger) -> hook | mcp | retrieval\n"
+    "  - need WORKFLOW (multi-step orchestration) -> skill | pipeline | mcp-step\n"
+    "  - need OUTPUT (present, render, or write externally) -> present | render | mcp-write"
+)
+
+AUTHOR_VS_REUSE_HEURISTIC = (
+    "Reuse before authoring: check the existing catalog (list_actions) for a "
+    "part that already covers the need before writing a new one. Author only "
+    "when nothing existing fits. Any authored part must be typed, "
+    "permissioned, and evaluated (judge_output) before it is promoted for "
+    "reuse -- an ungated authored part is a liability, not a shortcut."
+)
+
+# Cost-discipline (C1): a hard per-part-type-row character cap so the derived
+# map stays within the cache-static budget as the meta-registry grows -- the
+# frame carries the routing MODEL, never the pull-side catalog.
+MAX_PART_TYPE_ROW_CHARS = 100
+
+
+def _format_part_type_row(spec: object) -> str:
+    """Render one derived row -- ``name (category): role, role`` -- from a
+    ``PartTypeSpec``-shaped object (duck-typed on ``.name``/``.category``/
+    ``.roles`` to avoid a hard import of ``reyn.core.part_type_registry`` at
+    module scope). Raises if the row would exceed
+    :data:`MAX_PART_TYPE_ROW_CHARS`, so an over-verbose future part-type spec
+    fails loud instead of silently bloating every turn's SP as the registry
+    grows (0060 Addendum C, co-vet pin 3)."""
+    roles = ", ".join(sorted(spec.roles))
+    row = f"  - {spec.name} ({spec.category}): {roles}"
+    if len(row) > MAX_PART_TYPE_ROW_CHARS:
+        raise ValueError(
+            f"part-type row for {spec.name!r} is {len(row)} chars, over the "
+            f"{MAX_PART_TYPE_ROW_CHARS}-char per-row cache-static budget "
+            "(0060 Addendum C) -- shorten its category/name"
+        )
+    return row
+
+
+def render_part_role_map(registry: "dict[str, object] | None" = None) -> str:
+    """Render the part x role routing map, DERIVED from
+    ``reyn.core.part_type_registry.PART_TYPE_REGISTRY`` (0060 Addendum C, C3
+    -- the load-bearing decision: never a hand-written parallel table).
+
+    ``registry`` defaults to the live ``PART_TYPE_REGISTRY``; passing a
+    different ``dict[str, PartTypeSpec]`` lets tests exercise a
+    synthetic/rebuilt registry (the auto-appear and char-budget co-vet
+    witnesses) without mutating the shipped one."""
+    if registry is None:
+        from reyn.core.part_type_registry import PART_TYPE_REGISTRY
+
+        registry = PART_TYPE_REGISTRY
+    return "\n".join(
+        _format_part_type_row(spec) for _, spec in sorted(registry.items())
+    )
+
+
+def render_mechanism_routing_frame(registry: "dict[str, object] | None" = None) -> str:
+    """Full "## Mechanism routing" section: header + the derived part x role
+    map + the mechanism-selection decision tree + the author-vs-reuse
+    heuristic. This is what ``build_system_prompt`` injects into the static
+    cache-prefix (0060 Addendum C, C1) -- scheme-independent, appears
+    identically under every tool-use scheme."""
+    return "\n\n".join(
+        [
+            MECHANISM_ROUTING_HEADER,
+            render_part_role_map(registry),
+            MECHANISM_DECISION_TREE,
+            AUTHOR_VS_REUSE_HEURISTIC,
+        ]
+    )

--- a/src/reyn/runtime/router_system_prompt.py
+++ b/src/reyn/runtime/router_system_prompt.py
@@ -24,6 +24,7 @@ from reyn.prompt.router_frame import (
     ambiguity_rule,
     cwd_reference_mapping_sentence,
     output_language_directive,
+    render_mechanism_routing_frame,
     role_stamp,
 )
 from reyn.runtime.router_tools import MAX_DESC_LEN_FOR_LISTING
@@ -185,6 +186,15 @@ def build_system_prompt(
     # Delivered via slot_post_environment from the scheme's slot-map.
     if "slot_post_environment" in _slots:
         parts.append(_slots["slot_post_environment"])
+
+    # ── 3.6. Mechanism routing (part x role) — 0060 Addendum C, Layer C ──────
+    # Cache-static, scheme-independent (C1): DERIVED from PART_TYPE_REGISTRY
+    # (C3), NOT a scheme-owned tool_use_sp slot — it holds across all four
+    # tool-use schemes because every scheme funnels through this one builder.
+    # Placed before "## Behaviour" so it stays in the ~60%-coverage static
+    # prefix alongside Identity/Role/Behaviour, not the dynamic tail.
+    parts.append(render_mechanism_routing_frame())
+    parts.append("")
 
     # ── 4 & 5. Behaviour (static core) ─────────────────────────────────────
     # FP-0023 Change 1: Static Behaviour rules moved here (before dynamic

--- a/tests/test_mechanism_routing_frame_0060.py
+++ b/tests/test_mechanism_routing_frame_0060.py
@@ -1,0 +1,290 @@
+"""Tier 2: proposal 0060 Addendum C (Layer C) — the part x role mechanism
+routing frame in ``reyn.prompt.router_frame`` / injected by
+``reyn.runtime.router_system_prompt.build_system_prompt``.
+
+Three co-vet pins (Addendum C):
+
+1. **Registry-derivation (the crux, mirrors #2899's auto-appear witness)**:
+   dropping a new marked part-type into ``reyn.core.part_types`` (touching
+   NOTHING in ``render_part_role_map``/``render_mechanism_routing_frame``)
+   makes it auto-appear in the rendered frame. Falsify: a hand-written table
+   frozen at collection time does NOT pick up the new part-type — the exact
+   drift the derivation prevents becomes observable.
+2. **Scheme-independence**: the routing frame appears identically under all
+   four tool-use schemes' slot-map shapes (universal / enumerate / retrieval
+   / codeact), and even with NO scheme attached at all (``tool_use_sp=None``)
+   — proving it is not sourced from any scheme-owned slot. Falsify: were the
+   frame instead assembled inside a scheme-owned slot value, the bare/no-
+   scheme call would be missing it.
+3. **Char-budget / cache-static**: each derived part-type row is bounded by
+   ``MAX_PART_TYPE_ROW_CHARS``; a synthetic larger registry (more, longer-
+   named part-types) stays within a total budget that scales linearly (not
+   superlinearly) with the number of part-types, and an over-long row raises
+   instead of silently shipping. The frame also lands in the static section
+   of the assembled SP, ahead of "## Behaviour" and the dynamic tail.
+
+Real objects only (testing policy): no mocks. The registry-derivation witness
+drops a real ``.py`` module into the real ``reyn.core.part_types`` package,
+mirroring ``tests/test_part_type_registry_taxonomy_0060.py``.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+import reyn.core.part_types as part_types_pkg
+from reyn.core.part_type_registry import PART_TYPE_REGISTRY, build_part_type_registry
+from reyn.prompt.router_frame import (
+    MAX_PART_TYPE_ROW_CHARS,
+    MECHANISM_ROUTING_HEADER,
+    render_mechanism_routing_frame,
+    render_part_role_map,
+)
+from reyn.runtime.router_system_prompt import build_system_prompt
+from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
+
+_MARKER_SRC = """\
+from reyn.core.part_type_registry import PartTypeSpec
+
+PART_TYPE_SPEC = PartTypeSpec(
+    name={name!r},
+    roles=frozenset({{"input"}}),
+    category={category!r},
+    registry_ref="reyn.data.skills.registry:build_skill_registry",
+    description="a test-injected part-type (0060 Addendum C witness)",
+)
+"""
+
+
+# ── Pin 1: registry-derivation (the crux) ────────────────────────────────────
+
+
+def test_new_marked_part_type_auto_appears_in_routing_frame():
+    """Tier 2: drop a new marked part-type into the REAL
+    ``reyn.core.part_types`` package, touching NOTHING in
+    ``render_part_role_map``/``render_mechanism_routing_frame`` — it
+    auto-appears in the rendered frame (mirror of #2899's auto-appear
+    witness, applied at the SP layer, 0060 Addendum C C3)."""
+    real_dir = Path(part_types_pkg.__file__).parent
+    injected = real_dir / "_witness_routing_part.py"
+    mod_qual = "reyn.core.part_types._witness_routing_part"
+    injected.write_text(
+        _MARKER_SRC.format(name="witness_routing_part", category="witness_cat")
+    )
+    try:
+        importlib.invalidate_caches()
+        rebuilt = build_part_type_registry()
+        assert "witness_routing_part" in rebuilt
+
+        frame = render_mechanism_routing_frame(rebuilt)
+        assert "witness_routing_part (witness_cat): input" in frame, (
+            "a marker dropped into the real part_types package did not "
+            "auto-appear in the derived routing frame"
+        )
+        # The 5 real ones are still present (drop-in is additive, zero drift).
+        for real_name in ("skill", "pipeline", "mcp", "hook", "presentation"):
+            assert real_name in frame
+    finally:
+        injected.unlink(missing_ok=True)
+        sys.modules.pop(mod_qual, None)
+        importlib.invalidate_caches()
+
+
+def test_hand_written_table_frozen_at_collection_falsifies_the_new_part_type():
+    """Tier 2: FALSIFY — a hand-written table snapshotted BEFORE the new
+    part-type is dropped in does NOT pick it up (the drift a hand-maintained
+    parallel table would silently carry). This is the negative control that
+    proves pin 1's auto-appear is doing real work, not incidental."""
+    frozen_table = dict(PART_TYPE_REGISTRY)  # snapshot BEFORE the drop-in
+
+    real_dir = Path(part_types_pkg.__file__).parent
+    injected = real_dir / "_witness_routing_part2.py"
+    mod_qual = "reyn.core.part_types._witness_routing_part2"
+    injected.write_text(
+        _MARKER_SRC.format(name="witness_routing_part2", category="witness_cat2")
+    )
+    try:
+        importlib.invalidate_caches()
+        rebuilt = build_part_type_registry()
+        assert "witness_routing_part2" in rebuilt  # the live re-collect DOES see it
+
+        # But the frozen (hand-list-shaped) snapshot does NOT — this is the
+        # drift a hand-written parallel table would exhibit.
+        frozen_frame = render_mechanism_routing_frame(frozen_table)
+        assert "witness_routing_part2" not in frozen_frame, (
+            "a frozen/hand-maintained table unexpectedly reflects a part-type "
+            "registered after it was captured — derivation must be live"
+        )
+    finally:
+        injected.unlink(missing_ok=True)
+        sys.modules.pop(mod_qual, None)
+        importlib.invalidate_caches()
+
+
+def test_real_registry_five_part_types_all_appear_in_the_shipped_frame():
+    """Tier 2: sanity — the shipped frame (default registry, no injection)
+    lists all 5 currently-wired part-types, including ``hook`` (C2(3):
+    hooks made visible for the first time)."""
+    frame = render_mechanism_routing_frame()
+    for name in ("skill", "pipeline", "mcp", "hook", "presentation"):
+        assert name in frame
+    assert "hook (hook): input" in frame
+
+
+# ── Pin 2: scheme-independence ───────────────────────────────────────────────
+
+
+def _sp_universal() -> str:
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=True,
+        search_actions_enabled=False,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    return build_system_prompt(
+        agent_name="test", agent_role="tester", available_agents=[],
+        memory_index={}, tool_use_sp=slots,
+    )
+
+
+def _sp_enumerate() -> str:
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=True,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    return build_system_prompt(
+        agent_name="test", agent_role="tester", available_agents=[],
+        memory_index={}, tool_use_sp=slots,
+    )
+
+
+def _sp_retrieval() -> str:
+    slots = build_universal_tool_use_slots(
+        universal_wrappers_enabled=False,
+        search_actions_enabled=True,
+        discovery_mandate=False,
+        has_hot_list_aliases=False,
+        non_interactive=False,
+    )
+    slots["slot_post_catalog"] = (
+        "## Search\nCall search_actions with a natural-language query."
+    )
+    return build_system_prompt(
+        agent_name="test", agent_role="tester", available_agents=[],
+        memory_index={}, tool_use_sp=slots,
+    )
+
+
+def _sp_codeact() -> str:
+    # CodeAct's str-shim path (only slot_pre_environment) + its free-form
+    # code-API delivered via scheme_sp_fragment (#1618 REPLACE channel).
+    return build_system_prompt(
+        agent_name="test", agent_role="tester", available_agents=[],
+        memory_index={}, tool_use_sp="## Code API\nCall tools via tool(name, **args).",
+        scheme_sp_fragment="def file__read(path: str) -> str: ...",
+    )
+
+
+def _sp_bare_no_scheme() -> str:
+    # No scheme attached at all — bare OS frame.
+    return build_system_prompt(
+        agent_name="test", agent_role="tester", available_agents=[],
+        memory_index={}, tool_use_sp=None,
+    )
+
+
+def test_routing_frame_appears_under_all_four_schemes_and_bare_frame():
+    """Tier 2: the routing frame appears in the SP under every tool-use
+    scheme's slot shape (universal / enumerate / retrieval / codeact) AND
+    with no scheme attached at all (0060 Addendum C, C1: OS-frame, not a
+    scheme-owned slot)."""
+    for label, sp in (
+        ("universal", _sp_universal()),
+        ("enumerate", _sp_enumerate()),
+        ("retrieval", _sp_retrieval()),
+        ("codeact", _sp_codeact()),
+        ("bare/no-scheme", _sp_bare_no_scheme()),
+    ):
+        assert MECHANISM_ROUTING_HEADER in sp, (
+            f"mechanism routing frame missing under the {label} scheme shape"
+        )
+
+
+def test_routing_frame_present_with_zero_scheme_supplied_content():
+    """Tier 2: FALSIFY anchor for scheme-independence — with ``tool_use_sp=None``
+    (the empty slot-map path, ``_slots == {}``), the routing frame still
+    renders. Were it instead assembled from a scheme-owned slot value (e.g.
+    injected only via ``slot_post_catalog``), this bare call would be missing
+    it — exactly the regression pin 2 guards against."""
+    sp = _sp_bare_no_scheme()
+    assert MECHANISM_ROUTING_HEADER in sp
+    assert "need INPUT (new data or a reactive trigger) -> hook | mcp | retrieval" in sp
+
+
+# ── Pin 3: char-budget / cache-static ─────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _FakeSpec:
+    name: str
+    roles: frozenset
+    category: str
+
+
+def test_per_part_type_row_is_bounded_and_raises_when_exceeded():
+    """Tier 2: a pathologically long name/category raises instead of silently
+    shipping an over-budget row (falsify: without the cap, an arbitrarily
+    long row would render unbounded)."""
+    huge = _FakeSpec(
+        name="x" * 200, roles=frozenset({"input"}), category="y" * 200,
+    )
+    with pytest.raises(ValueError, match="cache-static budget"):
+        render_part_role_map({"huge": huge})
+
+
+def test_synthetic_larger_registry_stays_within_linear_budget():
+    """Tier 2: as the meta-registry grows (a synthetic 50-part-type
+    registry), the derived map's total size scales LINEARLY with the
+    number of part-types (bounded per-row cost, C1's cost-discipline pin) —
+    not superlinearly. Each individual row also respects the per-row cap."""
+    part_count = 50
+    synthetic = {
+        f"part_{i}": _FakeSpec(
+            name=f"part_{i}", roles=frozenset({"workflow"}), category="synthetic_cat",
+        )
+        for i in range(part_count)
+    }
+    rendered = render_part_role_map(synthetic)
+    lines = rendered.splitlines()
+    # One derived row per part-type — every synthetic name shows up, and
+    # nothing else does (a superlinear design, e.g. an O(N^2) all-pairs
+    # table, would not have this 1:1 correspondence).
+    assert {line.strip().split()[1] for line in lines} == set(synthetic)
+    for line in lines:
+        assert len(line) <= MAX_PART_TYPE_ROW_CHARS
+    # Linear bound: total length must not exceed part_count * per-row cap
+    # (+ small constant slack for joining newlines) — derived from the
+    # synthetic registry's own size, not a hardcoded magic number.
+    per_row_budget = MAX_PART_TYPE_ROW_CHARS
+    assert len(rendered) <= part_count * per_row_budget + part_count
+
+
+def test_routing_frame_sits_in_the_static_section_before_behaviour():
+    """Tier 2: the routing frame is placed ahead of "## Behaviour" in the
+    assembled SP — i.e. in the static cache-prefix block, not the dynamic
+    tail (0060 Addendum C, C1)."""
+    sp = _sp_universal()
+    routing_idx = sp.index(MECHANISM_ROUTING_HEADER)
+    behaviour_idx = sp.index("## Behaviour")
+    assert routing_idx < behaviour_idx, (
+        "mechanism routing frame must precede '## Behaviour' (static prefix, "
+        "not the dynamic tail)"
+    )


### PR DESCRIPTION
**[lead-coder]** — Layer C of proposal 0060 Phase 1 (part of proposal 0060; toward F2). Small, security-surface-free (unlike Layer A). Ratified design: `docs/deep-dives/proposals/0060-llm-wielding-foundation.md` Addendum C.

## What

Adds the scheme-independent **part×role mechanism-routing frame** to the OS system prompt so the model learns *which mechanism to reach for* by role, not just a flat action catalog.

### C1 — placement (cache-static, scheme-independent)
`render_mechanism_routing_frame()` in `src/reyn/prompt/router_frame.py`, injected by `build_system_prompt` into the STATIC cache-prefix block (a new `## Mechanism routing` section, **before** `## Behaviour`) — NOT a scheme-owned `tool_use_sp` slot. Every tool-use scheme funnels through this one OS-frame builder, so the frame holds identically across universal / enumerate / retrieval / codeact and the bare no-scheme frame.

### C2 — content
1. the derived part×role map;
2. a mechanism-selection decision tree (need INPUT → hook | mcp | retrieval; need WORKFLOW → skill | pipeline | mcp-step; need OUTPUT → present | render | mcp-write);
3. **hooks are now visible in the SP** for the first time (`hook (hook): input`);
4. an author-vs-reuse heuristic + a typed/permissioned/evaluated authoring-quality one-liner.

### C3 — LOAD-BEARING: the map is DERIVED from the meta-registry
`render_part_role_map()` walks `PART_TYPE_REGISTRY.items()` (sorted) and renders one row per part-type from that spec's own `.name` / `.category` / `.roles` frozenset — never a hand-written parallel table. A new marker dropped into `reyn.core.part_types` auto-appears with **zero edits** to `router_frame.py` (the #2899 completeness discipline applied at the SP layer). A per-part-type char cap (`MAX_PART_TYPE_ROW_CHARS`) keeps the derived rows within the cache-static budget as the registry grows.

## Tests — `tests/test_mechanism_routing_frame_0060.py` (3 co-vet pins)

1. **Registry-derivation (crux):** `test_new_marked_part_type_auto_appears_in_routing_frame` drops a real marked module into `reyn.core.part_types` → it appears in the rendered frame. `test_hand_written_table_frozen_at_collection_falsifies_the_new_part_type` is the negative control — a snapshot frozen before the drop-in does NOT reflect the new part-type (the drift a hand-list would carry).
2. **Scheme-independence:** `test_routing_frame_appears_under_all_four_schemes_and_bare_frame` + `test_routing_frame_present_with_zero_scheme_supplied_content` — frame present under all 4 scheme slot shapes and with `tool_use_sp=None`.
3. **Char-budget / cache-static:** `test_per_part_type_row_is_bounded_and_raises_when_exceeded`, `test_synthetic_larger_registry_stays_within_linear_budget` (50-part synthetic registry stays linear), `test_routing_frame_sits_in_the_static_section_before_behaviour`.

## Test plan
- [x] Full `pytest` (foreground, ~3.5min): **8348 passed, 20 skipped, 0 failed**.
- [x] `ruff check src tests`: clean.
- [x] `python scripts/test_tier_audit.py --strict tests/test_mechanism_routing_frame_0060.py`: 8/8 OK, 0 Tier-4.
- [x] `python scripts/verify_module_docstrings.py` on changed src: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)