### PR TITLE
fix: builtin skill/pipeline body reachable in a wheel deploy — route through importlib.resources (#2913)

### DIFF
--- a/src/reyn/builtin/docs.py
+++ b/src/reyn/builtin/docs.py
@@ -79,19 +79,32 @@ def read_builtin_doc(rel_path: str) -> str:
     return fallback.read_text(encoding="utf-8")
 
 
+# The ONLY subdirectories of ``reyn.builtin`` whose files are legitimate L2
+# body reads: ``reyn.builtin.registry``'s ``BUILTIN_SKILLS`` paths point at
+# ``skills/<name>/SKILL.md`` and ``BUILTIN_PIPELINES`` paths at
+# ``pipelines/<name>.yaml``. The ``reference/`` mirror is NOT here: it is read
+# via :func:`read_builtin_doc` directly (never through the ``read_file`` op),
+# so it needs no body-read bypass. Least-privilege (#2914 co-vet Ruling 1): a
+# path resolving INSIDE the package but OUTSIDE these body dirs (e.g. a
+# ``.py`` module) returns ``None`` and falls through to the normal read-zone
+# gate — the bypass cannot be repurposed as an arbitrary-builtin-source read.
+_BODY_READ_DIRS = frozenset({"skills", "pipelines"})
+
+
 def read_builtin_body_bytes(path_str: str) -> "bytes | None":
     """Wheel-safe read of a builtin skill/pipeline BODY file (#2913).
 
     Returns the file's raw bytes via :mod:`importlib.resources` when
-    *path_str* resolves to a location INSIDE the ``reyn.builtin`` package
-    directory (= it IS a builtin-provenance body — ``reyn.builtin.registry``
-    is the only place that stamps such absolute paths, and nothing else
-    lives under this package's ``skills/``/``pipelines/`` trees). Returns
-    ``None`` when *path_str* is NOT under ``reyn.builtin`` — the caller
+    *path_str* resolves to a file INSIDE one of the ``reyn.builtin`` package's
+    BODY directories (``skills/`` or ``pipelines/`` — see ``_BODY_READ_DIRS``):
+    it IS a builtin-provenance body (``reyn.builtin.registry`` is the only
+    place that stamps such absolute paths). Returns ``None`` otherwise — a
+    path NOT under ``reyn.builtin`` at all (an operator path), OR under the
+    package but outside the body dirs (a ``.py`` module, the ``reference/``
+    mirror, etc.). In every ``None`` case the caller
     (``reyn.core.op_runtime.file.handle``) falls through to the normal
-    ``_in_default_read_zone``-gated file read for every operator path,
-    unchanged (no security carve-out for anything but this package's own
-    shipped content).
+    ``_in_default_read_zone``-gated file read, unchanged — the permission
+    bypass is scoped to exactly the shipped body content, nothing else.
     """
     try:
         builtin_root = _resources.files("reyn.builtin")
@@ -112,6 +125,10 @@ def read_builtin_body_bytes(path_str: str) -> "bytes | None":
         rel = candidate.relative_to(builtin_dir)
     except ValueError:
         return None  # not under reyn.builtin — not a builtin body, let the normal gate handle it
+
+    # Least-privilege scoping: inside the package but outside a body dir → gated.
+    if not rel.parts or rel.parts[0] not in _BODY_READ_DIRS:
+        return None
 
     resource = builtin_root
     for part in rel.parts:

--- a/src/reyn/builtin/docs.py
+++ b/src/reyn/builtin/docs.py
@@ -1,6 +1,6 @@
-"""Production-reachable read path for the ``docs/reference/`` mirror.
+"""Production-reachable read path for builtin-tier content.
 
-Proposal 0060 Addendum D, D5b. ``resolve_reyn_root()``
+Proposal 0060 Addendum D, D5b (+ #2913 follow-up). ``resolve_reyn_root()``
 (``reyn.runtime.reyn_src.resolve_reyn_root``) raises ``RuntimeError`` in a
 wheel install — there is no co-located ``pyproject.toml`` to anchor the walk,
 so every ``docs/`` path built on top of it is unreachable in production. This
@@ -20,10 +20,26 @@ dev checkout (this is the ONLY caller allowed to treat that RuntimeError as
 "docs unavailable" rather than letting it propagate — every other caller
 should prefer this function over calling ``resolve_reyn_root()`` for docs
 access).
+
+**#2913 — builtin skill/pipeline BODY reads.** ``reyn.builtin.registry``'s
+``BUILTIN_SKILLS``/``BUILTIN_PIPELINES`` entries carry a ``path`` computed
+relative to THIS package's own on-disk location (``builtin/**/*``, F3a) —
+outside ``project_root`` in every deploy, not just a wheel. The generic
+``read_file`` op's ``_in_default_read_zone`` gate
+(``reyn.security.permissions.permissions``) treats any out-of-project-root
+path as "requires approval", which hard-fails non-interactively in
+production (there is no operator to approve). :func:`read_builtin_body_bytes`
+is the same ``importlib.resources`` idiom as :func:`read_builtin_doc`,
+generalized to any path under this package directory (not just
+``reference/``) — it lets the ``read_file`` op handler
+(``reyn.core.op_runtime.file``) short-circuit the read-zone gate for
+builtin-provenance body reads specifically, while leaving every operator
+(non-builtin) file read on the unmodified ``_in_default_read_zone`` path.
 """
 from __future__ import annotations
 
 import importlib.resources as _resources
+from pathlib import Path
 
 
 class DocNotFoundError(FileNotFoundError):
@@ -61,3 +77,48 @@ def read_builtin_doc(rel_path: str) -> str:
     if not fallback.is_file():
         raise DocNotFoundError(f"reference doc {rel_path!r} not found at {fallback}")
     return fallback.read_text(encoding="utf-8")
+
+
+def read_builtin_body_bytes(path_str: str) -> "bytes | None":
+    """Wheel-safe read of a builtin skill/pipeline BODY file (#2913).
+
+    Returns the file's raw bytes via :mod:`importlib.resources` when
+    *path_str* resolves to a location INSIDE the ``reyn.builtin`` package
+    directory (= it IS a builtin-provenance body — ``reyn.builtin.registry``
+    is the only place that stamps such absolute paths, and nothing else
+    lives under this package's ``skills/``/``pipelines/`` trees). Returns
+    ``None`` when *path_str* is NOT under ``reyn.builtin`` — the caller
+    (``reyn.core.op_runtime.file.handle``) falls through to the normal
+    ``_in_default_read_zone``-gated file read for every operator path,
+    unchanged (no security carve-out for anything but this package's own
+    shipped content).
+    """
+    try:
+        builtin_root = _resources.files("reyn.builtin")
+    except ModuleNotFoundError:
+        return None
+
+    try:
+        builtin_dir = Path(str(builtin_root)).resolve()
+    except (OSError, ValueError):
+        return None
+
+    try:
+        candidate = Path(path_str).expanduser().resolve()
+    except OSError:
+        return None
+
+    try:
+        rel = candidate.relative_to(builtin_dir)
+    except ValueError:
+        return None  # not under reyn.builtin — not a builtin body, let the normal gate handle it
+
+    resource = builtin_root
+    for part in rel.parts:
+        resource = resource / part
+    try:
+        if not resource.is_file():
+            return None
+        return resource.read_bytes()
+    except (OSError, NotADirectoryError):
+        return None

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Literal
 
+from reyn.builtin.docs import read_builtin_body_bytes
 from reyn.data.workspace.text_codec import decode_text_or_none, encode_text
 from reyn.schemas.models import FileIROp
 
@@ -200,6 +201,19 @@ def _resolve_for_gate(ctx: OpContext, path_str: str) -> str:
 
 
 async def handle(op: FileIROp, ctx: OpContext) -> dict:
+    # #2913: a builtin skill/pipeline BODY (`reyn.builtin.registry`'s
+    # `path` entries) resolves outside `project_root` in EVERY deploy
+    # (F3a — the path is package-directory-relative, not project-relative),
+    # so the standard out-of-root read-zone gate below would hard-deny it
+    # non-interactively in production. `read_builtin_body_bytes` returns
+    # non-None ONLY when `op.path` falls inside the `reyn.builtin` package
+    # directory (= it IS builtin-provenance content — nothing else lives
+    # there); every operator (non-builtin) path gets None and falls through
+    # to the unmodified `_in_default_read_zone` gate below, unchanged.
+    _builtin_bytes: "bytes | None" = (
+        read_builtin_body_bytes(op.path) if op.op == "read" else None
+    )
+
     # Permission check (single point for both frontends). For
     # `regenerate_index` the file actually written is `output_path`, not
     # `path`; everything else writes to `path`.
@@ -221,8 +235,11 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
                     ctx.permission_decl, _resolve_for_gate(ctx, op.dest_path), ctx.actor,
                     sandbox_policy=_sandbox, bus=ctx.intervention_bus,
                 )
-        elif op.op in _READ_OPS:
-            # read / glob / grep / stat — gate against read scope
+        elif op.op in _READ_OPS and _builtin_bytes is None:
+            # read / glob / grep / stat — gate against read scope. Skipped
+            # for a builtin body read (#2913, above) — that content is
+            # code-shipped and non-editable, the same trust tier as the
+            # source code the operator already has repo/package access to.
             await ctx.permission_resolver.require_file_read(
                 ctx.permission_decl, _resolve_for_gate(ctx, op.path), ctx.actor,
                 sandbox_policy=_sandbox, bus=ctx.intervention_bus,
@@ -277,7 +294,14 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         # short-circuited above via the #365 media-blocks path.) Permission
         # gating is identical — read_file_bytes resolves the read-zone the same
         # way read_file does.
-        raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
+        # #2913: a builtin body's bytes come from importlib.resources (see the
+        # short-circuit at the top of `handle`), not the workspace file read —
+        # everything below (decode ladder, offset/limit paging, truncation) is
+        # unchanged either way.
+        if _builtin_bytes is not None:
+            raw_bytes, found = _builtin_bytes, True
+        else:
+            raw_bytes, found = ctx.workspace.read_file_bytes(op.path)
         if not found:
             suggestions = _nearby_files(ctx.workspace, op.path)
             ctx.events.emit("tool_executed", op="read_file", path=op.path, found=False)

--- a/tests/test_2913_builtin_body_wheel_reachable.py
+++ b/tests/test_2913_builtin_body_wheel_reachable.py
@@ -1,0 +1,130 @@
+"""Tier 2: OS invariant — proposal 0060 F3 follow-up #2913.
+
+Co-vet pins:
+
+  1. **Wheel-layout reachability.** A builtin skill's body (``BUILTIN_SKILLS``'s
+     ``reyn_cheat_sheet`` entry, ``reyn.builtin.registry``) is readable through
+     the real ``read_file`` op (``reyn.core.op_runtime.file.handle``) even when
+     the ``PermissionResolver``'s ``project_root`` is a directory that does
+     NOT contain the builtin package (= the fact of a wheel install: the
+     package lives in site-packages, physically outside any given project's
+     ``project_root``). Prior to #2913 this hard-failed with a
+     ``PermissionError`` from ``_in_default_read_zone`` (confirmed defect,
+     issue #2913 / architect co-vet on #2912).
+  2. **Falsify.** Stripping the ``importlib.resources`` routing (reverting to
+     the plain ``ctx.workspace.read_file_bytes`` path for a builtin body, by
+     monkeypatching ``read_builtin_body_bytes`` back to always return
+     ``None``) makes the SAME read hit the out-of-root gate and raise
+     ``PermissionError`` — proving the wheel-layout test above is exercising
+     the new routing, not some other path that "just works".
+  3. **No security regression.** An operator (non-builtin) file outside the
+     read zone is still denied by the unmodified ``_in_default_read_zone``
+     gate — the builtin short-circuit does not widen the gate for anything
+     else.
+
+No mocks: real ``PermissionResolver`` + real ``OpContext`` + the real
+``handle()`` op dispatch, exactly the harness ``test_op_runtime_file_permissions.py``
+already established for this module.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.builtin.registry import BUILTIN_SKILLS
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime import file as file_mod
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+_CHEAT_SHEET_PATH = BUILTIN_SKILLS["reyn_cheat_sheet"]["path"]
+
+
+def _make_ctx(*, permission_resolver: PermissionResolver | None) -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=permission_resolver,
+        actor="test_skill",
+    )
+
+
+def _resolver(project_root: Path) -> PermissionResolver:
+    return PermissionResolver(
+        config_permissions={},
+        project_root=project_root,
+        interactive=False,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _read_op(path: str) -> FileIROp:
+    return FileIROp(kind="file", op="read", path=path)
+
+
+def test_builtin_skill_body_readable_with_project_root_elsewhere(tmp_path, monkeypatch):
+    """Tier 2: simulated wheel layout — project_root has NOTHING to do with the
+    installed package location (the real fact in a pip-installed deploy: the
+    package lives in site-packages, not under the user's project). The
+    cheat-sheet body still reads successfully through the real read_file op."""
+    monkeypatch.chdir(tmp_path)
+    unrelated_root = tmp_path / "unrelated_project"
+    unrelated_root.mkdir()
+    resolver = _resolver(unrelated_root)
+    ctx = _make_ctx(permission_resolver=resolver)
+
+    assert not str(Path(_CHEAT_SHEET_PATH).resolve()).startswith(
+        str(unrelated_root.resolve())
+    ), "fixture invariant: the builtin path must genuinely be outside project_root"
+
+    result = _run(handle(_read_op(_CHEAT_SHEET_PATH), ctx))
+
+    assert result["status"] == "ok", result
+    # Behavioral assertion (not a golden pin): the REAL SKILL.md content, via a
+    # distinctive marker from its own front-matter — not exact length/formatting.
+    assert "reyn_cheat_sheet" in result["content"]
+    assert "description:" in result["content"]
+
+
+def test_falsify_stripped_routing_hits_out_of_root_permission_error(tmp_path, monkeypatch):
+    """Tier 2: (falsify) with the importlib.resources routing stripped — simulating
+    a revert to the plain `ctx.workspace.read_file_bytes` path — the SAME builtin
+    body read now hits the out-of-project-root gate and raises PermissionError.
+    Proves the GREEN test above is actually exercising the new routing."""
+    monkeypatch.chdir(tmp_path)
+    unrelated_root = tmp_path / "unrelated_project"
+    unrelated_root.mkdir()
+    resolver = _resolver(unrelated_root)
+    ctx = _make_ctx(permission_resolver=resolver)
+
+    monkeypatch.setattr(file_mod, "read_builtin_body_bytes", lambda path_str: None)
+
+    with pytest.raises(PermissionError, match="read from"):
+        _run(handle(_read_op(_CHEAT_SHEET_PATH), ctx))
+
+
+def test_operator_file_outside_zone_still_denied(tmp_path, monkeypatch):
+    """Tier 2: no security regression — an ordinary (non-builtin) file outside
+    project_root is still denied by the unmodified _in_default_read_zone gate.
+    The builtin short-circuit only ever fires for a path under reyn.builtin;
+    an operator file living elsewhere on disk never matches it."""
+    monkeypatch.chdir(tmp_path)
+    resolver = _resolver(tmp_path)
+    ctx = _make_ctx(permission_resolver=resolver)
+
+    operator_file = tmp_path.parent / "operator_secret.txt"
+    operator_file.write_text("not a builtin body")
+
+    with pytest.raises(PermissionError, match="read from"):
+        _run(handle(_read_op(str(operator_file)), ctx))

--- a/tests/test_2913_builtin_body_wheel_reachable.py
+++ b/tests/test_2913_builtin_body_wheel_reachable.py
@@ -21,6 +21,13 @@ Co-vet pins:
      read zone is still denied by the unmodified ``_in_default_read_zone``
      gate — the builtin short-circuit does not widen the gate for anything
      else.
+  4. **Least-privilege scoping (#2914 co-vet Ruling 1).** A path that resolves
+     INSIDE the ``reyn.builtin`` package but OUTSIDE the body dirs
+     (``skills/``/``pipelines/``) — e.g. ``reyn/builtin/registry.py`` — returns
+     ``None`` from ``read_builtin_body_bytes`` (NOT bytes), so it goes through
+     the normal read gate, not the bypass. Falsify: widen the check back to
+     "any path under the package" and this test shows bytes returned = the
+     over-broad bypass.
 
 No mocks: real ``PermissionResolver`` + real ``OpContext`` + the real
 ``handle()`` op dispatch, exactly the harness ``test_op_runtime_file_permissions.py``
@@ -33,6 +40,8 @@ from pathlib import Path
 
 import pytest
 
+from reyn.builtin import registry as builtin_registry
+from reyn.builtin.docs import read_builtin_body_bytes
 from reyn.builtin.registry import BUILTIN_SKILLS
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime import file as file_mod
@@ -112,6 +121,32 @@ def test_falsify_stripped_routing_hits_out_of_root_permission_error(tmp_path, mo
 
     with pytest.raises(PermissionError, match="read from"):
         _run(handle(_read_op(_CHEAT_SHEET_PATH), ctx))
+
+
+def test_non_body_package_path_returns_none_not_bypassed(tmp_path, monkeypatch):
+    """Tier 2: least-privilege scoping — a path INSIDE the reyn.builtin package
+    but OUTSIDE the body dirs (skills/ + pipelines/), e.g. the package's own
+    registry.py module, returns None from read_builtin_body_bytes (so the read
+    would go through the NORMAL gate, not the bypass). Guards against the
+    over-broad "any path under the package" bypass the co-vet flagged."""
+    non_body_path = builtin_registry.__file__  # reyn/builtin/registry.py — a .py, not a body
+    assert Path(non_body_path).is_file(), "fixture: the package module must exist on disk"
+
+    # It IS inside the package dir (so the containment check alone would pass) ...
+    import importlib.resources as _res
+    pkg_dir = Path(str(_res.files("reyn.builtin"))).resolve()
+    assert str(Path(non_body_path).resolve()).startswith(str(pkg_dir)), (
+        "fixture: registry.py must live inside the reyn.builtin package dir"
+    )
+    assert Path(non_body_path).resolve().parent == pkg_dir, (
+        "fixture: registry.py must sit at the package root, outside skills/ or pipelines/"
+    )
+
+    # ... but it is NOT a body file → the helper returns None (falls through to the gate).
+    assert read_builtin_body_bytes(non_body_path) is None
+    # Sanity contrast: a genuine body path DOES return bytes (the bypass still works
+    # for what it's scoped to — this is not a vacuous None-for-everything result).
+    assert read_builtin_body_bytes(_CHEAT_SHEET_PATH) is not None
 
 
 def test_operator_file_outside_zone_still_denied(tmp_path, monkeypatch):


### PR DESCRIPTION
**[lead-coder]** — REQUIRED in-arc follow-up for proposal 0060 F3 (the "production-reachable cheat-sheet" gate). Closes #2913. D5b-analog slice — mirrors #2911's wheel-safe reader mechanism.

## Confirmed defect (architect-verified on #2912, not speculative)
The `reyn_cheat_sheet` builtin skill's body IS bundled in the wheel (F3a `builtin/**/*` glob), but reading it at L2 hard-failed in a wheel deploy: `read_file` → `_in_default_read_zone` (`permissions.py:174`) judges `site-packages/` as outside `project_root` → `Path.relative_to` raises → `PermissionError`. Non-interactive = no consent prompt to recover. The cheat-sheet is the D5-attach hub, so its body being unreadable in prod broke the docs-delivery deliverable where it matters most.

## The fix (reuses #2911's `read_builtin_doc` / importlib.resources reader)
#2911 (D5b) already built a wheel-safe reader — `reyn.builtin.docs.read_builtin_doc()` via `importlib.resources` (no repo root, works in a wheel), wired ONLY to reference-docs read. This PR generalizes that idiom to the skill/pipeline **body** read:

1. **`reyn.builtin.docs.read_builtin_body_bytes()`** (new) — same `importlib.resources` structure as `read_builtin_doc`, generalized to any path under the `reyn.builtin` package (not just `reference/`). Resolves `op.path` against the package dir; returns the file's bytes when the path is **inside** the package (= it IS a builtin-provenance body — `reyn.builtin.registry` is the only place that stamps such absolute paths), else returns `None`.

2. **Rerouted call-site: `src/reyn/core/op_runtime/file.py` `handle()` — the `op.op == "read"` path** (the L2 body read that currently goes through `require_file_read` → `_in_default_read_zone` and `ctx.workspace.read_file_bytes`). For a read op, it now calls `read_builtin_body_bytes(op.path)` up front; when non-None it (a) **skips** the `require_file_read` read-zone gate and (b) sources the raw bytes from the importlib.resources result instead of the workspace file read. Everything downstream (decode ladder, offset/limit paging, truncation) is unchanged. When `read_builtin_body_bytes` returns `None` — every operator (non-builtin) path — the flow is **byte-identical to before**: the unmodified `_in_default_read_zone` gate runs.

No security carve-out for anything but the package's own code-shipped, non-editable content (same trust tier as the source the operator already has repo/package access to).

## Witness (co-vet gate) — `tests/test_2913_builtin_body_wheel_reachable.py` (Tier 2)
- **wheel-layout reachability**: with the `PermissionResolver`'s `project_root` set to a directory unrelated to the package location (the fact of a wheel install — package in site-packages, outside any project), the cheat-sheet body reads `status="ok"` end-to-end through the **real** `handle()` op dispatch + real `PermissionResolver` (no mocks; same harness as `test_op_runtime_file_permissions.py`).
- **strip→RED falsify**: monkeypatch `read_builtin_body_bytes` back to always return `None` (= revert to the plain `read_file` path) → the SAME read hits the out-of-root gate → `PermissionError` (RED). Proves the GREEN test exercises the new routing, not a path that "just works".
- **no security regression**: an operator (non-builtin) file outside the read zone is still denied by the unmodified `_in_default_read_zone` gate.

Real `python -m build --wheel` install-and-read was assessed; the simulated-layout test (project_root genuinely outside the package dir — asserted in-test) reproduces the exact `relative_to`-raises condition #2913 names, so it IS the decisive gate here (same class as #2911's simulated-`resolve_reyn_root`-raises test).

## Design fork
- **Trust-tier decision (flagging, not asking)**: builtin-provenance body reads **bypass** the read-zone gate entirely rather than being added as a new allowed zone. Rationale: builtin content is code-shipped and operator-non-editable (the A9 provenance seam guarantees no LLM/install-op path can forge `provenance="builtin"`), so it sits at the same trust tier as the package source itself. The bypass is keyed structurally — `read_builtin_body_bytes` returns non-None ONLY for paths that resolve inside the `reyn.builtin` package dir — so it cannot be widened by operator input. If a reviewer prefers a formal "builtin zone" in `_in_default_read_zone` instead of a handler short-circuit, that's a mechanical swap; I chose the handler seam to keep the permission gate untouched (no new zone semantics for operator files).

## Testing
- **Full pytest** (foreground, to completion, not affected-only): **8408 passed, 20 skipped, 0 failures** (214s).
- **ruff check src tests**: clean.
- **tier-audit --strict** on `tests/test_2913_builtin_body_wheel_reachable.py`: 0 Tier-4 violations.
- **verify_module_docstrings.py** on changed src: clean.

## Test plan
- [x] `pytest` full suite green (0 failures)
- [x] `ruff check src tests` clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_2913_builtin_body_wheel_reachable.py` clean
- [x] `python scripts/verify_module_docstrings.py <changed src>` clean
- [x] wheel-layout body-read verified GREEN; strip→RED falsify confirmed; operator-file-still-denied confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
