### PR TITLE
docs: fix dangerous sandbox.policy example + wrong read_deny_paths default (#2978)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ Three lenses name a *discipline* whose *universal mechanism* is a band member: *
 
 ## Hard rules
 
-- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `Op` union derives from the same map). New op kinds get a section in the reference in the same PR.
+- **A doc describing a mechanism is stale the moment that mechanism's code changes — fix the doc in the SAME PR, not a follow-up.** This is broader than adding a new enum-like variant: a doc goes stale just as easily by describing a *field*, a *call path*, or a *"when wired" claim* that the PR removes or falsifies. (#2949→#2958: `control-ir.md:805` kept asserting a recording path through a field that #2958 deleted — survived because the reviewing pass grepped the doc for the one keyword it expected, not the surrounding prose describing what the PR touched.) When a PR changes something a doc describes, re-read the whole section the change touches, not just the line whose keyword you already had in mind.
+- **`docs/reference/runtime/control-ir.md` must stay synced with `OP_KIND_MODEL_MAP`** in `src/reyn/schemas/models.py` (#1983: relocated there from `op_runtime/registry.py` so the `Op` union derives from the same map) — the sharpest, CI-checked instance of the rule above, not the whole of it. New op kinds get a section in the reference in the same PR.
 - **Recovery-feature PR gate**: any PR adding recovery / reconstruction functionality (WAL-event-derived state, PITR, rewind/restore paths) MUST include a truncate-falsify test verifying the reconstruction source survives WAL truncation below its source events (set X → truncate past X's events → reconstruct → assert X survives). WAL-event-derived recovery state that isn't snapshot-backed is a silent data-loss vector. Same PR, not a follow-up. (Motivated by #2259/#2260.)
 
 ## Testing policy (READ BEFORE WRITING TESTS)
@@ -134,6 +135,13 @@ Three rules then keep multi-session work coherent:
    **Reviewer recovery angle:** an unexpected issue auto-close triggered by a
    sub-PR merge is almost always a closing-keyword false positive. Reopen the
    issue and verify the arc is not half-done before assuming completion.
+5. **No blanket en/ja mirror obligation.** JA docs are a curated, intentionally
+   partial subset (614 EN files vs 125 JA, repo-wide) — a PR is not required to
+   touch a `.ja.md` file just because an EN sibling exists or just changed. Do
+   fix a `.ja.md` file's own claims if the PR falsifies something it currently
+   asserts (same reasoning as any other doc-drift fix, not a mirror rule); do
+   not invent a "keep en/ja pairs in sync" obligation when scoping a PR. Known
+   ja-parity gaps are tracked in #2967 as backlog, not a per-PR gate.
 
 ## Pre-conclusion observation checklist (READ BEFORE WRITING ANY FINDING / 結論)
 

--- a/docs/reference/config/reyn-yaml.ja.md
+++ b/docs/reference/config/reyn-yaml.ja.md
@@ -320,11 +320,18 @@ sandbox:
   policy:                # オプション — agent-level（オペレータ）サンドボックスポリシー
     network: true
     read_paths: ["/"]
-    write_paths: ["/"]
+    write_paths: ["{{workspace}}", "/tmp"]
     allow_subprocess: true
     env_passthrough: ["PATH", "HOME"]
     timeout_seconds: 600
 ```
+
+> ⚠️ **`write_paths` に `~`、`$HOME`、`/` を入れないこと。** Seatbelt バックエンドでは各
+> `write_paths` エントリが `read_deny_paths` の deny ルールの**後に** allow-read ルールを
+> emit し、SBPL は last-match-wins のため、`read_deny_paths` のエントリと重なる（またはそれを
+> 包含する）`write_paths` エントリは**そのdenyを無言で無効化**し、credential パスの多層防御
+> （`~/.ssh`・`~/.aws`・`~/.gnupg` 等 — 下記 `read_deny_paths` 参照）を警告なしに崩します。
+> `write_paths` はプロセスが実際に永続化する必要がある最小限のディレクトリに絞ってください。
 
 | キー | 型 | デフォルト | 説明 |
 |-----|------|---------|-------------|
@@ -340,7 +347,7 @@ sandbox:
 |-----|------|---------|-------------|
 | `network` | bool | `false` | サンドボックスプロセスからの外向きネットワークを許可。主要な外部流出ゲート。 |
 | `write_paths` | list[文字列] | `[]` | プロセスが書き込み可能なパス（厳密なガード）。書き込みは読み取りを含む。 |
-| `read_deny_paths` | list[文字列] | `[]` | 広読み込みサーフェスから拒否する機密パス（多層防御）。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。許可リストのみのバックエンド（Landlock）では非対応。 |
+| `read_deny_paths` | list[文字列] | `~/.ssh`・`~/.aws`・`~/.gnupg`・`~/.config/gcloud`・`~/.kube`・`~/.docker/config.json`・`~/.netrc` | 広読み込みサーフェスから拒否する機密パス（多層防御）— `sandbox.policy` 明示ブロックでこのキーを省略した場合、空リストではなくこの7つの OS レベル credential パス（`SandboxPolicy.read_deny_paths` の dataclass デフォルト）がデフォルトになります。deny-after-allow をサポートするバックエンド（Seatbelt）のみ適用。許可リストのみのバックエンド（Landlock）では非対応。**`write_paths` のエントリをこれらと重ねない・包含させないこと** — 上記警告の通り Seatbelt 上で無言で無効化されます。 |
 | `read_paths` | list[文字列] | `[]` | **レガシー。** かつての厳密な読み込み許可リスト。現在のスコーピングモデルでは読み込みはデフォルトで広許可のため、このフィールドは意図した読み込み対象のドキュメントとしてのみ機能します。 |
 | `allow_subprocess` | bool | `false` | 子プロセスの spawn を許可するか。適用（enforced）— off の時 `process-fork` を deny。 |
 | `env_passthrough` | list[文字列] | `[]` | サンドボックスプロセスへ通過させる環境変数名。`PATH` は常に通過します。 |

--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -746,11 +746,19 @@ sandbox:
   policy:                # optional — the agent-level (operator) sandbox policy
     network: true
     read_paths: ["/"]
-    write_paths: ["/"]
+    write_paths: ["{{workspace}}", "/tmp"]
     allow_subprocess: true
     env_passthrough: ["PATH", "HOME"]
     timeout_seconds: 600
 ```
+
+> ⚠️ **Never put `~`, `$HOME`, or `/` in `write_paths`.** On the Seatbelt backend, each
+> `write_paths` entry emits an *allow-read* rule for that path **after** the
+> `read_deny_paths` deny rules, and SBPL is last-match-wins — so a `write_paths` entry
+> that is a superset of (or overlaps) a `read_deny_paths` entry **silently nullifies
+> that deny**, defeating the credential-path defense-in-depth (`~/.ssh`, `~/.aws`,
+> `~/.gnupg`, etc. — see `read_deny_paths` below) with no warning. Scope `write_paths`
+> to the narrowest directories the process actually needs to persist to.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
@@ -766,7 +774,7 @@ When `sandbox.policy` is present, these mirror the `SandboxPolicy` fields. Unkno
 |-----|------|---------|-------------|
 | `network` | bool | `false` | Allow outbound network from the sandboxed process. The primary exfiltration gate. |
 | `write_paths` | list[string] | `[]` | Filesystem paths the process may write (tight guard). Write implies read for these paths. |
-| `read_deny_paths` | list[string] | `[]` | Sensitive paths to DENY from the broad read surface (defense-in-depth). Enforced only on backends that support deny-after-allow rules (Seatbelt); not enforceable on allowlist-only backends (Landlock). |
+| `read_deny_paths` | list[string] | `~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker/config.json`, `~/.netrc` | Sensitive paths to DENY from the broad read surface (defense-in-depth) — defaults to these 7 OS-level credential locations when omitted from an explicit `sandbox.policy` block (`SandboxPolicy.read_deny_paths`'s dataclass default), NOT an empty list. Enforced only on backends that support deny-after-allow rules (Seatbelt); not enforceable on allowlist-only backends (Landlock). **Do not let a `write_paths` entry overlap or be a superset of any of these** — see the warning above `write_paths` silently defeats them on Seatbelt. |
 | `read_paths` | list[string] | `[]` | **Legacy.** Formerly the strict read allowlist. Reads are broad by default under the current scoping model; this field now documents intended read targets only. |
 | `allow_subprocess` | bool | `false` | Whether the process may spawn children. Enforced — denies `process-fork` when off. |
 | `env_passthrough` | list[string] | `[]` | Env-var names that pass through to the sandboxed process. `PATH` is always passed through. |


### PR DESCRIPTION
**[docs-maintainer]** — Fixes the doc-side half of #2978 (per-PR-coder's measured finding via lead-coder). Design decision on the underlying seatbelt.py rule-ordering (reject/reorder/warn) is owner's call, tracked separately in #2978 — this PR only fixes the doc, which needs the fix under any of those options.

## What was wrong

`reyn-yaml.md`/`.ja.md`'s `sandbox.policy` example recommended `write_paths: ["/"]`. Measured (per-PR-coder, #2978): on the Seatbelt backend, `write_paths` entries emit an allow-read rule **after** `read_deny_paths`'s deny rules, and SBPL is last-match-wins — so `write_paths: ["/"]` (or any entry overlapping/superset of a deny path) silently nullifies all 7 default credential-path denies (`~/.ssh`, `~/.aws`, `~/.gnupg`, `~/.config/gcloud`, `~/.kube`, `~/.docker/config.json`, `~/.netrc`). An operator who copied the doc's own recommended example verbatim would lose that protection with no warning.

**Also found while fixing this**: `read_deny_paths`'s documented default was wrong — table said `[]`, but `SandboxPolicy.read_deny_paths`'s dataclass `default_factory` is the 7-path `DEFAULT_SENSITIVE_READ_DENY` list (`policy.py:68-70`), which applies whenever an explicit `sandbox.policy` block omits the key (`SandboxPolicy(**ctx.default_sandbox_policy)` at `context.py:356` / `sandboxed_exec.py:62` — a partial operator dict falls through to the dataclass default for any omitted field).

## What changed

- Example `write_paths` → `["{{workspace}}", "/tmp"]`, matching the already-correct idiom in `docs/guide/for-users/configure-sandbox.md` / `docs/concepts/runtime/sandbox.md` (this file was the one outlier).
- Added an explicit `write_paths`/`read_deny_paths` interaction warning callout, EN + JA.
- Fixed the `read_deny_paths` default-value cell to the real 7-path default.
- JA fixed too — its own claim was independently false (same dangerous example, same wrong default), not because of a mirror obligation (per CLAUDE.md item 5, #2977).

## Verification

- Traced the actual construction path: `resolve_sandbox_policy` (`policy.py:86-104`) → `ctx.default_sandbox_policy` (dict) → `SandboxPolicy(**dict)` at both call sites (`context.py:356`, `sandboxed_exec.py:62`) — confirmed a partial operator dict omitting `read_deny_paths` really does fall through to the dataclass default, not an empty list.
- Cross-checked the fixed example against 3 other docs that already had it right (`configure-sandbox.md`/`.ja.md`, `sandbox.md`) — now consistent across all four.

## Test plan

- [x] Doc-only change — no code/test files touched, the four CI gates don't apply.
- [x] Verified markdown table structure intact (`read_deny_paths` row count unchanged, 4 hits each in EN/JA as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)