### PR TITLE
docs: fix allow_subprocess Advisory→Enforced drift in reyn-yaml.md

### DIFF
--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -342,7 +342,7 @@ sandbox:
 | `write_paths` | list[文字列] | `[]` | プロセスが書き込み可能なパス（厳密なガード）。書き込みは読み取りを含む。 |
 | `read_deny_paths` | list[文字列] | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。許可リストのみのバックエンド（Landlock）では非対応。 |
 | `read_paths` | list[文字列] | `[]` | **レガシー。** かつての厳密な読み込み許可リスト。現在のスコーピングモデルでは読み込みはデフォルトで広許可のため、このフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
-| `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。Seatbelt では advisory 扱い。 |
+| `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。適用（enforced）— off の時 `process-fork` を deny。 |
 | `env_passthrough` | list[文字列] | `[]` | サンドボックスプロセスへ通過させる環境変数名。`PATH` は常に通過します。 |
 | `timeout_seconds` | int | `60` | バックエンドが強制する実時間上限。 |
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -768,7 +768,7 @@ When `sandbox.policy` is present, these mirror the `SandboxPolicy` fields. Unkno
 | `write_paths` | list[string] | `[]` | Filesystem paths the process may write (tight guard). Write implies read for these paths. |
 | `read_deny_paths` | list[string] | `[]` | Sensitive paths to DENY from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow rules (Seatbelt); not enforceable on allowlist-only backends (Landlock). |
 | `read_paths` | list[string] | `[]` | **Legacy.** Formerly the strict read allowlist. Reads are broad by default under the current scoping model; this field now documents intended read targets only. |
-| `allow_subprocess` | bool | `false` | Whether the process may spawn children. Advisory under Seatbelt. |
+| `allow_subprocess` | bool | `false` | Whether the process may spawn children. Enforced — denies `process-fork` when off. |
 | `env_passthrough` | list[string] | `[]` | Env-var names that pass through to the sandboxed process. `PATH` is always passed through. |
 | `timeout_seconds` | int | `60` | Wall-clock cap enforced by the backend. |
 


### PR DESCRIPTION
**[per-PR-coder]** — Fixes a doc↔doc drift on `allow_subprocess` enforcement wording.

## Problem

`docs/reference/config/reyn-yaml.md:771` said `allow_subprocess` is **"Advisory under Seatbelt"**. `docs/guide/for-users/configure-sandbox.md:99` says it is **"Enforced"** for the same field. These directly contradict each other.

## Primary evidence (tiebreaker = actual behavior)

Owner's real run log (`.reyn/events/agents/default/chat/2026-07/2026-07-16T074129.jsonl`) shows `allow_subprocess=false` (default) actually **denying** a `subprocess.Popen(...)` fork with `[Errno 1] Operation not permitted` — not merely an audit-log/advisory notice. This confirms `configure-sandbox.md`'s "Enforced" is correct and `reyn-yaml.md`'s "Advisory" is the error.

## Fix

- `docs/reference/config/reyn-yaml.md:771` — "Advisory under Seatbelt" → "Enforced — denies `process-fork` when off" (matches `configure-sandbox.md`'s wording).
- `docs/reference/config/reyn-yaml.ja.md:345` — ja mirror updated in lockstep (this repo keeps en/ja pairs in sync).

## Grep for the same error class

Ran `grep -rni advisory docs/` before fixing — the only `allow_subprocess`-related "advisory" hit was the one at `reyn-yaml.md:771` (+ ja mirror). All other "advisory" occurrences in `docs/` refer to unrelated concepts (file locks, `compact` op, index locking) and are correct as-is.

## Scope note

This is a docs-only fix, independent of #2953 (which changes the `allow_subprocess` *default* value). Landing this first per owner's sequencing instruction, so #2953 can update the default-value column without conflicting with this wording fix.

## Test plan
- [x] `grep -rni advisory docs/` reviewed — no other `allow_subprocess`-related occurrences found (skipped further verification — text-only doc fix, no runtime surface).
- [x] en/ja wording now matches `configure-sandbox.md` phrasing convention.

Closes #2954