### PR TITLE
feat: proposal 0060 F3b — draft→judge→revise skill + status-card present-view builtins

### DIFF
--- a/src/reyn/builtin/registry.py
+++ b/src/reyn/builtin/registry.py
@@ -35,12 +35,17 @@ registering one is already inert until something names it (Addendum A3) —
 forcing an ``auto_invoke``-shaped field on them would invent state that does
 not exist in their schemas.
 
-F3a (this PR) ships ``BUILTIN_SKILLS`` / ``BUILTIN_PIPELINES`` /
-``BUILTIN_PRESENTATIONS`` EMPTY — the exemplar content is F3b (proposal §3
-F3, a later phase). ``build_builtin_config()`` on an empty registry returns
-three empty ``entries`` dicts, a no-op merge (byte-identical to pre-F3a
-config resolution) — this is what "ships inert" means at the mechanism
-level: zero behavior change until content lands.
+F3a shipped ``BUILTIN_SKILLS`` / ``BUILTIN_PIPELINES`` / ``BUILTIN_PRESENTATIONS``
+EMPTY (mechanism only) — ``build_builtin_config()`` on that empty registry
+returned three empty ``entries`` dicts, a no-op merge (byte-identical to
+pre-F3a config resolution): this is what "ships inert" means at the
+mechanism level, zero behavior change until content lands. F3b (proposal §3
+F3, Addendum D9.5's curated-5) populated the maps with the exemplar content
+across two PRs: the core spine (``reyn_cheat_sheet`` skill + the ``flagship``
+pipeline, #2912) and this sibling PR's remaining two exemplars
+(``draft_judge_revise`` skill + the ``status_card`` presentation). Every
+entry still carries ``provenance="builtin"`` and ships inert (A3) — the
+mechanism guarantee is unchanged, only the content maps are no longer empty.
 """
 from __future__ import annotations
 
@@ -48,13 +53,14 @@ from pathlib import Path
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# The builtin content maps. F3b (this phase) populates the SKILLS + PIPELINES
-# maps with the curated core-spine content (proposal 0060 Addendum D6: the
-# "reyn cheat sheet" skill is THE flagship builtin — the gap-filler between
-# "reyn has these parts" and "the LLM uses them" — plus the flagship
-# through-chain pipeline it documents). PRESENTATIONS ships empty in this
-# phase — the status-card present-view exemplar is proposed as a sibling PR
-# (see this PR's body for the split rationale). Shape mirrors the operator
+# The builtin content maps. F3b populates the SKILLS + PIPELINES maps with
+# the curated core-spine content (proposal 0060 Addendum D6: the "reyn cheat
+# sheet" skill is THE flagship builtin — the gap-filler between "reyn has
+# these parts" and "the LLM uses them" — plus the flagship through-chain
+# pipeline it documents). This F3b sibling PR adds the 2 remaining curated-5
+# exemplars (Addendum D9.5 #3/#4): the `draft_judge_revise` workflow skill
+# (Evaluation idiom) and the `status_card` present-view (the status/results
+# card, invoke-by-name, zero-token exemplar). Shape mirrors the operator
 # config entry shape exactly:
 #   BUILTIN_SKILLS = {"<name>": {"description": "...", "path": "...", "enabled": True, "auto_invoke": True}}
 #   BUILTIN_PIPELINES = {"<key>": {"path": "...", "description": "...", "enabled": True}}
@@ -87,6 +93,18 @@ BUILTIN_SKILLS: "dict[str, dict[str, Any]]" = {
         # kept explicit for readability, not because it changes anything.
         "auto_invoke": False,
     },
+    "draft_judge_revise": {
+        "description": (
+            "Draft an artifact, score it with judge_output against a rubric, "
+            "and revise on failure -- the standard Evaluation-gated workflow "
+            "for any 'produce then check quality' task (a summary, a doc "
+            "section, an email). Read this before handing off a "
+            "self-authored artifact you have not gated."
+        ),
+        "path": str(_BUILTIN_DIR / "skills" / "draft_judge_revise" / "SKILL.md"),
+        "enabled": True,
+        "auto_invoke": False,
+    },
 }
 BUILTIN_PIPELINES: "dict[str, dict[str, Any]]" = {
     "flagship": {
@@ -99,7 +117,36 @@ BUILTIN_PIPELINES: "dict[str, dict[str, Any]]" = {
         "enabled": True,
     },
 }
-BUILTIN_PRESENTATIONS: "dict[str, dict[str, Any]]" = {}
+BUILTIN_PRESENTATIONS: "dict[str, dict[str, Any]]" = {
+    # The status/results card exemplar (proposal 0060 Addendum D9.5 curated-5
+    # #4): a declarative blueprint -- fixed component set + `$bind` JSON
+    # Pointer, zero token cost -- rendering "show a result" as a card rather
+    # than as prose. Invoke by name: present(view="status_card",
+    # data_inline={"title": "...", "status": "...", "summary": "...",
+    # "duration": "..."}); any of the 4 fields may be omitted -- a missing
+    # $bind target soft-skips at render (present.md), it does not error.
+    "status_card": {
+        "description": (
+            "Status/results card -- a zero-token present blueprint showing "
+            "a title, status, summary, and duration as a compact card "
+            "instead of prose. Invoke by name: present(view='status_card', "
+            "data_inline={'title': ..., 'status': ..., 'summary': ..., "
+            "'duration': ...})."
+        ),
+        "blueprint": [
+            {"component": "markdown", "text": {"$bind": "/title"}},
+            {
+                "component": "keyvalue",
+                "rows": [
+                    {"label": "status", "value": {"$bind": "/status"}},
+                    {"label": "summary", "value": {"$bind": "/summary"}},
+                    {"label": "duration", "value": {"$bind": "/duration"}},
+                ],
+            },
+        ],
+        "enabled": True,
+    },
+}
 
 
 def _stamp_builtin_entry(entry: "dict[str, Any]", *, force_auto_invoke_false: bool) -> "dict[str, Any]":

--- a/src/reyn/builtin/skills/draft_judge_revise/SKILL.md
+++ b/src/reyn/builtin/skills/draft_judge_revise/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: draft_judge_revise
+description: Draft an artifact, score it with judge_output against a rubric, and revise on failure -- the standard Evaluation-gated workflow for any "produce then check quality" task (a summary, a doc section, an email, a report paragraph). Read this before handing off a self-authored artifact you have not gated.
+---
+
+# Draft -> judge -> revise
+
+The first-hour common task this skill covers: you produce a piece of text
+(a draft), and before you hand it off or ship it you want an objective pass
+against a rubric rather than your own say-so. This is the CLAUDE.md
+Evaluation lens applied to a single artifact, not just to a promoted
+skill/pipeline/hook (0060 Addendum D9.5 curated-5 #3).
+
+## The loop
+
+1. **Draft.** Produce the artifact as you normally would (write the summary,
+   the section, the email).
+2. **Judge.** Call `judge_output(data_inline=<the draft>, rubric="...",
+   threshold=<0.0-1.0>)`. Write the rubric yourself, in plain language --
+   the OS never interprets it (P7); it just scores your draft against your
+   own criteria and returns `{score, passed, reason}`.
+3. **Revise on fail.** If `passed` is `false`, revise the draft using
+   `reason` as the note to fix, then re-run `judge_output` on the revised
+   draft. **Bound the loop** (e.g. stop after 2 revisions and hand off the
+   best attempt with a caveat) rather than looping indefinitely --
+   Reliability lens: bounded loops with graceful force-close, never an
+   unbounded retry.
+4. **Hand off.** Once the draft passes (or the revision budget is spent),
+   show it to the operator via `present` (see `reyn_cheat_sheet`) instead of
+   pasting it into your reply, or continue with whatever workflow requested
+   the draft.
+
+**Worked example** -- a `judge_output` call scoring a drafted paragraph
+(this exact JSON is CI-verified as a valid `judge_output` argument set
+against the real op schema):
+
+```json
+{
+  "data_inline": "Reyn is an agent OS: it makes every LLM-driven action typed, permissioned, audited, and recoverable by construction.",
+  "rubric": "Score 0.0-1.0: is this paragraph clear, accurate, and free of jargon for a first-time reader? Reply as JSON {\"score\": <0-1 float>, \"reason\": <string>}.",
+  "threshold": 0.8,
+  "on_fail": "continue"
+}
+```
+
+If the call above returned `passed=false`, the next step is: revise the
+draft using the returned `reason`, then re-issue the same `judge_output`
+call with `data_inline` set to the revised text -- not a different rubric,
+not a lowered threshold (that would be gaming the gate, not passing it).
+
+Full `judge_output` spec: `docs/reference/runtime/control-ir.md` (`judge_output`
+section).

--- a/tests/test_0060_f3b_sibling_builtins.py
+++ b/tests/test_0060_f3b_sibling_builtins.py
@@ -1,0 +1,236 @@
+"""Tier 2: OS invariant — proposal 0060 F3b sibling PR: the 2 remaining
+curated-5 builtins (Addendum D9.5 #3/#4) that did not ship with the core
+spine (#2912) — the `draft_judge_revise` workflow SKILL and the
+`status_card` present-view.
+
+Co-vet-style pins:
+
+  1. **Both builtins load with provenance="builtin" and are inert.** The
+     skill is `auto_invoke=False` (discoverable, not auto-firing); the
+     presentation is invoke-by-name (inherently inert, A3).
+  2. **The skill's SKILL.md is well-formed** (parseable YAML frontmatter
+     with `name`/`description`) and its body is wheel-reachable via the same
+     `read_builtin_body_bytes` bypass #2913/#2914 established for
+     `reyn_cheat_sheet` (mirrors `test_2913_builtin_body_wheel_reachable.py`'s
+     wheel-layout scenario for this second skill).
+  3. **The skill's embedded worked example is D5a-executable**: the fenced
+     ```json``` `judge_output` argument set parses AND validates against the
+     REAL `JudgeOutputIROp` schema. Falsify: corrupt it (drop `rubric`) ->
+     schema validation fails, proving the positive test exercises real
+     validation.
+  4. **The status_card blueprint passes `validate_blueprint`** (the real
+     structural gate) and registers through the real
+     `build_presentation_registry` config-entry path. Falsify: corrupt the
+     blueprint (unknown component) -> `PresentBlueprintError`.
+
+No mocks: real `BUILTIN_SKILLS`/`BUILTIN_PRESENTATIONS` maps, the real
+`JudgeOutputIROp` pydantic model, the real `validate_blueprint` +
+`build_presentation_registry`, the real `read_file` op + `OpContext`
+(mirrors `test_2913_builtin_body_wheel_reachable.py`'s harness).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.builtin.docs import read_builtin_body_bytes
+from reyn.builtin.registry import (
+    BUILTIN_PRESENTATIONS,
+    BUILTIN_SKILLS,
+    build_builtin_config,
+)
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.core.present.catalog import PresentBlueprintError, validate_blueprint
+from reyn.data.presentations.registry import build_presentation_registry
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp, JudgeOutputIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+_SKILL_PATH = Path(BUILTIN_SKILLS["draft_judge_revise"]["path"])
+
+
+def _skill_body() -> str:
+    return _SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _extract_fenced_block(text: str, lang: str) -> str:
+    match = re.search(rf"```{re.escape(lang)}\n(.*?)```", text, re.DOTALL)
+    assert match is not None, f"no ```{lang} fenced block found in draft_judge_revise skill"
+    return match.group(1)
+
+
+# ---------------------------------------------------------------------------
+# Both builtins: provenance + inert
+# ---------------------------------------------------------------------------
+
+
+def test_draft_judge_revise_skill_ships_builtin_provenance_and_inert() -> None:
+    """Tier 2: the draft_judge_revise skill loads with provenance="builtin",
+    auto_invoke=False (discoverable, not auto-firing), enabled=True
+    (discoverable)."""
+    cfg = build_builtin_config()
+    entry = cfg["skills"]["entries"]["draft_judge_revise"]
+    assert entry["provenance"] == "builtin"
+    assert entry["auto_invoke"] is False
+    assert entry.get("enabled", True) is True
+
+
+def test_status_card_presentation_ships_builtin_provenance() -> None:
+    """Tier 2: the status_card presentation loads with provenance="builtin"
+    -- invoke-by-name is inherently inert (A3), no auto_invoke-shaped field
+    exists on a presentation entry to force."""
+    cfg = build_builtin_config()
+    entry = cfg["presentations"]["entries"]["status_card"]
+    assert entry["provenance"] == "builtin"
+
+
+def test_status_card_discoverable_not_auto_enabled() -> None:
+    """Tier 2: the status_card entry is discoverable (enabled defaults True)
+    but requires an explicit `present(view="status_card", ...)` call --
+    registering a template never self-triggers a render."""
+    assert BUILTIN_PRESENTATIONS["status_card"].get("enabled", True) is True
+
+
+# ---------------------------------------------------------------------------
+# draft_judge_revise: well-formed SKILL.md + wheel-reachable body
+# ---------------------------------------------------------------------------
+
+
+def test_skill_frontmatter_is_well_formed() -> None:
+    """Tier 2: the SKILL.md frontmatter (between the two `---` fences) is
+    valid YAML with the required `name`/`description` keys, matching the
+    registered BUILTIN_SKILLS entry name."""
+    body = _skill_body()
+    match = re.match(r"^---\n(.*?)\n---\n", body, re.DOTALL)
+    assert match is not None, "SKILL.md must open with a YAML frontmatter block"
+    frontmatter = yaml.safe_load(match.group(1))
+    assert frontmatter["name"] == "draft_judge_revise"
+    assert isinstance(frontmatter["description"], str) and frontmatter["description"]
+
+
+def test_skill_body_readable_with_project_root_elsewhere(tmp_path, monkeypatch):
+    """Tier 2: simulated wheel layout (mirrors
+    test_2913_builtin_body_wheel_reachable.py for the reyn_cheat_sheet skill)
+    -- the draft_judge_revise body reads successfully through the real
+    read_file op even when project_root has nothing to do with the package's
+    on-disk location."""
+    monkeypatch.chdir(tmp_path)
+    unrelated_root = tmp_path / "unrelated_project"
+    unrelated_root.mkdir()
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=unrelated_root, interactive=False,
+    )
+    events = EventLog()
+    ws = Workspace(events=events)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="test_skill",
+    )
+
+    assert not str(_SKILL_PATH.resolve()).startswith(str(unrelated_root.resolve())), (
+        "fixture invariant: the builtin path must genuinely be outside project_root"
+    )
+
+    op = FileIROp(kind="file", op="read", path=str(_SKILL_PATH))
+    result = asyncio.run(handle(op, ctx))
+
+    assert result["status"] == "ok", result
+    assert "draft_judge_revise" in result["content"]
+    assert "description:" in result["content"]
+
+
+def test_body_read_dir_bypass_reaches_the_second_skill_too() -> None:
+    """Tier 2: read_builtin_body_bytes (the #2913/#2914 wheel-reachable
+    bypass) is not hardcoded to the cheat-sheet path -- it generalizes to
+    ANY path under skills/, including this second builtin skill."""
+    raw = read_builtin_body_bytes(str(_SKILL_PATH))
+    assert raw is not None
+    assert b"draft_judge_revise" in raw
+
+
+# ---------------------------------------------------------------------------
+# D5a: the embedded judge_output worked example is executable
+# ---------------------------------------------------------------------------
+
+
+def test_skill_embedded_judge_output_example_validates_against_real_schema() -> None:
+    """Tier 2: the fenced ```json``` judge_output argument block embedded in
+    the skill parses as JSON AND validates against the REAL JudgeOutputIROp
+    pydantic model (D5a: every cheat-sheet-style example is CI-verified
+    against the real implementation, not just prose)."""
+    json_text = _extract_fenced_block(_skill_body(), "json")
+    args = json.loads(json_text)
+    op = JudgeOutputIROp(kind="judge_output", **args)
+    assert op.data_inline == args["data_inline"]
+    assert op.rubric == args["rubric"]
+    assert op.threshold == pytest.approx(0.8)
+    assert op.on_fail == "continue"
+
+
+def test_skill_embedded_example_corrupted_fails_schema_validation() -> None:
+    """Tier 2: FALSIFY anchor for D5a -- dropping the required `rubric` field
+    from the embedded example fails JudgeOutputIROp validation, proving the
+    positive test above is exercising real schema validation, not a vacuous
+    pass-through."""
+    json_text = _extract_fenced_block(_skill_body(), "json")
+    args = json.loads(json_text)
+    del args["rubric"]
+    with pytest.raises(Exception):  # pydantic ValidationError
+        JudgeOutputIROp(kind="judge_output", **args)
+
+
+def test_skill_embedded_example_both_target_and_data_inline_would_fail() -> None:
+    """Tier 2: FALSIFY anchor -- supplying BOTH target and data_inline (the
+    XOR the real model enforces) is rejected, confirming the embedded
+    example's single-source shape is load-bearing, not incidental."""
+    json_text = _extract_fenced_block(_skill_body(), "json")
+    args = json.loads(json_text)
+    args["target"] = "some.dotted.path"
+    with pytest.raises(Exception):  # pydantic ValidationError (XOR violated)
+        JudgeOutputIROp(kind="judge_output", **args)
+
+
+# ---------------------------------------------------------------------------
+# status_card: validate_blueprint + registry round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_status_card_blueprint_passes_validate_blueprint() -> None:
+    """Tier 2: the shipped status_card blueprint passes the REAL structural
+    gate (validate_blueprint) -- every component is in the display-only
+    catalog and every binding is a JSON Pointer string."""
+    blueprint = BUILTIN_PRESENTATIONS["status_card"]["blueprint"]
+    nodes = validate_blueprint(blueprint)
+    assert [n["component"] for n in nodes] == ["markdown", "keyvalue"]
+
+
+def test_status_card_blueprint_falsify_corrupted_component_rejected() -> None:
+    """Tier 2: FALSIFY anchor -- swapping in a non-catalog component name
+    raises PresentBlueprintError, proving the positive test above is
+    exercising the real structural gate, not a vacuous pass-through."""
+    import copy
+
+    corrupted = copy.deepcopy(BUILTIN_PRESENTATIONS["status_card"]["blueprint"])
+    corrupted[0]["component"] = "not_a_real_component"
+    with pytest.raises(PresentBlueprintError):
+        validate_blueprint(corrupted)
+
+
+def test_status_card_registers_through_the_real_presentation_registry() -> None:
+    """Tier 2: the builtin-tier config shape (build_builtin_config's
+    "presentations" block) round-trips through the REAL
+    build_presentation_registry config-entry loader (the production
+    population path), not just validate_blueprint in isolation."""
+    cfg = build_builtin_config()
+    registry = build_presentation_registry(cfg["presentations"], strict=True)
+    assert registry.has("status_card")
+    nodes = registry.get("status_card")
+    assert nodes is not None
+    assert [n["component"] for n in nodes] == ["markdown", "keyvalue"]

--- a/tests/test_0060_phase1_f3a_builtin_tier.py
+++ b/tests/test_0060_phase1_f3a_builtin_tier.py
@@ -93,30 +93,32 @@ def _make_ctx(tmp_path: Path, *, turn_origin: "str | None") -> OpContext:
     )
 
 # ---------------------------------------------------------------------------
-# F3a's own mechanism-only invariant, updated for F3b (proposal 0060 Phase 2):
-# F3a shipped all three maps EMPTY (mechanism only); F3b populates
-# BUILTIN_SKILLS/BUILTIN_PIPELINES with the curated core-spine content (see
-# tests/test_0060_phase2_f3b_builtin_content.py for F3b's own co-vet pins).
-# BUILTIN_PRESENTATIONS remains empty in this phase (the status-card
-# present-view exemplar is proposed as a sibling PR) — this file keeps
-# asserting THAT invariant; it no longer asserts skills/pipelines are empty,
-# since that was F3a's phase-scoped state, not a permanent one.
+# F3a's own mechanism-only invariant, updated for F3b (proposal 0060 Phase 2,
+# two PRs: #2912 = core spine skill+pipeline; this sibling PR = the remaining
+# curated-5 exemplars, draft_judge_revise skill + status_card presentation):
+# F3a shipped all three maps EMPTY (mechanism only); F3b populates all three
+# — this file no longer asserts any of the three maps stay empty, since that
+# was F3a's phase-scoped state, not a permanent one. See
+# tests/test_0060_phase2_f3b_builtin_content.py (core spine) and
+# tests/test_0060_f3b_sibling_builtins.py (this PR's 2 exemplars) for the
+# content-level co-vet pins.
 # ---------------------------------------------------------------------------
 
 
-def test_builtin_presentations_still_ships_empty_in_this_phase() -> None:
-    """Tier 2: BUILTIN_PRESENTATIONS remains empty in F3b (the present-view
-    exemplar ships in a sibling PR) — the mechanism-only invariant F3a
-    established still holds for this one map."""
-    assert BUILTIN_PRESENTATIONS == {}
+def test_builtin_presentations_now_populated_by_f3b() -> None:
+    """Tier 2: BUILTIN_PRESENTATIONS is populated by this F3b sibling PR (the
+    status_card exemplar) — the mechanism-only EMPTY invariant was F3a's
+    phase-scoped state, not permanent."""
+    assert BUILTIN_PRESENTATIONS != {}
+    assert "status_card" in BUILTIN_PRESENTATIONS
 
 
-def test_build_builtin_config_presentations_entries_still_empty() -> None:
-    """Tier 2: build_builtin_config()'s presentations entries are still an
-    empty no-op merge (skills/pipelines are now populated by F3b — see
-    test_0060_phase2_f3b_builtin_content.py for their own co-vet pins)."""
+def test_build_builtin_config_presentations_entries_populated() -> None:
+    """Tier 2: build_builtin_config()'s presentations entries are non-empty
+    now that F3b has shipped the status_card exemplar — an operator entry
+    still merges through unaffected (non-colliding names coexist)."""
     cfg = build_builtin_config()
-    assert cfg["presentations"] == {"entries": {}}
+    assert cfg["presentations"]["entries"]
     merged = _merge({"skills": {"entries": {"foo": {"path": "x"}}}}, cfg)
     # A distinct, non-colliding operator entry survives the merge unchanged.
     assert merged["skills"]["entries"]["foo"] == {"path": "x"}

--- a/tests/test_present_registry_fp0054_prc.py
+++ b/tests/test_present_registry_fp0054_prc.py
@@ -133,7 +133,13 @@ def test_config_roundtrip_named_template_reaches_registry(tmp_path: Path) -> Non
 
     registry = build_presentation_registry(cfg.presentations)
     assert registry.has("authors")
-    assert registry.names() == ["authors"]
+    # "authors" reached the registry via the operator config entry (the
+    # behavior under test); the exact full name list is NOT pinned here —
+    # cfg.presentations is the merged cascade, which also carries the
+    # builtin-tier's own presentation entries (proposal 0060 F3b,
+    # e.g. "status_card") as the lowest config tier (see
+    # reyn.builtin.registry.build_builtin_config).
+    assert "authors" in registry.names()
     nodes = registry.get("authors")
     # Stored as the NORMALIZED validated node list (structure preserved).
     assert nodes[0]["component"] == "table"


### PR DESCRIPTION
**[lead-coder]** — part of proposal 0060 (F3b sibling of #2912). The 2 remaining curated-5 exemplar builtins (Addendum D9.5 #3/#4) that did not ship with the F3b core spine (cheat-sheet hub + flagship pipeline + SP present-affordance + D5e). Both embedding-independent, INERT, `provenance="builtin"`.

## What ships

1. **`draft_judge_revise` SKILL** (`BUILTIN_SKILLS`) — the "improve a draft" first-hour common task. Teaches the `SKILL.md` live-format + the Evaluation idiom: draft → `judge_output(data_inline=..., rubric=..., threshold=...)` → revise on `passed=false` using `reason`, bounded loop (Reliability lens), hand off via `present`. Ships inert (`auto_invoke` force-stamped `False` by `_stamp_builtin_entry`, A3 — discoverable, never auto-fires). Body is under `skills/`, so wheel-reachable via `read_builtin_body_bytes` (#2914). Its embedded ```` ```json ```` `judge_output` worked example is **D5a-executable** — CI-verified to validate against the real `JudgeOutputIROp` pydantic schema.

2. **`status_card` present-view** (`BUILTIN_PRESENTATIONS`) — the "show a result card" output exemplar. A declarative blueprint (a `markdown` title + a `keyvalue` card of status/summary/duration), each value bound via `{"$bind": "<JSON-Pointer>"}` (RFC 6901), zero token cost. Invoke-by-name: `present(view="status_card", data_inline={...})` — inherently inert (A3, `PresentationRegistry` never self-triggers). Any of the 4 fields may be omitted (a missing `$bind` target soft-skips at render). Passes the real `validate_blueprint` structural gate.

No `BUILTIN_HOOKS` map (lead-ruled deferred — the hook exemplar stays as the cheat-sheet's inline CI-verified example).

## Tests (`tests/test_0060_f3b_sibling_builtins.py`, Tier 2)

- Both load with `provenance="builtin"` + inert (skill `auto_invoke=False`, present invoke-by-name, discoverable not auto-enabled).
- Skill `SKILL.md` frontmatter is well-formed YAML (`name`/`description`); body is wheel-reachable through the real `read_file` op with `project_root` elsewhere (mirrors #2914's wheel-layout scenario for this 2nd skill); `read_builtin_body_bytes` generalizes to any `skills/` path.
- Embedded `judge_output` example validates against the real schema; **falsify**: drop `rubric` → RED; supply both `target`+`data_inline` (XOR) → RED.
- `status_card` blueprint passes `validate_blueprint` + round-trips through the real `build_presentation_registry`; **falsify**: corrupt component name → `PresentBlueprintError`.

Also updated the F3a phase-scoped "`BUILTIN_PRESENTATIONS` ships empty" assertions (now populated) and relaxed `test_present_registry_fp0054_prc.py`'s exact-`names()` pin (the builtin tier now contributes `status_card` to the merged config cascade — the test's real subject, the operator entry reaching the registry, is unchanged).

## Design fork
None. Followed Addendum D9.5 #3/#4 exactly; the `judge_output` `data_inline` idiom and the `$bind` blueprint shape both reuse the mechanisms #2912 landed — no new vocabulary, no `BUILTIN_HOOKS` map.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on changed test files — 45 OK, 0 Tier-4
- [x] `python scripts/verify_module_docstrings.py src/reyn/builtin/registry.py` — OK
- [x] Full `pytest` foreground to completion — **8421 passed, 20 skipped, 0 failed** (rebased onto latest origin/main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)