### PR TITLE
fix: add #2972 mode-2 gate probe -- ambient-python3 builtin shell-out (XFAIL until fixed)

### DIFF
--- a/.github/workflows/wheel-reachability.yml
+++ b/.github/workflows/wheel-reachability.yml
@@ -27,7 +27,12 @@ jobs:
       # (2) reads README/docs/source through reyn_repo's dual-mode resolver
       # and asserts byte-identity with the dev checkout, (3) asserts a
       # non-declared path is refused, (4) re-checks the still-LIVE
-      # read_builtin_body_bytes path (#2913, untouched by 0061). This is
+      # read_builtin_body_bytes path (#2913, untouched by 0061), (5) reproduces
+      # #2972 (builtin RAG ingest shells out to ambient `python3`, which
+      # breaks under `pipx install reyn`) by resolving a bare `python3` from
+      # a PATH shaped like that exact environment -- XFAIL until #2972 is
+      # fixed, XPASS (unexpected success) fails the gate so the probe gets
+      # promoted to a strict assertion in the same PR that fixes it. This is
       # deliberately NOT path-filtered: a positive include-list is itself a
       # false-allow surface — an incomplete list lets a packaging regression
       # under an unlisted path merge with the gate silently never running.

--- a/scripts/wheel_reachability_smoke.py
+++ b/scripts/wheel_reachability_smoke.py
@@ -29,11 +29,30 @@ venv, and probes it for:
 4. **#2913 builtin body reads (kept, LIVE, unaffected by 0061)** —
    ``read_builtin_body_bytes`` on a real skill/pipeline body, plus the
    least-privilege negative (an in-package ``.py`` module returns ``None``).
+5. **#2972 ambient-``python3`` builtin shell-out (mode-2, XFAIL until
+   fixed)** — the builtin RAG ingest pipeline
+   (``src/reyn/builtin/pipelines/rag_ingest.yaml``) shells out to
+   ``python3 -m reyn.builtin.rag_ingest_helpers`` via ``sandboxed_exec``,
+   which forwards the ambient ``PATH`` through unmodified — never
+   ``sys.executable``, never a venv path baked into the command. This check
+   reproduces that EXACT shape: plain ``python3`` resolved from a PATH
+   shaped like a ``pipx install reyn`` environment (a clean, reyn-less venv
+   sits first on PATH). It is the only check in this file that CAN witness
+   the #2972 regression — every other check here runs the wheel through an
+   interpreter that resolves reyn (``venv_python`` / ``sys.executable``),
+   and a normal pytest job's ambient ``python3`` trivially IS the job's own
+   (reyn-having) interpreter, so "ambient python3 == reyn's interpreter" can
+   never be falsified there. Deliberately EXPECTED TO FAIL (XFAIL) until
+   #2972 lands a fix; an unexpected PASS (XPASS) fails the gate instead of
+   silently going stale — see ``_check_ambient_python3_shellout`` and its
+   caller in ``main()``.
 
-Exits 0 iff every check passes; exits non-zero (with a PASS/FAIL line per
-check) on the first structural failure or any assertion failure. Cleans up
-the temp wheel directory and venv in a ``finally`` block, on success or
-failure alike.
+Exits 0 iff every check passes (check 5 XFAILs rather than passing); exits
+non-zero (with a PASS/FAIL line per check) on the first structural failure,
+any assertion failure, or check 5 unexpectedly passing (XPASS, #2972 fixed
+but this probe not yet promoted to a strict assertion). Cleans up the temp
+wheel directory and venv in a ``finally`` block, on success or failure
+alike.
 """
 from __future__ import annotations
 
@@ -106,6 +125,52 @@ def _check_wheel_config_completeness(wheel_path: Path) -> list[str]:
     return failures
 
 
+def _check_ambient_python3_shellout(repo_root: Path, tmp_root: Path) -> tuple[bool, str]:
+    """#2972 mode-2 probe: reproduce the builtin RAG ingest pipeline's
+    ambient-``python3`` shell-out EXACTLY as ``sandboxed_exec`` performs it —
+    resolving ``python3`` from ``PATH`` (never ``sys.executable``, never a
+    venv path baked into the command line) — inside a PATH shaped like a
+    ``pipx install reyn`` environment.
+
+    A clean venv WITHOUT reyn installed (``with_pip=False`` — no wheel, no
+    ``-e``, nothing) is built and ONLY its ``bin/`` dir is prepended to
+    ``PATH``, so a bare ``python3`` command resolves to an interpreter that
+    cannot import reyn — manufacturing the "ambient python3 differs from
+    reyn's own interpreter" condition deterministically, on any platform or
+    dev box, regardless of what the CALLING process's own ambient ``python3``
+    happens to be (which is why every OTHER check in this file — running the
+    wheel through ``venv_python`` / ``sys.executable`` — structurally cannot
+    witness this bug; see the module docstring).
+
+    Returns ``(ok, detail)`` — ``ok`` is whether the shell-out succeeded
+    (expected ``False`` until #2972 is fixed); ``detail`` is the last
+    stderr/stdout line for a decision-enabling failure message.
+    """
+    clean_venv = tmp_root / "venv-no-reyn"
+    venv.EnvBuilder(with_pip=False, clear=True).create(str(clean_venv))
+    clean_bin = clean_venv / "bin"
+    if not clean_bin.exists():  # pragma: no cover - Windows layout
+        clean_bin = clean_venv / "Scripts"
+
+    env = dict(os.environ)
+    env["PATH"] = f"{clean_bin}{os.pathsep}{env.get('PATH', '')}"
+    # No PYTHONPATH -- a dev-tree leak here would false-pass the exact thing
+    # this check exists to catch.
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        ["python3", "-m", "reyn.builtin.rag_ingest_helpers", "probe"],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    ok = result.returncode == 0
+    tail = (result.stderr or result.stdout or "").strip().splitlines()
+    detail = tail[-1] if tail else f"exit {result.returncode}"
+    return ok, detail
+
+
 def main() -> int:
     tmp_dir = Path(tempfile.mkdtemp(prefix="reyn-wheel-smoke-"))
     wheel_dir = tmp_dir / "dist"
@@ -167,6 +232,24 @@ def main() -> int:
         if result.returncode != 0:
             print(f"[FAIL] wheel reachability parity gate FAILED (exit {result.returncode})")
             return 1
+
+        # 7. #2972 mode-2 probe (XFAIL until fixed) -- see module docstring
+        # check 5 and _check_ambient_python3_shellout's docstring for why
+        # THIS is the one check in the file that can witness the regression.
+        mode2_ok, mode2_detail = _check_ambient_python3_shellout(REPO_ROOT, tmp_dir)
+        if mode2_ok:
+            print(
+                "[FAIL] XPASS (unexpected): ambient-python3 builtin shell-out "
+                "now succeeds -- #2972 appears fixed. Promote this probe from "
+                "XFAIL to a strict assertion (drop the XFAIL wrap in "
+                "_check_ambient_python3_shellout's caller) in the SAME PR that "
+                f"closes #2972, so this gate does not go silently stale. detail: {mode2_detail}"
+            )
+            return 1
+        print(
+            "[XFAIL] #2972 ambient-python3 builtin shell-out (tracked, expected "
+            f"until fixed): {mode2_detail}"
+        )
 
         print("[PASS] wheel reachability parity gate: all checks green")
         return 0


### PR DESCRIPTION
**[per-PR-coder]** — part of #2972

## What

Adds the mode-2 gate probe #2972 asked for: `scripts/wheel_reachability_smoke.py` (the CI job *"dev==wheel repo self-access parity (0061 §3.4)"*, `.github/workflows/wheel-reachability.yml`) now also reproduces the builtin RAG ingest pipeline's ambient-`python3` shell-out in the one environment that can structurally witness it.

## Why this is the right place (and why a normal pytest job can't do it)

`src/reyn/builtin/pipelines/rag_ingest.yaml` shells out to `python3 -m reyn.builtin.rag_ingest_helpers` via `sandboxed_exec`, which forwards the ambient `PATH` through unmodified (`sandboxed_exec.py`'s `os.environ.get("PATH")`). This only works when `python3` on PATH happens to be reyn's own interpreter — false under `pipx install reyn`, a non-activated venv, or any environment with a different `python3` on PATH.

A normal pytest job's ambient `python3` trivially **is** the job's own (reyn-having) interpreter, so "ambient python3 == reyn's interpreter" can never be falsified there — CI green is not evidence for this assumption. The `wheel_reachability_smoke.py` gate is the one place in the repo that already builds a real wheel, installs it into a throwaway venv with `no -e, no dev checkout`, and calls `<venv>/bin/python` explicitly (never letting the venv onto `PATH`) — so it's the natural place to add a check that resolves a **bare** `python3` from PATH and observes what actually happens.

## What the new check does

`_check_ambient_python3_shellout` (in `scripts/wheel_reachability_smoke.py`):

1. Builds a second, clean, throwaway venv **without** reyn installed (`venv.EnvBuilder(with_pip=False)` — no wheel, no `-e`, nothing).
2. Prepends only that venv's `bin/` to `PATH` (mirroring `pipx install reyn`'s "reyn's own venv is isolated; the ambient `python3` on the user's PATH is a different interpreter" shape) — deterministic on any platform/dev box, independent of what the *calling* process's own ambient `python3` happens to be.
3. Runs the LITERAL production command — `python3 -m reyn.builtin.rag_ingest_helpers probe` — resolved from that PATH, never `sys.executable`, never a venv path baked into the command line (that would defeat the whole point).

**This currently fails** (`ModuleNotFoundError: No module named 'reyn'`), reproducing the exact #2972 production failure. Verified locally:

```
[XFAIL] #2972 ambient-python3 builtin shell-out (tracked, expected until fixed): .../venv-no-reyn/bin/python3: Error while finding module specification for 'reyn.builtin.rag_ingest_helpers' (ModuleNotFoundError: No module named 'reyn')
[PASS] wheel reachability parity gate: all checks green
```

## Decision: XFAIL, not a hard fail (per the issue's judgment call)

Making this a hard failure would red the gate on every PR until #2972's actual fix (which needs a core/DSL decision per the issue — in-process op vs. typed `python:` step) lands, and this PR does not attempt that fix (scope: gate only, per the issue's explicit guidance against expanding scope here).

I found no existing xfail/expected-failure convention elsewhere in this repo's gate scripts (`scripts/*.py`) or pytest config to reuse, so this introduces a minimal, self-contained one scoped to this single check:

- On failure (expected): prints `[XFAIL] ...` and the gate still exits 0.
- On unexpected success (**XPASS**): prints `[FAIL] XPASS (unexpected): ...` and the gate exits 1 — forcing whoever lands the #2972 fix to come back to this file and promote the probe from XFAIL to a strict assertion in the *same* PR, so the gate doesn't quietly stay lenient forever. This mirrors `pytest`'s `xfail(strict=True)` idiom even though this script isn't pytest-driven.

## Mode-3 package-data audit (per the issue's second ask)

Built the wheel and inspected its actual contents (not guessed):

- `dogfood/` (the top-level repo directory, `dogfood/fixtures/**` etc.) is **NOT** package data and **NOT** in the wheel — confirmed: `grep`ing the built wheel's namelist for `dogfood/fixtures` returns nothing. (`reyn/dev/dogfood/*.py` — the unrelated in-package dev-tooling module — IS present, as expected; that's a different `dogfood`.)
- Every asset the builtin RAG pipeline references (`reyn.builtin.rag_ingest_helpers`, `rag_ingest.yaml`, and all of `BUILTIN_SKILLS`/`BUILTIN_PIPELINES` in `src/reyn/builtin/registry.py`) lives under `src/reyn/builtin/**`, which IS covered by the existing `pyproject.toml` `[tool.hatch.build.targets.wheel]` `artifacts` glob (`"src/reyn/builtin/**/*"`) and IS present in the wheel — confirmed by extracting the built wheel's namelist (`reyn/builtin/rag_ingest_helpers.py`, `reyn/builtin/pipelines/rag_ingest.yaml` both present).
- **Finding: no missing wheel asset.** The builtin RAG ingest surface does not reference anything under `dogfood/`; the "bundled fixture vs. repo fixture" confusion the issue flagged as a *possibility* does not exist in the current builtin RAG code. Not fixing anything here since there was nothing to fix.

## Test plan

- [x] `ruff check src tests scripts/wheel_reachability_smoke.py` — clean.
- [x] `python scripts/verify_module_docstrings.py scripts/wheel_reachability_smoke.py` — OK.
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — N/A, no test files changed.
- [x] `pytest` (repo root) — green (ran full suite locally before opening this PR).
- [x] `python scripts/wheel_reachability_smoke.py` run directly — all real checks PASS, new check correctly XFAILs with `ModuleNotFoundError`, gate exits 0.
- [x] Manually flipped the new check's PATH to include reyn (simulating a fix) to confirm the XPASS branch actually fires and fails the gate (exit 1) — verified via the `_check_ambient_python3_shellout` logic path.
