### PR TITLE
fix: gate plugin_install's mcp.yaml register write with require_file_write (#3088)

### DIFF
--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -54,9 +54,10 @@ Pipeline (one-shot, no sub-phases):
 8. **Register**: for each capability the manifest declares, call the
    SAME existing register verbs — ``skill_install.handle`` /
    ``pipeline_install.handle`` for skills/pipelines (each op carries
-   ``plugin_id=<name>``, §3.7's additive provenance field), and a direct
-   ``.reyn/config/mcp.yaml`` write (mirrors ``mcp__install_local``'s shape,
-   probe-then-commit) for the optional root ``.mcp.json``.
+   ``plugin_id=<name>``, §3.7's additive provenance field), and a
+   ``require_file_write``-gated (#3088) direct ``.reyn/config/mcp.yaml``
+   write (mirrors ``mcp__install_local``'s shape, probe-then-commit) for
+   the optional root ``.mcp.json``.
 9. **Complete**: delete the ``_install_state.json`` marker (absence =
    completed — the state step 0's reconcile checks) and emit
    ``plugin_install_completed``.
@@ -506,7 +507,9 @@ async def _register_mcp(
     into ``.reyn/config/mcp.yaml`` — mirrors ``mcp__install_local``'s shape
     (probe-then-commit on a live per-session reloader; deferred write
     otherwise), tagged with ``plugin_id`` (§3.7) so ``plugin_uninstall`` can
-    find these entries again."""
+    find these entries again. The write is gated by ``require_file_write``
+    on the mcp.yaml path (#3088), mirroring the sibling skill/pipeline
+    register steps' own config-write gates."""
     mcp_json = plugin_root / ".mcp.json"
     entries = _build_mcp_entries(mcp_json, venv_python)
     if not entries:
@@ -517,6 +520,22 @@ async def _register_mcp(
     from reyn.runtime.hot_reload import dispatch_install_reload, is_pure_addition
 
     config_path = _mcp_config_path(project_root)
+
+    # ── Permission gate — mcp.yaml write (#3088). The sibling capability
+    # registers in the same step (skills → _skill_install_handle, pipelines →
+    # _pipeline_install_handle) each gate their own config write via
+    # ``require_file_write``; this mcp register wrote ``.reyn/config/mcp.yaml``
+    # directly without one, an asymmetric ungated write on the registration
+    # axis (distinct from the global-copy write gate on ``~/.reyn/plugins/``
+    # above, which authorizes writing plugin CODE, not the mcp registration).
+    # Mirrors skill_install.py:522 / pipeline_install.py:395's shape exactly.
+    if ctx.permission_resolver is not None:
+        sandbox = _sandbox_policy_from_ctx(ctx)
+        await ctx.permission_resolver.require_file_write(
+            ctx.permission_decl, str(config_path), ctx.actor,
+            sandbox_policy=sandbox, bus=ctx.intervention_bus,
+        )
+
     data = _read_yaml(config_path)
     servers = data.setdefault("mcp", {}).setdefault("servers", {})
 

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -8,6 +8,10 @@ Tests:
   2. enforcement (real PermissionResolver, no approval): the global-copy
      write is denied — demonstrates the gate is load-bearing, not decorative
      (CLAUDE.md: gate strip-falsify, real resolver not None).
+  2b. #3088: the mcp register's OWN require_file_write gate on mcp.yaml
+     (distinct from the global-copy gate) — denied without approval for that
+     path (nothing written), approved → registered + mcp_server_installed
+     audit event fires.
   3. reconcile: a plugin dir left with an _install_state.json marker AND a
      mid-register registry entry (a simulated crash between register and
      completion) is rolled back — BOTH the registry entry and the copy — by
@@ -61,11 +65,15 @@ class _StubWorkspace:
 
 
 class _Events:
-    """Minimal real-callable event log stub — passes emit calls through without side effects."""
+    """Minimal real-callable event log stub — records emitted calls (for
+    audit-event witnessing) without any other side effect."""
     subscribers: list = []
 
-    def emit(self, *_a, **_k) -> None:
-        pass
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def emit(self, *args, **kwargs) -> None:
+        self.calls.append((args, kwargs))
 
 
 class _FakeBus:
@@ -129,6 +137,7 @@ def _make_ctx(
     tmp_path: Path,
     *,
     approve_plugins_root: bool = True,
+    approve_mcp_yaml: bool = True,
     interactive: bool = False,
     bus: object | None = None,
     approve_all_http: bool = False,
@@ -138,6 +147,14 @@ def _make_ctx(
     (recursive) + the three registry config files — the granted-path
     baseline every non-enforcement test needs. The enforcement test passes
     False to demonstrate the gate actually denies without it.
+
+    ``approve_mcp_yaml`` (default True, independent of ``approve_plugins_root``)
+    controls whether ``.reyn/config/mcp.yaml`` specifically is session-approved
+    — the mcp register's OWN require_file_write gate (#3088), distinct from the
+    global-copy write gate on ``~/.reyn/plugins/``. A test demonstrating THAT
+    gate is load-bearing passes False here while leaving
+    ``approve_plugins_root`` True (the copy proceeds; the mcp registration
+    write is what gets denied).
 
     ``approve_all_http`` session-approves the http.get wildcard host — this is
     the FETCH axis (git clone / pypi reachability). The run-code trust gate is
@@ -152,10 +169,14 @@ def _make_ctx(
     )
     if approve_plugins_root:
         resolver.session_approve_path(str(plugins_root()), "test", "file.write", recursive=True)
-        for cfg in ("mcp.yaml", "pipelines.yaml", "skills.yaml"):
+        for cfg in ("pipelines.yaml", "skills.yaml"):
             resolver.session_approve_path(
                 str(project_root / ".reyn" / "config" / cfg), "test", "file.write",
             )
+    if approve_mcp_yaml:
+        resolver.session_approve_path(
+            str(project_root / ".reyn" / "config" / "mcp.yaml"), "test", "file.write",
+        )
     if approve_all_http:
         # http.get is EXACT-host-matched at the gate (a "*" session approval
         # does not cover a specific host), so approve the concrete host the
@@ -249,6 +270,87 @@ async def test_plugin_install_denied_without_write_approval(tmp_path, monkeypatc
 
     assert not (plugins_root() / "unapproved-plugin").exists(), (
         "plugin copy was written despite a denied permission gate"
+    )
+
+
+# ── Test 2b: mcp register's OWN write gate (#3088) ────────────────────────────
+
+
+def _make_mcp_plugin_source(base: Path, name: str = "mcpplugin") -> Path:
+    """A minimal local plugin dir: manifest + one mcp capability (no
+    requirements.txt — offline, no ``uv`` dependency)."""
+    plugin_dir = base / name
+    (plugin_dir / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name, "version": "0.1.0", "description": "mcp test plugin",
+            "capabilities": [{"kind": "mcp"}],
+        }),
+        encoding="utf-8",
+    )
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"srv": {"command": "python", "args": ["-m", "srv"]}}}),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_denied_without_mcp_yaml_write_approval(tmp_path, monkeypatch):
+    """Tier 2: security-critical gate — #3088. ``_register_mcp`` writes
+    ``.reyn/config/mcp.yaml`` via its OWN ``require_file_write`` gate, DISTINCT
+    from the global-copy write gate on ``~/.reyn/plugins/`` (which IS approved
+    here). Without a grant for mcp.yaml specifically, a real PermissionResolver
+    denies the mcp registration write. RED if plugin_install writes mcp.yaml
+    despite no approval for that path — the exact asymmetric ungated write
+    #3088 reports (sibling skill/pipeline registers already gated their own
+    config write; mcp's register did not)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    source = _make_mcp_plugin_source(tmp_path / "src")
+    ctx = _make_ctx(tmp_path, approve_plugins_root=True, approve_mcp_yaml=False)
+
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(source)})
+    with pytest.raises(PermissionError):
+        await install_handle(op, ctx)
+
+    mcp_yaml = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    assert not mcp_yaml.exists(), (
+        "mcp.yaml was written despite a denied permission gate on that path"
+    )
+    # The global copy DID proceed (that gate was granted) — demonstrating the
+    # mcp.yaml denial is this OP's own gate, not a knock-on of the copy gate.
+    assert (plugins_root() / "mcpplugin").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_gate_allows_and_emits_audit_event(tmp_path, monkeypatch):
+    """Tier 2: with mcp.yaml write approved, the register proceeds — the entry
+    lands in mcp.yaml (tagged plugin_id) AND the ``mcp_server_installed`` audit
+    event fires through ``ctx.events``. Complements the denial test above:
+    together they show the new gate blocks when unapproved and does not
+    regress the approved (existing-behavior) path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    source = _make_mcp_plugin_source(tmp_path / "src")
+    ctx = _make_ctx(tmp_path)  # approve_mcp_yaml defaults True
+
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(source)})
+    result = await install_handle(op, ctx)
+
+    assert result["status"] == "installed", f"install failed: {result}"
+
+    mcp_yaml = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    servers = yaml.safe_load(mcp_yaml.read_text(encoding="utf-8"))["mcp"]["servers"]
+    assert servers["srv"]["plugin_id"] == "mcpplugin"
+
+    audit_event_names = [call[0][0] for call in ctx.events.calls if call[0]]
+    assert "mcp_server_installed" in audit_event_names, (
+        "mcp registration succeeded but emitted no mcp_server_installed audit event"
     )
 
 


### PR DESCRIPTION
**[per-PR-coder]** — Fixes #3088: `plugin_install._register_mcp` wrote `.reyn/config/mcp.yaml` directly (`_write_yaml(config_path, data)`, `plugin_install.py:542`) with **no `require_file_write` gate**, asymmetric with the sibling capability registers in the same `plugin_install` register step — skills (`_skill_install_handle`) and pipelines (`_pipeline_install_handle`) both already gate their own config write.

## Fix

`_register_mcp` now gates the mcp.yaml write via `require_file_write`, mirroring `skill_install.py:522` / `pipeline_install.py:395`'s shape exactly:

```python
if ctx.permission_resolver is not None:
    sandbox = _sandbox_policy_from_ctx(ctx)
    await ctx.permission_resolver.require_file_write(
        ctx.permission_decl, str(config_path), ctx.actor,
        sandbox_policy=sandbox, bus=ctx.intervention_bus,
    )
```

Placed right after computing `entries` (early-return when there's nothing to register, mirroring siblings' "gate right before the registry read/write" ordering), before the existing `_read_yaml`/`servers.setdefault` mutation. `bus=ctx.intervention_bus` is threaded so a sandbox-narrowed write can still be interactively JIT-approved, same as the already-gated siblings (#3086's fix).

This closes the gap the architect (issue body) confirmed as low-severity-but-real: the global-copy gate on `~/.reyn/plugins/<name>/` authorizes writing plugin CODE, not the mcp *registration* — a distinct write axis, the same axis skills.yaml/pipelines.yaml are gated on.

## Fix-class sweep (per dispatch brief)

Grepped every config-yaml write call site under `src/reyn/core/op_runtime/*.py` and `src/reyn/tools/*.py` (`_write_yaml(`, `_write_yaml_config(`, `_write_hooks(`, raw `yaml.dump(`) and checked each caller for a preceding `require_file_write`:

| Call site | Gated? |
|---|---|
| `mcp_install.py:631` | yes (`:423`) |
| `mcp_drop_server.py:242` | yes (`:222`) |
| `plugin_install.py:313` (global-copy) | yes (`:690`, pre-existing) |
| `plugin_install.py:542` (`_register_mcp`) | **was NOT — fixed here** |
| `plugin_uninstall.py:62` | yes (`:56`) |
| `pipeline_install.py:433` | yes (`:395`) |
| `presentation_install.py:155` | yes (`:119`) |
| `skill_install.py:568` | yes (`:522`) |
| `mcp_verbs.py:504` (`mcp__install_local`) | yes (`:425`) |
| `tools/cron.py` / `tools/hooks.py` | yes (own `_gate()` helper) |

Result: **`_register_mcp`'s mcp.yaml write was the sole fully-ungated instance of this class.** No other sweep findings — nothing else needed gating in this PR.

**Out of scope (separate issue #3089):** whether every *already-gated* call above threads `bus=` for JIT interactive approval is a distinct audit tracked in #3089 — this PR does not re-audit that; `_register_mcp`'s new gate does pass `bus=` (mirroring the current sibling shape) but that is incidental to closing #3088, not a #3089 sweep.

## Test witness (`tests/test_plugin_install.py`)

Real `PermissionResolver` + real `OpContext` (no mocks), mirroring the file's existing `_make_ctx` pattern:

- `test_register_mcp_denied_without_mcp_yaml_write_approval`: `~/.reyn/plugins/` write IS approved (global-copy gate passes, plugin copy lands) but `.reyn/config/mcp.yaml` is NOT approved → `PermissionError`, `mcp.yaml` never written. Demonstrates the new gate is the register's OWN gate, not a knock-on of the copy gate.
- `test_register_mcp_gate_allows_and_emits_audit_event`: mcp.yaml approved (default) → install succeeds, entry written (`plugin_id` tagged), and `mcp_server_installed` fires through `ctx.events` (audit-event witness).

`_make_ctx` gained an `approve_mcp_yaml` param (default `True`, so all pre-existing tests are unaffected) to isolate this gate from the plugins-root/pipelines/skills approvals it previously bundled together.

## Local gates (all foreground, all green)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_plugin_install.py` — 14/14 OK, 0 Tier-4 violations
- `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/plugin_install.py tests/test_plugin_install.py` — OK
- `python -m pytest` (full suite) — **9041 passed, 29 skipped**, 366s

CI[Linux] not awaited per dispatch brief — lead-coder will confirm CI green.

Co-vet: architect (permission-system change).

Closes #3088