### PR TITLE
fix(3027): raise, not assert, for compaction budget self-consistency guard

### DIFF
--- a/docs/concepts/data-retrieval/chat-compaction.md
+++ b/docs/concepts/data-retrieval/chat-compaction.md
@@ -124,6 +124,20 @@ chat:
 Weights are sum-arbitrary — any positive integers work; Reyn normalises them at
 startup. Larger values give more token budget to that component.
 
+**Self-consistency guard:** budgets (head/tail/new_msg/body — and, derived
+from them, `B_M` and the compaction trigger `effective_trigger`) are computed
+against the *selected model's* context window, not a fixed number. If
+`component_weights` reserve too much of the window (in particular a large
+`body`/summary weight, or a large system prompt eating into the same pool)
+for a small-context model, `effective_trigger` or `B_M` can be computed as
+non-positive. `CompactionEngine` fails fast at construction time in that case
+(`CompactionBudgetSelfConsistencyError`, raised — not asserted, so the guard
+survives `python -O`) rather than silently letting compaction fire on every
+turn. The error message reports the model's context window, the resolved
+`component_weights`, and the computed budgets, so the fix is to reduce
+`component_weights` (or use a model with a larger context window) — never to
+clamp the computed value.
+
 **Removed keys:** `head_size`, `tail_size`, `trigger_total_tokens`, and
 `min_compact_batch` are no longer recognised. If present in `reyn.yaml`, Reyn
 emits a `DeprecationWarning` and ignores them. Remove these keys from your

--- a/src/reyn/services/compaction/__init__.py
+++ b/src/reyn/services/compaction/__init__.py
@@ -2,6 +2,7 @@
 from reyn.services.compaction.engine import (
     ChatSummary,
     ChatSummaryRaw,
+    CompactionBudgetSelfConsistencyError,
     CompactionEngine,
     CompactionOverflowError,
     ComputedBudgets,
@@ -27,6 +28,7 @@ __all__ = [
     "ChatSummary",
     "ChatSummaryRaw",
     "ComputedBudgets",
+    "CompactionBudgetSelfConsistencyError",
     "CompactionOverflowError",
     "ContextOverflowError",
     "HistoryChunkToCompact",

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -476,9 +476,15 @@ class CompactionBudgetSelfConsistencyError(Exception):
     stripped by -O; raise instead so the guard cannot vanish"). If this
     invariant is violated, ``effective_trigger`` (or ``B_M``) would flow
     downstream as a non-positive number; in particular the elide decision
-    ``total <= effective_trigger`` would always be true against a negative
-    ``effective_trigger``, so compaction would fire on every turn instead
-    of failing fast here.
+    ``total <= effective_trigger`` (``router_history_buffer.py``) is always
+    FALSE against a non-positive ``effective_trigger`` (``total`` is a sum
+    of non-negative token counts), so the elide/compact branch would be
+    taken on every turn instead of failing fast here.
+
+    Note: ``B_M <= 0`` has no standalone -O witness and cannot have one —
+    ``effective_trigger = min(main_M_room, B_M)``, so ``B_M <= 0`` implies
+    ``effective_trigger <= 0`` always (containment by construction via
+    ``min``, not a witness gap; see the comment at the ``B_M`` raise site).
 
     Attributes
     ----------
@@ -529,6 +535,15 @@ def assert_static_bounds(
         f"{[k for k, v in sw.items() if v < 0]}"
     )
     if budgets.B_M <= 0:
+        # #3027 co-vet: this branch has no standalone -O witness, and cannot
+        # have one — effective_trigger = min(main_M_room, B_M), so
+        # B_M <= 0 ⇒ effective_trigger = min(main_M_room, B_M) <= B_M <= 0
+        # always. Any budget config that trips THIS branch necessarily also
+        # trips the effective_trigger branch below, so the effective_trigger
+        # -O witness (tests/test_3027_budget_guard_survives_optimize.py)
+        # already exercises the same "raise survives -O" property for this
+        # branch too. This is containment by construction (via `min`), not a
+        # witness gap — do not add a same-shaped standalone B_M-only -O test.
         from reyn.llm.model_budget import get_max_input_tokens
         T_max = get_max_input_tokens(model)
         raise CompactionBudgetSelfConsistencyError(

--- a/src/reyn/services/compaction/engine.py
+++ b/src/reyn/services/compaction/engine.py
@@ -465,12 +465,49 @@ def compute_budgets(
     )
 
 
-def assert_static_bounds(cfg: "CompactionConfig", budgets: ComputedBudgets) -> None:
-    """Assert invariants on the computed budgets.
+class CompactionBudgetSelfConsistencyError(Exception):
+    """Raised when a computed budget violates a required self-consistency
+    invariant (``B_M > 0`` or ``effective_trigger > 0``).
+
+    ``assert`` is deliberately NOT used for these two checks: CPython
+    strips every ``assert`` statement under ``-O`` / ``PYTHONOPTIMIZE=1``,
+    so an assert-based guard here would silently vanish in an optimized
+    production run — the same failure class #2352 named ("assert is
+    stripped by -O; raise instead so the guard cannot vanish"). If this
+    invariant is violated, ``effective_trigger`` (or ``B_M``) would flow
+    downstream as a non-positive number; in particular the elide decision
+    ``total <= effective_trigger`` would always be true against a negative
+    ``effective_trigger``, so compaction would fire on every turn instead
+    of failing fast here.
+
+    Attributes
+    ----------
+    field:
+        Which computed budget violated its invariant (``"B_M"`` or
+        ``"effective_trigger"``).
+    value:
+        The computed (non-positive) value.
+    """
+
+    def __init__(self, field: str, value: int, detail: str) -> None:
+        self.field = field
+        self.value = value
+        super().__init__(detail)
+
+
+def assert_static_bounds(
+    cfg: "CompactionConfig", budgets: ComputedBudgets, model: str
+) -> None:
+    """Validate invariants on the computed budgets.
 
     PR-N6: validates component_weights / section_weights (sum > 0, all >= 0).
     Called at CompactionEngine.__init__ time so a misconfigured
     reyn.yaml fails fast at process start, not at first compaction.
+
+    #3027: the two self-consistency checks below (``B_M`` / ``effective_trigger``
+    positivity) raise ``CompactionBudgetSelfConsistencyError`` instead of using
+    ``assert``, because ``assert`` is removed entirely under ``python -O`` —
+    see the class docstring.
     """
     # PR-N6 weight-based assertions (replaces the ratio_sum <= 1.0 check).
     cw = cfg.component_weights
@@ -491,14 +528,35 @@ def assert_static_bounds(cfg: "CompactionConfig", budgets: ComputedBudgets) -> N
         f"CompactionConfig.section_weights has negative values: "
         f"{[k for k, v in sw.items() if v < 0]}"
     )
-    assert budgets.B_M > 0, (
-        f"B_M = {budgets.B_M} — compaction call self-bound violated "
-        f"(try adjusting component_weights or using a larger model)"
-    )
-    assert budgets.effective_trigger > 0, (
-        f"effective_trigger = {budgets.effective_trigger} — "
-        f"model context too small for chosen component_weights"
-    )
+    if budgets.B_M <= 0:
+        from reyn.llm.model_budget import get_max_input_tokens
+        T_max = get_max_input_tokens(model)
+        raise CompactionBudgetSelfConsistencyError(
+            "B_M",
+            budgets.B_M,
+            f"B_M = {budgets.B_M} — compaction call self-bound violated. "
+            f"model={model!r} context window T_max={T_max} tokens; "
+            f"component_weights={dict(cw)}; body_budget={budgets.body_budget} "
+            f"tokens. component_weights (especially the body/summary weight) "
+            f"are too large for this model's context — reduce component_weights "
+            f"or use a model with a larger context window."
+        )
+    if budgets.effective_trigger <= 0:
+        from reyn.llm.model_budget import get_max_input_tokens
+        T_max = get_max_input_tokens(model)
+        raise CompactionBudgetSelfConsistencyError(
+            "effective_trigger",
+            budgets.effective_trigger,
+            f"effective_trigger = {budgets.effective_trigger} — model context "
+            f"too small for chosen component_weights. model={model!r} context "
+            f"window T_max={T_max} tokens; component_weights={dict(cw)}; "
+            f"main_M_room={budgets.main_M_room}, B_M={budgets.B_M} "
+            f"(effective_trigger = min(main_M_room, B_M)). The system prompt "
+            f"(and/or component_weights, especially the SP-adjacent weights) "
+            f"is too large relative to this model's context — reduce the "
+            f"system prompt / component_weights, or use a model with a "
+            f"larger context window."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -917,7 +975,7 @@ class CompactionEngine:
             self._budgets = compute_budgets(
                 self._cfg, self._model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
             )
-            assert_static_bounds(self._cfg, self._budgets)
+            assert_static_bounds(self._cfg, self._budgets, self._model)
 
     def recompute_budgets(self) -> None:
         """Re-measure T_SP from the provider and recompute budgets.
@@ -935,7 +993,7 @@ class CompactionEngine:
         self._budgets = compute_budgets(
             self._cfg, self._model, T_SP=T_SP, T_comp_SP=self._T_comp_SP
         )
-        assert_static_bounds(self._cfg, self._budgets)
+        assert_static_bounds(self._cfg, self._budgets, self._model)
 
     @property
     def budgets(self) -> ComputedBudgets:
@@ -1471,6 +1529,7 @@ __all__ = [
     "ChatSummary",
     "ChatSummaryRaw",
     "ComputedBudgets",
+    "CompactionBudgetSelfConsistencyError",
     "CompactionOverflowError",
     "ContextOverflowError",
     "HistoryChunkToCompact",

--- a/tests/test_3027_budget_guard_survives_optimize.py
+++ b/tests/test_3027_budget_guard_survives_optimize.py
@@ -1,0 +1,102 @@
+"""Tier 2: assert_static_bounds's budget self-consistency guards survive
+``python -O`` (#3027).
+
+``assert budgets.effective_trigger > 0`` (and the sibling ``B_M > 0`` check)
+used to be plain ``assert`` statements in
+``reyn.services.compaction.engine.assert_static_bounds``. CPython strips
+every ``assert`` statement when the interpreter runs with ``-O`` /
+``PYTHONOPTIMIZE=1`` — so under an optimized production run the guard would
+silently vanish, letting a negative ``effective_trigger`` flow downstream
+(where ``elide``'s ``total <= effective_trigger`` compares against a
+negative number and is always true = compaction fires on every turn).
+
+#3027's fix replaces the two self-consistency checks with an explicit
+``raise CompactionBudgetSelfConsistencyError(...)`` (same class of fix as
+#2352: "raise, don't assert, so -O cannot strip the guard"). These tests
+run the guard in a real subprocess under ``-O`` — a mock/patch of
+``__debug__`` would NOT prove anything, because CPython's ``assert``
+stripping happens at compile time, not via a runtime flag a test can fake.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# The repo may be `pip install -e`'d from a different checkout (e.g. another
+# worktree) than the one pytest is running from — pytest itself picks up the
+# right `src/` via `pythonpath = ["src"]` in pyproject.toml, but a bare
+# subprocess `python -c` does not. Point PYTHONPATH at *this* checkout's
+# `src/` explicitly so the subprocess imports the code under test, not
+# whatever `reyn` happens to be installed in site-packages.
+_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
+
+_SCRIPT_TEMPLATE = """
+import sys
+from reyn.config.chat import CompactionConfig
+from reyn.services.compaction.engine import ComputedBudgets, assert_static_bounds
+
+cfg = CompactionConfig()
+budgets = ComputedBudgets(
+    main_pool=10_000, head_budget=1000, body_budget=500,
+    tail_budget=1000, new_msg_budget=500,
+    B_M={b_m}, main_M_room=5000, effective_trigger={effective_trigger},
+)
+assert_static_bounds(cfg, budgets, "test-model")
+print("NO_RAISE", file=sys.stdout)
+"""
+
+
+def _run(script: str, *, optimize: bool) -> subprocess.CompletedProcess:
+    args = [sys.executable]
+    if optimize:
+        args.append("-O")
+    args += ["-c", script]
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
+
+
+def test_effective_trigger_guard_fires_under_dash_o() -> None:
+    """Tier 2: the effective_trigger<=0 guard raises even under `python -O`.
+
+    This is the load-bearing witness for #3027: before the fix, this exact
+    scenario used a plain `assert` and would print NO_RAISE (exit 0) under
+    -O instead of raising.
+    """
+    script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=-7)
+    result = _run(script, optimize=True)
+    assert result.returncode != 0, (
+        f"guard did NOT fire under -O (stdout={result.stdout!r}): "
+        f"a negative effective_trigger silently flowed through"
+    )
+    assert "CompactionBudgetSelfConsistencyError" in result.stderr, result.stderr
+    assert "effective_trigger = -7" in result.stderr, result.stderr
+    assert "NO_RAISE" not in result.stdout
+
+
+def test_effective_trigger_guard_fires_in_normal_mode() -> None:
+    """Tier 2: regression — the guard still fires in normal (non -O) mode."""
+    script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=-7)
+    result = _run(script, optimize=False)
+    assert result.returncode != 0
+    assert "CompactionBudgetSelfConsistencyError" in result.stderr, result.stderr
+    assert "effective_trigger = -7" in result.stderr, result.stderr
+
+
+def test_valid_budgets_do_not_fire_under_dash_o() -> None:
+    """Tier 2: control — a self-consistent budget config does NOT raise
+    under -O (the guard is not over-firing)."""
+    script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=5000)
+    result = _run(script, optimize=True)
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    assert "NO_RAISE" in result.stdout
+
+
+def test_valid_budgets_do_not_fire_in_normal_mode() -> None:
+    """Tier 2: control — same as above in normal mode (no over-firing)."""
+    script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=5000)
+    result = _run(script, optimize=False)
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    assert "NO_RAISE" in result.stdout

--- a/tests/test_chat_compaction_engine_11axis.py
+++ b/tests/test_chat_compaction_engine_11axis.py
@@ -40,6 +40,7 @@ from reyn.config import CompactionConfig
 from reyn.core.events.events import EventLog
 from reyn.services.compaction.engine import (
     ChatSummary,
+    CompactionBudgetSelfConsistencyError,
     CompactionEngine,
     ComputedBudgets,
     HistoryChunkToCompact,
@@ -190,7 +191,7 @@ def test_assert_static_bounds_zero_weight_sum_raises() -> None:
         B_M=5000, main_M_room=10000, effective_trigger=5000,
     )
     with pytest.raises(AssertionError):
-        assert_static_bounds(cfg, budgets)
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 def test_assert_static_bounds_negative_weight_raises() -> None:
@@ -205,11 +206,16 @@ def test_assert_static_bounds_negative_weight_raises() -> None:
         B_M=5000, main_M_room=8000, effective_trigger=5000,
     )
     with pytest.raises(AssertionError):
-        assert_static_bounds(cfg, budgets)
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 def test_assert_static_bounds_B_M_zero_raises() -> None:
-    """Tier 2: assert_static_bounds raises AssertionError when B_M ≤ 0."""
+    """Tier 2: assert_static_bounds raises CompactionBudgetSelfConsistencyError when B_M ≤ 0.
+
+    #3027: this self-consistency guard must survive ``python -O`` (see
+    test_3027_budget_guard_survives_optimize.py for the -O witness), so it
+    raises an explicit exception instead of using ``assert``.
+    """
     cfg = _make_cfg()
     budgets = ComputedBudgets(
         main_pool=10_000, head_budget=1000, body_budget=500,
@@ -217,12 +223,17 @@ def test_assert_static_bounds_B_M_zero_raises() -> None:
         B_M=0,  # violation
         main_M_room=8000, effective_trigger=0,
     )
-    with pytest.raises(AssertionError, match="B_M"):
-        assert_static_bounds(cfg, budgets)
+    with pytest.raises(CompactionBudgetSelfConsistencyError, match="B_M"):
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 def test_assert_static_bounds_effective_trigger_zero_raises() -> None:
-    """Tier 2: assert_static_bounds raises AssertionError when effective_trigger ≤ 0."""
+    """Tier 2: assert_static_bounds raises CompactionBudgetSelfConsistencyError when effective_trigger ≤ 0.
+
+    #3027: this self-consistency guard must survive ``python -O`` (see
+    test_3027_budget_guard_survives_optimize.py for the -O witness), so it
+    raises an explicit exception instead of using ``assert``.
+    """
     cfg = _make_cfg()
     budgets = ComputedBudgets(
         main_pool=10_000, head_budget=1000, body_budget=500,
@@ -230,8 +241,30 @@ def test_assert_static_bounds_effective_trigger_zero_raises() -> None:
         B_M=5000, main_M_room=5000,
         effective_trigger=0,  # violation
     )
-    with pytest.raises(AssertionError, match="effective_trigger"):
-        assert_static_bounds(cfg, budgets)
+    with pytest.raises(CompactionBudgetSelfConsistencyError, match="effective_trigger"):
+        assert_static_bounds(cfg, budgets, "test-model")
+
+
+def test_assert_static_bounds_effective_trigger_zero_message_has_numbers() -> None:
+    """Tier 2: the effective_trigger guard's message is decision-enabling — it
+    must carry the concrete numbers (T_max, component_weights, main_M_room,
+    B_M), not just the field name, so a reader can act on the failure (#3027).
+    """
+    cfg = _make_cfg()
+    budgets = ComputedBudgets(
+        main_pool=10_000, head_budget=1000, body_budget=500,
+        tail_budget=1000, new_msg_budget=500,
+        B_M=5000, main_M_room=5000,
+        effective_trigger=-42,  # violation, distinctive value
+    )
+    with pytest.raises(CompactionBudgetSelfConsistencyError) as exc_info:
+        assert_static_bounds(cfg, budgets, "test-model")
+    msg = str(exc_info.value)
+    assert "-42" in msg, msg
+    assert "T_max=" in msg, msg
+    assert "component_weights=" in msg, msg
+    assert "main_M_room=5000" in msg, msg
+    assert "B_M=5000" in msg, msg
 
 
 def test_assert_static_bounds_passes_valid_config() -> None:
@@ -242,7 +275,7 @@ def test_assert_static_bounds_passes_valid_config() -> None:
         tail_budget=15000, new_msg_budget=10000,
         B_M=50000, main_M_room=65000, effective_trigger=50000,
     )
-    assert_static_bounds(cfg, budgets)  # must not raise
+    assert_static_bounds(cfg, budgets, "test-model")  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_n6_compaction_overflow_retry.py
+++ b/tests/test_pr_n6_compaction_overflow_retry.py
@@ -343,7 +343,7 @@ def test_assert_static_bounds_zero_component_sum_raises() -> None:
         B_M=5000, main_M_room=10000, effective_trigger=5000,
     )
     with pytest.raises(AssertionError):
-        assert_static_bounds(cfg, budgets)
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 def test_assert_static_bounds_negative_component_weight_raises() -> None:
@@ -356,7 +356,7 @@ def test_assert_static_bounds_negative_component_weight_raises() -> None:
         B_M=5000, main_M_room=8000, effective_trigger=5000,
     )
     with pytest.raises(AssertionError):
-        assert_static_bounds(cfg, budgets)
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 def test_assert_static_bounds_zero_section_sum_raises() -> None:
@@ -369,7 +369,7 @@ def test_assert_static_bounds_zero_section_sum_raises() -> None:
         B_M=5000, main_M_room=7000, effective_trigger=5000,
     )
     with pytest.raises(AssertionError):
-        assert_static_bounds(cfg, budgets)
+        assert_static_bounds(cfg, budgets, "test-model")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**[per-PR-coder]** — #3027の実体（budgetの自己整合ガードが`python -O`で消える）を修正します。

## 背景

`assert_static_bounds()`（`src/reyn/services/compaction/engine.py`）の `assert budgets.effective_trigger > 0` / `assert budgets.B_M > 0` は plain `assert` — CPythonは `python -O` / `PYTHONOPTIMIZE=1` で `assert` を丸ごとストリップするため、最適化モード本番ではこのガードが消え、負の `effective_trigger` が下流に流れます。`router_history_buffer.py` の `total <= effective_trigger` 判定は非負の `total` に対して常に false になり、elide/compact 分岐が常時選択されます（実測、下記）。#2352 が名指した "raise, not assert, so -O cannot strip the guard" と同じクラスです。

## 変更内容

- `CompactionBudgetSelfConsistencyError` を新設し、`B_M` / `effective_trigger` の自己整合チェックを `assert` から `raise` に変更。メッセージには model のコンテキスト長 (`T_max`)、resolved `component_weights`、算出済み `main_M_room`/`B_M`/`effective_trigger` を含め、decision-enabling にしました。
- `assert_static_bounds()` に `model: str` 引数を追加（メッセージ用の `T_max` 取得のため）。2つの呼び出し元（`CompactionEngine.__init__` / `recompute_budgets`）を更新。
- 計算式・headroom・クランプは一切変更していません（scope外）。
- `docs/concepts/data-retrieval/chat-compaction.md` に「self-consistency guard」節を追加 — `component_weights` を大きくしすぎた場合に何が起きるか（fail-fast、クランプしない）を明記。ja doc は既存の記述を falsify していないため未変更（#2967）。

## `-O` witness（本PRの主目的）

`tests/test_3027_budget_guard_survives_optimize.py` — 実際に `python -O` サブプロセスを起動してガードの発火を確認：
- `test_effective_trigger_guard_fires_under_dash_o`: `-O` 下でも `CompactionBudgetSelfConsistencyError` が発火することを確認（load-bearing witness）
- `test_effective_trigger_guard_fires_in_normal_mode`: 通常モードでも回帰なく発火
- `test_valid_budgets_do_not_fire_under_dash_o` / `_in_normal_mode`: 正常な budget では発火しない control

`tests/test_chat_compaction_engine_11axis.py::test_assert_static_bounds_effective_trigger_zero_message_has_numbers` — メッセージに実数値（`T_max=`, `component_weights=`, `main_M_room=`, `B_M=`, 具体的な負値）が含まれることを pin。

## 修正前 `-O` 挙動の実測

`assert` 版（旧実装）を一時的に復元し `python -O` サブプロセスで直接測定：
- `assert_static_bounds()` は例外を投げず `effective_trigger = -7` のまま返る（ガードが消えることを確認）
- `router_history_buffer.py` の elide 判定と同型の式 `total <= effective_trigger` を `total ∈ {0, 1, 100, 1_000_000}` で評価 → 全て `False`（`total` は非負のトークン数の和で構成されるため、負の `effective_trigger` に対して数学的に常に成立しない、代表値で実測確認）→ elide/compact 分岐が常時選択されることを確認しました。

## strip-falsify

`assert_static_bounds()` の `effective_trigger` チェックを一時的に `assert` に戻して確認：
- `test_effective_trigger_guard_fires_under_dash_o` / `_in_normal_mode` → RED（狙い通り。`-O` witness が load-bearing であることの証明）
- `test_valid_budgets_do_not_fire_*` の2件 → GREEN のまま（over-firing していないことの確認、影響なし）

## Tier宣言

全テスト Tier 2（OS invariant — budget自己整合ガードの振る舞い）。`docs/deep-dives/contributing/testing.ja.md` を読んだ上で執筆。`-O` witnessはサブプロセスで実プロセスを起動しており、mock/patchで "-Oのふり" はしていません。

## Local gates

- `ruff check src tests` — pass
- `python scripts/test_tier_audit.py --strict tests/test_3027_budget_guard_survives_optimize.py tests/test_chat_compaction_engine_11axis.py tests/test_pr_n6_compaction_overflow_retry.py` — 66 tests inspected, 0 errors
- `python scripts/verify_module_docstrings.py src/reyn/services/compaction/engine.py src/reyn/services/compaction/__init__.py` — OK
- `pytest`（foreground, timeout 600000ms） — 9362 passed, 39 skipped

## Scope外（対応していません）

- `effective_trigger` のクランプ（症状を隠すため、意図的に不採用）
- headroom（budget配分）そのものの変更
- 計算式の変更

Closes #3027