### PR TITLE
docs: remove dead config sections + fix stale details in reyn.local.yaml.example

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -33,7 +33,7 @@ models:
 | `action_retrieval` | マップ | ユニバーサルカタログの可視化 + 検索設定。以下参照。 |
 | `embedding` | マップ | RAG 埋め込みモデルクラスとバッチ設定。以下参照。 |
 | `chat` | マップ | チャットセッションの Head/Body/Tail 圧縮設定。以下参照。 |
-| `voice` | マップ | チャット TUI の音声入力（Whisper）設定。以下参照。 |
+| `voice` | マップ | ⚠️ 現在利用不可(consumerなし)。以下参照。 |
 | `events` | マップ | チャットセッションイベントファイルの監査ログローテーションポリシー。以下参照。 |
 | `observability` | マップ | P6 監査イベントの OpenTelemetry (OTLP) エクスポート（オプトイン）。デフォルトは無効。以下参照。 |
 | `mcp` | マップ | MCP サーバー定義と `search_threshold`。以下参照。 |
@@ -959,7 +959,9 @@ events:
 
 ## `voice` ブロック
 
-チャット TUI の音声入力（Whisper）設定（Ctrl+R で録音）。オプション機能 — `pip install 'reyn[voice]'`（`sounddevice` + `faster-whisper`）が必要です。ブロックは遅延ロードされるため、`[voice]` extra がない場合は録音キーが自動的に無効化されます。
+**⚠️ 現在利用不可。** このブロックは今もparseされます(設定してもエラーにはなりません)が、consumerがありません — 旧 Textual TUI の Ctrl+R Whisper バインディング用に構築されたものですが、そのTUIは削除され inline CUI に置き換わりました(音声入力バインディングなし)。スキーマの完全性のためだけに残しています。[コンセプト: voice](../../concepts/tools-integrations/voice.md) を参照。
+
+音声入力(Whisper)設定(consumerが存在する場合)。オプション機能 — `pip install 'reyn[voice]'`(`sounddevice` + `faster-whisper`)が必要です。ブロックは遅延ロードされるため、`[voice]` extra がない場合は録音キーが自動的に無効化されます。
 
 ```yaml
 voice:

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -35,7 +35,7 @@ models:
 | `action_retrieval` | map | Universal catalog visibility + retrieval settings. See below. |
 | `embedding` | map | RAG embedding model classes and batch settings. See below. |
 | `chat` | map | Chat-session compaction settings. See below. |
-| `voice` | map | Voice input (Whisper) settings for the chat TUI. See below. |
+| `voice` | map | ⚠️ Currently unavailable (no consumer). See below. |
 | `events` | map | Audit-log rotation policy for chat-session event files. See below. |
 | `observability` | map | Opt-in OpenTelemetry (OTLP) export of P6 audit-events. Off by default. See below. |
 | `tool_use` | map | Chat-layer tool-use scheme selector (`chat`). See below. |
@@ -1567,7 +1567,9 @@ Setting both `max_bytes` and `max_age_seconds` to `0` disables rotation entirely
 
 ## `voice` block
 
-Voice-input (Whisper) settings for the chat TUI (Ctrl+R to record). Optional — requires `pip install 'reyn[voice]'` (`sounddevice` + `faster-whisper`). The block is lazy-loaded; a missing `[voice]` extra silently disables the record key.
+**⚠️ Currently unavailable.** The block still parses (no error if set), but has no consumer — it was built for the Ctrl+R Whisper binding in the old Textual TUI, which was deleted and replaced by the inline CUI (no voice-input binding). Kept for schema completeness only. See [concepts: voice](../../concepts/tools-integrations/voice.md).
+
+Voice-input (Whisper) settings, when a consumer exists. Optional — requires `pip install 'reyn[voice]'` (`sounddevice` + `faster-whisper`). The block is lazy-loaded; a missing `[voice]` extra silently disables the record key.
 
 ```yaml
 voice:

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -117,19 +117,6 @@
 
 
 # -----------------------------------------------------------------------------
-# tool_calls_op_loop_skills: TRANSITIONAL. Skill names opted into the native-tools
-# op-loop phase mechanism — the phase act-loop drives the shared RouterLoop.run_loop
-# (the converged op-loop, #1092): ops are emitted as native tool_calls, run through
-# the shared executor, and threaded as native tool-role message-history. Default
-# empty = every skill uses json-mode (unchanged). Removed once the op-loop becomes
-# the default. (#1092 PR-C-3 merged the former separate routerloop_convergence_skills
-# gate into this one — the converged path is now the op-loop's implementation.)
-# -----------------------------------------------------------------------------
-# tool_calls_op_loop_skills:
-#   - my_skill
-
-
-# -----------------------------------------------------------------------------
 # permissions: pre-approved permission grants — same structure as phase
 # frontmatter ``permissions:`` block, but value is always ``allow``. Lets the
 # operator pre-approve specific tools so the router doesn't gate them at
@@ -142,7 +129,7 @@
 #   file.delete       — pre-approve file-delete ops
 #   file.write        — pre-approve all file-write ops (flat kind grant, non-glob)
 #   python.safe       — pre-approve the python preprocessor's safe mode
-#                       (stdlib skill_router uses this — already set in reyn.yaml)
+#                       (the chat router uses this — already set in reyn.yaml)
 #   mcp.<server>      — pre-approve a specific MCP server's tool surface
 # -----------------------------------------------------------------------------
 # permissions:
@@ -466,22 +453,6 @@
 
 
 # -----------------------------------------------------------------------------
-# skill_resume: policy for handling steps that have a
-# ``step_started`` WAL event but no matching ``step_completed`` / ``step_failed``
-# (= the op may have committed externally and only the operator can decide).
-#
-# Policies: ``retry`` (default; safe for read-only / idempotent ops),
-# ``skip`` (synthesize empty completion), ``discard_skill`` (abort + drop the
-# checkpoint), ``prompt`` (legacy/no-op under auto-resume, treated as retry).
-# -----------------------------------------------------------------------------
-# skill_resume:
-#   default: retry
-#   per_skill:
-#     fragile_external_writer: discard_skill
-#     idempotent_indexer:      retry
-
-
-# -----------------------------------------------------------------------------
 # time_travel: cost knobs for the time-travel (rewind/resume) feature (#1582).
 #
 # workspace_capture (default true): when true, every checkpoint boundary (turn /
@@ -517,21 +488,11 @@
 
 
 # -----------------------------------------------------------------------------
-# plan_resume_raw: how the resume coordinator treats
-# interrupted plan-mode runs on restart. Parsed lazily by the coordinator,
-# so the shape lives in ``reyn.plan`` rather than here. Set to a dict only
-# when the plan coordinator's docs explicitly direct it.
-# -----------------------------------------------------------------------------
-# plan_resume_raw: {}
-
-
-# -----------------------------------------------------------------------------
-# voice (chat TUI Whisper input, optional ``reyn[voice]`` extras): lazy-loaded
-# only when Ctrl+R is pressed. Default ``language: "ja"`` reflects Reyn's
-# Japanese-enterprise focus; set to empty string or null to auto-detect.
-#
-# Apple Silicon note: ``cpu_threads: 4`` avoids the OpenMP / Python-threading
-# deadlock observed at high core counts.
+# voice: ⚠️ CURRENTLY UNAVAILABLE. This block still parses (no error if set),
+# but has no consumer — it was built for the Ctrl+R Whisper binding in the
+# old Textual TUI, which was deleted and replaced by the inline CUI (which has
+# no voice-input binding). Kept here for schema completeness only; setting
+# these fields today has no effect. See docs/concepts/tools-integrations/voice.md.
 # -----------------------------------------------------------------------------
 # voice:
 #   enabled: true
@@ -715,27 +676,6 @@
 
 
 # -----------------------------------------------------------------------------
-# plan: plan-mode execution tuning.
-#
-#   step_max_iterations: RouterLoop iterations per plan step before the OS
-#                        records a step failure. Default 5.
-#   retry_limit:         automatic retries per step on transient errors.
-#                        Default 3. 0 = disable. Permission/budget exceptions
-#                        are always excluded from retry.
-#   step_compaction:     prior-step ``step_results`` compaction policy
-#                        (sibling to ``chat.compaction``).
-# -----------------------------------------------------------------------------
-# plan:
-#   step_max_iterations: 5
-#   retry_limit: 3
-#   step_compaction:
-#     recent_step_results_raw: 3
-#     summarize_older_threshold_tokens: null   # null = derive from main_pool
-#     step_results_ratio: 0.50
-#     use_chars4_estimate: false
-
-
-# -----------------------------------------------------------------------------
 # eval: trace export adapters. Empty list (default) =
 # no export. Supported types:
 #   - file        : local JSONL dumps under ``path``
@@ -774,24 +714,35 @@
 
 
 # -----------------------------------------------------------------------------
-# hooks: agent-lifecycle hooks (#1800/#2069) — a thin operator layer over the
-# inbox + the P6 lifecycle. A list of entries; each fires at a lifecycle point
-# (``on``) and carries EXACTLY ONE of three mutually-exclusive schemes:
-#   template_push — inject an attributed ``[hook:<name>]`` message from a config
-#                   Jinja2 template.
-#   shell_exec    — run an external command as a pure side-effect (output IGNORED).
-#   shell_push    — run a command whose STDOUT is a JSON push-directive → pushed
-#                   via the same path as template_push (stdout is the SOURCE).
+# hooks: agent-lifecycle hooks (#1800/#2069, Hook-Event Redesign proposal 0059)
+# — a thin operator layer over the inbox + the P6 lifecycle. A list of
+# entries; each fires at a hook-point (``on``) and carries EXACTLY ONE of
+# FOUR mutually-exclusive schemes:
+#   template_push  — inject an attributed ``[hook:<name>]`` message from a config
+#                    Jinja2 template.
+#   shell_exec     — run an external command as a pure side-effect (output IGNORED,
+#                    command line is STATIC — never Jinja2-templated, a deliberate
+#                    command-injection guard; event data arrives on stdin as JSON).
+#   shell_push     — run a command whose STDOUT is a JSON push-directive → pushed
+#                    via the same path as template_push (stdout is the SOURCE).
+#   pipeline_launch — launch a registered pipeline (async/detached), input
+#                    Jinja2-rendered from the event's template vars.
 #
-#   on:            turn_start | turn_end | session_start | session_end |
-#                  skill_start | skill_end | task_start | task_end
+#   on:            the 10 builtin points — turn_start | turn_end | session_start |
+#                  session_end | task_start | task_end | mcp_resource_updated |
+#                  file_changed | cron_fired | webhook_received — plus the two
+#                  open namespaces ``composed:<name>`` (a Composer's output,
+#                  below) and, as a Composer INPUT only (never a hook's own
+#                  ``on:``), ``llm:<session_id>:<event_name>`` (LLM-emitted via
+#                  the emit_hook_event op). Full syntax reference + matcher
+#                  grammar + composers: block: docs/concepts/runtime/hooks.md.
 #   template_push: message:   Jinja2 template → the message text
 #                  wake:      true  → start a new turn (self-continuation)  [default]
 #                             false → ride along with the next turn (passive context)
 #                  push_when: Jinja2 → bool; false skips the push (conditional)
-#                  session:   parsed + carried forward-compat; cross-session routing
-#                             is NOT yet wired (no-op today, tracked follow-up)
-#   shell_exec:    a command string
+#                  session:   parsed + carried; naming a DIFFERENT session routes
+#                              this push to that session's inbox (cross-session push)
+#   shell_exec:    a static command string (no templating — see above)
 #   shell_push:    a command string; its stdout must be a single JSON object
 #                  {"push_when": bool, "wake": bool, "message": str, "session"?: str}
 #                  (first three required). Pure JSON on stdout; logs → stderr.


### PR DESCRIPTION
**[docs-maintainer]** —

## Summary
User-directed investigation of `reyn.local.yaml.example`, cross-checked against current main.

**Removed 4 entirely dead config sections** (verified zero references anywhere in `src/reyn/`, and absent from the actively-maintained `docs/reference/config/reyn-yaml.md`):
- `tool_calls_op_loop_skills` — not even a `ReynConfig` field anymore.
- `skill_resume` — no config field; tied to the removed skill-run machinery.
- `plan_resume_raw` — no config field, no `reyn.plan` module.
- `plan:` block (`step_max_iterations`/`retry_limit`/`step_compaction`) — no `PlanConfig` class, no `plan*.py` module at all; plan-mode was removed.

**Fixed 3 stale details in the still-live `hooks:` section**:
- `on:` list included `skill_start`/`skill_end` — `src/reyn/hooks/schema.py`'s own docstring says these were "removed — never dispatched."
- "carries EXACTLY ONE of **three** mutually-exclusive schemes" — actually **four**; `pipeline_launch` was missing from the explanation entirely. Also added the 10-builtin-point + `composed:*`/`llm:*` vocabulary and a note that `shell_exec`'s command line is static (not Jinja2), consistent with the fuller reference in `docs/concepts/runtime/hooks.md` (PR #2892).
- `session:` field said cross-session push "is NOT yet wired (no-op today)" — it **is** wired (`#2072`, verified in `dispatcher.py`).

**Fixed the `voice:` section** (here + `docs/reference/config/reyn-yaml.md`/`.ja.md`, same defect in both): presented as a working Ctrl+R feature, but it has no consumer since the Textual TUI it was built for was deleted — matches `feature-map.md`'s own "currently unavailable" admission and `voice.md`'s existing status banner; `reyn-yaml.md`/`.ja.md` just hadn't been updated to match.

Also fixed one last "stdlib skill_router" mention (same class as #2909) in the `permissions:` block comment.

Every removal was verified by grepping `src/reyn/` for the config key before deleting — nothing here was guessed.

## Test plan
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — clean, no new warnings/aborts
- [x] `ruff check src tests` — clean (docs-only change)
- [x] Every deleted section confirmed zero references via `grep -rn` across `src/reyn/` before removal
- [x] Confirmed `docs/reference/config/reyn-yaml.md` (the actively-maintained reference) already doesn't document any of the 4 removed sections
- [x] Confirmed cross-session push is wired (`dispatcher.py`'s `cross_session_put`/`_current_session_id`, `#2072`) before correcting the stale claim
- [x] No stray blank-line artifacts left from the deletions (checked with an awk pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)