### PR TITLE
fix: RAG turnkey weak-model hardening — diagnose db-missing vs unreachable, surface real embed error, tighten SKILL.md param docs (#2955 follow-up)

### DIFF
--- a/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml
@@ -104,6 +104,23 @@ schema: PreflightCheck
 fields:
   status: {type: enum, values: ["ok"]}
 ---
+# #2955 weak-model-hardening follow-up: gates `_ingest_embed_and_upsert`'s
+# `embed` tool step. `embed`'s op handler (op_runtime/embed.py) stamps
+# `total_tokens` ONLY on a successful embed -- an error/cancelled result
+# carries `status`+`error`/`model` instead and never `total_tokens`. Before
+# this gate, a litellm failure (bad key, unpriceable model, provider outage)
+# canonicalized to an EMPTY view (`embed_to_canonical`'s `meta`/`structured`
+# stay unpopulated on error), so the pipeline crashed two steps later on
+# `ctx.embedded.meta.model` being absent -- discarding the real litellm
+# error text in favour of a generic "field absent" message. Requiring
+# `total_tokens` here makes the SAME `_run_tool_step` schema-failure detail
+# path #3070/#3064 already built (`result.get("error")` appended to the
+# raised message) surface the actual provider failure at the embed step
+# itself, not a misleading one two steps downstream.
+schema: EmbedOk
+fields:
+  total_tokens: {type: number, required: true}
+---
 pipeline: ingest
 description: >-
   FP-0063 P3 builtin RAG ingest: chunk -> embed -> store a file or folder
@@ -771,6 +788,7 @@ description: >-
 steps:
   - tool:
       name: embed
+      schema: EmbedOk
       args:
         texts: !expr "map(ctx.to_upsert, i -> i.text)"
         embedding_model: !expr ctx.embedding_model

--- a/src/reyn/builtin/plugins/rag/pipelines/rag_query.yaml
+++ b/src/reyn/builtin/plugins/rag/pipelines/rag_query.yaml
@@ -7,7 +7,20 @@
 #
 # Inputs (all optional except `query_text`/`db`):
 #   query_text          -- (required) the natural-language query.
-#   db                  -- (required) the sqlite file rag_ingest wrote to.
+#   db                  -- (required) the sqlite file rag_ingest wrote to
+#                          (rag_ingest's `output_db` INPUT param -- the
+#                          param name here is EXACTLY `db`, not `db_path`
+#                          -- that is the raw vector-store MCP tool's OWN
+#                          arg name, one layer down -- and not
+#                          `vector_store_path`, a plausible-sounding name
+#                          this pipeline has never accepted. #2955
+#                          weak-model-hardening follow-up: a live dogfood
+#                          witness had a weak model invent
+#                          `vector_store_path` unprompted; a missing/
+#                          misnamed `db` is now caught explicitly below
+#                          with this exact remedy, before it can be
+#                          misdiagnosed as the vector-store server being
+#                          unreachable).
 #   top_k               -- how many nearest chunks to return (default 5).
 #   embedding_model     -- MUST match what rag_ingest used for this db (a
 #                          mismatched vector dimension raises
@@ -22,11 +35,22 @@
 #                          `mcp.servers` (default reyn_vector_store).
 #
 # Output: `ctx.result` -- either the top-k list
-# `[{"id", "distance", "metadata"}, ...]` (nearest-first) or the pre-flight
-# decision-enabling message if the vector-store server is unreachable.
+# `[{"id", "distance", "metadata"}, ...]` (nearest-first) or a
+# decision-enabling blocked message: a missing/misnamed `db` param, an
+# unreachable vector-store server, or (#2955 follow-up) a failed query
+# embed -- each distinguished by cause, never a single generic string.
 schema: PreflightCheck
 fields:
   status: {type: enum, values: ["ok"]}
+---
+# #2955 weak-model-hardening follow-up (see rag_ingest.yaml's identical
+# EmbedOk doc for the full rationale): gates `_query_body`'s `embed` tool
+# step so a litellm failure surfaces its own error text at the embed step,
+# not as a misleading "field absent" crash on `ctx.embedded.structured` two
+# steps later.
+schema: EmbedOk
+fields:
+  total_tokens: {type: number, required: true}
 ---
 pipeline: query
 description: >-
@@ -39,13 +63,50 @@ steps:
   - transform: {value: "get(ctx, 'filters', null)", output: filters}
   - transform: {value: "get(ctx, 'vectorstore_server', 'reyn_vector_store')", output: vectorstore_server}
 
-  # X1-equivalent pre-flight: a real, cheap probe (list_metadata against
-  # THIS db, limit 1) before spending on the query embed -- schema-gated to
-  # status=="ok" (see rag_ingest.yaml for the full rationale). `parallel`
-  # with a single branch is reused (rather than a bare `tool` step) purely
-  # to get the "reachable: bool, no raised exception" shape ingest's own
-  # pre-flight uses -- a dropped (on_error: continue) branch's key is
-  # simply absent from collect's named map.
+  # #2955 weak-model-hardening follow-up: catch a missing/misnamed `db`
+  # BEFORE the MCP pre-flight probe below. Previously a null `ctx.db` (from
+  # e.g. a model calling with `vector_store_path` instead of `db`) flowed
+  # straight into the probe's `db_path` arg, the probe tool call itself
+  # errored (not a transport failure), the branch dropped, and the result
+  # was misdiagnosed as "the vector-store MCP server is unreachable" -- a
+  # server-down claim that was simply false. Caught explicitly here with
+  # the correct diagnosis and the exact required param name, at zero probe
+  # cost.
+  - transform: {value: "get(ctx, 'db', null) == null", output: db_missing}
+  - transform:
+      value: >-
+        "Missing required parameter `db` (the sqlite file rag_ingest wrote to, i.e. rag_ingest's `output_db`). The parameter name is EXACTLY `db` -- not `db_path`, not `vector_store_path`. Example: pipeline__run(name=\"rag_query.query\", input={\"query_text\": \"...\", \"db\": \"./rag/docs.sqlite\"})."
+      output: db_missing_message
+  - match:
+      on: ctx.db_missing
+      cases:
+        "True":
+          pipeline: _query_blocked
+          pass:
+            message: ctx.db_missing_message
+      default:
+        pipeline: _query_preflight
+        pass:
+          query_text: ctx.query_text
+          db: ctx.db
+          top_k: ctx.top_k
+          embedding_model: ctx.embedding_model
+          filters: ctx.filters
+          vectorstore_server: ctx.vectorstore_server
+      output: result
+---
+pipeline: _query_preflight
+description: >-
+  X1-equivalent pre-flight for query: a real, cheap probe (list_metadata
+  against THIS db, limit 1) before spending on the query embed. Ported from
+  rag_ingest.yaml's #3064 cause-capture idiom (#2955 weak-model-hardening
+  follow-up) -- a dropped probe branch's real cause (e.g. a genuinely
+  unreachable server, a half-materialised per-plugin venv, or any other
+  probe-call error `_query.query`'s own db-missing gate above did not
+  already catch) is now surfaced as EVIDENCE alongside the remedy, instead
+  of collapsing into one static "is unreachable" string regardless of the
+  actual fault.
+steps:
   - parallel:
       on_error: continue
       branches:
@@ -59,14 +120,21 @@ steps:
               tool_args: !expr "{db_path: ctx.db, limit: 1}"
       collect:
         transform:
-          value: "get(pipe, 'vectorstore', null) != null"
-      output: vectorstore_reachable
+          # #3070's PARALLEL_BRANCH_ERRORS_KEY (executor.py) carries the
+          # real cause text a dropped branch's schema-validation-failure
+          # exception now includes -- empty string for a branch that never
+          # dropped. Mirrors rag_ingest.yaml's `reachable` shape exactly.
+          value: >-
+            {ok: get(pipe, "vectorstore", null) != null,
+             cause: get(pipe, "__branch_errors__.vectorstore", "")}
+      output: reachable
   - transform:
       value: >-
         "Vector-store MCP server '" + ctx.vectorstore_server + "' is unreachable. It ships as part of the builtin `rag` plugin, not pre-installed -- install it yourself and the operator is prompted at the permission gate: plugin_management__install(source={\"kind\": \"builtin\", \"name\": \"rag\"}). This installs ALL of the rag plugin's capabilities in one call and materialises its dependencies (chonkie/apsw/sqlite-vec) into a dedicated per-plugin environment -- no hand-edited YAML."
+        + join(map(filter([{fired: ctx.reachable.cause != "", text: "\n\n[actual error observed] " + ctx.reachable.cause}], f -> f.fired), f -> f.text), "")
       output: remedy
   - match:
-      on: ctx.vectorstore_reachable
+      on: ctx.reachable.ok
       cases:
         "True":
           pipeline: _query_body
@@ -84,12 +152,13 @@ steps:
 ---
 pipeline: _query_blocked
 description: >-
-  Sibling of query -- returns the pre-flight failure as the run's own
-  (successful) output: a decision-enabling message, never a bare MCP
-  transport exception.
+  Sibling of query/_query_preflight -- returns a pre-flight failure (a
+  missing `db` param, an unreachable vector-store server, or a failed query
+  embed) as the run's own (successful) output: a decision-enabling message
+  naming the actual cause, never a bare transport/field-access exception.
 steps:
   - transform:
-      value: "'rag query blocked -- the vector-store MCP server is unreachable: ' + ctx.message"
+      value: "'rag query blocked: ' + ctx.message"
       output: blocked_reason
 ---
 pipeline: _query_body
@@ -99,6 +168,7 @@ description: >-
 steps:
   - tool:
       name: embed
+      schema: EmbedOk
       args:
         texts: !expr "[ctx.query_text]"
         embedding_model: !expr ctx.embedding_model

--- a/src/reyn/builtin/plugins/rag/skills/build_and_query_rag_corpus/SKILL.md
+++ b/src/reyn/builtin/plugins/rag/skills/build_and_query_rag_corpus/SKILL.md
@@ -101,12 +101,18 @@ Returns a summary: `files_scanned` / `chunks_upserted` / `chunks_removed` /
 with `priced: false` means the model could not be priced -- report it as
 "unknown", never as free.**
 
-**2. Query** -- the same `db` the ingest wrote.
+**2. Query** -- the same `db` the ingest wrote. **The parameter name is
+EXACTLY `db`** -- not `db_path` (the raw vector-store MCP tool's own arg
+name, one layer down) and not `vector_store_path` (a plausible-sounding
+name this pipeline has never accepted). A missing or misnamed `db` is not
+silently ignored: `rag_query.query` returns a blocked message naming this
+exact requirement, but passing the right name the first time saves a
+round trip.
 
 ```
 pipeline__run(name="rag_query.query", input={
   "query_text": "how does X work?",
-  "db": "./rag/docs.sqlite",
+  "db": "./rag/docs.sqlite",                 # EXACT param name: "db"
   "top_k": 5,                                # default 5
 })
 ```

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -54,6 +54,15 @@ Coverage:
      spawns no subprocess at all, and it passes ``max_results`` explicitly
      so a folder larger than ``glob_files``' silent 50-file default cap is
      still ingested whole.
+  7. #2955 weak-model-hardening follow-up (grounded in a live dogfood
+     witness, gh issue 2955's final comments): (a) a missing/misnamed
+     ``db`` query param is diagnosed as a missing-param message, never
+     misdiagnosed as "the vector-store MCP server is unreachable"; (b)
+     ``rag_query``'s pre-flight (ported from ``rag_ingest``'s #3064
+     cause-capture idiom) still blocks with a named remedy on a genuinely
+     unreachable server; (c) a failed query embed (a real provider error)
+     surfaces its own cause at the embed step, not an opaque "field ...
+     absent" crash two steps downstream.
 """
 from __future__ import annotations
 
@@ -293,11 +302,13 @@ def test_rag_ingest_pipeline_parses() -> None:
 
 
 def test_rag_query_pipeline_parses() -> None:
-    """Tier 2b: rag_query.yaml parses -- 3 pipeline: docs (query,
-    _query_blocked, _query_body)."""
+    """Tier 2b: rag_query.yaml parses -- 4 pipeline: docs (query,
+    _query_preflight, _query_blocked, _query_body -- #2955 weak-model-
+    hardening follow-up added _query_preflight, porting rag_ingest's #3064
+    cause-capture pre-flight idiom into query)."""
     docs = parse_pipeline_docs(_QUERY_PATH.read_text(encoding="utf-8"), SchemaRegistry())
     names = {p.name for p in docs}
-    assert names == {"query", "_query_blocked", "_query_body"}
+    assert names == {"query", "_query_preflight", "_query_blocked", "_query_body"}
 
 
 # ---------------------------------------------------------------------------
@@ -595,6 +606,54 @@ def test_rag_query_returns_the_ingested_chunk_as_top_result(
 
 
 # ---------------------------------------------------------------------------
+# 3b. #2955 weak-model-hardening follow-up: a missing/misnamed `db` query
+# param is diagnosed correctly, not misdiagnosed as an unreachable server.
+# ---------------------------------------------------------------------------
+
+
+def test_query_missing_db_param_is_diagnosed_not_misdiagnosed_as_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #2955 -- a live dogfood witness had a weak model call
+    ``rag_query.query`` with an invented param name (``vector_store_path``
+    instead of the correct ``db``), leaving ``ctx.db`` null. Before this
+    fix, that null flowed straight into the MCP pre-flight probe's
+    ``db_path`` arg, the probe call itself errored (not a transport
+    failure), and the run was misdiagnosed as "the vector-store MCP server
+    is unreachable" -- a claim that was simply false (the server was up).
+
+    strip-falsify: reverting ``query``'s explicit ``db_missing`` gate (and
+    routing straight to ``_query_preflight``/the old inline probe) restores
+    the old behavior -- the blocked message says "is unreachable" and never
+    names the missing parameter.
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+
+    args = _ns(
+        name="rag_query.query",
+        # The exact weak-model mistake observed live: a plausible-sounding
+        # but wrong param name instead of `db`.
+        input=json.dumps({"query_text": "banana", "vector_store_path": str(project_root / "rag.sqlite")}),
+        project=str(project_root), async_=False,
+    )
+    run_run(args)
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    blocked = result["named_stores"]["result"]
+    assert isinstance(blocked, str)
+    assert "`db`" in blocked, (
+        f"blocked message must name the exact required param name: {blocked!r}"
+    )
+    assert "is unreachable" not in blocked, (
+        f"a missing param must not be misdiagnosed as a server-down claim: {blocked!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 4. X1 pre-flight: decision-enabling block + falsifying control
 # ---------------------------------------------------------------------------
 
@@ -823,6 +882,129 @@ def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(
     result = _run_ingest(project_root, capsys)  # default vectorstore_server matches config
     summary = result["named_stores"]["result"]
     assert isinstance(summary, dict) and "chunks_upserted" in summary
+
+
+# ---------------------------------------------------------------------------
+# 4c. #2955 weak-model-hardening follow-up: rag_query's OWN pre-flight
+# (ported from rag_ingest's #3064 cause-capture idiom) still blocks with a
+# named remedy on a genuinely unreachable vector-store server.
+# ---------------------------------------------------------------------------
+
+
+def test_query_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #2955 follow-up -- rag_query's own pre-flight (restructured
+    into `_query_preflight`, mirroring rag_ingest's X1) still blocks a
+    genuinely unreachable vectorstore_server with a message naming the
+    server + a concrete remedy, once a valid `db` param rules out the
+    missing-param diagnosis (the sibling test above)."""
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)  # only registers "reyn_vector_store"
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+
+    args = _ns(
+        name="rag_query.query",
+        input=json.dumps({
+            "query_text": "banana",
+            "db": str(project_root / "rag.sqlite"),
+            "vectorstore_server": "not_configured_server",
+        }),
+        project=str(project_root), async_=False,
+    )
+    run_run(args)
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    blocked = result["named_stores"]["result"]
+    assert isinstance(blocked, str)
+    assert "not_configured_server" in blocked
+    assert "plugin_management__install" in blocked, (
+        "the remedy must name a concrete fix, not just the cause"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4d. #2955 weak-model-hardening follow-up: a failed query embed surfaces
+# its own real cause at the embed step, not an opaque "field ... absent"
+# crash two steps downstream.
+# ---------------------------------------------------------------------------
+
+
+class FailingEmbeddingProvider:
+    """A real (non-mock) EmbeddingProvider whose ``embed`` always raises --
+    stands in for a real litellm failure (bad API key / unpriced model /
+    provider outage) without a real network call, mirroring
+    ``FakeEmbeddingProvider`` above (same file, same established pattern)
+    but simulating the FAILURE branch instead of the success one."""
+
+    def __init__(self, message: str) -> None:
+        self._message = message
+        self._batch_size = 100
+
+    async def embed(self, texts: list[str], model: str):
+        raise RuntimeError(self._message)
+
+    def estimate_tokens(self, texts: list[str]) -> int:
+        return sum(len(t) for t in texts)
+
+    def get_dimension(self, model: str) -> int:
+        return 3
+
+
+def test_query_embed_failure_surfaces_the_real_provider_error_not_a_field_absent_crash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+) -> None:
+    """Tier 2b: #2955 follow-up -- when the `embed` op fails (a real
+    provider error, e.g. litellm's own `insufficient_quota` message), the
+    `embed` tool step in `_query_body` is now gated with `schema: EmbedOk`
+    (mirroring #3070's schema-gate idiom), so the raised
+    `PipelineExecutionError` carries the REAL provider error text at the
+    embed step itself.
+
+    Before this fix, an embed failure canonicalized to an empty view (no
+    `meta`, no `structured` -- `embed_to_canonical` only populates those
+    keys on success), and the pipeline crashed two steps later on
+    `find(ctx.embedded.structured, ...)` being absent -- an opaque
+    "path 'embedded.structured' is absent" message with no trace of the
+    real litellm failure.
+
+    strip-falsify: removing `schema: EmbedOk` from `_query_body`'s `embed`
+    step reproduces the old opaque "is absent" crash with the real message
+    (`insufficient_quota: the operator's API key`) nowhere in stderr.
+    """
+    monkeypatch.chdir(tmp_path)
+    project_root = _write_project(tmp_path)
+    docs_dir = project_root / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "a.txt").write_text("content", encoding="utf-8")
+    _run_ingest(project_root, capsys)
+
+    real_message = "insufficient_quota: the operator's API key has no remaining balance"
+    import reyn.core.op_runtime.embed as embed_mod
+    monkeypatch.setattr(
+        embed_mod, "get_provider", lambda *a, **k: FailingEmbeddingProvider(real_message),
+    )
+
+    args = _ns(
+        name="rag_query.query",
+        input=json.dumps({
+            "query_text": "banana",
+            "db": str(project_root / "rag.sqlite"),
+        }),
+        project=str(project_root), async_=False,
+    )
+    with pytest.raises(SystemExit) as exc_info:
+        run_run(args)
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert real_message in err, (
+        f"the real provider error must be surfaced at the embed step: {err!r}"
+    )
+    assert "is absent" not in err, (
+        f"must not regress to the opaque downstream field-absent crash: {err!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[per-PR-coder]** — RAG turnkey **weak-model hardening**, a follow-up on the already-merged FP-0063 RAG work (umbrella issue 2955, which is already in the CLOSED state — this PR carries **no** closing keyword and is not meant to reopen or re-close it). **co-vet = architect** (the pipeline restructure + the param-aliasing decision below are the design-touching pieces).

## 観測 grounding (#2955 の trace 実ミス)

Every change is grounded in the verbatim dogfood witness in #2955's own final comments (raw tool-call log + verbatim prompts), not speculation. The operator-corrected spots = where the weak model went wrong unprompted:

1. **query param 名ミス** — the model invented `vector_store_path` instead of the correct `db`. SKILL.md already documented `db` correctly, so this is a pure model error, not doc drift.
2. **query の 'unreachable' 誤診断** — because of the bad param, a null `db` flowed into the vectorstore pre-flight probe's `db_path` arg; the probe tool call itself errored (not a transport failure), the branch dropped, and the run reported **"vector-store MCP server is unreachable"** — a server-down claim that was simply **false** (the server was up; the DB param was just missing).
3. **embed 失敗の生エラー欠落** — a separate dogfood observation: when the embed op fails (real litellm error, e.g. `insufficient_quota`), the pipeline crashed two steps later on `ctx.embedded.meta.model` / `.structured` being absent (an opaque "field absent" error), discarding the real provider error text.
4. **inline 誤試行 / markitdown** — the model tried `pipeline__run_inline` and did not self-install markitdown. These were already addressed by #3091/#3038; this PR only reinforces the SKILL.md wording without contradicting them.

## 各改善と before/after

### 1. query の 'unreachable' 診断を decision-enabling に (code — `rag_query.yaml`)

A missing/misnamed `db` is now caught **explicitly, before any probe spend**, and the pre-flight probe is restructured into `_query_preflight`, **porting rag_ingest.yaml's #3064/#3070 cause-capture idiom** (existing mechanism reused, not reinvented — a dropped branch's real error text is appended as `[actual error observed] …` evidence to the remedy, never a static string alone).

- **before** (missing `db`): `Vector-store MCP server 'reyn_vector_store' is unreachable. It ships as part of the builtin rag plugin…` ← false server-down claim
- **after** (missing `db`): `Missing required parameter \`db\` (the sqlite file rag_ingest wrote to, i.e. rag_ingest's \`output_db\`). The parameter name is EXACTLY \`db\` — not \`db_path\`, not \`vector_store_path\`. Example: pipeline__run(name="rag_query.query", input={"query_text": "...", "db": "./rag/docs.sqlite"}).`
- **after** (genuinely unreachable server): still blocks with the named remedy **plus** the real probe cause appended as evidence.

### 2. embed 失敗の生エラー surface (code — `rag_ingest.yaml` + `rag_query.yaml`)

The `embed` tool step in `_ingest_embed_and_upsert` / `_query_body` is now gated with a new **`EmbedOk` schema** (`total_tokens` required — present only on a genuine embed success; an error/cancelled embed result carries `status`+`error` instead). This routes a real provider failure through the **same `_run_tool_step` schema-failure detail path #3064/#3070 already built** (`result.get("error")` appended to the raised message).

- **before**: `step 1 (transform) failed: path 'embedded.structured' is absent: no field …` ← real litellm error nowhere
- **after**: `step … (tool 'embed') output failed schema 'EmbedOk': … — the tool's own result: insufficient_quota: the operator's API key has no remaining balance`

### 3. SKILL.md param 明確化 (doc — `build_and_query_rag_corpus/SKILL.md`)

The query example now states inline: **"The parameter name is EXACTLY `db` — not `db_path` (the raw vector-store MCP tool's own arg name, one layer down) and not `vector_store_path` (a plausible-sounding name this pipeline has never accepted)"**, mirroring the existing `pipeline__run` vs `pipeline__run_inline` callout style. Doc improvement only, no new feature; does not contradict #3091's `pipeline__run` correction. The #3090 doc-code sync gate (`test_fp0063_p4_builtin_rag_skill.py`) stays green (verified).

## param aliasing の design 判断 (task item 4)

**Aliasing was NOT added.** Making `rag_query` accept both `db` and `vector_store_path` would change reyn's typed-param contract (reyn prefers a typed, single-named param over form-sniffing synonyms — the constitution's Tool-Contract lens). The explicit missing-`db` diagnostic gate + the SKILL.md clarification address the observed mistake at lower cost and keep the contract closed. **I judged SKILL.md clarification + a decision-enabling diagnostic sufficient and did not implement aliasing unilaterally** — flagging it here for architect co-vet in case the reviewer wants the flexibility trade-off reconsidered.

## strip-falsify

Each message improvement has a real-instance test in `tests/test_fp0063_p3_rag_pipelines.py` (Tier 2b, real pipeline executor + real MCP servers + a real — not mock — `FakeEmbeddingProvider` / `FailingEmbeddingProvider`), each verified by Edit-to-break → restore (no `git checkout`/`stash`):

- `test_query_missing_db_param_is_diagnosed_not_misdiagnosed_as_unreachable` — reverting the `db_missing` gate restores the "is unreachable" misdiagnosis.
- `test_query_preflight_blocks_on_unreachable_vectorstore_with_named_remedy` — falsify control: a genuinely unreachable server still blocks with the named remedy.
- `test_query_embed_failure_surfaces_the_real_provider_error_not_a_field_absent_crash` — removing `schema: EmbedOk` reproduces the opaque "is absent" crash with the real message gone.

## Out of scope (observed, not fixed)

The #2955 no-nudge witness also surfaced two raw operator-facing messages (a hallucinated `main.py` FileNotFoundError from `sandboxed_exec`, and a `glob not permitted (outside project)` denial on a plugin dir). Both are real but sit **outside the 4 enumerated hardening items** the owner scoped; I investigated them (both would be small, targeted fixes) but left them out to keep this PR minimal and focused per the brief. Recorded here so they are not lost.

## Test plan
- [x] `ruff check src tests` → All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_fp0063_p3_rag_pipelines.py` → 20/20 OK
- [x] `python scripts/verify_module_docstrings.py <changed src>` → OK
- [x] `pytest` (full suite, foreground, 600s) → **9056 passed, 29 skipped**
- [x] `pytest tests/test_fp0063_p3_rag_pipelines.py tests/test_fp0063_p4_builtin_rag_skill.py tests/test_2575_pipeline_disk_registration.py tests/test_3028_mcp_stdio_init_timeout.py` → 59 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
