### PR TITLE
fix: replace deleted phase-graph architecture narrative on website

### DIFF
--- a/website/_design/claude_design_prompt_architecture.md
+++ b/website/_design/claude_design_prompt_architecture.md
@@ -78,7 +78,7 @@ SECTION 01 — At a glance
         U(["User / External System"])
         subgraph I01["01 · Interface"]
             direction LR
-            CLI["CLI"] ~~~ TUI["TUI (Textual)"] ~~~ WEB["Web UI (FastAPI + WebSocket)"]
+            CLI["CLI"] ~~~ TUI["Inline CUI (terminal)"] ~~~ WEB["Web UI (FastAPI + WebSocket)"]
         end
         subgraph I02["02 · Agent Registry"]
             direction LR
@@ -94,11 +94,11 @@ SECTION 01 — At a glance
         end
         subgraph I05["05 · Skill"]
             direction LR
-            PG["Phase Graph + Transitions"] ~~~ FO["final_output_schema"] ~~~ PP["Postprocessor"]
+            L1["L1 · menu entry"] ~~~ L2["L2 · on-demand read"] ~~~ L3["L3 · bundled assets"]
         end
-        subgraph I06["06 · Phase"]
+        subgraph I06["06 · Control IR"]
             direction LR
-            PRE["Preprocessor"] ~~~ LO["LLM + Control IR ops"] ~~~ LP["↺ loops until transition/finish"]
+            OPV["Schema-validated op"] ~~~ PG2["Permission gate"] ~~~ DISP["Dispatch to tool/skill/pipeline/agent"]
         end
         subgraph I07["07 · Persistence"]
             direction LR
@@ -138,25 +138,21 @@ SECTION 03 — A request, end to end
     sequenceDiagram
         participant U as User
         participant A as Agent (ChatSession)
-        participant SK as Skill graph
-        participant PH as Phase loop
+        participant RL as RouterLoop
+        participant OS as OS (context · LLM · validation)
         participant WS as Workspace + Events
         U->>A: message
-        A->>A: RouterLoop picks Skill
-        A->>SK: invoke skill
-        SK->>PH: enter entry phase
-        loop Until transition or finish
-            PH->>PH: preprocessor (deterministic)
-            PH->>PH: LLM call (closed candidate set)
-            PH->>PH: validate output against schema
-            PH->>WS: execute Control IR ops · emit events
-            PH-->>SK: result + control decision
-            alt decision = transition
-                Note over SK: validate against next.input_schema
-                SK->>PH: enter next phase
+        A->>RL: dispatch turn
+        loop Bounded by force-close
+            RL->>OS: build context (incl. Skill instructions on demand)
+            OS->>OS: call LLM (closed candidate set)
+            OS->>OS: validate response as typed Control IR op
+            OS->>WS: dispatch op under permission gate · emit event
+            OS-->>RL: op result
+            alt decision = continue
+                Note over RL: pick next action — tool · skill read · delegate · pipeline
             else decision = finish
-                Note over SK: validate against final_output_schema
-                SK-->>A: final output
+                RL-->>A: final reply
             end
         end
         A-->>U: reply
@@ -201,11 +197,11 @@ SECTION 04 — Beyond a single agent
         end
         subgraph CLI2["MCP Client — implemented (stdio · HTTP)"]
             direction TB
-            PHASE["Reyn Phase (control_ir)"]
+            CTRL["Control IR (mcp op)"]
             MCIROP["MCPIROp  kind: mcp"]
             MCLIENT["MCPClient\nstdio / HTTP transport"]
             EXTMCP["External MCP Server"]
-            PHASE --> MCIROP --> MCLIENT --> EXTMCP
+            CTRL --> MCIROP --> MCLIENT --> EXTMCP
         end
     ```
 
@@ -282,7 +278,7 @@ Section 02 (The pieces):
 - {{ARCH_S02_NUM}}, {{ARCH_S02_LABEL}}, {{ARCH_S02_HEADING_HTML}}, {{ARCH_S02_BODY}}
 - {{ARCH_S02_C1_LABEL}}, {{ARCH_S02_C1_BODY}}  — Agent card
 - {{ARCH_S02_C2_LABEL}}, {{ARCH_S02_C2_BODY}}  — Skill card
-- {{ARCH_S02_C3_LABEL}}, {{ARCH_S02_C3_BODY}}  — Phase card
+- {{ARCH_S02_C3_LABEL}}, {{ARCH_S02_C3_BODY}}  — Control IR card
 - {{ARCH_S02_C4_LABEL}}, {{ARCH_S02_C4_BODY}}  — OS card
 - {{ARCH_S02_C5_LABEL}}, {{ARCH_S02_C5_BODY}}  — State card
 

--- a/website/architecture.html
+++ b/website/architecture.html
@@ -370,7 +370,7 @@ flowchart TB
     U(["User / External System"])
     subgraph I01["01 · Interface"]
         direction LR
-        CLI["CLI"] ~~~ TUI["TUI (Textual)"] ~~~ WEB["Web UI (FastAPI + WebSocket)"]
+        CLI["CLI"] ~~~ TUI["Inline CUI (terminal)"] ~~~ WEB["Web UI (FastAPI + WebSocket)"]
     end
     subgraph I02["02 · Agent Registry"]
         direction LR
@@ -386,11 +386,11 @@ flowchart TB
     end
     subgraph I05["05 · Skill"]
         direction LR
-        PG["Phase Graph + Transitions"] ~~~ FO["final_output_schema"] ~~~ PP["Postprocessor"]
+        L1["L1 · menu entry"] ~~~ L2["L2 · on-demand read"] ~~~ L3["L3 · bundled assets"]
     end
-    subgraph I06["06 · Phase"]
+    subgraph I06["06 · Control IR"]
         direction LR
-        PRE["Preprocessor"] ~~~ LO["LLM + Control IR ops"] ~~~ LP["↺ loops until transition/finish"]
+        OPV["Schema-validated op"] ~~~ PG2["Permission gate"] ~~~ DISP["Dispatch to tool/skill/pipeline/agent"]
     end
     subgraph I07["07 · Persistence"]
         direction LR
@@ -458,34 +458,28 @@ sequenceDiagram
     participant U as User
     participant A as Agent (ChatSession)
     participant PL as Planner (optional)
-    participant SK as Skill graph
-    participant PH as Phase loop
+    participant RL as RouterLoop
+    participant OS as OS (context · LLM · validation)
     participant WS as Workspace + Events
     U->>A: message
     alt Complex multi-step request
         A->>PL: plan_task(goal)
         PL-->>A: Plan { steps: [S1, S2, ...] }
-        Note over A: each step → skill invocation
+        Note over A: each step → an action below
     else Simple request
-        Note over A: RouterLoop picks Skill directly
+        Note over A: RouterLoop decides directly
     end
-    A->>SK: invoke skill
-    SK->>PH: enter entry phase
-    loop Until transition or finish
-        PH->>PH: preprocessor (deterministic)
-        PH->>PH: LLM call (closed candidate set)
-        PH->>PH: validate output against schema
-        PH->>WS: execute Control IR ops · emit events
-        PH-->>SK: result + control decision
-        alt decision = transition
-            Note over SK: validate against next.input_schema
-            SK->>PH: enter next phase
+    A->>RL: dispatch turn
+    loop Bounded by force-close
+        RL->>OS: build context (incl. Skill instructions on demand)
+        OS->>OS: call LLM (closed candidate set)
+        OS->>OS: validate response as typed Control IR op
+        OS->>WS: dispatch op under permission gate · emit event
+        OS-->>RL: op result
+        alt decision = continue
+            Note over RL: pick next action — tool · skill read · delegate · pipeline
         else decision = finish
-            Note over SK: validate against final_output_schema
-            opt postprocessor declared (skill-level)
-                SK->>WS: postprocessor steps · emit events
-            end
-            SK-->>A: final output
+            RL-->>A: final reply
         end
     end
     A-->>U: reply
@@ -541,11 +535,11 @@ flowchart LR
     end
     subgraph CLI2["MCP Client — implemented (stdio · HTTP)"]
         direction TB
-        PHASE["Reyn Phase (control_ir)"]
+        CTRL["Control IR (mcp op)"]
         MCIROP["MCPIROp  kind: mcp"]
         MCLIENT["MCPClient\nstdio / HTTP transport"]
         EXTMCP["External MCP Server"]
-        PHASE --> MCIROP --> MCLIENT --> EXTMCP
+        CTRL --> MCIROP --> MCLIENT --> EXTMCP
     end
         </div>
       </div>

--- a/website/copy.yaml
+++ b/website/copy.yaml
@@ -69,14 +69,14 @@ S01_BODY_HTML: >-
 # ── section 02: How it works ────────────────────────────────────────────────
 S02_NUM: "02"
 S02_LABEL: "How it works"
-S02_HEADING_HTML: "A skill graph, <em>conducted.</em>"
+S02_HEADING_HTML: "Every action, <em>typed.</em>"
 S02_BODY_P1: >-
-  A Skill is a directed graph of Phases. Each Phase declares its input
-  contract and runs to completion under a permission scope you control.
+  The LLM decides what to do next — call a tool, read a Skill's
+  instructions, delegate to another agent. Every decision becomes a
+  schema-validated Control IR op before it touches the world.
 S02_BODY_P2: >-
-  The LLM picks only from candidates the OS provides. Output is validated
-  against the next Phase's input schema. Workspace and Events make every
-  step replayable.
+  The OS dispatches the op under a permission gate you control. Workspace
+  and Events make every step inspectable and replayable.
 
 # ── section 03: Key concepts ────────────────────────────────────────────────
 S03_NUM: "03"
@@ -90,10 +90,10 @@ S03_C1_BODY: >-
   set of Skills it can invoke.
 
 S03_C2_LABEL: "Skill"
-S03_C2_TITLE: "A graph of phases."
+S03_C2_TITLE: "Instructions the model reads."
 S03_C2_BODY: >-
-  A directed graph plus a final-output schema. The OS routes work between
-  Phases based on LLM decisions and validated artifacts.
+  A folder the model chooses to open, not a program the OS executes —
+  a menu entry, an on-demand full read, and the assets it bundles.
 
 S03_C3_LABEL: "OS"
 S03_C3_TITLE: "An auditable runtime."
@@ -130,9 +130,10 @@ ARCH_S01_LABEL: "At a glance"
 ARCH_S01_HEADING_HTML: "The whole system,<br/>on one <em>page.</em>"
 ARCH_S01_BODY: >-
   Reyn is built from a small set of components. Agents hold long-lived
-  conversations. Skills describe directed phase graphs. Phases loop the LLM
-  through one task at a time. The OS runs everything under a strict
-  validation contract. Workspace and Events make every step inspectable
+  conversations and route each decision through a RouterLoop. Skills are
+  instructions the model reads on demand, not phase graphs the OS executes.
+  Every LLM decision becomes a typed Control IR op, validated and dispatched
+  under a permission gate. Workspace and Events make every step inspectable
   and replayable.
 
 # ── section 02: the pieces ──────────────────────────────────────────────────
@@ -140,9 +141,9 @@ ARCH_S02_NUM: "02"
 ARCH_S02_LABEL: "The pieces"
 ARCH_S02_HEADING_HTML: "Five components.<br/>Sharp <em>boundaries.</em>"
 ARCH_S02_BODY: >-
-  Each component has one job. Agents don't know about Phases.
-  Phases don't know about Skills. The OS is the only layer that touches
-  all of them — and it never embeds skill-specific logic.
+  Each component has one job. Agents don't know how a Skill's
+  instructions are written. The OS is the only layer that touches all of
+  them — and it never embeds skill-specific logic.
 
 ARCH_S02_C1_LABEL: "Agent"
 ARCH_S02_C1_BODY: >-
@@ -152,15 +153,15 @@ ARCH_S02_C1_BODY: >-
 
 ARCH_S02_C2_LABEL: "Skill"
 ARCH_S02_C2_BODY: >-
-  A directed graph of Phases. Owns the entry phase, the allowed
-  transitions, and the final-output schema. Cycles are first-class —
-  revision loops are a feature, not a workaround.
+  Layered-disclosure instructions the model chooses to read — a one-line
+  menu entry, an on-demand full read, and bundled assets. Not a program
+  the OS executes.
 
-ARCH_S02_C3_LABEL: "Phase"
+ARCH_S02_C3_LABEL: "Control IR"
 ARCH_S02_C3_BODY: >-
-  The execution unit. Declares an input contract and instructions, runs a
-  preprocessor, calls the LLM, dispatches Control IR ops. Loops until it
-  decides to transition or finish.
+  The typed contract. Every LLM decision — a tool call, a skill read, a
+  delegation — becomes a schema-validated op before it touches the world.
+  No side effect ever rides a free-form string.
 
 ARCH_S02_C4_LABEL: "OS"
 ARCH_S02_C4_BODY: >-
@@ -179,13 +180,14 @@ ARCH_S03_NUM: "03"
 ARCH_S03_LABEL: "A request, end to end"
 ARCH_S03_HEADING_HTML: "From message<br/>to <em>reply.</em>"
 ARCH_S03_BODY: >-
-  A user message arrives at an Agent. The RouterLoop picks a Skill.
-  The OS enters the entry Phase, runs its preprocessor, calls the LLM
-  with a closed candidate set, and validates the response. Control IR ops
-  are dispatched under permission gates and write to the Workspace.
-  An event records each step. The Phase either transitions to a peer or
-  finishes; the OS validates the final output against the Skill's schema
-  and the reply travels back to the user.
+  A user message arrives at an Agent. The RouterLoop decides what to do —
+  call a tool, read a Skill's instructions, or delegate to another agent.
+  The OS builds context, calls the LLM with a closed candidate set, and
+  validates the response as a typed Control IR op. The op dispatches
+  under a permission gate and writes to the Workspace; an event records
+  each step. The loop continues, bounded by force-close, until the
+  RouterLoop decides the turn is done, and the reply travels back to the
+  user.
 
 # ── section 04: beyond a single agent ───────────────────────────────────────
 ARCH_S04_NUM: "04"


### PR DESCRIPTION
**[per-PR-coder]** — part of #2747.

## Scope

#2747 flagged that the public website ("How it works" / `architecture.html`)
describes the **removed phase-graph skill engine** (Skill = directed graph of
Phases, a Phase execution unit that loops the LLM through transitions) as
reyn's current architecture. This PR is the **mechanical drift fix**: it
replaces the false mechanism description with an accurate summary of the
**current, already-canonical** architecture — it does not invent a new
narrative or make a product-positioning call.

**Canonical source used**: `docs/concepts/architecture/charter.md` (the 8×7
lens table, referenced from `CLAUDE.md` § Constitution) and
`docs/concepts/agent-engineering/system-design.md` ("The layer split: LLM
decides, OS executes, feature owns its own domain" — RouterLoop dispatch,
typed Control IR ops through a permission gate, Skills as layered-disclosure
instructions the model chooses to read, not a program the OS executes).

#2747's own framing explicitly gates the larger "how should we tell this
story" redesign on owner/architect judgment — that part is **not** done here
and stays open on #2747 (not closing the issue).

## What changed

- `website/copy.yaml`: S02 ("How it works"), S03 key-concept card for Skill,
  and the `ARCH_*` tokens for `architecture.html` sections 01–03.
- `website/architecture.html`: the "05 · Skill" / "06 · Phase" mermaid nodes
  (now "05 · Skill" layered-disclosure L1/L2/L3, "06 · Control IR"
  schema-validate → permission-gate → dispatch), the end-to-end sequence
  diagram (RouterLoop → OS context/LLM/validate → dispatch, replacing the
  Skill-graph/Phase-loop actors), and the MCP-client diagram's stale
  `Reyn Phase (control_ir)` node → `Control IR (mcp op)`.
- Also fixed, in the same diagram section: a stale `TUI (Textual)` label —
  the Textual-based TUI was fully replaced by the inline CUI (per
  `docs/feature-map.md` § Inline CUI) — found while re-reading the whole
  touched section per the CLAUDE.md doc-drift rule, not just the
  phase-graph keyword.
- `website/_design/claude_design_prompt_architecture.md`: the Claude Design
  regeneration prompt carried the identical stale diagram code and card
  labels; updated in the same PR so a future regeneration from this prompt
  doesn't reintroduce the same drift.

## Verification

- `python website/build.py` — clean build, 0 missing-token warnings.
- Extracted all 4 mermaid blocks from the built `architecture.html` and
  rendered each with `mmdc` (mermaid-cli) — all 4 render without error;
  spot-checked the new labels (`Control IR`, `Inline CUI`, `RouterLoop`,
  `Bounded by force-close`) actually appear in the output SVGs.
- `grep -n "phase-graph\|Phase Graph\|Phase\b\|Textual"` over the three
  touched files returns no hits.

## Test plan

- [x] `python website/build.py` builds cleanly with no missing-token warnings
- [x] All 4 mermaid diagrams in `architecture.html` render without syntax
      error (mmdc)
- [x] Grep for residual phase-graph/Textual references in touched files
      returns empty

## Requesting review

docs-maintainer — please co-vet for drift (does the new copy actually match
`charter.md` / `system-design.md`, does anything else in the touched
sections still reference the removed engine).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>