### PR TITLE
**[per-PR-coder]** — cli(embeddings): remove sentence-transformers cache management, keep SQLite index (PR-C, #3128)

### DIFF
--- a/src/reyn/interfaces/cli/commands/embeddings.py
+++ b/src/reyn/interfaces/cli/commands/embeddings.py
@@ -8,8 +8,15 @@ machinery that backs ``search_actions``:
   rebuild  force a rebuild of the action index on next chat session
            start (= removes the SQLite cache so the next ``build()``
            call re-embeds)
-  clear    wipe the cache directory entirely (= SQLite index, build
-           lock, downloaded sentence-transformers model cache)
+  clear    wipe the cache directory entirely (= SQLite index cache
+           + build lock)
+
+#3128 removed reyn's in-process sentence-transformers backend — reyn
+depends on litellm exclusively for embeddings now, so this command no
+longer manages a downloaded-model cache. It still manages the SQLite
+action-index cache (``.reyn/cache/index/actions/``), which is shared
+substrate with the litellm-fronted embedding path (and any other
+``IndexBackend`` source), not ST-specific.
 
 The shape mirrors ``reyn mcp list`` (= header + aligned rows) per the
 tui-coder + lead-coder consolidated O4 decision in FP-0043. ``--json``
@@ -25,7 +32,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import shutil
 import sqlite3
 from dataclasses import dataclass
@@ -44,10 +50,10 @@ class ClassRow:
     """One row in the ``status`` output."""
 
     name: str
-    backend: str          # "litellm" / "sentence-transformers"
+    backend: str          # always "litellm" (#3128: litellm-exclusive)
     model: str            # resolved model string (= class.model)
     cache_path: str       # filesystem path or "(memory only)"
-    size_mb: float        # cached SQLite + model bytes, 0.0 when absent
+    size_mb: float        # cached SQLite index bytes, 0.0 when absent
     indexed_actions: int  # vectors row count, 0 when absent / unreadable
     last_built: str       # ISO timestamp or "(never)"
 
@@ -67,25 +73,6 @@ def _resolve_action_index_dir(project_root: Path) -> Path:
     the absence is a clean state.
     """
     return cache_dir_for_source(project_root, DEFAULT_ACTION_SOURCE)
-
-
-def _resolve_st_cache_dir() -> Path:
-    """Return the sentence-transformers model cache dir.
-
-    Honours the same precedence the runtime backend uses:
-      REYN_CACHE_DIR > XDG_CACHE_HOME > ~/.cache/reyn/
-    See ``src/reyn/data/embedding/sentence_transformers_provider.py``
-    for the canonical implementation; we duplicate the resolution
-    here (rather than importing it) to avoid a transitive
-    ``sentence_transformers`` import the CLI doesn't need.
-    """
-    if v := os.environ.get("REYN_CACHE_DIR"):
-        root = Path(v).expanduser()
-    elif v := os.environ.get("XDG_CACHE_HOME"):
-        root = Path(v).expanduser() / "reyn"
-    else:
-        root = Path.home() / ".cache" / "reyn"
-    return root / "sentence-transformers"
 
 
 def _get_project_root() -> Path:
@@ -145,13 +132,6 @@ def _read_index_state(index_dir: Path) -> tuple[int, str]:
     return n, last_built
 
 
-def _backend_for_model(model: str) -> str:
-    """Return ``litellm`` or ``sentence-transformers`` based on prefix."""
-    if model.startswith("sentence-transformers/"):
-        return "sentence-transformers"
-    return "litellm"
-
-
 def _collect_status_rows(project_root: Path) -> list[ClassRow]:
     """Build one ``ClassRow`` per configured embedding class.
 
@@ -190,22 +170,15 @@ def _collect_status_rows(project_root: Path) -> list[ClassRow]:
         except (sqlite3.DatabaseError, OSError):
             pass
 
-    st_cache_dir = _resolve_st_cache_dir()
-    st_cache_size = _dir_size_mb(st_cache_dir)
     index_size = _dir_size_mb(index_dir)
 
     rows: list[ClassRow] = []
     for class_name, spec in sorted(classes.items()):
-        backend = _backend_for_model(spec.model)
-        # The cache_path column shows where each backend's persistent
-        # state lives: the action index SQLite for all classes, plus
-        # the HF model cache for sentence-transformers entries.
-        if backend == "sentence-transformers":
-            cache_path = str(st_cache_dir)
-            size_mb = st_cache_size + index_size
-        else:
-            cache_path = str(index_dir)
-            size_mb = index_size
+        # All classes route through litellm (#3128: no in-process ST
+        # backend), so cache_path / size_mb are always the shared
+        # action-index SQLite.
+        cache_path = str(index_dir)
+        size_mb = index_size
 
         # Only the class that the on-disk meta currently records gets
         # the indexed_actions / last_built numbers; others get the
@@ -220,7 +193,7 @@ def _collect_status_rows(project_root: Path) -> list[ClassRow]:
 
         rows.append(ClassRow(
             name=class_name,
-            backend=backend,
+            backend="litellm",
             model=spec.model,
             cache_path=cache_path,
             size_mb=size_mb,
@@ -347,29 +320,29 @@ def run_rebuild(args: argparse.Namespace) -> None:
 
 
 def run_clear(args: argparse.Namespace) -> None:
-    """``reyn embeddings clear`` — wipe action index + sentence-transformers cache.
+    """``reyn embeddings clear`` — wipe the action index cache.
 
     Aggressive: removes the entire action-index cache directory (the
-    unified ``.reyn/cache/index/actions/`` since FP-0057 Phase 0)
-    AND the sentence-transformers HF model cache resolved per the
-    REYN_CACHE_DIR / XDG_CACHE_HOME precedence. Useful for "the cache
-    is corrupted" or "I want to switch backends and reclaim disk".
+    unified ``.reyn/cache/index/actions/`` since FP-0057 Phase 0).
+    Useful for "the cache is corrupted" or "I want to reclaim disk".
+
+    #3128 removed the in-process sentence-transformers backend, so
+    this no longer also wipes a downloaded-model cache — the SQLite
+    action index is the only on-disk state this command manages.
     """
     project_root = _get_project_root()
     index_dir = _resolve_action_index_dir(project_root)
-    st_cache_dir = _resolve_st_cache_dir()
 
     removed_bytes_mb = 0.0
-    for target in (index_dir, st_cache_dir):
-        if target.exists():
-            removed_bytes_mb += _dir_size_mb(target)
-            try:
-                shutil.rmtree(target)
-                print(f"removed {target}")
-            except OSError as exc:
-                print(f"warning: could not remove {target}: {exc}")
-        else:
-            print(f"skip {target} (= absent)")
+    if index_dir.exists():
+        removed_bytes_mb += _dir_size_mb(index_dir)
+        try:
+            shutil.rmtree(index_dir)
+            print(f"removed {index_dir}")
+        except OSError as exc:
+            print(f"warning: could not remove {index_dir}: {exc}")
+    else:
+        print(f"skip {index_dir} (= absent)")
 
     if removed_bytes_mb > 0:
         print(f"freed ~{removed_bytes_mb:.2f} MB")
@@ -434,11 +407,10 @@ def register(sub: Any) -> None:
     # clear
     clear = inner.add_parser(
         "clear",
-        help="Wipe the action index and the local model cache directory",
+        help="Wipe the action index cache directory",
         description=(
-            "Remove .reyn/cache/index/actions/ AND the sentence-transformers "
-            "model cache directory. Aggressive: useful for cache "
-            "corruption or backend swap reclamation."
+            "Remove .reyn/cache/index/actions/. Aggressive: useful for "
+            "cache corruption or reclaiming disk."
         ),
     )
     clear.set_defaults(func=run_clear)

--- a/tests/test_reyn_embeddings_cli.py
+++ b/tests/test_reyn_embeddings_cli.py
@@ -7,16 +7,21 @@ Pins the operator-facing CLI surface:
      size_mb / indexed_actions / last_built).
   2. ``--json`` emits a JSON list matching the table column names so
      downstream scripts can aggregate without parsing the table.
-  3. Backend column is derived from the ``model`` prefix (= "litellm"
-     for non-prefixed / "sentence-transformers" for the ``sentence-
-     transformers/`` prefix).
-  4. ``reyn embeddings rebuild`` drops the on-disk action index SQLite
+  3. ``reyn embeddings rebuild`` drops the on-disk action index SQLite
      + the build-lock marker; a missing index reports "nothing to
      rebuild" without erroring.
-  5. ``reyn embeddings rebuild <name>`` rejects unknown class names.
-  6. ``reyn embeddings clear`` removes the action index directory AND
-     the sentence-transformers cache directory; absent paths are
-     reported as skipped.
+  4. ``reyn embeddings rebuild <name>`` rejects unknown class names.
+  5. ``reyn embeddings clear`` removes the action index directory;
+     an absent directory is reported as skipped.
+
+#3128 (PR-C) removed reyn's in-process sentence-transformers backend:
+``backend`` is now always ``"litellm"`` (all ``embedding.classes``
+route through litellm — see ``src/reyn/config/embedding.py``) and
+``clear`` no longer also wipes a downloaded-model cache dir. The
+SQLite action-index cache this command manages is shared substrate
+with the litellm-fronted embedding path (and any other
+``IndexBackend`` source), not ST-specific, so its status/rebuild/clear
+management is retained unchanged.
 
 FP-0057 Phase 0 (#2843): the action index now rides the unified
 ``IndexBackend`` (``chunks``/``meta`` schema, ``.reyn/cache/index/actions/``)
@@ -41,7 +46,6 @@ import numpy as np
 import pytest
 
 from reyn.interfaces.cli.commands.embeddings import (
-    _backend_for_model,
     _collect_status_rows,
     run_clear,
     run_rebuild,
@@ -103,17 +107,15 @@ def _write_index_db(
 # ── 1. backend resolution ─────────────────────────────────────────────────────
 
 
-def test_backend_for_litellm_prefix() -> None:
-    """Tier 2: non-prefixed model string → litellm backend."""
-    assert _backend_for_model("openai/text-embedding-3-small") == "litellm"
-
-
-def test_backend_for_sentence_transformers_prefix() -> None:
-    """Tier 2: ``sentence-transformers/`` prefix → sentence-transformers backend."""
-    assert (
-        _backend_for_model("sentence-transformers/all-MiniLM-L6-v2")
-        == "sentence-transformers"
-    )
+def test_status_rows_backend_is_always_litellm(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """Tier 2: every row's backend is "litellm" (#3128: litellm-exclusive)."""
+    monkeypatch.chdir(tmp_path)
+    rows = _collect_status_rows(tmp_path)
+    assert rows
+    for row in rows:
+        assert row.backend == "litellm"
 
 
 # ── 2. status row collection ────────────────────────────────────────────────
@@ -274,40 +276,32 @@ def test_rebuild_known_class_name_notes_shared_cache(
 # ── 5. clear ────────────────────────────────────────────────────────────────
 
 
-def test_clear_removes_index_dir_and_st_cache_dir(
+def test_clear_removes_index_dir(
     tmp_path: Path, monkeypatch, capsys,
 ) -> None:
-    """Tier 2: clear removes BOTH the action index dir AND the ST model cache.
+    """Tier 2: clear removes the action index cache directory.
 
-    Both directories are explicitly cleared; absent paths are reported
-    as skipped (= no crash on a clean install).
+    #3128 removed the in-process sentence-transformers backend, so
+    ``clear`` no longer also wipes a downloaded-model cache dir — the
+    SQLite action index is the only on-disk state it manages.
     """
-    # Override the ST cache so it's under tmp_path and we can verify removal
-    # without touching the developer's real ~/.cache.
-    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path / "reyn-cache"))
     monkeypatch.chdir(tmp_path)
     index_dir = _unified_index_dir(tmp_path)
     _write_index_db(index_dir, "standard", {"file__read": [0.1, 0.2]})
-    st_cache = tmp_path / "reyn-cache" / "sentence-transformers"
-    st_cache.mkdir(parents=True)
-    (st_cache / "model.bin").write_bytes(b"\x00" * 1024)
 
     run_clear(Namespace())
     out = capsys.readouterr().out
 
     assert not index_dir.exists(), "index dir should have been removed"
-    assert not st_cache.exists(), "ST cache dir should have been removed"
     assert "removed" in out
     assert "freed" in out
 
 
-def test_clear_on_absent_paths_reports_skip(
+def test_clear_on_absent_path_reports_skip(
     tmp_path: Path, monkeypatch, capsys,
 ) -> None:
     """Tier 2: clear on a clean project skips gracefully without error."""
-    monkeypatch.setenv("REYN_CACHE_DIR", str(tmp_path / "reyn-cache-empty"))
     monkeypatch.chdir(tmp_path)
     run_clear(Namespace())
     out = capsys.readouterr().out
-    # Both targets absent → two skip lines, no failure.
-    assert out.count("skip") >= 2
+    assert "skip" in out


### PR DESCRIPTION
**[per-PR-coder]** — PR-C of the #3128 5-PR clean-break arc (reyn depends on litellm exclusively for embeddings). co-vet = architect.

## Scope
`src/reyn/interfaces/cli/commands/embeddings.py` (+ its test). The `reyn embeddings` CLI is **kept** — only the in-process sentence-transformers pieces are removed, per the architect ruling in #3128: `status`/`rebuild`/`clear` manage the **SQLite action-index cache** (`.reyn/cache/index/actions/`), which is **shared substrate with the litellm-fronted embedding path** (and any other `IndexBackend` source), not ST-specific.

## Removed (ST-specific)
- `_resolve_st_cache_dir()` — the downloaded HF model-cache dir resolver (`REYN_CACHE_DIR`/`XDG_CACHE_HOME` > `~/.cache/reyn/sentence-transformers`). No in-process model to cache anymore.
- `_backend_for_model()` — the `sentence-transformers/`-prefix → `"sentence-transformers"` derivation. `ClassRow.backend` is now the literal `"litellm"` (all `embedding.classes` route through litellm — see `src/reyn/config/embedding.py`, ST default classes already removed in PR-A).
- `run_clear` no longer also `rmtree()`s the ST model-cache dir; it wipes the SQLite action-index dir only.
- ST-model bytes dropped from `status` `size_mb` accounting; the now-unused `os` import removed.
- Docstrings / argparse help updated (no more "downloaded model cache" / "backend swap").

## Kept (LiteLLM-shared, SQLite-index)
`status` (classes + on-disk index state), `rebuild` (drop `index.db` + WAL sidecars + `.build.lock`), `clear` (wipe index dir) — **behaviour unchanged** for the SQLite action-index cache.

## Split rationale (no over-removal of index management)
`backend` derivation and the ST-cache-dir resolver are the **only** ST-specific surfaces in this file. The entire `status`/`rebuild`/`clear` index-management body reads/writes the unified `IndexBackend` SQLite cache, which litellm-routed embeddings also populate — retained verbatim. No ambiguity where ST + index were entangled: the ST cache was a **separate directory** (`~/.cache/reyn/sentence-transformers`) with its own resolver, cleanly separable from the project-local `.reyn/cache/index/actions/` SQLite dir.

## Test adjustments
- Dropped the two `_backend_for_model` prefix tests → replaced with `test_status_rows_backend_is_always_litellm` (invariant: every status row's backend is `"litellm"`).
- Collapsed the two clear tests to the single index-dir target (no ST cache dir to stand up / assert removed): `test_clear_removes_index_dir` + `test_clear_on_absent_path_reports_skip`.
- SQLite-index `status`/`rebuild`/`clear` tests retained, real on-disk state in `tmp_path`, **no mocks**.

## Verification (local, foreground blocking — CI not awaited)
- `ruff check` (target files): pass
- `python scripts/test_tier_audit.py --strict tests/test_reyn_embeddings_cli.py`: 11/11 OK, 0 Tier-4
- `python scripts/verify_module_docstrings.py` (target src): OK
- target test: 11 passed
- **full-suite `pytest`: 8968 passed, 29 skipped in 341.56s**

## Out of scope
code (PR-A merged) / packaging (PR-B merged) / docs (PR-D) / grep-zero gate + wide test (PR-E, the final PR of the arc — it carries the umbrella-closing keywords for #3128 + #3046).

part of #3128

🤖 Generated with [Claude Code](https://claude.com/claude-code)

