### PR TITLE
fix(security): gate + audit + recovery-record mcp__install_local's recovery-core config write

### DIFF
--- a/src/reyn/tools/mcp_verbs.py
+++ b/src/reyn/tools/mcp_verbs.py
@@ -384,11 +384,51 @@ async def _handle_mcp_install_local(
         project_root = Path(workspace.root)
     config_path = _scope_to_path("local", project_root)
 
-    decl = PermissionDecl()
-    decl.file_write = [{"path": ".reyn/config/mcp.yaml"}]
-    resolver = getattr(rs, "permission_resolver", None) if rs is not None else None
+    # The OpContext is built HERE — before the gate — because the gate needs the
+    # operator's real PermissionDecl + the intervention bus off it. It used to be
+    # constructed further down (for the hot-reload probe only), which is why the
+    # gate below had nothing real to gate WITH.
+    _op_ctx = (
+        rs.op_context_factory()
+        if rs is not None and getattr(rs, "op_context_factory", None) is not None
+        else None
+    )
+
+    # ``.reyn/config/`` is a RECOVERY-CORE write-gate prefix (#2248 PR-C):
+    # deliberately carved OUT of the broad ``.reyn/`` default write zone, so a
+    # write here must be explicitly declared + gated, never silently allowed.
+    # This verb writes ``.reyn/config/mcp.yaml`` directly (bypassing the
+    # mcp_install op), so it must carry that gate itself.
+    #
+    # Three things were wrong and are fixed together, because fixing any one
+    # alone either leaves the hole open or breaks the verb:
+    #
+    # 1. The resolver was read as ``getattr(rs, "permission_resolver", None)`` —
+    #    a field ``RouterCallerState`` has NEVER declared. ``getattr``'s default
+    #    swallowed the miss, so the gate never fired in ANY context. The resolver
+    #    lives on the ToolContext (populated at all three production sites in
+    #    router_loop.py), so that is where it is read from now.
+    # 2. ``decl`` was a bare ``PermissionDecl()`` synthesized here. Gating against
+    #    a decl this function invented is self-granting: it must be the operator's
+    #    real declaration, which is what the OpContext carries.
+    # 3. No ``bus`` was passed, so an ungranted write would hard-deny
+    #    non-interactively — reviving (1)+(2) alone would make every install fail.
+    #    Threading the bus is what turns this into the operator DECISION the
+    #    inert-ship design (#2932 / proposal 0063 R3) intends: in chat the
+    #    operator is prompted; non-interactive callers (bus=None) still deny.
+    resolver = ctx.permission_resolver
     if resolver is not None:
-        await resolver.require_file_write(decl, str(config_path), "mcp__install_local")
+        decl = getattr(_op_ctx, "permission_decl", None)
+        if decl is None:
+            decl = PermissionDecl()
+            decl.file_write = [{"path": ".reyn/config/mcp.yaml"}]
+        await resolver.require_file_write(
+            decl,
+            str(config_path),
+            "mcp__install_local",
+            sandbox_policy=getattr(_op_ctx, "sandbox_policy", None),
+            bus=getattr(_op_ctx, "intervention_bus", None),
+        )
 
     entry: dict[str, Any] = {
         "type": "stdio",
@@ -411,15 +451,11 @@ async def _handle_mcp_install_local(
     # overwrite or no per-session reloader keeps the existing deferred behavior. The
     # per-session reloader (ctx.hot_reloader, #2761 PR-2) is reached via the router's
     # op-context factory (the single tool→op ctx source); absent (test / CLI) → deferred.
+    # ``_op_ctx`` is built once, above the permission gate (which needs it too).
     from reyn.core.cancellable import Cancelled
     from reyn.core.op_runtime.mcp_install import probe_mcp_server
     from reyn.runtime.hot_reload import dispatch_install_reload, is_pure_addition
 
-    _op_ctx = (
-        rs.op_context_factory()
-        if rs is not None and getattr(rs, "op_context_factory", None) is not None
-        else None
-    )
     _reloader = getattr(_op_ctx, "hot_reloader", None) if _op_ctx is not None else None
     _is_addition = is_pure_addition(name, servers)
     if _is_addition and _reloader is not None:
@@ -467,9 +503,41 @@ async def _handle_mcp_install_local(
     servers[name] = entry
     _write_yaml_config(config_path, data)
 
+    # #2259 PR-1: record the FULL post-state as a truncation-surviving config
+    # generation — the same call the mcp_install op makes after its own write.
+    # Without it this verb's server was SILENTLY ERASED by config reconstruction:
+    # ``_reconcile_config_as_of_cut`` restores every generation-tracked registry
+    # from its LATEST generation, and once ANY generation exists for
+    # ``config/mcp.yaml`` (i.e. after any op-path install), a rewind / crash
+    # recovery rewrote the file from that generation — dropping every server this
+    # verb had added, because it recorded none. ``.reyn/config/`` is recovery-core
+    # precisely because it is reconstructed; a writer there must contribute its
+    # generation or its writes are recovery-invisible.
+    from reyn.core.events.config_recovery import record_config_generation
+    await record_config_generation(
+        getattr(ctx, "state_log", None), config_path, data,
+    )
+
     await dispatch_install_reload(
         _reloader, source="mcp__install_local", is_addition=_is_addition,
     )
+
+    # P6 audit-event. The op path has always emitted ``mcp_server_installed``;
+    # this verb emitted NOTHING on success, so an LLM-initiated install left no
+    # audit trace at all — the operator could not see that a server had been
+    # added to their config. Same event name so both install paths land in one
+    # auditable stream.
+    if ctx.events is not None:
+        ctx.events.emit(
+            "mcp_server_installed",
+            server_id=name,
+            server_name=name,
+            scope="local",
+            runtime="stdio",
+            env_keys_set=sorted(entry.get("env", {})),
+            installed_path=str(config_path),
+            source="mcp__install_local",
+        )
 
     return {
         "status": "ok",

--- a/tests/test_2761_pr3_mcp_immediate_probe.py
+++ b/tests/test_2761_pr3_mcp_immediate_probe.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -45,6 +46,7 @@ from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
 from reyn.runtime.session import Session
 from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.mcp_verbs import _handle_mcp_install_local
+from reyn.tools.types import RouterCallerState, ToolContext
 
 _PID_SERVER = Path(__file__).parent / "_support" / "mcp_tools_only_pid_server.py"
 _STDIO = {"command": sys.executable, "args": [str(_PID_SERVER)]}
@@ -67,22 +69,33 @@ def _seam_recorder():
     return ran, make
 
 
-class _RS:
-    """Minimal RouterState carrying the op-context factory + resolver the install_local
-    handler reads — wired to REAL objects (a real session factory / a real reloader)."""
+def _RS(factory) -> RouterCallerState:
+    """The REAL RouterCallerState, carrying the op-context factory the handler reads.
 
-    def __init__(self, factory, resolver=None) -> None:
-        self.op_context_factory = factory
-        self.permission_resolver = resolver
+    This used to be a hand-rolled stand-in that also declared a ``permission_resolver``
+    attribute — a field ``RouterCallerState`` has never had. That invented field is what
+    kept the install_local permission gate looking tested while it could never fire in
+    production: the handler read the resolver off the router-state, which only the FAKE
+    supplied. Constructing the real dataclass is what makes this suite able to witness
+    that class of drift at all.
+    """
+    return RouterCallerState(op_context_factory=factory)
 
 
-class _Ctx:
-    """Minimal ToolContext plumbing (mirrors the existing install_local test's _FakeCtx)
-    — router_state + a workspace with a ``root``. All wired to real components."""
+def _Ctx(root: Path, rs: "RouterCallerState | None") -> ToolContext:
+    """The REAL ToolContext (a plain dataclass — a real instance, not a stand-in).
 
-    def __init__(self, root: Path, rs: "_RS | None") -> None:
-        self.router_state = rs
-        self.workspace = type("_W", (), {"root": str(root)})()
+    ``permission_resolver=None`` keeps these probe/reload tests focused on their own
+    invariant: the handler skips the gate without a resolver (the test / CLI contract).
+    The gate itself is covered in test_3037_mcp_install_local_recovery_core_gate.py.
+    """
+    return ToolContext(
+        events=None,
+        permission_resolver=None,
+        workspace=SimpleNamespace(root=str(root)),
+        caller_kind="router",
+        router_state=rs,
+    )
 
 
 def _session(tmp: Path) -> Session:
@@ -94,16 +107,16 @@ def _session(tmp: Path) -> Session:
     )
 
 
-def _session_ctx(session: Session, tmp: Path) -> _Ctx:
+def _session_ctx(session: Session, tmp: Path) -> ToolContext:
     """A ctx whose op-context factory is the session's REAL make_router_op_context (so
     ctx.hot_reloader is the session's per-session reloader). resolver=None → the
     install_local file-write gate is skipped (not under test)."""
-    return _Ctx(tmp, _RS(session._router_host.make_router_op_context, None))
+    return _Ctx(tmp, _RS(session._router_host.make_router_op_context))
 
 
 def _reloader_ctx(
     reloader: HotReloader, tmp: Path, *, cancel_event: "asyncio.Event | None" = None,
-) -> _Ctx:
+) -> ToolContext:
     """A ctx whose factory returns a bare OpContext carrying ``reloader`` — for the
     probe-then-commit tests that only need the immediate path to fire (no full roster).
 
@@ -119,7 +132,7 @@ def _reloader_ctx(
         hot_reloader=reloader,
         cancel_event=cancel_event,
     )
-    return _Ctx(tmp, _RS(lambda: op_ctx, None))
+    return _Ctx(tmp, _RS(lambda: op_ctx))
 
 
 def _servers_on_disk(tmp: Path) -> dict:
@@ -293,7 +306,7 @@ async def test_local_install_no_per_session_reloader_defers_no_probe(
     try:
         result = await _handle_mcp_install_local(
             {"name": "clisrv", "command": "/nonexistent/reyn-xyz", "args": []},
-            _Ctx(tmp_path, _RS(factory=None, resolver=None)),  # no op-context factory
+            _Ctx(tmp_path, _RS(factory=None)),  # no op-context factory
         )
     finally:
         set_active_hot_reloader(None)

--- a/tests/test_3037_mcp_install_local_recovery_core_gate.py
+++ b/tests/test_3037_mcp_install_local_recovery_core_gate.py
@@ -1,0 +1,206 @@
+"""Tier 2: ``mcp__install_local`` must honour the recovery-core write-gate contract.
+
+``.reyn/config/`` is a recovery-core write-gate prefix (``_RECOVERY_CORE_WRITE_PREFIXES``,
+#2248 PR-C): a write there must be explicitly GATED (never silently allowed by the broad
+``.reyn/`` default zone) and must contribute a truncation-surviving config GENERATION,
+because the directory is reconstructed from those generations.
+
+``mcp__install_local`` writes ``.reyn/config/mcp.yaml`` directly — bypassing the mcp_install
+op — and honoured neither half:
+
+* Its permission gate read ``getattr(rs, "permission_resolver", None)`` — a field
+  ``RouterCallerState`` has never declared, so ``getattr``'s default swallowed the miss and
+  the gate never fired in ANY context. An LLM could write the operator's MCP config with no
+  decision anywhere in the chain, which ``reyn pipe run``'s trusted-by-configuration
+  auto-grant (#2932) then turned into a live grant.
+* It recorded no config generation, so ``_reconcile_config_as_of_cut`` — which rewrites every
+  generation-tracked registry from its LATEST generation — silently ERASED its servers on any
+  rewind / crash recovery once a generation existed for ``config/mcp.yaml``.
+* It emitted no P6 audit-event on success, so the install left no trace to inspect.
+
+The three are tested together because they are one contract: gating the write without
+recording its generation would keep the recovery hole; recording without gating would keep
+the escalation.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from reyn.core.events.snapshot_generations import rewind
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.tools.mcp_verbs import MCP_INSTALL_LOCAL
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.user_intervention import InterventionAnswer
+
+
+class _RecordingBus:
+    """Real RequestBus-shaped collaborator (non-mock): records asks, answers a
+    pre-scripted choice. Mirrors the ``_FakeRequestBus`` idiom used across the suite."""
+
+    def __init__(self, answer_choice_id: str) -> None:
+        self._answer = answer_choice_id
+        self.asks: list = []
+
+    async def request(self, iv) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._answer, choice_id=self._answer)
+
+
+class _RecordingEvents:
+    """Real EventLog-shaped collaborator (non-mock): records emitted audit-events."""
+
+    def __init__(self) -> None:
+        self.emitted: list[tuple[str, dict]] = []
+
+    def emit(self, name: str, **payload) -> None:
+        self.emitted.append((name, payload))
+
+
+def _no_factory(_profile):
+    raise AssertionError("session factory must not be called")
+
+
+def _make_ctx(tmp_path, *, bus=None, resolver=None, events=None, state_log=None):
+    """Build a production-shaped router ToolContext.
+
+    The op-context factory mirrors what ``RouterHostAdapter.make_router_op_context``
+    wires (permission_decl / intervention_bus / sandbox_policy), which is where the
+    handler reads the operator's real declaration + bus from.
+    """
+    op_ctx = SimpleNamespace(
+        permission_decl=PermissionDecl(),
+        intervention_bus=bus,
+        sandbox_policy=None,
+        hot_reloader=None,
+        events=events,
+        cancel_event=None,
+        agent_id=None,
+    )
+    return ToolContext(
+        events=events if events is not None else _RecordingEvents(),
+        permission_resolver=resolver,
+        workspace=SimpleNamespace(root=str(tmp_path)),
+        caller_kind="router",
+        router_state=RouterCallerState(op_context_factory=lambda: op_ctx),
+        state_log=state_log,
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_local_asks_the_operator_before_writing_recovery_core_config(tmp_path):
+    """Tier 2: the write to ``.reyn/config/mcp.yaml`` is gated — the operator is ASKED.
+
+    ``.reyn/config/`` is carved out of the default write zone, so this write has no
+    standing grant and must reach the operator. Strip-falsify: point the handler's
+    resolver back at ``router_state`` (a field that does not exist) and the gate goes
+    silent — no ask is recorded and the config is written unasked.
+    """
+    (tmp_path / ".reyn").mkdir()
+    bus = _RecordingBus("yes")
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    ctx = _make_ctx(tmp_path, bus=bus, resolver=resolver)
+
+    result = await MCP_INSTALL_LOCAL.handler(
+        {"name": "planted", "command": "/bin/cat", "args": []}, ctx,
+    )
+
+    assert bus.asks, (
+        "the operator was never asked — the recovery-core write ran unGATED "
+        "(the getattr-on-an-undeclared-field bug)"
+    )
+    assert result["status"] == "ok"
+    assert (tmp_path / ".reyn" / "config" / "mcp.yaml").is_file()
+
+
+@pytest.mark.asyncio
+async def test_install_local_refused_by_operator_writes_nothing(tmp_path):
+    """Tier 2: a refused install must leave the operator's MCP config untouched.
+
+    The gate is only real if its DENY is real: refusing the prompt must raise and write
+    no server, else the ask is decoration.
+    """
+    (tmp_path / ".reyn").mkdir()
+    bus = _RecordingBus("no")
+    resolver = PermissionResolver(config_permissions={}, project_root=tmp_path)
+    ctx = _make_ctx(tmp_path, bus=bus, resolver=resolver)
+
+    with pytest.raises(PermissionError):
+        await MCP_INSTALL_LOCAL.handler(
+            {"name": "planted", "command": "/bin/cat", "args": []}, ctx,
+        )
+
+    assert not (tmp_path / ".reyn" / "config" / "mcp.yaml").exists(), (
+        "a refused install must not write the config"
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_local_emits_the_installed_audit_event(tmp_path):
+    """Tier 2: an install that mutates operator config leaves a P6 audit-event.
+
+    The op path has always emitted ``mcp_server_installed``; this verb emitted nothing on
+    success, so an LLM-initiated install was invisible to the operator.
+    """
+    (tmp_path / ".reyn").mkdir()
+    events = _RecordingEvents()
+    ctx = _make_ctx(tmp_path, events=events)
+
+    await MCP_INSTALL_LOCAL.handler(
+        {"name": "planted", "command": "/bin/cat", "args": []}, ctx,
+    )
+
+    names = [n for n, _ in events.emitted]
+    assert "mcp_server_installed" in names, (
+        f"install emitted no audit-event (saw {names}) — the mutation is unauditable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_local_server_survives_wal_truncation(tmp_path):
+    """Tier 2: a server installed via ``mcp__install_local`` survives WAL truncation.
+
+    Truncate-falsify (the CLAUDE.md recovery-feature gate).
+
+    Set X → truncate past X's events → reconstruct → assert X survives. ``.reyn/config/`` is
+    reconstructed from config GENERATIONS, so a writer that records none is recovery-invisible:
+    once ANY generation exists for ``config/mcp.yaml`` (i.e. after any op-path install), the
+    reconstruct rewrites the file from that generation and drops every server this verb added.
+    """
+    sl = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_no_factory, state_log=sl)
+    mcp_path = tmp_path / ".reyn" / "config" / "mcp.yaml"
+    mcp_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # An op-path install records a generation for config/mcp.yaml — this is what makes the
+    # path generation-tracked, and so what makes a non-recording writer lossy.
+    await reg.record_config_change("config/mcp.yaml", {"mcp": {"servers": {"A": {}}}})
+    mcp_path.write_text(yaml.dump({"mcp": {"servers": {"A": {}}}}), encoding="utf-8")
+
+    # The LLM installs B through the verb under test.
+    ctx = _make_ctx(tmp_path, state_log=sl)
+    await MCP_INSTALL_LOCAL.handler(
+        {"name": "B", "command": "/bin/cat", "args": []}, ctx,
+    )
+    cut = sl.current_seq
+
+    # The WAL advances far past the install, then GC truncates below the floor.
+    for i in range(120):
+        await sl.append("inbox_put", n=i)
+    await sl.truncate_below(100)
+    await sl.flush()
+
+    # Reconstruct: B must still be there.
+    await rewind(reg.state_log, target_n=cut)
+    reg._reconcile_config_as_of_cut(cut)
+
+    restored = yaml.safe_load(mcp_path.read_text(encoding="utf-8"))
+    assert "B" in restored["mcp"]["servers"], (
+        "the mcp__install_local-installed server was ERASED by config reconstruction — it "
+        "recorded no truncation-surviving generation, so the reconstruct rewrote the file "
+        "from the op-path generation that predates it"
+    )

--- a/tests/test_mcp_install_local_hot_reload.py
+++ b/tests/test_mcp_install_local_hot_reload.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Any
+from types import SimpleNamespace
+
+from reyn.tools.types import ToolContext
 
 
 class _FakeReloader:
@@ -29,25 +31,25 @@ class _FakeReloader:
         self.sources.append(source)
 
 
-class _FakePermissionResolver:
-    async def require_file_write(self, decl: Any, path: str, caller: str) -> None:
-        pass
+def _ctx(project_root: Path) -> ToolContext:
+    """The REAL ToolContext (a plain dataclass — a real instance, not a stand-in).
 
-
-class _FakeCtx:
-    router_state = None
-    permission_resolver = _FakePermissionResolver()
-
-    def __init__(self, project_root: Path) -> None:
-        self._root = project_root
-
-    @property
-    def workspace(self) -> Any:
-        class _W:
-            pass
-        w = _W()
-        w.root = str(self._root)
-        return w
+    This used to be a hand-rolled ``_FakeCtx`` carrying a ``_FakePermissionResolver``
+    whose ``require_file_write`` signature was frozen at the call shape of the day. Both
+    are gone: the fake resolver made the permission gate look exercised here while the
+    handler read its resolver off ``router_state`` (a field the real ``RouterCallerState``
+    never declared), so nothing was gated in production. ``permission_resolver=None``
+    keeps these tests on their own invariant — the hot-reload dispatch — and the gate is
+    covered against a REAL ``PermissionResolver`` in
+    test_3037_mcp_install_local_recovery_core_gate.py.
+    """
+    return ToolContext(
+        events=None,
+        permission_resolver=None,
+        workspace=SimpleNamespace(root=str(project_root)),
+        caller_kind="router",
+        router_state=None,
+    )
 
 
 def _run_install(
@@ -67,7 +69,7 @@ def _run_install(
         return asyncio.run(
             _handle_mcp_install_local(
                 {"name": name, "command": command, "args": args or ["/tmp/server.py"]},
-                _FakeCtx(project_root),
+                _ctx(project_root),
             )
         )
     finally:


### PR DESCRIPTION
**[per-PR-coder]** — part of #3036.

**This is not a gate revival — it is a privilege-escalation closure plus a silent data-loss fix.** Severity is for the reader to judge, so here is the primary data first.

## The chain, measured (not inferred)

A temp project whose `reyn.yaml` is `permissions: {}` — the operator has granted nothing:

```
STEP1 install status: ok
STEP1 audit-events emitted on SUCCESS: []
STEP2 load_config() sees servers: ['llm_planted']
STEP2 permissions AFTER auto-grant: {'llm_planted': 'allow'}
```

An LLM calling `mcp__install_local` planted a server into the operator's MCP config, unGATED and unAUDITED, and `reyn pipe run`'s trusted-by-configuration auto-grant (#2932 — it keys purely on the server NAME being present in the merged config) then granted it. **No operator decision anywhere in the chain.** `.reyn/config/mcp.yaml` merges LAST in `config/loader.py:510`, so this is the live path.

## Root cause: `getattr` swallowing a field that does not exist

`mcp_verbs.py:389` read the resolver off the **router-state**:

```python
resolver = getattr(rs, "permission_resolver", None) if rs is not None else None
if resolver is not None:
    await resolver.require_file_write(...)
```

`RouterCallerState` has **never declared** a `permission_resolver` field. Measured:

```
RouterCallerState has 'permission_resolver' field? False
resolver was asked: []          <- a REAL resolver on the ctx, never consulted
config written anyway: True
```

The production producer `_build_router_caller_state` (router_loop.py:3411) cannot populate a field that does not exist. `ctx.permission_resolver` **is** populated at all three production `ToolContext` sites (router_loop.py:2855/3368/3558). The gate was dead in every context.

## Why the one-line fix was wrong (falsified before shipping)

`resolver = ctx.permission_resolver` alone **breaks every install**:

```
default config (no disposition): BLOCKED -> "declared but not granted"
                                 Why: outside the default write zone (.reyn/)
```

`.reyn/config/` is a **recovery-core write-gate prefix** (`_RECOVERY_CORE_WRITE_PREFIXES`, permissions.py:89), deliberately carved OUT of the broad `.reyn/` default zone, and the call passed no `bus` → non-interactive hard-deny. So the fix threads the operator's **real** `PermissionDecl` + the **intervention bus** off the OpContext (hoisted above the gate — it was previously constructed *after* it, which is why the gate had nothing real to gate with). Measured after the fix:

```
[operator APPROVES]  prompted? True  -> status ok,             config written: True
[operator REFUSES ]  prompted? True  -> PermissionError,       config written: False
```

That is exactly the intended shape: **the LLM executes the install; the operator is asked precisely what the permission gate asks.**

## The second hole: the server was erased by recovery

`.reyn/config/` is recovery-core *because it is reconstructed*. `_reconcile_config_as_of_cut` (registry.py:1993) rewrites every generation-tracked registry from its LATEST generation. This verb recorded **no** generation, so once any generation existed for `config/mcp.yaml` (i.e. after any op-path install), reconstruction dropped every server it had added. Measured before the fix:

```
after install_local, on-disk servers: ['A', 'B']
generation-tracked paths: ['config/mcp.yaml']
after reconstruct, on-disk servers: ['A']
>>> server B survived? False
```

Fixed by recording the same `record_config_generation` the op path already does. **Truncate-falsify test included in this PR** (CLAUDE.md recovery-feature gate): set B → truncate past its events → reconstruct → assert B survives.

## Third: no P6 audit-event

The op path has always emitted `mcp_server_installed`; this verb emitted **nothing** on success (its only emit was `mcp_install_cancelled`). Same event name now, so both install paths land in one auditable stream. `audit-events emitted on SUCCESS: []` is the measurement; "invisible" is just the adjective for it.

The three are fixed together because they are one contract: gating without recording keeps the recovery hole; recording without gating keeps the escalation.

## Why no test caught this: the verification environment was structurally blind

The two suites covering this verb hand-rolled `ToolContext` stand-ins, and `test_2761`'s `_RS` stub **invented** a `permission_resolver` attribute — *the very field production lacks*:

```python
class _RS:
    def __init__(self, factory, resolver=None):
        self.op_context_factory = factory
        self.permission_resolver = resolver   # RouterCallerState has no such field
```

The gate looked exercised while it could never fire. The fake was the only thing that ever supplied what the handler read. Both suites now construct the **real** `ToolContext` / `RouterCallerState` (they are plain dataclasses — real instances, not stand-ins), so the suite can witness this class of drift. `test_mcp_install_local_hot_reload`'s `_FakePermissionResolver` is deleted for the same reason.

## Fix-class sweep — and the honest definition of the class

The instance is one site. **The class is not greppable**: "`getattr(obj, 'name', default)` reading a field the type never declared" leaves no text to grep for — *the absence is not written down*. Grep-for-zero answers "is this claim floating?"; it cannot answer "is something missing?".

So the sweep is **structural**, via AST: every attribute name read off `rs` / `router_state` across `src/`, diffed against `RouterCallerState.__dataclass_fields__`. Validated against the pristine tree (i.e. it is not a dead check):

```
# on origin/main:
declared fields: 28 | distinct names read off rs: 23
=== READ BUT NOT DECLARED ===
  'permission_resolver':
      src/reyn/tools/mcp_verbs.py:389 getattr

# on this branch:
declared fields: 28 | distinct names read off rs: 22
=== READ BUT NOT DECLARED ===
  (none)
```

One site, and the sweep proves it by construction rather than by my having looked.

## Scope note

`_scope_to_path` **ignores its `scope` argument** and always returns `.reyn/config/mcp.yaml` — which is what confines this verb's blast radius to that one path (it takes no `scope` param). That is load-bearing today and silently a lie the day a `scope` param is added. Left alone here (out of scope); flagging it rather than fixing it in a security PR.

## Test plan

All four CI gates run locally (pytest-green ≠ CI-green):

- [x] `ruff check src tests` — pass
- [x] `python scripts/test_tier_audit.py --strict` (3 files) — 20 inspected, 0 errors
- [x] `pytest` — 8785 passed, 24 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/mcp_verbs.py` — pass
- [x] **Strip-falsify, each fix reverted independently** (green is not evidence a test would catch anything):
  - revert the gate → both gate tests red
  - remove the generation record → truncation test red
  - remove the audit emit → audit test red
  - restore all → 4 passed

## What this PR deliberately does NOT do

It does **not** touch the `build_and_query_rag_corpus` SKILL.md or the `pip install markitdown-mcp` prose. Those are PR-2, sequenced deliberately **after** this one: the skill currently tells the LLM it *cannot* install these servers, and that prose should not be relaxed while the install path is unGATED. Correcting the doc first would open a window in which the docs recommend an ungated install.

Two findings that change the #3036 design and are worth recording:

- **`mcp__install_local` does NOT go through `RegistryClient`.** Its handler's own docstring says *"Bypasses registry + source_resolver."* It installs reyn's own builtins today — measured, all three (`reyn_chunker` / `reyn_vector_store` / `reyn_markitdown`) return `status=ok`. **No builtin manifest is needed** for the RAG case.
- **`MCP_INSTALL_LOCAL` / `_PACKAGE` / `_REGISTRY` are already `gates=ToolGates(router="allow", phase="allow")`** (mcp_verbs.py:583/595/607) and already registered (tools/__init__.py:264-266). The `router="deny"` is on the *legacy* `MCP_INSTALL_OP` only — a different ToolDefinition. **There is no gates work to do.**
