### PR TITLE
fix: hoist per-message WAL rescan out of active-branch history filter (#2941 chat freeze)

### DIFF
--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
@@ -175,6 +176,26 @@ def _make_is_active(abandoned: list[tuple[int, int]]):
 def is_active_seq(state_log: StateLog, seq: int) -> bool:
     """True if ``seq`` is on the current active branch (not in any abandoned segment)."""
     return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)
+
+
+def build_active_predicate(state_log: StateLog) -> Callable[[int], bool]:
+    """Build a reusable ``is_active(seq)`` predicate — ONE WAL scan for MANY seqs.
+
+    #2941 (owner-reported ``reyn chat`` freeze, growing with session length):
+    ``_abandoned_intervals(_rewind_records(state_log))`` depends only on the
+    state_log's rewind records, NOT on ``seq`` — so calling ``is_active_seq``
+    once per history message (``Session._active_branch_history``, the
+    LLM-facing hot path run every turn) re-scans the *entire* WAL
+    (``iter_from(1)``, json-decoding every line) once per message: O(N
+    messages x M WAL entries) per turn. This factors the seq-independent scan
+    out of that loop: call once per turn, then reuse the returned predicate
+    for every message's seq — O(N + M) per turn instead of O(N x M). Same
+    derivation as ``is_active_seq``; semantics are identical (this is a
+    call-shape optimization, not a behavior change) — ``is_active_seq`` itself
+    is UNCHANGED and still used by other (non-hot-loop) callers, including
+    crash-recovery paths, so their contract is untouched.
+    """
+    return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
 
 
 def active_rewind_target(state_log: StateLog) -> int | None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -3217,10 +3217,17 @@ class Session:
         always visible (backward-compatible, no migration)."""
         if self._state_log is None:
             return self.history
-        from reyn.core.events.snapshot_generations import is_active_seq
+        from reyn.core.events.snapshot_generations import build_active_predicate
+
+        # #2941: hoisted OUT of the per-message loop below. The abandoned-interval
+        # predicate depends only on the state_log's rewind records, never on a
+        # per-message seq — so it is computed ONCE per call (one WAL scan) and
+        # reused for every message, instead of re-scanning the whole WAL per
+        # message (was O(N messages x M WAL entries) per turn; now O(N + M)).
+        is_active = build_active_predicate(self._state_log)
 
         def _active(seq: "int | None") -> bool:
-            return seq is None or is_active_seq(self._state_log, seq)
+            return seq is None or is_active(seq)
 
         # #2360 (tool-cycle-aware): a GLOBAL cut lands at a WAL seq that may be a turn boundary for
         # the rewound session but fall MID-tool-cycle for another session's conversation (the

--- a/tests/test_active_branch_history_scan_bound_2941.py
+++ b/tests/test_active_branch_history_scan_bound_2941.py
@@ -1,0 +1,125 @@
+"""Tier 2: #2941 — the LLM-facing active-branch filter must not re-scan the WAL
+once PER HISTORY MESSAGE (the owner-reported ``reyn chat`` freeze, growing with
+session length).
+
+Root cause: ``Session._active_branch_history`` called ``is_active_seq(state_log,
+seq)`` once per history message; ``is_active_seq`` re-derives
+``_abandoned_intervals(_rewind_records(state_log))`` from scratch each time, and
+``_rewind_records`` does a FULL ``state_log.iter_from(1)`` scan (json-decoding
+every WAL line). So a turn with N history messages and an M-entry WAL did O(N x M)
+json.loads work EVERY turn. The fix (``build_active_predicate``) hoists the
+seq-independent abandoned-interval derivation OUT of the per-message loop: one
+``iter_from`` scan per ``build_history()`` call, reused for every message
+(O(N + M) instead of O(N x M)).
+
+Real seam: real ``Session`` + real ``StateLog`` + the real ``checkout`` reset-record
+primitive, with a ``StateLog`` subclass counting ``iter_from`` calls (a public
+method override — not a private-state peek) to assert the SCAN COUNT bound
+directly, rather than inferring it from wall-clock timing (flaky).
+
+This test must FLIP RED if the per-message ``is_active_seq`` scan is restored:
+locally reverting ``_active_branch_history`` to call ``is_active_seq`` per
+message (instead of ``build_active_predicate`` once) makes
+``iter_from_calls == n`` (one scan per message) instead of ``<= 2`` — confirmed
+during development (see PR body for the strip-falsification record).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+
+
+class _CountingStateLog(StateLog):
+    """A real ``StateLog`` that counts ``iter_from`` calls — a public-method
+    override, not a private-state assertion, so the scan-count bound is
+    verified through the same seam production code calls."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.iter_from_calls = 0
+
+    def iter_from(self, min_seq: int):
+        self.iter_from_calls += 1
+        return super().iter_from(min_seq)
+
+
+def _session(tmp_path: Path, state_log: StateLog) -> Session:
+    s = Session(
+        agent_name="alice", state_log=state_log,
+        snapshot_path=tmp_path / "alice_snapshot.json",
+    )
+    s.register_intervention_listener("test")
+    return s
+
+
+@pytest.mark.asyncio
+async def test_active_branch_history_scans_wal_o1_per_build_not_per_message(tmp_path, monkeypatch):
+    """Tier 2: N history messages + a rewind cost O(1) iter_from() calls per
+    build_history(), NOT O(N). Pre-hoist this was N calls (one full WAL scan per
+    message) — the actual freeze mechanism, worsening with both message count and
+    WAL length as the session grows."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _CountingStateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+
+    n = 40
+    anchors = []
+    for i in range(n):
+        await state_log.append("step_completed")  # WAL activity between turns (real turn shape)
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+        anchors.append(s.history[-1].meta["wal_seq"])
+    # A rewind exists so the abandoned-interval predicate is non-trivial (not the
+    # degenerate empty-list fast path).
+    await checkout(state_log, target_seq=anchors[5])
+
+    state_log.iter_from_calls = 0  # measure only the build_history() call under test
+    wire = s._history_buffer.build_history()
+
+    assert len(wire) > 0, "sanity: history is non-empty and visible"
+    assert state_log.iter_from_calls <= 2, (
+        f"expected O(1) WAL scans per build_history() (got {state_log.iter_from_calls} "
+        f"for n={n} history messages) — a per-message re-scan (the #2941 freeze bug) "
+        "would grow with N, not stay bounded"
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_branch_history_scan_count_independent_of_message_count(tmp_path, monkeypatch):
+    """Tier 2: the scan count for a build_history() call does NOT grow when the
+    message count grows (the O(N) vs O(1) discriminator) — a smaller history and
+    a larger history cost the SAME number of iter_from() calls."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _CountingStateLog(tmp_path / "state.wal")
+    s = _session(tmp_path, state_log)
+
+    async def _turn(i: int) -> int:
+        await state_log.append("step_completed")
+        s._append_history(ChatMessage(role="user", content=f"turn {i}"))
+        return s.history[-1].meta["wal_seq"]
+
+    for i in range(5):
+        await _turn(i)
+    await checkout(state_log, target_seq=(await _turn(5)))
+
+    state_log.iter_from_calls = 0
+    s._history_buffer.build_history()
+    small_count = state_log.iter_from_calls
+
+    for i in range(6, 60):
+        await _turn(i)
+
+    state_log.iter_from_calls = 0
+    s._history_buffer.build_history()
+    large_count = state_log.iter_from_calls
+
+    assert small_count == large_count, (
+        f"scan count must be independent of message count (small history: "
+        f"{small_count} calls, {60 - 6 + 6}x-larger history: {large_count} calls) — "
+        "a per-message scan would make large_count >> small_count"
+    )

--- a/tests/test_build_active_predicate_equivalence_2941.py
+++ b/tests/test_build_active_predicate_equivalence_2941.py
@@ -1,0 +1,89 @@
+"""Tier 2: #2941 — ``build_active_predicate`` (one WAL scan, reused per-seq) must
+return IDENTICAL visibility to per-seq ``is_active_seq`` (one WAL scan EACH call).
+
+``build_active_predicate`` hoists ``_abandoned_intervals(_rewind_records(state_log))``
+out of a per-message loop (the freeze fix, see ``Session._active_branch_history``).
+Since that derivation depends only on the state_log's rewind records — never on
+the seq being tested — the hoisted predicate is provably equivalent to calling
+``is_active_seq`` per seq; this test verifies that equivalence directly against a
+real ``StateLog`` across: no rewind, one rewind, nested/subsuming rewinds, and a
+checkout-back resurrection (the branch-tree scenarios ADR-0038 Stage 1b-1e define).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import (
+    build_active_predicate,
+    checkout,
+    is_active_seq,
+)
+from reyn.core.events.state_log import StateLog
+
+
+def _assert_equivalent(state_log: StateLog, seqs: range) -> None:
+    predicate = build_active_predicate(state_log)
+    for seq in seqs:
+        assert predicate(seq) == is_active_seq(state_log, seq), (
+            f"build_active_predicate diverges from is_active_seq at seq={seq}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_rewind_all_active(tmp_path: Path) -> None:
+    """Tier 2: with no rewind records every seq is active under both."""
+    state_log = StateLog(tmp_path / "state.wal")
+    for i in range(10):
+        await state_log.append("step_completed")
+    _assert_equivalent(state_log, range(1, 11))
+
+
+@pytest.mark.asyncio
+async def test_single_rewind_abandons_interval(tmp_path: Path) -> None:
+    """Tier 2: one rewind — the abandoned (target, R) interval hidden under both."""
+    state_log = StateLog(tmp_path / "state.wal")
+    seqs = [await state_log.append("step_completed") for _ in range(10)]
+    await checkout(state_log, target_seq=seqs[2])
+    _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
+
+
+@pytest.mark.asyncio
+async def test_nested_subsuming_rewinds(tmp_path: Path) -> None:
+    """Tier 2: a rewind, then more turns, then a rewind that subsumes the first
+    (nested abandonment) — equivalence holds through the composition."""
+    state_log = StateLog(tmp_path / "state.wal")
+    seqs = [await state_log.append("step_completed") for _ in range(6)]
+    await checkout(state_log, target_seq=seqs[4])  # abandon a small tail first
+    more = [await state_log.append("step_completed") for _ in range(4)]
+    await checkout(state_log, target_seq=seqs[1])  # subsumes the first rewind entirely
+    _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
+    assert more  # sanity: the intervening turns exist in the WAL
+
+
+@pytest.mark.asyncio
+async def test_checkout_back_resurrection(tmp_path: Path) -> None:
+    """Tier 2: rewind, branch forward, then checkout BACK to the old (now-abandoned)
+    tip — resurrects it. Equivalence holds across the resurrection."""
+    state_log = StateLog(tmp_path / "state.wal")
+    seqs = [await state_log.append("step_completed") for _ in range(6)]
+    await checkout(state_log, target_seq=seqs[2])       # rewind: abandons seqs[3:6]
+    for _ in range(3):
+        await state_log.append("step_completed")         # new branch forward
+    await checkout(state_log, target_seq=seqs[5])       # checkout back: resurrects seqs[3:6]
+    _assert_equivalent(state_log, range(1, state_log.current_seq + 1))
+
+
+@pytest.mark.asyncio
+async def test_predicate_is_reusable_across_many_seqs(tmp_path: Path) -> None:
+    """Tier 2: a single predicate instance (built once) answers correctly for
+    MANY different seqs — the exact reuse pattern ``_active_branch_history`` relies
+    on (build once per turn, apply per message)."""
+    state_log = StateLog(tmp_path / "state.wal")
+    seqs = [await state_log.append("step_completed") for _ in range(20)]
+    await checkout(state_log, target_seq=seqs[9])
+    predicate = build_active_predicate(state_log)
+    expected = [is_active_seq(state_log, s) for s in range(1, state_log.current_seq + 1)]
+    actual = [predicate(s) for s in range(1, state_log.current_seq + 1)]
+    assert actual == expected


### PR DESCRIPTION
**[per-PR-coder]** — Fixes the owner-reported `reyn chat` freeze (~60s between
Enter and the LLM request, on long sessions, worsening the longer the session
runs).

## Root cause

Owner py-spy stack showed the process stuck in `state_log.py` `iter_from`
doing `json.loads`, plus rewind-record iteration.

`Session._active_branch_history()` (`src/reyn/runtime/session.py`) is sliced
by `build_history` **every turn**. For **each** history message it called
`is_active_seq(self._state_log, seq)`
(`src/reyn/core/events/snapshot_generations.py`). `is_active_seq` =
`_make_is_active(_abandoned_intervals(_rewind_records(state_log)))(seq)`, and
`_rewind_records(state_log)` does a **full WAL scan** `state_log.iter_from(1)`,
json-decoding every line.

So per turn: **N** (history messages) x **M** (WAL entries) `json.loads` calls.
Both N and M grow as the session runs longer → the freeze gets worse over
time, exactly as reported. Falsified as NOT the cause (ruled out earlier):
litellm `token_counter`, compaction (no compaction events in the gap),
message size (`"hello"` still froze) — all consistent with an O(N x M) scan
cost independent of message content/size.

**Key correctness insight**: `_abandoned_intervals(_rewind_records(state_log))`
depends **only** on the state_log's rewind records — it is **independent of
`seq`**. Recomputing it per-message is pure waste; computing it once and
testing every seq against the same predicate is exactly equivalent.

## What shipped: #1 (hoist) only — NOT #2 (cross-turn memoization)

Added `build_active_predicate(state_log) -> Callable[[int], bool]` to
`snapshot_generations.py`:

```python
def build_active_predicate(state_log: StateLog) -> Callable[[int], bool]:
    return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
```

`_active_branch_history` now calls this **once per turn** and reuses the
returned closure for every message's `seq`, instead of calling
`is_active_seq` once per message. **O(N x M) → O(N + M) per turn** — one WAL
scan per turn instead of N.

`is_active_seq` itself is **byte-unchanged** (pure addition, no edit to its
body — see diff) and every other caller keeps calling it directly and
unaffected: `pipeline_recovery.py:98`, `config_generations.py:118`,
`registry.py:1036,1197,1359,1747,1792,2155,2168,2185,2190` (crash-recovery /
WAL-replay paths). Only `Session._active_branch_history`'s call shape
changed.

### Why memoization (#2) is NOT shipped here

I investigated cross-turn memoization (cache `(last_scanned_seq,
cached_rewind_records)`, extend incrementally via `iter_from(last_scanned_seq
+ 1)`) to amortize the remaining O(M) full-WAL-scan-per-turn further. Two
things stopped me from shipping it in this PR:

1. **`StateLog.iter_from(min_seq)` has no byte-offset seek** — it always opens
   the file and `json.loads`-parses **every line from the start**, filtering
   by `seq >= min_seq` only *after* parsing (`state_log.py` `iter_from`, see
   the `for line in f:` loop with the `seq < min_seq: continue` check coming
   after `json.loads`). So calling `iter_from(last_scanned_seq + 1)` instead
   of `iter_from(1)` does **not** actually reduce the parse cost — true O(Δ)
   incremental scanning would require adding a real offset-tracked read
   primitive to `StateLog` itself (a bigger, riskier change to shared
   recovery-critical WAL infra reused by crash recovery elsewhere), not just
   a cache in `snapshot_generations.py`.
2. **Pre-flagged recovery-safety gap**: an in-memory `(last_scanned_seq,
   cached_records)` cache interacts with mid-session retention
   floor-truncation (`retention.py`, ADR-0038 Stage 1e drops old WAL entries).
   The cache is in-memory and would NOT be invalidated by a truncation; I have
   not proven (and did not want to rush) that it can never serve a stale
   interval when retention drops a rewind record the cache had already
   scanned past. Retention's "reconstruct needs are retained" invariant likely
   makes this safe, but that needs its own clean proof + test, not a rushed
   addendum to an owner-severity freeze fix.

Given (1) the real perf mechanism (`iter_from` not supporting seek) means the
memoization wouldn't deliver the claimed O(Δ) win without touching `StateLog`
itself, and (2) the retention interaction is a non-trivial, unproven surface —
I'm shipping **hoist-only** here and tracking memoization as a fast-follow
(needs a `StateLog` offset-tracked read primitive + the retention x memoize
proof/test above, as its own PR).

**The hoist alone already turns the dominant O(N x M) term into O(M)** — for
any session with more than a handful of history messages (N), this is the
overwhelming majority of the win; verified below.

## Strip-falsification (the scan-count-bound test)

Reverted `_active_branch_history` locally to the pre-fix per-message
`is_active_seq` call and re-ran the new scan-count tests:

```
FAILED tests/test_active_branch_history_scan_bound_2941.py::test_active_branch_history_scans_wal_o1_per_build_not_per_message
  AssertionError: expected O(1) WAL scans per build_history() (got 80 for
  n=40 history messages) — assert 80 <= 2
FAILED tests/test_active_branch_history_scan_bound_2941.py::test_active_branch_history_scan_count_independent_of_message_count
  AssertionError: scan count must be independent of message count (small
  history: 12 calls, 60x-larger history: 120 calls) — assert 12 == 120
```

Both tests RED confirmed (80 iter_from calls for 40 messages ≈ 2x per
message — the tool-cycle-aware loop makes a couple of related checks per
message — clearly proportional to N, not bounded). Restored the fix
afterward; both tests GREEN again.

## Tests (Tier 2 — OS invariant)

- `tests/test_active_branch_history_scan_bound_2941.py` — real `Session` +
  real `StateLog` (subclassed to count `iter_from` calls, a public-method
  override, not a private-state peek) + real `checkout`. Asserts the scan
  count for `build_history()` is bounded (`<= 2`) regardless of history size
  (40 messages), and that it does not grow between a 6-message and a
  66-message history. FLIPS RED on revert (see above).
- `tests/test_build_active_predicate_equivalence_2941.py` — `
  build_active_predicate` vs per-seq `is_active_seq` equivalence across: no
  rewind (all active), single rewind (abandoned interval hidden),
  nested/subsuming rewinds, checkout-back resurrection, and reuse of one
  predicate instance across many seqs (the exact pattern
  `_active_branch_history` relies on).
- Existing `tests/test_conversation_rewind_2360.py` (rewind-hides-turns,
  fork-switch/no-discard, mid-tool-cycle cut, unanchored-turns-visible, and
  its own truncate-falsify test for the rewind reset-record surviving WAL
  truncation) all still pass unmodified — they exercise
  `_active_branch_history` end-to-end and now cover the hoisted path.

## Recovery / truncate-falsify gate

No new persisted or WAL-derived recovery state is introduced — `
build_active_predicate` is a pure, request-scoped, in-memory helper (built
fresh on every call, nothing cached across calls in this PR). The CLAUDE.md
recovery-feature PR gate (truncate-falsify test) does not apply: there is no
new reconstruction/derived-state surface to falsify against WAL truncation.
`is_active_seq`'s own truncate-falsify coverage (
`test_rewind_record_survives_wal_truncation` in
`test_conversation_rewind_2360.py`) is unchanged and still passes.

## Complexity

- Before: O(N messages x M WAL entries) per turn (re-scan whole WAL per
  message).
- After (this PR): O(N + M) per turn (one WAL scan per turn, reused
  predicate).
- Deferred fast-follow (memoization): O(Δ) amortized — blocked on (a) a
  `StateLog` offset-tracked read primitive and (b) the retention x memoize
  proof, both called out above.

## CI gates (all run locally, all green)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_active_branch_history_scan_bound_2941.py tests/test_build_active_predicate_equivalence_2941.py` — 7/7 OK, 0 warnings, 0 errors.
- `pytest` (full suite, repo root) — 8503 passed, 20 skipped.
- `python scripts/verify_module_docstrings.py src/reyn/core/events/snapshot_generations.py src/reyn/runtime/session.py` — OK.

## Test plan

- [x] Strip-falsification: revert hoist locally → scan-count tests RED (80
      calls for 40 messages) → restore → GREEN. (documented above)
- [x] Full equivalence suite (no rewind / single / nested-subsuming /
      checkout-back) passes for `build_active_predicate` vs `is_active_seq`.
- [x] Existing `#2360` conversation-rewind suite (incl. its own
      truncate-falsify test) passes unmodified.
- [x] Confirmed every non-Session `is_active_seq` caller (crash recovery,
      registry, config_generations, pipeline_recovery) is untouched — `
      is_active_seq`'s body is byte-identical in the diff.
