### PR TITLE
fix: reyn pipe list shows runnable name + run accepts bare entry-key (list/run consistency)

### DIFF
--- a/docs/guide/for-users/write-a-pipeline.ja.md
+++ b/docs/guide/for-users/write-a-pipeline.ja.md
@@ -143,11 +143,11 @@ Config written to: .reyn/config/pipelines.yaml
 ...
 
 $ reyn pipe list
-NAME   PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
-────────────────────────────────────────────────────────────────────────────────
-greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
+NAME         PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
+──────────────────────────────────────────────────────────────────────────────────────
+greet.greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
 
-$ reyn pipe run greet --input '{"name": "Reyn"}'
+$ reyn pipe run greet.greet --input '{"name": "Reyn"}'
 {
   "pipe_data": "Hello, Reyn! (shouted)",
   "named_stores": {
@@ -160,6 +160,8 @@ $ reyn pipe run greet --input '{"name": "Reyn"}'
 
 `reyn pipe install` は `--source <git/GitHub URL>` (`reyn mcp install` と同じ `//subdir` 記法) と、インストールする pipeline の identity を事前に明示する `--name` も受け付けます — DSL 自身が宣言する `pipeline:` 名と食い違う場合は、両者を静かに乖離させるのではなく、明確なエラーで拒否されます。
 
-`reyn pipe list` の **LOAD STATUS** 列は、ログを掘らずに壊れたエントリを直接見る手段です: `enabled: true` なのにパースに失敗したエントリ(DSL の不備、ファイル欠如、宣言名の重複)は、どこにも現れず静かに消えるのではなく、その場で `FAILED` と表示されます。
+`reyn pipe list` の **NAME** 列は、`loaded` エントリについては常に実行可能な名前(=`reyn pipe run` がそのまま受け付ける名前)そのものを表示します — ここに表示されたものはそのまま `reyn pipe run` に渡せます。`reyn pipe run` は、bare な entry-key(`greet.greet` の代わりに `greet`)がちょうど 1 つの登録済み pipeline に一意に一致する場合はそれも受け付け、`note: resolved '<key>' -> '<full-name>'` を stderr に出力して解決内容を明示します。key が複数の pipeline を登録している場合は一意に決まらないため、`run` は候補を列挙してエラーにします。
+
+`reyn pipe list` の **LOAD STATUS** 列は、ログを掘らずに壊れたエントリを直接見る手段です: `enabled: true` なのにパースに失敗したエントリ(DSL の不備、ファイル欠如、宣言名の重複)は(何も実行可能な形で登録されなかったため entry-key のまま)、どこにも現れず静かに消えるのではなく、その場で `FAILED` と表示されます。
 
 `reyn pipe run` は pipeline を **CLI プロセス自身の中で単独実行**します — `tool:` / `agent:` を含む、すべてのステップ種別が実行できます。`tool:` ステップは、ライブセッションの `tool` ステップと同じ実際のツール実行経路を通して(スタンドアロンな)ディスパッチされます。`agent:` ステップは `default` エージェントの下で本物の短命("ephemeral")セッションを spawn し、チャットセッションの `agent:` ステップと同様に最後まで実行します。`reyn pipe run` の背後にはライブなチャット REPL も `--docker`/`--sandbox-backend` によるコンテナオプションもありません(ホストのファイルシステム/実行のみ)— それらが必要な pipeline は `reyn chat`/`reyn run` から実行してください。また `reyn pipe run` の呼び出しにはクラッシュリカバリもありません: これは one-shot のフォアグラウンドコマンドなので、途中で kill/中断された実行は、他の CLI ツールと同様、単に失敗したコマンドであり、再開可能な driver-session ではありません。

--- a/docs/guide/for-users/write-a-pipeline.md
+++ b/docs/guide/for-users/write-a-pipeline.md
@@ -216,11 +216,11 @@ Config written to: .reyn/config/pipelines.yaml
 ...
 
 $ reyn pipe list
-NAME   PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
-────────────────────────────────────────────────────────────────────────────────
-greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
+NAME         PATH                      DESCRIPTION                  ENABLED  LOAD STATUS
+──────────────────────────────────────────────────────────────────────────────────────
+greet.greet  pipelines/greet.yaml      Greet a name and shout it    yes      loaded
 
-$ reyn pipe run greet --input '{"name": "Reyn"}'
+$ reyn pipe run greet.greet --input '{"name": "Reyn"}'
 {
   "pipe_data": {"text": "Hello, Reyn! (shouted)"},
   "named_stores": {
@@ -237,10 +237,20 @@ pipeline's identity up front — a mismatch against the DSL's own declared
 `pipeline:` name is refused with a clear error rather than silently diverging
 the two.
 
+`reyn pipe list`'s **NAME** column always shows the exact runnable name(s) —
+what `reyn pipe run` accepts — for a `loaded` entry, so anything printed there
+can be pasted straight into `reyn pipe run` without translation. `reyn pipe
+run` also accepts the bare entry-key (`greet` instead of `greet.greet`) when
+it unambiguously matches exactly one registered pipeline, printing a `note:
+resolved '<key>' -> '<full-name>'` to stderr so the resolution is transparent;
+if the key registers more than one pipeline, `run` reports the ambiguity and
+lists the candidates rather than guessing.
+
 `reyn pipe list`'s **LOAD STATUS** column is the direct way to see a broken
 entry without digging through logs: an entry that is `enabled: true` but
 failed to parse (bad DSL, missing file, a duplicate declared name) shows
-`FAILED` right there, instead of just silently not appearing anywhere.
+`FAILED` right there (keyed by its entry-key, since nothing runnable was
+registered), instead of just silently not appearing anywhere.
 
 `reyn pipe run` executes the pipeline **standalone, in the CLI process
 itself** — every step kind runs, including `tool:` and `agent:`. A `tool:`

--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -205,8 +205,13 @@ def register(sub) -> None:
         "name",
         metavar="NAME",
         help=(
-            "Registered pipeline's fully-qualified name "
-            "'<entry-key>.<declared-pipeline-name>' (see `reyn pipe list`)."
+            "Registered pipeline's name, as shown by `reyn pipe list` "
+            "(the fully-qualified '<entry-key>.<declared-pipeline-name>' "
+            "form). A bare '<entry-key>' is also accepted and resolved "
+            "automatically when it unambiguously matches exactly one "
+            "registered pipeline under that key's namespace; if the key "
+            "registers more than one pipeline, the fully-qualified name "
+            "is required."
         ),
     )
     run_p.add_argument(
@@ -274,6 +279,17 @@ def run_list(args: argparse.Namespace) -> None:
     per-entry-isolation posture) shows FAILED here, so ``reyn pipe list`` is a
     first-class way to SEE load failures without digging through
     dogfood_trace/logs.
+
+    NAME column (list/run consistency fix): a loaded entry shows the
+    ACTUAL registered name(s) — the RUNNABLE ``{key}.{declared-name}``
+    form ``reyn pipe run`` accepts via ``PipelineRegistry.get`` — never
+    the bare entry-key. An entry that registers more than one pipeline
+    (a DSL file with siblings, or an entry path that is a directory)
+    gets one row per runnable name, so every NAME printed here is
+    directly copy-pasteable into ``reyn pipe run``. A FAILED/disabled
+    entry registered nothing runnable, so it still shows the bare
+    entry-key (the diagnostic identity, not a runnable name) alongside
+    its status — unchanged from #2722.
     """
     from reyn.config import load_config
     from reyn.data.pipelines.registry import build_pipeline_registry
@@ -310,13 +326,19 @@ def run_list(args: argparse.Namespace) -> None:
         description = str(raw.get("description") or "")
         enabled = bool(raw.get("enabled", True))
         if not enabled:
-            status = "disabled"
-        elif any(n == key or n.startswith(f"{key}.") for n in loaded_names):
-            # #2722: a healthy entry registers under the `{key}.` namespace.
-            status = "loaded"
-        else:
-            status = "FAILED"
-        rows.append((key, path, description, "yes" if enabled else "no", status))
+            rows.append((key, path, description, "no", "disabled"))
+            continue
+        # #2722: a healthy entry registers under the `{key}.` namespace —
+        # possibly more than one name (a multi-pipeline DSL file / dir entry).
+        runnable_names = sorted(
+            n for n in loaded_names if n == key or n.startswith(f"{key}.")
+        )
+        if not runnable_names:
+            rows.append((key, path, description, "yes", "FAILED"))
+            continue
+        for runnable_name in runnable_names:
+            # every NAME shown here is exactly what `reyn pipe run` accepts.
+            rows.append((runnable_name, path, description, "yes", "loaded"))
 
     _W_NAME = max((len(r[0]) for r in rows), default=4)
     _W_NAME = max(_W_NAME, 4)
@@ -648,12 +670,36 @@ def run_run(args: argparse.Namespace) -> None:
         pipeline = pipeline_registry.get(name)
         schema_registry = pipeline_registry.get_schema_registry(name)
     except PipelineNotFoundError:
-        print(
-            f"error: pipeline '{name}' is not registered. "
-            "Run 'reyn pipe list' to see available pipelines.",
-            file=sys.stderr,
+        # list/run consistency fallback: `name` may be a bare entry-key
+        # (what `reyn pipe list` used to show before this fix, and what an
+        # operator may reasonably still type) rather than the fully-
+        # qualified `{key}.{declared-name}` registered form. Resolve it
+        # against the registry's own namespace, not by re-deriving the
+        # `pipelines.entries` cascade a second time.
+        candidates = sorted(
+            n for n in pipeline_registry.names()
+            if n == name or n.startswith(f"{name}.")
         )
-        sys.exit(1)
+        if len(candidates) == 1:
+            resolved = candidates[0]
+            print(f"note: resolved '{name}' -> '{resolved}'", file=sys.stderr)
+            name = resolved
+            pipeline = pipeline_registry.get(name)
+            schema_registry = pipeline_registry.get_schema_registry(name)
+        elif len(candidates) > 1:
+            print(
+                f"error: '{name}' is ambiguous — matches: "
+                f"{', '.join(candidates)}. Run one explicitly.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        else:
+            print(
+                f"error: pipeline '{name}' is not registered. "
+                "Run 'reyn pipe list' to see available pipelines.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # #2708 P3.2b: there is no conditional credential pre-check on this
     # per-surface startup path. The missing-cred check lives on the single LLM

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -148,8 +148,14 @@ def test_pipe_run_async_flag_parses_but_is_rejected_at_runtime(capsys):
 
 
 def test_list_shows_loaded_and_failed_entries(tmp_path, monkeypatch, capsys):
-    """Tier 2: a working entry shows 'loaded'; a broken one (missing file)
-    shows 'FAILED' — #2641's per-entry isolation surfaced visibly by the CLI."""
+    """Tier 2: a working entry shows 'loaded' under its RUNNABLE (compound)
+    name — #2722 always namespaces, so 'good_one' (declared name 'good_one')
+    registers as 'good_one.good_one', and that is what NAME shows now (list/run
+    consistency fix — see test_list_shows_runnable_compound_name_when_declared_name_differs
+    for the case that actually exposes the pre-fix bug). A broken entry
+    (missing file) shows 'FAILED' keyed by its bare entry-key (nothing
+    runnable was registered) — #2641's per-entry isolation surfaced visibly
+    by the CLI, unaffected by this fix."""
     monkeypatch.chdir(tmp_path)
 
     working_dsl = (
@@ -173,8 +179,46 @@ def test_list_shows_loaded_and_failed_entries(tmp_path, monkeypatch, capsys):
 
     out = capsys.readouterr().out
     lines = {ln.split()[0]: ln for ln in out.splitlines() if ln and not ln.startswith("─")}
-    assert "loaded" in lines["good_one"]
+    # FALSIFY: pre-fix, NAME showed the bare entry-key 'good_one' here — a
+    # name `reyn pipe run good_one` (bare) would previously 404 on, since the
+    # registry only ever held 'good_one.good_one'. Asserting the COMPOUND key
+    # is present (and the bare key is NOT a row) pins the fix.
+    assert "loaded" in lines["good_one.good_one"]
+    assert "good_one" not in lines
     assert "FAILED" in lines["missing_one"]
+
+
+def test_list_shows_runnable_compound_name_when_declared_name_differs(
+    tmp_path, monkeypatch, capsys,
+):
+    """Tier 2: the exact owner-reported trap — an entry-key that differs from
+    the DSL's declared 'pipeline:' name. Pre-fix, 'reyn pipe list' printed the
+    bare entry-key ('my_key') in NAME, but 'reyn pipe run' only accepted the
+    registered compound name ('my_key.actual_name'), so copy-pasting the NAME
+    column into 'run' 404'd. This test pins that 'list' now shows the exact
+    runnable name.
+
+    FALSIFY: assert the compound name IS a row and the bare entry-key is NOT
+    — a regression back to showing the bare key would make the first
+    assertion KeyError and the second assertion fail."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl = (
+        "pipeline: actual_name\n"
+        "description: declared name differs from entry key\n"
+        "steps:\n"
+        "  - transform: {value: \"ctx.x\", output: y}\n"
+    )
+    (tmp_path / "pipelines").mkdir()
+    (tmp_path / "pipelines" / "p.yaml").write_text(dsl, encoding="utf-8")
+    _write_reyn_yaml(tmp_path, {"my_key": {"path": "pipelines/p.yaml"}})
+
+    run_list(_ns())
+
+    out = capsys.readouterr().out
+    lines = {ln.split()[0]: ln for ln in out.splitlines() if ln and not ln.startswith("─")}
+    assert "loaded" in lines["my_key.actual_name"]
+    assert "my_key" not in lines
 
 
 def test_list_no_project_root_prints_message(tmp_path, monkeypatch, capsys):
@@ -303,6 +347,117 @@ def test_run_transform_pipeline_end_to_end(tmp_path, monkeypatch, capsys):
     result = json.loads(out)
     assert result["pipe_data"] == "hello world"
     assert result["named_stores"]["greeting"] == "hello world"
+
+
+def test_run_bare_entry_key_resolves_when_unambiguous(tmp_path, monkeypatch, capsys):
+    """Tier 2: list/run consistency fix, direction 2 — 'reyn pipe run
+    <bare-entry-key>' now resolves + runs when the key unambiguously matches
+    exactly one registered pipeline (here 'my_key' -> 'my_key.actual_name'),
+    printing a 'note: resolved ...' to stderr for transparency. This is the
+    owner-confirmed-working full-name form's shorter counterpart; before this
+    fix ONLY the full 'my_key.actual_name' form worked and the bare key 404'd.
+
+    FALSIFY: assert the pipeline's real output landed (not just no-exit-1) —
+    a broken resolution that silently no-ops would not produce this JSON."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl_path = tmp_path / "p.yaml"
+    dsl_path.write_text(
+        "pipeline: actual_name\n"
+        "steps:\n"
+        "  - transform: {value: \"'hi ' + ctx.name\", output: greeting}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"my_key": {"path": "p.yaml"}})
+
+    args = _ns(
+        name="my_key", input=json.dumps({"name": "reyn"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["named_stores"]["greeting"] == "hi reyn"
+    assert "resolved 'my_key' -> 'my_key.actual_name'" in captured.err
+
+
+def test_run_bare_entry_key_ambiguous_errors_with_candidates(tmp_path, monkeypatch, capsys):
+    """Tier 2: a bare entry-key that maps to MORE than one registered
+    pipeline is refused with an actionable ambiguity error listing every
+    candidate, rather than silently guessing one. A single config entry
+    registers exactly one pipeline (#2722's ``{key}.{declared-name}``), so
+    this drives the real ambiguity source directly: patch
+    ``build_pipeline_registry`` (imported locally inside ``run_run``, so
+    patching the module attribute it resolves from at call time is enough)
+    to additionally register a second pipeline under the same 'multi.'
+    namespace, mirroring a multi-pipeline DSL file/directory entry.
+
+    FALSIFY: assert BOTH candidate full names appear in the error and the
+    process exits non-zero — a silent pick-first-one regression would exit 0
+    with only one name ever surfaced."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl_path = tmp_path / "p.yaml"
+    dsl_path.write_text(
+        "pipeline: one\nsteps:\n  - transform: {value: \"1\", output: o}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"multi": {"path": "p.yaml"}})
+
+    import reyn.data.pipelines.registry as pipelines_registry_mod
+    real_build = pipelines_registry_mod.build_pipeline_registry
+
+    def _fake_build_pipeline_registry(pipelines_cfg, project_root, strict=False):
+        from reyn.core.pipeline.executor import Pipeline, TransformStep
+
+        reg = real_build(pipelines_cfg, project_root, strict=strict)
+        reg.register(
+            "multi.two",
+            Pipeline(steps=[TransformStep(value="2", output="o")], name="multi.two"),
+        )
+        return reg
+
+    monkeypatch.setattr(
+        pipelines_registry_mod, "build_pipeline_registry", _fake_build_pipeline_registry,
+    )
+
+    args = _ns(name="multi", input="{}", project=str(tmp_path), async_=False)
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "ambiguous" in err.lower()
+    assert "multi.one" in err
+    assert "multi.two" in err
+
+
+def test_run_full_qualified_name_still_works_no_regression(tmp_path, monkeypatch, capsys):
+    """Tier 2: the fast-path (fully-qualified '{key}.{declared-name}') that
+    already worked before this fix keeps working unchanged — the fallback
+    resolution only engages on PipelineNotFoundError, so a correct
+    fully-qualified name never touches the new resolution branch at all."""
+    monkeypatch.chdir(tmp_path)
+
+    dsl_path = tmp_path / "p.yaml"
+    dsl_path.write_text(
+        "pipeline: actual_name\n"
+        "steps:\n"
+        "  - transform: {value: \"'hi ' + ctx.name\", output: greeting}\n",
+        encoding="utf-8",
+    )
+    _write_reyn_yaml(tmp_path, {"my_key": {"path": "p.yaml"}})
+
+    args = _ns(
+        name="my_key.actual_name", input=json.dumps({"name": "reyn"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    captured = capsys.readouterr()
+    result = json.loads(captured.out)
+    assert result["named_stores"]["greeting"] == "hi reyn"
+    assert "resolved" not in captured.err  # no fallback note — fast path taken
 
 
 def test_run_unregistered_pipeline_is_clean_error(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
**[lead-coder]** — Fixes the owner-reported `reyn pipe list` / `reyn pipe run` UX trap.

## The trap

`reyn pipe list`'s NAME column displayed the config **entry-key**, but `reyn pipe run <name>` calls `pipeline_registry.get(name)`, which requires the **actual registered name** — `<entry-key>.<declared-pipeline-name>` (#2722's always-on namespacing). When the DSL's declared `pipeline:` name differs from the entry-key, the registry only holds the compound `key.declared_name`, so copy-pasting the bare key `list` showed into `run` produced `error: pipeline 'X' is not registered` — even though `list` had just shown `X` as `loaded`. The owner confirmed running with the `key.declared_name` prefix works.

## Fix (both directions)

1. **`run_list`** now prints the exact **runnable** name(s) for each `loaded` entry — one row per pipeline actually registered under that entry's `{key}.` namespace — so anything shown in NAME can be pasted straight into `reyn pipe run`. A `FAILED`/`disabled` entry registered nothing runnable, so it still shows the bare entry-key alongside its status (unchanged #2722 diagnostic).

2. **`run_run`** now falls back to resolving a **bare entry-key** when `pipeline_registry.get(name)` 404s: it computes `candidates = [n for n in registry.names() if n == name or n.startswith(f"{name}.")]`.
   - **Exactly 1 candidate** → resolves and runs it, printing `note: resolved '<key>' -> '<full-name>'` to stderr for transparency.
   - **>1 candidates** → errors: `'<key>' is ambiguous — matches: <a>, <b>. Run one explicitly.`
   - **0 candidates** → unchanged "not registered" error.

Updated the `reyn pipe run` NAME help text and both `docs/guide/for-users/write-a-pipeline.md`/`.ja.md` (the walkthrough's own `reyn pipe list`/`run greet` example was itself showing the pre-fix bare-key form — corrected to the compound `greet.greet` name, with prose describing the bare-key fallback).

## Before / after

Before:
```
$ reyn pipe list
NAME   ... LOAD STATUS
greet  ... loaded
$ reyn pipe run greet
error: pipeline 'greet' is not registered.
```

After:
```
$ reyn pipe list
NAME         ... LOAD STATUS
greet.greet  ... loaded
$ reyn pipe run greet
note: resolved 'greet' -> 'greet.greet'
{ ...real output... }
$ reyn pipe run greet.greet
{ ...real output, no note (fast path)... }
```

## Tests

Added to `tests/test_cli_pipe.py`:
- `test_list_shows_runnable_compound_name_when_declared_name_differs` — pins the exact owner-reported trap (list showed compound name, not bare key).
- `test_list_shows_loaded_and_failed_entries` — updated for the new compound NAME (FALSIFY: asserts bare key is absent as a row).
- `test_run_bare_entry_key_resolves_when_unambiguous` — bare key resolves + runs, note printed.
- `test_run_bare_entry_key_ambiguous_errors_with_candidates` — 2 candidates → SystemExit(1) listing both.
- `test_run_full_qualified_name_still_works_no_regression` — fast path unchanged, no fallback note printed.

## Gates (all green, foreground)

- `ruff check src tests` — All checks passed!
- `pytest` (repo root) — 8453 passed, 20 skipped
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/pipe.py` — OK
- `python scripts/test_tier_audit.py --strict tests/test_cli_pipe.py` — 24/24 OK, 0 Tier-4 violations

## Test plan
- [x] Ran all 4 CI gates locally (see above)
- [x] Manually traced the before/after `list`/`run` behavior against the new test cases