### PR TITLE
refactor(session): Introduce Parameter Object -- 12 flat params -> 4 cohesive objects (#3121 step1)

### DIFF
--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -36,7 +36,12 @@ from typing import TYPE_CHECKING, Any
 from reyn.runtime.agent import Agent
 from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.session import Session
-from reyn.runtime.session_params import CapabilityScope, PresentationWiring, TaskWiring
+from reyn.runtime.session_params import (
+    CapabilityScope,
+    PresentationWiring,
+    ReactivityConfig,
+    TaskWiring,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -107,12 +112,20 @@ def build_scoped_chat_session(
     if _registry is not None:
         from reyn.runtime.services.task_wake import TaskWaker  # noqa: PLC0415
         task_waker = TaskWaker(_registry, base["agent_name"])
-    # #3121 step1: group the scoped capability / task / presentation params into
-    # their cohesive parameter objects at this single construction chokepoint.
-    # ``intervention_bridge`` arrives via ``**base`` (each frontend's
-    # ``_session_factory`` wrapper forwards it) -- popped here so it joins its
-    # PresentationWiring siblings instead of flowing through Session directly.
+    # #3121 step1: group the scoped capability / task / presentation / reactivity
+    # params into their cohesive parameter objects at this single construction
+    # chokepoint. ``intervention_bridge`` and the ``hooks_config``/
+    # ``composers_config``/``fs_watch_config`` reyn.yaml blocks arrive via
+    # ``**base`` (each frontend passes them straight through to
+    # ``build_scoped_chat_session``) -- popped here so they join their
+    # PresentationWiring / ReactivityConfig siblings instead of flowing
+    # through Session as flat params.
     intervention_bridge = base.pop("intervention_bridge", None)
+    reactivity = ReactivityConfig(
+        hooks_config=base.pop("hooks_config", None),
+        composers_config=base.pop("composers_config", None),
+        fs_watch_config=base.pop("fs_watch_config", None),
+    )
     return Session(
         agent=agent,
         environment_backend=environment_backend,
@@ -124,6 +137,7 @@ def build_scoped_chat_session(
         non_interactive=non_interactive,
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
+        reactivity=reactivity,
         capability_scope=CapabilityScope(
             exclude_tools=exclude_tools,
             excluded_categories=excluded_categories,

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING, Any
 from reyn.runtime.agent import Agent
 from reyn.runtime.factory_config import SessionFactoryConfig
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope, PresentationWiring, TaskWiring
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -106,23 +107,38 @@ def build_scoped_chat_session(
     if _registry is not None:
         from reyn.runtime.services.task_wake import TaskWaker  # noqa: PLC0415
         task_waker = TaskWaker(_registry, base["agent_name"])
+    # #3121 step1: group the scoped capability / task / presentation params into
+    # their cohesive parameter objects at this single construction chokepoint.
+    # ``intervention_bridge`` arrives via ``**base`` (each frontend's
+    # ``_session_factory`` wrapper forwards it) -- popped here so it joins its
+    # PresentationWiring siblings instead of flowing through Session directly.
+    intervention_bridge = base.pop("intervention_bridge", None)
     return Session(
         agent=agent,
-        task_waker=task_waker,
         environment_backend=environment_backend,
         sandbox_backend=sandbox_backend,
         workspace_base_dir=workspace_base_dir,
         workspace_state_dir=workspace_state_dir,
-        exclude_tools=exclude_tools,
-        excluded_categories=excluded_categories,
-        contextual_permission=contextual_permission,
         agent_id=agent_id,
         router_max_iterations=router_max_iterations,
         non_interactive=non_interactive,
         eager_embedding_build=eager_embedding_build,
         allowed_mcp=allowed_mcp,
-        task_backend=task_backend,  # #1953 slice R
-        presentation_consumer=presentation_consumer,  # #2708 P1: present-sink consumer (.sink deferred to Session init)
+        capability_scope=CapabilityScope(
+            exclude_tools=exclude_tools,
+            excluded_categories=excluded_categories,
+            contextual_permission=contextual_permission,
+            available_skills=factory_config.available_skills,  # #2548 PR-A
+        ),
+        task_wiring=TaskWiring(
+            task_backend=task_backend,  # #1953 slice R
+            task_waker=task_waker,
+        ),
+        presentation_wiring=PresentationWiring(
+            presentation_registry=factory_config.presentation_registry,  # FP-0054 PR-C
+            presentation_consumer=presentation_consumer,  # #2708 P1: present-sink consumer (.sink deferred to Session init)
+            intervention_bridge=intervention_bridge,
+        ),
         sandbox_config=factory_config.sandbox_config,
         multimodal_config=factory_config.multimodal_config,
         action_retrieval_config=factory_config.action_retrieval_config,
@@ -130,9 +146,7 @@ def build_scoped_chat_session(
         router_config=factory_config.router_config,
         retry_config=factory_config.retry_config,  # #1835
         chat_tool_use_scheme=factory_config.chat_tool_use_scheme,
-        available_skills=factory_config.available_skills,  # #2548 PR-A
         pipeline_registry=factory_config.pipeline_registry,  # #2575
-        presentation_registry=factory_config.presentation_registry,  # FP-0054 PR-C
         observability_config=factory_config.observability_config,  # P5 ADR-0039
         **base,
     )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1321,6 +1321,47 @@ class Session:
             redirect snapshot I/O to a tmp_path without touching private
             attributes.
         """
+        # #3121 step1: resolve the 4 parameter objects against the flat params
+        # they replace. When a caller passes the object, its fields are the
+        # single source (the flat params are then dead pass-through, kept in
+        # the signature only for byte-identical direct/test construction that
+        # has not migrated to the object). When the object is omitted, it is
+        # built from the flat params -- identical to today's per-field
+        # defaults, so this resolution changes no observable behaviour.
+        reactivity = reactivity if reactivity is not None else ReactivityConfig(
+            hooks_config=hooks_config,
+            composers_config=composers_config,
+            fs_watch_config=fs_watch_config,
+        )
+        capability_scope = capability_scope if capability_scope is not None else CapabilityScope(
+            exclude_tools=exclude_tools,
+            excluded_categories=excluded_categories,
+            contextual_permission=contextual_permission,
+            available_skills=available_skills,
+        )
+        task_wiring = task_wiring if task_wiring is not None else TaskWiring(
+            task_backend=task_backend,
+            task_waker=task_waker,
+        )
+        presentation_wiring = (
+            presentation_wiring if presentation_wiring is not None else PresentationWiring(
+                presentation_registry=presentation_registry,
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            )
+        )
+        hooks_config = reactivity.hooks_config
+        composers_config = reactivity.composers_config
+        fs_watch_config = reactivity.fs_watch_config
+        exclude_tools = capability_scope.exclude_tools
+        excluded_categories = capability_scope.excluded_categories
+        contextual_permission = capability_scope.contextual_permission
+        available_skills = capability_scope.available_skills
+        task_backend = task_wiring.task_backend
+        task_waker = task_wiring.task_waker
+        presentation_registry = presentation_wiring.presentation_registry
+        presentation_consumer = presentation_wiring.presentation_consumer
+        intervention_bridge = presentation_wiring.intervention_bridge
         # FP-0043 Stage 2: the identity cluster is owned by the Agent value object,
         # assembled at the build_scoped_chat_session chokepoint and passed in. A
         # direct/test construction without one falls back to building it from the

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1194,21 +1194,6 @@ class Session:
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
         sandbox_config: "SandboxConfig | None" = None,
-        # #1800 slice 5b: the resolved ``hooks:`` config block (the parsed list,
-        # mirroring sandbox_config's seam). None/absent → empty registry → every
-        # HookDispatcher.dispatch() is a no-op (the no-hooks equivalence property).
-        hooks_config: "object | None" = None,
-        # Hook-Event Redesign Phase 4b/5 (proposal 0059 §5/§9, #2880/#2881):
-        # the resolved ``composers:`` config block (the raw parsed-at-load-time
-        # list, mirroring ``hooks_config``'s seam). None/absent → empty list →
-        # ``load_composers`` returns ``[]`` → ``start_composers`` never starts
-        # a Composer (byte-identical to pre-Composer-wiring behavior).
-        composers_config: "object | None" = None,
-        # #2608 H4: the resolved ``fs_watch:`` config block (``FsWatchConfig``,
-        # mirroring ``hooks_config``'s seam). None/absent -> FsWatchConfig()
-        # (paths=[]) -> the session-owned FsWatcher never starts (byte-identical
-        # to pre-H4). OUT-set-only in practice (see reyn.config.infra.FsWatchConfig).
-        fs_watch_config: "object | None" = None,
         # #1200 PR-F1 (agent-level-uniform backend, FS seam): the agent's
         # EnvironmentBackend INSTANCE, threaded to the chat Workspace so chat's
         # file ops run on the SAME backend as the phase path. None → HostBackend (the
@@ -1230,11 +1215,6 @@ class Session:
         sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
-        # #2548 PR-A: enabled skill registry snapshot (list[SkillEntry]), built
-        # from config.skills by SessionFactoryConfig.from_config. Threaded to the
-        # RouterHostAdapter so the router renders the ## Skills block. None → no
-        # skills (byte-identical to no-skills configs / direct test construction).
-        available_skills: Any = None,
         # #1593 PR-2: the chat-layer tool-use scheme name (config.tool_use.chat).
         # Threaded → RouterLoopDriver → RouterLoop(scheme_name=) so the chat
         # router resolves the selected ToolUseScheme. Default "universal-category"
@@ -1257,11 +1237,6 @@ class Session:
         router_config: "RouterConfig | None" = None,
         retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.* timing config
         agent_id: str | None = None,
-        exclude_tools: "frozenset[str] | set[str] | None" = None,  # #187: tool names hidden from the LLM catalog (e.g. web for faithful eval)
-        excluded_categories: "frozenset[str] | set[str] | None" = None,  # #1667: catalog categories hidden at source (e.g. reyn_repo for external-repo eval)
-        contextual_permission: "object | None" = None,  # #1827 S3: per-session capability_profile narrowing (ContextualPermission); from registry.resolved_profile_for; None = byte-identical
-        task_backend: "object | None" = None,  # #1953 slice 3a: session-scoped Task backend instance (injected by the session factory); None → op-runtime in-memory fallback
-        task_waker: "object | None" = None,  # #1953 slice 7: the OS TaskWaker driver (injected by the session factory); None → op-runtime no-op stub
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
         # FP-0043 Stage 5: the conversation session id this Session records WAL
@@ -1279,36 +1254,20 @@ class Session:
         # session). None (direct/test construction) → an empty registry, byte-
         # identical to pre-#2575's own-constructed empty one.
         pipeline_registry: "PipelineRegistry | None" = None,
-        # FP-0054 PR-C: the pre-built PresentationRegistry (operator named templates
-        # from presentations.yaml, built once at the session factory). None
-        # (direct/test construction) → an empty registry (byte-identical to pre-PR-C:
-        # every named template is "unknown" → generic fallback viewer).
-        presentation_registry: "object | None" = None,
-        # #2708 P1: the surface's present-sink CONSUMER. In production every Session is
-        # built via build_scoped_chat_session, which REQUIRES this (no default) — a
-        # frontend cannot silently omit a present sink. None is reachable ONLY by
-        # direct/test construction (forbidden in src/reyn by the #1402 invariant), where
-        # it falls back to the outbox-backed consumer (byte-identical to the pre-#2708
-        # uniform ``OutboxPresentationRenderer(self)`` default). The renderer is obtained
-        # lazily via ``consumer.sink(self)`` (deferred so the outbox sink can bind this
-        # Session, which does not exist when the factory kwarg is passed).
-        presentation_consumer: "object | None" = None,
-        # #2708 P3.2a: the spawn-time intervention BRIDGE (a
-        # ``SpawnBridgeInterventionListener``). None (every non-spawn / detached /
-        # ephemeral construction) keeps today's self-bound fail-closed behavior — the
-        # driver's ``ask_user`` routes through its own listener-less registry. Only the
-        # ATTACHED pipeline driver spawn (``session_api._spawn_pipeline_driver_session``)
-        # passes one, so the driver's router intervention bus dispatches on the PARENT
-        # session's live-operator listener instead of silently auto-refusing (#2721). The
-        # reusable capability-bundle inheritance seam — same threading as
-        # ``presentation_consumer`` (P3.1).
-        intervention_bridge: "object | None" = None,
-        # #3121 step1 (Introduce Parameter Object): cohesive replacements for
-        # the 12 flat params above (hooks_config/composers_config/fs_watch_config,
-        # exclude_tools/excluded_categories/contextual_permission/available_skills,
-        # task_backend/task_waker, presentation_registry/presentation_consumer/
-        # intervention_bridge). None -> built from the flat params (byte-identical
-        # fallback); once a caller passes the object, its fields take precedence.
+        # #3121 step1 (Introduce Parameter Object): 4 cohesive param objects
+        # replacing 12 flat params (see reyn.runtime.session_params for the
+        # per-field rationale each used to carry inline):
+        #   reactivity          -- hooks_config / composers_config / fs_watch_config
+        #   capability_scope    -- exclude_tools / excluded_categories /
+        #                          contextual_permission / available_skills
+        #   task_wiring         -- task_backend / task_waker
+        #   presentation_wiring -- presentation_registry / presentation_consumer /
+        #                          intervention_bridge (REQUIRED in production --
+        #                          build_scoped_chat_session always supplies a
+        #                          presentation_consumer; None is reachable only
+        #                          by direct/test construction)
+        # None -> the object's own all-None defaults (byte-identical to the old
+        # flat-param None defaults).
         reactivity: "ReactivityConfig | None" = None,
         capability_scope: "CapabilityScope | None" = None,
         task_wiring: "TaskWiring | None" = None,
@@ -1321,34 +1280,15 @@ class Session:
             redirect snapshot I/O to a tmp_path without touching private
             attributes.
         """
-        # #3121 step1: resolve the 4 parameter objects against the flat params
-        # they replace. When a caller passes the object, its fields are the
-        # single source (the flat params are then dead pass-through, kept in
-        # the signature only for byte-identical direct/test construction that
-        # has not migrated to the object). When the object is omitted, it is
-        # built from the flat params -- identical to today's per-field
-        # defaults, so this resolution changes no observable behaviour.
-        reactivity = reactivity if reactivity is not None else ReactivityConfig(
-            hooks_config=hooks_config,
-            composers_config=composers_config,
-            fs_watch_config=fs_watch_config,
-        )
-        capability_scope = capability_scope if capability_scope is not None else CapabilityScope(
-            exclude_tools=exclude_tools,
-            excluded_categories=excluded_categories,
-            contextual_permission=contextual_permission,
-            available_skills=available_skills,
-        )
-        task_wiring = task_wiring if task_wiring is not None else TaskWiring(
-            task_backend=task_backend,
-            task_waker=task_waker,
-        )
+        # #3121 step1: default each omitted parameter object to its own
+        # all-None defaults (byte-identical to the old flat-param None
+        # defaults), then unpack into the local names the rest of __init__
+        # reads (unchanged below this point).
+        reactivity = reactivity if reactivity is not None else ReactivityConfig()
+        capability_scope = capability_scope if capability_scope is not None else CapabilityScope()
+        task_wiring = task_wiring if task_wiring is not None else TaskWiring()
         presentation_wiring = (
-            presentation_wiring if presentation_wiring is not None else PresentationWiring(
-                presentation_registry=presentation_registry,
-                presentation_consumer=presentation_consumer,
-                intervention_bridge=intervention_bridge,
-            )
+            presentation_wiring if presentation_wiring is not None else PresentationWiring()
         )
         hooks_config = reactivity.hooks_config
         composers_config = reactivity.composers_config

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -82,6 +82,12 @@ from reyn.runtime.session_buses import (
     AuditOnlyInterventionBridge,
     ChatInterventionBus,
 )
+from reyn.runtime.session_params import (
+    CapabilityScope,
+    PresentationWiring,
+    ReactivityConfig,
+    TaskWiring,
+)
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
 from reyn.task.subscription import SubscriptionWriter
@@ -1297,6 +1303,16 @@ class Session:
         # reusable capability-bundle inheritance seam — same threading as
         # ``presentation_consumer`` (P3.1).
         intervention_bridge: "object | None" = None,
+        # #3121 step1 (Introduce Parameter Object): cohesive replacements for
+        # the 12 flat params above (hooks_config/composers_config/fs_watch_config,
+        # exclude_tools/excluded_categories/contextual_permission/available_skills,
+        # task_backend/task_waker, presentation_registry/presentation_consumer/
+        # intervention_bridge). None -> built from the flat params (byte-identical
+        # fallback); once a caller passes the object, its fields take precedence.
+        reactivity: "ReactivityConfig | None" = None,
+        capability_scope: "CapabilityScope | None" = None,
+        task_wiring: "TaskWiring | None" = None,
+        presentation_wiring: "PresentationWiring | None" = None,
     ) -> None:
         """
         snapshot_path: optional override for the per-agent snapshot file

--- a/src/reyn/runtime/session_params.py
+++ b/src/reyn/runtime/session_params.py
@@ -1,0 +1,66 @@
+"""Cohesive parameter objects for ``Session.__init__``.
+
+``Session`` accepts a large flat parameter list. The four dataclasses below
+group params that are consumed together (same seam, adjacent read sites) so
+the constructor signature carries one object per cohesive concern instead of
+several loose, individually-optional params. Each field keeps the exact
+default/semantics of the flat param it replaces — constructing the object
+with no args reproduces today's byte-identical fallback behaviour.
+
+- ``ReactivityConfig``: the three ``reyn.yaml``-resolved config blocks that
+  drive the session's reactive surfaces (hooks / composers / fs-watch).
+- ``CapabilityScope``: the per-session tool/category/skill visibility
+  narrowing surface (catalog exclusions + the resolved
+  ``ContextualPermission`` + the enabled skill snapshot).
+- ``TaskWiring``: the OS Task subsystem seam (backend instance + waker).
+- ``PresentationWiring``: the present-sink / spawn-intervention wiring
+  (registry + consumer + bridge).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reyn.runtime.presentation_consumer import PresentationConsumer
+
+
+@dataclass(frozen=True)
+class ReactivityConfig:
+    """The resolved ``hooks:`` / ``composers:`` / ``fs_watch:`` config blocks.
+
+    None/absent on any field reproduces the pre-Parameter-Object no-op
+    fallback for that seam (empty hook registry, no Composer started, no
+    FsWatcher path).
+    """
+
+    hooks_config: "object | None" = None
+    composers_config: "object | None" = None
+    fs_watch_config: "object | None" = None
+
+
+@dataclass(frozen=True)
+class CapabilityScope:
+    """The per-session tool/category/skill visibility narrowing surface."""
+
+    exclude_tools: "frozenset[str] | set[str] | None" = None
+    excluded_categories: "frozenset[str] | set[str] | None" = None
+    contextual_permission: "object | None" = None
+    available_skills: Any = None
+
+
+@dataclass(frozen=True)
+class TaskWiring:
+    """The OS Task subsystem seam: the session-scoped backend + waker."""
+
+    task_backend: "object | None" = None
+    task_waker: "object | None" = None
+
+
+@dataclass(frozen=True)
+class PresentationWiring:
+    """The present-sink / spawn-intervention wiring surface."""
+
+    presentation_registry: "object | None" = None
+    presentation_consumer: "PresentationConsumer | None" = None
+    intervention_bridge: "object | None" = None

--- a/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
+++ b/tests/scaffold/test_family3_hook_event_bundle_byte_identical.py
@@ -75,6 +75,7 @@ from reyn.hooks.event import HookEvent
 from reyn.runtime.fs_watcher import FsWatcher
 from reyn.runtime.hot_reload import HotReloader, get_active_hot_reloader
 from reyn.runtime.session import Session, _HookEventBundle
+from reyn.runtime.session_params import ReactivityConfig
 
 _TIMEOUT = 2.0  # bounds every await so a broken wiring fails RED, never hangs
 
@@ -90,8 +91,7 @@ def _make_session(
         agent_name=name,
         state_log=StateLog(tmp_path / f"{name}.wal"),
         snapshot_path=tmp_path / f"{name}.json",
-        hooks_config=hooks_config,
-        composers_config=composers_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=composers_config),
     )
 
 

--- a/tests/test_0060_phase2_f3b_builtin_content.py
+++ b/tests/test_0060_phase2_f3b_builtin_content.py
@@ -65,6 +65,7 @@ from reyn.prompt.router_frame import (
     REYN_CHEAT_SHEET_SKILL_NAME,
     render_mechanism_routing_frame,
 )
+from reyn.runtime.session_params import PresentationWiring
 
 _REPO_ROOT = Path(__file__).parent.parent
 _CHEAT_SHEET_PATH = Path(BUILTIN_SKILLS["reyn_cheat_sheet"]["path"])
@@ -197,8 +198,7 @@ def _agent_registry(tmp_path: Path, state_log, scripted: "_ScriptedAgentReply"):
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             resolver=resolver,

--- a/tests/test_0062_structured_output.py
+++ b/tests/test_0062_structured_output.py
@@ -38,6 +38,7 @@ from reyn.runtime.errors import (
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_agent_step
+from reyn.runtime.session_params import PresentationWiring
 
 _REVIEW_SCHEMA = {
     "fields": {
@@ -94,8 +95,7 @@ def _registry(
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             resolver=_resolver,
         )
         if scripted is not None:

--- a/tests/test_2073_per_agent_hooks.py
+++ b/tests/test_2073_per_agent_hooks.py
@@ -25,6 +25,7 @@ import pytest
 from reyn.config.loader import load_hot_reload_config, load_per_agent_hooks
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _AGENT = "pa-agent"
 _HOOK = "hooks:\n  - on: turn_end\n    template_push:\n      message: {msg}\n      wake: true\n"
@@ -36,7 +37,7 @@ def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
         agent_name=_AGENT,
         state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
     )
 
 

--- a/tests/test_2073_s2b_hooks_seam.py
+++ b/tests/test_2073_s2b_hooks_seam.py
@@ -21,6 +21,7 @@ from reyn.hooks.dispatcher import HookDispatcher
 from reyn.hooks.loader import load_hooks
 from reyn.runtime.hot_reload import validate_in_set
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _HOOK = "hooks:\n  - on: turn_end\n    template_push:\n      message: {msg}\n      wake: true\n"
 
@@ -79,7 +80,7 @@ def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
         agent_name="s2b-agent",
         state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
     )
 
 

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -28,6 +28,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 
 def _registry(tmp_path: Path) -> AgentRegistry:
@@ -40,8 +41,7 @@ def _registry(tmp_path: Path) -> AgentRegistry:
         # response is silently dropped (registry is None).
         return Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
-            presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge,
-        )
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
     holder["reg"] = reg  # set BEFORE any session is constructed (get_or_load / spawn)

--- a/tests/test_2548_skill_hotreload_toggle_pr_b.py
+++ b/tests/test_2548_skill_hotreload_toggle_pr_b.py
@@ -28,6 +28,7 @@ import yaml
 from reyn.core.events.state_log import StateLog
 from reyn.data.skills.registry import SkillEntry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -49,7 +50,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test-agent") -> Session:
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=available_skills,
+        capability_scope=CapabilityScope(available_skills=available_skills),
     )
 
 
@@ -175,10 +176,10 @@ def test_toggle_disable_skill_removes_from_live_list(tmp_path: Path) -> None:
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
             SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
-        ],
+        ]),
     )
     assert "deploy" in _skill_names(session)
 
@@ -198,9 +199,9 @@ def test_toggle_reenable_skill_restores_to_live_list(tmp_path: Path) -> None:
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
-        ],
+        ]),
     )
     session.set_capability_visible("skill", "deploy", False)
     assert "deploy" not in _skill_names(session)
@@ -218,9 +219,9 @@ def test_toggle_disable_unregistered_skill_is_noop(tmp_path: Path) -> None:
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="real-skill", description="real", path="skills/real/SKILL.md"),
-        ],
+        ]),
     )
     # Disable a name that is NOT in the registered set.
     session.set_capability_visible("skill", "nonexistent-skill", False)
@@ -246,9 +247,9 @@ def test_capability_visibility_state_includes_skill_kind(tmp_path: Path) -> None
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
-        ],
+        ]),
     )
     state = session.capability_visibility_state()
     authorized_skills = [e for e in state["authorized"] if e["kind"] == "skill"]
@@ -276,9 +277,9 @@ def test_skill_toggle_persists_to_visibility_yaml(tmp_path: Path) -> None:
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=snap,
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="linter", description="lint", path="skills/linter/SKILL.md"),
-        ],
+        ]),
     )
     session.set_capability_visible("skill", "linter", False)
 
@@ -300,10 +301,10 @@ def test_skill_toggle_restored_by_load_persisted_toggles(tmp_path: Path) -> None
     session_a = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s_a.wal"),
         snapshot_path=snap,
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
             SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
-        ],
+        ]),
     )
     session_a.set_capability_visible("skill", "deploy", False)
 
@@ -311,10 +312,10 @@ def test_skill_toggle_restored_by_load_persisted_toggles(tmp_path: Path) -> None
     session_b = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s_b.wal"),
         snapshot_path=snap,
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="deploy", description="deploy", path="skills/deploy/SKILL.md"),
             SkillEntry(name="review", description="review", path="skills/review/SKILL.md"),
-        ],
+        ]),
     )
     # Before restore the full set is visible (persisted toggle not yet applied).
     assert "deploy" in _skill_names(session_b)
@@ -337,9 +338,9 @@ def test_skill_toggle_persist_clears_when_reenabled(tmp_path: Path) -> None:
     session = Session(
         agent_name="a", state_log=StateLog(tmp_path / "s.wal"),
         snapshot_path=snap,
-        available_skills=[
+        capability_scope=CapabilityScope(available_skills=[
             SkillEntry(name="linter", description="lint", path="skills/linter/SKILL.md"),
-        ],
+        ]),
     )
     session.set_capability_visible("skill", "linter", False)
     vpath = snap.parent / "visibility.yaml"

--- a/tests/test_2575_pipeline_disk_registration.py
+++ b/tests/test_2575_pipeline_disk_registration.py
@@ -72,6 +72,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -626,8 +627,7 @@ async def test_disk_loaded_pipeline_invokable_through_full_live_loop(
             registry=holder.get("reg"), non_interactive=True,
             chat_tool_use_scheme="universal-category",
             pipeline_registry=loaded,  # the config-loaded registry, threaded as the factory would
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2581_pipeline_hotreload.py
+++ b/tests/test_2581_pipeline_hotreload.py
@@ -41,6 +41,7 @@ from reyn.core.pipeline.work_order import PipelineWorkOrder
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -267,8 +268,7 @@ def _worker_registry(tmp_path: Path, state_log: StateLog, pipeline_registry: Pip
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             pipeline_registry=pipeline_registry,

--- a/tests/test_2608_h1_mcp_resource_updated_hook.py
+++ b/tests/test_2608_h1_mcp_resource_updated_hook.py
@@ -27,6 +27,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.mcp.connection_service import MCPConnectionService
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _SUPPORT_DIR = Path(__file__).parent / "_support"
 _SUBSCRIBABLE_SERVER = _SUPPORT_DIR / "mcp_subscribable_resources_server.py"
@@ -52,7 +53,7 @@ def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
         agent_name="test-agent",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
     )
 
 

--- a/tests/test_2608_h3_pipeline_launch_hook.py
+++ b/tests/test_2608_h3_pipeline_launch_hook.py
@@ -52,6 +52,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring, ReactivityConfig
 
 # ---------------------------------------------------------------------------
 # Recording seam (mirrors test_hook_dispatcher_1800_5b.py's _Recorder)
@@ -342,11 +343,10 @@ def _agent_registry_with_hooks(
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            hooks_config=hooks_config, pipeline_registry=pipeline_registry,
+            reactivity=ReactivityConfig(hooks_config=hooks_config), pipeline_registry=pipeline_registry,
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_2608_h4_fs_watcher.py
+++ b/tests/test_2608_h4_fs_watcher.py
@@ -40,6 +40,7 @@ import pytest
 from reyn.hooks.matcher import matches
 from reyn.hooks.schema import ALLOWED_HOOK_POINTS
 from reyn.runtime.fs_watcher import FsWatcher
+from reyn.runtime.session_params import ReactivityConfig
 
 watchdog = pytest.importorskip("watchdog", reason="fs-watch extra ('pip install reyn[fs-watch]') not installed")
 
@@ -352,8 +353,7 @@ async def test_session_owned_watcher_fires_configured_hook_into_inbox(tmp_path):
         agent_name="test-agent",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
-        fs_watch_config=FsWatchConfig(paths=[str(watched_dir)], debounce_seconds=0.05),
+        reactivity=ReactivityConfig(hooks_config=hooks_config, fs_watch_config=FsWatchConfig(paths=[str(watched_dir)], debounce_seconds=0.05)),
     )
     try:
         await session._fs_watcher.start()  # mirrors run()'s own call; started via the public surface below is asserted

--- a/tests/test_2608_h5_cron_webhook_hooks.py
+++ b/tests/test_2608_h5_cron_webhook_hooks.py
@@ -33,6 +33,7 @@ from reyn.runtime.cron.runners import build_default_runner
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 
 class _NoRunAgentRegistry(AgentRegistry):
@@ -48,7 +49,7 @@ def _make_registry(tmp_path: Path, *, hooks_config=None) -> AgentRegistry:
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
     def _factory(profile: AgentProfile) -> Session:
-        s = Session(agent_name=profile.name, state_log=state_log, hooks_config=hooks_config)
+        s = Session(agent_name=profile.name, state_log=state_log, reactivity=ReactivityConfig(hooks_config=hooks_config))
         s.register_intervention_listener("test")
         return s
 

--- a/tests/test_2608_run_loop_pickup.py
+++ b/tests/test_2608_run_loop_pickup.py
@@ -38,6 +38,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
 
@@ -77,7 +78,7 @@ def _make_session(tmp_path: Path, *, hooks_config: list) -> Session:
         agent_name="test-agent",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
     )
 
 

--- a/tests/test_2620_bound_webhook_fire_and_forget.py
+++ b/tests/test_2620_bound_webhook_fire_and_forget.py
@@ -28,6 +28,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.hooks import external_fire
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 
 def _make_session(tmp_path: Path) -> Session:
@@ -35,7 +36,7 @@ def _make_session(tmp_path: Path) -> Session:
         {"on": "webhook_received", "template_push": {"message": "hit from {{ sender }}"}},
     ]
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
-    return Session(agent_name="bound_test_agent", state_log=state_log, hooks_config=hooks_config)
+    return Session(agent_name="bound_test_agent", state_log=state_log, reactivity=ReactivityConfig(hooks_config=hooks_config))
 
 
 async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:

--- a/tests/test_2707_pipeline_present_forwards_to_caller.py
+++ b/tests/test_2707_pipeline_present_forwards_to_caller.py
@@ -46,6 +46,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached
+from reyn.runtime.session_params import PresentationWiring
 
 # A distinctive token carried in the PRESENTED data. Its purpose is to prove the
 # render reached the PARENT surface — it is NOT part of the present op's compact
@@ -82,8 +83,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2708_p31_spawn_bridge_present.py
+++ b/tests/test_2708_p31_spawn_bridge_present.py
@@ -38,6 +38,7 @@ from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
+from reyn.runtime.session_params import PresentationWiring
 
 _MARKER = "REYN2708P31BRIDGEMARKER"
 
@@ -53,8 +54,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2708_p32a_spawn_bridge_intervention.py
+++ b/tests/test_2708_p32a_spawn_bridge_intervention.py
@@ -41,6 +41,7 @@ from reyn.core.pipeline.executor import Pipeline, ToolStep  # noqa: E402
 from reyn.runtime.registry import AgentRegistry  # noqa: E402
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session  # noqa: E402
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run  # noqa: E402
+from reyn.runtime.session_params import PresentationWiring
 
 _QUESTION = "REYN2708P32A which branch?"
 _ANSWER = "REYN2708P32A-the-blue-branch"
@@ -57,8 +58,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_2737_session_spawn_depth_cap.py
+++ b/tests/test_2737_session_spawn_depth_cap.py
@@ -30,6 +30,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_buses import SpawnBridgeInterventionListener
+from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import BridgeToParent
 from tests._support.router_host_adapter import make_adapter
 
@@ -44,8 +45,7 @@ def _registry(tmp_path: Path, state_log: StateLog, *, max_depth: int = 0) -> Age
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(

--- a/tests/test_2761_pr2_hotreload_immediate_apply.py
+++ b/tests/test_2761_pr2_hotreload_immediate_apply.py
@@ -44,6 +44,7 @@ from reyn.runtime.hot_reload import (
     set_active_hot_reloader,
 )
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope
 from reyn.security.permissions.permissions import PermissionDecl
 
 # ---------------------------------------------------------------------------
@@ -80,7 +81,7 @@ def _make_session(tmp_path: Path, *, agent_name: str = "pr2-agent") -> Session:
         agent_name=agent_name,
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        available_skills=available_skills,
+        capability_scope=CapabilityScope(available_skills=available_skills),
         pipeline_registry=pipeline_registry,
     )
 

--- a/tests/test_2769_agent_step_intervention_reaches_invoker.py
+++ b/tests/test_2769_agent_step_intervention_reaches_invoker.py
@@ -55,6 +55,7 @@ from reyn.runtime.session_buses import (
     AuditOnlyInterventionBridge,
     SpawnBridgeInterventionListener,
 )
+from reyn.runtime.session_params import PresentationWiring
 from reyn.schemas.models import PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 from reyn.user_intervention import UserIntervention
@@ -87,8 +88,7 @@ def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRe
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
-            non_interactive=True, presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            non_interactive=True, presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         s._loop_driver._loop_observer = (  # noqa: SLF001 — designed Tier-2 LLM seam
             lambda loop: setattr(loop, "_llm_caller", scripted)

--- a/tests/test_3049_driver_router_op_intervention_reaches_originator.py
+++ b/tests/test_3049_driver_router_op_intervention_reaches_originator.py
@@ -39,6 +39,7 @@ from reyn.intervention_choices import YES, generic_yn_choices
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemeral_session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
@@ -54,8 +55,7 @@ def _registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
-            non_interactive=True, presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            non_interactive=True, presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_3053_budget_bus_bridge_aware.py
+++ b/tests/test_3053_budget_bus_bridge_aware.py
@@ -52,6 +52,7 @@ from reyn.runtime.budget.budget import BudgetCheck
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import DEFAULT_CHAT_CHANNEL_ID, Session
 from reyn.runtime.session_api import _build_agent_step_narrowing, spawn_ephemeral_session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import AuditOnlyNoSurface, BridgeToParent
 
 
@@ -66,8 +67,7 @@ def _registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
-            non_interactive=False, presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            non_interactive=False, presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_3093_pipeline_registry_spawn_propagation.py
+++ b/tests/test_3093_pipeline_registry_spawn_propagation.py
@@ -75,6 +75,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.work_order import pipeline_run_dir, read_result
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import _handle_run_pipeline, _handle_run_pipeline_async
 from reyn.tools.types import RouterCallerState, ToolContext
 
@@ -98,8 +99,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             pipeline_registry=frozen_registry,
         )
         return s

--- a/tests/test_3097_config_projection_refresh_family_gate.py
+++ b/tests/test_3097_config_projection_refresh_family_gate.py
@@ -50,6 +50,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.runtime.spawn_routing import ReviewedNA
 
 
@@ -66,8 +67,7 @@ def _make_registry(tmp_path: Path) -> AgentRegistry:
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             mcp_servers={},
         )
         return s

--- a/tests/test_context_auto_1827_s4b.py
+++ b/tests/test_context_auto_1827_s4b.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.chat_message import ChatMessage
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import CapabilityScope
 from reyn.security.permissions.effective import (
     ContextualPermission,
     tool_contextually_denied,
@@ -30,7 +31,7 @@ def _session(tmp_path: Path, *, contextual=None) -> Session:
         agent_name="alpha",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        contextual_permission=contextual,
+        capability_scope=CapabilityScope(contextual_permission=contextual),
     )
     return s
 

--- a/tests/test_emit_hook_event_0059_phase5_part2.py
+++ b/tests/test_emit_hook_event_0059_phase5_part2.py
@@ -73,6 +73,7 @@ from reyn.core.op_runtime.emit_hook_event import handle as emit_handle
 from reyn.hooks.bus import HookBus
 from reyn.hooks.schema_registry import is_emittable_llm_kind
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 from reyn.schemas.models import EmitHookEventIROp
 from reyn.security.permissions.permissions import PermissionDecl
 from reyn.tools.emit_hook_event import EMIT_HOOK_EVENT
@@ -345,8 +346,7 @@ def _make_session(
         session_id="emit-sess",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
-        composers_config=composers_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=composers_config),
         safety=safety,
     )
 

--- a/tests/test_hook_composed_matcher_schema_2889.py
+++ b/tests/test_hook_composed_matcher_schema_2889.py
@@ -51,6 +51,7 @@ from reyn.hooks.event_pattern import EventPattern, validate_against_schema
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.schema_registry import HookSchemaError
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _DEPLOY_APPROVED_SCHEMAS: "dict[str, frozenset[str]]" = {
     "composed:deploy_approved": frozenset({"inputs", "correlation_key"}),
@@ -224,8 +225,7 @@ def test_session_boot_fails_loud_on_typo_composed_matcher(tmp_path: Path) -> Non
             agent_name="composed-matcher-2889-agent",
             state_log=StateLog(tmp_path / "state.wal"),
             snapshot_path=tmp_path / "snap.json",
-            hooks_config=hooks_config,
-            composers_config=_composer_config(),
+            reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=_composer_config()),
         )
 
 
@@ -244,8 +244,7 @@ def test_session_boot_loads_clean_with_valid_composed_matcher(tmp_path: Path) ->
         agent_name="composed-matcher-2889-agent-ok",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
-        composers_config=_composer_config(),
+        reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=_composer_config()),
     )  # no raise
 
 
@@ -259,8 +258,7 @@ def test_session_boot_fails_loud_on_dangling_composed_subscription(tmp_path: Pat
             agent_name="composed-dangling-2889-agent",
             state_log=StateLog(tmp_path / "state.wal"),
             snapshot_path=tmp_path / "snap.json",
-            hooks_config=hooks_config,
-            composers_config=_composer_config(),  # produces a DIFFERENT composed kind
+            reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=_composer_config()),
         )
 
 

--- a/tests/test_hook_composer_reachability_phase5.py
+++ b/tests/test_hook_composer_reachability_phase5.py
@@ -54,6 +54,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.hooks.loader import HookConfigError, load_hooks
 from reyn.hooks.schema_registry import build_hook_payload
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 _POLL_TIMEOUT = 3.0
 _POLL_INTERVAL = 0.01
@@ -86,8 +87,7 @@ def _make_session(
         agent_name="composer-reachability-agent",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
-        composers_config=composers_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config, composers_config=composers_config),
         safety=safety,
     )
 

--- a/tests/test_hook_dispatcher_1800_5b.py
+++ b/tests/test_hook_dispatcher_1800_5b.py
@@ -24,6 +24,7 @@ from reyn.hooks.dispatcher import HookDispatcher
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.schema import HookDef, PushBlock
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 # ---------------------------------------------------------------------------
 # Recording async callables — real instances (not mocks) for the injected seams
@@ -174,7 +175,7 @@ def _make_session(tmp_path: Path, *, hooks_config=None) -> Session:
         agent_name="test-agent",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=hooks_config,
+        reactivity=ReactivityConfig(hooks_config=hooks_config),
     )
 
 

--- a/tests/test_hook_event_bus_0059_phase4a.py
+++ b/tests/test_hook_event_bus_0059_phase4a.py
@@ -54,6 +54,7 @@ from reyn.hooks.event import HookEvent
 from reyn.hooks.registry import HookRegistry
 from reyn.hooks.schema import HookDef, PushBlock
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 # ---------------------------------------------------------------------------
 # Recording seam (mirrors test_hook_dispatcher_1800_5b.py's _Recorder)
@@ -316,7 +317,7 @@ def _make_session(tmp_path: Path, *, name: str) -> Session:
         agent_name="test-agent",
         state_log=StateLog(tmp_path / f"{name}.wal"),
         snapshot_path=tmp_path / f"{name}.json",
-        hooks_config=None,
+        reactivity=ReactivityConfig(hooks_config=None),
     )
 
 

--- a/tests/test_hook_event_ingress_adapter_0059_phase2.py
+++ b/tests/test_hook_event_ingress_adapter_0059_phase2.py
@@ -53,6 +53,7 @@ from reyn.hooks.schema_registry import BUILTIN_HOOK_SCHEMAS, HookSchemaError
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 
 async def _wait_for(predicate, *, attempts: int = 100, delay: float = 0.02) -> None:
@@ -199,7 +200,7 @@ async def test_cron_adapter_resolve_session_and_deliver_reaches_real_dispatcher(
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
     def _factory(profile: AgentProfile) -> Session:
-        s = Session(agent_name=profile.name, state_log=state_log, hooks_config=hooks_config)
+        s = Session(agent_name=profile.name, state_log=state_log, reactivity=ReactivityConfig(hooks_config=hooks_config))
         s.register_intervention_listener("test")
         return s
 
@@ -233,7 +234,7 @@ async def test_webhook_adapter_resolve_session_and_deliver_reaches_real_dispatch
     state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
 
     def _factory(profile: AgentProfile) -> Session:
-        s = Session(agent_name=profile.name, state_log=state_log, hooks_config=hooks_config)
+        s = Session(agent_name=profile.name, state_log=state_log, reactivity=ReactivityConfig(hooks_config=hooks_config))
         s.register_intervention_listener("test")
         return s
 

--- a/tests/test_pipeline_a2_spawn_ephemeral_session.py
+++ b/tests/test_pipeline_a2_spawn_ephemeral_session.py
@@ -21,6 +21,7 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import spawn_ephemeral_session
+from reyn.runtime.session_params import PresentationWiring
 
 
 def _registry(tmp_path: Path) -> AgentRegistry:
@@ -29,8 +30,7 @@ def _registry(tmp_path: Path) -> AgentRegistry:
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
             agent_name=profile.name, state_log=state_log,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_pipeline_driver_resource_caller_state_2567.py
+++ b/tests/test_pipeline_driver_resource_caller_state_2567.py
@@ -48,6 +48,7 @@ from reyn.core.pipeline.work_order import PipelineWorkOrder
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import PipelineExecutionError
 from reyn.tools.types import build_resource_caller_state
 
@@ -172,8 +173,7 @@ def _worker_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         return Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             mcp_servers={"servers": {"brave": {"command": "true"}}},

--- a/tests/test_pipeline_for_each_primitive.py
+++ b/tests/test_pipeline_for_each_primitive.py
@@ -64,6 +64,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ── happy path: concurrent isolated items, ordered collect, N2 out ───────────
 
@@ -588,8 +589,7 @@ def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgen
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_is2_driver_session.py
+++ b/tests/test_pipeline_is2_driver_session.py
@@ -59,6 +59,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import (
     _handle_run_pipeline,
     _handle_run_pipeline_async,
@@ -93,8 +94,7 @@ def _agent_registry(
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is3_dsl_parser.py
+++ b/tests/test_pipeline_is3_dsl_parser.py
@@ -29,6 +29,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ── plain dataclass-shape contract tests ────────────────────────────────────
 
@@ -283,8 +284,7 @@ def _agent_registry(
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_is4_inline.py
+++ b/tests/test_pipeline_is4_inline.py
@@ -52,6 +52,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import (
     _handle_run_pipeline_inline,
     _handle_run_pipeline_inline_async,
@@ -85,8 +86,7 @@ def _agent_registry(
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_is5_surfacing.py
+++ b/tests/test_pipeline_is5_surfacing.py
@@ -48,6 +48,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 
 def _registry_backed_session(tmp_path: Path):
@@ -69,8 +70,7 @@ def _registry_backed_session(tmp_path: Path):
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             chat_tool_use_scheme="universal-category",
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_pipeline_is6_attached.py
+++ b/tests/test_pipeline_is6_attached.py
@@ -69,6 +69,7 @@ from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.services.pipeline_executor_driver import PipelineExecutorDriver
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached, start_pipeline_run
+from reyn.runtime.session_params import PresentationWiring
 from reyn.tools.pipeline_verbs import _make_tool_dispatch
 from reyn.tools.types import ToolContext
 
@@ -102,8 +103,7 @@ def _agent_registry(
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_pipeline_parallel_primitive.py
+++ b/tests/test_pipeline_parallel_primitive.py
@@ -63,6 +63,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ── happy path: heterogeneous named branches, named-map collect, N2 out ──────
 
@@ -579,8 +580,7 @@ def _agent_registry(tmp_path: Path, state_log: StateLog, scripted: _ScriptedAgen
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
         )

--- a/tests/test_pipeline_r5_agent_step_executor.py
+++ b/tests/test_pipeline_r5_agent_step_executor.py
@@ -35,6 +35,7 @@ from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 
 # ── real-callable LLM stub (Tier 2c: LLM is incidental — see module docstring) ──
 
@@ -74,8 +75,7 @@ def _registry(
 
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
             resolver=resolver,

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -48,6 +48,7 @@ from reyn.runtime.session_api import (
     run_agent_step,
     spawn_ephemeral_session,
 )
+from reyn.runtime.session_params import PresentationWiring
 
 # ── real-callable LLM stub (Tier 2c: LLM is incidental) ─────────────────────
 
@@ -97,8 +98,7 @@ def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRe
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
             resolver=resolver,
         )
         if scripted is not None:

--- a/tests/test_pipeline_tui_bridge_2570.py
+++ b/tests/test_pipeline_tui_bridge_2570.py
@@ -39,6 +39,7 @@ from reyn.runtime.lifecycle_forwarder import ChatLifecycleForwarder
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import run_pipeline_attached
+from reyn.runtime.session_params import PresentationWiring
 from reyn.schemas.models import Event
 
 
@@ -58,8 +59,7 @@ def _agent_registry(tmp_path: Path, state_log: "StateLog") -> AgentRegistry:
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
 
     reg = AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)

--- a/tests/test_present_registry_fp0054_prc.py
+++ b/tests/test_present_registry_fp0054_prc.py
@@ -31,6 +31,7 @@ from reyn.data.presentations.registry import (
 )
 from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import PresentationWiring
 from reyn.schemas.models import ALL_OP_KINDS, PresentIROp
 from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
 
@@ -357,7 +358,7 @@ def _make_session(tmp_path: Path) -> Session:
         agent_name="prc-test",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        presentation_registry=build_presentation_registry(cfg.presentations),
+        presentation_wiring=PresentationWiring(presentation_registry=build_presentation_registry(cfg.presentations)),
     )
 
 

--- a/tests/test_rewind_inflight_disposition_2115.py
+++ b/tests/test_rewind_inflight_disposition_2115.py
@@ -20,6 +20,7 @@ import pytest
 from reyn.core.events.state_log import StateLog
 from reyn.runtime.registry import _count_inflight_disposition
 from reyn.runtime.session import Session
+from reyn.runtime.session_params import ReactivityConfig
 
 
 @pytest.mark.asyncio
@@ -48,7 +49,7 @@ def _make_session(tmp_path: Path) -> Session:
         agent_name="t",
         state_log=StateLog(tmp_path / "state.wal"),
         snapshot_path=tmp_path / "snap.json",
-        hooks_config=None,
+        reactivity=ReactivityConfig(hooks_config=None),
     )
 
 

--- a/tests/test_run_pipeline_tool_is1.py
+++ b/tests/test_run_pipeline_tool_is1.py
@@ -35,6 +35,7 @@ from reyn.llm.pricing import TokenUsage
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import _build_agent_step_narrowing
+from reyn.runtime.session_params import PresentationWiring
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.tools.pipeline_verbs import _handle_run_pipeline
 from reyn.tools.types import RouterCallerState, ToolContext
@@ -68,8 +69,7 @@ def _agent_registry(
         s = Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,  # #2708 P3.2a: accept + forward the attached driver spawn's intervention bridge
+            presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         if scripted is not None:
             s._loop_driver._loop_observer = (

--- a/tests/test_spawn_routing_detached_fail_mode_2708.py
+++ b/tests/test_spawn_routing_detached_fail_mode_2708.py
@@ -41,6 +41,7 @@ from reyn.runtime.session_buses import (
     AuditOnlyInterventionBridge,
     SpawnBridgeInterventionListener,
 )
+from reyn.runtime.session_params import PresentationWiring
 from reyn.user_intervention import UserIntervention
 
 
@@ -54,8 +55,7 @@ def _recording_registry(tmp_path: Path, state_log: "StateLog") -> "tuple[AgentRe
     def _factory(profile, *, presentation_consumer=None, intervention_bridge=None) -> Session:
         s = Session(
             agent_name=profile.name, state_log=state_log, registry=holder.get("reg"),
-            non_interactive=True, presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            non_interactive=True, presentation_wiring=PresentationWiring(presentation_consumer=presentation_consumer, intervention_bridge=intervention_bridge),
         )
         built.append(s)
         return s


### PR DESCRIPTION
**[per-PR-coder]** — #3121 (Session God-object 再設計) step1: **Introduce
Parameter Object**, per `refactoring` skill (owner-provided) + architect's
cohesion-verified design in the issue comments. This is the first
corrective step of the arc that follows #3082 (byte-identical construction
shuffling that grew `session.py` +1199 lines while preserving the
God-object) — co-vet = **architect**.

## What moved (Fowler Introduce Parameter Object, cohesion-verified, no junk-drawer)

`Session.__init__`'s flat param list included 12 params consumed together
at adjacent read-sites (architect's field-usage-span audit). Grouped into
4 new frozen dataclasses in `src/reyn/runtime/session_params.py`:

| New class | Groups (old flat params) |
|---|---|
| `ReactivityConfig` | `hooks_config` / `composers_config` / `fs_watch_config` |
| `CapabilityScope` | `exclude_tools` / `excluded_categories` / `contextual_permission` / `available_skills` |
| `TaskWiring` | `task_backend` / `task_waker` |
| `PresentationWiring` | `presentation_registry` / `presentation_consumer` / `intervention_bridge` |

12 params → 4 objects (**-8 net**: -12 flat, +4 object).

## Fowler tiny-steps (4 separate commits, move ≠ edit, compile+test green at every step)

1. `faf4b429` — define the 4 frozen dataclasses (pure addition, unused).
2. `f55a4cfb` — add the 4 object kwargs to `Session.__init__` with
   `None` defaults, alongside the 12 flat params (byte-identical, still
   unused).
3. `6f4ea5e0` — wire `Session.__init__`'s body to resolve/read from the 4
   objects (object wins when passed, else built from the flats — same
   effective values as before), and update the sole production
   construction chokepoint (`build_scoped_chat_session`, #1402 invariant)
   to pass the grouped objects instead of the 12 flat kwargs.
4. `17d490b9` — remove the 12 flat params from `Session.__init__` (now
   dead) and migrate every remaining direct `Session(...)` construction
   site — 48 test files — from the flat kwargs to the grouped objects, via
   an AST source-span rewrite (mechanical rename, same runtime values, no
   logic edit).

## ★ Measurement gate (whole-file, not per-commit)

| Metric | Before (baseline `main`) | After | Δ |
|---|---|---|---|
| `Session.__init__` param count | 53 | 45 | **-8** |
| `session.py` total lines | 8154 | 8151 | **-3** |
| `Session.__init__` line count | 969 | 960 | -9 |
| `Session.__init__` comment % | 62% (601/969) | 61% (582/960) | ~flat (comment-slimming is arc step2, not this step) |

(Note: the issue's step1 design comment cited baseline param count as 54;
direct `ast` measurement against `origin/main` gives 53 — off-by-one in
the issue text, doesn't change the -8 net delta, which is what the gate
is actually checking.)

New file `src/reyn/runtime/session_params.py`: +67 lines (a real,
independent, cohesion-verified abstraction — not a junk-drawer, not
injected back into `Session` as an unpacked bundle: `Session.__init__`
reads the 4 objects' fields directly).

`session.py` itself is **non-increasing** (net -3) — the gate #3082
skipped, met.

## Move ≠ edit

Every commit is either a pure structural move (dataclass definition,
signature addition, call-site rewrite) or a body-wiring change with
provably identical effective values (steps 2-3 default-fallback
construction of the object from the same flat inputs). No behavioral
edit in this PR.

## Testing

- Tier policy (`testing.ja.md`): pure structural refactor — behavior
  unchanged, so the existing suite is the correctness oracle. No new
  scaffold test added (no new subsystem behavior to pin; the
  `#1402`/`test_scoped_session_factory_invariant_1402.py` and
  `test_2708_p32a_spawn_bridge_intervention.py` /
  `test_2708_p31_spawn_bridge_present.py` etc. suites already exercise
  the grouped-object wiring end-to-end and are unmodified in intent, only
  in calling convention).
- 48 test files migrated from flat kwargs to grouped objects via a
  reviewed AST rewrite script (dry-run diffed on 3 representative files
  before bulk apply — single-param and multi-param-per-group merge cases
  both verified).

### 4 CI gates (local, before push)

- `ruff check src tests` — green.
- `python scripts/test_tier_audit.py --strict <48 changed test files>` —
  431 tests inspected, 0 Tier-4 violations.
- `pytest` (full suite, foreground, `timeout:600000`) — **9066 passed, 29
  skipped, 0 failed**.
- `python scripts/verify_module_docstrings.py <3 changed src files>` — OK.

CI green to be confirmed after push (macOS/Linux + env-dependent gates
per repo policy — will report back).

## Test plan

- [x] Full local `pytest` green (9066 passed / 29 skipped / 0 failed).
- [x] `ruff check src tests` green.
- [x] `test_tier_audit.py --strict` green on all 48 changed test files.
- [x] `verify_module_docstrings.py` green on all 3 changed src files.
- [x] `build_scoped_chat_session` (#1402 sole production chokepoint)
      invariant test green.
- [ ] CI green on GitHub (to confirm after push).

part of #3121
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
