### PR TITLE
fix: consume the canonical error signal in on_error, fold out #3098's interim schema gate

### DIFF
--- a/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
@@ -472,18 +472,23 @@ steps:
   - transform:
       value: "map(ctx.file_extensions, e -> ctx.input_path + '/**/*.' + e) + [ctx.input_path]"
       output: file_patterns
-  # #3095: `schema: PreflightCheck` (same status=="ok" gate X1 above already
-  # uses per MCP server) is what makes the `on_error: abort` above actually
-  # FIRE. Without it, a `tool:` step never raises on a tool-level failure
-  # (only a real transport/dispatch exception does) -- a `glob_files` call
-  # that hits `status: "denied"` (e.g. no file.read permission granted yet
-  # for `input_path`, the common case when it names a folder outside the
-  # reyn project root) returned NORMALLY with an error-shaped payload, so
-  # `on_error: abort` never engaged: the failed item flowed on as an
-  # ordinary "success" into the `fold` below, which assumes every item's
-  # `.structured` is a list -- and broke several steps downstream of the
-  # real failure with an opaque `list + dict` arithmetic error instead of a
-  # clean, decision-enabling "input_path is not readable" abort here.
+  # #3095/#3099 corrective (a): the `on_error: abort` below FIRES on a
+  # `glob_files` failure without any `schema:` gate. #3098 landed an interim
+  # `schema: PreflightCheck` here (a non-"ok" status fails validation and
+  # raises) because at the time the executor's `for_each`/`parallel`
+  # on_error trigger was raise-only -- a `tool:` step's own op-level failure
+  # (e.g. `glob_files` hitting `status: "denied"`, no file.read permission
+  # yet for `input_path`, the common case when it names a folder outside the
+  # reyn project root) returns NORMALLY (`execute_op` degrades it to a
+  # status-carrying dict, by design, rather than raising), so `on_error`
+  # never saw it. #3099 corrective (a) closed that at the SOURCE: the
+  # executor's fan-out coordinator now also trips `on_error` on a `tool:`
+  # step's CANONICAL error result (`meta.isError`, the SAME FP-0056 v2
+  # shared-error-seam signal a handle-inline step already branches on
+  # below -- see `meta.isError` further down this file), not just a raised
+  # exception. The per-call `schema: PreflightCheck` gate is therefore
+  # redundant here and removed -- point-fix + the now-general mechanism
+  # would otherwise coexist (owner no-debt ruling).
   - for_each:
       over: ctx.file_patterns
       max_parallel: 4
@@ -491,7 +496,6 @@ steps:
       do:
         tool:
           name: glob_files
-          schema: PreflightCheck
           args:
             pattern: !expr item
             # EXPLICIT, load-bearing: glob_files defaults to 50 and truncates
@@ -505,9 +509,10 @@ steps:
   # glob's real list of paths (#2994); before that it was newline-joined
   # text, which R1 (no `split`) could not consume at all -- the reason this
   # step had to be a python shell-out. Every item reaching here is now
-  # GUARANTEED `status: "ok"` (the `schema: PreflightCheck` gate above
-  # aborts the step on anything else), so `.structured` is guaranteed a
-  # list -- `acc + item.structured` can no longer see a dict.
+  # GUARANTEED `status: "ok"` (the `for_each: on_error: abort` above now
+  # fires on a canonical-error result too -- #3099 corrective (a) -- so a
+  # failed glob never survives to be collected), so `.structured` is
+  # guaranteed a list -- `acc + item.structured` can no longer see a dict.
   - fold:
       over: ctx.globbed
       init: "[]"

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -625,6 +625,55 @@ def _parse_on_error(raw: str) -> "_OnError":
     )
 
 
+def _tool_step_canonical_error(step: "Step", result: Any) -> "str | None":
+    """#3099 corrective (a): the ``on_error`` trigger for a fan-out ``do``/branch
+    (:func:`_run_item` / :func:`_run_branch` below) was raise-only — an
+    ``execute_op`` degrade (``PermissionError`` → ``status:"denied"``, or any other
+    op-level failure) never raises (``op_runtime/__init__.py``'s ``execute_op``
+    catches it BY DESIGN: "this function never raises for op-level failures"), so
+    it returned NORMALLY with an error-shaped payload and a declared
+    ``on_error: abort``/``continue``/``retry(n)`` silently never engaged (#3095's
+    root: the ``fold`` after ``for_each`` assumed every surviving item's
+    ``.structured`` was a list, and broke opaquely several steps downstream of the
+    real cause).
+
+    This closes that gap by consuming the ALREADY-COMPUTED canonical error signal
+    — not inventing a new field (FP-0056 v2's shared error seam, whose SSoT
+    predicate is ``reyn.core.offload.canonical._is_error``/``is_error_result``,
+    already runs on every ``tool:`` step's raw result inside
+    ``_run_tool_step``/``to_canonical`` and surfaces as ``meta.isError`` on the
+    ``ctx_result`` this function receives — the SAME field a handle-inline step
+    already branches on, e.g. ``rag_ingest.yaml``'s
+    ``get(ctx.converted, 'meta.isError', false)``). Reading ``meta.isError`` here
+    is reading that seam's output, not re-deriving it — ``_run_tool_step`` already
+    converted the raw dispatch result via ``to_canonical``/``canonical_to_ctx_fields``
+    before a fan-out coordinator ever sees it, so the raw ``status``/``isError``
+    keys are gone by this point; ``meta.isError`` is what survives the transform.
+
+    Returns the tool's own error message (from ``ctx_result["text"]``, which
+    ``error_to_canonical`` guarantees non-empty) when ``step`` is a :class:`ToolStep`
+    AND its result is canonical-error-flagged, else ``None`` (no trigger).
+
+    Scoped to :class:`ToolStep` ONLY: every other step kind (``transform``/
+    ``agent``/``call``/nested ``for_each``/``parallel``) already raises its OWN
+    :class:`PipelineExecutionError` (or propagates one) on failure through the
+    ordinary ``except Exception`` clause below — they never reach here with a
+    "normal return that is secretly a failure". Widening this predicate past
+    ``ToolStep`` would risk false-positiving on a legitimate ``isError``-named DATA
+    field some other step computed on purpose (the same over-match hazard
+    ``is_error_result``'s own docstring warns about) — canonicalize a NEW
+    non-conforming producer instead of widening this check (#3099 census note)."""
+    if not isinstance(step, ToolStep):
+        return None
+    if not isinstance(result, dict):
+        return None
+    meta = result.get("meta")
+    if isinstance(meta, dict) and meta.get("isError"):
+        text = result.get("text")
+        return str(text) if text else "tool step returned a canonical error result"
+    return None
+
+
 def _is_dropped_marker(value: Any) -> bool:
     """True iff ``value`` is a fan-out DROPPED kind-marker (exact 2-key set
     ``{_FAN_OUT_DROPPED_KEY, 'error'}``) — the ONE shared predicate the collect
@@ -1248,6 +1297,18 @@ async def _run_for_each_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
             )
             try:
                 result, durable, _ = await runner(do_inv)
+                canonical_error = _tool_step_canonical_error(step.do, result)
+                if canonical_error is not None:
+                    # #3099 corrective (a): a normal return that is secretly a
+                    # canonical-error result trips on_error exactly like a raised
+                    # exception (retry(n) re-runs it below, same as any other
+                    # item failure).
+                    last_exc = PipelineExecutionError(
+                        f"step {label}.for_each.{item_idx} (tool "
+                        f"{step.do.name!r}) returned a canonical error result: "
+                        f"{canonical_error}"
+                    )
+                    continue
                 return item_idx, result, durable, None
             except Exception as exc:  # noqa: BLE001 - item-failure boundary (on_error policy)
                 last_exc = exc
@@ -1435,6 +1496,18 @@ async def _run_parallel_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[s
             )
             try:
                 result, durable, _ = await runner(branch_inv)
+                canonical_error = _tool_step_canonical_error(branch_step, result)
+                if canonical_error is not None:
+                    # #3099 corrective (a): see the matching comment in
+                    # _run_item above — a normal return that is secretly a
+                    # canonical-error result trips on_error exactly like a
+                    # raised exception.
+                    last_exc = PipelineExecutionError(
+                        f"step {label}.parallel.{name} (tool "
+                        f"{branch_step.name!r}) returned a canonical error "
+                        f"result: {canonical_error}"
+                    )
+                    continue
                 return name, result, durable, None
             except Exception as exc:  # noqa: BLE001 - branch-failure boundary (on_error policy)
                 last_exc = exc

--- a/tests/test_3099_on_error_canonical_seam.py
+++ b/tests/test_3099_on_error_canonical_seam.py
@@ -1,0 +1,224 @@
+"""Tier 2: OS invariant — #3099 corrective (a): a `for_each`/`parallel`
+`on_error` trigger fires on a `tool:` step's CANONICAL error result
+(`meta.isError`), not just a raised exception.
+
+Background (#3096/#3098/#3099): `execute_op` (op_runtime's shared chokepoint)
+NEVER raises for an op-level failure by design — a `PermissionError` degrades
+to `{status:"denied", error:...}`, any other exception to
+`{status:"error", error:...}` (`reyn/core/op_runtime/__init__.py`). Before
+this fix, `_run_item`/`_run_branch` (the `for_each`/`parallel` fan-out
+coordinators in `reyn/core/pipeline/executor.py`) only tripped `on_error` on a
+RAISED exception — a `tool:` step that returned one of these degraded results
+NORMALLY (no exception) sailed through as an ordinary "success", so a
+declared `on_error: abort`/`continue`/`retry(n)` never engaged (#3095's root:
+`rag_ingest.yaml`'s `glob_files` for_each flowed a permission-denied item into
+a `fold` that assumed every item's `.structured` was a list, and broke with an
+opaque `list + dict` TypeError several steps downstream of the real cause).
+#3098 landed an interim per-call-site `schema: PreflightCheck` gate to force a
+raise; this corrective closes it at the SOURCE instead — the executor now ALSO
+consumes the tool result's own canonical error signal.
+
+That signal is NOT new: FP-0056 v2's shared error seam
+(`reyn.core.offload.canonical.is_error_result`/`_is_error`) already computes
+it for every `tool:` step's raw dispatch result inside `_run_tool_step`
+(`to_canonical`), and surfaces it as `meta.isError` on the `ctx_result` a
+fan-out coordinator receives (`_run_tool_step`'s return value is the
+CONVERTED ctx-shaped dict, not the raw envelope — `status`/`isError` no
+longer exist at the top level by the time `_run_item`/`_run_branch` see it;
+`meta.isError` is what survives the conversion). This is the SAME field a
+handle-inline pipeline step already branches on manually
+(`rag_ingest.yaml`: `get(ctx.converted, 'meta.isError', false)`) — the fix
+makes a DECLARED `on_error` consume it automatically too, without inventing
+any new field (`reyn.core.pipeline.executor._tool_step_canonical_error`).
+
+Real production `to_canonical`/`error_to_canonical`/`file_to_canonical`
+throughout (no mocks) — a dispatch result carrying a genuine
+`_canonical_source: "file"` tag with a `status: "denied"` + `error` shape
+(the EXACT shape `execute_op`'s own `PermissionError` handler produces, and
+the EXACT shape #3098's real end-to-end `glob_files`-against-an-unpermitted-
+folder test (`tests/test_fp0063_p3_rag_pipelines.py::
+test_ingest_file_discovery_aborts_clean_on_unreadable_input_path`) exercises
+through the real op_runtime chokepoint) drives every test here — no invented
+result shape.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+# Import the real op_runtime `file` module so its canonical declaration
+# (`file_to_canonical`) is registered — the same registration every real
+# `glob_files`/`read_file`/... call goes through in production.
+import reyn.core.op_runtime.file  # noqa: F401
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    ForEachStep,
+    ParallelStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+
+
+def _denied_file_result(pattern: str) -> dict:
+    """The REAL shape `execute_op`'s `PermissionError` handler produces for a
+    genuinely-registered `file`-kind op (`status: "denied"`, NOT `"error"` —
+    the exact shape a real `glob_files` permission-denial takes, per
+    `reyn/core/op_runtime/__init__.py`'s `except PermissionError` branch)."""
+    return {
+        "_canonical_source": "file",
+        "kind": "file",
+        "op": "glob",
+        "status": "denied",
+        "error": f"not permitted: {pattern}",
+    }
+
+
+# ── for_each: on_error now fires on a canonical-error NON-raising result ────
+
+
+@pytest.mark.asyncio
+async def test_for_each_on_error_abort_fires_on_canonical_error_without_raising():
+    """Tier 2: a `tool:` step that returns NORMALLY (no exception) but carries
+    a canonical error result (`meta.isError` — the real `file`-op permission-
+    denied shape) trips `on_error: abort` exactly like a raised exception
+    would."""
+    def _dispatch(name: str, args: dict) -> Any:
+        assert name == "glob_files"
+        pattern = args["pattern"]
+        if pattern == "bad/**":
+            return _denied_file_result(pattern)
+        return {"ok": True}
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["good/**", "bad/**"],
+            on_error="abort",
+            do=ToolStep(name="glob_files", args={"pattern": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError, match="canonical error"):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-3099-fe-abort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_for_each_on_error_continue_drops_canonical_error_item():
+    """Tier 2: `on_error: continue` DROPS a canonical-error item the same way
+    it drops a raised-exception item (a kind-marker, collect sees survivors
+    only) — the trigger widening does not change the on_error POLICY
+    semantics, only what counts as a failure."""
+    def _dispatch(name: str, args: dict) -> Any:
+        pattern = args["pattern"]
+        if pattern == "bad/**":
+            return _denied_file_result(pattern)
+        return {"ok": True}
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["good/**", "bad/**"],
+            on_error="continue",
+            do=ToolStep(name="glob_files", args={"pattern": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-3099-fe-continue",
+    )
+    assert result.pipe_data == [{"text": "", "structured": {"ok": True}}]
+    dropped = result.completed_step_results["0.for_each.1"]
+    assert dropped["__fan_out_dropped__"] is True
+    assert "not permitted" in dropped["error"]
+
+
+# ── parallel: same trigger widening over NAMED branches ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_parallel_on_error_abort_fires_on_canonical_error_without_raising():
+    """Tier 2: the `parallel` fan-out coordinator (`_run_branch`) gets the
+    SAME canonical-error trigger as `for_each`'s `_run_item` — a branch that
+    returns a canonical-error result normally trips `on_error: abort`."""
+    def _dispatch(name: str, args: dict) -> Any:
+        if args["pattern"] == "bad/**":
+            return _denied_file_result(args["pattern"])
+        return {"ok": True}
+
+    pipeline = Pipeline(steps=[
+        ParallelStep(
+            on_error="abort",
+            branches={
+                "good": ToolStep(name="glob_files", args={"pattern": "good/**"}),
+                "bad": ToolStep(name="glob_files", args={"pattern": "bad/**"}),
+            },
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError, match="canonical error"):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-3099-par-abort",
+        )
+
+
+# ── handle-inline preserved: a step WITHOUT on_error is unaffected ──────────
+
+
+@pytest.mark.asyncio
+async def test_plain_tool_step_without_on_error_still_surfaces_meta_iserror_inline():
+    """Tier 2: a step that does NOT sit inside a `for_each`/`parallel`
+    `on_error` (i.e. an ordinary top-level `tool:` step, the handle-inline
+    pattern rag_ingest.yaml's `mcp_convert`/`meta.isError` branch relies on)
+    is COMPLETELY UNAFFECTED by this fix — it still returns its
+    `meta.isError`-flagged ctx dict NORMALLY, with no raise/abort, so a later
+    step can branch on it itself. #3099 corrective (a) only widens the
+    trigger INSIDE a DECLARED for_each/parallel on_error; it must not turn a
+    plain tool step into an auto-aborting one."""
+    def _dispatch(name: str, args: dict) -> Any:
+        return _denied_file_result(args["pattern"])
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="glob_files", args={"pattern": "bad/**"}),
+        # A later step reads the flag inline — proves it survived, unraised.
+        TransformStep(value="get(pipe, 'meta.isError', false)"),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-3099-inline",
+    )
+    assert result.pipe_data is True
+
+
+@pytest.mark.asyncio
+async def test_non_tool_step_inside_for_each_on_error_is_unaffected():
+    """Tier 2: the canonical-error check is scoped to `ToolStep` ONLY — a
+    `transform`-do inside a `for_each` (which never returns a
+    canonical-envelope shape) is unaffected by the new check; its own
+    existing exception-only on_error behavior is preserved byte-for-byte."""
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=[1, 2],
+            on_error="abort",
+            # A dict result that HAPPENS to carry a `meta` key with `isError`
+            # would previously (and still) never trip on_error for a
+            # transform-do — the check only ever looks at ToolStep results.
+            do=TransformStep(value="{meta: {isError: true}, value: item}"),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=lambda *_a, **_k: None,
+        state_log=None, run_id="run-3099-transform-unaffected",
+    )
+    assert result.pipe_data == [
+        {"meta": {"isError": True}, "value": 1},
+        {"meta": {"isError": True}, "value": 2},
+    ]


### PR DESCRIPTION
**[per-PR-coder]** — #3099 corrective (a), implementing architect's impl-ready design record (`gh issue view 3099 --comments`). Part of the 0064 plugin-model / RAG live-witness structural corrective arc (#3096: "6 defects = ONE gap — mechanism unit-green, purpose-level live-wired seam unwitnessed").

## Background

#3095 (one of #3096's 6 witnessed defects): `execute_op` (op_runtime's shared chokepoint) never raises for an op-level failure by design — a `PermissionError` degrades to `{status:"denied", error:...}`, any other exception to `{status:"error", error:...}`. Before this fix, `rag_ingest.yaml`'s `glob_files` `for_each` declared `on_error: abort`, but the executor's fan-out coordinator only tripped `on_error` on a RAISED exception — a degraded (non-raising) tool result sailed through as an ordinary "success", so the failed item flowed into a `fold` that assumed every item's `.structured` was a list, breaking several steps downstream with an opaque `list + dict` TypeError.

#3098 closed this with an interim per-call-site `schema: PreflightCheck` gate (forcing a raise via schema validation). This PR closes it at the SOURCE per architect's design (#3099 comment), and folds out #3098's interim gate.

## The structural contract this PR fixes in place

`for_each`/`parallel`'s `on_error` now triggers on **raise OR the tool result's own canonical error signal** (`meta.isError`), not raise-only. This is **not a new field** — it is FP-0056 v2's existing shared error seam (`reyn.core.offload.canonical.is_error_result`/`_is_error`/`error_to_canonical`), which `_run_tool_step` already runs on every `tool:` step's raw dispatch result and surfaces as `meta.isError` on the ctx-shaped result a fan-out coordinator receives — the SAME field a handle-inline pipeline step already branches on manually (`rag_ingest.yaml`'s `get(ctx.converted, 'meta.isError', false)`). All tool-level failures now route uniformly to a DECLARED `on_error`, without inventing any per-call-site schema.

`src/reyn/core/pipeline/executor.py`: new `_tool_step_canonical_error(step, result)` helper, consumed by `_run_item` (for_each) and `_run_branch` (parallel). Scoped to `ToolStep` results ONLY — every other step kind (`transform`/`agent`/`call`) already raises its own `PipelineExecutionError` on failure, so widening past `ToolStep` risks false-positiving on a legitimate `isError`-named DATA field some other step computed on purpose.

**Handle-inline preserved**: a step that does NOT sit inside a declared `for_each`/`parallel` `on_error` is completely unaffected — it still returns its `meta.isError`-flagged result normally so a later step can branch on it itself.

## #3098 fold-out

`src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml`'s `glob_files` step no longer declares `schema: PreflightCheck` — the general on_error mechanism now makes it redundant (point-fix + the now-general mechanism coexisting = debt, per owner's no-debt ruling).

## Completeness census (#3099's co-vet item — full pass, not spot-check)

Enumerated every `register(kind, handler, canonical=...)` / tool `canonical=` declaration across `src/reyn/core/op_runtime/*.py` + `src/reyn/tools/*.py` (~85 declarations). Every MAPPED or `CANONICAL_TODO`-declared op routes through `is_error_result` before its success-shape rendering, so an `execute_op`-level failure (which always carries an `error` field) correctly sets `meta.isError`.

Re-verified architect's 3 spot-checked candidates directly:
- **`contextual_gate`**: not an op at all — a permission-gate concept whose `status` values route through the same universal `execute_op` PermissionError catch as every other op. False positive, confirmed.
- **`index_update`**: `index_update.py:204`'s `if embed_result.get("status") == "error": return embed_result` propagates the nested `embed` op's OWN already-canonical-compatible error result verbatim — not a distinct non-conforming shape. False positive, confirmed.
- **`semantic_search`**: shares `chunks_to_canonical` with `index_query` (a real mapper); no gap found.

**One NEW gap found** (not present in architect's 3-candidate spot-check), filed as follow-up **#3104** rather than fixed here: `to_canonical`'s dispatch runs `is_error_result` before the `CANONICAL_TODO` fallback, but BEFORE the `STRUCTURED_PASSTHROUGH`/`None` fallback occurs UNCONDITIONALLY (no `is_error_result` check at all) — so the 9 `STRUCTURED_PASSTHROUGH`-declared ops (`mcp_drop_server`, `mcp_install`, `mcp_subscribe_resource`, `mcp_unsubscribe_resource`, `pipeline_install`, `plugin_install`, `plugin_uninstall`, `presentation_install`, `skill_install` — all admin/install verbs) never get `meta.isError` set on an `execute_op`-level failure. **Not live-reachable today** — grep confirms none of these ops are used inside a `for_each`/`parallel` with `on_error` in any shipped pipeline. Fixing it means reordering FP-0056's load-bearing `to_canonical` dispatch, a separate higher-risk change needing its own review — out of this corrective's scope, tracked in #3104.

## Tests (`tests/test_3099_on_error_canonical_seam.py` — real production `to_canonical`/`error_to_canonical`/`file_to_canonical` throughout, no mocks)

- `for_each`/`parallel` `on_error: abort` fires on a canonical-error result that returns WITHOUT raising (the real `file`-op `status:"denied"` shape `execute_op`'s own `PermissionError` handler produces).
- `on_error: continue` DROPS a canonical-error item the same way it drops a raised-exception one — the widening changes only what COUNTS as a failure, not the on_error POLICY semantics.
- a plain `tool:` step with no declared `on_error` is unaffected (handle-inline preservation).
- a `transform`-do inside a `for_each` is unaffected — the check is scoped to `ToolStep` only.

**strip-falsify** (manual, `git stash` over `src/reyn/core/pipeline/executor.py` alone, #3098's schema fold-out kept applied): reverting ONLY the executor change reproduces the EXACT pre-#3098 `'list and dict'` `TypeError` in `tests/test_fp0063_p3_rag_pipelines.py::test_ingest_file_discovery_aborts_clean_on_unreadable_input_path` — confirms the new mechanism (not the removed schema gate) is what makes the abort fire.

## CI gates (all green locally before push)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_3099_on_error_canonical_seam.py` — 5/5 OK, 0 Tier-4 violations
- `PYTHONPATH=src python -m pytest` (repo root, foreground) — **8943 passed, 29 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/executor.py` — OK

## Landing gate — MERGE HELD, do not merge yet

Per lead's directive: **merge is held pending #3098's re-witness validating two preconditions** — (1) a status-degrade actually sets the canonical signal on a LIVE (not just unit-tested) failure path, (2) the handle-inline pattern is unaffected in a live run — plus **architect co-vet**. This PR is open for review/co-vet now; landing waits on that validation, not on anything further from me.

## Test plan

- [x] `ruff check src tests` green
- [x] `python scripts/test_tier_audit.py --strict tests/test_3099_on_error_canonical_seam.py` green
- [x] `PYTHONPATH=src python -m pytest` (repo root, foreground, full suite) green — 8943 passed / 29 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/executor.py` green
- [x] strip-falsify: revert executor change alone → reproduces pre-#3098 dead failure (manual, documented above)
- [x] handle-inline non-effect test passes
- [ ] (skipped — landing gate, not mine to run) #3098 live re-witness of the two preconditions + architect co-vet

part of #3096
part of #3099