### PR TITLE
feat: CI gate verifying dogfood scenario skill/event refs resolve against live registries (#2965)

### DIFF
--- a/src/reyn/dev/dogfood/verifiers/asset_refs.py
+++ b/src/reyn/dev/dogfood/verifiers/asset_refs.py
@@ -1,0 +1,249 @@
+"""Dogfood scenario asset-reference contract check (#2965).
+
+``dogfood/scenarios/*.yaml`` names skills (``expected_skill:`` / an
+artifact assertion's ``skill:`` key) and event kinds (``expected.events.
+must_emit`` / ``must_not_emit`` / ``must_emit_any`` / ``sequence``) as bare
+strings. Nothing at scenario-load time checks those strings against
+anything real — dogfood does not run in CI (it calls an LLM), so a
+reference that goes stale between one bulk deletion and the next stays
+silently dead until a human happens to run that scenario file by hand.
+This module is the structural check that closes that gap in CI, without
+needing to run dogfood itself.
+
+**Ground truth is derived, never grep-listed.** Two registries:
+
+- ``known_skills()`` — ``reyn.builtin.registry.BUILTIN_SKILLS`` (the
+  code-shipped skill tier) union any ``skills.entries`` declared in this
+  repo's own ``reyn.yaml`` (the operator-declared tier for THIS repo's
+  own dogfood runs). Whatever skill names exist for a real run of this
+  repo's dogfood suite, live here.
+- ``known_event_types()`` — every string literal passed as the ``type``
+  (positional or ``type=``/``kind=`` keyword) argument to any method
+  whose name contains ``emit`` anywhere under ``src/reyn``, found via an
+  ``ast`` walk of every module (not a text grep, and not sampled: a
+  literal event-kind string cannot be missed by mis-spelling or by
+  reading only the first few hits — see #2965's postmortem on why a
+  spelling-sensitive text grep is not a safe substitute for this). There
+  is no single closed "all event kinds" enum in this codebase (the
+  ``EVENT_AUDIT_REQUIREMENTS`` dict in ``core/events/event_schema.py`` is
+  a curated subset for audit-completeness tests, not exhaustive), so the
+  AST walk over every actual emit call site IS the registry — a scenario
+  referencing an event kind absent from this set is asserting on
+  something the current runtime provably never produces.
+
+``find_violations()`` walks every ``dogfood/scenarios/*.yaml`` file and
+returns one :class:`ScenarioRefViolation` per reference that resolves to
+neither registry. The corpus had known violations at the time this check
+was written (#2965 part 1 — reconstructing each one's *intent* needs a
+human judgement call between delete / re-point / drop, which this module
+does not make); those are tracked in ``KNOWN_PENDING_VIOLATIONS`` in
+``tests/test_dogfood_scenario_asset_refs_contract.py`` so the gate is
+green today while still hard-failing on any *new* dead reference.
+"""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SRC_ROOT = _REPO_ROOT / "src" / "reyn"
+_SCENARIOS_DIR = _REPO_ROOT / "dogfood" / "scenarios"
+_REYN_YAML = _REPO_ROOT / "reyn.yaml"
+
+
+@dataclass(frozen=True)
+class ScenarioRefViolation:
+    """One scenario reference that resolves to neither registry.
+
+    ``kind`` is ``"skill"`` or ``"event"``; ``value`` is the referenced
+    name; ``file``/``scenario_id`` locate it in the corpus.
+    """
+    file: str
+    scenario_id: str
+    kind: str
+    value: str
+
+
+# ---------------------------------------------------------------------------
+# Registries (ground truth, derived — not grep-listed)
+# ---------------------------------------------------------------------------
+
+
+def known_skills() -> frozenset[str]:
+    """Every skill name resolvable for a real run of this repo's dogfood suite.
+
+    ``BUILTIN_SKILLS`` (code-shipped tier, always present) union this
+    repo's own ``reyn.yaml`` ``skills.entries`` (operator tier), mirroring
+    ``reyn.config.loader.load_config``'s two lowest tiers without
+    depending on the full loader (which wants a live project context this
+    static check does not have).
+    """
+    from reyn.builtin.registry import BUILTIN_SKILLS
+
+    names = set(BUILTIN_SKILLS.keys())
+    if _REYN_YAML.exists():
+        doc = yaml.safe_load(_REYN_YAML.read_text(encoding="utf-8")) or {}
+        entries = ((doc.get("skills") or {}).get("entries")) or {}
+        if isinstance(entries, dict):
+            names.update(entries.keys())
+    return frozenset(names)
+
+
+def known_op_kinds() -> frozenset[str]:
+    """Every Control IR op kind — the ``OP_KIND_MODEL_MAP`` union.
+
+    Not currently cross-referenced by :func:`find_violations` (no
+    scenario field carries a bare op-kind string today — ``covers:``
+    tags use a separate free-form taxonomy, see module docstring), but
+    exposed for a future field that does, and so this module has a
+    single answer to "what op kinds exist" rather than each caller
+    re-deriving it.
+    """
+    from reyn.schemas.models import ALL_OP_KINDS
+
+    return ALL_OP_KINDS
+
+
+def known_event_types() -> frozenset[str]:
+    """Every event-kind string literal passed to an ``*emit*`` call in ``src/reyn``.
+
+    AST walk (``ast.parse`` + ``ast.walk``), not a text grep: every ``.py``
+    file under ``src/reyn`` is parsed, and every ``Call`` node whose
+    callee name contains ``"emit"`` contributes its string-literal
+    positional args and its ``type=``/``kind=`` keyword args. This over-
+    includes a handful of non-event string literals that happen to share
+    a call site with an ``emit*``-named method (harmless: it only makes
+    the registry more permissive, it can never hide a genuinely dead
+    reference), and under-includes nothing reachable by static string
+    literal — the two failure modes are asymmetric on purpose given this
+    is a "is X reachable at all" gate, not an exhaustive event catalogue.
+    """
+    found: set[str] = set()
+    for path in _SRC_ROOT.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else (
+                func.id if isinstance(func, ast.Name) else None
+            )
+            if not name or "emit" not in name.lower():
+                continue
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    found.add(arg.value)
+            for kw in node.keywords:
+                if kw.arg in ("type", "kind") and isinstance(kw.value, ast.Constant) and isinstance(
+                    kw.value.value, str
+                ):
+                    found.add(kw.value.value)
+    return frozenset(found)
+
+
+# ---------------------------------------------------------------------------
+# Scenario reference extraction
+# ---------------------------------------------------------------------------
+
+
+def _iter_event_type_refs(expected: dict[str, Any]) -> list[str]:
+    events = expected.get("events")
+    if not isinstance(events, dict):
+        return []
+    refs: list[str] = []
+    for bucket in ("must_emit", "must_not_emit", "must_emit_any"):
+        for item in events.get(bucket) or []:
+            if isinstance(item, dict) and isinstance(item.get("type"), str):
+                refs.append(item["type"])
+    for item in events.get("sequence") or []:
+        if isinstance(item, str):
+            refs.append(item)
+    return refs
+
+
+def _iter_skill_refs(raw_scenario: dict[str, Any], expected: dict[str, Any]) -> list[str]:
+    refs: list[str] = []
+    expected_skill = raw_scenario.get("expected_skill")
+    if isinstance(expected_skill, str):
+        refs.append(expected_skill)
+    artifacts = expected.get("artifacts")
+    if isinstance(artifacts, list):
+        for item in artifacts:
+            if isinstance(item, dict) and isinstance(item.get("skill"), str):
+                refs.append(item["skill"])
+    return refs
+
+
+def _iter_scenario_files(scenarios_dir: Path) -> list[Path]:
+    return sorted(scenarios_dir.glob("*.yaml"))
+
+
+def scanned_scenario_ids(scenarios_dir: Path | None = None) -> list[tuple[str, str]]:
+    """Return ``(file, scenario_id)`` for every scenario :func:`find_violations` inspects.
+
+    Exists so a test can assert the scan actually reached a non-empty
+    corpus. Without it, a wrong ``_SCENARIOS_DIR`` would make
+    ``find_violations`` glob zero files, report zero violations, and go
+    GREEN while checking nothing — the same always-verifies-empty shape
+    as #2959's artifact verifier. The registry-side failure mode is
+    fail-loud by contrast (an empty registry flags EVERY reference), so
+    only the corpus side needs this witness.
+    """
+    ids: list[tuple[str, str]] = []
+    for path in _iter_scenario_files(scenarios_dir or _SCENARIOS_DIR):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for raw in doc.get("scenarios") or []:
+            if isinstance(raw, dict):
+                ids.append((path.name, str(raw.get("id", "<unknown>"))))
+    return ids
+
+
+def find_violations(scenarios_dir: Path | None = None) -> list[ScenarioRefViolation]:
+    """Return every scenario skill/event reference absent from both registries.
+
+    Scans every ``<scenarios_dir>/*.yaml`` file (default: this repo's
+    ``dogfood/scenarios/``) directly via ``yaml.safe_load`` (not through
+    ``load_scenario_set``) because the legacy G4-spike scenario format
+    (``expected_skill:``, no ``type:`` key) and the ``skill:`` key on an
+    artifact assertion (accepted but silently dropped by
+    ``ArtifactAssertion``, since it has no ``skill`` field) both carry
+    references this check needs that the typed loader does not preserve.
+
+    ``scenarios_dir`` is overridable so a test can point this at a
+    synthetic fixture directory and prove the detector fires, without
+    monkeypatching module internals.
+    """
+    skills = known_skills()
+    events = known_event_types()
+    violations: list[ScenarioRefViolation] = []
+
+    for path in _iter_scenario_files(scenarios_dir or _SCENARIOS_DIR):
+        doc = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        raw_scenarios = doc.get("scenarios")
+        if not isinstance(raw_scenarios, list):
+            continue
+        for raw in raw_scenarios:
+            if not isinstance(raw, dict):
+                continue
+            scenario_id = str(raw.get("id", "<unknown>"))
+            expected = raw.get("expected")
+            expected = expected if isinstance(expected, dict) else {}
+
+            for event_type in _iter_event_type_refs(expected):
+                if event_type not in events:
+                    violations.append(
+                        ScenarioRefViolation(path.name, scenario_id, "event", event_type)
+                    )
+            for skill_name in _iter_skill_refs(raw, expected):
+                if skill_name not in skills:
+                    violations.append(
+                        ScenarioRefViolation(path.name, scenario_id, "skill", skill_name)
+                    )
+    return violations

--- a/tests/test_dogfood_scenario_asset_refs_contract.py
+++ b/tests/test_dogfood_scenario_asset_refs_contract.py
@@ -1,0 +1,196 @@
+"""Tier 1: dogfood scenario skill/event references resolve against live registries (#2965).
+
+dogfood does not run in CI (it calls an LLM), so a scenario referencing a
+skill or event kind that a bulk deletion later removed stays silently dead
+until a human happens to run that exact scenario file — as happened for 13
+days after #2434/#2438 deleted the entire stdlib-skill/phase-engine
+machinery (13 skills, the ``invoke_skill``/``run_skill`` op path, and the
+``skill_run_spawned``/``skill_run_completed``/``lint_completed`` event
+kinds) while 9+ live scenario references to that machinery were left
+behind. ``reyn.dev.dogfood.verifiers.asset_refs.find_violations`` closes
+that gap: it re-derives "what skills/event-kinds actually exist" from the
+real registries (``BUILTIN_SKILLS`` + this repo's ``reyn.yaml``; every
+``*emit*`` call site under ``src/reyn``, via ``ast``) and cross-references
+every scenario's ``expected_skill:`` / artifact ``skill:`` / event
+assertions against them — see that module's docstring for why this is
+derived rather than a name list some future deletion could just as easily
+outrun again.
+
+``KNOWN_PENDING_VIOLATIONS`` is the exception list for references that
+were ALREADY dead when this gate was written (#2965 part 1's own
+findings) — reconstructing each one's original intent needs a human
+judgement call (delete the scenario / re-point to one of the 2 skills
+that still exist / drop the assertion) that this gate does not make.
+Remove an entry the moment its scenario is fixed; do not add a new entry
+here to silence a violation this gate just caught — that defeats the gate.
+"""
+from __future__ import annotations
+
+from reyn.dev.dogfood.verifiers.asset_refs import (
+    ScenarioRefViolation,
+    find_violations,
+    known_event_types,
+    known_skills,
+    scanned_scenario_ids,
+)
+
+# (file, scenario_id, kind, value) — see module docstring. Every one of
+# these pre-dates this gate; #2965 part 1 investigated each but did not
+# resolve them (delete/re-point/drop needs an owner call).
+KNOWN_PENDING_VIOLATIONS: frozenset[tuple[str, str, str, str]] = frozenset({
+    # chat_router_smoke.yaml IS the main dogfood smoke set (#2965).
+    ("chat_router_smoke.yaml", "explicit_skill_invocation_word_stats", "event", "skill_run_spawned"),
+    ("chat_router_smoke.yaml", "explicit_skill_invocation_word_stats", "event", "skill_run_completed"),
+    ("chat_router_smoke.yaml", "explicit_skill_invocation_word_stats", "skill", "word_stats_demo"),
+    ("chat_router_smoke.yaml", "catalog_routing_decided_emitted", "skill", "direct_llm"),
+    # control_ir_ops.yaml: #2958 removed the judge_output_direct sibling
+    # (same class); these two were still there.
+    ("control_ir_ops.yaml", "lint_a_skill", "event", "lint_completed"),
+    ("control_ir_ops.yaml", "ask_user_round_trip", "event", "skill_run_spawned"),
+    ("multi_agent_and_mcp.yaml", "mcp_search_registry", "event", "skill_run_spawned"),
+    # permissions_enforcement.yaml: "write_file" was never a real event
+    # kind (writes emit tool_executed with op="write_file", a payload
+    # field, not a type) — a must_not_emit on it is a vacuous no-op, not
+    # a #2434/#2438 casualty, but still a dead reference this gate catches.
+    ("permissions_enforcement.yaml", "realignment_approvals_yaml_write_denied", "event", "write_file"),
+    ("permissions_enforcement.yaml", "file_write_outside_cwd_denied", "event", "write_file"),
+    # fp_0011_narration.yaml / fp_0011_0012_retest.yaml: frozen point-in-
+    # time spike/retest records for already-landed FP-0011/FP-0012,
+    # driven by scripts/dogfood_g4_spike.py against a since-merged spike
+    # branch — not part of the FP-0036 live-rerun corpus, but they still
+    # sit in dogfood/scenarios/ referencing the same deleted skills.
+    ("fp_0011_narration.yaml", "narr-1-mcp-search", "skill", "mcp_search"),
+    ("fp_0011_narration.yaml", "narr-2-eval-numeric", "skill", "eval"),
+    ("fp_0011_narration.yaml", "narr-3-skill-builder", "skill", "skill_builder"),
+    ("fp_0011_narration.yaml", "narr-4-skill-improver", "skill", "skill_improver"),
+    ("fp_0011_0012_retest.yaml", "s-fp11-1-builder-invalid-spec", "skill", "skill_builder"),
+    ("fp_0011_0012_retest.yaml", "s-fp11-2-eval-missing-target", "skill", "eval"),
+    ("fp_0011_0012_retest.yaml", "s-fp11-3-mcp-search-empty", "skill", "mcp_search"),
+    ("fp_0011_0012_retest.yaml", "s-fp12-spawn-1-builder-success-ack", "skill", "skill_builder"),
+    ("fp_0011_0012_retest.yaml", "s-fp12-completion-1-mcp-search-narrate", "skill", "mcp_search"),
+    ("fp_0011_0012_retest.yaml", "s-fp12-completion-2-error-narrate", "skill", "skill_builder"),
+})
+
+
+def _key(v: ScenarioRefViolation) -> tuple[str, str, str, str]:
+    return (v.file, v.scenario_id, v.kind, v.value)
+
+
+def test_no_new_dead_scenario_asset_references() -> None:
+    """Tier 1: no scenario references a skill/event absent from both registries, beyond the tracked #2965 exceptions."""
+    violations = find_violations()
+    unexpected = [v for v in violations if _key(v) not in KNOWN_PENDING_VIOLATIONS]
+    assert not unexpected, (
+        "New dead scenario skill/event reference(s) — not in #2965's tracked "
+        f"exception list (add the fix, not a new exception): {unexpected}"
+    )
+
+
+def test_known_pending_violations_list_has_no_stale_entries() -> None:
+    """Tier 1: every tracked #2965 exception still reproduces as a real violation.
+
+    Prevents allowlist rot: if a scenario is fixed without removing its
+    entry here, a later unrelated regression at the exact same (file,
+    scenario_id, kind, value) tuple would be silently swallowed by the
+    stale entry instead of failing the gate.
+    """
+    found_keys = {_key(v) for v in find_violations()}
+    stale = KNOWN_PENDING_VIOLATIONS - found_keys
+    assert not stale, (
+        f"Stale #2965 exception entries no longer reproduce (scenario was "
+        f"fixed — remove from KNOWN_PENDING_VIOLATIONS): {stale}"
+    )
+
+
+def test_gate_actually_scans_a_non_empty_corpus_against_real_registries() -> None:
+    """Tier 1: the scan reaches real scenarios and real registries — not vacuously green on empty inputs.
+
+    The gate's green signal is only meaningful if it inspected something.
+    A wrong scenarios dir would glob zero files and report zero
+    violations — green while checking nothing (#2959's artifact verifier
+    shipped exactly that shape; #2962's seccomp filter was never loaded
+    in production while its mechanism test stayed green). Asserts the
+    corpus and both registries are non-trivially populated, and that the
+    two skills known to ship are the ones found.
+    """
+    scanned = set(scanned_scenario_ids())
+    # Named real scenarios, not a count: an empty/misdirected scan fails
+    # this by membership, and it stays meaningful as the corpus grows.
+    assert ("chat_router_smoke.yaml", "explicit_skill_invocation_word_stats") in scanned
+    assert ("control_ir_ops.yaml", "file_read_via_chat") in scanned
+    assert ("permissions_enforcement.yaml", "file_write_outside_cwd_denied") in scanned
+
+    # BUILTIN_SKILLS is the code-shipped tier; these two are what registry.py declares.
+    assert known_skills() >= {"reyn_cheat_sheet", "draft_judge_revise"}
+    # A handful of event kinds that demonstrably have live emit call sites.
+    assert known_event_types() >= {"routing_decided", "tool_executed", "permission_denied"}
+
+
+def test_find_violations_detects_a_dead_skill_reference(tmp_path) -> None:
+    """Tier 1: find_violations() flags a synthetic reference to a skill that does not exist.
+
+    Mechanism-liveness proof (not a golden fixture): drives the real
+    detector against a scenario file naming a skill guaranteed absent
+    from BUILTIN_SKILLS, proving the gate's detector actually fires
+    rather than being green by construction on any input.
+    """
+    scenario_dir = tmp_path / "scenarios"
+    scenario_dir.mkdir()
+    (scenario_dir / "synthetic.yaml").write_text(
+        "type: dogfood_scenario_set\n"
+        "name: synthetic\n"
+        "scenarios:\n"
+        "  - id: broken\n"
+        "    input: hi\n"
+        "    expected_skill: totally_fake_skill_xyz\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(scenarios_dir=scenario_dir)
+    assert any(v.value == "totally_fake_skill_xyz" and v.kind == "skill" for v in violations)
+
+
+def test_find_violations_detects_a_dead_event_reference(tmp_path) -> None:
+    """Tier 1: find_violations() flags a synthetic must_emit on an event kind no code ever emits."""
+    scenario_dir = tmp_path / "scenarios"
+    scenario_dir.mkdir()
+    (scenario_dir / "synthetic.yaml").write_text(
+        "type: dogfood_scenario_set\n"
+        "name: synthetic\n"
+        "scenarios:\n"
+        "  - id: broken\n"
+        "    input: hi\n"
+        "    expected:\n"
+        "      events:\n"
+        "        must_emit:\n"
+        "          - { type: totally_fake_event_kind_xyz, count: '>=1' }\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(scenarios_dir=scenario_dir)
+    assert any(v.value == "totally_fake_event_kind_xyz" and v.kind == "event" for v in violations)
+
+
+def test_find_violations_accepts_a_live_reference(tmp_path) -> None:
+    """Tier 1: find_violations() does NOT flag a reference to a skill/event that genuinely exists.
+
+    Sibling to the two detects-a-break tests above: proves the gate is
+    not merely permissive-to-the-point-of-flagging-everything — a
+    reference to a currently-live skill and a currently-live event kind
+    both pass clean.
+    """
+    scenario_dir = tmp_path / "scenarios"
+    scenario_dir.mkdir()
+    (scenario_dir / "synthetic.yaml").write_text(
+        "type: dogfood_scenario_set\n"
+        "name: synthetic\n"
+        "scenarios:\n"
+        "  - id: ok\n"
+        "    input: hi\n"
+        "    expected_skill: reyn_cheat_sheet\n"
+        "    expected:\n"
+        "      events:\n"
+        "        must_emit:\n"
+        "          - { type: routing_decided, count: '>=1' }\n",
+        encoding="utf-8",
+    )
+    violations = find_violations(scenarios_dir=scenario_dir)
+    assert violations == []


### PR DESCRIPTION
**[per-PR-coder]** — part of #2965

Implements ask (2) — the structural gate. Ask (1) is an investigation report below; **no scenario content is changed in this PR** (each dead ref needs a delete/re-point/drop call that is yours to make).

## (2) The gate

`reyn.dev.dogfood.verifiers.asset_refs.find_violations()` + Tier-1 contract test. Cross-references every `dogfood/scenarios/*.yaml` skill/event reference against **derived** registries.

**Derived, not a name list** — the form is "registry is truth; is every scenario ref contained in it?", not "grep for known-bad names":

- `known_skills()` = `BUILTIN_SKILLS` ∪ this repo's `reyn.yaml` `skills.entries` (none declared → effectively `{reyn_cheat_sheet, draft_judge_revise}`).
- `known_event_types()` = an `ast` walk of **every** `*emit*` call site under `src/reyn`, collecting each string literal passed as the event type/kind → **205 kinds**. There is no closed event-kind enum to import: `EVENT_AUDIT_REQUIREMENTS` is a curated audit subset (15 entries), *not* exhaustive. So the AST walk over real production emit sites **is** the registry. A name-list grep is precisely the method that missed `judge_phase` (different spelling), so it is deliberately not used.

**RED observed — twice, both restored from byte-copy backups (never `git checkout`):**

1. **Live-ref break.** Changed a currently-live `must_emit: routing_decided` in `permissions_and_safety.yaml` to a nonexistent kind → `test_no_new_dead_scenario_asset_references` **FAILED**, naming exactly that violation. Restored → green.
2. **Vacuous-green break.** Misdirected `_SCENARIOS_DIR` → glob finds 0 files → 0 violations. **The main assertion passed VACUOUSLY.** This is the #2959 always-verifies-empty / #2962 never-loaded-seccomp shape, and I only found it by asking "what makes this gate green while checking nothing?". Added `test_gate_actually_scans_a_non_empty_corpus_against_real_registries`, which pins named real scenarios (not a count) and turns this RED. Restored → green.

Note the asymmetry that makes this safe: an *empty registry* fails loud (flags every ref); only an *empty corpus* failed silent — hence the guard is corpus-side.

3 further hermetic tests drive the detector against synthetic tmp-dir fixtures (dead skill → flagged; dead event → flagged; live `reyn_cheat_sheet` + `routing_decided` → clean), so the RED/GREEN boundary is exercised in CI permanently, not just once by hand.

**Green today via `KNOWN_PENDING_VIOLATIONS`** — an explicit `(file, scenario_id, kind, value)` allowlist of the 19 refs already dead *before* this gate. `test_known_pending_violations_list_has_no_stale_entries` asserts every entry still reproduces, so the list can only **shrink** as you resolve them, and can never silently absorb a new violation at the same key.

## (1) Investigation — 19 dead refs across 6 files, not 9

Re-derived from source (not marker grep): `BUILTIN_SKILLS` has exactly **2** entries. `tests/test_multi_agent_p7.py`'s `_KNOWN_SKILL_NAMES` is the canonical list of the 18 removed names.

**Hard-broken today** (`must_emit` on an event kind with zero producers ⇒ can never pass, whatever the LLM does):

| file | scenario | dead ref |
|---|---|---|
| `chat_router_smoke.yaml` (**main smoke set**) | `explicit_skill_invocation_word_stats` | `skill_run_spawned`, `skill_run_completed`, skill `word_stats_demo` |
| `control_ir_ops.yaml` | `lint_a_skill` | `lint_completed` + `validation__lint__skill_path` action + `index_events` skill — **triple-dead** |
| `control_ir_ops.yaml` | `ask_user_round_trip` | `skill_run_spawned` |
| `multi_agent_and_mcp.yaml` | `mcp_search_registry` | `skill_run_spawned` |

**What was dark in the smoke set for 13 days — narrower than feared.** Of `chat_router_smoke.yaml`'s 7 scenarios, 5 had *already* been de-risked off skill-invocation by the B48/B49 fixes (2026-05-22: *"forcing direct_llm dispatch incentivises unnecessary skill invocation"*). So routing/reply-quality coverage kept working; **only the one explicit-skill-invocation axis (`word_stats_demo`) was dead.** `catalog_routing_decided_emitted`'s `artifacts: [{skill: direct_llm}]` is also flagged, though that check is *separately* already vacuous per #2959 (`RunResult.artifacts` is hardcoded `[]`).

**Dead but non-fatal:** `permissions_enforcement.yaml` ×2 assert `must_not_emit: write_file`. `write_file` was **never** an event kind (writes emit `tool_executed` with `op="write_file"` as a *payload field*). A `must_not_emit` on a never-emitted kind is a vacuous no-op — flagged because it tests nothing, but **not** #2438 fallout.

**Important nuance — `mcp_search` the skill is dead, `mcp_search_registry` the tool is LIVE.** Every `src/reyn` hit is a *different identifier* (`mcp_search_registry` verb, `mcp_search_threshold` config, `mcp_search_invoked` event). So `mcp_search_registry`'s scenario **intent is still achievable** — only its `skill_run_spawned` assertion is dead. This looks re-pointable (drop that assertion, keep `routing_decided`), but it's your call.

**Not part of the live corpus at all (14 of the 19):** `fp_0011_narration.yaml` + `fp_0011_0012_retest.yaml` use the legacy `metadata:`/`expected_skill:` shape read *only* by `scripts/dogfood_g4_spike.py`, a one-off driver hardcoded to a **since-merged spike branch**, answering an **already-closed** question (FP-0011: should router-inline narration replace `skill_narrator`?). They are frozen investigation records, same shape as `docs/deep-dives/journal/dogfood/`. My read: they likely belong out of `dogfood/scenarios/` (they can never run again — the skills are gone). **I did not move them — owner call.**

### 🔴 Additional dead asset the gate does NOT cover (new finding)
`dogfood/scripts/run_skill_importer_chain.py` + `dogfood/fixtures/skill_importer_chain/` shell out to **`reyn run skill_search` / `reyn run skill_importer`**. #2438 deleted the `run` CLI subcommand outright — verified: `interfaces/cli/commands/` has only `run_once`, no `run`. **100% dead**, outside `dogfood/scenarios/` so my gate does not see it. Flagging rather than deleting (same owner call).

### Where I can't decide
The delete/re-point/drop disposition for all 19 + the importer-chain asset. `mcp_search_registry` looks re-pointable and the two FP-0011 files look journal-able, but I'm **not guessing** — reconstructing intent for a spike that's already landed is exactly where a wrong guess bakes in a false-green.

## Why #2438 didn't fix this (ask #3)
#2438 scoped itself to *machinery* (`src/reyn/skill/`, ops, tools, schemas, tests) and never touched `dogfood/scenarios/`. Its completeness gate was *"post-delete full-suite GREEN (7008 passed)"* — **which cannot see dogfood, because dogfood isn't in CI.** The deletion was complete by its own stated scope; the gap is that no CI-visible consumer existed to catch the sibling breakage. That's the gap (2) closes.

## Gates (all 4, local, final state)
- `ruff check src tests` — **All checks passed**
- `python scripts/test_tier_audit.py --strict tests/test_dogfood_scenario_asset_refs_contract.py` — **6/6 OK, 0 errors** (caught a real `len(...) > 10` Tier-4 pin in my own first draft; rewritten to named-scenario membership — `pytest`-green ≠ CI-green, as CLAUDE.md says)
- `pytest` (repo root) — **8560 passed, 20 skipped**, exit 0 (all 20 skips pre-existing/environmental: Docker, Linux-only, optional deps — none mine)
- `python scripts/verify_module_docstrings.py src/reyn/dev/dogfood/verifiers/asset_refs.py` — **OK**

## Test plan
- [x] `pytest tests/test_dogfood_scenario_asset_refs_contract.py -rs -v` → **6/6 passed, zero skips** (`-rs` confirms it is not silently skipped — the `Import ... could not be resolved` diagnostic is a stale editable-install pointing at *another* worktree; pytest's `pythonpath=["src"]` resolves this worktree correctly, verified by probe)
- [x] Falsify #1 (live ref): broke `must_emit` in `permissions_and_safety.yaml` → RED naming the violation → restored byte-identical → green
- [x] Falsify #2 (vacuous green): misdirected scenarios dir → RED via the new corpus guard (**and confirmed the main gate goes green vacuously without it**) → restored byte-identical → green
- [x] Full-repo `pytest` green (8560 passed)
- [x] Full census re-run without `head` truncation (bucketed by area) — surfaced the importer-chain asset a truncated grep would have missed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
