### PR TITLE
feat: 0062 structured output — schema constrains generation (response_format) + AgentStep.model

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -192,6 +192,7 @@ AgentBody     ::= "{" "prompt:" TPL
                       ["identity:" NAME]
                       ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
                       ["schema:" NAME]
+                      ["model:" NAME]
                       ["output:" NAME] "}"
 
 CallBody      ::= "{" "pipeline:" NAME            (* static literal, never EXPR *)
@@ -645,6 +646,29 @@ non-conformance fails the step. Schemas declared in the same DSL document set
 [inline pipeline](#ad-hoc-inline-launch) too, since its schemas travel with
 the same definition string.
 
+**`agent` step structured output (0062).** An `agent` step's `schema: NAME`
+does more than validate — it *constrains generation*: the ephemeral session's
+answer turn is issued with a provider-side `response_format` built from the
+named schema, so the model is asked for schema-shaped JSON directly rather
+than free-forming text the OS then hopes parses. The parsed value is still
+validated afterwards (belt-and-suspenders) and bound to `output`. This needs
+a model that supports structured output; an unsupported model, a
+provider-rejected schema, or exhausted-re-prompt non-conformance each fail
+the step with a distinct, diagnosable error rather than silently falling
+back to free-form text.
+
+An `agent` step also accepts `model: NAME`, an optional model-class override
+for that step's ephemeral session (e.g. `model: strong` for a step that needs
+a more capable model than the pipeline's default):
+
+```yaml
+- kind: agent
+  prompt: "Review {ctx.doc}."
+  model: strong
+  schema: Review
+  output: review
+```
+
 ## Invocation
 
 Four tools launch a pipeline. All four converge on the same execution: a
@@ -764,7 +788,7 @@ Step          ::= "transform:" "{" "value:" EXPR ["output:" NAME] "}"
                  | "shell:"    "{" "command:" ArgValue ["schema:" NAME] ["output:" NAME] ["timeout:" INT] "}"
                  | "agent:"    "{" "prompt:" TPL ["identity:" NAME]
                                     ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
-                                    ["schema:" NAME] ["output:" NAME] "}"
+                                    ["schema:" NAME] ["model:" NAME] ["output:" NAME] "}"
                  | "call:"     "{" "pipeline:" NAME ["pass:" "{" (NAME ":" EXPR)* "}"] ["output:" NAME] "}"
                  | "match:"    "{" "on:" EXPR "cases:" "{" (LABEL ":" MatchTarget)+ "}"
                                     ["default:" MatchTarget] ["output:" NAME] "}"

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -181,12 +181,20 @@ class AgentStep:
     (``run_agent_step``'s own contract; this step introduces no additional narrowing).
     ``schema``, if set, names a ``SchemaRegistry``-registered schema the parsed JSON
     reply must conform to — non-conformance fails the step exactly like a ``tool``
-    step's ``verify: schema``."""
+    step's ``verify: schema``. (0062: ``schema`` also now CONSTRAINS generation —
+    the ephemeral session's answer turn is provider-``response_format``-constrained
+    to it, not just post-hoc validated; see ``session_api.run_agent_step``.)
+
+    ``model`` (0062 layer 2, new): an optional model-CLASS override (e.g.
+    ``"strong"``) for the ephemeral session, threaded to ``run_agent_step``'s
+    ``model`` param — resolved the same way the ``/model`` slash command
+    resolves a session override, via the run's ``ModelResolver``."""
 
     prompt: str
     identity: "str | None" = None
     capabilities: "list[str] | None" = None
     schema: "str | None" = None
+    model: "str | None" = None
     output: "str | None" = None
 
 
@@ -860,6 +868,7 @@ async def _run_agent_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str,
             capabilities=step.capabilities,
             schema=step.schema,
             schema_registry=deps.schema_registry,
+            model=step.model,
             # #2769: forward the invoking pipeline's live session so this agent-step's
             # ask_user / permission / present reach the ORIGINATOR (via BridgeToParent +
             # the #2735 transitive bridge) when attached; None → AuditOnly fail-closed.

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -318,7 +318,7 @@ def _reject_unknown_keys(
 _TRANSFORM_KEYS = frozenset({"value", "output"})
 _TOOL_KEYS = frozenset({"name", "args", "schema", "output"})
 _SHELL_KEYS = frozenset({"command", "schema", "output", "timeout"})
-_AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "output"})
+_AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "model", "output"})
 _CALL_KEYS = frozenset({"pipeline", "pass", "output"})
 _MATCH_KEYS = frozenset({"on", "cases", "default", "output"})
 _MATCH_CASE_KEYS = frozenset({"pipeline", "pass"})
@@ -404,9 +404,12 @@ def _parse_agent_step(body: "dict[str, Any]") -> AgentStep:
     schema = body.get("schema")
     if schema is not None and not isinstance(schema, str):
         _fail(f"agent step 'schema': expected a schema-name string, got {type(schema).__name__}")
+    model = body.get("model")
+    if model is not None and not isinstance(model, str):
+        _fail(f"agent step 'model': expected a model-class literal string, got {type(model).__name__}")
     return AgentStep(
         prompt=prompt, identity=identity, capabilities=capabilities, schema=schema,
-        output=body.get("output"),
+        model=model, output=body.get("output"),
     )
 
 

--- a/src/reyn/core/pipeline/schema.py
+++ b/src/reyn/core/pipeline/schema.py
@@ -386,6 +386,66 @@ def _fields_of(ft: dict[str, Any], registry: SchemaRegistry) -> dict[str, dict[s
     return None
 
 
+def to_json_schema(schema: dict[str, Any] | str, registry: SchemaRegistry) -> dict[str, Any]:
+    """Convert a reyn pipeline ``Schema`` (this module's own field-type
+    vocabulary — ``bool``/``string``/``number``/``enum``/``list``/``object``/
+    ``ref``, see the module docstring) into a standard JSON Schema object
+    dict, suitable for an LLM provider's ``response_format={"type":
+    "json_schema", "json_schema": {"schema": ...}}`` (0062 §2.1).
+
+    Passed VERBATIM by the caller — this function does no strict-mode
+    augmentation (no injected ``"strict": true`` / ``"additionalProperties":
+    false`` / optional-field coercion; 0062 §2.3 pin). A provider that
+    rejects the resulting schema surfaces that as the caller's own
+    failure-mode-(b) typed error — augmentation, if ever added, is a
+    deliberate v2 follow-up, not a silent default here.
+
+    ``ref`` fields are expanded INLINE (not ``$ref``/``$defs`` — providers'
+    json_schema subsets vary in ``$ref`` support, and inlining sidesteps that
+    entirely). This always terminates: ``SchemaRegistry.register`` already
+    rejects a recursive schema (self- or mutually-referential ``ref``) at
+    registration time, so no ``ref`` chain reachable from a registered schema
+    can cycle.
+    """
+    if isinstance(schema, str):
+        schema = registry.get(schema)
+    return _fields_to_json_schema(schema["fields"], registry)
+
+
+def _fields_to_json_schema(
+    fields: dict[str, dict[str, Any]], registry: SchemaRegistry
+) -> dict[str, Any]:
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for fname, ft in fields.items():
+        properties[fname] = _field_type_to_json_schema(ft, registry)
+        if ft.get("required"):
+            required.append(fname)
+    out: dict[str, Any] = {"type": "object", "properties": properties}
+    if required:
+        out["required"] = required
+    return out
+
+
+def _field_type_to_json_schema(ft: dict[str, Any], registry: SchemaRegistry) -> dict[str, Any]:
+    t = ft.get("type")
+    if t == "bool":
+        return {"type": "boolean"}
+    if t == "string":
+        return {"type": "string"}
+    if t == "number":
+        return {"type": "number"}
+    if t == "enum":
+        return {"enum": list(ft["values"])}
+    if t == "list":
+        return {"type": "array", "items": _field_type_to_json_schema(ft["of"], registry)}
+    if t == "object":
+        return _fields_to_json_schema(ft["fields"], registry)
+    if t == "ref":
+        return _fields_to_json_schema(registry.get(ft["schema"])["fields"], registry)
+    raise SchemaError(f"to_json_schema: unknown field type {t!r}")
+
+
 def resolve_path(
     schema: dict[str, Any] | str, path: str, registry: SchemaRegistry
 ) -> dict[str, Any] | None:

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -107,6 +107,7 @@ def _encode_agent(step: "AgentStep") -> "dict[str, Any]":
         "identity": step.identity,
         "capabilities": list(step.capabilities) if step.capabilities is not None else None,
         "schema": step.schema,
+        "model": step.model,  # 0062: model-class override, mirrors `schema`'s encoding
         "output": step.output,
     }
 
@@ -131,6 +132,7 @@ def _decode_agent(data: "dict[str, Any]") -> "AgentStep":
         identity=data.get("identity"),
         capabilities=list(caps) if caps is not None else None,
         schema=data.get("schema"),
+        model=data.get("model"),  # 0062
         output=data.get("output"),
     )
 

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1790,6 +1790,7 @@ async def call_llm_tools(
     trace_caller: str | None = None,
     event_log: "EventLog | None" = None,
     emit_cost_events: bool = False,  # #1683: forwarded to recorded_acompletion (chat opts in)
+    response_format: "dict | None" = None,  # 0062: RouterLoop's separate no-tools structured-answer turn ONLY — every op-loop tool-decision call leaves this None (ADR-0035 D2 separate-decide preserved: never combined with a non-empty `tools`)
 ) -> LLMToolCallResult:
     """Tool-use variant of call_llm. Returns raw assistant message.
 
@@ -1801,6 +1802,13 @@ async def call_llm_tools(
       before the LLM call (raises BudgetExceeded if refused) and record_llm
       is called after a successful call. budget=None skips all tracking.
     budget_agent: agent name passed to budget.check_pre_llm / record_llm.
+
+    ``response_format`` (0062): passed straight to ``recorded_acompletion``
+    with NO ``fallback_without_response_format`` (unlike the judge_output /
+    compaction json-mode call sites) — a schema-bearing structured-output
+    call must never silently degrade to free-form text; a provider rejection
+    surfaces as-is for the caller (``RouterLoop._run_structured_answer_turn``)
+    to classify.
     """
     # Normalize model to ModelSpec — accept both str (backward compat) and ModelSpec.
     spec: ModelSpec = model if isinstance(model, ModelSpec) else ModelSpec(model=model, kwargs={})
@@ -1950,6 +1958,7 @@ async def call_llm_tools(
             recorder=None, extra_kwargs=_kw,
             emit_cost_events=emit_cost_events,  # #1683: chat opts in
             routing=_routing,  # #309 per-class api_base/provider (else global wins)
+            response_format=response_format,  # 0062: None for every op-loop tool call
         )
 
     # #2210 HIGH layer: when the per-call HTTP timeout + the Router/Reyn retries are ALL

--- a/src/reyn/runtime/errors.py
+++ b/src/reyn/runtime/errors.py
@@ -41,3 +41,39 @@ class AgentStepError(Exception):
     step's retry/error path), not a construction-time / programming error.
     """
 
+
+class StructuredOutputError(AgentStepError):
+    """Base for 0062 structured-output failures — a ``schema``-bearing
+    ``run_agent_step`` invocation whose provider-constrained (``response_format``)
+    answer turn (``RouterLoop``) could not produce a valid result. Subclasses
+    distinguish the THREE distinct failure modes the proposal requires never
+    be conflated (§2.1): unsupported model (pre-check, no call wasted),
+    provider-rejected schema (fail fast, no re-prompt), and generation-side
+    non-conformance (bounded re-prompt, then this). A subtype of
+    ``AgentStepError`` so the existing pipeline-executor / caller handling
+    (``except AgentStepError``) already covers it uniformly — no separate
+    catch site needed."""
+
+
+class StructuredOutputUnsupportedModelError(StructuredOutputError):
+    """Failure mode (a): the resolved model does not support provider-side
+    structured output (``litellm.supports_response_schema`` returned False).
+    Raised BEFORE the turn's first LLM call (the pre-check runs ahead of the
+    whole turn, tool calls included) so no completion is ever wasted on a
+    model that cannot honor ``response_format`` at all."""
+
+
+class StructuredOutputSchemaRejectedError(StructuredOutputError):
+    """Failure mode (b): the provider's own json_schema-subset validation
+    rejected the SCHEMA itself (a 400 on the constrained-generation call,
+    reached only after the mode-(a) pre-check already passed). Re-prompting
+    cannot fix an incompatible schema, so this is raised on the FIRST such
+    failure — never entered into the mode-(c) re-prompt loop."""
+
+
+class StructuredOutputNonConformingError(StructuredOutputError):
+    """Failure mode (c): the model returned syntactically-valid-schema but
+    semantically non-conforming JSON (or non-JSON text) after the bounded
+    re-prompt budget (feed-the-validation-error-back, N small attempts) was
+    exhausted."""
+

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1313,6 +1313,9 @@ class RouterLoop:
         on_limit: "Any | None" = None,  # OnLimitConfig | None — FP-0005 max_iterations checkpoint
         llm_caller: "Any | None" = None,  # Tier 2 test seam: real-fake injection
         scheme_name: "str | None" = None,  # #1593 PR-2: chat-layer tool-use scheme (None → universal default; the construction site resolves config.tool_use.chat)
+        response_format: "dict | None" = None,  # 0062: schema-constrained answer turn; None = byte-identical (no other caller sets this)
+        schema_validate_fn: "Any | None" = None,  # 0062: Callable[[Any], list[str]] — parsed-value -> validation-error strings ([] = conforming)
+        max_schema_reprompt_attempts: int = 2,  # 0062 §2.1 failure-mode-(c): bounded re-prompt budget (extra attempts beyond the first)
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1410,6 +1413,15 @@ class RouterLoop:
         # patch``. Production callers leave this as ``None``.
         self._llm_caller = llm_caller
         self._on_limit = on_limit  # FP-0005 max_iterations checkpoint config
+        # 0062: when set, the loop's terminal PlainText resolution routes through
+        # a SEPARATE no-tools response_format-constrained call (ADR-0035 D2
+        # separate-decide, reapplied to this loop — see ``_run_structured_answer_turn``)
+        # instead of emitting the tool-turn's own free-form content. None (every
+        # caller except a schema-bearing ``run_agent_step``) is byte-identical to
+        # today's behaviour.
+        self._response_format = response_format
+        self._schema_validate_fn = schema_validate_fn
+        self._max_schema_reprompt_attempts = max(0, int(max_schema_reprompt_attempts))
         self._catalog: dict[str, dict] = {}  # populated per run() — the ADVERTISED mirror
         # #1618 root-1: the DISPATCHABLE membership map (None ⇒ = self._catalog,
         # byte-identical for schemes whose advertised = dispatchable). Set per run()
@@ -1794,6 +1806,43 @@ class RouterLoop:
         terminals below remain host-polymorphic from that design.)
         """
         host = self.host
+        # 0062 §2.1 failure-mode-(a): the model-support pre-check runs BEFORE this
+        # turn's very first LLM call (tool-decision calls included) — a schema
+        # the resolved model cannot honor at all is rejected here so NO completion
+        # is ever wasted on it, whether this turn is a no-capability agent's sole
+        # call or a tool-using agent's multi-round turn.
+        if self._response_format is not None:
+            from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+            from reyn.llm.llm import proxy_kwargs, routing_for_spec
+            from reyn.runtime.errors import StructuredOutputUnsupportedModelError
+            _spec_fn = getattr(host, "resolve_model_spec", None)
+            if _spec_fn is not None:
+                _precheck_spec = _spec_fn(self.router_model)
+            else:
+                from reyn.llm.model_resolver import ModelSpec
+                _precheck_spec = ModelSpec(model=host.resolve_model(self.router_model), kwargs={})
+            # Strip the proxy provider-prefix EXACTLY like ``recorded_acompletion``
+            # does (llm.py) before checking — an operator-configured
+            # ``"openai/gemini-2.5-flash-lite"`` proxy alias must be checked as
+            # the underlying gemini model, not misclassified as an (unsupported)
+            # literal OpenAI model name.
+            _routing = routing_for_spec(_precheck_spec)
+            _extra = _routing if _routing is not None else proxy_kwargs()
+            _precheck_model = (
+                _precheck_spec.model.split("/", 1)[1]
+                if _extra.get("api_base") and "/" in _precheck_spec.model
+                else _precheck_spec.model
+            )
+            ensure_litellm_ready()
+            import litellm
+            if not litellm.supports_response_schema(_precheck_model):
+                raise StructuredOutputUnsupportedModelError(
+                    f"model {_precheck_model!r} does not support structured output "
+                    "(litellm.supports_response_schema returned False) — schema-"
+                    "constrained generation (response_format) requires provider "
+                    "support. Choose a different model class for this agent step, "
+                    "or drop its `schema`."
+                )
         # #1092 PR-B: keep the DISPATCH catalog (``self._catalog``, consumed by
         # ``_execute_tool`` → ``dispatch_tool``'s ``name in ctx.tool_catalog`` gate)
         # in lockstep with the ADVERTISED ``tools=``. For the chat ``run()`` path
@@ -2391,6 +2440,23 @@ class RouterLoop:
                     decision="inline_reply",
                     tool_calls_attempted=_tool_calls_attempted,
                 )
+            # 0062 §2.1/§2.2: this resolution point IS the "answer turn" — for a
+            # no-capability agent it is the sole call above; for a tool-using agent
+            # it is reached only once the model stops requesting tools. When a
+            # ``response_format`` is configured, do NOT emit the tool-turn's own
+            # free-form ``result.content`` — issue the SEPARATE no-tools
+            # constrained call instead (ADR-0035 D2 separate-decide: the tool
+            # round(s) above stayed tools-only/unconstrained the whole time).
+            if self._response_format is not None:
+                _structured_text = await self._run_structured_answer_turn(
+                    messages, resolved_spec,
+                )
+                await self.host.put_outbox(
+                    kind="agent",
+                    text=_structured_text,
+                    meta={"chain_id": self.chain_id, "reasoning": result.reasoning},
+                )
+                return self._total_usage
             await self.host.put_outbox(
                 kind="agent",
                 text=result.content or "",
@@ -2572,6 +2638,101 @@ class RouterLoop:
             {"role": "system", "content": wrap_up_system_prompt(reason=reason)},
             *non_system,
         ]
+
+    async def _run_structured_answer_turn(
+        self, messages: list[dict], resolved_spec: Any,
+    ) -> str:
+        """0062 §2.1: the separate no-tools ``response_format``-constrained
+        answer turn (ADR-0035 D2 separate-decide, reapplied here — the
+        preceding tool-decision round(s) stayed tools-only/unconstrained the
+        whole time; this is the ONE additional call that produces the actual
+        structured reply). Returns the raw JSON text — the caller
+        (``run_agent_step``) still ``json.loads`` + ``core.pipeline.schema.
+        validate``s it as belt-and-suspenders (0062 impl-focus 3: reyn-side
+        re-validate is kept even though the provider already constrained
+        generation).
+
+        Failure-mode separation (0062 §2.1, never conflated):
+          - mode (a) model-unsupported: already excluded by ``run_loop``'s
+            pre-check before this method is ever reached.
+          - mode (b) provider rejects the SCHEMA itself: since (a) already
+            passed, any exception on the FIRST attempt here can only be the
+            provider's json_schema-subset validation rejecting the schema —
+            raised immediately as :class:`StructuredOutputSchemaRejectedError`,
+            never entered into the re-prompt loop below (re-prompting cannot
+            fix an incompatible schema).
+          - mode (c) generation-side non-conformance: a syntactically-fine
+            call whose JSON fails ``json.loads`` or the caller-supplied
+            ``schema_validate_fn`` — bounded re-prompt (feed the error back,
+            ``self._max_schema_reprompt_attempts`` extra attempts), then
+            :class:`StructuredOutputNonConformingError` on exhaustion.
+        """
+        from reyn.runtime.errors import (
+            StructuredOutputNonConformingError,
+            StructuredOutputSchemaRejectedError,
+        )
+
+        attempt_messages = list(messages)
+        last_errors: list[str] = []
+        total_attempts = 1 + self._max_schema_reprompt_attempts
+        for attempt in range(total_attempts):
+            call_messages = attempt_messages
+            if last_errors:
+                call_messages = [
+                    *attempt_messages,
+                    {
+                        "role": "user",
+                        "content": (
+                            "Your previous reply did not conform to the required "
+                            "schema:\n- " + "\n- ".join(last_errors) +
+                            "\n\nReply again with ONLY the corrected JSON, "
+                            "conforming exactly to the schema."
+                        ),
+                    },
+                ]
+            try:
+                # Tier 2 testability (matches the tool-turn call above): honour
+                # ``self._llm_caller`` when a test injected one — the constrained
+                # answer-turn call must go through the SAME real-fake seam, not
+                # bypass it to the real ``call_llm_tools``/litellm.
+                _llm = self._llm_caller or call_llm_tools
+                result = await _llm(
+                    model=resolved_spec, messages=call_messages, tools=[],
+                    budget=self.budget, budget_agent=self.host.agent_name,
+                    trace_caller="router_structured_output",
+                    emit_cost_events=True,
+                    response_format=self._response_format,
+                )
+            except Exception as exc:
+                if attempt == 0:
+                    raise StructuredOutputSchemaRejectedError(
+                        "the model/provider rejected the response_format "
+                        f"schema (fail-fast, no re-prompt): {exc}"
+                    ) from exc
+                raise
+            if result.usage:
+                self._total_usage += result.usage
+                self._last_call_usage = result.usage
+            text = result.content or ""
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                last_errors = [f"output is not valid JSON: {exc}"]
+                attempt_messages = call_messages
+                continue
+            errors = (
+                self._schema_validate_fn(parsed)
+                if self._schema_validate_fn is not None else []
+            )
+            if not errors:
+                return text
+            last_errors = list(errors)
+            attempt_messages = call_messages
+        raise StructuredOutputNonConformingError(
+            "structured-output generation did not converge to a schema-"
+            f"conforming value after {total_attempts} attempt(s); last "
+            f"validation errors: {last_errors}"
+        )
 
     async def _force_close_call(
         self,

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -88,6 +88,15 @@ class RouterLoopDriver:
         # deep-cancel propagation into running subprocess ops (#1470).
         self._turn_cancel_requested: bool = False
         self._turn_cancel_event: asyncio.Event = asyncio.Event()
+        # 0062: per-session structured-output override, set post-construction by
+        # ``configure_structured_output`` (mirrors the existing ``_loop_observer``
+        # Tier-2 test-seam pattern — a public post-construction configure call, NOT
+        # a constructor kwarg thread-through every Session caller would need to
+        # touch). None for every Session except an ephemeral agent-step spawn
+        # whose ``AgentStep.schema`` is set — byte-identical otherwise.
+        self._response_format: "dict | None" = None
+        self._schema_validate_fn: "Any | None" = None
+        self._max_schema_reprompt_attempts: int = 2
         # #1470: wire cancel_event onto router_host so make_router_op_context
         # can thread it into OpContext → sandboxed_exec backend.
         _set_fn = getattr(router_host, "_set_cancel_event", None)
@@ -115,6 +124,28 @@ class RouterLoopDriver:
         """Set the cooperative cancel flag and cancel_event. Called by cancel_inflight()."""
         self._turn_cancel_requested = True
         self._turn_cancel_event.set()
+
+    # ── Structured output (0062) ─────────────────────────────────────────────
+
+    def configure_structured_output(
+        self, *,
+        response_format: "dict | None",
+        schema_validate_fn: "Any | None" = None,
+        max_reprompt_attempts: int = 2,
+    ) -> None:
+        """Configure the NEXT ``run_turn`` call's answer turn to be a
+        schema-constrained ``response_format`` call (0062 §2.1) instead of
+        emitting the tool-turn's own free-form text. Called by
+        ``session_api.run_agent_step`` right after spawning a
+        ``schema``-bearing agent-step's ephemeral session, before its one
+        ``MessageBus.request`` turn — mirrors the existing ``_loop_observer``
+        Tier-2 seam's "configure the constructed session before its turn"
+        shape, but is production wiring (not test-only): every OTHER Session
+        never calls this, so ``RouterLoop(response_format=None, ...)`` (this
+        driver's default) keeps every other turn byte-identical."""
+        self._response_format = response_format
+        self._schema_validate_fn = schema_validate_fn
+        self._max_schema_reprompt_attempts = max(0, int(max_reprompt_attempts))
 
     # ── Model resolution ──────────────────────────────────────────────────────
 
@@ -394,6 +425,11 @@ class RouterLoopDriver:
             # FP-0005: wire safety.on_limit so max_iterations exhaustion routes
             # through handle_limit_exceeded instead of flat-aborting.
             on_limit=getattr(self._safety, "on_limit", None),
+            # 0062: None for every Session except a schema-bearing agent-step spawn
+            # (configure_structured_output called before this run_turn).
+            response_format=self._response_format,
+            schema_validate_fn=self._schema_validate_fn,
+            max_schema_reprompt_attempts=self._max_schema_reprompt_attempts,
         )
         if self._loop_observer:
             self._loop_observer(loop)

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -52,7 +52,7 @@ from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
     _now_iso,
 )
 from reyn.runtime.error_format import classify_router_error
-from reyn.runtime.errors import RouterCapExceeded
+from reyn.runtime.errors import RouterCapExceeded, StructuredOutputError
 from reyn.runtime.limits.limit_handler import (
     LimitDecision,
     handle_limit_exceeded,
@@ -4650,46 +4650,58 @@ class Session:
         self._turn_idle.clear()
         self._turn_owner_task = asyncio.current_task()
         try:
-            if kind == "user":
-                await self._handle_user_message(
-                    payload.get("text", ""),
-                    chain_id=payload.get("chain_id") or _new_chain_id(),
+            try:
+                if kind == "user":
+                    await self._handle_user_message(
+                        payload.get("text", ""),
+                        chain_id=payload.get("chain_id") or _new_chain_id(),
+                    )
+                elif kind == "agent_request":
+                    await self._handle_agent_request(payload)
+                elif kind == "agent_response":
+                    await self._handle_agent_response(payload)
+                elif kind == "pipeline_result":
+                    # IS-2: an async pipeline driver-session posted its terminal
+                    # result here (the agent_response mirror — but chainless: the
+                    # launch returned immediately, so this is a fresh turn, routed
+                    # exactly like a task wake).
+                    await self._handle_pipeline_result(payload)
+                elif kind in ("task_ready", "task_dependency_aborted"):
+                    # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
+                    # (a dependent became ready, or a parent must decide recovery). Both
+                    # surface as an OS-originated message so the LLM acts via ordinary
+                    # task ops (P7 — no decision vocabulary).
+                    await self._handle_task_wake(payload)
+                elif kind == "hook":  # HOOK_INBOX_KIND (#1800 slice 5b)
+                    # E (wake=true) lifecycle-hook push delivered as a turn trigger:
+                    # a system-role [hook:name] message + one router turn (self-
+                    # continuation). The attribution + wake binding ride in the
+                    # payload (race-free; the slice-7 valve can count hook-driven
+                    # turns, and the audit trail attributes the turn to the hook).
+                    await self._handle_hook_message(payload)
+            finally:
+                self._turn_owner_task = None
+                self._turn_idle.set()
+                # Symmetric turn-end lifecycle event. turn_completed fires only on
+                # the router path; turn_settled fires for EVERY turn kind (including
+                # slash / intervention short-circuits that return before the router),
+                # giving UI working-indicators driven by turn_started a reliable
+                # clear signal regardless of how the turn ended.
+                self._chat_events.emit(
+                    "turn_settled", kind=kind, chain_id=payload.get("chain_id"),
                 )
-            elif kind == "agent_request":
-                await self._handle_agent_request(payload)
-            elif kind == "agent_response":
-                await self._handle_agent_response(payload)
-            elif kind == "pipeline_result":
-                # IS-2: an async pipeline driver-session posted its terminal
-                # result here (the agent_response mirror — but chainless: the
-                # launch returned immediately, so this is a fresh turn, routed
-                # exactly like a task wake).
-                await self._handle_pipeline_result(payload)
-            elif kind in ("task_ready", "task_dependency_aborted"):
-                # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
-                # (a dependent became ready, or a parent must decide recovery). Both
-                # surface as an OS-originated message + one router turn so the LLM
-                # acts via ordinary task ops (P7 — no decision vocabulary).
-                await self._handle_task_wake(payload)
-            elif kind == "hook":  # HOOK_INBOX_KIND (#1800 slice 5b)
-                # E (wake=true) lifecycle-hook push delivered as a turn trigger:
-                # a system-role [hook:name] message + one router turn (self-
-                # continuation). The attribution + wake binding ride in the
-                # payload (race-free; the slice-7 valve can count hook-driven
-                # turns, and the audit trail attributes the turn to the hook).
-                await self._handle_hook_message(payload)
         finally:
-            self._turn_owner_task = None
-            self._turn_idle.set()
-            # Symmetric turn-end lifecycle event. turn_completed fires only on
-            # the router path; turn_settled fires for EVERY turn kind (including
-            # slash / intervention short-circuits that return before the router),
-            # giving UI working-indicators driven by turn_started a reliable
-            # clear signal regardless of how the turn ended.
-            self._chat_events.emit(
-                "turn_settled", kind=kind, chain_id=payload.get("chain_id"),
-            )
-        self._maybe_schedule_ephemeral_vanish()
+            # 0062: an outer finally so an ephemeral agent-step session still gets
+            # scheduled to vanish even when the turn body raises past the inner
+            # finally (e.g. a StructuredOutputError re-raised by
+            # ``_handle_user_message`` — see session.py's ``except
+            # StructuredOutputError: raise``). Previously ``_maybe_schedule_
+            # ephemeral_vanish()`` sat AFTER this whole try block and was skipped
+            # on any propagating exception, leaking the ephemeral session; this
+            # feature is the first production path that raises a typed exception
+            # out of a NORMAL (non-cap) turn, so the pre-existing gap is closed
+            # here rather than shipped as a new leak.
+            self._maybe_schedule_ephemeral_vanish()
         return True
 
     def _maybe_schedule_ephemeral_vanish(self) -> None:
@@ -5050,6 +5062,16 @@ class Session:
 
         try:
             await self._run_router_loop(text, chain_id)
+        except StructuredOutputError:
+            # 0062: a schema-bearing agent-step turn's typed structured-output
+            # failure (unsupported model / provider-rejected schema / exhausted
+            # re-prompt budget) must reach the programmatic driver
+            # (``run_agent_step`` via ``MessageBus.request``) as the ORIGINAL
+            # typed exception — re-raise instead of falling through to the
+            # generic handler below, which would collapse it into an opaque
+            # classified "error" outbox string and lose the failure-mode
+            # distinction the caller needs (§2.1's 3 distinct modes).
+            raise
         except RouterCapExceeded as exc:
             await self._emit_router_cap_exhausted_user(exc, chain_id=chain_id, user_text=text)
             return

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -196,6 +196,7 @@ async def run_agent_step(
     capabilities: "list[str] | None" = None,
     schema: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
+    model: "str | None" = None,
     chain_id: "str | None" = None,
     timeout: "float | None" = None,
     invoker_session: "Any | None" = None,
@@ -209,12 +210,29 @@ async def run_agent_step(
     turn via ``MessageBus.request``, and return its collected reply.
 
     With ``schema`` unset, returns the joined ``kind="agent"`` reply text
-    verbatim. With ``schema`` set (a name registered in ``schema_registry``),
-    the text is JSON-parsed and validated against it; the parsed + validated
-    value is returned. A ``schema`` without a ``schema_registry``, non-JSON
-    text, or a schema-non-conforming value each raise ``AgentStepError`` — a
-    normal step failure for the executor's retry/error path, not a
-    construction-time error.
+    verbatim. With ``schema`` set (a name registered in ``schema_registry``):
+    0062 upgrades this from post-hoc-validate-only to ALSO constraining
+    generation — the ephemeral session's answer turn is configured
+    (``RouterLoopDriver.configure_structured_output``, before the turn is
+    driven) to pass a ``response_format`` built from the named schema
+    (``core.pipeline.schema.to_json_schema``), so the model's reply is
+    provider-constrained JSON rather than free-formed text. The reply text is
+    still JSON-parsed + validated here afterwards (belt-and-suspenders — the
+    provider constraint is not blindly trusted). A ``schema`` without a
+    ``schema_registry``, non-JSON text, or a schema-non-conforming value each
+    raise ``AgentStepError`` — a normal step failure for the executor's
+    retry/error path, not a construction-time error. An unsupported model /
+    a provider-rejected schema / an exhausted re-prompt budget raise one of
+    ``StructuredOutputUnsupportedModelError`` / ``StructuredOutputSchemaRejectedError``
+    / ``StructuredOutputNonConformingError`` (all ``AgentStepError`` subtypes —
+    see ``runtime.errors``), propagated from the turn itself.
+
+    ``model`` (0062 layer 2, ``AgentStep.model``): an optional model-CLASS
+    override for the ephemeral session's answer turn, applied the same way
+    the ``/model`` slash command overrides a session's model
+    (``session._model_override``) — resolved via the session's own
+    ``ModelResolver`` at call time, exactly like every other model-class
+    field in the codebase (no bespoke resolution path).
 
     ``chain_id`` defaults to a fresh uuid4 hex (mirrors ``MessageBus``'s own
     ``_new_request_id``). ``timeout`` defaults to
@@ -235,9 +253,19 @@ async def run_agent_step(
     pipe`` run with no live session, or a direct executor call) routes
     ``AuditOnlyNoSurface`` here directly.
     """
-    from reyn.core.pipeline.schema import validate
+    from reyn.core.pipeline.schema import to_json_schema, validate
     from reyn.runtime.message_bus import MessageBus
     from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
+
+    # Moved ahead of the spawn (was previously checked only after the turn ran):
+    # a ``schema`` without a ``schema_registry`` is a caller-contract error that
+    # can never succeed — failing before spawning the ephemeral session avoids
+    # wasting a spawn (+ its S5 budget charge) on a call that cannot complete.
+    if schema is not None and schema_registry is None:
+        raise AgentStepError(
+            f"run_agent_step(schema={schema!r}) requires schema_registry "
+            "(no registry to validate against)."
+        )
 
     narrowing = _build_agent_step_narrowing(capabilities)
     # #2769 (refines #2706/#2710 P3-item3): an agent-step's user-reaching capabilities route to the
@@ -268,6 +296,37 @@ async def run_agent_step(
             "register the spawned session under its own name/sid."
         )
 
+    # 0062 layer 1/2: configure THIS turn's answer to be schema-constrained
+    # (response_format) and/or override the model class, BEFORE driving the
+    # turn — mirrors the ``_loop_observer`` Tier-2 seam's "configure the
+    # constructed session before its turn" shape, but is production wiring:
+    # every other Session (chat, pipeline driver, ...) never calls
+    # ``configure_structured_output`` / sets ``_model_override`` from here, so
+    # this is a no-op (byte-identical) for every non-schema, non-model-override
+    # agent step.
+    if schema is not None:
+        json_schema = to_json_schema(schema, schema_registry)
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": schema, "schema": json_schema},
+        }
+
+        def _validate_fn(parsed_value: Any) -> "list[str]":
+            result = validate(parsed_value, schema, schema_registry)
+            return [
+                f"{e.path or '<root>'}: {e.message}" for e in result.errors
+            ]
+
+        session._loop_driver.configure_structured_output(  # noqa: SLF001 — production seam (RouterLoopDriver.configure_structured_output)
+            response_format=response_format,
+            schema_validate_fn=_validate_fn,
+        )
+    if model is not None:
+        # Same override point the ``/model`` slash command uses
+        # (``interfaces/slash/model.py``) — a model-CLASS string, resolved by
+        # the session's own ``ModelResolver`` at call time, not a bespoke path.
+        session._model_override = model  # noqa: SLF001
+
     bus = MessageBus()
     replies = await bus.request(
         session,
@@ -289,11 +348,7 @@ async def run_agent_step(
     if schema is None:
         return text
 
-    if schema_registry is None:
-        raise AgentStepError(
-            f"run_agent_step(schema={schema!r}) requires schema_registry "
-            "(no registry to validate against)."
-        )
+    # (schema_registry is None already rejected above, before the spawn.)
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError as exc:

--- a/tests/test_0062_structured_output.py
+++ b/tests/test_0062_structured_output.py
@@ -1,0 +1,304 @@
+"""Tier 2c: 0062 structured output — schema constrains generation
+(response_format) + AgentStep.model.
+
+Same harness as ``test_pipeline_r5_run_agent_step.py`` (real ``AgentRegistry``
+/ ``Session`` / ``RouterLoop`` / ``MessageBus`` throughout; the LLM completion
+is faked via a concrete real-callable stub injected through ``RouterLoop``'s
+designed ``_llm_caller`` Tier-2 test seam — never ``unittest.mock``). These
+tests exercise the NEW behavior 0062 adds: a set ``schema`` now drives
+provider-side ``response_format`` on the ephemeral session's answer turn
+(``RouterLoop._run_structured_answer_turn``), not just post-hoc validation,
+and the three DISTINCT failure modes (model-unsupported / provider-rejected-
+schema / generation-non-conforming) are never conflated.
+
+``_SequencedAgentReply`` is a concrete class with a typed ``__call__`` (NOT
+``unittest.mock.MagicMock``/``AsyncMock``/``patch``) that plays back a fixed
+script of responses (content strings or exceptions to raise) and records
+every call's ``model``/``response_format``/``tools`` kwargs — the record is
+the primary evidence for the "no wasted call" / "no re-prompt loop" /
+"model selected" assertions below.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.model_resolver import ModelResolver
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.errors import (
+    StructuredOutputNonConformingError,
+    StructuredOutputSchemaRejectedError,
+    StructuredOutputUnsupportedModelError,
+)
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import run_agent_step
+
+_REVIEW_SCHEMA = {
+    "fields": {
+        "verdict": {"type": "enum", "values": ["approve", "reject"], "required": True},
+        "confidence": {"type": "number", "required": True},
+    },
+}
+
+
+class _SequencedAgentReply:
+    """Plays back ``script`` (one entry consumed per call): a ``str`` returns
+    that content (no tool_calls, finish_reason=stop); an ``Exception``
+    instance is raised instead. Records every call's ``model`` /
+    ``response_format`` / ``tools`` kwargs in ``.calls`` — the primary
+    evidence the tests below assert on (call COUNT for the re-prompt-bound /
+    no-wasted-call claims, and kwarg CONTENT for the model-selection claim)."""
+
+    def __init__(self, script: "list[Any]") -> None:
+        self.script = list(script)
+        self.calls: "list[dict[str, Any]]" = []
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls.append({
+            "model": kwargs.get("model"),
+            "response_format": kwargs.get("response_format"),
+            "tools": kwargs.get("tools"),
+        })
+        item = self.script[len(self.calls) - 1]
+        if isinstance(item, Exception):
+            raise item
+        return LLMToolCallResult(
+            content=item, tool_calls=[], finish_reason="stop", usage=TokenUsage(),
+        )
+
+
+def _registry(
+    tmp_path: Path, scripted: "_SequencedAgentReply | None", *, resolver: "ModelResolver | None" = None,
+) -> AgentRegistry:
+    """Mirrors ``test_pipeline_r5_run_agent_step.py``'s ``_registry`` — real
+    ``AgentRegistry`` + real ``Session`` factory, scripted LLM wired via the
+    ``_loop_observer`` Tier-2 seam. ``resolver`` defaults to a ``standard`` ->
+    a REAL litellm-known model (``gemini/gemini-2.5-flash-lite`` — litellm's
+    static ``supports_response_schema`` table recognizes it with NO network
+    call) so the 0062 pre-check passes for tests that aren't specifically
+    exercising the unsupported-model failure mode."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    holder: dict = {}
+    _resolver = resolver or ModelResolver({
+        "standard": "gemini/gemini-2.5-flash-lite",
+        "strong": "gemini/gemini-2.5-pro",
+    })
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+            resolver=_resolver,
+        )
+        if scripted is not None:
+            s._loop_driver._loop_observer = (
+                lambda loop: setattr(loop, "_llm_caller", scripted)
+            )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    reg.create("worker")
+    return reg
+
+
+# ── success: response_format-constrained JSON parses + validates + binds ────
+
+
+@pytest.mark.asyncio
+async def test_schema_success_constrains_generation_and_binds_output(tmp_path: Path) -> None:
+    """Tier 2c: a response_format-supporting model + a conforming reply →
+    the constrained call's JSON parses, validates, and is returned as the
+    PARSED dict (proving run_agent_step's post-hoc parse+validate still runs
+    even though generation was already provider-constrained — 0062 impl-focus
+    3, belt-and-suspenders). 2 calls total: this RouterLoop's own tool-
+    decision call (ADR-0035 D2 separate-decide — tools-only, no
+    response_format; its free-form content is discarded once it resolves to
+    PlainText) THEN the separate response_format-constrained answer-turn
+    call whose JSON is what's actually returned."""
+    scripted = _SequencedAgentReply([
+        "(discarded tool-decision content)",
+        '{"verdict": "approve", "confidence": 0.9}',
+    ])
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", _REVIEW_SCHEMA)
+
+    result = await run_agent_step(
+        reg, identity="worker", prompt="review this",
+        schema="review", schema_registry=schema_registry,
+    )
+
+    assert result == {"verdict": "approve", "confidence": 0.9}
+    # Tuple-unpack (not a size check): raises ValueError itself if the
+    # structured-output path made anything other than EXACTLY 2 calls.
+    decide_call, answer_call = scripted.calls
+    # Call 0 (tool-decision): tools-only, no response_format.
+    assert decide_call["response_format"] is None
+    # Call 1 (the answer turn): schema-shaped response_format + NO tools
+    # (ADR-0035 D2 separate-decide: never combined in the SAME call).
+    rf = answer_call["response_format"]
+    assert rf["type"] == "json_schema"
+    assert rf["json_schema"]["schema"]["properties"]["verdict"]["enum"] == ["approve", "reject"]
+    assert answer_call["tools"] == []
+
+
+# ── failure mode (a): unsupported model — pre-check, no call wasted ─────────
+
+
+@pytest.mark.asyncio
+async def test_unsupported_model_precheck_raises_before_any_call(tmp_path: Path) -> None:
+    """Tier 2c: failure mode (a) — a model litellm.supports_response_schema
+    rejects raises StructuredOutputUnsupportedModelError BEFORE the turn's
+    first LLM call. Primary evidence: ``scripted.calls`` stays EMPTY — no
+    completion is ever issued (0062's explicit "no wasted call" requirement),
+    proven by inspecting the call log directly rather than inferring from
+    the error alone."""
+    scripted = _SequencedAgentReply(['{"verdict": "approve", "confidence": 0.9}'])
+    # "standard" resolves to a litellm-unknown provider/model pair →
+    # supports_response_schema() is False (no provider recognizes it at all).
+    resolver = ModelResolver({"standard": "not-a-real-provider/not-a-real-model"})
+    reg = _registry(tmp_path, scripted, resolver=resolver)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", _REVIEW_SCHEMA)
+
+    with pytest.raises(StructuredOutputUnsupportedModelError):
+        await run_agent_step(
+            reg, identity="worker", prompt="review this",
+            schema="review", schema_registry=schema_registry,
+        )
+
+    assert scripted.calls == []
+
+
+# ── failure mode (b): provider rejects the schema — fail fast, no re-prompt ─
+
+
+@pytest.mark.asyncio
+async def test_schema_rejected_by_provider_fails_fast_no_reprompt_loop(tmp_path: Path) -> None:
+    """Tier 2c: failure mode (b) — the LOAD-BEARING test. The scripted
+    callable's FIRST entry is this RouterLoop's own tool-decision call
+    (succeeds trivially, discarded once it resolves to PlainText); its
+    SECOND entry — the answer-turn's one and only attempt — raises,
+    simulating the provider rejecting the constrained-generation call. This
+    becomes StructuredOutputSchemaRejectedError WITHOUT entering the
+    failure-mode-(c) bounded re-prompt loop. Primary evidence: exactly 2
+    total calls (1 tool-decision + 1 rejected structured attempt, NOT 1 + N)
+    — re-prompting cannot fix an incompatible schema, so the structured path
+    makes exactly ONE attempt, never more (this is the assertion that would
+    catch a regression where failure modes (b) and (c) get conflated into
+    one retry path)."""
+    scripted = _SequencedAgentReply([
+        "(discarded tool-decision content)",
+        RuntimeError("400: schema violates json_schema subset"),
+    ])
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", _REVIEW_SCHEMA)
+
+    with pytest.raises(StructuredOutputSchemaRejectedError):
+        await run_agent_step(
+            reg, identity="worker", prompt="review this",
+            schema="review", schema_registry=schema_registry,
+        )
+
+    # Tuple-unpack (not a size check): raises ValueError itself unless the
+    # structured path made EXACTLY 2 calls (1 tool-decision + 1 rejected
+    # attempt — no re-prompt).
+    _decide_call, _rejected_call = scripted.calls
+
+
+# ── failure mode (c): generation-side non-conformance — bounded re-prompt ───
+
+
+@pytest.mark.asyncio
+async def test_nonconforming_json_recovers_within_reprompt_budget(tmp_path: Path) -> None:
+    """Tier 2c: failure mode (c) — the tool-decision call (entry 0, discarded)
+    is followed by a FIRST structured attempt that fails validation (wrong
+    type for `confidence`, entry 1) fed back as a re-prompt, then a
+    conforming SECOND structured attempt (entry 2) succeeds. Exactly 3 calls
+    total (1 tool-decision + 1 failing attempt + 1 re-prompt), not fewer and
+    not the full exhausted budget — proving the bounded re-prompt actually
+    re-invokes the model rather than failing immediately or looping past
+    success."""
+    scripted = _SequencedAgentReply([
+        "(discarded tool-decision content)",
+        '{"verdict": "approve", "confidence": "not-a-number"}',
+        '{"verdict": "approve", "confidence": 0.75}',
+    ])
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", _REVIEW_SCHEMA)
+
+    result = await run_agent_step(
+        reg, identity="worker", prompt="review this",
+        schema="review", schema_registry=schema_registry,
+    )
+
+    assert result == {"verdict": "approve", "confidence": 0.75}
+    # Tuple-unpack (not a size check): raises ValueError itself unless
+    # EXACTLY 3 calls were made (1 tool-decision + 1 failing + 1 re-prompt).
+    _decide_call, _bad_attempt, _good_attempt = scripted.calls
+
+
+@pytest.mark.asyncio
+async def test_nonconforming_json_exhausts_budget_then_typed_error(tmp_path: Path) -> None:
+    """Tier 2c: failure mode (c) exhaustion — a reply that NEVER conforms
+    raises StructuredOutputNonConformingError once the bounded re-prompt
+    budget (default: 1 initial + 2 re-prompts = 3 structured attempts) is
+    exhausted. Primary evidence: exactly 4 total calls (1 tool-decision + 3
+    structured attempts) — proves the bound is enforced (not unbounded, not
+    silently truncated to fewer attempts)."""
+    scripted = _SequencedAgentReply([
+        "(discarded tool-decision content)",
+        '{"verdict": "maybe", "confidence": 0.5}',
+        '{"verdict": "maybe", "confidence": 0.5}',
+        '{"verdict": "maybe", "confidence": 0.5}',
+    ])
+    reg = _registry(tmp_path, scripted)
+    schema_registry = SchemaRegistry()
+    schema_registry.register("review", _REVIEW_SCHEMA)
+
+    with pytest.raises(StructuredOutputNonConformingError):
+        await run_agent_step(
+            reg, identity="worker", prompt="review this",
+            schema="review", schema_registry=schema_registry,
+        )
+
+    # Tuple-unpack (not a size check): raises ValueError itself unless the
+    # bound produced EXACTLY 4 calls (1 tool-decision + 3 structured attempts
+    # = 1 initial + 2 re-prompts), never more and never fewer.
+    _decide_call, _a1, _a2, _a3 = scripted.calls
+
+
+# ── AgentStep.model — resolves via model_resolver ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_model_field_selects_resolved_model_class(tmp_path: Path) -> None:
+    """Tier 2c: ``model="strong"`` overrides the ephemeral session's model
+    the same way the ``/model`` slash command does — the LLM call's resolved
+    ``ModelSpec.model`` is the "strong" class's configured model, not the
+    default "standard" one. No schema involved (isolates the `model` field
+    from the response_format machinery)."""
+    scripted = _SequencedAgentReply(["plain text reply"])
+    reg = _registry(tmp_path, scripted)
+
+    result = await run_agent_step(
+        reg, identity="worker", prompt="hi", model="strong",
+    )
+
+    assert result == "plain text reply"
+    # Tuple-unpack (not a size check): raises ValueError itself unless
+    # EXACTLY 1 call was made (no schema → no separate structured answer
+    # turn — the tool-decision call's own plain text IS the reply).
+    (only_call,) = scripted.calls
+    assert only_call["model"].model == "gemini/gemini-2.5-pro"

--- a/tests/test_pipeline_r5_agent_step_executor.py
+++ b/tests/test_pipeline_r5_agent_step_executor.py
@@ -60,8 +60,17 @@ def _registry(
     """Real AgentRegistry + real Session factory (mirrors
     ``test_pipeline_r5_run_agent_step.py``'s ``holder`` deferred-registry-ref trick).
     ``scripted`` (when given) wires the fixed LLM reply into every spawned session's
-    real ``RouterLoopDriver`` via ``_loop_observer``, before the driver's first turn."""
+    real ``RouterLoopDriver`` via ``_loop_observer``, before the driver's first turn.
+
+    0062: resolves the default ``"standard"`` class to a real litellm-known
+    model (see ``test_pipeline_r5_run_agent_step.py``'s ``_registry`` for the
+    same fix + rationale — a schema-bearing agent step now runs RouterLoop's
+    model-support pre-check even though the turn's actual completion stays
+    fully scripted via ``_llm_caller``)."""
+    from reyn.llm.model_resolver import ModelResolver
+
     holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
@@ -69,6 +78,7 @@ def _registry(
             intervention_bridge=intervention_bridge,
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
+            resolver=resolver,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -76,9 +76,22 @@ def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRe
     ``holder`` deferred-registry-ref trick so the factory can pass
     ``registry=`` for ephemeral auto-vanish). When ``scripted`` is given, every
     constructed session's real ``RouterLoopDriver`` gets the scripted LLM
-    wired in via ``_loop_observer`` before the driver's first turn."""
+    wired in via ``_loop_observer`` before the driver's first turn.
+
+    0062: the resolver maps the default ``"standard"`` class to a REAL
+    litellm-known model name (``gemini/gemini-2.5-flash-lite``, litellm's
+    static ``supports_response_schema`` table recognizes it — no network
+    call) instead of leaving it unresolved (the pre-0062 default, where
+    ``resolve("standard")`` passed through the bare class name itself). A
+    schema-bearing ``run_agent_step`` now runs RouterLoop's model-support
+    PRE-CHECK (§2.1 mode-a) before the (still fully scripted, via
+    ``_llm_caller``) turn — an unresolved class name would fail that
+    pre-check even though the actual completion never touches litellm."""
+    from reyn.llm.model_resolver import ModelResolver
+
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     holder: dict = {}
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
@@ -86,6 +99,7 @@ def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRe
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
             intervention_bridge=intervention_bridge,
+            resolver=resolver,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (


### PR DESCRIPTION
**[lead-coder]** — Implements proposal 0062 (design-GO'd by architect + owner, `docs/deep-dives/proposals/0062-structured-output-ephemeral-sessions-agent-steps.md`, currently on `origin/docs/0062-structured-output-proposal`).

## The reframe

`AgentStep.schema: str | None` (`core/pipeline/executor.py:174`) **already existed** but only did POST-HOC validate (`run_agent_step`, `session_api.py`): the model free-formed text, the OS JSON-parsed + validated it afterwards, and non-conformance raised `AgentStepError`. That's the owner's bug — the field validates but never constrained *generation*. No new `output_schema` field is added; this PR enhances the existing `schema` path so it ALSO drives provider-side `response_format`, while keeping the post-hoc validate as belt-and-suspenders.

## Layer 1 — schema-constrained generation (root cause fix)

The gap: `RouterLoop` (chat/agent-step turn driver) has no separate "decide vs answer" turn — the SAME `call_llm_tools` call that could emit a tool_call is also the one whose plain-text `result.content` becomes the final reply (confirmed by trace: ADR-0035's "separate transition call" belonged to the now-removed Phase/skill `SkillRunner`, not the live `RouterLoop`). So this PR reintroduces that separation, scoped to `RouterLoop`:

- `RouterLoop` gains optional `response_format` / `schema_validate_fn` / `max_schema_reprompt_attempts` (all default `None`/2 — byte-identical for every session that doesn't set them, i.e. every session except a `schema`-bearing agent step).
- **Pre-check (mode a)**: at `run_loop` entry, BEFORE the turn's first LLM call (tool-decision calls included), `litellm.supports_response_schema(effective_model)` gates entry — an unsupported model raises `StructuredOutputUnsupportedModelError` immediately, proxy-prefix-stripped the same way `recorded_acompletion` strips it (so an `openai/<gemini-model>` proxy alias is checked as the underlying model, not misclassified).
- **Answer turn**: when the tool-decision round(s) resolve to PlainText (no more tool_calls), a SEPARATE no-tools `response_format`-constrained call is issued (`RouterLoop._run_structured_answer_turn`) — ADR-0035 D2's "separate-decide, never combine tools+response_format" reapplied here. `call_llm_tools` gained an optional `response_format` param (default `None`) threaded straight to `recorded_acompletion` with `fallback_without_response_format` never set (no silent degrade).
- **3 distinct failure modes, never conflated**:
  - (a) unsupported model → pre-check, no call wasted (see above).
  - (b) provider rejects the SCHEMA itself → since (a) already passed, ANY exception on the answer-turn's first attempt is classified as `StructuredOutputSchemaRejectedError` — fail fast, **never** enters the re-prompt loop (re-prompting cannot fix an incompatible schema).
  - (c) generation-side non-conformance (valid schema, bad JSON) → bounded re-prompt (feed the validation error back, default 2 extra attempts), then `StructuredOutputNonConformingError` on exhaustion.
- **Belt-and-suspenders (impl-focus 3)**: `run_agent_step`'s existing `json.loads` + `core.pipeline.schema.validate` still runs on the constrained call's output — the provider constraint is not blindly trusted.
- **§2.3 verbatim pin**: `core.pipeline.schema.to_json_schema` (new) converts reyn's own Schema vocabulary (bool/string/number/enum/list/object/ref) to a standard JSON Schema, passed AS-IS to `response_format` — no strict-mode augmentation; a provider rejection surfaces as the mode-(b) error telling the author what was rejected.
- **Exception surfacing**: `StructuredOutputError` (new, subclasses `AgentStepError`) is re-raised through `Session._handle_user_message` (added `except StructuredOutputError: raise` before the generic swallow-to-outbox handler) instead of being collapsed into an opaque `kind="error"` string — the caller (`run_agent_step` via `MessageBus.request`) sees the ORIGINAL typed exception. Side-fix: `run_one_iteration`'s ephemeral-vanish scheduling is now in an outer `finally` so this new "exception propagates out of a normal turn" path doesn't leak the ephemeral session (a pre-existing gap this PR would otherwise have newly exercised).

## Layer 2 — `AgentStep.model`

One new field: `AgentStep.model: str | None = None` (executor.py) + DSL serde (`serde.py`, mirrors `schema`'s encode/decode) + parser (`parser.py`, `_AGENT_KEYS` + validation) + threaded to `run_agent_step(model=...)`, which applies it via `session._model_override` — the SAME seam the `/model` slash command uses (`interfaces/slash/model.py:75`), resolved by the session's own `ModelResolver` at call time, no bespoke resolution path.

## Impl-focus evidence

- **Pre-check-before-call**: `test_unsupported_model_precheck_raises_before_any_call` asserts `scripted.calls == []` — literally zero completions issued.
- **Fail-fast-on-incompatible-schema (load-bearing)**: `test_schema_rejected_by_provider_fails_fast_no_reprompt_loop` — tuple-unpacks `scripted.calls` into exactly `(decide_call, rejected_call)`; a 3rd call would raise `ValueError` on unpack, proving no re-prompt loop entered.
- **Bounded re-prompt recovers**: `test_nonconforming_json_recovers_within_reprompt_budget` — 3 calls total (1 tool-decision + 1 failing + 1 succeeding).
- **Bounded re-prompt exhausts**: `test_nonconforming_json_exhausts_budget_then_typed_error` — exactly 4 calls (1 + 3 structured attempts), typed error on exhaustion.
- **model selection**: `test_model_field_selects_resolved_model_class` — asserts the scripted call's resolved `ModelSpec.model` is `"strong"`'s configured model, not `"standard"`'s.
- **post-hoc validate retained**: `test_schema_success_constrains_generation_and_binds_output` — asserts the PARSED dict is returned (not raw text), proving `run_agent_step`'s own validate still runs.

All new tests are Tier 2c (real `AgentRegistry`/`Session`/`RouterLoop`/`MessageBus`; only the LLM completion is faked via a concrete real-callable `_SequencedAgentReply`, injected through the existing `_llm_caller` seam — no mocks). Existing `test_pipeline_r5_run_agent_step.py` / `test_pipeline_r5_agent_step_executor.py` updated (their bare test `Session`s now resolve `"standard"` to a real litellm-known model, `gemini/gemini-2.5-flash-lite`, so the new pre-check passes — no network call, pure static litellm lookup).

## Docs

`docs/reference/runtime/pipeline-dsl.md` — grammar (`model:` field) + prose (schema now constrains generation, `model` example). (Japanese mirror `.ja.md` not updated in this PR — flagging for a fast-follow if reviewer wants ja parity.)

## Gates (all green, from repo root, this branch rebased onto latest origin/main)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 21/21 OK, 0 Tier-4 violations.
- `pytest` — 8491 passed, 20 skipped, 0 failed.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan
- [x] `pytest` full suite green (8491 passed / 20 skipped)
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean on all changed/new test files
- [x] `verify_module_docstrings.py` clean on all changed src files
- [x] Rebased onto latest `origin/main` (post #2932/#2933) — clean, no conflicts