### PR TITLE
refactor(session): extract SpawnTracker (spawn/vanish lifecycle) — #3133 P3 Extract Class

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -11,7 +11,6 @@ import logging
 import re
 import time
 import uuid
-from collections import OrderedDict
 from typing import Any, Awaitable, Callable, Literal
 
 logger = logging.getLogger(__name__)
@@ -92,6 +91,7 @@ from reyn.runtime.session_params import (
     ReactivityConfig,
     TaskWiring,
 )
+from reyn.runtime.spawn_tracker import SpawnTracker
 from reyn.security.permissions.permissions import PermissionResolver
 from reyn.services.compaction.engine import CompactionEngine
 from reyn.task.subscription import SubscriptionWriter
@@ -108,11 +108,8 @@ from reyn.user_intervention import (
 # (logged, never silently looped).
 _QUIESCE_MAX_ROUNDS = 50
 
-# #2103 S1bc-exec: cap on the in-flight spawned-task correlation record (sid → task).
-# Each entry is evicted when its result routes back; this cap bounds the pathological
-# case where results never arrive (spawned crash / lost reply) so the map can't grow
-# unbounded. Holds only pending spawns whose result hasn't returned.
-_MAX_SPAWNED_TASKS = 256
+# #2103 S1bc-exec: cap on the in-flight spawned-task correlation record (sid → task) —
+# moved to spawn_tracker.py's _MAX_SPAWNED_TASKS (#3133 P3 Extract Class).
 
 # Localized user-facing messages for the router retry-exhausted fallback (F8).
 # Keys are BCP-47-style language codes matching config `output_language`.
@@ -1040,10 +1037,10 @@ class Session:
         self._current_task_id: "str | None" = None
         # OS-authoritative provenance classification of the current turn, stamps entry["provenance"] (proposal 0060 Phase1 A7, see session-construction.md#safety-limits-interactive-mode)
         self._current_turn_origin: str = "auto_improvement"
-        # Spawned EPHEMERAL session auto-vanish state, set post-construction by the registry (#2103, see session-construction.md#safety-limits-interactive-mode)
+        # Spawned EPHEMERAL flag, set post-construction by the registry (#2103, see session-construction.md#safety-limits-interactive-mode).
+        # The vanish-scheduling state (_vanish_scheduled / _vanish_task) is owned by
+        # SpawnTracker, constructed below (see #3133 P3 Extract Class, spawn_tracker.py).
         self._ephemeral: bool = False
-        self._vanish_scheduled: bool = False
-        self._vanish_task: "asyncio.Task | None" = None
         # Lazily-resolved minimal _untrusted ContextualPermission cache (#1827 S4b context-auto)
         self._untrusted_contextual_cache = None
         # excluded_categories (#1667) + the visibility override (#2285) are owned by
@@ -1247,8 +1244,6 @@ class Session:
         # Publish as the process-wide active reloader so the hooks-write LLM-op can request_reload (#2073 S3, see session-construction.md#family-3-hook-event-reactivity)
         from reyn.runtime.hot_reload import set_active_hot_reloader
         set_active_hot_reloader(self._hot_reloader)
-        # sid -> trusted original-task record for spawned sessions, so a compromised sub-session can't forge task framing (#2103 S1bc-exec, see session-construction.md#capability-permission-visibility)
-        self._spawned_tasks: "OrderedDict[str, str]" = OrderedDict()
         # Detached by default; AgentRegistry.attach() flips this on to stop background display noise
         self.is_attached: bool = False
 
@@ -1306,6 +1301,23 @@ class Session:
         self._intervention_handler = _intervention_bundle.intervention_handler
         self._intervention_coordinator = _intervention_bundle.intervention_coordinator
         self._chain_timeout_glue = _intervention_bundle.chain_timeout_glue
+
+        # Owns the spawned-task correlation record + ephemeral auto-vanish scheduling
+        # state (#2103, see #3133 P3 Extract Class); Session holds one reference +
+        # delegates via thin forwarders, does not re-own the state (see spawn_tracker.py).
+        # session_id / ephemeral are read through LIVE providers -- both are reassigned
+        # post-construction by the registry (spawn-time re-key / ephemeral-spawn flip),
+        # so a value snapshot copied here would go stale (same hazard CapabilityVisibility,
+        # constructed below, documents for its own session_id_provider).
+        self._spawn_tracker = SpawnTracker(
+            registry=self._registry,
+            journal=self._journal,
+            chains=self._chains,
+            inbox=self.inbox,
+            agent_name=self.agent_name,
+            session_id_provider=lambda: self._session_id,
+            ephemeral_provider=lambda: self._ephemeral,
+        )
 
         # Delegation tracking for RouterLoop runs; None outside a run, cleared after each (F2)
         self._router_loop_delegations: list[dict] | None = None
@@ -1973,13 +1985,9 @@ class Session:
         return task
 
     def attach_anchor_store(self, anchor_store) -> None:
-        """Attach the shared per-checkpoint anchor store (#1547).
-
-        The registry injects its single ``AnchorStore`` so the journal's
-        ``cut_generation`` records the rewind-timeline preview text against the
-        same boundary seq the registry's ``list_rewind_points`` surfaces.
-        """
-        self._journal.set_anchor_store(anchor_store)
+        """Attach the shared per-checkpoint anchor store (#1547). Thin forwarder — see
+        ``SpawnTracker.attach_anchor_store`` for the full rationale (#3133 P3 Extract Class)."""
+        self._spawn_tracker.attach_anchor_store(anchor_store)
 
     def apply_per_session_narrowing(
         self, contextual_permission: "object | None", excluded_categories,
@@ -2840,24 +2848,17 @@ class Session:
         })
 
     # ── #2103 S1bc-exec: spawned-task correlation record (bounded) ──────────────
+    # Owned by SpawnTracker (#3133 P3 Extract Class); Session forwards.
 
     def record_spawned_task(self, sid: str, task: str) -> None:
-        """Record a session-I-spawned's ``sid → task`` BEFORE submitting it, so when its
-        result routes back the header renders ``task=<my OWN request>`` from this TRUSTED
-        record (not the spawned session's echo). Bounded: evicted on result arrival;
-        ``_MAX_SPAWNED_TASKS`` cap evicts oldest so a never-arriving result can't grow it."""
-        self._spawned_tasks[sid] = task
-        self._spawned_tasks.move_to_end(sid)
-        while len(self._spawned_tasks) > _MAX_SPAWNED_TASKS:
-            self._spawned_tasks.popitem(last=False)  # evict oldest in-flight
+        """Record a session-I-spawned's ``sid → task`` BEFORE submitting it. Thin
+        forwarder — see ``SpawnTracker.record_spawned_task`` for the full rationale."""
+        self._spawn_tracker.record_spawned_task(sid, task)
 
     def lookup_and_evict_spawned_task(self, sid: "str | None") -> "str | None":
-        """The TRUSTED task for a spawned ``sid``, or None (not one I spawned / already
-        consumed). Evict-on-read — a result is consumed once; a spoofed/unknown sid → None
-        → the caller renders the safe ``kind=agent`` fallback (still fenced)."""
-        if not sid:
-            return None
-        return self._spawned_tasks.pop(sid, None)
+        """The TRUSTED task for a spawned ``sid``, or None. Thin forwarder — see
+        ``SpawnTracker.lookup_and_evict_spawned_task`` for the full rationale."""
+        return self._spawn_tracker.lookup_and_evict_spawned_task(sid)
 
     async def shutdown(self) -> None:
         # `shutdown` is a control signal, not recovery state — skip WAL/snapshot.
@@ -5170,38 +5171,13 @@ class Session:
             await self._handle_hook_message(payload)
 
     def _maybe_schedule_ephemeral_vanish(self) -> None:
-        """#2103: an ephemeral spawned session auto-vanishes once its task is done —
-        the turn completed and no further trigger is queued (the inbox is drained, so
-        the run-loop is about to idle-block). Schedules a DETACHED teardown via the
-        registry's ``remove_session`` seam (the SAME teardown the rewind as-of-cut drop
-        uses): it quiesces + closes the per-session Task backend, cancels this idle
-        run-loop, drops the session, emits ``session_vanished``, and purges the dir.
-        Detached (not awaited here) because ``remove_session`` cancels THIS run-loop
-        task — running it inline would cancel the caller. Idempotent (the
-        ``_vanish_scheduled`` guard). The main session + persistent spawns are never
-        ``_ephemeral`` → unaffected.
-
-        "Task done" = the inbox is drained AND there is no AWAITED work whose resume
-        arrives OUTSIDE the now-empty inbox: a pending delegation chain (an
-        ``agent_response`` is still coming — ``self._chains``) or a live task-as-request
-        execution (``self._current_task_id``). Without these guards a spawned ephemeral
-        session that DELEGATES + awaits a response has a transiently-empty inbox
-        mid-await → it would vanish (dir purged + ``session_vanished``) before the
-        response lands = silent + destructive. A spawned session CAN reach delegate +
-        await (it has the full ChainManager + send_to_agent wiring), so the guard is
-        load-bearing, not theoretical."""
-        if (not self._ephemeral or self._vanish_scheduled
-                or self._registry is None or not self.inbox.empty()):
-            return
-        # awaited-work guard (delegate-then-await / live §16 task): the resume arrives
-        # outside the now-empty inbox, so emptiness alone is not "done".
-        if self._current_task_id is not None or self._chains.all_chain_ids():
-            return
-        self._vanish_scheduled = True
-        # Keep a strong ref (self._vanish_task) so the task is not GC'd before it runs
-        # (it self-cancels this run-loop, so it is otherwise unreferenced).
-        self._vanish_task = asyncio.create_task(
-            self._registry.remove_session(self.agent_name, self._session_id)
+        """#2103: schedule the ephemeral auto-vanish teardown once this session's turn
+        is idle-done. Thin forwarder — see ``SpawnTracker._maybe_schedule_ephemeral_vanish``
+        for the full rationale (#3133 P3 Extract Class). ``current_task_id`` is per-turn
+        mutable (reassigned every turn by ``_stamp_execution_context``), so it is threaded
+        as a call-time argument rather than baked into the tracker's construction."""
+        self._spawn_tracker._maybe_schedule_ephemeral_vanish(
+            current_task_id=self._current_task_id,
         )
 
     def _stamp_execution_context(self, kind: str, payload: dict) -> None:

--- a/src/reyn/runtime/spawn_tracker.py
+++ b/src/reyn/runtime/spawn_tracker.py
@@ -1,0 +1,184 @@
+"""SpawnTracker — the per-session spawn/vanish lifecycle subsystem (#3133 P3,
+extracted from ``Session`` via Extract Class, same Protocol-inject pattern as
+``CapabilityVisibility`` at #3129/#3121 step3).
+
+``Session`` historically owned three fields plus the four methods that
+read/write them: the trusted ``sid -> task`` record for sessions THIS session
+spawned (#2103 S1bc-exec), and the ephemeral auto-vanish scheduling state
+(#2103). This module extracts that cohesive field+method cluster into an
+INDEPENDENT class that OWNS the state — ``Session`` holds exactly one
+reference (``self._spawn_tracker``) and delegates via thin forwarders; it
+does not construct a bundle and unpack it back into its own fields (the
+#3082 Fowler anti-pattern this extraction is designed to avoid).
+
+Ownership split:
+
+- **Owned here**: ``_spawned_tasks`` (bounded ``sid -> task`` OrderedDict),
+  ``_vanish_scheduled`` (bool), ``_vanish_task`` (the detached teardown
+  task's strong ref) — mutated ONLY by the four methods below, no other
+  ``Session`` code path touches them (verified by grep).
+- **Injected dependency (constructor)**: ``registry`` / ``journal`` /
+  ``chains`` / ``inbox`` — stable for the session's lifetime, read but never
+  reassigned here. ``agent_name`` is likewise stable (``Agent`` is frozen,
+  same stability class as ``CapabilityVisibility.agent_name``).
+- **Injected dependency (live provider, constructor)**: ``session_id_provider``
+  and ``ephemeral_provider`` are zero-arg callables reading
+  ``Session._session_id`` / ``Session._ephemeral`` LIVE — both are
+  Session-owned state REASSIGNED post-construction by the owning
+  ``AgentRegistry`` (``session_id``: spawn-time re-key, ``registry.py``
+  ``spawn_session_recorded``; ``ephemeral``: ``registry.py``
+  ``spawn_session`` / ``pipeline_executor_driver.py`` set it True AFTER
+  ``Session.__init__`` returns), so a snapshot copied once at construction
+  would go stale and silently use the WRONG value (the same staleness hazard
+  ``CapabilityVisibility`` documents for its ``session_id_provider`` /
+  ``available_skills_provider``) — this class reads through a live getter
+  rather than owning a second, staleable copy. ★ Ground correction vs the
+  #3133 P3 firm comment (which specified plain ``session_id: str`` /
+  ``ephemeral: bool``): both fields are mutated by external assignment
+  (``session._session_id = ...`` / ``session._ephemeral = True``) after
+  construction, so a plain constructor value would freeze the pre-mutation
+  value forever — the same pattern #3129 already solved with a provider.
+- **Method-arg (per-turn mutable, NOT injected)**: ``current_task_id`` is
+  reassigned every turn (``session.py`` ``_stamp_execution_context``), so
+  ``_maybe_schedule_ephemeral_vanish`` takes it as a call-time argument
+  rather than a constructor dependency (per the #3133 P3 firm spec).
+"""
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from typing import Callable, Protocol
+
+_MAX_SPAWNED_TASKS = 256
+
+
+class _Registry(Protocol):
+    """The one method this class needs from its ``registry`` dep (the
+    ``AgentRegistry``): the single ephemeral-teardown seam also used by the
+    rewind as-of-cut drop. A Protocol keeps ``SpawnTracker`` decoupled from
+    the concrete registry type (no import of a ``Session`` sibling)."""
+
+    async def remove_session(self, agent_name: str, sid: str) -> bool: ...
+
+
+class _Journal(Protocol):
+    """The one method this class needs from its ``journal`` dep (the
+    session's recovery journal): attach the shared per-checkpoint anchor
+    store so ``cut_generation`` records against the registry's boundary."""
+
+    def set_anchor_store(self, anchor_store: object) -> None: ...
+
+
+class _Chains(Protocol):
+    """The one method this class needs from its ``chains`` dep (the
+    ``ChainManager``): whether a delegation chain is still pending an
+    ``agent_response`` — the awaited-work guard for auto-vanish."""
+
+    def all_chain_ids(self) -> "list[str]": ...
+
+
+class _Inbox(Protocol):
+    """The one method this class needs from the session's inbox queue:
+    whether the drain queue is empty (auto-vanish precondition)."""
+
+    def empty(self) -> bool: ...
+
+
+class SpawnTracker:
+    """Owns the per-session spawn/vanish lifecycle state (#2103 S1bc-exec /
+    #2103 auto-vanish) — the trusted spawned-task correlation record + the
+    ephemeral session auto-vanish scheduling."""
+
+    def __init__(
+        self,
+        *,
+        registry: "_Registry | None",
+        journal: "_Journal",
+        chains: "_Chains",
+        inbox: "_Inbox",
+        agent_name: str,
+        session_id_provider: "Callable[[], str]",
+        ephemeral_provider: "Callable[[], bool]",
+    ) -> None:
+        self._registry = registry
+        self._journal = journal
+        self._chains = chains
+        self._inbox = inbox
+        self._agent_name = agent_name
+        self._session_id_provider = session_id_provider
+        self._ephemeral_provider = ephemeral_provider
+        # sid -> trusted original-task record for spawned sessions, so a compromised
+        # sub-session can't forge task framing (#2103 S1bc-exec)
+        self._spawned_tasks: "OrderedDict[str, str]" = OrderedDict()
+        # Spawned EPHEMERAL session auto-vanish state (#2103)
+        self._vanish_scheduled: bool = False
+        self._vanish_task: "asyncio.Task | None" = None
+
+    # ── #2103 S1bc-exec: spawned-task correlation record (bounded) ──────────────
+
+    def record_spawned_task(self, sid: str, task: str) -> None:
+        """Record a session-I-spawned's ``sid -> task`` BEFORE submitting it, so when its
+        result routes back the header renders ``task=<my OWN request>`` from this TRUSTED
+        record (not the spawned session's echo). Bounded: evicted on result arrival;
+        ``_MAX_SPAWNED_TASKS`` cap evicts oldest so a never-arriving result can't grow it."""
+        self._spawned_tasks[sid] = task
+        self._spawned_tasks.move_to_end(sid)
+        while len(self._spawned_tasks) > _MAX_SPAWNED_TASKS:
+            self._spawned_tasks.popitem(last=False)  # evict oldest in-flight
+
+    def lookup_and_evict_spawned_task(self, sid: "str | None") -> "str | None":
+        """The TRUSTED task for a spawned ``sid``, or None (not one I spawned / already
+        consumed). Evict-on-read — a result is consumed once; a spoofed/unknown sid → None
+        → the caller renders the safe ``kind=agent`` fallback (still fenced)."""
+        if not sid:
+            return None
+        return self._spawned_tasks.pop(sid, None)
+
+    def attach_anchor_store(self, anchor_store: object) -> None:
+        """Attach the shared per-checkpoint anchor store (#1547).
+
+        The registry injects its single ``AnchorStore`` so the journal's
+        ``cut_generation`` records the rewind-timeline preview text against the
+        same boundary seq the registry's ``list_rewind_points`` surfaces.
+        """
+        self._journal.set_anchor_store(anchor_store)
+
+    def _maybe_schedule_ephemeral_vanish(self, *, current_task_id: "str | None") -> None:
+        """#2103: an ephemeral spawned session auto-vanishes once its task is done —
+        the turn completed and no further trigger is queued (the inbox is drained, so
+        the run-loop is about to idle-block). Schedules a DETACHED teardown via the
+        registry's ``remove_session`` seam (the SAME teardown the rewind as-of-cut drop
+        uses): it quiesces + closes the per-session Task backend, cancels this idle
+        run-loop, drops the session, emits ``session_vanished``, and purges the dir.
+        Detached (not awaited here) because ``remove_session`` cancels THIS run-loop
+        task — running it inline would cancel the caller. Idempotent (the
+        ``_vanish_scheduled`` guard). The main session + persistent spawns are never
+        ``_ephemeral`` -> unaffected.
+
+        "Task done" = the inbox is drained AND there is no AWAITED work whose resume
+        arrives OUTSIDE the now-empty inbox: a pending delegation chain (an
+        ``agent_response`` is still coming — ``self._chains``) or a live task-as-request
+        execution (``current_task_id``). Without these guards a spawned ephemeral
+        session that DELEGATES + awaits a response has a transiently-empty inbox
+        mid-await -> it would vanish (dir purged + ``session_vanished``) before the
+        response lands = silent + destructive. A spawned session CAN reach delegate +
+        await (it has the full ChainManager + send_to_agent wiring), so the guard is
+        load-bearing, not theoretical.
+
+        ``current_task_id`` is per-turn mutable (reassigned every turn by
+        ``Session._stamp_execution_context``), so the caller passes the current value
+        rather than this class owning a staleable copy.
+        """
+        if (not self._ephemeral_provider() or self._vanish_scheduled
+                or self._registry is None or not self._inbox.empty()):
+            return
+        # awaited-work guard (delegate-then-await / live §16 task): the resume arrives
+        # outside the now-empty inbox, so emptiness alone is not "done".
+        if current_task_id is not None or self._chains.all_chain_ids():
+            return
+        self._vanish_scheduled = True
+        # Keep a strong ref (self._vanish_task) so the task is not GC'd before it runs
+        # (it self-cancels this run-loop, so it is otherwise unreferenced).
+        self._vanish_task = asyncio.create_task(
+            self._registry.remove_session(self._agent_name, self._session_id_provider())
+        )

--- a/tests/test_2103_A_ephemeral_auto_vanish_1953.py
+++ b/tests/test_2103_A_ephemeral_auto_vanish_1953.py
@@ -70,7 +70,7 @@ async def test_ephemeral_spawn_auto_vanishes_persistent_survives(tmp_path):
     eph._maybe_schedule_ephemeral_vanish()
     per._maybe_schedule_ephemeral_vanish()
     # await the ephemeral teardown; the persistent session scheduled nothing.
-    vanish = eph._vanish_task
+    vanish = eph._spawn_tracker._vanish_task
     if vanish is not None:
         await vanish
 
@@ -100,8 +100,8 @@ async def test_ephemeral_does_not_vanish_while_awaiting_delegation(tmp_path):
     # drain any (erroneously) scheduled teardown so the assertion reflects the true
     # outcome — without this a stripped guard would schedule a DETACHED vanish that
     # hasn't run yet at the assert, hiding the regression.
-    if eph._vanish_task is not None:
-        await eph._vanish_task
+    if eph._spawn_tracker._vanish_task is not None:
+        await eph._spawn_tracker._vanish_task
 
     # the guard held: NOT vanished mid-await (public surface).
     assert sid in reg.session_ids("alice")
@@ -120,7 +120,7 @@ async def test_ephemeral_vanish_scheduled_once(tmp_path):
 
     eph._maybe_schedule_ephemeral_vanish()
     eph._maybe_schedule_ephemeral_vanish()  # second post-turn check — must not re-schedule
-    vanish = eph._vanish_task
+    vanish = eph._spawn_tracker._vanish_task
     if vanish is not None:
         await vanish
 

--- a/tests/test_2103_s1bc_exec_result_routing.py
+++ b/tests/test_2103_s1bc_exec_result_routing.py
@@ -255,7 +255,7 @@ async def test_gone_spawner_sid_drops_does_not_fallback_to_main(tmp_path, caplog
 async def test_spawned_tasks_record_is_bounded(tmp_path):
     """Tier 2: S1bc-exec — the trusted spawned-task record is bounded (evict-oldest past
     the cap) so never-arriving results can't grow it unbounded."""
-    from reyn.runtime.session import _MAX_SPAWNED_TASKS
+    from reyn.runtime.spawn_tracker import _MAX_SPAWNED_TASKS
     reg = _registry(tmp_path)
     main = reg.get_or_load("worker")
     # record cap+10 → the oldest 10 (indices 0..9) overflow + are evicted; indices

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -273,7 +273,7 @@ async def test_run_agent_step_ephemeral_session_vanishes(tmp_path: Path) -> None
     (spawned_sid,) = [sid for sid in reg.session_ids("worker") if sid != "main"]
     spawned = reg._peek_session("worker", spawned_sid)  # noqa: SLF001 — test-bridge, precedent above
     if spawned is not None:
-        vanish_task = spawned._vanish_task  # noqa: SLF001 — test-bridge, precedent above
+        vanish_task = spawned._spawn_tracker._vanish_task  # noqa: SLF001 — test-bridge, precedent above
         if vanish_task is not None:
             await vanish_task
 

--- a/tests/test_session_vanished_emit_2154.py
+++ b/tests/test_session_vanished_emit_2154.py
@@ -68,8 +68,8 @@ async def test_genuine_ephemeral_vanish_emits_session_vanished(tmp_path):
 
     eph = reg._peek_session("alice", sid)
     eph._maybe_schedule_ephemeral_vanish()
-    if eph._vanish_task is not None:
-        await eph._vanish_task
+    if eph._spawn_tracker._vanish_task is not None:
+        await eph._spawn_tracker._vanish_task
 
     # #2279: session_vanished is a FIRE-AND-FORGET WAL append (async-decoupled durability, #2259) —
     # drain the worker before the raw WAL read so the presence assert is deterministic (await'ing


### PR DESCRIPTION
**[per-PR-coder]** — part of #3133 (P3: Extract Class = SpawnTracker). co-vet=architect (厚め).

## 何をしたか
`Session` から **spawn/vanish ライフサイクル**を独立 class `SpawnTracker`（新 file `src/reyn/runtime/spawn_tracker.py`）へ Extract Class。#3129 `CapabilityVisibility` と同型の Protocol-inject + 委譲パターン。

- **抽出: 4 method / state 3** — `_spawned_tasks`（bounded sid→task record, #2103 S1bc-exec）/ `_vanish_scheduled` / `_vanish_task`（ephemeral auto-vanish, #2103）を **SpawnTracker が OWN**。method = `record_spawned_task` / `lookup_and_evict_spawned_task` / `attach_anchor_store` / `_maybe_schedule_ephemeral_vanish`（logic verbatim 移動）。`_MAX_SPAWNED_TASKS` も移設。
- **Protocol-inject（Session を import しない = 独立）** — `_Registry` / `_Journal` / `_Chains` / `_Inbox` の 4 Protocol で外部 dep を decouple。
  - ★ **firm spec からの ground 訂正**: architect の P3 firm は `session_id: str` / `ephemeral: bool` を plain 値で inject と指定でしたが、**両者とも構築後に外部代入で変わります**（`session._session_id = new_sid` at `registry.py` re-key / `session._ephemeral = True` at `registry.py` spawn + `pipeline_executor_driver.py`）。plain 値だと構築時の pre-mutation 値に凍結され stale になるため、#3129 が既に採った **live provider（`session_id_provider` / `ephemeral_provider`）**で受けています。dep 実数は 4 Protocol + agent_name + 2 provider。
- ★ **`_current_task_id` は per-turn mutable ゆえ inject でなく method-arg 化** — 毎ターン `_stamp_execution_context` で再代入されるため、`_maybe_schedule_ephemeral_vanish(current_task_id=...)` と呼び出し時に渡す。
- **Session 側**: `self._spawn_tracker = SpawnTracker(...)` の **1参照 + 委譲**。外部 caller のある 3 public method は **thin forwarder** を残す（byte-identical API）。★ logic の移動が本体、forwarder は API-glue。

## measurement gate（責務移譲で測る、#3082 lesson）
- `session.py`: **7381 → 7357 行**、diff は **+40 / −64（net −24 line 本体、うち forwarder が +数行の API-glue）**。owned-method **4 → 0**（thin forwarder に置換）、owned-state **3 → 0**。
- 新 `spawn_tracker.py`: **184 行、独立**（Protocol dep のみ、Session import なし、self-contained）。
- whole-repo は code 移動ゆえ横ばい（delete でなく move、#3129 と同じ）。

## ★ inject-back でない証明（grep 根拠）
```
# (1) Session は移動 state を再代入も直接 read もしない（全て _spawn_tracker 経由）
$ grep -n "self\._spawned_tasks\|self\._vanish_scheduled\|self\._vanish_task" src/reyn/runtime/session.py
（0 件）

# (2) Session の _spawn_tracker アクセスは「1 construction + 委譲のみ」
$ grep -n "self\._spawn_tracker" src/reyn/runtime/session.py
1312:  self._spawn_tracker = SpawnTracker(...)     # 唯一の construction
1990:  self._spawn_tracker.attach_anchor_store(...)   # 委譲
2856:  self._spawn_tracker.record_spawned_task(...)   # 委譲
2861:  return self._spawn_tracker.lookup_and_evict_spawned_task(...)  # 委譲
5179:  self._spawn_tracker._maybe_schedule_ephemeral_vanish(...)      # 委譲

# (3) SpawnTracker は Session を import しない（独立）
$ grep -n "import.*Session" src/reyn/runtime/spawn_tracker.py
59:  ...（docstring 内の "no import of a Session sibling" のみ、実 import なし）
```
→ SpawnTracker が state+method を OWN、Session は委譲のみ。`self._X = _tracker.Y` の再注入なし（#3082 Fowler anti-pattern 非該当）。

## Fowler 2コミット（move ≠ edit）
- commit 1 `move`: 新 `spawn_tracker.py` 追加（logic verbatim）。
- commit 2 `wire`: Session を委譲へ、旧 state/method/const 除去、test の test-bridge を `_spawn_tracker` 経由へ。

## behavior 不変
全既存 test 完全 green。spawn/vanish 関連 test（`test_2103_s1bc_exec_result_routing` / `test_2103_A_ephemeral_auto_vanish_1953` / `test_session_vanished_emit_2154` / `test_pipeline_r5_run_agent_step`）も更新の上 green。新 class の直接 unit test は追加せず、既存の Session 経由 behavior test が主 witness（testing.ja.md 準拠、過剰追加なし）。

## Test plan
- [x] `ruff check src tests` green
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` green（22 tests, 0 Tier-4 violation）
- [x] `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py src/reyn/runtime/spawn_tracker.py` green
- [x] `pytest`（full-suite, foreground blocking）green: **8977 passed, 29 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
