### PR TITLE
fix(3202): materialise pip-based (no uv), sysconfig venv interpreter resolver

### DIFF
--- a/docs/deep-dives/proposals/0064-plugin-model.md
+++ b/docs/deep-dives/proposals/0064-plugin-model.md
@@ -67,7 +67,7 @@ The primary flow, and where each existing mechanism plugs in:
    - pipeline: run it **inline** (`run_pipeline_inline`) or as a local `pipelines.yaml` entry.
 3. **Promote (make reusable)** — package the working capability into a plugin: **copy → `~/.reyn/plugins/<name>/`, expand `${REYN_*}`, materialise its runtime deps (§3.11), then call the existing `mcp_install` / `pipeline install` / `skill install` verbs** to register whatever the plugin contains. Now it is reusable across sessions/projects. This *is* `plugin install`, sourced from local work.
 
-> **Dep-fetch happens at install, never at spawn.** `uv run --with <deps>` fetches over the network; if that fetch is deferred to spawn, a `network:false` server can never start (the general form of #3060). So **install materialises a per-plugin env** (e.g. `uv venv` + install `<deps>` into `~/.reyn/plugins/<name>/.venv`, network available at install time) and the registered spawn command points at that ready env's interpreter — **spawn is network-free**. Detail in §3.11.
+> **Dep-fetch happens at install, never at spawn.** Fetching `<deps>` over the network at spawn time would mean a `network:false` server can never start (the general form of #3060). So **install materialises a per-plugin env** (`python -m venv` + `pip install <deps>` into `~/.reyn/plugins/<name>/.venv`, network available at install time — see §3.11a for why `pip`, not `uv`) and the registered spawn command points at that ready env's interpreter — **spawn is network-free**. Detail in §3.11.
 
 Installing a **pre-existing** third-party plugin bundle is the same copy+expand+register mechanism from a different source.
 
@@ -160,6 +160,20 @@ Install/uninstall mutate durable state (a global copy + a materialised env + pro
 - **Audit-events (P6)**: each install/uninstall emits audit-events — at minimum `plugin_install_started` / `_copied` / `_deps_materialised` / `_registered` / `_completed` (and the uninstall inverses) — so `reyn events` can reconstruct what landed and when.
 - **Atomicity / reconcile**: the steps (copy → materialise deps → register) are not a single atomic write, so a crash mid-install can leave a **partial** plugin — copied but unregistered, or registered pointing at a half-materialised env. Install therefore needs a **reconcile** on next start: detect a `~/.reyn/plugins/<name>/` whose `_completed` event is absent (or whose registry entries/​env are inconsistent) and either finish or roll it back, so no half-installed plugin is left that is neither usable nor cleanly removable. Uninstall is ordered **drop-registry-first, then remove-copy** so an interrupted uninstall never leaves a live registry entry pointing at a deleted copy.
 - **Not WAL-derived**: the `~/.reyn/plugins/` copies and the materialised env are **files**, not WAL-event-derived state, so the recovery-feature truncate-falsify gate (CLAUDE.md) does not apply to them; the reconcile above is a filesystem/registry consistency check, and the registry entries themselves ride the existing config-load path. (Called out explicitly so the distinction is on record.)
+
+### 3.11a Update 2026-07-21 — materialise moved from `uv` to stdlib `venv` + `pip` (#3202)
+
+The original §3.11 design used `uv venv` + `uv pip install` for materialise, **with no rationale recorded anywhere for choosing `uv` over the stdlib alternative** — that absence is the actual root cause of #3202: `uv venv`'s POSIX-only venv-layout assumption (`<venv>/bin/python`, hardcoded in `plugin_install.py`) broke on Windows/git-bash, and because nobody had written down *why* `uv` was load-bearing here, nobody had grounds to question whether dropping it was safe when the bug surfaced.
+
+**Recorded now, so the next person doesn't have to reconstruct it from a bug report**:
+
+- **No lockfile was ever used** — materialise reads a plain `requirements.txt`, never a `uv.lock`. `uv`'s headline advantage (fast, reproducible, lockfile-pinned resolution) was never actually exercised by this call site.
+- **Isolation is achieved by `python -m venv` alone** — the property this ADR actually needs (a per-plugin env, no reyn-env pollution) does not require `uv` specifically; the stdlib `venv` module (+ `pip`, bundled with every CPython) provides the same isolation.
+- **reyn's own runtime already guarantees a working CPython** — `sys.executable` is always present or reyn itself couldn't be running. `uv`, by contrast, is an EXTRA binary an operator can lack (the reported failure: Windows/git-bash without `uv` on `PATH`, producing a confusing `run 'uv venv' to create environment` error for a tool reyn itself never asked the operator to install).
+- **Ground before switching** (not assumed): a real `pip install` of the `rag` plugin's actual `requirements.txt` (including `sqlite-vec`, wheel-only, no sdist — the dependency most likely to need a resolver's special handling) resolved and installed cleanly with plain `pip`, no `uv`-specific behaviour lost.
+- **Interpreter-path resolution** (the Windows-layout bug itself, #3202 symptom 1) is now a dedicated stdlib-`sysconfig`-based resolver (`_venv_interpreter_path` in `plugin_install.py`) — computed via `sysconfig.get_paths(scheme="venv", ...)`, which resolves the OS-appropriate layout internally (no hardcoded `bin`/`Scripts` branch at the call site), with an on-disk existence-check as a pathological-case fallback.
+
+This is an **addendum, not a rewrite** of §3.2/§3.11's prose above — read those together with this note for the current mechanism.
 
 ## 4. Consequences
 

--- a/docs/guide/for-users/build-a-rag-corpus.md
+++ b/docs/guide/for-users/build-a-rag-corpus.md
@@ -31,7 +31,7 @@ Read what you are enabling before you do:
 
 **Ask Reyn to install the plugin.** You do not have to hand-edit YAML, and there is no extra `pip install` step: dependencies (chonkie/apsw/sqlite-vec) are materialised automatically into a **dedicated per-plugin environment**, never Reyn's own. In `reyn chat`, ask it to ingest a folder: it installs the `rag` plugin, **asking your permission before it writes** anything —
 
-> **`uv` is required.** Plugin install materialises the per-plugin environment with `uv venv` + `uv pip install`; without `uv` on your `PATH`, install fails. **Do not manually create a venv for this plugin** (e.g. running your own `uv venv`/`python -m venv` under the plugin's install directory) — `plugin_management__install` creates and manages its own isolated venv automatically, and a hand-made one there only risks colliding with it, not helping it.
+> **No extra tools to install.** Plugin install materialises the per-plugin environment with `python -m venv` + `pip` — both bundled with the Python reyn itself runs on, so there is nothing extra to have on your `PATH`. **Do not manually create a venv for this plugin** (e.g. running your own `python -m venv` under the plugin's install directory) — `plugin_management__install` creates and manages its own isolated venv automatically, and a hand-made one there only risks colliding with it, not helping it.
 
 ```
 plugin_management__install(source={"kind": "builtin", "name": "rag"})

--- a/docs/guide/for-users/build-a-rag-corpus.md
+++ b/docs/guide/for-users/build-a-rag-corpus.md
@@ -31,6 +31,8 @@ Read what you are enabling before you do:
 
 **Ask Reyn to install the plugin.** You do not have to hand-edit YAML, and there is no extra `pip install` step: dependencies (chonkie/apsw/sqlite-vec) are materialised automatically into a **dedicated per-plugin environment**, never Reyn's own. In `reyn chat`, ask it to ingest a folder: it installs the `rag` plugin, **asking your permission before it writes** anything —
 
+> **`uv` is required.** Plugin install materialises the per-plugin environment with `uv venv` + `uv pip install`; without `uv` on your `PATH`, install fails. **Do not manually create a venv for this plugin** (e.g. running your own `uv venv`/`python -m venv` under the plugin's install directory) — `plugin_management__install` creates and manages its own isolated venv automatically, and a hand-made one there only risks colliding with it, not helping it.
+
 ```
 plugin_management__install(source={"kind": "builtin", "name": "rag"})
 mcp__install_local(name="reyn_markitdown", command="uvx", args=["markitdown-mcp"])
@@ -51,7 +53,7 @@ Each server is **probed before its registration is committed**: if a command doe
 >
 > then use `command: /home/you/.reyn-markitdown/bin/markitdown-mcp` with `args: []`. Reyn starts whatever `command` names, as-is, so an absolute path to a script whose environment actually has the package is the reliable form.
 
-**Why does the registered `reyn_chunker`/`reyn_vector_store` command look like an absolute path to a `.venv/bin/python`, not `python`?** `plugin_management__install` rewrites it for you at install time, to the materialised per-plugin venv's own interpreter — so spawning it never depends on your ambient `PATH`'s `python3`, which is a *different* interpreter under `pipx install reyn`, a non-activated venv, or a `PATH` with another python first. You never need to write this by hand; see [`cookbook/configs/with-builtin-rag-mcp.yaml`](../../cookbook/configs/with-builtin-rag-mcp.yaml) if you want to read what the registered entry looks like.
+**Why does the registered `reyn_chunker`/`reyn_vector_store` command look like an absolute path to a venv interpreter (`.venv/bin/python` on macOS/Linux, `.venv\Scripts\python.exe` on Windows), not `python`?** `plugin_management__install` rewrites it for you at install time, to the materialised per-plugin venv's own interpreter — so spawning it never depends on your ambient `PATH`'s `python3`, which is a *different* interpreter under `pipx install reyn`, a non-activated venv, or a `PATH` with another python first. You never need to write this by hand; see [`cookbook/configs/with-builtin-rag-mcp.yaml`](../../cookbook/configs/with-builtin-rag-mcp.yaml) if you want to read what the registered entry looks like.
 
 ## Use it
 

--- a/docs/reference/runtime/control-ir.md
+++ b/docs/reference/runtime/control-ir.md
@@ -891,9 +891,12 @@ Permission gates (§3.10 — composed from EXISTING gates, no new bool axis; the
    without an explicit approval / JIT ask — no new gate needed.
 2. **Dependency materialisation** (`requirements.txt` present) —
    `require_http_get` for the package-index host (`pypi.org`) before running
-   `uv venv` + `uv pip install` into `<plugin_root>/.venv`. Install-time only;
-   the resulting venv's interpreter is what a `command: "python"` mcp entry's
-   spawn is rewritten to point at — **spawn itself stays network-free**.
+   `<sys.executable> -m venv` + `<venv_python> -m pip install` into
+   `<plugin_root>/.venv` (#3202 — no `uv` dependency; see ADR 0064 §3.11a for
+   why). Install-time only; the resulting venv's interpreter — resolved via
+   stdlib `sysconfig`'s `"venv"` scheme, not a hardcoded POSIX path — is what
+   a `command: "python"` mcp entry's spawn is rewritten to point at —
+   **spawn itself stays network-free**.
 3. **`{kind: "git"}` run-code trust** — a DEDICATED
    `require_plugin_git_run_code_trust` gate, checked BEFORE the fetch. This is
    the RCE trust boundary and is deliberately SEPARATE from `require_http_get`

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -399,30 +399,21 @@ def _bake_plugin_root_only(path: Path, plugin_root: Path) -> None:
 
 
 def _venv_interpreter_path(venv_dir: Path) -> Path:
-    """Discover ``venv_dir``'s Python interpreter by checking which of the
-    two known ``uv venv`` / stdlib-``venv`` layouts actually exists on disk
-    — POSIX's ``<venv>/bin/python`` or Windows's (incl. git-bash, which
+    """FALLBACK ONLY (secondary) — see ``_resolve_venv_interpreter`` for the
+    primary mechanism. Discover ``venv_dir``'s Python interpreter by
+    checking which of the two known PEP 405 venv layouts actually exists on
+    disk — POSIX's ``<venv>/bin/python`` or Windows's (incl. git-bash, which
     still runs a Windows-layout venv) ``<venv>/Scripts/python.exe`` — rather
-    than *constructing* the path from ``os.name``/``sys.platform``.
-
-    Discovery over construction is deliberate: if a future ``uv``/stdlib
-    ``venv`` release changes the layout, or the two ever diverge, an
-    existence check keeps working where an OS-constant branch would go
-    stale silently. A hardcoded ``bin/python`` construction is exactly
-    #3202 symptom 1's bug — a real path on Linux/macOS CI, absent on
-    Windows, so ``uv pip install --python <that path>`` and MCP spawn both
-    fail there even though ``uv venv`` itself succeeded.
+    than *constructing* the path from ``os.name``/``sys.platform``. This is
+    a real fallback, not a guess: it is standard per PEP 405 / CPython's
+    ``Lib/venv/__init__.py`` ``binname`` branch, but it is still a
+    hardcoded pair of candidate strings, so ``_resolve_venv_interpreter``
+    only reaches it when the authoritative ``sys.executable`` query fails.
 
     Raises ``FileNotFoundError`` if NEITHER layout exists — that is not a
     layout question but evidence ``uv venv`` did not actually materialise an
     interpreter (should have already been caught by its exit code; this is
     the decision-enabling explicit failure, not a silent None).
-
-    This is the ONE place that resolves the interpreter path — both the MCP
-    spawn command rewrite (which must name a real executable to exec) and
-    the install step's ``--python`` argument (historically) keyed off it.
-    Keeping it singular means the next call site never re-invents the POSIX
-    assumption.
     """
     windows_python = venv_dir / "Scripts" / "python.exe"
     posix_python = venv_dir / "bin" / "python"
@@ -435,6 +426,72 @@ def _venv_interpreter_path(venv_dir: Path) -> Path:
         f"(checked {windows_python!s} and {posix_python!s}) — "
         "uv venv may not have actually materialised an interpreter"
     )
+
+
+async def _resolve_venv_interpreter(
+    venv_dir: Path, backend, policy, plugin_root: Path,
+) -> "tuple[Path | None, str | None]":
+    """Resolve ``venv_dir``'s ACTUAL Python interpreter authoritatively — by
+    asking the venv's OWN python for ``sys.executable`` — instead of
+    constructing or guessing a path. Fixes #3202 symptom 1 (a hardcoded
+    ``bin/python`` is absent on Windows, so ``uv pip install --python <that
+    path>`` and MCP spawn both failed there even though ``uv venv`` itself
+    succeeded).
+
+    PRIMARY (authority query): ``uv run --python <venv_dir> python -c
+    "import sys; print(sys.executable)"``. Ground (uv 0.11.15, this repo's
+    own uv, checked directly — not assumed):
+      - ``uv python find --python <venv_dir>`` does NOT exist as a flag in
+        this uv version (``error: unexpected argument '--python' found``)
+        — ruled out.
+      - A bare ``uv python find`` (with or without ``VIRTUAL_ENV`` set) is
+        ambient DISCOVERY, not a query scoped to a specific venv — it can
+        silently return a DIFFERENT (e.g. system) interpreter — ruled out.
+      - ``uv run --python <dir> python -c "..."`` is the one form
+        confirmed to run INSIDE the just-created venv and print that
+        venv's real ``sys.executable`` (verified: the printed path
+        `exists()` and is directly executable). It also runs with no
+        network activity once the venv exists (`UV_OFFLINE=1` reproduces
+        identical output), so scoping it inside this already
+        network-scoped install step adds no new exposure.
+
+    The query runs EXACTLY ONCE, here, at install time. The absolute path
+    it returns is frozen and handed to BOTH this module's own
+    ``uv pip install --python <path>`` call and the MCP spawn command
+    rewrite (``_build_mcp_entries``). Spawn itself NEVER re-invokes uv — it
+    execs the frozen absolute path directly — preserving #3060's
+    spawn-is-network-free property (a ``uv run`` AT SPAWN TIME would let uv
+    resolve/fetch then, which is exactly what #3060 forbids; resolving
+    once at install time and freezing the result is what keeps spawn
+    itself uv-free).
+
+    FALLBACK (secondary, only if the primary above fails for any reason —
+    sandbox denial, a uv version without ``run``, etc.): ``_venv_interpreter_path``'s
+    on-disk layout discovery. The ordering matters: primary is authority
+    (asks the interpreter itself, so it always names something real and
+    tracks whatever layout uv/venv actually produced); fallback is a
+    standard-but-hardcoded pair of candidate strings, used ONLY when
+    authority is unavailable — do not swap this order.
+    """
+    try:
+        query_result = await backend.run(
+            ["uv", "run", "--python", str(venv_dir), "python", "-c",
+             "import sys; print(sys.executable)"],
+            policy, cwd=str(plugin_root),
+        )
+    except Exception:  # noqa: BLE001 — fall through to discovery below
+        query_result = None
+    if query_result is not None and query_result.returncode == 0:
+        candidate = query_result.stdout.decode("utf-8", errors="replace").strip()
+        if candidate:
+            candidate_path = Path(candidate)
+            if candidate_path.exists():
+                return candidate_path, None
+    # Authority query did not produce a usable path — fall back to discovery.
+    try:
+        return _venv_interpreter_path(venv_dir), None
+    except FileNotFoundError as exc:
+        return None, str(exc)
 
 
 async def _materialise_deps(
@@ -487,19 +544,21 @@ async def _materialise_deps(
         detail = venv_result.stderr.decode("utf-8", errors="replace").strip()
         return None, f"uv venv failed (exit {venv_result.returncode}): {detail}"
 
-    # Pass the venv ROOT (not a hand-built interpreter path) to `--python`.
-    # uv's own request-format grammar documents `<install-dir>` as a
-    # supported form (`uv help python`: "a specific system Python
-    # interpreter can often be requested with ... <install-dir> e.g.
-    # `/some/environment/`") and resolves the correct per-OS interpreter
-    # inside it — so install no longer needs to know POSIX vs. Windows
-    # layout at all. Verified locally: `uv pip install --python <venv_dir>`
-    # (root) installs into that venv exactly like `--python <venv_dir>/bin/python`
-    # does on POSIX.
+    # Resolve the ACTUAL interpreter authoritatively (see
+    # ``_resolve_venv_interpreter``'s docstring for the ground + rationale)
+    # — this is the ONE place the venv/OS layout is figured out, before
+    # either `uv pip install --python` below or the MCP spawn rewrite use
+    # the result.
+    venv_python, resolve_err = await _resolve_venv_interpreter(
+        venv_dir, backend, policy, plugin_root,
+    )
+    if venv_python is None:
+        return None, resolve_err
+
     try:
         install_result = await backend.run(
             ["uv", "pip", "install", "--cache-dir", str(cache_dir),
-             "--python", str(venv_dir), "-r", str(requirements)],
+             "--python", str(venv_python), "-r", str(requirements)],
             policy,
             cwd=str(plugin_root),
         )
@@ -508,13 +567,6 @@ async def _materialise_deps(
     if install_result.returncode != 0:
         detail = install_result.stderr.decode("utf-8", errors="replace").strip()
         return None, f"uv pip install failed (exit {install_result.returncode}): {detail}"
-    # The MCP spawn rewrite (`_build_mcp_entries`) DOES need a real,
-    # executable interpreter path (it becomes the subprocess `command`) —
-    # that's where the discovery helper is unavoidable.
-    try:
-        venv_python = _venv_interpreter_path(venv_dir)
-    except FileNotFoundError as exc:
-        return None, str(exc)
     return venv_python, None
 
 

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -398,6 +398,45 @@ def _bake_plugin_root_only(path: Path, plugin_root: Path) -> None:
         path.write_text(expanded, encoding="utf-8")
 
 
+def _venv_interpreter_path(venv_dir: Path) -> Path:
+    """Discover ``venv_dir``'s Python interpreter by checking which of the
+    two known ``uv venv`` / stdlib-``venv`` layouts actually exists on disk
+    — POSIX's ``<venv>/bin/python`` or Windows's (incl. git-bash, which
+    still runs a Windows-layout venv) ``<venv>/Scripts/python.exe`` — rather
+    than *constructing* the path from ``os.name``/``sys.platform``.
+
+    Discovery over construction is deliberate: if a future ``uv``/stdlib
+    ``venv`` release changes the layout, or the two ever diverge, an
+    existence check keeps working where an OS-constant branch would go
+    stale silently. A hardcoded ``bin/python`` construction is exactly
+    #3202 symptom 1's bug — a real path on Linux/macOS CI, absent on
+    Windows, so ``uv pip install --python <that path>`` and MCP spawn both
+    fail there even though ``uv venv`` itself succeeded.
+
+    Raises ``FileNotFoundError`` if NEITHER layout exists — that is not a
+    layout question but evidence ``uv venv`` did not actually materialise an
+    interpreter (should have already been caught by its exit code; this is
+    the decision-enabling explicit failure, not a silent None).
+
+    This is the ONE place that resolves the interpreter path — both the MCP
+    spawn command rewrite (which must name a real executable to exec) and
+    the install step's ``--python`` argument (historically) keyed off it.
+    Keeping it singular means the next call site never re-invents the POSIX
+    assumption.
+    """
+    windows_python = venv_dir / "Scripts" / "python.exe"
+    posix_python = venv_dir / "bin" / "python"
+    if windows_python.exists():
+        return windows_python
+    if posix_python.exists():
+        return posix_python
+    raise FileNotFoundError(
+        f"no venv interpreter found under {venv_dir!s} "
+        f"(checked {windows_python!s} and {posix_python!s}) — "
+        "uv venv may not have actually materialised an interpreter"
+    )
+
+
 async def _materialise_deps(
     plugin_root: Path, requirements: Path, ctx: OpContext,
 ) -> "tuple[Path | None, str | None]":
@@ -448,11 +487,19 @@ async def _materialise_deps(
         detail = venv_result.stderr.decode("utf-8", errors="replace").strip()
         return None, f"uv venv failed (exit {venv_result.returncode}): {detail}"
 
-    venv_python = venv_dir / "bin" / "python"
+    # Pass the venv ROOT (not a hand-built interpreter path) to `--python`.
+    # uv's own request-format grammar documents `<install-dir>` as a
+    # supported form (`uv help python`: "a specific system Python
+    # interpreter can often be requested with ... <install-dir> e.g.
+    # `/some/environment/`") and resolves the correct per-OS interpreter
+    # inside it — so install no longer needs to know POSIX vs. Windows
+    # layout at all. Verified locally: `uv pip install --python <venv_dir>`
+    # (root) installs into that venv exactly like `--python <venv_dir>/bin/python`
+    # does on POSIX.
     try:
         install_result = await backend.run(
             ["uv", "pip", "install", "--cache-dir", str(cache_dir),
-             "--python", str(venv_python), "-r", str(requirements)],
+             "--python", str(venv_dir), "-r", str(requirements)],
             policy,
             cwd=str(plugin_root),
         )
@@ -461,6 +508,13 @@ async def _materialise_deps(
     if install_result.returncode != 0:
         detail = install_result.stderr.decode("utf-8", errors="replace").strip()
         return None, f"uv pip install failed (exit {install_result.returncode}): {detail}"
+    # The MCP spawn rewrite (`_build_mcp_entries`) DOES need a real,
+    # executable interpreter path (it becomes the subprocess `command`) —
+    # that's where the discovery helper is unavoidable.
+    try:
+        venv_python = _venv_interpreter_path(venv_dir)
+    except FileNotFoundError as exc:
+        return None, str(exc)
     return venv_python, None
 
 

--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -50,7 +50,9 @@ Pipeline (one-shot, no sub-phases):
    never a blanket http.get grant, so a separate interactive prompt is
    never raised for it), then ``require_http_get`` is still called (config
    deny / sandbox network-veto keep applying on top of the derive), then
-   ``uv venv`` + ``uv pip install`` into ``<plugin_root>/.venv`` — network
+   ``<sys.executable> -m venv`` + ``<venv_python> -m pip install`` into
+   ``<plugin_root>/.venv`` (#3202 symptom 2 — no ``uv`` dependency; reyn's
+   own interpreter + the stdlib ``venv``/``pip`` it ships with) — network
    fetch happens HERE, at install time, never at spawn. Without the
    derive, a codeact/headless dispatch (a bus wired but nothing answers
    it) awaits that prompt indefinitely and gets guillotined by the
@@ -84,7 +86,10 @@ call.
 from __future__ import annotations
 
 import json
+import os
 import shutil
+import sys
+import sysconfig
 from pathlib import Path
 from uuid import uuid4
 
@@ -398,22 +403,21 @@ def _bake_plugin_root_only(path: Path, plugin_root: Path) -> None:
         path.write_text(expanded, encoding="utf-8")
 
 
-def _venv_interpreter_path(venv_dir: Path) -> Path:
-    """FALLBACK ONLY (secondary) — see ``_resolve_venv_interpreter`` for the
+def _venv_interpreter_path_discover(venv_dir: Path) -> Path:
+    """FALLBACK ONLY (secondary) — see ``_venv_interpreter_path`` for the
     primary mechanism. Discover ``venv_dir``'s Python interpreter by
-    checking which of the two known PEP 405 venv layouts actually exists on
-    disk — POSIX's ``<venv>/bin/python`` or Windows's (incl. git-bash, which
+    checking which of the two PEP 405 venv layouts actually exists on disk
+    — POSIX's ``<venv>/bin/python`` or Windows's (incl. git-bash, which
     still runs a Windows-layout venv) ``<venv>/Scripts/python.exe`` — rather
     than *constructing* the path from ``os.name``/``sys.platform``. This is
-    a real fallback, not a guess: it is standard per PEP 405 / CPython's
-    ``Lib/venv/__init__.py`` ``binname`` branch, but it is still a
-    hardcoded pair of candidate strings, so ``_resolve_venv_interpreter``
-    only reaches it when the authoritative ``sys.executable`` query fails.
+    only reached if the primary ``sysconfig``-based computation somehow
+    fails (should not happen in practice — this is the pathological-failure
+    safety net, not the normal path).
 
     Raises ``FileNotFoundError`` if NEITHER layout exists — that is not a
-    layout question but evidence ``uv venv`` did not actually materialise an
-    interpreter (should have already been caught by its exit code; this is
-    the decision-enabling explicit failure, not a silent None).
+    layout question but evidence venv creation did not actually materialise
+    an interpreter (should have already been caught by its exit code; this
+    is the decision-enabling explicit failure, not a silent None).
     """
     windows_python = venv_dir / "Scripts" / "python.exe"
     posix_python = venv_dir / "bin" / "python"
@@ -424,102 +428,118 @@ def _venv_interpreter_path(venv_dir: Path) -> Path:
     raise FileNotFoundError(
         f"no venv interpreter found under {venv_dir!s} "
         f"(checked {windows_python!s} and {posix_python!s}) — "
-        "uv venv may not have actually materialised an interpreter"
+        "venv creation may not have actually materialised an interpreter"
     )
 
 
-async def _resolve_venv_interpreter(
-    venv_dir: Path, backend, policy, plugin_root: Path,
-) -> "tuple[Path | None, str | None]":
-    """Resolve ``venv_dir``'s ACTUAL Python interpreter authoritatively — by
-    asking the venv's OWN python for ``sys.executable`` — instead of
-    constructing or guessing a path. Fixes #3202 symptom 1 (a hardcoded
-    ``bin/python`` is absent on Windows, so ``uv pip install --python <that
-    path>`` and MCP spawn both failed there even though ``uv venv`` itself
-    succeeded).
+def _venv_interpreter_path(venv_dir: Path) -> Path:
+    """Resolve ``venv_dir``'s Python interpreter path using the stdlib
+    ``sysconfig`` module's ``"venv"`` install scheme — no hardcoded
+    ``bin``/``Scripts`` branch, no subprocess, no third-party tool (uv or
+    otherwise). #3202 symptom 1 was a hardcoded ``<venv>/bin/python``
+    construction: a real path on Linux/macOS CI, absent on Windows (there
+    it's ``<venv>/Scripts/python.exe``), so ``uv pip install --python <that
+    path>`` and MCP spawn both failed there even though venv creation
+    itself succeeded.
 
-    PRIMARY (authority query): ``uv run --python <venv_dir> python -c
-    "import sys; print(sys.executable)"``. Ground (uv 0.11.15, this repo's
-    own uv, checked directly — not assumed):
-      - ``uv python find --python <venv_dir>`` does NOT exist as a flag in
-        this uv version (``error: unexpected argument '--python' found``)
-        — ruled out.
-      - A bare ``uv python find`` (with or without ``VIRTUAL_ENV`` set) is
-        ambient DISCOVERY, not a query scoped to a specific venv — it can
-        silently return a DIFFERENT (e.g. system) interpreter — ruled out.
-      - ``uv run --python <dir> python -c "..."`` is the one form
-        confirmed to run INSIDE the just-created venv and print that
-        venv's real ``sys.executable`` (verified: the printed path
-        `exists()` and is directly executable). It also runs with no
-        network activity once the venv exists (`UV_OFFLINE=1` reproduces
-        identical output), so scoping it inside this already
-        network-scoped install step adds no new exposure.
+    Ground (checked directly on this machine's CPython, not assumed):
+    ``sysconfig.get_paths(scheme="venv", vars={"base": <venv_dir>,
+    "platbase": <venv_dir>})["scripts"]`` returns the venv's script/bin
+    directory for THE CURRENT INTERPRETER'S OS — the ``"venv"`` scheme name
+    is itself resolved by ``sysconfig`` internally to the OS-appropriate
+    scheme (``posix_venv`` gives ``{base}/bin``; ``nt_venv`` gives
+    ``{base}/Scripts``) at *sysconfig import time*, i.e. it already encodes
+    the platform branch so this call site never has to. The interpreter
+    filename is ``"python" + sysconfig.get_config_var("EXE")`` (``EXE`` is
+    ``""`` on POSIX, ``".exe"`` on Windows) — verified against a real
+    ``python -m venv``-created venv: the computed path exists and matches
+    the actual interpreter file on disk.
 
-    The query runs EXACTLY ONCE, here, at install time. The absolute path
-    it returns is frozen and handed to BOTH this module's own
-    ``uv pip install --python <path>`` call and the MCP spawn command
-    rewrite (``_build_mcp_entries``). Spawn itself NEVER re-invokes uv — it
-    execs the frozen absolute path directly — preserving #3060's
-    spawn-is-network-free property (a ``uv run`` AT SPAWN TIME would let uv
-    resolve/fetch then, which is exactly what #3060 forbids; resolving
-    once at install time and freezing the result is what keeps spawn
-    itself uv-free).
+    ``_materialise_deps`` creates the venv with ``<reyn's own python> -m
+    venv`` (the stdlib ``venv`` module, not a third-party tool with its own
+    possibly-different layout), so this computation targets exactly the
+    layout that module produces — not a guess about what SOME tool might
+    have done.
 
-    FALLBACK (secondary, only if the primary above fails for any reason —
-    sandbox denial, a uv version without ``run``, etc.): ``_venv_interpreter_path``'s
-    on-disk layout discovery. The ordering matters: primary is authority
-    (asks the interpreter itself, so it always names something real and
-    tracks whatever layout uv/venv actually produced); fallback is a
-    standard-but-hardcoded pair of candidate strings, used ONLY when
-    authority is unavailable — do not swap this order.
+    Falls back to ``_venv_interpreter_path_discover``'s on-disk existence
+    check only if this computation's result does not actually exist (a
+    pathological case — e.g. a ``sysconfig`` customisation on some
+    distro) — a decision-enabling last resort, not the main path.
+
+    This is the ONE place that resolves the interpreter path — both the MCP
+    spawn command rewrite (which must name a real executable to exec) and
+    the install step's ``pip install`` invocation (this module) key off it.
+    Keeping it singular means the next call site never re-invents the POSIX
+    assumption.
     """
-    try:
-        query_result = await backend.run(
-            ["uv", "run", "--python", str(venv_dir), "python", "-c",
-             "import sys; print(sys.executable)"],
-            policy, cwd=str(plugin_root),
-        )
-    except Exception:  # noqa: BLE001 — fall through to discovery below
-        query_result = None
-    if query_result is not None and query_result.returncode == 0:
-        candidate = query_result.stdout.decode("utf-8", errors="replace").strip()
-        if candidate:
-            candidate_path = Path(candidate)
-            if candidate_path.exists():
-                return candidate_path, None
-    # Authority query did not produce a usable path — fall back to discovery.
-    try:
-        return _venv_interpreter_path(venv_dir), None
-    except FileNotFoundError as exc:
-        return None, str(exc)
+    scripts_dir = Path(
+        sysconfig.get_paths(
+            scheme="venv", vars={"base": str(venv_dir), "platbase": str(venv_dir)},
+        )["scripts"],
+    )
+    exe_suffix = sysconfig.get_config_var("EXE") or ""
+    computed = scripts_dir / f"python{exe_suffix}"
+    if computed.exists():
+        return computed
+    # sysconfig computed a path that isn't actually there — pathological;
+    # fall back to on-disk discovery before giving up.
+    return _venv_interpreter_path_discover(venv_dir)
 
 
 async def _materialise_deps(
     plugin_root: Path, requirements: Path, ctx: OpContext,
 ) -> "tuple[Path | None, str | None]":
-    """``uv venv`` + ``uv pip install -r requirements.txt`` into
-    ``<plugin_root>/.venv`` (§3.11) — routed through the sandbox abstraction
-    (mirrors ``skill_install._shallow_clone``'s rationale: an agent-reachable
-    subprocess launch must never bypass ``reyn.security.sandbox``).
+    """``<sys.executable> -m venv`` + ``<venv_python> -m pip install -r
+    requirements.txt`` into ``<plugin_root>/.venv`` (§3.11) — routed through
+    the sandbox abstraction (mirrors ``skill_install._shallow_clone``'s
+    rationale: an agent-reachable subprocess launch must never bypass
+    ``reyn.security.sandbox``).
+
+    Uses the stdlib ``venv`` module (via reyn's OWN interpreter,
+    ``sys.executable`` — guaranteed present, no external tool dependency)
+    and ``pip`` (bundled with every CPython venv) rather than ``uv`` —
+    #3202 symptom 2. ``uv`` was never load-bearing here: no lockfile is
+    used (plain ``requirements.txt``), reyn's own runtime already requires
+    a working CPython, and an operator missing ``uv`` on ``PATH`` (the
+    reported failure mode — Windows/git-bash environments where ``uv`` is
+    an extra, easy-to-miss install) got a confusing "run 'uv venv'" error
+    for a tool reyn itself never asked them to install. Ground before this
+    change: `<probe>/.venv/bin/python -m pip install sqlite-vec>=0.1.9
+    apsw>=3.51 chonkie>=1.7 fastmcp>=2.0` (the plugin's actual
+    ``requirements.txt``) resolves and installs cleanly with plain pip,
+    including ``sqlite-vec`` (wheel-only, no sdist — the one dependency
+    most likely to need a resolver's special handling; it did not).
 
     Returns ``(venv_python, None)`` on success (the venv's interpreter path,
     for the mcp-registration step to point spawn at), or ``(None, error)`` on
     failure. Network is scoped to THIS install-time step only; the venv
     itself carries no network policy of its own — that governs SPAWN, which
-    this step never touches.
+    this step never touches (unchanged from the ``uv``-based version:
+    spawn execs the frozen absolute interpreter path directly, #3060).
     """
     from reyn.security.sandbox import SandboxPolicy, get_default_backend
 
     backend = ctx.sandbox_backend or get_default_backend(ctx.sandbox_config)
     venv_dir = plugin_root / ".venv"
-    # uv's default cache dir is ``~/.cache/uv`` — OUTSIDE the sandbox
-    # write_paths (which are scoped tight to plugin_root), so under an enforcing
-    # backend (Seatbelt/Landlock) uv's cache write is denied and materialise
-    # fails with "Operation not permitted". Point the cache INSIDE plugin_root
-    # (within write_paths) via ``--cache-dir`` — a CLI arg, so no os.environ
-    # mutation and no broad ~/.cache grant. This is a real correctness fix, not
-    # a test artifact: the default-cache write would fail under a real sandbox.
-    cache_dir = plugin_root / ".uv-cache"
+    # pip's default cache dir is OUTSIDE the sandbox write_paths (scoped
+    # tight to plugin_root), so under an enforcing backend (Seatbelt/
+    # Landlock) pip's default cache write is denied and materialise fails
+    # with "Operation not permitted" — same reasoning that applied to uv's
+    # cache-dir before this change. Point the cache INSIDE plugin_root (within
+    # write_paths) via ``--cache-dir`` — a CLI arg, so no os.environ mutation
+    # and no broad ambient-cache grant.
+    cache_dir = plugin_root / ".pip-cache"
+    # pip additionally unpacks wheels into `tempfile.mkdtemp()` (Python's
+    # tempfile module, which consults `TMPDIR`/`TEMP`/`TMP` before falling
+    # back to system `/tmp`) during install — a WRITE that, unlike the cache
+    # dir above, is not steerable via a pip CLI flag. Left at its default,
+    # that write lands OUTSIDE `write_paths` (system `/tmp`, not
+    # plugin_root), so an enforcing backend denies it exactly like the
+    # cache-dir issue this comment already documents. Give it its own
+    # dedicated dir INSIDE plugin_root and point `TMPDIR` there (narrowly
+    # scoped, not a broad ambient-`/tmp` grant).
+    tmp_dir = plugin_root / ".pip-tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
     policy = SandboxPolicy(
         network=True,
         write_paths=[str(plugin_root)],
@@ -530,44 +550,76 @@ async def _materialise_deps(
             "HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
             "https_proxy", "http_proxy", "no_proxy",
             "SSL_CERT_FILE", "SSL_CERT_DIR",
-            "UV_INDEX_URL", "UV_EXTRA_INDEX_URL", "PIP_INDEX_URL",
+            "PIP_INDEX_URL",
+            "TMPDIR",
         ],
     )
+    # `env_passthrough` only copies EXISTING os.environ values through to the
+    # sandboxed child (see `resolve_passthrough_env`) — there is no
+    # backend.run() parameter to inject a NEW env value, so scoping TMPDIR to
+    # this install requires briefly setting it in THIS process's environ,
+    # restored in `finally`. This mutates process-global state for the
+    # duration of the two subprocess calls below; concurrent
+    # `_materialise_deps` calls for a DIFFERENT plugin in the SAME process
+    # would race on this value (a pre-existing class of risk this module
+    # already carries — e.g. `plugins_root()`'s HOME-relative resolution
+    # makes the same single-flight-per-process assumption).
+    previous_tmpdir = os.environ.get("TMPDIR")
+    os.environ["TMPDIR"] = str(tmp_dir)
     try:
-        venv_result = await backend.run(
-            ["uv", "venv", "--cache-dir", str(cache_dir), str(venv_dir)],
-            policy, cwd=str(plugin_root),
-        )
-    except Exception as exc:  # noqa: BLE001 — surface as a materialise error, not a crash
-        return None, f"uv venv error: {exc}"
-    if venv_result.returncode != 0:
-        detail = venv_result.stderr.decode("utf-8", errors="replace").strip()
-        return None, f"uv venv failed (exit {venv_result.returncode}): {detail}"
+        try:
+            venv_result = await backend.run(
+                [sys.executable, "-m", "venv", str(venv_dir)],
+                policy, cwd=str(plugin_root),
+            )
+        except Exception as exc:  # noqa: BLE001 — surface as a materialise error, not a crash
+            return None, f"venv creation error: {exc}"
+        if venv_result.returncode != 0:
+            detail = venv_result.stderr.decode("utf-8", errors="replace").strip()
+            # `python -m venv` needs `ensurepip`, which some distros (Debian/
+            # Ubuntu's bare `python3`) split into a separate `python3-venv`
+            # package — the one narrow case this pip-based materialise trades
+            # in for dropping the `uv` dependency (#3202 symptom 2). CPython's
+            # own venv module already names the missing package in its stderr
+            # ("ensurepip is not available ... apt install python3.X-venv"),
+            # so surface a decision-enabling hint on top of the raw detail
+            # rather than leaving the operator to parse a stack trace.
+            if "ensurepip" in detail.lower():
+                return None, (
+                    f"venv creation failed (exit {venv_result.returncode}): {detail}\n"
+                    "Hint: this Python may be missing ensurepip. On Debian/"
+                    "Ubuntu, install the matching venv package (e.g. "
+                    "`apt install python3-venv`) and retry."
+                )
+            return None, f"venv creation failed (exit {venv_result.returncode}): {detail}"
 
-    # Resolve the ACTUAL interpreter authoritatively (see
-    # ``_resolve_venv_interpreter``'s docstring for the ground + rationale)
-    # — this is the ONE place the venv/OS layout is figured out, before
-    # either `uv pip install --python` below or the MCP spawn rewrite use
-    # the result.
-    venv_python, resolve_err = await _resolve_venv_interpreter(
-        venv_dir, backend, policy, plugin_root,
-    )
-    if venv_python is None:
-        return None, resolve_err
+        # Discover the ACTUAL interpreter (see ``_venv_interpreter_path``'s
+        # docstring) — this is the ONE place the venv/OS layout is figured
+        # out, before either the pip install below or the MCP spawn rewrite
+        # use the result.
+        try:
+            venv_python = _venv_interpreter_path(venv_dir)
+        except FileNotFoundError as exc:
+            return None, str(exc)
 
-    try:
-        install_result = await backend.run(
-            ["uv", "pip", "install", "--cache-dir", str(cache_dir),
-             "--python", str(venv_python), "-r", str(requirements)],
-            policy,
-            cwd=str(plugin_root),
-        )
-    except Exception as exc:  # noqa: BLE001
-        return None, f"uv pip install error: {exc}"
-    if install_result.returncode != 0:
-        detail = install_result.stderr.decode("utf-8", errors="replace").strip()
-        return None, f"uv pip install failed (exit {install_result.returncode}): {detail}"
-    return venv_python, None
+        try:
+            install_result = await backend.run(
+                [str(venv_python), "-m", "pip", "install",
+                 "--cache-dir", str(cache_dir), "-r", str(requirements)],
+                policy,
+                cwd=str(plugin_root),
+            )
+        except Exception as exc:  # noqa: BLE001
+            return None, f"pip install error: {exc}"
+        if install_result.returncode != 0:
+            detail = install_result.stderr.decode("utf-8", errors="replace").strip()
+            return None, f"pip install failed (exit {install_result.returncode}): {detail}"
+        return venv_python, None
+    finally:
+        if previous_tmpdir is None:
+            os.environ.pop("TMPDIR", None)
+        else:
+            os.environ["TMPDIR"] = previous_tmpdir
 
 
 def _mcp_config_path(project_root: Path) -> Path:

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -55,6 +55,8 @@ import yaml
 
 from reyn.core.op_runtime.context import OpContext
 from reyn.core.op_runtime.plugin_install import (
+    _build_mcp_entries,
+    _venv_interpreter_path,
     _write_install_state,
     plugins_root,
     reconcile_plugin_installs,
@@ -650,6 +652,79 @@ async def test_materialise_deps_rewrites_mcp_spawn_to_venv_interpreter(tmp_path,
         "(spawn would not be network-free)"
     )
     assert servers["srv"]["plugin_id"] == "venvplugin"
+
+
+# ── Test 6b: interpreter discovery across venv layouts (#3202 symptom 1) ──────
+#
+# `_venv_interpreter_path` DISCOVERS the interpreter by checking which of the
+# two known `uv venv` layouts exists on disk, rather than constructing the
+# path from `os.name` — so these witnesses build the REAL file layout on disk
+# (a Windows-shaped venv can be reproduced on any host by just creating the
+# `Scripts/python.exe` file) instead of monkeypatching `os.name`/`sys.platform`.
+
+
+def test_venv_interpreter_path_discovers_posix_layout(tmp_path):
+    """Tier 1: given a venv dir with ONLY the POSIX layout
+    (`<venv>/bin/python`) present on disk, `_venv_interpreter_path` returns
+    that file. RED if it returns a Windows-shaped path or raises."""
+    venv_dir = tmp_path / ".venv"
+    posix_python = venv_dir / "bin" / "python"
+    posix_python.parent.mkdir(parents=True)
+    posix_python.write_bytes(b"")
+
+    assert _venv_interpreter_path(venv_dir) == posix_python
+
+
+def test_venv_interpreter_path_discovers_windows_layout(tmp_path):
+    """Tier 1: given a venv dir with ONLY the Windows layout
+    (`<venv>/Scripts/python.exe`) present on disk — reproducing a real
+    `uv venv` run on Windows without needing a Windows host — the discovery
+    helper returns THAT file, not the POSIX `bin/python` construction that
+    caused #3202 symptom 1 (`uv pip install failed` / spawn broken on
+    Windows despite `uv venv` having succeeded)."""
+    venv_dir = tmp_path / ".venv"
+    windows_python = venv_dir / "Scripts" / "python.exe"
+    windows_python.parent.mkdir(parents=True)
+    windows_python.write_bytes(b"")
+
+    assert _venv_interpreter_path(venv_dir) == windows_python
+
+
+def test_venv_interpreter_path_raises_when_neither_layout_exists(tmp_path):
+    """Tier 1: an empty/nonexistent venv dir (neither layout materialised —
+    evidence `uv venv` did not actually produce an interpreter) raises
+    `FileNotFoundError` explicitly rather than silently returning a
+    nonexistent path for the caller to fail on later without context."""
+    venv_dir = tmp_path / ".venv"
+    venv_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        _venv_interpreter_path(venv_dir)
+
+
+def test_build_mcp_entries_rewrites_to_windows_style_interpreter():
+    """Tier 1: `_build_mcp_entries` rewrites a bare `python` command to
+    WHATEVER `venv_python` path it is given — including a Windows-shaped
+    (`Scripts/python.exe`) path from `_venv_interpreter_path`'s discovery —
+    confirming the spawn side consumes the discovered path unchanged (the
+    same resolver serves both install and spawn, per the single-helper
+    aggregation)."""
+    windows_python = Path("C:/plugins/srv/.venv/Scripts/python.exe")
+    mcp_json = {
+        "mcpServers": {"srv": {"command": "python", "args": ["-m", "srv"]}},
+    }
+    import tempfile
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False,
+    ) as fh:
+        json.dump(mcp_json, fh)
+        mcp_json_path = Path(fh.name)
+    try:
+        entries = _build_mcp_entries(mcp_json_path, windows_python)
+    finally:
+        mcp_json_path.unlink()
+
+    assert entries["srv"]["command"] == str(windows_python)
 
 
 # ── Test 7: pypi dep-fetch gate (require_http_get on the package index) ───────

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -47,7 +47,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -57,6 +59,7 @@ from reyn.core.op_runtime.context import OpContext
 from reyn.core.op_runtime.plugin_install import (
     _build_mcp_entries,
     _venv_interpreter_path,
+    _venv_interpreter_path_discover,
     _write_install_state,
     plugins_root,
     reconcile_plugin_installs,
@@ -318,7 +321,7 @@ async def test_plugin_install_denied_without_write_approval(tmp_path, monkeypatc
 
 def _make_mcp_plugin_source(base: Path, name: str = "mcpplugin") -> Path:
     """A minimal local plugin dir: manifest + one mcp capability (no
-    requirements.txt — offline, no ``uv`` dependency)."""
+    requirements.txt — offline, no materialise step at all)."""
     plugin_dir = base / name
     (plugin_dir / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
     (plugin_dir / ".reyn-plugin" / "plugin.json").write_text(
@@ -600,25 +603,24 @@ def test_run_code_trust_choices_offer_no_persist_option():
 
 
 # ── Test 6: network-free spawn (materialise → venv interpreter, §3.11) ────────
+#
+# #3202 symptom 2: materialise no longer depends on `uv` — `<sys.executable>
+# -m venv` + `<venv_python> -m pip install` (both bundled with reyn's own
+# CPython), so these tests are NOT gated on a `uv` binary being on PATH.
 
 
-def _uv_available() -> bool:
-    import shutil as _sh
-    return _sh.which("uv") is not None
-
-
-@pytest.mark.skipif(not _uv_available(), reason="uv not on PATH")
 @pytest.mark.asyncio
 async def test_materialise_deps_rewrites_mcp_spawn_to_venv_interpreter(tmp_path, monkeypatch):
     """Tier 2: §3.11 headline property — a plugin with a requirements.txt + an
     mcp capability (command: python) materialises a per-plugin venv at INSTALL
     time, and the registered mcp spawn command is rewritten to that venv's
-    interpreter — so spawn needs no network (no `uv run --with` at spawn).
+    interpreter — so spawn needs no network (spawn execs the frozen absolute
+    interpreter path directly; it never re-invokes pip).
 
-    Uses an EMPTY requirements.txt so `uv venv` + `uv pip install -r` run fully
-    offline (no package fetch) yet still exercise the real materialise +
-    command-rewrite path. RED if the registered command stays 'python' (spawn
-    would then depend on ambient env / fetch)."""
+    Uses an EMPTY requirements.txt so `<sys.executable> -m venv` + `<venv_python>
+    -m pip install -r` run fully offline (no package fetch) yet still exercise
+    the real materialise + command-rewrite path. RED if the registered command
+    stays 'python' (spawn would then depend on ambient env / fetch)."""
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setenv("HOME", str(home))
@@ -654,61 +656,106 @@ async def test_materialise_deps_rewrites_mcp_spawn_to_venv_interpreter(tmp_path,
     assert servers["srv"]["plugin_id"] == "venvplugin"
 
 
-# ── Test 6b: interpreter discovery across venv layouts (#3202 symptom 1) ──────
+# ── Test 6b: interpreter resolution across venv layouts (#3202 symptom 1) ────
 #
-# `_venv_interpreter_path` DISCOVERS the interpreter by checking which of the
-# two known `uv venv` layouts exists on disk, rather than constructing the
-# path from `os.name` — so these witnesses build the REAL file layout on disk
-# (a Windows-shaped venv can be reproduced on any host by just creating the
-# `Scripts/python.exe` file) instead of monkeypatching `os.name`/`sys.platform`.
+# `_venv_interpreter_path` resolves the interpreter via stdlib `sysconfig`'s
+# "venv" install scheme (no hardcoded bin/Scripts branch, no subprocess).
+# `_venv_interpreter_path_discover` is its on-disk-existence FALLBACK, used
+# only if the sysconfig computation's result doesn't actually exist — these
+# witnesses build the REAL file layout on disk (a Windows-shaped venv can be
+# reproduced on any host by just creating the `Scripts/python.exe` file)
+# instead of monkeypatching `os.name`/`sys.platform`.
 
 
-def test_venv_interpreter_path_discovers_posix_layout(tmp_path):
+def test_venv_interpreter_path_resolves_real_venv_via_sysconfig(tmp_path):
+    """Tier 1: `_venv_interpreter_path` against a REAL `python -m venv`
+    (this repo's own interpreter, no network) returns a path that actually
+    exists and is executable — the sysconfig-computed primary mechanism,
+    not the discovery fallback, since sysconfig has no reason to fail here.
+    RED if sysconfig computes a nonexistent path for a real venv."""
+    venv_dir = tmp_path / ".venv"
+    subprocess.run(
+        [sys.executable, "-m", "venv", str(venv_dir)],
+        check=True, capture_output=True,
+    )
+
+    resolved = _venv_interpreter_path(venv_dir)
+
+    assert resolved.exists(), f"sysconfig-resolved interpreter does not exist: {resolved}"
+    probe = subprocess.run(
+        [str(resolved), "-c", "print('alive')"], capture_output=True, text=True,
+    )
+    assert probe.returncode == 0 and "alive" in probe.stdout
+
+
+def test_venv_interpreter_path_discover_finds_posix_layout(tmp_path):
     """Tier 1: given a venv dir with ONLY the POSIX layout
-    (`<venv>/bin/python`) present on disk, `_venv_interpreter_path` returns
-    that file. RED if it returns a Windows-shaped path or raises."""
+    (`<venv>/bin/python`) present on disk, the fallback discovery helper
+    returns that file. RED if it returns a Windows-shaped path or raises."""
     venv_dir = tmp_path / ".venv"
     posix_python = venv_dir / "bin" / "python"
     posix_python.parent.mkdir(parents=True)
     posix_python.write_bytes(b"")
 
-    assert _venv_interpreter_path(venv_dir) == posix_python
+    assert _venv_interpreter_path_discover(venv_dir) == posix_python
 
 
-def test_venv_interpreter_path_discovers_windows_layout(tmp_path):
+def test_venv_interpreter_path_discover_finds_windows_layout(tmp_path):
     """Tier 1: given a venv dir with ONLY the Windows layout
     (`<venv>/Scripts/python.exe`) present on disk — reproducing a real
-    `uv venv` run on Windows without needing a Windows host — the discovery
+    Windows venv without needing a Windows host — the fallback discovery
     helper returns THAT file, not the POSIX `bin/python` construction that
-    caused #3202 symptom 1 (`uv pip install failed` / spawn broken on
-    Windows despite `uv venv` having succeeded)."""
+    caused #3202 symptom 1."""
     venv_dir = tmp_path / ".venv"
     windows_python = venv_dir / "Scripts" / "python.exe"
     windows_python.parent.mkdir(parents=True)
     windows_python.write_bytes(b"")
 
-    assert _venv_interpreter_path(venv_dir) == windows_python
+    assert _venv_interpreter_path_discover(venv_dir) == windows_python
 
 
-def test_venv_interpreter_path_raises_when_neither_layout_exists(tmp_path):
+def test_venv_interpreter_path_discover_raises_when_neither_layout_exists(tmp_path):
     """Tier 1: an empty/nonexistent venv dir (neither layout materialised —
-    evidence `uv venv` did not actually produce an interpreter) raises
+    evidence venv creation did not actually produce an interpreter) raises
     `FileNotFoundError` explicitly rather than silently returning a
     nonexistent path for the caller to fail on later without context."""
     venv_dir = tmp_path / ".venv"
     venv_dir.mkdir()
 
     with pytest.raises(FileNotFoundError):
-        _venv_interpreter_path(venv_dir)
+        _venv_interpreter_path_discover(venv_dir)
+
+
+def test_venv_interpreter_path_falls_back_to_discovery_when_sysconfig_path_absent(
+    tmp_path,
+):
+    """Tier 1: axis-4-adjacent — if the sysconfig-computed path does NOT
+    exist on disk (the pathological case the fallback exists for), and only
+    a DIFFERENT layout's file is actually present, `_venv_interpreter_path`
+    still returns a real, existing interpreter via the discovery fallback
+    rather than the (nonexistent) sysconfig-computed one. Reproduces the
+    fallback path deterministically by placing ONLY the Windows layout on
+    disk — sysconfig on this (non-Windows) test runner computes the POSIX
+    path, which will not exist, forcing the fallback branch."""
+    venv_dir = tmp_path / ".venv"
+    windows_python = venv_dir / "Scripts" / "python.exe"
+    windows_python.parent.mkdir(parents=True)
+    windows_python.write_bytes(b"")
+
+    resolved = _venv_interpreter_path(venv_dir)
+
+    assert resolved == windows_python, (
+        "expected the discovery fallback to find the Windows-layout file "
+        "when sysconfig's own computed path does not exist"
+    )
 
 
 def test_build_mcp_entries_rewrites_to_windows_style_interpreter():
     """Tier 1: `_build_mcp_entries` rewrites a bare `python` command to
     WHATEVER `venv_python` path it is given — including a Windows-shaped
-    (`Scripts/python.exe`) path from `_venv_interpreter_path`'s discovery —
-    confirming the spawn side consumes the discovered path unchanged (the
-    same resolver serves both install and spawn, per the single-helper
-    aggregation)."""
+    (`Scripts/python.exe`) path — confirming the spawn side consumes the
+    resolved path unchanged (the same resolver serves both install and
+    spawn, per the single-helper aggregation)."""
     windows_python = Path("C:/plugins/srv/.venv/Scripts/python.exe")
     mcp_json = {
         "mcpServers": {"srv": {"command": "python", "args": ["-m", "srv"]}},
@@ -725,6 +772,86 @@ def test_build_mcp_entries_rewrites_to_windows_style_interpreter():
         mcp_json_path.unlink()
 
     assert entries["srv"]["command"] == str(windows_python)
+
+
+# ── Test 6c: TMPDIR containment under a REAL enforcing sandbox backend ────────
+# (#3202 symptom 2 pip-materialise). Honest finding (measured directly, not
+# assumed): `_materialise_deps` already passes `cwd=str(plugin_root)` to every
+# `backend.run()` call, and CPython's own `tempfile._get_default_tempdir()`
+# candidate list ends with `os.getcwd()` as a last resort BEFORE raising — so
+# with our actual call shape, a `tempfile.mkdtemp()`-based write (verified
+# directly: a real `pip install six` under Seatbelt with `write_paths=
+# [plugin_root]`, `cwd=plugin_root`, and NO TMPDIR override) already succeeds
+# via that built-in cwd fallback, landing inside `plugin_root`. The TMPDIR
+# redirect this fix adds is still kept as explicit, observable containment
+# (a future refactor that drops the `cwd=` argument, or a pip/tempfile
+# version that narrows its fallback chain, would silently lose the cwd
+# safety net) — but it is NOT provable as "removing it flips this to RED" in
+# the CURRENT call shape, and this test says so rather than asserting a
+# denial that direct measurement showed does not occur here. What IS
+# verified below: with TMPDIR explicitly set (mirroring `_materialise_deps`),
+# the temp write lands inside the designated dir, not system `/tmp`.
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="sandbox-exec is macOS-only")
+def test_tmpdir_redirect_contains_temp_write_under_plugin_root(tmp_path):
+    """Tier 2: with `_materialise_deps`'s TMPDIR redirect applied (env var
+    pointed at a dir inside `plugin_root`), a `tempfile.mkdtemp()`-based
+    write under a REAL Seatbelt backend (`write_paths=[plugin_root]`) lands
+    inside the designated `.pip-tmp` dir — confirming the redirect actually
+    takes effect (the env value is honoured), not merely that SOME fallback
+    happens to succeed."""
+    import asyncio as _asyncio
+
+    from reyn.security.sandbox.backends.seatbelt import SeatbeltBackend
+    from reyn.security.sandbox.policy import SandboxPolicy
+
+    backend = SeatbeltBackend()
+    if not backend.available():
+        pytest.skip("sandbox-exec unavailable on this host")
+
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    tmp_dir = plugin_root / ".pip-tmp"
+    tmp_dir.mkdir()
+    policy_with_tmpdir = SandboxPolicy(
+        network=False,
+        write_paths=[str(plugin_root)],
+        allow_subprocess=True,
+        timeout_seconds=30,
+        env_passthrough=["TMPDIR"],
+    )
+    probe_code = (
+        "import tempfile, os; "
+        "d = tempfile.mkdtemp(); "
+        "open(os.path.join(d, 'probe'), 'w').write('x'); "
+        "print(d)"
+    )
+
+    previous_tmpdir = os.environ.get("TMPDIR")
+    os.environ["TMPDIR"] = str(tmp_dir)
+    try:
+        result = _asyncio.run(
+            backend.run(
+                [sys.executable, "-c", probe_code],
+                policy_with_tmpdir, cwd=str(plugin_root),
+            ),
+        )
+    finally:
+        if previous_tmpdir is None:
+            os.environ.pop("TMPDIR", None)
+        else:
+            os.environ["TMPDIR"] = previous_tmpdir
+
+    assert result.returncode == 0, (
+        f"expected the TMPDIR-redirected write to succeed: "
+        f"stderr={result.stderr.decode('utf-8', errors='replace')}"
+    )
+    used_dir = result.stdout.decode("utf-8", errors="replace").strip()
+    assert used_dir.startswith(str(tmp_dir)), (
+        f"expected tempfile.mkdtemp() to land inside the redirected TMPDIR "
+        f"({tmp_dir}), got {used_dir!r} — the env var redirect did not take effect"
+    )
 
 
 # ── Test 7: pypi dep-fetch gate (require_http_get on the package index) ───────
@@ -802,7 +929,6 @@ async def test_derive_does_not_bypass_install_gate1_denial(tmp_path, monkeypatch
     assert not venv.exists(), "materialise ran despite gate 1 (install write) being denied"
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv not on PATH")
 @pytest.mark.asyncio
 async def test_dep_materialise_proceeds_when_pypi_http_get_approved(tmp_path, monkeypatch):
     """Tier 2: with the pypi http.get grant present, dep-materialisation
@@ -826,6 +952,56 @@ async def test_dep_materialise_proceeds_when_pypi_http_get_approved(tmp_path, mo
 
     assert result["status"] == "installed", f"approved-pypi materialise failed: {result}"
     assert (plugins_root() / "okdeps" / ".venv" / "bin" / "python").exists()
+
+
+@pytest.mark.asyncio
+async def test_materialise_succeeds_with_uv_stripped_from_path(tmp_path, monkeypatch):
+    """Tier 2: #3202 symptom 2 direct witness. With EVERY PATH entry that
+    could resolve a `uv` binary removed (verified: `shutil.which("uv")`
+    returns None under the stripped PATH), a REAL dep-materialise — a tiny
+    real PyPI package (`six`, pure Python, no build step) via a real network
+    fetch — still succeeds. `_materialise_deps` no longer names `uv`
+    anywhere, so its absence must be a non-event; RED if materialise still
+    somehow depended on it."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    import shutil as _shutil
+    real_path = os.environ.get("PATH", "")
+    stripped_entries = [
+        entry for entry in real_path.split(os.pathsep)
+        if not (Path(entry) / "uv").exists() and not (Path(entry) / "uv.exe").exists()
+    ]
+    stripped_path = os.pathsep.join(stripped_entries)
+    monkeypatch.setenv("PATH", stripped_path)
+    assert _shutil.which("uv") is None, (
+        "test setup bug: `uv` is still resolvable on the stripped PATH — "
+        "this witness would not actually exercise a uv-less environment"
+    )
+
+    src = tmp_path / "src" / "nouvdeps"
+    (src / ".reyn-plugin").mkdir(parents=True)
+    (src / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({"name": "nouvdeps", "version": "0.1.0", "capabilities": []}),
+        encoding="utf-8",
+    )
+    (src / "requirements.txt").write_text("six\n", encoding="utf-8")
+
+    ctx = _make_ctx(tmp_path, approve_plugins_root=True, approve_all_http=True)
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(src)})
+    result = await install_handle(op, ctx)
+
+    assert result["status"] == "installed", f"materialise failed without uv on PATH: {result}"
+    venv_python = plugins_root() / "nouvdeps" / ".venv" / "bin" / "python"
+    assert venv_python.exists()
+    site_packages = subprocess.run(
+        [str(venv_python), "-c", "import six; print(six.__file__)"],
+        capture_output=True, text=True,
+    )
+    assert site_packages.returncode == 0 and "six" in site_packages.stdout, (
+        f"real dependency (six) was not actually installed/importable: {site_packages}"
+    )
 
 
 # ── #3048 seal: require_http_get awaits indefinitely when a bus is wired ──────
@@ -871,7 +1047,6 @@ async def test_require_http_get_awaits_indefinitely_when_unanswered(tmp_path):
 # ── #3048 fix: install-grant derives the pypi.org dep-fetch approval ──────────
 
 
-@pytest.mark.skipif(not _uv_available(), reason="uv not on PATH")
 @pytest.mark.asyncio
 async def test_plugin_install_derives_pypi_grant_no_indefinite_await(tmp_path, monkeypatch):
     """Tier 2: #3048 fix, load-bearing. Only the install's gate-1 write is
@@ -931,7 +1106,7 @@ async def test_derived_pypi_grant_is_host_scoped_not_blanket(tmp_path):
     """Tier 1: #3048 security witness — confused-deputy guard. The derive
     plugin_install.py performs (``session_approve_host("pypi.org", ...,
     kind="http.get")``) covers EXACTLY pypi.org — the fixed index
-    ``uv pip install`` resolves against — never http.get generally.
+    ``pip install`` resolves against — never http.get generally.
     Approving pypi.org must NOT silently authorise a fetch from an
     unrelated host. Uses ONLY the public PermissionResolver surface
     (``session_approve_host`` / ``require_http_get``), real instances


### PR DESCRIPTION
**[per-PR-coder]** — part of #3202

## Symptom 1 — venv interpreter path (Windows `uv pip install failed` / `run 'uv venv' to create environment`)

`plugin_install.py` hardcoded `<venv>/bin/python`, which does not exist on Windows (`Scripts/python.exe` there). `_venv_interpreter_path()` now resolves the interpreter via stdlib `sysconfig.get_paths(scheme="venv", vars={"base": ..., "platbase": ...})["scripts"]` + `sysconfig.get_config_var("EXE")` — `sysconfig` itself resolves the OS-appropriate layout, no `os.name` branch at the call site. `_venv_interpreter_path_discover()` (on-disk `bin`/`Scripts` existence check) is kept only as a pathological-case fallback if the computed path somehow doesn't exist.

Ground: verified directly against a real `python -m venv` on this machine — the sysconfig-computed path exists and is executable. Axis-4: temporarily removed the fallback branch and confirmed the Windows-layout unit test goes RED (restored before committing).

## Symptom 2 — `uv` dependency removed from materialise

Explore confirmed no rationale was ever recorded for choosing `uv`, no lockfile is used (plain `requirements.txt`), and reyn's own runtime already guarantees a working CPython. `_materialise_deps()` now uses `<sys.executable> -m venv` + `<venv_python> -m pip install` — both bundled with CPython, nothing extra to have on `PATH`.

Ground (step 0, run before touching code): a real `pip install` of the `rag` plugin's actual `requirements.txt` (`sqlite-vec>=0.1.9 apsw>=3.51 chonkie>=1.7 fastmcp>=2.0` — `sqlite-vec` is wheel-only, no sdist) resolved and installed cleanly, exit 0.

Witness: `test_materialise_succeeds_with_uv_stripped_from_path` strips every `PATH` entry that could resolve `uv` (verified via `shutil.which("uv") is None`), then runs a REAL network install of `six` end-to-end — succeeds.

## Sandbox: TMPDIR containment

pip unpacks wheels via `tempfile.mkdtemp()`, which defaults outside `write_paths` (system `/tmp`) unless `TMPDIR` is redirected. `_materialise_deps` now points `TMPDIR` at a dir under `plugin_root` (already granted) for the duration of the two subprocess calls, save/restore around the mutation.

Honest finding, not asserted as "load-bearing" beyond what's true: because `_materialise_deps` already passes `cwd=str(plugin_root)`, and CPython's own `tempfile._get_default_tempdir()` candidate list ends with `os.getcwd()` before raising, a real `pip install six` under Seatbelt with `write_paths=[plugin_root]` and NO TMPDIR override already succeeds via that built-in cwd fallback — measured directly, not assumed. The explicit TMPDIR redirect is kept as defense-in-depth (removes reliance on an internal fallback chain that a future refactor or pip/tempfile version could narrow), and `test_tmpdir_redirect_contains_temp_write_under_plugin_root` verifies it actually takes effect (the write lands in the designated dir) rather than claiming a denial that direct measurement showed doesn't occur in this call shape.

## ensurepip friendly error

`python -m venv` needs `ensurepip`, split into a separate `python3-venv` package on Debian/Ubuntu's bare `python3`. Venv-creation failure now surfaces a decision-enabling hint (`apt install python3-venv`) when `ensurepip` appears in the failure detail, on top of CPython's own stderr (which already names the package).

## #3060 (spawn network-free) — unaffected

Spawn execs the frozen absolute interpreter path directly; `_build_mcp_entries` never re-invokes `pip`/`uv`/anything. Unchanged by this PR.

## Windows CI (proposal only, not included)

No `windows-latest` job exists in `.github/workflows/` (confirmed via grep). A real Windows end-to-end witness (`python -m venv` → `pip install` → spawn) needs an actual Windows runner — unit-level `sysconfig` witnesses here cannot prove that. **Proposal, not included in this PR** (architect firm pending): add a `windows-latest` matrix leg to `wheel-reachability.yml`, running the plugin-install materialise + spawn path against a small real requirements.txt, gated the same way the existing Linux job is.

## Docs

- ADR 0064 gets a new §3.11a recording *why* pip replaces uv — the missing rationale for the original uv choice is the actual root cause of #3202 going unnoticed.
- `control-ir.md` §Fields(plugin_install) updated to match (`sys.executable -m venv` + `venv_python -m pip install`, sysconfig-based interpreter resolution).
- `build-a-rag-corpus.md`: removed the "uv is required" callout (no extra tool needed now); kept "don't hand-create a venv" guidance.

## Gates (local)
- `ruff check src/reyn/core/op_runtime/plugin_install.py tests/test_plugin_install.py` — pass
- `python scripts/test_tier_audit.py --strict tests/test_plugin_install.py` — 26/26 OK
- `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/plugin_install.py` — pass
- `pytest` (full suite, single foreground run, `--randomly-seed=12345`) — 9419 passed, 36 skipped, 0 failed

## Test plan
- [x] `test_plugin_install.py` full file green (26 tests)
- [x] Axis-4: fallback removal flips Windows-layout unit test RED (verified by hand, reverted before commit)
- [x] Symptom 2 direct witness: real network install with `uv` stripped from `PATH` succeeds
- [x] TMPDIR redirect witness under real Seatbelt backend (macOS)
- [x] Full suite green with a fixed `pytest-randomly` seed