### PR TITLE
refactor(session): extract WAL-event/recovery bundle builder (#3082 Family 2, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -686,6 +686,24 @@ class _AuditEventBundle:
     otel_exporter: "object | None"
 
 
+@dataclass(frozen=True)
+class _RecoveryBundle:
+    """#3082 Family 2: the WAL-event/recovery pair — ``generation_store``
+    (ADR-0038 Stage 1a PITR generation store) → ``journal`` (``SnapshotJournal``,
+    the WAL append + snapshot-restore seam nearly every recovery path goes
+    through), constructed in that order because the journal is wired to this
+    same generation_store instance. Pure output→input value object:
+    :meth:`Session._build_recovery_bundle` is a byte-identical extraction of
+    the construction sequence that used to run inline in ``Session.__init__``
+    — same objects, same order, same args (including reading the LOCAL
+    ``state_log`` __init__ parameter, not ``self._state_log``, which is a
+    separate tracking assignment made later and is untouched by this
+    extraction). Same shape as ``_AuditEventBundle`` (#3082 Family 1)."""
+
+    generation_store: SnapshotGenerationStore
+    journal: SnapshotJournal
+
+
 class Session:
     def __init__(
         self,
@@ -1357,17 +1375,16 @@ class Session:
         self._snapshot_path = snapshot_path or (
             Path(".reyn") / "agents" / self.agent_name / "state" / "snapshot.json"
         )
-        # ADR-0038 Stage 1a: PITR generation store, kept beside snapshot.json.
-        self._generation_store = SnapshotGenerationStore(
-            self.agent_name, self._snapshot_path.parent / "generations",
+        # #3082 Family 2 (WAL-event/recovery): generation_store -> journal
+        # extracted into _build_recovery_bundle. Byte-identical extraction —
+        # same objects, same construction order, same args (builder reads the
+        # LOCAL state_log parameter, not self._state_log — see
+        # _RecoveryBundle's docstring).
+        _recovery_bundle = self._build_recovery_bundle(
+            self.agent_name, self._snapshot_path, state_log, session_id,
         )
-        self._journal = SnapshotJournal(
-            agent_name=self.agent_name,
-            snapshot_path=self._snapshot_path,
-            state_log=state_log,
-            generation_store=self._generation_store,
-            session_id=session_id,  # FP-0043 S5: per-session WAL routing
-        )
+        self._generation_store = _recovery_bundle.generation_store
+        self._journal = _recovery_bundle.journal
         # ADR-0038 Stage 1c: turn-idle event for quiescence. Set = no turn in
         # flight; cleared while run_one_iteration processes a turn. Lets a global
         # rewind await all in-flight WAL appends settling (await_quiescent) before
@@ -4020,6 +4037,57 @@ class Session:
             chat_events=chat_events,
             outbox_hub=outbox_hub,
             otel_exporter=otel_exporter,
+        )
+
+    # ── #3082 Family 2: WAL-event/recovery bundle builder ──
+
+    def _build_recovery_bundle(
+        self,
+        agent_name: str,
+        snapshot_path: Path,
+        state_log: "StateLog | None",
+        session_id: str,
+    ) -> "_RecoveryBundle":
+        """#3082 Family 2: build the WAL-event/recovery pair —
+        ``generation_store`` (ADR-0038 Stage 1a PITR generation store, kept
+        beside snapshot.json) -> ``journal`` (``SnapshotJournal``, wired to
+        this same generation_store instance).
+
+        Byte-identical extraction of the sequence that used to run inline in
+        ``__init__`` — same objects, same construction order, same args.
+        Takes ``agent_name`` / ``snapshot_path`` / ``state_log`` / ``session_id``
+        explicitly rather than reaching into ``self`` mid-construction:
+        ``agent_name`` is the property value already resolvable at the
+        original call site, ``snapshot_path`` is ``self._snapshot_path``
+        (constructed immediately before this builder ran), and — critically —
+        ``state_log`` is the LOCAL ``__init__`` parameter, NOT
+        ``self._state_log``. ``self._state_log = state_log`` is a separate
+        tracking assignment made later in ``__init__`` (for ops that need
+        direct WAL access outside the journal) and is out of scope for this
+        extraction; it keeps reading the same local parameter untouched.
+
+        ADR-0038 Stage 1a: PITR generation store, kept beside snapshot.json.
+
+        PR21: WAL + per-agent snapshot for crash recovery. state_log is
+        process-shared (owned by AgentRegistry); when None, persistence is
+        disabled (tests / non-chat invocation). PR-refactor-session-1 wave 2:
+        persistence now flows through SnapshotJournal (extracted service).
+
+        FP-0043 Stage 5: session_id is the conversation session id, threaded
+        to the journal so every WAL append carries it."""
+        generation_store = SnapshotGenerationStore(
+            agent_name, snapshot_path.parent / "generations",
+        )
+        journal = SnapshotJournal(
+            agent_name=agent_name,
+            snapshot_path=snapshot_path,
+            state_log=state_log,
+            generation_store=generation_store,
+            session_id=session_id,  # FP-0043 S5: per-session WAL routing
+        )
+        return _RecoveryBundle(
+            generation_store=generation_store,
+            journal=journal,
         )
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──

--- a/tests/scaffold/test_family2_recovery_bundle_byte_identical.py
+++ b/tests/scaffold/test_family2_recovery_bundle_byte_identical.py
@@ -1,0 +1,189 @@
+# scaffold: triggered_by="#3082 Family 2 (WAL-event/recovery bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 2
+extraction — ``Session._build_recovery_bundle`` pulling the
+``generation_store -> journal`` (``SnapshotGenerationStore`` /
+``SnapshotJournal``) sequence out of ``Session.__init__`` into one builder
+returning one typed bundle (``_RecoveryBundle``).
+
+This is a pure output->input builder pipeline stage: there is no separate
+"old" implementation left in the tree to diff against (the inline sequence
+was replaced, not duplicated), so byte-identical is pinned as the set of
+*construction-order + wiring invariants* the inline sequence guaranteed and
+the builder must reproduce exactly:
+
+1. ``journal`` is wired to the SAME ``generation_store`` instance the builder
+   returns (not a fresh one) — proven end-to-end: a generation cut through
+   ``journal.cut_generation`` lands in the very ``generation_store`` object
+   the caller holds, not some other store.
+2. ``journal`` is wired to the LOCAL ``state_log`` __init__ parameter (never
+   ``self._state_log``, a separate later tracking assignment out of scope
+   for this extraction) — proven end-to-end: a WAL-recorded mutation through
+   the journal durably lands in the exact ``state_log`` instance the caller
+   passed to the builder.
+3. ``journal`` is wired to the exact ``snapshot_path`` passed to the builder
+   — proven end-to-end: ``journal.save()`` writes to that exact path.
+4. ``agent_name`` / ``session_id`` pass through into the journal's in-memory
+   snapshot (``journal.snapshot.agent_name`` / ``.session_id``).
+
+Per the extracted-refactor idiom (``docs/deep-dives/contributing/testing.md``,
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold test is added and removed in the SAME PR that lands the
+extraction, once green — the builder has no independent behavior left to keep
+re-verifying past that point (it is a one-time mechanical extraction, not an
+area that will keep changing shape).
+
+No new WAL-derived recovery state is introduced by this extraction (pure
+move of existing construction code) so the CLAUDE.md truncate-falsify
+recovery-feature PR gate does not apply here; what this scaffold instead pins
+is that the WAL SUBSTRATE WIRING itself (journal <-> generation_store <->
+state_log) survives the extraction byte-identically, since that wiring — not
+new derived state — is where this extraction's recovery-fidelity risk lives.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.snapshot_generations import SnapshotGenerationStore
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.services.snapshot_journal import SnapshotJournal
+from reyn.runtime.session import Session, _RecoveryBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family2-recovery-bundle-test")
+
+
+class TestFamily2RecoveryBundleByteIdentical:
+    def test_bundle_types_and_wiring(self, session: Session) -> None:
+        """Tier 1: the builder produces the same TWO real object types the
+        inline sequence built, assigned to the same Session attributes."""
+        is_generation_store = isinstance(session._generation_store, SnapshotGenerationStore)
+        is_journal = isinstance(session.journal, SnapshotJournal)
+        assert is_generation_store
+        assert is_journal
+
+    def test_builder_returns_a_recovery_bundle(self, tmp_path, monkeypatch) -> None:
+        """Tier 1: calling the builder directly (public method on Session)
+        returns a ``_RecoveryBundle`` with the two expected real object
+        types — the builder's contract independent of ``__init__`` wiring."""
+        monkeypatch.chdir(tmp_path)
+        state_log = StateLog(tmp_path / "direct-builder.wal")
+        # Session() itself isn't needed to invoke the (instance) builder method
+        # directly — construct a minimal session only to obtain a bound method.
+        s = Session(agent_name="family2-direct-builder-test")
+        bundle = s._build_recovery_bundle(
+            "family2-direct-builder-test",
+            tmp_path / "direct-snapshot.json",
+            state_log,
+            "direct-session-id",
+        )
+        is_bundle = isinstance(bundle, _RecoveryBundle)
+        is_generation_store = isinstance(bundle.generation_store, SnapshotGenerationStore)
+        is_journal = isinstance(bundle.journal, SnapshotJournal)
+        assert is_bundle
+        assert is_generation_store
+        assert is_journal
+
+    @pytest.mark.asyncio
+    async def test_journal_cuts_generations_into_the_same_generation_store(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Tier 1: invariant 1 — ``journal.cut_generation`` durably records
+        into THE SAME ``generation_store`` object the builder returned (and
+        ``session._generation_store`` holds), not some other/fresh store.
+        Proven end-to-end via the generation_store's own public ``seqs()``
+        read, not a private-attribute identity peek. ``cut_generation`` is a
+        no-op with no WAL (state_log=None), so this test wires a real
+        ``StateLog`` — matching ``cut_generation``'s own documented
+        precondition ("No-op when no generation store / WAL is configured")."""
+        monkeypatch.chdir(tmp_path)
+        state_log = StateLog(tmp_path / "cut-generation.wal")
+        session = Session(agent_name="family2-cut-generation-test", state_log=state_log)
+        before = session._generation_store.seqs()
+        await session.journal.append_inbox(kind="test", payload={"x": 1})
+        await session.journal.cut_generation(anchor="probe")
+        await session.journal.flush()
+        after = session._generation_store.seqs()
+        assert len(after) > len(before)
+
+    @pytest.mark.asyncio
+    async def test_journal_writes_wal_entries_into_the_local_state_log_param(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Tier 1: invariant 2 — the journal durably appends into the EXACT
+        ``state_log`` instance passed to the builder (the LOCAL __init__
+        parameter), proven end-to-end by observing that state_log's own
+        ``current_seq`` / ``last_durable_seq`` advance, not by peeking at
+        ``journal._state_log`` identity."""
+        monkeypatch.chdir(tmp_path)
+        state_log = StateLog(tmp_path / "wiring.wal")
+        s = Session(agent_name="family2-state-log-wiring-test", state_log=state_log)
+        before = state_log.current_seq
+        await s.journal.append_inbox(kind="test", payload={"y": 2})
+        await state_log.flush()
+        after = state_log.current_seq
+        assert after > before
+
+    @pytest.mark.asyncio
+    async def test_journal_saves_to_the_exact_snapshot_path_passed_to_the_builder(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Tier 1: invariant 3 — ``journal.save()`` durably writes to the
+        EXACT ``snapshot_path`` the builder was given (``self._snapshot_path``
+        at the original inline call site), proven by reading the file back
+        from that exact path — not a private ``journal._snapshot_path``
+        peek."""
+        monkeypatch.chdir(tmp_path)
+        snap_path = tmp_path / "custom" / "snapshot.json"
+        s = Session(agent_name="family2-snapshot-path-test", snapshot_path=snap_path)
+        await s.journal.save()
+        assert snap_path.exists()
+
+    def test_agent_name_and_session_id_pass_through(self, tmp_path, monkeypatch) -> None:
+        """Tier 1: invariant 4 — ``agent_name`` / ``session_id`` builder
+        inputs reach the journal's in-memory snapshot, proven via the
+        journal's own public ``snapshot`` property."""
+        monkeypatch.chdir(tmp_path)
+        s = Session(
+            agent_name="family2-passthrough-test",
+            session_id="family2-custom-sid",
+        )
+        assert s.journal.snapshot.agent_name == "family2-passthrough-test"
+        assert s.journal.snapshot.session_id == "family2-custom-sid"
+
+    @pytest.mark.asyncio
+    async def test_strip_falsify_generation_store_identity_check_is_live(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Tier 1: strip-falsify — re-running invariant 1's check (does
+        ``seqs()`` grow after a real ``cut_generation``) against a FRESH,
+        never-written-to generation_store (instead of the real wired
+        ``session._generation_store``) must observe NO growth, proving the
+        growth observed in
+        ``test_journal_cuts_generations_into_the_same_generation_store`` is
+        genuinely reading the journal's real wired store, not a check that
+        would pass against any store regardless of wiring (non-vacuous)."""
+        monkeypatch.chdir(tmp_path)
+        state_log = StateLog(tmp_path / "strip-falsify.wal")
+        session = Session(agent_name="family2-strip-falsify-test", state_log=state_log)
+        fresh_store = SnapshotGenerationStore(
+            "family2-strip-falsify", session._snapshot_path.parent / "fresh-generations",
+        )
+        before = fresh_store.seqs()
+        await session.journal.append_inbox(kind="test", payload={"z": 3})
+        await session.journal.cut_generation(anchor="probe-poisoned")
+        await session.journal.flush()
+        after_fresh = fresh_store.seqs()
+        after_real = session._generation_store.seqs()
+        assert after_fresh == before, (
+            "strip-falsify: a cut through the real journal was observed on an "
+            "unrelated fresh generation_store — the wiring check would be vacuous"
+        )
+        assert len(after_real) > len(before)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — #3082 Family 2 = WAL-event/recovery pair の byte-identical 抽出です。architect の「Family 2 抽出スコープ spec」に厳密に沿っています。

## 抽出対象(現 :1361–1370 verbatim)
`self._generation_store = SnapshotGenerationStore(...)` と `self._journal = SnapshotJournal(agent_name=..., snapshot_path=self._snapshot_path, state_log=state_log, generation_store=self._generation_store, session_id=session_id)`。

## builder shape
`_build_recovery_bundle(agent_name, snapshot_path, state_log, session_id) -> _RecoveryBundle(generation_store, journal)`(frozen dataclass、Family 1 の `_AuditEventBundle` と同型)。builder 内で `self.` → local、construction 順(generation_store → journal)保持、journal は同一 generation_store instance に配線(builder 内で解決)。`__init__` は builder 呼び出しを**現 :1361 位置**に置き、2-field unpack → `self._generation_store` / `self._journal`。全 deferred consumer(:697/:1047/:1074/:1162/:1520)は不変解決。

## byte-identical で最重要な2点(recovery-critical = WAL substrate)
1. **builder は LOCAL `state_log` param を読む** — `self._state_log = state_log`(:1391)は builder の**後**の別 tracking 代入で **Family 2 対象外**(そのまま残す)。`self._task_subscription_writer = SubscriptionWriter(state_log)`(:1397)も LOCAL param を読む別 subsystem(Family 5)で対象外。両者ともそのまま同じ local param を読み続けます。
2. **assignment 位置を保持** — builder 呼び出しを現 :1361 位置に置いたので、`self._generation_store` / `self._journal` の全消費点が不変解決。

**reordering リスク = なし** — generation_store と journal は隣接(間に他コードなし)。Family 1 のような set-before-read 移動解析は不要。周辺コンテキスト(PR21/state_log コメント、snapshot_path 構築)は builder の前後に据え置き。

## byte-identical 検証結果(自分で実施)
- cross-tree diff vs merge-base: `Session.__init__` の実効挙動が pure extraction(構築順・配線・LOCAL param 参照が不変)であることを diff で確認。builder 呼び出し1本 + 2-field unpack が inline sequence を置換したのみ。
- construction-order 保持 / journal-wiring byte-identical: scaffold test で end-to-end 検証(下記)。

## truncate-falsify 非適用の理由(recovery-feature PR gate 判断)
これは**純粋な抽出**で **新規 WAL-derived state を足しません** ∴ CLAUDE.md の truncate-falsify gate は厳密には非適用(新しい reconstruction source なし)。ただし WAL substrate 構築を触るので、scaffold test は journal↔generation_store↔state_log の**配線 byte-identical** を pin します(recovery-fidelity は new state ではなく**配線**にある)。

## scaffold test(`tests/scaffold/`、triggered_by/removed_by、この landing PR で削除)= Tier 1
`tests/scaffold/test_family2_recovery_bundle_byte_identical.py`(7 test、全 real instance、mock 禁止遵守、公開面/builder 戻り値で assert)。pin する invariant:
- `journal.cut_generation` が builder の返した**同一** generation_store に durably 記録(fresh でない)—— 公開 `seqs()` で end-to-end 検証。
- journal WAL append が builder に渡した**EXACT な LOCAL param** の state_log に着地(`current_seq` 前進で観測)。
- `journal.save()` が builder に渡した**EXACT な** snapshot_path に書き込み(ファイル存在で観測)。
- agent_name / session_id が journal snapshot に pass-through。
- builder 出力型(`_RecoveryBundle` 2 field = SnapshotGenerationStore / SnapshotJournal)。
- **strip-falsify self-check**: fresh(未配線)generation_store は同じ cut 後も成長ゼロ → 配線 check が非 vacuous(RED になる)であることを実証。**Family 1 の教訓に従い、strip-falsify assertion を実際の invariant shape(= wiring 経由の seqs() 成長観測)に合わせています**。

## 4 gate(PR-open 前に local foreground 実行、全 green)
- `ruff check src tests` → All checks passed
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family2_recovery_bundle_byte_identical.py` → OK 7 / 0 violations
- `python -m pytest -q`(repo root, foreground, 10分 timeout)→ 8958 passed, 29 skipped
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` → OK

## co-vet = architect
security/recovery(WAL substrate)を触るため architect co-vet 必須です。cross-tree diff vs merge-base(pure extraction 確認)/ construction-order 保持 / journal-wiring byte-identical / scaffold strip-falsify をご確認ください。co-vet + CI green まで merge されません。

part of #3082
