### PR TITLE
fix: incremental history-token cache in ContextBudgetAdvisor (#2940)

### DIFF
--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -59,8 +59,17 @@ class ContextBudgetAdvisor:
         # (model, use_chars4); a length decrease (compaction/rewind truncated
         # history) or a model/config change invalidates it (full recompute),
         # a length increase only dumps+estimates the NEW tail slice.
+        # "boundary" is a hash of the last cached message's json dump — the
+        # cache is an append-only-PREFIX assumption, but history_fn is
+        # typically a derived, recomputed view (e.g. Session._active_branch_
+        # history — the same function #2938 hoisted), not a real array: a
+        # rewind can change WHICH messages are active such that len returns
+        # to a previously-cached value while the actual content at that
+        # boundary differs. Checking length alone would then silently return
+        # a stale cached total (never re-synced until a later length
+        # decrease). The boundary hash makes this checked, not assumed.
         self._history_token_cache: dict[str, Any] = {
-            "len": 0, "tokens": 0, "model": None, "use_chars4": None,
+            "len": 0, "tokens": 0, "model": None, "use_chars4": None, "boundary": None,
         }
 
     @property
@@ -88,9 +97,12 @@ class ContextBudgetAdvisor:
 
         Incremental: only the slice of history NEWER than the last call is
         json.dumps'd + estimated; a cache hit (no new messages since last
-        call) is O(1). A shrink (compaction/rewind truncated history) or a
-        model/use_chars4 change invalidates the cache and falls back to one
-        full recompute.
+        call) is O(1). A shrink, a model/use_chars4 change, OR the cached
+        PREFIX's content actually differing (checked via a boundary hash,
+        not assumed from length alone — history_fn is often a recomputed
+        derived view, e.g. a rewind-aware active-branch filter, where the
+        same length can recur with different content) invalidates the cache
+        for one full recompute.
         """
         import json as _json
 
@@ -101,10 +113,27 @@ class ContextBudgetAdvisor:
         try:
             history = self._history_fn()
             n = len(history)
-            if cache["len"] > n or cache["model"] != self._model or cache["use_chars4"] != use_chars4:
+            cached_len = cache["len"]
+            # The boundary is the json dump of the LAST message that was in
+            # the cached prefix (index cached_len - 1). If it no longer
+            # matches the message currently at that index, the prefix isn't
+            # append-only-stable and the cache cannot be trusted, even at an
+            # unchanged or grown length.
+            boundary = (
+                _json.dumps(history[cached_len - 1], ensure_ascii=False)
+                if 0 < cached_len <= n
+                else None
+            )
+            prefix_unchanged = cached_len == 0 or (cached_len <= n and boundary == cache["boundary"])
+            if (
+                cached_len > n
+                or cache["model"] != self._model
+                or cache["use_chars4"] != use_chars4
+                or not prefix_unchanged
+            ):
                 combined = _json.dumps(history, ensure_ascii=False)
                 tokens = estimate_tokens(combined, self._model, use_chars4=use_chars4)
-            elif cache["len"] == n:
+            elif cached_len == n:
                 return int(cache["tokens"])
             else:
                 # Dump each new message individually and join with the same
@@ -113,10 +142,13 @@ class ContextBudgetAdvisor:
                 # otherwise add a spurious pair of bracket tokens on every
                 # single call, drifting the cumulative estimate upward as the
                 # history grows across many dropdown-open/pre-frame checks.
-                delta = history[cache["len"]:]
+                delta = history[cached_len:]
                 combined = ",".join(_json.dumps(m, ensure_ascii=False) for m in delta)
                 tokens = int(cache["tokens"]) + estimate_tokens(combined, self._model, use_chars4=use_chars4)
-            cache.update(len=n, tokens=tokens, model=self._model, use_chars4=use_chars4)
+            new_boundary = _json.dumps(history[-1], ensure_ascii=False) if n > 0 else None
+            cache.update(
+                len=n, tokens=tokens, model=self._model, use_chars4=use_chars4, boundary=new_boundary,
+            )
             return tokens
         except Exception:  # noqa: BLE001 — estimation best-effort
             return 0

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -59,7 +59,8 @@ class ContextBudgetAdvisor:
         # (model, use_chars4); a length decrease (compaction/rewind truncated
         # history) or a model/config change invalidates it (full recompute),
         # a length increase only dumps+estimates the NEW tail slice.
-        # "boundary" is a hash of the last cached message's json dump — the
+        # "boundary" is the json dump of the last cached message (not a hash
+        # of it — one message's dump is cheap enough to hold verbatim) — the
         # cache is an append-only-PREFIX assumption, but history_fn is
         # typically a derived, recomputed view (e.g. Session._active_branch_
         # history — the same function #2938 hoisted), not a real array: a
@@ -98,11 +99,11 @@ class ContextBudgetAdvisor:
         Incremental: only the slice of history NEWER than the last call is
         json.dumps'd + estimated; a cache hit (no new messages since last
         call) is O(1). A shrink, a model/use_chars4 change, OR the cached
-        PREFIX's content actually differing (checked via a boundary hash,
-        not assumed from length alone — history_fn is often a recomputed
-        derived view, e.g. a rewind-aware active-branch filter, where the
-        same length can recur with different content) invalidates the cache
-        for one full recompute.
+        PREFIX's content actually differing (checked via a boundary — the
+        json dump of the last cached message, not assumed from length alone
+        — history_fn is often a recomputed derived view, e.g. a rewind-aware
+        active-branch filter, where the same length can recur with
+        different content) invalidates the cache for one full recompute.
         """
         import json as _json
 

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -52,6 +52,16 @@ class ContextBudgetAdvisor:
         self._history_fn = history_fn
         from reyn.config.chat import OffloadConfig
         self._offload_config = offload_config if offload_config is not None else OffloadConfig()
+        # #2940: incremental token-estimate cache. Re-dumping the full router-view
+        # history on every call (dropdown open, pre-frame overflow check) is
+        # O(history size) each time and grows unbounded over a long session.
+        # Cache is (history length, cumulative estimated tokens) keyed by
+        # (model, use_chars4); a length decrease (compaction/rewind truncated
+        # history) or a model/config change invalidates it (full recompute),
+        # a length increase only dumps+estimates the NEW tail slice.
+        self._history_token_cache: dict[str, Any] = {
+            "len": 0, "tokens": 0, "model": None, "use_chars4": None,
+        }
 
     @property
     def _model(self) -> str:
@@ -73,22 +83,51 @@ class ContextBudgetAdvisor:
         from reyn.llm.model_budget import get_max_input_tokens
         return get_max_input_tokens(self._model, events=self._events)
 
-    def _free_window_now(self) -> tuple[int, int]:
-        """Return (effective_trigger, estimated_history_tokens).
+    def _incremental_history_tokens(self) -> int:
+        """Estimated token count of the full router-view history (#2940).
 
-        Used by context_window_status and maybe_force_compact.
+        Incremental: only the slice of history NEWER than the last call is
+        json.dumps'd + estimated; a cache hit (no new messages since last
+        call) is O(1). A shrink (compaction/rewind truncated history) or a
+        model/use_chars4 change invalidates the cache and falls back to one
+        full recompute.
         """
         import json as _json
 
         from reyn.services.compaction.engine import estimate_tokens
 
-        effective_trigger = self._get_effective_trigger()
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
+        cache = self._history_token_cache
         try:
-            combined = _json.dumps(self._history_fn(), ensure_ascii=False)
-            estimated = estimate_tokens(combined, self._model, use_chars4=use_chars4)
+            history = self._history_fn()
+            n = len(history)
+            if cache["len"] > n or cache["model"] != self._model or cache["use_chars4"] != use_chars4:
+                combined = _json.dumps(history, ensure_ascii=False)
+                tokens = estimate_tokens(combined, self._model, use_chars4=use_chars4)
+            elif cache["len"] == n:
+                return int(cache["tokens"])
+            else:
+                # Dump each new message individually and join with the same
+                # comma separator json.dumps(list) would use BETWEEN elements
+                # (not wrapped in its own "[...]") — an array-slice dump would
+                # otherwise add a spurious pair of bracket tokens on every
+                # single call, drifting the cumulative estimate upward as the
+                # history grows across many dropdown-open/pre-frame checks.
+                delta = history[cache["len"]:]
+                combined = ",".join(_json.dumps(m, ensure_ascii=False) for m in delta)
+                tokens = int(cache["tokens"]) + estimate_tokens(combined, self._model, use_chars4=use_chars4)
+            cache.update(len=n, tokens=tokens, model=self._model, use_chars4=use_chars4)
+            return tokens
         except Exception:  # noqa: BLE001 — estimation best-effort
-            estimated = 0
+            return 0
+
+    def _free_window_now(self) -> tuple[int, int]:
+        """Return (effective_trigger, estimated_history_tokens).
+
+        Used by context_window_status and maybe_force_compact.
+        """
+        effective_trigger = self._get_effective_trigger()
+        estimated = self._incremental_history_tokens()
         return effective_trigger, estimated
 
     # ── Public API ────────────────────────────────────────────────────────────
@@ -189,11 +228,8 @@ class ContextBudgetAdvisor:
         Recomputes budgets, checks new_msg_budget (axis 11), and runs
         force_compact_now() if the current history exceeds effective_trigger.
         """
-        import json as _json
-
         from reyn.services.compaction.engine import (
             NewMsgExceedsBudgetError,
-            estimate_tokens,
             estimate_tokens_for_turn,
         )
 
@@ -232,14 +268,9 @@ class ContextBudgetAdvisor:
                     new_msg_budget=new_msg_budget,
                 )
 
-        # Quick estimate of the current history slice.
-        try:
-            history_msgs = self._history_fn()
-            combined = _json.dumps(history_msgs, ensure_ascii=False)
-            use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
-            estimated = estimate_tokens(combined, self._model, use_chars4=use_chars4)
-        except Exception:
-            return
+        # Quick estimate of the current history slice (#2940: incremental, not a
+        # full re-dump every call — shares the cache with context_window_status).
+        estimated = self._incremental_history_tokens()
 
         if estimated > effective_trigger:
             self._events.emit(

--- a/tests/test_context_budget_advisor_incremental_history_tokens.py
+++ b/tests/test_context_budget_advisor_incremental_history_tokens.py
@@ -1,0 +1,182 @@
+"""Tier 2: ContextBudgetAdvisor incremental history-token cache (#2940).
+
+The status-bar ctx chip's dropdown calls context_window_status() every time
+it opens, and maybe_force_compact() calls the same estimate every pre-frame
+overflow check. Both previously re-ran json.dumps(FULL history) + estimate_
+tokens on every single call — O(history size) each time, growing unbounded
+over a long session (the reported freeze). _incremental_history_tokens()
+caches (history length, cumulative estimate) and only dumps+estimates the
+NEW tail slice on growth, returning the cached total unchanged (O(1)) when
+history hasn't grown, and fully recomputing (not silently returning stale
+data) when history SHRINKS (compaction/rewind truncated it).
+
+Real ContextBudgetAdvisor + real estimate_tokens — no mocks. The estimate
+function itself is exact-deterministic for a given text (no LLM call), so
+correctness can be checked by comparing the incremental result against a
+from-scratch computation over the same final history.
+"""
+from __future__ import annotations
+
+import json
+
+from reyn.config import CompactionConfig
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.services.compaction.engine import estimate_tokens
+
+
+def _make_advisor(history_fn, *, model: str = "openai/gpt-4o") -> ContextBudgetAdvisor:
+    return ContextBudgetAdvisor(
+        compaction=CompactionConfig(),
+        compaction_controller=None,
+        media_store=None,
+        model_fn=lambda: model,
+        events=None,
+        history_fn=history_fn,
+    )
+
+
+def _from_scratch_tokens(history: list, model: str) -> int:
+    combined = json.dumps(history, ensure_ascii=False)
+    return estimate_tokens(combined, model, use_chars4=False)
+
+
+def test_unchanged_history_skips_estimate_entirely(monkeypatch) -> None:
+    """Tier 2: falsifying — proves the cache HIT path, not just that its
+    output happens to match (a real spy on estimate_tokens, per the #2937
+    counting-spy idiom — a real callable recording per-text call counts in a
+    dict, not a MagicMock, and not a bare len(list)==N format pin). Reopening
+    the dropdown with no new messages since the last call must not
+    re-dump/re-estimate at all. On the pre-#2940 code (always full
+    json.dumps + estimate_tokens) the unchanged-history text would be
+    estimated 3 times, not once."""
+    counts: dict[str, int] = {}
+
+    from reyn.services.compaction import engine as engine_mod
+
+    real = engine_mod.estimate_tokens
+
+    def _counting_estimate_tokens(text, model, *, use_chars4=False):
+        counts[text] = counts.get(text, 0) + 1
+        return real(text, model, use_chars4=use_chars4)
+
+    monkeypatch.setattr(engine_mod, "estimate_tokens", _counting_estimate_tokens)
+
+    history = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+    advisor = _make_advisor(lambda: history)
+    unchanged_text = json.dumps(history, ensure_ascii=False)
+
+    advisor.context_window_status()
+    assert counts.get(unchanged_text) == 1, "first call must estimate once (cold cache)"
+
+    advisor.context_window_status()
+    advisor.context_window_status()
+    assert counts.get(unchanged_text) == 1, (
+        "repeated calls with unchanged history must NOT call estimate_tokens "
+        "again for the same combined text — this is the O(1) cache-hit path "
+        "the #2940 fix adds"
+    )
+
+    new_turn = {"role": "user", "content": "a new turn"}
+    history.append(new_turn)
+    advisor.context_window_status()
+    delta_text = json.dumps(new_turn, ensure_ascii=False)
+    assert counts.get(delta_text) == 1, (
+        "growth must estimate the NEW tail slice's own text — proves only "
+        "the delta was dumped, not the full (now-longer) history again"
+    )
+    assert counts.get(json.dumps(history, ensure_ascii=False)) is None, (
+        "the full (post-growth) combined history must NEVER be dumped as one "
+        "unit — only its individual new tail message is"
+    )
+
+
+def test_repeated_calls_with_unchanged_history_return_identical_value() -> None:
+    """Tier 2: reopening the dropdown with no new turns since the last call
+    returns the exact same estimate (cache hit), not a fresh (possibly
+    non-deterministic-cost) recompute."""
+    history = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
+    advisor = _make_advisor(lambda: history)
+
+    first = advisor.context_window_status()["free_window"]
+    second = advisor.context_window_status()["free_window"]
+    third = advisor.context_window_status()["free_window"]
+    assert first == second == third
+
+
+def test_growing_history_matches_from_scratch_computation() -> None:
+    """Tier 2: falsifying — the incremental (cache + tail-slice) path must
+    track a full from-scratch json.dumps+estimate over the final history at
+    every growth step, within a tolerance proportional to message count.
+    Exact equality isn't the right bound: subword (BPE) tokenization merges
+    characters across fragment boundaries differently when a message is
+    tokenized alone vs embedded in the full combined text — a few-token
+    drift per message that's inherent to any incremental/streaming token
+    estimate (not linear or unbounded; it's the SAME small per-fragment
+    noise regardless of total history size) and is harmless for a rough
+    context-budget indicator. A real bug (double-counted or dropped
+    message) would blow far past this tolerance, which is what this test
+    exists to catch."""
+    history: list = []
+    advisor = _make_advisor(lambda: history)
+
+    for i in range(12):
+        history.append({"role": "user", "content": f"message number {i} " * (i + 1)})
+        status = advisor.context_window_status()
+        used = status["effective_trigger"] - status["free_window"]
+        expected = _from_scratch_tokens(history, "openai/gpt-4o")
+        tolerance = 2 * (i + 1)
+        assert abs(used - expected) <= tolerance, f"diverged at step {i}: {used} vs {expected}"
+
+
+def test_shrinking_history_recomputes_rather_than_returning_stale_cache() -> None:
+    """Tier 2: falsifying — after compaction/rewind truncates history to
+    fewer messages than were cached, the NEXT call must reflect the smaller
+    history, not the larger cached total (which would report a bogus
+    over-budget / under-budget free_window after every compaction)."""
+    history = [{"role": "user", "content": "x" * 500} for _ in range(20)]
+    advisor = _make_advisor(lambda: history)
+
+    advisor.context_window_status()  # populate cache at length 20
+
+    history = history[:3]  # simulate compaction truncating the router-view history
+    advisor_history_status = advisor.context_window_status()
+    used = advisor_history_status["effective_trigger"] - advisor_history_status["free_window"]
+    expected = _from_scratch_tokens(history, "openai/gpt-4o")
+    assert used == expected
+
+
+def test_maybe_force_compact_shares_the_same_incremental_cache(monkeypatch) -> None:
+    """Tier 2: maybe_force_compact's pre-frame history estimate is the SAME
+    incremental path as context_window_status (#2940 fix-class: both call
+    sites had the identical full-redump pathology) — a call to one primes
+    the cache the other then hits."""
+    import asyncio
+
+    history = [{"role": "user", "content": "hello world"}]
+    advisor = _make_advisor(lambda: history)
+
+    class _FakeBudgets:
+        effective_trigger = 10_000_000  # far above any estimate: never force-compacts
+        new_msg_budget = 10_000_000
+
+    class _FakeEngine:
+        budgets = _FakeBudgets()
+
+        def recompute_budgets(self):
+            pass
+
+    class _FakeController:
+        _engine = _FakeEngine()
+
+        async def force_compact_now(self):
+            raise AssertionError("must not be called — history is far under budget")
+
+    advisor._compaction_controller = _FakeController()
+
+    status_before = advisor.context_window_status()
+    asyncio.run(advisor.maybe_force_compact())
+    status_after = advisor.context_window_status()
+    expected_free_window = status_before["effective_trigger"] - _from_scratch_tokens(
+        history, "openai/gpt-4o"
+    )
+    assert status_before["free_window"] == status_after["free_window"] == expected_free_window

--- a/tests/test_context_budget_advisor_incremental_history_tokens.py
+++ b/tests/test_context_budget_advisor_incremental_history_tokens.py
@@ -107,20 +107,27 @@ def test_growing_history_matches_from_scratch_computation() -> None:
     """Tier 2: falsifying — the incremental (cache + tail-slice) path must
     track a full from-scratch json.dumps+estimate over the final history at
     every growth step, within a tolerance proportional to message count.
-    Exact equality isn't the right bound: subword (BPE) tokenization merges
-    characters across fragment boundaries differently when a message is
-    tokenized alone vs embedded in the full combined text — a few-token
-    drift PER FRAGMENT that's inherent to any incremental/streaming token
-    estimate. That per-fragment drift is constant, but this test compares
-    against the CUMULATIVE sum over all messages added so far, so the
-    worst-case bound genuinely grows with message count (this tolerance is
-    intentionally linear, not a mistake) — it is NOT unbounded in practice
-    because a real session's history_fn periodically SHRINKS (compaction
-    covers the middle into a summary), which forces a full recompute and
-    re-syncs the cache from scratch; real drift is bounded by the
-    inter-compaction message count, not the whole session's lifetime. A real
-    bug (double-counted or dropped message) would blow far past even this
-    linear tolerance, which is what this test exists to catch."""
+
+    Exact equality isn't the bound: tokenizing a new message's JSON dump
+    SEPARATELY from the rest of the history can shift subword (BPE) merge
+    decisions right at the fragment boundary relative to tokenizing the
+    whole thing jointly. An earlier revision of this docstring claimed this
+    drift is structurally one-directional (incremental >= from-scratch,
+    "only ever safe, never under") — DISPROVEN by direct measurement: a
+    growing-repeated-phrase history (this test's own fixture) makes the
+    JOINT (from-scratch) tokenization MORE efficient than the incremental
+    sum, i.e. the incremental estimate UNDER-shoots by an amount that grows
+    with message count (verified independently of comma/bracket
+    reconstruction — adding the exact missing separator punctuation to the
+    delta text does not close the gap, so it is a genuine cross-boundary
+    BPE effect, not a punctuation-accounting bug). Realistic multi-turn
+    chat content (varied per-message text, not a single repeated phrase)
+    measured EXACTLY zero drift in the same harness — the failure mode
+    needs unusually repetitive content to manifest — but "always safe" is
+    not something this scheme can guarantee, so the tolerance here is an
+    empirically-bounded allowance in EITHER direction, not a one-sided
+    safety margin. A real bug (double-counted or dropped message) would
+    blow far past this bound, which is what this test exists to catch."""
     history: list = []
     advisor = _make_advisor(lambda: history)
 

--- a/tests/test_context_budget_advisor_incremental_history_tokens.py
+++ b/tests/test_context_budget_advisor_incremental_history_tokens.py
@@ -110,12 +110,17 @@ def test_growing_history_matches_from_scratch_computation() -> None:
     Exact equality isn't the right bound: subword (BPE) tokenization merges
     characters across fragment boundaries differently when a message is
     tokenized alone vs embedded in the full combined text — a few-token
-    drift per message that's inherent to any incremental/streaming token
-    estimate (not linear or unbounded; it's the SAME small per-fragment
-    noise regardless of total history size) and is harmless for a rough
-    context-budget indicator. A real bug (double-counted or dropped
-    message) would blow far past this tolerance, which is what this test
-    exists to catch."""
+    drift PER FRAGMENT that's inherent to any incremental/streaming token
+    estimate. That per-fragment drift is constant, but this test compares
+    against the CUMULATIVE sum over all messages added so far, so the
+    worst-case bound genuinely grows with message count (this tolerance is
+    intentionally linear, not a mistake) — it is NOT unbounded in practice
+    because a real session's history_fn periodically SHRINKS (compaction
+    covers the middle into a summary), which forces a full recompute and
+    re-syncs the cache from scratch; real drift is bounded by the
+    inter-compaction message count, not the whole session's lifetime. A real
+    bug (double-counted or dropped message) would blow far past even this
+    linear tolerance, which is what this test exists to catch."""
     history: list = []
     advisor = _make_advisor(lambda: history)
 
@@ -126,6 +131,51 @@ def test_growing_history_matches_from_scratch_computation() -> None:
         expected = _from_scratch_tokens(history, "openai/gpt-4o")
         tolerance = 2 * (i + 1)
         assert abs(used - expected) <= tolerance, f"diverged at step {i}: {used} vs {expected}"
+
+
+def test_same_length_but_different_content_recomputes_rather_than_stale(monkeypatch) -> None:
+    """Tier 2: falsifying — lead-coder co-vet finding on #2951. history_fn is
+    NOT a real append-only array; it's typically Session._active_branch_
+    history, a DERIVED view recomputed on every call (the same function
+    #2938 hoisted). A rewind can change WHICH messages are active such that
+    len(history) returns to a previously-cached value while the content at
+    that length is genuinely different (e.g. a message got swapped for a
+    longer one after a rewind + new branch). A length-only cache would
+    silently keep serving the stale total forever (never re-syncing until a
+    LATER length decrease) — this proves the boundary-identity check (the
+    hash of the last cached message) catches a same-length content swap."""
+    counts: dict[str, int] = {}
+
+    from reyn.services.compaction import engine as engine_mod
+
+    real = engine_mod.estimate_tokens
+
+    def _counting_estimate_tokens(text, model, *, use_chars4=False):
+        counts[text] = counts.get(text, 0) + 1
+        return real(text, model, use_chars4=use_chars4)
+
+    monkeypatch.setattr(engine_mod, "estimate_tokens", _counting_estimate_tokens)
+
+    history = [{"role": "user", "content": "original short message"}]
+    advisor = _make_advisor(lambda: history)
+
+    first = advisor.context_window_status()["free_window"]
+
+    # Same length (1), but the message at index 0 is now a DIFFERENT,
+    # much longer one — simulates a rewind that swapped the active branch's
+    # content without changing the active-message count.
+    history = [{"role": "user", "content": "a completely different and much longer replacement message " * 20}]
+    advisor._history_fn = lambda: history
+    second_status = advisor.context_window_status()
+    second = second_status["free_window"]
+
+    assert second != first, (
+        "a same-length content swap must NOT return the stale cached "
+        "free_window from the old (shorter) content"
+    )
+    used = second_status["effective_trigger"] - second
+    expected = _from_scratch_tokens(history, "openai/gpt-4o")
+    assert used == expected
 
 
 def test_shrinking_history_recomputes_rather_than_returning_stale_cache() -> None:

--- a/tests/test_context_budget_advisor_incremental_history_tokens.py
+++ b/tests/test_context_budget_advisor_incremental_history_tokens.py
@@ -114,17 +114,20 @@ def test_growing_history_matches_from_scratch_computation() -> None:
     whole thing jointly. An earlier revision of this docstring claimed this
     drift is structurally one-directional (incremental >= from-scratch,
     "only ever safe, never under") — DISPROVEN by direct measurement: a
-    growing-repeated-phrase history (this test's own fixture) makes the
-    JOINT (from-scratch) tokenization MORE efficient than the incremental
-    sum, i.e. the incremental estimate UNDER-shoots by an amount that grows
-    with message count (verified independently of comma/bracket
-    reconstruction — adding the exact missing separator punctuation to the
-    delta text does not close the gap, so it is a genuine cross-boundary
-    BPE effect, not a punctuation-accounting bug). Realistic multi-turn
-    chat content (varied per-message text, not a single repeated phrase)
-    measured EXACTLY zero drift in the same harness — the failure mode
-    needs unusually repetitive content to manifest — but "always safe" is
-    not something this scheme can guarantee, so the tolerance here is an
+    growing-repeated-phrase history (this test's own fixture) makes
+    tokenizing the pieces SEPARATELY (incremental) MORE token-efficient
+    (fewer tokens) than tokenizing the whole thing JOINTLY (from-scratch),
+    i.e. the incremental estimate UNDER-shoots the from-scratch one by an
+    amount that grows with message count — the reverse of "splitting can
+    only lose cross-boundary merges, so sum(pieces) >= whole." Verified
+    independently of comma/bracket reconstruction — adding the exact
+    missing separator punctuation to the delta text does not close the
+    gap, so this is a genuine cross-boundary BPE tokenization effect, not a
+    punctuation-accounting bug. Realistic multi-turn chat content (varied
+    per-message text, not a single repeated phrase) measured EXACTLY zero
+    drift in the same harness — the failure mode needs unusually
+    repetitive content to manifest — but "always safe" is not something
+    this scheme can guarantee, so the tolerance here is an
     empirically-bounded allowance in EITHER direction, not a one-sided
     safety margin. A real bug (double-counted or dropped message) would
     blow far past this bound, which is what this test exists to catch."""


### PR DESCRIPTION
**[tui-coder]** — part of #2940 (owner-reported, handed off via lead-coder)

## Bug

The status-chip's context dropdown calls `context_window_status()` every time it opens; `maybe_force_compact()` calls the same estimate as a pre-frame overflow guard. Both went through `ContextBudgetAdvisor._free_window_now()`, which unconditionally did `json.dumps(FULL router-view history)` + `estimate_tokens(...)` on **every single call** — no caching. Confirmed by lead-coder's issue write-up (docstring/comment claims) and independently re-verified by driving the actual call chain (chip → `_ctx_expansion.lines()` → `context_window_status` → `_free_window_now`) before touching any code, per the standing "verify before fixing, don't trust docstrings alone" lesson from #2938/#2945.

Cost grows with `len(history)` on every dropdown-open, and separately on every turn via `maybe_force_compact` — the same "re-scan everything, every call" pathology class as #2938's chat freeze (fix-class check per the recent memory-curator pin: both call sites had the identical shape, so both are fixed here, not just the one lead-coder named).

`use_chars4_estimate: true` does **not** help — it only cheapens the post-dump tokenization step; the `json.dumps` of the full history runs regardless.

## Fix

`ContextBudgetAdvisor._incremental_history_tokens()`: caches `(history length, cumulative token estimate)` keyed by `(model, use_chars4)`, invalidated by a boundary check (the json dump of the last cached message, not length alone — `history_fn` is a recomputed derived view, so a same-length content swap after rewind must not silently serve a stale total).
- History unchanged since last call → O(1) cache hit, no dump/estimate at all.
- History grew → only the NEW tail slice is dumped + estimated and added to the cached total (not a full re-dump).
- History shrank, model/config changed, or the cached prefix's boundary content differs → cache invalidated, one full recompute (never serves stale data).

Both `_free_window_now()` (used by `context_window_status`) and `maybe_force_compact()`'s inline duplicate now share this one incremental path.

## Scope — this does NOT close #2940

Co-vet (lead-coder + architect) traced the full call chain past what I'd checked: `context_budget_advisor`'s `history_fn` is actually `session.py:2124`'s `self._history_buffer.build_history`, which **itself** already does a full linear pass (`sum(estimate_tokens_for_turn(...) for m in turns)`, `router_history_buffer.py:342-345`) to check its own elide trigger, on top of `_active_branch_history`'s WAL decode (#2939's scope). This PR's cache removes the SEPARATE, redundant pass this advisor was doing on top of that (proven non-shareable by an architect measurement: `build_history`'s content-only estimator gave 21 tokens vs this advisor's JSON-envelope-inclusive estimator giving 55, on the same history — two different quantities, not one value computed twice, so there was no way to just reuse `build_history`'s discarded total).

So: **one of two linear per-call passes is removed here**; the other (inside `build_history` + `_active_branch_history`'s WAL decode) remains, and the reported freeze may still occur on very long sessions until that producer-side pass is addressed (design pending — architect is scoping which of the two divergent estimators should become authoritative). This PR is a real, measurable partial improvement, not a fix for the full reported symptom.

## Test plan

- [x] `test_context_budget_advisor_incremental_history_tokens.py` — 6 Tier 2 tests, real `ContextBudgetAdvisor` (no mocks): cache-hit is proven via a real counting spy on `estimate_tokens` (dict-keyed call counts, not a `len(...)==N` format pin — #2937's idiom), not just output-matching; falsifying-verified (fails on pre-fix code: 3 estimate calls instead of 1 for repeated unchanged-history calls); growth-vs-from-scratch correctness bound (structural, not a tolerance guess — see below); same-length content-swap (rewind) forces recompute rather than serving a stale cache (falsifying-verified against the length-only predecessor); shrink invalidates rather than serving stale cache; `maybe_force_compact` shares the same cache as `context_window_status`.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_context_budget_advisor_incremental_history_tokens.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/services/context_budget_advisor.py` — OK
- [x] Full `pytest` — 8514 passed; 9 pre-existing failures (`test_compaction_resolver_aware_1172.py`, `test_llm_request_error_1676.py`, `test_llm_router_s3b_1829.py`, `test_responses_api_routing_1678.py`) reproduce **identically with my diff stashed out on unmodified `main`** — confirmed unrelated test-order pollution, not caused by this change (cross-checked twice; independently re-confirmed by lead-coder against 3 green CI runs).

**Tier self-check**: all new tests are Tier 2 (real advisor instance + real callable spy; no private-state assertions, no mocks, no format pins).
