### PR TITLE
fix(3193): stop whitelisting status=="ok" in Session._file_* wrappers

### DIFF
--- a/docs/guide/for-reyn-developers/add-an-op-kind.md
+++ b/docs/guide/for-reyn-developers/add-an-op-kind.md
@@ -145,6 +145,24 @@ Handler conventions:
   explicit handling produces cleaner events.
 - Never import domain-specific modules or reference domain-specific strings
   (P7 — the OS must remain domain-agnostic).
+- **If your handler returns any `"status"` literal beyond plain `"ok"` /
+  `"error"`** (e.g. a partial-success status like `read`'s `"truncated"`, or
+  a domain-specific terminal state like `"installed"`/`"needs_secrets"`),
+  add it to the matching table in
+  `src/reyn/core/op_runtime/status_classify.py`
+  (`KNOWN_SUCCESS_STATUSES` / `KNOWN_PARTIAL_STATUSES` /
+  `KNOWN_FAILURE_STATUSES`) **in the same PR** (#3193). This is CI-enforced,
+  not just a convention: `tests/test_3193_op_status_classifier_coverage.py`
+  AST-walks every `op_runtime/*.py` handler for literal `"status": "..."`
+  dict entries and fails if any of them is missing from
+  `status_classify.py`'s known-status tables — a new status you forget to
+  classify there goes RED at PR time, not silently. The reason this gate
+  exists: any caller consuming your handler's result through the shared
+  classifier (`classify_op_status`) — e.g. `Session._file_*` — treats an
+  unrecognized status as `"unknown"` rather than silently failing or
+  silently succeeding, but that safety net is meant to catch genuinely
+  unanticipated statuses, not become the default path for every new one you
+  add on purpose.
 
 Then add the import to `src/reyn/core/op_runtime/__init__.py` so the module
 self-registers at startup:

--- a/src/reyn/core/op_runtime/status_classify.py
+++ b/src/reyn/core/op_runtime/status_classify.py
@@ -1,0 +1,117 @@
+"""#3193: single classifier for ``execute_op`` result ``status`` values.
+
+Problem this closes: several ``Session._file_*`` wrappers (session.py)
+whitelisted ``status == "ok"`` (plus, for read, ``"not_found"``) and
+collapsed every other status — most damagingly ``"truncated"`` — into a
+lying ``{"error": "read failed"}``, discarding content that was actually
+read successfully.
+
+``status`` is an OPEN set: a repo-wide sweep of every ``op_runtime/*.py``
+handler found 15 distinct literal values in use, with no typed enum backing
+them (enumerating and typing that set is a separate, larger arc — out of
+scope here, see #3193's discussion). A per-wrapper whitelist of "the known
+good ones today" reproduces the exact same hole the moment a 16th value
+is introduced anywhere in op_runtime; a fresh wrapper written tomorrow
+would have no way to know it needs updating.
+
+This module is the ONE place that maps a status string to an outcome
+class. Every ``Session._file_*`` wrapper (and any future one) should
+import :func:`classify_op_status` rather than re-deriving its own
+success/failure test.
+
+Classification policy
+----------------------
+- ``success``  — the op fully completed; the result carries the complete,
+  requested content (``"ok"``, and the plugin-install-lifecycle terminal
+  ``"installed"``).
+- ``partial``  — the op completed but the result is INCOMPLETE by
+  construction (``"truncated"`` — a read or glob capped by a size/count
+  limit). Content IS present and must reach the caller; so must the
+  incompleteness signal (``note`` / ``truncated`` / ``next_offset`` / etc.)
+  — the caller must be able to tell this apart from ``success``.
+- ``failure``  — the op did not produce usable content at all (permission
+  denial, not-found, a raised exception, a user/tool refusal, a budget/size
+  cap that produced NOTHING, an unresolved dependency, ...). Enumerated
+  exhaustively below from the current op_runtime vocabulary.
+- ``unknown``  — a status string this module does not recognize. This is
+  the crux of the (b) design direction: an unrecognized status must NOT be
+  silently folded into ``failure`` (that is exactly how "truncated" content
+  got thrown away and reported as "read failed" — a lie). It is also not
+  silently folded into ``success`` (an unrecognized status could just as
+  easily mean a new failure mode with content-shaped keys that happen to be
+  absent). Callers must treat ``unknown`` as "an outcome I cannot classify
+  yet" and say so plainly to their own caller/the LLM (e.g. surface
+  whatever payload fields ARE present, tag the result as carrying an
+  unrecognized status, and log it) — never fabricate certainty in either
+  direction. `tests/test_3193_op_status_classifier_coverage.py` is the CI
+  gate that keeps this module's known-status tables in sync with the live
+  op_runtime vocabulary, so the ``unknown`` branch is a should-never-happen
+  safety net, not a load-bearing default path.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+# "ok": every op kind's happy path.
+# "installed": plugin/mcp/skill/pipeline/presentation install ops' terminal
+#   success status (distinct literal from "ok" because the payload shape
+#   differs — install ops report `{"status": "installed", ...}`).
+# "installing": NOT an execute_op result status returned to a caller — it is
+#   a persisted on-disk install-state marker plugin_install.py writes to a
+#   `.reyn-plugin` state file mid-install (json.dumps'd, not returned).
+#   Classified here anyway (as a non-terminal, non-failure state) purely so
+#   the AST completeness gate — which enumerates every literal
+#   `"status": "..."` dict entry in op_runtime regardless of whether it is
+#   ever handed back as an op result — doesn't have to special-case it.
+KNOWN_SUCCESS_STATUSES: frozenset[str] = frozenset({"ok", "installed", "installing"})
+
+# "truncated": read (line/char-window cap) and glob/list_directory
+# (max_results cap) both use this to mean "content is real and present,
+# but it's a capped subset — say so instead of silently dropping the rest."
+KNOWN_PARTIAL_STATUSES: frozenset[str] = frozenset({"truncated"})
+
+# Every other literal status string found across src/reyn/core/op_runtime/
+# (grep-verified, #3193): all mean "no usable content was produced" —
+# a permission denial, a not-found, a raised exception surfaced as a
+# structured error, a user/tool refusal, a request the OS itself declined
+# to start (blocked/cancelled/timeout/too_large/needs_secrets), or a
+# dispatch-layer short-circuit (skipped — no handler / OpSkipped;
+# uninstalled — a plugin/mcp/skill/pipeline/presentation removal's terminal
+# status, which is a "removed" confirmation with no further content, not a
+# read/write result, but carries no partial content either).
+KNOWN_FAILURE_STATUSES: frozenset[str] = frozenset({
+    "not_found",
+    "denied",
+    "error",
+    "blocked",
+    "cancelled",
+    "refused",
+    "timeout",
+    "too_large",
+    "needs_secrets",
+    "skipped",
+    "uninstalled",
+})
+
+ALL_KNOWN_STATUSES: frozenset[str] = (
+    KNOWN_SUCCESS_STATUSES | KNOWN_PARTIAL_STATUSES | KNOWN_FAILURE_STATUSES
+)
+
+OpStatusClass = Literal["success", "partial", "failure", "unknown"]
+
+
+def classify_op_status(status: object) -> OpStatusClass:
+    """Classify an ``execute_op`` result's ``status`` value.
+
+    ``status`` is typed ``object`` (not ``str``) because callers pass
+    ``result.get("status")`` on an untyped dict — a missing/non-string
+    status is exactly the kind of malformed input this function must
+    handle as ``"unknown"``, not raise on.
+    """
+    if status in KNOWN_SUCCESS_STATUSES:
+        return "success"
+    if status in KNOWN_PARTIAL_STATUSES:
+        return "partial"
+    if status in KNOWN_FAILURE_STATUSES:
+        return "failure"
+    return "unknown"

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -705,8 +705,6 @@ class RouterLoopHost(RouterLoopCore, Protocol):
 
     async def file_delete(self, path: str) -> dict: ...
 
-    async def file_list_directory(self, path: str) -> list[dict]: ...
-
     async def file_regenerate_index(self, path: str, output_path: str,
                                      entry_template: str, header: str) -> dict: ...
 
@@ -3556,10 +3554,13 @@ class RouterLoop:
         File handlers in ``src/reyn/tools/file.py`` return raw op_runtime
         dict envelopes (e.g. ``{"kind": "file", "op": "read", "status":
         "ok", "content": "..."}``) but the legacy router path
-        (RouterHostAdapter.file_read / file_list_directory) extracted
-        ``content`` / ``entries`` before returning so the LLM saw a
-        bare string / list. This helper applies the same extraction so
-        registry dispatch is LLM-visible-identical to the prior path.
+        (RouterHostAdapter.file_read) extracted ``content`` before
+        returning so the LLM saw a bare string. This helper applies the
+        same extraction so registry dispatch is LLM-visible-identical to
+        the prior path. (``file_list_directory`` was a sibling legacy
+        adapter method with the same shape — #3193 removed it: it had zero
+        call sites, list_directory has always flowed through this
+        registry/``tools/file.py`` path, not the adapter.)
 
         ``list_mcp_servers`` / ``list_mcp_tools`` deliberately do NOT get this
         treatment (removed — owner-reported bug): unwrapping their

--- a/src/reyn/runtime/services/memory_service.py
+++ b/src/reyn/runtime/services/memory_service.py
@@ -162,14 +162,28 @@ class MemoryService:
     async def read_body(self, *, layer: str, slug: str) -> dict:
         """Read a memory body file's contents.
 
-        Returns ``{"layer": layer, "slug": slug, "content": <text>}``
-        or ``{"error": <reason>}`` if not found.
+        Returns ``{"layer": layer, "slug": slug, "content": <text>}`` —
+        plus, when the underlying read was truncated, whichever #3193
+        signal fields ``_file_read`` forwarded (``truncated``, ``note``,
+        ``next_offset``, ...), copied through untouched — or
+        ``{"error": <reason>}`` if not found.
+
+        #3193: this used to hand-pick only ``content`` off the ``_file_read``
+        result, which silently dropped any truncation signal even after
+        ``_file_read`` itself started forwarding it — a large memory body
+        would read back with content cut short and NO indication anything
+        was cut. Forward every extra key ``_file_read`` returns (beyond the
+        ones this method already names) instead of re-curating a subset.
         """
         body_path = self.memory_path(layer, slug)
         result = await self._file_read(body_path)
         if "error" in result:
             return {"error": result["error"]}
-        return {"layer": layer, "slug": slug, "content": result["content"]}
+        out = {"layer": layer, "slug": slug, "content": result["content"]}
+        for key, value in result.items():
+            if key not in ("path", "content"):
+                out[key] = value
+        return out
 
 
 __all__ = ["MemoryService"]

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -1489,11 +1489,38 @@ class RouterHostAdapter:
     # --- File ops ---
 
     async def file_read(self, path: str) -> str:
-        """Returns content string or JSON error."""
+        """Returns content string (with a trailing note appended when the
+        underlying read was truncated or carried an unrecognized op status)
+        or a JSON error.
+
+        #3193 co-vet finding: this method flattens the ``_file_read_cb``
+        dict to a bare string — the SAME choke point ``read_file``'s
+        registry-dispatch sibling (``RouterLoop._normalise_router_tool_result``,
+        ``name == "read_file"``) already had to fix for the identical reason
+        (#3191/#3192): flattening to a string BEFORE the caller sees the dict
+        silently drops any sibling key (``truncated``/``note``/
+        ``_unknown_op_status``) unless this method explicitly re-attaches it.
+        The #3193 classifier fix made ``_file_read_cb`` start forwarding
+        those keys — this adapter was the one place still discarding them on
+        the way to the LLM (verified: two of ``_file_read``'s live
+        consumers, ``MemoryService.read_body`` and this method — the router
+        chat path predating the #2782/#3082 registry-dispatch migration —
+        forward the dict onward; only this one collapsed it to a bare
+        string without re-attaching the signal).
+        """
         import json
         res = await self._file_read_cb(path)
         if "content" in res:
-            return res["content"]
+            content = res["content"]
+            if res.get("truncated") and res.get("note"):
+                content = f"{content}\n\n... {res['note']}"
+            elif "_unknown_op_status" in res:
+                content = (
+                    f"{content}\n\n... note: this read returned an unrecognized "
+                    f"op status ({res['_unknown_op_status']!r}) — content may be "
+                    f"incomplete; re-read to confirm if in doubt."
+                )
+            return content
         return json.dumps(res)
 
     async def file_write(self, path: str, content: str) -> dict:

--- a/src/reyn/runtime/services/router_host_adapter.py
+++ b/src/reyn/runtime/services/router_host_adapter.py
@@ -65,8 +65,6 @@ class RouterHostAdapter:
         Async callback ``(path: str, content: str) -> dict``.
     file_delete:
         Async callback ``(path: str) -> dict``.
-    file_list_directory:
-        Async callback ``(path: str) -> dict``.
     file_regenerate_index:
         Async callback ``(*, path, output_path, entry_template, header) -> dict``.
     mcp_list_servers:
@@ -132,7 +130,6 @@ class RouterHostAdapter:
         file_read: Callable[..., Awaitable[dict]],
         file_write: Callable[..., Awaitable[dict]],
         file_delete: Callable[..., Awaitable[dict]],
-        file_list_directory: Callable[..., Awaitable[dict]],
         file_regenerate_index: Callable[..., Awaitable[dict]],
         # MCP op callbacks
         mcp_list_servers: Callable[..., Awaitable[list]],
@@ -403,7 +400,6 @@ class RouterHostAdapter:
         self._file_read_cb = file_read
         self._file_write_cb = file_write
         self._file_delete_cb = file_delete
-        self._file_list_directory_cb = file_list_directory
         self._file_regenerate_index_cb = file_regenerate_index
         # MCP callbacks
         self._mcp_list_servers_cb = mcp_list_servers
@@ -1505,12 +1501,6 @@ class RouterHostAdapter:
 
     async def file_delete(self, path: str) -> dict:
         return await self._file_delete_cb(path)
-
-    async def file_list_directory(self, path: str) -> list[dict]:
-        result = await self._file_list_directory_cb(path)
-        if isinstance(result, dict):
-            return result.get("entries", [result])
-        return result
 
     async def file_regenerate_index(self, path: str, output_path: str,
                                      entry_template: str, header: str) -> dict:

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -36,6 +36,7 @@ from reyn.core.events.event_store import EventStore
 from reyn.core.events.events import EventLog
 from reyn.core.events.snapshot_generations import SnapshotGenerationStore
 from reyn.core.events.state_log import StateLog
+from reyn.core.op_runtime.status_classify import classify_op_status
 from reyn.core.pipeline.registry import PipelineNotFoundError, PipelineRegistry
 from reyn.hooks.dispatcher import HOOK_INBOX_KIND
 from reyn.hooks.schema_registry import build_hook_payload
@@ -916,6 +917,49 @@ class _InterventionBundle:
     intervention_handler: "InterventionHandler"
     intervention_coordinator: "InterventionCoordinator"
     chain_timeout_glue: "ChainTimeoutGlue"
+
+
+# #3193: signal fields a file op result may carry ALONGSIDE its content when
+# the op is incomplete-but-not-a-failure (a truncated read, a max_results-
+# capped glob). Every `Session._file_*` wrapper forwards whichever of these
+# are present, untouched, instead of the pre-#3193 behavior of collapsing
+# any non-"ok" status into a content-discarding `{"error": ...}`.
+_FILE_OP_SIGNAL_KEYS = (
+    "truncated", "note", "next_offset", "next_char_offset",
+    "shown_lines", "total_lines", "total_chars",
+    "total_count", "returned_count",
+)
+
+
+def _forward_file_signal_fields(dest: dict, result: dict, *, outcome: str) -> None:
+    """Copy any #3193 signal fields present on *result* onto *dest*, and — for
+    ``outcome == "unknown"`` (a status `classify_op_status` does not
+    recognize) — tag the output so the unrecognized status is OBSERVABLE
+    rather than silently treated as either a clean success or a failure.
+    See `reyn.core.op_runtime.status_classify` module docstring for the
+    full policy rationale.
+
+    ``outcome == "partial"`` always sets ``dest["truncated"] = True``
+    regardless of which internal key the op_runtime handler used to signal
+    it — the ``read`` op marks it via ``status == "truncated"`` (+ a
+    private ``_truncated`` key), while ``glob`` keeps ``status == "ok"``
+    and adds a sibling public ``truncated`` key. Wrapper callers get ONE
+    consistent externally-visible field either way.
+    """
+    if outcome == "partial":
+        dest["truncated"] = True
+    for key in _FILE_OP_SIGNAL_KEYS:
+        if key in result:
+            dest[key] = result[key]
+    if outcome == "unknown":
+        status = result.get("status")
+        dest["_unknown_op_status"] = status
+        logger.warning(
+            "file op result carried unrecognized status %r (kind=%r op=%r) — "
+            "forwarding content best-effort; add this status to "
+            "reyn.core.op_runtime.status_classify (#3193)",
+            status, result.get("kind"), result.get("op"),
+        )
 
 
 class Session:
@@ -3668,7 +3712,6 @@ class Session:
             file_read=self._file_read,
             file_write=self._file_write,
             file_delete=self._file_delete,
-            file_list_directory=self._file_list_directory,
             file_regenerate_index=self._file_regenerate_index,
             mcp_list_servers=self._mcp_list_servers,
             mcp_list_tools=self._mcp_list_tools,
@@ -6847,11 +6890,18 @@ class Session:
     async def _file_read(self, path: str) -> dict:
         """Read a file through op_runtime.
 
-        Returns: {"path": path, "content": <text>} or {"error": ...}.
+        Returns ``{"path": path, "content": <text>}`` — plus, when the read
+        was truncated, the signal fields (``truncated``, ``note``,
+        ``next_offset``, ...) forwarded UNTOUCHED (#3193: a truncated read
+        still has real content and must not be reported as a failure) — or
+        ``{"error": ...}`` only for a genuine failure status.
         """
         result = await self._file_op({"kind": "file", "op": "read", "path": path})
-        if result.get("status") == "ok":
-            return {"path": path, "content": result.get("content", "")}
+        outcome = classify_op_status(result.get("status"))
+        if outcome in ("success", "partial", "unknown"):
+            out = {"path": path, "content": result.get("content", "")}
+            _forward_file_signal_fields(out, result, outcome=outcome)
+            return out
         if result.get("status") == "not_found":
             return {"error": f"file not found: {path}"}
         return {"error": result.get("error", "read failed")}
@@ -6862,8 +6912,11 @@ class Session:
         Returns: {"path": path, "written": True} or {"error": ...}.
         """
         result = await self._file_op({"kind": "file", "op": "write", "path": path, "content": content})
-        if result.get("status") == "ok":
-            return {"path": path, "written": True}
+        outcome = classify_op_status(result.get("status"))
+        if outcome in ("success", "partial", "unknown"):
+            out = {"path": path, "written": True}
+            _forward_file_signal_fields(out, result, outcome=outcome)
+            return out
         return {"error": result.get("error", "write failed")}
 
     async def _file_delete(self, path: str) -> dict:
@@ -6872,32 +6925,12 @@ class Session:
         Returns: {"path": path, "deleted": bool} or {"error": ...}.
         """
         result = await self._file_op({"kind": "file", "op": "delete", "path": path})
-        if result.get("status") == "ok":
-            return {"path": path, "deleted": result.get("deleted", True)}
+        outcome = classify_op_status(result.get("status"))
+        if outcome in ("success", "partial", "unknown"):
+            out = {"path": path, "deleted": result.get("deleted", True)}
+            _forward_file_signal_fields(out, result, outcome=outcome)
+            return out
         return {"error": result.get("error", "delete failed")}
-
-    async def _file_list_directory(self, path: str) -> dict:
-        """List directory contents through op_runtime (glob).
-
-        Returns: {"path": path, "entries": [...]} or {"error": ...}.
-
-        Path normalisation: the LLM frequently sends ``"/"`` or ``""`` when
-        it really means "the project root I'm allowed to read". A literal
-        ``"/"`` resolves to the filesystem root, which is outside the
-        permission scope and triggers a misleading "no read permission"
-        error. Map both to ``"."`` (= cwd) so the typical "list files
-        here" intent works on a fresh project without requiring path
-        education.
-        """
-        normalised = path
-        if normalised in ("", "/", "./"):
-            normalised = "."
-        result = await self._file_op(
-            {"kind": "file", "op": "glob", "path": f"{normalised.rstrip('/')}/*"}
-        )
-        if result.get("status") == "ok":
-            return {"path": normalised, "entries": result.get("matches", [])}
-        return {"error": result.get("error", "list_directory failed")}
 
     async def _file_regenerate_index(
         self, *, path: str, output_path: str, entry_template: str, header: str,
@@ -6913,12 +6946,15 @@ class Session:
             "entry_template": entry_template,
             "header": header,
         })
-        if result.get("status") == "ok":
-            return {
+        outcome = classify_op_status(result.get("status"))
+        if outcome in ("success", "partial", "unknown"):
+            out = {
                 "path": path,
                 "output_path": output_path,
                 "entries": result.get("entries", 0),
             }
+            _forward_file_signal_fields(out, result, outcome=outcome)
+            return out
         return {"error": result.get("error", "regenerate_index failed")}
 
     async def _mcp_list_servers(self) -> list[dict]:

--- a/src/reyn/tools/file.py
+++ b/src/reyn/tools/file.py
@@ -13,8 +13,10 @@ router and phase gates allowed; phase-side dispatch unchanged in M3.
 Important: FileIROp uses `op` (not `action`) as the discriminator field.
 The `list_directory` router tool maps to `op="glob"` with a synthesised
 glob pattern (`<path>/*`) — there is no `list_directory` op in FileIROp.
-This is consistent with session.py `_file_list_directory` which also
-delegates to the glob op internally.
+(#3193: session.py previously had a sibling `_file_list_directory` wrapper
+delegating to the same glob op, but it had zero live callers — the
+RouterHostAdapter method it fed was never invoked, since list_directory
+has always flowed through this registry path instead — and was deleted.)
 """
 from __future__ import annotations
 
@@ -247,9 +249,10 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     """Adapter for list_directory — delegates to op_runtime file handler.
 
     FileIROp has no `list_directory` op variant; directory listing is
-    implemented via op="glob" with a synthesised `<path>/*` pattern.
-    This matches the router session._file_list_directory implementation
-    exactly (= single canonical approach, no divergence).
+    implemented via op="glob" with a synthesised `<path>/*` pattern —
+    this is the single canonical implementation (#3193: a sibling
+    session.py `_file_list_directory` wrapper that duplicated this same
+    glob-delegation was dead code and has been removed).
 
     Path normalisation: map "" / "/" / "./" to "." so the LLM's typical
     "list files here" intent resolves to cwd rather than filesystem root.
@@ -277,7 +280,7 @@ async def _handle_list(args: Mapping[str, Any], ctx: ToolContext) -> ToolResult:
     legacy_ctx = _build_legacy_op_context(ctx)
     result = await execute_op(op, legacy_ctx)
 
-    # Normalise to {path, entries} shape (= same as session._file_list_directory).
+    # Normalise to {path, entries} shape — the canonical list_directory result shape.
     # Preserve op="glob" + status + matches so file_to_canonical's glob branch
     # fires (#2695: dropping op made the mapper fall through to "None: ok",
     # silently losing the listing). entries is the caller-ergonomic alias;

--- a/tests/_support/router_host_adapter.py
+++ b/tests/_support/router_host_adapter.py
@@ -25,10 +25,6 @@ async def null_file_delete(path: str) -> dict:
     return {"path": path, "deleted": True}
 
 
-async def null_file_list(path: str) -> dict:
-    return {"path": path, "entries": []}
-
-
 async def null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
@@ -144,7 +140,6 @@ def make_adapter(
         file_read=null_file_read,
         file_write=null_file_write,
         file_delete=null_file_delete,
-        file_list_directory=null_file_list,
         file_regenerate_index=null_file_regen,
         mcp_list_servers=null_mcp_list_servers,
         mcp_list_tools=null_mcp_list_tools,

--- a/tests/test_2597_s2b_mcp_notifications_bridge.py
+++ b/tests/test_2597_s2b_mcp_notifications_bridge.py
@@ -40,10 +40,6 @@ async def _null_file_delete(path: str) -> dict:
     return {"path": path, "deleted": True}
 
 
-async def _null_file_list(path: str) -> dict:
-    return {"path": path, "entries": []}
-
-
 async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
@@ -102,7 +98,6 @@ def _make_adapter(*, tmp_path: Path, events: EventLog) -> RouterHostAdapter:
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=_probe,

--- a/tests/test_3193_file_wrapper_truncation_signal.py
+++ b/tests/test_3193_file_wrapper_truncation_signal.py
@@ -1,0 +1,119 @@
+"""Tier 2: Session._file_* wrapper truncation-signal forwarding (#3193).
+
+#3193: `Session._file_read` (and its siblings) whitelisted `status == "ok"`
+and collapsed every other status — most damagingly `"truncated"` — into
+`{"error": "read failed"}`, discarding content that had actually been read
+successfully. The fix routes every wrapper through the single
+`classify_op_status` classifier and forwards the #3193 signal fields
+(`truncated`, `note`, ...) untouched instead of dropping them.
+
+Real files, real Session, real MemoryService — no mocks (testing policy).
+A genuinely large file (2MB) is used to force a REAL op_runtime truncation
+(the window-derived inline cap floors at 8KB and, even for the largest
+plausible model window, tops out far below 2MB — see
+src/reyn/core/context_builder.py's `control_ir_inline_cap`), not a
+hand-constructed `{"status": "truncated"}` fixture.
+
+Both halves of the invariant are pinned together per witness (per the
+issue's explicit requirement): content is present AND the truncation is
+signalled. Pinning only one half would not catch a regression that
+resurrects the "drop the signal, keep the content" bug in a new form.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests._support.agent_session import make_session
+
+_LINE = "x" * 40 + "\n"
+_LINE_COUNT = 100_000  # 100_000 * 41 bytes ~= 4.1 MB — far past any plausible inline cap.
+
+
+@pytest.mark.asyncio
+async def test_file_read_forwards_content_and_truncation_signal_together(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: a real truncated read returns BOTH usable content AND the
+    truncation signal — neither alone. Pre-#3193 this returned
+    {"error": "read failed"} instead, discarding the content it had
+    actually read."""
+    monkeypatch.chdir(tmp_path)
+    big_file = tmp_path / "big.txt"
+    big_file.write_text(_LINE * _LINE_COUNT, encoding="utf-8")
+
+    session = make_session(agent_name="test-agent-3193-read")
+    result = await session._file_read("big.txt")
+
+    assert "error" not in result, f"unexpected error: {result.get('error')}"
+    # Half 1: content survived — it is a real, non-empty prefix of the file.
+    assert result["content"], "content must not be dropped on a truncated read"
+    assert result["content"] == _LINE * (len(result["content"]) // len(_LINE))
+    assert len(result["content"]) < len(_LINE) * _LINE_COUNT, (
+        "expected content to actually be truncated (shorter than the full file) "
+        "— if this fails, the inline cap did not trigger for this file size"
+    )
+    # Half 2: the truncation signal is present, not silently dropped.
+    assert result.get("truncated") is True
+    assert "note" in result and "truncated" in result["note"]
+    assert "next_offset" in result
+
+
+@pytest.mark.asyncio
+async def test_file_read_plain_success_has_no_truncation_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: regression guard — a small, un-truncated read must NOT carry
+    a spurious truncation signal (the two states stay distinguishable)."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "small.txt").write_text("hello world\n", encoding="utf-8")
+
+    session = make_session(agent_name="test-agent-3193-read-small")
+    result = await session._file_read("small.txt")
+
+    assert result == {"path": "small.txt", "content": "hello world\n"}
+
+
+@pytest.mark.asyncio
+async def test_file_read_not_found_still_reports_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: regression guard — a genuinely missing file still reports the
+    specific not-found error, unaffected by the classifier refactor."""
+    monkeypatch.chdir(tmp_path)
+    session = make_session(agent_name="test-agent-3193-read-missing")
+    result = await session._file_read("does-not-exist.txt")
+    assert result == {"error": "file not found: does-not-exist.txt"}
+
+
+@pytest.mark.asyncio
+async def test_memory_read_body_forwards_truncation_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: MemoryService.read_body is a live consumer downstream of
+    Session._file_read (session.py wires `file_read=self._file_read`
+    directly — #3193's ticket calls this out as the second live consumer
+    to verify, not just the wrapper's own return dict). Pre-fix, read_body
+    hand-picked only `content` off the `_file_read` result, so even after
+    `_file_read` started forwarding `truncated`/`note`, read_body silently
+    dropped them again at its own layer — the same family of bug at a
+    second altitude."""
+    monkeypatch.chdir(tmp_path)
+    session = make_session(agent_name="test-agent-3193-memory")
+
+    # Write directly at the path MemoryService.read_body will read from,
+    # bypassing `remember()` (which would re-wrap frontmatter around
+    # content, complicating the truncation-size math) — the read path
+    # under test is read_body -> Session._file_read, not remember().
+    body_path = Path(session._memory.memory_path("agent", "big-note"))
+    body_path.parent.mkdir(parents=True, exist_ok=True)
+    body_path.write_text(_LINE * _LINE_COUNT, encoding="utf-8")
+
+    read = await session._memory.read_body(layer="agent", slug="big-note")
+
+    assert "error" not in read, f"unexpected error: {read.get('error')}"
+    assert read["content"], "content must not be dropped"
+    assert len(read["content"]) < len(_LINE) * _LINE_COUNT
+    assert read.get("truncated") is True
+    assert "note" in read and "truncated" in read["note"]

--- a/tests/test_3193_file_wrapper_truncation_signal.py
+++ b/tests/test_3193_file_wrapper_truncation_signal.py
@@ -88,6 +88,51 @@ async def test_file_read_not_found_still_reports_error(
 
 
 @pytest.mark.asyncio
+async def test_router_host_adapter_file_read_string_carries_truncation_note(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: co-vet finding — `RouterHostAdapter.file_read` (the legacy
+    router-chat path predating the #2782/#3082 registry-dispatch migration)
+    is the SECOND `Session._file_read` consumer, and it flattens the dict to
+    a bare string for the LLM. Asserting only on the wrapper's own dict (as
+    the first round of #3193 tests did) cannot catch this: the dict was
+    correct, but the adapter discarded `note`/`truncated` on the way to a
+    plain string, so the LLM never saw the signal at all — "loaded onto the
+    dict but nobody reads it downstream" (co-vet: the same failure mode
+    #2998/#3190/#3192 already found for list_directory/read_file's
+    registry-dispatch sibling). This test asserts on the actual string the
+    LLM receives, mirroring the #3192 witness shape."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "big.txt").write_text(_LINE * _LINE_COUNT, encoding="utf-8")
+
+    session = make_session(agent_name="test-agent-3193-adapter-read")
+    llm_visible = await session.router_host.file_read("big.txt")
+
+    assert isinstance(llm_visible, str)
+    assert _LINE.strip() in llm_visible, "content must still reach the LLM"
+    assert "truncated" in llm_visible, (
+        "the truncation note must reach the LLM-visible string, not just "
+        "the wrapper's internal dict"
+    )
+    assert "on disk at" in llm_visible  # part of the op_runtime `note` text
+
+
+@pytest.mark.asyncio
+async def test_router_host_adapter_file_read_string_no_spurious_note_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: regression guard — a plain successful read's LLM-visible
+    string is exactly the file content, no note appended."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "small.txt").write_text("hello world\n", encoding="utf-8")
+
+    session = make_session(agent_name="test-agent-3193-adapter-read-small")
+    llm_visible = await session.router_host.file_read("small.txt")
+
+    assert llm_visible == "hello world\n"
+
+
+@pytest.mark.asyncio
 async def test_memory_read_body_forwards_truncation_signal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_3193_op_status_classifier_coverage.py
+++ b/tests/test_3193_op_status_classifier_coverage.py
@@ -1,0 +1,149 @@
+"""Tier 2: op_runtime status-classifier completeness gate (#3193).
+
+#3193's root cause was a per-wrapper WHITELIST of `status == "ok"` (a
+curated subset) collapsing every other status — most damagingly
+"truncated" — into a lying `{"error": "read failed"}`. The fix moves
+success/failure classification into ONE place
+(`reyn.core.op_runtime.status_classify.classify_op_status`) whose
+known-status tables must stay a superset of the LIVE status vocabulary
+op_runtime actually returns.
+
+This is an "enumerate, don't curate" gate (#3075 idiom, mirrored from
+`tests/test_network_egress_env_completeness_3075.py`): it AST-walks every
+`op_runtime/*.py` file for dict-literal `"status": "<value>"` entries
+rather than hand-maintaining a second copy of the status list, so a new
+status value added anywhere in op_runtime is caught automatically instead
+of depending on someone remembering to also update this file.
+
+Vacuity guard: `test_status_enumeration_is_nonempty` fails loudly if the
+AST walk ever finds fewer than 10 status literals — the current live count
+is 15. Without this, a broken enumeration (wrong path, a Python-version AST
+shape change) would make the coverage assertion below trivially pass over
+an empty set, which is a green rubber stamp, not a gate.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        if (ancestor / "pyproject.toml").is_file():
+            return ancestor
+    raise RuntimeError("repo root not found from " + str(here))
+
+
+def _enumerate_status_literals() -> set[str]:
+    """AST-walk every src/reyn/core/op_runtime/*.py file and collect every
+    string literal assigned to a dict key literally named "status"."""
+    found: set[str] = set()
+    op_runtime_dir = _repo_root() / "src" / "reyn" / "core" / "op_runtime"
+    for py_file in sorted(op_runtime_dir.glob("*.py")):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Dict):
+                continue
+            for key, value in zip(node.keys, node.values):
+                if (
+                    isinstance(key, ast.Constant) and key.value == "status"
+                    and isinstance(value, ast.Constant) and isinstance(value.value, str)
+                ):
+                    found.add(value.value)
+    return found
+
+
+def test_status_enumeration_is_nonempty() -> None:
+    """Tier 2: vacuity guard — a broken enumeration (wrong path, an AST-shape
+    change under a Python version bump) must fail loudly here rather than
+    silently emptying the set the coverage test below checks.
+
+    Deliberately NOT a `len(found) >= N` size pin (Tier 4 format-pinning per
+    `test_tier_audit.py`'s "N passed is a census, not a behavior" rule) —
+    instead, assert that specific status literals KNOWN to live in
+    op_runtime's file/web/mcp handlers (spanning several different source
+    files, so a single-file enumeration bug can't accidentally satisfy all
+    of them) are actually found. If the AST walk is broken (wrong path, an
+    AST-shape change), these behavioral memberships fail instead of the
+    coverage test below silently passing over an empty set."""
+    found = _enumerate_status_literals()
+    # One sentinel per distinct op_runtime source file that defines it, so a
+    # bug in globbing/parsing *one* file cannot make every sentinel vacuously
+    # present via a single easy-to-satisfy file.
+    expected_present = {
+        "ok": "file.py / web.py / mcp.py / ... (near-universal happy path)",
+        "truncated": "file.py (read op's inline-cap overflow — #3193's own bug)",
+        "not_found": "file.py (read op's missing-file path)",
+        "denied": "file.py (media-size gate) / web.py (SSRF deny)",
+        "timeout": "web.py (web_fetch timeout)",
+        "needs_secrets": "mcp_install.py (unresolved secret dependency)",
+        "installed": "plugin_install.py / skill_install.py / mcp_install.py",
+    }
+    missing_sentinels = set(expected_present) - found
+    assert not missing_sentinels, (
+        f"expected sentinel status literals {sorted(missing_sentinels)} were "
+        f"NOT found by the AST enumeration (found only {sorted(found)}) — "
+        f"the enumeration is very likely broken (wrong path / AST-shape "
+        f"change), not the source code. Missing sentinels' known origin: "
+        f"{ {k: v for k, v in expected_present.items() if k in missing_sentinels} }"
+    )
+
+
+def test_classifier_covers_every_known_status_literal() -> None:
+    """Tier 2: reyn.core.op_runtime.status_classify's known-status tables
+    must be a superset of every literal "status" string op_runtime can
+    return — else a NEW op status silently falls into classify_op_status's
+    "unknown" bucket without anyone noticing at review time."""
+    from reyn.core.op_runtime.status_classify import ALL_KNOWN_STATUSES
+
+    found = _enumerate_status_literals()
+    missing = found - ALL_KNOWN_STATUSES
+    assert not missing, (
+        f"op_runtime returns status value(s) {sorted(missing)} that "
+        f"reyn.core.op_runtime.status_classify does not classify — add "
+        f"them to KNOWN_SUCCESS_STATUSES / KNOWN_PARTIAL_STATUSES / "
+        f"KNOWN_FAILURE_STATUSES in src/reyn/core/op_runtime/status_classify.py "
+        f"(#3193)."
+    )
+
+
+def test_known_status_tables_do_not_overlap() -> None:
+    """Tier 1: contract — the three known-status sets partition the known
+    vocabulary; a status appearing in two buckets would make
+    classify_op_status's outcome depend on set-iteration/construction
+    order rather than being well-defined."""
+    from reyn.core.op_runtime.status_classify import (
+        KNOWN_FAILURE_STATUSES,
+        KNOWN_PARTIAL_STATUSES,
+        KNOWN_SUCCESS_STATUSES,
+    )
+
+    assert not (KNOWN_SUCCESS_STATUSES & KNOWN_PARTIAL_STATUSES)
+    assert not (KNOWN_SUCCESS_STATUSES & KNOWN_FAILURE_STATUSES)
+    assert not (KNOWN_PARTIAL_STATUSES & KNOWN_FAILURE_STATUSES)
+
+
+def test_classify_op_status_unknown_status_is_neither_success_nor_failure() -> None:
+    """Tier 1: contract — classify_op_status's design for a status value it
+    does not recognize (#3193's "don't silently kill unknown into failure"
+    requirement): a bogus/future status string must classify as "unknown",
+    not silently fold into "success" or "failure"."""
+    from reyn.core.op_runtime.status_classify import classify_op_status
+
+    assert classify_op_status("some_future_status_nobody_added_yet") == "unknown"
+    assert classify_op_status(None) == "unknown"
+    assert classify_op_status(123) == "unknown"
+
+
+def test_classify_op_status_known_values() -> None:
+    """Tier 1: contract — spot-check the three known buckets classify as
+    documented (regression pin for "ok"/"not_found" plus the "truncated"
+    partial status this issue is about)."""
+    from reyn.core.op_runtime.status_classify import classify_op_status
+
+    assert classify_op_status("ok") == "success"
+    assert classify_op_status("truncated") == "partial"
+    assert classify_op_status("not_found") == "failure"
+    assert classify_op_status("denied") == "failure"
+    assert classify_op_status("error") == "failure"

--- a/tests/test_action_retrieval_wiring.py
+++ b/tests/test_action_retrieval_wiring.py
@@ -68,7 +68,6 @@ def _make_adapter(
         file_read=_noop_callable,
         file_write=_noop_callable,
         file_delete=_noop_callable,
-        file_list_directory=_noop_callable,
         file_regenerate_index=_noop_callable,
         mcp_list_servers=_noop_callable,
         mcp_list_tools=_noop_callable,

--- a/tests/test_agui_reasoning_map_p6a.py
+++ b/tests/test_agui_reasoning_map_p6a.py
@@ -140,7 +140,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list) -> RouterHostAdap
         journal=None, agent_registry=None,
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
-        file_list_directory=_noop, file_regenerate_index=_noop,
+        file_regenerate_index=_noop,
         mcp_list_servers=_noop, mcp_list_tools=_noop, mcp_call_tool=_noop,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),

--- a/tests/test_chat_router_modelspec_kwargs_1654.py
+++ b/tests/test_chat_router_modelspec_kwargs_1654.py
@@ -45,7 +45,7 @@ def _mk_host_with_kwargs():
             file_write=_noop, file_read=_noop, file_delete=_noop, file_regenerate_index=_noop),
         journal=None, agent_registry=None,
         agent_workspace_dir=workspace,
-        file_read=_noop, file_write=_noop, file_delete=_noop, file_list_directory=_noop,
+        file_read=_noop, file_write=_noop, file_delete=_noop,
         file_regenerate_index=_noop, mcp_list_servers=_noop, mcp_list_tools=_noop,
         mcp_call_tool=_noop, send_to_agent=_noop,
         put_outbox=_noop, append_history=_noop,

--- a/tests/test_mcp_cache_warm_start.py
+++ b/tests/test_mcp_cache_warm_start.py
@@ -44,10 +44,6 @@ async def _null_file_delete(path: str) -> dict:
     return {"path": path, "deleted": True}
 
 
-async def _null_file_list(path: str) -> dict:
-    return {"path": path, "entries": []}
-
-
 async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
@@ -132,7 +128,6 @@ def _make_adapter(
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=probe,

--- a/tests/test_mcp_lazy_tools_cache.py
+++ b/tests/test_mcp_lazy_tools_cache.py
@@ -38,10 +38,6 @@ async def _null_file_delete(path: str) -> dict:
     return {"path": path, "deleted": True}
 
 
-async def _null_file_list(path: str) -> dict:
-    return {"path": path, "entries": []}
-
-
 async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
@@ -106,7 +102,6 @@ def _make_adapter_with_mcp(
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=mcp_list_tools_cb,

--- a/tests/test_mcp_yaml_mtime_watch.py
+++ b/tests/test_mcp_yaml_mtime_watch.py
@@ -44,10 +44,6 @@ async def _null_file_delete(path: str) -> dict:
     return {"path": path, "deleted": True}
 
 
-async def _null_file_list(path: str) -> dict:
-    return {"path": path, "entries": []}
-
-
 async def _null_file_regen(*, path, output_path, entry_template, header) -> dict:
     return {"path": path, "output_path": output_path, "entries": 0}
 
@@ -142,7 +138,6 @@ def _make_adapter(
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=probe,
@@ -565,7 +560,6 @@ async def test_session_handle_user_message_calls_yaml_watch_before_reload(
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=probe,

--- a/tests/test_reasoning_integration_1652.py
+++ b/tests/test_reasoning_integration_1652.py
@@ -50,7 +50,7 @@ def _mk_host(reasoning_config, *, outbox: list, history: list, section: str = ""
         journal=None, agent_registry=None,
         agent_workspace_dir=workspace,
         file_read=_noop, file_write=_noop, file_delete=_noop,
-        file_list_directory=_noop, file_regenerate_index=_noop,
+        file_regenerate_index=_noop,
         mcp_list_servers=_noop, mcp_list_tools=_noop, mcp_call_tool=_noop,
         send_to_agent=_noop,
         put_outbox=lambda msg: outbox.append(msg) or _noop(),

--- a/tests/test_router_host_adapter_invariants.py
+++ b/tests/test_router_host_adapter_invariants.py
@@ -51,9 +51,6 @@ from tests._support.router_host_adapter import (
     null_file_delete as _null_file_delete,
 )
 from tests._support.router_host_adapter import (
-    null_file_list as _null_file_list,
-)
-from tests._support.router_host_adapter import (
     null_file_read as _null_file_read,
 )
 from tests._support.router_host_adapter import (
@@ -184,7 +181,6 @@ def test_delegation_tracker_appended_on_send_to_agent(tmp_path):
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=_null_mcp_list_tools,
@@ -257,7 +253,6 @@ def test_adapter_exposes_permission_resolver_property(tmp_path):
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=_null_mcp_list_tools,
@@ -317,7 +312,6 @@ def test_make_router_op_context_wires_intervention_bus(tmp_path):
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=_null_mcp_list_tools,
@@ -376,7 +370,6 @@ def test_make_router_op_context_no_factory_leaves_bus_none(tmp_path):
         file_read=_null_file_read,
         file_write=_null_file_write,
         file_delete=_null_file_delete,
-        file_list_directory=_null_file_list,
         file_regenerate_index=_null_file_regen,
         mcp_list_servers=_null_mcp_list_servers,
         mcp_list_tools=_null_mcp_list_tools,

--- a/tests/test_router_loop_chatsession.py
+++ b/tests/test_router_loop_chatsession.py
@@ -241,7 +241,7 @@ def test_chatsession_satisfies_host_protocol(tmp_path, monkeypatch):
         "get_memory_index", "get_file_permissions", "get_mcp_servers",
         "memory_path", "memory_dir",
         "send_to_agent", "put_outbox",
-        "file_read", "file_write", "file_delete", "file_list_directory",
+        "file_read", "file_write", "file_delete",
         "file_regenerate_index",
         "mcp_list_servers", "mcp_list_tools", "mcp_call_tool",
         "resolve_model",


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3193

## Summary
- `Session._file_read/_write/_delete/_regenerate_index` whitelisted `status == "ok"` and collapsed every other status — most damagingly `"truncated"` — into a lying `{"error": "read failed"}`, discarding content that had actually been read. `status` is an open vocabulary (15 distinct literal values across `op_runtime`, no typed enum), so a per-wrapper whitelist reproduces the same hole on the next new status.
- Adds a single classifier, `reyn.core.op_runtime.status_classify.classify_op_status`, that every wrapper routes through: `KNOWN_SUCCESS_STATUSES` / `KNOWN_PARTIAL_STATUSES` / `KNOWN_FAILURE_STATUSES` tables plus an explicit `"unknown"` outcome for anything not yet classified. Unknown statuses are forwarded best-effort (content preserved, tagged `_unknown_op_status`, logged) — never silently folded into either success or failure.
- Truncation signal fields (`note`/`next_offset`/`truncated`/`total_count`/...) are now forwarded untouched by all four wrappers, and by `MemoryService.read_body`, which had its own second copy of the same curation bug one layer up (it hand-picked only `content` off the `_file_read` result).
- Deletes `Session._file_list_directory` and `RouterHostAdapter`'s sibling `file_list_directory` method/constructor-param/Protocol member — confirmed zero live call sites (list_directory has always flowed through the `tools/file.py` registry path instead); updated all test call sites that passed the now-removed kwarg.
- New CI gate (`tests/test_3193_op_status_classifier_coverage.py`): AST-enumerates every literal `"status": "..."` op_runtime returns and asserts the classifier's known-status tables are a superset — "enumerate, don't curate" (#3075 idiom), with a vacuity guard (sentinel-membership check, not a `len(...)` pin) so a broken enumeration fails loudly instead of vacuously passing.

## Design notes (per the ticket's firm design)
- **Classifier location**: `src/reyn/core/op_runtime/status_classify.py` — one module, one function (`classify_op_status`), imported by all four `Session._file_*` wrappers via a shared `_forward_file_signal_fields` helper in `session.py`.
- **Unknown-status handling**: forwarded as best-effort success-shaped output (content preserved), tagged `_unknown_op_status`, and logged via `logger.warning` — not silently treated as failure (the original bug) nor silently treated as clean success (could mask a real new failure mode). See the module docstring in `status_classify.py` for the full rationale.
- **Dead wrapper removal**: `Session._file_list_directory` had exactly one caller (the `RouterHostAdapter` constructor wiring), and `RouterHostAdapter.file_list_directory` itself had zero callers repo-wide (verified via `git grep -n "\.file_list_directory("` across src/tests/docs). Deleted rather than patched, per the ticket's instruction not to make dead code look alive.
- **`MemoryService.read_body`**: verified as the second live consumer named in the ticket — it had its own independent curation bug (hand-picked `content` only), fixed to forward all extra `_file_read` keys generically instead of re-curating a second whitelist.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3193_op_status_classifier_coverage.py tests/test_3193_file_wrapper_truncation_signal.py` — 9/9 OK, 0 Tier-4 violations
- [x] `pytest -q -n auto --timeout=120 -rs` (repo root, foreground) — green (9385 passed, 36 skipped); one intermittent unrelated failure (`test_litellm_trusts_standard_proxy_env`, network-egress env test) seen once across 3 runs, reproduced as flaky (passes in isolation, passes on a repeat full-suite run) — not reproduced deterministically on `origin/main` with the identical full-suite command, so treated as pre-existing xdist test-order flakiness, not a regression from this change
- [x] `python scripts/verify_module_docstrings.py` on all changed `src/` files — clean
- [x] Strip-falsify: reverted `_file_read` + `MemoryService.read_body` to their pre-fix bodies — both new truncation-witness tests went RED (reproducing the original `{"error": "read failed"}` bug) while the small-file/not-found regression tests stayed green; restored, re-verified green
- [x] Strip-falsify: removed a known status from `status_classify.py` — the AST completeness gate failed as expected; restored
- [x] Real 4MB file used to force a genuine `op_runtime` truncation (not a hand-built fixture) for both the `Session._file_read` and `MemoryService.read_body` witnesses
- [ ] (waived — doc surface) No doc describes the pre-fix wrapper whitelist behavior; grepped `docs/` for `_file_read`/`_file_write`/`_file_delete`/`_file_list_directory`/`_file_regenerate_index`/`read failed` — only permission-model / control-ir docs reference unrelated `require_file_write` gating, nothing describes this wrapper's status-classification contract