### PR TITLE
perf: lazy-load litellm off the chat startup path (input box ~1.5s faster)

### DIFF
--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -197,6 +197,12 @@ def _resolve_ssl_verify(ctx: OpContext) -> bool | str:
       4. Both unset (None) → falls through to litellm.get_ssl_verify()
          (= SSL_VERIFY env → litellm.ssl_verify → SSL_CERT_FILE → True).
     """
+    # perf/log-routing chokepoint: a web op (e.g. the flagship web_search→agent
+    # pipeline) can be the FIRST litellm import in the process — funnel it
+    # through ensure_litellm_ready() so litellm's import-time console log
+    # routing (#2929) wraps this import too (idempotent; cheap on 2nd+ call).
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+    ensure_litellm_ready()
     from litellm.llms.custom_httpx.http_handler import get_ssl_verify
 
     cfg = ctx.web_config.fetch if ctx.web_config is not None else None

--- a/src/reyn/core/registry/client.py
+++ b/src/reyn/core/registry/client.py
@@ -156,6 +156,13 @@ class RegistryClient:
 
     async def __aenter__(self) -> "RegistryClient":
         import httpx
+
+        # perf/log-routing chokepoint: this client can be the FIRST litellm
+        # import in the process — funnel it through ensure_litellm_ready() so
+        # litellm's import-time console log routing (#2929) wraps it too
+        # (idempotent; cheap on 2nd+ call).
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        ensure_litellm_ready()
         from litellm.llms.custom_httpx.http_handler import get_ssl_verify
 
         # Resolve the verify value: explicit arg takes priority; None falls

--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -294,6 +294,12 @@ class LiteLLMEmbeddingProvider:
                 wait = self._retry_backoff ** attempt
                 await asyncio.sleep(wait)
             try:
+                # perf/log-routing chokepoint: an embedding/RAG-first path can
+                # be the FIRST litellm import in the process — funnel it through
+                # ensure_litellm_ready() so litellm's import-time console log
+                # routing (#2929) wraps it too (idempotent; cheap on 2nd+ call).
+                from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+                ensure_litellm_ready()
                 import litellm
                 response = await litellm.aembedding(
                     model=effective_model,

--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -7,11 +7,9 @@ instances; switching agents mid-REPL via `/attach <name>` happens through it.
 from __future__ import annotations
 
 import argparse
-import contextlib
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 from reyn.interfaces.cli.env_backend import (
     build_environment_backend,
@@ -21,9 +19,6 @@ from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
-
-if TYPE_CHECKING:
-    from collections.abc import Iterator
 
 # #187: send_to_agent_impl timeout for the one-shot (`reyn run-once`) drive. The
 # autonomous SWE agent may iterate for many minutes; the external bound is the
@@ -255,6 +250,13 @@ def _setup_interactive_logging(project_root: Path) -> None:
     logs to a file keeps the UI clean while preserving them for debugging. Called
     once, before load_project_context (which may emit WARNING records), so the
     file handler is in place before the first log call.
+
+    Deliberately does NOT import litellm (perf: ``import litellm`` costs
+    ~1.5s and this runs on the startup path, before the input box renders).
+    litellm's own log routing + ``suppress_debug_info`` is applied lazily at
+    the FIRST real litellm use — see ``reyn.llm.litellm_bootstrap.
+    ensure_litellm_ready`` — which reads the file handler this function
+    installs (so the routing still works whenever litellm is first touched).
     """
     log_dir = project_root / ".reyn" / "logs"
     log_dir.mkdir(parents=True, exist_ok=True)
@@ -264,77 +266,6 @@ def _setup_interactive_logging(project_root: Path) -> None:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
         force=True,  # safe: the interactive path has no prior logging setup
     )
-    # litellm prints its own banners ("Give Feedback / Get Help", "LiteLLM.Info")
-    # directly to stderr on a provider error — NOT via logging, so the file
-    # redirect above does not catch them. Suppress them so a provider error
-    # surfaces as just our clean classified message, not a wall of litellm noise.
-    with _litellm_import_logs_to_file():
-        try:
-            import litellm
-            litellm.suppress_debug_info = True
-        except Exception:  # noqa: BLE001 — best-effort; never block startup on this
-            pass
-
-
-_LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
-
-
-@contextlib.contextmanager
-def _litellm_import_logs_to_file() -> "Iterator[None]":
-    """Route litellm's own loggers to reyn's log file instead of stderr.
-
-    litellm's ``_logging.py`` module attaches a fresh ``logging.StreamHandler()``
-    (→ stderr, by construction) to each of ``"LiteLLM"`` / ``"LiteLLM Router"`` /
-    ``"LiteLLM Proxy"`` **unconditionally at import time** (module-level code,
-    not gated on whether the logger already has a handler) — the first
-    ``import litellm`` anywhere in the process attaches it, which for the
-    interactive CUI happens inside this context manager's ``with`` body.
-    Because the attach is unconditional, merely pre-configuring these loggers
-    *before* import does not stop litellm from ALSO adding its own console
-    handler — it would just add a second one. So the console redirect has to
-    intercept handler *construction* itself: for the duration of the
-    ``import litellm`` this swaps in a ``logging.StreamHandler`` subclass
-    whose default stream is reyn's log file instead of stderr, so every
-    StreamHandler litellm builds at import time — including the one behind
-    the cost-map-fetch-failure warning
-    ``litellm.litellm_core_utils.get_model_cost_map`` emits synchronously
-    during import — writes to the file, not the console.
-
-    On exit, the real ``StreamHandler`` class is restored and the three
-    loggers are stripped down to file-routed only: their handler lists are
-    cleared and ``propagate`` is set ``True``, so every *runtime* litellm log
-    (not just the import-time one) flows to the root logger's file handler
-    exactly once, with no leftover console sink. This also makes the
-    context manager safe to use when litellm was already imported earlier in
-    the process (e.g. by an unrelated import elsewhere) — the patch during
-    ``import litellm`` becomes a no-op (module cache hit, nothing re-runs),
-    but the handler-strip on exit still redirects it.
-    """
-    root_handlers = logging.getLogger().handlers
-    file_stream = root_handlers[0].stream if root_handlers else None
-    if file_stream is None:
-        # No file handler in place (shouldn't happen after basicConfig) — do
-        # not patch anything, so litellm's normal stderr behavior applies.
-        yield
-        return
-
-    original_stream_handler = logging.StreamHandler
-
-    class _FileRoutedStreamHandler(logging.StreamHandler):
-        """``StreamHandler`` that defaults to reyn's log file, not stderr."""
-
-        def __init__(self, stream: object = None) -> None:
-            super().__init__(stream=file_stream if stream is None else stream)
-
-    logging.StreamHandler = _FileRoutedStreamHandler  # type: ignore[misc]
-    try:
-        yield
-    finally:
-        logging.StreamHandler = original_stream_handler  # type: ignore[misc]
-        for name in _LITELLM_LOGGER_NAMES:
-            logger = logging.getLogger(name)
-            logger.handlers.clear()
-            logger.propagate = True
 
 
 def _run_remote(

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -1,0 +1,128 @@
+"""Single chokepoint for the first real ``import litellm`` in a process.
+
+``litellm``'s own package init pulls in a huge module tree (~1.5s cold-import
+cost). Every reyn call site that touches litellm does so lazily, inside a
+function — see ``reyn/__init__.py`` for the full inventory + the #2928
+``LITELLM_LOCAL_*`` env-var defaults that must be set before ANY of them run.
+This module adds the SECOND piece: routing litellm's own console log output
+(StreamHandlers it attaches to its "LiteLLM" / "LiteLLM Router" / "LiteLLM
+Proxy" loggers, unconditionally, at import time) to reyn's log file instead of
+stderr, so an interactive CUI session's terminal is never corrupted by a
+litellm banner or warning.
+
+``ensure_litellm_ready()`` is the ONE place that should perform this
+first-import work. Callers that need the ``litellm`` module still do their own
+``import litellm`` afterward (cheap — Python caches the module), but calling
+``ensure_litellm_ready()`` first guarantees the log-routing patch is active
+for whichever call site happens to import litellm first in a given process.
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+_LITELLM_LOGGER_NAMES = ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy")
+
+_litellm_ready = False
+
+
+@contextlib.contextmanager
+def _litellm_import_logs_to_file() -> "Iterator[None]":
+    """Route litellm's own loggers to reyn's log file instead of stderr.
+
+    litellm's ``_logging.py`` module attaches a fresh ``logging.StreamHandler()``
+    (→ stderr, by construction) to each of ``"LiteLLM"`` / ``"LiteLLM Router"`` /
+    ``"LiteLLM Proxy"`` **unconditionally at import time** (module-level code,
+    not gated on whether the logger already has a handler) — the first
+    ``import litellm`` anywhere in the process attaches it, which happens
+    inside this context manager's ``with`` body when routed through
+    ``ensure_litellm_ready``. Because the attach is unconditional, merely
+    pre-configuring these loggers *before* import does not stop litellm from
+    ALSO adding its own console handler — it would just add a second one. So
+    the console redirect has to intercept handler *construction* itself: for
+    the duration of the ``import litellm`` this swaps in a
+    ``logging.StreamHandler`` subclass whose default stream is reyn's log file
+    instead of stderr, so every StreamHandler litellm builds at import time —
+    including the one behind the cost-map-fetch-failure warning
+    ``litellm.litellm_core_utils.get_model_cost_map`` emits synchronously
+    during import — writes to the file, not the console.
+
+    On exit, the real ``StreamHandler`` class is restored and the three
+    loggers are stripped down to file-routed only: their handler lists are
+    cleared and ``propagate`` is set ``True``, so every *runtime* litellm log
+    (not just the import-time one) flows to the root logger's file handler
+    exactly once, with no leftover console sink. This also makes the
+    context manager safe to use when litellm was already imported earlier in
+    the process (e.g. by an unrelated call site's own lazy import racing ahead
+    of ``ensure_litellm_ready``) — the patch during ``import litellm`` becomes
+    a no-op (module cache hit, nothing re-runs), but the handler-strip on exit
+    still redirects it.
+    """
+    # Find the reyn.log FileHandler the interactive startup installed. Unlike
+    # the pre-lazy-load version — which ran only immediately after
+    # ``basicConfig(filename=...)`` so ``handlers[0]`` was guaranteed a
+    # FileHandler — this chokepoint is now reached from ANY first-litellm-use
+    # call site (interactive CUI, non-interactive run, tests under pytest's
+    # live-logging null handler). So scan for a FileHandler explicitly rather
+    # than assuming ``handlers[0]`` is stream-backed (a non-stream handler at
+    # [0] would otherwise ``AttributeError`` on ``.stream``).
+    file_stream = None
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.FileHandler):
+            file_stream = handler.stream
+            break
+    if file_stream is None:
+        # No file handler in place (non-interactive / --cui / no prior
+        # basicConfig call) — do not patch anything, so litellm's normal
+        # stderr behavior applies.
+        yield
+        return
+
+    original_stream_handler = logging.StreamHandler
+
+    class _FileRoutedStreamHandler(logging.StreamHandler):
+        """``StreamHandler`` that defaults to reyn's log file, not stderr."""
+
+        def __init__(self, stream: object = None) -> None:
+            super().__init__(stream=file_stream if stream is None else stream)
+
+    logging.StreamHandler = _FileRoutedStreamHandler  # type: ignore[misc]
+    try:
+        yield
+    finally:
+        logging.StreamHandler = original_stream_handler  # type: ignore[misc]
+        for name in _LITELLM_LOGGER_NAMES:
+            logger = logging.getLogger(name)
+            logger.handlers.clear()
+            logger.propagate = True
+
+
+def ensure_litellm_ready() -> None:
+    """Idempotent first-touch chokepoint: import litellm + apply its one-time setup.
+
+    Runs at most once per process. Wraps the (possibly first-ever) ``import
+    litellm`` in ``_litellm_import_logs_to_file`` (preserving the interactive
+    CUI's clean-terminal guarantee — #2929) and sets
+    ``litellm.suppress_debug_info = True`` (litellm prints "Give Feedback /
+    Get Help" banners straight to stderr on a provider error, NOT via
+    ``logging``, so the file redirect above doesn't catch them; this
+    suppresses them instead).
+
+    Call this before any bare ``import litellm`` in a lazy call site that
+    might be the first one to run in a given process — it costs one boolean
+    check on every call after the first, so it is cheap to call defensively.
+    """
+    global _litellm_ready
+    if _litellm_ready:
+        return
+    _litellm_ready = True
+    with _litellm_import_logs_to_file():
+        try:
+            import litellm
+            litellm.suppress_debug_info = True
+        except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
+            pass

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -17,6 +17,7 @@ import httpx
 logger = logging.getLogger(__name__)
 from reyn.llm.credentials import check_model_credentials
 from reyn.llm.json_parse import loads_lenient
+from reyn.llm.litellm_bootstrap import ensure_litellm_ready
 from reyn.llm.model_resolver import ModelSpec
 from reyn.llm.pricing import TokenUsage, estimate_cost
 from reyn.prompt.loop_control import G12_SIGNAL_ERROR_TEXT as _G12_SIGNAL_ERROR_TEXT
@@ -1556,6 +1557,11 @@ async def recorded_acompletion(
     Replay-safe: the call still bottoms out at ``litellm.acompletion``, which
     ``LLMReplay`` monkeypatches.
     """
+    # perf: litellm's own import is ~1.5s and is kept off the chat startup
+    # path (input box renders before any LLM use). ``ensure_litellm_ready``
+    # is the single chokepoint that applies the #2929 console-log routing +
+    # ``suppress_debug_info`` the first time ANY call site touches litellm.
+    ensure_litellm_ready()
     import litellm
 
     # #1652/②: canonical litellm mechanism for reasoning continuity across tool

--- a/src/reyn/llm/model_budget.py
+++ b/src/reyn/llm/model_budget.py
@@ -43,6 +43,11 @@ def _lookup_max_input(model: str) -> "int | None":
     (e.g. provider-prefix-strip, #1162).
     """
     try:
+        # perf: route through the single litellm-first-touch chokepoint (see
+        # litellm_bootstrap module docstring) so #2929's console-log routing
+        # is active regardless of which call site touches litellm first.
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        ensure_litellm_ready()
         import litellm
         info = litellm.get_model_info(model)
         max_input = info.get("max_input_tokens")

--- a/src/reyn/llm/model_cost_rate.py
+++ b/src/reyn/llm/model_cost_rate.py
@@ -28,6 +28,12 @@ def get_input_cost_per_1m_usd(model: str) -> float | None:
     an unknown cost as "no warning needed" rather than crashing the session.
     """
     try:
+        # perf: route through the single litellm-first-touch chokepoint so the
+        # #2929 console-log routing is active regardless of whether this
+        # session-start check or a later LLM call is the first real litellm
+        # touch in the process (see litellm_bootstrap module docstring).
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        ensure_litellm_ready()
         import litellm
         entry = litellm.model_cost.get(model, {})
         per_token = entry.get("input_cost_per_token")

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -98,6 +98,13 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     if cache_key in _token_cache:
         return _token_cache[cache_key]
     try:
+        # perf/log-routing chokepoint: per-turn token sizing runs BEFORE the
+        # first completion, so this can be the FIRST litellm import in the
+        # process — funnel it through ensure_litellm_ready() so litellm's
+        # import-time console log routing (#2929) wraps it too (idempotent;
+        # cheap on 2nd+ call).
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+        ensure_litellm_ready()
         import litellm
         m = model or "gpt-3.5-turbo"
         count = litellm.token_counter(model=m, text=text or "")

--- a/tests/test_inline_interactive_logging.py
+++ b/tests/test_inline_interactive_logging.py
@@ -1,19 +1,20 @@
 """Tier 2: interactive CUI routes logging to a file (no traceback leak into UI).
 
 The inline CUI owns the terminal; a caught-error traceback logged via
-logger.exception (or a litellm banner) must NOT print into the live chat region.
-`_setup_interactive_logging` redirects the root logger to .reyn/logs/reyn.log and
-quiets litellm's direct banners. Global logging/litellm state is saved+restored
-so the assertion does not leak into the rest of the suite.
+logger.exception must NOT print into the live chat region.
+`_setup_interactive_logging` redirects the root logger to .reyn/logs/reyn.log.
+Global logging state is saved+restored so the assertion does not leak into the
+rest of the suite.
+
+perf (lazy-load litellm off the chat startup path): `_setup_interactive_logging`
+no longer imports litellm — see `test_litellm_lazy_load.py` for the
+sys.modules-clean-at-startup proof and the moved #2929 log-routing tests
+(now targeting `reyn.llm.litellm_bootstrap.ensure_litellm_ready`, the first-
+real-litellm-use chokepoint).
 """
 from __future__ import annotations
 
 import logging
-import os
-import subprocess
-import sys
-import textwrap
-from pathlib import Path
 
 from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
 
@@ -35,108 +36,3 @@ def test_interactive_logging_redirects_root_logger_to_file(tmp_path) -> None:
     finally:
         root.handlers[:] = saved_handlers
         root.setLevel(saved_level)
-
-
-def test_interactive_logging_quiets_litellm_banners(tmp_path) -> None:
-    """Tier 2: litellm's direct stderr banners are suppressed for the CUI."""
-    import litellm
-    root = logging.getLogger()
-    saved_handlers, saved_level = root.handlers[:], root.level
-    saved_suppress = getattr(litellm, "suppress_debug_info", False)
-    try:
-        _setup_interactive_logging(tmp_path)
-        assert litellm.suppress_debug_info is True
-    finally:
-        root.handlers[:] = saved_handlers
-        root.setLevel(saved_level)
-        litellm.suppress_debug_info = saved_suppress
-
-
-def test_interactive_logging_routes_litellm_logger_to_file_not_console(
-    tmp_path,
-) -> None:
-    """Tier 2: litellm's "LiteLLM" logger has no console handler after setup —
-    its own module-level ``StreamHandler`` (attached at ``import litellm`` time,
-    which already ran earlier in this test process) is stripped, and a runtime
-    warning it emits lands in reyn.log via root-logger propagation instead.
-    FALSIFY: without `_litellm_import_logs_to_file`'s exit-time strip, the
-    "LiteLLM" logger keeps its own StreamHandler (→ stderr) alongside/instead of
-    reaching the file, so this assertion would fail.
-    """
-    import litellm  # noqa: F401 — ensures the "LiteLLM" logger + its handler exist
-
-    root = logging.getLogger()
-    litellm_logger = logging.getLogger("LiteLLM")
-    saved_root_handlers, saved_root_level = root.handlers[:], root.level
-    saved_litellm_handlers = litellm_logger.handlers[:]
-    saved_litellm_propagate = litellm_logger.propagate
-    try:
-        _setup_interactive_logging(tmp_path)
-        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
-
-        # No leftover console (StreamHandler) sink on litellm's own logger.
-        assert not any(
-            isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
-            for h in litellm_logger.handlers
-        )
-        assert litellm_logger.propagate is True
-
-        litellm_logger.warning("runtime-marker-9a1b-not-a-mock")
-        for h in root.handlers:
-            h.flush()
-        assert "runtime-marker-9a1b-not-a-mock" in log_file.read_text()
-    finally:
-        root.handlers[:] = saved_root_handlers
-        root.setLevel(saved_root_level)
-        litellm_logger.handlers[:] = saved_litellm_handlers
-        litellm_logger.propagate = saved_litellm_propagate
-
-
-def test_interactive_logging_routes_litellm_import_time_warning_to_file(
-    tmp_path,
-) -> None:
-    """Tier 2: litellm's cost-map-fetch-failure warning, emitted synchronously
-    *during* ``import litellm`` (not a runtime call reyn controls, so exercised
-    via a real subprocess), lands in reyn.log and NOT on stderr.
-
-    Forces the fetch-failure path explicitly (overrides the #2928
-    ``LITELLM_LOCAL_MODEL_COST_MAP`` setdefault so the remote fetch is
-    attempted) against an unreachable URL, so the warning is guaranteed to
-    fire — this is the decisive evidence for the import-time handler-
-    construction patch in `_litellm_import_logs_to_file`, independent of
-    whether the #2928 env var happens to skip the fetch entirely on a given
-    run. FALSIFY: without the patch, litellm's own StreamHandler prints this
-    warning straight to stderr — captured via a real subprocess, no mocks.
-    """
-    project_root = tmp_path
-    script = textwrap.dedent(
-        """
-        import os
-        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
-        os.environ["LITELLM_MODEL_COST_MAP_URL"] = "http://127.0.0.1:1/unreachable.json"
-
-        from pathlib import Path
-        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
-
-        _setup_interactive_logging(Path(%r))
-        """
-        % str(project_root)
-    )
-    # This test's own `src/` (not whatever path an editable install's
-    # site-packages .pth happens to point at — e.g. a sibling git worktree's
-    # checkout) must win on the child's sys.path, so the subprocess exercises
-    # THIS checkout's `_setup_interactive_logging`/`_litellm_import_logs_to_file`.
-    src_dir = Path(__file__).resolve().parents[1] / "src"
-    env = {**os.environ, "PYTHONPATH": str(src_dir)}
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        timeout=30,
-        env=env,
-    )
-    assert result.returncode == 0, result.stderr
-    log_file = project_root / ".reyn" / "logs" / "reyn.log"
-    log_text = log_file.read_text()
-    assert "Failed to fetch remote model cost map" in log_text
-    assert "Failed to fetch remote model cost map" not in result.stderr

--- a/tests/test_litellm_lazy_load.py
+++ b/tests/test_litellm_lazy_load.py
@@ -226,6 +226,50 @@ def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path) -> None:
     assert "Failed to fetch remote model cost map" not in result.stderr
 
 
+def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path) -> None:
+    """Tier 2: chokepoint-completeness — when a NON-recorded_acompletion litellm
+    call site is the FIRST to import litellm, the import-time cost-map-fetch
+    warning still lands in reyn.log, NOT stderr.
+
+    Exercises a genuine *sibling* first-import path: ``compaction.engine.
+    estimate_tokens`` (per-turn token sizing runs before the first completion,
+    so it can be the process's first ``import litellm``) — one of the four
+    sibling sites now wired to ``ensure_litellm_ready``. It never calls
+    ``recorded_acompletion``, so it proves the routing does not depend on the
+    LLM-call funnel.
+
+    FALSIFY: without the ``ensure_litellm_ready()`` call newly added at the
+    sibling site, this path's bare ``import litellm`` attaches litellm's own
+    stderr StreamHandler and the import-time warning leaks to the console —
+    the assertion `not in result.stderr` would fail. (Confirmed by removing
+    the wire and re-running: the warning appears on stderr.)
+    """
+    project_root = tmp_path
+    script = f"""
+        import os, sys
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+        os.environ["LITELLM_MODEL_COST_MAP_URL"] = "http://127.0.0.1:1/unreachable.json"
+
+        from pathlib import Path
+        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+        from reyn.services.compaction.engine import estimate_tokens
+
+        _setup_interactive_logging(Path({str(project_root)!r}))
+        assert "litellm" not in sys.modules, "litellm imported before the sibling call"
+        # SIBLING-FIRST: the very first litellm import in this process happens
+        # inside estimate_tokens (via its ensure_litellm_ready wire), NOT via
+        # recorded_acompletion / ensure_litellm_ready called directly.
+        estimate_tokens("some text to size", "gpt-3.5-turbo")
+        assert "litellm" in sys.modules, "sibling call did not import litellm"
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    log_file = project_root / ".reyn" / "logs" / "reyn.log"
+    log_text = log_file.read_text()
+    assert "Failed to fetch remote model cost map" in log_text
+    assert "Failed to fetch remote model cost map" not in result.stderr
+
+
 def test_measured_startup_latency_delta_from_deferring_litellm() -> None:
     """Tier 2: measures the actual latency delta the perf fix targets — the
     startup-path work (importing `reyn.interfaces.cli.commands.chat` +

--- a/tests/test_litellm_lazy_load.py
+++ b/tests/test_litellm_lazy_load.py
@@ -1,0 +1,270 @@
+"""Tier 2: litellm import is off the chat startup path (input-box perf, #2929 moved).
+
+``import litellm`` costs ~1.5s (its own huge module tree) and used to run
+eagerly inside ``_setup_interactive_logging`` — on the interactive chat
+startup path, BEFORE the input box renders. That eager import is removed;
+litellm now imports lazily on first real use, via the single chokepoint
+``reyn.llm.litellm_bootstrap.ensure_litellm_ready`` (called from
+``recorded_acompletion`` — the #1190 single LLM-call funnel — and from the
+other lazy litellm call sites that can plausibly run first in a session,
+e.g. the session-start cost-warn check).
+
+These tests exercise real subprocesses (not mocks) so the ``sys.modules``
+state and the log-routing behavior are the actual process-level facts, not
+an in-process assumption that could be contaminated by an earlier test's
+``import litellm``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+
+
+def _run(script: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": str(SRC_DIR)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def test_setup_interactive_logging_does_not_import_litellm(tmp_path) -> None:
+    """Tier 2: `_setup_interactive_logging` — the chat startup-path call — leaves
+    litellm out of `sys.modules`.
+
+    FALSIFY: before this change (eager `import litellm` inside the function),
+    `"litellm" in sys.modules` would be True immediately after the call.
+    """
+    script = f"""
+        import sys
+        from pathlib import Path
+        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+
+        _setup_interactive_logging(Path({str(tmp_path)!r}))
+        assert "litellm" not in sys.modules, "litellm was imported on the startup path"
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_chat_startup_path_clean_of_litellm_at_input_box_point(tmp_path) -> None:
+    """Tier 2: the full chat.py startup-path import (module import + the
+    startup-logging call, i.e. everything that runs before `run_repl`/the
+    input box) never touches litellm.
+
+    Decisive: imports `reyn.interfaces.cli.commands.chat` itself (module-level
+    imports run) AND calls `_setup_interactive_logging`, then asserts
+    `sys.modules` is clean. This is the "at input-box render" checkpoint the
+    perf fix targets — everything up to (not including) `run_repl` must never
+    have pulled litellm in.
+    """
+    script = f"""
+        import sys
+        from pathlib import Path
+        import reyn.interfaces.cli.commands.chat as chat_mod
+
+        chat_mod._setup_interactive_logging(Path({str(tmp_path)!r}))
+        assert "litellm" not in sys.modules, sorted(
+            m for m in sys.modules if "litellm" in m
+        )
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_ensure_litellm_ready_imports_litellm_and_is_idempotent(tmp_path) -> None:
+    """Tier 2: `ensure_litellm_ready` (the first-real-use chokepoint) imports
+    litellm exactly once, is safe to call repeatedly, and sets
+    `suppress_debug_info`.
+    """
+    script = """
+        import sys
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+        assert "litellm" not in sys.modules
+        ensure_litellm_ready()
+        ensure_litellm_ready()  # idempotent — must not re-import or raise
+        import litellm
+        assert litellm.suppress_debug_info is True
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_first_use_quiets_litellm_banners(tmp_path) -> None:
+    """Tier 2: #2929 moved — `ensure_litellm_ready`, called at first real
+    litellm use, still sets `suppress_debug_info` (litellm's direct-to-stderr
+    banners on a provider error are suppressed for the CUI)."""
+    import logging
+
+    import litellm
+
+    from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+    from reyn.llm import litellm_bootstrap
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    root = logging.getLogger()
+    saved_handlers, saved_level = root.handlers[:], root.level
+    saved_suppress = getattr(litellm, "suppress_debug_info", False)
+    # Reset the process-global one-shot guard so `ensure_litellm_ready` actually
+    # runs (an earlier suite test may have tripped it); simulate the pre-first-
+    # use state by clearing suppress_debug_info first.
+    saved_ready = litellm_bootstrap._litellm_ready
+    litellm_bootstrap._litellm_ready = False
+    litellm.suppress_debug_info = False
+    try:
+        _setup_interactive_logging(tmp_path)  # startup: file handler in place
+        ensure_litellm_ready()  # first real use
+        assert litellm.suppress_debug_info is True
+    finally:
+        root.handlers[:] = saved_handlers
+        root.setLevel(saved_level)
+        litellm.suppress_debug_info = saved_suppress
+        litellm_bootstrap._litellm_ready = saved_ready
+
+
+def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
+    """Tier 2: #2929 moved — after `_setup_interactive_logging` (startup, file
+    handler installed) followed by `ensure_litellm_ready` (first real use),
+    the "LiteLLM" logger has no console handler and routes to the file.
+
+    FALSIFY: without `ensure_litellm_ready`'s exit-time strip, the "LiteLLM"
+    logger keeps its own StreamHandler (→ stderr) instead of reaching the file.
+    """
+    import logging
+
+    import litellm  # noqa: F401 — ensures the "LiteLLM" logger + its handler exist
+
+    from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+    from reyn.llm import litellm_bootstrap
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    root = logging.getLogger()
+    litellm_logger = logging.getLogger("LiteLLM")
+    saved_root_handlers, saved_root_level = root.handlers[:], root.level
+    saved_litellm_handlers = litellm_logger.handlers[:]
+    saved_litellm_propagate = litellm_logger.propagate
+    # `ensure_litellm_ready` is process-global idempotent — an earlier suite
+    # test may have already tripped its one-shot guard, which would make the
+    # call below a no-op and skip the handler-strip we are asserting on. Reset
+    # the guard (a process singleton, not private assertion state) + re-attach
+    # a bare console StreamHandler to litellm's logger to reconstruct the
+    # pre-first-use state this test exercises.
+    saved_ready = litellm_bootstrap._litellm_ready
+    litellm_bootstrap._litellm_ready = False
+    litellm_logger.addHandler(logging.StreamHandler())
+    try:
+        _setup_interactive_logging(tmp_path)
+        ensure_litellm_ready()
+        log_file = tmp_path / ".reyn" / "logs" / "reyn.log"
+
+        assert not any(
+            isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+            for h in litellm_logger.handlers
+        )
+        assert litellm_logger.propagate is True
+
+        litellm_logger.warning("runtime-marker-9a1b-not-a-mock")
+        for h in root.handlers:
+            h.flush()
+        assert "runtime-marker-9a1b-not-a-mock" in log_file.read_text()
+    finally:
+        root.handlers[:] = saved_root_handlers
+        root.setLevel(saved_root_level)
+        litellm_logger.handlers[:] = saved_litellm_handlers
+        litellm_logger.propagate = saved_litellm_propagate
+        litellm_bootstrap._litellm_ready = saved_ready
+
+
+def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path) -> None:
+    """Tier 2: litellm's cost-map-fetch-failure warning, emitted synchronously
+    *during* ``import litellm`` (not a runtime call reyn controls, so exercised
+    via a real subprocess), lands in reyn.log and NOT on stderr — now via the
+    first-real-use chokepoint instead of the (removed) startup-path import.
+
+    Forces the fetch-failure path explicitly (overrides the #2928
+    ``LITELLM_LOCAL_MODEL_COST_MAP`` setdefault so the remote fetch is
+    attempted) against an unreachable URL, so the warning is guaranteed to
+    fire. FALSIFY: without the patch, litellm's own StreamHandler prints this
+    warning straight to stderr.
+    """
+    project_root = tmp_path
+    script = f"""
+        import os
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "False"
+        os.environ["LITELLM_MODEL_COST_MAP_URL"] = "http://127.0.0.1:1/unreachable.json"
+
+        from pathlib import Path
+        from reyn.interfaces.cli.commands.chat import _setup_interactive_logging
+        from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+        _setup_interactive_logging(Path({str(project_root)!r}))
+        assert "litellm" not in __import__("sys").modules
+        ensure_litellm_ready()  # first real litellm use -> import happens here
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    log_file = project_root / ".reyn" / "logs" / "reyn.log"
+    log_text = log_file.read_text()
+    assert "Failed to fetch remote model cost map" in log_text
+    assert "Failed to fetch remote model cost map" not in result.stderr
+
+
+def test_measured_startup_latency_delta_from_deferring_litellm() -> None:
+    """Tier 2: measures the actual latency delta the perf fix targets — the
+    startup-path work (importing `reyn.interfaces.cli.commands.chat` +
+    calling `_setup_interactive_logging`) is fast, while a bare
+    `import litellm` remains the ~1.5s cost, now off that path.
+
+    Not a strict pinned-timing assertion (no algorithm-level behavior is
+    pinned) — reports the measured delta and asserts only the qualitative,
+    load-bearing claim: the startup path is dramatically cheaper than a raw
+    litellm import, which is the whole point of deferring it.
+    """
+    startup_script = """
+        import time
+        t = time.perf_counter()
+        from pathlib import Path
+        import reyn.interfaces.cli.commands.chat as chat_mod
+        chat_mod._setup_interactive_logging(Path("/tmp"))
+        print(time.perf_counter() - t)
+        """
+    litellm_script = """
+        import time
+        t = time.perf_counter()
+        import litellm
+        print(time.perf_counter() - t)
+        """
+    startup_result = _run(startup_script)
+    litellm_result = _run(litellm_script)
+    assert startup_result.returncode == 0, startup_result.stderr
+    assert litellm_result.returncode == 0, litellm_result.stderr
+
+    startup_s = float(startup_result.stdout.strip().splitlines()[-1])
+    litellm_s = float(litellm_result.stdout.strip().splitlines()[-1])
+
+    # The startup path must be substantially cheaper than a bare litellm
+    # import (this is the whole perf claim) — a generous 3x margin avoids
+    # flaking on a loaded CI box while still falsifying a regression that
+    # re-adds the eager import (which would make startup_s >= litellm_s).
+    assert startup_s * 3 < litellm_s, (
+        f"startup path ({startup_s:.3f}s) is not substantially cheaper than "
+        f"a bare litellm import ({litellm_s:.3f}s) — litellm may be back on "
+        f"the startup path"
+    )


### PR DESCRIPTION
**[lead-coder]** — Defers litellm's ~1.5s import off the interactive chat startup critical path so the input box renders first; litellm imports lazily on the first real LLM use.

## Problem
`import litellm` costs ~1.5s (its huge module tree) and ran **eagerly** inside `_setup_interactive_logging` — which is called on the interactive chat startup path **before the input box renders**. The import was there only to (a) set `litellm.suppress_debug_info = True` and (b) apply the #2929 console-log routing (`_litellm_import_logs_to_file` CM → route litellm's StreamHandlers to `.reyn/logs/reyn.log`). The user waited ~1.5s longer than necessary for the input box.

## Fix
- **New chokepoint** `reyn.llm.litellm_bootstrap.ensure_litellm_ready()` — the single, idempotent, first-litellm-touch site. It runs the #2929 console-log-routing CM + `import litellm` + `suppress_debug_info = True` **once** per process.
- Routed through from `recorded_acompletion` (the #1190 single LLM-call funnel) and from the other lazy litellm call sites that can plausibly run first in a session (`model_cost_rate`, `model_budget`), so whichever touches litellm first, the #2929 routing wraps that import.
- `_setup_interactive_logging` keeps the root→file logging (`basicConfig` → reyn.log) at startup but **no longer imports litellm**.
- **#2929 preserved (moved, not removed):** litellm's own StreamHandlers now route to reyn.log at first-use instead of startup. The routing CM (`_litellm_import_logs_to_file`) moved verbatim into `litellm_bootstrap`.
- **Robustness fix** surfaced while testing: the moved CM previously assumed root `handlers[0]` is stream-backed (safe only because it ran right after `basicConfig(filename=...)`). Now it can be reached from any first-litellm-use context (non-interactive run, tests under pytest's live-logging null handler), so it scans for a `FileHandler` explicitly instead of `handlers[0].stream` (which would `AttributeError` on a non-stream handler). Only patches when a reyn.log file handler is present; otherwise no-op (litellm's normal stderr behavior).
- **#2928 env-vars in `__init__.py` untouched** (`LITELLM_LOCAL_MODEL_COST_MAP` etc. — they run on `import reyn`, before any litellm import regardless).

## Startup model-validation trade-off
`model_resolver.py:35`'s `reasoning_effort` validation is a **pure string/set membership check** (`VALID_REASONING_EFFORTS`) — it does NOT import litellm. It stays at config-load fail-fast, unaffected. The other litellm-touching "early" checks (session-start `model_cost_warn`, context-build `model_budget`) now route through `ensure_litellm_ready` — they still surface at the same point in the session lifecycle, just triggering the litellm import lazily there instead of at input-box render. No early error-surfacing is lost.

## Verification
- **sys.modules clean at input box** (decisive, real subprocess): after `import reyn.interfaces.cli.commands.chat` + `_setup_interactive_logging(...)` — i.e. everything up to (not including) `run_repl`/the input box — `"litellm" not in sys.modules`. FALSIFY: re-adding the eager import makes it present.
- **First-use log-routing (#2929) preserved:** `ensure_litellm_ready()` still strips litellm's console StreamHandlers to file-routed-only, and the import-time cost-map-fetch-failure warning lands in reyn.log, NOT stderr (real subprocess with forced remote-fetch failure).
- **Measured latency:** startup path (chat import + `_setup_interactive_logging`) ≈ **0.22s** vs a bare `import litellm` ≈ **1.46s** → **~1.24-1.5s** off the input-box render path.

## Test plan
- [x] `test_litellm_lazy_load.py` — sys.modules-clean-at-input-box, chokepoint idempotency, first-use banner-suppress + logger-routing + import-time warning to file, measured latency delta (all pass).
- [x] `test_inline_interactive_logging.py` — root→file logging still works (litellm-import assertions moved out).
- [x] 4 gates local: ruff (pass), tier audit (pass, 0 Tier-4), module docstrings (pass), pytest full suite (running — will confirm count in a comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)