### PR TITLE
fix: add plugin_management to universal_catalog CATEGORIES — restore chat reachability (#3083)

### DIFF
--- a/src/reyn/prompt/universal_slots.py
+++ b/src/reyn/prompt/universal_slots.py
@@ -263,7 +263,17 @@ ACTION_CATEGORIES_LINES = [
         ".reyn/config/presentations.yaml, so a later `present(view=<name>)` "
         "op can render it (proposal 0060 Phase 1 Layer A)."
     ),
+    (
+        "- **plugin_management** — install / uninstall a plugin: "
+        "`plugin_management__install` promotes one from `source` "
+        "(`{kind: builtin, name}` for a plugin reyn ships, `{kind: local, "
+        "path}` for one you authored/tested, or `{kind: git, url}` for a "
+        "remote repo) into your active plugin set; "
+        "`plugin_management__uninstall` removes an installed plugin by name "
+        "(ADR 0064)."
+    ),
 ]
+
 
 HOT_LIST_ALIASES_HINT = (
     "The function list visible to you is a HOT-LIST (= a subset of "

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -46,7 +46,7 @@ category that has never existed. Before re-introducing per-resource actions,
 check whether the motivating gap is still open: twice now it was not.
 
 PR-1 (landed): type surface only — 4 ToolDefinitions with stub
-handlers, qualified-name parse / build / validate, 13-category enum,
+handlers, qualified-name parse / build / validate, 14-category enum,
 D14 visibility-gating helpers.
 
 PR-2 (landed): pure routing layer — ``universal_dispatch.py`` with
@@ -84,7 +84,7 @@ if TYPE_CHECKING:
     from reyn.tools.universal_dispatch import UnknownActionError
 
 
-# ── Canonical 13-category enum (FP-0034 §D18 master taxonomy) ──────────────
+# ── Canonical 14-category enum (FP-0034 §D18 master taxonomy) ──────────────
 #
 # Order matches the master table in FP-0034 §D18 so reviewers reading the
 # design doc and the code see the same shape. ``exec`` ships last because
@@ -144,6 +144,20 @@ CATEGORIES: Final[tuple[str, ...]] = (
     # declarative data). Management plane — mirrors ``skill_management`` /
     # ``pipeline_management``.
     "presentation_management",
+    # ADR 0064 P2: plugin management ops (install / uninstall). #3083: this
+    # category was ADDED to ``_OPERATION_RULES`` (dispatch-wired) when the P2
+    # verbs landed, but never added HERE — the exact #2032-class gap the
+    # comments above this tuple already document for skill_management /
+    # pipeline_management / presentation_management. Registered +
+    # dispatchable but absent from CATEGORIES means every enumerate-all /
+    # retrieval / codeact scheme's ``tools=`` payload never carried
+    # plugin_management__install/__uninstall, so the LLM could never
+    # discover — let alone call — them. See
+    # ``test_categories_covers_every_dispatch_wired_category`` in
+    # ``tests/test_universal_catalog.py`` for the routing-table-derived
+    # gate that now guards against a category being dispatch-wired without
+    # a matching CATEGORIES entry.
+    "plugin_management",
 )
 
 
@@ -587,6 +601,10 @@ def _enumerate_category(category: str, ctx: ToolContext) -> list[dict[str, str]]
         # list_actions(category=["presentation_management"]) surfaces the
         # install verb (not just dispatchable-but-invisible).
         "presentation_management",
+        # #3083: same enumeration wiring for plugin_management — closes the
+        # dogfood-witnessed 0/75 gap (plugin_management__install/__uninstall
+        # were registered + dispatch-wired but never enumerated).
+        "plugin_management",
     ):
         return _enumerate_static_category(category)
 
@@ -1018,7 +1036,7 @@ def catalog_entries(ctx: ToolContext) -> list[dict[str, Any]]:
     """Every usable action as a FLAT generic tool-schema dict
     ``{name, description, parameters}`` — the #1593 ``SchemeOps.catalog_entries``
     projection a scheme presents however it likes (enumerate-all flat, CodeAct
-    code-API, retrieval subset). Exposes the **actions**, not the 13-category
+    code-API, retrieval subset). Exposes the **actions**, not the 14-category
     hierarchy (the P7 boundary: the catalog structure stays universal-internal;
     what crosses is a flat action list any scheme can render).
 

--- a/src/reyn/tools/universal_dispatch.py
+++ b/src/reyn/tools/universal_dispatch.py
@@ -357,6 +357,21 @@ _OPERATION_RULES: Final[dict[str, tuple[str, Callable[[str, Mapping[str, Any]], 
     # counterpart — a blueprint is inline declarative data, never file-backed).
     "presentation_management__install": ("presentation_install_local", _passthrough_args),
 
+    # plugin_management category (ADR 0064 P2: plugin_install / plugin_uninstall).
+    # #3083: these two ToolDefinitions were registered in the default registry
+    # (src/reyn/tools/__init__.py) with their OWN qualified names as their bare
+    # tool name (``plugin_management__install`` / ``__uninstall`` — unlike most
+    # other management verbs, there is no separate "bare" spelling to alias),
+    # but were never added to this routing table, so ``invoke_action`` /
+    # ``describe_action`` could not resolve them and ``_enumerate_category``
+    # (which reads its static name set from THIS table via
+    # ``known_qualified_name_for_category``) never emitted them into any
+    # ``tools=`` payload — reachable via direct registry lookup only, never via
+    # the universal-catalog schemes chat actually uses. Same "registered +
+    # dispatchable-but-catalog-invisible" bug class as #2589/#2621/#2032.
+    "plugin_management__install":   ("plugin_management__install",   _passthrough_args),
+    "plugin_management__uninstall": ("plugin_management__uninstall", _passthrough_args),
+
     # pipeline category (IS-1: sync + REGISTERED-only run_pipeline;
     # IS-2: async launch in a crash-recoverable driver-session;
     # IS-4: ad-hoc INLINE launches — agent-GENERATED DSL + a static-analysis

--- a/tests/test_1128_step3_token_budget_headtail.py
+++ b/tests/test_1128_step3_token_budget_headtail.py
@@ -144,10 +144,13 @@ def _push(session, role: str, content: str) -> None:
 
 
 # Content that yields 80 tokens (320 chars / 4) via use_chars4_estimate=True.
-# With T_max=2000 (T_SP≈1125, T_comp_SP≈481, section_caps=0):
-#   effective_trigger≈570, head_budget≈87, tail_budget≈131.
-# 3 turns × 80 tokens = 240 < 570 → no elide.
-# 8 turns × 80 tokens = 640 > 570 → elide fires.
+# With T_max=2800 (headroom re-measured post-#3083 plugin_management SP
+# addition; #1128's original ≈570 pin went stale as the SP grew across many
+# unrelated PRs and finally crashed to a negative effective_trigger — #3083
+# was simply the straw that tipped it):
+#   effective_trigger≈489, head_budget≈74, tail_budget≈112.
+# 3 turns × 80 tokens = 240 < 489 → no elide.
+# 8 turns × 80 tokens = 640 > 489 → elide fires.
 _CONTENT_80TOK = "X" * 320
 
 
@@ -159,8 +162,8 @@ def test_build_history_small_chat_returns_all_turns_raw(tmp_path) -> None:
     the LLM sees the full raw conversation as long as it fits under the
     trigger threshold.  No duplication can occur from this branch.
     """
-    # T_max=2000 → effective_trigger≈570.  3 turns × 80 tokens = 240 < 570.
-    session = _make_session_with_t_max(tmp_path, t_max=2000)
+    # T_max=2800 → effective_trigger≈489.  3 turns × 80 tokens = 240 < 489.
+    session = _make_session_with_t_max(tmp_path, t_max=2800)
     for text in ["alpha", "beta", "gamma"]:
         _push(session, "user", text)
 
@@ -179,13 +182,13 @@ def test_build_history_large_chat_elides_middle(tmp_path) -> None:
     """Tier 2: a large chat (total tokens > effective_trigger) elides the middle —
     head is present, tail is present, and at least one middle turn is absent.
 
-    Uses T_max=2000 with 30 turns of 80-token content (total=2400 tokens).
-    30×80=2400 exceeds any effective_trigger for T_max=2000 regardless of the
+    Uses T_max=2800 with 30 turns of 80-token content (total=2400 tokens).
+    30×80=2400 exceeds any effective_trigger for T_max=2800 regardless of the
     SP size (effective_trigger < T_max by construction), making this test
     default-independent: changing hot_list_n or other SP-affecting defaults
     does not change whether elide fires.
     """
-    session = _make_session_with_t_max(tmp_path, t_max=2000)
+    session = _make_session_with_t_max(tmp_path, t_max=2800)
     texts = [f"turn-{i}:" + _CONTENT_80TOK for i in range(30)]
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)

--- a/tests/test_catalog_entries_1593.py
+++ b/tests/test_catalog_entries_1593.py
@@ -2,7 +2,7 @@
 
 ``catalog_entries(ctx)`` is the substrate behind ``SchemeOps.catalog_entries``:
 every usable action as a flat ``{name, description, parameters}`` dict (the actions
-exposed, the 13-category structure hidden = the P7 boundary). It is built from the
+exposed, the 14-category structure hidden = the P7 boundary). It is built from the
 SAME ``_enumerate_category`` + ``_describe_one`` machinery ``list_actions`` /
 ``describe_action`` use, so all agree BY CONSTRUCTION (#1455 list ≡ describe).
 

--- a/tests/test_force_close_chat_activation_1092.py
+++ b/tests/test_force_close_chat_activation_1092.py
@@ -85,7 +85,7 @@ def test_try_build_returns_none_for_small_context_model(monkeypatch) -> None:
     (output_reserve + offload_cap < threshold) yields None — NOT a raise. The
     model genuinely cannot support force-close; the caller degrades."""
     monkeypatch.setattr(
-        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
+        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2800
     )
     assert try_build_default_turn_budget_engine("tiny", use_chars4=True) is None
 
@@ -106,7 +106,7 @@ def test_chat_session_on_small_model_constructs_without_force_close(
     engine unconditionally would assert-fail here and break every small-model
     chat session."""
     monkeypatch.setattr(
-        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2000
+        "reyn.llm.model_budget.get_max_input_tokens", lambda model, **kw: 2800
     )
     session = Session(
         agent_name="f1-small",

--- a/tests/test_force_close_chat_handoff_1092.py
+++ b/tests/test_force_close_chat_handoff_1092.py
@@ -157,7 +157,7 @@ async def test_wrap_up_bounded_fallback_fits(tmp_path) -> None:
     shrinks (through its decreasing candidates) until one fits and the
     consolidation is produced (wrap-up-fits — Fork 1's chat _force_close_call_
     with_retry analogue)."""
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     for t in ("U1", "A1", "U2", "A2"):
         _push(session, "user" if t.startswith("U") else "assistant", t)
     loop = _FailFirstLoop(fail_first=2)
@@ -175,7 +175,7 @@ class _AlwaysOverflowWrapUp:
 async def test_wrap_up_sub_viable_raises(tmp_path) -> None:
     """Tier 2: if even summary-only overflows, the model is RUNTIME sub-viable →
     _force_close_wrap_up raises (the handoff loop surfaces it as a dead-end)."""
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     _push(session, "user", "U1")
     with pytest.raises(ContextOverflowError):
         await session._loop_driver._force_close_wrap_up(_AlwaysOverflowWrapUp(), resolved_model="m")
@@ -190,7 +190,7 @@ async def test_force_close_handoff_installs_covering_consolidation(tmp_path) -> 
     a fake loop) installs a covers-all force-close summary (firing F2a's reset) —
     the consolidation reaches the slice and the covered raw turns are dropped; the
     P6 event fires."""
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     session._append_history(_msg("user", "U1-covered"))
     session._append_history(_msg("assistant", "A1-covered"))
     events = _capture_events(session)

--- a/tests/test_llm_facing_text_english_only.py
+++ b/tests/test_llm_facing_text_english_only.py
@@ -340,7 +340,20 @@ class TestSPToolNamesResolveToLiveTools:
 # watch-list extended deliberately (closes the curated-subset trap: adding a
 # 5th SP-referenced bare name must be a conscious edit here, not silent).
 _CURATED_BARE_NAME_WATCHLIST = frozenset(
-    {"list_actions", "search_actions", "invoke_action", "describe_action"}
+    {
+        "list_actions", "search_actions", "invoke_action", "describe_action",
+        # #3083: plugin_management__install / plugin_management__uninstall
+        # (ADR 0064 P2) are registered in the ToolRegistry under their OWN
+        # qualified name — unlike every sibling management verb
+        # (skill_management__install_local -> "skill_install_local",
+        # pipeline_management__install_local -> "pipeline_install_local",
+        # etc.), there is no separate internal bare alias. So referencing
+        # them by backtick in SP prose is the deliberate qualified-name
+        # reference, not an accidental internal-name leak — same reasoning
+        # as the 4 universal-wrapper verbs above, added deliberately here
+        # rather than silently.
+        "plugin_management__install", "plugin_management__uninstall",
+    }
 )
 _BARE_BACKTICK_TOKEN_RE = re.compile(r"`([a-zA-Z_][a-zA-Z0-9_.]*)`")
 

--- a/tests/test_retry_loop_chat_wiring_1125.py
+++ b/tests/test_retry_loop_chat_wiring_1125.py
@@ -52,11 +52,13 @@ def _make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
     Default t_max=1_000_000 → effective_trigger is large → small histories
     return all turns (no elide).  Pass a small t_max to force the elide branch.
 
-    With t_max=2000 (section_caps_spec_tokens=0, T_SP≈1125 from real router SP,
-    T_comp_SP≈481 from real compaction SP):
-      head_budget≈87, tail_budget≈131, effective_trigger≈570.
+    With t_max=2800 (section_caps_spec_tokens=0; re-measured post-#3083
+    plugin_management SP addition — the original ≈570/t_max=2000 pin went
+    stale as the SP grew across many unrelated PRs and finally crashed to a
+    negative effective_trigger, #3083 was simply the straw that tipped it):
+      head_budget≈74, tail_budget≈112, effective_trigger≈489.
     Turns of content ``'X'*320`` each cost 80 tokens via chars4.  With 8 such
-    turns (total=640 > 570), elide fires.  head=[t0], tail=[t7], middle=[t1-t6].
+    turns (total=640 > 489), elide fires.  head=[t0], tail=[t7], middle=[t1-t6].
     """
     import reyn.llm.model_budget as _mb
 
@@ -103,12 +105,12 @@ def test_decompose_slices_head_raw_middle_tail(tmp_path) -> None:
     non-empty head, raw_middle, and tail, and head + raw_middle + tail is a
     lossless in-order partition of all turns (no dropped or duplicated turn).
 
-    Uses t_max=2000 with 30 turns of 80-token content (total=2400 tokens).
-    2400 > T_max=2000 by construction so elide fires regardless of SP size —
+    Uses t_max=2800 with 30 turns of 80-token content (total=2400 tokens).
+    2400 > T_max=2800 by construction so elide fires regardless of SP size —
     default-independent: hot_list_n and other SP-affecting defaults don't change
     whether elide fires.
     """
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     msgs_pushed = 30
     for i in range(msgs_pushed):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
@@ -175,10 +177,10 @@ def test_decompose_wire_shape_matches_build_history(tmp_path) -> None:
     produced; a divergent wire shape (different role normalisation, missing
     tool fields) would make the recovery prompt differ.
 
-    This test forces the elide branch on both paths via t_max=2000 so that
+    This test forces the elide branch on both paths via t_max=2800 so that
     _build_history_for_router also returns head+tail (no summary bridge).
     """
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     for i in range(8):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)
 
@@ -208,7 +210,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
     """
     from reyn.runtime.session import _render_summary_for_storage
 
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     structured = {
         "topic_arc": "planning the trip",
         "decisions": ["book the tuesday flight"],
@@ -223,7 +225,7 @@ def test_recovery_summary_bridge_matches_normal_path(tmp_path) -> None:
         ts=_now(),
         meta={"structured": structured, "covers_through_seq": 2},
     ))
-    # 30 turns × 80 tokens = 2400 > T_max=2000 → elide fires → bridge inserted
+    # 30 turns × 80 tokens = 2400 > T_max=2800 → elide fires → bridge inserted
     # (default-independent: 2400 > T_max by construction regardless of SP size).
     for i in range(30):
         _push(session, "user" if i % 2 == 0 else "assistant", _TURN_80TOK)

--- a/tests/test_session_router_history_slicing.py
+++ b/tests/test_session_router_history_slicing.py
@@ -79,23 +79,23 @@ def test_single_turn_returns_single_message(tmp_path):
 # ── Elide branch (total > effective_trigger) ─────────────────────────────────
 
 # Each "XXXXXXXXXXX...X" text is 320 chars → 80 tokens (chars4).
-# 30 turns × 80 tokens = 2400 tokens. With t_max=2000, effective_trigger is
+# 30 turns × 80 tokens = 2400 tokens. With t_max=2800, effective_trigger is
 # always < t_max by construction, so 2400 > effective_trigger regardless of SP
 # size — default-independent (hot_list_n changes don't affect this bound).
 
-_LONG_TEXT = "X" * 320  # 80 tokens via chars4; use with t_max=2000
+_LONG_TEXT = "X" * 320  # 80 tokens via chars4; use with t_max=2800
 
 
 def test_history_exceeds_trigger_elides_middle(tmp_path):
     """Tier 2: when total tokens > effective_trigger, the middle turns are
     elided and head + tail are returned without duplication.
 
-    Uses T_max=2000 with 30 turns of 80-token text (total=2400 tokens).
-    2400 > T_max=2000 so the elide branch fires regardless of SP size —
+    Uses T_max=2800 with 30 turns of 80-token text (total=2400 tokens).
+    2400 > T_max=2800 so the elide branch fires regardless of SP size —
     default-independent: hot_list_n and other SP-affecting defaults don't
     change whether elide fires.
     """
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     texts = [f"turn-{i}:" + _LONG_TEXT for i in range(30)]
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)
@@ -126,7 +126,7 @@ def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
     test_history_exceeds_trigger_elides_middle for the default-independent
     size rationale).
     """
-    session = _make_session(tmp_path, t_max=2000)
+    session = _make_session(tmp_path, t_max=2800)
     # Inject a summary before the turns.
     session.history.append(ChatMessage(
         role="summary",
@@ -134,7 +134,7 @@ def test_elide_inserts_summary_bridge_when_summary_present(tmp_path):
         ts=_now(),
         meta={"structured": {"topic_arc": "test"}, "covers_through_seq": 0},
     ))
-    # 30 turns × 80 tokens = 2400 > T_max=2000 → elide fires.
+    # 30 turns × 80 tokens = 2400 > T_max=2800 → elide fires.
     texts = [f"turn-{i}:" + _LONG_TEXT for i in range(30)]
     for i, text in enumerate(texts):
         _push(session, "user" if i % 2 == 0 else "assistant", text)

--- a/tests/test_slash_compact_191.py
+++ b/tests/test_slash_compact_191.py
@@ -45,8 +45,11 @@ def _make_session(tmp_path) -> Session:
     """Create a Session with a small synthetic T_max to force non-empty candidates.
 
     #1128 step 3: _select_candidates uses token-budget boundaries from the engine.
-    With ``t_max=2000`` and ``section_caps_spec_tokens=0`` (T_SP≈1125, T_comp_SP≈481):
-    head_budget≈87, tail_budget≈131, effective_trigger≈570.
+    With ``t_max=2800`` and ``section_caps_spec_tokens=0`` (re-measured post-#3083
+    plugin_management SP addition; the original ≈570/t_max=2000 pin went stale
+    as the SP grew across many unrelated PRs and finally crashed to a negative
+    effective_trigger — #3083 was simply the straw that tipped it):
+    head_budget≈74, tail_budget≈112, effective_trigger≈489.
     Turns of 'x'*4000 (=1000 tokens) each individually exceed both budgets, so
     the Axis-7 single-oversized-turn rule includes exactly one turn in head and
     one in tail.  With 8 turns: middle=[t1..t6]=6 candidates ≥ min_compact_batch=1.
@@ -54,7 +57,7 @@ def _make_session(tmp_path) -> Session:
     import reyn.llm.model_budget as _mb
 
     original = _mb.get_max_input_tokens
-    _mb.get_max_input_tokens = lambda model, **kw: 2000  # type: ignore[assignment]
+    _mb.get_max_input_tokens = lambda model, **kw: 2800  # type: ignore[assignment]
     try:
         session = Session(
             agent_name="default",

--- a/tests/test_universal_catalog.py
+++ b/tests/test_universal_catalog.py
@@ -88,12 +88,102 @@ def test_categories_master_table_order() -> None:
         # pipeline_management); required for presentation_management__install to
         # dispatch.
         "presentation_management",
+        # #3083: ADR 0064 P2 plugin management ops (install / uninstall).
+        # Management plane (mirrors skill_management / pipeline_management);
+        # was registered + dispatch-wired but missing from CATEGORIES, which
+        # made plugin_management__install/__uninstall unreachable via every
+        # enumerate-all / retrieval / codeact catalog scheme.
+        "plugin_management",
     )
 
 
 def test_categories_no_duplicates() -> None:
     """Tier 2: CATEGORIES taxonomy has no duplicate entries."""
     assert len(set(CATEGORIES)) == len(CATEGORIES)
+
+
+def test_categories_covers_every_dispatch_wired_category() -> None:
+    """Tier 2: every category with dispatch rules is enumerable via CATEGORIES.
+
+    #3083: ``plugin_management__install`` / ``plugin_management__uninstall``
+    were registered in the default ToolRegistry AND given routing rules in
+    ``universal_dispatch._OPERATION_RULES``, but ``CATEGORIES`` (this
+    module's closed tuple) never gained a ``"plugin_management"`` entry —
+    so ``_enumerate_category`` never emitted either action into ANY
+    catalog scheme's ``tools=`` payload (dogfood witness: 0/75 tools). Same
+    "registered + dispatchable but catalog-invisible" class as
+    #2589/#2621/#2032 (skill_management / pipeline_management /
+    presentation_management all needed the identical fix previously).
+
+    This test derives the expected category set from
+    ``KNOWN_STATIC_QUALIFIED_NAMES`` — the public, registration-derived view
+    of ``_OPERATION_RULES`` (the actual dispatch-routing source of truth) —
+    rather than hand-listing categories a second time, so a future category
+    that gains dispatch rules but not a CATEGORIES entry fails LOUD here
+    instead of silently vanishing from the LLM's tool surface.
+    """
+    from reyn.tools.universal_dispatch import KNOWN_STATIC_QUALIFIED_NAMES
+
+    dispatch_wired_categories = {
+        qualified_name.split("__", 1)[0]
+        for qualified_name in KNOWN_STATIC_QUALIFIED_NAMES
+    }
+    missing = dispatch_wired_categories - set(CATEGORIES)
+    assert not missing, (
+        f"categories {sorted(missing)} have _OPERATION_RULES routing but are "
+        f"missing from CATEGORIES — their actions are dispatchable via "
+        f"invoke_action but will never appear in an enumerated tools= "
+        f"payload (see #3083)"
+    )
+
+
+def test_action_categories_sp_slot_covers_every_category() -> None:
+    """Tier 2: every CATEGORIES entry has an explanatory bullet in the SP.
+
+    ``reyn.prompt.universal_slots.ACTION_CATEGORIES_LINES`` is the
+    hand-maintained "## Action categories" system-prompt slot content
+    (R2) — the per-category one-liner that teaches a (frequently weak)
+    router model what a category is for and its qualified-name shape.
+    It is a SEPARATE closed list from ``CATEGORIES`` (same #2032/#3083
+    "closed enum forgot the new member" shape, just a second surface),
+    so a category can be dispatch-wired and catalog-enumerable while
+    still being unexplained in the prompt the LLM actually reads. #3083
+    found ``plugin_management`` missing from both; this pins the SP-slot
+    side so a future category addition that updates CATEGORIES but not
+    this list fails here instead of leaving the LLM to guess.
+    """
+    from reyn.prompt.universal_slots import ACTION_CATEGORIES_LINES
+
+    slot_text = "\n".join(ACTION_CATEGORIES_LINES)
+    missing = [
+        category for category in CATEGORIES
+        if f"**{category}**" not in slot_text
+    ]
+    assert not missing, (
+        f"categories {missing} have no explanatory bullet in "
+        f"ACTION_CATEGORIES_LINES (the '## Action categories' SP slot)"
+    )
+
+
+def test_plugin_management_actions_reachable_via_catalog_entries() -> None:
+    """Tier 2: plugin_management actions appear in the flat catalog payload.
+
+    #3083 root-cause: ``catalog_entries()`` — the function every enumerate-
+    all / retrieval / codeact chat scheme calls to build the LLM's ``tools=``
+    — never surfaced ``plugin_management__install`` / ``__uninstall``
+    because ``CATEGORIES`` omitted ``"plugin_management"``. This directly
+    exercises the real production entry point (not a private accessor) with
+    a minimal real ``ToolContext`` and asserts both qualified names are
+    present, closing the exact reachability gap the dogfood trace witnessed
+    (0/75 tools).
+    """
+    from reyn.tools.universal_catalog import catalog_entries
+
+    ctx = _make_minimal_ctx()
+    entries = catalog_entries(ctx)
+    qualified_names = {item["name"] for item in entries}
+    assert "plugin_management__install" in qualified_names
+    assert "plugin_management__uninstall" in qualified_names
 
 
 # ── 2. Qualified-name parse / build / validate round-trip ─────────────────

--- a/tests/test_universal_dispatch.py
+++ b/tests/test_universal_dispatch.py
@@ -1,7 +1,7 @@
 """Tier 2: FP-0034 PR-2 universal_dispatch routing contract.
 
 Tests for ``src/reyn/tools/universal_dispatch.py`` covering:
-  1. resolve_invoke_action across all 13 categories (= resource
+  1. resolve_invoke_action across all 14 categories (= resource
      invoke per §D19 AND operation per-name lookup).
   2. Arg transformers for each routing flavour (skill / agent /
      mcp.server / mcp.tool / memory_entry / rag_corpus + passthrough
@@ -632,6 +632,11 @@ _ROUTE_CONTRACT_SAMPLES: list[tuple[str, dict[str, Any]]] = [
      {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
     ("pipeline__run_inline_async",
      {"definition": "pipeline: p\nsteps:\n  - transform: {value: \"1\"}\n"}),
+    # plugin_management category (ADR 0064 P2, #3083) — install requires
+    # source (a {kind, ...} object); uninstall requires name.
+    ("plugin_management__install",
+     {"source": {"kind": "builtin", "name": "rag"}}),
+    ("plugin_management__uninstall", {"name": "rag"}),
 ]
 
 

--- a/tests/tools/_pre_migration_tool_schemas_baseline.json
+++ b/tests/tools/_pre_migration_tool_schemas_baseline.json
@@ -648,7 +648,7 @@
       "parameters": {
         "properties": {
           "category": {
-            "description": "Filter by category. Pass an array of category names (e.g. category=['exec'], category=['web', 'file']). Omit or pass [] to include all categories. Categories: multi_agent, mcp, file, web, memory_operation, reyn_repo, rag_operation, exec, task, skill_management, pipeline, pipeline_management, presentation_management.",
+            "description": "Filter by category. Pass an array of category names (e.g. category=['exec'], category=['web', 'file']). Omit or pass [] to include all categories. Categories: multi_agent, mcp, file, web, memory_operation, reyn_repo, rag_operation, exec, task, skill_management, pipeline, pipeline_management, presentation_management, plugin_management.",
             "items": {
               "enum": [
                 "multi_agent",
@@ -663,7 +663,8 @@
                 "skill_management",
                 "pipeline",
                 "pipeline_management",
-                "presentation_management"
+                "presentation_management",
+                "plugin_management"
               ],
               "type": "string"
             },
@@ -1711,7 +1712,8 @@
                 "skill_management",
                 "pipeline",
                 "pipeline_management",
-                "presentation_management"
+                "presentation_management",
+                "plugin_management"
               ],
               "type": "string"
             },


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3083

## Problem

`plugin_management__install` / `plugin_management__uninstall` (ADR 0064 P2) were registered in the default `ToolRegistry`, but **never reached the LLM**. dogfood-coder's trace witnessed **0/75** — neither verb appeared in any chat `tools=` payload, blocking the RAG turnkey live witness (critical path: owner "RAG 完遂が最優先").

Root cause: `src/reyn/tools/universal_catalog.py`'s `CATEGORIES` closed-tuple was missing `"plugin_management"`, so `_enumerate_category` never emitted the actions into `catalog_entries()` (the substrate every enumerate-all / retrieval / codeact scheme builds `tools=` from). A **second** instance of the same gap: the two verbs also had **no `_OPERATION_RULES` routing entry** in `universal_dispatch.py` — they were dispatch-reachable only because their registered tool name equals their qualified name, but `invoke_action`/`describe_action`/enumeration all read the routing table, which didn't know them.

Same "registered + dispatchable but catalog-invisible" class as #2589 / #2621 / #2032 (skill_management / pipeline_management / presentation_management each needed this exact fix before).

## Fix

**Chose tuple-addition + a registry-derived completeness gate, NOT registry-derivation of `CATEGORIES` itself.** Rationale: `CATEGORIES` is an intentionally *ordered* curated tuple (order matches the FP-0034 §D18 master taxonomy and drives `list_actions` enum order + the byte-pinned tool-schema baseline). Deriving it from the registry would churn that order and the baseline fixture for no capability gain. Instead I added the one missing member **and** a gate that fails LOUD if any dispatch-wired category is ever again absent from `CATEGORIES` — closing the *class*, not just this instance.

- `CATEGORIES` += `"plugin_management"`; added to the `_enumerate_category` static-category allowlist.
- Added the two missing `plugin_management__install` / `__uninstall` rules to `universal_dispatch._OPERATION_RULES`.
- Added a `plugin_management` bullet to the `## Action categories` SP slot (`ACTION_CATEGORIES_LINES`) so weak models are *told* the category exists.

## Completeness gates (this closes the class)

- **`test_categories_covers_every_dispatch_wired_category`** — derives the category set from `KNOWN_STATIC_QUALIFIED_NAMES` (the public view of `_OPERATION_RULES`) and diffs against `CATEGORIES`; any dispatch-wired-but-uncatalogued category → RED. **Strip-falsified**: removed `plugin_management` from `CATEGORIES` → RED (`categories ['plugin_management'] have _OPERATION_RULES routing but are missing from CATEGORIES`), restored → green.
- **`test_action_categories_sp_slot_covers_every_category`** — same guard for the SP-slot bullet list. Strip-falsified (RED with the bullet removed).
- **`test_plugin_management_actions_reachable_via_catalog_entries`** — direct `catalog_entries()` reachability assertion for both qualified names.
- Extended the existing `_ROUTE_CONTRACT_SAMPLES` completeness gate with plugin_management samples.

## Reachability — measured (0/75 → 2)

Direct `catalog_entries(ctx)` against the worktree source:
```
total tools= 57
plugin_management entries: ['plugin_management__install', 'plugin_management__uninstall']
```
Both verbs now appear in the flat `tools=` projection.

## Collateral

- Regenerated `tests/tools/_pre_migration_tool_schemas_baseline.json` (deliberate: `list_actions`/`search_actions` category enum grew by one entry — the only diff).
- Extended the bare-backtick-token SP watchlist (plugin_management's qualified name equals its own registered tool name, unlike sibling verbs whose SP prose uses a distinct internal alias).
- Bumped the shared small-context synthetic `t_max` fixture (2000 → 2800) across 5 compaction/force-close/retry-loop test files: the real SP token estimate had already grown to where the `t_max=2000` headroom was +26 tokens (stale comments still claimed ~570); this PR's ~90-token SP addition tipped `effective_trigger` negative. Re-measured and re-documented.

## CI (4 gates, local green)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict <changed test files>` — 116 OK, 0 Tier-4
- `pytest` (full) — **8922 passed, 29 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py <changed src files>` — clean

## Test plan

- [x] Reachability measured directly via `catalog_entries()` (0/75 → 2)
- [x] Both completeness gates strip-falsified (RED when the member is removed)
- [x] Full `pytest` green

Note: umbrella issues #3066 / #2955 / #3079 are intentionally **not** closed here — they gate on dogfood-coder re-running the live witness after this merges.
