### PR TITLE
ci: add x86_64 Linux job that live-validates the seccomp filter (#2982)

### DIFF
--- a/.github/workflows/sandbox-linux-live-x86_64.yml
+++ b/.github/workflows/sandbox-linux-live-x86_64.yml
@@ -1,0 +1,55 @@
+name: sandbox seccomp x86_64 live validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  seccomp-x86_64-live:
+    name: seccomp-BPF live probe (x86_64, sandbox-linux extra, #2982/#2983)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # `sandbox-linux` is deliberately OMITTED from test.yml's extras — it pulls
+      # in pyseccomp, which #2975 (`load_seccomp_filter`) makes a REAL, irrevocable
+      # default-deny filter for the calling process. test.yml's pytest session
+      # never installs this extra, so no job anywhere ran with pyseccomp actually
+      # present until this one. That gap is exactly why #2975's own live
+      # validation (24/24, aarch64) could never have run in CI at all before now.
+      - name: Install sandbox-linux extra
+        run: pip install -e ".[sandbox-linux]"
+
+      # scripts/sandbox_seccomp_x86_64_live_smoke.py is intentionally NOT a
+      # pytest file: loading a real seccomp filter is irrevocable for the rest
+      # of the process, so pytest's shared-session model is the wrong shape for
+      # it (#2975's own test-guard fix, 8f4405815, exists because ONE unguarded
+      # pytest-collected test loaded a real filter into the pytest process
+      # itself). This script forks a fresh subprocess per probe instead.
+      #
+      # Deliberately NOT path-filtered, same reasoning as wheel-reachability.yml
+      # (FP-0061): an incomplete include-list is itself a false-allow surface —
+      # letting a seccomp allowlist regression under an unlisted path merge with
+      # this gate silently never running would be worse than a few extra
+      # seconds of CI on every PR.
+      #
+      # #2975 was validated live ONLY on aarch64 (Ubuntu 24.04, colima) — an
+      # architecture that has no `stat`/`lstat` syscalls at all, so it could not
+      # possibly surface a missing `stat`/`lstat` allowlist entry. This job
+      # repeats that live validation on x86_64 (this runner), which DOES have
+      # those syscalls, closing that one specific blind spot. It does NOT
+      # validate: the #2980 landlock-package-API mismatch (reported, not fixed,
+      # by this script), the Landlock ABI 1-2 truncate gap (this runner's kernel
+      # ABI is whatever GitHub ships, not chosen for ABI coverage), or real
+      # end-to-end op-path enforcement. See #2982 / #2983.
+      - name: Live seccomp-BPF validation (x86_64)
+        run: python scripts/sandbox_seccomp_x86_64_live_smoke.py

--- a/scripts/sandbox_seccomp_x86_64_live_smoke.py
+++ b/scripts/sandbox_seccomp_x86_64_live_smoke.py
@@ -1,0 +1,443 @@
+"""x86_64 live validation of the seccomp-BPF filter (#2982, part of #2983).
+
+#2975 turned the seccomp-BPF filter live in production for the first time and
+validated it on a real Linux host — but that host was **aarch64** (Ubuntu 24.04,
+colima). aarch64 has no `stat`/`lstat` syscalls at all (only the `*at` forms), so
+no amount of aarch64 testing can surface a missing `stat`/`lstat` allowlist
+entry — the gap this script exists to close is *architecture-shaped*, not a bug
+that more aarch64 runs would ever find.
+
+This script repeats #2975's live validation (drive the two real production
+callsites with real workloads, observe survive/defend) on whatever host actually
+runs it — which in `.github/workflows/sandbox-linux-live-x86_64.yml` is a GitHub
+Actions `ubuntu-latest` runner (x86_64). It is intentionally NOT a pytest file:
+loading a real default-deny filter is irrevocable for the rest of the process
+(#2975's own test-guard fix, `8f4405815`), so each probe MUST run in its own
+subprocess — this script is that harness, not a test collected into the shared
+pytest session.
+
+Honesty, per #2982: this closes ONE of several structural blind spots #2975
+shipped with, not all of them:
+
+  - x86_64 syscall NAME resolution (stat/lstat are real x86_64 syscall numbers,
+    unlike aarch64 where they don't exist)          -> closed by this script
+  - whether an installed `landlock` package version matches the pinned API
+    (add_path_beneath_rule vs allow()/apply(), #2980)  -> reported, not fixed
+  - Landlock ABI 1-2 (the truncate gap's actual affected range: Ubuntu 22.04
+    LTS / RHEL 9 / Debian 12 — most of the installed base) -> NOT closed; this
+    runner's kernel ABI is whatever GitHub ships, not chosen for ABI coverage
+  - "does a deny actually fire in the product's real op path, end to end"
+     -> NOT closed; this is a syscall-filter mechanism probe, not an
+        end-to-end op-path test
+
+Do not read a green run of this script as "the sandbox is validated". Read it as
+"the syscall-name-resolution gap #2975 flagged as predicted-not-measured is now
+measured on x86_64" — see the PR body for the fuller table (#2983).
+"""
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+
+
+@dataclass
+class ProbeResult:
+    label: str
+    ok: bool
+    detail: str
+
+
+RESULTS: list[ProbeResult] = []
+
+
+def _record(label: str, ok: bool, detail: str = "") -> None:
+    RESULTS.append(ProbeResult(label, ok, detail))
+    status = "PASS" if ok else "FAIL"
+    print(f"[{status}] {label}" + (f" — {detail}" if detail else ""))
+
+
+# ---------------------------------------------------------------------------
+# Environment preflight — fail loudly if this isn't the environment the job
+# claims to be. A silent skip here would be exactly the "gate that cannot
+# witness its own assumption" failure mode #2982 is about.
+# ---------------------------------------------------------------------------
+
+
+def _preflight() -> None:
+    machine = platform.machine()
+    system = platform.system()
+    print(f"platform.system()  = {system}")
+    print(f"platform.machine() = {machine}")
+    try:
+        print(f"platform.libc_ver() = {platform.libc_ver()}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"platform.libc_ver() raised: {exc}")
+
+    if system != "Linux":
+        print("FATAL: this script requires Linux (seccomp-BPF is Linux-only).")
+        sys.exit(2)
+    if machine not in ("x86_64", "amd64", "AMD64"):
+        print(
+            f"FATAL: this script requires an x86_64 host (got {machine!r}). "
+            "It exists specifically to validate a gap aarch64 cannot surface "
+            "— running it on aarch64 would silently defeat its purpose."
+        )
+        sys.exit(2)
+
+    import reyn.security.sandbox.backends.seccomp as seccomp_mod
+
+    if not seccomp_mod.is_available():
+        print(
+            "FATAL: seccomp_mod.is_available() is False. This job installs "
+            "the sandbox-linux extra specifically so pyseccomp is present — "
+            "if this fires, the install step is broken, not the environment."
+        )
+        sys.exit(2)
+
+    # Honest note about glibc: on glibc >= 2.33, `stat(2)`/`lstat(2)` libc calls
+    # route through the newfstatat(2) syscall, not the legacy stat/lstat syscall
+    # numbers — so a MODERN glibc host (which GitHub's ubuntu-latest is) will
+    # NOT actually exercise the legacy stat/lstat syscalls at runtime even
+    # though this script confirms libseccomp can resolve their NAMES on the
+    # x86_64 syscall table. The runtime gap (Debian 11 / Ubuntu 20.04 / RHEL 8
+    # / Amazon Linux 2, glibc < 2.33) stays unmeasured by this job; only name
+    # resolution + filter load with those names present is measured here.
+    print(
+        "NOTE: this host's glibc is used to determine whether legacy "
+        "stat/lstat SYSCALLS get exercised — see script docstring."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Callsite 1: LandlockBackend._child_preexec (Popen/preexec_fn shape)
+# ---------------------------------------------------------------------------
+
+
+def _run_child_preexec_probe(workdir: str, ruleset: object | None) -> None:
+    """Drive `_child_preexec` exactly as `LandlockBackend.run` does: as a real
+    `preexec_fn` on a real `subprocess.Popen`, so the probed effect is the
+    production code path, not a re-implementation of it."""
+    from reyn.security.sandbox.backends.landlock import _child_preexec
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    policy = SandboxPolicy(write_paths=[workdir])
+
+    def _popen(argv: list[str], **kw: object) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            argv,
+            preexec_fn=lambda: _child_preexec(ruleset, policy),  # noqa: PLC0415
+            capture_output=True,
+            timeout=10,
+            **kw,  # type: ignore[arg-type]
+        )
+
+    survive = {
+        "echo": ["/bin/echo", "hello"],
+        "ls /": ["/bin/ls", "/"],
+        "cat": ["/bin/cat", "/etc/hostname"],
+    }
+    for label, argv in survive.items():
+        try:
+            proc = _popen(argv)
+            _record(
+                f"callsite1 survive: {label}",
+                proc.returncode == 0,
+                f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _record(f"callsite1 survive: {label}", False, f"raised {exc!r}")
+
+    # python: file read+write, mkdir/remove/rename/rmtree — driven inline so it
+    # is the real _child_preexec-wrapped python process doing the syscalls.
+    py_workload = f"""
+import os, shutil
+d = {workdir!r}
+p = os.path.join(d, "probe.txt")
+with open(p, "w") as f:
+    f.write("hi")
+with open(p) as f:
+    assert f.read() == "hi"
+os.mkdir(os.path.join(d, "subdir"))
+os.rename(os.path.join(d, "subdir"), os.path.join(d, "subdir2"))
+os.rmdir(os.path.join(d, "subdir2"))
+os.remove(p)
+print("workload-ok")
+"""
+    try:
+        proc = _popen([sys.executable, "-c", py_workload])
+        _record(
+            "callsite1 survive: python read+write+mkdir+remove+rename+rmtree",
+            proc.returncode == 0 and b"workload-ok" in proc.stdout,
+            f"rc={proc.returncode} stdout={proc.stdout!r} stderr={proc.stderr[:300]!r}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _record("callsite1 survive: python file workload", False, f"raised {exc!r}")
+
+    # chmod / truncate — must be refused (EPERM), matching #2975's own
+    # falsification (_EXCLUDED_UNGOVERNABLE).
+    for label, code in {
+        "chmod": f"import os; os.chmod({workdir!r}, 0o777)",
+        "truncate": (
+            f"import os; p={os.path.join(workdir, 'trunc.txt')!r}; "
+            "open(p, 'w').close(); os.truncate(p, 0)"
+        ),
+    }.items():
+        try:
+            proc = _popen([sys.executable, "-c", code])
+            refused = proc.returncode != 0
+            _record(
+                f"callsite1 defend (must be refused): {label}",
+                refused,
+                f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _record(f"callsite1 defend: {label}", False, f"raised {exc!r}")
+
+    defend = {
+        "subprocess spawn": [sys.executable, "-c", "import subprocess; subprocess.run(['/bin/echo','x'])"],
+        "os.fork": [sys.executable, "-c", "import os; os.fork()"],
+        "socket": [sys.executable, "-c", "import socket; socket.socket()"],
+    }
+    for label, argv in defend.items():
+        try:
+            proc = _popen(argv)
+            _record(
+                f"callsite1 defend (must be refused): {label}",
+                proc.returncode != 0,
+                f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _record(f"callsite1 defend: {label}", False, f"raised {exc!r}")
+
+    # ptrace: use ctypes to actually issue the syscall rather than relying on a
+    # higher-level API being present.
+    ptrace_code = (
+        "import ctypes; libc = ctypes.CDLL(None, use_errno=True); "
+        "r = libc.ptrace(0, 0, 0, 0); "
+        "import sys; sys.exit(0 if r == 0 else 1)"
+    )
+    try:
+        proc = _popen([sys.executable, "-c", ptrace_code])
+        _record(
+            "callsite1 defend (must be refused): ptrace",
+            proc.returncode != 0,
+            f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _record("callsite1 defend: ptrace", False, f"raised {exc!r}")
+
+
+def _validate_callsite1(workdir: str) -> None:
+    from reyn.security.sandbox.backends.landlock import LandlockBackend
+
+    backend = LandlockBackend()
+    if backend.available():
+        import landlock  # noqa: PLC0415
+
+        FS = landlock.FSAccess  # type: ignore[attr-defined]
+        read_rules = FS.READ_FILE | FS.READ_DIR | FS.EXECUTE
+        write_rules = (
+            read_rules
+            | FS.WRITE_FILE
+            | FS.MAKE_REG | FS.MAKE_DIR | FS.MAKE_SYM
+            | FS.MAKE_CHAR | FS.MAKE_BLOCK | FS.MAKE_FIFO | FS.MAKE_SOCK
+            | FS.REMOVE_FILE | FS.REMOVE_DIR
+        )
+        handled = read_rules | write_rules
+        ruleset = landlock.Ruleset(restrict_rules=handled)  # type: ignore[attr-defined]
+        ruleset.allow("/", rules=read_rules)
+        ruleset.allow(workdir, rules=write_rules)
+        print(
+            f"Landlock available on this host (ABI {backend._abi_version}); "
+            "stacking Landlock+seccomp together — NOT exercised by #2975's "
+            "aarch64 validation (that run used ruleset=None)."
+        )
+        _run_child_preexec_probe(workdir, ruleset)
+    else:
+        print(
+            "Landlock NOT available on this host "
+            f"(import_error={backend.import_error!r}); exercising the "
+            "seccomp-only shape (ruleset=None), same as #2975's aarch64 run."
+        )
+        _run_child_preexec_probe(workdir, None)
+
+
+# ---------------------------------------------------------------------------
+# Callsite 2: landlock_exec._apply_seccomp (plain os.execvp shape)
+# ---------------------------------------------------------------------------
+
+
+def _validate_callsite2(workdir: str) -> None:
+    """Drive `_apply_seccomp` (the shim's real seccomp step) followed by a real
+    `os.execvp`, matching the shape `landlock_exec.main()` uses in production —
+    without going through the shim's `_apply_landlock`, which #2975's PR body
+    already found unreachable on the pinned `landlock==1.0.0.dev5` package
+    (`add_path_beneath_rule` raises `AttributeError` before seccomp is ever
+    applied — a pre-existing #2980 defect, not something to route around
+    silently)."""
+    def _run(code_after_apply: str) -> subprocess.CompletedProcess:
+        script = f"""
+import sys
+sys.path.insert(0, {os.getcwd()!r})
+from reyn.security.sandbox.landlock_exec import _apply_seccomp
+from reyn.security.sandbox.policy import SandboxPolicy
+_apply_seccomp(SandboxPolicy(write_paths=[{workdir!r}]))
+{code_after_apply}
+"""
+        return subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, timeout=10,
+        )
+
+    survive = {
+        "shim execs echo": "import os; os.execvp('/bin/echo', ['/bin/echo', 'hi'])",
+        "shim execs ls": "import os; os.execvp('/bin/ls', ['/bin/ls', '/'])",
+        "shim execs python read+write": (
+            f"import os; p={os.path.join(workdir, 'shim.txt')!r}\n"
+            "with open(p, 'w') as f: f.write('x')\n"
+            "with open(p) as f: assert f.read() == 'x'\n"
+            "print('shim-workload-ok')"
+        ),
+    }
+    for label, code in survive.items():
+        try:
+            proc = _run(code)
+            _record(
+                f"callsite2 survive: {label}",
+                proc.returncode == 0,
+                f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _record(f"callsite2 survive: {label}", False, f"raised {exc!r}")
+
+    try:
+        proc = _run(
+            "import subprocess; subprocess.run(['/bin/echo', 'x'])"
+        )
+        _record(
+            "callsite2 defend (must be refused): subprocess spawn",
+            proc.returncode != 0,
+            f"rc={proc.returncode} stderr={proc.stderr[:200]!r}",
+        )
+    except Exception as exc:  # noqa: BLE001
+        _record("callsite2 defend: subprocess spawn", False, f"raised {exc!r}")
+
+    # Report (do not route around) whether the shim's real Landlock step is
+    # reachable on the installed landlock package version — this is #2980,
+    # surfaced here rather than fixed here.
+    #
+    # Build the shim's own `--policy` JSON via its real serializer
+    # (`_policy_to_json`) rather than hand-formatting JSON into an f-string —
+    # a hand-rolled version broke on quote-collision between the JSON string
+    # and the Python source string during local validation of this script.
+    from reyn.security.sandbox.landlock_exec import _policy_to_json
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    policy_arg = _policy_to_json(SandboxPolicy(write_paths=[workdir]))
+    shim_probe = f"""
+import sys
+sys.path.insert(0, {os.getcwd()!r})
+from reyn.security.sandbox.landlock_exec import main
+sys.exit(main(["--policy", {policy_arg!r}, "--", "/bin/echo", "shim-main-ok"]))
+"""
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", shim_probe], capture_output=True, timeout=10,
+        )
+        reachable = proc.returncode == 0 and b"shim-main-ok" in proc.stdout
+        print(
+            "[INFO] landlock_exec.main() end-to-end (includes _apply_landlock): "
+            + ("REACHABLE" if reachable else "NOT reachable")
+            + f" — rc={proc.returncode} stderr={proc.stderr[:300]!r}"
+        )
+        if not reachable and b"AttributeError" in proc.stderr:
+            print(
+                "[INFO] Matches #2975 PR body's finding: the shim's "
+                "_apply_landlock uses an API (add_path_beneath_rule) not "
+                "exposed by the pinned landlock package version — #2980, "
+                "pre-existing, not introduced or fixed here."
+            )
+    except Exception as exc:  # noqa: BLE001
+        print(f"[INFO] landlock_exec.main() probe raised: {exc!r}")
+
+
+# ---------------------------------------------------------------------------
+# denial.py (#2820) launcher-fork classification — must fire on Linux now that
+# the filter actually refuses fork with EPERM (not KILL).
+# ---------------------------------------------------------------------------
+
+
+def _validate_denial_classification(workdir: str) -> None:
+    from reyn.security.sandbox.backends.landlock import _child_preexec
+    from reyn.security.sandbox.denial import DENIAL_FORK, classify_denial
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    policy = SandboxPolicy(write_paths=[workdir])
+    shapes = {
+        "ls / | wc -l": "ls / | wc -l",
+        "ls /; echo done": "ls /; echo done",
+        "x=$(echo hi)": "x=$(echo hi); echo $x",
+    }
+    for label, shell_cmd in shapes.items():
+        try:
+            proc = subprocess.run(
+                ["/bin/bash", "-c", shell_cmd],
+                preexec_fn=lambda: _child_preexec(None, policy),  # noqa: PLC0415, B023
+                capture_output=True,
+                timeout=10,
+            )
+            klass = classify_denial(proc.returncode, proc.stderr)
+            _record(
+                f"denial.py classifies: {label}",
+                klass == DENIAL_FORK,
+                f"rc={proc.returncode} class={klass} stderr={proc.stderr[:200]!r}",
+            )
+        except Exception as exc:  # noqa: BLE001
+            _record(f"denial.py classifies: {label}", False, f"raised {exc!r}")
+
+
+def main() -> int:
+    _preflight()
+
+    with tempfile.TemporaryDirectory() as workdir:
+        print("\n=== Callsite 1: LandlockBackend._child_preexec ===")
+        _validate_callsite1(workdir)
+
+        print("\n=== Callsite 2: landlock_exec._apply_seccomp ===")
+        _validate_callsite2(workdir)
+
+        print("\n=== denial.py (#2820) launcher-fork classification ===")
+        _validate_denial_classification(workdir)
+
+    print("\n=== Summary ===")
+    n_ok = sum(1 for r in RESULTS if r.ok)
+    n_total = len(RESULTS)
+    for r in RESULTS:
+        if not r.ok:
+            print(f"  FAIL: {r.label} — {r.detail}")
+    print(f"{n_ok}/{n_total} probes as expected")
+
+    if n_ok != n_total:
+        print(
+            "\nAt least one probe did NOT behave as #2975's aarch64 run "
+            "predicted. Per #2982: this is exactly the kind of x86_64-only "
+            "defect this job exists to surface — do not paper over it with a "
+            "workaround here. Report the specific probe and its detail."
+        )
+        return 1
+
+    print(
+        "\nAll probes matched #2975's aarch64 expectations, now confirmed on "
+        "x86_64. This closes the syscall-name-resolution blind spot only — "
+        "see the script docstring and the #2982 PR body for what remains open "
+        "(#2980 package-API mismatch, Landlock ABI 1-2 truncate gap, and "
+        "end-to-end op-path enforcement)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2982
part of #2983

## Why

#2975 turned the seccomp-BPF default-deny filter live in production for the first time and validated it live — but only on **aarch64** (Ubuntu 24.04, colima). aarch64 has no `stat`/`lstat` syscalls at all (only the `*at` forms), so no amount of aarch64 testing could ever surface a missing `stat`/`lstat` allowlist entry. The module docstring already flags those two names as "predicted, not validated" for exactly this reason. Order-dependency is resolved: #2975's `8f4405815` fixed the one test (`test_load_has_no_deferred_form`) that was missing the `platform.system` guard, which is the prerequisite this issue names for being able to stand up a `[sandbox-linux]` pytest job at all.

## What this PR does

- **`.github/workflows/sandbox-linux-live-x86_64.yml`** — new workflow, `ubuntu-latest` (x86_64), unconditional on every push/PR (no path filter — same reasoning as `wheel-reachability.yml`'s mode-2 probe / FP-0061: a positive include-list is itself a false-allow surface). Installs `pip install -e ".[sandbox-linux]"` (the extra `test.yml` deliberately omits, so no CI job anywhere has run with real `pyseccomp` present until now) and runs the smoke script below.
- **`scripts/sandbox_seccomp_x86_64_live_smoke.py`** — repeats #2975's live validation on x86_64: drives both real production seccomp callsites (`LandlockBackend._child_preexec` and `landlock_exec._apply_seccomp`) with real subprocesses, exercising the same survive/defend workload set #2975 validated by hand on aarch64 (echo/ls/cat/python file I/O/mkdir/remove/rename/rmtree survive; fork/ptrace/socket/subprocess-spawn/chmod/truncate refused), plus `denial.py`'s (#2820) launcher-fork classification across 3 shell shapes.

Deliberately **not** a pytest file: loading the filter is irrevocable for the rest of the calling process — the same hazard #2975's own test-guard fix addresses for pytest's shared session. Each probe here forks its own subprocess instead.

The script also drives `landlock_exec.main()` end-to-end (including the shim's own `_apply_landlock`) as an **informational** probe (not gated pass/fail) — reporting whether the pinned `landlock` package version's API matches what the shim calls (`add_path_beneath_rule`), since #2975's PR body already found this unreachable and #2980 tracks it. This job can surface it again on a fresh install without silently routing around it.

## Honesty — what this job does and does NOT close (per #2982)

| Axis | Closed by this job? |
|---|---|
| x86_64 syscall-name resolution (does the filter even load with `stat`/`lstat` in the allowlist on the x86_64 syscall table) | Yes |
| `#2980` landlock-package-API mismatch | Possibly surfaced (reported as an informational finding, not asserted pass/fail — it's a pre-existing, separately-tracked defect) |
| Landlock ABI 1-2 (the `truncate` gap's actual affected range — Ubuntu 22.04 LTS / RHEL 9 / Debian 12, most of the installed base) | **No** — this runner's kernel ABI is whatever GitHub ships (probed and logged, not chosen for ABI coverage) |
| A deny firing in the real end-to-end op path | **No** — this is a syscall-filter mechanism probe, not an op-path integration test |

Also flagged honestly in the script's own preflight: GitHub's `ubuntu-latest` glibc is modern (>= 2.33), so `stat(2)`/`lstat(2)` libc calls route through `newfstatat`, not the legacy syscall numbers — this job confirms libseccomp can **resolve** `stat`/`lstat` as x86_64 syscall names and load a filter containing them, but does not exercise the legacy-glibc runtime path (Debian 11 / Ubuntu 20.04 / RHEL 8 / Amazon Linux 2) that originally motivated including them.

Per #2983: a green run of this job is not "the sandbox is validated" — it closes one specific structurally-blind axis from #2975, not the others.

## Structural fix rejected (recorded per issue instructions)

An autouse Darwin fixture guaranteeing "no test loads a real filter" was considered (and already rejected once, by #2975's author) because it would silently defeat the purpose of *this* job, which needs `is_available() == True`. The guard stays per-test and explicit.

## Local validation

- `ruff check src tests` — clean (also ran directly against the new script — clean)
- No test files changed — `test_tier_audit.py` N/A
- `pytest` from repo root — 8614 passed, 25 skipped
- No src files changed — `verify_module_docstrings.py` N/A
- Manual: ran the harness logic in a real Linux container (colima, aarch64 host — the only Linux available locally) with the x86_64 arch guard temporarily relaxed, to shake out bugs in the harness itself before it ever reaches a real x86_64 runner. Found and fixed a real bug this way: the shim-probe's hand-formatted JSON collided with the surrounding Python string quoting and threw a `SyntaxError` in the generated subprocess — replaced with the shim's own `_policy_to_json` serializer. After the fix: 17/17 probes matched #2975's aarch64 result shape, and the informational `landlock_exec.main()` probe correctly reported `#2980`'s `AttributeError` rather than silently passing.
- **Genuine x86_64 kernel behavior — the actual point of this job — can only be observed once this workflow runs for real on GitHub's x86_64 runner.** Watching the CI run on this PR for that signal; will report findings (not paper over them) if anything diverges from #2975's aarch64 expectations.

## Test plan
- [x] `ruff check src tests` (+ new script)
- [x] `pytest` from repo root — 8614 passed, 25 skipped
- [x] Manual: harness logic validated end-to-end inside a real Linux container (arch guard relaxed) — bug found and fixed
- [ ] Manual: real x86_64 CI run of the new job observed green (or findings reported if not) — pending this PR's own CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)