### PR TITLE
fix: build rag_ingest file:// URIs from absolute paths so a relative input_path indexes instead of silently skipping every file (Closes #3102)

### DIFF
--- a/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
@@ -30,12 +30,16 @@
 # Spawn is then network-free (ADR 0064 §3.11).
 #
 # Inputs (all optional except `input_path`/`output_db`):
-#   input_path          -- (required) an ABSOLUTE path to a document file
-#                          OR a folder of them. Absolute because the file
-#                          discovery below globs it directly: an absolute
-#                          pattern yields absolute source paths (which is
-#                          what `file://` conversion and the stored
-#                          source_path column both need).
+#   input_path          -- (required) a path to a document file OR a folder
+#                          of them, absolute OR relative (resolved against
+#                          the workspace root/CWD, same as any other reyn
+#                          file op -- #3102). The file-discovery `glob_files`
+#                          call below always passes `absolute: true`, so the
+#                          matches handed to `file://` conversion and the
+#                          stored source_path column are absolute regardless
+#                          of which form `input_path` was given in -- that
+#                          contract holds unconditionally, not just when the
+#                          operator happens to type an absolute path.
 #   output_db           -- (required) the sqlite file to write into.
 #   file_extensions     -- extensions to ingest when input_path is a folder
 #                          (default: the proposal-0063 target formats
@@ -88,7 +92,11 @@
 # and #3010's `files_skipped` / `skipped_files` naming every discovered file
 # that produced NO indexed content -- whether its conversion failed, it
 # reported an empty body, or it simply chunked to zero -- each with the
-# reason, so a file can never leave the corpus silently)
+# reason, so a file can never leave the corpus silently -- plus #3102's
+# `all_discovered_files_skipped`, true when EVERY discovered file was
+# skipped (0 chunks indexed this run despite `status: ok`), so a caller
+# does not have to re-derive that special case from files_scanned ==
+# files_skipped itself)
 # or `_blocked`'s X1 pre-flight failure message (cause + concrete remedy
 # per unreachable server -- mirrors #2932's `require_mcp` decision-enabling
 # error, never a bare transport exception).
@@ -499,6 +507,26 @@ steps:
             # corpus is dropped with no error anywhere -- the summary would
             # report a files_scanned that is simply wrong.
             max_results: !expr ctx.max_files
+            # #3102: EXPLICIT, load-bearing. `_ingest_one_file` builds
+            # `file://` + this match verbatim (see that pipeline's convert
+            # step) -- a bare relative match there ('corpus/note1.md')
+            # produces a MALFORMED URI ('file://corpus/note1.md', which the
+            # URI parser reads 'corpus' as a netloc, not a path segment) --
+            # markitdown then rejects every file with "Netloc must be empty
+            # or localhost", the whole folder is silently skipped, and
+            # ingest still reports `status: ok` with 0 chunks. `input_path`
+            # being relative (the natural way an operator points this
+            # pipeline at a project-root corpus, e.g. './corpus') is enough
+            # to hit this -- glob_files' own pattern-vs-path-root contract
+            # (a relative PATTERN globs relative to base_dir/CWD and
+            # returns project-relative matches; see Workspace.glob_files)
+            # is correct and shared by many other callers that WANT
+            # relative display paths, so it stays the default. `absolute:
+            # true` is the opt-in that makes THIS caller's contract hold
+            # unconditionally: file:// is always built from an absolute
+            # path, regardless of whether the operator's own input_path was
+            # relative or absolute.
+            absolute: true
       collect: {transform: {value: "pipe"}}
       output: globbed
   # Flatten one list per pattern into one flat file list. `structured` is
@@ -556,6 +584,21 @@ steps:
         map(filter(ctx.per_file_outcomes, o -> o.skipped_reason != ""),
             o -> {source_path: o.source_path, reason: o.skipped_reason})
       output: skipped_files
+
+  # #3102 -- the STRUCTURAL zero-yield gate. `skipped_files` (above) already
+  # names every individual file and why it was skipped, but a caller has to
+  # compute `files_scanned == files_skipped` itself to notice the SPECIAL
+  # case: every single discovered file was unusable, so this run indexed
+  # NOTHING, yet the pipeline still returns `status: ok` (no step raised --
+  # #3010's per-file skip path is a legitimate non-error outcome, and
+  # correctly so for a PARTIAL skip). A caller (chat rendering, an
+  # orchestrating pipeline, or an operator reading the summary) should not
+  # have to re-derive "ok but did nothing" from two counts; this flag names
+  # it directly. `count(ctx.files) > 0` excludes the (also legitimate)
+  # "input_path matched nothing" case from being reported as a skip.
+  - transform:
+      value: "count(ctx.files) > 0 and count(ctx.skipped_files) == count(ctx.files)"
+      output: all_discovered_files_skipped
 
   # C5: fetch the existing corpus SCOPED TO THIS input_path (via
   # `parent_context` -- repurposed here as the ingest-root tag stamped on
@@ -641,6 +684,7 @@ steps:
         {files_scanned: count(ctx.files),
          files_skipped: count(ctx.skipped_files),
          skipped_files: ctx.skipped_files,
+         all_discovered_files_skipped: ctx.all_discovered_files_skipped,
          chunks_upserted: ctx.upsert_outcome.upserted,
          chunks_removed: ctx.delete_result.structured.deleted,
          chunks_unchanged_skipped: ctx.unchanged_count,

--- a/src/reyn/core/op_runtime/file.py
+++ b/src/reyn/core/op_runtime/file.py
@@ -464,7 +464,9 @@ async def handle(op: FileIROp, ctx: OpContext) -> dict:
         # loop thread (called after the `await`, not inside the threaded call) —
         # EventStore.write ultimately does an `asyncio.Queue.put_nowait`, which is
         # NOT thread-safe if called from a to_thread worker thread.
-        matches = await asyncio.to_thread(ctx.workspace.glob_files, op.path, max_results=op.max_results)
+        matches = await asyncio.to_thread(
+            ctx.workspace.glob_files, op.path, max_results=op.max_results, absolute=op.absolute
+        )
         ctx.events.emit("tool_executed", op="glob_files", path=op.path, match_count=len(matches))
         return {
             "kind": "file",

--- a/src/reyn/data/workspace/workspace.py
+++ b/src/reyn/data/workspace/workspace.py
@@ -224,10 +224,25 @@ class Workspace:
         path = self._resolve_read(path_str)
         return self._read_backend_for(path).stat(path)
 
-    def glob_files(self, pattern: str, max_results: int = 50) -> list[str]:
+    def glob_files(
+        self, pattern: str, max_results: int = 50, *, absolute: bool = False
+    ) -> list[str]:
         """
         Expand a glob pattern. Relative patterns resolve under base_dir (CWD).
-        Returns project-relative path strings.
+        Returns project-relative path strings by default.
+
+        ``absolute=True`` (#3102) makes the RELATIVE-pattern branch return
+        absolute path strings instead of relativizing them against
+        ``base_dir`` — opt-in, so every existing caller that relies on the
+        project-relative default (the vast majority: display paths, "not
+        found" suggestions, etc.) is unaffected. A consumer that hands a
+        glob match straight into a ``file://`` URI (e.g. rag_ingest.yaml)
+        needs an absolute path regardless of whether the caller's own
+        pattern happened to be relative or absolute — this flag lets it ask
+        for that directly instead of leaving the caller to reconstruct an
+        absolute path itself (R1 pipelines have no abspath/cwd primitive to
+        do that with). The absolute-pattern branch already returns absolute
+        paths unconditionally, so this flag is a no-op there.
         """
         p = Path(pattern)
         if p.is_absolute():
@@ -277,6 +292,11 @@ class Workspace:
         ws_matches = sorted(
             self._read_backend_for(self.base_dir).glob(pattern, root=self.base_dir)
         )
+        if absolute:
+            # backend.glob(root=self.base_dir) already returns paths rooted
+            # at base_dir (Path.glob(root / pattern) is absolute when root
+            # is) — no relativize/re-resolve needed, just pass them through.
+            return [str(m) for m in ws_matches[:max_results]]
         result = []
         for m in ws_matches[:max_results]:
             try:

--- a/src/reyn/schemas/models.py
+++ b/src/reyn/schemas/models.py
@@ -18,6 +18,7 @@ class FileIROp(BaseModel):
     content: str | None = None       # write only
     dest_path: str | None = None     # move only: destination path
     max_results: int = 50            # glob only: cap on number of matching paths returned
+    absolute: bool = False           # glob only: return absolute paths even for a relative pattern (#3102)
     # read-specific
     offset: int | None = None        # line number to start reading from (0-indexed); None = beginning
     limit: int | None = None         # number of lines to read; None = all

--- a/src/reyn/tools/descriptions/io.py
+++ b/src/reyn/tools/descriptions/io.py
@@ -328,6 +328,23 @@ PARAMS: dict[str, dict[str, ParamDescription]] = {
                 "黙って切り捨てられる。"
             ),
         ),
+        "absolute": ParamDescription(
+            text=(
+                "When true, return absolute paths even for a relative "
+                "pattern (default false = project-relative paths). Set "
+                "this when the result feeds something that needs an "
+                "absolute path regardless of the pattern's own form (e.g. "
+                "a file:// URI) — do not try to reconstruct an absolute "
+                "path from a relative match yourself."
+            ),
+            ja=(
+                "true なら相対パターンでも絶対パスを返す（デフォルト false"
+                "＝プロジェクト相対パス）。パターン自体が相対かどうかに"
+                "関わらず絶対パスが必要な用途（file:// URI 構築等）で"
+                "使うこと — 相対一致から絶対パスを自前で組み立てようと"
+                "しないこと。"
+            ),
+        ),
     },
     "list_directory": {
         "max_results": ParamDescription(

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -157,6 +157,10 @@ _GLOB_FILES_PARAMETERS: dict[str, Any] = {
             "type": "integer",
             "description": _io_descriptions.PARAMS["glob_files"]["max_results"].text,
         },
+        "absolute": {
+            "type": "boolean",
+            "description": _io_descriptions.PARAMS["glob_files"]["absolute"].text,
+        },
     },
     "required": ["pattern"],
 }
@@ -341,6 +345,13 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     max_results=1000, got exactly 50 back). Callers ingesting a whole
     directory (e.g. RAG folder-indexing) must pass max_results explicitly
     when more than 50 matches are expected.
+
+    `absolute` (#3102) is forwarded to `FileIROp.absolute` — opt-in, default
+    False (unchanged project-relative return for every existing caller). A
+    caller that needs an absolute path regardless of whether its OWN
+    pattern was relative (e.g. building a `file://` URI) passes
+    `absolute: true` explicitly rather than relativizing/re-resolving the
+    match itself, which R1 pipelines have no primitive to do.
     """
     from reyn.core.op_runtime import execute_op
     from reyn.schemas.models import FileIROp
@@ -355,6 +366,7 @@ async def _handle_glob(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
         op="glob",
         path=combined,
         max_results=args.get("max_results", 50),
+        absolute=bool(args.get("absolute", False)),
     )
     legacy_ctx = _build_legacy_op_context(ctx)
     result = await execute_op(op, legacy_ctx)

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -96,6 +96,7 @@ _QUERY_PATH = _RAG_PLUGIN_DIR / "pipelines" / "rag_query.yaml"
 
 _STUB_MARKITDOWN_SERVER = '''
 import base64
+from urllib.parse import urlsplit
 from fastmcp import FastMCP
 
 mcp = FastMCP("stub-markitdown")
@@ -106,7 +107,23 @@ def convert_to_markdown(uri: str) -> str:
     if uri.startswith("data:"):
         _, _, payload = uri.partition(",")
         return base64.b64decode(payload).decode("utf-8")
-    path = uri[len("file://"):] if uri.startswith("file://") else uri
+    if uri.startswith("file://"):
+        # #3102: real markitdown-mcp parses the URI and REJECTS a non-empty,
+        # non-localhost netloc -- which is exactly what a naive 'file://' +
+        # <relative path> concatenation produces ('file://docs/a.txt' parses
+        # with netloc='docs', path='/a.txt'). Reproducing that check here
+        # (instead of the earlier lenient `uri[len("file://"):]` strip, which
+        # happened to still resolve a relative match against this test's own
+        # CWD and silently masked the bug) is what makes this stub actually
+        # exercise the real-world failure mode instead of passing vacuously.
+        parsed = urlsplit(uri)
+        if parsed.netloc not in ("", "localhost"):
+            raise ValueError(
+                f"Unsupported file URI: {uri}. Netloc must be empty or localhost."
+            )
+        path = parsed.path
+    else:
+        path = uri
     with open(path, encoding="utf-8") as f:
         return f.read()
 
@@ -802,3 +819,117 @@ def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(
     result = _run_ingest(project_root, capsys)  # default vectorstore_server matches config
     summary = result["named_stores"]["result"]
     assert isinstance(summary, dict) and "chunks_upserted" in summary
+
+
+# ---------------------------------------------------------------------------
+# 7. #3102: a RELATIVE input_path must index the corpus, not silently skip
+# every file via a malformed `file://` URI while still reporting status: ok.
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_with_relative_input_path_indexes_the_corpus(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #3102 -- a RELATIVE ``input_path`` (the natural way an
+    operator points this pipeline at a project-root corpus, e.g. ``docs`` or
+    ``./docs`` -- the most common real input shape, not an edge case) must
+    index the corpus exactly as an absolute ``input_path`` does.
+
+    Root cause: ``_ingest_body``'s file-discovery builds each glob PATTERN
+    from ``ctx.input_path`` verbatim (``ctx.input_path + '/**/*.' + e``). A
+    relative ``input_path`` makes the pattern relative, and
+    ``Workspace.glob_files``' relative branch (BY DESIGN -- it resolves
+    under ``base_dir``/CWD and returns project-relative matches, a contract
+    many OTHER callers rely on for display paths) then returns
+    project-relative matches too (``docs/a.txt``, not
+    ``/abs/project/docs/a.txt``). ``_ingest_one_file`` builds
+    ``'file://' + ctx.source_path`` from that match verbatim -- a relative
+    match there produces a MALFORMED URI (``file://docs/a.txt``, which a URI
+    parser reads ``docs`` as the netloc/host, not a path segment).
+    markitdown then rejects every file with "Netloc must be empty or
+    localhost", ``for_each: on_error: continue`` swallows each per-file
+    failure through the ordinary #3010 skip path (a real, intentional
+    non-error outcome for a PARTIAL skip), and the run completes with
+    ``status: ok`` and zero chunks -- a silent-success data-loss shape, not
+    a crash.
+
+    The fix (rag_ingest.yaml's file-discovery ``glob_files`` step) passes
+    the new ``absolute: true`` arg (#3102, ``Workspace.glob_files``'
+    opt-in absolute-path mode) so THIS caller's own contract --
+    ``file://`` is always built from an absolute path -- holds
+    unconditionally, without touching ``glob_files``' default
+    project-relative return that every other caller still depends on.
+
+    strip-falsify: reverting the ``absolute: true`` line in
+    rag_ingest.yaml's file-discovery step reproduces the original
+    ``files_skipped == files_scanned``, ``chunks_upserted == 0``,
+    ``status: ok`` silent-zero shape (independently verified while
+    developing this fix).
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("Alpha document about apples.", encoding="utf-8")
+
+    summary = _run_ingest(project_root, capsys, input_path="docs")["named_stores"]["result"]
+    assert isinstance(summary, dict), (
+        f"expected a summary dict (real ingest), got a blocked/str result instead: {summary!r:.300}"
+    )
+    assert summary["files_scanned"] == 1
+    assert summary["files_skipped"] == 0, (
+        "#3102 REGRESSION: a relative input_path must not be silently skipped via a "
+        f"malformed file:// URI -- got skipped_files={summary.get('skipped_files')}"
+    )
+    assert summary["all_discovered_files_skipped"] is False
+    assert summary["chunks_upserted"] >= 1, (
+        "#3102 REGRESSION: relative input_path produced 0 chunks despite status: ok"
+    )
+
+    from reyn.builtin.plugins.rag.scripts.vector_store_server import SqliteVecStore
+
+    with SqliteVecStore(str(project_root / "rag.sqlite")) as store:
+        rows = store.list_metadata()
+    assert rows, "expected at least one indexed chunk"
+    # The fixed contract: file:// (and the stored source_path column riding
+    # the same value) is always built from an ABSOLUTE path, regardless of
+    # whether the operator's own input_path was relative or absolute.
+    assert all(Path(r["metadata"]["source_path"]).is_absolute() for r in rows), (
+        f"stored source_path must be absolute even from a relative input_path -- "
+        f"got {[r['metadata']['source_path'] for r in rows]}"
+    )
+
+
+def test_ingest_all_discovered_files_skipped_flag_names_the_zero_yield_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #3102 -- when EVERY discovered file is unusable, the
+    summary's ``all_discovered_files_skipped`` flag is True: 0 chunks
+    indexed despite ``status: ok`` is a structural fact a caller should not
+    have to re-derive itself from ``files_scanned == files_skipped``.
+
+    Falsified in the same test: a normal, at-least-partially-successful
+    ingest reports False (not a flag that is vacuously always True)."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "corrupt.pdf").write_bytes(b"\xff\xfe\x00\x01broken")
+
+    summary = _run_ingest(project_root, capsys)["named_stores"]["result"]
+    assert summary["files_scanned"] == 1
+    assert summary["files_skipped"] == 1
+    assert summary["chunks_upserted"] == 0
+    assert summary["all_discovered_files_skipped"] is True, (
+        "a run that indexed nothing from a non-empty discovery must be NAMED as such"
+    )
+
+    # falsify: adding one usable file alongside the unusable one flips it False.
+    (docs_dir / "good.txt").write_text("Penguins huddle together for warmth.", encoding="utf-8")
+    summary_2 = _run_ingest(project_root, capsys)["named_stores"]["result"]
+    assert summary_2["files_skipped"] == 1
+    assert summary_2["chunks_upserted"] >= 1
+    assert summary_2["all_discovered_files_skipped"] is False, (
+        "the flag must not be vacuously True whenever ANY file is skipped -- "
+        "only when discovery yielded NOTHING usable at all"
+    )

--- a/tests/tools/_pre_migration_tool_schemas_baseline.json
+++ b/tests/tools/_pre_migration_tool_schemas_baseline.json
@@ -465,6 +465,10 @@
       "name": "glob_files",
       "parameters": {
         "properties": {
+          "absolute": {
+            "description": "When true, return absolute paths even for a relative pattern (default false = project-relative paths). Set this when the result feeds something that needs an absolute path regardless of the pattern's own form (e.g. a file:// URI) — do not try to reconstruct an absolute path from a relative match yourself.",
+            "type": "boolean"
+          },
           "max_results": {
             "description": "Maximum number of matching paths to return. Defaults to 50 — raise this explicitly when enumerating a directory that may hold more entries than that (e.g. bulk ingestion), otherwise matches beyond the cap are silently dropped.",
             "type": "integer"


### PR DESCRIPTION
**[per-PR-coder]** — RAG 完遂(#2955)の最後の関門。dogfood-coder が project-root 内の相対パス corpus で踏んだ silent data-loss を修正します。

## 症状
```
pipeline__run(name="rag_ingest.ingest", input={"input_path": "./corpus", "output_db": "./rag.sqlite"})
```
→ `scanned 1 file, skipped 1 file. skipped: corpus/note1.md — "Unsupported file URI: file://corpus/note1.md. Netloc must be empty or localhost." No chunks added.` — しかし **pipeline は `status: ok` で完走**。0 chunk なのにエラーで落ちないため、#3095 以上に気づけない。owner が最も自然に打つ入力形(相対パス corpus)で発生。

## Root cause(実測)
`_ingest_body` の file-discovery は glob **パターン**を `ctx.input_path` から verbatim に組む(`ctx.input_path + '/**/*.' + e`)。`Workspace.glob_files` の**相対 branch は設計上 base_dir/CWD 相対で解決し、project-relative なマッチを返す**(`docs/a.txt`、`/abs/.../docs/a.txt` ではない)。`_ingest_one_file` はそのマッチを `'file://' + ctx.source_path` に verbatim 連結する — 相対マッチだと `file://docs/a.txt` という**不正 URI**(URI パーサが `docs` を netloc/host と解釈、path segment ではない)。markitdown が "Netloc must be empty or localhost" で全ファイルを reject → `for_each: on_error: continue` が各 per-file failure を #3010 の通常 skip path で飲み込む → 0 chunk・`status: ok` で完走。

**この相対返しは glob_files の設計意図**(cwd 相対、display path 用途の多数の consumer が依存)であり、穴ではない。∴ 直す root 層は「file:// 構築の手前で絶対パス化」する側。

## 選んだ root 層(エビデンス付き)
`glob_files` に **opt-in `absolute: bool = False`** を追加(`Workspace.glob_files` → `FileIROp.absolute` → `_handle_glob` の全経路)。rag_ingest.yaml の file-discovery glob step が `absolute: true` を渡すことで、**「file:// は必ず絶対パスから構築する」契約を無条件で固定**する(operator の input_path が相対でも絶対でも同一挙動)。

- **なぜ tool 層か**: R1 pipeline DSL に abspath/cwd 相当の primitive が無い(実測確認)。∴ pipeline expression 側では絶対化できず、tool 層が唯一の root。
- **consumer 非影響(default-False)**: `absolute` は opt-in で default False。既存の `glob_files` consumer(全数 grep: `Workspace.glob_files` の唯一の呼び出しは `op_runtime/file.py` の glob handler と `_nearby_files`、後者は `absolute` を渡さない)は全て project-relative の既存契約のまま。#3098 と同種の format-change consumer-audit risk を default-False で回避。絶対パターン branch は元々無条件で絶対を返すので、このフラグは no-op。

## ★ silent-success 次元(owner「失敗を silent にするな」)
「N 件 discover したのに全 skip で 0 chunk、なのに status:ok」を、summary に **`all_discovered_files_skipped`** フラグとして surface(discover が非空 かつ 全件 skip のとき True)。caller(chat 描画・orchestrating pipeline・operator)が `files_scanned == files_skipped` を自前で再導出しなくても「ok だが何も indexed していない」を直接名指しできる。partial skip(一部成功)は False のまま(#3010 の per-file skip は正当な非エラー outcome ∴ pipeline status は ok が正しく、フラグだけが特殊ケースを名指す)。

## query の「vectorstore unreachable」誤診断(副次)
`vector_store_server.py` の `SqliteVecStore.__init__` は open 時に無条件で `_ensure_schema()` を走らせる ∴ 空/新規 DB でも `list_metadata` は成功し、query の pre-flight は "reachable" を返す。「unreachable」メッセージと空 DB の間に構造的な結線は見つからず(空 DB でも pre-flight は通る)、witness 時の観測は本 URI バグ由来の 0-chunk が真因と整合。**別 issue 化する構造的欠陥は現時点で特定できなかった**ため、本 PR では扱わず、fix 後の再 witness で query が正しく空/該当結果を返すことの確認に委ねます。

## strip-falsify
rag_ingest.yaml の file-discovery step から `absolute: true` を除去(`absolute: false` に戻す)すると、`test_ingest_with_relative_input_path_indexes_the_corpus` が RED になり、**報告と同一の shape** を再現:
```
files_skipped == files_scanned (1), chunks_upserted == 0, status: ok
skipped_files=[{'source_path': 'docs/a.txt', 'reason': "conversion failed: ... Unsupported file URI: file://docs/a.txt. Netloc must be empty or localhost."}]
```
`absolute: true` 復帰で GREEN。stub markitdown server は実 markitdown-mcp と同じ netloc-rejection を再現するよう修正(従来の寛容な `uri[len("file://"):]` strip は相対マッチをテスト自身の CWD に対して解決してしまい、バグを vacuous に mask していた)。

## 変更点
- `src/reyn/data/workspace/workspace.py` — `glob_files(..., *, absolute=False)`、相対 branch の絶対返し
- `src/reyn/schemas/models.py` — `FileIROp.absolute: bool = False`(glob only)
- `src/reyn/core/op_runtime/file.py` — glob handler が `op.absolute` を forward
- `src/reyn/tools/file.py` / `descriptions/io.py` — `absolute` を LLM-facing tool schema + 説明に追加
- `src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml` — glob step に `absolute: true`、`all_discovered_files_skipped` 追加、input_path doc を「絶対/相対どちらも可」に更新
- `tests/test_fp0063_p3_rag_pipelines.py` — 相対 input_path の実 ingest テスト + zero-yield フラグ双方向テスト、stub の netloc-rejection 再現
- `tests/tools/_pre_migration_tool_schemas_baseline.json` — 新 `absolute` param の意図的な surface 変更を反映(diff は当該 param のみ)

## Test plan
- [x] `ruff check src tests` green
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0063_p3_rag_pipelines.py tests/tools/test_tool_description_relocation.py` green(20/20)
- [x] `python scripts/verify_module_docstrings.py <changed src>` green
- [x] full-suite `pytest`(repo root, foreground)green(8940 passed, baseline 再生成後)
- [x] strip-falsify: `absolute: true` 除去で相対 input_path テストが報告と同一 shape で RED、復帰で GREEN
- [x] 隣接 glob/workspace テスト(`test_glob_files_only_1375_d10` 他)47/47 green

## 共有ファイル注意
`rag_ingest.yaml` は corrective (a)(#3099、glob step の `schema: PreflightCheck` 除去)と同ファイルを触りますが、別 hunk(あちらは L475 付近の schema 行、こちらは L269 の convert step + glob step の args + summary)。merge order は lead-coder が調整。

Closes #3102

🤖 Generated with [Claude Code](https://claude.com/claude-code)