### PR TITLE
fix: gate rag_ingest's corpus directory upfront, before the file-discovery fan-out (#3101)

### DIFF
--- a/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
@@ -466,20 +466,70 @@ description: >-
   dedup-saved estimate.
 steps:
   # ---- file discovery (#2972: reyn's own `glob_files` op, no shell-out) ----
-  # One recursive glob pattern per target extension, PLUS input_path itself
-  # as a literal pattern -- that one match is what makes "input_path names a
-  # single FILE" work: `glob_files` returns files only, so a literal file
-  # path matches itself while a literal directory path matches nothing, and
-  # the extension patterns do the reverse. Union covers both cases with no
-  # is-it-a-file test (R1 cannot stat anything).
+  # One recursive glob pattern per target extension (input_path itself is
+  # NOT in this list -- see the #3101 upfront-gate step immediately below,
+  # which globs it separately and FIRST).
   #
   # The extensions live in the PATTERN rather than in an R1 `filter`
   # because R1 has no string-suffix/lower primitive -- there is no
   # expression that says "ends with .pdf". The glob character classes
   # (`[pP][dD][fF]`) get case-insensitivity from the globber instead.
   - transform:
-      value: "map(ctx.file_extensions, e -> ctx.input_path + '/**/*.' + e) + [ctx.input_path]"
+      value: "map(ctx.file_extensions, e -> ctx.input_path + '/**/*.' + e)"
       output: file_patterns
+
+  # ---- #3101: upfront recursive-grant gate, SERIAL and BEFORE the fan-out
+  # below ----
+  #
+  # Requests read access to the corpus directory (`input_path`) itself, in
+  # ONE call, before ANY of the (up to 7) glob_files calls below run
+  # concurrently. This is the FIRST `glob_files` call this pipeline makes
+  # against `input_path` -- it also does the "input_path names a single
+  # FILE" job the removed 7th fan-out pattern used to do (`glob_files`
+  # returns files only, so a literal file path matches itself while a
+  # literal directory path matches nothing -- its result is folded into
+  # `files` below alongside the fan-out's).
+  #
+  # WHY upfront, not inside the fan-out: `require_file_read`'s recursive-
+  # parent grant (permissions.py's "[r] grant the parent directory
+  # recursively" JIT choice) is the model's already-correct answer to "one
+  # approval should cover this whole corpus" -- but it only WORKS when the
+  # grant is established before any sibling glob consults it. Architect
+  # analysis (#3101): there is no data race (approvals are a shared
+  # in-memory map, consulted/persisted synchronously, single-threaded
+  # asyncio) -- the bug is purely that the fan-out's `max_parallel: 4`
+  # starts every pattern's permission consult BEFORE any of them has
+  # reached the grant, so each one independently JIT-prompts (N prompts for
+  # 1 conceptual approval, and #3101's witness saw a `.txt` pattern denied
+  # mid-run because ITS prompt was answered "no" while another pattern's
+  # "yes, recursively" was still in flight). Gating the directory ONCE,
+  # here, before the fan-out starts means every pattern the fan-out globs
+  # is a descendant of `input_path` and therefore already covered by the
+  # recursive grant this call either found pre-existing or, on a fresh
+  # corpus, obtained interactively right here -- decision-enabling: the
+  # operator sees ONE prompt naming the corpus directory, not one per file
+  # extension. No new permission model or op -- this reuses `glob_files`'
+  # existing `require_file_read` gate (src/reyn/core/op_runtime/file.py),
+  # just called once, serially, ahead of the parallel patterns.
+  #
+  # `schema: PreflightCheck` is REQUIRED here (unlike the fan-out `do:`
+  # step below, where #3099 corrective (a) made a per-call schema gate
+  # redundant): this is a single, non-fan-out `tool:` step, and only the
+  # fan-out coordinator was taught to trip `on_error` on a canonical error
+  # result (#3099). A bare `tool:` step still returns a `status: "denied"`
+  # result NORMALLY (`execute_op` degrades every op error to a status-
+  # carrying dict rather than raising) -- without this gate, a denied
+  # upfront glob would flow on silently instead of aborting cleanly the
+  # same way the fan-out below does.
+  - tool:
+      name: glob_files
+      schema: PreflightCheck
+      args:
+        pattern: !expr ctx.input_path
+        max_results: !expr ctx.max_files
+        absolute: true
+      output: upfront_glob
+
   # #3095/#3099 corrective (a): the `on_error: abort` below FIRES on a
   # `glob_files` failure without any `schema:` gate. #3098 landed an interim
   # `schema: PreflightCheck` here (a non-"ok" status fails validation and
@@ -496,7 +546,11 @@ steps:
   # below -- see `meta.isError` further down this file), not just a raised
   # exception. The per-call `schema: PreflightCheck` gate is therefore
   # redundant here and removed -- point-fix + the now-general mechanism
-  # would otherwise coexist (owner no-debt ruling).
+  # would otherwise coexist (owner no-debt ruling). By the time this fan-out
+  # starts, the #3101 upfront step above has already established (or
+  # confirmed) the recursive read-grant on `input_path`, so every pattern
+  # here -- a descendant path -- resolves as a synchronous grant HIT with no
+  # further prompt.
   - for_each:
       over: ctx.file_patterns
       max_parallel: 4
@@ -533,17 +587,24 @@ steps:
             absolute: true
       collect: {transform: {value: "pipe"}}
       output: globbed
-  # Flatten one list per pattern into one flat file list. `structured` is
-  # glob's real list of paths (#2994); before that it was newline-joined
-  # text, which R1 (no `split`) could not consume at all -- the reason this
-  # step had to be a python shell-out. Every item reaching here is now
-  # GUARANTEED `status: "ok"` (the `for_each: on_error: abort` above now
-  # fires on a canonical-error result too -- #3099 corrective (a) -- so a
-  # failed glob never survives to be collected), so `.structured` is
-  # guaranteed a list -- `acc + item.structured` can no longer see a dict.
+  # Flatten one list per pattern into one flat file list, SEEDED with the
+  # #3101 upfront glob's own match(es) (`ctx.upfront_glob.structured` --
+  # `init`, like every other step, is a plain R1 expression evaluated
+  # against `ctx`) so the "input_path names a single FILE" match that step
+  # discovers is not lost now that it is no longer one of the fan-out's own
+  # patterns. `structured` is glob's real list of paths (#2994); before
+  # that it was newline-joined text, which R1 (no `split`) could not
+  # consume at all -- the reason this step had to be a python shell-out.
+  # Every item reaching here from the fan-out is now GUARANTEED
+  # `status: "ok"` (the `for_each: on_error: abort` above now fires on a
+  # canonical-error result too -- #3099 corrective (a) -- so a failed glob
+  # never survives to be collected), and the upfront glob is GUARANTEED
+  # `status: "ok"` by its own `schema: PreflightCheck` gate above, so
+  # `.structured` is guaranteed a list on both sides -- `acc + item.structured`
+  # can no longer see a dict.
   - fold:
       over: ctx.globbed
-      init: "[]"
+      init: "ctx.upfront_glob.structured"
       do: {transform: {value: "acc + item.structured"}}
       output: files
 

--- a/tests/test_3101_rag_ingest_upfront_permission_gate.py
+++ b/tests/test_3101_rag_ingest_upfront_permission_gate.py
@@ -1,0 +1,298 @@
+"""Tier 2b: #3101 -- ``rag_ingest.yaml``'s ``_ingest_body`` file-discovery
+fan-out gates the corpus directory (``input_path``) ONCE, upfront and
+serially, before the parallel ``glob_files`` fan-out over the 6 file-
+extension patterns -- architect design (issue #3101, two comments: the
+upfront-gate design + the concurrency-race analysis).
+
+Root cause (real witness, architect-confirmed via primary-data read of
+``permissions.py``): NO data race exists (approvals are a shared in-memory
+map, consulted/persisted synchronously inside a single-threaded asyncio
+process). The bug is purely CONSUMPTION: the file-discovery ``for_each``
+(``max_parallel: 4``) used to fan out over 7 patterns (6 extensions +
+``input_path`` itself), each independently calling ``require_file_read``
+BEFORE any of them reached a grant -- so ONE conceptual "approve the corpus"
+answer produced N concurrent JIT prompts (the reported witness: an operator
+answered "yes, recursively" once, yet a `.txt` pattern was denied a second
+later because its own prompt raced the recursive grant's persistence).
+
+Fix: ``_ingest_body`` now globs ``input_path`` itself in a single, SERIAL
+``tool:`` step (``schema: PreflightCheck``-gated so a denial aborts cleanly,
+same shape as X1's MCP pre-flight) BEFORE the parallel extension-pattern
+fan-out. By the time the fan-out starts, the corpus directory's recursive
+read-grant is already established (existing OR obtained via that one JIT
+prompt), so every fan-out pattern -- a descendant path of ``input_path`` --
+resolves as a synchronous grant HIT (``permissions.py``'s
+``_is_path_approved_for``'s recursive-parent match), never a race. This
+reuses the EXISTING permission model (the JIT prompt's "[r] grant the
+parent directory recursively" choice, ``permissions.py:744``) -- no new
+permission concept, no new op.
+
+Harness: drives ``_ingest_body`` (the real pipeline doc, loaded from the
+real ``rag_ingest.yaml`` via the real ``PipelineExecutor`` + ``PipelineRegistry``)
+against a REAL ``PermissionResolver`` (interactive) + a REAL, RequestBus-
+compatible Fake that pre-answers with a scripted choice (mirrors
+``tests/test_require_file_jit_ask_1505.py``'s ``_FakeBus`` -- no mocks) and
+the REAL ``glob_files`` tool handler (``reyn.tools.file._handle_glob`` via
+``reyn.tools.pipeline_verbs._make_tool_dispatch`` -- the exact seam a
+``tool:`` pipeline step dispatches through in production). The corpus
+directory is a genuine ``tmp_path``-sibling folder OUTSIDE the test
+project's root (the real-world "corpus is somewhere else on disk" case that
+triggers the JIT prompt at all -- an in-project corpus never leaves the
+default zone and this bug would never surface).
+
+The harness stops ``_ingest_body`` at file discovery: the corpus directory
+is left with no files matching the tested extensions, so the per-file
+``for_each`` (the NEXT fan-out, over ``ctx.files``) is a structural no-op and
+the run proceeds straight to the ``list_metadata`` MCP call, which fails
+cleanly (no MCP servers wired in this harness -- only the file-discovery
+permission path is under test) -- the expected, asserted-on abort point,
+distinguished from a permission-path abort by its error text.
+
+strip-falsify (verified manually while developing the fix, documented here
+per the ``test_ingest_file_discovery_aborts_clean_on_unreadable_input_path``
+precedent in ``tests/test_fp0063_p3_rag_pipelines.py``): reverting
+``rag_ingest.yaml`` to fold ``input_path`` back into the parallel
+``for_each`` (the pre-#3101 shape: 7 patterns, ``max_parallel: 4``, no
+upfront gate) against ``test_upfront_gate_answers_exactly_once`` below
+reproduces MULTIPLE ``bus.asks`` entries (one per pattern whose consult
+raced ahead of the recursive grant) instead of the fixed shape's single
+entry -- i.e. the upfront-gate step is load-bearing for the "one approval
+covers the corpus" contract this test pins.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import reyn.builtin as _builtin_pkg
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.pipeline.executor import PipelineExecutor
+from reyn.data.pipelines.registry import build_pipeline_registry
+from reyn.data.workspace import Workspace
+from reyn.intervention_choices import NO, RECURSIVE
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.tools.pipeline_verbs import _make_tool_dispatch
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+_RAG_PLUGIN_DIR = Path(_builtin_pkg.__file__).resolve().parent / "plugins" / "rag"
+_INGEST_PATH = _RAG_PLUGIN_DIR / "pipelines" / "rag_ingest.yaml"
+
+
+class _FakeBus:
+    """Real RequestBus-compatible Fake that pre-answers with a scripted
+    choice -- same pattern as ``tests/test_require_file_jit_ask_1505.py``'s
+    ``_FakeBus`` / ``tests/test_config_write_jit_bus_3086.py``'s -- no mocks."""
+
+    def __init__(self, choice: str) -> None:
+        self._choice = choice
+        self.asks: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._choice, choice_id=self._choice)
+
+
+def _write_project(project_root: Path) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "reyn.yaml").write_text(
+        yaml.dump(
+            {"pipelines": {"entries": {"rag_ingest": {"path": str(_INGEST_PATH)}}}},
+            allow_unicode=True, default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _bus_wired_tool_dispatch(project_root: Path, bus: "_FakeBus", *, resolver: PermissionResolver):
+    """Build the REAL ``glob_files`` dispatch path (``_make_tool_dispatch`` ->
+    the registered ``ToolDefinition``'s handler, ``reyn.tools.file._handle_glob``)
+    wired to a REAL, interactive ``PermissionResolver`` + the given Fake bus,
+    via ``RouterCallerState.op_context_factory`` -- the same seam
+    ``build_legacy_op_context`` (``reyn/tools/op_context_bridge.py``) reads in
+    production to build the op-runtime ``OpContext`` a delegating tool handler
+    uses. No stub op_runtime handler, no bypassed permission gate."""
+    events = EventLog()
+    workspace = Workspace(
+        events=events, permission_resolver=resolver, actor="rag_ingest_test",
+        base_dir=project_root,
+    )
+    op_ctx = OpContext(
+        workspace=workspace, events=events, permission_decl=PermissionDecl(),
+        permission_resolver=resolver, actor="rag_ingest_test", intervention_bus=bus,
+    )
+    router_state = RouterCallerState(op_context_factory=lambda: op_ctx)
+    tool_ctx = ToolContext(
+        events=events, permission_resolver=resolver, workspace=workspace,
+        caller_kind="router", router_state=router_state,
+    )
+    return _make_tool_dispatch(tool_ctx)
+
+
+def _seed_ctx(corpus_dir: Path, project_root: Path) -> dict:
+    return {
+        "input_path": str(corpus_dir),
+        "output_db": str(project_root / "rag.sqlite"),
+        "chunk_size": 400,
+        "chunk_overlap_ratio": 0.125,
+        "embedding_model": "standard",
+        "markitdown_server": "reyn_markitdown",
+        "chunker_server": "reyn_chunker",
+        "vectorstore_server": "reyn_vector_store",
+        "file_extensions": ["[tT][xX][tT]", "[mM][dD]", "[pP][dD][fF]",
+                             "[xX][lL][sS][xX]", "[pP][pP][tT][xX]", "[dD][oO][cC][xX]"],
+        "max_files": 10000,
+        "filter_none_conversions": True,
+    }
+
+
+async def _run_ingest_body(project_root: Path, corpus_dir: Path, bus: "_FakeBus",
+                            resolver: PermissionResolver) -> Exception:
+    """Run the real ``_ingest_body`` pipeline doc against ``corpus_dir``,
+    return the exception the run raised (this harness wires no real MCP
+    servers -- the run is expected to fail cleanly at the FIRST MCP call
+    reached AFTER file discovery, ``list_metadata`` -- see module docstring)."""
+    _write_project(project_root)
+    registry = build_pipeline_registry(
+        {"entries": {"rag_ingest": {"path": str(_INGEST_PATH)}}}, project_root, strict=True,
+    )
+    pipeline = registry.get("rag_ingest._ingest_body")
+    schema_registry = registry.get_schema_registry("rag_ingest._ingest_body")
+    tool_dispatch = _bus_wired_tool_dispatch(project_root, bus, resolver=resolver)
+    executor = PipelineExecutor()
+    with pytest.raises(Exception) as exc_info:  # noqa: PT011 -- exact type asserted by callers
+        await executor.run(
+            pipeline, _seed_ctx(corpus_dir, project_root), tool_dispatch=tool_dispatch,
+            state_log=None, run_id="test-3101", schema_registry=schema_registry,
+        )
+    return exc_info.value
+
+
+# ---------------------------------------------------------------------------
+# 1. Fixed shape: one recursive-answer JIT prompt covers the WHOLE corpus.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upfront_gate_answers_exactly_once(tmp_path: Path) -> None:
+    """Tier 2b: #3101 -- with the upfront gate in place, a fresh OUTSIDE-
+    project corpus directory triggers EXACTLY ONE JIT permission prompt
+    (the upfront ``glob_files(input_path)`` call), regardless of the 6
+    extension patterns the fan-out below it globs afterward. Answering that
+    ONE prompt "recursive" is enough: no further prompt fires, and the run
+    proceeds past file discovery cleanly (it fails downstream at the
+    unwired ``list_metadata`` MCP call -- confirmed by the error text NOT
+    naming glob_files/permission, i.e. file discovery itself never denied).
+
+    This is the "1 approval should cover the corpus" contract #3101's
+    witness found broken (a `.txt` pattern denied mid-run despite an
+    earlier recursive "yes") -- pinned here as exactly 1 ask.
+    """
+    project_root = tmp_path / "proj"
+    corpus_dir = tmp_path.parent / f"{tmp_path.name}_outside_corpus"
+    corpus_dir.mkdir()
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root,
+        file_zone_root=project_root, interactive=True,
+    )
+    bus = _FakeBus(RECURSIVE)
+
+    exc = await _run_ingest_body(project_root, corpus_dir, bus, resolver)
+
+    asked_prompts = [a.prompt for a in bus.asks]
+    assert bus.asks, "expected at least one JIT permission prompt for a fresh outside-project corpus"
+    # Behavioral core of the fix: NONE of the prompts name a glob PATTERN
+    # (a "*" character) -- every extension pattern the fan-out globs is a
+    # descendant of the already-granted corpus root, so the fan-out itself
+    # never independently reaches the JIT-ask branch. Were the upfront gate
+    # absent (the pre-#3101 shape), each of the 6 extension patterns races
+    # its own consult and several would show up here as their own asks.
+    assert all("*" not in p for p in asked_prompts), (
+        f"a fan-out pattern prompted independently -- the upfront gate did "
+        f"not cover it: {asked_prompts!r}"
+    )
+    # The one prompt that DID fire must be about the corpus root itself.
+    assert any(str(corpus_dir.resolve()) in p for p in asked_prompts), (
+        f"the prompt must name the corpus directory itself: {asked_prompts!r}"
+    )
+    # File discovery must have succeeded cleanly (no permission denial) --
+    # the run instead fails downstream, at the harness's unwired MCP call.
+    err = str(exc)
+    assert "glob_files" not in err and "denied" not in err.lower(), (
+        f"file discovery itself must not have failed -- got: {err!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upfront_gate_denial_aborts_before_the_fan_out(tmp_path: Path) -> None:
+    """Tier 2b: #3101 -- the symmetric case: if the operator DENIES the
+    single upfront prompt, ``_ingest_body`` aborts cleanly right there
+    (the ``schema: PreflightCheck``-gated upfront step raises), and the
+    parallel extension-pattern fan-out never even starts -- so a denial
+    also produces exactly ONE prompt, never a "denied N times" storm from
+    the fan-out re-consulting each pattern independently."""
+    project_root = tmp_path / "proj"
+    corpus_dir = tmp_path.parent / f"{tmp_path.name}_outside_corpus_denied"
+    corpus_dir.mkdir()
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root,
+        file_zone_root=project_root, interactive=True,
+    )
+    bus = _FakeBus(NO)
+
+    exc = await _run_ingest_body(project_root, corpus_dir, bus, resolver)
+
+    asked_prompts = [a.prompt for a in bus.asks]
+    assert bus.asks, "the upfront prompt must fire before the abort"
+    assert all("*" not in p for p in asked_prompts), (
+        f"a denied upfront prompt must abort BEFORE the fan-out re-asks each "
+        f"pattern -- got a fan-out-shaped (glob-pattern) prompt: {asked_prompts!r}"
+    )
+    err = str(exc)
+    assert "glob_files" in err and ("denied" in err.lower() or "not permitted" in err.lower()), (
+        f"the abort must be decision-enabling about the REAL cause "
+        f"(glob_files denial), not the harness's downstream MCP stub: {err!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_upfront_grant_persists_for_a_second_run_with_no_further_prompt(tmp_path: Path) -> None:
+    """Tier 2b: #3101 -- the upfront gate's recursive grant is a REAL
+    persisted/session approval (the existing permission model, not a
+    per-run cache this pipeline invented): running ``_ingest_body`` a
+    SECOND time against the SAME corpus directory, on the SAME resolver,
+    with a bus that would now DENY anything it is asked, sees ZERO new
+    prompts -- the first run's recursive "yes" already covers it. Public-
+    surface proof (repeat the real op path, observe the real bus), not an
+    assertion on resolver private state.
+    """
+    project_root = tmp_path / "proj"
+    corpus_dir = tmp_path.parent / f"{tmp_path.name}_outside_corpus_persist"
+    corpus_dir.mkdir()
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root,
+        file_zone_root=project_root, interactive=True,
+    )
+
+    first_bus = _FakeBus(RECURSIVE)
+    await _run_ingest_body(project_root, corpus_dir, first_bus, resolver)
+    assert first_bus.asks, "the first run must have prompted at least once"
+
+    second_bus = _FakeBus(NO)  # would deny anything it is asked
+    exc = await _run_ingest_body(project_root, corpus_dir, second_bus, resolver)
+
+    assert not second_bus.asks, (
+        "the recursive grant from the first run must cover the second run's "
+        f"file discovery with NO further prompt -- got: "
+        f"{[a.prompt for a in second_bus.asks]!r}"
+    )
+    err = str(exc)
+    assert "glob_files" not in err and "denied" not in err.lower(), (
+        f"second run's file discovery must not have failed either: {err!r}"
+    )

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -628,13 +628,17 @@ def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
 def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
 ) -> None:
-    """Tier 2b: #3095 -- `_ingest_body`'s file-discovery `for_each` over
-    `glob_files` (one call per extension pattern PLUS `input_path` itself,
-    see the pipeline's own comment) must abort CLEANLY when a `glob_files`
-    call fails -- e.g. `input_path` names a folder OUTSIDE the reyn project
-    root with no `file.read` permission granted for it yet, the ordinary
-    case for a real corpus (the reported dogfood witness pointed at
-    `/tmp/rag_witness5_docs`, well outside the project).
+    """Tier 2b: #3095 -- `_ingest_body`'s file discovery (the #3101 upfront
+    `glob_files` gate against `input_path` itself, followed by a `for_each`
+    fan-out of one `glob_files` call per extension pattern -- see the
+    pipeline's own comments) must abort CLEANLY when a `glob_files` call
+    fails -- e.g. `input_path` names a folder OUTSIDE the reyn project root
+    with no `file.read` permission granted for it yet, the ordinary case for
+    a real corpus (the reported dogfood witness pointed at
+    `/tmp/rag_witness5_docs`, well outside the project). Non-interactively
+    (this test's `bus=None` path) the very FIRST `glob_files` call --
+    #3101's upfront gate -- is the one that denies and aborts; the fan-out
+    below it never runs.
 
     Before the fix, a `glob_files` failure returned NORMALLY (op_runtime's
     own `except PermissionError`/`except Exception` degrade every op error


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #3101 (permission-adjacent, architect design — co-vet: **architect**, permission-adjacent + architect-authored design).

## Contract this PR fixes (pin, do not re-derive at review time)

`rag_ingest.yaml`'s `_ingest_body` gates the **corpus directory (`ctx.input_path`) ONCE, upfront and serially**, via a single `glob_files(pattern: ctx.input_path, schema: PreflightCheck)` tool step — **before** the parallel extension-pattern fan-out (`for_each` over the 6 extension patterns, `max_parallel: 4`). By the time the fan-out starts, `input_path`'s recursive read-grant is already established (pre-existing OR obtained via that one JIT prompt), so every fan-out pattern — a descendant path of `input_path` — resolves as a synchronous grant HIT (`permissions.py`'s `_is_path_approved_for` recursive-parent match). **No new permission model, no new op** — this reuses the existing JIT prompt's `[r]` "grant the parent directory recursively" choice (`permissions.py:744`).

## Root cause (architect, primary-data read of `permissions.py`, both issue comments)

**No data race** — approvals are a shared in-memory map, consulted/persisted synchronously inside a single-threaded asyncio process; a persisted recursive grant reaches every consult that happens *after* it. The bug was pure **consumption**: the old shape fanned out 7 `glob_files` patterns (6 extensions + `input_path` itself) at `max_parallel: 4`, each independently calling `require_file_read` *before* any of them reached a grant — so one conceptual "approve the corpus" answer produced N concurrent JIT prompts, and the witness saw a `.txt` pattern denied mid-run despite an earlier recursive "yes" (a **prompt-duplication + non-determinism** failure — Product Think / determinism, not correctness).

## Fix

`src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml`'s `_ingest_body`:
- `file_patterns` no longer includes the literal `input_path` pattern (6 extension patterns only).
- New upfront step: a single, serial `tool: {name: glob_files, schema: PreflightCheck, args: {pattern: ctx.input_path, ...}}` before the `for_each` fan-out. `schema: PreflightCheck` is REQUIRED here (unlike the fan-out's own `do:` step, where #3099 corrective (a) made a per-call schema gate redundant) — a standalone `tool:` step is not covered by the fan-out coordinator's canonical-error trip, so without the schema gate a denied upfront glob would flow on silently instead of aborting cleanly.
- The `fold` that flattens the fan-out's matches into `ctx.files` now SEEDS its `init` with `ctx.upfront_glob.structured` (the upfront call's own matches — this is also what makes "`input_path` names a single FILE" still work, since that case is no longer one of the fan-out's own patterns).
- Updated the stale `_ingest_body` file-discovery comments + `tests/test_fp0063_p3_rag_pipelines.py`'s `test_ingest_file_discovery_aborts_clean_on_unreadable_input_path` docstring (mechanism-describing prose that the PR's diff falsifies — CLAUDE.md hard rule).

## Tests (`tests/test_3101_rag_ingest_upfront_permission_gate.py`, Tier 2b)

Real `PermissionResolver` (interactive) + a real RequestBus-compatible Fake (`_FakeBus`, mirrors `tests/test_require_file_jit_ask_1505.py`'s precedent — no mocks) + the REAL `glob_files` tool handler (`reyn.tools.file._handle_glob` via `reyn.tools.pipeline_verbs._make_tool_dispatch` — the exact seam a pipeline `tool:` step dispatches through in production), driving the REAL `_ingest_body` pipeline doc loaded from the real `rag_ingest.yaml`, against a genuine outside-project-root corpus directory (the real-world case that triggers the JIT prompt at all).

1. `test_upfront_gate_answers_exactly_once` — a fresh outside-project corpus triggers a JIT prompt; **none** of the recorded prompts name a glob *pattern* (a `"*"` character) — i.e. the fan-out never independently re-consulted — and the one that did fire names the corpus root itself. File discovery completes cleanly (the run fails downstream at the harness's intentionally-unwired MCP call, confirmed by the error text).
2. `test_upfront_gate_denial_aborts_before_the_fan_out` — denying the upfront prompt aborts BEFORE the fan-out starts (no fan-out-shaped prompt), i.e. no "N-denials" storm either.
3. `test_upfront_grant_persists_for_a_second_run_with_no_further_prompt` — a second run against the same corpus, same resolver, with a bus that would deny anything asked, sees **zero** further prompts (public-surface proof, no private-state assertion).

Count-based assertions were converted to behavioral ones (Tier-4 `len(...) == N` format-pinning, per `scripts/test_tier_audit.py --strict`) — e.g. instead of `len(bus.asks) == 1`, the tests assert on the **extracted prompt text** (no ask names a glob pattern; the ask that fires names the corpus root).

### strip-falsify (manually verified, not left as a permanent second code path — same precedent as `test_ingest_file_discovery_aborts_clean_on_unreadable_input_path`'s own strip-falsify note)

Reverted `rag_ingest.yaml` to the pre-fix shape (`git stash` on just that file) and re-ran `test_upfront_gate_answers_exactly_once`: it FAILED, reproducing **2 concurrent JIT prompts** for a single conceptual "approve the corpus" (`assert len(bus.asks) == 1` — pre-conversion form — got `2`, both DIFFERENT glob patterns racing ahead of the recursive grant). Restored the fix, re-ran: green again. The upfront-gate step is load-bearing.

## CI gates (all green, local, foreground)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_3101_rag_ingest_upfront_permission_gate.py tests/test_fp0063_p3_rag_pipelines.py` — 20/20 OK, 0 Tier-4 violations
- `python -m pytest -q` (repo root, foreground) — **8954 passed, 29 skipped**, 0 failures
- `python scripts/verify_module_docstrings.py src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml` — OK

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_3101_rag_ingest_upfront_permission_gate.py tests/test_fp0063_p3_rag_pipelines.py`
- [x] `python -m pytest -q` (repo root, foreground, full suite)
- [x] `python scripts/verify_module_docstrings.py src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml`
- [x] Strip-falsify: reverted the upfront-gate step, confirmed `test_upfront_gate_answers_exactly_once` fails (2 concurrent prompts reproduced); restored, confirmed green.

Closes #3101
