### PR TITLE
test: assert ToolDescription.surfaced gate claims match registered ToolGates

### DIFF
--- a/tests/tools/test_tool_description_surfaced_gates_match.py
+++ b/tests/tools/test_tool_description_surfaced_gates_match.py
@@ -1,0 +1,61 @@
+"""Tier 1: a ToolDescription's `surfaced` gate claim matches the real ToolGates.
+
+Motivated by #2996: `descriptions/hooks.py`'s `hooks_add.surfaced` claimed
+`gates.phase=allow` while the registered `ToolGates` was `phase="deny"` — a
+wrong claim in LLM-facing review-aid text, caught by a human, not a test.
+`surfaced` is free-text prose (`ToolDescription.surfaced: str`,
+`descriptions/_types.py`); nothing previously cross-checked its
+`gates.router=`/`gates.phase=` tokens against the tool's actual, registered
+`ToolGates`. This test closes that gap structurally: it derives every
+(claim, actual) pair from the real registry and description package, not
+from a hand-picked subset.
+
+Entries whose `surfaced` makes no gate claim at all (e.g. a description
+variant explicitly documented as "NOT currently wired into any
+ToolDefinition") are skipped — this test asserts CONSISTENCY of a claim
+that's made, not that every entry must make one.
+"""
+from __future__ import annotations
+
+import re
+
+from reyn.tools import get_default_registry
+from reyn.tools.descriptions import ALL as ALL_DESCRIPTIONS
+
+_GATE_CLAIM_RE = re.compile(r"gates\.(router|phase)=(allow|deny)")
+
+
+def test_surfaced_gate_claims_match_registered_tool_gates() -> None:
+    """Tier 1: every `gates.router=`/`gates.phase=` token in `surfaced` matches reality.
+
+    Derives the actual `ToolGates` per tool from `get_default_registry()` (the
+    same construction path production uses to assemble the LLM-facing
+    `tools=[...]` payload) and cross-checks it against every claim token found
+    in `ALL_DESCRIPTIONS`'s `surfaced` strings — not a grepped subset of
+    `descriptions/`, the full registry-backed dict.
+    """
+    registry = get_default_registry()
+    gates_by_name = {t.name: t.gates for t in registry}
+
+    checked = 0
+    for key, desc in ALL_DESCRIPTIONS.items():
+        claims = dict(_GATE_CLAIM_RE.findall(desc.surfaced))
+        if not claims:
+            continue  # no gate claim in this entry's surfaced text — nothing to check
+
+        gates = gates_by_name.get(desc.tool_name)
+        assert gates is not None, (
+            f"descriptions.ALL[{key!r}] claims gates for tool_name="
+            f"{desc.tool_name!r}, but no such tool is registered"
+        )
+
+        for axis, claimed in claims.items():
+            actual = getattr(gates, axis)
+            assert claimed == actual, (
+                f"descriptions.ALL[{key!r}].surfaced claims gates.{axis}="
+                f"{claimed!r} for tool {desc.tool_name!r}, but the registered "
+                f"ToolGates has {axis}={actual!r} — surfaced={desc.surfaced!r}"
+            )
+        checked += 1
+
+    assert checked > 0, "no surfaced entry made a gate claim — the regex is probably wrong"


### PR DESCRIPTION
**[docs-maintainer]** — Requested by lead-coder ahead of #2997 (https://github.com/tya5/reyn/issues/2997), following up on #2996. Closes a real gap: the tool-description package's `surfaced` field makes a machine-checkable claim (`gates.router=X, gates.phase=Y`) that nothing previously verified against the real registry.

## The gap

#2996 fixed `hooks_add`'s `surfaced` field claiming `gates.phase=allow` when the actual registered `ToolGates` is `phase="deny"`. That was caught by a human reading a diff. The only existing test on `surfaced` (`test_tool_description_relocation.py::test_description_registry_entries_are_complete`) only asserts non-emptiness (`assert desc.surfaced.strip()`) — it has never verified the field's *content* is true.

## The test

`tests/tools/test_tool_description_surfaced_gates_match.py` — derives both sides of the comparison from the real construction paths, per lead-coder's design requirement (registry-derived, not a grepped subset):

- **Actual gates**: `get_default_registry()` (same path production uses to assemble the `tools=[...]` LLM payload) → `{t.name: t.gates for t in registry}`.
- **Claims**: `descriptions.ALL` (the full package dict, all 17 category buckets), regex-extracting every `gates\.(router|phase)=(allow|deny)` token from each entry's `surfaced` string.
- Entries whose `surfaced` makes no gate claim at all (e.g. `semantic_search_hide_legacy`, explicitly documented as "NOT currently wired into any ToolDefinition") are skipped — the invariant is "a claim that's made must be true," not "every entry must claim something."
- A sanity floor (`assert checked > 0`) guards against the regex silently matching nothing.

## Falsified before landing

Per testing.md's falsify-before-ship discipline: temporarily flipped `hooks_add`'s `surfaced` in `descriptions/hooks.py` to the wrong value, ran the test, confirmed it goes RED with a message naming the exact tool/axis/claimed-vs-actual values, then reverted (`git diff` empty after revert) and confirmed GREEN again.

## What it found

Ran against current `main`: 84 of 85 registered tools' `surfaced` entries make a gate claim (the 85th has none, per the skip logic above), and **all 84 already match** — no other residual mismatch beyond the one #2996 already fixed. (lead-coder's own manual census suggested a possible 2-3 more mismatches, but that census was explicitly not per-tool-matched — a grepped-subset count, not a registry-derived one. This test's registry-derived cross-check found the census count discrepancy was not a real defect.)

## Test plan

- [x] `ruff check tests/tools/test_tool_description_surfaced_gates_match.py` — pass.
- [x] `python scripts/test_tier_audit.py --strict tests/tools/test_tool_description_surfaced_gates_match.py` — pass (Tier 1, no violations).
- [x] `python scripts/verify_module_docstrings.py` — N/A, no `src/` files touched.
- [x] Scoped `pytest tests/tools/` — 4/4 pass (all pre-existing tests in that dir still green alongside the new one).
- [x] Full-suite `pytest` run hit pre-existing, unrelated failures from missing optional local deps (`fastmcp`, `reyn.plugins.sample_slack` — confirmed via direct inspection of the failure tracebacks, nothing touching tool descriptions or this test's code path). Not caused by this change; did not attempt to fix, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)