### PR TITLE
fix(test): wait for the chain watchdog to fire, not for 0.2s to elapse (#2339's surviving sibling)

### DIFF
--- a/tests/test_session_invariants.py
+++ b/tests/test_session_invariants.py
@@ -394,8 +394,14 @@ async def test_chain_timeout_fires_upstream_error_and_emits_event(tmp_path, monk
         "chain_id": "chain-timeout-001",
     })
 
-    # Wait long enough for the timeout to fire.
-    await asyncio.sleep(0.2)
+    # Wait for the watchdog to ACTUALLY fire, not for a fixed span to elapse.
+    # `upstream_received` is the fire's observable effect and it happens-after the
+    # WAL append: `ChainManager.fire_timeout` awaits `record_chain_timeout_fired`
+    # before returning the chain the upstream response is built from — so the
+    # `flush()` below drains an append that is already queued.
+    assert await wait_until(lambda: bool(upstream_received)), (
+        "chain timeout never fired within the bounded wait"
+    )
 
     # WAL must contain chain_register → chain_timeout_fired.
     await session._journal.flush()  # #2259 PR-2b: drain async WAL writes


### PR DESCRIPTION
**[per-PR-coder]** — **The surviving sibling of #2339's fix class. #2339 fixed the site and closed; the class kept one instance, and it just turned #3033 red.**

## What happened

CI on #3033 (Python 3.12; 3.11 passed):

```
tests/test_session_invariants.py:408
AssertionError: chain_timeout_fired missing: ['chain_register']
```

**#2339 diagnosed this exact class, verbatim:**

> *`test_postprocessor_mid_run_chain_timeout_fires` uses a **magic-sleep-vs-timer race**: `await asyncio.sleep(0.15)` waits for a `chain_seconds=0.05` watchdog to fire (0.05 + 0.1 margin). **On a loaded CI, the watchdog timer can fire LATE**, so at the assert the chain isn't force-resolved yet → fail; **`chain_timeout_fired` is never appended**, so the later WAL read finds nothing.*

**#2339 fixed `test_skill_postprocessor_chain.py` and closed. This site kept the idiom** — a `0.05` watchdog awaited by `asyncio.sleep(0.2)`. The deterministic replacement it prescribed, `wait_until`, already exists in `tests/_async_wait.py` and was already imported by this file.

## The fix

`upstream_received` is the predicate, not the WAL contents, because it **happens-after** the append: `ChainManager.fire_timeout` awaits `record_chain_timeout_fired` *before* returning the chain the upstream response is built from, so the existing `flush()` drains an append that is already queued. Choosing the WAL as the predicate would have moved the race rather than closed it.

**The wait is tightened; every assert is unchanged.** `wait_until` returns False on timeout, so the assert still pins the real condition.

## Falsify — deterministic, both arms

**Reproducing under load failed**: 6 attempts under 8-way CPU starvation, 0/6. That is a null measurement, not an exoneration — so I used **#2339's own alternative, "force a late timer"**, which is deterministic:

| arm | condition | result |
|---|---|---|
| **A** | fix present, watchdog forced to 0.5s (later than the old 0.2s sleep) | **PASS** |
| **B** | **same** late timer, magic sleep restored | **FAIL — `chain_timeout_fired missing: ['chain_register']`** |
| — | restored (fix, 0.05s) | PASS, **12/12 consecutive green** |

**Arm B reproduces the CI red's exact message on demand.** That is what makes this a diagnosis rather than "it passed on re-run".

## Scope: I swept the class, not the constant

My first enumeration was `grep 'chain_seconds=0.05'` → 1 hit. **That counts a constant, not the class** — a site sleeping 0.5s for a 0.3s watchdog is the same bug and that grep misses it.

**Class used instead:** *waiting for a deterministic condition (a timer/watchdog firing) to become true by letting a nondeterministic amount of time pass.*

**Directly inspected: 19 files** carrying fixed sleeps alongside timer/timeout configuration — each read at the test-body level to decide whether the assert after the sleep depends on a timer having fired. **Result: 1 in class** (this one). The other 18 are sleeps inside fake slow coroutines under test, bounded poll loops, filesystem-mtime advancement, and settle-windows asserting an *absence*. **I do not claim the suite is exhaustively swept** — the population is 138 sleep sites, and the deciding property is semantic.

**One borderline recorded, deliberately not changed:** `tests/test_await_quiescent.py:74` sleeps 0.12s past a 0.05s timeout and asserts the watchdog's effect did **not** land. Same idiom, inverse direction: a late timer there makes the test spuriously **pass**, not fail. It cannot produce this failure, and "fix" would mean changing what it pins — out of scope for a deflake.

## The gate question, measured — and the answer is no

The obvious follow-on is a lint so the idiom cannot regrow. **I prototyped it and measured it against the 19-file labeled set.**

Rule: a bare `await asyncio.sleep(<literal>)` inside a `test_*` function, not in a loop, in a function that also configures a timeout-ish constant, with an assert after it.

**It flags 19 sites. Every flagged site in the labeled files is a false positive** (settle-windows, fake slow collaborators, mtime, poll loops) — **precision 0/12 on the labeled portion**.

**The deciding property is semantic** ("does this assert depend on a timer having fired?"), which is exactly why classifying 19 files required reading their bodies. A syntactic gate cannot separate the class, and a gate that cries wolf 12 times to catch 0 teaches the bypass — the same argument that kept a session-wide gate out of #3033. This repo already holds that line explicitly: `scripts/verify_module_docstrings.py` is "deliberately narrow to keep **zero false positives**... The trade-off is accepted false negatives... those stay covered by review."

**So: N fixed, and the gate measured as not worth it.** The one shape that separated the class perfectly in my probes was the *intent comment* (`# Wait long enough for the timeout to fire.` — 1 hit, 0 false positives), and a gate on comments is evaded by rewording. Recorded here rather than shipped.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_session_invariants.py` — errors: 0
- [x] `python -m pytest -q -n auto --timeout=120` — 8793 passed, 24 skipped
- [x] Falsify arm A/B (force a late timer) — pre-fix RED with the exact CI message, post-fix GREEN
- [x] 12/12 consecutive green on the target test
- [x] Assert surface unchanged (diff shows only the wait replaced)

#2339 stays closed; this records that it fixed a site and left the class with one sibling.
