### PR TITLE
perf: flatten the O(M) per-turn WAL scan in the active-branch filter (#2939)

### DIFF
--- a/src/reyn/core/events/retention.py
+++ b/src/reyn/core/events/retention.py
@@ -71,13 +71,21 @@ def compute_retention_floor(
     abandoned interval touches the retained window has ``R >= floor`` and is kept.
     This argument is correct for runtime-state reconstruction (WAL replay uses
     only seqs >= floor), but ``history.jsonl`` is append-only and never
-    floor-truncated: ``_active_branch_history`` calls ``is_active_seq`` with
-    ``wal_seq`` anchors from ``history.jsonl`` that may be below the floor
-    (abandoned-branch turns). Dropping a rewind record below the floor therefore
-    lets abandoned conversation turns reappear in the LLM context. Fix: callers
-    of ``truncate_below`` pass ``always_keep_kinds=frozenset({REWIND_KIND})``
+    floor-truncated: ``_active_branch_history`` tests the branch model
+    (``build_active_predicate``) against ``wal_seq`` anchors from
+    ``history.jsonl`` that may be below the floor (abandoned-branch turns).
+    Dropping a rewind record below the floor therefore lets abandoned
+    conversation turns reappear in the LLM context. Fix: callers of
+    ``truncate_below`` pass ``always_keep_kinds=frozenset({REWIND_KIND})``
     (``snapshot_generations.REWIND_KIND``) so reset-records survive truncation
     regardless of the floor.
+
+    Note that this protection is what makes the record survive; it is NOT what
+    makes the branch model notice. The model's rewind-record index is
+    incremental (#2939), so it re-reads the WAL only as it grows — a rewrite is
+    caught by file identity and forces a rebuild. Truncation and the index are
+    therefore independent: keeping a record here keeps its abandoned interval,
+    and dropping one drops it, either way from the file that now exists.
     """
     if policy.is_live or policy.keep_generations is None:
         return live_floor

--- a/src/reyn/core/events/snapshot_generations.py
+++ b/src/reyn/core/events/snapshot_generations.py
@@ -22,6 +22,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
+from weakref import WeakKeyDictionary
 
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.state_log import StateLog
@@ -131,13 +132,62 @@ class RewindBeyondRetentionError(Exception):
     """
 
 
+class _RewindIndex:
+    """Incrementally-maintained rewind reset-record list for ONE StateLog (#2939).
+
+    Rewind records are a vanishingly small, append-only subset of the WAL, but
+    deriving them cost a FULL WAL scan (json-decoding every line) every time —
+    and every branch-model query below re-derives them. #2941 hoisted that scan
+    out of the per-MESSAGE loop (O(N x M) → O(N + M) per turn); the residual
+    O(M) is this: the scan still re-read the whole WAL once per turn, so the
+    cost of opening the chat's context dropdown grew with WAL SIZE, not with
+    what had actually changed (#2940 measured ~99.7% of that open in this scan).
+
+    Folding the records over a :class:`WalTailReader` makes the steady-state
+    cost O(delta) — normally zero new bytes, hence no decode at all. The reader
+    owns the correctness: it reports ``restarted`` whenever the WAL file was
+    rewritten (retention's ``truncate_below`` renames a fresh file into place),
+    and we then REBUILD from the new file instead of extending. That is what
+    keeps the index from serving a **stale abandoned interval** — a rewind
+    record the truncated WAL no longer holds would resurrect abandoned turns
+    into the LLM's context. The guarantee is structural (a rewrite cannot keep
+    the inode), not an argument about what retention chooses to keep.
+    """
+
+    def __init__(self, state_log: StateLog) -> None:
+        self._reader = state_log.tail_reader()
+        self._records: list[tuple[int, int]] = []
+
+    def records(self) -> list[tuple[int, int]]:
+        entries, restarted = self._reader.poll()
+        if restarted:
+            self._records = []
+        for e in entries:
+            if e.get("kind") == REWIND_KIND:
+                self._records.append((e["seq"], int(e["target_n"])))
+        return list(self._records)
+
+
+# Keyed by StateLog IDENTITY and weak, so an index never outlives its log (no
+# cross-test bleed, no unbounded growth); two StateLogs over the same file each
+# keep their own cursor, which is correct — each validates against the file
+# itself, not against the other's belief about it.
+_REWIND_INDEXES: "WeakKeyDictionary[StateLog, _RewindIndex]" = WeakKeyDictionary()
+
+
 def _rewind_records(state_log: StateLog) -> list[tuple[int, int]]:
-    """All rewind reset-records as ``(R, target_n)`` (R = the record's own seq)."""
-    out: list[tuple[int, int]] = []
-    for e in state_log.iter_from(1):
-        if e.get("kind") == REWIND_KIND and isinstance(e.get("seq"), int):
-            out.append((e["seq"], int(e["target_n"])))
-    return out
+    """All rewind reset-records as ``(R, target_n)`` (R = the record's own seq).
+
+    Incremental (#2939): folded over a resumable tail-reader per ``state_log``,
+    so repeated calls re-scan only WAL bytes appended since the last call —
+    see :class:`_RewindIndex`. Result is identical to the full re-scan this
+    replaces (same records, same file order); only the cost changes.
+    """
+    index = _REWIND_INDEXES.get(state_log)
+    if index is None:
+        index = _RewindIndex(state_log)
+        _REWIND_INDEXES[state_log] = index
+    return index.records()
 
 
 def _abandoned_intervals(rewinds: list[tuple[int, int]]) -> list[tuple[int, int]]:
@@ -179,21 +229,25 @@ def is_active_seq(state_log: StateLog, seq: int) -> bool:
 
 
 def build_active_predicate(state_log: StateLog) -> Callable[[int], bool]:
-    """Build a reusable ``is_active(seq)`` predicate — ONE WAL scan for MANY seqs.
+    """Build a reusable ``is_active(seq)`` predicate — ONE derivation for MANY seqs.
 
     #2941 (owner-reported ``reyn chat`` freeze, growing with session length):
     ``_abandoned_intervals(_rewind_records(state_log))`` depends only on the
     state_log's rewind records, NOT on ``seq`` — so calling ``is_active_seq``
     once per history message (``Session._active_branch_history``, the
-    LLM-facing hot path run every turn) re-scans the *entire* WAL
-    (``iter_from(1)``, json-decoding every line) once per message: O(N
-    messages x M WAL entries) per turn. This factors the seq-independent scan
-    out of that loop: call once per turn, then reuse the returned predicate
-    for every message's seq — O(N + M) per turn instead of O(N x M). Same
-    derivation as ``is_active_seq``; semantics are identical (this is a
-    call-shape optimization, not a behavior change) — ``is_active_seq`` itself
-    is UNCHANGED and still used by other (non-hot-loop) callers, including
-    crash-recovery paths, so their contract is untouched.
+    LLM-facing hot path run every turn) re-derived the whole branch model once
+    per message: O(N messages x M WAL entries) per turn. This factors the
+    seq-independent derivation out of that loop: call once per turn, then reuse
+    the returned predicate for every message's seq.
+
+    Prefer this over ``is_active_seq`` for ANY loop over seqs — that is the
+    whole point, and the sibling hot paths that still called ``is_active_seq``
+    per seq were the #2948 follow-up. Both share one derivation now, so the
+    per-turn cost is O(N + delta) rather than O(N + M): ``_rewind_records`` is
+    incremental (#2939), decoding only WAL entries appended since the previous
+    call instead of re-reading every line. ``is_active_seq`` is UNCHANGED and
+    equally cheap; it is simply the wrong shape when there is more than one seq
+    to test, since it rebuilds the predicate per call.
     """
     return _make_is_active(_abandoned_intervals(_rewind_records(state_log)))
 

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -120,6 +120,115 @@ WAL_EVENT_KINDS = (
 )
 
 
+class WalTailReader:
+    """Resumable reader over ONE StateLog file's durable entries (#2939).
+
+    ``iter_from(min_seq)`` re-reads and json-decodes the WHOLE file on every
+    call — it filters by ``seq >= min_seq`` only AFTER decoding, so it has no
+    seek and its cost is O(WAL size) regardless of how little is new. Any
+    derived state rebuilt from a full scan every turn therefore grows with the
+    WAL, not with the session's activity (#2939; the ``_rewind_records`` →
+    ``build_active_predicate`` chain is the motivating instance).
+
+    This reader closes that by remembering a **byte offset** into the file:
+    each :meth:`poll` returns only the entries appended since the previous
+    poll, so a caller folding them into derived state pays O(delta), not O(WAL).
+
+    Two properties make that safe rather than merely fast:
+
+    - **Rewrite detection is structural, not argued.** The WAL is append-only
+      in place, but ``truncate_below`` rewrites it via ``tmp.replace(path)`` —
+      a rename, so the surviving file always has a NEW inode. The reader
+      fingerprints ``(st_dev, st_ino)`` and treats any change (or a size that
+      fell below the cursor) as a **restart**: the offset resets to 0, the
+      whole new file is re-yielded, and ``restarted=True`` tells the caller to
+      REBUILD its derived state rather than extend it. So a cache built on this
+      reader cannot outlive the entries it was built from — it cannot serve a
+      record retention has since dropped.
+    - **The identity check and the read are atomic w.r.t. the rename.** The
+      stat is an ``fstat`` on the already-open descriptor and the delta bytes
+      are read through that same descriptor, so a ``truncate_below`` rewrite
+      landing mid-poll cannot make us read the NEW file at the OLD file's
+      offset. (POSIX keeps our fd pointed at the old inode; the next poll then
+      sees the new inode and restarts.)
+
+    Durability matches ``iter_from``: the log's single in-flight entry (written
+    but not yet fsync'd) is the tail, so the scan stops there WITHOUT advancing
+    past it — a later poll re-reads it once durable. A torn trailing line (no
+    newline yet) is likewise not consumed.
+
+    Contract: consume a poll's entries before calling ``poll`` again — the
+    cursor is advanced as they are yielded.
+    """
+
+    def __init__(self, state_log: "StateLog") -> None:
+        self._log = state_log
+        self._fingerprint: "tuple[int, int] | None" = None
+        self._offset = 0
+
+    def poll(self) -> "tuple[Iterator[dict], bool]":
+        """Return ``(entries, restarted)`` — durable entries appended since the
+        previous poll, and whether the file was rewritten (caller must rebuild).
+        """
+        try:
+            with self._log.path.open("rb") as f:
+                st = os.fstat(f.fileno())
+                fingerprint = (st.st_dev, st.st_ino)
+                restarted = (
+                    fingerprint != self._fingerprint or st.st_size < self._offset
+                )
+                start = 0 if restarted else self._offset
+                f.seek(start)
+                data = f.read()
+        except OSError:
+            # No file yet (or it vanished): nothing durable to report. Treat a
+            # previously-seen file's disappearance as a restart so a caller's
+            # derived state is rebuilt rather than silently kept.
+            restarted = self._fingerprint is not None
+            self._fingerprint = None
+            self._offset = 0
+            return iter(()), restarted
+        self._fingerprint = fingerprint
+        # Advance eagerly so an unconsumed batch re-reads from `start` on the
+        # next poll instead of resuming at a stale offset in a rewritten file.
+        self._offset = start
+        return self._iter_delta(data, start), restarted
+
+    def _iter_delta(self, data: bytes, start: int) -> "Iterator[dict]":
+        inflight = self._log._inflight_seq
+        pos = 0
+        while True:
+            nl = data.find(b"\n", pos)
+            if nl == -1:
+                break  # trailing partial line — a torn/incomplete write; retry next poll
+            entry = _parse_wal_line(data[pos:nl])
+            if entry is not None and entry.get("seq") == inflight:
+                break  # the in-flight (non-durable) entry — stop before consuming it
+            pos = nl + 1
+            self._offset = start + pos
+            if entry is not None:
+                yield entry
+
+
+def _parse_wal_line(raw: bytes) -> "dict | None":
+    """Decode one WAL line, or None if it is not a usable entry.
+
+    Mirrors ``iter_from``'s tolerance: blank lines, non-JSON (torn writes from a
+    crash), non-dicts, and entries without an integer ``seq`` are skipped rather
+    than raising — recovery is best-effort from whatever survived.
+    """
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    try:
+        entry = json.loads(stripped)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(entry, dict) or not isinstance(entry.get("seq"), int):
+        return None
+    return entry
+
+
 class StateLog:
     """Single-file WAL. Process-shared; ownership lives in AgentRegistry."""
 
@@ -169,6 +278,16 @@ class StateLog:
     @property
     def path(self) -> Path:
         return self._path
+
+    def tail_reader(self) -> WalTailReader:
+        """A fresh :class:`WalTailReader` cursor over this log (#2939).
+
+        For derived state that would otherwise be rebuilt by a full ``iter_from``
+        scan every turn. Each reader owns an independent cursor, so callers do
+        not interfere; a reader starts at offset 0 (its first poll yields the
+        whole file with ``restarted=True``).
+        """
+        return WalTailReader(self)
 
     @property
     def current_seq(self) -> int:
@@ -409,10 +528,15 @@ class StateLog:
         ``always_keep_kinds``: entries whose ``kind`` is in this set are kept
         unconditionally regardless of seq. Pass
         ``frozenset({REWIND_KIND})`` (``snapshot_generations.REWIND_KIND``) to
-        protect reset-records from being dropped: ``_active_branch_history`` calls
-        ``is_active_seq`` with ``wal_seq`` values from ``history.jsonl`` (which are
+        protect reset-records from being dropped: ``_active_branch_history`` tests
+        the branch model against ``wal_seq`` values from ``history.jsonl`` (which are
         append-only and can be below the floor), so dropping a rewind record causes
         abandoned conversation turns to reappear in the LLM context.
+
+        This rewrite is also the restart signal for :class:`WalTailReader` cursors
+        (the rename gives the surviving file a new inode), so derived state built
+        on one is rebuilt from the rewritten file rather than kept — a reader
+        cannot serve an entry this dropped.
 
         Atomic strategy (mirrors per-snapshot atomic save):
           1. Stream-read current ``wal.jsonl``, write surviving entries to

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -104,12 +104,14 @@ class ContextBudgetAdvisor:
         calling this. ``self._history_fn()`` is invoked before the cache is
         consulted (the cache is keyed on the history it returns, so it cannot
         be), and in production that fn is
-        ``RouterHistoryBuffer.build_history`` → ``Session._active_branch_history``,
-        which does an uncached full-WAL scan per call. Measured (#2940,
-        N=2000 msgs / M=100k WAL entries): ~445ms per call on a cache HIT, of
-        which the producer is ~99.7% and this cache saves ~10ms. Do not read
-        "cache hit" here as "cheap call" — the caller-facing cost is O(WAL
-        size) either way. Flattening that is #2939's scope.
+        ``RouterHistoryBuffer.build_history`` → ``Session._active_branch_history``
+        — a whole-conversation derivation that runs on every call regardless of
+        this cache. So a "cache hit" here is not a cheap call: it still costs
+        O(history), and this cache's share of the total is small (#2940
+        measured it at ~2% when the producer was also re-scanning the WAL).
+        #2939 removed that WAL scan from the producer, so the caller-facing
+        cost now scales with the conversation rather than with WAL size — but
+        it is still the producer, not this, that dominates.
 
         A shrink, a model/use_chars4 change, OR the cached
         PREFIX's content actually differing (checked via a boundary — the

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -180,9 +180,20 @@ class RouterHistoryBuffer:
 
     # ── Internal helpers ─────────────────────────────────────────────────────
 
-    def _latest_summary(self) -> Any | None:
-        """Return the most recent summary message, or None."""
-        for m in reversed(self._history_fn()):
+    def _latest_summary(self, history: "list | None" = None) -> Any | None:
+        """Return the most recent summary message, or None.
+
+        ``history`` — the already-materialised history to search. #2939: callers
+        that have ALREADY called ``self._history_fn()`` must pass it, because
+        ``_history_fn`` is not a cheap accessor: in production it is
+        ``Session._active_branch_history``, a recomputed rewind-aware view over
+        the whole conversation. Re-invoking it here made one ``build_history``
+        produce the view 2x (3x on the elide path, which calls this again) —
+        multiplying the most expensive thing on the turn's hot path by 2-3.
+        Omit it only where no history has been fetched yet (the fn is then
+        invoked once, as before).
+        """
+        for m in reversed(self._history_fn() if history is None else history):
             if m.role == "summary":
                 return m
         return None
@@ -313,7 +324,7 @@ class RouterHistoryBuffer:
         # consolidations only (the dedicated `consolidation` field) — normal
         # compaction summaries fall through to the unchanged head/tail+bridge
         # path below, so normal chat stays byte-identical.
-        _fc_summary = self._latest_summary()
+        _fc_summary = self._latest_summary(history)
         if _fc_summary is not None and _is_force_close_consolidation(_fc_summary):
             from reyn.runtime.chat_message import ChatMessage
             _idx = next(
@@ -354,7 +365,7 @@ class RouterHistoryBuffer:
             # Overlap guard: dedupe by identity so no turn appears twice.
             head_ids = {id(t) for t in head}
             tail_deduped = [t for t in tail if id(t) not in head_ids]
-            summary = self._latest_summary()
+            summary = self._latest_summary(history)
             if summary:
                 summary_text = (
                     summary.content if isinstance(summary.content, str)
@@ -432,7 +443,7 @@ class RouterHistoryBuffer:
                 if id(t) not in head_id_set and id(t) not in tail_id_set
             ]
 
-        summary_msg = self._latest_summary()
+        summary_msg = self._latest_summary(history)
         summary_dict: dict | None = None
         if summary_msg is not None:
             structured = (summary_msg.meta or {}).get("structured")

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -6752,20 +6752,25 @@ class Session:
         dropdown (status bar reads only public accessors, see
         interfaces/inline/app.py's module docstring).
 
-        Non-trivial cost — callers must not invoke this from a per-render-frame
-        path. #2951 added an incremental cache to the advisor's OWN
-        json.dumps + token-estimate of the router-view history, so that step is
-        no longer paid on every call (only on a cache miss: history shrink,
-        model/use_chars4 change, or a changed cached prefix). The remaining —
-        and dominant — cost is the PRODUCER: ``history_fn`` is
-        ``RouterHistoryBuffer.build_history``, which calls
-        ``_active_branch_history`` 2x (3x on the elide path: ``build_history``
-        itself plus each ``_latest_summary``), and each of those does one full
-        ``build_active_predicate`` WAL scan (json-decoding every line, no
-        cache). So this is O(WAL size) per call, NOT O(1) on a cache hit.
-        Measured (#2940, N=2000 msgs / M=100k WAL entries, warm token cache):
-        ~445ms per call, of which build_history is ~99.7%; the #2951 cache
-        saves ~10ms of it. The residual WAL scan is #2939's scope."""
+        Cost is proportional to the CONVERSATION, not to the WAL. Three layers
+        got it there, and each is load-bearing: #2951 caches the advisor's own
+        json.dumps + token-estimate of the router-view history (re-paid only on
+        a miss — history shrink, model/use_chars4 change, changed cached
+        prefix); #2939 made ``build_history`` materialise its producer
+        (``_active_branch_history``) ONCE instead of 2x (3x on the elide path,
+        via each ``_latest_summary``); and #2939 made that producer's
+        ``build_active_predicate`` derivation incremental, so it decodes only
+        WAL entries appended since the previous turn rather than re-scanning
+        every line. Measured (N=2000 msgs, warm token cache, Darwin/arm64):
+        ~2.5ms per call, flat from M=5k to M=100k WAL entries — where before
+        #2939 the same open cost ~20ms at M=5k rising to ~341ms at M=100k
+        (#2940 measured ~445ms at M=100k on the same shape, ~99.7% of it in
+        that scan).
+
+        Still not free, and still not a per-render-frame call: it walks and
+        serialises the whole conversation, so it scales with history length
+        (N). The ctx chip's own denominator should use ``raw_context_window``
+        below, which is O(1)."""
         return self._budget_advisor.context_window_status()
 
     def raw_context_window(self) -> dict:

--- a/tests/test_build_history_producer_calls_2939.py
+++ b/tests/test_build_history_producer_calls_2939.py
@@ -1,0 +1,131 @@
+"""Tier 2: #2939 — building the router view must materialise its history producer
+ONCE per call, not once per internal consumer.
+
+``RouterHistoryBuffer._history_fn`` is not a cheap accessor. In production it is
+``Session._active_branch_history``: a rewind-aware view recomputed over the whole
+conversation on every invocation. ``build_history`` fetched it, then
+``_latest_summary`` silently fetched it AGAIN (and a third time on the elide
+path, which calls ``_latest_summary`` a second time) — so the single most
+expensive step on the turn's hot path ran 2-3x per turn. #2940 measured that
+producer at ~99.7% of a context-dropdown open, making the multiplier a direct
+2-3x on the user-visible cost.
+
+The invariant is the call count, not a duration: how long the producer takes is
+environment-dependent, but "each ``build_history`` materialises the view exactly
+once" is a property of the code's shape and is what stops a re-multiplication
+from being reintroduced by a future caller that reaches for ``self._history_fn()``
+instead of threading the list it already has.
+
+Real seam: the real ``RouterHistoryBuffer`` and the real ``CompactionConfig`` /
+budget resolution, with a real counting callable as the producer (not a Mock).
+Both branches of ``build_history`` are covered — the non-elide path and the
+elide path, which is where the third call used to appear.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config.chat import CompactionConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+
+
+def _buffer(history: list, model: str):
+    """Real RouterHistoryBuffer over a counting producer; returns (buf, counter)."""
+    calls = {"n": 0}
+
+    def counting_history_fn() -> list:
+        calls["n"] += 1
+        return history
+
+    buf = RouterHistoryBuffer(
+        history_fn=counting_history_fn,
+        compaction=CompactionConfig(),
+        compaction_controller=None,  # → window resolved straight from the model
+        model_fn=lambda: model,
+        events=None,
+        media_store=None,
+        router_host=None,
+        action_retrieval=None,
+        non_interactive=False,
+    )
+    return buf, calls
+
+
+def _conversation(n: int, filler: int = 8) -> list:
+    out: list = []
+    for i in range(n):
+        out.append(ChatMessage(role="user", content=f"q{i} " + "word " * filler))
+        out.append(ChatMessage(role="assistant", content=f"a{i} " + "word " * filler))
+    return out
+
+
+def test_build_history_materialises_the_producer_once_without_elide():
+    """Tier 2: a conversation that fits the window costs exactly one producer
+    call — the pre-#2939 shape re-fetched it for the summary lookup."""
+    buf, calls = _buffer(_conversation(10), "openai/gpt-4o")
+
+    wire = buf.build_history()
+
+    assert wire, "sanity: the router view is non-empty"
+    assert calls["n"] == 1, (
+        f"build_history must materialise its history producer once (got "
+        f"{calls['n']} calls) — the producer is a recomputed whole-conversation "
+        "view, so each extra call is a full extra derivation on the turn hot path"
+    )
+
+
+def test_build_history_materialises_the_producer_once_on_the_elide_path():
+    """Tier 2: the elide path (history over the trigger, summary bridge inserted)
+    also costs exactly one producer call — this branch consults the summary a
+    SECOND time, and used to re-derive the whole view for it."""
+    history = _conversation(200, filler=60)
+    history.insert(0, ChatMessage(role="summary", content="earlier conversation"))
+    # gpt-4's 8K window against a large conversation → over the trigger → elide.
+    buf, calls = _buffer(history, "openai/gpt-4")
+
+    wire = buf.build_history()
+
+    assert any(
+        "[summary of earlier conversation]" in m.get("content", "")
+        for m in wire
+        if isinstance(m.get("content"), str)
+    ), "test premise: this must actually take the elide path (summary bridge present)"
+    assert calls["n"] == 1, (
+        f"the elide path must materialise its history producer once (got "
+        f"{calls['n']} calls) — its extra summary lookup is where the third "
+        "whole-view derivation used to come from"
+    )
+
+
+def test_decompose_history_for_retry_materialises_the_producer_once():
+    """Tier 2: the retry decomposition shares build_history's producer contract —
+    it fetches the view, then looks up the summary, and must not re-derive."""
+    history = _conversation(20)
+    history.insert(0, ChatMessage(role="summary", content="earlier conversation"))
+    buf, calls = _buffer(history, "openai/gpt-4o")
+
+    head, _raw_middle, _tail, _summary = buf.decompose_history_for_retry()
+
+    assert head, "sanity: the decomposition is non-empty"
+    assert calls["n"] == 1, (
+        f"decompose_history_for_retry must materialise its history producer once "
+        f"(got {calls['n']} calls)"
+    )
+
+
+@pytest.mark.parametrize("model", ["openai/gpt-4o", "openai/gpt-4"])
+def test_producer_call_count_does_not_grow_with_conversation_size(model):
+    """Tier 2: the producer call count is a property of build_history's shape, not
+    of the conversation — a 20x-larger history costs the same number of calls.
+    Pins the invariant against re-multiplication on either window branch."""
+    _buf_small, small = _buffer(_conversation(10), model)
+    _buf_small.build_history()
+
+    _buf_large, large = _buffer(_conversation(200, filler=60), model)
+    _buf_large.build_history()
+
+    assert small["n"] == large["n"], (
+        f"producer calls must not depend on conversation size (small: {small['n']}, "
+        f"20x-larger: {large['n']})"
+    )

--- a/tests/test_rewind_index_incremental_2939.py
+++ b/tests/test_rewind_index_incremental_2939.py
@@ -1,0 +1,191 @@
+"""Tier 2: #2939 — deriving the active branch must not re-decode the WHOLE WAL on
+every turn, and the incremental derivation must never outlive the entries it was
+built from.
+
+Residual after #2941: that fix hoisted the ``is_active_seq`` scan out of the
+per-MESSAGE loop (O(N x M) -> O(N + M) per turn), but the surviving scan still
+json-decoded every WAL line once per turn. So the cost of a turn (and of opening
+the chat's context dropdown, which drives the same producer) grew with WAL SIZE
+rather than with what had actually changed — #2940 measured that scan at ~99.7%
+of a dropdown open.
+
+**Why the #2941 seam could not see this bug.** ``test_active_branch_history_scan_
+bound_2941.py`` counts ``iter_from`` CALLS, and that count was already constant
+(2 per open) at every WAL size — the call count is structurally blind to the M
+axis, which is exactly how this residual survived a green suite. These tests
+therefore measure WAL lines DECODED, the quantity that actually grew, and pin it
+against a *growing* WAL rather than a fixed one.
+
+Real seam throughout: real ``StateLog`` on a real on-disk WAL, the real
+``checkout`` reset-record primitive, the real ``truncate_below`` rewrite, and the
+real ``build_active_predicate`` / ``is_active_seq`` derivations. Decodes are
+counted by wrapping ``json.loads`` with a real counting function (not a Mock) —
+the seam every WAL reader goes through, so a revert to a full ``iter_from(1)``
+re-scan is caught rather than silently bypassing the counter.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from reyn.core.events.snapshot_generations import (
+    REWIND_KIND,
+    build_active_predicate,
+    checkout,
+    is_active_seq,
+)
+from reyn.core.events.state_log import StateLog
+
+
+def _count_decodes(monkeypatch):
+    """Wrap json.loads with a real counting function; returns the live counter."""
+    calls = {"n": 0}
+    real_loads = json.loads
+
+    def counting_loads(*args, **kwargs):
+        calls["n"] += 1
+        return real_loads(*args, **kwargs)
+
+    monkeypatch.setattr(json, "loads", counting_loads)
+    return calls
+
+
+async def _grow_wal(state_log: StateLog, n: int) -> int:
+    """Append n ordinary WAL entries; return the last seq."""
+    seq = 0
+    for _ in range(n):
+        seq = await state_log.append("step_completed")
+    return seq
+
+
+@pytest.mark.asyncio
+async def test_active_branch_derivation_decodes_do_not_grow_with_wal_size(tmp_path, monkeypatch):
+    """Tier 2: re-deriving the active-branch predicate costs WAL lines decoded
+    proportional to what was APPENDED since the last derivation, not to the WAL's
+    total size. A full re-scan (the #2939 residual) makes the decode count grow
+    with the WAL; the incremental index keeps it flat."""
+    state_log = StateLog(tmp_path / "state.wal")
+    anchor = await _grow_wal(state_log, 50)
+    await checkout(state_log, target_seq=anchor // 2)
+    build_active_predicate(state_log)  # warm
+
+    counter = _count_decodes(monkeypatch)
+
+    # Derive against a small WAL, then again against a much larger one. The WAL
+    # grew ~20x between the two; a full re-scan would decode ~20x more lines.
+    counter["n"] = 0
+    build_active_predicate(state_log)
+    small = counter["n"]
+
+    await _grow_wal(state_log, 1000)
+    build_active_predicate(state_log)  # absorb the delta once
+
+    counter["n"] = 0
+    build_active_predicate(state_log)
+    large = counter["n"]
+
+    assert large == small, (
+        f"decodes per derivation must not grow with WAL size (small WAL: {small} "
+        f"lines decoded, ~20x-larger WAL: {large}) — a full re-scan would make "
+        "large >> small, which is the #2939 residual this pins"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_derivation_over_unchanged_wal_decodes_nothing(tmp_path, monkeypatch):
+    """Tier 2: when nothing was appended, re-deriving decodes no WAL lines at all
+    — the dropdown-open / per-turn path pays for change, not for history size."""
+    state_log = StateLog(tmp_path / "state.wal")
+    anchor = await _grow_wal(state_log, 200)
+    await checkout(state_log, target_seq=anchor // 2)
+    build_active_predicate(state_log)  # warm
+
+    counter = _count_decodes(monkeypatch)
+    counter["n"] = 0
+    build_active_predicate(state_log)
+
+    assert counter["n"] == 0, (
+        f"an unchanged WAL must cost zero decodes to re-derive (got {counter['n']}) "
+        "— any non-zero count means the whole log is being re-read per turn"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rewind_appended_after_warm_index_takes_effect(tmp_path):
+    """Tier 2: a reset-record appended AFTER the index warmed is honoured — the
+    incremental cursor must pick up mid-session rewinds, not freeze the branch
+    model at whatever was on disk when it was first built."""
+    state_log = StateLog(tmp_path / "state.wal")
+    anchor = await _grow_wal(state_log, 10)
+    abandoned_seq = await _grow_wal(state_log, 5)
+
+    assert is_active_seq(state_log, abandoned_seq), "sanity: active before any rewind"
+
+    await checkout(state_log, target_seq=anchor)
+
+    assert not is_active_seq(state_log, abandoned_seq), (
+        "a rewind appended after the derivation was first built must abandon the "
+        "seqs it rewound past — a frozen index would still call them active"
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncation_dropping_a_rewind_record_does_not_serve_a_stale_interval(tmp_path):
+    """Tier 2: when retention's WAL rewrite drops a reset-record, the branch model
+    must rebuild from the rewritten file — never keep serving the abandoned
+    interval that record used to imply.
+
+    This is the #2939 staleness hazard: an in-memory index of rewind records is
+    not itself truncated, so a cache that merely appended would answer from a
+    record the WAL no longer holds, and abandoned conversation turns would
+    silently reappear in the LLM's context. ``truncate_below`` renames a fresh
+    file into place, so the index's file-identity check must catch it.
+    """
+    state_log = StateLog(tmp_path / "state.wal")
+    anchor = await _grow_wal(state_log, 10)
+    abandoned_seq = await _grow_wal(state_log, 5)
+    await checkout(state_log, target_seq=anchor)
+    head = await _grow_wal(state_log, 5)
+
+    # Warm the derivation while the reset-record is present.
+    assert not is_active_seq(state_log, abandoned_seq), "sanity: abandoned pre-truncation"
+
+    # Retention rewrite WITHOUT always_keep_kinds → the reset-record is dropped.
+    await state_log.truncate_below(head)
+    await state_log.flush()
+    surviving_kinds = [e.get("kind") for e in state_log.iter_from(0)]
+    assert REWIND_KIND not in surviving_kinds, (
+        "test premise: this truncation must actually drop the reset-record, "
+        "otherwise it cannot witness staleness"
+    )
+
+    assert is_active_seq(state_log, abandoned_seq), (
+        "after the reset-record was truncated away, the branch model must reflect "
+        "the WAL that now exists (nothing abandoned) — still reporting the seq as "
+        "abandoned means a stale interval was served from a cache the truncation "
+        "could not reach"
+    )
+
+
+@pytest.mark.asyncio
+async def test_truncation_preserving_rewind_records_keeps_them_active(tmp_path):
+    """Tier 2: the complement — a retention rewrite that PRESERVES reset-records
+    (the production call, which passes always_keep_kinds) must leave the branch
+    model intact. The rebuild-on-rewrite must re-read the kept records, not
+    forget them."""
+    state_log = StateLog(tmp_path / "state.wal")
+    anchor = await _grow_wal(state_log, 10)
+    abandoned_seq = await _grow_wal(state_log, 5)
+    await checkout(state_log, target_seq=anchor)
+    head = await _grow_wal(state_log, 5)
+
+    assert not is_active_seq(state_log, abandoned_seq), "sanity: abandoned pre-truncation"
+
+    await state_log.truncate_below(head, always_keep_kinds=frozenset({REWIND_KIND}))
+    await state_log.flush()
+
+    assert not is_active_seq(state_log, abandoned_seq), (
+        "a truncation that keeps the reset-record must keep its abandoned interval "
+        "— dropping it here would resurrect rewound-past turns into the LLM context"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2939.

<!-- closing-check: discussing #2940 -->
<!-- closing-check: discussing #2941 -->
<!-- closing-check: discussing #2948 -->
<!-- closing-check: discussing #2951 -->
<!-- closing-check: discussing #3022 -->

#2940 stays **open** and is untouched by this PR — see "What this does not settle" below.

## The witness

The only claim that matters here is a measurement, not a complexity argument. Real wiring (`ContextBudgetAdvisor(history_fn=build_history)` ← `RouterHistoryBuffer` ← the **real** `Session._active_branch_history` bound to a shim ← real `StateLog` on a real on-disk WAL), N=2000 msgs, warm token cache, interleaved 7 reps, median. Darwin/arm64.

| M (WAL entries) | before | after |
|---|---|---|
| 5,000 | 20.3ms | **2.5ms** |
| 20,000 | 73.1ms | **2.5ms** |
| 50,000 | 170.4ms | **2.5ms** |
| 100,000 | **341.3ms** | **2.5ms** |
| `history_fn()` calls / `build_history()` | 2 (3 on elide) | **1** |

**The invariant is the flat column, not the 137x.** Dropdown-open cost no longer grows with WAL size. Both columns come from the same harness on the same machine, re-measured after rebasing onto `origin/main` (`6731fb25`).

The residual ~2.5ms scales with the **conversation** (N) — the honest floor for a call that serialises the whole history.

## Two fixes, one invariant

I did both in one PR: they are the same invariant measured at the same seam, share one witness harness, and the second is a 4-line change. Split, the "flat across M" claim is unverifiable in isolation — the 2-3x multiplier sits directly on top of the scan.

**1. `_rewind_records` is incremental** (`snapshot_generations.py`). It folds over a new resumable `WalTailReader` cursor (`state_log.py`), decoding only WAL bytes appended since the previous call.

Applied at the **sole chokepoint**: all 8 branch-model derivation sites (`is_active_seq`, `build_active_predicate`, `active_rewind_target`, `branches`, …) already route through `_rewind_records`, so all 8 benefit. Deliberate — #2948 is the precedent where a new hoist primitive was applied to *one* call site and 7 siblings survived. I used grep as the authority, not a call-site list.

**2. `build_history` materialises its producer once** (`router_history_buffer.py`). `_latest_summary()` re-invoked `_history_fn` — in production `_active_branch_history`, a recomputed whole-conversation view. It now takes the already-fetched list. Swept the identical pattern in `decompose_history_for_retry`.

## Why the staleness hazard is closed structurally, not argued

The issue flagged this as highest-priority: an in-memory rewind-record cache is not truncated by retention, so it could serve a **stale abandoned interval** — a record the WAL no longer holds — and abandoned conversation turns would silently reappear in the LLM's context.

I did not resolve this by reasoning about what retention chooses to keep. `truncate_below` rewrites via `tmp.replace(path)` — a **rename**, so the surviving file always has a new inode. `WalTailReader` fingerprints `(st_dev, st_ino)`, reports `restarted`, and the index rebuilds from the file that now exists. The cache **cannot** outlive the entries it was built from.

Two supporting details:
- The identity check is an `fstat` on the **already-open fd**, and the delta is read through that same fd — so a rewrite landing mid-poll cannot make us read the *new* file at the *old* file's offset. The next poll sees the new inode and restarts.
- Durability semantics match `iter_from`: the single in-flight (written, not-yet-fsync'd) entry is not consumed, and the cursor never advances past it or past a torn trailing line.

**Recovery gate**: this is in-memory derived state with no persistence, rebuilt from the WAL on demand — no snapshot, so CLAUDE.md's truncate-falsify gate has no persisted reconstruction source to protect (same class as #2937). The analogous risk is *inverted* here (cache outliving truncation, not dying with it), and that is pinned by `test_truncation_dropping_a_rewind_record_does_not_serve_a_stale_interval` plus its complement.

## Test design — why structure, not time

Per the brief, wall-clock assertions are environment-dependent and flaky. But the sharper reason is that **the existing seam was structurally blind to this bug**.

`test_active_branch_history_scan_bound_2941.py` counts `iter_from` **calls** — and that count was already **2 at every WAL size** before this PR. Call count cannot see the M axis. That is precisely how this residual survived a green suite. So my tests measure **WAL lines decoded** (via a real counting wrapper around `json.loads` — a real callable, not a Mock) against a *growing* WAL, and assert the count does not grow.

## Strip-falsification (every test, confirmed red)

Green tests prove nothing until they can fail. I reverted each mechanism locally and re-ran:

| Strip | Result |
|---|---|
| `_rewind_records` → pre-#2939 full re-scan | `decodes must not grow with WAL size` → **51 vs 1051** (20x growth = the bug, witnessed) |
| same | `unchanged WAL must cost zero decodes` → **got 201** |
| `_RewindIndex` → naive append-only (drop `restarted` handling) | staleness test → **red** (serves the truncated-away interval) |
| index frozen after first build | mid-session-rewind test → **red**; staleness → **red** |
| `_latest_summary` → re-fetch `_history_fn()` | **2 calls** non-elide, **3 on elide** |

The last row independently reproduces #2940's measured "2x / 3x on elide" claim from the other side.

All strips verified removed (grep for residue) before commit.

## Docs corrected in this PR (not a follow-up)

Per the CLAUDE.md hard rule — this PR falsifies prose that #3022 had just made accurate:
- `session.py` `context_window_status` — asserted 2x/3x producer calls, a full uncached WAL scan per call, "O(WAL size) per call", ~445ms. All falsified. Rewritten with the new measurement and the honest residual (still O(N), still not a per-frame call).
- `context_budget_advisor.py` `_incremental_history_tokens` — asserted "uncached full-WAL scan per call" and "O(WAL size) either way".
- `snapshot_generations.py` `build_active_predicate` — "ONE WAL scan"; now also points siblings at the #2948 lesson.
- `state_log.py` `truncate_below` + `retention.py` floor argument — both describe the truncation↔rewind-record interaction my index now participates in. Their `always_keep_kinds` reasoning is unchanged and still correct; I made the call path precise (it said `is_active_seq`, which #2941 had already replaced) and named the rebuild-on-rewrite.

No `docs/*.md` file describes the changed mechanism — ADR-0038 pins `iter_from`'s *contract*, which this PR leaves untouched. Checked, not assumed.

## What this does not settle

**#2940 stays open.** My 341ms is not the owner's freeze either — the same honest gap the measuring coder recorded: their real M may be larger, my Darwin/arm64 + SSD may be fast, or another factor is present. This PR removes the mechanism that #2940 measured at 99.7% of a dropdown open; it does **not** demonstrate that the owner's freeze was that mechanism. That link needs an owner-session measurement (py-spy stack + events gap), which I have not done.

Also not measured: x86_64. My synthetic WAL entries are small (~80B), so real entries make the *before* column worse, not better.

## Test plan

- [x] `ruff check src tests` — pass
- [x] `python scripts/test_tier_audit.py --strict` on both new test files — 9/9 OK, 0 Tier-4 violations, exit 0
- [x] `pytest -q -n auto --timeout=120` from repo root — **8790 passed, 22 skipped**. All 22 skips read via `-rs` and enumerated: Linux-only (Landlock/seccomp), docker VM bind-mount, unmounted F4 endpoints, absent optional deps (trafilatura/slack_bolt/linebot), absent `~/.aws` `~/.netrc` etc. All environment-gated and pre-existing; none in the touched area.
- [x] `python scripts/verify_module_docstrings.py` on all 6 changed src files — pass
- [x] Rebased onto `origin/main` (`6731fb25`) and **re-measured + re-ran all four gates** after the rebase
- [x] Strip-falsified every new test (table above); verified no strip residue remains
- [x] Existing rewind/WAL/retention suites pass unmodified (`test_build_active_predicate_equivalence_2941`, `test_conversation_rewind_2360`, `test_state_log_truncate`, `test_registry_wal_truncate`, …) — the derivation's equivalence is already pinned there and still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
