### PR TITLE
fix: stop indexing reyn's own affordances and a converter's errors as document content

### DIFF
--- a/src/reyn/builtin/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/pipelines/rag_ingest.yaml
@@ -62,6 +62,17 @@
 #                          provider actually RESOLVED, read back from
 #                          `embed`'s own envelope meta -- so the column can
 #                          never disagree with the vectors beside it.
+#   filter_none_conversions -- treat a conversion whose ENTIRE output is the
+#                          literal string "None" as a failed conversion
+#                          (default true). markitdown manufactures that
+#                          string from an undecodable file and reports
+#                          SUCCESS -- see the long note at the gate in
+#                          _ingest_one_file for the measured chain and the
+#                          upstream line responsible. Exact equality only, so
+#                          a document merely mentioning None is unaffected;
+#                          set false if a document's real content IS "None"
+#                          (a .txt of exactly that is content, not a bug, and
+#                          this pipeline cannot tell the two apart).
 #   markitdown_server / chunker_server / vectorstore_server -- the MCP
 #                          server names as configured under `mcp.servers`
 #                          (defaults: reyn_markitdown / reyn_chunker /
@@ -72,7 +83,11 @@
 # added/updated/removed/unchanged, the resolved `embedding_model`, and the
 # X2a METERED spend for this batch: `tokens_embedded` / `cost_usd` /
 # `priced`, read from `embed`'s own envelope meta -- plus X5's
-# `estimated_tokens_saved_by_dedup`, the one necessarily-estimated figure)
+# `estimated_tokens_saved_by_dedup`, the one necessarily-estimated figure,
+# and #3010's `files_skipped` / `skipped_files` naming every discovered file
+# that produced NO indexed content -- whether its conversion failed, it
+# reported an empty body, or it simply chunked to zero -- each with the
+# reason, so a file can never leave the corpus silently)
 # or `_blocked`'s X1 pre-flight failure message (cause + concrete remedy
 # per unreachable server -- mirrors #2932's `require_mcp` decision-enabling
 # error, never a bare transport exception).
@@ -101,6 +116,9 @@ steps:
                                      '[xX][lL][sS][xX]', '[pP][pP][tT][xX]', '[dD][oO][cC][xX]'])
       output: file_extensions
   - transform: {value: "get(ctx, 'max_files', 10000)", output: max_files}
+  - transform:
+      value: "get(ctx, 'filter_none_conversions', true)"
+      output: filter_none_conversions
 
   # ---- X1: pre-flight -- a REAL probe call per server (not just "is it
   # configured"), schema-gated to status=="ok" so an MCP-layer error
@@ -192,6 +210,7 @@ steps:
             vectorstore_server: ctx.vectorstore_server
             file_extensions: ctx.file_extensions
             max_files: ctx.max_files
+            filter_none_conversions: ctx.filter_none_conversions
       default:
         pipeline: _blocked
         pass: {message: ctx.preflight_message}
@@ -212,12 +231,16 @@ steps:
 ---
 pipeline: _ingest_one_file
 description: >-
-  Convert one file to Markdown (markitdown) and chunk it (chunker). Called
-  once per file by ingest's for_each fan-out. Returns this file's candidate
-  chunk items: [{source_path, text, content_hash, chunk_index, size_tokens,
-  est_tokens}, ...] -- the chunker returns content_hash/chunk_index/
-  est_tokens itself (#2972), so the only work left here is tagging each
-  chunk with the file it came from.
+  Convert one file to Markdown (markitdown) and, when the conversion
+  actually produced a document, chunk it (chunker). Called once per file by
+  ingest's for_each fan-out. Returns this file's OUTCOME:
+  {source_path, items, skipped_reason} -- `items` is the candidate chunk
+  list ([{source_path, text, content_hash, chunk_index, size_tokens,
+  est_tokens}, ...]; the chunker returns content_hash/chunk_index/est_tokens
+  itself (#2972), so the only work left is tagging each chunk with the file
+  it came from), and `skipped_reason` is "" for an ingested file or the
+  operator-facing reason string for a skipped one (the single skipped/not
+  representation -- all three ways to yield nothing report through it).
 steps:
   - tool:
       name: call_mcp_tool
@@ -226,12 +249,128 @@ steps:
         mcp_tool_name: convert_to_markdown
         tool_args: !expr "{uri: 'file://' + ctx.source_path}"
       output: converted
+
+  # ---- #3010: the two facts the converter already told us, READ ----
+  #
+  # Cause 1 -- `meta.isError`. A failed conversion (e.g. a corrupt/zero-byte
+  # PDF -> PDFSyntaxError) comes back as an MCP result with `isError: true`,
+  # whose `text` IS the error message ("Error executing tool
+  # convert_to_markdown: ..."). The MCP layer RAISES NOTHING for it, so
+  # ingest's `for_each on_error: continue` never fires -- the step
+  # "succeeds" and, before this gate, the error MESSAGE ITSELF was handed to
+  # the chunker, embedded (real token spend) and upserted into the store as
+  # though it were the document's content.
+  #
+  # Cause 2 -- `meta.empty`. A file that converts PERFECTLY but holds no
+  # text (the scanned PDF with no text layer -- the most common real-corpus
+  # case) is NOT an error: markitdown faithfully returns "". reyn renders
+  # that legit-empty success as the marker "(no content)" for the chat LLM,
+  # and before #3010 the marker was the ONLY form the fact had -- so this
+  # pipeline chunked and embedded the literal string "(no content)".
+  # `meta.empty` is that same fact as DATA. We read the FACT, never the
+  # marker text: string-matching "(no content)" would bind this pipeline to
+  # today's chat wording and break silently the day it changes.
+  #
+  # Both are reported, never silently dropped -- silence over a poisoned
+  # index is precisely the bug (`chunks_upserted: 12`, all garbage).
+  - transform:
+      value: "get(ctx.converted, 'meta.isError', false)"
+      output: conversion_failed
+  - transform:
+      value: "get(ctx.converted, 'meta.empty', false)"
+      output: conversion_empty
+
+  # ---- the "None" filter: working around a markitdown BUG ----
+  #
+  # This is a literal string comparison against a converter's output, which
+  # is normally indefensible. It is here because markitdown MANUFACTURES the
+  # string "None" out of an unreadable file, and says it succeeded:
+  #
+  #   markitdown/converters/_plain_text_converter.py -- PlainTextConverter.convert()
+  #       else:
+  #           text_content = str(from_bytes(file_stream.read()).best())   # <- no None check
+  #
+  # `charset_normalizer.from_bytes(...).best()` returns None for bytes whose
+  # encoding it cannot determine, and `str(None)` == "None". Measured chain
+  # (converters instrumented) on a 16-byte non-PDF:
+  #
+  #   corrupt.pdf (\x00\x01\x02 not a pdf \xff\xfe)
+  #     PdfConverter       -> raised PDFSyntaxError "No /Root object!"   (correct)
+  #     PlainTextConverter -> SUCCESS  markdown='None'                   (the bug)
+  #     final result: 'None'
+  #
+  # The fixture contains no "None" (16 bytes, hexdump-verified) -- markitdown
+  # GENERATES it. And markitdown's own design is right (_markitdown.py:624):
+  # `if len(failed_attempts) > 0: raise FileConversionException(...)` -- had
+  # PlainTextConverter not "succeeded", the file would have raised and our
+  # meta.isError gate above would have caught it. One missing None check
+  # disables markitdown's own official error channel, which is why a defense
+  # this crude is the only thing left at this layer.
+  #
+  # EXACT equality, never `"None" in text`: a legitimate document that merely
+  # MENTIONS None must not be dropped. Even so, a .txt whose entire content
+  # is "None" is CONTENT, not a bug (markitdown detects the charset and takes
+  # the `.decode(charset)` branch, correctly returning "None") -- and this
+  # pipeline cannot see which branch ran. That false positive is structural,
+  # not an oversight, which is why the filter is opt-out
+  # (`filter_none_conversions: false`) rather than clever. No extension
+  # sniffing: "only distrust .pdf" would be a guess about which converters
+  # can hit this path, and the census of markitdown's converters is not ours
+  # to keep -- the operator's own opt-out is the honest lever.
+  #
+  # It converts to an ERROR rather than a silent skip: the file did not
+  # convert, so it reports through the same named-with-a-reason path as a
+  # raised conversion failure. One reporting path, not three.
+  - transform:
+      value: "ctx.filter_none_conversions and ctx.converted.text == 'None'"
+      output: conversion_is_none
+
+  # The reason strings, built like X1's `preflight_message`: a filtered list
+  # + join, since R1 has no conditional expression.
+  - transform:
+      value: >-
+        join(map(filter([{fired: ctx.conversion_failed, why: "conversion failed: " + ctx.converted.text},
+                         {fired: ctx.conversion_is_none, why: "conversion returned the literal string \"None\" -- a markitdown bug (PlainTextConverter has no None check on charset detection failure), meaning the file could not be decoded at all. If this document's real content IS \"None\", set filter_none_conversions: false."},
+                         {fired: ctx.conversion_empty, why: "no text content extracted (e.g. a scanned PDF with no text layer, or an empty document)"}],
+                        r -> r.fired), r -> r.why), "; ")
+      output: skip_reason
+  - transform:
+      value: "ctx.conversion_failed or ctx.conversion_is_none or ctx.conversion_empty"
+      output: unusable
+  - match:
+      on: ctx.unusable
+      cases:
+        "True":
+          pipeline: _ingest_skipped_file
+          pass:
+            source_path: ctx.source_path
+            reason: ctx.skip_reason
+      default:
+        pipeline: _ingest_chunk_file
+        pass:
+          source_path: ctx.source_path
+          converted_text: ctx.converted.text
+          chunk_size: ctx.chunk_size
+          chunk_overlap_ratio: ctx.chunk_overlap_ratio
+          chunker_server: ctx.chunker_server
+      output: outcome
+---
+pipeline: _ingest_chunk_file
+description: >-
+  Sibling of _ingest_skipped_file -- the "the conversion produced a
+  document" branch: chunk it and tag each chunk with its source file.
+  Reached only when the convert step flagged neither `meta.isError` nor
+  `meta.empty`, so the chunker/embedder are never handed an error message
+  or an explicit-empty marker as if either were content. Carries the
+  zero-chunk gate: converting cleanly to no chunks is still "nothing was
+  indexed", and is reported as such.
+steps:
   - tool:
       name: call_mcp_tool
       args:
         server: !expr ctx.chunker_server
         mcp_tool_name: chunk
-        tool_args: !expr "{text: ctx.converted.text, size: ctx.chunk_size, overlap_ratio: ctx.chunk_overlap_ratio}"
+        tool_args: !expr "{text: ctx.converted_text, size: ctx.chunk_size, overlap_ratio: ctx.chunk_overlap_ratio}"
       output: chunked
   # Tag each chunk with its source file. content_hash / chunk_index /
   # est_tokens already ride the chunker's own output (#2972) -- R1 could
@@ -246,6 +385,47 @@ steps:
                                                  size_tokens: c.token_count,
                                                  est_tokens: c.est_tokens})
       output: items
+
+  # ---- #3010, the SILENT-ZERO gate: a file that yielded no chunks ----
+  # The `meta.empty` gate above catches an empty conversion only when the
+  # converter says so. It cannot when the converter's MCP server returns
+  # structured output alongside its empty text (a `structuredContent`-era
+  # MCP SDK sends {"content": "", "structuredContent": {"result": ""}}):
+  # reyn carries that as a structured attachment, and an attachment-carrying
+  # result never takes the explicit-empty path, so `meta.empty` is absent
+  # and `text` is a bare "". Nothing is garbage here -- and nothing is
+  # REPORTED either: the file chunks to zero, contributes no items, and
+  # vanishes from the run entirely. `files_scanned` counts it; nothing says
+  # it produced nothing. That is the same "the operator cannot tell what
+  # happened" failure as the garbage, arrived at from the opposite side.
+  #
+  # So the last word is the STRUCTURAL outcome, not any signal: zero chunks
+  # means nothing was indexed, whatever the converter did or did not say.
+  # This gate needs no marker, no meta and no SDK assumption -- which is
+  # also why it stays even though `meta.empty` usually fires first.
+  - transform:
+      value: >-
+        join(map(filter([{fired: count(ctx.items) == 0,
+                          why: "no chunks produced (the document converted, but yielded no text to index)"}],
+                        r -> r.fired), r -> r.why), "; ")
+      output: zero_chunk_reason
+  - transform:
+      value: >-
+        {source_path: ctx.source_path, items: ctx.items,
+         skipped_reason: ctx.zero_chunk_reason}
+      output: outcome
+---
+pipeline: _ingest_skipped_file
+description: >-
+  Sibling of _ingest_chunk_file -- the "this file yielded no usable
+  document" branch. Contributes ZERO chunk items (nothing to chunk, embed or
+  index) and carries the reason so the run's summary can NAME the file the
+  operator's corpus is missing, instead of the silent-garbage alternative.
+steps:
+  - transform:
+      value: >-
+        {source_path: ctx.source_path, items: [], skipped_reason: ctx.reason}
+      output: outcome
 ---
 pipeline: _ingest_body
 description: >-
@@ -314,17 +494,33 @@ steps:
             chunk_overlap_ratio: ctx.chunk_overlap_ratio
             markitdown_server: ctx.markitdown_server
             chunker_server: ctx.chunker_server
+            filter_none_conversions: ctx.filter_none_conversions
       collect: {transform: {value: "pipe"}}
-      output: per_file_items
+      output: per_file_outcomes
 
-  # Flatten the list-of-lists (one list per file) into one flat list of
-  # chunk items -- `fold` + list concatenation (R1's `+` also concatenates
-  # lists; there is no flatten/flatMap combinator).
+  # Flatten the per-file outcomes' item lists into one flat list of chunk
+  # items -- `fold` + list concatenation (R1's `+` also concatenates lists;
+  # there is no flatten/flatMap combinator). A skipped file (#3010 cause 1)
+  # carries `items: []`, so it contributes nothing here BY CONSTRUCTION --
+  # no chunk, no embedding spend, no store entry.
   - fold:
-      over: ctx.per_file_items
+      over: ctx.per_file_outcomes
       init: "[]"
-      do: {transform: {value: "acc + item"}}
+      do: {transform: {value: "acc + item.items"}}
       output: all_items
+
+  # #3010 -- the skipped files, NAMED. `files_scanned` alone cannot tell an
+  # operator that a file was discovered but yielded nothing: that is exactly
+  # the "clean number over a poisoned index" reporting this bug was made of.
+  # Each entry is {source_path, reason} so the summary says WHICH file is
+  # absent from the corpus and WHY. A file is skipped iff it carries a
+  # reason -- one representation, so the three ways to yield nothing
+  # (isError / meta.empty / zero chunks) all report through one path.
+  - transform:
+      value: >-
+        map(filter(ctx.per_file_outcomes, o -> o.skipped_reason != ""),
+            o -> {source_path: o.source_path, reason: o.skipped_reason})
+      output: skipped_files
 
   # C5: fetch the existing corpus SCOPED TO THIS input_path (via
   # `parent_context` -- repurposed here as the ingest-root tag stamped on
@@ -408,6 +604,8 @@ steps:
   - transform:
       value: >-
         {files_scanned: count(ctx.files),
+         files_skipped: count(ctx.skipped_files),
+         skipped_files: ctx.skipped_files,
          chunks_upserted: ctx.upsert_outcome.upserted,
          chunks_removed: ctx.delete_result.structured.deleted,
          chunks_unchanged_skipped: ctx.unchanged_count,

--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -18,7 +18,11 @@ interpret:
 - ``meta``        — small structured signal the LLM reads inline as YAML frontmatter (``returncode``,
                     ``truncated``, …). High-signal-only: transport identifiers (``kind``, duplicate
                     ``status``, ``server``, ``tool`` echo) are dropped — they never change what the
-                    LLM does next. ``isError`` is retained as the sole error-path driver.
+                    LLM does next. ``isError`` is retained as the sole error-path driver (and is the
+                    one key ``seam.py`` keeps OUT of the frontmatter — the error path renders it).
+                    ``empty`` (#3010) is the "this success legitimately produced no body" fact. ``meta``
+                    is also the channel through which a DATA-path consumer (a pipeline step, via
+                    ``canonical_to_ctx_fields``) reads a fact whose only other form is display prose.
 
 FP-0056 PR-F1 — coverage enforcement by construction (this module's endgame). The pre-F1 design had
 two structural defects the 2026-07-09 dogfood incident exposed (a ``reyn_repo__read`` doc read
@@ -290,18 +294,47 @@ def error_to_canonical(result: dict) -> CanonicalToolResult:
     )
 
 
-def _explicit_empty(text: str, marker: str) -> str:
-    """Render a legit-empty SUCCESS body (an empty file read, a no-output command, an empty
-    template render, …) as an EXPLICIT marker instead of a blank string.
+def _explicit_empty(text: str, marker: str, meta: "dict[str, Any]") -> str:
+    """Record the FACT that a legit-empty SUCCESS body produced nothing (``meta["empty"] = True``)
+    and return that fact's CHAT RENDERING — an explicit marker ("(empty file)" / "(no output)" / …)
+    instead of a blank string.
 
-    Two reasons (FP-0056 v2 piece #2): (1) a blank ``text`` with no attachments on a non-error
-    result would spuriously fire the runtime ``canonical_degraded`` invariant, which exists to catch
-    a *success-mapper losing content it had* (M2) — a genuinely-empty success is not that loss;
-    (2) an explicit "(empty file)" / "(no output)" is better LLM UX than a blank tool result the
-    model has to guess about. Only mappers whose success path can legitimately produce no output
-    wrap their body here; a mapper that regresses to empty when it should always produce something
-    (or an unknown future mapper) still fires the invariant."""
-    return text if text.strip() else marker
+    Two reasons the marker exists (FP-0056 v2 piece #2): (1) a blank ``text`` with no attachments on
+    a non-error result would spuriously fire the runtime ``canonical_degraded`` invariant, which
+    exists to catch a *success-mapper losing content it had* (M2) — a genuinely-empty success is not
+    that loss; (2) an explicit "(empty file)" / "(no output)" is better LLM UX than a blank tool
+    result the model has to guess about. Only mappers whose success path can legitimately produce no
+    output wrap their body here; a mapper that regresses to empty when it should always produce
+    something (or an unknown future mapper) still fires the invariant.
+
+    #3010 — why ``meta`` is a REQUIRED parameter rather than the marker being the whole story. An
+    empty success is a TRUE and legitimate state, not an error: a scanned PDF with no text layer
+    converts perfectly, and "there is no text here" is the converter's honest report. The marker is
+    the right thing to SHOW a chat LLM. But a canonical result is also consumed as DATA
+    (``canonical_to_ctx_fields`` → a pipeline step's ``ctx.<name>``), and on that path the marker is
+    prose that OVERWRITES the very fact it describes: the builtin RAG ingest pipeline received the
+    literal string ``"(no content)"`` where the converter had faithfully returned ``""``, then
+    chunked it, EMBEDDED it (real token spend) and upserted it into the operator's vector store as
+    though it were the document's text — reporting a clean ``chunks_upserted: 1`` over a poisoned
+    index. The producer's signal was intact; this function destroyed it.
+
+    Hence the split this signature enforces: the FACT ("this body was legitimately empty") lives in
+    ``meta`` as structured data a data-path consumer READS; the marker is one RENDERING of that fact,
+    for the chat path. ``meta`` is required — not optional, not a return value a caller may drop — so
+    a mapper cannot render the display without also recording the fact (the same by-construction
+    discipline PR-F1 applied to the declarations themselves). A data-path consumer therefore never
+    has to string-match ``"(no content)"``: that string is today's phrasing of the display, not the
+    fact, and a consumer bound to it would break silently the day the wording changes.
+
+    ``empty`` is a SIBLING of ``isError``, never a substitute for it: an empty success is not an
+    error, and flagging it as one would be a lie (the converter succeeded). Unlike ``isError`` it DOES
+    render into the chat frontmatter — it is an ordinary signal, and stating outright that a success
+    produced no body is the same "better UX than a blank result" reasoning the marker rests on. It
+    ADDS a frontmatter line and never rewrites ``text``, which stays the marker byte-for-byte."""
+    if text.strip():
+        return text
+    meta["empty"] = True
+    return marker
 
 
 def mcp_to_canonical(result: dict) -> CanonicalToolResult:
@@ -318,13 +351,13 @@ def mcp_to_canonical(result: dict) -> CanonicalToolResult:
         attachments.append({"kind": "structured", "data": structured})
     for block in result.get("media_blocks") or []:
         attachments.append({"kind": "media", "block": block})
-    meta = {"isError": True} if _is_error(result) else {}
+    meta: dict[str, Any] = {"isError": True} if _is_error(result) else {}
     text = result.get("content", "") or ""
     # A successful MCP call with no content AND no attachments renders an explicit empty (else the
     # canonical_degraded invariant fires on a legit no-output tool). An error keeps its (possibly
     # terse) message untouched; an attachment-carrying result already has visible content.
     if not attachments and not _is_error(result):
-        text = _explicit_empty(text, "(no content)")
+        text = _explicit_empty(text, "(no content)", meta)
     return CanonicalToolResult(
         text=text,
         attachments=attachments,
@@ -349,10 +382,10 @@ def mcp_read_resource_to_canonical(result: dict) -> CanonicalToolResult:
             text_parts.append(str(item["text"]))
         elif "blob" in item:
             attachments.append({"kind": "structured", "data": item})
-    meta = {"isError": True} if _is_error(result) else {}
+    meta: dict[str, Any] = {"isError": True} if _is_error(result) else {}
     text = "\n".join(text_parts)
     if not attachments and not _is_error(result):
-        text = _explicit_empty(text, "(no content)")
+        text = _explicit_empty(text, "(no content)", meta)
     return CanonicalToolResult(
         text=text,
         attachments=attachments,
@@ -377,10 +410,10 @@ def mcp_get_prompt_to_canonical(result: dict) -> CanonicalToolResult:
             text_parts.append(str(content["text"]))
         elif content is not None:
             attachments.append({"kind": "structured", "data": content})
-    meta = {"isError": True} if _is_error(result) else {}
+    meta: dict[str, Any] = {"isError": True} if _is_error(result) else {}
     text = "\n".join(text_parts)
     if not attachments and not _is_error(result):
-        text = _explicit_empty(text, "(no content)")
+        text = _explicit_empty(text, "(no content)", meta)
     return CanonicalToolResult(
         text=text,
         attachments=attachments,
@@ -397,10 +430,10 @@ def web_fetch_to_canonical(result: dict) -> CanonicalToolResult:
     ``"text/html"``) is carried on the RENDERER-only ``content_type`` sidecar (#2663), never into
     ``meta``/the frontmatter, so present's stage-3 default viewer can pick a markdown/code default
     for the offloaded body without the LLM-visible frontmatter growing a transport field."""
+    meta: dict[str, Any] = {}
     content = result.get("content")
     text = content if content else str(result.get("preview") or "")
-    text = _explicit_empty(text, "(no content)")
-    meta: dict[str, Any] = {}
+    text = _explicit_empty(text, "(no content)", meta)
     if result.get("truncated"):
         meta["truncated"] = True
         next_start = result.get("next_start")
@@ -461,8 +494,8 @@ def sandboxed_exec_to_canonical(result: dict) -> CanonicalToolResult:
         text = stdout
     # A command that produced no stdout/stderr (e.g. mkdir/touch/mv) renders an explicit empty so the
     # canonical_degraded invariant does not fire on a legit no-output exec (returncode carries signal).
-    text = _explicit_empty(text, "(no output)")
     meta: dict[str, Any] = {}
+    text = _explicit_empty(text, "(no output)", meta)
     returncode = result.get("returncode")
     if returncode:  # nonzero (or truthy) only — a 0 exit is not actionable signal
         meta["returncode"] = returncode
@@ -491,7 +524,8 @@ def shell_to_canonical(result: dict) -> CanonicalToolResult:
     a JSON-emitting command), else the raw text. ``stderr``/``returncode`` never reach this seam (they
     are dropped one layer up, by that same locked design) — the one respect this mapper CANNOT mirror
     ``sandboxed_exec_to_canonical`` (whose ``returncode`` signal meta this would carry, were it visible
-    here); ``meta`` is therefore always empty for ``shell``.
+    here); ``meta`` therefore carries no signal of its OWN for ``shell`` — only the shared ``empty``
+    fact a no-output command records through :func:`_explicit_empty` (#3010).
 
     The shape THIS mapper actually receives (post ``unwrap_dispatch_envelope``) is one of:
 
@@ -509,8 +543,9 @@ def shell_to_canonical(result: dict) -> CanonicalToolResult:
     else:
         value = result
     text = value if isinstance(value, str) else json.dumps(value, default=str)
-    text = _explicit_empty(text, "(no output)")
-    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
+    meta: dict[str, Any] = {}
+    text = _explicit_empty(text, "(no output)", meta)
+    return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
 
 
 def chunks_to_canonical(result: dict) -> CanonicalToolResult:
@@ -544,13 +579,20 @@ def run_pipeline_to_canonical(result: dict) -> CanonicalToolResult:
     ruling)."""
     output = result.get("output")
     if isinstance(output, str):
+        meta: dict[str, Any] = {}
+        text = _explicit_empty(output, "(no output)", meta)
         return CanonicalToolResult(
-            text=_explicit_empty(output, "(no output)"), attachments=[], source_ref=None, meta={},
+            text=text, attachments=[], source_ref=None, meta=meta,
         )
     if output is None:
         # A pipeline that completed with no final output: explicit empty text (no structured to carry
-        # it), so a legit no-output run does not fire the canonical_degraded invariant.
-        return CanonicalToolResult(text="(no output)", attachments=[], source_ref=None, meta={})
+        # it), so a legit no-output run does not fire the canonical_degraded invariant. Routed through
+        # ``_explicit_empty`` rather than hardcoding the marker so this branch records the SAME
+        # ``meta.empty`` fact as its sibling above (#3010) — a caller reading a pipeline's result as
+        # DATA must not have to tell these two no-output paths apart by their prose.
+        none_meta: dict[str, Any] = {}
+        text = _explicit_empty("", "(no output)", none_meta)
+        return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=none_meta)
     return CanonicalToolResult(
         text="", attachments=[{"kind": "structured", "data": output}], source_ref=None, meta={},
     )
@@ -617,7 +659,7 @@ def file_to_canonical(result: dict) -> CanonicalToolResult:
         # An empty file read (no media blocks carrying an image body) renders an explicit empty so the
         # canonical_degraded invariant does not fire on a legit read of a genuinely empty file.
         if not attachments:
-            text = _explicit_empty(text, "(empty file)")
+            text = _explicit_empty(text, "(empty file)", meta)
         return CanonicalToolResult(
             text=text, attachments=attachments, source_ref=None, meta=meta,
         )
@@ -741,8 +783,8 @@ def reyn_repo_to_canonical(result: dict) -> CanonicalToolResult:
     fallback + fires ``canonical_fallback_used`` — the SAME recoverable output as the old inline
     whole-dict return, now AUDITED (fail-visible) rather than silently unmapped."""
     if "content" in result:
-        meta = {"path": result["path"]} if result.get("path") is not None else {}
-        text = _explicit_empty(result.get("content", "") or "", "(empty file)")
+        meta: dict[str, Any] = {"path": result["path"]} if result.get("path") is not None else {}
+        text = _explicit_empty(result.get("content", "") or "", "(empty file)", meta)
         return CanonicalToolResult(
             text=text, attachments=[], source_ref=None, meta=meta,
         )
@@ -789,7 +831,7 @@ def render_template_to_canonical(result: dict) -> CanonicalToolResult:
     undefined_vars = result.get("undefined_vars")
     if undefined_vars:
         meta["undefined_vars"] = undefined_vars
-    text = _explicit_empty(result.get("rendered", "") or "", "(empty render)")
+    text = _explicit_empty(result.get("rendered", "") or "", "(empty render)", meta)
     return CanonicalToolResult(
         text=text, attachments=[], source_ref=None, meta=meta,
     )
@@ -866,7 +908,7 @@ def memory_body_to_canonical(result: dict) -> CanonicalToolResult:
         value = result.get(key)
         if value is not None:
             meta[key] = value
-    text = _explicit_empty(result.get("content", "") or "", "(empty)")
+    text = _explicit_empty(result.get("content", "") or "", "(empty)", meta)
     return CanonicalToolResult(
         text=text, attachments=[], source_ref=None, meta=meta,
     )
@@ -922,7 +964,7 @@ def make_status_text_mapper(
                 meta[key] = value
         if result.get("status") == "cancelled":
             return CanonicalToolResult(text="Cancelled.", attachments=[], source_ref=None, meta=meta)
-        text = _explicit_empty(render(result), empty_marker)
+        text = _explicit_empty(render(result), empty_marker, meta)
         return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta=meta)
 
     return _mapper
@@ -1239,9 +1281,10 @@ def ask_user_to_canonical(result: dict) -> CanonicalToolResult:
         reason = str(result.get("reason", "") or "")
         text = f"(no answer — refused: {reason})" if reason else "(no answer — refused)"
         return CanonicalToolResult(text=text, attachments=[], source_ref=None, meta={})
-    text = _explicit_empty(str(result.get("answer", "") or ""), "(no answer)")
+    meta: dict[str, Any] = {}
+    text = _explicit_empty(str(result.get("answer", "") or ""), "(no answer)", meta)
     return CanonicalToolResult(
-        text=text, attachments=[], source_ref=None, meta={},
+        text=text, attachments=[], source_ref=None, meta=meta,
     )
 
 
@@ -1764,8 +1807,17 @@ def canonical_to_ctx_fields(canonical: CanonicalToolResult) -> "dict[str, Any]":
     ``meta`` is the producer's SIGNAL channel — the small, high-signal fields a mapper deliberately
     kept out of the body because they change what the caller does next: ``embed``'s ``model``/
     ``total_tokens``/``cost_usd``/``priced``, ``sandboxed_exec``'s nonzero ``returncode``, an MCP
-    result's ``isError``. The chat side has always seen these (``seam.py`` reads ``meta``); the
-    pipeline side did not, so a ``tool:`` step could read a producer's body but never its signal.
+    result's ``isError``, and (#3010) ``empty`` — "this success legitimately produced no content".
+    The chat side has always seen these (``seam.py`` reads ``meta``); the pipeline side did not, so a
+    ``tool:`` step could read a producer's body but never its signal.
+
+    ``empty`` is why this reducer, not just the chat renderer, is load-bearing. ``text`` is written
+    FOR the chat path: a legitimately-empty body arrives here as the prose marker ``"(no content)"``,
+    which is a *rendering* of a fact, not the fact. A pipeline that reads only ``text`` cannot tell
+    "the document said '(no content)'" from "the document was empty" — the FP-0063 ingest pipeline
+    could not, and embedded the marker into the operator's vector store (#3010). ``meta.empty``
+    gives the data path the fact itself, so no consumer ever has to string-match display prose (which
+    would break silently the day the wording changes).
 
     FP-0063 P3 (#2966) is why this is no longer acceptable: the ingest pipeline must stamp each
     chunk's ``embedding_model`` from the model that ACTUALLY produced the vectors (FP-0057 C4 —

--- a/src/reyn/core/offload/seam.py
+++ b/src/reyn/core/offload/seam.py
@@ -80,6 +80,10 @@ def build_offload_body(
             structured_items.append(att.get("data"))
 
     # Signal meta goes to the frontmatter as-is (``isError`` is handled by the error path, never here).
+    # ``empty`` (#3010) deliberately DOES render: it is an ordinary signal, the same class as
+    # ``returncode``/``truncated``, and telling the LLM outright that a success produced no body is
+    # the same "better UX than a blank result" reasoning the explicit marker itself rests on. It
+    # ADDS a frontmatter line; it never rewrites ``text``, which stays the marker byte-for-byte.
     frontmatter: dict[str, Any] = {
         k: v for k, v in (canonical.get("meta") or {}).items() if k != "isError"
     }

--- a/tests/test_3010_empty_success_fact_data_path.py
+++ b/tests/test_3010_empty_success_fact_data_path.py
@@ -1,0 +1,138 @@
+"""A legitimately-empty tool success is readable as a FACT, not only as display prose (#3010).
+
+The invariant under test is a seam rule of the canonical layer, not a bug repro: a canonical result
+is consumed by TWO paths with different needs, and an empty success must be legible to both.
+
+- The CHAT path reads a rendering. A blank tool body is bad LLM UX, so a legit-empty success renders
+  as an explicit marker ("(no content)" / "(no output)" / "(empty file)"). That is prose, chosen for
+  a reader.
+- The DATA path (a pipeline `tool:` step, via ``canonical_to_ctx_fields``) reads values. Handed only
+  the marker, it cannot distinguish "the document contained the text '(no content)'" from "the
+  document was empty" -- and it must never have to string-match display prose to find out, because
+  that binds a data consumer to today's chat wording.
+
+An empty success is a TRUE state, NOT an error: a scanned PDF with no text layer converts perfectly,
+and "there is no text here" is the converter's honest report. So the fact rides ``meta.empty``, a
+sibling of ``meta.isError`` -- never ``isError`` itself, which would be a lie about a success.
+
+These pin the invariant in both directions: the fact is present for the data path, AND the chat
+rendering is unchanged by its presence (the marker still IS the body; the fact is not echoed into
+the frontmatter, where it would only restate what the body already says).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.offload.canonical import canonical_to_ctx_fields, to_canonical
+from reyn.core.offload.seam import build_offload_body, render_tool_result
+from reyn.tools import get_default_registry
+
+# Canonical declarations are born at the REGISTRATION seam (FP-0056 PR-F1), so the registry must be
+# built before ``to_canonical`` can dispatch on an invoked identity -- otherwise every case below
+# silently takes the whole-dict fallback and asserts nothing about its mapper (observed while
+# writing these: all 10 cases failed on the fallback shape, not on the invariant).
+get_default_registry()
+
+# (source, empty-success result, the marker that success renders as) for the producers whose success
+# path can legitimately yield no body. Driven through the REAL ``to_canonical`` dispatch (the invoked
+# identity), not by reaching for a private mapper.
+#
+# Deliberately NOT MCP-only. Whether the MCP mappers reach ``_explicit_empty`` at all depends on the
+# third-party server's SDK version: a server on a ``structuredContent``-era SDK returns
+# ``{"content": "", "structuredContent": {"result": ""}}``, which reyn carries as a structured
+# attachment -- and the mapper skips the marker when an attachment is present. The producers below
+# that never touch MCP (``read_file``/``shell``/``sandboxed_exec``/``render_template``) call
+# ``_explicit_empty`` directly, so they pin this invariant independently of any SDK version.
+_EMPTY_SUCCESS_CASES = [
+    # --- non-MCP: reached today, on every SDK ---
+    ("read_file", {"op": "read", "status": "ok", "content": ""}, "(empty file)"),
+    ("shell", {"status": "ok", "data": ""}, "(no output)"),
+    ("sandboxed_exec", {"stdout": "", "stderr": "", "returncode": 0}, "(no output)"),
+    ("render_template", {"rendered": ""}, "(empty render)"),
+    ("read_memory_body", {"content": ""}, "(empty)"),
+    ("run_pipeline", {"output": ""}, "(no output)"),
+    # A pipeline that finished with no output at all -- the branch that hardcoded its marker
+    # instead of calling the helper, and so was invisible to a grep for it.
+    ("run_pipeline", {"output": None}, "(no output)"),
+    # --- MCP: reachable when the server emits no structuredContent ---
+    ("call_mcp_tool", {"content": ""}, "(no content)"),
+    ("read_mcp_resource", {"contents": []}, "(no content)"),
+    ("web_fetch", {"content": "", "preview": ""}, "(no content)"),
+]
+
+
+@pytest.mark.parametrize("source,result,marker", _EMPTY_SUCCESS_CASES)
+def test_empty_success_carries_the_fact_to_the_data_path(
+    source: str, result: dict, marker: str,
+) -> None:
+    """Tier 2b: an empty SUCCESS reaches a pipeline step as a readable fact (``meta.empty``).
+
+    This is what a data-path consumer reads INSTEAD of matching the marker string.
+    """
+    ctx_fields = canonical_to_ctx_fields(to_canonical(result, source=source))
+
+    assert ctx_fields.get("meta", {}).get("empty") is True, (
+        f"{source}: an empty success must be a readable fact on the data path -- otherwise the only "
+        f"evidence it happened is the prose {marker!r}, which a consumer would have to string-match"
+    )
+    # ...and it is NOT an error: the producer succeeded. Flagging it would be a false report, and
+    # would route a legitimate empty down an error path.
+    assert "isError" not in ctx_fields.get("meta", {}), (
+        f"{source}: an empty success is not an error -- the conversion/command succeeded"
+    )
+
+
+@pytest.mark.parametrize("source,result,marker", _EMPTY_SUCCESS_CASES)
+def test_empty_success_still_renders_its_marker_to_the_llm(
+    source: str, result: dict, marker: str,
+) -> None:
+    """Tier 2b: the LLM-visible BODY is untouched -- ``text`` stays the marker, byte for byte.
+
+    Recording the fact may ADD a frontmatter signal (``empty`` renders, like ``returncode`` and
+    unlike ``isError``), but it must never rewrite the body: a data-path fix that changed what the
+    chat LLM reads would be a regression in the path that was working.
+    """
+    canonical = to_canonical(result, source=source)
+    frontmatter, text, _media, _content_type = build_offload_body(canonical)
+
+    assert text == marker, f"{source}: the LLM must still see the explicit marker, not a blank body"
+    assert frontmatter.get("empty") is True, (
+        f"{source}: the fact is an ordinary signal -- the LLM reads it alongside the marker"
+    )
+    # The fact reaches the LLM as a frontmatter line; the marker survives verbatim as the body.
+    rendered = render_tool_result(frontmatter, text)
+    assert rendered.endswith(marker)
+    assert "empty: true" in rendered
+
+
+def test_non_empty_success_is_not_flagged_empty() -> None:
+    """Tier 2b: falsify direction -- the fact tracks emptiness, it is not stamped unconditionally.
+
+    Without this, a mapper that always set the flag would pass every assertion above while telling
+    the data path that every document is empty.
+    """
+    ctx_fields = canonical_to_ctx_fields(
+        to_canonical({"content": "real document text"}, source="call_mcp_tool"),
+    )
+
+    assert ctx_fields["text"] == "real document text"
+    assert "empty" not in ctx_fields.get("meta", {})
+
+
+def test_a_document_whose_text_is_the_marker_is_distinguishable_from_an_empty_one() -> None:
+    """Tier 2b: the fact -- not the prose -- is what separates the two.
+
+    This is the case a string-matching consumer gets wrong, and the reason the fact must exist: both
+    results render the identical body, so ``text`` alone cannot tell them apart. A document that
+    genuinely contains "(no content)" is real content and must be indexed; an empty one must not.
+    """
+    real_doc = canonical_to_ctx_fields(
+        to_canonical({"content": "(no content)"}, source="call_mcp_tool"),
+    )
+    empty_doc = canonical_to_ctx_fields(to_canonical({"content": ""}, source="call_mcp_tool"))
+
+    assert real_doc["text"] == empty_doc["text"], (
+        "precondition: the two are indistinguishable by text -- that is the whole problem"
+    )
+    assert "empty" not in real_doc.get("meta", {}), "a real document is not empty"
+    assert empty_doc.get("meta", {}).get("empty") is True

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -22,7 +22,7 @@ parser/executor, the MCP client/gateway/permission gate, the two real
 builtin MCP servers, sqlite-vec/apsw/chonkie -- is real.
 
 Coverage:
-  1. Parse: both pipeline files parse cleanly (four + three ``pipeline:``
+  1. Parse: both pipeline files parse cleanly (eight + three ``pipeline:``
      docs respectively) via ``parse_pipeline_docs``.
   2. C5 add/update/remove convergence + X5 dedup visibility: ingest a
      2-file folder, re-ingest unchanged (0 upserts, dedup skip reported),
@@ -249,14 +249,15 @@ def _run_ingest(project_root: Path, capsys: pytest.CaptureFixture, **input_overr
 
 
 def test_rag_ingest_pipeline_parses() -> None:
-    """Tier 2b: rag_ingest.yaml parses -- 6 pipeline: docs (ingest, _blocked,
-    _ingest_one_file, _ingest_body, _ingest_embed_and_upsert,
-    _ingest_noop_upsert)."""
+    """Tier 2b: rag_ingest.yaml parses -- 8 pipeline: docs (ingest, _blocked,
+    _ingest_one_file, _ingest_chunk_file, _ingest_skipped_file, _ingest_body,
+    _ingest_embed_and_upsert, _ingest_noop_upsert)."""
     docs = parse_pipeline_docs(_INGEST_PATH.read_text(encoding="utf-8"), SchemaRegistry())
     names = {p.name for p in docs}
     assert names == {
-        "ingest", "_blocked", "_ingest_one_file", "_ingest_body",
-        "_ingest_embed_and_upsert", "_ingest_noop_upsert",
+        "ingest", "_blocked", "_ingest_one_file", "_ingest_chunk_file",
+        "_ingest_skipped_file", "_ingest_body", "_ingest_embed_and_upsert",
+        "_ingest_noop_upsert",
     }
 
 
@@ -317,6 +318,149 @@ def test_ingest_add_then_dedup_then_update_then_remove(
     assert summary_4["files_scanned"] == 1
     assert summary_4["chunks_removed"] >= 1
     assert summary_4["chunks_upserted"] == 0
+
+
+def test_only_real_document_content_reaches_the_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2c: a file that yields no usable document is NOT indexed, and IS reported (#3010).
+
+    The invariant: what lands in the operator's vector store is document content -- never a
+    converter's error message, never reyn's own prose about the absence of content -- and a file that
+    contributed nothing is NAMED, because "the operator cannot tell what happened" is the failure
+    this pipeline shipped with. Asserted against the REAL sqlite store, not only the summary: a clean
+    ``chunks_upserted`` over a poisoned index IS the bug.
+
+    Two of the three ways a file yields nothing are exercised here:
+
+    - the conversion FAILS (``meta.isError``) -- the MCP layer raises nothing, so ``for_each``'s
+      ``on_error: continue`` never fires; the error MESSAGE was chunked+embedded as content;
+    - the conversion SUCCEEDS but yields no text -- caught here by the ZERO-CHUNK gate. Note which
+      gate fires and why: this stub runs on a ``structuredContent``-era MCP SDK, so an empty
+      conversion arrives as ``{"content": "", "structuredContent": {"result": ""}}`` -- a structured
+      attachment, and an attachment-carrying result never takes the explicit-empty path. So
+      ``meta.empty`` is ABSENT here, and before the zero-chunk gate this file vanished unreported
+      (measured: ``files_scanned: 3, files_skipped: 1``, notext.pdf in neither index nor report).
+
+    The third way -- ``meta.empty``, the marker path that motivated #3010 -- is NOT witnessed by this
+    test and cannot be, for the SDK reason above. It is pinned SDK-independently against the non-MCP
+    producers in ``tests/test_3010_empty_success_fact_data_path.py``.
+
+    Stub fidelity (the stub stands in for markitdown-mcp -- see module docstring): both branches ride
+    the stub's own natural behavior over real fixture bytes, mirroring what the real library was
+    MEASURED to do at this boundary (``MarkItDown().convert_uri(...).markdown`` on the #3010
+    fixtures): a no-text-layer PDF returns ``''`` (here: an empty file the stub reads as ``''``) and
+    an unparseable PDF RAISES, surfaced as ``isError`` (here: undecodable bytes raise
+    UnicodeDecodeError). No sentinel or special-case branch is added to the stub.
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    # A real document -- the falsify direction: the gates must skip the unusable files WITHOUT
+    # skipping this one (a fix that indexed nothing would satisfy every "no garbage" assertion).
+    (docs_dir / "good.txt").write_text("Penguins huddle together for warmth.", encoding="utf-8")
+    # Converts fine, holds no text (the scanned-PDF class) -> "" -> "(no content)".
+    (docs_dir / "notext.pdf").write_bytes(b"")
+    # Cannot be parsed at all -> the converter raises -> isError.
+    (docs_dir / "corrupt.pdf").write_bytes(b"\xff\xfe\x00\x01broken")
+
+    summary = _run_ingest(project_root, capsys)["named_stores"]["result"]
+
+    from reyn.builtin.mcp_servers.vector_store_server import SqliteVecStore
+
+    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+        rows = store.list_metadata()
+
+    indexed = {Path(r["metadata"]["source_path"]).name for r in rows}
+    assert indexed == {"good.txt"}, (
+        "only real document content may be indexed -- a file that yielded no document must "
+        f"contribute no chunks, got {sorted(indexed)}"
+    )
+    assert summary["files_scanned"] == 3
+    assert summary["files_skipped"] == 2, (
+        "a discovered-but-unusable file must be REPORTED; a clean chunks_upserted over a poisoned "
+        "index is exactly the failure this guards"
+    )
+    # The report NAMES each file, so the operator can tell which documents their corpus lacks.
+    skipped = {Path(s["source_path"]).name: s["reason"] for s in summary["skipped_files"]}
+    assert set(skipped) == {"notext.pdf", "corrupt.pdf"}
+    assert all(reason for reason in skipped.values()), "each skip must carry a reason"
+
+
+def test_a_none_conversion_is_reported_as_a_failure_not_indexed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2c: a conversion whose whole output is "None" is treated as a failed conversion (#3010).
+
+    markitdown MANUFACTURES the string "None" from a file it cannot decode and reports SUCCESS
+    (``PlainTextConverter`` runs ``str(from_bytes(...).best())`` with no None check, and
+    ``str(None) == "None"``), which suppresses markitdown's own FileConversionException path. reyn
+    cannot see that from the outside, so the pipeline defends locally -- and reports through the
+    SAME named-with-a-reason path as any other failed conversion, rather than inventing a third.
+
+    The boundary is what makes this a filter and not a blunt instrument, so both directions are
+    pinned: EXACT equality drops the manufactured value, while a real document that merely MENTIONS
+    None is indexed untouched.
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    # The bug's signature: the converter's entire output is "None".
+    (docs_dir / "undecodable.txt").write_text("None", encoding="utf-8")
+    # A real document that merely mentions None -- must survive (the falsify direction: an
+    # `"None" in text` filter would silently drop this legitimate content).
+    (docs_dir / "real.txt").write_text(
+        "The function returns None when the cache is cold.", encoding="utf-8",
+    )
+
+    summary = _run_ingest(project_root, capsys)["named_stores"]["result"]
+
+    from reyn.builtin.mcp_servers.vector_store_server import SqliteVecStore
+
+    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+        indexed = {Path(r["metadata"]["source_path"]).name for r in store.list_metadata()}
+
+    assert indexed == {"real.txt"}, (
+        "a document mentioning None is CONTENT and must be indexed; only the exact-match "
+        f"manufactured value is dropped -- got {sorted(indexed)}"
+    )
+    skipped = {Path(s["source_path"]).name: s["reason"] for s in summary["skipped_files"]}
+    assert set(skipped) == {"undecodable.txt"}
+    assert "None" in skipped["undecodable.txt"], "the reason must name what was seen"
+    assert "filter_none_conversions" in skipped["undecodable.txt"], (
+        "the reason must name the opt-out, since a document whose real content IS 'None' is "
+        "indistinguishable here -- the operator needs the lever named at the point of loss"
+    )
+
+
+def test_the_none_filter_is_opt_out(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2c: an operator can turn the None filter off, and then "None" is indexed as content.
+
+    The false positive is structural (a .txt whose real content is "None" reaches the pipeline
+    identically to the markitdown bug's output), so the escape hatch has to actually work -- a
+    default that cannot be overridden would make the corpus lossy with no recourse.
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "literally_none.txt").write_text("None", encoding="utf-8")
+
+    summary = _run_ingest(project_root, capsys, filter_none_conversions=False)["named_stores"]["result"]
+
+    from reyn.builtin.mcp_servers.vector_store_server import SqliteVecStore
+
+    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+        indexed = {Path(r["metadata"]["source_path"]).name for r in store.list_metadata()}
+
+    assert indexed == {"literally_none.txt"}, (
+        "with the filter off, 'None' is ordinary content and must be indexed"
+    )
+    assert summary["files_skipped"] == 0
 
 
 def test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias(


### PR DESCRIPTION
**[per-PR-coder]** — part of #3010

Broken files were indexed as if they were documents, and the run reported a clean number over the poisoned index. This fixes the two reyn-side causes, plus two more paths found while measuring.

## The witness (measured, same 4 fixtures, before vs after)

**Before** — three of four files produce garbage or silence:

```
### WHAT LANDS IN THE STORE ###
indexed files: ['corrupt.pdf', 'good.txt', 'undecodable.txt']

### WHAT THE OPERATOR SEES ###
{ "files_scanned": 4, "files_skipped": "<field does not exist>",
  "chunks_upserted": 3, "tokens_embedded": 152 }
```

`corrupt.pdf` is the converter's **error message**, indexed. `undecodable.txt` is the string **`"None"`**, indexed. `notext.pdf` is in neither the store nor any report — it simply vanished. **152 tokens of real embedding spend**, most of it on garbage.

**After** — only the real document is indexed; every other file is named with a reason:

```
### WHAT LANDS IN THE STORE ###
indexed files: ['good.txt']

### WHAT THE OPERATOR SEES ###
{ "files_scanned": 4, "files_skipped": 3,
  "chunks_upserted": 1, "tokens_embedded": 36 }

- undecodable.txt
    conversion returned the literal string "None" -- a markitdown bug (PlainTextConverter has no
    None check on charset detection failure), meaning the file could not be decoded at all. If this
    document's real content IS "None", set filter_none_conversions: false.
- corrupt.pdf
    conversion failed: Error calling tool 'convert_to_markdown': 'utf-8' codec can't decode byte 0xff...
- notext.pdf
    no chunks produced (the document converted, but yielded no text to index)
```

Spend drops 152 → 36 tokens: the 116 tokens were being burned on error text and `"None"`.

## Cause 2 — the structural fix (`_explicit_empty`)

`"(no content)"` is a **chat affordance** (verbatim: *"better LLM UX than a blank tool result"*). A canonical result is also read as **data** (`canonical_to_ctx_fields` → a pipeline's `ctx.<name>`), and on that path the marker is prose that **overwrites the fact it describes**: markitdown faithfully returns `""` (measured), and reyn replaced it with a sentence, which the pipeline then chunked and embedded.

The fix is the fact/display split: the FACT rides `meta.empty`; the marker is one **rendering** of it.

`meta` is a **required parameter** of `_explicit_empty`, so a mapper cannot render the display without recording the fact — bounded by construction, not by discipline. (A `-> tuple[str, bool]` variant was considered; it would leave `if is_empty: meta["empty"] = True` duplicated at every site, each able to silently forget the second line and stay green.)

`empty` is a **sibling of `isError`, never a substitute** — an empty success is not an error; the converter succeeded. It renders into the frontmatter like any other signal. **`text` is unchanged, byte for byte.**

**All 14 call sites** thread `meta`. That is 14, not 13: `run_pipeline_to_canonical`'s `output is None` branch **hardcoded `"(no output)"` without calling the helper**, so it was invisible to a grep for `_explicit_empty` — the same fact, expressed as a duplicate. It now goes through the helper.

## Cause 1 + two more, all reporting through one path

1. **`meta.isError`** — a failed conversion returns `isError` as a *result*; nothing raises, so `for_each`'s `on_error: continue` never fired and the error message was indexed as content.
2. **`meta.empty`** — the marker path above.
3. **Zero chunks** *(found while measuring)* — a file that converts to nothing chunks to nothing and **vanished unreported**. Live today: measured `files_scanned: 3, files_skipped: 1` with `notext.pdf` in neither the index nor the report. This gate reads the structural outcome, so it needs no marker, no meta and no SDK assumption.
4. **The `"None"` filter** — opt-out, default on, **exact equality**.

All four report through the **one** named-with-a-reason path: `files_skipped` + `skipped_files: [{source_path, reason}]`. A file can no longer leave the corpus silently.

## The `"None"` filter is a markitdown bug, not reyn's

A literal string comparison against a converter's output is normally indefensible. It is here because markitdown **manufactures** the string and reports success:

```
markitdown/converters/_plain_text_converter.py -- PlainTextConverter.convert()
    else:
        text_content = str(from_bytes(file_stream.read()).best())    # <- no None check
```

`charset_normalizer...best()` returns `None` for undecodable bytes; `str(None) == "None"`. Measured chain on a 16-byte non-PDF (fixture contains no `"None"` — hexdump-verified, so markitdown *generates* it):

```
PdfConverter       -> raised PDFSyntaxError "No /Root object!"   (correct)
PlainTextConverter -> SUCCESS  markdown='None'                   (the bug)
```

markitdown's own design is right (`_markitdown.py:624`: `if len(failed_attempts) > 0: raise FileConversionException(...)`). One missing None check makes `PlainTextConverter` "succeed", disabling markitdown's official error channel — which is why a defense this crude is all that is left at this layer.

**Exact equality, never `"None" in text`** — a document that merely mentions None must not be dropped (pinned by a test). Even so, a `.txt` whose real content *is* `"None"` is **content, not a bug**, and this pipeline cannot see which markitdown branch ran. That false positive is **structural**, hence the opt-out (`filter_none_conversions: false`) rather than cleverness. No extension sniffing: "only distrust `.pdf`" would be a guess about which converters reach this path.

## Correction to the record (#3011's premise)

The issue states markitdown returns `None` and FastMCP's `-> str` stringifies it. **Falsified by direct measurement**: `MarkItDown().convert_uri(...).markdown` returns the **`str` `'None'`** (`.text_content` too). FastMCP is not the stringifier; markitdown is. #3011 is closed; no wrapper.

## Tests

- `tests/test_3010_empty_success_fact_data_path.py` — the fact/display invariant, both directions (fact present for data; `text` unchanged for chat), plus the case that motivates it: a document whose text *is* `"(no content)"` vs an empty one render **identically**, so `text` alone cannot separate them.
  - Driven through the real `to_canonical` dispatch, and deliberately **not MCP-only**. Whether the MCP mappers reach `_explicit_empty` depends on the third-party server's SDK: a `structuredContent`-era server returns `{"content": "", "structuredContent": {"result": ""}}`, and an attachment-carrying result skips the marker path. The non-MCP producers (`read_file`/`shell`/`sandboxed_exec`/`render_template`/`read_memory_body`/`run_pipeline`) call it directly, pinning the invariant independently of any SDK version.
- `tests/test_fp0063_p3_rag_pipelines.py` — three e2e against the **real sqlite store**: only real content is indexed; the `"None"` filter's exact-match boundary; the opt-out.

**Falsify:** stripping `meta["empty"] = True` turns the 5 data-path tests RED while the 5 chat-rendering tests stay green — correct, since those assert the chat path is *unchanged*.

**Honest limits:** the `meta.empty` gate is **not** witnessed by the RAG e2e and cannot be — the stub runs a `structuredContent`-era SDK, so that path is unreachable there (the zero-chunk gate catches the file instead). It is pinned SDK-independently in the unit tests. The stub's two branches ride its natural behavior over real fixture bytes, mirroring the measured real-library boundary (no-text-layer → `''`; unparseable → raises); no sentinel was added.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — 18 inspected, 0 Tier-4
- [x] `pytest` (repo root) — read from pytest's own summary line, not `tail`
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] Before/after witness measured on the same fixtures (above)
- [x] Falsify: strip the fix → RED
- [x] Worktree probe under pytest using a symbol only this branch has (`_explicit_empty`'s `meta` param + `filter_none_conversions`) — resolves this tree
