### PR TITLE
fix: sweep the O(WAL²) per-seq is_active_seq fix-class off the cold-start path (#2938 sibling)

### DIFF
--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Callable
 
 import yaml
 
@@ -104,18 +105,29 @@ class ConfigGenerationStore:
         )
         return seq, content if isinstance(content, dict) else {}
 
-    def latest_active(self, rel_path: str, state_log: object) -> "tuple[int, dict] | None":
+    def latest_active(
+        self, rel_path: str, is_active: "Callable[[int], bool]",
+    ) -> "tuple[int, dict] | None":
         """The (seq, content) of the highest generation for `rel_path` on the ACTIVE WAL
-        branch (``is_active_seq``), or None when no active generation exists.
+        branch, or None when no active generation exists.
+
+        ``is_active`` is the caller-supplied membership predicate (``is_active_seq``'s
+        derivation is seq-independent — see ``build_active_predicate``). A caller
+        reconciling MANY rel_paths in one pass (e.g.
+        ``AgentRegistry._reconcile_config_as_of_cut``) MUST hoist ONE
+        ``build_active_predicate(state_log)`` and reuse it here per rel_path — passing
+        ``is_active_seq`` re-bound per call would re-scan the whole WAL once per
+        rel_path (the #2941 sibling quadratic-cold-start shape this signature exists to
+        prevent). A single-path caller may pass
+        ``lambda s: is_active_seq(state_log, s)`` directly.
 
         #2405: ``latest_at_or_below(cut=N)`` has the symmetric gap — post-rewind active
         generations (seq > R > N) are excluded, reverting config to as-of-N on crash
-        recovery. ``is_active_seq`` covers all three regions correctly:
-        • Pre-target (seq ≤ N): ``is_active_seq=True`` → applied.
-        • Abandoned branch (N < seq < R): ``is_active_seq=False`` → skipped.
-        • Post-rewind active (seq > R): ``is_active_seq=True`` → applied."""
-        from reyn.core.events.snapshot_generations import is_active_seq  # noqa: PLC0415
-        seqs = [s for s in self._entries().get(rel_path, ()) if is_active_seq(state_log, s)]
+        recovery. The active-branch predicate covers all three regions correctly:
+        • Pre-target (seq ≤ N): active=True → applied.
+        • Abandoned branch (N < seq < R): active=False → skipped.
+        • Post-rewind active (seq > R): active=True → applied."""
+        seqs = [s for s in self._entries().get(rel_path, ()) if is_active(s)]
         if not seqs:
             return None
         seq = seqs[-1]

--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -25,7 +25,12 @@ Two entry points:
     split ``StateLog.append``/``append_nowait`` already draws for WAL entries.
   - ``latest_pipeline_state`` — the reader seam ``resume`` calls: the latest
     generation for a run ON THE ACTIVE WAL BRANCH (``is_active_seq``), mirroring
-    ``ConfigGenerationStore.latest_active``'s semantics exactly.
+    ``ConfigGenerationStore.latest_active``'s SEMANTICS (active-branch membership,
+    latest-wins, no forward-replay) but NOT its signature: that store multiplexes
+    MANY rel_paths, so it takes a caller-hoisted ``is_active`` predicate to keep a
+    multi-path reconcile from re-scanning the WAL per path. This store is scoped to
+    ONE run (a handful of generation files, one run per caller), so there is no
+    per-path loop to hoist out of and it takes the ``state_log`` directly.
 """
 from __future__ import annotations
 
@@ -92,8 +97,17 @@ class PipelineStateStore:
 
     def latest_active(self, state_log: object) -> "tuple[int, dict] | None":
         """The (seq, content) of the highest generation on the ACTIVE WAL branch
-        (``is_active_seq``), or None if no active generation exists. Mirrors
-        ``ConfigGenerationStore.latest_active``."""
+        (``is_active_seq``), or None if no active generation exists.
+
+        Mirrors ``ConfigGenerationStore.latest_active``'s SEMANTICS (active-branch
+        membership, latest-wins, no forward-replay) but deliberately NOT its
+        signature: that store takes a caller-hoisted ``is_active`` predicate because
+        it multiplexes MANY rel_paths, so calling ``is_active_seq`` internally made a
+        multi-path reconcile re-scan the whole WAL once per path (quadratic BY
+        CONSTRUCTION — no caller-side hoist could fix it). This store is scoped to ONE
+        run: ``_seqs()`` is that run's own handful of generation files and the sole
+        caller (``latest_pipeline_state``) resolves a single run, so there is no
+        per-path loop to hoist out of and taking the ``state_log`` stays correct."""
         from reyn.core.events.snapshot_generations import is_active_seq  # noqa: PLC0415
         seqs = [s for s in self._seqs() if is_active_seq(state_log, s)]  # type: ignore[arg-type]
         if not seqs:

--- a/src/reyn/core/events/pipeline_recovery.py
+++ b/src/reyn/core/events/pipeline_recovery.py
@@ -24,20 +24,18 @@ Two entry points:
     (``state_log.submit_durable_nowait``) path, mirroring the durable/non-durable
     split ``StateLog.append``/``append_nowait`` already draws for WAL entries.
   - ``latest_pipeline_state`` — the reader seam ``resume`` calls: the latest
-    generation for a run ON THE ACTIVE WAL BRANCH (``is_active_seq``), mirroring
-    ``ConfigGenerationStore.latest_active``'s SEMANTICS (active-branch membership,
-    latest-wins, no forward-replay) but NOT its signature: that store multiplexes
-    MANY rel_paths, so it takes a caller-hoisted ``is_active`` predicate to keep a
-    multi-path reconcile from re-scanning the WAL per path. This store is scoped to
-    ONE run (a handful of generation files, one run per caller), so there is no
-    per-path loop to hoist out of and it takes the ``state_log`` directly.
+    generation for a run ON THE ACTIVE WAL BRANCH, mirroring
+    ``ConfigGenerationStore.latest_active``'s semantics exactly (active-branch
+    membership, latest-wins, no forward-replay), down to the predicate-taking
+    signature: ``PipelineStateStore.latest_active`` takes a caller-hoisted
+    ``is_active`` so no reader can re-scan the WAL once per generation seq.
 """
 from __future__ import annotations
 
 import json
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from reyn.core.events.config_recovery import reyn_root
 
@@ -95,21 +93,25 @@ class PipelineStateStore:
         content = json.loads(self._path_for(seq).read_text(encoding="utf-8"))
         return seq, content
 
-    def latest_active(self, state_log: object) -> "tuple[int, dict] | None":
-        """The (seq, content) of the highest generation on the ACTIVE WAL branch
-        (``is_active_seq``), or None if no active generation exists.
+    def latest_active(
+        self, is_active: "Callable[[int], bool]",
+    ) -> "tuple[int, dict] | None":
+        """The (seq, content) of the highest generation on the ACTIVE WAL branch, or
+        None if no active generation exists. Mirrors
+        ``ConfigGenerationStore.latest_active`` exactly — same active-branch
+        membership / latest-wins / no-forward-replay semantics, and the same
+        predicate-taking signature.
 
-        Mirrors ``ConfigGenerationStore.latest_active``'s SEMANTICS (active-branch
-        membership, latest-wins, no forward-replay) but deliberately NOT its
-        signature: that store takes a caller-hoisted ``is_active`` predicate because
-        it multiplexes MANY rel_paths, so calling ``is_active_seq`` internally made a
-        multi-path reconcile re-scan the whole WAL once per path (quadratic BY
-        CONSTRUCTION — no caller-side hoist could fix it). This store is scoped to ONE
-        run: ``_seqs()`` is that run's own handful of generation files and the sole
-        caller (``latest_pipeline_state``) resolves a single run, so there is no
-        per-path loop to hoist out of and taking the ``state_log`` stays correct."""
-        from reyn.core.events.snapshot_generations import is_active_seq  # noqa: PLC0415
-        seqs = [s for s in self._seqs() if is_active_seq(state_log, s)]  # type: ignore[arg-type]
+        ``is_active`` is the caller-supplied membership predicate (its derivation is
+        seq-independent — see ``build_active_predicate``). Taking a ``state_log`` here
+        would force an internal ``is_active_seq`` call per generation seq, re-scanning
+        the whole WAL each time: O(generations x WAL) per read, and quadratic BY
+        CONSTRUCTION for any caller that ever loops over runs — a shape no caller-side
+        hoist could fix. That is exactly how the config store's defect arose (it was
+        census-safe until ``AgentRegistry._reconcile_config_as_of_cut`` grew a rel_path
+        loop), so this store takes the predicate too rather than relying on today's
+        one-run-per-caller census holding forever."""
+        seqs = [s for s in self._seqs() if is_active(s)]
         if not seqs:
             return None
         seq = seqs[-1]
@@ -165,11 +167,19 @@ async def record_pipeline_state(
 def latest_pipeline_state(run_id: str, state_log: "StateLog") -> "dict[str, Any] | None":
     """The latest pipeline control-plane-state generation for `run_id` on the
     active WAL branch, or None if no generation was ever recorded (a fresh
-    run — `resume` should treat this as run-from-scratch)."""
+    run — `resume` should treat this as run-from-scratch).
+
+    Builds the active-branch predicate ONCE and hands it to the store — the hoist
+    ``PipelineStateStore.latest_active``'s signature obliges. A caller resolving MANY
+    runs should hoist ``build_active_predicate`` above its loop and drive the store
+    directly rather than calling this per run."""
+    from reyn.core.events.snapshot_generations import (  # noqa: PLC0415
+        build_active_predicate,
+    )
     store = _store(state_log, run_id)
     if store is None:
         return None
-    latest = store.latest_active(state_log)
+    latest = store.latest_active(build_active_predicate(state_log))
     if latest is None:
         return None
     _seq, content = latest

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -46,6 +46,7 @@ from reyn.core.events.snapshot_generations import (
     SnapshotGenerationStore,
     active_rewind_target,
     branch_ids_for,
+    build_active_predicate,
     is_active_seq,
     lineage_predecessor,
     list_branches,
@@ -1033,7 +1034,7 @@ class AgentRegistry:
         # not rewound) — only Reyn's own subscription is replayed.
         self._task_subscriptions.replay(
             self._state_log.iter_from(0),
-            is_active=lambda s: is_active_seq(self._state_log, s),
+            is_active=build_active_predicate(self._state_log),
         )
         # #2187 Stage 4: the recovery RE-READ seam — the binding is restored above; now
         # re-read the CURRENT backend task-state (the external master, not rewound).
@@ -1184,6 +1185,10 @@ class AgentRegistry:
         if not state_root.is_dir():
             return []
         rewoken: "list[str]" = []
+        # Hoisted once for the whole scan (not per run_dir) — same call-shape fix
+        # as restore_all's task-subscription replay: the seq-independent derivation
+        # otherwise re-scans the WAL once per pipeline run dir (#2941 sibling).
+        is_active = build_active_predicate(self._state_log)
         for run_dir in sorted(state_root.iterdir()):
             if not run_dir.is_dir() or has_result(run_dir):
                 continue
@@ -1194,8 +1199,8 @@ class AgentRegistry:
                     "— skipping (nothing to resume from)", run_dir,
                 )
                 continue
-            if work_order.spawn_seq is not None and not is_active_seq(
-                self._state_log, work_order.spawn_seq,
+            if work_order.spawn_seq is not None and not is_active(
+                work_order.spawn_seq,
             ):
                 # Provably rewound-away (abandoned WAL branch) — do not resurrect.
                 continue
@@ -1407,12 +1412,16 @@ class AgentRegistry:
 
         # Union of generation boundary seqs across every known agent. Default =
         # active branch only (1f); include_abandoned = all branches (Phase-2 tree).
+        # Hoisted once for the whole (names x seqs) scan — the same fix-class as
+        # restore_all/#2941: the seq-independent derivation must not re-scan the
+        # WAL per candidate seq.
+        is_active = build_active_predicate(self._state_log)
         seqs: set[int] = set()
         for name in self.list_names():
             for s in self._store_for(name).seqs():
                 if oldest_seq is not None and s < oldest_seq:
                     continue  # #2236: truncated out of WAL — not reachable
-                if include_abandoned or is_active_seq(self._state_log, s):
+                if include_abandoned or is_active(s):
                     seqs.add(s)
         if not seqs:
             return []
@@ -1739,12 +1748,20 @@ class AgentRegistry:
         recovery. Both production callers guarantee a rewind record exists (see
         comment at the ``drop_cut`` assignment above). Inert when no ``agent_archived``
         events exist (the #1954 file-only tombstone is left untouched)."""
+        # Hoisted once for the whole archived.items() scan (fix-class sibling of
+        # #2941/restore_all — the seq-independent derivation must not re-scan the
+        # WAL once per archived agent).
+        is_active = (
+            build_active_predicate(self._state_log)
+            if self._state_log is not None
+            else None
+        )
         for name, aseq in archived.items():
             target = self._dir / name
             if not target.is_dir():
                 continue
             marker = target / ARCHIVED_MARKER
-            if self._state_log is not None and is_active_seq(self._state_log, aseq):
+            if is_active is not None and is_active(aseq):
                 marker.write_text(str(aseq), encoding="utf-8")
             elif marker.is_file():
                 marker.unlink()
@@ -1786,10 +1803,18 @@ class AgentRegistry:
         #2405: ``is_active_seq`` replaces the former ``e[0] ≤ cut`` filter — same
         symmetric gap as vanish/archive: post-rewind active mutations (seq > R) were
         excluded, reverting topology state to as-of-N on crash recovery."""
+        # Hoisted once for the whole (names x lifecycle-events) scan — same
+        # fix-class sibling as above: one WAL scan for every topology name's
+        # events, not one scan per event.
+        is_active = (
+            build_active_predicate(self._state_log)
+            if self._state_log is not None
+            else None
+        )
         for name, evs in self._topology_lifecycle().items():
-            if self._state_log is not None:
+            if is_active is not None:
                 latest = max(
-                    (e for e in evs if is_active_seq(self._state_log, e[0])),
+                    (e for e in evs if is_active(e[0])),
                     key=lambda e: e[0], default=None,
                 )
             else:
@@ -1923,10 +1948,18 @@ class AgentRegistry:
         import yaml  # noqa: PLC0415 — local, matching the file convention
 
         store = self._config_generation_store()
+        # Hoisted once for the whole store.paths() scan — same fix-class sibling as
+        # above: `latest_active` takes the predicate directly so this loop doesn't
+        # re-derive (and re-scan the whole WAL for) `is_active_seq` once per rel_path.
+        is_active = (
+            build_active_predicate(self._state_log)
+            if self._state_log is not None
+            else None
+        )
         for rel_path in store.paths():
             latest = (
-                store.latest_active(rel_path, self._state_log)
-                if self._state_log is not None
+                store.latest_active(rel_path, is_active)
+                if is_active is not None
                 else store.latest_at_or_below(rel_path, cut)
             )
             abs_path = (self._project_root / ".reyn" / rel_path).resolve()
@@ -2145,15 +2178,23 @@ class AgentRegistry:
         # (rewind_to appends it at line 1091 before line 1095; recover_rewind_if_needed
         # gates on active_rewind_target is not None at line 2011 before line 2014).
         drop_cut = workspace_at_or_below
+        # Hoisted once for the whole materialise pass — the same fix-class as
+        # restore_all/#2941: the below loops call the seq-independent predicate once
+        # per (created-agent, agent, session) triple; without hoisting, each call
+        # re-scans the entire WAL (`is_active_seq` → `_rewind_records` →
+        # `iter_from(1)`), turning this cold-start/rewind path quadratic in WAL size.
+        is_active = (
+            build_active_predicate(self._state_log)
+            if self._state_log is not None
+            else None
+        )
         # #2103 S2 re-materialise: an agent on the ACTIVE branch, NOT purged, currently
         # ABSENT (dropped at a prior cut) → re-create from its agent_created record
         # so a forward-checkout-past-drop brings it back (the inverse of the drop).
         for _rname, (_rcseq, _rpayload, _rparent, _rpseq) in ag_created.items():
             if _rname in ag_purged:
                 continue  # fork A: purged = permanent, never re-materialised
-            _is_active = (
-                self._state_log is None or is_active_seq(self._state_log, _rcseq)
-            )
+            _is_active = is_active is None or is_active(_rcseq)
             if _is_active and not (self._dir / _rname).is_dir():
                 self._rematerialise_agent(_rname, _rpayload)
         for name in self.list_names():
@@ -2164,8 +2205,8 @@ class AgentRegistry:
             agent_seq = created_at.get(("agent", name, ""))
             _on_abandoned = (
                 agent_seq is not None
-                and self._state_log is not None
-                and not is_active_seq(self._state_log, agent_seq)
+                and is_active is not None
+                and not is_active(agent_seq)
             )
             if name in ag_purged or _on_abandoned:
                 self._drop_agent(name)
@@ -2181,13 +2222,13 @@ class AgentRegistry:
                 van_seq = sess_vanished.get((name, sid))
                 spawned_after_cut = (
                     sess_seq is not None
-                    and self._state_log is not None
-                    and not is_active_seq(self._state_log, sess_seq)
+                    and is_active is not None
+                    and not is_active(sess_seq)
                 )
                 vanished_by_cut = (
                     van_seq is not None
-                    and self._state_log is not None
-                    and is_active_seq(self._state_log, van_seq)
+                    and is_active is not None
+                    and is_active(van_seq)
                 )
                 if spawned_after_cut or vanished_by_cut:
                     # #2125/#2180: detach now (quiesce in-flight writes; the global Task

--- a/tests/test_restore_all_subscription_scan_bound_2944.py
+++ b/tests/test_restore_all_subscription_scan_bound_2944.py
@@ -1,0 +1,122 @@
+"""Tier 2: #2944 — ``AgentRegistry.restore_all``'s task-subscription replay must not
+re-scan the WAL once PER WAL ENTRY (the O(WAL²) cold-start sibling of #2941/#2938).
+
+Root cause: ``restore_all`` called ``self._task_subscriptions.replay(..., is_active=
+lambda s: is_active_seq(self._state_log, s))``. ``SubscriptionRegistry.replay`` calls
+``is_active(seq)`` once PER WAL ENTRY it iterates; each call re-derives
+``_abandoned_intervals(_rewind_records(state_log))`` from scratch, and
+``_rewind_records`` does a FULL ``state_log.iter_from(1)`` scan (json-decoding every
+WAL line). So an M-entry WAL did O(M²) json.loads work on EVERY cold start (before
+the input box appears) — measured 250->0.130s, 500->0.503s, 1000->1.991s,
+2000->8.057s (quadratic growth). The fix (``build_active_predicate``, added by #2938
+for the sibling turn-loop bug) hoists the seq-independent abandoned-interval
+derivation OUT of the per-entry loop: one ``iter_from`` scan for the whole replay,
+reused for every entry (O(M) instead of O(M^2)).
+
+Real seam: real ``AgentRegistry`` + real ``StateLog`` + the real ``checkout`` reset-
+record primitive, with a ``StateLog`` subclass counting ``iter_from`` calls (a
+public-method override, not a private-state peek) to assert the SCAN COUNT bound
+directly — mirrors ``tests/test_active_branch_history_scan_bound_2941.py``.
+
+This test must FLIP RED if the per-entry ``is_active_seq`` scan is restored: locally
+reverting the ``restore_all`` hoist to
+``is_active=lambda s: is_active_seq(self._state_log, s)`` makes the WAL-scan count
+grow with WAL size instead of staying bounded (confirmed during development — see the
+PR body for the strip-falsification record).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import checkout
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+
+
+class _CountingStateLog(StateLog):
+    """A real ``StateLog`` that counts ``iter_from`` calls — a public-method
+    override, not a private-state assertion, so the scan-count bound is verified
+    through the same seam production code calls."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.iter_from_calls = 0
+
+    def iter_from(self, min_seq: int):
+        self.iter_from_calls += 1
+        return super().iter_from(min_seq)
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called in these tests")
+
+
+def _make_registry(tmp_path: Path, state_log: StateLog) -> AgentRegistry:
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=_no_factory, state_log=state_log,
+    )
+
+
+async def _seed_wal(state_log: StateLog, n: int) -> "list[int]":
+    seqs = []
+    for i in range(n):
+        seqs.append(await state_log.append("step_completed", i=i))
+    return seqs
+
+
+@pytest.mark.asyncio
+async def test_restore_all_scan_count_independent_of_wal_size(tmp_path, monkeypatch):
+    """Tier 2: restore_all's WAL-scan count does NOT grow when the WAL grows — the
+    O(1) vs O(M) discriminator. A smaller WAL and a much larger WAL (both with a
+    rewind, so the abandoned-interval predicate is non-trivial) cost the SAME number
+    of ``iter_from`` calls."""
+    monkeypatch.chdir(tmp_path)
+
+    small_log = _CountingStateLog(tmp_path / "small" / ".reyn" / "wal.jsonl")
+    seqs = await _seed_wal(small_log, 30)
+    await checkout(small_log, target_seq=seqs[5])
+    small_reg = _make_registry(tmp_path / "small", small_log)
+    small_log.iter_from_calls = 0
+    await small_reg.restore_all()
+    small_count = small_log.iter_from_calls
+
+    large_log = _CountingStateLog(tmp_path / "large" / ".reyn" / "wal.jsonl")
+    seqs = await _seed_wal(large_log, 600)
+    await checkout(large_log, target_seq=seqs[5])
+    large_reg = _make_registry(tmp_path / "large", large_log)
+    large_log.iter_from_calls = 0
+    await large_reg.restore_all()
+    large_count = large_log.iter_from_calls
+
+    assert small_count > 0, "sanity: restore_all does scan the WAL at all"
+    assert small_count == large_count, (
+        f"restore_all's iter_from() call count must be independent of WAL size "
+        f"(30-entry WAL: {small_count} calls, 600-entry WAL: {large_count} calls) — "
+        "a per-entry is_active_seq re-scan (the #2944 O(WAL^2) cold-start bug) would "
+        "make large_count grow proportionally with entry count, not stay equal"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restore_all_scan_count_bounded_not_proportional_to_wal_entries(
+    tmp_path, monkeypatch,
+):
+    """Tier 2: the actual bug — restore_all's WAL-scan count stays BOUNDED (a small
+    constant), not proportional to the number of WAL entries replayed."""
+    monkeypatch.chdir(tmp_path)
+    state_log = _CountingStateLog(tmp_path / ".reyn" / "wal.jsonl")
+    n = 200
+    seqs = await _seed_wal(state_log, n)
+    await checkout(state_log, target_seq=seqs[10])  # non-trivial abandoned interval
+    reg = _make_registry(tmp_path, state_log)
+
+    state_log.iter_from_calls = 0
+    await reg.restore_all()
+
+    assert state_log.iter_from_calls < 20, (
+        f"expected a small, WAL-size-independent number of iter_from() calls "
+        f"(got {state_log.iter_from_calls} for a {n}-entry WAL) — a per-entry "
+        "is_active_seq scan (the #2944 bug) would scale with n, not stay bounded"
+    )

--- a/tests/test_subscription_replay_hoist_equivalence_2944.py
+++ b/tests/test_subscription_replay_hoist_equivalence_2944.py
@@ -1,0 +1,118 @@
+"""Tier 2: #2944 — the hoisted ``is_active`` predicate wired into
+``AgentRegistry.restore_all``'s ``SubscriptionRegistry.replay`` call must produce
+IDENTICAL restored bindings to the pre-hoist per-seq ``is_active_seq`` call shape,
+across the rewind scenarios ADR-0038 Stage 1b-1e define: no rewind, one rewind,
+nested/subsuming rewinds, and a checkout-back resurrection.
+
+``build_active_predicate`` is already proven pointwise-equivalent to ``is_active_seq``
+(``tests/test_build_active_predicate_equivalence_2941.py``); this test verifies the
+WIRING at the actual #2944 call site — ``SubscriptionRegistry.replay`` — produces the
+same live task→binding map under both call shapes, using real WAL
+``task_subscribed``/``task_rebound`` entries (no mocks).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.snapshot_generations import build_active_predicate, is_active_seq
+from reyn.core.events.state_log import StateLog
+from reyn.task.subscription import SubscriptionRegistry
+
+
+def _snapshot(reg: SubscriptionRegistry) -> "dict[str, tuple[str | None, str | None, str]]":
+    """Public-surface read of every binding (no private-state peek — ``exists`` /
+    ``assignee_of`` / ``requester_of`` / ``requester_kind_of`` are all public)."""
+    return {
+        tid: (
+            reg.assignee_of(tid), reg.requester_of(tid), reg.requester_kind_of(tid),
+        )
+        for tid in reg.task_ids()
+    }
+
+
+def _replay_both_ways(state_log: StateLog) -> None:
+    """Replay via the OLD per-seq call shape and the NEW hoisted-predicate call
+    shape into two fresh registries; assert their restored bindings match exactly."""
+    old_way = SubscriptionRegistry()
+    old_way.replay(
+        state_log.iter_from(0), is_active=lambda s: is_active_seq(state_log, s),
+    )
+    new_way = SubscriptionRegistry()
+    new_way.replay(
+        state_log.iter_from(0), is_active=build_active_predicate(state_log),
+    )
+    assert _snapshot(old_way) == _snapshot(new_way), (
+        "hoisted build_active_predicate wiring diverges from the per-seq "
+        "is_active_seq call shape it replaced"
+    )
+
+
+async def _sub(log: StateLog, task_id: str, assignee: str) -> int:
+    return await log.append(
+        "task_subscribed", task_id=task_id, assignee=assignee,
+        requester="alice", requester_kind="session",
+    )
+
+
+async def _rebind(log: StateLog, task_id: str, assignee: "str | None") -> int:
+    return await log.append("task_rebound", task_id=task_id, assignee=assignee)
+
+
+@pytest.mark.asyncio
+async def test_equivalence_no_rewind(tmp_path: Path) -> None:
+    """Tier 2: with no rewind, every subscription is active under both call shapes."""
+    log = StateLog(tmp_path / "state.wal")
+    await _sub(log, "t1", "alice")
+    await _sub(log, "t2", "bob")
+    await _rebind(log, "t1", "carol")
+    _replay_both_ways(log)
+
+
+@pytest.mark.asyncio
+async def test_equivalence_one_rewind(tmp_path: Path) -> None:
+    """Tier 2: one rewind abandons a binding — the abandoned interval must be
+    hidden identically under both call shapes."""
+    from reyn.core.events.snapshot_generations import checkout
+
+    log = StateLog(tmp_path / "state.wal")
+    await _sub(log, "t1", "alice")
+    target = await _sub(log, "t2", "bob")          # rewind target
+    await _rebind(log, "t2", "carol")               # abandoned by the rewind below
+    await _sub(log, "t3", "dave")                    # abandoned too
+    await checkout(log, target_seq=target)
+    _replay_both_ways(log)
+
+
+@pytest.mark.asyncio
+async def test_equivalence_nested_subsuming_rewinds(tmp_path: Path) -> None:
+    """Tier 2: a rewind, then more turns, then a rewind that subsumes the first —
+    equivalence holds through the composition."""
+    from reyn.core.events.snapshot_generations import checkout
+
+    log = StateLog(tmp_path / "state.wal")
+    await _sub(log, "t1", "alice")
+    inner_target = await _sub(log, "t2", "bob")
+    await _sub(log, "t3", "carol")
+    await checkout(log, target_seq=inner_target)     # abandon t3's create (small tail)
+    outer_target = await _sub(log, "t4", "dave")
+    await _sub(log, "t5", "eve")
+    await checkout(log, target_seq=outer_target)     # subsumes the first rewind entirely
+    _replay_both_ways(log)
+
+
+@pytest.mark.asyncio
+async def test_equivalence_checkout_back_resurrection(tmp_path: Path) -> None:
+    """Tier 2: rewind, branch forward, then checkout BACK to the old (now-abandoned)
+    tip — resurrects it. Equivalence holds across the resurrection."""
+    from reyn.core.events.snapshot_generations import checkout
+
+    log = StateLog(tmp_path / "state.wal")
+    await _sub(log, "t1", "alice")
+    rewind_point = await _sub(log, "t2", "bob")
+    tip = await _sub(log, "t3", "carol")              # abandoned by the rewind below
+    await checkout(log, target_seq=rewind_point)      # rewind: abandons t3
+    await _sub(log, "t4", "dave")                     # new branch forward
+    await checkout(log, target_seq=tip)               # checkout back: resurrects t3
+    _replay_both_ways(log)


### PR DESCRIPTION
**[per-PR-coder]** — the surviving O(WAL²) sibling of the #2937/#2938/#2941 chat-freeze arc, on the **cold-start** path this time.

## The defect — O(M²) before the input box appears

`AgentRegistry.restore_all` rebuilt the task-subscription registry with a **per-seq** predicate:

```python
self._task_subscriptions.replay(
    self._state_log.iter_from(0),
    is_active=lambda s: is_active_seq(self._state_log, s),   # ← called once PER WAL ENTRY
)
```

`SubscriptionRegistry.replay` (`src/reyn/task/subscription.py:87-94`) calls `is_active(seq)` once per WAL entry it iterates. Each call → `is_active_seq` → `_abandoned_intervals(_rewind_records(state_log))` → `for e in state_log.iter_from(1)` = **a full WAL re-read + `json.loads` of every line**. M entries ⇒ M full scans ⇒ **O(M²)** — on the path that runs *before* the input box appears.

**Measured growth curve** (synthetic WAL reproducing the exact call shape):

| WAL entries | time | vs. previous |
|---|---|---|
| 250 | 0.130s | — |
| 500 | 0.503s | 3.9× |
| 1000 | 1.991s | 4.0× |
| 2000 | **8.057s** | 4.0× |

8× entries → 62× time (8² = 64) = textbook quadratic. Extrapolates to **~2 min of startup stall at ~8k entries**. This repo's own WAL is 14 lines, which is exactly why it is invisible locally — it is not verifiable by timing this repo.

## The fix — the primitive already existed

`#2938` added **`build_active_predicate(state_log)`** for precisely this call shape: the `_abandoned_intervals(_rewind_records(...))` derivation depends **only** on the state_log's rewind records, never on `seq`, so it hoists out and the returned predicate is reused. #2938 applied it to the hot turn-loop caller (`Session._active_branch_history`) but **did not sweep the siblings** — that is what this PR fixes.

Semantics are identical: this is a **call-shape optimization**, not a behavior change (`build_active_predicate` ≡ `is_active_seq` pointwise, already proven by `tests/test_build_active_predicate_equivalence_2941.py`, and re-proven at this PR's call site below).

## Fix-class completeness sweep — every site enumerated

Sites found by grepping the fix class across the **whole repo** (`grep -rn "is_active_seq" src/ tests/` — inclusive pattern, no `grep -v` exclusion filter), not from the briefed line-number list.

**A note on the briefed list:** the brief pointed at `snapshot_generations.py:262 / 277 / 312 / 369 / 402`. Grep shows those are **not** `is_active_seq` callers — they are *internal* `_abandoned_intervals(_rewind_records(...))` calls inside `snapshot_generations.py` itself (`branch_ids_for`, `list_branches`, `lineage_predecessor`, `rewind`, `reconstruct`). Each already does **one** derivation per call and then applies the resulting interval list many times via `_branch_of_seq` / `_make_is_active` — i.e. they are *already* the hoisted shape and need no change. The real per-seq-in-a-loop callers live in `registry.py` and `config_generations.py`. Grep was the authority; the list was a hint. Full enumeration:

### HOISTED (per-seq call inside a loop/comprehension over many seqs)

| # | Site | Loop shape | Disposition |
|---|---|---|---|
| 1 | `registry.py::restore_all` — subscription replay | **once per WAL entry** (the reported defect) | ✅ hoisted — `is_active=build_active_predicate(self._state_log)` |
| 2 | `registry.py::_rewake_pipeline_runs` | once per pipeline run dir | ✅ hoisted above the `for run_dir` loop |
| 3 | `registry.py::list_rewind_points` | once per (agent × generation seq) | ✅ hoisted above the nested loop |
| 4 | `registry.py::_reconcile_archived_as_of_cut` | once per archived agent | ✅ hoisted above `archived.items()` |
| 5 | `registry.py::_reconcile_topologies_as_of_cut` | once per (topology × lifecycle event) | ✅ hoisted above the nested loop |
| 6 | `registry.py::_reconcile_config_as_of_cut` → `ConfigGenerationStore.latest_active` | once per (rel_path × generation seq) | ✅ hoisted; **`latest_active` signature changed** to take the predicate directly (see below) |
| 7 | `registry.py::_materialize_rewind` — 4 inner checks (`ag_created` re-materialise, `agent_seq` abandoned, `sess_seq` spawned-after-cut, `van_seq` vanished-by-cut) | once per (created-agent, agent, session) | ✅ **one** predicate hoisted to the top of the method, reused by all four |
| 8 | `pipeline_recovery.py::PipelineStateStore.latest_active` (via `latest_pipeline_state`) | once per generation seq of a run | ✅ **signature symmetrized** to take the predicate (see below) — `latest_pipeline_state` hoists `build_active_predicate` once. Initially deferred; **corrected on architect review** (rationale below). |

### LEFT AS-IS (legitimately one-shot — single seq, no loop)

| # | Site | Why the per-seq form is correct |
|---|---|---|
| 8 | `registry.py::rewind_to` (`is_active_seq(self._state_log, target_n)`) | **one-shot**: validates exactly ONE user-supplied target seq. Building a predicate to call it once is strictly equivalent work (one WAL scan either way) with no benefit. This is also why the `is_active_seq` import stays in `registry.py`. |

*(After the site-8 symmetrization there is exactly **one** deferral. Remaining `is_active_seq` grep hits across `src/` are docstring/comment references only — no call sites. Test-file hits are assertions against `is_active_seq` itself, which is unchanged, so they are untouched and green.)*

### Structural fix — both `latest_active` stores now take the predicate (sites 6 + 8)

`ConfigGenerationStore.latest_active(rel_path, state_log)` → `latest_active(rel_path, is_active)`, and `PipelineStateStore.latest_active(state_log)` → `latest_active(is_active)`.

Taking a `state_log` **forced** each store to call `is_active_seq` internally, so any caller that loops was quadratic **by construction** — a shape no caller-side hoist could fix. Taking the predicate makes the hoist the caller's obligation (documented at both sites), so the fix-class cannot silently regrow at either seam.

**Correction on architect review — the pipeline store was initially deferred, and that was wrong.** My deferral rested on a **caller census** ("one run per caller today"), not on structure. But census-based safety is precisely what failed for the config store: it was census-safe until `_reconcile_config_as_of_cut` (`registry.py:1961`) grew a rel_path loop, and the defect appeared. The API shape — not the current caller set — is what has to forbid the defect, which is the whole reason I changed the config store's signature in the first place. Leaving a self-described "mirror" asymmetric would have been the path to a **4th recurrence** of a class that has now recurred three times (#2937 → #2938 → #2948). It was also **not free today**: `_seqs()` grows with a run's generation count, so each resume was O(N_run_generations × M_WAL) — not a startup killer, but the same shape.

With both stores symmetric, "mirrors `ConfigGenerationStore.latest_active` exactly" is **true again**, so the docstrings state it plainly rather than carrying an except-signature clause. (The earlier doc-only commit `b73929cf` recorded the drift; `73e24f60` removes it.)

**Blast radius**: `latest_pipeline_state`'s own signature is **unchanged**, so both production callers (`executor.py:1587`, `pipeline_executor_driver.py:202`) and all 7 test callers are untouched. The store's only caller is that wrapper, and `PipelineStateStore` has no other construction site (verified by grep: `\.latest_active(`, `latest_pipeline_state(`, `PipelineStateStore(`). No `is_active_seq` call site remains in `pipeline_recovery.py`.

## `is_active_seq` byte-unchanged — confirmed

Per the brief, `is_active_seq` has many crash-recovery callers (`pipeline_recovery.py`, `config_generations.py`, `registry.py`) and was **not** touched. `snapshot_generations.py` is **entirely absent from this diff**:

```
$ git diff origin/main -- src/reyn/core/events/snapshot_generations.py | wc -l
0
```

So `is_active_seq` is byte-unchanged **by construction**, not merely by inspection. This PR is an ADD (`build_active_predicate` import) + call-shape change only.

## Tests

### 1. Scan-count bound — the actual bug (`tests/test_restore_all_subscription_scan_bound_2944.py`, Tier 2)

A real `StateLog` **subclass** counting `iter_from` calls (a **public-method override**, not a private-state peek — mirrors `tests/test_active_branch_history_scan_bound_2941.py`). Real `AgentRegistry` + real `StateLog` + the real `checkout` primitive; no mocks.

- `test_restore_all_scan_count_independent_of_wal_size` — 30-entry vs 600-entry WAL (both with a rewind, so the abandoned-interval predicate is non-trivial) must cost the **same** number of `iter_from` calls.
- `test_restore_all_scan_count_bounded_not_proportional_to_wal_entries` — a 200-entry WAL's `restore_all` must stay under a small constant of scans.

**Strip-falsification result** (reverted the hoist locally to `is_active=lambda s: is_active_seq(self._state_log, s)`, re-ran, restored):

| | 30-entry WAL | 600-entry WAL | verdict |
|---|---|---|---|
| **pre-hoist** (per-seq `is_active_seq`) | **44** scans | **614** scans | 🔴 RED — `assert 44 == 614` |
| **post-hoist** (`build_active_predicate`) | equal | equal | 🟢 GREEN — bounded |

The call count tracks WAL size 1:1 (600 entries → 614 scans), which is the O(M) scan-count signature that makes the total work O(M²). **Both** tests flipped RED on the revert and GREEN on restore.

### 2. Equivalence (`tests/test_subscription_replay_hoist_equivalence_2944.py`, Tier 2)

Restored bindings must be **identical** under the old per-seq call shape and the new hoisted one, at the real `SubscriptionRegistry.replay` call site, with real WAL `task_subscribed`/`task_rebound` entries and the real `checkout` primitive — no mocks. Read through the **public surface** (`task_ids` / `assignee_of` / `requester_of` / `requester_kind_of`) — no private-state asserts. Scenarios: **no rewind**, **one rewind**, **nested-subsuming**, **checkout-back resurrection**.

(Pointwise `build_active_predicate ≡ is_active_seq` equivalence is already covered by #2941's `test_build_active_predicate_equivalence_2941.py`; this test covers the **wiring** at this PR's call site.)

### 3. Existing suites stay green

Full `pytest` from the repo root: **8520 passed, 20 skipped, 0 failed** — including every rewind/registry/recovery suite (`test_registry_rewind_to`, `test_config_rewind_reconcile_2405`, `test_topology_rewind_2103_piece2`, `test_agent_lifecycle_rewind_2103_s2`, `test_session_vanished_emit_2154`, `test_registry_list_rewind_points_1f`, `test_conversation_rewind_2360`, the `test_2259_*` truncation suites, `test_multi_session_restore`).

## Recovery gate (CLAUDE.md truncate-falsify) — reasoning, not omission

**N/A**, with the reasoning stated explicitly rather than omitted:

The CLAUDE.md gate binds any PR "adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths)" — the hazard it guards is *WAL-event-derived recovery state that isn't snapshot-backed*. This PR adds **no** recovery functionality and **no persisted state**: it is a pure call-shape optimization over an existing derivation. The reconstruction **source** is unchanged (the same `_rewind_records(state_log)` scan over the same reset-records), the **derivation** is unchanged (the same `_abandoned_intervals`), and `is_active_seq` is byte-unchanged (0-line diff, above). Truncation behavior is therefore bit-identical to `origin/main`: the reset-record's truncation-survival is already pinned by `test_conversation_rewind_2360.py` (`always_keep_kinds` protects `rewind` records so `is_active_seq` can still classify post-truncation), and this PR neither strengthens nor weakens that. Same class as **#2938**, where the architect confirmed N/A on identical grounds.

**Falsification of the N/A claim:** if this PR *did* change what survives truncation, the equivalence tests above (which exercise nested/subsuming/checkout-back reconstruction against a real `StateLog`) would have to diverge between the two call shapes. They do not.

## CI gates (all run locally, **foreground**, green)

- ✅ `ruff check src tests` — All checks passed
- ✅ `python scripts/test_tier_audit.py --strict tests/test_restore_all_subscription_scan_bound_2944.py tests/test_subscription_replay_hoist_equivalence_2944.py` — 6 inspected, 0 warnings, 0 Tier-4 errors
- ✅ `pytest` from repo root — 8520 passed, 20 skipped (re-run foreground after the symmetrization: 231s)
- ✅ `python scripts/verify_module_docstrings.py src/reyn/core/events/pipeline_recovery.py src/reyn/runtime/registry.py src/reyn/core/events/config_generations.py` — OK

## Test plan

- [x] Strip-falsify the scan-bound test (revert hoist → RED at 44 vs 614 scans; restore → GREEN) — done, numbers reported above
- [x] Full-repo grep sweep for the `is_active_seq`-per-seq fix class; every site enumerated with disposition — done, tables above (**8 hoisted/symmetrized, 1 left one-shot**; the pipeline-store deferral was corrected on architect review)
- [x] Confirm `is_active_seq` byte-unchanged (`git diff` on `snapshot_generations.py` = 0 lines) — done
- [x] All four CI gates run locally in the foreground — done, green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

