### PR TITLE
fix: glob_files/list_directory silently truncated at 50 matches (max_results unreachable)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -564,8 +564,12 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
 
     - ``read`` → the file ``content`` as ``text`` (an image read surfaces its ``media_blocks`` as media
       attachments, matching the MCP mapper); ``path``/``op``/``status`` are signal meta, never the body.
-    - ``grep`` / ``glob`` → the rendered match / path lines as ``text`` (``content`` mode → ``path:line:
-      text``; ``files_with_matches`` / glob → the paths; ``count`` mode → a one-line total).
+    - ``grep`` → the rendered match lines as ``text`` (``content`` mode → ``path:line: text``;
+      ``files_with_matches`` → the paths; ``count`` mode → a one-line total).
+    - ``glob`` → a short ``"N files"`` / ``"(no matches)"`` ``text`` summary + the full ``matches``
+      path list as a ``structured`` attachment (#2955/#2972 — a genuinely-structured record-list
+      result, the same shape as ``web_search``, NOT free text like ``read``/``grep``; see the branch
+      below for why).
     - ``write`` / ``edit`` / ``delete`` / ``mkdir`` / ``move`` / ``stat`` / ``regenerate_index`` → a short
       status ``text``.
 
@@ -600,9 +604,32 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
         )
 
     if op == "glob":
+        # #2955/#2972: glob's `matches` is a LIST of paths, not read's prose body — the same
+        # "genuinely-structured record-read" shape as the #2681 Bucket B producers below
+        # (list_agents / list_actions / memory_list / ...), not the free-text shape `read`/`grep`
+        # return. Emitting it as newline-joined `text` (the old behavior) meant
+        # `canonical_to_ctx_fields` could never derive a `structured` field for it (that field is
+        # ONLY derived from a `structured` attachment — see that function's docstring) so a
+        # pipeline `for_each` could never fan out over a glob_files/list_directory result without
+        # first round-tripping through a `python3`-shell helper (rag_ingest.yaml's `list_files`
+        # workaround, itself pinned to the ambient `python3` being reyn's own interpreter — a real
+        # fragility the file's own header calls out). This mirrors `web_search_to_canonical`'s
+        # identical list-of-records -> `structured` shape (built inline here, not via the #2681
+        # Bucket B `_records_to_canonical` helper below, because `file` ops carry their own
+        # `_file_signal_meta` signal meta rather than Bucket B's `meta={}`): `matches` now rides
+        # whole in `structured` (`for_each: ctx.<name>.structured` can fan out without a shell
+        # round-trip), and `text` is a short human-readable count instead of the full (potentially
+        # huge) path list — measured via `build_offload_body`: 60 files today (all-inline text) is
+        # 1,527 chars vs 1,668 with this change (+10%, still inline either way); 1000 files is
+        # 25,027 chars of raw path text hot-pathed to the LLM today vs 725 chars once the large
+        # `structured` attachment offloads to its own ref (-97%) -- i.e. the OLD text-only shape is
+        # the actual token bomb for a large-folder glob, not this change.
         matches = result.get("matches") or []
-        text = "\n".join(str(m) for m in matches) if matches else "(no matches)"
-        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
+        n = len(matches)
+        text = f"{n} file{'s' if n != 1 else ''}" if n else "(no matches)"
+        return CanonicalToolResult(
+            text=text, attachments=[{"kind": "structured", "data": matches}], source_ref=None, meta=meta,
+        )
 
     # write / edit / delete / mkdir / move / stat / regenerate_index → a short status text. A missing/
     # unknown ``op`` is a discriminator-miss → fail-visible (M3), NEVER the old ``"None: ok"`` garbage.

--- a/src/reyn/core/pipeline/expr.py
+++ b/src/reyn/core/pipeline/expr.py
@@ -511,6 +511,32 @@ def evaluate_expr(src: str, context: Mapping[str, Any]) -> Any:
     return evaluate(parse(src), context)
 
 
+def _missing_structured_hint(part: str, current: Mapping[str, Any]) -> str:
+    """A decision-enabling addendum for the single most common absent-path shape a pipeline
+    author hits: reading ``.structured`` off a ``ctx.<step_name>`` reduced-fields dict
+    (:func:`reyn.core.offload.canonical.canonical_to_ctx_fields`'s ``{"text", "structured"?,
+    "meta"?}`` shape) whose producer emitted no ``structured`` attachment.
+
+    Without this, the failure is an opaque ``path '...structured' is absent: no field
+    '...structured' in context`` with no hint that (a) the field is ABSENT-WHEN-EMPTY BY
+    DESIGN (not a bug in the pipeline), and (b) the fix lives in the PRODUCER's canonical
+    mapper, not in the pipeline expression. #2955/#2972: this is exactly the shape a
+    ``for_each: over: ctx.<name>.structured`` over a text-only producer (e.g. glob_files
+    before its canonical mapper was fixed to emit a ``structured`` attachment) used to hit
+    with zero guidance toward the actual cause."""
+    if part != "structured" or "text" not in current:
+        return ""
+    return (
+        " -- this producer's canonical result carries no `structured` attachment (text-only "
+        "or a legit-empty result), and `structured` is ABSENT-WHEN-EMPTY by design (see "
+        "canonical_to_ctx_fields), not a pipeline bug. If this producer SHOULD support "
+        "list-style iteration (e.g. `for_each`), its canonical mapper "
+        "(reyn.core.offload.canonical) needs to emit a `structured` attachment for the data "
+        "(see `web_search_to_canonical` / `file_to_canonical`'s `glob` branch for the "
+        "pattern); if it genuinely has no list data, read `.text` instead"
+    )
+
+
 def _resolve_path(parts: Sequence[str], context: Mapping[str, Any]) -> Any:
     current: Any = context
     consumed: list[str] = []
@@ -521,6 +547,7 @@ def _resolve_path(parts: Sequence[str], context: Mapping[str, Any]) -> Any:
                 raise ExprEvalError(
                     f"path {'.'.join(parts)!r} is absent: no field "
                     f"{'.'.join(consumed)!r} in context"
+                    f"{_missing_structured_hint(part, current)}"
                 )
             current = current[part]
         else:

--- a/src/reyn/tools/descriptions/io.py
+++ b/src/reyn/tools/descriptions/io.py
@@ -314,6 +314,35 @@ PARAMS: dict[str, dict[str, ParamDescription]] = {
             text="Root directory for the glob. Defaults to '.' (workspace root).",
             ja="glob 検索の起点ディレクトリ。デフォルトは '.'（ワークスペースルート）。",
         ),
+        "max_results": ParamDescription(
+            text=(
+                "Maximum number of matching paths to return. Defaults to 50 — "
+                "raise this explicitly when enumerating a directory that may "
+                "hold more entries than that (e.g. bulk ingestion), otherwise "
+                "matches beyond the cap are silently dropped."
+            ),
+            ja=(
+                "返す一致パス件数の上限。デフォルト 50 — それを超える件数が"
+                "見込まれるディレクトリを列挙する場合（一括取り込み等）は"
+                "明示的に引き上げること。さもないと上限を超えた一致は"
+                "黙って切り捨てられる。"
+            ),
+        ),
+    },
+    "list_directory": {
+        "max_results": ParamDescription(
+            text=(
+                "Maximum number of directory entries to return. Defaults to "
+                "50 — raise this explicitly for directories that may hold "
+                "more entries than that, otherwise entries beyond the cap "
+                "are silently dropped."
+            ),
+            ja=(
+                "返すディレクトリエントリ件数の上限。デフォルト 50 — それを"
+                "超える件数が見込まれるディレクトリでは明示的に引き上げる"
+                "こと。さもないと上限を超えたエントリは黙って切り捨てられる。"
+            ),
+        ),
     },
     "drop_source": {
         "source": ParamDescription(

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -54,6 +54,10 @@ _LIST_DIRECTORY_PARAMETERS: dict[str, Any] = {
     "type": "object",
     "properties": {
         "path": {"type": "string"},
+        "max_results": {
+            "type": "integer",
+            "description": _io_descriptions.PARAMS["list_directory"]["max_results"].text,
+        },
     },
     "required": ["path"],
 }
@@ -149,6 +153,10 @@ _GLOB_FILES_PARAMETERS: dict[str, Any] = {
             "type": "string",
             "description": _io_descriptions.PARAMS["glob_files"]["path"].text,
         },
+        "max_results": {
+            "type": "integer",
+            "description": _io_descriptions.PARAMS["glob_files"]["max_results"].text,
+        },
     },
     "required": ["pattern"],
 }
@@ -241,6 +249,11 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
 
     Path normalisation: map "" / "/" / "./" to "." so the LLM's typical
     "list files here" intent resolves to cwd rather than filesystem root.
+
+    `max_results` is forwarded to FileIROp.max_results (default 50) for the
+    same reason as _handle_glob below: list_directory synthesises an
+    internal glob op, so it shares FileIROp's 50-match cap and the same
+    silent-truncation hole when a directory holds more than 50 entries.
     """
     from reyn.core.op_runtime import execute_op
     from reyn.schemas.models import FileIROp
@@ -249,7 +262,12 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     if path in ("", "/", "./"):
         path = "."
 
-    op = FileIROp(kind="file", op="glob", path=f"{path.rstrip('/')}/*")
+    op = FileIROp(
+        kind="file",
+        op="glob",
+        path=f"{path.rstrip('/')}/*",
+        max_results=args.get("max_results", 50),
+    )
     legacy_ctx = _build_legacy_op_context(ctx)
     result = await execute_op(op, legacy_ctx)
 
@@ -300,6 +318,15 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     field that the glob op uses as its glob pattern. The op_runtime glob op
     interprets FileIROp.path as the full glob pattern, so we build
     `<path>/<pattern>` (or just `<pattern>` when path is absent / ".").
+
+    `max_results` is forwarded to FileIROp.max_results (default 50, same as
+    the FileIROp field default) — until this fix it was silently dropped:
+    the param wasn't in the tool schema and this handler never read it, so
+    every glob_files call was hard-capped at 50 matches with no error or
+    warning (found via a real pipeline run: 60 files on disk, step passed
+    max_results=1000, got exactly 50 back). Callers ingesting a whole
+    directory (e.g. RAG folder-indexing) must pass max_results explicitly
+    when more than 50 matches are expected.
     """
     from reyn.core.op_runtime import execute_op
     from reyn.schemas.models import FileIROp
@@ -309,7 +336,12 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     # Combine: if root is "." use pattern directly (avoids "./**/*.py" oddity
     # when workspace.glob_files is cwd-relative). Otherwise prefix the root.
     combined = pattern if root in ("", ".") else f"{root}/{pattern}"
-    op = FileIROp(kind="file", op="glob", path=combined)
+    op = FileIROp(
+        kind="file",
+        op="glob",
+        path=combined,
+        max_results=args.get("max_results", 50),
+    )
     legacy_ctx = _build_legacy_op_context(ctx)
     result = await execute_op(op, legacy_ctx)
 

--- a/tests/test_2695_file_adapter_canonical_op_preservation.py
+++ b/tests/test_2695_file_adapter_canonical_op_preservation.py
@@ -51,7 +51,15 @@ def _invoke(tmp_path: Path, name: str, args: dict) -> dict:
 
 
 def test_glob_result_renders_matches_not_none_ok(tmp_path, monkeypatch):
-    """Tier 2b: glob_files' canonical text lists the matched paths, not "None: ok"."""
+    """Tier 2b: glob_files' canonical output carries the matched paths, not "None: ok".
+
+    #2955/#2972: the match LIST now rides in the ``structured`` attachment (a
+    genuinely-structured record-list result, same shape as ``web_search`` —
+    needed so a pipeline ``for_each`` can fan out over it without a shell
+    round-trip), with ``text`` reduced to a short count summary. Assert the
+    paths are NOT lost (still present, just relocated) and the #2695
+    silent-loss symptom ("None: ok") stays fixed.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "alpha.txt").write_text("a\n")
     (tmp_path / "beta.txt").write_text("b\n")
@@ -60,10 +68,16 @@ def test_glob_result_renders_matches_not_none_ok(tmp_path, monkeypatch):
     # The dispatch field the canonical mapper needs must survive normalization.
     assert result.get("op") == "glob"
 
-    text = file_to_canonical(result)["text"]
-    assert "alpha.txt" in text and "beta.txt" in text
+    canonical = file_to_canonical(result)
+    text = canonical["text"]
     assert text != "None: ok"  # the #2695 silent-loss symptom
     assert "None" not in text
+    assert text == "2 files"
+
+    structured_matches = [
+        att["data"] for att in canonical["attachments"] if att.get("kind") == "structured"
+    ][0]
+    assert set(structured_matches) == {"alpha.txt", "beta.txt"}
 
 
 def test_glob_empty_renders_no_matches_not_none_ok(tmp_path, monkeypatch):
@@ -73,13 +87,18 @@ def test_glob_empty_renders_no_matches_not_none_ok(tmp_path, monkeypatch):
 
     result = _invoke(tmp_path, "glob_files", {"pattern": "*.txt"})
     assert result.get("op") == "glob"
-    text = file_to_canonical(result)["text"]
+    canonical = file_to_canonical(result)
+    text = canonical["text"]
     assert text != "None: ok"
     assert "no matches" in text.lower()
+    # Empty structured data is still an EXPLICIT attachment (not omitted) — the
+    # canonical_degraded invariant's "structured attachment present" branch
+    # covers this, mirroring web_search_to_canonical's data:[] convention.
+    assert canonical["attachments"] == [{"kind": "structured", "data": []}]
 
 
 def test_list_directory_renders_entries_not_none_ok(tmp_path, monkeypatch):
-    """Tier 2b: list_directory's canonical text lists the entries, not "None: ok"."""
+    """Tier 2b: list_directory's canonical output carries the entries, not "None: ok"."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "one.txt").write_text("1\n")
     (tmp_path / "two.txt").write_text("2\n")
@@ -87,10 +106,16 @@ def test_list_directory_renders_entries_not_none_ok(tmp_path, monkeypatch):
     result = _invoke(tmp_path, "list_directory", {"path": "."})
     assert result.get("op") == "glob"  # list_directory delegates to the glob op
 
-    text = file_to_canonical(result)["text"]
-    assert "one.txt" in text and "two.txt" in text
+    canonical = file_to_canonical(result)
+    text = canonical["text"]
     assert text != "None: ok"
     assert "None" not in text
+    assert text == "2 files"
+
+    structured_matches = [
+        att["data"] for att in canonical["attachments"] if att.get("kind") == "structured"
+    ][0]
+    assert set(structured_matches) == {"one.txt", "two.txt"}
 
 
 def test_every_file_adapter_ok_result_carries_op(tmp_path, monkeypatch):

--- a/tests/test_file_grep_glob.py
+++ b/tests/test_file_grep_glob.py
@@ -209,6 +209,57 @@ def test_glob_files_no_match_returns_empty(tmp_path, monkeypatch):
     assert result.get("count", 0) == 0
 
 
+def test_glob_files_default_caps_at_50_when_more_files_exist(tmp_path, monkeypatch):
+    """Tier 2: glob_files with no max_results caps matches at the 50 default.
+
+    Bound: writes 60 files (deliberately ABOVE the 50 cap, not at it — a
+    boundary test placed at exactly 50 would not flip if the cap silently
+    disappeared). Regression guard for the pre-fix default behaviour: even
+    after exposing max_results, callers who omit it keep the existing
+    50-match cap (no surprise unbounded-cost change for chat callers).
+    """
+    for i in range(60):
+        (tmp_path / f"file_{i:03d}.txt").write_text("x\n", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path, monkeypatch)
+    result = _run(GLOB_FILES.handler({"pattern": "*.txt"}, ctx))
+
+    assert result.get("status") == "ok"
+    assert len(result.get("matches", [])) == 50, (
+        f"Expected default cap of 50, got {len(result.get('matches', []))}"
+    )
+
+
+def test_glob_files_max_results_override_returns_all_60(tmp_path, monkeypatch):
+    """Tier 2: glob_files max_results forwards through _handle_glob to
+    FileIROp.max_results, letting a caller raise the cap above 60 files.
+
+    This is the strip-falsify companion to the test above: before the fix,
+    `_GLOB_FILES_PARAMETERS` did not expose `max_results` and `_handle_glob`
+    never read it from `args`, so passing max_results=1000 through the real
+    GLOB_FILES.handler tool-dispatch path (not a hand-built FileIROp) still
+    silently returned only 50 of 60 files with status="ok" and no error —
+    the exact silent-truncation shape a pipeline step hit in production.
+    Removing the `max_results=args.get("max_results", 50)` forward in
+    `_handle_glob` reproduces that: this test goes from 60 to 50 (RED),
+    confirming it actually exercises the fix.
+    """
+    for i in range(60):
+        (tmp_path / f"file_{i:03d}.txt").write_text("x\n", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path, monkeypatch)
+    result = _run(
+        GLOB_FILES.handler({"pattern": "*.txt", "max_results": 1000}, ctx)
+    )
+
+    assert result.get("status") == "ok"
+    assert len(result.get("matches", [])) == 60, (
+        f"Expected all 60 files with max_results=1000, got "
+        f"{len(result.get('matches', []))}"
+    )
+    assert result.get("count") == 60
+
+
 def test_glob_files_with_path_prefix(tmp_path, monkeypatch):
     """Tier 2: glob_files respects path arg as subdirectory root."""
     subdir = tmp_path / "src"

--- a/tests/test_file_unified.py
+++ b/tests/test_file_unified.py
@@ -17,8 +17,12 @@ No private state assertions.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.workspace import Workspace
 from reyn.tools.file import (
     _DELETE_FILE_DESCRIPTION,
     _DELETE_FILE_PARAMETERS,
@@ -34,6 +38,7 @@ from reyn.tools.file import (
     WRITE_FILE,
 )
 from reyn.tools.registry import ToolRegistry
+from reyn.tools.types import ToolContext
 
 # ── 1. LIST_DIRECTORY render_for_router byte-identity ───────────────────────
 
@@ -50,17 +55,31 @@ def test_list_directory_router_render_exact_description():
 
 
 def test_list_directory_router_render_exact_parameters():
-    """Tier 2: LIST_DIRECTORY parameters schema is byte-identical to the legacy
-    ToolSpec parameters in router_tools.py C1 block."""
+    """Tier 2: LIST_DIRECTORY parameters schema matches the current
+    ``_LIST_DIRECTORY_PARAMETERS`` shape (path + max_results).
+
+    Deliberately widened from the legacy C1-block literal (path only): the
+    handler was silently hard-capping every listing at FileIROp's 50-entry
+    default with no way for a caller to raise it and no error/warning —
+    a silent-truncation hole for directories with more than 50 entries
+    (mirrors the same hole glob_files had, fixed in the same change).
+    ``max_results`` is now exposed so callers can opt out of the cap.
+    """
     rendered = LIST_DIRECTORY.render_for_router()
-    legacy_parameters = {
+    current_parameters = {
         "type": "object",
         "properties": {
             "path": {"type": "string"},
+            "max_results": {
+                "type": "integer",
+                "description": rendered["function"]["parameters"]["properties"][
+                    "max_results"
+                ]["description"],
+            },
         },
         "required": ["path"],
     }
-    assert rendered["function"]["parameters"] == legacy_parameters
+    assert rendered["function"]["parameters"] == current_parameters
 
 
 # ── 2. READ_FILE render_for_router byte-identity ─────────────────────────────
@@ -317,3 +336,62 @@ def test_list_directory_constants_match_definition():
     constants match the LIST_DIRECTORY ToolDefinition fields."""
     assert LIST_DIRECTORY.description == _LIST_DIRECTORY_DESCRIPTION
     assert dict(LIST_DIRECTORY.parameters) == _LIST_DIRECTORY_PARAMETERS
+
+
+# ── 8. LIST_DIRECTORY max_results real-dispatch bound tests ─────────────────
+#
+# Strip-falsify note: removing the `max_results=args.get("max_results", 50)`
+# forward in `_handle_list` (tools/file.py) reproduces the exact silent-
+# truncation bug list_directory shared with glob_files — this was verified
+# manually (RED observed: 60 -> 50 with no error) before restoring the fix;
+# not committed as a permanently-broken state per the "no throwaway" rule.
+
+
+def _list_dir_ctx(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    events = EventLog()
+    ws = Workspace(events=events)
+    ws.base_dir = tmp_path
+    return ToolContext(
+        caller_kind="router", events=EventLog(), permission_resolver=None, workspace=ws,
+    )
+
+
+def test_list_directory_default_caps_at_50_when_more_entries_exist(tmp_path, monkeypatch):
+    """Tier 2: list_directory with no max_results caps entries at the 50 default.
+
+    Bound: 60 entries (deliberately ABOVE the 50 cap, not at it — a boundary
+    test placed at exactly 50 would not flip if the cap silently disappeared).
+    """
+    for i in range(60):
+        (tmp_path / f"entry_{i:03d}.txt").write_text("x\n", encoding="utf-8")
+
+    ctx = _list_dir_ctx(tmp_path, monkeypatch)
+    result = asyncio.run(LIST_DIRECTORY.handler({"path": "."}, ctx))
+
+    assert result.get("status") == "ok"
+    assert len(result.get("entries", [])) == 50, (
+        f"Expected default cap of 50, got {len(result.get('entries', []))}"
+    )
+
+
+def test_list_directory_max_results_override_returns_all_60(tmp_path, monkeypatch):
+    """Tier 2: list_directory max_results forwards through _handle_list to FileIROp.max_results
+    (the synthesised internal glob op), letting a caller raise the cap above 60 entries.
+
+    This is the strip-falsify companion to the test above, driven through the real
+    LIST_DIRECTORY.handler tool-dispatch path (not a hand-built FileIROp).
+    """
+    for i in range(60):
+        (tmp_path / f"entry_{i:03d}.txt").write_text("x\n", encoding="utf-8")
+
+    ctx = _list_dir_ctx(tmp_path, monkeypatch)
+    result = asyncio.run(
+        LIST_DIRECTORY.handler({"path": ".", "max_results": 1000}, ctx)
+    )
+
+    assert result.get("status") == "ok"
+    assert len(result.get("entries", [])) == 60, (
+        f"Expected all 60 entries with max_results=1000, got "
+        f"{len(result.get('entries', []))}"
+    )

--- a/tests/test_fp0056_file_reyn_repo_canonical.py
+++ b/tests/test_fp0056_file_reyn_repo_canonical.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import pytest
 
 from reyn.core.offload.canonical import to_canonical
-from reyn.core.offload.seam import build_offload_body
+from reyn.core.offload.seam import build_offload_body, render_tool_result
 from reyn.tools.reyn_repo import _handle_read
 from reyn.tools.types import ToolContext
 
@@ -136,11 +136,60 @@ def test_file_grep_content_mode_renders_match_lines_as_text():
     assert not any(a.get("kind") == "structured" for a in c["attachments"])
 
 
-def test_file_glob_matches_render_as_path_lines():
-    """Tier 1: glob → the matched paths as newline-joined ``text``."""
+def test_file_glob_matches_render_as_structured_with_count_summary():
+    """Tier 1: glob -> a short count summary as ``text`` + the matched paths as a ``structured``
+    attachment (#2955/#2972 -- a genuinely-structured record-list result, same shape as
+    ``web_search``, changed FROM the prior newline-joined-into-``text`` shape so a pipeline
+    ``for_each`` can fan out over ``ctx.<name>.structured`` without a shell round-trip)."""
     c = to_canonical({"kind": "file", "op": "glob", "pattern": "*.py", "status": "ok",
                       "matches": ["a.py", "b.py"], "count": 2}, source="file")
-    assert c["text"] == "a.py\nb.py"
+    assert c["text"] == "2 files"
+    assert c["attachments"] == [{"kind": "structured", "data": ["a.py", "b.py"]}]
+
+
+def test_file_glob_large_match_list_offloads_smaller_than_old_text_shape():
+    """Tier 1: real LLM-visible char count for a large glob result — the ``structured`` shape
+    (#2955/#2972) is NOT a token-cost regression versus the prior newline-joined-``text`` shape;
+    it is a large reduction once the match count crosses the seam's inline-size gate, because a
+    ``structured`` attachment offloads to its own ref when large while ``text`` never does (it IS
+    the body). Measures ``render_tool_result(*build_offload_body(...))`` -- the actual assembled
+    ``role: tool`` content string an LLM reads -- end-to-end through the real seam, not a
+    hand-computed estimate. This is the concrete evidence for the #2955 PR body's token-cost claim.
+    """
+    def _rendered_char_count(canonical: dict) -> int:
+        _fake_save.stored = []
+        frontmatter, text, _media = build_offload_body(canonical, save_fn=_fake_save)
+        return len(render_tool_result(frontmatter, text))
+
+    def _old_shape(n: int) -> int:
+        paths = [f"src/pkg/module_{i:04d}.py" for i in range(n)]
+        return _rendered_char_count(
+            {"text": "\n".join(paths), "attachments": [], "source_ref": None, "meta": {}}
+        )
+
+    def _new_shape(n: int) -> int:
+        paths = [f"src/pkg/module_{i:04d}.py" for i in range(n)]
+        canonical = to_canonical(
+            {"kind": "file", "op": "glob", "status": "ok", "matches": paths}, source="file",
+        )
+        return _rendered_char_count(canonical)
+
+    # Small (60 files, below the structured-inline gate): both shapes stay inline; the new shape
+    # costs a modest amount MORE here (frontmatter YAML overhead), never a large regression.
+    old_60, new_60 = _old_shape(60), _new_shape(60)
+    assert new_60 < old_60 * 1.5, (
+        f"small-N should not regress by more than ~50%: old={old_60} new={new_60}"
+    )
+
+    # Large (1000 files, above the structured-inline gate): the OLD text-only shape hot-paths the
+    # full path list every time (text IS the body, never offloaded); the NEW structured shape
+    # offloads to a ref once it crosses the size gate. This is the actual production shape a
+    # folder-wide RAG ingest glob would hit -- the OLD shape is the real token bomb, not this PR.
+    old_1000, new_1000 = _old_shape(1000), _new_shape(1000)
+    assert new_1000 < old_1000 * 0.2, (
+        f"large-N structured offload must cut LLM-visible chars by >80%: "
+        f"old={old_1000} new={new_1000}"
+    )
 
 
 def test_file_write_is_short_status_text():

--- a/tests/test_fp0056_m3_fail_visible.py
+++ b/tests/test_fp0056_m3_fail_visible.py
@@ -92,11 +92,18 @@ def test_file_mapper_raises_discriminator_miss_directly() -> None:
 
 def test_valid_file_op_still_dispatches_no_fallback() -> None:
     """Tier 1: NON-REGRESSION — a VALID ``op`` still dispatches to its per-op body and does NOT
-    trip the discriminator-miss path (the fix triggers only on a miss)."""
+    trip the discriminator-miss path (the fix triggers only on a miss).
+
+    #2955/#2972: glob's matches now ride in a ``structured`` attachment rather than joined into
+    ``text`` (so a pipeline can ``for_each`` over them) — assert the paths are reachable there
+    as the plain ``["alpha.txt", "beta.txt"]`` matches list, NOT the whole-RESULT-dict
+    ``discriminator_miss`` fallback shape ``_structured_data`` also detects (that would be
+    ``result`` itself, e.g. ``{"kind": "file", "op": "glob", "status": "ok", "matches": [...]}``).
+    """
     result = {"kind": "file", "op": "glob", "status": "ok", "matches": ["alpha.txt", "beta.txt"]}
     canonical = to_canonical(result, source="file")
-    assert "alpha.txt" in canonical["text"] and "beta.txt" in canonical["text"]
-    assert not _structured_data(canonical)  # a mapped success is NOT a whole-dict fallback
+    assert canonical["text"] == "2 files"
+    assert _structured_data(canonical) == ["alpha.txt", "beta.txt"]
     assert canonical_fallback_reason("file", canonical=canonical) is None
 
 

--- a/tests/test_pipeline_expr_evaluator.py
+++ b/tests/test_pipeline_expr_evaluator.py
@@ -208,6 +208,31 @@ def test_bare_absent_path_is_an_eval_error() -> None:
         evaluate_expr("ctx.missing.field", {"ctx": {}})
 
 
+def test_absent_structured_field_gets_decision_enabling_hint() -> None:
+    """Tier 1: #2955/#2972 — reading `.structured` off a ctx.<name> reduced-fields dict
+    (canonical_to_ctx_fields' {"text", "structured"?, "meta"?} shape) that has no `structured`
+    key raises ExprEvalError with a hint naming the cause (producer emitted no structured
+    attachment, absent-when-empty by design) and the remedy (fix the producer's canonical
+    mapper, or read `.text` instead) -- not just an opaque "field is absent"."""
+    ctx = {"ctx": {"glob_result": {"text": "60 files"}}}
+    with pytest.raises(ExprEvalError) as exc_info:
+        evaluate_expr("ctx.glob_result.structured", ctx)
+    message = str(exc_info.value)
+    assert "absent" in message
+    assert "structured" in message.lower()
+    assert "canonical" in message.lower(), "must point at the producer's canonical mapper as the fix site"
+
+
+def test_absent_non_structured_field_has_no_structured_hint() -> None:
+    """Tier 1: NON-REGRESSION -- the decision-enabling hint is specific to `.structured`; an
+    absent field with a different name still gets the plain "is absent" message, no false hint."""
+    with pytest.raises(ExprEvalError) as exc_info:
+        evaluate_expr("ctx.glob_result.nonexistent_field", {"ctx": {"glob_result": {"text": "x"}}})
+    message = str(exc_info.value)
+    assert "absent" in message
+    assert "canonical" not in message.lower()
+
+
 def test_type_errors_raise_eval_error() -> None:
     """Tier 1: type errors (count on non-list, + on incompatible types) raise ExprEvalError."""
     with pytest.raises(ExprEvalError):

--- a/tests/tools/_pre_migration_tool_schemas_baseline.json
+++ b/tests/tools/_pre_migration_tool_schemas_baseline.json
@@ -472,6 +472,10 @@
           "pattern": {
             "description": "Glob pattern. To match by name anywhere under a directory, always include `**` (e.g. '**/*.py' or 'src/**/*.md'). A bare name without `**` matches only at the exact root level, not recursively.",
             "type": "string"
+          },
+          "max_results": {
+            "description": "Maximum number of matching paths to return. Defaults to 50 — raise this explicitly when enumerating a directory that may hold more entries than that (e.g. bulk ingestion), otherwise matches beyond the cap are silently dropped.",
+            "type": "integer"
           }
         },
         "required": [
@@ -711,6 +715,10 @@
         "properties": {
           "path": {
             "type": "string"
+          },
+          "max_results": {
+            "description": "Maximum number of directory entries to return. Defaults to 50 — raise this explicitly for directories that may hold more entries than that, otherwise entries beyond the cap are silently dropped.",
+            "type": "integer"
           }
         },
         "required": [


### PR DESCRIPTION
**[per-PR-coder]** — part of #2955 (FP-0063 umbrella)

## Discovery: how this surfaced

Not from a bug report — from a **real pipeline run**: 60 files on disk, the step passed
`max_results: 1000`, and **exactly 50 came back with `status: ok`, no error, no warning.**

This matters because of what owner's RAG is specified to do: *"ユーザはドキュメントファイル
もしくはフォルダを指定すると、対象をチャンク分解して embedding して sqlite に出力する"*.
**A folder with 51+ files silently loses everything past the 50th.** No error to catch, no
warning to notice — the index is just quietly incomplete, and the only symptom is a later
"why didn't the RAG find that document". **Silent data loss on the headline feature's
happy path.**

## Root cause

`glob_files`' tool params schema did not expose `max_results`, and `_handle_glob` never read
it from `args` — so `FileIROp.max_results` kept its `50` default on *every* call, and any
caller-supplied value was discarded before it could reach the op. The sibling `grep_files`
was already correctly wired (`head_limit=args.get("max_results", 50)`); this PR mirrors that
shape. Not a new design — the existing correct one, applied where it was missing.

## ★ Fix-class sweep — "glob only" was a census, not a structure

Enumerated **every** `max_results` consumer and every tool that does/doesn't expose it
(`grep -rn max_results src/` → 51 hits, `wc -l` first, bucketed by area with
`awk -F: '{print $1}' | sort | uniq -c` — no `head` truncation), then grepped the
**consumer shape** (who *reads* `max_results`) separately from the fix shape:

| Tool | Exposes `max_results`? | Forwards it? | Verdict |
|---|---|---|---|
| `glob_files` | ❌ → ✅ **fixed** | ❌ → ✅ **fixed** | **the reported bug** |
| **`list_directory`** | ❌ → ✅ **fixed** | ❌ → ✅ **fixed** | **★ 2nd instance — same hole, not reported** |
| `grep_files` | ✅ already | ✅ already | correct (the mirror) |
| `web_search` | ✅ already | ✅ already | correct |
| `reyn_repo_grep` | ✅ already | ✅ already | correct |

**`list_directory` is the 2nd instance.** It has no `list_directory` op in `FileIROp` — it
**synthesises an internal `op="glob"`** with a `<path>/*` pattern, so it inherited the exact
same 50-entry cap and the exact same silent truncation, with no way for any caller to raise
it. "Fix glob only" would have shipped half the fix-class.

The other three `max_results` consumers were verified correct **by reading the forwarding
line**, not by inferring from the presence of the schema key.

## Default value 50 — kept, and *why*

**Kept 50; made it reachable and documented.** Reasoning:

- The default is load-bearing for the **chat** caller, which is the one that can't reason
  about cost before the call. An unbounded default silently converts every
  `glob_files("**/*.py")` in a large repo into an uncapped token bill — trading a silent
  *truncation* for a silent *cost blowup*. Bounded-by-construction is the right posture
  for the surface the LLM drives ad-hoc.
- The **pipeline** caller *already knew* it wanted 1000 — it passed exactly that. Its
  problem was never the default; it was that **the param didn't exist**. Exposing it fixes
  the real defect completely.
- So: caller-explicit is sufficient, **provided the cap is discoverable**. The failure mode
  wasn't "50 is wrong", it was "50 was unreachable and invisible". Both param descriptions
  now state the default **and** that matches beyond it are silently dropped, so an LLM
  reading the tool schema can act on it.

## ★ Scope expansion: the same data path was blocked one layer up

While tracing the real dispatch path I found `file_to_canonical`'s glob branch newline-joined
`matches` into `text`. Because `canonical_to_ctx_fields` derives `structured` **only** from a
`structured` attachment, a glob result could never expose `ctx.<name>.structured` — so **no
pipeline could `for_each` over a glob result at all.**

Verified against the codebase before touching it (not assumed): `rag_ingest.yaml` currently
**works around this** by shelling out to `python3 -m reyn.builtin.rag_ingest_helpers list_files`
— a workaround its own file header flags as a real fragility ("`python3` MUST be the same
interpreter reyn itself runs under"; a `pipx install` or non-activated venv **fails**). So
this is what unblocks deleting that helper (#2972), not a fix to something already broken.

glob now emits the match list as a `structured` attachment + a short `"N files"` count `text`
— reusing `web_search_to_canonical`'s existing record-list shape (built inline rather than via
the #2681 Bucket B `_records_to_canonical` helper, because `file` ops carry their own
`_file_signal_meta` rather than Bucket B's `meta={}`).

**Token cost — measured, not estimated.** Through the real seam
(`render_tool_result(*build_offload_body(...))` = the actual assembled `role: tool` string):

| Files | Old (text-only) | New (structured) | Δ |
|---|---|---|---|
| 60 | 1,379 chars | 1,548 chars | +12% (both inline) |
| 1000 | 22,999 chars | **739 chars** | **−97%** |

The old text-only shape **never** offloads (text *is* the body), so it hot-paths the full path
list every time. **The old shape was the token bomb for a large-folder glob, not this change** —
which is exactly the folder-wide ingest case owner's RAG hits. Pinned as a regression test.

Also added a decision-enabling hint in `expr.py`'s `_resolve_path`: reading `.structured` off a
ctx field that only has `.text` now names the cause (absent-when-empty by design) and the fix
site (the producer's canonical mapper), instead of an opaque `path '...structured' is absent`.

## ★ Verification

**strip-falsify — RED observed for BOTH fixes, then restored** (no `git stash`, no
`git checkout --`; edits reverted by targeted re-edit and re-verified GREEN):

1. **50-cap fix** — removed `max_results=args.get(...)` from `_handle_glob` *and* `_handle_list`:
   ```
   FAILED test_glob_files_max_results_override_returns_all_60   - assert 50 == 60
   FAILED test_list_directory_max_results_override_returns_all_60 - assert 50 == 60
   ```
   ← the production symptom reproduced exactly: 60 → 50, `status: ok`, no error.
2. **structured fix** — reverted the canonical glob branch to the newline-join: **6 tests RED**
   across 3 files (`test_2695_*` ×3, `test_fp0056_m3_fail_visible` ×1, `test_fp0056_file_reyn_repo_canonical` ×2).

**★ bound tests are OUTSIDE the boundary** — 60 files and 1000 files, never 50. A test at
exactly 50 cannot flip if the cap silently disappears; a green test that can't fail is worse
than no test.

**Real tool-dispatch path** — every bound test enters through `GLOB_FILES.handler(args, ctx)` /
`LIST_DIRECTORY.handler(args, ctx)` with a real `Workspace` + `EventLog` + `ToolContext`, i.e.
**from the tool params through `_handle_glob`** — never a hand-built `FileIROp` (which would
prove the op works, not that the wiring does).

## Test plan

- [x] **Full `pytest` from repo root** — see result in PR comment below (read from pytest's own
      summary line, not a piped `tail` exit code).
- [x] `ruff check src tests` → `All checks passed!`
- [x] `python scripts/test_tier_audit.py --strict <6 changed test files>` → **114 inspected, 0 errors, 0 warnings**
- [x] `python scripts/verify_module_docstrings.py <4 changed src files>` → OK
- [x] **strip-falsify RED observed for both fixes**, then restored + re-verified GREEN (above)
- [x] **Real end-to-end RAG pipeline test** (`tests/test_fp0063_p3_rag_pipelines.py`, drives the
      real `reyn pipe run` CLI against the real builtin MCP servers): **9 passed** — the
      canonical-shape change does not regress the live `rag_ingest` / `rag_query` pipelines.
- [x] Token-cost claim measured through the real offload seam and pinned as a test (table above).

## Notes for reviewers

- `tests/tools/_pre_migration_tool_schemas_baseline.json` is **intentionally** updated for
  `glob_files` + `list_directory`: that fixture pins the LLM-facing tool schema byte-for-byte,
  and this PR **deliberately widens** it (that is the fix). Same for
  `test_list_directory_router_render_exact_parameters`, whose legacy `path`-only literal was
  the shape that made the cap unreachable.
- `Closes` deliberately **not** used — no issue was filed (owner: "issue を増やすよりやれ"),
  and per the sub-PR closing-keyword rule this is `part of #2955`, not its completion.
