### PR TITLE
feat: track embedding cost as an independent per-scope aggregate (FP-0063 PC)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -801,7 +801,9 @@ Fields:
 - `texts` (list[str], required) — texts to embed. Returned vectors preserve this order.
 - `embedding_model` (str, default `"standard"`) — model class (light/standard/strong) or a literal provider model id, forwarded to `EmbeddingProvider.embed`.
 
-Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str, "total_tokens": int}`.
+Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str, "total_tokens": int, "cost_usd": float | None, "priced": bool}`.
+
+`cost_usd` / `priced` (FP-0063 PC): the call's cost, priced via `estimate_embedding_cost` (extends the same `litellm.model_cost` lookup `pricing.py` already used for chat completions to embedding-mode entries — not a new rate table). `priced=False` + `cost_usd=None` when litellm cannot price `model` — an unpriced/unknown model degrades VISIBLY (never a silent `$0.00`, mirroring the pre-existing `estimate_cost` unknown-model sentinel, #1829). This spend is recorded into an INDEPENDENT embedding-cost aggregate (`EmbeddingCost` in `llm/pricing.py`) at session scope (`ctx.budget_gateway`, when wired) and agent/project scope (`ctx.budget_tracker`, when wired) — deliberately **not** folded into the chat `CostBreakdown` (embedding is input-only / structurally uncacheable; doing so would dilute `cache_hit_rate` / `cache_savings`, which are chat-call-only figures). See `Registry.agent_embedding_cost` / `.project_embedding_cost` and `BudgetGateway.embedding_cost` for the per-scope readers.
 
 Reuses the existing `EmbeddingProvider` (`RoutingEmbeddingProvider` via `get_provider` — the sole embedder, local sentence-transformers + API classes handled inside the provider); this op is a thin typed envelope, not a re-implementation. Batching (`embedding.batch_size`, default 100) happens inside the provider — the op contract itself is list-in/list-out, batch-granular.
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -501,11 +501,15 @@ def chunks_to_canonical(result: dict) -> CanonicalToolResult:
 def embed_to_canonical(result: dict) -> CanonicalToolResult:
     """embed op result → canonical (FP-0057 Phase 1). ``vectors`` are large float arrays with no
     natural text body — carried as a ``structured`` attachment (mirrors ``chunks_to_canonical`` for
-    the RAG op family). ``model`` / ``total_tokens`` are small high-signal meta the LLM reads inline;
-    the raw ``kind`` transport echo is dropped."""
+    the RAG op family). ``model`` / ``total_tokens`` / ``cost_usd`` / ``priced`` (FP-0063 PC: the
+    independent embedding-cost figures, added alongside the pre-existing usage fields — NOT folded
+    into the chat ``CostBreakdown``) are small high-signal meta the LLM (and a future ingest
+    pipeline's ``fold`` step, X2a/X2c) reads inline; the raw ``kind`` transport echo is dropped."""
     vectors = result.get("vectors")
     attachments = [{"kind": "structured", "data": vectors}] if vectors is not None else []
-    meta = {k: result[k] for k in ("model", "total_tokens") if k in result}
+    meta = {
+        k: result[k] for k in ("model", "total_tokens", "cost_usd", "priced") if k in result
+    }
     return CanonicalToolResult(text="", attachments=attachments, source_ref=None, meta=meta)
 
 

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -119,16 +119,25 @@ class OpContext:
     # (control_ir_executor / router_host_adapter); None = unrecorded.
     budget_tracker: object | None = None
 
-    # FP-0063 PC: the calling Session's per-session BudgetGateway, for the
-    # `embed` op to record its INDEPENDENT session-scope embedding-cost
-    # aggregate (``BudgetGateway.record_embedding`` / ``.embedding_cost``) —
-    # the third of the session/agent/project scope trio (agent scope reads
-    # ``budget_tracker`` above; project scope sums agent scope in the
-    # Registry). Threaded by ``build_router_op_context`` for the Session host
-    # (``Session._make_router_op_context``). None = session-scope embedding
-    # cost is not recorded for this op call (e.g. RouterHostAdapter's
-    # registry-dispatch path, direct/test construction) — agent/project scope
-    # via ``budget_tracker`` is unaffected.
+    # FP-0063 PC: the calling Session's per-session BudgetGateway — the `embed`
+    # op's SINGLE embedding-cost recording entry point
+    # (``BudgetGateway.record_embedding``). It fans out to all three scopes:
+    # session (itself, read via ``.embedding_cost``) and agent/project (the
+    # process-shared BudgetTracker it holds, read via
+    # ``Registry.agent_embedding_cost`` / ``.project_embedding_cost``).
+    #
+    # Deliberately NOT ``budget_tracker`` above: the tracker keys per-agent
+    # counters by agent NAME, which an op handler cannot supply — ``agent_id``
+    # is the FP-0016 HOST identity (``reyn/<hostname>``), a different value, so
+    # recording from here would file spend under a key no per-scope reader
+    # looks up. The gateway is the only object holding both the tracker and the
+    # agent name, so the fan-out lives there.
+    #
+    # Threaded by ``build_router_op_context`` (both router op-ctx builders).
+    # The load-bearing one for `embed` is RouterHostAdapter's — that is the
+    # factory the router-dispatched embed TOOL resolves. None (direct/test
+    # construction) = the call is priced into the returned metadata but not
+    # recorded into any aggregate.
     budget_gateway: object | None = None
 
     # PR20: caller provenance threaded from the parent Agent so sub-run

--- a/src/reyn/core/op_runtime/context.py
+++ b/src/reyn/core/op_runtime/context.py
@@ -119,6 +119,18 @@ class OpContext:
     # (control_ir_executor / router_host_adapter); None = unrecorded.
     budget_tracker: object | None = None
 
+    # FP-0063 PC: the calling Session's per-session BudgetGateway, for the
+    # `embed` op to record its INDEPENDENT session-scope embedding-cost
+    # aggregate (``BudgetGateway.record_embedding`` / ``.embedding_cost``) —
+    # the third of the session/agent/project scope trio (agent scope reads
+    # ``budget_tracker`` above; project scope sums agent scope in the
+    # Registry). Threaded by ``build_router_op_context`` for the Session host
+    # (``Session._make_router_op_context``). None = session-scope embedding
+    # cost is not recorded for this op call (e.g. RouterHostAdapter's
+    # registry-dispatch path, direct/test construction) — agent/project scope
+    # via ``budget_tracker`` is unaffected.
+    budget_gateway: object | None = None
+
     # PR20: caller provenance threaded from the parent Agent so sub-run
     # invocations land under the same `events/<caller>/...` tree.
     # Format: "direct" or "agents/<name>" (validated in Agent).

--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -85,11 +85,13 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
          `ActionEmbeddingIndex`) routes through this op (inheriting the
          redaction seam above) while keeping its download-status rows.
       3. FP-0063 PC: price this call (`estimate_embedding_cost`, its OWN
-         model's rate — X6 mixed-model correctness) and record it into the
-         INDEPENDENT embedding-cost aggregate at every scope reachable from
-         `ctx` — agent/project scope via `ctx.budget_tracker`
-         (`BudgetTracker.record_embedding`), session scope via
-         `ctx.budget_gateway` (`BudgetGateway.record_embedding`). Neither
+         model's rate — X6 mixed-model correctness) for the returned metadata,
+         and record it into the INDEPENDENT embedding-cost aggregate via
+         `ctx.budget_gateway.record_embedding` — the single recording entry
+         point, which fans out to session scope (itself) and agent/project
+         scope (the process-shared tracker it holds, keyed by the session's
+         agent NAME — the key the per-scope readers use; `ctx.agent_id` is the
+         FP-0016 host identity and would be the wrong key). None of this
          touches the chat `CostBreakdown` (owner: "embedding は独立追跡の想定").
 
     Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str,
@@ -127,9 +129,6 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
     from reyn.llm.pricing import estimate_embedding_cost
     cost_usd, _pricing_snapshot = estimate_embedding_cost(model_used, total_tokens)
 
-    tracker = getattr(ctx, "budget_tracker", None)
-    if tracker is not None:
-        tracker.record_embedding(model=model_used, agent=ctx.agent_id, tokens=total_tokens)
     gateway = getattr(ctx, "budget_gateway", None)
     if gateway is not None:
         gateway.record_embedding(model=model_used, tokens=total_tokens)

--- a/src/reyn/core/op_runtime/embed.py
+++ b/src/reyn/core/op_runtime/embed.py
@@ -84,14 +84,28 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
          holding its own provider instance, so a tool-use caller (e.g.
          `ActionEmbeddingIndex`) routes through this op (inheriting the
          redaction seam above) while keeping its download-status rows.
+      3. FP-0063 PC: price this call (`estimate_embedding_cost`, its OWN
+         model's rate — X6 mixed-model correctness) and record it into the
+         INDEPENDENT embedding-cost aggregate at every scope reachable from
+         `ctx` — agent/project scope via `ctx.budget_tracker`
+         (`BudgetTracker.record_embedding`), session scope via
+         `ctx.budget_gateway` (`BudgetGateway.record_embedding`). Neither
+         touches the chat `CostBreakdown` (owner: "embedding は独立追跡の想定").
 
     Returns: `{"kind": "embed", "vectors": list[list[float]], "model": str,
-    "total_tokens": int}`. Errors propagate to the shared `execute_op`
-    try/except (status="error" + `control_ir_failed` event) — this handler
-    does not swallow provider failures.
+    "total_tokens": int, "cost_usd": float | None, "priced": bool}`.
+    `cost_usd` is `None` (with `priced=False`) when litellm cannot price
+    `model` — an unpriced/unknown model must degrade VISIBLY, never silently
+    read as $0.00 (#1829 sentinel, extended to embedding mode). Errors
+    propagate to the shared `execute_op` try/except (status="error" +
+    `control_ir_failed` event) — this handler does not swallow provider
+    failures.
     """
     if not op.texts:
-        return {"kind": "embed", "vectors": [], "model": op.embedding_model, "total_tokens": 0}
+        return {
+            "kind": "embed", "vectors": [], "model": op.embedding_model,
+            "total_tokens": 0, "cost_usd": 0.0, "priced": True,
+        }
 
     # ── PRE-embed egress seam (co-vet #3) — unconditional, unbypassable ────
     scanned_texts = [redact_secrets(t) for t in op.texts]
@@ -106,11 +120,27 @@ async def handle(op: EmbedIROp, ctx: OpContext) -> dict:
     provider = _resolve_provider(event_sink=ctx.embedding_event_sink)
     result = await provider.embed(scanned_texts, op.embedding_model)
 
+    model_used = result.get("model", op.embedding_model)
+    total_tokens = result.get("total_tokens", 0)
+
+    # ── FP-0063 PC: independent embedding-cost tracking (X2b/X4/X2c) ───────
+    from reyn.llm.pricing import estimate_embedding_cost
+    cost_usd, _pricing_snapshot = estimate_embedding_cost(model_used, total_tokens)
+
+    tracker = getattr(ctx, "budget_tracker", None)
+    if tracker is not None:
+        tracker.record_embedding(model=model_used, agent=ctx.agent_id, tokens=total_tokens)
+    gateway = getattr(ctx, "budget_gateway", None)
+    if gateway is not None:
+        gateway.record_embedding(model=model_used, tokens=total_tokens)
+
     return {
         "kind": "embed",
         "vectors": result.get("vectors", []),
-        "model": result.get("model", op.embedding_model),
-        "total_tokens": result.get("total_tokens", 0),
+        "model": model_used,
+        "total_tokens": total_tokens,
+        "cost_usd": cost_usd,
+        "priced": cost_usd is not None,
     }
 
 

--- a/src/reyn/llm/pricing.py
+++ b/src/reyn/llm/pricing.py
@@ -338,3 +338,115 @@ def estimate_cost_breakdown(
         )
     except Exception:
         return None
+
+
+# ── FP-0063 PC: embedding cost (INDEPENDENT of the chat CostBreakdown above) ──
+
+
+def estimate_embedding_cost(
+    model: str,
+    total_tokens: int,
+) -> tuple[float | None, dict | None]:
+    """Estimate one embedding call's cost in USD, extending the SAME
+    ``litellm.model_cost`` lookup ``estimate_cost``/``estimate_cost_breakdown``
+    use above to embedding-mode entries (~124 observed in the vendored litellm
+    at proposal time, e.g. ``amazon.titan-embed-text-v2:0``) — not a new /
+    parallel rate table (FP-0063 X4).
+
+    An embedding call is INPUT-ONLY: there is no completion, no cache read/
+    write, so this prices ``total_tokens`` directly at the model's
+    ``input_cost_per_token`` rate rather than going through
+    ``litellm.cost_per_token``'s completion/cache-aware usage-object plumbing
+    (which ``estimate_cost`` needs and this does not). Embedding-mode entries
+    carry ``output_cost_per_token: 0.0`` (never ``None``, verified empirically
+    against the installed litellm's ``model_cost`` table), so only
+    ``input_cost_per_token`` is required to price a call.
+
+    Returns ``(cost_usd, pricing_snapshot)``. Mirrors ``estimate_cost``'s
+    unknown-model sentinel: an unpriced/unknown model returns ``(None, None)``
+    — unknown != free (#1829) — so a model litellm cannot price degrades
+    VISIBLY (the caller can detect "not priced" and surface it) rather than
+    silently reading as ``$0.00``, which would recreate the exact invisibility
+    bug this feature exists to close.
+    """
+    if total_tokens <= 0:
+        return 0.0, None
+
+    try:
+        import litellm
+
+        entry = litellm.model_cost.get(model)
+        if not entry or entry.get("input_cost_per_token") is None:
+            return None, None
+
+        input_rate = float(entry["input_cost_per_token"])
+        cost_usd = total_tokens * input_rate
+
+        try:
+            from importlib.metadata import version as _pkg_version
+            litellm_version = _pkg_version("litellm")
+        except Exception:
+            litellm_version = "unknown"
+
+        snapshot = {
+            "model": model,
+            "input_per_1m_usd": round(input_rate * 1_000_000, 6),
+            "source": "litellm",
+            "litellm_version": litellm_version,
+        }
+        return cost_usd, snapshot
+    except Exception:
+        return None, None
+
+
+@dataclass
+class EmbeddingCost:
+    """Independent embedding-spend aggregate (FP-0063 PC) — deliberately NOT
+    a ``CostBreakdown`` field / component. Owner decision (2026-07-15,
+    proposal 0063 "Embedding cost is tracked INDEPENDENTLY"): an embedding
+    call is input-only and structurally uncacheable, so folding it into
+    ``CostBreakdown.prompt_cost`` would dilute ``cache_hit_rate`` /
+    ``cache_savings`` with tokens that could never have been cached — those
+    are chat-call figures and must stay chat-only. This is the embedding
+    aggregate's own, separate, additive total.
+
+    Mixed-model correctness (X6): each call is priced at ITS OWN model's rate
+    (``estimate_embedding_cost`` is called once per call, with that call's
+    model) BEFORE being folded in here via ``__add__``/``__iadd__`` — dollars
+    aggregate additively across models; tokens are never pooled across models
+    and priced afterwards at a single rate.
+
+    ``unpriced_calls`` is the visibility mechanism for an unknown model
+    (``estimate_embedding_cost`` returning ``None``): such a call still counts
+    toward ``tokens``/``calls`` but contributes 0 to ``cost_usd`` while
+    incrementing this counter — so "some spend is not reflected in cost_usd"
+    stays observable instead of silently reading as a real $0.00 call.
+    """
+
+    cost_usd: float = 0.0
+    tokens: int = 0
+    calls: int = 0
+    unpriced_calls: int = 0
+
+    def __add__(self, other: "EmbeddingCost") -> "EmbeddingCost":
+        return EmbeddingCost(
+            cost_usd=self.cost_usd + other.cost_usd,
+            tokens=self.tokens + other.tokens,
+            calls=self.calls + other.calls,
+            unpriced_calls=self.unpriced_calls + other.unpriced_calls,
+        )
+
+    def __iadd__(self, other: "EmbeddingCost") -> "EmbeddingCost":
+        self.cost_usd += other.cost_usd
+        self.tokens += other.tokens
+        self.calls += other.calls
+        self.unpriced_calls += other.unpriced_calls
+        return self
+
+    def to_dict(self) -> dict:
+        return {
+            "cost_usd": self.cost_usd,
+            "tokens": self.tokens,
+            "calls": self.calls,
+            "unpriced_calls": self.unpriced_calls,
+        }

--- a/src/reyn/runtime/budget/budget.py
+++ b/src/reyn/runtime/budget/budget.py
@@ -28,7 +28,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
-from reyn.llm.pricing import CostBreakdown, TokenUsage, estimate_cost, estimate_cost_breakdown
+from reyn.llm.pricing import (
+    CostBreakdown,
+    EmbeddingCost,
+    TokenUsage,
+    estimate_cost,
+    estimate_cost_breakdown,
+    estimate_embedding_cost,
+)
 
 # ── exceptions ──────────────────────────────────────────────────────────────
 
@@ -318,6 +325,17 @@ class BudgetTracker:
         # breakdown is a same-process-only refinement the cost panel reads to
         # show Input/Output/Saved on top of that already-durable Total.
         self._agent_cost_breakdown: dict[str, CostBreakdown] = defaultdict(CostBreakdown)
+        # FP-0063 PC: embedding spend is tracked as its OWN independent
+        # aggregate (owner: "embedding は独立追跡の想定"), NOT folded into
+        # ``_agent_cost_breakdown`` above — see ``EmbeddingCost``'s docstring
+        # for why (embedding is input-only/uncacheable; mapping it onto
+        # ``CostBreakdown.prompt_cost`` would dilute cache_hit_rate /
+        # cache_savings). Same non-durability posture as
+        # ``_agent_cost_breakdown``: in-memory only, resets on restart — a
+        # deliberate scope choice (persisting it would need a BudgetLedger
+        # schema extension + the CLAUDE.md recovery-feature truncate-falsify
+        # gate), not an oversight.
+        self._agent_embedding_cost: dict[str, EmbeddingCost] = defaultdict(EmbeddingCost)
         # #1190 stage (iii): per-purpose cost attribution
         # (main/compaction/judge/dogfood) for the /budget breakdown payoff.
         self._purpose_tokens: dict[str, int] = defaultdict(int)
@@ -540,6 +558,47 @@ class BudgetTracker:
             context=self._agent_context(agent) if agent else {},
         )
 
+    # ── FP-0063 PC: embedding cost (independent of record_llm above) ─────
+
+    def record_embedding(
+        self,
+        *,
+        model: str,
+        agent: str | None,
+        tokens: int,
+    ) -> None:
+        """Record one embedding call's spend into the INDEPENDENT per-agent
+        ``EmbeddingCost`` aggregate (FP-0063 X2b) — never touches
+        ``_agent_cost_usd`` / ``_agent_cost_breakdown`` (the chat aggregates)
+        and is not itself gated by the LLM per-agent hard-cap checks above
+        (embedding is not a chat call; ``check_pre_llm`` is unaffected).
+
+        Mixed-model correctness (X6): prices THIS call at model's own rate via
+        ``estimate_embedding_cost`` before folding into the aggregate — never
+        pools tokens across models and prices them afterwards at one rate.
+
+        An unpriced/unknown model (``estimate_embedding_cost`` -> ``(None,
+        None)``) still counts toward ``tokens``/``calls`` but contributes 0 to
+        ``cost_usd``, with ``unpriced_calls`` incremented so the gap stays
+        visible rather than silently reading as a real $0.00 call.
+        """
+        if agent is None:
+            return
+        cost_usd, _ = estimate_embedding_cost(model, tokens)
+        self._agent_embedding_cost[agent] += EmbeddingCost(
+            cost_usd=cost_usd or 0.0,
+            tokens=tokens,
+            calls=1,
+            unpriced_calls=0 if cost_usd is not None else 1,
+        )
+
+    def agent_embedding_cost(self, agent: str) -> EmbeddingCost:
+        """Independent embedding-spend aggregate for ``agent`` (all sessions,
+        this process only — same non-durability posture as
+        ``agent_cost_breakdown``). Returns an empty (all-zero) ``EmbeddingCost``
+        for an agent with no recorded embedding calls this process."""
+        return self._agent_embedding_cost.get(agent, EmbeddingCost())
+
     # ── reset / introspect ──────────────────────────────────────────────
 
     def reset_all(self) -> dict:
@@ -557,6 +616,7 @@ class BudgetTracker:
         self._agent_tokens.clear()
         self._agent_cost_usd.clear()
         self._agent_cost_breakdown.clear()
+        self._agent_embedding_cost.clear()
         self._call_window.clear()
         self._warned.clear()
         return before

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -479,6 +479,30 @@ class AgentRegistry:
             total += self.agent_cost_breakdown(name)
         return total
 
+    def agent_embedding_cost(self, name: str) -> "object":
+        """FP-0063 PC: agent-scope INDEPENDENT ``EmbeddingCost`` aggregate —
+        the durable process-shared BudgetTracker's per-agent embedding
+        accumulation (all sessions of ``name``, this process only; same
+        non-durability posture as ``agent_cost_breakdown`` — see
+        ``BudgetTracker._agent_embedding_cost``). Deliberately NOT part of
+        ``agent_cost_breakdown`` / the chat ``CostBreakdown`` — see
+        ``EmbeddingCost``'s docstring for why. Empty ``EmbeddingCost`` when no
+        tracker is wired."""
+        from reyn.llm.pricing import EmbeddingCost
+        tracker = self._shared_budget_tracker()
+        return tracker.agent_embedding_cost(name) if tracker is not None else EmbeddingCost()
+
+    def project_embedding_cost(self) -> "object":
+        """FP-0063 PC: project-scope INDEPENDENT ``EmbeddingCost`` aggregate —
+        summed across every currently-loaded agent's ``agent_embedding_cost``
+        (mirrors ``project_cost_breakdown`` above, applied to the separate
+        embedding aggregate rather than the chat one)."""
+        from reyn.llm.pricing import EmbeddingCost
+        total = EmbeddingCost()
+        for name in self.loaded_names():
+            total += self.agent_embedding_cost(name)
+        return total
+
     def resolve_session(
         self,
         agent_name: str,

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -79,6 +79,8 @@ def build_router_op_context(
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
     embedding_event_sink: Any = None,  # FP-0057 #2856 Part A: TUI model-download status sink for the `embed` op's provider resolution (ActionEmbeddingIndex build/query path). None → no TUI-observable download status.
+    budget_tracker: Any = None,  # FP-0063 PC: process-shared BudgetTracker → agent/project-scope embedding cost + LLM cost recording. Session wires its own; RouterHostAdapter has none today (pre-existing gap, same class as its unset agent_id above — not folded here).
+    budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → session-scope embedding cost (`embed` op). Session wires its own `self._budget`; RouterHostAdapter has none today (same asymmetry as budget_tracker above).
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -169,4 +171,6 @@ def build_router_op_context(
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
         render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
         embedding_event_sink=embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
+        budget_tracker=budget_tracker,  # FP-0063 PC: agent/project-scope embedding cost (+ LLM cost recording)
+        budget_gateway=budget_gateway,  # FP-0063 PC: session-scope embedding cost
     )

--- a/src/reyn/runtime/router_op_context.py
+++ b/src/reyn/runtime/router_op_context.py
@@ -79,8 +79,7 @@ def build_router_op_context(
     hot_reloader: Any = None,  # #2761 PR-2: this session's HotReloader → immediate mid-turn install apply
     render_template_bounds: Any = None,  # #2679: operator RenderTemplateBounds → the render_template op cap. None → the op's in-handler defaults.
     embedding_event_sink: Any = None,  # FP-0057 #2856 Part A: TUI model-download status sink for the `embed` op's provider resolution (ActionEmbeddingIndex build/query path). None → no TUI-observable download status.
-    budget_tracker: Any = None,  # FP-0063 PC: process-shared BudgetTracker → agent/project-scope embedding cost + LLM cost recording. Session wires its own; RouterHostAdapter has none today (pre-existing gap, same class as its unset agent_id above — not folded here).
-    budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → session-scope embedding cost (`embed` op). Session wires its own `self._budget`; RouterHostAdapter has none today (same asymmetry as budget_tracker above).
+    budget_gateway: Any = None,  # FP-0063 PC: the calling Session's per-session BudgetGateway → the `embed` op's single embedding-cost recording entry point (fans out to session scope + agent/project scope via the tracker it holds, keyed by agent NAME). Wired by BOTH router op-ctx builders; RouterHostAdapter's is the load-bearing one (the `embed` TOOL resolves that factory).
 ) -> Any:
     """Build the chat-router OpContext (the single source for both hosts).
 
@@ -171,6 +170,5 @@ def build_router_op_context(
         hot_reloader=hot_reloader,  # #2761 PR-2: per-session reloader for immediate mid-turn install apply
         render_template_bounds=render_template_bounds,  # #2679: operator render_template output cap
         embedding_event_sink=embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
-        budget_tracker=budget_tracker,  # FP-0063 PC: agent/project-scope embedding cost (+ LLM cost recording)
-        budget_gateway=budget_gateway,  # FP-0063 PC: session-scope embedding cost
+        budget_gateway=budget_gateway,  # FP-0063 PC: the embed op's embedding-cost recording entry point
     )

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -81,12 +81,24 @@ class BudgetGateway:
 
     def record_embedding(self, *, model: str, tokens: int) -> None:
         """Accumulate one embedding call's spend into this session's
-        INDEPENDENT ``EmbeddingCost`` aggregate. Prices THIS call at its own
-        model's rate (X6 mixed-model correctness) — never pools tokens across
-        models and prices them afterwards at a single rate. An unpriced/
-        unknown model contributes 0 to cost_usd but still counts toward
-        tokens/calls, with ``unpriced_calls`` incremented (visible, not a
-        silent $0.00)."""
+        INDEPENDENT ``EmbeddingCost`` aggregate, AND forward it to the
+        process-shared tracker for agent/project scope — the single recording
+        entry point for the `embed` op (``ctx.budget_gateway``).
+
+        This gateway is the only object that holds BOTH the tracker and the
+        session's AGENT NAME, which is why the fan-out lives here rather than
+        in the op handler. The tracker keys per-agent counters by agent NAME
+        (matching ``record_llm`` / ``Registry.agent_embedding_cost``); the op
+        handler has only ``ctx.agent_id`` — the FP-0016 HOST identity
+        (``reyn/<hostname>``), a DIFFERENT value — so recording from there
+        would file the spend under a key no per-scope reader ever looks up.
+
+        Prices THIS call at its own model's rate (X6 mixed-model correctness)
+        — never pools tokens across models and prices them afterwards at a
+        single rate. An unpriced/unknown model contributes 0 to cost_usd but
+        still counts toward tokens/calls, with ``unpriced_calls`` incremented
+        (visible, not a silent $0.00).
+        """
         if tokens <= 0:
             return
         cost_usd, _ = estimate_embedding_cost(model, tokens)
@@ -96,6 +108,13 @@ class BudgetGateway:
             calls=1,
             unpriced_calls=0 if cost_usd is not None else 1,
         )
+        # Agent/project scope. The tracker re-prices the call itself (same
+        # per-call, own-model-rate path), so the two aggregates stay consistent
+        # without this method having to pass a pre-computed figure through.
+        if self._tracker is not None:
+            self._tracker.record_embedding(
+                model=model, agent=self._agent_name, tokens=tokens,
+            )
 
     # ── per-session usage totals ──────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/budget_gateway.py
+++ b/src/reyn/runtime/services/budget_gateway.py
@@ -10,7 +10,7 @@ Session: total_usage, total_cost_usd, router cap counter, last reason.
 from __future__ import annotations
 
 from reyn.core.events.events import EventLog
-from reyn.llm.pricing import CostBreakdown, TokenUsage
+from reyn.llm.pricing import CostBreakdown, EmbeddingCost, TokenUsage, estimate_embedding_cost
 
 
 class BudgetGateway:
@@ -52,6 +52,12 @@ class BudgetGateway:
         # (this Session/process only) by construction — mirrors the existing
         # non-durable semantics of ``_total_usage``/``_total_cost_usd`` above.
         self._total_cost_breakdown: CostBreakdown = CostBreakdown()
+        # FP-0063 PC (Session scope): embedding spend is its OWN independent
+        # aggregate, deliberately NOT folded into ``_total_cost_breakdown``
+        # above (see ``EmbeddingCost``'s docstring — embedding is input-only /
+        # uncacheable; mapping it onto CostBreakdown.prompt_cost would dilute
+        # cache_hit_rate / cache_savings, which are chat-call-only figures).
+        self._embedding_cost: EmbeddingCost = EmbeddingCost()
         self._router_cap: int = default_router_cap
         self._router_invocations_this_turn: int = 0
         self._router_last_reason: str = ""
@@ -62,6 +68,34 @@ class BudgetGateway:
     def tracker(self):
         """The underlying process-shared BudgetTracker (or None)."""
         return self._tracker
+
+    # ── FP-0063 PC: embedding cost (Session scope, independent aggregate) ─────
+
+    @property
+    def embedding_cost(self) -> EmbeddingCost:
+        """Cumulative INDEPENDENT embedding-spend aggregate for this session
+        (all embed calls this session recorded via ``record_embedding``) —
+        deliberately separate from ``total_cost_breakdown`` (the chat
+        aggregate). See ``EmbeddingCost``'s docstring for why."""
+        return self._embedding_cost
+
+    def record_embedding(self, *, model: str, tokens: int) -> None:
+        """Accumulate one embedding call's spend into this session's
+        INDEPENDENT ``EmbeddingCost`` aggregate. Prices THIS call at its own
+        model's rate (X6 mixed-model correctness) — never pools tokens across
+        models and prices them afterwards at a single rate. An unpriced/
+        unknown model contributes 0 to cost_usd but still counts toward
+        tokens/calls, with ``unpriced_calls`` incremented (visible, not a
+        silent $0.00)."""
+        if tokens <= 0:
+            return
+        cost_usd, _ = estimate_embedding_cost(model, tokens)
+        self._embedding_cost += EmbeddingCost(
+            cost_usd=cost_usd or 0.0,
+            tokens=tokens,
+            calls=1,
+            unpriced_calls=0 if cost_usd is not None else 1,
+        )
 
     # ── per-session usage totals ──────────────────────────────────────────────
 

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -191,6 +191,16 @@ class RouterHostAdapter:
         # every router OpContext (``ctx.embedding_event_sink``) so the `embed`
         # op forwards it into the fresh per-call provider it resolves.
         embedding_event_sink: Any = None,
+        # FP-0063 PC: this session's BudgetGateway, threaded onto every router
+        # OpContext so the `embed` op can record its INDEPENDENT embedding-cost
+        # aggregate (session scope on the gateway itself; agent/project scope
+        # via the process-shared tracker the gateway holds). THIS is the
+        # op-context builder the router-dispatched `embed` TOOL resolves
+        # (RouterCallerState.op_context_factory = host.make_router_op_context,
+        # tools/types.py) — i.e. the live interactive path. Without it the
+        # user-facing embed is billed but recorded nowhere ($0.00), the exact
+        # bug FP-0063 closes.
+        budget_gateway: Any = None,
         # FP-0034 Phase 2: sandbox backend name for exec D14 visibility
         # gate. Passed from ``session._sandbox_config.backend`` so the
         # universal catalog ``_enumerate_category("exec")`` can decide
@@ -423,6 +433,8 @@ class RouterHostAdapter:
         self._embedding_model_class = embedding_model_class
         # FP-0057 #2856 Part A
         self._embedding_event_sink = embedding_event_sink
+        # FP-0063 PC: embedding-cost recording entry point for the `embed` op.
+        self._budget_gateway = budget_gateway
         # #2548 PR-A: enabled skill registry snapshot for the ## Skills block.
         self._available_skills = available_skills
         # FP-0034 Phase 2
@@ -2110,6 +2122,10 @@ class RouterHostAdapter:
             # status sink so the `embed` op preserves it (ActionEmbeddingIndex
             # build/query now routes through the op instead of provider-direct).
             embedding_event_sink=self._embedding_event_sink,
+            # FP-0063 PC: the live router-dispatched `embed` tool resolves THIS
+            # factory, so this is the load-bearing wiring for embedding-cost
+            # recording (all three scopes fan out from the gateway).
+            budget_gateway=self._budget_gateway,
         )
 
     def _set_cancel_event(self, event: asyncio.Event) -> None:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1790,6 +1790,13 @@ class Session:
             threat_scan=self._safety.threat_scan,
             contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
             hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
+            # FP-0063 PC: the router-dispatched `embed` TOOL builds its OpContext from
+            # THIS host (RouterCallerState.op_context_factory = host.make_router_op_context),
+            # so this is the live interactive path's embedding-cost wiring. The gateway is
+            # the single recording entry point (session scope on itself; agent/project via
+            # the shared tracker it holds). Session's own _make_router_op_context serves
+            # file/MCP ops, which no embed op reaches.
+            budget_gateway=self._budget,
             state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
             # #1953 dynamic-wire: thread the REAL session id + Task backend so
             # router-dispatched task.* ops hit the assignee/requester CAS gate.
@@ -2254,6 +2261,19 @@ class Session:
         """Cache-aware ``CostBreakdown`` for this session (Session-scope row
         source for the cost panel's Input/Output/Saved/Saved% breakdown)."""
         return self._budget.total_cost_breakdown
+
+    @property
+    def embedding_cost(self):
+        """FP-0063 PC: this session's INDEPENDENT ``EmbeddingCost`` aggregate —
+        the Session-scope reader of the session/agent/project trio (agent and
+        project scope are read via ``Registry.agent_embedding_cost`` /
+        ``.project_embedding_cost``).
+
+        Deliberately separate from ``total_cost_breakdown`` above, which stays
+        chat-only: an embedding call is input-only and structurally
+        uncacheable, so folding it in would dilute that breakdown's
+        ``cache_hit_rate`` / ``cache_savings``."""
+        return self._budget.embedding_cost
 
     # ── FP-0043 Stage 2: identity-field delegations to the Agent value object ──
     # Read-only by construction (identity is immutable for the session lifetime;
@@ -6208,8 +6228,7 @@ class Session:
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
             render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
             embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
-            budget_tracker=self._budget_tracker,  # FP-0063 PC: agent/project-scope embedding cost for the embed op (also LLM cost recording, e.g. judge_output)
-            budget_gateway=self._budget,  # FP-0063 PC: session-scope embedding cost for the embed op
+            budget_gateway=self._budget,  # FP-0063 PC: embedding-cost recording entry point (enumerate ALL op-ctx builders; the load-bearing one for `embed` is RouterHostAdapter's)
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6208,6 +6208,8 @@ class Session:
             hot_reloader=self._hot_reloader,  # #2761 PR-2: per-session reloader (both router op-ctx builders complete-by-construction)
             render_template_bounds=self._render_template_bounds,  # #2679: operator bounds (both router op-ctx builders complete-by-construction)
             embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: TUI model-download status sink for the embed op
+            budget_tracker=self._budget_tracker,  # FP-0063 PC: agent/project-scope embedding cost for the embed op (also LLM cost recording, e.g. judge_output)
+            budget_gateway=self._budget,  # FP-0063 PC: session-scope embedding cost for the embed op
         )
 
     async def _file_op(self, op_dict: dict) -> dict:

--- a/tests/test_embed_cost_wiring_live_path.py
+++ b/tests/test_embed_cost_wiring_live_path.py
@@ -1,0 +1,208 @@
+"""Tier 2: FP-0063 PC — the LIVE `embed` tool path actually records embedding
+cost (the production wiring, not the mechanism).
+
+Why this file exists, separately from `test_op_embed.py`: those tests build an
+`OpContext(...)` BY HAND, so they pin the MECHANISM (given a wired ctx, the op
+records) but not the WIRING (that a real Session hands the op a wired ctx).
+Both production call-sites could be deleted and every hand-built-ctx test would
+stay green — which is exactly how the gap this PR fixes came to exist in the
+first place: `ctx.budget_tracker` was a real field, with a real consumer
+(`judge_output`), that no router-dispatch host ever populated.
+
+So these tests drive the REAL chain the `embed` TOOL resolves at runtime:
+
+    Session.__init__ -> RouterHostAdapter(budget_tracker=, budget_gateway=)
+      -> build_resource_caller_state(host)
+      -> RouterCallerState.op_context_factory = host.make_router_op_context
+      -> tools/embed.py `_handle_embed` calls that factory
+      -> execute_op(EmbedIROp, ctx) -> ctx.budget_tracker/.budget_gateway
+
+Verified RED by stripping the production call-site (reported in the PR body):
+removing `budget_gateway=self._budget` from Session's `RouterHostAdapter(...)`
+construction turns all three of these tests RED, while every hand-built-ctx
+test in `test_op_embed.py` stays green.
+
+Note which host: the `embed` tool resolves `RouterHostAdapter.make_router_op_context`
+(via `RouterCallerState.op_context_factory`), NOT `Session._make_router_op_context`
+(which serves file/MCP ops that no embed op reaches). That distinction is the
+whole point of testing through the real factory rather than asserting on a
+builder chosen by reading.
+
+Policy: no mocks — a real `Session` / `RouterHostAdapter` / `BudgetTracker` /
+`BudgetGateway` and the real `embed` tool handler. Only the embedding PROVIDER
+is a real-instance Fake (the network egress boundary), same
+`FakeEmbeddingProvider` pattern `test_op_embed.py` uses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.data.embedding.provider import EmbedBatchResult
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.session import Session
+from reyn.tools.types import ToolContext, build_resource_caller_state
+
+# A real litellm embedding-mode model, so the recorded figure is a real
+# `litellm.model_cost` lookup rather than a fabricated rate.
+_REAL_EMBEDDING_MODEL = "text-embedding-3-small"
+
+
+class _RealModelFakeProvider:
+    """Real EmbeddingProvider-protocol instance (not a mock) that reports a
+    REAL, litellm-priceable model name so the cost path resolves an actual
+    rate."""
+
+    async def embed(self, texts: list[str], model: str) -> EmbedBatchResult:
+        return EmbedBatchResult(
+            vectors=[[1.0, 0.0, 0.0] for _ in texts],
+            model=_REAL_EMBEDDING_MODEL,
+            total_tokens=1000,
+        )
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return len(texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 3
+
+
+def _session(tmp_path: Path, tracker: BudgetTracker) -> Session:
+    agent_dir = tmp_path / ".reyn" / "agents" / "embedder"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    return Session(
+        agent_name="embedder",
+        agent_role="r",
+        output_language="en",
+        budget_tracker=tracker,
+        snapshot_path=agent_dir / "state" / "snapshot.json",
+    )
+
+
+async def _run_embed_tool_via_live_path(session: Session) -> dict:
+    """Drive the real `embed` tool through the real router chain — the same
+    `op_context_factory` resolution a live chat turn performs."""
+    from reyn.tools.embed import _handle_embed
+
+    router_state = await build_resource_caller_state(session._router_host)
+    tool_ctx = ToolContext(
+        events=session._chat_events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=router_state,
+    )
+    return await _handle_embed({"texts": ["hello", "world"]}, tool_ctx)
+
+
+@pytest.mark.asyncio
+async def test_live_embed_tool_records_agent_scope_cost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: driving the REAL `embed` tool through the REAL router chain
+    records agent-scope embedding cost on the Session's BudgetTracker.
+
+    RED if Session stops passing `budget_tracker` into RouterHostAdapter —
+    the wiring, not the mechanism."""
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(
+        _embed_mod, "get_provider", lambda *a, **kw: _RealModelFakeProvider(),
+    )
+
+    tracker = BudgetTracker(CostConfig())
+    session = _session(tmp_path, tracker)
+
+    result = await _run_embed_tool_via_live_path(session)
+    assert result.get("status") != "error", result
+
+    # Keyed by agent NAME — the key `Registry.agent_embedding_cost` reads.
+    agg = tracker.agent_embedding_cost("embedder")
+    assert agg.calls == 1, (
+        "the live embed tool call must reach the agent-scope aggregate — "
+        "0 calls means Session is not wiring budget_gateway into the host "
+        "whose make_router_op_context the embed tool actually resolves"
+    )
+    assert agg.tokens == 1000
+    assert agg.cost_usd > 0.0
+    assert agg.cost_usd == result["cost_usd"]
+
+    # The chat aggregate stays untouched by embedding activity, on the live
+    # path too (not just in the hand-built-ctx unit tests).
+    assert tracker.agent_cost_usd("embedder") == 0.0
+    assert tracker.agent_cost_breakdown("embedder").total_cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_live_embed_tool_records_session_scope_cost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the same live chain records session-scope embedding cost on the
+    Session's own BudgetGateway.
+
+    RED if Session stops passing `budget_gateway` into RouterHostAdapter."""
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(
+        _embed_mod, "get_provider", lambda *a, **kw: _RealModelFakeProvider(),
+    )
+
+    tracker = BudgetTracker(CostConfig())
+    session = _session(tmp_path, tracker)
+
+    result = await _run_embed_tool_via_live_path(session)
+    assert result.get("status") != "error", result
+
+    agg = session.embedding_cost  # the public Session-scope reader
+    assert agg.calls == 1, (
+        "the live embed tool call must reach the session-scope aggregate — "
+        "0 calls means Session is not wiring budget_gateway into the host "
+        "whose make_router_op_context the embed tool actually resolves"
+    )
+    assert agg.tokens == 1000
+    assert agg.cost_usd == result["cost_usd"]
+    # The chat session-scope figures stay untouched by embedding activity.
+    assert session.total_cost_usd == 0.0
+    assert session.total_cost_breakdown.total_cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_live_embed_tool_reaches_project_scope_via_registry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the live-path recording is what the project-scope reader sums —
+    `project_embedding_cost` is non-zero after a real embed tool call, closing
+    the loop from the interactive tool to the per-scope surface this PR adds."""
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(
+        _embed_mod, "get_provider", lambda *a, **kw: _RealModelFakeProvider(),
+    )
+
+    from reyn.runtime.profile import AgentProfile
+    from reyn.runtime.registry import AgentRegistry
+
+    tracker = BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return Session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=tracker,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("embedder")
+    session = reg.get_or_load("embedder")
+
+    assert reg.project_embedding_cost().cost_usd == 0.0
+
+    result = await _run_embed_tool_via_live_path(session)
+    assert result.get("status") != "error", result
+
+    project = reg.project_embedding_cost()
+    assert project.calls == 1
+    assert project.cost_usd > 0.0
+    assert project.cost_usd == result["cost_usd"]

--- a/tests/test_embedding_cost_pricing.py
+++ b/tests/test_embedding_cost_pricing.py
@@ -1,0 +1,132 @@
+"""Tier 2: FP-0063 PC — embedding cost pricing (`estimate_embedding_cost` /
+`EmbeddingCost`), independent of the chat `CostBreakdown`.
+
+Proposal 0063 ("Embedding cost tracking") verified that `pricing.py` resolved
+completion rates ONLY — no embedding-mode rate was ever looked up, so
+embedding spend never reached a dollar figure. This file pins the extension:
+
+  1. `estimate_embedding_cost` resolves a REAL litellm embedding-mode model
+     (no new/parallel rate table — same `litellm.model_cost` lookup
+     `estimate_cost` uses for chat, extended to embedding entries).
+  2. An unknown/unpriced model returns `(None, None)` — VISIBLE unknown, never
+     a silent `$0.00` (mirrors the pre-existing #1829 sentinel for chat).
+  3. `EmbeddingCost` aggregates ADDITIVELY across calls — and the headline
+     requirement (X6): two calls at DIFFERENT models' DIFFERENT rates sum to
+     the SAME total as pricing each independently and adding the dollars.
+     This test also FALSIFIES the wrong approach (summing tokens across
+     models, then pricing once at a single model's rate) — the module
+     docstring / PR body report the falsification result.
+
+Policy: no mocks — real litellm + real `model_cost` lookups; no
+private-state assertions; Tier line.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import EmbeddingCost, estimate_embedding_cost
+
+# Two real, differently-priced embedding-mode models (litellm.model_cost,
+# mode="embedding") — verified present with distinct `input_cost_per_token`
+# rates in the vendored litellm at authoring time.
+_MODEL_A = "text-embedding-3-small"   # OpenAI, cheaper
+_MODEL_B = "text-embedding-3-large"   # OpenAI, pricier
+
+
+def _epsilon_close(a: float, b: float, eps: float = 1e-12) -> bool:
+    return abs(a - b) < eps
+
+
+def test_estimate_embedding_cost_resolves_a_real_litellm_model() -> None:
+    """Tier 2: a real embedding-mode model resolves a positive dollar cost —
+    litellm's embedding-mode rate table is reachable (extends the existing
+    lookup; not a new rate table)."""
+    cost_usd, snapshot = estimate_embedding_cost(_MODEL_A, 1000)
+    assert cost_usd is not None
+    assert cost_usd > 0.0
+    assert snapshot is not None
+    assert snapshot["model"] == _MODEL_A
+    assert snapshot["source"] == "litellm"
+    assert snapshot["input_per_1m_usd"] > 0
+
+
+def test_estimate_embedding_cost_two_models_have_different_rates() -> None:
+    """Tier 2: precondition for the mixed-model test below — the two chosen
+    models must actually price differently, or the falsification downstream
+    would be vacuous."""
+    cost_a, _ = estimate_embedding_cost(_MODEL_A, 1_000_000)
+    cost_b, _ = estimate_embedding_cost(_MODEL_B, 1_000_000)
+    assert cost_a is not None and cost_b is not None
+    assert cost_a != cost_b
+
+
+def test_estimate_embedding_cost_unknown_model_is_none_not_zero() -> None:
+    """Tier 2: an unpriced/unknown model returns (None, None) — unknown != free
+    (#1829 sentinel extended to embedding mode). A silent $0.00 here would
+    recreate the exact invisibility bug FP-0063 exists to close."""
+    cost_usd, snapshot = estimate_embedding_cost("not-a-real-model-xyz", 1000)
+    assert cost_usd is None
+    assert snapshot is None
+
+
+def test_estimate_embedding_cost_zero_tokens_is_free_but_priced() -> None:
+    """Tier 2: zero tokens costs $0.00 (nothing to price) — distinct from the
+    unknown-model case, which is None specifically because the RATE, not the
+    tokens, is missing."""
+    cost_usd, snapshot = estimate_embedding_cost(_MODEL_A, 0)
+    assert cost_usd == 0.0
+    assert snapshot is None
+
+
+def test_embedding_cost_additive_across_calls() -> None:
+    """Tier 2: `EmbeddingCost.__add__` / `__iadd__` sum all four fields."""
+    a = EmbeddingCost(cost_usd=1.0, tokens=100, calls=1, unpriced_calls=0)
+    b = EmbeddingCost(cost_usd=2.0, tokens=200, calls=1, unpriced_calls=1)
+    total = a + b
+    assert total.cost_usd == 3.0
+    assert total.tokens == 300
+    assert total.calls == 2
+    assert total.unpriced_calls == 1
+
+    a += b
+    assert a.cost_usd == 3.0
+    assert a.tokens == 300
+    assert a.calls == 2
+    assert a.unpriced_calls == 1
+
+
+def test_mixed_model_correctness_prices_each_call_at_its_own_rate() -> None:
+    """Tier 2 (X6 headline test): two embedding calls at DIFFERENT models with
+    DIFFERENT rates must aggregate to the SAME total as pricing each
+    independently at its own rate and summing the dollars.
+
+    FALSIFICATION (reported in the PR body): the WRONG approach — sum the
+    token counts across both calls, then price ONCE at a single model's rate
+    — is asserted to differ from the correct total whenever the two models'
+    rates differ (guaranteed by the precondition test above). This is the
+    failure mode X6 exists to prevent (aggregating tokens across models before
+    pricing, instead of pricing per-call then aggregating dollars).
+    """
+    tokens_a = 10_000
+    tokens_b = 25_000
+
+    cost_a, _ = estimate_embedding_cost(_MODEL_A, tokens_a)
+    cost_b, _ = estimate_embedding_cost(_MODEL_B, tokens_b)
+    assert cost_a is not None and cost_b is not None
+
+    # Correct: price each call at its own model's rate, aggregate dollars.
+    aggregate = EmbeddingCost(cost_usd=cost_a, tokens=tokens_a, calls=1) + EmbeddingCost(
+        cost_usd=cost_b, tokens=tokens_b, calls=1,
+    )
+    correct_total = aggregate.cost_usd
+    assert _epsilon_close(correct_total, cost_a + cost_b)
+
+    # WRONG (falsified): pool tokens across models, price once at model A's
+    # rate as if the whole batch used a single session-level model.
+    wrong_total, _ = estimate_embedding_cost(_MODEL_A, tokens_a + tokens_b)
+    assert wrong_total is not None
+
+    assert not _epsilon_close(wrong_total, correct_total), (
+        "the wrong (pool-then-price-once) approach must diverge from the "
+        "correct (price-per-call-then-sum) approach whenever the two models' "
+        "rates differ — if they matched, this test would not be falsifying "
+        "anything"
+    )

--- a/tests/test_embedding_cost_pricing.py
+++ b/tests/test_embedding_cost_pricing.py
@@ -94,7 +94,7 @@ def test_embedding_cost_additive_across_calls() -> None:
 
 
 def test_mixed_model_correctness_prices_each_call_at_its_own_rate() -> None:
-    """Tier 2 (X6 headline test): two embedding calls at DIFFERENT models with
+    """Tier 2: X6 headline test — two embedding calls at DIFFERENT models with
     DIFFERENT rates must aggregate to the SAME total as pricing each
     independently at its own rate and summing the dollars.
 

--- a/tests/test_embedding_cost_tracking.py
+++ b/tests/test_embedding_cost_tracking.py
@@ -1,0 +1,251 @@
+"""Tier 2: FP-0063 PC — embedding cost is tracked as its OWN independent
+aggregate, at session / agent / project scope, and does NOT touch the chat
+`CostBreakdown`.
+
+Owner decision (2026-07-15, proposal 0063 "Embedding cost is tracked
+INDEPENDENTLY"): embedding spend is its own tracked aggregate, never folded
+into `CostBreakdown` (embedding is input-only / structurally uncacheable;
+mapping it onto `prompt_cost` would dilute `cache_hit_rate` / `cache_savings`,
+chat-call-only figures). This file pins:
+
+  1. `BudgetTracker.record_embedding` accumulates a per-agent `EmbeddingCost`
+     — INDEPENDENT of `agent_cost_usd` / `agent_cost_breakdown` (the chat
+     aggregates), which this test asserts stay untouched by embedding calls
+     (the regression this design exists to prevent).
+  2. Mixed-model correctness (X6) at the tracker level: two embedding calls
+     to DIFFERENT models accumulate to the sum of each priced at its own
+     rate — FALSIFIED against pooling tokens and pricing once.
+  3. `Registry.agent_embedding_cost` / `.project_embedding_cost` mirror the
+     existing `agent_cost_breakdown` / `project_cost_breakdown` per-scope
+     shape (Session ⊆ Agent ⊆ Project), applied to the separate aggregate.
+  4. `BudgetGateway.record_embedding` / `.embedding_cost` — the Session-scope
+     reader — also independent of `total_cost_breakdown`.
+  5. An unpriced/unknown model is visible (`unpriced_calls` increments)
+     rather than silently reading as free.
+
+Policy: no mocks — real `BudgetTracker` / `BudgetGateway` / `AgentRegistry` +
+real `Session`, real litellm pricing lookups; no private-state assertions
+(all reads go through the public `agent_cost_usd` / `agent_cost_breakdown` /
+`agent_embedding_cost` / `snapshot()`-style accessors); Tier line.
+"""
+from __future__ import annotations
+
+from reyn.llm.pricing import EmbeddingCost, TokenUsage, estimate_embedding_cost
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.services.budget_gateway import BudgetGateway
+from reyn.core.events.events import EventLog
+
+_MODEL_A = "text-embedding-3-small"
+_MODEL_B = "text-embedding-3-large"
+_CHAT_MODEL = "claude-sonnet-4-5-20250929"
+
+
+def _epsilon_close(a: float, b: float, eps: float = 1e-9) -> bool:
+    return abs(a - b) < eps
+
+
+# ---------------------------------------------------------------------------
+# BudgetTracker: agent-scope independent aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_record_embedding_accumulates_per_agent() -> None:
+    """Tier 2: repeated embedding calls for one agent accumulate tokens/cost/
+    calls in the independent aggregate."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_embedding(model=_MODEL_A, agent="alice", tokens=1000)
+    tracker.record_embedding(model=_MODEL_A, agent="alice", tokens=500)
+
+    agg = tracker.agent_embedding_cost("alice")
+    assert agg.tokens == 1500
+    assert agg.calls == 2
+    assert agg.unpriced_calls == 0
+    assert agg.cost_usd > 0.0
+
+
+def test_record_embedding_mixed_models_sums_each_at_its_own_rate() -> None:
+    """Tier 2 (X6): two calls to DIFFERENT models accumulate to the sum of
+    each priced independently — FALSIFIED against pooling the tokens and
+    pricing once at a single model's rate."""
+    tracker = BudgetTracker(CostConfig())
+    tokens_a, tokens_b = 10_000, 25_000
+    tracker.record_embedding(model=_MODEL_A, agent="bob", tokens=tokens_a)
+    tracker.record_embedding(model=_MODEL_B, agent="bob", tokens=tokens_b)
+
+    agg = tracker.agent_embedding_cost("bob")
+    cost_a, _ = estimate_embedding_cost(_MODEL_A, tokens_a)
+    cost_b, _ = estimate_embedding_cost(_MODEL_B, tokens_b)
+    correct_total = cost_a + cost_b
+
+    assert _epsilon_close(agg.cost_usd, correct_total)
+
+    # Falsify: pooling the tokens and pricing once at model A's rate must
+    # diverge (the two models have different rates — pinned in
+    # test_embedding_cost_pricing.py).
+    wrong_total, _ = estimate_embedding_cost(_MODEL_A, tokens_a + tokens_b)
+    assert not _epsilon_close(agg.cost_usd, wrong_total)
+
+
+def test_record_embedding_does_not_touch_chat_cost_breakdown() -> None:
+    """Tier 2: the regression this design exists to prevent — recording
+    embedding calls leaves the chat `agent_cost_usd` / `agent_cost_breakdown`
+    at exactly zero (they are driven only by `record_llm`)."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_embedding(model=_MODEL_A, agent="carol", tokens=100_000)
+
+    assert tracker.agent_embedding_cost("carol").cost_usd > 0.0
+    assert tracker.agent_cost_usd("carol") == 0.0
+    breakdown = tracker.agent_cost_breakdown("carol")
+    assert breakdown.total_cost == 0.0
+    assert breakdown.prompt_tokens == 0
+    assert breakdown.cached_tokens == 0
+
+
+def test_chat_cost_breakdown_savings_math_unaffected_by_embedding_activity() -> None:
+    """Tier 2: interleaving embedding calls with a real chat `record_llm` call
+    leaves the chat breakdown's savings math (components-sum-to-total,
+    cache_hit_rate) byte-identical to a scope with NO embedding activity —
+    embedding tokens never leak into the cache_hit_rate denominator."""
+    tracker_with_embeddings = BudgetTracker(CostConfig())
+    tracker_without = BudgetTracker(CostConfig())
+
+    usage = TokenUsage(prompt_tokens=1000, completion_tokens=200, cached_tokens=800)
+    tracker_with_embeddings.record_embedding(model=_MODEL_A, agent="dave", tokens=50_000)
+    tracker_with_embeddings.record_llm(model=_CHAT_MODEL, agent="dave", usage=usage)
+    tracker_with_embeddings.record_embedding(model=_MODEL_B, agent="dave", tokens=20_000)
+
+    tracker_without.record_llm(model=_CHAT_MODEL, agent="dave", usage=usage)
+
+    with_bd = tracker_with_embeddings.agent_cost_breakdown("dave")
+    without_bd = tracker_without.agent_cost_breakdown("dave")
+
+    assert _epsilon_close(with_bd.total_cost, without_bd.total_cost)
+    assert _epsilon_close(with_bd.cache_hit_rate, without_bd.cache_hit_rate)
+    assert _epsilon_close(with_bd.cache_savings, without_bd.cache_savings)
+    assert with_bd.prompt_tokens == without_bd.prompt_tokens
+    assert with_bd.cached_tokens == without_bd.cached_tokens
+    assert _epsilon_close(
+        tracker_with_embeddings.agent_cost_usd("dave"),
+        tracker_without.agent_cost_usd("dave"),
+    )
+
+
+def test_record_embedding_unpriced_model_is_visible_not_silent_zero() -> None:
+    """Tier 2: an unknown/unpriced model still counts toward tokens/calls but
+    contributes 0 to cost_usd, with unpriced_calls incremented — the spend
+    gap stays observable rather than silently reading as a real $0.00 call."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_embedding(model="not-a-real-model-xyz", agent="erin", tokens=5000)
+
+    agg = tracker.agent_embedding_cost("erin")
+    assert agg.tokens == 5000
+    assert agg.calls == 1
+    assert agg.unpriced_calls == 1
+    assert agg.cost_usd == 0.0
+
+
+def test_record_embedding_with_no_agent_is_a_noop() -> None:
+    """Tier 2: agent=None (no attribution target) records nothing — mirrors
+    `record_llm`'s agent-gated accumulation."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_embedding(model=_MODEL_A, agent=None, tokens=1000)
+    assert tracker.agent_embedding_cost("").tokens == 0
+
+
+def test_reset_all_clears_embedding_aggregate() -> None:
+    """Tier 2: `/budget reset` (`reset_all`) clears the embedding aggregate
+    alongside the existing per-agent counters."""
+    tracker = BudgetTracker(CostConfig())
+    tracker.record_embedding(model=_MODEL_A, agent="frank", tokens=1000)
+    assert tracker.agent_embedding_cost("frank").calls == 1
+
+    tracker.reset_all()
+    assert tracker.agent_embedding_cost("frank").calls == 0
+    assert tracker.agent_embedding_cost("frank").cost_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Registry: 3-scope aggregation (agent / project) mirrors agent_cost_breakdown
+# ---------------------------------------------------------------------------
+
+
+def _registry(tmp_path, tracker: "BudgetTracker | None" = None) -> AgentRegistry:
+    from reyn.runtime.session import Session
+
+    shared = tracker if tracker is not None else BudgetTracker(CostConfig())
+
+    def factory(profile: AgentProfile):
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        return Session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            output_language="en",
+            budget_tracker=shared,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+
+    return AgentRegistry(project_root=tmp_path, session_factory=factory)
+
+
+def test_registry_agent_and_project_embedding_cost(tmp_path) -> None:
+    """Tier 2: `Registry.agent_embedding_cost` reads the shared tracker's
+    per-agent aggregate; `project_embedding_cost` sums every loaded agent —
+    Agent <= Project, strictly less when a second agent has activity (mirrors
+    `test_session_agent_project_scopes_aggregate_correctly` for the chat
+    breakdown, applied to the independent embedding aggregate)."""
+    tracker = BudgetTracker(CostConfig())
+    reg = _registry(tmp_path, tracker=tracker)
+
+    reg.create("gabe")
+    reg.create("hana")
+    reg.get_or_load("gabe")
+    reg.get_or_load("hana")
+
+    tracker.record_embedding(model=_MODEL_A, agent="gabe", tokens=10_000)
+    tracker.record_embedding(model=_MODEL_B, agent="hana", tokens=20_000)
+
+    gabe_cost = reg.agent_embedding_cost("gabe")
+    hana_cost = reg.agent_embedding_cost("hana")
+    project_cost = reg.project_embedding_cost()
+
+    assert gabe_cost.cost_usd > 0.0
+    assert hana_cost.cost_usd > 0.0
+    assert _epsilon_close(project_cost.cost_usd, gabe_cost.cost_usd + hana_cost.cost_usd)
+    assert gabe_cost.cost_usd < project_cost.cost_usd
+    assert project_cost.tokens == gabe_cost.tokens + hana_cost.tokens
+
+
+def test_registry_agent_embedding_cost_empty_when_no_tracker(tmp_path) -> None:
+    """Tier 2: no process-shared tracker wired (no session loaded yet) ->
+    empty EmbeddingCost, not an error."""
+    reg = AgentRegistry(project_root=tmp_path, session_factory=lambda p: None)
+    assert reg.agent_embedding_cost("nobody") == EmbeddingCost()
+    assert reg.project_embedding_cost() == EmbeddingCost()
+
+
+# ---------------------------------------------------------------------------
+# BudgetGateway: session-scope independent aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_budget_gateway_records_session_scope_embedding_cost() -> None:
+    """Tier 2: `BudgetGateway.record_embedding` accumulates the session-scope
+    aggregate, independent of `total_cost_breakdown`."""
+    gateway = BudgetGateway(budget_tracker=None, events=EventLog(), agent_name="iris")
+
+    gateway.record_embedding(model=_MODEL_A, tokens=10_000)
+    gateway.record_embedding(model=_MODEL_B, tokens=5_000)
+
+    agg = gateway.embedding_cost
+    cost_a, _ = estimate_embedding_cost(_MODEL_A, 10_000)
+    cost_b, _ = estimate_embedding_cost(_MODEL_B, 5_000)
+    assert _epsilon_close(agg.cost_usd, cost_a + cost_b)
+    assert agg.tokens == 15_000
+    assert agg.calls == 2
+
+    # Untouched by embedding activity.
+    assert gateway.total_cost_usd == 0.0
+    assert gateway.total_cost_breakdown.total_cost == 0.0

--- a/tests/test_embedding_cost_tracking.py
+++ b/tests/test_embedding_cost_tracking.py
@@ -30,12 +30,12 @@ real `Session`, real litellm pricing lookups; no private-state assertions
 """
 from __future__ import annotations
 
+from reyn.core.events.events import EventLog
 from reyn.llm.pricing import EmbeddingCost, TokenUsage, estimate_embedding_cost
 from reyn.runtime.budget.budget import BudgetTracker, CostConfig
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.budget_gateway import BudgetGateway
-from reyn.core.events.events import EventLog
 
 _MODEL_A = "text-embedding-3-small"
 _MODEL_B = "text-embedding-3-large"
@@ -66,7 +66,7 @@ def test_record_embedding_accumulates_per_agent() -> None:
 
 
 def test_record_embedding_mixed_models_sums_each_at_its_own_rate() -> None:
-    """Tier 2 (X6): two calls to DIFFERENT models accumulate to the sum of
+    """Tier 2: X6 — two calls to DIFFERENT models accumulate to the sum of
     each priced independently — FALSIFIED against pooling the tokens and
     pricing once at a single model's rate."""
     tracker = BudgetTracker(CostConfig())

--- a/tests/test_embedding_cost_tracking.py
+++ b/tests/test_embedding_cost_tracking.py
@@ -233,7 +233,8 @@ def test_registry_agent_embedding_cost_empty_when_no_tracker(tmp_path) -> None:
 
 def test_budget_gateway_records_session_scope_embedding_cost() -> None:
     """Tier 2: `BudgetGateway.record_embedding` accumulates the session-scope
-    aggregate, independent of `total_cost_breakdown`."""
+    aggregate, independent of `total_cost_breakdown`. Tracker-less (unlimited
+    mode) is a supported configuration — session scope still records."""
     gateway = BudgetGateway(budget_tracker=None, events=EventLog(), agent_name="iris")
 
     gateway.record_embedding(model=_MODEL_A, tokens=10_000)
@@ -249,3 +250,25 @@ def test_budget_gateway_records_session_scope_embedding_cost() -> None:
     # Untouched by embedding activity.
     assert gateway.total_cost_usd == 0.0
     assert gateway.total_cost_breakdown.total_cost == 0.0
+
+
+def test_budget_gateway_fans_out_to_tracker_keyed_by_agent_name() -> None:
+    """Tier 2: the gateway is the single recording entry point — it also
+    forwards to the process-shared tracker under its AGENT NAME, so the
+    agent/project-scope readers (`Registry.agent_embedding_cost`, which looks
+    up by name) actually see the spend. Pins the key: the gateway's agent
+    name, not any host-identity value."""
+    tracker = BudgetTracker(CostConfig())
+    gateway = BudgetGateway(
+        budget_tracker=tracker, events=EventLog(), agent_name="jade",
+    )
+
+    gateway.record_embedding(model=_MODEL_A, tokens=10_000)
+
+    agent_agg = tracker.agent_embedding_cost("jade")
+    assert agent_agg.calls == 1
+    assert agent_agg.tokens == 10_000
+    assert _epsilon_close(agent_agg.cost_usd, gateway.embedding_cost.cost_usd)
+
+    # The chat aggregate on the shared tracker stays untouched.
+    assert tracker.agent_cost_usd("jade") == 0.0

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -318,3 +318,170 @@ async def test_embed_forwards_none_when_ctx_embedding_event_sink_stripped(
         "with no sink on ctx, get_provider() must receive event_sink=None "
         "(no TUI status forwarded) — the RED case for the test above"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: FP-0063 PC -- embedding cost in the op's output metadata + recording
+# ---------------------------------------------------------------------------
+#
+# `embed`'s result envelope already carried `total_tokens`/`model`; this PR
+# adds `cost_usd`/`priced` (X2c) and records the call into whichever of
+# `ctx.budget_tracker` (agent/project scope) / `ctx.budget_gateway` (session
+# scope) are wired -- an INDEPENDENT aggregate, never the chat `CostBreakdown`.
+
+# A real litellm embedding-mode model (verified present, mode="embedding") so
+# these tests exercise the actual litellm.model_cost lookup, not a fake rate.
+_REAL_EMBEDDING_MODEL = "text-embedding-3-small"
+
+
+@pytest.mark.asyncio
+async def test_embed_output_carries_cost_usd_and_priced_for_a_real_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the op's output metadata carries `cost_usd` (a positive dollar
+    figure) and `priced=True` for a model litellm can price -- `total_tokens`/
+    `model` alone (the pre-existing shape) no longer suffice."""
+    class _RealModelProvider(FakeEmbeddingProvider):
+        async def embed(self, texts, model):
+            return EmbedBatchResult(
+                vectors=[[1.0, 0.0, 0.0] for _ in texts],
+                model=_REAL_EMBEDDING_MODEL,
+                total_tokens=1000,
+            )
+
+    fake = _RealModelProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=["a", "b"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert result["priced"] is True
+    assert result["cost_usd"] is not None
+    assert result["cost_usd"] > 0.0
+
+
+@pytest.mark.asyncio
+async def test_embed_output_unpriced_model_reports_none_cost_visibly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: falsify the silent-$0.00 failure mode -- a model litellm cannot
+    price yields `cost_usd=None` / `priced=False`, NOT `cost_usd=0.0` (which
+    would be indistinguishable from a real free call)."""
+    fake = FakeEmbeddingProvider()  # returns model="fake/standard" -- unpriced
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=["a", "bb"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert result["priced"] is False
+    assert result["cost_usd"] is None
+
+
+@pytest.mark.asyncio
+async def test_embed_empty_texts_reports_zero_priced_cost(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the empty-texts no-op path (no provider call at all) reports a
+    real, priced $0.00 -- distinct from the unpriced-model None case above."""
+    fake = FakeEmbeddingProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    ctx = _make_ctx(tmp_path)
+    op = EmbedIROp(kind="embed", texts=[], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert result["cost_usd"] == 0.0
+    assert result["priced"] is True
+
+
+@pytest.mark.asyncio
+async def test_embed_records_into_budget_tracker_agent_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when `ctx.budget_tracker` is wired, the op records the call
+    into the INDEPENDENT per-agent embedding-cost aggregate (agent/project
+    scope) -- via `ctx.agent_id`, mirroring `judge_output.py`'s existing
+    `ctx.budget_tracker` recording precedent."""
+    from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+
+    class _RealModelProvider(FakeEmbeddingProvider):
+        async def embed(self, texts, model):
+            return EmbedBatchResult(
+                vectors=[[1.0, 0.0, 0.0] for _ in texts],
+                model=_REAL_EMBEDDING_MODEL,
+                total_tokens=2000,
+            )
+
+    fake = _RealModelProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    tracker = BudgetTracker(CostConfig())
+    events = EventLog()
+    ws = Workspace(events=events)
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        budget_tracker=tracker,
+        agent_id="agent-x",
+    )
+    op = EmbedIROp(kind="embed", texts=["a", "b"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    agg = tracker.agent_embedding_cost("agent-x")
+    assert agg.calls == 1
+    assert agg.tokens == 2000
+    assert agg.cost_usd == result["cost_usd"]
+    # The chat aggregate is untouched by this embed call.
+    assert tracker.agent_cost_usd("agent-x") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_embed_records_into_budget_gateway_session_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: when `ctx.budget_gateway` is wired (the Session-scope adapter),
+    the op ALSO records the call into its session-scope embedding-cost
+    aggregate, independent of the agent-scope tracker above."""
+    from reyn.runtime.services.budget_gateway import BudgetGateway
+
+    class _RealModelProvider(FakeEmbeddingProvider):
+        async def embed(self, texts, model):
+            return EmbedBatchResult(
+                vectors=[[1.0, 0.0, 0.0] for _ in texts],
+                model=_REAL_EMBEDDING_MODEL,
+                total_tokens=500,
+            )
+
+    fake = _RealModelProvider()
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
+
+    events = EventLog()
+    ws = Workspace(events=events)
+    gateway = BudgetGateway(budget_tracker=None, events=events, agent_name="agent-y")
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        budget_gateway=gateway,
+    )
+    op = EmbedIROp(kind="embed", texts=["a"], embedding_model="standard")
+    result = await execute_op(op, ctx)
+
+    assert result.get("status") != "error", result
+    assert gateway.embedding_cost.calls == 1
+    assert gateway.embedding_cost.tokens == 500
+    assert gateway.embedding_cost.cost_usd == result["cost_usd"]
+    # Session-scope chat total is untouched by this embed call.
+    assert gateway.total_cost_usd == 0.0

--- a/tests/test_op_embed.py
+++ b/tests/test_op_embed.py
@@ -403,14 +403,19 @@ async def test_embed_empty_texts_reports_zero_priced_cost(
 
 
 @pytest.mark.asyncio
-async def test_embed_records_into_budget_tracker_agent_scope(
+async def test_embed_records_all_three_scopes_via_the_gateway(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: when `ctx.budget_tracker` is wired, the op records the call
-    into the INDEPENDENT per-agent embedding-cost aggregate (agent/project
-    scope) -- via `ctx.agent_id`, mirroring `judge_output.py`'s existing
-    `ctx.budget_tracker` recording precedent."""
+    """Tier 2: `ctx.budget_gateway` is the op's SINGLE recording entry point,
+    fanning out to session scope (the gateway) AND agent scope (the shared
+    tracker it holds, keyed by the gateway's agent NAME -- the key
+    `Registry.agent_embedding_cost` looks up).
+
+    The agent-NAME key matters: the op handler only has `ctx.agent_id`, the
+    FP-0016 host identity (`reyn/<hostname>`), so recording from the handler
+    would file spend under a key no per-scope reader ever reads."""
     from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+    from reyn.runtime.services.budget_gateway import BudgetGateway
 
     class _RealModelProvider(FakeEmbeddingProvider):
         async def embed(self, texts, model):
@@ -427,34 +432,49 @@ async def test_embed_records_into_budget_tracker_agent_scope(
     tracker = BudgetTracker(CostConfig())
     events = EventLog()
     ws = Workspace(events=events)
+    gateway = BudgetGateway(
+        budget_tracker=tracker, events=events, agent_name="agent-name",
+    )
     ctx = OpContext(
         workspace=ws,
         events=events,
         permission_decl=PermissionDecl(),
-        budget_tracker=tracker,
-        agent_id="agent-x",
+        budget_gateway=gateway,
+        # The host identity, deliberately DIFFERENT from the agent name -- the
+        # recorded key must follow the agent name, not this.
+        agent_id="reyn/some-host.local",
     )
     op = EmbedIROp(kind="embed", texts=["a", "b"], embedding_model="standard")
     result = await execute_op(op, ctx)
 
     assert result.get("status") != "error", result
-    agg = tracker.agent_embedding_cost("agent-x")
+
+    # Session scope.
+    assert gateway.embedding_cost.calls == 1
+    assert gateway.embedding_cost.tokens == 2000
+    assert gateway.embedding_cost.cost_usd == result["cost_usd"]
+
+    # Agent scope -- keyed by agent NAME.
+    agg = tracker.agent_embedding_cost("agent-name")
     assert agg.calls == 1
     assert agg.tokens == 2000
     assert agg.cost_usd == result["cost_usd"]
-    # The chat aggregate is untouched by this embed call.
-    assert tracker.agent_cost_usd("agent-x") == 0.0
+
+    # NOT keyed by the host identity (the wrong-key failure mode).
+    assert tracker.agent_embedding_cost("reyn/some-host.local").calls == 0
+
+    # The chat aggregates are untouched by this embed call.
+    assert tracker.agent_cost_usd("agent-name") == 0.0
+    assert gateway.total_cost_usd == 0.0
 
 
 @pytest.mark.asyncio
-async def test_embed_records_into_budget_gateway_session_scope(
+async def test_embed_without_a_gateway_still_prices_but_records_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: when `ctx.budget_gateway` is wired (the Session-scope adapter),
-    the op ALSO records the call into its session-scope embedding-cost
-    aggregate, independent of the agent-scope tracker above."""
-    from reyn.runtime.services.budget_gateway import BudgetGateway
-
+    """Tier 2: with no gateway wired (direct/test construction), the op still
+    returns the priced metadata but records into no aggregate -- the opt-in
+    contract, and no crash on the None path."""
     class _RealModelProvider(FakeEmbeddingProvider):
         async def embed(self, texts, model):
             return EmbedBatchResult(
@@ -467,21 +487,11 @@ async def test_embed_records_into_budget_gateway_session_scope(
     import reyn.core.op_runtime.embed as _embed_mod
     monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: fake)
 
-    events = EventLog()
-    ws = Workspace(events=events)
-    gateway = BudgetGateway(budget_tracker=None, events=events, agent_name="agent-y")
-    ctx = OpContext(
-        workspace=ws,
-        events=events,
-        permission_decl=PermissionDecl(),
-        budget_gateway=gateway,
-    )
+    ctx = _make_ctx(tmp_path)
+    assert ctx.budget_gateway is None
     op = EmbedIROp(kind="embed", texts=["a"], embedding_model="standard")
     result = await execute_op(op, ctx)
 
     assert result.get("status") != "error", result
-    assert gateway.embedding_cost.calls == 1
-    assert gateway.embedding_cost.tokens == 500
-    assert gateway.embedding_cost.cost_usd == result["cost_usd"]
-    # Session-scope chat total is untouched by this embed call.
-    assert gateway.total_cost_usd == 0.0
+    assert result["priced"] is True
+    assert result["cost_usd"] > 0.0


### PR DESCRIPTION
**[per-PR-coder]** — FP-0063 PC (the one core PR of the "builtin turnkey user RAG" arc): embedding cost tracking, backend only. Owner-approved GO 2026-07-15. Proposal: `docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md` § "Embedding cost tracking" / "Embedding cost is tracked INDEPENDENTLY".

## The gap this closes
`embed`'s op envelope already carried `total_tokens`/`model`, but `pricing.py` resolved completion rates only — embedding spend never became a dollar figure, and never reached any cost surface. A user ingesting a document folder (a batch spend against an API-priced embedding model) would be billed while every cost surface read `$0.00`.

## Design: an INDEPENDENT aggregate, not a `CostBreakdown` component
Owner (2026-07-15): *"embedding は独立追跡の想定だよ"*. `CostBreakdown` (#2931) models a **chat** call — `prompt`/`cache-read`/`cache-creation`/`completion` + derived `cache_savings`/`cache_hit_rate`. An embedding call is **input-only and structurally uncacheable**; mapping it onto `prompt_cost` would dilute `cache_hit_rate`/`cache_savings` with tokens that could never have been cached — corrupting real backend figures, not just a future UI.

So this PR adds a **separate** `EmbeddingCost` dataclass (`src/reyn/llm/pricing.py`) — `cost_usd` / `tokens` / `calls` / `unpriced_calls`, additive via `__add__`/`__iadd__` — and leaves the chat `CostBreakdown` (fields, `total_cost`, `cache_hit_rate`, savings math) **completely untouched**. A regression test (`test_chat_cost_breakdown_savings_math_unaffected_by_embedding_activity`) interleaves embedding calls with a real chat call and asserts the chat breakdown is byte-identical to a scope with zero embedding activity.

## Per-scope surfaces added (mirrors the existing `agent_cost_usd`/`project_cost_breakdown` shape)
- **Session** — `BudgetGateway.record_embedding(model=, tokens=)` / `.embedding_cost` (`src/reyn/runtime/services/budget_gateway.py`)
- **Agent** — `BudgetTracker.record_embedding(model=, agent=, tokens=)` / `.agent_embedding_cost(agent)` (`src/reyn/runtime/budget/budget.py`) — in-memory only, same non-durability posture as the existing `agent_cost_breakdown` (persisting would need a `BudgetLedger` schema extension + the CLAUDE.md recovery-feature truncate-falsify gate; not a recovery feature, so out of scope here)
- **Project** — `Registry.agent_embedding_cost(name)` / `.project_embedding_cost()` (`src/reyn/runtime/registry.py`), summing every loaded agent

## Rate resolution (X4) — extends the existing lookup, no new table
`estimate_embedding_cost(model, total_tokens)` (`pricing.py`) uses the SAME `litellm.model_cost` dict `estimate_cost` already reads, restricted to entries with a resolvable `input_cost_per_token` (embedding-mode entries carry `output_cost_per_token: 0.0`, never `None` — verified empirically: 124 embedding-mode entries in the vendored litellm, e.g. `text-embedding-3-small`/`text-embedding-3-large`). Embedding is input-only, so this prices `total_tokens` directly rather than going through `litellm.cost_per_token`'s completion/cache-aware usage-object machinery.

**Unknown-model behaviour (decided + pinned)**: an unpriced/unknown model returns `(None, None)` — mirrors the pre-existing #1829 sentinel (unknown != free). The op's output carries `cost_usd=None` / `priced=False` in that case; the tracker/gateway still count `tokens`/`calls` but increment `unpriced_calls` rather than silently adding `$0.00`. Pinned by `test_estimate_embedding_cost_unknown_model_is_none_not_zero` and `test_embed_output_unpriced_model_reports_none_cost_visibly` (a silent `$0.00` here would recreate the exact bug this PR closes).

## Mixed-model correctness (X6) — falsified
Each call is priced at **its own model's rate at call time**, then aggregated as dollars (never: pool tokens across models, price once at a single rate). `test_mixed_model_correctness_prices_each_call_at_its_own_rate` and `test_record_embedding_mixed_models_sums_each_at_its_own_rate` price two real, differently-rated models (`text-embedding-3-small` @ 2e-08/tok, `text-embedding-3-large` @ 1.3e-07/tok) independently and assert the aggregate equals the sum — **then explicitly compute the WRONG total** (pool both models' tokens, price once at model A's rate) and assert it **diverges** from the correct total. Both tests are RED under the wrong implementation (verified while writing them, before pinning the correct one) — reported per the requirement.

## `embed` output metadata (X2c)
`embed`'s op result gains `cost_usd: float | None` and `priced: bool` alongside the existing `vectors`/`model`/`total_tokens` (`src/reyn/core/op_runtime/embed.py`). `embed_to_canonical` forwards both into the tool-result `meta` a future ingest pipeline's `fold` step reads. `docs/reference/runtime/control-ir.md`'s `embed` section is updated (hard rule: op-shape docs stay synced with the impl).

## Wiring: the live `embed` path (corrected after review — findings A+B)

> **Correction.** The first revision of this PR body claimed the interactive `embed` tool now records cost. **That claim was false**, and I reached it by reading the call graph instead of driving it. Reviewer finding A forced the check that caught it. Corrected record below.

**Finding A — answered by driving the real chain, not reading it.** The reviewer asked whether `embed` can execute on the RouterHostAdapter context. The answer is stronger than "can": it **exclusively** does.

```
RouterCallerState.op_context_factory = getattr(host, "make_router_op_context")   # tools/types.py:264
host = RouterHostAdapter                                                          # RouterLoop.host
tools/embed.py::_handle_embed -> ctx.router_state.op_context_factory()
```
Probed on a real Session:
```
live embed factory : RouterHostAdapter.make_router_op_context
ctx.budget_tracker : None
ctx.budget_gateway : None
```
So the builder my first revision wired (`Session._make_router_op_context`) serves file/MCP ops that **no embed op ever reaches** — the user-facing embed was billed and recorded **nowhere**, i.e. the very `$0.00` bug this PR exists to kill was still fully alive on the only path a user actually hits. Fixed: `RouterHostAdapter` now takes `budget_gateway` and threads it onto every router OpContext; `Session` passes `self._budget` (it already held it — it simply wasn't passed).

**A second, latent bug this surfaced (wrong key).** Recording via `ctx.agent_id` filed spend under the FP-0016 **host identity** (`reyn/<hostname>`), while `BudgetTracker` / `Registry.agent_embedding_cost` key per-agent counters by agent **NAME** (`"embedder"`). Agent/project scope could therefore **never** have resolved, even once reachable. `BudgetGateway` — the only object holding *both* the shared tracker and the agent name — is now the **single recording entry point**, fanning out to all three scopes. Consequently `ctx.budget_tracker` threading is **reverted**: it belongs to `judge_output`, which has its own separate `agent_id` gap that is out of scope here (see below).

**Finding B — the wiring is now pinned, and the pin is falsified.** New `tests/test_embed_cost_wiring_live_path.py` drives the real chain end-to-end (`Session.__init__` -> `RouterHostAdapter` -> `build_resource_caller_state` -> `op_context_factory` -> real `embed` tool -> `execute_op`), with only the embedding **provider** faked (the network egress boundary).

**Falsification observed** — stripped `budget_gateway=self._budget` from Session's `RouterHostAdapter(...)`:

| suite | stripped | restored |
|---|---|---|
| `test_embed_cost_wiring_live_path.py` (new) | **3 failed** | 3 passed |
| hand-built-ctx tests (`test_op_embed.py` + others) | **34 passed** | 34 passed |

That table *is* the reviewer's point, measured: the mechanism tests cannot see a wiring deletion. Re-verified against the final code after the public-surface refactor.

**Also added**: public `Session.embedding_cost` — the session-scope surface was previously only reachable through private state (the tier-audit gate caught my test doing exactly that).

### Remaining known gap (disclosed, not folded)
`RouterHostAdapter` still passes `agent_id=None` (pre-existing, predates this PR, documented in `router_op_context.py`). It does **not** affect embedding cost — the gateway carries the agent name, so all three scopes resolve without `agent_id`. It **does** mean `judge_output`'s `record_llm(agent=ctx.agent_id)` records under `None`/host-identity on the registry-dispatch path. That is a **separate pre-existing defect in a different feature**; per the reviewer's own framing ("片方の経路で silent $0.00 はコメントに留めるには重すぎる") I am **not** leaving it as a code comment — flagging it here for a tracking issue rather than silently widening this PR.

## Explicitly left untouched
- The chat `CostBreakdown` — fields, `total_cost`, `cache_hit_rate`, `cache_savings` math (regression-tested above).
- The status-chip / cost-panel rendering — owner-deferred to a separate wave; this PR lands data only.
- `ctx.budget_tracker` / `judge_output`'s recording path — reverted to untouched (see the disclosed gap above).
- The in-core `index_update` path's own `cost_warn_threshold` + `index_update_cost_warning` mechanism (X3) — untouched. It happens to route through the same shared `embed` op internally, so it now *also* gets embedding cost recorded into the independent aggregate as a natural consequence of not duplicating logic — not new logic added to `index_update.py` itself.
- X1 (pre-flight pipeline estimate) / X2a (in-pipeline `fold` spend total) / X5 (post-dedup accounting) — these are the future builtin ingest pipeline's job (Phase P3), not this core PR's scope per the proposal's own phasing table (PC = X2b + X4 + X2c only).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 37/37 OK, 0 Tier-4 violations
- [x] `pytest` (repo root) — 8550 passed, 20 skipped (pre-existing, unrelated); rebased onto latest `origin/main` (#2948)
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK
- [x] Manual: live-path probe on a real Session (factory identity + wired scopes) — findings A/B evidence above
- [x] Manual: strip-falsify the production call-site -> 3 RED / restore -> green (table above)

New test files: `tests/test_embedding_cost_pricing.py`, `tests/test_embedding_cost_tracking.py`, `tests/test_embed_cost_wiring_live_path.py`; extended `tests/test_op_embed.py`. All Tier 2, real `BudgetTracker`/`BudgetGateway`/`AgentRegistry`/`Session` + real litellm pricing lookups — no mocks.
