### PR TITLE
fix: bucket restore_all WAL replay by (agent, session_id) (#2946 item 2)

### DIFF
--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -212,12 +212,39 @@ class AgentSnapshot:
         ``session_id`` defaults to "main" when absent (legacy entries written
         pre-S5, and the default single session) — so legacy entries deterministically
         replay into the agent's "main" session, and a spawned session only absorbs
-        its own entries. This is the per-session replay-determinism guarantee."""
-        agent_matches = (
-            event.get("target") == self.agent_name
-            or event.get("agent") == self.agent_name
-        )
-        return agent_matches and event.get("session_id", "main") == self.session_id
+        its own entries. This is the per-session replay-determinism guarantee.
+
+        #2946 item 2: delegates to ``event_route_key`` (the single source of truth
+        for the routing rule) so a bucketing caller (``registry.restore_all``) can
+        pre-sort a WAL tail by (agent, session) WITHOUT re-deriving — and risking
+        drift from — this matching rule."""
+        return self.event_route_key(event) == (self.agent_name, self.session_id)
+
+    @staticmethod
+    def event_route_key(event: dict) -> "tuple[str, str] | None":
+        """The (agent_name, session_id) bucket a WAL ``event`` routes to, or
+        ``None`` if it carries neither ``target`` nor ``agent`` (never matches
+        any snapshot — same as ``_matches_agent`` returning False for every
+        snapshot).
+
+        #2946 item 2: ``restore_all`` calls this ONCE per WAL entry to bucket
+        the shared tail by (agent, session) up front, so each snapshot applies
+        only its own bucket instead of re-walking the whole tail and calling
+        ``_matches_agent`` on every OTHER agent's entries too (the O(agents ×
+        tail) re-scan the issue describes). Mirrors ``_matches_agent``'s rule
+        exactly: falls back from ``target`` to ``agent`` (the two are written
+        mutually-exclusively — ``SnapshotJournal``'s single WAL-append
+        chokepoint passes exactly one per call — so this is equivalent to the
+        boolean-or `agent_matches` it replaces, not a precedence choice over a
+        case that occurs), and ``session_id`` defaults to "main" when absent
+        (the same legacy/default-session fallback ``_matches_agent`` documents
+        above)."""
+        agent_name = event.get("target")
+        if agent_name is None:
+            agent_name = event.get("agent")
+        if agent_name is None:
+            return None
+        return (agent_name, event.get("session_id", "main"))
 
     def _apply_one(self, event: dict) -> None:
         kind = event.get("kind")

--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -1132,13 +1132,26 @@ class AgentRegistry:
         if not all_snaps:
             return {}
 
-        # 2-3. WAL replay from min(applied_seq) + 1. Each snapshot's
-        # _matches_agent now filters by (agent, session_id), so a shared WAL tail
-        # routes every entry to exactly its (name, sid) snapshot.
+        # 2-3. WAL replay from min(applied_seq) + 1.
+        # #2946 item 2: read the shared tail ONCE, then bucket it by (agent,
+        # session_id) — ``AgentSnapshot.event_route_key`` — BEFORE handing entries
+        # to snapshots. Handing every snapshot the same full `wal_entries` list (the
+        # prior shape) made EACH snapshot's `apply_events` walk the WHOLE tail and
+        # call `_matches_agent` on every OTHER (agent, session)'s entries too — an
+        # O(agents × tail) re-scan where one lagging idle agent's low applied_seq
+        # widens the tail for every OTHER agent's walk as well. Bucketing makes the
+        # tail-walk O(tail) once (one route_key lookup per entry) and each
+        # snapshot's apply O(its own bucket) — O(tail) total, not O(agents × tail).
+        # Structural, not a census fix: this holds regardless of how many (agent,
+        # session) pairs restore_all discovers.
         min_seq = min(s.applied_seq for s in all_snaps.values())
-        wal_entries = list(self._state_log.iter_from(min_seq + 1))
-        for snap in all_snaps.values():
-            snap.apply_events(wal_entries)
+        buckets: dict[tuple[str, str], list[dict]] = {}
+        for event in self._state_log.iter_from(min_seq + 1):
+            key = AgentSnapshot.event_route_key(event)
+            if key is not None:
+                buckets.setdefault(key, []).append(event)
+        for key, snap in all_snaps.items():
+            snap.apply_events(buckets.get(key, ()))
 
         # 4. Save the post-replay snapshots back to their per-session paths.
         for (name, sid), snap in all_snaps.items():

--- a/tests/test_2946_item2_restore_all_bucketing.py
+++ b/tests/test_2946_item2_restore_all_bucketing.py
@@ -1,0 +1,212 @@
+"""Tier 2: #2946 item 2 — ``restore_all`` (agent, session_id) bucketing, truncate-falsify.
+
+Prior shape: ``restore_all`` computed ONE ``min_seq`` across every discovered
+(agent, session) snapshot, materialised the shared WAL tail once, then handed
+the SAME full tail list to EVERY snapshot's ``apply_events`` — which walks the
+WHOLE list and calls ``_matches_agent`` per entry regardless of whether the
+entry belongs to that snapshot. One lagging/idle agent's low ``applied_seq``
+widens the tail for every OTHER agent's O(tail) walk too: O(agents × tail).
+
+Fix: bucket the shared tail by ``AgentSnapshot.event_route_key`` (agent,
+session_id) ONCE, then hand each snapshot only its own bucket — O(tail) total.
+
+This test is a structural correctness proof for the bucketing (not a timing
+benchmark): it proves reconstruction is IDENTICAL to the pre-fix behavior —
+each (agent, session) restores exactly its own state, no cross-contamination
+— AND is the CLAUDE.md recovery-feature PR gate truncate-falsify: the
+architect-specified regression point is ``_matches_agent``'s ``session_id``
+defaulting to "main" for entries written WITHOUT a session_id field (legacy
+pre-FP-0043-Stage-5 WAL entries). A bucketing implementation that keys on
+``event.get("session_id")`` WITHOUT the "main" default would silently drop
+such an entry into a bucket no snapshot claims (key ``(agent, None)``) —
+this test's session_id-less entry would then vanish from EVERY reconstruction,
+not just survive-across-truncation. Real StateLog / AgentRegistry / Session
+throughout (no mocks).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+
+AGENT = "alpha"
+
+
+def _make_registry(tmp_path: Path, wal: Path) -> AgentRegistry:
+    """A fresh registry over the SAME project_root + WAL file simulates a
+    process restart: it re-discovers on-disk snapshots and replays the WAL
+    tail (mirrors ``tests/test_multi_session_restore.py``)."""
+    state_log = StateLog(wal)
+
+    def _factory(profile: AgentProfile) -> Session:
+        s = Session(agent_name=profile.name, state_log=state_log)
+        s.register_intervention_listener("test")
+        return s
+
+    return AgentRegistry(
+        project_root=tmp_path,
+        session_factory=_factory,
+        state_log=state_log,
+    )
+
+
+def _iv_dict(iv_id: str, run_id: str) -> dict:
+    return {
+        "kind": "ask_user",
+        "prompt": f"Q-{iv_id}?",
+        "detail": "",
+        "choices": [],
+        "suggestions": [],
+        "run_id": run_id,
+        "actor": "demo",
+        "id": iv_id,
+    }
+
+
+def _active_iv_ids(session: "Session") -> list[str]:
+    return [iv.id for iv in session.interventions.list_active()]
+
+
+
+
+@pytest.mark.asyncio
+async def test_restore_all_buckets_by_agent_session_and_survives_truncation(tmp_path, monkeypatch):
+    """Tier 2: #2946 item 2 truncate-falsify (CLAUDE.md recovery-feature PR gate).
+
+    Set up main + a spawned session under one agent, each with distinct state
+    plus ONE session_id-less (legacy pre-S5) WAL entry that must default into
+    the MAIN bucket. Reconstruct once (bakes everything into durable
+    per-session snapshots via the bucketed replay), truncate the WAL BELOW
+    every source event, then reconstruct again from a FRESH registry over the
+    SAME (now-truncated) WAL + on-disk snapshots. All three pieces of state —
+    main's intervention, the spawned session's intervention, AND the legacy
+    session_id-less inbox message — must survive, each still attached to
+    exactly its own (agent, session) bucket (no cross-contamination).
+    """
+    monkeypatch.chdir(tmp_path)
+
+    agent_dir = tmp_path / ".reyn" / "agents" / AGENT
+    agent_dir.mkdir(parents=True)
+    AgentProfile.new(AGENT, role="").save(agent_dir)
+    wal = tmp_path / ".reyn" / "wal.jsonl"
+
+    # ── run 1: assign distinct state to main + a spawned session ──
+    reg1 = _make_registry(tmp_path, wal)
+    main1 = reg1.get_or_load(AGENT)
+    sid = reg1.spawn_session(AGENT, presentation_consumer=None, intervention_bridge=None)
+    spawned1 = reg1.get_session(AGENT, sid)
+    assert spawned1 is not None
+
+    await main1.journal.record_intervention_dispatched(
+        intervention_id="iv_main", iv_dict=_iv_dict("iv_main", "rM"),
+    )
+    await spawned1.journal.record_intervention_dispatched(
+        intervention_id="iv_spawn", iv_dict=_iv_dict("iv_spawn", "rS"),
+    )
+    await main1.journal.flush()
+
+    # a session_id-LESS entry (bypasses SnapshotJournal's funnel, which always
+    # injects session_id=) — simulates a legacy pre-FP-0043-Stage-5 WAL entry.
+    # `event_route_key`'s "main" default must route this into main's bucket.
+    # Uses `intervention_dispatched` (like iv_main/iv_spawn above) rather than
+    # `inbox_put`, hermetically — a restored `outstanding_intervention` just
+    # re-enqueues for the user to answer, unlike a restored inbox message
+    # (which can trigger a LIVE LLM turn on `ensure_running`, per
+    # `test_multi_session_restore.py`'s docstring on this same hazard).
+    state_log1 = reg1._state_log
+    assert state_log1 is not None
+    await state_log1.append(
+        "intervention_dispatched", target=AGENT,
+        intervention_id="iv_legacy", iv_dict=_iv_dict("iv_legacy", "rL"),
+    )
+    await state_log1.flush()
+    await state_log1.aclose()
+
+    # ── reconstruct #1: bakes the legacy entry's effect into the durable
+    # per-session snapshots via the bucketed replay (this is what makes it
+    # survive a LATER truncation — snapshot-backed, not WAL-derived). ──
+    reg2 = _make_registry(tmp_path, wal)
+    await reg2.restore_all()
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    main2 = reg2.get_session(AGENT)
+    spawned2 = reg2.get_session(AGENT, sid)
+    assert main2 is not None and spawned2 is not None
+    assert sorted(_active_iv_ids(main2)) == ["iv_legacy", "iv_main"], (
+        "sanity: the legacy session_id-less entry must bucket into MAIN alongside iv_main"
+    )
+    assert _active_iv_ids(spawned2) == ["iv_spawn"], (
+        "sanity: the legacy entry must NOT leak into the spawned bucket"
+    )
+
+    state_log2 = reg2._state_log
+    assert state_log2 is not None
+
+    # the source events (iv_main / iv_spawn / iv_legacy dispatch) are durable
+    # below this point pre-truncation.
+    pre_truncate_lines = [ln for ln in wal.read_text().splitlines() if ln.strip()]
+    assert any('"iv_legacy"' in ln for ln in pre_truncate_lines), (
+        "sanity: the iv_legacy source event must be durable pre-truncation"
+    )
+
+    # push filler far past every source event, then truncate BELOW them all.
+    for i in range(150):
+        await state_log2.append("inbox_put", target="filler-agent", n=i)
+    floor = state_log2.current_seq - 5
+    await state_log2.truncate_below(floor)
+    await state_log2.flush()
+    stats = state_log2.last_truncate_stats
+    assert stats["dropped"] >= 140, f"filler + source events must be truncated; dropped={stats['dropped']}"
+
+    post_truncate_lines = [ln for ln in wal.read_text().splitlines() if ln.strip()]
+    assert not any('"iv_legacy"' in ln for ln in post_truncate_lines), (
+        "the iv_legacy source event must actually be GONE from the WAL post-truncation "
+        "(not just counted) — else this test would pass vacuously even for a "
+        "WAL-derived (non-snapshot-backed) design"
+    )
+    assert not any('"iv_main"' in ln for ln in post_truncate_lines)
+    assert not any('"iv_spawn"' in ln for ln in post_truncate_lines)
+
+    await state_log2.aclose()  # simulate the crash: tear down run2's WAL worker
+
+    # ── reconstruct #2: fresh registry over the SAME (now-truncated) WAL +
+    # on-disk snapshots. All three pieces of state must survive AND stay
+    # correctly bucketed — this is what would go RED if the bucketing
+    # implementation dropped the session_id "main" default (iv_legacy would
+    # vanish entirely — its post-#2946 bucket key would be (AGENT, None),
+    # which no snapshot's (AGENT, "main") key matches) or cross-routed
+    # entries between (agent, session) buckets. ──
+    reg3 = _make_registry(tmp_path, wal)
+    await reg3.restore_all()
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    main3 = reg3.get_session(AGENT)
+    spawned3 = reg3.get_session(AGENT, sid)
+    assert main3 is not None, "main session must survive truncation below its source events"
+    assert spawned3 is not None, "spawned session must survive truncation below its source events"
+
+    assert sorted(_active_iv_ids(main3)) == ["iv_legacy", "iv_main"], (
+        "main's interventions (INCLUDING the session_id-less legacy one) must survive WAL "
+        "truncation, snapshot-backed rather than WAL-derived, and still default into MAIN's "
+        "bucket post-reconstruction (the architect-specified regression point)"
+    )
+    assert _active_iv_ids(spawned3) == ["iv_spawn"], (
+        "spawned session's intervention must survive WAL truncation, isolated from main, "
+        "with no leakage of the legacy entry into the spawned bucket"
+    )
+    # cross-contamination guard, both directions (mirrors test_multi_session_restore.py).
+    assert "iv_spawn" not in _active_iv_ids(main3)
+    assert "iv_main" not in _active_iv_ids(spawned3)
+    assert "iv_legacy" not in _active_iv_ids(spawned3)
+
+    reg3_state_log = reg3._state_log
+    assert reg3_state_log is not None
+    await reg3_state_log.aclose()


### PR DESCRIPTION
**[per-PR-coder]** — `part of #2946` (Item 2 のみ。#2946 は複数 item の umbrella ゆえ `Closes` にはしません)。co-vet = architect。

## Item 2 = `restore_all` の (agent, session_id) bucket 化

### 問題(#2946 コメントで確定)
`restore_all` は全 snapshot 横断で1つの `min_seq` を計算し、その後 **同じ WAL tail 全体を各 snapshot の `apply_events` に渡していました**。`apply_events` は tail 全体を walk し、各 entry について `_matches_agent` を(自分のものでなくても)呼びます。∴ **1つの lagging idle agent の低い `applied_seq` が min_seq を下げると、その広い tail を全 agent が walk させられる** = O(agents × tail)。

### 修正(構造 fix、census ではない)
共有 tail を **一度だけ read** し、`AgentSnapshot.event_route_key`(agent, session_id)で **前もって bucket 化** → 各 snapshot には **自分の bucket だけ** を渡します。
- tail-walk は route_key lookup 1回/entry で O(tail)、各 snapshot の apply は O(自分の bucket) → 合計 **O(tail)**(O(agents × tail) ではない)。
- #2948 が確立した標準に従い、**「今 caller が N 個だけ」という census 論法に依らず** 成立(discover される (agent, session) pair 数に無関係)。
- `event_route_key` を routing rule の **単一の真実源** とし、`_matches_agent` はこれに委譲。∴ bucketing caller が matching rule(特に `session_id → "main"` legacy default)から drift できません。

### before / after(走査量)
- before: 各 snapshot が `min(applied_seq)+1..tail` 全体を walk → **O(agents × tail)**。
- after: tail を1回 bucket 化(O(tail))+ 各 snapshot は自分の bucket のみ apply → **O(tail)**。

### behavior 不変
再構成結果は完全に同一(各 (agent, session) が自分の state のみを復元、cross-contamination なし)。走査量だけが削減されます。full-suite green(9029 passed, 29 skipped)。

## ★ truncate-falsify test(CLAUDE.md Recovery-feature PR gate — 同 PR)
`tests/test_2946_item2_restore_all_bucketing.py`(Tier 2)。

**set → truncate → survive-assert**:
1. **set X**: 1 agent 下に main + spawned session を作り、各々に intervention(`iv_main` / `iv_spawn`)。さらに **SnapshotJournal の funnel を迂回した `session_id` 無しの legacy intervention(`iv_legacy`)** を WAL に直書き — pre-FP-0043-S5 の legacy entry を模擬。一度 `restore_all` して durable per-session snapshot に焼き込む。
2. **truncate**: filler 150件を積み、`iv_main` / `iv_spawn` / `iv_legacy` の source events **より下に** WAL を truncate(post-truncate に3件が WAL から消えていることを assert = vacuous pass 防止)。
3. **survive-assert**: 新 registry で再 `restore_all` → 3件全て生存し、かつ **`iv_legacy` が MAIN bucket に正しく入る**(architect 指定の regression 点 = `session_id → "main"` defaulting が bucketing 後も保存される)。spawned bucket への leak 無しも両方向 assert。

**RED-on-strip 確認済**: `event_route_key` を naive な `event.get("session_id")`(main default 無し)に一時的に差し替えると、`iv_legacy` の key が `(agent, None)` になり `(agent, "main")` snapshot に match せず消失 → test RED。機構を戻すと green。∴ load-bearing。mock なし(real StateLog / AgentRegistry / Session)、private state assert なし(public surface: `interventions.list_active()` 経由)。

## Test plan
- [x] `ruff check src tests` green
- [x] `python scripts/test_tier_audit.py --strict tests/test_2946_item2_restore_all_bucketing.py` green(1 test, 0 error)
- [x] `python scripts/verify_module_docstrings.py <changed src>` green
- [x] full `pytest` foreground green(9029 passed, 29 skipped, 352s)
- [x] truncate-falsify RED-on-strip を Edit で機構破壊 → 確認 → 復元
- [ ] (co-vet=architect) truncate-falsify の RED-on-strip 独立確認 + full-suite

co-vet CLEAR + CI[Linux] green まで merge しません。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
