### PR TITLE
docs: correct the ctx-dropdown cost attribution stale since #2951 (#2940)

### DIFF
--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -97,8 +97,21 @@ class ContextBudgetAdvisor:
         """Estimated token count of the full router-view history (#2940).
 
         Incremental: only the slice of history NEWER than the last call is
-        json.dumps'd + estimated; a cache hit (no new messages since last
-        call) is O(1). A shrink, a model/use_chars4 change, OR the cached
+        json.dumps'd + estimated; on a cache hit (no new messages since the
+        last call) THIS function's own dump+estimate work is O(1).
+
+        That O(1) is scoped to the dump+estimate ONLY — it is NOT the cost of
+        calling this. ``self._history_fn()`` is invoked before the cache is
+        consulted (the cache is keyed on the history it returns, so it cannot
+        be), and in production that fn is
+        ``RouterHistoryBuffer.build_history`` → ``Session._active_branch_history``,
+        which does an uncached full-WAL scan per call. Measured (#2940,
+        N=2000 msgs / M=100k WAL entries): ~445ms per call on a cache HIT, of
+        which the producer is ~99.7% and this cache saves ~10ms. Do not read
+        "cache hit" here as "cheap call" — the caller-facing cost is O(WAL
+        size) either way. Flattening that is #2939's scope.
+
+        A shrink, a model/use_chars4 change, OR the cached
         PREFIX's content actually differing (checked via a boundary — the
         json dump of the last cached message, not assumed from length alone
         — history_fn is often a recomputed derived view, e.g. a rewind-aware

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6750,9 +6750,22 @@ class Session:
         Public — read by both the RouterHostAdapter SP context-size signal
         (via the callback wired at __init__) and the inline UI's ctx chip
         dropdown (status bar reads only public accessors, see
-        interfaces/inline/app.py's module docstring). Non-trivial cost: does a
-        json.dumps + token-estimate of the full router-view history on every
-        call — callers should not invoke this from a per-render-frame path."""
+        interfaces/inline/app.py's module docstring).
+
+        Non-trivial cost — callers must not invoke this from a per-render-frame
+        path. #2951 added an incremental cache to the advisor's OWN
+        json.dumps + token-estimate of the router-view history, so that step is
+        no longer paid on every call (only on a cache miss: history shrink,
+        model/use_chars4 change, or a changed cached prefix). The remaining —
+        and dominant — cost is the PRODUCER: ``history_fn`` is
+        ``RouterHistoryBuffer.build_history``, which calls
+        ``_active_branch_history`` 2x (3x on the elide path: ``build_history``
+        itself plus each ``_latest_summary``), and each of those does one full
+        ``build_active_predicate`` WAL scan (json-decoding every line, no
+        cache). So this is O(WAL size) per call, NOT O(1) on a cache hit.
+        Measured (#2940, N=2000 msgs / M=100k WAL entries, warm token cache):
+        ~445ms per call, of which build_history is ~99.7%; the #2951 cache
+        saves ~10ms of it. The residual WAL scan is #2939's scope."""
         return self._budget_advisor.context_window_status()
 
     def raw_context_window(self) -> dict:


### PR DESCRIPTION
**[lead-coder]** — part of #2940. Docstrings only, no runtime change.

## What was stale

#2951 added the incremental history-token cache to `ContextBudgetAdvisor`. Two docstrings describing that path went stale in the same moment, and both misattribute where the cost actually is:

| site | claim | status |
|---|---|---|
| `session.py:6753` | *"does a json.dumps + token-estimate of the full router-view history **on every call**"* | **stale** — after #2951 that step is paid only on a cache MISS |
| `context_budget_advisor.py:100` | *"a cache hit ... is **O(1)**"* | **misleading** — true of its own dump+estimate, false of the call |

The second is the sharper one. `_incremental_history_tokens` calls `self._history_fn()` **before** consulting the cache (it must — the cache is keyed on what that fn returns). In production `history_fn` is `RouterHistoryBuffer.build_history` → `Session._active_branch_history`, which does an uncached full-WAL `build_active_predicate` scan per call. So a reader who takes "cache hit → O(1)" at face value concludes the call is cheap. It is O(WAL size) either way.

## Measurement backing the new text

Composed the real wiring (advisor ← `build_history` ← `_active_branch_history`-shaped fn over a real `StateLog`), warm token cache, interleaved reps, N=2000 messages / M=100k WAL entries:

```
  cache HIT (post-#2951): min= 435.4ms median= 445.3ms
  cache MISS (pre-#2951): min= 445.4ms median= 455.0ms
     build_history alone: min= 439.9ms median= 444.1ms

#2951 saves (miss-hit)  : +9.6ms of 445ms total
producer share of total : 99.7%
```

`build_history` calls `_active_branch_history` **2x** (3x on the elide path — `build_history` itself plus each `_latest_summary`), each a full json-decode of the WAL. That, not the `json.dumps`, is the cost. Residual is #2939's scope.

Both docstrings now name the producer as dominant and carry the numbers.

## Scope

This PR corrects documentation. It does not change the perf behaviour, and #2940 stays open — the measurement above is reported to the owner separately for the fix decision.

## Test plan

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/services/context_budget_advisor.py` — OK
- [x] Full `pytest` — 8780 passed, 22 skipped (read from the summary line, not `tail`; `-rs` confirms skips are pre-existing)
- [x] `tests/test_context_budget_advisor_incremental_history_tokens.py` — 6 passed
- [x] No test-file changes → `test_tier_audit.py` N/A

**Doc-drift rule**: per CLAUDE.md, re-read the whole section each change touches rather than grepping for one keyword — both stale claims were found by driving the chain, not by matching a string.