### PR TITLE
refactor(session): make agent required, drop 9 duplicate flat identity params (#3133 P0 step-2)

### DIFF
--- a/docs/reference/runtime/session-construction.md
+++ b/docs/reference/runtime/session-construction.md
@@ -15,13 +15,18 @@ decomposition (identity, capability/visibility, multimodal, safety, misc lifecyc
 
 ## Identity (the `Agent` value object) — FP-0043 Stage 2
 
-`self._agent` is either the caller-supplied `Agent` value object, or (when `agent=None`,
-the direct/test-construction path) built from the flat identity params
-(`agent_name`/`model`/`permission_resolver`/`workspace_base_dir`/`workspace_state_dir`/
-`sandbox_config`/`sandbox_backend`/`environment_backend`/`agent_role`). In production,
-`build_scoped_chat_session` is the single chokepoint that assembles the real `Agent` and
-passes it in; the fallback exists purely so tests / other direct construction sites don't
-need to build one by hand — it is byte-identical to the pre-FP-0043 direct-attribute shape.
+`agent: Agent` is a **required** `__init__` param — the sole source of identity
+(#3133 Priority-0 step-2). There is no `agent=None` fallback and no duplicate flat
+identity params (`agent_name`/`model`/`permission_resolver`/`workspace_base_dir`/
+`workspace_state_dir`/`sandbox_config`/`sandbox_backend`/`environment_backend`/
+`agent_role`) on `Session.__init__` — they were removed together with the
+`Agent(...)` fallback construction they fed, so `agent_name != agent.agent_name`
+is no longer constructible. In production, `build_scoped_chat_session` is the
+single chokepoint that assembles the real `Agent` and passes it in as `agent=`.
+Tests build an `Agent` explicitly too — `tests/_support/agent_session.py`'s
+`make_session` helper (and the compaction helper in `tests/_support/session.py`)
+do this for every test call site, so no test constructs `Session` with the old
+flat identity kwargs either.
 
 `agent_name`/`model`/`_perm`/workspace dirs/`environment_backend`/`sandbox_config`/
 `sandbox_backend`/`workspace_dir`/`agent_role` are then read-only `@property` delegations

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -88,14 +88,15 @@ def build_scoped_chat_session(
     # scoped env/sandbox/workspace params + the name/model/resolver/role that flow
     # via ``**base``). Session reads all identity fields through this object
     # (delegating properties). This is the prerequisite seam for N Sessions sharing
-    # one Agent (a later stage); behaviour here is byte-identical. The identity
-    # params still flow through (for Session's direct/test fallback) — pruning
-    # them is a later-stage cleanup once sharing is wired.
+    # one Agent (a later stage); behaviour here is byte-identical.
+    # #3133 Priority-0 step-2: the 9 identity fields are POPPED from ``base``
+    # (not just read) so Session — whose flat identity params were removed —
+    # receives ``agent=`` exactly once, never a duplicate flat projection.
     agent = Agent(
-        agent_name=base["agent_name"],
-        role=base.get("agent_role", ""),
-        model=base.get("model", "standard"),
-        permission_resolver=base.get("permission_resolver"),
+        agent_name=base.pop("agent_name"),
+        role=base.pop("agent_role", ""),
+        model=base.pop("model", "standard"),
+        permission_resolver=base.pop("permission_resolver", None),
         workspace_base_dir=workspace_base_dir,
         workspace_state_dir=workspace_state_dir,
         sandbox_config=factory_config.sandbox_config,
@@ -111,7 +112,7 @@ def build_scoped_chat_session(
     task_waker = None
     if _registry is not None:
         from reyn.runtime.services.task_wake import TaskWaker  # noqa: PLC0415
-        task_waker = TaskWaker(_registry, base["agent_name"])
+        task_waker = TaskWaker(_registry, agent.agent_name)
     # #3121 step1: group the scoped capability / task / presentation / reactivity
     # params into their cohesive parameter objects at this single construction
     # chokepoint. ``intervention_bridge`` and the ``hooks_config``/
@@ -128,10 +129,6 @@ def build_scoped_chat_session(
     )
     return Session(
         agent=agent,
-        environment_backend=environment_backend,
-        sandbox_backend=sandbox_backend,
-        workspace_base_dir=workspace_base_dir,
-        workspace_state_dir=workspace_state_dir,
         agent_id=agent_id,
         router_max_iterations=router_max_iterations,
         non_interactive=non_interactive,
@@ -153,7 +150,6 @@ def build_scoped_chat_session(
             presentation_consumer=presentation_consumer,  # #2708 P1: present-sink consumer (.sink deferred to Session init)
             intervention_bridge=intervention_bridge,
         ),
-        sandbox_config=factory_config.sandbox_config,
         multimodal_config=factory_config.multimodal_config,
         action_retrieval_config=factory_config.action_retrieval_config,
         embedding_config=factory_config.embedding_config,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -30,7 +30,6 @@ from reyn.config import (  # noqa: F401
     RenderTemplateConfig,
     RouterConfig,
     SafetyConfig,
-    SandboxConfig,
 )
 from reyn.core.events.agent_snapshot import AgentSnapshot
 from reyn.core.events.anchor_store import truncate_anchor as _truncate_anchor
@@ -925,18 +924,21 @@ class _InterventionBundle:
 class Session:
     def __init__(
         self,
-        agent_name: str,
-        model: str = "standard",
+        # Identity value object (single source of truth; FP-0043, see
+        # session-construction.md#identity-the-agent-value-object-fp-0043-stage-2).
+        # Required — #3133 Priority-0 step-2 removed the 9 flat identity params
+        # (agent_name / agent_role / model / permission_resolver /
+        # workspace_base_dir / workspace_state_dir / sandbox_config /
+        # sandbox_backend / environment_backend) and the fallback construction
+        # path they fed, so agent_name != agent.agent_name is no longer
+        # constructible.
+        agent: "Agent",
         resolver: ModelResolver | None = None,
-        permission_resolver: PermissionResolver | None = None,
-        # Identity value object; None -> built from the identity params below (FP-0043, see session-construction.md#identity-the-agent-value-object-fp-0043-stage-2)
-        agent: "Agent | None" = None,
         safety: "SafetyConfig | None" = None,
         mcp_servers: dict | None = None,
         output_language: str | None = None,
         prompt_cache_enabled: bool = True,
         project_context: str = "",
-        agent_role: str = "",
         compaction_config: "CompactionConfig | None" = None,
         reasoning_config: "ReasoningConfig | None" = None,  # #1652 chat.reasoning
         registry: "AgentRegistry | None" = None,
@@ -951,13 +953,6 @@ class Session:
         state_log: StateLog | None = None,
         budget_tracker: BudgetTracker | None = None,
         snapshot_path: "Path | None" = None,
-        sandbox_config: "SandboxConfig | None" = None,
-        # Agent EnvironmentBackend INSTANCE for the chat FS seam (#1200 PR-F1, see session-construction.md#identity-the-agent-value-object-fp-0043-stage-2)
-        environment_backend: "EnvironmentBackend | None" = None,
-        workspace_base_dir: "Path | None" = None,  # #187: chat OpContext FS root — the container repo root (e.g. /testbed) when env-backend routes the repo into a container; None → host cwd
-        workspace_state_dir: "Path | None" = None,  # #187: host-side OS state dir, decoupled from a container base_dir (survives container death)
-        # Agent SandboxBackend INSTANCE for the chat exec seam (#1200 PR-F2, see session-construction.md#identity-the-agent-value-object-fp-0043-stage-2)
-        sandbox_backend: "SandboxBackend | None" = None,
         multimodal_config: "MultimodalConfig | None" = None,
         action_retrieval_config: "ActionRetrievalConfig | None" = None,
         # Chat-layer tool-use scheme name, threaded to RouterLoop (#1593 PR-2, default per #1657)
@@ -1010,18 +1005,10 @@ class Session:
         presentation_registry = presentation_wiring.presentation_registry
         presentation_consumer = presentation_wiring.presentation_consumer
         intervention_bridge = presentation_wiring.intervention_bridge
-        # Identity cluster owned by Agent; test-construction falls back to identity params (FP-0043, see session-construction.md#identity-the-agent-value-object-fp-0043-stage-2)
-        self._agent = agent if agent is not None else Agent(
-            agent_name=agent_name,
-            role=agent_role,
-            model=model,
-            permission_resolver=permission_resolver,
-            workspace_base_dir=workspace_base_dir,
-            workspace_state_dir=workspace_state_dir,
-            sandbox_config=sandbox_config,
-            sandbox_backend=sandbox_backend,
-            environment_backend=environment_backend,
-        )
+        # Identity cluster owned by Agent — single source of truth, no fallback
+        # construction (#3133 Priority-0 step-2; the 9 flat identity params +
+        # the None-fallback Agent(...) build were removed here).
+        self._agent = agent
         self._resolver = resolver or ModelResolver({})
         # Per-session runtime model override set by /model <class>; None -> Agent identity default, in-memory only
         self._model_override: str | None = None
@@ -1079,7 +1066,7 @@ class Session:
                 ),
                 project_root=Path.cwd(),
                 # path-refs carry resource_uri/source_agent for cross-host dispatch (#385 β sub-task 1)
-                agent_name=agent_name,
+                agent_name=self.agent_name,
                 # path-refs carry a url when this instance is HTTP-reachable (#385 β sub-task 3b)
                 base_url=multimodal_config.base_url,
             )
@@ -1107,7 +1094,7 @@ class Session:
         self._outbox_interceptor: Any = None
         # Embedding block + action_usage_tracker, byte-identical extraction, unmoved (#3082 Family 5, see session-construction.md#family-5-retrieval)
         _retrieval_bundle = self._build_retrieval_bundle(
-            self._action_retrieval, embedding_config, agent_name,
+            self._action_retrieval, embedding_config, self.agent_name,
         )
         self._action_embedding_index = _retrieval_bundle.action_embedding_index
         self._embedding_provider = _retrieval_bundle.embedding_provider

--- a/tests/_support/agent_session.py
+++ b/tests/_support/agent_session.py
@@ -1,26 +1,20 @@
 """Shared test helper: construct ``Session`` through its ``Agent`` identity
-object (single source of truth), instead of the pre-#3133-Priority-0 pattern
-of 259 test call sites constructing ``Session`` with flat identity kwargs
-(``agent_name`` / ``agent_role`` / ``model`` / ``permission_resolver`` /
-``workspace_base_dir`` / ``workspace_state_dir`` / ``sandbox_config`` /
-``sandbox_backend`` / ``environment_backend``) and leaving ``agent=None``.
+object (single source of truth) — the only construction path since
+#3133 Priority-0 step-2 made ``agent: Agent`` a required ``Session`` param
+and removed the 9 duplicate flat identity kwargs (``agent_name`` /
+``agent_role`` / ``model`` / ``permission_resolver`` / ``workspace_base_dir``
+/ ``workspace_state_dir`` / ``sandbox_config`` / ``sandbox_backend`` /
+``environment_backend``).
 
-Production construction (``scoped_session_factory.py``) always builds an
-``Agent`` explicitly and passes it alongside the same flat identity kwargs
-(see ``build_scoped_chat_session`` — the identity params still flow through
-``**base`` for Session's direct/test fallback path; pruning that duplication
-is #3133 Priority-0 step-2, a signature change out of scope here). This
-helper mirrors that exact production shape: it builds the ``Agent`` from the
-identity-owned kwargs *and* forwards the same kwargs to ``Session`` flat, so
-``self._agent`` (Agent SSoT) and the local ``agent_name`` variable Session
-still reads directly in a couple of spots (``_build_retrieval_bundle``,
-``MediaStore`` wiring) stay equal by construction rather than by
-coincidence.
-
-``Session.__init__`` itself is unchanged by this helper (step-1 is
-test-only) — it still accepts either ``agent=`` or the flat identity kwargs.
-This helper simply makes every migrated test call site exercise the same
-"build an Agent, pass it in" path production code uses.
+Production construction (``scoped_session_factory.py``) builds an ``Agent``
+from the identity-owned inputs and passes it as ``agent=`` alone (no
+duplicate flat forwarding — step-2 also stopped the factory's ``**base``
+double-pass). This helper mirrors that exact production shape: it pops the
+identity kwargs out of ``kwargs``, builds the ``Agent`` from them, and calls
+``Session(agent=agent, **kwargs)`` with the identity kwargs no longer present
+— so ``self._agent`` (Agent SSoT) and the ``self.agent_name`` property
+Session still reads directly in a couple of spots (``_build_retrieval_bundle``,
+``MediaStore`` wiring) are equal by construction, not by coincidence.
 """
 from __future__ import annotations
 
@@ -30,10 +24,12 @@ from reyn.runtime.agent import Agent
 from reyn.runtime.session import Session
 
 # Identity fields owned by Agent (see reyn.runtime.agent.Agent). Extracted
-# here (by their Session-kwarg name, which differs from the Agent field name
-# only for role/agent_role) so the helper can build the Agent instance from
-# whichever of these a call site happens to pass, while leaving them in
-# ``kwargs`` too — Session forwards them onward exactly as it did pre-helper.
+# here (by their pre-step-2 Session-kwarg name, which differs from the Agent
+# field name only for role/agent_role) so the helper can build the Agent
+# instance from whichever of these a call site happens to pass. These keys
+# are POPPED out of ``kwargs`` before the ``Session(...)`` call — step-2
+# removed them from Session's signature, so forwarding them flat would now
+# raise ``TypeError``.
 _AGENT_FIELD_FROM_KWARG = {
     "agent_name": "agent_name",
     "agent_role": "role",
@@ -51,7 +47,7 @@ def make_session(*, role: str | None = None, **kwargs: Any) -> Session:
     """Build a ``Session`` via an explicit ``Agent`` (identity SSoT).
 
     Accepts every kwarg the pre-migration flat ``Session(...)`` call sites
-    already pass — ``agent_name`` / ``agent_role`` / ``model`` / the other
+    already passed — ``agent_name`` / ``agent_role`` / ``model`` / the other
     Agent-owned fields, plus anything else Session's constructor takes
     (``state_log``, ``budget_tracker``, ``safety``, ...). ``role`` is the
     #3133-architect-authored alias for ``agent_role`` (both are accepted so a
@@ -60,8 +56,8 @@ def make_session(*, role: str | None = None, **kwargs: Any) -> Session:
     required).
 
     ``agent_name`` defaults to ``"test-agent"`` when the caller supplies
-    neither (Session's own ``agent_name`` param has no default, so every
-    prior direct-construction call site necessarily passed one already —
+    neither (Session's own ``agent`` param has no default, so every prior
+    direct-construction call site necessarily passed an identity already —
     this default only covers the degenerate case of calling the helper with
     no identity kwargs at all).
     """
@@ -70,7 +66,7 @@ def make_session(*, role: str | None = None, **kwargs: Any) -> Session:
     kwargs.setdefault("agent_name", "test-agent")
 
     agent_field_kwargs = {
-        agent_field: kwargs[kwarg_name]
+        agent_field: kwargs.pop(kwarg_name)
         for kwarg_name, agent_field in _AGENT_FIELD_FROM_KWARG.items()
         if kwarg_name in kwargs
     }

--- a/tests/_support/session.py
+++ b/tests/_support/session.py
@@ -56,18 +56,13 @@ def make_session(tmp_path: Path, *, t_max: int = 1_000_000) -> Session:
         use_chars4_estimate=True,  # deterministic: chars // 4
         section_caps_spec_tokens=0,  # keeps B_M positive for small T_max values
     )
-    # Built explicitly (rather than left for Session's agent=None fallback)
-    # so this helper also exercises the Agent-SSoT construction path (#3133
-    # Priority-0 step-1) -- agent_name/agent_role are still passed flat too,
-    # matching production's scoped_session_factory.py double-pass shape (see
-    # tests/_support/agent_session.py module docstring for why).
+    # Agent is the sole identity SSoT (#3133 Priority-0 step-2 removed the
+    # flat identity kwargs Session used to also accept alongside ``agent=``).
     agent = Agent(agent_name="default", role="")
     # Monkeypatch covers the engine's compute_budgets() call at Session init.
     with synthetic_t_max(t_max):
         return Session(
             agent=agent,
-            agent_name="default",
-            agent_role="",
             output_language="en",
             budget_tracker=bt,
             state_log=state_log,

--- a/tests/test_intervention_agent_routing.py
+++ b/tests/test_intervention_agent_routing.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 import pytest
 
+from reyn.runtime.agent import Agent
 from reyn.runtime.session import Session
 from reyn.runtime.session_buses import AgentRequestBus
 from reyn.user_intervention import InterventionAnswer, UserIntervention
@@ -130,7 +131,7 @@ def test_self_answer_branch_returns_directly_without_dispatch() -> None:
     handler returns it immediately without invoking
     ``_dispatch_intervention`` — the user surface is never touched.
     """
-    session = _SelfAnsweringSession(agent_name="t")
+    session = _SelfAnsweringSession(agent=Agent(agent_name="t"))
     iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
 
     answer = asyncio.run(session.handle_intervention(iv))
@@ -145,7 +146,7 @@ def test_self_answer_branch_emits_self_answer_event() -> None:
     """Tier 2: the self_answer branch emits ``intervention_routed`` with
     ``route="self_answer"``.
     """
-    session = _SelfAnsweringSession(agent_name="t")
+    session = _SelfAnsweringSession(agent=Agent(agent_name="t"))
     iv = UserIntervention(kind="permission.shell", prompt="Run ls?")
 
     asyncio.run(session.handle_intervention(iv))
@@ -185,8 +186,8 @@ def test_parent_delegate_branch_forwards_to_parent() -> None:
     child.handle_intervention → parent.handle_intervention →
     parent._try_self_answer.
     """
-    parent = _SelfAnsweringSession(agent_name="parent")
-    child = _DelegatingSession(agent_name="child")
+    parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"))
+    child = _DelegatingSession(agent=Agent(agent_name="child"))
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
@@ -203,8 +204,8 @@ def test_parent_delegate_branch_emits_parent_delegate_event() -> None:
     forwarding. The parent's own routing decision generates a separate
     event on the parent's chat_events log.
     """
-    parent = _SelfAnsweringSession(agent_name="parent")
-    child = _DelegatingSession(agent_name="child")
+    parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"))
+    child = _DelegatingSession(agent=Agent(agent_name="child"))
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
@@ -245,8 +246,8 @@ def test_self_answer_takes_precedence_over_parent_delegate() -> None:
     This encodes "the agent has its own will" per the Reyn peer-to-peer
     design (issue #254 design discussion log).
     """
-    parent = _SelfAnsweringSession(agent_name="parent")
-    child = _SelfAndParentSession(agent_name="child")
+    parent = _SelfAnsweringSession(agent=Agent(agent_name="parent"))
+    child = _SelfAndParentSession(agent=Agent(agent_name="child"))
     child.set_parent(parent)
 
     iv = UserIntervention(kind="ask_user", prompt="Q?")
@@ -273,7 +274,7 @@ def test_self_answer_visible_through_request_bus_adapter() -> None:
     the self_answer policy fire — the adapter is fully transparent to
     the routing decision happening behind it.
     """
-    session = _SelfAnsweringSession(agent_name="t")
+    session = _SelfAnsweringSession(agent=Agent(agent_name="t"))
     bus = session.as_request_bus()
     assert isinstance(bus, AgentRequestBus)
 


### PR DESCRIPTION
**[per-PR-coder]** — #3133 Priority-0 **step-2** (architect spec firm, see issue comments). base = main (step-1 #3148 merged, 9c6ac4b3). co-vet = architect.

## What changed (3 synchronized locations)

1. **`src/reyn/runtime/session.py`** — `Session.__init__`:
   - `agent: Agent` is now **required** (no `agent=None` default).
   - Removed the **9 duplicate flat identity params**: `agent_name`, `agent_role`, `model`, `permission_resolver`, `workspace_base_dir`, `workspace_state_dir`, `sandbox_config`, `sandbox_backend`, `environment_backend`.
   - Removed the `agent=None` **fallback construction** (`Agent(agent_name=..., role=..., ...)`) that built an `Agent` from the flat params.
   - Redirected the **2 direct `agent_name` bare-Name reads** inside `__init__` (MediaStore wiring, `_build_retrieval_bundle` call) to `self.agent_name` (the existing `self._agent`-delegating property). All other identity accesses were already property-delegated (unchanged, per architect ground: verified via AST + direct read).

2. **`tests/_support/agent_session.py`** (`make_session`) — stopped forwarding the 9 identity kwargs flat to `Session(...)`; they are now **popped** out of `kwargs`, used only to build the `Agent`, and `Session(agent=agent, **kwargs)` is called with no duplicate identity kwargs left.

3. **`tests/_support/session.py`** (compaction test helper) — same double-pass stopped; now calls `Session(agent=agent, ...)` without the flat `agent_name=`/`agent_role=` duplicates.

4. **`src/reyn/runtime/scoped_session_factory.py`** — `build_scoped_chat_session`:
   - The identity fields are now **popped** from `**base` while building the `Agent` (`base.pop("agent_name")`, `base.pop("agent_role", "")`, `base.pop("model", "standard")`, `base.pop("permission_resolver", None)`) instead of merely read, so they can never re-flow into `Session(...)` via `**base`.
   - Removed the explicit duplicate `environment_backend=` / `sandbox_backend=` / `workspace_base_dir=` / `workspace_state_dir=` / `sandbox_config=` kwargs on the `Session(...)` call (Session no longer accepts them; the `Agent` object already carries them).
   - The one downstream reader of `base["agent_name"]` (TaskWaker construction) now reads `agent.agent_name` instead (the key was popped).

5. **`docs/reference/runtime/session-construction.md`** — Identity section rewritten to describe the required-`agent`, no-fallback, no-duplicate-params shape (was describing the pre-step-2 `agent=None` fallback + flat-param duplication).

## ★ Collision found and fixed during main-grep sweep

`grep -rn "agent_name="` (etc.) against `Session(`-touching files surfaced **`tests/test_intervention_agent_routing.py`**: three `Session` subclasses (`_SelfAnsweringSession`, `_DelegatingSession`, `_SelfAndParentSession`) were instantiated directly with `agent_name="..."` at 9 call sites (they don't override `__init__`, so the kwarg flowed straight to `Session.__init__`). Fixed by constructing an `Agent` explicitly and passing `agent=Agent(agent_name="...")` at each site (`import Agent` added).

Post-fix, `grep -rln "Session(" src tests | xargs grep -l "agent_name=\|agent_role=\|permission_resolver=\|workspace_base_dir=\|workspace_state_dir=\|sandbox_config=\|sandbox_backend=\|environment_backend="` still lists a handful of files, but every hit is a **false positive** (unrelated `agent_name=`/`permission_resolver=` usage — e.g. `OpContext` construction, `make_session(agent_name=...)`, docstring text — not a bare `Session(...)` call with a flat identity kwarg). The full-suite green run (below) is the structural proof: any missed caller would have raised `TypeError: unexpected keyword argument`.

`tests/test_scoped_session_factory_invariant_1402.py` independently pins that `Session(...)` is constructed only inside `scoped_session_factory.py` within `src/reyn` — unaffected by this PR, still green.

## Measurement gate

- **param count: 45 → 36** (AST-measured, `-9` exactly).
- `agent_name != agent.agent_name` is now **type-impossible to construct** (no separate `agent_name` param exists).
- Behavior unchanged — `self._agent` construction is byte-identical to what the removed fallback produced (architect-verified pre-step); all identity reads still resolve through the same delegating properties.

## Local gates (foreground, blocking — CI not awaited)

- `ruff check src tests` → **All checks passed!**
- `python scripts/test_tier_audit.py --strict <changed test files>` → **0 errors** (11 tests inspected in `test_intervention_agent_routing.py`, all OK)
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/scoped_session_factory.py` → **OK**
- `pytest` (full suite, foreground, from repo root) → **8977 passed, 29 skipped, 0 failed**

## Test plan

- [x] Full FULL-suite green (8977 passed / 29 skipped / 0 failed) — see gates above.
- [x] ruff clean.
- [x] tier audit clean on changed test files.
- [x] module-docstring check clean.
- [x] Main-grep collision sweep performed; the one real collision (`test_intervention_agent_routing.py` subclasses) found and fixed in this PR.
- [x] Doc (`session-construction.md`) updated in the same PR (Hard rule: doc-mechanism-change sync).

part of #3133

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>