### PR TITLE
feat: carry content_type/mimeType to present's stage-3 as a renderer-only sidecar

### DIFF
--- a/docs/reference/runtime/present.md
+++ b/docs/reference/runtime/present.md
@@ -116,9 +116,18 @@ hot-reloads at the turn boundary. Full field table + merge order:
 Resolution degrades until something renders (never a hard error):
 
 1. **Registered `view`** → 2. **inline `blueprint`** → 3. **default viewer**
-(synthesized from data shape: `list[dict]` → `table`, `dict` → `keyvalue`, scalar →
-`text`, diff-sniff → `diff`) → 4. **generic** (structured → YAML into `text`, plain text
-as-is — always renders).
+(a recognition ladder: **declared content-type** → diff-sniff → data shape — a
+markdown/code type → `markdown`/`code`; else `list[dict]` → `table`, `dict` →
+`keyvalue`, scalar → `text`, diff-sniff → `diff`) → 4. **generic** (structured →
+YAML into `text`, plain text as-is — always renders).
+
+The declared-content-type step is populated for a `data_ref` source whose canonical
+tool-result producer declared a `content_type`/`mimeType` — carried from the offload
+producer to here as a **renderer-only sidecar** (never the LLM-visible tool-result
+frontmatter): the producer's declared type drives the offload store's `mime_type`
+(the on-disk ref extension), and `present` recovers it back from that extension when
+resolving the ref. Inline data (`data_inline`) has no content-type source and always
+degrades straight to diff-sniff → shape, unchanged.
 
 The fallback fires on an all-miss view or an unknown view name. The ack reports the
 **requested** view's stats plus a `note` naming the stage that actually rendered.

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -65,12 +65,24 @@ from typing import Any, Callable, TypedDict
 
 
 class CanonicalToolResult(TypedDict, total=False):
-    """The single shape all tool results are normalized to before offload (see module docstring)."""
+    """The single shape all tool results are normalized to before offload (see module docstring).
+
+    ``content_type`` (#2663) — the RENDERER sidecar, not an LLM-next-action signal: a mapper's
+    optional declaration of ``text``'s MIME type (e.g. ``"text/html"``, ``"text/markdown"``) when the
+    producer genuinely knows it (an HTTP ``Content-Type`` header, a file extension). It is carried
+    ONLY as far as the offload store's ``mime_type`` (which already drives the on-disk file
+    extension for images — #385 — this reuses that exact existing channel for text, nothing new
+    invented) so present's stage-3 default viewer can later derive it back from the ref's extension
+    (``reyn.data.workspace.media_store.mime_type_for_ext``). It never reaches ``meta``/the frontmatter
+    (``seam.py``'s ``build_offload_body`` does not read it into ``frontmatter``) and never reaches
+    ``canonical_to_ctx_fields`` — it is dropped there exactly like ``text``/``source_ref`` themselves,
+    a producer-to-renderer channel only, never a pipeline-ctx or LLM-visible field."""
 
     text: str
     attachments: list[dict]
     source_ref: "dict | None"
     meta: dict
+    content_type: "str | None"
 
 
 # A canonical mapper: an invoked producer's raw result dict → the canonical shape.
@@ -380,8 +392,11 @@ def mcp_get_prompt_to_canonical(result: dict) -> CanonicalToolResult:
 def web_fetch_to_canonical(result: dict) -> CanonicalToolResult:
     """web_fetch result → canonical. The fetched page text (``content``, or the op's own ``preview``
     when it pre-offloaded to a ``path_ref``) → ``text``. Signal meta: ``truncated`` + ``next_start``
-    (the LLM's pagination handle) when the fetch was cut. Transport (url/status/content_type/extractor)
-    is dropped."""
+    (the LLM's pagination handle) when the fetch was cut. Transport (url/status/extractor) is dropped
+    from ``meta`` — but ``content_type`` (the HTTP response's declared MIME type, e.g.
+    ``"text/html"``) is carried on the RENDERER-only ``content_type`` sidecar (#2663), never into
+    ``meta``/the frontmatter, so present's stage-3 default viewer can pick a markdown/code default
+    for the offloaded body without the LLM-visible frontmatter growing a transport field."""
     content = result.get("content")
     text = content if content else str(result.get("preview") or "")
     text = _explicit_empty(text, "(no content)")
@@ -391,7 +406,16 @@ def web_fetch_to_canonical(result: dict) -> CanonicalToolResult:
         next_start = result.get("next_start")
         if next_start is not None:
             meta["next_start"] = next_start
-    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+    # Only declare content_type for the RAW fetched body (``extractor: "none"``) — an
+    # HTML page run through the trafilatura/stdlib extractor becomes plain readable
+    # text, no longer HTML, so echoing the original ``text/html`` header here would be
+    # a stale/misleading declaration for that (different) body.
+    content_type = (
+        result.get("content_type") or None if result.get("extractor") == "none" else None
+    )
+    return CanonicalToolResult(
+        text=text, attachments=[], source_ref=None, meta=meta, content_type=content_type,
+    )
 
 
 def web_search_to_canonical(result: dict) -> CanonicalToolResult:

--- a/src/reyn/core/offload/seam.py
+++ b/src/reyn/core/offload/seam.py
@@ -49,13 +49,18 @@ def build_offload_body(
     *,
     save_fn: "Callable[..., dict] | None" = None,
     enabled: bool = True,
-) -> tuple[dict, str, list[dict]]:
-    """Return ``(frontmatter, text, media_blocks)`` for a canonical tool result.
+) -> tuple[dict, str, list[dict], "str | None"]:
+    """Return ``(frontmatter, text, media_blocks, content_type)`` for a canonical tool result.
 
     ``frontmatter`` = the signal meta + the structured data (inline when small, or ``structured_ref`` +
     ``structured_preview`` when large and a ``save_fn`` is available). Empty ``{}`` when there is
     nothing but plain text. ``text`` = the (uncapped) body the caller then caps + assembles via
     :func:`render_tool_result`. ``media_blocks`` = the raw media blocks for the vision follow-up.
+    ``content_type`` (#2663) = the canonical's RENDERER-only sidecar (``canonical.get("content_type")``)
+    — deliberately NEVER folded into ``frontmatter`` (that would leak a transport/renderer signal into
+    the LLM-visible ``role: tool`` body); the caller threads it to the ``text`` offload store's
+    ``mime_type`` instead, so present's stage-3 default viewer can later recover it from the stored
+    ref's file extension (the store already does exactly this for images — #385).
 
     ``save_fn`` may be ``None`` (no media store): the format still applies — an oversized structured
     attachment is kept INLINE (it cannot be offloaded without a store) rather than dropped.
@@ -94,7 +99,7 @@ def build_offload_body(
         else:
             frontmatter["structured"] = combined
 
-    return frontmatter, canonical.get("text", "") or "", media_blocks
+    return frontmatter, canonical.get("text", "") or "", media_blocks, canonical.get("content_type")
 
 
 def render_tool_result(frontmatter: dict, text: str) -> str:

--- a/src/reyn/core/op_runtime/present.py
+++ b/src/reyn/core/op_runtime/present.py
@@ -161,7 +161,7 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     #    → status="denied"; the read-authority-equivalence invariant).
     if op.data_ref is not None:
         try:
-            data, ingested = await resolve_present_source(op.data_ref, ctx)
+            data, ingested, content_type = await resolve_present_source(op.data_ref, ctx)
         except PresentSourceNotFound as exc:
             return {
                 "kind": "present", "status": "not_found",
@@ -170,8 +170,11 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
         data_ref_field: str = op.data_ref
     else:
         # Inline data is in the LLM's context by construction → ingested "full".
+        # No content-type source exists for inline data (a present op has no
+        # content-type field) — stage 3 degrades to diff-sniff → shape, unchanged.
         data = op.data_inline
         ingested = "full"
+        content_type = None
         data_ref_field = _INLINE_MARKER
 
     mode = _mode(op)
@@ -186,6 +189,7 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
     try:
         requested, rendered, fallback_stage = _resolve_presentation(
             op, data, mode=mode, surface=surface, registry=ctx.presentation_registry,
+            content_type=content_type,
         )
     except PresentBlueprintError as exc:
         return {"kind": "present", "status": "error", "ok": False, "error": str(exc)}
@@ -241,6 +245,7 @@ async def handle(op: PresentIROp, ctx: OpContext) -> dict:
 
 def _resolve_presentation(
     op: PresentIROp, data: Any, *, mode: str, surface: str, registry: Any,
+    content_type: "str | None" = None,
 ) -> "tuple[ResolvedPresentation | None, ResolvedPresentation, str | None]":
     """Run the FP-0054 §3 4-stage view-source fallback chain (FP-0055 PR-1:
     ``mode="default"`` skips straight to stage 3).
@@ -266,6 +271,12 @@ def _resolve_presentation(
     a fallback trigger) — the caller surfaces ``status="error"``. A registered
     view is already validated at registry-build time, so it never re-validates
     here.
+
+    ``content_type`` (#2663) — the ``data_ref``'s declared MIME type (recovered from
+    the stored ref's extension by :func:`resolve_present_source`; ``None`` for
+    inline data or an untyped/legacy ref) — passed to stage 3's
+    ``default_viewer_blueprint`` so a known markdown/code ref defaults to a rich
+    ``markdown``/``code`` component instead of diff-sniff → shape.
     """
     # ``op.data_ref`` (None for inline data) is threaded through to
     # ``resolve_bindings`` so a `cap_rows`-capped table/list node's visible
@@ -291,7 +302,8 @@ def _resolve_presentation(
 
     # Stage 3 — content-type default viewer (synthesized from the data's shape).
     stage3 = resolve_bindings(
-        validate_blueprint(default_viewer_blueprint(data)), data, surface=surface, ref=ref,
+        validate_blueprint(default_viewer_blueprint(data, content_type=content_type)),
+        data, surface=surface, ref=ref,
     )
     if not stage3.all_bindings_missed:
         # In default mode, stage 3 IS the requested rendering — not a fallback.

--- a/src/reyn/core/op_runtime/render_template.py
+++ b/src/reyn/core/op_runtime/render_template.py
@@ -116,7 +116,7 @@ async def _resolve_data(op: Any, ctx: OpContext) -> Any:
     ``file.read`` authority (the same seam ``present`` uses), or ``data_inline``
     verbatim (already in the LLM's context)."""
     if op.data_ref is not None:
-        value, _ingested = await resolve_present_source(op.data_ref, ctx)
+        value, _ingested, _content_type = await resolve_present_source(op.data_ref, ctx)
         return value
     return op.data_inline
 

--- a/src/reyn/core/present/fallback.py
+++ b/src/reyn/core/present/fallback.py
@@ -20,13 +20,17 @@ fresh here.
   **declared content-type → diff-sniff (FP-0051 heuristic) → data shape**.
 
   1. *Declared content-type* — an explicit ``text``/``markdown`` type → a
-     ``markdown`` component; a ``code`` type → a ``code`` component. This stage is
-     populated **only** from inline data / an explicit op arg: a `present` op has no
-     content-type field today, and — verified — an offloaded ``data_ref`` carries no
-     content-type in its frontmatter (the tool-result canonical mappers drop
-     ``content_type`` as transport). So for a ``data_ref`` source ``content_type`` is
-     ``None`` and we fall straight to diff-sniff → shape (an endorsed correct
-     degrade), never reading a content-type that is not there.
+     ``markdown`` component; a ``code`` type → a ``code`` component. A `present`
+     op still has no content-type field itself (inline data always passes
+     ``content_type=None``), but (#2663) a ``data_ref`` source now CAN carry one:
+     a canonical mapper's optional ``content_type`` sidecar (never the LLM-visible
+     frontmatter — see ``offload/canonical.py``'s ``CanonicalToolResult`` docstring)
+     is threaded to the offload store's ``mime_type`` at write time, and
+     ``resolve_present_source`` recovers it back from the stored ref's file
+     extension at read time (``media_store.mime_type_for_ext``). A mapper that
+     declares no ``content_type`` (the common case — most mappers still don't) or a
+     ref that predates #2663 yields ``None`` here, unchanged: falls straight to
+     diff-sniff → shape (still an endorsed correct degrade).
   2. *Diff-sniff* — a string that looks like a unified diff defaults to the ``diff``
      viewer (diff is common and should highlight).
   3. *Shape* — a list of objects → a ``table`` over the union of the first rows'
@@ -70,8 +74,9 @@ _SNIFF_BYTES = 4096
 _DIFF_HUNK_RE = re.compile(r"^@@ .* @@", re.MULTILINE)
 
 # Content-type prefixes that map to the markdown / code default components. Matched
-# case-insensitively against a *declared* content-type only (inline data / explicit
-# op arg) — never derived from an offloaded ``data_ref`` (no content-type there).
+# case-insensitively against a *declared* content-type — inline data has none (always
+# ``None``); a ``data_ref`` source may have one recovered from its stored ref's
+# extension (#2663) when the producing canonical mapper declared it.
 _MARKDOWN_TYPES = ("text/markdown", "text/x-markdown")
 _CODE_TYPE_HINTS = ("application/json", "text/x-", "application/x-", "text/css", "text/html")
 

--- a/src/reyn/core/present/replay.py
+++ b/src/reyn/core/present/replay.py
@@ -104,9 +104,15 @@ def _best_effort_resolved(
     back to. The original inline blueprint is not in the event, so this is the faithful
     best-effort view of the data's shape. ``ref`` (the event's ``data_ref``) threads
     through so a `cap_rows`-capped table/list still carries its §5 visible truncation
-    tail on replay (issue #2669)."""
+    tail on replay (issue #2669), and (#2663) so stage 3 recovers the SAME declared
+    content-type from the ref's extension the live op would (``None`` for
+    ``<inline-data>`` / an untyped ref — unchanged diff-sniff → shape degrade)."""
+    from reyn.data.workspace.media_store import mime_type_for_ext
+
+    content_type = mime_type_for_ext(ref) if ref else None
     stage3 = resolve_bindings(
-        validate_blueprint(default_viewer_blueprint(value)), value, surface=surface, ref=ref,
+        validate_blueprint(default_viewer_blueprint(value, content_type=content_type)),
+        value, surface=surface, ref=ref,
     )
     if not stage3.all_bindings_missed:
         return stage3

--- a/src/reyn/core/present/source.py
+++ b/src/reyn/core/present/source.py
@@ -70,12 +70,22 @@ async def _gate_and_read_ref(ref: str, ctx: "OpContext") -> tuple[bytes, str]:
     return raw_bytes, ingested
 
 
-async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, str]:
+async def resolve_present_source(
+    data_ref: str, ctx: "OpContext",
+) -> "tuple[Any, str, str | None]":
     """Resolve ``data_ref`` to its full value under ``file.read`` authority.
 
-    Returns ``(value, ingested)`` where ``value`` is the re-hydrated structured
-    object (when the ref's bytes parse as JSON) or the decoded text, and
-    ``ingested`` ∈ ``{none, partial, full}`` (OS-computed).
+    Returns ``(value, ingested, content_type)`` where ``value`` is the re-hydrated
+    structured object (when the ref's bytes parse as JSON) or the decoded text,
+    ``ingested`` ∈ ``{none, partial, full}`` (OS-computed), and ``content_type``
+    (#2663) is the ref's declared MIME type recovered from its stored file
+    extension (:func:`~reyn.data.workspace.media_store.mime_type_for_ext`) — the
+    SAME channel a canonical mapper's ``content_type`` sidecar was carried through
+    to at offload-store time (``tool_result_cap.cap_tool_result_content`` /
+    ``MediaStore.save_tool_result``'s ``mime_type``). ``None`` when the extension
+    is absent/unrecognized (the ref predates #2663, or the producer declared no
+    content type) — present's stage-3 default viewer then degrades to
+    diff-sniff → shape exactly as before, unchanged.
 
     Raises ``PermissionError`` when the read is not authorized (identical gate to
     ``file.read``); ``PresentSourceNotFound`` when the path is missing.
@@ -91,7 +101,10 @@ async def resolve_present_source(data_ref: str, ctx: "OpContext") -> tuple[Any, 
     else:
         value = rehydrate_ref_text(text)
 
-    return value, ingested
+    from reyn.data.workspace.media_store import mime_type_for_ext
+
+    content_type = mime_type_for_ext(data_ref)
+    return value, ingested, content_type
 
 
 async def resolve_ref_text(ref: str, ctx: "OpContext") -> tuple[str, str]:

--- a/src/reyn/data/workspace/media_store.py
+++ b/src/reyn/data/workspace/media_store.py
@@ -66,8 +66,11 @@ from reyn.services.offload.store import offload_value, read_offloaded
 
 # Conservative mapping from MIME type to file extension; unknown types
 # fall back to ``""`` so the storage layer still writes a file (= user
-# can rename / inspect with their preferred tool). Extension is purely
-# for explorability — it isn't used by the lookup path.
+# can rename / inspect with their preferred tool). Extension was purely
+# for explorability originally — #2663 additionally reuses it as the
+# read-side recovery channel (:func:`mime_type_for_ext`) so present's
+# stage-3 default viewer can recover a ``data_ref``'s declared content type
+# from the stored ref's extension, without any new sidecar field.
 _MIME_TO_EXT: dict[str, str] = {
     "image/png": ".png",
     "image/jpeg": ".jpg",
@@ -81,6 +84,10 @@ _MIME_TO_EXT: dict[str, str] = {
     "application/xml": ".xml",
 }
 
+# The reverse of ``_MIME_TO_EXT`` (built once, module load) — ``.txt``/``.json``
+# collide with no other extension so the mapping is unambiguous either direction.
+_EXT_TO_MIME: dict[str, str] = {ext: mime for mime, ext in _MIME_TO_EXT.items()}
+
 
 def _ext_for_mime(mime: str) -> str:
     """Return the file extension (with leading dot) for ``mime``.
@@ -90,6 +97,17 @@ def _ext_for_mime(mime: str) -> str:
     """
     base = mime.split(";", 1)[0].strip().lower() if mime else ""
     return _MIME_TO_EXT.get(base, "")
+
+
+def mime_type_for_ext(path: str) -> "str | None":
+    """Return the declared MIME type for a stored ref's file extension, or ``None``
+    when the extension is unknown/absent (#2663 — the read-side counterpart of
+    :func:`_ext_for_mime`, the write-side lookup ``save_tool_result``'s ``mime_type``
+    already drives). This is the ONLY channel present's stage-3 default viewer uses to
+    recover a ``data_ref``'s content type — no separate sidecar metadata file is written;
+    the extension IS the sidecar, already persisted by the existing store write path."""
+    suffix = Path(path).suffix.lower()
+    return _EXT_TO_MIME.get(suffix)
 
 
 def _safe_token(value: str) -> str:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3225,7 +3225,7 @@ class RouterLoop:
                         text = _cap(text_full) if _cap is not None else text_full
                         content_str = f"Error: {text}"
                     else:
-                        frontmatter, text, built_media = build_offload_body(
+                        frontmatter, text, built_media, content_type = build_offload_body(
                             canonical, save_fn=_save_fn,
                             # opt-in flip: a host with no ``offload_enabled`` attribute
                             # (legacy/test double) falls closed — offload stays off.
@@ -3279,7 +3279,11 @@ class RouterLoop:
                         # injection cannot hide past the size cap.
                         scan_target = render_tool_result(frontmatter, text)
                         if _cap is not None:
-                            text = _cap(text)
+                            # #2663: thread the canonical's renderer-only content_type through to the
+                            # text offload store as its mime_type — NEVER into frontmatter (built
+                            # above, already sealed) — so a later present(data_ref=<this ref>) can
+                            # recover it from the stored ref's file extension.
+                            text = _cap(text, content_type=content_type)
                         content_str = render_tool_result(frontmatter, text)
             if post_text:
                 content_str = f"{content_str}\n\n---\n{post_text}"

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -173,13 +173,18 @@ class ContextBudgetAdvisor:
         from reyn.runtime.services.tool_result_cap import compute_cap_tokens
         return compute_cap_tokens(self._get_effective_trigger())
 
-    def cap_tool_result(self, content_str: str) -> str:
+    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
         """Cap an oversized chat tool result (#1128 size axis).
 
         No-op when no media_store is configured, or when ``offload.enabled: false``
         (tool-result-schema-redesign §5 debug lever — never truncate). ``content_str``
         is the canonical ``text`` body (#2425 案B) — already the clean payload, so the
         stored body is it as-is and the inline is a bounded plain-text preview.
+
+        ``content_type`` (#2663) — the canonical's renderer-only sidecar (a mapper's declared MIME
+        type, e.g. ``"text/html"``); forwarded to the store's ``mime_type`` so the offloaded ref's
+        on-disk extension carries it (never into any LLM-visible field — this only ever reaches the
+        store, never the frontmatter this method's caller builds separately).
         """
         if not self._offload_config.enabled:
             return content_str
@@ -196,6 +201,7 @@ class ContextBudgetAdvisor:
             save_fn=store.save_tool_result,
             use_chars4=use_chars4,
             events=self._events,
+            content_type=content_type,
         )
 
     def media_followup_budget(self, tool_content: str) -> "int | None":

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -581,18 +581,18 @@ class RouterHostAdapter:
 
     # --- RouterLoopHost identity attributes ---
 
-    def cap_tool_result(self, content_str: str) -> str:
+    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
         """#1128 size axis: cap an oversized tool-result string at the
         router_loop chokepoint. Delegates to the session-supplied callable
         (which offloads the full body via the #385 store + returns a bounded
         plain-text preview); identity when no capper was wired.
 
         #2425 案B: caps the canonical ``text`` body (already the clean payload) — a single string,
-        no clean-payload kwargs.
-        """
+        no clean-payload kwargs. ``content_type`` (#2663) is the canonical's renderer-only sidecar,
+        forwarded to the session capper unchanged (identity path ignores it — nothing to store)."""
         if self._cap_tool_result is None:
             return content_str
-        return self._cap_tool_result(content_str)
+        return self._cap_tool_result(content_str, content_type=content_type)
 
     def media_followup_budget(self, tool_content: str) -> int | None:
         """#272 media axis: tokens left for a tool turn's media follow-up after

--- a/src/reyn/runtime/services/tool_result_cap.py
+++ b/src/reyn/runtime/services/tool_result_cap.py
@@ -70,6 +70,7 @@ def cap_tool_result_content(
     save_fn: Callable[..., dict],
     use_chars4: bool = False,
     events: Any = None,
+    content_type: "str | None" = None,
 ) -> str:
     """Return *content_str* unchanged if within the cap, else its offloaded plain-text preview.
 
@@ -91,6 +92,11 @@ def cap_tool_result_content(
                       ``effective_trigger`` budget the cap is derived from.
         events:       Optional EventLog; a ``tool_result_offloaded`` audit event
                       is emitted on offload (P6).
+        content_type: (#2663) The canonical producer's declared MIME type (renderer-only sidecar,
+                      e.g. ``"text/html"``), forwarded to ``save_fn``'s ``mime_type`` so the stored
+                      ref's on-disk extension carries it (``None`` → the store's own
+                      ``"text/plain"`` default, unchanged behaviour). Never read into ``content_str``
+                      or any LLM-visible output of this function.
 
     Returns:
         The original string when ``estimate_tokens(content_str) <= cap_tokens``;
@@ -103,7 +109,10 @@ def cap_tool_result_content(
     if estimate_tokens(content_str, model, use_chars4=use_chars4) <= cap_tokens:
         return content_str
 
-    block = save_fn(content_str)
+    if content_type:
+        block = save_fn(content_str, mime_type=content_type)
+    else:
+        block = save_fn(content_str)
     preview_source = content_str
     ref = block.get("path", "")
     content_hash = block.get("content_hash", "")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6731,12 +6731,14 @@ class Session:
 
     # --- RouterLoop orchestration ---
 
-    def _cap_tool_result(self, content_str: str) -> str:
+    def _cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
         """Forwarding → ContextBudgetAdvisor.cap_tool_result (PR-1).
 
         #2425 案B: the router chokepoint caps the canonical ``text`` body (already the clean payload),
-        so the capper takes a single string — no clean-payload kwargs."""
-        return self._budget_advisor.cap_tool_result(content_str)
+        so the capper takes a single string — no clean-payload kwargs. ``content_type`` (#2663) is the
+        canonical's renderer-only sidecar, forwarded so an offloaded ref's on-disk extension carries it
+        for present's stage-3 default viewer — never read into any LLM-visible field here."""
+        return self._budget_advisor.cap_tool_result(content_str, content_type=content_type)
 
     def _media_followup_budget(self, tool_content: str) -> "int | None":
         """Forwarding → ContextBudgetAdvisor.media_followup_budget (PR-1)."""

--- a/tests/test_2425_offload_seam.py
+++ b/tests/test_2425_offload_seam.py
@@ -33,7 +33,7 @@ def test_large_structured_is_offloaded_to_own_ref_not_competing_with_text():
         "content": "the body text",
         "structured": {"rows": ["x" * 3000]},  # large → its own ref
     }, source="mcp")
-    frontmatter, text, media = build_offload_body(canonical, save_fn=_fake_save)
+    frontmatter, text, media, _ct = build_offload_body(canonical, save_fn=_fake_save)
 
     assert text == "the body text", "text is the body payload the caller caps"
     assert frontmatter.get("structured") == "offloaded", "the large structured is offloaded"
@@ -48,7 +48,7 @@ def test_small_structured_stays_inline():
     _fake_save.stored = []
     canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
                               "content": "hi", "structured": {"n": 1}}, source="mcp")
-    frontmatter, _text, _media = build_offload_body(canonical, save_fn=_fake_save)
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
     assert frontmatter.get("structured") == {"n": 1}, "small structured stays inline"
     assert _fake_save.stored == [], "no offload for a small structured"
 
@@ -58,7 +58,7 @@ def test_structured_stays_inline_without_a_store():
     offloaded, so it is kept INLINE (never dropped); the frontmatter format still applies."""
     canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
                               "content": "hi", "structured": {"rows": ["x" * 3000]}}, source="mcp")
-    frontmatter, _text, _media = build_offload_body(canonical, save_fn=None)
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=None)
     assert frontmatter.get("structured") == {"rows": ["x" * 3000]}, "kept inline with no store"
 
 
@@ -68,14 +68,14 @@ def test_media_blocks_returned_for_followup_not_in_body():
     _fake_save.stored = []
     canonical = to_canonical({"kind": "mcp", "status": "ok", "server": "s", "tool": "t",
                               "content": "hi", "media_blocks": [{"type": "image", "data": "b64"}]}, source="mcp")
-    frontmatter, _text, media = build_offload_body(canonical, save_fn=_fake_save)
+    frontmatter, _text, media, _ct = build_offload_body(canonical, save_fn=_fake_save)
     assert media == [{"type": "image", "data": "b64"}], "media returned for the vision follow-up"
     assert "structured" not in frontmatter, "media is not left in the tool-message body"
 
 
 def test_render_plain_text_when_no_frontmatter():
     """Tier 1: no structured/signal-meta → the LLM-visible content is the plain text (no wrapper)."""
-    frontmatter, text, _media = build_offload_body(
+    frontmatter, text, _media, _ct = build_offload_body(
         to_canonical({"kind": "mcp", "status": "ok", "content": "just text", "media_blocks": []}, source="mcp"),
         save_fn=_fake_save,
     )
@@ -85,7 +85,7 @@ def test_render_plain_text_when_no_frontmatter():
 def test_render_frontmatter_then_text_is_parseable_yaml():
     """Tier 1: structured/signal-meta present → a ``---``-delimited YAML frontmatter block precedes the
     text body, and the block parses back to the structured data (no exact-whitespace pin)."""
-    frontmatter, text, _media = build_offload_body(
+    frontmatter, text, _media, _ct = build_offload_body(
         to_canonical({"kind": "sandboxed_exec", "status": "error", "returncode": 3,
                       "stdout": "the output", "stderr": ""}, source="sandboxed_exec"),
         save_fn=_fake_save,

--- a/tests/test_2425_step1c_chat_chokepoint.py
+++ b/tests/test_2425_step1c_chat_chokepoint.py
@@ -36,12 +36,12 @@ class _CapHost:
     def __init__(self, store: "MediaStore | None") -> None:
         self.media_store = store
 
-    def cap_tool_result(self, content_str: str) -> str:
+    def cap_tool_result(self, content_str: str, *, content_type: "str | None" = None) -> str:
         if self.media_store is None:
             return content_str
         return cap_tool_result_content(
             content_str, cap_tokens=100, model=_MODEL, save_fn=self.media_store.save_tool_result,
-            use_chars4=True,
+            use_chars4=True, content_type=content_type,
         )
 
     def media_followup_budget(self, _content_str: str) -> int:

--- a/tests/test_2663_present_content_type_sidecar.py
+++ b/tests/test_2663_present_content_type_sidecar.py
@@ -1,0 +1,234 @@
+"""#2663 — carry content_type/mimeType from an offload producer to present's stage-3 default
+viewer, as a RENDERER-only sidecar that never reaches the LLM-visible frontmatter.
+
+The chain (real components throughout, no collaborator mocks):
+
+  canonical mapper (``content_type`` sidecar on ``CanonicalToolResult``, #2663)
+    -> ``build_offload_body`` (returns it as a 4th tuple element, NEVER folds it into
+       ``frontmatter`` — that would leak a renderer/transport signal into the LLM's
+       ``role: tool`` body)
+    -> ``cap_tool_result_content`` (forwards it to the store's ``mime_type``, so the
+       offloaded ref's ON-DISK EXTENSION carries it — reusing the #385 image-store
+       mechanism verbatim, no new sidecar field/file)
+    -> ``resolve_present_source`` (recovers it back from the ref's extension via
+       ``media_store.mime_type_for_ext``)
+    -> ``default_viewer_blueprint`` (stage 3: a declared markdown/code type defaults to
+       a rich ``markdown``/``code`` component instead of diff-sniff -> shape).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.core.offload.canonical import to_canonical
+from reyn.core.offload.seam import build_offload_body
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.present import handle
+from reyn.core.present.source import resolve_present_source
+from reyn.data.workspace.media_store import MediaStore, mime_type_for_ext
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.services.tool_result_cap import cap_tool_result_content
+from reyn.schemas.models import PresentIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+_MODEL = "gpt-4o"
+
+
+def _resolver(tmp_path: Path) -> PermissionResolver:
+    return PermissionResolver(config_permissions={}, project_root=tmp_path, interactive=False)
+
+
+def _ctx(tmp_path: Path) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    resolver = _resolver(tmp_path)
+    ws = Workspace(events=events, permission_resolver=resolver)
+    ctx = OpContext(
+        workspace=ws, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="present_2663_test",
+    )
+    return ctx, events
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class _RecordingRenderer:
+    """Real (non-mock) PresentationRenderer recording what reached the surface."""
+
+    surface_name = "inline-cui"
+
+    def __init__(self) -> None:
+        self.rendered: list = []
+
+    def render(self, resolved) -> None:
+        self.rendered.append(resolved)
+
+
+# ── Tier 1: canonical mapper declares content_type (renderer sidecar only) ───
+
+
+def test_web_fetch_raw_body_declares_content_type():
+    """Tier 1: a RAW (non-extracted) web_fetch body carries the HTTP content_type as the
+    canonical's renderer-only sidecar."""
+    c = to_canonical({
+        "kind": "web_fetch", "url": "http://x", "status": "ok",
+        "content": "# Title\n\nbody", "content_type": "text/markdown", "extractor": "none",
+    }, source="web_fetch")
+    assert c.get("content_type") == "text/markdown"
+
+
+def test_web_fetch_extracted_html_does_not_declare_content_type():
+    """Tier 1: an HTML page run through the trafilatura/stdlib extractor becomes plain
+    readable text (no longer HTML) — the original ``text/html`` header must NOT be
+    echoed as the extracted text's content_type (it would be a stale/misleading
+    declaration for a different body)."""
+    c = to_canonical({
+        "kind": "web_fetch", "url": "http://x", "status": "ok",
+        "content": "Title\n\nbody", "content_type": "text/html", "extractor": "trafilatura",
+    }, source="web_fetch")
+    assert c.get("content_type") is None
+
+
+def test_web_fetch_content_type_absent_when_source_has_none():
+    """Tier 1: falsify direction — no content_type on the raw result -> None (not KeyError,
+    not an empty-string false-positive)."""
+    c = to_canonical({
+        "kind": "web_fetch", "url": "http://x", "status": "ok",
+        "content": "text", "extractor": "none",
+    }, source="web_fetch")
+    assert c.get("content_type") is None
+
+
+# ── Tier 1: build_offload_body never leaks content_type into the LLM-visible frontmatter ──
+
+
+def test_build_offload_body_returns_content_type_but_never_in_frontmatter():
+    """Tier 1: CORE — content_type is returned as its own tuple element, and is bound-out
+    of frontmatter/meta entirely — the whole point of #2663's sidecar design (it must
+    never reach the LLM's ``role: tool`` YAML frontmatter)."""
+    canonical = to_canonical({
+        "kind": "web_fetch", "url": "http://x", "status": "ok",
+        "content": "raw body", "content_type": "text/markdown", "extractor": "none",
+        "truncated": True, "next_start": 10,
+    }, source="web_fetch")
+    frontmatter, text, _media, content_type = build_offload_body(canonical, save_fn=None)
+
+    assert content_type == "text/markdown"
+    assert text == "raw body"
+    # Strip-falsify anchor: meta (truncated/next_start) DOES reach frontmatter (existing
+    # signal channel) while content_type (renderer-only) explicitly does not.
+    assert frontmatter.get("truncated") is True
+    assert "content_type" not in frontmatter
+    assert "content_type" not in str(frontmatter), "content_type must not leak anywhere in the YAML frontmatter dict"
+
+
+def test_build_offload_body_content_type_none_when_mapper_declares_none():
+    """Tier 1: falsify direction — a mapper/result with no content_type -> the 4th tuple
+    element is None (identity), not a missing-key crash."""
+    canonical = to_canonical({
+        "kind": "mcp", "status": "ok", "server": "s", "tool": "t", "content": "hi",
+    }, source="mcp")
+    _fm, _text, _media, content_type = build_offload_body(canonical, save_fn=None)
+    assert content_type is None
+
+
+# ── Tier 2: cap_tool_result_content forwards content_type to the store's mime_type ──
+
+
+def test_cap_tool_result_content_type_drives_stored_ref_extension(tmp_path: Path) -> None:
+    """Tier 2: OS invariant — an oversized body offloaded WITH a declared content_type is
+    stored under an extension matching that type (real MediaStore, no fake collaborator);
+    with content_type=None the store's existing text/plain default (``.txt``) is unchanged.
+    """
+    store = MediaStore(project_root=tmp_path)
+    big = "# Title\n\n" + ("word " * 20_000)
+
+    out_md = cap_tool_result_content(
+        big, cap_tokens=64, model=_MODEL, save_fn=store.save_tool_result,
+        use_chars4=True, content_type="text/markdown",
+    )
+    ref_md = _ref_from(out_md)
+    assert ref_md.endswith(".md"), f"declared text/markdown must drive a .md ref, got {ref_md}"
+
+    out_plain = cap_tool_result_content(
+        big, cap_tokens=64, model=_MODEL, save_fn=store.save_tool_result,
+        use_chars4=True, content_type=None,
+    )
+    ref_plain = _ref_from(out_plain)
+    assert ref_plain.endswith(".txt"), "no declared content_type -> unchanged .txt default"
+
+
+def _ref_from(preview: str) -> str:
+    import re
+    m = re.search(r'file__read\(path="([^"]+)"\)', preview)
+    assert m, f"preview must name a file__read read-back path: {preview[:200]!r}"
+    return m.group(1)
+
+
+# ── Tier 2: media_store.mime_type_for_ext round-trips a non-default value ───
+
+
+def test_mime_type_for_ext_roundtrips_markdown_and_rejects_unknown():
+    """Tier 2: round-trip a NON-default MIME type (text/markdown, not the text/plain
+    default) through the write-side extension table and the read-side reverse lookup;
+    an unrecognized/absent extension yields None (safe degrade, not a crash/guess)."""
+    assert mime_type_for_ext("a/b/2026-tool-1.md") == "text/markdown"
+    assert mime_type_for_ext("a/b/2026-tool-1.txt") == "text/plain"
+    assert mime_type_for_ext("a/b/2026-tool-1.unknownext") is None
+    assert mime_type_for_ext("a/b/no_extension_at_all") is None
+
+
+# ── Tier 2: end-to-end wiring — present(data_ref=...) picks the declared-type default ──
+
+
+def test_present_data_ref_defaults_to_markdown_when_ref_carries_markdown_type(
+    tmp_path: Path, monkeypatch: "object",
+) -> None:
+    """Tier 2: OS invariant — WIRING PROOF. A ref stored with ``mime_type="text/markdown"``
+    (the real store write-path #2663 threads content_type through) resolves through the
+    real ``present`` op (mode="default", no view/blueprint) to a ``markdown`` component —
+    not the generic ``text`` stage-3 default a same-shaped untyped ref would get.
+    Strip-falsify: an identical body stored WITHOUT a declared type renders as ``text``,
+    proving the markdown default came from the declared type, not the data's shape."""
+    monkeypatch.chdir(tmp_path)
+    store = MediaStore(project_root=tmp_path)
+    body = "# Heading\n\nSome *emphasis* text."
+
+    md_block = store.save_tool_result(body, mime_type="text/markdown", tool="t", seq=1)
+    plain_block = store.save_tool_result(body, mime_type="text/plain", tool="t", seq=2)
+
+    ctx, _events = _ctx(tmp_path)
+    renderer = _RecordingRenderer()
+    ctx.presentation_renderer = renderer
+
+    md_op = PresentIROp(kind="present", data_ref=md_block["path"])
+    ack = _run(handle(md_op, ctx))
+    assert ack["status"] == "ok"
+    assert renderer.rendered, "renderer must have received the resolved presentation"
+    md_components = [n.get("component") for n in renderer.rendered[-1].nodes]
+    assert "markdown" in md_components, f"declared text/markdown ref must default to markdown, got {md_components}"
+
+    plain_op = PresentIROp(kind="present", data_ref=plain_block["path"])
+    _run(handle(plain_op, ctx))
+    plain_components = [n.get("component") for n in renderer.rendered[-1].nodes]
+    assert plain_components == ["text"], (
+        f"an identical body with NO declared markdown type must still default to text "
+        f"(falsifies that the markdown default is shape-derived, not type-derived); got {plain_components}"
+    )
+
+
+def test_resolve_present_source_recovers_content_type_from_stored_ref(
+    tmp_path: Path, monkeypatch: "object",
+) -> None:
+    """Tier 2: resolve_present_source's 3rd return value recovers the content_type a
+    producer declared at store time, purely from the ref's on-disk extension — the
+    read-side half of the #2663 sidecar (no separate metadata file)."""
+    monkeypatch.chdir(tmp_path)
+    store = MediaStore(project_root=tmp_path)
+    block = store.save_tool_result("code here", mime_type="application/json", tool="t", seq=1)
+
+    ctx, _events = _ctx(tmp_path)
+    _value, _ingested, content_type = _run(resolve_present_source(block["path"], ctx))
+    assert content_type == "application/json"

--- a/tests/test_fp0056_file_reyn_repo_canonical.py
+++ b/tests/test_fp0056_file_reyn_repo_canonical.py
@@ -158,7 +158,7 @@ def test_file_glob_large_match_list_offloads_smaller_than_old_text_shape():
     """
     def _rendered_char_count(canonical: dict) -> int:
         _fake_save.stored = []
-        frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+        frontmatter, text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
         return len(render_tool_result(frontmatter, text))
 
     def _old_shape(n: int) -> int:

--- a/tests/test_fp0056_file_reyn_repo_canonical.py
+++ b/tests/test_fp0056_file_reyn_repo_canonical.py
@@ -53,7 +53,7 @@ def test_incident_file_read_offloads_clean_text_not_whole_dict_blob():
         "no whole-dict structured attachment — the incident's blob is gone"
 
     _fake_save.stored = []
-    frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+    frontmatter, text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
     assert text == _BIG_DOC, "the readable body is the text stream the LLM reads"
     assert "structured" not in frontmatter and "structured_ref" not in frontmatter, \
         "no structured ref/preview — the 600-char JSON-dict preview the agent saw is gone"
@@ -69,7 +69,7 @@ def test_incident_reyn_repo_read_offloads_clean_text_not_whole_dict_blob():
     assert not any(a.get("kind") == "structured" for a in canonical["attachments"])
 
     _fake_save.stored = []
-    frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+    frontmatter, text, _media, _ct = build_offload_body(canonical, save_fn=_fake_save)
     assert text == _BIG_DOC
     assert "structured" not in frontmatter and "structured_ref" not in frontmatter
 

--- a/tests/test_offload_config_gate_pr3.py
+++ b/tests/test_offload_config_gate_pr3.py
@@ -114,7 +114,7 @@ def test_offload_disabled_default_keeps_oversized_structured_inline():
         raise AssertionError("save_fn must not be called when offload is disabled")
 
     canonical = {"text": "", "attachments": [{"kind": "structured", "data": big}], "meta": {}}
-    frontmatter, _text, _media = build_offload_body(canonical, save_fn=_save_fn, enabled=False)
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=_save_fn, enabled=False)
     assert frontmatter["structured"] == big
     assert "structured_ref" not in frontmatter
 
@@ -133,7 +133,7 @@ def test_offload_enabled_opted_in_offloads_oversized_structured():
         return {"path": "/tmp/fake-structured-ref.json"}
 
     canonical = {"text": "", "attachments": [{"kind": "structured", "data": big}], "meta": {}}
-    frontmatter, _text, _media = build_offload_body(canonical, save_fn=_save_fn, enabled=True)
+    frontmatter, _text, _media, _ct = build_offload_body(canonical, save_fn=_save_fn, enabled=True)
     assert frontmatter["structured"] == "offloaded"
     assert frontmatter["structured_ref"] == "/tmp/fake-structured-ref.json"
     assert saved["tool"] == "structured"


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2663

## Summary

Implements the sidecar-field design already ratified in #2663: an offload producer's declared `content_type`/`mimeType` (e.g. an HTTP response's `Content-Type`) now reaches present's stage-3 default viewer, so a `data_ref` known to be markdown/code defaults to a rich `markdown`/`code` component instead of diff-sniff → shape — WITHOUT the type ever reaching the LLM-visible tool-result frontmatter.

## Design-still-valid check (per dispatch brief)

Before implementing, I verified the issue's design against tonight's changes:
- **#2966** (`canonical_to_ctx_fields` exposing `meta`) does **not** conflict — `meta` is proven (via `offload/seam.py`'s `build_offload_body`, line ~78) to ALSO feed the LLM-visible `role: tool` frontmatter, so it is not a present-only channel and stuffing `content_type` into it would violate the issue's explicit "never LLM-visible" requirement. I introduced a **separate** `content_type` field on `CanonicalToolResult`, kept fully out of `meta`/frontmatter.
- **The rumored in-flight PR adding a `glob` `structured` attachment to `canonical.py`**: I checked `gh pr list --state open` and found no such PR — only #2988/#2989, neither touching `canonical.py`/glob. This appears to be stale/superseded information; no merge-conflict risk found at time of this PR.

## Mechanism (reuses an existing channel, invents nothing new)

`MediaStore.save_tool_result`'s `mime_type` param has **always** driven the on-disk file extension (`_ext_for_mime`) for images (#385) — this PR reuses that exact mechanism for tool-result text:

1. `canonical.py`: `CanonicalToolResult.content_type` (optional). `web_fetch_to_canonical` populates it from the raw HTTP content-type, but **only** for the raw (non-extracted) body (`extractor == "none"`) — an HTML page run through trafilatura/stdlib is no longer HTML once extracted, so echoing `text/html` for that body would be a stale/misleading declaration.
2. `seam.py`: `build_offload_body` returns `content_type` as a 4th tuple element, never folded into `frontmatter`.
3. `router_loop.py` → `session.py` → `router_host_adapter.py` → `context_budget_advisor.py` → `tool_result_cap.py`: `content_type` threads through as an optional kwarg down to `cap_tool_result_content`, which forwards it to `save_fn`'s `mime_type` when present (identity/`text/plain` default otherwise — no behavior change for untyped producers).
4. `media_store.py`: new `mime_type_for_ext()` — the reverse of the existing `_ext_for_mime` table (built once at import).
5. `present/source.py`: `resolve_present_source` now returns `(value, ingested, content_type)`, recovering `content_type` from the ref's stored extension.
6. `op_runtime/present.py` / `present/fallback.py` / `present/replay.py`: `content_type` threads to `default_viewer_blueprint`, including the replay re-render path (derives it fresh from the recorded `data_ref`'s extension, for parity with the live op).

## Verification

- **Strip-falsify** (production code, not test doubles): reverted the `content_type=content_type` argument at the `op_runtime/present.py` call site → the new wiring test (`test_present_data_ref_defaults_to_markdown_when_ref_carries_markdown_type`) went RED (`assert 'markdown' in ['text']` failed) → restored → GREEN. Also stripped a deliberate frontmatter-leak (temporarily added `content_type` into `frontmatter`) → `test_build_offload_body_returns_content_type_but_never_in_frontmatter` went RED → restored → GREEN.
- Real components throughout the new test file (`tests/test_2663_present_content_type_sidecar.py`): real `MediaStore`, real `Workspace`/`OpContext`, real `handle()` op dispatch, real `PermissionResolver` — no `unittest.mock`.
- Bound test avoids the "can't-fail" trap: the markdown-vs-text comparison test stores **two identical bodies** (one `text/markdown`, one `text/plain`) and asserts they render differently — proving the markdown default is type-derived, not shape-derived (an all-`text` false positive would be caught).
- Full suite: `8659 passed, 25 skipped` (baseline before this change: `8650 passed, 25 skipped` — net +9, all new).
- All 4 CI gates run locally and green: `ruff check src tests`, `test_tier_audit.py --strict` (new + touched test files), `pytest` (repo root), `verify_module_docstrings.py` (all touched src files).

## Doc

`docs/reference/runtime/present.md` § "View fallback — 4 stages" updated to describe the declared-content-type ladder step and the sidecar mechanism. `.ja.md` counterpart left untouched — it does not assert the specific "data_ref carries no content-type" claim that changed (per CLAUDE.md, `.ja.md` is not a required mirror; only fix when the doc's own claim becomes false).

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict <touched/new test files>` — 47 inspected, 0 errors, 0 warnings
- [x] `pytest` (repo root) — 8659 passed, 25 skipped
- [x] `python scripts/verify_module_docstrings.py <touched src files>` — OK
- [x] Strip-falsify RED→GREEN observed for both the markdown-default wiring and the frontmatter-leak guard (see Verification above)