### PR TITLE
ci: add -rs to pytest so CI skips are legible, not just counted

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,18 @@ jobs:
         # hangs the whole -n auto job to the 15-min job timeout → cancel, with no
         # name. The cap interrupts the hung test (signal method on Linux) and
         # NAMES it. Permanent CI hardening (#1800-7 diagnostic).
-        run: python -m pytest -q -n auto --timeout=120
+        #
+        # -rs: prints each SKIPPED test's file:line and reason in the summary
+        # (verified to survive -n auto/xdist — xdist merges the per-worker
+        # reports before the summary is rendered). Without it, `-q` + a green
+        # `rc=0` only proves "everything that ran passed" — it says nothing
+        # about *what ran*. #2999: a docker-daemon-driven skip (or a missing
+        # optional extra, #2952) is indistinguishable from "ran and passed" in
+        # plain `-q` output; `N passed, M skipped` is a census, not evidence
+        # any specific test executed. -rs makes "what didn't run, and why"
+        # permanently legible in the CI log instead of requiring a rerun with
+        # extra flags to find out after the fact.
+        run: python -m pytest -q -n auto --timeout=120 -rs
 
   lint:
     name: ruff


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2999 (outside code span so GitHub parses it)

## What

`.github/workflows/test.yml:47` pytest invocation gets `-rs` added:

```
run: python -m pytest -q -n auto --timeout=120 -rs
```

## Why (the invariant this protects)

**`rc=0` / `N passed` tells you "everything that ran was green" — it does not tell you *what ran*. Skip is green too.**

Tonight this nearly caused real harm: lead-coder concluded `rc=0 / 8686 passed / 19 skipped` falsified a docker-build concern. architect falsified that conclusion by re-running with `-rs`: every docker test was `SKIPPED: no reachable Docker daemon` — the "green" said nothing about whether docker builds actually ran. `-q` alone never prints individual skip reasons, so nobody could tell from CI's plain `-q` output whether the docker e2e suite runs in CI or is quietly skipped (#2999).

Same fix-class, same repo, prior incidents: **#2965** (dogfood didn't run in CI for 13 days, referencing a deleted skill, invisible because CI was green) · **#2962** (a seccomp filter silently failed to load, hiding a downstream defect) · **#2952** (a missing optional extra `importorskip`'d an entire test module, CI stayed green, caught just before merge).

> A dead mechanism only fires the defect it was hiding the moment it wakes back up.

`-rs` makes "what didn't run, and why" a permanent, readable part of the CI log instead of something that requires a manual rerun with extra flags to discover after the fact.

## Witness — `-rs` verified to survive `-n auto` (xdist)

Ran locally against this repo (`python -m pytest -q -n auto --timeout=120 -rs`, real run, not asserted):

```
=========================== short test summary info ============================
SKIPPED [1] tests/gateway/sample_line/test_webhook.py:28: could not import 'linebot.v3': No module named 'linebot'
SKIPPED [1] tests/gateway/sample_slack/test_webhook.py:39: could not import 'slack_bolt': No module named 'slack_bolt'
SKIPPED [1] tests/test_sandbox_factory.py:87: Linux-specific test
SKIPPED [1] tests/test_mount_e2e_1332.py:121: docker daemon cannot bind-mount the pytest temp dir (VM file-sharing excludes it — typical for colima / Docker Desktop with /var/folders). Runs on native Linux docker (e.g. GitHub Actions), where the mount round-trips.
SKIPPED [1] tests/test_mount_e2e_1332.py:172: docker daemon cannot bind-mount the pytest temp dir (VM file-sharing excludes it — typical for colima / Docker Desktop with /var/folders). Runs on native Linux docker (e.g. GitHub Actions), where the mount round-trips.
SKIPPED [1] tests/test_mount_e2e_1332.py:131: docker daemon cannot bind-mount the pytest temp dir (VM file-sharing excludes it — typical for colima / Docker Desktop with /var/folders). Runs on native Linux docker (e.g. GitHub Actions), where the mount round-trips.
SKIPPED [1] tests/test_mount_e2e_1332.py:181: docker daemon cannot bind-mount the pytest temp dir (VM file-sharing excludes it — typical for colima / Docker Desktop with /var/folders). Runs on native Linux docker (e.g. GitHub Actions), where the mount round-trips.
SKIPPED [1] tests/test_mount_e2e_1332.py:197: docker daemon cannot bind-mount the pytest temp dir (VM file-sharing excludes it — typical for colima / Docker Desktop with /var/folders). Runs on native Linux docker (e.g. GitHub Actions), where the mount round-trips.
SKIPPED [1] tests/test_fp0001_a2a_endpoints.py:521: Deferred to F5 e2e: async_mode full round-trip requires F1/F2/F3 integration
SKIPPED [1] tests/test_web_fetch_extractor_selection.py:112: could not import 'trafilatura': No module named 'trafilatura'
SKIPPED [1] tests/test_sandbox_landlock.py:141: LandlockBackend is Linux-only
SKIPPED [1] tests/test_sandbox_landlock.py:116: LandlockBackend is Linux-only
SKIPPED [1] tests/test_2976_mcp_sandbox_write_paths.py:233: ~/.config/gcloud not present on this machine
SKIPPED [1] tests/test_2976_mcp_sandbox_write_paths.py:233: ~/.netrc not present on this machine
SKIPPED [1] tests/test_2976_mcp_sandbox_write_paths.py:233: ~/.aws not present on this machine
SKIPPED [1] tests/test_2976_mcp_sandbox_write_paths.py:233: ~/.kube not present on this machine
SKIPPED [1] tests/test_2976_mcp_sandbox_write_paths.py:233: ~/.gnupg not present on this machine
SKIPPED [1] tests/test_fp0001_e2e_ask_user_roundtrip.py:410: F4 router endpoints (...) are not yet mounted. Remove this skip once F4 lands.
SKIPPED [1] tests/test_fp0001_e2e_ask_user_roundtrip.py:230: F4 router endpoints (...) are not yet mounted. Remove this skip once F4 lands.
SKIPPED [1] tests/test_fp0001_e2e_ask_user_roundtrip.py:299: F4 router endpoints (...) are not yet mounted. Remove this skip once F4 lands.
SKIPPED [1] tests/test_subprocess_cancel_1470.py:177: LandlockBackend is Linux-only
SKIPPED [1] tests/test_subprocess_cancel_1470.py:198: LandlockBackend is Linux-only
1 failed, 8666 passed, 22 skipped, 31 warnings in 181.61s (0:03:01)
```

**Confirms**: `-rs` + `-n auto` (pytest-xdist) prints every skipped test's `file:line` and reason — xdist merges each worker's per-test report before the summary renders, so parallelization does not swallow the skip detail. This is exactly the per-test legibility #2999 asked for; a plain `-q` run never shows any of this.

(The `1 failed` line is a pre-existing, unrelated local-environment flake — not touched by this PR; a second local run showed a different local-only flake instead, both unrelated to `.github/workflows/test.yml`.)

## Output volume

25 SKIPPED lines locally (docker/Linux-only/missing-optional-extra/deferred-feature skips) — one line each, well within acceptable CI log growth.

## Same fix-class swept across all workflows

Enumerated every job in `.github/workflows/` that invokes pytest (`grep -rn pytest .github/workflows/*.yml`, full count not piped through `head`):

- `test.yml:47` — the only job that runs `python -m pytest`. Fixed here.
- `wheel-reachability.yml`, `sandbox-linux-live-x86_64.yml` — run standalone Python smoke scripts (`scripts/wheel_reachability_smoke.py`, `scripts/sandbox_seccomp_x86_64_live_smoke.py`), not pytest — no `-r` flag applies, out of scope for this fix-class.
- `dogfood-finding-triage.yml`, `pages.yml`, `release.yml` — no pytest invocation at all.

No other job needs this fix.

## Gates run

- `ruff check src tests` — all checks passed.
- `pytest` (repo root) — ran twice locally as the witness runs above; both show only pre-existing, unrelated flakes, no new failures introduced by this change.
- tier-audit / module-docstring gate — **not run**: no `src/**.py` or `tests/**.py` files changed, only `.github/workflows/test.yml`. Both gates are scoped to changed src/test files on PR events and would no-op.

## Test plan

- [x] Verified `-rs` output survives `-n auto`/xdist locally (pasted above).
- [x] Verified this is the only pytest-invoking job in `.github/workflows/`.
- [x] Confirmed no `src/`/`tests/` files changed (tier-audit / docstring gates not applicable).

Closes #2999