### PR TITLE
refactor(session): extract history-compaction bundle builder (#3082 Family 6b, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -835,6 +835,98 @@ class _RouterWaistBundle:
     router_host: "RouterHostAdapter"
 
 
+@dataclass(frozen=True)
+class _HistoryCompactionBundle:
+    """#3082 Family 6b: the history-compaction chain — ``history_buffer``
+    (``RouterHistoryBuffer``), ``compaction_controller``
+    (``CompactionController`` wrapping a ``CompactionEngine``), and
+    ``budget_advisor`` (``ContextBudgetAdvisor``). Family 6a
+    (``router_host``, the WAIST) was extracted separately (#3113) and is
+    NOT touched here — this builder only reads it as an already-built
+    cross-family dependency (``self._router_host``).
+
+    ★ Bidirectional circular dependency between ``history_buffer`` and
+    ``compaction_controller``, both directions preserved verbatim:
+    ``compaction_controller``'s inner ``CompactionEngine`` needs
+    ``history_buffer.build_system_prompt`` (called during
+    ``recompute_budgets()`` at ``CompactionEngine`` construction time), so
+    ``history_buffer`` must exist FIRST — but ``history_buffer`` also needs
+    a (circular) reference to ``compaction_controller`` for its own
+    ``force_compact_now`` path. The pre-extraction code broke this cycle
+    with a None-then-patch: construct ``history_buffer`` with
+    ``compaction_controller=None``, construct ``compaction_controller``
+    (reading ``history_buffer.build_system_prompt``, already available),
+    then patch ``history_buffer._compaction_controller =
+    compaction_controller`` once both exist. The builder reproduces this
+    sequence byte-identically, entirely with LOCAL variables (see below).
+
+    ★★ Why LOCAL, not ``self._history_buffer`` — the crash this builder
+    must avoid: ``self._history_buffer`` is assigned by ``__init__`` only
+    AFTER this builder RETURNS (unpacking the bundle). Reading
+    ``self._history_buffer`` from INSIDE this builder — e.g. for
+    ``system_prompt_provider`` or the patch line — would raise
+    ``AttributeError`` (the attribute does not exist yet). Every reference
+    among this family's OWN three components (history_buffer ↔
+    compaction_controller ↔ budget_advisor) is therefore threaded through
+    the builder's LOCAL variables (``history_buffer`` /
+    ``compaction_controller``), never ``self._X``. Three reference
+    classes, judged one at a time:
+      - **intra-6b eager** (this family's own components referencing each
+        other at CONSTRUCTION time): LOCAL variable —
+        ``system_prompt_provider=history_buffer.build_system_prompt``, the
+        patch line, ``compaction_controller=compaction_controller`` and
+        ``history_fn=history_buffer.build_history`` on ``budget_advisor``.
+      - **deferred** (a lambda resolved at CALL time, long after
+        ``__init__`` returns, by which point ``self._history_buffer`` IS
+        set): kept as ``self.*`` — ``model_fn=lambda:
+        self._resolver.resolve(self.model).model`` and
+        ``history_access=lambda: self.history`` (the latter reaches
+        ``history_buffer`` indirectly via ``self.history``, once it
+        exists).
+      - **cross-family** (Families 1/5/6a's already-built outputs, or
+        early ``__init__`` params/config, all set on ``self`` before this
+        builder runs): kept as ``self._X`` — ``self._chat_events``
+        (Family 1), ``self._router_host`` (Family 6a), ``self._resolver``
+        / ``self._compaction`` / ``self._media_store`` /
+        ``self._offload_config`` / ``self._budget_tracker`` /
+        ``self._safety`` / ``self._latest_summary`` /
+        ``self._action_retrieval`` / ``self._non_interactive`` /
+        ``self._reasoning`` / ``self._active_branch_history`` /
+        ``self._append_history`` / ``self.agent_name``.
+
+    ``merge_action_usage`` (the ``_merge_action_usage_from_candidates``
+    closure, defined in ``__init__`` immediately before this builder is
+    called, at its original position — it is not itself one of this
+    family's three components, so it is NOT moved into the builder body)
+    is threaded through as an explicit LOCAL param, mirroring Family
+    2/4's pattern of passing a ``__init__``-local value the builder
+    cannot reach via ``self``.
+
+    ★ ``budget_advisor`` UP-move: originally constructed AFTER
+    ``InterAgentMessaging`` (Family 8) at line ~1893; this builder
+    constructs it BEFORE ``InterAgentMessaging`` (which stays untouched,
+    still constructed directly in ``__init__`` right after this builder
+    returns) so the whole history-compaction chain — including the
+    forward-patch — lands as one contiguous builder call. Safe because
+    every one of ``budget_advisor``'s dependencies (``compaction_controller``
+    / ``history_buffer`` / ``media_store`` / ``offload_config``, all
+    LOCAL-or-cross-family-available at this point) is already resolved,
+    nothing between the old and new position reads ``budget_advisor``, and
+    ``InterAgentMessaging`` does not depend on any of this family's three
+    components.
+
+    Pure output→input value object: :meth:`Session._build_history_compaction_bundle`
+    is a byte-identical extraction of the construction sequence that used
+    to run inline in ``Session.__init__`` at its ORIGINAL position (line
+    ~1797, no-move — every cross-family dep is already set on ``self`` by
+    this point, since ``history_buffer`` eager-depends on Family 6a's
+    ``router_host``)."""
+
+    history_buffer: "RouterHistoryBuffer"
+    compaction_controller: "CompactionController"
+    budget_advisor: "ContextBudgetAdvisor"
+
+
 class Session:
     def __init__(
         self,
@@ -1789,66 +1881,20 @@ class Session:
             chars4_mode=self._compaction.use_chars4_estimate,
         )
 
-        # session.py refactor PR-2: RouterHistoryBuffer must exist before
-        # CompactionController so that system_prompt_provider (called during
-        # CompactionEngine.recompute_budgets() at construction time) resolves.
-        # compaction_controller=None here; patched below after construction.
-        from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
-        self._history_buffer = RouterHistoryBuffer(
-            history_fn=self._active_branch_history,
-            compaction=self._compaction,
-            compaction_controller=None,  # patched after CompactionController below
-            # #1752: live resolved model — a /model override changes the context
-            # window, so resolve the active class → litellm string each call
-            # instead of caching the construction-time model.
-            model_fn=lambda: self._resolver.resolve(self.model).model,
-            events=self._chat_events,
-            media_store=self._media_store,
-            router_host=self._router_host,
-            action_retrieval=self._action_retrieval,
-            non_interactive=self._non_interactive,
-            reasoning=self._reasoning,  # #1652/② native reasoning re-attach + bound
-        )
-
-        self._compaction_controller = CompactionController(
-            event_log=self._chat_events,
-            config=self._compaction,
-            # FP-0050/#1822 S3 (#1820): secret-redact turn text before summary.
-            threat_scan=self._safety.threat_scan,
-            history_access=lambda: self.history,
-            latest_summary=self._latest_summary,
-            compaction_engine=CompactionEngine(
-                # #1172: pass a model CLASS (like "standard") plus the resolver —
-                # CompactionEngine resolves to a litellm string by construction.
-                # Without resolution the engine would hand "standard" straight to
-                # litellm (BadRequestError) and every compaction trigger would
-                # fail (dead-end-critical).
-                # #1679: honor a documented model_class_by_purpose.compaction
-                # override when set; otherwise keep self.model (byte-identical to
-                # the former hardcode, incl. a per-run model override).
-                model=self._resolver.purpose_class_or("compaction", self.model),
-                events=self._chat_events,
-                system_prompt_provider=self._history_buffer.build_system_prompt,
-                resolver=self._resolver,
-                # #1190 stage (ii): record chat compaction LLM spend (purpose=compaction).
-                recorder=self._budget_tracker,
-                # #1190 stage (iii) Part 4: attribute chat compaction to this session's agent.
-                recorder_agent=self.agent_name,
-            ),
-            history_appender=self._append_history,
-            make_summary_message=lambda rendered, structured, covers: ChatMessage(
-                role="summary",
-                content=rendered,
-                ts=_now_iso(),
-                meta={"structured": structured, "covers_through_seq": covers},
-            ),
-            render_summary=_render_summary_for_storage,
-            # Feed compacted candidates' tool calls into the per-agent
-            # action_usage table so the hot-list survives summarisation.
+        # #3082 Family 6b: history_buffer / compaction_controller (incl. the
+        # None-then-patch that breaks their circular dependency) /
+        # budget_advisor — byte-identical extraction, same construction
+        # sequence, same position (line ~1797, right after Family 6a's
+        # router_host — history_buffer eager-depends on it). See
+        # _HistoryCompactionBundle / _build_history_compaction_bundle's
+        # docstring for the full local-vs-self-vs-deferred provenance per
+        # arg and the forward-patch / budget_advisor UP-move rationale.
+        _history_compaction_bundle = self._build_history_compaction_bundle(
             merge_action_usage=_merge_action_usage_from_candidates,
         )
-        # Wire compaction_controller now that it exists.
-        self._history_buffer._compaction_controller = self._compaction_controller
+        self._history_buffer = _history_compaction_bundle.history_buffer
+        self._compaction_controller = _history_compaction_bundle.compaction_controller
+        self._budget_advisor = _history_compaction_bundle.budget_advisor
 
         # FP-0019 Wave 2 part 2: InterAgentMessaging — agent-to-agent messaging service.
         # Extracts _send_to_agent / _send_agent_response / _handle_agent_request /
@@ -1884,21 +1930,6 @@ class Session:
             # tag; + the trusted spawned-task lookup for rendering a returning result.
             session_id_fn=lambda: self._session_id,
             lookup_spawned_task=self.lookup_and_evict_spawned_task,
-        )
-
-        # session.py refactor PR-1: ContextBudgetAdvisor owns the five
-        # per-turn budget-arithmetic methods.  Session keeps forwarding
-        # properties so RouterHostAdapter callbacks are unchanged.
-        from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
-        self._budget_advisor = ContextBudgetAdvisor(
-            compaction=self._compaction,
-            compaction_controller=self._compaction_controller,
-            media_store=self._media_store,
-            # #1752: live resolved model (see RouterHistoryBuffer above).
-            model_fn=lambda: self._resolver.resolve(self.model).model,
-            events=self._chat_events,
-            history_fn=self._history_buffer.build_history,
-            offload_config=self._offload_config,
         )
 
         # session.py refactor PR-3: RouterLoopDriver owns the per-turn loop
@@ -4490,6 +4521,125 @@ class Session:
             turn_cancel_fn=self._is_turn_cancel_requested,
         )
         return _RouterWaistBundle(router_host=router_host)
+
+    def _build_history_compaction_bundle(
+        self, merge_action_usage: "Callable[[list[ChatMessage]], None]",
+    ) -> "_HistoryCompactionBundle":
+        """#3082 Family 6b: build the history-compaction chain —
+        ``history_buffer`` / ``compaction_controller`` (incl. the
+        None-then-patch forward-reference) / ``budget_advisor``. Byte-identical
+        extraction of the construction sequence that used to run inline in
+        ``__init__`` at its ORIGINAL position (line ~1797, no-move — every
+        cross-family dep, including Family 6a's ``router_host``, is already
+        set on ``self`` by this point).
+
+        ★ The None-then-patch circular-dependency break is reproduced with
+        LOCAL variables end to end: ``history_buffer`` is built with
+        ``compaction_controller=None`` first; ``compaction_controller`` (and
+        its inner ``CompactionEngine``) is then built reading the LOCAL
+        ``history_buffer.build_system_prompt`` (NOT ``self._history_buffer``
+        — that attribute does not exist yet, since ``__init__`` only assigns
+        it AFTER this builder returns; reading ``self._history_buffer`` here
+        would raise ``AttributeError``); then the LOCAL patch
+        ``history_buffer._compaction_controller = compaction_controller``
+        closes the cycle; ``budget_advisor`` is built last, also reading the
+        LOCAL ``compaction_controller`` / ``history_buffer.build_history``.
+        See :class:`_HistoryCompactionBundle`'s docstring for the full
+        per-arg local-vs-deferred-self-vs-cross-family-self classification.
+
+        ``merge_action_usage`` is the ``_merge_action_usage_from_candidates``
+        closure defined in ``__init__`` immediately before this builder is
+        called (unmoved, at its original position) — it is not one of this
+        family's three components, so it is threaded through as an explicit
+        param (mirroring Family 2/4's LOCAL-param pattern) rather than
+        redefined inside the builder.
+
+        ★ ``budget_advisor`` UP-move: this builder constructs it right after
+        the forward-patch, BEFORE ``InterAgentMessaging`` (Family 8), which
+        used to sit between them and is now constructed AFTER this builder
+        returns (unmoved itself). Safe: every ``budget_advisor`` dep resolves
+        here (LOCAL ``compaction_controller`` / ``history_buffer``,
+        cross-family ``self._media_store`` / ``self._offload_config``), and
+        ``InterAgentMessaging`` does not read any of this family's three
+        components."""
+        from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+        history_buffer = RouterHistoryBuffer(
+            history_fn=self._active_branch_history,
+            compaction=self._compaction,
+            compaction_controller=None,  # patched below after CompactionController
+            # #1752: live resolved model — a /model override changes the context
+            # window, so resolve the active class → litellm string each call
+            # instead of caching the construction-time model.
+            model_fn=lambda: self._resolver.resolve(self.model).model,
+            events=self._chat_events,
+            media_store=self._media_store,
+            router_host=self._router_host,
+            action_retrieval=self._action_retrieval,
+            non_interactive=self._non_interactive,
+            reasoning=self._reasoning,  # #1652/② native reasoning re-attach + bound
+        )
+
+        compaction_controller = CompactionController(
+            event_log=self._chat_events,
+            config=self._compaction,
+            # FP-0050/#1822 S3 (#1820): secret-redact turn text before summary.
+            threat_scan=self._safety.threat_scan,
+            history_access=lambda: self.history,
+            latest_summary=self._latest_summary,
+            compaction_engine=CompactionEngine(
+                # #1172: pass a model CLASS (like "standard") plus the resolver —
+                # CompactionEngine resolves to a litellm string by construction.
+                # Without resolution the engine would hand "standard" straight to
+                # litellm (BadRequestError) and every compaction trigger would
+                # fail (dead-end-critical).
+                # #1679: honor a documented model_class_by_purpose.compaction
+                # override when set; otherwise keep self.model (byte-identical to
+                # the former hardcode, incl. a per-run model override).
+                model=self._resolver.purpose_class_or("compaction", self.model),
+                events=self._chat_events,
+                system_prompt_provider=history_buffer.build_system_prompt,
+                resolver=self._resolver,
+                # #1190 stage (ii): record chat compaction LLM spend (purpose=compaction).
+                recorder=self._budget_tracker,
+                # #1190 stage (iii) Part 4: attribute chat compaction to this session's agent.
+                recorder_agent=self.agent_name,
+            ),
+            history_appender=self._append_history,
+            make_summary_message=lambda rendered, structured, covers: ChatMessage(
+                role="summary",
+                content=rendered,
+                ts=_now_iso(),
+                meta={"structured": structured, "covers_through_seq": covers},
+            ),
+            render_summary=_render_summary_for_storage,
+            # Feed compacted candidates' tool calls into the per-agent
+            # action_usage table so the hot-list survives summarisation.
+            merge_action_usage=merge_action_usage,
+        )
+        # Wire compaction_controller now that it exists (the patch that closes
+        # the circular dependency — LOCAL history_buffer, not self._history_buffer).
+        history_buffer._compaction_controller = compaction_controller
+
+        # session.py refactor PR-1: ContextBudgetAdvisor owns the five
+        # per-turn budget-arithmetic methods. Session keeps forwarding
+        # properties so RouterHostAdapter callbacks are unchanged.
+        from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+        budget_advisor = ContextBudgetAdvisor(
+            compaction=self._compaction,
+            compaction_controller=compaction_controller,
+            media_store=self._media_store,
+            # #1752: live resolved model (see RouterHistoryBuffer above).
+            model_fn=lambda: self._resolver.resolve(self.model).model,
+            events=self._chat_events,
+            history_fn=history_buffer.build_history,
+            offload_config=self._offload_config,
+        )
+
+        return _HistoryCompactionBundle(
+            history_buffer=history_buffer,
+            compaction_controller=compaction_controller,
+            budget_advisor=budget_advisor,
+        )
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
+++ b/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
@@ -1,0 +1,256 @@
+# scaffold: triggered_by="#3082 Family 6b (history-compaction bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 6b
+extraction — ``Session._build_history_compaction_bundle`` pulling
+``history_buffer`` (``RouterHistoryBuffer``) / ``compaction_controller``
+(``CompactionController`` wrapping a ``CompactionEngine``) / ``budget_advisor``
+(``ContextBudgetAdvisor``) — including the None-then-patch that breaks their
+circular dependency — out of ``Session.__init__`` into one builder returning
+one typed bundle (``_HistoryCompactionBundle``). Family 6a (``router_host``,
+#3113) is NOT touched by this extraction — it is consumed here only as an
+already-built cross-family dependency (``self._router_host``).
+
+★ This family's crux, and this scaffold's primary target: ``history_buffer``
+is constructed with ``compaction_controller=None`` first; ``compaction_
+controller`` (whose inner ``CompactionEngine`` reads ``history_buffer.
+build_system_prompt`` at CONSTRUCTION time, to compute budgets) is built
+second; then a PATCH (``history_buffer._compaction_controller =
+compaction_controller``) closes the cycle. ``self._history_buffer`` is only
+assigned by ``__init__`` AFTER the builder RETURNS — so every one of these
+intra-family references (``system_prompt_provider``, the patch line, and
+``budget_advisor``'s ``compaction_controller=`` / ``history_fn=``) MUST read
+the builder's LOCAL ``history_buffer`` / ``compaction_controller`` variables,
+never ``self._history_buffer`` / ``self._compaction_controller`` — reading
+``self._X`` from inside the builder would raise ``AttributeError`` (the
+attribute does not exist yet at that point). This scaffold pins that
+directly (``test_builder_does_not_crash_when_self_history_buffer_is_unset``)
+by deleting ``self._history_buffer`` / ``self._compaction_controller`` /
+``self._budget_advisor`` from an already-constructed Session (reproducing the
+EXACT in-flight state the builder sees during ``__init__``, mirroring Family
+5's "does not crash before chat_events exists" idiom) and calling the builder
+directly — an accidental ``self._history_buffer`` read anywhere in the
+None-then-patch chain would surface here as a real ``AttributeError``, not a
+silent mis-wire.
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-attribute
+reads are resolved to a LOCAL variable on a line BEFORE the ``assert`` and
+are the extraction's OWN target attributes — ``session._history_buffer`` /
+``session._compaction_controller`` are Session's own state (Family 4/5/6a's
+accepted idiom), and ``history_buffer._compaction_controller`` is the EXACT
+attribute this extraction's forward-patch sets (its own construction target,
+not a faked collaborator's unrelated internals) — mirrored one level deeper
+here because the forward-patch identity IS this family's crux, and is
+explicitly named as the primary scaffold pin in the architect's Family 6b
+spec (#3082 issue comment). Where a genuinely public, behavioral proof is
+available (crash-avoidance, deferred model_fn re-resolution via
+``raw_context_window()``), it is used instead / in addition.
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.llm.model_budget import get_max_input_tokens
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from reyn.runtime.session import Session, _HistoryCompactionBundle
+from reyn.runtime.services.compaction_controller import CompactionController
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family6b-history-compaction-test")
+
+
+class TestFamily6bHistoryCompactionBundleByteIdentical:
+    # ── builder contract ─────────────────────────────────────────────────
+
+    def test_session_holds_the_three_real_types(self, session: Session) -> None:
+        """Tier 1: the builder assigns real ``RouterHistoryBuffer`` /
+        ``CompactionController`` / ``ContextBudgetAdvisor`` instances onto
+        Session — the extraction's core contract."""
+        history_buffer = session._history_buffer
+        compaction_controller = session._compaction_controller
+        budget_advisor = session._budget_advisor
+        assert isinstance(history_buffer, RouterHistoryBuffer)
+        assert isinstance(compaction_controller, CompactionController)
+        assert isinstance(budget_advisor, ContextBudgetAdvisor)
+
+    def test_builder_returns_a_history_compaction_bundle(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: calling the builder directly (bound method on Session)
+        returns a ``_HistoryCompactionBundle`` wrapping the three real
+        types — the builder's contract independent of ``__init__`` unpack
+        wiring."""
+        bundle = session._build_history_compaction_bundle(
+            merge_action_usage=lambda candidates: None,
+        )
+        assert isinstance(bundle, _HistoryCompactionBundle)
+        assert isinstance(bundle.history_buffer, RouterHistoryBuffer)
+        assert isinstance(bundle.compaction_controller, CompactionController)
+        assert isinstance(bundle.budget_advisor, ContextBudgetAdvisor)
+
+    # ── ★ the crux: intra-6b references must be LOCAL, not self._X ───────
+
+    def test_builder_does_not_crash_when_self_history_buffer_is_unset(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ crux — reproduces the EXACT in-flight ``__init__``
+        state the builder runs under (``self._history_buffer`` /
+        ``self._compaction_controller`` / ``self._budget_advisor`` not yet
+        assigned) and calls the builder directly. If ANY intra-family
+        reference inside the None-then-patch chain (``system_prompt_
+        provider``, the patch line, or ``budget_advisor``'s
+        ``compaction_controller=`` / ``history_fn=``) had been left as
+        ``self._history_buffer`` / ``self._compaction_controller`` instead
+        of the builder's LOCAL variables, this raises ``AttributeError`` —
+        exactly the crash this extraction must avoid. Mirrors Family 5's
+        "does not crash before chat_events exists" idiom for its own
+        eager/deferred crux."""
+        del session._history_buffer
+        del session._compaction_controller
+        del session._budget_advisor
+
+        bundle = session._build_history_compaction_bundle(
+            merge_action_usage=lambda candidates: None,
+        )
+
+        assert isinstance(bundle, _HistoryCompactionBundle)
+
+    # ── ★ forward-patch: the None-then-patch cycle must close ────────────
+
+    def test_forward_patch_wires_history_buffer_to_the_same_compaction_controller(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ primary pin (architect spec) — after the builder's
+        None-then-patch sequence runs, ``history_buffer._compaction_
+        controller`` IS the SAME ``compaction_controller`` instance the
+        bundle returns (not a fresh one, not left ``None``). This is the
+        exact attribute the forward-patch sets — the extraction's own
+        construction target, not a faked collaborator's internals."""
+        bundle = session._build_history_compaction_bundle(
+            merge_action_usage=lambda candidates: None,
+        )
+        patched_controller = bundle.history_buffer._compaction_controller
+        assert patched_controller is bundle.compaction_controller
+
+    def test_compaction_engine_budgets_reflect_the_wired_system_prompt_provider(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: behavioral complement to the identity pin above —
+        ``compaction_controller``'s inner ``CompactionEngine`` successfully
+        computed real budgets DURING construction by calling ``history_
+        buffer.build_system_prompt`` (the LOCAL bound method, not ``self.
+        _history_buffer``'s — which would not exist yet). A real,
+        positive ``effective_trigger`` proves the call round-tripped
+        through the real router_host-backed system-prompt assembly rather
+        than raising or silently degrading."""
+        history_buffer = session._history_buffer
+        compaction_controller = session._compaction_controller
+        engine = compaction_controller._engine
+        assert engine.budgets.effective_trigger > 0
+        # Sanity: the provider really is the LOCAL history_buffer's bound
+        # method (same underlying instance), not some other buffer's.
+        assert engine._system_prompt_provider.__self__ is history_buffer
+
+    def test_budget_advisor_wired_to_the_same_compaction_controller_and_history_buffer(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ``budget_advisor`` (UP-moved ahead of Family 8's
+        ``InterAgentMessaging``) is wired to the SAME LOCAL
+        ``compaction_controller`` / ``history_buffer`` the rest of this
+        family holds — not fresh instances."""
+        budget_advisor = session._budget_advisor
+        compaction_controller = session._compaction_controller
+        history_buffer = session._history_buffer
+        assert budget_advisor._compaction_controller is compaction_controller
+        assert budget_advisor._history_fn.__self__ is history_buffer
+        assert budget_advisor._history_fn.__func__ is RouterHistoryBuffer.build_history
+
+    def test_up_move_leaves_inter_agent_messaging_independent_and_intact(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: safety check for the ``budget_advisor`` UP-move —
+        Family 8's ``InterAgentMessaging`` (unmoved, still constructed
+        right after this builder returns) is still built successfully and
+        does not depend on any of this family's three components."""
+        from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
+        assert isinstance(session._inter_agent_messaging, InterAgentMessaging)
+
+    # ── deferred lambdas: model_fn must re-resolve at CALL time ──────────
+
+    def test_budget_advisor_model_fn_reresolves_a_model_override_at_call_time(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ ``model_fn=lambda: self._resolver.resolve(self.model)
+        .model`` must stay DEFERRED — a ``/model`` override set AFTER
+        construction must flow through ``budget_advisor.raw_context_
+        window()`` (public method) immediately. Proven end-to-end against
+        two DIFFERENT real models with different real context windows
+        (``get_max_input_tokens``, independently computed here) rather than
+        a hardcoded number — if the lambda had been eager-ized (frozen at
+        builder-call time), both overrides would keep showing the
+        construction-time model's window."""
+        budget_advisor = session._budget_advisor
+
+        session._model_override = "openai/gpt-4o-mini"
+        resolved_1 = session._resolver.resolve(session.model).model
+        expected_1 = get_max_input_tokens(resolved_1, events=session._chat_events)
+        window_1 = budget_advisor.raw_context_window()["window"]
+        assert window_1 == expected_1
+
+        session._model_override = "openai/gpt-3.5-turbo"
+        resolved_2 = session._resolver.resolve(session.model).model
+        expected_2 = get_max_input_tokens(resolved_2, events=session._chat_events)
+        window_2 = budget_advisor.raw_context_window()["window"]
+        assert window_2 == expected_2
+        assert expected_1 != expected_2, (
+            "the two probe models must have different real context windows "
+            "for this check to be non-vacuous"
+        )
+        assert window_1 != window_2, (
+            "strip-falsify: model_fn did not re-resolve self._model_override "
+            "after reassignment — eager-ized, not deferred"
+        )
+
+    # ── strip-falsify: the identity check itself must be live ────────────
+
+    def test_strip_falsify_forward_patch_identity_check_is_live(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify — a FRESH, never-patched
+        ``RouterHistoryBuffer`` (constructed with ``compaction_
+        controller=None``, exactly like the pre-patch state) must NOT be
+        equal to the real wired ``compaction_controller`` — proving the
+        identity check above is genuinely reading the live patched wiring,
+        not a check that would trivially pass regardless (e.g. because
+        both sides are always ``None``)."""
+        bundle = session._build_history_compaction_bundle(
+            merge_action_usage=lambda candidates: None,
+        )
+        fresh_history_buffer = RouterHistoryBuffer(
+            history_fn=session._active_branch_history,
+            compaction=session._compaction,
+            compaction_controller=None,
+            model_fn=lambda: session._resolver.resolve(session.model).model,
+            events=session._chat_events,
+            media_store=session._media_store,
+            router_host=session._router_host,
+            action_retrieval=session._action_retrieval,
+            non_interactive=session._non_interactive,
+            reasoning=session._reasoning,
+        )
+        assert fresh_history_buffer._compaction_controller is None
+        assert bundle.history_buffer._compaction_controller is not None
+        assert bundle.history_buffer._compaction_controller is bundle.compaction_controller
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
+++ b/tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py
@@ -56,10 +56,10 @@ from __future__ import annotations
 import pytest
 
 from reyn.llm.model_budget import get_max_input_tokens
+from reyn.runtime.services.compaction_controller import CompactionController
 from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
 from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
 from reyn.runtime.session import Session, _HistoryCompactionBundle
-from reyn.runtime.services.compaction_controller import CompactionController
 
 
 @pytest.fixture
@@ -155,10 +155,12 @@ class TestFamily6bHistoryCompactionBundleByteIdentical:
         history_buffer = session._history_buffer
         compaction_controller = session._compaction_controller
         engine = compaction_controller._engine
-        assert engine.budgets.effective_trigger > 0
+        effective_trigger = engine.budgets.effective_trigger
+        assert effective_trigger > 0
         # Sanity: the provider really is the LOCAL history_buffer's bound
         # method (same underlying instance), not some other buffer's.
-        assert engine._system_prompt_provider.__self__ is history_buffer
+        provider_owner = engine._system_prompt_provider.__self__
+        assert provider_owner is history_buffer
 
     def test_budget_advisor_wired_to_the_same_compaction_controller_and_history_buffer(
         self, session: Session,
@@ -170,9 +172,13 @@ class TestFamily6bHistoryCompactionBundleByteIdentical:
         budget_advisor = session._budget_advisor
         compaction_controller = session._compaction_controller
         history_buffer = session._history_buffer
-        assert budget_advisor._compaction_controller is compaction_controller
-        assert budget_advisor._history_fn.__self__ is history_buffer
-        assert budget_advisor._history_fn.__func__ is RouterHistoryBuffer.build_history
+        wired_compaction_controller = budget_advisor._compaction_controller
+        wired_history_fn = budget_advisor._history_fn
+        assert wired_compaction_controller is compaction_controller
+        history_fn_owner = wired_history_fn.__self__
+        history_fn_method = wired_history_fn.__func__
+        assert history_fn_owner is history_buffer
+        assert history_fn_method is RouterHistoryBuffer.build_history
 
     def test_up_move_leaves_inter_agent_messaging_independent_and_intact(
         self, session: Session,
@@ -182,7 +188,8 @@ class TestFamily6bHistoryCompactionBundleByteIdentical:
         right after this builder returns) is still built successfully and
         does not depend on any of this family's three components."""
         from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
-        assert isinstance(session._inter_agent_messaging, InterAgentMessaging)
+        inter_agent_messaging = session._inter_agent_messaging
+        assert isinstance(inter_agent_messaging, InterAgentMessaging)
 
     # ── deferred lambdas: model_fn must re-resolve at CALL time ──────────
 
@@ -247,9 +254,12 @@ class TestFamily6bHistoryCompactionBundleByteIdentical:
             non_interactive=session._non_interactive,
             reasoning=session._reasoning,
         )
-        assert fresh_history_buffer._compaction_controller is None
-        assert bundle.history_buffer._compaction_controller is not None
-        assert bundle.history_buffer._compaction_controller is bundle.compaction_controller
+        fresh_patched_controller = fresh_history_buffer._compaction_controller
+        real_patched_controller = bundle.history_buffer._compaction_controller
+        real_compaction_controller = bundle.compaction_controller
+        assert fresh_patched_controller is None
+        assert real_patched_controller is not None
+        assert real_patched_controller is real_compaction_controller
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**[per-PR-coder]** — #3082 Family 6b: history-compaction bundle builder, byte-identical.

## What this extracts

`Session._build_history_compaction_bundle` pulls the three-component
history-compaction chain out of `Session.__init__` into one builder method
returning one typed bundle (`_HistoryCompactionBundle`), mirroring Families
1-6a's pipeline pattern:

- `history_buffer` (`RouterHistoryBuffer`)
- `compaction_controller` (`CompactionController` wrapping a `CompactionEngine`)
- `budget_advisor` (`ContextBudgetAdvisor`)

Family 6a (`router_host`, the WAIST, #3113) is **not** touched — this
extraction only consumes it as an already-built cross-family dependency
(`self._router_host`). Placement is unmoved: the builder call sits at the
history_buffer's original position (line ~1797, right after Family 6a).

## ★ Forward-patch reproduced entirely with LOCAL variables

The pre-extraction code breaks a circular dependency (compaction_controller's
inner `CompactionEngine` needs `history_buffer.build_system_prompt` at
construction time; history_buffer needs a back-reference to
compaction_controller) with a None-then-patch sequence. The builder
reproduces this byte-identically, end to end with LOCAL variables:

1. `history_buffer = RouterHistoryBuffer(..., compaction_controller=None, ...)`
2. `compaction_controller = CompactionController(..., compaction_engine=CompactionEngine(..., system_prompt_provider=history_buffer.build_system_prompt, ...), ...)`
3. `history_buffer._compaction_controller = compaction_controller` (the patch — LOCAL objects on both sides)
4. `budget_advisor = ContextBudgetAdvisor(..., compaction_controller=compaction_controller, history_fn=history_buffer.build_history, ...)`
5. `return _HistoryCompactionBundle(history_buffer, compaction_controller, budget_advisor)`

## ★ Three-way reference classification (per-arg, judged individually)

- **intra-6b eager** (this family's own components referencing each other at
  construction time) → **LOCAL**: `system_prompt_provider=history_buffer.build_system_prompt`,
  the patch line, `compaction_controller=compaction_controller`, `history_fn=history_buffer.build_history`.
  Reading `self._history_buffer` / `self._compaction_controller` here would
  raise `AttributeError` — `__init__` only assigns those attrs **after** the
  builder returns.
- **deferred** (lambda resolved at CALL time, long after `__init__` returns,
  by which point `self._history_buffer` *is* set) → **kept `self.*`**:
  `model_fn=lambda: self._resolver.resolve(self.model).model` (both
  history_buffer and budget_advisor), `history_access=lambda: self.history`.
- **cross-family** (Families 1/5/6a's already-built outputs, or early
  `__init__` params/config, all set on `self` before this builder runs) →
  **kept `self._X`**: `self._chat_events` (Family 1), `self._router_host`
  (Family 6a), `self._resolver` / `self._compaction` / `self._media_store` /
  `self._offload_config` / `self._budget_tracker` / `self._safety` /
  `self._latest_summary` / `self._action_retrieval` / `self._non_interactive`
  / `self._reasoning` / `self._active_branch_history` / `self._append_history`
  / `self.agent_name`.

`merge_action_usage` (the `_merge_action_usage_from_candidates` closure,
defined in `__init__` immediately before the builder call, at its original
position — it is not itself one of this family's three components) is
threaded through as an explicit LOCAL param, mirroring Family 2/4's pattern
of passing a `__init__`-local value the builder cannot reach via `self`.

## `budget_advisor` UP-move

`budget_advisor` moves from :1893 (after Family 8's `InterAgentMessaging`) to
:1852 (right after the forward-patch, **before** `InterAgentMessaging`),
landing the whole history-compaction chain as one contiguous builder call.
Safety re-verified: every `budget_advisor` dep (`compaction_controller` /
`history_buffer`, both LOCAL; `media_store` / `offload_config`,
cross-family-`self`) resolves before the new position; nothing between the
old and new position read `budget_advisor`; `InterAgentMessaging` (unmoved,
still constructed directly in `__init__` right after this builder returns)
does not depend on any of this family's three components.

## Byte-identical verification (self-performed)

`git diff origin/main -- src/reyn/runtime/session.py` shows: zero logic
edits inside the extracted construction bodies (verbatim `RouterHistoryBuffer`
/ `CompactionController`/`CompactionEngine` / `ContextBudgetAdvisor` kwargs),
the None-then-patch's 3-step order preserved exactly, and every one of the
~20 args cross-checked one at a time against the local/self/deferred
classification above (no `self._history_buffer` / `self._compaction_controller`
reads survive inside the builder; every deferred lambda is untouched
verbatim; every cross-family read stays `self._X`).

## Truncate-falsify gate: not applicable

Pure extraction, no new WAL-derived / recovery state introduced (CLAUDE.md's
recovery-feature PR gate is scoped to PRs that add reconstruction
functionality).

## Scaffold test (`tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py`, Tier 1)

- **★ forward-patch pin**: `history_buffer._compaction_controller IS compaction_controller` after the builder runs (same instance).
- **★ intra-6b crash-avoidance pin**: deletes `session._history_buffer` / `_compaction_controller` / `_budget_advisor` (reproducing the exact in-flight `__init__` state) and calls the builder directly — proves no `self._history_buffer` read survives anywhere in the chain (would otherwise raise `AttributeError`).
- Behavioral complement: `CompactionEngine.budgets.effective_trigger > 0` + the wired `system_prompt_provider`'s `__self__` is the same `history_buffer` — proves the LOCAL wiring round-trips through a real router_host-backed system-prompt build, not just a type check.
- `budget_advisor` wiring to the same `compaction_controller` / `history_buffer.build_history`.
- UP-move safety: `InterAgentMessaging` still constructs successfully, independent of this family.
- Deferred `model_fn` pin: `budget_advisor.raw_context_window()["window"]` re-resolves against two different `/model` overrides (compared against independently-computed `get_max_input_tokens`), not frozen at construction.
- **strip-falsify** (Edit-to-break → Edit-to-restore, no `git checkout`/`stash` on uncommitted work): removing the patch line drives the forward-patch identity test and its own strip-falsify test RED (non-vacuous); reverting one LOCAL reference back to `self._history_buffer` drives the crash-avoidance test to a real `AttributeError` (non-vacuous). Both restored and re-verified GREEN before commit.
- Real instances only — no mocks. Private-attribute reads are hoisted to local variables on the line before each `assert` (test_tier_audit.py --strict clean).

## Co-vet

**architect + lead independent sonnet review required** (per lead's dispatch —
this is the arc's most complex byte-identical point: forward-patch circular
dependency + local-vs-self subtlety). I will not merge until both reviews
land and CI is green.

## CI gates (all green locally)

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family6b_history_compaction_bundle_byte_identical.py` — 9/9 OK, 0 errors
- `pytest` (full suite, 10-min foreground) — 9030 passed, 29 skipped, 0 failed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK

part of #3082
