### PR TITLE
fix: stamp meta.isError on _fallback_structured's error branch (Closes #3104)

### DIFF
--- a/src/reyn/core/offload/canonical.py
+++ b/src/reyn/core/offload/canonical.py
@@ -1627,15 +1627,30 @@ _DISCRIMINATOR_MISS_MARKER = "_discriminator_miss"
 
 def _fallback_structured(result: dict, *, discriminator_miss: bool = False) -> CanonicalToolResult:
     """The lossless whole-dict fallback: the entire result becomes a ``structured`` attachment
-    (readable as frontmatter YAML, ``ctx.<name>.structured.<field>`` still programmatically reachable),
-    ``text`` empty. Used for a declared ``STRUCTURED_PASSTHROUGH`` producer, a provisional
+    (readable as frontmatter YAML, ``ctx.<name>.structured.<field>`` still programmatically reachable).
+    Used for a declared ``STRUCTURED_PASSTHROUGH`` producer, a provisional
     ``CANONICAL_TODO`` producer, a genuinely unregistered ``source`` (dynamic/edge), AND a mapped
     producer whose inner discriminator missed (``discriminator_miss=True`` — FP-0056 v2 piece #3, M3).
     PR-F2 emits ``canonical_fallback_used`` on the ``CANONICAL_TODO`` + unregistered paths, and piece #3
     on the discriminator-miss path (degrade-with-audit) — but NOT on ``STRUCTURED_PASSTHROUGH`` (a
-    reviewed, legitimate whole-dict view)."""
+    reviewed, legitimate whole-dict view).
+
+    #3104 — the whole-dict view is lossless but NOT error-shape-neutral: an op-level failure
+    (``_is_error``) on ANY of these paths (the 9 ``STRUCTURED_PASSTHROUGH`` admin/install verbs +
+    ``None``/unregistered + ``CANONICAL_TODO`` + discriminator-miss — the full ``_fallback_structured``
+    registry) must still surface through the SAME ``meta.isError`` + non-empty ``text`` signal
+    :func:`error_to_canonical` stamps, so the shared on_error seam (:func:`is_error_result` consumers,
+    #3105's ``_tool_step_canonical_error``) fires uniformly regardless of dispatch path. A SUCCESS
+    fallback (the common case) is unchanged: ``text=""``, ``meta={}``. Only the error branch gains a
+    signal; the whole-dict attachment (both branches) and the dispatch order in :func:`to_canonical`
+    are untouched — this is a chokepoint stamp, not a re-dispatch (FP-0056 dispatch-reorder risk
+    avoided per architect design, #3104)."""
+    is_err = _is_error(result)
     canonical = CanonicalToolResult(
-        text="", attachments=[{"kind": "structured", "data": result}], source_ref=None, meta={},
+        text=_extract_error_message(result) if is_err else "",
+        attachments=[{"kind": "structured", "data": result}],
+        source_ref=None,
+        meta={"isError": True} if is_err else {},
     )
     if discriminator_miss:
         canonical[_DISCRIMINATOR_MISS_MARKER] = True  # type: ignore[typeddict-unknown-key]

--- a/tests/test_3104_fallback_structured_error_stamp.py
+++ b/tests/test_3104_fallback_structured_error_stamp.py
@@ -1,0 +1,200 @@
+"""Tier 1/2: #3104 — ``_fallback_structured`` stamps ``meta.isError`` (+ non-empty ``text``) on an
+op-level ERROR result, closing the census gap #3105 (corrective (a)) flagged during co-vet.
+
+Background (#3099 → #3105 → #3104): #3099's corrective (a) taught ``for_each``/``parallel``
+``on_error`` to consume the ALREADY-COMPUTED canonical error signal (``meta.isError`` on a
+``tool:`` step's converted ``ctx_result`` — ``reyn.core.pipeline.executor._tool_step_canonical_error``).
+That signal comes from ``reyn.core.offload.canonical.to_canonical``, whose dispatch (:func:`to_canonical`
+in ``canonical.py``) EXITS via ``_fallback_structured`` for a declared ``STRUCTURED_PASSTHROUGH``
+producer or a genuinely-unregistered ``source`` BEFORE ``is_error_result``/``error_to_canonical`` ever
+runs — so an op-level failure on one of the 9 ``STRUCTURED_PASSTHROUGH`` admin/install verbs
+(``mcp_drop_server``/``mcp_install``/``mcp_subscribe_resource``/``mcp_unsubscribe_resource``/
+``pipeline_install``/``plugin_install``/``plugin_uninstall``/``presentation_install``/``skill_install``)
+— or ``None``/unregistered, ``CANONICAL_TODO``, or a mapper's discriminator-miss fallback — never got
+``meta.isError`` stamped, so a declared ``on_error`` fan-out over one of these ops silently never
+triggered (the same class of gap #3099 closed for MAPPED producers, left open here — #3105's co-vet
+flagged it as REQUIRED, user-pipeline reachable via ``on_error`` fan-out over these verbs).
+
+The fix (architect design, #3104 issue comment) is a CHOKEPOINT stamp, not a dispatch reorder (the
+higher-risk FP-0056 dispatch-reorder alternative was explicitly rejected): ``_fallback_structured``
+itself now stamps ``meta.isError`` + the extracted error message on its ERROR branch only (``_is_error``
+— the SAME predicate ``error_to_canonical`` uses), leaving the SUCCESS branch (``text=""``, ``meta={}``)
+byte-for-byte unchanged. Because every one of the 9 ops + ``None``/unregistered + ``CANONICAL_TODO`` +
+discriminator-miss ALL funnel through this one function (``to_canonical``'s three call sites at
+:1680/:1684/:1693 in ``canonical.py``), the fix covers the whole registry from one seam — no per-op
+patch, no dispatch-order change.
+
+Real registrations only (no mocks): ``import reyn.core.op_runtime`` registers all 9 real
+``STRUCTURED_PASSTHROUGH`` declarations at import time (the same registration every real op call goes
+through in production) — the registry-derived list below is read back from the SAME
+``reyn.core.offload.canonical._DECLARATIONS`` registry the coverage-gate test
+(``test_fp0056_m3_fail_visible.py``) already reads, not a hand-typed guess.
+"""
+from __future__ import annotations
+
+import pytest
+
+# Registers every real op handler's canonical declaration (the 9 STRUCTURED_PASSTHROUGH admin/install
+# verbs among them) — the same import path every real op dispatch goes through in production.
+import reyn.core.op_runtime as _op_runtime  # noqa: F401
+from reyn.core.offload.canonical import (
+    _DECLARATIONS,
+    STRUCTURED_PASSTHROUGH,
+    _fallback_structured,
+    to_canonical,
+)
+from reyn.core.pipeline.executor import (
+    ExprRef,
+    ForEachStep,
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+
+# Registry-derived (not hand-typed): every source_id the real registrations declared
+# STRUCTURED_PASSTHROUGH, read back from the SAME registry the coverage-gate test consults.
+_STRUCTURED_PASSTHROUGH_SOURCES = sorted(
+    k for k, v in _DECLARATIONS.items() if v is STRUCTURED_PASSTHROUGH
+)
+
+
+def test_registry_actually_declares_the_nine_admin_install_verbs() -> None:
+    """Tier 1: vacuity guard — the registry-derived list is non-trivial and names exactly the 9
+    admin/install verbs the #3104 fix design enumerates (fails loudly if a future PR adds/removes a
+    STRUCTURED_PASSTHROUGH declaration without updating this expectation)."""
+    assert _STRUCTURED_PASSTHROUGH_SOURCES == [
+        "mcp_drop_server",
+        "mcp_install",
+        "mcp_subscribe_resource",
+        "mcp_unsubscribe_resource",
+        "pipeline_install",
+        "plugin_install",
+        "plugin_uninstall",
+        "presentation_install",
+        "skill_install",
+    ]
+
+
+@pytest.mark.parametrize("source", _STRUCTURED_PASSTHROUGH_SOURCES)
+def test_structured_passthrough_op_error_result_stamps_meta_iserror(source: str) -> None:
+    """Tier 1: every registered STRUCTURED_PASSTHROUGH op's op-level FAILURE (the real
+    ``execute_op``-degrade shape: ``{status: "error", error: <message>}``) canonicalizes with
+    ``meta.isError`` set and a non-empty ``text`` carrying the message — closing the #3105-flagged gap
+    for the full 9-op registry from the ``_fallback_structured`` chokepoint."""
+    result = {"kind": source, "status": "error", "error": f"{source} failed: quota exceeded"}
+    canonical = to_canonical(result, source=source)
+    assert canonical["meta"] == {"isError": True}
+    assert canonical["text"] == f"{source} failed: quota exceeded"
+    # Lossless: the whole dict still rides the structured attachment (chokepoint stamp, not a
+    # dispatch reorder — error_to_canonical's mapper path is untouched).
+    assert canonical["attachments"] == [{"kind": "structured", "data": result}]
+
+
+@pytest.mark.parametrize("source", _STRUCTURED_PASSTHROUGH_SOURCES)
+def test_structured_passthrough_op_success_result_meta_stays_empty(source: str) -> None:
+    """Tier 1: negative/pin — a SUCCESS result on the same 9 ops is byte-for-byte unaffected —
+    ``meta == {}`` and ``text == ""`` still, exactly as before #3104. The fix stamps the ERROR branch
+    only; it must never mislabel a success passthrough as an error."""
+    result = {"kind": source, "status": "ok", "installed": True}
+    canonical = to_canonical(result, source=source)
+    assert canonical["meta"] == {}
+    assert canonical["text"] == ""
+    assert canonical["attachments"] == [{"kind": "structured", "data": result}]
+
+
+def test_unregistered_source_error_result_also_stamps_meta_iserror() -> None:
+    """Tier 1: a genuinely-unregistered/``None`` ``source`` (the other ``_fallback_structured`` entry
+    besides STRUCTURED_PASSTHROUGH) gets the same error stamp — the chokepoint covers this path too,
+    not just the 9 named ops."""
+    result = {"kind": "totally_unknown_producer", "status": "error", "error": "boom"}
+    canonical = to_canonical(result, source="totally_unknown_producer")
+    assert canonical["meta"] == {"isError": True}
+    assert canonical["text"] == "boom"
+    canonical_none_source = to_canonical(result, source=None)
+    assert canonical_none_source["meta"] == {"isError": True}
+
+
+def test_discriminator_miss_error_result_stamps_meta_iserror_too() -> None:
+    """Tier 1: the discriminator-miss fallback (piece #3, M3) is the SAME ``_fallback_structured``
+    function — its ``discriminator_miss=True`` marker keeps working alongside the new error stamp
+    (the two concerns are orthogonal: one flags audit-visibility, the other flags on_error)."""
+    result = {"status": "error", "error": "inner dispatch missed"}
+    canonical = _fallback_structured(result, discriminator_miss=True)
+    assert canonical["meta"] == {"isError": True}
+    assert canonical["text"] == "inner dispatch missed"
+    assert canonical.get("_discriminator_miss") is True
+
+
+# ── end-to-end: on_error fan-out over a STRUCTURED_PASSTHROUGH op now fires (#3099 x #3104) ────────
+
+
+@pytest.mark.asyncio
+async def test_for_each_on_error_abort_fires_on_structured_passthrough_op_canonical_error():
+    """Tier 2: the #3105 on_error-consumes-canonical-error wiring (``_tool_step_canonical_error``)
+    NOW fires for a STRUCTURED_PASSTHROUGH op too (before #3104 it silently never did — the exact gap
+    #3105's co-vet flagged as required follow-up). A ``for_each`` over ``plugin_install`` calls with a
+    declared ``on_error: abort`` aborts the pipeline the same way it already does for a mapped op
+    (mirrors ``tests/test_3099_on_error_canonical_seam.py``'s ``file`` case, but for a passthrough
+    op — end-to-end through the real ``plugin_install`` STRUCTURED_PASSTHROUGH registration)."""
+    def _dispatch(name: str, args: dict) -> dict:
+        assert name == "plugin_install"
+        plugin = args["plugin"]
+        if plugin == "bad-plugin":
+            return {
+                "_canonical_source": "plugin_install",
+                "kind": "plugin_install",
+                "status": "error",
+                "error": f"install failed: {plugin} not found",
+            }
+        return {"_canonical_source": "plugin_install", "kind": "plugin_install", "status": "ok"}
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["good-plugin", "bad-plugin"],
+            on_error="abort",
+            do=ToolStep(name="plugin_install", args={"plugin": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    with pytest.raises(PipelineExecutionError, match="canonical error"):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-3104-passthrough-abort",
+        )
+
+
+@pytest.mark.asyncio
+async def test_for_each_on_error_continue_survives_good_items_over_structured_passthrough_op():
+    """Tier 2: ``on_error: continue`` over the same STRUCTURED_PASSTHROUGH op drops only the failing
+    item — the collected pipe carries the survivor, proving the trigger is real (not a false
+    positive on the success item too)."""
+    def _dispatch(name: str, args: dict) -> dict:
+        plugin = args["plugin"]
+        if plugin == "bad-plugin":
+            return {
+                "_canonical_source": "plugin_install",
+                "kind": "plugin_install",
+                "status": "error",
+                "error": "install failed",
+            }
+        return {"_canonical_source": "plugin_install", "kind": "plugin_install", "status": "ok"}
+
+    pipeline = Pipeline(steps=[
+        ForEachStep(
+            items=["good-plugin", "bad-plugin"],
+            on_error="continue",
+            do=ToolStep(name="plugin_install", args={"plugin": ExprRef("item")}),
+            collect=TransformStep(value="pipe"),
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-3104-passthrough-continue",
+    )
+    assert result.pipe_data == [
+        {"text": "", "structured": {"kind": "plugin_install", "status": "ok"}},
+    ]
+    dropped = result.completed_step_results["0.for_each.1"]
+    assert dropped["__fan_out_dropped__"] is True


### PR DESCRIPTION
**[per-PR-coder]** — architect fix design (issue #3104 comment, ground済み). corrective (a)=#3105(既に merge済)の co-vet census gap を根治。

## Gap（正確な機構）

`to_canonical`(`reyn.core.offload.canonical`)は **STRUCTURED_PASSTHROUGH 宣言の op**（9 admin/install verb: `mcp_drop_server`/`mcp_install`/`mcp_subscribe_resource`/`mcp_unsubscribe_resource`/`pipeline_install`/`plugin_install`/`plugin_uninstall`/`presentation_install`/`skill_install`）や `None`/unregistered/`CANONICAL_TODO`/discriminator-miss を `_fallback_structured` に dispatch し、`is_error_result`/`error_to_canonical` の前で EXIT する。`_fallback_structured` は常に `meta={}` を返していたため、これらの op-level 失敗が `meta.isError` を立てず、#3105 が実装した on_error-consumes-canonical-error 配線（`_tool_step_canonical_error`）が発火しなかった。**user-pipeline reachable**（ユーザが on_error でこれらの op に fan-out する pipeline を書ける）。

## Fix = chokepoint（architect 設計、dispatch 並替なし）

`_fallback_structured`（`canonical.py`）の **error 形にのみ** `_is_error` に基づき `meta.isError` + `_extract_error_message` を stamp。成功/passthrough 形（`text=""`, `meta={}`）は無変更。`to_canonical` の dispatch 順序・`error_to_canonical`/mapper path は無変更 — FP-0056 dispatch-reorder の higher-risk 代替案は不採用（architect 設計どおり）。

`_fallback_structured` は STRUCTURED_PASSTHROUGH の 9 op + `None`/unregistered + `CANONICAL_TODO` + discriminator-miss の**全経路が集まる 1 箇所**なので、1 箇所の stamp で registry 全体を cover する（per-op patch ではなく seam 高度の fix）。

## 下流安全性の独立確認

- `meta=={}` を fallback 判定に使う consumer は grep で確認した限り**存在しない** — `canonical_fallback_reason`（監査イベント判定）は `_DISCRIMINATOR_MISS_MARKER`/宣言の種類で判定しており `meta` を見ない。
- `canonical.py:1786`（`canonical_degraded_reason`）の consumer は既に `_is_error(result) or meta.isError` の両方を見ており、fix は両 signal を一致させるのみ（競合なし）。`_fallback_structured` の attachments は常に非空なので `canonical_degraded_reason` はこの経路で元々発火しない。
- `seam.py:88` は `meta` から `isError` キーを明示的に除外して frontmatter に渡している（isError は error 描画の別経路で処理）— fix と整合。
- `executor.py:670`（`_tool_step_canonical_error`）は `result.get("meta")` の `isError` を読むだけで、`to_canonical` 変換後の shape に依存しており fix の恩恵をそのまま受ける。

## Strip-falsify

`src/reyn/core/offload/canonical.py` の stamp のみ revert して新規テストを実行 → 13/23 が RED（gap の再現: `meta=={}` のまま、on_error abort/continue テストも失敗）。revert 解除で 23/23 GREEN に復帰。

## Test（testing.ja.md 準拠）

`tests/test_3104_fallback_structured_error_stamp.py`:
- registry-derived な 9 op 列挙（vacuity-guard 付き、`reyn.core.offload.canonical._DECLARATIONS` から読み戻し・ハードコードでない）
- 9 op 全てで op-level error → `meta.isError` + non-empty text を確認（parametrize）
- 9 op 全てで **成功形には `meta.isError` が付かない**negative/pin test（parametrize）
- `None`/unregistered、discriminator-miss の 2 path も個別確認
- end-to-end: `plugin_install` への `on_error: abort`/`continue` fan-out が実際に発火/生存することを real `PipelineExecutor` で確認（`tests/test_3099_on_error_canonical_seam.py` と同じ実型パターン、mock 不使用）

## CI gate（全て green、ローカル実行済）

- `ruff check src tests` — All checks passed
- `python scripts/test_tier_audit.py --strict tests/test_3104_fallback_structured_error_stamp.py` — 7/7 OK
- `PYTHONPATH=src python3 -m pytest`（foreground, timeout 600000ms） — 8974 passed, 29 skipped
- `python scripts/verify_module_docstrings.py src/reyn/core/offload/canonical.py` — OK

## co-vet

**architect co-vet 必須**。私（per-PR-coder）は co-vet + CI green まで merge しません。

land すれば #3105 の interim doc 注記（"passthrough verb は on_error を trigger しない"限界）は不要化します（architect のコメント参照）。

Closes #3104

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>