### PR TITLE
fix: bound the out-of-process external-event hook dispatch (#2620)

### DIFF
--- a/src/reyn/hooks/external_fire.py
+++ b/src/reyn/hooks/external_fire.py
@@ -1,54 +1,178 @@
-"""reyn.hooks.external_fire — non-blocking dispatch helper for OUT-OF-SESSION
-external-event ingress (#2608 H5: cron + webhook).
+"""reyn.hooks.external_fire — bounded, non-blocking dispatch helper for
+OUT-OF-SESSION external-event ingress (#2608 H5: cron + webhook; bounded by
+#2620).
 
 H1 (``mcp_resource_updated``) and H4 (``file_changed``) both fire their hook
-from INSIDE the session's own process — a bounded queue drained on a
-dedicated task/loop, decoupling the producer (MCP receive-loop task / watchdog
-thread) from the hook dispatch. Cron and webhook ingress have no such
+from INSIDE the session's own process — a bounded ``asyncio.Queue`` drained
+by ONE dedicated background task, decoupling the producer (MCP receive-loop
+task / watchdog thread) from the hook dispatch (see
+``reyn.hooks.ingress._BoundedEventBridge``: fixed-size queue, ``put_nowait``,
+drop-newest-and-log on overflow). Cron and webhook ingress have no such
 producer/drain split: ``reyn.runtime.cron.routing.resolve_cron_session`` /
 ``reyn.runtime.webhook_routing.resolve_webhook_session`` resolve the target
 Session directly at fire/request time, in the SAME coroutine that also does
 the ingress's own delivery work (the cron job's inbox push / the webhook
-plugin's HTTP response).
+plugin's HTTP response) — there is no already-running producer task/thread
+to own a bridge the way H1/H4's adapters do.
 
-:func:`fire_and_forget` is the H5 non-blocking discipline: the hook dispatch
-is scheduled as a background ``asyncio.create_task`` rather than awaited
-inline, so a slow hook action (a ``shell_exec`` that runs a multi-second
-command) can never stall the cron job's own delivery or delay the webhook
-plugin's response. ``HookDispatcher.dispatch`` already isolates per-hook
-failures internally (never raises — see ``reyn.hooks.dispatcher``); the
-second ``try/except`` here exists purely so an unretrieved background-task
-exception never surfaces an "exception was never retrieved" asyncio warning.
+:func:`fire_and_forget` closes that gap (#2620): rather than scheduling an
+unbounded ``asyncio.create_task`` per fire (the pre-#2620 shape — a webhook
+flood could spawn arbitrarily many concurrent hook-dispatch tasks, each
+running the configured hook actions), each SESSION now gets its own
+:class:`_SessionFireBridge` — the exact ``_BoundedEventBridge`` shape
+(fixed-size ``asyncio.Queue`` + one lazily-started sequential drain task),
+lazily created on first fire and reused across every subsequent fire for
+that session. A burst of fires beyond the queue's ``maxsize`` drops the
+NEWEST event and logs a warning rather than growing the queue unboundedly or
+spawning another concurrent dispatch task — cron_fired is rate-limited by
+the schedule in practice (this bound is inert for it), webhook_received is
+the surface this actually protects (an inbound webhook flood, #2608 H5's
+"semi-trusted surface" note).
+
+``session.dispatch_external_event`` already isolates per-hook failures
+internally (never raises — see ``reyn.hooks.dispatcher``); the drain loop's
+own ``try/except`` exists purely so one bad dispatch never kills the whole
+session's drain task (mirrors ``_BoundedEventBridge._drain``'s per-event
+isolation).
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+import weakref
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Mirrors reyn.hooks.ingress._BoundedEventBridge's own default (the H1/H4
+# in-process bridge's ``maxsize=32``) so H5's out-of-process bound matches
+# the bound its in-process siblings already use for the same class of risk.
+_DEFAULT_MAXSIZE = 32
 
-def fire_and_forget(session: Any, point: str, template_vars: dict) -> None:
-    """Schedule ``session.dispatch_external_event(point, template_vars)`` as a
-    background task rather than awaiting it inline.
+
+class _SessionFireBridge:
+    """Per-Session bounded dispatch bridge (#2620) — the ``_BoundedEventBridge``
+    shape (``reyn.hooks.ingress``) applied to the out-of-process H5 path: a
+    bounded ``asyncio.Queue`` plus a lazily-created background drain task
+    that awaits ``session.dispatch_external_event`` for each queued
+    ``(point, template_vars)`` pair, ONE AT A TIME (never concurrently for
+    the same session), with per-event ``try/except`` (one bad dispatch must
+    never kill the drain task, same discipline as
+    ``_BoundedEventBridge._drain``).
+
+    One instance per Session, created lazily on first :func:`fire_and_forget`
+    call for that session and cached in the module-level
+    ``_session_bridges`` WeakKeyDictionary so a session that never fires an
+    external-event hook never allocates a queue/task at all (byte-identical
+    to a build with no H5 dispatch)."""
+
+    def __init__(self, *, session: Any, maxsize: int) -> None:
+        self._session = session
+        self._maxsize = maxsize
+        self._queue: "asyncio.Queue[tuple[str, dict]] | None" = None
+        self._drain_task: "asyncio.Task | None" = None
+        # #2620 Observability lens: a fail-visible counter (public via
+        # ``dropped_dispatch_count``) alongside the WARNING log line — a test
+        # or operator can confirm the bound actually triggered without
+        # scraping logs or reaching into this bridge's private state.
+        self._drop_count = 0
+
+    def submit(self, point: str, template_vars: dict) -> None:
+        """SYNCHRONOUS, non-blocking, never raises. Lazily starts this
+        session's drain task on first call. A full queue drops the NEWEST
+        ``(point, template_vars)`` pair and logs — bounded by construction,
+        the producer (the webhook/cron ingress coroutine) is never blocked
+        and never spawns an additional concurrent dispatch task."""
+        if self._queue is None:
+            self._queue = asyncio.Queue(maxsize=self._maxsize)
+        if self._drain_task is None or self._drain_task.done():
+            self._drain_task = asyncio.create_task(self._drain())
+        try:
+            self._queue.put_nowait((point, template_vars))
+        except asyncio.QueueFull:
+            self._drop_count += 1
+            logger.warning(
+                "external-event hook dispatch queue full (maxsize=%d) — dropping "
+                "point=%r (fires arriving faster than hooks can be dispatched "
+                "for this session)",
+                self._maxsize, point,
+            )
+
+    def pending_count(self) -> int:
+        """Public, snapshot-style read of the number of ``(point,
+        template_vars)`` pairs still queued (not yet drained) for this
+        session. ``0`` before the first :meth:`submit` call (no queue
+        allocated yet)."""
+        return 0 if self._queue is None else self._queue.qsize()
+
+    def dropped_count(self) -> int:
+        """Public, snapshot-style read of the cumulative number of pairs
+        dropped by this bridge because the queue was full at ``submit``
+        time (#2620)."""
+        return self._drop_count
+
+    async def _drain(self) -> None:
+        assert self._queue is not None
+        while True:
+            point, template_vars = await self._queue.get()
+            try:
+                await self._session.dispatch_external_event(point, template_vars)
+            except Exception:  # noqa: BLE001 — one bad dispatch must not kill the drain task
+                logger.warning(
+                    "external-event hook dispatch failed for point=%r", point, exc_info=True,
+                )
+
+
+# Module-level, keyed by session identity (weak so a garbage-collected
+# session's bridge/queue is reclaimed with it rather than pinned forever —
+# #2620 introduces a per-session bridge that outlives any single fire, unlike
+# the pre-#2620 one-task-per-fire shape, so this cache must not be a plain
+# dict).
+_session_bridges: "weakref.WeakKeyDictionary[Any, _SessionFireBridge]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def fire_and_forget(
+    session: Any, point: str, template_vars: dict, *, maxsize: int = _DEFAULT_MAXSIZE,
+) -> None:
+    """Schedule ``session.dispatch_external_event(point, template_vars)``
+    through ``session``'s bounded dispatch bridge (#2620) rather than
+    awaiting it inline or spawning an unbounded background task per call.
 
     Never raises into the caller — safe to call unconditionally from an
     ingress's fast path, empty-hook-registry included (``dispatch`` itself is
     a no-op when nothing is registered for ``point``, so an empty registry is
     byte-identical to a build with no hook mechanism at all beyond the
-    negligible cost of scheduling one no-op task).
+    negligible cost of one queued no-op dispatch). ``maxsize`` mirrors
+    ``_BoundedEventBridge``'s own constructor knob — overridable per call
+    for a caller that wants a different bound than the default, but every
+    current call site (``reyn.hooks.ingress``'s Cron/Webhook adapters) uses
+    the default.
     """
-
-    async def _run() -> None:
-        try:
-            await session.dispatch_external_event(point, template_vars)
-        except Exception:  # noqa: BLE001 — background dispatch must never raise into the caller
-            logger.warning(
-                "external-event hook dispatch failed for point=%r", point, exc_info=True,
-            )
-
-    asyncio.create_task(_run())
+    bridge = _session_bridges.get(session)
+    if bridge is None:
+        bridge = _SessionFireBridge(session=session, maxsize=maxsize)
+        _session_bridges[session] = bridge
+    bridge.submit(point, template_vars)
 
 
-__all__ = ["fire_and_forget"]
+def pending_dispatch_count(session: Any) -> int:
+    """Public, snapshot-style read (Observability lens, #2620): the number of
+    ``fire_and_forget`` calls for ``session`` still queued and not yet
+    drained. ``0`` if ``session`` has never called :func:`fire_and_forget`
+    (no bridge allocated yet) — the no-fire-yet equivalence property."""
+    bridge = _session_bridges.get(session)
+    return 0 if bridge is None else bridge.pending_count()
+
+
+def dropped_dispatch_count(session: Any) -> int:
+    """Public, snapshot-style read (Observability lens, #2620): the
+    cumulative number of ``fire_and_forget`` calls for ``session`` dropped
+    because its dispatch queue was full at submit time. ``0`` if ``session``
+    has never called :func:`fire_and_forget`."""
+    bridge = _session_bridges.get(session)
+    return 0 if bridge is None else bridge.dropped_count()
+
+
+__all__ = ["dropped_dispatch_count", "fire_and_forget", "pending_dispatch_count"]

--- a/tests/test_2620_bound_webhook_fire_and_forget.py
+++ b/tests/test_2620_bound_webhook_fire_and_forget.py
@@ -1,0 +1,148 @@
+"""Tier 2b: #2620 — ``reyn.hooks.external_fire.fire_and_forget`` bounds the
+number of concurrently-queued external-event dispatches PER SESSION rather
+than scheduling an unbounded ``asyncio.create_task`` per fire.
+
+Before #2620, ``fire_and_forget`` scheduled one background
+``asyncio.create_task`` per call with no bound at all — a webhook flood
+(H5's out-of-process, semi-trusted ingress path) could spawn arbitrarily
+many concurrent hook-dispatch tasks. #2620 gives each session its own
+bounded dispatch bridge (mirroring ``reyn.hooks.ingress._BoundedEventBridge``,
+the shape H1/H4 already use for their in-process ingress): a fixed-size
+``asyncio.Queue`` drained by one sequential background task, drop-newest
+and log on overflow.
+
+Real instances only (testing policy): a real ``Session`` (no registry
+needed — ``dispatch_external_event`` is a plain method on Session), the
+REAL ``WebhookIngressAdapter``/``dispatch_webhook_received`` production
+call path (not a hand-rolled call to ``fire_and_forget``), and the session's
+own public ``inbox`` to observe how many hook dispatches actually landed.
+No ``unittest.mock``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks import external_fire
+from reyn.runtime.session import Session
+
+
+def _make_session(tmp_path: Path) -> Session:
+    hooks_config = [
+        {"on": "webhook_received", "template_push": {"message": "hit from {{ sender }}"}},
+    ]
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return Session(agent_name="bound_test_agent", state_log=state_log, hooks_config=hooks_config)
+
+
+async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await asyncio.sleep(delay)
+
+
+def _drain_hook_texts(session: Session) -> list[str]:
+    items = []
+    while not session.inbox.empty():
+        items.append(session.inbox.get_nowait())
+    return [payload["text"] for kind, payload in items if kind == "hook"]
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_drops_newest_beyond_bound_not_unbounded_tasks(tmp_path):
+    """Tier 2b: the CORE #2620 proof. Fire N+3 real ``webhook_received``
+    events (via the real ``WebhookIngressAdapter``/``fire_and_forget`` path,
+    not the raw ``asyncio.create_task`` production used pre-#2620) in a
+    tight loop with NO ``await`` in between — since the drain task cannot
+    run until this coroutine yields, this places every fire ahead of the
+    boundary N (queue maxsize) at the moment it is submitted, not merely
+    "used a bounded queue so it must be bounded". The queue must actually
+    fill and actually drop the overflow (observed via the public
+    ``dropped_dispatch_count``/``pending_dispatch_count`` snapshot reads —
+    never private bridge state)."""
+    maxsize = 4
+    session = _make_session(tmp_path)
+
+    from reyn.hooks.ingress import WebhookIngressAdapter
+
+    adapter = WebhookIngressAdapter()
+    total_fires = maxsize + 3  # strictly outside the boundary, not merely at it
+    for i in range(total_fires):
+        event = adapter.to_event(f"webhook:sender-{i}")
+        # Exercise the REAL production entry point with the test's small
+        # bound instead of the 32-default, so the boundary is crossed
+        # within a fast unit test.
+        external_fire.fire_and_forget(
+            session, "webhook_received", event.payload, maxsize=maxsize,
+        )
+
+    # Before the drain task gets a chance to run (no await yet in THIS
+    # coroutine), every one of total_fires calls already resolved to either
+    # "queued" or "dropped" synchronously inside fire_and_forget.
+    assert external_fire.pending_dispatch_count(session) == maxsize
+    assert external_fire.dropped_dispatch_count(session) == total_fires - maxsize
+
+    # Let the drain task actually process the (bounded) backlog.
+    await _wait_for(lambda: external_fire.pending_dispatch_count(session) == 0)
+    await asyncio.sleep(0.05)  # let the last dispatch's hook push land in the inbox
+
+    hook_texts = _drain_hook_texts(session)
+    # Exactly `maxsize` hooks actually dispatched — the dropped overflow
+    # never reached HookDispatcher at all (bounded by construction, not by
+    # HookDispatcher happening to be fast).
+    assert len(hook_texts) == maxsize
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_at_the_boundary_drops_nothing(tmp_path):
+    """Tier 2b: negative control for the bound test above — exactly maxsize
+    fires (AT, not beyond, the boundary) drop nothing. Without this, the
+    prior test alone couldn't distinguish "bounded at N" from "bounded at
+    some smaller N' that also happens to make N+3 overflow"."""
+    maxsize = 4
+    session = _make_session(tmp_path)
+
+    from reyn.hooks.ingress import WebhookIngressAdapter
+
+    adapter = WebhookIngressAdapter()
+    for i in range(maxsize):
+        event = adapter.to_event(f"webhook:sender-{i}")
+        external_fire.fire_and_forget(
+            session, "webhook_received", event.payload, maxsize=maxsize,
+        )
+
+    assert external_fire.pending_dispatch_count(session) == maxsize
+    assert external_fire.dropped_dispatch_count(session) == 0
+
+    await _wait_for(lambda: external_fire.pending_dispatch_count(session) == 0)
+    await asyncio.sleep(0.05)
+    assert len(_drain_hook_texts(session)) == maxsize
+
+
+@pytest.mark.asyncio
+async def test_fire_and_forget_reuses_one_bridge_per_session(tmp_path):
+    """Tier 2b: two separate fires for the SAME session share one bounded
+    bridge (not a fresh queue/task per call — that would silently defeat
+    the bound by giving every call its own private maxsize slots)."""
+    maxsize = 2
+    session = _make_session(tmp_path)
+
+    from reyn.hooks.ingress import WebhookIngressAdapter
+
+    adapter = WebhookIngressAdapter()
+    # Fill the bound in one call...
+    for i in range(maxsize):
+        event = adapter.to_event(f"webhook:sender-{i}")
+        external_fire.fire_and_forget(
+            session, "webhook_received", event.payload, maxsize=maxsize,
+        )
+    assert external_fire.dropped_dispatch_count(session) == 0
+    # ...then a THIRD call before the drain task runs must be dropped
+    # against the SAME queue, not a brand-new one.
+    event = adapter.to_event("webhook:sender-overflow")
+    external_fire.fire_and_forget(session, "webhook_received", event.payload, maxsize=maxsize)
+    assert external_fire.dropped_dispatch_count(session) == 1


### PR DESCRIPTION
**[per-PR-coder]** — `Closes #2620`

## What

`reyn.hooks.external_fire.fire_and_forget` scheduled one **unbounded** `asyncio.create_task` per fire. For `cron_fired` that is inert (the schedule rate-limits it); for `webhook_received` an inbound flood could spawn arbitrarily many concurrent hook-dispatch tasks, each running the configured hook actions.

Each **session** now owns a `_SessionFireBridge`: a fixed-size `asyncio.Queue` + **one** lazily-started sequential drain task, created on first fire and reused for every subsequent fire. Overflow drops the newest and logs.

## ⚠️ I did NOT copy `hooks/bus.py` — I copied `hooks/ingress.py`. Please review this deviation.

The brief said to mirror `hooks/bus.py`'s bounded-queue. **`bus.py` is the wrong precedent and I did not use it.** It is a **pub/sub broadcast** bus: N per-subscriber queues, the same event handed to every subscriber, **drop-oldest** (bounding *staleness* for a self-paced poller). `external_fire` is **single-consumer dispatch** — there are no subscribers, nothing to broadcast to, and dropping the oldest would discard a hook that is next to run in favor of a newer one.

The precedent that actually fits is **`reyn.hooks.ingress._BoundedEventBridge`** — and it is the one **#2620's own text names**: *"H1 (MCP notifications) and H4 (fs-watcher) already bound their external-event dispatch via a fixed-size `asyncio.Queue` (put_nowait + drop+log on overflow)"*. That is `_BoundedEventBridge`, not `bus.py`. Same fixed-size queue, same `put_nowait`, same **drop-newest**-and-log, same one-drain-task-with-per-event-`try/except`, same `maxsize=32` default. This unifies all four external-event sources on one dispatch model, which is the issue's stated goal.

**What is bound:** *queue depth of pending dispatches per session* (32), which transitively bounds concurrency to **1 in-flight dispatch per session** (one sequential drain task, replacing 1-task-per-fire). Not a rate limit — the ingress fast path is never blocked or slowed, matching `_BoundedEventBridge`.

## Design decision: the two public counters (raised in review, answering explicitly)

`pending_dispatch_count()` / `dropped_dispatch_count()` are public **because `bus.py` already established that a bounded queue in this subsystem exposes its drop counter publicly** — `HookBus.snapshot_drop_counts()` + `subscriber_count`, added by #2886 under the Observability lens ("a drop must never be silent"). A dropped webhook hook is a silently-not-fired side effect; a WARNING log alone is not an inspectable surface. These are snapshot-style copies, not live views into internals — the same shape `snapshot_drop_counts` has. So this is the bus precedent applied where it *does* transfer (observability), even though its queue discipline does not.

Being straight about it: they are also what let the tests observe the bound without asserting private state. If reviewers judge that insufficient standalone justification, the honest alternative is deleting them and asserting on `caplog` — say the word and I'll switch.

## Verification — measured, not inferred

- **Bound measured with real input past the boundary.** N+3 fires (N=4) through the real `WebhookIngressAdapter.to_event` → `fire_and_forget` path in a tight loop with no `await`, so the drain task provably cannot run and every fire is submitted against a genuinely full queue. Observed: `pending == 4`, `dropped == 3`, and exactly **4** hook pushes reach the session's public inbox — the 3 dropped never reached `HookDispatcher` at all. Not a "used a bounded queue so it must be bounded" inference.
- **Tested outside the boundary** (N+3, not N), **plus a negative control at exactly N** that drops nothing — so the test distinguishes "bounded at 4" from "bounded at some smaller N' that also overflows at 7". Without the control, the bound test could pass against a wrong bound.
- **strip-falsify → RED observed, twice.** (1) Against pre-fix `HEAD` (unbounded `create_task`): 3/3 fail. (2) Sharper: kept the whole bridge and flipped only `maxsize=self._maxsize` → `maxsize=0` (unbounded queue) — `assert 7 == 4`, i.e. the assertion fails *on the bound itself*, not on a signature error. Restored, green.
- **Real path**, not a hand-built `create_task` call.

**Disclosure:** mid-work I ran `git checkout --` on the uncommitted implementation and destroyed it (the trap CLAUDE.md warns about). I reconstructed it and re-verified from scratch — the strip-falsify RED/GREEN and every gate below were run against the current tree, not the lost one. A stale diagnostic from that window (`"pending_dispatch_count" is not a known attribute`) reflects the destroyed file, not this PR.

## Test plan

- [x] `ruff check src tests` → **All checks passed**
- [x] `python scripts/test_tier_audit.py --strict tests/test_2620_bound_webhook_fire_and_forget.py` → **3 OK, 0 Tier-4 violations**
- [x] `pytest` (repo root) → **8653 passed, 25 skipped**, exit 0
- [x] `python scripts/verify_module_docstrings.py src/reyn/hooks/external_fire.py` → **OK**
- [x] strip-falsify RED observed then restored (both variants above)
- [x] Pre-existing `test_2608_h5_cron_webhook_hooks.py` + `test_hook_event_ingress_adapter_0059_phase2.py` (22 tests) still green — no behavior change on the non-flood path

## Docs

No doc change: `docs/` describes the hook points and their config surface, not `fire_and_forget`'s scheduling internals — no doc's claim becomes false. The mechanism is documented in the module docstring, which is where the pre-existing `create_task` description lived. Grepped `external_fire`/`fire_and_forget` across `docs/` — no hits. Flag if you'd rather this land in a doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)