### PR TITLE
fix: defer httpx import off the CLI cold-start path

### DIFF
--- a/src/reyn/interfaces/cli/commands/chat.py
+++ b/src/reyn/interfaces/cli/commands/chat.py
@@ -15,7 +15,6 @@ from reyn.interfaces.cli.env_backend import (
     build_environment_backend,
     register_env_backend_args,
 )
-from reyn.llm.llm import run_async
 
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
@@ -344,6 +343,7 @@ def run(args: argparse.Namespace) -> None:
 
     from reyn.config import _find_project_root, load_project_context
     from reyn.interfaces.repl.repl import run_repl
+    from reyn.llm.llm import run_async
     from reyn.runtime.factory_config import SessionFactoryConfig
     from reyn.runtime.presentation_consumer import OutboxPresentationConsumer
     from reyn.runtime.profile import AgentProfile

--- a/src/reyn/interfaces/cli/commands/mcp.py
+++ b/src/reyn/interfaces/cli/commands/mcp.py
@@ -18,8 +18,6 @@ import os
 import sys
 from pathlib import Path
 
-from reyn.llm.llm import run_async
-
 from ..common_args import add_common_args
 from ..invocation_context import InvocationContext
 
@@ -323,6 +321,7 @@ def register(sub) -> None:
 def run_serve(args: argparse.Namespace) -> None:
     from reyn.config import _find_project_root, load_project_context
     from reyn.core.events.state_log import StateLog
+    from reyn.llm.llm import run_async
     from reyn.mcp.server import serve_stdio
     from reyn.runtime.budget.budget import BudgetTracker
     from reyn.runtime.factory_config import SessionFactoryConfig

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -12,8 +12,6 @@ from datetime import UTC, datetime
 from email.utils import parsedate_to_datetime
 from typing import TYPE_CHECKING, Coroutine, NamedTuple, TypeVar, Union
 
-import httpx
-
 logger = logging.getLogger(__name__)
 from reyn.llm.credentials import check_model_credentials
 from reyn.llm.json_parse import loads_lenient
@@ -597,6 +595,29 @@ class LLMToolCallResult:
 # Resolved lazily so importing this module does not trigger `import litellm`.
 _RETRYABLE_LITELLM_EXCEPTIONS: tuple | None = None
 
+# Resolved lazily so importing this module does not trigger `import httpx` (its
+# CLI pretty-printing subtree — rich.progress / rich.syntax / pygments — costs
+# ~90ms and reyn never invokes it; cold-start sweep companion to #2930's
+# litellm chokepoint, see litellm_bootstrap.py's module docstring).
+_HTTPX_READ_TIMEOUT_EXC: "type[BaseException] | None" = None
+_HTTPX_CONNECT_ERROR_EXC: "type[BaseException] | None" = None
+
+
+def _get_httpx_exc_types() -> "tuple[type[BaseException], type[BaseException]]":
+    """Return ``(httpx.ConnectError, httpx.ReadTimeout)``, loading httpx lazily.
+
+    Cached in _HTTPX_CONNECT_ERROR_EXC / _HTTPX_READ_TIMEOUT_EXC after first call.
+    Kept as two distinct classes (not a pre-built isinstance tuple) so callers
+    can select only the subset they mean — e.g. ``_is_llm_timeout_exc`` cares
+    about ReadTimeout only, not ConnectError.
+    """
+    global _HTTPX_READ_TIMEOUT_EXC, _HTTPX_CONNECT_ERROR_EXC
+    if _HTTPX_READ_TIMEOUT_EXC is None:
+        import httpx  # noqa: PLC0415
+        _HTTPX_READ_TIMEOUT_EXC = httpx.ReadTimeout
+        _HTTPX_CONNECT_ERROR_EXC = httpx.ConnectError
+    return _HTTPX_CONNECT_ERROR_EXC, _HTTPX_READ_TIMEOUT_EXC
+
 def _env_num(name: str, default: "int | float", lo: "int | float", hi: "int | float",
              cast):
     """Operator tuning knob from the environment, clamped to ``[lo, hi]``; falls back
@@ -773,9 +794,12 @@ def _is_llm_timeout_exc(exc: BaseException) -> bool:
     """#2210: True for a per-call HTTP TIMEOUT (a hung/slow provider) — ``litellm`` Timeout or
     an ``httpx`` read timeout, the timeout subset of ``_is_retryable_exc``. Used to route ONLY
     a persistent timeout through the on_limit policy (other infra errors surface as-is).
-    ``litellm`` is lazy-imported (this module avoids a module-level ``import litellm``)."""
+    ``litellm`` is lazy-imported (this module avoids a module-level ``import litellm``),
+    and ``httpx`` likewise (avoids a module-level ``import httpx`` — see
+    ``_get_httpx_exc_types``)."""
     import litellm  # noqa: PLC0415
-    return isinstance(exc, (litellm.exceptions.Timeout, httpx.ReadTimeout))
+    _, read_timeout_exc = _get_httpx_exc_types()
+    return isinstance(exc, (litellm.exceptions.Timeout, read_timeout_exc))
 
 
 def _resolve_llm_call_bounds(
@@ -879,7 +903,7 @@ def _is_retryable_exc(exc: BaseException) -> bool:
         return True
     if isinstance(exc, _get_retryable_litellm_exceptions()):
         return True
-    if isinstance(exc, (httpx.ConnectError, httpx.ReadTimeout)):
+    if isinstance(exc, _get_httpx_exc_types()):
         return True
     return False
 

--- a/tests/test_httpx_lazy_load_cli_entry.py
+++ b/tests/test_httpx_lazy_load_cli_entry.py
@@ -1,0 +1,140 @@
+"""Tier 2: httpx import is off the CLI cold-start path (`reyn --help` etc, #2930 companion).
+
+``import httpx`` used to run eagerly on EVERY ``reyn`` invocation — via a
+module-level ``from reyn.llm.llm import run_async`` in
+``reyn.interfaces.cli.commands.chat`` / ``reyn.interfaces.cli.commands.mcp``,
+which pulled in ``reyn.llm.llm``'s own module-level ``import httpx``. httpx's
+own CLI pretty-printing subtree (``rich.progress`` / ``rich.syntax`` /
+``pygments``) makes this cost ~90ms, ~25% of `reyn.interfaces.cli`'s total
+import time, for a capability (network calls) the CLI entry never invokes.
+
+This mirrors the ``ensure_litellm_ready`` chokepoint pattern (#2930,
+``test_litellm_lazy_load.py``): `run_async` is now imported lazily inside the
+functions that call it, and ``reyn.llm.llm``'s two ``isinstance(exc, httpx.X)``
+exception-classification sites (``_is_llm_timeout_exc`` /
+``_is_retryable_exc``) resolve the httpx exception classes lazily via
+``_get_httpx_exc_types()`` (same shape as the existing
+``_get_retryable_litellm_exceptions()`` for litellm).
+
+Exercised via a real subprocess (not mocks) so ``sys.modules`` state is the
+actual process-level fact, not an in-process assumption contaminated by an
+earlier test's ``import httpx``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+
+
+def _run(script: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": str(SRC_DIR)}
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def test_chat_command_module_import_does_not_import_httpx() -> None:
+    """Tier 2: importing `reyn.interfaces.cli.commands.chat` leaves httpx unimported.
+
+    FALSIFY: restoring the eager `from reyn.llm.llm import run_async` at module
+    scope in chat.py (which pulls llm.py's `import httpx`) flips this RED —
+    confirmed manually during development (see PR body).
+    """
+    script = """
+        import sys
+        import reyn.interfaces.cli.commands.chat  # noqa: F401
+        assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_mcp_command_module_import_does_not_import_httpx() -> None:
+    """Tier 2: importing `reyn.interfaces.cli.commands.mcp` leaves httpx unimported."""
+    script = """
+        import sys
+        import reyn.interfaces.cli.commands.mcp  # noqa: F401
+        assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_llm_module_import_does_not_import_httpx() -> None:
+    """Tier 2: importing `reyn.llm.llm` directly leaves httpx unimported — the
+    two `isinstance(exc, httpx.X)` exception-classification sites must resolve
+    httpx lazily, not via a module-level `import httpx`."""
+    script = """
+        import sys
+        import reyn.llm.llm  # noqa: F401
+        assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_cli_help_invocation_does_not_import_httpx() -> None:
+    """Tier 2: the full `reyn --help` entry path (the actual cold-start
+    invocation this fix targets) never touches httpx.
+
+    Decisive: runs `reyn._cli.main()` with `--help` (the CLI's own SystemExit
+    on --help is caught) and asserts `sys.modules` is clean — the exact
+    checkpoint the #2930-style cold-start sweep is measured against.
+    """
+    script = """
+        import sys
+        sys.argv = ["reyn", "--help"]
+        from reyn._cli import main
+        try:
+            main()
+        except SystemExit:
+            pass
+        assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+def test_httpx_exception_classification_still_resolves_lazily() -> None:
+    """Tier 2: `_get_httpx_exc_types()` (the httpx-equivalent of
+    `_get_retryable_litellm_exceptions`) imports httpx on first call and
+    returns the real `(httpx.ConnectError, httpx.ReadTimeout)` pair, so the
+    lazy-load refactor does not silently break the retry/timeout
+    classification `_is_retryable_exc` / `_is_llm_timeout_exc` depend on.
+
+    Behavioral tests for the classification itself already live in
+    `tests/test_llm_call_retry.py` (test_httpx_errors_retried,
+    test_is_retryable_exc_classification) — this test pins only the
+    lazy-resolution invariant those tests rely on.
+    """
+    script = """
+        import sys
+        assert "httpx" not in sys.modules
+        from reyn.llm.llm import _get_httpx_exc_types
+        connect_exc, read_timeout_exc = _get_httpx_exc_types()
+        assert "httpx" in sys.modules
+        import httpx
+        assert connect_exc is httpx.ConnectError
+        assert read_timeout_exc is httpx.ReadTimeout
+        print("OK")
+        """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout


### PR DESCRIPTION
**[per-PR-coder]** — Cold-start latency fix: `import httpx` was escaping #2930's lazy-import sweep, running on every `reyn` invocation (including `reyn --help`).

## Defect

`src/reyn/interfaces/cli/commands/chat.py:18` (and `commands/mcp.py:21`) did `from reyn.llm.llm import run_async` at **module scope**, which pulled `src/reyn/llm/llm.py:15`'s module-level `import httpx` on every process start. httpx's own CLI pretty-printing subtree (`rich.progress` / `rich.syntax` / `pygments`) makes this expensive for a capability (network calls) the CLI entry never invokes.

## Enumeration of every `httpx` consumer in the import chain (grep -rn "httpx" src/)

| Site | Disposition |
|---|---|
| `interfaces/cli/commands/chat.py:18` module-level `from reyn.llm.llm import run_async` | **Fixed** — moved into `run()` (already has its own lazy-import block at L345) |
| `llm/llm.py:15` module-level `import httpx` | **Fixed** — removed; two `isinstance(exc, httpx.X)` sites now resolve lazily via new `_get_httpx_exc_types()` |
| `interfaces/cli/commands/mcp.py:21` module-level `from reyn.llm.llm import run_async` | **Fixed** — moved into `run_serve()` (already has its own lazy-import block at L324) |
| `_ssrf_pin.py` (`import httpx` at L195, L215) | Already lazy (function-local) — no change |
| `core/registry/client.py` (`import httpx` at L158, L210) | Already lazy (function-local) — no change |
| `core/op_runtime/web.py:223` (`import httpx`) | Already lazy (function-local) — no change |
| `security/secrets/oauth.py` (L287, L497, L631) | Already lazy (function-local) — no change |
| `dev/dogfood/publish.py:409` | Already lazy (function-local) — no change |
| `interfaces/repl/remote_client.py:99` | Already lazy (function-local, with a `missing_dep_message` fallback) — no change |
| `interfaces/web/notifications.py` (L32, L71) | Already lazy (function-local, optional-dep gated) — no change |
| All other hits (`_ssrf_guard.py`, `core/cancellable.py`, `runtime/error_format.py`, `runtime/channel_state.py`, `mcp/client.py`, `interfaces/transport/agui/client.py`, `interfaces/repl/client_driver.py`, `core/kernel/_python_allowlist.py`) | Comments/docstrings only, no import | N/A |

Only `llm.py:15` + the two module-level `run_async` re-exports in `chat.py` / `mcp.py` were the actual eager path — everything else in the repo was already lazy.

## Type-annotation check

No `httpx` symbols are used at type-annotation level in `llm.py` — only two `isinstance(exc, httpx.X)` runtime checks (`_is_llm_timeout_exc`, `_is_retryable_exc`), handled below. No `TYPE_CHECKING` gate was needed.

## Exception-handling paths

`_is_llm_timeout_exc` and `_is_retryable_exc` reference `httpx.ReadTimeout` / `httpx.ConnectError`. Added `_get_httpx_exc_types()` — same shape as the existing `_get_retryable_litellm_exceptions()` lazy-litellm cache — returning `(httpx.ConnectError, httpx.ReadTimeout)` as two separate cached class refs (not a merged isinstance tuple), because `_is_llm_timeout_exc` intentionally only matches `ReadTimeout` (not `ConnectError`) — a shared tuple would have silently widened its semantics. Both call sites updated to pull from the cache; behavior unchanged (verified: `tests/test_llm_call_retry.py::test_httpx_errors_retried` and `test_is_retryable_exc_classification` still pass).

## Measured importtime (before / after), `reyn --help` entry path, same machine

- **Before**: `httpx` cumulative = 62031 μs (~62ms); `reyn.interfaces.cli` cumulative = 405771 μs (~405.8ms)
- **After**: `httpx` does not appear anywhere in the trace at all (confirmed via `grep httpx` on the after trace — zero hits, `rich.*`/`pygments` subtree also gone); `reyn.interfaces.cli` cumulative = 286839 μs (~286.8ms)
- **Delta**: ~118.9ms removed (~29% of `reyn.interfaces.cli`'s total import time) — larger than the httpx-alone figure because httpx's own `rich`/`pygments` subtree is also fully eliminated from the default path.

(Both traces taken with `PYTHONPATH=<worktree>/src` against the worktree source, not the editable-installed copy, to avoid measuring a stale path.)

## Real network path still works

`_get_httpx_exc_types()` imports httpx lazily on first call and returns the real `httpx.ConnectError` / `httpx.ReadTimeout` classes — pinned by the new `test_httpx_exception_classification_still_resolves_lazily` test. The existing retry/timeout classification tests (`tests/test_llm_call_retry.py`) were NOT skipped and still pass against the real httpx exception types.

## Tests added (`tests/test_httpx_lazy_load_cli_entry.py`)

5 Tier-2 subprocess tests pinning the invariant (not timing):
- `test_chat_command_module_import_does_not_import_httpx`
- `test_mcp_command_module_import_does_not_import_httpx`
- `test_llm_module_import_does_not_import_httpx`
- `test_cli_help_invocation_does_not_import_httpx` (the actual `reyn --help` checkpoint)
- `test_httpx_exception_classification_still_resolves_lazily`

**Strip-falsification**: restored the eager `import httpx` at the top of `llm.py` locally and re-ran the suite — 4/5 tests flipped RED (`AssertionError` listing all the loaded `httpx.*` submodules), confirming they actually detect the regression. The 5th (`test_httpx_exception_classification_still_resolves_lazily`) correctly stayed green, since it tests the lazy-resolution mechanism itself, not the eager-import regression. Restored the fix afterward; full suite green again.

## CI gates (all run locally, foreground)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_httpx_lazy_load_cli_entry.py` — 5/5 OK, 0 warnings, 0 errors
- `pytest` (repo root) — 8519 passed, 20 skipped, 0 failed
- `python scripts/verify_module_docstrings.py <changed src files>` — OK

## Test plan
- [x] `python -X importtime` before/after confirms httpx (+ rich/pygments subtree) is off the default `reyn --help` path
- [x] Retry/timeout classification tests (`test_llm_call_retry.py`) still pass unmodified
- [x] New invariant tests pass, and were strip-falsified against the pre-fix code
- [x] All 4 CI gates green locally