### PR TITLE
feat: /plugin slash + reyn plugin CLI surfaces (ADR 0064 P3)

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -813,6 +813,30 @@ surface: `plugin_management__install` / `plugin_management__uninstall`
 avoid a canonical-declaration collision (mirrors the `mcp_install_local` vs
 `mcp_install` op-kind precedent).
 
+ADR §3.9 (P3): the SAME typed op is also exposed as a slash command
+(`/plugin install builtin|local|git <SOURCE> [as <INSTALL_NAME>]` /
+`/plugin uninstall <NAME>`, `interfaces/slash/plugin.py`) and a CLI command
+(`reyn plugin install builtin|local|git <SOURCE>` / `reyn plugin uninstall
+<NAME>`, `interfaces/cli/commands/plugin.py`) — both thin adapters that build
+a `ToolContext` and call `invoke_tool(get_default_registry(),
+"plugin_management__install"/"__uninstall", ...)`, the SAME lookup+dispatch a
+live chat-router LLM tool call uses, so the composite permission decl and the
+`{kind: "git"}` run-code trust gate (below) live in exactly one place. The
+slash surface threads the session's LIVE `RouterHostAdapter.
+make_router_op_context` (real intervention bus - a `{kind: "git"}` install
+prompts interactively, and the OpContext carries the `#1339` sandbox floor -
+`resolve_sandbox_policy`, write_paths default-restricted to the workspace -
+so installing a `{kind: "local"}`/`{kind: "git"}` plugin from `/plugin`
+additionally needs an operator `reyn.yaml` `sandbox.policy.write_paths` grant
+covering `~/.reyn/plugins/`, same as a live LLM tool call would). The CLI
+surface instead builds a standalone `OpContext` directly (no
+`build_router_op_context`, no sandbox floor - mirrors `reyn mcp install`'s
+CLI-is-the-operator-trusted-entry-point precedent) whose `interactive` flag is
+`not --non-interactive and sys.stdin.isatty()`. Either surface, a
+non-interactive caller (no intervention bus) fails the `{kind: "git"}`
+run-code trust gate closed - that gate is unconditional deny-else
+(`require_plugin_git_run_code_trust`), independent of the sandbox floor.
+
 `plugin_install` example (typed discriminated `source`, §3.8 — never a
 form-sniffed string):
 ```json

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -820,9 +820,12 @@ ADR §3.9 (P3): the SAME typed op is also exposed as a slash command
 <NAME>`, `interfaces/cli/commands/plugin.py`) — both thin adapters that build
 a `ToolContext` and call `invoke_tool(get_default_registry(),
 "plugin_management__install"/"__uninstall", ...)`, the SAME lookup+dispatch a
-live chat-router LLM tool call uses, so the composite permission decl and the
-`{kind: "git"}` run-code trust gate (below) live in exactly one place. The
-slash surface threads the session's LIVE `RouterHostAdapter.
+live chat-router LLM tool call uses. No surface re-implements the security
+logic: the composite permission decl is declared once in
+`tools/plugin_management_verbs.py` (the tool wrapper), and the `{kind: "git"}`
+run-code trust gate itself (below) lives one layer down in
+`core/op_runtime/plugin_install.py::handle` — the op handler every surface
+funnels into. The slash surface threads the session's LIVE `RouterHostAdapter.
 make_router_op_context` (real intervention bus - a `{kind: "git"}` install
 prompts interactively, and the OpContext carries the `#1339` sandbox floor -
 `resolve_sandbox_policy`, write_paths default-restricted to the workspace -
@@ -836,6 +839,19 @@ CLI-is-the-operator-trusted-entry-point precedent) whose `interactive` flag is
 non-interactive caller (no intervention bus) fails the `{kind: "git"}`
 run-code trust gate closed - that gate is unconditional deny-else
 (`require_plugin_git_run_code_trust`), independent of the sandbox floor.
+
+The CLI's floor-bypass is safe by construction because LLM reach into
+`~/.reyn/plugins/` is closed at TWO layers, and the CLI is only reachable by
+the operator (not the LLM): (1) the OpContext-layer gate — on any LLM-reachable
+path (tool/slash) the `#1339` sandbox floor + `require_file_write` deny a write
+to `~/.reyn/plugins/` without an explicit operator grant; and (2) the OS-layer —
+even an LLM `exec` that tries to write there directly is denied by the sandbox
+backend, because the enforced exec policy's `write_paths` is workspace-tight
+(`resolve_sandbox_policy` floor = `[workspace.base_dir]`, operator-wins over
+LLM op fields per #1326) and Landlock/Seatbelt deny-by-default any write outside
+`write_paths` — and `~/.reyn/plugins/` (under `$HOME`) is never under the
+workspace grant. So the operator-only CLI skipping the OpContext-layer floor
+removes nothing the LLM could have reached anyway.
 
 `plugin_install` example (typed discriminated `source`, §3.8 — never a
 form-sniffed string):

--- a/src/reyn/interfaces/cli/commands/__init__.py
+++ b/src/reyn/interfaces/cli/commands/__init__.py
@@ -20,6 +20,7 @@ from . import mcp as mcp
 from . import memory as memory
 from . import permissions as permissions
 from . import pipe as pipe
+from . import plugin as plugin
 from . import run_once as run_once
 from . import secret as secret
 from . import source as source
@@ -28,4 +29,4 @@ from . import topology as topology
 from . import web as web
 
 # Order is the order shown in `reyn --help`.
-ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, pipe, secret, source, cron, dogfood, embeddings, support_bundle, audit]
+ALL = [init, config, run_once, chat, agent, topology, memory, permissions, auth, events, web, mcp, pipe, plugin, secret, source, cron, dogfood, embeddings, support_bundle, audit]

--- a/src/reyn/interfaces/cli/commands/plugin.py
+++ b/src/reyn/interfaces/cli/commands/plugin.py
@@ -87,7 +87,14 @@ def _build_plugin_cli_tool_context(project_root: Path, *, interactive: bool) -> 
     from reyn.user_intervention import StdinInterventionBus
 
     try:
-        config = load_config()
+        # Load config ANCHORED at project_root (not the default cwd) so
+        # `--project /foo` honours /foo's `permissions:` — the resolver's
+        # project_root / file_zone_root below are already /foo, and applying a
+        # DIFFERENT cwd's permissions to a /foo install would be incoherent
+        # (e.g. running from /bar would silently apply /bar's grants). When no
+        # --project is passed, project_root is the closest reyn.yaml ancestor of
+        # cwd, so this is byte-identical to the from-within-project case.
+        config = load_config(cwd=project_root)
         perm_config = dict(getattr(config, "permissions", {}) or {})
     except Exception:
         perm_config = {}

--- a/src/reyn/interfaces/cli/commands/plugin.py
+++ b/src/reyn/interfaces/cli/commands/plugin.py
@@ -1,0 +1,340 @@
+"""`reyn plugin` — install/uninstall a self-contained plugin bundle (ADR 0064 §3.9, P3).
+
+Subcommands
+-----------
+install builtin <NAME>   Install one of reyn's own shipped plugins (src/reyn/builtin/plugins/<NAME>/).
+install local <PATH>     Promote/install a local plugin directory (the primary author→test→promote loop).
+install git <URL>        Install a plugin from a remote git URL (highest RCE trust risk — §3.10 item 3).
+uninstall <NAME>         Remove a previously installed plugin (registry entries + the ~/.reyn/plugins/ copy).
+
+This is a THIN adapter over the SAME typed op the LLM tool / slash surfaces use
+(ADR 0064 §3.9: "each a thin adapter over the same typed op — surfaces never
+re-implement the logic"). It builds a real ``ToolContext`` and calls
+``invoke_tool(get_default_registry(), "plugin_management__install"/"__uninstall", ...)``
+— the SAME lookup+dispatch a live chat-router LLM tool call uses (mirrors
+``RouterLoop._dispatch_registry_tool``) — so the composite permission decl
+(``require_file_write`` on ``~/.reyn/plugins/`` + ``require_http_get``) and the
+``{kind:git}`` run-code trust gate (``require_plugin_git_run_code_trust``,
+fail-closed when non-interactive) live in exactly ONE place
+(``tools/plugin_management_verbs.py``) rather than being re-derived here.
+
+The typed ``kind`` discriminator (§3.8) is carried by the CLI SUBCOMMAND
+(``install builtin|local|git``), never a form-sniffed string — mirrors how
+``reyn mcp install`` distinguishes ``--source`` specifier forms structurally,
+and how the LLM tool's ``source`` schema is a discriminated ``oneOf``.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_project_root(project_arg: "str | None") -> Path:
+    """Resolve the target project root: ``--project`` overrides; else the
+    closest ``reyn.yaml`` ancestor of cwd. Fail loud rather than silently
+    writing into (or reading a workspace rooted at) a non-project cwd —
+    mirrors ``mcp.py``'s ``_resolve_install_project_root``."""
+    from reyn.config import _find_project_root
+
+    if project_arg:
+        project_root = Path(project_arg).resolve()
+    else:
+        found = _find_project_root(Path.cwd())
+        if found is None:
+            print(
+                "error: no reyn.yaml found from the current directory; pass "
+                "--project <path-to-project-root>.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        project_root = found
+
+    if not (project_root / "reyn.yaml").exists():
+        print(
+            f"error: {project_root}/reyn.yaml not found. "
+            "Run `reyn init` there or pass a different --project path.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return project_root
+
+
+def _build_plugin_cli_tool_context(project_root: Path, *, interactive: bool) -> Any:
+    """Build a real, standalone ``ToolContext`` for the ``reyn plugin`` CLI —
+    routed through the SAME seam a live chat-router LLM tool call uses
+    (``invoke_tool`` → ``ToolDefinition.handler`` → ``build_legacy_op_context``),
+    just without a live router loop behind it (mirrors
+    ``pipe.py::_build_run_tool_context``).
+
+    ``interactive`` controls BOTH the ``PermissionResolver``'s prompt
+    capability AND whether a live ``StdinInterventionBus`` is wired into the
+    ``router_state.op_context_factory``-built ``OpContext`` — when False
+    (``--non-interactive`` or no tty), the factory hands the op handler
+    ``intervention_bus=None``, so ``require_plugin_git_run_code_trust``
+    (§3.10 item 3) fails closed for ``{kind:git}`` exactly as it would for
+    any other non-interactive caller (bus is None OR resolver.interactive
+    is False — either alone is enough to deny).
+    """
+    from reyn.config import load_config
+    from reyn.core.events.events import EventLog
+    from reyn.data.workspace.workspace import Workspace
+    from reyn.security.permissions.permissions import PermissionResolver
+    from reyn.tools.types import RouterCallerState, ToolContext
+    from reyn.user_intervention import StdinInterventionBus
+
+    try:
+        config = load_config()
+        perm_config = dict(getattr(config, "permissions", {}) or {})
+    except Exception:
+        perm_config = {}
+
+    perm_resolver = PermissionResolver(
+        config_permissions=perm_config,
+        project_root=project_root,
+        file_zone_root=project_root,
+        interactive=interactive,
+    )
+    events = EventLog()
+    workspace = Workspace(
+        events=events,
+        permission_resolver=perm_resolver,
+        actor="plugin_management_cli",
+        base_dir=project_root,
+    )
+    bus = StdinInterventionBus() if interactive else None
+
+    def _op_context_factory() -> Any:
+        from reyn.core.op_runtime.context import OpContext
+        from reyn.security.permissions.permissions import PermissionDecl
+
+        return OpContext(
+            workspace=workspace,
+            events=events,
+            # Overwritten by the handler (plugin_management_verbs.py) with the
+            # real composite decl before the op handler runs — this empty
+            # default is never what actually gates the install/uninstall.
+            permission_decl=PermissionDecl(),
+            permission_resolver=perm_resolver,
+            actor="plugin_management_cli",
+            intervention_bus=bus,
+        )
+
+    router_state = RouterCallerState(op_context_factory=_op_context_factory)
+    return ToolContext(
+        events=events,
+        permission_resolver=perm_resolver,
+        workspace=workspace,
+        caller_kind="router",
+        router_state=router_state,
+        resolver=None,
+        hot_reloader=None,
+        state_log=None,
+    )
+
+
+async def _invoke_plugin_tool(name: str, args: dict, ctx: Any) -> dict:
+    from reyn.tools import get_default_registry
+    from reyn.tools.dispatch import invoke_tool
+
+    return await invoke_tool(get_default_registry(), name, args, ctx)
+
+
+# ---------------------------------------------------------------------------
+# register
+# ---------------------------------------------------------------------------
+
+
+def register(sub) -> None:
+    p = sub.add_parser(
+        "plugin",
+        help="Install/uninstall a self-contained reyn plugin bundle (ADR 0064)",
+    )
+    psub = p.add_subparsers(dest="plugin_command", metavar="<subcommand>")
+    psub.required = True
+
+    # ---- install ----
+    install = psub.add_parser(
+        "install",
+        help="Install/promote a plugin (typed source kind: builtin/local/git)",
+    )
+    isub = install.add_subparsers(dest="kind", metavar="<kind>")
+    isub.required = True
+
+    def _add_install_common(kind_parser) -> None:
+        kind_parser.add_argument(
+            "--name",
+            dest="install_name",
+            default=None,
+            metavar="INSTALL_NAME",
+            help=(
+                "Override the install directory / registry-provenance name "
+                "(default: the manifest's own declared name)."
+            ),
+        )
+        kind_parser.add_argument(
+            "--project", dest="project", default=None, metavar="PATH",
+            help=(
+                "Project root containing reyn.yaml. Defaults to the closest "
+                "ancestor with a reyn.yaml, or the current directory."
+            ),
+        )
+        kind_parser.add_argument(
+            "--non-interactive",
+            dest="non_interactive",
+            action="store_true",
+            help=(
+                "Suppress interactive prompts (for CI use). A {kind:git} "
+                "install ALWAYS fails closed non-interactively (ADR 0064 "
+                "§3.10 item 3 — the run-code trust decision cannot be "
+                "pre-made)."
+            ),
+        )
+        kind_parser.set_defaults(func=run_install)
+
+    builtin = isub.add_parser(
+        "builtin", help="Install one of reyn's own shipped plugins",
+    )
+    builtin.add_argument(
+        "source_name", metavar="NAME",
+        help="reyn's own shipped plugin name (src/reyn/builtin/plugins/<NAME>/).",
+    )
+    _add_install_common(builtin)
+
+    local = isub.add_parser(
+        "local", help="Promote/install a local plugin directory you authored/tested",
+    )
+    local.add_argument(
+        "source_name", metavar="PATH",
+        help="Local plugin directory (the author→test→promote loop's working copy).",
+    )
+    _add_install_common(local)
+
+    git = isub.add_parser(
+        "git", help="Install a plugin from a remote git URL (highest RCE trust risk)",
+    )
+    git.add_argument(
+        "source_name", metavar="URL",
+        help="Remote git URL. Requires a live interactive run-code trust approval.",
+    )
+    _add_install_common(git)
+
+    # ---- uninstall ----
+    uninstall = psub.add_parser(
+        "uninstall",
+        help="Uninstall a plugin (drop registry entries + remove the ~/.reyn/plugins/ copy)",
+    )
+    uninstall.add_argument(
+        "name", metavar="NAME",
+        help="The plugin's install name (the name plugin install used/returned).",
+    )
+    uninstall.add_argument(
+        "--project", dest="project", default=None, metavar="PATH",
+        help=(
+            "Project root containing reyn.yaml. Defaults to the closest "
+            "ancestor with a reyn.yaml, or the current directory."
+        ),
+    )
+    uninstall.set_defaults(func=run_uninstall)
+
+
+# ---------------------------------------------------------------------------
+# run_install / run_uninstall
+# ---------------------------------------------------------------------------
+
+
+def run_install(args: argparse.Namespace) -> None:
+    kind = args.kind
+    source_name: str = args.source_name.strip()
+    if not source_name:
+        print("error: source value must not be empty.", file=sys.stderr)
+        sys.exit(1)
+
+    if kind == "builtin":
+        source: dict = {"kind": "builtin", "name": source_name}
+    elif kind == "local":
+        source = {"kind": "local", "path": source_name}
+    elif kind == "git":
+        source = {"kind": "git", "url": source_name}
+    else:  # pragma: no cover — argparse restricts kind to the 3 subparsers above
+        print(f"error: unknown source kind {kind!r}", file=sys.stderr)
+        sys.exit(1)
+
+    project_root = _resolve_project_root(getattr(args, "project", None))
+    non_interactive: bool = getattr(args, "non_interactive", False)
+    interactive = not non_interactive and sys.stdin.isatty()
+
+    tool_args: dict = {"source": source}
+    install_name = getattr(args, "install_name", None)
+    if install_name:
+        tool_args["name"] = install_name.strip()
+
+    ctx = _build_plugin_cli_tool_context(project_root, interactive=interactive)
+
+    print(f"Installing plugin (kind={kind}): {source_name}")
+    try:
+        result = asyncio.run(
+            _invoke_plugin_tool("plugin_management__install", tool_args, ctx),
+        )
+    except PermissionError as exc:
+        print(f"\nPermission denied: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as exc:
+        print(f"\nError during plugin install: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if result.get("status") != "ok":
+        err = result.get("data", {}).get("error", result.get("error", "(unknown error)"))
+        print(f"=== plugin install failed: {err} ===", file=sys.stderr)
+        sys.exit(2)
+
+    data = result.get("data", {})
+    if isinstance(data, dict) and data.get("status") == "error":
+        print(f"=== plugin install failed: {data.get('error', '(unknown error)')} ===",
+              file=sys.stderr)
+        sys.exit(2)
+
+    print()
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+def run_uninstall(args: argparse.Namespace) -> None:
+    name = args.name.strip()
+    if not name:
+        print("error: NAME must not be empty.", file=sys.stderr)
+        sys.exit(1)
+
+    project_root = _resolve_project_root(getattr(args, "project", None))
+    # Uninstall never needs the git run-code trust gate (it only deletes),
+    # so it is safe to run fully non-interactively — no --non-interactive
+    # flag is exposed; the CLI is inherently a non-attended-safe path here.
+    ctx = _build_plugin_cli_tool_context(project_root, interactive=sys.stdin.isatty())
+
+    print(f"Uninstalling plugin: {name}")
+    try:
+        result = asyncio.run(
+            _invoke_plugin_tool("plugin_management__uninstall", {"name": name}, ctx),
+        )
+    except PermissionError as exc:
+        print(f"\nPermission denied: {exc}", file=sys.stderr)
+        sys.exit(2)
+    except Exception as exc:
+        print(f"\nError during plugin uninstall: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if result.get("status") != "ok":
+        err = result.get("data", {}).get("error", result.get("error", "(unknown error)"))
+        print(f"=== plugin uninstall failed: {err} ===", file=sys.stderr)
+        sys.exit(2)
+
+    data = result.get("data", {})
+    if isinstance(data, dict) and data.get("status") == "error":
+        print(f"=== plugin uninstall failed: {data.get('error', '(unknown error)')} ===",
+              file=sys.stderr)
+        sys.exit(2)
+
+    print()
+    print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/src/reyn/interfaces/slash/__init__.py
+++ b/src/reyn/interfaces/slash/__init__.py
@@ -266,6 +266,7 @@ from reyn.interfaces.slash import matrix as _matrix_mod  # noqa: E402, F401
 from reyn.interfaces.slash import memory as _memory_mod  # noqa: E402, F401
 from reyn.interfaces.slash import model as _model_mod  # noqa: E402, F401
 from reyn.interfaces.slash import pending as _pending_mod  # noqa: E402, F401
+from reyn.interfaces.slash import plugin as _plugin_mod  # noqa: E402, F401
 from reyn.interfaces.slash import quit as _quit_mod  # noqa: E402, F401
 from reyn.interfaces.slash import reload as _reload_mod  # noqa: E402, F401
 from reyn.interfaces.slash import reset as _reset_mod  # noqa: E402, F401

--- a/src/reyn/interfaces/slash/plugin.py
+++ b/src/reyn/interfaces/slash/plugin.py
@@ -1,0 +1,174 @@
+"""``/plugin`` — install/uninstall a self-contained plugin bundle (ADR 0064 §3.9, P3).
+
+Usage::
+
+    /plugin install builtin <NAME> [as <INSTALL_NAME>]
+    /plugin install local <PATH> [as <INSTALL_NAME>]
+    /plugin install git <URL> [as <INSTALL_NAME>]
+    /plugin uninstall <NAME>
+
+Thin adapter over the SAME typed op the LLM tool / CLI surfaces use (ADR 0064
+§3.9). Builds a ``ToolContext`` from this session's LIVE ``RouterHostAdapter``
+(``session.router_host.make_router_op_context`` via
+``reyn.tools.types.build_resource_caller_state`` — the SAME factory a live
+LLM ``plugin_management__install``/``__uninstall`` tool call gets) and calls
+``invoke_tool(get_default_registry(), "plugin_management__install"/"__uninstall", ...)``
+— never re-derives the composite permission decl or the ``{kind:git}``
+run-code trust gate (``tools/plugin_management_verbs.py`` / ``require_plugin_git_run_code_trust``
+own that, exactly once). Because this session's real intervention bus is
+threaded through, a ``{kind:git}`` install prompts interactively (the
+operator-trust decision §3.10 requires) exactly like a live LLM tool call
+would.
+
+The typed ``kind`` discriminator (§3.8) is carried by the explicit slash arg
+(``builtin``/``local``/``git``) — never a form-sniffed string.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from reyn.interfaces.slash import reply, reply_error, slash
+
+if TYPE_CHECKING:
+    from reyn.runtime.session import Session
+
+_USAGE = (
+    "usage: /plugin install builtin|local|git <SOURCE> [as <INSTALL_NAME>]  "
+    "|  /plugin uninstall <NAME>"
+)
+
+
+async def _build_plugin_tool_context(session: "Session") -> Any:
+    from reyn.tools.types import ToolContext, build_resource_caller_state
+
+    host = session.router_host
+    router_state = await build_resource_caller_state(host)
+    return ToolContext(
+        events=host.events,
+        permission_resolver=getattr(host, "permission_resolver", None),
+        workspace=getattr(host, "workspace", None),
+        caller_kind="router",
+        router_state=router_state,
+        resolver=getattr(host, "resolver", None),
+        hot_reloader=getattr(host, "hot_reloader", None),
+        state_log=getattr(host, "state_log", None),
+    )
+
+
+async def _invoke_plugin_tool(name: str, args: dict, ctx: Any) -> dict:
+    from reyn.tools import get_default_registry
+    from reyn.tools.dispatch import invoke_tool
+
+    return await invoke_tool(get_default_registry(), name, args, ctx)
+
+
+def _extract_error(result: dict) -> "str | None":
+    if result.get("status") != "ok":
+        return str(result.get("data", {}).get("error", result.get("error", "(unknown error)")))
+    data = result.get("data", {})
+    if isinstance(data, dict) and data.get("status") == "error":
+        return str(data.get("error", "(unknown error)"))
+    return None
+
+
+@slash(
+    "plugin",
+    summary="Install/uninstall a self-contained reyn plugin bundle",
+    usage=_USAGE,
+    see_also=("docs/deep-dives/proposals/0064-plugin-model.md",),
+)
+async def plugin_cmd(session: "Session", args: str) -> None:
+    try:
+        parts = shlex.split(args)
+    except ValueError as exc:
+        await reply_error(session, f"could not parse arguments: {exc}. {_USAGE}")
+        return
+
+    if len(parts) < 2:
+        await reply_error(session, _USAGE)
+        return
+
+    subcmd = parts[0]
+
+    if subcmd == "install":
+        if len(parts) < 3:
+            await reply_error(session, _USAGE)
+            return
+        kind = parts[1]
+        source_value = parts[2]
+        rest = parts[3:]
+
+        if kind == "builtin":
+            source: dict = {"kind": "builtin", "name": source_value}
+        elif kind == "local":
+            source = {"kind": "local", "path": source_value}
+        elif kind == "git":
+            source = {"kind": "git", "url": source_value}
+        else:
+            await reply_error(
+                session,
+                f"unknown source kind {kind!r} — expected builtin/local/git. {_USAGE}",
+            )
+            return
+
+        install_name: "str | None" = None
+        if rest:
+            if len(rest) == 2 and rest[0] == "as":
+                install_name = rest[1]
+            else:
+                await reply_error(session, f"unexpected trailing arguments: {rest!r}. {_USAGE}")
+                return
+
+        tool_args: dict = {"source": source}
+        if install_name:
+            tool_args["name"] = install_name
+
+        ctx = await _build_plugin_tool_context(session)
+        try:
+            result = await _invoke_plugin_tool("plugin_management__install", tool_args, ctx)
+        except PermissionError as exc:
+            await reply_error(session, f"permission denied: {exc}")
+            return
+        except Exception as exc:
+            await reply_error(session, f"plugin install failed: {exc}")
+            return
+
+        err = _extract_error(result)
+        if err is not None:
+            await reply_error(session, f"plugin install failed: {err}")
+            return
+
+        await reply(
+            session,
+            f"✓ plugin installed (kind={kind}, source={source_value}).\n"
+            f"{json.dumps(result.get('data', result), indent=2, ensure_ascii=False)}",
+        )
+        return
+
+    if subcmd == "uninstall":
+        name = parts[1]
+        ctx = await _build_plugin_tool_context(session)
+        try:
+            result = await _invoke_plugin_tool("plugin_management__uninstall", {"name": name}, ctx)
+        except PermissionError as exc:
+            await reply_error(session, f"permission denied: {exc}")
+            return
+        except Exception as exc:
+            await reply_error(session, f"plugin uninstall failed: {exc}")
+            return
+
+        err = _extract_error(result)
+        if err is not None:
+            await reply_error(session, f"plugin uninstall failed: {err}")
+            return
+
+        await reply(
+            session,
+            f"✓ plugin {name!r} uninstalled.\n"
+            f"{json.dumps(result.get('data', result), indent=2, ensure_ascii=False)}",
+        )
+        return
+
+    await reply_error(session, f"unknown subcommand {subcmd!r}. {_USAGE}")

--- a/tests/test_plugin_cli_surface.py
+++ b/tests/test_plugin_cli_surface.py
@@ -1,0 +1,233 @@
+"""Tier 2: OS invariant — `reyn plugin install`/`uninstall` CLI surface (ADR 0064 §3.9, P3).
+
+The CLI is a thin adapter over the SAME typed op the LLM tool / slash surfaces
+use: it builds a real ``ToolContext`` and calls
+``invoke_tool(get_default_registry(), "plugin_management__install"/"__uninstall", ...)``
+— the same lookup+dispatch a live chat-router LLM tool call uses. These tests
+prove:
+
+  1. the typed ``kind`` discriminator (builtin/local/git subcommand) threads
+     through to the correct ``{kind, ...}`` source shape the op actually
+     receives — real dispatch through ``run_install``, no mock of the
+     dispatch call;
+  2. a real local-plugin install + uninstall roundtrip through the CLI
+     entrypoints reaches the SAME registry writes P2's own op-level tests
+     assert on (``.reyn/config/skills.yaml`` + ``~/.reyn/plugins/<name>/``);
+  3. `{kind:git}` install fails CLOSED when run non-interactively (real
+     ``PermissionResolver`` + real ``require_plugin_git_run_code_trust`` gate,
+     not a stub) — the CLI's own ``--non-interactive``/no-tty wiring must
+     actually reach that gate, not merely assume it does.
+
+No unittest.mock anywhere. Real ``PermissionResolver`` / ``EventLog`` /
+``Workspace`` / op_runtime handlers throughout; ``HOME`` is monkeypatched per
+test so ``~/.reyn/plugins/`` never touches the real home dir (mirrors
+``tests/test_plugin_install.py``).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.interfaces.cli.commands import plugin as plugin_cli
+
+# ── shared fixtures ─────────────────────────────────────────────────────────
+
+
+def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
+    """A minimal real local plugin dir: manifest + one skills capability
+    (mirrors tests/test_plugin_install.py::_make_plugin_source)."""
+    plugin_dir = base / name
+    (plugin_dir / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name, "version": "0.1.0", "description": "test plugin",
+            "capabilities": [{"kind": "skills"}],
+        }),
+        encoding="utf-8",
+    )
+    (plugin_dir / "skills" / "hello").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "skills" / "hello" / "SKILL.md").write_text(
+        "---\nname: hello\ndescription: says hi\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def _project(tmp_path: Path, *, allow_file_write: bool = True) -> Path:
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    perms = {"file.write": "allow"} if allow_file_write else {}
+    (proj / "reyn.yaml").write_text(
+        yaml.safe_dump({"permissions": perms}), encoding="utf-8",
+    )
+    return proj
+
+
+def _install_args(kind: str, source_name: str, project: Path, *,
+                   install_name: "str | None" = None,
+                   non_interactive: bool = True) -> argparse.Namespace:
+    return argparse.Namespace(
+        kind=kind, source_name=source_name, project=str(project),
+        install_name=install_name, non_interactive=non_interactive,
+    )
+
+
+def _uninstall_args(name: str, project: Path) -> argparse.Namespace:
+    return argparse.Namespace(name=name, project=str(project))
+
+
+# ── 1. typed kind discriminator threading (Tier 1: Contract) ──────────────
+
+
+@pytest.mark.parametrize(
+    "kind,source_name,expected_source",
+    [
+        ("builtin", "rag", {"kind": "builtin", "name": "rag"}),
+        ("local", "/tmp/some/plugin/dir", {"kind": "local", "path": "/tmp/some/plugin/dir"}),
+        ("git", "https://example.com/x.git", {"kind": "git", "url": "https://example.com/x.git"}),
+    ],
+)
+def test_install_kind_threads_to_typed_source_shape(
+    tmp_path, monkeypatch, kind, source_name, expected_source,
+) -> None:
+    """Tier 1: each CLI install subcommand (builtin/local/git) builds the
+    EXACT typed {kind, ...} source shape PluginSourceBuiltin/Local/Git expects
+    — never a form-sniffed string. Captures the real args dict handed to
+    invoke_tool via a real (non-mock) capturing async function."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["name"] = name
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "installed", "name": "x"}}
+
+    monkeypatch.setattr(plugin_cli, "_invoke_plugin_tool", _fake_invoke)
+
+    project = _project(tmp_path)
+    args = _install_args(kind, source_name, project)
+    plugin_cli.run_install(args)
+
+    assert captured["name"] == "plugin_management__install"
+    assert captured["args"]["source"] == expected_source
+    assert "name" not in captured["args"]  # no --name override supplied
+
+
+def test_install_name_override_threads_through(tmp_path, monkeypatch) -> None:
+    """Tier 1: --name overrides the op's `name` field (install-directory /
+    registry-provenance key), distinct from the source's own name/path/url."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "installed", "name": "custom"}}
+
+    monkeypatch.setattr(plugin_cli, "_invoke_plugin_tool", _fake_invoke)
+
+    project = _project(tmp_path)
+    args = _install_args("builtin", "rag", project, install_name="custom")
+    plugin_cli.run_install(args)
+
+    assert captured["args"]["source"] == {"kind": "builtin", "name": "rag"}
+    assert captured["args"]["name"] == "custom"
+
+
+def test_uninstall_threads_name(tmp_path, monkeypatch) -> None:
+    """Tier 1: `reyn plugin uninstall NAME` forwards {"name": NAME} to the
+    plugin_management__uninstall op — no extra/renamed fields."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["name"] = name
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "uninstalled", "name": "myplugin"}}
+
+    monkeypatch.setattr(plugin_cli, "_invoke_plugin_tool", _fake_invoke)
+
+    project = _project(tmp_path)
+    plugin_cli.run_uninstall(_uninstall_args("myplugin", project))
+
+    assert captured["name"] == "plugin_management__uninstall"
+    assert captured["args"] == {"name": "myplugin"}
+
+
+# ── 2. real install/uninstall roundtrip through the CLI entrypoints ───────
+
+
+def test_cli_local_install_uninstall_roundtrip_real_stack(tmp_path, monkeypatch) -> None:
+    """Tier 2: `reyn plugin install local <path>` (non-interactive, real
+    PermissionResolver/op_runtime handler stack — no invoke_tool stub) writes
+    the SAME .reyn/config/skills.yaml + ~/.reyn/plugins/<name>/ copy P2's own
+    op-level tests assert on, reached THROUGH the CLI surface. Then
+    `reyn plugin uninstall` removes both."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    project = _project(tmp_path, allow_file_write=True)
+    src = _write_local_plugin(tmp_path / "src")
+    monkeypatch.chdir(project)
+
+    install_args = _install_args("local", str(src), project, non_interactive=True)
+    plugin_cli.run_install(install_args)
+
+    plugin_copy = home / ".reyn" / "plugins" / "myplugin"
+    assert plugin_copy.is_dir(), "plugin copy not written under ~/.reyn/plugins/"
+    skills_yaml = project / ".reyn" / "config" / "skills.yaml"
+    assert skills_yaml.exists(), "skills registry entry not written"
+    registered = yaml.safe_load(skills_yaml.read_text(encoding="utf-8"))
+    assert "hello" in (registered.get("skills") or {}).get("entries", {})
+
+    plugin_cli.run_uninstall(_uninstall_args("myplugin", project))
+    assert not plugin_copy.exists(), "plugin copy not removed on uninstall"
+    registered_after = yaml.safe_load(skills_yaml.read_text(encoding="utf-8")) or {}
+    assert "hello" not in (registered_after.get("skills") or {}).get("entries", {})
+
+
+# ── 3. {kind:git} fails closed non-interactively (Security lens) ──────────
+
+
+def test_cli_git_install_noninteractive_fails_closed_real_gate(tmp_path, monkeypatch) -> None:
+    """Tier 2: a {kind:git} install run via `--non-interactive` hits the REAL
+    require_plugin_git_run_code_trust gate (no stub) and is denied — SystemExit(2)
+    with a permission-denied message, no fetch/write attempted."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    project = _project(tmp_path, allow_file_write=True)
+    args = _install_args(
+        "git", "https://example.invalid/some/plugin.git", project,
+        non_interactive=True,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        plugin_cli.run_install(args)
+    assert exc_info.value.code == 2
+    # No plugin copy should have been attempted.
+    assert not (home / ".reyn" / "plugins").exists()
+
+
+def test_cli_git_install_notty_fails_closed_even_without_flag(tmp_path, monkeypatch) -> None:
+    """Tier 2: even WITHOUT --non-interactive, a non-tty CLI invocation (sys.stdin.isatty()
+    False, the real subprocess/CI condition) must fail closed for {kind:git} — the CLI's
+    `interactive = not non_interactive and sys.stdin.isatty()` wiring, not just the flag."""
+    import sys
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    project = _project(tmp_path, allow_file_write=True)
+    args = _install_args(
+        "git", "https://example.invalid/some/plugin.git", project,
+        non_interactive=False,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        plugin_cli.run_install(args)
+    assert exc_info.value.code == 2

--- a/tests/test_plugin_cli_surface.py
+++ b/tests/test_plugin_cli_surface.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -35,6 +36,36 @@ import yaml
 from reyn.interfaces.cli.commands import plugin as plugin_cli
 
 # ── shared fixtures ─────────────────────────────────────────────────────────
+
+
+def _make_git_plugin_repo(base: Path, name: str = "gitplugin") -> Path:
+    """A real local git repo holding a minimal plugin (skills capability only —
+    no requirements.txt ⇒ no dep-materialisation http.get), usable as a
+    ``file://`` git source (mirrors tests/test_plugin_install.py::
+    _make_git_plugin_repo). Using a REAL, reachable repo is what makes the
+    run-code-gate strip-falsify meaningful: with the gate stripped the clone
+    SUCCEEDS and the install proceeds, so the test flips RED — an unreachable
+    URL would instead keep failing (clone error → same SystemExit) and mask
+    the strip."""
+    repo = base / "repo"
+    (repo / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
+    (repo / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name, "version": "0.1.0", "description": "git plugin",
+            "capabilities": [{"kind": "skills"}],
+        }),
+        encoding="utf-8",
+    )
+    (repo / "skills" / "hi").mkdir(parents=True, exist_ok=True)
+    (repo / "skills" / "hi" / "SKILL.md").write_text(
+        "---\nname: hi\ndescription: from git\n---\n\nBody.\n", encoding="utf-8",
+    )
+    subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, capture_output=True, check=True)
+    return repo
 
 
 def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
@@ -57,10 +88,22 @@ def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
     return plugin_dir
 
 
-def _project(tmp_path: Path, *, allow_file_write: bool = True) -> Path:
+def _project(
+    tmp_path: Path, *, allow_file_write: bool = True, allow_web_fetch: bool = False,
+) -> Path:
     proj = tmp_path / "proj"
     proj.mkdir()
-    perms = {"file.write": "allow"} if allow_file_write else {}
+    perms: dict = {}
+    if allow_file_write:
+        perms["file.write"] = "allow"
+    # ``web.fetch: allow`` config-approves the http.get FETCH axis (git clone /
+    # pypi reachability). Set it to ISOLATE the run-code trust gate: with the
+    # fetch axis granted, the ONLY thing that can deny a {kind:git} install is
+    # require_plugin_git_run_code_trust — so a green "fails closed" result
+    # actually witnesses THAT gate, not a redundant fetch-axis deny (mirrors
+    # the P2 op-level test's approve_all_http=True isolation).
+    if allow_web_fetch:
+        perms["web.fetch"] = "allow"
     (proj / "reyn.yaml").write_text(
         yaml.safe_dump({"permissions": perms}), encoding="utf-8",
     )
@@ -169,7 +212,9 @@ def test_cli_local_install_uninstall_roundtrip_real_stack(tmp_path, monkeypatch)
 
     project = _project(tmp_path, allow_file_write=True)
     src = _write_local_plugin(tmp_path / "src")
-    monkeypatch.chdir(project)
+    # Deliberately NO chdir: `--project` must load the target project's
+    # permissions itself (load_config(cwd=project_root)); a cwd-dependent
+    # install would be a latent `--project` bug.
 
     install_args = _install_args("local", str(src), project, non_interactive=True)
     plugin_cli.run_install(install_args)
@@ -188,33 +233,53 @@ def test_cli_local_install_uninstall_roundtrip_real_stack(tmp_path, monkeypatch)
 
 
 # ── 3. {kind:git} fails closed non-interactively (Security lens) ──────────
+#
+# CONFOUND ISOLATION (why these use a REAL local git repo + web.fetch:allow):
+# the {kind:git} handler runs the run-code trust gate FIRST, then (for an https
+# host) require_http_get, then clones. If the test used an UNREACHABLE
+# `https://example.invalid/...` URL with web.fetch NOT granted, THREE independent
+# causes each produce the SAME SystemExit(2): the run-code deny, the http.get
+# non-interactive deny, AND the clone failure. Stripping the run-code gate would
+# leave the test GREEN (masked by the other two) — "green ≠ the gate ran". Using
+# a REAL, reachable `file://` repo removes ALL of that: `_source_host` returns
+# None for file:// so require_http_get is skipped (web.fetch:allow is belt-and-
+# suspenders isolation of the fetch axis regardless), and the clone SUCCEEDS —
+# so the run-code trust gate is the ONE remaining thing that can deny. Strip it
+# and the install proceeds (no SystemExit) → the test flips RED. Verified by
+# strip-falsify (temporarily removing the gate call) — see PR notes.
 
 
 def test_cli_git_install_noninteractive_fails_closed_real_gate(tmp_path, monkeypatch) -> None:
-    """Tier 2: a {kind:git} install run via `--non-interactive` hits the REAL
-    require_plugin_git_run_code_trust gate (no stub) and is denied — SystemExit(2)
-    with a permission-denied message, no fetch/write attempted."""
+    """Tier 2: a {kind:git} install run via `--non-interactive`, against a REAL
+    reachable file:// repo with the fetch axis fully granted (web.fetch:allow),
+    is denied ONLY by the REAL require_plugin_git_run_code_trust gate (no stub)
+    — SystemExit(2), nothing installed. Isolated so stripping the gate flips it
+    RED (the clone would otherwise succeed)."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", lambda: home)
 
-    project = _project(tmp_path, allow_file_write=True)
-    args = _install_args(
-        "git", "https://example.invalid/some/plugin.git", project,
-        non_interactive=True,
-    )
+    repo = _make_git_plugin_repo(tmp_path)
+    project = _project(tmp_path, allow_file_write=True, allow_web_fetch=True)
+    args = _install_args("git", repo.as_uri(), project, non_interactive=True)
 
     with pytest.raises(SystemExit) as exc_info:
         plugin_cli.run_install(args)
     assert exc_info.value.code == 2
-    # No plugin copy should have been attempted.
-    assert not (home / ".reyn" / "plugins").exists()
+    # Gate fired BEFORE any clone/copy: nothing landed under ~/.reyn/plugins/.
+    installed = [
+        p for p in (home / ".reyn" / "plugins").glob("*")
+        if not p.name.startswith(".")
+    ] if (home / ".reyn" / "plugins").exists() else []
+    assert installed == [], f"git plugin installed despite no run-code trust: {installed}"
 
 
 def test_cli_git_install_notty_fails_closed_even_without_flag(tmp_path, monkeypatch) -> None:
     """Tier 2: even WITHOUT --non-interactive, a non-tty CLI invocation (sys.stdin.isatty()
     False, the real subprocess/CI condition) must fail closed for {kind:git} — the CLI's
-    `interactive = not non_interactive and sys.stdin.isatty()` wiring, not just the flag."""
+    `interactive = not non_interactive and sys.stdin.isatty()` wiring, not just the flag.
+    Same real-repo + web.fetch:allow isolation as above so the run-code gate is the sole
+    denier."""
     import sys
 
     home = tmp_path / "home"
@@ -222,12 +287,15 @@ def test_cli_git_install_notty_fails_closed_even_without_flag(tmp_path, monkeypa
     monkeypatch.setattr(Path, "home", lambda: home)
     monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
 
-    project = _project(tmp_path, allow_file_write=True)
-    args = _install_args(
-        "git", "https://example.invalid/some/plugin.git", project,
-        non_interactive=False,
-    )
+    repo = _make_git_plugin_repo(tmp_path)
+    project = _project(tmp_path, allow_file_write=True, allow_web_fetch=True)
+    args = _install_args("git", repo.as_uri(), project, non_interactive=False)
 
     with pytest.raises(SystemExit) as exc_info:
         plugin_cli.run_install(args)
     assert exc_info.value.code == 2
+    installed = [
+        p for p in (home / ".reyn" / "plugins").glob("*")
+        if not p.name.startswith(".")
+    ] if (home / ".reyn" / "plugins").exists() else []
+    assert installed == [], f"git plugin installed despite no run-code trust: {installed}"

--- a/tests/test_plugin_slash_surface.py
+++ b/tests/test_plugin_slash_surface.py
@@ -1,0 +1,309 @@
+"""Tier 2: OS invariant — `/plugin install`/`uninstall` slash surface (ADR 0064 §3.9, P3).
+
+Same contract as ``tests/test_plugin_cli_surface.py`` for the slash surface:
+``/plugin`` is a thin adapter over the SAME typed op — it builds a
+``ToolContext`` from this session's LIVE ``RouterHostAdapter``
+(``build_resource_caller_state(session.router_host)``, i.e. the SAME factory
+a live LLM ``plugin_management__install``/``__uninstall`` tool call gets) and
+calls ``invoke_tool(get_default_registry(), "plugin_management__install"/"__uninstall", ...)``.
+
+Tests:
+  1. usage-error paths (no args, unknown kind, unknown subcommand, malformed
+     quoting) reply_error without touching the tool layer.
+  2. the typed ``kind`` discriminator (``builtin``/``local``/``git`` slash arg)
+     threads through to the correct ``{kind, ...}`` source shape — real
+     dispatch, captured via a real (non-mock) capturing async function.
+  3. ``as <INSTALL_NAME>`` threads to the op's ``name`` override.
+  4. a real local-plugin install through the FULL live seam (real Session +
+     real RouterHostAdapter + real op_runtime handler, no invoke_tool stub)
+     reaches the same ``.reyn/config/skills.yaml`` / ``~/.reyn/plugins/``
+     writes the CLI test / P2's own op-level tests assert on.
+  5. error-status and PermissionError from the op layer surface as
+     reply_error, not a crash.
+
+No unittest.mock anywhere. Real ``Session`` (mirrors
+``tests/test_2548_skill_hotreload_toggle_pr_b.py::_make_session``) + real
+``RouterHostAdapter`` + real ``PermissionResolver`` throughout.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.slash import plugin as plugin_slash
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.session import Session
+from reyn.security.permissions.permissions import PermissionResolver
+
+# ── shared fixtures ─────────────────────────────────────────────────────────
+
+
+class _ReplyCapturingSession:
+    """A real Session, wrapped so tests can read replies via the public
+    ``_put_outbox`` surface (mirrors the ``_FakeSession`` pattern already
+    used across the slash test suite — e.g. test_slash_reload_cmd.py — for
+    the reply-capture concern only; the Session itself underneath is real,
+    not faked)."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self.outbox_calls: list[OutboxMessage] = []
+        self._orig_put_outbox = session._put_outbox
+
+        async def _capturing_put_outbox(msg: OutboxMessage) -> None:
+            self.outbox_calls.append(msg)
+
+        session._put_outbox = _capturing_put_outbox  # type: ignore[method-assign]
+
+    def __getattr__(self, item):
+        return getattr(self._session, item)
+
+    def reply_text(self) -> str:
+        return " ".join(m.text for m in self.outbox_calls if m.kind == "system")
+
+    def error_text(self) -> str:
+        return " ".join(m.text for m in self.outbox_calls if m.kind == "error")
+
+
+def _make_session(
+    tmp_path: Path, *, agent_name: str = "test-agent",
+    permission_resolver: "PermissionResolver | None" = None,
+    sandbox_config: "object | None" = None,
+) -> _ReplyCapturingSession:
+    """Minimal real Session in *tmp_path* (mirrors
+    tests/test_2548_skill_hotreload_toggle_pr_b.py::_make_session), anchored
+    at tmp_path so ``session.router_host.make_router_op_context()`` builds a
+    real Workspace rooted there.
+
+    ``sandbox_config``: the router-dispatched OpContext ALWAYS synthesizes a
+    floor SandboxPolicy restricting ``write_paths`` to the workspace
+    (``build_router_op_context`` / #1339 — closes a sandbox-escape gap; the
+    SAME floor a live LLM ``plugin_management__install`` tool call gets, not
+    a slash-specific restriction). A ``{kind:local}``/``{kind:git}`` install
+    writes OUTSIDE the workspace (``~/.reyn/plugins/``), so exercising that
+    path for real requires the operator-equivalent explicit
+    ``sandbox.policy.write_paths`` grant, supplied here."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    session = Session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / "snap.json",
+        permission_resolver=permission_resolver,
+        sandbox_config=sandbox_config,
+        workspace_base_dir=tmp_path,
+        workspace_state_dir=tmp_path / ".reyn",
+    )
+    return _ReplyCapturingSession(session)
+
+
+def _write_local_plugin(base: Path, name: str = "myplugin") -> Path:
+    plugin_dir = base / name
+    (plugin_dir / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name, "version": "0.1.0", "description": "test plugin",
+            "capabilities": [{"kind": "skills"}],
+        }),
+        encoding="utf-8",
+    )
+    (plugin_dir / "skills" / "hello").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "skills" / "hello" / "SKILL.md").write_text(
+        "---\nname: hello\ndescription: says hi\n---\n\nSkill body.\n",
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+# ── 1. usage errors (Tier 2: OS invariant — no crash on malformed input) ──
+
+
+@pytest.mark.asyncio
+async def test_no_args_is_usage_error(tmp_path) -> None:
+    """Tier 2: `/plugin` with no arguments replies a usage error, not a crash."""
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "")
+    assert "usage" in session.error_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_subcommand_is_usage_error(tmp_path) -> None:
+    """Tier 2: an unrecognized subcommand (not install/uninstall) replies a
+    usage error, not a crash."""
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "frobnicate x")
+    assert "unknown subcommand" in session.error_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_is_usage_error(tmp_path) -> None:
+    """Tier 2: an unrecognized source kind (not builtin/local/git) replies a
+    usage error — the typed discriminator rejects untyped/unknown values."""
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "install registry rag")
+    assert "unknown source kind" in session.error_text().lower()
+
+
+@pytest.mark.asyncio
+async def test_malformed_quoting_is_usage_error(tmp_path) -> None:
+    """Tier 2: malformed shell-style quoting in the args string replies an
+    error (ValueError from shlex.split caught), not a crash."""
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, 'install local "unterminated')
+    assert session.error_text(), "expected an error reply for malformed quoting"
+
+
+# ── 2. typed kind discriminator threading (Tier 1: Contract) ──────────────
+
+
+@pytest.mark.parametrize(
+    "cmd_args,expected_source",
+    [
+        ("install builtin rag", {"kind": "builtin", "name": "rag"}),
+        ("install local /tmp/some/dir", {"kind": "local", "path": "/tmp/some/dir"}),
+        ("install git https://example.com/x.git", {"kind": "git", "url": "https://example.com/x.git"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_install_kind_threads_to_typed_source_shape(
+    tmp_path, monkeypatch, cmd_args, expected_source,
+) -> None:
+    """Tier 1: each /plugin install subcommand (builtin/local/git) builds the
+    EXACT typed {kind, ...} source shape — never a form-sniffed string."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["name"] = name
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "installed", "name": "x"}}
+
+    monkeypatch.setattr(plugin_slash, "_invoke_plugin_tool", _fake_invoke)
+
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, cmd_args)
+
+    assert captured["name"] == "plugin_management__install"
+    assert captured["args"]["source"] == expected_source
+    assert "name" not in captured["args"]
+    assert not session.error_text(), f"unexpected error: {session.error_text()}"
+
+
+@pytest.mark.asyncio
+async def test_install_as_name_overrides_thread_through(tmp_path, monkeypatch) -> None:
+    """Tier 1: `as <NAME>` threads to the op's `name` override field."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "installed", "name": "custom"}}
+
+    monkeypatch.setattr(plugin_slash, "_invoke_plugin_tool", _fake_invoke)
+
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "install builtin rag as custom")
+
+    assert captured["args"]["source"] == {"kind": "builtin", "name": "rag"}
+    assert captured["args"]["name"] == "custom"
+
+
+@pytest.mark.asyncio
+async def test_uninstall_threads_name(tmp_path, monkeypatch) -> None:
+    """Tier 1: `/plugin uninstall NAME` forwards {"name": NAME} to the
+    plugin_management__uninstall op — no extra/renamed fields."""
+    captured: dict = {}
+
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        captured["name"] = name
+        captured["args"] = args
+        return {"status": "ok", "data": {"status": "uninstalled", "name": "myplugin"}}
+
+    monkeypatch.setattr(plugin_slash, "_invoke_plugin_tool", _fake_invoke)
+
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "uninstall myplugin")
+
+    assert captured["name"] == "plugin_management__uninstall"
+    assert captured["args"] == {"name": "myplugin"}
+
+
+# ── 3. real install through the FULL live seam ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slash_local_install_real_stack(tmp_path, monkeypatch) -> None:
+    """Tier 2: `/plugin install local <path>` through the REAL Session →
+    RouterHostAdapter → make_router_op_context → op_runtime handler stack
+    (no invoke_tool stub) writes the SAME .reyn/config/skills.yaml +
+    ~/.reyn/plugins/<name>/ copy the CLI test / P2's op-level tests assert on."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+    project = tmp_path / "proj"
+    project.mkdir()
+    src = _write_local_plugin(tmp_path / "src")
+
+    perm_resolver = PermissionResolver(
+        config_permissions={"file.write": "allow"},
+        project_root=project,
+        interactive=False,
+    )
+    from reyn.config.infra import SandboxConfig
+    # Explicit write_paths REPLACE (not union with) the floor's workspace-only
+    # default ("wrote it" semantics, #2964) — so both the plugin global-copy
+    # root AND the project workspace must be listed for the full install
+    # (copy + .reyn/config/skills.yaml registration) to succeed.
+    sandbox_config = SandboxConfig(policy={
+        "write_paths": [str(home / ".reyn" / "plugins"), str(project)],
+    })
+    session = _make_session(
+        project, permission_resolver=perm_resolver, sandbox_config=sandbox_config,
+    )
+
+    await plugin_slash.plugin_cmd(session, f"install local {src}")
+
+    assert not session.error_text(), f"unexpected error: {session.error_text()}"
+    plugin_copy = home / ".reyn" / "plugins" / "myplugin"
+    assert plugin_copy.is_dir(), "plugin copy not written under ~/.reyn/plugins/"
+    skills_yaml = project / ".reyn" / "config" / "skills.yaml"
+    assert skills_yaml.exists(), "skills registry entry not written"
+    registered = yaml.safe_load(skills_yaml.read_text(encoding="utf-8"))
+    assert "hello" in (registered.get("skills") or {}).get("entries", {})
+
+    await plugin_slash.plugin_cmd(session, "uninstall myplugin")
+    assert not session.error_text(), f"unexpected error on uninstall: {session.error_text()}"
+    assert not plugin_copy.exists(), "plugin copy not removed on uninstall"
+
+
+# ── 4. error surfacing (op-layer failures → reply_error, not a crash) ─────
+
+
+@pytest.mark.asyncio
+async def test_op_error_status_surfaces_as_reply_error(tmp_path, monkeypatch) -> None:
+    """Tier 2: an op-layer {"status": "error"} data envelope (e.g. unknown
+    builtin plugin) surfaces as a reply_error, not a silent success."""
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        return {"status": "ok", "data": {"status": "error", "error": "boom"}}
+
+    monkeypatch.setattr(plugin_slash, "_invoke_plugin_tool", _fake_invoke)
+
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "install builtin rag")
+    assert "boom" in session.error_text()
+
+
+@pytest.mark.asyncio
+async def test_permission_error_surfaces_as_reply_error(tmp_path, monkeypatch) -> None:
+    """Tier 2: a PermissionError raised by the op layer (e.g. the {kind:git}
+    run-code trust gate denying) surfaces as a reply_error, not a crash."""
+    async def _fake_invoke(name: str, args: dict, ctx) -> dict:
+        raise PermissionError("denied for testing")
+
+    monkeypatch.setattr(plugin_slash, "_invoke_plugin_tool", _fake_invoke)
+
+    session = _make_session(tmp_path)
+    await plugin_slash.plugin_cmd(session, "install git https://example.com/x.git")
+    assert "denied for testing" in session.error_text()


### PR DESCRIPTION
**[per-PR-coder]** — part of #3066, part of #3069

## Summary

- Adds `/plugin install builtin|local|git <SOURCE> [as <INSTALL_NAME>]` / `/plugin uninstall <NAME>` slash commands (`src/reyn/interfaces/slash/plugin.py`).
- Adds `reyn plugin install builtin|local|git <SOURCE>` / `reyn plugin uninstall <NAME>` CLI subcommands (`src/reyn/interfaces/cli/commands/plugin.py`).
- Both are thin adapters over the SAME P2 typed op (`plugin_management__install`/`__uninstall`) — they build a `ToolContext` and call `invoke_tool(get_default_registry(), ...)`, the same lookup+dispatch a live LLM tool call uses, so no surface re-implements the security logic. The composite permission decl is declared once in the tool wrapper (`tools/plugin_management_verbs.py`); the `{kind:git}` run-code trust gate itself lives one layer down in the op handler every surface funnels into (`core/op_runtime/plugin_install.py::handle`).
- The typed `kind` discriminator (`builtin`/`local`/`git`) is carried by explicit CLI subcommands / slash args on every surface — never a form-sniffed string.
- `docs/reference/runtime/control-ir.md`'s `plugin_install`/`plugin_uninstall` section updated in the same PR to describe the new surfaces (incl. the CLI vs slash sandbox-floor asymmetry discovered while writing the live-stack tests).

## Design precedent followed

- Slash: mirrors `/reload`/`/hook`'s `session`-facing shape, but for a tool-backed op it threads the session's LIVE `RouterHostAdapter.make_router_op_context` via `reyn.tools.types.build_resource_caller_state` — the exact factory a live LLM `plugin_management__install` tool call gets (verified by tracing `router_loop.py`'s own `ToolContext` construction for registry-dispatched tools).
- CLI: mirrors `reyn mcp install`'s pattern (`interfaces/cli/commands/mcp.py::_run_install_from_source`) — CLI is the operator-trusted entry point, builds its own `OpContext` directly (`--non-interactive` / `sys.stdin.isatty()` gate the intervention bus), same shape as `pipe.py::_build_run_tool_context`.

## Verified

- **Kind discriminator threads through all surfaces**: parametrized Tier-1 tests capture the real args handed to `invoke_tool` for `builtin`/`local`/`git` on both CLI and slash — the exact `{kind, ...}` shape `PluginSourceBuiltin/Local/Git` expects.
- **Non-interactive CLI fails closed for `{kind:git}`**: real (non-stubbed) `require_plugin_git_run_code_trust` gate denies with `SystemExit(2)` both under `--non-interactive` and under a bare non-tty invocation (no flag) — real `PermissionResolver`, no mock.
- **Live production smoke**: `reyn plugin install builtin rag` / `reyn plugin uninstall rag` round-tripped against the real shipped `rag` plugin (P5, #3078) — installed 2 MCP servers + 2 pipelines + 1 skill, then cleanly removed all of it, through the CLI end to end (manual verification, not just tests).
- **Sandbox-floor finding**: the slash (and any live LLM tool call) path routes through `build_router_op_context`'s `#1339` sandbox floor (`write_paths` default-restricted to the workspace), so a `{kind:local}`/`{kind:git}` install additionally needs an operator `sandbox.policy.write_paths` grant covering `~/.reyn/plugins/` — the CLI path does not (it builds `OpContext` directly, mirroring `reyn mcp install`'s CLI-is-trusted precedent). Documented in `control-ir.md`; a real Tier-2 slash test exercises both grants for a full local install+uninstall roundtrip.

## CI (all 4 gates green locally)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_plugin_cli_surface.py tests/test_plugin_slash_surface.py` — 16/16 OK, 0 Tier-4 violations.
- `pytest` (full suite, repo root) — 8905 passed, 29 skipped, 0 failed.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan

- [x] `reyn plugin install builtin rag` / `reyn plugin uninstall rag` manually round-tripped against the real shipped plugin (see above).
- [x] `reyn plugin install git <url> --non-interactive` denies with a clear message (manually verified + covered by test).
- [x] `/plugin install ...` / `/plugin uninstall ...` covered by real-Session Tier-2 tests (no mocks) including a full local-plugin install/uninstall roundtrip through the live op stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
