### PR TITLE
docs: FP-0065 orchestration foundation (オーケストレーション基盤整備) + reactive_orchestration_plugins skill

### DIFF
--- a/docs/deep-dives/proposals/0065-orchestration-foundation.md
+++ b/docs/deep-dives/proposals/0065-orchestration-foundation.md
@@ -1,0 +1,137 @@
+# 0065 — Orchestration foundation (オーケストレーション基盤整備): external-event plugins as a first-class unit
+
+- **Status**: Proposed (awaiting owner review)
+- **Date**: 2026-07-20
+- **Arc**: picks up the piece [0064 §Deferred](0064-plugin-model.md) named and did not decide — *"agents/hooks (incl. event composition) plugin containment"* — and is the **receiver for [#2839](https://github.com/tya5/reyn/issues/2839)** (abolish the internal task system in favour of MCP-external orchestration).
+- **Deferred (named, not decided here)**: multi-file skill bodies ([#3162](https://github.com/tya5/reyn/issues/3162)); time-triggered activation (the `cron` surface already exists and is not extended here); cross-session event observation (0059 §keeps this out of v1).
+
+> Design contract: every "reyn already has X" claim in §2 is verified against `origin/main` at the cited path. Claims about *current behaviour* are deliberately anchored to locations rather than restated, because a restated mechanism goes stale and then misleads — this proposal exists partly because a stale `Status:` header in ADR-0039 caused its own author to design around a subsystem that was already built.
+
+## 1. Context — what we are actually building
+
+#2839 replaces reyn's internal task system with **MCP-external orchestration**. That decision moves the orchestrator *out* of reyn, which makes a question load-bearing that was previously cosmetic: **what does reyn core owe an external orchestrator so that it can be a plugin?**
+
+The concrete driver used to find the gaps was a dynamic-UI plugin (a Streamlit app the agent edits, which reports breakage back so the agent can fix it). That is the **first consumer, not the motivation** — every gap below is a property of "something outside pushes, reyn reacts", not of Streamlit.
+
+The loop a reactive plugin needs:
+
+```
+external system changes
+  → server pushes a notification
+  → reyn turns it into a hook event
+  → an action runs (context staged / a turn woken / a pipeline launched)
+  → a result travels back out
+```
+
+### 1.1 Why autonomous reaction is in-bounds
+
+Everything here causes agent turns to run **when no human is present** — that is the point of a reactive plugin, and it needs saying explicitly because it is easy to mis-read as a constitutional problem.
+
+It is not. "Agency is bounded **by construction**" is bounded by *typed, permissioned, auditable, rewindable ops* — the tagline names **spawn** and **orchestrate** as things agents legitimately do. Bounded does **not** mean "a human is watching". Reading it that way would forbid the self-driving behaviour reyn exists to provide.
+
+The operative test is therefore four properties, not human presence:
+
+| Property | Mechanism |
+|---|---|
+| **Permissioned** | the activation is granted by the operator (install + grant), not self-assumed |
+| **Bounded** | a stable unit, not unbounded growth; runaway wakes hit `safety.loop.max_hook_driven_turns` |
+| **Auditable** | the trigger leaves a P6 trace (`hook_push_fired`) and the resulting turn leaves the ordinary turn trail |
+| **Killable** | stopping the reyn process stops all of it |
+
+**`cron` is the standing precedent that this shape is already accepted**: an operator approves a job per-job at registration, the scheduler then resolves-or-spawns that job's own persistent session and boots its run-loop **with nobody watching**, the firing is audit-evented, and the whole thing exists only while the reyn process does. This proposal asks for the same shape for push-driven sources — it does not introduce a new class of autonomy.
+
+## 2. Grounding — what reyn already has (verified on `origin/main`)
+
+The recurring failure when designing here is **proposing a mechanism that exists**. This section is the anti-reinvention list.
+
+| Need | Already provided | Location |
+|---|---|---|
+| Server→client push | `notifications/resources/updated` becomes the `mcp_resource_updated` hook event | `src/reyn/mcp/message_handler.py`, subscribe in `src/reyn/mcp/client.py` |
+| Many distinct signals | **The URI is the namespace** — `matcher` glob-matches `uri` | `src/reyn/hooks/matcher.py` |
+| Burst / flap suppression | Composer `window` / `debounce`, consumed as `composed:<name>` | `src/reyn/hooks/composer.py` |
+| Interrupt vs ride-along | wake (inbox push) / no-wake (next-turn staging) / shell / `pipeline_launch` | `src/reyn/hooks/dispatcher.py` |
+| Runaway bounding | `safety.loop.max_hook_driven_turns` | `src/reyn/config/chat.py` |
+| Hot hook changes | live registry swap, reapplied at the turn boundary | `HookDispatcher.replace_registry` |
+| Returning a result outward | `pipeline_launch` renders `input_template` against the event's template vars, runs async, result returns on this session's inbox; a `shell` step is the write-back leg | `src/reyn/hooks/dispatcher.py`, `src/reyn/core/pipeline/parser.py` |
+| Asking the human | MCP elicitation, per connection, with timeout + listener check | `src/reyn/mcp/connection_service.py` |
+| Tearing a subscription down | `unsubscribe_mcp_resource` op | `src/reyn/tools/mcp.py` |
+| Scoping | workspace `hooks:` + per-agent `.reyn/agents/<name>/hooks.yaml`; bus/registry are per-session | `load_per_agent_hooks`, `src/reyn/hooks/bus.py` |
+
+**Consequences of this table** (things this proposal therefore does *not* add): no new event kind per signal; no server-side debounce; no callback/correlation convention; no crash-recovery story for external state (out of scope **by standing ruling** — the external world is not a reyn recovery source).
+
+## 3. The gaps (measured)
+
+**G1 — Activation is incoherent across three parts.** A reactive loop needs a held connection, a live subscription, and an installed hook. Today each has a *different* decider and timeline: the connection is **lazy** (opens when something calls a tool — `src/reyn/mcp/connection_service.py`), the subscription is **imperative** (an op the agent must call), and the hooks come from **config** (hot-reloaded at the turn boundary). There is no single "this orchestration is now running", and therefore no way to be *partially* correct — connected but unsubscribed, or hooked with nothing pushing.
+
+**G2 — The LLM cannot register the hook this design needs.** `hooks_add` accepts only six lifecycle points (`turn_start`, `turn_end`, `session_start`, `session_end`, `task_start`, `task_end`) and only builds a `template_push` action (`src/reyn/tools/hooks.py`). `mcp_resource_updated` is **not** in that set and `pipeline_launch` is **not** constructible. So the "the agent decides to start an orchestration" pattern is structurally impossible today, even though the agent *can* already open the connection and subscribe.
+
+**G3 — A plugin cannot ship its reactive wiring.** The capability union is `mcp` / `pipelines` / `skills` (`src/reyn/plugins/manifest.py`) and install registers into exactly those three registries (`src/reyn/core/op_runtime/plugin_install.py`). A plugin whose entire value is "react to my events" cannot deliver that value by being installed.
+
+**G4 — Durability is asymmetric.** Hooks persist (a config file); the connection and subscription are volatile. After a crash the residue is *hooks that fire on nothing*.
+
+**G5 — A no-wake staging can starve.** Next-turn ride-along is the correct default when a human is in the loop, but if no next turn ever comes it is never consumed. It must not be the only path for something that must be acted on.
+
+## 4. Decision
+
+### 4.1 One activation unit, three entry points
+
+A **reactive activation** is the triple *{hold this server, subscribe these URIs, install these hooks}* — activated together, torn down together, **scoped to a session**. This single unit closes G1, G3 and the scoping question at once: hooks are live exactly while the plugin is active in that session, so no new session-id bookkeeping is invented (the connection lifetime already *is* per-session).
+
+**Scope of the unit — only for sources that require a held connection.** Of the four external event points, only `mcp_resource_updated` originates from a connection the session must hold and subscribe on. `file_changed` is an in-process watcher; `cron_fired` and `webhook_received` arrive **out-of-process** and resolve their target session themselves (`src/reyn/hooks/ingress.py`). Those three need **no activation unit at all — a hook alone is sufficient**, and for `cron` the operator pattern is already fully available today via the `reyn cron` CLI. This proposal's §4.1 therefore applies to MCP-push orchestration; §4.3 and §4.5 apply to all four.
+
+Three ways to trigger it, by layer:
+
+| Entry point | Surface | Role |
+|---|---|---|
+| **CLI** | `reyn <cmd>` (precedent: `plugin`, `mcp`, `cron`) | Workspace/agent layer: *may* be used here; always-on declaration |
+| **slash** | `/<cmd>` (precedent: `/agent`, `/budget`) | This session, now — matches the session-scoped lifetime |
+| **LLM op** | a typed op | On demand, **within the operator's grant** |
+
+### 4.2 Authority split — content vs timing
+
+**The operator authors what runs; the LLM decides when it is live.** The hook bodies, pipelines and subscribed URIs come from the plugin definition, reviewed when the operator installs it. The LLM only activates and deactivates.
+
+This is what makes LLM-triggered activation safe without loosening `hooks_add`'s existing restrictions: the agent is not authoring a hook, it is switching on an operator-approved one.
+
+### 4.3 `hooks_add` extension (G2)
+
+Extend by the same discriminator — **who authored the content that runs**:
+
+| Change | Decision | Rationale |
+|---|---|---|
+| Add **all four** external event points (`mcp_resource_updated`, `file_changed`, `cron_fired`, `webhook_received`) to the allowed `on:` set | **Add** | The single reason the LLM pattern cannot exist today. Runaways are bounded by the existing loop valve; no-wake pushes are benign. **`cron_fired` needs no carve-out**: registering a hook does not create a schedule — the schedule is created by `cron__register`, which is already gated by the `cron_register` permission key **and** a per-job operator approval prompt. Reacting to an approved job grants no new authority. |
+| Allow the `pipeline_launch` action | **Add** | It launches a **registered** pipeline — content is operator-installed; the LLM chooses only which and when. Also the only path for returning a result outward. |
+| Allow `shell_exec` / `shell_push` | **Keep restricted** | The LLM would *author the command string* — that hands over content authority, a different class from the two above. |
+
+**URI scope for an LLM-registered external-event hook**: it may target only the event surface of a plugin **this session activated**, and the reaction is visible only in that session. A session must not be able to attach itself to another plugin's or another session's signals. (Same shape as 0059's tiering of the `on:` vocabulary.)
+
+### 4.4 Stopping — converge to the crash residue
+
+Stop tears down all three parts. Three rules:
+
+1. **No partial stop.** A left-over subscription costs pushes nobody handles; a left-over hook accumulates as a dead entry.
+2. **Stop leaves the same state a crash leaves.** This is the rule that fixes G4: rather than making the connection/subscription durable, the activation is defined as **volatile** — after a restart a session begins **inactive**. The operator pattern re-declares itself from config; the LLM pattern re-decides. Stop-path and failure-path then produce one state, and one test covers both.
+3. **Idempotent.** Stopping twice, or stopping something never started, is a no-op, not an error.
+
+In-flight work at stop time (a Composer buffer, a running pipeline, an armed escalation) is **discarded** — consistent with the Composer's existing best-effort posture rather than inventing a second durability story.
+
+### 4.5 Inbox `escalate_after` (G5) — independent
+
+An inbox entry queued **without** a wake may carry an `escalate_after`; on expiry it is promoted to a waking delivery through the **existing** wake path, so the existing loop valve counts and bounds it. Opt-in per producer (never a global default — "nobody asked, so it does not matter" is the correct semantics for most no-wake pushes). Escalation emits an audit event: a silent escalation is worse than none. Best-effort across a crash, matching §4.4.
+
+This is a general inbox property, not a hook feature — every no-wake producer benefits. It is separable from §4.1–4.4 and can land independently.
+
+## 5. Consequences
+
+- An external orchestrator becomes installable-and-it-works, which is the precondition #2839 needs before the internal task system can go.
+- Activation becomes an auditable event with a single decider, instead of an emergent property of "someone happened to call a tool".
+- The volatile-activation ruling (§4.4) means **a reactive plugin is not automatically running after a restart**. That is a deliberate trade: predictability and one recovery story, at the cost of a re-activation step. The operator pattern hides this; the LLM pattern does not.
+- `hooks_add` becomes more capable, and the `shell_exec` line becomes the explicit boundary of LLM hook authorship rather than an accident of what was implemented first.
+
+## 6. Rejected alternatives
+
+- **Make connection + subscription durable so activation survives a crash.** Rejected: it creates a second durability story next to the WAL, and the external world is out of recovery scope by ruling. §4.4 converges downward instead.
+- **A per-session hook config layer keyed by session id.** Rejected: session ids are runtime-generated and re-keyable, so the file layer has no author. The connection lifetime already provides per-session scoping for free.
+- **A correlation/callback mechanism for returning results.** Rejected: `pipeline_launch` + `input_template` + a `shell` step already closes the loop, with the correlation id carried in the URI.
+- **Let `hooks_add` register `shell_exec`.** Rejected per §4.3.
+- **Extend `reyn_cheat_sheet` with the authoring guidance.** Rejected: it is at ~98.7% of the default read cap (#3162). The guidance ships as the sibling skill `reactive_orchestration_plugins`.

--- a/docs/deep-dives/proposals/0065-orchestration-foundation.md
+++ b/docs/deep-dives/proposals/0065-orchestration-foundation.md
@@ -52,7 +52,7 @@ The recurring failure when designing here is **proposing a mechanism that exists
 | Interrupt vs ride-along | wake (inbox push) / no-wake (next-turn staging) / shell / `pipeline_launch` | `src/reyn/hooks/dispatcher.py` |
 | Runaway bounding | `safety.loop.max_hook_driven_turns` | `src/reyn/config/chat.py` |
 | Hot hook changes | live registry swap, reapplied at the turn boundary | `HookDispatcher.replace_registry` |
-| Returning a result outward | `pipeline_launch` renders `input_template` against the event's template vars, runs async, result returns on this session's inbox; a `shell` step is the write-back leg | `src/reyn/hooks/dispatcher.py`, `src/reyn/core/pipeline/parser.py` |
+| Returning a result outward | `pipeline_launch` renders `input_template` against the event's template vars, runs async, result returns on this session's inbox (`src/reyn/hooks/dispatcher.py`) — and the launched pipeline's `shell` step is the write-back leg (`src/reyn/core/pipeline/parser.py`, which defines the `transform`/`tool`/`shell` step set) | see inline |
 | Asking the human | MCP elicitation, per connection, with timeout + listener check | `src/reyn/mcp/connection_service.py` |
 | Tearing a subscription down | `unsubscribe_mcp_resource` op | `src/reyn/tools/mcp.py` |
 | Scoping | workspace `hooks:` + per-agent `.reyn/agents/<name>/hooks.yaml`; bus/registry are per-session | `load_per_agent_hooks`, `src/reyn/hooks/bus.py` |

--- a/docs/deep-dives/proposals/0065-orchestration-foundation.md
+++ b/docs/deep-dives/proposals/0065-orchestration-foundation.md
@@ -121,14 +121,109 @@ An inbox entry queued **without** a wake may carry an `escalate_after`; on expir
 
 This is a general inbox property, not a hook feature — every no-wake producer benefits. It is separable from §4.1–4.4 and can land independently.
 
-## 5. Consequences
+## 5. Interfaces
+
+Three surfaces, one activation unit behind them. Each follows the existing idiom of its surface rather than inventing a shape: CLI = argparse sub-parser + `set_defaults(func=...)` (`src/reyn/interfaces/cli/commands/cron.py`); slash = the `@slash(name, summary=...)` decorator (`src/reyn/interfaces/slash/`); LLM = a typed IR op (`kind: Literal[...]` on a pydantic model, `src/reyn/schemas/models.py`) surfaced as a catalog verb.
+
+**Naming is deliberately shared across all three** — the same noun (`reactive`) and the same two verbs (`activate` / `deactivate`) — so an operator reading an audit trail sees one concept regardless of which surface triggered it.
+
+### 5.1 Plugin interface — what a plugin declares
+
+A fourth capability variant, mirroring the existing three (discriminated union, `entries` empty = discover by layout convention):
+
+```python
+class PluginReactiveCapability(BaseModel):
+    kind: Literal["reactive"] = "reactive"
+    entries: tuple[str, ...] = ()      # empty = discover reactive/*.yaml
+```
+
+Each declared file is one **activation definition**:
+
+```yaml
+# <plugin_root>/reactive/<name>.yaml
+name: streamlit_ui            # activation id, unique within the plugin
+server: streamlit             # the .mcp.json server this activation holds
+subscribe:                    # URIs subscribed on activate, dropped on deactivate
+  - "app://status"
+composers:                    # optional — same schema as the workspace `composers:`
+  - name: app_settled
+    op: debounce
+    ttl: 3
+    on: mcp_resource_updated
+    matcher: {server: streamlit, uri: "app://status"}
+hooks:                        # same schema as the workspace `hooks:`
+  - on: composed:app_settled
+    template_push: {message: "...", wake: false}
+```
+
+Rules:
+
+- **A plugin may only name its own `server:`** and may only subscribe/match URIs on that server. This is the containment 0064 deferred; it is what makes plugin-shipped hooks safe to install without a per-hook review.
+- **`shell_exec` / `shell_push` in a plugin-shipped hook requires an explicit grant at install time**, surfaced as its own approval line — same reasoning as §4.3: the plugin, not the operator, authored the command string.
+- Registration is plugin-attributed so `plugin_uninstall` removes the definitions exactly like the existing three registries.
+- **Declaring an activation does not activate it.** Shipping ≠ running; activation is always one of §5.2 / §5.3.
+
+### 5.2 User interface — CLI (durable) and slash (this session)
+
+**CLI — workspace/agent layer, durable.** New sub-parser group under the existing plugin command family:
+
+| Command | Effect |
+|---|---|
+| `reyn reactive list` | Every declared activation, its plugin, and whether it is granted / auto-start |
+| `reyn reactive grant <plugin>/<name> [--agent <a>]` | Permit LLM activation. **Without a grant, §5.3 fails closed.** |
+| `reyn reactive revoke <plugin>/<name>` | Withdraw the grant; deactivates it wherever it is live |
+| `reyn reactive auto <plugin>/<name> --on\|--off [--agent <a>]` | Activate automatically in every session of that agent |
+
+**slash — this session, now.** `/reactive` follows the `@slash` idiom:
+
+| Command | Effect |
+|---|---|
+| `/reactive` | What is active in THIS session, and what is available to activate |
+| `/reactive on <plugin>/<name>` | Activate here |
+| `/reactive off <plugin>/<name>` | Deactivate here |
+
+`/reactive off` works on an activation the LLM started — the operator is the higher authority (§4.4 rule 1 applies to whoever stops it).
+
+### 5.3 LLM interface
+
+Two ops, permission-gated on a single new axis (`require_reactive_activate`), scoped per activation id:
+
+```python
+class ReactiveActivateIROp(BaseModel):
+    kind: Literal["reactive_activate"]
+    activation: str      # "<plugin>/<name>"
+
+class ReactiveDeactivateIROp(BaseModel):
+    kind: Literal["reactive_deactivate"]
+    activation: str
+```
+
+Semantics:
+
+- **Fails closed without an operator grant** (§5.2). The LLM cannot self-grant; this is the "operator authors content and availability, LLM decides timing" split of §4.2 made mechanical.
+- **Activate is all-or-nothing** — hold + subscribe + install, or none of it (§4.4 rule 1 in the forward direction).
+- **Idempotent** both ways (§4.4 rule 3).
+- Both emit an audit event carrying the activation id and the deciding surface, so a trail shows *who* started it, not merely that hooks fired.
+- Deactivate is implicit at session end — activation is session-scoped and volatile (§4.4 rule 2).
+
+**`hooks_add` is not extended for plugin activations.** The extension in §4.3 remains for hooks the LLM registers *directly*; a plugin's hooks arrive via activation, already authored. The two paths stay distinct so the `shell_exec` boundary is enforced in one place per path.
+
+### 5.4 What each surface may NOT do
+
+| Surface | Cannot |
+|---|---|
+| Plugin | Name another plugin's server; subscribe outside its own server; ship a `shell_exec` hook without an install-time grant |
+| LLM | Grant itself; activate an ungranted activation; register a hook on another plugin's event surface; author a `shell_exec` hook |
+| Operator | *(no restriction — the operator is the authority both other surfaces derive from)* |
+
+## 6. Consequences
 
 - An external orchestrator becomes installable-and-it-works, which is the precondition #2839 needs before the internal task system can go.
 - Activation becomes an auditable event with a single decider, instead of an emergent property of "someone happened to call a tool".
 - The volatile-activation ruling (§4.4) means **a reactive plugin is not automatically running after a restart**. That is a deliberate trade: predictability and one recovery story, at the cost of a re-activation step. The operator pattern hides this; the LLM pattern does not.
 - `hooks_add` becomes more capable, and the `shell_exec` line becomes the explicit boundary of LLM hook authorship rather than an accident of what was implemented first.
 
-## 6. Rejected alternatives
+## 7. Rejected alternatives
 
 - **Make connection + subscription durable so activation survives a crash.** Rejected: it creates a second durability story next to the WAL, and the external world is out of recovery scope by ruling. §4.4 converges downward instead.
 - **A per-session hook config layer keyed by session id.** Rejected: session ids are runtime-generated and re-keyable, so the file layer has no author. The connection lifetime already provides per-session scoping for free.

--- a/docs/deep-dives/proposals/0065-orchestration-foundation.md
+++ b/docs/deep-dives/proposals/0065-orchestration-foundation.md
@@ -35,10 +35,10 @@ The operative test is therefore four properties, not human presence:
 |---|---|
 | **Permissioned** | the activation is granted by the operator (install + grant), not self-assumed |
 | **Bounded** | a stable unit, not unbounded growth; runaway wakes hit `safety.loop.max_hook_driven_turns` |
-| **Auditable** | the trigger leaves a P6 trace (`hook_push_fired`) and the resulting turn leaves the ordinary turn trail |
+| **Auditable** | a hook-driven push leaves a P6 trace (`hook_push_fired`) and any woken turn leaves the ordinary turn trail. *Measured caveat*: a bare cron job's fire itself emits **no dedicated P6 event** (`src/reyn/runtime/cron/` has no emit) — the trail starts at the hook push / the woken turn |
 | **Killable** | stopping the reyn process stops all of it |
 
-**`cron` is the standing precedent that this shape is already accepted**: an operator approves a job per-job at registration, the scheduler then resolves-or-spawns that job's own persistent session and boots its run-loop **with nobody watching**, the firing is audit-evented, and the whole thing exists only while the reyn process does. This proposal asks for the same shape for push-driven sources — it does not introduce a new class of autonomy.
+**`cron` is the standing precedent that this shape is already accepted**: an operator approves a job per-job at registration, the scheduler then resolves-or-spawns that job's own persistent session and boots its run-loop **with nobody watching**, a hook-driven push is audit-evented and the woken turn leaves the ordinary trail, and the whole thing exists only while the reyn process does. This proposal asks for the same shape for push-driven sources — it does not introduce a new class of autonomy.
 
 ## 2. Grounding — what reyn already has (verified on `origin/main`)
 
@@ -103,6 +103,8 @@ Extend by the same discriminator — **who authored the content that runs**:
 | Allow the `pipeline_launch` action | **Add** | It launches a **registered** pipeline — content is operator-installed; the LLM chooses only which and when. Also the only path for returning a result outward. |
 | Allow `shell_exec` / `shell_push` | **Keep restricted** | The LLM would *author the command string* — that hands over content authority, a different class from the two above. |
 
+**Storage — an LLM-registered external-event hook is session-scoped and ephemeral.** `hooks_add` today persists to the workspace runtime layer (`.reyn/config/hooks.yaml`), hot-reloaded into **every** session. That is correct for the six lifecycle points it currently accepts, but for external event points it would contradict the scoping rule below (the reaction must be visible only to the registering session) and would let a hook **outlive the session whose activations its guard references** — a dangling scope. Ruling: `hooks_add` registrations on external event points go into the registering session's own per-session registry (the bus/registry are already per-session — `src/reyn/hooks/bus.py`) and **die with the session; `hooks.yaml` is never written**. Lifecycle-point registrations keep today's persistent semantics unchanged.
+
 **URI scope for an LLM-registered external-event hook**: it may target only the event surface of a plugin **this session activated**, and the reaction is visible only in that session. A session must not be able to attach itself to another plugin's or another session's signals. (Same shape as 0059's tiering of the `on:` vocabulary.)
 
 ### 4.4 Stopping — converge to the crash residue
@@ -125,7 +127,7 @@ This is a general inbox property, not a hook feature — every no-wake producer 
 
 Three surfaces, one activation unit behind them. Each follows the existing idiom of its surface rather than inventing a shape: CLI = argparse sub-parser + `set_defaults(func=...)` (`src/reyn/interfaces/cli/commands/cron.py`); slash = the `@slash(name, summary=...)` decorator (`src/reyn/interfaces/slash/`); LLM = a typed IR op (`kind: Literal[...]` on a pydantic model, `src/reyn/schemas/models.py`) surfaced as a catalog verb.
 
-**Naming is deliberately shared across all three** — the same noun (`reactive`) and the same two verbs (`activate` / `deactivate`) — so an operator reading an audit trail sees one concept regardless of which surface triggered it.
+**Naming is deliberately shared across all three** — the same noun and the same two verbs (`activate` / `deactivate`) — so an operator reading an audit trail sees one concept regardless of which surface triggered it. **The noun is provisional**: this section writes `reactive`; the recommended final name is **`reactions`** (a plural artifact noun, matching the existing capability names `mcp` / `pipelines` / `skills` and honestly predicting the file's content: trigger + action), pending the owner's pick. Whichever noun is chosen propagates to all five derived names in one sweep — capability `kind`, the `<plugin_root>/<noun>/` directory, the two IR ops, the CLI/slash command, and the permission axis.
 
 ### 5.1 Plugin interface — what a plugin declares
 
@@ -143,6 +145,7 @@ Each declared file is one **activation definition**:
 # <plugin_root>/reactive/<name>.yaml
 name: streamlit_ui            # activation id, unique within the plugin
 server: streamlit             # the .mcp.json server this activation holds
+exclusive: true               # server owns an exclusive resource (a port, one UI)
 subscribe:                    # URIs subscribed on activate, dropped on deactivate
   - "app://status"
 composers:                    # optional — same schema as the workspace `composers:`
@@ -158,7 +161,9 @@ hooks:                        # same schema as the workspace `hooks:`
 
 Rules:
 
-- **A plugin may only name its own `server:`** and may only subscribe/match URIs on that server. This is the containment 0064 deferred; it is what makes plugin-shipped hooks safe to install without a per-hook review.
+- **A plugin may only name its own `server:`** and may only subscribe/match URIs on that server. This is the containment 0064 deferred; it is what makes plugin-shipped hooks safe to install without a per-hook review. Enforced **at plugin load** (a definition naming a foreign server is rejected — enforce-at-load, 0059's posture) **and re-checked at activate**.
+- **`exclusive: true` fails closed on a second session.** stdio transport spawns **one server subprocess per holding session**, so a server owning an exclusive resource (a bound port, a single UI — the Streamlit first consumer is exactly this) cannot be held twice: the second `activate` fails with an error **naming the holding session**, instead of a silent port clash or a half-broken duplicate. Non-exclusive servers (stateless, e.g. the RAG pair) multi-activate freely.
+- **Activation is not access control.** The plugin's server is registered into `mcp.yaml` at install, and its *tools* remain callable from any session under the ordinary MCP permission gates whether or not an activation is live. The containment above bounds **reactions** (what may subscribe and fire), not tool access.
 - **`shell_exec` / `shell_push` in a plugin-shipped hook requires an explicit grant at install time**, surfaced as its own approval line — same reasoning as §4.3: the plugin, not the operator, authored the command string.
 - Registration is plugin-attributed so `plugin_uninstall` removes the definitions exactly like the existing three registries.
 - **Declaring an activation does not activate it.** Shipping ≠ running; activation is always one of §5.2 / §5.3.
@@ -184,6 +189,8 @@ Rules:
 
 `/reactive off` works on an activation the LLM started — the operator is the higher authority (§4.4 rule 1 applies to whoever stops it).
 
+**`auto` semantics** (the deactivation lattice, stated so it need not be discovered later): `auto` is an operator-surface action and therefore **requires no grant** — the grant of §5.2/§5.3 gates only the LLM op. `auto` applies **at session start only**: a mid-session deactivate (either `/reactive off` or the LLM op) sticks for the remainder of that session, and auto re-applies at the next session start. No mid-session tug-of-war, no livelock.
+
 ### 5.3 LLM interface
 
 Two ops, permission-gated on a single new axis (`require_reactive_activate`), scoped per activation id:
@@ -201,6 +208,8 @@ class ReactiveDeactivateIROp(BaseModel):
 Semantics:
 
 - **Fails closed without an operator grant** (§5.2). The LLM cannot self-grant; this is the "operator authors content and availability, LLM decides timing" split of §4.2 made mechanical.
+- **The grant lives in the permission layer, not a new registry** — the same shape as `require_cron_register` (a permission axis + per-item operator approval), persisted with the agent's permissions. No new config file is invented for grants.
+- The LLM may deactivate **any** activation live in its session, including an auto-started one; per §5.2's `auto` semantics the deactivation sticks for that session only.
 - **Activate is all-or-nothing** — hold + subscribe + install, or none of it (§4.4 rule 1 in the forward direction).
 - **Idempotent** both ways (§4.4 rule 3).
 - Both emit an audit event carrying the activation id and the deciding surface, so a trail shows *who* started it, not merely that hooks fired.
@@ -216,14 +225,31 @@ Semantics:
 | LLM | Grant itself; activate an ungranted activation; register a hook on another plugin's event surface; author a `shell_exec` hook |
 | Operator | *(no restriction — the operator is the authority both other surfaces derive from)* |
 
-## 6. Consequences
+## 6. Implementation notes — build by isomorphism, not invention
+
+- **Activation lifecycle ≅ plugin install/uninstall.** Attributed registration + idempotent teardown + converge-to-a-known-state is the shape `plugin_install` already implements (step-tracked progression; attributed removal in `plugin_uninstall`). Reuse that shape — do not grow a parallel lifecycle machine.
+- **One hooks/composers schema, three carriers.** The workspace `hooks:` config, the per-agent layer, and the activation definition carry the **same** schema and must flow through the **same** loader/validation path (`load_hooks`). A second parser is how carriers drift apart.
+- **Grant ≅ cron's per-job approval** (§5.3): one existing permission-axis pattern, reused — not a new grant store.
+
+## 7. Verification obligations (for the implementing PRs)
+
+Per repo discipline (ADR-0039 D8 carried a reachability + fail-close assert per phase; `docs/deep-dives/contributing/verification-hazards.md`):
+
+- **All-or-nothing witness** (§5.3): force a mid-activation failure (e.g. the subscribe step fails) → assert **nothing** is left installed — no hook in the registry, no held connection.
+- **Grant fail-close negative witness**: witness the **deny side** — an ungranted `*_activate` op is refused. A granted happy-path test alone cannot prove the gate exists.
+- **Exclusivity witness** (§5.1): with an `exclusive: true` activation held by session A, session B's activate fails closed with the error naming A.
+- **Session-scope witness for ephemeral hooks** (§4.3): register an external-event hook via `hooks_add`, end the session → the hook is gone **and `hooks.yaml` is byte-untouched**.
+- **Escalation-through-valve witness** (§4.5): an `escalate_after` promotion flows through the ordinary wake path such that `max_hook_driven_turns` counts it — remove the valve interaction and the bound test must flip RED.
+- **Minimal-strip discipline**: every strip-falsify names the **single** property it breaks (a broad revert that breaks several mechanisms at once proves nothing about any of them).
+
+## 8. Consequences
 
 - An external orchestrator becomes installable-and-it-works, which is the precondition #2839 needs before the internal task system can go.
 - Activation becomes an auditable event with a single decider, instead of an emergent property of "someone happened to call a tool".
 - The volatile-activation ruling (§4.4) means **a reactive plugin is not automatically running after a restart**. That is a deliberate trade: predictability and one recovery story, at the cost of a re-activation step. The operator pattern hides this; the LLM pattern does not.
 - `hooks_add` becomes more capable, and the `shell_exec` line becomes the explicit boundary of LLM hook authorship rather than an accident of what was implemented first.
 
-## 7. Rejected alternatives
+## 9. Rejected alternatives
 
 - **Make connection + subscription durable so activation survives a crash.** Rejected: it creates a second durability story next to the WAL, and the external world is out of recovery scope by ruling. §4.4 converges downward instead.
 - **A per-session hook config layer keyed by session id.** Rejected: session ids are runtime-generated and re-keyable, so the file layer has no author. The connection lifetime already provides per-session scoping for free.

--- a/src/reyn/builtin/registry.py
+++ b/src/reyn/builtin/registry.py
@@ -128,6 +128,25 @@ BUILTIN_SKILLS: "dict[str, dict[str, Any]]" = {
         "enabled": True,
         "visibility": VISIBILITY_ON_DEMAND,
     },
+    "reactive_orchestration_plugins": {
+        # Kept verbatim-identical to the SKILL.md front-matter description so
+        # the two never drift apart (there is no gate comparing them).
+        "description": (
+            "How to build something that REACTS to an external system (an "
+            "orchestrator, a watcher, a UI, any MCP server that pushes) -- "
+            "which reyn mechanism already answers each requirement, and the "
+            "anti-pattern list of things people re-invent. Read this BEFORE "
+            "designing any external-event-driven plugin, server-push "
+            "handling, wake/notification behaviour, or browser UI "
+            "integration. Companion to reyn_cheat_sheet (which covers "
+            "choosing between skill/pipeline/mcp/hook/present in general)."
+        ),
+        "path": str(
+            _BUILTIN_DIR / "skills" / "reactive_orchestration_plugins" / "SKILL.md"
+        ),
+        "enabled": True,
+        "visibility": VISIBILITY_ON_DEMAND,
+    },
     # FP-0063's `build_and_query_rag_corpus` skill (+ the `rag_ingest`/
     # `rag_query` pipelines it documents) moved OUT of this always-on
     # builtin registry under ADR 0064 P5 ("builtin RAG becomes the first

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: reactive_orchestration_plugins
+description: How to build something that REACTS to an external system (an orchestrator, a watcher, a UI, any MCP server that pushes) -- which reyn mechanism already answers each requirement, and the anti-pattern list of things people re-invent. Read this BEFORE designing any external-event-driven plugin, server-push handling, wake/notification behaviour, or browser UI integration. Companion to reyn_cheat_sheet (which covers choosing between skill/pipeline/mcp/hook/present in general).
+---
+
+# Reactive / orchestration plugins
+
+reyn<->MCP is **bidirectional**: you call the server's tools, and the server
+pushes back at you. The recurring failure when designing here is **proposing
+a mechanism reyn already has**.
+
+**How to read this file.** It names *where to look*, not what the code
+currently does. A doc that restates behaviour goes stale and then actively
+misleads -- that is exactly how this file's own author got six design
+decisions wrong in one session, including reading a stale `Status:` header
+and concluding an implemented subsystem did not exist. **Open the cited path
+and confirm before you rely on it.** If a claim here and the code disagree,
+the code wins and this file is the bug.
+
+## Reuse map -- check here before designing anything
+
+| You are about to build | Already exists |
+|---|---|
+| A new event kind per signal | **URI namespace** on one hook point |
+| Burst/flap suppression in your server | **Composer** `window` / `debounce` |
+| A callback convention to return results | **`pipeline_launch`** + a `shell` step |
+| A channel to ask the human a question | **MCP elicitation** |
+| A wire protocol for a browser UI | **AG-UI** |
+| A crash-recovery story for external state | Nothing -- **out of scope by ruling** |
+
+## The push path
+
+A server-pushed `notifications/resources/updated` surfaces as the
+`mcp_resource_updated` hook point. Bridge: `src/reyn/mcp/message_handler.py`.
+Subscribe call: `src/reyn/mcp/client.py`.
+
+The notification carries the **URI, not the resource body** -- the reacting
+side re-reads.
+
+**The URI is your signal namespace.** `matcher` glob-matches `uri` (see the
+glob-field set in `src/reyn/hooks/matcher.py`), so ONE hook point carries
+unlimited distinct signals: `orch://job/<id>/done`, `orch://job/<id>/failed`,
+`app://status`. Carry correlation ids in the URI. Do not ask for a new event
+kind per signal.
+
+## Coalescing bursts
+
+A flapping job, or a file saved five times while someone edits, is the
+**Composer's** job -- not your server's, and not a sleep in a hook.
+`window` / `debounce` live in `src/reyn/hooks/composer.py`, are declared as
+`composers:` and consumed as `composed:<name>`.
+
+Trailing debounce = **"react to the settled state"**, which is almost always
+what you want after a burst of edits. Check that module's docstring for the
+crash-durability guarantee before depending on a pending buffer surviving.
+
+## Wake vs ride-along
+
+The action seams are listed at the top of `src/reyn/hooks/dispatcher.py`.
+Two of them decide whether the agent is interrupted:
+
+- **wake=true** (inbox push) -- starts a turn NOW. Loop-valved; find the knob
+  under `safety.loop` in the chat config and confirm the current default.
+- **wake=false** (next-turn ride-along) -- benign, costs nothing, but **if no
+  next turn ever comes it is never consumed**.
+
+Choose by asking *"is a human already in this loop?"* If yes, ride-along:
+the context is already staged when they next speak, so the first reply is
+fully informed and no turn is spent on noise. If nobody is watching, wake --
+and expect the valve to bound a runaway edit->break->fix->break cycle.
+
+**Do not make ride-along the only path for something that must be acted on.**
+
+## Returning a conclusion to the outside
+
+You do **not** need a callback convention. `pipeline_launch` renders
+`input_template` against the event's template vars -- so a correlation id
+carried in the URI reaches the pipeline -- runs async, and the result comes
+back on this session's own inbox. A `shell` step is the write-back leg to the
+external system. A worked `pipeline_launch` example lives in the Hooks
+section of the `reyn_cheat_sheet` skill.
+
+## Asking the human
+
+MCP **elicitation** is installed per connection with a timeout and a
+listener check (`src/reyn/mcp/connection_service.py`). Use it instead of
+inventing a question channel.
+
+**Sampling is a different primitive** (server asks the client for a model
+completion). Check whether it is wired at all before designing around it.
+
+## Scope -- a workspace-level hook fires in EVERY session
+
+Config layers: the workspace `hooks:` config, and per-agent under
+`.reyn/agents/<name>/hooks.yaml` (`load_per_agent_hooks` in
+`src/reyn/config/loader.py`). The bus and registry are per-session
+(`src/reyn/hooks/bus.py`).
+
+If your reaction is only meaningful while a particular server is attached,
+say so in the design -- otherwise unrelated sessions react to your events.
+
+## What a plugin may ship
+
+The capability union is `src/reyn/plugins/manifest.py`; what install actually
+registers is `src/reyn/core/op_runtime/plugin_install.py`. **Read both before
+assuming your plugin can ship a given part** -- the set is smaller than the
+set of things reyn supports.
+
+## Vocabulary -- two different UI protocols
+
+Never write bare "UI protocol"; they are not interchangeable.
+
+- **AG-UI** -- the agent<->UI **wire transport** (event stream + turn
+  submit). This is what a browser or a thin client speaks to reyn:
+  `src/reyn/interfaces/transport/agui/`.
+- **A2UI** -- an agent-generated-UI **component spec**. reyn's present layer
+  is *structurally isomorphic* to it, which is **not** the same as speaking
+  it on the wire. See `docs/deep-dives/proposals/0054-present-layer.md`.
+
+## Size ceiling for skills
+
+A skill body is read through the ordinary read op, whose inline cap is
+**derived from the model window** (`_read_inline_cap` in
+`src/reyn/core/op_runtime/file.py`). With no model resolved the cap is small.
+A body over the cap comes back `status: "truncated"` -- the reader silently
+gets a partial skill. Keep a skill body well under it, and prefer a new
+sibling skill over growing an existing one past its ceiling.


### PR DESCRIPTION
**[architect]** — #2839(内製 task system 廃止 → MCP-external orchestration)の**受け皿**であり、[0064 が deferred と名指しした](docs/deep-dives/proposals/0064-plugin-model.md)「agents/hooks(イベント合成含む)plugin containment」を引き継ぐ提案です。

owner との設計壁打ち(2026-07-20)の結論を doc 化したもので、**実装は含みません**(Status: Proposed / owner レビュー待ち)。

## この提案が小さい理由

reactive plugin に必要なものの**大半は既に reyn にあります**。§2 は「既にあるもの」の grounding 表(server-push→hook event / URI がシグナル名前空間 / Composer の window・debounce / wake vs 相乗り / 結果を返す `pipeline_launch` / elicitation / loop valve)で、**§6 は「既にあるから却下した案」の記録**です。

この arc 自体が「**既にある機構を新規に作ろうとする**」失敗の連続から生まれており(著者は 1 セッションで 6 回それをやりました)、その予防が §2 の役割です。

## 残った 5 つの gap と、2 つの追加

- **活性化ユニット** `{接続保持, URI 購読, hook 設置}` をセッションスコープで一括起動/一括停止。**保持を要する接続を持つ push 源(MCP)にのみ適用** — cron / fswatch / webhook は ingress が自分で対象セッションを解決するので **hook だけで足ります**。
- **`escalate_after`**(no-wake の inbox エントリの昇格)を **既存の wake 経路経由**で。だから既存の loop valve が自動的に有界化します。独立に着地可能。

## 特筆すべき 2 つの裁定

**停止は crash の残骸に収束させる。** 活性化を volatile と定義し、再起動後のセッションは非活性で始まる ⇒ **停止経路と障害経路が同じ状態を残し、テストが 1 本で済む**。接続・購読を永続化して WAL の隣に第二の耐久性ストーリーを作る案は却下(§6)。

**`hooks_add` の拡張は 1 軸だけ** ——「**走る中身を誰が書いたか**」。外部イベント点と `pipeline_launch` を開放し、`shell_exec` は operator 専用に据え置き。`cron_fired` に例外は不要です:**hook を張ってもスケジュールは作られず**、スケジュール作成の入口 `cron__register` は既に per-job 承認で gate 済。

## §1.1 — 自律実行が憲章内である理由

この基盤は「**人がいない時にエージェントのターンが走る**」ものなので、正当化を明示しました:「bounded by construction」は **typed / permissioned / auditable / rewindable** であって「**人が見ていること**」ではない — タグライン自体が **spawn と orchestrate をエージェントの行為として明示**しています。**`cron` が既にこの形の先例**(per-job 承認 → 無人で session を spawn → 監査証跡あり → プロセス停止で封じ込め)。

## 併載する skill

`reactive_orchestration_plugins`(builtin)。**`reyn_cheat_sheet` の拡張ではなく兄弟として**出しています — cheat sheet は **default read cap の約 98.7%**(#3162)で、追記すると `status: "truncated"` で返るため(実際に踏んで CI が捕捉しました)。

skill は **振る舞いを再記述せず場所を指す**書き方に統一しています。振る舞いを写した doc は陳腐化して誤導する、というのがこの arc を生んだ失敗そのものだからです(ADR-0039 の stale な `Status:` が著者を誤らせた → #3161 で修正)。

## Test plan

- [x] Manual: builtin skill の drift gate + wheel 到達性(`test_builtin_skill_tool_name_drift_3092` / `test_2913_builtin_body_wheel_reachable`)= 10 passed
- [x] Manual: 新 skill が read-op の default inline cap(8192)内に収まることを実測(6197 chars、余裕 1995)
- [x] Manual: `ruff check src tests` = All checks passed
- [x] Manual: §2 grounding 表の各主張を `origin/main` の該当パスで確認(表は場所を指す形式)
- [x] Manual: docs-maintainer に drift audit 依頼を投函(AG-UI/A2UI 混同が他 doc に残る可能性を重点観点として明示)

関連: part of #2839 / #3162(skill の容量問題)/ #3161(ADR-0039 の drift 修正)