### PR TITLE
fix(2993): make ConfigGenerationStore path encoding injective for any rel_path

### DIFF
--- a/src/reyn/core/events/config_generations.py
+++ b/src/reyn/core/events/config_generations.py
@@ -26,26 +26,39 @@ _GEN_RE = re.compile(r"^(?P<rel>.+)@(?P<seq>\d+)\.yaml$")
 def _encode(rel_path: str) -> str:
     """`config/mcp.yaml` → `config__mcp.yaml` (path-segment-safe single filename).
 
-    #2352: the encoding maps ``/`` → ``__`` and is injective ONLY for paths with NO ``__``
-    in any segment — ``_decode`` reverses EVERY ``__`` to ``/``, so ``_decode(_encode("a__b/c"))``
-    would yield ``"a/b/c"`` ≠ the original. Config-registry rel_paths are ``__``-free by
-    construction (``.reyn``-relative config file names like ``config/mcp.yaml``), so this
-    enforces that invariant LOUD rather than silently colliding two distinct paths onto one
-    ``<safe-rel>@<seq>.yaml`` generation file — which would return the wrong generation on
-    config-rewind / time-travel (a durability keying corruption). Raising (not asserting) so
-    ``-O`` cannot strip the guard. Existing generation file names are unchanged (no migration):
-    every real path stays ``__``-free, so its encoding is byte-identical to before.
+    #2993: the previous encoding mapped ``/`` → ``__`` directly and RAISED when the
+    rel_path already contained ``__`` (#2352 guard) — a defense that assumed every real
+    caller passes a fixed literal path with no ``__`` in it. That assumption broke for
+    agent-scoped config paths like ``agents/<name>/hooks.yaml`` where ``<name>`` is
+    LLM/operator-chosen and validated only by ``_AGENT_NAME_RE`` (which permits ``__``,
+    e.g. ``my__agent``) — the guard then raised AFTER the ``.yaml`` write had already
+    landed, leaving the config mutated with no recovery generation recorded (a silent
+    recovery hole, not merely a rejected write).
+
+    The fix is a proper escape-then-map scheme, injective over ANY string with no
+    assumption about the input alphabet (no regex, no allow-list): first ``%`` → ``%25``,
+    then ``_`` → ``%5F`` (escaping ``%`` first so the escape sequences themselves can never
+    be misread as user content — standard percent-escaping order), and only THEN
+    ``/`` → ``__`` (now safe: no lone ``_`` survives to be confused with the separator).
+    ``_decode`` reverses in the exact opposite order. Existing generation file names are
+    unchanged (no migration): every real caller path is ``_``/``%``-free, so the escape
+    step is a no-op and the encoding stays byte-identical to before.
     """
-    if "__" in rel_path:
-        raise ValueError(
-            f"config-generation rel_path must not contain '__' (it collides with the '/' → '__' "
-            f"encoding and would round-trip wrong): {rel_path!r}"
-        )
-    return rel_path.replace("/", "__")
+    escaped = rel_path.replace("%", "%25").replace("_", "%5F")
+    return escaped.replace("/", "__")
 
 
 def _decode(safe_rel: str) -> str:
-    return safe_rel.replace("__", "/")
+    """Exact inverse of ``_encode`` — reverse the three substitutions in reverse order:
+    ``__`` → ``/``, then ``%5F`` → ``_``, then ``%25`` → ``%``. This order is load-bearing:
+    reversing ``__`` first can only ever re-form a genuine ``/`` (no lone ``_`` character
+    survives after encode, since every literal ``_`` was escaped to ``%5F`` before the
+    ``/`` → ``__`` step ran), and un-escaping ``%5F``/``%25`` last means those literal
+    substrings from the ORIGINAL path (if any) are restored only after all structural
+    markers are gone — so a decode never mistakes original content for a marker."""
+    unslashed = safe_rel.replace("__", "/")
+    unescaped_underscore = unslashed.replace("%5F", "_")
+    return unescaped_underscore.replace("%25", "%")
 
 
 class ConfigGenerationStore:

--- a/tests/test_2993_config_generation_encoding_injective.py
+++ b/tests/test_2993_config_generation_encoding_injective.py
@@ -1,0 +1,124 @@
+"""Tier 2: #2993 — ConfigGenerationStore path encoding must be injective for ANY rel_path,
+independent of ``_AGENT_NAME_RE`` or any other caller-side allow-list.
+
+``_encode`` used to map ``/`` → ``__`` and RAISE when the rel_path already contained ``__``
+(#2352 guard). Every real caller passed a fixed literal path (e.g. ``config/mcp.yaml``), so the
+guard was never exercised — until an agent-scoped path like ``agents/<name>/hooks.yaml`` carries
+an operator-chosen ``<name>`` that ``_AGENT_NAME_RE`` legally permits to contain ``__`` (e.g.
+``my__agent``). The guard then raised AFTER the ``.yaml`` had already been persisted, leaving the
+config mutated with NO recovery generation recorded — a silent recovery hole (#2088 would have
+been the first caller to hit it).
+
+The fix (escape ``%`` → ``%25``, then ``_`` → ``%5F``, THEN map ``/`` → ``__``; decode reverses
+in the opposite order) is injective over any string, with no assumption about the input alphabet.
+
+Real ``StateLog`` + real ``ConfigGenerationStore`` throughout (no mocks/fakes).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.config_generations import ConfigGenerationStore, _encode
+from reyn.core.events.state_log import StateLog
+
+# The 7 real caller rel_paths in production (grepped from every `record_config_generation` /
+# `record_config_change` call site: hooks.py, cron.py, mcp_install.py/mcp_verbs.py/
+# mcp_drop_server.py/plugin_install.py (all resolve to config/mcp.yaml), skill_install.py,
+# presentation_install.py, pipeline_install.py, index_drop.py). None contain '_' or '%', so the
+# new escape step is a no-op and every encoding stays byte-identical to the pre-#2993 output.
+_REAL_CALLER_PATHS_TO_LEGACY_ENCODING = {
+    "config/hooks.yaml": "config__hooks.yaml",
+    "config/cron.yaml": "config__cron.yaml",
+    "config/mcp.yaml": "config__mcp.yaml",
+    "config/skills.yaml": "config__skills.yaml",
+    "config/presentations.yaml": "config__presentations.yaml",
+    "config/pipelines.yaml": "config__pipelines.yaml",
+    "config/index/sources.yaml": "config__index__sources.yaml",
+}
+
+
+def test_real_caller_paths_encode_unchanged_filenames() -> None:
+    """Tier 2: #2993 — for every real production rel_path (the 7 literal paths grepped from
+    call sites), the new escape-then-map encoding produces the EXACT SAME filename as the old
+    direct '/' → '__' map (no '_' or '%' in any real path → the escape step is a no-op). This
+    pins backward compatibility: existing on-disk generation files remain readable with no
+    rename / migration."""
+    for rel_path, expected_encoded in _REAL_CALLER_PATHS_TO_LEGACY_ENCODING.items():
+        assert _encode(rel_path) == expected_encoded, (
+            f"{rel_path!r} must encode to the same filename as before #2993: "
+            f"{expected_encoded!r} (no migration)"
+        )
+
+
+def _make_log_and_store(tmp_path: Path) -> "tuple[StateLog, ConfigGenerationStore]":
+    log = StateLog(tmp_path / ".reyn" / "state" / "wal.jsonl")
+    store = ConfigGenerationStore(tmp_path / ".reyn" / "config" / "generations")
+    return log, store
+
+
+def test_truncate_falsify_underscore_collision_pair_survives_and_stays_distinct(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: CLAUDE.md recovery-feature truncate-falsify gate — record a generation for an
+    agent-scoped rel_path containing '__' (``agents/my__agent/hooks.yaml``-shaped), truncate the
+    WAL below its recording seq, and confirm reconstruct still returns the correct config — the
+    generation is a FILE (a base), not a truncatable WAL event, so it survives.
+
+    Non-vacuous witness (architect requirement): the former collision pair
+    ``agents/my__agent/hooks.yaml`` and ``agents/my/agent/hooks.yaml`` both flattened to the SAME
+    safe-rel filename under the OLD direct '/' → '__' map. Both are recorded here, at DIFFERENT
+    seqs with DIFFERENT content, survive the same truncation, and must round-trip to their OWN
+    distinct content — neither overwrites nor is shadowed by the other.
+
+    RED under the pre-#2993 code (verified by hand, Edit-only, no git checkout/stash): reverting
+    ``_encode``/``_decode`` to the direct '/' → '__' map + '__' guard raises ``ValueError`` the
+    moment ``path_a`` (which contains '__') is recorded — this test fails immediately instead of
+    reaching the truncate/reconstruct assertions.
+    """
+    path_a = "agents/my__agent/hooks.yaml"
+    path_b = "agents/my/agent/hooks.yaml"
+    content_a = {"hooks": [{"name": "a-hook"}]}
+    content_b = {"hooks": [{"name": "b-hook"}]}
+
+    async def scenario() -> "tuple[int, int]":
+        log, store = _make_log_and_store(tmp_path)
+
+        await log.append("inbox_put", target="x", payload={"i": 1})
+        await log.flush()
+        seq_a = log.last_durable_seq
+        store.record(path_a, content_a, seq_a)  # generation for the '__'-bearing path
+
+        await log.append("inbox_put", target="x", payload={"i": 2})
+        await log.flush()
+        seq_b = log.last_durable_seq
+        store.record(path_b, content_b, seq_b)  # generation for the collision-partner path
+
+        # Advance the WAL well past both generation seqs, then truncate everything below a
+        # floor ABOVE both — the WAL events at seq_a/seq_b are dropped, but the generations
+        # (files) are not WAL entries and must survive.
+        for i in range(3, 8):
+            await log.append("inbox_put", target="x", payload={"i": i})
+        await log.flush()
+        await log.truncate_below(6)
+        await log.flush()
+        return seq_a, seq_b
+
+    seq_a, seq_b = asyncio.run(scenario())
+
+    # Reconstruct: a fresh store handle over the same directory (simulates process restart —
+    # nothing but the on-disk generation files is consulted).
+    _log2, store2 = _make_log_and_store(tmp_path)
+    result_a = store2.latest_at_or_below(path_a, cut=seq_b + 100)
+    result_b = store2.latest_at_or_below(path_b, cut=seq_b + 100)
+
+    assert result_a is not None, "path_a's generation must survive WAL truncation"
+    assert result_b is not None, "path_b's generation must survive WAL truncation"
+    assert result_a == (seq_a, content_a), (
+        f"path_a must reconstruct its OWN content, not path_b's (collision witness); "
+        f"got {result_a}"
+    )
+    assert result_b == (seq_b, content_b), (
+        f"path_b must reconstruct its OWN content, not path_a's (collision witness); "
+        f"got {result_b}"
+    )

--- a/tests/test_events_pure_helpers.py
+++ b/tests/test_events_pure_helpers.py
@@ -67,16 +67,52 @@ def test_encode_decode_roundtrip_nested() -> None:
     assert _decode(_encode(path)) == path
 
 
-def test_encode_rejects_double_underscore_in_path() -> None:
-    """Tier 2: #2352 — _encode RAISES on a rel_path containing '__'. The encoding maps '/' → '__'
-    and is injective ONLY for '__'-free paths, so a segment with '__' would silently collide two
-    distinct config paths onto one generation file (wrong generation on config-rewind = a
-    durability keying corruption). The guard enforces the '__'-free invariant loud. RED before the
-    guard: _encode('a__b/c.yaml') silently returned 'a__b__c.yaml' → _decode → 'a/b/c.yaml' ≠ the
-    original. Real config-registry paths stay '__'-free, so existing generation file names are
-    unchanged (no migration)."""
-    with pytest.raises(ValueError, match="must not contain '__'"):
-        _encode("a__b/c.yaml")
+def test_encode_decode_roundtrips_path_with_double_underscore() -> None:
+    """Tier 2: #2993 — a rel_path containing '__' now round-trips correctly instead of the
+    #2352 guard raising. The #2352 guard assumed every real caller passes a fixed literal
+    path with no '__' in it; that assumption broke for agent-scoped paths like
+    'agents/<name>/hooks.yaml' where '<name>' may legally contain '__' (_AGENT_NAME_RE
+    permits it), so the guard raised AFTER the .yaml write had already landed (a recovery
+    hole, not a rejected write). The new encoding escapes '_' → '%5F' (and '%' → '%25')
+    BEFORE mapping '/' → '__', so '__' in the original content never collides with the
+    '/' separator marker."""
+    original = "a__b/c.yaml"
+    assert _decode(_encode(original)) == original
+
+
+_INJECTIVE_ROUNDTRIP_CASES = [
+    "config/mcp.yaml",
+    "a__b/c.yaml",
+    "a/b/c",
+    "agents/my__agent/hooks.yaml",
+    "agents/my_agent/hooks.yaml",
+    "a%b/c.yaml",
+    "a%5Fb/c.yaml",
+    "a%25b/c.yaml",
+    "a_b__c/d.yaml",
+    "%__%5F__%25",
+    "___",
+    "____",
+    "/",
+    "",
+    "a/b__c/d_e%f",
+]
+
+
+@pytest.mark.parametrize("original", _INJECTIVE_ROUNDTRIP_CASES)
+def test_encode_decode_injective_roundtrip(original: str) -> None:
+    """Tier 2: #2993 — _decode(_encode(x)) == x for ANY string, including combinations of
+    '_', '__', '%', '%5F', '%25', and '/' — no assumption about the input alphabet (the
+    escape-then-map scheme is injective by construction, unlike the old direct '/' → '__'
+    map which only round-tripped '__'-free paths)."""
+    assert _decode(_encode(original)) == original
+
+
+def test_encode_distinguishes_former_collision_pair() -> None:
+    """Tier 2: #2993 non-vacuous witness — under the OLD encoding, 'a__b/c' and 'a/b/c' both
+    mapped to the same safe-rel 'a__b__c' (a real collision: two distinct config paths would
+    share one generation file). Under the new encoding they must map to DIFFERENT safe-rels."""
+    assert _encode("a__b/c") != _encode("a/b/c")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2993

## Problem (実測済み)

`ConfigGenerationStore._encode` (`src/reyn/core/events/config_generations.py`) mapped rel-path `/` → `__`, and raised `ValueError` (#2352 guard) when the rel-path already contained `__` — a defense that assumed every real caller passes a fixed literal path with no `__` in it.

That assumption breaks for agent-scoped config paths such as `.reyn/agents/<name>/hooks.yaml`, where `<name>` is validated only by `_AGENT_NAME_RE = ^[a-z0-9][a-z0-9_-]{0,31}$` — which legally permits `__` (e.g. `my__agent`). For such a path, the `.yaml` write lands FIRST, and only then does the generation-store `record()` call raise — leaving the config mutated on disk with **no recovery generation recorded** (a silent recovery hole). All current callers pass fixed literal paths, so this hole is latent today; #2088 would have been the first caller to hit it, and this fix unblocks that work (#2088 itself is untouched by this PR).

## Fix

`_encode` now escapes `%` → `%25`, then `_` → `%5F`, and only then maps `/` → `__`. `_decode` reverses in the exact opposite order (`__` → `/`, then `%5F` → `_`, then `%25` → `%`). This is injective for **any** input string, with **no dependency on `_AGENT_NAME_RE` or any other caller-side invariant** — the `__`-collision guard is no longer needed and is removed.

## Backward compatibility (no migration)

All 7 real production rel_paths (grepped from every `record_config_generation` / `record_config_change` call site) contain neither `_` nor `%`:
`config/hooks.yaml`, `config/cron.yaml`, `config/mcp.yaml`, `config/skills.yaml`, `config/presentations.yaml`, `config/pipelines.yaml`, `config/index/sources.yaml`.

So the escape step is a no-op for all of them and every encoded filename stays byte-identical to before — pinned by `test_real_caller_paths_encode_unchanged_filenames`. Existing on-disk generation files require no rename/migration.

## Tests (recovery-core gate, CLAUDE.md)

New file `tests/test_2993_config_generation_encoding_injective.py`:
- `test_real_caller_paths_encode_unchanged_filenames` — byte-identical pin for the 7 real caller paths.
- `test_truncate_falsify_underscore_collision_pair_survives_and_stays_distinct` — **truncate-falsify test** (real `StateLog` + real `ConfigGenerationStore`, no mocks): records generations for `agents/my__agent/hooks.yaml` and `agents/my/agent/hooks.yaml` (the former collision pair — both flattened to `agents__my__agent__hooks.yaml`-shaped names under the OLD direct `/`→`__` map) at different seqs, truncates the WAL below both, then reconstructs and asserts BOTH survive as files and round-trip to their OWN distinct content — neither overwrites nor is shadowed by the other.
  - Verified RED under the pre-fix encoding by temporarily reverting `_encode`/`_decode` in-place (Edit-only, no git checkout/stash), confirming the test fails, then restoring the fix.

Updated `tests/test_events_pure_helpers.py`:
- Added `test_encode_decode_injective_roundtrip` (parametrized over `_`/`__`/`%`/`%5F`/`%25`/`/` combinations, including agent-name-like values) and `test_encode_distinguishes_former_collision_pair`.
- Replaced `test_encode_rejects_double_underscore_in_path` (asserted the now-removed `ValueError` guard) with `test_encode_decode_roundtrips_path_with_double_underscore`, asserting the new correct round-trip behavior instead.

All tests use real `StateLog`/`ConfigGenerationStore` instances — no mocks/fakes. Each test docstring declares its Tier (all Tier 2).

## Docs

`config_generations.py`'s `_encode`/`_decode` docstrings were rewritten (not keyword-patched) to describe the new escape-then-map scheme, its rationale, and the load-bearing reverse-order requirement in `_decode`. No other doc in `docs/` describes this encoding (grepped — no hits).

## Local gates (all green)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_2993_config_generation_encoding_injective.py tests/test_events_pure_helpers.py` — 24 tests inspected, 0 errors, 0 warnings
- `pytest` (full suite, foreground) — 9290 passed, 33 skipped
- `python scripts/verify_module_docstrings.py src/reyn/core/events/config_generations.py` — OK

## Test plan

- [x] Full local pytest suite green (9290 passed, 33 skipped)
- [x] ruff clean
- [x] Tier audit clean (strict mode) on changed test files
- [x] Module docstring check clean
- [x] Manually verified RED-under-strip for the truncate-falsify collision-witness test (Edit-only revert + restore)
- [ ] CI green (not awaited by this session per dispatch instructions — architect co-vet + CI-green gate the merge)