### PR TITLE
fix: default LITELLM_LOCAL_MODEL_COST_MAP=True (silence startup cost-table fetch warning)

### DIFF
--- a/src/reyn/__init__.py
+++ b/src/reyn/__init__.py
@@ -5,5 +5,28 @@ notably ``reyn.core.kernel._codeact_harness``, the CodeAct sandbox child-process
 entry point — does not pull the agent / llm / httpx chain in through the package
 root. (FP-0008 C4: keeping the harness cold-import path well under the
 python-step timeout.)
+
+It DOES set two ``os.environ`` defaults (no import cost) before anything else
+runs, because they must exist before litellm's own package init executes:
+litellm's ``__init__.py`` calls ``get_model_cost_map(...)`` and (lazily,
+on first Anthropic call) the beta-headers manager at *module import time*, each
+doing a network fetch of a remote config unless the corresponding
+``LITELLM_LOCAL_*`` env var is already set. Every ``import litellm`` in this
+codebase is lazy (inside functions, in ``reyn.llm.*`` and friends) and none of
+them precede a `reyn` submodule import, so this package root — which Python
+guarantees runs before any ``reyn.*`` submodule is importable — is the
+earliest point that is still guaranteed to run before the first
+``import litellm`` on every startup path (CLI, tests, scripts).
 """
 from __future__ import annotations
+
+import os
+
+# Silence litellm's startup network fetches (remote cost-table / remote beta-
+# headers config) by defaulting to its bundled local snapshots. ``setdefault``
+# (not a forced assignment) so an operator who explicitly wants the remote
+# fetch (e.g. sets the var to a falsey value themselves) is respected — see
+# reyn's no-uncustomizable-hardcodes rule. Must run before litellm is imported
+# anywhere; see the module docstring above for why this is the right place.
+os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+os.environ.setdefault("LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS", "True")


### PR DESCRIPTION
**[lead-coder]** — Silence the litellm startup warning about not being able to fetch the remote model-cost table.

## The warning
At startup litellm logs `LiteLLM: Failed to fetch remote model cost map from <github url>: ... Falling back to local backup.` (and, on the first Anthropic call, an analogous "Failed to fetch remote beta headers config … Falling back to local backup").

## Root cause (verified in installed litellm 1.89.3)
`litellm/__init__.py` runs `model_cost = get_model_cost_map(url=...)` at **module-import time**, which fetches `model_prices_and_context_window.json` from GitHub. When the fetch fails (offline / corporate network / GitHub unreachable), it warns and falls back to its bundled local snapshot. Pricing still works — the warning is just noise. The sibling `anthropic_beta_headers_manager.py` does the same class of remote fetch.

## The fix
Default both of litellm's own documented opt-out env vars to `"True"` via `os.environ.setdefault(...)` so litellm uses its bundled local snapshots from the start and attempts **zero** remote fetches → no warning, faster startup:
- `LITELLM_LOCAL_MODEL_COST_MAP` (checked in `litellm/litellm_core_utils/get_model_cost_map.py:258`)
- `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS` (checked in `litellm/anthropic_beta_headers_manager.py:142`)

## Why placement matters
The fetch happens at litellm **import** time, so the env var must exist **before** the first `import litellm` on any startup path. Placed at the very top of `src/reyn/__init__.py` (a real, non-namespace package init) because:
- Python guarantees `reyn/__init__.py` runs before any `reyn.*` submodule is importable (including the CLI shim `reyn._cli` → `reyn.interfaces.cli`).
- Every `import litellm` / `from litellm` in `src/reyn/` is lazy (function-local) — grep confirms **no module-level litellm import** precedes the package root.
`setdefault` (not a forced assignment) respects an explicit operator override: a user who WANTS the remote fetch can set the var to a falsey value themselves (reyn's no-uncustomizable-hardcodes principle).

## Pricing trade-off
`litellm.model_cost` is now populated from the bundled snapshot (pinned to the litellm version) rather than the remote map. Since the remote fetch was **failing anyway** in the reported condition and falling back to the same bundled map, behavior is effectively unchanged — just silent. reyn's own usages (`llm/pricing.py`, `model_budget.py`, `model_cost_rate.py`) read `litellm.model_cost`, which is non-empty either way, so budget/pricing lookups still succeed.

## Verification
- **No-warning (real startup, offline simulated)**: subprocess pointing litellm's remote URL at an unreachable host (`http://127.0.0.1:1/...`) with `logging` at WARNING: with `import reyn` first, zero warnings logged, `litellm.model_cost` non-empty (bundled map loaded), no fetch attempted.
- **FALSIFY**: without the setdefault (vars unset), the same subprocess logs `Failed to fetch remote model cost map ... Falling back to local backup.` — confirming the remote fetch path is what we suppress.
- **Override respected**: `LITELLM_LOCAL_MODEL_COST_MAP=False` / `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS=False` in env before `import reyn` → both remain `"False"` after import (setdefault did not overwrite).
- No test references the remote cost-map or these env vars (grep of `tests/`); the env-var side-effect (runs in every test that imports reyn) broke nothing.

## Test plan
- [x] `ruff check src tests` — all checks passed
- [x] `pytest` (repo root) — **8453 passed, 20 skipped** (8 pre-existing unrelated warnings)
- [x] `python scripts/verify_module_docstrings.py src/reyn/__init__.py` — OK
- [x] tier audit — n/a (no test files changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)