### PR TITLE
fix: config-projection refresh family-gate — close the 9 _reapply_* seams uniformly at spawn (#3097)

### DIFF
--- a/src/reyn/runtime/hot_reload.py
+++ b/src/reyn/runtime/hot_reload.py
@@ -155,6 +155,13 @@ class HotReloader:
         whether it changed anything; it must not raise (the applier isolates it)."""
         self._seams.append((name, fn))
 
+    def seam_names(self) -> "tuple[str, ...]":
+        """#3097: the registered seam names, in registration order — the single
+        source of truth a completeness gate derives its expected-coverage set
+        from (never a hand-written subset: a future ``register_seam`` call is
+        covered automatically)."""
+        return tuple(name for name, _fn in self._seams)
+
     def set_validate(self, fn: "Callable[[dict], str | None]") -> None:
         """Set the validate-before-apply hook (#2073 S2): ``fn(in_set) -> reason |
         None``; a non-None reason rejects the reload atomically (no seam runs)."""
@@ -301,6 +308,58 @@ class HotReloader:
                 failed=failed,
             )
         return {"source": source, "applied": applied, "failed": failed}
+
+    async def apply_all(self, *, exclude: "frozenset[str]" = frozenset()) -> "dict":
+        """#3097: fire EVERY registered seam except ``exclude`` — the
+        ephemeral/spawn action-boundary use (``Session.refresh_config_projections``),
+        independent of both the deferred ``pending`` flag (:meth:`apply_pending`) and
+        the source-scoped immediate path (:meth:`apply_now`). Same IN-set safety
+        boundary + validate-before-apply as both: the OUT-set is never opened, and a
+        malformed IN-set REJECTS the whole call (no seam runs, live config unchanged).
+
+        Returns ``{"source": "spawn_refresh", "invoked", "applied", "failed"}`` (plus
+        ``"rejected"`` on a rejected IN-set) — ``invoked`` lists every seam name that
+        was actually called (regardless of whether it reported a change), the set a
+        completeness gate checks against :meth:`seam_names` minus ``exclude``.
+        Never raises out — each seam is isolated exactly like ``apply_pending``/
+        ``apply_now``."""
+        in_set = load_hot_reload_config(self._project_root)
+
+        if self._validate is not None:
+            reason = self._validate(in_set)
+            if reason:
+                _log.warning(
+                    "hot-reload (spawn_refresh) REJECTED (invalid IN-set): %s — "
+                    "live config unchanged", reason,
+                )
+                if self._events is not None:
+                    self._events.emit(
+                        "config_reload_rejected", source="spawn_refresh", reason=reason,
+                    )
+                return {
+                    "source": "spawn_refresh", "rejected": reason,
+                    "invoked": [], "applied": [], "failed": [],
+                }
+
+        invoked: list[str] = []
+        applied: list[str] = []
+        failed: list[str] = []
+        for name, fn in self._seams:
+            if name in exclude:
+                continue
+            invoked.append(name)
+            try:
+                if await fn(in_set):
+                    applied.append(name)
+            except Exception as exc:  # noqa: BLE001 — a seam never breaks the spawn
+                _log.warning("hot-reload (spawn_refresh) seam %r failed: %s", name, exc)
+                failed.append(name)
+
+        if self._events is not None:
+            self._events.emit(
+                "config_reloaded", source="spawn_refresh", components=applied, failed=failed,
+            )
+        return {"source": "spawn_refresh", "invoked": invoked, "applied": applied, "failed": failed}
 
 
 # ── process-wide active HotReloader (#2073 S3) ──────────────────────────────

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -2957,29 +2957,42 @@ class AgentRegistry:
             presentation_consumer=presentation_consumer,
             intervention_bridge=intervention_bridge,
         )
-        # #3036: every programmatic spawn funnels through here (agent-step ephemeral
-        # workers via spawn_ephemeral_session, pipeline driver-sessions via
+        # #3036/#3097: every programmatic spawn funnels through here (agent-step
+        # ephemeral workers via spawn_ephemeral_session, pipeline driver-sessions via
         # _spawn_pipeline_driver_session — mode="persistent" — and delegate_to_agent's
         # session_spawn tool). None of these callers ever fire a "turn boundary" of
         # their own BEFORE their first programmatic step runs — that trigger is a
         # RouterLoopDriver-only chat-turn concept (Session._run_router_loop), and the
-        # spawned session's config-derived projections (MCP roster first — the family's
-        # other 9 reapply seams are latent until each is independently driven-verified
-        # safe off the chat turn boundary, see #3036) are otherwise frozen at whatever
-        # the (baked-once-at-registry-construction) session_factory closure captured —
-        # stale even for a server installed (mcp_install writes the IN-set
-        # .reyn/config/mcp.yaml) moments before THIS spawn. Reading it fresh here — the
-        # spawned session's own action-boundary (invariant: "programmatic/ephemeral
-        # sessions refresh at spawn + before each dispatch", #3036 architect verdict) —
-        # closes the gap the RAG turnkey flow hit 100%: install (chat session) always
-        # precedes the pipeline-driver/agent-step spawn that consumes it, so a
-        # spawn-time refresh alone is sufficient (no mid-run re-spawn case exists on
-        # this path). ``refresh_mcp_servers`` never raises (documented contract) — no
-        # try/except needed. Best-effort no-op when the peeked session is somehow gone
-        # (should not happen — spawn_session above just constructed it).
+        # spawned session's config-derived projections are otherwise frozen at
+        # whatever the (baked-once-at-registry-construction) session_factory closure
+        # captured — stale even for config an install wrote (e.g. mcp_install's IN-set
+        # .reyn/config/mcp.yaml, or a plugin_install's pipelines/skills/presentations
+        # entry) moments before THIS spawn. #3036/#3061 closed this for the MCP roster
+        # alone; #3094 point-fixed the pipeline registry alone after that seam
+        # surfaced live (#3094); #3097 closes the WHOLE family uniformly —
+        # refresh_config_projections() iterates EVERY registered hot-reload seam
+        # (session.py's _register_hot_reload_seams(), the same registry a live
+        # /reload uses) except cron (the one genuinely side-effecting seam — see
+        # that method's own docstring). Reading it fresh here — the spawned
+        # session's own action-boundary (invariant: "programmatic/ephemeral sessions
+        # refresh at spawn + before each dispatch", #3036 architect verdict) — closes
+        # the gap the RAG turnkey flow hit: install (chat session) always precedes
+        # the pipeline-driver/agent-step spawn that consumes it, so a spawn-time
+        # refresh alone is sufficient (no mid-run re-spawn case exists on this
+        # path). ``refresh_config_projections`` never raises (each seam is isolated
+        # by the applier) — no try/except needed. Best-effort no-op when the peeked
+        # session is somehow gone (should not happen — spawn_session above just
+        # constructed it).
+        #
+        # ★ Recovery invariant: crash-recovery re-wake (``restore_all`` /
+        # _rewake_pipeline_runs) calls the lower-level ``spawn_session`` directly,
+        # NEVER this method — so a re-woken session never has its config
+        # projections refreshed to CURRENT disk state here; it only gets whatever
+        # ``restore_state``/the work-order snapshot restores (pre-crash snapshot
+        # fidelity, by construction of this call graph, not a special-cased guard).
         spawned_session = self._peek_session(name, sid)
         if spawned_session is not None:
-            await spawned_session.refresh_mcp_servers()
+            await spawned_session.refresh_config_projections()
         if mode == "ephemeral":
             # #2103: mark the live session so it auto-vanishes once its task is done
             # (Session._maybe_schedule_ephemeral_vanish, via this registry's

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2480,6 +2480,16 @@ class Session:
         return self._pipeline_registry
 
     @property
+    def contextual_permission(self) -> "object | None":
+        """#3097: read-only accessor for the live ``ContextualPermission`` (#1827
+        S3) — the per-turn gate value ``_reapply_visibility_override`` maintains
+        (envelope ∩ session override, restrict-only, narrow-only). A
+        ``snapshot()``-style public read so a test can verify the security-core
+        seam narrows correctly (``visible ⊆ authorized``) without reaching into
+        the private ``_contextual_permission`` field directly."""
+        return self._contextual_permission
+
+    @property
     def presentation_registry(self):
         """Read-only accessor for the session's owning PresentationRegistry
         (FP-0054 PR-C — operator named templates from presentations.yaml). Mirrors
@@ -2827,6 +2837,25 @@ class Session:
         ])
         self._contextual_permission = final_ctx
         self._excluded_categories = final_excl
+
+    async def _reapply_visibility_override_seam(self, in_set: dict) -> bool:
+        """#3097: ``HotReloader``-seam wrapper for ``_reapply_visibility_override``
+        (security-core — see that method's docstring for the restrict-only compose
+        that keeps ``visible ⊆ authorized`` by construction). Registered so both the
+        operator ``/reload`` path and ``Session.refresh_config_projections()``'s
+        spawn-time family gate cover it uniformly, DERIVED from the seam registry
+        rather than a hand-picked call site.
+
+        ``in_set`` is unused — the envelope's own source is
+        ``AgentRegistry.resolved_profile_for`` (topology ∩ delegate floor ∩ the
+        persisted per-session narrowing config), independent of the hot-reload
+        IN-set — same "in_set ignored, re-derive from the real source" shape as
+        ``_reapply_skills``/``_reapply_pipelines``. Always reports a fire (there is
+        no cheap way to detect a true no-op short of re-running the compose and
+        diffing the result, which is exactly what re-resolving already does) —
+        matches ``_reapply_hooks``'s always-True posture."""
+        self._reapply_visibility_override()
+        return True
 
     def _reapply_skill_visibility(self) -> None:
         """#2548 PR-B: recompute the live skill list from the base registered set minus the session override.
@@ -3866,6 +3895,74 @@ class Session:
             },
         }
 
+    # ── #3097: config-projection refresh family-gate ─────────────────────────
+
+    async def refresh_config_projections(self) -> dict:
+        """#3097 (#3061 follow-up): fire EVERY registered config hot-reload seam
+        (``_register_hot_reload_seams()``) at THIS session's own ephemeral/spawn
+        action-boundary — EXCLUDING ``cron`` (the one genuinely SIDE-EFFECTING
+        seam: it mutates the global scheduler; a short-lived programmatically-
+        spawned worker must never reschedule cron on its own, and has no active
+        scheduler to reschedule anyway).
+
+        Closes the #3036/#3061 gap the RAG turnkey flow hit: a programmatic spawn
+        (``AgentRegistry.spawn_session_recorded`` — every agent-step ephemeral
+        worker, pipeline driver-session, and ``session_spawn``/``delegate_to_agent``
+        target) never fires a chat "turn boundary" of its own before its first
+        dispatch, so every one of its config-derived projections (MCP roster,
+        pipeline/presentation/skill registries, hooks, per-agent capability, the
+        session visibility override, …) is otherwise frozen at whatever the
+        (baked-once-at-registry-construction) ``session_factory`` closure
+        captured — stale even for config an install wrote moments before this
+        spawn. #3061 closed this for MCP alone; #3094 point-fixed the pipeline
+        registry alone after it surfaced live — this closes the WHOLE family
+        uniformly, DERIVED from the seam registry (never a hand-picked subset),
+        so a future ``register_seam`` addition is covered on registration, with
+        no one needing to remember it.
+
+        Every included seam is a read-only projection (re-read the IN-set /
+        cascade → swap or re-derive) or a confirming no-op
+        (``_reapply_new_agent``) — never a mutation of anything outside this
+        session's own in-memory holders — so firing them off the chat turn
+        boundary is idempotent-safe: a spawn with unchanged config is a no-op,
+        and a spawn racing a fresh install simply picks up the fresher state.
+
+        ``_reapply_visibility_override`` (security-core: visible ⊆ authorized)
+        is included — firing it here re-resolves the JUST-SPAWNED session's OWN
+        envelope from its CURRENT base (topology ∩ delegate floor ∩ persisted
+        per-session narrowing) ∩ its (empty, freshly-constructed) override, which
+        can only narrow relative to the authorized envelope, never grant beyond
+        it (see that method's own docstring for why the compose is restrict-only
+        by construction).
+
+        ``_reapply_skill_visibility`` has no seam of its own — it is already
+        re-derived as the tail of the ``skills`` seam (``_reapply_skills``)
+        whenever the base skill set changes, so it is covered transitively.
+
+        MUST NOT be called on a crash-recovery re-wake (``AgentRegistry.
+        restore_all`` / ``_rewake_pipeline_runs``, registry.py): those paths
+        call the lower-level ``spawn_session`` directly (never
+        ``spawn_session_recorded``, the sole caller of this method), by
+        construction — recovery RESTORES the pre-crash snapshot (snapshot
+        fidelity), it must not overwrite it with whatever the CURRENT on-disk
+        config happens to be.
+
+        Returns the ``HotReloader.apply_all()`` summary
+        (``{"source", "invoked", "applied", "failed"}``) — ``invoked`` is the
+        set a completeness gate checks against ``hot_reload_seam_names()`` minus
+        ``{"cron"}``. Never raises (each seam is isolated by the applier)."""
+        return await self._hot_reloader.apply_all(exclude=frozenset({"cron"}))
+
+    def hot_reload_seam_names(self) -> "tuple[str, ...]":
+        """#3097: the public read of every hot-reload seam name registered on
+        this session's ``HotReloader`` (``_register_hot_reload_seams()``), in
+        registration order. The completeness-gate test for
+        ``refresh_config_projections()`` derives its expected-coverage set from
+        THIS (never a hand-written marker subset), so a future
+        ``register_seam`` addition is covered automatically — the same
+        registry-derived-enumeration discipline the family gate itself uses."""
+        return self._hot_reloader.seam_names()
+
     # ── #3082 Family 1: audit-event spine builder ──
 
     def _build_audit_event_bundle(
@@ -3945,6 +4042,10 @@ class Session:
         hr.register_seam("skills", self._reapply_skills)  # #2548 PR-B: skills hot-reload
         hr.register_seam("pipelines", self._reapply_pipelines)  # #2581: pipeline hot-reload
         hr.register_seam("presentations", self._reapply_presentations)  # FP-0054 PR-C
+        # #3097: the security-core envelope re-resolve (see the wrapper's own docstring
+        # for why it needs its own seam — its data source, resolved_profile_for, is
+        # independent of every other registered seam's IN-set/cascade re-read).
+        hr.register_seam("visibility_override", self._reapply_visibility_override_seam)
 
     def _build_hook_registry(self, in_set: "dict | None" = None) -> "object":
         """Build the LAYERED hook registry — the three-layer COMBINE (#2073 S2b + the
@@ -4456,6 +4557,14 @@ class Session:
             return
 
         from reyn.runtime.session_api import start_pipeline_run
+        # #3097: no explicit pipeline_registry hand-off needed — the spawned
+        # driver-session's own _reapply_pipelines seam fires uniformly at ITS
+        # spawn (AgentRegistry.spawn_session_recorded -> refresh_config_projections,
+        # inside start_pipeline_run -> _spawn_pipeline_driver_session), rebuilding
+        # from the current on-disk cascade directly. Folds out #3094's spawn-local
+        # override (which forwarded THIS session's live registry object) — the
+        # family gate achieves the same effect without depending on the caller
+        # having a fresh in-memory copy to hand off.
         await start_pipeline_run(
             self._registry,
             pipeline=pipeline,
@@ -4465,10 +4574,6 @@ class Session:
             reply_to_sid=self._session_id,
             state_log=self._state_log,
             schema_registry=schema_registry,
-            # #3093: THIS session's own live PipelineRegistry — a sibling
-            # call/match target resolves correctly in the spawned driver
-            # instead of against the frozen per-frontend startup snapshot.
-            pipeline_registry=self._pipeline_registry,
         )
 
     async def _drain_to_wake(

--- a/src/reyn/runtime/session_api.py
+++ b/src/reyn/runtime/session_api.py
@@ -379,31 +379,27 @@ async def _spawn_pipeline_driver_session(
     run_id: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
     attached_parent_session: "Any | None" = None,
-    pipeline_registry: "Any | None" = None,
 ) -> "tuple[Any, str, str]":
     """Spawn + arm a pipeline driver-session, up to (but NOT including) the
     run/resume nudge — the shared launch prefix of the async (``start_pipeline_run``)
     and sync-attached (``run_pipeline_attached``) paths.
 
-    ``pipeline_registry`` (#3093): when given, the freshly-spawned driver-
-    session's OWN ``PipelineRegistry`` is overwritten with it
-    (``Session.set_pipeline_registry`` — the same dual-write the hot-reload
-    seam uses) right after spawn. Every spawned session otherwise inherits
-    the ``SessionFactoryConfig.pipeline_registry`` snapshot, built ONCE per
-    frontend at startup and never touched by later hot-reloads (those only
-    mutate the LAUNCHING session's own registry in place) — so a pipeline
-    installed mid-conversation resolves fine when the caller looks its NAME
-    up (it already has the fresh registry), but a driver-session spawned to
-    RUN it inherits the stale pre-install snapshot. The pipeline's own steps
-    still execute (the whole ``Pipeline`` is serialized by VALUE into
-    ``invocation.json`` — no registry lookup needed for itself), but a
-    ``call``/``match`` step's SIBLING target, resolved by NAME against the
-    driver's registry at run time, fails "not registered" — exactly the
-    symptom a plugin-installed multi-document pipeline file hits when its
-    main pipeline calls a same-file sibling. Callers pass the LAUNCHING
-    caller's current (already-live) registry here; omitting it preserves
-    the pre-#3093 inherited-snapshot behavior (e.g. a caller with no live
-    registry to hand off).
+    #3097 (folds out #3094's spawn-local override): the freshly-spawned
+    driver-session's ``PipelineRegistry`` no longer needs an explicit hand-off
+    from the caller. ``registry.spawn_session_recorded`` below (the single
+    funnel every programmatic spawn shares) now fires
+    ``Session.refresh_config_projections()`` on the newly-spawned session
+    BEFORE this function returns — which includes the ``pipelines`` seam
+    (``Session._reapply_pipelines``), rebuilding the driver-session's OWN
+    registry from the CURRENT on-disk config cascade uniformly, the same
+    mechanism a live ``/reload`` uses. This is equivalent to (and supersedes)
+    #3093/#3094's point-fix: a pipeline installed mid-conversation writes to
+    disk BEFORE the spawn that runs it (confirmed topology, #3061), so the
+    driver-session's own fresh rebuild finds it without needing the caller to
+    have already hot-reloaded its own in-memory copy. See
+    ``Session.refresh_config_projections``'s docstring for the full family-gate
+    mechanism and ``Session._reapply_pipelines`` for the pipeline-specific
+    rebuild.
 
     In crash-safety order:
 
@@ -496,11 +492,6 @@ async def _spawn_pipeline_driver_session(
             f"pipeline launch: spawned driver-session ({reply_to_agent!r}, "
             f"{sid!r}) not found in the registry"
         )
-    # #3093: seed the driver-session with the LAUNCHING caller's current
-    # PipelineRegistry — see this function's docstring. Skipped when omitted
-    # (the pre-#3093 inherited-SessionFactoryConfig-snapshot behavior).
-    if pipeline_registry is not None:
-        session.set_pipeline_registry(pipeline_registry)
     session.set_loop_driver(
         PipelineExecutorDriver(
             work_order, registry=registry, state_log=state_log,
@@ -521,7 +512,6 @@ async def start_pipeline_run(
     state_log: "object",
     run_id: "str | None" = None,
     schema_registry: "SchemaRegistry | None" = None,
-    pipeline_registry: "Any | None" = None,
 ) -> str:
     """IS-2: launch an ASYNC pipeline run in a dedicated driver-session (D案).
 
@@ -536,11 +526,10 @@ async def start_pipeline_run(
     (``schema_defs``) so the driver-session's ``verify: schema`` steps are
     enforced — on the original run and on any later crash-recovery re-wake.
 
-    ``pipeline_registry`` (#3093): the LAUNCHING caller's current
-    ``PipelineRegistry`` — forwarded to ``_spawn_pipeline_driver_session`` so
-    the driver-session resolves a ``call``/``match`` sibling correctly
-    instead of against the frozen per-frontend startup snapshot. See that
-    function's docstring for the full mechanism.
+    #3097: the driver-session's OWN pipeline registry is refreshed at ITS
+    spawn by the config-projection family gate (``spawn_session_recorded`` ->
+    ``Session.refresh_config_projections()``) — no caller hand-off needed. See
+    ``_spawn_pipeline_driver_session``'s docstring for the full mechanism.
 
     Returns the ``run_id`` immediately; the result arrives later on the invoker's
     inbox as a ``pipeline_result`` message."""
@@ -555,7 +544,6 @@ async def start_pipeline_run(
         notify_reply=True,
         run_id=run_id,
         schema_registry=schema_registry,
-        pipeline_registry=pipeline_registry,
     )
     await session.submit_user_text("")  # the no-payload run nudge (D案)
     registry.ensure_session_running(reply_to_agent, sid)
@@ -655,17 +643,11 @@ async def run_pipeline_attached(
     # blocks the run).
     caller_session = registry.get_session(reply_to_agent, reply_to_sid)
 
-    # #3093: the SAME live caller_session already resolved above (for the present-sink
-    # bridge) also carries the launching caller's CURRENT (already hot-reloaded)
-    # PipelineRegistry — hand it to the spawn so the driver-session resolves a
-    # call/match sibling correctly instead of against the frozen per-frontend startup
-    # snapshot every spawn otherwise inherits. See _spawn_pipeline_driver_session's
-    # docstring for the full mechanism. None caller_session (should not happen on the
-    # attached path) → no override, same as the pre-#3093 behavior.
-    caller_pipeline_registry = (
-        getattr(caller_session, "pipeline_registry", None) if caller_session is not None else None
-    )
-
+    # #3097: no explicit pipeline_registry hand-off needed — the driver-session's
+    # OWN registry is refreshed at ITS spawn by the config-projection family gate
+    # (spawn_session_recorded -> Session.refresh_config_projections(), which
+    # includes the pipelines seam). Folds out #3094's caller_pipeline_registry
+    # forwarding. See _spawn_pipeline_driver_session's docstring for the mechanism.
     session, rid, sid = await _spawn_pipeline_driver_session(
         registry,
         pipeline=pipeline,
@@ -678,7 +660,6 @@ async def run_pipeline_attached(
         run_id=run_id,
         schema_registry=schema_registry,
         attached_parent_session=caller_session,
-        pipeline_registry=caller_pipeline_registry,
     )
     if caller_events is not None:
         caller_events.emit(

--- a/src/reyn/tools/pipeline_verbs.py
+++ b/src/reyn/tools/pipeline_verbs.py
@@ -542,12 +542,6 @@ async def _handle_run_pipeline_async(
             reply_to_sid=reply_sid,
             state_log=state_log,
             schema_registry=schema_registry,
-            # #3093: hand the caller's OWN (already hot-reloaded) live
-            # PipelineRegistry to the spawn so the detached driver-session
-            # resolves a call/match sibling correctly instead of against the
-            # frozen per-frontend startup snapshot every spawn otherwise
-            # inherits — see start_pipeline_run's docstring.
-            pipeline_registry=pipeline_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}
@@ -837,12 +831,10 @@ async def _handle_run_pipeline_inline_async(
     from reyn.runtime.session_api import start_pipeline_run
 
     reply_sid = getattr(host, "live_session_id", None) or "main"
-    rs = ctx.router_state
-    # #3093: an inline definition can still `call`/`match` a REGISTERED sibling
-    # by name — hand the caller's own live PipelineRegistry to the spawn so the
-    # detached driver-session resolves it correctly, same as the non-inline
-    # async path above.
-    pipeline_registry = rs.pipeline_registry if rs is not None else None
+    # #3097: an inline definition can still `call`/`match` a REGISTERED sibling by
+    # name — resolved correctly because the detached driver-session's OWN registry
+    # is refreshed at ITS spawn by the config-projection family gate (folds out
+    # #3093/#3094's explicit caller-registry hand-off).
     try:
         run_id = await start_pipeline_run(
             agent_registry,
@@ -853,7 +845,6 @@ async def _handle_run_pipeline_inline_async(
             reply_to_sid=reply_sid,
             state_log=state_log,
             schema_registry=schema_registry,
-            pipeline_registry=pipeline_registry,
         )
     except ValueError as exc:
         return {"status": "error", "data": {"error": str(exc)}}

--- a/tests/test_2073_s2_reapply_seams.py
+++ b/tests/test_2073_s2_reapply_seams.py
@@ -89,12 +89,17 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
 def test_seams_registered_on_the_reloader(tmp_path: Path) -> None:
     """Tier 2: the Session registers its reapply seams on the HotReloader (the 4 S2
     seams + the S2b hooks seam + the #2548 PR-B skills seam + the #2581 pipelines
-    seam + the FP-0054 PR-C presentations seam)."""
+    seam + the FP-0054 PR-C presentations seam + the #3097 visibility_override
+    seam). Reads the PUBLIC ``hot_reload_seam_names()`` accessor (not the private
+    ``_hot_reloader._seams`` list) — #3097's completeness gate
+    (``tests/test_3097_config_projection_refresh_family_gate.py``) is the one that
+    actually needs this enumeration to grow with the registry automatically; this
+    test just pins today's registered set for visibility."""
     session = _make_session(tmp_path)
-    names = [name for (name, _fn) in session._hot_reloader._seams]
+    names = list(session.hot_reload_seam_names())
     assert names == [
         "cron", "mcp", "per_agent_capability", "new_agent", "hooks", "skills",
-        "pipelines", "presentations",
+        "pipelines", "presentations", "visibility_override",
     ]
 
 

--- a/tests/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/test_3093_pipeline_registry_spawn_propagation.py
@@ -1,6 +1,6 @@
 """Tier 2: OS invariant — #3093 a spawned pipeline driver-session must resolve a
-``call``/``match`` sibling against the LAUNCHING caller's CURRENT ``PipelineRegistry``,
-not the frozen per-frontend ``SessionFactoryConfig`` snapshot every spawn otherwise
+``call``/``match`` sibling against the CURRENT on-disk pipeline config, not the
+frozen per-frontend ``SessionFactoryConfig`` snapshot every spawn otherwise
 inherits.
 
 Root cause (confirmed by direct reproduction, not the plugin-install registration
@@ -9,18 +9,11 @@ pipeline parsing + ``{key}.{name}`` namespacing, ``reyn/data/pipelines/registry.
 was independently verified correct): ``SessionFactoryConfig.pipeline_registry`` is
 built ONCE per frontend at startup and threaded to every spawned ``Session``
 (``factory_config.py``'s own docstring: "Threaded to every Session (incl. spawns,
-which reuse this bundle)"). The hot-reload seam (``Session._reapply_pipelines``)
-only mutates the LAUNCHING session's own registry (dual-write onto ``Session`` +
-its ``RouterHostAdapter``) — it never touches the shared, frozen
-``SessionFactoryConfig`` bundle. So a pipeline installed (or updated) mid-
-conversation resolves fine when the CALLER looks its name up
-(``pipeline_registry.get(name)`` — the caller's own registry is live), but the
-PIPELINE DRIVER SESSION spawned to actually RUN it
-(``_spawn_pipeline_driver_session`` in ``session_api.py``) starts with whatever
-registry ITS OWN ``Session.__init__`` was given — the stale pre-install snapshot
-in production (a real chat session), or (in this test) simply the DEFAULT empty
-``PipelineRegistry`` every bare test-factory session gets when no registry is
-threaded through it.
+which reuse this bundle)"). So a pipeline installed (or updated) mid-conversation
+resolves fine when the CALLER looks its name up (its own registry is live via the
+hot-reload seam), but the PIPELINE DRIVER SESSION spawned to actually RUN it
+(``_spawn_pipeline_driver_session`` in ``session_api.py``) started with whatever
+registry ITS OWN ``Session.__init__`` was given — the stale pre-install snapshot.
 
 The main/top-level pipeline itself always "resolves" regardless (its whole
 ``Pipeline`` dataclass is serialized BY VALUE into ``invocation.json`` — no registry
@@ -32,35 +25,43 @@ pipeline file hits when its main pipeline calls a same-file sibling (issue #3093
 the main pipeline's own steps run fine, but the ``call``/``match`` step targeting the
 sibling fails "is not registered".
 
-Fix: ``_spawn_pipeline_driver_session`` (``session_api.py``) accepts an optional
-``pipeline_registry`` override; ``run_pipeline_attached``/``start_pipeline_run``
-forward the LAUNCHING caller's own CURRENT ``pipeline_registry`` into it — threaded
-from ``pipeline_verbs.py``'s ``_handle_run_pipeline`` (sync, derives it from the
-caller session ``run_pipeline_attached`` already resolves internally),
-``_handle_run_pipeline_async`` and ``_handle_run_pipeline_inline_async`` (both
-already had ``rs.pipeline_registry`` in local scope), and
-``Session._launch_pipeline_from_hook``. ``Session.set_pipeline_registry`` (the same
-dual-write ``_reapply_pipelines`` already used) applies the override onto the
-freshly-spawned driver-session right after spawn.
+#3094 point-fixed this by threading the LAUNCHING caller's live in-memory
+``PipelineRegistry`` into the spawn (``_spawn_pipeline_driver_session``'s
+``pipeline_registry`` override + ``Session.set_pipeline_registry``). #3097
+(this revision) FOLDS THAT OUT: the config-projection refresh family-gate
+(``AgentRegistry.spawn_session_recorded`` -> ``Session.refresh_config_projections()``)
+now fires ``Session._reapply_pipelines`` uniformly on EVERY programmatic spawn
+(the same funnel ``_spawn_pipeline_driver_session`` uses), rebuilding the
+driver-session's OWN registry from the CURRENT ON-DISK config cascade — no
+explicit caller hand-off needed. This is equivalent to (and supersedes) the
+#3094 point-fix given the confirmed topology (#3061): an install always writes
+to disk BEFORE the spawn that consumes it (no code path installs and consumes
+in the same run), so a driver-session's own fresh disk-rebuild at ITS spawn
+finds a just-installed sibling without needing the caller's in-memory copy.
 
 Real ``AgentRegistry``/``Session``/``StateLog``/``PipelineExecutor`` throughout (no
 mocks) — mirrors ``tests/test_pipeline_is2_driver_session.py``'s harness, driving
 the REAL production tool-verb entry points (``_handle_run_pipeline`` /
 ``_handle_run_pipeline_async``) rather than the lower-level ``session_api``
 functions directly, so the exact code path a real chat session takes is exercised.
+Pipelines are installed the PRODUCTION way — an on-disk DSL file + a
+``.reyn/config/pipelines.yaml`` entry (mirrors ``tests/test_2581_pipeline_hotreload.py``'s
+``_write_pipeline``/``_write_dynamic_entries`` helpers) — so the family-gate's
+disk-cascade rebuild has something real to find.
 
 Coverage:
   1. Async detached (``_handle_run_pipeline_async`` — the ``run_pipeline_async``
-     tool's real handler): a caller whose OWN registry carries both the main
-     pipeline and a sibling it ``call``s launches successfully and the sibling
+     tool's real handler): a main pipeline ``call``ing a same-file sibling,
+     installed to disk before the spawn, launches successfully and the sibling
      actually runs.
   2. Sync attached (``_handle_run_pipeline`` — the ``run_pipeline`` tool's real
      handler): same scenario, attached path.
-  3. Strip-falsify (CLAUDE.md testing policy): calling the internal spawn helper
-     directly WITHOUT the ``pipeline_registry`` override (the exact pre-#3093 call
-     shape) reproduces the dogfood-witnessed "target pipeline ... is not
-     registered" failure verbatim — proving the two passing tests above are not
-     vacuously green.
+  3. Strip-falsify (CLAUDE.md testing policy): spawning the driver-session via
+     the LOWER-LEVEL ``spawn_session`` (the crash-recovery re-wake call shape,
+     which never fires the family gate) instead of ``spawn_session_recorded``
+     reproduces the exact "target pipeline ... is not registered" failure —
+     proving (a) the two passing tests above are not vacuously green, and (b)
+     the family gate (not something else) is what makes them pass.
 """
 from __future__ import annotations
 
@@ -68,14 +69,12 @@ import asyncio
 from pathlib import Path
 
 import pytest
+import yaml
 
 from reyn.core.events.state_log import StateLog
-from reyn.core.pipeline.executor import CallStep, Pipeline, ToolStep
-from reyn.core.pipeline.registry import PipelineRegistry
 from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
-from reyn.runtime.session_api import _spawn_pipeline_driver_session
 from reyn.tools.pipeline_verbs import _handle_run_pipeline, _handle_run_pipeline_async
 from reyn.tools.types import RouterCallerState, ToolContext
 
@@ -83,11 +82,17 @@ from reyn.tools.types import RouterCallerState, ToolContext
 def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     """Real AgentRegistry + real Session factory (mirrors
     ``test_pipeline_is2_driver_session.py``'s ``_agent_registry``). Every spawned
-    session — including a driver-session — gets the DEFAULT (empty) PipelineRegistry
-    ``Session.__init__`` builds when none is threaded in: this IS the production
-    "frozen per-frontend snapshot" a real chat deployment reuses across spawns,
-    reproduced here without needing a real ``SessionFactoryConfig``."""
+    session builds its ``PipelineRegistry`` from whatever ``pipelines.entries``
+    the config cascade declared AT FACTORY-CONSTRUCTION time (built once, closed
+    over below) — this IS the production "frozen per-frontend snapshot" a real
+    chat deployment reuses across spawns."""
+    from reyn.config.loader import load_config
+    from reyn.data.pipelines.registry import build_pipeline_registry
+
+    if not (tmp_path / "reyn.yaml").exists():
+        (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
     holder: dict = {}
+    frozen_registry = build_pipeline_registry(load_config(tmp_path).pipelines, tmp_path)
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
@@ -95,6 +100,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
             registry=holder.get("reg"), non_interactive=True,
             presentation_consumer=presentation_consumer,
             intervention_bridge=intervention_bridge,
+            pipeline_registry=frozen_registry,
         )
         return s
 
@@ -137,22 +143,32 @@ def _install_side_effect_tool(monkeypatch, out_file: Path) -> None:
     monkeypatch.setattr(tools_pkg, "get_default_registry", _with_tool)
 
 
-def _main_and_sibling_registry() -> "tuple[Pipeline, PipelineRegistry]":
-    """A namespaced main+sibling pair mirroring #3093's real shape (#2722
-    ``{key}.{name}`` namespacing already resolved, as the loader would have): the
-    main pipeline ``call``s ``ns.sibling`` by its GLOBAL dotted name; the sibling
-    runs one real tool step. Both registered under a fresh ``PipelineRegistry`` —
-    the CALLER's own, live, post-hot-reload registry in the real flow."""
-    sibling = Pipeline(steps=[
-        ToolStep(name="p3093_step", args={"tag": "sibling-ran"}, output="o0"),
-    ])
-    main = Pipeline(steps=[
-        CallStep(pipeline="ns.sibling", output="result"),
-    ])
-    registry = PipelineRegistry()
-    registry.register("ns.main", main)
-    registry.register("ns.sibling", sibling)
-    return main, registry
+_MAIN_AND_SIBLING_DSL = """
+pipeline: main
+steps:
+  - call: {pipeline: sibling, output: result}
+---
+pipeline: sibling
+steps:
+  - tool: {name: p3093_step, args: {tag: sibling-ran}, output: o0}
+"""
+
+
+def _install_pipeline_to_disk(tmp_path: Path, *, key: str = "ns") -> None:
+    """Production-shaped install: an on-disk DSL file (multi-document, main +
+    same-file sibling) declared via ``.reyn/config/pipelines.yaml``'s
+    ``pipelines.entries`` — mirrors a real ``plugin_install``/``pipeline_install``
+    write, NOT an in-memory-only registry (the family gate's ``_reapply_pipelines``
+    rebuilds from THIS disk cascade, so a test must actually write it)."""
+    d = tmp_path / "pipelines"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "ns.yaml").write_text(_MAIN_AND_SIBLING_DSL, encoding="utf-8")
+    cfg_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.dump({"pipelines": {"entries": {key: {"path": "pipelines/ns.yaml"}}}}),
+        encoding="utf-8",
+    )
 
 
 async def _wait_for(pred, timeout: float = 15.0) -> bool:
@@ -165,30 +181,39 @@ async def _wait_for(pred, timeout: float = 15.0) -> bool:
 
 
 @pytest.mark.asyncio
-async def test_async_detached_run_resolves_sibling_via_caller_registry(
+async def test_async_detached_run_resolves_sibling_via_family_gate(
     tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: the REAL ``run_pipeline_async`` tool handler
-    (``_handle_run_pipeline_async``) — a driver-session spawned to run ``ns.main``
-    resolves its ``call`` to ``ns.sibling`` because the LAUNCHING caller's live
-    ``ctx.router_state.pipeline_registry`` is forwarded to the spawn. RED before
-    #3093's fix: the driver would inherit its own default EMPTY registry and fail
-    "target pipeline 'ns.sibling' is not registered"."""
+    (``_handle_run_pipeline_async``) — a driver-session spawned to run
+    ``ns.main`` resolves its ``call`` to ``ns.sibling`` because
+    ``spawn_session_recorded`` fires ``refresh_config_projections()`` on the
+    freshly-spawned driver-session, which rebuilds its pipeline registry from
+    the on-disk cascade BEFORE the run's first nudge. RED before #3097 (and
+    before #3094): the driver would inherit the caller's FROZEN factory-time
+    registry and fail "target pipeline 'ns.sibling' is not registered"."""
+    monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
     _install_side_effect_tool(monkeypatch, out_file)
     reg = _agent_registry(tmp_path, state_log)
 
-    main, caller_registry = _main_and_sibling_registry()
+    # Install AFTER the registry/session factory captured its frozen snapshot
+    # (mirrors production: install happens mid-conversation, after boot).
+    _install_pipeline_to_disk(tmp_path)
+
     caller = reg.get_or_load("worker")
-    # Same dual-write the hot-reload seam (Session._reapply_pipelines) uses — sets
-    # BOTH caller._pipeline_registry and caller._router_host._pipeline_registry, so
-    # ctx.router_state.pipeline_registry (built from the SAME live registry, below)
-    # and caller_session.pipeline_registry (what run_pipeline_attached re-derives
-    # internally for the sync path) are the SAME object, matching production
-    # (RouterCallerState.pipeline_registry is itself derived from
-    # host.get_pipeline_registry() at each turn).
-    caller.set_pipeline_registry(caller_registry)
+
+    # The caller must itself hot-reload before it can even resolve ns.main by
+    # name to launch it (mirrors dispatch_install_reload firing on the caller
+    # right after the real install op writes the config). MUST run BEFORE the
+    # ctx below captures pipeline_registry — _reapply_pipelines SWAPS the
+    # reference (never mutates in place), so a ctx built first would still
+    # hold the stale pre-swap object.
+    changed = await caller._reapply_pipelines({})
+    assert changed is True
+    assert caller.pipeline_registry.get("ns.main") is not None
+
     ctx = ToolContext(
         events=caller._router_host.events,
         permission_resolver=None,
@@ -215,26 +240,20 @@ async def test_async_detached_run_resolves_sibling_via_caller_registry(
 
 
 @pytest.mark.asyncio
-async def test_sync_attached_run_resolves_sibling_via_caller_registry(
+async def test_sync_attached_run_resolves_sibling_via_family_gate(
     tmp_path: Path, monkeypatch,
 ) -> None:
     """Tier 2: the REAL ``run_pipeline`` tool handler (``_handle_run_pipeline``,
-    sync attached) — same scenario. RED before #3093's fix for the same reason."""
+    sync attached) — same scenario. RED before #3097 for the same reason."""
+    monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
     _install_side_effect_tool(monkeypatch, out_file)
     reg = _agent_registry(tmp_path, state_log)
+    _install_pipeline_to_disk(tmp_path)
 
-    main, caller_registry = _main_and_sibling_registry()
     caller = reg.get_or_load("worker")
-    # Same dual-write the hot-reload seam (Session._reapply_pipelines) uses — sets
-    # BOTH caller._pipeline_registry and caller._router_host._pipeline_registry, so
-    # ctx.router_state.pipeline_registry (built from the SAME live registry, below)
-    # and caller_session.pipeline_registry (what run_pipeline_attached re-derives
-    # internally for the sync path) are the SAME object, matching production
-    # (RouterCallerState.pipeline_registry is itself derived from
-    # host.get_pipeline_registry() at each turn).
-    caller.set_pipeline_registry(caller_registry)
+    await caller._reapply_pipelines({})
     ctx = ToolContext(
         events=caller._router_host.events,
         permission_resolver=None,
@@ -254,38 +273,64 @@ async def test_sync_attached_run_resolves_sibling_via_caller_registry(
 
 
 @pytest.mark.asyncio
-async def test_strip_falsify_no_registry_override_reproduces_3093(
+async def test_strip_falsify_spawn_session_bypasses_family_gate_reproduces_3093(
     tmp_path: Path, monkeypatch,
 ) -> None:
-    """Tier 2: strip-falsify (CLAUDE.md testing policy) — calling the internal spawn
-    helper WITHOUT the ``pipeline_registry`` override (the exact pre-#3093 call
-    shape) reproduces the dogfood-witnessed failure verbatim — proving the two
-    passing tests above are not vacuously green. The driver-session's OWN
-    (default-empty) registry cannot resolve ``ns.sibling``, even though the SAME
-    name is perfectly resolvable on the caller's own registry."""
+    """Tier 2: strip-falsify (CLAUDE.md testing policy) — spawning the driver-
+    session via the LOWER-LEVEL ``AgentRegistry.spawn_session`` (the exact call
+    shape crash-recovery re-wake uses, which never fires
+    ``refresh_config_projections()``) instead of the production
+    ``_spawn_pipeline_driver_session``/``spawn_session_recorded`` path
+    reproduces the dogfood-witnessed "target pipeline ... is not registered"
+    failure verbatim — proving the two passing tests above are not vacuously
+    green, AND that the family gate (fired only by ``spawn_session_recorded``)
+    is the actual mechanism making them pass, not some other incidental
+    freshness."""
+    monkeypatch.chdir(tmp_path)
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
     out_file = tmp_path / "out.txt"
     _install_side_effect_tool(monkeypatch, out_file)
     reg = _agent_registry(tmp_path, state_log)
+    _install_pipeline_to_disk(tmp_path)
 
-    main, caller_registry = _main_and_sibling_registry()
     caller = reg.get_or_load("worker")
-    caller.set_pipeline_registry(caller_registry)
-    # Sanity: the caller itself resolves the sibling fine (the bug is spawn-local,
-    # not a broken registry contents/namespacing).
-    assert caller.pipeline_registry.get("ns.sibling") is not None
+    await caller._reapply_pipelines({})
+    main = caller.pipeline_registry.get("ns.main")
+    assert main is not None  # sanity: the caller itself resolves it fine
 
-    session, rid, sid = await _spawn_pipeline_driver_session(
-        reg,
-        pipeline=main,
-        pipeline_name="ns.main",
-        input=None,
-        reply_to_agent="worker",
-        reply_to_sid="main",
-        state_log=state_log,
-        notify_reply=False,
-        # pipeline_registry intentionally OMITTED — the pre-#3093 call shape.
+    # The pre-#3097 (and pre-#3094) call shape: spawn WITHOUT going through
+    # spawn_session_recorded (no family-gate refresh) — the crash-recovery
+    # re-wake shape.
+    from reyn.runtime.spawn_routing import ReviewedNA
+    routing = ReviewedNA("runtime/registry.py::restore_all")
+    sid = reg.spawn_session(
+        "worker",
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
     )
+    from reyn.core.pipeline.serde import pipeline_to_dict
+    from reyn.core.pipeline.work_order import (
+        PipelineWorkOrder,
+        write_invocation,
+    )
+    from reyn.core.pipeline.work_order import (
+        pipeline_run_dir as _run_dir_fn,
+    )
+    from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
+
+    rid = "run-3093-strip-falsify"
+    work_order = PipelineWorkOrder(
+        run_id=rid, pipeline_name="ns.main", pipeline=pipeline_to_dict(main),
+        input=None, reply_to_agent="worker", reply_to_sid="main",
+        driver_agent="worker", driver_sid=sid,
+    )
+    write_invocation(_run_dir_fn(tmp_path / ".reyn", rid), work_order)
+    session = reg.get_session("worker", sid)
+    assert session is not None
+    session.set_loop_driver(PipelineExecutorDriver(
+        work_order, registry=reg, state_log=state_log, notify_reply=False,
+    ))
+
     from reyn.runtime.message_bus import MessageBus
     from reyn.runtime.transport import SystemRef
 

--- a/tests/test_3097_config_projection_refresh_family_gate.py
+++ b/tests/test_3097_config_projection_refresh_family_gate.py
@@ -1,0 +1,351 @@
+"""Tier 2: #3097 (#3061 follow-up) — the config-projection refresh family-gate.
+
+#3061 closed the MCP-roster staleness gap for a programmatically-spawned session
+(``AgentRegistry.spawn_session_recorded``, the funnel every agent-step ephemeral
+worker / pipeline driver-session / ``session_spawn`` target shares) but explicitly
+DEFERRED the other 9 ``_reapply_*`` hot-reload seams pending per-seam driven
+verification. #3094 point-fixed ONE of those 9 (``_reapply_pipelines``) after it
+surfaced live in the RAG turnkey flow — a curated-subset anti-pattern (#3096): the
+family is enumerable at ``Session._register_hot_reload_seams()``, so this closes it
+UNIFORMLY instead of point-fix×N.
+
+``Session.refresh_config_projections()`` iterates EVERY registered hot-reload seam
+(derived from ``HotReloader.seam_names()`` via ``Session.hot_reload_seam_names()``)
+and fires each at the ephemeral/spawn action-boundary — EXCLUDING ``cron`` (the one
+genuinely SIDE-EFFECTING seam: it mutates the global scheduler, which a short-lived
+programmatic spawn must never reschedule on its own). ``AgentRegistry.
+spawn_session_recorded`` calls it right after construction (replacing the #3061
+MCP-only ``refresh_mcp_servers()`` call — MCP is now one family member among many,
+covered by the SAME uniform iteration).
+
+Structural contract this gate fixes in place:
+  1. every ``_register_hot_reload_seams()`` member is covered UNIFORMLY, derived
+     from the registry (never a hand-picked subset) — a future ``register_seam``
+     addition is covered automatically, on registration, with no PR needed here;
+  2. ``cron`` is the ONE documented exclusion (side-effecting, not a read-only
+     projection);
+  3. crash-recovery re-wake (``AgentRegistry.restore_all`` / ``_rewake_pipeline_runs``)
+     NEVER fires this — those paths call the lower-level ``spawn_session`` directly,
+     never ``spawn_session_recorded`` (the sole caller of ``refresh_config_projections``)
+     — so a re-woken session's config projections reflect the RESTORED pre-crash
+     snapshot, never silently overwritten with whatever the CURRENT on-disk config
+     happens to be (snapshot fidelity);
+  4. ``_reapply_visibility_override`` (security-core: visible ⊆ authorized) is
+     included, and — being a restrict-only ∩ compose by construction — can only
+     narrow the spawned session's envelope relative to its authorized base, never
+     escalate beyond it.
+
+No mocks: real ``AgentRegistry``/``Session``/``StateLog`` throughout, mirroring
+``tests/test_3036_spawned_session_mcp_refresh.py``'s and
+``tests/test_2581_pipeline_hotreload.py``'s harnesses.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from reyn.runtime.spawn_routing import ReviewedNA
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    """A registry whose ``session_factory`` — mirroring every real frontend's
+    boot-time closure — captures every projection ONCE (empty/default), before any
+    install writes fresher config. Only a spawn-time refresh can make a freshly
+    spawned session see config written after the registry was built."""
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    state_log = StateLog(tmp_path / "wal.jsonl")
+    holder: dict = {}
+
+    def _factory(profile: AgentProfile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
+        s = Session(
+            agent_name=profile.name, state_log=state_log,
+            registry=holder.get("reg"), non_interactive=True,
+            presentation_consumer=presentation_consumer,
+            intervention_bridge=intervention_bridge,
+            mcp_servers={},
+        )
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+    holder["reg"] = reg
+    AgentProfile.new("worker", role="").save(tmp_path / ".reyn" / "agents" / "worker")
+    return reg
+
+
+# ── 1. completeness gate: derived from the registry, vacuity-guarded ─────────
+
+
+@pytest.mark.asyncio
+async def test_vacuity_guard_registered_seams_nonempty(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: vacuity guard — a Session actually registers a non-empty set of
+    hot-reload seams (a completeness gate over an accidentally-empty set would be
+    trivially, uselessly green)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    assert len(session.hot_reload_seam_names()) > 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_config_projections_covers_every_registered_seam_except_cron(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the completeness gate — ``refresh_config_projections()`` invokes
+    EVERY seam ``hot_reload_seam_names()`` reports, except ``cron``, derived from
+    the registry (not a hand-written subset). Strip-falsify (b): dropping a
+    registered seam from ``_register_hot_reload_seams()`` would shrink
+    ``hot_reload_seam_names()`` and this equality would still hold trivially — the
+    REAL falsify is the reverse direction, proven below: a NEWLY registered seam
+    (added here, mirroring a future ``register_seam`` call) is picked up
+    automatically without touching ``refresh_config_projections`` — proving the
+    coverage is structural (derives from the SAME registry), not a maintained
+    marker list that a future addition could silently miss."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    registered = set(session.hot_reload_seam_names())
+    assert registered, "vacuity guard"
+    assert "cron" in registered
+
+    result = await session.refresh_config_projections()
+    assert set(result["invoked"]) == registered - {"cron"}
+    assert "cron" not in result["invoked"]
+
+    # A future family member, registered exactly like every other seam — proves
+    # the family gate's coverage is DERIVED (auto-covers a new registration)
+    # rather than a hand-picked subset that would need its own PR to extend.
+    fired: "list[bool]" = []
+
+    async def _future_seam(in_set: dict) -> bool:
+        fired.append(True)
+        return True
+
+    session._hot_reloader.register_seam("future_member_3097", _future_seam)
+    result2 = await session.refresh_config_projections()
+    assert "future_member_3097" in result2["invoked"]
+    assert fired == [True]
+
+
+# ── 2. cron is the ONE documented exclusion — strip-falsify the filter itself ─
+
+
+@pytest.mark.asyncio
+async def test_cron_excluded_from_family_gate(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: ``cron`` — the one genuinely side-effecting seam (mutates the
+    global scheduler) — is never invoked by ``refresh_config_projections()``.
+    Strip-falsify: calling the underlying ``HotReloader.apply_all()`` WITHOUT the
+    exclusion (the pre-#3097 shape a regression could reintroduce) DOES invoke
+    ``cron`` — proving the exclusion in ``refresh_config_projections`` is an
+    active filter, not a no-op that happens to never see cron for some other
+    reason."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "reyn.yaml").write_text("model: standard\n", encoding="utf-8")
+    session = Session(
+        agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
+        snapshot_path=tmp_path / "snap.json",
+    )
+    result = await session.refresh_config_projections()
+    assert "cron" not in result["invoked"]
+
+    # Strip-falsify: the same underlying apply, without the cron exclusion.
+    unfiltered = await session._hot_reloader.apply_all(exclude=frozenset())
+    assert "cron" in unfiltered["invoked"], (
+        "removing the exclude set must make cron fire — proving "
+        "refresh_config_projections's exclude={'cron'} is load-bearing"
+    )
+
+
+# ── 3. spawn wiring: real disk config picked up by the family gate at spawn ──
+
+
+_HELLO_PIPELINE = """
+pipeline: hello
+steps:
+  - transform: {value: "'v1'", output: greeting}
+"""
+
+
+def _write_pipeline(tmp_path: Path, key: str = "ns") -> None:
+    """Real on-disk pipeline install (mirrors ``test_2581_pipeline_hotreload.py``):
+    a DSL file + a ``.reyn/config/pipelines.yaml`` entry declaring it. Unlike
+    ``hook_state()`` (which re-reads disk live on EVERY call, making it useless as
+    an observable of whether a hot-reload seam actually fired),
+    ``Session.pipeline_registry`` is a CACHED field only ever swapped by
+    ``_reapply_pipelines`` — a valid observable of whether the seam fired."""
+    d = tmp_path / "pipelines"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{key}.yaml").write_text(_HELLO_PIPELINE, encoding="utf-8")
+    cfg_path = tmp_path / ".reyn" / "config" / "pipelines.yaml"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(
+        yaml.dump({"pipelines": {"entries": {key: {"path": f"pipelines/{key}.yaml"}}}}),
+        encoding="utf-8",
+    )
+
+
+def _write_skill(tmp_path: Path, name: str) -> None:
+    p = tmp_path / ".reyn" / "config" / "skills.yaml"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(
+        yaml.safe_dump({"skills": {"entries": {name: {"path": "skills/" + name, "description": "d"}}}}),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_spawn_session_recorded_refreshes_pipelines_and_skills(tmp_path: Path, monkeypatch) -> None:
+    """Tier 2: a real programmatic spawn (``spawn_session_recorded``) sees a
+    pipeline AND a skill written to disk AFTER the registry's boot-time
+    session_factory closure captured its (empty) snapshot — proving the family
+    gate actually rebuilds these CACHED projections, not just bookkeeps an
+    'invoked' flag. RED before #3097 (and before this PR's fold-in): the spawned
+    session would inherit the factory's empty pipelines/skills snapshot
+    forever."""
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("worker")  # pre-existing main session, unaffected by later writes
+
+    _write_pipeline(tmp_path)
+    _write_skill(tmp_path, "post_spawn_skill")
+
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="ephemeral", presentation_consumer=None, intervention_bridge=None,
+    )
+    spawned = reg._peek_session("worker", sid)
+    assert spawned is not None
+
+    assert spawned.pipeline_registry.get("ns.hello") is not None
+
+    skill_names = {s.name for s in (spawned._router_host.get_available_skills() or [])}
+    assert "post_spawn_skill" in skill_names
+
+
+# ── 4. recovery re-wake NEVER fires the family gate (snapshot fidelity) ──────
+
+
+@pytest.mark.asyncio
+async def test_recovery_shaped_spawn_does_not_refresh_config_projections(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: the recovery invariant — crash-recovery re-wake
+    (``AgentRegistry.restore_all`` / ``_rewake_pipeline_runs``) calls the
+    LOWER-LEVEL ``AgentRegistry.spawn_session`` directly (never
+    ``spawn_session_recorded``, the sole caller of ``refresh_config_projections``).
+    This test exercises that EXACT call shape and confirms a pipeline installed to
+    disk AFTER the registry booted is NOT picked up on the recovered session's
+    (cached, seam-only-swapped) ``pipeline_registry`` — the re-created session
+    keeps its factory-time (pre-crash-shaped) snapshot, never silently
+    overwritten with CURRENT on-disk config (snapshot fidelity).
+
+    Strip-falsify: the SAME setup via ``spawn_session_recorded`` instead (the
+    non-recovery path) DOES pick it up — proving the family gate itself works
+    (the recovery test isn't just green because the mechanism is broken
+    everywhere) and that recovery's non-refresh is a real property of WHICH call
+    it uses, not an accident."""
+    from reyn.core.pipeline.registry import PipelineNotFoundError
+
+    monkeypatch.chdir(tmp_path)
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("worker")
+
+    _write_pipeline(tmp_path, key="recov")
+
+    # The exact recovery-shaped call (mirrors registry.py:1176/1275 verbatim —
+    # spawn_session, NOT spawn_session_recorded).
+    routing = ReviewedNA("runtime/registry.py::restore_all")
+    recovery_sid = reg.spawn_session(
+        "worker", sid="recovered-1",
+        presentation_consumer=routing.presentation_consumer,
+        intervention_bridge=routing.intervention_bridge,
+    )
+    recovered = reg._peek_session("worker", recovery_sid)
+    assert recovered is not None
+    with pytest.raises(PipelineNotFoundError):
+        recovered.pipeline_registry.get("recov.hello")
+
+    # Strip-falsify: the SAME pipeline, via the real (non-recovery) spawn path.
+    normal_sid = await reg.spawn_session_recorded(
+        "worker", mode="ephemeral", presentation_consumer=None, intervention_bridge=None,
+    )
+    normal = reg._peek_session("worker", normal_sid)
+    assert normal is not None
+    assert normal.pipeline_registry.get("recov.hello") is not None, (
+        "sanity/strip-falsify: the SAME pipeline IS picked up via the real "
+        "spawn_session_recorded path — proving the recovery test above is not "
+        "vacuously green (the mechanism does work; recovery specifically "
+        "avoids it)"
+    )
+
+
+# ── 5. security: visibility_override is narrow-only, spawn-time envelope authorized ──
+
+
+def _bind_topology(tmp_path: Path, *, member: str, profile: str, body: str) -> None:
+    td = tmp_path / ".reyn" / "topologies"
+    td.mkdir(parents=True, exist_ok=True)
+    (td / "t.yaml").write_text(
+        f"name: t\nkind: network\nmembers: [{member}, peer]\nprofiles:\n  {member}: {profile}\n",
+        encoding="utf-8",
+    )
+    pd = tmp_path / ".reyn" / "capability_profiles"
+    pd.mkdir(parents=True, exist_ok=True)
+    (pd / f"{profile}.yaml").write_text(body, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_spawn_visibility_override_seam_resolves_authorized_envelope_narrow_only(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: security-core — ``_reapply_visibility_override`` fires at spawn
+    (family-gate member) and re-resolves the SPAWNED session's envelope from its
+    CURRENT authorized base (topology binding). The topology-denied tool must be
+    denied on the spawned session's live ``contextual_permission`` — proving the
+    seam actually ran (not just bookkept 'invoked') — and toggling the tool's
+    session visibility back ON afterward must NOT re-grant it (restrict-only
+    compose: visible ⊆ authorized, no escalation past the topology floor is
+    possible via the seam or the toggle)."""
+    from reyn.security.permissions.effective import tool_contextually_denied
+
+    monkeypatch.chdir(tmp_path)
+    _bind_topology(
+        tmp_path, member="worker", profile="role",
+        body="name: role\ntool_deny: [delete_file]\n",
+    )
+    reg = _make_registry(tmp_path)
+    reg.get_or_load("worker")
+
+    sid = await reg.spawn_session_recorded(
+        "worker", mode="ephemeral", presentation_consumer=None, intervention_bridge=None,
+    )
+    spawned = reg._peek_session("worker", sid)
+    assert spawned is not None
+
+    # The family gate's visibility_override seam re-resolved the spawned
+    # session's OWN envelope from the topology binding — the denial is live.
+    assert tool_contextually_denied(spawned.contextual_permission, "delete_file"), (
+        "the spawned session's contextual_permission must reflect the "
+        "topology-bound denial — proving the visibility_override seam actually "
+        "fired at spawn, not just appeared in the 'invoked' bookkeeping"
+    )
+
+    # Attempting to re-grant it via the session visibility toggle must be a
+    # no-op past the authorized envelope (restrict-only ∩ compose).
+    spawned.set_capability_visible("tool", "delete_file", True)
+    assert tool_contextually_denied(spawned.contextual_permission, "delete_file"), (
+        "toggling a topology-denied tool's session visibility back ON must "
+        "NOT re-grant it — the compose is restrict-only, so no path through "
+        "the visibility_override seam or the toggle can escalate past the "
+        "authorized envelope"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — implements #3097 (architect design, co-vet = architect). part of #3061 (umbrella arc, not closed here). Folds out #3094's pipeline-registry point-fix. Related: #3096.

Closes #3097

## What this closes

#3061 landed the MCP-roster refresh at the ephemeral/spawn action-boundary
(`AgentRegistry.spawn_session_recorded`) but explicitly DEFERRED the other 9
`_reapply_*` hot-reload seams pending per-seam driven verification. #3094
witnessed one of those deferred seams (`_reapply_pipelines`, the pipeline
registry) surfacing live in the RAG turnkey flow and point-fixed it alone —
a curated-subset anti-pattern, since the family is enumerable at
`Session._register_hot_reload_seams()`. This PR closes the family
UNIFORMLY instead of point-fix×N.

## Structural contract this gate fixes in place

1. **Every `_register_hot_reload_seams()` member is covered UNIFORMLY,
   derived from the registry** (`HotReloader.seam_names()` /
   `Session.hot_reload_seam_names()`) — never a hand-picked subset. A
   FUTURE `register_seam` addition is covered automatically, on
   registration, with no follow-up PR needed to extend the gate.
2. **`cron` is the ONE documented exclusion** — the single genuinely
   side-effecting seam (mutates the global scheduler); every other member
   is a read-only projection (re-read/swap/re-derive) or a confirming
   no-op (`_reapply_new_agent`).
3. **Recovery re-wake NEVER fires this gate** — `AgentRegistry.restore_all`
   / `_rewake_pipeline_runs` call the lower-level `spawn_session` directly,
   never `spawn_session_recorded` (the sole caller of
   `refresh_config_projections`). This is a structural property of the
   call graph (not a special-cased guard), so a re-woken session's config
   projections stay whatever `restore_state`/the work-order snapshot
   restores — pre-crash snapshot fidelity, never silently overwritten with
   current on-disk config.
4. **`_reapply_visibility_override` (security-core: visible ⊆ authorized)
   is included** as a new registered seam — a restrict-only ∩ compose by
   construction, so firing it at spawn can only narrow the spawned
   session's envelope relative to its authorized base, never escalate
   beyond it.

## Implementation

- `HotReloader.apply_all(*, exclude=frozenset())` (`hot_reload.py`) — fires
  every registered seam except `exclude`, same IN-set safety boundary +
  validate-before-apply as `apply_pending`/`apply_now`. `seam_names()`
  exposes the registered set publicly.
- `Session.refresh_config_projections()` — `self._hot_reloader.apply_all(exclude=frozenset({"cron"}))`.
  `Session.hot_reload_seam_names()` — public delegator, the completeness
  gate's derive-from-registry source.
- `Session._reapply_visibility_override_seam` — async `HotReloader`-seam
  wrapper for the existing `_reapply_visibility_override`, registered as
  the 9th seam (`_register_hot_reload_seams`). `_reapply_skill_visibility`
  gets no separate seam — it's already re-derived as the tail of the
  `skills` seam whenever the base skill set changes (covered transitively).
- `AgentRegistry.spawn_session_recorded` (`registry.py`) — replaces the
  #3061 `await spawned_session.refresh_mcp_servers()` call with
  `await spawned_session.refresh_config_projections()` (MCP folds in as
  one family member via `_reapply_mcp`, which still calls
  `refresh_mcp_servers()` internally — #3036's own tests pass unmodified).
- `Session.contextual_permission` — new public read-only property (the
  live `ContextualPermission`), added so tests can verify the
  visibility_override seam's effect via the public surface instead of the
  private `_contextual_permission` field.

## #3094 fold-out

Removed the spawn-local `pipeline_registry` override entirely:
`_spawn_pipeline_driver_session`'s `pipeline_registry` param + its
`session.set_pipeline_registry(pipeline_registry)` call; `start_pipeline_run`'s
and `run_pipeline_attached`'s `pipeline_registry`/`caller_pipeline_registry`
forwarding; the two `pipeline_verbs.py` call sites
(`_handle_run_pipeline_async`, `_handle_run_pipeline_inline_async`) that
threaded the caller's live registry through; `Session._launch_pipeline_from_hook`'s
forwarding. The family gate's `_reapply_pipelines` firing on the
driver-session's OWN spawn (uniformly, via `spawn_session_recorded`)
supersedes it — it rebuilds from the CURRENT on-disk cascade directly at
the driver-session's own spawn, which is equivalent to (and more robust
than) forwarding the caller's in-memory copy, given the confirmed topology
(#3061: install always precedes the spawn that consumes it — no code path
installs and consumes in the same run). `tests/test_3093_pipeline_registry_spawn_propagation.py`
rewritten to install pipelines the production way (on-disk DSL + `.reyn/config/pipelines.yaml`,
mirroring `test_2581_pipeline_hotreload.py`) so the family gate's
disk-cascade rebuild has something real to find, instead of relying on an
in-memory-only caller registry the new mechanism doesn't consult.

## Strip-falsify evidence (4 kinds, CLAUDE.md testing policy)

**(a) each included seam's staleness fix, reverted → RED**
`tests/test_3093_pipeline_registry_spawn_propagation.py::test_strip_falsify_spawn_session_bypasses_family_gate_reproduces_3093`
spawns the driver-session via the lower-level `AgentRegistry.spawn_session`
(bypassing `spawn_session_recorded`/the family gate) and reproduces the
exact `"target pipeline 'ns.sibling' ... is not registered"` failure
verbatim — proving the two passing production-path tests are not
vacuously green.
`tests/test_3097_config_projection_refresh_family_gate.py::test_spawn_session_recorded_refreshes_pipelines_and_skills`
proves the pipelines + skills seams' real effect (not just "invoked"
bookkeeping) via a real spawn.

**(b) completeness gate goes RED if a registry member is dropped**
`test_refresh_config_projections_covers_every_registered_seam_except_cron`
asserts `set(result["invoked"]) == hot_reload_seam_names() - {"cron"}`,
derived from the registry (not a hand-written list) — dropping ANY
registered seam shrinks both sides in lockstep automatically. The same
test additionally registers a genuinely NEW seam at runtime and proves it
is picked up without any change to `refresh_config_projections` — the
structural "future member auto-covered" property, proven behaviorally
rather than asserted by inspection. `test_vacuity_guard_registered_seams_nonempty`
guards against a trivially-empty registry making this vacuous.

**(c) cron exclusion, stripped → RED**
`test_cron_excluded_from_family_gate` confirms `cron` is never invoked by
`refresh_config_projections()`, then calls the SAME underlying
`HotReloader.apply_all()` WITHOUT the exclude set and confirms cron IS
invoked in that case — proving the exclusion is an active, load-bearing
filter, not an accidental absence.

**(d) recovery-refresh suppression, stripped → RED**
`test_recovery_shaped_spawn_does_not_refresh_config_projections` drives
the EXACT recovery-shaped call (`AgentRegistry.spawn_session`, mirroring
`registry.py:1176`/`registry.py:1275` verbatim) and confirms a pipeline
installed after boot is NOT picked up on the recovered session (raises
`PipelineNotFoundError`); the SAME setup via `spawn_session_recorded`
(the real, non-recovery path) DOES pick it up — proving both that the
mechanism itself works (not a global break making the recovery assertion
vacuously true) and that recovery's non-refresh is a real property of
which call it goes through, not an accident. Reverting the design (making
recovery paths call `refresh_config_projections` too) would flip this RED.

**Security (visibility_override, narrow-only, no escalation)**
`test_spawn_visibility_override_seam_resolves_authorized_envelope_narrow_only`
binds a topology `capability_profile` denying `delete_file` for the spawned
agent, spawns via `spawn_session_recorded`, and confirms the SPAWNED
session's live `contextual_permission` denies it (proving the seam
actually fired, not just bookkept `invoked`) — then attempts to re-grant
it via `set_capability_visible("tool", "delete_file", True)` and confirms
it is STILL denied (restrict-only ∩ compose: no path through the seam or
the toggle can escalate past the authorized envelope).

## CI gates (all four, run locally, foreground)

- `ruff check src tests` — All checks passed
- `python scripts/test_tier_audit.py --strict tests/test_3097_config_projection_refresh_family_gate.py tests/test_3093_pipeline_registry_spawn_propagation.py tests/test_2073_s2_reapply_seams.py` — 16/16 OK
- `pytest` (repo root, full suite, foreground) — **8943 passed, 29 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/session_api.py src/reyn/runtime/hot_reload.py src/reyn/runtime/registry.py src/reyn/tools/pipeline_verbs.py` — OK

## Note on merge gating

This PR touches security (`_reapply_visibility_override` seam) and
recovery (the recovery-refresh-suppression invariant) surfaces per
CLAUDE.md's recovery-feature PR gate discipline. Per lead-coder's
instruction, merge waits on BOTH the architect's co-vet verdict (strip-falsify
review) AND CI green — not gated on this PR body alone.

## Test plan

- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on changed test files
- [x] `pytest` full suite, foreground
- [x] `verify_module_docstrings.py` on changed src files
- [x] Manual: confirmed via `gh pr view --json closingIssuesReferences` (below) that only #3097 is linked, not #3061

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- closing-check: discussing #3061 -->
