### PR TITLE
fix(3162): standard ${CLAUDE_SKILL_DIR} link references, drop non-standard front-matter (part 4)

### DIFF
--- a/docs/concepts/tools-integrations/skills.md
+++ b/docs/concepts/tools-integrations/skills.md
@@ -214,7 +214,7 @@ Use `pypdf` for form-field operations...
 
 There is no dedicated "run this skill" primitive at any layer — a skill is discovered via L1, loaded via L2, and its assets are just files. The model decides relevance from the L1 description; the OS does not gate *which* skill the model may read, only *which paths* it may read (the standard permission model — reading inside the project root is a default; outside requires the usual declaration + approval).
 
-## Splitting a large skill: front-matter `references:` (#3162)
+## Splitting a large skill: `${CLAUDE_SKILL_DIR}` references (#3162)
 
 `SKILL.md`'s body is read via the ordinary `file__read` op, so it is subject
 to that op's inline-read cap — the model-unresolved default floor is
@@ -225,41 +225,55 @@ worst kind of failure, because the same file behaves differently depending
 on an orthogonal runtime variable. When a skill genuinely cannot shrink
 below the floor without losing its value as a single-topic index (splitting
 it by sub-topic would destroy the thing that makes it useful — see #3162),
-it can split into an **L2 router + L3 references** instead:
+it can split into an **L2 router + L3 bundled references** instead, using
+the standard Agent Skills mechanism for referencing a bundled file: a
+Markdown link in the `SKILL.md` body whose target is
+`${CLAUDE_SKILL_DIR}/references/<file>.md` (`CLAUDE_SKILL_DIR` is reyn's
+alias for `REYN_SKILL_DIR`, `src/reyn/plugins/tokens.py`):
 
 ```markdown
 ---
 name: reyn_cheat_sheet
 description: ...
-references:
-  - hooks-and-events.md
-  - pipelines-and-present.md
 ---
+
+Deeper detail on hooks and MCP:
+[hooks-and-events.md](${CLAUDE_SKILL_DIR}/references/hooks-and-events.md)
 ```
 
-- `references:` is an **optional** front-matter key — a skill that omits it
-  stays today's single-`SKILL.md` shape, ungated by the mechanism below.
-- Each entry is a bare filename resolved against a `references/`
-  subdirectory sibling to `SKILL.md` (`skills/<name>/references/<file>.md`).
+- A bare relative path (e.g. `references/foo.md`) does **not** work here —
+  reyn's `file__read` op resolves a non-absolute path against the
+  **workspace root**, not the skill's own directory
+  (`src/reyn/core/op_runtime/file.py`), so it would silently miss the
+  skill's own `references/` folder. `${CLAUDE_SKILL_DIR}` is an
+  invocation-time token expanded only in `SKILL.md` itself (never in a
+  bundled file — `src/reyn/plugins/skill_load.py`), so the expanded link
+  resolves to an absolute path regardless of the workspace the skill is
+  read from.
 - The router (`SKILL.md` itself) should stay small enough to let the model
   decide *whether* it needs to go deeper, and *which* reference to read,
   without having read the references yet — name each reference file for the
-  question it answers.
+  question it answers, and keep the one-line "when to read this" note next
+  to each link.
 - Each reference is read the same way as `SKILL.md` (ordinary `file__read`),
   so it is subject to the **same** default inline cap.
 
-References are declared in YAML front-matter rather than linked from
-Markdown prose specifically so the checks below stay structural (a prose
-Markdown-link parser breaks silently on notation drift): every declared
-reference must exist under `references/`, every file under `references/`
-must be declared (bidirectional — no orphans), every declared reference
-must be reachable through the same wheel-safe body-read routing as
-`SKILL.md`, and every reference must itself be strictly under the default
-inline cap. All four are enforced by
-`tests/test_skill_references_gate_3162.py` for every shipped skill
-(builtin registry + plugin skills-on-disk), the same registry-plus-disk-walk
+`tests/test_skill_references_gate_3162.py` gates, for every shipped skill
+(builtin registry + plugin skills-on-disk, the same registry-plus-disk-walk
 enumeration `test_skill_md_default_inline_cap_gate.py` and
-`test_builtin_registry_disk_parity.py` use.
+`test_builtin_registry_disk_parity.py` use): every `${CLAUDE_SKILL_DIR}`- or
+`${REYN_SKILL_DIR}`-prefixed link in a `SKILL.md` body resolves to a real
+file under the skill's directory; the `references/` directory's file set
+and the set of such links pointing into it match exactly in both directions
+(no orphan file, no dangling link); every `.md` file under a skill's
+directory is strictly under the default inline cap; and no file under a
+skill's `references/` directory itself contains a `${CLAUDE_SKILL_DIR}`-/
+`${REYN_SKILL_DIR}`-prefixed Markdown link pointing at another file. That
+last check enforces a one-level-deep invariant: L1 (menu) -> L2 (router,
+`SKILL.md`) -> L3 (reference) is the whole chain, and an L3 file is always a
+leaf — a link from inside a reference to yet another file would be
+unreachable anyway (only `SKILL.md` gets token expansion), so an
+L3-to-L3 link is always a bug, not a valid deeper level.
 
 ## Hot-reload
 

--- a/src/reyn/builtin/skills/reyn_cheat_sheet/SKILL.md
+++ b/src/reyn/builtin/skills/reyn_cheat_sheet/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: reyn_cheat_sheet
 description: Reyn-specific usage cheat sheet -- which mechanism to reach for (skill/pipeline/mcp/hook/present), composition idioms, op essentials, and pointers to the full specs. Read this before authoring a new part or composing several.
-references:
-  - input-hooks-and-mcp.md
-  - workflow-pipelines-and-skills.md
-  - output-present-and-self-review.md
 ---
 
 # Reyn cheat sheet
@@ -25,22 +21,24 @@ need it.
 - Need **input** (new data, or a reactive trigger) -> `hook` | `mcp` |
   `retrieval` (`semantic_search`). Deeper detail (hook action schemes, a
   CI-verified worked hook example, MCP tool discovery):
-  `references/input-hooks-and-mcp.md` -- read when wiring a reactive
-  trigger or calling an external tool/resource.
+  [input-hooks-and-mcp.md](${CLAUDE_SKILL_DIR}/references/input-hooks-and-mcp.md)
+  -- read when wiring a reactive trigger or calling an external tool/resource.
 - Need **workflow** (multi-step orchestration) -> `skill` | `pipeline` | an
   `mcp` tool call mid-flow. Deeper detail (pipeline step grammar, the
   flagship CI-verified worked pipeline, `SKILL.md` authoring shape):
-  `references/workflow-pipelines-and-skills.md` -- read when writing
-  pipeline DSL steps or authoring a new skill.
+  [workflow-pipelines-and-skills.md](${CLAUDE_SKILL_DIR}/references/workflow-pipelines-and-skills.md)
+  -- read when writing pipeline DSL steps or authoring a new skill.
 - Need **output** (show a result, or write externally) -> `present` |
   `render_template` | an `mcp` write. Deeper detail (`present`'s blueprint
   catalog and the input/output caveat, the self-review gate before
-  promotion): `references/output-present-and-self-review.md` -- read when
-  deciding whether/how to show a result via `present`, or self-reviewing an
-  authored asset before it becomes a reused part.
+  promotion):
+  [output-present-and-self-review.md](${CLAUDE_SKILL_DIR}/references/output-present-and-self-review.md)
+  -- read when deciding whether/how to show a result via `present`, or
+  self-reviewing an authored asset before it becomes a reused part.
 
 Reuse before authoring: check the existing catalog (`list_actions`) for a
 part that already covers the need. Author only when nothing fits, and
 self-review anything you author or promote (an `agent` step + `schema`, see
-`references/output-present-and-self-review.md`) before it becomes a reused
-asset -- an ungated authored part is a liability, not a shortcut.
+[output-present-and-self-review.md](${CLAUDE_SKILL_DIR}/references/output-present-and-self-review.md))
+before it becomes a reused asset -- an ungated authored part is a liability,
+not a shortcut.

--- a/tests/test_skill_references_gate_3162.py
+++ b/tests/test_skill_references_gate_3162.py
@@ -1,84 +1,96 @@
-"""Tier 2: OS invariant -- front-matter-declared `references:` for a
-multi-file skill (#3162 part 3).
+"""Tier 2: OS invariant -- standard `${CLAUDE_SKILL_DIR}`/`${REYN_SKILL_DIR}`
+Markdown-link references from a `SKILL.md` body to a bundled `references/`
+file (#3162 part 4, rebuild).
 
-**Motivation.** #3162 part 1 (#3169) fixed the immediate cap overflow. Part 2
-(a future PR) will let a skill split its body into an L2 router (`SKILL.md`)
-+ L3 `references/*.md`, so a skill that is a genuine single-topic index
-(`reyn_cheat_sheet`) can keep growing without either truncating or losing
-its index-ness by being split by topic. THIS gate is the guard that must
-exist BEFORE any consumer declares `references:` (architect co-vet on
-#3162: "逆順にすると、ゲートが無い期間に参照切れを作り込む余地が生まれる").
+**Why this replaced the front-matter `references:` gate.** #3170 introduced
+a NON-standard front-matter `references:` front-matter key as the mechanism
+for declaring a skill's bundled files. The official Anthropic Agent Skills
+spec has no such field -- the standard way to reference a bundled file from
+`SKILL.md` is a plain Markdown link in the body
+(https://code.claude.com/docs/en/skills.md). This module removes the
+front-matter convention entirely and gates the standard mechanism instead:
+a Markdown link whose URL is `${CLAUDE_SKILL_DIR}/<path>` (or reyn's
+underlying `${REYN_SKILL_DIR}` -- `src/reyn/plugins/tokens.py` aliases the
+former to the latter). A bare relative path written in prose (e.g.
+``references/foo.md``) is NOT reachable at read time: reyn's `file` read op
+resolves a non-absolute path against the WORKSPACE root, not the skill's own
+directory (`src/reyn/core/op_runtime/file.py`) -- only the token-prefixed
+absolute-path form resolves correctly, and only `SKILL.md` itself gets
+token expansion (`src/reyn/plugins/skill_load.py`, matched on basename).
 
-**Why front-matter, not prose links.** Parsing Markdown prose for reference
-links is a semantic operation (notation drift breaks it silently — the same
-"ゲート化できない" class as #3164's stale-Status check). Declaring
-references in YAML front-matter keeps this a structural check: the
-`references:` list is machine-read the same way `description` already is
-(`tests/test_builtin_registry_disk_parity.py`).
+**Four properties, each gated separately** (a RED result names which one
+broke -- strip-falsify verified per-property, see PR body):
 
-**Convention gated here** (also documented in
-`docs/concepts/tools-integrations/skills.md`):
+1. **Link resolution** -- every `${CLAUDE_SKILL_DIR}`/`${REYN_SKILL_DIR}`-
+   prefixed Markdown link in a `SKILL.md` body points at a file that exists
+   under that skill's own directory.
+2. **Bidirectional orphan parity** -- for a skill with a `references/`
+   subdirectory, the file set actually present under `references/` and the
+   set of property-1 link targets pointing into `references/` match exactly
+   in both directions (no file on disk undeclared by any link, no link
+   dangling at a missing file).
+3. **Size cap** -- every `.md` file anywhere under a skill's directory
+   (including `SKILL.md` itself) stays strictly under
+   `MAX_CONTROL_IR_RESULT_INLINE_BYTES` -- the same model-unresolved
+   inline-read floor `test_skill_md_default_inline_cap_gate.py` gates for
+   `SKILL.md` alone, generalized to every shipped `.md` body.
+4. **L3-is-a-leaf** -- a file under a skill's `references/` directory must
+   NOT itself contain a token-prefixed Markdown link to another file. Only
+   `SKILL.md` gets invocation-time token expansion (point 2 above), so a
+   link like this sitting inside a reference file would never resolve for
+   the model reading it -- it is always a bug, not a valid second level of
+   the progressive-disclosure chain (L1 menu -> L2 router `SKILL.md` -> L3
+   reference, one level deep by design). NOTE: a bare `${...}` token used
+   in prose or a command example inside a reference file is NOT itself a
+   violation -- only a `](${TOKEN}/...)` -shaped Markdown link is in scope
+   (a peer-session correction folded into this rebuild after the token-ban
+   framing of an earlier draft proved too broad: `tokens.py`'s own docs
+   treat an unexpanded token as an ordinary, expected outcome, and banning
+   all token mentions would leave a reference file no way to legitimately
+   talk about `${CLAUDE_SKILL_DIR}` at all).
 
-- `references:` is an OPTIONAL front-matter key -- a skill that doesn't
-  declare it stays today's single-`SKILL.md` shape, ungated by this module.
-- Every declared entry is a bare filename (e.g. ``hooks-and-events.md``)
-  resolved against a ``references/`` subdirectory sibling to ``SKILL.md``.
+**Enumeration -- real directory walk + registry, no hardcoded name list**
+(same pattern as `test_skill_md_default_inline_cap_gate.py` /
+`test_builtin_registry_disk_parity.py`, so a newly shipped skill on either
+surface is picked up automatically): `BUILTIN_SKILLS`' registered `SKILL.md`
+paths, unioned with every `SKILL.md` found by walking
+``src/reyn/builtin/plugins/*/skills/*/``.
 
-**Four properties, each gated separately (a RED result names which one
-broke -- strip-falsify verified per-property, see PR body):**
+**Vacuity guards.** The real-tree test asserts it found a non-zero number of
+skills AND (separately) that it found a non-zero number of token-prefixed
+links across those skills -- reyn_cheat_sheet already ships 4 such links
+(#3162 fix), so an empty match set here would indicate the extraction regex
+itself broke, not that no skill uses the mechanism.
 
-1. **Link resolution** -- every declared `references:` entry exists on disk
-   under `references/`.
-2. **Wheel reachability** -- a body path under a skill's `references/`
-   subdirectory is servable through the same wheel-safe
-   ``read_builtin_body_bytes`` routing ``test_2913_builtin_body_wheel_reachable.py``
-   proved for ``SKILL.md`` itself -- proof that the mechanism generalizes
-   to ANY body file under ``skills/<name>/``, not just the top-level file.
-3. **Orphan detection** -- the on-disk `references/*.md` file set and the
-   declared `references:` set match exactly, in both directions (missing
-   declared file, AND undeclared file on disk) -- the same bidirectional-
-   parity shape as ``test_builtin_registry_disk_parity.py`` (#3168).
-4. **Cap** -- each reference file is strictly under the SAME default
-   (model-unresolved) inline read cap as ``SKILL.md`` itself
-   (``MAX_CONTROL_IR_RESULT_INLINE_BYTES`` -- imported, not re-declared, so
-   this cannot silently desync from ``test_skill_md_default_inline_cap_gate.py``).
-   Skipping this is exactly how #3162's original hole (a body silently
-   truncated by a model-unresolved read) would reopen one directory level
-   down, inside ``references/``.
-
-**Vacuity.** At the time of writing NO shipped skill declares
-`references:` -- properties 1/2/3/4 above are checked against a REAL,
-zero-sized set and pass trivially. That is intentional (the convention is
-declared before any consumer exists, per the architect's explicit ordering
-above) and MUST NOT be papered over by asserting `len(...) >= 1` the way
-the sibling gates do. Instead, the ``Fixture witnesses`` section below
-builds synthetic skills under ``tmp_path`` -- one broken per property -- and
-proves the SAME checking function used against real skills actually goes
-RED for each break, and GREEN for a fully consistent fixture. The checking
-function (`_check_skill_references`) is the one piece of logic shared by
-both the real-skill tests and the fixture tests, so a fixture GREEN/RED
-result is evidence about the real-skill tests' detection power, not a
-disconnected toy.
-
-No fakes: real front-matter parser (`reyn.core.frontmatter.split_frontmatter`),
-real files on disk (both the shipped tree and `tmp_path` fixtures), and the
-real `read_builtin_body_bytes` wheel-read routing.
+No fakes: real front-matter/body split via `split()`-on-Markdown (no YAML
+front-matter is consulted by this gate at all -- it is a pure Markdown-link
+scan), real files on disk (both the shipped tree and `tmp_path` fixtures).
+Each of the 4 properties has a dedicated fixture built under `tmp_path` that
+breaks ONLY that property and is asserted to go RED via the SAME shared
+checking function the real-tree test uses, plus a fully-consistent control
+fixture proving the checks are not vacuously always-red.
 """
 from __future__ import annotations
 
-import importlib.resources as importlib_resources
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import reyn.builtin.docs as builtin_docs_module
 import reyn.builtin.registry as registry_module
-from reyn.builtin.docs import read_builtin_body_bytes
 from reyn.builtin.registry import BUILTIN_SKILLS
 from reyn.core.context_builder import MAX_CONTROL_IR_RESULT_INLINE_BYTES
-from reyn.core.frontmatter import split_frontmatter
 
 _BUILTIN_DIR = Path(registry_module.__file__).parent
 _PLUGINS_DIR = _BUILTIN_DIR / "plugins"
+
+# Matches a Markdown link `[text](${CLAUDE_SKILL_DIR}/path/to/file.md)` or
+# the `${REYN_SKILL_DIR}` alias it expands to (`tokens.py`). Captures the
+# path suffix after the token. Deliberately a literal string match on the
+# token, NOT an attempt to expand it -- expansion is skill_load.py's job,
+# this gate only checks the reachable *form*.
+_TOKEN_LINK_RE = re.compile(
+    r"\]\(\$\{(?:CLAUDE_SKILL_DIR|REYN_SKILL_DIR)\}/([^)\s]+)\)"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -112,242 +124,301 @@ def _all_shipped_skill_md_paths() -> "set[Path]":
 @dataclass(frozen=True)
 class _ReferenceCheckResult:
     skill_md_path: Path
-    declared: "list[str]" = field(default_factory=list)
-    missing: "list[str]" = field(default_factory=list)  # declared, absent on disk
-    orphans: "list[str]" = field(default_factory=list)  # on disk, not declared
-    oversize: "dict[str, int]" = field(default_factory=dict)  # declared, >= cap
+    links: "list[str]" = field(default_factory=list)  # extracted link targets
+    missing: "list[str]" = field(default_factory=list)  # link target absent on disk
+    orphans: "list[str]" = field(default_factory=list)  # under references/, no link
+    dangling: "list[str]" = field(default_factory=list)  # linked into references/, absent
+    oversize: "dict[str, int]" = field(default_factory=dict)  # .md file >= cap
+    nested_links: "dict[str, list[str]]" = field(default_factory=dict)  # ref file -> its own links
 
 
-def _check_skill_references(skill_md_path: Path, cap: int) -> _ReferenceCheckResult:
-    """Property (1) link resolution, (3) orphan parity, (4) cap -- for one
-    skill's `references:` front-matter declaration against its `references/`
-    directory. Property (2) wheel reachability is checked separately below
-    (it needs the real `reyn.builtin` package resolution, not a plain stat)."""
-    references_dir = skill_md_path.parent / "references"
-    front_matter, _body = split_frontmatter(skill_md_path.read_text(encoding="utf-8"))
-    declared = list(front_matter.get("references") or [])
+def extract_token_links(text: str) -> "list[str]":
+    """Property (1)'s extraction primitive: every ``${CLAUDE_SKILL_DIR}``/
+    ``${REYN_SKILL_DIR}``-prefixed Markdown link target found in *text*, as
+    the raw path suffix after the token (e.g. ``references/foo.md``)."""
+    return _TOKEN_LINK_RE.findall(text)
+
+
+def _check_skill(skill_md_path: Path, cap: int) -> _ReferenceCheckResult:
+    """Properties (1) link resolution, (2) bidirectional orphan parity,
+    (3) size cap, (4) L3-is-a-leaf -- for one skill directory."""
+    skill_dir = skill_md_path.parent
+    body = skill_md_path.read_text(encoding="utf-8")
+    links = extract_token_links(body)
 
     missing: "list[str]" = []
-    oversize: "dict[str, int]" = {}
-    for name in declared:
-        ref_path = references_dir / name
-        if not ref_path.is_file():
-            missing.append(name)
-            continue
-        size = len(ref_path.read_text(encoding="utf-8"))
-        if size >= cap:
-            oversize[name] = size
+    for rel in links:
+        if not (skill_dir / rel).is_file():
+            missing.append(rel)
 
-    disk_names = {p.name for p in references_dir.glob("*.md")} if references_dir.is_dir() else set()
-    orphans = sorted(disk_names - set(declared))
+    references_dir = skill_dir / "references"
+    orphans: "list[str]" = []
+    dangling: "list[str]" = []
+    if references_dir.is_dir():
+        disk_files = {
+            str(p.relative_to(skill_dir)) for p in references_dir.rglob("*") if p.is_file()
+        }
+        linked_into_references = {
+            rel for rel in links if _is_under(skill_dir / rel, references_dir)
+        }
+        orphans = sorted(disk_files - linked_into_references)
+        dangling = sorted(
+            rel for rel in linked_into_references if not (skill_dir / rel).is_file()
+        )
+
+    oversize: "dict[str, int]" = {}
+    for md_path in skill_dir.rglob("*.md"):
+        size = len(md_path.read_text(encoding="utf-8"))
+        if size >= cap:
+            oversize[str(md_path.relative_to(skill_dir))] = size
+
+    nested_links: "dict[str, list[str]]" = {}
+    if references_dir.is_dir():
+        for ref_path in references_dir.rglob("*.md"):
+            found = extract_token_links(ref_path.read_text(encoding="utf-8"))
+            if found:
+                nested_links[str(ref_path.relative_to(skill_dir))] = found
 
     return _ReferenceCheckResult(
         skill_md_path=skill_md_path,
-        declared=declared,
+        links=links,
         missing=sorted(missing),
         orphans=orphans,
+        dangling=dangling,
         oversize=oversize,
+        nested_links=nested_links,
     )
 
 
+def _is_under(path: Path, directory: Path) -> bool:
+    try:
+        path.resolve().relative_to(directory.resolve())
+    except ValueError:
+        return False
+    return True
+
+
 # ---------------------------------------------------------------------------
-# Real-skill gates (1) link resolution, (3) orphan parity, (4) cap.
-# Vacuous today (0 skills declare `references:`) -- see module docstring and
-# the fixture witnesses below for why that is acceptable here.
+# Real-skill gate -- all 4 properties, against every shipped skill.
 # ---------------------------------------------------------------------------
 
 
-def test_every_declared_reference_resolves_and_has_no_orphans_and_fits_cap() -> None:
-    """Tier 2: OS invariant -- properties (1)+(3)+(4) against every shipped
-    skill. Vacuous today (see module docstring): 0 shipped skills currently
-    declare `references:`, so this passes trivially. Detection power is
-    proven by the fixture witnesses below, which apply the SAME
-    `_check_skill_references` function to synthetic broken skills."""
+def test_every_skill_reference_link_resolves_has_no_orphans_fits_cap_and_leaf() -> None:
+    """Tier 2: OS invariant -- properties (1)+(2)+(3)+(4) against every
+    shipped skill (builtin registry + plugin skills-on-disk). Vacuity-
+    guarded: asserts a non-zero skill count AND a non-zero token-link count
+    were actually found, so an empty match set cannot silently pass."""
     all_paths = _all_shipped_skill_md_paths()
     assert len(all_paths) >= 1, (
         "vacuity guard: no SKILL.md found across either shipping surface -- "
         "this gate would pass trivially with nothing to check"
     )
 
-    missing_by_skill = {}
-    orphans_by_skill = {}
-    oversize_by_skill = {}
+    missing_by_skill: "dict[str, list[str]]" = {}
+    orphans_by_skill: "dict[str, list[str]]" = {}
+    dangling_by_skill: "dict[str, list[str]]" = {}
+    oversize_by_skill: "dict[str, dict[str, int]]" = {}
+    nested_by_skill: "dict[str, dict[str, list[str]]]" = {}
+    total_links = 0
+
     for path in sorted(all_paths):
-        result = _check_skill_references(path, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+        result = _check_skill(path, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+        total_links += len(result.links)
         if result.missing:
             missing_by_skill[str(path)] = result.missing
         if result.orphans:
             orphans_by_skill[str(path)] = result.orphans
+        if result.dangling:
+            dangling_by_skill[str(path)] = result.dangling
         if result.oversize:
             oversize_by_skill[str(path)] = result.oversize
+        if result.nested_links:
+            nested_by_skill[str(path)] = result.nested_links
+
+    assert total_links >= 1, (
+        "vacuity guard: no ${CLAUDE_SKILL_DIR}/${REYN_SKILL_DIR}-prefixed "
+        "link found across any shipped skill -- reyn_cheat_sheet ships 4 "
+        "such links, so an empty count here means the extraction regex "
+        "itself broke, not that the mechanism is unused"
+    )
 
     assert not missing_by_skill, (
-        "declared `references:` entry does not exist under references/: "
-        f"{missing_by_skill}"
+        "a ${CLAUDE_SKILL_DIR}/${REYN_SKILL_DIR}-prefixed link's target does "
+        f"not exist under the skill's own directory: {missing_by_skill}"
     )
     assert not orphans_by_skill, (
-        "file(s) under references/ are not declared in front-matter "
-        f"`references:` (orphan, unreachable via the router): {orphans_by_skill}"
+        "file(s) under references/ are not linked from SKILL.md via a "
+        f"token-prefixed link (unreachable via the router): {orphans_by_skill}"
+    )
+    assert not dangling_by_skill, (
+        "a token-prefixed link points into references/ at a file that does "
+        f"not exist: {dangling_by_skill}"
     )
     assert not oversize_by_skill, (
-        "reference file exceeds the default (model-unresolved) inline read "
-        f"cap ({MAX_CONTROL_IR_RESULT_INLINE_BYTES} chars): {oversize_by_skill}"
+        "a .md file under a skill directory exceeds the default "
+        f"(model-unresolved) inline read cap ({MAX_CONTROL_IR_RESULT_INLINE_BYTES} "
+        f"chars): {oversize_by_skill}"
     )
-
-
-# ---------------------------------------------------------------------------
-# Real-skill gate (2) wheel reachability -- generalizes test_2913's proof
-# (SKILL.md is readable via read_builtin_body_bytes even when project_root
-# is elsewhere) to whatever `references:` a skill declares. Vacuous today
-# for the same reason as above; the fixture witness proves the underlying
-# routing generalizes beyond the top-level SKILL.md filename.
-# ---------------------------------------------------------------------------
-
-
-def test_every_declared_reference_is_wheel_reachable() -> None:
-    """Tier 2: OS invariant -- every declared reference, for every shipped
-    skill, is servable through read_builtin_body_bytes (the same wheel-safe
-    routing test_2913 proved for SKILL.md). Vacuous today (0 declared
-    references) -- see the fixture-based generalization witness below."""
-    all_paths = _all_shipped_skill_md_paths()
-    unreachable = {}
-    for path in sorted(all_paths):
-        result = _check_skill_references(path, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
-        for name in result.declared:
-            ref_path = path.parent / "references" / name
-            if not ref_path.is_file():
-                continue  # already reported by the link-resolution gate above
-            if read_builtin_body_bytes(str(ref_path)) is None:
-                unreachable.setdefault(str(path), []).append(name)
-    assert not unreachable, (
-        f"declared reference(s) not reachable via read_builtin_body_bytes: {unreachable}"
+    assert not nested_by_skill, (
+        "a file under references/ itself contains a token-prefixed link to "
+        "another file -- L3 references must be leaves (only SKILL.md gets "
+        f"token expansion): {nested_by_skill}"
     )
 
 
 # ---------------------------------------------------------------------------
 # Fixture witnesses -- vacuity guard. Each test builds a synthetic skill
 # under tmp_path with exactly one property broken and asserts the SHARED
-# checking function (used by the real-skill gates above) goes RED for it.
-# A final control fixture is fully consistent and must go GREEN across all
-# four properties, proving the checks are not vacuously always-red either.
+# checking function (used by the real-skill gate above) goes RED for it,
+# while staying silent about the other 3 properties. A final control
+# fixture is fully consistent and must go GREEN across all four properties.
 # ---------------------------------------------------------------------------
 
 
-def _write_skill(skill_dir: Path, *, references: "list[str] | None", body_extra: str = "") -> Path:
+def _write_skill(skill_dir: Path, *, body_links: str = "") -> Path:
     skill_dir.mkdir(parents=True, exist_ok=True)
-    front_matter_lines = ["---", "name: fixture_skill", "description: witness fixture"]
-    if references is not None:
-        front_matter_lines.append("references:")
-        front_matter_lines.extend(f"  - {name}" for name in references)
-    front_matter_lines.append("---")
-    text = "\n".join(front_matter_lines) + f"\n\n# Fixture\n\n{body_extra}"
+    text = (
+        "---\n"
+        "name: fixture_skill\n"
+        "description: witness fixture\n"
+        "---\n\n"
+        "# Fixture\n\n"
+        f"{body_links}\n"
+    )
     skill_md = skill_dir / "SKILL.md"
     skill_md.write_text(text, encoding="utf-8")
     return skill_md
 
 
-def test_witness_missing_declared_reference_is_detected(tmp_path) -> None:
-    """Tier 2: fixture witness (a) -- a `references:` entry declared in
-    front-matter but absent on disk under references/ must be flagged as
-    `missing` by `_check_skill_references` (property 1, link resolution)."""
-    skill_md = _write_skill(tmp_path / "fixture_skill", references=["does-not-exist.md"])
-    result = _check_skill_references(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
-    assert result.missing == ["does-not-exist.md"], result
+def test_witness_dangling_reference_link_is_detected(tmp_path) -> None:
+    """Tier 2: fixture witness (a) -- a ${CLAUDE_SKILL_DIR}-prefixed link in
+    SKILL.md whose target does not exist on disk must be flagged as
+    `missing` (property 1, link resolution) -- and must NOT trip
+    orphans/oversize/nested_links."""
+    skill_dir = tmp_path / "fixture_skill"
+    skill_md = _write_skill(
+        skill_dir,
+        body_links="[gone](${CLAUDE_SKILL_DIR}/references/does-not-exist.md)",
+    )
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    assert result.missing == ["references/does-not-exist.md"], result
     assert not result.orphans
+    assert not result.dangling
     assert not result.oversize
+    assert not result.nested_links
 
 
 def test_witness_orphan_reference_file_is_detected(tmp_path) -> None:
     """Tier 2: fixture witness (b) -- a file sitting under references/ that
-    is NOT declared in front-matter `references:` must be flagged as an
-    `orphan` by `_check_skill_references` (property 3, bidirectional parity)."""
+    NO token-prefixed link in SKILL.md points at must be flagged as an
+    `orphan` (property 2, bidirectional parity) -- and must NOT trip
+    missing/oversize/nested_links."""
     skill_dir = tmp_path / "fixture_skill"
-    skill_md = _write_skill(skill_dir, references=[])
-    (skill_dir / "references").mkdir()
-    (skill_dir / "references" / "undeclared.md").write_text("orphan content", encoding="utf-8")
-    result = _check_skill_references(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
-    assert result.orphans == ["undeclared.md"], result
+    skill_md = _write_skill(skill_dir, body_links="No links here.")
+    references_dir = skill_dir / "references"
+    references_dir.mkdir()
+    (references_dir / "undeclared.md").write_text("orphan content", encoding="utf-8")
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    assert result.orphans == ["references/undeclared.md"], result
     assert not result.missing
+    assert not result.dangling
     assert not result.oversize
+    assert not result.nested_links
 
 
-def test_witness_oversize_reference_is_detected(tmp_path) -> None:
-    """Tier 2: fixture witness (c) -- a declared reference file at/over the
-    default inline cap must be flagged as `oversize` by
-    `_check_skill_references` (property 4, cap)."""
+def test_witness_oversize_md_file_is_detected(tmp_path) -> None:
+    """Tier 2: fixture witness (c) -- an .md file (SKILL.md or a reference)
+    at/over the default inline cap must be flagged as `oversize`
+    (property 3, size cap) -- and must NOT trip missing/orphans/nested_links
+    (the reference is correctly linked, just too big)."""
     skill_dir = tmp_path / "fixture_skill"
-    skill_md = _write_skill(skill_dir, references=["huge.md"])
+    skill_md = _write_skill(
+        skill_dir,
+        body_links="[huge](${CLAUDE_SKILL_DIR}/references/huge.md)",
+    )
     references_dir = skill_dir / "references"
     references_dir.mkdir()
     (references_dir / "huge.md").write_text(
         "x" * MAX_CONTROL_IR_RESULT_INLINE_BYTES, encoding="utf-8"
     )
-    result = _check_skill_references(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
-    assert result.oversize == {"huge.md": MAX_CONTROL_IR_RESULT_INLINE_BYTES}, result
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    assert result.oversize == {
+        "references/huge.md": MAX_CONTROL_IR_RESULT_INLINE_BYTES
+    }, result
     assert not result.missing
     assert not result.orphans
+    assert not result.dangling
+    assert not result.nested_links
+
+
+def test_witness_nested_reference_link_is_detected(tmp_path) -> None:
+    """Tier 2: fixture witness (d) -- a reference file that itself contains
+    a token-prefixed Markdown link to another file must be flagged in
+    `nested_links` (property 4, L3-is-a-leaf) -- and must NOT trip
+    missing/orphans/oversize. A bare ${...} mention that is NOT inside a
+    `](${TOKEN}/...)` link shape must NOT trip this check (the peer
+    correction folded into this rebuild: token mentions in prose are fine,
+    only the link *form* is gated)."""
+    skill_dir = tmp_path / "fixture_skill"
+    skill_md = _write_skill(
+        skill_dir,
+        body_links="[ref](${CLAUDE_SKILL_DIR}/references/leaf.md)",
+    )
+    references_dir = skill_dir / "references"
+    references_dir.mkdir()
+    (references_dir / "leaf.md").write_text(
+        "See ${CLAUDE_SKILL_DIR} in prose (fine on its own), but also a real "
+        "nested link: [deeper](${CLAUDE_SKILL_DIR}/references/other.md)",
+        encoding="utf-8",
+    )
+    (references_dir / "other.md").write_text("unrelated leaf", encoding="utf-8")
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    assert result.nested_links == {
+        "references/leaf.md": ["references/other.md"]
+    }, result
+    assert not result.missing
+    assert not result.oversize
+    # other.md is on disk but not linked from SKILL.md itself (only from the
+    # nested, invalid link inside leaf.md) -- it correctly still reports as
+    # an orphan too, since property (2) only counts links FROM SKILL.md.
+    assert result.orphans == ["references/other.md"]
 
 
 def test_witness_consistent_fixture_is_fully_green(tmp_path) -> None:
-    """Tier 2: fixture control -- a skill whose `references:` declaration
-    exactly matches its references/ directory, all under cap, must report
-    NO missing/orphan/oversize entries. Without this control, a checker
-    that always reports something broken would pass the three RED witnesses
-    above vacuously."""
+    """Tier 2: fixture control -- a skill whose SKILL.md links match its
+    references/ directory exactly, all under cap, with no nested links,
+    must report NO missing/orphan/dangling/oversize/nested entries. Without
+    this control, a checker that always reports something broken would pass
+    the four RED witnesses above vacuously."""
     skill_dir = tmp_path / "fixture_skill"
-    skill_md = _write_skill(skill_dir, references=["a.md", "b.md"])
+    skill_md = _write_skill(
+        skill_dir,
+        body_links=(
+            "[a](${CLAUDE_SKILL_DIR}/references/a.md)\n"
+            "[b](${REYN_SKILL_DIR}/references/b.md)\n"
+        ),
+    )
     references_dir = skill_dir / "references"
     references_dir.mkdir()
     (references_dir / "a.md").write_text("small a", encoding="utf-8")
     (references_dir / "b.md").write_text("small b", encoding="utf-8")
-    result = _check_skill_references(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
     assert not result.missing
     assert not result.orphans
+    assert not result.dangling
     assert not result.oversize
+    assert not result.nested_links
 
 
-def test_witness_no_references_declared_is_ungated(tmp_path) -> None:
-    """Tier 2: fixture control -- a skill with no `references:` key at all
-    (today's shape for every shipped skill) reports nothing broken --
-    `references:` is opt-in, not a new requirement on existing skills."""
-    skill_md = _write_skill(tmp_path / "fixture_skill", references=None)
-    result = _check_skill_references(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
-    assert result.declared == []
+def test_witness_no_references_dir_is_ungated(tmp_path) -> None:
+    """Tier 2: fixture control -- a skill with no references/ directory at
+    all (a genuinely single-file skill) reports nothing broken --
+    references/ is opt-in, not a new requirement on existing skills."""
+    skill_md = _write_skill(tmp_path / "fixture_skill", body_links="No references needed.")
+    result = _check_skill(skill_md, MAX_CONTROL_IR_RESULT_INLINE_BYTES)
+    assert result.links == []
     assert not result.missing
     assert not result.orphans
+    assert not result.dangling
     assert not result.oversize
-
-
-def test_witness_wheel_reachability_generalizes_beyond_skill_md(tmp_path, monkeypatch) -> None:
-    """Tier 2: fixture witness for property (2) -- proves
-    `read_builtin_body_bytes` reaches a body path under `skills/<name>/`
-    generically (not special-cased to the literal SKILL.md filename), by
-    redirecting the function's package-root resolution to a synthetic
-    `skills/<name>/references/*.md` tree under tmp_path. Falsify: a file
-    OUTSIDE the body dirs (skills/pipelines) still returns None, proving
-    the least-privilege scope (#2914 Ruling 1) is not widened by this
-    generalization."""
-    package_root = tmp_path / "package_root"
-    skill_dir = package_root / "skills" / "fixture_skill"
-    references_dir = skill_dir / "references"
-    references_dir.mkdir(parents=True)
-    ref_path = references_dir / "hooks-and-events.md"
-    ref_path.write_text("reference body content", encoding="utf-8")
-
-    non_body_path = package_root / "registry.py"
-    non_body_path.write_text("not a body file", encoding="utf-8")
-
-    monkeypatch.setattr(importlib_resources, "files", lambda pkg: package_root)
-    # docs.py imports `importlib.resources as _resources` at module scope --
-    # patch that bound name directly so the real function under test picks
-    # up the redirected resolver.
-    monkeypatch.setattr(builtin_docs_module._resources, "files", lambda pkg: package_root)
-
-    reachable = read_builtin_body_bytes(str(ref_path))
-    assert reachable == b"reference body content", reachable
-
-    unreachable = read_builtin_body_bytes(str(non_body_path))
-    assert unreachable is None, (
-        "a path inside the package but outside skills/ or pipelines/ must "
-        "stay gated -- the reference generalization must not widen scope"
-    )
+    assert not result.nested_links


### PR DESCRIPTION
**[per-PR-coder]** — part of #3162

## Summary

The official Anthropic Agent Skills spec (https://code.claude.com/docs/en/skills.md) references a bundled file from `SKILL.md` via a plain Markdown link in the body — not a front-matter `references:` key. #3170 added such a front-matter field to reyn; it was non-standard and is removed here.

- **Task A**: `src/reyn/builtin/skills/reyn_cheat_sheet/SKILL.md` — the 3 bundled-file mentions (previously bare relative paths like `` `references/input-hooks-and-mcp.md` `` written as inline code, which are unreachable at read time since reyn's `file` read op resolves non-absolute paths against the workspace root, not the skill directory) are now markdown links of the form `[name](${CLAUDE_SKILL_DIR}/references/name.md)`. Front-matter `references:` key removed. `description:` untouched (byte-identical, per #3168's parity gate).
- **Task B**: `tests/test_skill_references_gate_3162.py` rebuilt to check the standard mechanism across every skill under both builtin and plugin skill directories (real filesystem walk, no hardcoded name list — same pattern as `test_skill_md_default_inline_cap_gate.py`):
  1. **Link resolution** — every `${CLAUDE_SKILL_DIR}`/`${REYN_SKILL_DIR}`-prefixed Markdown link in a `SKILL.md` body resolves to a real file under the skill's directory.
  2. **Bidirectional orphan parity** — a skill's `references/` file set and the link-target set pointing into it match exactly, both directions.
  3. **Size cap** — every `.md` file under a skill directory stays under `MAX_CONTROL_IR_RESULT_INLINE_BYTES` (imported, not hardcoded).
  4. **L3-is-a-leaf** — a file under `references/` must not itself contain a token-prefixed link to another file (only `SKILL.md` gets token expansion, per `src/reyn/plugins/skill_load.py`; a link inside a reference would never resolve). Note: a bare `${...}` mention in prose is fine — only the `](${TOKEN}/...)` link *form* is gated (this definition was corrected mid-task by a peer session review; the original "ban all tokens in references" framing was too broad since `tokens.py` treats an unexpanded token as an ordinary, expected outcome).

Docs updated in the same PR (`docs/concepts/tools-integrations/skills.md`) since the mechanism the doc described changed.

## Design notes / divergences from the dispatch brief

- Dropped the old gate's "wheel reachability" property (`read_builtin_body_bytes` routing) — the brief's Task B lists exactly 4 properties and doesn't mention it; I followed the brief literally rather than carrying over a 5th property from the old gate.
- `reactive_orchestration_plugins` (sibling PR #3172's target) already exists in this worktree's main but has no `references/` dir or token-links yet — the fixture witnesses (`test_witness_*`) independently confirm the `${CLAUDE_SKILL_DIR}` link format classifies correctly regardless.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_skill_references_gate_3162.py` — 7/7 OK, 0 errors
- [x] Full `pytest` from repo root — 9304 passed, 33 skipped, 0 failed
- [x] `tests/test_0060_phase2_f3b_builtin_content.py`, `tests/test_builtin_registry_disk_parity.py` (#3168), `tests/test_skill_md_default_inline_cap_gate.py` (#3169) all still green
- [x] Each of the 4 new gate properties independently strip-falsified: temporarily defeated each check in `_check_skill`, ran the corresponding fixture test, confirmed it goes RED, then reverted the exact lines back (verified via `git diff` clean before commit) — no `git checkout`/`stash`/`restore` used