### PR TITLE
fix: reyn pipe run grants configured MCP servers + document per-server MCP permission

### DIFF
--- a/docs/concepts/tools-integrations/mcp.md
+++ b/docs/concepts/tools-integrations/mcp.md
@@ -294,9 +294,11 @@ See [Concepts: permission model](../runtime/permission-model.md) → "Collapse a
 MCP tool calls cross two checks before they leave the process:
 
 1. **Phase declaration.** A phase MUST list each server it intends to use under `permissions.mcp` in its frontmatter. The runtime calls `require_mcp(decl, server, ...)`; if `server not in decl.mcp`, the call fails with a clear error pointing at the missing declaration.
-2. **Approval.** Like every other capability, the first invocation per workflow prompts (`y` / `j` / `r` / `N`). Persistent approvals land in `.reyn/approvals.yaml` keyed by `<skill>/mcp.<server>`. Pre-approve project-wide with `permissions.mcp: allow` in `reyn.yaml` if you trust the project broadly.
+2. **Approval.** Like every other capability, the first invocation per workflow prompts (`y` / `j` / `r` / `N`). Persistent approvals land in `.reyn/approvals.yaml` keyed by `<skill>/mcp.<server>`. Pre-approve project-wide with `permissions.mcp: allow` in `reyn.yaml` if you trust the project broadly, or grant one server at a time with `permissions.mcp: {<server>: allow}` — see [the permissions reference](../../reference/config/permissions.md) → "Granting an MCP server permission" for the full per-server-vs-approvals-file breakdown. A denied call's error names the server and points at both grant routes directly.
 
 This matches reyn's general permission model — see [../runtime/permission-model.md](../runtime/permission-model.md). One skill's MCP approval doesn't leak to another skill, and a sub-skill invoked via `run_skill` has to ask for its own permissions.
+
+**`reyn pipe run`** (a one-shot, non-interactive CLI command with no one to answer the approval prompt above) auto-grants `permissions.mcp` for every server already present in the merged MCP config — an operator who configured a server AND explicitly ran the pipeline is trusted for that invocation. An unconfigured server still denies; the gate itself, and `reyn chat`'s own interactive prompt, are unchanged. Full detail: [permissions.md](../../reference/config/permissions.md) → "Granting an MCP server permission".
 
 Three audit events are emitted per call:
 

--- a/docs/reference/config/permissions.md
+++ b/docs/reference/config/permissions.md
@@ -143,9 +143,31 @@ permissions:
 
 Use `allow` only when the project is trusted. `ask` (the default) prompts; `deny` rejects.
 
+## Granting an MCP server permission
+
+MCP's per-server gate (`permissions.mcp`) has two independent grant surfaces — pick the one that matches when you're deciding:
+
+1. **`reyn.yaml` / `reyn.local.yaml` — declare up front, before any prompt fires.**
+
+   ```yaml
+   permissions:
+     mcp:
+       github: allow   # grant this MCP server's tools project-wide
+   ```
+
+   A flat blanket form also works (`permissions.mcp: allow` grants every server), but the per-server dict form above is the one to reach for when you trust one server and not others. This is a config file, edited by the operator — it takes effect the next time reyn loads config, no running session needed.
+
+2. **`.reyn/approvals.yaml` — the saved-approvals store the interactive prompt writes.**
+
+   When a chat session hits an undeclared MCP server, it prompts (`y` / `j` / `r` / `N` — see "Approval flow" above); choosing a persistent option (`j`/`r`) writes `mcp.<server>: true` under that skill's key in `.reyn/approvals.yaml`. You can also hand-edit this file directly, but it's normally the session's own record of "you already answered this," not something you author from scratch.
+
+Both surfaces feed the same runtime check (`require_mcp` — see "Runtime gate: `permissions.mcp`" in [the MCP concept doc](../../concepts/tools-integrations/mcp.md)); `reyn.yaml` is the declarative up-front grant, `.reyn/approvals.yaml` is the session's own memory of interactive answers.
+
+**`reyn pipe run`'s default:** running a pipeline via `reyn pipe run` (a one-shot, non-interactive CLI command — see below) auto-grants `permissions.mcp` for every MCP server already present in the merged MCP config (`.reyn/config/mcp.yaml` plus `reyn.yaml`/`reyn.local.yaml`'s `mcp.servers`). The gate itself is unchanged — an MCP server that is NOT configured there still denies, and an explicit `deny` you've set for a specific server (or a blanket `mcp: deny`) is never auto-overridden. This only changes the pipe-run *default* for servers you've already configured; it does not touch `reyn chat`'s own interactive prompt.
+
 ## Non-interactive runs (CI)
 
-`reyn run-once` runs non-interactively — there is no prompt. Approvals must be pre-arranged either in `reyn.yaml` or `.reyn/approvals.yaml` (e.g. by running the agent once interactively first).
+`reyn run-once` runs non-interactively — there is no prompt. Approvals must be pre-arranged either in `reyn.yaml` or `.reyn/approvals.yaml` (e.g. by running the agent once interactively first). `reyn pipe run` is the same non-interactive model, EXCEPT for MCP servers — see "Granting an MCP server permission" above for the pipe-run-specific auto-grant of already-configured servers.
 
 ## Inspecting and revoking
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -1099,7 +1099,7 @@ See [Concepts: permission model](../../concepts/runtime/permission-model.md) →
 
 > Legacy `permissions.mcp_install` keys in older `reyn.yaml` files are accepted with a `DeprecationWarning` and translate to the equivalent `file.write` / `http.get` gates during the migration window.
 
-The full permission grammar is documented in `reference/config/permissions.md`.
+The full permission grammar is documented in `reference/config/permissions.md`. Note this section is about *installing* an MCP server — granting an already-installed server's tools to be *called* (`permissions.mcp.<server>: allow`, including `reyn pipe run`'s auto-grant of configured servers) is a separate axis, covered in `reference/config/permissions.md` → "Granting an MCP server permission".
 
 ## `${VAR}` interpolation {#var-interpolation}
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -131,13 +131,25 @@
 #   python.safe       — pre-approve the python preprocessor's safe mode
 #                       (the chat router uses this — already set in reyn.yaml)
 #   mcp.<server>      — pre-approve a specific MCP server's tool surface
+#                       (e.g. `mcp.<server-name>: allow` — see the nested
+#                       `mcp: {<server-name>: allow}` form below; also
+#                       settable per-server via .reyn/approvals.yaml's
+#                       `mcp.<server-name>: true`, written by the chat
+#                       session's own interactive approval prompt — see
+#                       docs/reference/config/permissions.md).
+#                       `reyn pipe run` auto-grants any MCP server it finds
+#                       already CONFIGURED (.reyn/config/mcp.yaml / this
+#                       file's own `mcp.servers`) — this block is only
+#                       needed for a server NOT yet configured, or to
+#                       override that default (e.g. an explicit per-server
+#                       `deny` here is never auto-overridden).
 # -----------------------------------------------------------------------------
 # permissions:
 #   shell: allow
 #   file.delete: allow
 #   python.safe: allow
 #   mcp:
-#     github: allow
+#     github: allow   # grant this MCP server's tools
 #
 # Headless / benchmark pre-approval: benchmark Agents are constructed with
 # ``intervention_bus=None`` (= ``reyn eval benchmark ...``), so any permission

--- a/src/reyn/interfaces/cli/commands/pipe.py
+++ b/src/reyn/interfaces/cli/commands/pipe.py
@@ -59,6 +59,22 @@ the ``default`` identity's own Session's ``RouterHostAdapter`` (every real
 ``Session`` builds one unconditionally in ``__init__``, live chat loop or
 not) — the exact same machinery the async pipeline driver-session's tool-step
 dispatch already uses (``runtime/services/pipeline_executor_driver.py``).
+
+MCP default (option (A) — was: a ``tool:`` step against ANY MCP server denied
+in a non-interactive ``reyn pipe run``, stranding an operator whose pipeline
+has a legitimate, already-configured MCP step): ``_build_run_tool_context``
+auto-grants the ``mcp`` permission axis for every server present in the
+merged MCP config (``.reyn/config/mcp.yaml`` + ``reyn.yaml``/``reyn.local.
+yaml`` ``mcp.servers``) — see :func:`_grant_configured_mcp_servers`. This is
+a DEFAULT change, not a gate removal: the operator both configured the
+server (an explicit, auditable act) AND explicitly ran ``reyn pipe run`` (a
+second explicit act), so a CONFIGURED server is treated as trusted for THIS
+command; an UNCONFIGURED server, or one the operator explicitly denies via
+``permissions.mcp``, still goes through the unchanged ``require_mcp`` gate
+and is denied (with an actionable error naming the server — see
+``security/permissions/permissions.py``'s ``require_mcp``). Scoped to ``reyn
+pipe run`` ONLY — ``reyn chat``'s own interactive JIT-approval posture is
+untouched.
 """
 from __future__ import annotations
 
@@ -485,8 +501,47 @@ def run_install(args: argparse.Namespace) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _grant_configured_mcp_servers(perm_config: dict, configured_servers: "list[str]") -> dict:
+    """Auto-grant the ``mcp`` permission axis for every MCP server present in
+    the merged MCP config (option (A), owner-decided): the operator
+    explicitly configured these servers (``.reyn/config/mcp.yaml`` /
+    ``reyn.yaml`` ``mcp.servers``) AND explicitly ran ``reyn pipe run`` — so
+    they are treated as trusted-by-configuration for THIS command only. This
+    is a DEFAULT change, not a gate removal: ``require_mcp``'s ∩-gate (declared
+    authority + config/approvals-file/interactive approval) still runs on
+    every call; this function only pre-seeds the config-approval layer
+    (``PermissionResolver._is_config_approved``) that layer reads.
+
+    An operator's own explicit disposition always wins over the auto-grant:
+      - a top-level flat ``mcp: allow`` / ``mcp: deny`` string (blanket grant
+        or blanket deny) is left completely untouched — a blanket ``deny``
+        means NO server auto-grants, configured or not.
+      - a per-server entry already present in a ``mcp: {<server>: ...}`` dict
+        (most notably an explicit ``deny``) is preserved via ``setdefault`` —
+        never overwritten by the auto-grant.
+    Only a configured server with NO existing disposition gets the implicit
+    ``allow``; an UNCONFIGURED server gets none and still denies (falls
+    through to ``require_mcp``'s existing actionable-error path).
+    """
+    mcp_val = perm_config.get("mcp")
+    if isinstance(mcp_val, str):
+        # Blanket allow/deny already decided by the operator for the WHOLE
+        # axis — an auto-grant here could not add anything (already-allow)
+        # or would violate an explicit blanket deny. Leave untouched.
+        return perm_config
+    mcp_dict = dict(mcp_val) if isinstance(mcp_val, dict) else {}
+    for server in configured_servers:
+        mcp_dict.setdefault(server, "allow")
+    if not mcp_dict:
+        return perm_config
+    merged = dict(perm_config)
+    merged["mcp"] = mcp_dict
+    return merged
+
+
 def _build_run_tool_context(
     project_root: Path, router_state: "Any | None", *, grant_file_write: bool = False,
+    config: "Any | None" = None,
 ):
     """Build a real, standalone ``ToolContext`` for ``reyn pipe run``'s
     ``tool:`` step dispatch — routed through the SAME seam a live agent
@@ -497,8 +552,18 @@ def _build_run_tool_context(
     Field-by-field:
       - ``events``: a real ``EventLog`` (mirrors ``reyn pipe install``).
       - ``permission_resolver``: **fail-closed by default** — ``perm_config``
-        is exactly ``reyn.yaml``'s own ``permissions:`` section, byte-
-        identical to ``reyn chat``'s own no-flag posture. ``grant_file_write``
+        is ``run_run``'s already-``_grant_configured_mcp_servers``-merged
+        ``config.permissions`` (see ``run_run``: it applies the same MCP
+        auto-grant to ``config.permissions`` BEFORE this function is called,
+        so both this ToolContext's resolver AND the ``default`` identity's
+        own Session resolver — built from the same mutated ``config`` by
+        ``build_agent_registry_from_project`` — see the SAME grant. This
+        function's own resolver gates non-MCP ``tool:`` dispatch, e.g.
+        ``write_file``; MCP ``tool:`` dispatch (``mcp__<server>__<tool>``)
+        instead routes through ``ctx.router_state.host.mcp_call_tool`` ->
+        ``Session._mcp_call_tool``, which gates via the SESSION's own
+        resolver, not this one — carrying the mutated config through both
+        construction paths keeps them consistent). ``grant_file_write``
         (``--grant-file-write``, off by default) mirrors ``reyn chat
         --grant-file-write`` exactly (``file.read``/``file.write`` only).
         ``http.get`` is NEVER blanket-granted — ``reyn chat`` doesn't either
@@ -507,7 +572,10 @@ def _build_run_tool_context(
         denied, same as a non-interactive ``reyn chat``). A pipeline
         installed from an untrusted source (``reyn pipe install --source``)
         must not silently gain broad file/network access merely by being
-        RUN — the operator opts in per invocation.
+        RUN — the operator opts in per invocation for file access (MCP is
+        different: only servers the operator ALREADY configured auto-grant,
+        so an untrusted pipeline gains no new MCP surface merely by
+        declaring a ``tool:`` step against a server nobody configured).
       - ``workspace``: a real ``reyn.data.workspace.Workspace`` anchored on
         ``project_root`` (host backend) — a real tool handler (``read_file``,
         ``write_file``, …) calls real methods on it (``read_file_bytes`` etc.),
@@ -540,8 +608,25 @@ def _build_run_tool_context(
 
     perm_config: dict = {}
     try:
-        from reyn.config import load_config
-        perm_config = dict(getattr(load_config(), "permissions", {}) or {})
+        # `run_run` already loads config once and applies
+        # `_grant_configured_mcp_servers` to `config.permissions` (see its
+        # docstring for why that must happen before both this function AND
+        # `build_agent_registry_from_project` are called) — reuse that same
+        # object when the caller supplies it, so this ToolContext's resolver
+        # and the Session's own resolver see byte-identical config. Fall
+        # back to a fresh load (re-applying the same grant) only for a
+        # caller that doesn't thread ``config`` through (keeps this a valid
+        # standalone helper, matching its pre-existing signature).
+        if config is None:
+            from reyn.config import load_config
+            config = load_config()
+            configured_servers = sorted(
+                (getattr(config, "mcp", {}) or {}).get("servers", {}) or {}
+            )
+            config.permissions = _grant_configured_mcp_servers(
+                dict(getattr(config, "permissions", {}) or {}), configured_servers,
+            )
+        perm_config = dict(getattr(config, "permissions", {}) or {})
     except Exception:
         perm_config = {}
     if grant_file_write:
@@ -664,6 +749,22 @@ def run_run(args: argparse.Namespace) -> None:
 
     from reyn.config import load_config
     config = load_config()
+    # Option (A) — auto-grant every MCP server present in the merged MCP
+    # config (config.mcp.servers) for THIS `reyn pipe run` invocation. Must
+    # happen HERE, before `build_agent_registry_from_project` reads
+    # `config.permissions` to build the `default` identity's own Session
+    # PermissionResolver — MCP tool dispatch (`tool: mcp__<server>__<tool>`)
+    # routes through `ctx.router_state.host.mcp_call_tool` ->
+    # `Session._mcp_call_tool`, which gates via THAT Session's OWN
+    # PermissionResolver (built in registry_bootstrap.py from
+    # `config.permissions`), NOT `_build_run_tool_context`'s separate
+    # ToolContext-level resolver (which only gates non-MCP tool dispatch,
+    # e.g. `write_file`). See `_grant_configured_mcp_servers`'s docstring for
+    # the exact allow/deny-preserving merge semantics.
+    configured_mcp_servers = sorted((config.mcp or {}).get("servers", {}) or {})
+    config.permissions = _grant_configured_mcp_servers(
+        dict(config.permissions or {}), configured_mcp_servers,
+    )
     pipeline_registry = build_pipeline_registry(config.pipelines, project_root, strict=False)
 
     try:
@@ -767,7 +868,7 @@ def run_run(args: argparse.Namespace) -> None:
                 return _router_state_cache["state"]
 
             tool_ctx = _build_run_tool_context(
-                project_root, None, grant_file_write=grant_file_write,
+                project_root, None, grant_file_write=grant_file_write, config=config,
             )
             base_dispatch = _make_tool_dispatch(tool_ctx)
 

--- a/src/reyn/security/permissions/permissions.py
+++ b/src/reyn/security/permissions/permissions.py
@@ -1254,7 +1254,24 @@ class PermissionResolver:
             bus,
             user_prompt=f"Allow access to MCP server {server!r}?",
         ):
-            raise PermissionError(f"MCP server {server!r} access denied")
+            # Decision-enabling deny (was a bare "access denied"): name the
+            # server and the two concrete ways to grant it — either
+            # declaring/installing the server so it's CONFIGURED (which
+            # `reyn pipe run` auto-grants — see pipe.py's
+            # `_grant_configured_mcp_servers`), or a one-off explicit
+            # config grant. Both routes covered so this fires the same for
+            # an unconfigured server AND a configured-but-explicitly-denied
+            # one.
+            raise PermissionError(
+                f"MCP server {server!r} access denied. To grant it: "
+                f"(1) configure the server — add it to "
+                f".reyn/config/mcp.yaml, or run `reyn mcp install {server}` "
+                f"(a `reyn pipe run` invocation auto-grants any server it "
+                f"finds configured there), or "
+                f"(2) grant it explicitly — add `permissions:\\n  mcp:\\n"
+                f"    {server}: allow` to reyn.yaml. See "
+                f"docs/reference/config/permissions.md."
+            )
 
     async def require_tool(
         self, decl: PermissionDecl, tool: str, bus: RequestBus,

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -767,6 +767,104 @@ def test_run_tool_step_dispatches_mcp_action_for_real(tmp_path, monkeypatch, cap
     assert result["named_stores"]["r"]["text"] == "ping:hi reyn"
 
 
+def test_run_tool_step_mcp_auto_grants_configured_server_no_explicit_permission(
+    tmp_path, monkeypatch, capsys,
+):
+    """Tier 2: option (A) — a 'tool:' step calling a CONFIGURED MCP server
+    (present in reyn.yaml's mcp.servers) now dispatches for real through
+    'reyn pipe run' with NO explicit `permissions.mcp` declaration at all —
+    the owner-reported stuck-on-access-denied case. Mirrors
+    test_run_tool_step_dispatches_mcp_action_for_real exactly, MINUS the
+    `permissions: {mcp: {echo: allow}}` block that test needed pre-fix —
+    the auto-grant (_grant_configured_mcp_servers) now supplies it.
+
+    FALSIFY: the sibling test below (unconfigured server) proves the gate
+    itself still denies when the server is NOT configured — so this success
+    is attributable to the configured-server auto-grant, not a broken gate."""
+    monkeypatch.chdir(tmp_path)
+    import reyn.mcp.connection_service as connection_service_mod
+    import reyn.mcp.pool as pool_mod
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(connection_service_mod, "MCPClient", _FakeMCPClient)
+
+    dsl_path = tmp_path / "uses_mcp.yaml"
+    dsl_path.write_text(
+        "pipeline: uses_mcp\n"
+        "steps:\n"
+        "  - tool: {name: mcp__echo__ping, args: {msg: !expr ctx.msg}, output: r}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "models": {"standard": "openai/gpt-4o-mini"},
+                "mcp": {"servers": {"echo": {"type": "stdio", "command": "x"}}},
+                # No `permissions:` block at all — the auto-grant is the
+                # ONLY thing that can make this succeed.
+                "pipelines": {"entries": {"uses_mcp": {"path": "uses_mcp.yaml"}}},
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    args = _ns(
+        name="uses_mcp.uses_mcp", input=json.dumps({"msg": "hi reyn"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert result["named_stores"]["r"]["text"] == "ping:hi reyn"
+
+
+def test_run_tool_step_mcp_unconfigured_server_still_denied_with_actionable_error(
+    tmp_path, monkeypatch, capsys,
+):
+    """Tier 2: falsify pin for the auto-grant above — a server that is NOT
+    in the merged MCP config still gets no grant and is denied, with an
+    actionable error naming the server (was a bare 'access denied')."""
+    monkeypatch.chdir(tmp_path)
+    import reyn.mcp.connection_service as connection_service_mod
+    import reyn.mcp.pool as pool_mod
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(connection_service_mod, "MCPClient", _FakeMCPClient)
+
+    dsl_path = tmp_path / "uses_mcp.yaml"
+    dsl_path.write_text(
+        "pipeline: uses_mcp\n"
+        "steps:\n"
+        "  - tool: {name: mcp__ghost__ping, args: {msg: !expr ctx.msg}, output: r}\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "models": {"standard": "openai/gpt-4o-mini"},
+                # 'ghost' is NOT configured anywhere — no mcp.servers entry.
+                "pipelines": {"entries": {"uses_mcp": {"path": "uses_mcp.yaml"}}},
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+    args = _ns(
+        name="uses_mcp.uses_mcp", input=json.dumps({"msg": "hi reyn"}),
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    text = result["named_stores"]["r"]["text"]
+    assert "ghost" in text
+    assert "denied" in text.lower() or "not declared" in text.lower()
+
+
 @pytest.mark.asyncio
 async def test_router_state_resource_categories_populated_from_real_session(
     tmp_path, monkeypatch,

--- a/tests/test_cli_pipe.py
+++ b/tests/test_cli_pipe.py
@@ -707,13 +707,199 @@ class _FakeMCPClient:
     def is_initialized(self) -> bool:
         return True
 
+    # Class-level transport-reach counter (reset per test): lets a test assert
+    # whether the real MCP transport was EVER reached — the load-bearing signal
+    # for the focus-3 privilege-escalation gate (a narrowed agent step must not
+    # reach the transport of an MCP server its capabilities exclude, even when
+    # `reyn pipe run` has auto-granted that server in config).
+    call_tool_count = 0
+
     async def call_tool(
         self, name: str, args: dict, *, progress_callback=None, timeout_seconds=None,
     ) -> dict:
+        type(self).call_tool_count += 1
         return {
             "content": [{"type": "text", "text": f"{name}:{args.get('msg', '')}"}],
             "isError": False,
         }
+
+
+def _fake_acompletion_one_tool_then_stop(tool_name: str, tool_args: dict):
+    """Stateful real-async fake for litellm.acompletion (the documented replay
+    seam): the FIRST call returns a single ``tool_name`` tool_call (forcing the
+    router to attempt that dispatch REGARDLESS of catalog visibility — so a
+    denial can only come from the DISPATCH-time permission gate, not merely
+    from the tool being hidden); every subsequent call returns a plain-text
+    stop. Lets a narrowed agent step be scripted to TRY an excluded MCP call."""
+    state = {"n": 0}
+
+    async def _acompletion(*_args, **_kwargs):
+        state["n"] += 1
+        if state["n"] == 1:
+            return litellm.ModelResponse(
+                choices=[{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": None,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": json.dumps(tool_args),
+                            },
+                        }],
+                    },
+                    "finish_reason": "tool_calls",
+                }],
+                usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                model="openai/gpt-4o-mini",
+            )
+        return litellm.ModelResponse(
+            choices=[{
+                "index": 0,
+                "message": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop",
+            }],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            model="openai/gpt-4o-mini",
+        )
+
+    return _acompletion
+
+
+def _write_agent_mcp_reyn_yaml(tmp_path, *, capabilities_line: str) -> None:
+    """reyn.yaml with `echo` MCP server CONFIGURED (so `reyn pipe run`'s option-A
+    auto-grant enables `permissions.mcp.echo`), NO explicit `permissions` block,
+    and a single-`agent`-step pipeline whose `capabilities` are supplied by the
+    caller (present → narrowed; absent line → un-narrowed control)."""
+    (tmp_path / "uses_agent_mcp.yaml").write_text(
+        "pipeline: uses_agent_mcp\n"
+        "steps:\n"
+        "  - agent:\n"
+        "      prompt: 'call the echo server'\n"
+        "      identity: default\n"
+        f"{capabilities_line}"
+        "      output: reply\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "models": {"standard": "openai/gpt-4o-mini"},
+                "mcp": {"servers": {"echo": {"type": "stdio", "command": "x"}}},
+                "pipelines": {"entries": {"uses_agent_mcp": {"path": "uses_agent_mcp.yaml"}}},
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_agent_step_capabilities_narrowing_blocks_autogranted_mcp_server(
+    tmp_path, monkeypatch, capsys,
+):
+    """Tier 2: focus-3 privilege-escalation merge-gate. A pipeline `agent` step
+    whose `capabilities` EXCLUDE the MCP tool, run via `reyn pipe run` with the
+    `echo` server present-and-auto-granted in config, must NOT be able to invoke
+    that server — the per-step capability NARROWING wins over the pipe-run MCP
+    auto-grant (the ∩-gate holds; never-elevate).
+
+    Mechanism (pinned, not assumed): the sub-agent's LLM is SCRIPTED to emit a
+    `call_mcp_tool` call anyway (bypassing any catalog-visibility hiding), so the
+    only thing that can stop it is a DISPATCH-time gate. The agent-step narrowing
+    (`_build_agent_step_narrowing`) sets `tool_allow` only — it does NOT set the
+    `allowed_mcp`/`mcp_deny` axis that `require_mcp` reads — yet the call is still
+    denied, because the router's single contextual TOOL-axis gate
+    (`RouterLoop._excluded_result` -> `tool_contextually_denied`) rejects
+    `call_mcp_tool` (not in `tool_allow=[read_file]`) BEFORE the MCP op / its
+    `require_mcp` gate is ever reached. So the auto-grant (which only pre-seeds
+    the config-approval layer of the LOWER `require_mcp` MCP-axis) is structurally
+    dominated by the narrowing on the TOOL axis (never-elevate = `all()`).
+
+    Evidence: the real MCP transport (`_FakeMCPClient.call_tool`) is NEVER
+    reached (`call_tool_count == 0`). The paired control below proves the same
+    scripted call DOES reach the transport when `call_mcp_tool` is in
+    `capabilities` — isolating the narrowing as the cause of the denial."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-focus3-dummy")
+    _FakeMCPClient.call_tool_count = 0
+    import reyn.mcp.connection_service as connection_service_mod
+    import reyn.mcp.pool as pool_mod
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(connection_service_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _fake_acompletion_one_tool_then_stop(
+            "call_mcp_tool",
+            {"server": "echo", "mcp_tool_name": "ping", "tool_args": {"msg": "hi"}},
+        ),
+    )
+
+    # capabilities EXCLUDE call_mcp_tool (only read_file allowed) → the echo
+    # server is unreachable for this sub-agent despite the pipe-run auto-grant.
+    _write_agent_mcp_reyn_yaml(
+        tmp_path, capabilities_line="      capabilities: {tools: [read_file]}\n",
+    )
+
+    args = _ns(
+        name="uses_agent_mcp.uses_agent_mcp", input="{}",
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    assert _FakeMCPClient.call_tool_count == 0, (
+        "PRIVILEGE ESCALATION: a narrowed agent step (capabilities exclude "
+        "call_mcp_tool) reached the auto-granted MCP server's transport — the "
+        "narrowing did NOT win over the pipe-run auto-grant."
+    )
+
+
+def test_agent_step_without_narrowing_reaches_autogranted_mcp_server_control(
+    tmp_path, monkeypatch, capsys,
+):
+    """Tier 2: paired CONTROL for the focus-3 gate above — the SAME scripted
+    `call_mcp_tool` under an agent step whose `capabilities` INCLUDE
+    `call_mcp_tool` DOES reach the auto-granted `echo` server's transport
+    (`call_tool_count >= 1`). This isolates the denial in the sibling test to
+    the capability NARROWING (not an unrelated dispatch failure) and confirms
+    the pipe-run auto-grant genuinely enables a configured server for an agent
+    step when the step's own capabilities permit the MCP verb."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-focus3-dummy")
+    _FakeMCPClient.call_tool_count = 0
+    import reyn.mcp.connection_service as connection_service_mod
+    import reyn.mcp.pool as pool_mod
+    monkeypatch.setattr(pool_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(connection_service_mod, "MCPClient", _FakeMCPClient)
+    monkeypatch.setattr(
+        litellm, "acompletion",
+        _fake_acompletion_one_tool_then_stop(
+            "call_mcp_tool",
+            {"server": "echo", "mcp_tool_name": "ping", "tool_args": {"msg": "hi"}},
+        ),
+    )
+
+    # capabilities INCLUDE call_mcp_tool → the TOOL-axis gate permits it, and the
+    # auto-grant lets require_mcp(echo) pass → the transport IS reached.
+    _write_agent_mcp_reyn_yaml(
+        tmp_path,
+        capabilities_line="      capabilities: {tools: [call_mcp_tool]}\n",
+    )
+
+    args = _ns(
+        name="uses_agent_mcp.uses_agent_mcp", input="{}",
+        project=str(tmp_path), async_=False,
+    )
+    run_run(args)
+
+    assert _FakeMCPClient.call_tool_count >= 1, (
+        "control failed: an agent step whose capabilities INCLUDE call_mcp_tool "
+        "did NOT reach the auto-granted echo server — the test can no longer "
+        "attribute the sibling denial to narrowing."
+    )
 
 
 def test_run_tool_step_dispatches_mcp_action_for_real(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
**[lead-coder]** — A user built a pipeline with an MCP tool step, ran it via `reyn pipe run`, and got stuck on MCP access-denied. Root cause: `reyn pipe run` is permission fail-closed and non-interactive (mirroring `reyn chat`'s no-flag posture); only `--grant-file-write` exists (file ops only), and there's no interactive prompt in pipe run to grant MCP. MCP permission is a per-server capability (`permissions.mcp.<server>: allow`), and a general user with a perfectly legitimate, already-configured MCP server has no way to get past the gate non-interactively.

## Fix — option (A) (owner-decided)

`reyn pipe run` now auto-grants the `mcp` permission axis for every server present in the merged MCP config (`.reyn/config/mcp.yaml` + `reyn.yaml`/`reyn.local.yaml`'s `mcp.servers`). Rationale: the operator both configured the server (an explicit act) AND explicitly ran `reyn pipe run` (a second explicit act), so a CONFIGURED server is trusted-by-configuration for THAT invocation.

**The gate stays intact** — this is a default change, not a gate removal:
- An **unconfigured** server still denies (falls through to `require_mcp`'s unchanged check).
- An operator's own explicit disposition always wins: a blanket `mcp: deny` is left untouched (no auto-grant at all), and a per-server `mcp: {<server>: deny}` is preserved via `setdefault` (never overwritten).
- `reyn chat`'s own interactive JIT-approval posture is completely untouched — this is scoped to `pipe.py` only (`_grant_configured_mcp_servers`, applied to `config.permissions` in `run_run` before it feeds both `_build_run_tool_context`'s ToolContext resolver and `build_agent_registry_from_project`'s Session resolver — the latter is what MCP tool dispatch actually gates through, since `tool: mcp__<server>__<tool>` routes via `ctx.router_state.host.mcp_call_tool` → `Session._mcp_call_tool`, not the ToolContext-level resolver).

**Better error**: `require_mcp`'s previously-bare `"MCP server 'x' access denied"` now names the server and both concrete grant routes (configure it in `.reyn/config/mcp.yaml` / `reyn mcp install`, or declare it explicitly via `permissions.mcp.<server>: allow`), pointing at `docs/reference/config/permissions.md`.

## Docs

- `reyn.local.yaml.example`: extended the existing `mcp.<server>` comment with the pipe-run auto-grant behavior + a pointer to `.reyn/approvals.yaml`'s parallel `mcp.<server>: true` form, and an inline `# grant this MCP server's tools` comment on the example line itself.
- `docs/reference/config/permissions.md`: new "Granting an MCP server permission" section consolidating the two syntaxes (`reyn.yaml permissions.mcp.<server>: allow` — declare up front vs `.reyn/approvals.yaml`'s `mcp.<server>: true` — the chat prompt's saved-approvals store) and documenting the pipe-run auto-grant default.
- `docs/concepts/tools-integrations/mcp.md` and `docs/reference/config/reyn-yaml.md`: cross-linked to the new section, and reyn-yaml.md's MCP-install section now distinguishes "installing a server" (file.write/http.get axis) from "granting an installed server's tools to be called" (the `permissions.mcp` axis this PR touches).
- No `docs/reference/cli/pipe.md` exists yet (confirmed via `ls docs/reference/cli/`) — out of scope for this fix; the module docstring in `pipe.py` documents the behavior at the code level.

## Test plan

- [x] `test_run_tool_step_mcp_auto_grants_configured_server_no_explicit_permission` (new) — a pipeline `tool:` step against a CONFIGURED MCP server dispatches for real via `reyn pipe run` with **no** `permissions.mcp` declaration in `reyn.yaml` at all (the owner-reported stuck case).
- [x] `test_run_tool_step_mcp_unconfigured_server_still_denied_with_actionable_error` (new) — FALSIFY pin: an unconfigured server (`mcp__ghost__ping`) still denies, and the error text names `ghost` + is actionable, not a bare "access denied".
- [x] Existing `test_run_tool_step_dispatches_mcp_action_for_real` (unmodified, still passes) — its own explicit `permissions.mcp: {echo: allow}` grant is now redundant-but-harmless given the auto-grant, confirming no regression.
- [x] `reyn chat` posture unchanged — `chat.py` is untouched by this diff (confirmed via `git diff --name-only`); ran the wider `test_permissions.py` / `test_1199_s31b_mcp_cutover.py` / `test_2074_s4a_mcp_unify.py` / `test_permission_prompt_phrasing.py` / `test_2597_*` suites (97 passed) to confirm the shared `require_mcp` message-text change doesn't break any pinned assertion.
- [x] `reyn.local.yaml.example` parses / example-validation tests still pass (`test_reyn_local_example_benchmark_permissions.py`, `test_config_mirror_coverage_1056.py`).

## Gates (all run foreground)

- `ruff check src tests` — all checks passed.
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/cli/commands/pipe.py src/reyn/security/permissions/permissions.py` — OK.
- `python scripts/test_tier_audit.py --strict tests/test_cli_pipe.py` — 26/26 OK, 0 Tier-4 violations.
- `pytest` (repo root) — **8457 passed, 20 skipped**, 0 failed.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0 (pre-existing INFO-level ja-mirror anchor notices only, unrelated to this diff).