### PR TITLE
fix(dev-env): make "the environment runs the tree I am measuring" declarable and measured (#3024)

### DIFF
--- a/docs/deep-dives/contributing/testing.md
+++ b/docs/deep-dives/contributing/testing.md
@@ -365,6 +365,33 @@ When adding new infra that touches user home (`~/.reyn/registry-cache/`, `~/.rey
 
 Module-level constants (`_SECRETS_FILE = Path.home() / ".reyn" / "secrets.env"`) are evaluated at import time — `monkeypatch.setenv("HOME", ...)` after import has no effect. The env-var-at-call-time pattern avoids that footgun.
 
+## Spawning a subprocess that imports `reyn` (= declare it)
+
+**In-process, a test always reads the checkout it was started from** — `[tool.pytest.ini_options] pythonpath = ["src"]` puts `<rootdir>/src` on `sys.path`. **A subprocess gets no such favour**: it re-resolves `reyn` from the venv. In a git worktree — which has no venv of its own, and borrows the main checkout's — that answer is **whatever checkout the venv's editable `.pth` points at**, i.e. *someone else's working tree*. Both halves then go green while disagreeing, and the spawning half is the wrong one (#3024).
+
+**If your test spawns anything that imports `reyn`, request `out_of_process_reyn` and pin what it returns:**
+
+```python
+def test_something(out_of_process_reyn):
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
+    subprocess.run([sys.executable, "-c", script], env=env)
+```
+
+The fixture derives the src root from the **in-process** `reyn` and verifies by measurement that a subprocess pinned to it reads that same `reyn` — so the test measures the tree under test, in a worktree as well as in CI.
+
+**An MCP stdio server needs the pin threaded through the server's *configured* env**, not inherited: the MCP SDK passes a six-key whitelist (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER`) that **drops `PYTHONPATH`**. See `tests/test_fp0063_p3_rag_pipelines.py`.
+
+**If your test runs a `[project.scripts]` console script by name** (`reyn`, `reyn-rag-chunker`, `reyn-rag-vector-store`), also request **`reyn_console_scripts`**. A venv installed before an entry point was declared does not carry that script, and the failure says neither "absent" nor "stale venv" — it surfaces as `execvp() failed` or, through a stdio client, `McpError: Connection closed`, both of which read as a broken feature. The fixture skips with the absent subject named, and **fails under CI** (where the venv installs this checkout, so an absence there is a CI-setup defect rather than a reason to go green).
+
+To diagnose an environment directly — including outside pytest, e.g. a manual e2e or a co-vet run:
+
+```bash
+python scripts/verify_env_identity.py            # all checks
+python scripts/verify_env_identity.py --only console-scripts
+```
+
+**Never re-install a stale venv by running `pip install -e .` from inside a worktree.** That repoints the shared venv's editable `.pth` at that worktree, and every other consumer of the venv silently starts reading it. Install from the checkout the venv is meant to serve.
+
 ## Out of policy
 
 These belong outside the test suite:

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -325,8 +325,8 @@ def check_console_scripts(root: Path) -> list[Finding]:
 
 
 # The enumeration. A check is registered here or it does not run — `main` and the
-# pytest session gate both derive their work from this map rather than from a
-# hand-kept call list, so adding a check cannot leave a caller behind.
+# `tests/conftest.py` fixtures both derive their work from this map rather than
+# from a hand-kept call list, so adding a check cannot leave a caller behind.
 CHECKS = {
     "tree-identity": check_tree_identity,
     "pinned-tree": check_pinned_tree,

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Fail when the environment would run a different ``reyn`` than the tree under test.
+
+An observation does not name its own referent. ``import reyn`` succeeding says
+nothing about *which checkout* answered; ``execvp() failed`` and
+``McpError: Connection closed`` do not distinguish "the feature is broken" from
+"this venv has no such console script". #3024 collected eight measurement
+failures in one day that all reduce to one sentence: **the thing measured was
+not the thing that runs.** Two of them reached a co-vet verdict — the merge gate.
+
+This module answers, mechanically, the question a reader of those errors has to
+answer by hand today: *does this environment resolve the checkout I mean?* It
+reports each way the answer can be "no" as a **separately named** finding,
+because collapsing distinct referents into one word is the failure being closed
+(the #3023 post-mortem, verbatim: "three different things — flake / main-red /
+venv-console-script-absent — collapsed into one word").
+
+Two properties are load-bearing:
+
+**It never imports reyn.** ``reyn``'s own resolution is the subject under test;
+an importer would be asserting with the very mechanism whose trustworthiness is
+in question. Checks run reyn out-of-process and compare *paths*, and the module
+stays stdlib-only (tomllib / subprocess / shutil), mirroring
+``scripts/test_tier_audit.py`` and ``scripts/verify_module_docstrings.py``.
+
+**It measures rather than infers.** Import resolution is not re-implemented from
+``.pth`` files and ``sys.path`` rules — a subprocess is spawned and asked where
+``reyn`` actually came from. ``CHECKS`` below is the enumeration; each entry
+carries the remedy for its own finding, so the gate that fires is the thing that
+explains itself.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+# What a `mcp.client.stdio`-spawned server inherits. The MCP SDK passes only
+# `DEFAULT_INHERITED_ENV_VARS` to a stdio server — six keys on POSIX, and
+# PYTHONPATH is not among them. That whitelist is the reason a server subprocess
+# resolves the *ambient* install even when the parent was pinned to a checkout
+# with PYTHONPATH: the pin does not survive the spawn. Mirrored here (rather
+# than imported) to keep this module dependency-free and to keep it measuring
+# the shape that bit #3006 / #3008 / #3010 even if the SDK is absent.
+MCP_INHERITED_ENV_VARS = ("HOME", "LOGNAME", "PATH", "SHELL", "TERM", "USER")
+
+# Ask a subprocess where `reyn` resolves, without importing it. `find_spec` locates
+# the package without executing its `__init__`, so a heavy import chain (or an
+# import-time failure in a half-synced env) cannot turn a *location* question
+# into a *health* question — precisely the conflation this gate exists to end.
+_ORIGIN_PROBE = (
+    "import importlib.util as u;"
+    "s = u.find_spec('reyn');"
+    "print(s.origin if s and s.origin else '')"
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One named way the environment disagrees with the tree under test."""
+
+    check: str
+    detail: str
+    remedy: str
+
+    def render(self) -> str:
+        return f"  [{self.check}]\n    {self.detail}\n    remedy: {self.remedy}"
+
+
+def _probe_origin(env: dict[str, str]) -> tuple[str | None, str]:
+    """Return (origin, stderr) for `reyn` as resolved by a subprocess under ``env``."""
+    proc = subprocess.run(
+        [sys.executable, "-c", _ORIGIN_PROBE],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
+    origin = proc.stdout.strip()
+    return (origin or None), proc.stderr.strip()
+
+
+def _mcp_shaped_env() -> dict[str, str]:
+    """The env an MCP stdio server is actually handed."""
+    return {k: os.environ[k] for k in MCP_INHERITED_ENV_VARS if k in os.environ}
+
+
+def _declared_scripts(root: Path) -> dict[str, int]:
+    """Map each ``[project.scripts]`` name to its pyproject.toml line number.
+
+    The line number is half the point: a finding that says "declared at
+    pyproject.toml:185" sends the reader to the declaration, which is what
+    distinguishes "this venv is stale" from "this feature is broken".
+    """
+    pyproject = root / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    names = list(data.get("project", {}).get("scripts", {}))
+    lines = pyproject.read_text(encoding="utf-8").splitlines()
+    located: dict[str, int] = {}
+    for name in names:
+        pattern = re.compile(rf"^\s*{re.escape(name)}\s*=")
+        located[name] = next(
+            (i for i, line in enumerate(lines, 1) if pattern.match(line)), 0
+        )
+    return located
+
+
+def _tree_of(origin: str) -> str:
+    """Render a resolved origin as the checkout that owns it, for a diagnosis."""
+    path = Path(origin)
+    # <tree>/src/reyn/__init__.py -> <tree>; site-packages installs render as-is.
+    if len(path.parents) >= 3 and path.parents[1].name == "src":
+        return str(path.parents[2])
+    return str(path.parent)
+
+
+def check_tree_identity(root: Path) -> list[Finding]:
+    """A subprocess must resolve `reyn` to the checkout under test.
+
+    `pytest` puts ``<rootdir>/src`` on `sys.path` (``[tool.pytest.ini_options]
+    pythonpath``), so an *in-process* test always reads the checkout it was
+    started from. A subprocess has no such favour: it re-resolves `reyn` from
+    the venv, and in a git worktree with no venv of its own that answer is
+    whatever checkout the ambient venv's editable ``.pth`` points at. Both
+    halves are then green and disagree, silently.
+    """
+    expected = root / "src" / "reyn"
+    findings: list[Finding] = []
+
+    for check, env, note in (
+        (
+            "tree-identity/inherited",
+            dict(os.environ),
+            "a plain subprocess (a test spawning sys.executable, a shell-out)",
+        ),
+        (
+            "tree-identity/mcp-env",
+            _mcp_shaped_env(),
+            "an MCP stdio server (PYTHONPATH is not in the SDK's inherited-env whitelist)",
+        ),
+    ):
+        origin, stderr = _probe_origin(env)
+        if origin is None:
+            findings.append(
+                Finding(
+                    check=check,
+                    detail=(
+                        f"{note} cannot import reyn at all.\n"
+                        f"    This is NOT evidence that reyn is broken — it is an "
+                        f"un-installed environment.\n"
+                        f"    interpreter: {sys.executable}\n"
+                        f"    stderr: {stderr[-200:] or '(none)'}"
+                    ),
+                    remedy=(
+                        f"install reyn into {sys.prefix} (`pip install -e '.[dev]'` "
+                        f"run FROM {root}) — see the warning in `check_console_scripts`."
+                    ),
+                )
+            )
+            continue
+        if Path(origin).parent != expected:
+            findings.append(
+                Finding(
+                    check=check,
+                    detail=(
+                        f"{note} resolves a DIFFERENT checkout than the tree under test.\n"
+                        f"    tree under test: {root}\n"
+                        f"    subprocess reads: {_tree_of(origin)}\n"
+                        f"    (origin: {origin})\n"
+                        f"    In-process tests here read {expected}; anything spawned "
+                        f"reads the tree above. Both can be green while disagreeing."
+                    ),
+                    remedy=(
+                        f"give this checkout its own venv, or pin PYTHONPATH={root / 'src'} "
+                        f"for spawns (note: PYTHONPATH does NOT survive an MCP stdio spawn)."
+                    ),
+                )
+            )
+    return findings
+
+
+def check_pinned_tree(root: Path) -> list[Finding]:
+    """A subprocess pinned to this checkout's src must read this checkout.
+
+    This is the question a test asks when it spawns something that imports reyn
+    and threads ``PYTHONPATH`` to keep it honest. It is deliberately separate
+    from `check_tree_identity`: that check asks what an *unpinned* spawn reads
+    (and in a worktree the answer is another checkout, permanently, which no
+    session can fix), whereas this one asks whether the pin — the thing a test
+    can actually control — delivers. A pin that silently fails to win over an
+    editable ``.pth`` would put a test back to measuring another tree while
+    looking careful.
+    """
+    src = root / "src"
+    env = {**os.environ, "PYTHONPATH": str(src)}
+    origin, stderr = _probe_origin(env)
+    if origin is None:
+        return [
+            Finding(
+                check="pinned-tree",
+                detail=(
+                    f"a subprocess pinned to PYTHONPATH={src} still cannot import reyn.\n"
+                    f"    interpreter: {sys.executable}\n"
+                    f"    stderr: {stderr[-200:] or '(none)'}"
+                ),
+                remedy=f"check that {src / 'reyn'} exists and this interpreter can read it.",
+            )
+        ]
+    if Path(origin).parent != src / "reyn":
+        return [
+            Finding(
+                check="pinned-tree",
+                detail=(
+                    f"a subprocess pinned to PYTHONPATH={src} reads a DIFFERENT checkout.\n"
+                    f"    pinned to: {src}\n"
+                    f"    reads:     {origin}\n"
+                    f"    The pin did not win — spawned tests would measure the tree above."
+                ),
+                remedy=(
+                    f"{src / 'reyn'} does not exist — {root} is not a checkout with a src "
+                    f"layout, so the pin had nothing to point at and the venv answered "
+                    f"instead."
+                    if not (src / "reyn").exists()
+                    else (
+                        "something ahead of PYTHONPATH on sys.path resolves reyn first; "
+                        f"inspect {sys.prefix}'s .pth files."
+                    )
+                ),
+            )
+        ]
+    return []
+
+
+def check_console_scripts(root: Path) -> list[Finding]:
+    """Every declared console script must exist in this venv and read this tree.
+
+    A `[project.scripts]` entry in pyproject.toml is a *declaration*; the console
+    script is a file `pip` writes into a venv's `bin/`. Adding an entry does not
+    reach into a venv that was installed before it (#2955 P2 added
+    ``reyn-rag-vector-store``; every venv installed earlier has never heard of
+    it). The absent script then surfaces as ``execvp() failed`` or, through a
+    stdio client, ``McpError: Connection closed`` — neither of which says
+    "absent", so both read as a broken feature. That misread reached a co-vet
+    verdict twice in one day.
+    """
+    bin_dir = Path(sys.executable).parent
+    findings: list[Finding] = []
+
+    for name, line in _declared_scripts(root).items():
+        declared_at = f"pyproject.toml:{line}" if line else "pyproject.toml"
+        script = bin_dir / name
+        if not script.exists():
+            findings.append(
+                Finding(
+                    check="console-scripts/present",
+                    detail=(
+                        f"console script `{name}` is declared at {declared_at} but is "
+                        f"ABSENT from {bin_dir}.\n"
+                        f"    This venv is stale — it predates the declaration.\n"
+                        f"    It is NOT evidence that `{name}` is broken, and NOT a flake: "
+                        f"running it fails deterministically, as `execvp() failed` or "
+                        f"`McpError: Connection closed`."
+                    ),
+                    remedy=(
+                        f"re-install reyn into {sys.prefix} by running "
+                        f"`pip install -e '.[dev]'` FROM the checkout this venv is "
+                        f"meant to serve. Do NOT run it from a throwaway worktree: that "
+                        f"repoints this venv's editable .pth at that worktree and every "
+                        f"other consumer of the venv silently starts reading it (#3024)."
+                    ),
+                )
+            )
+            continue
+
+        # The console script that will actually run is the one PATH finds, not the
+        # one adjacent to sys.executable — an earlier venv on PATH shadows it.
+        found = shutil.which(name)
+        if found and Path(found).resolve() != script.resolve():
+            findings.append(
+                Finding(
+                    check="console-scripts/present",
+                    detail=(
+                        f"console script `{name}` on PATH is NOT this venv's copy.\n"
+                        f"    PATH resolves: {found}\n"
+                        f"    this venv has: {script}\n"
+                        f"    A spawn by name runs the PATH copy, which belongs to "
+                        f"another environment."
+                    ),
+                    remedy=f"put {bin_dir} ahead of {Path(found).parent} on PATH.",
+                )
+            )
+            continue
+
+        # `pip` stamps a console script's shebang with the ABSOLUTE interpreter it
+        # was installed into. A script left behind by an interpreter that no longer
+        # matches this venv runs someone else's reyn while looking local.
+        shebang = script.read_text(encoding="utf-8", errors="replace").splitlines()[:1]
+        if shebang and shebang[0].startswith("#!"):
+            interpreter = shebang[0][2:].strip().split()[0]
+            if Path(interpreter).resolve() != Path(sys.executable).resolve():
+                findings.append(
+                    Finding(
+                        check="console-scripts/tree",
+                        detail=(
+                            f"console script `{name}` is stamped with a DIFFERENT "
+                            f"interpreter than this venv's.\n"
+                            f"    `{name}` runs: {interpreter}\n"
+                            f"    this venv is: {sys.executable}\n"
+                            f"    Whatever that interpreter resolves for `reyn` is what "
+                            f"`{name}` executes — not necessarily {root}."
+                        ),
+                        remedy=(
+                            f"re-install reyn into {sys.prefix} (see the "
+                            f"console-scripts/present remedy for the .pth warning)."
+                        ),
+                    )
+                )
+    return findings
+
+
+# The enumeration. A check is registered here or it does not run — `main` and the
+# pytest session gate both derive their work from this map rather than from a
+# hand-kept call list, so adding a check cannot leave a caller behind.
+CHECKS = {
+    "tree-identity": check_tree_identity,
+    "pinned-tree": check_pinned_tree,
+    "console-scripts": check_console_scripts,
+}
+
+
+def verify(root: Path, only: tuple[str, ...] = ()) -> list[Finding]:
+    """Run the registered checks against ``root`` and return every finding."""
+    selected = only or tuple(CHECKS)
+    findings: list[Finding] = []
+    for name in selected:
+        findings.extend(CHECKS[name](root))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="the checkout under test (default: the one containing this script)",
+    )
+    parser.add_argument(
+        "--only",
+        action="append",
+        choices=sorted(CHECKS),
+        default=[],
+        help="run only the named check group (repeatable)",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    findings = verify(root, tuple(args.only))
+    if not findings:
+        print(f"env-identity OK: {root} is the checkout this environment runs.")
+        return 0
+
+    print(
+        f"env-identity FAILED for {root}\n"
+        f"The environment does not run the checkout you are measuring. "
+        f"Findings below are distinct — read each one's referent:\n",
+        file=sys.stderr,
+    )
+    for finding in findings:
+        print(finding.render(), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,20 @@ Record mode is also activated automatically when a fixture file is missing
 
 Environment identity
 --------------------
-``pytest_sessionstart`` refuses to start a session whose venv is missing a
-console script this checkout declares, and ``out_of_process_reyn`` is the
-fixture a test requests when it spawns something that imports ``reyn``. Both
-delegate to ``scripts/verify_env_identity.py`` — see #3024 and that module's
-docstring for why "the environment runs the tree I am measuring" is not
-something a test may assume.
+Two fixtures a test requests to declare what it depends on, both delegating to
+``scripts/verify_env_identity.py``:
+
+``out_of_process_reyn``
+    Requested when the test spawns something that imports ``reyn``. Yields the
+    src root to pin as ``PYTHONPATH``, so the spawn reads the checkout under
+    test rather than whichever one the venv resolves.
+``reyn_console_scripts``
+    Requested when the test runs a ``[project.scripts]`` console script by name.
+    Skips (or, under CI, fails) when this venv predates a declared script.
+
+Neither is autouse: a test that does not spawn declares nothing and pays
+nothing. See #3024 and that module's docstring for why "the environment runs
+the tree I am measuring" is not something a test may assume.
 """
 from __future__ import annotations
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,19 @@ Environment variables
 
 Record mode is also activated automatically when a fixture file is missing
 (first-run bootstrap).
+
+Environment identity
+--------------------
+``pytest_sessionstart`` refuses to start a session whose venv is missing a
+console script this checkout declares, and ``out_of_process_reyn`` is the
+fixture a test requests when it spawns something that imports ``reyn``. Both
+delegate to ``scripts/verify_env_identity.py`` — see #3024 and that module's
+docstring for why "the environment runs the tree I am measuring" is not
+something a test may assume.
 """
 from __future__ import annotations
 
+import importlib.util
 import os
 import sys
 from pathlib import Path
@@ -64,6 +74,105 @@ if _REPO_ROOT not in sys.path:
 # tests) force a fresh re-import of ``reyn.interfaces.web.server`` per test —
 # it does not rely on, or get affected by, this session-wide default.
 os.environ.setdefault("REYN_WEB_ENABLE_SURFACES", "a2a,mcp")
+
+# ── Environment identity (#3024) ───────────────────────────────────────────────
+#
+# Loaded by path, not imported as a package: `scripts/` is not importable, and
+# the checker is deliberately stdlib-only and reyn-free (it cannot ask `reyn`
+# where `reyn` is — that is the question).
+
+
+def _load_env_identity():
+    path = Path(_REPO_ROOT) / "scripts" / "verify_env_identity.py"
+    spec = importlib.util.spec_from_file_location("_reyn_env_identity", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Registered before exec: `@dataclass` resolves its own module through
+    # `sys.modules[cls.__module__]` while the class body executes.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ENV_IDENTITY = _load_env_identity()
+
+
+@pytest.fixture(scope="session")
+def reyn_console_scripts() -> None:
+    """Declare that this test runs a `[project.scripts]` console script by name.
+
+    A `[project.scripts]` entry is a declaration; the console script is a file `pip`
+    writes into a venv. A venv installed before the entry existed has never heard of
+    it, and the resulting failure names neither the venv nor the absence — it
+    surfaces as ``execvp() failed``, or, through a stdio client, as
+    ``McpError: Connection closed``. Both read as a broken feature. #3024: that
+    misread reached a co-vet verdict twice in one day, once as "a pre-existing flake
+    on origin/main" for a venv that was simply missing the script.
+
+    Unlike tree divergence — which a test dissolves itself by pinning
+    ``out_of_process_reyn`` — an absent console script cannot be fixed from inside
+    the suite: installing it belongs to whoever provisions the venv. So the
+    unreachability here is genuine, and the honest response is to skip **naming the
+    absent subject**, rather than to run and report a deterministic RED as evidence
+    about the feature.
+
+    Under CI it **fails** instead. A skip is only honest while the property is
+    witnessed somewhere, and CI — which installs this checkout — is that somewhere.
+    A CI venv missing a script this checkout declares is a defect in CI's setup, and
+    silently skipping there would make the whole mechanism dormant.
+    """
+    findings = _ENV_IDENTITY.verify(Path(_REPO_ROOT), only=("console-scripts",))
+    if not findings:
+        return
+    rendered = "\n".join(f.render() for f in findings)
+    message = (
+        f"this venv does not carry every console script {_REPO_ROOT} declares, so "
+        f"running one would measure the venv's staleness, not the feature.\n{rendered}"
+    )
+    if os.environ.get("CI"):
+        pytest.fail(f"env-identity (CI installs this checkout — its venv must be complete): {message}")
+    pytest.skip(f"env-identity: {message}")
+
+
+@pytest.fixture(scope="session")
+def out_of_process_reyn() -> str:
+    """Declare that this test spawns something importing ``reyn``; yield the src root to pin.
+
+    In-process, a test always reads the checkout it was started from —
+    ``[tool.pytest.ini_options] pythonpath`` puts ``<rootdir>/src`` on `sys.path`.
+    A subprocess gets no such favour: it re-resolves `reyn` from the venv, and in a
+    git worktree (which has no venv of its own) that answer is whatever checkout
+    the ambient venv's editable ``.pth`` points at. The two halves then disagree
+    silently, and the spawning half is the one that is wrong.
+
+    Pin the returned path as ``PYTHONPATH`` in the spawn's environment. Note that
+    an MCP stdio server needs it threaded through the server's *configured* env:
+    the SDK passes a six-key whitelist that drops ``PYTHONPATH``, so inheriting is
+    not enough (``tests/test_fp0063_p3_rag_pipelines.py`` does this).
+
+    Requesting the fixture is what makes the dependency a declaration rather than a
+    thing each author rediscovers — the pin exists by hand in several files today,
+    each added after the same lesson was learned again.
+
+    The root is derived from the **in-process** ``reyn``, not from the rootdir, so
+    the check below is the invariant itself rather than a proxy for it: *the reyn a
+    spawn reads is the reyn this test imports*. That can be false exactly where it
+    matters (a worktree, where the two halves diverge) and it is asserted there —
+    a check that can only run where its property is trivially true is not a witness.
+    """
+    import reyn
+
+    root = Path(reyn.__file__).resolve().parents[2]
+    findings = _ENV_IDENTITY.verify(root, only=("pinned-tree",))
+    if findings:
+        rendered = "\n".join(f.render() for f in findings)
+        pytest.fail(
+            f"env-identity: a subprocess pinned to this checkout does not read the same "
+            f"reyn this test imported ({reyn.__file__}), so the two halves of this test "
+            f"would measure different checkouts.\n{rendered}"
+        )
+    return str(root / "src")
+
 
 # ── Secret store isolation ─────────────────────────────────────────────────────
 

--- a/tests/test_3009_mcp_tool_call_write_denial_hint.py
+++ b/tests/test_3009_mcp_tool_call_write_denial_hint.py
@@ -180,7 +180,9 @@ def _enforcing_backend_or_skip():
 
 
 @pytest.mark.parametrize("precreate_target_dir", [False, True], ids=["dir-absent", "dir-exists"])
-def test_a_denied_tool_write_tells_the_operator_the_knob(precreate_target_dir, monkeypatch):
+def test_a_denied_tool_write_tells_the_operator_the_knob(
+    precreate_target_dir, monkeypatch, reyn_console_scripts, out_of_process_reyn
+):
     """Tier 2c: a real server denied a real write names the sandbox and the knob.
 
     The whole chain, real throughout — real sandbox backend, real spawned MCP
@@ -202,10 +204,11 @@ def test_a_denied_tool_write_tells_the_operator_the_knob(precreate_target_dir, m
     # The mcp SDK hands the child an allowlisted env subset that drops
     # PYTHONPATH, so an editable/src-layout checkout must pass it explicitly or
     # the SERVER silently runs a different tree than the one under test.
-    src_root = str(Path(__file__).resolve().parents[1] / "src")
+    # `out_of_process_reyn` derives and verifies that pin; `reyn_console_scripts`
+    # states that this test runs `reyn-rag-vector-store` by name (#3024).
     client = MCPClient(
         {"type": "stdio", "command": "reyn-rag-vector-store",
-         "env": {"PATH": os.environ.get("PATH", ""), "PYTHONPATH": src_root}},
+         "env": {"PATH": os.environ.get("PATH", ""), "PYTHONPATH": out_of_process_reyn}},
         server_name="reyn_vector_store",
     )
 

--- a/tests/test_3024_env_identity.py
+++ b/tests/test_3024_env_identity.py
@@ -1,0 +1,142 @@
+"""Tier 1: scripts/verify_env_identity.py console-script staleness contract.
+
+Pins the invariant #3024 ratified: a `[project.scripts]` entry is a declaration,
+and a venv installed before that declaration does not carry the script — so the
+checker must report the *absence*, naming the venv as stale, rather than let the
+absence surface as ``execvp() failed`` / ``McpError: Connection closed`` and read
+as a broken feature. That misread reached a co-vet verdict twice in one day.
+
+``check_console_scripts`` reads a real pyproject.toml and a real bin directory —
+no network, no venv construction — so this is a Tier 1 contract test against
+known on-disk inputs. The fixtures are real files in ``tmp_path``, not mocks: the
+check's whole subject is what is *actually on disk*, so faking the filesystem
+would remove the only thing under test.
+
+Public surface only: each case calls the module's registered check and asserts on
+the returned ``Finding`` objects' public fields (``check`` / ``detail``).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "verify_env_identity.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_env_identity_under_test", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _checkout(tmp_path: Path, scripts: dict[str, str]) -> Path:
+    """A real checkout whose pyproject declares ``scripts``."""
+    root = tmp_path / "checkout"
+    (root / "src" / "reyn").mkdir(parents=True)
+    (root / "src" / "reyn" / "__init__.py").write_text("")
+    declared = "\n".join(f'{name} = "{target}"' for name, target in scripts.items())
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "reyn"\n\n[project.scripts]\n{declared}\n'
+    )
+    return root
+
+
+def _venv_bin(tmp_path: Path, present: list[str]) -> Path:
+    """A real bin directory carrying ``present``, each stamped like `pip` stamps.
+
+    The shebang names this bin's own interpreter — `pip` stamps the absolute path of
+    the interpreter it installed into, and the checker compares against it.
+    """
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    interpreter = bin_dir / "python"
+    interpreter.write_text("")
+    for name in present:
+        script = bin_dir / name
+        script.write_text(f"#!{interpreter}\nprint('{name}')\n")
+        script.chmod(0o755)
+    return bin_dir
+
+
+def test_a_declared_script_absent_from_the_venv_is_reported_as_venv_staleness(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a declared-but-absent console script is named, and named as stale.
+
+    FALSIFY: without this check the same environment reports healthy — the absence
+    only surfaces later, when something runs the script and dies with a message
+    that mentions neither the script's absence nor the venv.
+    """
+    module = _load()
+    root = _checkout(tmp_path, {"reyn": "reyn._cli:main", "reyn-rag-vector-store": "reyn.v:main"})
+    bin_dir = _venv_bin(tmp_path, present=["reyn"])  # installed before the second entry
+    monkeypatch.setattr(module.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(module.shutil, "which", lambda name: str(bin_dir / name))
+
+    findings = module.check_console_scripts(root)
+
+    assert [f.check for f in findings] == ["console-scripts/present"]
+    detail = findings[0].detail
+    assert "reyn-rag-vector-store" in detail
+    # The three things the #3023 post-mortem found collapsed into one word must
+    # each be separable from this finding: which subject, that it is the venv that
+    # is stale, and that this is neither breakage nor a flake.
+    assert "pyproject.toml:" in detail
+    assert "stale" in detail
+    assert "NOT evidence" in detail and "NOT a flake" in detail
+
+
+def test_a_venv_carrying_every_declared_script_is_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: the check stays silent when the venv matches the declaration."""
+    module = _load()
+    root = _checkout(tmp_path, {"reyn": "reyn._cli:main", "reyn-rag-vector-store": "reyn.v:main"})
+    bin_dir = _venv_bin(tmp_path, present=["reyn", "reyn-rag-vector-store"])
+    monkeypatch.setattr(module.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(module.shutil, "which", lambda name: str(bin_dir / name))
+
+    assert module.check_console_scripts(root) == []
+
+
+def test_a_console_script_shadowed_on_path_names_the_foreign_copy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 1: a spawn-by-name runs PATH's copy, so a foreign copy is reported.
+
+    FALSIFY: comparing only against the venv's own bin/ would call this clean while
+    every spawn of `reyn` executes another environment's script.
+    """
+    module = _load()
+    root = _checkout(tmp_path, {"reyn": "reyn._cli:main"})
+    bin_dir = _venv_bin(tmp_path, present=["reyn"])
+    foreign = _venv_bin(tmp_path / "other", present=["reyn"])
+    monkeypatch.setattr(module.sys, "executable", str(bin_dir / "python"))
+    monkeypatch.setattr(module.shutil, "which", lambda name: str(foreign / name))
+
+    findings = module.check_console_scripts(root)
+
+    assert [f.check for f in findings] == ["console-scripts/present"]
+    assert str(foreign) in findings[0].detail
+
+
+def test_every_registered_check_is_reachable_through_verify(tmp_path: Path) -> None:
+    """Tier 1: `verify` derives its work from CHECKS, so a registered check runs.
+
+    The enumeration is the contract: a check that is registered but never dispatched
+    would be a gate that cannot fire, which is the failure mode this module exists
+    to prevent.
+    """
+    module = _load()
+    root = _checkout(tmp_path, {"reyn": "reyn._cli:main"})
+
+    for name in module.CHECKS:
+        # Each selector must dispatch and return findings (possibly none) rather
+        # than silently doing nothing.
+        assert isinstance(module.verify(root, only=(name,)), list)

--- a/tests/test_litellm_lazy_load.py
+++ b/tests/test_litellm_lazy_load.py
@@ -22,11 +22,11 @@ import sys
 import textwrap
 from pathlib import Path
 
-SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 
-
-def _run(script: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:
-    env = {**os.environ, "PYTHONPATH": str(SRC_DIR)}
+def _run(
+    src_root: str, script: str, extra_env: dict | None = None
+) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": src_root}
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
@@ -38,7 +38,7 @@ def _run(script: str, extra_env: dict | None = None) -> subprocess.CompletedProc
     )
 
 
-def test_setup_interactive_logging_does_not_import_litellm(tmp_path) -> None:
+def test_setup_interactive_logging_does_not_import_litellm(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: `_setup_interactive_logging` — the chat startup-path call — leaves
     litellm out of `sys.modules`.
 
@@ -54,12 +54,12 @@ def test_setup_interactive_logging_does_not_import_litellm(tmp_path) -> None:
         assert "litellm" not in sys.modules, "litellm was imported on the startup path"
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_chat_startup_path_clean_of_litellm_at_input_box_point(tmp_path) -> None:
+def test_chat_startup_path_clean_of_litellm_at_input_box_point(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: the full chat.py startup-path import (module import + the
     startup-logging call, i.e. everything that runs before `run_repl`/the
     input box) never touches litellm.
@@ -81,12 +81,12 @@ def test_chat_startup_path_clean_of_litellm_at_input_box_point(tmp_path) -> None
         )
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_ensure_litellm_ready_imports_litellm_and_is_idempotent(tmp_path) -> None:
+def test_ensure_litellm_ready_imports_litellm_and_is_idempotent(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: `ensure_litellm_ready` (the first-real-use chokepoint) imports
     litellm exactly once, is safe to call repeatedly, and sets
     `suppress_debug_info`.
@@ -102,7 +102,7 @@ def test_ensure_litellm_ready_imports_litellm_and_is_idempotent(tmp_path) -> Non
         assert litellm.suppress_debug_info is True
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
@@ -192,7 +192,7 @@ def test_first_use_routes_litellm_logger_to_file_not_console(tmp_path) -> None:
         litellm_bootstrap._litellm_ready = saved_ready
 
 
-def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path) -> None:
+def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: litellm's cost-map-fetch-failure warning, emitted synchronously
     *during* ``import litellm`` (not a runtime call reyn controls, so exercised
     via a real subprocess), lands in reyn.log and NOT on stderr — now via the
@@ -218,7 +218,7 @@ def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path) -> None:
         assert "litellm" not in __import__("sys").modules
         ensure_litellm_ready()  # first real litellm use -> import happens here
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     log_file = project_root / ".reyn" / "logs" / "reyn.log"
     log_text = log_file.read_text()
@@ -226,7 +226,7 @@ def test_first_use_routes_litellm_import_time_warning_to_file(tmp_path) -> None:
     assert "Failed to fetch remote model cost map" not in result.stderr
 
 
-def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path) -> None:
+def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path, out_of_process_reyn) -> None:
     """Tier 2: chokepoint-completeness — when a NON-recorded_acompletion litellm
     call site is the FIRST to import litellm, the import-time cost-map-fetch
     warning still lands in reyn.log, NOT stderr.
@@ -262,7 +262,7 @@ def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path) -> No
         estimate_tokens("some text to size", "gpt-3.5-turbo")
         assert "litellm" in sys.modules, "sibling call did not import litellm"
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     log_file = project_root / ".reyn" / "logs" / "reyn.log"
     log_text = log_file.read_text()
@@ -270,7 +270,7 @@ def test_sibling_first_import_routes_import_time_warning_to_file(tmp_path) -> No
     assert "Failed to fetch remote model cost map" not in result.stderr
 
 
-def test_measured_startup_latency_delta_from_deferring_litellm() -> None:
+def test_measured_startup_latency_delta_from_deferring_litellm(out_of_process_reyn) -> None:
     """Tier 2: measures the actual latency delta the perf fix targets — the
     startup-path work (importing `reyn.interfaces.cli.commands.chat` +
     calling `_setup_interactive_logging`) is fast, while a bare
@@ -295,8 +295,8 @@ def test_measured_startup_latency_delta_from_deferring_litellm() -> None:
         import litellm
         print(time.perf_counter() - t)
         """
-    startup_result = _run(startup_script)
-    litellm_result = _run(litellm_script)
+    startup_result = _run(out_of_process_reyn, startup_script)
+    litellm_result = _run(out_of_process_reyn, litellm_script)
     assert startup_result.returncode == 0, startup_result.stderr
     assert litellm_result.returncode == 0, litellm_result.stderr
 


### PR DESCRIPTION
**[per-PR-coder]** — **Closes #3024.**

**The invariant this lands:** *"`pyproject.toml` declares an entry point" does not mean "the venv has that console script", and "`import reyn` worked" does not mean "it was **this** checkout".* **And when the environment is wrong, the failure wears the mask of a broken feature** — `execvp() failed`, `McpError: Connection closed` — **it never says "the binary is absent" or "that was another tree".**

## What the primary data said (and where it corrected the issue)

**Measured in an agent worktree, at the correct rootdir:**

```
IN-PROCESS  reyn: <worktree>/src/reyn/__init__.py      ← pytest's pythonpath = ["src"]
SUBPROCESS  reyn: <main checkout>/src/reyn/__init__.py ← the venv's editable .pth
```

**#3024 framed the root as "worktree venvs go stale". Measurement says something else: the worktrees have no venv at all — 0 of 136.** They inherit the main checkout's `.venv`, whose `_editable_impl_reyn.pth` points at **the main checkout** — *someone else's working tree, on some other branch, with uncommitted edits*. So in a worktree, **in-process and out-of-process `reyn` are two different trees permanently, by construction — not by staleness.** Both halves are green while disagreeing.

**This PR therefore does not implement direction (c)** (entry-point ↔ venv `bin/` reconciliation), which catches only root 1. It closes roots 1–3 on two axes with two different remedies.

## Two axes, two remedies, one gate that spans neither

| | Fixable from a test? | ∴ shape |
|---|---|---|
| **Tree divergence** | **Yes** — `PYTHONPATH` wins over an editable `.pth` (measured) | **Dissolve it.** `out_of_process_reyn` pins; the test runs and measures the right tree. |
| **Console script absent** | **No** — installing it belongs to whoever provisions the venv | **Legible skip**, naming the absent subject. **CI fails instead.** |

### `out_of_process_reyn` — the seam (dissolves the defect, does not detect it)

A test declares that it spawns something importing `reyn`, and receives the src root to pin. **The root is derived from the in-process `reyn`, not the rootdir**, so the assert is the invariant itself — *a spawn reads the reyn this test imported* — and **can be false exactly in a worktree, where it is asserted.** A check that only runs where its property is trivially true is not a witness.

**This pattern already existed, hand-applied, one author at a time** — specimens of *"a note is not a gate"*, each added after its author independently rediscovered the same lesson:

- `test_fp0063_p3_rag_pipelines.py:124` — *"the MCP SDK otherwise passes a 6-key whitelist that excludes PYTHONPATH"*, docstring recording the incident: *"another worktree's copy, so its new fields were 'missing' and every ingest assertion failed for a reason that had nothing to do with the diff"*
- `web/test_openui_shell.py:322`, `web/test_smoke.py:73` — a constant literally named `_WORKTREE_SRC`
- `test_landlock_exec_shim_1344e.py:133` — *"env-dependent path lesson"*

Migrating these is **#3032**, not this PR. Two are migrated here as live consumers.

### `reyn_console_scripts` — genuine unreachability, so: skip, but legibly

**CI fails rather than skips.** A skip is honest only while the property is witnessed somewhere; CI installs this checkout, so a CI venv missing a declared script is a defect in CI's setup — silently skipping there would make the whole mechanism dormant.

### `scripts/verify_env_identity.py` — the standalone diagnosis

**Both verdict-polluting incidents happened *outside* pytest** (manual e2e, co-vet). This is that layer's entry point, and the harness's, for deciding whether a worktree needs its own venv. **It never imports `reyn`** — reyn's own resolution is the subject under test, so an importer would assert with the mechanism whose trustworthiness is in question. It **measures by spawning** rather than re-implementing `.pth`/`sys.path` resolution.

## Witness — measured, not asserted green

**1. A real stale venv, built by installing (not simulated by deleting).** Installed editable from a pre-#2955 `pyproject.toml`; `pip` wrote `reyn` and `reyn-rag-chunker` and **not** `reyn-rag-vector-store` — wt23's state, reproduced. Then the checkout advanced (the entry returns) while the venv stayed put:

```
[console-scripts/present]
  console script `reyn-rag-vector-store` is declared at pyproject.toml:185 but is ABSENT from …/stalevenv/bin.
  This venv is stale — it predates the declaration.
  It is NOT evidence that `reyn-rag-vector-store` is broken, and NOT a flake: running it fails
  deterministically, as `execvp() failed` or `McpError: Connection closed`.
```

**The gate separates the three things the #3023 post-mortem found collapsed into one word** (flake / main-red / venv-console-script-absent). What a human sees without it: `env: reyn-rag-vector-store: No such file or directory`.

**2. Strip-falsify.** Same stale venv, console-scripts check removed → **`env-identity OK`, exit 0.** The RED is caused by the check, not by ambient noise.

**3. The fix, measured in the worktree** (`out_of_process_reyn`): `subprocess reyn` → `<worktree>/src/reyn/__init__.py`, identical to in-process. Unpinned, the same worktree read the main checkout.

**4. Both arms of the skip, under the real condition** (a checkout declaring a script the venv predates — reproduced in `pyproject.toml`, restored byte-identical): worktree → **legible SKIP**; `CI=1` → **FAIL**.

**5. The tests are armed.** Stripping the absence branch → RED; restored → green.

## On the population — a number I retract

An earlier census of mine — *"40 files spawn `sys.executable`, 7 pin PYTHONPATH, ∴ 33 measure the wrong tree"* — **is wrong, and #3032 records it as not-to-be-reused.** **Spawning ≠ the spawn target importing `reyn`.** `test_mcp_client.py`, which I had named as a prime instance, spawns `_support/mcp_fastmcp_echo_server.py` and `mcp_paginated_tools_server.py` — **`grep -c 'import reyn|from reyn'` on both = 0**, pure FastMCP test doubles, unaffected. **Directly inspected: ~6. Remaining ~27 unexamined.** This PR claims no number; #3032 inventories them.

## Scope note: the remedy that is a new way to break things

**The remedy for a stale venv is never `pip install -e .` from a worktree.** That repoints the shared venv's editable `.pth` at that worktree, and every other consumer silently starts reading it — **that is incident #4 in #3024, exactly.** The finding text says so at the point of failure, not in a doc.

## Test plan

- [x] `ruff check src tests scripts` — clean
- [x] `python scripts/test_tier_audit.py --strict` (4 changed test files) — errors: 0
- [x] `python scripts/verify_module_docstrings.py scripts/verify_env_identity.py` — clean
- [x] `python -m pytest -q -n auto --timeout=120 -rs` — **8793 passed, 24 skipped**; skip count **unchanged** from the pre-change baseline (8789 + 4 new tests), i.e. **no env-identity skip crept in** — verified from the `-rs` list, not from the pass count
- [x] Manual: real stale venv built by `pip install -e` from a pre-#2955 pyproject → `console-scripts/present` RED naming the subject
- [x] Manual: strip-falsify → same venv reports `env-identity OK`, exit 0
- [x] Manual: `out_of_process_reyn` → subprocess reads this worktree (was: main checkout)
- [x] Manual: `pinned-tree` arm-witness → RED when the pin does not deliver
- [x] Manual: `reyn_console_scripts` → legible SKIP in worktree, FAIL under `CI=1`
- [x] Manual: `pyproject.toml` restored byte-identical after the witness (`git diff` = 0 lines)

## A note on this PR's own trustworthiness

**I fell into this issue while implementing it.** My first measurement ran a probe file from the scratchpad, so pytest's rootdir was not this worktree and `pythonpath = ["src"]` never applied — **the in-process half was reading the main checkout, and I nearly recorded it as "the worktree's src".** It only came apart when I moved the probe into the worktree's own `tests/`. **Tonight the same fourth face caught the coder, the architect, and the lead-coder — each while implementing, adjudicating, or directing the fix for it.**

Related: #3032 (test-correctness migration), #3006 / #3008 / #3010 / #3016 / #3019 / #3023 (incidents), #2955 P2 (the entry point that started root 1).
