### PR TITLE
test: isolate test_full_schema_contract_matches_baseline from global-registry pollution (#2898)

### DIFF
--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -30,6 +30,14 @@ _HOOK_POINTS = [
     "turn_start", "turn_end", "session_start", "session_end",
     "task_start", "task_end",
 ]
+# Isolation note (#2898): the schema below embeds ``list(_HOOK_POINTS)`` — a
+# defensive copy — NOT the module list by reference. ``render_for_router`` only
+# shallow-copies ``parameters``, so a by-reference embed would alias the module
+# list into every rendered schema; any later mutation of ``_HOOK_POINTS`` would
+# then silently corrupt every ``hooks_add`` render for the rest of the process
+# (a shared-mutable-state × test-order flake vector). The copy decouples the
+# rendered enum from the module list (same convention as
+# ``universal_catalog.py``'s ``"enum": list(CATEGORIES)``).
 
 # Relocated to reyn.tools.descriptions.hooks (Phase 3 tool-description
 # package refactor — byte-identical, no LLM-facing text change).
@@ -46,7 +54,7 @@ _HOOKS_ADD_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "on": {
-            "type": "string", "enum": _HOOK_POINTS,
+            "type": "string", "enum": list(_HOOK_POINTS),
             "description": _hooks_descriptions.PARAMS["hooks_add"]["on"].text,
         },
         "message": {

--- a/tests/test_2073_s3_hooks_write_op.py
+++ b/tests/test_2073_s3_hooks_write_op.py
@@ -53,6 +53,42 @@ def test_hooks_add_has_no_path_parameter() -> None:
     assert props == {"on", "message", "wake", "push_when", "name"}
 
 
+def test_hooks_add_on_enum_is_isolated_from_module_hook_points_list() -> None:
+    """Tier 2: HOOKS_ADD's rendered ``on`` enum is decoupled from the module-level
+    ``_HOOK_POINTS`` list — mutating that list must NOT leak into the rendered
+    schema (#2898 shared-mutable-state × test-order isolation).
+
+    ``render_for_router`` only shallow-copies ``parameters``, so a by-reference
+    embed of ``_HOOK_POINTS`` would alias the module list into every render;
+    one stray mutation would then pollute every later ``hooks_add`` render (the
+    exact flake class). The schema embeds a defensive copy, so this cannot
+    happen. Falsification: append to the module list, render, assert the enum
+    is unchanged (the append is undone in ``finally`` so this test leaves no
+    global-state residue of its own)."""
+    import reyn.tools.hooks as hooks_mod
+
+    def _rendered_on_enum() -> list[str]:
+        return hooks_mod.HOOKS_ADD.render_for_router()[
+            "function"]["parameters"]["properties"]["on"]["enum"]
+
+    expected = list(hooks_mod._HOOK_POINTS)
+    assert _rendered_on_enum() == expected, (
+        "precondition: the rendered enum should match the module hook points"
+    )
+
+    _POLLUTANT = "__2898_pollutant_hook_point__"
+    hooks_mod._HOOK_POINTS.append(_POLLUTANT)
+    try:
+        assert _POLLUTANT not in _rendered_on_enum(), (
+            "mutating the module-level _HOOK_POINTS list leaked into HOOKS_ADD's "
+            "rendered `on` enum — the schema must embed a defensive copy so a "
+            "shared-mutable mutation cannot pollute a later render (#2898)"
+        )
+        assert _rendered_on_enum() == expected
+    finally:
+        hooks_mod._HOOK_POINTS.remove(_POLLUTANT)
+
+
 @pytest.mark.asyncio
 async def test_hooks_add_writes_in_set_only_not_reyn_yaml(tmp_path: Path) -> None:
     """Tier 2: the op writes .reyn/hooks.yaml (IN-set) + leaves reyn.yaml (OUT-set)


### PR DESCRIPTION
**[lead-coder]** — Closes #2898

## Root cause (shared-mutable-state × test-order, 3rd of the class after #2861 / #2869)
`hooks_add`'s rendered `on` enum embedded the module-level `_HOOK_POINTS` list **by reference** (`"enum": _HOOK_POINTS`). `ToolDefinition.render_for_router()` only *shallow*-copies `parameters` (`dict(self.parameters)`), so that same list object aliased into every rendered `HOOKS_ADD` schema **and** stayed identical to the module global. Any mutation of `_HOOK_POINTS` anywhere in a process would silently corrupt every later `hooks_add` render — the exact reported symptom: `test_full_schema_contract_matches_baseline` (which reads the global `get_default_registry()`) sees `hooks_add`'s schema diverge from the frozen baseline under certain `pytest-randomly` orderings.

Frozen `@dataclass(frozen=True)` on `ToolDefinition` protects the `.description` **str** (can't be reassigned) — but not nested mutable containers inside `.parameters`. The `enum` list was the one such by-reference embed in the whole `tools/` package.

## Fix (structural, not a bandaid)
Embed a **defensive copy** `list(_HOOK_POINTS)`, matching the codebase's own convention — `universal_catalog.py` already does `"enum": list(CATEGORIES)`. This decouples `HOOKS_ADD`'s schema from the mutable module list, so no mutation of `_HOOK_POINTS` (test or runtime) can pollute a later render. No order-pinning, no retry. The rendered enum **value is byte-identical**, so the pre-migration baseline fixture (`_pre_migration_tool_schemas_baseline.json`) is unchanged.

## Reproduction / polluter note
I could not reproduce a RED ordering after ~180 randomized seeds on the tool-test subset, and confirmed **no test currently mutates `_HOOK_POINTS`** — so the live polluter is not in the committed tree (consistent with the non-repro; the flake was observed during #2897 development). Regardless, the by-reference embed is a real latent defect on the exact `hooks_add` schema surface named in the issue, and fixing it structurally closes the vector. If a future polluter appears it can no longer leak through this seam.

## Witness (Tier 2, falsified)
`test_hooks_add_on_enum_is_isolated_from_module_hook_points_list`: appends a pollutant to `_HOOK_POINTS` post-import, asserts `HOOKS_ADD.render_for_router()`'s enum is unaffected (append undone in `finally` — no global residue). Verified **RED before the fix** (pollutant leaks into the render), green after.

## Gates (all local-green)
- `ruff check` — pass
- `test_tier_audit.py --strict tests/test_2073_s3_hooks_write_op.py` — 9/9 OK, 0 Tier-4
- `verify_module_docstrings.py src/reyn/tools/hooks.py` — OK
- affected suites (relocation baseline / hooks / external-content flagset / llm-facing-english / hook-config-schema / composer-reachability) across `-p randomly` seeds {1,42,100,2898,31337} — 139 passed each
- full-suite `-p randomly` sweep (6 seeds) — running; will report in a comment

## Test plan
- [x] Witness falsified (RED without fix, green with fix)
- [x] Baseline fixture unchanged (byte-identical enum value)
- [x] 4 CI gates green locally
- [x] Multi-seed randomized run green on affected suites
- [ ] Full-suite `-p randomly` multi-seed sweep green (in progress; comment to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)