### PR TITLE
fix: list_mcp_servers/list_mcp_tools reported 0 to the LLM while conversation showed the real count

### DIFF
--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3770,6 +3770,17 @@ class RouterLoop:
         found nothing, reporting "0" to the LLM while the raw list still
         displayed correctly (as "N items") in the conversation transcript.
         Returning the dict unchanged lets both consumers read the same shape.
+
+        The former ``describe_mcp_tool`` branch was ALSO removed in the same
+        change, but for an unrelated reason (consolidation, not the bug
+        above): it was ``if name == "describe_mcp_tool": return result`` —
+        byte-identical to this function's own unconditional fallthrough
+        (``return result`` at the end), i.e. a documented no-op. Deleting it
+        changes zero behavior; kept only as a comment here so a future reader
+        diffing this docstring against the code doesn't mistake its absence
+        for an accidental drop (co-vet finding, lead-coder — this file's own
+        docstring is exactly what should have named all three removed
+        branches the first time).
         """
         import json
         if name == "read_file":

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3757,6 +3757,19 @@ class RouterLoop:
         ``content`` / ``entries`` before returning so the LLM saw a
         bare string / list. This helper applies the same extraction so
         registry dispatch is LLM-visible-identical to the prior path.
+
+        ``list_mcp_servers`` / ``list_mcp_tools`` deliberately do NOT get this
+        treatment (removed — owner-reported bug): unwrapping their
+        ``{"servers": [...]}`` / ``{"mcp_tools": [...]}`` dict down to a bare
+        list here defeated the canonicalization mappers (``list_mcp_servers_
+        to_canonical`` / ``list_mcp_tools_to_canonical``, ``canonical.py``),
+        which expect that dict key to still be present when ``to_canonical``
+        runs — ``dispatch_tool``'s envelope wraps whatever this returns, and
+        ``unwrap_dispatch_envelope`` only peels a ``dict``-shaped ``data``, so
+        a bare list stayed wrapped and the mapper's ``result.get("servers")``
+        found nothing, reporting "0" to the LLM while the raw list still
+        displayed correctly (as "N items") in the conversation transcript.
+        Returning the dict unchanged lets both consumers read the same shape.
         """
         import json
         if name == "read_file":
@@ -3768,23 +3781,6 @@ class RouterLoop:
         if name == "list_directory":
             if isinstance(result, dict):
                 return result.get("entries", [result])
-            return result
-        if name == "list_mcp_servers":
-            if isinstance(result, dict) and "servers" in result:
-                return result["servers"]
-            return result
-        if name == "list_mcp_tools":
-            # FP-0032: key renamed from "tools" to "mcp_tools"; handle both
-            # for backward-compat during transition.
-            if isinstance(result, dict):
-                if "mcp_tools" in result:
-                    return result["mcp_tools"]
-                if "tools" in result:
-                    return result["tools"]
-            return result
-        if name == "describe_mcp_tool":
-            # Return the full dict (= {name, description, input_schema}).
-            # No unwrapping needed — the LLM sees it as structured data.
             return result
         return result
 

--- a/tests/test_list_mcp_servers_canonical_shape.py
+++ b/tests/test_list_mcp_servers_canonical_shape.py
@@ -1,0 +1,113 @@
+"""Tier 2: owner-reported bug — list_mcp_servers/list_mcp_tools reported "0" to the
+LLM while the conversation transcript correctly showed the real count.
+
+Root cause: ``RouterLoop._normalise_router_tool_result`` (router_loop.py) unwrapped
+the handler's ``{"servers": [...]}`` / ``{"mcp_tools": [...]}`` dict down to a bare
+list — a legacy "LLM-visible-identical to the pre-registry-dispatch path" shim that
+predates the canonicalization system. ``dispatch_tool``'s envelope then wrapped a
+bare list as ``data``; ``unwrap_dispatch_envelope`` only peels a dict-shaped
+``data``, so it stayed wrapped, and ``list_mcp_servers_to_canonical``'s
+``result.get("servers")`` found nothing — reporting "0 MCP servers." to the LLM,
+while the conversation's raw-dict summary (which tolerates a bare list, showing
+"N items") displayed the real count. Restart-invariant: a pure shape bug, not state.
+
+Verified end-to-end (real Session, real event bus, real ChatLifecycleForwarder,
+real RouterLoop, real dispatch_tool — not hand-built envelope data) before writing
+this fix, per the owner's explicit push to confirm the two "sources" (conversation
+display vs LLM-facing text) actually derive from the literal same call.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+from pathlib import Path
+
+from reyn.config.loader import load_config
+from reyn.core.dispatch.dispatcher import DispatchContext, dispatch_tool
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
+from reyn.runtime.router_loop import RouterLoop
+from reyn.runtime.session import Session
+from reyn.tools import get_default_registry
+from reyn.tools.scheme import ExecutionResult
+
+
+def _session(tmp_path: Path) -> Session:
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    (tmp_path / "reyn.local.yaml").write_text(
+        "mcp:\n  servers:\n"
+        "    s1:\n      command: /usr/bin/true\n      description: server 1\n"
+        "    s2:\n      command: /usr/bin/true\n      description: server 2\n",
+        encoding="utf-8",
+    )
+    config = load_config(cwd=tmp_path)
+    return Session(
+        agent_name="alice",
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        mcp_servers=config.mcp,
+    )
+
+
+def test_end_to_end_list_mcp_servers_matches_conversation_and_llm_text(tmp_path) -> None:
+    """Tier 2: falsifying, end-to-end — real Session, real event bus, real
+    ChatLifecycleForwarder (conversation display source), real RouterLoop.feedback
+    (LLM-facing text source), fed by ONE real dispatch_tool() call (not hand-built
+    envelope data). Both consumers must report the SAME server count.
+
+    Pre-fix: the conversation showed "2 items" (or similar bare-list rendering)
+    while the LLM-facing text showed "0 MCP servers." — this test's assertions on
+    the LLM text would fail against the pre-fix code."""
+    get_default_registry()
+    session = _session(tmp_path)
+
+    outbox = session.outbox
+    forwarder = ChatLifecycleForwarder(outbox)
+    session._chat_events.add_subscriber(forwarder)
+
+    loop = RouterLoop(host=session._router_host, chain_id="c1", router_model="gpt-4o")
+    catalog = {"list_mcp_servers": {"function": {"name": "list_mcp_servers", "parameters": {}}}}
+    ctx = DispatchContext(
+        caller_kind="router", caller_id="alice", chain_id="c1",
+        tool_catalog=catalog, events=session._chat_events,
+    )
+
+    async def _dispatch():
+        return await dispatch_tool(
+            name="list_mcp_servers", args={}, ctx=ctx,
+            invoker=functools.partial(loop._invoke_router_tool, "list_mcp_servers"),
+        )
+
+    dispatch_return = asyncio.run(_dispatch())
+
+    completed = []
+    while not outbox.empty():
+        msg = outbox.get_nowait()
+        if msg.kind == "tool_call_completed":
+            completed.append(msg)
+    assert completed, "expected a tool_call_completed outbox message"
+    conversation_result = completed[-1].meta.get("result")
+    conversation_servers = (
+        conversation_result.get("servers")
+        if isinstance(conversation_result, dict)
+        else conversation_result
+    )
+    conversation_names = {s["name"] for s in (conversation_servers or [])}
+    assert conversation_names == {"s1", "s2"}, (
+        f"conversation display must show both configured servers, got: {conversation_result}"
+    )
+
+    dispatch_return.setdefault("_canonical_source", "list_mcp_servers")
+    exec_result = ExecutionResult(
+        tool_results=[dispatch_return],
+        tool_calls=[{"id": "call_1", "type": "function", "function": {"name": "list_mcp_servers"}}],
+        assistant_content="",
+    )
+    llm_messages = loop.feedback(exec_result)
+    tool_message = next(m for m in llm_messages if m["role"] == "tool")
+
+    assert "2 MCP servers" in tool_message["content"], (
+        f"LLM-facing text must report the real server count, not 0 — got: "
+        f"{tool_message['content']!r}"
+    )
+    assert "0 MCP servers" not in tool_message["content"]


### PR DESCRIPTION
**[tui-coder]** — closes #2984 (owner-reported)

## Bug

Owner's `reyn chat` (MCP servers in `reyn.local.yaml`, restart-invariant): the conversation transcript's `⎿` row for a `list_mcp_servers` call correctly showed the real server count ("N items"), but the SAME call's text reaching the LLM was `structured: [] --- 0 MCP servers.` — confirmed byte-identical to what the owner pasted.

## Root cause

`RouterLoop._normalise_router_tool_result` (`router_loop.py`) had a special case unwrapping `list_mcp_servers`'s `{"servers": [...]}` handler return down to a bare list — a legacy shim ("match registry-handler output to the legacy router-branch shape") that predates the canonicalization system (`to_canonical` / `list_mcp_servers_to_canonical`, `canonical.py`).

- `dispatch_tool`'s envelope wraps whatever this returns as `data`.
- `unwrap_dispatch_envelope` only peels a **dict**-shaped `data` — a bare list fails that check, so the envelope stays wrapped: `{"status":"ok","data":[...]}`.
- `list_mcp_servers_to_canonical`'s `result.get("servers")` then finds nothing on that still-wrapped dict → `n=0` → `"0 MCP servers."`
- Meanwhile the conversation's raw-dict summary (`summarize_tool_result`) tolerates a bare list fine (`isinstance(result, list)` branch → `"N items"`), so it displayed the correct count — masking the bug rather than exposing it.

Confirmed the identical pattern for `list_mcp_tools` (`{"mcp_tools": [...]}`, same shim shape).

This is restart-invariant (a pure shape bug, not a timing/state issue) — exactly matching the owner's report.

## Investigation note

Getting here took several rounds of hypotheses that didn't reproduce (dual roster holders, tool-result capping, canonical-mapper registration, envelope-chain logic with hand-built data, multi-tool-call ordering, project-root staleness) — all individually correct, but none matched the actual symptom. The owner correctly pushed back that hand-built test data verifies *understanding* of the implementation, not the implementation *itself*; the actual bug only surfaced once `dispatch_tool()` was called for real, end-to-end, with a real event bus, rather than manually re-deriving each pipeline stage's input from the previous stage's assumed output.

## Fix

Removed all THREE branches from `_normalise_router_tool_result` in one diff: `list_mcp_servers` / `list_mcp_tools` (the bug fix, no backward-compat flag) AND `describe_mcp_tool` (a separate, unrelated no-op consolidation — its branch was `return result`, byte-identical to this function's own unconditional fallthrough at the end, so deleting it changes zero behavior). Only `read_file` / `list_directory` are untouched. **Correction**: an earlier revision of this PR body said "`describe_mcp_tool` untouched" — that was wrong; the branch was deleted, just with no behavior change (caught in co-vet).

## Test plan

- [x] `test_list_mcp_servers_canonical_shape.py` — one Tier 2 end-to-end test: real `Session`, real event bus, real `ChatLifecycleForwarder` (conversation-display source), real `RouterLoop.feedback` (LLM-facing-text source), all driven by ONE real `dispatch_tool()` call (not hand-built envelope data). Falsifying-verified: fails on pre-fix code, reproducing the EXACT reported string `'---\nstructured: []\n---\n0 MCP servers.'`; passes with the fix.
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_list_mcp_servers_canonical_shape.py` — 0 errors
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py` — OK
- [x] Full `pytest` — 8550 passed; 9 pre-existing failures (`test_compaction_resolver_aware_1172.py`, `test_llm_request_error_1676.py`, `test_llm_router_s3b_1829.py`, `test_responses_api_routing_1678.py`) — same known-unrelated set tracked across recent PRs in this repo.

**Tier self-check**: the one new test is Tier 2 (real Session/RouterLoop/event-bus objects, no mocks; asserts on public outputs — outbox message content and LLM message text — not private state).
