### PR TITLE
refactor(session): fold agent_id into Agent (identity SSoT) — #3133 P0-follow-up

### DIFF
--- a/src/reyn/runtime/agent.py
+++ b/src/reyn/runtime/agent.py
@@ -24,9 +24,11 @@ agent-scoped). Conceptually the agent owns the profile; the wiring waits.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from reyn.config.infra import _default_agent_id
 
 if TYPE_CHECKING:
     from reyn.security.permissions.permissions import PermissionResolver
@@ -42,6 +44,12 @@ class Agent:
     agent_name: str
     role: str = ""
     model: str = "standard"
+    # ``reyn.yaml`` ``agent.id`` — the audit-event / X-Reyn-Agent-Id identifier
+    # (#3133 P0-follow-up: folded in from Session's former standalone
+    # ``agent_id`` param + ``_default_agent_id()`` fallback; identity SSoT now
+    # owns its own default instead of Session constructing it on Agent's
+    # behalf). Immutable — never reassigned post-construction (verified).
+    agent_id: str = field(default_factory=_default_agent_id)
 
     # Authority + scoping.
     permission_resolver: "PermissionResolver | None" = None

--- a/src/reyn/runtime/scoped_session_factory.py
+++ b/src/reyn/runtime/scoped_session_factory.py
@@ -92,7 +92,7 @@ def build_scoped_chat_session(
     # #3133 Priority-0 step-2: the 9 identity fields are POPPED from ``base``
     # (not just read) so Session — whose flat identity params were removed —
     # receives ``agent=`` exactly once, never a duplicate flat projection.
-    agent = Agent(
+    _agent_kwargs: dict[str, Any] = dict(
         agent_name=base.pop("agent_name"),
         role=base.pop("agent_role", ""),
         model=base.pop("model", "standard"),
@@ -103,6 +103,12 @@ def build_scoped_chat_session(
         sandbox_backend=sandbox_backend,
         environment_backend=environment_backend,
     )
+    # #3133 P0-follow-up: agent_id folds into Agent (identity SSoT) instead of
+    # a separate Session param — None means "let Agent's own default_factory
+    # (_default_agent_id) apply", matching the pre-fold fallback behaviour.
+    if agent_id is not None:
+        _agent_kwargs["agent_id"] = agent_id
+    agent = Agent(**_agent_kwargs)
     # #1953 slice 7: construct the OS TaskWaker for this session at the single
     # factory chokepoint (every frontend builds sessions here). It closes over the
     # AgentRegistry + this agent's name to resolve + wake sibling sessions on a
@@ -129,7 +135,6 @@ def build_scoped_chat_session(
     )
     return Session(
         agent=agent,
-        agent_id=agent_id,
         router_max_iterations=router_max_iterations,
         non_interactive=non_interactive,
         eager_embedding_build=eager_embedding_build,

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -961,7 +961,6 @@ class Session:
         # reyn.yaml llm.router.* ambient ContextVar (#1829 S3b)
         router_config: "RouterConfig | None" = None,
         retry_config: "object | None" = None,  # #1835: reyn.yaml llm.retry.* timing config
-        agent_id: str | None = None,
         router_max_iterations: int = 5,  # #187: per-message tool-call budget for the MAIN chat loop (interactive=5; one-shot autonomous SWE sets higher)
         non_interactive: bool = False,  # #1439 Fix #1: run-once (piped, no TTY) — no user to ask, so the SP directs proceed-with-assumption instead of clarifying
         # Conversation session id WAL entries are recorded under, default "main" (FP-0043 Stage 5)
@@ -1083,11 +1082,10 @@ class Session:
         self._chat_tool_use_scheme = chat_tool_use_scheme  # #1593 PR-2, passed to RouterLoopDriver below
         # RouterLoop awaits the embedding index build synchronously on turn 1 when True (B25-S5-1 fix, see session-construction.md#family-5-retrieval)
         self._eager_embedding_build = eager_embedding_build
-        # Falls back to a default identifier when the factory doesn't supply agent.id (FP-0016 Component E)
-        if agent_id is None:
-            from reyn.config import _default_agent_id
-            agent_id = _default_agent_id()
-        self._agent_id: str = agent_id
+        # agent_id is now owned by Agent (identity SSoT) — see the `agent_id`
+        # property below. FP-0016 Component E's gap (Agent lacked the field,
+        # so Session carried a separate param + `_default_agent_id()`
+        # fallback) is closed (#3133 P0-follow-up).
         # Sender of the most-recently-dispatched inbox item, for sender-transition state_change entries (FP-0041 #489 PR-A)
         self._last_sender: str | None = None
         # Reply-to attribution captured from an inbound payload's reply_to (FP-0041 #489 PR-D2)
@@ -1514,6 +1512,10 @@ class Session:
     @property
     def agent_name(self) -> str:
         return self._agent.agent_name
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent.agent_id
 
     @property
     def model(self) -> str:
@@ -3050,7 +3052,7 @@ class Session:
         ``__init__`` — same objects, same construction order, same args.
         Reads only attributes ``__init__`` has already set by this point
         (``self.outbox`` / ``self.agent_name`` / ``self.events_dir`` /
-        ``self._events_config`` / ``self._agent_id``); takes
+        ``self._events_config`` / ``self._agent.agent_id``); takes
         ``observability_config`` explicitly since it is an ``__init__``
         parameter, not a ``self`` attribute.
 
@@ -3078,7 +3080,7 @@ class Session:
         )
         chat_events = EventLog(
             subscribers=[event_store],
-            agent_id=self._agent_id,  # FP-0016 E: auto-inject agent_id into every event
+            agent_id=self._agent.agent_id,  # FP-0016 E: auto-inject agent_id into every event
         )
         otel_exporter = None
         try:
@@ -6762,7 +6764,7 @@ class Session:
                 if getattr(self, "_sandbox_config", None) is not None
                 else None
             ),
-            agent_id=self._agent_id,
+            agent_id=self._agent.agent_id,
             # #2708 P1: this builder serves file/MCP ops (_file_op / MCP), which no
             # `present` op reaches — so the present sink is EXPLICITLY None (the required
             # kwarg forces the decision, no silent omission). The visible present path is
@@ -6953,11 +6955,11 @@ class Session:
         # connection open for a sub-second-lived session is pure churn.
         gateway = (
             MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
                 cancel_event=self._loop_driver.cancel_event,
             )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
+            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             return await gateway.list_tools(server, expanded)
@@ -6995,11 +6997,11 @@ class Session:
 
         gateway = (
             MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
                 cancel_event=self._loop_driver.cancel_event,
             )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
+            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             resources = await gateway.list_resources(server, expanded)
@@ -7038,11 +7040,11 @@ class Session:
 
         gateway = (
             MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
                 cancel_event=self._loop_driver.cancel_event,
             )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
+            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             return await gateway.list_resource_templates(server, expanded)
@@ -7177,11 +7179,11 @@ class Session:
 
         gateway = (
             MCPGateway(
-                pool=self._mcp_connection_service, agent_id=self._agent_id,
+                pool=self._mcp_connection_service, agent_id=self._agent.agent_id,
                 cancel_event=self._loop_driver.cancel_event,
             )
             if not self._ephemeral
-            else MCPGateway(agent_id=self._agent_id, cancel_event=self._loop_driver.cancel_event)
+            else MCPGateway(agent_id=self._agent.agent_id, cancel_event=self._loop_driver.cancel_event)
         )
         try:
             prompts = await gateway.list_prompts(server, expanded)

--- a/tests/_support/agent_session.py
+++ b/tests/_support/agent_session.py
@@ -4,7 +4,10 @@ object (single source of truth) — the only construction path since
 and removed the 9 duplicate flat identity kwargs (``agent_name`` /
 ``agent_role`` / ``model`` / ``permission_resolver`` / ``workspace_base_dir``
 / ``workspace_state_dir`` / ``sandbox_config`` / ``sandbox_backend`` /
-``environment_backend``).
+``environment_backend``). The #3133 P0-follow-up folded a 10th identity
+field, ``agent_id``, into ``Agent`` the same way (closing the FP-0016
+Component E gap where ``Agent`` lacked the field Session's fallback
+comment already named ``agent.id``).
 
 Production construction (``scoped_session_factory.py``) builds an ``Agent``
 from the identity-owned inputs and passes it as ``agent=`` alone (no
@@ -40,6 +43,9 @@ _AGENT_FIELD_FROM_KWARG = {
     "sandbox_config": "sandbox_config",
     "sandbox_backend": "sandbox_backend",
     "environment_backend": "environment_backend",
+    # #3133 P0-follow-up: agent_id folded into Agent (identity SSoT) — no
+    # longer a separate Session param.
+    "agent_id": "agent_id",
 }
 
 


### PR DESCRIPTION
**[per-PR-coder]** — #3133 P0-follow-up: **agent_id → agent.id fold** — closes the last identity-SSoT gap. Owner GO, architect-designed; co-vet = architect.

## What changed (agent_id → agent.id fold)
- **Agent (frozen dataclass) gains `agent_id`** — `agent_id: str = field(default_factory=_default_agent_id)`. Identity SSoT now owns its own default instead of Session minting one on Agent's behalf.
- **Session param 36 → 35** — the standalone `agent_id: str | None = None` param **and** the `_default_agent_id()` fallback block are deleted; `agent_id` is now a delegating **property** `return self._agent.agent_id` (same shape as the `agent_name` property). All internal reads rewritten to `self._agent.agent_id`.
- **Factory / helper flow agent_id through Agent** — `scoped_session_factory.build_scoped_chat_session` keeps its `agent_id` public param but folds it into the `Agent(...)` build (None → Agent's own `default_factory` applies, matching the pre-fold fallback); `make_session` helper adds `agent_id → agent_id` to `_AGENT_FIELD_FROM_KWARG`.
- **Agent = 10-field complete identity SSoT** — the FP-0016 Component E gap (the `session.py` fallback comment named `agent.id` as the design source, but Agent lacked the field) is closed.

## frozen-safe (no live-provider needed)
`agent_id` is **never reassigned post-construction** — grep-confirmed: no `self._agent_id = …` remains in session.py and no `*.agent_id =` reassignment anywhere (unlike `session_id`/`ephemeral`, which are mutable and stay Session-owned). ∴ a plain frozen Agent field is safe; no live-provider indirection.

## import cycle
None — `reyn.runtime.agent` → `reyn.config.infra._default_agent_id`; `config.infra` → `runtime.budget.budget` → `llm.pricing` (leaf), no path back to `runtime.agent`. Verified by direct import + default-factory equality.

## main-grep collision (signature change)
`grep -rn "agent_id=" src tests` swept: **zero** remaining callers pass `agent_id=` to `Session(...)` directly (the one grep hit is a `SimpleNamespace` op-context, not a Session). The 6 `build_scoped_chat_session(agent_id=…)` callers (registry_bootstrap/web/mcp/dogfood pass None; chat.py passes `config.agent.id`) are correct — the factory param is retained and threads into Agent. No prod direct-construction or Session subclass passes the old param.

## behaviour unchanged
`self._agent.agent_id` resolves to the same value the old param/fallback produced (identical `default_factory`), so audit-event injection (`EventLog(agent_id=…)`) and the `X-Reyn-Agent-Id` header (MCPGateway) consumers are byte-identically unaffected.

## Gates (all foreground, local)
- `ruff check src tests` ✅
- `python scripts/test_tier_audit.py --strict tests/_support/agent_session.py` ✅
- `python scripts/verify_module_docstrings.py <changed src>` ✅
- **full FULL-suite**: `9019 passed, 29 skipped` ✅

part of #3133. co-vet = architect (signature change). I will not merge until architect co-vet + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)