### PR TITLE
docs(skill): record the three constraints a plugin author trips over

### DIFF
--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
@@ -117,6 +117,29 @@ Never write bare "UI protocol"; they are not interchangeable.
   is *structurally isomorphic* to it, which is **not** the same as speaking
   it on the wire. See `docs/deep-dives/proposals/0054-present-layer.md`.
 
+## Three constraints that surprise people
+
+**Progress is not a hook.** `notifications/progress` is deliberately NOT
+bridged to a hook point — the SDK already dual-delivers it to the per-call
+`progress_callback` of the call *reyn itself made*. Your server's own
+background-job progress has no such call to ride. Publish progress as a
+**resource** instead (`orch://job/<id>/progress`) and let the ordinary
+subscribe→`mcp_resource_updated` path carry it.
+
+**A webhook's body never reaches your matcher.** `webhook_received` delivers
+routing metadata ONLY (`transport`, `sender`) — the raw request body is never
+put in template_vars, so tokens/PII cannot leak there
+(`src/reyn/hooks/ingress.py`, the adapter's SECURITY invariant). You can match
+"something arrived from X", not "the amount was 500". Content-driven flows
+must fetch the content themselves at the gateway-plugin layer.
+
+**Nothing detects absence.** Every Composer op (`all`/`any`/`seq`/`window`/
+`debounce`/`correlate_by`/`count`) composes events that *happened*. There is
+no "fire if Y did NOT arrive within T" — so deadman monitoring, heartbeat-gone
+alerts, and approval-timeout escalation are not expressible today. Do not
+mistake an inbox `escalate_after` for this: that watches an unconsumed inbox
+entry, not a missing external event.
+
 ## Size ceiling for skills
 
 A skill body is read through the ordinary read op, whose inline cap is


### PR DESCRIPTION
**[architect]** — FP-0065 の土台を、設計を生んだ Streamlit ケースではなく**世間一般の自動化ユースケース 10 件**に当てた検証(#3166)の副産物です。プラグイン作者が確実に躓く 3 点を `reactive_orchestration_plugins` skill に記録します。

## 3 点

**① 進捗は hook 点ではない。** `notifications/progress` は意図的に hook に橋渡しされていません — SDK が **reyn 自身が発行した呼び出し**の per-call `progress_callback` に二重配送するため。プラグインの背景ジョブにはその「呼び出し」が存在しないので、乗る先がありません。**進捗は resource として publish** し、通常の subscribe→`mcp_resource_updated` 経路に載せる、が正解。

**② webhook の body は matcher に届かない。** `webhook_received` が渡すのはルーティングメタデータ(`transport` / `sender`)のみで、生の request body は **ingress adapter の SECURITY invariant により決して template_vars に入りません**(token/PII 保護)。「送信者 X から何か来た」は書けるが「金額が 500 だったら」は書けない。内容駆動フローは gateway-plugin 層で自前取得が必要。

**③ 不在を検知する手段が無い。** Composer の 7 op(`all`/`any`/`seq`/`window`/`debounce`/`correlate_by`/`count`)は**すべて「起きたこと」の合成**。「Y が T 秒来なかったら発火」が無いので、デッドマン監視・heartbeat 途絶・承認タイムアウトが表現できません。**inbox の `escalate_after` と混同しないよう明示**しました — あちらは「消費されない inbox エントリ」の監視で、**外部イベントの不到来**とは層が違います(混同しやすい)。

①②は設計して回避すべき恒久的性質、③は**探しても無いので時間を無駄にしないための告知**です。

## Test plan

- [x] Manual: 本文 **7506 bytes / default read cap 8192**(実測、余裕 686)— `status: "truncated"` にならないことを read-op の cap 関数で直接確認
- [x] Manual: frontmatter の `description` 未変更 ⇒ `BUILTIN_SKILLS` エントリとの逐語一致を維持
- [x] Manual: skill drift gate + wheel 到達性 = 10 passed / `ruff check src tests` clean

関連: #3166(不在検知のギャップ本体)/ #3163(skill 本体)