### PR TITLE
fix: RAG skill/cookbook default to cwd-relative output_db (#3009 item 1)

### DIFF
--- a/docs/cookbook/configs/with-builtin-rag-mcp.yaml
+++ b/docs/cookbook/configs/with-builtin-rag-mcp.yaml
@@ -96,17 +96,40 @@
 #
 # Once the three servers above are configured + granted, invoke the builtin
 # pipelines by name. `input_path` must be ABSOLUTE (the pipeline globs it
-# directly); it may be a folder or a single file:
+# directly); it may be a folder or a single file. `output_db`/`db`, in
+# contrast, is a plain sandboxed write: the default write grant for a
+# stdio MCP server is its own `cwd` (the directory you ran `reyn` from),
+# so a CWD-RELATIVE path needs no extra config at all -- this is the
+# zero-config default, not a shortcut:
 #
 #   run_pipeline(name="rag_ingest.ingest", input={
-#     "input_path": "/abs/path/to/docs", "output_db": "/abs/path/to/docs.sqlite"})
+#     "input_path": "/abs/path/to/docs", "output_db": "./rag/docs.sqlite"})
 #   run_pipeline(name="rag_query.query", input={
-#     "query_text": "how does X work?", "db": "/abs/path/to/docs.sqlite"})
+#     "query_text": "how does X work?", "db": "./rag/docs.sqlite"})
 #
 # Or, outside a chat session:
 #
 #   reyn pipe run rag_ingest.ingest \
-#     --input '{"input_path": "/abs/path/to/docs", "output_db": "/abs/path/to/docs.sqlite"}'
+#     --input '{"input_path": "/abs/path/to/docs", "output_db": "./rag/docs.sqlite"}'
+#
+# Want the store somewhere OUTSIDE cwd instead (an absolute path, or a
+# path in another project)? That is supported, but it is a DECLARED
+# DEVIATION from the default above, not a drop-in substitute for it: add
+# a `write_paths` entry naming that location to the `reyn_vector_store`
+# server's own config --
+#
+#   mcp:
+#     servers:
+#       reyn_vector_store:
+#         type: stdio
+#         command: reyn-rag-vector-store
+#         write_paths: ["~/reyn-rag"]
+#
+# -- then `output_db`/`db` may point anywhere under it, absolute or not.
+# Without a matching `write_paths` entry, the sandbox DENIES the write and
+# the ingest fails with a raw sqlite error, not a reyn-authored one -- do
+# not hand an absolute `output_db` to `rag_ingest` unless this is already
+# in place.
 #
 # The `build_and_query_rag_corpus` builtin SKILL (FP-0063 P4) carries the
 # "when/how" these two one-line descriptions cannot: which of reyn's two

--- a/src/reyn/builtin/skills/build_and_query_rag_corpus/SKILL.md
+++ b/src/reyn/builtin/skills/build_and_query_rag_corpus/SKILL.md
@@ -48,11 +48,16 @@ a crash. When you get one:
 
 **1. Ingest** -- `input_path` **must be absolute**; the pipeline globs it
 directly, and a relative pattern yields the wrong `source_path` column.
+`output_db`, in contrast, is written by the `reyn_vector_store` MCP server
+itself and resolves like any other write: **relative to the sandbox's
+default write grant, which is the directory you ran `reyn` from.** A
+**cwd-relative `output_db` needs no config at all** -- keep it there unless
+the operator wants the store somewhere else (see below).
 
 ```
 run_pipeline(name="rag_ingest.ingest", input={
   "input_path": "/abs/path/to/docs",        # a folder OR a single file
-  "output_db": "/abs/path/to/docs.sqlite",
+  "output_db": "./rag/docs.sqlite",         # zero-config: written under cwd
 })
 ```
 
@@ -67,10 +72,19 @@ with `priced: false` means the model could not be priced -- report it as
 ```
 run_pipeline(name="rag_query.query", input={
   "query_text": "how does X work?",
-  "db": "/abs/path/to/docs.sqlite",
+  "db": "./rag/docs.sqlite",
   "top_k": 5,                                # default 5
 })
 ```
+
+**Want the store somewhere outside cwd instead** (an absolute path, or a
+path outside the project)? That is supported, but it is a **declared
+deviation, not the default**: the operator must add a `write_paths` entry
+naming that location to the `reyn_vector_store` server's config (see
+`docs/cookbook/configs/with-builtin-rag-mcp.yaml`). Without it, the sandbox
+denies the write and the ingest fails with a raw sqlite error -- **do not
+pass an absolute `output_db`/`db` unless the operator has already declared
+`write_paths` for it.**
 
 Returns `[{id, distance, metadata}, ...]`, **nearest first**. `metadata`
 carries `source_path` / `chunk_index` / `content_hash` / `embedding_model`.
@@ -118,7 +132,7 @@ drop-in swap needs no edit at all -- just pass the new name:
 
 ```
 run_pipeline(name="rag_ingest.ingest", input={
-  "input_path": "/abs/docs", "output_db": "/abs/docs.sqlite",
+  "input_path": "/abs/docs", "output_db": "./docs.sqlite",
   "vectorstore_server": "my_qdrant",
 })
 ```


### PR DESCRIPTION
**[per-PR-coder]** — part of #3009 (item 1 only; item 2 = extending the write-denial hint to the tool-call path is separate, architect is designing it, not touched here).

## What

The shipped `build_and_query_rag_corpus` skill and `docs/cookbook/configs/with-builtin-rag-mcp.yaml` taught `/abs/path/to/docs.sqlite` as the primary `output_db`/`db` example. No shipped config declares `write_paths` for the `reyn_vector_store` MCP server, so the sandbox's default write grant is `[cwd]` only — an operator who copied the example verbatim as-is got a raw sqlite `EPERM`, not any reyn-authored guidance (owner-approved direction on #3009: "cookbook では宣言しなくても使えるパスも提示したいよね" — show the zero-config path first, absolute-path guidance is for the deliberate deviation).

Changed:
- `src/reyn/builtin/skills/build_and_query_rag_corpus/SKILL.md` — both `output_db` examples (ingest + backend-swap section) now use a cwd-relative path (`./rag/docs.sqlite` / `./docs.sqlite`) as the primary example, with a new paragraph explaining *why* (sandbox default write grant = cwd) and that an absolute path is a **declared deviation** requiring `write_paths`.
- `docs/cookbook/configs/with-builtin-rag-mcp.yaml` — same flip in the copy-paste block, plus a `write_paths` example (`mcp.servers.reyn_vector_store.write_paths: ["~/reyn-rag"]`) shown as the opt-in path for "want the store somewhere else."

`db_path`/`output_db` itself is NOT constrained to cwd — per FP-0063 C2 (vector store is EXTERNAL, reyn builds no adapter) and the owner's "reyn must not obstruct the operator's own environment prep." cwd-relative is the *recommended default example*, not an enforced restriction; absolute paths still work once `write_paths` is declared.

## Verified before changing the docs (the open question the brief flagged)

Traced the actual code path (not assumed): `src/reyn/mcp/client.py:1178` (`_build_mcp_sandbox_policy`) computes `cwd = self._config.get("cwd") or os.getcwd()` for the sandbox's write-path grant, and `client.py:1262` (`_open_stdio`) launches the `StdioTransport` with `cwd=self._config.get("cwd")` — i.e. when no `cwd` is configured (true of every shipped RAG server config), the subprocess simply **inherits reyn's own process cwd**, the same directory the write-grant computation used. `src/reyn/builtin/mcp_servers/vector_store_server.py:102-104` opens `db_path` with `apsw.Connection(db_path)` directly — no rewriting/resolution layer anywhere between the tool call and the subprocess (`client.py`'s `call_tool` / `gateway.py`'s `call_tool` pass the string through unmodified). So a relative path resolves exactly where an operator who `cd`'d into their project before running `reyn` would expect.

**Live witness** (not just code-reading): reused the real end-to-end harness from `tests/test_fp0063_p3_rag_pipelines.py` (real `chunker_server` + `vector_store_server` subprocesses, a stub standing in for `markitdown-mcp`, a fake embedding provider — no network) in a throwaway script, `cd`'d into a fresh temp project dir (mirroring the real operator sequence), then ran `rag_ingest.ingest` with the **exact literal `output_db` value now in the fixed SKILL.md** (`"./rag/docs.sqlite"`), with **no `write_paths` declared anywhere** — the shipped-cookbook shape:

```
PIPELINE SUMMARY: {
  "files_scanned": 1, "chunks_upserted": 1, "chunks_removed": 0,
  "chunks_unchanged_skipped": 0, "embedding_model": "fake/standard", ...
}
expected sqlite path = <project_root>/rag/docs.sqlite
expected path exists = True
WITNESS PASSED: relative output_db='./rag/docs.sqlite' landed exactly at
<project_root>/rag/docs.sqlite, matching the directory the operator invoked
`reyn pipe run` from, with NO write_paths declared.
```

i.e. the doc's primary example, copied verbatim, ingests successfully with zero extra config — the invariant the brief named.

## Scope

- Does NOT touch `db_path` constraints (FP-0063 C2 stays: vector store is external, no reyn adapter).
- Does NOT touch item 2 (extending the write-denial hint to the `upsert` tool-call failure path) — architect is designing that, wiring target (JSON-RPC tool-error payload, not stderr) only just settled.
- Does NOT touch `docs/guide/for-users/build-a-rag-corpus.md` — not named in the owner's item-1 scope; its own absolute-path examples are a pre-existing, separate gap this PR doesn't widen.

## 4 gates

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict <changed test files>` — **no-op**: no test files changed (doc/skill/cookbook only).
- `pytest` (repo root) — 8722 passed, 22 skipped. Read every skip with `-rs`: all 22 are pre-existing environment gates unrelated to this change (Linux-only sandbox backends, docker-VM bind-mount limitation, optional deps not installed — `trafilatura`/`slack_bolt`/`linebot`, machine-specific dotfile absence in `test_2976_mcp_sandbox_write_paths.py`, and two F4/F5-deferred a2a-router skips). None touch RAG/MCP-write-path code.
- `python scripts/verify_module_docstrings.py <changed src files>` — **no-op**: no `.py` files changed.

## Test plan
- [x] Live witness: exact SKILL.md example ingests end-to-end with zero config (above).
- [x] `ruff check src tests` clean.
- [x] Full `pytest` green, all skips inspected and unrelated.
- [x] `tests/test_fp0063_p4_builtin_rag_skill.py` (the skill's own fixture test, checks frontmatter/pointers, not path content) still passes.