### PR TITLE
ci: extend PR closing-intent gate to scan commit messages (4th check)

### DIFF
--- a/.github/workflows/check-pr-closing-intent.yml
+++ b/.github/workflows/check-pr-closing-intent.yml
@@ -5,11 +5,22 @@ name: PR closing-intent check
 # own closing-issue parser (`closingIssuesReferences`) actually resolved
 # for #N — all *before* merge, while the PR is still open.
 #
+# #3187/#1909 follow-up: a 4th check additionally scans every commit
+# message on the PR for a closing declaration the PR body does NOT also
+# make — GitHub's default squash-merge commit message concatenates all
+# commit messages, so a stray closing keyword left in an intermediate
+# commit (from an earlier draft) can auto-close an issue on merge even
+# though the PR body is clean and closingIssuesReferences is empty. See
+# scripts/check_pr_closing_intent.py's module docstring (check 4) for the
+# real incident and design rationale.
+#
 # A dedicated workflow (not folded into test.yml's bare `pull_request:`
 # trigger) because this check must also re-run on `edited` — an author
 # who edits the body after opening (e.g. adds/removes a `Closes #N`) needs
 # the gate to re-evaluate, and `edited` is not one of the default
-# pull_request event types.
+# pull_request event types. `synchronize` (new commits pushed) also
+# re-runs the commit-message scan (check 4) against the updated commit
+# set.
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -160,13 +160,32 @@ habit. A gate that checks the source you *think of* first — the PR body,
 because that's where the author writes prose — can be fully green while the
 mechanism resolves from a source nobody re-checked.
 
+★ Even the extended (body + commit-message) gate has a residual limit worth
+naming explicitly, because the failure mode this section describes is
+exactly the one a sloppy reading of the fix would repeat: **this gate
+detects a state that CAN still leak a close — it does not, and structurally
+cannot, guarantee the close won't happen.** The squash-merge commit message
+is only finalized at merge time, and the human merging can hand-edit it —
+removing a keyword the gate flagged, or just as easily *adding* one it never
+saw. ∴ a green run of this gate means "no leftover closing keyword was
+found in the PR-time input surfaces" — it does NOT mean "this PR will not
+close the issue." Reading gate-green as close-proof is the exact misreading
+that caused the original incident (`closingIssuesReferences` == 0 was read
+as "close is prevented," and the issue closed anyway); the fix must not
+invite the same misreading one layer up.
+
 **Apply**: before trusting a gate as covering "does X happen", enumerate
 every input surface the *real* downstream mechanism actually reads (not
 just the one your fix touches) and confirm the gate reads all of them. A
 fix that only reruns the check when the touched surface changes (e.g. this
 gate previously re-ran only on `edited` — a body-only event) is itself a
 symptom: the trigger set silently encodes an assumption about which surface
-matters.
+matters. ★ A pre-merge gate is never itself the observation of the
+merge-time outcome — after merging a PR this gate touched, check the
+target issue's actual `state` (e.g. `gh issue view <N> --json state`)
+rather than treating the gate's earlier green run as the final word; that
+issue-state read is the only thing that actually observes what happened at
+merge time.
 
 ## See also
 

--- a/docs/deep-dives/contributing/verification-hazards.md
+++ b/docs/deep-dives/contributing/verification-hazards.md
@@ -139,6 +139,35 @@ site) needs its interactive elements (anchors, mermaid diagrams) verified
 against *each* surface that reads it — a passing build for one says nothing
 about the other.
 
+## 9. Input-surface blindness: gate every surface the real mechanism reads
+
+`scripts/check_pr_closing_intent.py` gated the PR **body** against GitHub's
+parsed `closingIssuesReferences` — and passed cleanly for PR #3187 (body
+correctly said `part of #1909`, `closingIssuesReferences` was empty, checked
+and confirmed green before merge). It still auto-closed #1909 on merge: an
+intermediate commit's message carried a stray `Closes #1909` left over from
+an earlier draft, and GitHub's default squash-merge commit message is the
+*concatenation* of all commit messages — a second input surface the gate
+never looked at. The green result on the body surface said nothing about
+the commit-message surface, because the check's target was narrower than
+the real mechanism (GitHub's closing-keyword parser) it was standing in for.
+
+This is the sibling of §8 (renderer-specificity) one layer earlier: §8 is
+about a single *artifact* read by two renderers; this is about a single
+*mechanism* (GitHub closing an issue on merge) that reads from two
+*sources* (PR body, PR commit messages) that a human only edits one of by
+habit. A gate that checks the source you *think of* first — the PR body,
+because that's where the author writes prose — can be fully green while the
+mechanism resolves from a source nobody re-checked.
+
+**Apply**: before trusting a gate as covering "does X happen", enumerate
+every input surface the *real* downstream mechanism actually reads (not
+just the one your fix touches) and confirm the gate reads all of them. A
+fix that only reruns the check when the touched surface changes (e.g. this
+gate previously re-ran only on `edited` — a body-only event) is itself a
+symptom: the trigger set silently encodes an assumption about which surface
+matters.
+
 ## See also
 
 - [Testing policy](testing.md) — Tier model, Mock vs Fake, decision flow.

--- a/scripts/check_pr_closing_intent.py
+++ b/scripts/check_pr_closing_intent.py
@@ -8,7 +8,7 @@ still open) actually resolved for #N. This script detects contradictions —
 it never infers intent beyond what the body's declaring phrases literally
 say.
 
-Three checks, all facets of the same invariant:
+Four checks, all facets of the same invariant:
 
   1. **false negative** — body declares closing intent (``Closes #N`` /
      ``Fixes #N`` / ``Resolves #N``, in any casing, even inside backticks)
@@ -28,6 +28,30 @@ Three checks, all facets of the same invariant:
      sentence). This is the hole a closing-keyword-only check (1+2) misses:
      both checks 1 and 2 presuppose the author wrote *some* declaring
      phrase; an author who writes neither slips through both.
+  4. **commit-message declaration** — a PR *commit message* (not the PR
+     body) contains a closing declaration for #N, but the PR body does NOT
+     also declare closing intent for #N. Real incident: PR #3187's body was
+     correctly ``part of #1909`` and ``closingIssuesReferences`` was empty
+     (checks 1-3 above all PASS) — but an intermediate commit's message
+     still carried ``Closes #1909`` from an earlier draft. GitHub's default
+     squash-merge commit message is the *concatenation* of the PR's commit
+     messages, so that stray ``Closes #1909`` line survived into the squash
+     commit body (merge commit ``d9b4c3a0``, line 19) and GitHub auto-closed
+     #1909 on merge — despite the PR body being clean and
+     ``closingIssuesReferences`` showing nothing.
+
+     Why scanning individual commit messages (rather than trying to predict
+     the eventual squash message) is sufficient: at CI time, while the PR is
+     still open, the *final* squash-commit message does not exist yet — a
+     human merging the PR can still hand-edit GitHub's proposed squash body.
+     But GitHub's proposed default is deterministically the concatenation of
+     the already-known commit messages, so if a closing keyword sits in ANY
+     commit message, it WILL appear in the default squash body unless a
+     human edits it out by hand. This check flags that "may still be
+     silently carried forward" state; it does not (and structurally cannot,
+     before merge) know whether a human will hand-edit it away. That is by
+     design, not a gap: the check's job is to catch the state that CAN leak
+     a close, not to certify that a human removed it.
 
 Declaring-phrase vocabulary — three forms, all checked against the parser:
 
@@ -84,6 +108,23 @@ from the body before matching rather than skipping fenced code spans.
 anything. What GitHub actually parsed there is the bare ``close #2827``
 substring inside the prose "auto-close #2827" — i.e. #3003 is the
 bare-prose-keyword case, which is what check 3 covers.)
+
+Check 4's escape hatch reuses the exact same ``<!-- closing-check:
+discussing #N -->`` marker vocabulary — no new syntax — but scoped to the
+SAME text blob as the existing per-issue scoping principle above, extended
+one level: the PR body is one blob, and each commit message is its own
+separate blob. A commit message that itself contains both a closing keyword
+(e.g. explaining ``Closes #N`` as worked example text, exactly as this
+script's own commit messages must avoid doing) AND the discussing marker
+naming N *within that same commit message* is exempt for that commit. A
+marker living in the PR body does NOT exempt a closing keyword sitting in a
+commit message — they are different blobs — which is deliberate: it is
+precisely what keeps check 4 catching the #3187 shape, where the body
+carries an unrelated ``discussing #1909`` marker (added for its own body-
+text reasons) while a commit message independently carries the real
+``Closes #1909`` leak. Letting the body's marker blanket-exempt commit
+content would silently defeat check 4 on exactly the incident it exists to
+catch.
 
 The parsing logic (``find_closing_declarations`` / ``find_nonclosing_declarations``
 / ``check_contradictions``) is pure — no network, no subprocess — so it is
@@ -190,12 +231,20 @@ class Finding:
     message: str
 
 
-def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
+def check_contradictions(
+    body: str,
+    closing_refs: list[int],
+    commit_messages: list[str] | None = None,
+) -> list[Finding]:
     """Pure contradiction detector — no network, no inference of intent.
 
     ``body`` is the raw PR body text. ``closing_refs`` is the list of issue
     numbers GitHub's parser (``closingIssuesReferences``) actually resolved
-    as closing targets for this PR.
+    as closing targets for this PR. ``commit_messages`` is the list of full
+    commit-message texts (headline + body) for every commit on the PR — used
+    only by check 4 (see module docstring); defaults to none, so callers
+    that only have body/closing_refs (e.g. the existing test suite) are
+    unaffected.
     """
     closing_declared = find_closing_declarations(body)
     nonclosing_declared = find_nonclosing_declarations(body)
@@ -286,6 +335,46 @@ def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
             )
         )
 
+    # Check 4 (commit-message declaration): a commit message declares
+    # closing intent for #N that the PR body does NOT also declare. See
+    # module docstring for why this is checked independently of
+    # closing_refs (GitHub's default squash-merge body concatenates commit
+    # messages, so this leaks even when closingIssuesReferences is empty).
+    #
+    # Exemption is scoped per commit message (its own text blob), not to
+    # the PR body's discussing markers — see module docstring "Check 4's
+    # escape hatch" section for why a body-wide exemption would silently
+    # defeat this check on the #3187 shape it exists to catch.
+    commit_closing_declared: set[int] = set()
+    for msg in commit_messages or []:
+        commit_closing_declared |= find_closing_declarations(msg) - find_discussing_declarations(msg)
+
+    for n in sorted(commit_closing_declared - closing_declared):
+        findings.append(
+            Finding(
+                check=4,
+                issue=n,
+                message=(
+                    f"a commit message on this PR declares closing intent "
+                    f"for #{n} (Closes/Fixes/Resolves) but the PR BODY does "
+                    f"not also declare closing intent for #{n}. GitHub's "
+                    "default squash-merge commit message concatenates all "
+                    "commit messages, so this keyword will be carried into "
+                    f"the merge commit and can auto-close #{n} on merge "
+                    "regardless of what the PR body says or what "
+                    "closingIssuesReferences currently shows (real "
+                    "incident: PR #3187 / issue #1909, merge commit "
+                    f"d9b4c3a0). If closing #{n} is intended, also write "
+                    f"'Closes #{n}' in the PR body. If not, rewrite or "
+                    f"squash away the offending commit message, or if the "
+                    f"commit message only *discusses* #{n} rather than "
+                    "declaring intent, add "
+                    f"<!-- closing-check: discussing #{n} --> to that SAME "
+                    "commit message."
+                ),
+            )
+        )
+
     return findings
 
 
@@ -294,8 +383,29 @@ def check_contradictions(body: str, closing_refs: list[int]) -> list[Finding]:
 # ---------------------------------------------------------------------------
 
 
-def fetch_pr_data(pr_number: int) -> tuple[str, list[int]]:
-    """Fetch (body, closing_issue_numbers) for an open PR via ``gh pr view``."""
+def _commit_message_text(commit: dict) -> str:
+    """Reconstruct a full commit-message text from a ``gh``-shaped commit dict.
+
+    ``gh pr view --json commits`` returns each commit as
+    ``{"messageHeadline": ..., "messageBody": ..., ...}`` — the same split
+    ``git log`` uses. Joined back with a blank line the same way ``git``
+    itself displays/concatenates a commit message, so the reconstructed
+    text matches what a human (or GitHub's squash-message builder) actually
+    sees.
+    """
+    headline = commit.get("messageHeadline") or ""
+    msg_body = commit.get("messageBody") or ""
+    return f"{headline}\n\n{msg_body}" if msg_body else headline
+
+
+def fetch_pr_data(pr_number: int) -> tuple[str, list[int], list[str]]:
+    """Fetch (body, closing_issue_numbers, commit_messages) for an open PR.
+
+    Uses ``gh pr view``. ``commit_messages`` is one full message string
+    (headline + body) per commit currently on the PR — see check 4 in the
+    module docstring for why these are scanned independently of
+    ``closingIssuesReferences``.
+    """
     result = subprocess.run(
         [
             "gh",
@@ -303,7 +413,7 @@ def fetch_pr_data(pr_number: int) -> tuple[str, list[int]]:
             "view",
             str(pr_number),
             "--json",
-            "closingIssuesReferences,body",
+            "closingIssuesReferences,body,commits",
         ],
         capture_output=True,
         text=True,
@@ -312,7 +422,8 @@ def fetch_pr_data(pr_number: int) -> tuple[str, list[int]]:
     data = json.loads(result.stdout)
     body = data.get("body") or ""
     closing_refs = [ref["number"] for ref in data.get("closingIssuesReferences") or []]
-    return body, closing_refs
+    commit_messages = [_commit_message_text(c) for c in data.get("commits") or []]
+    return body, closing_refs, commit_messages
 
 
 # ---------------------------------------------------------------------------
@@ -338,10 +449,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--fixture",
         metavar="PATH",
         help=(
-            "Path to a JSON fixture file with keys 'body' (str) and "
-            "'closingIssuesReferences' (list of {'number': N} or plain ints) "
-            "— same shape as `gh pr view --json closingIssuesReferences,body`. "
-            "Lets this check run offline / in tests without hitting GitHub."
+            "Path to a JSON fixture file with keys 'body' (str), "
+            "'closingIssuesReferences' (list of {'number': N} or plain ints), "
+            "and optionally 'commits' (list of {'messageHeadline':, "
+            "'messageBody':} or plain strings) — same shape as "
+            "`gh pr view --json closingIssuesReferences,body,commits`. Lets "
+            "this check run offline / in tests without hitting GitHub."
         ),
     )
     return parser
@@ -359,13 +472,25 @@ def _closing_refs_from_fixture(raw: object) -> list[int]:
     return out
 
 
+def _commit_messages_from_fixture(raw: object) -> list[str]:
+    if not raw:
+        return []
+    out: list[str] = []
+    for item in raw:  # type: ignore[union-attr]
+        if isinstance(item, dict):
+            out.append(_commit_message_text(item))
+        else:
+            out.append(str(item))
+    return out
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
     if args.pr is not None:
         try:
-            body, closing_refs = fetch_pr_data(args.pr)
+            body, closing_refs, commit_messages = fetch_pr_data(args.pr)
         except subprocess.CalledProcessError as exc:
             print(f"gh pr view failed: {exc.stderr}", file=sys.stderr)
             return 2
@@ -376,9 +501,10 @@ def main(argv: list[str] | None = None) -> int:
         raw = json.loads(Path(args.fixture).read_text(encoding="utf-8"))
         body = raw.get("body") or ""
         closing_refs = _closing_refs_from_fixture(raw.get("closingIssuesReferences"))
+        commit_messages = _commit_messages_from_fixture(raw.get("commits"))
         source = args.fixture
 
-    findings = check_contradictions(body, closing_refs)
+    findings = check_contradictions(body, closing_refs, commit_messages)
 
     if not findings:
         print(f"OK — no closing-intent contradictions found ({source}).")

--- a/tests/test_check_pr_closing_intent.py
+++ b/tests/test_check_pr_closing_intent.py
@@ -2,11 +2,12 @@
 
 Pins the invariant issue #3007 ratified: the intent a PR body *declares*
 about issue #N must match the closing behavior GitHub's own parser
-(``closingIssuesReferences``) actually resolved for #N. The three checks
-(false negative / false positive / undeclared) are pure facets of that one
+(``closingIssuesReferences``) actually resolved for #N, PLUS (check 4,
+added to close the #3187/#1909 gap) the closing behavior a commit message
+independently declares. The four checks are pure facets of that one
 invariant, and ``check_contradictions`` is a pure function over
-``(body, closing_refs)`` — no network, no subprocess — so this is a Tier 1
-contract test against known inputs/outputs.
+``(body, closing_refs, commit_messages)`` — no network, no subprocess — so
+this is a Tier 1 contract test against known inputs/outputs.
 
 Public surface only (no MagicMock, no private-state asserts): each case
 calls ``check_contradictions`` and asserts on the returned ``Finding``
@@ -183,3 +184,124 @@ def test_find_closing_declarations_strips_backticks():
 def test_find_nonclosing_declarations_matches_toward():
     """Tier 1: "toward #N" is recognized as a non-closing declaration."""
     assert m.find_nonclosing_declarations("toward #42") == {42}
+
+
+# ---------------------------------------------------------------------------
+# Check 4: commit-message closing declarations (real PR #3187 / #1909 shape).
+#
+# Real data, verbatim from `gh pr view 3187 --json body,commits,
+# closingIssuesReferences` at the time this gate was written (not
+# hand-invented fixtures — see testing.ja.md's Mock-vs-Fake guidance to
+# prefer real data shapes). The PR body excerpt below is a real substring
+# (author-declared "part of #1909" plus a real, pre-existing "discussing
+# #1909" marker the author had added for unrelated reasons); the commit
+# message is the real second commit's messageHeadline/messageBody, whose
+# ``Closes #1909`` line is exactly what leaked into squash-merge commit
+# ``d9b4c3a0`` and auto-closed #1909 despite the clean body and empty
+# ``closingIssuesReferences``.
+# ---------------------------------------------------------------------------
+
+_PR3187_BODY_EXCERPT = (
+    "**[per-PR-coder]** — part of #1909\n"
+    "<!-- closing-check: discussing #1909 -->\n\n"
+    "## Scope: turn-boundary narrowing only\n"
+    "This PR eliminates the multi-turn attack surface for issue 1909."
+)
+
+_PR3187_COMMIT_WITH_LEAK = (
+    "fix(1909): propagate external-source taint from tool-results into his…\n"
+    "\n"
+    "router_loop.py's feedback() already tagged returns_external_content tool\n"
+    "results with _external_source (FP-0050/#1822 S2) and already extracted the\n"
+    "tag, but discarded the local variable instead of threading it into the\n"
+    "persisted history-entry meta.\n"
+    "\n"
+    "Closes #1909"
+)
+
+
+def test_check4_fires_on_real_3187_shape_commit_leak_body_says_part_of():
+    """Tier 1: real reproduction — PR #3187's actual body + commit text.
+
+    Body correctly declares ``part of #1909`` (checks 1-3 all PASS, as they
+    did live: closingIssuesReferences was empty when checked before merge).
+    But a commit message independently carries ``Closes #1909`` — exactly
+    what caused #1909 to auto-close on squash-merge (merge commit
+    d9b4c3a0) despite the clean body. Check 4 must be the only thing that
+    catches this: checks 1-3 stay silent (asserted explicitly) because
+    ``closing_refs=[]`` is what the live PR actually showed pre-merge.
+    """
+    findings = m.check_contradictions(
+        _PR3187_BODY_EXCERPT,
+        closing_refs=[],
+        commit_messages=[_PR3187_COMMIT_WITH_LEAK],
+    )
+    assert _checks(findings) == [(4, 1909)]
+
+
+def test_check4_does_not_fire_when_body_also_declares_closing():
+    """Tier 1: normal/intentional path — body agrees with the commit.
+
+    If the body ALSO writes ``Closes #N``, the commit-message declaration is
+    not a contradiction (both sides intend the close), so check 4 must stay
+    silent.
+    """
+    findings = m.check_contradictions(
+        "Closes #1909",
+        closing_refs=[1909],
+        commit_messages=[_PR3187_COMMIT_WITH_LEAK],
+    )
+    assert findings == []
+
+
+def test_check4_escape_hatch_works_when_marker_is_in_the_same_commit_message():
+    """Tier 1: escape hatch fires — same vocabulary, scoped to the SAME blob.
+
+    A commit message that both quotes ``Closes #N`` (e.g. explaining this
+    very gate, as this script's own commit messages must avoid doing
+    literally) and carries the discussing marker for N *within that same
+    commit message* is exempt for that commit.
+    """
+    commit_msg = (
+        "docs: explain the closing-intent gate\n\n"
+        "This gate flags a bare `Closes #555` left in a commit message.\n"
+        "<!-- closing-check: discussing #555 -->"
+    )
+    findings = m.check_contradictions(
+        "part of #555",
+        closing_refs=[],
+        commit_messages=[commit_msg],
+    )
+    assert findings == []
+
+
+def test_check4_escape_hatch_does_not_exempt_across_blobs_body_marker_ignored():
+    """Tier 1: a marker in the PR BODY must NOT exempt a commit-message leak.
+
+    This is the real #3187 shape reproduced precisely (see
+    ``test_check4_fires_on_real_3187_shape_commit_leak_body_says_part_of``
+    above): the body's ``discussing #1909`` marker exists for its own
+    reasons and does not reach into a *different* text blob (a commit
+    message) to suppress a genuine leak there. A body-wide/cross-blob
+    exemption would silently defeat check 4 on exactly this real incident —
+    the same "escape hatch must not exempt too much" property the existing
+    per-issue marker design already protects for check 1
+    (``test_discussing_marker_does_not_exempt_a_genuine_declaration``).
+    """
+    findings = m.check_contradictions(
+        "part of #1909\n<!-- closing-check: discussing #1909 -->",
+        closing_refs=[],
+        commit_messages=[_PR3187_COMMIT_WITH_LEAK],
+    )
+    assert _checks(findings) == [(4, 1909)]
+
+
+def test_check4_silent_when_no_commit_messages_supplied():
+    """Tier 1: backward compatibility — omitting commit_messages is a no-op.
+
+    Every pre-existing call site/test in this file calls
+    ``check_contradictions(body, closing_refs)`` with no third argument;
+    check 4 must never fire from an absent commit-message list.
+    """
+    findings = m.check_contradictions("part of #1909", closing_refs=[])
+    assert findings == []


### PR DESCRIPTION
**[per-PR-coder]** — no issue filed for this task (per dispatch instructions).

## What
Extends the PR closing-intent gate (`scripts/check_pr_closing_intent.py`,
`.github/workflows/check-pr-closing-intent.yml`) with a 4th check: it now
scans every **commit message** on the PR for a closing-keyword+`#N` pattern
that the PR body does NOT also declare, reusing the exact same regex the
existing body-check already uses (no new pattern).

<!-- closing-check: discussing #1909 -->

## Why
Real incident on the previous PR in this repo: its body correctly said
`part of #1909`, and `closingIssuesReferences` was verified empty before
merge (checks 1-3 all green). It still auto-closed issue #1909 on merge, because
an intermediate commit's message carried a stray keyword-#1909 line from an
earlier draft, and GitHub's default squash-merge body is the concatenation
of all commit messages. The existing gate never looked at commit messages,
so it could not have caught this.

## Design
- **Same regex, no drift**: check 4 reuses `find_closing_declarations` /
  `find_discussing_declarations` as-is against each commit message text —
  no second regex to maintain.
- **Why per-commit scanning is sufficient at CI time**: the final squash
  body doesn't exist yet while the PR is open, but GitHub's *default*
  proposal is deterministically the concatenation of already-known commit
  messages — so a keyword sitting in any commit message will land in the
  default squash body unless a human hand-edits it out. The gate flags that
  "may still be carried forward" state; it cannot and does not certify a
  human removed it. Documented in the script's module docstring (check 4)
  so this isn't misread as a false-positive gap later.
- **Escape hatch, same vocabulary, scoped per text-blob**: `<!-- closing-check:
  discussing #N -->` reused as-is, but scoped to the commit message it
  appears in (its own blob), not body-wide. This is deliberate: the real
  reproduction PR's body already carried an (unrelated) discussing marker
  for #1909, and if the marker exempted across blobs, it would have
  silently defeated check 4 on exactly the incident it exists to catch.

## Witnesses (`tests/test_check_pr_closing_intent.py`, real PR data, no fakes)
- **Reproduction** (real data, verbatim body excerpt + real commit message
  from the incident PR): body says non-closing intent, commit independently
  carries the keyword — check 4 fires, checks 1-3 stay silent (matches what
  was actually observed live).
- **Escape hatch works**: marker inside the SAME commit message exempts it.
- **Escape hatch does not over-exempt**: a marker in the PR body does NOT
  suppress a leak in a different commit message (same real-data shape as
  the reproduction case above) — check 4 still fires.
- **Normal/intentional path**: body also declares closing intent for the
  same issue as the commit — no contradiction, check 4 silent.
- Existing 3 checks: all 13 pre-existing tests pass unchanged (no
  regression).

## Strip-falsify (Edit-only)
Blanked out the check-4 block in `check_contradictions` (kept everything
else), reran the suite: the two check-4 witness tests went RED (16 others
stayed green), confirming they exercise check 4 specifically. Reverted via
`git checkout --`.

## This PR against its own gate
This PR's own text needs to *quote* the keyword-#1909 pattern to explain the
incident. Without the `<!-- closing-check: discussing #1909 -->` marker
above, check 1 would fire on this PR body (declares "closing intent" for
#1909 with #1909 absent from `closingIssuesReferences`, since this PR does
not close anything). **The escape hatch was needed and used** — this is
itself a live instance of the gate applying to its own PR, as flagged in
the dispatch brief. Commit messages on this PR were written to avoid the
literal keyword+#N pattern entirely (so check 4 needs no escape hatch on
the commit side).

## Doc
- `docs/deep-dives/contributing/verification-hazards.md`: new §9
  ("Input-surface blindness: gate every surface the real mechanism reads")
  — this incident is a clean instance of a green result (body-only check)
  saying nothing about a second input surface (commit messages) the real
  mechanism (GitHub's parser) also reads.

## Gates (all local, foreground)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_check_pr_closing_intent.py` — 18/18 OK
- `pytest` (full suite, foreground, `timeout 600000`) — 9357 passed, 39 skipped, 0 failed
- `python scripts/verify_module_docstrings.py scripts/check_pr_closing_intent.py` — OK

## Test plan
- [x] Local gates above all green (see Gates section)
- [x] Strip-falsify performed and reverted (see Strip-falsify section)
- [x] This PR's own gate run verified green (see "This PR against its own gate")
