### PR TITLE
fix: make the CodeAct shim's tool name positional-only so a tool's own `name` arg can't collide (#3041)

### DIFF
--- a/src/reyn/core/kernel/_codeact_harness.py
+++ b/src/reyn/core/kernel/_codeact_harness.py
@@ -4,7 +4,7 @@ Invoked as ``python -m reyn.core.kernel._codeact_harness`` inside the sandbox. U
 ``_python_harness`` (a pure one-shot function runner), CodeAct code interleaves
 computation with **synchronous tool calls** mid-execution, so this harness opens a
 **duplex control channel** to the parent: the only world-effect path exposed to the
-snippet is a ``tool(name, **args)`` shim that round-trips each call to the parent,
+snippet is a ``tool(name, /, **args)`` shim that round-trips each call to the parent,
 where the SAME OS exclude + ``dispatch_tool`` + permission gate runs it (P5). The
 snippet never holds permission authority or reaches Reyn internals directly.
 
@@ -83,15 +83,29 @@ class _ControlChannelClosed(RuntimeError):
 
 
 def _make_tool_shim(channel: _ControlChannel):
-    """Build the ``tool(name, **args)`` callable injected into the snippet namespace.
+    """Build the ``tool(name, /, **args)`` callable injected into the snippet namespace.
 
     Marshals ``(name, args)`` to the parent, which runs the OS exclude +
     ``dispatch_tool`` + permission gate, and returns the result envelope's payload.
     A ``status == "error"`` envelope is raised as ``ToolError`` so the snippet can
     try/except it the way it would a normal Python call (permission_denied /
-    tool_excluded / unknown_tool surface here)."""
+    tool_excluded / unknown_tool surface here).
 
-    def tool(name: str, **args: Any) -> Any:
+    ``name`` is **positional-only** (#3041). It means "which tool to call", but
+    ``**args`` carries the TARGET tool's own schema keys — and ~20 registered tools
+    (``mcp__install_local``, ``agent_spawn``, ``remember_shared``, ``pipeline__run``
+    …) declare a parameter literally called ``name``. Without the ``/``, that key
+    binds to this function's own ``name`` slot, which ``_make_action_stub`` has
+    ALREADY filled positionally, and Python raises ``TypeError: got multiple values
+    for argument 'name'`` before the call ever reaches the parent gate — making every
+    such tool uncallable under CodeAct with no LLM-side workaround (the collision is
+    in the shim, not in the snippet). The ``/`` closes the namespace: a positional-only
+    parameter cannot be filled by a keyword, so ``name='reyn_chunker'`` lands in
+    ``**args`` where it belongs. A ``**kwargs`` catch-all can never collide, so
+    pinning ``name`` behind the ``/`` is sufficient — no other parameter here is
+    keyword-reachable."""
+
+    def tool(name: str, /, **args: Any) -> Any:
         reply = channel.call({"op": "tool_call", "name": name, "args": args})
         result = reply.get("result", {})
         if isinstance(result, dict) and result.get("status") == "error":
@@ -117,7 +131,12 @@ def _make_action_stub(qualified_name: str, tool_shim: Any):
     identical to the old ``tool('file__read', ...)`` proxy; only the LLM-facing surface
     changes (a selected identifier, never a produced string). Keyword args only
     (matches the proxy contract + the SP's keyword example); a positional call raises a
-    clear TypeError the model self-corrects from."""
+    clear TypeError the model self-corrects from.
+
+    The qualified name rides ``tool``'s POSITIONAL-ONLY first slot (#3041), so a
+    ``kwargs`` key named ``name`` — which the target tool's own schema is entitled to
+    declare — flows through to the parent as an argument instead of colliding with
+    this stub's "which tool" channel."""
 
     def _stub(**kwargs: Any) -> Any:
         return tool_shim(qualified_name, **kwargs)

--- a/src/reyn/core/kernel/codeact_runner.py
+++ b/src/reyn/core/kernel/codeact_runner.py
@@ -1,7 +1,7 @@
 """Parent-side orchestrator for a CodeAct snippet (#1593 PR-3, S2).
 
 Runs the model's snippet in a subprocess (``reyn.core.kernel._codeact_harness``) and
-services its duplex permission-proxy: each ``tool(name, **args)`` the snippet calls
+services its duplex permission-proxy: each ``tool(name, /, **args)`` the snippet calls
 round-trips over an inherited AF_UNIX socketpair to ``dispatch`` here in the parent
 — the SAME OS exclude + ``dispatch_tool`` + permission gate (P5). The snippet holds
 no permission authority and cannot reach Reyn internals; the socket is the single,

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -180,7 +180,7 @@ class CodeActScheme:
         ``tool_use_sp`` (#1618 root-3 REPLACE channel — the code-API replaces the
         universal tool-use SP region, vs the #1601 ``sp_fragment`` APPEND that left the
         universal vocab in place) — each action a callable the model invokes via the
-        ``tool(name, **args)`` proxy. No JSON ``tools=`` (``llm_tools_payload`` empty):
+        ``tool(name, /, **args)`` proxy. No JSON ``tools=`` (``llm_tools_payload`` empty):
         the model writes a Python snippet in its content, not tool calls.
 
         ``ops.catalog_entries()`` is async (the SchemeOps adapter ensures the

--- a/tests/test_codeact_name_collision_3041.py
+++ b/tests/test_codeact_name_collision_3041.py
@@ -1,0 +1,137 @@
+"""Tier 2: #3041 — the CodeAct shim must not eat a target tool's own ``name`` key.
+
+The direct-function stub (#1658) marshals its qualified name through ``tool``'s first
+parameter, which is itself called ``name``. Any tool whose OWN schema declares a
+parameter named ``name`` therefore had its ``name`` kwarg collide with the already-
+filled positional slot → ``TypeError: got multiple values for argument 'name'``,
+raised in the SHIM before the parent gate ever ran. Deterministic Python argument
+binding: no LLM-side calling convention could avoid it, so ~20 tools
+(``mcp__install_local``, ``agent_spawn``, ``remember_shared``, ``pipeline__run`` …)
+were simply uncallable under CodeAct. Fix: ``def tool(name, /, **args)`` — a
+positional-only parameter cannot be filled by a keyword.
+
+The affected set is derived FROM THE REGISTRY (every tool declaring a ``name``
+property), not from a hand-listed subset, so a tool that grows a ``name`` parameter
+later is covered on the day it is registered rather than the day someone remembers
+to extend a literal list.
+
+Real ``CodeActRunner`` + a real async dispatch double (no mocks); ``allow_unsandboxed``
+(the test-only transport escape — the sandbox is orthogonal to the binding proof).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.kernel.codeact_runner import CodeActRunner
+from reyn.tools import get_default_registry
+from reyn.tools.schemes.codeact import _build_actions_map
+
+
+def _tools_declaring_a_name_param() -> list[str]:
+    """Every registered tool whose OWN parameter schema has a ``name`` property —
+    the exact set at risk of the shim collision, read off the registry."""
+    return sorted(
+        t.name
+        for t in get_default_registry()
+        if "name" in ((t.parameters or {}).get("properties", {}) or {})
+    )
+
+
+@pytest.mark.asyncio
+async def test_every_registry_tool_with_a_name_param_is_callable_under_codeact() -> None:
+    """Tier 2: #3041 — for EVERY registered tool declaring its own ``name`` parameter,
+    a CodeAct call passing ``name=`` reaches the parent gate with (a) the tool's real
+    qualified name as the dispatch target and (b) ``name`` intact as an ARGUMENT.
+
+    Both halves matter: the shim must keep routing on the qualified name while no
+    longer consuming the caller's same-spelled argument."""
+    qualified = _tools_declaring_a_name_param()
+    assert qualified, "registry declares no tool with a 'name' param — the guard would be vacuous"
+    actions = _build_actions_map(qualified)  # the REAL scheme identifier map
+    ident_of = {q: i for i, q in actions.items()}
+
+    seen: dict[str, dict] = {}
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen[name] = args
+        return {"status": "ok", "data": name}
+
+    # One snippet calling every at-risk stub — the pre-fix TypeError was raised by the
+    # first one, so reaching the end at all is itself the regression signal.
+    calls = "\n".join(
+        f"{ident_of[q]}(name={q!r})" for q in qualified
+    )
+    out = await CodeActRunner().run(
+        code=calls + "\nresult = 'done'",
+        dispatch=dispatch,
+        actions=actions,
+        allow_unsandboxed=True,
+    )
+
+    assert out["ok"] is True, f"a name-declaring tool still fails under CodeAct: {out}"
+    # Every tool dispatched, and each received its own 'name' as an argument.
+    assert set(seen) == set(qualified)
+    assert seen == {q: {"name": q} for q in qualified}
+
+
+@pytest.mark.asyncio
+async def test_target_name_arg_does_not_hijack_the_dispatch_target() -> None:
+    """Tier 2: #3041 — a ``name`` ARGUMENT must not be able to redirect WHICH tool the
+    gate runs. The qualified name rides a positional-only slot, so a snippet passing
+    ``name='file__read'`` to one tool still dispatches the tool it named in code.
+
+    This is the security-relevant half of the fix: were ``name`` keyword-reachable, a
+    snippet could aim the marshalling primitive at a different tool than the stub the
+    gate's exclude list was reasoning about."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": "ok"}
+
+    out = await CodeActRunner().run(
+        code="result = mcp__install_local(name='file__read', command='c', args=[])",
+        dispatch=dispatch,
+        actions={"mcp__install_local": "mcp__install_local"},
+        allow_unsandboxed=True,
+    )
+
+    assert out["ok"] is True, out
+    # Dispatched the stub the code named, NOT the value of the 'name' argument.
+    assert seen == [
+        ("mcp__install_local", {"name": "file__read", "command": "c", "args": []})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_reported_install_call_reaches_the_gate() -> None:
+    """Tier 2: #3041 — the exact call the live LLM wrote in the reported trace
+    (``mcp__install_local(name=..., command=..., args=[])``) now reaches the gate.
+
+    Also pins the sibling non-collision: ``args`` is the shim's ``**kwargs`` catch-all,
+    which no keyword can collide with, so a tool declaring its own ``args`` parameter
+    (as this one does) rides through as a plain argument."""
+    seen: list[tuple[str, dict]] = []
+
+    async def dispatch(name: str, args: dict) -> dict:
+        seen.append((name, args))
+        return {"status": "ok", "data": {"installed": args.get("name")}}
+
+    out = await CodeActRunner().run(
+        code=(
+            "result = mcp__install_local("
+            "name='reyn_chunker', command='reyn-rag-chunker', args=[])"
+        ),
+        dispatch=dispatch,
+        actions={"mcp__install_local": "mcp__install_local"},
+        allow_unsandboxed=True,
+    )
+
+    assert out["ok"] is True, out
+    assert out["result"] == {"installed": "reyn_chunker"}
+    assert seen == [
+        (
+            "mcp__install_local",
+            {"name": "reyn_chunker", "command": "reyn-rag-chunker", "args": []},
+        )
+    ]


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3041.

The `codeact` scheme's shim ate the target tool's own `name` argument. One character fixes it; the interesting part is the measurement.

## The defect

`_make_action_stub` marshals via `tool_shim(qualified_name, **kwargs)`, filling `tool(name, **args)`'s first parameter — itself called `name`, meaning "which tool" — positionally. If the TARGET tool's schema also declares `name`, that key arrives in `**kwargs` and collides with the already-filled slot. Deterministic Python argument binding: **the collision is in the shim, not in the snippet**, so no LLM-side calling convention avoids it. The call died before `dispatch_tool` and the permission gate ever ran.

## The fix

```python
def tool(name: str, /, **args: Any) -> Any:
```

A positional-only parameter cannot be filled by a keyword, so `name='reyn_chunker'` lands in `**args`. The `**kwargs` catch-all can never collide with anything, so pinning `name` behind the `/` is sufficient — no other parameter here is keyword-reachable. This was lead-coder's proposed direction; I measured it rather than assuming it, and it holds.

It also closes a latent seam worth naming: were `name` keyword-reachable, a snippet passing `name='file__read'` could aim the marshalling primitive at a **different tool than the stub the exclude list was reasoning about**. Pinned by `test_target_name_arg_does_not_hijack_the_dispatch_target`.

## Blast radius — derived from the registry, each individually driven

The issue honestly flagged 9 tools as "not individually verified". Enumerating from the registry instead of counting the list, it is **20 of 87** — the issue's grep of `required` missed tools where `name` is optional (`hooks_add`, `skill_install_*`, `pipeline_install_*`, `cron_enable/disable`, …).

All 20 driven individually through the real `CodeActRunner` subprocess:

| | before | after |
|---|---|---|
| codeact | **20/20 TypeError** (gate never reached) | **20/20 dispatch, `name` intact** |

`agent_spawn` · `cron_register` · `cron_unregister` · `cron_enable` · `cron_disable` · `describe_agent` · `get_mcp_prompt` · `hooks_add` · `mcp_install_local` · `pipeline_install_local` · `pipeline_install_source` · `presentation_install_local` · `remember_agent` · `remember_shared` · `run_pipeline` · `run_pipeline_async` · `skill_install_local` · `skill_install_source` · `task.create` · `topology_create`

The test derives this set **from the registry**, so a tool that grows a `name` parameter later is covered on the day it is registered, not the day someone remembers to extend a literal list.

## `enumerate-all` (the default) — measured, not assumed

The issue flagged "probably unaffected, unverified". **Verified: unaffected.** `dispatch_tool(*, name, args: dict)` is keyword-only and never splats `args`, so the collision is structurally impossible. Drove all 20 through it: **20/20 reach the invoker with `name` intact on current main.** Severity stays confined to configs opting into `tool_use.chat: codeact` — the default is clean.

## Effect on tonight's other PRs

#3037's permission gate and #3038's refusal text sit **behind** this TypeError, so neither was reachable from codeact. Both were correct; this was one layer earlier. They should now be exercisable.

## Test plan

- [x] **Live-reproduced before fixing** — real `CodeActRunner` subprocess, unfixed main (`46176566`): the exact call from the issue's LLM trace, `mcp__install_local(name='reyn_chunker', command='reyn-rag-chunker', args=[])` → `TypeError: got multiple values for argument 'name'`, and the dispatch double recorded **zero** calls, confirming the gate is unreachable.
- [x] **Falsified the tests** — reverted the `/`, all 3 fail with the exact TypeError; restored, all 3 pass. (Restored from a file copy, not `git stash` / `git checkout`.)
- [x] **`#3033` guard** — asserted `inspect.getsource` of the *loaded* harness contains the fix before trusting any post-fix number. This bit me for real: my first run printed the worktree path despite `cwd`+`PYTHONPATH` pointing elsewhere.
- [x] Post-fix: the issue's exact live call reaches the gate as `{'name': 'reyn_chunker', 'command': 'reyn-rag-chunker', 'args': []}` — note `args=[]` rides through too, empirically confirming the catch-all can't collide.
- [x] CI gates, all four separately: `ruff check src tests` ✅ · `test_tier_audit.py --strict` ✅ (3 OK, 0 Tier-4) · `pytest` ✅ **8788 passed, 24 skipped** (skips all platform/optional-dep — no codeact test skipped) · `verify_module_docstrings.py` ✅
- [ ] (not done) End-to-end via a real TUI + real LLM. My verification drives the real subprocess harness and the real registry, but stops below the live-model layer — the original reporter is better placed to confirm the owner's RAG flow now completes.

## Docs

Per the same-PR doc rule, updated the three docstrings describing this mechanism's signature (`_codeact_harness.py` module + `_make_tool_shim` + `_make_action_stub`, `codeact_runner.py`, `schemes/codeact.py`), including *why* the `/` is load-bearing so it doesn't get "cleaned up" later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
