### PR TITLE
fix(3191): forward read_file's truncation note through the router flatten choke point

### DIFF
--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -93,7 +93,7 @@ Each is a distinct op kind with its own schema; there is no `op` sub-field.
 
 | Kind | Permission | Notes |
 |------|-----------|-------|
-| `read_file` | `file.read` | `offset` / `limit` (line range) optional. When the resolved path's filename is exactly `SKILL.md`, the decoded content additionally passes through invocation-time `${REYN_*}`/`${CLAUDE_*}`/`${env:VAR}` expansion (`reyn.plugins.skill_load.load_skill_body`, ADR 0064 §3.5, P4/#3070) before it is returned — every other path is unaffected. |
+| `read_file` | `file.read` | `offset` / `limit` (line range) optional. When the resolved path's filename is exactly `SKILL.md`, the decoded content additionally passes through invocation-time `${REYN_*}`/`${CLAUDE_*}`/`${env:VAR}` expansion (`reyn.plugins.skill_load.load_skill_body`, ADR 0064 §3.5, P4/#3070) before it is returned — every other path is unaffected. When the inline cap self-bounds the read, the result carries `status: "truncated"` and a `note` (chars shown of total + the on-disk path/offset to resume from); the chat router's `read_file` alias, which otherwise flattens the result to a bare string before `to_canonical` runs, appends that same `note` inline instead of dropping it (#3191). |
 | `write_file` | `file.write` | Creates or overwrites; parent dirs created as needed. |
 | `edit_file` | `file.write` | `old_string` must be unique unless `replace_all: true`. |
 | `delete_file` | `file.write` | |

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3589,7 +3589,20 @@ class RouterLoop:
         if name == "read_file":
             if isinstance(result, dict):
                 if "content" in result:
-                    return result["content"]
+                    content = result["content"]
+                    # #3191: this branch flattens to a bare string BEFORE `to_canonical`
+                    # ever runs (same choke point #2998/#3190 already found for
+                    # list_directory/glob), so the op_runtime read handler's
+                    # `status == "truncated"` signal — and the `note` it carries — would
+                    # otherwise be silently dropped here. Only set when the op layer
+                    # actually truncated (never unconditionally — mirrors the #2998
+                    # list_directory fix below). Reuse the op layer's own `note` rather
+                    # than re-deriving a summary: it is already decision-enabling (chars
+                    # shown of total, plus the on-disk path + offset to resume from) —
+                    # see op_runtime/file.py's `read` handler.
+                    if result.get("status") == "truncated" and result.get("note"):
+                        content = f"{content}\n\n... {result['note']}"
+                    return content
                 return json.dumps(result)
             return result
         if name == "list_directory":

--- a/tests/test_3191_read_file_truncation_router_signal.py
+++ b/tests/test_3191_read_file_truncation_router_signal.py
@@ -1,0 +1,117 @@
+"""Tier 2: interactive chat router's `read_file` alias signals a self-bounded
+truncation instead of silently dropping it (#3191).
+
+``op_runtime/file.py``'s `read` handler already sets `status: "truncated"` +
+a decision-enabling `note` (chars shown of total, on-disk path, resume offset)
+when the inline cap self-bounds a read — this ALREADY reaches the pipeline/
+CodeAct consumer path via `file_to_canonical`'s `_file_signal_meta` (`status`
+is in its whitelist). But `RouterLoop._normalise_router_tool_result` flattens
+`read_file` to a bare `result["content"]` string BEFORE `to_canonical` ever
+runs for the interactive chat tool-calling loop (same choke point #2998/#3190
+already found for `list_directory`/`glob`) — so the LLM in that path saw only
+the truncated text with no signal at all that anything was cut.
+
+Three witnesses, each real-file-backed (no mocks, no fakes):
+  1. Consumer reach: the router choke point (`_normalise_router_tool_result`)
+     appends the op layer's own `note` when the op layer actually truncated —
+     asserts the signal is IN the string the LLM sees, not just set upstream
+     on a dict nobody downstream reads (the failure #2998/#3190 named).
+  2. Control: an untruncated read passes through byte-identical to the pre-fix
+     shape — no spurious note (a "make truncated always True" non-fix would
+     also pass witness 1 without this control).
+  3. End-to-end via the real `READ_FILE` handler + a real inline-cap-sized
+     file, confirming the op layer's `status`/`note` fields the router branch
+     reads actually exist on a genuine result (not just the synthetic dict
+     fed to witness 1).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from reyn.core.events.events import EventLog
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.router_loop import RouterLoop
+from reyn.tools.file import READ_FILE
+from reyn.tools.types import ToolContext
+
+
+def _make_ctx(tmp_path: Path, monkeypatch) -> ToolContext:
+    monkeypatch.chdir(tmp_path)
+    ws = Workspace(events=EventLog())
+    ws.base_dir = tmp_path
+    return ToolContext(
+        caller_kind="router", events=EventLog(), permission_resolver=None, workspace=ws,
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ── 1. Consumer reach: interactive chat router's read_file alias ──────────────
+
+
+def test_normalise_router_tool_result_read_file_appends_truncation_note():
+    """Tier 2: `RouterLoop._normalise_router_tool_result` is the exact choke point
+    that flattens a dict result to `result["content"]` BEFORE `to_canonical` ever
+    runs for `read_file` in the interactive chat tool-calling loop (verified by
+    reading router_loop.py: `_invoke_via_registry` calls this, and its return
+    value feeds straight into the content_str builder that only calls
+    `to_canonical` when the value is still a dict). Asserting the note is IN the
+    returned string is asserting the signal survives past this choke point to
+    what the LLM actually sees."""
+    result = {
+        "kind": "file", "op": "read", "path": "big.txt", "status": "truncated",
+        "content": "line one\nline two\n",
+        "note": (
+            "content truncated to fit context (19 of 5000 chars shown); the "
+            "full file is on disk at 'big.txt' — re-read from offset 2 to continue."
+        ),
+        "next_offset": 2, "total_chars": 5000,
+    }
+    out = RouterLoop._normalise_router_tool_result("read_file", result)
+
+    assert isinstance(out, str)
+    assert out.startswith(result["content"])
+    assert "19 of 5000 chars shown" in out
+    assert "re-read from offset 2" in out
+
+
+def test_normalise_router_tool_result_read_file_no_note_when_not_truncated():
+    """Tier 2: control — an untruncated (`status: "ok"`) read passes through
+    byte-identical to the pre-#3191 shape (bare content, no note appended). A
+    "always append the note" non-fix would fail this and make the signal
+    meaningless."""
+    result = {
+        "kind": "file", "op": "read", "path": "small.txt", "status": "ok",
+        "content": "whole file\n",
+    }
+    out = RouterLoop._normalise_router_tool_result("read_file", result)
+
+    assert out == "whole file\n"
+
+
+# ── 2. End-to-end: real handler + a real inline-cap-sized file ────────────────
+
+
+def test_read_file_handler_truncated_status_and_note_are_real(tmp_path, monkeypatch):
+    """Tier 2: the op_runtime `read` handler genuinely sets `status: "truncated"`
+    + a `note` on a real oversized file (not just a synthetic dict as in witness
+    1 above) — confirms the field names the router branch reads actually exist
+    on a live result, and that the router branch (fed this exact shape) also
+    appends the note."""
+    big = "x" * 200_000 + "\n"
+    (tmp_path / "big.txt").write_text(big, encoding="utf-8")
+    ctx = _make_ctx(tmp_path, monkeypatch)
+
+    result = _run(READ_FILE.handler({"path": "big.txt"}, ctx))
+
+    assert result.get("status") == "truncated"
+    assert result.get("note")
+    assert len(result["content"]) < len(big)
+
+    out = RouterLoop._normalise_router_tool_result("read_file", result)
+    assert isinstance(out, str)
+    assert out.startswith(result["content"])
+    assert result["note"] in out


### PR DESCRIPTION
**[per-PR-coder]** — 

Fixes the `read_file` half of #3191: `RouterLoop._normalise_router_tool_result` flattens `read_file`'s op_runtime dict result to a bare `result["content"]` string BEFORE `to_canonical` ever runs (same choke point #2998/#3190 already found and fixed for `list_directory`/`glob`), so the op layer's `status == "truncated"` signal — and the decision-enabling `note` it already carries (chars shown of total, on-disk path, resume offset) — never reached the interactive chat LLM.

## Fix
`_normalise_router_tool_result`'s `read_file` branch now appends `result["note"]` to the returned content, but **only** when `result["status"] == "truncated"` (never unconditionally — an always-present marker would make the signal meaningless).

## Signal shape chosen
Reused the op layer's existing `note` field verbatim rather than inventing a new counts-only summary like #3190's list_directory fix. `op_runtime/file.py`'s `read` handler already produces a fuller, more decision-enabling message than counts alone: chars shown of total **and** the on-disk path + exact offset to resume from. No new field, no new LLM-facing tool-description text (so no `LLMReplay` fixture re-record was needed for this PR).

## Consumer-reach witness
`tests/test_3191_read_file_truncation_router_signal.py` — 3 tests, no mocks/fakes:
1. `_normalise_router_tool_result("read_file", ...)` appends the note into the returned **string** (asserts the signal reaches what the LLM sees, not just that `result["status"]` was set upstream).
2. Control: untruncated read passes through byte-identical (no spurious note).
3. End-to-end: a real 200KB file through the real `READ_FILE` handler → real `status="truncated"` + `note` → router branch appends it.

Strip-falsify (Edit-only, single property): commented out the `if status == "truncated" ...` append line → witnesses 1 and 3 turned RED, control (2) stayed green. Reverted before commit.

## Exhaustive sweep (requirement #4)
`_normalise_router_tool_result` has exactly two flattening branches: `read_file` and `list_directory`. No third choke point exists — every other tool name falls through the function's unconditional `return result` (dict preserved, `to_canonical` handles it normally).

## Doc update
`docs/reference/runtime/control-ir.md`'s `read_file` row now documents the self-bounding truncation `status`/`note` fields and the router's forwarding fix, mirroring the existing `glob_files` row's description of the analogous list_directory fix.

## Gates (all local, green)
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_3191_read_file_truncation_router_signal.py` — 3/3 OK, 0 errors
- `pytest` (foreground, full suite) — 9373 passed, 39 skipped, 369.54s
- `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py tests/test_3191_read_file_truncation_router_signal.py` — OK

Closes #3191