### PR TITLE
feat(plugins): plugin.json manifest schema + ${REYN_*} token expansion (P1, #3067)

### DIFF
--- a/docs/deep-dives/proposals/0064-plugin-model.md
+++ b/docs/deep-dives/proposals/0064-plugin-model.md
@@ -104,7 +104,7 @@ Today a skill body is read raw with zero substitution — the only capability wi
 
 `${CLAUDE_*}` is honoured by **exactly one host** (Claude Code); no other agent expands it; there is **no vendor-neutral token** (LSP/DAP/MCP define none). Adopting it verbatim brand-locks to a competitor and buys no portability.
 
-- **Canonical**: `${REYN_PLUGIN_ROOT}` / `${REYN_SKILL_DIR}` / `${REYN_PROJECT_DIR}`, resolved via the existing `resolve_reyn_root()` (`runtime/reyn_repo.py`), as a layer **distinct from** the os.environ `expand_env` (config env-injection ≠ plugin/skill location).
+- **Canonical**: `${REYN_PLUGIN_ROOT}` / `${REYN_SKILL_DIR}` / `${REYN_PROJECT_DIR}`, as a layer **distinct from** the os.environ `expand_env` (config env-injection ≠ plugin/skill location). Two different value sources: `${REYN_PLUGIN_ROOT}` / `${REYN_SKILL_DIR}` are **anchor** locations (the plugin's / skill's own copied dir) — the anchoring uses reyn's dual-mode `resolve_reyn_root()` (`runtime/reyn_repo.py`) to find reyn's *own* install for a builtin plugin; `${REYN_PROJECT_DIR}` is **not** `resolve_reyn_root()` (that resolves reyn-the-project, not the operator's project) — it is a *dynamic* per-invocation value carried from the live session's workspace root and threaded through the expansion context (`PluginTokenContext`), matching §3.4's stable-location-vs-dynamic-param split.
 - **Alias `${CLAUDE_*}`** only in the code path that ingests a Claude-authored SKILL.md/plugin. Preserve the `SKILL_DIR` vs `PLUGIN_ROOT` distinction.
 - The **SKILL.md format** is the one genuine open standard (agentskills.io; adopted by Codex/Gemini/Cursor/Copilot) — honour as-is.
 

--- a/src/reyn/plugins/__init__.py
+++ b/src/reyn/plugins/__init__.py
@@ -1,0 +1,12 @@
+"""reyn.plugins — the plugin model substrate (ADR 0064).
+
+P1 Foundation slice (#3067): the typed ``.reyn-plugin/plugin.json`` manifest
+schema (``manifest.py``), the ``${REYN_*}`` / ``${CLAUDE_*}`` token-expansion
+layer (``tokens.py``), and the ``kind``-precedence ordering for name
+collisions across plugin sources (``source.py``).
+
+Install machinery, permission gates, and the LLM/CLI/slash surfaces that
+consume this substrate are out of scope here (ADR 0064 §3.2/§3.9/§3.10 —
+P2+).
+"""
+from __future__ import annotations

--- a/src/reyn/plugins/manifest.py
+++ b/src/reyn/plugins/manifest.py
@@ -1,0 +1,150 @@
+"""Typed schema for ``.reyn-plugin/plugin.json`` (ADR 0064 §3.1).
+
+A plugin is a self-contained directory; the manifest declares its identity
+(``name`` / ``version``) and WHICH capability subdirs are present — every
+capability is optional (§3.1: "a valid plugin may be *just* an MCP server,
+*just* a pipeline, or any combination"). Mirrors the house convention for
+typed, discriminated-union side-effect payloads used across reyn's op
+schemas (``reyn.schemas.models`` — ``kind: Literal[...]`` per variant,
+``Field(discriminator="kind")`` on the union) rather than a form-sniffed
+untyped string.
+
+``capabilities`` declares presence + an optional explicit entry list per
+capability; an empty ``entries`` tuple means "discover everything reyn's
+plugin layout convention expects" (root ``.mcp.json`` for ``mcp``,
+``pipelines/*.yaml`` for ``pipelines``, ``skills/*/SKILL.md`` for
+``skills`` — ADR §3.1's directory layout). Discovery/registration itself is
+P2 (install machinery); this module only defines and validates the shape.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+# Reserved so a future collision-precedence read (ADR §3.8, see
+# ``reyn.plugins.source``) can trust ``name`` as the stable collision key
+# without also having to guard against '.', which pipeline/skill namespacing
+# already treats as a separator (mirrors ``PipelineInstallIROp.name``'s '.'
+# reservation, ``reyn.schemas.models``).
+_RESERVED_NAME_CHARS = "."
+
+
+class PluginManifestError(ValueError):
+    """Raised when ``.reyn-plugin/plugin.json`` is missing, malformed, or
+    fails schema validation. Wraps the lower-level ``OSError`` /
+    ``json.JSONDecodeError`` / pydantic ``ValidationError`` so callers have
+    one exception type to catch."""
+
+
+class PluginMCPCapability(BaseModel):
+    """The plugin ships an MCP server declared at its root ``.mcp.json``
+    (ADR §3.1 — standard shape, no reyn-specific fields)."""
+
+    kind: Literal["mcp"] = "mcp"
+
+
+class PluginPipelinesCapability(BaseModel):
+    """The plugin ships one or more pipeline DSL files under ``pipelines/``
+    (ADR §3.1 — a declared reyn extension, no standard equivalent).
+
+    ``entries``: explicit list of DSL filenames (relative to ``pipelines/``)
+    to register. Empty = discover every ``pipelines/*.yaml`` file.
+    """
+
+    kind: Literal["pipelines"] = "pipelines"
+    entries: tuple[str, ...] = ()
+
+
+class PluginSkillsCapability(BaseModel):
+    """The plugin ships one or more standard ``SKILL.md`` skills under
+    ``skills/<name>/`` (ADR §3.1 — honoured as-is, the one genuine open
+    standard per §3.6).
+
+    ``entries``: explicit list of skill directory names under ``skills/``
+    to register. Empty = discover every ``skills/*/SKILL.md``.
+    """
+
+    kind: Literal["skills"] = "skills"
+    entries: tuple[str, ...] = ()
+
+
+PluginCapability = Annotated[
+    Union[PluginMCPCapability, PluginPipelinesCapability, PluginSkillsCapability],
+    Field(discriminator="kind"),
+]
+
+
+class PluginManifest(BaseModel):
+    """``.reyn-plugin/plugin.json`` — the typed plugin manifest (ADR §3.1).
+
+    ``name`` is the plugin's stable identity — the collision key for
+    ``reyn.plugins.source.resolve_name_collision`` and the ``~/.reyn/plugins/
+    <name>/`` install-target directory name (P2). ``.`` is reserved (mirrors
+    ``PipelineInstallIROp``/``SkillInstallIROp``'s namespace-separator
+    convention) so a plugin name never collides with a capability's own
+    dotted namespace key.
+
+    ``capabilities`` is a discriminated union list (`kind` in
+    ``{"mcp", "pipelines", "skills"}``) — every entry optional, any subset,
+    duplicates of the same ``kind`` rejected (a manifest declares each
+    capability at most once).
+    """
+
+    name: str
+    version: str
+    description: str = ""
+    capabilities: tuple[PluginCapability, ...] = ()
+
+    @property
+    def capability_kinds(self) -> frozenset[str]:
+        return frozenset(cap.kind for cap in self.capabilities)
+
+    @model_validator(mode="after")
+    def _validate(self) -> "PluginManifest":
+        if not self.name:
+            raise ValueError("PluginManifest.name must be non-empty")
+        if any(ch in self.name for ch in _RESERVED_NAME_CHARS):
+            raise ValueError(
+                f"PluginManifest.name {self.name!r} must not contain "
+                f"reserved namespace-separator characters ({_RESERVED_NAME_CHARS!r})"
+            )
+        kinds = [cap.kind for cap in self.capabilities]
+        if len(kinds) != len(set(kinds)):
+            raise ValueError(
+                f"PluginManifest.capabilities declares duplicate kinds: {kinds!r} "
+                "(each capability kind may appear at most once)"
+            )
+        return self
+
+
+_MANIFEST_RELATIVE_PATH = Path(".reyn-plugin") / "plugin.json"
+
+
+def manifest_path_for(plugin_dir: Path) -> Path:
+    """The canonical manifest path inside a plugin directory (ADR §3.1 layout)."""
+    return plugin_dir / _MANIFEST_RELATIVE_PATH
+
+
+def load_plugin_manifest(plugin_dir: Path) -> PluginManifest:
+    """Read + validate ``<plugin_dir>/.reyn-plugin/plugin.json``.
+
+    Raises ``PluginManifestError`` (never a bare ``OSError`` / JSON /
+    pydantic error) on a missing file, invalid JSON, or a schema violation,
+    so every caller catches one exception type.
+    """
+    path = manifest_path_for(plugin_dir)
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PluginManifestError(f"cannot read plugin manifest at {path}: {exc}") from exc
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PluginManifestError(f"invalid JSON in plugin manifest {path}: {exc}") from exc
+    try:
+        return PluginManifest.model_validate(data)
+    except ValidationError as exc:
+        raise PluginManifestError(f"invalid plugin manifest {path}: {exc}") from exc

--- a/src/reyn/plugins/source.py
+++ b/src/reyn/plugins/source.py
@@ -1,0 +1,41 @@
+"""Plugin source ``kind`` vocabulary + name-collision precedence (ADR 0064 §3.8/§3.10).
+
+The ADR's typed ``plugin_install`` op (P2+) takes a discriminated ``source``
+of ``kind in {"builtin", "local", "git"}`` — reyn's own shipped plugin, a
+local directory the LLM authored/tested, or a remote git URL, in that
+increasing order of RCE trust risk (§3.10: "builtin ≤ local ≪ git/remote").
+
+P1 defines the shared ``kind`` vocabulary and the **name-collision
+precedence** this ordering also settles: when two plugin sources declare the
+same ``PluginManifest.name``, ``builtin`` wins over ``local`` wins over
+``git`` — the lower-trust-risk source never silently shadows a
+higher-trust-risk one. This is a schema/resolution-layer definition only;
+the P2 install op is what actually calls it during a real name collision.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+PluginSourceKind = Literal["builtin", "local", "git"]
+
+# Index = precedence rank, lower wins a name collision. Mirrors the RCE
+# trust-risk ordering in ADR 0064 §3.10 ("builtin <= local << git/remote"):
+# the shipped-with-reyn plugin is the most trusted, so it always wins a
+# same-name collision over anything the operator installed themselves.
+PLUGIN_SOURCE_PRECEDENCE: tuple[PluginSourceKind, ...] = ("builtin", "local", "git")
+
+_RANK: dict[PluginSourceKind, int] = {
+    kind: rank for rank, kind in enumerate(PLUGIN_SOURCE_PRECEDENCE)
+}
+
+
+def resolve_name_collision(candidates: "list[PluginSourceKind]") -> PluginSourceKind:
+    """Given the ``kind``s of every plugin source declaring the same name,
+    return the one that wins (ADR 0064 §3.8: "builtin priority" on collision).
+
+    Raises ``ValueError`` on an empty list — a collision needs >= 1 candidate,
+    and the caller should not invoke this for a name with a single source.
+    """
+    if not candidates:
+        raise ValueError("resolve_name_collision requires at least one candidate kind")
+    return min(candidates, key=lambda kind: _RANK[kind])

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -1,0 +1,136 @@
+"""``${REYN_*}`` plugin/skill location-token expansion (ADR 0064 §3.4/§3.5/§3.6).
+
+**A separate layer from ``expand_env`` (``security/secrets/interpolation.py``,
+ADR-0030).** ``expand_env`` expands ``${VAR}`` from ``os.environ`` across an
+MCP server's spawn config — a config-time env-injection concern. This module
+expands a **different, fixed token vocabulary** (``REYN_PLUGIN_ROOT`` /
+``REYN_SKILL_DIR`` / ``REYN_PROJECT_DIR``, plus the ``CLAUDE_*`` alias) whose
+values come from an explicit :class:`PluginTokenContext`, never from
+``os.environ``. The two layers are deliberately not merged (owner: "config
+variable expansion is a separate thing") — a plugin author's ``${VAR}`` (an
+env var they want at spawn time) and reyn's own ``${REYN_PLUGIN_ROOT}`` (a
+location reyn resolves) must not be confusable with each other.
+
+**Variable kind split (§3.4), uniform across mcp / pipeline / skill:**
+
+- **stable location** (``REYN_PLUGIN_ROOT``, ``REYN_SKILL_DIR``) — fixed the
+  instant a plugin is copied to its install dir; resolved ONCE at copy time
+  and baked into the copied files (P2 concern). This module's
+  :func:`expand_reyn_tokens` is the primitive that P2's copy step calls.
+- **dynamic param** (``REYN_PROJECT_DIR``, plus ``${env:VAR}`` / per-run
+  ``ctx`` params handled elsewhere) — only has a value at invocation
+  (mcp spawn / pipeline run / skill-load, §3.5); expanded fresh each call,
+  never baked into the copy.
+
+Both kinds go through the SAME :func:`expand_reyn_tokens` call — the
+distinction is in *when* the caller invokes it (copy time vs. invocation
+time) and *which* :class:`PluginTokenContext` fields it supplies, not in the
+expansion mechanism itself (no asymmetry between capability types, §3.4).
+
+Any ``${...}`` token this module does not recognise (an env var for
+``expand_env``, a pipeline ``ctx`` param, an unset field) is left untouched
+— the two expansion layers compose by each ignoring what the other owns.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+# Matches ${VAR_NAME} — word chars only, mirrors interpolation.py's _ENV_VAR_RE
+# shape so both layers share the same token *syntax*, not the same *vocabulary*.
+_TOKEN_RE = re.compile(r"\$\{(\w+)\}")
+
+# ``${CLAUDE_*}`` -> canonical ``${REYN_*}`` alias map (§3.6). Applied ONLY at
+# ingestion of a Claude-authored plugin/skill — never unconditionally, so a
+# reyn-native plugin never has to know the alias exists. Preserves the
+# SKILL_DIR vs PLUGIN_ROOT distinction (both aliases resolve to their OWN
+# reyn token, never collapsed to one root).
+CLAUDE_ALIAS_MAP: dict[str, str] = {
+    "CLAUDE_PLUGIN_ROOT": "REYN_PLUGIN_ROOT",
+    "CLAUDE_SKILL_DIR": "REYN_SKILL_DIR",
+    "CLAUDE_PROJECT_DIR": "REYN_PROJECT_DIR",
+}
+
+
+@dataclass(frozen=True)
+class PluginTokenContext:
+    """The resolved values for one expansion pass.
+
+    ``plugin_root``: the plugin's install directory (``~/.reyn/plugins/
+    <name>/`` once P2 lands, or the local working-copy dir during the
+    author/test loop, ADR §3.2). Stable location.
+
+    ``project_dir``: the current project/workspace root — NOT reyn's own
+    installed-package root (``reyn.runtime.reyn_repo.resolve_reyn_root``
+    resolves reyn's own repo/wheel location, a different and unrelated
+    concept from "the project the operator is working in"). Dynamic param:
+    callers re-resolve this per invocation from the live session's
+    workspace, they never bake it into a copied file.
+
+    ``skill_dir``: a specific skill's directory within the plugin
+    (``<plugin_root>/skills/<name>/``). ``None`` outside a skill-load
+    context (§3.5) — expanding an MCP config or a pipeline never has a
+    skill dir, so ``${REYN_SKILL_DIR}`` is correctly left unresolved there
+    rather than silently defaulting to ``plugin_root`` (the SKILL_DIR vs
+    PLUGIN_ROOT distinction §3.4/§3.6 calls out by name).
+    """
+
+    plugin_root: Path
+    project_dir: Path
+    skill_dir: Path | None = None
+
+    def tokens(self) -> dict[str, str]:
+        values = {
+            "REYN_PLUGIN_ROOT": str(self.plugin_root),
+            "REYN_PROJECT_DIR": str(self.project_dir),
+        }
+        if self.skill_dir is not None:
+            values["REYN_SKILL_DIR"] = str(self.skill_dir)
+        return values
+
+
+def _resolve_token_map(ctx: PluginTokenContext, *, alias_claude: bool) -> dict[str, str]:
+    values = ctx.tokens()
+    if alias_claude:
+        for claude_name, reyn_name in CLAUDE_ALIAS_MAP.items():
+            if reyn_name in values:
+                values[claude_name] = values[reyn_name]
+    return values
+
+
+def _expand_str(value: str, token_map: dict[str, str]) -> str:
+    def _replace(m: re.Match) -> str:
+        name = m.group(1)
+        # Unrecognised token (an expand_env var, a pipeline ctx param, an
+        # unresolved dynamic param) is left as-is for a later expansion pass.
+        return token_map.get(name, m.group(0))
+
+    return _TOKEN_RE.sub(_replace, value)
+
+
+def expand_reyn_tokens(obj: Any, ctx: PluginTokenContext, *, alias_claude: bool = False) -> Any:
+    """Recursively expand ``${REYN_*}`` (and, if ``alias_claude``, ``${CLAUDE_*}``)
+    tokens in all string values of a dict / list / str tree.
+
+    ``alias_claude`` must be ``True`` only in the code path ingesting a
+    Claude-authored SKILL.md/plugin (§3.6) — never unconditionally, so a
+    reyn-native plugin's own literal ``${CLAUDE_...}`` text (however
+    unlikely) is never rewritten.
+
+    Non-string scalars (int, bool, None, …) are returned unchanged, mirroring
+    ``expand_env``'s shape.
+    """
+    token_map = _resolve_token_map(ctx, alias_claude=alias_claude)
+    return _expand(obj, token_map)
+
+
+def _expand(obj: Any, token_map: dict[str, str]) -> Any:
+    if isinstance(obj, str):
+        return _expand_str(obj, token_map)
+    if isinstance(obj, dict):
+        return {k: _expand(v, token_map) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_expand(v, token_map) for v in obj]
+    return obj

--- a/src/reyn/plugins/tokens.py
+++ b/src/reyn/plugins/tokens.py
@@ -102,10 +102,13 @@ def _resolve_token_map(ctx: PluginTokenContext, *, alias_claude: bool) -> dict[s
 
 def _expand_str(value: str, token_map: dict[str, str]) -> str:
     def _replace(m: re.Match) -> str:
-        name = m.group(1)
+        # group(1) is the (\w+) capture — always present on a match (the
+        # pattern cannot match without it), so ``name`` is a concrete str.
+        name: str = m.group(1)
+        whole: str = m.group(0)
         # Unrecognised token (an expand_env var, a pipeline ctx param, an
         # unresolved dynamic param) is left as-is for a later expansion pass.
-        return token_map.get(name, m.group(0))
+        return token_map.get(name, whole)
 
     return _TOKEN_RE.sub(_replace, value)
 

--- a/tests/plugins/test_manifest.py
+++ b/tests/plugins/test_manifest.py
@@ -1,0 +1,157 @@
+"""Tier 1: Contract — ``.reyn-plugin/plugin.json`` typed manifest schema (ADR 0064 §3.1, #3067).
+
+Round-trips a manifest with non-default values (all three capability kinds,
+non-empty explicit ``entries``, a non-empty ``description``) through the real
+``PluginManifest`` schema and the real ``load_plugin_manifest`` file-reading
+path — no fakes, real ``Path``/JSON I/O via ``tmp_path``.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from reyn.plugins.manifest import (
+    PluginManifest,
+    PluginManifestError,
+    PluginMCPCapability,
+    PluginPipelinesCapability,
+    PluginSkillsCapability,
+    load_plugin_manifest,
+    manifest_path_for,
+)
+
+
+def _write_manifest(plugin_dir, data: dict) -> None:
+    manifest_dir = plugin_dir / ".reyn-plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_manifest_round_trips_nondefault_values(tmp_path):
+    """Tier 1: non-default round-trip — all 3 capability kinds present,
+    non-empty entries, description set, real file I/O + model_dump_json ->
+    model_validate round-trip."""
+    plugin_dir = tmp_path / "my-plugin"
+    data = {
+        "name": "rag",
+        "version": "1.2.3",
+        "description": "builtin RAG plugin (dogfood template, ADR §3.1)",
+        "capabilities": [
+            {"kind": "mcp"},
+            {"kind": "pipelines", "entries": ["ingest.yaml", "query.yaml"]},
+            {"kind": "skills", "entries": ["rag-search"]},
+        ],
+    }
+    _write_manifest(plugin_dir, data)
+
+    manifest = load_plugin_manifest(plugin_dir)
+
+    assert manifest.name == "rag"
+    assert manifest.version == "1.2.3"
+    assert manifest.description == "builtin RAG plugin (dogfood template, ADR §3.1)"
+    assert manifest.capability_kinds == frozenset({"mcp", "pipelines", "skills"})
+
+    pipelines_cap = next(
+        cap for cap in manifest.capabilities if isinstance(cap, PluginPipelinesCapability)
+    )
+    assert pipelines_cap.entries == ("ingest.yaml", "query.yaml")
+    skills_cap = next(
+        cap for cap in manifest.capabilities if isinstance(cap, PluginSkillsCapability)
+    )
+    assert skills_cap.entries == ("rag-search",)
+    assert any(isinstance(cap, PluginMCPCapability) for cap in manifest.capabilities)
+
+    # Round-trip through model_dump -> model_validate (JSON mode, the
+    # serialised shape a P2 install step would persist/copy).
+    dumped = json.loads(manifest.model_dump_json())
+    reloaded = PluginManifest.model_validate(dumped)
+    assert reloaded == manifest
+
+
+def test_manifest_capabilities_are_optional_any_subset(tmp_path):
+    """Tier 1: §3.1 'every capability subdir is optional' — a manifest with
+    zero capabilities (declares only identity) is valid, matching the common
+    case of building just an MCP server with no skill (§1)."""
+    plugin_dir = tmp_path / "bare"
+    _write_manifest(plugin_dir, {"name": "bare-server", "version": "0.1.0"})
+
+    manifest = load_plugin_manifest(plugin_dir)
+
+    assert manifest.capabilities == ()
+    assert manifest.capability_kinds == frozenset()
+
+
+def test_manifest_path_for_matches_adr_layout(tmp_path):
+    """Tier 1: the manifest path is the ADR §3.1 layout constant, not an
+    implementation-chosen path."""
+    plugin_dir = tmp_path / "some-plugin"
+    assert manifest_path_for(plugin_dir) == plugin_dir / ".reyn-plugin" / "plugin.json"
+
+
+def test_manifest_missing_file_raises_typed_error(tmp_path):
+    """Tier 1: a missing manifest file raises the typed ``PluginManifestError``,
+    not a bare ``OSError``."""
+    plugin_dir = tmp_path / "does-not-exist"
+    with pytest.raises(PluginManifestError):
+        load_plugin_manifest(plugin_dir)
+
+
+def test_manifest_invalid_json_raises_typed_error(tmp_path):
+    """Tier 1: malformed JSON raises the typed ``PluginManifestError``, not a
+    bare ``json.JSONDecodeError``."""
+    plugin_dir = tmp_path / "bad-json"
+    manifest_dir = plugin_dir / ".reyn-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(PluginManifestError):
+        load_plugin_manifest(plugin_dir)
+
+
+def test_manifest_missing_required_field_raises_typed_error(tmp_path):
+    """Tier 1: schema-level — ``version`` is required; omitting it fails
+    validation (via the typed ``PluginManifestError``), not a silent
+    default."""
+    plugin_dir = tmp_path / "no-version"
+    _write_manifest(plugin_dir, {"name": "incomplete"})
+
+    with pytest.raises(PluginManifestError):
+        load_plugin_manifest(plugin_dir)
+
+
+def test_manifest_name_rejects_reserved_namespace_separator():
+    """Tier 1: ``name`` rejects ``.`` — the reserved namespace-separator
+    character (mirrors ``PipelineInstallIROp``/``SkillInstallIROp``)."""
+    with pytest.raises(ValidationError):
+        PluginManifest(name="a.b", version="1.0.0")
+
+
+def test_manifest_rejects_duplicate_capability_kind():
+    """Tier 1: a manifest declaring the same capability kind twice is
+    malformed — each capability is registered at most once (P2 register step
+    has no 'merge two pipelines blocks' semantics to fall back on)."""
+    with pytest.raises(ValidationError):
+        PluginManifest(
+            name="dup",
+            version="1.0.0",
+            capabilities=[
+                PluginPipelinesCapability(entries=("a.yaml",)),
+                PluginPipelinesCapability(entries=("b.yaml",)),
+            ],
+        )
+
+
+def test_manifest_capability_kind_is_a_typed_discriminated_union_not_a_string():
+    """Tier 1: Tool-Contract lens — an unrecognised ``kind`` value fails
+    validation at the schema boundary rather than being silently
+    form-sniffed/ignored."""
+    with pytest.raises(ValidationError):
+        PluginManifest.model_validate(
+            {
+                "name": "x",
+                "version": "1.0.0",
+                "capabilities": [{"kind": "not-a-real-capability"}],
+            }
+        )

--- a/tests/plugins/test_source.py
+++ b/tests/plugins/test_source.py
@@ -1,0 +1,41 @@
+"""Tier 1: Contract — plugin source ``kind`` precedence on name collision (ADR 0064 §3.8, #3067).
+
+Pins: ``builtin`` wins a same-name collision over ``local`` and ``git``;
+``local`` wins over ``git``; order of the input list does not matter
+(the precedence is a property of the kinds, not of arrival order).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.plugins.source import PLUGIN_SOURCE_PRECEDENCE, resolve_name_collision
+
+
+def test_builtin_wins_over_local_and_git():
+    """Tier 1: ``builtin`` wins a 3-way collision (ADR §3.8: builtin priority)."""
+    assert resolve_name_collision(["local", "git", "builtin"]) == "builtin"
+
+
+def test_local_wins_over_git():
+    """Tier 1: ``local`` wins over ``git`` absent a ``builtin`` candidate."""
+    assert resolve_name_collision(["git", "local"]) == "local"
+
+
+def test_order_independent():
+    """Tier 1: the winner does not depend on the input list's order."""
+    assert resolve_name_collision(["git", "builtin", "local"]) == "builtin"
+    assert resolve_name_collision(["builtin", "local", "git"]) == "builtin"
+
+
+def test_single_candidate_returns_itself():
+    """Tier 1: a single candidate (no actual collision) returns itself for
+    every kind in the precedence order."""
+    for kind in PLUGIN_SOURCE_PRECEDENCE:
+        assert resolve_name_collision([kind]) == kind
+
+
+def test_empty_candidates_raises():
+    """Tier 1: an empty candidate list is a caller error, not a silent
+    default winner."""
+    with pytest.raises(ValueError):
+        resolve_name_collision([])

--- a/tests/plugins/test_tokens.py
+++ b/tests/plugins/test_tokens.py
@@ -1,0 +1,133 @@
+"""Tier 1: Contract — ``${REYN_*}`` / ``${CLAUDE_*}`` token expansion (ADR 0064 §3.4/§3.5/§3.6, #3067).
+
+Pins: each canonical token expands to its real ``PluginTokenContext`` value;
+the ``${CLAUDE_*}`` alias only fires when ``alias_claude=True`` (ingestion
+boundary, §3.6); ``SKILL_DIR`` and ``PLUGIN_ROOT`` resolve to DIFFERENT
+values and neither collapses into the other (§3.4/§3.6's named distinction);
+an unrecognised token (owned by a different expansion layer, e.g.
+``expand_env``'s ``os.environ`` vars) is left untouched, proving the two
+layers are separate and compose rather than collide.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens
+
+
+def _ctx(tmp_path: Path) -> PluginTokenContext:
+    return PluginTokenContext(
+        plugin_root=tmp_path / "plugins" / "rag",
+        project_dir=tmp_path / "my-project",
+        skill_dir=tmp_path / "plugins" / "rag" / "skills" / "rag-search",
+    )
+
+
+def test_expands_each_canonical_reyn_token(tmp_path):
+    """Tier 1: each of the three canonical ``${REYN_*}`` tokens expands to
+    its real ``PluginTokenContext`` field value."""
+    ctx = _ctx(tmp_path)
+    obj = {
+        "root": "${REYN_PLUGIN_ROOT}/server.py",
+        "skill": "${REYN_SKILL_DIR}/SKILL.md",
+        "project": "${REYN_PROJECT_DIR}/config.yaml",
+    }
+
+    expanded = expand_reyn_tokens(obj, ctx)
+
+    assert expanded["root"] == f"{ctx.plugin_root}/server.py"
+    assert expanded["skill"] == f"{ctx.skill_dir}/SKILL.md"
+    assert expanded["project"] == f"{ctx.project_dir}/config.yaml"
+
+
+def test_skill_dir_and_plugin_root_are_distinct_values(tmp_path):
+    """Tier 1: §3.4/§3.6 'the SKILL_DIR vs PLUGIN_ROOT distinction' must not
+    be collapsed — expanding both tokens must not yield the same string."""
+    ctx = _ctx(tmp_path)
+    obj = "${REYN_PLUGIN_ROOT}|${REYN_SKILL_DIR}"
+
+    expanded = expand_reyn_tokens(obj, ctx)
+
+    root_str, skill_str = expanded.split("|")
+    assert root_str == str(ctx.plugin_root)
+    assert skill_str == str(ctx.skill_dir)
+    assert root_str != skill_str
+
+
+def test_skill_dir_left_unexpanded_when_absent_from_context(tmp_path):
+    """Tier 1: outside a skill-load context (mcp config / pipeline yaml),
+    ``skill_dir`` is None — ``${REYN_SKILL_DIR}`` must NOT silently default
+    to plugin_root; it is left as a literal token for a later pass."""
+    ctx = PluginTokenContext(
+        plugin_root=tmp_path / "plugins" / "rag",
+        project_dir=tmp_path / "my-project",
+    )
+
+    expanded = expand_reyn_tokens("${REYN_SKILL_DIR}/x", ctx)
+
+    assert expanded == "${REYN_SKILL_DIR}/x"
+
+
+def test_claude_alias_not_expanded_by_default(tmp_path):
+    """Tier 1: §3.6 the alias only fires at the ingestion-of-Claude-authored-
+    content boundary — never unconditionally."""
+    ctx = _ctx(tmp_path)
+
+    expanded = expand_reyn_tokens("${CLAUDE_PLUGIN_ROOT}/server.py", ctx)
+
+    assert expanded == "${CLAUDE_PLUGIN_ROOT}/server.py"
+
+
+def test_claude_alias_expands_to_same_value_as_reyn_token_when_ingesting(tmp_path):
+    """Tier 1: with ``alias_claude=True``, each ``${CLAUDE_*}`` alias expands
+    to the SAME value as its canonical ``${REYN_*}`` counterpart."""
+    ctx = _ctx(tmp_path)
+    obj = {
+        "root": "${CLAUDE_PLUGIN_ROOT}",
+        "skill": "${CLAUDE_SKILL_DIR}",
+        "project": "${CLAUDE_PROJECT_DIR}",
+    }
+
+    expanded = expand_reyn_tokens(obj, ctx, alias_claude=True)
+
+    assert expanded["root"] == str(ctx.plugin_root)
+    assert expanded["skill"] == str(ctx.skill_dir)
+    assert expanded["project"] == str(ctx.project_dir)
+
+
+def test_unrecognised_token_left_untouched_for_other_expansion_layer(tmp_path):
+    """Tier 1: a token this layer doesn't own (e.g. an ``expand_env``
+    os.environ var, or a pipeline ``ctx`` param) must be left as-is — proves
+    the two expansion layers compose instead of one clobbering the other's
+    syntax."""
+    ctx = _ctx(tmp_path)
+
+    expanded = expand_reyn_tokens("${SOME_OTHER_ENV_VAR}", ctx)
+
+    assert expanded == "${SOME_OTHER_ENV_VAR}"
+
+
+def test_recurses_into_nested_dict_and_list(tmp_path):
+    """Tier 1: expansion recurses into nested dict values and list items
+    (the whole-config-tree shape mcp/pipeline configs actually have)."""
+    ctx = _ctx(tmp_path)
+    obj = {
+        "env": {"PYTHONPATH": "${REYN_PLUGIN_ROOT}/lib"},
+        "args": ["--root", "${REYN_PLUGIN_ROOT}"],
+    }
+
+    expanded = expand_reyn_tokens(obj, ctx)
+
+    assert expanded["env"]["PYTHONPATH"] == f"{ctx.plugin_root}/lib"
+    assert expanded["args"] == ["--root", str(ctx.plugin_root)]
+
+
+def test_non_string_scalars_returned_unchanged(tmp_path):
+    """Tier 1: non-string scalars (int, bool, None) pass through unchanged,
+    mirroring ``expand_env``'s shape."""
+    ctx = _ctx(tmp_path)
+    obj = {"count": 3, "enabled": True, "nothing": None}
+
+    expanded = expand_reyn_tokens(obj, ctx)
+
+    assert expanded == obj


### PR DESCRIPTION
**[per-PR-coder]** — P1 Foundation of the plugin-model arc (ADR 0064). Substrate only; install machinery, permission gates, and the LLM/CLI/slash surfaces are P2+ and explicitly out of scope here.

## What landed

- **`src/reyn/plugins/manifest.py`** — typed `PluginManifest` for `.reyn-plugin/plugin.json` (ADR §3.1). `name` / `version` / `description` + `capabilities` as a **pydantic discriminated union** (`kind` in `mcp` / `pipelines` / `skills`), mirroring the `reyn.schemas.models` house convention (`kind: Literal[...]` per variant + `Field(discriminator="kind")` on the union) rather than a form-sniffed untyped string (Tool-Contract lens). Every capability optional, any subset (§3.1); duplicate-kind and a reserved-`.`-in-name are rejected. `load_plugin_manifest` wraps `OSError` / JSON / pydantic errors in one typed `PluginManifestError`.
- **`src/reyn/plugins/tokens.py`** — `${REYN_PLUGIN_ROOT}` / `${REYN_SKILL_DIR}` / `${REYN_PROJECT_DIR}` expansion (ADR §3.4/§3.5/§3.6) as a **layer distinct from** the `os.environ`-based `expand_env` (`security/secrets/interpolation.py`, ADR-0030): values come from an explicit `PluginTokenContext`, **never** `os.environ` — the two are deliberately not merged (owner: config variable expansion is a separate thing). `${CLAUDE_*}` alias fires **only** with `alias_claude=True` (the Claude-authored-content ingestion boundary, §3.6); the `SKILL_DIR` vs `PLUGIN_ROOT` distinction is preserved (never collapsed to one root); unrecognised tokens are left untouched so the two expansion layers compose. Note: `REYN_PROJECT_DIR` = the operator's project/workspace root, NOT `resolve_reyn_root()` (reyn's own repo/wheel) — the ADR's `resolve_reyn_root` reference is the resolver reyn uses to locate *itself*; the project dir is a dynamic per-invocation param from the live session, so it is threaded via `PluginTokenContext` rather than baked.
- **`src/reyn/plugins/source.py`** — `builtin` / `local` / `git` source-`kind` vocabulary + name-collision precedence (`builtin` wins over `local` wins over `git`, ADR §3.8/§3.10 RCE-trust ordering).

## Tests (Tier 1 Contract, real instances, no fakes)

`tests/plugins/` — non-default manifest **round-trip** (all 3 capability kinds + non-empty `entries` + description, real file I/O + `model_dump_json` → `model_validate`); each `${REYN_*}` token + the `${CLAUDE_*}` alias (only when ingesting) + `SKILL_DIR ≠ PLUGIN_ROOT` pinned; source-kind precedence.

## CI (all four gates run locally, green)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/plugins/*.py` — 22/22 OK
- `pytest` (repo root) — 8841 passed, 29 skipped
- `python scripts/verify_module_docstrings.py src/reyn/plugins/*.py` — OK

No new op `kind` is added (install op is P2), so `docs/reference/runtime/control-ir.md` / `OP_KIND_MODEL_MAP` are untouched — no sync obligation triggered.

## Test plan

- [x] Automated — Tier 1 contract tests exercise the public functions directly (manifest parse + token expansion as the substrate exerciser; P2 is the production consumer).

Closes #3067
part of #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)
