### PR TITLE
feat: builtin vector-store + chunker MCP servers (FP-0063 P2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,11 @@ jobs:
         #   web  — fastapi + uvicorn + websockets, used by tests/web/
         #   fs-watch — `watchdog` (#2608 H4), used by tests/test_fs_watcher.py
         #   observability — opentelemetry SDK, used by tests/observability/
-        run: pip install -e ".[dev,mcp,web,fs-watch,observability]"
+        #   builtin-rag — sqlite-vec + apsw + chonkie (FP-0063 P2), used by
+        #     tests/test_fp0063_p2_builtin_mcp_rag.py. Load-bearing: that file
+        #     `pytest.importorskip`s all three, so WITHOUT this extra the whole
+        #     module silently SKIPS and CI goes green having verified nothing.
+        run: pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]"
 
       - name: Run tests
         # --timeout=120: a per-test wall-clock cap (pytest-timeout). Without it a

--- a/docs/cookbook/configs/with-builtin-rag-mcp.yaml
+++ b/docs/cookbook/configs/with-builtin-rag-mcp.yaml
@@ -1,0 +1,50 @@
+# FP-0063 P2 -- builtin turnkey user RAG, the MCP layer.
+#
+# This entire ``mcp.servers`` block ships COMMENTED OUT / INERT. Do not
+# assume uncommenting it is safe by default: an MCP server entry, once it
+# appears under ``mcp.servers.<name>`` in ANY merged config tier, is
+# auto-granted the moment you run ``reyn pipe run`` (#2932's
+# trusted-by-configuration auto-grant -- it keys purely on the server's
+# NAME being present in the merged config, not on any "enabled" flag,
+# because no such flag exists on an MCP server entry today). That premise
+# ("the operator explicitly configured this server") only holds if YOU are
+# the one who copies this block into your own reyn.yaml and uncomments it
+# -- reyn itself never wires this in (see reyn.builtin.mcp_servers module
+# docstring). Read the two servers before enabling them: the vector-store
+# server writes to whatever sqlite file `db_path` names; the chunker server
+# reads no filesystem paths itself but the ingest pipeline that will call
+# it (a later phase, P3) reads document files from the folder you point it
+# at.
+#
+# Install the extra runtime deps first (NOT part of reyn's base install):
+#   pip install "reyn[builtin-rag]"
+#
+# Then copy this block into your reyn.yaml (or reyn.local.yaml) and
+# uncomment it:
+#
+# permissions:
+#   mcp.reyn_vector_store: allow
+#   mcp.reyn_chunker: allow
+#
+# mcp:
+#   servers:
+#     reyn_vector_store:
+#       type: stdio
+#       command: python
+#       args: ["-m", "reyn.builtin.mcp_servers.vector_store_server"]
+#       # Tools: upsert(db_path, items) / query(db_path, vector, top_k,
+#       # filters) / list_metadata(db_path, filters, limit) /
+#       # delete(db_path, ids). Every call takes db_path explicitly --
+#       # there is no server-side default; you always name the sqlite file.
+#
+#     reyn_chunker:
+#       type: stdio
+#       command: python
+#       args: ["-m", "reyn.builtin.mcp_servers.chunker_server"]
+#       # Tool: chunk(text, size=400, overlap_ratio=0.125,
+#       # min_characters_per_chunk=24). size/overlap are real parameters,
+#       # not baked-in constants -- tune them per document type.
+#
+# A third-party parser server (e.g. `uvx markitdown-mcp`, Microsoft,
+# converts txt/md/pdf/xlsx/pptx/docx -> Markdown) belongs alongside these
+# two once the ingest pipeline (P3) lands; out of scope for this file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,30 @@ web = [
 # empty extra so existing `pip install -e ".[mcp]"` invocations (CI, user docs,
 # `reyn[mcp]`) keep resolving instead of erroring on an unknown extra.
 mcp = []
+# FP-0063 P2 builtin turnkey user RAG -- the two thin builtin MCP servers in
+# `reyn.builtin.mcp_servers` (vector-store over sqlite-vec, chunker over
+# chonkie). `fastmcp` itself is already core (see above); these three are the
+# ONLY new deps this arc adds, kept extras-only so a base `pip install reyn`
+# is unaffected. Neither server is wired into the merged config by default —
+# they ship INERT (see `reyn.builtin.mcp_servers` module docstring) — so
+# installing this extra alone activates nothing.
+#   - sqlite-vec (dual MIT/Apache-2.0): pure-C SQLite extension, no bundled
+#     embedding model -> no HuggingFace-fetch hazard (FP-0057 line 55).
+#   - apsw (zlib-like "any-OSI"): sqlite-vec loads via
+#     `sqlite3.Connection.load_extension`, which the STDLIB `sqlite3` module
+#     is not guaranteed to support (e.g. this repo's own pyenv-built
+#     CPython 3.12.7 .venv has no `enable_load_extension`). apsw statically
+#     bundles its own SQLite with extension loading always enabled, so
+#     loading is portable regardless of how the host interpreter's `sqlite3`
+#     was compiled.
+#   - chonkie (MIT): recursive/semantic/etc. chunking, ~15 MiB vs LangChain's
+#     ~80 MiB; no bundled model in the default character-tokenizer path used
+#     here -> no network fetch at import or call time.
+builtin-rag = [
+    "sqlite-vec>=0.1.9",
+    "apsw>=3.51",
+    "chonkie>=1.7",
+]
 # #2608 H4: filesystem watcher external-event source (`fs_watch:` config block ->
 # `file_changed` hook). Extras-only — a build with no fs_watch config configured
 # never imports this, and a build WITH config but no extra installed degrades to

--- a/src/reyn/builtin/mcp_servers/__init__.py
+++ b/src/reyn/builtin/mcp_servers/__init__.py
@@ -1,0 +1,44 @@
+"""Builtin MCP servers (FP-0063 P2 -- builtin turnkey user RAG).
+
+Two thin bundled MCP servers that the ingest/query pipelines (P3, a later
+phase) will call as external MCP vessels -- exactly like any other
+operator-configured MCP server (FP-0057 C2: the user RAG store is EXTERNAL,
+never in-core; reyn contributes no store/chunker code path of its own,
+only these standalone scripts that happen to ship inside the reyn wheel):
+
+- :mod:`reyn.builtin.mcp_servers.vector_store_server` -- wraps
+  ``sqlite-vec`` (dual MIT/Apache-2.0, no bundled embedding model). Accepts
+  externally pre-computed vectors (FP-0057 C1: reyn is the SOLE embedder),
+  writes to a user-specified single sqlite file, and exposes generic
+  upsert/query/list/delete ops -- the ingest pipeline (not this server)
+  owns the ``content_hash`` add/update/remove diff (C5, settled at co-vet
+  in the proposal).
+- :mod:`reyn.builtin.mcp_servers.chunker_server` -- wraps ``chonkie``
+  (MIT). ``size``/``overlap`` are tool parameters with 2026-default
+  values (recursive, 256-512 tokens, 10-15% overlap), never hardcoded
+  constants, so the first thing a template-copying user wants to tune is
+  easy to find (R2/R4 in the proposal).
+
+Neither server is wired into ``reyn.builtin.registry.build_builtin_config()``
+-- doing so would make its ``mcp.servers.<name>`` key "configured" the
+instant reyn is installed, which would let ``reyn pipe run``'s
+trusted-by-configuration auto-grant (#2932) silently fire with no operator
+decision anywhere in the chain (proposal R3 / architect co-vet F-D). Both
+servers ship as pure INERT sample content instead: a commented config block
+an operator must copy into their own ``reyn.yaml`` and explicitly enable --
+see ``docs/cookbook/configs/with-builtin-rag-mcp.yaml``. This mirrors the
+precedent set for builtin skills (``force_auto_invoke_false``, "A3
+inert-ship" in ``reyn.builtin.registry``), adapted to MCP's structurally
+different inertness mechanism: an ``mcp.servers`` entry has no ``enabled``
+flag anywhere in the codebase today (#2932's auto-grant keys purely on
+dict-key presence), so absence-from-merged-config is the only inert
+posture available without inventing new core schema + auto-grant code --
+which is out of scope for this arc's "zero reyn core change" target.
+
+Both are runnable as ``python -m reyn.builtin.mcp_servers.<module>`` (stdio
+transport, via ``fastmcp`` -- already a core dependency, see
+``pyproject.toml``). The extra runtime deps they need
+(``sqlite-vec``/``apsw``/``chonkie``) live in the ``builtin-rag`` optional
+extra so a base ``pip install reyn`` is unaffected.
+"""
+from __future__ import annotations

--- a/src/reyn/builtin/mcp_servers/chunker_server.py
+++ b/src/reyn/builtin/mcp_servers/chunker_server.py
@@ -1,0 +1,110 @@
+"""Builtin chunking MCP server -- wraps ``chonkie`` (FP-0063 P2).
+
+P1 (the OSS selection spike) confirmed no chunking-ONLY MCP server exists
+-- every OSS candidate bundles chunking into a specific vector store,
+which would violate FP-0057 C2 (the user store is EXTERNAL / reyn hosts
+none of it). This thin wrapper around ``chonkie`` (MIT, ~15 MiB, 10
+chunker types vs LangChain's ~80 MiB) is therefore still "builtin
+content", not a reyn-core dependency: it ships as an independent MCP
+server the ingest pipeline (P3) calls, exactly like any other bundled
+server.
+
+**No network / no bundled model.** ``chonkie``'s default tokenizer used
+here is character-based (chonkie's own default), so this module never
+downloads anything at import or call time -- it carries none of the
+HuggingFace-fetch hazard FP-0057 line 55 recorded for the embedding
+model. (A user who opts into a HF tokenizer via chonkie's own tokenizer
+param would re-acquire that hazard themselves -- not this module's
+default path.)
+
+**``size`` and ``overlap`` are tool parameters, not constants** (proposal
+R4): the 2026 default for persistent, quality-sensitive RAG is recursive
+chunking at 256-512 tokens with 10-15% overlap -- deliberately NOT
+FP-0057 line 51's 800-1024 figure, which that doc explicitly scopes to
+"throwaway ephemeral" attachments, a different case. Defaults land at the
+midpoint (chunk_size=400, overlap_ratio=0.125) but every call can
+override both, because the builtin is a template people copy and tune --
+the first thing a user wants to change must not be the hardest to find.
+
+Overlap is implemented via chonkie's ``OverlapRefinery`` (context_size as
+a fraction of chunk_size, suffix-merged into each chunk's ``.text`` so
+consecutive chunks physically share a tail/head span) -- ``RecursiveChunker``
+itself has no overlap parameter; this is chonkie's own documented two-step
+shape (chunk, then refine), not a workaround.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def chunk_text(
+    text: str,
+    size: int = 400,
+    overlap_ratio: float = 0.125,
+    min_characters_per_chunk: int = 24,
+) -> list[dict[str, Any]]:
+    """Recursively chunk ``text`` into ``size``-token pieces with
+    ``overlap_ratio`` (fraction of ``size``) of suffix overlap between
+    consecutive chunks.
+
+    Returns an ordered list of
+    ``{"text", "token_count", "start_index", "end_index"}`` -- ``start_index``/
+    ``end_index`` are offsets into the ORIGINAL text (pre-overlap-merge),
+    letting a caller reconstruct provenance even though ``text`` itself
+    may include a merged-in overlap span.
+    """
+    from chonkie import OverlapRefinery, RecursiveChunker  # noqa: PLC0415
+
+    chunker = RecursiveChunker(
+        chunk_size=size, min_characters_per_chunk=min_characters_per_chunk,
+    )
+    chunks = chunker.chunk(text)
+    if overlap_ratio > 0 and len(chunks) > 1:
+        refinery = OverlapRefinery(context_size=overlap_ratio, method="suffix")
+        chunks = refinery.refine(chunks)
+    return [
+        {
+            "text": c.text,
+            "token_count": c.token_count,
+            "start_index": c.start_index,
+            "end_index": c.end_index,
+        }
+        for c in chunks
+    ]
+
+
+def build_server() -> Any:
+    """Build the ``FastMCP`` server exposing :func:`chunk_text` as a tool."""
+    from fastmcp import FastMCP  # noqa: PLC0415
+
+    mcp = FastMCP("reyn-builtin-chunker")
+
+    @mcp.tool
+    def chunk(
+        text: str,
+        size: int = 400,
+        overlap_ratio: float = 0.125,
+        min_characters_per_chunk: int = 24,
+    ) -> list[dict[str, Any]]:
+        """Recursively chunk text into `size`-token pieces (default 400,
+        the 256-512 2026 persistent-RAG default) with `overlap_ratio`
+        (default 0.125 = 12.5%, within the 10-15% default band) of
+        suffix overlap between consecutive chunks. Both are tunable per
+        call -- there is no hardcoded chunk size. Returns
+        [{"text", "token_count", "start_index", "end_index"}, ...]."""
+        return chunk_text(
+            text,
+            size=size,
+            overlap_ratio=overlap_ratio,
+            min_characters_per_chunk=min_characters_per_chunk,
+        )
+
+    return mcp
+
+
+def main() -> None:
+    build_server().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reyn/builtin/mcp_servers/vector_store_server.py
+++ b/src/reyn/builtin/mcp_servers/vector_store_server.py
@@ -1,0 +1,402 @@
+"""Builtin vector-store MCP server -- wraps ``sqlite-vec`` (FP-0063 P2).
+
+P1 (the OSS selection spike) found no off-the-shelf MCP vector-DB server
+that accepts externally pre-computed vectors (FP-0057 C1 -- reyn is the
+SOLE embedder; a server that embeds internally splits the vector space and
+breaks C4's "one source = one embedding model" invariant). The owner then
+approved writing this MCP surface ourselves, backed by ``sqlite-vec``
+(dual MIT/Apache-2.0 licensed, actively maintained, a pure-C SQLite
+extension with **no bundled model** -- it never downloads anything, so it
+carries none of the HuggingFace-fetch hazard FP-0057 line 55 recorded).
+
+**Portable extension loading -- a discovered, not assumed, dependency.**
+``sqlite-vec`` loads via ``sqlite3.Connection.load_extension``, but the
+stdlib ``sqlite3`` module is not guaranteed to be built with loadable-
+extension support -- e.g. this very repository's own pyenv-built
+CPython 3.12.7 ``.venv`` has ``hasattr(sqlite3.Connection,
+"enable_load_extension") is False``. Rather than fail unpredictably
+depending on the operator's Python distribution, this module uses
+``apsw`` (Another Python SQLite Wrapper, zlib-like "any-OSI" license) --
+it statically bundles its own SQLite build with extension loading always
+enabled, so ``sqlite-vec`` loads deterministically regardless of how the
+host interpreter's ``sqlite3`` module was compiled. This is reported as a
+genuine environment finding in the PR body per the task's "do not paper
+over it" instruction, not silently worked around.
+
+Five gates satisfied by construction (proposal 0063 P2 spec):
+
+1. **Pre-computed vectors** -- ``upsert`` takes a ``vector: list[float]``
+   per item; this module never computes an embedding itself.
+2. **User-specified single sqlite file** -- every tool call takes an
+   explicit ``db_path``; the schema is created lazily in that one file.
+3. **top-k + metadata filter query** -- ``query`` runs a plain SQL
+   ``WHERE`` over the metadata columns, joined against the KNN match.
+4. **Metadata passthrough** -- the ``reyn_rag_chunks`` table carries the
+   full ``ChunkMetadata`` shape (source_path/source_type/content_hash/
+   embedding_model/chunk_index/size_tokens/parent_context/extra).
+5. **Generic ops for a pipeline-owned diff** -- ``list_metadata`` (no
+   vectors, Chroma ``get(where=...)`` shape), ``upsert`` (replaces by
+   ``id``, no duplication), ``delete``. The ``content_hash`` add/update/
+   remove diff logic is deliberately NOT here -- it lives in the ingest
+   pipeline (P3), per C5 ownership settled at co-vet: keeping the server
+   generic keeps a future backend swap "re-point the MCP server", not
+   "find a server that implements our diff semantics".
+
+``SqliteVecStore`` holds the storage logic as a plain Python class so it
+can be exercised directly (no MCP transport needed) by tests; the module-
+level ``mcp = FastMCP(...)`` object below is the thin tool-call skin over
+it, run via ``python -m reyn.builtin.mcp_servers.vector_store_server``
+(stdio transport).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+# ChunkMetadata's field order (FP-0057 / ADR-0033, reyn.schemas.models).
+# Duplicated here rather than imported: this module is builtin CONTENT
+# (proposal 0063's owner framing -- "MCP means bundling standard MCP
+# servers", not reyn-core code), so it deliberately has no reyn-core
+# import dependency and can be copied wholesale by a user who wants a
+# different backend (owner: "user who wants a different vector DB copies
+# the builtin and re-points the MCP server" -- the extension mechanism).
+METADATA_COLUMNS: tuple[str, ...] = (
+    "source_path",
+    "source_type",
+    "content_hash",
+    "embedding_model",
+    "chunk_index",
+    "size_tokens",
+    "parent_context",
+)
+
+
+class VectorDimensionMismatchError(ValueError):
+    """Raised when an upserted vector's length doesn't match the store's
+    established dimension (fixed at the first upsert into a fresh db)."""
+
+
+class SqliteVecStore:
+    """Thin generic vector store over one sqlite file, backed by
+    ``sqlite-vec`` loaded through ``apsw`` (see module docstring for why
+    apsw, not stdlib ``sqlite3``).
+
+    One instance == one open connection to one ``db_path``. Callers
+    (the MCP tool functions below, or a test) construct one per call
+    and close it -- these stores are opened by a user-named file path
+    that can be anywhere, so no connection pooling / caching is done
+    (this is "builtin content", not a service; simplicity over
+    performance is the deliberate trade-off, matching R2 readability).
+    """
+
+    def __init__(self, db_path: str) -> None:
+        import apsw  # noqa: PLC0415 -- optional extra (builtin-rag)
+        import sqlite_vec  # noqa: PLC0415 -- optional extra (builtin-rag)
+
+        self._db_path = db_path
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = apsw.Connection(db_path)
+        self._conn.enable_load_extension(True)
+        self._conn.load_extension(sqlite_vec.loadable_path())
+        self._conn.enable_load_extension(False)
+        self._ensure_schema()
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> "SqliteVecStore":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- schema -------------------------------------------------------
+
+    def _ensure_schema(self) -> None:
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS reyn_rag_chunks (
+                rag_id TEXT UNIQUE NOT NULL,
+                source_path TEXT NOT NULL,
+                source_type TEXT NOT NULL DEFAULT 'generic',
+                content_hash TEXT NOT NULL,
+                embedding_model TEXT NOT NULL,
+                chunk_index INTEGER NOT NULL DEFAULT 0,
+                size_tokens INTEGER NOT NULL DEFAULT 0,
+                parent_context TEXT,
+                extra TEXT NOT NULL DEFAULT '{}'
+            )
+            """
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS reyn_rag_config (dim INTEGER NOT NULL)"
+        )
+
+    def _dim(self) -> int | None:
+        row = self._conn.execute("SELECT dim FROM reyn_rag_config").fetchone()
+        return int(row[0]) if row else None
+
+    def _ensure_vec_table(self, dim: int) -> None:
+        existing = self._dim()
+        if existing is None:
+            self._conn.execute(
+                "INSERT INTO reyn_rag_config(dim) VALUES (?)", (dim,)
+            )
+            self._conn.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS reyn_rag_vectors "
+                f"USING vec0(embedding float[{dim}])"
+            )
+        elif existing != dim:
+            raise VectorDimensionMismatchError(
+                f"store {self._db_path!r} was initialized with dim={existing}; "
+                f"got a vector of dim={dim}. One sqlite file holds one "
+                "embedding-vector-space (FP-0057 C4: different model -> "
+                "different source/store)."
+            )
+
+    # -- ops ------------------------------------------------------------
+
+    def upsert(self, items: list[dict[str, Any]]) -> int:
+        """Insert or replace each item (keyed by ``id``). Returns the count
+        upserted. Replaces rather than duplicates: an existing ``id`` is
+        deleted (both tables) before the new row lands.
+        """
+        import sqlite_vec  # noqa: PLC0415
+
+        count = 0
+        for item in items:
+            rag_id = item["id"]
+            vector = item["vector"]
+            metadata = item.get("metadata") or {}
+            self._ensure_vec_table(len(vector))
+            self._delete_one(rag_id)
+            extra = metadata.get("extra") or {}
+            self._conn.execute(
+                """
+                INSERT INTO reyn_rag_chunks
+                    (rag_id, source_path, source_type, content_hash,
+                     embedding_model, chunk_index, size_tokens,
+                     parent_context, extra)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    rag_id,
+                    metadata.get("source_path", ""),
+                    metadata.get("source_type", "generic"),
+                    metadata.get("content_hash", ""),
+                    metadata.get("embedding_model", ""),
+                    int(metadata.get("chunk_index", 0)),
+                    int(metadata.get("size_tokens", 0)),
+                    metadata.get("parent_context"),
+                    json.dumps(extra),
+                ),
+            )
+            new_rowid = self._conn.last_insert_rowid()
+            self._conn.execute(
+                "INSERT INTO reyn_rag_vectors(rowid, embedding) VALUES (?, ?)",
+                (new_rowid, sqlite_vec.serialize_float32(list(vector))),
+            )
+            count += 1
+        return count
+
+    def _delete_one(self, rag_id: str) -> None:
+        row = self._conn.execute(
+            "SELECT rowid FROM reyn_rag_chunks WHERE rag_id = ?", (rag_id,)
+        ).fetchone()
+        if row is None:
+            return
+        rowid = row[0]
+        self._conn.execute("DELETE FROM reyn_rag_chunks WHERE rowid = ?", (rowid,))
+        # The vec0 virtual table may not exist yet if this id was never
+        # actually vectorized (defensive; upsert always creates it first).
+        if self._dim() is not None:
+            self._conn.execute(
+                "DELETE FROM reyn_rag_vectors WHERE rowid = ?", (rowid,)
+            )
+
+    def delete(self, ids: list[str]) -> int:
+        """Delete each id from both tables. Returns the count actually
+        deleted (ids that don't exist are silently skipped)."""
+        deleted = 0
+        for rag_id in ids:
+            row = self._conn.execute(
+                "SELECT rowid FROM reyn_rag_chunks WHERE rag_id = ?", (rag_id,)
+            ).fetchone()
+            if row is None:
+                continue
+            self._delete_one(rag_id)
+            deleted += 1
+        return deleted
+
+    @staticmethod
+    def _row_to_metadata(row: tuple, columns: tuple[str, ...]) -> dict[str, Any]:
+        meta: dict[str, Any] = {}
+        for col, val in zip(columns, row, strict=True):
+            if col == "extra":
+                meta["extra"] = json.loads(val) if val else {}
+            else:
+                meta[col] = val
+        return meta
+
+    def _build_filter_clause(
+        self, filters: dict[str, Any] | None, *, alias: str = "",
+    ) -> tuple[str, list[Any]]:
+        if not filters:
+            return "", []
+        prefix = f"{alias}." if alias else ""
+        clauses: list[str] = []
+        params: list[Any] = []
+        for key, value in filters.items():
+            if key not in METADATA_COLUMNS:
+                raise ValueError(
+                    f"unsupported filter key {key!r}; must be one of "
+                    f"{METADATA_COLUMNS} (plain-SQL-WHERE metadata filtering "
+                    "only -- 'extra' is a JSON blob and not filterable here)"
+                )
+            clauses.append(f"{prefix}{key} = ?")
+            params.append(value)
+        return " AND " + " AND ".join(clauses), params
+
+    def list_metadata(
+        self, filters: dict[str, Any] | None = None, limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Metadata-filtered listing WITHOUT vectors (Chroma
+        ``get(where=...)`` shape) -- the generic op the pipeline's
+        content_hash diff (C5) reads from."""
+        where, params = self._build_filter_clause(filters)
+        columns = ("rag_id", *METADATA_COLUMNS, "extra")
+        sql = (
+            f"SELECT {', '.join(columns)} FROM reyn_rag_chunks WHERE 1=1{where} "
+            f"LIMIT ?"
+        )
+        rows = self._conn.execute(sql, (*params, limit)).fetchall()
+        out = []
+        for row in rows:
+            rag_id = row[0]
+            meta = self._row_to_metadata(row[1:], (*METADATA_COLUMNS, "extra"))
+            out.append({"id": rag_id, "metadata": meta})
+        return out
+
+    def query(
+        self,
+        vector: list[float],
+        top_k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """top-k nearest-neighbor query with an optional plain-SQL metadata
+        WHERE filter. Returns ``[{"id", "distance", "metadata"}, ...]``
+        ordered nearest-first.
+
+        The KNN ``k`` bound is set to the store's total row count (not
+        ``top_k``) so the metadata filter is applied to the FULL
+        candidate set before truncating to ``top_k`` -- otherwise a
+        vec0 ``k=top_k`` clause could exclude a matching row before the
+        ``WHERE`` filter ever sees it. This module targets a personal/
+        folder-scale RAG store, where a full KNN scan is cheap; a future
+        backend swap free to reintroduce a real ANN index.
+        """
+        import sqlite_vec  # noqa: PLC0415
+
+        dim = self._dim()
+        if dim is None:
+            return []
+        if len(vector) != dim:
+            raise VectorDimensionMismatchError(
+                f"query vector has dim={len(vector)}; store dim={dim}"
+            )
+        total = self._conn.execute(
+            "SELECT COUNT(*) FROM reyn_rag_vectors"
+        ).fetchone()[0]
+        if total == 0:
+            return []
+        where, params = self._build_filter_clause(filters, alias="c")
+        columns = ("c.rag_id", *(f"c.{c}" for c in METADATA_COLUMNS), "c.extra")
+        sql = (
+            f"SELECT {', '.join(columns)}, v.distance "
+            "FROM reyn_rag_vectors v "
+            "JOIN reyn_rag_chunks c ON c.rowid = v.rowid "
+            f"WHERE v.embedding MATCH ? AND k = ?{where} "
+            "ORDER BY v.distance LIMIT ?"
+        )
+        rows = self._conn.execute(
+            sql,
+            (sqlite_vec.serialize_float32(list(vector)), total, *params, top_k),
+        ).fetchall()
+        out = []
+        for row in rows:
+            rag_id = row[0]
+            meta = self._row_to_metadata(row[1:-1], (*METADATA_COLUMNS, "extra"))
+            distance = row[-1]
+            out.append({"id": rag_id, "distance": distance, "metadata": meta})
+        return out
+
+
+# ---------------------------------------------------------------------------
+# MCP tool skin (fastmcp). Imports are deferred to server construction so
+# this module remains importable (for the ``SqliteVecStore`` class above)
+# in environments without fastmcp/apsw/sqlite-vec/chonkie installed.
+# ---------------------------------------------------------------------------
+
+
+def build_server() -> Any:
+    """Build the ``FastMCP`` server exposing ``SqliteVecStore`` as tools."""
+    from fastmcp import FastMCP  # noqa: PLC0415
+
+    mcp = FastMCP("reyn-builtin-vector-store")
+
+    @mcp.tool
+    def upsert(db_path: str, items: list[dict[str, Any]]) -> dict[str, Any]:
+        """Insert or replace vector+metadata items in the sqlite-vec store
+        at db_path. Each item: {"id": str, "vector": list[float],
+        "metadata": {source_path, source_type, content_hash,
+        embedding_model, chunk_index, size_tokens, parent_context, extra}}.
+        An existing id is replaced (never duplicated)."""
+        with SqliteVecStore(db_path) as store:
+            n = store.upsert(items)
+        return {"upserted": n}
+
+    @mcp.tool
+    def query(
+        db_path: str,
+        vector: list[float],
+        top_k: int = 5,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """top-k nearest-neighbor query against db_path, with an optional
+        plain-SQL equality filter over ChunkMetadata columns (source_path,
+        source_type, content_hash, embedding_model, chunk_index,
+        size_tokens, parent_context). Returns nearest-first
+        [{"id", "distance", "metadata"}, ...]."""
+        with SqliteVecStore(db_path) as store:
+            return store.query(vector, top_k=top_k, filters=filters)
+
+    @mcp.tool
+    def list_metadata(
+        db_path: str,
+        filters: dict[str, Any] | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Metadata-filtered listing WITHOUT vectors (Chroma
+        get(where=...) shape) -- for a pipeline-owned content_hash diff.
+        Returns [{"id", "metadata"}, ...]."""
+        with SqliteVecStore(db_path) as store:
+            return store.list_metadata(filters=filters, limit=limit)
+
+    @mcp.tool
+    def delete(db_path: str, ids: list[str]) -> dict[str, Any]:
+        """Delete the given ids from db_path (both metadata and vector
+        tables). Returns {"deleted": count}; unknown ids are skipped."""
+        with SqliteVecStore(db_path) as store:
+            n = store.delete(ids)
+        return {"deleted": n}
+
+    return mcp
+
+
+def main() -> None:
+    build_server().run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fp0063_p2_builtin_mcp_rag.py
+++ b/tests/test_fp0063_p2_builtin_mcp_rag.py
@@ -1,0 +1,268 @@
+"""Tier 2b: subsystem invariant -- FP-0063 P2, the two builtin MCP servers
+(``reyn.builtin.mcp_servers.vector_store_server`` / ``chunker_server``),
+docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md.
+
+Pins the five vector-store gates + the chunker size/overlap-is-a-parameter
+contract, using REAL ``apsw`` + real ``sqlite-vec`` + real ``chonkie``
+instances throughout (``pytest.importorskip`` guards the whole module: the
+``builtin-rag`` extra is optional, a base install must not fail collection).
+No mocks anywhere -- every assertion drives the actual ``SqliteVecStore`` /
+``chunk_text`` call path, per testing policy.
+
+Coverage:
+  1. Pre-computed-vector round trip: store -> query -> the SAME vector's
+     metadata comes back nearest (gate 1+4).
+  2. User-specified sqlite path: the db file lands at the exact path passed
+     in, including creating missing parent directories (gate 2).
+  3. Metadata-filtered listing returns metadata WITHOUT vectors (gate 5,
+     Chroma ``get(where=...)`` shape) -- strip-falsified below (#4).
+  4. STRIP-FALSIFICATION: removing the ``list_metadata`` column-restriction
+     (simulated by calling the SELECT with ``*`` including the embedding
+     join) would leak vector data; the real implementation's dict keys are
+     asserted to exclude "vector"/"embedding" -- and a broken variant that
+     forgets the restriction is shown RED to prove the assertion is live
+     (not vacuously true).
+  5. Upsert replaces rather than duplicates (same id, new vector -> row
+     count unchanged, new vector wins the query).
+  6. Delete removes (gate 5) and is a no-op for unknown ids.
+  7. Top-k + a plain-SQL metadata filter narrows results (gate 3).
+  8. Chunker: ``size``/``overlap_ratio`` are real parameters with real
+     effect on the output (R4) -- smaller size -> more chunks; higher
+     overlap -> larger merged chunk token counts. Defaults hit the
+     256-512-token 2026 band.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+apsw = pytest.importorskip(
+    "apsw", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+sqlite_vec = pytest.importorskip(
+    "sqlite_vec", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+pytest.importorskip(
+    "chonkie", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+
+from reyn.builtin.mcp_servers.chunker_server import chunk_text  # noqa: E402
+from reyn.builtin.mcp_servers.vector_store_server import (  # noqa: E402
+    METADATA_COLUMNS,
+    SqliteVecStore,
+    VectorDimensionMismatchError,
+)
+
+
+def _sample_metadata(**overrides) -> dict:
+    base = {
+        "source_path": "docs/intro.md",
+        "source_type": "doc",
+        "content_hash": "hash-a",
+        "embedding_model": "text-embedding-3-small",
+        "chunk_index": 0,
+        "size_tokens": 42,
+        "parent_context": "Introduction",
+        "extra": {"lang": "en"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_precomputed_vector_round_trip(tmp_path: Path) -> None:
+    """Tier 2b: Gate 1+4: a caller-supplied vector + full ChunkMetadata shape survive
+    store -> query, and the query for that exact vector returns it nearest
+    with metadata intact (source_path/source_type/content_hash/
+    embedding_model/chunk_index/size_tokens/parent_context/extra)."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([
+            {"id": "c1", "vector": [1.0, 0.0, 0.0], "metadata": _sample_metadata()},
+            {"id": "c2", "vector": [0.0, 1.0, 0.0], "metadata": _sample_metadata(
+                source_path="docs/other.md", content_hash="hash-b",
+            )},
+        ])
+        results = store.query([1.0, 0.0, 0.0], top_k=2)
+
+    assert results[0]["id"] == "c1"
+    assert results[0]["distance"] == pytest.approx(0.0, abs=1e-6)
+    meta = results[0]["metadata"]
+    assert meta["source_path"] == "docs/intro.md"
+    assert meta["source_type"] == "doc"
+    assert meta["content_hash"] == "hash-a"
+    assert meta["embedding_model"] == "text-embedding-3-small"
+    assert meta["chunk_index"] == 0
+    assert meta["size_tokens"] == 42
+    assert meta["parent_context"] == "Introduction"
+    assert meta["extra"] == {"lang": "en"}
+
+
+def test_db_lands_at_user_specified_path_incl_missing_parents(tmp_path: Path) -> None:
+    """Tier 2b: Gate 2: the sqlite file is created at the EXACT path passed by the
+    caller, including creating a missing parent directory -- mirrors the
+    owner's "output file name specified" requirement."""
+    db_path = tmp_path / "nested" / "sub" / "my_project.sqlite"
+    assert not db_path.parent.exists()
+    with SqliteVecStore(str(db_path)) as store:
+        store.upsert([{"id": "c1", "vector": [1.0], "metadata": _sample_metadata()}])
+    assert db_path.is_file()
+    # Real sqlite file: openable independently via stdlib sqlite3 (a distinct
+    # connection than the one the store held), proving it's a genuine
+    # on-disk sqlite db and not merely a placeholder.
+    conn = sqlite3.connect(str(db_path))
+    tables = {
+        row[0]
+        for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    conn.close()
+    assert "reyn_rag_chunks" in tables
+
+
+def test_list_metadata_excludes_vectors(tmp_path: Path) -> None:
+    """Tier 2b: Gate 5: metadata-filtered listing returns metadata WITHOUT vectors."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([{"id": "c1", "vector": [1.0, 2.0, 3.0], "metadata": _sample_metadata()}])
+        listed = store.list_metadata()
+
+    assert [e["id"] for e in listed] == ["c1"]
+    entry = listed[0]
+    assert entry["id"] == "c1"
+    assert "vector" not in entry
+    assert "vector" not in entry["metadata"]
+    assert "embedding" not in entry["metadata"]
+    assert set(entry["metadata"]) == set(METADATA_COLUMNS) | {"extra"}
+
+
+def test_strip_falsify_list_metadata_would_leak_vectors_if_joined(tmp_path: Path) -> None:
+    """Tier 2b: STRIP-FALSIFICATION -- show the RED that would
+    result if ``list_metadata`` joined the vector table instead of reading
+    only ``reyn_rag_chunks``. We don't monkeypatch production code (no
+    mocks/patches allowed) -- instead we reproduce the broken query
+    ourselves against the SAME real db/schema the store created, proving
+    the real implementation's column restriction is load-bearing rather
+    than vacuously true (i.e. the vector data really is sitting right next
+    to the metadata columns and a naive listing WOULD surface it)."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([{"id": "c1", "vector": [1.0, 2.0, 3.0], "metadata": _sample_metadata()}])
+        good = store.list_metadata()
+        assert "vector" not in good[0]["metadata"]  # GREEN: real implementation
+
+    # The "broken variant": a naive listing that also selects the raw
+    # vector blob via the same rowid join the store's own `query()` uses
+    # internally. This opens a SEPARATE, independent connection to the
+    # SAME on-disk file (public surface only -- no reach into the store's
+    # internals) purely to PROVE the vector bytes are retrievable at all
+    # in this schema, i.e. that list_metadata's vector-exclusion is a
+    # deliberate choice guarding real data, not an accident of the data
+    # not being there.
+    probe = apsw.Connection(db_path)
+    probe.enable_load_extension(True)
+    probe.load_extension(sqlite_vec.loadable_path())
+    probe.enable_load_extension(False)
+    row = probe.execute(
+        "SELECT v.embedding FROM reyn_rag_vectors v "
+        "JOIN reyn_rag_chunks c ON c.rowid = v.rowid WHERE c.rag_id = ?",
+        ("c1",),
+    ).fetchone()
+    probe.close()
+    assert row is not None and row[0] is not None, (
+        "RED (expected if this fails): the broken naive-join query returned "
+        "no vector bytes, meaning the leak this test guards against isn't "
+        "reachable in this schema -- list_metadata's vector-exclusion would "
+        "then be vacuous rather than a real gate."
+    )
+
+
+def test_upsert_replaces_not_duplicates(tmp_path: Path) -> None:
+    """Tier 2b: same id, new vector+metadata -> no duplicate row is
+    created and the NEW vector wins subsequent queries."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([{"id": "c1", "vector": [1.0, 0.0], "metadata": _sample_metadata(content_hash="v1")}])
+        store.upsert([{"id": "c1", "vector": [0.0, 1.0], "metadata": _sample_metadata(content_hash="v2")}])
+        listed = store.list_metadata()
+        results = store.query([0.0, 1.0], top_k=5)
+
+    assert [e["id"] for e in listed] == ["c1"]
+    assert listed[0]["metadata"]["content_hash"] == "v2"
+    assert [r["id"] for r in results] == ["c1"]
+    assert results[0]["distance"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_delete_removes_and_is_noop_for_unknown_id(tmp_path: Path) -> None:
+    """Tier 2b: Gate 5: delete removes an existing id; an unknown id is skipped
+    (no error, ``deleted`` count reflects only real removals)."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([
+            {"id": "c1", "vector": [1.0], "metadata": _sample_metadata()},
+            {"id": "c2", "vector": [2.0], "metadata": _sample_metadata()},
+        ])
+        deleted = store.delete(["c1", "does-not-exist"])
+        remaining = store.list_metadata()
+
+    assert deleted == 1
+    assert [entry["id"] for entry in remaining] == ["c2"]
+
+
+def test_topk_with_metadata_filter(tmp_path: Path) -> None:
+    """Tier 2b: Gate 3: top-k + a plain-SQL equality metadata filter narrows the
+    candidate set even when an unfiltered top-k would include a nearer
+    non-matching row."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([
+            {"id": "near-wrong-source", "vector": [1.0, 0.0], "metadata": _sample_metadata(source_path="wrong.md")},
+            {"id": "far-right-source", "vector": [0.0, 1.0], "metadata": _sample_metadata(source_path="right.md")},
+        ])
+        unfiltered = store.query([1.0, 0.0], top_k=1)
+        filtered = store.query([1.0, 0.0], top_k=1, filters={"source_path": "right.md"})
+
+    assert unfiltered[0]["id"] == "near-wrong-source"
+    assert filtered[0]["id"] == "far-right-source"
+
+
+def test_dimension_mismatch_raises(tmp_path: Path) -> None:
+    """Tier 2b: C4 guard -- a store's vector dimension is fixed at first upsert; a
+    later vector of a different dimension is rejected rather than silently
+    corrupting the vec0 table."""
+    db_path = str(tmp_path / "rag.sqlite")
+    with SqliteVecStore(db_path) as store:
+        store.upsert([{"id": "c1", "vector": [1.0, 2.0, 3.0], "metadata": _sample_metadata()}])
+        with pytest.raises(VectorDimensionMismatchError):
+            store.upsert([{"id": "c2", "vector": [1.0, 2.0], "metadata": _sample_metadata()}])
+
+
+def test_chunker_size_and_overlap_are_real_parameters() -> None:
+    """Tier 2b: R4 -- size/overlap are tool parameters with real effect, not baked-in
+    constants -- smaller size yields more chunks; nonzero overlap yields
+    larger (suffix-merged) token counts on non-final chunks."""
+    text = "".join(f"Sentence number {i} continues the document. " for i in range(400))
+
+    small_chunks = chunk_text(text, size=32, overlap_ratio=0.0)
+    big_chunks = chunk_text(text, size=128, overlap_ratio=0.0)
+    assert len(small_chunks) > len(big_chunks)
+
+    no_overlap = chunk_text(text, size=64, overlap_ratio=0.0)
+    with_overlap = chunk_text(text, size=64, overlap_ratio=0.25)
+    assert with_overlap[1]["token_count"] > no_overlap[1]["token_count"]
+
+
+def test_chunker_default_lands_in_2026_persistent_rag_band() -> None:
+    """Tier 2b: R4/co-vet #3 -- the DEFAULT size (no override) is the 256-512-token
+    persistent-RAG band, not FP-0057 line 51's 800-1024 ephemeral-attachment
+    figure."""
+    text = "".join(f"Sentence number {i} continues the document. " for i in range(400))
+    chunks = chunk_text(text)  # defaults only
+    # Every non-final chunk should be close to the 256-512 band (chonkie's
+    # recursive splitter respects sentence boundaries so exact equality to
+    # `size` isn't guaranteed, but it must not silently reproduce the
+    # 800-1024 ephemeral figure).
+    assert all(c["token_count"] <= 512 for c in chunks[:-1])

--- a/uv.lock
+++ b/uv.lock
@@ -204,6 +204,81 @@ wheels = [
 ]
 
 [[package]]
+name = "apsw"
+version = "3.53.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/2a/ec1dfda955cda4b8d77b076553b87d428315bd3a17ea4286aa9dc40901fe/apsw-3.53.3.1.tar.gz", hash = "sha256:7684d24e77dc9e3b301ee5374a8a9501ad8a85b821ce85391260a2448dd02323", size = 1243718, upload-time = "2026-07-10T16:32:23.409Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/61/41a09f915d2f8c8c8dd9925a45c130fa1213eaf74a0f555969d275042e93/apsw-3.53.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0d9bf61d7abdd17bee3774d2cc2c07544bf04fffe8fee662e1c73598ed9de90b", size = 3272489, upload-time = "2026-07-10T16:30:31.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/63/5beba60f3bf645fbeb2aaa9cc1bf023f8651f13be24f2416d23b24594bbb/apsw-3.53.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:553ebc04cceb59ccaf8f601aeb9179ea0d55f8df29225c21442d2a762b50abf1", size = 3068584, upload-time = "2026-07-10T16:30:33.328Z" },
+    { url = "https://files.pythonhosted.org/packages/af/db/245915afaa48e80e8d7d5d116f6beacf502712da98cfd008fbb17ba26496/apsw-3.53.3.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:9a6fa83a0a8b01799b4ea42dc9940fc6821524c662fb926fe495e5004cec2b6d", size = 3489603, upload-time = "2026-07-10T16:30:35.047Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f9/b04381832f56a27251fb0175172dc642bdf9cdc7f7f7e6ba62a68bc1e2a5/apsw-3.53.3.1-cp311-cp311-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:124fe7789ecec7149752c5e98ea0f5d63bc8c08d41faafbda400c240375b57f0", size = 3272699, upload-time = "2026-07-10T16:30:36.496Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1b/a47ec9ae1c353e348e5781a3e6c13de25114654a2664929dfdf4ce7c8ed2/apsw-3.53.3.1-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:c2f911bdb5a827d5d65d6f3e506d6fab55ca2bbc1969cbdfb0bff17d3c936847", size = 3888998, upload-time = "2026-07-10T16:30:38.164Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b2/37307c4c4f6130ee093db97191d1139d1280e4094f3168727820ee8ff59b/apsw-3.53.3.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:f9135c7bc6bb2043375fb50503edc175ac11c6fbf4de25ede5807d928378129f", size = 3648680, upload-time = "2026-07-10T16:30:40.568Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c9/74bd2bc85448ed16a26f189d7f02098f3cc3aa2de9d7bc21e40c85129693/apsw-3.53.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3bea5d8a4fbd407c914fab0af6fc0a103a0b71f7f1c16a3d050487af90ee7edd", size = 3497886, upload-time = "2026-07-10T16:30:42.04Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b8/1c7b76779f3b64b896b37517249beffe164423f1c4ad667bf7b891731a5a/apsw-3.53.3.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:742edd743b03f6da4d08186d501507dc781013f9ec04c32216e3c1eb0e36a487", size = 3278323, upload-time = "2026-07-10T16:30:43.67Z" },
+    { url = "https://files.pythonhosted.org/packages/12/68/13f1500cb77f5c093318bb1ec584c28c57d0672458903aed3669f589f9c4/apsw-3.53.3.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a8d9e38cb95e486f3f4e5ba43c632d5bd2d8a3c12c3fe9565c9dd15760f1e07c", size = 3907721, upload-time = "2026-07-10T16:30:45.095Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/8821b636403862ed9f7292c40ecb426b3e9463c66ca4ac8affb468bc453b/apsw-3.53.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:93bcee0bf0142abb552fc0ef4e8e2e634a0d98546af9457b2c7b0e71d65e0f3e", size = 3655451, upload-time = "2026-07-10T16:30:46.632Z" },
+    { url = "https://files.pythonhosted.org/packages/25/32/d997f782d10327a4a48b41238abdfb2dad23053a56ba7e55cf3cc88db5ea/apsw-3.53.3.1-cp311-cp311-win32.whl", hash = "sha256:c36a0bf7823e53db4118bf7dfe39d363503ceb508cf601062fe91e6268c004e5", size = 2868741, upload-time = "2026-07-10T16:30:48.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/76/9e078db7f3d8b7a6790749155804f95ecf00f1450c315af7b031a27c6ea4/apsw-3.53.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:203c133e0435ad69066f8920b91d93b5ad20afa60814ccfa20bdffdd317a2c1c", size = 3260499, upload-time = "2026-07-10T16:30:49.825Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e0/47c13c66d727556109a3569f0a8bcad0e86caea7a2e9a2bf79a2f0b29347/apsw-3.53.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:4a7e0ba1ec942a11edc1b03447832a5ad3332d32ac4e8635ca7d98a07722b6f2", size = 2868160, upload-time = "2026-07-10T16:30:51.274Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ea/06e2f4372166990955822b9967d9f6342de37f66f632b629b5a906b8bfa2/apsw-3.53.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:dbe5f966fbd2811caba537917ddc5cda00710eb8bf6e2d84ba993cc5b775a68e", size = 3271540, upload-time = "2026-07-10T16:30:52.839Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a0/7102083831244c08e08e1806caf167eac6439ac56bca0453406604896814/apsw-3.53.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d0561fe85559c32ca0bf4ec8d51289c4300dc79788da492f82325729a8e50ef", size = 3067549, upload-time = "2026-07-10T16:30:54.861Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/0c3a6a0b0655158793a7ef855f4f6e9d076fea939322b4e66968c426e242/apsw-3.53.3.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2ccaad934046a63820f1bb3748d9f0889252aaad47c17022b57599f1d3ca24c3", size = 3480346, upload-time = "2026-07-10T16:30:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ac/e11a39fe22b175fef3018f6f68eb282e092b8c48a0976f8b535132a7ed4e/apsw-3.53.3.1-cp312-cp312-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0f72e269032c9e66c2b86c2a68a524d54e5942d220ddf0e15c1363541be5cb3f", size = 3267797, upload-time = "2026-07-10T16:30:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7b/790161e710f53fe1dfb8ae46b75b8862cf54447c4058b92382b9b94c9ded/apsw-3.53.3.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:d4a1211c154e7228254ea5f338d7efaf434c404975a64e746b10a83e35a775b3", size = 3879964, upload-time = "2026-07-10T16:30:59.512Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/10dad311137cc6483b52a727c5556684b9d104d6c2f1642a18709e79a101/apsw-3.53.3.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7c5d4f736dcf9fe02c31fb3ce5d99268316537f1f808641ea09efa1b55bf1c2f", size = 3636959, upload-time = "2026-07-10T16:31:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/82/29/4de0214db032b820d3df1c241c10f8f0f3e5633cff8f49d2e6249dc812b9/apsw-3.53.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c914f72fff9e9eee5363437e8c6830584463763d388d73315aedaf0a697162c", size = 3491023, upload-time = "2026-07-10T16:31:02.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c9/2cfd4703f976c59b12a0ae56ab2988b26d01de1d2be483f6bdc4a7c81381/apsw-3.53.3.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8ff249ef948f696793f9e90c1f056181db670b116522c0257b313fa1f14bc3e6", size = 3276654, upload-time = "2026-07-10T16:31:04.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/14/c40f06a51835ed2630cbd93c109768590af369761c054dfe92b606145dc2/apsw-3.53.3.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:2850122468691840f4165e87e922dd2d0df93abaa446fc53fd4e79e575a5b655", size = 3896547, upload-time = "2026-07-10T16:31:06.084Z" },
+    { url = "https://files.pythonhosted.org/packages/11/69/aa792d1d15dbf18b7aed1cd596e6d226428093978a7f463dddb920ce51b7/apsw-3.53.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dfc32208563f9cef924a222011598b80ab4b50f326cac26ea79017d8d3cde48c", size = 3647566, upload-time = "2026-07-10T16:31:07.914Z" },
+    { url = "https://files.pythonhosted.org/packages/89/45/860ee931ca14100770ef8202b8879919447256f97c8ec5e698e49a789774/apsw-3.53.3.1-cp312-cp312-win32.whl", hash = "sha256:b4f41bf8436c3b45e3c65b97a24df7328dae461b5fa580f16479cc8584a73472", size = 2868462, upload-time = "2026-07-10T16:31:09.34Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/58/dbc435be6e29d5f480ae5313d18ecf5530f9f14c06ec84fa8ad1b866adcc/apsw-3.53.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:9d398575194c5856c2543be29366c53044b920b46cfa0554130ca3e06428f515", size = 3258006, upload-time = "2026-07-10T16:31:11.274Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7b/0de118dc9ec3eee0c672b43f4332893565fe61bfb73c1725f2691f20bc77/apsw-3.53.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:9bea63b524cfa3df2905d64e0a68c81d1bee4664e8034ef937ab0fc5bc541910", size = 2867313, upload-time = "2026-07-10T16:31:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a8/3377ef31ac0d94b5efd22a97ae9e558b0b6f440d573b2921947f9613b7ca/apsw-3.53.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:571ed8ebddcf5bbf5c8bd85b62463f4e21f5fee6a86bc4b0df0fececbd97247e", size = 3269180, upload-time = "2026-07-10T16:31:14.353Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/505319294530cd2db21b962c6699e3909776250629a4695a50cac365b5c9/apsw-3.53.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:db98126fccdedaf91e521a86ada3703f2a66d0ed4a6af727a8ddeb5b3e76db0d", size = 3064651, upload-time = "2026-07-10T16:31:16.02Z" },
+    { url = "https://files.pythonhosted.org/packages/72/93/d4194de9e617bad8e2c9ee0b2f86d745f08160c6d2734a20e85217856a5c/apsw-3.53.3.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0dc15a658720094b35485f7deaceae4fe35acf1b71f84ed1b032182efad83332", size = 3480557, upload-time = "2026-07-10T16:31:17.528Z" },
+    { url = "https://files.pythonhosted.org/packages/40/d8/0b8c889219ec2d896a7f8e971bec670971608cff2d9d30088e970b90197f/apsw-3.53.3.1-cp313-cp313-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:33a3e077d0a884c14bee1888bb6765e1ce47e4b15aea7aa93e1413fa4612b9fb", size = 3269990, upload-time = "2026-07-10T16:31:19.169Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/fe/3a56dafc58542da094459ca31a9854fae29812e473b6eb362140ee428490/apsw-3.53.3.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:1843e7d0cf9f295eb814901af4ffede94331cbe976475f11975d6bab9b2253d0", size = 3873656, upload-time = "2026-07-10T16:31:20.799Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/bf/c78c0027998b676dbca06d0fe2d84e55cf4966f476cae22b2f7dd1ba38dc/apsw-3.53.3.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:396d6714df126fa8b8f615b10a3c6555a57d3ff7dba20a93dad27ae9c54ac3cb", size = 3642668, upload-time = "2026-07-10T16:31:22.445Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/f6/1bd97edbd78188be680a6e77850978fe76b790e3aabacf77b5d2c609b8c2/apsw-3.53.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:51eaf30e55565841757d2e0ec126b7891659a58dc24540f081b9370e20b3d50d", size = 3488793, upload-time = "2026-07-10T16:31:24.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/72/50e8e8e5b5d3ea2ee212827005cf541bab52d3b0b71144f00eff7ca3e5fe/apsw-3.53.3.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:095d16ccafe168056c1560ef22ab0554126ef60319ac66f033486c2d0b9e52a5", size = 3278993, upload-time = "2026-07-10T16:31:25.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ef/e7e486aa107732140fa04fb520fc344d680b5668908a1d3a2c2a1521a744/apsw-3.53.3.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:9c3a4ad302992dcbcda3ac15fed72aedd50263d44b649fb5088bd4c95c16c589", size = 3892083, upload-time = "2026-07-10T16:31:27.017Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d8/b924d1e5e3166a882ccea169f521fa65bed6c566bd6bba094fe3eab490eb/apsw-3.53.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c8fceedd79fe94ff064630782211cce41760e4262ce0657aa9ad3f37ab7f451c", size = 3647261, upload-time = "2026-07-10T16:31:28.972Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/11/c8ceffd7cb17be2ee1e4dac546cc6119f11a7381e354a8d38bf336278b6e/apsw-3.53.3.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:153b9b61c8aeb614614d0aa975faf51b564b21174900a89f1b9be6b81a70913a", size = 1287735, upload-time = "2026-07-10T16:31:30.647Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/9a/81018a56e21aeb3886500147bb976768c3d2201be6eda6e6493eb9b34687/apsw-3.53.3.1-cp313-cp313-win32.whl", hash = "sha256:651e4724a8066b31a64af810cef1bf3b48141d8e01e2916adbd4a54fa7dc8d68", size = 2867376, upload-time = "2026-07-10T16:31:32.154Z" },
+    { url = "https://files.pythonhosted.org/packages/18/88/a6651ae070478bd96e6bbb17ea7baac83fc25d60dfce5d114e6af2e5f430/apsw-3.53.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:db7bf119a66d7d8f5ac39a12393ae66fd0888f3190734094a12cc3dd3183a7ab", size = 3256103, upload-time = "2026-07-10T16:31:33.589Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/4e/c04a3322139e060b4d8dbba0f40e4bb88d7fb97b09155347b3e44f5b9c11/apsw-3.53.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6bf835864378dbaad030d33cb51911d33a6001652696791003f26262fcd23e6", size = 2865913, upload-time = "2026-07-10T16:31:35.123Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a8/b7bd647a1f735b8087de3ffb0e99b7dbd6a7782e596b02e16a59e4999e03/apsw-3.53.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:812316f207219acad5690c70a6d600532176f532d3910265c9ad3c9a5886b818", size = 3273332, upload-time = "2026-07-10T16:31:36.786Z" },
+    { url = "https://files.pythonhosted.org/packages/43/99/32bc0425c6265d7d7ac9fae826e1087b4c18b20deb3b9c56c8ce517a72d8/apsw-3.53.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ad1fa6dad91167bee9b288ce0a1c7c0558035725de74247cc486e2f12d12ac5f", size = 3064955, upload-time = "2026-07-10T16:31:38.337Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ac/a78e36d2f65a9ff3e82a58f1036585959bcc1f7dad0a6a2e675170c11c11/apsw-3.53.3.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3f2567082005014407b8ac61c8463b0442717b3e87d340a8a1618f3f7d90ba2f", size = 3481452, upload-time = "2026-07-10T16:31:40.088Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c8/f33adde9d43888736c33aa4f0ded9e608b27269e16487b85e4834a76ffc2/apsw-3.53.3.1-cp314-cp314-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6c0d24bdc5d5c5ad9046430f904d81b916a2c579c0dc392ca6aba8d793088758", size = 3268754, upload-time = "2026-07-10T16:31:41.707Z" },
+    { url = "https://files.pythonhosted.org/packages/da/8f/87ab0a02b3f7523c7bf0afc322d03b325f60441e299828377a727b2db2f7/apsw-3.53.3.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:7286a7aeb4289434f3d192174b946dde69c31fcdbde447cd55fcf9540c378318", size = 3873968, upload-time = "2026-07-10T16:31:43.279Z" },
+    { url = "https://files.pythonhosted.org/packages/03/08/1e51f630fb9767969cf5b2e5f240913597064df4831af798789c9e002006/apsw-3.53.3.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:3a07279328078fb9ef2f5609f39a673cd63966307d3bb553478b77b0f6a9c4e0", size = 3642823, upload-time = "2026-07-10T16:31:44.97Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/8f16a60303c7cfffc9e4a2a9a96660a0bb29a0e8b2daf3e25f7b88611fad/apsw-3.53.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:affbb481b6fe565feb431cbfdc0b5290d162f5bb051570c77497d0ad252e8da9", size = 3490006, upload-time = "2026-07-10T16:31:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/af/16/ee06a5247747e32a1b28257f2c7c501d34f376a7e6ed13f32e52afe2c819/apsw-3.53.3.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:fbd054520d28fe54a622b0b60e90c7320fc7f35c1fa157a5bbad098524a053d8", size = 3277186, upload-time = "2026-07-10T16:31:48.609Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/32/4e6a419bd2a67b9cf0b3b71bc267d4989df0bc18055336226e07bc7ac9d6/apsw-3.53.3.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:747f83a5801918548d131cc5921013ee757c8c9d02d465b7af8c4801b5948dd9", size = 3892041, upload-time = "2026-07-10T16:31:50.111Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/51f4b9345d042ada1e3ef996d6acdbd88b988fdc94f9d0e8d60a7fd2100a/apsw-3.53.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ab9ebb923106557cb047ad2deb785b0a7d06049568b8641c485f4c82cc942bda", size = 3647482, upload-time = "2026-07-10T16:31:51.927Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/45/93ea92d54192aead3ddba4f42a6d827f7c7d8de3d97a983f745ad1eec59a/apsw-3.53.3.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:e4950e2081de554ecab88ecf7308ac50c1dcd5dfd3d6123ffb0d5237f65ff69d", size = 2057919, upload-time = "2026-07-10T16:31:53.598Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/3f/921e3bb7a960beb363b8404fc8fecf5845c73a121b9f46fb3a4830ede534/apsw-3.53.3.1-cp314-cp314-win32.whl", hash = "sha256:bcf7eee33c6fa32574c951f5a23fe8eb1a9690ea90d1c972d603966a343b00bc", size = 2932950, upload-time = "2026-07-10T16:31:55.234Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/5a/6b7b9106d9fa0017830d7e14f5593ee3786572d8a5cfb27cf243b8d7ffb4/apsw-3.53.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:9ff7d9e888d5db192f6c58c32d2784177d86de31915936400971e515baf15576", size = 3339281, upload-time = "2026-07-10T16:31:57.38Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bf/d6be2368091ed490f7fe537819f8056428c6d39a6b1015d979a0f2fd2a0c/apsw-3.53.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:e368521bea565fbd57ab426bb2be2d5dff14d8cdafb0baa6458769a1e776faa9", size = 2939544, upload-time = "2026-07-10T16:31:58.93Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/f201b04e70674ad69e32f2a6d109fa6ab850fba5e0bd02b5341dba7e4ccb/apsw-3.53.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fe4ce4f22cafa0acf293521e1d9d5e65c81cec7def5225c4feb7de2e992bb5d3", size = 3280322, upload-time = "2026-07-10T16:32:00.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/52/88486794cf1e0165dcb9fc177e39b3e761deee7beb5284495373aedc2496/apsw-3.53.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8a17cee2b62d3d97ebd3bcd990e31705592f196561e1b3e8a053315a97dc1ae0", size = 3076232, upload-time = "2026-07-10T16:32:02.383Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/47/9aa43af0d2c41501c14b0f71a6d89b2b80049cb366005e18c6dd63475a81/apsw-3.53.3.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:3a9d4a3af69197224988d9b0b259d7debf411632c284a0a7387a834d3b1fbc33", size = 3454774, upload-time = "2026-07-10T16:32:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a5/a44fda85bba494bfcf194e311b8f76b1f5bcb40c90b93462fb8843be9b0e/apsw-3.53.3.1-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0f429900bf2be18a47ba710b5a1c25699a78fc591f72cb02b53ee4ddebb9bbd2", size = 3247305, upload-time = "2026-07-10T16:32:05.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/2c/dcbe09dacdfe7f9e1f041a8fb770348dbe7b5151f5be1c4911c3721b062e/apsw-3.53.3.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:0f352b9de362aa8b16d2abeabb91f72b07c66bd67b9579daa4ca68d6f6541071", size = 3844467, upload-time = "2026-07-10T16:32:07.405Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/40/53c59a2019f54e3f7f63b72215927739fa9ab690cde1950c828c990f654b/apsw-3.53.3.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:085849d26b775737c5bb8908f92313199e06007a291b5ac6c75197b295f31d24", size = 3617813, upload-time = "2026-07-10T16:32:09.276Z" },
+    { url = "https://files.pythonhosted.org/packages/02/4d/c63cec22675e797a32a1c7bebad5e9f15bedef7e64717bf6ded29030dfad/apsw-3.53.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bdbf4a47b11ef22bf0aadfa6850422b033bd7973812fbefbe7d4823d13af4b3a", size = 3462436, upload-time = "2026-07-10T16:32:10.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1c/6b6003c4900789e522a27b0464f911d810a4c0d09eafe23e3087cafdeb78/apsw-3.53.3.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:0d531f57a463d3aa190149369013483dfadd15f74d68a2f0d47dea1e99ee0a8f", size = 3254984, upload-time = "2026-07-10T16:32:13.078Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/67/56487885ea53724250b0125f4b71253f3499f1a37a480416fe1cb5f8e064/apsw-3.53.3.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ca4289629f3e9fd45a11dfd8c998f55f280f1946efb3f452740c6d384f96a709", size = 3862070, upload-time = "2026-07-10T16:32:14.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0b/ee1f7dedeee7d73c0c94ffd2ac848f5f67e35605cbf8fcc643f6f18e902b/apsw-3.53.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6fc4312cd93a78599bab45bbe661b3907e95e115795ddbea8aaf43d2d5a6432e", size = 3623454, upload-time = "2026-07-10T16:32:16.838Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/66/a0f2532dd06637d30d0d43ff778646c6ff966a42960151301f16519c95d3/apsw-3.53.3.1-cp314-cp314t-win32.whl", hash = "sha256:1c5ab8bbea3df033f34def748f9a8d42a92d937502e300b1f288a6c62cf88171", size = 2938713, upload-time = "2026-07-10T16:32:18.474Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b5/7372979ac8b239e573b3d98e603224f0328675662476766f5d8aaeaebcd6/apsw-3.53.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:3d3493f35c859f6eaa3bab88ff844c2d20ece21494b67a1949d1a7924dacc60f", size = 3345300, upload-time = "2026-07-10T16:32:20.053Z" },
+    { url = "https://files.pythonhosted.org/packages/69/99/2a7190c33945ae37f9f9b45193674d75547748f2e472c0aecac844955c11/apsw-3.53.3.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0ae765e0d6f2aaa1c35f11a4cacc6055d89a965f9e531ab20a63193a09c3a86d", size = 2942462, upload-time = "2026-07-10T16:32:21.759Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +704,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
     { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "chonkie"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chonkie-core" },
+    { name = "httpx" },
+    { name = "numpy" },
+    { name = "tenacity" },
+    { name = "tokie" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/67/e6ceace2b2066cc38206c81e9105735975d7a58d89c9e7a871fe9acef63d/chonkie-1.7.0.tar.gz", hash = "sha256:4352aa214b66376c32523e524b94b7f1456a5e7611c48037dadb45e46f436b18", size = 190834, upload-time = "2026-07-07T10:06:02.475Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/c0/b5f91fb340d354a8c20e2f65d08b9dab357360da78d230e96c6d79b36a2e/chonkie-1.7.0-py3-none-any.whl", hash = "sha256:98822ca80fbf3c0775f59329a4f6b6bfedb34edff004b5e04e53c3281369b921", size = 233764, upload-time = "2026-07-07T10:06:00.824Z" },
+]
+
+[[package]]
+name = "chonkie-core"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/17/ad31bbcfe1a7b63f76e065684a8e9cd98552d3c627fb28d8fbc05f1a9456/chonkie_core-0.10.2.tar.gz", hash = "sha256:c8e40ef8f3a034a7c5dd23a0401dce2ef2b4883f5a6a29cf94176d64b209bdbb", size = 69966, upload-time = "2026-05-28T19:16:12.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/0b/4c28270b24d9e756c90a52966f26ddff5fa2f639aed7e6cd9cc1e1728176/chonkie_core-0.10.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a431af90ac4e4072e02699ac1300efcaaff2ee432b052fe51027998859af1055", size = 349504, upload-time = "2026-05-28T19:15:45.801Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a6/069b46520a23264585ddacd117bee62594afff0f851cd1dfedf32b900faf/chonkie_core-0.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:712ecc448302bdc8f3ab4aab1e17d5d37b50d57d89d4fa4ec44821a37eb8fa57", size = 339673, upload-time = "2026-05-28T19:15:46.992Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/05/513baf0c159fb93e6c05bf199cca79045b2c186e9fea1fd7ebf47d063c7b/chonkie_core-0.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff79cbe5016f85a8fac2164e1716f3335b631704bfa486f0d1de02c6d88c2bce", size = 390030, upload-time = "2026-05-28T19:15:48.434Z" },
+    { url = "https://files.pythonhosted.org/packages/50/65/4a86e1648147df94bcc2d681b6c5f40a21c57df65b45bf2f3ceb72fcb784/chonkie_core-0.10.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f69969fa3f75930bd10f1ec502993b758df4e5a62d170c373a4fa73743dc2f93", size = 374622, upload-time = "2026-05-28T19:15:49.836Z" },
+    { url = "https://files.pythonhosted.org/packages/54/62/425bca737db62a371b1e3393d76f69f483baf3482ccd88504089501ee0e4/chonkie_core-0.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:cbe5a8a1e89a79a74bac99409e1bf5e7a5b3e2286ac5f2185077d39f5fa95175", size = 231028, upload-time = "2026-05-28T19:15:50.956Z" },
+    { url = "https://files.pythonhosted.org/packages/56/2f/4dd88b4af9ef0e9ed31a3c6a3d8e44327c5ca22b074076830b0224e0ad58/chonkie_core-0.10.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:31f8fa3415d2e93cc3bdb1e99c3b6865278169af348c68fb2943aed2fcabc010", size = 347520, upload-time = "2026-05-28T19:15:52.331Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/3f/ba4083f21b4ef52ed130a79f371fed453b7edf998bf08079694137880bff/chonkie_core-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a6d081363fbfaad0f36c66e67e6dec1c9f9850c04c0475b64b3e47084257b646", size = 336897, upload-time = "2026-05-28T19:15:53.787Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9f/cbfec0f25e35d2a5b62a9cba7a5a85cfc5349210b9f9acb40832060211e4/chonkie_core-0.10.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51dbf2163dac5ad695dde3f92155c6febb9332b5fb5a174ac80ae9fc8f8ccde9", size = 387231, upload-time = "2026-05-28T19:15:54.851Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c8/b0d91419730bff4566305f2c85f27fb1378e8e1e99f8e59403c6b25d43a2/chonkie_core-0.10.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5a09bcb56d9d9f2fa6ec84485aeecbcaa375567eea9fbec18517d2ef643b9029", size = 371506, upload-time = "2026-05-28T19:15:56.172Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c2/05c2c85b11d092f04768c41fb9cfdd27a9d27fa7e10e107188a51ce8813f/chonkie_core-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:ac686d192c4dd7e038cea4aba59c677d45e2b1e8de8eb1dd45d269b22a4ae201", size = 229686, upload-time = "2026-05-28T19:15:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/0814d2bd9abddbbc37f8c204f056d28f2ab7d14bf742515e9684062bd758/chonkie_core-0.10.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:25372879e43b235dee01f48309634a3fce07b55c382a7fbe200d6b66769267e4", size = 346848, upload-time = "2026-05-28T19:15:58.979Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/33/b640f406b6d2fe30d5c41d4a91411d9ed1dc22acf6497cda837a6f121ba4/chonkie_core-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3da60e797b2fcbef3e17fad3e46bb7d4f5541ac5f87a5556c2c610cef83a549a", size = 336613, upload-time = "2026-05-28T19:16:00.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/079296e83d2ed6e34b8ed24bd23e59193b502b53ddfa176b3e921410a5db/chonkie_core-0.10.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebeba2d2cb0d30eefdbdb18d2ab2fcfbc0ea0d5121f61f537a6114a1da56101", size = 386412, upload-time = "2026-05-28T19:16:01.425Z" },
+    { url = "https://files.pythonhosted.org/packages/04/6e/2c505276878b695b4cee07eb35a5c536ed92d60c722b4547da1517fb3e41/chonkie_core-0.10.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:72974163eab058d14c365f45b53d2367b1e04a0dcd779dedd828973cf21256d7", size = 371726, upload-time = "2026-05-28T19:16:02.8Z" },
+    { url = "https://files.pythonhosted.org/packages/38/39/158f85b728d84e85a00768ccebe3a289d21462f52ba7850db9e01e61e4df/chonkie_core-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:9f77811bb722bd019a52353364bc6dcea1a9998120a413f1c2a1c79153a66386", size = 229447, upload-time = "2026-05-28T19:16:04.21Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/45/e4d68840847133afa9c69fc0e28575270afdd9dcc0c13280a9b40445377d/chonkie_core-0.10.2-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cb0626fa4d9df5128188eef069f69809571fbfc6db47e348d5f4d1199fa34b9c", size = 346802, upload-time = "2026-05-28T19:16:05.415Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4d/29e42ac094624a0ebfe74684ce62eb870e640679c1feb8da63e631a45cde/chonkie_core-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5266bdb8887c223782096c97a72eb49f19930f797213fa65b82199042742dc98", size = 336470, upload-time = "2026-05-28T19:16:06.575Z" },
+    { url = "https://files.pythonhosted.org/packages/56/05/b3e206f063e6515a1b2e1f873ff33d91bf1eaab99554577c47804ebbbf37/chonkie_core-0.10.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4b6e2cf0411cb675d8b22f2b234b07e20724ded6cf84b2bc625b677885d2ef7", size = 386170, upload-time = "2026-05-28T19:16:07.761Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/4c775aec3d7ef6ff6ad90570c5b6f612fda9bf1ae7dfb4bd322d0fe55ffe/chonkie_core-0.10.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d1999d993df8ecf941361b8eff9618f2a9bf3436b4a1851ec3f3f42d9a9c1a7e", size = 370624, upload-time = "2026-05-28T19:16:08.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d0/103da313f8990607ac77c4735f372734a4d96afe79fdabc5883731bb2063/chonkie_core-0.10.2-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:acf83c774d5646dd9f16b896722155db8e87948fc93ee952fd649b5344d9205d", size = 101801, upload-time = "2026-05-28T19:16:10.226Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/93/e3167b1823f919f1a4c517092f73dc4107737de8bb53c67ff60c964b5244/chonkie_core-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:20c9d64b9c5169d1f7e5ceeaa22bff3613017b8937c224ba85e3e24748fb0ba3", size = 228655, upload-time = "2026-05-28T19:16:11.357Z" },
 ]
 
 [[package]]
@@ -3872,6 +3993,11 @@ all-samples = [
     { name = "line-bot-sdk" },
     { name = "slack-bolt" },
 ]
+builtin-rag = [
+    { name = "apsw" },
+    { name = "chonkie" },
+    { name = "sqlite-vec" },
+]
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
@@ -3928,8 +4054,10 @@ web = [
 
 [package.metadata]
 requires-dist = [
+    { name = "apsw", marker = "extra == 'builtin-rag'", specifier = ">=3.51" },
     { name = "build", marker = "extra == 'release'", specifier = ">=1.0" },
     { name = "charset-normalizer", specifier = ">=3.0" },
+    { name = "chonkie", marker = "extra == 'builtin-rag'", specifier = ">=1.7" },
     { name = "croniter", specifier = ">=2.0" },
     { name = "ddgs", specifier = ">=8.0" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110,<0.137" },
@@ -3963,6 +4091,7 @@ requires-dist = [
     { name = "slack-bolt", marker = "extra == 'all-samples'", specifier = ">=1.18" },
     { name = "slack-bolt", marker = "extra == 'sample-slack'", specifier = ">=1.18" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6" },
+    { name = "sqlite-vec", marker = "extra == 'builtin-rag'", specifier = ">=0.1.9" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=1.0,<1.3" },
     { name = "torch", marker = "extra == 'local-embed'", specifier = ">=2.0" },
     { name = "trafilatura", marker = "extra == 'fetch'", specifier = ">=1.8" },
@@ -3971,7 +4100,7 @@ requires-dist = [
     { name = "watchdog", marker = "extra == 'fs-watch'", specifier = ">=4.0" },
     { name = "websockets", marker = "extra == 'web'", specifier = ">=12" },
 ]
-provides-extras = ["dev", "fetch", "local-embed", "docs", "web", "mcp", "fs-watch", "release", "sandbox-linux", "voice", "observability", "sample-slack", "sample-line", "all-samples"]
+provides-extras = ["dev", "fetch", "local-embed", "docs", "web", "mcp", "builtin-rag", "fs-watch", "release", "sandbox-linux", "voice", "observability", "sample-slack", "sample-line", "all-samples"]
 
 [[package]]
 name = "rfc3986"
@@ -4489,6 +4618,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlite-vec"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/85/9fad0045d8e7c8df3e0fa5a56c630e8e15ad6e5ca2e6106fceb666aa6638/sqlite_vec-0.1.9-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:1b62a7f0a060d9475575d4e599bbf94a13d85af896bc1ce86ee80d1b5b48e5fb", size = 131171, upload-time = "2026-03-31T08:02:31.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/3677e0cd2f92e5ebc43cd29fbf565b75582bff1ccfa0b8327c7508e1084f/sqlite_vec-0.1.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1d52e30513bae4cc9778ddbf6145610434081be4c3afe57cd877893bad9f6b6c", size = 165434, upload-time = "2026-03-31T08:02:32.712Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d4/f2b936d3bdc38eadcbd2a87875815db36430fab0363182ba5d12cd8e0b51/sqlite_vec-0.1.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e921e592f24a5f9a18f590b6ddd530eb637e2d474e3b1972f9bbeb773aa3cb9", size = 160076, upload-time = "2026-03-31T08:02:33.796Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ad/6afd073b0f817b3e03f9e37ad626ae341805891f23c74b5292818f49ac63/sqlite_vec-0.1.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:1515727990b49e79bcaf75fdee2ffc7d461f8b66905013231251f1c8938e7786", size = 163388, upload-time = "2026-03-31T08:02:34.888Z" },
+    { url = "https://files.pythonhosted.org/packages/42/89/81b2907cda14e566b9bf215e2ad82fc9b349edf07d2010756ffdb902f328/sqlite_vec-0.1.9-py3-none-win_amd64.whl", hash = "sha256:4a28dc12fa4b53d7b1dced22da2488fade444e96b5d16fd2d698cd670675cf32", size = 292804, upload-time = "2026-03-31T08:02:36.035Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -4524,6 +4665,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -4622,6 +4772,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tokie"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/ea/00ee6ed9b873b3f11ff3ddf75eb4c6e22813eff86affb6aa61c57522ba0c/tokie-0.0.10.tar.gz", hash = "sha256:6333aa7bdd5c0056f83f51d1768fe0b4c41fdf1206a590a891997cbe8a7216a9", size = 135391, upload-time = "2026-05-28T17:56:42.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/4d/6a17a48ef7fdd489e5aa7cf27d7f08297afda1ac2c93359b2874857c8260/tokie-0.0.10-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:435ce67c7703cd610353bb455cea8258c6734c26d56539f4b3860efbebed373e", size = 2553174, upload-time = "2026-05-28T17:56:10.853Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/50/e4773d7a939a961abafaa75dc5dfd079453891e83811857fb6f271f09ca7/tokie-0.0.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:aba89b0f6a50d2af393fb1d07fce44305dc36f666f0bf0643b935c8a1301879b", size = 2466128, upload-time = "2026-05-28T17:56:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/46/2cc8af76480c9d7ab81e12b679dd88d06db87f0f493ca85ce1c509385706/tokie-0.0.10-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbfcf10b8abbde08201f66484e43a8febfbfd66fc718d291f1bb2c82e8f2f06", size = 2760417, upload-time = "2026-05-28T17:56:13.772Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1d/b83e7c4c9ec2de0be9ba02ba9d244a8da5c569000d44ed20a686795ce6ae/tokie-0.0.10-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bba46af6a4427338f624f90e2d65405a07261616bb8c7698770c83fe39cd6577", size = 2728677, upload-time = "2026-05-28T17:56:15.281Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b0/3a2e2cc2167bc97755701c506ae1ebe0f7e4557e84f102d7cb7d56f4b7c1/tokie-0.0.10-cp311-cp311-win_amd64.whl", hash = "sha256:b71c92febb8122ad7dd9fca9eecf1bb3070171525e27797cccfa665d03d9a42d", size = 2310118, upload-time = "2026-05-28T17:56:16.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/74692d64e7d1b64bae59f03b3521c06b830e2c3f9f2b1898abeef63abbf7/tokie-0.0.10-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:792079ab39712bf2bbbd6146039191d0523f67266ca98f97e94203e5071b5548", size = 2549253, upload-time = "2026-05-28T17:56:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/6e/8cccd2ed7539ef04884983bc5eb92473470045bb500dc265dfefcd86a635/tokie-0.0.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b126a9535a9debce71b65d508fdfff28e0bbe151d7b255baf239a14d395b0a3", size = 2463044, upload-time = "2026-05-28T17:56:19.534Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/07/692eb9884c6756198f7228e79a580953699fa15841276cb91377a2270a93/tokie-0.0.10-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0969b7d168c1f812ac95810a23b1d9917cb4bc949c76485e913c73bb7e0de50f", size = 2759503, upload-time = "2026-05-28T17:56:20.871Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/3d/7abb78a99d7ae881fd6e0cbf43685df9d4e985c2cc6cd1a6d3909ee079c8/tokie-0.0.10-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86db7abada9ef77d673ae760e937d6215aedc3312229b2954a4c62f66b59797b", size = 2727113, upload-time = "2026-05-28T17:56:22.215Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/bb/40eec34b7e703fd383d2bee5f36b692a45c4befac3bc020f64225f6615b9/tokie-0.0.10-cp312-cp312-win_amd64.whl", hash = "sha256:a399078a0e17a0df7b381ec44c9ae632fa99c0e116c5252bb2b99f34f6db2e5c", size = 2309938, upload-time = "2026-05-28T17:56:23.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/53/0bd8ef223b5f52228be6616815199256c7ea2fcc573cec6bc6bcf1afd077/tokie-0.0.10-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:00a985f7ee7f3773b1ea181d79ee9bd823860aae2797d0063fa31c9f23444e72", size = 2549143, upload-time = "2026-05-28T17:56:25.214Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/e2/557c1686825f289e72a5ecdbf3575b301f22d4322e55612397cd7bb94906/tokie-0.0.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:02e8d6be8062d253960e89a59090fee74535c825a577c900c50a5b47b2413d0f", size = 2463276, upload-time = "2026-05-28T17:56:26.637Z" },
+    { url = "https://files.pythonhosted.org/packages/04/7c/ffb15e7fd0e8b9eca6b4d359d47518c34c9013b4a0780320659b275d7509/tokie-0.0.10-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:60a750d991716e16fcce8b1716f28d0fdd68924ebf87b26fc15af3b43f4b2df2", size = 2759344, upload-time = "2026-05-28T17:56:28.45Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/bb/f7e75d6f6e801e1687f54c1765b1e4cf8a0e2cec13e2e9119f878292f398/tokie-0.0.10-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b860e80661649acc19649b495a6505e653aa2ecedf6c5ca8a93812b68ae4d8b1", size = 2726957, upload-time = "2026-05-28T17:56:29.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c5/726ed23e7c14dc58fefde38f54200a990a6e9e353d8e0cf3f40824adc434/tokie-0.0.10-cp313-cp313-win_amd64.whl", hash = "sha256:37bb978ec99d0dce405ffdcae8bc3e1e5da3e3201a9036b701ddb20cc1169c1f", size = 2309450, upload-time = "2026-05-28T17:56:31.293Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9f/5f548d1eb97c152d0b7bbdc36b9426f97483910935e97cc9770f2bd12e25/tokie-0.0.10-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3e261220bb8a03a2276d2d501fd199df5a6e882894b1c0340a07f6ba5db6c96a", size = 2549506, upload-time = "2026-05-28T17:56:32.742Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/08/b73ba4246d604421e75749f1c01e3fbf4f50799f8c9138abd4bfb9be1a69/tokie-0.0.10-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bce1191e38a8d02259aa010b88f394e712416208868acee15aaf7e3f48525d69", size = 2463438, upload-time = "2026-05-28T17:56:34.15Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d0/74fc6f80ffcb8d39cd9ef0a7f000d118aea2db1c91c299008437938060e1/tokie-0.0.10-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d0d40b2818c9f8c30e5e2adddadb55019b8a3ae7b34b8d4f898124308923fdc", size = 2759145, upload-time = "2026-05-28T17:56:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8c/34acdcc8fa973bac37d5e01505bf6f24353ddd22afca9e848283a6a430a1/tokie-0.0.10-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a96450b25adad9e71466e16ae77b4aa36a00ce0d5be0d4af6dc6e0bb82b361e2", size = 2727485, upload-time = "2026-05-28T17:56:37.243Z" },
+    { url = "https://files.pythonhosted.org/packages/30/64/795e8befa06fc7dcbd12ce1b63bfe9bc50d4a5d4c6742b5bc7383ebf81d1/tokie-0.0.10-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:84d457a1bba82561ad618fc227b3f93e27f3cd6e9248a23c4406b81318ce64e5", size = 761029, upload-time = "2026-05-28T17:56:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/62/88/0da7795e99f373a63a52ccf2afa055032d3e6aabbb8860f7ffa7a64504aa/tokie-0.0.10-cp314-cp314-win_amd64.whl", hash = "sha256:c517811de6a9f4ed230619317f50e1c9a5f2bc948f11f95251ee93cff3c67cb7", size = 2309656, upload-time = "2026-05-28T17:56:40.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**[per-PR-coder]** — FP-0063 P2: the builtin MCP layer of the "builtin turnkey user RAG" arc (docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md). P1 (selection spike) found no OSS MCP vector-DB server satisfying C1 (pre-computed vectors); owner approved writing the MCP surface ourselves. This PR ships the two thin bundled MCP servers P1's fallback anticipated.

## What's here

- `src/reyn/builtin/mcp_servers/vector_store_server.py` — wraps `sqlite-vec` (a pure-C SQLite extension, no bundled embedding model).
- `src/reyn/builtin/mcp_servers/chunker_server.py` — wraps `chonkie`.
- `pyproject.toml`: new `builtin-rag` extra (`sqlite-vec`, `apsw`, `chonkie`) — `fastmcp` is **already core** (promoted in an earlier PR), so this is the only new-dependency surface. `uv.lock` regenerated (`uv lock`) and `uv lock --check` passes.
- `docs/cookbook/configs/with-builtin-rag-mcp.yaml` — the INERT sample config (commented out) an operator copies + uncomments to enable either server.
- `tests/test_fp0063_p2_builtin_mcp_rag.py` — 10 Tier-2b tests, no mocks.
- `.github/workflows/test.yml` — adds `builtin-rag` to the CI extras list. **This one is load-bearing, see below.**

## ⚠️ The CI extras fix — caught by falsification, not by reading

The test file `pytest.importorskip`s `apsw`/`sqlite_vec`/`chonkie`. CI's install line was `pip install -e ".[dev,mcp,web,fs-watch,observability]"` — **no `builtin-rag`**. So as first written, this PR would have gone **green in CI while the entire test module silently skipped, verifying nothing** — the exact "green CI, zero verification" failure class this repo has been bitten by before.

Verified both directions on clean venvs rather than assuming:

```
# WITHOUT builtin-rag (the pre-fix CI state):
SKIPPED [1] tests/test_fp0063_p2_builtin_mcp_rag.py:44: builtin-rag extra not installed
1 skipped in 0.14s

# WITH the fixed CI extras string, clean venv, resolved from PyPI:
10 passed in 2.54s
```

The workflow change is CI config, **not** a reyn-core change — `src/reyn/**` is untouched by this PR (the zero-core target holds).

## The five vector-store gates (proposal §Vector-DB MCP)

1. **Pre-computed vectors** — `upsert(db_path, items)` takes `items: [{"id", "vector", "metadata"}]`; the module never computes an embedding.
2. **User-specified single sqlite file** — every tool call takes `db_path` explicitly; parent dirs are created lazily.
3. **top-k + metadata filter** — `query(db_path, vector, top_k, filters)` runs a real SQL `WHERE` over the metadata columns joined against the sqlite-vec KNN match (see "why k=total-rows" in the module docstring — the filter is applied to the FULL candidate set, not post-`top_k`, so a filter can't be defeated by an early KNN truncation).
4. **Metadata passthrough** — `reyn_rag_chunks` carries the full `ChunkMetadata` shape: `source_path`, `source_type`, `content_hash`, `embedding_model`, `chunk_index`, `size_tokens`, `parent_context`, `extra` (JSON blob).
5. **Generic ops for a pipeline-owned diff** — `list_metadata(db_path, filters)` (Chroma `get(where=...)` shape, no vectors), `upsert` (replaces by `id`, never duplicates), `delete(db_path, ids)`. **No `content_hash` add/update/remove logic lives here** — that's the ingest pipeline's job (P3), settled at co-vet (C5).

## Chunker: size/overlap are parameters, not constants (R4)

`chunk(text, size=400, overlap_ratio=0.125, min_characters_per_chunk=24)` — defaults land in the 2026 persistent-RAG band (256–512 tokens, 10–15% overlap), explicitly NOT FP-0057 line 51's 800–1024 figure (that number is scoped to throwaway ephemeral attachments). Overlap is chonkie's own `OverlapRefinery` two-step shape (chunk, then refine) — `RecursiveChunker` itself has no overlap param.

## Driven, not just read (per task instruction C)

Every claim above was exercised, not inferred from reading the code:

**In-process (fastmcp `Client`)**:
```
TOOLS: ['upsert', 'query', 'list_metadata', 'delete']
UPSERT RESULT: {'upserted': 1}
QUERY RESULT: [{'id': 'x1', 'distance': 0.0, 'metadata': {...}}]
LIST RESULT: [{'id': 'x1', 'metadata': {...}}]
DELETE RESULT: {'deleted': 1}
```

**Real subprocess stdio round-trip** (`PythonStdioTransport` spawning `python -m reyn.builtin.mcp_servers.vector_store_server` as a genuine child process over stdin/stdout, not in-process):
```
SUBPROCESS TOOLS: ['upsert', 'query', 'list_metadata', 'delete']
SUBPROCESS UPSERT: {'upserted': 1}
SUBPROCESS QUERY: [{'id': 's1', 'distance': 0.0, 'metadata': {...}}]
file at user path exists: True
```

**Chunker, in-process**:
```
TOOLS: ['chunk']
num chunks: 100  (size=64, overlap_ratio=0.2, 200-sentence input)
default chunks: 15, token_count[0]: 431   (size/overlap defaults only)
```

## Strip-falsification (required)

Temporarily broke `list_metadata`'s column restriction (joined the vector table and leaked the raw embedding blob into the returned metadata dict), then ran `tests/test_fp0063_p2_builtin_mcp_rag.py`. Observed RED on exactly the two tests that guard this:

```
FAILED tests/test_fp0063_p2_builtin_mcp_rag.py::test_list_metadata_excludes_vectors
FAILED tests/test_fp0063_p2_builtin_mcp_rag.py::test_strip_falsify_list_metadata_would_leak_vectors_if_joined
2 failed, 8 passed in 0.94s
```
Reverted; full suite green again (`10 passed`). The `test_strip_falsify_...` test also independently proves the guard isn't vacuous — it opens a second, separate `apsw` connection to the same on-disk file and confirms the vector bytes really are retrievable via the naive join (i.e. the omission in `list_metadata` is a deliberate choice guarding real data).

## Inert-ship posture (A / R3 / F-D) — verified, not assumed

Neither server is wired into `reyn.builtin.registry.build_builtin_config()`. Confirmed by direct investigation of `#2932`'s auto-grant (`src/reyn/interfaces/cli/commands/pipe.py`): it keys **purely on the server name being a key in the merged `config.mcp.servers` dict** (`sorted((config.mcp or {}).get("servers", {}) or {})`) — there is no `enabled` field anywhere in the MCP server schema for it to check, so **any** entry appearing under `mcp.servers` from **any** config tier (including a hypothetical builtin tier) would be auto-granted the instant `reyn pipe run` executes, with zero operator decision in the chain. That's why this PR does NOT add an `mcp` key to `build_builtin_config()`'s output — the sample config lives purely in `docs/cookbook/configs/with-builtin-rag-mcp.yaml` (mirroring the existing `with-mcp.yaml` precedent — those files are never auto-loaded; confirmed by grep, the only reference to `docs/cookbook/*.yaml` in `src/` is a CLI help-text `print()` in `interfaces/cli/commands/init.py`). An operator must copy the block into their own `reyn.yaml` and uncomment it themselves — that's the only way either server's name ever reaches `mcp.servers`.

Zero reyn-core files changed. Only new/added: two builtin-content modules, an extras group + lockfile update, a doc sample, and a test file.

## Dependencies added (builtin-rag extra, base install unaffected)

| Package | Version | License |
|---|---|---|
| `sqlite-vec` | 0.1.9 | dual MIT / Apache-2.0 |
| `apsw` | ≥3.51 (3.53.3.1 locked) | zlib-like ("any-OSI" per PyPI classifier) |
| `chonkie` | ≥1.7 | MIT |

`fastmcp` (already core) is unchanged.

## Offline/firewall finding (R1/D) — reported, not papered over

- **No HuggingFace / no network fetch at all**, in either server: `sqlite-vec` is a pure-C extension with no bundled model; `chonkie`'s default (character) tokenizer used here downloads nothing. Neither server repeats the FP-0057 line-55 firewall failure class.
- **A different, previously-undiscovered environment gate**: `sqlite-vec` loads via `sqlite3.Connection.load_extension`, which the **stdlib `sqlite3` module is not guaranteed to support** — confirmed directly: this very repo's own pyenv-built CPython 3.12.7 `.venv` has `hasattr(sqlite3.Connection, "enable_load_extension") is False` (same for `/usr/bin/python3` on this Mac; `/opt/homebrew/bin/python3` and `python3.13` DO support it — it varies by distribution/build flags, not by OS). Rather than silently fail (or worse, work on the author's machine and break on the operator's), `vector_store_server.py` uses `apsw` instead of stdlib `sqlite3` — apsw statically bundles its own SQLite build with extension loading always enabled, so `sqlite-vec` loads deterministically regardless of how the host interpreter was compiled. This is a portability fix baked into the design, not a workaround left for later — but it's worth flagging in review as a real, previously-unstated constraint on any future sqlite-vec-based work in this codebase.

## Out of scope (per task)

Ingest/query pipelines (P3), the skill (P4), the firewall step-0 reachability check (P5), and `markitdown-mcp`'s config entry (left to P3, third-party server, not written here).

## Test plan

- [x] `ruff check src tests` — green ("All checks passed!").
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0063_p2_builtin_mcp_rag.py` — 10/10 OK, 0 errors.
- [x] `pytest` from repo root — green: **8552 passed, 17 skipped** in 239s (none of the 17 are this PR's).
- [x] **Verified this PR's 10 tests RUN, not skip** — `pytest tests/test_fp0063_p2_builtin_mcp_rag.py -v -rs` → 10 PASSED / 0 skipped, against really-installed `sqlite-vec 0.1.9` / `apsw 3.53.3.1` / `chonkie 1.7.0`. Re-verified on a from-scratch venv built with the exact CI extras string (10 passed), and falsified in the negative direction (without the extra → module skips).
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — OK.
- [x] `uv lock --check` — green after `uv lock` regeneration.
- [x] Driven tool calls (in-process + real subprocess stdio) for both servers — see above.
- [x] Strip-falsification — RED observed and reverted, see above.
