### PR TITLE
fix: route litellm logs to .reyn/logs/reyn.log (off console)

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -7,8 +7,11 @@ instances; switching agents mid-REPL via `/attach <name>` happens through it.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import logging
 import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from reyn.interfaces.cli.env_backend import (
     build_environment_backend,
@@ -18,6 +21,9 @@ from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 # #187: send_to_agent_impl timeout for the one-shot (`reyn run-once`) drive. The
 # autonomous SWE agent may iterate for many minutes; the external bound is the
@@ -250,7 +256,6 @@ def _setup_interactive_logging(project_root: Path) -> None:
     once, before load_project_context (which may emit WARNING records), so the
     file handler is in place before the first log call.
     """
-    import logging
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
@@ -263,11 +268,73 @@ def _setup_interactive_logging(project_root: Path) -> None:
     # directly to stderr on a provider error — NOT via logging, so the file
     # redirect above does not catch them. Suppress them so a provider error
     # surfaces as just our clean classified message, not a wall of litellm noise.
+    with _litellm_import_logs_to_file():
+        try:
+            import litellm
+            litellm.suppress_debug_info = True
+        except Exception:  # noqa: BLE001 — best-effort; never block startup on this
+            pass
+
+
+_LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
+
+@contextlib.contextmanager
+def _litellm_import_logs_to_file() -> "Iterator[None]":
+    """Route litellm's own loggers to reyn's log file instead of stderr.
+
+    litellm's ``_logging.py`` module attaches a fresh ``logging.StreamHandler()``
+    (→ stderr, by construction) to each of ``"LiteLLM"`` / ``"LiteLLM Router"`` /
+    ``"LiteLLM Proxy"`` **unconditionally at import time** (module-level code,
+    not gated on whether the logger already has a handler) — the first
+    ``import litellm`` anywhere in the process attaches it, which for the
+    interactive CUI happens inside this context manager's ``with`` body.
+    Because the attach is unconditional, merely pre-configuring these loggers
+    *before* import does not stop litellm from ALSO adding its own console
+    handler — it would just add a second one. So the console redirect has to
+    intercept handler *construction* itself: for the duration of the
+    ``import litellm`` this swaps in a ``logging.StreamHandler`` subclass
+    whose default stream is reyn's log file instead of stderr, so every
+    StreamHandler litellm builds at import time — including the one behind
+    the cost-map-fetch-failure warning
+    ``litellm.litellm_core_utils.get_model_cost_map`` emits synchronously
+    during import — writes to the file, not the console.
+
+    On exit, the real ``StreamHandler`` class is restored and the three
+    loggers are stripped down to file-routed only: their handler lists are
+    cleared and ``propagate`` is set ``True``, so every *runtime* litellm log
+    (not just the import-time one) flows to the root logger's file handler
+    exactly once, with no leftover console sink. This also makes the
+    context manager safe to use when litellm was already imported earlier in
+    the process (e.g. by an unrelated import elsewhere) — the patch during
+    ``import litellm`` becomes a no-op (module cache hit, nothing re-runs),
+    but the handler-strip on exit still redirects it.
+    """
+    root_handlers = logging.getLogger().handlers
+    file_stream = root_handlers[0].stream if root_handlers else None
+    if file_stream is None:
+        # No file handler in place (shouldn't happen after basicConfig) — do
+        # not patch anything, so litellm's normal stderr behavior applies.
+        yield
+        return
+
+    original_stream_handler = logging.StreamHandler
+
+    class _FileRoutedStreamHandler(logging.StreamHandler):
+        """``StreamHandler`` that defaults to reyn's log file, not stderr."""
+
+        def __init__(self, stream: object = None) -> None:
+            super().__init__(stream=file_stream if stream is None else stream)
+
+    logging.StreamHandler = _FileRoutedStreamHandler  # type: ignore[misc]
     try:
-        import litellm
-        litellm.suppress_debug_info = True
-    except Exception:  # noqa: BLE001 — best-effort; never block startup on this
-        pass
+        yield
+    finally:
+        logging.StreamHandler = original_stream_handler  # type: ignore[misc]
+        for name in _LITELLM_LOGGER_NAMES:
+            logger = logging.getLogger(name)
+            logger.handlers.clear()
+            logger.propagate = True
 
 
 def _run_remote(

--- a/tests/test_inline_interactive_logging.py
+++ b/tests/test_inline_interactive_logging.py
@@ -9,6 +9,11 @@ so the assertion does not leak into the rest of the suite.
 from __future__ import annotations
 
 import logging
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
 
 from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
 
@@ -45,3 +50,93 @@ def test_interactive_logging_quiets_litellm_banners(tmp_path) -> None:
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
         litellm.suppress_debug_info = saved_suppress
+
+
+def test_interactive_logging_routes_litellm_logger_to_file_not_console(
+    tmp_path,
+) -> None:
+    """Tier 2: litellm's "LiteLLM" logger has no console handler after setup —
+    its own module-level ``StreamHandler`` (attached at ``import litellm`` time,
+    which already ran earlier in this test process) is stripped, and a runtime
+    warning it emits lands in reyn.log via root-logger propagation instead.
+    FALSIFY: without `_litellm_import_logs_to_file`'s exit-time strip, the
+    "LiteLLM" logger keeps its own StreamHandler (→ stderr) alongside/instead of
+    reaching the file, so this assertion would fail.
+    """
+    import litellm  # noqa: F401 — ensures the "LiteLLM" logger + its handler exist
+
+    root = logging.getLogger()
+    litellm_logger = logging.getLogger("LiteLLM")
+    saved_root_handlers, saved_root_level = root.handlers[:], root.level
+    saved_litellm_handlers = litellm_logger.handlers[:]
+    saved_litellm_propagate = litellm_logger.propagate
+    try:
+        _setup_interactive_logging(tmp_path)
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+
+        # No leftover console (StreamHandler) sink on litellm's own logger.
+        assert not any(
+            isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+            for h in litellm_logger.handlers
+        )
+        assert litellm_logger.propagate is True
+
+        litellm_logger.warning("runtime-marker-9a1b-not-a-mock")
+        for h in root.handlers:
+            h.flush()
+        assert "runtime-marker-9a1b-not-a-mock" in log_file.read_text()
+    finally:
+        root.handlers[:] = saved_root_handlers
+        root.setLevel(saved_root_level)
+        litellm_logger.handlers[:] = saved_litellm_handlers
+        litellm_logger.propagate = saved_litellm_propagate
+
+
+def test_interactive_logging_routes_litellm_import_time_warning_to_file(
+    tmp_path,
+) -> None:
+    """Tier 2: litellm's cost-map-fetch-failure warning, emitted synchronously
+    *during* ``import litellm`` (not a runtime call reyn controls, so exercised
+    via a real subprocess), lands in reyn.log and NOT on stderr.
+
+    Forces the fetch-failure path explicitly (overrides the #2928
+    ``LITELLM_LOCAL_MODEL_COST_MAP`` setdefault so the remote fetch is
+    attempted) against an unreachable URL, so the warning is guaranteed to
+    fire — this is the decisive evidence for the import-time handler-
+    construction patch in `_litellm_import_logs_to_file`, independent of
+    whether the #2928 env var happens to skip the fetch entirely on a given
+    run. FALSIFY: without the patch, litellm's own StreamHandler prints this
+    warning straight to stderr — captured via a real subprocess, no mocks.
+    """
+    project_root = tmp_path
+    script = textwrap.dedent(
+        """
+        import os
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+        os.environ["LITELLM_MODEL_COST_MAP_URL"] = "http://127.0.0.1:1/unreachable.json"
+
+        from pathlib import Path
+        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+
+        _setup_interactive_logging(Path(%r))
+        """
+        % str(project_root)
+    )
+    # This test's own `src/` (not whatever path an editable install's
+    # site-packages .pth happens to point at — e.g. a sibling git worktree's
+    # checkout) must win on the child's sys.path, so the subprocess exercises
+    # THIS checkout's `_setup_interactive_logging`/`_litellm_import_logs_to_file`.
+    src_dir = Path(__file__).resolve().parents[1] / "src"
+    env = {**os.environ, "PYTHONPATH": str(src_dir)}
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    log_file = project_root / ".reyn" / "logs" / "reyn.log"
+    log_text = log_file.read_text()
+    assert "Failed to fetch remote model cost map" in log_text
+    assert "Failed to fetch remote model cost map" not in result.stderr


### PR DESCRIPTION
**[lead-coder]** — Route litellm's own logs to reyn's log file instead of the console.

## Problem
The owner sees a litellm startup warning (remote cost-map fetch) printed to the console during interactive chat. litellm's own loggers — `logging.getLogger("LiteLLM")` (+ Router/Proxy) — get a fresh `logging.StreamHandler()` (→ stderr) attached **unconditionally at `import litellm` time** in `litellm/_logging.py` (module-level `verbose_logger.addHandler(handler)`, not gated on existing handlers). This bypasses reyn's root-logger file config in `_setup_interactive_logging` (`logging.basicConfig(filename=.reyn/logs/reyn.log, force=True)`), so litellm WARNING/INFO records — notably the cost-map-fetch-failure warning `get_model_cost_map.py` emits **synchronously during import** — hit the console instead of reyn.log, corrupting the inline CUI's live region.

## Fix (this PR)
In `_setup_interactive_logging`, wrap the lazy `import litellm` in a new `_litellm_import_logs_to_file()` context manager:

- **During import** (the tricky import-time warning): litellm adds its StreamHandler *unconditionally*, so pre-configuring the loggers alone would just add a *second* handler. Instead the CM intercepts handler **construction** — for the duration of `import litellm` it swaps `logging.StreamHandler` for a subclass whose default stream is reyn's log-file stream. So every StreamHandler litellm builds at import time (including the one behind the cost-map warning) writes to the **file**, not stderr.
- **On exit** (all runtime litellm logs): restores the real `StreamHandler` class and strips the three litellm loggers to file-routed-only — `handlers.clear()` + `propagate = True` — so every runtime litellm log flows to the root file handler exactly once, no leftover console sink.
- Keeps the existing `litellm.suppress_debug_info = True`.

The `#2928` env-var defaults (`LITELLM_LOCAL_MODEL_COST_MAP` / `LITELLM_LOCAL_ANTHROPIC_BETA_HEADERS`) in `src/reyn/__init__.py` are **left untouched** (identical to main) — this PR is purely additive log-routing.

## Decisive-test evidence (real subprocess, no mocks)
A subprocess forces litellm's remote cost-map fetch (`LITELLM_LOCAL_MODEL_COST_MAP=False`) against an unreachable URL (`http://127.0.0.1:1/...`) so the warning is guaranteed to fire during import, then runs `_setup_interactive_logging`:

- `"Failed to fetch remote model cost map"` **IS** present in `.reyn/logs/reyn.log` ✅
- `"Failed to fetch remote model cost map"` **NOT** on stderr ✅

FALSIFY: without the CM, litellm's own StreamHandler prints the warning straight to stderr (verified — restoring `src/reyn/__init__.py` alone leaves the warning on the console).

## Scope
Focused on the interactive chat path (`_setup_interactive_logging`), where the owner sees it. Factored into a reusable `_litellm_import_logs_to_file()` CM so `reyn web`/`reyn run` could adopt it — noted as a trivial follow-up, not expanded here.

## Test plan
- [x] `tests/test_inline_interactive_logging.py` — 4 tests pass (2 new: runtime-logger-to-file + import-time-warning subprocess decisive test)
- [x] ruff check src tests — clean
- [x] tier audit (changed test file) — 4/4 OK
- [x] verify_module_docstrings (changed src) — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)