### PR TITLE
ci: detect PR-body vs GitHub-parser closing-intent contradictions

### DIFF
--- a/.github/workflows/check-pr-closing-intent.yml
+++ b/.github/workflows/check-pr-closing-intent.yml
@@ -1,0 +1,42 @@
+name: PR closing-intent check
+
+# #3007: detect contradictions between what a PR body *declares* about
+# issue #N (Closes/Fixes/Resolves, or part-of/toward) and what GitHub's
+# own closing-issue parser (`closingIssuesReferences`) actually resolved
+# for #N — all *before* merge, while the PR is still open.
+#
+# A dedicated workflow (not folded into test.yml's bare `pull_request:`
+# trigger) because this check must also re-run on `edited` — an author
+# who edits the body after opening (e.g. adds/removes a `Closes #N`) needs
+# the gate to re-evaluate, and `edited` is not one of the default
+# pull_request event types.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  closing-intent:
+    name: closing-intent contradiction check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      # scripts/check_pr_closing_intent.py is stdlib-only (argparse / json /
+      # re / subprocess). No pip install needed.
+      - name: Check PR body vs GitHub's parsed closing intent
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/check_pr_closing_intent.py --pr "${{ github.event.pull_request.number }}"

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -13,8 +13,10 @@ Three checks, all facets of the same invariant:
   1. **false negative** — body declares closing intent (``Closes #N`` /
      ``Fixes #N`` / ``Resolves #N``, in any casing, even inside backticks)
      but N is NOT in ``closingIssuesReferences`` → the author *wanted* to
-     close N but GitHub's parser did not pick it up (wrong keyword form,
-     wrong issue number, etc). Real examples: #2990→#2620, #3006→#2972.
+     close N but GitHub's parser did not pick it up. In both real examples
+     the cause is backtick-fencing: #2990 wrote `` `Closes #2620` `` and
+     #3006 wrote `` `Closes #2972` ``, GitHub honored neither, and both
+     issues stayed open until a human closed them by hand.
   2. **false positive** — body declares non-closing intent (``part of #N`` /
      ``toward #N``) but N IS in ``closingIssuesReferences`` → the PR will
      auto-close N on merge despite the author saying it shouldn't. Real
@@ -27,6 +29,31 @@ Three checks, all facets of the same invariant:
      both checks 1 and 2 presuppose the author wrote *some* declaring
      phrase; an author who writes neither slips through both.
 
+Declaring-phrase vocabulary — three forms, all checked against the parser:
+
+  * **closing** — ``Closes #N`` / ``Fixes #N`` / ``Resolves #N``
+  * **non-closing (scope)** — ``part of #N`` / ``toward #N``
+  * **mention-only** — ``<!-- closing-check: discussing #N -->``
+
+The third form exists because a PR body that *talks about* closing keywords
+rather than using them is a real and unavoidable false-positive class for
+checks 1/2 — a doc PR, a CLAUDE.md rule-4 explanation, or this script's own
+PR, which must quote ``Closes #N`` to explain what it detects. It is also
+broader than quoting: #2989's ordinary prose "Order-dependency is resolved:
+#2975" collides with the keyword+``#N`` shape and trips check 1 with no
+keyword being discussed at all.
+
+The marker is a *declaration*, not a mute — it says "I mention N, I do not
+close N", and is checked against the parser exactly like the other two
+forms (marker says discussing #N while ``closingIssuesReferences`` contains
+N → check 2 FAILs). It is scoped per-issue, never body-wide, so a body that
+both declares and discusses keeps check 1 live on its genuine declaration.
+An HTML comment is the chosen form because it is invisible when rendered
+but visible, greppable, and explicit in the source — as against an
+invisible zero-width space, which is a disguise rather than a declaration:
+undiscoverable by the next author, who would then have no way to tell a
+true finding from a mystery red and would learn to ignore the gate.
+
 Design constraint (ratified in issue #3007's discussion): check 3 must NOT
 re-enumerate GitHub's own closing-keyword vocabulary (closes/fixes/resolves/
 closed/fixed/resolved/close/fix/resolve and so on) — that would be a census
@@ -38,10 +65,25 @@ parser output (``closingIssuesReferences``) remains the sole source of
 truth for what will actually close.
 
 Backtick defusal: Check 1 must still match ``Closes #N`` even when written
-as `` `Closes #N` `` — GitHub's real closing-keyword parser does not respect
-backticks for auto-closing either (hence the #3003 near-miss risk), so this
-script strips backtick characters from the body before matching rather than
-skipping fenced code spans.
+as `` `Closes #N` ``. GitHub's parser **does** respect backticks and will
+silently decline to close a fenced reference — that gap is precisely the
+defect check 1 exists to catch, not something to mirror. Verified on the
+motivating incidents: #2990's body carries a fully-backticked
+`` `Closes #2620` `` and #3006's a `` `Closes #2972` ``, and both PRs'
+``closingIssuesReferences`` are empty — which is *why* #2620 and #2972
+stayed open after merge and a human had to close them by hand.
+
+So this matcher is deliberately **stricter than** GitHub's, in the one
+direction that surfaces the contradiction: a fenced ``Closes #N`` is still
+the author *declaring* intent to close N, and GitHub not honoring it is the
+mismatch worth failing on. The script therefore strips backtick characters
+from the body before matching rather than skipping fenced code spans.
+
+(#3003 is *not* evidence about backticks: its body's backticked
+`` `Closes` `` has no adjacent issue number and could not have closed
+anything. What GitHub actually parsed there is the bare ``close #2827``
+substring inside the prose "auto-close #2827" — i.e. #3003 is the
+bare-prose-keyword case, which is what check 3 covers.)
 
 The parsing logic (``find_closing_declarations`` / ``find_nonclosing_declarations``
 / ``check_contradictions``) is pure — no network, no subprocess — so it is
@@ -76,14 +118,41 @@ _NONCLOSING_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Mention-only declaration (the third declaration type):
+#     <!-- closing-check: discussing #2620 #2972 -->
+# An HTML comment, so it is invisible in the rendered PR body but visible,
+# greppable, and explicit in the source. It names the specific issue numbers
+# the body merely *talks about* (quoting a closing keyword to explain it,
+# or prose that happens to collide with the keyword+#N shape) rather than
+# declares intent to close.
+#
+# This is a declaration, not a mute: it says "I mention N, I do not close N",
+# and it is checked against the parser exactly like the other two forms — if
+# the parser closes N anyway, that is a contradiction and check 2 fails.
+# Deliberately per-issue rather than body-wide: a body-wide switch would
+# disable check 1 for a body's *genuine* declarations too (this script's own
+# PR both declares `Closes #3007` and discusses #2620/#2972/#2827 as
+# examples — a body-wide marker would silently drop check-1 protection from
+# the real declaration, turning the escape hatch into a bypass).
+_DISCUSSING_MARKER_RE = re.compile(
+    r"<!--\s*closing-check:\s*discussing\s+((?:#\d+[\s,]*)+?)\s*-->",
+    re.IGNORECASE,
+)
+_ISSUE_NUM_RE = re.compile(r"#(\d+)")
+
 
 def _strip_backticks(text: str) -> str:
     """Remove backtick characters so fenced/defused keywords still match.
 
-    GitHub's own closing-keyword parser does not respect backticks for
-    auto-closing (a PR body containing `` `Closes #N` `` still auto-closes
-    N on merge) — this script's own regex must therefore see through
-    backticks the same way, rather than skipping fenced code spans.
+    GitHub's parser **does** respect backticks — a body containing
+    `` `Closes #N` `` does NOT auto-close N on merge (verified: #2990 and
+    #3006 both fence their closing keyword and both have an empty
+    ``closingIssuesReferences``; #2620 and #2972 consequently stayed open).
+
+    This matcher is deliberately stricter: a fenced ``Closes #N`` is still
+    the author declaring intent to close N, so we must see the declaration
+    that GitHub's parser ignored — that mismatch IS the check-1 defect.
+    Hence: strip the fence characters, don't skip fenced spans.
     """
     return text.replace("`", "")
 
@@ -98,6 +167,20 @@ def find_nonclosing_declarations(body: str) -> set[int]:
     """Return the set of issue numbers the body declares non-closing-intent for."""
     text = _strip_backticks(body)
     return {int(m.group(1)) for m in _NONCLOSING_RE.finditer(text)}
+
+
+def find_discussing_declarations(body: str) -> set[int]:
+    """Return issue numbers declared mention-only via a ``closing-check`` marker.
+
+    Reads ``<!-- closing-check: discussing #N #M -->`` markers (see
+    ``_DISCUSSING_MARKER_RE``). Backticks are NOT stripped first: the marker
+    is an exact, deliberate syntax an author types, so it should be matched
+    as written rather than reconstructed out of fenced text.
+    """
+    out: set[int] = set()
+    for marker in _DISCUSSING_MARKER_RE.finditer(body):
+        out.update(int(n) for n in _ISSUE_NUM_RE.findall(marker.group(1)))
+    return out
 
 
 @dataclass
@@ -116,11 +199,20 @@ def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
     """
     closing_declared = find_closing_declarations(body)
     nonclosing_declared = find_nonclosing_declarations(body)
+    discussing_declared = find_discussing_declarations(body)
     closing_refs_set = set(closing_refs)
     findings: list[Finding] = []
 
     # Check 1 (false negative): declared closing but parser did not close.
-    for n in sorted(closing_declared - closing_refs_set):
+    #
+    # Exempt only the issue numbers a `closing-check: discussing` marker
+    # names. The exemption is per-issue, so a body that both declares
+    # (`Closes #A`) and discusses (`#B`) keeps check 1 live on #A. And it
+    # never reaches the parser's output: an N that IS in closing_refs while
+    # marked "discussing" is caught by check 2 below, so the marker can
+    # silence a *declaration* the author says they never made, but can
+    # never silence an actual closure.
+    for n in sorted(closing_declared - closing_refs_set - discussing_declared):
         findings.append(
             Finding(
                 check=1,
@@ -128,32 +220,53 @@ def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
                 message=(
                     f"body declares closing intent for #{n} (Closes/Fixes/"
                     f"Resolves) but GitHub's parser did NOT resolve #{n} as "
-                    "a closing reference — merge will NOT close it. Check the "
-                    "keyword form and issue number are exactly what GitHub's "
-                    "parser expects."
+                    "a closing reference — merge will NOT close it. Note "
+                    "GitHub does NOT honor a closing keyword inside backticks "
+                    "(this is how #2620 and #2972 stayed open), so check the "
+                    f"keyword for #{n} is unfenced and its form/number are "
+                    "exactly what GitHub's parser expects. If the body only "
+                    f"*discusses* #{n} (quoting a keyword, or prose that "
+                    "collides with the keyword shape) rather than declaring "
+                    f"intent, add: <!-- closing-check: discussing #{n} -->"
                 ),
             )
         )
 
     # Check 2 (false positive): declared non-closing but parser will close.
-    for n in sorted(nonclosing_declared & closing_refs_set):
+    #
+    # Both non-closing declaration forms land here — "part of/toward #N"
+    # (scope) and a `discussing #N` marker (mention-only). They contradict
+    # the parser identically: the author said they are not closing N, and
+    # GitHub says it will.
+    for n in sorted((nonclosing_declared | discussing_declared) & closing_refs_set):
+        form = (
+            "a closing-check 'discussing' marker"
+            if n in discussing_declared and n not in nonclosing_declared
+            else "part of/toward"
+        )
         findings.append(
             Finding(
                 check=2,
                 issue=n,
                 message=(
-                    f"body declares non-closing intent for #{n} (part of/"
-                    f"toward) but GitHub's parser WILL close #{n} on merge — "
-                    "the declared intent and the parsed behavior contradict. "
-                    f"Rewrite the reference to #{n} so it isn't a closing "
-                    f"keyword, or if closing #{n} is actually intended, use "
+                    f"body declares non-closing intent for #{n} ({form}) but "
+                    f"GitHub's parser WILL close #{n} on merge — the declared "
+                    "intent and the parsed behavior contradict. Rewrite the "
+                    f"reference to #{n} so it isn't a closing keyword (GitHub "
+                    "parses bare keywords in prose, e.g. 'auto-close "
+                    f"#{n}'), or if closing #{n} is actually intended, use "
                     "Closes/Fixes/Resolves instead."
                 ),
             )
         )
 
     # Check 3 (undeclared): parser will close but body says nothing about N.
-    declared_any = closing_declared | nonclosing_declared
+    #
+    # A `discussing` marker counts as a declaration here so the same N is
+    # not reported twice — the marker-vs-parser contradiction is already
+    # reported by check 2 above, with a more precise message. No N in
+    # closing_refs can escape: it is covered by check 2 or check 3.
+    declared_any = closing_declared | nonclosing_declared | discussing_declared
     for n in sorted(closing_refs_set - declared_any):
         findings.append(
             Finding(
@@ -163,11 +276,12 @@ def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
                     f"#{n} will be closed on merge (GitHub's parser resolved "
                     f"it via closingIssuesReferences) but the body contains "
                     f"no declaration at all about #{n} (no Closes/Fixes/"
-                    f"Resolves, no part of/toward). GitHub's parser likely "
-                    f"picked up a bare keyword in prose (e.g. 'auto-close "
-                    f"#{n}'). If closing #{n} is intentional, write "
-                    f"'Closes #{n}' explicitly; if not, rephrase so the "
-                    f"reference to #{n} doesn't read as a closing keyword."
+                    f"Resolves, no part of/toward, no closing-check marker). "
+                    "GitHub's parser likely picked up a bare keyword in prose "
+                    f"(e.g. 'auto-close #{n}'). If closing #{n} is "
+                    f"intentional, write 'Closes #{n}' explicitly; if not, "
+                    f"rephrase so the reference to #{n} doesn't read as a "
+                    "closing keyword."
                 ),
             )
         )

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Detect PR-body / GitHub-parser contradictions about issue-closing intent.
+
+INVARIANT: the intent a PR body *declares* about issue #N must match the
+closing behavior GitHub's own parser (``closingIssuesReferences``, readable
+via ``gh pr view <N> --json closingIssuesReferences,body`` while the PR is
+still open) actually resolved for #N. This script detects contradictions —
+it never infers intent beyond what the body's declaring phrases literally
+say.
+
+Three checks, all facets of the same invariant:
+
+  1. **false negative** — body declares closing intent (``Closes #N`` /
+     ``Fixes #N`` / ``Resolves #N``, in any casing, even inside backticks)
+     but N is NOT in ``closingIssuesReferences`` → the author *wanted* to
+     close N but GitHub's parser did not pick it up (wrong keyword form,
+     wrong issue number, etc). Real examples: #2990→#2620, #3006→#2972.
+  2. **false positive** — body declares non-closing intent (``part of #N`` /
+     ``toward #N``) but N IS in ``closingIssuesReferences`` → the PR will
+     auto-close N on merge despite the author saying it shouldn't. Real
+     example: #3003→#2827.
+  3. **undeclared** — N IS in ``closingIssuesReferences`` but the body
+     contains NO declaration at all (neither closing nor non-closing) about
+     N → GitHub's parser silently picked up a closing reference from prose
+     the author never flagged as intentional (e.g. "auto-close #N" in a
+     sentence). This is the hole a closing-keyword-only check (1+2) misses:
+     both checks 1 and 2 presuppose the author wrote *some* declaring
+     phrase; an author who writes neither slips through both.
+
+Design constraint (ratified in issue #3007's discussion): check 3 must NOT
+re-enumerate GitHub's own closing-keyword vocabulary (closes/fixes/resolves/
+closed/fixed/resolved/close/fix/resolve and so on) — that would be a census
+of GitHub's parser that silently breaks the moment GitHub changes its
+keyword set. Check 3 only needs our own small declaring-phrase vocabulary
+(closing: Closes/Fixes/Resolves variants; non-closing: part of/toward) to
+decide whether the body says *anything at all* about N — GitHub's own
+parser output (``closingIssuesReferences``) remains the sole source of
+truth for what will actually close.
+
+Backtick defusal: Check 1 must still match ``Closes #N`` even when written
+as `` `Closes #N` `` — GitHub's real closing-keyword parser does not respect
+backticks for auto-closing either (hence the #3003 near-miss risk), so this
+script strips backtick characters from the body before matching rather than
+skipping fenced code spans.
+
+The parsing logic (``find_closing_declarations`` / ``find_nonclosing_declarations``
+/ ``check_contradictions``) is pure — no network, no subprocess — so it is
+fully unit-testable. ``fetch_pr_data`` is a thin ``gh`` wrapper kept
+separate so the pure logic can be exercised without hitting GitHub.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Declaring-phrase vocabulary (OUR vocabulary — deliberately small and NOT a
+# re-enumeration of GitHub's closing-keyword parser; see module docstring).
+# ---------------------------------------------------------------------------
+
+# Closing-intent declaration: Close(s|d)/Fix(es|ed)/Resolve(s|d) followed by
+# "#N", optionally separated by a colon/whitespace. Case-insensitive so
+# "closes", "Closes", "CLOSES" all match (as does GitHub's own parser).
+_CLOSING_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+# Non-closing-intent declaration: "part of #N" / "toward(s) #N".
+_NONCLOSING_RE = re.compile(
+    r"\b(?:part of|towards?)\s*:?\s*#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _strip_backticks(text: str) -> str:
+    """Remove backtick characters so fenced/defused keywords still match.
+
+    GitHub's own closing-keyword parser does not respect backticks for
+    auto-closing (a PR body containing `` `Closes #N` `` still auto-closes
+    N on merge) — this script's own regex must therefore see through
+    backticks the same way, rather than skipping fenced code spans.
+    """
+    return text.replace("`", "")
+
+
+def find_closing_declarations(body: str) -> set[int]:
+    """Return the set of issue numbers the body declares closing-intent for."""
+    text = _strip_backticks(body)
+    return {int(m.group(1)) for m in _CLOSING_RE.finditer(text)}
+
+
+def find_nonclosing_declarations(body: str) -> set[int]:
+    """Return the set of issue numbers the body declares non-closing-intent for."""
+    text = _strip_backticks(body)
+    return {int(m.group(1)) for m in _NONCLOSING_RE.finditer(text)}
+
+
+@dataclass
+class Finding:
+    check: int
+    issue: int
+    message: str
+
+
+def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
+    """Pure contradiction detector — no network, no inference of intent.
+
+    ``body`` is the raw PR body text. ``closing_refs`` is the list of issue
+    numbers GitHub's parser (``closingIssuesReferences``) actually resolved
+    as closing targets for this PR.
+    """
+    closing_declared = find_closing_declarations(body)
+    nonclosing_declared = find_nonclosing_declarations(body)
+    closing_refs_set = set(closing_refs)
+    findings: list[Finding] = []
+
+    # Check 1 (false negative): declared closing but parser did not close.
+    for n in sorted(closing_declared - closing_refs_set):
+        findings.append(
+            Finding(
+                check=1,
+                issue=n,
+                message=(
+                    f"body declares closing intent for #{n} (Closes/Fixes/"
+                    f"Resolves) but GitHub's parser did NOT resolve #{n} as "
+                    "a closing reference — merge will NOT close it. Check the "
+                    "keyword form and issue number are exactly what GitHub's "
+                    "parser expects."
+                ),
+            )
+        )
+
+    # Check 2 (false positive): declared non-closing but parser will close.
+    for n in sorted(nonclosing_declared & closing_refs_set):
+        findings.append(
+            Finding(
+                check=2,
+                issue=n,
+                message=(
+                    f"body declares non-closing intent for #{n} (part of/"
+                    f"toward) but GitHub's parser WILL close #{n} on merge — "
+                    "the declared intent and the parsed behavior contradict. "
+                    f"Rewrite the reference to #{n} so it isn't a closing "
+                    f"keyword, or if closing #{n} is actually intended, use "
+                    "Closes/Fixes/Resolves instead."
+                ),
+            )
+        )
+
+    # Check 3 (undeclared): parser will close but body says nothing about N.
+    declared_any = closing_declared | nonclosing_declared
+    for n in sorted(closing_refs_set - declared_any):
+        findings.append(
+            Finding(
+                check=3,
+                issue=n,
+                message=(
+                    f"#{n} will be closed on merge (GitHub's parser resolved "
+                    f"it via closingIssuesReferences) but the body contains "
+                    f"no declaration at all about #{n} (no Closes/Fixes/"
+                    f"Resolves, no part of/toward). GitHub's parser likely "
+                    f"picked up a bare keyword in prose (e.g. 'auto-close "
+                    f"#{n}'). If closing #{n} is intentional, write "
+                    f"'Closes #{n}' explicitly; if not, rephrase so the "
+                    f"reference to #{n} doesn't read as a closing keyword."
+                ),
+            )
+        )
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# gh wrapper (thin — kept separate from the pure logic above)
+# ---------------------------------------------------------------------------
+
+
+def fetch_pr_data(pr_number: int) -> tuple[str, list[int]]:
+    """Fetch (body, closing_issue_numbers) for an open PR via ``gh pr view``."""
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--json",
+            "closingIssuesReferences,body",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+    body = data.get("body") or ""
+    closing_refs = [ref["number"] for ref in data.get("closingIssuesReferences") or []]
+    return body, closing_refs
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Detect contradictions between a PR body's declared closing "
+            "intent and GitHub's parsed closingIssuesReferences."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--pr",
+        type=int,
+        metavar="N",
+        help="Live PR number — fetched via `gh pr view N --json closingIssuesReferences,body`.",
+    )
+    group.add_argument(
+        "--fixture",
+        metavar="PATH",
+        help=(
+            "Path to a JSON fixture file with keys 'body' (str) and "
+            "'closingIssuesReferences' (list of {'number': N} or plain ints) "
+            "— same shape as `gh pr view --json closingIssuesReferences,body`. "
+            "Lets this check run offline / in tests without hitting GitHub."
+        ),
+    )
+    return parser
+
+
+def _closing_refs_from_fixture(raw: object) -> list[int]:
+    if not raw:
+        return []
+    out: list[int] = []
+    for item in raw:  # type: ignore[union-attr]
+        if isinstance(item, dict):
+            out.append(int(item["number"]))
+        else:
+            out.append(int(item))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.pr is not None:
+        try:
+            body, closing_refs = fetch_pr_data(args.pr)
+        except subprocess.CalledProcessError as exc:
+            print(f"gh pr view failed: {exc.stderr}", file=sys.stderr)
+            return 2
+        source = f"PR #{args.pr}"
+    else:
+        from pathlib import Path
+
+        raw = json.loads(Path(args.fixture).read_text(encoding="utf-8"))
+        body = raw.get("body") or ""
+        closing_refs = _closing_refs_from_fixture(raw.get("closingIssuesReferences"))
+        source = args.fixture
+
+    findings = check_contradictions(body, closing_refs)
+
+    if not findings:
+        print(f"OK — no closing-intent contradictions found ({source}).")
+        return 0
+
+    print(f"FAIL — closing-intent contradictions found ({source}):\n")
+    for f in findings:
+        print(f"  [check {f.check}] #{f.issue}: {f.message}\n")
+    print(f"Total: {len(findings)} contradiction(s) across checks "
+          f"{sorted({f.check for f in findings})}.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_pr_closing_intent.py
+++ b/tests/test_check_pr_closing_intent.py
@@ -1,0 +1,128 @@
+"""Tier 1: scripts/check_pr_closing_intent.py contradiction-detection contract.
+
+Pins the invariant issue #3007 ratified: the intent a PR body *declares*
+about issue #N must match the closing behavior GitHub's own parser
+(``closingIssuesReferences``) actually resolved for #N. The three checks
+(false negative / false positive / undeclared) are pure facets of that one
+invariant, and ``check_contradictions`` is a pure function over
+``(body, closing_refs)`` — no network, no subprocess — so this is a Tier 1
+contract test against known inputs/outputs.
+
+Public surface only (no MagicMock, no private-state asserts): each case
+calls ``check_contradictions`` and asserts on the returned ``Finding``
+objects' public fields (``check`` / ``issue``).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_module():
+    """Import scripts/check_pr_closing_intent.py without a scripts/ package.
+
+    scripts/ has no ``__init__.py`` (mirrors the loader idiom used by
+    ``tests/test_tier_audit_format_pin.py`` for the sibling audit script).
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    path = repo_root / "scripts" / "check_pr_closing_intent.py"
+    spec = importlib.util.spec_from_file_location("check_pr_closing_intent", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_pr_closing_intent"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+m = _load_module()
+
+
+def _checks(findings):
+    return sorted((f.check, f.issue) for f in findings)
+
+
+def test_check1_fires_on_backtick_fenced_closing_keyword_not_resolved():
+    """Tier 1: backtick-fenced `Closes #N` still triggers check 1.
+
+    Real GitHub closing-keyword auto-close also ignores backticks, so our
+    own regex must see through them the same way rather than being defused
+    by fencing, when the parser did not resolve N as a closing reference.
+    """
+    body = "Some prose. `Closes #123` more prose."
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert _checks(findings) == [(1, 123)]
+
+
+def test_check1_passes_when_parser_agrees():
+    """Tier 1: `Closes #N` with N present in closingIssuesReferences is clean."""
+    body = "Closes #77"
+    findings = m.check_contradictions(body, closing_refs=[77])
+    assert findings == []
+
+
+def test_check2_fires_on_part_of_when_parser_will_close():
+    """Tier 1: real historical case #3003 triggers check 2.
+
+    Body says "part of #2827" while closingIssuesReferences contains 2827
+    (fixture built from the PR's own real declaration text and parser
+    output, per issue #3007's falsification requirement #2).
+    """
+    body = "part of #2827 (part 2 only; part 1 is a separate PR)."
+    findings = m.check_contradictions(body, closing_refs=[2827])
+    assert _checks(findings) == [(2, 2827)]
+
+
+def test_check2_passes_when_referenced_issue_correctly_absent():
+    """Tier 1: `part of #N` with N correctly absent from closingIssuesReferences
+
+    is clean (real PR #3014: "part of #3009", closingIssuesReferences == []).
+    """
+    body = "part of #3009 (item 1 only)."
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert findings == []
+
+
+def test_check3_fires_on_undeclared_parser_closure():
+    """Tier 1: closingIssuesReferences non-empty for N, body has zero
+
+    declaring phrases (closing or non-closing) about N — the architect's
+    hole: prose like "addresses #N" parses as a closing reference without
+    the author ever writing Closes/Fixes/Resolves or part of/toward.
+    """
+    body = "This PR addresses #55 nicely, thanks reviewer."
+    findings = m.check_contradictions(body, closing_refs=[55])
+    assert _checks(findings) == [(3, 55)]
+
+
+def test_check3_does_not_fire_when_nonclosing_declaration_present():
+    """Tier 1: check 3 only requires SOME declaration (closing or
+
+    non-closing) about N — a bare "part of #N" mention is enough to avoid
+    check 3 even though it would still trip check 2 if the parser closes N.
+    """
+    body = "part of #90"
+    findings = m.check_contradictions(body, closing_refs=[90])
+    # check 2 fires (declared non-closing, parser closes) but check 3 must
+    # NOT — the body does declare something about #90.
+    assert _checks(findings) == [(2, 90)]
+
+
+def test_clean_pr_multiple_issues_no_contradictions():
+    """Tier 1: a well-formed body — proper `Closes #N` outside backticks
+
+    matching closingIssuesReferences exactly, and `part of #M` with M
+    correctly absent — produces zero findings (must not cry wolf).
+    """
+    body = "Closes #200\n\npart of #300 (separate scope, not closed here)."
+    findings = m.check_contradictions(body, closing_refs=[200])
+    assert findings == []
+
+
+def test_find_closing_declarations_strips_backticks():
+    """Tier 1: the closing-declaration finder itself sees through backticks."""
+    assert m.find_closing_declarations("`Fixes #9`") == {9}
+
+
+def test_find_nonclosing_declarations_matches_toward():
+    """Tier 1: "toward #N" is recognized as a non-closing declaration."""
+    assert m.find_nonclosing_declarations("toward #42") == {42}

--- a/tests/test_check_pr_closing_intent.py
+++ b/tests/test_check_pr_closing_intent.py
@@ -118,8 +118,65 @@ def test_clean_pr_multiple_issues_no_contradictions():
     assert findings == []
 
 
+def test_discussing_marker_exempts_check1_for_named_issue():
+    """Tier 1: a `closing-check: discussing #N` marker exempts check 1 for N.
+
+    The mention-only declaration form: the body quotes a closing keyword to
+    explain it (as this script's own PR must) rather than declaring intent,
+    so the declared-but-unresolved contradiction does not apply to N.
+    """
+    body = (
+        "<!-- closing-check: discussing #2620 -->\n"
+        "We quote `Closes #2620` as a worked example."
+    )
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert findings == []
+
+
+def test_discussing_marker_does_not_exempt_a_genuine_declaration():
+    """Tier 1: the marker is per-issue — it must not become a body-wide bypass.
+
+    A body that both declares (`Closes #3007`) and discusses (#2620) keeps
+    check 1 live on the genuine declaration. A body-wide marker would
+    silently drop check-1 protection from the real `Closes`, turning the
+    escape hatch into the very defect this gate exists to catch.
+    """
+    body = (
+        "Closes #3007\n"
+        "<!-- closing-check: discussing #2620 -->\n"
+        "We quote `Closes #2620` as a worked example."
+    )
+    # #3007 declared but NOT resolved by the parser → check 1 must still fire.
+    findings = m.check_contradictions(body, closing_refs=[])
+    assert _checks(findings) == [(1, 3007)]
+
+
+def test_discussing_marker_cannot_silence_an_actual_closure():
+    """Tier 1: the marker never reaches the parser's output.
+
+    "discussing #N" while `closingIssuesReferences` contains N is itself a
+    contradiction (author says mention-only, GitHub says it closes) → check
+    2. An exemption that suppressed this would reintroduce the #3003 defect.
+    """
+    body = "<!-- closing-check: discussing #2827 -->\nWe discuss `Closes #2827`."
+    findings = m.check_contradictions(body, closing_refs=[2827])
+    assert _checks(findings) == [(2, 2827)]
+
+
+def test_find_discussing_declarations_reads_multiple_issue_numbers():
+    """Tier 1: one marker can name several issue numbers."""
+    body = "<!-- closing-check: discussing #2620 #2972 #2827 -->"
+    assert m.find_discussing_declarations(body) == {2620, 2972, 2827}
+
+
 def test_find_closing_declarations_strips_backticks():
-    """Tier 1: the closing-declaration finder itself sees through backticks."""
+    """Tier 1: the closing-declaration finder itself sees through backticks.
+
+    GitHub does NOT honor a fenced keyword (verified: #2990's fenced
+    `Closes #2620` left `closingIssuesReferences` empty and #2620 open), so
+    this matcher is deliberately stricter than GitHub's in the direction
+    that surfaces the contradiction.
+    """
     assert m.find_closing_declarations("`Fixes #9`") == {9}
 
 


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3007

<!-- closing-check: discussing #2620 #2972 #2827 #2964 #2978 #2975 #2940 #2159 #123 #200 #300 #55 -->

## Invariant

The intent a PR body **declares** about issue #N must match the closing
behavior GitHub's own parser (`closingIssuesReferences`, readable via
`gh pr view <N> --json closingIssuesReferences,body` while the PR is still
open) **actually resolved** for #N. No inference of intent beyond this —
pure contradiction detection, ratified across the issue #3007 discussion.

## The 3 checks — one invariant, three facets

| | author's declaration | parser output | real example |
|---|---|---|---|
| **Check 1** (false negative) | `Closes #N` / `Fixes #N` / `Resolves #N` | N **not** resolved | #2990→#2620, #3006→#2972 |
| **Check 2** (false positive) | `part of #N` / `toward #N`, or a `discussing` marker | N **is** resolved | #3003→#2827, **#2951→#2940** |
| **Check 3** (undeclared) | **no declaration at all** about N | N **is** resolved | the hole checks 1+2 both miss |

Check 3 exists because checks 1 and 2 both *presuppose* the author wrote
some declaring phrase. A PR that writes neither — only prose like
`addresses #N` / `auto-close #N` that GitHub's parser silently picks up —
slips through both. Per the ratified design constraint, **check 3 does not
re-enumerate GitHub's own closing-keyword vocabulary** — that would be a
census of GitHub's parser that silently breaks if GitHub changes its
keyword set. Check 3 only checks whether *our own* declaring vocabulary
mentions N at all; `closingIssuesReferences` remains the sole ground truth
for what actually closes.

## How GitHub actually treats backticks (corrected — my first version had this backwards)

An earlier revision of this PR asserted that GitHub's parser *ignores*
backticks for auto-closing. **That is false, and the repo's own primary data
falsifies it:**

```
$ gh pr view 2990 --json closingIssuesReferences   # body: `Closes #2620` (fenced)
{"closingIssuesReferences":[]}
$ gh pr view 3006 --json closingIssuesReferences   # body: `Closes #2972` (fenced)
{"closingIssuesReferences":[]}
```

**GitHub DOES respect backticks — that is precisely why #2620 and #2972
stayed open and a human closed them by hand.** The fencing is the *cause* of
check 1's motivating incidents, not something the parser ignores.

I had also cited #3003 as evidence for the backtick claim. It is not: its
body reads ``` `Closes` here would auto-close #2827 ```, where the fenced
`Closes` has **no adjacent issue number** and could not have closed anything.
What GitHub actually parsed is the bare `close #2827` substring inside the
prose `auto-close #2827` — the bare-prose-keyword case (check 3's domain),
which says nothing about backtick handling.

**The design is unchanged; only the rationale was inverted.** We strip
backticks because a fenced `Closes #N` is still the author *declaring*
intent, while GitHub's parser respects the fence and silently declines to
close — and that gap is exactly the defect check 1 exists to catch. This
matcher is deliberately **stricter than** GitHub's, in the one direction
that surfaces the contradiction. Fixed at all three sites (module docstring,
`_strip_backticks` docstring, this body).

## The mention-only declaration (replaces the ZWSP — it was a disguise)

A PR body that *discusses* closing keywords rather than using them is a real
FP class for checks 1/2 — a doc PR, a rule-4 explanation, **or this PR**,
which must quote `Closes #N` to explain what it detects. My first revision
worked around this with invisible zero-width spaces. **That was wrong and is
fully removed** (this body contains zero ZWSP): an invisible, ungreppable,
undocumented disguise is the same "mechanism appears present but is silently
bypassed" shape this PR exists to kill. The next author would go red, fail to
find the cause, and learn to ignore the gate.

The replacement is a **third declaration type** — visible, greppable,
documented, and surfaced in the failure message:

```
<!-- closing-check: discussing #2620 #2972 -->
```

It is a declaration, not a mute: *"I mention N, I do not close N"*, checked
against the parser like the other two forms.

- **Per-issue, never body-wide.** This PR both declares a real `Closes #3007`
  and discusses #2620/#2972/#2827. A body-wide marker would disable check 1
  for the whole body **including the genuine declaration** — the escape hatch
  would become the bypass. Pinned by
  `test_discussing_marker_does_not_exempt_a_genuine_declaration`: with a
  marker present, `Closes #3007` unresolved still FAILs check 1.
- **The exemption never reaches the parser's output.** Marker says
  "discussing #N" but `closingIssuesReferences` contains N → **check 2 FAIL**.
  That is #3003 exactly, the strongest case the gate has. Pinned by
  `test_discussing_marker_cannot_silence_an_actual_closure`.
- **Check 3 keeps full coverage.** No N in `closingIssuesReferences` can
  escape: it is caught by check 2 (declared) or check 3 (undeclared). The
  marker counts as a declaration for check 3 only to avoid double-reporting
  the same N that check 2 already reports more precisely.

## Falsification (4 required cases + the bypass test)

**1. Fenced closing keyword, parser did NOT resolve it — still FAILs check 1:**
```
>>> check_contradictions('Some prose. `Closes #123` more prose.', closing_refs=[])
[Finding(check=1, issue=123, ...)]
```

**2. Real historical case #3003 (real `gh pr view` data, not hand-built):**
```
$ gh pr view 3003 --json closingIssuesReferences,body > /tmp/pr3003.json
$ python3 scripts/check_pr_closing_intent.py --fixture /tmp/pr3003.json
FAIL — closing-intent contradictions found (/tmp/pr3003.json):
  [check 2] #2827: body declares non-closing intent for #2827 (part of/toward)
  but GitHub's parser WILL close #2827 on merge ...
Total: 1 contradiction(s) across checks [2].
```
Exit 1, correctly reports check-2 for #2827.

**3. Check 3 — parser resolves N, body has zero declaring phrases:**
```
>>> check_contradictions('This PR addresses #55 nicely, thanks reviewer.', closing_refs=[55])
[Finding(check=3, issue=55, ...)]
```

**4. Clean PR — must NOT cry wolf:**
```
>>> check_contradictions('Closes #200\n\npart of #300 (separate scope).', closing_refs=[200])
[]
```

**5. Bypass test (the marker must not protect a genuine declaration):**
```
>>> body = 'Closes #3007\n<!-- closing-check: discussing #2620 -->\n`Closes #2620` example.'
>>> check_contradictions(body, closing_refs=[])
[Finding(check=1, issue=3007, ...)]     # marker did NOT shield the real declaration
```

## Measurement over 69 real PRs — all three checks

```
sample: 69 PRs | non-empty closingIssuesReferences: 16
check-1 fires: 6   check-2 fires: 2   check-3 fires: 0
PRs with >=1 fire: 7/69 = 10.1%   -> [2951, 2986, 2989, 2990, 2992, 3003, 3006]
```

**Check 3: 0/69.** Checks 1/2: 8 fires across 7 PRs. I inspected **each of the
8 individually** rather than extrapolating:

| PR → issue | verdict | evidence |
|---|---|---|
| **#2951 → #2940** | **TRUE POS — live, unremediated** | body says `this does NOT close #2940`; that sentence auto-closed it (`closer: PullRequest #2951`). **#2940 is CLOSED right now.** |
| #2986 → #2964, #2978 | TRUE POS | fenced `Closes`; human closed both by hand 6 min post-merge (`closer: null`, actor `tya5`) |
| #2990 → #2620 | TRUE POS | known incident |
| #3006 → #2972 | TRUE POS | known incident |
| #3003 → #2827 | TRUE POS | known incident |
| #2992 → #2159 | ambiguous | body's `Closes` fenced → not parsed; the squash-**commit** message closed it 2s post-merge. Author's intent achieved via the commit path, not the body. |
| **#2989 → #2975** | **FALSE POS** | prose *"Order-dependency is resolved: #2975"* collides with `resolve[sd]?\s*:?\s*#`. No keyword being discussed — ordinary prose. |

**Checks 1/2 false-positive rate: 1/8 fires (12.5%), or 1/69 PRs (1.4%).**

**★ New defect found by this measurement: #2951 → #2940.** Nobody had
identified it. The PR body explicitly says `## Scope — this does NOT close
#2940` and that very sentence auto-closed the issue, which is **still
closed today**. This is a second, unremediated instance of the #3003 class —
found only because the gate was run over history. It is exactly what CLAUDE.md
rule 4 warns about, and this gate would have blocked it pre-merge.

**This PR then reproduced the same defect on itself — and its own gate caught
it.** Quoting those two incidents in this body as plain prose made GitHub
parse them, so `closingIssuesReferences` came back `[2827, 2940, 3007]` —
this PR was about to auto-close both of those issues on merge. Check 2 fired
and blocked it, and the `discussing` marker correctly **refused** to silence
it (the exemption never reaches the parser's output). Fixed by fencing the
quotes, which GitHub does not parse — the same fencing that causes check 1's
incidents is, here, the correct tool.

It then happened a **second** time: the sentence describing the fix
reintroduced an unfenced quote and re-armed the closure, caught again on the
next run. Two independent self-hits in one PR is the honest measure of how
easy this defect is to commit by hand — and the strongest witness the
mechanism has: it caught the exact defect it was built for, on its own
author, twice, pre-merge.

**Marker FP class — measured, not predicted.** The prediction was "#3015
itself plus future rule-4 PRs — small but nonzero." Measured: **1 historical
case (#2989) + this PR = ≥1 real case, so the hatch is not speculative.** It
is also *broader* than "discussing a keyword": #2989 discusses nothing — its
ordinary prose merely collides with the keyword+`#N` shape. I left the
`:?` colon-optional in the regex deliberately: removing it would drop the
legitimate `Closes: #N` form and turn a check-1 false positive into a check-1
**false negative** (a silent gate), which is the worse failure.

**Corrected caveat.** My earlier revision claimed `closingIssuesReferences`
"drops issues that closed and stayed closed" on merged PRs, and used that to
dismiss the check-1 fires as measurement artifacts. **That was unverified
inference and it is false** — 15 of the 16 sampled PRs with non-empty
`closingIssuesReferences` point at issues that are **CLOSED**, so the field
plainly retains them. The fires were real. The actual limit is narrower and
worth stating: this gate is designed to run **pre-merge on open PRs**, and
only one PR (#3014) was open at measurement time, so the 69-PR sample is
retrospective. It is direct evidence about the checks' *discrimination*
(verified per-item above), not a live-traffic FP rate.

## Testing

`tests/test_check_pr_closing_intent.py` — 13 Tier 1 (Contract) tests against
the pure `check_contradictions` contract: backtick defusal, clean-pass and
fail shapes for all 3 checks, the marker's exemption, the bypass test, and
the marker-cannot-silence-a-closure test. No mocks, no private-state asserts.

## CI gates

- `ruff check src tests` → All checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_check_pr_closing_intent.py` → 13 OK, 0 errors, exit 0.
- `pytest` (repo root, full suite) → green; skips are pre-existing environment gates unrelated to this change.
- `python scripts/verify_module_docstrings.py <changed src files>` → **no-op**: no `src/` files touched (only `scripts/`, `tests/`, `.github/`).

## Self-test

This PR is its own test subject. It carries a real `Closes #3007` (verified
parsed), discusses several closing keywords as examples, declares them via
the marker, and **passes its own check with zero ZWSP** — green because the
design accommodates a legitimate case, not because it was evaded.
