### PR TITLE
fix: stop wiping the token-estimate cache on every compaction (long-chat freeze)

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -845,8 +845,18 @@ class CompactionEngine:
         Raises on LLM error; callers wrap in try/except and emit
         ``compaction_failed`` if needed.
         """
-        # Clear the per-run token cache for fresh estimates each compaction.
-        _token_cache.clear()
+        # No `_token_cache.clear()` here (removed): the cache key is
+        # `(model, hash(text))` and `use_chars4_estimate` is a fixed per-session
+        # config (never toggled mid-session), so a cached count is valid for the
+        # lifetime of the process — text is immutable and the tokenizer/fallback
+        # choice never changes underneath an existing entry. Clearing it forced
+        # a COLD, synchronous, full-history re-tokenization on every turn right
+        # after a compaction (build_history() re-estimates the whole raw history
+        # every turn to check the elide trigger) — on a long conversation this
+        # froze the event loop for real, user-visible seconds, repeating every
+        # time compaction fired again as the chat kept growing. Leaving the
+        # cache warm makes token estimation naturally incremental: only text
+        # that has never been tokenized before is a miss.
 
         user_content = json.dumps({
             "previous_summary": input_chunk.previous_summary,

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -48,6 +48,7 @@ import asyncio
 import hashlib
 import json
 import logging
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
@@ -71,9 +72,55 @@ logger = logging.getLogger(__name__)
 
 _token_counter_fallback_warned: bool = False
 
-# Per-compaction-run cache: (model, text_hash) -> int
-# Cleared between compaction runs in CompactionEngine.compact().
-_token_cache: dict[tuple[str, str], int] = {}
+# Process-lifetime cache: (model, text_hash) -> int. Keyed by a hash, not the
+# raw text, so an entry stays tiny regardless of the source message's length
+# (a long tool-output turn costs the same few bytes as a short one).
+#
+# Bounded LRU (#2937 revision): a cached count for a given (model, text) is
+# valid for the process's entire lifetime — text is immutable and the
+# tokenizer/fallback choice (`use_chars4_estimate`) is a fixed per-session
+# config, never toggled mid-session, so there is no STALENESS reason to ever
+# evict an entry. The bound below exists ONLY to cap memory, not for
+# correctness: `CompactionEngine.compact()` used to `_token_cache.clear()`
+# unconditionally at its start, which (a) was doing double duty as this
+# module's ONLY size bound (no other prune/maxsize existed anywhere in the
+# codebase) and (b) forced a fully-synchronous, on-the-event-loop re-estimate
+# of the WHOLE conversation history on every turn immediately following a
+# compaction (`build_history()` re-checks "total tokens <= trigger" every
+# turn) — measured at ~470x slower cold vs warm on a real ~3000-message
+# history, freezing the inline CUI for real seconds on a long chat. Losing
+# the clear() naively (unbounded dict) would trade that freeze for a slow
+# memory leak proportional to total-distinct-turns-ever, worsening in the
+# exact same "long session" scenario. `OrderedDict` LRU eviction (recency,
+# not insertion order — a `move_to_end` on every hit) keeps recently-touched
+# turns warm (the perf fix) while bounding total memory (the leak fix).
+_TOKEN_CACHE_MAXSIZE = 8192
+_token_cache: "OrderedDict[tuple[str, str], int]" = OrderedDict()
+
+
+def _token_cache_get(cache_key: "tuple[str, str]") -> "int | None":
+    """LRU read: a hit bumps recency (moves to MRU end); a miss returns None."""
+    if cache_key not in _token_cache:
+        return None
+    _token_cache.move_to_end(cache_key)
+    return _token_cache[cache_key]
+
+
+def _token_cache_put(cache_key: "tuple[str, str]", value: int) -> None:
+    """LRU write: insert/overwrite as MRU, then evict the LRU entry if the
+    bound is exceeded. A plain dict has no eviction primitive cheaper than
+    O(n) — OrderedDict.popitem(last=False) is O(1)."""
+    _token_cache[cache_key] = value
+    _token_cache.move_to_end(cache_key)
+    if len(_token_cache) > _TOKEN_CACHE_MAXSIZE:
+        _token_cache.popitem(last=False)
+
+
+def token_cache_size() -> int:
+    """Public read of the token-estimate cache's current entry count — the
+    sanctioned surface for tests/diagnostics (mirrors testing.md's
+    snapshot()-style-read guidance; the OrderedDict itself stays private)."""
+    return len(_token_cache)
 
 # Fixed token cost used for image parts when litellm cannot count them.
 _IMAGE_FIXED_TOKEN_COST = 1024
@@ -89,14 +136,16 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     Axis 10: uses litellm.token_counter by default; falls back to chars//4
     on error and emits ``token_counter_fallback`` once per process.
 
-    Results are cached per (model, text-hash) within a compaction run.
+    Results are cached per (model, text-hash) for the process's lifetime,
+    bounded by an LRU eviction policy (see ``_token_cache`` docstring above).
     """
     global _token_counter_fallback_warned
     if use_chars4:
         return max(1, len(text or "") // 4)
     cache_key = (model, _text_hash(text or ""))
-    if cache_key in _token_cache:
-        return _token_cache[cache_key]
+    cached = _token_cache_get(cache_key)
+    if cached is not None:
+        return cached
     try:
         # perf/log-routing chokepoint: per-turn token sizing runs BEFORE the
         # first completion, so this can be the FIRST litellm import in the
@@ -109,7 +158,7 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
         m = model or "gpt-3.5-turbo"
         count = litellm.token_counter(model=m, text=text or "")
         if count and count > 0:
-            _token_cache[cache_key] = count
+            _token_cache_put(cache_key, count)
             return count
     except Exception:
         pass
@@ -122,7 +171,7 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
             model,
         )
     result = max(1, len(text or "") // 4)
-    _token_cache[cache_key] = result
+    _token_cache_put(cache_key, result)
     return result
 
 
@@ -845,18 +894,19 @@ class CompactionEngine:
         Raises on LLM error; callers wrap in try/except and emit
         ``compaction_failed`` if needed.
         """
-        # No `_token_cache.clear()` here (removed): the cache key is
-        # `(model, hash(text))` and `use_chars4_estimate` is a fixed per-session
-        # config (never toggled mid-session), so a cached count is valid for the
-        # lifetime of the process — text is immutable and the tokenizer/fallback
-        # choice never changes underneath an existing entry. Clearing it forced
-        # a COLD, synchronous, full-history re-tokenization on every turn right
-        # after a compaction (build_history() re-estimates the whole raw history
-        # every turn to check the elide trigger) — on a long conversation this
-        # froze the event loop for real, user-visible seconds, repeating every
-        # time compaction fired again as the chat kept growing. Leaving the
-        # cache warm makes token estimation naturally incremental: only text
-        # that has never been tokenized before is a miss.
+        # No `_token_cache.clear()` here (removed, #2937): text is immutable and
+        # the tokenizer/fallback choice is a fixed per-session config, so a
+        # cached (model, text) count is valid for the process's entire
+        # lifetime — clearing it had no staleness justification. It forced a
+        # COLD, synchronous, full-history re-tokenization on every turn right
+        # after a compaction (build_history() re-estimates the whole raw
+        # history every turn to check the elide trigger) — on a long
+        # conversation this froze the event loop for real, user-visible
+        # seconds, repeating every time compaction fired again as the chat
+        # kept growing. The cache is now LRU-bounded (`_token_cache_put`)
+        # instead of periodically nuked, so it stays warm (the perf fix)
+        # without growing unboundedly (the memory-leak risk a naive removal
+        # of the clear would have traded it for).
 
         user_content = json.dumps({
             "previous_summary": input_chunk.previous_summary,

--- a/tests/test_compaction_token_cache_incremental.py
+++ b/tests/test_compaction_token_cache_incremental.py
@@ -12,12 +12,18 @@ conversation. On a long chat this froze the inline CUI's event loop for real,
 user-visible seconds, and recurred every time compaction fired again as the
 conversation kept growing.
 
-THE FIX: the clear was removed — the cache is now naturally incremental
-(warm entries survive compaction; only genuinely new text is a miss).
+THE FIX: the unconditional clear was removed. But the clear had ALSO been the
+codebase's ONLY size bound on this cache (no other prune/maxsize existed
+anywhere) — naively removing it would trade the freeze for an unbounded
+memory leak proportional to total-distinct-turns-ever, worsening in the exact
+same "long session" scenario. The cache is now LRU-bounded
+(`_TOKEN_CACHE_MAXSIZE`) instead: warm entries survive compaction (the perf
+fix) AND the cache never exceeds its bound (the memory fix).
 
-Asserted via the PUBLIC-surface proxy for "was this a cache hit": count real
-underlying tokenizer invocations (`litellm.token_counter`), not the private
-`_token_cache` dict (Tier 4 — no private-state assertions).
+Asserted via PUBLIC-surface proxies, not the private `_token_cache` dict
+(Tier 4 forbids private-state assertions): "was this a cache hit" is observed
+by counting real underlying tokenizer invocations (`litellm.token_counter`);
+"is the cache bounded" is observed via `token_cache_size()`.
 """
 from __future__ import annotations
 
@@ -25,13 +31,30 @@ import asyncio
 import json
 from types import SimpleNamespace
 
+import pytest
+
 from reyn.config import CompactionConfig
 from reyn.core.events.events import EventLog
+from reyn.services.compaction import engine as engine_mod
 from reyn.services.compaction.engine import (
     CompactionEngine,
     HistoryChunkToCompact,
     estimate_tokens,
+    token_cache_size,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clean_token_cache():
+    """Tier 2 hygiene: `_token_cache` is a module-global shared across every
+    test in the process — clear it before each test so exact size/eviction
+    assertions aren't polluted by entries other tests warmed. Setup/teardown,
+    not an assertion (Tier 4 forbids asserting on private state, not touching
+    it for isolation — the same pattern as this session's `_clean_task_polls`
+    for `_TASK_POLLS`)."""
+    engine_mod._token_cache.clear()
+    yield
+    engine_mod._token_cache.clear()
 
 
 def _resp(content: str) -> SimpleNamespace:
@@ -130,3 +153,84 @@ def test_repeated_estimate_of_unchanged_text_is_a_cache_hit_across_compactions(m
     second = estimate_tokens(text, model, use_chars4=False)
     assert second == first
     assert counts.get(text) == 1  # never re-tokenized across either compaction
+
+
+def test_cache_never_exceeds_its_bound(monkeypatch) -> None:
+    """Tier 2: falsifying memory-leak guard. Shrink the bound to 5 and
+    push 20 distinct texts through the cache — `token_cache_size()` must never
+    exceed 5. A regression to an unbounded dict (the naive "just remove the
+    clear" fix) would let this grow to 20 and fail.
+
+    Verified locally: with LRU eviction (`_token_cache_put`) stubbed to a
+    no-op bound-check, this genuinely goes RED — the bound is not a lucky
+    accident of test ordering.
+    """
+    monkeypatch.setattr(engine_mod, "_TOKEN_CACHE_MAXSIZE", 5)
+    counts: dict = {}
+    monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
+
+    for i in range(20):
+        estimate_tokens(f"distinct historical turn number {i}", "test-model-bound", use_chars4=False)
+        assert token_cache_size() <= 5, (
+            f"cache grew to {token_cache_size()} entries after {i + 1} distinct "
+            "texts — the LRU bound is not being enforced (memory-leak regression)"
+        )
+
+    assert token_cache_size() == 5  # settled at exactly the bound, not below it
+    expected_texts = {f"distinct historical turn number {i}" for i in range(20)}
+    assert set(counts) == expected_texts  # all 20 were really tokenized (no false hits/misses)
+
+
+def test_recently_used_entry_survives_eviction_pressure(monkeypatch) -> None:
+    """Tier 2: LRU (recency), not FIFO (insertion order) — re-touching an old
+    entry before the bound is exceeded keeps it alive past newer entries that
+    are never touched again. Proves eviction targets the LEAST-recently-used
+    entry, not simply the oldest-inserted one."""
+    monkeypatch.setattr(engine_mod, "_TOKEN_CACHE_MAXSIZE", 3)
+    counts: dict = {}
+    monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
+    model = "test-model-lru-order"
+
+    estimate_tokens("A", model, use_chars4=False)
+    estimate_tokens("B", model, use_chars4=False)
+    estimate_tokens("C", model, use_chars4=False)
+    # Bound is 3, all present. Re-touch "A" — it becomes MRU, "B" becomes LRU.
+    estimate_tokens("A", model, use_chars4=False)
+    assert counts.get("A") == 1  # the re-touch was itself a cache hit
+
+    # Insert a 4th distinct text — must evict "B" (the LRU), not "A" or "C".
+    estimate_tokens("D", model, use_chars4=False)
+    assert token_cache_size() == 3
+
+    estimate_tokens("A", model, use_chars4=False)
+    assert counts.get("A") == 1  # still a hit — "A" survived eviction
+    estimate_tokens("B", model, use_chars4=False)
+    assert counts.get("B") == 2  # "B" was evicted — re-tokenized (a miss)
+
+
+def test_cache_is_derived_not_a_recovery_source(monkeypatch) -> None:
+    """Tier 2: crash-recovery witness. `_token_cache` is IN-MEMORY-ONLY,
+    DERIVED from history text — not a WAL/snapshot-backed recovery source, so
+    the #1983 truncate-falsify gate (CLAUDE.md's recovery-feature PR rule)
+    does not apply to it. This proves the derivation property directly: an
+    entry lost from a cold/empty cache (the crash scenario — the process
+    restarts with a fresh, empty `_token_cache`) recomputes to the IDENTICAL
+    value from the same text, with no external state needed beyond the text
+    itself (which `history.jsonl` already durably holds independently of this
+    cache)."""
+    counts: dict = {}
+    monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
+    model = "test-model-crash-repopulate"
+    text = "a historical turn that must survive a cold restart"
+
+    before_crash = estimate_tokens(text, model, use_chars4=False)
+    assert token_cache_size() == 1
+
+    # Simulate a process restart: the cache starts fresh (nothing persisted to
+    # carry over — this IS the recovery path, not a special-cased one).
+    engine_mod._token_cache.clear()
+    assert token_cache_size() == 0
+
+    after_crash = estimate_tokens(text, model, use_chars4=False)
+    assert after_crash == before_crash  # recomputed from the SAME durable text
+    assert counts.get(text) == 2  # a genuine re-tokenization, not a stale hit

--- a/tests/test_compaction_token_cache_incremental.py
+++ b/tests/test_compaction_token_cache_incremental.py
@@ -1,0 +1,132 @@
+"""Tier 2: CompactionEngine.compact() must NOT wipe the token-estimate cache.
+
+THE BUG: `compact()` used to unconditionally `_token_cache.clear()` at its start
+("fresh estimates each compaction"). The cache key is `(model, hash(text))` and
+`use_chars4_estimate` is a fixed per-session config (never toggled mid-session)
+— text is immutable and the tokenizer/fallback choice never changes underneath
+an existing entry, so a cached count is valid for the process's lifetime. The
+blanket clear forced the NEXT `build_history()` call (which re-estimates
+tokens across the WHOLE raw history every turn to check the elide trigger) to
+recompute from a cold cache — synchronous, on the event loop, for the entire
+conversation. On a long chat this froze the inline CUI's event loop for real,
+user-visible seconds, and recurred every time compaction fired again as the
+conversation kept growing.
+
+THE FIX: the clear was removed — the cache is now naturally incremental
+(warm entries survive compaction; only genuinely new text is a miss).
+
+Asserted via the PUBLIC-surface proxy for "was this a cache hit": count real
+underlying tokenizer invocations (`litellm.token_counter`), not the private
+`_token_cache` dict (Tier 4 — no private-state assertions).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.services.compaction.engine import (
+    CompactionEngine,
+    HistoryChunkToCompact,
+    estimate_tokens,
+)
+
+
+def _resp(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _counting_token_counter(counts: dict):
+    """Real callable (not a mock) standing in for litellm.token_counter, so a
+    cache hit vs miss is observable by call count instead of reaching into the
+    private `_token_cache` dict."""
+    def _counter(*, model: str, text: str) -> int:
+        counts[text] = counts.get(text, 0) + 1
+        return max(1, len(text) // 4)
+    return _counter
+
+
+def test_compact_does_not_clear_the_token_cache(monkeypatch) -> None:
+    """Tier 2: a token estimate cached BEFORE compact() runs is served from
+    cache (the underlying tokenizer is NOT invoked a second time) AFTER
+    compact() returns — the load-bearing fix. A regression to
+    `_token_cache.clear()` at the top of `compact()` would make this fail
+    (the tokenizer would be called again for the same text)."""
+    model = "test-model-cache-a"
+    warm_text = "this text was estimated before any compaction ran"
+    counts: dict = {}
+    monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
+
+    # Warm the cache for text UNRELATED to this compaction's own input
+    # (simulates the rest of a long conversation's already-estimated turns).
+    warm_value = estimate_tokens(warm_text, model, use_chars4=False)
+    assert counts.get(warm_text) == 1  # one real tokenizer call so far
+
+    async def _capture(**kwargs):
+        return _resp(json.dumps({
+            "topic_arc": "arc", "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+
+    monkeypatch.setattr("litellm.acompletion", _capture)
+
+    engine = CompactionEngine(
+        model=model,
+        events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=False),
+    )
+    chunk = HistoryChunkToCompact(
+        previous_summary=None,
+        new_turns=[{"role": "user", "text": "hi", "seq": 1}],
+        section_token_caps={},
+    )
+    asyncio.run(engine.compact(chunk))
+
+    # Re-estimating the SAME text after compact() must be a cache HIT: same
+    # value, and the tokenizer is NOT invoked again (still exactly 1 call).
+    assert estimate_tokens(warm_text, model, use_chars4=False) == warm_value
+    assert counts.get(warm_text) == 1, (
+        f"tokenizer was invoked {counts.get(warm_text)} times for unchanged "
+        "text — compact() re-cleared the cache (regression)"
+    )
+
+
+def test_repeated_estimate_of_unchanged_text_is_a_cache_hit_across_compactions(monkeypatch) -> None:
+    """Tier 2: end-to-end incrementality — estimating the SAME text across TWO
+    separate compact() calls invokes the real tokenizer only ONCE. This is the
+    actual UX property the fix restores: repeated history turns are priced
+    once, not re-priced every compaction cycle."""
+    model = "test-model-cache-b"
+    text = "a stable historical turn that never changes"
+    counts: dict = {}
+    monkeypatch.setattr("litellm.token_counter", _counting_token_counter(counts))
+
+    first = estimate_tokens(text, model, use_chars4=False)
+
+    async def _capture(**kwargs):
+        return _resp(json.dumps({
+            "topic_arc": "arc", "new_turn_seqs": [1],
+            "decisions": [], "pending": [],
+            "session_user_facts": [], "artifacts_referenced": [],
+        }))
+
+    monkeypatch.setattr("litellm.acompletion", _capture)
+    engine = CompactionEngine(
+        model=model, events=EventLog(),
+        cfg=CompactionConfig(use_chars4_estimate=False),
+    )
+    chunk = HistoryChunkToCompact(
+        previous_summary=None, new_turns=[{"role": "user", "text": "t1", "seq": 1}],
+        section_token_caps={},
+    )
+    asyncio.run(engine.compact(chunk))
+    asyncio.run(engine.compact(chunk))  # a SECOND compaction cycle
+
+    second = estimate_tokens(text, model, use_chars4=False)
+    assert second == first
+    assert counts.get(text) == 1  # never re-tokenized across either compaction


### PR DESCRIPTION
**[tui-coder]** — owner-reported bug, no live repro available (owner's environment is a separate company machine; investigated via static profiling with real-sized data instead).

## Report
"長時間使ってると input enter してから数十秒画面が固まるよ" — after long usage, the screen freezes for tens of seconds after Enter.

## Root cause
`CompactionEngine.compact()` unconditionally called `_token_cache.clear()` at its start ("fresh estimates each compaction"). But the cache key is `(model, hash(text))` and `use_chars4_estimate` is a **fixed per-session config** (never toggled mid-session) — text is immutable and the tokenizer/fallback choice never changes underneath an existing entry, so a cached count is valid for the **entire process lifetime**. There is no staleness reason for the blanket clear.

The cost: `build_history()` (called every turn) re-estimates tokens across the **whole raw history** every time, to check `total <= effective_trigger`. Right after any compaction cleared the cache, the next turn paid a **cold, fully-synchronous** re-tokenization of the entire conversation — on the event loop, freezing rendering and input handling for its duration.

**Measured** against a real 2964-message `history.jsonl` (local checkout data), even using the cheap `chars//4` fallback path (not litellm's real tokenizer, which failed in my sandboxed env):
- cold (post-clear): **1.41s**
- warm (cache hit): **0.003s** — ~470x

A real tokenizer on a longer conversation plausibly stretches this into "tens of seconds". This recurs **every time compaction fires again** as the conversation keeps growing — matching the "gets worse the longer you use it" report exactly.

## Fix
Removed the `.clear()` call in `compact()` (`src/reyn/services/compaction/engine.py`). The cache is now naturally incremental: only genuinely new text (never estimated before) is a miss; unchanged historical turns are a cache hit regardless of how many compactions have run.

## "compact が壊れることがないように" — verification
- New Tier 2 tests assert via the **public-surface proxy** for cache-hit (a real counting `litellm.token_counter` callable — not the private `_token_cache` dict, which Tier 4 forbids asserting on): a pre-warmed estimate survives `compact()`, and across **two** separate compactions the same text is tokenized exactly once.
- **Falsifying**: verified RED when the removed `.clear()` is reinstated (script-verified locally, not just claimed).
- Full compaction test suite (67 tests incl. `test_compaction_resolver_aware_1172.py`, which directly drives `engine.compact()`) — **green**.
- The 3 pre-existing full-suite-only failures in that resolver file are **confirmed unrelated**: `git stash` A/B with this change fully reverted reproduces the byte-identical failure (a `myvendor/` provider-prefix stripping bug in model-string resolution, orthogonal to token caching) — not introduced or affected by this diff.
- Full `pytest`: 8487 passed; only the same 9 pre-existing unrelated failures across the whole session (LLM-router/compaction-resolver pollution, consistently reproduced this way all session).

## Test plan
- [x] `ruff check` (changed) — clean
- [x] `test_tier_audit.py --strict` — 2 OK, 0 Tier-4
- [x] `verify_module_docstrings.py` — clean
- [x] targeted compaction suites — 67 passed
- [x] full `pytest` — 8487 passed, only pre-existing unrelated failures
- [x] falsifiability verified (reinstating the clear() → RED)
- [ ] live long-conversation reproduction — **not possible in this environment** (owner's repro is a separate company machine); flagging for the owner/reviewer to spot-check on a real long chat if practical

@lead-coder — please review carefully per owner request. This touches shared compaction infra (`src/reyn/services/compaction/engine.py`), not TUI-only, so it's outside my usual narrow surface — happy to address any concerns about the cache-lifetime reasoning or the removed clear().