### PR TITLE
fix: default action_retrieval.embedding_class to null (semantic action-search truly opt-in)

### DIFF
--- a/docs/concepts/tools-integrations/universal-catalog.md
+++ b/docs/concepts/tools-integrations/universal-catalog.md
@@ -410,16 +410,29 @@ action_retrieval:
   universal_wrappers_enabled: false
 ```
 
-## `embedding_class` default + graceful degrade (FP-0043 Phase 4)
+## `embedding_class` default + graceful degrade
 
-Since **FP-0043 Phase 4**,
-`ActionRetrievalConfig.embedding_class` defaults to `"local-mini"`
-(= `sentence-transformers/all-MiniLM-L6-v2`). This makes
+**FP-0043 Phase 4** defaulted `ActionRetrievalConfig.embedding_class` to
+`"local-mini"` (= `sentence-transformers/all-MiniLM-L6-v2`), making
 `search_actions` automatically available for any fresh installation
-that runs `pip install 'reyn[local-embed]'` — no `reyn.yaml` edits
-required.
+that ran `pip install 'reyn[local-embed]'` — no `reyn.yaml` edits
+required. The **semantic-search-opt-in fix** reverted this: a truthy
+default made reyn attempt a Hugging Face model download at chat
+startup even on zero-config / offline installs, surfacing as a
+startup warning when the download failed — contradicting the
+project's standing principle that semantic search is opt-in.
 
-When the `local-embed` extras are NOT installed, `Session.__init__`
+`ActionRetrievalConfig.embedding_class` now defaults to `None` (off).
+With no class configured, no embedding index build is attempted at
+all — `search_actions` is simply absent from `tools=` per the §D14
+gate below, silently (there is nothing to fail or warn about).
+Operators opt in explicitly via `action_retrieval.embedding_class:
+local-mini` (local model, needs the `reyn[local-embed]` extras) or
+`standard` (API-backed, no local download) in `reyn.yaml` — see
+[Guide: enable semantic search](../../guide/for-users/enable-semantic-search.md).
+
+When an operator opts into an ST-backed class but the `local-embed`
+extras are NOT installed, `Session.__init__`
 detects the missing import via a cheap `importlib.util.find_spec`
 probe and silently treats the configured class as if it were `None`:
 no `ActionEmbeddingIndex` is built, `search_actions` stays hidden by
@@ -455,7 +468,8 @@ deferred:
   `list_actions` response carries a structured **hidden-state hint**
   pointing operators at `pip install 'reyn[local-embed]'` /
   `reyn embeddings status` so the install path is self-discoverable
-  mid-chat. The local backend is the default; the OpenAI-backed
+  mid-chat. Off by default (opt-in only, per the semantic-search-opt-in
+  fix); once opted in, the local backend and the OpenAI-backed
   classes (`light` / `standard` / `strong`) are equally usable. See
   [Guide: enable semantic search](../../guide/for-users/enable-semantic-search.md)
   and the [`reyn embeddings`](../../reference/cli/embeddings.md) CLI for

--- a/docs/guide/for-users/enable-semantic-search.ja.md
+++ b/docs/guide/for-users/enable-semantic-search.ja.md
@@ -2,7 +2,7 @@
 
 `reyn chat` には、LLM が実行可能なことを発見するための 2 つの手段が同梱されています: 高速な **`list_actions`** ブラウザ（= カテゴリ接頭辞による列挙、常時利用可能）と、**`search_actions`** セマンティック検索（= 全アクションの埋め込みインデックスに対する自然言語クエリ）です。本ガイドではセマンティックな経路を有効にする手順を説明します。
 
-> **TL;DR**: `pip install 'reyn[local-embed]'` を一度実行すれば、`search_actions` は認証情報なしで使えるようになります。OpenAI の埋め込み API（わずかに高品質）を使いたい場合は、`reyn secret set OPENAI_API_KEY` のあと `reyn.yaml` で `action_retrieval.embedding_class: standard` を設定してください。
+> **TL;DR**: `search_actions` は **デフォルトで無効**（semantic search はプロジェクト全体で opt-in の方針）。`pip install 'reyn[local-embed]'` を実行し、さらに `reyn.yaml` で `action_retrieval.embedding_class: local-mini` を設定すれば、認証情報なしで使えるようになります。OpenAI の埋め込み API（わずかに高品質、ローカルダウンロード不要）を使いたい場合は、`reyn secret set OPENAI_API_KEY` のあと `reyn.yaml` で `action_retrieval.embedding_class: standard` を設定してください。
 
 ## どんなときに欲しくなるか
 
@@ -11,7 +11,7 @@
 - **無い場合**: LLM はあなたの意図がどのカテゴリ（`file` / `mcp` / `memory_entry` / …）に属するかを推測し、`list_actions(category=[...])` を実行して列挙する必要があります。_「PDF をテキストに変換するアクションを探して」_ のような自然言語の依頼では、すぐに一致が見つからないと LLM が試したうえで断ることもあります。
 - **有る場合**: LLM は `search_actions(query="PDF to text")` を実行し、全カテゴリ横断で関連度順に並んだ top-K のリストを得ます。その後そのまま `describe_action` や `invoke_action` を実行できます。
 
-`action_retrieval.embedding_class` のデフォルトは `local-mini` なので、必要な手順は `local-embed` extras のインストールだけです。extras が無い場合、Session はこれを暗黙に「クラス未設定」として扱い、`search_actions` は LLM のツールリストから **除外** され（[可視性ゲート](../../concepts/tools-integrations/universal-catalog.md#what-stays-out-of-phase-1) を参照）、`list_actions` が本ガイドを指す hidden-state ヒントを提示します。
+`action_retrieval.embedding_class` のデフォルトは `null`（無効）です — semantic search は opt-in なので、明示的な `reyn.yaml` 設定と（ローカル経路の場合）`local-embed` extras の両方が必要です。クラス未設定の場合、`search_actions` は LLM のツールリストから **除外** され（[可視性ゲート](../../concepts/tools-integrations/universal-catalog.md#what-stays-out-of-phase-1) を参照）— これは何も試行されないため起動時警告なしで silent に行われます。ST 系クラスを設定したのに extras が無い場合も Session は同様に「クラス未設定」として graceful に扱い、`list_actions` が本ガイドを指す hidden-state ヒントを提示します。
 
 ## 経路 A — ローカルの sentence-transformers（初めての方に推奨）
 
@@ -19,7 +19,14 @@
 pip install 'reyn[local-embed]'
 ```
 
-これだけです。`local-embed` extras は `sentence-transformers` + `torch` をインストールします。デフォルトの `action_retrieval.embedding_class` はすでに `local-mini`（= `all-MiniLM-L6-v2`、22 MB、384 次元、英語）なので、import が成功した時点で配線が有効になります。`reyn.yaml` の編集は不要です。
+続けて `reyn.yaml` で明示的に opt-in します（デフォルトは `null` / 無効）:
+
+```yaml
+action_retrieval:
+  embedding_class: local-mini
+```
+
+`local-embed` extras は `sentence-transformers` + `torch` をインストールします。`local-mini`（= `all-MiniLM-L6-v2`、22 MB、384 次元、英語）は同梱モデルの中で最小です。extras と `reyn.yaml` 設定の両方が揃うと、次のセッションで配線が有効になります。
 
 `reyn chat` が初めて `search_actions` に到達したとき、モデルがダウンロードされ（一般的な接続で約 5〜10 秒）、埋め込みインデックスが構築されます。TUI の Memory タブはダウンロード中に `⟳ loading…` 行を、完了時に `✓ loaded · all-MiniLM-L6-v2 · 384d` 行を表示します。以降のセッションはローカルキャッシュから 1 秒未満でウォームスタートします。
 

--- a/docs/guide/for-users/enable-semantic-search.md
+++ b/docs/guide/for-users/enable-semantic-search.md
@@ -2,7 +2,7 @@
 
 `reyn chat` ships with two ways for the LLM to discover what it can do: a fast **`list_actions`** browser (= category-prefix enumeration, always available) and a **`search_actions`** semantic search (= natural-language queries against an embedding index of every action). This guide walks through enabling the semantic path.
 
-> **TL;DR**: run `pip install 'reyn[local-embed]'` once and `search_actions` becomes usable with no credentials. If you'd rather use OpenAI's embedding API (slightly higher quality), set `action_retrieval.embedding_class: standard` in `reyn.yaml` after `reyn secret set OPENAI_API_KEY`.
+> **TL;DR**: `search_actions` is **off by default** (semantic search is opt-in project-wide). Run `pip install 'reyn[local-embed]'` AND set `action_retrieval.embedding_class: local-mini` in `reyn.yaml` to enable it with no credentials. If you'd rather use OpenAI's embedding API (slightly higher quality, no local download), set `action_retrieval.embedding_class: standard` in `reyn.yaml` after `reyn secret set OPENAI_API_KEY`.
 
 ## When you'd want it
 
@@ -11,7 +11,7 @@
 - **Without it**: the LLM has to guess which category your intent belongs to (`file` / `mcp` / `memory_entry` / …) and run `list_actions(category=[...])` to enumerate. For natural-language asks like _"find an action that converts PDF to text"_ the LLM may also try and refuse if it doesn't immediately spot a match.
 - **With it**: the LLM runs `search_actions(query="PDF to text")` and gets a top-K relevance-ranked list across every category. It can then `describe_action` or `invoke_action` directly.
 
-`action_retrieval.embedding_class` defaults to `local-mini`, so installing the `local-embed` extras is the only step required. If the extras are absent, Session silently treats this as "no class configured" — `search_actions` is gated **out** of the LLM's tool list (see [visibility gate](../../concepts/tools-integrations/universal-catalog.md#what-stays-out-of-phase-1)) and `list_actions` surfaces the hidden-state hint pointing back at this guide.
+`action_retrieval.embedding_class` defaults to `null` (off) — semantic search is opt-in, so both an explicit `reyn.yaml` setting AND (for the local path) the `local-embed` extras are required. With no class configured, `search_actions` is gated **out** of the LLM's tool list (see [visibility gate](../../concepts/tools-integrations/universal-catalog.md#what-stays-out-of-phase-1)) — silently, with no startup warning, since nothing is attempted. If you configure an ST-backed class but the extras are absent, Session gracefully treats this as "no class configured" the same way, and `list_actions` surfaces the hidden-state hint pointing back at this guide.
 
 ## Path A — local sentence-transformers (recommended for first-time users)
 
@@ -19,7 +19,14 @@
 pip install 'reyn[local-embed]'
 ```
 
-That's it. The `local-embed` extras install `sentence-transformers` + `torch`. The default `action_retrieval.embedding_class` is already `local-mini` (= `all-MiniLM-L6-v2`, 22 MB, 384-dim, English), so the moment the import succeeds the wiring activates — no `reyn.yaml` edit needed.
+Then opt in explicitly in `reyn.yaml` (the default is `null` / off):
+
+```yaml
+action_retrieval:
+  embedding_class: local-mini
+```
+
+The `local-embed` extras install `sentence-transformers` + `torch`; `local-mini` (= `all-MiniLM-L6-v2`, 22 MB, 384-dim, English) is the smallest bundled model. Once both the extras and the `reyn.yaml` setting are in place, the wiring activates on the next session.
 
 The first time `reyn chat` reaches `search_actions`, the model downloads (~5–10 s on a typical connection) and the embedding index builds. The TUI Memory tab shows a `⟳ loading…` row during the download and a `✓ loaded · all-MiniLM-L6-v2 · 384d` row when done; subsequent sessions warm-start from the local cache in <1 s.
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -355,7 +355,7 @@ sandbox:
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # デフォルト; false でオプトアウト
-  embedding_class: local-mini         # デフォルト; null で search_actions 無効
+  # embedding_class: local-mini       # デフォルトは null (無効); opt-in するにはコメント解除
   hot_list_n: 0                       # 0 = 無効（デフォルト）; opt-in は例えば 10
   mode: default                       # default | minimal | performance
 ```
@@ -365,9 +365,28 @@ action_retrieval:
 | フィールド | 型 | デフォルト | 説明 |
 |-----|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | `tool_use` scheme が `universal-category` に解決される layer について、`true`(デフォルト)の時、その layer の `tools=` は 4 universal wrappers (`list_actions` / `search_actions` / `describe_action` / `invoke_action`) + hot list direct aliases のみ。 legacy per-kind tool (`invoke_skill` / `call_mcp_tool` 等) はその layer で LLM に surface されず、 wrapper の backing handler として残存。 `search_actions` は `embedding_class` で別途ゲート。 `false` 設定でその layer の wrapper surface 自体を無効化 (= legacy のみが addressing path)。 scheme が `enumerate-all`(`chat` layer 自身のデフォルト)である layer には影響しない — その scheme はこのフラグを一切参照しない。 |
-| `embedding_class` | string \| null | `"local-mini"` | action-retrieval の semantic 検索に使用する [`embedding.classes`](../../concepts/data-retrieval/rag.md) のエントリ名。 デフォルト `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`)。 `null` または空の場合、 wrapper が有効でも `search_actions` は `tools=` から除外される。 設定すると cold-start session で eager embedding build を発動し初回ターンの hallucination を回避。 **Graceful degrade**: 選んだクラスが `sentence-transformers/` モデルを指すのに `local-embed` extras 未インストールの場合、 reyn は黙って `null` 扱いとし `list_actions` がインストールコマンドを LLM に surface する。 `standard` (= OpenAI) や `null` (= opt out) で上書き可能。 |
+| `embedding_class` | string \| null | `null` | action-retrieval の semantic 検索に使用する [`embedding.classes`](../../concepts/data-retrieval/rag.md) のエントリ名。 **デフォルト `null` (無効) — semantic `search_actions` は opt-in。** `null` または空の場合、 wrapper が有効でも `search_actions` は `tools=` から除外され、 embedding index の build も一切試行されない (= silent、失敗も警告も発生しない)。 opt-in するには明示的に `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`; ローカル、`reyn[local-embed]` extras と初回の Hugging Face モデルダウンロードが必要) または `standard` (= OpenAI backed、ローカルダウンロード不要、`OPENAI_API_KEY` が必要) を設定する。 設定すると cold-start session で eager embedding build を発動し初回ターンの hallucination を回避。 **Graceful degrade**: 選んだクラスが `sentence-transformers/` モデルを指すのに `local-embed` extras 未インストールの場合、 reyn は黙って `null` 扱いとし `list_actions` がインストールコマンドを LLM に surface する。 |
 | `hot_list_n` | int | `0` | top-N `freq+recency` direct alias のホットリスト投影サイズ。 デフォルト `0` (= 無効) — `list_actions` が正規の discovery path。 opt-in は `10` 以上を設定; seed・usage tracker・alias-builder は完全維持。 |
 | `mode` | string | `"default"` | 運用モードラベル: `"minimal"` (キャッシュ安定性最大、 ホットリストなし) / `"default"` (バランス) / `"performance"` (大規模ホットリスト)。 自由文字列で、 呼び出し側がセマンティクスを上乗せ。 |
+
+### クイックスタート — semantic `search_actions` を opt-in
+
+`search_actions` はデフォルトで無効 (`embedding_class: null`) — semantic search はプロジェクト全体で opt-in の方針です。有効にするには:
+
+```yaml
+# reyn.yaml — ローカルモデル (`pip install 'reyn[local-embed]'` が必要;
+# 初回利用時に Hugging Face から ~22 MB ダウンロード)
+action_retrieval:
+  embedding_class: local-mini
+```
+
+```yaml
+# reyn.yaml — API backed、ローカルダウンロード不要 (`OPENAI_API_KEY` が必要)
+action_retrieval:
+  embedding_class: standard
+```
+
+詳細な手順（オフライン/エアギャップ環境のガイダンスを含む）は [ガイド: semantic search を有効にする](../../guide/for-users/enable-semantic-search.ja.md) を参照。
 
 ### クイックスタート — オプトアウト
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -781,7 +781,7 @@ Universal catalog visibility + retrieval settings.  Scheme *selection* is genera
 ```yaml
 action_retrieval:
   universal_wrappers_enabled: true    # default; set false to opt out
-  embedding_class: local-mini         # default; null disables search_actions
+  # embedding_class: local-mini       # default is null (off); uncomment to opt in
   hot_list_n: 0                       # 0 = off (default); set e.g. 10 to opt in
   mode: default                       # default | minimal | performance
 ```
@@ -791,10 +791,29 @@ action_retrieval:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `universal_wrappers_enabled` | bool | `true` | For a layer whose `tool_use` scheme resolves to `universal-category`, `true` (default) exposes only the 4 universal wrappers (`list_actions`, `search_actions`, `describe_action`, `invoke_action`) plus hot-list direct aliases in that layer's `tools=`.  Legacy per-kind tools (`invoke_skill`, `call_mcp_tool`, etc.) are no longer surfaced to the LLM on that layer but remain available as wrapper backing handlers.  `search_actions` is gated separately by `embedding_class`.  Set `false` to disable the wrapper surface entirely for that layer (= legacy tools become the only addressing path again).  Does not affect a layer whose scheme is `enumerate-all` (the `chat` layer's own default) — that scheme never consults this flag. |
-| `embedding_class` | string \| null | `"local-mini"` | Name of an entry in [`embedding.classes`](../../concepts/data-retrieval/rag.md) to use for action-retrieval semantic search.  Default `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`).  When `null` or empty, `search_actions` is excluded from `tools=` even when wrappers are enabled.  Setting this also enables eager embedding build on cold-start sessions to avoid first-turn hallucinations.  **Graceful degrade**: if the chosen class points at a `sentence-transformers/` model but the `local-embed` extras aren't installed, reyn silently treats this as `null` and `list_actions` surfaces the install command to the LLM. Set explicitly to `standard` (= OpenAI) or `null` (= opt out) to override. |
+| `embedding_class` | string \| null | `null` | Name of an entry in [`embedding.classes`](../../concepts/data-retrieval/rag.md) to use for action-retrieval semantic search. **Default `null` (off) — semantic `search_actions` is opt-in.** When `null` or empty, `search_actions` is excluded from `tools=` even when wrappers are enabled, and no embedding index build is attempted (silent — nothing to fail or warn about). To opt in, set it explicitly to `local-mini` (= `sentence-transformers/all-MiniLM-L6-v2`; local, needs the `reyn[local-embed]` extras and a one-time Hugging Face model download) or `standard` (= OpenAI-backed, needs `OPENAI_API_KEY`, no local download). Setting this also enables eager embedding build on cold-start sessions to avoid first-turn hallucinations. **Graceful degrade**: if the chosen class points at a `sentence-transformers/` model but the `local-embed` extras aren't installed, reyn silently treats this as `null` and `list_actions` surfaces the install command to the LLM. |
 | `hot_list_n` | int | `0` | Hot-list projection size for top-N `freq+recency` direct aliases. `0` (default) disables hot-list entirely — `list_actions` is the canonical discovery path. Set to `10` or higher to opt in; the seed, usage tracker, and alias-builder remain fully operative. |
 | `mode` | string | `"default"` | Operational mode label: `"minimal"` (max cache stability, no hot list) / `"default"` (balanced) / `"performance"` (large hot list).  Free-form string; callers layer semantics on top. |
 | `hot_list_seed` | list \| string | `"default"` | Seed for the hot-list projection. `"default"` uses the built-in freq+recency seeding; a list of qualified action names (e.g. `["mcp__call_tool"]`) pins those as the initial hot list before usage stats accumulate. |
+
+### Quick-start — opt in to semantic `search_actions`
+
+`search_actions` is off by default (`embedding_class: null`) — semantic search is opt-in project-wide. To turn it on:
+
+```yaml
+# reyn.yaml — local model (needs `pip install 'reyn[local-embed]'`; downloads
+# ~22 MB from Hugging Face on first use)
+action_retrieval:
+  embedding_class: local-mini
+```
+
+```yaml
+# reyn.yaml — API-backed, no local download (needs OPENAI_API_KEY)
+action_retrieval:
+  embedding_class: standard
+```
+
+See [Guide: enable semantic search](../../guide/for-users/enable-semantic-search.md) for the full walkthrough, including offline/air-gapped guidance.
 
 ### Quick-start — opt out
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -809,10 +809,10 @@
 #       ``search_actions`` is gated separately via ``embedding_class``.
 #   embedding_class:
 #       Name of an entry under ``embedding.classes`` used for semantic
-#       ``search_actions``. Default ``"local-mini"`` — activates when
-#       ``pip install 'reyn[local-embed]'`` succeeds; silently no-ops otherwise
-#       (= ``list_actions`` surfaces a hint). Set ``null`` to disable
-#       ``search_actions`` entirely.
+#       ``search_actions``. Default ``null`` (off) — semantic search is
+#       opt-in. Set to ``local-mini`` (needs ``pip install
+#       'reyn[local-embed]'``) or ``standard`` (API-backed, no local
+#       download) to opt in explicitly.
 #   hot_list_n:
 #       Top-N freq+recency projection size. Default 20 — must be ≥
 #       ``DEFAULT_HOT_LIST_SEED`` length (= 17) so the seed isn't truncated.
@@ -824,7 +824,7 @@
 # -----------------------------------------------------------------------------
 # action_retrieval:
 #   universal_wrappers_enabled: true
-#   embedding_class: local-mini       # null disables search_actions
+#   embedding_class: local-mini       # default is null (off); uncomment to opt in
 #   hot_list_n: 20
 #   mode: default
 #   hot_list_seed: default            # "default" | [] | [qualified-name, ...]

--- a/src/reyn/config/embedding.py
+++ b/src/reyn/config/embedding.py
@@ -270,22 +270,26 @@ class ActionRetrievalConfig:
             empty, ``search_actions`` is excluded from tools= even if
             ``universal_wrappers_enabled`` is True (§D14 gating).
 
-            **Default since FP-0043 Phase 4**: ``"local-mini"`` (=
-            ``sentence-transformers/all-MiniLM-L6-v2``). When the
-            ``local-embed`` extras are not installed (= ``import
-            sentence_transformers`` fails), Session silently
-            degrades to None — ``search_actions`` stays hidden and
-            ``list_actions`` injects a hidden-state hint pointing
-            operators at ``pip install 'reyn[local-embed]'``. So the
-            new default is "active when the import succeeds, no-op
-            otherwise", giving zero-config fresh users semantic
-            search the moment they install the extras.
+            **Default since the semantic-search-opt-in fix (2026)**:
+            ``None`` (= off). ``search_actions`` is a semantic-search
+            feature and the project's standing principle is that
+            semantic search is opt-in, never on by default — a
+            default of ``"local-mini"`` (FP-0043 Phase 4 through
+            2026) made reyn attempt a Hugging Face model download at
+            startup even for zero-config / offline installs, which
+            surfaced as a startup warning when the download failed.
+            Defaulting to ``None`` makes the off-path silent: no
+            index build is attempted, so there is nothing to fail or
+            warn about; ``search_actions`` is simply absent from
+            tools= (§D14 gating).
 
-            Operators who want OpenAI-backed embeddings instead can
-            set ``action_retrieval.embedding_class: standard`` (= or
-            ``light`` / ``strong``) explicitly in reyn.yaml. Setting
-            it to ``null`` or empty disables ``search_actions``
-            entirely.
+            Operators who want semantic ``search_actions`` set
+            ``action_retrieval.embedding_class`` explicitly in
+            reyn.yaml: ``local-mini`` for the local
+            ``sentence-transformers/all-MiniLM-L6-v2`` model (needs
+            the ``reyn[local-embed]`` extras and a one-time HF
+            download), or ``standard`` (= or ``light`` / ``strong``)
+            for an API-backed class that needs no local download.
 
         hot_list_n:
             Hot list size for top-N freq+recency projection (§D2).
@@ -305,7 +309,7 @@ class ActionRetrievalConfig:
     """
 
     universal_wrappers_enabled: bool = True
-    embedding_class: str | None = "local-mini"
+    embedding_class: str | None = None
     hot_list_n: int = 0
     mode: str = "default"
     # FP-0034 §D16: seed qualified names for initial hot list (before freq

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -179,8 +179,11 @@ def _embedding_class_needs_missing_extras(
     """Whether the configured embedding class needs sentence-transformers
     extras that haven't been installed (FP-0043 Phase 4 graceful-degrade).
 
-    The Phase 4 default flip makes ``action_retrieval.embedding_class``
-    default to ``"local-mini"``. For fresh installs that don't have
+    FP-0043 Phase 4 defaulted ``action_retrieval.embedding_class`` to
+    ``"local-mini"``; the semantic-search-opt-in fix (2026) reverted the
+    default to ``None`` (off), but this probe still matters whenever an
+    operator explicitly opts INTO an ST-backed class (``local-mini`` /
+    ``local-e5``). For installs that opted in without having run
     ``pip install 'reyn[local-embed]'`` yet, we don't want to instantiate
     an ActionEmbeddingIndex whose first embed() call will ImportError —
     we want ``search_actions`` to stay hidden and let list_actions

--- a/tests/test_action_retrieval_config.py
+++ b/tests/test_action_retrieval_config.py
@@ -18,6 +18,7 @@ No mocks; uses real load_config with a yaml file written to tmp_path.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -28,6 +29,7 @@ from reyn.config import (
     _build_action_retrieval_config,
     load_config,
 )
+from reyn.tools.universal_catalog import is_search_available
 
 # ── 1. Default values ─────────────────────────────────────────────────────
 
@@ -37,14 +39,17 @@ def test_default_action_retrieval_config_is_on() -> None:
 
     PR-3b-iv flipped universal_wrappers_enabled from False to True.
     FP-0034 Phase 6 removed hide_legacy_tools (wrapper-only is the sole path).
-    FP-0043 Phase 4 flipped embedding_class default from None to "local-mini"
-    so semantic action search is on the moment ``reyn[local-embed]`` extras
-    are installed — graceful-degrade kicks in at Session construction
-    when the extras are absent.
+    FP-0043 Phase 4 flipped embedding_class default from None to "local-mini";
+    the semantic-search-opt-in fix (2026) flipped it back to None — a
+    default of "local-mini" attempted a Hugging Face model download at
+    startup even for zero-config / offline installs, contradicting the
+    project's semantic_search-is-opt-in principle. search_actions is now
+    off (silently — no build is attempted) until an operator explicitly
+    sets ``action_retrieval.embedding_class`` in reyn.yaml.
     """
     cfg = ActionRetrievalConfig()
     assert cfg.universal_wrappers_enabled is True
-    assert cfg.embedding_class == "local-mini"
+    assert cfg.embedding_class is None
     assert cfg.hot_list_n == 0  # N=0 default: viability verdict; opt-in via reyn.yaml
     assert cfg.mode == "default"
 
@@ -234,7 +239,7 @@ def test_load_config_without_action_retrieval_uses_defaults(tmp_path: Path) -> N
 
     cfg = load_config(cwd=tmp_path)
     assert cfg.action_retrieval.universal_wrappers_enabled is True
-    assert cfg.action_retrieval.embedding_class == "local-mini"  # FP-0043 Phase 4
+    assert cfg.action_retrieval.embedding_class is None  # off by default; opt-in only
     assert cfg.action_retrieval.hot_list_n == 0  # N=0 default
     assert cfg.action_retrieval.mode == "default"
 
@@ -268,6 +273,52 @@ def test_hot_list_n_default_is_zero() -> None:
     in reyn.yaml). The seed/tracker/alias-builder remain operative as opt-in.
     """
     assert ActionRetrievalConfig().hot_list_n == 0
+
+
+# ── 6. Semantic-search-opt-in fix: the null default is SILENT ─────────────
+
+
+def test_fresh_config_null_embedding_class_gates_search_actions_silently(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: a fresh (no ``action_retrieval:`` block) ``load_config`` call
+    resolves ``embedding_class`` to None AND emits NO "disabled" /
+    "Semantic search_actions" warning anywhere in the load path.
+
+    This is the crux of the semantic-search-opt-in fix: the old default
+    ("local-mini") made reyn attempt an index build at chat startup that
+    failed offline, surfacing a "Semantic search_actions disabled … index
+    build failed …" warning even for operators who never asked for
+    semantic search. The fix makes the off-path load-bearing-silent: with
+    no class configured there is nothing to build and nothing to fail, so
+    ``_reconcile_embedding_class`` (the only warning source at config-load
+    time — see ``config/loader.py``) must take its early-return branch
+    (``if not ec or ec in cfg.embedding.classes: return``) without logging.
+
+    FALSIFY: if the default reverts to a truthy value (e.g. "local-mini")
+    without ``embedding.classes`` containing that class in this test's
+    fixture, ``_reconcile_embedding_class`` follows its non-early-return
+    branch and DOES log a "Semantic search_actions disabled: …" warning —
+    this test would then fail on the ``caplog`` assertion, proving the
+    silent-null-path guarantee is actually exercised (not vacuously true).
+    """
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        cfg = load_config(cwd=tmp_path)
+
+    assert cfg.action_retrieval.embedding_class is None
+    assert is_search_available(
+        action_retrieval_embedding_class=cfg.action_retrieval.embedding_class,
+    ) is False
+    disabled_records = [
+        r for r in caplog.records
+        if "search_actions" in r.getMessage() and "disabled" in r.getMessage().lower()
+    ]
+    assert disabled_records == [], (
+        "expected no 'disabled' warning on the null-embedding_class path, got: "
+        f"{[r.getMessage() for r in disabled_records]}"
+    )
 
 
 def test_load_config_hot_list_n_explicit_opt_in(tmp_path: Path) -> None:

--- a/tests/test_config_schema_enforcement_1056.py
+++ b/tests/test_config_schema_enforcement_1056.py
@@ -48,7 +48,8 @@ from reyn.config.config_schema import (
 _VALID_NONDEFAULT_OVERRIDES: dict[str, object] = {
     # #1454: embedding_class is closed-world — a class not in embedding.classes
     # degrades to None at load (graceful). "standard" is a real builtin class
-    # (!= the "local-mini" default), so it survives the membership check.
+    # (!= the None default, opt-in-off since the semantic-search-opt-in fix),
+    # so it survives the membership check.
     "action_retrieval.embedding_class": "standard",
 }
 

--- a/tests/test_embedding_class_reconciliation_1454.py
+++ b/tests/test_embedding_class_reconciliation_1454.py
@@ -69,9 +69,30 @@ def test_none_class_is_noop():
 
 
 def test_default_classes_keep_local_mini_resolvable():
-    """Tier 2: #1454 — the zero-config default (builtin classes intact, which
-    include local-mini) is NOT degraded: local-mini resolves normally."""
-    cfg = ReynConfig()  # full defaults: builtin embedding.classes incl local-mini
+    """Tier 2: #1454 — an operator who opts IN to local-mini (builtin classes
+    intact, which include local-mini) is NOT degraded: local-mini resolves
+    normally.
+
+    Since the semantic-search-opt-in fix (2026), ``ReynConfig()`` defaults
+    ``embedding_class`` to None (off) rather than "local-mini" — so this
+    test explicitly opts in via ``ActionRetrievalConfig(embedding_class=...)``
+    rather than relying on the zero-config default, to isolate the
+    reconciliation behavior (builtin classes registry membership) from the
+    separate opt-in-off default-value concern.
+    """
+    cfg = ReynConfig(action_retrieval=ActionRetrievalConfig(embedding_class="local-mini"))
     assert cfg.action_retrieval.embedding_class == "local-mini"
     _reconcile_embedding_class(cfg)
     assert cfg.action_retrieval.embedding_class == "local-mini"
+
+
+def test_zero_config_default_is_off_and_reconciliation_is_noop():
+    """Tier 2: the semantic-search-opt-in fix (2026) — a true zero-config
+    ``ReynConfig()`` has embedding_class=None, and reconciliation leaves it
+    untouched (None is always a no-dangling-alias no-op; see
+    ``test_none_class_is_noop``). This pins the NEW default distinctly from
+    the reconciliation-behavior test above."""
+    cfg = ReynConfig()
+    assert cfg.action_retrieval.embedding_class is None
+    _reconcile_embedding_class(cfg)
+    assert cfg.action_retrieval.embedding_class is None

--- a/tests/test_fp0043_phase4_default_switch.py
+++ b/tests/test_fp0043_phase4_default_switch.py
@@ -1,10 +1,16 @@
-"""Tier 2: FP-0043 Phase 4 — default ``embedding_class`` flip to ``local-mini``
-+ Session graceful-degrade probe when the ``local-embed`` extras
-aren't installed.
+"""Tier 2: FP-0043 Phase 4 default-flip history + Session graceful-degrade
+probe when the ``local-embed`` extras aren't installed.
+
+NOTE: the semantic-search-opt-in fix (2026) flipped ``embedding_class``'s
+default back to ``None`` (off) — see ``test_default_embedding_class_is_local_mini``
+below, which now pins the CURRENT (opt-in-off) default rather than the
+Phase 4 local-mini default. The probe mechanism (items 2-6) is unchanged:
+it still matters whenever an operator explicitly opts into an ST-backed
+class (``local-mini`` / ``local-e5``) without the extras installed.
 
 What lands here:
-  1. ``ActionRetrievalConfig`` default is ``"local-mini"`` (= flipped
-     from None in this PR).
+  1. ``ActionRetrievalConfig`` default is ``None`` (= opt-in-off; see
+     module note above for the local-mini → None history).
   2. ``is_available()`` is a cheap importlib.util.find_spec probe and
      reflects the live env (= True iff sentence_transformers is
      importable).
@@ -46,13 +52,18 @@ from reyn.runtime.session import _embedding_class_needs_missing_extras
 
 
 def test_default_embedding_class_is_local_mini() -> None:
-    """Tier 2: out-of-the-box ``ActionRetrievalConfig`` selects local-mini.
+    """Tier 2: out-of-the-box ``ActionRetrievalConfig`` has NO embedding class.
 
-    Phase 4 design: zero-config fresh users with ``reyn[local-embed]``
-    installed get semantic search active without touching reyn.yaml.
+    FP-0043 Phase 4 defaulted this to "local-mini" (zero-config fresh
+    users with ``reyn[local-embed]`` installed got semantic search active
+    without touching reyn.yaml). The semantic-search-opt-in fix (2026)
+    reverted that: a truthy default made reyn attempt a Hugging Face
+    model download at startup even for offline installs, which is not
+    "opt-in". search_actions is now off until the operator explicitly
+    sets ``action_retrieval.embedding_class`` in reyn.yaml.
     """
     cfg = ActionRetrievalConfig()
-    assert cfg.embedding_class == "local-mini"
+    assert cfg.embedding_class is None
 
 
 # ── 2. is_available() probe ────────────────────────────────────────────────


### PR DESCRIPTION
**[lead-coder]** — Make semantic action-search (`search_actions`) truly opt-in / off by default.

## The report
On fresh/offline installs, chat startup printed:
`Semantic search_actions disabled for this session: … index build failed for model class 'local-mini' …`

## Root cause
`ActionRetrievalConfig.embedding_class` defaulted to `"local-mini"` (`src/reyn/config/embedding.py`), so reyn attempted to build a semantic action-index using the local MiniLM model at startup — which requires a one-time Hugging Face model download. When that download fails (offline / firewalled / HF-blocked corporate network), the index build fails and surfaces the warning. This contradicts the project's standing principle that **semantic search is opt-in, never on by default**.

## The fix
Default `action_retrieval.embedding_class` to `None` (off). The null path is **silent by construction**: with no class configured, no embedding index build is attempted at all — so there is nothing to fail or warn about. `search_actions` is simply gated out of the tool catalog (§D14 `is_search_available`). The two warning sources both fire only for a *configured* class:
- `router_loop.py` `_action_index_build_failure_warning` (~502–524) is reached only from `_build_action_embedding_index_background`, which callers gate behind `_provider is not None` + truthy `_model_class` (~1499–1534). Null class → no provider → no build → no warning.
- `config/loader.py:343` `_reconcile_embedding_class` takes its early-return branch (`if not ec or ec in cfg.embedding.classes: return`) for `None`, so no "disabled" log.

## Behavior change for existing installs
Installs that relied on the default `local-mini` being on (with `reyn[local-embed]` extras installed) will now need to opt in explicitly. That is the intended opt-in posture.

## How to opt in
```yaml
# reyn.yaml — local model (needs `pip install 'reyn[local-embed]'`)
action_retrieval:
  embedding_class: local-mini
```
```yaml
# reyn.yaml — API-backed, no local download (needs OPENAI_API_KEY)
action_retrieval:
  embedding_class: standard
```

## Docs
- `docs/reference/config/reyn-yaml.md` + `.ja.md` — new default `null`, field description, and a "Quick-start — opt in to semantic `search_actions`" block.
- `docs/guide/for-users/enable-semantic-search.md` + `.ja.md` — TL;DR + Path A now require the explicit `reyn.yaml` opt-in.
- `docs/concepts/tools-integrations/universal-catalog.md` — default-flip history + silent-off explanation.
- `reyn.local.yaml.example` — commented `embedding_class` with the new default noted.

## Tests
- Updated old `"local-mini"`-default assertions: `test_action_retrieval_config.py`, `test_fp0043_phase4_default_switch.py`, `test_embedding_class_reconciliation_1454.py`, `test_config_schema_enforcement_1056.py`.
- **New silent-opt-in-off test** `test_fresh_config_null_embedding_class_gates_search_actions_silently` (real `load_config`, no mocks) proving: fresh config → `embedding_class is None` → `is_search_available` False → **no "disabled" warning** in `caplog`. Includes a FALSIFY note (reverting the default to a truthy dangling class re-triggers the reconcile warning → test fails).

## Test plan
- [x] `ruff check src tests` — All checks passed
- [x] tier audit on changed test files — 0 errors / 0 warnings
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK
- [x] `pytest` (scoped config/catalog suites, 114 passed); full `pytest` run — see comment
