### PR TITLE
fix: close glob_files' error-branch status contract so on_error:abort actually fires

### DIFF
--- a/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
@@ -472,6 +472,18 @@ steps:
   - transform:
       value: "map(ctx.file_extensions, e -> ctx.input_path + '/**/*.' + e) + [ctx.input_path]"
       output: file_patterns
+  # #3095: `schema: PreflightCheck` (same status=="ok" gate X1 above already
+  # uses per MCP server) is what makes the `on_error: abort` above actually
+  # FIRE. Without it, a `tool:` step never raises on a tool-level failure
+  # (only a real transport/dispatch exception does) -- a `glob_files` call
+  # that hits `status: "denied"` (e.g. no file.read permission granted yet
+  # for `input_path`, the common case when it names a folder outside the
+  # reyn project root) returned NORMALLY with an error-shaped payload, so
+  # `on_error: abort` never engaged: the failed item flowed on as an
+  # ordinary "success" into the `fold` below, which assumes every item's
+  # `.structured` is a list -- and broke several steps downstream of the
+  # real failure with an opaque `list + dict` arithmetic error instead of a
+  # clean, decision-enabling "input_path is not readable" abort here.
   - for_each:
       over: ctx.file_patterns
       max_parallel: 4
@@ -479,6 +491,7 @@ steps:
       do:
         tool:
           name: glob_files
+          schema: PreflightCheck
           args:
             pattern: !expr item
             # EXPLICIT, load-bearing: glob_files defaults to 50 and truncates
@@ -491,7 +504,10 @@ steps:
   # Flatten one list per pattern into one flat file list. `structured` is
   # glob's real list of paths (#2994); before that it was newline-joined
   # text, which R1 (no `split`) could not consume at all -- the reason this
-  # step had to be a python shell-out.
+  # step had to be a python shell-out. Every item reaching here is now
+  # GUARANTEED `status: "ok"` (the `schema: PreflightCheck` gate above
+  # aborts the step on anything else), so `.structured` is guaranteed a
+  # list -- `acc + item.structured` can no longer see a dict.
   - fold:
       over: ctx.globbed
       init: "[]"

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -285,7 +285,21 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             "entries": matches,
             "matches": matches,
         }
-    return {"error": result.get("error", "list_directory failed")}
+    # #3095: preserve `status` on the error branch too (op_runtime's own
+    # denied/error result always carries one). Dropping it here made this
+    # adapter's error shape `{"error": ...}` — no `status` key at all — an
+    # ASYMMETRIC contract vs. the success shape above (`status: "ok"`
+    # always present). A pipeline `tool:` step gates on tool-level failure
+    # via `schema: {status: {type: enum, values: ["ok"]}}` (see
+    # rag_ingest.yaml's X1 preflight); with `status` missing, that gate
+    # silently PASSES a failed call (enum check only fires when the field
+    # is present-and-wrong, and this field was absent-not-required), so the
+    # failure surfaced later and opaquely wherever the caller consumed the
+    # data instead of at the schema gate meant to catch it.
+    return {
+        "status": result.get("status", "error"),
+        "error": result.get("error", "list_directory failed"),
+    }
 
 
 async def _handle_grep(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
@@ -357,7 +371,22 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
             "matches": result.get("matches", []),
             "count": result.get("count", 0),
         }
-    return {"error": result.get("error", "glob_files failed")}
+    # #3095: preserve `status` on the error branch (see the matching comment
+    # in `_handle_list` above — same adapter-level bug, same fix). Without
+    # it, a glob_files failure (e.g. a permission-denied source directory)
+    # produced `{"error": ...}` with no `status` key: a pipeline `tool:`
+    # step that gates on `schema: {status: {type: enum, values: ["ok"]}}`
+    # (the rag_ingest.yaml X1 preflight pattern) could not catch it (the
+    # enum check only fires when the field is present-and-wrong), so the
+    # already-declared `for_each: on_error: abort` around this exact call in
+    # `rag_ingest.yaml`'s file-discovery step never engaged — the failure
+    # instead flowed on as a normal "success" item into a `fold` that
+    # assumed every item's `.structured` was a list, and broke on `list +
+    # dict` several steps downstream of the real failure (#3095).
+    return {
+        "status": result.get("status", "error"),
+        "error": result.get("error", "glob_files failed"),
+    }
 
 
 from reyn.core.offload.canonical import file_to_canonical  # noqa: E402

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -602,6 +602,86 @@ def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
     assert "pip install" in blocked, "the remedy must name a concrete fix, not just the cause"
 
 
+# ---------------------------------------------------------------------------
+# 4b. #3095: file-discovery aborts CLEAN on a glob_files failure, instead of
+# corrupting the downstream fold's list-only assumption.
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #3095 -- `_ingest_body`'s file-discovery `for_each` over
+    `glob_files` (one call per extension pattern PLUS `input_path` itself,
+    see the pipeline's own comment) must abort CLEANLY when a `glob_files`
+    call fails -- e.g. `input_path` names a folder OUTSIDE the reyn project
+    root with no `file.read` permission granted for it yet, the ordinary
+    case for a real corpus (the reported dogfood witness pointed at
+    `/tmp/rag_witness5_docs`, well outside the project).
+
+    Before the fix, a `glob_files` failure returned NORMALLY (op_runtime's
+    own `except PermissionError`/`except Exception` degrade every op error
+    to a `status`-carrying result dict rather than raising) with a payload
+    whose `.structured` was the WHOLE raw error dict (`error_to_canonical`'s
+    deliberate, lossless, uniform shape for ANY producer's error case) --
+    NOT the list `glob_files`' own SUCCESS shape always produces. The
+    `for_each`'s already-declared `on_error: abort` never saw this as a
+    failure (only a raised Python exception trips it), so the bad item
+    flowed on into `fold: {do: {transform: {value: "acc + item.structured"}}}`,
+    which broke with an opaque `arithmetic '+' requires two numbers ... got
+    list and dict` several steps downstream of the actual cause.
+
+    The fix closes this in two parts (both required -- see the strip-falsify
+    note below): (1) `_handle_glob`/`_handle_list` (src/reyn/tools/file.py)
+    now preserve `status` on their error branch (previously dropped,
+    `{"error": ...}` with no `status` key at all -- an asymmetric contract
+    vs. their own `status: "ok"` success shape); (2) the `glob_files`
+    `tool:` step in `_ingest_body`'s `for_each` now declares
+    `schema: PreflightCheck` (the SAME `status == "ok"` gate X1 already uses
+    per MCP server, reused here) so a non-"ok" status now FAILS schema
+    validation and raises -- which is what actually makes the pipeline's own
+    already-declared `on_error: abort` engage. Every item that survives to
+    the `fold` is now GUARANTEED `status: "ok"`, so `.structured` is
+    guaranteed a list.
+
+    strip-falsify: reverting either (1) or (2) alone reproduces the original
+    'list and dict' failure (both were independently verified against this
+    test while developing the fix).
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    # A folder OUTSIDE project_root with no permission grant -- Workspace's
+    # own default-deny boundary for absolute paths outside base_dir/state_dir
+    # (see tests/test_workspace_glob_outside_root_perm.py) with `reyn pipe
+    # run`'s non-interactive resolver (`_build_run_tool_context`: "fail-
+    # closed by default"), so the PermissionError is real, not simulated.
+    outside_docs = tmp_path.parent / f"{tmp_path.name}_outside_docs"
+    outside_docs.mkdir()
+    (outside_docs / "a.txt").write_text("content", encoding="utf-8")
+
+    seed = {
+        "input_path": str(outside_docs),
+        "output_db": str(project_root / "rag.sqlite"),
+    }
+    args = _ns(
+        name="rag_ingest.ingest", input=json.dumps(seed),
+        project=str(project_root), async_=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert "arithmetic" not in err and "list and dict" not in err, (
+        f"regressed to the opaque fold list+dict TypeError instead of a clean "
+        f"abort at the real failure site: {err!r}"
+    )
+    # Decision-enabling: names the failing tool + the real cause (glob_files'
+    # own denial message, surfaced via the schema gate's #3070 detail
+    # extraction), not a bare downstream arithmetic exception.
+    assert "glob_files" in err
+    assert "not permitted" in err or "permission" in err.lower()
+
+
 def test_ingest_is_unaffected_by_a_hostile_ambient_python3(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
 ) -> None:


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #3095: `rag_ingest._ingest_body`'s file-discovery `fold` breaking with `arithmetic '+' requires two numbers ... got list and dict` when a `glob_files` call fails (e.g. `input_path` names a folder outside the reyn project root with no `file.read` permission yet — the dogfood witness pointed at `/tmp/rag_witness5_docs`).

Closes #3095

## Root cause (measured, not inferred)

I reproduced the failure end-to-end with real code (`execute_op` → `_handle_glob` → `to_canonical` → `canonical_to_ctx_fields`, no mocks) before touching anything, and again after each half of the fix, including a strip-falsify of each half independently:

- `ws.glob_files(<literal existing directory>, ...)` with permission granted → `[]` (matches the pipeline comment's stated design: "a literal directory path matches nothing"). **Not** the bug.
- The same call **without** a `file.read` permission grant for a path outside the project root → `Workspace.glob_files` raises `PermissionError`, which `op_runtime.execute_op`'s own `except PermissionError`/`except Exception` degrade to a normal (non-raising) `{"status": "denied"/"error", "error": "..."}` result — by design, this never propagates as a Python exception.
- `src/reyn/tools/file.py`'s `_handle_glob` (and `_handle_list`, same pattern) then re-shaped that into `{"error": "..."}` — **dropping `status` entirely**, even though the success branch two lines above always sets `status: "ok"`. An asymmetric, untyped contract: the adapter's error shape carried no discriminator its own success shape has.
- `error_to_canonical` (FP-0056 v2, deliberate & uniform across every producer) wraps ANY `is_error_result`-classified dict wholesale into the `structured` attachment. So `.structured` became `{"error": "..."}` — **a dict**, where `glob_files`' SUCCESS shape is always a list of paths.
- `rag_ingest.yaml`'s file-discovery `for_each` already declares `on_error: abort` — but `on_error` only fires on a *raised* exception (`executor.py::_run_item`'s `except Exception` boundary); a `tool:` step whose underlying op degrades its own failure into a returned dict (as above) never raises, so `on_error: abort` was silently dead for this call. The bad item flowed on as an ordinary "success" into `fold: {do: {transform: {value: "acc + item.structured"}}}`, which assumes every item's `.structured` is a list — and broke on `list + dict`, several steps downstream of the actual cause.

## Structural fix (not a yaml band-aid)

Per owner steer, this closes the broken **type contract** rather than papering over the fold:

1. **`src/reyn/tools/file.py`** — `_handle_glob`/`_handle_list` now preserve `status` on their error branch (`{"status": <the real status>, "error": ...}`), restoring the discriminated-union shape `{status:"ok", ...} | {status:<error-status>, error:str}` that every other op_runtime result already has, instead of an asymmetric shape that only carried a discriminator on success.
2. **`rag_ingest.yaml`** — the `glob_files` tool step now declares `schema: PreflightCheck` (the identical `status == "ok"` schema-gate X1 already uses per MCP-server preflight probe, reused here rather than duplicated). With `status` now always present, a failed glob now FAILS schema validation → raises → `on_error: abort` (already declared, previously dead) finally engages, and the pipeline aborts with a clean, decision-enabling message naming the tool and the real cause instead of the opaque arithmetic error.

**The structural invariant this fixes closes**: every item reaching `_ingest_body`'s file-discovery `fold` is now GUARANTEED `status: "ok"` by construction (the schema gate aborts the step otherwise), so `.structured` is guaranteed a list — the `fold`'s `acc + item.structured` can no longer see a dict. This is enforced by the type/schema layer, not by an `if`/`get(...)` guard inside the fold's own expression.

## Fix-class sweep

Grepped every builtin pipeline for the same "tool result assumed-list `fold`/`+`" pattern: `fold:` appears in exactly one builtin pipeline file — `src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml` (the one fixed here). No other builtin pipeline has this shape.

Also checked every other `.structured` access across builtin pipelines (`rag_query.yaml`, `rag_ingest.yaml`): all are single, non-arithmetic field reads on individually schema/`meta.isError`-gated steps (e.g. `ctx.chunked.structured.result`, `ctx.embedded.structured`) — a producer failure there hits the existing "path '...structured' is absent" fail-visible error from `expr.py`, not the silent list/dict type-confusion this PR fixes. None combine an error-tolerant tool step with list-arithmetic over its result, so no sibling fix is needed.

Also checked `_handle_grep` (same file, same adapter family): it returns `execute_op`'s result verbatim on both success and failure, so it never had the status-dropping bug — only `_handle_glob`/`_handle_list`'s normalize-on-success/re-shape-on-error pattern did.

## Upstream design observation (not implemented here — reporting per owner instruction)

The general mechanism that made `on_error: abort` silently dead is a real DSL gap: a pipeline `tool:` step only fails (and thus only participates in `for_each`/`parallel`'s `on_error` policy) when the underlying dispatch *raises*, or when the step author manually opts in with `schema: <a schema whose only real job is "status must be ok">`. `op_runtime.execute_op`, however, deliberately degrades most op-level failures (`PermissionError`, generic `Exception`) into a *returned* status dict rather than raising — so a pipeline author must remember to bolt on an ad hoc status-enum schema per tool step to get `on_error` to mean what it says, and (as this bug shows) that only works if the adapter's error shape happens to still carry the field being checked. I did **not** change this DSL-level default here (a blanket "raise on tool-level error inside for_each" would break `rag_ingest.yaml`'s own OTHER, deliberate use of the opposite pattern — `ctx.converted`'s `get(ctx.converted, 'meta.isError', false)` gate, which intentionally does NOT want the step to raise, so per-file markitdown conversion failures can be tallied into `files_skipped` (#3010) instead of aborting the whole ingest). Flagging this as upstream design feedback: the DSL currently has no declarative, typed way to say "abort this `for_each`/`parallel` item on ANY tool-level failure" that doesn't depend on an adapter incidentally preserving the right field — worth an architect look at whether `for_each`/`tool:` should gain an explicit opt-in (e.g. `on_tool_error: abort`) distinct from `schema:`, rather than every pipeline author reinventing the `schema: {status: enum[ok]}` idiom per call site.

## Test plan

- [x] `tests/test_fp0063_p3_rag_pipelines.py::test_ingest_file_discovery_aborts_clean_on_unreadable_input_path` — new Tier 2b test, drives the real `rag_ingest.ingest` pipeline via `reyn pipe run` against a real, unpermitted, outside-project `input_path`; asserts the abort message never contains `arithmetic`/`list and dict` and does name `glob_files` + the real permission cause. Strip-falsified against each half of the fix independently (both reproduce the exact reported `step 14.match.2.fold.0 ... got list and dict` message when reverted alone).
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0063_p3_rag_pipelines.py` — 15/15 OK, 0 Tier-4 violations
- [x] `pytest` from repo root — 8935 passed, 29 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/tools/file.py` — OK
