### PR TITLE
fix: repaint the empty input immediately on submit, ahead of the scrollback echo race

### DIFF
--- a/src/reyn/interfaces/inline/app.py
+++ b/src/reyn/interfaces/inline/app.py
@@ -1229,6 +1229,17 @@ async def run_inline_input(read_model, renderer, config=None, transport=None) ->
     def _do_submit(event) -> None:
         text = buf.text
         buf.reset(append_to_history=True)
+        # Force the "input is empty" repaint to land BEFORE the async submit
+        # path's own scrollback echo does. Without this, the user's own line
+        # coming back through session.outbox → broadcast → run_in_terminal
+        # (called moments later, once the background _submit task's outbox put
+        # is drained) suspends the live app for its own erase/print/redraw
+        # cycle — prompt_toolkit's `in_terminal()` (application/run_in_terminal.py)
+        # ERASES the live region first, then redraws at the very end, so
+        # buf.reset()'s own clear only becomes visually true at THAT redraw,
+        # not at this line. An explicit invalidate here paints the empty input
+        # immediately, ahead of that race.
+        event.app.invalidate()
         stripped = text.strip()
         if not stripped:
             return


### PR DESCRIPTION
**[tui-coder]** — small, targeted UX fix from a design brainstorm with the owner.

## What
`buf.reset()` clears the input buffer in-memory synchronously on Enter, but the VISUAL "input is empty" repaint was racing the submitted line's own scrollback echo (`session.outbox` → broadcast → `run_in_terminal`, called moments later once the background `_submit` task's outbox put drains).

## Root cause (primary evidence: `prompt_toolkit/application/run_in_terminal.py`)
`in_terminal()` **erases** the live region first, runs the print callback, and only **redraws at the very end**:
```python
if previous_run_in_terminal_f is not None:
    await previous_run_in_terminal_f     # chains behind any still-in-flight print
if app.output.responds_to_cpr:
    await app.renderer.wait_for_cpr_responses()
app.renderer.erase()                     # live region (incl. input box) blanked
...
finally:
    app._redraw()                        # input box only correctly shows "empty" HERE
```
So `buf.reset()`'s own clear only becomes visually true at that tail redraw — not at `buf.reset()` itself — making the input look like it hadn't cleared yet, especially when a prior `run_in_terminal` call (trailing trace/status output) is still chaining.

## Fix
`src/reyn/interfaces/inline/app.py` — `_do_submit`: an explicit `event.app.invalidate()` right after `buf.reset()` forces the empty-input repaint to land before the async submit path's own echo cycle can race it.

## Verification
- Live tmux + litellm proxy (`reyn chat --model gemini-flash-lite`): submit → tool calls (`web_search`, `web_fetch`) → permission prompt → completion, rendered cleanly with no corruption/regression.
- No new test added — per this module's existing testing discipline (`docs` / prior design notes), live prompt_toolkit `Application` redraw timing is explicitly out of Tier-test scope (would require heavy `Application`/layout scaffolding that becomes a low-value mechanism test itself); verified via live capture instead.
- `ruff check` clean, `verify_module_docstrings.py` clean.
- Existing suites unaffected: `test_inline_pr3a_app.py` / `test_inline_renderer_cutover.py` / `test_chat_turn_completed_inline.py` / `test_inline_pr3b_status_bar.py` — 142 passed.
- Full `pytest` — 8485 passed; the same 9 pre-existing LLM-router/compaction failures (unrelated, seen consistently across this session, confirmed pre-existing). No new failures from this diff.

## Test plan
- [x] `ruff check` (changed) — clean
- [x] `verify_module_docstrings.py` (changed) — clean
- [x] targeted inline-app test suites — 142 passed
- [x] full `pytest` — 8485 passed, only pre-existing unrelated failures
- [x] live tmux verification (submit → tool calls → permission prompt → completion) — no corruption