### PR TITLE
fix(3025): remove the per-turn Indexed-sources prefetch build_system_prompt discarded

### DIFF
--- a/scripts/dogfood_sp_render.py
+++ b/scripts/dogfood_sp_render.py
@@ -23,9 +23,8 @@ Usage:
     python scripts/dogfood_sp_render.py --skill code_review=review_code --skill skill_builder=build
     python scripts/dogfood_sp_render.py --agent-peer planner=plan_and_decompose
 
-    # With MCP servers and indexed sources:
+    # With MCP servers:
     python scripts/dogfood_sp_render.py --mcp-servers brave=search_the_web
-    python scripts/dogfood_sp_render.py --indexed-sources meetings --indexed-sources docs
 
     # With file scope:
     python scripts/dogfood_sp_render.py --file-scope read=/workspace write=/workspace/out
@@ -104,23 +103,12 @@ def _parse_file_scope(raw_list: list[str]) -> dict[str, list[str]]:
     return result if (result["read"] or result["write"]) else None  # type: ignore[return-value]
 
 
-def _parse_indexed_sources(names: list[str]) -> str | None:
-    """Build a minimal indexed_sources_section string from a list of source names."""
-    if not names:
-        return None
-    lines = ["## Indexed sources"]
-    for name in names:
-        lines.append(f"- {name}")
-    return "\n".join(lines)
-
-
 def _build_sp(args: argparse.Namespace) -> str:
     """Construct the system prompt from parsed CLI args."""
     skills = [_parse_kv(s, "skill") for s in (args.skill or [])]
     agents = [_parse_kv(a, "agent_peer") for a in (args.agent_peer or [])]
     mcp_servers = [_parse_kv(m, "mcp-servers") for m in (args.mcp_servers or [])] or None
     file_permissions = _parse_file_scope(args.file_scope or [])
-    indexed_sources_section = _parse_indexed_sources(args.indexed_sources or [])
 
     memory_index: dict = {"status": "not_found", "content": ""}
 
@@ -134,7 +122,6 @@ def _build_sp(args: argparse.Namespace) -> str:
         mcp_servers=mcp_servers,
         output_language=args.output_language,
         project_context=args.project_context or "",
-        indexed_sources_section=indexed_sources_section,
         universal_wrappers_enabled=args.universal_wrappers_enabled,
     )
 
@@ -258,15 +245,6 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "MCP server in name=description form. "
             "Repeatable (e.g. --mcp-servers brave=search_the_web)."
-        ),
-    )
-    parser.add_argument(
-        "--indexed-sources",
-        action="append",
-        metavar="NAME",
-        help=(
-            "Indexed source name (plain string). "
-            "Repeatable (e.g. --indexed-sources meetings --indexed-sources docs)."
         ),
     )
     parser.add_argument(

--- a/scripts/s7_driver.py
+++ b/scripts/s7_driver.py
@@ -181,7 +181,6 @@ os.chdir('{WORKSPACE}')
 from pathlib import Path
 from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.runtime.session import _merge_memory_indexes
-from reyn.data.index.source_manifest import get_source_manifest
 
 async def main():
     # Build memory index the same way ChatSession does
@@ -193,18 +192,15 @@ async def main():
         agent_name='{AGENT_NAME}',
     )
 
-    # Build indexed sources section (should be 0 available — no sources.yaml in workspace)
-    manifest = get_source_manifest(Path.cwd())
-    indexed_sources = await manifest.format_for_prompt()
-
-    # Build system prompt
+    # Build system prompt. #3025: build_system_prompt no longer accepts an
+    # indexed_sources_section — the "## Indexed sources" SP section was never
+    # rendered in the wrapper-only path and its per-turn prefetch was removed.
     sp = build_system_prompt(
         agent_name='{AGENT_NAME}',
         agent_role='dogfood test assistant',
         available_skills=[],
         available_agents=[],
         memory_index=memory_index,
-        indexed_sources_section=indexed_sources,
     )
     print('=== SYSTEM_PROMPT_START ===')
     print(sp)

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -10,11 +10,9 @@ import asyncio
 import functools
 import json
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from reyn.core.dispatch import DispatchContext, dispatch_tool
-from reyn.data.index.source_manifest import get_source_manifest
 from reyn.llm.llm import call_llm_tools
 from reyn.llm.pricing import TokenUsage
 from reyn.prompt.loop_control import (
@@ -1506,13 +1504,16 @@ class RouterLoop:
         if self._system_prompt_override is not None:
             system_prompt = self._system_prompt_override
         else:
-            # ADR-0033: pre-fetch indexed sources before building the
-            # (sync) system prompt. format_for_prompt() reads the mem
-            # cache (fast path when manifest already loaded) and returns
-            # the rendered section including the empty-state hint.
-            indexed_sources = await get_source_manifest(
-                Path.cwd()
-            ).format_for_prompt()
+            # #3025: the router no longer pre-fetches SourceManifest.
+            # format_for_prompt() here. The "## Indexed sources" SP section it
+            # rendered was accepted by build_system_prompt as
+            # ``indexed_sources_section`` and then discarded — the wrapper-only
+            # SP has not injected it since B23-PRE-1, so every turn paid a
+            # SourceManifest.get_all() (sources.yaml read + parse) to build a
+            # string nothing read. Corpus discovery is the ``list_rag_sources``
+            # verb (#3026), not the SP, so the prefetch + dead parameter are
+            # removed rather than revived (reviving it would re-introduce the
+            # per-corpus, operator-scaling SP cost #3026 removed).
             system_prompt = build_system_prompt(
                 agent_name=host.agent_name,
                 agent_role=host.agent_role,
@@ -1523,7 +1524,6 @@ class RouterLoop:
                 web_fetch_allowed=host.get_web_fetch_allowed(),
                 output_language=host.output_language,
                 project_context=host.get_project_context(),
-                indexed_sources_section=indexed_sources,
                 cwd=_cwd_str,
                 # #1627 Stage 4: scheme-owned slot-map (all 4 schemes populate
                 # tool_use_sp via build_universal_tool_use_slots or their own

--- a/src/reyn/runtime/router_system_prompt.py
+++ b/src/reyn/runtime/router_system_prompt.py
@@ -45,7 +45,6 @@ def build_system_prompt(
     web_fetch_allowed: bool = True,  # FP-0022: always-on; parameter kept for backward compat
     output_language: str | None = None,
     project_context: str = "",
-    indexed_sources_section: str | None = None,
     cwd: str | None = None,
     tool_use_sp: "str | dict[str, str] | None" = None,  # #1627 Stage 4: scheme-owned slot-map (or str back-compat shim); None → {} (bare OS frame, no tool-use SP)
     context_size_signal: str | None = None,  # #272/#1128 — pre-rendered, appended LAST
@@ -88,10 +87,6 @@ def build_system_prompt(
             When None (= user did not configure output_language), no
             language directive is emitted — the LLM picks the reply
             language based on the user's input naturally.
-        indexed_sources_section: pre-rendered "## Indexed sources ..."
-            markdown string from ``SourceManifest.format_for_prompt()``.
-            When provided, injected verbatim after the Memory section.
-            When None (default), no Indexed sources section is emitted.
         cwd: current working directory the agent is running from. When
             provided, an ## Environment section tells the LLM to treat
             unqualified references like "this repo" / "this code" /
@@ -231,7 +226,7 @@ def build_system_prompt(
 
     # ==========================================================================
     # DYNAMIC — varies per session / configuration
-    # Sections 6–13: project_context, Memory, Indexed sources,
+    # Sections 6–13: project_context, Memory,
     # + dynamic Behaviour conditionals (output_language).
     # ==========================================================================
 
@@ -264,9 +259,14 @@ def build_system_prompt(
     # wrapper-only path. Memory discovery goes through
     # list_actions(category=['memory_entry']) at runtime.
 
-    # ── 10. Indexed sources (ADR-0033 UX gap fix A) ──────────────────────────
-    # B23-PRE-1 SP role-separation: ## Indexed sources omitted in wrapper-only
-    # path — list_actions(category=['rag_corpus']) discovers at runtime.
+    # ── 10. Indexed sources ──────────────────────────────────────────────────
+    # No ## Indexed sources section is rendered. B23-PRE-1 dropped it from the
+    # wrapper-only path; #3025 then removed the vestigial ``indexed_sources_
+    # section`` parameter and the per-turn ``SourceManifest.format_for_prompt()``
+    # prefetch that fed it (the rendered string was accepted and discarded).
+    # Corpus discovery is the ``list_rag_sources`` verb (#3026) — one tool
+    # regardless of corpus count — not a per-corpus SP list that would scale
+    # with the operator's corpora.
 
     # ── 11. Files ────────────────────────────────────────────────────────────
     # B23-PRE-1 SP role-separation: ## Files section omitted in wrapper-only
@@ -277,9 +277,8 @@ def build_system_prompt(
     # only path — list_actions(category=['mcp.server','mcp.tool']) discovers.
 
     # ── 13. Dynamic Behaviour conditionals ───────────────────────────────────
-    # These vary per session config (output_language) or per-request state
-    # (indexed_sources_section). They are Behaviour addenda that cannot live
-    # in the static prefix above.
+    # These vary per session config (output_language). They are Behaviour
+    # addenda that cannot live in the static prefix above.
 
     # Explicit language instruction (only when the user configured one):
     # a concrete language tag is stronger than "match the user's language"
@@ -416,59 +415,4 @@ def _render_files(file_permissions: dict | None) -> list[str]:
         lines.append(f"read scope:  {', '.join(read_paths)}")
     if write_paths:
         lines.append(f"write scope: {', '.join(write_paths)}")
-    return lines
-
-
-_ENTRY_FULL_RE = re.compile(
-    r"^\s*-\s*\[([^\]]+)\]\(([^)]+)\.md\)\s*[—–-]+\s*(.+)$"
-)
-
-
-def _parse_memory_entries(
-    content: str,
-) -> dict[str, list[tuple[str, str, str]]]:
-    """Return {layer: [(slug, name, description), ...]} from merged memory
-    index text. Layers are "shared" and "agent"."""
-    shared: list[tuple[str, str, str]] = []
-    agent: list[tuple[str, str, str]] = []
-    current: list[tuple[str, str, str]] | None = None
-
-    for line in content.splitlines():
-        h = _SECTION_HEADER_RE.match(line.strip())
-        if h:
-            current = shared if h.group("layer") == "shared" else agent
-            continue
-        if current is None:
-            continue
-        m = _ENTRY_FULL_RE.match(line)
-        if m:
-            name, slug, desc = m.group(1), m.group(2), m.group(3).strip()
-            current.append((slug, name, desc))
-    return {"shared": shared, "agent": agent}
-
-
-def _render_memory(memory_index: dict) -> list[str]:
-    """Return lines for the memory section.
-
-    Inline all entries with their descriptions so the LLM can answer
-    recall queries directly without round-tripping through list_memory.
-    Memory is bounded per agent (~tens of entries typically) so linear
-    rendering is acceptable. read_memory_body remains available for cases
-    where the description is too vague to answer from.
-    """
-    if memory_index.get("status") != "ok":
-        return ["shared: (no entries)", "agent: (no entries)"]
-
-    content = memory_index.get("content", "")
-    entries = _parse_memory_entries(content)
-
-    lines: list[str] = []
-    for layer in ("shared", "agent"):
-        layer_entries = entries.get(layer, [])
-        if not layer_entries:
-            lines.append(f"{layer}: (no entries)")
-            continue
-        lines.append(f"{layer}:")
-        for slug, _name, desc in layer_entries:
-            lines.append(f"  - {slug}: {desc}")
     return lines

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -464,12 +464,6 @@ class RouterHistoryBuffer:
         :class:`~reyn.services.compaction.engine.CompactionEngine`
         so that T_SP is measured dynamically — operator-editable REYN.md and
         action catalog changes are reflected before each pre-frame budget check.
-
-        Note: ``indexed_sources_section`` is omitted (= None) because this
-        method is synchronous and cannot await ``get_source_manifest()``.
-        The omission means T_SP is slightly under-counted, which is conservative
-        (= compaction triggers slightly more often than strictly necessary).
-        The error is small relative to the total context window.
         """
         from reyn.runtime.router_system_prompt import build_system_prompt
         from reyn.tools.schemes._discovery import tier_wants_discovery_mandate
@@ -502,7 +496,6 @@ class RouterHistoryBuffer:
             web_fetch_allowed=rh.get_web_fetch_allowed(),
             output_language=rh.output_language,
             project_context=rh.get_project_context(),
-            indexed_sources_section=None,
             tool_use_sp=tool_use_sp,
             # #1652: include the prior-reasoning continuity section so the T_SP
             # estimate (and the override/budget SP path) accounts for it. Host-

--- a/src/reyn/tools/descriptions/discovery.py
+++ b/src/reyn/tools/descriptions/discovery.py
@@ -18,8 +18,10 @@ the discovery verb that replaced the ``rag_corpus__<name>`` catalog
 category when #3026 collapsed the per-resource action surface, so
 ``semantic_search``'s ``sources`` argument stays answerable without one
 action per corpus in ``tools=``. Its text (and ``semantic_search``'s, which
-used to point at an "Indexed sources" system-prompt section that is no
-longer rendered — see #3025) names it explicitly, because a required
+used to point at an "Indexed sources" system-prompt section that was never
+rendered in the wrapper-only path — the vestigial ``indexed_sources_section``
+parameter and its per-turn prefetch were removed in #3025) names it
+explicitly, because a required
 closed-set argument with no stated way to enumerate it is the same
 reachability gap #2971 closed for skills.
 """

--- a/src/reyn/tools/rag_discovery.py
+++ b/src/reyn/tools/rag_discovery.py
@@ -15,13 +15,15 @@ back as a VERB whose result carries the names, exactly one tool regardless of
 corpus count — the same shape #2971 used for ``skill_management__list`` and
 #879 used for ``mcp__list_tools``.
 
-**Why not the system prompt.** ``semantic_search``'s ``sources`` description has
-long pointed at an "Indexed sources" SP section, and ``build_system_prompt``
-still accepts an ``indexed_sources_section`` argument — but that section has not
-been rendered for some time (the parameter is accepted and discarded; see
-#3025). Reviving it would put a per-corpus list in every turn's prompt: the same
-operator-scaling cost this PR is removing, just moved from ``tools=`` into the
-SP. A verb is paid for only when the model actually asks.
+**Why not the system prompt.** ``semantic_search``'s ``sources`` description
+once pointed at an "Indexed sources" SP section, and ``build_system_prompt``
+used to accept an ``indexed_sources_section`` argument — but that section had
+not been rendered since B23-PRE-1, so the argument was accepted and discarded
+while the router still paid a per-turn ``SourceManifest.format_for_prompt()``
+to build it (#3025 removed both the parameter and that prefetch). Reviving it
+would put a per-corpus list in every turn's prompt: the same operator-scaling
+cost this PR is removing, just moved from ``tools=`` into the SP. A verb is
+paid for only when the model actually asks.
 
 Read-only, and no permission gate: it returns the operator's own corpus
 declarations from the snapshot the router already built for this session —

--- a/tests/test_2548_skill_registry_pr_a.py
+++ b/tests/test_2548_skill_registry_pr_a.py
@@ -373,7 +373,6 @@ def _sp_base_kwargs() -> dict:
         "mcp_servers": None,
         "output_language": None,
         "project_context": "",
-        "indexed_sources_section": None,
     }
 
 

--- a/tests/test_router_indexed_sources.py
+++ b/tests/test_router_indexed_sources.py
@@ -1,19 +1,26 @@
-"""Tier 2 tests — Router system prompt "Indexed sources" section (ADR-0033 UX gap fix A).
+"""Tier 1/2 tests — Router system prompt and the (removed) "Indexed sources" wiring.
 
-Verifies that SourceManifest.format_for_prompt() output is correctly injected
-into the router system prompt, including the empty-state getting-started hint
-and section ordering guarantees.
+Two orthogonal things live here:
 
-Phase 6 cleanup note: build_system_prompt() in the wrapper-only path no longer
-injects indexed_sources_section into the SP (discovery goes through
-list_actions(category=['rag_corpus']) at runtime). Tests that verified SP
-injection are removed. SourceManifest.format_for_prompt() output correctness
-tests remain (they test the manifest, not the SP).
+- ``SourceManifest.format_for_prompt()`` output correctness (Tier 2): the
+  manifest renders the empty-state getting-started hint and lists sources with
+  chunk counts. This is manifest behaviour, independent of the SP.
+
+- The absence of any "## Indexed sources" section in the wrapper-only SP, plus
+  the absence of the ``indexed_sources_section`` parameter on
+  ``build_system_prompt`` (Tier 1 contract). B23-PRE-1 dropped the section from
+  the wrapper-only path; #3025 then removed the vestigial parameter and the
+  per-turn ``SourceManifest.format_for_prompt()`` prefetch that fed it (the
+  rendered string was accepted and discarded every turn). Corpus discovery is
+  the ``list_rag_sources`` verb (#3026), not the SP.
 """
 from __future__ import annotations
 
+import inspect
+
 import pytest
 
+import reyn.runtime.router_system_prompt as router_system_prompt
 from reyn.data.index.source_manifest import SourceEntry, SourceManifest
 from reyn.runtime.router_system_prompt import build_system_prompt
 from reyn.tools.schemes._universal_sp import build_universal_tool_use_slots
@@ -48,8 +55,8 @@ def _default_slots() -> "dict[str, str]":
     )
 
 
-def _minimal_prompt(indexed_sources_section: str | None = None) -> str:
-    """Build a minimal system prompt with the given indexed_sources_section.
+def _minimal_prompt() -> str:
+    """Build a minimal wrapper-only system prompt.
 
     #1627 Stage 4: tool_use_sp slot-map required for tool-use SP content.
     """
@@ -58,7 +65,6 @@ def _minimal_prompt(indexed_sources_section: str | None = None) -> str:
         agent_role="general assistant",
         available_agents=[],
         memory_index=_SYNTHETIC_MEMORY,
-        indexed_sources_section=indexed_sources_section,
         tool_use_sp=_default_slots(),
     )
 
@@ -78,16 +84,19 @@ class TestEmptyStateHint:
         assert "reyn run index_docs" in rendered
 
     @pytest.mark.asyncio
-    async def test_empty_manifest_hint_not_in_sp(self, tmp_path):
-        """Tier 2: In wrapper-only path, indexed_sources_section is not injected into SP.
+    async def test_manifest_hint_text_absent_from_wrapper_sp(self, tmp_path):
+        """Tier 2: the manifest's rendered section does not appear in the wrapper-only SP.
 
-        Phase 6 cleanup: SP injection removed; discovery via list_actions at runtime.
+        #3025: the SP has no "## Indexed sources" section, and even the distinctive
+        empty-state hint text the manifest renders is absent from the SP — corpus
+        discovery is the list_rag_sources verb (#3026), never the prompt.
         """
         manifest = SourceManifest(tmp_path)
         section = await manifest.format_for_prompt()
-        prompt = _minimal_prompt(indexed_sources_section=section)
-        # The section text is NOT injected in wrapper-only path
+        assert "No indexed sources yet" in section  # sanity: manifest DID render it
+        prompt = _minimal_prompt()
         assert "## Indexed sources" not in prompt
+        assert "No indexed sources yet" not in prompt
 
 
 class TestSourcesInPrompt:
@@ -132,22 +141,41 @@ class TestSourcesInPrompt:
         assert "## Indexed sources (2 available)" in section
 
 
-class TestBackwardCompat:
-    def test_section_absent_when_none(self):
-        """Tier 2: indexed_sources_section=None means no Indexed sources block in prompt."""
-        prompt = _minimal_prompt(indexed_sources_section=None)
+class TestNoIndexedSourcesSection:
+    def test_section_absent_from_wrapper_sp(self):
+        """Tier 2: the wrapper-only SP has no ## Indexed sources block."""
+        prompt = _minimal_prompt()
         assert "## Indexed sources" not in prompt
 
-    def test_no_section_by_default(self):
-        """Tier 2: build_system_prompt omits Indexed sources when parameter not passed."""
+    def test_no_section_with_empty_memory(self):
+        """Tier 2: build_system_prompt omits Indexed sources regardless of memory state."""
         prompt = build_system_prompt(
             agent_name="chat",
             agent_role="assistant",
             available_agents=[],
             memory_index=_EMPTY_MEMORY,
-            # indexed_sources_section not passed — default is None
         )
         assert "## Indexed sources" not in prompt
+
+
+class TestDeadParamAndHelperRemoved:
+    """Tier 1 (Contract): the discarded indexed_sources_section wiring is gone.
+
+    #3025 removed the parameter build_system_prompt accepted-and-discarded, the
+    per-turn SourceManifest.format_for_prompt() prefetch that fed it, and the
+    caller-less _render_memory helper. These contract assertions go RED if any
+    of that dead wiring is reintroduced (a re-added parameter would once again
+    let a caller pay to build a section nothing renders).
+    """
+
+    def test_build_system_prompt_has_no_indexed_sources_param(self):
+        """Tier 1: build_system_prompt exposes no indexed_sources_section parameter."""
+        params = inspect.signature(build_system_prompt).parameters
+        assert "indexed_sources_section" not in params
+
+    def test_render_memory_helper_removed(self):
+        """Tier 1: the caller-less _render_memory helper no longer exists."""
+        assert not hasattr(router_system_prompt, "_render_memory")
 
 
 class TestDeterministicOrder:
@@ -212,7 +240,7 @@ class TestVocabDisambiguationB17S53:
         B17-S5-3 fix: wrapper-only SP uses invoke_action routing vocabulary
         (no intent-axis labels). 'Recall — read persisted facts' must be absent.
         """
-        prompt = _minimal_prompt(indexed_sources_section=None)
+        prompt = _minimal_prompt()
         # Old intent label must NOT be present
         assert "Recall — read persisted facts" not in prompt
         # Also the corrected label form should not be present (intent axis removed)
@@ -220,6 +248,6 @@ class TestVocabDisambiguationB17S53:
 
     def test_sp_uses_invoke_action_routing(self):
         """Tier 2: Wrapper-only SP routes all actions through invoke_action."""
-        prompt = _minimal_prompt(indexed_sources_section=None)
+        prompt = _minimal_prompt()
         assert "invoke_action" in prompt
         assert "ROUTING RULE (ABSOLUTE)" in prompt

--- a/tests/test_router_sp_universal_categories.py
+++ b/tests/test_router_sp_universal_categories.py
@@ -32,7 +32,6 @@ _BASE_KWARGS = {
     "mcp_servers": None,
     "output_language": None,
     "project_context": "",
-    "indexed_sources_section": None,
 }
 
 

--- a/tests/test_semantic_search_missing_args_defensive.py
+++ b/tests/test_semantic_search_missing_args_defensive.py
@@ -132,11 +132,12 @@ async def test_recall_error_message_names_the_source_discovery_verb():
     missing arg.
 
     #3026 changed WHERE that pointer points, not whether there is one. The message
-    used to name the 'Indexed sources' system-prompt section; that section is not
-    rendered (the SP builder accepts an ``indexed_sources_section`` argument and
-    discards it — see #3025), so the message was directing the model to something
-    that was never in its context. It now names ``list_rag_sources``, the verb
-    #3026 added to enumerate the corpora. Pinning the referent keeps the
-    educational pointer honest if someone edits the wording."""
+    used to name the 'Indexed sources' system-prompt section; that section was
+    never rendered in the wrapper-only path (the SP builder accepted-and-discarded
+    an ``indexed_sources_section`` argument, since removed — see #3025), so the
+    message was directing the model to something that was never in its context. It
+    now names ``list_rag_sources``, the verb #3026 added to enumerate the corpora.
+    Pinning the referent keeps the educational pointer honest if someone edits the
+    wording."""
     result = await _handle_semantic_search({"query": "x"}, _make_ctx())
     assert "list_rag_sources" in result["error_message"]


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3025

## What the issue reported vs. what I found (ground-first)

The issue named two defects. Ground-first re-measurement against current `main` (issue #3026 merged **after** #3025 was filed) shows they now have different statuses:

1. **"semantic_search's description points at a section that is never rendered" — already fixed by #3026, NOT revived here.** The live `semantic_search` description (`descriptions/discovery.py` → `semantic_search.py`) no longer says *"Available sources are listed under 'Indexed sources' in the system prompt"*; it now says *"Call `list_rag_sources` to see which sources exist"*. #3026 added the `list_rag_sources` verb as the corpus-discovery surface (one tool regardless of corpus count) and **deliberately chose not to render a per-corpus SP section** to avoid re-introducing operator-scaling SP cost. `rag_discovery.py`'s module docstring states this explicitly. Reviving the section would re-add the exact cost #3026 removed, so this PR does **not** render it.

2. **The per-turn build-and-discard — the real, still-live defect this PR closes.** `router_loop` still ran `await get_source_manifest(Path.cwd()).format_for_prompt()` every turn and passed the result as `build_system_prompt(indexed_sources_section=...)`, but the wrapper-only SP has not injected a `## Indexed sources` section since B23-PRE-1. The rendered string was **accepted and discarded** — every turn paid a `SourceManifest.get_all()` (sources.yaml disk read + YAML parse under the cross-process cache check) plus building a markdown string (~95 tokens for the empty-state hint, more when populated) that nothing read.

3. **`_render_memory` (caller-count zero) removed**, together with its only-callees `_parse_memory_entries` and `_ENTRY_FULL_RE` (`_SECTION_HEADER_RE` is retained — still used by `_parse_memory_counts`).

## Changes

- **`router_loop.py`** — drop the per-turn `format_for_prompt()` prefetch + the `indexed_sources_section=` kwarg; remove the now-unused `get_source_manifest` and `Path` imports.
- **`router_system_prompt.py`** — remove the accepted-and-discarded `indexed_sources_section` parameter (+ its docstring and the stale section-10 comment), and the dead `_render_memory` / `_parse_memory_entries` / `_ENTRY_FULL_RE` cluster.
- **`router_history_buffer.py`** — remove the second production callsite's `indexed_sources_section=None` kwarg + its now-moot docstring note.
- **doc-drift (same PR)** — `rag_discovery.py` and `descriptions/discovery.py` docstrings updated from "the parameter is accepted and discarded" to "the parameter and its per-turn prefetch were removed (#3025)".
- **stale dogfood scripts** — `dogfood_sp_render.py` / `s7_driver.py` de-referenced the deleted param. (See "Known limitation" below.)
- **tests** — `test_router_indexed_sources.py` gains a Tier-1 `TestDeadParamAndHelperRemoved` contract class (the parameter and `_render_memory` are gone); `test_manifest_hint_text_absent_from_wrapper_sp` witnesses that even the manifest's distinctive hint text does not appear in a real `build_system_prompt` output; the three other files that passed the param were updated.

## Clean-break completeness (full-repo grep)

Grepped the whole repo (not just src/tests) for `indexed_sources_section`, `_render_memory`, and the per-turn `format_for_prompt()` prefetch. Callsites found and handled:
- `router_history_buffer.py` — production, passed `None` (sync T_SP path); updated.
- `dogfood_sp_render.py`, `s7_driver.py` — stale, non-CI dogfood scripts; de-referenced.
- Test kwargs dicts (`test_2548_...`, `test_router_sp_universal_categories.py`) — updated.
- `docs/deep-dives/journal/...` and `docs/deep-dives/proposals/0050-...` — **historical records** (dated dogfood findings / a proposal correction note that already states `_render_memory` was dead); left intact.

No live consumer actually **used** a rendered section — every callsite either passed `None` or was stale dogfood, so the "dead param" premise holds.

## Known limitation (pre-existing, not introduced here)

`scripts/s7_driver.py` was **already broken** against the current `build_system_prompt` signature (it passes `available_skills=[]`, a kwarg the signature no longer has → TypeError) and its verdict logic (`has_indexed_sources_section`) is entirely premised on the never-rendered section. I removed only the deleted-param reference to keep this PR focused; its `## Indexed sources` string-search verdict logic (pre-existing dead code, string-based, not a symbol reference) is left as-is. Same for `dogfood_sp_render.py`'s unrelated `available_skills` / `universal_wrappers_enabled` kwargs.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK
- [x] `python scripts/test_tier_audit.py --strict <changed tests>` — 48 inspected, 0 errors
- [x] `pytest` (full suite, foreground) — **9269 passed, 33 skipped, 0 failed** (366s)
- [x] Strip-falsify (Edit-only): re-added the `indexed_sources_section` parameter → `test_build_system_prompt_has_no_indexed_sources_param` went RED; removed it → GREEN.
- [x] Edited scripts byte-compile; edited src modules import cleanly.