### PR TITLE
perf(runtime): lazy-load topology YAML on first access (#2946 item 4)

### DIFF
--- a/src/reyn/runtime/registry.py
+++ b/src/reyn/runtime/registry.py
@@ -322,8 +322,13 @@ class AgentRegistry:
         # PR12: topology declarations under `.reyn/topologies/<name>.yaml`.
         # Bad files become warnings rather than startup errors so a hand-edited
         # yaml doesn't lock the user out of `reyn chat`.
-        self._topologies: dict[str, Topology] = {}
-        self._reload_topologies()
+        # #2946 Item 4: lazy — ``None`` means "not yet loaded from disk". The
+        # glob + per-file YAML parse only runs on first access (the
+        # ``_topologies`` property below), not at construction, so a
+        # `reyn chat` cold-start that never touches topologies pays nothing.
+        # ★ behavior change: a malformed topology yaml's warning now surfaces
+        # at first topology access instead of at Registry construction time.
+        self._topologies_raw: dict[str, Topology] | None = None
 
     @property
     def state_log(self) -> StateLog | None:
@@ -3443,22 +3448,35 @@ class AgentRegistry:
 
     # ── topology ────────────────────────────────────────────────────────────────
 
+    @property
+    def _topologies(self) -> dict[str, Topology]:
+        """#2946 Item 4: lazy-loaded topology map — the blocking glob + per-file
+        YAML parse (``_reload_topologies``) only runs on first access, not at
+        Registry construction. ``_topologies_raw`` is ``None`` until then.
+        Every reader/writer below goes through this property (mutating the
+        returned dict in place, e.g. ``self._topologies[name] = topo``), so
+        the lazy-load is transparent to all existing call sites."""
+        if self._topologies_raw is None:
+            self._reload_topologies()
+        assert self._topologies_raw is not None
+        return self._topologies_raw
+
     def _reload_topologies(self) -> None:
-        self._topologies = {}
-        if not self._topology_dir.is_dir():
-            return
-        for path in sorted(self._topology_dir.glob("*.yaml")):
-            try:
-                topo = Topology.load(path)
-            except Exception as e:
-                # Hand-edited / outdated yaml — surface but don't crash.
-                import sys
-                print(
-                    f"warning: skipping malformed topology {path.name}: {e}",
-                    file=sys.stderr,
-                )
-                continue
-            self._topologies[topo.name] = topo
+        topologies: dict[str, Topology] = {}
+        if self._topology_dir.is_dir():
+            for path in sorted(self._topology_dir.glob("*.yaml")):
+                try:
+                    topo = Topology.load(path)
+                except Exception as e:
+                    # Hand-edited / outdated yaml — surface but don't crash.
+                    import sys
+                    print(
+                        f"warning: skipping malformed topology {path.name}: {e}",
+                        file=sys.stderr,
+                    )
+                    continue
+                topologies[topo.name] = topo
+        self._topologies_raw = topologies
 
     def _affiliated_agents(self) -> set[str]:
         """Names of agents that belong to at least one user-declared topology."""

--- a/tests/test_2946_item4_topology_lazy_load.py
+++ b/tests/test_2946_item4_topology_lazy_load.py
@@ -1,0 +1,94 @@
+"""Tier 2: #2946 Item 4 — topology YAML parsing is lazy (first-access, not construction).
+
+Registry construction used to blocking-glob + parse every ``.reyn/topologies/*.yaml``
+file eagerly (``_reload_topologies`` called from ``__init__``), even for a `reyn chat`
+run that never touches topologies. That is pure cold-start cost with no payoff for the
+common case. The fix defers the glob+parse to first access (the ``_topologies``
+property) — ``_topologies_raw`` starts ``None`` and is populated on first read.
+
+★ behavior change (documented in the issue / PR, intentional, low-risk): a malformed
+topology yaml's "skipping malformed topology" warning used to surface at Registry
+construction time; it now surfaces at first topology access instead. Once loaded, all
+topology behavior (list/get/exists/create/delete/rename) is unchanged — same real
+AgentRegistry + StateLog, no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.topology import TOPOLOGY_DIRNAME, Topology
+
+
+def _registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    return AgentRegistry(
+        project_root=tmp_path, session_factory=lambda p: None, state_log=state_log
+    )
+
+
+def _write_malformed_topology(tmp_path: Path, name: str = "bad") -> Path:
+    topo_dir = tmp_path / ".reyn" / TOPOLOGY_DIRNAME
+    topo_dir.mkdir(parents=True, exist_ok=True)
+    path = topo_dir / f"{name}.yaml"
+    # Not a mapping at all — Topology.load's ``data.get(...)`` calls raise, which
+    # _reload_topologies catches and turns into the stderr warning.
+    path.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    return path
+
+
+def test_construction_does_not_parse_topology_yaml(tmp_path: Path, capsys):
+    """Tier 2: constructing the Registry with a malformed topology yaml on disk must
+    NOT surface the malformed-yaml warning — the glob+parse hasn't run yet (lazy)."""
+    _write_malformed_topology(tmp_path)
+    _registry(tmp_path)
+    captured = capsys.readouterr()
+    assert "skipping malformed topology" not in captured.err
+
+
+def test_first_topology_access_parses_and_warns(tmp_path: Path, capsys):
+    """Tier 2: the first call that touches topologies (list_topologies) triggers the
+    glob+parse — the malformed-yaml warning now appears, timing-shifted from
+    construction to first access (the documented #2946 Item 4 behavior change)."""
+    _write_malformed_topology(tmp_path)
+    reg = _registry(tmp_path)
+    capsys.readouterr()  # discard anything from construction (should be empty)
+
+    reg.list_topologies()
+
+    captured = capsys.readouterr()
+    assert "skipping malformed topology" in captured.err
+
+
+def test_valid_topology_loaded_lazily_and_visible(tmp_path: Path):
+    """Tier 2: a well-formed topology yaml is invisible until first access, then
+    resolves correctly — the lazy-load defers timing but doesn't change the result."""
+    topo_dir = tmp_path / ".reyn" / TOPOLOGY_DIRNAME
+    Topology(name="squad", kind="network", members=("alice", "bob")).save(
+        topo_dir / "squad.yaml"
+    )
+    reg = _registry(tmp_path)
+
+    # Behavioral witness that load hasn't happened yet: the backing cache is still
+    # unpopulated (checked via the public topology_exists surface, which itself
+    # triggers the lazy-load — so we assert on the OUTCOME of that first call
+    # rather than peeking at private state).
+    assert reg.topology_exists("squad") is True
+    names = {t.name for t in reg.list_topologies()}
+    assert "squad" in names
+
+
+def test_repeated_access_is_stable(tmp_path: Path):
+    """Tier 2: once lazily loaded, repeated access returns the same topology set
+    (the lazy-load populates once and is reused, not re-parsed per call in a way
+    that would change results)."""
+    topo_dir = tmp_path / ".reyn" / TOPOLOGY_DIRNAME
+    Topology(name="squad", kind="network", members=("alice",)).save(
+        topo_dir / "squad.yaml"
+    )
+    reg = _registry(tmp_path)
+
+    first = {t.name for t in reg.list_topologies()}
+    second = {t.name for t in reg.list_topologies()}
+    assert first == second == {"squad", "_default"}


### PR DESCRIPTION
**[per-PR-coder]** — part of #2946

## Item 4 = topology lazy-load

`AgentRegistry.__init__` used to call `_reload_topologies()` unconditionally, which
blocking-globs `.reyn/topologies/*.yaml` and YAML-parses every file — even for a run
(e.g. `reyn chat`) that never touches topologies. architect scope (#2946 comment):
Item 4 = "SHIP(3番、cheap) — 中(小 win だが低 risk・低コスト lazy-load), behavior 変化 note のみ".

## Fix

Deferred the glob+parse to first access:

- `self._topologies_raw: dict[str, Topology] | None = None` replaces the eager
  `self._topologies = {}` + `self._reload_topologies()` call in `__init__`.
- A new `_topologies` property lazily calls `_reload_topologies()` on first read
  (when `_topologies_raw is None`) and returns the populated dict. All existing
  read/write call sites (`list_topologies`, `get_topology`, `topology_exists`,
  `create_topology`, delete/rename, `_reconcile_topologies_as_of_cut`, etc.) go
  through this property unchanged — they already only ever subscript/mutate
  `self._topologies` in place, so the lazy-load is transparent to them.
- `_reload_topologies()` itself now builds a local dict and assigns it to
  `self._topologies_raw` at the end (no behavior change to the parse logic itself).

## ★ Behavior change (intentional, documented)

A malformed topology yaml's `"warning: skipping malformed topology ..."` message
used to print at **Registry construction time**. It now prints at **first topology
access** (the first call to any of `list_topologies` / `get_topology` /
`topology_exists` / etc.). No other topology behavior changes — once loaded, the
resulting topology set and all downstream logic (can_send, `_default` synthesis,
create/delete/rename) is identical.

This is not WAL-recovery-core (topology YAML lives outside the WAL — only
`_reconcile_topologies_as_of_cut`, which is WAL-driven reconciliation, touches
`_topologies` for recovery, and it already goes through the lazy property
correctly), so no truncate-falsify test is required per architect's #2946 scope
comment.

## Test witness (`tests/test_2946_item4_topology_lazy_load.py`, Tier 2, real
AgentRegistry + StateLog, no mocks)

- `test_construction_does_not_parse_topology_yaml` — a malformed topology yaml on
  disk at construction time produces **no** warning on stderr right after
  `AgentRegistry(...)` returns (behavioral timing witness that the parse hasn't run).
- `test_first_topology_access_parses_and_warns` — the first `list_topologies()` call
  **does** produce the warning (behavioral witness that the parse now runs on first
  access, not before).
- `test_valid_topology_loaded_lazily_and_visible` — a well-formed topology is
  correctly resolved via `topology_exists` / `list_topologies` after being lazily
  loaded (result equivalence, not just timing).
- `test_repeated_access_is_stable` — repeated `list_topologies()` calls return the
  same set (the lazy population runs once and is reused).

## Local gates (all green, foreground)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_2946_item4_topology_lazy_load.py` — 4/4 OK, 0 errors
- `python scripts/verify_module_docstrings.py src/reyn/runtime/registry.py` — OK
- Targeted topology suite (9 files incl. `test_2103_C1_topology_create_tool_1953.py`,
  `test_topology_rewind_2103_piece2.py`, `test_cascade_profile_preserve_2103.py`,
  `test_multi_agent_p7.py`, new test file) — 46 passed
- **Full suite** (`pytest -q`, foreground, ~6m) — **9033 passed, 29 skipped, 0 failed**

co-vet = architect.

CI[Linux] not awaited per dispatch instructions (lead monitors).