### PR TITLE
fix: unify network egress on standard proxy/CA env (#3075)

### DIFF
--- a/src/reyn/_network.py
+++ b/src/reyn/_network.py
@@ -101,6 +101,34 @@ def reset_ssl_verify_disabled_latch_for_tests() -> None:
     _ssl_verify_disabled_latched.clear()
 
 
+def resolve_ssl_verify_from_env() -> "bool | str":
+    """Resolve SSL verification from the standard env, litellm-free (#3075).
+
+    Mirrors ``litellm.get_ssl_verify``'s precedence for the in-process
+    ``urllib.request`` egress (safe-mode HTTP + safe-mode MCP registry), which
+    must not pull in the heavy ``litellm`` import just to read two env vars:
+
+      1. ``SSL_VERIFY`` ∈ {false, 0, no, off} → ``False`` (verification disabled;
+         the caller is responsible for the :func:`note_ssl_verify_disabled` audit)
+      2. ``SSL_CERT_FILE`` pointing at an existing path  → that path (custom CA)
+      3. ``REQUESTS_CA_BUNDLE`` pointing at an existing path → that path (custom CA)
+      4. otherwise → ``True`` (system trust store)
+
+    ``SSL_CERT_FILE`` is honoured natively by ``ssl.create_default_context()``
+    too; returning it here lets the urllib opener builder apply it uniformly and
+    also pick up ``REQUESTS_CA_BUNDLE`` (which the ssl module does *not* read on
+    its own — the gap #3075 closes for this egress class).
+    """
+    raw = os.environ.get("SSL_VERIFY", "").strip().lower()
+    if raw in ("false", "0", "no", "off"):
+        return False
+    for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        path = os.environ.get(name, "").strip()
+        if path and os.path.exists(path):
+            return path
+    return True
+
+
 def resolve_env_proxy_url(scheme: str = "https") -> str | None:
     """Return the standard-env proxy URL for *scheme*, or ``None``.
 

--- a/src/reyn/_network.py
+++ b/src/reyn/_network.py
@@ -1,0 +1,182 @@
+"""DRY constructor for every reyn-originated ``httpx`` client (#3075).
+
+**Not a network layer.** reyn does not reinvent proxy/CA configuration — the
+standard env (``HTTP(S)_PROXY``/``NO_PROXY``, ``SSL_CERT_FILE``/
+``REQUESTS_CA_BUNDLE``) is the single source of truth, and Python's own libs
+(``httpx``, ``litellm``, the sandbox backends) already read it when given the
+chance. This module is the one small **constructor** every reyn-owned httpx
+client goes through, so "does this client honour the standard env" is answered
+once, here, instead of re-derived ad hoc at each of the ~7 construction sites
+that existed before #3075 (some honouring it by accident of never passing
+``transport=``, one (SSRF-pin) not honouring it at all — see issue #3075's
+enumeration table).
+
+Two constructors:
+
+* :func:`build_async_http_client` — the common case (all current production
+  sites are async).
+* :func:`build_sync_http_client` — sync sibling for the one sync call site
+  (``reyn.dev.dogfood.publish``).
+
+Both default to plain ``httpx`` behaviour (``trust_env=True`` is httpx's own
+default and is preserved as long as no ``transport=`` is passed — see
+``httpx.Client.__init__``: ``allow_env_proxies = trust_env and transport is
+None``). ``pin_ssrf=True`` opts a client into
+:func:`reyn._ssrf_pin.ssrf_aware_client_kwargs`, the DNS-rebind-resistant,
+proxy-aware transport used for LLM-reachable fetch surfaces (``web_fetch``,
+the MCP ``RegistryClient``) — this is the only case that needs a ``transport=``
+override, and centralizing it here is what keeps proxy-awareness attached to
+every future SSRF-pinned client automatically.
+
+The structural completeness gate (``tests/network/test_egress_env_completeness.py``)
+asserts no ``httpx.Client(``/``httpx.AsyncClient(`` construction in ``src/reyn``
+bypasses these two functions — so a new call site that free-hands its own
+``httpx.AsyncClient(...)`` fails CI instead of silently re-opening the "almost
+every egress" gap.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import httpx
+
+    from reyn.core.events.events import EventLog
+
+logger = logging.getLogger(__name__)
+
+# ── standard env enumeration (#3075 completeness gate reads these) ────────────
+
+STANDARD_PROXY_ENV_NAMES: tuple[str, ...] = (
+    "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "ALL_PROXY",
+    "http_proxy", "https_proxy", "no_proxy", "all_proxy",
+)
+STANDARD_CA_ENV_NAMES: tuple[str, ...] = (
+    "SSL_CERT_FILE", "REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS", "PIP_CERT",
+)
+# The full set the sandbox forwards to every child by default (#3075 fix 5) —
+# a curated, known-non-secret allowlist, not a relaxation of the sandboxed
+# child's clean-env floor (secrets stay denied).
+STANDARD_NETWORK_ENV_NAMES: tuple[str, ...] = (
+    STANDARD_PROXY_ENV_NAMES + STANDARD_CA_ENV_NAMES
+)
+
+# ── ssl-verify-disabled audit hook (#3075 "ssl_verify:false" decision) ────────
+# One-time WARN + one P6 audit-event per (process, egress name) — never silent,
+# but never spammy either. A module-level latch (not per-client-instance) is
+# deliberate: the operator-set env is process-wide, so "affected egress" is a
+# process-wide fact reported once per egress class, mirroring the litellm
+# import-log-routing latch pattern in ``llm/litellm_bootstrap.py``.
+_ssl_verify_disabled_latched: set[str] = set()
+
+
+def note_ssl_verify_disabled(
+    events: "EventLog | None", egress: str
+) -> None:
+    """WARN once + emit ``network_ssl_verify_disabled`` (P6) the first time a
+    given *egress* class resolves ``verify=False`` in this process.
+
+    Called by every constructor call site whose resolved ``verify`` value is
+    ``False`` — the recommended path is a custom CA (``SSL_CERT_FILE``);
+    ``SSL_VERIFY=false`` is an explicit, audited escape hatch, not a silent one.
+    """
+    if egress in _ssl_verify_disabled_latched:
+        return
+    _ssl_verify_disabled_latched.add(egress)
+    logger.warning(
+        "SSL certificate verification is DISABLED for %s egress (SSL_VERIFY=false "
+        "or an equivalent config override). This is an explicit, audited escape "
+        "hatch — prefer a custom CA bundle via SSL_CERT_FILE/REQUESTS_CA_BUNDLE.",
+        egress,
+    )
+    if events is not None:
+        events.emit("network_ssl_verify_disabled", egress=egress)
+
+
+def reset_ssl_verify_disabled_latch_for_tests() -> None:
+    """Test-only: clear the one-shot latch so a test can re-observe the WARN/event."""
+    _ssl_verify_disabled_latched.clear()
+
+
+def resolve_env_proxy_url(scheme: str = "https") -> str | None:
+    """Return the standard-env proxy URL for *scheme*, or ``None``.
+
+    For libraries that take a single proxy URL string rather than reading env
+    themselves (``ddgs.DDGS(proxy=...)`` — #3075 fix 4). Honours the same
+    upper/lowercase + scheme-specific-then-ALL_PROXY priority httpx's own
+    ``get_environment_proxies`` uses, without pulling in NO_PROXY parsing (the
+    caller here is a single outbound search call, not a per-request mount
+    table).
+    """
+    names = (f"{scheme.upper()}_PROXY", f"{scheme.lower()}_proxy", "ALL_PROXY", "all_proxy")
+    for name in names:
+        value = os.environ.get(name, "").strip()
+        if value:
+            return value
+    return None
+
+
+# ── DRY httpx client constructors ──────────────────────────────────────────────
+
+
+def _resolve_verify_and_note(
+    verify: "bool | str", *, events: "EventLog | None", egress: str
+) -> "bool | str":
+    if verify is False:
+        note_ssl_verify_disabled(events, egress)
+    return verify
+
+
+def build_async_http_client(
+    *,
+    verify: "bool | str" = True,
+    pin_ssrf: bool = False,
+    events: "EventLog | None" = None,
+    egress: str = "unknown",
+    **client_kwargs: Any,
+) -> "httpx.AsyncClient":
+    """The one constructor for every reyn-owned ``httpx.AsyncClient`` (#3075).
+
+    ``pin_ssrf=True`` routes through :func:`reyn._ssrf_pin.ssrf_aware_client_kwargs`
+    (DNS-rebind pin, proxy-aware) — use for any client that fetches an
+    LLM-supplied or otherwise untrusted URL (``web_fetch``, the MCP
+    ``RegistryClient``). ``pin_ssrf=False`` (default) builds a plain
+    ``httpx.AsyncClient(verify=verify, **client_kwargs)`` — httpx's own
+    ``trust_env=True`` default (unset here, so it stays the default) already
+    honours the standard proxy env because no ``transport=`` is passed.
+
+    ``events``/``egress`` feed the ``verify=False`` audit hook (best-effort —
+    pass ``events=None`` for construction sites with no ``EventLog`` in scope;
+    the WARN still fires, only the P6 audit-event is skipped).
+    """
+    import httpx
+
+    verify = _resolve_verify_and_note(verify, events=events, egress=egress)
+    if pin_ssrf:
+        from reyn._ssrf_pin import ssrf_aware_client_kwargs
+
+        transport_kwargs = ssrf_aware_client_kwargs(verify=verify)
+        return httpx.AsyncClient(**transport_kwargs, **client_kwargs)
+    return httpx.AsyncClient(verify=verify, **client_kwargs)
+
+
+def build_sync_http_client(
+    *,
+    verify: "bool | str" = True,
+    events: "EventLog | None" = None,
+    egress: str = "unknown",
+    **client_kwargs: Any,
+) -> "httpx.Client":
+    """Sync sibling of :func:`build_async_http_client`.
+
+    No ``pin_ssrf`` option — no current sync call site fetches an untrusted URL
+    (the SSRF-pin transport is async-only, wrapping ``httpx.AsyncHTTPTransport``);
+    add one here if a sync SSRF-pinned client is ever needed.
+    """
+    import httpx
+
+    verify = _resolve_verify_and_note(verify, events=events, egress=egress)
+    return httpx.Client(verify=verify, **client_kwargs)

--- a/src/reyn/_ssrf_pin.py
+++ b/src/reyn/_ssrf_pin.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import asyncio
 import http.client
 import ipaddress
+import os
 import socket
 import urllib.request
 
@@ -39,6 +40,82 @@ from reyn import _ssrf_guard
 def _resolve_allow_private() -> bool:
     """Operator opt-in for private-IP fetches (env-exported by config loader)."""
     return _ssrf_guard.resolve_allow_private()
+
+
+def _ssrf_strict() -> bool:
+    """``REYN_SSRF_STRICT`` opt-in (#3075 SSRF-x-proxy decision): when set truthy,
+    a configured proxy is refused for reyn-originated SSRF-pinned egress and
+    reyn's own target-IP pin is kept instead — the operator is choosing
+    rebind-resistance over proxy routing for this class of request."""
+    return os.environ.get("REYN_SSRF_STRICT", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def ssrf_aware_client_kwargs(verify: bool | str = True) -> dict:
+    """Build the ``httpx.AsyncClient`` ``transport=``/``mounts=`` kwargs that make
+    an SSRF-pinned client honour the standard proxy env (#3075).
+
+    **The decision** (issue #3075, "SSRF-pin x proxy"): ``PinnedAsyncHTTPTransport``
+    pins each request to a pre-resolved, pre-validated IP — good DNS-rebind
+    defense for a target httpx itself resolves, but structurally exclusive with a
+    forward proxy: when a proxy is in play, the PROXY does the final target
+    resolution/connect, not reyn, so there is no target IP for reyn to pin.
+
+    Resolution (UX-first, tightening opt-in):
+
+    * **No proxy configured** (no ``HTTP_PROXY``/``HTTPS_PROXY``/``ALL_PROXY`` for
+      the request's scheme, honouring ``NO_PROXY``) — unchanged: every request
+      goes through ``PinnedAsyncHTTPTransport(verify=verify)``, reyn's own
+      resolve-validate-pin.
+    * **Proxy configured, ``REYN_SSRF_STRICT`` unset** — the PROXY endpoint itself
+      is SSRF-validated once at construction time (it is a fixed,
+      operator-configured host, not LLM-supplied), then requests for that scheme
+      are routed through ``httpx.AsyncHTTPTransport(proxy=..., verify=verify)``
+      — final-target rebind protection is delegated to the proxy (its job: it is
+      the one actually resolving + connecting to the target). ``NO_PROXY``
+      exclusions still resolve direct through the pinned transport.
+    * **Proxy configured, ``REYN_SSRF_STRICT`` truthy** — the proxy is refused for
+      this SSRF-pinned client entirely; every request stays on
+      ``PinnedAsyncHTTPTransport`` (reyn's own pin), matching the no-proxy case.
+      An operator who needs rebind-resistance on a request stream they don't
+      trust the corporate proxy for opts into this.
+
+    Returns a dict suitable for ``httpx.AsyncClient(**ssrf_aware_client_kwargs(...))``
+    (merge with the caller's other kwargs) — always contains ``"transport"``, and
+    contains ``"mounts"`` only when a (non-strict) proxy was found.
+    """
+    default_transport = PinnedAsyncHTTPTransport(verify=verify)
+    if _ssrf_strict():
+        return {"transport": default_transport}
+
+    from httpx._utils import get_environment_proxies
+
+    env_proxies = get_environment_proxies()
+    if not env_proxies:
+        return {"transport": default_transport}
+
+    import httpx
+
+    mounts: dict[str, object] = {}
+    for pattern, proxy_url in env_proxies.items():
+        if proxy_url is None:
+            # NO_PROXY exclusion pattern — explicit "no proxy for this pattern",
+            # httpx represents this as a mount to None. Leave it None so httpx
+            # falls back to the default transport (our pin) for excluded hosts.
+            mounts[pattern] = None
+            continue
+        proxy_host = httpx.URL(proxy_url).host
+        # The proxy endpoint is operator-configured (standard env, not
+        # LLM-supplied), so a one-shot validation at construction time is the
+        # right scope — not per-request re-pinning (the proxy resolves the
+        # actual target on every request, which is the whole point of using it).
+        _ssrf_guard.assert_fetch_host_allowed(
+            proxy_host, allow_private=_resolve_allow_private()
+        )
+        mounts[pattern] = httpx.AsyncHTTPTransport(proxy=proxy_url, verify=verify)
+
+    return {"transport": default_transport, "mounts": mounts}
 
 
 # ── urllib (stdlib http.client) ───────────────────────────────────────────────

--- a/src/reyn/_ssrf_pin.py
+++ b/src/reyn/_ssrf_pin.py
@@ -32,6 +32,7 @@ import http.client
 import ipaddress
 import os
 import socket
+import urllib.parse
 import urllib.request
 
 from reyn import _ssrf_guard
@@ -110,9 +111,14 @@ def ssrf_aware_client_kwargs(verify: bool | str = True) -> dict:
         # LLM-supplied), so a one-shot validation at construction time is the
         # right scope — not per-request re-pinning (the proxy resolves the
         # actual target on every request, which is the whole point of using it).
-        _ssrf_guard.assert_fetch_host_allowed(
-            proxy_host, allow_private=_resolve_allow_private()
-        )
+        # #3075 private-IP proxy exempt (architect-recommended): a corporate
+        # forward proxy commonly lives on an RFC1918 address, and the operator
+        # explicitly configured it — so RFC1918/ULA is allowed here even when
+        # the run-wide ``allow_private`` is off. ``assert_fetch_host_allowed``
+        # still blocks loopback / link-local / cloud-metadata for the proxy host
+        # (see ``_ssrf_guard._deny_reason``): those are never a legitimate
+        # operator proxy and remain a hard SSRF deny.
+        _ssrf_guard.assert_fetch_host_allowed(proxy_host, allow_private=True)
         mounts[pattern] = httpx.AsyncHTTPTransport(proxy=proxy_url, verify=verify)
 
     return {"transport": default_transport, "mounts": mounts}
@@ -360,3 +366,113 @@ class PinnedAsyncHTTPTransport:
         )
 
         return await self._transport.handle_async_request(pinned_request)
+
+
+# ── urllib (sync, safe-mode) DRY opener constructor ──────────────────────────
+
+
+def _standard_env_proxies() -> dict[str, str]:
+    """Env-only proxy map (mirrors httpx's ``get_environment_proxies`` scope).
+
+    ``urllib.request.getproxies_environment()`` reads ONLY ``*_PROXY`` env vars
+    (not the macOS/Windows system proxy config that bare ``getproxies()`` also
+    consults), keeping the urllib egress's proxy source identical to the httpx
+    egress's — the standard env, nothing more. ``NO_PROXY`` is applied per-host
+    at request time by ``ProxyHandler`` (via ``proxy_bypass``), so an excluded
+    host still bypasses the proxy correctly.
+    """
+    return urllib.request.getproxies_environment()
+
+
+def _build_ca_ssl_context(events: object = None, egress: str = "urllib") -> object:
+    """SSL context for the urllib egress honouring the standard CA env (#3075).
+
+    Resolution via :func:`reyn._network.resolve_ssl_verify_from_env`:
+      * ``SSL_VERIFY=false`` → an unverified context, plus a one-time WARN +
+        ``network_ssl_verify_disabled`` P6 audit-event (never silent).
+      * a CA path (``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE``) → a default context
+        with that bundle loaded (``ssl.create_default_context`` already reads
+        ``SSL_CERT_FILE``; loading the resolved path also covers
+        ``REQUESTS_CA_BUNDLE``, which the ssl module does not read on its own).
+      * ``True`` → the system default context.
+    """
+    import ssl
+
+    from reyn._network import note_ssl_verify_disabled, resolve_ssl_verify_from_env
+
+    verify = resolve_ssl_verify_from_env()
+    if verify is False:
+        note_ssl_verify_disabled(events, egress)  # type: ignore[arg-type]
+        return ssl._create_unverified_context()
+    ctx = ssl.create_default_context()  # reads SSL_CERT_FILE / SSL_CERT_DIR
+    if isinstance(verify, str):
+        ctx.load_verify_locations(cafile=verify)
+    return ctx
+
+
+def ssrf_aware_urllib_opener(
+    *extra_handlers: object,
+    events: object = None,
+    egress: str = "urllib",
+) -> object:
+    """Build a urllib opener honouring the standard proxy/CA env + strict (#3075).
+
+    The single DRY constructor every reyn-owned ``build_opener`` call routes
+    through — the urllib sibling of :func:`ssrf_aware_client_kwargs`, so the
+    completeness gate can assert no ``urllib.request.build_opener`` in
+    ``src/reyn`` bypasses it (a new urllib egress that free-hands its own opener
+    fails CI instead of shipping proxy/CA-blind).
+
+    Handler selection mirrors the SSRF-pin × proxy decision exactly:
+
+    * **No proxy in the standard env, or ``REYN_SSRF_STRICT`` set** — the pinned
+      handlers (``_PinnedHTTP(S)Handler``): DNS-rebind-resistant direct connect,
+      with the CA-aware SSL context applied to the HTTPS pin.
+    * **Proxy in the standard env, non-strict** — each proxy endpoint is
+      validated once (private-IP exempt, same rule as the httpx path: an
+      operator-configured corporate proxy on RFC1918 is allowed, loopback /
+      link-local / cloud-metadata stay blocked), then requests route through a
+      ``ProxyHandler`` + a plain (non-pinned) CA-aware ``HTTPSHandler``. The
+      proxy performs the final target resolution, so pinning the request host is
+      meaningless — identical tradeoff to the httpx egress dropping the pinned
+      transport when a proxy transport is mounted. Check-time SSRF gating on the
+      target is still enforced by the caller's redirect/initial-host guards
+      passed in ``extra_handlers``.
+
+    ``extra_handlers`` (e.g. the caller's SSRF redirect handler) are prepended so
+    they take effect on every request regardless of the proxy branch.
+    """
+    ssl_ctx = _build_ca_ssl_context(events=events, egress=egress)
+    proxies = {} if _ssrf_strict() else _standard_env_proxies()
+
+    if proxies:
+        for proxy_url in proxies.values():
+            parsed = urllib.parse.urlparse(
+                proxy_url if "://" in proxy_url else f"http://{proxy_url}"
+            )
+            proxy_host = parsed.hostname or ""
+            if proxy_host:
+                # Private-IP exempt (architect-recommended, #3075): trust the
+                # operator's configured proxy on RFC1918; metadata/loopback/
+                # link-local remain a hard deny (see _ssrf_guard._deny_reason).
+                _ssrf_guard.assert_fetch_host_allowed(proxy_host, allow_private=True)
+        handlers = [
+            *extra_handlers,
+            urllib.request.ProxyHandler(proxies),
+            urllib.request.HTTPSHandler(context=ssl_ctx),  # type: ignore[arg-type]
+        ]
+    else:
+        # An explicit empty ProxyHandler is REQUIRED here, not merely tidy:
+        # ``build_opener`` auto-adds a default ``ProxyHandler()`` (which reads the
+        # env proxies) whenever the caller passes none — so without this, the
+        # ``REYN_SSRF_STRICT`` branch and the genuinely-no-proxy branch would BOTH
+        # silently proxy via the auto-added default, defeating strict entirely.
+        # ``ProxyHandler({})`` registers no proxy methods AND suppresses the
+        # default, so the pinned direct-connect path is truly proxy-free.
+        handlers = [
+            *extra_handlers,
+            urllib.request.ProxyHandler({}),
+            _PinnedHTTPHandler(),
+            _PinnedHTTPSHandler(context=ssl_ctx),  # type: ignore[arg-type]
+        ]
+    return urllib.request.build_opener(*handlers)

--- a/src/reyn/api/safe/http.py
+++ b/src/reyn/api/safe/http.py
@@ -44,11 +44,10 @@ from urllib.error import HTTPError as _HTTPError
 from urllib.parse import urlparse as _urlparse
 from urllib.request import HTTPRedirectHandler as _HTTPRedirectHandler
 from urllib.request import Request as _Request
-from urllib.request import build_opener as _build_opener
 
 from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
-from reyn._ssrf_pin import _PinnedHTTPHandler, _PinnedHTTPSHandler
+from reyn._ssrf_pin import ssrf_aware_urllib_opener
 
 # ── Internal state ─────────────────────────────────────────────────────────
 #
@@ -132,13 +131,15 @@ class _SSRFSafeRedirectHandler(_HTTPRedirectHandler):
 # kept under the ``_urlopen`` name as the stable seam ``_request`` calls (and
 # that tests patch to inject fake responses) — a drop-in for the old
 # ``urllib.request.urlopen`` but redirect-safe.
-# #1972: _PinnedHTTP(S)Handler ensure each connection goes to the pre-validated
-# IP (pinned at check time), closing the DNS-rebind TOCTOU window.
-_urlopen = _build_opener(
-    _SSRFSafeRedirectHandler(),
-    _PinnedHTTPHandler(),
-    _PinnedHTTPSHandler(),
-).open
+# #1972: the pinned handlers ensure each connection goes to the pre-validated IP
+# (pinned at check time), closing the DNS-rebind TOCTOU window.
+# #3075: constructed via the DRY ``ssrf_aware_urllib_opener`` so this egress
+# honours the standard proxy/CA env + ``REYN_SSRF_STRICT`` like every other
+# reyn egress (no reyn EventLog is in scope at this safe-mode import, so an
+# ``SSL_VERIFY=false`` here still WARNs but skips the P6 audit-event).
+_urlopen = ssrf_aware_urllib_opener(
+    _SSRFSafeRedirectHandler(), egress="safe.http"
+).open  # type: ignore[attr-defined]
 
 
 def _response_dict(resp: Any) -> dict:

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -316,7 +316,7 @@ async def handle(
         from reyn.core.registry.client import RegistryClient, RegistryError
 
         try:
-            async with RegistryClient() as client:
+            async with RegistryClient(events=ctx.events) as client:
                 server_json = await client.get_server(op.server_id)
         except RegistryError as exc:
             # #1471: 404 = server not in registry → decision-enabling guidance so

--- a/src/reyn/core/op_runtime/web.py
+++ b/src/reyn/core/op_runtime/web.py
@@ -5,7 +5,7 @@ import asyncio
 import html.parser
 from typing import Literal
 
-from reyn._ssrf_pin import PinnedAsyncHTTPTransport
+from reyn._network import build_async_http_client
 from reyn.schemas.models import WebFetchIROp, WebSearchIROp
 
 from . import register
@@ -287,16 +287,22 @@ async def handle_web_fetch(op: WebFetchIROp, ctx: OpContext) -> dict:
     try:
         # SSL verification — priority: reyn.yaml web.fetch config → env-var chain.
         # #1956: follow_redirects=False — we follow manually so each hop is gated.
-        # #1972: PinnedAsyncHTTPTransport pins each hop's connect to the pre-
-        # validated IP (resolve_and_validate at gate time) so the client never
-        # re-resolves the host at connect time — closing the DNS-rebind TOCTOU.
-        # The manual redirect loop's _gate_hop L1+L2 logic is preserved; the
-        # transport adds connect-time pinning on top of the check-time gate.
-        async with httpx.AsyncClient(
+        # #1972/#3075: pin_ssrf=True routes through PinnedAsyncHTTPTransport,
+        # which pins each hop's connect to the pre-validated IP
+        # (resolve_and_validate at gate time) so the client never re-resolves
+        # the host at connect time — closing the DNS-rebind TOCTOU — AND (as of
+        # #3075) is proxy-aware: when the standard HTTP(S)_PROXY env is set, the
+        # proxy endpoint is validated once and final-target rebind protection is
+        # delegated to it (see ``ssrf_aware_client_kwargs`` docstring). The
+        # manual redirect loop's _gate_hop L1+L2 logic is preserved either way.
+        async with build_async_http_client(
             timeout=op.timeout,
             follow_redirects=False,
             headers={"User-Agent": "reyn/1.0"},
-            transport=PinnedAsyncHTTPTransport(verify=_resolve_ssl_verify(ctx)),
+            verify=_resolve_ssl_verify(ctx),
+            pin_ssrf=True,
+            events=ctx.events,
+            egress="web_fetch",
         ) as client:
             _url = op.url
             for _hop in range(_ssrf_guard.MAX_REDIRECTS + 1):

--- a/src/reyn/core/registry/client.py
+++ b/src/reyn/core/registry/client.py
@@ -25,11 +25,8 @@ import os
 import urllib.parse
 from typing import TYPE_CHECKING
 
-from reyn import _ssrf_guard
-from reyn._ssrf_pin import PinnedAsyncHTTPTransport
-
 if TYPE_CHECKING:
-    pass
+    from reyn.core.events.events import EventLog
 
 
 class RegistryError(Exception):
@@ -150,13 +147,22 @@ class RegistryClient:
     existing env-var behaviour so all current callers remain unaffected.
     """
 
-    def __init__(self, verify: bool | str | None = None) -> None:
+    def __init__(
+        self,
+        verify: bool | str | None = None,
+        *,
+        events: "EventLog | None" = None,
+    ) -> None:
         self._client = None  # httpx.AsyncClient — lazy init
         self._verify = verify  # None = use litellm env-var fallback
+        # Optional — op-handler callers (mcp_install.py) pass ctx.events so a
+        # verify=False resolution emits the #3075 audit-event; standalone CLI
+        # callers that construct RegistryClient outside an op context omit it
+        # (the WARN still fires; only the P6 event is skipped — see
+        # reyn._network.note_ssl_verify_disabled).
+        self._events = events
 
     async def __aenter__(self) -> "RegistryClient":
-        import httpx
-
         # perf/log-routing chokepoint: this client can be the FIRST litellm
         # import in the process — funnel it through ensure_litellm_ready() so
         # litellm's import-time console log routing (#2929) wraps it too
@@ -165,18 +171,24 @@ class RegistryClient:
         ensure_litellm_ready()
         from litellm.llms.custom_httpx.http_handler import get_ssl_verify
 
+        from reyn._network import build_async_http_client
+
         # Resolve the verify value: explicit arg takes priority; None falls
         # through to the litellm env-var chain (same as web_fetch handler).
         verify = self._verify if self._verify is not None else get_ssl_verify()
         # SSL verification — priority: constructor arg → litellm env-var chain.
-        # #1972: PinnedAsyncHTTPTransport replaces the old event_hooks approach —
+        # #1972/#3075: pin_ssrf=True routes through PinnedAsyncHTTPTransport —
         # it both validates (L2 SSRF IP-deny, #1956) AND pins the connect-time
-        # socket to the pre-validated IP, closing the DNS-rebind TOCTOU window.
-        self._client = httpx.AsyncClient(
+        # socket to the pre-validated IP, closing the DNS-rebind TOCTOU window,
+        # and (as of #3075) is proxy-aware — see ``ssrf_aware_client_kwargs``.
+        self._client = build_async_http_client(
             timeout=15.0,
             follow_redirects=True,
             headers={"User-Agent": "reyn/1.0"},
-            transport=PinnedAsyncHTTPTransport(verify=verify),
+            verify=verify,
+            pin_ssrf=True,
+            events=self._events,
+            egress="mcp_registry",
         )
         return self
 

--- a/src/reyn/dev/dogfood/publish.py
+++ b/src/reyn/dev/dogfood/publish.py
@@ -404,8 +404,6 @@ def _graphql_request(
     httpx.Client configured with a MockTransport so we avoid network I/O
     without introducing MagicMock.
     """
-    import httpx
-
     payload = {"query": query}
     if variables:
         payload["variables"] = variables
@@ -418,7 +416,9 @@ def _graphql_request(
 
     owns_client = False
     if http_client is None:
-        http_client = httpx.Client(timeout=15.0)
+        from reyn._network import build_sync_http_client
+
+        http_client = build_sync_http_client(timeout=15.0, egress="github_graphql")
         owns_client = True
 
     try:

--- a/src/reyn/interfaces/repl/remote_client.py
+++ b/src/reyn/interfaces/repl/remote_client.py
@@ -116,7 +116,11 @@ async def run_remote_repl(
     if token:
         params["token"] = token
 
-    async with httpx.AsyncClient(timeout=httpx.Timeout(None, connect=10.0)) as client:
+    from reyn._network import build_async_http_client
+
+    async with build_async_http_client(
+        timeout=httpx.Timeout(None, connect=10.0), egress="remote_repl"
+    ) as client:
         # Monotonic timestamp of the last client→server POST of ANY kind (a real
         # turn/answer/cancel, or a prior heartbeat). The heartbeat loop piggybacks
         # on real traffic: if one already crossed the wire within the interval

--- a/src/reyn/interfaces/web/notifications.py
+++ b/src/reyn/interfaces/web/notifications.py
@@ -68,7 +68,7 @@ async def post_webhook(
     created automatically.
     """
     try:
-        import httpx
+        import httpx  # noqa: F401 — availability probe only; see except below
     except ImportError:
         logger.warning(
             "webhook post skipped: httpx not installed. "
@@ -81,7 +81,7 @@ async def post_webhook(
 
     for attempt_idx in range(policy.max_attempts):
         last_result = await _post_once(
-            url, payload, timeout=timeout, httpx_mod=httpx,
+            url, payload, timeout=timeout,
             http_client=_http_client,
         )
         if last_result.ok:
@@ -106,7 +106,6 @@ async def _post_once(
     payload: dict,
     *,
     timeout: float,
-    httpx_mod: object,
     http_client: "httpx.AsyncClient | None",
 ) -> DeliveryResult:
     """One attempt at POSTing the payload, returning categorised result."""
@@ -114,7 +113,11 @@ async def _post_once(
         if http_client is not None:
             response = await http_client.post(url, json=payload)
         else:
-            async with httpx_mod.AsyncClient(timeout=timeout) as client:
+            from reyn._network import build_async_http_client
+
+            async with build_async_http_client(
+                timeout=timeout, egress="webhook_notification"
+            ) as client:
                 response = await client.post(url, json=payload)
     except Exception as exc:  # noqa: BLE001 — transport errors categorised
         logger.warning("webhook post failed: url=%s error=%s", url, exc)

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -124,5 +124,15 @@ def ensure_litellm_ready() -> None:
         try:
             import litellm
             litellm.suppress_debug_info = True
+            # #3075 fix 1: litellm's aiohttp transport defaults
+            # aiohttp_trust_env=False, so it is proxy-blind even when the
+            # operator's standard HTTP(S)_PROXY/NO_PROXY env is set — the
+            # highest-volume egress reyn originates (every LLM/embedding call)
+            # was the sharpest non-conformer in the #3075 enumeration. Flipping
+            # this makes litellm read the standard proxy env like every other
+            # conforming egress; it already honours SSL_CERT_FILE/
+            # REQUESTS_CA_BUNDLE via get_ssl_verify(), so this is the one
+            # missing piece for full conformance.
+            litellm.aiohttp_trust_env = True
         except Exception:  # noqa: BLE001 — best-effort; never block the caller on this
             pass

--- a/src/reyn/llm/litellm_bootstrap.py
+++ b/src/reyn/llm/litellm_bootstrap.py
@@ -115,6 +115,17 @@ def ensure_litellm_ready() -> None:
     Call this before any bare ``import litellm`` in a lazy call site that
     might be the first one to run in a given process — it costs one boolean
     check on every call after the first, so it is cheap to call defensively.
+
+    #3075 chokepoint coverage: this is the sole place the
+    ``litellm.aiohttp_trust_env = True`` flip is applied, and BOTH litellm
+    egress families reach it before their first real call — the completion
+    path via ``recorded_acompletion`` (``reyn.llm.llm``, the #1190 single
+    ``litellm.acompletion`` chokepoint, which calls this before the
+    ``acompletion``) and the embedding path via
+    ``LiteLLMEmbeddingProvider.embed_batch`` (``reyn.data.embedding.
+    litellm_provider``, which calls this before ``_aembedding_bounded`` →
+    ``litellm.aembedding``). So the proxy-trust flip covers every
+    litellm-originated request, not just chat.
     """
     global _litellm_ready
     if _litellm_ready:

--- a/src/reyn/mcp/registry.py
+++ b/src/reyn/mcp/registry.py
@@ -86,7 +86,7 @@ from typing import Any
 # user code through this safe namespace surface.
 from reyn import _ssrf_guard
 from reyn._http_limits import read_capped
-from reyn._ssrf_pin import _PinnedHTTPHandler, _PinnedHTTPSHandler
+from reyn._ssrf_pin import ssrf_aware_urllib_opener
 from reyn.core.registry import cache as _cache
 from reyn.core.registry.client import _dedup_by_latest
 from reyn.core.registry.models import server_info_from_raw
@@ -157,12 +157,11 @@ def _http_get_json(url: str) -> dict:
     req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
     # #1956 SSRF: gate the initial host + (via the opener's redirect handler)
     # each redirect hop against the IP-deny guard. Both surface as RegistryError.
-    # #1972: _PinnedHTTP(S)Handler pin the socket connect to the pre-validated IP.
-    opener = urllib.request.build_opener(
-        _SSRFRedirectHandler(),
-        _PinnedHTTPHandler(),
-        _PinnedHTTPSHandler(),
-    )
+    # #1972: the pinned handlers pin the socket connect to the pre-validated IP.
+    # #3075: built via the DRY ``ssrf_aware_urllib_opener`` so this egress honours
+    # the standard proxy/CA env + ``REYN_SSRF_STRICT`` (the opener is rebuilt per
+    # call, so a proxy/CA env change is picked up on the next registry request).
+    opener = ssrf_aware_urllib_opener(_SSRFRedirectHandler(), egress="mcp.registry")
     try:
         _ssrf_guard.assert_fetch_host_allowed(
             urllib.parse.urlparse(url).hostname or "",

--- a/src/reyn/observability/otel_exporter.py
+++ b/src/reyn/observability/otel_exporter.py
@@ -521,6 +521,27 @@ def build_otel_exporter(
         return exporter
 
 
+def _bridge_standard_ca_to_otel_env() -> None:
+    """#3075 fix 3: bridge the standard CA env to OTEL's own env var.
+
+    The OTLP HTTP exporters (``opentelemetry-exporter-otlp-proto-http``) read
+    ``OTEL_EXPORTER_OTLP_CERTIFICATE`` for a custom CA bundle — a DIFFERENT
+    variable than the standard ``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE`` every
+    other reyn egress honours, so an operator with a corporate CA configured
+    the standard way was silently unauthenticated (or failing TLS) for OTEL
+    only. Bridge once, here, right before the exporter reads its env — never
+    overrides an operator who already set ``OTEL_EXPORTER_OTLP_CERTIFICATE``
+    explicitly (``setdefault``).
+    """
+    if os.environ.get("OTEL_EXPORTER_OTLP_CERTIFICATE"):
+        return
+    for name in ("SSL_CERT_FILE", "REQUESTS_CA_BUNDLE"):
+        ca_path = os.environ.get(name, "").strip()
+        if ca_path:
+            os.environ["OTEL_EXPORTER_OTLP_CERTIFICATE"] = ca_path
+            return
+
+
 def _build_pipeline(
     *,
     endpoint: str,
@@ -533,6 +554,8 @@ def _build_pipeline(
     atexit shutdown. Raises if the OpenTelemetry SDK is not installed — the
     caller catches and falls back to not-attached (fail-open)."""
     import atexit
+
+    _bridge_standard_ca_to_otel_env()
 
     from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.metrics import MeterProvider

--- a/src/reyn/security/sandbox/backends/landlock.py
+++ b/src/reyn/security/sandbox/backends/landlock.py
@@ -37,7 +37,7 @@ import subprocess
 
 from .._subprocess_io import communicate_capped, kill_process_tree
 from ..backend import SandboxResult, WrappedCommand
-from ..policy import SandboxPolicy, expand_policy_path
+from ..policy import SandboxPolicy, expand_policy_path, resolve_passthrough_env
 from .seccomp import load_seccomp_filter, preload_native_dependency
 
 _logger = logging.getLogger(__name__)
@@ -387,11 +387,10 @@ class LandlockBackend:
 
         abi = self._abi_version or 0  # guaranteed non-None after available() == True
 
-        # Build env from the passthrough allowlist (mirrors NoopBackend exactly).
-        env: dict[str, str] = {}
-        for name in policy.env_passthrough:
-            if name in os.environ:
-                env[name] = os.environ[name]
+        # Build env from the passthrough allowlist ∪ the standard proxy/CA env
+        # (#3075) — mirrors NoopBackend/SeatbeltBackend exactly via the shared
+        # resolve_passthrough_env chokepoint.
+        env = resolve_passthrough_env(policy)
         if "PATH" not in env and "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
 

--- a/src/reyn/security/sandbox/backends/seatbelt.py
+++ b/src/reyn/security/sandbox/backends/seatbelt.py
@@ -31,7 +31,11 @@ from pathlib import Path
 
 from reyn.security.sandbox._subprocess_io import communicate_capped, kill_process_tree
 from reyn.security.sandbox.backend import SandboxResult, WrappedCommand
-from reyn.security.sandbox.policy import SandboxPolicy, expand_policy_path
+from reyn.security.sandbox.policy import (
+    SandboxPolicy,
+    expand_policy_path,
+    resolve_passthrough_env,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -245,11 +249,9 @@ class SeatbeltBackend:
         """
         profile_text = _build_sbpl_profile(policy)
 
-        # Build env from passthrough allowlist; fall back PATH if not listed.
-        env: dict[str, str] = {}
-        for name in policy.env_passthrough:
-            if name in os.environ:
-                env[name] = os.environ[name]
+        # Build env from passthrough allowlist ∪ the standard proxy/CA env
+        # (#3075); fall back PATH if not listed.
+        env = resolve_passthrough_env(policy)
         if "PATH" not in env and "PATH" in os.environ:
             env["PATH"] = os.environ["PATH"]
 

--- a/src/reyn/security/sandbox/noop_backend.py
+++ b/src/reyn/security/sandbox/noop_backend.py
@@ -18,7 +18,7 @@ import subprocess
 
 from ._subprocess_io import communicate_capped, kill_process_tree
 from .backend import SandboxBackend, SandboxResult, WrappedCommand
-from .policy import SandboxPolicy
+from .policy import SandboxPolicy, resolve_passthrough_env
 
 _logger = logging.getLogger(__name__)
 
@@ -44,10 +44,9 @@ def _reset_warning_for_tests() -> None:
 
 
 def _build_env(policy: SandboxPolicy) -> dict[str, str]:
-    env: dict[str, str] = {}
-    for name in policy.env_passthrough:
-        if name in os.environ:
-            env[name] = os.environ[name]
+    # #3075: resolve_passthrough_env unions policy.env_passthrough with the
+    # standard proxy/CA env (forwarded to every sandboxed child by default).
+    env = resolve_passthrough_env(policy)
     if "PATH" not in env and "PATH" in os.environ:
         env["PATH"] = os.environ["PATH"]
     return env

--- a/src/reyn/security/sandbox/policy.py
+++ b/src/reyn/security/sandbox/policy.py
@@ -36,6 +36,7 @@ Fields:
 """
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -83,6 +84,31 @@ DEFAULT_SENSITIVE_READ_DENY: tuple[str, ...] = (
     "~/.docker/config.json",
     "~/.netrc",
 )
+
+
+def resolve_passthrough_env(policy: "SandboxPolicy") -> dict[str, str]:
+    """Build the env dict every sandbox backend passes to a spawned child
+    (#3075 fix 5 — the shared chokepoint all three backends call).
+
+    ``policy.env_passthrough`` ∪ the standard proxy/CA env
+    (:data:`reyn._network.STANDARD_NETWORK_ENV_NAMES`) — the sandbox forwards
+    the standard set to EVERY sandboxed child by default, generalising the
+    git-clone-specific forwarding that used to live only in
+    ``skill_install.py`` (#3075's sharpest symptom: git-clone conformed,
+    its sibling uvx/npx subprocess did not). This is additive only — an
+    operator-declared ``env_passthrough`` entry is still honoured, and no
+    secret-bearing var is ever added here (the standard set is a curated,
+    known-non-secret allowlist: proxy URLs + CA bundle *paths*, not
+    credentials — the CA bundle *file* was already broad-read-floor
+    readable; only the env var pointing at it was missing before #3075).
+
+    PATH fallback is applied by each backend after calling this (preserves the
+    existing "PATH always available" behaviour independent of this set).
+    """
+    from reyn._network import STANDARD_NETWORK_ENV_NAMES
+
+    names = set(policy.env_passthrough) | set(STANDARD_NETWORK_ENV_NAMES)
+    return {name: os.environ[name] for name in names if name in os.environ}
 
 
 @dataclass

--- a/src/reyn/security/secrets/oauth.py
+++ b/src/reyn/security/secrets/oauth.py
@@ -284,10 +284,10 @@ async def _post_refresh(
     pass an httpx.AsyncClient configured with a MockTransport so we
     avoid network I/O without introducing MagicMock.
     """
-    import httpx
-
     if http_client is None:
-        http_client = httpx.AsyncClient(timeout=timeout)
+        from reyn._network import build_async_http_client
+
+        http_client = build_async_http_client(timeout=timeout, egress="oauth_refresh")
         owns_client = True
     else:
         owns_client = False
@@ -628,11 +628,13 @@ async def device_grant_flow(
     5. After expires_in seconds without success → raise
        DeviceGrantError(error_code="timeout").
     """
-    import httpx
-
     owns_client = http_client is None
     if owns_client:
-        http_client = httpx.AsyncClient(timeout=_DEVICE_HTTP_TIMEOUT)
+        from reyn._network import build_async_http_client
+
+        http_client = build_async_http_client(
+            timeout=_DEVICE_HTTP_TIMEOUT, egress="oauth_device_grant"
+        )
 
     try:
         # ── Step 1: request device_code ──────────────────────────────────

--- a/src/reyn/tools/search_backends/duckduckgo.py
+++ b/src/reyn/tools/search_backends/duckduckgo.py
@@ -1,3 +1,5 @@
+from reyn._network import resolve_env_proxy_url
+
 from . import SearchResult
 
 
@@ -13,7 +15,14 @@ class DuckDuckGoBackend:
                 "Install with: pip install ddgs"
             ) from exc
 
-        raw = list(DDGS().text(query, max_results=max_results))
+        # #3075 fix 4: ddgs only reads its own DDGS_PROXY env var, not the
+        # standard HTTP(S)_PROXY/ALL_PROXY — pass the resolved standard-env
+        # proxy explicitly so this egress conforms like every other one.
+        raw = list(
+            DDGS(proxy=resolve_env_proxy_url("https")).text(
+                query, max_results=max_results
+            )
+        )
         return [
             SearchResult(
                 title=hit.get("title", ""),

--- a/tests/test_install_package_visibility_1471.py
+++ b/tests/test_install_package_visibility_1471.py
@@ -65,7 +65,15 @@ class _RegistryClientNotFound:
     Used via monkeypatch.setattr on reyn.core.registry.client.RegistryClient so
     mcp_install.handle's local import resolves to this class without touching
     the real network.  No AsyncMock — pure subclass with real coroutine methods.
+
+    ``__init__`` accepts (and ignores) the real ``RegistryClient``'s
+    ``verify``/``events`` constructor args (#3075 added ``events``) so this
+    fake's signature stays a drop-in match for however ``mcp_install.handle``
+    constructs it.
     """
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
 
     async def __aenter__(self) -> "_RegistryClientNotFound":
         return self
@@ -79,6 +87,9 @@ class _RegistryClientNotFound:
 
 class _RegistryClientNetworkError:
     """Real fake RegistryClient that raises a non-404 network error."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
 
     async def __aenter__(self) -> "_RegistryClientNetworkError":
         return self

--- a/tests/test_network_egress_env_completeness_3075.py
+++ b/tests/test_network_egress_env_completeness_3075.py
@@ -3,25 +3,38 @@
 Issue #3075's requirement is completeness, not a fix per class: EVERY
 reyn-originated network egress honours the standard proxy/CA env
 (``HTTP(S)_PROXY``/``NO_PROXY``, ``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE``), zero
-exceptions. This file is the "enumerate, don't curate" spine for that claim:
+exceptions. This file is the "enumerate, don't curate" spine for that claim.
 
-* one behavioral test per egress class from #3075's enumeration table, each
-  asserting the class actually reads a SENTINEL value from the standard env
-  (not "the code looks right" — an observed effect of setting the env), and
-* two structural (AST) guards: no ``httpx.Client(``/``httpx.AsyncClient(``
-  construction in ``src/reyn`` bypasses the DRY constructor
-  (``reyn._network.build_async_http_client`` / ``build_sync_http_client``), and
-  the DRY constructor module DOES construct httpx clients (positive guard —
-  the AST-guard pattern from ``test_present_sink_ast_guard_2708.py``: a
-  bypass-check that always passes because the chokepoint is empty is not a
-  guard).
+The enumeration was grep-derived, not memory-derived (an earlier curated version
+missed two whole transport families — ``urllib.request`` and third-party libs —
+which two reviewers found separately, the classic "curated subset" tell). The
+egress classes, by transport:
 
-A new egress class that skips this file's enumeration is invisible to the
-completeness claim by construction — the intended failure mode is "someone
-adds egress #7 and forgets to enumerate it here", which this file cannot
-detect on its own (that's why the structural guard below matters: a NEW
-call site is caught even if nobody remembers to add a class-specific test for
-it, as long as it goes through ``httpx.Client``/``httpx.AsyncClient`` directly).
+* **httpx** (async/sync) — litellm, web_fetch/RegistryClient (SSRF-pin),
+  remote-MCP/OAuth/webhook/remote-repl. All go through the DRY
+  ``reyn._network.build_async_http_client`` / ``build_sync_http_client``.
+* **urllib.request** — safe-mode HTTP (``reyn.api.safe.http``) + safe-mode MCP
+  registry (``reyn.mcp.registry``). Both go through the DRY
+  ``reyn._ssrf_pin.ssrf_aware_urllib_opener``.
+* **third-party libs reyn does not own the client for** — ddgs (web_search),
+  huggingface_hub (local-embed download, via ``requests``), fastmcp
+  (remote-MCP transport, via ``httpx``). These conform by the lib's own
+  ``trust_env``-style default; the witness tests below RED if a lib ships a
+  transport that stops honouring the env (the exact litellm-``aiohttp_trust_env``
+  degradation, generalised).
+* **subprocess** — uvx/npx/uv, via the sandbox child-env forward.
+
+For each class: a behavioral test asserting a SENTINEL value from the standard
+env is actually honoured (an observed effect, not "the code looks right"), plus
+structural (AST) guards that no construction in ``src/reyn`` bypasses the DRY
+constructor for that transport — one for ``httpx.Client``/``AsyncClient``, one
+for ``urllib.request.build_opener`` — mirroring
+``test_present_sink_ast_guard_2708.py`` (a bypass-check that vacuously passes
+because the chokepoint is empty is not a guard, so each has a positive twin).
+
+A NEW egress that free-hands its own client/opener is caught by the structural
+guard even if nobody remembers to add a class-specific behavioral test for it —
+that is what keeps "all" from decaying to "almost all" as the code grows.
 """
 from __future__ import annotations
 
@@ -52,6 +65,8 @@ def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.delenv("REYN_SSRF_STRICT", raising=False)
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_CERTIFICATE", raising=False)
+    monkeypatch.delenv("SSL_VERIFY", raising=False)
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
 
 
 # ── #1 litellm ──────────────────────────────────────────────────────────────
@@ -153,6 +168,153 @@ def test_ddgs_backend_honours_no_proxy_absence() -> None:
     from reyn._network import resolve_env_proxy_url
 
     assert resolve_env_proxy_url("https") is None
+
+
+# ── urllib.request egress (safe.http + mcp.registry) ────────────────────────
+
+
+def _proxy_handler_proxies(opener: object) -> dict:
+    """Extract the active ProxyHandler's proxy map from a urllib opener (public
+    surface: OpenerDirector.handlers is a documented attribute)."""
+    for handler in opener.handlers:  # type: ignore[attr-defined]
+        if type(handler).__name__ == "ProxyHandler":
+            return dict(getattr(handler, "proxies", {}))
+    return {}
+
+
+def test_urllib_opener_routes_through_proxy_when_env_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the urllib egress (safe.http / mcp.registry) honours the standard
+    proxy env — with HTTPS_PROXY set, the opener carries an active ProxyHandler
+    for that scheme instead of the previous env-blind pinned-only opener."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://8.8.8.8:3128")  # public proxy IP
+    from reyn._ssrf_pin import ssrf_aware_urllib_opener
+
+    opener = ssrf_aware_urllib_opener()
+    assert _proxy_handler_proxies(opener).get("https") == "http://8.8.8.8:3128"
+
+
+def test_urllib_opener_pins_when_no_proxy() -> None:
+    """Tier 2: with no proxy env, the urllib opener keeps the DNS-rebind-resistant
+    pinned handlers and no active proxy (unchanged pre-#3075 security posture)."""
+    from reyn._ssrf_pin import ssrf_aware_urllib_opener
+
+    opener = ssrf_aware_urllib_opener()
+    handler_names = [type(h).__name__ for h in opener.handlers]  # type: ignore[attr-defined]
+    assert any("Pinned" in n for n in handler_names)
+    assert _proxy_handler_proxies(opener) == {}
+
+
+def test_urllib_opener_strict_refuses_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: REYN_SSRF_STRICT=true makes the urllib egress refuse the env proxy
+    and keep its own pin — the build_opener auto-added default ProxyHandler must
+    NOT silently re-enable proxying under strict."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://8.8.8.8:3128")
+    monkeypatch.setenv("REYN_SSRF_STRICT", "true")
+    from reyn._ssrf_pin import ssrf_aware_urllib_opener
+
+    opener = ssrf_aware_urllib_opener()
+    assert _proxy_handler_proxies(opener) == {}
+    handler_names = [type(h).__name__ for h in opener.handlers]  # type: ignore[attr-defined]
+    assert any("Pinned" in n for n in handler_names)
+
+
+def test_urllib_opener_private_ip_proxy_exempt_but_metadata_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: an operator proxy on an RFC1918 address is exempt from the
+    private-IP SSRF block (#3075 architect decision), but a proxy pointed at the
+    cloud-metadata endpoint is STILL a hard deny (never a legit operator proxy)."""
+    from reyn._ssrf_guard import SSRFBlocked
+    from reyn._ssrf_pin import ssrf_aware_urllib_opener
+
+    monkeypatch.delenv("REYN_FETCH_ALLOW_PRIVATE_IPS", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://10.0.0.5:3128")  # RFC1918 — exempt
+    ssrf_aware_urllib_opener()  # no raise
+
+    monkeypatch.setenv("HTTPS_PROXY", "http://169.254.169.254:3128")  # metadata
+    with pytest.raises(SSRFBlocked):
+        ssrf_aware_urllib_opener()
+
+
+def test_urllib_egress_resolves_standard_ca_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: the urllib egress's CA resolution honours the standard CA env,
+    including REQUESTS_CA_BUNDLE (which the ssl module does NOT read natively —
+    the gap #3075 closes for this class). Uses a real file so the existing-path
+    check in the resolver passes."""
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".pem", delete=False) as fh:
+        fh.write(b"# not a real cert, just an existing path for the resolver\n")
+        ca_path = fh.name
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", ca_path)
+    from reyn._network import resolve_ssl_verify_from_env
+
+    assert resolve_ssl_verify_from_env() == ca_path
+
+
+def test_urllib_ssl_verify_false_emits_audit_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: SSL_VERIFY=false on the urllib egress emits the same
+    network_ssl_verify_disabled P6 audit-event (never silent), wired through the
+    opener's CA-context builder."""
+    monkeypatch.setenv("SSL_VERIFY", "false")
+    from reyn._network import reset_ssl_verify_disabled_latch_for_tests
+    from reyn._ssrf_pin import _build_ca_ssl_context
+    from reyn.core.events.events import EventLog
+
+    reset_ssl_verify_disabled_latch_for_tests()
+    events = EventLog()
+    _build_ca_ssl_context(events=events, egress="urllib_test")
+    matches = [e for e in events.all() if e.type == "network_ssl_verify_disabled"]
+    assert matches
+    assert matches[0].data.get("egress") == "urllib_test"
+    reset_ssl_verify_disabled_latch_for_tests()
+
+
+# ── third-party libs reyn doesn't own the client for (degradation witnesses) ──
+
+
+def test_ddgs_backend_uses_standard_env_proxy_resolver() -> None:
+    """Tier 2: structural — the ddgs backend feeds DDGS(proxy=...) from the
+    standard-env resolver (not ddgs' own non-standard DDGS_PROXY). A refactor
+    that drops the proxy= wiring reopens the env-blind gap."""
+    import inspect
+
+    from reyn.tools.search_backends import duckduckgo
+
+    src = inspect.getsource(duckduckgo)
+    assert "resolve_env_proxy_url" in src
+    assert "DDGS(proxy=" in src
+
+
+def test_huggingface_hub_session_trusts_env() -> None:
+    """Tier 2: degradation witness — huggingface_hub (local-embed download) uses a
+    requests Session with trust_env=True, so it honours HTTP(S)_PROXY /
+    REQUESTS_CA_BUNDLE. RED if a future HF release ships trust_env=False (the
+    litellm-aiohttp_trust_env degradation, in another lib)."""
+    pytest.importorskip("huggingface_hub")
+    from huggingface_hub.utils import get_session
+
+    session = get_session()
+    assert session.trust_env is True
+
+
+def test_fastmcp_remote_transport_built_on_env_trusting_httpx() -> None:
+    """Tier 2: degradation witness — fastmcp's remote-MCP transport
+    (StreamableHttpTransport, which reyn passes to fastmcp.Client without owning
+    the httpx client) is built on httpx and does NOT disable trust_env, so it
+    honours the standard proxy/CA env by httpx's default. RED if fastmcp swaps to
+    a non-env transport or sets trust_env=False."""
+    import inspect
+
+    pytest.importorskip("fastmcp")
+    from fastmcp.client.transports import StreamableHttpTransport
+
+    src = inspect.getsource(StreamableHttpTransport)
+    assert "httpx" in src
+    assert "trust_env=False" not in src
 
 
 # ── #5 subprocess (sandbox child env) ───────────────────────────────────────
@@ -321,4 +483,65 @@ def test_dry_constructor_module_actually_constructs_httpx_clients() -> None:
     assert kinds == {"Client", "AsyncClient"}, (
         f"expected reyn._network to construct both httpx.Client and "
         f"httpx.AsyncClient; found {kinds}"
+    )
+
+
+# ── structural gate: no raw urllib build_opener bypass ─────────────────────
+
+# The urllib DRY constructor is ssrf_aware_urllib_opener in _ssrf_pin.py, so the
+# ONLY build_opener call in src/reyn allowed to exist is the one inside it.
+_URLLIB_CONSTRUCTOR_MODULE = "src/reyn/_ssrf_pin.py"
+
+
+def _is_build_opener_call(node: ast.AST) -> bool:
+    """True for a ``urllib.request.build_opener(...)`` / ``build_opener(...)`` call."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Attribute) and func.attr == "build_opener":
+        return True
+    if isinstance(func, ast.Name) and func.id == "build_opener":
+        return True
+    return False
+
+
+def test_no_raw_urllib_build_opener_bypasses_the_dry_constructor() -> None:
+    """Tier 2: structural — every urllib.request.build_opener(...) in src/reyn
+    lives inside the DRY urllib constructor (ssrf_aware_urllib_opener in
+    reyn._ssrf_pin). This is the guard whose ABSENCE let the urllib egress
+    (safe.http + mcp.registry) ship env-blind before #3075: the httpx-only AST
+    guard could not see a urllib.request bypass. A new urllib egress that
+    free-hands its own build_opener now fails here, named file:line."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    constructor_path = (root / _URLLIB_CONSTRUCTOR_MODULE).resolve()
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        if py.resolve() == constructor_path:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if _is_build_opener_call(node):
+                offenders.append(f"{py.relative_to(root)}:{node.lineno}")
+
+    assert not offenders, (
+        "Raw urllib.request.build_opener(...) construction outside the DRY urllib "
+        "constructor (reyn._ssrf_pin.ssrf_aware_urllib_opener) — bypasses #3075's "
+        "standard proxy/CA env + REYN_SSRF_STRICT wiring for the urllib egress. "
+        f"Route it through ssrf_aware_urllib_opener instead. Offending sites: {offenders}"
+    )
+
+
+def test_urllib_dry_constructor_module_actually_calls_build_opener() -> None:
+    """Tier 2: positive twin — the urllib constructor module DOES call
+    build_opener (the chokepoint exists and is used, so the bypass-check above
+    is not vacuously green on an empty chokepoint)."""
+    root = _repo_root()
+    constructor_path = root / _URLLIB_CONSTRUCTOR_MODULE
+    tree = ast.parse(constructor_path.read_text(encoding="utf-8"))
+    calls = [node.lineno for node in ast.walk(tree) if _is_build_opener_call(node)]
+    assert calls, (
+        "reyn._ssrf_pin.ssrf_aware_urllib_opener must call urllib.request."
+        "build_opener (the single allowed urllib-opener chokepoint) — none found"
     )

--- a/tests/test_network_egress_env_completeness_3075.py
+++ b/tests/test_network_egress_env_completeness_3075.py
@@ -1,0 +1,324 @@
+"""Tier 2: network-egress standard-env completeness gate (#3075).
+
+Issue #3075's requirement is completeness, not a fix per class: EVERY
+reyn-originated network egress honours the standard proxy/CA env
+(``HTTP(S)_PROXY``/``NO_PROXY``, ``SSL_CERT_FILE``/``REQUESTS_CA_BUNDLE``), zero
+exceptions. This file is the "enumerate, don't curate" spine for that claim:
+
+* one behavioral test per egress class from #3075's enumeration table, each
+  asserting the class actually reads a SENTINEL value from the standard env
+  (not "the code looks right" — an observed effect of setting the env), and
+* two structural (AST) guards: no ``httpx.Client(``/``httpx.AsyncClient(``
+  construction in ``src/reyn`` bypasses the DRY constructor
+  (``reyn._network.build_async_http_client`` / ``build_sync_http_client``), and
+  the DRY constructor module DOES construct httpx clients (positive guard —
+  the AST-guard pattern from ``test_present_sink_ast_guard_2708.py``: a
+  bypass-check that always passes because the chokepoint is empty is not a
+  guard).
+
+A new egress class that skips this file's enumeration is invisible to the
+completeness claim by construction — the intended failure mode is "someone
+adds egress #7 and forgets to enumerate it here", which this file cannot
+detect on its own (that's why the structural guard below matters: a NEW
+call site is caught even if nobody remembers to add a class-specific test for
+it, as long as it goes through ``httpx.Client``/``httpx.AsyncClient`` directly).
+"""
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+SENTINEL_PROXY = "http://sentinel-proxy.invalid:9"
+SENTINEL_CA = "/sentinel/ca-bundle.pem"
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every standard proxy/CA var so each test controls its own sentinel."""
+    from reyn._network import STANDARD_NETWORK_ENV_NAMES
+
+    for name in STANDARD_NETWORK_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("REYN_SSRF_STRICT", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_CERTIFICATE", raising=False)
+
+
+# ── #1 litellm ──────────────────────────────────────────────────────────────
+
+
+def test_litellm_trusts_standard_proxy_env() -> None:
+    """Tier 2: ensure_litellm_ready() flips litellm.aiohttp_trust_env on so the
+    highest-volume egress reads HTTP(S)_PROXY like every other conforming path."""
+    import litellm
+
+    from reyn.llm.litellm_bootstrap import ensure_litellm_ready
+
+    ensure_litellm_ready()
+    assert litellm.aiohttp_trust_env is True
+
+
+# ── #2 SSRF-pin (web_fetch / RegistryClient) ────────────────────────────────
+
+
+def test_ssrf_pinned_client_mounts_a_transport_for_the_env_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: with a standard-env proxy set, ssrf_aware_client_kwargs (the
+    public function build_async_http_client(pin_ssrf=True) delegates to)
+    returns a mount for that scheme instead of silently ignoring the env
+    (#3075 fix 2 — the sharpest non-conformer: explicit transport= previously
+    disabled httpx's own env-proxy reading entirely)."""
+    monkeypatch.setenv("HTTPS_PROXY", SENTINEL_PROXY)
+    from reyn._ssrf_pin import ssrf_aware_client_kwargs
+
+    kwargs = ssrf_aware_client_kwargs(verify=True)
+    assert kwargs.get("mounts"), "expected an env-proxy mount when HTTPS_PROXY is set"
+
+
+def test_ssrf_strict_env_refuses_the_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: REYN_SSRF_STRICT=true keeps the pin-only transport even when a
+    proxy is configured (#3075 SSRF-x-proxy decision's tightening opt-in)."""
+    monkeypatch.setenv("HTTPS_PROXY", SENTINEL_PROXY)
+    monkeypatch.setenv("REYN_SSRF_STRICT", "true")
+    from reyn._ssrf_pin import ssrf_aware_client_kwargs
+
+    kwargs = ssrf_aware_client_kwargs(verify=True)
+    assert "mounts" not in kwargs
+
+
+def test_no_proxy_env_keeps_pin_only_default_transport() -> None:
+    """Tier 2: with no proxy env at all, pin_ssrf=True is unchanged behavior —
+    every request still goes through PinnedAsyncHTTPTransport, no mounts."""
+    from reyn._ssrf_pin import PinnedAsyncHTTPTransport, ssrf_aware_client_kwargs
+
+    kwargs = ssrf_aware_client_kwargs(verify=True)
+    assert isinstance(kwargs["transport"], PinnedAsyncHTTPTransport)
+    assert "mounts" not in kwargs
+
+
+# ── #3 OTEL CA bridge ────────────────────────────────────────────────────────
+
+
+def test_otel_bridges_standard_ca_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: the standard CA env bridges to OTEL's own var (a DIFFERENT name
+    than every other reyn egress reads) when reyn configures the exporter."""
+    monkeypatch.setenv("SSL_CERT_FILE", SENTINEL_CA)
+    from reyn.observability.otel_exporter import _bridge_standard_ca_to_otel_env
+
+    _bridge_standard_ca_to_otel_env()
+    assert os.environ.get("OTEL_EXPORTER_OTLP_CERTIFICATE") == SENTINEL_CA
+
+
+def test_otel_bridge_never_overrides_explicit_operator_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: an operator who already set OTEL_EXPORTER_OTLP_CERTIFICATE
+    explicitly is never silently overridden by the standard-env bridge."""
+    monkeypatch.setenv("SSL_CERT_FILE", SENTINEL_CA)
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_CERTIFICATE", "/operator/explicit.pem")
+    from reyn.observability.otel_exporter import _bridge_standard_ca_to_otel_env
+
+    _bridge_standard_ca_to_otel_env()
+    assert os.environ["OTEL_EXPORTER_OTLP_CERTIFICATE"] == "/operator/explicit.pem"
+
+
+# ── #4 ddgs / web_search ─────────────────────────────────────────────────────
+
+
+def test_ddgs_backend_resolves_standard_proxy_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: resolve_env_proxy_url (fed to DDGS(proxy=...)) reads the standard
+    HTTPS_PROXY, not ddgs' own non-standard DDGS_PROXY."""
+    monkeypatch.setenv("HTTPS_PROXY", SENTINEL_PROXY)
+    from reyn._network import resolve_env_proxy_url
+
+    assert resolve_env_proxy_url("https") == SENTINEL_PROXY
+
+
+def test_ddgs_backend_honours_no_proxy_absence() -> None:
+    """Tier 2: with no proxy env set, resolve_env_proxy_url returns None (ddgs
+    then uses its own default / DDGS_PROXY fallback, unaffected)."""
+    from reyn._network import resolve_env_proxy_url
+
+    assert resolve_env_proxy_url("https") is None
+
+
+# ── #5 subprocess (sandbox child env) ───────────────────────────────────────
+
+
+def test_sandbox_child_env_includes_standard_set_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: the sandbox forwards the standard proxy/CA env to EVERY spawned
+    child by default (#3075 fix 5) — even when the caller's own
+    ``env_passthrough`` allowlist is empty (the git-clone-only forwarding this
+    generalises always listed its vars explicitly)."""
+    monkeypatch.setenv("HTTP_PROXY", SENTINEL_PROXY)
+    monkeypatch.setenv("SSL_CERT_FILE", SENTINEL_CA)
+    from reyn.security.sandbox.policy import SandboxPolicy, resolve_passthrough_env
+
+    policy = SandboxPolicy(env_passthrough=[])
+    env = resolve_passthrough_env(policy)
+    assert env.get("HTTP_PROXY") == SENTINEL_PROXY
+    assert env.get("SSL_CERT_FILE") == SENTINEL_CA
+
+
+def test_sandbox_child_env_still_honours_explicit_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: additive, not a replacement — an operator-declared
+    env_passthrough entry is still forwarded alongside the standard set."""
+    monkeypatch.setenv("MY_CUSTOM_VAR", "keep-me")
+    from reyn.security.sandbox.policy import SandboxPolicy, resolve_passthrough_env
+
+    policy = SandboxPolicy(env_passthrough=["MY_CUSTOM_VAR"])
+    env = resolve_passthrough_env(policy)
+    assert env.get("MY_CUSTOM_VAR") == "keep-me"
+
+
+def test_noop_backend_and_seatbelt_and_landlock_share_the_chokepoint() -> None:
+    """Tier 2: structural — all three sandbox backends call
+    resolve_passthrough_env (not a hand-duplicated env_passthrough loop each),
+    so #3075's default-forward can't drift out of sync between them."""
+    import reyn.security.sandbox.backends.landlock as landlock_mod
+    import reyn.security.sandbox.backends.seatbelt as seatbelt_mod
+    import reyn.security.sandbox.noop_backend as noop_mod
+
+    for mod in (noop_mod, seatbelt_mod, landlock_mod):
+        src = Path(mod.__file__).read_text(encoding="utf-8")
+        assert "resolve_passthrough_env(policy)" in src, (
+            f"{mod.__name__} does not call the shared resolve_passthrough_env "
+            "chokepoint — #3075's default proxy/CA forwarding can silently "
+            "drift out of sync with the other backends"
+        )
+
+
+# ── #6 ssl_verify:false audit-event ─────────────────────────────────────────
+
+
+def test_verify_false_emits_audit_event_once() -> None:
+    """Tier 2: a verify=False client construction emits network_ssl_verify_disabled
+    exactly once per (process, egress) — never silent (#3075 ssl_verify decision)."""
+    from reyn._network import (
+        build_sync_http_client,
+        reset_ssl_verify_disabled_latch_for_tests,
+    )
+    from reyn.core.events.events import EventLog
+
+    reset_ssl_verify_disabled_latch_for_tests()
+    events = EventLog()
+    c1 = build_sync_http_client(verify=False, events=events, egress="test_once")
+    c1.close()
+    after_first = [e for e in events.all() if e.type == "network_ssl_verify_disabled"]
+    assert after_first, "expected one network_ssl_verify_disabled event after the first verify=False construction"
+    assert after_first[0].data.get("egress") == "test_once"
+
+    c2 = build_sync_http_client(verify=False, events=events, egress="test_once")
+    c2.close()
+    after_second = [e for e in events.all() if e.type == "network_ssl_verify_disabled"]
+    # Latched: the second verify=False construction for the SAME egress must not
+    # add a second event — the audit trail stays exactly what it was.
+    assert after_second == after_first
+    reset_ssl_verify_disabled_latch_for_tests()
+
+
+def test_verify_true_never_emits_the_audit_event() -> None:
+    """Tier 2: negative guard — verify=True (the default / recommended path)
+    never emits network_ssl_verify_disabled."""
+    from reyn._network import (
+        build_sync_http_client,
+        reset_ssl_verify_disabled_latch_for_tests,
+    )
+    from reyn.core.events.events import EventLog
+
+    reset_ssl_verify_disabled_latch_for_tests()
+    events = EventLog()
+    c = build_sync_http_client(verify=True, events=events, egress="test_true")
+    c.close()
+    assert not [e for e in events.all() if e.type == "network_ssl_verify_disabled"]
+
+
+# ── structural gate: no raw httpx.Client/AsyncClient bypass ────────────────
+
+_CONSTRUCTOR_MODULE = "src/reyn/_network.py"
+# Additional intentional construction sites: the SSRF-pin transport itself
+# wraps httpx.AsyncHTTPTransport (a *transport*, not a Client — out of this
+# gate's scope) and constructs the plain AsyncHTTPTransport used for the
+# proxy-mount path; that file is the transport-level primitive the DRY
+# constructor builds on, not a bypass of it.
+_ALLOWED_TRANSPORT_MODULE = "src/reyn/_ssrf_pin.py"
+
+
+def _is_httpx_client_construction(node: ast.AST) -> str | None:
+    """Return 'Client' / 'AsyncClient' if *node* constructs one, else None."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    # httpx.Client(...) / httpx.AsyncClient(...)
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        if func.value.id == "httpx" and func.attr in ("Client", "AsyncClient"):
+            return func.attr
+    # Client(...) / AsyncClient(...) after `from httpx import Client`
+    if isinstance(func, ast.Name) and func.id in ("Client", "AsyncClient"):
+        return func.id
+    return None
+
+
+def test_no_raw_httpx_client_construction_bypasses_the_dry_constructor() -> None:
+    """Tier 2: structural — every httpx.Client(...)/httpx.AsyncClient(...)
+    construction in src/reyn lives inside the DRY constructor module
+    (reyn._network). A new call site that free-hands its own client
+    construction re-opens the #3075 "almost every egress" gap and must fail
+    here instead of shipping silently non-conformant."""
+    root = _repo_root()
+    src = root / "src" / "reyn"
+    constructor_path = (root / _CONSTRUCTOR_MODULE).resolve()
+    transport_path = (root / _ALLOWED_TRANSPORT_MODULE).resolve()
+
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        resolved = py.resolve()
+        if resolved in (constructor_path, transport_path):
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            kind = _is_httpx_client_construction(node)
+            if kind:
+                offenders.append(f"{py.relative_to(root)}:{node.lineno} ({kind})")
+
+    assert not offenders, (
+        "Raw httpx.Client(...)/httpx.AsyncClient(...) construction outside the "
+        "DRY constructor (reyn._network.build_async_http_client / "
+        "build_sync_http_client) — bypasses #3075's proxy/CA + SSRF-pin env "
+        f"wiring. Offending sites: {offenders}"
+    )
+
+
+def test_dry_constructor_module_actually_constructs_httpx_clients() -> None:
+    """Tier 2: positive guard — the constructor module DOES construct
+    httpx.Client/AsyncClient (the chokepoint exists and is used, not merely
+    an empty pass-through the bypass-check above vacuously satisfies)."""
+    root = _repo_root()
+    constructor_path = root / _CONSTRUCTOR_MODULE
+    tree = ast.parse(constructor_path.read_text(encoding="utf-8"))
+    kinds = {
+        kind
+        for node in ast.walk(tree)
+        if (kind := _is_httpx_client_construction(node)) is not None
+    }
+    assert kinds == {"Client", "AsyncClient"}, (
+        f"expected reyn._network to construct both httpx.Client and "
+        f"httpx.AsyncClient; found {kinds}"
+    )

--- a/tests/test_web_fetch_ssl_config.py
+++ b/tests/test_web_fetch_ssl_config.py
@@ -15,6 +15,14 @@ value to httpx's TLS layer, based on the priority order:
 real httpx transport (which would load a fake CA path). ``httpx.AsyncClient`` is
 still monkeypatched to capture constructor kwargs (now ``transport=``).
 
+#3075: both call sites now build their client via
+``reyn._network.build_async_http_client(pin_ssrf=True, ...)``, which delegates
+transport construction to ``reyn._ssrf_pin.ssrf_aware_client_kwargs`` — the
+``PinnedAsyncHTTPTransport`` symbol used at construction time is therefore
+``reyn._ssrf_pin.PinnedAsyncHTTPTransport`` regardless of which production
+module (``web.py`` / ``registry/client.py``) triggered the construction, so
+every monkeypatch below targets that one definition site.
+
 No unittest.mock. All helpers are real instances / recording stand-ins — a
 structural invariant (the right layer receives the verify value), not a
 behavioral assertion on httpx internals.
@@ -162,7 +170,7 @@ def test_verify_ssl_ca_bundle_in_config_passes_to_httpx(monkeypatch: pytest.Monk
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
     monkeypatch.setattr(
-        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx))
 
@@ -189,7 +197,7 @@ def test_verify_ssl_false_in_config_passes_to_httpx(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
     monkeypatch.setattr(
-        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx))
 
@@ -214,7 +222,7 @@ def test_verify_ssl_true_in_config_passes_to_httpx(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
     monkeypatch.setattr(
-        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx))
 
@@ -243,7 +251,7 @@ def test_ca_bundle_takes_priority_over_verify_ssl(monkeypatch: pytest.MonkeyPatc
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
     monkeypatch.setattr(
-        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx))
 
@@ -280,7 +288,7 @@ def test_env_var_fallback_when_config_unset(
 
     monkeypatch.setattr(httpx, "AsyncClient", _CaptureAsyncClient)
     monkeypatch.setattr(
-        "reyn.core.op_runtime.web.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
     asyncio.run(handle_web_fetch(op=op, ctx=ctx))
 
@@ -356,7 +364,7 @@ def test_registry_client_verify_false_passed_to_httpx(monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(httpx, "AsyncClient", _CapturingClient)
     monkeypatch.setattr(
-        "reyn.core.registry.client.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
 
     async def _run() -> None:
@@ -393,7 +401,7 @@ def test_registry_client_ca_bundle_passed_to_httpx(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(httpx, "AsyncClient", _CapturingClient)
     monkeypatch.setattr(
-        "reyn.core.registry.client.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
+        "reyn._ssrf_pin.PinnedAsyncHTTPTransport", _RecordVerifyTransport,
     )
 
     async def _run() -> None:


### PR DESCRIPTION
**[per-PR-coder]** — implements issue #3075 (network egress → standard proxy/CA env unification). **security-critical (SSRF / SSL / proxy) — architect co-vet required before merge.**

## Design followed
Per #3075's owner-directed design: no `reyn.yaml` network block, no reyn resolver/client layer. The standard env (`HTTP(S)_PROXY`/`NO_PROXY`, `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`) is the single source of truth; this PR makes every reyn-originated egress honour it, closing the "almost every egress" gap in the issue's enumeration table.

## Fixes (#3075's 5 non-conforming paths + DRY + gate)

1. **litellm** (`src/reyn/llm/litellm_bootstrap.py`) — `litellm.aiohttp_trust_env = True` at the `ensure_litellm_ready()` chokepoint. One line; the highest-volume egress (every LLM/embedding call) was proxy-blind (`aiohttp_trust_env` defaults `False` in litellm).
2. **SSRF-pin** (`web_fetch` / `RegistryClient`) — `src/reyn/_ssrf_pin.py` gains `ssrf_aware_client_kwargs()`: with no proxy, unchanged (`PinnedAsyncHTTPTransport` pins the target IP). With a proxy configured (`get_environment_proxies()`, honours `NO_PROXY`), the **proxy endpoint** is SSRF-validated once and mounted via `httpx.AsyncHTTPTransport(proxy=..., verify=...)` per scheme — final-target rebind protection is delegated to the proxy (its job — it does the actual resolve+connect). `REYN_SSRF_STRICT=true` refuses the proxy for this class of client and keeps reyn's own pin.
3. **OTEL** (`src/reyn/observability/otel_exporter.py`) — `_bridge_standard_ca_to_otel_env()` bridges `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` → `OTEL_EXPORTER_OTLP_CERTIFICATE` (a *different* var OTEL reads) right before the exporter pipeline is built; never overrides an operator-set value (`setdefault` semantics).
4. **ddgs** (`src/reyn/tools/search_backends/duckduckgo.py`) — `DDGS(proxy=resolve_env_proxy_url("https"))`; ddgs only reads its own non-standard `DDGS_PROXY`, not `HTTP(S)_PROXY`.
5. **subprocess (uvx/npx/uv dep-fetch)** — `src/reyn/security/sandbox/policy.py` adds `resolve_passthrough_env(policy)`, the shared chokepoint all three backends (`noop_backend.py`, `backends/seatbelt.py`, `backends/landlock.py`) now call instead of a hand-duplicated `env_passthrough` loop. It unions `policy.env_passthrough` with `reyn._network.STANDARD_NETWORK_ENV_NAMES` (proxy upper/lowercase + `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE`/`NODE_EXTRA_CA_CERTS`/`PIP_CERT`) — forwarded to **every** sandboxed child by default, generalising the git-clone-only forwarding in `skill_install.py` (the sharpest symptom in #3075's table: git-clone conformed, its sibling uvx/npx did not). Curated known-non-secret allowlist — no relaxation of the sandbox's clean-env secret-deny floor.
6. **HF-hub** — confirmed conforming (built on `requests`, which honours `HTTP(S)_PROXY`/`REQUESTS_CA_BUNDLE` by default); no code change, table updated from "confirm" to "✓".

## ssl_verify:false (#3075 decision)
`SSL_VERIFY=false` stays a standard-env escape hatch (already resolved via `litellm.get_ssl_verify()`), but never silently: `reyn._network.note_ssl_verify_disabled()` fires a one-time WARN + `network_ssl_verify_disabled` P6 audit-event per (process, egress name) the first time a client resolves `verify=False`. Wired at every DRY-constructor call site.

## DRY constructor (not a network layer)
`src/reyn/_network.py` — `build_async_http_client()` / `build_sync_http_client()`, the one constructor every reyn-owned `httpx.Client`/`httpx.AsyncClient` now goes through (`web.py`, `core/registry/client.py`, `security/secrets/oauth.py` ×2, `dev/dogfood/publish.py`, `interfaces/repl/remote_client.py`, `interfaces/web/notifications.py` — 7 production sites, was 2 SSRF-pinned + 5 plain-but-accidentally-conforming). `pin_ssrf=True` opts into the proxy-aware SSRF transport (fix 2); default preserves httpx's own `trust_env=True`.

## Completeness gate (`tests/test_network_egress_env_completeness_3075.py`)
Enumerates every egress class from #3075's table with a sentinel-env behavioral test (litellm `aiohttp_trust_env`, SSRF-pin proxy mount + `REYN_SSRF_STRICT`, OTEL CA bridge + no-override, ddgs proxy resolution, sandbox `resolve_passthrough_env` default-forward + still-honours-explicit, ssl_verify:false audit-event once+never-on-true), plus two structural AST guards mirroring `test_present_sink_ast_guard_2708.py`'s pattern:
- **negative**: no `httpx.Client(`/`httpx.AsyncClient(` construction anywhere in `src/reyn` outside `_network.py` (the transport-level `_ssrf_pin.py` is allowlisted — it builds the primitive the constructor wraps, not a bypass of it).
- **positive**: `_network.py` DOES construct both `Client` and `AsyncClient` (an empty chokepoint would vacuously pass the negative check).

A new egress that free-hands its own `httpx.AsyncClient(...)` fails this gate at PR time, named file:line.

## Known interaction to flag for co-vet
Proxy-endpoint SSRF validation (fix 2) applies the existing `assert_fetch_host_allowed` check to the *proxy host* — a corporate proxy on a private IP (common) requires the operator's existing `REYN_FETCH_ALLOW_PRIVATE_IPS` opt-in, same as any other private-IP fetch target. Not new behavior, but worth a second look given it's the first time the SSRF gate sees a proxy host rather than a target host.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict` on all changed/new test files — 0 errors
- [x] `pytest -q -n auto --timeout=120` from repo root — 8856 passed, 29 skipped (pre-existing skips, unrelated)
- [x] `python scripts/verify_module_docstrings.py` on all changed src files — clean
- [x] Manual: live-verified each mechanism in a REPL before writing tests (litellm flag, SSRF proxy mounts + strict refusal, OTEL CA bridge, sandbox `resolve_passthrough_env`, ssl_verify:false audit-event) — see PR discussion if asked for transcripts
- [ ] litellm proxy smoke — N/A: this change sets `litellm.aiohttp_trust_env` (a process-level trust flag), it does not plumb a new provider/`allowed_openai_params` through an `acompletion()` call, so the referenced proxy-smoke gate (for provider-param additions) doesn't apply here. Flagging for co-vet to confirm this read is correct.

part of #3075 (SSRF-pin/OTEL/ddgs/subprocess/litellm/DRY-constructor/gate all land in this one PR per the issue's "same PR" instruction for the completeness gate; marking `part of` rather than `Closes` in case co-vet wants a narrower landing).
