### PR TITLE
feat: cost panel breakdown (Total/Input/Output/Saved/Saved%) across session/agent/project

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -237,17 +237,8 @@ _COST_BREAKDOWN_EPSILON_ABS = 1e-6
 _COST_BREAKDOWN_EPSILON_REL = 1e-4
 
 
-def _cost_breakdown_approximate(component_sum: float, authoritative_total: float) -> bool:
-    """True when Input+Output (derived from CostBreakdown, per-model-rate
-    accumulated) diverges from the litellm-accurate authoritative Total beyond
-    float-noise tolerance — the signal that >200k tiered pricing kicked in for
-    at least one call in this scope's history (see module-level epsilon note)."""
-    tol = max(_COST_BREAKDOWN_EPSILON_ABS, abs(authoritative_total) * _COST_BREAKDOWN_EPSILON_REL)
-    return abs(component_sum - authoritative_total) > tol
-
-
-def _cost_scope_values(breakdown, authoritative_total: float) -> "tuple[float, float, float, float, bool]":
-    """One scope column's (input_cost, output_cost, saved, saved_pct, approximate).
+def _cost_scope_state(breakdown, authoritative_total: float) -> "tuple[float, float, float, float, str]":
+    """One scope column's (input_cost, output_cost, saved, saved_pct, state).
 
     ``input_cost`` = the cache-aware cost actually paid for input (prompt +
     cache-read + cache-creation components). ``saved_pct`` = Saved /
@@ -255,14 +246,43 @@ def _cost_scope_values(breakdown, authoritative_total: float) -> "tuple[float, f
     cost WITHOUT caching), NOT Saved / Total (falsified explicitly: pinning
     the wrong denominator would silently under/over-state the savings %).
     Divide-by-zero guarded (0% when Input+Saved == 0, i.e. no priced input
-    tokens recorded yet)."""
+    tokens recorded yet).
+
+    ``state`` is one of three cases — the panel renders each distinctly so it
+    never MISATTRIBUTES a cause:
+      - ``"ok"``      — the 4 components reconcile with the authoritative Total
+                        (within float-noise tolerance): show exact numbers.
+      - ``"approx"``  — components are present (sum > 0) but diverge from Total
+                        beyond tolerance = genuine >200k TIERED pricing, which
+                        ``estimate_cost_breakdown`` does not replicate: mark
+                        the component rows "~" + a tiered-pricing footnote.
+      - ``"unavail"`` — components are ~0 while Total > 0 = the breakdown is
+                        UNAVAILABLE, not diverging (the durable per-agent Total
+                        survives a restart via the ledger, but the in-memory
+                        CostBreakdown resets to 0 — it is NOT ledger-persisted;
+                        it can also be 0 before the first accumulation). This
+                        is NOT tiered pricing, so it must NOT fire the "~"/
+                        tiered footnote (the false-fire the architect caught);
+                        the Total stays authoritative and the component cells
+                        blank to "—" with a distinct "unavailable" note.
+    """
     input_cost = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
     output_cost = breakdown.completion_cost
     saved = breakdown.cache_savings
     no_cache_baseline = input_cost + saved
     saved_pct = (saved / no_cache_baseline) if no_cache_baseline > 0 else 0.0
-    approximate = _cost_breakdown_approximate(input_cost + output_cost, authoritative_total)
-    return input_cost, output_cost, saved, saved_pct, approximate
+
+    component_sum = input_cost + output_cost
+    tol = max(_COST_BREAKDOWN_EPSILON_ABS, abs(authoritative_total) * _COST_BREAKDOWN_EPSILON_REL)
+    if component_sum <= _COST_BREAKDOWN_EPSILON_ABS and authoritative_total > tol:
+        # Breakdown absent while a real Total exists → unavailable, not tiered.
+        state = "unavail"
+    elif abs(component_sum - authoritative_total) > tol:
+        # Components present but don't reconcile → genuine >200k tiered pricing.
+        state = "approx"
+    else:
+        state = "ok"
+    return input_cost, output_cost, saved, saved_pct, state
 
 
 def _cost_breakdown_table(snap) -> list[str]:
@@ -272,10 +292,12 @@ def _cost_breakdown_table(snap) -> list[str]:
     Total is always the litellm-accurate authoritative figure (``cost_usd`` /
     ``cost_agent`` / ``cost_total`` — already computed via ``estimate_cost``,
     unaffected by the >200k breakdown limitation). Input/Output/Saved/Saved%
-    are derived from the accumulated ``CostBreakdown`` per scope; when their
-    sum doesn't reconcile with the authoritative Total (>200k tiered pricing —
-    see ``_cost_breakdown_approximate``), the scope's Input/Output cells get a
-    "~" marker rather than showing numbers that visibly don't add up.
+    are derived from the accumulated ``CostBreakdown`` per scope. Per-scope
+    ``state`` (see ``_cost_scope_state``) decides how the component cells
+    render: exact ("ok"), "~"-marked with a tiered-pricing footnote ("approx"
+    = genuine >200k tiering), or "—" with an "unavailable" note ("unavail" =
+    breakdown reset post-restart / not-yet-accumulated — NEVER misattributed
+    to tiered pricing).
     """
     from reyn.llm.pricing import CostBreakdown
 
@@ -288,33 +310,39 @@ def _cost_breakdown_table(snap) -> list[str]:
     header = "COST" + "".join(f"{name:>{col_w}}" for name, _, _ in scopes)
 
     per_scope = [
-        (name, total, *_cost_scope_values(breakdown, total))
+        (name, total, *_cost_scope_state(breakdown, total))
         for name, breakdown, total in scopes
     ]
-    any_approx = any(approx for *_rest, approx in per_scope)
+    any_approx = any(state == "approx" for *_rest, state in per_scope)
+    any_unavail = any(state == "unavail" for *_rest, state in per_scope)
 
     total_row = "Total" + "".join(f"{'$' + format(total, '.4f'):>{col_w}}" for _, total, *_ in per_scope)
 
-    def _marked(value: float, approx: bool) -> str:
+    def _cell(value: float, state: str) -> str:
+        if state == "unavail":
+            return "—"
         s = f"${value:.4f}"
-        return ("~" + s)[:col_w] if approx else s
+        return ("~" + s)[:col_w] if state == "approx" else s
 
     input_row = "Input" + "".join(
-        f"{_marked(inp, approx):>{col_w}}" for _, _, inp, _out, _sav, _pct, approx in per_scope
+        f"{_cell(inp, state):>{col_w}}" for _, _, inp, _out, _sav, _pct, state in per_scope
     )
     output_row = "Output" + "".join(
-        f"{_marked(out, approx):>{col_w}}" for _, _, _inp, out, _sav, _pct, approx in per_scope
+        f"{_cell(out, state):>{col_w}}" for _, _, _inp, out, _sav, _pct, state in per_scope
     )
     saved_row = "Saved" + "".join(
-        f"{_marked(sav, approx):>{col_w}}" for _, _, _inp, _out, sav, _pct, approx in per_scope
+        f"{_cell(sav, state):>{col_w}}" for _, _, _inp, _out, sav, _pct, state in per_scope
     )
     pct_row = "Saved%" + "".join(
-        f"{round(100 * pct)}%".rjust(col_w) for _, _, _inp, _out, _sav, pct, _approx in per_scope
+        ("—".rjust(col_w) if state == "unavail" else f"{round(100 * pct)}%".rjust(col_w))
+        for _, _, _inp, _out, _sav, pct, state in per_scope
     )
 
     rows = [header, total_row, input_row, output_row, saved_row, pct_row]
     if any_approx:
         rows.append("~ approx at high volume (>200k tiered pricing)")
+    if any_unavail:
+        rows.append("— breakdown unavailable this session (Total is exact)")
     return rows
 
 

--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -225,16 +225,106 @@ def _cache_hit_line(label: str, cached: int, prompt: int, *, note: str = "") -> 
     return f"{label:<9}{pct}% hit ({cached:,} / {prompt:,} prompt tokens{tail})"
 
 
+# Cost-panel breakdown (#cost-panel-breakdown): the >200k tiered-pricing guard
+# tolerance. estimate_cost_breakdown() does not replicate litellm's >200k
+# tiered rates (see its docstring), so the 4 components' sum can legitimately
+# diverge from the litellm-accurate Total at very high token volumes. A pure
+# floating-point rounding residual from summing many small per-call floats is
+# NOT the same thing as tiered pricing kicking in — the relative tolerance
+# below absorbs float noise while still catching a real tiered-rate mismatch
+# (which is typically a multi-percent divergence, not a rounding-error one).
+_COST_BREAKDOWN_EPSILON_ABS = 1e-6
+_COST_BREAKDOWN_EPSILON_REL = 1e-4
+
+
+def _cost_breakdown_approximate(component_sum: float, authoritative_total: float) -> bool:
+    """True when Input+Output (derived from CostBreakdown, per-model-rate
+    accumulated) diverges from the litellm-accurate authoritative Total beyond
+    float-noise tolerance — the signal that >200k tiered pricing kicked in for
+    at least one call in this scope's history (see module-level epsilon note)."""
+    tol = max(_COST_BREAKDOWN_EPSILON_ABS, abs(authoritative_total) * _COST_BREAKDOWN_EPSILON_REL)
+    return abs(component_sum - authoritative_total) > tol
+
+
+def _cost_scope_values(breakdown, authoritative_total: float) -> "tuple[float, float, float, float, bool]":
+    """One scope column's (input_cost, output_cost, saved, saved_pct, approximate).
+
+    ``input_cost`` = the cache-aware cost actually paid for input (prompt +
+    cache-read + cache-creation components). ``saved_pct`` = Saved /
+    (Input + Saved) — the no-cache-baseline denominator (what input would have
+    cost WITHOUT caching), NOT Saved / Total (falsified explicitly: pinning
+    the wrong denominator would silently under/over-state the savings %).
+    Divide-by-zero guarded (0% when Input+Saved == 0, i.e. no priced input
+    tokens recorded yet)."""
+    input_cost = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
+    output_cost = breakdown.completion_cost
+    saved = breakdown.cache_savings
+    no_cache_baseline = input_cost + saved
+    saved_pct = (saved / no_cache_baseline) if no_cache_baseline > 0 else 0.0
+    approximate = _cost_breakdown_approximate(input_cost + output_cost, authoritative_total)
+    return input_cost, output_cost, saved, saved_pct, approximate
+
+
+def _cost_breakdown_table(snap) -> list[str]:
+    """The 5-row (Total/Input/Output/Saved/Saved%) x 3-column
+    (Session/Agent/Project) cost-panel breakdown table.
+
+    Total is always the litellm-accurate authoritative figure (``cost_usd`` /
+    ``cost_agent`` / ``cost_total`` — already computed via ``estimate_cost``,
+    unaffected by the >200k breakdown limitation). Input/Output/Saved/Saved%
+    are derived from the accumulated ``CostBreakdown`` per scope; when their
+    sum doesn't reconcile with the authoritative Total (>200k tiered pricing —
+    see ``_cost_breakdown_approximate``), the scope's Input/Output cells get a
+    "~" marker rather than showing numbers that visibly don't add up.
+    """
+    from reyn.llm.pricing import CostBreakdown
+
+    scopes = [
+        ("Ses", snap.get("cost_breakdown_session", CostBreakdown()), snap["cost_usd"]),
+        ("Agt", snap.get("cost_breakdown_agent", CostBreakdown()), snap.get("cost_agent", snap["cost_usd"])),
+        ("Prj", snap.get("cost_breakdown_project", CostBreakdown()), snap.get("cost_total", snap["cost_usd"])),
+    ]
+    col_w = 9
+    header = "COST" + "".join(f"{name:>{col_w}}" for name, _, _ in scopes)
+
+    per_scope = [
+        (name, total, *_cost_scope_values(breakdown, total))
+        for name, breakdown, total in scopes
+    ]
+    any_approx = any(approx for *_rest, approx in per_scope)
+
+    total_row = "Total" + "".join(f"{'$' + format(total, '.4f'):>{col_w}}" for _, total, *_ in per_scope)
+
+    def _marked(value: float, approx: bool) -> str:
+        s = f"${value:.4f}"
+        return ("~" + s)[:col_w] if approx else s
+
+    input_row = "Input" + "".join(
+        f"{_marked(inp, approx):>{col_w}}" for _, _, inp, _out, _sav, _pct, approx in per_scope
+    )
+    output_row = "Output" + "".join(
+        f"{_marked(out, approx):>{col_w}}" for _, _, _inp, out, _sav, _pct, approx in per_scope
+    )
+    saved_row = "Saved" + "".join(
+        f"{_marked(sav, approx):>{col_w}}" for _, _, _inp, _out, sav, _pct, approx in per_scope
+    )
+    pct_row = "Saved%" + "".join(
+        f"{round(100 * pct)}%".rjust(col_w) for _, _, _inp, _out, _sav, pct, _approx in per_scope
+    )
+
+    rows = [header, total_row, input_row, output_row, saved_row, pct_row]
+    if any_approx:
+        rows.append("~ approx at high volume (>200k tiered pricing)")
+    return rows
+
+
 def _cost_expansion(snap, dispatch):
     def lines():
         p, c, t = snap["usage"]
-        session = snap["cost_usd"]
         agent_t = snap.get("agent_tokens", t)
         cached = snap.get("session_cached_tokens", 0)
         return [
-            f"total    ${snap.get('cost_total', session):.4f}",
-            f"agent    ${snap.get('cost_agent', session):.4f}",
-            f"session  ${session:.4f}",
+            *_cost_breakdown_table(snap),
             f"tokens   prompt {p} · completion {c} · total {agent_t}",
             _cache_hit_line("cache", cached, p, note="cumulative"),
         ]
@@ -807,6 +897,14 @@ def _snapshot(registry, task_cache=None, config=None):
         "cost_total": cost_total,
         "cost_agent": cost_agent,
         "agent_tokens": agent_tokens,
+        # Cost-panel breakdown (#cost-panel-breakdown): per-scope CostBreakdown
+        # (Input/Output/Saved/Saved% rows) mirroring the 3 $ totals above.
+        "cost_breakdown_session": s.total_cost_breakdown,
+        "cost_breakdown_agent": (
+            registry.agent_cost_breakdown(registry.attached_name)
+            if registry.attached_name else s.total_cost_breakdown
+        ),
+        "cost_breakdown_project": registry.project_cost_breakdown(),
         "ctx_used": ctx_used,
         "ctx_window": ctx_window,
         "ctx_source": ctx_source,

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-from reyn.llm.pricing import TokenUsage, estimate_cost
+from reyn.llm.pricing import CostBreakdown, TokenUsage, estimate_cost, estimate_cost_breakdown
 
 # ── exceptions ──────────────────────────────────────────────────────────────
 
@@ -305,6 +305,19 @@ class BudgetTracker:
         self._config = config
         self._agent_tokens: dict[str, int] = defaultdict(int)
         self._agent_cost_usd: dict[str, float] = defaultdict(float)
+        # Cost-panel breakdown (#cost-panel-breakdown): per-agent CostBreakdown
+        # (prompt/cache-read/cache-creation/completion + savings), accumulated
+        # per call in ``record_llm`` alongside ``_agent_cost_usd``. NOT ledger-
+        # persisted — in-memory only, resets on restart (unlike
+        # ``_agent_cost_usd`` above, which the ledger hydrates). This is a
+        # deliberate scope choice, not an oversight: persisting it durably
+        # would mean extending ``BudgetLedger``'s on-disk schema with the 4
+        # cache-breakdown fields and would trigger the CLAUDE.md recovery-
+        # feature PR gate (truncate-falsify test). The authoritative, durable,
+        # restart-surviving TOTAL is ``_agent_cost_usd`` (unchanged); this
+        # breakdown is a same-process-only refinement the cost panel reads to
+        # show Input/Output/Saved on top of that already-durable Total.
+        self._agent_cost_breakdown: dict[str, CostBreakdown] = defaultdict(CostBreakdown)
         # #1190 stage (iii): per-purpose cost attribution
         # (main/compaction/judge/dogfood) for the /budget breakdown payoff.
         self._purpose_tokens: dict[str, int] = defaultdict(int)
@@ -486,6 +499,14 @@ class BudgetTracker:
             new_cost = self._agent_cost_usd[agent] + cost_usd
             self._agent_cost_usd[agent] = new_cost
 
+            # Cost-panel breakdown accumulation (session/agent/project scope
+            # rows). ``estimate_cost_breakdown`` returns None for an unpriced/
+            # unknown model (mirrors ``estimate_cost``'s None-sentinel) — skip
+            # accumulation rather than treat unknown as free.
+            breakdown = estimate_cost_breakdown(model, usage)
+            if breakdown is not None:
+                self._agent_cost_breakdown[agent] += breakdown
+
             cap = self._config.per_agent_tokens
             if cap.is_active and cap.warn_threshold is not None:
                 if new_tokens >= cap.warn_threshold:
@@ -535,6 +556,7 @@ class BudgetTracker:
         }
         self._agent_tokens.clear()
         self._agent_cost_usd.clear()
+        self._agent_cost_breakdown.clear()
         self._call_window.clear()
         self._warned.clear()
         return before
@@ -744,6 +766,13 @@ class BudgetTracker:
         """All-time cumulative TOTAL tokens for ``agent`` (durable, ledger-hydrated). Total only —
         the prompt/completion breakdown is not persisted per ledger record (only ``total_tokens``)."""
         return self._agent_tokens.get(agent, 0)
+
+    def agent_cost_breakdown(self, agent: str) -> CostBreakdown:
+        """Cache-aware ``CostBreakdown`` accumulated for ``agent`` (cost-panel Input/Output/Saved
+        rows). Same-process only (see ``__init__``'s note) — NOT ledger-hydrated, unlike
+        ``agent_cost_usd``/``agent_tokens`` above; resets on restart. Returns an empty (all-zero)
+        ``CostBreakdown`` for an agent with no recorded calls this process."""
+        return self._agent_cost_breakdown.get(agent, CostBreakdown())
 
     def _agent_context(self, agent: str | None) -> dict:
         if agent is None:

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -456,6 +456,28 @@ class AgentRegistry:
                 total += sess.total_usage
         return total
 
+    def agent_cost_breakdown(self, name: str) -> "object":
+        """Agent-scope cache-aware ``CostBreakdown`` — the durable process-shared
+        BudgetTracker's per-agent accumulation (all sessions of ``name``, this
+        process only; see ``BudgetTracker._agent_cost_breakdown`` for why it is
+        NOT ledger-durable unlike ``agent_cost_usd``). Cost-panel Agent column
+        source. Empty ``CostBreakdown`` when no tracker is wired."""
+        from reyn.llm.pricing import CostBreakdown
+        tracker = self._shared_budget_tracker()
+        return tracker.agent_cost_breakdown(name) if tracker is not None else CostBreakdown()
+
+    def project_cost_breakdown(self) -> "object":
+        """Project-scope cache-aware ``CostBreakdown`` — summed across every
+        currently-loaded agent's ``agent_cost_breakdown`` (mirrors the existing
+        ad hoc ``sum(agent_cost_usd(name) for name in loaded_names())`` Project
+        total the inline status bar already computes). Cost-panel Project
+        column source."""
+        from reyn.llm.pricing import CostBreakdown
+        total = CostBreakdown()
+        for name in self.loaded_names():
+            total += self.agent_cost_breakdown(name)
+        return total
+
     def resolve_session(
         self,
         agent_name: str,

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -10,7 +10,7 @@ Session: total_usage, total_cost_usd, router cap counter, last reason.
 from __future__ import annotations
 
 from reyn.core.events.events import EventLog
-from reyn.llm.pricing import TokenUsage
+from reyn.llm.pricing import CostBreakdown, TokenUsage
 
 
 class BudgetGateway:
@@ -46,6 +46,12 @@ class BudgetGateway:
         self._total_usage: TokenUsage = TokenUsage()
         self._last_call_usage: TokenUsage = TokenUsage()
         self._total_cost_usd: float = 0.0
+        # Cost-panel breakdown (Session scope, #cost-panel-breakdown):
+        # cache-aware CostBreakdown accumulated turn-by-turn in
+        # ``add_router_usage`` alongside ``_total_cost_usd``. Session-scoped
+        # (this Session/process only) by construction — mirrors the existing
+        # non-durable semantics of ``_total_usage``/``_total_cost_usd`` above.
+        self._total_cost_breakdown: CostBreakdown = CostBreakdown()
         self._router_cap: int = default_router_cap
         self._router_invocations_this_turn: int = 0
         self._router_last_reason: str = ""
@@ -70,6 +76,12 @@ class BudgetGateway:
         return self._total_cost_usd
 
     @property
+    def total_cost_breakdown(self) -> CostBreakdown:
+        """Cumulative cache-aware ``CostBreakdown`` for this session (Session
+        scope for the cost panel's Input/Output/Saved/Saved% rows)."""
+        return self._total_cost_breakdown
+
+    @property
     def last_call_usage(self) -> TokenUsage:
         """TokenUsage of the single MOST RECENT LLM call only — distinct from
         BOTH the cumulative session total AND a turn-summed figure. A chat
@@ -83,12 +95,21 @@ class BudgetGateway:
     def accumulate(self, result) -> None:
         """Accumulate a single LLM call result's tokens + cost into per-session
         totals. Mirrors Session._accumulate. ``result.token_usage`` is already
-        a single call's usage (not turn-summed), so it doubles as last_call_usage."""
+        a single call's usage (not turn-summed), so it doubles as last_call_usage.
+
+        ``result.cost_breakdown`` (a ``CostBreakdown``) is OPTIONAL — this call
+        site has no ``model`` in scope to derive one itself, unlike
+        ``add_router_usage`` (the actual production accumulation path), so a
+        caller that already computed one can pass it through; absent, the
+        session's ``total_cost_breakdown`` simply does not grow from this call."""
         if result.token_usage is not None:
             self._total_usage += result.token_usage
             self._last_call_usage = result.token_usage
         if result.cost_usd is not None:
             self._total_cost_usd += result.cost_usd
+        cost_breakdown = getattr(result, "cost_breakdown", None)
+        if cost_breakdown is not None:
+            self._total_cost_breakdown += cost_breakdown
 
     def add_router_usage(
         self, *, usage: TokenUsage, last_call_usage: "TokenUsage | None" = None,
@@ -113,7 +134,7 @@ class BudgetGateway:
         self._last_call_usage = last_call_usage if last_call_usage is not None else usage
         # F4 Bug 1: strip proxy prefix so estimate_cost lookup succeeds.
         from reyn.llm.llm import proxy_kwargs
-        from reyn.llm.pricing import estimate_cost
+        from reyn.llm.pricing import estimate_cost, estimate_cost_breakdown
         resolved = resolver.resolve(router_model_name).model
         pricing_model = (
             resolved.split("/", 1)[1]
@@ -123,6 +144,13 @@ class BudgetGateway:
         cost_usd, _ = estimate_cost(pricing_model, usage)
         if cost_usd is not None:
             self._total_cost_usd += cost_usd
+        # Cost-panel breakdown (Session scope): accumulate the same call's
+        # cache-aware component breakdown. None for an unpriced/unknown model
+        # (mirrors estimate_cost's None-sentinel) — skip rather than treat
+        # unknown as free.
+        breakdown = estimate_cost_breakdown(pricing_model, usage)
+        if breakdown is not None:
+            self._total_cost_breakdown += breakdown
 
     # ── router cap ────────────────────────────────────────────────────────────
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2249,6 +2249,12 @@ class Session:
     def total_cost_usd(self) -> float:
         return self._budget.total_cost_usd
 
+    @property
+    def total_cost_breakdown(self):
+        """Cache-aware ``CostBreakdown`` for this session (Session-scope row
+        source for the cost panel's Input/Output/Saved/Saved% breakdown)."""
+        return self._budget.total_cost_breakdown
+
     # ── FP-0043 Stage 2: identity-field delegations to the Agent value object ──
     # Read-only by construction (identity is immutable for the session lifetime;
     # no field is reassigned post-__init__, verified). Every former direct

--- a/tests/test_cost_panel_breakdown_3scope.py
+++ b/tests/test_cost_panel_breakdown_3scope.py
@@ -1,0 +1,193 @@
+"""Tier 2: cost-panel 3-scope breakdown accumulation (#cost-panel-breakdown).
+
+#2931 added ``CostBreakdown`` / ``estimate_cost_breakdown`` (cache-aware
+prompt/cache-read/cache-creation/completion components + ``cache_savings`` +
+``cache_hit_rate``) as backend-only, no panel wiring. This file pins the
+wiring this PR adds:
+
+  1. ``BudgetTracker.record_llm`` now accumulates a per-agent ``CostBreakdown``
+     (``agent_cost_breakdown``) alongside the existing ``agent_cost_usd`` float,
+     driven by REAL per-call ``estimate_cost_breakdown`` invocations — including
+     across TWO DIFFERENT MODELS with different rates, to falsify the
+     multi-model aggregation hazard (re-pricing aggregated token counts with a
+     single model's rate would be wrong; accumulating each call's own
+     model-rate breakdown is the correct approach and is what is under test).
+  2. Total (litellm-accurate, ``agent_cost_usd``) equals Input+Output
+     (``prompt_cost + cache_read_cost + cache_creation_cost + completion_cost``,
+     i.e. ``CostBreakdown.total_cost``) for a mixed-model scope, below the
+     >200k tiered-pricing threshold.
+  3. Saved% uses the correct no-cache-baseline denominator — Saved /
+     (Input + Saved) — FALSIFIED against the wrong denominator (Saved / Total).
+  4. The 3 scopes aggregate correctly: Session-scope calls are a subset of
+     Agent-scope calls (all sessions of one agent) are a subset of
+     Project-scope calls (all agents) — Session ⊆ Agent ⊆ Project by sum.
+
+Policy: no mocks — real ``BudgetTracker`` + real ``litellm`` pricing lookups
+(the same real accumulation path ``call_llm_tools`` drives in production, via
+directly-invoked ``record_llm``, since a real network completion isn't needed
+to exercise this bookkeeping).
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+# Two real, differently-priced models (falsifies re-pricing aggregated token
+# counts with a single model's rate — see module docstring point 1).
+_MODEL_A = "claude-sonnet-4-5-20250929"  # cache-capable, higher rate
+_MODEL_B = "gpt-4o-mini"                 # cache-capable, much lower rate
+
+
+def _epsilon_close(a: float, b: float, eps: float = 1e-6) -> bool:
+    return abs(a - b) < eps
+
+
+def test_agent_cost_breakdown_accumulates_across_calls_and_models() -> None:
+    """Tier 2: per-agent CostBreakdown accumulates across multiple calls to
+    DIFFERENT models — each call is priced at ITS OWN model's rate (not a
+    single re-priced rate applied to the summed tokens)."""
+    tracker = BudgetTracker(CostConfig())
+
+    usage_a1 = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=800, cache_creation_tokens=100)
+    usage_a2 = TokenUsage(prompt_tokens=500, completion_tokens=50, cached_tokens=0, cache_creation_tokens=0)
+    usage_b1 = TokenUsage(prompt_tokens=2000, completion_tokens=300, cached_tokens=1000, cache_creation_tokens=0)
+
+    tracker.record_llm(model=_MODEL_A, agent="alice", usage=usage_a1)
+    tracker.record_llm(model=_MODEL_A, agent="alice", usage=usage_a2)
+    tracker.record_llm(model=_MODEL_B, agent="alice", usage=usage_b1)
+
+    breakdown = tracker.agent_cost_breakdown("alice")
+
+    # Cross-check against independently-computed per-call breakdowns summed
+    # by hand (mirrors what estimate_cost_breakdown itself returns per call —
+    # NOT re-derived from a single re-priced rate over the combined tokens).
+    from reyn.llm.pricing import estimate_cost_breakdown
+    expected = (
+        estimate_cost_breakdown(_MODEL_A, usage_a1)
+        + estimate_cost_breakdown(_MODEL_A, usage_a2)
+        + estimate_cost_breakdown(_MODEL_B, usage_b1)
+    )
+    assert _epsilon_close(breakdown.total_cost, expected.total_cost)
+    assert _epsilon_close(breakdown.cache_savings, expected.cache_savings)
+    assert breakdown.prompt_tokens == expected.prompt_tokens
+    assert breakdown.cached_tokens == expected.cached_tokens
+
+
+def test_total_equals_input_plus_output_below_200k() -> None:
+    """Tier 2: the authoritative Total (agent_cost_usd, litellm-accurate) equals
+    Input+Output derived from the accumulated CostBreakdown, for a mixed-model
+    scope below the >200k tiered-pricing threshold."""
+    tracker = BudgetTracker(CostConfig())
+
+    usage_a = TokenUsage(prompt_tokens=1500, completion_tokens=250, cached_tokens=1000, cache_creation_tokens=200)
+    usage_b = TokenUsage(prompt_tokens=3000, completion_tokens=400, cached_tokens=1500, cache_creation_tokens=0)
+
+    tracker.record_llm(model=_MODEL_A, agent="bob", usage=usage_a)
+    tracker.record_llm(model=_MODEL_B, agent="bob", usage=usage_b)
+
+    total = tracker.agent_cost_usd("bob")
+    breakdown = tracker.agent_cost_breakdown("bob")
+    input_cost = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
+    output_cost = breakdown.completion_cost
+
+    assert _epsilon_close(total, input_cost + output_cost), (
+        f"Total ({total}) must equal Input+Output ({input_cost + output_cost}) "
+        "below the 200k tiered-pricing threshold"
+    )
+
+
+def test_saved_pct_uses_input_plus_saved_denominator_not_total() -> None:
+    """Tier 2: FALSIFY the wrong denominator. Saved% = Saved / (Input + Saved)
+    — the no-cache BASELINE input cost — not Saved / Total. Total includes
+    Output, which is unrelated to the input cache discount; using Total as the
+    denominator would silently understate the savings percentage whenever
+    Output is nonzero (as it always is for a real call)."""
+    tracker = BudgetTracker(CostConfig())
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=500, cached_tokens=800, cache_creation_tokens=0)
+    tracker.record_llm(model=_MODEL_A, agent="carol", usage=usage)
+
+    breakdown = tracker.agent_cost_breakdown("carol")
+    input_cost = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
+    saved = breakdown.cache_savings
+    total = tracker.agent_cost_usd("carol")
+
+    correct_denominator = input_cost + saved
+    correct_pct = saved / correct_denominator
+    wrong_pct_using_total = saved / total  # the bug this test falsifies
+
+    assert correct_denominator > 0
+    assert saved > 0, "this scenario has cached tokens, so savings must be > 0"
+    # Output being nonzero means Total > Input+Saved always in this scenario,
+    # so the wrong-denominator % must be strictly LOWER than the correct one —
+    # a real, observable divergence, not just a formula difference on paper.
+    assert wrong_pct_using_total < correct_pct
+    assert 0.0 < correct_pct < 1.0
+
+
+def test_saved_pct_zero_when_no_priced_input_recorded() -> None:
+    """Tier 2: Saved% divide-by-zero guard — 0% (not an exception) when no
+    input cost has been recorded yet for a scope (Input + Saved == 0)."""
+    tracker = BudgetTracker(CostConfig())
+    breakdown = tracker.agent_cost_breakdown("nobody-yet")
+    input_cost = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
+    saved = breakdown.cache_savings
+    denominator = input_cost + saved
+    pct = (saved / denominator) if denominator > 0 else 0.0
+    assert pct == 0.0
+
+
+def test_session_agent_project_scopes_aggregate_correctly() -> None:
+    """Tier 2: Session ⊆ Agent ⊆ Project — a registry-style 3-scope sum built
+    the same way ``registry.agent_cost_breakdown`` / ``project_cost_breakdown``
+    do (one shared BudgetTracker; per-agent accumulation; Project = sum over
+    every agent) reconstructs correctly from real per-call recordings."""
+    tracker = BudgetTracker(CostConfig())
+
+    # "dave" has TWO sessions' worth of calls (session-scope would only see
+    # ONE of them; agent-scope sees both — mirroring registry.agent_total_usage
+    # summing across all sids of one agent).
+    dave_session1_usage = TokenUsage(prompt_tokens=1000, completion_tokens=100, cached_tokens=500)
+    dave_session2_usage = TokenUsage(prompt_tokens=800, completion_tokens=80, cached_tokens=300)
+    tracker.record_llm(model=_MODEL_A, agent="dave", usage=dave_session1_usage)
+    tracker.record_llm(model=_MODEL_A, agent="dave", usage=dave_session2_usage)
+
+    # A second agent, "erin", also recorded — only shows up in Project scope.
+    erin_usage = TokenUsage(prompt_tokens=2000, completion_tokens=200, cached_tokens=1000)
+    tracker.record_llm(model=_MODEL_B, agent="erin", usage=erin_usage)
+
+    from reyn.llm.pricing import estimate_cost_breakdown
+
+    session1_breakdown = estimate_cost_breakdown(_MODEL_A, dave_session1_usage)
+    dave_agent_breakdown = tracker.agent_cost_breakdown("dave")
+    erin_agent_breakdown = tracker.agent_cost_breakdown("erin")
+    project_breakdown = dave_agent_breakdown + erin_agent_breakdown  # mirrors registry.project_cost_breakdown
+
+    # Session (session1 only) is strictly <= Agent (both dave sessions summed).
+    assert session1_breakdown.total_cost <= dave_agent_breakdown.total_cost
+    assert session1_breakdown.total_cost < dave_agent_breakdown.total_cost  # session2 adds strictly more
+
+    # Agent (dave) is strictly <= Project (dave + erin).
+    assert dave_agent_breakdown.total_cost <= project_breakdown.total_cost
+    assert dave_agent_breakdown.total_cost < project_breakdown.total_cost  # erin adds strictly more
+
+    # Project total_cost is exactly the sum of the two agents' totals — no
+    # double counting, no dropped calls.
+    assert _epsilon_close(
+        project_breakdown.total_cost,
+        dave_agent_breakdown.total_cost + erin_agent_breakdown.total_cost,
+    )
+
+
+def test_agent_cost_breakdown_not_ledger_durable_resets_on_new_tracker() -> None:
+    """Tier 2: agent_cost_breakdown is explicitly NOT ledger-persisted (see
+    BudgetTracker.__init__'s docstring) — a fresh tracker (simulating restart)
+    starts at empty even though the durable agent_cost_usd would, via
+    hydrate(), have survived. This test documents/pins the scope choice so a
+    future change to durability is a deliberate decision, not silent drift."""
+    tracker = BudgetTracker(CostConfig())
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=100, cached_tokens=500)
+    tracker.record_llm(model=_MODEL_A, agent="frank", usage=usage)
+    assert tracker.agent_cost_breakdown("frank").total_cost > 0
+
+    fresh_tracker = BudgetTracker(CostConfig())
+    assert fresh_tracker.agent_cost_breakdown("frank").total_cost == 0.0

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -41,6 +41,7 @@ from reyn.interfaces.inline.app import (
 )
 from reyn.interfaces.inline.region import DetailElement
 from reyn.interfaces.inline.region_command import CommandUIElement
+from reyn.llm.pricing import CostBreakdown
 
 
 def _snap(**over):
@@ -729,18 +730,25 @@ def test_cost_expansion_tokens_fallback_to_session_total_when_absent() -> None:
     assert "total 209" in " ".join(lines)
 
 
-def test_cost_expansion_breaks_down_total_agent_session() -> None:
-    """Tier 2: cost expansion shows distinct total / agent / session amounts when
-    multiple agents/sessions accrue cost (total across agents ≥ the attached
-    session). Each level renders its own dollar amount, not one collapsed total."""
+def test_cost_expansion_breaks_down_ses_agt_prj() -> None:
+    """Tier 2: cost expansion's Total row shows distinct Session / Agent /
+    Project amounts when multiple agents/sessions accrue cost (Project total
+    across agents >= the attached session). Each scope column renders its own
+    dollar amount, not one collapsed total (owner-approved 5-row x 3-scope
+    cost-panel design, #cost-panel-breakdown)."""
     snap = _snap(cost_usd=0.0100, cost_agent=0.0100, cost_total=0.0750)
     lines = _cost_expansion(snap, lambda _: None).lines()
-    by_label = {ln.split()[0]: ln for ln in lines if ln.split()}
-    assert {"total", "agent", "session"} <= set(by_label)
-    assert "0.0750" in by_label["total"]      # sum across loaded agents
-    assert "0.0100" in by_label["session"]    # the attached session
-    # the breakdown is not collapsed: total reflects the cross-agent sum
-    assert by_label["total"] != by_label["session"]
+    joined = "\n".join(lines)
+    header = next(ln for ln in lines if ln.startswith("COST"))
+    total_row = next(ln for ln in lines if ln.startswith("Total"))
+    # the 3 scope headers are present, in Session/Agent/Project order
+    assert ["Ses", "Agt", "Prj"] == header.split()[-3:]
+    assert "0.0750" in total_row     # Project: sum across loaded agents
+    assert "0.0100" in total_row     # Session (and Agent, same value here)
+    # the breakdown is not collapsed: distinct Project vs Session figures
+    # both appear in the Total row (not just one repeated number).
+    assert total_row.count("0.0100") >= 1 and "0.0750" in total_row
+    assert "Input" in joined and "Output" in joined and "Saved" in joined
 
 
 def test_cost_expansion_shows_cumulative_cache_hit_rate() -> None:
@@ -751,6 +759,110 @@ def test_cost_expansion_shows_cumulative_cache_hit_rate() -> None:
     lines = _cost_expansion(snap, lambda _: None).lines()
     joined = "\n".join(lines)
     assert "75% hit (60,000 / 80,000 prompt tokens, cumulative)" in joined
+
+
+def test_cost_expansion_input_output_saved_rows_render_expected_values() -> None:
+    """Tier 2: Input/Output/Saved/Saved% rows render the session-scope
+    CostBreakdown's derived values — Input = prompt+cache_read+cache_creation
+    cost, Output = completion_cost, Saved = cache_savings, Saved% = Saved /
+    (Input + Saved) (the no-cache-baseline denominator, not Saved / Total)."""
+    breakdown = CostBreakdown(
+        prompt_cost=0.0010,
+        cache_read_cost=0.0002,
+        cache_creation_cost=0.0004,
+        completion_cost=0.0089,
+        cache_savings=0.0072,
+        prompt_tokens=1000,
+        cached_tokens=800,
+    )
+    session_total = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost + breakdown.completion_cost
+    snap = _snap(cost_usd=session_total, cost_breakdown_session=breakdown)
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    input_row = next(ln for ln in lines if ln.startswith("Input"))
+    output_row = next(ln for ln in lines if ln.startswith("Output"))
+    saved_row = next(ln for ln in lines if ln.startswith("Saved") and not ln.startswith("Saved%"))
+    pct_row = next(ln for ln in lines if ln.startswith("Saved%"))
+
+    expected_input = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost
+    expected_pct = round(100 * breakdown.cache_savings / (expected_input + breakdown.cache_savings))
+
+    assert f"${expected_input:.4f}" in input_row
+    assert f"${breakdown.completion_cost:.4f}" in output_row
+    assert f"${breakdown.cache_savings:.4f}" in saved_row
+    assert f"{expected_pct}%" in pct_row
+
+
+def test_cost_expansion_saved_pct_denominator_is_input_plus_saved_not_total() -> None:
+    """Tier 2: FALSIFY the wrong denominator. Saved% must be computed as
+    Saved / (Input + Saved), NOT Saved / Total. Total includes Output, which
+    is unrelated to the cache discount — using it as the denominator would
+    silently understate the shown percentage."""
+    breakdown = CostBreakdown(
+        prompt_cost=0.0010,
+        cache_read_cost=0.0002,
+        completion_cost=0.0500,  # large Output relative to Input — makes the
+        cache_savings=0.0072,    # two candidate denominators visibly diverge
+        prompt_tokens=1000,
+        cached_tokens=800,
+    )
+    input_cost = breakdown.prompt_cost + breakdown.cache_read_cost
+    total = input_cost + breakdown.completion_cost
+    correct_pct = round(100 * breakdown.cache_savings / (input_cost + breakdown.cache_savings))
+    wrong_pct = round(100 * breakdown.cache_savings / total)
+    assert correct_pct != wrong_pct, "scenario must make the two denominators diverge"
+
+    snap = _snap(cost_usd=total, cost_breakdown_session=breakdown)
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    pct_row = next(ln for ln in lines if ln.startswith("Saved%"))
+    assert f"{correct_pct}%" in pct_row
+    assert f"{wrong_pct}%" not in pct_row
+
+
+def test_cost_expansion_shows_approximate_marker_when_breakdown_diverges_from_total() -> None:
+    """Tier 2: >200k tiered-pricing guard — when the accumulated breakdown's
+    Input+Output sum materially diverges from the authoritative (litellm-
+    accurate) Total, the panel marks the affected scope's rows with "~"
+    (approximate) instead of showing exact numbers that visibly don't add up,
+    and appends a footnote. Below-threshold scenarios (the other tests in this
+    file) must NOT show the marker."""
+    breakdown = CostBreakdown(
+        prompt_cost=1.0,
+        completion_cost=1.0,
+        cache_savings=0.1,
+        prompt_tokens=1000,
+        cached_tokens=100,
+    )
+    # authoritative Total materially disagrees with breakdown.total_cost (2.0)
+    # — simulates >200k tiered pricing having kicked in for this scope.
+    diverging_total = 3.0
+    snap = _snap(cost_usd=diverging_total, cost_breakdown_session=breakdown)
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+    input_row = next(ln for ln in lines if ln.startswith("Input"))
+    assert "~" in input_row
+    assert any("approx" in ln for ln in lines)
+    # Total row itself stays exact — it's the authoritative figure, never
+    # marked approximate.
+    total_row = next(ln for ln in lines if ln.startswith("Total"))
+    assert "~" not in total_row
+    assert f"${diverging_total:.4f}" in total_row
+
+
+def test_cost_expansion_no_approximate_marker_when_breakdown_reconciles() -> None:
+    """Tier 2: the normal (below-200k) case shows no approximate marker — the
+    guard must not false-positive on ordinary floating-point-exact scenarios."""
+    breakdown = CostBreakdown(
+        prompt_cost=0.001, completion_cost=0.002, cache_savings=0.0005,
+        prompt_tokens=100, cached_tokens=10,
+    )
+    reconciled_total = breakdown.total_cost
+    snap = _snap(
+        cost_usd=reconciled_total, cost_agent=0.0, cost_total=0.0,
+        cost_breakdown_session=breakdown,
+    )
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    assert not any("~" in ln for ln in lines)
+    assert not any("approx" in ln for ln in lines)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -24,6 +24,7 @@ from reyn.interfaces.inline.app import (
     _agent_expansion,
     _build_task_tree,
     _cost_expansion,
+    _cost_scope_state,
     _cron_category_expansion,
     _extract_skills,
     _hook_category_expansion,
@@ -888,9 +889,27 @@ def test_cost_expansion_restart_state_does_not_false_fire_tiered_marker() -> Non
 
     Without the state guard (i.e. if divergence alone drove the marker), this
     scenario's 0-vs-nonzero gap would fire the tiered footnote — this test
-    fails against that pre-fix behavior.
+    fails against that pre-fix behavior. Verified load-bearing: neutralizing
+    the ``unavail`` branch (``if False``) makes BOTH the direct-state assertion
+    AND the rendering assertions below go RED (the state becomes ``approx`` and
+    the "~"/tiered footnote false-fires).
     """
     from reyn.llm.pricing import CostBreakdown
+
+    # Direct-state contract: empty breakdown + non-zero authoritative Total
+    # classifies as "unavail" (NOT "approx"). This is the load-bearing branch
+    # under strip — asserting the returned state directly (not just the
+    # rendered rows) makes the guard impossible to satisfy without the branch.
+    empty_state = _cost_scope_state(CostBreakdown(), authoritative_total=5.0)
+    assert empty_state[-1] == "unavail", (
+        f"empty breakdown + Total>0 must be 'unavail', got {empty_state[-1]!r}"
+    )
+    # a scope WITH divergent-but-present components is the DISTINCT 'approx'
+    # case — pins the two causes apart so 'unavail' can't absorb tiering.
+    present_diverging = _cost_scope_state(
+        CostBreakdown(prompt_cost=1.0, completion_cost=1.0), authoritative_total=3.0,
+    )
+    assert present_diverging[-1] == "approx"
 
     # Agent scope: durable Total rebuilt from ledger, breakdown reset to empty.
     empty = CostBreakdown()

--- a/tests/test_inline_pr3b_status_bar.py
+++ b/tests/test_inline_pr3b_status_bar.py
@@ -776,7 +776,10 @@ def test_cost_expansion_input_output_saved_rows_render_expected_values() -> None
         cached_tokens=800,
     )
     session_total = breakdown.prompt_cost + breakdown.cache_read_cost + breakdown.cache_creation_cost + breakdown.completion_cost
-    snap = _snap(cost_usd=session_total, cost_breakdown_session=breakdown)
+    snap = _snap(
+        cost_usd=session_total, cost_agent=0.0, cost_total=0.0,
+        cost_breakdown_session=breakdown,
+    )
     lines = _cost_expansion(snap, lambda _: None).lines()
     input_row = next(ln for ln in lines if ln.startswith("Input"))
     output_row = next(ln for ln in lines if ln.startswith("Output"))
@@ -811,7 +814,10 @@ def test_cost_expansion_saved_pct_denominator_is_input_plus_saved_not_total() ->
     wrong_pct = round(100 * breakdown.cache_savings / total)
     assert correct_pct != wrong_pct, "scenario must make the two denominators diverge"
 
-    snap = _snap(cost_usd=total, cost_breakdown_session=breakdown)
+    snap = _snap(
+        cost_usd=total, cost_agent=0.0, cost_total=0.0,
+        cost_breakdown_session=breakdown,
+    )
     lines = _cost_expansion(snap, lambda _: None).lines()
     pct_row = next(ln for ln in lines if ln.startswith("Saved%"))
     assert f"{correct_pct}%" in pct_row
@@ -833,14 +839,19 @@ def test_cost_expansion_shows_approximate_marker_when_breakdown_diverges_from_to
         cached_tokens=100,
     )
     # authoritative Total materially disagrees with breakdown.total_cost (2.0)
-    # — simulates >200k tiered pricing having kicked in for this scope.
+    # — simulates >200k tiered pricing having kicked in for this scope. Agent /
+    # Project scopes zeroed so only the Session column drives this assertion.
     diverging_total = 3.0
-    snap = _snap(cost_usd=diverging_total, cost_breakdown_session=breakdown)
+    snap = _snap(
+        cost_usd=diverging_total, cost_agent=0.0, cost_total=0.0,
+        cost_breakdown_session=breakdown,
+    )
     lines = _cost_expansion(snap, lambda _: None).lines()
-    joined = "\n".join(lines)
     input_row = next(ln for ln in lines if ln.startswith("Input"))
     assert "~" in input_row
     assert any("approx" in ln for ln in lines)
+    # a genuine divergence is NOT reported as "unavailable" (distinct causes).
+    assert not any("unavailable" in ln for ln in lines)
     # Total row itself stays exact — it's the authoritative figure, never
     # marked approximate.
     total_row = next(ln for ln in lines if ln.startswith("Total"))
@@ -863,6 +874,48 @@ def test_cost_expansion_no_approximate_marker_when_breakdown_reconciles() -> Non
     lines = _cost_expansion(snap, lambda _: None).lines()
     assert not any("~" in ln for ln in lines)
     assert not any("approx" in ln for ln in lines)
+
+
+def test_cost_expansion_restart_state_does_not_false_fire_tiered_marker() -> None:
+    """Tier 2: FALSIFY the >200k-marker false-fire after restart. The durable
+    per-agent Total survives restart (ledger-hydrated), but the in-memory
+    CostBreakdown resets to 0 (NOT ledger-persisted). A scope with an empty
+    breakdown (component-sum 0) but a non-zero authoritative Total is
+    "breakdown UNAVAILABLE", NOT ">200k tiered pricing" — the panel must NOT
+    show the "~"/tiered footnote (the misattribution the architect caught), and
+    must instead show the Total exact + a distinct "unavailable" note with the
+    component cells blanked to "—".
+
+    Without the state guard (i.e. if divergence alone drove the marker), this
+    scenario's 0-vs-nonzero gap would fire the tiered footnote — this test
+    fails against that pre-fix behavior.
+    """
+    from reyn.llm.pricing import CostBreakdown
+
+    # Agent scope: durable Total rebuilt from ledger, breakdown reset to empty.
+    empty = CostBreakdown()
+    snap = _snap(
+        cost_usd=0.0,            # session (this process) genuinely 0 → ok/empty
+        cost_agent=5.0,          # durable per-agent Total survived restart
+        cost_total=5.0,          # project = that one agent
+        cost_breakdown_session=empty,
+        cost_breakdown_agent=empty,
+        cost_breakdown_project=empty,
+    )
+    lines = _cost_expansion(snap, lambda _: None).lines()
+    joined = "\n".join(lines)
+
+    # The false-fire is suppressed: no tiered-pricing marker/footnote.
+    assert not any("~" in ln for ln in lines)
+    assert "approx" not in joined
+    assert "tiered" not in joined
+    # Instead, the distinct "unavailable" note appears, and the Total stays exact.
+    assert "unavailable" in joined
+    total_row = next(ln for ln in lines if ln.startswith("Total"))
+    assert "$5.0000" in total_row
+    # component cells blanked to the em-dash placeholder, not fake $0.0000.
+    input_row = next(ln for ln in lines if ln.startswith("Input"))
+    assert "—" in input_row
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[lead-coder]** — Builds the cost-panel breakdown display on top of #2931's backend-only `CostBreakdown` / `estimate_cost_breakdown` (cache-aware component costs + `cache_savings`, aggregatable). Owner-approved design.

## Owner-approved design — 5 rows x 3 scopes

```
COST      Ses      Agt      Prj
Total  $0.0235  $0.1800  $1.8200
Input  $0.0146  $0.1200  $1.2000
Output  $0.0089  $0.0600  $0.6200
Saved  $0.0072  $0.0500  $0.4800
Saved%      33%      29%      29%
```

- **Rows**: Total / Input / Output / Saved / Saved%
  - `Input` = cache-aware input cost (`prompt_cost + cache_read_cost + cache_creation_cost` — cache discounts applied)
  - `Output` = `completion_cost`
  - `Saved` = `cache_savings` (USD saved vs the full input rate)
  - `Saved %` = **`Saved / (Input + Saved)`** — savings as a fraction of the *no-cache baseline* (denominator = what input would have cost WITHOUT caching). NOT `Saved / Total` (Total includes Output, unrelated to the cache discount). Guarded to 0% when `Input + Saved == 0`.
- **Columns** = 3 scopes: Session (current session) / Agent (current agent, all its sessions) / Project (all agents). Compact headers `Ses / Agt / Prj`, right-aligned `$` columns to fit the narrow dropdown.

The status bar's single-number Total is unchanged (already made cache-aware by #2931) — this adds the panel breakdown only.

## Multi-model per-call breakdown accumulation

A scope can span calls to different models at different rates, so re-pricing aggregated token counts with one model would be wrong. Instead **each call's `CostBreakdown` is computed at that call's model rate and accumulated** into the scope's running breakdown (`CostBreakdown.__iadd__`). Wiring:

- **Agent scope** — `BudgetTracker.record_llm` accumulates a per-agent `CostBreakdown` (`_agent_cost_breakdown[agent] += estimate_cost_breakdown(model, usage)`) alongside the existing `agent_cost_usd` float; exposed via `BudgetTracker.agent_cost_breakdown` / `registry.agent_cost_breakdown`.
- **Session scope** — `BudgetGateway.add_router_usage` (the production per-turn accumulation site) accumulates `_total_cost_breakdown`; exposed via `Session.total_cost_breakdown`.
- **Project scope** — `registry.project_cost_breakdown` sums `agent_cost_breakdown` over `loaded_names()` (mirrors the existing ad hoc `sum(agent_cost_usd(...))` Project total).
- `_snapshot()` feeds all three into the panel; `_cost_expansion` renders the table.

The agent-scope breakdown is **in-memory only (not ledger-persisted)** — the durable Total (`agent_cost_usd`) is unchanged. Documented as a deliberate scope choice: persisting the 4 breakdown components durably would extend the `BudgetLedger` on-disk schema and trigger the CLAUDE.md recovery-feature PR gate. The panel shows the breakdown on top of the already-durable Total.

## >200k tiered-pricing guard

`estimate_cost` (the Total) is litellm-delegated and correct above Claude's 200k tiered-pricing threshold, but `estimate_cost_breakdown` does not replicate litellm's >200k tiered rates, so the 4 components can legitimately fail to sum to the Total at high volume. Handled gracefully:

- The **Total row is always authoritative** (litellm-accurate, never marked).
- When a scope's `Input + Output` diverges from its authoritative Total beyond a float-noise tolerance (`max(1e-6, |total|*1e-4)`), that scope's Input/Output/Saved cells get a `~` marker and a `~ approx at high volume (>200k tiered pricing)` footnote is appended — rather than showing exact numbers that visibly don't add up. Below-threshold scenarios show no marker (guard doesn't false-positive on ordinary float-exact sums).

## Tests (real, no mocks)

- `tests/test_cost_panel_breakdown_3scope.py` (6 tests) — real `BudgetTracker` + real litellm pricing across TWO models (`claude-sonnet-4-5` + `gpt-4o-mini`): per-call breakdown accumulates at each model's own rate (multi-model); Total = Input+Output below 200k; Saved% denominator = Input+Saved (FALSIFIED against `Saved/Total`); Session ⊆ Agent ⊆ Project aggregation; divide-by-zero guard; non-durable-resets-on-fresh-tracker.
- `tests/test_inline_pr3b_status_bar.py` — updated `_cost_expansion` tests for the new table + 5 new tests: Input/Output/Saved/Saved% render, Saved% wrong-denominator falsification, approximate-marker on divergence, no-false-positive marker.

## Gates

- `ruff check src tests` — clean
- `pytest` (repo root, foreground) — **8475 passed, 20 skipped**
- `python scripts/verify_module_docstrings.py <changed src>` — OK
- `python scripts/test_tier_audit.py --strict <changed test files>` — 85 tests, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)