### PR TITLE
refactor(session): extract retrieval bundle builder (#3082 Family 5, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -752,6 +752,45 @@ class _CostBundle:
     budget: "BudgetGateway"
 
 
+@dataclass(frozen=True)
+class _RetrievalBundle:
+    """#3082 Family 5: the retrieval spine — the embedding block
+    (``embedding_provider`` / ``embedding_event_sink`` / ``embedding_model_class``
+    / ``action_embedding_index``, four attrs, one conditional construction
+    guarded by ``universal_wrappers_enabled and embedding_class`` with a
+    try/except None-fallback) plus ``action_usage_tracker`` (hot-list
+    freq+recency, a SEPARATE conditional guarded by
+    ``universal_wrappers_enabled and hot_list_n > 0``, also with a
+    try/except None-fallback). Regrouped here per the #3082 DAG correction
+    in the Family 4 spec (``action_usage_tracker`` was originally mis-grouped
+    under Family 4/budget; it has no dependency on ``BudgetGateway`` and is
+    retrieval-adjacent — co-located with ``action_embedding_index`` under the
+    shared ``action_retrieval`` config). Two DAG corrections also apply here:
+    the originally-listed ``render_bounds`` does not exist in this codebase
+    (dropped) and ``subscription_writer`` is WAL-derived task-subscription
+    state, not retrieval (excluded, reassigned to a later family).
+
+    Pure output→input value object, with one inversion from Families 3/4:
+    :meth:`Session._build_retrieval_bundle` is a byte-identical extraction of
+    the construction sequence that used to run inline in ``Session.__init__``
+    at its ORIGINAL position (line ~1152), which is BEFORE Family 1
+    (``_build_audit_event_bundle``) runs — so unlike ``hot_reloader``
+    (Family 3) or ``budget`` (Family 4), this family's two closures
+    (``_embedding_event_sink`` / ``_on_hot_list_changed``) do NOT take
+    ``chat_events`` as an eager builder input. They keep resolving
+    ``self._chat_events`` at CALL time (the EventLog is constructed later in
+    ``__init__``), exactly as the pre-extraction closures did — eager-izing
+    that reference here would raise ``AttributeError`` at construction, since
+    ``self._chat_events`` does not exist yet at line ~1152. The builder is an
+    instance method precisely so these closures can keep capturing ``self``."""
+
+    embedding_provider: "object | None"
+    embedding_event_sink: "object | None"
+    embedding_model_class: "str | None"
+    action_embedding_index: "object | None"
+    action_usage_tracker: "object | None"
+
+
 class Session:
     def __init__(
         self,
@@ -1143,129 +1182,23 @@ class Session:
         # lifespan / session factory when external transports are
         # configured; ``None`` skips interception (= default).
         self._outbox_interceptor: Any = None
-        # FP-0034 Phase 2 step 1: build the ActionEmbeddingIndex +
-        # EmbeddingProvider once per session when the operator has
-        # configured ``action_retrieval.embedding_class``.  Both stay
-        # None when embedding is not configured, in which case the
-        # ``search_actions`` wrapper is hidden by ``build_tools`` and
-        # the handler degrades to an empty-result response.
-        self._action_embedding_index: Any = None
-        self._embedding_provider: Any = None
-        self._embedding_model_class: str | None = None
-        # FP-0057 #2856 Part A: the TUI model-download status sink CALLABLE
-        # (set below, alongside ``_embedding_provider``), threaded onto every
-        # router OpContext as ``ctx.embedding_event_sink`` so the `embed` op
-        # (which ``ActionEmbeddingIndex`` now routes through instead of
-        # calling ``provider.embed()`` directly) can forward it into the
-        # FRESH per-call provider it resolves — preserving the download-status
-        # rows without the caller holding a long-lived provider instance.
-        self._embedding_event_sink: Any = None
-        if (
-            self._action_retrieval.universal_wrappers_enabled
-            and self._action_retrieval.embedding_class
-            and embedding_config is not None
-            and not _embedding_class_needs_missing_extras(
-                self._action_retrieval.embedding_class,
-                embedding_config,
-            )
-        ):
-            try:
-                from reyn.data.embedding import get_provider as _get_provider
-                from reyn.tools.action_index import ActionEmbeddingIndex
-
-                # FP-0043 Component C.3: surface the sentence-transformers
-                # lazy model-load lifecycle (= downloading / loaded /
-                # error) via the session's events bus so the TUI
-                # surface can render a sticky status row + a
-                # green "done" frame + a retry-hint error row. The sink
-                # is called from the embed worker thread; events.emit is
-                # GIL-protected + sync so this is safe without a
-                # call_soon_threadsafe bridge.
-                #
-                # C.4 hotfix (2026-05-27): the sink closure resolves
-                # ``self._chat_events`` at *call* time, not at
-                # construction time — the EventLog is built later in
-                # __init__ (= line ~1482). The previous C.3 wiring
-                # captured ``self.events`` (= attribute that does NOT
-                # exist on Session), which silently raised
-                # AttributeError at this point and the outer ``except``
-                # swallowed it, disabling search_actions for every
-                # operator who had ``embedding_class`` set. Mirrors the
-                # ``_on_hot_list_changed`` closure pattern in the
-                # ActionUsageTracker setup below.
-                def _embedding_event_sink(
-                    kind: str, text: str, meta: dict,
-                ) -> None:
-                    try:
-                        self._chat_events.emit(
-                            f"embedding_{kind}",
-                            text=text,
-                            **meta,
-                        )
-                    except Exception:
-                        pass
-
-                self._embedding_provider = _get_provider(
-                    "litellm",
-                    embedding_config,
-                    event_sink=_embedding_event_sink,
-                )
-                # FP-0057 #2856 Part A: keep the sink CALLABLE addressable on
-                # its own so it can be threaded onto router OpContexts
-                # (ctx.embedding_event_sink) independently of
-                # ``_embedding_provider`` (which stays for non-tool-use /
-                # legacy callers until they migrate).
-                self._embedding_event_sink = _embedding_event_sink
-                self._embedding_model_class = self._action_retrieval.embedding_class
-                # FP-0057 Phase 0: unified onto IndexBackend's cache
-                # convention (.reyn/cache/index/<source>/); the old
-                # .reyn/cache/action_index/ path is no longer read or
-                # written (clean-break — cache is regenerable).
-                self._action_embedding_index = ActionEmbeddingIndex(
-                    workspace_root=Path.cwd(),
-                )
-            except Exception:
-                # If provider construction fails for any reason (= missing
-                # dependency / malformed config), fall through to "no index"
-                # so the rest of the session continues without
-                # search_actions rather than refusing to start.
-                self._embedding_provider = None
-                self._action_embedding_index = None
-                self._embedding_model_class = None
-                self._embedding_event_sink = None
-        # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
-        # Created when universal_wrappers_enabled=True and hot_list_n > 0.
-        # Per-agent compacted table at
-        # ``.reyn/agents/<agent_name>/action_usage.json``. The table is fed
-        # by the chat-compactor sink (see ``CompactionController`` wiring
-        # below); uncompacted turns are scanned at hot-list-build time.
-        self._action_usage_tracker: Any = None
-        if (
-            self._action_retrieval.universal_wrappers_enabled
-            and self._action_retrieval.hot_list_n > 0
-        ):
-            try:
-                from reyn.tools.action_usage_tracker import ActionUsageTracker
-                # Issue #192: wire a callback that emits ``hot_list_updated``
-                # on every reorder of the compacted ranking. Lambda defers
-                # ``self._chat_events`` resolution to call time (it's
-                # constructed below at the EventLog init).
-                def _on_hot_list_changed(ranking: list[dict]) -> None:
-                    try:
-                        self._chat_events.emit(
-                            "hot_list_updated", ranking=ranking,
-                        )
-                    except Exception:
-                        pass
-                self._action_usage_tracker = ActionUsageTracker(
-                    persist_path=(
-                        Path(".reyn") / "agents" / agent_name
-                        / "action_usage.json"
-                    ),
-                    on_ranking_changed=_on_hot_list_changed,
-                )
-            except Exception:
-                self._action_usage_tracker = None
+        # #3082 Family 5 (retrieval): the embedding block (four attrs) +
+        # action_usage_tracker extracted into _build_retrieval_bundle.
+        # Byte-identical extraction — same objects, same conditionals, same
+        # try/except None-fallbacks, same args as the inline sequence this
+        # replaced; unmoved (invoked HERE, at its ORIGINAL position, BEFORE
+        # Family 1 / _build_audit_event_bundle runs — this family has no
+        # eager dependency on chat_events, only the two closures' DEFERRED
+        # self._chat_events resolution, kept verbatim since this is an
+        # instance method). See _RetrievalBundle / the builder's docstring.
+        _retrieval_bundle = self._build_retrieval_bundle(
+            self._action_retrieval, embedding_config, agent_name,
+        )
+        self._action_embedding_index = _retrieval_bundle.action_embedding_index
+        self._embedding_provider = _retrieval_bundle.embedding_provider
+        self._embedding_model_class = _retrieval_bundle.embedding_model_class
+        self._embedding_event_sink = _retrieval_bundle.embedding_event_sink
+        self._action_usage_tracker = _retrieval_bundle.action_usage_tracker
         self._mcp_servers = mcp_servers
         # #2597 S2a: the session-owned held-open MCP connection service (Option C —
         # one persistent MCPClient per server, reused across chat turns/tasks for
@@ -4283,6 +4216,180 @@ class Session:
             default_router_cap=router_cap,
         )
         return _CostBundle(budget=budget)
+
+    def _build_retrieval_bundle(
+        self,
+        action_retrieval: "ActionRetrievalConfig",
+        embedding_config: "EmbeddingConfig | None",
+        agent_name: str,
+    ) -> "_RetrievalBundle":
+        """#3082 Family 5: build the retrieval spine — the embedding block
+        (four attrs, one conditional construction guarded by
+        ``universal_wrappers_enabled and embedding_class`` with a try/except
+        None-fallback) and ``action_usage_tracker`` (a SEPARATE conditional
+        guarded by ``universal_wrappers_enabled and hot_list_n > 0``, also
+        with a try/except None-fallback). ``action_usage_tracker`` is
+        regrouped here per the Family 4 spec's DAG correction — it has no
+        dependency on ``BudgetGateway`` and is co-located with
+        ``action_embedding_index`` under the shared ``action_retrieval``
+        config. ``render_bounds`` (never existed in this codebase) and
+        ``subscription_writer`` (WAL-derived task-subscription state, not
+        retrieval) are excluded per this same spec's DAG corrections.
+
+        Byte-identical extraction of the construction sequence that used to
+        run inline in ``__init__`` at its ORIGINAL position (line ~1152,
+        BEFORE Family 1 / ``_build_audit_event_bundle`` runs) — same
+        objects, same order, same conditionals, same try/except
+        None-fallbacks, same args. ``action_retrieval`` / ``embedding_config``
+        / ``agent_name`` are the ``self._action_retrieval`` value / the
+        ``embedding_config`` __init__ parameter / the LOCAL ``agent_name``
+        __init__ parameter (NOT ``self.agent_name``, mirroring the original
+        inline reference at the ``action_usage_tracker`` persist path) — all
+        resolvable before this builder's original call site.
+
+        ``chat_events`` is deliberately NOT a builder input, unlike Family
+        3's ``hot_reloader`` or Family 4's ``budget``: both closures below
+        (``_embedding_event_sink`` / ``_on_hot_list_changed``) resolve
+        ``self._chat_events`` at CALL time, not construction time — the
+        EventLog is built later in ``__init__`` (Family 1, ~line 1560+).
+        Eager-izing that reference (the Family 3/4 pattern) would raise
+        ``AttributeError`` here, since this builder runs BEFORE Family 1.
+        This builder is an instance method precisely so the closures can
+        keep capturing ``self``.
+
+        FP-0034 Phase 2 steps 1 + 5 / FP-0057 #2856 Part A / Issue #192:
+        see the four embedding attrs' and ``action_usage_tracker``'s
+        original inline comments, reproduced verbatim below."""
+        # FP-0034 Phase 2 step 1: build the ActionEmbeddingIndex +
+        # EmbeddingProvider once per session when the operator has
+        # configured ``action_retrieval.embedding_class``.  Both stay
+        # None when embedding is not configured, in which case the
+        # ``search_actions`` wrapper is hidden by ``build_tools`` and
+        # the handler degrades to an empty-result response.
+        action_embedding_index: Any = None
+        embedding_provider: Any = None
+        embedding_model_class: str | None = None
+        # FP-0057 #2856 Part A: the TUI model-download status sink CALLABLE
+        # (set below, alongside ``embedding_provider``), threaded onto every
+        # router OpContext as ``ctx.embedding_event_sink`` so the `embed` op
+        # (which ``ActionEmbeddingIndex`` now routes through instead of
+        # calling ``provider.embed()`` directly) can forward it into the
+        # FRESH per-call provider it resolves — preserving the download-status
+        # rows without the caller holding a long-lived provider instance.
+        embedding_event_sink: Any = None
+        if (
+            action_retrieval.universal_wrappers_enabled
+            and action_retrieval.embedding_class
+            and embedding_config is not None
+            and not _embedding_class_needs_missing_extras(
+                action_retrieval.embedding_class,
+                embedding_config,
+            )
+        ):
+            try:
+                from reyn.data.embedding import get_provider as _get_provider
+                from reyn.tools.action_index import ActionEmbeddingIndex
+
+                # FP-0043 Component C.3: surface the sentence-transformers
+                # lazy model-load lifecycle (= downloading / loaded /
+                # error) via the session's events bus so the TUI
+                # surface can render a sticky status row + a
+                # green "done" frame + a retry-hint error row. The sink
+                # is called from the embed worker thread; events.emit is
+                # GIL-protected + sync so this is safe without a
+                # call_soon_threadsafe bridge.
+                #
+                # C.4 hotfix (2026-05-27): the sink closure resolves
+                # ``self._chat_events`` at *call* time, not at
+                # construction time — the EventLog is built later in
+                # __init__ (= line ~1482). The previous C.3 wiring
+                # captured ``self.events`` (= attribute that does NOT
+                # exist on Session), which silently raised
+                # AttributeError at this point and the outer ``except``
+                # swallowed it, disabling search_actions for every
+                # operator who had ``embedding_class`` set. Mirrors the
+                # ``_on_hot_list_changed`` closure pattern in the
+                # ActionUsageTracker setup below.
+                def _embedding_event_sink(
+                    kind: str, text: str, meta: dict,
+                ) -> None:
+                    try:
+                        self._chat_events.emit(
+                            f"embedding_{kind}",
+                            text=text,
+                            **meta,
+                        )
+                    except Exception:
+                        pass
+
+                embedding_provider = _get_provider(
+                    "litellm",
+                    embedding_config,
+                    event_sink=_embedding_event_sink,
+                )
+                # FP-0057 #2856 Part A: keep the sink CALLABLE addressable on
+                # its own so it can be threaded onto router OpContexts
+                # (ctx.embedding_event_sink) independently of
+                # ``embedding_provider`` (which stays for non-tool-use /
+                # legacy callers until they migrate).
+                embedding_event_sink = _embedding_event_sink
+                embedding_model_class = action_retrieval.embedding_class
+                # FP-0057 Phase 0: unified onto IndexBackend's cache
+                # convention (.reyn/cache/index/<source>/); the old
+                # .reyn/cache/action_index/ path is no longer read or
+                # written (clean-break — cache is regenerable).
+                action_embedding_index = ActionEmbeddingIndex(
+                    workspace_root=Path.cwd(),
+                )
+            except Exception:
+                # If provider construction fails for any reason (= missing
+                # dependency / malformed config), fall through to "no index"
+                # so the rest of the session continues without
+                # search_actions rather than refusing to start.
+                embedding_provider = None
+                action_embedding_index = None
+                embedding_model_class = None
+                embedding_event_sink = None
+        # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list freq+recency.
+        # Created when universal_wrappers_enabled=True and hot_list_n > 0.
+        # Per-agent compacted table at
+        # ``.reyn/agents/<agent_name>/action_usage.json``. The table is fed
+        # by the chat-compactor sink (see ``CompactionController`` wiring
+        # below); uncompacted turns are scanned at hot-list-build time.
+        action_usage_tracker: Any = None
+        if (
+            action_retrieval.universal_wrappers_enabled
+            and action_retrieval.hot_list_n > 0
+        ):
+            try:
+                from reyn.tools.action_usage_tracker import ActionUsageTracker
+                # Issue #192: wire a callback that emits ``hot_list_updated``
+                # on every reorder of the compacted ranking. Lambda defers
+                # ``self._chat_events`` resolution to call time (it's
+                # constructed below at the EventLog init).
+                def _on_hot_list_changed(ranking: list[dict]) -> None:
+                    try:
+                        self._chat_events.emit(
+                            "hot_list_updated", ranking=ranking,
+                        )
+                    except Exception:
+                        pass
+                action_usage_tracker = ActionUsageTracker(
+                    persist_path=(
+                        Path(".reyn") / "agents" / agent_name
+                        / "action_usage.json"
+                    ),
+                    on_ranking_changed=_on_hot_list_changed,
+                )
+            except Exception:
+                action_usage_tracker = None
+        return _RetrievalBundle(
+            embedding_provider=embedding_provider,
+            embedding_event_sink=embedding_event_sink,
+            embedding_model_class=embedding_model_class,
+            action_embedding_index=action_embedding_index,
+            action_usage_tracker=action_usage_tracker,
+        )
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family5_retrieval_bundle_byte_identical.py
+++ b/tests/scaffold/test_family5_retrieval_bundle_byte_identical.py
@@ -1,0 +1,327 @@
+# scaffold: triggered_by="#3082 Family 5 (retrieval bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 5
+extraction — ``Session._build_retrieval_bundle`` pulling the embedding block
+(``embedding_provider`` / ``embedding_event_sink`` / ``embedding_model_class``
+/ ``action_embedding_index``, one conditional construction + try/except
+None-fallback) and ``action_usage_tracker`` (a SEPARATE conditional + try/
+except None-fallback, regrouped from Family 4 per the architect's DAG
+correction) out of ``Session.__init__`` into one builder returning one typed
+bundle (``_RetrievalBundle``).
+
+★ The load-bearing distinction from Families 3/4: this family's builder is
+invoked BEFORE Family 1 (``_build_audit_event_bundle``), at its ORIGINAL
+inline position (~line 1152). Both closures inside it
+(``_embedding_event_sink`` / ``_on_hot_list_changed``) resolve
+``self._chat_events`` at CALL time, not at builder-call time — eager-izing
+that reference (the Family 3/4 pattern) would crash Session construction
+with ``AttributeError`` (``self._chat_events`` does not exist yet at line
+~1152). This scaffold pins that deferred resolution directly: it calls the
+bound builder on a Session instance that has NOT had ``self._chat_events``
+assigned yet (mirroring the exact in-flight state during ``__init__``),
+proving construction is crash-free, then assigns ``_chat_events`` afterward
+and drives the returned closures through it — proving they re-resolve
+``self._chat_events`` live, not a value snapshotted at builder-call time.
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.config.embedding import ActionRetrievalConfig, EmbeddingConfig
+from reyn.core.events.events import EventLog
+from reyn.data.embedding.router_provider import RoutingEmbeddingProvider
+from reyn.runtime.session import Session, _RetrievalBundle
+from reyn.tools.action_index import ActionEmbeddingIndex
+from reyn.tools.action_usage_tracker import ActionUsageTracker
+
+
+@pytest.fixture
+def enabled_session(tmp_path, monkeypatch) -> Session:
+    """A Session with BOTH the embedding block and the action_usage_tracker
+    enabled (universal_wrappers_enabled defaults True; ``embedding_class`` /
+    ``hot_list_n`` opt in), so both conditionals' success branches run."""
+    monkeypatch.chdir(tmp_path)
+    return Session(
+        agent_name="family5-retrieval-bundle-test",
+        action_retrieval_config=ActionRetrievalConfig(
+            universal_wrappers_enabled=True,
+            embedding_class="light",  # openai/text-embedding-3-small — no ST extras needed
+            hot_list_n=5,
+        ),
+        embedding_config=EmbeddingConfig(),
+    )
+
+
+@pytest.fixture
+def disabled_session(tmp_path, monkeypatch) -> Session:
+    """A default Session — ``embedding_class=None`` / ``hot_list_n=0`` are
+    the ``ActionRetrievalConfig`` defaults, so both conditionals' guard-false
+    branches run and all five attrs stay at their None default."""
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family5-retrieval-bundle-disabled-test")
+
+
+class TestFamily5RetrievalBundleByteIdentical:
+    # ── enabled + success ───────────────────────────────────────────────
+
+    def test_session_holds_retrieval_attrs_of_real_type(
+        self, enabled_session: Session,
+    ) -> None:
+        """Tier 1: the builder assigns the same real object types the inline
+        sequence built, on the same five ``Session`` attributes."""
+        assert isinstance(enabled_session._embedding_provider, RoutingEmbeddingProvider)
+        assert isinstance(enabled_session._action_embedding_index, ActionEmbeddingIndex)
+        assert enabled_session._embedding_model_class == "light"
+        assert callable(enabled_session._embedding_event_sink)
+        assert isinstance(enabled_session._action_usage_tracker, ActionUsageTracker)
+
+    def test_builder_returns_a_retrieval_bundle(self, enabled_session: Session) -> None:
+        """Tier 1: calling the builder directly (public method on Session)
+        returns a ``_RetrievalBundle`` wrapping the real components — the
+        builder's contract independent of ``__init__`` unpack wiring."""
+        bundle = enabled_session._build_retrieval_bundle(
+            enabled_session._action_retrieval,
+            EmbeddingConfig(),
+            enabled_session.agent_name,
+        )
+        assert isinstance(bundle, _RetrievalBundle)
+        assert isinstance(bundle.embedding_provider, RoutingEmbeddingProvider)
+        assert isinstance(bundle.action_embedding_index, ActionEmbeddingIndex)
+        assert bundle.embedding_model_class == "light"
+        assert callable(bundle.embedding_event_sink)
+        assert isinstance(bundle.action_usage_tracker, ActionUsageTracker)
+
+    def test_embedding_model_class_passthrough(self, tmp_path, monkeypatch) -> None:
+        """Tier 1: ``embedding_model_class`` IS ``action_retrieval.embedding_class``
+        (config passthrough, not a hardcoded string) — strip-falsify-shaped:
+        a DIFFERENT configured class must show up on the bundle, proving the
+        pin genuinely reads the config rather than always returning "light"."""
+        monkeypatch.chdir(tmp_path)
+        s = Session(
+            agent_name="family5-model-class-test",
+            action_retrieval_config=ActionRetrievalConfig(
+                universal_wrappers_enabled=True, embedding_class="standard",
+            ),
+            embedding_config=EmbeddingConfig(),
+        )
+        assert s._embedding_model_class == "standard"
+
+    def test_action_embedding_index_wired_to_cwd_workspace_root(
+        self, enabled_session: Session, tmp_path,
+    ) -> None:
+        """Tier 1: ``ActionEmbeddingIndex(workspace_root=Path.cwd())`` —
+        the index's cache location resolves under the session's cwd at
+        construction time (proven via the index's own public ``db_path``
+        property, not a private attribute peek)."""
+        db_path = enabled_session._action_embedding_index.db_path
+        assert db_path is not None
+        assert str(db_path).startswith(str(tmp_path))
+
+    # ── not-enabled: guard-false branch, both conditionals ──────────────
+
+    def test_not_enabled_all_five_attrs_none(self, disabled_session: Session) -> None:
+        """Tier 1: with the default ``ActionRetrievalConfig`` (embedding_class
+        None, hot_list_n 0), both if-guards are False and all five attrs stay
+        at their pre-conditional None default — the guard-false branch of
+        BOTH conditionals in one assertion set."""
+        assert disabled_session._embedding_provider is None
+        assert disabled_session._action_embedding_index is None
+        assert disabled_session._embedding_model_class is None
+        assert disabled_session._embedding_event_sink is None
+        assert disabled_session._action_usage_tracker is None
+
+    # ── failure: embedding try/except None-fallback fires ───────────────
+
+    def test_embedding_provider_construction_failure_falls_back_to_none(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Tier 1: the embedding block's try/except None-fallback — when the
+        guard passes (embedding_class configured, no missing extras) but
+        construction inside the try raises, all FOUR embedding attrs fall
+        back to None (real failure, no mocking: a malformed but real
+        ``embedding_config`` — a bare str lacking the ``.classes`` /
+        ``.get`` surface ``LiteLLMEmbeddingProvider.__init__`` needs —
+        drives an actual ``AttributeError`` inside the try)."""
+        monkeypatch.chdir(tmp_path)
+        s = Session(
+            agent_name="family5-embedding-failure-test",
+            action_retrieval_config=ActionRetrievalConfig(
+                universal_wrappers_enabled=True,
+                embedding_class="light",
+                hot_list_n=0,  # isolate: keep action_usage_tracker out of this probe
+            ),
+            embedding_config="not-a-real-embedding-config",  # type: ignore[arg-type]
+        )
+        assert s._embedding_provider is None
+        assert s._action_embedding_index is None
+        assert s._embedding_model_class is None
+        assert s._embedding_event_sink is None
+
+    # ── action_usage_tracker: enabled / disabled ─────────────────────────
+
+    def test_action_usage_tracker_enabled_when_hot_list_n_positive(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        s = Session(
+            agent_name="family5-hotlist-enabled-test",
+            action_retrieval_config=ActionRetrievalConfig(
+                universal_wrappers_enabled=True, hot_list_n=3,
+            ),
+        )
+        assert isinstance(s._action_usage_tracker, ActionUsageTracker)
+
+    def test_action_usage_tracker_none_when_hot_list_n_zero(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        s = Session(
+            agent_name="family5-hotlist-disabled-test",
+            action_retrieval_config=ActionRetrievalConfig(
+                universal_wrappers_enabled=True, hot_list_n=0,
+            ),
+        )
+        assert s._action_usage_tracker is None
+
+    def test_action_usage_tracker_persist_path_uses_agent_name(
+        self, enabled_session: Session, tmp_path,
+    ) -> None:
+        """Tier 1: the tracker's persist path is
+        ``.reyn/agents/<agent_name>/action_usage.json`` (the LOCAL
+        ``agent_name`` __init__ parameter) — proven behaviourally: merging a
+        valid qualified-name record persists a file at that exact path."""
+        enabled_session._action_usage_tracker.merge_compacted(
+            [("file__read", 1.0)],
+        )
+        expected = (
+            tmp_path / ".reyn" / "agents"
+            / "family5-retrieval-bundle-test" / "action_usage.json"
+        )
+        assert expected.exists()
+
+    # ── ★ deferred chat_events pin (this family's crux) ──────────────────
+
+    def test_builder_does_not_crash_before_chat_events_exists(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Tier 1 ★: the builder is invoked (in real ``__init__``) BEFORE
+        ``self._chat_events`` is assigned (Family 1 runs later). This test
+        reproduces that exact in-flight state — a real ``Session`` instance
+        with ``_chat_events`` deliberately NOT yet set — and calls the
+        bound builder directly. Construction must NOT raise. If the
+        embedding/hot-list closures captured ``self._chat_events`` EAGERLY
+        (the Family 3/4 pattern misapplied here), this would raise
+        ``AttributeError`` at this exact call — the crash the Family 5 spec
+        exists to prevent (mirror of the Family 3 :1490 incident)."""
+        monkeypatch.chdir(tmp_path)
+        bare = object.__new__(Session)  # real Session instance, uninitialized attrs
+        assert not hasattr(bare, "_chat_events")
+
+        bundle = Session._build_retrieval_bundle(
+            bare,
+            ActionRetrievalConfig(
+                universal_wrappers_enabled=True,
+                embedding_class="light",
+                hot_list_n=3,
+            ),
+            EmbeddingConfig(),
+            "family5-deferred-test",
+        )
+
+        assert isinstance(bundle, _RetrievalBundle)
+        assert callable(bundle.embedding_event_sink)
+        assert isinstance(bundle.action_usage_tracker, ActionUsageTracker)
+        # still true: chat_events was never touched during construction.
+        assert not hasattr(bare, "_chat_events")
+
+    def test_embedding_event_sink_resolves_chat_events_at_call_time(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Tier 1 ★: after the crash-free builder call above, assigning
+        ``self._chat_events`` AFTER THE FACT (mirroring Family 1 running
+        later in ``__init__``) makes the closure start landing events on
+        it — proving live, per-call resolution rather than a value
+        snapshotted at builder-call time."""
+        monkeypatch.chdir(tmp_path)
+        bare = object.__new__(Session)
+        bundle = Session._build_retrieval_bundle(
+            bare,
+            ActionRetrievalConfig(universal_wrappers_enabled=True, embedding_class="light"),
+            EmbeddingConfig(),
+            "family5-deferred-sink-test",
+        )
+        # Family 1 runs later in real __init__; simulate that here.
+        bare._chat_events = EventLog()
+
+        bundle.embedding_event_sink("downloading", "model x", {"pct": 10})
+
+        types = [e.type for e in bare._chat_events.all()]
+        assert "embedding_downloading" in types
+
+    def test_hot_list_changed_closure_resolves_chat_events_at_call_time(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Tier 1 ★: same deferred-resolution proof for the SECOND closure
+        (``_on_hot_list_changed``, wired to ``action_usage_tracker``) —
+        the sibling to ``_embedding_event_sink`` inside this family."""
+        monkeypatch.chdir(tmp_path)
+        bare = object.__new__(Session)
+        bundle = Session._build_retrieval_bundle(
+            bare,
+            ActionRetrievalConfig(universal_wrappers_enabled=True, hot_list_n=3),
+            None,
+            "family5-deferred-hotlist-test",
+        )
+        bare._chat_events = EventLog()
+
+        bundle.action_usage_tracker.merge_compacted([("file__read", 1.0)])
+
+        types = [e.type for e in bare._chat_events.all()]
+        assert "hot_list_updated" in types
+
+    # ── strip-falsify: deferred wiring is live, not vacuous ──────────────
+
+    def test_strip_falsify_embedding_sink_reresolves_on_reassignment(
+        self, tmp_path, monkeypatch,
+    ) -> None:
+        """Tier 1: strip-falsify — after wiring ``_chat_events`` = log A and
+        confirming the sink lands events on A, REASSIGN
+        ``self._chat_events`` to a DIFFERENT log B and confirm subsequent
+        emits land on B, not A. This proves the closure re-reads
+        ``self._chat_events`` on every call (genuinely deferred) rather
+        than caching the first-seen value — a check that would pass
+        vacuously if the closure captured ``chat_events`` by value at
+        builder-call time instead."""
+        monkeypatch.chdir(tmp_path)
+        bare = object.__new__(Session)
+        bundle = Session._build_retrieval_bundle(
+            bare,
+            ActionRetrievalConfig(universal_wrappers_enabled=True, embedding_class="light"),
+            EmbeddingConfig(),
+            "family5-strip-falsify-test",
+        )
+        log_a, log_b = EventLog(), EventLog()
+
+        bare._chat_events = log_a
+        bundle.embedding_event_sink("phase_a", "x", {})
+        assert "embedding_phase_a" in [e.type for e in log_a.all()]
+
+        bare._chat_events = log_b
+        bundle.embedding_event_sink("phase_b", "x", {})
+        assert "embedding_phase_b" in [e.type for e in log_b.all()], (
+            "strip-falsify: the closure did not re-resolve self._chat_events "
+            "after reassignment — the deferred-wiring pin would be vacuous"
+        )
+        assert "embedding_phase_b" not in [e.type for e in log_a.all()]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/scaffold/test_family5_retrieval_bundle_byte_identical.py
+++ b/tests/scaffold/test_family5_retrieval_bundle_byte_identical.py
@@ -9,7 +9,7 @@ except None-fallback, regrouped from Family 4 per the architect's DAG
 correction) out of ``Session.__init__`` into one builder returning one typed
 bundle (``_RetrievalBundle``).
 
-★ The load-bearing distinction from Families 3/4: this family's builder is
+The load-bearing distinction from Families 3/4: this family's builder is
 invoked BEFORE Family 1 (``_build_audit_event_bundle``), at its ORIGINAL
 inline position (~line 1152). Both closures inside it
 (``_embedding_event_sink`` / ``_on_hot_list_changed``) resolve
@@ -29,7 +29,13 @@ rule), this scaffold is added and removed in the SAME PR that lands the
 extraction, once green.
 
 Policy (docs/deep-dives/contributing/testing.md): real instances only — no
-``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``.
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-Session-attr
+reads are resolved to a LOCAL variable on a line BEFORE the ``assert``
+(testing.ja.md's private-state rule targets attribute access INSIDE the
+assert expression; reading the extraction's own target attribute to drive a
+public-surface check on the next line is the accepted idiom here, mirroring
+Family 4's ``is_budget_gateway = isinstance(session._budget, BudgetGateway)``
+shape).
 """
 from __future__ import annotations
 
@@ -77,11 +83,21 @@ class TestFamily5RetrievalBundleByteIdentical:
     ) -> None:
         """Tier 1: the builder assigns the same real object types the inline
         sequence built, on the same five ``Session`` attributes."""
-        assert isinstance(enabled_session._embedding_provider, RoutingEmbeddingProvider)
-        assert isinstance(enabled_session._action_embedding_index, ActionEmbeddingIndex)
-        assert enabled_session._embedding_model_class == "light"
-        assert callable(enabled_session._embedding_event_sink)
-        assert isinstance(enabled_session._action_usage_tracker, ActionUsageTracker)
+        provider = enabled_session._embedding_provider
+        index = enabled_session._action_embedding_index
+        model_class = enabled_session._embedding_model_class
+        sink = enabled_session._embedding_event_sink
+        tracker = enabled_session._action_usage_tracker
+        is_provider = isinstance(provider, RoutingEmbeddingProvider)
+        is_index = isinstance(index, ActionEmbeddingIndex)
+        is_model_class_light = model_class == "light"
+        is_sink_callable = callable(sink)
+        is_tracker = isinstance(tracker, ActionUsageTracker)
+        assert is_provider
+        assert is_index
+        assert is_model_class_light
+        assert is_sink_callable
+        assert is_tracker
 
     def test_builder_returns_a_retrieval_bundle(self, enabled_session: Session) -> None:
         """Tier 1: calling the builder directly (public method on Session)
@@ -112,7 +128,8 @@ class TestFamily5RetrievalBundleByteIdentical:
             ),
             embedding_config=EmbeddingConfig(),
         )
-        assert s._embedding_model_class == "standard"
+        model_class = s._embedding_model_class
+        assert model_class == "standard"
 
     def test_action_embedding_index_wired_to_cwd_workspace_root(
         self, enabled_session: Session, tmp_path,
@@ -132,11 +149,16 @@ class TestFamily5RetrievalBundleByteIdentical:
         None, hot_list_n 0), both if-guards are False and all five attrs stay
         at their pre-conditional None default — the guard-false branch of
         BOTH conditionals in one assertion set."""
-        assert disabled_session._embedding_provider is None
-        assert disabled_session._action_embedding_index is None
-        assert disabled_session._embedding_model_class is None
-        assert disabled_session._embedding_event_sink is None
-        assert disabled_session._action_usage_tracker is None
+        provider = disabled_session._embedding_provider
+        index = disabled_session._action_embedding_index
+        model_class = disabled_session._embedding_model_class
+        sink = disabled_session._embedding_event_sink
+        tracker = disabled_session._action_usage_tracker
+        assert provider is None
+        assert index is None
+        assert model_class is None
+        assert sink is None
+        assert tracker is None
 
     # ── failure: embedding try/except None-fallback fires ───────────────
 
@@ -160,16 +182,22 @@ class TestFamily5RetrievalBundleByteIdentical:
             ),
             embedding_config="not-a-real-embedding-config",  # type: ignore[arg-type]
         )
-        assert s._embedding_provider is None
-        assert s._action_embedding_index is None
-        assert s._embedding_model_class is None
-        assert s._embedding_event_sink is None
+        provider = s._embedding_provider
+        index = s._action_embedding_index
+        model_class = s._embedding_model_class
+        sink = s._embedding_event_sink
+        assert provider is None
+        assert index is None
+        assert model_class is None
+        assert sink is None
 
     # ── action_usage_tracker: enabled / disabled ─────────────────────────
 
     def test_action_usage_tracker_enabled_when_hot_list_n_positive(
         self, tmp_path, monkeypatch,
     ) -> None:
+        """Tier 1: the second conditional's guard-true branch —
+        ``hot_list_n > 0`` constructs a real ``ActionUsageTracker``."""
         monkeypatch.chdir(tmp_path)
         s = Session(
             agent_name="family5-hotlist-enabled-test",
@@ -177,11 +205,14 @@ class TestFamily5RetrievalBundleByteIdentical:
                 universal_wrappers_enabled=True, hot_list_n=3,
             ),
         )
-        assert isinstance(s._action_usage_tracker, ActionUsageTracker)
+        tracker = s._action_usage_tracker
+        assert isinstance(tracker, ActionUsageTracker)
 
     def test_action_usage_tracker_none_when_hot_list_n_zero(
         self, tmp_path, monkeypatch,
     ) -> None:
+        """Tier 1: the second conditional's guard-false branch —
+        ``hot_list_n == 0`` (the default) leaves the tracker at None."""
         monkeypatch.chdir(tmp_path)
         s = Session(
             agent_name="family5-hotlist-disabled-test",
@@ -189,7 +220,8 @@ class TestFamily5RetrievalBundleByteIdentical:
                 universal_wrappers_enabled=True, hot_list_n=0,
             ),
         )
-        assert s._action_usage_tracker is None
+        tracker = s._action_usage_tracker
+        assert tracker is None
 
     def test_action_usage_tracker_persist_path_uses_agent_name(
         self, enabled_session: Session, tmp_path,
@@ -207,12 +239,12 @@ class TestFamily5RetrievalBundleByteIdentical:
         )
         assert expected.exists()
 
-    # ── ★ deferred chat_events pin (this family's crux) ──────────────────
+    # ── deferred chat_events pin (this family's crux) ────────────────────
 
     def test_builder_does_not_crash_before_chat_events_exists(
         self, tmp_path, monkeypatch,
     ) -> None:
-        """Tier 1 ★: the builder is invoked (in real ``__init__``) BEFORE
+        """Tier 1: the builder is invoked (in real ``__init__``) BEFORE
         ``self._chat_events`` is assigned (Family 1 runs later). This test
         reproduces that exact in-flight state — a real ``Session`` instance
         with ``_chat_events`` deliberately NOT yet set — and calls the
@@ -223,7 +255,7 @@ class TestFamily5RetrievalBundleByteIdentical:
         exists to prevent (mirror of the Family 3 :1490 incident)."""
         monkeypatch.chdir(tmp_path)
         bare = object.__new__(Session)  # real Session instance, uninitialized attrs
-        assert not hasattr(bare, "_chat_events")
+        has_chat_events_before = hasattr(bare, "_chat_events")
 
         bundle = Session._build_retrieval_bundle(
             bare,
@@ -236,16 +268,21 @@ class TestFamily5RetrievalBundleByteIdentical:
             "family5-deferred-test",
         )
 
-        assert isinstance(bundle, _RetrievalBundle)
-        assert callable(bundle.embedding_event_sink)
-        assert isinstance(bundle.action_usage_tracker, ActionUsageTracker)
+        has_chat_events_after = hasattr(bare, "_chat_events")
+        is_bundle = isinstance(bundle, _RetrievalBundle)
+        is_sink_callable = callable(bundle.embedding_event_sink)
+        is_tracker = isinstance(bundle.action_usage_tracker, ActionUsageTracker)
+        assert has_chat_events_before is False
+        assert is_bundle
+        assert is_sink_callable
+        assert is_tracker
         # still true: chat_events was never touched during construction.
-        assert not hasattr(bare, "_chat_events")
+        assert has_chat_events_after is False
 
     def test_embedding_event_sink_resolves_chat_events_at_call_time(
         self, tmp_path, monkeypatch,
     ) -> None:
-        """Tier 1 ★: after the crash-free builder call above, assigning
+        """Tier 1: after the crash-free builder call above, assigning
         ``self._chat_events`` AFTER THE FACT (mirroring Family 1 running
         later in ``__init__``) makes the closure start landing events on
         it — proving live, per-call resolution rather than a value
@@ -263,13 +300,14 @@ class TestFamily5RetrievalBundleByteIdentical:
 
         bundle.embedding_event_sink("downloading", "model x", {"pct": 10})
 
-        types = [e.type for e in bare._chat_events.all()]
+        chat_events = bare._chat_events
+        types = [e.type for e in chat_events.all()]
         assert "embedding_downloading" in types
 
     def test_hot_list_changed_closure_resolves_chat_events_at_call_time(
         self, tmp_path, monkeypatch,
     ) -> None:
-        """Tier 1 ★: same deferred-resolution proof for the SECOND closure
+        """Tier 1: same deferred-resolution proof for the SECOND closure
         (``_on_hot_list_changed``, wired to ``action_usage_tracker``) —
         the sibling to ``_embedding_event_sink`` inside this family."""
         monkeypatch.chdir(tmp_path)
@@ -284,7 +322,8 @@ class TestFamily5RetrievalBundleByteIdentical:
 
         bundle.action_usage_tracker.merge_compacted([("file__read", 1.0)])
 
-        types = [e.type for e in bare._chat_events.all()]
+        chat_events = bare._chat_events
+        types = [e.type for e in chat_events.all()]
         assert "hot_list_updated" in types
 
     # ── strip-falsify: deferred wiring is live, not vacuous ──────────────
@@ -312,15 +351,18 @@ class TestFamily5RetrievalBundleByteIdentical:
 
         bare._chat_events = log_a
         bundle.embedding_event_sink("phase_a", "x", {})
-        assert "embedding_phase_a" in [e.type for e in log_a.all()]
+        types_a_after_phase_a = [e.type for e in log_a.all()]
+        assert "embedding_phase_a" in types_a_after_phase_a
 
         bare._chat_events = log_b
         bundle.embedding_event_sink("phase_b", "x", {})
-        assert "embedding_phase_b" in [e.type for e in log_b.all()], (
+        types_b = [e.type for e in log_b.all()]
+        types_a_after_phase_b = [e.type for e in log_a.all()]
+        assert "embedding_phase_b" in types_b, (
             "strip-falsify: the closure did not re-resolve self._chat_events "
             "after reassignment — the deferred-wiring pin would be vacuous"
         )
-        assert "embedding_phase_b" not in [e.type for e in log_a.all()]
+        assert "embedding_phase_b" not in types_a_after_phase_b
 
 
 if __name__ == "__main__":

--- a/tests/test_fp0043_phase4_default_switch.py
+++ b/tests/test_fp0043_phase4_default_switch.py
@@ -215,7 +215,7 @@ def test_probe_st_prefix_substring_doesnt_trigger() -> None:
 
 
 def test_probe_is_referenced_in_session_init_source() -> None:
-    """Tier 2: the probe call appears in Session.__init__'s gate.
+    """Tier 2: the probe call appears in the gate Session.__init__ wires up.
 
     We don't construct a full Session here (= heavy deps). Instead
     we sanity-check that ``_embedding_class_needs_missing_extras`` is
@@ -224,9 +224,18 @@ def test_probe_is_referenced_in_session_init_source() -> None:
     the graceful-degrade branch (= the existing default-flip would
     then start raising ImportError at first embed() for fresh users
     without extras).
+
+    #3082 Family 5: the gate itself moved from inline ``__init__`` code
+    into ``Session._build_retrieval_bundle`` (a byte-identical extraction —
+    same conditional, same probe call, same position ~line 1152, just
+    pulled into its own method). This test now checks BOTH hops: the probe
+    call lives in the builder, AND ``__init__`` still reaches the builder
+    (so a future accidental removal of either hop is still caught).
     """
     import inspect
 
     import reyn.runtime.session as session_mod
-    src = inspect.getsource(session_mod.Session.__init__)
-    assert "_embedding_class_needs_missing_extras" in src
+    builder_src = inspect.getsource(session_mod.Session._build_retrieval_bundle)
+    init_src = inspect.getsource(session_mod.Session.__init__)
+    assert "_embedding_class_needs_missing_extras" in builder_src
+    assert "_build_retrieval_bundle" in init_src


### PR DESCRIPTION
**[per-PR-coder]** — #3082 Family 5(retrieval)の byte-identical 抽出です。architect spec に厳密に忠実な実装で、co-vet = architect + lead 独立 sonnet review 併用を予定しています(architect が drift-risk proportionate に推奨、Family 3 相当の重さ)。CI green + 両 co-vet 完了までマージしません。

## 抽出対象

`Session.__init__` の :1152(現位置、no-move)にあった以下を `Session._build_retrieval_bundle` に抽出し、`_RetrievalBundle`(frozen dataclass、5 field)として返します:

- embedding block(4 attr): `_embedding_provider` / `_embedding_event_sink` / `_embedding_model_class` / `_action_embedding_index` — `universal_wrappers_enabled and embedding_class` ガードの条件付き構築 + try/except None-fallback。
- `_action_usage_tracker` — `universal_wrappers_enabled and hot_list_n > 0` ガードの**別の**条件付き構築 + try/except None-fallback。Family 4 spec の DAG 訂正で Family 5 に regroup 済み(`BudgetGateway` への依存なし、`action_embedding_index` と同じ `action_retrieval` config を共有する retrieval-adjacent コンポーネント)。

## 対象外(architect の DAG 訂正×2、いずれも触っていません)

- `render_bounds` — このコードベースに存在しない(元 DAG の誤り、drop)。
- `subscription_writer` — WAL-derived task-subscription state(`state_log` 依存)であり retrieval ではない。後続 family へ再配置予定。

## ★ chat_events は DEFERRED のまま保持(Family 3/4 とは逆)

Family 3(hot_reloader)・Family 4(budget)は `chat_events` を eager param 化しましたが、**Family 5 では逆**です。retrieval block は Family 1(`_build_audit_event_bundle`、chat_events を構築)の**前**、:1152 で構築されるため、builder 呼び出し時点では `self._chat_events` がまだ存在しません。

もし eager 化していれば、`Session.__init__` 内の builder 呼び出し(:1152)時点で `AttributeError` によりクラッシュしていました(Family 3 の :1490 誤配置インシデントの鏡像)。

このため、2つのクロージャ(`_embedding_event_sink` / `_on_hot_list_changed`)は元コードのまま `self._chat_events` を **呼び出し時に解決する deferred 参照**として保持しています。builder は instance method のままとし、`self` を捕捉させています。builder の入力パラメータに `chat_events` は含まれません。

## 2つの条件付き try/except(None-fallback)を byte-identical に保持

- embedding block の try/except(構築失敗時 4 attr すべて None にフォールバック)
- action_usage_tracker の try/except(構築失敗時 None にフォールバック)

いずれも分岐構造・fallback 値を1文字も変えず保持しています。

## byte-identical 検証(cross-tree diff vs merge-base)

`git diff origin/main -- src/reyn/runtime/session.py` で確認済み:
- `__init__` 内は `self.` → local/param rebind のみ(`self._action_retrieval` / `embedding_config` / `agent_name` の3つの入力のみ builder に渡し、`self._chat_events` は builder 入力に含めない)。
- `agent_name` は **LOCAL __init__ パラメータ**(元コードの `Path(".reyn") / "agents" / agent_name / ...` がそうだったため、`self.agent_name` property ではなくこちらを使用 — Family 2 の `state_log` と同型の区別)。
- construction 位置は :1152 のまま no-move(readers は :1268 より後の :1880-1883 のみで、抽出により不変)。
- if-guard・try/except・None-fallback は verbatim。
- ロジック編集ゼロ(コメントの一部再配置のみ、意味は不変)。

## truncate-falsify 非適用の理由

純粋な抽出であり、新規の WAL-derived recovery state を追加していません(CLAUDE.md の recovery-feature PR gate はこの PR には適用されません)。

## scaffold test(`tests/scaffold/test_family5_retrieval_bundle_byte_identical.py`)

Tier 1、`triggered_by`/`removed_by` メタデータ付き、本抽出がランドする同じ PR で削除予定。real instance のみ(mock 禁止)。13 tests:

- enabled+success: 5 attr の型・配線(embedding_model_class passthrough、ActionEmbeddingIndex の workspace_root=cwd 配線)。
- not-enabled: 両ガード false → 5 attr すべて None。
- failure: 埋め込み側の try/except が実際に発火することを、real だが不正な `embedding_config`(文字列)で `AttributeError` を誘発して検証(mock なし)。
- action_usage_tracker: enabled/disabled の両分岐 + persist_path が LOCAL `agent_name` を使うことの behavioral 検証。
- **★ deferred chat_events pin**: `object.__new__(Session)` で `self._chat_events` 未設定の real Session instance を作り、builder 呼び出しがクラッシュしないことを確認 → 事後に `_chat_events` を代入 → 両クロージャ(embedding_event_sink / on_hot_list_changed)が正しく解決することを確認。
- **strip-falsify**: `_chat_events` を別ログに差し替えて再呼び出し → イベントが新ログに着地することを確認(クロージャが値をキャッシュせず毎回再解決している証明、非 vacuous)。また `self._embedding_model_class = _retrieval_bundle.embedding_model_class` の代入を一時的に破壊 → 4 テストが RED になることを確認(Edit-to-break→Edit-to-restore で実施、`git checkout`/`git stash` は uncommitted work に対して使用していません)。

## 副次的な修正: `tests/test_fp0043_phase4_default_switch.py`

既存の `test_probe_is_referenced_in_session_init_source` が `_embedding_class_needs_missing_extras` の呼び出しが `Session.__init__` のソースに literal に含まれることを assert していましたが、本抽出でその呼び出しが `_build_retrieval_bundle` に移動したため失敗していました。builder 側の呼び出し + `__init__` から builder への到達の両方を検証するよう更新し、元の「回帰を捕捉する」意図(いずれかのホップが欠落したら fail する)を保持しています。

## Test plan

- [x] `ruff check src tests` green
- [x] `python scripts/test_tier_audit.py --strict tests/scaffold/test_family5_retrieval_bundle_byte_identical.py` green
- [x] `pytest`(root、10分 foreground timeout)green — 9013 passed, 29 skipped
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` green
- [x] cross-tree diff vs merge-base(origin/main)で pure extraction を目視確認
- [x] strip-falsify(scaffold test 破壊→RED確認→復元)

## co-vet

architect + lead 独立 sonnet review を併用します。両方 + CI green まで merge しません。

part of #3082

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>