### PR TITLE
feat: builtin RAG ingest + query pipelines + expose signal `meta` on pipeline ctx (FP-0063 P3)

### DIFF
--- a/docs/cookbook/configs/with-builtin-rag-mcp.yaml
+++ b/docs/cookbook/configs/with-builtin-rag-mcp.yaml
@@ -1,4 +1,6 @@
-# FP-0063 P2 -- builtin turnkey user RAG, the MCP layer.
+# FP-0063 -- builtin turnkey user RAG, the MCP layer (P2) + the two
+# builtin pipelines that call it (P3: reyn.builtin.pipelines.rag_ingest /
+# rag_query, registered as rag_ingest.ingest / rag_query.query).
 #
 # This entire ``mcp.servers`` block ships COMMENTED OUT / INERT. Do not
 # assume uncommenting it is safe by default: an MCP server entry, once it
@@ -10,14 +12,16 @@
 # ("the operator explicitly configured this server") only holds if YOU are
 # the one who copies this block into your own reyn.yaml and uncomments it
 # -- reyn itself never wires this in (see reyn.builtin.mcp_servers module
-# docstring). Read the two servers before enabling them: the vector-store
+# docstring). Read the three servers before enabling them: the vector-store
 # server writes to whatever sqlite file `db_path` names; the chunker server
-# reads no filesystem paths itself but the ingest pipeline that will call
-# it (a later phase, P3) reads document files from the folder you point it
-# at.
+# reads no filesystem paths itself; markitdown reads whatever `uri` the
+# ingest pipeline passes it (every file under the folder you point rag_ingest
+# at).
 #
 # Install the extra runtime deps first (NOT part of reyn's base install):
 #   pip install "reyn[builtin-rag]"
+#   uvx markitdown-mcp   # or: pip install markitdown-mcp (pre-install --
+#                         # see the note on R1/uvx-firewall below)
 #
 # Then copy this block into your reyn.yaml (or reyn.local.yaml) and
 # uncomment it:
@@ -25,6 +29,7 @@
 # permissions:
 #   mcp.reyn_vector_store: allow
 #   mcp.reyn_chunker: allow
+#   mcp.reyn_markitdown: allow
 #
 # mcp:
 #   servers:
@@ -45,6 +50,34 @@
 #       # min_characters_per_chunk=24). size/overlap are real parameters,
 #       # not baked-in constants -- tune them per document type.
 #
-# A third-party parser server (e.g. `uvx markitdown-mcp`, Microsoft,
-# converts txt/md/pdf/xlsx/pptx/docx -> Markdown) belongs alongside these
-# two once the ingest pipeline (P3) lands; out of scope for this file.
+#     reyn_markitdown:
+#       type: stdio
+#       command: uvx
+#       args: ["markitdown-mcp"]
+#       # Tool: convert_to_markdown(uri) -- file:/http:/https:/data: -- the
+#       # owner's target format list (txt/md/pdf/xlsx/pptx/docx) plus 15+
+#       # more. `uvx` fetches the package from PyPI on first run: if your
+#       # network is firewalled (FP-0057's own line-55 finding, the same
+#       # failure class as the default embedding model's HuggingFace fetch),
+#       # pre-install instead of relying on the first-run fetch:
+#       #   pip install markitdown-mcp
+#       # and point `command`/`args` at that installed console script
+#       # instead of `uvx`. rag_ingest's own step-0 pre-flight (X1) checks
+#       # reachability BEFORE any embedding spend and fails with this same
+#       # guidance, naming the exact server, rather than a bare transport
+#       # exception.
+#
+# Once the three servers above are configured + granted, run the builtin
+# pipelines directly (no separate skill needed -- invoke-by-name):
+#
+#   run_pipeline(name="rag_ingest.ingest", input={
+#     "input_path": "docs/", "output_db": ".reyn/rag/docs.sqlite"})
+#   run_pipeline(name="rag_query.query", input={
+#     "query_text": "how does X work?", "db": ".reyn/rag/docs.sqlite"})
+#
+# Want a different vector-DB / chunker / parser? Copy
+# src/reyn/builtin/pipelines/rag_ingest.yaml (+ rag_query.yaml) into your
+# own project and re-point the `*_server` inputs (or the MCP config entries
+# they name) at your replacement -- FP-0057 C2: reyn builds no adapter for
+# a user's RAG store, so "copy the builtin and re-point the MCP server" IS
+# the extension mechanism, not a workaround.

--- a/docs/cookbook/configs/with-builtin-rag-mcp.yaml
+++ b/docs/cookbook/configs/with-builtin-rag-mcp.yaml
@@ -1,4 +1,4 @@
-# FP-0063 -- builtin turnkey user RAG, the MCP layer (P2) + the two
+# FP-0063 -- builtin user RAG, the MCP layer (P2) + the two
 # builtin pipelines that call it (P3: reyn.builtin.pipelines.rag_ingest /
 # rag_query, registered as rag_ingest.ingest / rag_query.query).
 #
@@ -66,6 +66,15 @@
 #       # reachability BEFORE any embedding spend and fails with this same
 #       # guidance, naming the exact server, rather than a bare transport
 #       # exception.
+#
+# ⚠️ rag_ingest ALSO requires that `python3` on your PATH be reyn's own
+# interpreter -- it shells out to `python3 -m reyn.builtin.rag_ingest_helpers`
+# and sandboxed_exec forwards the ambient PATH. A `pipx install reyn` or a
+# non-activated venv will NOT work. Check with:
+#   python3 -c 'import reyn; print(reyn.__file__)'
+# It must print the same install you run reyn from. rag_ingest's step-0
+# pre-flight reports this rather than failing opaquely, but it is a real
+# limitation (tracked on the FP-0063 umbrella), not a formality.
 #
 # Once the three servers above are configured + granted, run the builtin
 # pipelines directly (no separate skill needed -- invoke-by-name):

--- a/docs/reference/runtime/pipeline-dsl.ja.md
+++ b/docs/reference/runtime/pipeline-dsl.ja.md
@@ -218,19 +218,44 @@ FieldType     ::= "{" "type:" ("bool" | "string" | "number") "}"
 #### `tool` ステップの結果 {#tool-step-results}
 
 `tool`(および `shell`)ステップの結果 — `pipe` と `ctx.<output>` に入るもの —
-は常にフラットな 2 フィールド形状 `{text: ..., structured: ...}` で、
+は常にフラットな形状 `{text: ..., structured: ..., meta: ...}` で、
 すべてのツール種別で統一されています(chat 側が LLM に見せるのと同じ形状):
 
 - **`text`** — ツールの正規の文字列本体(ツールにテキスト形状の結果が無い場合は空文字列)。
 - **`structured`** — ツールが非テキストのデータを出したときだけ存在する。それ以外は
   キー自体が無い。認識されない形状のツール結果 dict は、丸ごと `structured` として
   ラップされる(何も失われない)。
+- **`meta`** — ツールの**シグナル**フィールド。「呼び出し側が次に何をするかを変える」ため、
+  producer が本体からあえて外した、小さく情報量の多い値。ツールが何かシグナルを出した
+  ときだけ存在し、それ以外はキー自体が無い — 成功結果の多くはシグナルを持たないので、
+  無いほうが通常です。
 
 この変換は**形状のみ**です — chat 側のツール結果パスのように値を切り詰めたり
 offload したり cap したりは絶対にしません。pipeline ステップの `ctx` は、後続の
 ステップがプログラム的に消費できるよう、値をフルで保持します。ツールのテキスト本体は
 `ctx.<name>.text` で、structured なペイロードは `ctx.<name>.structured`(またはその
 フィールド、例: `ctx.hits.structured.count`)で読みます。
+
+**`meta` を安全に読む。** `meta` は producer がシグナルを出さないと存在しないため、
+そうした producer に対して素の `ctx.<name>.meta.<field>` パスは**例外を投げます**
+(素のパスは safe navigation ではありません — [R1 式言語](#the-r1-expression-language)
+参照)。これは意図的です: シグナルに依存するステップは、黙って既定値を読むのではなく、
+大きな音を立てて失敗すべきだからです。シグナルが本当に任意の場合は `get(...)` を使います:
+
+```yaml
+- tool: {name: embed, args: {texts: !expr ctx.chunks}, output: embedded}
+# 実際にベクトルを生成したモデル(`embedding_model` 入力は "standard" のような
+# モデル**クラス別名**でありうる。`meta.model` はそれが解決された結果):
+- transform: {value: "ctx.embedded.meta.model", output: resolved_model}
+# 任意のシグナル — raise させずに既定値を使う:
+- transform: {value: "get(ctx.embedded, 'meta.cost_usd', null)", output: spend}
+```
+
+あるツールが `meta` に何を入れるかは、そのツール自身の契約です。代表例:
+`embed` → `model` / `total_tokens` / `cost_usd` / `priced`、`sandboxed_exec` →
+非ゼロの `returncode`(ゼロ終了はシグナルではないのでキー無し)、MCP 呼び出し →
+`isError`。結果そのものである `structured` に対し、`meta` は「その結果が**いくら
+かかったか**」「**どう**生成されたか」が必要なときに使います。
 
 `shell` は `"shell"` という名前の `tool` ステップのシュガーです: `command` は operator のサンドボックス(`sandboxed_exec` — 直接の `sandboxed_exec` 呼び出しと同じ閉じ込め、ポリシー優先順位、監査イベント)の中で `/bin/sh -c <command>` として実行されます。ステップに入ってくる pipe data はプロセスの **STDIN に JSON エンコードされて**渡されます。プロセスの **STDOUT がステップの結果になります** — JSON として parse できればデコードされ(`dict` を要求する `verify: schema` が JSON を出力するコマンドに適用できるように)、できなければ生のテキストのままです — そして、その(生または JSON デコード済みの)値は他の `tool` ステップと同じ `text`/`structured` 変換を経ます(JSON デコードされた dict は `ctx.<name>.structured` に、生のテキストは `ctx.<name>.text` に入ります)。
 

--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -297,7 +297,7 @@ registered tool name (`web_search`).
 #### `tool` step results
 
 A `tool` (and `shell`) step's result — what lands as `pipe` and `ctx.<output>`
-— is always the flat two-field shape `{text: ..., structured: ...}`, uniform
+— is always the flat shape `{text: ..., structured: ..., meta: ...}`, uniform
 across every tool kind (the same shape the chat side exposes to an LLM):
 
 - **`text`** — the tool's canonical string body (empty string when the tool
@@ -305,12 +305,39 @@ across every tool kind (the same shape the chat side exposes to an LLM):
 - **`structured`** — present only when the tool produced non-text data; absent
   entirely (no key) otherwise. A tool result dict with no recognized shape is
   wrapped whole as `structured` (nothing is ever lost).
+- **`meta`** — the tool's **signal** fields: small, high-signal values the
+  producer deliberately kept out of the body because they change what the
+  caller does next. Present only when the tool emitted any; absent entirely
+  (no key) otherwise — which is the common case, since most successful
+  results carry no signal.
 
 This conversion is **shape-only** — it never truncates, offloads, or caps a
 value the way the chat-side tool-result path does; a pipeline step's `ctx`
 retains the full value for downstream steps to consume programmatically.
 Read a tool's text body via `ctx.<name>.text` and its structured payload via
 `ctx.<name>.structured` (or a field of it, e.g. `ctx.hits.structured.count`).
+
+**Reading `meta` safely.** Because `meta` is absent when a producer emits no
+signal, a bare `ctx.<name>.meta.<field>` path *raises* on such a producer
+(bare paths are not safe navigation — see
+[The R1 expression language](#the-r1-expression-language)). That is
+deliberate: a step that depends on a signal fails loudly rather than silently
+reading a default. Use `get(...)` when the signal is genuinely optional:
+
+```yaml
+- tool: {name: embed, args: {texts: !expr ctx.chunks}, output: embedded}
+# the model that ACTUALLY produced the vectors (an `embedding_model` input may
+# be a model-CLASS alias like "standard"; meta.model is what it resolved to):
+- transform: {value: "ctx.embedded.meta.model", output: resolved_model}
+# optional signals — default rather than raise:
+- transform: {value: "get(ctx.embedded, 'meta.cost_usd', null)", output: spend}
+```
+
+What a given tool puts in `meta` is that tool's own contract; common examples:
+`embed` → `model` / `total_tokens` / `cost_usd` / `priced`; `sandboxed_exec` →
+a nonzero `returncode` (a zero exit is not signal, so no key); an MCP call →
+`isError`. Reach for `meta` when you need what a result *cost* or *how* it was
+produced — as opposed to `structured`, which is the result itself.
 
 `shell` is sugar for a `tool` step named `"shell"`: `command` runs as
 `/bin/sh -c <command>` inside the operator's sandbox

--- a/src/reyn/builtin/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/pipelines/rag_ingest.yaml
@@ -1,4 +1,4 @@
-# Builtin turnkey RAG -- ingest pipeline (FP-0063 P3).
+# Builtin RAG -- ingest pipeline (FP-0063 P3).
 # docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md
 #
 # Reads a file or a folder, converts each document to Markdown (the
@@ -12,6 +12,17 @@
 # `*_server` inputs (or the MCP config entries they name) at a different
 # backend. Every tunable is a `ctx.*` INPUT with a sane default, never a
 # constant baked into a step (R4).
+#
+# ⚠️ ENVIRONMENT REQUIREMENT -- this is NOT yet turnkey. This pipeline
+# shells out to `python3` (for hashing / string length / zip-by-index, the
+# three things the R1 expression language cannot express), and
+# `sandboxed_exec` forwards the ambient PATH, so `python3` MUST be the same
+# interpreter reyn itself runs under. A `pipx install reyn`, a
+# non-activated venv, or any PATH whose `python3` differs will FAIL. The
+# DSL cannot reach `sys.executable` today; closing this needs a core/DSL
+# decision, tracked on the FP-0063 umbrella. Step 0 pre-flights it so the
+# failure is named rather than opaque -- but it is a real limitation, not
+# a formality.
 #
 # Inputs (all optional except `input_path`/`output_db`):
 #   input_path          -- (required) a document file OR a folder of them.
@@ -49,11 +60,12 @@ fields:
 ---
 pipeline: ingest
 description: >-
-  FP-0063 P3 builtin turnkey RAG ingest: chunk -> embed -> store a file or
-  folder into a user-named sqlite vector store, incrementally by
-  content_hash (add/update/remove). Pre-flights the 3 required MCP servers
-  before any embedding spend (X1); reports spend AFTER the dedup skip
-  (X2a/X5).
+  FP-0063 P3 builtin RAG ingest: chunk -> embed -> store a file or folder
+  into a user-named sqlite vector store, incrementally by content_hash
+  (add/update/remove). Pre-flights its 3 MCP servers AND its python3
+  helper before any embedding spend (X1); reports spend AFTER the dedup
+  skip (X2a/X5). REQUIRES that `python3` on PATH be reyn's own
+  interpreter -- see the file header.
 steps:
   # ---- inputs-with-defaults (R4: never a constant baked into a step) ----
   - transform: {value: "get(ctx, 'chunk_size', 400)", output: chunk_size}
@@ -75,8 +87,24 @@ steps:
       value: >-
         {markitdown: "MarkItDown MCP server '" + ctx.markitdown_server + "' is unreachable. (1) it may not be enabled yet -- builtin MCP configs ship INERT by design; add/uncomment mcp.servers." + ctx.markitdown_server + " in reyn.yaml (or reyn.local.yaml) and set permissions.mcp." + ctx.markitdown_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if it is already enabled, uvx likely failed to fetch markitdown-mcp from PyPI on first run (e.g. a firewalled network) -- pre-install it instead of relying on the first-run fetch: pip install markitdown-mcp.",
          chunker: "Chunker MCP server '" + ctx.chunker_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.chunker_server + " in reyn.yaml and set permissions.mcp." + ctx.chunker_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependency: pip install \"reyn[builtin-rag]\" (chonkie).",
-         vectorstore: "Vector-store MCP server '" + ctx.vectorstore_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.vectorstore_server + " in reyn.yaml and set permissions.mcp." + ctx.vectorstore_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependencies: pip install \"reyn[builtin-rag]\" (apsw + sqlite-vec)."}
+         vectorstore: "Vector-store MCP server '" + ctx.vectorstore_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.vectorstore_server + " in reyn.yaml and set permissions.mcp." + ctx.vectorstore_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependencies: pip install \"reyn[builtin-rag]\" (apsw + sqlite-vec).",
+         helpers: "`python3 -m reyn.builtin.rag_ingest_helpers` failed -- the `python3` on PATH cannot import reyn. This pipeline shells out to `python3` for the three things the R1 expression language cannot do (hash, string length, zip-by-index), and it must be the SAME interpreter reyn itself runs under: sandboxed_exec passes the ambient PATH through, and the DSL cannot reach sys.executable today (a known FP-0063 limitation -- reyn is NOT turnkey in this respect; see the umbrella issue). (1) run reyn from an environment whose `python3` IS reyn's interpreter -- typically `source .venv/bin/activate` for the venv you installed reyn into; note a `pipx install reyn` or a non-activated venv will NOT satisfy this. (2) check what you actually have: `python3 -c 'import reyn; print(reyn.__file__)'` -- it must print the SAME install that is running this pipeline (if it prints a different reyn, that is the bug, and this pre-flight cannot detect it for you)."}
       output: remedies
+
+  # The helper-interpreter probe -- part of X1 (a reachability check, so it
+  # rides the same pre-flight list as the MCP servers below). A FAILING
+  # `shell` step does NOT raise: `shell` returns stdout ONLY (returncode and
+  # stderr are dropped above the canonical seam by #2593's locked design, so
+  # `meta` is always empty for a shell step -- there is no `meta.returncode`
+  # to read here). Empty stdout means no `structured` key, which is what this
+  # detects. Without it, a `python3` that cannot import reyn surfaces later as
+  # an opaque "path 'ctx.files_raw.structured' is absent".
+  - shell:
+      command: "python3 -m reyn.builtin.rag_ingest_helpers probe"
+      output: helper_probe
+  - transform:
+      value: "get(ctx.helper_probe, 'structured', null) != null"
+      output: helpers_ok
   - parallel:
       on_error: continue
       branches:
@@ -115,7 +143,8 @@ steps:
       value: >-
         [{name: "markitdown (" + ctx.markitdown_server + ")", ok: ctx.reachable.markitdown, remedy: ctx.remedies.markitdown},
          {name: "chunker (" + ctx.chunker_server + ")", ok: ctx.reachable.chunker, remedy: ctx.remedies.chunker},
-         {name: "vectorstore (" + ctx.vectorstore_server + ")", ok: ctx.reachable.vectorstore, remedy: ctx.remedies.vectorstore}]
+         {name: "vectorstore (" + ctx.vectorstore_server + ")", ok: ctx.reachable.vectorstore, remedy: ctx.remedies.vectorstore},
+         {name: "helpers (python3 -m reyn.builtin.rag_ingest_helpers)", ok: ctx.helpers_ok, remedy: ctx.remedies.helpers}]
       output: preflight_checks
   - transform:
       value: "count(filter(ctx.preflight_checks, c -> not c.ok)) == 0"
@@ -151,13 +180,14 @@ pipeline: _blocked
 description: >-
   Sibling of ingest -- returns the X1 pre-flight failure as the run's own
   (successful) output: a typed, decision-enabling message naming every
-  unreachable server + its concrete remedy, instead of letting a bare MCP
-  transport exception (e.g. "ImportError: No module named 'apsw'") reach
-  the operator.
+  unreachable prerequisite (the 3 MCP servers + the python3 helper) and its
+  concrete remedy, instead of letting a bare transport exception (e.g.
+  "ImportError: No module named 'apsw'") or an opaque downstream
+  "path 'ctx.files_raw.structured' is absent" reach the operator.
 steps:
   - transform:
       value: >-
-        "rag ingest blocked -- one or more required MCP servers are unreachable:\n\n" + ctx.message
+        "rag ingest blocked -- one or more prerequisites are unreachable:\n\n" + ctx.message
       output: blocked_reason
 ---
 pipeline: _ingest_one_file
@@ -195,9 +225,10 @@ description: >-
   discover files -> per-file convert+chunk+hash (fan-out) -> flatten ->
   diff against the vector store's existing metadata by content_hash (C5:
   add/update/remove) -> embed only the new/changed chunks, stamping
-  embedding_model from THIS pipeline's own input (C4 -- see ingest's
-  description for why not envelope.model) -> upsert + remove -> report a
-  summary including the X2a/X5 estimated-spend figures.
+  embedding_model from the RESOLVED model on embed's own envelope meta
+  (C4 -- see _ingest_embed_and_upsert) -> upsert + remove -> report a
+  summary carrying the X2a METERED spend for the batch plus X5's
+  dedup-saved estimate.
 steps:
   - transform: {value: "{input_path: ctx.input_path}"}
   - shell:

--- a/src/reyn/builtin/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/pipelines/rag_ingest.yaml
@@ -23,16 +23,12 @@
 #   chunk_overlap_ratio -- chunker overlap fraction (default 0.125 = 12.5%,
 #                          within the 10-15% 2026 default band).
 #   embedding_model     -- passed to reyn's `embed` tool (default
-#                          "standard"). Stamped onto every chunk's
-#                          `embedding_model` column (C4) -- pass a CONCRETE
-#                          model id (not a class alias like the default) if
-#                          the alias could ever re-resolve to a different
-#                          model later, since that is the one thing this
-#                          arc CANNOT read back from `embed`'s own envelope
-#                          today (`envelope.model` is not reachable from
-#                          pipeline `ctx` -- see the PR body's architecture-
-#                          gap note; a small, separate core PR could close
-#                          this).
+#                          "standard"). This may be a model-CLASS alias;
+#                          what gets STAMPED onto each chunk's
+#                          `embedding_model` column (C4) is the model the
+#                          provider actually RESOLVED, read back from
+#                          `embed`'s own envelope meta -- so the column can
+#                          never disagree with the vectors beside it.
 #   markitdown_server / chunker_server / vectorstore_server -- the MCP
 #                          server names as configured under `mcp.servers`
 #                          (defaults: reyn_markitdown / reyn_chunker /
@@ -40,9 +36,12 @@
 #                          docs/cookbook/configs/with-builtin-rag-mcp.yaml).
 #
 # Output: `ctx.result` -- either `_ingest_body`'s summary (files/chunks
-# added/updated/removed/unchanged + the X2a/X5 estimated-spend figures) or
-# `_blocked`'s X1 pre-flight failure message (cause + concrete remedy per
-# unreachable server -- mirrors #2932's `require_mcp` decision-enabling
+# added/updated/removed/unchanged, the resolved `embedding_model`, and the
+# X2a METERED spend for this batch: `tokens_embedded` / `cost_usd` /
+# `priced`, read from `embed`'s own envelope meta -- plus X5's
+# `estimated_tokens_saved_by_dedup`, the one necessarily-estimated figure)
+# or `_blocked`'s X1 pre-flight failure message (cause + concrete remedy
+# per unreachable server -- mirrors #2932's `require_mcp` decision-enabling
 # error, never a bare transport exception).
 schema: PreflightCheck
 fields:
@@ -260,7 +259,12 @@ steps:
       output: to_remove_ids
 
   # X5: dedup visibility -- how many chunks were SKIPPED (unchanged), and
-  # the estimated tokens that would have been spent re-embedding them.
+  # the tokens that would have been spent re-embedding them. The SKIPPED
+  # side is inherently an ESTIMATE (chars/4, the same fallback embed's own
+  # provider uses): the only way to know a skipped chunk's true token count
+  # is to send it to the embedder, which is exactly the spend the skip
+  # exists to avoid. The EMBEDDED side, by contrast, is measured exactly --
+  # see the summary step below.
   - transform: {value: "count(ctx.all_items) - count(ctx.to_upsert)", output: unchanged_count}
   - transform: {value: "sum(map(ctx.all_items, i -> i.est_tokens))", output: est_tokens_if_no_dedup}
   - transform: {value: "sum(map(ctx.to_upsert, i -> i.est_tokens))", output: est_tokens_embedded}
@@ -293,15 +297,22 @@ steps:
         tool_args: !expr "{db_path: ctx.output_db, ids: ctx.to_remove_ids}"
       output: delete_result
 
+  # X2a -- the spend report. `tokens_embedded` / `cost_usd` are embed's OWN
+  # METERED figures (envelope meta), not an estimate; `embedding_model` is
+  # the model that actually produced the vectors (C4). Only
+  # `estimated_tokens_saved_by_dedup` is an estimate, and necessarily so
+  # (see the X5 step above) -- its name says which of the two it is.
   - transform:
       value: >-
         {files_scanned: count(ctx.files),
          chunks_upserted: ctx.upsert_outcome.upserted,
          chunks_removed: ctx.delete_result.structured.deleted,
          chunks_unchanged_skipped: ctx.unchanged_count,
-         estimated_tokens_embedded: ctx.est_tokens_embedded,
-         estimated_tokens_saved_by_dedup: ctx.est_tokens_if_no_dedup - ctx.est_tokens_embedded,
-         note: "token figures are a chars/4 ESTIMATE (the same fallback embed's own provider uses), not the metered actual -- embed's per-call cost_usd/total_tokens are not reachable from pipeline ctx today (see the PR body's architecture-gap note)."}
+         embedding_model: ctx.upsert_outcome.model,
+         tokens_embedded: ctx.upsert_outcome.tokens,
+         cost_usd: ctx.upsert_outcome.cost_usd,
+         priced: ctx.upsert_outcome.priced,
+         estimated_tokens_saved_by_dedup: ctx.est_tokens_if_no_dedup - ctx.est_tokens_embedded}
       output: summary
 ---
 pipeline: _ingest_embed_and_upsert
@@ -317,10 +328,19 @@ steps:
         texts: !expr "map(ctx.to_upsert, i -> i.text)"
         embedding_model: !expr ctx.embedding_model
       output: embedded
+
+  # C4 -- stamp the RESOLVED model (`embed`'s own envelope meta), NOT this
+  # pipeline's `embedding_model` INPUT. The input is typically a model-CLASS
+  # alias ("standard"); writing that into the per-chunk embedding_model
+  # column would record a model that never produced these vectors -- the
+  # exact "the column becomes a lie" failure FP-0057's C1 hard gate exists
+  # to prevent. `envelope.model` is what the provider actually resolved, so
+  # C4 holds BY CONSTRUCTION here.
+  - transform: {value: "ctx.embedded.meta.model", output: resolved_model}
   - transform:
       value: >-
         {items: ctx.to_upsert, vectors: ctx.embedded.structured,
-         embedding_model: ctx.embedding_model, parent_context: ctx.input_path}
+         embedding_model: ctx.resolved_model, parent_context: ctx.input_path}
   - shell:
       command: "python3 -m reyn.builtin.rag_ingest_helpers zip_vectors"
       output: to_upsert_zipped
@@ -331,12 +351,28 @@ steps:
         mcp_tool_name: upsert
         tool_args: !expr "{db_path: ctx.output_db, items: ctx.to_upsert_zipped.structured}"
       output: upsert_result
-  - transform: {value: "ctx.upsert_result.structured", output: outcome}
+
+  # X2a -- the MEASURED spend for this batch (embed's own metered usage),
+  # not an estimate. `cost_usd` is null when litellm cannot price the model
+  # (an unpriced model degrades VISIBLY, never silently as $0.00 -- the
+  # #1829 sentinel), so it is carried through as-is alongside `priced`.
+  - transform:
+      value: >-
+        {upserted: ctx.upsert_result.structured.upserted,
+         tokens: ctx.embedded.meta.total_tokens,
+         cost_usd: get(ctx.embedded, "meta.cost_usd", null),
+         priced: get(ctx.embedded, "meta.priced", false),
+         model: ctx.resolved_model}
+      output: outcome
 ---
 pipeline: _ingest_noop_upsert
 description: >-
   Sibling of _ingest_embed_and_upsert -- the "nothing new to embed" branch
-  (X5: a fully-deduped re-ingest), returning the same {"upserted": 0} shape
-  without calling embed at all.
+  (X5: a fully-deduped re-ingest), returning the same outcome shape without
+  calling embed at all. Spend is a REAL zero here (nothing was embedded),
+  hence priced: true -- distinct from the unpriced-model null cost_usd the
+  sibling can carry.
 steps:
-  - transform: {value: "{upserted: 0}", output: outcome}
+  - transform:
+      value: "{upserted: 0, tokens: 0, cost_usd: 0.0, priced: true, model: null}"
+      output: outcome

--- a/src/reyn/builtin/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/pipelines/rag_ingest.yaml
@@ -1,0 +1,342 @@
+# Builtin turnkey RAG -- ingest pipeline (FP-0063 P3).
+# docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md
+#
+# Reads a file or a folder, converts each document to Markdown (the
+# `markitdown` MCP server), chunks it (the `chunker` MCP server), embeds
+# only the NEW/CHANGED chunks (reyn's own `embed` tool -- C1: reyn is the
+# SOLE embedder), and upserts them into a user-named sqlite vector store
+# (the `vectorstore` MCP server) -- FP-0057 C2: the store is external, reyn
+# hosts none of it.
+#
+# This file IS the extension mechanism (R2): copy it and re-point the
+# `*_server` inputs (or the MCP config entries they name) at a different
+# backend. Every tunable is a `ctx.*` INPUT with a sane default, never a
+# constant baked into a step (R4).
+#
+# Inputs (all optional except `input_path`/`output_db`):
+#   input_path          -- (required) a document file OR a folder of them.
+#   output_db           -- (required) the sqlite file to write into.
+#   chunk_size          -- chunker token size (default 400 -- the 2026
+#                          256-512-token persistent-RAG band, NOT FP-0057's
+#                          800-1024 (that number is for throwaway ephemeral
+#                          attachments -- a different case, R4)).
+#   chunk_overlap_ratio -- chunker overlap fraction (default 0.125 = 12.5%,
+#                          within the 10-15% 2026 default band).
+#   embedding_model     -- passed to reyn's `embed` tool (default
+#                          "standard"). Stamped onto every chunk's
+#                          `embedding_model` column (C4) -- pass a CONCRETE
+#                          model id (not a class alias like the default) if
+#                          the alias could ever re-resolve to a different
+#                          model later, since that is the one thing this
+#                          arc CANNOT read back from `embed`'s own envelope
+#                          today (`envelope.model` is not reachable from
+#                          pipeline `ctx` -- see the PR body's architecture-
+#                          gap note; a small, separate core PR could close
+#                          this).
+#   markitdown_server / chunker_server / vectorstore_server -- the MCP
+#                          server names as configured under `mcp.servers`
+#                          (defaults: reyn_markitdown / reyn_chunker /
+#                          reyn_vector_store -- see
+#                          docs/cookbook/configs/with-builtin-rag-mcp.yaml).
+#
+# Output: `ctx.result` -- either `_ingest_body`'s summary (files/chunks
+# added/updated/removed/unchanged + the X2a/X5 estimated-spend figures) or
+# `_blocked`'s X1 pre-flight failure message (cause + concrete remedy per
+# unreachable server -- mirrors #2932's `require_mcp` decision-enabling
+# error, never a bare transport exception).
+schema: PreflightCheck
+fields:
+  status: {type: enum, values: ["ok"]}
+---
+pipeline: ingest
+description: >-
+  FP-0063 P3 builtin turnkey RAG ingest: chunk -> embed -> store a file or
+  folder into a user-named sqlite vector store, incrementally by
+  content_hash (add/update/remove). Pre-flights the 3 required MCP servers
+  before any embedding spend (X1); reports spend AFTER the dedup skip
+  (X2a/X5).
+steps:
+  # ---- inputs-with-defaults (R4: never a constant baked into a step) ----
+  - transform: {value: "get(ctx, 'chunk_size', 400)", output: chunk_size}
+  - transform: {value: "get(ctx, 'chunk_overlap_ratio', 0.125)", output: chunk_overlap_ratio}
+  - transform: {value: "get(ctx, 'embedding_model', 'standard')", output: embedding_model}
+  - transform: {value: "get(ctx, 'markitdown_server', 'reyn_markitdown')", output: markitdown_server}
+  - transform: {value: "get(ctx, 'chunker_server', 'reyn_chunker')", output: chunker_server}
+  - transform: {value: "get(ctx, 'vectorstore_server', 'reyn_vector_store')", output: vectorstore_server}
+
+  # ---- X1: pre-flight -- a REAL probe call per server (not just "is it
+  # configured"), schema-gated to status=="ok" so an MCP-layer error
+  # (unconfigured server / permission-denied / transport fault / a raised
+  # ImportError inside the server itself -- e.g. "No module named 'apsw'")
+  # fails that ONE branch without aborting the others (`parallel`'s
+  # `on_error: continue` -- a dropped branch's key is simply absent from
+  # `collect`'s named map, so we know WHICH server failed by name, with no
+  # need to parse the underlying transport error text). ----
+  - transform:
+      value: >-
+        {markitdown: "MarkItDown MCP server '" + ctx.markitdown_server + "' is unreachable. (1) it may not be enabled yet -- builtin MCP configs ship INERT by design; add/uncomment mcp.servers." + ctx.markitdown_server + " in reyn.yaml (or reyn.local.yaml) and set permissions.mcp." + ctx.markitdown_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if it is already enabled, uvx likely failed to fetch markitdown-mcp from PyPI on first run (e.g. a firewalled network) -- pre-install it instead of relying on the first-run fetch: pip install markitdown-mcp.",
+         chunker: "Chunker MCP server '" + ctx.chunker_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.chunker_server + " in reyn.yaml and set permissions.mcp." + ctx.chunker_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependency: pip install \"reyn[builtin-rag]\" (chonkie).",
+         vectorstore: "Vector-store MCP server '" + ctx.vectorstore_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.vectorstore_server + " in reyn.yaml and set permissions.mcp." + ctx.vectorstore_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependencies: pip install \"reyn[builtin-rag]\" (apsw + sqlite-vec)."}
+      output: remedies
+  - parallel:
+      on_error: continue
+      branches:
+        markitdown:
+          tool:
+            name: call_mcp_tool
+            schema: PreflightCheck
+            args:
+              server: !expr ctx.markitdown_server
+              mcp_tool_name: convert_to_markdown
+              tool_args: {uri: "data:text/plain;base64,cmVhY2hhYmlsaXR5IHByb2Jl"}
+        chunker:
+          tool:
+            name: call_mcp_tool
+            schema: PreflightCheck
+            args:
+              server: !expr ctx.chunker_server
+              mcp_tool_name: chunk
+              tool_args: {text: "reachability probe", size: 50, overlap_ratio: 0.0}
+        vectorstore:
+          tool:
+            name: call_mcp_tool
+            schema: PreflightCheck
+            args:
+              server: !expr ctx.vectorstore_server
+              mcp_tool_name: list_metadata
+              tool_args: !expr "{db_path: ctx.output_db, limit: 1}"
+      collect:
+        transform:
+          value: >-
+            {markitdown: get(pipe, "markitdown", null) != null,
+             chunker: get(pipe, "chunker", null) != null,
+             vectorstore: get(pipe, "vectorstore", null) != null}
+      output: reachable
+  - transform:
+      value: >-
+        [{name: "markitdown (" + ctx.markitdown_server + ")", ok: ctx.reachable.markitdown, remedy: ctx.remedies.markitdown},
+         {name: "chunker (" + ctx.chunker_server + ")", ok: ctx.reachable.chunker, remedy: ctx.remedies.chunker},
+         {name: "vectorstore (" + ctx.vectorstore_server + ")", ok: ctx.reachable.vectorstore, remedy: ctx.remedies.vectorstore}]
+      output: preflight_checks
+  - transform:
+      value: "count(filter(ctx.preflight_checks, c -> not c.ok)) == 0"
+      output: preflight_ok
+  - transform:
+      value: >-
+        join(map(filter(ctx.preflight_checks, c -> not c.ok), c -> c.name + ": " + c.remedy), "\n\n")
+      output: preflight_message
+
+  # ---- gate: only proceed to the real ingest work if every server probed
+  # OK; otherwise return the decision-enabling message as the run's own
+  # output (never a bare exception -- see _blocked below). ----
+  - match:
+      on: ctx.preflight_ok
+      cases:
+        "True":
+          pipeline: _ingest_body
+          pass:
+            input_path: ctx.input_path
+            output_db: ctx.output_db
+            chunk_size: ctx.chunk_size
+            chunk_overlap_ratio: ctx.chunk_overlap_ratio
+            embedding_model: ctx.embedding_model
+            markitdown_server: ctx.markitdown_server
+            chunker_server: ctx.chunker_server
+            vectorstore_server: ctx.vectorstore_server
+      default:
+        pipeline: _blocked
+        pass: {message: ctx.preflight_message}
+      output: result
+---
+pipeline: _blocked
+description: >-
+  Sibling of ingest -- returns the X1 pre-flight failure as the run's own
+  (successful) output: a typed, decision-enabling message naming every
+  unreachable server + its concrete remedy, instead of letting a bare MCP
+  transport exception (e.g. "ImportError: No module named 'apsw'") reach
+  the operator.
+steps:
+  - transform:
+      value: >-
+        "rag ingest blocked -- one or more required MCP servers are unreachable:\n\n" + ctx.message
+      output: blocked_reason
+---
+pipeline: _ingest_one_file
+description: >-
+  Convert one file to Markdown (markitdown), chunk it (chunker), and hash
+  each chunk (reyn.builtin.rag_ingest_helpers.hash_chunks -- R1 has no
+  string-length/hash primitive). Called once per file by ingest's for_each
+  fan-out. Returns this file's candidate chunk items: [{id, text,
+  content_hash, chunk_index, size_tokens, est_tokens, source_path}, ...].
+steps:
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.markitdown_server
+        mcp_tool_name: convert_to_markdown
+        tool_args: !expr "{uri: 'file://' + ctx.source_path}"
+      output: converted
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.chunker_server
+        mcp_tool_name: chunk
+        tool_args: !expr "{text: ctx.converted.text, size: ctx.chunk_size, overlap_ratio: ctx.chunk_overlap_ratio}"
+      output: chunked
+  - transform:
+      value: "{source_path: ctx.source_path, chunks: ctx.chunked.structured.result}"
+  - shell:
+      command: "python3 -m reyn.builtin.rag_ingest_helpers hash_chunks"
+      output: enriched
+  - transform: {value: "ctx.enriched.structured", output: items}
+---
+pipeline: _ingest_body
+description: >-
+  The real ingest work, run only after ingest's X1 pre-flight passes:
+  discover files -> per-file convert+chunk+hash (fan-out) -> flatten ->
+  diff against the vector store's existing metadata by content_hash (C5:
+  add/update/remove) -> embed only the new/changed chunks, stamping
+  embedding_model from THIS pipeline's own input (C4 -- see ingest's
+  description for why not envelope.model) -> upsert + remove -> report a
+  summary including the X2a/X5 estimated-spend figures.
+steps:
+  - transform: {value: "{input_path: ctx.input_path}"}
+  - shell:
+      command: "python3 -m reyn.builtin.rag_ingest_helpers list_files"
+      output: files_raw
+  - transform: {value: "ctx.files_raw.structured", output: files}
+
+  # Per-file fan-out (concurrent, isolated -- pipeline-dsl.md's for_each):
+  # one bad file does not abort the whole ingest (on_error: continue).
+  - for_each:
+      over: ctx.files
+      max_parallel: 4
+      on_error: continue
+      do:
+        call:
+          pipeline: _ingest_one_file
+          pass:
+            source_path: item
+            chunk_size: ctx.chunk_size
+            chunk_overlap_ratio: ctx.chunk_overlap_ratio
+            markitdown_server: ctx.markitdown_server
+            chunker_server: ctx.chunker_server
+      collect: {transform: {value: "pipe"}}
+      output: per_file_items
+
+  # Flatten the list-of-lists (one list per file) into one flat list of
+  # chunk items -- `fold` + list concatenation (R1's `+` also concatenates
+  # lists; there is no flatten/flatMap combinator).
+  - fold:
+      over: ctx.per_file_items
+      init: "[]"
+      do: {transform: {value: "acc + item"}}
+      output: all_items
+
+  # C5: fetch the existing corpus SCOPED TO THIS input_path (via
+  # `parent_context` -- repurposed here as the ingest-root tag stamped on
+  # every chunk this pipeline writes, since `list_metadata`'s filter is
+  # single-field-equality only, and content_hash/source_path alone can't
+  # scope a multi-file "what did THIS folder ingest previously" query).
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.vectorstore_server
+        mcp_tool_name: list_metadata
+        tool_args: !expr "{db_path: ctx.output_db, filters: {parent_context: ctx.input_path}, limit: 1000000}"
+      output: existing_raw
+  - transform: {value: "ctx.existing_raw.structured.result", output: existing}
+
+  # C5 diff: new/changed = no existing entry with the SAME id AND the SAME
+  # content_hash. remove = an existing id no longer present among the
+  # current items (the file was deleted, or re-chunked away).
+  - transform:
+      value: >-
+        filter(ctx.all_items, i -> find(ctx.existing, e -> e.id == i.id and e.metadata.content_hash == i.content_hash) == null)
+      output: to_upsert
+  - transform:
+      value: >-
+        map(filter(ctx.existing, e -> find(ctx.all_items, i -> i.id == e.id) == null), e -> e.id)
+      output: to_remove_ids
+
+  # X5: dedup visibility -- how many chunks were SKIPPED (unchanged), and
+  # the estimated tokens that would have been spent re-embedding them.
+  - transform: {value: "count(ctx.all_items) - count(ctx.to_upsert)", output: unchanged_count}
+  - transform: {value: "sum(map(ctx.all_items, i -> i.est_tokens))", output: est_tokens_if_no_dedup}
+  - transform: {value: "sum(map(ctx.to_upsert, i -> i.est_tokens))", output: est_tokens_embedded}
+
+  # embed ONLY the new/changed chunks (C1: reyn is the sole embedder). The
+  # `embed` tool itself REJECTS an empty `texts` array (a hard "missing
+  # required arg" result, not a graceful empty-vectors reply) -- gate it
+  # behind a match so a fully-deduped run (X5: to_upsert empty) never calls
+  # it at all, rather than feeding it something it refuses.
+  - match:
+      on: "count(ctx.to_upsert) > 0"
+      cases:
+        "True":
+          pipeline: _ingest_embed_and_upsert
+          pass:
+            to_upsert: ctx.to_upsert
+            embedding_model: ctx.embedding_model
+            input_path: ctx.input_path
+            output_db: ctx.output_db
+            vectorstore_server: ctx.vectorstore_server
+        "False":
+          pipeline: _ingest_noop_upsert
+      output: upsert_outcome
+
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.vectorstore_server
+        mcp_tool_name: delete
+        tool_args: !expr "{db_path: ctx.output_db, ids: ctx.to_remove_ids}"
+      output: delete_result
+
+  - transform:
+      value: >-
+        {files_scanned: count(ctx.files),
+         chunks_upserted: ctx.upsert_outcome.upserted,
+         chunks_removed: ctx.delete_result.structured.deleted,
+         chunks_unchanged_skipped: ctx.unchanged_count,
+         estimated_tokens_embedded: ctx.est_tokens_embedded,
+         estimated_tokens_saved_by_dedup: ctx.est_tokens_if_no_dedup - ctx.est_tokens_embedded,
+         note: "token figures are a chars/4 ESTIMATE (the same fallback embed's own provider uses), not the metered actual -- embed's per-call cost_usd/total_tokens are not reachable from pipeline ctx today (see the PR body's architecture-gap note)."}
+      output: summary
+---
+pipeline: _ingest_embed_and_upsert
+description: >-
+  Embed the to_upsert chunks, pair each with its vector by position (R1 has
+  no index-zip), stamp embedding_model + parent_context (C4), and upsert
+  into the vector store. Called only when to_upsert is non-empty (see
+  ingest's match gate above -- embed rejects an empty texts array).
+steps:
+  - tool:
+      name: embed
+      args:
+        texts: !expr "map(ctx.to_upsert, i -> i.text)"
+        embedding_model: !expr ctx.embedding_model
+      output: embedded
+  - transform:
+      value: >-
+        {items: ctx.to_upsert, vectors: ctx.embedded.structured,
+         embedding_model: ctx.embedding_model, parent_context: ctx.input_path}
+  - shell:
+      command: "python3 -m reyn.builtin.rag_ingest_helpers zip_vectors"
+      output: to_upsert_zipped
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.vectorstore_server
+        mcp_tool_name: upsert
+        tool_args: !expr "{db_path: ctx.output_db, items: ctx.to_upsert_zipped.structured}"
+      output: upsert_result
+  - transform: {value: "ctx.upsert_result.structured", output: outcome}
+---
+pipeline: _ingest_noop_upsert
+description: >-
+  Sibling of _ingest_embed_and_upsert -- the "nothing new to embed" branch
+  (X5: a fully-deduped re-ingest), returning the same {"upserted": 0} shape
+  without calling embed at all.
+steps:
+  - transform: {value: "{upserted: 0}", output: outcome}

--- a/src/reyn/builtin/pipelines/rag_query.yaml
+++ b/src/reyn/builtin/pipelines/rag_query.yaml
@@ -1,4 +1,4 @@
-# Builtin turnkey RAG -- query pipeline (FP-0063 P3).
+# Builtin RAG -- query pipeline (FP-0063 P3).
 # docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md
 #
 # Embeds the query text (reyn's own `embed` tool -- C1) and returns the
@@ -30,8 +30,10 @@ fields:
 ---
 pipeline: query
 description: >-
-  FP-0063 P3 builtin turnkey RAG query: embed the query text and return
-  the top-k nearest chunks from a user-named sqlite vector store.
+  FP-0063 P3 builtin RAG query: embed the query text and return the top-k
+  nearest chunks from a user-named sqlite vector store. (Unlike
+  rag_ingest, this pipeline shells out to nothing, so it carries no
+  python3-on-PATH requirement.)
 steps:
   - transform: {value: "get(ctx, 'top_k', 5)", output: top_k}
   - transform: {value: "get(ctx, 'embedding_model', 'standard')", output: embedding_model}

--- a/src/reyn/builtin/pipelines/rag_query.yaml
+++ b/src/reyn/builtin/pipelines/rag_query.yaml
@@ -1,0 +1,117 @@
+# Builtin turnkey RAG -- query pipeline (FP-0063 P3).
+# docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md
+#
+# Embeds the query text (reyn's own `embed` tool -- C1) and returns the
+# top-k nearest chunks from a user-named sqlite vector store (the same
+# builtin `vectorstore` MCP server rag_ingest.yaml writes into).
+#
+# Inputs (all optional except `query_text`/`db`):
+#   query_text          -- (required) the natural-language query.
+#   db                  -- (required) the sqlite file rag_ingest wrote to.
+#   top_k               -- how many nearest chunks to return (default 5).
+#   embedding_model     -- MUST match what rag_ingest used for this db (a
+#                          mismatched vector dimension raises
+#                          VectorDimensionMismatchError -- one sqlite file
+#                          holds one embedding-vector-space, FP-0057 C4).
+#                          Default "standard".
+#   filters             -- optional metadata equality filter, e.g.
+#                          {source_path: "docs/x.md"} (same shape as the
+#                          vector-store server's `query` tool -- see
+#                          vector_store_server.py's METADATA_COLUMNS).
+#   vectorstore_server  -- the MCP server name as configured under
+#                          `mcp.servers` (default reyn_vector_store).
+#
+# Output: `ctx.result` -- either the top-k list
+# `[{"id", "distance", "metadata"}, ...]` (nearest-first) or the pre-flight
+# decision-enabling message if the vector-store server is unreachable.
+schema: PreflightCheck
+fields:
+  status: {type: enum, values: ["ok"]}
+---
+pipeline: query
+description: >-
+  FP-0063 P3 builtin turnkey RAG query: embed the query text and return
+  the top-k nearest chunks from a user-named sqlite vector store.
+steps:
+  - transform: {value: "get(ctx, 'top_k', 5)", output: top_k}
+  - transform: {value: "get(ctx, 'embedding_model', 'standard')", output: embedding_model}
+  - transform: {value: "get(ctx, 'filters', null)", output: filters}
+  - transform: {value: "get(ctx, 'vectorstore_server', 'reyn_vector_store')", output: vectorstore_server}
+
+  # X1-equivalent pre-flight: a real, cheap probe (list_metadata against
+  # THIS db, limit 1) before spending on the query embed -- schema-gated to
+  # status=="ok" (see rag_ingest.yaml for the full rationale). `parallel`
+  # with a single branch is reused (rather than a bare `tool` step) purely
+  # to get the "reachable: bool, no raised exception" shape ingest's own
+  # pre-flight uses -- a dropped (on_error: continue) branch's key is
+  # simply absent from collect's named map.
+  - parallel:
+      on_error: continue
+      branches:
+        vectorstore:
+          tool:
+            name: call_mcp_tool
+            schema: PreflightCheck
+            args:
+              server: !expr ctx.vectorstore_server
+              mcp_tool_name: list_metadata
+              tool_args: !expr "{db_path: ctx.db, limit: 1}"
+      collect:
+        transform:
+          value: "get(pipe, 'vectorstore', null) != null"
+      output: vectorstore_reachable
+  - transform:
+      value: >-
+        "Vector-store MCP server '" + ctx.vectorstore_server + "' is unreachable. (1) enable it: add/uncomment mcp.servers." + ctx.vectorstore_server + " in reyn.yaml and set permissions.mcp." + ctx.vectorstore_server + ": allow -- see docs/cookbook/configs/with-builtin-rag-mcp.yaml. (2) if already enabled, install its dependencies: pip install \"reyn[builtin-rag]\" (apsw + sqlite-vec)."
+      output: remedy
+  - match:
+      on: ctx.vectorstore_reachable
+      cases:
+        "True":
+          pipeline: _query_body
+          pass:
+            query_text: ctx.query_text
+            db: ctx.db
+            top_k: ctx.top_k
+            embedding_model: ctx.embedding_model
+            filters: ctx.filters
+            vectorstore_server: ctx.vectorstore_server
+      default:
+        pipeline: _query_blocked
+        pass: {message: ctx.remedy}
+      output: result
+---
+pipeline: _query_blocked
+description: >-
+  Sibling of query -- returns the pre-flight failure as the run's own
+  (successful) output: a decision-enabling message, never a bare MCP
+  transport exception.
+steps:
+  - transform:
+      value: "'rag query blocked -- the vector-store MCP server is unreachable: ' + ctx.message"
+      output: blocked_reason
+---
+pipeline: _query_body
+description: >-
+  The real query work: embed the query text, then ask the vector-store MCP
+  server for the top-k nearest chunks.
+steps:
+  - tool:
+      name: embed
+      args:
+        texts: !expr "[ctx.query_text]"
+        embedding_model: !expr ctx.embedding_model
+      output: embedded
+  - transform:
+      value: "find(ctx.embedded.structured, v -> true)"
+      output: query_vector
+  - tool:
+      name: call_mcp_tool
+      args:
+        server: !expr ctx.vectorstore_server
+        mcp_tool_name: query
+        tool_args: !expr "{db_path: ctx.db, vector: ctx.query_vector, top_k: ctx.top_k, filters: ctx.filters}"
+      output: queried
+  - transform:
+      value: "ctx.queried.structured.result"
+      output: top_k_results

--- a/src/reyn/builtin/rag_ingest_helpers.py
+++ b/src/reyn/builtin/rag_ingest_helpers.py
@@ -1,0 +1,158 @@
+"""Small stdin/stdout JSON helpers for the builtin ``rag_ingest`` pipeline
+(FP-0063 P3) -- local data munging the pipeline DSL's R1 expression language
+(``docs/reference/runtime/pipeline-dsl.md``) cannot express itself: R1 has no
+string-length/hash/zip-by-index primitives (its combinator set is
+``map``/``filter``/``all``/``any``/``find``/``count``/``sum``/``join``/``get``/
+``parse_json`` only). Rather than force those gaps through a clever R1
+one-liner (or a reyn-core change), the ingest pipeline's ``shell`` steps
+invoke this module as ``python3 -m reyn.builtin.rag_ingest_helpers
+<subcommand>`` -- plain, testable, ruff/docstring-gated Python, same as the
+rest of ``reyn.builtin`` (it ships alongside ``mcp_servers/`` as builtin
+CONTENT, not a ``src/reyn/core`` change; the ingest pipeline is the only
+caller).
+
+Each subcommand reads one JSON value from stdin and prints one JSON value to
+stdout -- the same convention the pipeline DSL's ``shell`` step already uses
+(JSON-decoded stdin via the previous step's pipe data, JSON-decoded stdout
+when it parses -- see ``src/reyn/tools/shell.py``). No reyn imports: this
+module intentionally stays a free-standing script (like the MCP servers in
+``mcp_servers/``) so a user who copies the pipeline (R2 -- "the builtin IS
+the template people copy and tune") can copy this file alongside it with no
+reyn-core import dependency to carry along.
+
+Subcommands:
+
+- ``list_files`` -- stdin ``{"input_path": str}`` -> stdout a JSON list of
+  absolute file paths: the path itself if it names a file, or every file
+  under it (recursively) whose extension is one of the owner's target
+  formats (txt/md/pdf/xlsx/pptx/docx -- proposal 0063 line 20) if it names a
+  directory.
+- ``hash_chunks`` -- stdin ``{"source_path": str, "chunks": [{"text":
+  str, "token_count": int, ...}, ...]}`` (the chunker MCP server's own
+  per-chunk shape) -> stdout a JSON list of candidate chunk items:
+  ``[{"id", "text", "content_hash", "chunk_index", "size_tokens",
+  "est_tokens", "source_path"}, ...]``. ``id`` is a stable
+  ``source_path::chunk_index`` key (C5's add/update/remove diff key);
+  ``content_hash`` is the chunk TEXT's sha256 (C5's change-detection key);
+  ``est_tokens`` is the chars/4 estimate (the SAME fallback heuristic
+  ``EmbeddingProvider.estimate_tokens`` uses, e.g.
+  ``src/reyn/data/embedding/litellm_provider.py``) -- used for the X2a/X5
+  spend ESTIMATE the pipeline reports, since the real per-call
+  ``total_tokens``/``cost_usd`` on ``embed``'s own envelope is not reachable
+  from pipeline ``ctx`` today (``canonical_to_ctx_fields`` only exposes
+  ``text``/``structured``, never ``meta`` -- see this arc's PR body).
+- ``zip_vectors`` -- stdin ``{"items": [...], "vectors": [[float, ...],
+  ...], "embedding_model": str}`` (same order, from a ``to_upsert`` list and
+  ``embed``'s own vectors) -> stdout a JSON list of
+  ``[{"id", "vector", "metadata": {...}}, ...]`` in the EXACT shape
+  ``reyn.builtin.mcp_servers.vector_store_server``'s ``upsert`` tool expects
+  -- pairing each item with its vector BY POSITION (R1 has no index-based
+  zip) and stamping ``metadata.embedding_model`` from ``embedding_model``
+  (the pipeline's OWN configured input -- see the module docstring note
+  above on why not ``envelope.model``).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+
+# The owner's target format list (proposal 0063 line 20): txt/md/pdf/xlsx/
+# pptx/docx. Lower-cased extension match, recursive directory walk.
+_TARGET_EXTENSIONS = (".txt", ".md", ".pdf", ".xlsx", ".pptx", ".docx")
+
+
+def _read_stdin_json() -> "dict":
+    return json.load(sys.stdin)
+
+
+def _print_json(value: object) -> None:
+    print(json.dumps(value))
+
+
+def list_files() -> None:
+    """``list_files`` subcommand -- see module docstring."""
+    payload = _read_stdin_json()
+    input_path = os.path.abspath(payload["input_path"])
+    if not os.path.isdir(input_path):
+        _print_json([input_path])
+        return
+    found: list[str] = []
+    for root, _dirs, files in os.walk(input_path):
+        for name in files:
+            if name.lower().endswith(_TARGET_EXTENSIONS):
+                found.append(os.path.join(root, name))
+    _print_json(sorted(found))
+
+
+def hash_chunks() -> None:
+    """``hash_chunks`` subcommand -- see module docstring."""
+    payload = _read_stdin_json()
+    source_path = payload["source_path"]
+    items = []
+    for index, chunk in enumerate(payload["chunks"]):
+        text = chunk["text"]
+        items.append({
+            "id": f"{source_path}::{index}",
+            "text": text,
+            "content_hash": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            "chunk_index": index,
+            "size_tokens": chunk.get("token_count", 0),
+            "est_tokens": max(1, len(text) // 4),
+            "source_path": source_path,
+        })
+    _print_json(items)
+
+
+def zip_vectors() -> None:
+    """``zip_vectors`` subcommand -- see module docstring."""
+    payload = _read_stdin_json()
+    items = payload["items"]
+    vectors = payload["vectors"]
+    embedding_model = payload["embedding_model"]
+    parent_context = payload.get("parent_context")
+    if len(items) != len(vectors):
+        raise ValueError(
+            f"zip_vectors: {len(items)} items but {len(vectors)} vectors -- "
+            "embed's output order must match the items it was called with"
+        )
+    out = []
+    for item, vector in zip(items, vectors, strict=True):
+        out.append({
+            "id": item["id"],
+            "vector": vector,
+            "metadata": {
+                "source_path": item["source_path"],
+                "source_type": "generic",
+                "content_hash": item["content_hash"],
+                "embedding_model": embedding_model,
+                "chunk_index": item["chunk_index"],
+                "size_tokens": item["size_tokens"],
+                "parent_context": parent_context,
+                "extra": {},
+            },
+        })
+    _print_json(out)
+
+
+_SUBCOMMANDS = {
+    "list_files": list_files,
+    "hash_chunks": hash_chunks,
+    "zip_vectors": zip_vectors,
+}
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in _SUBCOMMANDS:
+        print(
+            f"usage: python3 -m reyn.builtin.rag_ingest_helpers "
+            f"{{{'|'.join(_SUBCOMMANDS)}}}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    _SUBCOMMANDS[sys.argv[1]]()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/reyn/builtin/rag_ingest_helpers.py
+++ b/src/reyn/builtin/rag_ingest_helpers.py
@@ -36,20 +36,23 @@ Subcommands:
   ``content_hash`` is the chunk TEXT's sha256 (C5's change-detection key);
   ``est_tokens`` is the chars/4 estimate (the SAME fallback heuristic
   ``EmbeddingProvider.estimate_tokens`` uses, e.g.
-  ``src/reyn/data/embedding/litellm_provider.py``) -- used for the X2a/X5
-  spend ESTIMATE the pipeline reports, since the real per-call
-  ``total_tokens``/``cost_usd`` on ``embed``'s own envelope is not reachable
-  from pipeline ``ctx`` today (``canonical_to_ctx_fields`` only exposes
-  ``text``/``structured``, never ``meta`` -- see this arc's PR body).
+  ``src/reyn/data/embedding/litellm_provider.py``). ``est_tokens`` funds
+  ONLY the pipeline's X5 "tokens saved by dedup" figure, which is
+  necessarily a counterfactual: the sole way to learn a SKIPPED chunk's
+  true token count is to send it to the embedder, i.e. to spend exactly
+  what the skip exists to avoid. Tokens actually EMBEDDED are never
+  estimated -- the pipeline reads ``embed``'s own metered
+  ``total_tokens``/``cost_usd`` off its envelope meta instead.
 - ``zip_vectors`` -- stdin ``{"items": [...], "vectors": [[float, ...],
   ...], "embedding_model": str}`` (same order, from a ``to_upsert`` list and
   ``embed``'s own vectors) -> stdout a JSON list of
   ``[{"id", "vector", "metadata": {...}}, ...]`` in the EXACT shape
   ``reyn.builtin.mcp_servers.vector_store_server``'s ``upsert`` tool expects
   -- pairing each item with its vector BY POSITION (R1 has no index-based
-  zip) and stamping ``metadata.embedding_model`` from ``embedding_model``
-  (the pipeline's OWN configured input -- see the module docstring note
-  above on why not ``envelope.model``).
+  zip) and stamping ``metadata.embedding_model`` from ``embedding_model``.
+  The caller passes the RESOLVED model (``embed``'s ``envelope.model``),
+  never a model-class alias: the column must name the model that actually
+  produced the vectors beside it (FP-0057 C4).
 """
 from __future__ import annotations
 

--- a/src/reyn/builtin/rag_ingest_helpers.py
+++ b/src/reyn/builtin/rag_ingest_helpers.py
@@ -20,8 +20,30 @@ module intentionally stays a free-standing script (like the MCP servers in
 the template people copy and tune") can copy this file alongside it with no
 reyn-core import dependency to carry along.
 
+**``python3`` must be reyn's own interpreter -- a REAL constraint, not a
+nicety.** The ingest pipeline reaches this module by shelling out to
+``python3 -m reyn.builtin.rag_ingest_helpers``, and ``sandboxed_exec`` passes
+the ambient ``PATH`` straight through (``sandboxed_exec.py``'s
+``os.environ.get("PATH")``), so ``python3`` resolves however the operator's
+shell would resolve it. ``sys.executable`` is NOT reachable from the pipeline
+DSL, so the pipeline cannot ask for "the interpreter reyn is running under".
+Consequence: a ``pipx install reyn``, a non-activated venv, or any environment
+whose ``python3`` differs from reyn's will FAIL -- and the arc is therefore
+not turnkey in those environments. The ``probe`` subcommand below exists so
+that failure is caught by the ingest pipeline's step-0 pre-flight, with a
+decision-enabling message, instead of surfacing later as an opaque
+"path 'ctx.files_raw.structured' is absent". Closing the gap properly needs a
+core/DSL decision (expose the interpreter, a ``python:`` step, or resolve
+``python3`` -> ``sys.executable`` in ``sandboxed_exec``) and is tracked on the
+FP-0063 umbrella; this module only makes the failure VISIBLE.
+
 Subcommands:
 
+- ``probe`` -- stdin ignored -> stdout ``[sys.executable, <reyn package dir>]``.
+  Answers "is THIS ``python3`` an interpreter that can see reyn at all?" for
+  the ingest pipeline's pre-flight. It does NOT (and cannot) detect the
+  subtler case where ``python3`` sees a DIFFERENT reyn install than the one
+  running the pipeline -- it reports the paths so a human can compare.
 - ``list_files`` -- stdin ``{"input_path": str}`` -> stdout a JSON list of
   absolute file paths: the path itself if it names a file, or every file
   under it (recursively) whose extension is one of the owner's target
@@ -72,6 +94,19 @@ def _read_stdin_json() -> "dict":
 
 def _print_json(value: object) -> None:
     print(json.dumps(value))
+
+
+def probe() -> None:
+    """``probe`` subcommand -- see module docstring.
+
+    Emits a JSON LIST (not an object) deliberately: a ``shell`` step whose
+    stdout decodes to a dict renders as ``text`` with NO ``structured`` key
+    (``shell_to_canonical``), whereas a list lands in ``ctx.<name>.structured``
+    -- which is what makes "did this run at all?" a one-expression check for
+    the caller. Same reason every other subcommand here emits a list.
+    """
+    import reyn  # noqa: PLC0415 -- probing THIS interpreter's reyn, if any
+    _print_json([sys.executable, os.path.dirname(reyn.__file__)])
 
 
 def list_files() -> None:
@@ -140,6 +175,7 @@ def zip_vectors() -> None:
 
 
 _SUBCOMMANDS = {
+    "probe": probe,
     "list_files": list_files,
     "hash_chunks": hash_chunks,
     "zip_vectors": zip_vectors,

--- a/src/reyn/builtin/registry.py
+++ b/src/reyn/builtin/registry.py
@@ -116,6 +116,32 @@ BUILTIN_PIPELINES: "dict[str, dict[str, Any]]" = {
         "path": str(_BUILTIN_DIR / "pipelines" / "flagship_research_and_report.yaml"),
         "enabled": True,
     },
+    # FP-0063 P3 -- builtin turnkey user RAG (proposal 0063). Both pipelines
+    # call the P2 builtin MCP servers (vector_store_server / chunker_server,
+    # #2952) plus a third-party markitdown MCP server -- all of which ship
+    # INERT (R3, mirrors the skill A3 posture): registering these two
+    # pipelines is itself inert (invoke-by-name only, Addendum A3), and
+    # every step's MCP calls additionally fail cleanly with a decision-
+    # enabling message (X1) until the operator explicitly configures +
+    # grants the three servers (docs/cookbook/configs/with-builtin-rag-mcp.yaml).
+    "rag_ingest": {
+        "description": (
+            "Turnkey RAG ingest: chunk -> embed -> store a file or folder "
+            "into a user-named sqlite vector store, incrementally by "
+            "content_hash (add/update/remove) -- proposal 0063 P3."
+        ),
+        "path": str(_BUILTIN_DIR / "pipelines" / "rag_ingest.yaml"),
+        "enabled": True,
+    },
+    "rag_query": {
+        "description": (
+            "Turnkey RAG query: embed the query text and return the top-k "
+            "nearest chunks from a sqlite vector store rag_ingest wrote to "
+            "-- proposal 0063 P3."
+        ),
+        "path": str(_BUILTIN_DIR / "pipelines" / "rag_query.yaml"),
+        "enabled": True,
+    },
 }
 BUILTIN_PRESENTATIONS: "dict[str, dict[str, Any]]" = {
     # The status/results card exemplar (proposal 0060 Addendum D9.5 curated-5

--- a/src/reyn/builtin/registry.py
+++ b/src/reyn/builtin/registry.py
@@ -116,7 +116,7 @@ BUILTIN_PIPELINES: "dict[str, dict[str, Any]]" = {
         "path": str(_BUILTIN_DIR / "pipelines" / "flagship_research_and_report.yaml"),
         "enabled": True,
     },
-    # FP-0063 P3 -- builtin turnkey user RAG (proposal 0063). Both pipelines
+    # FP-0063 P3 -- builtin user RAG (proposal 0063). Both pipelines
     # call the P2 builtin MCP servers (vector_store_server / chunker_server,
     # #2952) plus a third-party markitdown MCP server -- all of which ship
     # INERT (R3, mirrors the skill A3 posture): registering these two
@@ -126,17 +126,19 @@ BUILTIN_PIPELINES: "dict[str, dict[str, Any]]" = {
     # grants the three servers (docs/cookbook/configs/with-builtin-rag-mcp.yaml).
     "rag_ingest": {
         "description": (
-            "Turnkey RAG ingest: chunk -> embed -> store a file or folder "
-            "into a user-named sqlite vector store, incrementally by "
-            "content_hash (add/update/remove) -- proposal 0063 P3."
+            "RAG ingest: chunk -> embed -> store a file or folder into a "
+            "user-named sqlite vector store, incrementally by content_hash "
+            "(add/update/remove). Requires `python3` on PATH to be reyn's "
+            "own interpreter (it shells out; step 0 pre-flights this) -- "
+            "proposal 0063 P3."
         ),
         "path": str(_BUILTIN_DIR / "pipelines" / "rag_ingest.yaml"),
         "enabled": True,
     },
     "rag_query": {
         "description": (
-            "Turnkey RAG query: embed the query text and return the top-k "
-            "nearest chunks from a sqlite vector store rag_ingest wrote to "
+            "RAG query: embed the query text and return the top-k nearest "
+            "chunks from a sqlite vector store rag_ingest wrote to "
             "-- proposal 0063 P3."
         ),
         "path": str(_BUILTIN_DIR / "pipelines" / "rag_query.yaml"),

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1471,10 +1471,13 @@ def topology_create_to_canonical(result: dict) -> CanonicalToolResult:
 
 # A private, NON-rendered marker key stamped on the whole-dict fallback canonical when it was taken
 # because an inner-dispatch mapper raised :class:`CanonicalDiscriminatorMiss` (FP-0056 v2 piece #3, M3).
-# It is a signal channel for :func:`canonical_fallback_reason` only — the renderer (``build_offload_body``
-# reads ``attachments``/``meta``) and the ctx reducer (``canonical_to_ctx_fields`` reads ``text``/
-# ``attachments``) never read it, so it never reaches the LLM body (unlike ``meta``, which renders as
-# frontmatter YAML).
+# It is an INTERNAL flag for :func:`canonical_fallback_reason` only — deliberately NOT part of
+# ``meta`` (the producer-authored signal channel that DOES reach both consumers). Its containment
+# rests on being a TOP-LEVEL key on the canonical dict rather than on which keys the consumers read:
+# the renderer (``build_offload_body`` reads ``attachments``/``meta``) and the ctx reducer
+# (``canonical_to_ctx_fields`` reads ``text``/``attachments``/``meta`` — #2966 added ``meta``) both
+# select named keys, and neither names this one. So it reaches neither the LLM body nor a pipeline's
+# ``ctx.<name>`` — a mapper cannot leak it by populating ``meta``, because it never lives there.
 _DISCRIMINATOR_MISS_MARKER = "_discriminator_miss"
 
 

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1682,14 +1682,39 @@ def unwrap_dispatch_envelope(result: Any) -> Any:
 
 
 def canonical_to_ctx_fields(canonical: CanonicalToolResult) -> "dict[str, Any]":
-    """Reduce a :class:`CanonicalToolResult` to the flat ``{"text": ..., "structured": ...}`` shape a
-    pipeline step's ``ctx.<name>`` exposes (``structured`` key absent when there is no structured
-    attachment) — shape-only, mirroring ``seam.py``'s attachments reduction but with NO size gating:
-    pipeline ctx retains full values for downstream programmatic step processing (owner ruling)."""
+    """Reduce a :class:`CanonicalToolResult` to the flat ``{"text": ..., "structured": ...,
+    "meta": ...}`` shape a pipeline step's ``ctx.<name>`` exposes (``structured``/``meta`` keys
+    absent when there is no structured attachment / no signal meta) — shape-only, mirroring
+    ``seam.py``'s attachments reduction but with NO size gating: pipeline ctx retains full values
+    for downstream programmatic step processing (owner ruling).
+
+    ``meta`` is the producer's SIGNAL channel — the small, high-signal fields a mapper deliberately
+    kept out of the body because they change what the caller does next: ``embed``'s ``model``/
+    ``total_tokens``/``cost_usd``/``priced``, ``sandboxed_exec``'s nonzero ``returncode``, an MCP
+    result's ``isError``. The chat side has always seen these (``seam.py`` reads ``meta``); the
+    pipeline side did not, so a ``tool:`` step could read a producer's body but never its signal.
+
+    FP-0063 P3 (#2966) is why this is no longer acceptable: the ingest pipeline must stamp each
+    chunk's ``embedding_model`` from the model that ACTUALLY produced the vectors (FP-0057 C4 —
+    "one source = one embedding model"). Without ``meta``, the pipeline's only available source was
+    its own INPUT, which is typically a model-CLASS alias (``"standard"``) rather than the resolved
+    id — i.e. the per-chunk ``embedding_model`` column would record a model that never produced
+    those vectors. That is precisely the "the column becomes a lie" failure FP-0057's C1 hard gate
+    exists to prevent (it is why a vector-DB server with a built-in embedder is rejected); reaching
+    it via the ctx reducer instead of via the server would have defeated the gate's purpose by
+    another route. Exposing ``meta`` makes C4 correct BY CONSTRUCTION rather than by documentation.
+
+    Absent-when-empty mirrors ``structured``'s own convention exactly: a mapper that emits no signal
+    meta (the common case — most successful results have none) adds no key, so a step reading
+    ``ctx.<name>.meta`` on such a producer fails loudly rather than silently reading ``{}``. Use
+    ``get(ctx.<name>, "meta.<field>", <default>)`` for safe navigation (see pipeline-dsl.md)."""
     fields: dict[str, Any] = {"text": canonical.get("text", "")}
     structured_items = [
         att.get("data") for att in canonical.get("attachments", []) or [] if att.get("kind") == "structured"
     ]
     if structured_items:
         fields["structured"] = structured_items[0] if len(structured_items) == 1 else structured_items
+    meta = canonical.get("meta") or {}
+    if meta:
+        fields["meta"] = meta
     return fields

--- a/tests/test_2425_pipeline_tool_ctx_canonical_shape.py
+++ b/tests/test_2425_pipeline_tool_ctx_canonical_shape.py
@@ -1,11 +1,19 @@
 """Tier 1/2: #2425 PR-2 — pipeline `tool:` step results expose the same
-`text`/`structured` two-field ctx shape chat gets, uniformly across op kinds,
+`text`/`structured`/`meta` ctx shape chat gets, uniformly across op kinds,
 and NEVER go through the chat-side offload/size-gate machinery.
 
 Covers:
   1. Tier 1: `canonical_to_ctx_fields` reduces `CanonicalToolResult.attachments`
      to `structured` (absent / single item / list) exactly like `seam.py`'s own
      reduction, minus any size gating.
+  1b. Tier 1 (#2966): the same reducer exposes the producer's SIGNAL channel as
+     `meta`, absent-when-empty on the same convention `structured` uses. Chat
+     always saw `meta` (`seam.py` reads it); the pipeline did not, so a `tool:`
+     step could read a producer's body but never its signal — which forced
+     FP-0063's ingest pipeline to stamp each chunk's `embedding_model` from its
+     own INPUT (a model-CLASS alias) instead of from the model that actually
+     produced the vectors, i.e. the "column becomes a lie" failure FP-0057's C1
+     gate exists to prevent.
   2. Tier 2: a real `PipelineExecutor.run` through `_run_tool_step` exposes
      `ctx.<name>.text`/`.structured` uniformly for TWO distinct real op kinds
      (`mcp`, `sandboxed_exec`) via the REAL R1 expression evaluator.
@@ -80,6 +88,33 @@ def test_canonical_to_ctx_fields_ignores_media_attachments():
         "meta": {},
     }
     assert canonical_to_ctx_fields(canonical) == {"text": "body"}
+
+
+def test_canonical_to_ctx_fields_exposes_meta_signal_fields():
+    """Tier 1: #2966 — a producer's signal meta reaches pipeline ctx as 'meta',
+    so a step can read what a result COST / HOW it was produced — not just its
+    body. Pinned with embed's own field set, the motivating producer."""
+    canonical = {
+        "text": "",
+        "attachments": [{"kind": "structured", "data": [[0.1, 0.2]]}],
+        "source_ref": None,
+        "meta": {"model": "text-embedding-3-small", "total_tokens": 42, "cost_usd": 0.001},
+    }
+    assert canonical_to_ctx_fields(canonical) == {
+        "text": "",
+        "structured": [[0.1, 0.2]],
+        "meta": {"model": "text-embedding-3-small", "total_tokens": 42, "cost_usd": 0.001},
+    }
+
+
+def test_canonical_to_ctx_fields_meta_absent_when_producer_emits_no_signal():
+    """Tier 1: #2966 — no signal meta → no 'meta' key at all (the same
+    absent-when-empty convention 'structured' uses). Load-bearing: a step
+    reading ctx.<name>.meta.<field> on a signal-less producer must RAISE
+    rather than silently read {} and default — see pipeline-dsl.md."""
+    assert canonical_to_ctx_fields(
+        {"text": "hi", "attachments": [], "source_ref": None, "meta": {}}
+    ) == {"text": "hi"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -341,11 +341,24 @@ def test_from_config_builds_populated_registry_from_project_root(tmp_path: Path)
     fc = SessionFactoryConfig.from_config(config, tmp_path)
 
     # proposal 0060 F3b: the builtin tier (merged as the LOWEST config tier,
-    # below every operator file) now ships one real pipeline
-    # (flagship.research_and_report) alongside whatever the project's own
-    # reyn.yaml declares — both are present, since the builtin tier is
-    # additive, not exclusive.
-    assert set(fc.pipeline_registry.names()) == {"hello.hello", "flagship.research_and_report"}
+    # below every operator file) ships builtin pipelines alongside whatever
+    # the project's own reyn.yaml declares — both are present, since the
+    # builtin tier is additive, not exclusive. Expected builtin names are
+    # derived from BUILTIN_PIPELINES itself (parsing each entry's file) so
+    # this assertion does not need a manual update every time a new builtin
+    # pipeline (or a new sibling `pipeline:` doc inside one) is added —
+    # #2955/FP-0063 P3 added rag_ingest/rag_query, each with several
+    # same-file sibling pipelines.
+    from reyn.builtin.registry import BUILTIN_PIPELINES
+    from reyn.core.pipeline.parser import parse_pipeline_docs
+    from reyn.core.pipeline.schema import SchemaRegistry
+
+    expected_builtin_names = {
+        f"{entry_key}.{doc.name}"
+        for entry_key, entry in BUILTIN_PIPELINES.items()
+        for doc in parse_pipeline_docs(Path(entry["path"]).read_text(encoding="utf-8"), SchemaRegistry())
+    }
+    assert set(fc.pipeline_registry.names()) == {"hello.hello", *expected_builtin_names}
 
 
 def test_from_config_without_project_root_is_empty(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -104,7 +104,22 @@ class FakeEmbeddingProvider:
     """Deterministic real EmbeddingProvider (mirrors
     ``tests/test_op_embed.py``'s own fixture) -- a fixed-length vector per
     text so distinct chunk texts get distinct (but reproducible) vectors,
-    with no real embedding API call."""
+    with no real embedding API call.
+
+    **``embed`` RESOLVES the requested model to ``fake/<model>``** rather
+    than echoing it back -- exactly as ``tests/test_op_embed.py``'s fixture
+    does, and as the real ``RoutingEmbeddingProvider`` does when handed a
+    model-CLASS alias (``"standard"`` -> a concrete provider model id). This
+    is load-bearing for the C4 test: were the resolved name identical to the
+    requested one, "stamped from the pipeline's INPUT" and "stamped from
+    ``envelope.model``" would be indistinguishable and the assertion would
+    pass vacuously against either implementation.
+
+    ``total_tokens`` is deliberately NOT the chars/4 value the pipeline's
+    own ``est_tokens`` heuristic would compute -- it is ``len(text)``, ~4x
+    larger. That gap is what lets the X2a test prove the reported figure
+    came from the metered envelope rather than the estimate.
+    """
 
     def __init__(self) -> None:
         self._batch_size = 100
@@ -112,7 +127,9 @@ class FakeEmbeddingProvider:
     async def embed(self, texts: list[str], model: str):
         from reyn.data.embedding.provider import EmbedBatchResult
         vectors = [[float(len(t) % 97), float(sum(map(ord, t)) % 89), 1.0] for t in texts]
-        return EmbedBatchResult(vectors=vectors, model=model, total_tokens=sum(len(t) for t in texts))
+        return EmbedBatchResult(
+            vectors=vectors, model=f"fake/{model}", total_tokens=sum(len(t) for t in texts),
+        )
 
     def estimate_tokens(self, texts: list[str]) -> int:
         return sum(len(t) for t in texts)
@@ -264,26 +281,73 @@ def test_ingest_add_then_dedup_then_update_then_remove(
     assert summary_4["chunks_upserted"] == 0
 
 
-def test_upserted_chunk_embedding_model_is_stamped_from_pipeline_input(
+def test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
 ) -> None:
-    """Tier 2b: C4 -- every upserted chunk's embedding_model column is
-    stamped from the ingest pipeline's OWN input (not hardcoded), verified
-    by reading it straight back out of the real sqlite store."""
+    """Tier 2b: C4 -- every upserted chunk's embedding_model column names the
+    model that ACTUALLY produced its vector (embed's envelope.model), not the
+    model-CLASS alias the pipeline was invoked with.
+
+    The provider resolves "standard" -> "fake/standard" (see
+    FakeEmbeddingProvider), so the two candidate sources are distinguishable:
+    stamping the pipeline's own input would write "standard" -- a model that
+    never produced these vectors, i.e. the "column becomes a lie" failure
+    FP-0057's C1 gate exists to prevent. Read straight back out of the real
+    sqlite store."""
     monkeypatch.chdir(tmp_path)
     project_root = _write_project(tmp_path)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("A short note about penguins.", encoding="utf-8")
 
-    _run_ingest(project_root, capsys, embedding_model="fake-embed-v7")
+    _run_ingest(project_root, capsys, embedding_model="standard")
 
     from reyn.builtin.mcp_servers.vector_store_server import SqliteVecStore
 
     with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
         rows = store.list_metadata()
     assert rows, "expected at least one upserted chunk"
-    assert all(r["metadata"]["embedding_model"] == "fake-embed-v7" for r in rows)
+    assert all(r["metadata"]["embedding_model"] == "fake/standard" for r in rows), (
+        "C4 VIOLATION: the embedding_model column must name the RESOLVED model "
+        "(envelope.model = 'fake/standard'), not the requested alias 'standard' "
+        f"-- got {sorted({r['metadata']['embedding_model'] for r in rows})}"
+    )
+
+
+def test_ingest_reports_metered_spend_not_the_chars4_estimate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: X2a -- the summary's tokens_embedded is embed's OWN METERED
+    total_tokens (envelope meta), not the pipeline's chars/4 estimate.
+
+    The provider meters len(text) while the pipeline's est_tokens heuristic
+    computes len(text)//4, so the two differ ~4x and the reported figure is
+    attributable to exactly one source. Also pins that the resolved model
+    and the priced flag ride the same envelope meta."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    body = "Alpha document about apples and oranges. " * 20
+    (docs_dir / "a.txt").write_text(body, encoding="utf-8")
+
+    summary = _run_ingest(project_root, capsys)["named_stores"]["result"]
+
+    # The metered figure is ~4x the chars/4 estimate of the same text; assert
+    # against the metered side, and explicitly NOT against the estimate.
+    assert summary["tokens_embedded"] > 0
+    assert summary["tokens_embedded"] > summary["estimated_tokens_saved_by_dedup"]
+    approx_estimate = len(body) // 4
+    assert summary["tokens_embedded"] > approx_estimate * 2, (
+        "X2a REGRESSION: tokens_embedded looks like the chars/4 ESTIMATE "
+        f"(~{approx_estimate}), not embed's metered total_tokens (~{len(body)})"
+    )
+    assert summary["embedding_model"] == "fake/standard"
+    assert summary["priced"] is False, (
+        "the fake model is unpriceable by litellm, so priced must be False and "
+        "cost_usd None -- an unpriced model must degrade VISIBLY, never as $0.00"
+    )
+    assert summary["cost_usd"] is None
 
 
 def test_rag_query_returns_the_ingested_chunk_as_top_result(

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -1,0 +1,360 @@
+"""Tier 2b: subsystem invariant -- FP-0063 P3, the two builtin RAG pipelines
+(``reyn.builtin.pipelines.rag_ingest`` / ``rag_query``),
+docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md.
+
+Drives both pipelines end-to-end through the REAL ``reyn pipe run`` CLI path
+(``src/reyn/interfaces/cli/commands/pipe.py::run_run``) against REAL builtin
+MCP servers (``reyn.builtin.mcp_servers.vector_store_server`` /
+``chunker_server``, started as real ``python -m ...`` stdio subprocesses --
+the ``builtin-rag`` extra IS installed in this environment, verified by
+``pytest.importorskip`` guarding the whole module so a base install still
+collects). The THIRD server (markitdown) is substituted by a small, real
+FastMCP stdio server written to disk for the test (the real
+``markitdown-mcp`` PyPI package is not installed here, and fetching it via
+``uvx`` would need network) -- this substitution is disclosed in the PR
+body, not silently passed off as "real markitdown-mcp".
+
+Only the embedding PROVIDER is faked (mirrors ``tests/test_op_embed.py``'s
+``FakeEmbeddingProvider`` precedent -- monkeypatching
+``reyn.core.op_runtime.embed.get_provider``, NOT ``unittest.mock``) so the
+tests need no real embedding API key/network. Everything else -- the pipeline
+parser/executor, the MCP client/gateway/permission gate, the two real
+builtin MCP servers, sqlite-vec/apsw/chonkie -- is real.
+
+Coverage:
+  1. Parse: both pipeline files parse cleanly (four + three ``pipeline:``
+     docs respectively) via ``parse_pipeline_docs``.
+  2. C5 add/update/remove convergence + X5 dedup visibility: ingest a
+     2-file folder, re-ingest unchanged (0 upserts, dedup skip reported),
+     modify one file and re-ingest (that file's chunks update), delete one
+     file and re-ingest (its chunks are removed).
+  3. C4: every upserted chunk's stored ``embedding_model`` matches the
+     pipeline's own ``embedding_model`` input (stamped, not hardcoded).
+  4. X1 pre-flight: pointing ``vectorstore_server`` at an unconfigured name
+     blocks the run with a decision-enabling message naming that server +
+     a concrete remedy, WITHOUT a bare transport exception -- falsified by
+     asserting the SAME run with a valid name proceeds past pre-flight.
+  5. rag_query: after ingest, querying returns the ingested chunk as its
+     top-1 nearest result.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+pytest.importorskip(
+    "apsw", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+pytest.importorskip(
+    "chonkie", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+pytest.importorskip(
+    "sqlite_vec", reason="builtin-rag extra ('pip install reyn[builtin-rag]') not installed",
+)
+
+from reyn.builtin.registry import BUILTIN_PIPELINES  # noqa: E402
+from reyn.core.pipeline.parser import parse_pipeline_docs  # noqa: E402
+from reyn.core.pipeline.schema import SchemaRegistry  # noqa: E402
+from reyn.interfaces.cli.commands.pipe import run_run  # noqa: E402
+
+_INGEST_PATH = Path(BUILTIN_PIPELINES["rag_ingest"]["path"])
+_QUERY_PATH = Path(BUILTIN_PIPELINES["rag_query"]["path"])
+
+# ---------------------------------------------------------------------------
+# A real, minimal FastMCP stdio server standing in for markitdown-mcp (not
+# installed in this environment -- see module docstring). Converts a
+# "file://<path>" URI to Markdown by reading the file as UTF-8 text; good
+# enough for .txt/.md fixtures, which is all these tests ingest.
+# ---------------------------------------------------------------------------
+
+_STUB_MARKITDOWN_SERVER = '''
+import base64
+from fastmcp import FastMCP
+
+mcp = FastMCP("stub-markitdown")
+
+
+@mcp.tool
+def convert_to_markdown(uri: str) -> str:
+    if uri.startswith("data:"):
+        _, _, payload = uri.partition(",")
+        return base64.b64decode(payload).decode("utf-8")
+    path = uri[len("file://"):] if uri.startswith("file://") else uri
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+if __name__ == "__main__":
+    mcp.run()
+'''
+
+
+def _ns(**kwargs: Any) -> argparse.Namespace:
+    return argparse.Namespace(**kwargs)
+
+
+class FakeEmbeddingProvider:
+    """Deterministic real EmbeddingProvider (mirrors
+    ``tests/test_op_embed.py``'s own fixture) -- a fixed-length vector per
+    text so distinct chunk texts get distinct (but reproducible) vectors,
+    with no real embedding API call."""
+
+    def __init__(self) -> None:
+        self._batch_size = 100
+
+    async def embed(self, texts: list[str], model: str):
+        from reyn.data.embedding.provider import EmbedBatchResult
+        vectors = [[float(len(t) % 97), float(sum(map(ord, t)) % 89), 1.0] for t in texts]
+        return EmbedBatchResult(vectors=vectors, model=model, total_tokens=sum(len(t) for t in texts))
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return sum(len(t) for t in texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 3
+
+
+@pytest.fixture(autouse=True)
+def _fake_embedding_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    import reyn.core.op_runtime.embed as embed_mod
+
+    fake = FakeEmbeddingProvider()
+    monkeypatch.setattr(embed_mod, "get_provider", lambda *a, **k: fake)
+
+
+def _write_project(tmp_path: Path, *, vectorstore_server: str = "reyn_vector_store") -> Path:
+    """Write a reyn.yaml wiring the 3 MCP servers (2 real, 1 stub) + the two
+    builtin RAG pipeline entries, and return project_root."""
+    stub_path = tmp_path / "stub_markitdown_server.py"
+    stub_path.write_text(_STUB_MARKITDOWN_SERVER, encoding="utf-8")
+
+    (tmp_path / "reyn.yaml").write_text(
+        yaml.dump(
+            {
+                "model": "standard",
+                "models": {"standard": "openai/gpt-4o-mini"},
+                "mcp": {
+                    "servers": {
+                        "reyn_markitdown": {
+                            "type": "stdio",
+                            "command": sys.executable,
+                            "args": [str(stub_path)],
+                        },
+                        "reyn_chunker": {
+                            "type": "stdio",
+                            "command": sys.executable,
+                            "args": ["-m", "reyn.builtin.mcp_servers.chunker_server"],
+                        },
+                        vectorstore_server: {
+                            "type": "stdio",
+                            "command": sys.executable,
+                            "args": ["-m", "reyn.builtin.mcp_servers.vector_store_server"],
+                        },
+                    },
+                },
+                "pipelines": {
+                    "entries": {
+                        "rag_ingest": {"path": str(_INGEST_PATH)},
+                        "rag_query": {"path": str(_QUERY_PATH)},
+                    },
+                },
+            },
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+def _run_ingest(project_root: Path, capsys: pytest.CaptureFixture, **input_overrides: Any) -> dict:
+    seed = {
+        "input_path": str(project_root / "docs"),
+        "output_db": str(project_root / "rag.sqlite"),
+        **input_overrides,
+    }
+    args = _ns(
+        name="rag_ingest.ingest", input=json.dumps(seed),
+        project=str(project_root), async_=False,
+    )
+    run_run(args)
+    out = capsys.readouterr().out
+    return json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# 1. Parse
+# ---------------------------------------------------------------------------
+
+
+def test_rag_ingest_pipeline_parses() -> None:
+    """Tier 2b: rag_ingest.yaml parses -- 6 pipeline: docs (ingest, _blocked,
+    _ingest_one_file, _ingest_body, _ingest_embed_and_upsert,
+    _ingest_noop_upsert)."""
+    docs = parse_pipeline_docs(_INGEST_PATH.read_text(encoding="utf-8"), SchemaRegistry())
+    names = {p.name for p in docs}
+    assert names == {
+        "ingest", "_blocked", "_ingest_one_file", "_ingest_body",
+        "_ingest_embed_and_upsert", "_ingest_noop_upsert",
+    }
+
+
+def test_rag_query_pipeline_parses() -> None:
+    """Tier 2b: rag_query.yaml parses -- 3 pipeline: docs (query,
+    _query_blocked, _query_body)."""
+    docs = parse_pipeline_docs(_QUERY_PATH.read_text(encoding="utf-8"), SchemaRegistry())
+    names = {p.name for p in docs}
+    assert names == {"query", "_query_blocked", "_query_body"}
+
+
+# ---------------------------------------------------------------------------
+# 2/3/5. End-to-end: C5 add/update/remove, X5 dedup, C4 stamping, rag_query
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_add_then_dedup_then_update_then_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: C5's full add/update/remove convergence + X5's dedup
+    visibility, driven end-to-end via 'reyn pipe run' against the REAL
+    chunker + vector-store MCP servers."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("Alpha document about apples and oranges.", encoding="utf-8")
+    (docs_dir / "b.txt").write_text("Beta document about bananas and grapes.", encoding="utf-8")
+
+    # -- add: first ingest -- both files' chunks get upserted, none removed.
+    result_1 = _run_ingest(project_root, capsys)
+    summary_1 = result_1["named_stores"]["result"]
+    assert summary_1["files_scanned"] == 2
+    assert summary_1["chunks_upserted"] >= 2
+    assert summary_1["chunks_removed"] == 0
+    assert summary_1["chunks_unchanged_skipped"] == 0
+
+    # -- dedup (X5): re-ingest the SAME, unchanged folder -- zero upserts,
+    # every chunk reported as unchanged/skipped.
+    result_2 = _run_ingest(project_root, capsys)
+    summary_2 = result_2["named_stores"]["result"]
+    assert summary_2["chunks_upserted"] == 0, "re-ingesting an unchanged folder must cost ~0 upserts"
+    assert summary_2["chunks_unchanged_skipped"] == summary_1["chunks_upserted"]
+    assert summary_2["estimated_tokens_saved_by_dedup"] > 0
+
+    # -- update: change a.txt's content -- only a.txt's chunk(s) re-upsert.
+    (docs_dir / "a.txt").write_text("Alpha document REWRITTEN about cherries.", encoding="utf-8")
+    result_3 = _run_ingest(project_root, capsys)
+    summary_3 = result_3["named_stores"]["result"]
+    assert summary_3["chunks_upserted"] >= 1
+    assert summary_3["chunks_removed"] == 0
+
+    # -- remove: delete b.txt entirely -- its chunk(s) are removed, a.txt's
+    # (now stable) chunk is reported unchanged.
+    (docs_dir / "b.txt").unlink()
+    result_4 = _run_ingest(project_root, capsys)
+    summary_4 = result_4["named_stores"]["result"]
+    assert summary_4["files_scanned"] == 1
+    assert summary_4["chunks_removed"] >= 1
+    assert summary_4["chunks_upserted"] == 0
+
+
+def test_upserted_chunk_embedding_model_is_stamped_from_pipeline_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: C4 -- every upserted chunk's embedding_model column is
+    stamped from the ingest pipeline's OWN input (not hardcoded), verified
+    by reading it straight back out of the real sqlite store."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("A short note about penguins.", encoding="utf-8")
+
+    _run_ingest(project_root, capsys, embedding_model="fake-embed-v7")
+
+    from reyn.builtin.mcp_servers.vector_store_server import SqliteVecStore
+
+    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+        rows = store.list_metadata()
+    assert rows, "expected at least one upserted chunk"
+    assert all(r["metadata"]["embedding_model"] == "fake-embed-v7" for r in rows)
+
+
+def test_rag_query_returns_the_ingested_chunk_as_top_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: rag_query.query, run after rag_ingest.ingest, returns a
+    top-k result whose metadata source_path is the ingested file."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    target = docs_dir / "notes.txt"
+    target.write_text("Reyn is an operating system for LLM agents.", encoding="utf-8")
+
+    _run_ingest(project_root, capsys)
+
+    args = _ns(
+        name="rag_query.query",
+        input=json.dumps({
+            "query_text": "what is reyn",
+            "db": str(project_root / "rag.sqlite"),
+            "top_k": 3,
+        }),
+        project=str(project_root), async_=False,
+    )
+    run_run(args)
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    top_k = result["named_stores"]["result"]
+    assert isinstance(top_k, list) and len(top_k) >= 1
+    assert top_k[0]["metadata"]["source_path"] == str(target.resolve())
+
+
+# ---------------------------------------------------------------------------
+# 4. X1 pre-flight: decision-enabling block + falsifying control
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: X1 -- pointing vectorstore_server at a name NOT present in
+    mcp.servers blocks the run with a decision-enabling message naming that
+    server + a concrete remedy (never a bare transport exception), and does
+    NOT attempt any embedding spend (falsified below by the working case)."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)  # only registers "reyn_vector_store"
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+
+    result = _run_ingest(project_root, capsys, vectorstore_server="not_configured_server")
+    blocked = result["named_stores"]["result"]
+    assert isinstance(blocked, str)
+    assert "not_configured_server" in blocked
+    assert "pip install" in blocked, "the remedy must name a concrete fix, not just the cause"
+
+
+def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: FALSIFY control for the block above -- the SAME setup with
+    the real, configured server name proceeds past pre-flight into the
+    real ingest body (proves the sibling test's block is attributable to
+    the unreachable server, not a broken pre-flight gate)."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+
+    result = _run_ingest(project_root, capsys)  # default vectorstore_server matches config
+    summary = result["named_stores"]["result"]
+    assert isinstance(summary, dict) and "chunks_upserted" in summary

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -404,6 +405,44 @@ def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
     assert isinstance(blocked, str)
     assert "not_configured_server" in blocked
     assert "pip install" in blocked, "the remedy must name a concrete fix, not just the cause"
+
+
+def test_ingest_preflight_blocks_when_python3_cannot_import_reyn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: X1 -- when the ambient `python3` cannot import reyn (the real
+    `pipx install reyn` / non-activated-venv / different-PATH class), step 0
+    blocks with a decision-enabling message instead of letting the run die
+    later on an opaque "path 'ctx.files_raw.structured' is absent".
+
+    Driven by pointing PATH at a python3 shim that has no reyn -- which is
+    exactly what sandboxed_exec forwards (it passes os.environ's PATH
+    straight through), so this reproduces the real failure rather than
+    simulating it at a seam."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+
+    # A python3 that exists and runs but has no reyn -- the pipx/venv case.
+    shim_dir = tmp_path / "bin"
+    shim_dir.mkdir()
+    shim = shim_dir / "python3"
+    shim.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    shim.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{shim_dir}:{os.environ.get('PATH', '')}")
+
+    result = _run_ingest(project_root, capsys)
+    blocked = result["named_stores"]["result"]
+    assert isinstance(blocked, str), (
+        "a python3 that cannot import reyn must BLOCK at pre-flight, not "
+        f"proceed -- got {type(blocked).__name__}: {blocked!r:.200}"
+    )
+    assert "rag_ingest_helpers" in blocked
+    # cause + concrete remedies, per the #2932 require_mcp precedent
+    assert "activate" in blocked
+    assert "print(reyn.__file__)" in blocked
 
 
 def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(


### PR DESCRIPTION
**[per-PR-coder]** — part of #2955 (FP-0063 P3). Design:
`docs/deep-dives/proposals/0063-builtin-turnkey-user-rag.md`.

The two builtin pipelines the P2 MCP servers (#2952) exist to serve.

## ⚠️ NOT turnkey yet — `python3` on PATH must be reyn's own interpreter

**Named blocker, deliberately not fixed here** (needs a DSL/core decision; tracked on #2955).

`rag_ingest` shells out to `python3 -m reyn.builtin.rag_ingest_helpers` for the three things R1
genuinely cannot express (hash / string length / zip-by-index). `sandboxed_exec` forwards the
**ambient PATH** (`os.environ.get("PATH")`) and `sys.executable` is **unreachable from the DSL**,
so `python3` resolves however the operator's shell resolves it. It therefore works **only where
`python3` happens to be reyn's interpreter** — a `pipx install reyn` (the *most* turnkey install),
a non-activated venv, or any differing PATH breaks it.

**CI structurally cannot witness this class** — CI's `python3` *is* the `pip install -e` job's own
interpreter, so it is always green. **"7/7 CI green" is not evidence here**, the same way #2965
stayed invisible for 13 days because dogfood doesn't run in CI.

**What this PR does about it**: since FP-0063's whole subject is *turnkey* user RAG, I removed
every "turnkey"/"ready to use" claim from the pipeline headers, step descriptions, registry
entries and cookbook, and stated the requirement at each surface instead. The failure is also now
**caught at step 0 with a named remedy** rather than surfacing as an opaque
`path 'ctx.files_raw.structured' is absent` (see ③ below). Unmet, written as unmet.

| Pipeline | Registered as | Does |
|---|---|---|
| `rag_ingest.yaml` | `rag_ingest.ingest` | file/folder → markdown → chunk → embed → sqlite vector store, incrementally by `content_hash` |
| `rag_query.yaml` | `rag_query.query` | embed the query → top-k nearest chunks |

## ⚠️ The proposal's **F-B premise is false** — and this PR carries the minimal core change it forces

The proposal states (line 112 / co-vet finding F-B):

> **`embed`'s result envelope already carries usage** … so a **pipeline can read spend directly**

and builds two conclusions on it: **X2a** ("`fold` `envelope.total_tokens`") and
**"F-B also settles C4 for free"** ("stamp chunk metadata from `envelope.model`").

**Both were unreachable.** Verified directly (primary data — the actual outputs, not inference):

```
canonical meta      : {'model': 'text-embedding-3-small', 'total_tokens': 42, 'cost_usd': 0.001, 'priced': True}
pipeline ctx.<name> : {'text': '', 'structured': [[0.1, 0.2]]}
total_tokens reachable from ctx?  False
cost_usd     reachable from ctx?  False
```

`embed_to_canonical` correctly puts the usage into `meta` — its docstring even anticipates "a
future ingest pipeline's `fold` step, X2a/X2c reads [them] inline". But
`canonical_to_ctx_fields`, which builds `ctx.<name>`, read **`text` + `structured` only**. `meta`
— every producer's signal channel, which the *chat* side has always seen via `seam.py` — died at
the pipeline boundary.

**Why the fix is in this PR rather than deferred.** P3's "zero core change" gate was a
*prediction* resting on F-B being true. With F-B falsified, that gate's premise is gone. The two
honest options were "make the minimal core change that makes the arc correct" or "keep the gate
by writing a value we know is wrong" — and the second is not shippable, because the wrong value
is **specifically the failure C1 exists to prevent**:

> a server-internal embedder violates C1 *and* breaks **C4** — the per-chunk `embedding_model`
> column would record a model that never produced those vectors, i.e. **the column becomes a lie**

We reject vector-DB servers with built-in embedders for causing exactly that. Reaching the same
lie through the ctx reducer instead of through the server would have defeated the gate by another
route. (The owner's constraint is *"reyn 側のコード変更は最小限"* — minimal, not zero — and this
arc already has a sanctioned core PR, PC/#2949.)

### The core change

`canonical_to_ctx_fields` now exposes `meta`, **absent-when-empty** on the identical convention
`structured` already uses. Additive: a producer emitting no signal adds no key, so nothing that
previously read `ctx.<name>` changes shape. Absent-when-empty is deliberate — a step depending on
a signal then **fails loudly** instead of silently reading `{}` and defaulting.

### What it bought

| Req | Before (doc-only mitigation) | Now |
|---|---|---|
| **C4** | stamped the pipeline's INPUT — a class alias (`"standard"`), i.e. a model that never produced the vectors. Mitigation was a comment telling users to pass a concrete id. | stamped from **`envelope.model`** — the resolved model. **Correct by construction.** |
| **X2a** | chars/4 **estimate**, carrying a `note` field apologizing for itself | **metered** `tokens_embedded` / `cost_usd` / `priced` off the envelope. The caveat is deleted. |

Observed end-to-end with a real litellm-priceable model — **actual money, not an estimate**:

```
RUN: real priceable model (text-embedding-3-small)
  embedding_model  = 'text-embedding-3-small'
  tokens_embedded  = 9176
  cost_usd         = 0.00018352      ← 9176 x $0.02/1M. Real dollars.
  priced           = True
```

### Falsification (the wiring is *proven* to be load-bearing)

Stripping the two-line `meta` wiring from `canonical_to_ctx_fields` turns the C4 and X2a tests
**RED**, then green on restore:

```
error: pipeline 'rag_ingest.ingest' failed: step 11.match.12.match.1 (transform) failed:
  path 'ctx.embedded.meta.model' is absent: no field 'ctx.embedded.meta' in context

FAILED test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias
FAILED test_ingest_reports_metered_spend_not_the_chars4_estimate
5 failed, 3 passed          (restored -> 8 passed)
```

Note the failure *mode*: the absent path makes it **fail loudly**, not stamp a wrong value.

**The fakes are built so these tests cannot pass vacuously**, which is the real risk here:
- the provider **resolves** `"standard"` → `"fake/standard"` (mirroring `test_op_embed.py`'s own
  fixture, and what a real `RoutingEmbeddingProvider` does with a class alias). Had it echoed the
  input back, "stamped from INPUT" and "stamped from `envelope.model`" would be **indistinguishable**
  and the C4 assertion would pass against either implementation.
- it meters `len(text)` while the pipeline's estimate computes `len(text)//4` — a ~4x gap, so the
  reported figure is attributable to exactly one source (`1726` metered vs `429` estimated).

### One figure stays an estimate — necessarily

`estimated_tokens_saved_by_dedup` is a **counterfactual**: the only way to learn a *skipped*
chunk's true token count is to send it to the embedder — i.e. spend precisely what the skip
exists to avoid. Its name says which of the two it is; everything actually embedded is metered.

## What's here

- **`src/reyn/builtin/pipelines/rag_ingest.yaml`** — 6 `pipeline:` docs (entry + 5 same-file siblings).
- **`src/reyn/builtin/pipelines/rag_query.yaml`** — 3 `pipeline:` docs.
- **`src/reyn/builtin/rag_ingest_helpers.py`** — 4 stdin/stdout JSON subcommands (`probe` / `list_files` / `hash_chunks` / `zip_vectors`) for the three things R1 genuinely cannot express: **hashing**, **string length**, and **zip-by-index**. Invoked via `shell:` steps. Builtin content, no reyn-core import — copyable alongside the pipelines (R2).
- **`src/reyn/builtin/registry.py`** — registers both (inert: invoke-by-name, A3).
- **`src/reyn/core/offload/canonical.py`** — ⚠️ **the one core change**: expose `meta` on the pipeline ctx shape (see above).
- **`docs/reference/runtime/pipeline-dsl.md` + `.ja.md`** — the normative ctx-shape reference called this a "two-field shape"; now documents `meta`, the absent-when-empty rule, and the `get(...)` safe-navigation idiom. Both language mirrors.
- **`docs/cookbook/configs/with-builtin-rag-mcp.yaml`** — adds the markitdown server entry P2 deferred to P3, + how to run both pipelines, + the "copy and re-point" extension note. Still ships **commented-out / INERT** (R3 / F-D: an `mcp.servers.<name>` entry is auto-granted by `reyn pipe run`).

### X1 pre-flight (the decision-enabling error)

Step 0 makes a **real probe call** per server (not a config-presence check), each
`schema: PreflightCheck`-gated inside a `parallel { on_error: continue }` — so a failure
drops *that one branch* and we know **which** server failed **by name**, without parsing
transport error text. An unreachable server yields, per the #2932 `require_mcp` precedent
(**cause + two concrete remedies**), e.g.:

> Vector-store MCP server 'reyn_vector_store' is unreachable. **(1)** enable it: add/uncomment `mcp.servers.reyn_vector_store` in reyn.yaml and set `permissions.mcp.reyn_vector_store: allow` — see `docs/cookbook/configs/with-builtin-rag-mcp.yaml`. **(2)** if already enabled, install its dependencies: `pip install "reyn[builtin-rag]"` (apsw + sqlite-vec).

The markitdown remedy additionally names the **R1 firewall** case explicitly (`uvx` fetches
from PyPI on first run → pre-install instead) — the owner's own network is the acceptance test.
A bare `ImportError: No module named 'apsw'` never reaches the operator: the block is the
run's own successful *output*, not an exception.

### C5 / X5 — observed, not assumed

Ingest runs, printing the real summary (2 files, ~429 chars/4 tokens):

```
RUN 1 (cold -- everything new)
  chunks_upserted                  = 5
  chunks_unchanged_skipped         = 0
  estimated_tokens_embedded        = 429
  estimated_tokens_saved_by_dedup  = 0
RUN 2 (X5: re-ingest UNCHANGED folder)
  chunks_upserted                  = 0      ← costs ~0 …
  chunks_unchanged_skipped         = 5
  estimated_tokens_embedded        = 0
  estimated_tokens_saved_by_dedup  = 429    ← … and REPORTS that it did
```

X5's stated purpose ("re-ingesting an unchanged folder must cost ≈0 **and report that it
did**") is met. Note `embed` is not called at all on a fully-deduped run — it *rejects* an
empty `texts` array, so a `match` gate routes around it rather than feeding it something it
refuses.

## Test plan

`tests/test_fp0063_p3_rag_pipelines.py` — 7 tests, driving the **real** `reyn pipe run`
path against the **real** P2 MCP servers as real `python -m` stdio subprocesses.

- [x] **Tests actually RUN — not skipped.** `pytest tests/test_fp0063_p3_rag_pipelines.py -q -rs` → **`8 passed`**, zero skips. **CI-side proof**: main baseline `8559 passed / 16 skipped` → this PR `8566 passed / 16 skipped` = **+7 passed, +0 skipped** on the first push. The P2 near-miss (module-wide skip under CI green) did not recur. CI installs the extra (`test.yml:39` → `pip install -e ".[dev,mcp,web,fs-watch,observability,builtin-rag]"`, added by P2/#2952), so this holds in CI too — but the local `-rs` run above is the evidence, not CI green.
- [x] **`ruff check src tests`** → `All checks passed!`
- [x] **`python scripts/test_tier_audit.py --strict <both changed test files>`** → `OK: 30, warnings: 0, errors: 0` (exit 0)
- [x] **`pytest` (full, repo root)** → **`8577 passed, 20 skipped, 0 failed`** (223s), after all review rounds.
- [x] **`python scripts/verify_module_docstrings.py <changed src files>`** → OK
- [x] **C5 add → dedup → update → remove converges** (`test_ingest_add_then_dedup_then_update_then_remove`), driven through real chunker + vector-store servers.
- [x] **C4 = the RESOLVED model, read back out of the real sqlite** (`test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias`): invoked with the alias `"standard"`, every stored row carries `"fake/standard"`. Non-vacuous by construction (see the fakes note above).
- [x] **X2a = metered, not estimated** (`test_ingest_reports_metered_spend_not_the_chars4_estimate`): asserts the reported figure is ~4x the chars/4 estimate of the same text, plus `priced is False` / `cost_usd is None` for an unpriceable model (visible degradation, never a silent $0.00 — the #1829 sentinel).
- [x] **`meta` reducer pinned directly** (Tier 1, in `test_2425_pipeline_tool_ctx_canonical_shape.py`): present-when-signal / absent-when-empty.
- [x] **Falsification observed**: stripped the `meta` wiring → C4 + X2a RED; restored → green (output above).
- [x] **X1 block + falsifying control** — unconfigured server → named remedy; the *same* setup with the real name proceeds into the ingest body, so the block is attributable to the unreachable server, not a broken gate.
- [x] **X1 catches a reyn-less `python3`** (`test_ingest_preflight_blocks_when_python3_cannot_import_reyn`) — drives the REAL failure by pointing PATH at a python3 shim without reyn (which is precisely what `sandboxed_exec` forwards), not by faking a seam. Asserts cause + both remedies are present.
- [x] **rag_query top-k** returns the ingested chunk (`test_rag_query_returns_the_ingested_chunk_as_top_result`).
- [x] **X2a/X5 purpose observed end-to-end** — re-ingesting an unchanged folder upserts **0** and *reports* the 429 tokens the dedup saved; a priceable model reports **`$0.00018352`** of real spend. Driven manually, printed from the pipeline's own output.

### Test honesty notes

- ⚠️ **markitdown is SUBSTITUTED — the owner's named formats are UNVERIFIED.** `markitdown-mcp`
  is not installed here and `uvx` would need network, so the tests run a **small real FastMCP
  stdio server** (written to disk by the test) that reads `file://`/`data:` URIs as UTF-8. The
  chunker and vector-store servers are the **real** builtin ones, and only `.txt` fixtures are
  ingested — so **this PR has NOT exercised real pdf / xlsx / pptx / docx through real
  markitdown**, i.e. exactly the format list the owner named (txt, md, pdf, エクセル, パワポ,
  ワード). Not claimed as working. Belongs to P4/P5 as real-environment verification; flagged
  for #2955 rather than papered over.
- **The embedding provider is faked** (`FakeEmbeddingProvider`, mirroring
  `tests/test_op_embed.py`'s own fixture, monkeypatched onto `op_runtime.embed.get_provider`)
  — no `unittest.mock`, no API key/network. Everything else is real.

## Review round 2 — three in-PR findings

**① The C4 fossil (my bug).** `_ingest_body`'s description still described the design that was
*rejected* — "stamping embedding_model from **THIS pipeline's own input** … see ingest's
description for **why not envelope.model**" — while the implementation does the opposite and
`ingest`'s own description was already correct. An **inverted cross-reference**: readers were sent
to a doc that now explains the exact opposite. Residue of the very class this PR pins, sitting
inside the PR whose thesis is *correct by construction, not by documentation*. Fixed.

**② The marker comment (my bug, introduced by this PR).** `canonical.py`'s
`_DISCRIMINATOR_MISS_MARKER` justified its containment with *"the ctx reducer
(`canonical_to_ctx_fields` **reads `text`/`attachments`**) never read it"* — which **this PR made
false** by adding `meta`. The **conclusion** survives (the marker is a *top-level* key, not a
`meta` field, so no consumer names it) but the **stated mechanism** was wrong, and it collided on
the term *"signal channel"* with `meta`'s new docstring. Restated: containment rests on being
top-level, and the two channels are now distinguished by name.

**③ The silent shell-step failure — the proposed mechanism does not exist.**

The review asked the pipeline to read its own `shell` steps' `meta.returncode`. **It cannot**:
`shell._handle` returns **`stdout` only** — `returncode`/`stderr` are dropped *one layer above*
the canonical seam by #2593's locked design, so `shell_to_canonical`'s meta is **always `{}`**
(its own docstring says so). Verified by driving a failing shell step end-to-end:

```
shell step result in ctx : {'text': ''}      ← no meta, no returncode
did the pipeline abort?  : NO -- it completed
```

There is no `meta.returncode` to read. But the **goal** — make the silent failure diagnosable —
is reachable, and that is what shipped: a `probe` subcommand wired into the **existing X1
pre-flight list** (it is a reachability check, so it belongs beside the MCP checks rather than as
new scaffolding). Empty stdout ⇒ no `structured` key ⇒ detected, **before any embedding spend**.

Observed — the 30-minute opaque failure is now a named remedy:

```
rag ingest blocked -- one or more prerequisites are unreachable:

helpers (python3 -m reyn.builtin.rag_ingest_helpers): `python3 -m reyn.builtin.rag_ingest_helpers`
failed -- the `python3` on PATH cannot import reyn. […] (1) run reyn from an environment whose
`python3` IS reyn's interpreter -- typically `source .venv/bin/activate` […] a `pipx install reyn`
or a non-activated venv will NOT satisfy this. (2) check what you actually have:
`python3 -c 'import reyn; print(reyn.__file__)'` […]
```

Honest limits: the probe catches **"`python3` has no reyn"** (the common pipx/venv/PATH case). It
**cannot** catch **"`python3` has a *different* reyn"** (the architect's two-install incident) —
that imports fine. So it *reports the paths* for a human to compare, and says so in the message
rather than implying a guarantee. `rag_query` shells out to nothing, so it carries no probe and no
`python3` requirement.

## Other

- **`tests/test_2575_pipeline_disk_registration.py` touched (unavoidable).** It pinned
  `set(pipeline_registry.names()) == {"hello.hello", "flagship.research_and_report"}` — a
  hardcoded set that any new builtin pipeline breaks. Rewritten to **derive** expected names
  from `BUILTIN_PIPELINES` itself, so the next builtin needs no edit here. The test still
  asserts the same invariant (builtin tier is additive, not exclusive).
- **The proposal doc is untracked in `main`** — it exists only in the lead-coder's working
  tree, so the path above will 404 for reviewers until it's committed. Not committing
  someone else's uncommitted draft from a sub-PR; flagging for the lead-coder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
