### PR TITLE
**[per-PR-coder]** — fix(security): thread bus= through 4 require_file_write callers (#3089 audit)

### DIFF
--- a/src/reyn/core/op_runtime/index_drop.py
+++ b/src/reyn/core/op_runtime/index_drop.py
@@ -60,7 +60,7 @@ async def handle(
         sources_yaml = workspace_root / ".reyn" / "config" / "index" / "sources.yaml"
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(sources_yaml), ctx.actor,
-            sandbox_policy=sandbox_policy,
+            sandbox_policy=sandbox_policy, bus=ctx.intervention_bus,
         )
         # #1199 S3.4 Part1: gate the actual deletion target — the source dir —
         # not just the manifest, so the destructive drop respects the phase
@@ -69,7 +69,7 @@ async def handle(
         source_dir = workspace_root / ".reyn" / "cache" / "index" / op.source
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(source_dir), ctx.actor,
-            sandbox_policy=sandbox_policy,
+            sandbox_policy=sandbox_policy, bus=ctx.intervention_bus,
         )
 
     # #2856 Part B: forward the cap into the backend — `drop` now self-gates

--- a/src/reyn/core/op_runtime/index_update.py
+++ b/src/reyn/core/op_runtime/index_update.py
@@ -111,12 +111,12 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
         db_path = cache_dir_for_source(workspace_root, op.source) / "index.db"
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(db_path), ctx.actor,
-            sandbox_policy=sandbox_policy,
+            sandbox_policy=sandbox_policy, bus=ctx.intervention_bus,
         )
         sources_yaml = sources_manifest_path(workspace_root)
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(sources_yaml), ctx.actor,
-            sandbox_policy=sandbox_policy,
+            sandbox_policy=sandbox_policy, bus=ctx.intervention_bus,
         )
 
     # #2856 Part B: forward the cap into the backend — its own self-gate on

--- a/src/reyn/core/op_runtime/mcp_drop_server.py
+++ b/src/reyn/core/op_runtime/mcp_drop_server.py
@@ -221,7 +221,7 @@ async def handle(
         # same as op_runtime/file.py — was missing here (permission-only gap).
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.actor,
-            sandbox_policy=_sandbox_policy_from_ctx(ctx),
+            sandbox_policy=_sandbox_policy_from_ctx(ctx), bus=ctx.intervention_bus,
         )
 
     # ── 3. Capture env keys before mutation ────────────────────────────

--- a/src/reyn/core/op_runtime/mcp_install.py
+++ b/src/reyn/core/op_runtime/mcp_install.py
@@ -420,9 +420,19 @@ async def handle(
         # same as op_runtime/file.py — was missing here, so the write/http gates
         # ran permission-only (SandboxLayer ⊤). None → ⊤ (unchanged).
         _sandbox = _sandbox_policy_from_ctx(ctx)
+        # #3089: thread ctx.intervention_bus through the write gate too — mirrors
+        # the require_http_get call right below in this SAME function, which
+        # already threads ctx.intervention_bus unconditionally (line ~435).
+        # Without this, a narrowed sandbox_policy that puts config_path OUTSIDE
+        # write_paths hard-denies with no prompt even when a real bus is sitting
+        # on ctx (the CLI ``mcp install --source`` entry point already
+        # constructs an OpContext with a real StdinInterventionBus —
+        # interfaces/cli/commands/mcp.py — so a future sandbox-narrowing fix
+        # there would silently regain the pre-#1505 hard-deny-only behavior
+        # without this).
         await ctx.permission_resolver.require_file_write(
             ctx.permission_decl, str(config_path), ctx.actor,
-            sandbox_policy=_sandbox,
+            sandbox_policy=_sandbox, bus=ctx.intervention_bus,
         )
         # Registry fetch happened via RegistryClient above — gate the
         # host symmetrically so the OS exercises its own permission

--- a/src/reyn/tools/cron.py
+++ b/src/reyn/tools/cron.py
@@ -200,6 +200,11 @@ async def _gate(ctx: ToolContext, job_name: str) -> None:
     ctx.permission_resolver.session_approve_path(
         cron_yaml_path, "cron", "file.write",
     )
+    # bus= not threaded: the session_approve_path above pre-approves this exact
+    # path (AgentLayer._approved → True) and no sandbox_policy is passed
+    # (SandboxLayer ⊤, no veto), so require_file_write's EffectivePermission
+    # returns early — the JIT-ask branch (`if bus is not None`) is unreachable
+    # here. Exempt, not an oversight (#3089 registry audit, 1 of 2 exempt sites).
     await ctx.permission_resolver.require_file_write(decl, cron_yaml_path, "cron")
 
 

--- a/src/reyn/tools/hooks.py
+++ b/src/reyn/tools/hooks.py
@@ -137,6 +137,11 @@ async def _gate(ctx: ToolContext) -> None:
     hooks_yaml_path = str(_hooks_yaml_path(ctx))
     decl = PermissionDecl(file_write=[{"path": hooks_yaml_path, "scope": "just_path"}])
     ctx.permission_resolver.session_approve_path(hooks_yaml_path, "hooks", "file.write")
+    # bus= not threaded: the session_approve_path above pre-approves this exact
+    # path (AgentLayer._approved → True) and no sandbox_policy is passed
+    # (SandboxLayer ⊤, no veto), so require_file_write's EffectivePermission
+    # returns early — the JIT-ask branch (`if bus is not None`) is unreachable
+    # here. Exempt, not an oversight (#3089 registry audit, 2 of 2 exempt sites).
     await ctx.permission_resolver.require_file_write(decl, hooks_yaml_path, "hooks")
 
 

--- a/tests/test_3089_op_runtime_require_file_write_bus.py
+++ b/tests/test_3089_op_runtime_require_file_write_bus.py
@@ -1,0 +1,424 @@
+"""Tier 2: OS invariant — #3089 index_update / index_drop / mcp_drop_server /
+mcp_install thread ``bus=ctx.intervention_bus`` through their config-write
+``require_file_write`` gate calls, mirroring the #3086 fix already applied to
+skill_install / pipeline_install / presentation_install.
+
+Root cause (same defect class as #3086): ``require_file_write`` only fires its
+JIT interactive prompt (#1505) when ``bus is not None`` — ``bus=None`` hard-
+denies outside the effective write zone with NO prompt (documented
+non-interactive behaviour). The four handlers audited here built the gate's
+``sandbox_policy=`` kwarg but omitted ``bus=ctx.intervention_bus``, so even
+when a real ``RequestBus`` was available on ``ctx`` these config writes could
+never be interactively approved once denied.
+
+Per-entry reachability (architect audit, #3089 issue comment — bounded,
+per-entry, #3037):
+
+  - **index_update / index_drop / mcp_drop_server** (FIX — reachable): their
+    tool wrappers (``tools/index_update.py`` / ``tools/drop_source.py`` /
+    ``tools/mcp_drop.py``) all prefer ``ctx.router_state.op_context_factory()``
+    when bound. That factory resolves to ``RouterHostAdapter.make_router_op_
+    context`` in the standard chat/phase host, which threads BOTH a real
+    (operator-narrowable via ``reyn.yaml``'s ``sandbox.policy.write_paths``)
+    ``default_sandbox_policy`` AND a real ``intervention_bus`` inline
+    (``router_host_adapter.py::make_router_op_context``, "RouterHostAdapter
+    wires intervention_bus inline" per ``router_op_context.py`` module
+    docstring). Their config write targets (``.reyn/config/index/sources.yaml``
+    / ``.reyn/config/mcp.yaml``) also live under the ``.reyn/config/``
+    recovery-core carve-out (``_RECOVERY_CORE_WRITE_PREFIXES`` —
+    ``permissions.py``), which is EXCLUDED from the broad ``.reyn/`` default
+    write zone — so a decl that hasn't explicitly declared/session-approved
+    the exact path denies at the AgentLayer stage alone, independent of any
+    sandbox narrowing. bus= is the only path back to a live decision instead
+    of a silent hard-deny.
+  - **mcp_install** (FIX — reachable, evidenced narrower than the other
+    three): unlike its 3 siblings, ``tools/mcp_install.py::_handle_mcp_
+    install_op`` never calls ``ctx.router_state.op_context_factory()`` — it
+    always builds a minimal ``OpContext`` that (today) never threads
+    ``default_sandbox_policy``. The fix mirrors the ``require_http_get`` call
+    in the SAME function (``op_runtime/mcp_install.py``, a few lines below),
+    which already threads ``ctx.intervention_bus`` unconditionally — and the
+    CLI ``mcp install --source`` entry point (``interfaces/cli/commands/
+    mcp.py``) already constructs a REAL ``StdinInterventionBus`` on its
+    ``OpContext`` for this exact ``handle()`` call. Reachability is proven
+    the same way the other three ops' handler-level tests prove it: a real
+    ``OpContext`` with a narrowed ``default_sandbox_policy`` + a real bus,
+    dispatched straight at ``op_runtime.mcp_install.handle`` (bypassing which
+    upstream tool wrapper built it — the require_file_write call itself does
+    not care who built its ctx, only what is ON it).
+
+Real ``PermissionResolver`` + a real-``RequestBus``-compatible Fake that
+pre-answers a scripted choice (mirrors ``test_config_write_jit_bus_3086.py``'s
+``_FakeBus`` / ``test_require_file_jit_ask_1505.py``) — no mocks.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.workspace.workspace import Workspace
+from reyn.intervention_choices import NO, YES
+from reyn.schemas.models import (
+    IndexDropIROp,
+    IndexUpdateIROp,
+    MCPDropServerIROp,
+    MCPInstallIROp,
+)
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+from reyn.user_intervention import InterventionAnswer, UserIntervention
+
+
+class _FakeBus:
+    """Real RequestBus-compatible Fake that pre-answers with a scripted
+    choice — implements the real ``request`` surface, not a mock (mirrors
+    ``test_config_write_jit_bus_3086.py``'s ``_FakeBus``)."""
+
+    def __init__(self, choice: str) -> None:
+        self._choice = choice
+        self.asks: list[UserIntervention] = []
+
+    async def request(self, iv: UserIntervention) -> InterventionAnswer:
+        self.asks.append(iv)
+        return InterventionAnswer(text=self._choice, choice_id=self._choice)
+
+
+def _make_ctx(
+    tmp_path: Path, *, bus: object | None, write_paths: list[str],
+) -> OpContext:
+    """A real OpContext whose ``default_sandbox_policy.write_paths`` excludes
+    the config write target (``.reyn/config/...``) — narrowing the gate
+    OUTSIDE the effective write zone (SandboxLayer ∩ AgentLayer), same shape
+    as ``test_config_write_jit_bus_3086.py``'s ``_make_ctx``. ``decl`` is a
+    bare ``PermissionDecl()`` (nothing declared/approved), so the AgentLayer's
+    OWN decl-less recovery-core-carve-out denial already reaches the JIT-ask
+    branch — the sandbox narrowing is an evidenced COMPOUNDING reachability
+    factor (an operator-set ``sandbox.policy.write_paths``), not the only one.
+    """
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    events = EventLog()
+    workspace = Workspace(events=events, base_dir=project_root)
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=True,
+    )
+    decl = PermissionDecl()  # no declared grants — zone/sandbox conjunction decides
+    return OpContext(
+        workspace=workspace,
+        events=events,
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=bus,
+        default_sandbox_policy={"write_paths": write_paths},
+    )
+
+
+# ── 1. index_update ─────────────────────────────────────────────────────────
+
+
+def _index_update_write_paths(tmp_path: Path) -> list[str]:
+    # #2856 Part B: SqliteIndexBackend.drop/write/delete AND SourceManifest's
+    # own atomic-write ALSO self-gate against sandbox_write_paths at the real
+    # write site (independent of the require_file_write gate under test) — so
+    # a write_paths cap that excludes the cache/manifest dir would deny there
+    # too, masking whether THIS gate's bus= fix is what let the op through.
+    # The whole project root is in scope here (SandboxLayer ⊤ for this
+    # write): the JIT-ask under test fires from the AgentLayer's OWN
+    # decl-less recovery-core-carve-out denial (``.reyn/config/`` is NOT the
+    # default write zone and nothing here declares/approves it), independent
+    # of any sandbox narrowing — mirrors the compounding-not-sole-cause note
+    # in the module docstring.
+    return [str(tmp_path / "proj")]
+
+
+@pytest.mark.asyncio
+async def test_index_update_sources_yaml_bus_none_denies(tmp_path):
+    """Tier 2: #3089 — non-interactive baseline unchanged: bus=None + the
+    sources.yaml config-write gate outside the effective zone → PermissionError,
+    no config written."""
+    from reyn.core.op_runtime.index_update import handle
+
+    ctx = _make_ctx(tmp_path, bus=None, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexUpdateIROp(kind="index_update", source="mysrc", chunks=[])
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    sources_yaml = ctx.workspace.base_dir / ".reyn" / "config" / "index" / "sources.yaml"
+    assert not sources_yaml.exists()
+
+
+@pytest.mark.asyncio
+async def test_index_update_sources_yaml_bus_approves(tmp_path):
+    """Tier 2: #3089 fix — a real bus threaded through the gate lets the
+    operator interactively approve the narrowed sources.yaml write; the op
+    succeeds and the JIT prompt fired exactly once. RED if bus= is not passed
+    through to require_file_write (the #3089 regression)."""
+    from reyn.core.op_runtime.index_update import handle
+
+    bus = _FakeBus(YES)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexUpdateIROp(kind="index_update", source="mysrc", chunks=[])
+
+    result = await handle(op, ctx)
+
+    assert "error" not in result or result.get("error") is None, f"update failed: {result}"
+    (ask,) = bus.asks  # exactly one prompt fired
+    assert "sources.yaml" in ask.prompt or "sources.yaml" in ask.detail
+    sources_yaml = ctx.workspace.base_dir / ".reyn" / "config" / "index" / "sources.yaml"
+    assert "mysrc" in sources_yaml.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_index_update_sources_yaml_bus_denies_after_prompt(tmp_path):
+    """Tier 2: #3089 — the operator can DENY via the prompt; PermissionError
+    still raised, but only after a prompt fired."""
+    from reyn.core.op_runtime.index_update import handle
+
+    bus = _FakeBus(NO)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexUpdateIROp(kind="index_update", source="mysrc", chunks=[])
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    (ask,) = bus.asks
+    assert "sources.yaml" in ask.prompt or "sources.yaml" in ask.detail
+
+
+# ── 2. index_drop ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_index_drop_sources_yaml_bus_none_denies(tmp_path):
+    """Tier 2: #3089 — non-interactive baseline unchanged for index_drop."""
+    from reyn.core.op_runtime.index_drop import handle
+
+    ctx = _make_ctx(tmp_path, bus=None, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexDropIROp(kind="index_drop", source="mysrc")
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+
+@pytest.mark.asyncio
+async def test_index_drop_sources_yaml_bus_approves(tmp_path):
+    """Tier 2: #3089 fix — index_drop threads bus= through the sources.yaml
+    gate; a narrowed write is interactively approvable and the drop completes."""
+    from reyn.core.op_runtime.index_drop import handle
+
+    bus = _FakeBus(YES)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexDropIROp(kind="index_drop", source="mysrc")
+
+    result = await handle(op, ctx)
+
+    assert result["chunks_dropped"] == 0  # nothing was ever indexed — a clean no-op drop
+    (ask,) = bus.asks  # exactly one prompt fired (source_dir write is in-zone, no ask needed)
+    assert "sources.yaml" in ask.prompt or "sources.yaml" in ask.detail
+
+
+@pytest.mark.asyncio
+async def test_index_drop_sources_yaml_bus_denies_after_prompt(tmp_path):
+    """Tier 2: #3089 — index_drop operator denial via prompt."""
+    from reyn.core.op_runtime.index_drop import handle
+
+    bus = _FakeBus(NO)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=_index_update_write_paths(tmp_path))
+    op = IndexDropIROp(kind="index_drop", source="mysrc")
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    (ask,) = bus.asks
+    assert "sources.yaml" in ask.prompt or "sources.yaml" in ask.detail
+
+
+# ── 3. mcp_drop_server ───────────────────────────────────────────────────────
+
+
+def _seed_mcp_yaml(tmp_path: Path, server: str) -> Path:
+    config_path = tmp_path / "proj" / ".reyn" / "config" / "mcp.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        f"mcp:\n  servers:\n    {server}:\n      type: stdio\n      command: /bin/cat\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+@pytest.mark.asyncio
+async def test_mcp_drop_server_config_write_bus_none_denies(tmp_path):
+    """Tier 2: #3089 — non-interactive baseline unchanged for mcp_drop_server."""
+    from reyn.core.op_runtime.mcp_drop_server import handle
+
+    _seed_mcp_yaml(tmp_path, "planted")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    ctx = _make_ctx(tmp_path, bus=None, write_paths=[str(unrelated)])
+    op = MCPDropServerIROp(kind="mcp_drop_server", server="planted")
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    config_path = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    assert "planted" in config_path.read_text(encoding="utf-8")  # untouched
+
+
+@pytest.mark.asyncio
+async def test_mcp_drop_server_config_write_bus_approves(tmp_path):
+    """Tier 2: #3089 fix — mcp_drop_server threads bus= through the mcp.yaml
+    gate; the narrowed write is interactively approvable and the drop
+    completes. RED if bus= is not passed through (the #3089 regression)."""
+    from reyn.core.op_runtime.mcp_drop_server import handle
+
+    _seed_mcp_yaml(tmp_path, "planted")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    bus = _FakeBus(YES)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=[str(unrelated)])
+    op = MCPDropServerIROp(kind="mcp_drop_server", server="planted")
+
+    result = await handle(op, ctx)
+
+    assert result["status"] == "ok", f"drop failed: {result}"
+    (ask,) = bus.asks
+    assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail
+    config_path = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    assert "planted" not in config_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_mcp_drop_server_config_write_bus_denies_after_prompt(tmp_path):
+    """Tier 2: #3089 — mcp_drop_server operator denial via prompt."""
+    from reyn.core.op_runtime.mcp_drop_server import handle
+
+    _seed_mcp_yaml(tmp_path, "planted")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    bus = _FakeBus(NO)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=[str(unrelated)])
+    op = MCPDropServerIROp(kind="mcp_drop_server", server="planted")
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    (ask,) = bus.asks
+    assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail
+
+
+# ── 4. mcp_install ───────────────────────────────────────────────────────────
+
+# npm: --source skips the registry fetch (op.source is set) entirely — the
+# only remaining external dependency is the npx binary on PATH, which is
+# stubbed via ``shutil.which`` (same technique test_mcp_source_install.py
+# uses for the identical source-install path) so the test needs no network.
+_NPM_SOURCE = "npm:@example-org/example-mcp-server"
+
+
+@pytest.mark.asyncio
+async def test_mcp_install_config_write_bus_none_denies(tmp_path, monkeypatch):
+    """Tier 2: #3089 — non-interactive baseline unchanged for mcp_install."""
+    from reyn.core.op_runtime.mcp_install import handle
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npx")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    ctx = _make_ctx(tmp_path, bus=None, write_paths=[str(unrelated)])
+    op = MCPInstallIROp(kind="mcp_install", server_id="", source=_NPM_SOURCE)
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    config_path = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    assert not config_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_mcp_install_config_write_bus_approves(tmp_path, monkeypatch):
+    """Tier 2: #3089 fix — mcp_install threads bus= through the mcp.yaml
+    gate (mirrors its own require_http_get call a few lines below, which
+    already does this); the narrowed write is interactively approvable and
+    the install completes. RED if bus= is not passed through to
+    require_file_write (the #3089 regression)."""
+    from reyn.core.op_runtime.mcp_install import handle
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npx")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    bus = _FakeBus(YES)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=[str(unrelated)])
+    op = MCPInstallIROp(kind="mcp_install", server_id="", source=_NPM_SOURCE)
+
+    result = await handle(op, ctx)
+
+    assert result["status"] == "ok", f"install failed: {result}"
+    (ask,) = bus.asks
+    assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail
+    config_path = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
+    assert "example-mcp-server" in config_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_mcp_install_config_write_bus_denies_after_prompt(tmp_path, monkeypatch):
+    """Tier 2: #3089 — mcp_install operator denial via prompt."""
+    from reyn.core.op_runtime.mcp_install import handle
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/npx")
+    unrelated = tmp_path / "unrelated"
+    unrelated.mkdir(parents=True, exist_ok=True)
+    bus = _FakeBus(NO)
+    ctx = _make_ctx(tmp_path, bus=bus, write_paths=[str(unrelated)])
+    op = MCPInstallIROp(kind="mcp_install", server_id="", source=_NPM_SOURCE)
+
+    with pytest.raises(PermissionError):
+        await handle(op, ctx)
+
+    (ask,) = bus.asks
+    assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail
+
+
+# ── 5. strip-falsify — the defect class in isolation ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_strip_falsify_omitting_bus_reproduces_original_bug(tmp_path):
+    """Tier 2: #3089 — strip-falsify at the PermissionResolver level, proving
+    the defect class the production fix closes: a config-write gate call that
+    OMITS ``bus=`` (the exact pre-fix shape of index_update.py / index_drop.py
+    / mcp_drop_server.py / mcp_install.py's require_file_write calls) denies
+    even when a bus that WOULD approve is sitting right there on the context.
+    Passing that same bus through (the fix) succeeds. RED if
+    require_file_write's bus=None default ever stops mattering (i.e. if
+    outside-zone writes start being silently granted regardless of bus)."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    unrelated_write_dir = tmp_path / "unrelated"
+    unrelated_write_dir.mkdir(parents=True, exist_ok=True)
+    config_path = project_root / ".reyn" / "config" / "mcp.yaml"
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=True,
+    )
+    decl = PermissionDecl()
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    sandbox = SandboxPolicy(write_paths=[str(unrelated_write_dir)])
+    bus_that_would_approve = _FakeBus(YES)
+
+    # Pre-fix shape: bus= omitted (mirrors all 4 handlers' bug verbatim).
+    with pytest.raises(PermissionError):
+        await resolver.require_file_write(
+            decl, str(config_path), "test", sandbox_policy=sandbox,
+        )
+    assert not bus_that_would_approve.asks, "a bus that was never passed cannot have been consulted"
+
+    # Fixed shape: bus= threaded through — same resolver, same sandbox, same path.
+    await resolver.require_file_write(
+        decl, str(config_path), "test", sandbox_policy=sandbox, bus=bus_that_would_approve,
+    )
+    (ask,) = bus_that_would_approve.asks  # exactly one prompt fired
+    assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail

--- a/tests/test_3089_op_runtime_require_file_write_bus.py
+++ b/tests/test_3089_op_runtime_require_file_write_bus.py
@@ -47,6 +47,17 @@ per-entry, #3037):
     upstream tool wrapper built it — the require_file_write call itself does
     not care who built its ctx, only what is ON it).
 
+Registry-completeness (architect co-vet, #3089): all 18 ``require_file_write``
+callers were enumerated FROM THE REGISTRY (not the issue's curated 4). 6 omit
+``bus=``: the 4 fixed here + 2 legitimately EXEMPT —
+``tools/cron.py::_gate`` and ``tools/hooks.py::_gate``. Both
+``session_approve_path`` the exact write path IMMEDIATELY before the gate AND
+pass no ``sandbox_policy``, so ``EffectivePermission`` returns early
+(AgentLayer._approved → True; SandboxLayer ⊤) and the JIT-ask branch is
+unreachable — threading ``bus=`` there would be dead code. Section 5 below
+witnesses that exempt condition at the real resolver (+ falsifies its premise),
+so the audit is 6/6 registry-complete, not a curated subset.
+
 Real ``PermissionResolver`` + a real-``RequestBus``-compatible Fake that
 pre-answers a scripted choice (mirrors ``test_config_write_jit_bus_3086.py``'s
 ``_FakeBus`` / ``test_require_file_jit_ask_1505.py``) — no mocks.
@@ -381,7 +392,84 @@ async def test_mcp_install_config_write_bus_denies_after_prompt(tmp_path, monkey
     assert "mcp.yaml" in ask.prompt or "mcp.yaml" in ask.detail
 
 
-# ── 5. strip-falsify — the defect class in isolation ───────────────────────
+# ── 5. registry-completeness: the 2 EXEMPT sites (cron / hooks) ─────────────
+#
+# architect co-vet enumerated ALL 18 require_file_write callers from the
+# registry (not the issue's curated 4): 6 omit bus=, of which 4 are the fixes
+# above and 2 are legitimately EXEMPT — ``tools/cron.py::_gate`` and
+# ``tools/hooks.py::_gate``. Both call ``session_approve_path(path, actor,
+# "file.write")`` IMMEDIATELY before ``require_file_write`` AND pass no
+# sandbox_policy. The pre-approval makes AgentLayer._approved True (→
+# EffectivePermission returns early) and the absent sandbox_policy leaves
+# SandboxLayer ⊤ (no veto) — so the JIT-ask branch (``if bus is not None``) is
+# UNREACHABLE. Threading bus= there would be dead code. This test witnesses
+# that exempt condition at the real resolver (the exact call shape both _gate
+# helpers use), so "bus= unnecessary" is a verified mechanism, not an assertion.
+
+
+@pytest.mark.asyncio
+async def test_exempt_session_approved_path_never_reaches_jit_ask(tmp_path):
+    """Tier 2: #3089 registry-completeness — the cron/hooks exempt condition.
+
+    Reproduces ``tools/cron.py::_gate`` / ``tools/hooks.py::_gate``'s exact
+    call shape (session_approve_path THEN require_file_write, no sandbox_policy)
+    against a recovery-core config path. Even with a bus that WOULD approve
+    threaded through, the JIT prompt NEVER fires — the pre-approval short-
+    circuits before the ask branch. This is why bus= is unnecessary (exempt)
+    at those two sites: there is no reachable ask for a bus to answer."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    # A recovery-core config path (same carve-out class as cron.yaml/hooks.yaml)
+    # — outside the default write zone, so ONLY the session-approval grants it.
+    config_path = str(project_root / ".reyn" / "config" / "cron.yaml")
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=True,
+    )
+    decl = PermissionDecl(file_write=[{"path": config_path, "scope": "just_path"}])
+    bus_that_would_approve = _FakeBus(YES)
+
+    # Exact _gate shape: pre-approve, then gate WITH a bus but WITHOUT sandbox_policy.
+    resolver.session_approve_path(config_path, "cron", "file.write")
+    await resolver.require_file_write(
+        decl, config_path, "cron", bus=bus_that_would_approve,
+    )
+
+    # The pre-approval short-circuited EffectivePermission — the JIT-ask branch
+    # was never reached, so the bus was never consulted. This is the exempt
+    # invariant: no reachable ask ⇒ bus= is dead ⇒ omitting it is correct.
+    assert not bus_that_would_approve.asks, (
+        "a session-approved path must pass WITHOUT reaching the JIT-ask branch; "
+        "if a prompt fired, the cron/hooks exempt rationale would be false"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exempt_falsify_without_preapproval_the_ask_would_fire(tmp_path):
+    """Tier 2: #3089 — falsify the exempt claim's premise: REMOVE the
+    session_approve_path (the only thing that makes cron/hooks exempt) and the
+    SAME recovery-core write DOES reach the JIT-ask (bus consulted). This
+    proves the exemption rests specifically on the pre-approval, not on the
+    path happening to be granted some other way — so the two exempt sites are
+    exempt BECAUSE of their session_approve_path, nothing incidental."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    config_path = str(project_root / ".reyn" / "config" / "cron.yaml")
+
+    resolver = PermissionResolver(
+        config_permissions={}, project_root=project_root, interactive=True,
+    )
+    decl = PermissionDecl(file_write=[{"path": config_path, "scope": "just_path"}])
+    bus = _FakeBus(YES)
+
+    # NO session_approve_path — the recovery-core carve-out path is now ungranted.
+    await resolver.require_file_write(decl, config_path, "cron", bus=bus)
+
+    (ask,) = bus.asks  # the ask DID fire — pre-approval was the exempting factor
+    assert "cron.yaml" in ask.prompt or "cron.yaml" in ask.detail
+
+
+# ── 6. strip-falsify — the defect class in isolation ───────────────────────
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — `require_file_write` の bus= 欠落 audit(#3089)。co-vet=architect。

part of #3089

## 背景
`require_file_write(bus=…)` は #1505 の JIT-ask を `bus is not None` のときだけ発火。`bus=None` は effective write zone 外を **prompt 無しで hard-deny**(#631 declare-only の #571 exemption は旧 bool-axis prompt 廃止を正当化するのみで、#1505 bus= JIT-ask には及ばない → curated 4経路は exempt でない)。

## registry-complete 完全性(★ curated-subset でなく registry 列挙)
architect co-vet が **全 18 の `require_file_write` caller を registry 列挙**(issue の curated 4 でなく)→ **bus= 無しは 6**。内訳 = **4 fixed + 2 exempt = 6/6 完全**([[coverage_migration_enumerate_from_registry_not_marker_subset]]の精神)。一括撒きでなく各 entry の reachability を per-entry で ground。

## per-entry 判定表(registry-derived 6/6)

| # | 経路 | write path | 判定 | reachability の根拠 |
|---|---|---|---|---|
| 1 | `op_runtime/index_update.py` (:112/:117) | `.reyn/config/index/sources.yaml`(+ index db) | **bus= 追加** | tool wrapper `tools/index_update.py` は `router_state.op_context_factory()` を優先 → `RouterHostAdapter.make_router_op_context` が `default_sandbox_policy`(operator が `reyn.yaml` の `sandbox.policy.write_paths` で narrow 可)+ `intervention_bus` を inline で thread。write 先 `.reyn/config/` は recovery-core carve-out で default write zone 外 ∴ decl-less で AgentLayer denial → JIT-ask 到達。 |
| 2 | `op_runtime/index_drop.py` (:61) | `.reyn/config/index/sources.yaml` | **bus= 追加** | 同上(wrapper=`tools/drop_source.py`、同 factory 経路)。`source_dir` gate(:70)は default-zone 内で ask 不要 ∴ sources.yaml の1回のみ ask。 |
| 3 | `op_runtime/mcp_drop_server.py` (:222) | `.reyn/config/mcp.yaml` | **bus= 追加** | 同上(wrapper=`tools/mcp_drop.py`、同 factory 経路)。 |
| 4 | `op_runtime/mcp_install.py` (:423) | `.reyn/config/mcp.yaml` | **bus= 追加** | ★ 3経路と異なり wrapper `tools/mcp_install.py` は factory を使わず minimal OpContext を組む。だが **同一 handle 関数内の直下(:442) `require_http_get` が既に `ctx.intervention_bus` を無条件 thread**(parity は per-entry で個別確認済、外挿でない)、かつ **CLI `mcp install --source`(`interfaces/cli/commands/mcp.py`)が実 `StdinInterventionBus` を OpContext に載せてこの handle を呼ぶ** ∴ reachable。 |
| 5 | `tools/cron.py` (:203) | `.reyn/config/cron.yaml` | **EXEMPT** | `require_file_write` の直前に `session_approve_path` で pre-approve(AgentLayer._approved → True)+ **sandbox_policy 未渡し**(SandboxLayer ⊤、veto 無し)→ `EffectivePermission` が早期 return → **JIT-ask branch 未到達 ∴ bus= 不要(足すと dead code)**。 |
| 6 | `tools/hooks.py` (:140) | `.reyn/config/hooks.yaml` | **EXEMPT** | 同上(`_gate` が同一 shape: session_approve_path → require_file_write、sandbox_policy 無し)。 |

**判定: 4 fixed / 2 exempt(exempt=正当、code logic 変更不要)**。architect 見立て「likely 4/4 bus= 要」を curated-4 で per-entry confirm、さらに registry 列挙で exempt 2 を追加 grounding。parity は hypothesis として各 entry で invariant を個別検証。

## テスト(`tests/test_3089_op_runtime_require_file_write_bus.py`, Tier 2, real-bus, mock 禁止)
real `PermissionResolver` + real-`RequestBus`-互換 Fake(`test_config_write_jit_bus_3086.py` と同 idiom)。

**fixed 4経路**(各 entry):
- `bus=None` baseline(hard-deny、prompt 無し、config 未書込)
- `bus=YES`(JIT-ask がちょうど1回発火 + op 成功 + config 書込)
- `bus=NO`(ask 発火後に deny)
- resolver-level strip-falsify(bus= 省略で deny、thread で approve)

**exempt 2サイト**(cron/hooks の `_gate` と同一 call shape を real resolver で再現):
- `test_exempt_session_approved_path_never_reaches_jit_ask`: session-approved path は would-approve bus を thread しても JIT-ask に到達しない(= bus 不要が真、exempt invariant を witness)
- `test_exempt_falsify_without_preapproval_the_ask_would_fire`: session_approve_path を除くと同じ recovery-core write が JIT-ask に到達(= exemption は pre-approval に依存、incidental でないことを falsify で確認)

**load-bearing 実証**: 4つの production `bus=` を strip(`git stash`)すると fix 依存 8 assertion が全 RED、baseline/strip-falsify/exempt は green(bus=None 側・exempt 側は不変を確認)。復元後 15/15 green。

## gate 結果(全 local、CI は待たず — co-vet=architect が確認)
- `ruff check src tests` → All checks passed
- `test_tier_audit.py --strict`(新 test file)→ 15 OK / 0 warn / 0 err
- `verify_module_docstrings.py`(6 src + 1 test)→ OK
- **full-suite `pytest`(foreground blocking)→ 8996 passed, 29 skipped(exit 0)**

## co-vet 観点(architect)
(1) registry-derived 6/6 完全性(4 fixed + 2 exempt、各 reachability の根拠明記)、(2) real-bus JIT-ask test が load-bearing(bus= strip で RED)、(3) 一括撒きでなく per-entry で invariant 検証、(4) mcp_install の narrower evidence(同関数 require_http_get parity + CLI 実 bus)、(5) exempt 2サイトの witness + falsify test。

closingRefs 実測空(`part of #3089` のみ、Closes/Fixes/Resolves 無し — merge 後の手動 close 判断は lead-coder)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
