### PR TITLE
refactor(session): extract hook-event/reactivity bundle builder (#3082 Family 3, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -704,6 +704,35 @@ class _RecoveryBundle:
     journal: SnapshotJournal
 
 
+@dataclass(frozen=True)
+class _HookEventBundle:
+    """#3082 Family 3: the hook-event / reactivity spine — ``hook_bus``
+    (the per-Session HookBus, Phase 4a) → ``hook_dispatcher`` (the awaited
+    HookDispatcher every lifecycle dispatch() site routes through) →
+    ``fs_watcher`` (the session-owned filesystem watcher, #2608 H4) →
+    ``composer_registry`` (the composed:* Composers) → ``composed_consumer``
+    (the composed:*→Sync bridge) → ``hot_reloader`` (the IN-set config
+    hot-reloader). Pure output→input value object:
+    :meth:`Session._build_hook_event_bundle` is a byte-identical extraction of
+    the construction sequence that used to run inline in ``Session.__init__``
+    — same objects, same construction order, same args (eager sibling reads
+    use the builder's LOCAL variables; deferred lambdas keep resolving
+    ``self._hook_dispatcher`` / ``self._chat_events`` at call time, exactly as
+    before). This family CONSUMES Family 1's ``chat_events`` (the
+    ``hot_reloader`` reads it eagerly at construction), so the builder is
+    invoked AFTER the audit-event bundle is unpacked — the #3082 pipeline's
+    output→input order. Config-derivation (``_boot_in_set`` /
+    ``_composer_defs`` / ``_composed_schemas`` / ``_fs_watch_cfg``) is a
+    precursor that stays inline and is threaded in as explicit inputs."""
+
+    hook_bus: "HookBus"
+    hook_dispatcher: "HookDispatcher"
+    fs_watcher: "FsWatcher"
+    composer_registry: "ComposerRegistry"
+    composed_consumer: "ComposedEventConsumer"
+    hot_reloader: "HotReloader"
+
+
 class Session:
     def __init__(
         self,
@@ -1262,25 +1291,15 @@ class Session:
             elicitation_gate=lambda: self._interventions.has_active_listener(),
             agent_name=self.agent_name,
         )
-        # #2608 H4: the session-owned filesystem watcher (see
-        # reyn.runtime.fs_watcher's module docstring for the thread->async
-        # bridge design). Constructed unconditionally (cheap — no OS thread
-        # spun up here, only inside FsWatcher.start()); ``hook_trigger`` is the
-        # SAME deferred-lambda-over-``self._hook_dispatcher`` pattern H1 uses
-        # above (the dispatcher itself is built later in this __init__, but
-        # this lambda is never CALLED until FsWatcher.start() is awaited from
-        # ``run()``, long after __init__ has finished). ``paths``/
-        # ``debounce_seconds`` default to empty/0.2 when no ``fs_watch:``
-        # config block was resolved (mirrors ``hooks_config`` defaulting to []).
+        # #2608 H4 / #3082 Family 3: resolve the ``fs_watch:`` config block here
+        # (a precursor / builder input); the FsWatcher itself is constructed in
+        # ``_build_hook_event_bundle`` alongside the rest of the hook-event
+        # family. ``paths``/``debounce_seconds`` default to empty/0.2 when no
+        # ``fs_watch:`` config block was resolved (mirrors ``hooks_config``
+        # defaulting to []).
         from reyn.config.infra import FsWatchConfig
-        from reyn.runtime.fs_watcher import FsWatcher
         _fs_watch_cfg = (
             fs_watch_config if isinstance(fs_watch_config, FsWatchConfig) else FsWatchConfig()
-        )
-        self._fs_watcher = FsWatcher(
-            paths=_fs_watch_cfg.paths,
-            debounce_seconds=_fs_watch_cfg.debounce_seconds,
-            hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
         )
         self.output_language = output_language
         self._prompt_cache_enabled = prompt_cache_enabled
@@ -1426,26 +1445,12 @@ class Session:
         # restore_state.  Cleared (durably) after injection at the trigger turn.
         self._next_turn_context: list[dict] = []
 
-        # #1800 slice 5b: the awaited HookDispatcher. Hooks load from the resolved
-        # ``hooks:`` block; None/absent → empty registry → every dispatch() is a
-        # no-op (run-loop byte-identical to a hooks-free build). Constructed
-        # unconditionally so the 4 lifecycle dispatch() sites are uniform.
-        from reyn.hooks.bus import HookBus
-        from reyn.hooks.dispatcher import HookDispatcher
-        # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): one HookBus
-        # PER SESSION, constructed here alongside the HookDispatcher it feeds
-        # and never shared across sessions (§3.3 v1 = per-Session scope — no
-        # cross-session event observation/correlation). No subscriber ever
-        # attaches unless something explicitly calls ``session._hook_bus.
-        # subscribe()`` (nothing does yet in Phase 4a — the Composer, Phase
-        # 4b, is the first consumer) — until then this is a no-op alongside
-        # every dispatch() call (see HookBus.publish's zero-subscriber path).
-        # #2886: the same deferred-lambda emit_event sink threaded into
-        # HookDispatcher/Composer below (self._chat_events is assigned later
-        # in __init__; the lambda only resolves it at first-drop time, never
-        # at construction) — so a subscriber-queue drop is fail-visible via a
-        # metadata-only bus_subscriber_dropped P6 audit-event.
-        self._hook_bus = HookBus(emit_event=lambda et, **d: self._chat_events.emit(et, **d))
+        # #1800 slice 5b / #3082 Family 3: the HookBus + awaited HookDispatcher
+        # (+ fs_watcher / composers / hot_reloader) are constructed together in
+        # ``_build_hook_event_bundle`` (invoked below, after the Family 1
+        # chat_events assignment this family consumes). The config-derivation
+        # that feeds them — the startup hooks/composers layers, the boot IN-set,
+        # and the composer defs/schemas — stays inline here as builder inputs.
         # #2073 S2b: hooks are LAYERED — the reyn.yaml startup layer (OUT-set,
         # captured once here, NEVER re-read on a reload) ∪ the .reyn/hooks.yaml
         # runtime layer (IN-set, hot-reloadable; the LLM-op writes it in S3).
@@ -1487,70 +1492,6 @@ class Session:
         self._composed_schemas: "dict[str, frozenset[str]]" = {
             d.emit_kind: frozenset({"inputs", "correlation_key"}) for d in self._composer_defs
         }
-        self._hook_dispatcher = HookDispatcher(
-            self._build_hook_registry(_boot_in_set),
-            put_inbox=self._put_inbox,
-            stage_next_turn_context=self._stage_next_turn_context,
-            # #2072: route a push whose `session` names a different session to THAT session
-            # (cross-session); `current_session_id` keeps a self/unnamed push local.
-            cross_session_put=self._cross_session_hook_put,
-            current_session_id=self._session_id,
-            # #2608 H3: launch a registered pipeline from a hook's
-            # pipeline_launch action (async/detached start_pipeline_run) —
-            # the closure resolves against THIS session's own PipelineRegistry
-            # / AgentRegistry / StateLog / (agent, sid) identity.
-            launch_pipeline=self._launch_pipeline_from_hook,
-            # #2285: per-session hook applicability gate — skip a hook this session disabled. A
-            # callable (not a snapshot) so a toggle applies live to the next dispatch.
-            is_hook_disabled=lambda hook: hook.name is not None and hook.name in self._disabled_hooks,
-            sandbox_config=self._sandbox_config,
-            sandbox_backend=self._sandbox_backend,
-            # #2095: route a not-yet-allowlisted shell-hook's consent prompt
-            # through this session's RequestBus, but ONLY when a live
-            # intervention listener is attached (TUI / web / A2A-override) —
-            # i.e. a surface that will actually answer. ``has_active_listener``
-            # is checked per-dispatch (listeners attach/detach after this
-            # construction: TUI mount, A2A request windows). Plain mcp-serve and
-            # headless (no listener) → the dispatcher passes consent_bus=None →
-            # the runner's REYN_ACCEPT_HOOKS / fail-closed path, and ``reyn run``
-            # on a TTY (no listener) → the runner's stdin prompt — both
-            # byte-identical to pre-#2095.
-            consent_bus=self.as_request_bus(),
-            # Lambda defers the lookup: ``self._interventions`` is constructed
-            # below this point, and the gate is only called at dispatch time.
-            consent_gate=lambda: self._interventions.has_active_listener(),
-            # #2095 P3: P6-event sink so an auto-run (allowlisted) shell hook
-            # surfaces in the events tab instead of being a silent side-effect.
-            # Lambda defers ``self._chat_events`` (assigned below this point);
-            # only called at dispatch time.
-            emit_event=lambda et, **d: self._chat_events.emit(et, **d),
-            # Phase 4a: broadcast every dispatched HookEvent to this session's
-            # own bus, independently of the Sync hooks_for() loop above.
-            bus=self._hook_bus,
-        )
-        # Hook-Event Redesign Phase 4b/5 (#2880/#2881): the Composer definitions
-        # (``self._composer_defs``, built above — ahead of the hook registry,
-        # #2889) + the composed:*->Sync consumer bridge. Neither is STARTED
-        # here (starting means spawning background asyncio tasks, which
-        # belongs in ``run()``, this session's async entry point —
-        # construction here is synchronous); `run()` calls
-        # `self._composer_registry.start()` / `self._composed_consumer.
-        # start()` once. `stop()`ed in `run()`'s shutdown `finally` (mirrors
-        # the FsWatcher start/stop shape).
-        from reyn.hooks.composed_consumer import ComposedEventConsumer
-        from reyn.hooks.composer import Composer, ComposerRegistry
-        self._composer_registry = ComposerRegistry(
-            composers=[
-                Composer(
-                    d, bus=self._hook_bus,
-                    emit_event=lambda et, **kw: self._chat_events.emit(et, **kw),
-                )
-                for d in self._composer_defs
-            ],
-        )
-        self._composed_consumer = ComposedEventConsumer(
-            bus=self._hook_bus, dispatcher=self._hook_dispatcher,
-        )
         # #2073 S4: track the RUNTIME (.reyn/cron.yaml) cron job names so the cron
         # reapply seam can unschedule jobs removed from the runtime file WITHOUT
         # touching startup (reyn.yaml) jobs (the same startup/runtime layering as
@@ -1604,6 +1545,37 @@ class Session:
         self._event_store = _audit_bundle.event_store
         self._chat_events = _audit_bundle.chat_events
         self._otel_exporter = _audit_bundle.otel_exporter
+        # #3082 Family 3 (hook-event / reactivity): hook_bus -> hook_dispatcher
+        # -> fs_watcher -> composer_registry -> composed_consumer -> hot_reloader
+        # extracted into _build_hook_event_bundle. Byte-identical extraction —
+        # same objects, same construction order, same args as the inline
+        # sequence this replaced. Invoked HERE, right after the Family 1
+        # chat_events assignment above, because this family CONSUMES chat_events:
+        # hot_reloader reads it EAGERLY at construction (``events=chat_events``),
+        # and hook_bus / hook_dispatcher / the Composers emit through deferred
+        # ``self._chat_events`` lambdas. The config-derivation this builder
+        # takes as inputs (_boot_in_set / _composer_defs / _fs_watch_cfg) is a
+        # precursor already resolved above. See _HookEventBundle / the builder's
+        # docstring for the eager-vs-deferred sibling-reference split.
+        _hook_bundle = self._build_hook_event_bundle(
+            _boot_in_set,
+            self._composer_defs,
+            _fs_watch_cfg,
+            self._chat_events,
+            self._registry,
+            self._session_id,
+        )
+        self._hook_bus = _hook_bundle.hook_bus
+        self._hook_dispatcher = _hook_bundle.hook_dispatcher
+        self._fs_watcher = _hook_bundle.fs_watcher
+        self._composer_registry = _hook_bundle.composer_registry
+        self._composed_consumer = _hook_bundle.composed_consumer
+        self._hot_reloader = _hook_bundle.hot_reloader
+        # #2073 S3: publish as the process-wide active reloader so the hooks-write
+        # LLM-op can request_reload after writing .reyn/hooks.yaml (mirrors
+        # set_active_scheduler). Multi-session = last-registered wins (cron caveat).
+        from reyn.runtime.hot_reload import set_active_hot_reloader
+        set_active_hot_reloader(self._hot_reloader)
         # #2103 S1bc-exec: sid → original-task record for sessions THIS session spawned.
         # When a spawned session's result routes back, the result header renders
         # ``task=<the spawner's OWN request>`` from THIS trusted record (keyed by the
@@ -1616,18 +1588,6 @@ class Session:
         # agents don't accumulate display noise.
         self.is_attached: bool = False
 
-        # #2073 S1: the config hot-reloader. Reads ONLY the IN-set (.reyn/*.yaml);
-        # the OUT-set (reyn.yaml) is restart-only. Applies at the turn_end safe-point
-        # (apply_pending below). Per-component reapply seams are registered in S2.
-        from reyn.runtime.hot_reload import HotReloader, set_active_hot_reloader
-        self._hot_reloader = HotReloader(
-            project_root=getattr(self._registry, "_project_root", None) or Path.cwd(),
-            events=self._chat_events,
-        )
-        # #2073 S3: publish as the process-wide active reloader so the hooks-write
-        # LLM-op can request_reload after writing .reyn/hooks.yaml (mirrors
-        # set_active_scheduler). Multi-session = last-registered wins (cron caveat).
-        set_active_hot_reloader(self._hot_reloader)
         # #1669: publish this session's EventLog as the ambient sink for the LLM
         # acompletion chokepoint, so every in-session LLM call emits an observable
         # `llm_request` event (non-message params) without threading events through
@@ -4088,6 +4048,176 @@ class Session:
         return _RecoveryBundle(
             generation_store=generation_store,
             journal=journal,
+        )
+
+    # ── #3082 Family 3: hook-event / reactivity bundle builder ──
+
+    def _build_hook_event_bundle(
+        self,
+        boot_in_set: "dict",
+        composer_defs: list,
+        fs_watch_cfg: "object",
+        chat_events: "EventLog",
+        registry: "AgentRegistry | None",
+        session_id: str,
+    ) -> "_HookEventBundle":
+        """#3082 Family 3: build the hook-event / reactivity spine —
+        ``hook_bus`` → ``hook_dispatcher`` → ``fs_watcher`` →
+        ``composer_registry`` → ``composed_consumer`` → ``hot_reloader``, in
+        dependency order.
+
+        Byte-identical extraction of the sequence that used to run inline in
+        ``__init__`` — same objects, same construction order, same args. The
+        subtlety this family carries: eager sibling references use this
+        builder's LOCAL variables, while deferred lambdas keep resolving
+        ``self.*`` at CALL time exactly as before. Concretely — the
+        HookDispatcher's ``bus=``, the ComposedEventConsumer's ``bus=`` /
+        ``dispatcher=``, and each Composer's ``bus=`` are read AT
+        construction, before ``__init__`` unpacks the bundle onto ``self``, so
+        they must read the local ``hook_bus`` / ``hook_dispatcher``; whereas
+        fs_watcher's ``hook_trigger`` and every ``emit_event`` sink are
+        lambdas that fire only from ``run()`` / dispatch (long after
+        __init__), so they keep resolving ``self._hook_dispatcher`` /
+        ``self._chat_events`` unchanged.
+
+        Placement (call-site in ``__init__``): this family is built AFTER the
+        Family 1 audit-event bundle because it CONSUMES ``chat_events`` —
+        ``hot_reloader`` reads it EAGERLY (``events=chat_events``). That is the
+        #3082 pipeline's output→input order (Family 1 → Family 3), and it is
+        also byte-identical to the original inline code, where the
+        hot_reloader was likewise constructed after the ``chat_events`` EventLog.
+
+        Config-derivation is a precursor threaded in explicitly rather than
+        folded in: ``boot_in_set`` (the IN-set — ALSO read by cron, so it must
+        stay a shared precursor, not a hook-only concern), ``composer_defs``
+        (the resolved ComposerDefs — ALSO the source of ``_composed_schemas``),
+        and ``fs_watch_cfg`` (the resolved FsWatchConfig). ``registry`` supplies
+        the hot-reloader's project_root; ``session_id`` is the dispatcher's
+        cross-session-routing self-id.
+
+        None of the six constructors (nor FsWatcher's inner FsIngressAdapter)
+        starts a thread / task / observer — each just stores its args
+        (FsWatcher keeps ``_observer=None`` / ``_started=False``;
+        ComposerRegistry / ComposedEventConsumer keep ``_tasks=[]`` /
+        ``_task=None`` until ``start()`` is called from ``run()``), so gathering
+        them here (moving the FsWatcher / HookBus constructions down from their
+        former, earlier positions) re-times no side effect."""
+        from reyn.hooks.bus import HookBus
+        from reyn.hooks.composed_consumer import ComposedEventConsumer
+        from reyn.hooks.composer import Composer, ComposerRegistry
+        from reyn.hooks.dispatcher import HookDispatcher
+        from reyn.runtime.fs_watcher import FsWatcher
+        from reyn.runtime.hot_reload import HotReloader
+        # Hook-Event Redesign Phase 4a (proposal 0059 §3.2/§3.3): one HookBus
+        # PER SESSION, constructed here alongside the HookDispatcher it feeds
+        # and never shared across sessions (§3.3 v1 = per-Session scope — no
+        # cross-session event observation/correlation). No subscriber ever
+        # attaches unless something explicitly calls ``session._hook_bus.
+        # subscribe()`` (nothing does yet in Phase 4a — the Composer, Phase
+        # 4b, is the first consumer) — until then this is a no-op alongside
+        # every dispatch() call (see HookBus.publish's zero-subscriber path).
+        # #2886: the same deferred-lambda emit_event sink threaded into
+        # HookDispatcher/Composer below — the lambda resolves ``self._chat_events``
+        # only at first-drop time, never at construction — so a subscriber-queue
+        # drop is fail-visible via a metadata-only bus_subscriber_dropped P6
+        # audit-event.
+        hook_bus = HookBus(emit_event=lambda et, **d: self._chat_events.emit(et, **d))
+        # #1800 slice 5b: the awaited HookDispatcher. Hooks load from the resolved
+        # ``hooks:`` block; None/absent → empty registry → every dispatch() is a
+        # no-op (run-loop byte-identical to a hooks-free build). Constructed
+        # unconditionally so the 4 lifecycle dispatch() sites are uniform.
+        hook_dispatcher = HookDispatcher(
+            self._build_hook_registry(boot_in_set),
+            put_inbox=self._put_inbox,
+            stage_next_turn_context=self._stage_next_turn_context,
+            # #2072: route a push whose `session` names a different session to THAT session
+            # (cross-session); `current_session_id` keeps a self/unnamed push local.
+            cross_session_put=self._cross_session_hook_put,
+            current_session_id=session_id,
+            # #2608 H3: launch a registered pipeline from a hook's
+            # pipeline_launch action (async/detached start_pipeline_run) —
+            # the closure resolves against THIS session's own PipelineRegistry
+            # / AgentRegistry / StateLog / (agent, sid) identity.
+            launch_pipeline=self._launch_pipeline_from_hook,
+            # #2285: per-session hook applicability gate — skip a hook this session disabled. A
+            # callable (not a snapshot) so a toggle applies live to the next dispatch.
+            is_hook_disabled=lambda hook: hook.name is not None and hook.name in self._disabled_hooks,
+            sandbox_config=self._sandbox_config,
+            sandbox_backend=self._sandbox_backend,
+            # #2095: route a not-yet-allowlisted shell-hook's consent prompt
+            # through this session's RequestBus, but ONLY when a live
+            # intervention listener is attached (TUI / web / A2A-override) —
+            # i.e. a surface that will actually answer. ``has_active_listener``
+            # is checked per-dispatch (listeners attach/detach after this
+            # construction: TUI mount, A2A request windows). Plain mcp-serve and
+            # headless (no listener) → the dispatcher passes consent_bus=None →
+            # the runner's REYN_ACCEPT_HOOKS / fail-closed path, and ``reyn run``
+            # on a TTY (no listener) → the runner's stdin prompt — both
+            # byte-identical to pre-#2095.
+            consent_bus=self.as_request_bus(),
+            # Lambda defers the lookup: ``self._interventions`` is constructed
+            # later in ``__init__`` (after this builder returns), and the gate is
+            # only called at dispatch time.
+            consent_gate=lambda: self._interventions.has_active_listener(),
+            # #2095 P3: P6-event sink so an auto-run (allowlisted) shell hook
+            # surfaces in the events tab instead of being a silent side-effect.
+            # Lambda defers ``self._chat_events`` resolution to dispatch time.
+            emit_event=lambda et, **d: self._chat_events.emit(et, **d),
+            # Phase 4a: broadcast every dispatched HookEvent to this session's
+            # own bus, independently of the Sync hooks_for() loop above.
+            bus=hook_bus,
+        )
+        # #2608 H4: the session-owned filesystem watcher (see
+        # reyn.runtime.fs_watcher's module docstring for the thread->async
+        # bridge design). Constructed unconditionally (cheap — no OS thread
+        # spun up here, only inside FsWatcher.start()); ``hook_trigger`` is the
+        # SAME deferred-lambda-over-``self._hook_dispatcher`` pattern H1 uses
+        # (the dispatcher is unpacked onto ``self`` after this builder returns,
+        # but this lambda is never CALLED until FsWatcher.start() is awaited from
+        # ``run()``, long after __init__ has finished). ``paths``/
+        # ``debounce_seconds`` default to empty/0.2 when no ``fs_watch:``
+        # config block was resolved (mirrors ``hooks_config`` defaulting to []).
+        fs_watcher = FsWatcher(
+            paths=fs_watch_cfg.paths,
+            debounce_seconds=fs_watch_cfg.debounce_seconds,
+            hook_trigger=lambda point, template_vars: self._hook_dispatcher.dispatch(point, template_vars),
+        )
+        # Hook-Event Redesign Phase 4b/5 (#2880/#2881): the Composer definitions
+        # (``composer_defs``, built above — ahead of the hook registry, #2889) +
+        # the composed:*->Sync consumer bridge. Neither is STARTED here (starting
+        # means spawning background asyncio tasks, which belongs in ``run()``,
+        # this session's async entry point — construction here is synchronous);
+        # `run()` calls `self._composer_registry.start()` / `self.
+        # _composed_consumer.start()` once. `stop()`ed in `run()`'s shutdown
+        # `finally` (mirrors the FsWatcher start/stop shape).
+        composer_registry = ComposerRegistry(
+            composers=[
+                Composer(
+                    d, bus=hook_bus,
+                    emit_event=lambda et, **kw: self._chat_events.emit(et, **kw),
+                )
+                for d in composer_defs
+            ],
+        )
+        composed_consumer = ComposedEventConsumer(
+            bus=hook_bus, dispatcher=hook_dispatcher,
+        )
+        # #2073 S1: the config hot-reloader. Reads ONLY the IN-set (.reyn/*.yaml);
+        # the OUT-set (reyn.yaml) is restart-only. Applies at the turn_end safe-point
+        # (apply_pending below). Per-component reapply seams are registered in S2.
+        # Reads ``chat_events`` EAGERLY (this is why the family is built after the
+        # Family 1 bundle) and ``registry`` for its project_root.
+        hot_reloader = HotReloader(
+            project_root=getattr(registry, "_project_root", None) or Path.cwd(),
+            events=chat_events,
+        )
+        return _HookEventBundle(
+            hook_bus=hook_bus,
+            hook_dispatcher=hook_dispatcher,
+            fs_watcher=fs_watcher,
+            composer_registry=composer_registry,
+            composed_consumer=composed_consumer,
+            hot_reloader=hot_reloader,
         )
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──

--- a/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
+++ b/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
@@ -1,0 +1,343 @@
+# scaffold: triggered_by="#3082 Family 3 (hook-event / reactivity bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 3
+extraction — ``Session._build_hook_event_bundle`` pulling the six-element
+hook-event / reactivity spine (``hook_bus`` -> ``hook_dispatcher`` ->
+``fs_watcher`` -> ``composer_registry`` -> ``composed_consumer`` ->
+``hot_reloader``) out of ``Session.__init__`` into one builder returning one
+typed bundle (``_HookEventBundle``).
+
+This is a pure output->input builder pipeline stage: there is no separate
+"old" implementation left in the tree to diff against (the inline sequence
+was replaced, not duplicated), so byte-identical is pinned as the set of
+*intra-family wiring invariants* the inline sequence guaranteed and the
+builder must reproduce exactly — pinned BEHAVIORALLY (drive the wired object,
+observe the downstream family effect) rather than by peeking at private
+identity, per the Family 2 lesson:
+
+1. ``hook_dispatcher`` is wired to the family's ``hook_bus`` — a
+   ``dispatch()`` publishes onto the very bus a subscriber attached to
+   ``session._hook_bus`` observes.
+2. ``composed_consumer`` bridges family ``hook_bus`` events to the family
+   ``hook_dispatcher`` — a ``composed:*`` event published onto
+   ``session._hook_bus`` runs a Sync ``on: composed:*`` hook registered on
+   ``session._hook_dispatcher`` (proving BOTH ``consumer.bus IS hook_bus``
+   AND ``consumer.dispatcher IS hook_dispatcher`` end-to-end).
+3. ``fs_watcher``'s deferred ``hook_trigger`` lambda reaches the family
+   ``hook_dispatcher`` — the family-specific deferred wiring (the lambda
+   closes over ``self._hook_dispatcher``, which is unpacked onto ``self``
+   only AFTER the builder returns): invoking the wired trigger publishes onto
+   ``session._hook_bus``.
+4. ``hook_bus``'s ``emit_event`` sink reaches the family ``chat_events`` — a
+   forced subscriber-queue drop fires a ``bus_subscriber_dropped`` P6
+   audit-event that lands in ``session._chat_events``.
+5. ``hot_reloader.events IS chat_events`` (the value-dependency at the heart
+   of the pre-impl-caught crash: ``hot_reloader`` reads ``chat_events``
+   EAGERLY at construction, which is why the family is built AFTER Family 1)
+   — a ``hot_reloader`` reload emits a ``config_reloaded`` event that lands in
+   ``session._chat_events``.
+6. ``get_active_hot_reloader()`` publishes THIS session's ``hot_reloader``.
+
+Strip-falsify (invariant 2 is live / non-vacuous): re-running invariant 2's
+routing against a ``composed_consumer`` deliberately wired to a DIFFERENT bus
+observes NO dispatch — proving the routing observed in
+``test_composed_consumer_bridges_bus_events_to_the_family_dispatcher`` genuinely
+depends on the consumer being wired to ``session._hook_bus``, not a check that
+would pass against any bus.
+
+No new WAL-derived recovery state is introduced by this extraction (pure move
+of existing construction code), so the CLAUDE.md truncate-falsify
+recovery-feature PR gate does not apply; what this scaffold instead pins is
+that the hook-event WIRING itself survives the extraction byte-identically —
+including the reordering (fs_watcher / hook_bus move ~200+ lines down into the
+builder, and the whole family moves AFTER the Family 1 chat_events
+assignment). Per the extracted-refactor idiom
+(``docs/deep-dives/contributing/testing.md`` Annex: Scaffolding tests /
+CLAUDE.md's byte-identical-staged-externalization rule), this scaffold is
+added and removed in the SAME PR that lands the extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.hooks.bus import HookBus
+from reyn.hooks.composed_consumer import ComposedEventConsumer
+from reyn.hooks.composer import ComposerRegistry
+from reyn.hooks.dispatcher import HookDispatcher
+from reyn.hooks.event import HookEvent
+from reyn.runtime.fs_watcher import FsWatcher
+from reyn.runtime.hot_reload import HotReloader, get_active_hot_reloader
+from reyn.runtime.session import Session, _HookEventBundle
+
+_TIMEOUT = 2.0  # bounds every await so a broken wiring fails RED, never hangs
+
+
+def _make_session(
+    tmp_path: Path,
+    *,
+    name: str = "family3-hook-event-test",
+    hooks_config: "list | None" = None,
+    composers_config: "list | None" = None,
+) -> Session:
+    return Session(
+        agent_name=name,
+        state_log=StateLog(tmp_path / f"{name}.wal"),
+        snapshot_path=tmp_path / f"{name}.json",
+        hooks_config=hooks_config,
+        composers_config=composers_config,
+    )
+
+
+async def _wait_until(pred, *, timeout: float = _TIMEOUT) -> None:
+    """Poll ``pred`` to True within ``timeout`` (a broken wiring never
+    satisfies it, so the caller's assertion fails RED)."""
+    async def _loop() -> None:
+        while not pred():
+            await asyncio.sleep(0.01)
+    await asyncio.wait_for(_loop(), timeout=timeout)
+
+
+class TestFamily3HookEventBundleByteIdentical:
+    def test_session_holds_six_hook_event_attrs_of_real_types(self, tmp_path) -> None:
+        """Tier 1: the builder assigns the same SIX real object types the
+        inline sequence built, on the same Session attributes."""
+        s = _make_session(tmp_path)
+        is_hook_bus = isinstance(s._hook_bus, HookBus)
+        is_dispatcher = isinstance(s._hook_dispatcher, HookDispatcher)
+        is_fs_watcher = isinstance(s._fs_watcher, FsWatcher)
+        is_composer_registry = isinstance(s._composer_registry, ComposerRegistry)
+        is_composed_consumer = isinstance(s._composed_consumer, ComposedEventConsumer)
+        is_hot_reloader = isinstance(s._hot_reloader, HotReloader)
+        assert is_hook_bus
+        assert is_dispatcher
+        assert is_fs_watcher
+        assert is_composer_registry
+        assert is_composed_consumer
+        assert is_hot_reloader
+
+    def test_builder_returns_a_hook_event_bundle(self, tmp_path) -> None:
+        """Tier 1: calling the builder directly (public method on Session)
+        returns a ``_HookEventBundle`` with the six expected real object types
+        — the builder's contract independent of ``__init__`` unpack wiring."""
+        from reyn.config.infra import FsWatchConfig
+
+        s = _make_session(tmp_path)
+        bundle = s._build_hook_event_bundle(
+            {},                        # boot_in_set
+            [],                        # composer_defs
+            FsWatchConfig(),           # fs_watch_cfg
+            s._chat_events,            # chat_events (Family 1 EventLog)
+            s._registry,              # registry
+            "family3-direct-sid",      # session_id
+        )
+        assert isinstance(bundle, _HookEventBundle)
+        assert isinstance(bundle.hook_bus, HookBus)
+        assert isinstance(bundle.hook_dispatcher, HookDispatcher)
+        assert isinstance(bundle.fs_watcher, FsWatcher)
+        assert isinstance(bundle.composer_registry, ComposerRegistry)
+        assert isinstance(bundle.composed_consumer, ComposedEventConsumer)
+        assert isinstance(bundle.hot_reloader, HotReloader)
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_publishes_to_the_family_hook_bus(self, tmp_path) -> None:
+        """Tier 1: invariant 1 — ``hook_dispatcher.bus IS hook_bus``. A
+        ``dispatch()`` on the family dispatcher publishes onto the family bus
+        (``dispatch()`` broadcasts to ``self._bus`` unconditionally), observed
+        via ``session._hook_bus``'s own public subscribe() surface — not a
+        ``dispatcher._bus`` identity peek."""
+        s = _make_session(tmp_path)
+        sub = s._hook_bus.subscribe()
+        try:
+            await s._hook_dispatcher.dispatch("turn_end", {"chain_id": "disp-probe"})
+            event = await asyncio.wait_for(sub.get(), timeout=_TIMEOUT)
+            assert event.payload["chain_id"] == "disp-probe"
+        finally:
+            sub.close()
+
+    @pytest.mark.asyncio
+    async def test_composed_consumer_bridges_bus_events_to_the_family_dispatcher(
+        self, tmp_path
+    ) -> None:
+        """Tier 1: invariant 2 — ``composed_consumer.bus IS hook_bus`` AND
+        ``composed_consumer.dispatcher IS hook_dispatcher``, proven end-to-end:
+        a ``composed:*`` event published onto ``session._hook_bus`` is bridged
+        by the family ``composed_consumer`` into the family
+        ``hook_dispatcher``, which runs a Sync ``on: composed:*`` hook whose
+        wake=true push lands on the Session's public inbox. Observed via the
+        inbox's public ``qsize()`` — not a private wiring peek."""
+        hooks_config = [
+            {"on": "composed:family3_probe",
+             "template_push": {"message": "composed probe", "wake": True}},
+        ]
+        # a producing composer is required (the #2889 gate rejects an
+        # ``on: composed:X`` hook naming a kind no composer emits).
+        composers_config = [
+            {"name": "family3_probe", "op": "any",
+             "inputs": [{"kind": "builtin:external:file_changed"}],
+             "emit": {"kind": "composed:family3_probe"}},
+        ]
+        s = _make_session(tmp_path, hooks_config=hooks_config, composers_config=composers_config)
+        before = s.inbox.qsize()
+        s._composed_consumer.start()
+        try:
+            # publish must land AFTER the consumer's subscription is live, or
+            # HookBus's broadcast-only publish silently drops it.
+            await _wait_until(lambda: s._hook_bus.subscriber_count >= 1)
+            s._hook_bus.publish(
+                HookEvent(kind="composed:family3_probe", payload={"inputs": [], "correlation_key": "k"}),
+            )
+            await _wait_until(lambda: s.inbox.qsize() > before)
+        finally:
+            await s._composed_consumer.stop()
+        assert s.inbox.qsize() > before
+
+    @pytest.mark.asyncio
+    async def test_fs_watcher_hook_trigger_reaches_the_family_dispatcher(
+        self, tmp_path
+    ) -> None:
+        """Tier 1: invariant 3 — the family ``fs_watcher``'s deferred
+        ``hook_trigger`` lambda reaches the family ``hook_dispatcher`` (whose
+        ``dispatch()`` publishes onto the family ``hook_bus``). This is the
+        family-specific DEFERRED wiring: the lambda closes over
+        ``self._hook_dispatcher``, assigned onto ``self`` only AFTER the
+        builder returns, so this pins that the deferred reference resolves to
+        the SAME dispatcher the family built. Invoking the wired trigger
+        callable + observing the family bus is behavioral (not an identity
+        peek); a real-file-write drive (``test_2608_h4_fs_watcher.py``) is the
+        full public route but needs watchdog + is slow/flaky, unsuited to a
+        wiring scaffold."""
+        s = _make_session(tmp_path)
+        sub = s._hook_bus.subscribe()
+        try:
+            await s._fs_watcher._hook_trigger("turn_end", {"chain_id": "fs-probe"})
+            event = await asyncio.wait_for(sub.get(), timeout=_TIMEOUT)
+            assert event.payload["chain_id"] == "fs-probe"
+        finally:
+            sub.close()
+
+    @pytest.mark.asyncio
+    async def test_hook_bus_emit_event_reaches_family_chat_events(self, tmp_path) -> None:
+        """Tier 1: invariant 4 — the family ``hook_bus``'s ``emit_event`` sink
+        is wired to the family ``chat_events``. Forcing a subscriber-queue
+        overflow (publish past the subscriber maxsize without draining) makes
+        the bus drop its oldest entry and — on the first drop — fire a
+        metadata-only ``bus_subscriber_dropped`` P6 audit-event through
+        ``emit_event``; that event lands in ``session._chat_events``, observed
+        via the EventLog's public ``all()`` read."""
+        s = _make_session(tmp_path)
+        # Attach ONE never-drained subscriber, then overflow it: HookBus's
+        # default subscriber queue is bounded (128), so >128 undrained
+        # publishes guarantees at least one drop.
+        _sub = s._hook_bus.subscribe()
+        try:
+            for i in range(200):
+                s._hook_bus.publish(HookEvent(kind="turn_end", payload={"i": i}))
+            types = [e.type for e in s._chat_events.all()]
+            assert "bus_subscriber_dropped" in types
+        finally:
+            _sub.close()
+
+    @pytest.mark.asyncio
+    async def test_hot_reloader_events_is_the_family_chat_events(self, tmp_path) -> None:
+        """Tier 1: invariant 5 — ``hot_reloader.events IS chat_events`` (the
+        value-dependency whose omission from the original spec's safety
+        enumeration would have crashed construction had the builder run before
+        the Family 1 chat_events assignment). Proven behaviorally: a
+        ``hot_reloader`` reload emits a ``config_reloaded`` P6 event through
+        its ``events`` sink, which lands in ``session._chat_events`` (EventLog
+        ``all()``) iff the sink IS that EventLog."""
+        s = _make_session(tmp_path)
+        before = len(s._chat_events.all())
+        await s._hot_reloader.apply_all(exclude=frozenset({"cron"}))
+        after = [e.type for e in s._chat_events.all()]
+        assert len(after) > before
+        assert "config_reloaded" in after
+
+    def test_get_active_hot_reloader_is_this_sessions_reloader(self, tmp_path) -> None:
+        """Tier 1: invariant 6 — the builder-produced ``hot_reloader`` is
+        published process-wide via ``set_active_hot_reloader`` (the side effect
+        that moved WITH the family to after the builder call), so
+        ``get_active_hot_reloader()`` returns THIS session's instance."""
+        s = _make_session(tmp_path)
+        this_sessions_reloader = s._hot_reloader
+        assert get_active_hot_reloader() is this_sessions_reloader
+
+    @pytest.mark.asyncio
+    async def test_composer_registry_composers_subscribe_to_the_family_hook_bus(
+        self, tmp_path
+    ) -> None:
+        """Tier 1: ``composer.bus IS hook_bus`` — a started family Composer
+        subscribes to the family ``hook_bus``, observed via the bus's public
+        ``subscriber_count``. Uses a real composers_config so the family
+        registry actually holds a Composer."""
+        composers_config = [
+            {
+                "name": "family3_composer",
+                "op": "any",
+                "inputs": [{"kind": "builtin:external:file_changed"}],
+                "emit": {"kind": "composed:family3_composed"},
+            }
+        ]
+        s = _make_session(tmp_path, composers_config=composers_config)
+        before = s._hook_bus.subscriber_count
+        s._composer_registry.start()
+        try:
+            # the Composer subscribed to THIS session's bus (composer.bus IS
+            # hook_bus); _wait_until raises RED if the count never grows. Read
+            # the peak WHILE the composer is live — stop() unsubscribes it.
+            await _wait_until(lambda: s._hook_bus.subscriber_count > before)
+            peak = s._hook_bus.subscriber_count
+        finally:
+            await s._composer_registry.stop()
+        assert peak > before
+
+    @pytest.mark.asyncio
+    async def test_strip_falsify_composed_routing_is_live(self, tmp_path) -> None:
+        """Tier 1: strip-falsify — re-run invariant 2's routing with a
+        ``composed_consumer`` deliberately wired to a DIFFERENT (fresh) bus
+        instead of ``session._hook_bus``. Publishing the same composed event
+        onto ``session._hook_bus`` must NOT reach the dispatcher (the fresh-bus
+        consumer never observes it), so the inbox does NOT grow — proving the
+        real routing test genuinely depends on the consumer being wired to
+        ``session._hook_bus`` (non-vacuous)."""
+        hooks_config = [
+            {"on": "composed:family3_probe",
+             "template_push": {"message": "composed probe", "wake": True}},
+        ]
+        composers_config = [
+            {"name": "family3_probe", "op": "any",
+             "inputs": [{"kind": "builtin:external:file_changed"}],
+             "emit": {"kind": "composed:family3_probe"}},
+        ]
+        s = _make_session(tmp_path, hooks_config=hooks_config, composers_config=composers_config)
+        before = s.inbox.qsize()
+        # A consumer wired to a FRESH bus but the SAME (real) dispatcher — the
+        # single wiring under falsification is consumer.bus.
+        other_bus = HookBus()
+        poisoned = ComposedEventConsumer(bus=other_bus, dispatcher=s._hook_dispatcher)
+        poisoned.start()
+        try:
+            await _wait_until(lambda: other_bus.subscriber_count >= 1)
+            s._hook_bus.publish(
+                HookEvent(kind="composed:family3_probe", payload={"inputs": [], "correlation_key": "k"}),
+            )
+            # give any (wrongly) live routing a chance to fire, then confirm none did
+            await asyncio.sleep(0.2)
+            assert s.inbox.qsize() == before, (
+                "strip-falsify: a composed event on session._hook_bus reached the "
+                "dispatcher through a consumer wired to an UNRELATED bus — the "
+                "routing check would be vacuous"
+            )
+        finally:
+            await poisoned.stop()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — part of #3082 (Session __init__ decomposition arc). Family 3 = the hook-event / reactivity spine, extracted byte-identically per the architect's Family 3 spec + the **Option A ruling** (builder call at the post-chat_events position).

## What this does
Gathers the **six** hook-event elements out of `Session.__init__` into one instance-method builder `_build_hook_event_bundle(boot_in_set, composer_defs, fs_watch_cfg, chat_events, registry, session_id) -> _HookEventBundle`, dep-ordered:

`hook_bus → hook_dispatcher → fs_watcher → composer_registry → composed_consumer → hot_reloader`

`__init__` unpacks the 6-field bundle onto the same `self._*` attrs, then runs `set_active_hot_reloader(self._hot_reloader)` (moved with the family).

## builder shape
`_HookEventBundle` is a frozen dataclass (same shape as Family 1 `_AuditEventBundle` / Family 2 `_RecoveryBundle`). Eager sibling references (HookDispatcher/ComposedEventConsumer/Composer `bus=`/`dispatcher=`) rebind to the builder's **LOCAL** variables (the attrs aren't on `self` until the caller unpacks); deferred lambdas (fs_watcher `hook_trigger`, every `emit_event` sink) keep resolving `self._hook_dispatcher` / `self._chat_events` at call time, verbatim.

## Placement = Option A (builder call AFTER Family 1 chat_events)
The original spec placed the builder at `:1490`; **pre-impl verification caught that this crashes** — `hot_reloader` reads `events=self._chat_events` **eagerly** at construction, and `_chat_events` isn't assigned until the Family 1 bundle unpack. The architect owned the spec bug and ruled **Option A**: invoke the builder right after `self._chat_events = _audit_bundle.chat_events`. This is the #3082 pipeline's output→input order (Family 3 consumes Family 1) and byte-identical to the original inline code (hot_reloader was likewise built after the chat_events EventLog).

## Reordering safety — 4 grounds (coder re-verified)
`fs_watcher` (~210 lines) and `hook_bus` move down into the builder; the whole family moves after Family 1. Safe because:
1. **No external (non-hook) read of the 6 attrs before the builder call.** First external reads are the RouterHostAdapter (`:1783`/`:1798`/`:1799`) and `_register_hot_reload_seams()` (`:1980`), all AFTER the call site. The MCPConnectionService `hook_trigger` at the old fs_watcher position is a deferred lambda (resolves at call time, not construction).
2. **All 6 constructors + FsWatcher's inner FsIngressAdapter are side-effect-free** — each only stores its args (FsWatcher `_observer=None`/`_started=False`; ComposerRegistry/ComposedEventConsumer `_tasks=[]`/`_task=None`); threads/tasks/observers spawn only in `start()`/`run()` from `run()`. Moving the constructions re-times no side effect.
3. **All 6 deps set before the call site**: `_chat_events` (:1547), `_registry` (:1295), `_session_id` (:1374), `_boot_in_set` (:1468), `_composer_defs` (:1486), `_fs_watch_cfg` (:1277). `_sandbox_config`/`_sandbox_backend` are `@property` delegations to `self._agent` (set :872).
4. **Zero `_hook_bus`/`_hook_dispatcher` references between the old positions and the call site** except the constructions themselves (now moved).

## Shared config-derivation stays inline (input, not fold-in)
`_boot_in_set` (also read by cron `_runtime_cron_names`), `_composer_defs` (also the source of `_composed_schemas`), `_composed_schemas`, and `_fs_watch_cfg` are **precursors** left inline and threaded in as builder params — folding them in would break the cron / schema reads.

## Moved / retained side effects
- **Moved with the family**: `set_active_hot_reloader(self._hot_reloader)` + its import, to right after the builder call.
- **Retained inline**: `set_llm_request_event_log(self._chat_events)` (Family 1), `_runtime_cron_names` (cron), `_composed_schemas` (input side).

## truncate-falsify gate: N/A (justified)
This is a **pure extraction** — no new WAL-derived recovery state is introduced (the CLAUDE.md recovery-feature PR gate applies to *new* derived state). The scaffold instead pins that the hook-event **wiring** survives byte-identically.

## Byte-identical verification
Cross-tree diff vs `origin/main` confirms every constructor-arg change is a self-attr → param/local rebinding to the **same value/instance** at call time (`_boot_in_set`→`boot_in_set`, `self._session_id`→`session_id`, `bus=self._hook_bus`→`bus=hook_bus`, `self._registry`→`registry`, `self._chat_events`→`chat_events`, etc.); deferred lambdas kept `self.` verbatim. Same 7 constructor sites (FsWatcher/HookBus reordered into dep order). Pure reorder, zero logic edits.

## Scaffold test (Tier 1, `tests/scaffold/`, triggered_by/removed_by)
Behavioral intra-family wiring pins (real instances only, no mocks; private-attr reads use the Family-2 local-var idiom):
- `hook_dispatcher.bus IS hook_bus` — dispatch publishes onto `session._hook_bus`.
- `composed_consumer` bridges bus→dispatcher — a `composed:*` event on `session._hook_bus` runs a Sync `on: composed:*` hook whose wake=true push lands on the public inbox (proves consumer.bus IS hook_bus **and** consumer.dispatcher IS hook_dispatcher).
- `fs_watcher.hook_trigger → hook_dispatcher.dispatch` — the family-specific **deferred** lambda; invoking the wired trigger publishes onto `session._hook_bus`.
- `hook_bus.emit_event → chat_events.emit` — a forced subscriber-queue drop fires `bus_subscriber_dropped` into `session._chat_events`.
- **`hot_reloader.events IS chat_events`** (the architect's added value-dep pin, at the heart of the caught crash) — a reload emits `config_reloaded` into `session._chat_events`.
- `get_active_hot_reloader()` IS this session's reloader.
- `composer.bus IS hook_bus` — a started Composer subscribes to `session._hook_bus`.
- **strip-falsify**: an in-suite test wires a `composed_consumer` to a **different** bus → publishing to `session._hook_bus` does NOT reach the dispatcher (inbox unchanged), proving the routing pin is non-vacuous. Additionally confirmed out-of-band: breaking the real `composed_consumer` wiring (`bus=HookBus()`) flips the routing pin RED.

## CI gates (all green locally)
- `ruff check src tests` — passed
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family3_hook_event_bundle_byte_identical.py` — 10/10 OK, 0 Tier-4
- `pytest` (full suite) — 8994 passed, 29 skipped, 0 failed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK

## Review
**Co-vet = architect + lead independent sonnet review** (both requested; this family's ~210-line move is heavier than Family 2). Please do not merge until both verdicts + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
