### PR TITLE
fix: surface the real RAG pre-flight probe exception instead of a static "unreachable"

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -566,6 +566,18 @@ not any one branch's result directly.
 | `on_error` | no | One of `continue`, `abort` (the default when omitted — unlike `for_each`, where `on_error` is required), or `retry(N)` — same semantics as `for_each`'s `on_error`. A `continue`-dropped branch's key is absent from `collect`'s named map. |
 | `output` | no | Named store to write `collect`'s result to. |
 
+When at least one branch actually dropped (`on_error: continue`), `collect`'s
+named map ALSO carries a reserved `__branch_errors__` entry — `{branch_name:
+error_text}` for every dropped branch, the failing branch's own error text
+(e.g. a `verify: schema` failure names the tool's own `error`/`content` when
+the result carried one, not just which field mismatched) — so `collect` can
+report **why** a branch failed, not just that it did (a schema-gated
+reachability probe like the builtin RAG ingest pipeline's X1 pre-flight reads
+`get(pipe, "__branch_errors__.<name>", "")` for this). Absent entirely when no
+branch dropped — a `collect` step that never loses a branch sees no shape
+change. A branch may not be named `__branch_errors__` (parse error) since it
+would collide with this reserved key.
+
 Each branch's context is `{ctx, pipe}` — `ctx` an isolated copy of the outer
 named stores, `pipe` this step's own incoming pipe data held constant across
 every branch. There is no `item`/`acc` (those are `for_each`/`fold`-only) and

--- a/src/reyn/builtin/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/pipelines/rag_ingest.yaml
@@ -172,23 +172,41 @@ steps:
               tool_args: !expr "{db_path: ctx.output_db, limit: 1}"
       collect:
         transform:
+          # #3070: a branch is dropped on ANY failure of its `tool` step --
+          # including the "handshake ok, the PROBE TOOL CALL ITSELF errored"
+          # case (e.g. a missing `pip install "reyn[builtin-rag]"` extra
+          # raising ImportError inside the server, or a bad tool arg) -- which
+          # is a DIFFERENT fact than "the MCP server is unreachable" and was
+          # previously indistinguishable from it. `get(pipe, "__branch_errors__.<name>",
+          # "")` (executor.py's PARALLEL_BRANCH_ERRORS_KEY) reads the real
+          # cause text a dropped branch's schema-validation-failure exception
+          # now carries (`_run_tool_step`'s tool-result detail, #3070) --
+          # empty string for a branch that never dropped.
           value: >-
-            {markitdown: get(pipe, "markitdown", null) != null,
-             chunker: get(pipe, "chunker", null) != null,
-             vectorstore: get(pipe, "vectorstore", null) != null}
+            {markitdown: {ok: get(pipe, "markitdown", null) != null, cause: get(pipe, "__branch_errors__.markitdown", "")},
+             chunker: {ok: get(pipe, "chunker", null) != null, cause: get(pipe, "__branch_errors__.chunker", "")},
+             vectorstore: {ok: get(pipe, "vectorstore", null) != null, cause: get(pipe, "__branch_errors__.vectorstore", "")}}
       output: reachable
   - transform:
       value: >-
-        [{name: "markitdown (" + ctx.markitdown_server + ")", ok: ctx.reachable.markitdown, remedy: ctx.remedies.markitdown},
-         {name: "chunker (" + ctx.chunker_server + ")", ok: ctx.reachable.chunker, remedy: ctx.remedies.chunker},
-         {name: "vectorstore (" + ctx.vectorstore_server + ")", ok: ctx.reachable.vectorstore, remedy: ctx.remedies.vectorstore}]
+        [{name: "markitdown (" + ctx.markitdown_server + ")", ok: ctx.reachable.markitdown.ok, remedy: ctx.remedies.markitdown, cause: ctx.reachable.markitdown.cause},
+         {name: "chunker (" + ctx.chunker_server + ")", ok: ctx.reachable.chunker.ok, remedy: ctx.remedies.chunker, cause: ctx.reachable.chunker.cause},
+         {name: "vectorstore (" + ctx.vectorstore_server + ")", ok: ctx.reachable.vectorstore.ok, remedy: ctx.remedies.vectorstore, cause: ctx.reachable.vectorstore.cause}]
       output: preflight_checks
   - transform:
       value: "count(filter(ctx.preflight_checks, c -> not c.ok)) == 0"
       output: preflight_ok
+  # The real per-server cause (#3070) is appended to its remedy, never
+  # replacing it: the remedy still names the concrete install/config step,
+  # and the cause is the EVIDENCE the failed branch actually reported --
+  # "install not done" vs "misconfigured" vs "transport fault" now read
+  # differently instead of collapsing into one static "is unreachable" string.
   - transform:
       value: >-
-        join(map(filter(ctx.preflight_checks, c -> not c.ok), c -> c.name + ": " + c.remedy), "\n\n")
+        join(map(filter(ctx.preflight_checks, c -> not c.ok),
+                 c -> c.name + ": " + c.remedy +
+                      join(map(filter([{fired: c.cause != "", text: "\n\n[actual error observed] " + c.cause}], f -> f.fired), f -> f.text), "")),
+             "\n\n")
       output: preflight_message
 
   # ---- gate: only proceed to the real ingest work if every server probed

--- a/src/reyn/core/op_runtime/mcp.py
+++ b/src/reyn/core/op_runtime/mcp.py
@@ -152,9 +152,18 @@ async def _execute(op: MCPIROp, ctx: OpContext) -> dict:
             media_blocks.append(item)
 
     is_error = bool(result.get("isError"))
+    # #3070: an errored tool call previously logged ONLY the boolean — the tool's
+    # own error text (e.g. "Error calling tool 'list_metadata': No module named
+    # 'apsw'") lived in `text` above but was never audited, so a probe failure
+    # was indistinguishable, from the P6 audit log alone, from any other error.
+    # `mcp_failed` (the transport-fault branch above) already carries `error`
+    # in full — this mirrors it for the "handshake ok, tool call itself errored"
+    # case, which is a DIFFERENT failure than a transport fault and was
+    # previously undiagnosable without re-running the call under a debugger.
     ctx.events.emit(
         "mcp_completed", server=op.server, tool=op.tool, is_error=is_error,
         media_block_count=len(media_blocks),
+        error=text if is_error else None,
     )
     out = {
         "kind": "mcp",

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -581,6 +581,20 @@ _DEFAULT_MAX_PIPELINE_SPAWNS = 100
 # ``serde``'s ``__exprref__`` marker uses.
 _FAN_OUT_DROPPED_KEY = "__fan_out_dropped__"
 
+# #3070: a DROPPED parallel branch's real failure text used to be recorded
+# ONLY in the internal recovery/resume ``completed_step_results`` map (never
+# reachable from the R1 expression language a ``collect`` step evaluates), so
+# a pre-flight probe built from ``parallel``/``on_error: continue`` (e.g.
+# rag_ingest.yaml's X1) could tell a branch was DROPPED but never WHY — it
+# fell back to a static, cause-blind message. This reserved key is injected
+# into the SAME named map ``collect``'s ``pipe`` already receives, alongside
+# the (unchanged, still-filtered) surviving branch results, so an author who
+# wants the real cause can read ``get(pipe, "__branch_errors__", {})`` — one
+# more dict entry, never a shape change to the branches' own keys. A branch is
+# not permitted to be named this (see the parser-side guard) so the two can
+# never collide.
+PARALLEL_BRANCH_ERRORS_KEY = "__branch_errors__"
+
 _ON_ERROR_RETRY_RE = re.compile(r"^retry\((?P<n>\d+)\)$")
 
 
@@ -787,9 +801,24 @@ async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, 
             )
         validation = validate(result, step.schema, deps.schema_registry)
         if not validation.conforming:
+            # #3070: `validation.errors` alone only ever says WHICH FIELD failed
+            # (e.g. "status: 'error' not in ['ok']") — never WHY the tool itself
+            # reported an error. A dict-result op almost always carries that
+            # cause under `error` (the ops/__init__.py + most op_runtime handlers'
+            # own convention) or, for the mcp op's `isError` branch specifically,
+            # under `content` (the MCP tool's own error text — see
+            # reyn.core.op_runtime.mcp._execute). Surfacing it here means a
+            # schema-gated pre-flight probe (e.g. rag_ingest.yaml's X1) can
+            # report the REAL exception instead of a generic "schema mismatch"
+            # or a static "unreachable" that swallows it (#3070).
+            detail = ""
+            if isinstance(result, dict):
+                tool_message = result.get("error") or result.get("content")
+                if isinstance(tool_message, str) and tool_message.strip():
+                    detail = f" — the tool's own result: {tool_message}"
             raise PipelineExecutionError(
                 f"step {inv.step_label} (tool {step.name!r}) output failed schema "
-                f"{step.schema!r}: {validation.errors}"
+                f"{step.schema!r}: {validation.errors}{detail}"
             )
     # #2425 PR-2: ctx exposes the same text/structured shape chat gets, uniformly across every op
     # kind — shape-only (to_canonical), NEVER offloaded/size-gated (owner ruling: ctx/pipe data
@@ -1307,6 +1336,23 @@ def _parallel_results(
     return out
 
 
+def _parallel_branch_errors(
+    completed_step_results: "dict[str, Any]", label: str, names: "list[str]",
+) -> "dict[str, str]":
+    """The DROPPED branches' real failure text, keyed by branch name (#3070) —
+    the counterpart :func:`_parallel_results` omits by design (a dropped
+    branch's kind-marker is never a legitimate ``do`` result). Only names
+    with a genuinely dropped branch appear; a branch that ran to completion
+    (success OR a still-conforming error result) is absent, same convention
+    as ``_parallel_results`` itself."""
+    out: "dict[str, str]" = {}
+    for name in names:
+        value = completed_step_results[f"{label}.parallel.{name}"]
+        if _is_dropped_marker(value):
+            out[name] = value.get("error", "")
+    return out
+
+
 async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
     """The heterogeneous NAMED-branch fan-out runner (S5-bounded) — reuses the
     EXACT fan-out substrate :func:`_run_for_each_step` established (concurrent
@@ -1440,6 +1486,12 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
     # collect runs ONCE over the NAMED MAP of surviving results (dropped
     # filtered out).
     results_map = _parallel_results(completed, label, names)
+    # #3070: inject the dropped branches' real error text under the reserved
+    # key ONLY when at least one branch actually dropped — a `collect` step
+    # that never fails a branch sees no shape change at all.
+    branch_errors = _parallel_branch_errors(completed, label, names)
+    if branch_errors:
+        results_map = {**results_map, PARALLEL_BRANCH_ERRORS_KEY: branch_errors}
     collect_ctx = {"ctx": outer_stores, "pipe": results_map}
     collect_runner = STEP_DISPATCH.get(type(step.collect))
     if collect_runner is None:  # pragma: no cover - Step is a closed union

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -611,6 +611,17 @@ def _parse_parallel_step(body: "dict[str, Any]", *, index: "int | str") -> Paral
     raw_branches = body.get("branches")
     if not isinstance(raw_branches, dict) or not raw_branches:
         _fail("parallel step: 'branches' must be a non-empty mapping of NAME -> Step")
+    # #3070: the executor injects a dropped-branch-error map into `collect`'s
+    # named `pipe` under this reserved key (PARALLEL_BRANCH_ERRORS_KEY) — a
+    # branch actually named this would collide with it silently.
+    from reyn.core.pipeline.executor import PARALLEL_BRANCH_ERRORS_KEY  # noqa: PLC0415
+
+    if PARALLEL_BRANCH_ERRORS_KEY in raw_branches:
+        _fail(
+            f"parallel step: branch name {PARALLEL_BRANCH_ERRORS_KEY!r} is reserved "
+            "(the executor uses it to carry dropped-branch error text into "
+            "collect's `pipe`) -- rename this branch"
+        )
     branches = {
         name: _parse_step(branch_body, index=f"{index} (parallel branch {name!r})")
         for name, branch_body in raw_branches.items()

--- a/tests/test_3070_mcp_probe_error_surfaced.py
+++ b/tests/test_3070_mcp_probe_error_surfaced.py
@@ -1,0 +1,344 @@
+"""#3070 — a probe/pre-flight `tool` step that FAILS on the tool's own error
+(not a transport fault) must surface the real cause, never collapse into a
+static "unreachable"/schema-mismatch string.
+
+Root-cause chain measured on this issue (dogfood-coder's e2e report +
+direct reproduction here): `rag_ingest.yaml`'s X1 pre-flight probes each MCP
+server with a real tool call, schema-gated to `status == "ok"`
+(`PreflightCheck`). All three servers' MCP HANDSHAKE succeeds
+(`mcp_initialized`), but the chunker/vector-store PROBE TOOL CALL itself can
+fail (observed: the `builtin-rag` extra -- apsw/sqlite-vec/chonkie -- not
+installed in the probing environment raises `ModuleNotFoundError` INSIDE the
+tool handler, which FastMCP reports as `isError: true` with the exception
+text as content). Three swallow points hid that real exception end to end:
+
+  1. `op_runtime/mcp.py`'s `mcp_completed` audit event recorded only the
+     `is_error` boolean, never the tool's own error text -- undiagnosable
+     from the P6 audit log alone.
+  2. `executor.py`'s tool-step `verify: schema` failure raised
+     `PipelineExecutionError` naming only the schema-validation error (e.g.
+     "status: 'error' not in ['ok']"), discarding the tool's own result
+     entirely.
+  3. `executor.py`'s `parallel` step (`on_error: continue`) DROPS a failed
+     branch from `collect`'s named `pipe` map by design (`_parallel_results`)
+     -- so even with (2) fixed, the real cause never reached a `collect` step
+     built from the R1 expression language, which could only ever observe
+     ABSENCE, never WHY.
+
+Each test below pins one closed swallow point. Real `EventLog` / `MCPClient`
+/ `PipelineExecutor` / `SchemaRegistry` throughout (only the deepest fastmcp
+transport is faked, mirroring `test_mcp_progress_and_timeout.py`'s own
+precedent for this exact seam) -- no mocks of reyn's own collaborators.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.pipeline.executor import (
+    ParallelStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+from reyn.core.pipeline.parser import PipelineParseError, parse_pipeline_dsl
+from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.mcp.client import MCPClient
+from reyn.schemas.models import MCPIROp
+
+_PREFLIGHT_SCHEMA = {"fields": {"status": {"type": "enum", "values": ["ok"]}}}
+
+
+# ── 1. the mcp op handler's own audit event carries the real text ───────────
+
+
+class _StubPool:
+    """Test double for MCPClientPool — get() returns a pre-set client (a359 P2),
+    the same Real Fake `test_mcp_progress_and_timeout.py` already uses for this
+    exact seam."""
+
+    def __init__(self, client: MCPClient) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> "_StubPool":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    @property
+    def owner_task(self) -> None:
+        return None
+
+    async def get(self, server: str, config: dict, *, agent_id: str | None = None) -> MCPClient:
+        return self._client
+
+
+class _FakeServerCapabilities:
+    tools: Any = object()
+    resources: Any = None
+    prompts: Any = None
+    logging: Any = None
+    completions: Any = None
+
+
+def _bypass_initialize(client: MCPClient, fake_fastmcp_client: Any) -> None:
+    client._initialized = True
+    client._client = fake_fastmcp_client
+    client._negotiated_version = "2025-11-25"
+    client._server_capabilities = _FakeServerCapabilities()
+
+
+class _ErroringFastMCPClient:
+    """Stands in for the deepest `fastmcp.Client` transport (see
+    `test_mcp_progress_and_timeout.py`'s own precedent for faking this ONE
+    seam): the tool call itself REPORTS an error (as a real FastMCP-wrapped
+    ImportError would from a missing `builtin-rag` extra), it does not raise."""
+
+    def __init__(self, error_text: str) -> None:
+        self._error_text = error_text
+
+    async def call_tool_mcp(
+        self, name: str, arguments: "dict | None" = None, **kwargs: Any,
+    ) -> Any:
+        # `_result_to_dict` (reyn.mcp.client) reads `.content`/`.isError` as
+        # plain ATTRIBUTES (mirrors ``mcp.types.CallToolResult``), and a
+        # content item is either a pydantic model (``model_dump()``) or a
+        # plain dict passed through unchanged -- the latter is simplest here.
+        class _Result:
+            content = [{"type": "text", "text": self._error_text}]
+            isError = True
+            structuredContent = None
+
+        return _Result()
+
+
+def test_mcp_completed_event_carries_the_real_error_text_on_isError() -> None:
+    """Tier 2: `mcp_completed` records the tool's own error text (not just the
+    `is_error` boolean) when the tool call reports `isError: true` -- the
+    enabler this whole issue turns on: without it, an errored probe is
+    undiagnosable from the P6 audit log alone."""
+    from reyn.core.op_runtime import mcp as mcp_op_handler
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    real_text = "Error calling tool 'list_metadata': No module named 'sqlite_vec'"
+    events = EventLog()
+    ctx = OpContext(
+        workspace=None,  # type: ignore[arg-type]
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        mcp_servers={"reyn_vector_store": {"type": "stdio", "command": "/bin/true"}},
+    )
+    client = MCPClient({"type": "stdio", "command": "/bin/true"})
+    _bypass_initialize(client, _ErroringFastMCPClient(real_text))
+    ctx.mcp_pool = _StubPool(client)
+
+    op = MCPIROp(kind="mcp", server="reyn_vector_store", tool="list_metadata", args={})
+    asyncio.run(mcp_op_handler._execute(op, ctx))
+
+    completed = [e for e in events.all() if e.type == "mcp_completed"]
+    # exactly one `mcp_completed` event: this single-unpack IS the assertion
+    # (raises ValueError if zero or more than one landed), not a length pin.
+    (only,) = completed
+    assert only.data["is_error"] is True
+    assert only.data["error"] == real_text
+
+
+def test_mcp_completed_event_carries_no_error_text_on_success() -> None:
+    """Tier 2: the new `error` field stays None on a clean result -- the fix
+    adds diagnosability to the failure path, it does not invent noise on the
+    success path."""
+    from reyn.core.op_runtime import mcp as mcp_op_handler
+    from reyn.core.op_runtime.context import OpContext
+    from reyn.security.permissions.permissions import PermissionDecl
+
+    events = EventLog()
+    ctx = OpContext(
+        workspace=None,  # type: ignore[arg-type]
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=None,
+        mcp_servers={"reyn_chunker": {"type": "stdio", "command": "/bin/true"}},
+    )
+    client = MCPClient({"type": "stdio", "command": "/bin/true"})
+
+    class _OkFastMCPClient:
+        async def call_tool_mcp(self, name: str, arguments=None, **kwargs: Any) -> Any:
+            class _Result:
+                content = [{"type": "text", "text": "ok"}]
+                isError = False
+                structuredContent = None
+            return _Result()
+
+    _bypass_initialize(client, _OkFastMCPClient())
+    ctx.mcp_pool = _StubPool(client)
+
+    op = MCPIROp(kind="mcp", server="reyn_chunker", tool="chunk", args={})
+    asyncio.run(mcp_op_handler._execute(op, ctx))
+
+    completed = [e for e in events.all() if e.type == "mcp_completed"]
+    (only,) = completed
+    assert only.data["is_error"] is False
+    assert only.data["error"] is None
+
+
+# ── 2. the executor's schema-validation failure keeps the tool's own text ───
+
+
+def test_schema_validation_failure_includes_the_tools_own_error_detail() -> None:
+    """Tier 1: a `verify: schema`-gated tool step whose result fails
+    validation because the TOOL ITSELF reported an error (a dict carrying
+    `error`/`content`) surfaces that text in the raised
+    `PipelineExecutionError` -- not just which schema field mismatched.
+    STRIP-FALSIFY: reverting the `detail` block in `_run_tool_step` makes
+    this RED (the message reverts to naming only `validation.errors`)."""
+    registry = SchemaRegistry()
+    registry.register("preflight", _PREFLIGHT_SCHEMA)
+
+    def _erroring_dispatch(_name: str, _args: dict) -> dict:
+        return {
+            "status": "error",
+            "content": "Error calling tool 'list_metadata': No module named 'sqlite_vec'",
+        }
+
+    pipeline = Pipeline(
+        steps=[ToolStep(name="probe", args={}, output="p", schema="preflight")]
+    )
+    with pytest.raises(PipelineExecutionError) as excinfo:
+        asyncio.run(
+            PipelineExecutor().run(
+                pipeline, None,
+                tool_dispatch=_erroring_dispatch, state_log=None,
+                run_id="run-3070-schema-detail", schema_registry=registry,
+            )
+        )
+    assert "No module named 'sqlite_vec'" in str(excinfo.value)
+
+
+def test_schema_validation_failure_with_no_tool_message_stays_unchanged() -> None:
+    """Tier 1: when the failing result carries neither `error` nor `content`,
+    no bogus detail is invented -- the message is exactly the pre-existing
+    schema-only wording."""
+    registry = SchemaRegistry()
+    registry.register("preflight", _PREFLIGHT_SCHEMA)
+
+    def _dispatch(_name: str, _args: dict) -> dict:
+        return {"status": "error"}
+
+    pipeline = Pipeline(
+        steps=[ToolStep(name="probe", args={}, output="p", schema="preflight")]
+    )
+    with pytest.raises(PipelineExecutionError) as excinfo:
+        asyncio.run(
+            PipelineExecutor().run(
+                pipeline, None,
+                tool_dispatch=_dispatch, state_log=None,
+                run_id="run-3070-schema-no-detail", schema_registry=registry,
+            )
+        )
+    assert "the tool's own result" not in str(excinfo.value)
+
+
+# ── 3. the dropped branch's real cause reaches collect's `pipe` ─────────────
+
+
+def test_parallel_continue_surfaces_the_dropped_branchs_real_error_to_collect() -> None:
+    """Tier 2: `on_error: continue` still DROPS the failed branch from the
+    named-map `pipe` (unchanged -- `_parallel_results`'s existing contract),
+    but `collect` can additionally read the branch's real failure text via
+    the reserved `pipe.__branch_errors__.<name>` entry (#3070) -- the piece
+    that lets a `collect` step (X1's `reachable` builder) report WHY a probe
+    failed, not just THAT it did. STRIP-FALSIFY: reverting the
+    `_parallel_branch_errors`/`PARALLEL_BRANCH_ERRORS_KEY` wiring in
+    `_run_parallel_step` makes this RED (`__branch_errors__` never appears)."""
+    registry = SchemaRegistry()
+    registry.register("preflight", _PREFLIGHT_SCHEMA)
+
+    def _dispatch(name: str, args: dict) -> dict:
+        if args["v"] == "bad":
+            return {
+                "status": "error",
+                "content": "Error calling tool 'chunk': No module named 'chonkie'",
+            }
+        return {"status": "ok"}
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="continue",
+            branches={
+                "good": ToolStep(name="probe", args={"v": "ok"}, schema="preflight"),
+                "bad": ToolStep(name="probe", args={"v": "bad"}, schema="preflight"),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = asyncio.run(
+        PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None,
+            run_id="run-3070-parallel-cause", schema_registry=registry,
+        )
+    )
+    # the surviving-map contract is UNCHANGED: "bad" is absent, not None.
+    assert "bad" not in result.pipe_data
+    assert "good" in result.pipe_data
+    # ...and the real cause is reachable under the reserved key.
+    errors = result.pipe_data["__branch_errors__"]
+    assert "No module named 'chonkie'" in errors["bad"]
+    assert "good" not in errors
+
+
+def test_parallel_no_dropped_branch_never_adds_the_errors_key() -> None:
+    """Tier 2: when no branch drops, `__branch_errors__` never appears at all
+    -- the fix adds a key only on an actual drop, so a `collect` step that
+    never fails a branch sees NO shape change."""
+    registry = SchemaRegistry()
+    registry.register("preflight", _PREFLIGHT_SCHEMA)
+
+    def _dispatch(_name: str, _args: dict) -> dict:
+        return {"status": "ok"}
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="continue",
+            branches={
+                "a": ToolStep(name="probe", args={}, schema="preflight"),
+                "b": ToolStep(name="probe", args={}, schema="preflight"),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = asyncio.run(
+        PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None,
+            run_id="run-3070-parallel-no-drop", schema_registry=registry,
+        )
+    )
+    assert "__branch_errors__" not in result.pipe_data
+
+
+def test_parser_rejects_a_branch_named_the_reserved_errors_key() -> None:
+    """Tier 1: a branch literally named `__branch_errors__` would collide
+    with the executor's own reserved key (#3070) -- the parser fails it
+    loud at parse time rather than letting it silently clobber the real
+    dropped-branch-error map at run time."""
+    dsl = """
+pipeline: bad-branch-name
+description: a branch shadows the reserved parallel-branch-errors key
+steps:
+  - parallel:
+      on_error: continue
+      branches:
+        __branch_errors__: {transform: {value: "1"}}
+      collect: {transform: {value: "pipe"}}
+"""
+    with pytest.raises(PipelineParseError, match="reserved"):
+        parse_pipeline_dsl(dsl, SchemaRegistry())

--- a/tests/test_pipeline_parallel_primitive.py
+++ b/tests/test_pipeline_parallel_primitive.py
@@ -261,8 +261,12 @@ async def test_on_error_continue_drops_failed_branch_and_collect_sees_survivors(
     )
     # collect saw only the survivors — the failed branch is absent, not None.
     # #2425 PR-2: a str ToolStep result maps to the flat {"text": ...} ctx shape.
-    assert result.pipe_data == {"good": {"text": "OK"}}
+    # #3070: a genuine drop additionally exposes its real cause under the
+    # reserved `__branch_errors__` key (additive — "good"'s own shape is
+    # untouched).
+    assert result.pipe_data["good"] == {"text": "OK"}
     assert "bad" not in result.pipe_data
+    assert "boom" in result.pipe_data["__branch_errors__"]["bad"]
     dropped = result.completed_step_results["0.parallel.bad"]
     assert dropped["__fan_out_dropped__"] is True
     assert "boom" in dropped["error"]


### PR DESCRIPTION
**[per-PR-coder]** — root-cause fix, dispatched by lead-coder off dogfood-coder's fresh-chat e2e measurement. Closes #3063.

## What was wrong

`rag_ingest.yaml`'s X1 pre-flight probes each of the 3 builtin RAG MCP servers with a real tool call, schema-gated to `status == "ok"`. All 3 servers' MCP **handshake** succeeds (`mcp_initialized` x3 in the audit trail), but the chunker/vector-store **probe tool call itself** can fail — and that failure was reported as a static "reyn_chunker and reyn_vector_store MCP servers are unreachable", indistinguishable from an actually-unreachable server.

## Root cause — confirmed by direct reproduction

Full writeup + falsification of the initial cwd/relative-path hypothesis is in #3063. Short version: the real cause reproduced here is the `builtin-rag` optional extras (`apsw`/`sqlite-vec`/`chonkie`) not being installed in the probing environment — the probe tool call raises `ModuleNotFoundError` *inside the server*, FastMCP reports it as `isError: true` with the exception text as content, and that text was swallowed at three separate points before ever reaching the operator:

1. `op_runtime/mcp.py`'s `mcp_completed` audit event recorded only the `is_error` boolean, never the tool's own error text.
2. `executor.py`'s `verify: schema` failure (X1's `PreflightCheck` requires `status == "ok"`) raised `PipelineExecutionError` naming only the schema mismatch, discarding the tool's own result (`content`/`error`).
3. `executor.py`'s `parallel` step (`on_error: continue`) drops a failed branch from `collect`'s named `pipe` map by design — so even with (2) fixed, the real cause never reached the R1 expression building X1's message.

## Fix

- `op_runtime/mcp.py`: `mcp_completed` now carries `error=<content>` when `isError` (was: boolean only).
- `executor.py` (`_run_tool_step`): a schema-validation failure now appends the failing result's own `error`/`content` text to the raised exception.
- `executor.py` (`_run_parallel_step`): a dropped branch's real error text is now exposed to `collect` via a reserved `pipe.__branch_errors__.<branch>` entry — **additive only**: the existing filtered `pipe` shape for surviving branches, and the existing absence-of-a-dropped-branch's-own-key contract, are both unchanged. The parser rejects a branch literally named `__branch_errors__` (collision guard).
- `rag_ingest.yaml`'s X1 pre-flight now appends the real observed cause to each failing server's existing remedy text.
- `docs/reference/runtime/pipeline-dsl.md`: documents the new `__branch_errors__` reserved key.

## Verification

- Direct reproduction via `reyn pipe run rag_ingest.ingest` against this checkout's own MCP servers (real subprocesses): with the `builtin-rag` extras installed, a relative `output_db` resolves correctly (falsifies the cwd hypothesis); with `apsw`/`sqlite_vec`/`chonkie` shadowed by stub modules that raise `ModuleNotFoundError`, the pre-flight message now reads e.g. `"[actual error observed] ... No module named 'sqlite_vec'"` instead of the generic boilerplate.
- 7 new tests in `tests/test_3070_mcp_probe_error_surfaced.py` (Tier 1 + Tier 2, real `EventLog`/`MCPClient`/`PipelineExecutor`/`SchemaRegistry`, only the deepest fastmcp transport faked per `test_mcp_progress_and_timeout.py`'s existing precedent for that exact seam) — each strip-falsified (reverting the corresponding fix turns it RED).
- Updated `tests/test_pipeline_parallel_primitive.py::test_on_error_continue_drops_failed_branch_and_collect_sees_survivors` for the new additive key.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3070_mcp_probe_error_surfaced.py tests/test_pipeline_parallel_primitive.py` — 0 Tier-4 violations
- [x] `pytest -q -n auto --timeout=120` (repo root) — 8819 passed, 29 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py <changed src files>` — clean
- [x] Strip-falsify: each new/changed test goes RED when its corresponding fix is reverted (verified locally via `git stash`)

## Relationship to #3062

#3062 is a different stall (all 3 servers unreachable with no subprocess spawned at all, even after the config-refresh fix). This PR's repro has the config correctly wired and fails specifically at the tool-call layer. The fix here is general-purpose diagnosability and should help whoever picks up #3062, but does not itself close it.