### PR TITLE
refactor(session): extract inter_agent_messaging bundle builder (#3082 Family 8a, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1014,6 +1014,57 @@ class _InterventionBundle:
     chain_timeout_glue: "ChainTimeoutGlue"
 
 
+@dataclass(frozen=True)
+class _InterAgentMessagingBundle:
+    """#3082 Family 8a: ``inter_agent_messaging`` (``InterAgentMessaging``,
+    the agent-to-agent messaging service — depth-guarded request/response
+    dispatch, inbox handlers, multi-hop chain relay resolution). Per the
+    architect's ★ Family 8 DAG correction, the originally-planned "Family 8
+    = memory → inter_agent_messaging + mcp_connection_service" grouping does
+    not hold: the residual five leftover components (mcp_connection_service,
+    render_template_bounds, task_subscription_writer, memory,
+    inter_agent_messaging) are mutually independent, scattered, and straddle
+    the router-host WAIST (Family 6a) on BOTH sides — they cannot be
+    gathered into one builder. render_template_bounds (a 2-arg config) and
+    task_subscription_writer (a 1-line ternary) stay inline (trivial, not
+    worth a builder). The three substantial leaves — inter_agent_messaging
+    (8a, this one), memory (8b), mcp_connection_service (8c) — each get
+    their own no-move, single-component builder, landing in separate PRs.
+
+    Single-field bundle (mirrors Family 4's ``_CostBundle`` and Family 6a's
+    ``_RouterWaistBundle`` — one unconditional component, no intra-family
+    DAG); kept as a bundle rather than a bare return for pipeline-pattern
+    consistency with every other Family builder.
+
+    ``inter_agent_messaging`` is POST-WAIST: it reads Family 7's ``chains``
+    (``chain_manager=self._chains``) and Family 1's ``chat_events``
+    (``event_log=self._chat_events``) EAGERLY, plus a long tail of Session
+    bound methods (``self._put_outbox`` / ``self._a2a_send_request`` /
+    ``self._on_chain_timeout_fire`` / etc.) — all already set on ``self`` by
+    the time this builder runs (its call site sits at the construction's
+    ORIGINAL position, right after Family 7's ``_build_intervention_bundle``
+    returns). A handful of args are DEFERRED ``lambda``s that close over
+    ``self`` and resolve at CALL time, long after ``__init__`` returns —
+    these read per-turn / post-construction state
+    (``self._router_loop_delegations`` / ``self._router_loop_agent_replies``
+    / ``self._session_id``) that has no stable value yet at construction
+    time, so eager-izing them would either read a stale/None snapshot or
+    (for the setter lambdas) be impossible to express eagerly at all. This
+    is a SINGLE independent component (unlike Family 6b/7's multi-component
+    families), so there is no intra-family local-vs-self split — every
+    reference here is either an eager ``self._X`` (cross-family / config,
+    already resolved) or a deferred ``self.*`` bound method / ``lambda:
+    self.*`` closure (kept verbatim, never eager-ized).
+
+    Pure output→input value object:
+    :meth:`Session._build_inter_agent_messaging_bundle` is a byte-identical
+    extraction of the construction that used to run inline in
+    ``Session.__init__`` — same object, same 22 keyword args, same
+    construction order, same (unmoved) position."""
+
+    inter_agent_messaging: "InterAgentMessaging"
+
+
 class Session:
     def __init__(
         self,
@@ -1970,35 +2021,16 @@ class Session:
         # Hybrid design (案 C): InterAgentMessaging owns agent-side logic; transport-side
         # routing handled by FP-0013 RoutingLayer via send_request_callback /
         # send_response_callback injection.
-
-        self._inter_agent_messaging = InterAgentMessaging(
-            event_log=self._chat_events,
-            chain_manager=self._chains,
-            agent_name=self.agent_name,
-            max_hop_depth=self._max_hop_depth,
-            safety_extensions=self._safety_extensions,
-            output_language=self.output_language,
-            # FP-0050/#1822 S4b (EP5): fence untrusted inbound peer text.
-            threat_scan=self._safety.threat_scan,
-            append_history=self._append_history_for_inter_agent_messaging,
-            put_outbox=self._put_outbox,
-            handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
-            run_router_loop=lambda text, cid: self._run_router_loop(text, cid),
-            reset_router_turn_counter=self._reset_router_turn_counter,
-            send_request_callback=self._a2a_send_request,
-            send_response_callback=self._a2a_send_response,
-            on_chain_timeout_fire=self._on_chain_timeout_fire,
-            emit_router_cap_exhausted_fn=self._emit_router_cap_exhausted_user,
-            get_router_loop_delegations=lambda: self._router_loop_delegations,
-            set_router_loop_delegations=lambda v: setattr(self, "_router_loop_delegations", v),
-            get_router_loop_agent_replies=lambda: self._router_loop_agent_replies,
-            set_router_loop_agent_replies=lambda v: setattr(self, "_router_loop_agent_replies", v),
-            # #2103 S1bc-exec: read this session's LIVE sid (spawned sessions are stamped
-            # post-construction, so a cached value would be stale) for the responder_sid
-            # tag; + the trusted spawned-task lookup for rendering a returning result.
-            session_id_fn=lambda: self._session_id,
-            lookup_spawned_task=self.lookup_and_evict_spawned_task,
-        )
+        #
+        # #3082 Family 8a: byte-identical extraction, same construction order,
+        # same (unmoved) position — post-waist, reads Family 7's self._chains
+        # and Family 1's self._chat_events eagerly (both already set by this
+        # point) plus a tail of deferred self.*/lambda: self.* closures kept
+        # verbatim. See _InterAgentMessagingBundle /
+        # _build_inter_agent_messaging_bundle's docstring for the full
+        # eager-vs-deferred provenance per arg.
+        _inter_agent_messaging_bundle = self._build_inter_agent_messaging_bundle()
+        self._inter_agent_messaging = _inter_agent_messaging_bundle.inter_agent_messaging
 
         # session.py refactor PR-3: RouterLoopDriver owns the per-turn loop
         # orchestration (run_turn, shrink/overflow, cap enforcement, cancel).
@@ -4800,6 +4832,57 @@ class Session:
             intervention_coordinator=intervention_coordinator,
             chain_timeout_glue=chain_timeout_glue,
         )
+
+    def _build_inter_agent_messaging_bundle(self) -> "_InterAgentMessagingBundle":
+        """#3082 Family 8a: build ``inter_agent_messaging``. Byte-identical
+        extraction of the construction that used to run inline in
+        ``__init__`` — same object, same 22 keyword args, same construction
+        order, same (unmoved) position (right after Family 7's
+        ``_build_intervention_bundle`` returns).
+
+        This is a single independent leaf component (unlike Family 6b/7's
+        multi-component families) — every arg is either an eager
+        ``self._X`` (cross-family / config, already set on ``self`` by this
+        point: Family 7's ``self._chains``, Family 1's
+        ``self._chat_events``, plus early params/properties) or a deferred
+        bound method / ``lambda`` closing over ``self`` (kept verbatim,
+        NEVER eager-ized — ``run_router_loop`` /
+        ``get_router_loop_delegations`` / ``set_router_loop_delegations`` /
+        ``get_router_loop_agent_replies`` / ``set_router_loop_agent_replies``
+        / ``session_id_fn`` all resolve per-turn / post-construction state at
+        CALL time, not at builder-call time). No intra-family local-vs-self
+        split applies — there is nothing else in this family to be local
+        against. See :class:`_InterAgentMessagingBundle`'s docstring for the
+        full eager-vs-deferred provenance per arg."""
+        inter_agent_messaging = InterAgentMessaging(
+            event_log=self._chat_events,
+            chain_manager=self._chains,
+            agent_name=self.agent_name,
+            max_hop_depth=self._max_hop_depth,
+            safety_extensions=self._safety_extensions,
+            output_language=self.output_language,
+            # FP-0050/#1822 S4b (EP5): fence untrusted inbound peer text.
+            threat_scan=self._safety.threat_scan,
+            append_history=self._append_history_for_inter_agent_messaging,
+            put_outbox=self._put_outbox,
+            handle_chat_limit_checkpoint=self._handle_chat_limit_checkpoint,
+            run_router_loop=lambda text, cid: self._run_router_loop(text, cid),
+            reset_router_turn_counter=self._reset_router_turn_counter,
+            send_request_callback=self._a2a_send_request,
+            send_response_callback=self._a2a_send_response,
+            on_chain_timeout_fire=self._on_chain_timeout_fire,
+            emit_router_cap_exhausted_fn=self._emit_router_cap_exhausted_user,
+            get_router_loop_delegations=lambda: self._router_loop_delegations,
+            set_router_loop_delegations=lambda v: setattr(self, "_router_loop_delegations", v),
+            get_router_loop_agent_replies=lambda: self._router_loop_agent_replies,
+            set_router_loop_agent_replies=lambda v: setattr(self, "_router_loop_agent_replies", v),
+            # #2103 S1bc-exec: read this session's LIVE sid (spawned sessions are stamped
+            # post-construction, so a cached value would be stale) for the responder_sid
+            # tag; + the trusted spawned-task lookup for rendering a returning result.
+            session_id_fn=lambda: self._session_id,
+            lookup_spawned_task=self.lookup_and_evict_spawned_task,
+        )
+        return _InterAgentMessagingBundle(inter_agent_messaging=inter_agent_messaging)
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family8a_inter_agent_messaging_bundle_byte_identical.py
+++ b/tests/scaffold/test_family8a_inter_agent_messaging_bundle_byte_identical.py
@@ -1,0 +1,211 @@
+# scaffold: triggered_by="#3082 Family 8a (inter_agent_messaging bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 8a
+extraction — ``Session._build_inter_agent_messaging_bundle`` pulling
+``inter_agent_messaging`` (``InterAgentMessaging``) out of
+``Session.__init__`` into one builder returning one typed bundle
+(``_InterAgentMessagingBundle``).
+
+★ Family 8 DAG correction (owned by the architect): the originally-planned
+"Family 8 = memory → inter_agent_messaging + mcp_connection_service"
+grouping does not hold — the five residual leftover components
+(mcp_connection_service, render_template_bounds, task_subscription_writer,
+memory, inter_agent_messaging) are mutually independent and straddle the
+router-host WAIST (Family 6a) on both sides, so they cannot be gathered
+into one builder. render_template_bounds and task_subscription_writer stay
+inline (trivial — a 2-arg config and a 1-line ternary, not worth a
+builder). The three substantial leaves — inter_agent_messaging (8a, this
+PR), memory (8b), mcp_connection_service (8c) — each get their own no-move,
+single-component builder, in separate PRs.
+
+★ Post-waist, cross-family EAGER deps: ``inter_agent_messaging`` reads
+Family 7's ``chains`` (``chain_manager=self._chains``) and Family 1's
+``chat_events`` (``event_log=self._chat_events``) EAGERLY at construction
+time — both already set on ``self`` by the time this builder runs (its
+call site sits at the construction's ORIGINAL, unmoved position, right
+after Family 7's ``_build_intervention_bundle`` returns).
+
+★ Deferred lambda/bound-method tail (kept verbatim, never eager-ized):
+``run_router_loop`` / ``get_router_loop_delegations`` /
+``set_router_loop_delegations`` / ``get_router_loop_agent_replies`` /
+``set_router_loop_agent_replies`` / ``session_id_fn`` all close over
+``self`` and resolve per-turn / post-construction state at CALL time, long
+after ``__init__`` returns. This scaffold pins that a value mutated on
+``Session`` AFTER construction is visible through these closures (proving
+they are not frozen snapshots taken at builder-call time).
+
+Single independent leaf component (unlike Family 6b/7's multi-component
+families) — no intra-family local-vs-self split applies, since there is
+nothing else in this family to be local against.
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-attribute
+reads are resolved to a LOCAL variable on a line BEFORE the ``assert`` and
+are the extraction's OWN target attributes (``inter_agent_messaging._chains``
+/ ``inter_agent_messaging._events``) — Session's own state plus the exact
+wiring targets this extraction's eager-vs-deferred split is about (Family
+4/5/6a/6b/7's accepted idiom).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.services.chain_manager import ChainManager
+from reyn.runtime.services.inter_agent_messaging import InterAgentMessaging
+from reyn.runtime.session import Session, _InterAgentMessagingBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family8a-inter-agent-messaging-test")
+
+
+class TestFamily8aInterAgentMessagingBundleByteIdentical:
+    # ── builder contract ─────────────────────────────────────────────────
+
+    def test_session_holds_the_real_type(self, session: Session) -> None:
+        """Tier 1: the builder assigns a real ``InterAgentMessaging``
+        instance onto Session — the extraction's core contract."""
+        inter_agent_messaging = session._inter_agent_messaging
+        assert isinstance(inter_agent_messaging, InterAgentMessaging)
+
+    def test_builder_returns_an_inter_agent_messaging_bundle(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: calling the builder directly (bound method on Session)
+        returns an ``_InterAgentMessagingBundle`` wrapping the real type —
+        the builder's contract independent of ``__init__`` unpack wiring."""
+        bundle = session._build_inter_agent_messaging_bundle()
+        assert isinstance(bundle, _InterAgentMessagingBundle)
+        assert isinstance(bundle.inter_agent_messaging, InterAgentMessaging)
+
+    # ── ★ post-waist cross-family EAGER deps: chains (F7) / chat_events (F1) ──
+
+    def test_chain_manager_is_the_same_chains_instance(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ F7→F8a cross-dep pin — ``inter_agent_messaging`` reads
+        ``chain_manager=self._chains`` EAGERLY at construction time. This
+        proves it is the SAME ``ChainManager`` instance Family 7 built, not
+        a fresh one and not unset."""
+        inter_agent_messaging = session._inter_agent_messaging
+        wired_chains = inter_agent_messaging._chains
+        session_chains = session._chains
+        assert wired_chains is session_chains
+
+    def test_event_log_is_the_same_chat_events_instance(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ F1→F8a cross-dep pin — ``inter_agent_messaging`` reads
+        ``event_log=self._chat_events`` EAGERLY at construction time. This
+        proves it is the SAME ``EventLog`` instance Family 1 built."""
+        inter_agent_messaging = session._inter_agent_messaging
+        wired_events = inter_agent_messaging._events
+        session_events = session._chat_events
+        assert wired_events is session_events
+
+    # ── ★ deferred lambdas: resolve current value at CALL time, not builder-call time ──
+
+    def test_get_router_loop_delegations_reflects_a_post_construction_mutation(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ deferred pin — ``get_router_loop_delegations`` is a
+        ``lambda: self._router_loop_delegations`` closure. Mutating
+        ``session._router_loop_delegations`` AFTER construction and AFTER
+        the builder already returned must still be visible through the
+        closure — proving it resolves live state at CALL time, not a
+        snapshot frozen when the builder ran (which would have captured the
+        pre-``__init__``-completion value)."""
+        inter_agent_messaging = session._inter_agent_messaging
+        get_delegations = inter_agent_messaging._get_router_loop_delegations
+
+        assert get_delegations() is None
+
+        sentinel = [{"probe": "post-construction-delegation"}]
+        session._router_loop_delegations = sentinel
+
+        assert get_delegations() is sentinel
+
+    def test_set_router_loop_delegations_writes_back_onto_session(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ deferred pin — ``set_router_loop_delegations`` is a
+        ``lambda v: setattr(self, "_router_loop_delegations", v)`` closure.
+        Calling it through ``inter_agent_messaging`` must mutate
+        ``session._router_loop_delegations`` itself (not a local copy),
+        proving the setter closure is still bound to the live ``Session``,
+        not a value captured at builder-call time."""
+        inter_agent_messaging = session._inter_agent_messaging
+        set_delegations = inter_agent_messaging._set_router_loop_delegations
+
+        sentinel = [{"probe": "set-via-closure"}]
+        set_delegations(sentinel)
+
+        written_delegations = session._router_loop_delegations
+        assert written_delegations is sentinel
+
+    def test_session_id_fn_reflects_a_post_construction_mutation(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ deferred pin — ``session_id_fn`` is a
+        ``lambda: self._session_id`` closure (#2103 S1bc-exec: spawned
+        sessions stamp their LIVE sid post-construction, so a cached value
+        would be stale). Mutating ``session._session_id`` AFTER
+        construction must be visible through the closure."""
+        inter_agent_messaging = session._inter_agent_messaging
+        session_id_fn = inter_agent_messaging._session_id_fn
+
+        session._session_id = "probe-post-construction-sid"
+
+        assert session_id_fn() == "probe-post-construction-sid"
+
+    # ── strip-falsify: the identity checks themselves must be live ───────
+
+    def test_strip_falsify_chain_manager_check_is_live(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify for the F7→F8a cross-dep pin — a FRESH,
+        independently-constructed ``ChainManager`` must NOT be the same
+        instance ``inter_agent_messaging`` actually holds, proving that pin
+        genuinely reads the live cross-family wiring rather than trivially
+        passing regardless of what is wired."""
+        fresh_chains = ChainManager(
+            journal=session._journal,
+            events=session._chat_events,
+            chain_timeout_seconds=session._chain_timeout_seconds,
+            max_hop_depth=session._max_hop_depth,
+        )
+
+        wired_chains = session._inter_agent_messaging._chains
+        session_chains = session._chains
+
+        assert fresh_chains is not session_chains
+        assert wired_chains is session_chains
+        assert wired_chains is not fresh_chains
+
+    def test_strip_falsify_deferred_delegations_check_is_live(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify for the deferred-lambda pin — a value NOT
+        written onto ``session._router_loop_delegations`` must NOT be what
+        the getter closure returns, proving the getter pin is genuinely
+        reading live Session state at call time rather than a value that
+        would appear regardless of what is set."""
+        get_delegations = session._inter_agent_messaging._get_router_loop_delegations
+        never_written_sentinel = [{"probe": "never-written"}]
+
+        assert get_delegations() is not never_written_sentinel
+
+        session._router_loop_delegations = never_written_sentinel
+
+        assert get_delegations() is never_written_sentinel
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — part of #3082 (God-constructor decomposition). Extracts `InterAgentMessaging` construction (Family 8a, per the architect's Family 8 spec — issue #3082 comments) into a single-component builder, byte-identical.

## Scope

- **Extraction target**: `inter_agent_messaging` only (`InterAgentMessaging`, currently constructed inline in `Session.__init__`). This PR does **not** touch the other Family 8 residual leaves — `memory` (8b) and `mcp_connection_service` (8c) are separate, sequential PRs; `render_template_bounds` and `task_subscription_writer` stay inline (trivial: a 2-arg config and a 1-line ternary, per the architect's spec, not worth a builder).
- **DAG note**: per the architect's ★ Family 8 spec correction, the originally-planned "Family 8 = memory → inter_agent_messaging + mcp_connection_service" grouping does not hold — the five residual leaves are mutually independent and straddle the router-host WAIST (Family 6a) on both sides, so a single gathering builder is not possible. Each substantial leaf gets its own no-move, single-component builder instead.

## Byte-identical extraction

- `_build_inter_agent_messaging_bundle()` constructs `InterAgentMessaging` with the exact same **22 keyword args**, in the exact same order, at the exact same (unmoved) call-site position in `__init__` — right after Family 7's `_build_intervention_bundle()` returns. (The architect's spec description mentions "31 args" for this family; the actual `InterAgentMessaging.__init__` signature has 22 params, all passed at the call site — noting the count discrepancy here since the spec's stated number doesn't match the ground-truth signature, though it doesn't change what needed to be extracted: the single, unambiguous `InterAgentMessaging(...)` call site.)
- Cross-tree diff vs `origin/main` confirms: no logic edit, no argument added/removed/reordered, all inline comments (including the `# FP-0050/#1822 S4b (EP5)` and `# #2103 S1bc-exec` comments) preserved **verbatim** (per #3114's lesson).

## Eager / deferred / cross-family classification (3-way, per spec)

Single independent leaf component — no intra-family local-vs-self split applies (there is nothing else in this family to be local against). Every arg is one of:
- **Eager `self._X` (cross-family, already set)**: `event_log=self._chat_events` (Family 1), `chain_manager=self._chains` (Family 7) — both builders run before this one.
- **Eager `self.*` bound methods / properties**: `agent_name`, `output_language`, `threat_scan=self._safety.threat_scan`, `append_history`, `put_outbox`, `handle_chat_limit_checkpoint`, `reset_router_turn_counter`, `send_request_callback`, `send_response_callback`, `on_chain_timeout_fire`, `emit_router_cap_exhausted_fn`, `lookup_spawned_task`, plus config attrs `max_hop_depth` / `safety_extensions`.
- **Deferred `lambda: self.*` / `lambda v: setattr(self, ...)` closures (kept verbatim, NOT eager-ized)**: `run_router_loop`, `get_router_loop_delegations`, `set_router_loop_delegations`, `get_router_loop_agent_replies`, `set_router_loop_agent_replies`, `session_id_fn` — these resolve per-turn / post-construction state at CALL time (e.g. `self._session_id` is stamped post-construction for spawned sessions).

## Scaffold test (`tests/scaffold/test_family8a_inter_agent_messaging_bundle_byte_identical.py`, Tier 1)

Pins, behaviorally (no private-identity peeking beyond the extraction's own construction targets):
- `inter_agent_messaging._chains IS session._chains` (F7→F8a cross-dep).
- `inter_agent_messaging._events IS session._chat_events` (F1→F8a cross-dep).
- The deferred closures (`get_router_loop_delegations` / `set_router_loop_delegations` / `session_id_fn`) resolve **live** Session state mutated *after* construction — not a frozen snapshot.
- **Strip-falsify** (Edit-to-break → Edit-to-restore, no `git checkout`): verified manually by temporarily swapping `chain_manager=self._chains` for a freshly-constructed `ChainManager` in the builder — the two identity-pin tests (`test_chain_manager_is_the_same_chains_instance`, `test_strip_falsify_chain_manager_check_is_live`) went RED as expected, then the edit was reverted and the suite is green again. The scaffold also includes a dedicated `test_strip_falsify_deferred_delegations_check_is_live` verifying the deferred-getter pin is non-vacuous (an unwritten sentinel does not appear).
- Test policy: real instances only, no mocks. Private reads pre-bound to a local variable before the `assert` line (matches Family 4/5/6a/6b/7's accepted idiom for `test_tier_audit.py --strict`).

## Recovery-feature gate

Not applicable — pure extraction, no new WAL-derived state, no recovery/reconstruction path touched.

## Co-vet

**Reviewers: architect (per-family co-vet: cross-tree diff, eager/deferred/cross-family classification, comment verbatim, scaffold strip-falsify) + an independent sonnet review**, per the architect's Family 8 proportionate-judgment note (8a recommended for independent review — 22-arg eager cross-family + deferred-lambda tail, mini-waist-adjacent drift-risk). I (per-PR-coder) will not merge until both reviews are in and CI is green.

## CI gates (all green locally before push)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family8a_inter_agent_messaging_bundle_byte_identical.py` — 9/9 OK, 0 Tier-4 violations.
- `pytest` (full suite, foreground, 10-minute timeout) — 9047 passed, 29 skipped, 0 failed.
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK.

part of #3082

## Test plan

- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green on the new scaffold test
- [x] Full `pytest` suite green (9047 passed / 29 skipped / 0 failed)
- [x] `verify_module_docstrings.py` green
- [x] Manual strip-falsify (Edit-to-break/Edit-to-restore) on the F7→F8a cross-dep pin, confirmed non-vacuous