### PR TITLE
fix(3162): split reactive_orchestration_plugins into L2 router + L3 references

### DIFF
--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: reactive_orchestration_plugins
 description: How to build something that REACTS to an external system (an orchestrator, a watcher, a UI, any MCP server that pushes) -- which reyn mechanism already answers each requirement, and the anti-pattern list of things people re-invent. Read this BEFORE designing any external-event-driven plugin, server-push handling, wake/notification behaviour, or browser UI integration. Companion to reyn_cheat_sheet (which covers choosing between skill/pipeline/mcp/hook/present in general).
+references:
+  - incoming-events-coalescing-and-wake.md
+  - returning-results-and-elicitation.md
+  - scope-plugin-surface-and-vocabulary.md
 ---
 
 # Reactive / orchestration plugins
@@ -28,123 +32,26 @@ the code wins and this file is the bug.
 | A wire protocol for a browser UI | **AG-UI** |
 | A crash-recovery story for external state | Nothing -- **out of scope by ruling** |
 
-## The push path
+## Where to read more
 
-A server-pushed `notifications/resources/updated` surfaces as the
-`mcp_resource_updated` hook point. Bridge: `src/reyn/mcp/message_handler.py`.
-Subscribe call: `src/reyn/mcp/client.py`.
+Each reference below is self-contained; open only the one(s) your design
+question maps to.
 
-The notification carries the **URI, not the resource body** -- the reacting
-side re-reads.
-
-**The URI is your signal namespace.** `matcher` glob-matches `uri` (see the
-glob-field set in `src/reyn/hooks/matcher.py`), so ONE hook point carries
-unlimited distinct signals: `orch://job/<id>/done`, `orch://job/<id>/failed`,
-`app://status`. Carry correlation ids in the URI. Do not ask for a new event
-kind per signal.
-
-## Coalescing bursts
-
-A flapping job, or a file saved five times while someone edits, is the
-**Composer's** job -- not your server's, and not a sleep in a hook.
-`window` / `debounce` live in `src/reyn/hooks/composer.py`, are declared as
-`composers:` and consumed as `composed:<name>`.
-
-Trailing debounce = **"react to the settled state"**, which is almost always
-what you want after a burst of edits. Check that module's docstring for the
-crash-durability guarantee before depending on a pending buffer surviving.
-
-## Wake vs ride-along
-
-The action seams are listed at the top of `src/reyn/hooks/dispatcher.py`.
-Two of them decide whether the agent is interrupted:
-
-- **wake=true** (inbox push) -- starts a turn NOW. Loop-valved; find the knob
-  under `safety.loop` in the chat config and confirm the current default.
-- **wake=false** (next-turn ride-along) -- benign, costs nothing, but **if no
-  next turn ever comes it is never consumed**.
-
-Choose by asking *"is a human already in this loop?"* If yes, ride-along:
-the context is already staged when they next speak, so the first reply is
-fully informed and no turn is spent on noise. If nobody is watching, wake --
-and expect the valve to bound a runaway edit->break->fix->break cycle.
-
-**Do not make ride-along the only path for something that must be acted on.**
-
-## Returning a conclusion to the outside
-
-You do **not** need a callback convention. `pipeline_launch` renders
-`input_template` against the event's template vars -- so a correlation id
-carried in the URI reaches the pipeline -- runs async, and the result comes
-back on this session's own inbox. A `shell` step is the write-back leg to the
-external system. A worked `pipeline_launch` example lives in the Hooks
-section of the `reyn_cheat_sheet` skill.
-
-## Asking the human
-
-MCP **elicitation** is installed per connection with a timeout and a
-listener check (`src/reyn/mcp/connection_service.py`). Use it instead of
-inventing a question channel.
-
-**Sampling is a different primitive** (server asks the client for a model
-completion). Check whether it is wired at all before designing around it.
-
-## Scope -- a workspace-level hook fires in EVERY session
-
-Config layers: the workspace `hooks:` config, and per-agent under
-`.reyn/agents/<name>/hooks.yaml` (`load_per_agent_hooks` in
-`src/reyn/config/loader.py`). The bus and registry are per-session
-(`src/reyn/hooks/bus.py`).
-
-If your reaction is only meaningful while a particular server is attached,
-say so in the design -- otherwise unrelated sessions react to your events.
-
-## What a plugin may ship
-
-The capability union is `src/reyn/plugins/manifest.py`; what install actually
-registers is `src/reyn/core/op_runtime/plugin_install.py`. **Read both before
-assuming your plugin can ship a given part** -- the set is smaller than the
-set of things reyn supports.
-
-## Vocabulary -- two different UI protocols
-
-Never write bare "UI protocol"; they are not interchangeable.
-
-- **AG-UI** -- the agent<->UI **wire transport** (event stream + turn
-  submit). This is what a browser or a thin client speaks to reyn:
-  `src/reyn/interfaces/transport/agui/`.
-- **A2UI** -- an agent-generated-UI **component spec**. reyn's present layer
-  is *structurally isomorphic* to it, which is **not** the same as speaking
-  it on the wire. See `docs/deep-dives/proposals/0054-present-layer.md`.
-
-## Three constraints that surprise people
-
-**Progress is not a hook.** `notifications/progress` is deliberately NOT
-bridged to a hook point — the SDK already dual-delivers it to the per-call
-`progress_callback` of the call *reyn itself made*. Your server's own
-background-job progress has no such call to ride. Publish progress as a
-**resource** instead (`orch://job/<id>/progress`) and let the ordinary
-subscribe→`mcp_resource_updated` path carry it.
-
-**A webhook's body never reaches your matcher.** `webhook_received` delivers
-routing metadata ONLY (`transport`, `sender`) — the raw request body is never
-put in template_vars, so tokens/PII cannot leak there
-(`src/reyn/hooks/ingress.py`, the adapter's SECURITY invariant). You can match
-"something arrived from X", not "the amount was 500". Content-driven flows
-must fetch the content themselves at the gateway-plugin layer.
-
-**Nothing detects absence.** Every Composer op (`all`/`any`/`seq`/`window`/
-`debounce`/`correlate_by`/`count`) composes events that *happened*. There is
-no "fire if Y did NOT arrive within T" — so deadman monitoring, heartbeat-gone
-alerts, and approval-timeout escalation are not expressible today. Do not
-mistake an inbox `escalate_after` for this: that watches an unconsumed inbox
-entry, not a missing external event.
-
-## Size ceiling for skills
-
-A skill body is read through the ordinary read op, whose inline cap is
-**derived from the model window** (`_read_inline_cap` in
-`src/reyn/core/op_runtime/file.py`). With no model resolved the cap is small.
-A body over the cap comes back `status: "truncated"` -- the reader silently
-gets a partial skill. Keep a skill body well under it, and prefer a new
-sibling skill over growing an existing one past its ceiling.
+- **`incoming-events-coalescing-and-wake.md`** -- how a server-pushed
+  notification reaches a hook (`mcp_resource_updated`), how to namespace
+  distinct signals on the URI without new event kinds, how to coalesce a
+  flapping/bursty source with the Composer, and how to choose wake=true
+  (interrupt now) vs wake=false (ride-along). Read this when you are
+  wiring the *inbound* side of a reactive plugin.
+- **`returning-results-and-elicitation.md`** -- how to send a conclusion
+  back out via `pipeline_launch` + a `shell` step (no callback convention
+  needed), and how to ask the human a question via MCP elicitation
+  (vs. sampling). Read this when your design needs a write-back leg or a
+  human-in-the-loop question.
+- **`scope-plugin-surface-and-vocabulary.md`** -- hook config scope
+  (workspace vs per-agent, and why a workspace-level hook fires in every
+  session), what a plugin manifest may actually ship, the AG-UI vs A2UI
+  vocabulary split, three constraints that repeatedly surprise authors
+  (progress is not a hook, a webhook body never reaches your matcher,
+  nothing detects absence), and the skill-body size ceiling itself. Read
+  this for plugin-packaging, config-scope, or UI-protocol questions.

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: reactive_orchestration_plugins
 description: How to build something that REACTS to an external system (an orchestrator, a watcher, a UI, any MCP server that pushes) -- which reyn mechanism already answers each requirement, and the anti-pattern list of things people re-invent. Read this BEFORE designing any external-event-driven plugin, server-push handling, wake/notification behaviour, or browser UI integration. Companion to reyn_cheat_sheet (which covers choosing between skill/pipeline/mcp/hook/present in general).
-references:
-  - incoming-events-coalescing-and-wake.md
-  - returning-results-and-elicitation.md
-  - scope-plugin-surface-and-vocabulary.md
 ---
 
 # Reactive / orchestration plugins
@@ -32,26 +28,30 @@ the code wins and this file is the bug.
 | A wire protocol for a browser UI | **AG-UI** |
 | A crash-recovery story for external state | Nothing -- **out of scope by ruling** |
 
-## Where to read more
+## Additional resources
 
-Each reference below is self-contained; open only the one(s) your design
-question maps to.
+These files live next to this one, under `references/`. `skill_list` gives
+you this file's absolute path -- resolve each link below against that same
+directory and read it with the ordinary file read op when your question
+maps to it; do not read all three unconditionally.
 
-- **`incoming-events-coalescing-and-wake.md`** -- how a server-pushed
-  notification reaches a hook (`mcp_resource_updated`), how to namespace
-  distinct signals on the URI without new event kinds, how to coalesce a
-  flapping/bursty source with the Composer, and how to choose wake=true
-  (interrupt now) vs wake=false (ride-along). Read this when you are
-  wiring the *inbound* side of a reactive plugin.
-- **`returning-results-and-elicitation.md`** -- how to send a conclusion
-  back out via `pipeline_launch` + a `shell` step (no callback convention
-  needed), and how to ask the human a question via MCP elicitation
-  (vs. sampling). Read this when your design needs a write-back leg or a
-  human-in-the-loop question.
-- **`scope-plugin-surface-and-vocabulary.md`** -- hook config scope
-  (workspace vs per-agent, and why a workspace-level hook fires in every
-  session), what a plugin manifest may actually ship, the AG-UI vs A2UI
-  vocabulary split, three constraints that repeatedly surprise authors
-  (progress is not a hook, a webhook body never reaches your matcher,
-  nothing detects absence), and the skill-body size ceiling itself. Read
-  this for plugin-packaging, config-scope, or UI-protocol questions.
+- [incoming-events-coalescing-and-wake.md](references/incoming-events-coalescing-and-wake.md)
+  -- how a server-pushed notification reaches a hook
+  (`mcp_resource_updated`), how to namespace distinct signals on the URI
+  without new event kinds, how to coalesce a flapping/bursty source with
+  the Composer, and how to choose wake=true (interrupt now) vs wake=false
+  (ride-along). Read this when you are wiring the *inbound* side of a
+  reactive plugin.
+- [returning-results-and-elicitation.md](references/returning-results-and-elicitation.md)
+  -- how to send a conclusion back out via `pipeline_launch` + a `shell`
+  step (no callback convention needed), and how to ask the human a
+  question via MCP elicitation (vs. sampling). Read this when your design
+  needs a write-back leg or a human-in-the-loop question.
+- [scope-plugin-surface-and-vocabulary.md](references/scope-plugin-surface-and-vocabulary.md)
+  -- hook config scope (workspace vs per-agent, and why a workspace-level
+  hook fires in every session), what a plugin manifest may actually ship,
+  the AG-UI vs A2UI vocabulary split, three constraints that repeatedly
+  surprise authors (progress is not a hook, a webhook body never reaches
+  your matcher, nothing detects absence), and the skill-body size ceiling
+  itself. Read this for plugin-packaging, config-scope, or UI-protocol
+  questions.

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/SKILL.md
@@ -30,24 +30,24 @@ the code wins and this file is the bug.
 
 ## Additional resources
 
-These files live next to this one, under `references/`. `skill_list` gives
-you this file's absolute path -- resolve each link below against that same
-directory and read it with the ordinary file read op when your question
-maps to it; do not read all three unconditionally.
+These files live next to this one, under `references/`. `${CLAUDE_SKILL_DIR}`
+expands to this file's own directory when SKILL.md is loaded -- read a link
+below with the ordinary file read op when your question maps to it; do not
+read all three unconditionally.
 
-- [incoming-events-coalescing-and-wake.md](references/incoming-events-coalescing-and-wake.md)
+- [incoming-events-coalescing-and-wake.md](${CLAUDE_SKILL_DIR}/references/incoming-events-coalescing-and-wake.md)
   -- how a server-pushed notification reaches a hook
   (`mcp_resource_updated`), how to namespace distinct signals on the URI
   without new event kinds, how to coalesce a flapping/bursty source with
   the Composer, and how to choose wake=true (interrupt now) vs wake=false
   (ride-along). Read this when you are wiring the *inbound* side of a
   reactive plugin.
-- [returning-results-and-elicitation.md](references/returning-results-and-elicitation.md)
+- [returning-results-and-elicitation.md](${CLAUDE_SKILL_DIR}/references/returning-results-and-elicitation.md)
   -- how to send a conclusion back out via `pipeline_launch` + a `shell`
   step (no callback convention needed), and how to ask the human a
   question via MCP elicitation (vs. sampling). Read this when your design
   needs a write-back leg or a human-in-the-loop question.
-- [scope-plugin-surface-and-vocabulary.md](references/scope-plugin-surface-and-vocabulary.md)
+- [scope-plugin-surface-and-vocabulary.md](${CLAUDE_SKILL_DIR}/references/scope-plugin-surface-and-vocabulary.md)
   -- hook config scope (workspace vs per-agent, and why a workspace-level
   hook fires in every session), what a plugin manifest may actually ship,
   the AG-UI vs A2UI vocabulary split, three constraints that repeatedly

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/references/incoming-events-coalescing-and-wake.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/references/incoming-events-coalescing-and-wake.md
@@ -1,0 +1,42 @@
+## The push path
+
+A server-pushed `notifications/resources/updated` surfaces as the
+`mcp_resource_updated` hook point. Bridge: `src/reyn/mcp/message_handler.py`.
+Subscribe call: `src/reyn/mcp/client.py`.
+
+The notification carries the **URI, not the resource body** -- the reacting
+side re-reads.
+
+**The URI is your signal namespace.** `matcher` glob-matches `uri` (see the
+glob-field set in `src/reyn/hooks/matcher.py`), so ONE hook point carries
+unlimited distinct signals: `orch://job/<id>/done`, `orch://job/<id>/failed`,
+`app://status`. Carry correlation ids in the URI. Do not ask for a new event
+kind per signal.
+
+## Coalescing bursts
+
+A flapping job, or a file saved five times while someone edits, is the
+**Composer's** job -- not your server's, and not a sleep in a hook.
+`window` / `debounce` live in `src/reyn/hooks/composer.py`, are declared as
+`composers:` and consumed as `composed:<name>`.
+
+Trailing debounce = **"react to the settled state"**, which is almost always
+what you want after a burst of edits. Check that module's docstring for the
+crash-durability guarantee before depending on a pending buffer surviving.
+
+## Wake vs ride-along
+
+The action seams are listed at the top of `src/reyn/hooks/dispatcher.py`.
+Two of them decide whether the agent is interrupted:
+
+- **wake=true** (inbox push) -- starts a turn NOW. Loop-valved; find the knob
+  under `safety.loop` in the chat config and confirm the current default.
+- **wake=false** (next-turn ride-along) -- benign, costs nothing, but **if no
+  next turn ever comes it is never consumed**.
+
+Choose by asking *"is a human already in this loop?"* If yes, ride-along:
+the context is already staged when they next speak, so the first reply is
+fully informed and no turn is spent on noise. If nobody is watching, wake --
+and expect the valve to bound a runaway edit->break->fix->break cycle.
+
+**Do not make ride-along the only path for something that must be acted on.**

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/references/returning-results-and-elicitation.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/references/returning-results-and-elicitation.md
@@ -1,0 +1,17 @@
+## Returning a conclusion to the outside
+
+You do **not** need a callback convention. `pipeline_launch` renders
+`input_template` against the event's template vars -- so a correlation id
+carried in the URI reaches the pipeline -- runs async, and the result comes
+back on this session's own inbox. A `shell` step is the write-back leg to the
+external system. A worked `pipeline_launch` example lives in the Hooks
+section of the `reyn_cheat_sheet` skill.
+
+## Asking the human
+
+MCP **elicitation** is installed per connection with a timeout and a
+listener check (`src/reyn/mcp/connection_service.py`). Use it instead of
+inventing a question channel.
+
+**Sampling is a different primitive** (server asks the client for a model
+completion). Check whether it is wired at all before designing around it.

--- a/src/reyn/builtin/skills/reactive_orchestration_plugins/references/scope-plugin-surface-and-vocabulary.md
+++ b/src/reyn/builtin/skills/reactive_orchestration_plugins/references/scope-plugin-surface-and-vocabulary.md
@@ -1,0 +1,59 @@
+## Scope -- a workspace-level hook fires in EVERY session
+
+Config layers: the workspace `hooks:` config, and per-agent under
+`.reyn/agents/<name>/hooks.yaml` (`load_per_agent_hooks` in
+`src/reyn/config/loader.py`). The bus and registry are per-session
+(`src/reyn/hooks/bus.py`).
+
+If your reaction is only meaningful while a particular server is attached,
+say so in the design -- otherwise unrelated sessions react to your events.
+
+## What a plugin may ship
+
+The capability union is `src/reyn/plugins/manifest.py`; what install actually
+registers is `src/reyn/core/op_runtime/plugin_install.py`. **Read both before
+assuming your plugin can ship a given part** -- the set is smaller than the
+set of things reyn supports.
+
+## Vocabulary -- two different UI protocols
+
+Never write bare "UI protocol"; they are not interchangeable.
+
+- **AG-UI** -- the agent<->UI **wire transport** (event stream + turn
+  submit). This is what a browser or a thin client speaks to reyn:
+  `src/reyn/interfaces/transport/agui/`.
+- **A2UI** -- an agent-generated-UI **component spec**. reyn's present layer
+  is *structurally isomorphic* to it, which is **not** the same as speaking
+  it on the wire. See `docs/deep-dives/proposals/0054-present-layer.md`.
+
+## Three constraints that surprise people
+
+**Progress is not a hook.** `notifications/progress` is deliberately NOT
+bridged to a hook point — the SDK already dual-delivers it to the per-call
+`progress_callback` of the call *reyn itself made*. Your server's own
+background-job progress has no such call to ride. Publish progress as a
+**resource** instead (`orch://job/<id>/progress`) and let the ordinary
+subscribe→`mcp_resource_updated` path carry it.
+
+**A webhook's body never reaches your matcher.** `webhook_received` delivers
+routing metadata ONLY (`transport`, `sender`) — the raw request body is never
+put in template_vars, so tokens/PII cannot leak there
+(`src/reyn/hooks/ingress.py`, the adapter's SECURITY invariant). You can match
+"something arrived from X", not "the amount was 500". Content-driven flows
+must fetch the content themselves at the gateway-plugin layer.
+
+**Nothing detects absence.** Every Composer op (`all`/`any`/`seq`/`window`/
+`debounce`/`correlate_by`/`count`) composes events that *happened*. There is
+no "fire if Y did NOT arrive within T" — so deadman monitoring, heartbeat-gone
+alerts, and approval-timeout escalation are not expressible today. Do not
+mistake an inbox `escalate_after` for this: that watches an unconsumed inbox
+entry, not a missing external event.
+
+## Size ceiling for skills
+
+A skill body is read through the ordinary read op, whose inline cap is
+**derived from the model window** (`_read_inline_cap` in
+`src/reyn/core/op_runtime/file.py`). With no model resolved the cap is small.
+A body over the cap comes back `status: "truncated"` -- the reader silently
+gets a partial skill. Keep a skill body well under it, and prefer a new
+sibling skill over growing an existing one past its ceiling.

--- a/tests/test_reactive_orchestration_plugins_references_reachable_3162.py
+++ b/tests/test_reactive_orchestration_plugins_references_reachable_3162.py
@@ -1,0 +1,124 @@
+"""Tier 2: OS invariant -- #3162's L2-router-plus-L3-references split for
+`reactive_orchestration_plugins` (2nd consumer, after `reyn_cheat_sheet`
+#3171) uses the OFFICIAL Agent Skills convention: relative markdown links in
+the SKILL.md BODY, not a front-matter `references:` declaration (owner
+ruling: https://code.claude.com/docs/en/skills.md documents body links as
+the standard; front-matter `references:` is not part of it).
+
+That convention only pays off if the reachability chain actually closes for
+a model: (1) `skill_list` hands the model this skill's absolute SKILL.md
+`path`, (2) the model reads the body and finds a *relative* link such as
+`references/incoming-events-coalescing-and-wake.md`, (3) the model resolves
+that relative link against the directory of (1) and issues an ordinary
+`file` read op against the resulting absolute path. This test exercises
+exactly that chain against the REAL `reyn.core.op_runtime.file.handle` read
+op (the same one #2913's wheel-reachability test used for SKILL.md itself),
+not just `read_builtin_body_bytes` in isolation -- proving the reference is
+not merely *present on disk* but *readable through the op a model would
+actually call*.
+
+No mocks: real `BUILTIN_SKILLS` registry entry, real file bytes, real
+`PermissionResolver` + `OpContext` + `handle()` dispatch (the same harness
+`test_2913_builtin_body_wheel_reachable.py` established).
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+from reyn.builtin.registry import BUILTIN_SKILLS
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.file import handle
+from reyn.data.workspace.workspace import Workspace
+from reyn.schemas.models import FileIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+_SKILL_PATH = Path(BUILTIN_SKILLS["reactive_orchestration_plugins"]["path"])
+_SKILL_DIR = _SKILL_PATH.parent
+_REFERENCES_DIR = _SKILL_DIR / "references"
+
+# Matches the same relative-markdown-link shape the router body uses, e.g.
+# "[incoming-events-coalescing-and-wake.md](references/incoming-events-coalescing-and-wake.md)".
+_RELATIVE_LINK_RE = re.compile(r"\]\((references/[^)\s]+\.md)\)")
+
+
+def _linked_relative_paths() -> "list[str]":
+    body = _SKILL_PATH.read_text(encoding="utf-8")
+    return _RELATIVE_LINK_RE.findall(body)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_ctx() -> OpContext:
+    events = EventLog()
+    ws = Workspace(events=events)
+    resolver = PermissionResolver(
+        config_permissions={},
+        # A project root elsewhere -- the same #2913 wheel-layout condition,
+        # so this test also proves the builtin-body bypass generalizes to a
+        # sibling reference file, not just SKILL.md itself.
+        project_root=Path("/does/not/contain/the/builtin/package"),
+        interactive=False,
+    )
+    return OpContext(
+        workspace=ws,
+        events=events,
+        permission_decl=PermissionDecl(),
+        permission_resolver=resolver,
+        actor="test_skill",
+    )
+
+
+def test_skill_body_declares_at_least_one_relative_reference_link() -> None:
+    """Tier 2: vacuity guard -- the body actually contains the links this
+    test exercises, so a stripped/renamed link is caught here rather than
+    making every test below pass trivially over an empty list."""
+    links = _linked_relative_paths()
+    assert links, "expected relative markdown links into references/ in the SKILL.md body"
+
+
+def test_every_linked_reference_resolves_on_disk_next_to_skill_md() -> None:
+    """Tier 2: OS invariant, property (1) -- each relative link in the body
+    resolves, against the SKILL.md's own directory, to a real file under
+    references/."""
+    for rel in _linked_relative_paths():
+        resolved = (_SKILL_DIR / rel).resolve()
+        assert resolved.is_file(), f"linked reference does not exist on disk: {resolved}"
+        assert resolved.parent == _REFERENCES_DIR.resolve()
+
+
+def test_references_dir_has_no_orphans_beyond_the_linked_set() -> None:
+    """Tier 2: OS invariant -- bidirectional parity: every file physically
+    under references/ is reachable from a body link (unlinked = unreachable
+    dead weight)."""
+    linked_names = {Path(rel).name for rel in _linked_relative_paths()}
+    on_disk_names = {p.name for p in _REFERENCES_DIR.glob("*.md")}
+    assert on_disk_names == linked_names, (
+        f"references/ set {on_disk_names} != linked set {linked_names}"
+    )
+
+
+def test_every_linked_reference_is_readable_through_the_real_file_read_op() -> None:
+    """Tier 2: OS invariant, property (3), the reachability chain -- resolve
+    each body link against the SKILL.md path the model gets from
+    `skill_list`, then issue the SAME real `file` read op a model would
+    call, with a PermissionResolver whose project_root does not contain the
+    package (the wheel-install condition). Asserts actual byte-for-byte
+    content, not merely a non-None/no-raise."""
+    ctx = _make_ctx()
+    for rel in _linked_relative_paths():
+        resolved = (_SKILL_DIR / rel).resolve()
+        expected_bytes = resolved.read_bytes()
+
+        op = FileIROp(kind="file", op="read", path=str(resolved))
+        result = _run(handle(op, ctx))
+
+        assert result.get("status") == "ok", result
+        content = result["content"]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        assert content == expected_bytes, f"content mismatch for {resolved}"

--- a/tests/test_reactive_orchestration_plugins_references_reachable_3162.py
+++ b/tests/test_reactive_orchestration_plugins_references_reachable_3162.py
@@ -1,21 +1,32 @@
 """Tier 2: OS invariant -- #3162's L2-router-plus-L3-references split for
 `reactive_orchestration_plugins` (2nd consumer, after `reyn_cheat_sheet`
-#3171) uses the OFFICIAL Agent Skills convention: relative markdown links in
-the SKILL.md BODY, not a front-matter `references:` declaration (owner
-ruling: https://code.claude.com/docs/en/skills.md documents body links as
-the standard; front-matter `references:` is not part of it).
+#3171) uses the OFFICIAL Agent Skills convention: a `${CLAUDE_SKILL_DIR}`-
+prefixed relative markdown link in the SKILL.md BODY, not a front-matter
+`references:` declaration (owner ruling, ground-truthed against both
+https://code.claude.com/docs/en/skills.md and reyn's own token-expansion
+code: `${CLAUDE_SKILL_DIR}` is the documented standard for making a
+same-skill link resolve regardless of install location; a bare
+`references/foo.md` relative path is NOT expanded by anything and the
+`file` read op resolves a non-absolute path against the WORKSPACE, not the
+skill's own directory (`reyn/core/op_runtime/file.py`'s `_resolve_for_gate`
+/ `is_absolute()` branch) -- so a bare relative link would silently never
+reach the skill's own `references/` directory).
 
-That convention only pays off if the reachability chain actually closes for
-a model: (1) `skill_list` hands the model this skill's absolute SKILL.md
-`path`, (2) the model reads the body and finds a *relative* link such as
-`references/incoming-events-coalescing-and-wake.md`, (3) the model resolves
-that relative link against the directory of (1) and issues an ordinary
-`file` read op against the resulting absolute path. This test exercises
-exactly that chain against the REAL `reyn.core.op_runtime.file.handle` read
-op (the same one #2913's wheel-reachability test used for SKILL.md itself),
-not just `read_builtin_body_bytes` in isolation -- proving the reference is
-not merely *present on disk* but *readable through the op a model would
-actually call*.
+That convention only pays off if the FULL chain actually closes for a
+model: (1) `skill_list` hands the model this skill's absolute SKILL.md
+`path`; (2) reading SKILL.md through the real `file` read op runs it
+through `reyn.plugins.skill_load.load_skill_body`
+(`is_skill_body_path` routes any read whose basename is `SKILL.md`,
+`alias_claude=True` unconditionally so the `${CLAUDE_*}` alias table in
+`reyn.plugins.tokens.CLAUDE_ALIAS_MAP` applies), which expands
+`${CLAUDE_SKILL_DIR}` to this skill's own absolute directory; (3) the model
+resolves the now-absolute link and issues an ordinary `file` read op
+against it. This test exercises that FULL chain against the REAL
+`reyn.core.op_runtime.file.handle` op for BOTH reads (SKILL.md's own body,
+then each reference) -- not `read_builtin_body_bytes` in isolation and not
+a hand-rolled token substitution -- proving the token actually expands at
+the same seam a model's read would go through, and that the resulting
+absolute path is readable.
 
 No mocks: real `BUILTIN_SKILLS` registry entry, real file bytes, real
 `PermissionResolver` + `OpContext` + `handle()` dispatch (the same harness
@@ -39,14 +50,15 @@ _SKILL_PATH = Path(BUILTIN_SKILLS["reactive_orchestration_plugins"]["path"])
 _SKILL_DIR = _SKILL_PATH.parent
 _REFERENCES_DIR = _SKILL_DIR / "references"
 
-# Matches the same relative-markdown-link shape the router body uses, e.g.
-# "[incoming-events-coalescing-and-wake.md](references/incoming-events-coalescing-and-wake.md)".
-_RELATIVE_LINK_RE = re.compile(r"\]\((references/[^)\s]+\.md)\)")
-
-
-def _linked_relative_paths() -> "list[str]":
-    body = _SKILL_PATH.read_text(encoding="utf-8")
-    return _RELATIVE_LINK_RE.findall(body)
+# Matches the router body's `${CLAUDE_SKILL_DIR}`-prefixed reference link
+# shape, e.g.
+# "[incoming-events-coalescing-and-wake.md](${CLAUDE_SKILL_DIR}/references/incoming-events-coalescing-and-wake.md)".
+_TOKEN_LINK_RE = re.compile(
+    r"\]\(\$\{CLAUDE_SKILL_DIR\}/(references/[^)\s]+\.md)\)"
+)
+# Same shape, but against the EXPANDED body (token already replaced by an
+# absolute path) -- captures the absolute path directly.
+_EXPANDED_LINK_RE = re.compile(r"\]\((/[^)\s]+\.md)\)")
 
 
 def _run(coro):
@@ -73,29 +85,76 @@ def _make_ctx() -> OpContext:
     )
 
 
-def test_skill_body_declares_at_least_one_relative_reference_link() -> None:
-    """Tier 2: vacuity guard -- the body actually contains the links this
-    test exercises, so a stripped/renamed link is caught here rather than
-    making every test below pass trivially over an empty list."""
-    links = _linked_relative_paths()
-    assert links, "expected relative markdown links into references/ in the SKILL.md body"
+def _read_skill_md_via_real_op(ctx: OpContext) -> str:
+    """Reads SKILL.md through the REAL `file` read op -- the same op a
+    model's read would go through, including the skill-load token-expansion
+    pass (`is_skill_body_path` routes on basename == "SKILL.md")."""
+    op = FileIROp(kind="file", op="read", path=str(_SKILL_PATH))
+    result = _run(handle(op, ctx))
+    assert result.get("status") == "ok", result
+    return result["content"]
 
 
-def test_every_linked_reference_resolves_on_disk_next_to_skill_md() -> None:
-    """Tier 2: OS invariant, property (1) -- each relative link in the body
-    resolves, against the SKILL.md's own directory, to a real file under
-    references/."""
-    for rel in _linked_relative_paths():
-        resolved = (_SKILL_DIR / rel).resolve()
-        assert resolved.is_file(), f"linked reference does not exist on disk: {resolved}"
+def test_raw_disk_body_uses_the_claude_skill_dir_token_not_a_bare_relative_path() -> None:
+    """Tier 2: vacuity guard -- the UNEXPANDED body on disk actually contains
+    `${CLAUDE_SKILL_DIR}`-prefixed links (not bare `references/...` links,
+    which the file read op would resolve against the workspace, never
+    reaching this skill's own directory)."""
+    raw_body = _SKILL_PATH.read_text(encoding="utf-8")
+    token_links = _TOKEN_LINK_RE.findall(raw_body)
+    assert token_links, (
+        "expected ${CLAUDE_SKILL_DIR}-prefixed reference links in the raw "
+        "SKILL.md body on disk"
+    )
+    bare_relative = re.findall(r"\]\((references/[^)\s]+\.md)\)", raw_body)
+    assert not bare_relative, (
+        f"found bare relative reference link(s), never expanded by anything "
+        f"and not resolvable against the skill's own directory: {bare_relative}"
+    )
+
+
+def test_reading_skill_md_through_the_real_op_expands_the_token_to_an_absolute_path() -> None:
+    """Tier 2: OS invariant -- reading SKILL.md through the REAL `file` read
+    op (the seam `reyn.plugins.skill_load.load_skill_body` hooks) expands
+    `${CLAUDE_SKILL_DIR}` to this skill's own absolute directory. Falsify
+    surface: if the expansion seam were not wired for this file, the raw
+    `${CLAUDE_SKILL_DIR}` token would still be present in the op's result
+    and this assertion would fail."""
+    ctx = _make_ctx()
+    expanded_body = _read_skill_md_via_real_op(ctx)
+
+    assert "${CLAUDE_SKILL_DIR}" not in expanded_body, (
+        "the read op did not expand ${CLAUDE_SKILL_DIR} -- skill-load "
+        "token expansion did not run for this file"
+    )
+
+    expanded_links = _EXPANDED_LINK_RE.findall(expanded_body)
+    assert expanded_links, "expected absolute reference links after expansion"
+    for link in expanded_links:
+        assert link.startswith(str(_SKILL_DIR)), (
+            f"expanded link {link!r} does not start with this skill's own "
+            f"directory {_SKILL_DIR} -- ${{CLAUDE_SKILL_DIR}} resolved wrong"
+        )
+
+
+def test_every_expanded_link_resolves_on_disk_under_references() -> None:
+    """Tier 2: OS invariant, property (1) -- each ${CLAUDE_SKILL_DIR}-expanded
+    link, once the real read op has expanded it, resolves to a real file
+    under this skill's references/ directory."""
+    ctx = _make_ctx()
+    expanded_body = _read_skill_md_via_real_op(ctx)
+    for link in _EXPANDED_LINK_RE.findall(expanded_body):
+        resolved = Path(link).resolve()
+        assert resolved.is_file(), f"expanded reference link does not exist on disk: {resolved}"
         assert resolved.parent == _REFERENCES_DIR.resolve()
 
 
 def test_references_dir_has_no_orphans_beyond_the_linked_set() -> None:
     """Tier 2: OS invariant -- bidirectional parity: every file physically
-    under references/ is reachable from a body link (unlinked = unreachable
-    dead weight)."""
-    linked_names = {Path(rel).name for rel in _linked_relative_paths()}
+    under references/ is reachable from a (token-prefixed) body link
+    (unlinked = unreachable dead weight)."""
+    raw_body = _SKILL_PATH.read_text(encoding="utf-8")
+    linked_names = {Path(rel).name for rel in _TOKEN_LINK_RE.findall(raw_body)}
     on_disk_names = {p.name for p in _REFERENCES_DIR.glob("*.md")}
     assert on_disk_names == linked_names, (
         f"references/ set {on_disk_names} != linked set {linked_names}"
@@ -103,15 +162,19 @@ def test_references_dir_has_no_orphans_beyond_the_linked_set() -> None:
 
 
 def test_every_linked_reference_is_readable_through_the_real_file_read_op() -> None:
-    """Tier 2: OS invariant, property (3), the reachability chain -- resolve
-    each body link against the SKILL.md path the model gets from
-    `skill_list`, then issue the SAME real `file` read op a model would
-    call, with a PermissionResolver whose project_root does not contain the
-    package (the wheel-install condition). Asserts actual byte-for-byte
-    content, not merely a non-None/no-raise."""
+    """Tier 2: OS invariant, property (3), the FULL reachability chain --
+    read SKILL.md through the real op to get the expanded absolute links,
+    then issue the SAME real `file` read op a model would call against each
+    resulting path, with a PermissionResolver whose project_root does not
+    contain the package (the wheel-install condition). Asserts actual
+    byte-for-byte content, not merely a non-None/no-raise."""
     ctx = _make_ctx()
-    for rel in _linked_relative_paths():
-        resolved = (_SKILL_DIR / rel).resolve()
+    expanded_body = _read_skill_md_via_real_op(ctx)
+    links = _EXPANDED_LINK_RE.findall(expanded_body)
+    assert links, "expected at least one expanded reference link to exercise"
+
+    for link in links:
+        resolved = Path(link).resolve()
         expected_bytes = resolved.read_bytes()
 
         op = FileIROp(kind="file", op="read", path=str(resolved))
@@ -122,3 +185,16 @@ def test_every_linked_reference_is_readable_through_the_real_file_read_op() -> N
         if isinstance(content, str):
             content = content.encode("utf-8")
         assert content == expected_bytes, f"content mismatch for {resolved}"
+
+
+def test_reference_files_do_not_themselves_contain_unexpanded_tokens() -> None:
+    """Tier 2: OS invariant -- token expansion is documented (and wired,
+    `is_skill_body_path`) to run ONLY for the basename `SKILL.md`; a
+    reference file under references/ must not rely on it, since it would be
+    handed to the model unexpanded (owner ruling)."""
+    for ref_path in _REFERENCES_DIR.glob("*.md"):
+        text = ref_path.read_text(encoding="utf-8")
+        assert "${CLAUDE_SKILL_DIR}" not in text, (
+            f"{ref_path} contains an unexpanded ${{CLAUDE_SKILL_DIR}} token -- "
+            "only SKILL.md itself is expanded"
+        )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3162

Splits `reactive_orchestration_plugins/SKILL.md` (7,506B, 91.5% of the 8,192B cap) into an L2 router + L3 `references/*.md`, using the OFFICIAL Agent Skills convention confirmed by ground-truthing skills.md docs + reyn's `plugins/tokens.py` / `plugins/skill_load.py`: `${CLAUDE_SKILL_DIR}`-prefixed relative markdown links in the body (no front-matter `references:` — not part of the standard).

**Router** (3,496B): front-matter, intro, Reuse map (kept — this skill's decision table), "Additional resources" pointers.
**References**: `incoming-events-coalescing-and-wake.md` (1,939B — push path/coalescing/wake), `returning-results-and-elicitation.md` (794B — pipeline_launch/elicitation), `scope-plugin-surface-and-vocabulary.md` (2,985B — scope/plugin manifest/AG-UI-A2UI/3 constraints/size ceiling). All verbatim, all well under cap.

Added a witness test (`test_reactive_orchestration_plugins_references_reachable_3162.py`) exercising the real `file` read op end to end: SKILL.md read → `${CLAUDE_SKILL_DIR}` actually expands to the skill's own absolute dir → each expanded link is byte-for-byte readable via the same real op.

**Known pre-existing conflict**: `tests/test_skill_references_gate_3162.py` (#3170) still fails against this skill — its orphan-detection scans `references/` unconditionally, independent of front-matter `references:` presence, so it flags these files as orphans now that no front-matter list exists. Left untouched per explicit instruction; its rework to the body-link convention is being handled separately.

Consumer check: repo-wide grep for `reactive_orchestration_plugins` found no test asserting on this skill's body content (unlike `reyn_cheat_sheet`'s `_cheat_sheet_body()`), so no consumer fix was needed.

## Test plan
- [x] `ruff check src tests` — green
- [x] `pytest` (foreground, full suite) — 9310 passed, 33 skipped, 1 known pre-existing failure (see above)
- [x] `python scripts/test_tier_audit.py --strict tests/test_reactive_orchestration_plugins_references_reachable_3162.py` — green
- [x] `python scripts/verify_module_docstrings.py` on changed SKILL.md — green