### PR TITLE
fix: propagate caller's live PipelineRegistry into spawned pipeline driver-session (Closes #3093)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2567,6 +2567,33 @@ class Session:
         """Forwarding → RouterLoopDriver.is_cancel_requested (PR-3)."""
         return self._loop_driver.is_cancel_requested()
 
+    def set_pipeline_registry(self, registry: "PipelineRegistry") -> None:
+        """Swap this session's ``PipelineRegistry`` post-construction (#3093).
+
+        Dual-write — mirrors ``_reapply_pipelines``'s tail exactly:
+        ``RouterHostAdapter`` holds its OWN ``_pipeline_registry`` attribute
+        captured at construction and never re-reads Session, so both holders
+        must be reassigned or the adapter's copy (the one ``run_pipeline``
+        actually resolves ``call``/``match`` targets against, via
+        ``get_pipeline_registry()``) would silently keep serving the stale
+        registry.
+
+        Used by two callers: (1) ``_reapply_pipelines`` itself (the hot-reload
+        seam, after a full rebuild-from-disk), and (2)
+        ``session_api._spawn_pipeline_driver_session`` (#3093), which seeds a
+        freshly-spawned PIPELINE DRIVER session with the LAUNCHING caller's
+        current (already hot-reloaded) registry instead of the frozen
+        ``SessionFactoryConfig.pipeline_registry`` snapshot every spawn
+        otherwise inherits (built ONCE per frontend at startup — a plugin/
+        pipeline installed mid-conversation is invisible to it). Without this,
+        a driver-session resolves its OWN pipeline by VALUE (no lookup — the
+        whole ``Pipeline`` is serialized into ``invocation.json``), but a
+        ``call``/``match`` step's SIBLING target is looked up BY NAME against
+        this registry at run time — so a just-installed pipeline's main entry
+        appears to work while any sibling it calls fails "not registered"."""
+        self._pipeline_registry = registry
+        self._router_host._pipeline_registry = registry
+
     def set_loop_driver(self, driver: "ExecutionDriver") -> None:
         """IS-2: swap this session's execution driver post-construction.
 
@@ -4221,8 +4248,7 @@ class Session:
             return False
         # Dual-write swap (Session + the adapter's own captured copy) — only reached
         # after a fully successful build, so a failure above never half-applies.
-        self._pipeline_registry = new_registry
-        self._router_host._pipeline_registry = new_registry
+        self.set_pipeline_registry(new_registry)
         return True
 
     async def _reapply_presentations(self, in_set: dict) -> bool:
@@ -4439,6 +4465,10 @@ class Session:
             reply_to_sid=self._session_id,
             state_log=self._state_log,
             schema_registry=schema_registry,
+            # #3093: THIS session's own live PipelineRegistry — a sibling
+            # call/match target resolves correctly in the spawned driver
+            # instead of against the frozen per-frontend startup snapshot.
+            pipeline_registry=self._pipeline_registry,
         )
 
     async def _drain_to_wake(

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -379,10 +379,31 @@ async def _spawn_pipeline_driver_session(
     run_id: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
     attached_parent_session: "Any | None" = None,
+    pipeline_registry: "Any | None" = None,
 ) -> "tuple[Any, str, str]":
     """Spawn + arm a pipeline driver-session, up to (but NOT including) the
     run/resume nudge — the shared launch prefix of the async (``start_pipeline_run``)
     and sync-attached (``run_pipeline_attached``) paths.
+
+    ``pipeline_registry`` (#3093): when given, the freshly-spawned driver-
+    session's OWN ``PipelineRegistry`` is overwritten with it
+    (``Session.set_pipeline_registry`` — the same dual-write the hot-reload
+    seam uses) right after spawn. Every spawned session otherwise inherits
+    the ``SessionFactoryConfig.pipeline_registry`` snapshot, built ONCE per
+    frontend at startup and never touched by later hot-reloads (those only
+    mutate the LAUNCHING session's own registry in place) — so a pipeline
+    installed mid-conversation resolves fine when the caller looks its NAME
+    up (it already has the fresh registry), but a driver-session spawned to
+    RUN it inherits the stale pre-install snapshot. The pipeline's own steps
+    still execute (the whole ``Pipeline`` is serialized by VALUE into
+    ``invocation.json`` — no registry lookup needed for itself), but a
+    ``call``/``match`` step's SIBLING target, resolved by NAME against the
+    driver's registry at run time, fails "not registered" — exactly the
+    symptom a plugin-installed multi-document pipeline file hits when its
+    main pipeline calls a same-file sibling. Callers pass the LAUNCHING
+    caller's current (already-live) registry here; omitting it preserves
+    the pre-#3093 inherited-snapshot behavior (e.g. a caller with no live
+    registry to hand off).
 
     In crash-safety order:
 
@@ -475,6 +496,11 @@ async def _spawn_pipeline_driver_session(
             f"pipeline launch: spawned driver-session ({reply_to_agent!r}, "
             f"{sid!r}) not found in the registry"
         )
+    # #3093: seed the driver-session with the LAUNCHING caller's current
+    # PipelineRegistry — see this function's docstring. Skipped when omitted
+    # (the pre-#3093 inherited-SessionFactoryConfig-snapshot behavior).
+    if pipeline_registry is not None:
+        session.set_pipeline_registry(pipeline_registry)
     session.set_loop_driver(
         PipelineExecutorDriver(
             work_order, registry=registry, state_log=state_log,
@@ -495,6 +521,7 @@ async def start_pipeline_run(
     state_log: "object",
     run_id: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
+    pipeline_registry: "Any | None" = None,
 ) -> str:
     """IS-2: launch an ASYNC pipeline run in a dedicated driver-session (D案).
 
@@ -509,6 +536,12 @@ async def start_pipeline_run(
     (``schema_defs``) so the driver-session's ``verify: schema`` steps are
     enforced — on the original run and on any later crash-recovery re-wake.
 
+    ``pipeline_registry`` (#3093): the LAUNCHING caller's current
+    ``PipelineRegistry`` — forwarded to ``_spawn_pipeline_driver_session`` so
+    the driver-session resolves a ``call``/``match`` sibling correctly
+    instead of against the frozen per-frontend startup snapshot. See that
+    function's docstring for the full mechanism.
+
     Returns the ``run_id`` immediately; the result arrives later on the invoker's
     inbox as a ``pipeline_result`` message."""
     session, rid, sid = await _spawn_pipeline_driver_session(
@@ -522,6 +555,7 @@ async def start_pipeline_run(
         notify_reply=True,
         run_id=run_id,
         schema_registry=schema_registry,
+        pipeline_registry=pipeline_registry,
     )
     await session.submit_user_text("")  # the no-payload run nudge (D案)
     registry.ensure_session_running(reply_to_agent, sid)
@@ -621,6 +655,17 @@ async def run_pipeline_attached(
     # blocks the run).
     caller_session = registry.get_session(reply_to_agent, reply_to_sid)
 
+    # #3093: the SAME live caller_session already resolved above (for the present-sink
+    # bridge) also carries the launching caller's CURRENT (already hot-reloaded)
+    # PipelineRegistry — hand it to the spawn so the driver-session resolves a
+    # call/match sibling correctly instead of against the frozen per-frontend startup
+    # snapshot every spawn otherwise inherits. See _spawn_pipeline_driver_session's
+    # docstring for the full mechanism. None caller_session (should not happen on the
+    # attached path) → no override, same as the pre-#3093 behavior.
+    caller_pipeline_registry = (
+        getattr(caller_session, "pipeline_registry", None) if caller_session is not None else None
+    )
+
     session, rid, sid = await _spawn_pipeline_driver_session(
         registry,
         pipeline=pipeline,
@@ -633,6 +678,7 @@ async def run_pipeline_attached(
         run_id=run_id,
         schema_registry=schema_registry,
         attached_parent_session=caller_session,
+        pipeline_registry=caller_pipeline_registry,
     )
     if caller_events is not None:
         caller_events.emit(

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -542,6 +542,12 @@ async def _handle_run_pipeline_async(
             reply_to_sid=reply_sid,
             state_log=state_log,
             schema_registry=schema_registry,
+            # #3093: hand the caller's OWN (already hot-reloaded) live
+            # PipelineRegistry to the spawn so the detached driver-session
+            # resolves a call/match sibling correctly instead of against the
+            # frozen per-frontend startup snapshot every spawn otherwise
+            # inherits — see start_pipeline_run's docstring.
+            pipeline_registry=pipeline_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -831,6 +837,12 @@ async def _handle_run_pipeline_inline_async(
     from reyn.runtime.session_api import start_pipeline_run
 
     reply_sid = getattr(host, "live_session_id", None) or "main"
+    rs = ctx.router_state
+    # #3093: an inline definition can still `call`/`match` a REGISTERED sibling
+    # by name — hand the caller's own live PipelineRegistry to the spawn so the
+    # detached driver-session resolves it correctly, same as the non-inline
+    # async path above.
+    pipeline_registry = rs.pipeline_registry if rs is not None else None
     try:
         run_id = await start_pipeline_run(
             agent_registry,
@@ -841,6 +853,7 @@ async def _handle_run_pipeline_inline_async(
             reply_to_sid=reply_sid,
             state_log=state_log,
             schema_registry=schema_registry,
+            pipeline_registry=pipeline_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}

--- a/tests/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/test_3093_pipeline_registry_spawn_propagation.py
@@ -1,0 +1,304 @@
+"""Tier 2: OS invariant — #3093 a spawned pipeline driver-session must resolve a
+``call``/``match`` sibling against the LAUNCHING caller's CURRENT ``PipelineRegistry``,
+not the frozen per-frontend ``SessionFactoryConfig`` snapshot every spawn otherwise
+inherits.
+
+Root cause (confirmed by direct reproduction, not the plugin-install registration
+path the originating dogfood witness suspected — that mechanism (multi-document
+pipeline parsing + ``{key}.{name}`` namespacing, ``reyn/data/pipelines/registry.py``)
+was independently verified correct): ``SessionFactoryConfig.pipeline_registry`` is
+built ONCE per frontend at startup and threaded to every spawned ``Session``
+(``factory_config.py``'s own docstring: "Threaded to every Session (incl. spawns,
+which reuse this bundle)"). The hot-reload seam (``Session._reapply_pipelines``)
+only mutates the LAUNCHING session's own registry (dual-write onto ``Session`` +
+its ``RouterHostAdapter``) — it never touches the shared, frozen
+``SessionFactoryConfig`` bundle. So a pipeline installed (or updated) mid-
+conversation resolves fine when the CALLER looks its name up
+(``pipeline_registry.get(name)`` — the caller's own registry is live), but the
+PIPELINE DRIVER SESSION spawned to actually RUN it
+(``_spawn_pipeline_driver_session`` in ``session_api.py``) starts with whatever
+registry ITS OWN ``Session.__init__`` was given — the stale pre-install snapshot
+in production (a real chat session), or (in this test) simply the DEFAULT empty
+``PipelineRegistry`` every bare test-factory session gets when no registry is
+threaded through it.
+
+The main/top-level pipeline itself always "resolves" regardless (its whole
+``Pipeline`` dataclass is serialized BY VALUE into ``invocation.json`` — no registry
+lookup needed to find itself), but a ``call``/``match`` step's SIBLING target IS
+resolved BY NAME against the driver-session's OWN registry at run time
+(``PipelineExecutorDriver._pipeline_registry()`` -> ``RouterHostAdapter
+.get_pipeline_registry()``) — exactly the symptom a plugin-installed multi-document
+pipeline file hits when its main pipeline calls a same-file sibling (issue #3093):
+the main pipeline's own steps run fine, but the ``call``/``match`` step targeting the
+sibling fails "is not registered".
+
+Fix: ``_spawn_pipeline_driver_session`` (``session_api.py``) accepts an optional
+``pipeline_registry`` override; ``run_pipeline_attached``/``start_pipeline_run``
+forward the LAUNCHING caller's own CURRENT ``pipeline_registry`` into it — threaded
+from ``pipeline_verbs.py``'s ``_handle_run_pipeline`` (sync, derives it from the
+caller session ``run_pipeline_attached`` already resolves internally),
+``_handle_run_pipeline_async`` and ``_handle_run_pipeline_inline_async`` (both
+already had ``rs.pipeline_registry`` in local scope), and
+``Session._launch_pipeline_from_hook``. ``Session.set_pipeline_registry`` (the same
+dual-write ``_reapply_pipelines`` already used) applies the override onto the
+freshly-spawned driver-session right after spawn.
+
+Real ``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor`` throughout (no
+mocks) — mirrors ``tests/test_pipeline_is2_driver_session.py``'s harness, driving
+the REAL production tool-verb entry points (``_handle_run_pipeline`` /
+``_handle_run_pipeline_async``) rather than the lower-level ``session_api``
+functions directly, so the exact code path a real chat session takes is exercised.
+
+Coverage:
+  1. Async detached (``_handle_run_pipeline_async`` — the ``run_pipeline_async``
+     tool's real handler): a caller whose OWN registry carries both the main
+     pipeline and a sibling it ``call``s launches successfully and the sibling
+     actually runs.
+  2. Sync attached (``_handle_run_pipeline`` — the ``run_pipeline`` tool's real
+     handler): same scenario, attached path.
+  3. Strip-falsify (CLAUDE.md testing policy): calling the internal spawn helper
+     directly WITHOUT the ``pipeline_registry`` override (the exact pre-#3093 call
+     shape) reproduces the dogfood-witnessed "target pipeline ... is not
+     registered" failure verbatim — proving the two passing tests above are not
+     vacuously green.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.core.pipeline.executor import CallStep, Pipeline, ToolStep
+from reyn.core.pipeline.registry import PipelineRegistry
+from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.session_api import _spawn_pipeline_driver_session
+from reyn.tools.pipeline_verbs import _handle_run_pipeline, _handle_run_pipeline_async
+from reyn.tools.types import RouterCallerState, ToolContext
+
+
+def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
+    """Real AgentRegistry + real Session factory (mirrors
+    ``test_pipeline_is2_driver_session.py``'s ``_agent_registry``). Every spawned
+    session — including a driver-session — gets the DEFAULT (empty) PipelineRegistry
+    ``Session.__init__`` builds when none is threaded in: this IS the production
+    "frozen per-frontend snapshot" a real chat deployment reuses across spawns,
+    reproduced here without needing a real ``SessionFactoryConfig``."""
+    holder: dict = {}
+
+    def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+        )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    if not reg.exists("worker"):
+        reg.create("worker")
+    return reg
+
+
+def _install_side_effect_tool(monkeypatch, out_file: Path) -> None:
+    """Real side-effecting tool: appends a line per call — proof the sibling
+    pipeline's OWN step actually ran (not just that ``call`` resolved)."""
+    import reyn.tools as tools_pkg
+    from reyn.tools.types import ToolDefinition, ToolGates
+
+    async def _handler(args, ctx):
+        p = Path(out_file)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        with p.open("a", encoding="utf-8") as f:
+            f.write(str(args.get("tag", "x")) + "\n")
+        return {"tag": str(args.get("tag", "x"))}
+
+    tool = ToolDefinition(
+        name="p3093_step",
+        description="#3093 test: append a line per call (real side effect).",
+        parameters={"type": "object", "properties": {}},
+        gates=ToolGates(router="allow", phase="allow"),
+        handler=_handler,
+        category="io",
+        purity="side_effect",
+    )
+    base = tools_pkg.get_default_registry
+
+    def _with_tool():
+        registry = base()
+        registry.register(tool)
+        return registry
+
+    monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
+
+
+def _main_and_sibling_registry() -> "tuple[Pipeline, PipelineRegistry]":
+    """A namespaced main+sibling pair mirroring #3093's real shape (#2722
+    ``{key}.{name}`` namespacing already resolved, as the loader would have): the
+    main pipeline ``call``s ``ns.sibling`` by its GLOBAL dotted name; the sibling
+    runs one real tool step. Both registered under a fresh ``PipelineRegistry`` —
+    the CALLER's own, live, post-hot-reload registry in the real flow."""
+    sibling = Pipeline(steps=[
+        ToolStep(name="p3093_step", args={"tag": "sibling-ran"}, output="o0"),
+    ])
+    main = Pipeline(steps=[
+        CallStep(pipeline="ns.sibling", output="result"),
+    ])
+    registry = PipelineRegistry()
+    registry.register("ns.main", main)
+    registry.register("ns.sibling", sibling)
+    return main, registry
+
+
+async def _wait_for(pred, timeout: float = 15.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.05)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_async_detached_run_resolves_sibling_via_caller_registry(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the REAL ``run_pipeline_async`` tool handler
+    (``_handle_run_pipeline_async``) — a driver-session spawned to run ``ns.main``
+    resolves its ``call`` to ``ns.sibling`` because the LAUNCHING caller's live
+    ``ctx.router_state.pipeline_registry`` is forwarded to the spawn. RED before
+    #3093's fix: the driver would inherit its own default EMPTY registry and fail
+    "target pipeline 'ns.sibling' is not registered"."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    _install_side_effect_tool(monkeypatch, out_file)
+    reg = _agent_registry(tmp_path, state_log)
+
+    main, caller_registry = _main_and_sibling_registry()
+    caller = reg.get_or_load("worker")
+    # Same dual-write the hot-reload seam (Session._reapply_pipelines) uses — sets
+    # BOTH caller._pipeline_registry and caller._router_host._pipeline_registry, so
+    # ctx.router_state.pipeline_registry (built from the SAME live registry, below)
+    # and caller_session.pipeline_registry (what run_pipeline_attached re-derives
+    # internally for the sync path) are the SAME object, matching production
+    # (RouterCallerState.pipeline_registry is itself derived from
+    # host.get_pipeline_registry() at each turn).
+    caller.set_pipeline_registry(caller_registry)
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=caller.pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline_async({"name": "ns.main", "input": None}, ctx)
+    assert result["status"] == "started", result
+    run_id = result["data"]["run_id"]
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", run_id)
+
+    assert await _wait_for(lambda: read_result(run_dir) is not None)
+    terminal = read_result(run_dir)
+    assert terminal["status"] == "ok", terminal
+    # The sibling's OWN step really ran (not just that `call` resolved a stub).
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["sibling-ran"]
+
+
+@pytest.mark.asyncio
+async def test_sync_attached_run_resolves_sibling_via_caller_registry(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the REAL ``run_pipeline`` tool handler (``_handle_run_pipeline``,
+    sync attached) — same scenario. RED before #3093's fix for the same reason."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    _install_side_effect_tool(monkeypatch, out_file)
+    reg = _agent_registry(tmp_path, state_log)
+
+    main, caller_registry = _main_and_sibling_registry()
+    caller = reg.get_or_load("worker")
+    # Same dual-write the hot-reload seam (Session._reapply_pipelines) uses — sets
+    # BOTH caller._pipeline_registry and caller._router_host._pipeline_registry, so
+    # ctx.router_state.pipeline_registry (built from the SAME live registry, below)
+    # and caller_session.pipeline_registry (what run_pipeline_attached re-derives
+    # internally for the sync path) are the SAME object, matching production
+    # (RouterCallerState.pipeline_registry is itself derived from
+    # host.get_pipeline_registry() at each turn).
+    caller.set_pipeline_registry(caller_registry)
+    ctx = ToolContext(
+        events=caller._router_host.events,
+        permission_resolver=None,
+        workspace=None,
+        caller_kind="router",
+        router_state=RouterCallerState(
+            pipeline_registry=caller.pipeline_registry,
+            agent_registry=reg,
+            host=caller._router_host,
+        ),
+        state_log=state_log,
+    )
+
+    result = await _handle_run_pipeline({"name": "ns.main", "input": None}, ctx)
+    assert result["status"] == "ok", result
+    assert out_file.read_text(encoding="utf-8").splitlines() == ["sibling-ran"]
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_no_registry_override_reproduces_3093(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: strip-falsify (CLAUDE.md testing policy) — calling the internal spawn
+    helper WITHOUT the ``pipeline_registry`` override (the exact pre-#3093 call
+    shape) reproduces the dogfood-witnessed failure verbatim — proving the two
+    passing tests above are not vacuously green. The driver-session's OWN
+    (default-empty) registry cannot resolve ``ns.sibling``, even though the SAME
+    name is perfectly resolvable on the caller's own registry."""
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    out_file = tmp_path / "out.txt"
+    _install_side_effect_tool(monkeypatch, out_file)
+    reg = _agent_registry(tmp_path, state_log)
+
+    main, caller_registry = _main_and_sibling_registry()
+    caller = reg.get_or_load("worker")
+    caller.set_pipeline_registry(caller_registry)
+    # Sanity: the caller itself resolves the sibling fine (the bug is spawn-local,
+    # not a broken registry contents/namespacing).
+    assert caller.pipeline_registry.get("ns.sibling") is not None
+
+    session, rid, sid = await _spawn_pipeline_driver_session(
+        reg,
+        pipeline=main,
+        pipeline_name="ns.main",
+        input=None,
+        reply_to_agent="worker",
+        reply_to_sid="main",
+        state_log=state_log,
+        notify_reply=False,
+        # pipeline_registry intentionally OMITTED — the pre-#3093 call shape.
+    )
+    from reyn.runtime.message_bus import MessageBus
+    from reyn.runtime.transport import SystemRef
+
+    bus = MessageBus()
+    await bus.request(
+        session, kind="user", payload={"text": "", "chain_id": "chain"},
+        reply_to=SystemRef(), timeout=15.0,
+    )
+
+    run_dir = pipeline_run_dir(tmp_path / ".reyn", rid)
+    result = read_result(run_dir)
+    assert result is not None
+    assert result["status"] == "failed", result
+    assert "ns.sibling" in result["error"] and "not registered" in result["error"], result
+    # The sibling's step never ran — the failure is the lookup, not a broader break.
+    assert not out_file.exists()


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3093.

## Symptom (dogfood witness)
Plugin-installed multi-document pipeline file (builtin `rag`'s `rag_ingest.yaml`, 8 `pipeline:` docs) fails at runtime:
```
pipeline 'rag_ingest.ingest' failed: step 14 (match label 'False') target pipeline 'rag_ingest._blocked' is not registered
```
`rag_query.query` fails identically on `rag_query._query_blocked`. The **main** pipeline runs; only its same-file **sibling** `call`/`match` targets are unresolvable → ingest and query both unusable via plugin install.

## Root cause — NOT the registration path
The issue's suspected cause (plugin_install not registering siblings) was **falsified by direct reproduction**: `data/pipelines/registry.py`'s multi-doc parsing + `{key}.{name}` namespacing is correct — `plugin_install.handle` writes one `pipelines.entries.rag_ingest` entry, and a fresh `build_pipeline_registry(load_config().pipelines)` registers **all 8** siblings (`rag_ingest._blocked` present). This matches the old builtin-loader behavior.

The gap is **spawn-local**:
- `SessionFactoryConfig.pipeline_registry` is built **ONCE per frontend at startup** and threaded to **every** spawned `Session` (its own docstring: "Threaded to every Session (incl. spawns, which reuse this bundle)").
- The hot-reload seam `Session._reapply_pipelines` (fired by `plugin_install`'s `dispatch_install_reload`) rebuilds and dual-writes **only the LAUNCHING session's own** registry — it never touches the frozen `SessionFactoryConfig` bundle.
- So a mid-conversation-installed pipeline resolves when the **caller** looks its name up (its own registry is live), but the **pipeline driver-session** spawned by `_spawn_pipeline_driver_session` to actually RUN it starts with the **stale frozen snapshot**.
- The main pipeline runs regardless (serialized BY VALUE into `invocation.json` — no registry lookup to find itself), but a `call`/`match` **sibling** target is resolved BY NAME against the driver-session's own registry at run time (`PipelineExecutorDriver._pipeline_registry()` → `RouterHostAdapter.get_pipeline_registry()`) → "not registered".

## Fix — equivalence with the old single-registry resolution
- `Session.set_pipeline_registry(registry)` — extracts the existing `_reapply_pipelines` dual-write (Session + its RouterHostAdapter's own captured `_pipeline_registry`). `_reapply_pipelines` now calls it.
- `_spawn_pipeline_driver_session` gains an optional `pipeline_registry` override; when given, the freshly-spawned driver-session is seeded with it right after spawn (same dual-write). Omitting it preserves pre-fix behavior.
- All four launch call-sites forward the **launching caller's CURRENT** registry: `run_pipeline_attached` (from the already-resolved `caller_session`), `start_pipeline_run`, and the three tool handlers (`_handle_run_pipeline_async`, `_handle_run_pipeline_inline_async`, and `_handle_run_pipeline` via `run_pipeline_attached`), plus `Session._launch_pipeline_from_hook`.

## Fix-class sweep (siblings)
- **skill_install**: no sibling-reference class — each skill is a single `SKILL.md` dir; no cross-file name resolution. Not affected.
- **mcp**: single server per entry. Not affected.

## Test — real install-equivalent + strip-falsify
`tests/test_3093_pipeline_registry_spawn_propagation.py` (Tier 2, real `AgentRegistry`/`Session`/`StateLog`/`PipelineExecutor`, no mocks — mirrors `test_pipeline_is2_driver_session.py`):
1. **async detached** (`_handle_run_pipeline_async`, the real `run_pipeline_async` handler): a main pipeline `call`ing `ns.sibling`, both on the caller's live registry, launches and the sibling's real side-effect step runs.
2. **sync attached** (`_handle_run_pipeline`, the real `run_pipeline` handler): same, attached path.
3. **strip-falsify**: calling `_spawn_pipeline_driver_session` **without** the override (pre-fix call shape) reproduces the exact `ns.sibling ... is not registered` failure — the sibling step never runs — proving 1+2 are not vacuous.

## CI (all four gates green locally)
- `ruff check src tests` — All checks passed
- `test_tier_audit.py --strict tests/test_3093_...py` — 3/3 OK
- `pytest` (full suite) — **8937 passed, 29 skipped**
- `verify_module_docstrings.py` (3 changed src files) — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)