### PR TITLE
fix(test): repair RED main -- fp0063 arc-witness _factory for #3121 step1 PresentationWiring

### DIFF
--- a/tests/test_fp0063_arc_witness.py
+++ b/tests/test_fp0063_arc_witness.py
@@ -406,6 +406,7 @@ def _build_registry(tmp_path: Path, project_root: Path):
     from reyn.llm.model_resolver import ModelResolver
     from reyn.runtime.registry import AgentRegistry
     from reyn.runtime.session import Session
+    from reyn.runtime.session_params import PresentationWiring
     from reyn.security.permissions.permissions import PermissionResolver
 
     state_log = StateLog(project_root / ".reyn" / "wal.jsonl")
@@ -465,8 +466,12 @@ def _build_registry(tmp_path: Path, project_root: Path):
         return Session(
             agent_name=profile.name, state_log=state_log,
             registry=holder.get("reg"), non_interactive=True,
-            presentation_consumer=presentation_consumer,
-            intervention_bridge=intervention_bridge,
+            # #3121 step1 folded presentation_consumer / intervention_bridge into
+            # the PresentationWiring parameter object.
+            presentation_wiring=PresentationWiring(
+                presentation_consumer=presentation_consumer,
+                intervention_bridge=intervention_bridge,
+            ),
             resolver=resolver, permission_resolver=perm_resolver,
             sandbox_config=sandbox_config,
         )


### PR DESCRIPTION
**[per-PR-coder]** — **hotfix for a currently-RED main**, discovered while verifying CI on the #3121 step2 PR (#3124).

## The breakage

`origin/main` HEAD (815462c8, the #3121 step1 merge) is **RED** on `pytest (Python 3.11)` and `pytest (Python 3.12)`:

```
E  TypeError: Session.__init__() got an unexpected keyword argument 'presentation_consumer'
   tests/test_fp0063_arc_witness.py:465
1 failed, 9056 passed, 39 skipped
```

Verified on the actual main test.yml run (run 29662564068, SHA 815462c8) — both Linux pytest jobs failed. This blocks every downstream PR's CI, including #3124.

## Root cause (merge-ordering regression)

- #3122 landed `tests/test_fp0063_arc_witness.py` with a session `_factory` passing `presentation_consumer=` / `intervention_bridge=` **directly** to `Session(...)`.
- #3123 (#3121 **step1**, Introduce Parameter Object) then folded those two flat kwargs into the `PresentationWiring` parameter object — removing them from `Session.__init__`'s signature.
- Because #3122 merged **before** #3123, and #3123's own PR CI predated the test's arrival on main, this helper was never updated. The regression only surfaced once both were on main together.

(The test module is `pytest.importorskip`-gated on the `builtin-rag` extra — apsw/chonkie/sqlite_vec — which CI installs, so it runs on CI[Linux]; it is not skipped.)

## The fix

Wrap the two kwargs into `PresentationWiring(presentation_consumer=..., intervention_bridge=...)` and pass `presentation_wiring=`, exactly as step1 intends. The registry→factory contract (`_factory`'s own `*, presentation_consumer, intervention_bridge` signature) and the `spawn_ephemeral_session` API are **unchanged** — only what `_factory` does internally with the two kwargs changes.

## Gates

- `pytest tests/test_fp0063_arc_witness.py` — **1 passed** (11.7s local, builtin-rag extra installed).
- `ruff check tests/test_fp0063_arc_witness.py` — passed.
- `python scripts/test_tier_audit.py --strict tests/test_fp0063_arc_witness.py` — OK (Tier 3a, exit 0).

## Why separate from #3124

#3124 (step2 comment-slim) is a deliberately **pure comment-edit** PR whose review centers on a "zero code-line changed" proof; this test-helper fix is unrelated step1 fallout and belongs in its own PR so both stay cleanly reviewable. Merging this unblocks #3124's CI (and all other PRs) from the RED main.

part of #3121

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>