### PR TITLE
fix: route driver-session router-op interventions through the bridge-aware bus (#3049 RAG hang)

### DIFF
--- a/docs/concepts/runtime/intervention-delivery.md
+++ b/docs/concepts/runtime/intervention-delivery.md
@@ -1,0 +1,105 @@
+---
+type: concept
+topic: runtime
+audience: [human, agent]
+search_hints: [intervention delivery, ask_user, permission prompt, intervention bus, BridgeToParent, spawn bridge, pipeline driver, originator, answering surface, fail-close, intervention orphan, stalled intervention, present routing]
+---
+
+# Intervention delivery
+
+An **intervention** is any moment where the OS must pause an in-flight operation and get an
+answer from a human: an `ask_user` question, a just-in-time permission prompt, an MCP
+elicitation, a `safety.limit` "keep going?" gate. The work that raises an intervention is
+often **not running where the operator is looking** — it may be a spawned pipeline driver, an
+agent-step worker, or a deep fan-out branch. Intervention delivery is the guarantee that the
+question still reaches the person who can answer it, and that when nobody can, the run does not
+hang.
+
+## The rule
+
+> **Whichever component (step) raises it, an intervention — and a `present` — is answered by
+> the originator the run is ultimately attached to. When there is no attached originator, it is
+> closed and answered (fail-close).**
+
+Two clauses, no per-step branch. There is deliberately no "…except for a tool step" or "…MCP
+calls are special". A feature that needs its own delivery path is the failure sign (see below).
+
+## The resolution is existing and correct — the fix is uniform threading
+
+The hard part — *which* surface answers — is already solved and is **not** re-invented per
+call site. A spawned session carries a typed **intervention bridge**
+(`runtime/session_buses.py`):
+
+- **`SpawnBridgeInterventionListener`** (an *attached* spawn — a pipeline driver spawned
+  `BridgeToParent`, an agent-step worker under an attached invoker) resolves *compositionally
+  toward the outermost attached originator*. It walks parent → parent, so a grandchild's prompt
+  reaches the human via the first ancestor that actually serves an operator, never pinning on an
+  intermediate headless session.
+- **`AuditOnlyInterventionBridge`** (a *detached* / headless spawn — `start_pipeline_run`, a
+  `reyn pipe` run, a worker with no live invoker) resolves every intervention to a typed,
+  reason'd **refusal** that returns immediately — the fail-close clause, by construction, at
+  every depth. Never an unbounded park.
+
+Both clauses of the rule are therefore *properties of the bridge chain*, decided once at spawn
+time. The only thing an individual op does is **build its intervention bus from that chain**
+rather than binding it to its own session. When every IV-raising leaf does that uniformly, the
+rule holds with no branching.
+
+### The single construction seam
+
+For router-initiated ops, that bus is built in exactly one place —
+`Session._make_router_intervention_bus()`:
+
+- **bridge present** (this session is an attached driver/worker) → dispatch on the parent's
+  live-operator listener (the chain above);
+- **no bridge** (a root chat, or a detached session whose bridge is `AuditOnly`) → a self-bound
+  `ChatInterventionBus` on this session's own registry.
+
+`RouterHostAdapter`'s intervention-bus factory and every MCP op method (`_mcp_call_tool` and its
+resource/prompt siblings) route through this one seam. `ask_user` and `present` already reached
+the originator because they, too, ride the spawn-time bridge (`present` via the analogous
+`SpawnBridgePresentationConsumer`) — the fix brought the MCP leaf into the same discipline.
+
+## The failure that motivated the rule (#3049)
+
+A chat-invoked `rag_ingest` pipeline hung indefinitely. Its X1 pre-flight fanned out
+`call_mcp_tool` reachability probes; each probe's permission gate raised a `permission.generic`
+intervention. The driver session's MCP op methods **hardcoded a self-bound
+`ChatInterventionBus(self, …)`**, bypassing the bridge. So on an *attached* driver — where a live
+operator was blocked on the parent, ready to answer — the prompt landed on the *driver's own*
+listener-less registry: dispatched, parked stalled, and awaited forever. (Live-process
+measurement id-matched all 18 orphaned branch futures 1:1 to the stalled `permission.generic`
+interventions.)
+
+The self-bound bus was *correct* for a root chat and *wrong* for a driver — a single hardcoded
+construction cannot tell the two apart. Routing it through the bridge-aware seam fixes both
+uniformly: the attached driver reaches the operator, the detached one fails closed.
+
+## The failure sign
+
+> If an implementation needs a **different way to deliver** for one step kind or one op — a
+> bespoke bus, a special-cased routing branch — that is fragmentation leaking back into the
+> rule.
+
+The correct design has one resolution (the bridge chain) and one construction seam; a leaf only
+chooses to *use* it. When a new IV-raising router-op seam is added, it inherits origin-delivery
+for free by building its bus through `_make_router_intervention_bus`. A seam that instead
+constructs its own self-bound bus reintroduces the #3049 orphan for any attached spawn — the
+structural guard in `tests/test_3049_driver_router_op_intervention_reaches_originator.py`
+fails on exactly that.
+
+## Not yet uniform: the limit-policy bus
+
+The per-LLM-call `safety.limit` gates (`cost.*`, `timeout.llm_call`) are dispatched through a
+**separate** bus wiring (`_ChatBudgetBus` → `Session._dispatch_intervention`), not the router-op
+seam above. For a spawned session this bus is *also* not bridge-aware — a `safety.limit` prompt
+there does not reach the originator (it auto-refuses locally rather than hanging). This is the
+same fix-class as #3049 but a distinct seam and a distinct symptom; it was not the measured RAG
+hang and is tracked separately. The rule stated above is the target for that seam too.
+
+## See also
+
+- [Permission model](permission-model.md) — the gates that raise `permission.*` interventions.
+- [Present layer](present.md) — `present` rides the same spawn-time surface routing.
+- [Safety](safety.md) — the `on_limit` policy behind the `safety.limit` gate.
+- [Pipelines](pipelines.md) — attached vs detached pipeline runs (the driver spawn modes).

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1960,14 +1960,11 @@ class Session:
             # refusing. Non-driver / detached / ephemeral sessions (bridge is None) keep the
             # self-bound bus, byte-identical. Mirror of the presentation_renderer_factory
             # spawn-bridge below.
-            intervention_bus_factory=lambda: (
-                self._intervention_bridge.bus(run_id=None, actor="chat_router")
-                if self._intervention_bridge is not None
-                else ChatInterventionBus(
-                    self, run_id=None, actor="chat_router",
-                    channel_id=DEFAULT_CHAT_CHANNEL_ID,
-                )
-            ),
+            # #3049: single-sourced with the MCP op callers via
+            # ``_make_router_intervention_bus`` (bridge-aware — driver → parent, else
+            # self-bound) so router-op interventions resolve to the SAME surface
+            # regardless of which seam builds the OpContext.
+            intervention_bus_factory=self._make_router_intervention_bus,
             # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
             # so a `present` op reaches the surface's sink instead of PR-A's null surface.
             # Built per make_router_op_context() call, mirroring the intervention_bus_factory
@@ -6231,6 +6228,36 @@ class Session:
             budget_gateway=self._budget,  # FP-0063 PC: embedding-cost recording entry point (enumerate ALL op-ctx builders; the load-bearing one for `embed` is RouterHostAdapter's)
         )
 
+    def _make_router_intervention_bus(self):
+        """The chat-router intervention bus for a router-initiated op, resolved
+        BRIDGE-AWARE.
+
+        SINGLE SOURCE for "which surface answers a router op's intervention",
+        shared with the ``RouterHostAdapter`` ``intervention_bus_factory``
+        (constructed above, ~session.py:1963): when this session is an ATTACHED
+        pipeline DRIVER (it carries a ``SpawnBridgeInterventionListener`` — see
+        ``_spawn_pipeline_driver_session``), the bus dispatches on the PARENT
+        session's live-operator listener (compositionally resolved toward the
+        outermost attached originator); otherwise a self-bound
+        ``ChatInterventionBus`` on this session's own registry (a root chat, or a
+        detached/headless run whose bridge is ``AuditOnlyInterventionBridge`` and
+        thus fail-closes).
+
+        #3049: the MCP op callers below (``_mcp_call_tool`` and its resource /
+        prompt siblings) previously HARDCODED the self-bound branch, so a driver
+        session's ``call_mcp_tool`` permission prompt (e.g. the ``rag_ingest``
+        X1 pre-flight probes) orphaned on the driver's own listener-less
+        registry — dispatched, stalled, and awaited forever (the confirmed hang).
+        Routing them through this helper makes every IV-raising router leaf reach
+        the pipeline originator uniformly, exactly as ``ask_user`` / ``present``
+        already do via the bridge-aware ``RouterHostAdapter.make_router_op_context``."""
+        if self._intervention_bridge is not None:
+            return self._intervention_bridge.bus(run_id=None, actor="chat_router")
+        return ChatInterventionBus(
+            self, run_id=None, actor="chat_router",
+            channel_id=DEFAULT_CHAT_CHANNEL_ID,
+        )
+
     async def _file_op(self, op_dict: dict) -> dict:
         """Dispatch a file op via op_runtime. Returns result dict."""
         from reyn.core.op_runtime import execute_op
@@ -6464,10 +6491,9 @@ class Session:
 
         op = MCPReadResourceIROp(kind="mcp_read_resource", server=server, uri=uri)
         ctx = self._make_router_op_context()
-        ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, actor="chat_router",
-            channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+        # #3049: bridge-aware — a driver session's MCP permission prompt reaches the
+        # pipeline originator instead of orphaning on the driver's own registry.
+        ctx.intervention_bus = self._make_router_intervention_bus()
         ctx.permission_decl = PermissionDecl(
             file_read=ctx.permission_decl.file_read,
             file_write=ctx.permission_decl.file_write,
@@ -6509,10 +6535,9 @@ class Session:
 
         op = MCPSubscribeResourceIROp(kind="mcp_subscribe_resource", server=server, uri=uri)
         ctx = self._make_router_op_context()
-        ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, actor="chat_router",
-            channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+        # #3049: bridge-aware — a driver session's MCP permission prompt reaches the
+        # pipeline originator instead of orphaning on the driver's own registry.
+        ctx.intervention_bus = self._make_router_intervention_bus()
         ctx.permission_decl = PermissionDecl(
             file_read=ctx.permission_decl.file_read,
             file_write=ctx.permission_decl.file_write,
@@ -6538,10 +6563,9 @@ class Session:
 
         op = MCPUnsubscribeResourceIROp(kind="mcp_unsubscribe_resource", server=server, uri=uri)
         ctx = self._make_router_op_context()
-        ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, actor="chat_router",
-            channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+        # #3049: bridge-aware — a driver session's MCP permission prompt reaches the
+        # pipeline originator instead of orphaning on the driver's own registry.
+        ctx.intervention_bus = self._make_router_intervention_bus()
         ctx.permission_decl = PermissionDecl(
             file_read=ctx.permission_decl.file_read,
             file_write=ctx.permission_decl.file_write,
@@ -6612,10 +6636,9 @@ class Session:
             kind="mcp_get_prompt", server=server, name=name, arguments=dict(arguments or {}),
         )
         ctx = self._make_router_op_context()
-        ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, actor="chat_router",
-            channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+        # #3049: bridge-aware — a driver session's MCP permission prompt reaches the
+        # pipeline originator instead of orphaning on the driver's own registry.
+        ctx.intervention_bus = self._make_router_intervention_bus()
         ctx.permission_decl = PermissionDecl(
             file_read=ctx.permission_decl.file_read,
             file_write=ctx.permission_decl.file_write,
@@ -6656,10 +6679,9 @@ class Session:
         op = MCPIROp(kind="mcp", server=server, tool=tool, args=args)
         ctx = self._make_router_op_context()
         # MCP handler requires intervention_bus; wire the session's bus
-        ctx.intervention_bus = ChatInterventionBus(
-            self, run_id=None, actor="chat_router",
-            channel_id=DEFAULT_CHAT_CHANNEL_ID,
-        )
+        # #3049: bridge-aware — a driver session's MCP permission prompt reaches the
+        # pipeline originator instead of orphaning on the driver's own registry.
+        ctx.intervention_bus = self._make_router_intervention_bus()
         # Narrow mcp scope to just this server while preserving file perms from the
         # populated decl. PermissionDecl.mcp must include the server for require_mcp to pass.
         ctx.permission_decl = PermissionDecl(

--- a/tests/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -1,0 +1,260 @@
+"""#3049 — a pipeline DRIVER session's router-op intervention reaches the pipeline ORIGINATOR.
+
+The RAG-ingest hang: the ``rag_ingest`` X1 pre-flight fans out ``call_mcp_tool`` reachability
+probes. Each probe's ``require_mcp`` permission gate raised a ``permission.generic`` intervention
+on a bus the driver session HARDCODED to itself (``Session._mcp_call_tool`` and its 4 MCP-op
+siblings built ``ChatInterventionBus(self, ...)`` directly, bypassing the session's
+``_intervention_bridge``). So on an ATTACHED driver (spawned ``BridgeToParent`` — see
+``_spawn_pipeline_driver_session``) the prompt landed on the driver's OWN listener-less
+``InterventionRegistry`` instead of the operator's parent surface: dispatched, parked stalled,
+and ``await``-ed forever (the confirmed indefinite hang, orphan-future id-matched 18/18 to the
+stalled ``permission.generic`` interventions in the live-process measurement on #3049).
+
+The fix routes every router-op intervention bus through ``Session._make_router_intervention_bus``
+— bridge-aware (attached driver → parent's live listener; root/detached → self-bound /
+fail-close), the SAME resolution the ``RouterHostAdapter`` intervention-bus factory already used.
+One construction seam, uniform across every IV-raising router-op leaf — exactly as a ``tool:
+ask_user`` step already reached the parent (it never overrode the bridge-aware bus, which is why
+``ask_user`` worked while ``call_mcp_tool`` orphaned).
+
+Real ``AgentRegistry`` / ``Session`` / ``PermissionResolver`` / bridge + intervention machinery —
+no collaborator mocks. The permission gate (``require_mcp`` / ``require_tool``) is driven for real
+and its ``permission.generic`` intervention is witnessed CROSS-SESSION on the originator's own
+active queue (a single-session harness could never witness this — the bug is precisely that the
+prompt lands on the WRONG session's registry; #3037-inverse). Mirrors the operator-reach pattern
+of ``test_2708_p32a_spawn_bridge_intervention`` / ``test_2769_agent_step_intervention_reaches_invoker``.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.intervention_choices import YES, generic_yn_choices
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
+from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemeral_session
+from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+_SERVER = "reyn3049_probe_server"
+_TOOL = "reyn3049_probe_tool"
+
+
+def _registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Real AgentRegistry + a Session factory that forwards BOTH spawn overrides, so the
+    driver spawn threads a parent-bound ``intervention_bridge`` exactly as production does."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        return Session(
+            agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
+            non_interactive=True, presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+async def _spawn_driver(reg: "AgentRegistry", routing) -> Session:
+    """A pipeline driver session spawned with ``routing``'s intervention bridge — the SAME
+    spawn shape ``_spawn_pipeline_driver_session`` uses (BridgeToParent attached / AuditOnly
+    detached)."""
+    sid = await spawn_ephemeral_session(
+        reg, identity="worker", narrowing=_build_agent_step_narrowing(None),
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+    driver = reg.get_session("worker", sid)
+    assert driver is not None
+    return driver
+
+
+def _cancel_tasks(reg: "AgentRegistry") -> None:
+    for task in list(reg._tasks.values()):  # noqa: SLF001 — teardown precedent (sibling tests)
+        if not task.done():
+            task.cancel()
+
+
+# ── Attached: a driver-session MCP permission prompt reaches the originator operator ──────
+
+
+@pytest.mark.asyncio
+async def test_attached_driver_mcp_permission_reaches_originator_operator(tmp_path: Path) -> None:
+    """Tier 2: an ATTACHED pipeline driver's ``call_mcp_tool`` permission gate — driven for real
+    through ``PermissionResolver.require_mcp`` on the bus the driver's MCP op builds
+    (``_make_router_intervention_bus``) — delivers its ``permission.generic`` prompt to the
+    ORIGINATOR operator's live listener, and the operator's grant flows back so the call proceeds.
+    RED before the fix: the MCP op hardcoded ``ChatInterventionBus(self, ...)`` → the prompt
+    orphaned on the driver's own listener-less registry (stalled + awaited forever = the #3049 hang),
+    never reaching the parent."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log)
+    originator = reg.get_or_load("worker")
+    originator.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    driver = await _spawn_driver(reg, BridgeToParent(originator))
+
+    # The EXACT bus the driver's _mcp_call_tool builds for the permission gate (the production seam).
+    bus = driver._make_router_intervention_bus()  # noqa: SLF001 — production op-ctx construction seam
+    resolver = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    decl = PermissionDecl(mcp=[_SERVER])  # statically authorized, not pre-approved → prompts
+
+    gate = asyncio.ensure_future(resolver.require_mcp(decl, _SERVER, bus))
+
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not originator.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert originator.interventions.list_active(), (
+        "the driver's MCP permission prompt never reached the ORIGINATOR operator's active queue — "
+        "it orphaned on the driver's own listener-less registry (the #3049 stall)."
+    )
+    # Delivered to the LIVE listener, not parked stalled on the parent (the bridge stamps the
+    # channel the operator actually listens on).
+    assert originator.list_stalled_interventions() == [], (
+        "the bridged MCP prompt was parked in the originator's stalled queue instead of its live "
+        "listener."
+    )
+
+    # The operator grants on the originator surface; require_mcp returns (allow), no hang.
+    consumed = await originator.answer_oldest_intervention_choice(YES)
+    assert consumed is True
+    await asyncio.wait_for(gate, timeout=5.0)  # returns None on allow; MUST NOT raise/hang
+
+    _cancel_tasks(reg)
+
+
+@pytest.mark.asyncio
+async def test_attached_driver_permission_kind_agnostic_same_bus(tmp_path: Path) -> None:
+    """Tier 2: the fix is at the BUS-CONSTRUCTION seam, so it is IV-KIND-agnostic — the same
+    driver bus that carries an MCP-server ``permission.generic`` also carries a tool-authority
+    ``permission.generic`` (``require_tool``) to the originator. Guards that the delivery rides the
+    surface, not a per-gate special-case (the whole point of the single ``_make_router_intervention_bus``
+    seam: a future permission consumer inherits origin-delivery for free)."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log)
+    originator = reg.get_or_load("worker")
+    originator.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    driver = await _spawn_driver(reg, BridgeToParent(originator))
+    bus = driver._make_router_intervention_bus()  # noqa: SLF001 — production seam
+    resolver = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    decl = PermissionDecl(tool=[_TOOL])
+
+    gate = asyncio.ensure_future(resolver.require_tool(decl, _TOOL, bus))
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 5.0
+    while loop.time() < deadline and not originator.interventions.list_active():
+        await asyncio.sleep(0.02)
+    assert originator.interventions.list_active(), (
+        "a tool-authority permission prompt on the same driver bus did NOT reach the originator — "
+        "delivery must ride the bus seam uniformly, not per permission-gate."
+    )
+    consumed = await originator.answer_oldest_intervention_choice(YES)
+    assert consumed is True
+    await asyncio.wait_for(gate, timeout=5.0)
+
+    _cancel_tasks(reg)
+
+
+# ── Detached: a headless driver's MCP permission fails closed (never reaches, never hangs) ─
+
+
+@pytest.mark.asyncio
+async def test_detached_driver_mcp_permission_fail_closed_deny(tmp_path: Path) -> None:
+    """Tier 2: (fail-close half of the rule "no attached originator → close and answer") a DETACHED
+    driver (spawned ``AuditOnlyNoSurface``, as ``start_pipeline_run`` does) builds its router-op bus
+    the same way, and its MCP permission gate resolves to a typed refusal → ``require_mcp`` DENIES
+    (``PermissionError``), never reaching (nor hanging on) any operator. The fix preserves the
+    detached fail-close by construction (bridge is ``AuditOnlyInterventionBridge``), not by a
+    per-op special case."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    reg = _registry(tmp_path, state_log)
+    # A would-be operator exists but this driver is NOT attached to it — it must never be consulted.
+    originator = reg.get_or_load("worker")
+    originator.register_intervention_listener(DEFAULT_CHAT_CHANNEL_ID)
+
+    driver = await _spawn_driver(reg, AuditOnlyNoSurface())
+    bus = driver._make_router_intervention_bus()  # noqa: SLF001 — production seam
+    resolver = PermissionResolver({}, project_root=tmp_path, interactive=True)
+    decl = PermissionDecl(mcp=[_SERVER])
+
+    with pytest.raises(PermissionError):
+        # The AuditOnly refusal (choice_id=None) is consumed as DENY — require_mcp raises,
+        # resolving immediately (no park). A refuse→allow hole would let this pass.
+        await asyncio.wait_for(resolver.require_mcp(decl, _SERVER, bus), timeout=3.0)
+
+    # The non-attached originator's live listener was never consulted.
+    assert originator.interventions.list_active() == [], (
+        "a detached driver's MCP prompt reached a non-attached operator — detached must fail-close "
+        "locally, not bridge to an unrelated surface."
+    )
+
+    _cancel_tasks(reg)
+
+
+# ── Structural: every router-op intervention bus is the single bridge-aware seam ──────────
+
+
+def _self_bound_bus_construction_methods() -> "list[str]":
+    """Enumerate ``Session`` methods whose body constructs a SELF-BOUND
+    ``ChatInterventionBus(self, ...)`` directly (positional first arg ``self``) — derived from
+    the live class source, never hand-listed, so a NEWLY-added router-op seam that hardcodes its
+    own self-bound bus is caught automatically. ``_make_router_intervention_bus`` (the ONE
+    sanctioned construction point, which chooses self-bound only when no bridge is present) is
+    excluded — it is the seam every other method must route through."""
+    src = textwrap.dedent(inspect.getsource(Session))
+    tree = ast.parse(src)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name == "_make_router_intervention_bus":
+            continue
+        for call in ast.walk(node):
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "ChatInterventionBus"
+                and call.args
+                and isinstance(call.args[0], ast.Name)
+                and call.args[0].id == "self"
+            ):
+                offenders.append(node.name)
+                break
+    return offenders
+
+
+def test_router_op_intervention_bus_has_single_bridge_aware_seam() -> None:
+    """Tier 2: #3049's fix-class guard — no ``Session`` method may hardcode a self-bound
+    ``ChatInterventionBus(self, ...)`` outside ``_make_router_intervention_bus``. That helper is the
+    ONE bridge-aware construction seam (attached driver → originator; root/detached → self-bound /
+    fail-close), so EVERY IV-raising router-op leaf inherits origin-delivery by construction. A new
+    MCP-style op method that builds its own self-bound bus — reintroducing the #3049 orphan for a
+    driver session — makes this list non-empty and fails here. RED before the fix: the 5 MCP op
+    methods (``_mcp_call_tool`` + resource/prompt siblings) each hardcoded the self-bound bus."""
+    offenders = _self_bound_bus_construction_methods()
+    assert offenders == [], (
+        "these Session methods construct a self-bound ChatInterventionBus(self, ...) directly, "
+        "bypassing the bridge-aware _make_router_intervention_bus seam — a driver session's "
+        f"intervention raised there would orphan on its own registry (#3049): {sorted(set(offenders))}"
+    )
+
+    # Vacuity guard: the helper itself MUST contain the sanctioned self-bound construction, else
+    # the scan matches nothing for a trivial reason (renamed class / moved seam) and the guard is
+    # inert. Assert the one legitimate site exists so "offenders == []" means "swept", not "empty scan".
+    helper_src = inspect.getsource(Session._make_router_intervention_bus)
+    assert "ChatInterventionBus(" in helper_src and "_intervention_bridge" in helper_src, (
+        "the bridge-aware seam _make_router_intervention_bus no longer contains the guarded "
+        "construction — the structural scan would be vacuously green (guard inert)."
+    )


### PR DESCRIPTION
**[per-PR-coder]** — Root-fix for the #3049 RAG-ingest indefinite hang. Owner GO'd, architect co-vets.

## Root cause (MEASURED, diverges from the initial survey)

A chat-invoked `rag_ingest` pipeline hung at its X1 pre-flight `call_mcp_tool` probes. Each probe's `require_mcp` permission gate raised a `permission.generic` intervention, but `Session._mcp_call_tool` (and its 4 MCP-op siblings) **hardcoded a self-bound `ChatInterventionBus(self, …)`**, bypassing `self._intervention_bridge`. On an ATTACHED pipeline driver (spawned `BridgeToParent`) the prompt landed on the driver's OWN listener-less registry → dispatched, parked stalled, awaited forever. This matches the live-process measurement exactly (`origin_channel_id='tui', actor='chat_router', run_id=None`, stalled; 18/18 orphan-future id-match).

**Divergence from the architect survey (owner explicitly demanded I measure, not trust the survey):** the leak is NOT in the executor's `_run_tool_step` / `tool_dispatch`. Threading the surface there would not have fixed it — MCP tools route via `host.mcp_call_tool` → the driver session's `_mcp_call_tool`, which ignores the closure ctx's bus and hardcodes self-bound. `ask_user` tool-steps already reached the operator precisely because they never overrode the bridge-aware bus; the MCP methods did. Primary-data verification in the commit + measurement script.

## Fix (single bridge-aware seam)

`Session._make_router_intervention_bus()` — bridge present (attached driver/worker) → parent's live listener via the existing `SpawnBridge` chain; no bridge (root chat, or detached whose bridge is `AuditOnly`) → self-bound / fail-close. The 5 MCP op methods + the `RouterHostAdapter` intervention-bus factory now route through this one seam. Resolution (the bridge chain) is unchanged and already correct; only the construction is made uniform. Realizes the architect's ratified rule ("whichever step raises it, the intervention is answered by the originator the run is attached to; else fail-close") without any per-step branch.

## Tests (`tests/test_3049_driver_router_op_intervention_reaches_originator.py`)

Real `Session`/`AgentRegistry`/`PermissionResolver`/bridge — no mocks. Cross-session deliver witness (a single-session harness cannot catch this class — #3037-inverse):
- attached driver MCP permission → reaches originator operator (RED pre-fix);
- kind-agnostic: `require_tool` on the same bus also reaches origin (the fix is at the bus seam, IV-kind-independent);
- detached driver → typed DENY fail-close (never reaches, never hangs);
- structural guard: no `Session` method may hardcode a self-bound bus outside the seam (AST-derived, vacuity-guarded) — a future MCP-style seam is auto-RED.
- **Strip-falsify**: reverting the seam turns all attached cells RED (shown locally).

CI gates run locally: ruff ✓, tier-audit ✓, module-docstrings ✓, targeted pytest ✓ (1081 passed across mcp/intervention/session/router_host suites, no regression).

## ⚠️ Scope question for co-vet (reported to lead via broker; awaiting A/B)

The two IV kinds are **not** the same wiring (I verified by measurement):
- **permission** (MCP) → `_make_router_intervention_bus` → **fixed here**.
- **safety-limit** (`cost.*` / `timeout.llm_call`) → a SEPARATE bus `_ChatBudgetBus` → `Session._dispatch_intervention`, NOT bridge-aware. For a spawned session it does not reach the originator — but it **auto-refuses** (fail-closed), it does **not** hang, and it was **not** the measured #3049 cause (100% `permission.generic`).

This PR is scoped to the measured hang (**option A**). The safety-limit path is the same fix-class but a distinct seam + distinct symptom; documented in `intervention-delivery.md` § "Not yet uniform" as a tracked follow-up. If co-vet prefers **option B** (sweep safety-limit in this PR), say so and I'll extend.

## Doc

`docs/concepts/runtime/intervention-delivery.md` — the delivery rule, the resolution-is-existing / threading-is-the-fix framing, the failure sign, and the safety-limit follow-up note. `control-ir.md` needs no sync (bus-construction change, op catalog + `ask_user` contract unchanged). Sent to docs-maintainer for drift audit.

## Test plan
- [x] Automated: new Tier-2 suite passes; strip-falsify shows RED without the seam.
- [x] Regression: mcp/intervention/session/router_host suites green (1081 passed).
- [ ] (co-vet) confirm scope A vs B (safety-limit sibling).

Closes #3049
