### PR TITLE
refactor(session): extract cost/budget bundle builder (#3082 Family 4, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -733,6 +733,25 @@ class _HookEventBundle:
     hot_reloader: "HotReloader"
 
 
+@dataclass(frozen=True)
+class _CostBundle:
+    """#3082 Family 4: the cost/budget gateway — ``budget`` (``BudgetGateway``,
+    the per-session budget adapter that absorbs total_usage / total_cost_usd /
+    router-cap state). Single-field bundle for now (the simplest family — one
+    unconditional component, no intra-family DAG); kept as a bundle rather
+    than a bare return for pipeline-pattern consistency with Families 1-3, and
+    so it can grow without a call-site signature change if a future PR adds a
+    sibling cost component. Pure output→input value object:
+    :meth:`Session._build_cost_bundle` is a byte-identical extraction of the
+    construction that used to run inline in ``Session.__init__`` — same
+    object, same args. This family CONSUMES Family 1's ``chat_events``
+    (``BudgetGateway`` reads it eagerly at construction, ``events=``), so the
+    builder takes it as an explicit input rather than reading ``self.``
+    directly (same pattern as Family 3's ``hot_reloader``)."""
+
+    budget: "BudgetGateway"
+
+
 class Session:
     def __init__(
         self,
@@ -1664,15 +1683,17 @@ class Session:
             self._on_chat_event_for_state_change,
         )
 
-        # PR-refactor-session-1 wave 3 PR1: per-session budget adapter.
-        # Absorbs total_usage / total_cost_usd / router-cap state that
-        # previously lived as scattered attributes on Session.
-        self._budget = BudgetGateway(
-            budget_tracker=budget_tracker,
-            events=self._chat_events,
-            agent_name=self.agent_name,
-            default_router_cap=_router_cap,
+        # #3082 Family 4 (cost/budget): budget adapter extracted into
+        # _build_cost_bundle. Byte-identical extraction — same object, same
+        # args as the inline construction this replaced; unmoved (this
+        # family has no reordering — the simplest of the #3082 families).
+        # Invoked HERE (unchanged position) because it CONSUMES Family 1's
+        # chat_events, read EAGERLY (``events=``); see _CostBundle / the
+        # builder's docstring.
+        _cost_bundle = self._build_cost_bundle(
+            budget_tracker, self._chat_events, self.agent_name, _router_cap,
         )
+        self._budget = _cost_bundle.budget
 
         # PR-refactor-session-1 wave 3 PR2: memory persistence adapter.
         # Absorbs memory path resolution + remember / forget / read_body.
@@ -4219,6 +4240,49 @@ class Session:
             composed_consumer=composed_consumer,
             hot_reloader=hot_reloader,
         )
+
+    # ── #3082 Family 4: cost/budget bundle builder ──
+
+    def _build_cost_bundle(
+        self,
+        budget_tracker: "BudgetTracker | None",
+        chat_events: "EventLog",
+        agent_name: str,
+        router_cap: int,
+    ) -> "_CostBundle":
+        """#3082 Family 4: build the cost/budget gateway — ``budget``
+        (``BudgetGateway``, the per-session budget adapter). The simplest
+        family: a single unconditional component, no intra-family DAG, no
+        reordering — this builder is invoked at its ORIGINAL inline call
+        site, unmoved.
+
+        Byte-identical extraction of the construction that used to run
+        inline in ``__init__`` — same object, same args. Takes
+        ``budget_tracker`` / ``chat_events`` / ``agent_name`` / ``router_cap``
+        explicitly rather than reaching into ``self`` mid-construction:
+        ``budget_tracker`` is the LOCAL ``__init__`` parameter (NOT
+        ``self._budget_tracker``, which is a separate tracking assignment
+        made earlier in ``__init__`` for callers that receive the tracker by
+        value, and is out of scope for this extraction — same shape as
+        Family 2's ``state_log``); ``chat_events`` is Family 1's
+        ``EventLog``, read EAGERLY here (``events=chat_events``), which is
+        why this builder is invoked after the Family 1 bundle is unpacked
+        (same eager-sibling-dependency shape as Family 3's ``hot_reloader``);
+        ``agent_name`` is the property value already resolvable at the
+        original call site; ``router_cap`` is the local ``_router_cap``
+        resolved from ``safety.loop.max_router_calls_per_turn`` immediately
+        before the original inline construction.
+
+        PR-refactor-session-1 wave 3 PR1: per-session budget adapter.
+        Absorbs total_usage / total_cost_usd / router-cap state that
+        previously lived as scattered attributes on Session."""
+        budget = BudgetGateway(
+            budget_tracker=budget_tracker,
+            events=chat_events,
+            agent_name=agent_name,
+            default_router_cap=router_cap,
+        )
+        return _CostBundle(budget=budget)
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family4_cost_bundle_byte_identical.py
+++ b/tests/scaffold/test_family4_cost_bundle_byte_identical.py
@@ -1,0 +1,157 @@
+# scaffold: triggered_by="#3082 Family 4 (cost/budget bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 4
+extraction — ``Session._build_cost_bundle`` pulling the ``BudgetGateway``
+construction out of ``Session.__init__`` into one builder returning one
+typed bundle (``_CostBundle``). The simplest of the #3082 families: a single
+unconditional component, no intra-family DAG, no reordering (the builder is
+invoked at its original inline call site, unmoved).
+
+This is a pure output->input builder pipeline stage: there is no separate
+"old" implementation left in the tree to diff against (the inline sequence
+was replaced, not duplicated), so byte-identical is pinned as the set of
+*wiring invariants* the inline sequence guaranteed and the builder must
+reproduce exactly — pinned BEHAVIORALLY (drive the wired object, observe the
+downstream effect through its PUBLIC surface) rather than by peeking at
+private identity (the Family 2/3 lesson):
+
+1. ``budget.tracker IS`` the LOCAL ``budget_tracker`` __init__ parameter
+   (never ``self._budget_tracker``, a separate later tracking assignment out
+   of scope for this extraction) — observed via ``BudgetGateway.tracker``'s
+   own public property, not a private ``_tracker`` peek.
+2. ``budget``'s ``events`` sink IS Family 1's ``chat_events`` (the
+   value-dependency this family shares with Family 3's ``hot_reloader`` —
+   ``BudgetGateway`` reads ``events`` EAGERLY at construction, which is why
+   the family is built after Family 1) — proven end-to-end: exhausting the
+   router cap emits a ``router_retry_exhausted`` P6 event that lands in
+   ``session._chat_events``, observed via the EventLog's public ``all()``
+   read.
+3. ``router_cap`` passes through into the gateway's public ``router_cap``
+   property.
+
+Strip-falsify (invariant 2 is live / non-vacuous): re-running the
+router-cap-exhaustion probe against a bundle built with a DIFFERENT
+(fresh) EventLog instead of ``session._chat_events`` shows the
+``router_retry_exhausted`` event does NOT land in ``session._chat_events`` —
+proving the invariant-2 observation genuinely depends on the gateway being
+wired to ``session._chat_events``, not a check that would pass regardless.
+
+No new WAL-derived recovery state is introduced by this extraction (pure
+move of existing construction code), so the CLAUDE.md truncate-falsify
+recovery-feature PR gate does not apply. Per the extracted-refactor idiom
+(``docs/deep-dives/contributing/testing.md`` Annex: Scaffolding tests /
+CLAUDE.md's byte-identical-staged-externalization rule), this scaffold is
+added and removed in the SAME PR that lands the extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.runtime.budget.budget import BudgetTracker, CostConfig
+from reyn.runtime.errors import RouterCapExceeded
+from reyn.runtime.services.budget_gateway import BudgetGateway
+from reyn.runtime.session import Session, _CostBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family4-cost-bundle-test")
+
+
+def _exhaust_router_cap(budget: BudgetGateway) -> None:
+    """Drive ``budget`` past its configured ``router_cap`` (read via the
+    gateway's own public property, so this helper works whether the cap is 1,
+    3 [the default], or anything else) so the call ONE PAST the cap raises
+    ``RouterCapExceeded`` and, on the way, emits ``router_retry_exhausted``
+    onto the gateway's wired ``events`` sink."""
+    for _ in range(budget.router_cap):
+        budget.check_and_increment_router_cap("call")  # increments, no raise
+    with pytest.raises(RouterCapExceeded):
+        budget.check_and_increment_router_cap("one past cap")  # cap reached -> raises
+
+
+class TestFamily4CostBundleByteIdentical:
+    def test_session_holds_budget_attr_of_real_type(self, session: Session) -> None:
+        """Tier 1: the builder assigns the same real object type
+        (``BudgetGateway``) the inline sequence built, on the same
+        ``Session._budget`` attribute."""
+        is_budget_gateway = isinstance(session._budget, BudgetGateway)
+        assert is_budget_gateway
+
+    def test_builder_returns_a_cost_bundle(self, session: Session) -> None:
+        """Tier 1: calling the builder directly (public method on Session)
+        returns a ``_CostBundle`` wrapping a real ``BudgetGateway`` — the
+        builder's contract independent of ``__init__`` unpack wiring."""
+        bundle = session._build_cost_bundle(
+            None,                  # budget_tracker
+            session._chat_events,  # chat_events (Family 1 EventLog)
+            session.agent_name,
+            3,                     # router_cap
+        )
+        assert isinstance(bundle, _CostBundle)
+        assert isinstance(bundle.budget, BudgetGateway)
+
+    def test_budget_tracker_local_param_is_wired(self, tmp_path, monkeypatch) -> None:
+        """Tier 1: invariant 1 — the builder wires the LOCAL ``budget_tracker``
+        __init__ parameter into the gateway, observed via ``BudgetGateway
+        .tracker``'s own public property (not a private ``_tracker`` peek)."""
+        monkeypatch.chdir(tmp_path)
+        tracker = BudgetTracker(CostConfig())
+        s = Session(agent_name="family4-tracker-wiring-test", budget_tracker=tracker)
+        wired_tracker = s._budget.tracker
+        assert wired_tracker is tracker
+
+    def test_router_cap_param_passthrough(self, session: Session) -> None:
+        """Tier 1: invariant 3 — ``router_cap`` passes through into the
+        gateway's public ``router_cap`` property."""
+        bundle = session._build_cost_bundle(
+            None, session._chat_events, session.agent_name, 7,
+        )
+        assert bundle.budget.router_cap == 7
+
+    def test_budget_events_is_the_family_chat_events(self, session: Session) -> None:
+        """Tier 1: invariant 2 — the REAL, ``__init__``-wired
+        ``session._budget``'s ``events`` sink IS Family 1's ``chat_events``
+        (drives the actual call-site wiring, not a manually reconstructed
+        bundle). Exhausting the router cap emits a ``router_retry_exhausted``
+        P6 event that lands in ``session._chat_events`` (EventLog ``all()``)
+        iff the sink IS that EventLog."""
+        before = len(session._chat_events.all())
+        _exhaust_router_cap(session._budget)
+        after = [e.type for e in session._chat_events.all()]
+        assert len(after) > before
+        assert "router_retry_exhausted" in after
+
+    def test_strip_falsify_budget_events_wiring_is_live(self, session: Session) -> None:
+        """Tier 1: strip-falsify — re-run invariant 2's probe against a
+        gateway built with a DIFFERENT (fresh) EventLog instead of
+        ``session._chat_events`` (same construction the builder performs,
+        just pointed at an unrelated log). The ``router_retry_exhausted``
+        event must NOT land in ``session._chat_events`` — proving the
+        invariant-2 observation genuinely depends on the REAL
+        ``session._budget`` being wired to ``session._chat_events``, not a
+        check that would pass regardless of wiring (non-vacuous)."""
+        other_events = EventLog()
+        poisoned = BudgetGateway(
+            budget_tracker=None, events=other_events,
+            agent_name=session.agent_name, default_router_cap=1,
+        )
+        before = len(session._chat_events.all())
+        _exhaust_router_cap(poisoned)
+        after = [e.type for e in session._chat_events.all()]
+        assert len(after) == before, (
+            "strip-falsify: a router-cap-exhaustion event reached "
+            "session._chat_events through a gateway wired to an UNRELATED "
+            "EventLog — the invariant-2 check would be vacuous"
+        )
+        # confirm the event actually fired (just onto the OTHER log)
+        assert "router_retry_exhausted" in [e.type for e in other_events.all()]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — #3082 **Family 4 (cost/budget)** byte-identical extraction. co-vet=architect (this is the simplest family — architect judged co-vet + CI proportionate, no independent review). Landing gated on architect's co-vet + CI green.

## What this extracts (single component)

The single `BudgetGateway` construction (formerly inline at `session.py:1670`) is pulled into `Session._build_cost_bundle(...)` returning a frozen `_CostBundle(budget)` — the same builder + frozen-dataclass shape as Families 1/2/3 (`_AuditEventBundle` / `_RecoveryBundle` / `_HookEventBundle`).

**Builder shape:** `_build_cost_bundle(budget_tracker, chat_events, agent_name, router_cap) -> _CostBundle(budget)`. `self.` → local/param rebind only; the construction args, wiring, and LOCAL-param reads are byte-identical.

## No move, no reorder

Unlike Family 3 (which moved `fs_watcher` ~210 lines down), this family is the simplest: a **single unconditional component, no intra-family DAG, no reordering**. The builder is invoked at its **original inline call site (unmoved)** — placed after the Family 1 chat_events assignment because `BudgetGateway` reads `events=chat_events` EAGERLY (same value-dependency shape as Family 3's `hot_reloader`). Verified `_budget` has zero readers between the Family 1 unpack and the call site; all external readers are after it.

## `budget_tracker` is a LOCAL param

The builder reads the **LOCAL `budget_tracker` `__init__` parameter**, NOT `self._budget_tracker` (`session.py:1508`, a separate tracking assignment left untouched — same shape as Family 2's `state_log`). `_cost_warn_config` is a different, `BudgetGateway`-independent config and is likewise out of scope / untouched.

## DAG correction applied (architect's Family 4 spec)

The original #3082 DAG grouped `budget → action_usage_tracker`, but **that dependency arrow does not exist** (no cross-reference either way; different subjects — budget = token-cost gateway, action_usage_tracker = action-frequency hot-list, retrieval-adjacent). Per the architect's ruling, `action_usage_tracker` is regrouped into **Family 5 (retrieval)** and is **untouched** here. Family 4 = budget only.

## byte-identical verification (self, cross-tree diff vs merge-base)

`git diff origin/main -- src/reyn/runtime/session.py` is a pure insert/reroute: new `_CostBundle` dataclass + new `_build_cost_bundle` method + the `__init__` call site rerouted from the inline `BudgetGateway(...)` to `self._build_cost_bundle(budget_tracker, self._chat_events, self.agent_name, _router_cap)` → `self._budget = _cost_bundle.budget`. Zero logic edits; every arg is a `self.`→param/local rebind with identical value. No move ∴ no reorder analysis needed.

## truncate-falsify gate: not applicable (pure extraction)

This is a pure move of existing construction code — **no new WAL-derived recovery state** is introduced ∴ the CLAUDE.md recovery-feature truncate-falsify gate does not apply. What the scaffold pins instead is that the budget WIRING (tracker / router_cap / events) survives the extraction byte-identically.

## scaffold test (Tier 1, `tests/scaffold/`, triggered_by/removed_by, deleted in this landing PR)

`tests/scaffold/test_family4_cost_bundle_byte_identical.py` — 6 tests pinning the wiring **BEHAVIORALLY** (public surface, no private-identity peek — Family 2/3 lesson):
- `budget.tracker IS` the LOCAL `budget_tracker` param (via `BudgetGateway.tracker` public property).
- `router_cap` passthrough (via `budget.router_cap`).
- **invariant 2 (value-dependency):** the REAL `__init__`-wired `session._budget`'s `events` sink IS Family 1's `chat_events` — exhausting the router cap emits a `router_retry_exhausted` P6 event that lands in `session._chat_events`.
- builder output type (`_CostBundle.budget` = `BudgetGateway`).

**strip-falsify (non-vacuous):** a `BudgetGateway` built with a fresh unrelated `EventLog` shows the `router_retry_exhausted` event does NOT land in `session._chat_events` (it lands on the other log). I additionally self-checked by Edit-to-break the real `__init__` call site (pointing it at a fresh `EventLog`) → invariant-2 test went RED as expected → Edit-to-restore. **No `git checkout`/`git stash` on uncommitted work** was used for the falsify (per the standing hazard note).

## Gates (all green locally)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family4_cost_bundle_byte_identical.py` — 6/6 OK
- `python -m pytest` (full suite, foreground) — **9000 passed, 29 skipped, 0 failed** (321s)
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK

## co-vet request (architect)
cross-tree diff vs merge-base (pure extraction) + eager-chat_events param-ization byte-identical + budget-wiring (budget_tracker / router_cap / events) + scaffold strip-falsify.

part of #3082
