### PR TITLE
refactor(session): extract intervention bundle builder (#3082 Family 7, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -927,6 +927,93 @@ class _HistoryCompactionBundle:
     budget_advisor: "ContextBudgetAdvisor"
 
 
+@dataclass(frozen=True)
+class _InterventionBundle:
+    """#3082 Family 7: the intervention/chain-lifecycle group — ``chains``
+    (``ChainManager``), ``interventions`` (``InterventionRegistry``),
+    ``intervention_handler`` (``InterventionHandler``),
+    ``intervention_coordinator`` (``InterventionCoordinator``), and
+    ``chain_timeout_glue`` (``ChainTimeoutGlue``). Five components; the DAG
+    grouping is accurate here — all five belong together (unlike Families
+    4/5, which needed a mid-arc correction).
+
+    ★ NO forward-patch / circular dependency (simpler than Family 6b's
+    history_buffer ↔ compaction_controller cycle): ``chains`` and
+    ``chain_timeout_glue`` reference each other, but ASYMMETRICALLY —
+    ``chain_timeout_glue`` reads ``chains`` EAGERLY
+    (``chains=self._chains`` at construction time), while ``chains`` only
+    reaches ``chain_timeout_glue`` INDIRECTLY, through the bound method
+    ``_on_chain_timeout_fire`` wired into ``InterAgentMessaging`` (Family
+    8, unmoved) — that bound method forwards to
+    ``self._chain_timeout_glue.on_chain_timeout_fire`` only when CALLED,
+    long after both exist. So construction is strictly LINEAR: chains →
+    interventions → intervention_handler → intervention_coordinator →
+    chain_timeout_glue. No None-then-patch needed.
+
+    ★ ``chain_timeout_glue`` Family-8-straddling UP-move: originally
+    constructed at line ~1979, ~160 lines AFTER ``InterAgentMessaging``
+    (Family 8, line ~1906); this builder constructs it immediately after
+    ``intervention_coordinator`` (mirroring Family 6b's ``budget_advisor``
+    UP-move) so all five Family 7 components land as one contiguous
+    builder call BEFORE ``InterAgentMessaging`` (which stays untouched,
+    still constructed directly in ``__init__`` right after this builder
+    returns). Safe: every one of ``chain_timeout_glue``'s deps (LOCAL
+    ``chains``, cross-family ``self._journal`` [Family 2] /
+    ``self._chat_events`` [Family 1], plus a handful of already-set bound
+    methods / config) is already resolved at the new position; nothing
+    between the old and new position ever reads ``chain_timeout_glue``
+    (its only caller outside ``__init__`` is at line ~6774); and
+    ``InterAgentMessaging`` does not depend on ``chain_timeout_glue``.
+
+    ★★ Family-8 cross-dep preserved: ``InterAgentMessaging`` (unmoved, at
+    line ~1906) reads ``chain_manager=self._chains``. This builder's call
+    site is placed at ``chains``'s ORIGINAL position (line ~1784), so
+    ``self._chains`` is assigned well before ``InterAgentMessaging`` is
+    constructed — the F8→F7 cross-family dependency resolves exactly as
+    before.
+
+    ★ intra-Family-7 local-vs-self (mirrors Family 6b's local-vs-self
+    split): ``self._interventions`` / ``self._intervention_handler`` /
+    ``self._chains`` are all assigned by ``__init__`` only AFTER this
+    builder RETURNS — reading them as ``self._X`` from INSIDE the builder
+    would raise ``AttributeError``. Every eager reference among this
+    family's OWN five components is therefore threaded through LOCAL
+    variables:
+      - ``intervention_handler``'s ``registry=interventions`` (not
+        ``self._interventions``);
+      - ``intervention_coordinator``'s ``registry=interventions`` /
+        ``handler=intervention_handler`` (not ``self._interventions`` /
+        ``self._intervention_handler``);
+      - ``chain_timeout_glue``'s ``chains=chains`` (not ``self._chains``).
+    Deferred bound methods that resolve at CALL time (long after
+    ``__init__`` returns, by which point the attributes ARE set) are kept
+    as ``self.*`` — ``on_announce=self._announce_intervention`` on
+    ``interventions``. Cross-family / config dependencies (already set on
+    ``self`` before this builder runs) are kept as ``self._X`` —
+    ``self._journal`` (Family 2), ``self._chat_events`` (Family 1),
+    ``self._chain_timeout_seconds``, ``self._max_hop_depth``, plus
+    ``chain_timeout_glue``'s bound-method callbacks
+    (``self._append_history`` / ``self._reset_router_turn_counter`` /
+    ``self._run_router_loop`` / ``self._emit_router_cap_exhausted_user`` /
+    ``self._put_outbox`` / ``self.inbox`` / ``self._on_limit`` /
+    ``self._handle_chat_limit_checkpoint`` / ``self._send_agent_response`` /
+    ``self._put_inbox``).
+
+    Pure output→input value object: :meth:`Session._build_intervention_bundle`
+    is a byte-identical extraction of the construction sequence that used
+    to run inline in ``Session.__init__`` — four of the five components
+    stay at their ORIGINAL position (line ~1784); only
+    ``chain_timeout_glue`` moves UP from line ~1979 to become part of this
+    same contiguous builder call, straddling Family 8's
+    ``InterAgentMessaging``."""
+
+    chains: "ChainManager"
+    interventions: "InterventionRegistry"
+    intervention_handler: "InterventionHandler"
+    intervention_coordinator: "InterventionCoordinator"
+    chain_timeout_glue: "ChainTimeoutGlue"
+
+
 class Session:
     def __init__(
         self,
@@ -1781,49 +1868,30 @@ class Session:
         # queue ownership extracted into services. The session orchestrates the
         # callbacks (_announce_intervention, _on_chain_timeout_fire) but holds
         # no state for them.
-        self._chains = ChainManager(
-            journal=self._journal,
-            events=self._chat_events,
-            chain_timeout_seconds=self._chain_timeout_seconds,
-            max_hop_depth=self._max_hop_depth,
-        )
-        self._interventions = InterventionRegistry(
-            on_announce=self._announce_intervention,
-            # issue #254 Phase 1: fail-closed when no listener is wired
-            # (= no TUI mounted, no A2A override, no test fixture
-            # registered). Without this, ``handle_limit_exceeded`` with
-            # ``ask_timeout_seconds=0`` would await an unresolvable future
-            # in test / headless contexts.
-            enforce_listener_presence=True,
-        )
         # F4: a one-shot command-UI request (e.g. the /rewind checkpoint picker)
         # that a front-end renders as a selector. The inline CUI region polls it
         # (like it polls the head intervention); the plain --cui path renders a
         # text fallback. None = nothing pending. A dict carries {"kind", ...}.
         self._pending_command_ui: dict | None = None
 
-        # FP-0019 Wave 2 part 1: InterventionHandler — ask_user dispatch service.
-        # Extracted from Session.  Session keeps thin wrappers on
-        # _dispatch_intervention / _maybe_answer_oldest_intervention /
-        # _announce_intervention / _deliver_answer_to so the existing test
-        # surface (and ChatInterventionBus) remain stable.
-        self._intervention_handler = InterventionHandler(
-            intervention_registry=self._interventions,
-            journal=self._journal,
-            event_log=self._chat_events,
-            put_outbox=self._put_outbox,
-            append_history=self._append_history_for_handler,
-            # FP-0050 / #1862 (EP7): fences external peer-answer copies
-            # bound for conversation context (history sink only).
-            threat_scan=self._safety.threat_scan,
-        )
-        # Owns the chain-override state + the per-intervention dispatch
-        # orchestration.
-        self._intervention_coordinator = InterventionCoordinator(
-            registry=self._interventions,
-            handler=self._intervention_handler,
-            events=self._chat_events,
-        )
+        # #3082 Family 7: chains / interventions / intervention_handler /
+        # intervention_coordinator / chain_timeout_glue — byte-identical
+        # extraction, same construction order, same position (line ~1784,
+        # chains's original spot). chain_timeout_glue is the one exception —
+        # UP-moved from its original position (~160 lines below, AFTER Family
+        # 8's InterAgentMessaging) to land here, inside this same contiguous
+        # builder call, BEFORE InterAgentMessaging (which stays untouched and
+        # reads self._chains — see _InterventionBundle's docstring for why
+        # this UP-move is safe and why the F8→F7 self._chains cross-dep is
+        # preserved). See _InterventionBundle / _build_intervention_bundle's
+        # docstring for the full local-vs-deferred-self-vs-cross-family-self
+        # provenance per arg.
+        _intervention_bundle = self._build_intervention_bundle()
+        self._chains = _intervention_bundle.chains
+        self._interventions = _intervention_bundle.interventions
+        self._intervention_handler = _intervention_bundle.intervention_handler
+        self._intervention_coordinator = _intervention_bundle.intervention_coordinator
+        self._chain_timeout_glue = _intervention_bundle.chain_timeout_glue
 
         # F2: Delegation tracking for RouterLoop runs. Set to a list before
         # calling RouterLoop.run(); send_to_agent appends dispatched targets.
@@ -1972,26 +2040,6 @@ class Session:
         # step-boundary ``cancel_check``). Empty for every ordinary turn, so the
         # normal turn-cancel path is byte-identical when nothing is registered.
         self._cancel_forward_targets: list[Callable[[], None]] = []
-
-        # session.py refactor PR-4 (FP-0019 series final): ChainTimeoutGlue owns
-        # chain timeout lifecycle.
-        from reyn.runtime.services.chain_timeout_glue import ChainTimeoutGlue
-        self._chain_timeout_glue = ChainTimeoutGlue(
-            append_history_fn=self._append_history,
-            events=self._chat_events,
-            reset_turn_counter_fn=self._reset_router_turn_counter,
-            run_router_loop_fn=self._run_router_loop,
-            emit_cap_exhausted_fn=self._emit_router_cap_exhausted_user,
-            put_outbox_fn=self._put_outbox,
-            inbox=self.inbox,
-            journal=self._journal,
-            on_limit=self._on_limit,
-            chains=self._chains,
-            limit_checkpoint_fn=self._handle_chat_limit_checkpoint,
-            chain_timeout_seconds=self._chain_timeout_seconds,
-            send_agent_response_fn=self._send_agent_response,
-            put_inbox_fn=self._put_inbox,
-        )
 
     # ── cost accumulation ───────────────────────────────────────────────────────
 
@@ -4639,6 +4687,118 @@ class Session:
             history_buffer=history_buffer,
             compaction_controller=compaction_controller,
             budget_advisor=budget_advisor,
+        )
+
+    def _build_intervention_bundle(self) -> "_InterventionBundle":
+        """#3082 Family 7: build ``chains`` / ``interventions`` /
+        ``intervention_handler`` / ``intervention_coordinator`` /
+        ``chain_timeout_glue``. Byte-identical extraction of the
+        construction sequence that used to run inline in ``__init__`` —
+        four of the five components stay at their ORIGINAL position (line
+        ~1784, ``chains``'s original spot); only ``chain_timeout_glue``
+        moves UP from its original position (~160 lines below, AFTER
+        Family 8's ``InterAgentMessaging``) into this same contiguous
+        builder call.
+
+        ★ NO forward-patch / circular dependency: unlike Family 6b's
+        history_buffer ↔ compaction_controller cycle, this family's
+        chains ↔ chain_timeout_glue relationship is ASYMMETRIC —
+        ``chain_timeout_glue`` reads ``chains`` EAGERLY at construction
+        time, while ``chains`` only reaches ``chain_timeout_glue``
+        INDIRECTLY through the bound method ``_on_chain_timeout_fire``
+        (wired into Family 8's ``InterAgentMessaging``, unmoved), which
+        forwards to ``self._chain_timeout_glue.on_chain_timeout_fire``
+        only when CALLED — long after both exist. So construction is
+        strictly LINEAR: chains → interventions → intervention_handler →
+        intervention_coordinator → chain_timeout_glue. No None-then-patch
+        needed.
+
+        ★★ Family-8 cross-dep preserved: Family 8's ``InterAgentMessaging``
+        (unmoved, constructed directly in ``__init__`` right after this
+        builder returns) reads ``chain_manager=self._chains`` — this
+        builder's call site sits at ``chains``'s ORIGINAL position, so
+        ``self._chains`` is assigned by ``__init__`` well before
+        ``InterAgentMessaging`` is constructed. The F8→F7 cross-family
+        dependency resolves exactly as before.
+
+        ★ intra-Family-7 local-vs-self: ``self._interventions`` /
+        ``self._intervention_handler`` / ``self._chains`` are all assigned
+        by ``__init__`` only AFTER this builder RETURNS — reading them as
+        ``self._X`` from INSIDE the builder would raise ``AttributeError``.
+        Every eager reference among this family's OWN five components is
+        threaded through LOCAL variables (``chains`` / ``interventions`` /
+        ``intervention_handler``), never ``self._X``. Deferred bound
+        methods that resolve at CALL time (by which point the attributes
+        ARE set) are kept as ``self.*`` — ``self._announce_intervention``.
+        Cross-family / config dependencies (already set on ``self`` before
+        this builder runs) are kept as ``self._X``. See
+        :class:`_InterventionBundle`'s docstring for the full per-arg
+        classification."""
+        chains = ChainManager(
+            journal=self._journal,
+            events=self._chat_events,
+            chain_timeout_seconds=self._chain_timeout_seconds,
+            max_hop_depth=self._max_hop_depth,
+        )
+        interventions = InterventionRegistry(
+            on_announce=self._announce_intervention,
+            # issue #254 Phase 1: fail-closed when no listener is wired
+            # (= no TUI mounted, no A2A override, no test fixture
+            # registered). Without this, ``handle_limit_exceeded`` with
+            # ``ask_timeout_seconds=0`` would await an unresolvable future
+            # in test / headless contexts.
+            enforce_listener_presence=True,
+        )
+
+        # FP-0019 Wave 2 part 1: InterventionHandler — ask_user dispatch service.
+        # Extracted from Session.  Session keeps thin wrappers on
+        # _dispatch_intervention / _maybe_answer_oldest_intervention /
+        # _announce_intervention / _deliver_answer_to so the existing test
+        # surface (and ChatInterventionBus) remain stable.
+        intervention_handler = InterventionHandler(
+            intervention_registry=interventions,
+            journal=self._journal,
+            event_log=self._chat_events,
+            put_outbox=self._put_outbox,
+            append_history=self._append_history_for_handler,
+            # FP-0050 / #1862 (EP7): fences external peer-answer copies
+            # bound for conversation context (history sink only).
+            threat_scan=self._safety.threat_scan,
+        )
+        # Owns the chain-override state + the per-intervention dispatch
+        # orchestration.
+        intervention_coordinator = InterventionCoordinator(
+            registry=interventions,
+            handler=intervention_handler,
+            events=self._chat_events,
+        )
+
+        # session.py refactor PR-4 (FP-0019 series final): ChainTimeoutGlue owns
+        # chain timeout lifecycle.
+        from reyn.runtime.services.chain_timeout_glue import ChainTimeoutGlue
+        chain_timeout_glue = ChainTimeoutGlue(
+            append_history_fn=self._append_history,
+            events=self._chat_events,
+            reset_turn_counter_fn=self._reset_router_turn_counter,
+            run_router_loop_fn=self._run_router_loop,
+            emit_cap_exhausted_fn=self._emit_router_cap_exhausted_user,
+            put_outbox_fn=self._put_outbox,
+            inbox=self.inbox,
+            journal=self._journal,
+            on_limit=self._on_limit,
+            chains=chains,
+            limit_checkpoint_fn=self._handle_chat_limit_checkpoint,
+            chain_timeout_seconds=self._chain_timeout_seconds,
+            send_agent_response_fn=self._send_agent_response,
+            put_inbox_fn=self._put_inbox,
+        )
+
+        return _InterventionBundle(
+            chains=chains,
+            interventions=interventions,
+            intervention_handler=intervention_handler,
+            intervention_coordinator=intervention_coordinator,
+            chain_timeout_glue=chain_timeout_glue,
         )
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──

--- a/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
+++ b/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
@@ -182,7 +182,8 @@ class TestFamily7InterventionBundleByteIdentical:
         inter_agent_messaging = session._inter_agent_messaging
         assert isinstance(inter_agent_messaging, InterAgentMessaging)
         wired_chains = inter_agent_messaging._chains
-        assert wired_chains is session._chains
+        session_chains = session._chains
+        assert wired_chains is session_chains
 
     # ── deferred: chains → chain_timeout_glue resolves only via a bound method, at CALL time ──
 
@@ -249,9 +250,10 @@ class TestFamily7InterventionBundleByteIdentical:
         )
 
         wired_chains = session._inter_agent_messaging._chains
+        session_chains = session._chains
 
-        assert fresh_chains is not session._chains
-        assert wired_chains is session._chains
+        assert fresh_chains is not session_chains
+        assert wired_chains is session_chains
         assert wired_chains is not fresh_chains
 
 

--- a/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
+++ b/tests/scaffold/test_family7_intervention_bundle_byte_identical.py
@@ -1,0 +1,259 @@
+# scaffold: triggered_by="#3082 Family 7 (intervention bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 7
+extraction — ``Session._build_intervention_bundle`` pulling ``chains``
+(``ChainManager``) / ``interventions`` (``InterventionRegistry``) /
+``intervention_handler`` (``InterventionHandler``) / ``intervention_
+coordinator`` (``InterventionCoordinator``) / ``chain_timeout_glue``
+(``ChainTimeoutGlue``) out of ``Session.__init__`` into one builder
+returning one typed bundle (``_InterventionBundle``). Five components — the
+DAG grouping is accurate here (unlike Families 4/5, which needed a mid-arc
+correction).
+
+★ NO forward-patch / circular dependency (simpler than Family 6b's
+history_buffer ↔ compaction_controller cycle): ``chains`` and ``chain_
+timeout_glue`` reference each other, but ASYMMETRICALLY — ``chain_timeout_
+glue`` reads ``chains`` EAGERLY (``chains=self._chains``, at construction
+time), while ``chains`` only reaches ``chain_timeout_glue`` INDIRECTLY,
+through the bound method ``Session._on_chain_timeout_fire`` (wired into
+Family 8's ``InterAgentMessaging``, unmoved), which forwards to
+``self._chain_timeout_glue.on_chain_timeout_fire`` only when CALLED — long
+after both exist. So construction is strictly LINEAR: chains →
+interventions → intervention_handler → intervention_coordinator →
+chain_timeout_glue. No None-then-patch needed, unlike Family 6b.
+
+★ ``chain_timeout_glue`` Family-8-straddling UP-move: originally
+constructed AFTER Family 8's ``InterAgentMessaging``; this builder
+constructs it as the last of the five components, landing the whole family
+as one contiguous builder call BEFORE ``InterAgentMessaging`` (unmoved,
+still constructed directly in ``__init__`` right after this builder
+returns).
+
+★★ Family-8 cross-dep: ``InterAgentMessaging`` reads ``chain_manager=self.
+_chains`` — the builder call site sits at ``chains``'s ORIGINAL position,
+so ``self._chains`` is assigned by ``__init__`` well before
+``InterAgentMessaging`` is constructed. This scaffold pins that the F8→F7
+dependency is preserved (``InterAgentMessaging``'s ``_chains`` IS the same
+``ChainManager`` instance).
+
+★ intra-Family-7 local-vs-self: ``self._interventions`` / ``self._
+intervention_handler`` / ``self._chains`` are all assigned by ``__init__``
+only AFTER this builder RETURNS — reading them as ``self._X`` from INSIDE
+the builder would raise ``AttributeError``. This scaffold pins that
+directly (``test_builder_does_not_crash_when_self_chains_is_unset``) by
+deleting ``self._chains`` / ``self._interventions`` / ``self._intervention_
+handler`` / ``self._intervention_coordinator`` / ``self._chain_timeout_
+glue`` from an already-constructed Session (reproducing the EXACT in-flight
+state the builder sees during ``__init__``, mirroring Family 5/6b's "does
+not crash before X exists" idiom) and calling the builder directly.
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-attribute
+reads are resolved to a LOCAL variable on a line BEFORE the ``assert`` and
+are the extraction's OWN target attributes (``session._chains`` /
+``coordinator._registry`` / ``coordinator._handler`` / ``handler._registry``
+/ ``glue._chains`` / ``inter_agent_messaging._chains``) — Session's own
+state plus the exact wiring targets this extraction's local-vs-self split
+is about (Family 4/5/6a/6b's accepted idiom, mirrored one level deeper here
+because the wiring identity IS this family's crux and is explicitly named
+as the primary scaffold pin in the architect's Family 7 spec (#3082 issue
+comment)).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.services.chain_manager import ChainManager
+from reyn.runtime.services.chain_timeout_glue import ChainTimeoutGlue
+from reyn.runtime.services.intervention_coordinator import InterventionCoordinator
+from reyn.runtime.services.intervention_handler import InterventionHandler
+from reyn.runtime.services.intervention_registry import InterventionRegistry
+from reyn.runtime.session import Session, _InterventionBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family7-intervention-test")
+
+
+class TestFamily7InterventionBundleByteIdentical:
+    # ── builder contract ─────────────────────────────────────────────────
+
+    def test_session_holds_the_five_real_types(self, session: Session) -> None:
+        """Tier 1: the builder assigns real ``ChainManager`` /
+        ``InterventionRegistry`` / ``InterventionHandler`` /
+        ``InterventionCoordinator`` / ``ChainTimeoutGlue`` instances onto
+        Session — the extraction's core contract."""
+        chains = session._chains
+        interventions = session._interventions
+        intervention_handler = session._intervention_handler
+        intervention_coordinator = session._intervention_coordinator
+        chain_timeout_glue = session._chain_timeout_glue
+        assert isinstance(chains, ChainManager)
+        assert isinstance(interventions, InterventionRegistry)
+        assert isinstance(intervention_handler, InterventionHandler)
+        assert isinstance(intervention_coordinator, InterventionCoordinator)
+        assert isinstance(chain_timeout_glue, ChainTimeoutGlue)
+
+    def test_builder_returns_an_intervention_bundle(self, session: Session) -> None:
+        """Tier 1: calling the builder directly (bound method on Session)
+        returns an ``_InterventionBundle`` wrapping the five real types —
+        the builder's contract independent of ``__init__`` unpack wiring."""
+        bundle = session._build_intervention_bundle()
+        assert isinstance(bundle, _InterventionBundle)
+        assert isinstance(bundle.chains, ChainManager)
+        assert isinstance(bundle.interventions, InterventionRegistry)
+        assert isinstance(bundle.intervention_handler, InterventionHandler)
+        assert isinstance(bundle.intervention_coordinator, InterventionCoordinator)
+        assert isinstance(bundle.chain_timeout_glue, ChainTimeoutGlue)
+
+    # ── ★ the crux: intra-F7 references must be LOCAL, not self._X ───────
+
+    def test_builder_does_not_crash_when_self_chains_is_unset(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ crux — reproduces the EXACT in-flight ``__init__``
+        state the builder runs under (none of this family's five
+        attributes assigned yet) and calls the builder directly. If ANY
+        intra-family reference (``intervention_handler``'s ``registry=``,
+        ``intervention_coordinator``'s ``registry=``/``handler=``, or
+        ``chain_timeout_glue``'s ``chains=``) had been left as ``self._X``
+        instead of the builder's LOCAL variables, this raises
+        ``AttributeError`` — exactly the crash this extraction must avoid.
+        Mirrors Family 5/6b's "does not crash before X exists" idiom for
+        its own local-vs-self crux."""
+        del session._chains
+        del session._interventions
+        del session._intervention_handler
+        del session._intervention_coordinator
+        del session._chain_timeout_glue
+
+        bundle = session._build_intervention_bundle()
+
+        assert isinstance(bundle, _InterventionBundle)
+
+    # ── ★ intra-F7 wiring: coordinator/handler/glue point at THIS family's own instances ──
+
+    def test_intra_family_wiring_points_at_this_family_s_own_instances(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ primary pin (architect spec) — after the builder
+        runs, ``intervention_coordinator``'s ``registry``/``handler``,
+        ``intervention_handler``'s ``registry``, and ``chain_timeout_
+        glue``'s ``chains`` are all the SAME instances this family itself
+        built — not fresh ones, and not left unset. These are the exact
+        attributes the local-vs-self split targets — the extraction's own
+        construction targets, not a faked collaborator's internals."""
+        bundle = session._build_intervention_bundle()
+
+        coordinator_registry = bundle.intervention_coordinator._registry
+        coordinator_handler = bundle.intervention_coordinator._handler
+        handler_registry = bundle.intervention_handler._registry
+        glue_chains = bundle.chain_timeout_glue._chains
+
+        assert coordinator_registry is bundle.interventions
+        assert coordinator_handler is bundle.intervention_handler
+        assert handler_registry is bundle.interventions
+        assert glue_chains is bundle.chains
+
+    # ── ★ F8→F7 cross-dep: self._chains must be set before InterAgentMessaging ──
+
+    def test_inter_agent_messaging_chain_manager_is_the_same_chains_instance(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ F8-dep pin (architect spec) — Family 8's
+        ``InterAgentMessaging`` (unmoved, constructed directly in
+        ``__init__`` right after this builder returns) reads
+        ``chain_manager=self._chains``. If the builder call had been
+        placed AFTER ``InterAgentMessaging``'s construction (or if
+        ``self._chains`` had not been assigned before that point), this
+        cross-family dependency would have broken — either an
+        ``AttributeError`` at ``__init__`` time, or (undetectably) a
+        DIFFERENT ``ChainManager`` instance wired into
+        ``InterAgentMessaging``. This proves it is the SAME instance."""
+        from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
+
+        inter_agent_messaging = session._inter_agent_messaging
+        assert isinstance(inter_agent_messaging, InterAgentMessaging)
+        wired_chains = inter_agent_messaging._chains
+        assert wired_chains is session._chains
+
+    # ── deferred: chains → chain_timeout_glue resolves only via a bound method, at CALL time ──
+
+    @pytest.mark.asyncio
+    async def test_chain_timeout_fire_reaches_the_same_glue_via_deferred_bound_method(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ deferred pin — ``chains`` never holds a direct,
+        eager reference to ``chain_timeout_glue`` (that would be the
+        None-then-patch shape Family 6b needed and Family 7 explicitly
+        does NOT). Instead, the reverse direction is wired through
+        ``Session._on_chain_timeout_fire``, a bound method that forwards
+        to ``self._chain_timeout_glue.on_chain_timeout_fire`` only when
+        CALLED. This proves the forwarding reaches the SAME
+        ``chain_timeout_glue`` instance this family built, resolved at
+        call time (not frozen at construction time)."""
+        called_with: list[str] = []
+
+        async def _fake_on_chain_timeout_fire(chain_id: str) -> None:
+            called_with.append(chain_id)
+
+        session._chain_timeout_glue.on_chain_timeout_fire = _fake_on_chain_timeout_fire
+
+        await session._on_chain_timeout_fire("probe-chain-id")
+
+        assert called_with == ["probe-chain-id"]
+
+    # ── strip-falsify: the identity checks themselves must be live ───────
+
+    def test_strip_falsify_intra_family_wiring_checks_are_live(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify — a FRESH, independently-constructed
+        ``InterventionRegistry`` (never passed into this family's real
+        ``intervention_handler`` / ``intervention_coordinator``) must NOT
+        be the same instance as the one those two components actually
+        hold — proving the identity checks above are genuinely reading
+        live wiring, not a check that would trivially pass regardless."""
+        bundle = session._build_intervention_bundle()
+        fresh_interventions = InterventionRegistry(
+            on_announce=session._announce_intervention,
+            enforce_listener_presence=True,
+        )
+
+        handler_registry = bundle.intervention_handler._registry
+        coordinator_registry = bundle.intervention_coordinator._registry
+
+        assert fresh_interventions is not bundle.interventions
+        assert handler_registry is not fresh_interventions
+        assert coordinator_registry is not fresh_interventions
+        assert handler_registry is bundle.interventions
+        assert coordinator_registry is bundle.interventions
+
+    def test_strip_falsify_f8_dep_check_is_live(self, session: Session) -> None:
+        """Tier 1: strip-falsify for the F8→F7 cross-dep pin — a FRESH,
+        independently-constructed ``ChainManager`` must NOT be the same
+        instance ``InterAgentMessaging`` actually holds — proving that
+        pin is genuinely reading the live cross-family wiring."""
+        fresh_chains = ChainManager(
+            journal=session._journal,
+            events=session._chat_events,
+            chain_timeout_seconds=session._chain_timeout_seconds,
+            max_hop_depth=session._max_hop_depth,
+        )
+
+        wired_chains = session._inter_agent_messaging._chains
+
+        assert fresh_chains is not session._chains
+        assert wired_chains is session._chains
+        assert wired_chains is not fresh_chains
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — part of #3082 (Family 7 = intervention: `chains` / `interventions` / `intervention_handler` / `intervention_coordinator` / `chain_timeout_glue`), per the architect's Family 7 spec (issue #3082 comment). Byte-identical extraction — no behavior change.

## What moved

Five components (accurate DAG grouping — all five belong together, unlike Families 4/5 which needed a mid-arc correction):

- `chains` (`ChainManager`)
- `interventions` (`InterventionRegistry`)
- `intervention_handler` (`InterventionHandler`)
- `intervention_coordinator` (`InterventionCoordinator`)
- `chain_timeout_glue` (`ChainTimeoutGlue`)

into `Session._build_intervention_bundle()` returning a frozen `_InterventionBundle` dataclass (same shape as Families 1-6a/6b's builders). `__init__` calls the builder at `chains`'s ORIGINAL position and unpacks the 5 fields.

## ★ NO forward-patch / circular dependency (simpler than Family 6b)

`chains` ↔ `chain_timeout_glue` are ASYMMETRIC, not circular: `chain_timeout_glue` reads `chains` EAGERLY (`chains=self._chains` at construction time), while `chains` only reaches `chain_timeout_glue` INDIRECTLY through the bound method `Session._on_chain_timeout_fire` (wired into Family 8's `InterAgentMessaging`, unmoved) — that method forwards to `self._chain_timeout_glue.on_chain_timeout_fire` only when CALLED, long after both exist. So construction is strictly LINEAR (chains → interventions → intervention_handler → intervention_coordinator → chain_timeout_glue); no None-then-patch needed.

## ★ `chain_timeout_glue` Family-8-straddling UP-move

Originally constructed ~160 lines AFTER Family 8's `InterAgentMessaging`; the builder now constructs it last, immediately after `intervention_coordinator`, landing all five Family 7 components as one contiguous call BEFORE `InterAgentMessaging` (unmoved, still constructed directly in `__init__` right after the builder returns). Safe: every `chain_timeout_glue` dep (LOCAL `chains`, cross-family `self._journal`[F2]/`self._chat_events`[F1], already-set bound methods/config) resolves at the new position; nothing between old and new position reads `chain_timeout_glue` (its only other caller is `Session._on_chain_timeout_fire`, outside `__init__`); `InterAgentMessaging` doesn't depend on it.

## ★★ F8→F7 cross-dep preserved (self._chains before InterAgentMessaging)

Family 8's `InterAgentMessaging` (unmoved, `chain_manager=self._chains`) needs `self._chains` set before its own construction. The builder call sits at `chains`'s ORIGINAL position, so `self._chains` is assigned by `__init__` well before `InterAgentMessaging` runs — the cross-family dependency resolves exactly as before. Pinned directly by the scaffold test (`test_inter_agent_messaging_chain_manager_is_the_same_chains_instance`).

## ★ intra-F7 local-vs-self (3-way classification)

- **intra-F7 (this family's own components referencing each other eagerly)** → LOCAL builder variables: `intervention_handler`'s `registry=interventions`, `intervention_coordinator`'s `registry=interventions`/`handler=intervention_handler`, `chain_timeout_glue`'s `chains=chains`. (`self._interventions`/`self._intervention_handler`/`self._chains` don't exist yet inside the builder — `__init__` only assigns them AFTER the builder returns; reading `self._X` here would raise `AttributeError`.)
- **deferred (bound method resolved at CALL time)** → kept `self.*`: `on_announce=self._announce_intervention`.
- **cross-family / config (already set on `self` before this builder runs)** → kept `self._X`: `self._journal`(F2), `self._chat_events`(F1), `self._chain_timeout_seconds`, `self._max_hop_depth`, plus `chain_timeout_glue`'s bound-method callbacks (`self._append_history`, `self._reset_router_turn_counter`, `self._run_router_loop`, `self._emit_router_cap_exhausted_user`, `self._put_outbox`, `self.inbox`, `self._on_limit`, `self._handle_chat_limit_checkpoint`, `self._send_agent_response`, `self._put_inbox`).

## Comment verbatim

All inline comments moved with their construction blocks are kept byte-identical (verbatim text) — no rewording, per the #3114 (Family 6b) lesson noted in the architect's spec.

## Byte-identical verification (self-performed)

Diffed the extraction against the pre-PR tree: pure logic move, zero edits to any argument value or resolution timing. Confirmed via `python -c "ast.parse(...)"` + full pytest run (below) that no behavior changed; cross-checked every arg's local/self classification against the spec's crux list one at a time.

## truncate-falsify: not applicable

This PR is a pure construction-sequence refactor (no WAL-event-derived state, no PITR/rewind/restore path, no new recovery/reconstruction functionality) — the CLAUDE.md recovery-feature PR gate does not apply.

## Scaffold test (`tests/scaffold/test_family7_intervention_bundle_byte_identical.py`)

Tier 1, `triggered_by`/`removed_by` metadata, deleted in the same PR that lands the extraction (this one) once green — real instances only, no mocks. Pins:
- the 5-element builder contract (real types, real bundle),
- ★ crash-avoidance when this family's own attrs are unset on `self` (proves intra-F7 refs are LOCAL, not `self._X`),
- ★ intra-F7 wiring identity (`coordinator._registry`/`_handler`, `handler._registry`, `glue._chains` all point at this family's own instances),
- ★ F8→F7 cross-dep (`InterAgentMessaging._chains IS session._chains`),
- ★ deferred chains→glue forwarding via the bound method, resolved at call time,
- **strip-falsify**: both the intra-F7 identity checks and the F8-dep identity check are proven live (a fresh, independently-constructed collaborator is NOT the same instance) — verified RED (`AttributeError`) by hand-editing the wiring back to `self._X` and back to a self-`registry` read, then restored via Edit (no `git checkout`/`git stash` used).

## Co-vet

**architect + an independent sonnet review**, per the architect's Family 7 spec recommendation (Family-8 interleave + cross-family dep + intra-F7 local-vs-self drift surfaces). I will not merge until both reviews land AND CI is green.

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/scaffold/test_family7_intervention_bundle_byte_identical.py` — green (0 Tier-4 violations)
- [x] `pytest` (full suite, 600s foreground) — 9038 passed, 29 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK
- [x] strip-falsify verified RED then restored (both pins)