### PR TITLE
perf(cold-start): tail-read StateLog seq watermark, full-scan fallback (#2946 item 1)

### DIFF
--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -658,14 +658,79 @@ class StateLog:
                 "min_kept_seq": min_kept, "max_kept_seq": max_kept}
 
     def _scan_max_seq(self) -> int:
-        """Initialize the counter from the highest seq present in the WAL.
+        """Initialize the counter from the highest seq present in the WAL — cold-start
+        recovery of the seq watermark, BLOCKING, before the event loop starts (#2946 Item 1).
 
-        Read the whole file once at construction. Cheap for typical sizes
-        (millions of small lines = ~hundreds of MB), which we're nowhere
-        near. WAL truncation is OOS for PR21.
+        Tries a **tail read** first: appends are seq-monotonic in file order (each
+        ``_wal_write_job`` increments the counter and appends immediately — the file is
+        never written out of seq order), and ``_do_truncate`` preserves that ordering
+        (a single forward streaming pass over survivors, in their original relative
+        order) while ALWAYS keeping the highest seq present (its ``effective_floor``
+        never drops it — see ``_do_truncate``'s watermark comment) — so the last
+        well-formed entry in the file is always the max seq, whether or not
+        ``always_keep_kinds`` entries (e.g. a ``rewind`` reset-record) also survive
+        below the truncation floor elsewhere in the file. Reading backward from EOF in
+        a growing window (skip a possibly-torn trailing line from a prior crash, same
+        tolerance as ``iter_from``) therefore reaches that entry in O(tail), not
+        O(WAL) — the win for a long-running session's cold start.
+
+        Falls back to the full O(WAL) scan (``_full_scan_max_seq``, the original
+        PR21 implementation) whenever the tail read cannot establish a definite
+        answer from disk (an ``OSError`` mid-read — e.g. a concurrent external
+        rewrite of the file) or reports "empty/no valid entries", since that is
+        indistinguishable from "genuinely empty" without walking the rest of the
+        file. The two paths MUST return identical values for every file — this is a
+        behavior-preserving optimization of the same reconstruction, not a new
+        derivation.
         """
         if not self._path.is_file():
             return 0
+        tail_max = self._tail_scan_max_seq()
+        if tail_max is not None:
+            return tail_max
+        return self._full_scan_max_seq()
+
+    def _tail_scan_max_seq(self, chunk_size: int = 65536) -> "int | None":
+        """Read the WAL backward from EOF, in a doubling window, for the last
+        well-formed ``seq``-bearing entry. Returns ``None`` (triggering the
+        ``_full_scan_max_seq`` fallback) on any I/O error, or once the ENTIRE file has
+        been read this way without finding a single valid entry — that case is cheap
+        to detect (no cost beyond what a full scan would already pay) but is left to
+        the full scan to resolve so there is exactly one code path that decides
+        "the WAL has no usable seq at all" (`0`)."""
+        try:
+            size = self._path.stat().st_size
+        except OSError:
+            return None
+        if size == 0:
+            return 0
+        try:
+            with self._path.open("rb") as f:
+                read_size = min(chunk_size, size)
+                while True:
+                    f.seek(-read_size, os.SEEK_END)
+                    data = f.read(read_size)
+                    read_whole_file = read_size >= size
+                    lines = data.split(b"\n")
+                    # The window may start mid-line unless it spans the whole file —
+                    # drop that leading fragment so we never mis-parse a partial line
+                    # as a (wrong) valid entry.
+                    usable = lines if read_whole_file else lines[1:]
+                    for raw in reversed(usable):
+                        entry = _parse_wal_line(raw)
+                        if entry is not None:
+                            return entry["seq"]
+                    if read_whole_file:
+                        return None
+                    read_size = min(read_size * 2, size)
+        except OSError:
+            return None
+
+    def _full_scan_max_seq(self) -> int:
+        """The original PR21 scan: read every line, json.loads it, and take the
+        max ``seq`` seen. O(WAL) — the fallback ``_tail_scan_max_seq`` exists to avoid
+        paying on cold start; kept here verbatim as the source of truth its result
+        must match."""
         max_seq = 0
         try:
             with self._path.open("r", encoding="utf-8") as f:

--- a/tests/test_2946_item1_state_log_tail_scan.py
+++ b/tests/test_2946_item1_state_log_tail_scan.py
@@ -1,0 +1,183 @@
+"""Tests for StateLog._scan_max_seq's tail-read optimization (#2946 Item 1).
+
+Tier 2: OS invariant — the cold-start seq-watermark recovery (`StateLog.__init__` →
+`_scan_max_seq`) must recover EXACTLY the same `max_seq` a full O(WAL) scan would,
+via a cheaper O(tail) backward read, including across a WAL truncation that keeps
+`always_keep_kinds` entries below the truncation floor (CLAUDE.md Recovery-feature
+PR gate: any PR touching WAL-event-derived recovery state needs a truncate-falsify
+test — set X, truncate past X's events, reconstruct, assert X survives).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from reyn.core.events.snapshot_generations import REWIND_KIND
+from reyn.core.events.state_log import StateLog
+
+
+def test_scan_max_seq_empty_wal_is_zero(tmp_path):
+    """Tier 2: no WAL file on disk — current_seq starts at 0 (edge case: empty)."""
+    log = StateLog(tmp_path / "wal.jsonl")
+    assert log.current_seq == 0
+
+
+def test_scan_max_seq_matches_full_scan_on_fresh_wal(tmp_path):
+    """Tier 2: after a batch of appends (no truncation), a freshly-constructed
+    StateLog over the same file recovers the max_seq a full scan would have found
+    (the tail-read and full-scan paths must agree here too, not only in the
+    truncated-WAL case)."""
+    path = tmp_path / "wal.jsonl"
+    log = StateLog(path)
+
+    async def go():
+        for i in range(1, 51):
+            await log.append("inbox_put", target=f"a{i}", payload={"i": i})
+        await log.flush()
+
+    asyncio.run(go())
+
+    log2 = StateLog(path)
+    assert log2.current_seq == 50
+
+
+def test_scan_max_seq_survives_truncate_with_always_keep_kinds_below_floor(tmp_path):
+    """Tier 2: ★ truncate-falsify (CLAUDE.md Recovery-feature PR gate).
+
+    Hazard (architect, #2946 scope comment): `_do_truncate` preserves the highest
+    seq present as a watermark AND keeps `always_keep_kinds` entries (e.g. a
+    `rewind` reset-record) below the truncation floor. A naive tail-read that
+    special-cases `always_keep_kinds` — e.g. treating them as non-counter-bearing
+    "sentinel" records to be skipped when scanning backward for the max seq — is
+    fooled: it can walk straight past the true watermark (which may itself be an
+    `always_keep_kinds` entry, appended most recently) and under-recover the
+    counter, silently re-issuing already-used seqs on the next append.
+
+    Set X: append entries 1..6, with seq=2 an early `rewind` record (kept below
+    the floor purely via `always_keep_kinds`) and seq=6 a LATER `rewind` record
+    that is also the true watermark (the highest seq in the file, and itself an
+    `always_keep_kinds` kind — the case a naive "skip always_keep_kinds" tail-read
+    gets wrong).
+
+    Truncate past X's low-seq events (min_keep_seq=5): entries 1,3,4 are dropped;
+    entry 2 survives ONLY via always_keep_kinds; entries 5,6 survive on seq alone.
+
+    Reconstruct: a new StateLog over the truncated file must recover max_seq=6 —
+    not 2 (the low always_keep_kinds entry) and not some undercount from skipping
+    the always_keep_kinds watermark entry.
+
+    (Strip-falsify verified manually: temporarily changing the tail-read to skip
+    `kind == "rewind"` entries when scanning backward made this assertion fail
+    with `current_seq == 5` instead of `6` — confirming the test actually
+    discriminates the hazard, not just the happy path.)
+    """
+    path = tmp_path / "wal.jsonl"
+    log = StateLog(path)
+
+    async def go():
+        await log.append("inbox_put", target="a1", payload={})  # seq 1
+        await log.append(REWIND_KIND, target_n=0)  # seq 2 (rewind, below floor)
+        await log.append("inbox_put", target="a3", payload={})  # seq 3
+        await log.append("inbox_put", target="a4", payload={})  # seq 4
+        await log.append("inbox_put", target="a5", payload={})  # seq 5
+        await log.append(REWIND_KIND, target_n=1)  # seq 6 (rewind, true watermark)
+        await log.flush()
+        await log.truncate_below(5, always_keep_kinds=frozenset({REWIND_KIND}))
+        await log.flush()
+        return log.last_truncate_stats
+
+    stats = asyncio.run(go())
+
+    # Sanity on the truncate itself: 2 survives despite seq<5 (always_keep_kinds);
+    # 1,3,4 are dropped; 5,6 survive on seq alone.
+    surviving = _read_all(path)
+    assert {e["seq"] for e in surviving} == {2, 5, 6}
+    assert stats["dropped"] == 3  # seq 1, 3, 4
+
+    # Reconstruct: a brand-new StateLog over the truncated file.
+    log2 = StateLog(path)
+    assert log2.current_seq == 6, (
+        "tail-read must recover the true watermark (seq 6, itself an "
+        "always_keep_kinds entry) — not be fooled into stopping at the low "
+        "always_keep_kinds entry (seq 2) or undercounting"
+    )
+    # The counter must never re-issue a used seq.
+    new_seq = asyncio.run(log2.append("inbox_put", target="a_new", payload={}))
+    assert new_seq == 7
+
+
+def test_scan_max_seq_after_truncate_to_single_watermark(tmp_path):
+    """Tier 2: edge case — truncate leaves exactly one survivor (the watermark);
+    the tail-read must still recover it (not confuse "one line" with "empty")."""
+    path = tmp_path / "wal.jsonl"
+    log = StateLog(path)
+
+    async def go():
+        for i in range(1, 6):
+            await log.append("inbox_put", target=f"a{i}", payload={})
+        await log.truncate_below(100)  # drop everything but the watermark (seq 5)
+        await log.flush()
+
+    asyncio.run(go())
+
+    log2 = StateLog(path)
+    assert log2.current_seq == 5
+
+
+def test_scan_max_seq_matches_full_scan_with_torn_trailing_line(tmp_path):
+    """Tier 2: edge case — a torn/incomplete trailing line (crash mid-write) must be
+    skipped by the tail-read exactly as the full scan skips it, recovering the last
+    WELL-FORMED entry's seq, not raising and not miscounting the torn line."""
+    path = tmp_path / "wal.jsonl"
+    log = StateLog(path)
+
+    async def go():
+        for i in range(1, 4):
+            await log.append("inbox_put", target=f"a{i}", payload={})
+        await log.flush()
+
+    asyncio.run(go())
+
+    # Inject a torn fragment after the last well-formed entry (no closing brace/newline).
+    with path.open("a", encoding="utf-8") as f:
+        f.write('{"seq": 99, "kind": "inb')
+
+    log2 = StateLog(path)
+    assert log2.current_seq == 3
+
+
+def test_scan_max_seq_large_wal_parity(tmp_path):
+    """Tier 2: a WAL large enough to exceed the tail-read's default backward-read
+    window (~500KB, past the 64KB first read) must still recover the exact same
+    max_seq as a small WAL would — parity must hold at scale, not only for WALs
+    that fit entirely inside the first backward read."""
+    path = tmp_path / "wal.jsonl"
+    log = StateLog(path)
+
+    async def go():
+        for i in range(1, 2001):
+            await log.append("inbox_put", target=f"a{i}", payload={"pad": "x" * 200})
+        await log.flush()
+
+    asyncio.run(go())
+
+    log2 = StateLog(path)
+    assert log2.current_seq == 2000
+
+
+def _read_all(path: Path) -> list[dict]:
+    out: list[dict] = []
+    if not path.is_file():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(entry, dict):
+            out.append(entry)
+    return out


### PR DESCRIPTION
**[per-PR-coder]** — #2946 cold-start UX、**Item 1 のみ**。base=main（Item 2=#3134 merge 済）。co-vet=architect。

## 何を直したか
`StateLog.__init__`（`state_log.py`）は seq counter を `_scan_max_seq` で復元しており、これが **WAL 全行を読んで `json.loads` し max(seq) を求める**（BLOCKING、event loop 前、O(WAL)）。cold-start が WAL 長に線形。

**Item 1 = `_scan_max_seq` の tail-read 化（full-scan fallback）**:
- WAL を **EOF から後ろ向きに doubling window で読み**、最後の well-formed entry の seq を返す（O(tail)）。append は file 上 seq-monotonic、`_do_truncate` もその順序を保存しつつ最高 seq を watermark として必ず残す ∴ 最後の well-formed 行 = max seq。
- 元の full scan は `_full_scan_max_seq` として**そのまま保持し fallback に**。tail-read が確定答を出せない場合（read 中の I/O error / empty-or-no-valid-entry window）のみ full scan へ。両path は全 file で同一値を返す = 同一 reconstruction の behavior 保存最適化。

## ★ truncate-falsify test（CLAUDE.md Recovery-feature PR gate、architect 指定 hazard）
`_do_truncate` は `always_keep_kinds`（例 `rewind` reset-record）を truncation floor 以下でも保持し、かつ最高 seq を watermark として残す。**naive な tail-read が `always_keep_kinds` を special-case（後ろ向き走査中に skip）すると、true watermark 自体が `always_keep_kinds` entry の場合に騙されて undercount → 使用済み seq を再発行**。
- test: seq 1..6（2 と 6 が `rewind`）→ `truncate_below(5, always_keep_kinds={rewind})` → survivors `{2,5,6}` → reconstruct → **`current_seq == 6`**（2 でも undercount でもない）を assert。
- **strip→RED 確認済**: tail-read を `kind=="rewind"` skip に一時退化させると `current_seq==5` になり RED。実装復元で GREEN。

## behavior 不変（max_seq 同一、edge case 確認）
- 空 WAL → 0 / truncate-to-single-watermark → 復元 / torn trailing line（crash mid-write、full-scan と同様に skip）/ large WAL（最初の後ろ向き read window を超える）— いずれも full-scan と同一値。

## gate（local 実測）
- `ruff check src tests` → All checks passed
- `test_tier_audit.py --strict` 新 test → 6/6 OK（Tier 4 violations 0）
- `verify_module_docstrings.py state_log.py` → OK
- **full-suite `pytest` → 9035 passed, 29 skipped**（foreground blocking 実測）

## scope
Item 1 のみ。**Item 2（済）/ Item 3 / Item 4 には触れていません。**

part of #2946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
