### PR TITLE
feat: cache-aware cost total + prompt/cache/completion breakdown in cost panel

### DIFF
--- a/src/reyn/llm/__init__.py
+++ b/src/reyn/llm/__init__.py
@@ -1,10 +1,10 @@
 """llm — LLM client, pricing, and model resolution."""
 from .llm import proxy_kwargs, run_async, shutdown_logging
 from .model_resolver import ModelResolver
-from .pricing import TokenUsage, estimate_cost
+from .pricing import CostBreakdown, TokenUsage, estimate_cost, estimate_cost_breakdown
 
 __all__ = [
     "run_async", "proxy_kwargs", "shutdown_logging",
-    "TokenUsage", "estimate_cost",
+    "TokenUsage", "estimate_cost", "CostBreakdown", "estimate_cost_breakdown",
     "ModelResolver",
 ]

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -83,12 +83,51 @@ class TokenUsage:
         )
 
 
+def _usage_object_for(usage: TokenUsage):
+    """Build a ``litellm.types.utils.Usage`` carrying the cache breakdown so
+    ``litellm.cost_per_token`` prices cached tokens at the cache rate instead
+    of the full input rate.
+
+    Provider-convention note: reyn's ``TokenUsage.prompt_tokens`` ALREADY
+    INCLUDES ``cached_tokens`` and ``cache_creation_tokens`` as subsets — this
+    is litellm's own normalized ``response.usage.prompt_tokens`` value (see
+    ``_extract_usage`` in ``llm.py``; litellm's Anthropic transformation adds
+    both cache figures into ``prompt_tokens`` before returning the response
+    object, matching the OpenAI convention where ``prompt_tokens_details.
+    cached_tokens`` is a subset of ``prompt_tokens``). Passing the breakdown
+    via ``prompt_tokens_details`` (OpenAI-style) rather than the top-level
+    ``cache_read_input_tokens`` / ``cache_creation_input_tokens`` kwargs is
+    deliberate: litellm's ``cost_per_token`` treats the latter as "Anthropic
+    style" (prompt_tokens EXCLUDES cache) and RE-ADDS them to prompt_tokens
+    before costing — which would double-count here, since our prompt_tokens
+    already includes them. The ``prompt_tokens_details`` path takes
+    prompt_tokens at face value and subtracts cache tokens internally
+    (``text_tokens = prompt_tokens - cache_hit - cache_creation``), which is
+    the correct convention for reyn's already-normalized TokenUsage.
+    """
+    from litellm.types.utils import Usage
+
+    return Usage(
+        prompt_tokens=usage.prompt_tokens,
+        completion_tokens=usage.completion_tokens,
+        prompt_tokens_details={
+            "cached_tokens": usage.cached_tokens,
+            "cache_creation_tokens": usage.cache_creation_tokens,
+        },
+    )
+
+
 def estimate_cost(
     model: str,
     usage: TokenUsage,
 ) -> tuple[float | None, dict | None]:
     """
-    Estimate cost in USD using litellm's pricing database.
+    Estimate cost in USD using litellm's pricing database — cache-aware
+    (#cache-cost-accuracy): cached (cache-read) prompt tokens are priced at
+    the model's discounted cache-read rate and cache-creation (cache-write)
+    tokens at the cache-creation rate, not the full input rate, by passing
+    the cache breakdown to ``litellm.cost_per_token`` (see
+    ``_usage_object_for`` for the provider-convention this relies on).
 
     Returns (cost_usd, pricing_snapshot).
     pricing_snapshot records the per-token prices litellm used at this moment
@@ -115,8 +154,7 @@ def estimate_cost(
 
         prompt_cost, completion_cost = litellm.cost_per_token(
             model=model,
-            prompt_tokens=usage.prompt_tokens,
-            completion_tokens=usage.completion_tokens,
+            usage_object=_usage_object_for(usage),
         )
         total_cost = prompt_cost + completion_cost
 
@@ -142,3 +180,161 @@ def estimate_cost(
 
     except Exception:
         return None, None
+
+
+@dataclass
+class CostBreakdown:
+    """Cache-aware cost breakdown for one LLM call (or an aggregation across
+    many, via ``__add__`` / ``__iadd__``) — the 4 components the cost panel
+    is expected to render (#cache-cost-accuracy), plus the SAVINGS figures the
+    owner flagged as first-class for the panel's savings block.
+
+    ``prompt_cost`` covers only the NON-cached portion of the prompt (see
+    ``estimate_cost_breakdown`` for the exact token split). ``total_cost`` is
+    the sum of all 4 cost components — decisively pinned equal to
+    ``estimate_cost``'s litellm-derived total by the accuracy test
+    (components-sum-to-total invariant).
+
+    Savings surface (backend-only; no panel UI yet):
+      - ``cache_savings`` — how many USD the cached (cache-read) tokens saved
+        vs paying the full input rate for them:
+        ``cached_tokens × (input_rate − cache_read_rate)``. A dollar amount,
+        so it aggregates additively like the cost components.
+      - ``cache_hit_rate`` — token-level cache hit rate,
+        ``cached_tokens / prompt_tokens`` (0.0 when ``prompt_tokens`` is 0 —
+        divide-by-zero guarded). Derived from the aggregatable
+        ``prompt_tokens`` / ``cached_tokens`` counters so the ratio stays
+        correct across a multi-turn aggregation (summing per-turn ratios
+        would be wrong — summing the underlying token counts is not).
+    """
+    prompt_cost: float = 0.0
+    cache_read_cost: float = 0.0
+    cache_creation_cost: float = 0.0
+    completion_cost: float = 0.0
+    # Savings block inputs (aggregatable). ``cache_savings`` is a USD amount;
+    # ``prompt_tokens`` / ``cached_tokens`` back the derived ``cache_hit_rate``.
+    cache_savings: float = 0.0
+    prompt_tokens: int = 0
+    cached_tokens: int = 0
+
+    @property
+    def total_cost(self) -> float:
+        return (
+            self.prompt_cost
+            + self.cache_read_cost
+            + self.cache_creation_cost
+            + self.completion_cost
+        )
+
+    @property
+    def cache_hit_rate(self) -> float:
+        """Token-level cache hit rate ``cached_tokens / prompt_tokens``; 0.0
+        when ``prompt_tokens`` is 0 (divide-by-zero guard)."""
+        if self.prompt_tokens <= 0:
+            return 0.0
+        return self.cached_tokens / self.prompt_tokens
+
+    def __add__(self, other: "CostBreakdown") -> "CostBreakdown":
+        return CostBreakdown(
+            prompt_cost=self.prompt_cost + other.prompt_cost,
+            cache_read_cost=self.cache_read_cost + other.cache_read_cost,
+            cache_creation_cost=self.cache_creation_cost + other.cache_creation_cost,
+            completion_cost=self.completion_cost + other.completion_cost,
+            cache_savings=self.cache_savings + other.cache_savings,
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            cached_tokens=self.cached_tokens + other.cached_tokens,
+        )
+
+    def __iadd__(self, other: "CostBreakdown") -> "CostBreakdown":
+        self.prompt_cost += other.prompt_cost
+        self.cache_read_cost += other.cache_read_cost
+        self.cache_creation_cost += other.cache_creation_cost
+        self.completion_cost += other.completion_cost
+        self.cache_savings += other.cache_savings
+        self.prompt_tokens += other.prompt_tokens
+        self.cached_tokens += other.cached_tokens
+        return self
+
+    def to_dict(self) -> dict:
+        return {
+            "prompt_cost": self.prompt_cost,
+            "cache_read_cost": self.cache_read_cost,
+            "cache_creation_cost": self.cache_creation_cost,
+            "completion_cost": self.completion_cost,
+            "total_cost": self.total_cost,
+            "cache_savings": self.cache_savings,
+            "cache_hit_rate": self.cache_hit_rate,
+            "prompt_tokens": self.prompt_tokens,
+            "cached_tokens": self.cached_tokens,
+        }
+
+
+def estimate_cost_breakdown(
+    model: str,
+    usage: TokenUsage,
+) -> "CostBreakdown | None":
+    """Cache-aware cost BREAKDOWN into 4 components: prompt (non-cached input)
+    / cache-read (cache-hit discount) / cache-creation (cache-write surcharge)
+    / completion (output), plus the savings figures (``cache_savings`` USD +
+    ``cache_hit_rate``) for the panel's savings block. Data-only — no
+    rendering; the cost panel reads this to display a breakdown instead of
+    just the total.
+
+    Token-split convention (mirrors litellm's own ``generic_cost_per_token``,
+    verified empirically — see ``_usage_object_for``'s docstring for why):
+    ``TokenUsage.prompt_tokens`` already INCLUDES ``cached_tokens`` and
+    ``cache_creation_tokens`` as subsets, so the non-cached ("regular")
+    portion priced at the full input rate is
+    ``prompt_tokens - cached_tokens - cache_creation_tokens`` (floored at 0).
+
+    Cache-rate fallback: when a model has no explicit
+    ``cache_read_input_token_cost`` / ``cache_creation_input_token_cost``
+    entry, litellm itself defaults that rate to ``0.0`` (NOT the input rate —
+    verified against ``litellm.litellm_core_utils.llm_cost_calc.utils.
+    _get_cost_per_unit``'s ``default_value=0.0``); this function does the same
+    so the components-sum-to-total invariant holds against litellm's own
+    total for every model, cache-capable or not.
+
+    Note: does not replicate litellm's >200k-token TIERED pricing threshold
+    (rare for reyn's usage) — the accuracy test stays below that threshold.
+
+    Returns ``None`` for an unpriced/unknown model (mirrors ``estimate_cost``'s
+    None-sentinel — unknown ≠ free, #1829).
+    """
+    if usage.total_tokens == 0:
+        return CostBreakdown()
+
+    try:
+        import litellm
+
+        entry = litellm.model_cost.get(model)
+        if (not entry
+                or entry.get("input_cost_per_token") is None
+                or entry.get("output_cost_per_token") is None):
+            return None
+
+        input_rate = float(entry["input_cost_per_token"])
+        output_rate = float(entry["output_cost_per_token"])
+        cache_read_rate = float(entry.get("cache_read_input_token_cost") or 0.0)
+        cache_creation_rate = float(entry.get("cache_creation_input_token_cost") or 0.0)
+
+        regular_prompt_tokens = max(
+            usage.prompt_tokens - usage.cached_tokens - usage.cache_creation_tokens,
+            0,
+        )
+
+        # Savings: what the cached tokens would have cost at the full input
+        # rate MINUS what they actually cost at the cache-read rate.
+        cache_savings = usage.cached_tokens * (input_rate - cache_read_rate)
+
+        return CostBreakdown(
+            prompt_cost=regular_prompt_tokens * input_rate,
+            cache_read_cost=usage.cached_tokens * cache_read_rate,
+            cache_creation_cost=usage.cache_creation_tokens * cache_creation_rate,
+            completion_cost=usage.completion_tokens * output_rate,
+            cache_savings=cache_savings,
+            prompt_tokens=usage.prompt_tokens,
+            cached_tokens=usage.cached_tokens,
+        )
+    except Exception:
+        return None

--- a/tests/test_cache_aware_cost_breakdown.py
+++ b/tests/test_cache_aware_cost_breakdown.py
@@ -1,0 +1,263 @@
+"""Tier 2: cache-aware cost total + 4-component breakdown (#cache-cost-accuracy).
+
+reyn's cost accounting was cache-UNAWARE: ``estimate_cost`` called
+``litellm.cost_per_token(prompt_tokens=..., completion_tokens=...)`` without
+the cache breakdown, so cached (cache-read) prompt tokens were billed at the
+full input rate instead of the discounted cache-read rate. reyn already
+CAPTURED the cache tokens (``TokenUsage.cached_tokens`` / ``.cache_creation_
+tokens``, #1772) — they were just not used in the cost formula.
+
+This file pins:
+  1. ``estimate_cost`` now returns the cache-aware total (decisively lower
+     than the old naive total on a cached scenario — FALSIFYING the old
+     overcharge).
+  2. ``estimate_cost_breakdown`` returns the 4 components (prompt / cache-read
+     / cache-creation / completion) that SUM to the same cache-aware total
+     litellm itself computes (the components-sum-to-total invariant).
+  3. An unpriced/unknown model still returns ``None`` (no #1829 regression),
+     for both ``estimate_cost`` and ``estimate_cost_breakdown``.
+
+Provider-convention note pinned by these tests: ``TokenUsage.prompt_tokens``
+ALREADY INCLUDES ``cached_tokens`` + ``cache_creation_tokens`` as subsets
+(litellm's own Anthropic-transformation adds both cache figures into
+``response.usage.prompt_tokens`` before reyn ever sees it) — so the
+non-cached ("regular") portion priced at the full input rate is
+``prompt_tokens - cached_tokens - cache_creation_tokens``, not
+``prompt_tokens`` itself. See ``pricing.py``'s ``_usage_object_for`` /
+``estimate_cost_breakdown`` docstrings for the empirical verification this
+relies on (a real ``litellm.cost_per_token`` call, no mocks).
+
+Policy: no mocks — real litellm + real model_cost lookups; no private-state
+assertions; Tier line.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import (
+    CostBreakdown,
+    TokenUsage,
+    estimate_cost,
+    estimate_cost_breakdown,
+)
+
+# A real cache-capable Anthropic model (supports_prompt_caching=True, has
+# cache_read_input_token_cost / cache_creation_input_token_cost entries in
+# litellm.model_cost as of the pinned litellm version this repo vendors).
+_CACHE_MODEL = "claude-sonnet-4-5-20250929"
+
+
+def _epsilon_close(a: float, b: float, eps: float = 1e-9) -> bool:
+    return abs(a - b) < eps
+
+
+def test_cache_aware_total_prices_cached_tokens_at_cache_rate() -> None:
+    """Tier 2: cached tokens are billed at the cache-read rate, not the full
+    input rate — decisively lower total than the old (naive) formula.
+
+    FALSIFY the old path: the old formula was
+    ``litellm.cost_per_token(model=model, prompt_tokens=P, completion_tokens=C)``
+    with NO cache args — which bills the full 1000 prompt tokens (including
+    the 800 cached + 100 cache-creation) at the plain input rate. That naive
+    total must be strictly GREATER than the new cache-aware total.
+    """
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        cached_tokens=800,
+        cache_creation_tokens=100,
+    )
+
+    cache_aware_cost, snapshot = estimate_cost(_CACHE_MODEL, usage)
+    assert cache_aware_cost is not None and snapshot is not None
+
+    import litellm
+
+    naive_prompt_cost, naive_completion_cost = litellm.cost_per_token(
+        model=_CACHE_MODEL,
+        prompt_tokens=usage.prompt_tokens,
+        completion_tokens=usage.completion_tokens,
+    )
+    naive_total = naive_prompt_cost + naive_completion_cost
+
+    assert cache_aware_cost < naive_total, (
+        "cache-aware total must be strictly less than the naive (cache-unaware) "
+        "total — otherwise the cache-read discount is not being applied"
+    )
+    delta = naive_total - cache_aware_cost
+    assert delta > 0.001, (
+        f"expected a material overcharge delta on this cached scenario, got {delta}"
+    )
+
+
+def test_breakdown_components_sum_to_cache_aware_total() -> None:
+    """Tier 2: the 4 breakdown components SUM to litellm's cache-aware total
+    (the decisive components-sum-to-total invariant)."""
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        cached_tokens=800,
+        cache_creation_tokens=100,
+    )
+
+    cache_aware_cost, _ = estimate_cost(_CACHE_MODEL, usage)
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+
+    assert breakdown is not None
+    assert cache_aware_cost is not None
+    assert _epsilon_close(breakdown.total_cost, cache_aware_cost), (
+        f"components sum ({breakdown.total_cost}) must equal litellm's "
+        f"cache-aware total ({cache_aware_cost})"
+    )
+
+
+def test_breakdown_cache_read_uses_discounted_rate() -> None:
+    """Tier 2: cache_read_cost is priced at ~10% of the input rate for this
+    model (Anthropic's published cache-read discount), not the full input rate."""
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        cached_tokens=800,
+        cache_creation_tokens=100,
+    )
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+    assert breakdown is not None
+
+    import litellm
+    entry = litellm.model_cost[_CACHE_MODEL]
+    input_rate = entry["input_cost_per_token"]
+    cache_read_rate = entry["cache_read_input_token_cost"]
+
+    # cache-read rate must be a material discount vs the full input rate
+    assert cache_read_rate < input_rate * 0.5
+    # and the computed cache_read_cost must reflect the discounted rate,
+    # not the full input rate, for the 800 cached tokens
+    full_rate_cost = 800 * input_rate
+    assert breakdown.cache_read_cost < full_rate_cost
+
+
+def test_breakdown_regular_prompt_excludes_cache_subsets() -> None:
+    """Tier 2: the non-cached ("regular") prompt portion is
+    prompt_tokens - cached_tokens - cache_creation_tokens (1000-800-100=100),
+    NOT the full prompt_tokens (1000) — pins the provider-convention
+    assumption documented in ``estimate_cost_breakdown``."""
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        cached_tokens=800,
+        cache_creation_tokens=100,
+    )
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+    assert breakdown is not None
+
+    import litellm
+    input_rate = litellm.model_cost[_CACHE_MODEL]["input_cost_per_token"]
+    expected_regular_prompt_cost = 100 * input_rate  # 1000 - 800 - 100 = 100
+    assert _epsilon_close(breakdown.prompt_cost, expected_regular_prompt_cost)
+
+
+def test_breakdown_aggregates_across_turns() -> None:
+    """Tier 2: CostBreakdown.__add__ / __iadd__ sum components across turns,
+    mirroring TokenUsage's own aggregation contract."""
+    usage_a = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=800, cache_creation_tokens=100)
+    usage_b = TokenUsage(prompt_tokens=500, completion_tokens=100, cached_tokens=400, cache_creation_tokens=0)
+
+    b_a = estimate_cost_breakdown(_CACHE_MODEL, usage_a)
+    b_b = estimate_cost_breakdown(_CACHE_MODEL, usage_b)
+    assert b_a is not None and b_b is not None
+
+    combined = b_a + b_b
+    assert _epsilon_close(combined.prompt_cost, b_a.prompt_cost + b_b.prompt_cost)
+    assert _epsilon_close(combined.total_cost, b_a.total_cost + b_b.total_cost)
+
+    running = CostBreakdown()
+    running += b_a
+    running += b_b
+    assert _epsilon_close(running.total_cost, combined.total_cost)
+
+
+def test_cache_savings_equals_fullprice_minus_actual_cache_read() -> None:
+    """Tier 2: cache_savings = (full input-rate cost of the cached tokens) −
+    (actual cache-read cost of the cached tokens). This is the money the
+    cache-read discount saved on this call."""
+    usage = TokenUsage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        cached_tokens=800,
+        cache_creation_tokens=100,
+    )
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+    assert breakdown is not None
+
+    import litellm
+    entry = litellm.model_cost[_CACHE_MODEL]
+    input_rate = entry["input_cost_per_token"]
+    cache_read_rate = entry["cache_read_input_token_cost"]
+
+    full_price_of_cached = 800 * input_rate
+    actual_cache_read_cost = 800 * cache_read_rate
+    expected_savings = full_price_of_cached - actual_cache_read_cost
+
+    assert _epsilon_close(breakdown.cache_savings, expected_savings)
+    # sanity: savings == full-price-of-cached − the breakdown's own cache_read_cost
+    assert _epsilon_close(
+        breakdown.cache_savings, full_price_of_cached - breakdown.cache_read_cost
+    )
+    assert breakdown.cache_savings > 0
+
+
+def test_cache_hit_rate_and_divide_by_zero_guard() -> None:
+    """Tier 2: cache_hit_rate = cached_tokens / prompt_tokens; 0.0 when
+    prompt_tokens is 0 (divide-by-zero guard)."""
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=800)
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+    assert breakdown is not None
+    assert _epsilon_close(breakdown.cache_hit_rate, 0.8)
+
+    # zero-usage → empty breakdown → guarded 0.0, not ZeroDivisionError
+    empty = estimate_cost_breakdown(_CACHE_MODEL, TokenUsage())
+    assert empty is not None
+    assert empty.cache_hit_rate == 0.0
+
+
+def test_savings_and_hit_rate_aggregate_across_turns() -> None:
+    """Tier 2: cache_savings sums additively; cache_hit_rate is recomputed
+    from the AGGREGATED token counts (not a sum of per-turn ratios)."""
+    usage_a = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=800)
+    usage_b = TokenUsage(prompt_tokens=1000, completion_tokens=100, cached_tokens=200)
+
+    b_a = estimate_cost_breakdown(_CACHE_MODEL, usage_a)
+    b_b = estimate_cost_breakdown(_CACHE_MODEL, usage_b)
+    assert b_a is not None and b_b is not None
+
+    combined = b_a + b_b
+    assert _epsilon_close(combined.cache_savings, b_a.cache_savings + b_b.cache_savings)
+    # aggregated hit rate = (800 + 200) / (1000 + 1000) = 0.5, NOT (0.8 + 0.2)
+    assert _epsilon_close(combined.cache_hit_rate, 0.5)
+
+
+def test_unpriced_model_returns_none_not_zero_for_total_and_breakdown() -> None:
+    """Tier 2: an unpriced/unknown model → None (unknown != free, #1829 —
+    both the total AND the breakdown must preserve this sentinel)."""
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=100)
+    unknown_model = "this-model-does-not-exist-in-litellm-pricing-db-xyz"
+
+    cost, snapshot = estimate_cost(unknown_model, usage)
+    assert cost is None and snapshot is None
+
+    breakdown = estimate_cost_breakdown(unknown_model, usage)
+    assert breakdown is None
+
+
+def test_status_bar_total_equals_sum_of_breakdown() -> None:
+    """Tier 2: the value the status bar would show (estimate_cost's total)
+    equals the sum of the panel's future component breakdown — the two
+    surfaces must never visibly disagree."""
+    usage = TokenUsage(
+        prompt_tokens=2000,
+        completion_tokens=300,
+        cached_tokens=1500,
+        cache_creation_tokens=50,
+    )
+    total, _ = estimate_cost(_CACHE_MODEL, usage)
+    breakdown = estimate_cost_breakdown(_CACHE_MODEL, usage)
+    assert total is not None and breakdown is not None
+    assert _epsilon_close(total, breakdown.total_cost)


### PR DESCRIPTION
**[lead-coder]** — reyn's cost accounting was **cache-UNAWARE**. `estimate_cost` called `litellm.cost_per_token(model=..., prompt_tokens=..., completion_tokens=...)` with NO cache breakdown, so cached (cache-read) prompt tokens were billed at the **full input rate** instead of the discounted cache-read rate. reyn already CAPTURES the cache tokens (`TokenUsage.cached_tokens` / `.cache_creation_tokens`, #1772) — they were simply unused in the cost formula. This overcharges every cached call.

## What changed (backend only — no panel UI yet)

1. **Cache-aware total** (`pricing.py::estimate_cost`): now passes a `litellm.types.utils.Usage` carrying `prompt_tokens_details` (`cached_tokens` + `cache_creation_tokens`) via `cost_per_token(usage_object=...)`, so the returned total prices cached tokens at the cache-read rate and cache-creation at the cache-write rate. Preserves the #1829 None-sentinel: an unpriced model → `(None, None)` (unknown ≠ free — verified non-regressed).

2. **4-component breakdown** (`CostBreakdown` + `estimate_cost_breakdown`): computes, from `litellm.model_cost[model]` per-token rates × the respective token counts —
   - `prompt_cost` = non-cached input × input rate
   - `cache_read_cost` = cached × cache-read rate
   - `cache_creation_cost` = cache-creation × cache-write rate
   - `completion_cost` = completion × output rate

   **Invariant (decisive test):** the 4 components SUM to litellm's own cache-aware total (float-epsilon).

3. **Savings block inputs** (owner flagged savings-viz as first-class): `cache_savings` = `cached_tokens × (input_rate − cache_read_rate)` (USD the cache-read discount saved vs full input rate), and `cache_hit_rate` = `cached_tokens / prompt_tokens` (divide-by-zero guarded). Both aggregatable — `cache_savings` sums additively; `cache_hit_rate` is derived from the aggregated token counts so a multi-turn aggregate is a true blended rate, not a sum of per-turn ratios.

4. `CostBreakdown` aggregates across turns/scopes (`__add__` / `__iadd__`) exactly like `TokenUsage`, so the panel can accumulate then render.

`estimate_cost_breakdown` returns `None` for an unpriced model (mirrors `estimate_cost`), so both surfaces preserve the unknown-sentinel.

## Provider-convention assumption

`TokenUsage.prompt_tokens` **already INCLUDES** `cached_tokens` + `cache_creation_tokens` as subsets — this is litellm's own normalized `response.usage.prompt_tokens` (litellm's Anthropic transform folds both cache figures into `prompt_tokens` before reyn's `_extract_usage` ever sees the response, matching the OpenAI convention where `prompt_tokens_details.cached_tokens ⊆ prompt_tokens`). Therefore the non-cached ("regular") portion priced at the full input rate is `prompt_tokens − cached_tokens − cache_creation_tokens` (floored at 0). This is why the total path passes the breakdown via `prompt_tokens_details` (face-value, subtract-internally) rather than the top-level `cache_read_input_tokens`/`cache_creation_input_tokens` kwargs (which litellm treats as Anthropic-style and RE-ADDS to prompt_tokens → would double-count here). Verified empirically against a real `litellm.cost_per_token` call.

Cache-rate fallback: when a model has no `cache_read_input_token_cost`/`cache_creation_input_token_cost`, litellm defaults that rate to `0.0` (not the input rate); this code does the same, so components-sum-to-total holds for every model.

## Before/after (cached scenario: prompt=1000, cached=800, cache_creation=100, completion=200, claude-sonnet-4-5)

| | value |
|---|---|
| naive OLD total (cache-unaware) | `$0.006000` |
| **cache-aware total** | **`$0.003915`** |
| components sum | `$0.003915` (= total ✓) |
| **before/after delta** | **`$0.002085` — 34.8% overcharge removed** |
| `cache_savings` | `$0.002160` |
| `cache_hit_rate` | `0.80` |
| cache-read rate vs input | `$3e-07` vs `$3e-06` = **10% of input** |

## Tests (Tier 2, real litellm, no mocks)

`tests/test_cache_aware_cost_breakdown.py` (10 tests): cache-aware total < naive (falsifies old overcharge); components sum to litellm total; cache-read priced at discounted rate; regular-prompt excludes cache subsets (pins the convention); savings = full-price-of-cached − actual-cache-read-cost; hit-rate + divide-by-zero guard; savings/hit-rate aggregate across turns; unpriced model → None for both total and breakdown; status-bar total == sum of breakdown.

## Note

The Ctrl+B cost-panel UI render + status-bar wiring are NOT in this PR (backend data only, per the revised brief). The breakdown structure is ready for the panel to consume.

## 4 gates (all foreground)
- `ruff check src tests` → All checks passed
- `pytest` (repo root) → **8465 passed, 20 skipped**
- `python scripts/verify_module_docstrings.py` → OK
- tier audit (`test_cache_aware_cost_breakdown.py`) → 10/10 OK, 0 Tier-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)