### PR TITLE
fix(1909): propagate external-source taint from tool-results into context-auto narrowing

### DIFF
--- a/docs/concepts/runtime/capability-profile.md
+++ b/docs/concepts/runtime/capability-profile.md
@@ -97,7 +97,13 @@ active context — no explicit binding needed:
 `.reyn/capability_profiles/_untrusted.yaml`)
 
 **Trigger:** any history/context entry whose meta carries `external_source=true`
-(stamped by the content-fence seam at ingest).
+(stamped by the content-fence seam at ingest). Two seams stamp it today: an
+external peer's `ask_user` answer (A2A / webhook), and the result of any tool
+declaring `returns_external_content` (e.g. web fetch) — both land in
+`self.history` meta, and the narrowing check (`metas_have_untrusted`) live-scans
+`self.history` on every turn rather than caching the verdict, so the very next
+dispatch after an external tool-result lands is already narrowed, and the
+narrowing self-clears once that entry compacts out of context.
 
 **Built-in deny-set:** memory writes/deletes, re-delegation, sandboxed
 execution, MCP install. Untrusted content can be read and reasoned about, but

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3090,11 +3090,24 @@ class RouterLoop:
                 "content": content_str,
             })
             # E-full PR-E (#383): persist the tool response (capped form).
+            # #1909: carry the ``external_source`` taint (already extracted above,
+            # FP-0050/#1822 S2) into the persisted history-entry meta — the SAME
+            # convention the S4 external-peer-answer seam uses
+            # (intervention_handler.py, ``UNTRUSTED_META_KEY`` in
+            # capability_profile.py). ``_effective_contextual_for_turn`` live-scans
+            # ``self.history`` meta every turn (not cached), so once this lands the
+            # NEXT dispatch is already capability-narrowed — no separate re-narrowing
+            # step is needed intra-turn.
+            _tool_meta: "dict[str, object]" = {
+                "chain_id": self.chain_id, "source": "router_tool_turn",
+            }
+            if external_source:
+                _tool_meta["external_source"] = True
             if _append_entry is not None:
                 _append_entry(
                     role="tool",
                     content=content_str,
-                    meta={"chain_id": self.chain_id, "source": "router_tool_turn"},
+                    meta=_tool_meta,
                     tool_call_id=tc["id"],
                     name=tc.get("function", {}).get("name"),
                 )

--- a/src/reyn/security/permissions/capability_profile.py
+++ b/src/reyn/security/permissions/capability_profile.py
@@ -193,9 +193,10 @@ def compose_resolved(
 # is live in the agent's active context, the agent is also CAPABILITY-narrowed —
 # so even a partial prompt-injection has no dangerous tools to reach. This is
 # **seam-agnostic**: any untrusted-content seam stamps ``UNTRUSTED_META_KEY`` on
-# its history/context entry meta (the external peer answer in S4 v1; external
-# tool-results in the #1909 follow-up), and the tainted-derivation is marker-
-# driven, not seam-specific.
+# its history/context entry meta — the external peer answer (S4 v1,
+# ``intervention_handler.py``) and external tool-results (#1909,
+# ``router_loop.py``'s ``feedback()``, tagged by ``returns_external_content``) both
+# do — and the tainted-derivation is marker-driven, not seam-specific.
 
 # The marker key a seam stamps on a history-entry meta to mark untrusted content.
 UNTRUSTED_META_KEY: "str" = "external_source"

--- a/tests/test_1909_external_tool_result_narrowing.py
+++ b/tests/test_1909_external_tool_result_narrowing.py
@@ -1,0 +1,198 @@
+"""Tier 3: external tool-result → context-auto capability narrowing (#1909).
+
+The #1827 S4 context-auto defense (capability narrowing while untrusted external
+content is live in context) worked for the external-peer-answer seam
+(``intervention_handler.py``) but NOT for external tool-results: ``router_loop.py``
+already tagged a ``returns_external_content`` result with ``_external_source``
+(FP-0050/#1822 S2, used by the fence) and already extracted it in ``feedback()``,
+but the extracted flag was discarded instead of reaching the persisted history
+entry's ``meta`` — so ``metas_have_untrusted``/``_effective_contextual_for_turn``
+(``session.py``) never saw it and narrowing never engaged for this seam.
+
+#1909 fixes the ONE gap: ``feedback()``'s tool-result ``append_history_entry`` call
+now includes ``meta["external_source"] = True`` when the dispatched tool declared
+``returns_external_content`` — the SAME marker convention the S4 answer seam uses
+(``UNTRUSTED_META_KEY`` in ``capability_profile.py``). No new narrowing mechanism is
+added: ``_effective_contextual_for_turn`` already live-scans ``self.history`` meta
+on every call (not cached), so once the marker lands, the very next time a
+``RouterLoop`` is constructed (``RouterLoopDriver.execute`` calls
+``contextual_for_turn_fn()`` fresh before each turn) the narrowed profile is live.
+
+**Grounding note on timing** (verified empirically, not assumed): ``RouterLoop``'s
+``_contextual_permission`` is resolved ONCE per ``RouterLoop.__init__`` (i.e. once
+per ``Session._handle_user_message`` turn) and stays fixed for every LLM/tool
+round WITHIN that same turn's ``run()`` — so a tool result that taints history
+mid-turn does not retroactively narrow a LATER dispatch in the SAME multi-round
+turn. The narrowing takes effect starting the turn's window: NEXT turn boundary
+(the next ``_handle_user_message`` call, which is the same "no separate
+re-narrowing" story the #1827 S4 answer seam already relies on — an answer is
+appended to history by the intervention handler and only the NEXT turn's fresh
+``contextual_for_turn_fn()`` picks it up too). These tests pin THAT boundary, not
+a within-a-single-multi-round-loop re-narrow (which the codebase does not do for
+either seam).
+
+Real ``Session`` + real history + real tool registry throughout — no
+``_FakeMessage`` / hand-rolled host stand-in (#2957 PR-A precedent: a fake here
+would hide exactly the "tag set but not propagated" bug this PR fixes).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+_REMEMBER_ARGS = {
+    "slug": "y", "name": "n", "description": "d", "type": "user", "body": "x",
+}
+
+
+def _tool_call_result(calls: list[dict]) -> LLMToolCallResult:
+    tool_calls = [
+        {
+            "id": c.get("id", f"tc_{i}"),
+            "type": "function",
+            "function": {"name": c["name"], "arguments": json.dumps(c.get("args", {}))},
+        }
+        for i, c in enumerate(calls)
+    ]
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls, finish_reason="tool_calls", usage=_USAGE,
+    )
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(content=text, tool_calls=[], finish_reason="stop", usage=_USAGE)
+
+
+def _scripted_llm(rounds: list[LLMToolCallResult]):
+    state = {"n": 0}
+
+    async def _call(**kwargs: Any) -> LLMToolCallResult:
+        r = rounds[state["n"]]
+        state["n"] += 1
+        return r
+    return _call
+
+
+def _make(tmp_path) -> Session:
+    return make_session(agent_name="test_agent")
+
+
+@pytest.mark.asyncio
+async def test_external_tool_result_meta_carries_taint_marker(tmp_path, monkeypatch):
+    """Tier 3: the persisted tool-result history entry for an
+    ``returns_external_content`` tool (``list_memory``) carries
+    ``meta["external_source"] = True`` — the propagation this PR adds at
+    ``router_loop.py`` ``feedback()``. A trusted-internal tool call in the
+    same turn does NOT carry the marker (source-scoped, not blanket)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make(tmp_path)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([
+                {"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"},
+                {"name": "list_agents", "args": {}, "id": "tc_trusted"},
+            ]),
+            _text_result("ok"),
+        ]),
+    )
+    await session._handle_user_message("look things up", chain_id="c1")
+
+    tool_msgs = {m.tool_call_id: m for m in session.history if m.role == "tool"}
+    assert tool_msgs["tc_ext"].meta.get("external_source") is True
+    assert not tool_msgs["tc_trusted"].meta.get("external_source")
+
+
+@pytest.mark.asyncio
+async def test_baseline_without_taint_remember_shared_succeeds(tmp_path, monkeypatch):
+    """Tier 3 control: with NO external content ever in context,
+    ``remember_shared`` (a tool the ``_untrusted`` floor denies) succeeds
+    normally. This is the control the negative witness below is measured
+    against — proves the later denial is CAUSED by narrowing, not by some
+    unrelated dispatch failure."""
+    monkeypatch.chdir(tmp_path)
+    session = _make(tmp_path)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_r"}]),
+            _text_result("done"),
+        ]),
+    )
+    await session._handle_user_message("remember this", chain_id="c1")
+
+    (tool_msg,) = [m for m in session.history if m.role == "tool"]
+    assert "tool_excluded" not in str(tool_msg.content)
+
+
+@pytest.mark.asyncio
+async def test_next_turn_dispatch_denied_negative_witness(tmp_path, monkeypatch):
+    """Tier 3: NEGATIVE + TIMING witness. Turn 1 dispatches an external tool
+    (``list_memory``). Turn 2 — the VERY NEXT ``_handle_user_message`` call on
+    the SAME session, no compaction in between — attempts ``remember_shared``
+    (denied by the built-in ``_untrusted`` floor). Without the meta-propagation
+    fix this call SUCCEEDS (see the control test above); with it, it is
+    rejected with ``tool_excluded`` — the operation that would otherwise have
+    gone through is actually blocked, not just "profile has an attribute"."""
+    monkeypatch.chdir(tmp_path)
+    session = _make(tmp_path)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _text_result("ok fetched"),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_denied"}]),
+            _text_result("done"),
+        ]),
+    )
+    await session._handle_user_message("look something up", chain_id="c1")
+    await session._handle_user_message("now remember it", chain_id="c2")
+
+    (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
+    assert "tool_excluded" in str(denied_msg.content)
+    assert "remember_shared" in str(denied_msg.content)
+
+
+@pytest.mark.asyncio
+async def test_self_clears_after_tainted_entry_compacted_out(tmp_path, monkeypatch):
+    """Tier 3: SELF-CLEAR witness. After the tainted tool-result entry is
+    removed from active history (simulating compaction — same technique
+    ``test_context_auto_1827_s4b.py`` uses for the S4 seam), a THIRD turn's
+    ``remember_shared`` call succeeds again — narrowing is until-compaction
+    scope, not a permanent lock, for the tool-result seam same as the answer
+    seam."""
+    monkeypatch.chdir(tmp_path)
+    session = _make(tmp_path)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _text_result("ok fetched"),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_denied"}]),
+            _text_result("done"),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_allowed"}]),
+            _text_result("done again"),
+        ]),
+    )
+    await session._handle_user_message("look something up", chain_id="c1")
+    await session._handle_user_message("now remember it", chain_id="c2")
+    (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
+    assert "tool_excluded" in str(denied_msg.content)
+
+    # Simulate compaction evicting the tainted tool-result entry from active context.
+    session.history = [
+        m for m in session.history if not (m.meta or {}).get("external_source")
+    ]
+
+    await session._handle_user_message("try again", chain_id="c3")
+    (allowed_msg,) = [m for m in session.history if m.tool_call_id == "tc_allowed"]
+    assert "tool_excluded" not in str(allowed_msg.content)

--- a/tests/test_1909_external_tool_result_narrowing.py
+++ b/tests/test_1909_external_tool_result_narrowing.py
@@ -142,7 +142,19 @@ async def test_next_turn_dispatch_denied_negative_witness(tmp_path, monkeypatch)
     (denied by the built-in ``_untrusted`` floor). Without the meta-propagation
     fix this call SUCCEEDS (see the control test above); with it, it is
     rejected with ``tool_excluded`` — the operation that would otherwise have
-    gone through is actually blocked, not just "profile has an attribute"."""
+    gone through is actually blocked, not just "profile has an attribute".
+
+    **Scope note (what this does NOT verify):** this pins the TURN boundary
+    (``RouterLoopDriver.run_turn`` constructs a fresh ``RouterLoop`` per
+    ``_handle_user_message`` call and resolves ``contextual_for_turn_fn()``
+    once at that construction — see its ``#1827 S4b: per-turn effective
+    contextual`` comment). It does **not** exercise — and does not claim
+    coverage of — narrowing WITHIN a single turn's multi-round tool loop
+    (list_memory and a would-be-denied call in the SAME ``_handle_user_message``
+    call): verified empirically that a same-turn later round is NOT narrowed,
+    because ``RouterLoop._contextual_permission`` is fixed once per
+    construction and is not re-derived per iteration. That intra-turn gap is
+    tracked as a separate follow-up issue, not closed by this PR."""
     monkeypatch.chdir(tmp_path)
     session = _make(tmp_path)
     monkeypatch.setattr(
@@ -169,7 +181,13 @@ async def test_self_clears_after_tainted_entry_compacted_out(tmp_path, monkeypat
     ``test_context_auto_1827_s4b.py`` uses for the S4 seam), a THIRD turn's
     ``remember_shared`` call succeeds again — narrowing is until-compaction
     scope, not a permanent lock, for the tool-result seam same as the answer
-    seam."""
+    seam.
+
+    **Scope note**: like the negative/timing witness above, the taint→deny and
+    deny→clear transitions this pins are both observed at TURN boundaries
+    (separate ``_handle_user_message`` calls), not within one turn's
+    multi-round tool loop. Does not verify intra-turn self-clear (out of
+    scope — see the negative-witness test's scope note)."""
     monkeypatch.chdir(tmp_path)
     session = _make(tmp_path)
     monkeypatch.setattr(

--- a/tests/test_1909_external_tool_result_narrowing.py
+++ b/tests/test_1909_external_tool_result_narrowing.py
@@ -114,7 +114,7 @@ async def test_external_tool_result_meta_carries_taint_marker(tmp_path, monkeypa
 
 @pytest.mark.asyncio
 async def test_baseline_without_taint_remember_shared_succeeds(tmp_path, monkeypatch):
-    """Tier 3 control: with NO external content ever in context,
+    """Tier 3: control — with NO external content ever in context,
     ``remember_shared`` (a tool the ``_untrusted`` floor denies) succeeds
     normally. This is the control the negative witness below is measured
     against — proves the later denial is CAUSED by narrowing, not by some


### PR DESCRIPTION
**[per-PR-coder]** — part of #1909
<!-- closing-check: discussing #1909 -->

## ⚠️ Scope: turn-boundary narrowing only — intra-turn is NOT closed by this PR

**This PR eliminates the multi-turn attack surface (meta reaches history, so the
NEXT turn is narrowed) but leaves one window open: an external tool-result
read and a would-be-denied dispatch happening as two rounds of the SAME
turn's multi-round tool loop are NOT narrowed against each other by this PR.**
That intra-turn gap is real, verified empirically (see below), and tracked as
a separate follow-up issue — do not read this PR as having completed issue 1909
completely.

## What
`router_loop.py`'s `feedback()` already tagged `returns_external_content` tool results with `_external_source` (FP-0050/#1822 S2) and already extracted the tag — but only used it to drive the fence, then discarded the local variable. The #1827 S4 context-auto narrowing (`_effective_contextual_for_turn` / `metas_have_untrusted` in `session.py`) live-scans **history-entry meta**, so it never engaged for external tool-results, only for the external-peer-answer seam (`intervention_handler.py`) that already stamped `meta["external_source"] = True`.

Fix (single hunk, `router_loop.py` `feedback()`): the tool-result `append_history_entry` call now includes `meta["external_source"] = True` when `external_source` was extracted — same convention/key the S4 answer seam uses (`UNTRUSTED_META_KEY` in `capability_profile.py`). No new narrowing mechanism was added — `_effective_contextual_for_turn` re-derives from live history on every turn already.

## Grounding correction (verified empirically before writing tests — original brief said intra-turn needed no extra implementation; that was wrong, retracted by the design owner)
`RouterLoopDriver.run_turn` (:367) constructs a fresh `RouterLoop` per `_handle_user_message` call (:395), and that construction site's own comment names the design intent: **"#1827 S4b: per-turn effective contextual"**. `RouterLoop._contextual_permission` is therefore resolved **once per `RouterLoop.__init__`** — i.e. once per turn — and stays fixed for every LLM/tool round **within** that turn's `run()`. Confirmed by running a real Session with a tainting tool call followed immediately by a would-be-denied call in the *same* multi-round turn: the second call was NOT denied. Narrowing engages starting the **next** turn boundary (the next `_handle_user_message` call) — same boundary the existing S4 answer seam already relies on.

**Decision (owner-level): merge this PR as-is, track intra-turn re-narrowing as a separate issue.** Rationale: (1) re-evaluating contextual permission per tool-round would change the evaluation timing of the permission contract itself — a security-contract change with blast radius across all tool dispatch, not a same-shape fix; (2) this PR's meta-propagation is independently correct and valuable — it eliminates the multi-turn attack sequence; (3) the co-vet angle differs (this PR = propagation witness; intra-turn = a regression/gap witness on a different mechanism).

## Witnesses (`tests/test_1909_external_tool_result_narrowing.py`, real Session/history/registry, no fakes)
- **Propagation**: `list_memory` tool-result entry's meta carries `external_source=True`; a trusted tool call in the same turn does not.
- **Negative + timing (turn-boundary scope — see docstring "Scope note")**: turn 1 dispatches `list_memory`; turn 2 (the very next `_handle_user_message`, same session, no compaction) attempts `remember_shared` (denied by the built-in `_untrusted` floor) and gets `tool_excluded`. Does **not** cover a same-turn (same `run()`) later round — that's the open intra-turn gap above.
- **Control**: a fresh session with no external content ever dispatched — `remember_shared` succeeds, proving the denial above is caused by narrowing, not something else.
- **Self-clear (also turn-boundary scope)**: after simulating the tainted entry compacting out of history, a further turn's `remember_shared` succeeds again.

Each witness docstring now states explicitly what it does and does NOT verify, so a future reader can't misread "turn-boundary verified" as "intra-turn verified".

## Strip-falsify
Edit-only: commented out the `_tool_meta["external_source"] = True` line, reran the 4 tests → propagation/negative/self-clear tests went RED (control stayed green, as expected), then restored — file set verified identical to the committed diff before push.

## Docs
- `docs/concepts/runtime/capability-profile.md`: documented both seams that stamp the marker today (was previously silent on tool-results).
- `src/reyn/security/permissions/capability_profile.py:190-198`: updated the "#1909 follow-up" comment to present tense (both seams now implemented at the turn-boundary granularity described above).

## Gates (all local, foreground)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_1909_external_tool_result_narrowing.py` — 4/4 OK
- `pytest` (full suite, foreground, `timeout 600000`) — 9352 passed, 39 skipped, 0 failed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py src/reyn/security/permissions/capability_profile.py` — OK

## Test plan
- [x] Local gates above all green (see Gates section)
- [x] Strip-falsify performed and reverted (see Strip-falsify section)

