### PR TITLE
fix: emit per-sid session_vanished on the agent-purge cascade (#2159)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -795,13 +795,22 @@ class AgentRegistry:
             self._record_agent_identity_generation(name)
         return profile
 
-    def remove(self, name: str, *, purge: bool = False) -> "list[tuple[str, Topology | None]]":
+    def remove(
+        self, name: str, *, purge: bool = False,
+    ) -> "tuple[list[tuple[str, Topology | None]], list[str]]":
         """Delete an agent. Default (#1954 Option A) = ARCHIVE (soft-delete): the
         runtime PITR generations are kept in place so rewind-to-before-delete
         works within the retention window, plus a tombstone recording the archival
         WAL seq (the slice-2 WAL-window GC hinge). ``purge=True`` is the guarded
         escape hatch — a real hard-delete (rmtree) that destroys the rewind
-        history (time-travel-to-before-purge is intentionally unsupported)."""
+        history (time-travel-to-before-purge is intentionally unsupported).
+
+        Returns ``(topology_changes, vanished_sids)`` — #2103 MUST-1's topology
+        cascade, plus (#2159) the agent's non-main spawned session ids subsumed
+        by a purge's rmtree, so the async caller (this method is sync — no WAL
+        access here) can emit ``session_vanished`` for each through the logged
+        seam. Archive cascades neither list — topology membership and sessions
+        are both preserved on disk."""
         if name == DEFAULT_AGENT_NAME:
             raise ValueError("cannot remove the default agent")
         if self._attached is not None and self._attached[0] == name:
@@ -812,6 +821,14 @@ class AgentRegistry:
         # Cancel any cached tasks / drop in-memory sessions (both paths).
         # FP-0043 Stage 3: removing an agent drops ALL its sessions (every sid).
         sids = list(self._sessions.get(name, {}).keys())
+        # #2159: enumerate the agent's spawned sessions BEFORE the in-memory map is
+        # popped below — ``_discover_session_ids`` unions the in-memory keys with
+        # on-disk discovery, and a session that was only ever spawned in-memory
+        # (never yet flushed to ``state/sessions/<sid>/``) would otherwise be missed
+        # once ``self._sessions.pop(name, None)`` clears its only record of existing.
+        vanished_sids = [
+            sid for sid in self._discover_session_ids(name) if sid != _DEFAULT_SID
+        ]
         for task_dict in (self._tasks, self._forward_tasks):
             for sid in sids:
                 task = task_dict.pop((name, sid), None)
@@ -820,6 +837,12 @@ class AgentRegistry:
         self._sessions.pop(name, None)
         self._identities.pop(name, None)
         if purge:
+            # #2159: the purge rmtree below subsumes every nested spawned session
+            # (they live under agents/<name>/state/sessions/<sid>/) with no
+            # per-session destroy record — "main" (_DEFAULT_SID) is the agent's own
+            # primary session, not a spawned one — the agent_purged record already
+            # covers it. Return the pre-pop enumeration (above) so the async caller
+            # can emit the session_vanished destroy-side mirror for each.
             # Explicit hard-delete — agents/<name>/ is reyn-managed. Destroys the
             # runtime PITR generations (rewind-to-before-purge is intentionally
             # unsupported); the real escape hatch for a genuine delete.
@@ -832,7 +855,7 @@ class AgentRegistry:
             # so drop it from every topology (a team losing its leader / an
             # emptied topology is removed entirely). #2103 MUST-1: return the
             # cascade's topology changes so the async caller emits them logged.
-            return self._cascade_agent_removal(name)
+            return self._cascade_agent_removal(name), vanished_sids
         else:
             # #1954 Option A: archive-default. Keep generations in place (rewind
             # works) + tombstone with the archival WAL seq. Hidden from active
@@ -845,7 +868,7 @@ class AgentRegistry:
             # window (slice 2).
             seq = self._state_log.last_durable_seq if self._state_log is not None else 0
             (target / ARCHIVED_MARKER).write_text(str(seq), encoding="utf-8")
-        return []  # archive does not cascade — topology membership preserved (#1954)
+        return [], []  # archive does not cascade — topology + sessions preserved (#1954)
 
     async def archive_agent(self, name: str, *, purge: bool = False) -> None:
         """#2103 S2b: the action-layer DELETE seam — archive (or purge) the agent
@@ -872,12 +895,21 @@ class AgentRegistry:
             aclose_event_store = getattr(session, "aclose_event_store", None)
             if callable(aclose_event_store):
                 await aclose_event_store()
-        cascade_changes = self.remove(name, purge=purge)
+        cascade_changes, vanished_sids = self.remove(name, purge=purge)
         if self._state_log is not None:
             await self._state_log.append(
                 "agent_purged" if purge else "agent_archived",
                 entity_kind="agent", name=name,
             )
+            # #2159: a purge's rmtree subsumes the agent's spawned sessions — emit
+            # the destroy-side session_vanished mirror for each (the same genuine-
+            # destroy record remove_session's record=True path appends, #2154) so
+            # the WAL keeps create↔destroy symmetry instead of the sessions just
+            # vanishing from the WAL's perspective with no destroy record.
+            for sid in vanished_sids:
+                await self._state_log.append(
+                    "session_vanished", entity_kind="session", name=name, sid=sid,
+                )
             # #2103 MUST-1: emit the purge cascade's topology changes through the
             # logged seam so rewind reconstructs the topology config-set consistently.
             for tname, topo in cascade_changes:
@@ -2483,9 +2515,25 @@ class AgentRegistry:
                 seq = self._archived_seq(name)
                 if seq is None or seq >= floor:
                     continue
+                # #2159: same cascade-emit gap as the explicit remove(purge=True)
+                # path — this rmtree ALSO subsumes the agent's nested spawned
+                # sessions with no per-session destroy record. Enumerate from disk
+                # before the rmtree (main excluded — it's the agent's own primary
+                # session, covered by no vanish record of its own here either way).
+                vanished_sids = [
+                    sid for sid in self._discover_session_ids(name)
+                    if sid != _DEFAULT_SID
+                ]
                 # #2187 S1: the Task backend is GLOBAL (not under this agent dir) — the
                 # #2180 per-agent close-before-rmtree is gone.
                 shutil.rmtree(self._dir / name, ignore_errors=True)
+                # #2159: emit the destroy-side session_vanished mirror for each
+                # subsumed session through the logged seam (async GC path already
+                # awaits emits below for the topology cascade — same shape).
+                for sid in vanished_sids:
+                    await self._state_log.append(
+                        "session_vanished", entity_kind="session", name=name, sid=sid,
+                    )
                 # Now a permanent hard-delete → drop the (previously preserved)
                 # topology membership so no dangling reference is left behind.
                 # #2103 MUST-1: emit the cascade's topology changes through the

--- a/tests/test_agent_purge_session_vanished_cascade_2159.py
+++ b/tests/test_agent_purge_session_vanished_cascade_2159.py
@@ -1,0 +1,155 @@
+"""Tier 2: OS invariant — #2159 agent-purge cascade emits per-sid session_vanished.
+
+The gap: an agent-purge (``AgentRegistry.archive_agent(name, purge=True)`` and the
+slice-2 WAL-window auto-purge, ``_purge_archived_below``) rmtree's the agent dir,
+which subsumes every spawned session nested under it (``state/sessions/<sid>/``) —
+but neither path emitted the per-session ``session_vanished`` destroy record. The
+sessions vanished from the WAL's perspective with no destroy record, breaking the
+create<->destroy symmetry #2154 established for ``remove_session`` (session_spawned
+IS emitted at spawn; the purge cascade must mirror it at destroy).
+
+Mirrors test_session_vanished_emit_2154.py's real AgentRegistry + StateLog + Session
+setup (no mocks) and its ``_vanished_sids`` WAL-read helper.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        # #2159 test-hygiene: root snapshot_path under tmp_path (NOT the default
+        # relative ``.reyn/agents/<name>/...``, which resolves against the real
+        # process cwd and leaks a ``.reyn/`` dir into the repo working tree). This
+        # also makes the per-session state dir land under tmp_path, so disk-based
+        # session discovery (``_discover_session_ids``) — what the purge cascade
+        # under test actually reads — is exercised for real, not just the
+        # in-memory session map.
+        snapshot_path = (
+            tmp_path / ".reyn" / "agents" / profile.name / "state" / "snapshot.json"
+        )
+        s = Session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            snapshot_path=snapshot_path,
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    return reg
+
+
+def _vanished_sids(log: StateLog, name: str) -> list[str]:
+    return [
+        e.get("sid") for e in log.iter_from(0)
+        if e.get("kind") == "session_vanished" and e.get("name") == name
+    ]
+
+
+@pytest.mark.asyncio
+async def test_purge_emits_session_vanished_for_every_spawned_session(tmp_path):
+    """Tier 2: purging an agent with MULTIPLE spawned sessions emits session_vanished
+    for EACH one (the bound test — a single-session case can't distinguish "one event
+    per agent" from "one event per session"; this witnesses the per-sid boundary)."""
+    reg = _make_registry(tmp_path)
+    AgentProfile.new("victim", role="").save(tmp_path / ".reyn" / "agents" / "victim")
+    reg.get_or_load("victim")
+
+    sid_a = await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    sid_b = await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    sid_c = await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    await reg.state_log.flush()
+    assert _vanished_sids(reg.state_log, "victim") == []  # none yet — spawn only
+
+    await reg.archive_agent("victim", purge=True)
+    await reg.state_log.flush()
+
+    vanished = _vanished_sids(reg.state_log, "victim")
+    assert set(vanished) == {sid_a, sid_b, sid_c}  # ALL three, not just one
+    assert not (tmp_path / ".reyn" / "agents" / "victim").exists()  # real hard-delete happened
+
+
+@pytest.mark.asyncio
+async def test_purge_of_agent_with_no_spawned_sessions_emits_none(tmp_path):
+    """Tier 2: an agent purge with no spawned sessions (only its "main" primary
+    session) emits zero session_vanished — "main" is the agent's own session
+    (covered by agent_purged), not a spawned one."""
+    reg = _make_registry(tmp_path)
+    AgentProfile.new("solo", role="").save(tmp_path / ".reyn" / "agents" / "solo")
+    reg.get_or_load("solo")
+
+    await reg.archive_agent("solo", purge=True)
+    await reg.state_log.flush()
+
+    assert _vanished_sids(reg.state_log, "solo") == []
+
+
+@pytest.mark.asyncio
+async def test_archive_delete_does_not_emit_session_vanished(tmp_path):
+    """Tier 2: the DEFAULT archive (soft-delete, not purge) preserves sessions on
+    disk — no rmtree happens, so no session_vanished should fire."""
+    reg = _make_registry(tmp_path)
+    AgentProfile.new("victim", role="").save(tmp_path / ".reyn" / "agents" / "victim")
+    reg.get_or_load("victim")
+    await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    await reg.state_log.flush()
+
+    await reg.archive_agent("victim", purge=False)
+    await reg.state_log.flush()
+
+    assert _vanished_sids(reg.state_log, "victim") == []
+    # archive is a soft-delete — no rmtree, so nothing was actually subsumed.
+    assert (tmp_path / ".reyn" / "agents" / "victim").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_wal_window_auto_purge_emits_session_vanished_for_every_session(tmp_path):
+    """Tier 2: the OTHER purge site — the slice-2 WAL-window GC auto-purge
+    (``_purge_archived_below``) hard-deletes an archived agent once the retention
+    floor passes its archival seq. Same cascade-emit gap, same bound-test shape
+    (multiple sessions)."""
+    reg = _make_registry(tmp_path)
+    AgentProfile.new("victim", role="").save(tmp_path / ".reyn" / "agents" / "victim")
+    reg.get_or_load("victim")
+    sid_a = await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    sid_b = await reg.spawn_session_recorded(
+        "victim", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+
+    await reg.archive_agent("victim", purge=False)   # archive (default) — no cascade yet
+    archival_seq = reg._archived_seq("victim")        # the tombstone's WAL-window GC hinge
+    assert archival_seq is not None
+    assert _vanished_sids(reg.state_log, "victim") == []
+
+    # Floor at the archival seq -> still within the window -> not purged yet.
+    await reg._purge_archived_below(archival_seq)
+    assert (tmp_path / ".reyn" / "agents" / "victim").is_dir()
+    assert _vanished_sids(reg.state_log, "victim") == []
+
+    # Floor past the archival seq -> soft-delete left the window -> hard-purged.
+    await reg._purge_archived_below(archival_seq + 1)
+    await reg.state_log.flush()
+
+    assert not (tmp_path / ".reyn" / "agents" / "victim").exists()
+    assert set(_vanished_sids(reg.state_log, "victim")) == {sid_a, sid_b}


### PR DESCRIPTION
**[per-PR-coder]** — `Closes #2159`

## The gap

An agent-purge rmtree's the agent dir, which **subsumes every spawned session nested under it** (`state/sessions/<sid>/`) — but neither purge site emitted the per-session `session_vanished` destroy record. The sessions vanished from the WAL's perspective with no destroy record, breaking the create↔destroy symmetry #2154 established for `remove_session` (`session_spawned` IS emitted at spawn).

Audit found exactly the **two sites** the issue names, both in `src/reyn/runtime/registry.py`.

## The fix

| Site | Shape |
|---|---|
| `remove(purge=True)` | Enumerates the agent's non-main sids, **returns** them so `archive_agent` (the async seam) emits through the logged path — mirroring the #2103 MUST-1 topology cascade's "collect changes → async caller emits" split. `remove()` is sync (no WAL access), hence the split. |
| `_purge_archived_below` (slice-2 WAL-window GC auto-purge) | Same enumeration before its own rmtree, emitting inline (already async). |

`remove()`'s return widens `list[tuple[str, Topology｜None]]` → `tuple[list[tuple[str, Topology｜None]], list[str]]`. Grepped every callsite: **one production caller** (`archive_agent`, registry.py:894) and no test unpacks the return — no other consumer to update.

### Existing producer's shape — copied verbatim, not reinvented

Grepped all `session_vanished` references in `src/` (10 hits, `wc -l` first, no `head`). The **sole producer** is `remove_session`'s #2154 `record=True` genuine-destroy path (registry.py:2106):

```python
await self._state_log.append(
    "session_vanished", entity_kind="session", name=name, sid=sid,
)
```

Both new emit sites copy that call verbatim — same kind, same `entity_kind`, same field set.

### Two subtleties

- **Enumeration happens BEFORE `self._sessions.pop()`** — `_discover_session_ids` unions the in-memory map with on-disk discovery, and a session not yet flushed to disk would be missed once the map is cleared. (Caught by the bound test failing before the hoist.)
- **`main` (`_DEFAULT_SID`) is excluded** — it is the agent's own primary session, not a spawned one; `agent_purged` already records its destruction.

## Consumer side — what actually happens when these records land

Grepped all consumers (`src/` + `tests/`). The **sole reader** is `_session_vanished_map` (#2154), which feeds `_materialize_rewind`'s `vanished_by_cut` guard: drop a session whose vanish is at-or-before the cut.

**No reconstruction behavior changes today.** A purged agent is torn down wholesale one loop earlier — `if name in ag_purged or _on_abandoned: self._drop_agent(name); continue` — so the new records never reach the per-session guard for a purged agent. Their value is:

1. **P6 audit truthfulness now** — the WAL stops claiming sessions that were destroyed still exist.
2. **Forward-correctness** — once a session re-materialise seam exists, a session spawned under a purged agent would otherwise reconstruct from `session_spawned` with **no destroy record to cut it** (the resurrection guard would have nothing to consult). This is the gap the issue filed.

Verified the guard interaction by reading the real `_materialize_rewind` flow, not by inference from the emit call alone.

## Verification — observed, not inferred

- **Real path, real WAL**: both cascade tests drive the actual registry purge (`archive_agent(purge=True)` / `_purge_archived_below`) and read events back out of the real `StateLog` via a public `iter_from(0)` read. No hand-built event bus, no mocks, no private-state asserts.
- **strip-falsify → RED observed**: with the production emit stripped, both cascade tests fail with `assert set() == {'9c65068d', '9d520673', 'f7c0a990'}` — **0 events emitted**. Fix restored → GREEN. A test that never saw RED proves nothing; this one did.
- **★ bound test**: `test_purge_emits_session_vanished_for_every_spawned_session` purges an agent with **THREE** spawned sessions and asserts **all three** sids appear. A 1-session test passes on a per-agent emit and would not witness the per-sid contract — this puts the input outside that boundary.
- Test factory roots `snapshot_path` under `tmp_path`, so the **on-disk** session discovery the cascade actually reads is exercised for real (and no stray `.reyn/` leaks into the working tree).

## Conflict check (#2987, tonight)

**No conflict.** #2987 touched `src/reyn/builtin/registry.py` and `src/reyn/data/skills/registry.py` — different files from `src/reyn/runtime/registry.py`. Verified via `git show 557fb74a --stat`. Branch is cut from current `origin/main` (`ca32739e`).

## Doc

No doc change needed — verified by grep, not assumption. `session_vanished` appears in **no** doc under `docs/` (only `docs/proposals/`, an untracked local file). `docs/concepts/runtime/events.md` documents the audit-event model and carries **no per-kind catalog**, so no doc claim becomes false. The kind is registered in `state_log.py`'s WAL-kind list, which is code, already correct, and untouched by this PR.

## Test plan

- [x] **`ruff check src tests`** → `All checks passed!`
- [x] **`python scripts/test_tier_audit.py --strict tests/test_agent_purge_session_vanished_cascade_2159.py`** → `✓ OK: 4, warnings: 0, errors: 0`, exit 0
- [x] **`pytest` (repo root, full suite)** → **8654 passed, 25 skipped** in 258s, exit 0
- [x] **`python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py`** → `OK: no module-docstring refactor narrative`
- [x] **strip-falsify**: emit removed from production → RED observed (`set()` == 0 events, both cascade tests) → restored → GREEN
- [x] **bound test**: 3-session purge → all 3 sids witnessed in the real event log
- [x] **Regression sweep**: `pytest -k "registry or session_vanished or archive or rewind or 2103 or 1954 or purge"` → 685 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)