### PR TITLE
fix(3162): split reyn_cheat_sheet into L2 router + L3 references

### DIFF
--- a/src/reyn/builtin/skills/reyn_cheat_sheet/SKILL.md
+++ b/src/reyn/builtin/skills/reyn_cheat_sheet/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: reyn_cheat_sheet
 description: Reyn-specific usage cheat sheet -- which mechanism to reach for (skill/pipeline/mcp/hook/present), composition idioms, op essentials, and pointers to the full specs. Read this before authoring a new part or composing several.
+references:
+  - input-hooks-and-mcp.md
+  - workflow-pipelines-and-skills.md
+  - output-present-and-self-review.md
 ---
 
 # Reyn cheat sheet
@@ -11,162 +15,32 @@ this skill is the composition know-how in the cracks between them (0060
 Addendum D1). Read on demand when deciding which mechanism to use, or before
 authoring a new skill/pipeline/hook/present-view.
 
+This L2 router stays deliberately small: it is enough on its own to decide
+*whether* you need to go deeper and *which* `references/` file answers your
+question -- you should not need to open a reference just to find out if you
+need it.
+
 ## Decision tree (which mechanism)
 
-- Need **input** (new data, or a reactive trigger) -> `hook` | `mcp` | `retrieval` (`semantic_search`).
-- Need **workflow** (multi-step orchestration) -> `skill` | `pipeline` | an `mcp` tool call mid-flow.
-- Need **output** (show a result, or write externally) -> `present` | `render_template` | an `mcp` write.
+- Need **input** (new data, or a reactive trigger) -> `hook` | `mcp` |
+  `retrieval` (`semantic_search`). Deeper detail (hook action schemes, a
+  CI-verified worked hook example, MCP tool discovery):
+  `references/input-hooks-and-mcp.md` -- read when wiring a reactive
+  trigger or calling an external tool/resource.
+- Need **workflow** (multi-step orchestration) -> `skill` | `pipeline` | an
+  `mcp` tool call mid-flow. Deeper detail (pipeline step grammar, the
+  flagship CI-verified worked pipeline, `SKILL.md` authoring shape):
+  `references/workflow-pipelines-and-skills.md` -- read when writing
+  pipeline DSL steps or authoring a new skill.
+- Need **output** (show a result, or write externally) -> `present` |
+  `render_template` | an `mcp` write. Deeper detail (`present`'s blueprint
+  catalog and the input/output caveat, the self-review gate before
+  promotion): `references/output-present-and-self-review.md` -- read when
+  deciding whether/how to show a result via `present`, or self-reviewing an
+  authored asset before it becomes a reused part.
 
 Reuse before authoring: check the existing catalog (`list_actions`) for a
 part that already covers the need. Author only when nothing fits, and
 self-review anything you author or promote (an `agent` step + `schema`, see
-below) before it becomes a reused asset -- an ungated authored part is a
-liability, not a shortcut.
-
-## `present` -- show results without spending tokens
-
-`present(data_ref=..., blueprint=...)` (or `data_inline=...` for a value
-already in hand) renders directly to the operator's UI at **zero token
-cost to you** -- you never see the render, only a short ack. Use it for
-RESULTS you want the operator to see (a status card, a table, a diff)
-instead of dumping content into your own reply.
-
-**The critical caveat, both directions matter:**
-
-- **OUTPUT -> present.** Show results to the operator with `present` instead
-  of pasting them into your reply.
-- **INPUT -> read, never present.** Content YOU must read or act on (a
-  skill's own body, a doc, a file you need to process) goes through the
-  ordinary read op into your OWN context. Do **not** `present` it -- `present`
-  renders to the operator's screen, not yours; presenting content you need to
-  reason about means you never actually see it.
-
-Blueprint catalog (8 components, display-only, non-executable): `text` /
-`markdown` / `code` / `diff` / `keyvalue` / `table` / `list` / `image`. A
-value inside a component binds via `{"$bind": "<json-pointer>"}` (RFC 6901)
-against the presented data; anything else is a literal label. Full spec +
-`$bind` grammar: `docs/reference/runtime/control-ir.md` (`present` section).
-
-## Self-review -- gate before you promote (`agent` step + `schema`)
-
-Score a value against your own checklist with a pipeline `agent` step whose
-`schema:` names a small schema you declare (e.g. `{score: number, reason:
-string}`) -- it **constrains generation and validates the parsed result**
-(typed, validated scoring, not a bespoke op). Compare the parsed score
-against your own threshold with a plain `transform` step. This is
-**self-review, not objectivity**: you write the draft, you write the
-checklist, and the same model family scores it -- useful, not independent.
-Mandatory gate for auto-improvement promotion (0060 J-D). Full spec:
-`docs/reference/runtime/pipeline-dsl.md`; worked loop: `draft_judge_revise`.
-
-## Pipelines -- orchestration DSL essentials
-
-A `pipeline:` document is a list of `steps:`; each step is single-key
-(`transform` / `tool` / `shell` / `agent` / `call` / `match` / `fold` /
-`for_each` / `parallel`). `output: NAME` on a step makes it readable as
-`ctx.NAME` from every later step; the preceding step's own result is also
-readable as bare `pipe`. A `tool`/`shell` argument is a literal unless
-tagged `!expr EXPR` (an R1 expression against `ctx`/`pipe`); an `agent`
-step's `prompt` interpolates `{ctx.dotted.path}` / `{pipe}` as a template
-string. Full grammar: `docs/reference/runtime/pipeline-dsl.md`.
-
-**A `tool` step's `ctx.<output>` is always the flat `{text, structured}`
-shape** (uniform across every tool) -- never the tool's raw meta fields. An
-`agent` step's `ctx.<output>` differs: no `schema:` -> plain-text reply;
-`schema:` set -> the schema-validated PARSED value directly (e.g.
-`ctx.verdict.score`, no `text`/`structured` wrapper).
-
-**Worked example -- the flagship through-chain** (input -> workflow ->
-output in one pipeline; this exact text is CI-verified to parse AND run):
-
-```yaml
-pipeline: research_and_report
-description: >-
-  Flagship through-chain exemplar (proposal 0060 F3) -- web_search -> agent
-  (summarize) -> agent (self-review, schema-validated) -> present (zero-token
-  operator output). Shows the input -> workflow -> output composition thesis
-  end to end. Ships builtin + inert (invoke-by-name only, never auto-launched).
-steps:
-  - tool:
-      name: web_search
-      args: {query: !expr ctx.query, max_results: 5}
-      output: results
-  - agent:
-      prompt: >-
-        Summarize these web search results into a concise, accurate answer
-        to the query "{ctx.query}". Search results: {ctx.results}
-      output: summary
-  - agent:
-      prompt: >-
-        Self-review this summary against your own checklist: is it accurate,
-        is it concise, and does it directly answer the query "{ctx.query}"?
-        Summary: {ctx.summary}. Give a score in [0.0, 1.0] and a short reason.
-      schema: Verdict
-      output: verdict
-  - transform: {value: "ctx.verdict.score >= 0.6", output: passed}
-  - tool:
-      name: present
-      args:
-        data_inline: !expr "{summary: ctx.summary, verdict: ctx.verdict, passed: ctx.passed}"
-        blueprint:
-          - component: markdown
-            text: {$bind: /summary}
-          - component: keyvalue
-            rows:
-              - {label: score, value: {$bind: /verdict/score}}
-              - {label: passed, value: {$bind: /passed}}
-              - {label: reason, value: {$bind: /verdict/reason}}
-      output: shown
----
-schema: Verdict
-fields:
-  score: {type: number}
-  reason: {type: string}
-```
-
-This ships as the builtin pipeline `flagship.research_and_report` (inert --
-invoke by name: `pipeline__run(name="flagship.research_and_report",
-input={"query": "..."})`, not copy-pasted inline).
-
-## Hooks -- reactive input, made visible
-
-A hook fires an action at a lifecycle point (`session_start` / `turn_end` /
-...) or an external-event point (`file_changed` / `mcp_resource_updated` /
-`cron_fired` / `webhook_received`). Four action schemes: `template_push`
-(inject context or self-continue), `shell_exec` (sandboxed side effect),
-`shell_push` (stdout decides the push), `pipeline_launch` (launch a
-registered pipeline, async). Hooks are operator-config only (`hooks:` in
-`reyn.yaml`) -- you cannot author one yourself; `emit_hook_event` is the one
-op that lets you put an event onto your OWN session's bus for an
-operator-configured Composer/hook to react to. Full spec:
-`docs/concepts/runtime/hooks.md`.
-
-**Worked example -- a `file_changed` hook launching a pipeline** (this exact
-text is CI-verified to load without a `HookConfigError`):
-
-```yaml-hooks
-hooks:
-  - on: file_changed
-    matcher: {path: "docs/**"}
-    pipeline_launch:
-      name: flagship.research_and_report
-      input_template: {query: "summarize the change at {{ path }}"}
-```
-
-## Skills -- authoring a new one
-
-A `SKILL.md` is YAML frontmatter (`name`, `description`) + a free-form
-Markdown body -- not a schema the OS parses (the pre-1.0 phase-graph
-`entry:`/`graph:`/`final_output:` shape is REMOVED). The registry never
-reads the body -- only `path`/`description` populate the L1 menu; you read
-the body yourself at L2 via the ordinary read op when its description looks
-relevant. Install via `skill_management__install_local` /
-`skill_management__install_source`. Full spec:
-`docs/concepts/tools-integrations/skills.md`.
-
-## MCP -- external capability
-
-An MCP server is an external tool/resource/prompt provider, registered via
-`mcp.servers` config. `describe_mcp_tool` gives a live round-trip spec for
-any tool a connected server exposes. Full spec:
-`docs/concepts/tools-integrations/mcp.md`.
+`references/output-present-and-self-review.md`) before it becomes a reused
+asset -- an ungated authored part is a liability, not a shortcut.

--- a/src/reyn/builtin/skills/reyn_cheat_sheet/references/input-hooks-and-mcp.md
+++ b/src/reyn/builtin/skills/reyn_cheat_sheet/references/input-hooks-and-mcp.md
@@ -1,0 +1,37 @@
+# Input mechanisms: hooks and MCP
+
+Read this when wiring a reactive trigger (a hook) or reaching for an
+external tool/resource/prompt provider (MCP) -- the two answers to the
+cheat sheet's decision tree "need **input**" branch.
+
+## Hooks -- reactive input, made visible
+
+A hook fires an action at a lifecycle point (`session_start` / `turn_end` /
+...) or an external-event point (`file_changed` / `mcp_resource_updated` /
+`cron_fired` / `webhook_received`). Four action schemes: `template_push`
+(inject context or self-continue), `shell_exec` (sandboxed side effect),
+`shell_push` (stdout decides the push), `pipeline_launch` (launch a
+registered pipeline, async). Hooks are operator-config only (`hooks:` in
+`reyn.yaml`) -- you cannot author one yourself; `emit_hook_event` is the one
+op that lets you put an event onto your OWN session's bus for an
+operator-configured Composer/hook to react to. Full spec:
+`docs/concepts/runtime/hooks.md`.
+
+**Worked example -- a `file_changed` hook launching a pipeline** (this exact
+text is CI-verified to load without a `HookConfigError`):
+
+```yaml-hooks
+hooks:
+  - on: file_changed
+    matcher: {path: "docs/**"}
+    pipeline_launch:
+      name: flagship.research_and_report
+      input_template: {query: "summarize the change at {{ path }}"}
+```
+
+## MCP -- external capability
+
+An MCP server is an external tool/resource/prompt provider, registered via
+`mcp.servers` config. `describe_mcp_tool` gives a live round-trip spec for
+any tool a connected server exposes. Full spec:
+`docs/concepts/tools-integrations/mcp.md`.

--- a/src/reyn/builtin/skills/reyn_cheat_sheet/references/output-present-and-self-review.md
+++ b/src/reyn/builtin/skills/reyn_cheat_sheet/references/output-present-and-self-review.md
@@ -1,0 +1,42 @@
+# Output mechanisms: present and self-review
+
+Read this when deciding whether/how to show a result to the operator via
+`present`, or when self-reviewing an authored/promoted asset before it
+becomes a reused part -- the two answers to the cheat sheet's decision tree
+"need **output**" branch.
+
+## `present` -- show results without spending tokens
+
+`present(data_ref=..., blueprint=...)` (or `data_inline=...` for a value
+already in hand) renders directly to the operator's UI at **zero token
+cost to you** -- you never see the render, only a short ack. Use it for
+RESULTS you want the operator to see (a status card, a table, a diff)
+instead of dumping content into your own reply.
+
+**The critical caveat, both directions matter:**
+
+- **OUTPUT -> present.** Show results to the operator with `present` instead
+  of pasting them into your reply.
+- **INPUT -> read, never present.** Content YOU must read or act on (a
+  skill's own body, a doc, a file you need to process) goes through the
+  ordinary read op into your OWN context. Do **not** `present` it -- `present`
+  renders to the operator's screen, not yours; presenting content you need to
+  reason about means you never actually see it.
+
+Blueprint catalog (8 components, display-only, non-executable): `text` /
+`markdown` / `code` / `diff` / `keyvalue` / `table` / `list` / `image`. A
+value inside a component binds via `{"$bind": "<json-pointer>"}` (RFC 6901)
+against the presented data; anything else is a literal label. Full spec +
+`$bind` grammar: `docs/reference/runtime/control-ir.md` (`present` section).
+
+## Self-review -- gate before you promote (`agent` step + `schema`)
+
+Score a value against your own checklist with a pipeline `agent` step whose
+`schema:` names a small schema you declare (e.g. `{score: number, reason:
+string}`) -- it **constrains generation and validates the parsed result**
+(typed, validated scoring, not a bespoke op). Compare the parsed score
+against your own threshold with a plain `transform` step. This is
+**self-review, not objectivity**: you write the draft, you write the
+checklist, and the same model family scores it -- useful, not independent.
+Mandatory gate for auto-improvement promotion (0060 J-D). Full spec:
+`docs/reference/runtime/pipeline-dsl.md`; worked loop: `draft_judge_revise`.

--- a/src/reyn/builtin/skills/reyn_cheat_sheet/references/workflow-pipelines-and-skills.md
+++ b/src/reyn/builtin/skills/reyn_cheat_sheet/references/workflow-pipelines-and-skills.md
@@ -1,0 +1,85 @@
+# Workflow mechanisms: pipelines and skills
+
+Read this when writing a `pipeline:` document's steps, or authoring a new
+`SKILL.md` -- the two answers to the cheat sheet's decision tree "need
+**workflow**" branch (multi-step orchestration).
+
+## Pipelines -- orchestration DSL essentials
+
+A `pipeline:` document is a list of `steps:`; each step is single-key
+(`transform` / `tool` / `shell` / `agent` / `call` / `match` / `fold` /
+`for_each` / `parallel`). `output: NAME` on a step makes it readable as
+`ctx.NAME` from every later step; the preceding step's own result is also
+readable as bare `pipe`. A `tool`/`shell` argument is a literal unless
+tagged `!expr EXPR` (an R1 expression against `ctx`/`pipe`); an `agent`
+step's `prompt` interpolates `{ctx.dotted.path}` / `{pipe}` as a template
+string. Full grammar: `docs/reference/runtime/pipeline-dsl.md`.
+
+**A `tool` step's `ctx.<output>` is always the flat `{text, structured}`
+shape** (uniform across every tool) -- never the tool's raw meta fields. An
+`agent` step's `ctx.<output>` differs: no `schema:` -> plain-text reply;
+`schema:` set -> the schema-validated PARSED value directly (e.g.
+`ctx.verdict.score`, no `text`/`structured` wrapper).
+
+**Worked example -- the flagship through-chain** (input -> workflow ->
+output in one pipeline; this exact text is CI-verified to parse AND run):
+
+```yaml
+pipeline: research_and_report
+description: >-
+  Flagship through-chain exemplar (proposal 0060 F3) -- web_search -> agent
+  (summarize) -> agent (self-review, schema-validated) -> present (zero-token
+  operator output). Shows the input -> workflow -> output composition thesis
+  end to end. Ships builtin + inert (invoke-by-name only, never auto-launched).
+steps:
+  - tool:
+      name: web_search
+      args: {query: !expr ctx.query, max_results: 5}
+      output: results
+  - agent:
+      prompt: >-
+        Summarize these web search results into a concise, accurate answer
+        to the query "{ctx.query}". Search results: {ctx.results}
+      output: summary
+  - agent:
+      prompt: >-
+        Self-review this summary against your own checklist: is it accurate,
+        is it concise, and does it directly answer the query "{ctx.query}"?
+        Summary: {ctx.summary}. Give a score in [0.0, 1.0] and a short reason.
+      schema: Verdict
+      output: verdict
+  - transform: {value: "ctx.verdict.score >= 0.6", output: passed}
+  - tool:
+      name: present
+      args:
+        data_inline: !expr "{summary: ctx.summary, verdict: ctx.verdict, passed: ctx.passed}"
+        blueprint:
+          - component: markdown
+            text: {$bind: /summary}
+          - component: keyvalue
+            rows:
+              - {label: score, value: {$bind: /verdict/score}}
+              - {label: passed, value: {$bind: /passed}}
+              - {label: reason, value: {$bind: /verdict/reason}}
+      output: shown
+---
+schema: Verdict
+fields:
+  score: {type: number}
+  reason: {type: string}
+```
+
+This ships as the builtin pipeline `flagship.research_and_report` (inert --
+invoke by name: `pipeline__run(name="flagship.research_and_report",
+input={"query": "..."})`, not copy-pasted inline).
+
+## Skills -- authoring a new one
+
+A `SKILL.md` is YAML frontmatter (`name`, `description`) + a free-form
+Markdown body -- not a schema the OS parses (the pre-1.0 phase-graph
+`entry:`/`graph:`/`final_output:` shape is REMOVED). The registry never
+reads the body -- only `path`/`description` populate the L1 menu; you read
+the body yourself at L2 via the ordinary read op when its description looks
+relevant. Install via `skill_management__install_local` /
+`skill_management__install_source`. Full spec:
+`docs/concepts/tools-integrations/skills.md`.

--- a/tests/test_0060_phase2_f3b_builtin_content.py
+++ b/tests/test_0060_phase2_f3b_builtin_content.py
@@ -74,7 +74,19 @@ _FLAGSHIP_PIPELINE_PATH = Path(BUILTIN_PIPELINES["flagship"]["path"])
 
 
 def _cheat_sheet_body() -> str:
-    return _CHEAT_SHEET_PATH.read_text(encoding="utf-8")
+    """The cheat sheet's full content -- the L2 router (SKILL.md) PLUS every
+    L3 `references/*.md` file it declares (#3162 part 2: the worked
+    pipeline/hook examples and the five curated-axes markers moved out of
+    SKILL.md into references/ to fit the inline-read cap; this helper reads
+    the same aggregate content a model reaches by following the router, so
+    the D5a executable-example and axes-coverage checks below still see the
+    real shipped text)."""
+    router_text = _CHEAT_SHEET_PATH.read_text(encoding="utf-8")
+    references_dir = _CHEAT_SHEET_PATH.parent / "references"
+    reference_texts = [
+        p.read_text(encoding="utf-8") for p in sorted(references_dir.glob("*.md"))
+    ]
+    return "\n\n".join([router_text, *reference_texts])
 
 
 def _extract_fenced_block(text: str, lang: str) -> str:


### PR DESCRIPTION
**[per-PR-coder]** — part of #3162 (② L2 router + L3 references split). ①(#3169 cap gate) and ③(#3170 references gate) are already merged; ④ `reactive_orchestration_plugins` migration is intentionally out of scope here.

## Why not split by topic
`reyn_cheat_sheet` is a single-topic index ("which mechanism to reach for: skill/pipeline/mcp/hook/present"), not a bundle of separate topics — splitting it into independent skills (as the RAG skill was split) would destroy the index itself. Instead: L2 router (`SKILL.md`, kept small) + L3 `references/*.md` (read on demand), declared via #3170's front-matter `references:` gate contract.

## What moved where
- `references/input-hooks-and-mcp.md` (1,560B) — Hooks section (incl. worked `file_changed` example) + MCP section, verbatim.
- `references/workflow-pipelines-and-skills.md` (3,691B) — Pipelines DSL essentials (incl. the flagship worked example) + Skills-authoring section, verbatim.
- `references/output-present-and-self-review.md` (2,288B) — `present` section + Self-review section, verbatim.
- Router `SKILL.md` (2,445B, 30% of cap) keeps the Decision tree (unchanged branches) + a 1-2 line "when to read" pointer per reference, plus the reuse-before-authoring paragraph. No content dropped.

## Consumer fix
`tests/test_0060_phase2_f3b_builtin_content.py`'s `_cheat_sheet_body()` read only `SKILL.md`; updated to concatenate the router + all `references/*.md` (the same aggregate a model reaches by following the router) so the D5a executable-example and axes-coverage checks still see the real shipped content.

## Gate results (all green, foreground `pytest` full suite: 9305 passed, 33 skipped)
- `tests/test_skill_references_gate_3162.py` (#3170) — now non-vacuous: `reyn_cheat_sheet` is the first real `references:` consumer.
- `tests/test_skill_md_default_inline_cap_gate.py` (#3169 cap) — green.
- `tests/test_builtin_registry_disk_parity.py` (#3168 parity) — green (description untouched, verbatim match to registry).
- `ruff check src tests` — clean. `test_tier_audit.py --strict` on the changed test file — 17/17 OK.

## Observation
`reactive_orchestration_plugins` (7,506B = 91.5% of cap) is close to the floor too, but is out of scope per the issue — no action taken here.