### PR TITLE
refactor(session): extract memory bundle builder (#3082 Family 8b, byte-identical)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1065,6 +1065,45 @@ class _InterAgentMessagingBundle:
     inter_agent_messaging: "InterAgentMessaging"
 
 
+@dataclass(frozen=True)
+class _MemoryBundle:
+    """#3082 Family 8b: ``memory`` (``MemoryService``, the memory-persistence
+    adapter that absorbs memory path resolution + remember / forget /
+    read_body). Per the architect's #3082 Family 8 DAG correction, this is
+    one of three mutually-independent leftover leaves (8a
+    ``inter_agent_messaging``, 8b ``memory`` here, 8c
+    ``mcp_connection_service``) that straddle the router-host WAIST (Family
+    6a) on both sides — they cannot be gathered into one builder, so each
+    gets its own no-move, single-component builder. Single-field bundle
+    (mirrors Family 4's ``_CostBundle`` / Family 6a's ``_RouterWaistBundle``
+    / Family 8a's ``_InterAgentMessagingBundle`` — one unconditional
+    component, no intra-family DAG); kept as a bundle rather than a bare
+    return for pipeline-pattern consistency with every other Family builder.
+
+    ``memory`` is PRE-WAIST: ``_build_router_waist`` (Family 6a) reads
+    ``self._memory`` eagerly (``memory=self._memory``) when it builds
+    ``RouterHostAdapter``. This is the inverse direction of Family 7's
+    F8→F7 ``chains`` dependency (there, a LATER family read an EARLIER
+    one's post-waist output; here, waist-builder Family 6a reads THIS
+    pre-waist family's output) — so ``self._memory`` MUST be assigned
+    before the waist builder call, not after. The builder call stays at
+    its ORIGINAL position (unmoved), which sits well before
+    ``_build_router_waist`` runs, satisfying this ordering constraint. All
+    of ``memory``'s own args are themselves already eager on ``self`` by
+    this point — Family 1's ``self._chat_events`` (``events=``) plus the
+    ``file_write`` / ``file_read`` / ``file_delete`` /
+    ``file_regenerate_index`` bound methods and the ``workspace_dir``
+    property — so there is no deferred lambda and no intra-family
+    local-vs-self split (a single independent leaf, like 8a).
+
+    Pure output→input value object: :meth:`Session._build_memory_bundle` is
+    a byte-identical extraction of the construction that used to run inline
+    in ``Session.__init__`` — same object, same keyword args, same
+    (unmoved) position."""
+
+    memory: "MemoryService"
+
+
 class Session:
     def __init__(
         self,
@@ -1906,14 +1945,12 @@ class Session:
         # Absorbs memory path resolution + remember / forget / read_body.
         # PR3 (RouterHostAdapter) holds a direct reference; session delegates
         # via the adapter's memory_path / memory_dir.
-        self._memory = MemoryService(
-            agent_workspace_dir=self.workspace_dir,
-            events=self._chat_events,
-            file_write=self._file_write,
-            file_read=self._file_read,
-            file_delete=self._file_delete,
-            file_regenerate_index=self._file_regenerate_index,
-        )
+        # #3082 Family 8b: extracted to _build_memory_bundle (byte-identical, same
+        # args as the inline construction this replaced; unmoved (no-move) — this
+        # position is PRE-WAIST, before _build_router_waist (Family 6a, below)
+        # reads self._memory eagerly. See _MemoryBundle / the builder's docstring.
+        _memory_bundle = self._build_memory_bundle()
+        self._memory = _memory_bundle.memory
 
         # PR-refactor-session-1 wave 2: pending-chain lifecycle and intervention
         # queue ownership extracted into services. The session orchestrates the
@@ -4883,6 +4920,37 @@ class Session:
             lookup_spawned_task=self.lookup_and_evict_spawned_task,
         )
         return _InterAgentMessagingBundle(inter_agent_messaging=inter_agent_messaging)
+
+    def _build_memory_bundle(self) -> "_MemoryBundle":
+        """#3082 Family 8b: build ``memory``. Byte-identical extraction of the
+        construction that used to run inline in ``__init__`` — same object,
+        same keyword args, same (unmoved) position.
+
+        This is a single independent leaf component (like Family 8a's
+        ``inter_agent_messaging``) — every arg is an eager ``self._X``
+        (Family 1's ``self._chat_events``, already set on ``self`` by this
+        point) or a bound method / property already available at
+        construction time (``self._file_write`` / ``self._file_read`` /
+        ``self._file_delete`` / ``self._file_regenerate_index`` /
+        ``self.workspace_dir``). No deferred lambda, no intra-family
+        local-vs-self split — see :class:`_MemoryBundle`'s docstring for the
+        full provenance.
+
+        ★ PRE-WAIST placement: this builder's call site (in ``__init__``)
+        MUST stay before ``_build_router_waist`` runs (Family 6a), which
+        reads ``self._memory`` eagerly when constructing
+        ``RouterHostAdapter``. Moving this call after the waist builder
+        call would leave ``self._memory`` unassigned when the waist builder
+        reads it, raising ``AttributeError``."""
+        memory = MemoryService(
+            agent_workspace_dir=self.workspace_dir,
+            events=self._chat_events,
+            file_write=self._file_write,
+            file_read=self._file_read,
+            file_delete=self._file_delete,
+            file_regenerate_index=self._file_regenerate_index,
+        )
+        return _MemoryBundle(memory=memory)
 
     # ── #2073 S2: config hot-reload reapply seams (registered on the HotReloader) ──
 

--- a/tests/scaffold/test_family8b_memory_bundle_byte_identical.py
+++ b/tests/scaffold/test_family8b_memory_bundle_byte_identical.py
@@ -1,0 +1,166 @@
+# scaffold: triggered_by="#3082 Family 8b (memory bundle builder) extraction lands"
+# scaffold: removed_by="The same PR that lands the extraction, once this test is green"
+"""Tier 1: byte-identical characterization gate for the #3082 Family 8b
+extraction — ``Session._build_memory_bundle`` pulling ``memory``
+(``MemoryService``) out of ``Session.__init__`` into one builder returning
+one typed bundle (``_MemoryBundle``).
+
+Per the architect's #3082 Family 8 DAG correction (see the Family 8a
+scaffold's docstring for the full grouping rationale), ``memory`` is one of
+three mutually-independent leftover leaves (8a ``inter_agent_messaging``,
+8b ``memory`` here, 8c ``mcp_connection_service``) straddling the
+router-host WAIST (Family 6a) on both sides — each gets its own no-move,
+single-component builder.
+
+★ PRE-WAIST placement crux (the one thing that matters for this family):
+``memory`` is PRE-WAIST — ``_build_router_waist`` (Family 6a) reads
+``self._memory`` EAGERLY (``memory=self._memory``) when it constructs
+``RouterHostAdapter``. This is the inverse direction of Family 7's F8→F7
+``chains`` dependency (there, a LATER family reads an EARLIER family's
+post-waist output; here, the WAIST builder itself reads THIS pre-waist
+family's output) — so ``self._memory`` must be assigned before
+``_build_router_waist`` runs. The builder call stays at its original,
+unmoved position, well before the waist builder call, satisfying this.
+This scaffold pins that ``RouterHostAdapter``'s wired memory IS the exact
+same ``MemoryService`` instance ``Session._memory`` holds — proof the
+waist builder picked up the pre-waist assignment rather than reading it
+unset or reading a stale/fresh instance.
+
+★ Cross-family EAGER dep: ``memory`` reads Family 1's ``chat_events``
+(``events=self._chat_events``) eagerly at construction time (already set
+on ``self`` by the time this builder runs, per the unmoved call-site
+position).
+
+Single independent leaf component (no deferred lambda, no intra-family
+local-vs-self split — unlike Family 8a which has a deferred-lambda tail).
+
+Per the extracted-refactor idiom (docs/deep-dives/contributing/testing.md
+Annex: Scaffolding tests / CLAUDE.md's byte-identical-staged-externalization
+rule), this scaffold is added and removed in the SAME PR that lands the
+extraction, once green.
+
+Policy (docs/deep-dives/contributing/testing.md): real instances only — no
+``unittest.mock``/``MagicMock``/``AsyncMock``/``patch``. Private-attribute
+reads are resolved to a LOCAL variable on a line BEFORE the ``assert`` and
+are the extraction's OWN target attributes (``memory._events`` /
+``router_host._memory``) — Session's own state plus the exact wiring
+targets this extraction's eager-dep and pre-waist-placement pins are about
+(Family 4/5/6a/6b/7/8a's accepted idiom).
+"""
+from __future__ import annotations
+
+import pytest
+
+from reyn.runtime.services.memory_service import MemoryService
+from reyn.runtime.session import Session, _MemoryBundle
+
+
+@pytest.fixture
+def session(tmp_path, monkeypatch) -> Session:
+    monkeypatch.chdir(tmp_path)
+    return Session(agent_name="family8b-memory-test")
+
+
+class TestFamily8bMemoryBundleByteIdentical:
+    # ── builder contract ─────────────────────────────────────────────────
+
+    def test_session_holds_the_real_type(self, session: Session) -> None:
+        """Tier 1: the builder assigns a real ``MemoryService`` instance
+        onto Session — the extraction's core contract."""
+        memory = session._memory
+        assert isinstance(memory, MemoryService)
+
+    def test_builder_returns_a_memory_bundle(self, session: Session) -> None:
+        """Tier 1: calling the builder directly (bound method on Session)
+        returns a ``_MemoryBundle`` wrapping the real type — the builder's
+        contract independent of ``__init__`` unpack wiring."""
+        bundle = session._build_memory_bundle()
+        assert isinstance(bundle, _MemoryBundle)
+        assert isinstance(bundle.memory, MemoryService)
+
+    # ── ★ cross-family EAGER dep: chat_events (F1) ────────────────────────
+
+    def test_memory_events_is_the_same_chat_events_instance(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ F1→F8b cross-dep pin — ``memory`` reads
+        ``events=self._chat_events`` EAGERLY at construction time. This
+        proves it is the SAME ``EventLog`` instance Family 1 built, not a
+        fresh one and not unset."""
+        wired_events = session._memory._events
+        session_events = session._chat_events
+        assert wired_events is session_events
+
+    # ── ★ pre-waist placement pin: RouterHostAdapter reads self._memory ──
+
+    def test_router_host_memory_is_the_same_session_memory_instance(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: ★ pre-waist placement pin — ``_build_router_waist``
+        (Family 6a) reads ``self._memory`` EAGERLY (``memory=self._memory``)
+        when constructing ``RouterHostAdapter``. This proves the memory
+        builder's call site genuinely runs BEFORE the waist builder call —
+        the waist-built ``RouterHostAdapter`` holds the exact SAME
+        ``MemoryService`` instance ``Session._memory`` holds, not an unset
+        attribute (which would have raised ``AttributeError`` at
+        construction) and not a different instance."""
+        wired_memory = session._router_host._memory
+        session_memory = session._memory
+        assert wired_memory is session_memory
+
+    # ── strip-falsify: the identity checks themselves must be live ───────
+
+    def test_strip_falsify_events_check_is_live(self, session: Session) -> None:
+        """Tier 1: strip-falsify for the F1→F8b cross-dep pin — a FRESH,
+        independently-constructed ``MemoryService`` wired to a DIFFERENT
+        ``EventLog`` must NOT be indistinguishable from the wired one,
+        proving the events pin genuinely reads the live cross-family wiring
+        rather than trivially passing regardless of what is wired."""
+        from reyn.core.events.events import EventLog
+
+        fresh_events = EventLog()
+        fresh_memory = MemoryService(
+            agent_workspace_dir=session.workspace_dir,
+            events=fresh_events,
+            file_write=session._file_write,
+            file_read=session._file_read,
+            file_delete=session._file_delete,
+            file_regenerate_index=session._file_regenerate_index,
+        )
+
+        wired_events = session._memory._events
+        session_events = session._chat_events
+        fresh_memory_events = fresh_memory._events
+
+        assert fresh_memory_events is not session_events
+        assert wired_events is session_events
+        assert wired_events is not fresh_events
+
+    def test_strip_falsify_router_host_memory_check_is_live(
+        self, session: Session,
+    ) -> None:
+        """Tier 1: strip-falsify for the pre-waist placement pin — a FRESH,
+        independently-constructed ``MemoryService`` must NOT be the same
+        instance ``session._router_host`` actually holds, proving the
+        pre-waist pin genuinely reads the live waist wiring rather than
+        trivially passing regardless of what was assigned before the waist
+        builder ran."""
+        fresh_memory = MemoryService(
+            agent_workspace_dir=session.workspace_dir,
+            events=session._chat_events,
+            file_write=session._file_write,
+            file_read=session._file_read,
+            file_delete=session._file_delete,
+            file_regenerate_index=session._file_regenerate_index,
+        )
+
+        wired_memory = session._router_host._memory
+        session_memory = session._memory
+
+        assert fresh_memory is not session_memory
+        assert wired_memory is session_memory
+        assert wired_memory is not fresh_memory
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
**[per-PR-coder]** — #3082 Family 8b(memory)の byte-identical 抽出です。architect の issue #3082 コメント「Family 8b(memory)detail」(post-#3116 main で ground)に厳密に忠実に実装しました。

## 抽出対象

**単一 `MemoryService`**(現 `:1948`(post-#3116 main での行番号)、architect spec の `:1909` から Family 8a(#3116)分の +39 行シフト)を builder + frozen dataclass(Family 1–8a と同型)に抽出:

- `Session._build_memory_bundle(self) -> _MemoryBundle` を新設。`__init__` は builder 呼び出し + `self._memory = bundle.memory` の unpack のみ。
- **8b のみが対象**。8a(inter_agent_messaging)は #3116 で merge 済 ∴ 本 PR では触れません。8c(mcp_connection_service)/ trivial 2件(render_template_bounds / task_subscription_writer)は対象外(architect spec: 各々別 PR / inline 存置)。

## 全 args eager `self._X`(deferred/local-vs-self の crux なし)

- `events=self._chat_events`(Family 1、`:1772` 相当で set 済、EAGER)
- `file_write` / `file_read` / `file_delete` / `file_regenerate_index`(bound method)
- `agent_workspace_dir=self.workspace_dir`(property)

単一 leaf component ゆえ deferred lambda なし・intra-family local-vs-self split なし = F8 中最も単純(architect 評)。

## no-move(現位置のまま)

builder 呼び出しは元の inline construction と同じ位置(`__init__` 内、変更前と同じ相対順序)に置いています。移動していません。

## ★ pre-waist placement(唯一の注意点)

`_build_router_waist()`(Family 6a waist builder、`__init__` 内で本抽出箇所より後方)が、その内部(`RouterHostAdapter` 構築)で `memory=self._memory` を EAGER に読みます。∴ **`self._memory` の代入は waist builder 呼び出しより前に確定している必要があります**。本抽出は no-move(元位置のまま)なので、この pre-waist 依存は自動的に維持されます — builder 呼び出しを waist builder 呼び出しより後ろに動かすと `AttributeError: 'Session' object has no attribute '_memory'` でクラッシュします(strip-falsify で実地検証済み、下記)。

## comment verbatim

抽出箇所の直前コメント(`# PR-refactor-session-1 wave 3 PR2: memory persistence adapter. ...`)はそのまま維持し、抽出の説明コメントのみ追加しています(#3114 の反省を踏まえ verbatim 維持を確認済み)。

## truncate-falsify 非適用理由

本 PR は WAL-event-derived recovery / reconstruction 機能を追加するものではなく、既存の `Session.__init__` 内オブジェクト構築を builder メソッドへ移すだけの純粋なコード整理(byte-identical extraction)です。したがって CLAUDE.md の「Recovery-feature PR gate」(truncate-falsify test 必須)は適用対象外です。

## byte-identical 検証(cross-tree diff vs merge-base)

`git diff origin/main -- src/reyn/runtime/session.py` で確認:
- 新規追加は `_MemoryBundle` frozen dataclass + `_build_memory_bundle` メソッドのみ
- 元の6 kwargs(`agent_workspace_dir` / `events` / `file_write` / `file_read` / `file_delete` / `file_regenerate_index`)は一字一句そのまま、順序不変
- 呼び出し位置は no-move
- ロジック編集ゼロ

## scaffold test(`tests/scaffold/test_family8b_memory_bundle_byte_identical.py`、Tier 1、`triggered_by`/`removed_by` 付き、landing 後に削除予定)

- `memory.events IS chat_events`(Family 1 cross-family 配線)pin
- **★ `RouterHostAdapter._memory IS session._memory`**(pre-waist 配線 pin — waist builder が pre-waist で代入された memory を正しく受け取っている証明)
- **strip-falsify 実施済み**(edit-to-break → RED 確認 → edit-to-restore、`git checkout`/`git stash` 不使用):
  - events pin: builder 内で fresh `EventLog()` に差し替え → `test_memory_events_is_the_same_chat_events_instance` / `test_strip_falsify_events_check_is_live` が RED になることを確認 → 復元
  - pre-waist pin: builder 呼び出しを waist builder 呼び出しの**後**に移動 → `AttributeError: 'Session' object has no attribute '_memory'` で fixture setup 自体がクラッシュすることを確認(architect 予告どおり)→ 復元
- real instance のみ(mock 不使用)

## co-vet

**co-vet = architect**(architect proportionate 判断: 8b は F8 中最も単純ゆえ独立 review 不要、co-vet + CI で十分)。**co-vet + CI green を確認するまでマージしません。**

## 4 gate(全て green、ローカルで実行確認済み)

- `ruff check src tests` — All checks passed
- `python scripts/test_tier_audit.py --strict tests/scaffold/test_family8b_memory_bundle_byte_identical.py` — 6/6 OK, 0 errors
- `pytest`(foreground、timeout 600000ms 明示)— 9053 passed, 29 skipped, 0 failed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK

part of #3082

## Test plan
- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green (scaffold test)
- [x] full `pytest` green (9053 passed, 29 skipped)
- [x] `verify_module_docstrings.py` green
- [x] byte-identical cross-tree diff confirmed (no logic edits, comment verbatim, no-move)
- [x] scaffold strip-falsify confirmed for both pins (events pin + pre-waist pin), non-vacuous RED then restored

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>