### PR TITLE
fix: token_counter_fallback warning misfires on valid count==0 (#2961)

### DIFF
--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -134,7 +134,13 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
     """Estimate tokens for a text string.
 
     Axis 10: uses litellm.token_counter by default; falls back to chars//4
-    on error and emits ``token_counter_fallback`` once per process.
+    only when litellm.token_counter itself raises (a genuine failure), and
+    emits ``token_counter_fallback`` the first time that happens in this
+    process (subsequent calls retry litellm.token_counter as normal — the
+    warning is a warn-once notice, not a record of a permanent fallback).
+
+    ``count == 0`` (e.g. estimating an empty string) is a valid litellm
+    result, not a failure, and does NOT trigger the fallback path (#2961).
 
     Results are cached per (model, text-hash) for the process's lifetime,
     bounded by an LRU eviction policy (see ``_token_cache`` docstring above).
@@ -157,17 +163,24 @@ def estimate_tokens(text: str, model: str, *, use_chars4: bool = False) -> int:
         import litellm
         m = model or "gpt-3.5-turbo"
         count = litellm.token_counter(model=m, text=text or "")
-        if count and count > 0:
+        # #2961: litellm.token_counter returns 0 (not an exception) for an
+        # empty string — that is the correct answer, not a failure. Only a
+        # raised exception (the `except` below) is a genuine tokenizer
+        # failure that should fall back to chars//4.
+        if count is not None and count >= 0:
             _token_cache_put(cache_key, count)
             return count
     except Exception:
         pass
-    # Fallback path.
+    # Fallback path — reached only when litellm.token_counter raised (or, in
+    # principle, returned something other than a non-negative int).
     if not _token_counter_fallback_warned:
         _token_counter_fallback_warned = True
         logger.warning(
             "litellm.token_counter failed for model=%r; "
-            "falling back to chars//4 for this process",
+            "using chars//4 for this call. This is a warn-once notice, not "
+            "a record of a permanent fallback: every subsequent call to "
+            "estimate_tokens() retries litellm.token_counter normally.",
             model,
         )
     result = max(1, len(text or "") // 4)

--- a/tests/test_2961_token_counter_fallback_false_positive.py
+++ b/tests/test_2961_token_counter_fallback_false_positive.py
@@ -1,0 +1,104 @@
+"""Tier 2: estimate_tokens() must not misreport a valid ``count == 0`` litellm
+result as a tokenizer failure.
+
+THE BUG (#2961): ``litellm.token_counter(model=..., text="")`` returns ``0``
+— it does NOT raise. ``engine.py``'s old guard, ``if count and count > 0:``,
+treats a falsy ``0`` the same as a raised exception, so estimating an empty
+string alone was enough to fire the ``token_counter_fallback`` warning even
+though the tokenizer never failed. The warning's wording compounded this:
+"falling back to chars//4 for this process" implied a permanent, process-wide
+switch, but ``_token_counter_fallback_warned`` is only a warn-once log latch
+— every subsequent ``estimate_tokens()`` call still retries
+``litellm.token_counter`` normally. A reviewer who saw the warning fire
+concluded (wrongly) that their entire measurement session had silently
+degraded to chars//4, and retracted correct BPE-based findings as a result.
+
+THE FIX: only a raised exception from ``litellm.token_counter`` (the
+`except Exception` branch, unchanged) reaches the chars//4 fallback path now;
+a returned ``count >= 0`` is treated as success and cached directly, and the
+warning text no longer claims a process-wide fallback.
+
+These tests exercise the REAL litellm.token_counter (no ``unittest.mock``) —
+this environment's litellm is live and offline-capable via its local
+tokenizer, per testing.ja.md's Mock-vs-Fake rule.
+"""
+from __future__ import annotations
+
+import logging
+
+import litellm
+import pytest
+
+from reyn.services.compaction import engine as engine_mod
+from reyn.services.compaction.engine import estimate_tokens
+
+
+@pytest.fixture(autouse=True)
+def _clean_token_state():
+    """Tier 2 hygiene: both the token-estimate cache and the warn-once latch
+    are module-globals shared across the whole test process. Reset them for
+    isolation (setup/teardown, not an assertion — testing.ja.md's Tier-4 ban
+    is on *asserting* private state, not on resetting it between tests; the
+    same pattern used by test_compaction_token_cache_incremental.py)."""
+    engine_mod._token_cache.clear()
+    engine_mod._token_counter_fallback_warned = False
+    yield
+    engine_mod._token_cache.clear()
+    engine_mod._token_counter_fallback_warned = False
+
+
+def test_empty_string_estimate_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """Tier 2: estimating an empty string must NOT fire token_counter_fallback.
+
+    Pins the bug's exact trigger: litellm.token_counter("") returns 0 (a
+    valid answer), not an exception, so it must not be treated as a failure.
+    """
+    with caplog.at_level(logging.WARNING, logger=engine_mod.logger.name):
+        estimate_tokens("", "gpt-4o")
+
+    fallback_warnings = [
+        r for r in caplog.records if "token_counter" in r.getMessage()
+    ]
+    assert fallback_warnings == [], (
+        f"estimate_tokens('') must not warn about a token_counter failure "
+        f"(count==0 is a valid result, not a failure); got: {fallback_warnings}"
+    )
+
+
+def test_empty_string_estimate_matches_real_litellm_count() -> None:
+    """Tier 2: estimate_tokens("") returns litellm's real answer, not the
+    chars//4 fallback's forced minimum of 1.
+
+    Independent oracle: call litellm.token_counter directly and compare —
+    this is exactly the same call estimate_tokens() makes internally, so a
+    match here proves the BPE path (not the fallback path) produced the
+    result.
+    """
+    expected = litellm.token_counter(model="gpt-4o", text="")
+    result = estimate_tokens("", "gpt-4o")
+    assert result == expected, (
+        f"estimate_tokens('') should equal litellm.token_counter's own "
+        f"answer ({expected}), not silently swap in the chars//4 fallback "
+        f"value; got {result}"
+    )
+    # Document the currently-measured real value so a future litellm/tokenizer
+    # change that flips this away from 0 is visible rather than silently
+    # accepted (the chars//4 fallback's forced max(1, ...) would have made
+    # this 1; the real tokenizer's answer for an empty string is 0).
+    assert result == 0
+
+
+def test_nonempty_estimate_still_succeeds_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Tier 2: a normal non-empty estimate is unaffected by the fix — still
+    uses the real tokenizer, still no spurious warning.
+    """
+    with caplog.at_level(logging.WARNING, logger=engine_mod.logger.name):
+        result = estimate_tokens("hello world", "gpt-4o")
+
+    assert result > 0
+    fallback_warnings = [
+        r for r in caplog.records if "token_counter" in r.getMessage()
+    ]
+    assert fallback_warnings == []


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2961

## Root cause (verified by reading the code, not inferred)

`estimate_tokens()` in `src/reyn/services/compaction/engine.py` had two
independent false claims in its fallback path:

1. **Firing condition**: `if count and count > 0:` treats `litellm.token_counter`'s
   return value of `0` (the correct, non-exceptional answer for an empty
   string) the same as a raised exception. Estimating a single empty string
   was enough to trigger the `token_counter_fallback` warning — the tokenizer
   never failed.
2. **Wording**: `"falling back to chars//4 for this process"` implies a
   permanent, process-wide switch. But `_token_counter_fallback_warned` is
   only a warn-once *log* latch — every subsequent call still retries
   `litellm.token_counter` normally. Verified by reading the code: the
   `except Exception: pass` branch (genuine failures) is untouched by this
   fix and still routes to the same fallback path as before.

## Fix

- `if count is not None and count >= 0:` accepts a real `0` as success and
  returns/caches it directly — only a **raised exception** now reaches the
  chars//4 fallback.
- Warning text now says "using chars//4 for this call" instead of "for this
  process," and adds an explicit note that this is a warn-once log notice,
  not a permanent switch.

## Design note on `_token_counter_fallback_warned` (per issue ask — proposal only, not implemented here)

The warn-once boolean latch itself is a reasonable anti-log-spam mechanism
(the same pattern exists elsewhere in the codebase: `model_budget._warned_models`,
`router_loop._warned`, `budget.Budget._warned`). The problem #2961 surfaced
wasn't the latch — it was that firing **once** reads to a human as "this
switched permanently," which the old wording actively reinforced.

Given the fix above (accurate firing condition + accurate wording), I'd
recommend **keeping the boolean latch as-is** rather than redesigning it in
this PR, for two reasons:
- A real exception from `litellm.token_counter` on a valid non-empty string
  is a genuinely rare path in practice (I could not reproduce one through
  the public API even with a nonsense model name — litellm's own tokenizer
  fallback swallows unknown models internally); log-spam risk from raising
  the bar here is low.
- Turning this into an audit-event (Observability lens) is more invasive
  than the bug warrants: it would be the first audit-event emitted from a
  pure token-estimation helper with no state-changing observable effect an
  operator needs `reyn events` for.

If a future occurrence shows fallback exceptions recurring often enough to
want a summary rather than a single log line, the incremental next step
would be to swap the boolean for a per-model counter (`_token_counter_fallback_counts: dict[str, int]`)
and log a periodic/final summary ("chars//4 fallback used N times for model
X this process") rather than the current one-shot message — that keeps it a
log concern, not an audit-event concern, while making "this happened
repeatedly" directly visible instead of implied by a boolean.

## Test plan

- [x] `test_empty_string_estimate_does_not_warn` — estimating `""` fires no
  `token_counter_fallback` warning. Falsified against pre-fix code: **fails**
  (warning fires) before the fix, **passes** after.
- [x] `test_empty_string_estimate_matches_real_litellm_count` — `estimate_tokens("", "gpt-4o")`
  equals `litellm.token_counter(model="gpt-4o", text="")` directly (both `0`
  in this environment), not the chars//4 fallback's forced `max(1, 0)`.
  Falsified against pre-fix code: **fails** before the fix.
- [x] `test_nonempty_estimate_still_succeeds_without_warning` — non-empty
  estimate unaffected by the fix, still no spurious warning.
- [x] `ruff check src tests` — all checks passed.
- [x] `python scripts/test_tier_audit.py --strict tests/test_2961_token_counter_fallback_false_positive.py` — 3/3 OK, 0 Tier-4 violations.
- [x] `pytest` (repo root) — 8577 passed, 17 skipped (pre-existing, unrelated).
- [x] `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py` — OK.

Tests exercise the real `litellm.token_counter` (no `unittest.mock`), per
testing.ja.md's Mock-vs-Fake rule — this environment's litellm is live and
offline-capable via its local tokenizer.