### PR TITLE
feat(plugins): skill-load verb -- invocation-time variable expansion for SKILL.md bodies (P4)

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -56,7 +56,7 @@ never consulted. The two fields therefore describe **four** states, not six —
 > behavior `false` actually delivered, not the narrower thing its old
 > description promised).
 
-The registry never reads `SKILL.md` itself — only `path` and `description` from the config entry populate the L1 menu and the `skill_list` result. The file is read by the model at L2, on demand, via the ordinary file-read op.
+The registry never reads `SKILL.md` itself — only `path` and `description` from the config entry populate the L1 menu and the `skill_list` result. The file is read by the model at L2, on demand, via the ordinary file-read op — which, for exactly the `SKILL.md` filename, additionally expands invocation-time `${REYN_*}`/`${CLAUDE_*}`/`${env:VAR}` tokens in the body before returning it (see [Skill-load variable expansion](#skill-load-variable-expansion) below).
 
 ## Discovering and using a skill
 
@@ -75,6 +75,38 @@ project root; the file-read op resolves those paths through a least-privilege
 carve-out scoped to the package's `skills/` and `pipelines/` directories, so
 they read cleanly in a non-interactive run without an operator to approve
 anything.
+
+## Skill-load variable expansion
+
+Reading a `SKILL.md` body is not a byte-identical file read: the `file` read
+op (`reyn.core.op_runtime.file.handle`) routes the SAME request through a
+skill-load pass (`reyn.plugins.skill_load`, ADR 0064 §3.5) whenever the
+resolved path's filename is exactly `SKILL.md`. This is still the ordinary
+read op — no dedicated "invoke skill" verb exists (see below) — the pass
+just does one more thing to the content before returning it.
+
+Three token kinds expand, in order:
+
+| Token | Source | Resolved |
+|-------|--------|----------|
+| `${REYN_PLUGIN_ROOT}` | the skill's plugin directory (a `.reyn-plugin/plugin.json` marker found walking up from the skill's own directory; falls back to the skill's own directory for a standalone, non-plugin skill) | every load (see note below) |
+| `${REYN_SKILL_DIR}` | the skill's own containing directory | every load |
+| `${REYN_PROJECT_DIR}` | the current session's workspace root | every load, freshly |
+| `${CLAUDE_PLUGIN_ROOT}` / `${CLAUDE_SKILL_DIR}` / `${CLAUDE_PROJECT_DIR}` | alias of the three `${REYN_*}` tokens above (ADR §3.6) — `SKILL.md` is a shared open standard (agentskills.io), so this alias is always active for a skill-load, not gated behind a separate provenance check | every load |
+| `${env:VAR_NAME}` | `os.environ` — namespaced (`env:` prefix), deliberately NOT the bare `${VAR}` syntax mcp spawn config uses, so a literal `${VAR}`-shaped code example in a skill body's prose is never mistaken for a token; an unset `${env:VAR_NAME}` is left untouched rather than blanked | every load, freshly |
+
+`${REYN_PLUGIN_ROOT}`/`${REYN_SKILL_DIR}` are, per the ADR, "stable location"
+values meant to be baked once at plugin-install copy time (`plugin_install`,
+plugin-model P2 — not yet built) rather than re-expanded per read; skill-load
+expands them anyway today because no installed skill body has ever had them
+baked, and doing so is a no-op once P2 starts baking them (a baked body has
+no `${...}` left to match). `${REYN_PROJECT_DIR}` and `${env:VAR_NAME}` are
+genuinely dynamic and are always resolved fresh, never baked.
+
+Reuses `reyn.plugins.tokens` (`PluginTokenContext` / `expand_reyn_tokens`) —
+the same expansion primitive an mcp server's spawn config and a pipeline's
+`ctx` params use (ADR §3.4's "uniform across capabilities" split) — rather
+than a skill-specific reimplementation.
 
 ## Config cascade
 
@@ -107,7 +139,7 @@ Use `pypdf` for form-field operations...
 | Layer | What the model sees | Mechanism |
 |-------|---------------------|-----------|
 | **L1 — menu** | A dedicated `## Skills` system-prompt block, one line per enabled + auto-invoke skill: `name — description [path]`. | Built once per turn from the registry; no dedicated dispatch. |
-| **L2 — instructions** | The full `SKILL.md` body, read only when the model judges the current task matches an entry's description. | Ordinary `file__read` — no dedicated "invoke skill" op. |
+| **L2 — instructions** | The full `SKILL.md` body, read only when the model judges the current task matches an entry's description. | Ordinary `file__read` — no dedicated "invoke skill" op, but the body passes through invocation-time variable expansion (see [Skill-load variable expansion](#skill-load-variable-expansion)) before it reaches the model. |
 | **L3 — bundled assets** | Any additional files the skill's instructions reference (templates, scripts, reference data) sitting alongside `SKILL.md`. | Ordinary `file__read`, gated by the standard permission model like any other path. |
 
 There is no dedicated "run this skill" primitive at any layer — a skill is discovered via L1, loaded via L2, and its assets are just files. The model decides relevance from the L1 description; the OS does not gate *which* skill the model may read, only *which paths* it may read (the standard permission model — reading inside the project root is a default; outside requires the usual declaration + approval).

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -93,7 +93,7 @@ Each is a distinct op kind with its own schema; there is no `op` sub-field.
 
 | Kind | Permission | Notes |
 |------|-----------|-------|
-| `read_file` | `file.read` | `offset` / `limit` (line range) optional. |
+| `read_file` | `file.read` | `offset` / `limit` (line range) optional. When the resolved path's filename is exactly `SKILL.md`, the decoded content additionally passes through invocation-time `${REYN_*}`/`${CLAUDE_*}`/`${env:VAR}` expansion (`reyn.plugins.skill_load.load_skill_body`, ADR 0064 §3.5, P4/#3070) before it is returned — every other path is unaffected. |
 | `write_file` | `file.write` | Creates or overwrites; parent dirs created as needed. |
 | `edit_file` | `file.write` | `old_string` must be unique unless `replace_all: true`. |
 | `delete_file` | `file.write` | |
@@ -900,8 +900,16 @@ higher-trust one.
    (VCS metadata excluded) into `~/.reyn/plugins/<name>/`. Emit
    `plugin_install_copied`.
 6. Expand `${REYN_*}` stable-location tokens (P1 `reyn.plugins.tokens.
-   expand_reyn_tokens`) into the copied `.mcp.json` / `pipelines/*.yaml` /
-   `skills/*/SKILL.md` files.
+   expand_reyn_tokens`) into the copied `.mcp.json` / `pipelines/*.yaml`
+   files (every token the copy-time context carries a value for). A
+   `skills/*/SKILL.md` file gets a NARROWER bake: only `${REYN_PLUGIN_ROOT}`
+   (`plugin_install.py`'s `_bake_plugin_root_only`) — `${REYN_SKILL_DIR}` and
+   `${REYN_PROJECT_DIR}` are deliberately left as literal tokens for the
+   skill-load verb (`reyn.plugins.skill_load.load_skill_body`, P4/#3070) to
+   resolve fresh at every invocation, since the plugin's global
+   `~/.reyn/plugins/<name>/` copy can be enabled into more than one project
+   (§3.3) — baking one install call's project into the shared copy would
+   freeze every later enabling project to whichever one installed it first.
 7. Materialise deps (gate 2, when `requirements.txt` is present). Emit
    `plugin_install_deps_materialised`.
 8. Register: for each manifest capability, call `skill_install.handle` /

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from reyn.builtin.docs import read_builtin_body_bytes
 from reyn.data.workspace.text_codec import decode_text_or_none, encode_text
+from reyn.plugins.skill_load import is_skill_body_path, load_skill_body
 from reyn.schemas.models import FileIROp
 
 from . import register
@@ -326,6 +327,29 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         # charset-normalizer); the plain-UTF-8 fast path keeps the result shape
         # byte-identical (no `encoding` field) for the common case.
         _enc_field = {"encoding": _detected_encoding} if _detected_encoding else {}
+
+        # ADR 0064 §3.5 (plugin-model P4, #3070): a SKILL.md body gets ONE
+        # additional pass — invocation-time ${REYN_*}/${CLAUDE_*}/${env:...}
+        # expansion (`reyn.plugins.skill_load`) — before the windowing/
+        # truncation logic below runs on it. This is still the SAME `read`
+        # op (#2971: reading is the invocation, no dedicated verb), it just
+        # no longer hands back byte-identical disk content for exactly this
+        # one filename. `alias_claude=True` unconditionally: SKILL.md is the
+        # one open standard (agentskills.io) multiple hosts share, so every
+        # skill-load IS the ingestion boundary §3.6 scopes the alias to —
+        # there is no narrower "this one is Claude-authored" signal to gate
+        # on, and a stray literal `${CLAUDE_*}` in prose is vanishingly
+        # unlikely. project_dir comes from the live workspace root — the
+        # dynamic param that must be resolved fresh on every load, never
+        # baked (§3.4).
+        if is_skill_body_path(op.path):
+            content = load_skill_body(
+                content,
+                skill_path=_resolve_for_gate(ctx, op.path),
+                project_dir=ctx.workspace.base_dir,
+                alias_claude=True,
+            )
+            ctx.events.emit("skill_body_loaded", path=op.path)
         # #2335: read MODE. An explicit LINE window (offset/limit given, no char_offset) is honored
         # VERBATIM — the LLM's line-based read contract, byte-identical — AS LONG AS its slice fits
         # the inline cap. Otherwise (an unbounded read, a char_offset mid-line RESUME, OR an explicit

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -334,23 +334,59 @@ def _expand_plugin_files(plugin_root: Path, token_ctx: PluginTokenContext) -> No
     capability might read (§3.4/§3.5): the root ``.mcp.json``, every
     ``pipelines/*.yaml``, and every ``skills/*/SKILL.md``. Non-existent
     globs are simply empty — every capability is optional (§3.1)."""
-    candidates: list[Path] = [plugin_root / ".mcp.json"]
+    mcp_and_pipeline_candidates: list[Path] = [plugin_root / ".mcp.json"]
     pipelines_dir = plugin_root / "pipelines"
     if pipelines_dir.is_dir():
-        candidates.extend(pipelines_dir.glob("*.yaml"))
+        mcp_and_pipeline_candidates.extend(pipelines_dir.glob("*.yaml"))
+    for path in mcp_and_pipeline_candidates:
+        _bake_all_tokens(path, token_ctx)
+
+    # SKILL.md bakes ONLY ${REYN_PLUGIN_ROOT} here — ${REYN_PROJECT_DIR} is a
+    # dynamic param (§3.4), never baked at copy: the plugin's global
+    # ~/.reyn/plugins/ copy can be ENABLED into many different projects
+    # (§3.3 — code installs once globally, enablement is project-local), so
+    # baking THIS install call's project_root into the shared copy would
+    # freeze every future enabling project to whichever one happened to
+    # install it first. ${REYN_SKILL_DIR} is left unbaked too. Both resolve
+    # fresh at invocation instead, via the skill-load verb
+    # (`reyn.plugins.skill_load.load_skill_body`, P4/#3070).
     skills_dir = plugin_root / "skills"
     if skills_dir.is_dir():
-        candidates.extend(skills_dir.glob("*/SKILL.md"))
-    for path in candidates:
-        if not path.is_file():
-            continue
-        try:
-            text = path.read_text(encoding="utf-8")
-        except OSError:
-            continue
-        expanded = expand_reyn_tokens(text, token_ctx)
-        if expanded != text:
-            path.write_text(expanded, encoding="utf-8")
+        for path in skills_dir.glob("*/SKILL.md"):
+            _bake_plugin_root_only(path, token_ctx.plugin_root)
+
+
+def _bake_all_tokens(path: Path, token_ctx: PluginTokenContext) -> None:
+    """Expand every ``${REYN_*}`` token *token_ctx* carries a value for, in
+    place — the mcp/pipeline copy-time bake, unchanged from pre-#3070
+    behavior."""
+    if not path.is_file():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    expanded = expand_reyn_tokens(text, token_ctx)
+    if expanded != text:
+        path.write_text(expanded, encoding="utf-8")
+
+
+def _bake_plugin_root_only(path: Path, plugin_root: Path) -> None:
+    """Expand ONLY ``${REYN_PLUGIN_ROOT}`` in *path*, in place — every other
+    ``${REYN_*}``/``${CLAUDE_*}``/``${env:...}`` token is left as a literal
+    string for the invocation-time skill-load pass. A targeted string
+    replace rather than ``expand_reyn_tokens`` (whose ``PluginTokenContext``
+    requires ``project_dir``, which this call must NOT supply a baked value
+    for — see the caller's docstring)."""
+    if not path.is_file():
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    expanded = text.replace("${REYN_PLUGIN_ROOT}", str(plugin_root))
+    if expanded != text:
+        path.write_text(expanded, encoding="utf-8")
 
 
 async def _materialise_deps(

--- a/src/reyn/plugins/skill_load.py
+++ b/src/reyn/plugins/skill_load.py
@@ -1,0 +1,164 @@
+"""Skill-load: invocation-time ``${REYN_*}``/``${CLAUDE_*}`` expansion for a
+SKILL.md body (ADR 0064 §3.5, plugin-model P4, #3070).
+
+**The seam.** Before this module, a skill body was read raw by the ordinary
+``file`` read op (``reyn.core.op_runtime.file.handle``) — zero substitution,
+the only capability with no invocation-time expansion pass (ADR §3.5). This
+module supplies the missing pass; ``file.handle`` calls
+:func:`load_skill_body` for exactly one file: the resolved read target whose
+basename is the standard ``SKILL.md`` filename (:data:`SKILL_BODY_FILENAME`,
+the agentskills.io convention ADR §3.6 honours as-is). Every other read
+(a regular file, an ``L3`` bundled asset a skill's instructions reference)
+is untouched — this is NOT a new execution surface (#2971's "no run_skill
+verb" rationale still holds: reading is still the invocation, just no longer
+byte-identical to what's on disk); it is the SAME read op, doing one more
+thing to the content it already decoded.
+
+**Reuses P1's token layer verbatim** (``reyn.plugins.tokens`` —
+:func:`~reyn.plugins.tokens.expand_reyn_tokens` /
+:class:`~reyn.plugins.tokens.PluginTokenContext`), per the standing
+"no reinventing existing functionality" rule. This module supplies only what
+P1 could not: WHERE a given skill's location-token values come from at
+invocation time.
+
+**Location vars are resolved here too, redundantly with P2's copy-time
+bake — deliberately.** ADR §3.4 designates ``${REYN_PLUGIN_ROOT}``/
+``${REYN_SKILL_DIR}`` "stable location, baked at copy time". P2
+(``plugin_install``'s ``_expand_plugin_files``, already merged) bakes
+``${REYN_PLUGIN_ROOT}`` into every ``skills/*/SKILL.md`` at copy time —
+but deliberately does NOT bake ``${REYN_SKILL_DIR}`` there (no per-skill
+``skill_dir`` on the whole-plugin bake pass) and, since #3070, does NOT bake
+``${REYN_PROJECT_DIR}`` into a skill body either (a global
+``~/.reyn/plugins/<name>/`` copy can be ENABLED into many different
+projects, §3.3 — baking one install call's project into the shared copy
+would freeze every future enabling project to whichever one installed it
+first). This module resolves ALL THREE tokens on every load regardless:
+for a body P2 already baked ``${REYN_PLUGIN_ROOT}`` into, a second pass
+through the same expander is a no-op (no ``${...}`` left to match); for a
+body from the pre-plugin-model install path (``skill_management__install_*``,
+no P2 bake at all) or for ``${REYN_SKILL_DIR}``/``${REYN_PROJECT_DIR}``
+(never baked by either path), this is the ONLY place they resolve.
+``${REYN_PROJECT_DIR}`` in particular MUST be resolved fresh on every
+load — baking it anywhere would go stale the moment the operator points a
+session at a different project, or a different project enables the same
+globally-installed plugin.
+
+**Plugin-root resolution.** A skill installed via
+``skill_management__install_local``/``_install_source`` (the pre-plugin-model
+skill install path, unrelated to a ``.reyn-plugin/plugin.json`` manifest) has
+no separate plugin directory — its own directory IS the root for
+``${REYN_PLUGIN_ROOT}`` purposes there, so :func:`resolve_plugin_root` falls
+back to the skill's own directory when it finds no manifest walking upward.
+A plugin-shipped skill (``<plugin_root>/skills/<name>/SKILL.md``) resolves
+to the real, distinct plugin root — reusing P1's
+``reyn.plugins.manifest.manifest_path_for`` to find the ``.reyn-plugin/``
+marker rather than re-deriving the plugin layout convention independently.
+
+**``${env:VAR}`` — a NAMESPACED env-var token, deliberately NOT
+``expand_env``'s bare ``${VAR}`` syntax.** ADR §3.4's table lists
+``${env:VAR}`` (with the ``env:`` prefix, literally) as skill-load's dynamic
+os.environ bucket. A skill body is free-form Markdown prose an author writes
+— unlike an mcp spawn config or a pipeline yaml (structured values authors
+already expect to template), a skill body routinely contains literal
+``${VAR}``-shaped text in code-block examples (shell snippets, other tools'
+config samples). Reusing ``expand_env``'s bare-``${VAR}`` syntax here would
+silently mangle that prose (blank out an unset "variable" that was never
+meant to be one) and emit spurious ``UserWarning``s for every such example.
+The ``env:`` prefix is the disambiguator — this module owns exactly
+``${env:VAR_NAME}`` and reads directly from ``os.environ`` (unset → left
+untouched, NOT blanked, so an author's stray ``${env:...}``-shaped prose
+degrades to "unexpanded token" rather than "silently deleted text"); it does
+NOT call ``reyn.security.secrets.interpolation.expand_env`` (that remains
+scoped to mcp spawn config, its own established call site, ADR-0030).
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from reyn.plugins.manifest import manifest_path_for
+from reyn.plugins.tokens import PluginTokenContext, expand_reyn_tokens
+
+# The one filename this module routes through skill-load expansion instead
+# of a byte-identical read (agentskills.io convention, ADR §3.6). Matched on
+# basename only — a skill's containing directory name is never dictated by
+# the standard, only the body filename inside it is.
+SKILL_BODY_FILENAME = "SKILL.md"
+
+# ``${env:VAR_NAME}`` — namespaced so it cannot collide with a plain
+# ``${VAR}`` example a skill author writes in prose (see module docstring).
+_ENV_TOKEN_RE = re.compile(r"\$\{env:(\w+)\}")
+
+
+def _expand_env_tokens(text: str) -> str:
+    """Expand ``${env:VAR}`` from ``os.environ`` — unset leaves the token
+    untouched (never blanks skill-body prose; see module docstring)."""
+
+    def _replace(m: re.Match) -> str:
+        value = os.environ.get(m.group(1))
+        return value if value is not None else m.group(0)
+
+    return _ENV_TOKEN_RE.sub(_replace, text)
+
+
+def is_skill_body_path(path: "str | Path") -> bool:
+    """True when *path*'s filename is the standard SKILL.md body filename —
+    the one signal ``file.handle`` uses to route a read through skill-load
+    expansion rather than a raw pass-through."""
+    return Path(path).name == SKILL_BODY_FILENAME
+
+
+def resolve_plugin_root(skill_dir: Path) -> Path:
+    """Find the plugin root a skill at *skill_dir* belongs to.
+
+    Walks *skill_dir* and its parents looking for ``.reyn-plugin/plugin.json``
+    (P1's :func:`~reyn.plugins.manifest.manifest_path_for` — the SAME marker
+    P2's install step will write, not a re-derived convention). Returns the
+    first directory found; falls back to *skill_dir* itself (already
+    ``.resolve()``d) when no manifest is found anywhere above it — a
+    standalone (non-plugin) skill's own directory is its own root.
+    """
+    current = skill_dir.resolve()
+    for candidate in (current, *current.parents):
+        if manifest_path_for(candidate).is_file():
+            return candidate
+    return current
+
+
+def load_skill_body(
+    content: str,
+    *,
+    skill_path: "str | Path",
+    project_dir: Path,
+    alias_claude: bool = False,
+) -> str:
+    """Expand invocation-time ``${REYN_*}``/``${CLAUDE_*}``/``${env:...}``
+    tokens in a decoded SKILL.md body (§3.5's "skill-load verb").
+
+    ``content`` is the ALREADY-DECODED text of the file at *skill_path* (the
+    caller — ``file.handle`` — has already run the decode ladder; this
+    function does no I/O of its own and never re-reads the file). Returns the
+    expanded body; the caller returns it verbatim as the read op's `content`.
+
+    ``alias_claude`` should be ``True`` only when *skill_path* is known to be
+    a Claude-authored SKILL.md (ADR §3.6's ingestion-boundary rule, mirroring
+    ``expand_reyn_tokens``'s own parameter) — the caller decides that, this
+    function just threads it through.
+    """
+    skill_dir = Path(skill_path).resolve().parent
+    token_ctx = PluginTokenContext(
+        plugin_root=resolve_plugin_root(skill_dir),
+        project_dir=project_dir,
+        skill_dir=skill_dir,
+    )
+    expanded = expand_reyn_tokens(content, token_ctx, alias_claude=alias_claude)
+    return _expand_env_tokens(expanded)
+
+
+__all__ = [
+    "SKILL_BODY_FILENAME",
+    "is_skill_body_path",
+    "resolve_plugin_root",
+    "load_skill_body",
+]

--- a/tests/plugins/test_skill_load.py
+++ b/tests/plugins/test_skill_load.py
@@ -1,0 +1,370 @@
+"""Tier 1/2: skill-load invocation-time variable expansion (ADR 0064 §3.5,
+plugin-model P4, #3070).
+
+Pins (real instances throughout — no mocks):
+
+  1. ``load_skill_body`` expands ``${REYN_PLUGIN_ROOT}``/``${REYN_SKILL_DIR}``/
+     ``${REYN_PROJECT_DIR}`` to real, DISTINCT non-default filesystem paths
+     (Tier 1, ``reyn.plugins.skill_load``).
+  2. ``resolve_plugin_root`` walks up from a skill dir to a real
+     ``.reyn-plugin/plugin.json`` written to disk, and returns a DIFFERENT
+     value than ``skill_dir`` when one exists — falls back to ``skill_dir``
+     itself when none does (no collapse in either direction).
+  3. ``${CLAUDE_*}`` aliases expand to the SAME value as their canonical
+     ``${REYN_*}`` counterpart (§3.6), reusing P1's ``PluginTokenContext``.
+  4. ``${env:VAR}`` expands from a real (non-default) ``os.environ`` value;
+     an UNSET ``${env:VAR}`` is left untouched (not blanked); a bare
+     ``${SOME_VAR}`` (no ``env:`` prefix) is left untouched even when
+     ``SOME_VAR`` IS set — proving the namespaced syntax doesn't fall back
+     to ``expand_env``'s bare-``${VAR}`` behaviour.
+  5. Integration (Tier 2): the real ``file`` read op (``file.handle``) routes
+     a ``SKILL.md``-named file through skill-load expansion end to end, and
+     emits a ``skill_body_loaded`` audit-event (read via ``EventLog.all()``,
+     the public surface — never private state). A same-content, differently-
+     named file is NOT expanded (falsify: proves the routing is keyed on the
+     ``SKILL.md`` filename, not "any file that happens to contain tokens").
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.plugins.skill_load import (
+    is_skill_body_path,
+    load_skill_body,
+    resolve_plugin_root,
+)
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── is_skill_body_path ───────────────────────────────────────────────────────
+
+def test_is_skill_body_path_matches_only_skill_md_basename(tmp_path):
+    """Tier 1: routes on the SKILL.md basename only, not directory naming."""
+    assert is_skill_body_path(tmp_path / "some-skill" / "SKILL.md")
+    assert not is_skill_body_path(tmp_path / "SKILL.md.bak")
+    assert not is_skill_body_path(tmp_path / "some-skill" / "reference.md")
+    assert not is_skill_body_path(tmp_path / "skill.md")  # case-sensitive
+
+
+# ── resolve_plugin_root ──────────────────────────────────────────────────────
+
+def test_resolve_plugin_root_finds_manifest_walking_up(tmp_path):
+    """Tier 1: a real .reyn-plugin/plugin.json above the skill dir is found,
+    and the returned root is a DIFFERENT path than skill_dir itself."""
+    plugin_dir = tmp_path / "my-plugin"
+    manifest_dir = plugin_dir / ".reyn-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps({"name": "my-plugin", "version": "1.0.0"}), encoding="utf-8",
+    )
+    skill_dir = plugin_dir / "skills" / "rag-search"
+    skill_dir.mkdir(parents=True)
+
+    root = resolve_plugin_root(skill_dir)
+
+    assert root == plugin_dir.resolve()
+    assert root != skill_dir.resolve()
+
+
+def test_resolve_plugin_root_falls_back_to_skill_dir_when_no_manifest(tmp_path):
+    """Tier 1: a standalone (non-plugin) skill has no manifest above it —
+    resolve_plugin_root falls back to skill_dir itself."""
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+
+    root = resolve_plugin_root(skill_dir)
+
+    assert root == skill_dir.resolve()
+
+
+# ── load_skill_body: REYN_* tokens ───────────────────────────────────────────
+
+def test_load_skill_body_expands_reyn_tokens_to_distinct_real_paths(tmp_path):
+    """Tier 1: PLUGIN_ROOT / SKILL_DIR / PROJECT_DIR each expand to their
+    own real, non-default, DISTINCT filesystem path."""
+    plugin_dir = tmp_path / "acme-plugin"
+    manifest_dir = plugin_dir / ".reyn-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps({"name": "acme-plugin", "version": "2.3.4"}), encoding="utf-8",
+    )
+    skill_dir = plugin_dir / "skills" / "widget-maker"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text("body", encoding="utf-8")
+    project_dir = tmp_path / "operator-project-xyz"
+    project_dir.mkdir()
+
+    content = (
+        "root=${REYN_PLUGIN_ROOT} skill=${REYN_SKILL_DIR} "
+        "project=${REYN_PROJECT_DIR}"
+    )
+
+    expanded = load_skill_body(content, skill_path=skill_path, project_dir=project_dir)
+
+    assert f"root={plugin_dir.resolve()}" in expanded
+    assert f"skill={skill_dir.resolve()}" in expanded
+    assert f"project={project_dir.resolve()}" in expanded
+    # all three resolve to genuinely distinct values -- no collapse (§3.4/§3.6)
+    assert len({str(plugin_dir.resolve()), str(skill_dir.resolve()), str(project_dir.resolve())}) == 3
+
+
+def test_load_skill_body_claude_alias_matches_reyn_token_value(tmp_path):
+    """Tier 1: §3.6 -- ${CLAUDE_*} expands to the SAME value as its
+    canonical ${REYN_*} counterpart, reusing P1's PluginTokenContext."""
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+
+    content = "${CLAUDE_SKILL_DIR}|${REYN_SKILL_DIR}"
+    expanded = load_skill_body(
+        content, skill_path=skill_path, project_dir=project_dir, alias_claude=True,
+    )
+
+    claude_val, reyn_val = expanded.split("|")
+    assert claude_val == reyn_val == str(skill_dir.resolve())
+
+
+def test_load_skill_body_claude_alias_off_leaves_token_untouched(tmp_path):
+    """Tier 1: with alias_claude=False (the default), a ${CLAUDE_*} token is
+    left as a literal, unexpanded string."""
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+
+    expanded = load_skill_body(
+        "${CLAUDE_SKILL_DIR}", skill_path=skill_path, project_dir=project_dir,
+        alias_claude=False,
+    )
+
+    assert expanded == "${CLAUDE_SKILL_DIR}"
+
+
+# ── load_skill_body: ${env:VAR} ──────────────────────────────────────────────
+
+def test_load_skill_body_expands_env_token_from_real_environ(tmp_path, monkeypatch):
+    """Tier 1: ${env:VAR} expands from a real, non-default os.environ value."""
+    monkeypatch.setenv("REYN_SKILL_LOAD_TEST_TOKEN", "quetzal-9182")
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+
+    expanded = load_skill_body(
+        "value=${env:REYN_SKILL_LOAD_TEST_TOKEN}",
+        skill_path=skill_path, project_dir=project_dir,
+    )
+
+    assert expanded == "value=quetzal-9182"
+
+
+def test_load_skill_body_unset_env_token_left_untouched(tmp_path, monkeypatch):
+    """Tier 1: an UNSET ${env:VAR} is left as a literal token, never blanked."""
+    monkeypatch.delenv("REYN_SKILL_LOAD_TEST_UNSET_TOKEN", raising=False)
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+
+    expanded = load_skill_body(
+        "${env:REYN_SKILL_LOAD_TEST_UNSET_TOKEN}",
+        skill_path=skill_path, project_dir=project_dir,
+    )
+
+    assert expanded == "${env:REYN_SKILL_LOAD_TEST_UNSET_TOKEN}"
+
+
+def test_load_skill_body_bare_var_not_expanded_even_when_set(tmp_path, monkeypatch):
+    """Tier 1: a bare ${VAR} (no env: prefix) is left untouched even though
+    the same-named env var IS set -- proves skill-load does NOT fall back to
+    expand_env's bare-${VAR} syntax (collision-avoidance is the whole point,
+    see module docstring)."""
+    monkeypatch.setenv("SOME_VAR", "should-not-appear")
+    skill_dir = tmp_path / "standalone-skill"
+    skill_dir.mkdir()
+    skill_path = skill_dir / "SKILL.md"
+    project_dir = tmp_path / "some-project"
+    project_dir.mkdir()
+
+    expanded = load_skill_body(
+        "example: ${SOME_VAR}", skill_path=skill_path, project_dir=project_dir,
+    )
+
+    assert expanded == "example: ${SOME_VAR}"
+    assert "should-not-appear" not in expanded
+
+
+# ── Integration: the real file read op ───────────────────────────────────────
+
+def _make_ctx(project_root: Path) -> tuple[OpContext, EventLog]:
+    events = EventLog()
+    ws = Workspace(events=events, base_dir=project_root)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False,
+    )
+    ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="test_skill_load",
+    )
+    return ctx, events
+
+
+def test_file_read_op_expands_skill_md_body_end_to_end(tmp_path):
+    """Tier 2: OS invariant -- the real `file` read op expands a SKILL.md
+    body's ${REYN_PROJECT_DIR} token to the REAL project root, and emits a
+    skill_body_loaded audit-event (read via the public EventLog.all())."""
+    project_root = tmp_path / "project-root-real"
+    project_root.mkdir()
+    skill_dir = project_root / "skills" / "greeter"
+    skill_dir.mkdir(parents=True)
+    skill_path = skill_dir / "SKILL.md"
+    skill_path.write_text(
+        "---\nname: greeter\n---\nProject: ${REYN_PROJECT_DIR}\n", encoding="utf-8",
+    )
+    rel_path = str(skill_path.relative_to(project_root))
+    ctx, events = _make_ctx(project_root)
+
+    result = _run(handle(FileIROp(kind="file", op="read", path=rel_path), ctx))
+
+    assert result["status"] == "ok", result
+    assert f"Project: {project_root.resolve()}" in result["content"]
+    assert "${REYN_PROJECT_DIR}" not in result["content"]
+
+    skill_load_events = [e for e in events.all() if e.type == "skill_body_loaded"]
+    assert skill_load_events, "expected a skill_body_loaded audit-event to be emitted"
+    assert any(e.data["path"] == rel_path for e in skill_load_events)
+
+
+def test_file_read_op_does_not_expand_non_skill_md_file(tmp_path):
+    """Tier 2: (falsify) the SAME token text in a differently-named file is
+    returned VERBATIM -- proves expansion is keyed on the SKILL.md filename,
+    not on content that merely looks like a token."""
+    project_root = tmp_path / "project-root-real"
+    project_root.mkdir()
+    other_path = project_root / "notes.md"
+    other_path.write_text("Project: ${REYN_PROJECT_DIR}\n", encoding="utf-8")
+    ctx, events = _make_ctx(project_root)
+
+    result = _run(handle(FileIROp(kind="file", op="read", path="notes.md"), ctx))
+
+    assert result["status"] == "ok", result
+    assert "Project: ${REYN_PROJECT_DIR}" in result["content"]
+    assert not [e for e in events.all() if e.type == "skill_body_loaded"]
+
+
+# ── Integration: a real plugin_install (P2) copy feeding skill-load (P4) ────
+#
+# P2's `plugin_install` bakes ${REYN_PLUGIN_ROOT} into a plugin's SKILL.md
+# files at COPY time (`_expand_plugin_files`, `reyn.core.op_runtime.
+# plugin_install`) but deliberately leaves ${REYN_SKILL_DIR}/${REYN_PROJECT_DIR}
+# unbaked (see that module's docstring, updated by #3070) -- this test proves
+# BOTH halves of that split with one real end-to-end run: install a real local
+# plugin, then read its installed SKILL.md through the real file read op.
+
+
+def test_plugin_install_bakes_plugin_root_skill_load_resolves_the_rest(tmp_path, monkeypatch):
+    """Tier 2: OS invariant -- ${REYN_PLUGIN_ROOT} is ALREADY a literal path
+    in the file plugin_install (P2) copied to disk (baked at copy time, no
+    skill-load pass needed to see it); ${REYN_SKILL_DIR} and
+    ${REYN_PROJECT_DIR} are STILL literal ${...} tokens in that same copied
+    file until the real file read op's skill-load pass (P4) expands them to
+    the REAL, current project root -- proving the split is not merely
+    documented but actually holds for a real plugin_install output."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    from reyn.core.op_runtime.plugin_install import handle as install_handle
+    from reyn.core.op_runtime.plugin_install import plugins_root
+    from reyn.schemas.models import PluginInstallIROp
+
+    source = tmp_path / "src-plugin"
+    (source / ".reyn-plugin").mkdir(parents=True)
+    (source / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": "loadertest", "version": "0.1.0", "description": "d",
+            "capabilities": [{"kind": "skills"}],
+        }),
+        encoding="utf-8",
+    )
+    (source / "skills" / "greeter").mkdir(parents=True)
+    (source / "skills" / "greeter" / "SKILL.md").write_text(
+        "---\nname: greeter\n---\n"
+        "root=${REYN_PLUGIN_ROOT} skill=${REYN_SKILL_DIR} project=${REYN_PROJECT_DIR}\n",
+        encoding="utf-8",
+    )
+
+    project_root = tmp_path / "operator-project"
+    project_root.mkdir()
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=False,
+    )
+    resolver.session_approve_path(str(plugins_root()), "test", "file.write", recursive=True)
+    resolver.session_approve_path(str(plugins_root()), "test", "file.read", recursive=True)
+    for cfg in ("mcp.yaml", "pipelines.yaml", "skills.yaml"):
+        resolver.session_approve_path(
+            str(project_root / ".reyn" / "config" / cfg), "test", "file.write",
+        )
+    events = EventLog()
+    ws = Workspace(
+        events=events, base_dir=project_root,
+        permission_resolver=resolver, actor="test",
+    )
+    install_ctx = OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(
+            file_write=[{"path": str(plugins_root()), "scope": "recursive"}],
+        ),
+        permission_resolver=resolver,
+        actor="test",
+    )
+
+    install_op = PluginInstallIROp(
+        kind="plugin_install", source={"kind": "local", "path": str(source)},
+    )
+    install_result = _run(install_handle(install_op, install_ctx))
+    assert install_result["status"] == "installed", install_result
+
+    plugin_root = plugins_root() / "loadertest"
+    skill_path = plugin_root / "skills" / "greeter" / "SKILL.md"
+
+    # Pin the copy-time half directly: ${REYN_PLUGIN_ROOT} is ALREADY a
+    # literal path on disk, before any file read op runs.
+    on_disk = skill_path.read_text(encoding="utf-8")
+    assert f"root={plugin_root.resolve()}" in on_disk
+    assert "${REYN_SKILL_DIR}" in on_disk
+    assert "${REYN_PROJECT_DIR}" in on_disk
+
+    # Now read it through the real file op -- skill-load resolves the rest.
+    read_result = _run(handle(FileIROp(kind="file", op="read", path=str(skill_path)), install_ctx))
+    assert read_result["status"] == "ok", read_result
+    content = read_result["content"]
+    assert f"root={plugin_root.resolve()}" in content
+    assert f"skill={skill_path.parent.resolve()}" in content
+    assert f"project={project_root.resolve()}" in content
+    assert "${REYN_SKILL_DIR}" not in content
+    assert "${REYN_PROJECT_DIR}" not in content


### PR DESCRIPTION
**[per-PR-coder]** — ADR 0064 plugin-model P4: skill-load tool with invocation-time variable expansion for SKILL.md bodies.

## Summary

- Before this PR, a `SKILL.md` body was read raw by the ordinary `file` read op — zero substitution, the only capability with no invocation-time expansion pass (ADR §3.5).
- `reyn.plugins.skill_load` routes exactly the `SKILL.md` filename through a skill-load pass (`file.handle` -> `load_skill_body`) before returning content. Still the SAME read op — #2971's "no run_skill verb" rationale holds (reading is still the invocation); it just no longer hands back byte-identical disk content for that one filename.
- Reuses P1's `reyn.plugins.tokens` (`PluginTokenContext` / `expand_reyn_tokens`) verbatim for `${REYN_*}`/`${CLAUDE_*}` — no reimplementation.
- Adds a namespaced `${env:VAR_NAME}` token, deliberately NOT `expand_env`'s bare `${VAR}` syntax: a skill body is free-form prose that routinely contains literal `${VAR}`-shaped code examples (shell snippets, other tools' config samples) — the `env:` prefix disambiguates instead of silently mangling that prose.
- `${CLAUDE_*}` alias is always active for a skill-load (SKILL.md is the one open standard multiple hosts share, agentskills.io — there is no narrower "Claude-authored" signal to gate on for this format specifically).

## A gap this PR also closes in already-merged P2

`plugin_install`'s `_expand_plugin_files` (P2, merged as #3076) was baking `${REYN_PROJECT_DIR}` into a plugin's `SKILL.md` at COPY time. Since a plugin's global `~/.reyn/plugins/<name>/` copy can be ENABLED into multiple different projects (§3.3 — code installs once globally, enablement is project-local), baking one install call's project root into the shared copy would freeze every later enabling project to whichever project happened to install it first — contradicting §3.4's explicit "REYN_PROJECT_DIR is a dynamic param, expanded at invocation, never baked" rule.

Fix: `SKILL.md` now bakes ONLY `${REYN_PLUGIN_ROOT}` at copy time (new `_bake_plugin_root_only`); `${REYN_SKILL_DIR}`/`${REYN_PROJECT_DIR}` are left as literal tokens for skill-load to resolve fresh on every invocation. mcp/pipeline copy-time baking is unchanged (out of this ticket's scope — P4 is skill-load only).

## Tests (Tier 1/2, real instances only, testing.md-compliant)

- Each token kind (`REYN_PLUGIN_ROOT`/`REYN_SKILL_DIR`/`REYN_PROJECT_DIR`) pinned to real, DISTINCT, non-default filesystem paths.
- `resolve_plugin_root` walking up to a real `.reyn-plugin/plugin.json`, and falling back to the skill's own dir when none exists.
- `${CLAUDE_*}` alias on/off, matching its canonical `${REYN_*}` counterpart.
- `${env:VAR}` set (non-default value)/unset(left untouched, not blanked)/bare-`${VAR}`-not-expanded (proves it does NOT fall back to `expand_env`'s syntax).
- A real `file` read op integration test (SKILL.md gets expanded + emits a `skill_body_loaded` audit-event, read via `EventLog.all()`) + a falsify test (a same-content, differently-named file is NOT expanded).
- A real `plugin_install` -> `file` read end-to-end test proving the copy-time/invocation-time split actually holds against real `plugin_install` output (not just documented intent).

## Docs

`docs/reference/runtime/control-ir.md` (the `read_file` row + `plugin_install`'s step 6) and `docs/concepts/tools-integrations/skills.md` (new "Skill-load variable expansion" section) updated in the same PR — both described the now-changed read path / copy-time bake scope.

## CI gates (all local-green before push)

- `ruff check src tests` — pass
- `python scripts/test_tier_audit.py --strict tests/plugins/test_skill_load.py` — pass (0 Tier-4 violations)
- `pytest` (full suite, twice) — 8897 passed, 29 skipped, 0 failed
- `python scripts/verify_module_docstrings.py <changed src files>` — pass

part of #3066
part of #3070

🤖 Generated with [Claude Code](https://claude.com/claude-code)