### PR TITLE
fix: refresh a spawned session's MCP roster at its own action-boundary (part of #3036)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2957,13 +2957,35 @@ class AgentRegistry:
             presentation_consumer=presentation_consumer,
             intervention_bridge=intervention_bridge,
         )
+        # #3036: every programmatic spawn funnels through here (agent-step ephemeral
+        # workers via spawn_ephemeral_session, pipeline driver-sessions via
+        # _spawn_pipeline_driver_session — mode="persistent" — and delegate_to_agent's
+        # session_spawn tool). None of these callers ever fire a "turn boundary" of
+        # their own BEFORE their first programmatic step runs — that trigger is a
+        # RouterLoopDriver-only chat-turn concept (Session._run_router_loop), and the
+        # spawned session's config-derived projections (MCP roster first — the family's
+        # other 9 reapply seams are latent until each is independently driven-verified
+        # safe off the chat turn boundary, see #3036) are otherwise frozen at whatever
+        # the (baked-once-at-registry-construction) session_factory closure captured —
+        # stale even for a server installed (mcp_install writes the IN-set
+        # .reyn/config/mcp.yaml) moments before THIS spawn. Reading it fresh here — the
+        # spawned session's own action-boundary (invariant: "programmatic/ephemeral
+        # sessions refresh at spawn + before each dispatch", #3036 architect verdict) —
+        # closes the gap the RAG turnkey flow hit 100%: install (chat session) always
+        # precedes the pipeline-driver/agent-step spawn that consumes it, so a
+        # spawn-time refresh alone is sufficient (no mid-run re-spawn case exists on
+        # this path). ``refresh_mcp_servers`` never raises (documented contract) — no
+        # try/except needed. Best-effort no-op when the peeked session is somehow gone
+        # (should not happen — spawn_session above just constructed it).
+        spawned_session = self._peek_session(name, sid)
+        if spawned_session is not None:
+            await spawned_session.refresh_mcp_servers()
         if mode == "ephemeral":
             # #2103: mark the live session so it auto-vanishes once its task is done
             # (Session._maybe_schedule_ephemeral_vanish, via this registry's
             # remove_session teardown seam). Persistent spawns leave the flag False.
-            ephemeral_session = self._peek_session(name, sid)
-            if ephemeral_session is not None:
-                ephemeral_session._ephemeral = True
+            if spawned_session is not None:
+                spawned_session._ephemeral = True
                 # #2585 PR2: an ephemeral spawn is structurally headless — it
                 # receives exactly ONE prompt via MessageBus.request (see
                 # session_api.run_agent_step) and returns; there is no
@@ -2974,7 +2996,7 @@ class AgentRegistry:
                 # have a real user eventually) so the worker always lands on
                 # the "proceed with assumption" SP branch instead of wasting
                 # its one turn asking a question no one can answer.
-                ephemeral_session._non_interactive = True
+                spawned_session._non_interactive = True
         if narrowing:
             import yaml
             cfg_path = self._session_state_dir(name, sid) / "config.yaml"

--- a/tests/test_2597_s2a_mcp_connection_service.py
+++ b/tests/test_2597_s2a_mcp_connection_service.py
@@ -189,14 +189,34 @@ async def test_remove_session_teardown_closes_held_connections(tmp_path: Path):
     """Tier 2: registry.remove_session's teardown seam closes any MCP connections a
     spawned session held open (#2597 S2a wiring) — a dropped/rewound session must not
     leak an open subprocess. Real AgentRegistry + real spawned session + real stdio
-    server (no mocks)."""
+    server (no mocks).
+
+    #3036: ``spawn_session_recorded`` now refreshes the spawned session's MCP roster
+    from the on-disk config cascade right after construction (closing the "spawned
+    session's roster frozen at the registry's boot-time session_factory snapshot"
+    gap) — so ``srv`` must be written to the IN-set ``.reyn/config/mcp.yaml`` under
+    THIS registry's ``project_root`` (not merely passed via the factory's in-memory
+    ``mcp_servers=`` kwarg), and the factory must thread ``registry=`` through so the
+    spawned session resolves that same root (mirrors every real frontend factory).
+    Otherwise the #3036 refresh would read an empty/foreign cascade and wipe the
+    in-memory-only ``srv`` entry before this test ever calls it."""
+    import yaml
+
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
 
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    cfg_path = tmp_path / ".reyn" / "config" / "mcp.yaml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(yaml.safe_dump({"mcp": {"servers": {"srv": _CFG}}}), encoding="utf-8")
+
+    holder: dict = {}
+
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
-        return Session(agent_name=profile.name, mcp_servers={"srv": _CFG})
+        return Session(agent_name=profile.name, mcp_servers={"srv": _CFG}, registry=holder.get("reg"))
 
     registry = AgentRegistry(project_root=tmp_path, session_factory=_factory)
+    holder["reg"] = registry
     registry.create("s2a-owner")
     sid = await registry.spawn_session_recorded("s2a-owner", mode="persistent", presentation_consumer=None, intervention_bridge=None)
     session = registry._peek_session("s2a-owner", sid)

--- a/tests/test_3036_spawned_session_mcp_refresh.py
+++ b/tests/test_3036_spawned_session_mcp_refresh.py
@@ -1,0 +1,162 @@
+"""Tier 2: #3036 — a programmatically-spawned session's MCP roster is fresh at spawn, not
+frozen at the registry's boot-time session_factory closure.
+
+Root cause (dogfood-coder, #3036, 100% reproduction): `refresh_mcp_servers()` (the
+`#2372` roster re-read + tool-probe chain) previously fired ONLY from
+`Session._run_router_loop`'s turn-boundary hook (chat's per-user-message hot-reload
+safe-point). A session `AgentRegistry.spawn_session_recorded` spawns programmatically
+— an `agent`-step ephemeral worker (`spawn_ephemeral_session`), a pipeline
+driver-session (`_spawn_pipeline_driver_session`, `mode="persistent"`), or a
+`delegate_to_agent` sub-agent — never fires that chat-turn-boundary event itself, so
+its `_mcp_servers` stayed whatever the registry's `session_factory` closure captured
+at REGISTRY construction (boot time), even for a server `mcp_install` wrote to the
+IN-set `.reyn/config/mcp.yaml` moments before this exact spawn (the RAG turnkey flow:
+install in the chat session, then `pipeline__run` spawns the ingest driver-session —
+topology-confirmed as ALWAYS two sessions with install strictly preceding the spawn,
+never a mid-run mutation of an already-spawned session, so a spawn-time-only refresh
+is sufficient for this family member).
+
+Fix: `AgentRegistry.spawn_session_recorded` now calls `spawned_session.
+refresh_mcp_servers()` right after construction (before returning the sid to the
+caller), for every mode — the single funnel all three programmatic-spawn call sites
+share.
+
+Mirrors `tests/test_mcp_hot_reload_2372.py`'s pattern (install to the IN-set, assert
+via the public `_router_host.get_mcp_servers()` router-facing enumeration) but drives
+it through a REAL `AgentRegistry.spawn_session_recorded` — the actual production
+call path every ephemeral/driver/delegate spawn takes — rather than calling
+`refresh_mcp_servers()` directly (which would not exercise the fix at all).
+
+FALSIFY: revert the `await spawned_session.refresh_mcp_servers()` call added to
+`spawn_session_recorded` → the spawned session's roster stays whatever the registry's
+session_factory captured at construction (empty, in this test's factory) even though
+the server was installed to disk before the spawn — RED.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+
+def _install_server_in_config(project_root: Path, name: str) -> None:
+    """Write a new MCP server to the IN-set `.reyn/config/mcp.yaml` — where
+    `mcp_install` writes, mirroring the RAG SKILL.md's `mcp__install_local` flow."""
+    cfg = project_root / ".reyn" / "config" / "mcp.yaml"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(
+        yaml.safe_dump({"mcp": {"servers": {name: {"command": "/nonexistent", "description": "d"}}}}),
+        encoding="utf-8",
+    )
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """A registry whose `session_factory` — mirroring every real frontend's boot-time
+    closure (`registry_bootstrap.py`, `scoped_session_factory.py`) — captures the
+    MCP roster ONCE, before any install happens. Every session it constructs
+    (main + every programmatic spawn) starts with this EMPTY snapshot; only the fix
+    under test (a spawn-time `refresh_mcp_servers()` call) can make a freshly
+    spawned session see a server installed after the registry was built."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=False,
+            mcp_servers={},  # the boot-time snapshot: no servers yet
+        )
+        s.register_intervention_listener("test")
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("alice", role="").save(tmp_path / ".reyn" / "agents" / "alice")
+    return reg
+
+
+def _server_names(session: Session) -> list[str]:
+    return [s["name"] for s in session._router_host.get_mcp_servers()]
+
+
+@pytest.mark.asyncio
+async def test_ephemeral_spawn_sees_server_installed_before_spawn(tmp_path, monkeypatch):
+    """Tier 2: #3036 — an `agent`-step ephemeral worker (`mode="ephemeral"`, the
+    `spawn_ephemeral_session` path) enumerates a server installed to the IN-set BEFORE
+    the spawn, with no restart and no explicit `refresh_mcp_servers()` call from the
+    test — the registry's spawn seam must do it. RED if the spawn-time refresh is
+    reverted (the ephemeral worker would inherit the factory's empty boot-time
+    snapshot forever, reproducing the dogfood-observed `mcp_servers={}`)."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")  # the live main session — pre-existing, unaffected
+
+    _install_server_in_config(tmp_path, "reyn_chunker")  # disk write BEFORE the spawn
+
+    eph_sid = await reg.spawn_session_recorded(
+        "alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None,
+    )
+    eph = reg._peek_session("alice", eph_sid)
+
+    assert "reyn_chunker" in _server_names(eph), (
+        "an ephemeral agent-step worker must see a server installed before its own "
+        "spawn — its MCP roster must not be frozen at the registry's boot-time "
+        "session_factory snapshot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_persistent_driver_session_spawn_sees_server_installed_before_spawn(tmp_path, monkeypatch):
+    """Tier 2: #3036 — the SAME gap, `mode="persistent"` — the pipeline driver-session
+    path (`_spawn_pipeline_driver_session`, the session that actually runs
+    `rag_ingest.ingest`'s X1 pre-flight `call_mcp_tool` steps) is NOT the
+    `spawn_ephemeral_session` wrapper the #3036 architect verdict named as the hook
+    point — it calls `registry.spawn_session_recorded(mode="persistent")` directly.
+    Scoping the fix to `mode == "ephemeral"` only would leave the actual RAG-flow
+    session (persistent) still stale. RED if the fix is narrowed to the ephemeral
+    branch instead of covering every `spawn_session_recorded` call unconditionally."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("alice")
+
+    _install_server_in_config(tmp_path, "reyn_vector_store")
+
+    driver_sid = await reg.spawn_session_recorded(
+        "alice", mode="persistent", presentation_consumer=None, intervention_bridge=None,
+    )
+    driver = reg._peek_session("alice", driver_sid)
+
+    assert "reyn_vector_store" in _server_names(driver), (
+        "a persistent driver-session spawn (the pipeline driver's own mode) must see "
+        "a server installed before its spawn — the fix must not be scoped to "
+        "mode == 'ephemeral' only"
+    )
+
+
+@pytest.mark.asyncio
+async def test_preexisting_main_session_is_not_retroactively_refreshed_by_a_later_spawn(tmp_path, monkeypatch):
+    """Tier 2: #3036 — the fix is scoped to the NEWLY spawned session only; it must not
+    reach back and refresh the pre-existing main/caller session as a side effect (that
+    remains the chat turn-boundary's job, unchanged by this PR). Proves no accidental
+    over-broad refresh was introduced."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    main = reg.get_or_load("alice")
+    assert _server_names(main) == []  # boot-time empty snapshot, no turn has run yet
+
+    _install_server_in_config(tmp_path, "reyn_markitdown")
+    await reg.spawn_session_recorded(
+        "alice", mode="ephemeral", presentation_consumer=None, intervention_bridge=None,
+    )
+
+    assert _server_names(main) == [], (
+        "spawning a child session must not retroactively refresh the pre-existing "
+        "main session's own MCP roster — that stays the chat turn-boundary's job"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — MCP-first land fixing the config-refresh root cause behind the `#2955` RAG-turnkey umbrella. architect verdict: #3036 latest comment ((A), invariant reframed, MCP-first sequencing).

Closes #3036

## Root cause (unchanged from dogfood's finding, confirmed live in code)

`Session.refresh_mcp_servers()` (session.py:3755) previously fired ONLY from the chat turn-boundary (`_run_router_loop` → `self._hot_reloader.apply_pending()`, session.py:6949 — a `RouterLoopDriver`-only event). Every programmatic spawn (`AgentRegistry.spawn_session_recorded`) never fires that event on itself before its first dispatch, so its `_mcp_servers` stayed whatever the registry's `session_factory` closure captured at REGISTRY construction (boot time) — stale even for a server `mcp_install` had just written to the IN-set `.reyn/config/mcp.yaml` moments before the spawn.

## ★ Topology confirmation (the architect's requested check)

**Install and use are always TWO sessions, install strictly BEFORE spawn — never a same-session mid-run mutation.** Traced the actual call path:
- `mcp__install_local` is a router TOOL call — only reachable from a `RouterLoopDriver`-driven session (the calling chat session). It is never a pipeline step and an `agent`-step worker cannot reach `pipeline__run`/`run_pipeline` (structurally denied, `_DELEGATION_DENY_TOOLS`, session_api.py:133).
- `rag_ingest.ingest`'s `call_mcp_tool` steps (the X1 pre-flight) run on a NEW `PipelineExecutorDriver`-backed session, spawned by `_spawn_pipeline_driver_session` (session_api.py:369, `mode="persistent"` — **not** the `spawn_ephemeral_session` wrapper the architect's verdict named as the hook point).

So ONE hook point is not enough: `spawn_ephemeral_session` alone would miss the actual RAG-flow session (the pipeline driver, mode="persistent"). Since install always precedes the spawn (confirmed: no code path lets an agent-step or pipeline-driver session both install AND consume in the same run), a spawn-time-only refresh is sufficient — no mid-run re-spawn case exists on this path.

## Fix

`AgentRegistry.spawn_session_recorded` (registry.py:2931) — the single funnel ALL THREE programmatic-spawn call sites share (`spawn_ephemeral_session`, `_spawn_pipeline_driver_session`, and the LLM's `session_spawn`/`delegate_to_agent` tool via `router_host_adapter.py:1137`) — now calls `spawned_session.refresh_mcp_servers()` right after construction, unconditionally (not scoped to `mode == "ephemeral"`). One hook point covers the actual RAG-flow session correctly, closing the gap the earlier hook-point suggestion would have missed.

## Family scope (explicitly NOT in this PR)

Per the architect's #3055-lesson-applied sequencing: MCP is read-only/idempotent-safe to sweep now. The other 9 `_register_hot_reload_seams` members (cron / hooks / new_agent / per_agent_capability / pipelines / presentations / skill_visibility / skills / visibility_override) are NOT touched here — `_reapply_cron` and `_reapply_new_agent` in particular have side-effect/reentrancy profiles that need their own per-seam driven safety check before joining a spawn-time family sweep. Flagging as latent, tracked against `#3036` / a new issue — not silently dropped.

## Tests (Tier 2, real AgentRegistry + real Session, no mocks)

`tests/test_3036_spawned_session_mcp_refresh.py` — 3 new tests, falsify-verified (reverting the fix flips 2 of them RED):
1. an `agent`-step ephemeral worker sees a server installed to the IN-set before its own spawn
2. **the persistent pipeline-driver-session mode** sees the same (proving the fix is not narrowed to `mode == "ephemeral"` — this is the actual RAG-flow session type)
3. a pre-existing main session is NOT retroactively refreshed by a later child spawn (scope containment)

`tests/test_2597_s2a_mcp_connection_service.py` — one pre-existing test's factory relied on an in-memory-only `mcp_servers=` dict never backed by disk config; the new spawn-time refresh (correctly) reads the real cascade and would otherwise wipe it. Fixed by giving the test's session a `registry=` reference (mirroring every real frontend factory) and writing the matching IN-set `.reyn/config/mcp.yaml` — the test's actual subject (held-connection teardown) is unaffected.

## CI gates run locally

`ruff check src tests` / `python scripts/test_tier_audit.py --strict <changed test files>` / `pytest` (8812 passed, 29 skipped, 0 failed) / `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py` — all green.

## Scope note

Closes #3036 (the config-refresh root-cause issue). It does NOT close the `#2955` umbrella — `#2955`'s P4 end-to-end (a real `banana`-query result through the full turnkey flow) still needs separate live/dogfood verification, not claimed here.
