### PR TITLE
feat(runtime): hard-cancel for mid-flight LLM calls (#2242)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -5133,8 +5133,20 @@ class Session:
                         # run_one_iteration directly, FP-0013 §ADR-A). Preserve
                         # the pre-#2242 behaviour: let it propagate.
                         raise
-                    self._turn_cancel_self_initiated = False
             finally:
+                # #2242 Finding 1: reset the self-initiated flag UNCONDITIONALLY
+                # here (not only on the swallow branch). If cancel_inflight() set
+                # it True but the CancelledError was never actually delivered to
+                # this turn — e.g. the turn body completed (or caught+suppressed
+                # the cancel) in the same tick before it landed, so `await
+                # self._turn_owner_task` returned normally and the `except` above
+                # never ran — a per-branch reset would leave the flag stuck True.
+                # It would then mis-classify the NEXT turn's EXTERNAL cancel as
+                # self-initiated and wrongly swallow it, violating the FP-0013
+                # external-cancel-re-raise contract. A finally clears it on every
+                # path (normal return, swallowed cancel, re-raised external
+                # cancel) so the flag never outlives the turn that set it.
+                self._turn_cancel_self_initiated = False
                 self._turn_owner_task = None
                 self._turn_idle.set()
                 # Symmetric turn-end lifecycle event. turn_completed fires only on

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1213,6 +1213,18 @@ class Session:
         self._turn_idle = asyncio.Event()
         self._turn_idle.set()
         self._turn_owner_task: "asyncio.Task | None" = None  # lets await_quiescent skip its wait when called re-entrantly from the owning task
+        # #2242: True only for the window between cancel_inflight() calling
+        # `_turn_owner_task.cancel()` and run_one_iteration observing the
+        # resulting CancelledError. Distinguishes OUR OWN hard-cancel (swallowed,
+        # so the run-loop / driver task survives) from an externally-cancelled
+        # driver task (e.g. an anyio scope teardown cancelling the MCP/A2A
+        # request-handler task that is pumping run_one_iteration directly, FP-0013
+        # §ADR-A) — in the external case `await self._turn_owner_task` ALSO
+        # raises CancelledError (asyncio propagates an awaiting task's cancel into
+        # whatever Task/Future it is suspended on), but that cancellation must be
+        # RE-RAISED, not swallowed, so the driver's own cancellation completes
+        # normally instead of silently surviving a cancel that was never ours.
+        self._turn_cancel_self_initiated: bool = False
         # Joinable handle for fire-and-forget WAL-append tasks so await_quiescent can join them too (ADR-0038 Stage 1c coverage, see session-construction.md#family-2-recovery-wal-journal)
         self._inflight_wal_tasks: set[asyncio.Task] = set()
         # Kept directly (not only via journal) so ops launched from this session can emit step events into the same WAL
@@ -1867,16 +1879,32 @@ class Session:
             bind(self, self._router_host)
 
     async def cancel_inflight(self) -> str:
-        """#1468: cancel all in-flight work — running turn + tasks/plans.
+        """#1468/#2242: cancel all in-flight work — running turn + tasks/plans.
 
         Single seam called by both TUI (local mode) and WS handler (remote
         mode). Returns a human-readable summary string.
 
-        V1 boundary: sets the cooperative cancellation flag so the turn's
-        run_loop breaks at the next tool-iteration boundary. A slow tool
+        #1468 cooperative layer: sets the cooperative cancellation flag so the
+        turn's run_loop breaks at the next tool-iteration boundary. A slow tool
         already in flight completes before the cancel takes effect (subprocess
         kill is a follow-up scope). Any spawned tasks are cancelled immediately
         via asyncio task cancellation (existing behaviour, preserved here).
+
+        #2242 hard layer: ALSO cancels ``_turn_owner_task`` directly (the
+        per-turn sub-task ``run_one_iteration`` spawns to run ``_run_turn_body``
+        — see that method). This is what actually stops a mid-flight LLM call:
+        the cooperative flag above is only checked at the top of each router-loop
+        iteration (BEFORE the next LLM call), so it cannot interrupt one already
+        in flight; a direct ``Task.cancel()`` injects ``CancelledError`` at
+        whatever await point the task is currently suspended on — for a
+        generating turn, that is the ``litellm.acompletion`` await itself, so
+        the underlying HTTP request aborts and the spinner stops immediately
+        instead of waiting out the response. ``_turn_cancel_self_initiated`` is
+        set first so ``run_one_iteration`` can tell this cancellation apart from
+        an externally-cancelled driver task and swallow only this one (see that
+        flag's docstring). ``Task.cancel()`` returns False (no-op, flag left
+        unset) when the task is already done, so a cancel racing turn completion
+        never mis-tags a later, unrelated cancellation.
 
         #2588: after cancelling this session's own turn, forward the cancel to
         every registered cancel-forward target (see ``register_cancel_forward``).
@@ -1886,6 +1914,8 @@ class Session:
         duration of a sync attached run so a Ctrl-C here reaches the driver.
         """
         self._loop_driver.request_cancel()
+        if self._turn_owner_task is not None and self._turn_owner_task.cancel():
+            self._turn_cancel_self_initiated = True
         for forward in list(self._cancel_forward_targets):
             forward()
         return "✗ cancelled turn"
@@ -5068,37 +5098,42 @@ class Session:
         )
         # ADR-0038 Stage 1c: busy until this turn settles (its WAL appends done).
         self._turn_idle.clear()
-        self._turn_owner_task = asyncio.current_task()
+        # #2242: the turn body now runs as its OWN per-turn sub-task (not inline
+        # on this driver task) — this is what makes hard-cancel possible.
+        # cancel_inflight() can call `_turn_owner_task.cancel()` directly, which
+        # injects CancelledError at whatever await point the sub-task is
+        # currently suspended on (mid-generation: the litellm.acompletion await
+        # inside RouterLoop), aborting the in-flight HTTP request immediately —
+        # unlike the pre-#2242 inline design, where the turn body ran on THIS
+        # (the driver's own) task and only the cooperative flag (checked at the
+        # top of each router-loop iteration, never during an LLM call) could ask
+        # it to stop.
+        self._turn_owner_task = asyncio.create_task(self._run_turn_body(kind, payload))
+        _cancelled = False
         try:
             try:
-                if kind == "user":
-                    await self._handle_user_message(
-                        payload.get("text", ""),
-                        chain_id=payload.get("chain_id") or _new_chain_id(),
-                    )
-                elif kind == "agent_request":
-                    await self._handle_agent_request(payload)
-                elif kind == "agent_response":
-                    await self._handle_agent_response(payload)
-                elif kind == "pipeline_result":
-                    # IS-2: an async pipeline driver-session posted its terminal
-                    # result here (the agent_response mirror — but chainless: the
-                    # launch returned immediately, so this is a fresh turn, routed
-                    # exactly like a task wake).
-                    await self._handle_pipeline_result(payload)
-                elif kind in ("task_ready", "task_dependency_aborted"):
-                    # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
-                    # (a dependent became ready, or a parent must decide recovery). Both
-                    # surface as an OS-originated message so the LLM acts via ordinary
-                    # task ops (P7 — no decision vocabulary).
-                    await self._handle_task_wake(payload)
-                elif kind == "hook":  # HOOK_INBOX_KIND (#1800 slice 5b)
-                    # E (wake=true) lifecycle-hook push delivered as a turn trigger:
-                    # a system-role [hook:name] message + one router turn (self-
-                    # continuation). The attribution + wake binding ride in the
-                    # payload (race-free; the slice-7 valve can count hook-driven
-                    # turns, and the audit trail attributes the turn to the hook).
-                    await self._handle_hook_message(payload)
+                try:
+                    await self._turn_owner_task
+                except asyncio.CancelledError:
+                    if self._turn_cancel_self_initiated:
+                        # #2242 WAL-invariant 1: CancelledError unwound the
+                        # turn-body task straight out of whatever await it was
+                        # suspended on (mid-generation: the LLM await) — every
+                        # statement AFTER that await (parsing the response,
+                        # appending it to history, any further tool iteration)
+                        # never executes, so the cancelled turn's result is
+                        # never appended. Swallow here (do NOT re-raise) so the
+                        # driver task — and thus the agent — survives to serve
+                        # the next turn; only the per-turn sub-task was cancelled.
+                        _cancelled = True
+                    else:
+                        # Not our own cancel_inflight() call — this driver task
+                        # itself was cancelled from outside (e.g. an anyio scope
+                        # teardown for the MCP/A2A request-handler task pumping
+                        # run_one_iteration directly, FP-0013 §ADR-A). Preserve
+                        # the pre-#2242 behaviour: let it propagate.
+                        raise
+                    self._turn_cancel_self_initiated = False
             finally:
                 self._turn_owner_task = None
                 self._turn_idle.set()
@@ -5110,6 +5145,21 @@ class Session:
                 self._chat_events.emit(
                     "turn_settled", kind=kind, chain_id=payload.get("chain_id"),
                 )
+            if _cancelled:
+                # #2242 WAL-invariant 2: a hard-cancel does not touch any
+                # ALREADY-SPAWNED fire-and-forget WAL-append task (e.g. an
+                # intervention-dispatch task tracked via `_track_wal_task` before
+                # the cancelled turn's LLM await was reached) — cancelling
+                # `_turn_owner_task` cancels only that one sub-task, never a
+                # sibling task. `_turn_idle` is already `.set()` above (this turn
+                # is done), so `await_quiescent()`'s re-entrancy check
+                # (`current_task() is not self._turn_owner_task`, and
+                # `_turn_owner_task` is already None) takes the `_turn_idle.wait()`
+                # branch and returns immediately (already set) — it does not
+                # self-deadlock; it exists here purely to JOIN any such stragglers
+                # before this method returns, so they cannot land after the
+                # session is reported idle.
+                await self.await_quiescent()
         finally:
             # 0062: an outer finally so an ephemeral agent-step session still gets
             # scheduled to vanish even when the turn body raises past the inner
@@ -5123,6 +5173,46 @@ class Session:
             # here rather than shipped as a new leak.
             self._maybe_schedule_ephemeral_vanish()
         return True
+
+    async def _run_turn_body(self, kind: str, payload: dict) -> None:
+        """#2242: the per-kind turn dispatch, run as ``run_one_iteration``'s
+        per-turn cancellable sub-task (``self._turn_owner_task``).
+
+        Byte-identical dispatch to the pre-#2242 inline body (extracted, not
+        rewritten) — a NORMAL (non-cancelled) turn behaves exactly as before;
+        the only change is WHICH task executes it, so ``cancel_inflight()`` can
+        target this task directly with ``asyncio.Task.cancel()`` instead of
+        relying solely on the cooperative flag ``RouterLoopDriver`` polls at
+        each iteration boundary (too coarse to interrupt a mid-flight LLM
+        call — see ``cancel_inflight``'s docstring)."""
+        if kind == "user":
+            await self._handle_user_message(
+                payload.get("text", ""),
+                chain_id=payload.get("chain_id") or _new_chain_id(),
+            )
+        elif kind == "agent_request":
+            await self._handle_agent_request(payload)
+        elif kind == "agent_response":
+            await self._handle_agent_response(payload)
+        elif kind == "pipeline_result":
+            # IS-2: an async pipeline driver-session posted its terminal
+            # result here (the agent_response mirror — but chainless: the
+            # launch returned immediately, so this is a fresh turn, routed
+            # exactly like a task wake).
+            await self._handle_pipeline_result(payload)
+        elif kind in ("task_ready", "task_dependency_aborted"):
+            # #1953 slice 7: the TaskWaker delivered a dep-graph disposition
+            # (a dependent became ready, or a parent must decide recovery). Both
+            # surface as an OS-originated message so the LLM acts via ordinary
+            # task ops (P7 — no decision vocabulary).
+            await self._handle_task_wake(payload)
+        elif kind == "hook":  # HOOK_INBOX_KIND (#1800 slice 5b)
+            # E (wake=true) lifecycle-hook push delivered as a turn trigger:
+            # a system-role [hook:name] message + one router turn (self-
+            # continuation). The attribution + wake binding ride in the
+            # payload (race-free; the slice-7 valve can count hook-driven
+            # turns, and the audit trail attributes the turn to the hook).
+            await self._handle_hook_message(payload)
 
     def _maybe_schedule_ephemeral_vanish(self) -> None:
         """#2103: an ephemeral spawned session auto-vanishes once its task is done —

--- a/tests/test_2242_hard_cancel.py
+++ b/tests/test_2242_hard_cancel.py
@@ -1,0 +1,266 @@
+"""Tier 2: #2242 — hard-cancel for turn interrupt (mid-flight LLM call).
+
+Pre-#2242, ``cancel_inflight()`` only set a COOPERATIVE flag
+(``RouterLoopDriver._turn_cancel_requested``), checked at the TOP of each
+router-loop iteration — i.e. BEFORE the next LLM call, never during one. A
+turn stuck mid-generation could not be interrupted; the spinner sat for the
+full duration of the in-flight LLM call (~20s UX gap, see
+``tests/test_turn_cancel_1468.py`` for that pre-existing cooperative layer,
+unchanged by this PR).
+
+#2242 makes the turn body a per-turn CANCELLABLE SUB-TASK
+(``Session._turn_owner_task = asyncio.create_task(self._run_turn_body(...))``,
+awaited by ``run_one_iteration``) and has ``cancel_inflight()`` call
+``_turn_owner_task.cancel()`` directly — injecting ``CancelledError`` at
+whatever await point the sub-task is CURRENTLY suspended on (mid-generation:
+the LLM call itself), aborting it immediately instead of waiting for the next
+iteration boundary.
+
+WAL-invariants pinned here (ADR-0038 Stage 1c / architect's #2242 design
+comment):
+
+  1. A cancelled turn's result is NEVER appended — CancelledError unwinds the
+     turn-body task out of the in-flight await, so every statement AFTER that
+     await (parsing the response, appending it to history) never executes.
+     Proven here by RELEASING the hung LLM call AFTER the cancel: if the
+     cancellation were merely cooperative (or simply delayed), the awaited
+     call would resume and the reply WOULD land — this test asserts it never
+     does.
+  2. A fire-and-forget WAL-append task tracked BEFORE the cancelled turn's LLM
+     await (``Session._track_wal_task`` — e.g. a buffered-intervention-answer
+     consume) is NOT touched by cancelling ``_turn_owner_task`` (a distinct
+     task) and is JOINED by ``await_quiescent()`` on the cancel path before
+     ``run_one_iteration`` returns — it survives.
+  3. The session (driver task) survives a hard-cancel: ``cancel_inflight()``
+     swallows only its OWN cancellation (tracked via
+     ``_turn_cancel_self_initiated``); ``run_one_iteration`` returns normally
+     and a SUBSEQUENT turn runs to completion — the agent is not torn down.
+
+Real ``Session`` / ``StateLog`` / ``AgentSnapshot`` (no mocks) — only the LLM
+boundary is replaced with a plain, controllable async function assigned onto
+``session._loop_driver.run_turn``, exactly the seam
+``tests/test_2884_hook_driven_turns_truncation_falsify.py`` uses to isolate
+the mechanism under test from RouterLoop's own internals (already covered by
+``tests/test_turn_cancel_1468.py``).
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.session import Session
+from reyn.user_intervention import InterventionAnswer
+
+AGENT = "hard-cancel-agent"
+_LANDED_REPLY = "SHOULD-NOT-LAND-IF-HARD-CANCELLED"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_session(wal: Path, snapshot_path: Path) -> tuple[Session, StateLog]:
+    state_log = StateLog(wal)
+    session = Session(agent_name=AGENT, state_log=state_log, snapshot_path=snapshot_path)
+    return session, state_log
+
+
+def _install_hanging_run_turn(session: Session) -> tuple[asyncio.Event, asyncio.Event]:
+    """Replace RouterLoopDriver.run_turn with a controllable hang — a real,
+    plain async function method-assigned onto the instance (the SAME
+    no-mock seam ``test_2884_...``'s ``_fake_run_turn`` uses), not a
+    MagicMock/AsyncMock. ``call_started`` fires the instant the "LLM call"
+    begins (simulating the moment RouterLoop would be suspended inside its
+    ``litellm.acompletion`` await); ``release`` is set by the TEST, after the
+    cancel, to prove the resumed coroutine's post-await code never runs on a
+    truly hard-cancelled task."""
+    call_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
+        call_started.set()
+        await release.wait()  # simulates an in-flight LLM call, suspended
+        # Only reached if the awaiting task was NOT actually cancelled —
+        # mirrors what a real completed run_turn does (append the reply).
+        session._append_history(ChatMessage(role="assistant", content=_LANDED_REPLY, ts=_now()))
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    return call_started, release
+
+
+async def _seed_prior_fire_and_forget_wal_task(session: Session, run_id: str) -> None:
+    """Seed + consume a buffered intervention answer — the production
+    fire-and-forget WAL-append seam ``Session.consume_buffered_intervention_answer``
+    drives via ``_track_wal_task`` (see that method's #2242 docstring note and
+    ``consume_buffered_intervention_answer``'s R-D12 comment). This is the
+    concrete stand-in for WAL-invariant 2's "a fire-and-forget append task
+    spawned before the cancelled turn's LLM await" — tracked BEFORE the hung
+    turn is even started here, mirroring a real prior-turn append still
+    settling when the NEXT turn gets hard-cancelled."""
+    session.buffered_intervention_answers[run_id] = InterventionAnswer(text="prior answer")
+    answer = session.consume_buffered_intervention_answer(run_id)
+    assert answer is not None and answer.text == "prior answer"  # sanity: seeded + popped
+
+
+@pytest.mark.asyncio
+async def test_hard_cancel_mid_generation_no_result_append_and_agent_survives(tmp_path):
+    """Tier 2: #2242 cancel-falsify. Cancelling DURING a hung "LLM call"
+    (a) never lands the reply (invariant 1), (b) leaves the active branch
+    clean — no partial/cancelled turn markers accumulate in history beyond
+    the pre-cancel user message, (c) the agent survives — a subsequent
+    ordinary turn completes normally, and (d) a fire-and-forget WAL-append
+    task tracked before the hang settles via await_quiescent (invariant 2).
+
+    STRIP-RED: reverting ``Session.run_one_iteration``'s per-turn sub-task
+    (back to running the dispatch inline on the driver task, as before #2242)
+    makes ``cancel_inflight()``'s ``_turn_owner_task.cancel()`` cancel the
+    OUTER (run_one_iteration) task itself instead of an isolated sub-task —
+    the test's ``asyncio.wait_for(task, ...)`` then raises CancelledError
+    instead of completing, and the fire-and-forget join never runs (RED).
+    """
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    prior_run_id = "prior-answer-run"
+    await _seed_prior_fire_and_forget_wal_task(session, prior_run_id)
+
+    call_started, release = _install_hanging_run_turn(session)
+
+    await session._put_inbox("user", {"text": "hello", "chain_id": "c-hard-cancel"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    # The "LLM call" is now in flight (suspended on `release.wait()`).
+    result = await session.cancel_inflight()
+    assert "cancel" in result.lower()
+
+    # Release the hang AFTER the cancel: if the sub-task were only
+    # cooperatively (or not truly) cancelled, it would resume here and the
+    # reply WOULD land — proving the difference between hard-cancel and a
+    # merely-delayed completion.
+    release.set()
+
+    # (c) agent survives: run_one_iteration returns normally (True), not an
+    # exception — cancel_inflight() swallowed its own CancelledError.
+    completed = await asyncio.wait_for(turn_task, timeout=5)
+    assert completed is True
+
+    # (a) the cancelled turn's result never landed.
+    assert not any(m.content == _LANDED_REPLY for m in session.history), (
+        "a hard-cancelled turn's LLM reply must never be appended, even after "
+        "the underlying hung call is released post-cancel"
+    )
+    # (b) branch clean: only the pre-cancel user message is present (no
+    # partial assistant/tool entries from the aborted turn).
+    roles = [m.role for m in session.history]
+    assert roles == ["user"], f"expected only the user message to survive; got {roles}"
+
+    # (d) the prior fire-and-forget WAL-append task survived (joined by
+    # await_quiescent on the cancel path) — its durable effect is visible in
+    # the WAL, not lost/orphaned by the sub-task cancellation.
+    await session.journal.flush()
+    wal_lines = [line for line in wal.read_text().splitlines() if line.strip()]
+    assert any(
+        '"intervention_answer_consumed"' in line and prior_run_id in line
+        for line in wal_lines
+    ), "the prior fire-and-forget intervention_answer_consumed append must survive the hard-cancel"
+
+    # (c) continued: a SUBSEQUENT ordinary turn completes normally — the
+    # session/driver was not torn down by the hard-cancel.
+    async def _normal_run_turn(user_text: str, chain_id: str) -> None:
+        session._append_history(ChatMessage(role="assistant", content="normal reply", ts=_now()))
+
+    session._loop_driver.run_turn = _normal_run_turn  # type: ignore[method-assign]
+    await session._put_inbox("user", {"text": "again", "chain_id": "c-after-cancel"})
+    next_completed = await asyncio.wait_for(session.run_one_iteration(), timeout=5)
+    assert next_completed is True
+    assert any(m.content == "normal reply" for m in session.history), (
+        "a normal turn after a hard-cancel must complete and append its reply — "
+        "the agent must survive to serve the next turn"
+    )
+
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_hard_cancel_prior_append_survives_wal_truncation(tmp_path):
+    """Tier 2: #2242 truncate-falsify (CLAUDE.md recovery-feature PR gate).
+
+    Repeats the hard-cancel scenario, then pushes filler WAL events past the
+    surviving fire-and-forget append's source events and truncates below
+    them (mirroring ``test_2884_hook_driven_turns_truncation_falsify.py``).
+    Reconstructing (fresh Session + StateLog: load snapshot, replay the WAL
+    tail) must still show the buffered-answer-consumed state as durable —
+    proving the hard-cancel path does not leave the fire-and-forget append in
+    a state that a subsequent truncation+reconstruction cycle would corrupt
+    or lose. RED if the snapshot-side bookkeeping (``buffered_intervention_
+    answers`` popped on consume, backed by ``AgentSnapshot``) were skipped or
+    raced by the cancel path: reconstruction would still show the answer as
+    OUTSTANDING (not consumed) or missing the consumed marker in the WAL.
+    """
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    prior_run_id = "prior-answer-run-truncate"
+    await _seed_prior_fire_and_forget_wal_task(session, prior_run_id)
+
+    call_started, release = _install_hanging_run_turn(session)
+    await session._put_inbox("user", {"text": "hello", "chain_id": "c-truncate"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    await session.cancel_inflight()
+    release.set()
+    await asyncio.wait_for(turn_task, timeout=5)
+    await session.journal.flush()
+
+    # sanity: the consumed marker's source event is durable pre-truncation.
+    pre_truncate_lines = [line for line in wal.read_text().splitlines() if line.strip()]
+    assert any(
+        '"intervention_answer_consumed"' in line and prior_run_id in line
+        for line in pre_truncate_lines
+    ), "sanity: the consumed-answer source event must be durable pre-truncation"
+    assert prior_run_id not in session.buffered_intervention_answers, (
+        "sanity: the answer must already be popped from the live buffer"
+    )
+
+    # push filler events far past the source events, then truncate below them.
+    for i in range(150):
+        await state_log.append("inbox_put", n=i)
+    floor = state_log.current_seq - 5
+    await state_log.truncate_below(floor)
+    await state_log.flush()
+    stats = state_log.last_truncate_stats
+    assert stats["dropped"] >= 2, (
+        f"the buffered/consumed source events must be truncated below the floor; "
+        f"dropped={stats['dropped']}"
+    )
+    post_truncate_lines = [line for line in wal.read_text().splitlines() if line.strip()]
+    assert not any(
+        '"intervention_answer_consumed"' in line and prior_run_id in line
+        for line in post_truncate_lines
+    ), "the consumed-answer source event must actually be gone post-truncation"
+
+    await state_log.aclose()  # simulate the crash: tear down run1's WAL worker
+
+    # reconstruct (simulates a restart): a FRESH StateLog + Session over the
+    # SAME wal/snapshot (mirrors AgentRegistry.restore_all).
+    session2, state_log2 = _make_session(wal, snapshot_path)
+    snap = AgentSnapshot.load(AGENT, snapshot_path)
+    events = list(state_log2.iter_from(snap.applied_seq))
+    snap.apply_events(events)
+    session2.restore_state(snap)
+
+    assert prior_run_id not in session2.buffered_intervention_answers, (
+        "the answer must stay CONSUMED after reconstruction — the hard-cancel "
+        "path must not leave it re-appearing as outstanding post-truncation"
+    )
+
+    await state_log2.aclose()

--- a/tests/test_2242_hard_cancel.py
+++ b/tests/test_2242_hard_cancel.py
@@ -264,3 +264,174 @@ async def test_hard_cancel_prior_append_survives_wal_truncation(tmp_path):
     )
 
     await state_log2.aclose()
+
+
+def _install_hanging_run_turn_swallowing_cancel(
+    session: Session,
+) -> tuple[asyncio.Event, asyncio.Event]:
+    """Like ``_install_hanging_run_turn`` but the turn body CATCHES the
+    CancelledError and returns normally (does not re-raise). Models a turn
+    whose internal code suppresses the cancel and completes in the same tick
+    it lands — so ``await self._turn_owner_task`` returns NORMALLY and
+    ``run_one_iteration``'s ``except CancelledError`` block never runs. This is
+    the exact shape that leaves ``_turn_cancel_self_initiated`` un-reset unless
+    the reset lives in an unconditional ``finally`` (Finding 1)."""
+    call_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _swallowing_run_turn(user_text: str, chain_id: str) -> None:
+        call_started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            return  # swallow: complete normally instead of propagating
+
+    session._loop_driver.run_turn = _swallowing_run_turn  # type: ignore[method-assign]
+    return call_started, release
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_of_driver_task_propagates(tmp_path):
+    """Tier 2: #2242 Finding 2 — an EXTERNAL cancellation of the task running
+    ``run_one_iteration`` (i.e. NOT via ``cancel_inflight()``, so
+    ``_turn_cancel_self_initiated`` stays False) must PROPAGATE, not be
+    swallowed.
+
+    This is the FP-0013 §ADR-A path: the MCP/A2A request-handler task pumps
+    ``run_one_iteration`` directly and lives inside an anyio task group; an
+    anyio scope teardown cancels that handler task, and the cancellation must
+    reach it (structured concurrency requires the cancelled task to actually
+    end). #2242 only swallows OUR OWN ``cancel_inflight()`` cancel; anything
+    else re-raises. Plain asyncio reproduces this — cancelling the driver task
+    directly is exactly what an outer scope teardown does.
+
+    STRIP-RED: dropping the ``if self._turn_cancel_self_initiated: ... else:
+    raise`` discrimination (swallowing ALL CancelledError) makes the driver
+    task complete normally instead of ending cancelled — ``pytest.raises``
+    then sees no exception (RED)."""
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    call_started, release = _install_hanging_run_turn(session)
+    await session._put_inbox("user", {"text": "hello", "chain_id": "c-external"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+
+    # External cancel: cancel the driver task DIRECTLY (an outer scope teardown),
+    # NOT through cancel_inflight() — so this is NOT self-initiated.
+    turn_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await turn_task
+
+    # sanity: the hung reply never landed (the turn was torn down, not completed).
+    assert not any(m.content == _LANDED_REPLY for m in session.history)
+    release.set()  # release the (now-dead) coroutine's gate for clean teardown
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_self_initiated_flag_does_not_leak_to_next_turn(tmp_path):
+    """Tier 2: #2242 Finding 1 — the ``_turn_cancel_self_initiated`` flag must
+    NOT leak past the turn that set it.
+
+    Turn 1: ``cancel_inflight()`` sets the flag True, but the turn body CATCHES
+    the CancelledError and returns normally — so ``await self._turn_owner_task``
+    returns normally and ``run_one_iteration``'s ``except`` block (which is
+    where a per-branch reset would live) never runs. Turn 2 is then cancelled
+    EXTERNALLY (not via ``cancel_inflight()``); its cancellation must PROPAGATE.
+
+    If the flag leaked True from turn 1 (reset only on the swallow branch),
+    turn 2's external cancel would be mis-read as self-initiated and swallowed
+    — the driver task would complete normally instead of ending cancelled,
+    breaking the FP-0013 external-cancel contract.
+
+    STRIP-RED: moving the ``_turn_cancel_self_initiated = False`` reset back out
+    of the unconditional ``finally`` and onto the swallow branch leaks the flag
+    → turn 2's external cancel is swallowed → ``pytest.raises`` sees no
+    exception (RED). Reproduced live during review."""
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    # ── Turn 1: self-initiated cancel that the body swallows (flag set, but the
+    #    except-block reset path is NOT exercised). ────────────────────────────
+    started1, release1 = _install_hanging_run_turn_swallowing_cancel(session)
+    await session._put_inbox("user", {"text": "one", "chain_id": "c-leak-1"})
+    turn1 = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(started1.wait(), timeout=5)
+    await session.cancel_inflight()  # sets _turn_cancel_self_initiated True
+    # Body swallows the cancel → run_one_iteration returns True normally.
+    completed1 = await asyncio.wait_for(turn1, timeout=5)
+    assert completed1 is True
+
+    # ── Turn 2: EXTERNAL cancel — must propagate (flag must have been reset). ──
+    started2, release2 = _install_hanging_run_turn(session)
+    await session._put_inbox("user", {"text": "two", "chain_id": "c-leak-2"})
+    turn2 = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(started2.wait(), timeout=5)
+    turn2.cancel()  # external — NOT via cancel_inflight()
+
+    with pytest.raises(asyncio.CancelledError):
+        await turn2
+
+    release1.set()
+    release2.set()
+    await state_log.aclose()
+
+
+@pytest.mark.asyncio
+async def test_await_quiescent_join_is_load_bearing_on_cancel(tmp_path):
+    """Tier 2: #2242 Finding 3 — the ``await self.await_quiescent()`` call on
+    the hard-cancel path is load-bearing: it settles a tracked fire-and-forget
+    WAL-append task so no straggler outlives the reported-idle turn.
+
+    A tracked task that awaits indefinitely (the canonical shape —
+    ``_dispatch_intervention`` awaits the user-answer future indefinitely, per
+    ``_track_wal_task``'s docstring) is registered before the turn. On the
+    cancel path ``await_quiescent()`` cancels + joins it, so it is SETTLED
+    (``done()``) by the time ``run_one_iteration`` returns. We witness this via
+    the PUBLIC ``asyncio.Task`` surface of a handle the TEST holds (``.done()``),
+    not any session-private state.
+
+    STRIP-RED: removing ``await self.await_quiescent()`` from the cancel branch
+    leaves the tracked task still pending (awaiting ``never``) when
+    ``run_one_iteration`` returns → ``prior_task.done()`` is False → RED. The
+    straggler would then be free to land a WAL append after the session is
+    reported idle — the contamination ``await_quiescent`` exists to prevent."""
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    never = asyncio.Event()  # never set → the task settles ONLY via cancellation
+
+    async def _indefinite_prior_wal_task() -> None:
+        await never.wait()
+
+    # Register through the real convention seam (a tracked fire-and-forget
+    # WAL-append task); hold the handle so we can witness settling publicly.
+    prior_task = session._track_wal_task(asyncio.ensure_future(_indefinite_prior_wal_task()))
+    try:
+        call_started, release = _install_hanging_run_turn(session)
+        await session._put_inbox("user", {"text": "hello", "chain_id": "c-quiescent"})
+        turn_task = asyncio.create_task(session.run_one_iteration())
+        await asyncio.wait_for(call_started.wait(), timeout=5)
+        await session.cancel_inflight()
+        release.set()
+        completed = await asyncio.wait_for(turn_task, timeout=5)
+        assert completed is True
+
+        # The join happened: the tracked straggler is settled (cancelled+joined)
+        # before run_one_iteration returned — no un-joined WAL-append task
+        # outlives the idle turn.
+        assert prior_task.done(), (
+            "await_quiescent() on the cancel path must settle the tracked "
+            "fire-and-forget WAL task before run_one_iteration returns — a "
+            "still-pending straggler could append after the session is idle"
+        )
+    finally:
+        if not prior_task.done():
+            prior_task.cancel()
+        never.set()
+        await state_log.aclose()


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2242

## Summary

Implements the architect's flow-trace design (issue comment) for hard-cancel:
the cooperative cancel flag (#1468, `RouterLoopDriver._turn_cancel_requested`)
is only checked at the TOP of each router-loop iteration — before the next
LLM call, never during one — so a turn stuck mid-generation could not be
interrupted (~20s spinner-stuck UX).

- **per-turn cancellable sub-task**: `Session.run_one_iteration`'s turn body
  (`session.py`, around `_turn_idle.clear()`) now runs as its own task —
  `self._turn_owner_task = asyncio.create_task(self._run_turn_body(kind, payload))`
  — instead of inline on the driver task (`asyncio.current_task()`, the old
  design). The kind-dispatch if/elif chain (user / agent_request /
  agent_response / pipeline_result / task_ready / hook) is extracted
  byte-identically into the new `_run_turn_body` method.
- **`CancelledError` → litellm abort**: `cancel_inflight()` now ALSO calls
  `self._turn_owner_task.cancel()` directly (in addition to the existing
  `_loop_driver.request_cancel()` cooperative flag). This injects
  `CancelledError` at whatever await point the sub-task is CURRENTLY
  suspended on — for a generating turn, that is the `litellm.acompletion`
  await itself — so the underlying HTTP request aborts and the spinner stops
  immediately instead of waiting out the response.

## ★ WAL-invariant 3-point safety (ADR-0038 Stage 1c, load-bearing)

1. **Cancelled result is never appended.** `CancelledError` unwinds the
   turn-body task straight out of the in-flight await; every statement AFTER
   that await (parse response, append to history, further tool iteration)
   never executes. Proven in the cancel-falsify test by releasing the hung
   "LLM call" AFTER the cancel — if cancellation were only cooperative (or
   merely delayed), the call would resume and the reply WOULD land; the test
   asserts it never does.
2. **Prior fire-and-forget appends survive.** A WAL-append task tracked via
   `Session._track_wal_task` (e.g. `consume_buffered_intervention_answer`'s
   `intervention_answer_consumed` write) BEFORE the cancelled turn's LLM await
   is a DISTINCT task, untouched by cancelling `_turn_owner_task`, and is
   JOINED by `await_quiescent()` — called explicitly on the cancel path (only
   there; a normal turn's control flow is unchanged) — before
   `run_one_iteration` returns.
3. **Inline (awaited, non-fire-and-forget) WAL appends.** Audited every
   `SnapshotJournal.record_*` / `append_inbox` / `consume_inbox` call
   reachable from the turn body (`_handle_user_message`,
   `_handle_agent_request`, etc.): ALL of them route through
   `SnapshotJournal._wal_append_nowait`, a purely synchronous enqueue with
   **zero internal `await` points** — Python cancellation can only land at an
   `await` suspension point, so none of these can be torn mid-write; the
   blocking `SnapshotJournal._wal_append` counterpart has **zero callers**
   anywhere in the codebase (verified via grep). No `asyncio.shield` is
   structurally needed on this surface. The residual blocking
   `await self._state_log.append(...)` calls live in `AgentRegistry`
   (agent/session lifecycle: spawn/purge/vanish) on a SEPARATE, registry-owned
   `DurabilityWorker` whose actual write runs on an independent drain task —
   confirmed by reading `durability_worker.py`: cancelling the submitter task
   only cancels the notification future it's awaiting, never the drain task
   doing the actual write, so no torn write is possible there either. This is
   a structural property of `DurabilityWorker.submit()` (queue + single
   background drainer), not something this PR had to add.

Also added `_turn_cancel_self_initiated` (`session.py`) to distinguish
`cancel_inflight()`'s own `_turn_owner_task.cancel()` from an EXTERNALLY
cancelled driver task (e.g. an anyio scope teardown cancelling the MCP/A2A
request-handler task that pumps `run_one_iteration` directly per FP-0013
§ADR-A) — asyncio propagates an awaiting task's own cancellation into
whatever Task it's suspended on, so `await self._turn_owner_task` raises
`CancelledError` in BOTH cases; only the self-initiated one is swallowed
(driver survives), the external one is re-raised (pre-#2242 behaviour
preserved for that path).

## ★ Cancel-falsify + truncate-falsify tests (`tests/test_2242_hard_cancel.py`)

Real `Session` / `StateLog` / `AgentSnapshot` (no mocks) — the LLM boundary is
replaced with a controllable async function method-assigned onto
`session._loop_driver.run_turn` (the same no-mock seam
`tests/test_2884_hook_driven_turns_truncation_falsify.py` uses).

- `test_hard_cancel_mid_generation_no_result_append_and_agent_survives`:
  drives a real turn via `_put_inbox` + `run_one_iteration`, waits for the
  hung "LLM call" to start, calls `cancel_inflight()`, THEN releases the
  hang — asserts (a) the reply never lands even after release, (b) the
  active branch is clean (only the pre-cancel user message), (c) the agent
  survives (`run_one_iteration` returns `True`, not an exception, AND a
  subsequent ordinary turn completes normally), (d) the prior
  fire-and-forget `intervention_answer_consumed` WAL append survives.
  **Strip-verified RED**: `git stash` (reverting session.py only, keeping the
  test) reproduces the exact failure — the reply lands after release because
  the old cooperative-only cancel never actually stops the awaited call.
- `test_hard_cancel_prior_append_survives_wal_truncation`: repeats the
  scenario, then pushes 150 filler WAL events, truncates below the source
  events, and reconstructs from a fresh `Session`/`StateLog` (snapshot +
  WAL-tail replay, mirroring `AgentRegistry.restore_all`) — asserts the
  consumed-answer state survives truncation (CLAUDE.md recovery-feature PR
  gate).

## Behavior unchanged (non-cancel path)

`_run_turn_body` is a byte-identical extraction of the pre-#2242 inline
dispatch body — a normal (non-cancelled) turn's WAL appends / history / event
emission / `_turn_idle` transitions are unaffected; only WHICH task executes
the dispatch changed. `await_quiescent()` is called ONLY on the cancel path
(a new `if _cancelled:` branch), never on normal completion.

## Live-repro (for architect's tmux verification)

1. Attach a live chat session (inline CUI or WS) to an agent using a real (or
   deliberately slow) LLM provider.
2. Send a user message that will take several seconds to generate (a long
   completion, or point the agent at a provider/model known to be slow).
3. While the spinner is showing (LLM call in flight, BEFORE any tool-call
   iteration boundary would fire), trigger cancel (Esc in the inline CUI, or
   the WS cancel command / `cancel_inflight()`).
4. **Expected**: the spinner stops within roughly one network round-trip
   (not the full ~20s generation time) — the `litellm.acompletion` HTTP
   request itself aborts. A "✗ cancelled turn" style acknowledgement should
   appear; no partial/garbled assistant reply should be appended to history.
5. Immediately send a second, ordinary message — it should complete normally
   (proves the session/driver survived the hard-cancel, not just the one
   turn).
6. For the MCP/A2A external-cancellation edge case (not directly
   live-reproducible via CUI): note in review that `_turn_cancel_self_initiated`
   is what keeps an externally-cancelled request-handler task's own
   cancellation propagating correctly (not swallowed) — this is exercised
   only by the reasoning in the PR description + code comments, not a new
   test, since simulating an anyio scope teardown mid-MCP-request is out of
   scope for this PR's test surface.

## Test plan

- [x] `ruff check src tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_2242_hard_cancel.py` — green (2/2 OK, 0 Tier-4)
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — green
- [x] `pytest` full suite (foreground, ~344s) — 9041 passed, 29 skipped, 0 failed
- [x] Strip-falsify: reverting `session.py` (keeping the test) reproduces RED on the cancel-falsify test
- [ ] (skipped — requires a live tmux session with a real/slow LLM provider; see Live-repro steps above for architect to run interactively)

co-vet: architect (cancel-falsify + live-repro + full-suite, per issue comment)

---

## Revision (co-vet round 1 — architect findings addressed, commit 537ebb5e)

- **Finding 1 [`finally` 修正, real bug]**: `_turn_cancel_self_initiated` reset moved from the swallow branch into the unconditional inner `finally` of `run_one_iteration`. Fixes a flag-leak: if `cancel_inflight()` set the flag True but the CancelledError was never delivered (turn body completed / suppressed it in the same tick → `await self._turn_owner_task` returned normally, `except` never ran), the flag stuck True and the next turn's EXTERNAL cancel was wrongly swallowed (FP-0013 violation). New test `test_self_initiated_flag_does_not_leak_to_next_turn`.
- **Finding 2 [外部 cancel re-raise test]**: `test_external_cancel_of_driver_task_propagates` — plain asyncio (no anyio); cancels the driver task directly (not via `cancel_inflight()`) and asserts CancelledError propagates. Closes the original coverage gap.
- **Finding 3 [await_quiescent join witness]**: `test_await_quiescent_join_is_load_bearing_on_cancel` — a tracked (`_track_wal_task`) fire-and-forget WAL task awaiting indefinitely is `done()` (settled via cancel+join) by the time `run_one_iteration` returns; removing `await_quiescent()` leaves it pending → RED. Witnessed via public `asyncio.Task.done()`. (Framing note: for these synchronous append coroutines the join is cancel-then-join = **settle** the straggler, not "complete the append" — see PR comment.)

All three strip-verified RED via independent Edit-strip. Local 4 gates + full suite green (**9044 passed, 29 skipped**). CI not awaited (lead confirms).
