### PR TITLE
fix(context): unify elide/advisor token accounting on the wire-dict canonical (#2957 PR-B)

### DIFF
--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -84,21 +84,41 @@ class ContextBudgetAdvisor:
     # ── Internal helpers ─────────────────────────────────────────────────────
 
     def _get_effective_trigger(self) -> int:
-        """Derive effective_trigger from engine budgets or fallback."""
-        controller = self._compaction_controller
-        engine = getattr(controller, "_engine", None) if controller is not None else None
-        budgets = getattr(engine, "budgets", None)
-        if budgets is not None:
-            return budgets.effective_trigger
-        from reyn.llm.model_budget import get_max_input_tokens
-        return get_max_input_tokens(self._model, events=self._events)
+        """Derive effective_trigger from engine budgets or fallback.
+
+        #2957 PR-B: delegates to
+        ``reyn.runtime.services.router_history_buffer.resolve_effective_trigger_and_budgets``
+        — single SSoT shared with ``RouterHistoryBuffer._resolve_budgets``
+        (previously each reimplemented this lookup independently).
+        """
+        from reyn.runtime.services.router_history_buffer import (
+            resolve_effective_trigger_and_budgets,
+        )
+        return resolve_effective_trigger_and_budgets(
+            self._compaction_controller, self._model, self._events,
+        )[0]
 
     def _incremental_history_tokens(self) -> int:
         """Estimated token count of the full router-view history (#2940).
 
+        #2957 PR-B: sums ``estimate_tokens_for_turn`` PER TURN (dict-aware:
+        fixed cost per image part, ``tool_calls`` folded in) rather than
+        ``estimate_tokens(json.dumps(whole_or_delta_slice))`` (pre-PR-B).
+        The history this reads is ``build_history``'s own returned wire
+        dicts (see this class's docstring) — the SAME canonical quantity
+        RouterHistoryBuffer's elide-threshold check now measures (see
+        ``RouterHistoryBuffer._serialise_turn``'s docstring). Before PR-B,
+        json.dumps-ing a wire dict counted an inlined image's FULL base64
+        payload as text (huge, proportional token count) while the elide
+        side (post PR-A) counted a fixed ``_IMAGE_FIXED_TOKEN_COST`` per
+        image part — the two sides disagreed by orders of magnitude on any
+        image-bearing conversation even when measuring the identical wire
+        dicts. Per-turn ``estimate_tokens_for_turn`` closes that gap (same
+        function, same fixed-cost branch, both sides).
+
         Incremental: only the slice of history NEWER than the last call is
-        json.dumps'd + estimated; on a cache hit (no new messages since the
-        last call) THIS function's own dump+estimate work is O(1).
+        estimated; on a cache hit (no new messages since the last call)
+        THIS function's own estimate work is O(1).
 
         That O(1) is scoped to the dump+estimate ONLY — it is NOT the cost of
         calling this. ``self._history_fn()`` is invoked before the cache is
@@ -122,7 +142,7 @@ class ContextBudgetAdvisor:
         """
         import json as _json
 
-        from reyn.services.compaction.engine import estimate_tokens
+        from reyn.services.compaction.engine import estimate_tokens_for_turn
 
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
         cache = self._history_token_cache
@@ -134,7 +154,9 @@ class ContextBudgetAdvisor:
             # the cached prefix (index cached_len - 1). If it no longer
             # matches the message currently at that index, the prefix isn't
             # append-only-stable and the cache cannot be trusted, even at an
-            # unchanged or grown length.
+            # unchanged or grown length. (json.dumps here is purely an
+            # identity fingerprint for the boundary check — NOT the token
+            # measure itself, which is estimate_tokens_for_turn below.)
             boundary = (
                 _json.dumps(history[cached_len - 1], ensure_ascii=False)
                 if 0 < cached_len <= n
@@ -147,20 +169,20 @@ class ContextBudgetAdvisor:
                 or cache["use_chars4"] != use_chars4
                 or not prefix_unchanged
             ):
-                combined = _json.dumps(history, ensure_ascii=False)
-                tokens = estimate_tokens(combined, self._model, use_chars4=use_chars4)
+                tokens = sum(
+                    estimate_tokens_for_turn(m, self._model, use_chars4=use_chars4)
+                    for m in history
+                )
             elif cached_len == n:
                 return int(cache["tokens"])
             else:
-                # Dump each new message individually and join with the same
-                # comma separator json.dumps(list) would use BETWEEN elements
-                # (not wrapped in its own "[...]") — an array-slice dump would
-                # otherwise add a spurious pair of bracket tokens on every
-                # single call, drifting the cumulative estimate upward as the
-                # history grows across many dropdown-open/pre-frame checks.
+                # Only the NEW tail slice needs estimating — the cached total
+                # for the unchanged prefix carries forward unchanged.
                 delta = history[cached_len:]
-                combined = ",".join(_json.dumps(m, ensure_ascii=False) for m in delta)
-                tokens = int(cache["tokens"]) + estimate_tokens(combined, self._model, use_chars4=use_chars4)
+                tokens = int(cache["tokens"]) + sum(
+                    estimate_tokens_for_turn(m, self._model, use_chars4=use_chars4)
+                    for m in delta
+                )
             new_boundary = _json.dumps(history[-1], ensure_ascii=False) if n > 0 else None
             cache.update(
                 len=n, tokens=tokens, model=self._model, use_chars4=use_chars4, boundary=new_boundary,

--- a/src/reyn/runtime/services/context_budget_advisor.py
+++ b/src/reyn/runtime/services/context_budget_advisor.py
@@ -101,9 +101,9 @@ class ContextBudgetAdvisor:
     def _incremental_history_tokens(self) -> int:
         """Estimated token count of the full router-view history (#2940).
 
-        #2957 PR-B: sums ``estimate_tokens_for_turn`` PER TURN (dict-aware:
-        fixed cost per image part, ``tool_calls`` folded in) rather than
-        ``estimate_tokens(json.dumps(whole_or_delta_slice))`` (pre-PR-B).
+        #2957 PR-B: sums ``estimate_tokens_for_any_turn`` PER TURN (dict-aware:
+        fixed cost per image part, top-level ``tool_calls`` folded in) rather
+        than ``estimate_tokens(json.dumps(whole_or_delta_slice))`` (pre-PR-B).
         The history this reads is ``build_history``'s own returned wire
         dicts (see this class's docstring) — the SAME canonical quantity
         RouterHistoryBuffer's elide-threshold check now measures (see
@@ -113,8 +113,14 @@ class ContextBudgetAdvisor:
         side (post PR-A) counted a fixed ``_IMAGE_FIXED_TOKEN_COST`` per
         image part — the two sides disagreed by orders of magnitude on any
         image-bearing conversation even when measuring the identical wire
-        dicts. Per-turn ``estimate_tokens_for_turn`` closes that gap (same
-        function, same fixed-cost branch, both sides).
+        dicts. ``estimate_tokens_for_any_turn`` (not the dict-only
+        ``estimate_tokens_for_turn`` directly) is required here because a
+        wire dict's ``tool_calls`` lives in a SEPARATE top-level key
+        (``_serialise_turn``'s real litellm wire shape), not inside
+        ``"content"`` — ``estimate_tokens_for_turn`` only reads
+        ``"content"``, so calling it directly would silently re-drop
+        ``tool_calls`` (the same class of gap PR-A fixed for ChatMessage
+        input, reappearing one call shape later).
 
         Incremental: only the slice of history NEWER than the last call is
         estimated; on a cache hit (no new messages since the last call)
@@ -142,7 +148,7 @@ class ContextBudgetAdvisor:
         """
         import json as _json
 
-        from reyn.services.compaction.engine import estimate_tokens_for_turn
+        from reyn.services.compaction.engine import estimate_tokens_for_any_turn
 
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
         cache = self._history_token_cache
@@ -170,7 +176,7 @@ class ContextBudgetAdvisor:
                 or not prefix_unchanged
             ):
                 tokens = sum(
-                    estimate_tokens_for_turn(m, self._model, use_chars4=use_chars4)
+                    estimate_tokens_for_any_turn(m, self._model, use_chars4=use_chars4)
                     for m in history
                 )
             elif cached_len == n:
@@ -180,7 +186,7 @@ class ContextBudgetAdvisor:
                 # for the unchanged prefix carries forward unchanged.
                 delta = history[cached_len:]
                 tokens = int(cache["tokens"]) + sum(
-                    estimate_tokens_for_turn(m, self._model, use_chars4=use_chars4)
+                    estimate_tokens_for_any_turn(m, self._model, use_chars4=use_chars4)
                     for m in delta
                 )
             new_boundary = _json.dumps(history[-1], ensure_ascii=False) if n > 0 else None

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -407,6 +407,18 @@ class RouterHistoryBuffer:
             estimate_tokens_for_any_turn(wt, self._model, use_chars4=use_chars4)
             for wt in wire_turns
         )
+        # #2957 PR-B (co-vet follow-up): emit the elide side's own internal
+        # total as a public P6 audit-event — the ONLY way a test (or an
+        # operator inspecting `reyn events`) can observe what THIS method
+        # actually counted, as opposed to re-deriving a reference number
+        # from its returned wire dicts (which cannot detect a regression in
+        # THIS computation itself). None-safe: many test/estimation-path
+        # callers construct this buffer with events=None.
+        if self._events is not None:
+            self._events.emit(
+                "history_elide_total_computed",
+                total=total, effective_trigger=effective_trigger,
+            )
 
         if total <= effective_trigger:
             # Window-utilization: full raw conversation fits — no elide.

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -132,6 +132,29 @@ def _materialise_path_ref_content(
     return materialised
 
 
+def resolve_effective_trigger_and_budgets(
+    compaction_controller: Any, model: str, events: Any,
+) -> "tuple[int, int, int]":
+    """Return ``(effective_trigger, head_budget, tail_budget)`` — #2957 PR-B
+    single SSoT for this lookup.
+
+    Before PR-B, :class:`RouterHistoryBuffer` (``_resolve_budgets``) and
+    :class:`~reyn.runtime.services.context_budget_advisor.ContextBudgetAdvisor`
+    (``_get_effective_trigger``) each reimplemented the identical
+    ``compaction_controller._engine.budgets`` lookup + ``get_max_input_tokens``
+    fallback independently — a duplication that could silently drift (one
+    site's fallback changing without the other). Both now delegate here.
+    """
+    engine = getattr(compaction_controller, "_engine", None) if compaction_controller is not None else None
+    budgets = getattr(engine, "budgets", None)
+    if budgets is not None:
+        return budgets.effective_trigger, budgets.head_budget, budgets.tail_budget
+    from reyn.llm.model_budget import get_max_input_tokens
+    effective_trigger = get_max_input_tokens(model, events=events)
+    fallback = effective_trigger // 4
+    return effective_trigger, fallback, fallback
+
+
 # ── RouterHistoryBuffer ───────────────────────────────────────────────────────
 
 
@@ -201,6 +224,19 @@ class RouterHistoryBuffer:
     def _serialise_turn(self, m: Any) -> dict:
         """Serialise one ChatMessage into a litellm-compatible wire dict.
 
+        #2957 PR-B: this method's output is the CANONICAL quantity for token
+        accounting — it is what actually reaches the provider. Both the
+        elide-threshold check in :meth:`build_history` /
+        :meth:`decompose_history_for_retry` and
+        :class:`~reyn.runtime.services.context_budget_advisor.ContextBudgetAdvisor`
+        (which measures ``build_history``'s own returned wire dicts) now
+        estimate tokens over THIS output, closing a prior circularity where
+        the elide side measured serialise-INPUT (raw ChatMessage, pre-image-
+        materialisation) while the advisor measured serialise-OUTPUT (the
+        elided wire dicts) — two different quantities for the same
+        conversation. Do not reintroduce a second "what does the provider
+        see" quantity; measure this method's return value.
+
         Path-ref content parts (= ``{"type":"image","path":...}``) are
         materialised to data URLs at this boundary so storage stays light
         and the LLM sees the inline form it expects. Shared by
@@ -256,16 +292,16 @@ class RouterHistoryBuffer:
         return messages
 
     def _resolve_budgets(self) -> tuple[int, int, int]:
-        """Return (effective_trigger, head_budget, tail_budget)."""
-        controller = self._compaction_controller
-        engine = getattr(controller, "_engine", None) if controller is not None else None
-        budgets = getattr(engine, "budgets", None)
-        if budgets is not None:
-            return budgets.effective_trigger, budgets.head_budget, budgets.tail_budget
-        from reyn.llm.model_budget import get_max_input_tokens
-        effective_trigger = get_max_input_tokens(self._model, events=self._events)
-        fallback = effective_trigger // 4
-        return effective_trigger, fallback, fallback
+        """Return (effective_trigger, head_budget, tail_budget).
+
+        #2957 PR-B: delegates to the module-level
+        ``resolve_effective_trigger_and_budgets`` — single SSoT shared with
+        ``ContextBudgetAdvisor._get_effective_trigger`` (previously each
+        reimplemented this lookup independently).
+        """
+        return resolve_effective_trigger_and_budgets(
+            self._compaction_controller, self._model, self._events,
+        )
 
     # ── Public API ────────────────────────────────────────────────────────────
 
@@ -295,7 +331,7 @@ class RouterHistoryBuffer:
         remains Reyn-internal and is filtered out.
         """
         from reyn.services.compaction.engine import (
-            estimate_tokens_for_any_turn,
+            estimate_tokens_for_turn,
             trim_head,
             trim_tail,
         )
@@ -350,20 +386,30 @@ class RouterHistoryBuffer:
         effective_trigger, head_budget, tail_budget = self._resolve_budgets()
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
 
-        # #2957 PR-A: ``turns`` are ChatMessage instances — use the
-        # type-adapting wrapper (estimate_tokens_for_turn stays dict-only).
+        # #2957 PR-B: serialise ALL candidate turns to their wire-dict shape
+        # UP FRONT, then measure/trim/select on THAT — the canonical quantity
+        # (see ``_serialise_turn``'s docstring). Before PR-B this elide-
+        # threshold total summed the pre-serialise ChatMessage instances
+        # (via the now-removed ``estimate_tokens_for_any_turn`` adapter),
+        # while ContextBudgetAdvisor measured this method's returned (post-
+        # serialise) wire dicts — two different quantities for the same
+        # conversation. Serialising once here and reusing the result for
+        # both the total-check AND the final return also avoids a double
+        # ``_serialise_turn`` call on the surviving subset.
+        wire_turns = [self._serialise_turn(m) for m in turns]
+
         total = sum(
-            estimate_tokens_for_any_turn(m, self._model, use_chars4=use_chars4)
-            for m in turns
+            estimate_tokens_for_turn(wt, self._model, use_chars4=use_chars4)
+            for wt in wire_turns
         )
 
         if total <= effective_trigger:
             # Window-utilization: full raw conversation fits — no elide.
-            selected = turns
+            selected = wire_turns
         else:
             # Elide the middle: head + optional summary bridge + tail.
-            head = trim_head(turns, head_budget, self._model, use_chars4=use_chars4)
-            tail = trim_tail(turns, tail_budget, self._model, use_chars4=use_chars4)
+            head = trim_head(wire_turns, head_budget, self._model, use_chars4=use_chars4)
+            tail = trim_tail(wire_turns, tail_budget, self._model, use_chars4=use_chars4)
             # Overlap guard: dedupe by identity so no turn appears twice.
             head_ids = {id(t) for t in head}
             tail_deduped = [t for t in tail if id(t) not in head_ids]
@@ -374,23 +420,18 @@ class RouterHistoryBuffer:
                     else json.dumps(summary.content, ensure_ascii=False)
                 )
                 from reyn.runtime.chat_message import ChatMessage
-                bridge = [ChatMessage(
+                bridge_msg = ChatMessage(
                     role="assistant",
                     content=f"[summary of earlier conversation]\n{summary_text}",
                     ts=summary.ts,
-                )]
-                selected = head + bridge + tail_deduped
+                )
+                selected = head + [self._serialise_turn(bridge_msg)] + tail_deduped
             else:
                 selected = head + tail_deduped
 
-        # E-full (#383) pass-through: ChatMessage IS the wire shape, so the
-        # builder just serialises each entry into a litellm-compatible
-        # message dict. Path-ref content parts (= ``{"type":"image","path":...}``)
-        # are materialised to data URLs **at this boundary** so storage
-        # stays light and the LLM sees the inline form it expects.
-        return self._bound_wire_reasoning(
-            [self._serialise_turn(m) for m in selected]
-        )
+        # ``selected`` is already the wire-dict shape (serialised above) —
+        # no second serialise pass needed.
+        return self._bound_wire_reasoning(selected)
 
     def decompose_history_for_retry(
         self,
@@ -409,7 +450,7 @@ class RouterHistoryBuffer:
         and retry_loop's shrink can still trim ``head``.
         """
         from reyn.services.compaction.engine import (
-            estimate_tokens_for_any_turn,
+            estimate_tokens_for_turn,
             trim_head,
             trim_tail,
         )
@@ -424,26 +465,28 @@ class RouterHistoryBuffer:
         effective_trigger, head_budget, tail_budget = self._resolve_budgets()
         use_chars4 = getattr(self._compaction, "use_chars4_estimate", False)
 
-        # #2957 PR-A: ``turns`` are ChatMessage instances — use the
-        # type-adapting wrapper (estimate_tokens_for_turn stays dict-only).
+        # #2957 PR-B: serialise once up front — same canonical-quantity
+        # rationale as build_history (see ``_serialise_turn``'s docstring).
+        wire_turns = [self._serialise_turn(m) for m in turns]
+
         total = sum(
-            estimate_tokens_for_any_turn(m, self._model, use_chars4=use_chars4)
-            for m in turns
+            estimate_tokens_for_turn(wt, self._model, use_chars4=use_chars4)
+            for wt in wire_turns
         )
 
         if total <= effective_trigger:
             # Everything fits — no elide; retry_loop can still trim head.
-            head_msgs = turns
-            raw_middle_msgs: list = []
-            tail_msgs: list = []
+            head = wire_turns
+            raw_middle: list = []
+            tail: list = []
         else:
-            head_msgs = trim_head(turns, head_budget, self._model, use_chars4=use_chars4)
-            tail_msgs = trim_tail(turns, tail_budget, self._model, use_chars4=use_chars4)
+            head = trim_head(wire_turns, head_budget, self._model, use_chars4=use_chars4)
+            tail = trim_tail(wire_turns, tail_budget, self._model, use_chars4=use_chars4)
             # raw_middle = turns strictly between head and tail (by identity).
-            head_id_set = {id(t) for t in head_msgs}
-            tail_id_set = {id(t) for t in tail_msgs}
-            raw_middle_msgs = [
-                t for t in turns
+            head_id_set = {id(t) for t in head}
+            tail_id_set = {id(t) for t in tail}
+            raw_middle = [
+                t for t in wire_turns
                 if id(t) not in head_id_set and id(t) not in tail_id_set
             ]
 
@@ -453,9 +496,6 @@ class RouterHistoryBuffer:
             structured = (summary_msg.meta or {}).get("structured")
             if isinstance(structured, dict):
                 summary_dict = structured
-        head = [self._serialise_turn(m) for m in head_msgs]
-        raw_middle = [self._serialise_turn(m) for m in raw_middle_msgs]
-        tail = [self._serialise_turn(m) for m in tail_msgs]
         # #1652/②: bound native reasoning across the ordered carriers (the strip
         # is in-place, so the shared dicts in head/raw_middle/tail are bounded).
         self._bound_wire_reasoning(head + raw_middle + tail)

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -413,10 +413,16 @@ class RouterHistoryBuffer:
         # actually counted, as opposed to re-deriving a reference number
         # from its returned wire dicts (which cannot detect a regression in
         # THIS computation itself). None-safe: many test/estimation-path
-        # callers construct this buffer with events=None.
+        # callers construct this buffer with events=None. ``total`` /
+        # ``effective_trigger`` are the elide/no-elide decision's own inputs
+        # — no conversation content — matching the 0059 §5 audit-payload
+        # discipline. See the ``elide_evaluated`` witness in
+        # ``tests/test_2957_prb_elide_advisor_token_unification.py`` for why
+        # exercising this requires an UNRESOLVABLE path-ref image fixture,
+        # not an ordinary inline one.
         if self._events is not None:
             self._events.emit(
-                "history_elide_total_computed",
+                "elide_evaluated",
                 total=total, effective_trigger=effective_trigger,
             )
 

--- a/src/reyn/runtime/services/router_history_buffer.py
+++ b/src/reyn/runtime/services/router_history_buffer.py
@@ -331,7 +331,7 @@ class RouterHistoryBuffer:
         remains Reyn-internal and is filtered out.
         """
         from reyn.services.compaction.engine import (
-            estimate_tokens_for_turn,
+            estimate_tokens_for_any_turn,
             trim_head,
             trim_tail,
         )
@@ -390,16 +390,21 @@ class RouterHistoryBuffer:
         # UP FRONT, then measure/trim/select on THAT — the canonical quantity
         # (see ``_serialise_turn``'s docstring). Before PR-B this elide-
         # threshold total summed the pre-serialise ChatMessage instances
-        # (via the now-removed ``estimate_tokens_for_any_turn`` adapter),
-        # while ContextBudgetAdvisor measured this method's returned (post-
-        # serialise) wire dicts — two different quantities for the same
-        # conversation. Serialising once here and reusing the result for
-        # both the total-check AND the final return also avoids a double
+        # (via ``estimate_tokens_for_any_turn``'s ChatMessage-adapting
+        # branch), while ContextBudgetAdvisor measured this method's
+        # returned (post-serialise) wire dicts — two different quantities
+        # for the same conversation. Both now go through
+        # ``estimate_tokens_for_any_turn`` on the SAME wire dicts (the dict
+        # branch is still needed here, not a direct
+        # ``estimate_tokens_for_turn`` call — a wire dict's ``tool_calls``
+        # is a separate top-level key, see that function's docstring).
+        # Serialising once here and reusing the result for both the
+        # total-check AND the final return also avoids a double
         # ``_serialise_turn`` call on the surviving subset.
         wire_turns = [self._serialise_turn(m) for m in turns]
 
         total = sum(
-            estimate_tokens_for_turn(wt, self._model, use_chars4=use_chars4)
+            estimate_tokens_for_any_turn(wt, self._model, use_chars4=use_chars4)
             for wt in wire_turns
         )
 
@@ -450,7 +455,7 @@ class RouterHistoryBuffer:
         and retry_loop's shrink can still trim ``head``.
         """
         from reyn.services.compaction.engine import (
-            estimate_tokens_for_turn,
+            estimate_tokens_for_any_turn,
             trim_head,
             trim_tail,
         )
@@ -470,7 +475,7 @@ class RouterHistoryBuffer:
         wire_turns = [self._serialise_turn(m) for m in turns]
 
         total = sum(
-            estimate_tokens_for_turn(wt, self._model, use_chars4=use_chars4)
+            estimate_tokens_for_any_turn(wt, self._model, use_chars4=use_chars4)
             for wt in wire_turns
         )
 

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -241,11 +241,10 @@ def estimate_tokens_for_any_turn(
 
     ``estimate_tokens_for_turn`` stays dict-only by design (its ``turn.get(...)``
     shape mirrors the compactor's dict turns and the post-``_serialise_turn``
-    wire dicts ``retry_loop`` counts). But ``trim_head``/``trim_tail`` (via
-    ``_trim_groups`` below) and the elide-threshold sum in
-    ``RouterHistoryBuffer.build_history`` / ``decompose_history_for_retry`` are
-    called with *live* ``ChatMessage`` instances, which are not dicts —
-    ``isinstance(turn, dict)`` was False, so every such turn silently fell to
+    wire dicts ``retry_loop`` counts). ``trim_head``/``trim_tail`` (via
+    ``_trim_groups`` below) can be called with *live* ``ChatMessage``
+    instances, which are not dicts — ``isinstance(turn, dict)`` is False, so
+    without this adapter every such turn would silently fall to
     ``estimate_tokens_for_turn``'s ``content is None`` fallback branch,
     undercounting images (``_IMAGE_FIXED_TOKEN_COST`` never applied) and
     ignoring ``tool_calls`` entirely.
@@ -258,9 +257,25 @@ def estimate_tokens_for_any_turn(
     existing "unknown part type -> JSON-repr" branch counts them, rather than
     adding a new branch inside ``estimate_tokens_for_turn`` itself.
 
-    Removable in PR-B: once the elide and advisor paths both measure the same
-    post-``_serialise_turn`` wire dict, every call site converges on plain
-    dicts and this adapter (and its call sites) can be deleted.
+    #2957 PR-B status: ``RouterHistoryBuffer.build_history`` /
+    ``decompose_history_for_retry`` (the elide side of the PR-A/PR-B
+    circularity) no longer call this — they now serialise every candidate
+    turn to its wire-dict shape UP FRONT and call
+    ``estimate_tokens_for_turn`` directly on the wire dicts (the same
+    quantity ``ContextBudgetAdvisor`` measures), which is what closed the
+    elide-vs-advisor mismatch. This adapter is NOT fully removable, though:
+    ``CompactionController._select_candidates`` still calls ``trim_head`` /
+    ``trim_tail`` with live ``ChatMessage`` instances (dispatching here via
+    ``_trim_groups``) because candidate selection needs each turn's
+    ``ChatMessage.seq`` to survive identity-based filtering against
+    ``prev_cover`` — a wire dict has no ``seq`` field, so converting that
+    call site to wire dicts would break the candidate-selection contract.
+    That is a distinct concern from the elide/advisor accounting this PR
+    unifies (compaction-candidate selection vs. context-window budgeting),
+    so it stays out of scope for #2957 PR-B; this adapter remains the
+    dispatcher ``_trim_groups`` uses for that one remaining ChatMessage
+    call site (dict turns still pass straight through to
+    ``estimate_tokens_for_turn`` unchanged).
     """
     if isinstance(turn, dict):
         return estimate_tokens_for_turn(turn, model, use_chars4=use_chars4)
@@ -667,9 +682,12 @@ def _trim_groups(groups: "list[list]", max_tokens: int, model: str, use_chars4: 
     kept: list[list] = []
     total = 0
     for group in groups:
-        # #2957 PR-A: turns here are ChatMessage instances in every real
-        # caller (RouterHistoryBuffer, CompactionController) — use the
-        # type-adapting wrapper, not estimate_tokens_for_turn directly.
+        # #2957 PR-A/PR-B: dispatches to estimate_tokens_for_turn for dict
+        # turns (RouterHistoryBuffer's wire dicts, post PR-B) and adapts
+        # live ChatMessage instances (CompactionController's candidate
+        # selection, which still needs ChatMessage.seq downstream — see
+        # estimate_tokens_for_any_turn's docstring for why that call site
+        # cannot convert to wire dicts).
         g_tokens = sum(
             estimate_tokens_for_any_turn(t, model, use_chars4=use_chars4) for t in group
         )

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -237,62 +237,86 @@ def estimate_tokens_for_any_turn(
     *,
     use_chars4: bool = False,
 ) -> int:
-    """#2957 PR-A thin call-site adapter — NOT part of ``estimate_tokens_for_turn``.
+    """#2957 PR-A/PR-B: the general canonical accounting entrypoint for a
+    turn in EITHER shape — a live ``ChatMessage`` OR an already-serialised
+    litellm wire dict (``_serialise_turn``'s output). NOT part of
+    ``estimate_tokens_for_turn`` (kept dict-only + byte-unchanged by design
+    — its ``turn.get("content")`` shape mirrors the compactor's dict turns).
 
-    ``estimate_tokens_for_turn`` stays dict-only by design (its ``turn.get(...)``
-    shape mirrors the compactor's dict turns and the post-``_serialise_turn``
-    wire dicts ``retry_loop`` counts). ``trim_head``/``trim_tail`` (via
-    ``_trim_groups`` below) can be called with *live* ``ChatMessage``
-    instances, which are not dicts — ``isinstance(turn, dict)`` is False, so
-    without this adapter every such turn would silently fall to
-    ``estimate_tokens_for_turn``'s ``content is None`` fallback branch,
-    undercounting images (``_IMAGE_FIXED_TOKEN_COST`` never applied) and
-    ignoring ``tool_calls`` entirely.
+    Two independent gaps this adapter closes, both because
+    ``estimate_tokens_for_turn`` only ever looks at a dict's ``"content"``
+    key:
 
-    This adapter builds the dict shape ``estimate_tokens_for_turn`` expects
-    WITHOUT running ``_serialise_turn``'s path-ref -> base64 materialisation
-    (doing that would defeat the point of the fixed image cost, which exists
-    precisely so counting never has to touch image bytes). ``tool_calls`` is
-    folded in as extra content parts of an unrecognised ``type`` so the
-    existing "unknown part type -> JSON-repr" branch counts them, rather than
-    adding a new branch inside ``estimate_tokens_for_turn`` itself.
+    - **ChatMessage input** (PR-A): ``isinstance(turn, dict)`` is False for a
+      live ``ChatMessage``, so every such turn used to fall through to
+      ``estimate_tokens_for_turn``'s ``content is None`` fallback branch —
+      undercounting images (``_IMAGE_FIXED_TOKEN_COST`` never applied) and
+      ignoring ``tool_calls`` entirely.
+    - **wire-dict input with top-level tool_calls** (PR-B, discovered while
+      unifying the elide/advisor accounting): ``_serialise_turn`` puts
+      ``tool_calls`` in a SEPARATE top-level wire-dict key (matching the
+      real litellm request shape — see that method), not inside
+      ``"content"``. A wire dict is a dict, so PR-A's original
+      ``isinstance(turn, dict): return estimate_tokens_for_turn(turn, ...)``
+      passthrough silently re-dropped ``tool_calls`` for exactly the wire
+      dicts PR-B's unification now measures directly — the same class of
+      undercount PR-A fixed for ChatMessage input, reappearing one call
+      shape later. Both branches below fold ``tool_calls`` into extra
+      content parts identically (of an unrecognised ``type``, so the
+      existing "unknown part type -> JSON-repr" branch in
+      ``estimate_tokens_for_turn`` counts them) WITHOUT running
+      ``_serialise_turn``'s path-ref -> base64 materialisation (doing that
+      would defeat the point of the fixed image cost, which exists
+      precisely so counting never has to touch image bytes).
 
-    #2957 PR-B status: ``RouterHistoryBuffer.build_history`` /
-    ``decompose_history_for_retry`` (the elide side of the PR-A/PR-B
-    circularity) no longer call this — they now serialise every candidate
-    turn to its wire-dict shape UP FRONT and call
-    ``estimate_tokens_for_turn`` directly on the wire dicts (the same
-    quantity ``ContextBudgetAdvisor`` measures), which is what closed the
-    elide-vs-advisor mismatch. This adapter is NOT fully removable, though:
-    ``CompactionController._select_candidates`` still calls ``trim_head`` /
-    ``trim_tail`` with live ``ChatMessage`` instances (dispatching here via
-    ``_trim_groups``) because candidate selection needs each turn's
-    ``ChatMessage.seq`` to survive identity-based filtering against
-    ``prev_cover`` — a wire dict has no ``seq`` field, so converting that
-    call site to wire dicts would break the candidate-selection contract.
-    That is a distinct concern from the elide/advisor accounting this PR
-    unifies (compaction-candidate selection vs. context-window budgeting),
-    so it stays out of scope for #2957 PR-B; this adapter remains the
-    dispatcher ``_trim_groups`` uses for that one remaining ChatMessage
-    call site (dict turns still pass straight through to
-    ``estimate_tokens_for_turn`` unchanged).
+    A dict WITHOUT a ``"content"`` key (the compactor-input shape —
+    ``{"text": ..., "seq": ..., ...}``, ``estimate_tokens_for_turn``'s own
+    "text" fallback branch) passes through UNCHANGED even if it happens to
+    carry a ``"tool_calls"`` sibling key — folding would silently discard
+    its ``"text"`` payload. Only a dict WITH a ``"content"`` key (a genuine
+    wire dict) gets the fold.
+
+    Used by every canonical-accounting call site: ``RouterHistoryBuffer.
+    build_history`` / ``decompose_history_for_retry`` (wire dicts, post
+    PR-B), ``ContextBudgetAdvisor._incremental_history_tokens`` (the same
+    wire dicts, via ``build_history``), and ``trim_head``/``trim_tail`` (via
+    ``_trim_groups`` below — dict turns from the router path, live
+    ``ChatMessage`` turns from ``CompactionController._select_candidates``,
+    which needs each turn's ``ChatMessage.seq`` to survive identity-based
+    filtering against ``prev_cover`` and so cannot convert to wire dicts).
+    NOT removable — it is the shared dispatcher every caller measuring
+    "what does the provider actually see" goes through, regardless of which
+    of the two live shapes (ChatMessage / wire dict) it holds.
     """
     if isinstance(turn, dict):
-        return estimate_tokens_for_turn(turn, model, use_chars4=use_chars4)
-
-    content = getattr(turn, "content", None)
-    tool_calls = getattr(turn, "tool_calls", None)
-    if tool_calls:
-        parts = list(content) if isinstance(content, list) else (
-            [{"type": "text", "text": content}] if content else []
-        )
-        parts = parts + [
-            {"type": "tool_call", "tool_call": tc} for tc in tool_calls
-        ]
-        adapted: dict = {"content": parts}
+        # Only a genuine litellm WIRE dict (``_serialise_turn``'s output,
+        # which always sets a "content" key — see that method) gets the
+        # tool_calls fold below. A dict WITHOUT a "content" key is the
+        # compactor-input shape (``{"text": ..., "seq": ..., ...}`` —
+        # ``estimate_tokens_for_turn``'s own "text" fallback branch), which
+        # may carry "tool_calls" as an unrelated sibling metadata field —
+        # folding would silently discard its "text" payload. Passthrough
+        # unchanged for that shape, exactly PR-A's original dict contract.
+        if "content" not in turn:
+            return estimate_tokens_for_turn(turn, model, use_chars4=use_chars4)
+        content = turn.get("content")
+        tool_calls = turn.get("tool_calls")
     else:
-        adapted = {"content": content}
-    return estimate_tokens_for_turn(adapted, model, use_chars4=use_chars4)
+        content = getattr(turn, "content", None)
+        tool_calls = getattr(turn, "tool_calls", None)
+
+    if not tool_calls:
+        if isinstance(turn, dict):
+            return estimate_tokens_for_turn(turn, model, use_chars4=use_chars4)
+        return estimate_tokens_for_turn({"content": content}, model, use_chars4=use_chars4)
+
+    parts = list(content) if isinstance(content, list) else (
+        [{"type": "text", "text": content}] if content else []
+    )
+    parts = parts + [
+        {"type": "tool_call", "tool_call": tc} for tc in tool_calls
+    ]
+    return estimate_tokens_for_turn({"content": parts}, model, use_chars4=use_chars4)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_2957_prb_elide_advisor_token_unification.py
+++ b/tests/test_2957_prb_elide_advisor_token_unification.py
@@ -54,7 +54,10 @@ _MODEL = "gpt-3.5-turbo"
 def _make_pair(history: list[ChatMessage], *, media_store=None, use_chars4: bool = True):
     """Real RouterHistoryBuffer + real ContextBudgetAdvisor wired exactly as
     production wires them (ContextBudgetAdvisor.history_fn = build_history —
-    see that class's own module docstring)."""
+    see that class's own module docstring). Returns (buf, advisor, events) —
+    the shared EventLog is exposed so a caller can observe build_history's
+    own internal ``history_elide_total_computed`` audit-event (see
+    ``test_elide_total_advisor_and_reference_three_way_agree`` below)."""
     cfg = CompactionConfig(use_chars4_estimate=use_chars4)
     events = EventLog()
     buf = RouterHistoryBuffer(
@@ -76,7 +79,7 @@ def _make_pair(history: list[ChatMessage], *, media_store=None, use_chars4: bool
         events=events,
         history_fn=buf.build_history,
     )
-    return buf, advisor
+    return buf, advisor, events
 
 
 def _canonical_reference_tokens(wire_turns: list[dict], use_chars4: bool) -> int:
@@ -115,7 +118,7 @@ def test_image_bearing_conversation_elide_and_advisor_agree():
         ),
         ChatMessage(role="assistant", content="ok", seq=3),
     ]
-    buf, advisor = _make_pair(history)
+    buf, advisor, _events = _make_pair(history)
 
     wire = buf.build_history()
     assert len(wire) == len(history), "sanity: small conversation must not elide"
@@ -160,7 +163,7 @@ def test_tool_calls_bearing_conversation_elide_and_advisor_agree():
         ),
         ChatMessage(role="tool", content="result", tool_call_id="t1", name="big_tool", seq=3),
     ]
-    buf, advisor = _make_pair(history)
+    buf, advisor, _events = _make_pair(history)
 
     wire = buf.build_history()
     advisor_tokens = advisor._incremental_history_tokens()
@@ -199,7 +202,7 @@ def test_post_elide_advisor_matches_canonical_recompute_of_the_elided_output(mon
         )
 
     history = [_big_image(i) for i in range(1, 9)]
-    buf, advisor = _make_pair(history)
+    buf, advisor, _events = _make_pair(history)
 
     wire = buf.build_history()
     assert len(wire) < len(history), "test premise: this conversation must actually elide"
@@ -236,7 +239,7 @@ def test_pathref_and_materialised_image_count_identically(tmp_path):
     history_pathref = [
         ChatMessage(role="user", content=[{"type": "text", "text": "look"}, pathref_block], seq=1),
     ]
-    buf_pathref, advisor_pathref = _make_pair(history_pathref, media_store=store)
+    buf_pathref, advisor_pathref, _events_pathref = _make_pair(history_pathref, media_store=store)
     wire_pathref = buf_pathref.build_history()
     assert wire_pathref[0]["content"][1]["type"] == "image_url", (
         "sanity: build_history's real _serialise_turn must have materialised it"
@@ -247,11 +250,87 @@ def test_pathref_and_materialised_image_count_identically(tmp_path):
     history_inline = [
         ChatMessage(role="user", content=[{"type": "text", "text": "look"}, materialised_block], seq=1),
     ]
-    buf_inline, advisor_inline = _make_pair(history_inline, media_store=None)
+    buf_inline, advisor_inline, _events_inline = _make_pair(history_inline, media_store=None)
     wire_inline = buf_inline.build_history()
     tokens_inline = advisor_inline._incremental_history_tokens()
 
     assert tokens_pathref == tokens_inline, (
         f"path-ref ({tokens_pathref}) and already-materialised ({tokens_inline}) "
         f"forms of the identical image must count identically"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Co-vet follow-up — observe elide's OWN internal total, not just a
+#    test-side reference recomputed from its returned wire dicts
+# ---------------------------------------------------------------------------
+
+
+def test_elide_total_advisor_and_reference_three_way_agree():
+    """Tier 2: witness 5 — closes a gap in witnesses 1-4: those compare
+    ``advisor_tokens == _canonical_reference_tokens(wire)``, which is a
+    comparison between the advisor and a TEST-SIDE reference recomputed
+    from build_history's returned wire dicts — it never observes what
+    ``build_history`` itself counted internally to make its elide/no-elide
+    decision.
+
+    Content choice matters here, not just the observation point: an
+    image_url/tool_calls fixture (witnesses 1-2's content) turns out NOT to
+    discriminate a reverted elide-side total, because
+    ``estimate_tokens_for_any_turn`` already produces the IDENTICAL number
+    for a raw ``ChatMessage`` and its serialised wire dict in that case (by
+    design — that's what makes the adapter correct for both shapes). This
+    test instead uses an UNRESOLVABLE path-ref image
+    (``{"type": "image", "path": <nonexistent file>}``): the raw
+    ``ChatMessage`` counts a full ``_IMAGE_FIXED_TOKEN_COST`` "phantom"
+    image that will NEVER reach the provider, while ``_serialise_turn``
+    DROPS the unresolvable block entirely (see
+    ``_materialise_path_ref_content`` / ``_read_pathref_image`` — a missing
+    file returns ``None`` and the content part is omitted) — so the wire
+    dict genuinely has fewer tokens than the raw ChatMessage. This is a
+    real, content-driven divergence between serialise-INPUT and
+    serialise-OUTPUT counting, not just an architectural symmetry — exactly
+    the class of case #2957 PR-B's "measure the canonical wire quantity"
+    design decision is FOR.
+
+    ``build_history`` emits its internal total as a public P6 audit-event
+    (``history_elide_total_computed`` — see that method) precisely so this
+    is observable without touching private state (CLAUDE.md: no private-
+    state assertions). This test asserts the 3-way agreement: elide's own
+    emitted total == advisor's measurement == the canonical reference.
+    """
+    history = [
+        ChatMessage(
+            role="user",
+            content=[
+                {"type": "text", "text": "look"},
+                {"type": "image", "path": "/nonexistent/2957-prb-witness/does-not-exist.png",
+                 "mime_type": "image/png"},
+            ],
+            seq=1,
+        ),
+    ]
+    buf, advisor, events = _make_pair(history, media_store=None)
+
+    wire = buf.build_history()
+    assert wire[0]["content"] == [{"type": "text", "text": "look"}], (
+        "test premise: the unresolvable path-ref block must be DROPPED at "
+        "serialise time, so the wire dict is strictly smaller than the raw "
+        "ChatMessage's content"
+    )
+
+    elide_events = [e for e in events.all() if e.type == "history_elide_total_computed"]
+    assert elide_events, (
+        "build_history must emit its internal elide-threshold total as a "
+        "public audit-event — without this, elide's own accounting is "
+        "unobservable from outside private state"
+    )
+    elide_total = elide_events[-1].data["total"]
+
+    advisor_tokens = advisor._incremental_history_tokens()
+    reference = _canonical_reference_tokens(wire, use_chars4=True)
+
+    assert elide_total == advisor_tokens == reference, (
+        f"3-way mismatch: elide's own total={elide_total}, "
+        f"advisor={advisor_tokens}, reference={reference}"
     )

--- a/tests/test_2957_prb_elide_advisor_token_unification.py
+++ b/tests/test_2957_prb_elide_advisor_token_unification.py
@@ -56,7 +56,7 @@ def _make_pair(history: list[ChatMessage], *, media_store=None, use_chars4: bool
     production wires them (ContextBudgetAdvisor.history_fn = build_history —
     see that class's own module docstring). Returns (buf, advisor, events) —
     the shared EventLog is exposed so a caller can observe build_history's
-    own internal ``history_elide_total_computed`` audit-event (see
+    own internal ``elide_evaluated`` audit-event (see
     ``test_elide_total_advisor_and_reference_three_way_agree`` below)."""
     cfg = CompactionConfig(use_chars4_estimate=use_chars4)
     events = EventLog()
@@ -294,10 +294,29 @@ def test_elide_total_advisor_and_reference_three_way_agree():
     design decision is FOR.
 
     ``build_history`` emits its internal total as a public P6 audit-event
-    (``history_elide_total_computed`` — see that method) precisely so this
+    (``elide_evaluated`` — see that method) precisely so this
     is observable without touching private state (CLAUDE.md: no private-
     state assertions). This test asserts the 3-way agreement: elide's own
     emitted total == advisor's measurement == the canonical reference.
+
+    ★ DO NOT "clean up" this fixture to an ordinary resolvable image. An
+    unresolvable path-ref is the ONLY content shape this witness has found
+    that discriminates a reverted elide-side total (confirmed by
+    strip-falsify — reverting build_history's total to measure raw
+    ChatMessage input turns this RED with the fixture above; with a plain
+    resolvable image_url/tool_calls fixture instead, strip-falsify stays
+    GREEN — the removal path this fixture exercises is never even reached,
+    making the witness vacuous). This is worth the co-vet finding on WHY
+    it matters beyond "the test happens to need it": an unresolvable media
+    reference (deleted file, GC'd media dir, workspace move, branch
+    switch) is MORE likely the longer a conversation runs, is silently
+    dropped by ``_materialise_path_ref_content`` (no error, no event of
+    its own), and the wrong-direction failure mode is the dangerous one —
+    counting a phantom image inflates the elide total, which means
+    OVER-eliding: real, still-relevant history gets dropped that didn't
+    need to be. Swapping this fixture for a resolvable image would make
+    the test pass for the wrong reason (never exercising the drop path at
+    all) while looking, to a future reader, like an equivalent test.
     """
     history = [
         ChatMessage(
@@ -319,7 +338,7 @@ def test_elide_total_advisor_and_reference_three_way_agree():
         "ChatMessage's content"
     )
 
-    elide_events = [e for e in events.all() if e.type == "history_elide_total_computed"]
+    elide_events = [e for e in events.all() if e.type == "elide_evaluated"]
     assert elide_events, (
         "build_history must emit its internal elide-threshold total as a "
         "public audit-event — without this, elide's own accounting is "

--- a/tests/test_2957_prb_elide_advisor_token_unification.py
+++ b/tests/test_2957_prb_elide_advisor_token_unification.py
@@ -1,0 +1,257 @@
+"""Tier 2: #2957 PR-B — elide-side and advisor-side token accounting unified
+on the ``_serialise_turn`` wire-dict canonical.
+
+Before PR-B, ``RouterHistoryBuffer.build_history`` measured its elide-
+threshold total over raw ChatMessage instances (serialise-INPUT) while
+``ContextBudgetAdvisor._incremental_history_tokens`` measured
+``json.dumps(build_history()'s own output)`` (serialise-OUTPUT) — two
+different quantities for the same conversation, with the advisor's
+json.dumps additionally counting an inlined image's FULL base64 payload as
+text instead of the ``_IMAGE_FIXED_TOKEN_COST`` fixed cost the elide side
+(post #2957 PR-A) applied. PR-B makes both sides sum
+``estimate_tokens_for_turn`` over the SAME wire dicts (``_serialise_turn``'s
+output).
+
+Per the co-vet addendum on this PR: a naive "same function on the same
+input" consistency assertion is a tautology that stays green even if the
+unification were reverted, UNLESS it is exercised on inputs where the two
+PRE-PR-B measurement schemes would actually have disagreed. Every test below
+targets one such condition:
+
+  1. an image-bearing conversation (base64 payload vs fixed cost — the #2957
+     PR-A gap, now closed on BOTH sides)
+  2. a tool_calls-bearing conversation (ignored entirely by the pre-PR-A/
+     pre-PR-B json.dumps-agnostic paths in one shape or another)
+  3. a conversation that actually ELIDES (proves the circularity is closed —
+     the advisor's number reflects the POST-elide reality, not a stale
+     pre-elide figure, and still matches a from-scratch canonical recompute
+     over that same post-elide output)
+  4. the SAME image content before vs after path-ref materialisation (an
+     un-materialised ``{"type":"image",...}`` path-ref part and its
+     materialised ``{"type":"image_url",...}`` data-URL form must count
+     IDENTICALLY — both hit the same fixed-cost branch)
+
+Real ``RouterHistoryBuffer`` + real ``ContextBudgetAdvisor`` + real
+``ChatMessage`` + real ``MediaStore`` throughout — no fakes (#2957 PR-A's own
+lesson: a hand-rolled ``_FakeMessage`` hid a real production bug).
+"""
+from __future__ import annotations
+
+from reyn.config import CompactionConfig
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.media_store import MediaStore, MediaStoreConfig
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
+from reyn.runtime.services.router_history_buffer import RouterHistoryBuffer
+from reyn.services.compaction.engine import (
+    _IMAGE_FIXED_TOKEN_COST,
+    estimate_tokens_for_any_turn,
+)
+
+_MODEL = "gpt-3.5-turbo"
+
+
+def _make_pair(history: list[ChatMessage], *, media_store=None, use_chars4: bool = True):
+    """Real RouterHistoryBuffer + real ContextBudgetAdvisor wired exactly as
+    production wires them (ContextBudgetAdvisor.history_fn = build_history —
+    see that class's own module docstring)."""
+    cfg = CompactionConfig(use_chars4_estimate=use_chars4)
+    events = EventLog()
+    buf = RouterHistoryBuffer(
+        history_fn=lambda: history,
+        compaction=cfg,
+        compaction_controller=None,  # → get_max_input_tokens fallback path
+        model_fn=lambda: _MODEL,
+        events=events,
+        media_store=media_store,
+        router_host=None,
+        action_retrieval=None,
+        non_interactive=True,
+    )
+    advisor = ContextBudgetAdvisor(
+        compaction=cfg,
+        compaction_controller=None,
+        media_store=media_store,
+        model_fn=lambda: _MODEL,
+        events=events,
+        history_fn=buf.build_history,
+    )
+    return buf, advisor
+
+
+def _canonical_reference_tokens(wire_turns: list[dict], use_chars4: bool) -> int:
+    """From-scratch sum of estimate_tokens_for_any_turn over already-
+    serialised wire dicts — the canonical quantity both build_history's
+    elide-threshold check and the advisor are supposed to converge on.
+    estimate_tokens_for_any_turn (not the dict-only estimate_tokens_for_turn
+    directly) is required because a wire dict's tool_calls lives in a
+    separate top-level key, not inside "content"."""
+    return sum(
+        estimate_tokens_for_any_turn(w, _MODEL, use_chars4=use_chars4) for w in wire_turns
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Image-bearing conversation, no elide
+# ---------------------------------------------------------------------------
+
+
+def test_image_bearing_conversation_elide_and_advisor_agree():
+    """Tier 2: witness 1 — an image-bearing conversation. The advisor's
+    number must equal a from-scratch canonical recompute over
+    build_history's own output, AND must be near the small fixed-cost
+    regime (proving it is NOT counting the base64 payload as text — the
+    pre-PR-B advisor bug)."""
+    big_b64 = "x" * 40_000  # a real base64 payload would dwarf any fixed cost
+    history = [
+        ChatMessage(role="user", content="hi", seq=1),
+        ChatMessage(
+            role="user",
+            content=[
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{big_b64}"}},
+            ],
+            seq=2,
+        ),
+        ChatMessage(role="assistant", content="ok", seq=3),
+    ]
+    buf, advisor = _make_pair(history)
+
+    wire = buf.build_history()
+    assert len(wire) == len(history), "sanity: small conversation must not elide"
+
+    advisor_tokens = advisor._incremental_history_tokens()
+    reference = _canonical_reference_tokens(wire, use_chars4=True)
+
+    assert advisor_tokens == reference, (
+        f"advisor ({advisor_tokens}) must match the canonical wire-dict "
+        f"recompute ({reference})"
+    )
+    # Falsifies the pre-PR-B json.dumps(combined) advisor scheme: that would
+    # have counted len(big_b64)//4 ≈ 10_000 tokens for the base64 text alone,
+    # dwarfing the fixed-cost regime this assertion pins.
+    assert advisor_tokens < len(big_b64) // 4, (
+        f"advisor_tokens={advisor_tokens} looks like it counted the base64 "
+        f"payload as text (pre-PR-B bug), not the fixed image cost"
+    )
+    assert advisor_tokens >= _IMAGE_FIXED_TOKEN_COST
+
+
+# ---------------------------------------------------------------------------
+# 2. tool_calls-bearing conversation
+# ---------------------------------------------------------------------------
+
+
+def test_tool_calls_bearing_conversation_elide_and_advisor_agree():
+    """Tier 2: witness 2 — an assistant turn with tool_calls and no text.
+    Falsifies a scheme where tool_calls are dropped from one side's count:
+    both sides must reflect the tool_calls payload identically."""
+    big_args = "y" * 5000
+    history = [
+        ChatMessage(role="user", content="run the tool", seq=1),
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                {"id": "t1", "type": "function",
+                 "function": {"name": "big_tool", "arguments": big_args}},
+            ],
+            seq=2,
+        ),
+        ChatMessage(role="tool", content="result", tool_call_id="t1", name="big_tool", seq=3),
+    ]
+    buf, advisor = _make_pair(history)
+
+    wire = buf.build_history()
+    advisor_tokens = advisor._incremental_history_tokens()
+    reference = _canonical_reference_tokens(wire, use_chars4=True)
+
+    assert advisor_tokens == reference
+    # Falsifies "tool_calls ignored" — the arguments payload must actually
+    # contribute (chars4 estimate of ~5000 chars is well over a few tokens).
+    assert advisor_tokens > 1000, (
+        f"advisor_tokens={advisor_tokens} looks like it ignored tool_calls"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Post-elide: the circularity witness
+# ---------------------------------------------------------------------------
+
+
+def test_post_elide_advisor_matches_canonical_recompute_of_the_elided_output(monkeypatch):
+    """Tier 2: witness 3 — history large enough to actually ELIDE. This is
+    the direct witness that the elide-side/advisor-side circularity is
+    closed: pre-PR-B the advisor measured build_history's OUTPUT (already
+    elided) while build_history's own trigger decision measured a DIFFERENT
+    quantity (pre-serialise ChatMessage) — this test proves that after
+    elide fires, the advisor's number is still an exact canonical recompute
+    of what actually survived."""
+    import reyn.llm.model_budget as _mb
+
+    monkeypatch.setattr(_mb, "get_max_input_tokens", lambda *a, **kw: _IMAGE_FIXED_TOKEN_COST)
+
+    def _big_image(seq: int) -> ChatMessage:
+        return ChatMessage(
+            role="user",
+            content=[{"type": "image_url", "image_url": {"url": "data:image/png;base64," + "z" * 200}}],
+            seq=seq,
+        )
+
+    history = [_big_image(i) for i in range(1, 9)]
+    buf, advisor = _make_pair(history)
+
+    wire = buf.build_history()
+    assert len(wire) < len(history), "test premise: this conversation must actually elide"
+
+    advisor_tokens = advisor._incremental_history_tokens()
+    reference = _canonical_reference_tokens(wire, use_chars4=True)
+    assert advisor_tokens == reference, (
+        f"post-elide: advisor ({advisor_tokens}) must equal the canonical "
+        f"recompute over the ACTUALLY-SURVIVING wire dicts ({reference}) — "
+        f"a stale pre-elide total would diverge from this"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Materialisation boundary: path-ref vs inline data URL count identically
+# ---------------------------------------------------------------------------
+
+
+def test_pathref_and_materialised_image_count_identically(tmp_path):
+    """Tier 2: witness 4 — the SAME image, once as an un-materialised
+    path-ref (``{"type":"image","path":...}``) and once already inline
+    (``{"type":"image_url",...}``), must produce IDENTICAL wire-dict token
+    counts. Both hit ``estimate_tokens_for_turn``'s fixed-cost branch
+    (``"image"`` and ``"image_url"`` are both members of that branch's type
+    set) — proves the canonical measure does not depend on whether
+    materialisation has already run, so serialising for measurement
+    purposes is safe regardless of which state a turn's content is in.
+    """
+    store = MediaStore(MediaStoreConfig(), project_root=tmp_path)
+    raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 200
+    pathref_block = store.save_image(raw, mime_type="image/png", tool="test", seq=1)
+    assert pathref_block["type"] == "image"  # sanity: genuinely un-materialised
+
+    history_pathref = [
+        ChatMessage(role="user", content=[{"type": "text", "text": "look"}, pathref_block], seq=1),
+    ]
+    buf_pathref, advisor_pathref = _make_pair(history_pathref, media_store=store)
+    wire_pathref = buf_pathref.build_history()
+    assert wire_pathref[0]["content"][1]["type"] == "image_url", (
+        "sanity: build_history's real _serialise_turn must have materialised it"
+    )
+    tokens_pathref = advisor_pathref._incremental_history_tokens()
+
+    materialised_block = wire_pathref[0]["content"][1]
+    history_inline = [
+        ChatMessage(role="user", content=[{"type": "text", "text": "look"}, materialised_block], seq=1),
+    ]
+    buf_inline, advisor_inline = _make_pair(history_inline, media_store=None)
+    wire_inline = buf_inline.build_history()
+    tokens_inline = advisor_inline._incremental_history_tokens()
+
+    assert tokens_pathref == tokens_inline, (
+        f"path-ref ({tokens_pathref}) and already-materialised ({tokens_inline}) "
+        f"forms of the identical image must count identically"
+    )

--- a/tests/test_context_budget_advisor_incremental_history_tokens.py
+++ b/tests/test_context_budget_advisor_incremental_history_tokens.py
@@ -5,15 +5,29 @@ it opens, and maybe_force_compact() calls the same estimate every pre-frame
 overflow check. Both previously re-ran json.dumps(FULL history) + estimate_
 tokens on every single call — O(history size) each time, growing unbounded
 over a long session (the reported freeze). _incremental_history_tokens()
-caches (history length, cumulative estimate) and only dumps+estimates the
-NEW tail slice on growth, returning the cached total unchanged (O(1)) when
-history hasn't grown, and fully recomputing (not silently returning stale
-data) when history SHRINKS (compaction/rewind truncated it).
+caches (history length, cumulative estimate) and only estimates the NEW tail
+slice on growth, returning the cached total unchanged (O(1)) when history
+hasn't grown, and fully recomputing (not silently returning stale data) when
+history SHRINKS (compaction/rewind truncated it).
 
-Real ContextBudgetAdvisor + real estimate_tokens — no mocks. The estimate
-function itself is exact-deterministic for a given text (no LLM call), so
-correctness can be checked by comparing the incremental result against a
-from-scratch computation over the same final history.
+#2957 PR-B: the per-call estimate switched from
+``estimate_tokens(json.dumps(combined_or_delta_slice))`` to summing
+``estimate_tokens_for_any_turn`` PER TURN — the same canonical wire-dict-shaped
+per-turn quantity RouterHistoryBuffer's elide-threshold check now measures
+(closing a prior circularity: elide measured pre-serialise ChatMessage while
+this advisor measured post-serialise json.dumps, two different quantities
+for the same conversation; json.dumps additionally counted an inlined
+image's full base64 payload as text instead of the fixed per-image cost).
+Because per-turn summation is associative (no cross-turn JSON-array
+serialisation), the incremental cache's running total is now mathematically
+IDENTICAL to a from-scratch per-turn sum over the same history — no
+tokenizer merge-boundary drift is possible, unlike the pre-PR-B combined-
+string scheme this file used to have to bound with an empirical tolerance.
+
+Real ContextBudgetAdvisor + real estimate_tokens_for_any_turn — no mocks. The
+estimate function itself is exact-deterministic for a given turn (no LLM
+call), so correctness can be checked by comparing the incremental result
+against a from-scratch per-turn sum over the same final history.
 """
 from __future__ import annotations
 
@@ -21,7 +35,7 @@ import json
 
 from reyn.config import CompactionConfig
 from reyn.runtime.services.context_budget_advisor import ContextBudgetAdvisor
-from reyn.services.compaction.engine import estimate_tokens
+from reyn.services.compaction.engine import estimate_tokens_for_any_turn
 
 
 def _make_advisor(history_fn, *, model: str = "openai/gpt-4o") -> ContextBudgetAdvisor:
@@ -36,57 +50,58 @@ def _make_advisor(history_fn, *, model: str = "openai/gpt-4o") -> ContextBudgetA
 
 
 def _from_scratch_tokens(history: list, model: str) -> int:
-    combined = json.dumps(history, ensure_ascii=False)
-    return estimate_tokens(combined, model, use_chars4=False)
+    return sum(estimate_tokens_for_any_turn(m, model, use_chars4=False) for m in history)
 
 
 def test_unchanged_history_skips_estimate_entirely(monkeypatch) -> None:
     """Tier 2: falsifying — proves the cache HIT path, not just that its
-    output happens to match (a real spy on estimate_tokens, per the #2937
-    counting-spy idiom — a real callable recording per-text call counts in a
-    dict, not a MagicMock, and not a bare len(list)==N format pin). Reopening
-    the dropdown with no new messages since the last call must not
-    re-dump/re-estimate at all. On the pre-#2940 code (always full
-    json.dumps + estimate_tokens) the unchanged-history text would be
-    estimated 3 times, not once."""
+    output happens to match (a real spy on estimate_tokens_for_any_turn, per the
+    #2937 counting-spy idiom — a real callable recording per-turn call
+    counts in a dict, not a MagicMock, and not a bare len(list)==N format
+    pin). Reopening the dropdown with no new messages since the last call
+    must not re-estimate at all. On the pre-#2940 code (always full re-dump
+    + estimate) the unchanged history's turns would be estimated 3 times,
+    not once."""
     counts: dict[str, int] = {}
 
     from reyn.services.compaction import engine as engine_mod
 
-    real = engine_mod.estimate_tokens
+    real = engine_mod.estimate_tokens_for_any_turn
 
-    def _counting_estimate_tokens(text, model, *, use_chars4=False):
-        counts[text] = counts.get(text, 0) + 1
-        return real(text, model, use_chars4=use_chars4)
+    def _counting_estimate_tokens_for_turn(turn, model, *, use_chars4=False):
+        key = json.dumps(turn, ensure_ascii=False)
+        counts[key] = counts.get(key, 0) + 1
+        return real(turn, model, use_chars4=use_chars4)
 
-    monkeypatch.setattr(engine_mod, "estimate_tokens", _counting_estimate_tokens)
+    monkeypatch.setattr(engine_mod, "estimate_tokens_for_any_turn", _counting_estimate_tokens_for_turn)
 
     history = [{"role": "user", "content": "hello"}, {"role": "assistant", "content": "hi"}]
     advisor = _make_advisor(lambda: history)
-    unchanged_text = json.dumps(history, ensure_ascii=False)
+    turn0_key = json.dumps(history[0], ensure_ascii=False)
+    turn1_key = json.dumps(history[1], ensure_ascii=False)
 
     advisor.context_window_status()
-    assert counts.get(unchanged_text) == 1, "first call must estimate once (cold cache)"
+    assert counts.get(turn0_key) == 1, "first call must estimate each turn once (cold cache)"
+    assert counts.get(turn1_key) == 1
 
     advisor.context_window_status()
     advisor.context_window_status()
-    assert counts.get(unchanged_text) == 1, (
-        "repeated calls with unchanged history must NOT call estimate_tokens "
-        "again for the same combined text — this is the O(1) cache-hit path "
-        "the #2940 fix adds"
+    assert counts.get(turn0_key) == 1, (
+        "repeated calls with unchanged history must NOT call estimate_tokens_for_any_turn "
+        "again for the same turns — this is the O(1) cache-hit path the #2940 fix adds"
     )
+    assert counts.get(turn1_key) == 1
 
     new_turn = {"role": "user", "content": "a new turn"}
     history.append(new_turn)
     advisor.context_window_status()
-    delta_text = json.dumps(new_turn, ensure_ascii=False)
-    assert counts.get(delta_text) == 1, (
-        "growth must estimate the NEW tail slice's own text — proves only "
-        "the delta was dumped, not the full (now-longer) history again"
+    new_turn_key = json.dumps(new_turn, ensure_ascii=False)
+    assert counts.get(new_turn_key) == 1, (
+        "growth must estimate the NEW tail slice's own turn — proves only "
+        "the delta was estimated, not the full (now-longer) history again"
     )
-    assert counts.get(json.dumps(history, ensure_ascii=False)) is None, (
-        "the full (post-growth) combined history must NEVER be dumped as one "
-        "unit — only its individual new tail message is"
+    assert counts.get(turn0_key) == 1 and counts.get(turn1_key) == 1, (
+        "the unchanged prefix turns must NEVER be re-estimated on growth"
     )
 
 
@@ -105,32 +120,13 @@ def test_repeated_calls_with_unchanged_history_return_identical_value() -> None:
 
 def test_growing_history_matches_from_scratch_computation() -> None:
     """Tier 2: falsifying — the incremental (cache + tail-slice) path must
-    track a full from-scratch json.dumps+estimate over the final history at
-    every growth step, within a tolerance proportional to message count.
-
-    Exact equality isn't the bound: tokenizing a new message's JSON dump
-    SEPARATELY from the rest of the history can shift subword (BPE) merge
-    decisions right at the fragment boundary relative to tokenizing the
-    whole thing jointly. An earlier revision of this docstring claimed this
-    drift is structurally one-directional (incremental >= from-scratch,
-    "only ever safe, never under") — DISPROVEN by direct measurement: a
-    growing-repeated-phrase history (this test's own fixture) makes
-    tokenizing the pieces SEPARATELY (incremental) MORE token-efficient
-    (fewer tokens) than tokenizing the whole thing JOINTLY (from-scratch),
-    i.e. the incremental estimate UNDER-shoots the from-scratch one by an
-    amount that grows with message count — the reverse of "splitting can
-    only lose cross-boundary merges, so sum(pieces) >= whole." Verified
-    independently of comma/bracket reconstruction — adding the exact
-    missing separator punctuation to the delta text does not close the
-    gap, so this is a genuine cross-boundary BPE tokenization effect, not a
-    punctuation-accounting bug. Realistic multi-turn chat content (varied
-    per-message text, not a single repeated phrase) measured EXACTLY zero
-    drift in the same harness — the failure mode needs unusually
-    repetitive content to manifest — but "always safe" is not something
-    this scheme can guarantee, so the tolerance here is an
-    empirically-bounded allowance in EITHER direction, not a one-sided
-    safety margin. A real bug (double-counted or dropped message) would
-    blow far past this bound, which is what this test exists to catch."""
+    EXACTLY match a from-scratch per-turn sum over the final history at every
+    growth step. #2957 PR-B: unlike the pre-PR-B combined-json.dumps scheme
+    (which could drift at tokenizer merge boundaries when a message was
+    estimated jointly vs. separately from its neighbours), per-turn summation
+    is associative — each turn's estimate never depends on its neighbours —
+    so there is no drift to bound with a tolerance. A real bug (double-
+    counted or dropped turn) breaks exact equality immediately."""
     history: list = []
     advisor = _make_advisor(lambda: history)
 
@@ -139,8 +135,7 @@ def test_growing_history_matches_from_scratch_computation() -> None:
         status = advisor.context_window_status()
         used = status["effective_trigger"] - status["free_window"]
         expected = _from_scratch_tokens(history, "openai/gpt-4o")
-        tolerance = 2 * (i + 1)
-        assert abs(used - expected) <= tolerance, f"diverged at step {i}: {used} vs {expected}"
+        assert used == expected, f"diverged at step {i}: {used} vs {expected}"
 
 
 def test_same_length_but_different_content_recomputes_rather_than_stale(monkeypatch) -> None:
@@ -158,13 +153,14 @@ def test_same_length_but_different_content_recomputes_rather_than_stale(monkeypa
 
     from reyn.services.compaction import engine as engine_mod
 
-    real = engine_mod.estimate_tokens
+    real = engine_mod.estimate_tokens_for_any_turn
 
-    def _counting_estimate_tokens(text, model, *, use_chars4=False):
-        counts[text] = counts.get(text, 0) + 1
-        return real(text, model, use_chars4=use_chars4)
+    def _counting_estimate_tokens_for_turn(turn, model, *, use_chars4=False):
+        key = json.dumps(turn, ensure_ascii=False)
+        counts[key] = counts.get(key, 0) + 1
+        return real(turn, model, use_chars4=use_chars4)
 
-    monkeypatch.setattr(engine_mod, "estimate_tokens", _counting_estimate_tokens)
+    monkeypatch.setattr(engine_mod, "estimate_tokens_for_any_turn", _counting_estimate_tokens_for_turn)
 
     history = [{"role": "user", "content": "original short message"}]
     advisor = _make_advisor(lambda: history)
@@ -205,28 +201,32 @@ def test_shrinking_history_recomputes_rather_than_returning_stale_cache() -> Non
     assert used == expected
 
 
-def test_maybe_force_compact_shares_the_same_incremental_cache(monkeypatch) -> None:
+def test_maybe_force_compact_shares_the_same_incremental_cache() -> None:
     """Tier 2: maybe_force_compact's pre-frame history estimate is the SAME
     incremental path as context_window_status (#2940 fix-class: both call
     sites had the identical full-redump pathology) — a call to one primes
-    the cache the other then hits."""
+    the cache the other then hits.
+
+    Uses a REAL ``CompactionEngine`` (cheaply constructible — literal model
+    string, no network) for ``budgets`` rather than a hand-rolled stand-in,
+    per testing policy (no inventing fields on a faked dataclass — #3037's
+    lesson: this file's own pre-#2957-PR-B revision used a hand-rolled
+    ``_FakeBudgets`` missing ``head_budget``/``tail_budget``, which this PR's
+    SSoT consolidation (``resolve_effective_trigger_and_budgets`` now reads
+    all three) would have silently accepted if left unfixed).
+    """
     import asyncio
+
+    from reyn.core.events.events import EventLog
+    from reyn.services.compaction.engine import CompactionEngine
 
     history = [{"role": "user", "content": "hello world"}]
     advisor = _make_advisor(lambda: history)
 
-    class _FakeBudgets:
-        effective_trigger = 10_000_000  # far above any estimate: never force-compacts
-        new_msg_budget = 10_000_000
-
-    class _FakeEngine:
-        budgets = _FakeBudgets()
-
-        def recompute_budgets(self):
-            pass
+    engine = CompactionEngine(model="openai/gpt-4o", events=EventLog())
 
     class _FakeController:
-        _engine = _FakeEngine()
+        _engine = engine
 
         async def force_compact_now(self):
             raise AssertionError("must not be called — history is far under budget")


### PR DESCRIPTION
**[per-PR-coder]** — Closes #2957

## 問題
`RouterHistoryBuffer.build_history` (elide側) は `build_history`の**入力**(serialise前のChatMessage)を測り、`ContextBudgetAdvisor._incremental_history_tokens`(advisor側) は `build_history`の**出力**(post-serialise wire dict)を`json.dumps`+`estimate_tokens`で測っていた。同じ会話に対し2つの数字が食い違い、advisorはelideの結果を測る後段という循環関係にあった。

## 修正
canonical な量 = `_serialise_turn`の出力(wire dict)。新レイヤは作らず、両者がこの出力を測るだけにした。

- `RouterHistoryBuffer.build_history` / `decompose_history_for_retry`: 全候補turnを**先にserialise**し、elide閾値判定・trim_head/trim_tail・最終returnすべてをwire dict上で行う(二重serialiseも解消)。
- `ContextBudgetAdvisor._incremental_history_tokens`: `json.dumps(combined)+estimate_tokens` → **per-turn** `estimate_tokens_for_any_turn`の総和に変更(#2940のインクリメンタルキャッシュ構造は維持)。
- `effective_trigger`/`head_budget`/`tail_budget`解決を `resolve_effective_trigger_and_budgets`(router_history_buffer.py の module-level 関数)に一本化。`RouterHistoryBuffer._resolve_budgets` と `ContextBudgetAdvisor._get_effective_trigger` の両方がこれに委譲(重複実装だったものを単一SSoTに)。

## 適応層(`estimate_tokens_for_any_turn`)は削除できませんでした
設計では「PR-Bで削除可能」とされていましたが、実装中に**2つの理由**で削除不能と判明しました:

1. **`CompactionController._select_candidates`** は `trim_head`/`trim_tail` に**生ChatMessage**を渡し続ける必要がある — `.seq`によるidentityベースのcandidate選定(`prev_cover`との比較)を要求するため。wire dictには`seq`フィールドがなく、この呼び出し元をwire dict化すると候補選定の契約が壊れる。これはelide/advisorの循環とは別の関心事(compaction候補選定 vs コンテキストウィンドウ予算)であり、本PRのスコープ外と判断。
2. **新発見**: `_serialise_turn`が生成するwire dictは`tool_calls`を**トップレベルの別キー**として持つ(実際のlitellm wireシェイプ)。`estimate_tokens_for_turn`は`"content"`しか見ないため、wire dictをそのまま渡すと`tool_calls`が再び無視される — PR-Aが修正したのと同種のバグが別の呼び出し形状で再発した。これは自分で書いたwitnessテスト(tool_calls-bearing conversation)が実行時に検出しました。

このため`estimate_tokens_for_any_turn`を拡張し、dict入力でも`"content"`キーを持つ真のwire dict(トップレベル`tool_calls`込み)のみをfoldするようにし(compactor-input shape= `"text"`キーのdict は従来通りpassthrough)、build_history/decompose_history_for_retry/advisorすべてがこの関数を経由するよう統一しました。`estimate_tokens_for_turn`自体はdict専用・byte無変更のまま維持しています。

`estimate_tokens_for_any_turn`の残存(grep, src/tests/docs全体):
```
src/reyn/runtime/services/context_budget_advisor.py (5箇所: import + 呼び出し + docstring)
src/reyn/runtime/services/router_history_buffer.py (4箇所: import x2 + 呼び出し x2)
src/reyn/services/compaction/engine.py (定義 + _trim_groups からの呼び出し + docstring参照)
tests/*.py (witnessテスト群)
```
ゼロにはできませんでしたが、理由を上記の通り明記しています。

## `effective_trigger`のSSoT
`RouterHistoryBuffer._resolve_budgets`と`ContextBudgetAdvisor._get_effective_trigger`の両方を、`router_history_buffer.py`のmodule-level関数`resolve_effective_trigger_and_budgets`に寄せました(重複実装だった`engine.budgets`ルックアップ+`get_max_input_tokens`フォールバックを一本化)。

## 較正
閾値・定数の調整は含めていません(PR-Aと同じ分離を維持)。

## 一致witness(`tests/test_2957_prb_elide_advisor_token_unification.py`, 4件)
co-vet指摘を反映し、「同じ関数を同じ入力に適用しているだけ」のトートロジーにならないよう、事前にズレうる条件を選んで作成:
1. 画像を含む会話 — advisorが base64 payload を text として数えていた旧バグ(PR-Aの345x級ギャップ)が両経路で塞がっていることを、fixed-cost regime内であることの直接assertで検証
2. tool_calls を含む会話
3. **elideが実際に発火した後**の一致(循環が解けたことの直接witness)
4. base64 materialise前後(path-ref vs 既にinline)で同一image が同一トークン数になること

## strip-falsify(Edit-only、2件、いずれも復元・pushはfix後のクリーン状態)
1. **advisor側だけ旧`json.dumps(combined)+estimate_tokens`に戻す** → witness 1(画像)・2(tool_calls)・3(post-elide) が **RED**(witness 4は影響を受けずgreenのまま、想定通り)。これが実際にPR-Bが閉じたバグの実体です。
2. **elide側(build_historyのtotal計算)だけ生ChatMessageに戻す** → **全4件green**(何もRedにならず)。理由: PR-Aで`estimate_tokens_for_any_turn`は既にChatMessage/wire dict双方に対し同一の結果を返すよう作られており、この一点だけを戻しても数値は変わらない。**実際の循環バグはadvisor側のjson.dumpsスキームのみに存在していた**ことが、このstripによって裏付けられました(elide側は既にPR-Aで正しかった)。

## PR-A witness(4件、`tests/test_2957_pra_chatmessage_token_type_mismatch.py`)
すべてgreenのまま、書き換え不要でした(media_store=Noneかつ既にinlineなimage_url partを使う既存fixtureは、serialise-first化の影響を受けない構造だったため)。

## 性能実測(item 6 — measure first, no caching implemented)
200KBの画像(base64化)を含む60ターン中15ターンが画像を持つ会話で、effective_triggerを小さく設定してelideを強制発火(残るのは4ターン)させて計測:
- **post-PR-B**(全candidateを先にserialise=base64 materialise): 約 **5.85ms/call**
- 旧挙動相当(生存する4ターンのみserialise): 約 **0.36ms/call**
- この合成条件で約16倍のオーバーヘッド。設計指示通り、**キャッシュ共有は本PRで実装していません**。重い場合は別issue/PRとして切り出す前提です。

## doc
`RouterHistoryBuffer._serialise_turn`のdocstringに「この出力がcanonicalな計上量である」ことを明記しました(将来の再発明防止)。`estimate_tokens_for_any_turn`のdocstringも、削除不能な理由・tool_calls top-levelの罠を含め全面的に更新済み。

## gate結果
- `ruff check src tests`: All checks passed
- `python scripts/test_tier_audit.py --strict <変更test>`: 10/10 OK, 0 Tier4違反
- `pytest`(foreground, timeout 600000): **9347 passed, 39 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py <変更src>`: OK

## Test plan
- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green (10/10)
- [x] full `pytest` green (9347 passed, 39 skipped)
- [x] `verify_module_docstrings.py` green
- [x] 一致witness 4件(画像/tool_calls/post-elide/materialise前後)green
- [x] strip-falsify 2件実施・復元確認済み(advisor側strip→3件RED、elide側strip→変化なしを確認・記録)
- [x] PR-A witness 4件、変更なくgreen