### PR TITLE
refactor(session): extract router_host waist builder (#3082 Family 6a, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -791,6 +791,50 @@ class _RetrievalBundle:
     action_usage_tracker: "object | None"
 
 
+@dataclass(frozen=True)
+class _RouterWaistBundle:
+    """#3082 Family 6a: the router-host WAIST — ``router_host``
+    (``RouterHostAdapter``, the concrete ``RouterLoopHost`` implementation
+    that aggregates ~40 already-constructed Session sub-components —
+    Families 1-5's outputs (``chat_events`` / ``journal`` / ``hot_reloader``
+    / ``hook_dispatcher`` / ``hook_bus`` / ``budget``) plus the many
+    params/early attrs set earlier in ``__init__`` (``task_backend`` /
+    ``permission_resolver`` / ``resolver`` / ``registry`` /
+    ``pipeline_registry`` / ``presentation_registry`` / ``file_*`` /
+    ``mcp_*`` / ``memory`` / …) — into a single object most later families
+    read through. Single-field bundle (mirrors ``_CostBundle``'s
+    one-unconditional-component shape) so it can grow without a call-site
+    signature change.
+
+    Pure output→input value object: :meth:`Session._build_router_waist` is
+    a byte-identical extraction of the construction that used to run inline
+    in ``Session.__init__`` at its ORIGINAL position (line ~1726, no-move —
+    every one of the ~40 deps is already set on ``self`` by that point) —
+    same object, same construction order, same ~40 args. Because
+    parameterizing ~40 explicit builder args is impractical (and Families
+    3-5 already establish the instance-method-reads-``self`` precedent for
+    eager sibling dependencies), this builder takes NO explicit params: it
+    reads every dependency as ``self._X`` / ``self.X`` directly, exactly as
+    the inline construction did.
+
+    ★ Three of the ~40 args are DEFERRED lambdas, NOT eager values —
+    ``live_session_id_fn`` / ``current_task_id_fn`` / ``turn_origin_fn``
+    resolve per-turn / post-construction Session state (``_current_task_id``
+    and ``_current_turn_origin`` are not even SET until the first turn
+    runs — eager-reading them here would raise ``AttributeError``, and even
+    where the attribute already exists at construction time,
+    e.g. ``_session_id``, the value can change afterward for spawned
+    sessions). These three (plus the bound method
+    ``record_spawned_task`` and the two tracker lambdas
+    ``delegation_tracker`` / ``agent_replies_tracker``, already
+    lambdas pre-extraction) are kept byte-identical, still closing over
+    ``self`` and resolved at CALL time — eager-izing any of them would
+    freeze a per-turn value at construction (the Family 3/5 deferred/eager
+    pitfall this builder must not repeat)."""
+
+    router_host: "RouterHostAdapter"
+
+
 class Session:
     def __init__(
         self,
@@ -1701,230 +1745,20 @@ class Session:
         # forward the reply upstream. None = not capturing (user-turn context).
         self._router_loop_agent_replies: list[str] | None = None
 
-        # #1092 PR-F1 (chat activation): build the chat axis's turn_budget engine
-        # off the RESOLVED model (#1172-safe — resolve self.model exactly as the
-        # CompactionEngine does; never hand the cosmetic class to the budget).
-        # try_build_* returns None (NOT raise) when the model's context is too
-        # small to satisfy the by-construction force-close floor (output_reserve +
-        # offload_cap < threshold) — a small-context model is a legitimate chat
-        # session that simply cannot support force-close, so it degrades to the
-        # pre-force-close path (no cap, no handoff) rather than failing __init__.
-        # ADDITIVE: the engine's sole consumer is
-        # RouterHostAdapter.wrap_up_output_reserve, inert until the F2 handoff
-        # calls _force_close_call — chat stays REACTIVE-only (see the property's
-        # docstring for the deliberate per-axis choice).
-        from reyn.services.turn_budget import try_build_default_turn_budget_engine
-        _chat_turn_budget_engine = try_build_default_turn_budget_engine(
-            self._resolver.resolve(self.model).model,
-            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
-        )
-
-        # PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
-        # RouterLoopHost implementation extracted from Session. Constructed
-        # last in __init__ because it receives callbacks that reference self
-        # (all of which are bound methods, resolved at call time not here).
-        self._router_host = RouterHostAdapter(
-            # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
-            # so the spawn SEAM (agent_spawn / topology_create) routes spawn-limit exceeds
-            # through the same mode-driven framework as inter_agent_messaging's max_agent_hops.
-            handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
-            safety_extensions=self._safety_extensions,
-            # #1092 PR-F1: the chat turn_budget engine (resolved-model, asserted).
-            turn_budget_engine=_chat_turn_budget_engine,
-            # FP-0050 / #1822 S2: content-threat scan + fence config.
-            threat_scan=self._safety.threat_scan,
-            contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
-            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
-            # FP-0063 PC: the router-dispatched `embed` TOOL builds its OpContext from
-            # THIS host (RouterCallerState.op_context_factory = host.make_router_op_context),
-            # so this is the live interactive path's embedding-cost wiring. The gateway is
-            # the single recording entry point (session scope on itself; agent/project via
-            # the shared tracker it holds). Session's own _make_router_op_context serves
-            # file/MCP ops, which no embed op reaches.
-            budget_gateway=self._budget,
-            state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
-            # #1953 dynamic-wire: thread the REAL session id + Task backend so
-            # router-dispatched task.* ops hit the assignee/requester CAS gate.
-            session_id=self._session_id,
-            task_backend=self._task_backend,
-            task_waker=self._task_waker,  # #2107: thread the TaskWaker into the router op-ctx
-            task_subscription_writer=self._task_subscription_writer,  # #2187 backend-master: the Task subscription WAL writer
-            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: task_start/end (router path)
-            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
-            agent_name=self.agent_name,
-            agent_role=self._agent_role,
-            output_language=self.output_language,
-            allowed_mcp=self._allowed_mcp,
-            permission_resolver=self._perm,
-            mcp_servers=self._mcp_servers,
-            project_context=self._project_context,
-            events=self._chat_events,
-            resolver=self._resolver,
-            memory=self._memory,
-            journal=self._journal,
-            agent_registry=self._registry,
-            # IS-5: the session's real (initially empty) PipelineRegistry —
-            # mirrors agent_registry above. Exposed via
-            # RouterHostAdapter.get_pipeline_registry() and read onto
-            # RouterCallerState.pipeline_registry by
-            # RouterLoop._build_router_caller_state.
-            pipeline_registry=self._pipeline_registry,
-            # FP-0054 PR-C: the session's PresentationRegistry — mirrors
-            # pipeline_registry above; the adapter threads its CURRENT snapshot into
-            # each router OpContext, and _reapply_presentations swaps both copies.
-            presentation_registry=self._presentation_registry,
-            # #2103 S1bc-exec: record a spawned session's sid→task (the trusted result
-            # header source) + read this session's LIVE sid (the cached session_id above
-            # is stale for spawned sessions, stamped post-construction) for the non-main
-            # spawn guard.
-            record_spawned_task=self.record_spawned_task,
-            live_session_id_fn=lambda: self._session_id,
-            # #1953 §16: the per-turn execution context (set in run_one_iteration),
-            # read at op-ctx-build time so a router task.create derives ownership.
-            current_task_id_fn=lambda: self._current_task_id,
-            # proposal 0060 Phase 1 (A7): mirrors current_task_id_fn exactly — a live
-            # callback (not a fixed init value) because turn_origin varies per turn.
-            turn_origin_fn=lambda: self._current_turn_origin,
-            agent_workspace_dir=self.workspace_dir,
-            file_read=self._file_read,
-            file_write=self._file_write,
-            file_delete=self._file_delete,
-            file_list_directory=self._file_list_directory,
-            file_regenerate_index=self._file_regenerate_index,
-            mcp_list_servers=self._mcp_list_servers,
-            mcp_list_tools=self._mcp_list_tools,
-            mcp_call_tool=self._mcp_call_tool,
-            # #2597 slice ②a: resources consumption (list/read/templates).
-            mcp_list_resources=self._mcp_list_resources,
-            mcp_list_resource_templates=self._mcp_list_resource_templates,
-            mcp_read_resource=self._mcp_read_resource,
-            # #2597 slice ②b: resource subscriptions.
-            mcp_subscribe_resource=self._mcp_subscribe_resource,
-            mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
-            # #2597 slice ②c: prompts consumption (list/get).
-            mcp_list_prompts=self._mcp_list_prompts,
-            mcp_get_prompt=self._mcp_get_prompt,
-            send_to_agent=self._send_to_agent,
-            put_outbox=self._put_outbox,
-            append_history=self._append_history,
-            delegation_tracker=lambda: self._router_loop_delegations,
-            agent_replies_tracker=lambda: self._router_loop_agent_replies,
-            universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
-            action_embedding_index=self._action_embedding_index,
-            embedding_provider=self._embedding_provider,
-            embedding_model_class=self._embedding_model_class,
-            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: forwarded to make_router_op_context
-            # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list.
-            action_usage_tracker=self._action_usage_tracker,
-            uncompacted_tool_call_records_fn=(
-                self._uncompacted_tool_call_records
-            ),
-            action_retrieval_config=self._action_retrieval,
-            available_skills=self._available_skills,  # #2548 PR-A
-            # FP-0034 Phase 2: sandbox backend for exec D14 visibility gate.
-            # #1417: gate on the INJECTED backend's real capability, not the
-            # reyn.yaml config STRING. The exec capability comes from the
-            # injected ``self._sandbox_backend`` instance (the SAME object used
-            # for actual exec at line 1847 / sandboxed_exec.py: ``ctx.sandbox_
-            # backend or get_default_backend(...)``); both injected types expose
-            # ``.name`` (DockerEnvironmentBackend.name="docker" / SandboxBackend
-            # .name). Without this, ``sandbox.backend=noop`` config + an injected
-            # exec backend (``--env-backend=docker``) would HIDE exec from
-            # discovery even though sandboxed_exec is functionally available
-            # (the construction-forwarding-gap: config string ≠ live instance).
-            # No injected instance → fall back to the config string (auto /
-            # host-default behaviour unchanged).
-            sandbox_backend=_exec_gate_backend_name(
-                self._sandbox_backend, self._sandbox_config
-            ),
-            # #187: the FS env-backend instance + container repo root + host-side
-            # state dir for the LIVE router OpContext Workspace (the registry
-            # file-dispatch factory). Same source as the chat OpContext (#1410).
-            environment_backend=self._environment_backend,
-            workspace_base_dir=self._workspace_base_dir,
-            workspace_state_dir=self._workspace_state_dir,
-            # #187 exec-seam (10th defect): the exec backend INSTANCE so the LIVE
-            # router's sandboxed_exec runs in the container repo, not the host
-            # seatbelt fallback. Same instance the legacy _make_router_op_context
-            # passes (4824); chat.py injects the SAME docker backend at both FS +
-            # exec seams (#1289 single-shared-sandbox). Distinct from the D14
-            # STRING above.
-            sandbox_backend_instance=self._sandbox_backend,
-            # #1339 / sandbox-model completion: thread the operator sandbox
-            # policy so make_router_op_context resolves a concrete agent-level
-            # policy onto the router OpContext (closes the chat-factory wiring gap).
-            sandbox_policy=(
-                self._sandbox_config.policy if self._sandbox_config is not None
-                else None
-            ),
-            # Issue #364 multi-modal cluster: media-size gate config.
-            multimodal_config=self._multimodal_config,
-            # FP-0055 / #2679: operator render_template output bounds → the router
-            # OpContext (the render_template op reads ctx.render_template_bounds).
-            render_template_bounds=self._render_template_bounds,
-            # #1652: reasoning config (display/continuity/recent_turns gates) +
-            # the bounded prior-reasoning section renderer (reads this session's
-            # history). The host exposes reasoning_display_enabled() /
-            # reasoning_continuity_enabled() / reasoning_continuity_section() to
-            # the router loop for emit-gating, persist-gating, and SP replay.
-            reasoning_config=self._reasoning,
-            reasoning_continuity_section_fn=self.reasoning_continuity_section,
-            # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
-            media_store=self._media_store,
-            # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).
-            # Late-bound method — the engine budgets it reads are computed by
-            # the time a tool result flows through router_loop at runtime.
-            cap_tool_result=self._cap_tool_result,
-            # #272 media axis: per-turn media budget (= cap − tool text tokens)
-            # so router_loop bounds the media follow-up (overflow media → ref).
-            media_followup_budget=self._media_followup_budget,
-            # tool-result-schema-redesign §5: gates build_offload_body's structured
-            # inline-size gate (STRUCTURED_INLINE_MAX_CHARS). Static per-session config,
-            # not a callable (unlike the two budgets above, which read live engine state).
-            offload_enabled=self._offload_config.enabled,
-            # #272/#1128 compact op: voluntary-compaction callback so the LLM-
-            # emittable `compact` control_ir op can compact chat history.
-            compact_now=self._compact_now_for_op,
-            # #272/#1128 context-size signal: live exact-token budget so the
-            # router SP can show the LLM the free window (header).
-            context_window_status=self.context_window_status,
-            # B25-S5-1: thread eager-build flag so RouterLoop awaits build
-            # before computing _search_visible on the first turn.
-            eager_embedding_build=self._eager_embedding_build,
-            # FP-0022 fix (#53): give the router OpContext a real
-            # InterventionBus so web_fetch / mcp install / mcp drop
-            # handlers can run their interactive (Layer 4) approval
-            # flow. The bus is built per make_router_op_context() call
-            # — short-lived, scoped to the chat_router turn, identical
-            # to what session._mcp_call_tool wires manually today.
-            # #2708 P3.2a: when this session is an ATTACHED pipeline driver (it carries a
-            # SpawnBridgeInterventionListener), the router intervention bus dispatches on the
-            # PARENT session's live-operator listener instead of the driver's own
-            # listener-less registry — so a pipeline-step ``ask_user`` reaches the operator
-            # blocked on the parent by construction (#2721), instead of silently auto-
-            # refusing. Non-driver / detached / ephemeral sessions (bridge is None) keep the
-            # self-bound bus, byte-identical. Mirror of the presentation_renderer_factory
-            # spawn-bridge below.
-            # #3049: single-sourced with the MCP op callers via
-            # ``_make_router_intervention_bus`` (bridge-aware — driver → parent, else
-            # self-bound) so router-op interventions resolve to the SAME surface
-            # regardless of which seam builds the OpContext.
-            intervention_bus_factory=self._make_router_intervention_bus,
-            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
-            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
-            # Built per make_router_op_context() call, mirroring the intervention_bus_factory
-            # above. The sink is obtained from the surface's declared PresentationConsumer
-            # (orphan-impossible: OutboxPresentationRenderer is constructible ONLY inside
-            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
-            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
-            # FP-0037 S2: yaml mtime watch needs the project root to resolve
-            # the 3 yaml scope tier paths. None falls back to user-global only.
-            project_root=getattr(self._registry, "_project_root", None),
-            # #1468: cooperative turn-cancel forwarding. The adapter's
-            # _is_turn_cancel_requested() forwards to RouterLoopDriver; run_loop
-            # checks it via getattr at each iteration boundary.
-            turn_cancel_fn=self._is_turn_cancel_requested,
-        )
+        # #3082 Family 6a: the router-host WAIST — RouterHostAdapter aggregates
+        # ~40 already-constructed Session sub-components (Families 1-5's
+        # outputs + params/early attrs set earlier in __init__) into a
+        # single object most later families read through. Byte-identical
+        # extraction — same object, same construction order, same ~40 args
+        # (including the 3 DEFERRED per-turn lambdas —
+        # live_session_id_fn / current_task_id_fn / turn_origin_fn — kept
+        # verbatim, still closing over self and resolved at call time, NOT
+        # eager-ized); unmoved (invoked HERE, at its ORIGINAL position —
+        # every dep is already set on self by this point). See
+        # _RouterWaistBundle / _build_router_waist's docstring for the full
+        # per-arg provenance (reproduced verbatim in the builder below).
+        _router_waist_bundle = self._build_router_waist()
+        self._router_host = _router_waist_bundle.router_host
 
         # #2073 S2: register the per-component hot-reload reapply seams now that the
         # sub-components they orchestrate (router_host etc.) exist. Each
@@ -4390,6 +4224,272 @@ class Session:
             action_embedding_index=action_embedding_index,
             action_usage_tracker=action_usage_tracker,
         )
+
+    def _build_router_waist(self) -> "_RouterWaistBundle":
+        """#3082 Family 6a: build the router-host WAIST — ``router_host``
+        (``RouterHostAdapter``, the concrete ``RouterLoopHost`` implementation
+        that aggregates ~40 already-constructed Session sub-components).
+
+        Byte-identical extraction of the construction sequence that used to
+        run inline in ``__init__`` at its ORIGINAL position (line ~1726,
+        no-move — every dep below is already set on ``self`` by this point)
+        — same object, same construction order, same ~40 args. This builder
+        takes NO explicit params (unlike Families 2-5, which thread one or a
+        few LOCAL ``__init__`` params/eager siblings explicitly): parameterizing
+        ~40 args is impractical, and every one of router_host's dependencies
+        is ALREADY an attribute on ``self`` (or a bound method / property) by
+        the time this builder runs — so, following the Family 3/5
+        instance-method precedent for eager sibling reads, this builder reads
+        every dependency as ``self._X`` / ``self.X`` directly, exactly as the
+        inline construction did.
+
+        ★ Three args are DEFERRED lambdas, NOT eager values —
+        ``live_session_id_fn`` / ``current_task_id_fn`` / ``turn_origin_fn``
+        keep resolving ``self._session_id`` / ``self._current_task_id`` /
+        ``self._current_turn_origin`` at CALL time, not here: both already
+        carry a pre-turn DEFAULT at construction (``_current_task_id`` is
+        ``None``, set at :1074; ``_current_turn_origin`` is
+        ``"auto_improvement"``, set at :1083 — both BEFORE this builder
+        runs), but both are then REASSIGNED per turn inside
+        ``run_one_iteration`` (far after ``__init__`` returns) — an
+        eager-captured value here would freeze the pre-turn default forever,
+        never seeing a real turn's task id / origin; ``live_session_id_fn``
+        is deferred because a spawned session's live session id can change
+        AFTER this constructor runs (the cached ``self._session_id`` read
+        here is stale for that case — see the inline comment above
+        ``record_spawned_task`` below). Eager-izing any of the three would
+        freeze a per-turn value at
+        construction time — the Family 3/5 deferred/eager pitfall repeated
+        here for a third and heavier family. ``record_spawned_task`` (a bound
+        method) and the two tracker lambdas ``delegation_tracker`` /
+        ``agent_replies_tracker`` are likewise kept verbatim, still closing
+        over ``self``.
+
+        PR-refactor-session-1 wave 3 PR3: RouterHostAdapter — concrete
+        RouterLoopHost implementation extracted from Session. Constructed
+        last in __init__ because it receives callbacks that reference self
+        (all of which are bound methods, resolved at call time not here)."""
+        # #1092 PR-F1 (chat activation): build the chat axis's turn_budget engine
+        # off the RESOLVED model (#1172-safe — resolve self.model exactly as the
+        # CompactionEngine does; never hand the cosmetic class to the budget).
+        # try_build_* returns None (NOT raise) when the model's context is too
+        # small to satisfy the by-construction force-close floor (output_reserve +
+        # offload_cap < threshold) — a small-context model is a legitimate chat
+        # session that simply cannot support force-close, so it degrades to the
+        # pre-force-close path (no cap, no handoff) rather than failing __init__.
+        # ADDITIVE: the engine's sole consumer is
+        # RouterHostAdapter.wrap_up_output_reserve, inert until the F2 handoff
+        # calls _force_close_call — chat stays REACTIVE-only (see the property's
+        # docstring for the deliberate per-axis choice).
+        from reyn.services.turn_budget import try_build_default_turn_budget_engine
+        _chat_turn_budget_engine = try_build_default_turn_budget_engine(
+            self._resolver.resolve(self.model).model,
+            use_chars4=getattr(self._compaction, "use_chars4_estimate", False),
+        )
+
+        router_host = RouterHostAdapter(
+            # #2175: the safety.on_limit checkpoint + the shared per-run extension dict —
+            # so the spawn SEAM (agent_spawn / topology_create) routes spawn-limit exceeds
+            # through the same mode-driven framework as inter_agent_messaging's max_agent_hops.
+            handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
+            safety_extensions=self._safety_extensions,
+            # #1092 PR-F1: the chat turn_budget engine (resolved-model, asserted).
+            turn_budget_engine=_chat_turn_budget_engine,
+            # FP-0050 / #1822 S2: content-threat scan + fence config.
+            threat_scan=self._safety.threat_scan,
+            contextual_permission=self._contextual_permission,  # #1827 S3 → control-IR OpContext
+            hot_reloader=self._hot_reloader,  # #2073 S3 → per-session reload route (tool ctx)
+            # FP-0063 PC: the router-dispatched `embed` TOOL builds its OpContext from
+            # THIS host (RouterCallerState.op_context_factory = host.make_router_op_context),
+            # so this is the live interactive path's embedding-cost wiring. The gateway is
+            # the single recording entry point (session scope on itself; agent/project via
+            # the shared tracker it holds). Session's own _make_router_op_context serves
+            # file/MCP ops, which no embed op reaches.
+            budget_gateway=self._budget,
+            state_log=self._state_log,  # #2259 PR-1 → config generation emit from config ops
+            # #1953 dynamic-wire: thread the REAL session id + Task backend so
+            # router-dispatched task.* ops hit the assignee/requester CAS gate.
+            session_id=self._session_id,
+            task_backend=self._task_backend,
+            task_waker=self._task_waker,  # #2107: thread the TaskWaker into the router op-ctx
+            task_subscription_writer=self._task_subscription_writer,  # #2187 backend-master: the Task subscription WAL writer
+            hook_dispatcher=self._hook_dispatcher,  # #1800 slice 5c: task_start/end (router path)
+            hook_bus=self._hook_bus,  # Hook-Event Redesign Phase 5 part 2: emit_hook_event's publish target
+            agent_name=self.agent_name,
+            agent_role=self._agent_role,
+            output_language=self.output_language,
+            allowed_mcp=self._allowed_mcp,
+            permission_resolver=self._perm,
+            mcp_servers=self._mcp_servers,
+            project_context=self._project_context,
+            events=self._chat_events,
+            resolver=self._resolver,
+            memory=self._memory,
+            journal=self._journal,
+            agent_registry=self._registry,
+            # IS-5: the session's real (initially empty) PipelineRegistry —
+            # mirrors agent_registry above. Exposed via
+            # RouterHostAdapter.get_pipeline_registry() and read onto
+            # RouterCallerState.pipeline_registry by
+            # RouterLoop._build_router_caller_state.
+            pipeline_registry=self._pipeline_registry,
+            # FP-0054 PR-C: the session's PresentationRegistry — mirrors
+            # pipeline_registry above; the adapter threads its CURRENT snapshot into
+            # each router OpContext, and _reapply_presentations swaps both copies.
+            presentation_registry=self._presentation_registry,
+            # #2103 S1bc-exec: record a spawned session's sid→task (the trusted result
+            # header source) + read this session's LIVE sid (the cached session_id above
+            # is stale for spawned sessions, stamped post-construction) for the non-main
+            # spawn guard.
+            record_spawned_task=self.record_spawned_task,
+            live_session_id_fn=lambda: self._session_id,
+            # #1953 §16: the per-turn execution context (set in run_one_iteration),
+            # read at op-ctx-build time so a router task.create derives ownership.
+            current_task_id_fn=lambda: self._current_task_id,
+            # proposal 0060 Phase 1 (A7): mirrors current_task_id_fn exactly — a live
+            # callback (not a fixed init value) because turn_origin varies per turn.
+            turn_origin_fn=lambda: self._current_turn_origin,
+            agent_workspace_dir=self.workspace_dir,
+            file_read=self._file_read,
+            file_write=self._file_write,
+            file_delete=self._file_delete,
+            file_list_directory=self._file_list_directory,
+            file_regenerate_index=self._file_regenerate_index,
+            mcp_list_servers=self._mcp_list_servers,
+            mcp_list_tools=self._mcp_list_tools,
+            mcp_call_tool=self._mcp_call_tool,
+            # #2597 slice ②a: resources consumption (list/read/templates).
+            mcp_list_resources=self._mcp_list_resources,
+            mcp_list_resource_templates=self._mcp_list_resource_templates,
+            mcp_read_resource=self._mcp_read_resource,
+            # #2597 slice ②b: resource subscriptions.
+            mcp_subscribe_resource=self._mcp_subscribe_resource,
+            mcp_unsubscribe_resource=self._mcp_unsubscribe_resource,
+            # #2597 slice ②c: prompts consumption (list/get).
+            mcp_list_prompts=self._mcp_list_prompts,
+            mcp_get_prompt=self._mcp_get_prompt,
+            send_to_agent=self._send_to_agent,
+            put_outbox=self._put_outbox,
+            append_history=self._append_history,
+            delegation_tracker=lambda: self._router_loop_delegations,
+            agent_replies_tracker=lambda: self._router_loop_agent_replies,
+            universal_wrappers_enabled=self._action_retrieval.universal_wrappers_enabled,
+            action_embedding_index=self._action_embedding_index,
+            embedding_provider=self._embedding_provider,
+            embedding_model_class=self._embedding_model_class,
+            embedding_event_sink=self._embedding_event_sink,  # FP-0057 #2856 Part A: forwarded to make_router_op_context
+            # FP-0034 Phase 2 step 5: ActionUsageTracker for hot list.
+            action_usage_tracker=self._action_usage_tracker,
+            uncompacted_tool_call_records_fn=(
+                self._uncompacted_tool_call_records
+            ),
+            action_retrieval_config=self._action_retrieval,
+            available_skills=self._available_skills,  # #2548 PR-A
+            # FP-0034 Phase 2: sandbox backend for exec D14 visibility gate.
+            # #1417: gate on the INJECTED backend's real capability, not the
+            # reyn.yaml config STRING. The exec capability comes from the
+            # injected ``self._sandbox_backend`` instance (the SAME object used
+            # for actual exec at line 1847 / sandboxed_exec.py: ``ctx.sandbox_
+            # backend or get_default_backend(...)``); both injected types expose
+            # ``.name`` (DockerEnvironmentBackend.name="docker" / SandboxBackend
+            # .name). Without this, ``sandbox.backend=noop`` config + an injected
+            # exec backend (``--env-backend=docker``) would HIDE exec from
+            # discovery even though sandboxed_exec is functionally available
+            # (the construction-forwarding-gap: config string ≠ live instance).
+            # No injected instance → fall back to the config string (auto /
+            # host-default behaviour unchanged).
+            sandbox_backend=_exec_gate_backend_name(
+                self._sandbox_backend, self._sandbox_config
+            ),
+            # #187: the FS env-backend instance + container repo root + host-side
+            # state dir for the LIVE router OpContext Workspace (the registry
+            # file-dispatch factory). Same source as the chat OpContext (#1410).
+            environment_backend=self._environment_backend,
+            workspace_base_dir=self._workspace_base_dir,
+            workspace_state_dir=self._workspace_state_dir,
+            # #187 exec-seam (10th defect): the exec backend INSTANCE so the LIVE
+            # router's sandboxed_exec runs in the container repo, not the host
+            # seatbelt fallback. Same instance the legacy _make_router_op_context
+            # passes (4824); chat.py injects the SAME docker backend at both FS +
+            # exec seams (#1289 single-shared-sandbox). Distinct from the D14
+            # STRING above.
+            sandbox_backend_instance=self._sandbox_backend,
+            # #1339 / sandbox-model completion: thread the operator sandbox
+            # policy so make_router_op_context resolves a concrete agent-level
+            # policy onto the router OpContext (closes the chat-factory wiring gap).
+            sandbox_policy=(
+                self._sandbox_config.policy if self._sandbox_config is not None
+                else None
+            ),
+            # Issue #364 multi-modal cluster: media-size gate config.
+            multimodal_config=self._multimodal_config,
+            # FP-0055 / #2679: operator render_template output bounds → the router
+            # OpContext (the render_template op reads ctx.render_template_bounds).
+            render_template_bounds=self._render_template_bounds,
+            # #1652: reasoning config (display/continuity/recent_turns gates) +
+            # the bounded prior-reasoning section renderer (reads this session's
+            # history). The host exposes reasoning_display_enabled() /
+            # reasoning_continuity_enabled() / reasoning_continuity_section() to
+            # the router loop for emit-gating, persist-gating, and SP replay.
+            reasoning_config=self._reasoning,
+            reasoning_continuity_section_fn=self.reasoning_continuity_section,
+            # Issue #383 PR-C: shared MediaStore for image + tool-result storage.
+            media_store=self._media_store,
+            # #1128 size axis: per-turn tool-result cap/offload (dead-end #1).
+            # Late-bound method — the engine budgets it reads are computed by
+            # the time a tool result flows through router_loop at runtime.
+            cap_tool_result=self._cap_tool_result,
+            # #272 media axis: per-turn media budget (= cap − tool text tokens)
+            # so router_loop bounds the media follow-up (overflow media → ref).
+            media_followup_budget=self._media_followup_budget,
+            # tool-result-schema-redesign §5: gates build_offload_body's structured
+            # inline-size gate (STRUCTURED_INLINE_MAX_CHARS). Static per-session config,
+            # not a callable (unlike the two budgets above, which read live engine state).
+            offload_enabled=self._offload_config.enabled,
+            # #272/#1128 compact op: voluntary-compaction callback so the LLM-
+            # emittable `compact` control_ir op can compact chat history.
+            compact_now=self._compact_now_for_op,
+            # #272/#1128 context-size signal: live exact-token budget so the
+            # router SP can show the LLM the free window (header).
+            context_window_status=self.context_window_status,
+            # B25-S5-1: thread eager-build flag so RouterLoop awaits build
+            # before computing _search_visible on the first turn.
+            eager_embedding_build=self._eager_embedding_build,
+            # FP-0022 fix (#53): give the router OpContext a real
+            # InterventionBus so web_fetch / mcp install / mcp drop
+            # handlers can run their interactive (Layer 4) approval
+            # flow. The bus is built per make_router_op_context() call
+            # — short-lived, scoped to the chat_router turn, identical
+            # to what session._mcp_call_tool wires manually today.
+            # #2708 P3.2a: when this session is an ATTACHED pipeline driver (it carries a
+            # SpawnBridgeInterventionListener), the router intervention bus dispatches on the
+            # PARENT session's live-operator listener instead of the driver's own
+            # listener-less registry — so a pipeline-step ``ask_user`` reaches the operator
+            # blocked on the parent by construction (#2721), instead of silently auto-
+            # refusing. Non-driver / detached / ephemeral sessions (bridge is None) keep the
+            # self-bound bus, byte-identical. Mirror of the presentation_renderer_factory
+            # spawn-bridge below.
+            # #3049: single-sourced with the MCP op callers via
+            # ``_make_router_intervention_bus`` (bridge-aware — driver → parent, else
+            # self-bound) so router-op interventions resolve to the SAME surface
+            # regardless of which seam builds the OpContext.
+            intervention_bus_factory=self._make_router_intervention_bus,
+            # FP-0054 PR-B / #2708 P1: give the router OpContext a real PresentationRenderer
+            # so a `present` op reaches the surface's sink instead of PR-A's null surface.
+            # Built per make_router_op_context() call, mirroring the intervention_bus_factory
+            # above. The sink is obtained from the surface's declared PresentationConsumer
+            # (orphan-impossible: OutboxPresentationRenderer is constructible ONLY inside
+            # OutboxPresentationConsumer.sink) — bound to THIS Session via sink(self).
+            presentation_renderer_factory=lambda: self._presentation_consumer.sink(self),
+            # FP-0037 S2: yaml mtime watch needs the project root to resolve
+            # the 3 yaml scope tier paths. None falls back to user-global only.
+            project_root=getattr(self._registry, "_project_root", None),
+            # #1468: cooperative turn-cancel forwarding. The adapter's
+            # _is_turn_cancel_requested() forwards to RouterLoopDriver; run_loop
+            # checks it via getattr at each iteration boundary.
+            turn_cancel_fn=self._is_turn_cancel_requested,
+        )
+        return _RouterWaistBundle(router_host=router_host)
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py
+++ b/tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py
@@ -100,9 +100,12 @@ class TestFamily6aRouterWaistBundleByteIdentical:
         wired_agent_registry = router_host.get_agent_registry()
         wired_pipeline_registry = router_host.get_pipeline_registry()
         wired_presentation_registry = router_host.get_presentation_registry()
-        assert wired_agent_registry is session._registry
-        assert wired_pipeline_registry is session._pipeline_registry
-        assert wired_presentation_registry is session._presentation_registry
+        session_agent_registry = session._registry
+        session_pipeline_registry = session._pipeline_registry
+        session_presentation_registry = session._presentation_registry
+        assert wired_agent_registry is session_agent_registry
+        assert wired_pipeline_registry is session_pipeline_registry
+        assert wired_presentation_registry is session_presentation_registry
 
     def test_events_state_log_permission_resolver_resolver_wired(
         self, session: Session,
@@ -115,10 +118,14 @@ class TestFamily6aRouterWaistBundleByteIdentical:
         wired_state_log = router_host.state_log
         wired_permission_resolver = router_host.permission_resolver
         wired_resolver = router_host.resolver
-        assert wired_events is session._chat_events
-        assert wired_state_log is session._state_log
-        assert wired_permission_resolver is session._perm
-        assert wired_resolver is session._resolver
+        session_chat_events = session._chat_events
+        session_state_log = session._state_log
+        session_perm = session._perm
+        session_resolver = session._resolver
+        assert wired_events is session_chat_events
+        assert wired_state_log is session_state_log
+        assert wired_permission_resolver is session_perm
+        assert wired_resolver is session_resolver
 
     def test_agent_name_and_role_passthrough(self, session: Session) -> None:
         """Tier 1: ``agent_name``/``agent_role`` passthrough — proven via
@@ -126,23 +133,25 @@ class TestFamily6aRouterWaistBundleByteIdentical:
         router_host = session._router_host
         wired_agent_name = router_host.agent_name
         wired_agent_role = router_host.agent_role
+        session_agent_role = session._agent_role
         assert wired_agent_name == session.agent_name
-        assert wired_agent_role == session._agent_role
+        assert wired_agent_role == session_agent_role
 
     # ── ★ the 3 deferred per-turn lambdas: crux of this family ───────────
 
     def test_live_session_id_resolves_at_call_time_not_construction_time(
         self, session: Session,
     ) -> None:
-        """Tier 1 / ★ crux: ``live_session_id_fn=lambda: self._session_id``
+        """Tier 1: ★ crux — ``live_session_id_fn=lambda: self._session_id``
         must be DEFERRED — reassigning ``session._session_id`` AFTER
         construction (mirroring a spawned session's post-construction sid
         stamp) must show up on ``router_host.live_session_id`` immediately.
         If the lambda had been eager-ized to a fixed value at builder-call
         time, this would still show the OLD sid — the strip-falsify shape."""
         router_host = session._router_host
+        session_session_id = session._session_id
         original_live_sid = router_host.live_session_id
-        assert original_live_sid == session._session_id
+        assert original_live_sid == session_session_id
 
         session._session_id = "spawned-session-live-sid"
 
@@ -155,7 +164,7 @@ class TestFamily6aRouterWaistBundleByteIdentical:
     def test_current_task_id_and_turn_origin_resolve_at_call_time(
         self, session: Session,
     ) -> None:
-        """Tier 1 / ★ crux: ``current_task_id_fn`` / ``turn_origin_fn`` must
+        """Tier 1: ★ crux — ``current_task_id_fn`` / ``turn_origin_fn`` must
         be DEFERRED per-turn callbacks, NOT frozen at construction. Both
         ``_current_task_id`` (default ``None``) and ``_current_turn_origin``
         (default ``"auto_improvement"``) already carry a PRE-TURN default at

--- a/tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py
+++ b/tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py
@@ -1,0 +1,213 @@
+# scaffold: triggered_by="#3082 Family 6a (router_host waist bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 6a
+extraction — ``Session._build_router_waist`` pulling the ``RouterHostAdapter``
+construction (the pipeline's WAIST: ~40 already-constructed Session
+sub-components aggregated into one object) out of ``Session.__init__`` into
+one builder returning one typed bundle (``_RouterWaistBundle``).
+
+The load-bearing distinction from Families 1-5: this family's builder is an
+instance method with NO explicit params at all (unlike Family 2's local
+``state_log`` or Family 4/5's local ``chat_events``/``agent_name`` args) —
+every one of ``RouterHostAdapter``'s ~40 dependencies is already an attribute
+on ``self`` (or a bound method / property) by the time the builder runs, so
+parameterizing them individually was judged impractical by the architect
+spec. This scaffold pins two things behaviorally:
+
+1. A representative sample of the ~40 eager wiring args — proven via
+   ``RouterHostAdapter``'s OWN public accessors (``get_agent_registry()`` /
+   ``get_pipeline_registry()`` / ``get_presentation_registry()`` / ``events``
+   / ``state_log`` / ``permission_resolver`` / ``resolver`` / ``agent_name``
+   / ``agent_role``), never a private-attribute peek into the adapter's
+   internals — compared by identity/equality against the SAME Session
+   attributes that fed the builder (which is this extraction's own target
+   state, the accepted idiom per Family 4/5's ``isinstance(session._budget,
+   BudgetGateway)`` shape).
+2. ★ The 3 DEFERRED per-turn lambdas — ``live_session_id_fn`` /
+   ``current_task_id_fn`` / ``turn_origin_fn`` — MUST keep resolving
+   ``self._session_id`` / ``self._current_task_id`` / ``self._current_turn_
+   origin`` at CALL time, not at builder-call time. Both
+   ``_current_task_id`` (default ``None``) and ``_current_turn_origin``
+   (default ``"auto_improvement"``) already carry a pre-turn default at
+   construction, before the builder runs; they are REASSIGNED per turn
+   inside ``run_one_iteration``, far after ``__init__`` returns. Proven via
+   ``RouterHostAdapter``'s public surface: the ``live_session_id`` property
+   and ``make_router_op_context().current_task_id`` /
+   ``.turn_origin`` fields, read BEFORE and AFTER mutating the owning
+   Session's per-turn state post-construction (mirroring exactly what
+   ``run_one_iteration`` does at runtime). If any of the three were
+   eager-ized (the Family 3/5 deferred/eager pitfall), the value read after
+   the post-construction mutation would still show the STALE
+   pre-turn/construction-time default — the strip-falsify shape this
+   scaffold pins.
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-Session-attr
+reads (``session._router_host``, ``session._registry`` etc.) are resolved to
+a LOCAL variable on a line BEFORE the ``assert`` and are the extraction's own
+target attribute / this Session's own state — not a faked collaborator.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.services.router_host_adapter import RouterHostAdapter
+from reyn.runtime.session import Session, _RouterWaistBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family6a-router-waist-test")
+
+
+class TestFamily6aRouterWaistBundleByteIdentical:
+    # ── builder contract ─────────────────────────────────────────────────
+
+    def test_session_holds_router_host_of_real_type(self, session: Session) -> None:
+        """Tier 1: the builder assigns a real ``RouterHostAdapter`` onto
+        ``Session._router_host`` — the extraction's core contract."""
+        router_host = session._router_host
+        is_adapter = isinstance(router_host, RouterHostAdapter)
+        assert is_adapter
+
+    def test_builder_returns_a_router_waist_bundle(self, session: Session) -> None:
+        """Tier 1: calling the builder directly (a public-ish bound method on
+        Session) returns a ``_RouterWaistBundle`` wrapping a real
+        ``RouterHostAdapter`` — the builder's contract independent of
+        ``__init__`` unpack wiring."""
+        bundle = session._build_router_waist()
+        is_bundle = isinstance(bundle, _RouterWaistBundle)
+        is_adapter = isinstance(bundle.router_host, RouterHostAdapter)
+        assert is_bundle
+        assert is_adapter
+
+    # ── representative sample of the ~40 eager aggregate wires ───────────
+
+    def test_agent_registry_pipeline_registry_presentation_registry_wired(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: three of the Family-1-5-adjacent registries router_host
+        aggregates are the SAME instances Session holds (byte-identical
+        eager wiring, not fresh copies) — proven via router_host's own
+        public accessors."""
+        router_host = session._router_host
+        wired_agent_registry = router_host.get_agent_registry()
+        wired_pipeline_registry = router_host.get_pipeline_registry()
+        wired_presentation_registry = router_host.get_presentation_registry()
+        assert wired_agent_registry is session._registry
+        assert wired_pipeline_registry is session._pipeline_registry
+        assert wired_presentation_registry is session._presentation_registry
+
+    def test_events_state_log_permission_resolver_resolver_wired(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: the Family-1 EventLog / recovery WAL / permission
+        resolver / model resolver are the SAME instances (byte-identical
+        eager wiring), proven via router_host's own public properties."""
+        router_host = session._router_host
+        wired_events = router_host.events
+        wired_state_log = router_host.state_log
+        wired_permission_resolver = router_host.permission_resolver
+        wired_resolver = router_host.resolver
+        assert wired_events is session._chat_events
+        assert wired_state_log is session._state_log
+        assert wired_permission_resolver is session._perm
+        assert wired_resolver is session._resolver
+
+    def test_agent_name_and_role_passthrough(self, session: Session) -> None:
+        """Tier 1: ``agent_name``/``agent_role`` passthrough — proven via
+        router_host's own public properties, not hardcoded on the bundle."""
+        router_host = session._router_host
+        wired_agent_name = router_host.agent_name
+        wired_agent_role = router_host.agent_role
+        assert wired_agent_name == session.agent_name
+        assert wired_agent_role == session._agent_role
+
+    # ── ★ the 3 deferred per-turn lambdas: crux of this family ───────────
+
+    def test_live_session_id_resolves_at_call_time_not_construction_time(
+        self, session: Session,
+    ) -> None:
+        """Tier 1 / ★ crux: ``live_session_id_fn=lambda: self._session_id``
+        must be DEFERRED — reassigning ``session._session_id`` AFTER
+        construction (mirroring a spawned session's post-construction sid
+        stamp) must show up on ``router_host.live_session_id`` immediately.
+        If the lambda had been eager-ized to a fixed value at builder-call
+        time, this would still show the OLD sid — the strip-falsify shape."""
+        router_host = session._router_host
+        original_live_sid = router_host.live_session_id
+        assert original_live_sid == session._session_id
+
+        session._session_id = "spawned-session-live-sid"
+
+        updated_live_sid = router_host.live_session_id
+        assert updated_live_sid == "spawned-session-live-sid", (
+            "strip-falsify: live_session_id_fn did not re-resolve "
+            "self._session_id after reassignment — eager-ized, not deferred"
+        )
+
+    def test_current_task_id_and_turn_origin_resolve_at_call_time(
+        self, session: Session,
+    ) -> None:
+        """Tier 1 / ★ crux: ``current_task_id_fn`` / ``turn_origin_fn`` must
+        be DEFERRED per-turn callbacks, NOT frozen at construction. Both
+        ``_current_task_id`` (default ``None``) and ``_current_turn_origin``
+        (default ``"auto_improvement"``) already carry a PRE-TURN default at
+        construction time, BEFORE the builder runs — proven via
+        ``make_router_op_context()``'s ``current_task_id`` / ``turn_origin``
+        fields reflecting exactly those pre-turn defaults on a fresh
+        session, then reflecting freshly-set per-turn values immediately
+        after mutation (mirroring exactly what a real turn does in
+        ``run_one_iteration``). An eager-captured lambda would keep showing
+        the PRE-TURN default forever, even after a real turn reassigns it —
+        the strip-falsify shape this pins."""
+        router_host = session._router_host
+
+        ctx_before = router_host.make_router_op_context()
+        assert ctx_before.current_task_id is None
+        assert ctx_before.turn_origin == "auto_improvement"
+
+        session._current_task_id = "task-42"
+        session._current_turn_origin = "user_directed"
+
+        ctx_after = router_host.make_router_op_context()
+        assert ctx_after.current_task_id == "task-42", (
+            "strip-falsify: current_task_id_fn did not re-resolve "
+            "self._current_task_id after the turn set it — eager-ized, not deferred"
+        )
+        assert ctx_after.turn_origin == "user_directed", (
+            "strip-falsify: turn_origin_fn did not re-resolve "
+            "self._current_turn_origin after the turn set it — eager-ized, not deferred"
+        )
+
+    def test_strip_falsify_current_task_id_reresolves_on_second_reassignment(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify — after observing task-42 flow through,
+        reassign to a DIFFERENT task id and confirm the NEW value flows
+        through too. This proves the lambda re-reads
+        ``self._current_task_id`` on EVERY call (genuinely deferred) rather
+        than caching the first-seen value, which would pass the single-
+        mutation check above vacuously."""
+        router_host = session._router_host
+
+        session._current_task_id = "task-a"
+        ctx_a = router_host.make_router_op_context()
+        assert ctx_a.current_task_id == "task-a"
+
+        session._current_task_id = "task-b"
+        ctx_b = router_host.make_router_op_context()
+        assert ctx_b.current_task_id == "task-b", (
+            "strip-falsify: current_task_id_fn cached the first-seen value "
+            "instead of re-resolving self._current_task_id on every call"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — extracts Session.__init__'s inline `RouterHostAdapter` construction (the #3082 pipeline's **WAIST**) into a byte-identical builder + frozen dataclass, per the architect's Family 6a spec (issue #3082 comment).

## Scope — 6a only, 6b out of scope

`RouterHostAdapter` (formerly constructed inline at `:1726`, verbatim comment reproduced at the new call site) aggregates ~40 already-constructed Session sub-components — Families 1-5's outputs (`chat_events` / `journal` / `hot_reloader` / `hook_dispatcher` / `hook_bus` / `budget`) plus params/early attrs set earlier in `__init__` (`task_backend` / `permission_resolver` / `resolver` / `registry` / `pipeline_registry` / `presentation_registry` / `file_*` / `mcp_*` / `memory` / …).

**Family 6b (`history_buffer` + `compaction_controller` + `budget_advisor`, including the `None`-then-patch forward-patch circular-dependency break and the `budget_advisor` UP-move across Family 8) is explicitly NOT touched here** — the architect spec recommends splitting Family 6 into 6a (this PR) and 6b (separate follow-up PR, after this lands), because the two constructs are ~240 lines apart and independent.

## Builder shape

- `Session._build_router_waist(self) -> _RouterWaistBundle` — **no explicit params** (unlike Families 2/4/5, which thread one or a few LOCAL `__init__` params/eager siblings explicitly). Parameterizing ~40 args individually was judged impractical by the architect spec; every one of `RouterHostAdapter`'s dependencies is already an attribute on `self` (or a bound method / property) by the time the builder runs, so this builder reads every dependency as `self._X` / `self.X` directly — the Family 3/5 instance-method precedent for eager sibling reads.
- `_RouterWaistBundle(router_host)` — single-field frozen dataclass (mirrors `_CostBundle`'s one-unconditional-component shape).
- Invoked at the construction's **ORIGINAL position** (no-move) — every dependency is already set on `self` by that point.

## ★ The 3 deferred per-turn lambdas — kept verbatim, NOT eager-ized

`live_session_id_fn=lambda: self._session_id` / `current_task_id_fn=lambda: self._current_task_id` / `turn_origin_fn=lambda: self._current_turn_origin` resolve **per-turn** Session state at CALL time, not at builder-call time:

- `_current_task_id` (default `None`) and `_current_turn_origin` (default `"auto_improvement"`) both already carry a pre-turn default at construction, but are **reassigned per turn** inside `run_one_iteration`, far after `__init__` returns.
- `live_session_id_fn` is deferred because a spawned session's live session id can change **after** this constructor runs (the cached `self._session_id` is stale for that case).

Eager-izing any of the three would freeze a per-turn value at construction time — the Family 3/5 deferred/eager pitfall this family must not repeat. `record_spawned_task` (bound method) and the two tracker lambdas (`delegation_tracker` / `agent_replies_tracker`) are likewise kept verbatim.

## Byte-identical verification (self-performed)

Diffed the extracted `RouterHostAdapter(...)` argument block (all lines from `RouterHostAdapter(` through the closing `)`, stripped of the assignment-target prefix) against the pre-extraction `git show HEAD:src/reyn/runtime/session.py` version with `diff` — **zero-line diff**, confirming all 83 top-level kwargs (spec's informal "~40" estimate; actual count is higher) are verbatim, including every comment. The `_chat_turn_budget_engine` precursor (the only local variable feeding the construction) was also diffed separately — zero-line diff. Every arg is either `self._X`/`self.X` (eager, value-identical since Families 1-5 already ran) or one of the 3 deferred lambdas / bound methods (verbatim).

## truncate-falsify gate — not applicable

This is a pure extraction adding no new WAL-event-derived recovery state (no PITR/rewind/restore path touched), so the CLAUDE.md recovery-feature PR gate does not apply — same judgment as Family 2's spec for the analogous WAL-adjacent `journal`/`generation_store` extraction.

## scaffold test (Tier 1, `tests/scaffold/`, deleted in this same PR once merged)

`tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py` — real `Session`/`RouterHostAdapter` instances only, no mocks:

- Builder contract: `Session._router_host` / `_build_router_waist()` return real typed objects.
- Representative sample of the ~40 eager wires (agent_registry / pipeline_registry / presentation_registry / events / state_log / permission_resolver / resolver / agent_name / agent_role), proven via `RouterHostAdapter`'s own public accessors compared against Session's own attributes (never a peek into the adapter's private internals).
- ★ **The 3 deferred lambdas**, pinned behaviorally via `router_host.live_session_id` and `router_host.make_router_op_context().current_task_id`/`.turn_origin`: read before and after mutating the owning Session's per-turn state post-construction, proving live re-resolution.
- **Strip-falsify performed by hand**: temporarily eager-ized `current_task_id_fn` to `lambda _v=self._current_task_id: _v`, confirmed the two pins (`test_current_task_id_and_turn_origin_resolve_at_call_time` / `test_strip_falsify_current_task_id_reresolves_on_second_reassignment`) go RED (non-vacuous), then restored via `Edit` (no `git checkout`/`git stash` on uncommitted work) and confirmed all 8 tests green again.

## co-vet

**architect + lead independent sonnet review required** (architect-flagged: this is the arc's heaviest, highest drift-risk family — ~40-dep WAIST + 3 deferred lambdas). I will not merge until both reviews land and CI is green.

part of #3082

## Test plan
- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/scaffold/test_family6a_router_waist_bundle_byte_identical.py` — green (0 Tier-4 violations)
- [x] `pytest` (full suite, foreground, 600s timeout) — 9021 passed, 29 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — green
- [x] Byte-identical arg-block diff vs pre-extraction `session.py` — zero-line diff
- [x] Strip-falsify performed and restored (Edit, not git checkout)