### PR TITLE
security: flip SandboxPolicy.allow_subprocess default false→true (#2953)

### DIFF
--- a/docs/concepts/runtime/sandbox.ja.md
+++ b/docs/concepts/runtime/sandbox.ja.md
@@ -19,7 +19,7 @@ Reyn のサンドボックスレイヤーは、ワークフローが宣言した
 | `network` | `bool` | `false` | アウトバウンドネットワーク接続を許可 |
 | `read_paths` | `list[str]` | `[]` | サブプロセスが読み取り可能なファイルシステムパス（glob パターンおよび `{{workspace}}` テンプレート可） |
 | `write_paths` | `list[str]` | `[]` | サブプロセスが書き込み可能なファイルシステムパス |
-| `allow_subprocess` | `bool` | `false` | サンドボックス対象プロセスが子プロセスを生成することを許可。Linux (seccomp) / macOS (Seatbelt) で適用（off の時 `process-fork` を deny、対象自身の exec は `process-exec*` で動作）。 |
+| `allow_subprocess` | `bool` | `true` | サンドボックス対象プロセスが子プロセスを生成することを許可。Linux (seccomp) / macOS (Seatbelt) で適用（off の時 `process-fork` を deny、対象自身の exec は `process-exec*` で動作）。フォークを拒否するには `false` を設定。 |
 | `env_passthrough` | `list[str]` | `[]` | サブプロセスに引き渡す環境変数名（それ以外はすべて除去） |
 | `timeout_seconds` | `int` | `60` | ウォールクロック上限（超過時にプロセスを強制終了） |
 

--- a/docs/concepts/runtime/sandbox.md
+++ b/docs/concepts/runtime/sandbox.md
@@ -20,7 +20,7 @@ Defined in `src/reyn/security/sandbox/policy.py`. Passed as fields on a `sandbox
 | `write_paths` | `list[str]` | `[]` | Filesystem paths the subprocess may write (tight guard). |
 | `read_deny_paths` | `list[str]` | [OS credential paths] | Sensitive paths denied from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt). Default: `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker/config.json`, `~/.netrc`. |
 | `read_paths` | `list[str]` | `[]` | **Legacy** — formerly the read allowlist. Under the current broad-read model reads are not restricted to this list; retained for backward compatibility and as documentation of intended read targets. |
-| `allow_subprocess` | `bool` | `false` | Allow the sandboxed process to spawn child processes. Enforced on Linux (seccomp) and macOS (Seatbelt: `process-fork` denied when off; the target's own exec still works via `process-exec*`). |
+| `allow_subprocess` | `bool` | `true` | Allow the sandboxed process to spawn child processes. Enforced on Linux (seccomp) and macOS (Seatbelt: `process-fork` denied when off; the target's own exec still works via `process-exec*`). Set `false` to deny forking. |
 | `env_passthrough` | `list[str]` | `[]` | Environment variable names passed through to the subprocess (all others are stripped). `PATH` is always passed. |
 | `timeout_seconds` | `int` | `60` | Wall-clock limit; process is killed on expiry. |
 

--- a/docs/guide/for-users/configure-sandbox.ja.md
+++ b/docs/guide/for-users/configure-sandbox.ja.md
@@ -62,7 +62,7 @@ sandbox:
 | `write_paths` | パスのリスト | `[]` | プロセスが書き込めるパス（厳密なガード）。書き込みは読み取りを含む。 |
 | `read_deny_paths` | パスのリスト | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。Landlock では非対応。 |
 | `read_paths` | パスのリスト | `[]` | レガシー — かつての厳密な読み込み許可リスト。現在、読み込みはデフォルトで広許可のためこのフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
-| `allow_subprocess` | bool | `false` | 子プロセスの生成を許可。Linux (seccomp) / macOS (Seatbelt) ともに適用。 |
+| `allow_subprocess` | bool | `true` | 子プロセスの生成を許可。Linux (seccomp) / macOS (Seatbelt) ともに適用。制限したいデプロイでは `false` を設定してフォークを拒否。 |
 | `env_passthrough` | 文字列のリスト | `[]` | プロセスに引き渡す環境変数名。`PATH` は常に引き渡されます。 |
 | `timeout_seconds` | int | `60` | ウォールクロック制限。期限超過でプロセスを終了。 |
 

--- a/docs/guide/for-users/configure-sandbox.md
+++ b/docs/guide/for-users/configure-sandbox.md
@@ -68,7 +68,7 @@ restriction: op-level fields govern, and the SandboxLayer is unrestricted.
 | `write_paths` | list of paths | `[]` | Paths the process may write (tight guard). Write implies read. |
 | `read_deny_paths` | list of paths | `[]` | Sensitive paths to deny from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow (Seatbelt); not enforceable on Landlock. |
 | `read_paths` | list of paths | `[]` | Legacy — formerly the strict read allowlist. Reads are broad by default; this field now documents intended read targets only. |
-| `allow_subprocess` | bool | `false` | Allow child-process spawning. Enforced on Linux (seccomp) and macOS (Seatbelt). |
+| `allow_subprocess` | bool | `true` | Allow child-process spawning. Enforced on Linux (seccomp) and macOS (Seatbelt). Set `false` to deny forking for a restrictive deployment. |
 | `env_passthrough` | list of strings | `[]` | Env vars passed through to the process. `PATH` is always passed. |
 | `timeout_seconds` | int | `60` | Wall-clock limit; process is killed on expiry. |
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -342,7 +342,7 @@ sandbox:
 | `write_paths` | list[文字列] | `[]` | プロセスが書き込み可能なパス（厳密なガード）。書き込みは読み取りを含む。 |
 | `read_deny_paths` | list[文字列] | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。許可リストのみのバックエンド（Landlock）では非対応。 |
 | `read_paths` | list[文字列] | `[]` | **レガシー。** かつての厳密な読み込み許可リスト。現在のスコーピングモデルでは読み込みはデフォルトで広許可のため、このフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
-| `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。適用（enforced）— off の時 `process-fork` を deny。 |
+| `allow_subprocess` | bool | `true` | 子プロセスの spawn を許可するか。適用（enforced）— off の時 `process-fork` を deny。制限したい operator は `false` を設定。 |
 | `env_passthrough` | list[文字列] | `[]` | サンドボックスプロセスへ通過させる環境変数名。`PATH` は常に通過します。 |
 | `timeout_seconds` | int | `60` | バックエンドが強制する実時間上限。 |
 

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -768,7 +768,7 @@ When `sandbox.policy` is present, these mirror the `SandboxPolicy` fields. Unkno
 | `write_paths` | list[string] | `[]` | Filesystem paths the process may write (tight guard). Write implies read for these paths. |
 | `read_deny_paths` | list[string] | `[]` | Sensitive paths to DENY from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow rules (Seatbelt); not enforceable on allowlist-only backends (Landlock). |
 | `read_paths` | list[string] | `[]` | **Legacy.** Formerly the strict read allowlist. Reads are broad by default under the current scoping model; this field now documents intended read targets only. |
-| `allow_subprocess` | bool | `false` | Whether the process may spawn children. Enforced — denies `process-fork` when off. |
+| `allow_subprocess` | bool | `true` | Whether the process may spawn children. Enforced — denies `process-fork` when off. Set `false` to deny forking (restrictive operator). |
 | `env_passthrough` | list[string] | `[]` | Env-var names that pass through to the sandboxed process. `PATH` is always passed through. |
 | `timeout_seconds` | int | `60` | Wall-clock cap enforced by the backend. |
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -722,22 +722,32 @@
 #                   ignore (silent fallback)
 #   policy:         operator-level SandboxPolicy overrides (see
 #                   docs/reference/config/reyn-yaml.md "sandbox.policy
-#                   sub-keys" for the full field list). Absent (the default)
-#                   means no agent-level restriction beyond each field's own
-#                   dataclass default (network off, allow_subprocess on,
-#                   write_paths empty, etc).
+#                   sub-keys" for the full field list). NOTE: this mapping is
+#                   applied WHOLESALE, not merged field-by-field — any field
+#                   you omit falls back to its SandboxPolicy default rather
+#                   than to a "restrictive" value. Declare every axis you care
+#                   about explicitly.
 # -----------------------------------------------------------------------------
 # sandbox:
 #   backend: auto
 #   on_unsupported: warn
 #   policy:
-#     # allow_subprocess defaults to true (#2953) — an agent whose workload
-#     # never needs to fork (e.g. a pure data-processing pipeline with no
-#     # git/pytest/build-tool steps) can deny it outright to close off
-#     # fork-based sandbox-escape and resource-exhaustion vectors (spawning
-#     # unbounded children, forking to dodge the parent's own rlimits). The
-#     # other axes (network / write_paths / read_deny_paths) are unaffected
-#     # by this setting and keep enforcing independently.
+#     # Deny forking for a workload that never legitimately needs it (e.g. a
+#     # pure data-processing pipeline with no git / pytest / build-tool steps,
+#     # and no /bin/sh pipeline — a shell pipeline forks per stage).
+#     #
+#     # Denying buys two concrete guarantees, both of which are LOST once
+#     # forking is allowed:
+#     #   1. timeout_seconds stays a real bound. The timeout path kills the
+#     #      direct child; with no fork, "kill the child" == "kill everything".
+#     #      A workload that CAN fork may leave orphaned descendants running
+#     #      past timeout_seconds.
+#     #   2. On Linux, the seccomp default-deny (KILL) syscall filter is
+#     #      installed ONLY when allow_subprocess is false (backends/landlock.py,
+#     #      landlock_exec.py). Allowing fork skips that entire layer, which is
+#     #      also what excludes ptrace / process_vm_readv / keyctl.
+#     #
+#     # (rlimits are NOT a reason either way — they are inherited across fork.)
 #     allow_subprocess: false
 
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -720,10 +720,25 @@
 #   on_unsupported: warn (default, log + fall back to noop)
 #                   error (raise; useful in enforced production)
 #                   ignore (silent fallback)
+#   policy:         operator-level SandboxPolicy overrides (see
+#                   docs/reference/config/reyn-yaml.md "sandbox.policy
+#                   sub-keys" for the full field list). Absent (the default)
+#                   means no agent-level restriction beyond each field's own
+#                   dataclass default (network off, allow_subprocess on,
+#                   write_paths empty, etc).
 # -----------------------------------------------------------------------------
 # sandbox:
 #   backend: auto
 #   on_unsupported: warn
+#   policy:
+#     # allow_subprocess defaults to true (#2953) — an agent whose workload
+#     # never needs to fork (e.g. a pure data-processing pipeline with no
+#     # git/pytest/build-tool steps) can deny it outright to close off
+#     # fork-based sandbox-escape and resource-exhaustion vectors (spawning
+#     # unbounded children, forking to dodge the parent's own rlimits). The
+#     # other axes (network / write_paths / read_deny_paths) are unaffected
+#     # by this setting and keep enforcing independently.
+#     allow_subprocess: false
 
 
 # -----------------------------------------------------------------------------

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -26,7 +26,15 @@ Fields:
         deny-after-allow rule (Seatbelt / SBPL); NOT enforceable on
         allowlist-only backends (Landlock), which rely on the network gate.
         Defaults to OS-level credential locations; ``~`` is expanded.
-    allow_subprocess: whether the process may spawn children
+    allow_subprocess: whether the process may spawn children. Defaults to
+        True (#2953) — operator-tunable, not LLM-tunable (the
+        ``exec__sandboxed_exec`` tool surface never exposes this field; see
+        ``tools/sandboxed_exec.py``). The other axes are the actual security
+        boundary: ``network`` gates exfiltration, ``write_paths`` gates
+        persistence, ``read_deny_paths`` gates credential reads — none of
+        those change with this default. Set ``allow_subprocess: false`` in
+        ``reyn.yaml``'s ``sandbox.policy`` to deny forking for a restrictive
+        deployment.
     env_passthrough: env-var names that pass through to the sandboxed process
     timeout_seconds: wall-clock cap (enforced by the backend)
     max_output_bytes: per-stream cap (bytes) on captured stdout/stderr — output
@@ -68,7 +76,7 @@ class SandboxPolicy:
     read_deny_paths: list[str] = field(
         default_factory=lambda: list(DEFAULT_SENSITIVE_READ_DENY)
     )
-    allow_subprocess: bool = False
+    allow_subprocess: bool = True
     env_passthrough: list[str] = field(default_factory=list)
     timeout_seconds: int = 60
     max_output_bytes: int = MAX_SUBPROCESS_OUTPUT_BYTES

--- a/tests/test_op_sandboxed_exec.py
+++ b/tests/test_op_sandboxed_exec.py
@@ -40,7 +40,7 @@ def test_policy_defaults():
     assert p.network is False
     assert p.read_paths == []
     assert p.write_paths == []
-    assert p.allow_subprocess is False
+    assert p.allow_subprocess is True  # #2953: default flipped false→true
     assert p.env_passthrough == []
     assert p.timeout_seconds == 60
 

--- a/tests/test_sandbox_seccomp.py
+++ b/tests/test_sandbox_seccomp.py
@@ -81,11 +81,12 @@ def test_syscall_allowlist_network_when_enabled() -> None:
     assert "accept" in result
 
 
-def test_syscall_allowlist_no_subprocess_by_default() -> None:
-    """Tier 2: subprocess syscalls absent when policy.allow_subprocess is False (default)."""
+def test_syscall_allowlist_no_subprocess_when_disabled() -> None:
+    """Tier 2: subprocess syscalls absent when policy.allow_subprocess=False (#2953: no
+    longer the SandboxPolicy() default, so this pins the explicit-off case)."""
     from reyn.security.sandbox.backends.seccomp import _build_syscall_allowlist
 
-    result = _build_syscall_allowlist(SandboxPolicy())
+    result = _build_syscall_allowlist(SandboxPolicy(allow_subprocess=False))
     assert "execve" not in result
     assert "fork" not in result
 


### PR DESCRIPTION
**[per-PR-coder]** — Owner-directed security-default relaxation. **Requires security-reviewer co-vet before merge.** This body is written so a reviewer knows exactly what to verify.

> **Stacked on #2956** (the #2954 doc fix). Base is `docs/2954-fix-allow-subprocess-advisory-drift`, not `main` — both PRs touch the same `reyn-yaml.md:771` line. **Merge #2956 first**; this PR's base then auto-retargets to `main`.

## What changes

1. `SandboxPolicy.allow_subprocess`: `False` → `True` (`src/reyn/security/sandbox/policy.py:71`).
2. `reyn.local.yaml.example`: adds a `sandbox.policy:` block with a commented `allow_subprocess: false` (deny-side) example + a rationale comment naming the threat it closes.
3. Default-value column updated in every doc documenting this field, en+ja mirrors (grep-swept, see below).

## Scope: how this differs from #2820 part C (`04d037da`)

Reviewers should not treat this as "same as the precedent."

| | #2820 part C | **This PR** |
|---|---|---|
| What flipped | `_build_mcp_sandbox_policy` only (`mcp/client.py:1039`, `self._config.get("subprocess", True)`) | The `SandboxPolicy` **dataclass default** itself |
| Surface | **MCP stdio server launch only** — a known, operator-declared binary | **Every consumer of the bare `SandboxPolicy()` default**, including `exec__sandboxed_exec`, the general-purpose tool through which the LLM runs arbitrary argv |
| Threat model | Operator picked the server; it forks to bootstrap | LLM picks the argv |

**This is materially broader than the precedent.** The narrowing fact is the LLM-reachability boundary below.

## Why this is defensible despite the broader surface (structural, not census)

`exec__sandboxed_exec` **cannot set the sandbox policy at all**. The tool schema is trimmed to `{argv, timeout_seconds}` (`tools/sandboxed_exec.py:32-45`); `_SANDBOXED_EXEC_PARAMETERS` deliberately omits `network` / `read_paths` / `write_paths` / `allow_subprocess` (pinned by `tests/test_sandbox_model_completion_1339.py::test_tool_schema_is_argv_only`). The handler then resolves the policy from `ctx.default_sandbox_policy` (operator-or-default), which **wins over the op's own fields** (`core/op_runtime/sandboxed_exec.py:61-70`, #1326/#1339).

So this changes **what the operator's silent default is**, not what the LLM can request. An operator who wants fork denied sets it in `reyn.yaml` — hence the new example block. Symmetric with the existing `DEFAULT_SANDBOX_NETWORK = True` owner decision (`policy.py:81`): the operator, not the LLM, owns the policy.

## Verification: the other gates keep enforcing (read from code, not assumed)

**Answering the review question "does flipping this default loosen anything else?" — No.** Each axis is a separate rule keyed off a *different* `SandboxPolicy` field; nothing in either backend branches on `allow_subprocess` to reach another axis.

**Seatbelt** (`security/sandbox/backends/seatbelt.py`, `_build_sbpl_profile`):
- `allow_subprocess` gates **exactly one** rule — L90-93: `(allow process-fork)` if true, else `(deny process-fork)`. That's its entire blast radius.
- **network** — L~96+: `(allow network*)` emitted only when `policy.network`. Unchanged and still `False` by default (`policy.py:65`). **The exfiltration gate is untouched.**
- **read_deny_paths** — L107-112: `(deny file-read* (subpath ...))` per path, emitted after the broad `(allow file-read*)` (SBPL last-match-wins). Still defaults to the 7 credential paths (`DEFAULT_SENSITIVE_READ_DENY`).
- **write_paths** — L114+: `(allow file-write* (subpath ...))`, still `[]` by default.
- The base `(deny default)` + `(import "bsd.sb")` are unconditional.

**seccomp** (`security/sandbox/backends/seccomp.py`, `_build_syscall_allowlist`):
- `allow_subprocess` adds **only** the `execve`/`fork`/`clone` set (L164, `_SUBPROCESS_SYSCALLS` L65). Network syscalls (`socket`/`connect`/`accept`) stay behind `policy.network`.
- Escape hatches (`ptrace`, `process_vm_readv`, `keyctl`, `modify_ldt`, `request_key`) are excluded **unconditionally** — pinned by `test_syscall_allowlist_excludes_escape_hatches`, which asserts against the *most permissive* policy (`network=True, allow_subprocess=True`), i.e. this exact post-flip shape. Destructive fs syscalls (`unlink`/`rmdir`/`rename`/...) likewise never allowed.

**Runtime confirmation** that a deny-side config still resolves correctly through the real resolver:
```
resolve_sandbox_policy({'allow_subprocess': False}, write_paths=['/ws'])  → {'allow_subprocess': False}
SandboxPolicy(**that)  → allow_subprocess=False, network=False,
                          read_deny_paths=['~/.ssh', '~/.aws', ... '~/.netrc']
```
An explicit operator `false` is **not** overridden by the new default, and the sibling axes retain their own defaults.

## Test changes (2 tests pinned the OLD default)

- `test_op_sandboxed_exec.py::test_policy_defaults` — `allow_subprocess is False` → `is True`.
- `test_sandbox_seccomp.py::test_syscall_allowlist_no_subprocess_by_default` → renamed `..._when_disabled`, now passes `SandboxPolicy(allow_subprocess=False)` explicitly (it's no longer the bare default, so the old test would have silently stopped testing the deny path — the negative-coverage case is preserved, not deleted).

Audited all 9 test files referencing `allow_subprocess`: the rest (`test_seatbelt_subprocess_enforcement_1914`, `test_sandbox_argv0_resolve_2820`, `test_1800_hook_shell_runner`, `test_2095_shell_hook_consent_bus`, `test_1199_effective_permission`) pass the field **explicitly** and are default-independent — they stay green and continue guarding the deny path. `hooks/shell_runner.py:422` also hardcodes `allow_subprocess=False`; unaffected.

## Doc sweep (grep-verified, en+ja mirrors)

`grep -rn "allow_subprocess" docs/` — default-value column updated in all 6 user-facing files:
`reyn-yaml.md` / `.ja.md`, `configure-sandbox.md` / `.ja.md`, `concepts/runtime/sandbox.md` / `.ja.md`.

Intentionally **not** changed: `reference/runtime/control-ir.md` / `.ja.md` document the **op-level** `SandboxedExecIROp.allow_subprocess` field, whose Pydantic default remains `False` (`schemas/models.py:293`) — that path is only reachable for phase-authored Control IR, and the operator policy wins over it anyway. Journal / proposal docs (`0017-sandboxed-execution.md`, dogfood results) are historical records and left as-is.

## Test plan
- [x] `SandboxPolicy()` default is `allow_subprocess=True` — `test_policy_defaults` (updated, passing).
- [x] The new `policy:` example is valid YAML — extracted the commented block, `yaml.safe_load` → `{'sandbox': {'backend': 'auto', 'on_unsupported': 'warn', 'policy': {'allow_subprocess': False}}}`.
- [x] Existing tests that explicitly verify `allow_subprocess=False` stay green (the default does not override an explicit value) — `pytest -k "sandbox or subprocess"`: **222 passed, 8 skipped**.
- [x] `ruff check src tests` — All checks passed.
- [x] `python scripts/test_tier_audit.py --strict tests/test_op_sandboxed_exec.py tests/test_sandbox_seccomp.py` — 27 inspected, 0 Tier-4 violations, exit 0.
- [x] `pytest` (repo root) — **8550 passed, 21 skipped** in 216s.
- [x] `python scripts/verify_module_docstrings.py src/reyn/security/sandbox/policy.py` — OK.

Closes #2953