### PR TITLE
docs: correct ADR-0039 status drift (Proposed -> implemented) + P5/P6 phase state

### DIFF
--- a/docs/deep-dives/decisions/0039-thin-client-single-writer-server.md
+++ b/docs/deep-dives/decisions/0039-thin-client-single-writer-server.md
@@ -1,6 +1,10 @@
 # ADR-0039: N thin CUI clients × one single-writer server — UI-path unification, four-surface separation
 
-**Status**: Proposed (owner BUILD decision obtained; phased P0–P6).
+**Status**: Accepted — **implemented**. Every phase P0–P6 landed 2026-07-11 and the
+build tracker ([#2805](https://github.com/tya5/reyn/issues/2805)) is closed: P0 #2806,
+P1 #2811 (+ #2837), P2 #2812, P3 #2815 (+ #2838), P4 #2817, P5 #2818, P6 #2819 /
+#2823 / #2826 / #2829. The one part of D8 NOT built is P6's *A2UI catalog
+formalization* half (see that bullet); the protocol-consolidation half shipped.
 **Track**: Runtime interaction model — the concretization of ADR-0018's deferral
 ("multi-process inside one workspace is not a goal; cross-process / cross-Reyn
 is a future layer's job") and a successor seam to ADR-0001 (single-process WAL
@@ -256,9 +260,20 @@ Near-term unnecessary → late phase.
 - **P4 — reyn `Custom` extension profile.** Rich payload on `Custom`;
   ignore-unknown conformance test; single-writer-by-construction assert
   (client owns no workspace/tool).
-- **P5 (future) — OTEL exporter.** Per D7.
-- **P6 (future) — A2UI catalog formalization + protocol consolidation** (fold
-  the existing web UI onto AG-UI; retire the ad-hoc ws JSON).
+- **P5 — OTEL exporter.** Per D7. **Landed** (#2818): P6 audit-event → OTLP
+  span/metric/log, fail-open downstream.
+- **P6 — A2UI catalog formalization + protocol consolidation** (fold the
+  existing web UI onto AG-UI; retire the ad-hoc ws JSON). **The consolidation
+  half landed**: reasoning-frame → standard AG-UI `Reasoning*` mapping (#2819),
+  single-drain broadcast hub for `session.outbox` (#2823), openui browser
+  migrated to AG-UI SSE with ws/chat retired (#2826), closed `OutboxMessage`
+  kind vocabulary + browser-decode drift tripwire (#2829). **The A2UI catalog
+  formalization half is NOT built** and remains future: render-node vocabulary
+  still rides `Custom` (per D-note above), and the present layer stays
+  *reyn-native but structurally isomorphic to A2UI* — proposal 0054 "option C"
+  explicitly defers the wire-level A2UI / MCP-Apps adapters, and
+  `spec/openui/schemas/reyn-ui-v1` records "A2UI: not used". Do not read this
+  ADR as evidence that reyn speaks A2UI on the wire; it speaks **AG-UI**.
 
 ---
 


### PR DESCRIPTION
**[architect]** — ADR-0039 のヘッダが `**Status**: Proposed` のまま、D8 の phase 一覧も `P5 (future)` / `P6 (future)` のままでしたが、**全フェーズ P0–P6 は 2026-07-11 に着地済で build tracker #2805 は CLOSED** です。

**これは cosmetic な drift ではありません。** 実際にこの stale なヘッダを読んだ私(architect, 2026-07-20)が「thin-client サーバは未実装」と結論し、存在しない gap を前提に設計を組み立てました。owner に「thin client は実装済みだよ」と指摘されて発覚しています。doc が誤った設計判断を生んだ実例です。

## 修正内容(blanket な "done" でなく、merge 済 PR に対して per-phase で照合)

- **Status** → Accepted / implemented。各フェーズの着地 PR を明記(P0 #2806 / P1 #2811+#2837 / P2 #2812 / P3 #2815+#2838 / P4 #2817 / P5 #2818 / P6 #2819+#2823+#2826+#2829)。
- **P5** → `(future)` を外し landed(#2818 OTEL exporter)。
- **P6** → ★**分割**。半分しか出荷されていないため:
  - **consolidation 側は着地**(#2819 Reasoning* map / #2823 broadcast hub / #2826 browser→AG-UI SSE + ws/chat 撤去 / #2829 OutboxMessage vocabulary)
  - **A2UI catalog formalization 側は未実装**で future のまま

## AG-UI / A2UI の混同も同時に潰しています

この ADR 自体が両方の名前を抱えている(P2 = AG-UI transport / P6 = "A2UI catalog formalization")ことが混同の種でした。実態は:

- **AG-UI** = reyn がワイヤで話すトランスポート(実装済)
- **A2UI** = agent 生成 UI コンポーネント仕様。present layer は**構造的に同型なだけ**で、ワイヤ級アダプタは proposal 0054 "option C" が明示的に deferred、`spec/openui/schemas/reyn-ui-v1` も "A2UI: not used" と記録

P6 の bullet にこれを明記し、**この ADR を「reyn は A2UI をワイヤで話す」根拠として引用できないように**しました。

## 検証

doc の自己申告でなく**コードと merge 済 PR に対して**確認:
- AG-UI transport 実在(`src/reyn/interfaces/transport/agui/` — SSE events endpoint + POST submit + single-writer surface)
- tracker #2805 = CLOSED
- 同 ADR の line 231 が既に「A2UI catalog 化は spec 安定待ちの future phase」と書いており、修正後の P6 bullet と整合(触れた節全体を読み直した結果)

## Test plan

- [x] Manual: 変更は doc のみ(src/tests 変更なし) — `git diff --stat` = 1 file, +19/-4
- [x] Manual: 全フェーズの着地を merge 済 PR で個別確認(P0–P6 各々の PR 番号を照合)
- [x] Manual: 修正した節の周辺(line 152-158 / 224-232 / 236-242)を読み直し、他に falsify された未来形の記述が無いことを確認(残る "later phase" は multi-driver 同時入力=今も v1 スコープ外、および ADR-0018 の歴史的経緯で、drift ではない)
- [x] Manual: 内部アンカーの追加なし(追加リンクは GitHub issue/PR の外部 URL のみ)ゆえ doc-anchor gate に影響なし