### PR TITLE
fix: collapse embed() wire count 9->3 (max_retries, part of #3047)

### DIFF
--- a/src/reyn/data/embedding/litellm_provider.py
+++ b/src/reyn/data/embedding/litellm_provider.py
@@ -11,9 +11,13 @@ Supports:
     at the op because that is where `ctx.cancel_event` lives and because every
     embedding egress in the OS funnels through that op.
     The bound is a LATENCY invariant, not a COST one — it caps how long we
-    wait, not how many requests the provider receives (the OpenAI SDK client
-    retries underneath it: up to 3 per attempt, 9 across `max_retries: 3`).
-    See `_embed_batch_with_retry` for the measured detail and #3047.
+    wait, not how many requests the provider receives. The COST invariant
+    (#3047) is `max_retries=0` passed explicitly to every `litellm.aembedding`
+    call in `_aembedding_bounded`, so the OpenAI SDK client cannot silently
+    retry underneath reyn's own retry loop (unset -> litellm's
+    `DEFAULT_MAX_RETRIES` = 2 SDK-internal retries per attempt, 9 requests
+    across `max_retries: 3` instead of 3). See `_aembedding_bounded` for the
+    measured detail.
   - Exponential-backoff retry on transient errors
   - tiktoken-based token estimation with char-count fallback
   - Static dimension table with 1536 default for unknown models
@@ -366,14 +370,14 @@ class LiteLLMEmbeddingProvider:
         actually reads this knob at: one deadline for the whole attempt. Without the
         wrap, ``timeout: 60`` would silently mean up to 180s per attempt.
 
-        ★ SCOPE — this bounds WAITING, not SPENDING. It does not reduce how many
-        requests reach the provider: the SDK's internal retry sits UNDER this bound,
-        so one attempt can deliver up to 3 requests and ``max_retries: 3`` up to 9.
-        Against a fast-erroring provider all 9 were measured delivered in 7.6s with
-        the default 60.0s bound — i.e. the bound never engaged. Lowering it does not
-        lower that count. Reducing REQUESTS is a different lever (an explicit
-        ``max_retries=0`` to litellm, collapsing 9 -> 3) and an open decision in
-        #3047 — deliberately NOT bundled here.
+        ★ SCOPE — this bounds WAITING, not SPENDING. Left alone, the OpenAI SDK
+        client retries INTERNALLY under this bound (litellm's implicit
+        ``max_retries or DEFAULT_MAX_RETRIES`` -> 2), so one attempt could
+        deliver up to 3 requests and ``max_retries: 3`` up to 9 — measured, all
+        9 delivered in 7.6s against a fast-erroring provider with the default
+        60.0s bound never engaging. ``_aembedding_bounded`` closes that lever
+        with an explicit ``max_retries=0``, collapsing 9 -> 3: reyn's own retry
+        loop here is then the ONLY retry layer (#3047).
         """
         extra = _proxy_kwargs()
         # Strip provider prefix when routing via local proxy (mirrors call_llm)
@@ -431,7 +435,47 @@ class LiteLLMEmbeddingProvider:
         ``aembedding`` unbounded by forgetting to wrap it (the swept-missed shape
         that produced this bug). ``self._timeout is None`` = operator opted out
         (``embedding.timeout <= 0``) → the historical unbounded call, unchanged.
+
+        ``max_retries=0`` (#3047, measured): without it, litellm's
+        ``llms/openai/openai.py::OpenAIChatCompletion.embedding``'s
+        ``max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES`` turns our
+        omitted kwarg (``None``) into ``2``, which litellm hands to the OpenAI
+        SDK client as ``AsyncOpenAI(max_retries=2)`` — 1 initial + 2 SDK-internal
+        retries = 3 HTTP requests PER attempt of the retry loop above, i.e. 9 on
+        the wire for ``max_retries: 3``, all invisible to the ``attempt %d/%d``
+        log line.
+
+        ★ Passing ``max_retries=0`` as a kwarg ALONE does not fix this — ``0`` is
+        just as falsy as ``None``, so ``0 or litellm.DEFAULT_MAX_RETRIES`` lands
+        on ``2`` again (measured: still 9 requests). This is the SECOND ``x or
+        DEFAULT`` trap in the same code path (the first is the one that made the
+        omitted kwarg silently mean ``2`` in the first place) — passing our own
+        falsy value straight into it changes nothing. The fix has to defeat the
+        ``or`` itself: setting ``litellm.DEFAULT_MAX_RETRIES = 0`` makes the
+        right-hand side of that ``or`` resolve to ``0`` too, so ANY falsy
+        ``max_retries`` (ours, or a future omitted one) now correctly means "no
+        SDK-level retry" instead of silently reviving 2. Audited for blast
+        radius: reyn's chat-completion path (`llm.py`) always passes an
+        explicit non-``None`` ``num_retries`` into ``litellm.acompletion``,
+        which litellm maps to its own ``max_retries`` BEFORE this fallback would
+        ever run (`main.py`: ``if num_retries is not None: max_retries =
+        num_retries``) — so this global does not change chat's retry count, only
+        embedding's, which is exactly the intended scope. Set once, permanently
+        for the process (no per-call save/restore) — a temporal monkeypatch
+        would race concurrent litellm calls sharing this event loop; a
+        permanent process-wide 0 does not, because nothing in reyn ever relies
+        on the ``2`` fallback firing.
+
+        Passing ``max_retries=0`` explicitly as a kwarg too (redundant given the
+        above, kept for self-documentation): reyn's own retry loop above is then
+        the ONLY retry layer — 3 requests for 3 configured attempts, matching
+        what the operator's config says. This is the SPENDING lever (vs.
+        ``self._timeout``, the WAITING lever, above) — see #3047 for the
+        measured 9->3 wire count. Does not touch cost-tracking's
+        post-await-only recording (#3047 part b, separate follow-up).
         """
+        litellm.DEFAULT_MAX_RETRIES = 0
+        kwargs.setdefault("max_retries", 0)
         if self._timeout is None:
             return await litellm.aembedding(**kwargs)
         async with asyncio.timeout(self._timeout):

--- a/tests/test_embed_max_retries_wire_count_3047.py
+++ b/tests/test_embed_max_retries_wire_count_3047.py
@@ -17,6 +17,27 @@ see `_embed_batch_with_retry`'s docstring). The fix passes `max_retries=0`
 into every `litellm.aembedding(...)` call (`_aembedding_bounded`), making
 reyn's own retry loop the ONLY retry layer.
 
+**Blast-radius check (architect co-vet on #3054): does chat's wire count
+change too?** The fix also sets `litellm.DEFAULT_MAX_RETRIES = 0` — a
+process-wide global, not a per-call kwarg, since a falsy ``max_retries=0``
+kwarg alone revives the same ``x or DEFAULT`` trap. That global is read in
+exactly one place in the pinned litellm: `OpenAIChatCompletion.embedding()`'s
+``max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES``
+(`llms/openai/openai.py`). The sibling `OpenAIChatCompletion.completion()`
+method — chat's call path — never reads `litellm.DEFAULT_MAX_RETRIES` at
+all: it does ``inference_params.pop("max_retries", 2)``, and reyn's chat path
+(`llm.py`) always passes an explicit non-`None` `num_retries` into
+`litellm.acompletion`, which `litellm.main.py` maps onto `max_retries` in
+`optional_params` BEFORE `completion()` ever pops it — so the fallback
+literal `2` there is dead code for every reyn chat call, same as the global
+mutation is. `test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation`
+below drives ONE real `litellm.acompletion` call shaped like reyn's chat call
+site (explicit `num_retries`, `stream=False`) against the same
+request-counting server, once with the global at its untouched litellm
+default (2) and once forced to 0 (the fix's post-import state), and asserts
+the wire count is identical — closing the "discussed structurally, not
+driven" gap the architect flagged.
+
 **Why this needs a real request-counting server, not a mock.** A test that
 patches `litellm.aembedding` never exercises the OpenAI SDK client that does
 the amplifying — it would pass identically whether the fix is wired or not.
@@ -33,6 +54,7 @@ from __future__ import annotations
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+import litellm
 import pytest
 
 from reyn.data.embedding.litellm_provider import LiteLLMEmbeddingProvider
@@ -131,3 +153,48 @@ async def test_single_attempt_no_reyn_retry_delivers_exactly_one_request(
         await provider.embed(["hello"], "standard")
 
     assert counting_server.request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_acompletion_wire_count_unaffected_by_embed_global_mutation(
+    counting_server, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Tier 2: the embed fix's `litellm.DEFAULT_MAX_RETRIES = 0` global mutation
+    does not change chat's wire count (architect co-vet on #3054, driven not
+    inferred).
+
+    Drives ONE `litellm.acompletion(...)` call — shaped like reyn's real chat
+    call site in `llm.py` (explicit `num_retries=`, `stream=False`, routed at
+    a real local HTTP server via `api_base`, no monkeypatching of litellm or
+    of the call itself) — against the SAME request-counting server the embed
+    tests above use, once with `litellm.DEFAULT_MAX_RETRIES` at the untouched
+    litellm default (2, i.e. the state BEFORE any embed provider has run) and
+    once forced to 0 (the state AFTER `_aembedding_bounded` has run, since the
+    mutation is process-wide and permanent). If the two wire counts differ,
+    the embed fix's global has reached into chat's retry count and the fix
+    needs a different (non-global) shape.
+    """
+    import os
+
+    api_base = os.environ["LITELLM_API_BASE"]  # set by the counting_server fixture
+    counts: dict[int, int] = {}
+    for default_max_retries in (2, 0):
+        monkeypatch.setattr(litellm, "DEFAULT_MAX_RETRIES", default_max_retries)
+        counting_server.request_count = 0
+        with pytest.raises(litellm.exceptions.InternalServerError):
+            await litellm.acompletion(
+                model="openai/gpt-4o-mini",
+                messages=[{"role": "user", "content": "hi"}],
+                num_retries=3,  # same shape as llm.py's call_kwargs["num_retries"]
+                timeout=5.0,
+                stream=False,
+                api_base=api_base,
+            )
+        counts[default_max_retries] = counting_server.request_count
+
+    assert counts[2] == counts[0], (
+        f"chat's wire count changed with litellm.DEFAULT_MAX_RETRIES "
+        f"(2 -> {counts[2]} requests, 0 -> {counts[0]} requests) — the embed "
+        f"fix's global mutation is NOT scoped to embedding as intended"
+    )
+    assert counts[2] > 0, "sanity: the stand-in server must have been hit at all"

--- a/tests/test_embed_max_retries_wire_count_3047.py
+++ b/tests/test_embed_max_retries_wire_count_3047.py
@@ -1,0 +1,133 @@
+"""Tier 2: one `embed()` call puts `max_retries: 3` requests on the wire, not 9 (#3047).
+
+#3043 measured (cost-probe-coder, driven against a REAL localhost stand-in
+server, never a real provider) that `litellm.aembedding(...)` was called
+without `max_retries=`, so litellm's own
+`max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES` turned the missing
+kwarg into `2`, which litellm hands to the OpenAI SDK client as
+`AsyncOpenAI(max_retries=2)`. That client retries INTERNALLY, underneath
+reyn's own `_embed_batch_with_retry` loop: 1 initial + 2 SDK retries = 3 HTTP
+requests per reyn attempt, times reyn's configured `max_retries: 3` = **9
+requests delivered on the wire for one `embed()` call** — invisible to the
+`attempt %d/%d` log line, which only ever counts to 3.
+
+This is the COST lever (not #3043's LATENCY lever — `embedding.timeout`
+bounds how long a call WAITS, it does not reduce how many requests are SENT;
+see `_embed_batch_with_retry`'s docstring). The fix passes `max_retries=0`
+into every `litellm.aembedding(...)` call (`_aembedding_bounded`), making
+reyn's own retry loop the ONLY retry layer.
+
+**Why this needs a real request-counting server, not a mock.** A test that
+patches `litellm.aembedding` never exercises the OpenAI SDK client that does
+the amplifying — it would pass identically whether the fix is wired or not.
+So this test is a REAL `LiteLLMEmbeddingProvider` routed (via
+`LITELLM_API_BASE`, the provider's own production proxy knob — no
+monkeypatching of the provider or of litellm) at a REAL local HTTP server
+that answers every request with a retryable 500 instantly, and the server
+counts requests it actually received. Pre-fix this counts 9; post-fix, 3 —
+driven, not inferred. No real provider is contacted and no cost is spent
+(local socket only, per #3047's brief).
+"""
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from reyn.data.embedding.litellm_provider import LiteLLMEmbeddingProvider
+
+_MODEL = "openai/text-embedding-3-small"
+
+
+class _CountingRetryableErrorHandler(BaseHTTPRequestHandler):
+    """Answers every POST with a retryable 500 instantly — no stall, no delay.
+
+    A 500 is treated as transient by both the OpenAI SDK client's own retry
+    logic AND reyn's `_embed_batch_with_retry` `except Exception` catch-all,
+    so every request in both retry layers actually fires (nothing short-
+    circuits on a shape mismatch that would undercount the wire).
+    """
+
+    request_count = 0
+    _lock = threading.Lock()
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        self.rfile.read(length)  # drain the full body — a real delivered request
+        with _CountingRetryableErrorHandler._lock:
+            _CountingRetryableErrorHandler.request_count += 1
+        body = b'{"error": {"message": "stand-in 500", "type": "server_error"}}'
+        self.send_response(500)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):  # silence
+        pass
+
+
+@pytest.fixture
+def counting_server(monkeypatch: pytest.MonkeyPatch):
+    _CountingRetryableErrorHandler.request_count = 0
+    srv = HTTPServer(("127.0.0.1", 0), _CountingRetryableErrorHandler)
+    port = srv.server_address[1]
+    thread = threading.Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv("LITELLM_API_BASE", f"http://127.0.0.1:{port}")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-key-never-used")
+    try:
+        yield _CountingRetryableErrorHandler
+    finally:
+        srv.shutdown()
+        thread.join(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_one_embed_call_delivers_exactly_reyn_max_retries_requests(
+    counting_server,
+) -> None:
+    """Tier 2: `max_retries: 3` puts exactly 3 requests on the wire, not 9.
+
+    Pre-fix (no `max_retries=` passed to `litellm.aembedding`) this counted 9 —
+    3 reyn attempts x 3 OpenAI-SDK-internal retries each, all against the SAME
+    real local server counting real delivered requests.
+    """
+    provider = LiteLLMEmbeddingProvider(
+        {
+            "timeout": 5.0,
+            "max_retries": 3,
+            "retry_backoff": 1.0,  # 1.0^attempt == 1s sleeps; keeps the test quick
+            "classes": {"standard": _MODEL},
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="Embedding failed after 3 attempts"):
+        await provider.embed(["hello"], "standard")
+
+    assert counting_server.request_count == 3, (
+        f"expected 3 requests on the wire (reyn's own retry loop, SDK retry "
+        f"disabled), got {counting_server.request_count}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_attempt_no_reyn_retry_delivers_exactly_one_request(
+    counting_server,
+) -> None:
+    """Tier 2: with reyn's own retry loop disabled (`max_retries: 1`), exactly
+    ONE request reaches the wire — pre-fix the SDK's own hidden retry would
+    still have delivered 3 for this single reyn attempt."""
+    provider = LiteLLMEmbeddingProvider(
+        {
+            "timeout": 5.0,
+            "max_retries": 1,
+            "classes": {"standard": _MODEL},
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="Embedding failed after 1 attempts"):
+        await provider.embed(["hello"], "standard")
+
+    assert counting_server.request_count == 1


### PR DESCRIPTION
**[per-PR-coder]** — implements **(a)** of #3047: collapse one `embed()` call's wire count from **9 requests to 3**. Part b (cost-record timing semantics + consumer audit) is out of scope — architect designing separately, so this is `part of #3047`, not `Closes`.

## The bug (measured in #3047)

`_embed_batch_with_retry` calls `litellm.aembedding(...)` with **no** `max_retries=`. litellm's `llms/openai/openai.py::OpenAIChatCompletion.embedding` then runs:

```python
max_retries = max_retries or litellm.DEFAULT_MAX_RETRIES   # None -> 2
```

→ `AsyncOpenAI(max_retries=2)` = 1 initial + 2 SDK-internal retries = **3 HTTP requests per reyn attempt**, × reyn's own `max_retries: 3` loop = **9 requests on the wire**, all invisible to the `attempt %d/%d` log line (operator sees 3, wire carries 9). This is a **COST** lever, orthogonal to #3043's **LATENCY** bound (`embedding.timeout` caps waiting, not the request count — the SDK retry sits *under* that bound).

## The fix — and the second `or DEFAULT` trap

The obvious fix (`max_retries=0` as a kwarg) does **not** work: `0` is falsy, so `0 or litellm.DEFAULT_MAX_RETRIES` lands on `2` again (measured: still 9). This is the same `x or DEFAULT` pattern that caused the bug, firing twice in one path. So the fix sets:

```python
litellm.DEFAULT_MAX_RETRIES = 0
```

in `_aembedding_bounded` (the single chokepoint where the bound is already applied), making the `or`'s right-hand side `0` too — so any falsy `max_retries` correctly means "no SDK retry".

**Blast-radius audit**: reyn's chat-completion path (`llm.py`) always passes an explicit non-`None` `num_retries` into `litellm.acompletion`, which litellm maps to `max_retries` *before* this fallback would run (`main.py`: `if num_retries is not None: max_retries = num_retries`). So the global does not touch chat's retry count — only embedding's, which is exactly the intended scope. Set once process-wide (no per-call restore — a temporal patch would race concurrent litellm calls on the shared loop; nothing in reyn relies on the `2` fallback).

## Driven verification (9→3, real measurement, zero cost)

`tests/test_embed_max_retries_wire_count_3047.py` points a **real** `LiteLLMEmbeddingProvider` (via `LITELLM_API_BASE`, its own production proxy knob — no monkeypatching of provider or litellm) at a **real localhost HTTP server that counts delivered requests** and answers each with a retryable 500. No real provider, no spend.

- `max_retries: 3` → asserts **exactly 3** requests on the wire (pre-fix: 9)
- `max_retries: 1` → asserts **exactly 1** (pre-fix: 3 — the SDK's own hidden retry)

Falsify-checked: reverted the fix → both tests go **clean red** (`9 == 3` fails), restored → green. A mock-based test would pass either way (it never exercises the amplifying SDK client), which is why this drives a real socket.

## Gates (all green locally)
- `ruff check src tests` ✅
- `python scripts/test_tier_audit.py --strict tests/test_embed_max_retries_wire_count_3047.py` ✅ (2 Tier-2 tests OK)
- `python scripts/verify_module_docstrings.py src/reyn/data/embedding/litellm_provider.py` ✅
- `pytest` full suite ✅ 8803 passed, 24 skipped

## Test plan
- [x] Wire count 9→3 measured against localhost stand-in (driven, not inferred)
- [x] Falsify: tests go red on reverted fix
- [x] Blast-radius audit: chat path unaffected (explicit `num_retries` short-circuits the fallback)
- [x] Full suite green

part of #3047

🤖 Generated with [Claude Code](https://claude.com/claude-code)