### PR TITLE
fix(3202): sync arc-witness docstrings + sysconfig-based venv assert (co-vet follow-ups)

### DIFF
--- a/tests/test_fp0063_arc_witness.py
+++ b/tests/test_fp0063_arc_witness.py
@@ -83,8 +83,9 @@ sandbox's ``builtin-rag`` extra already provides apsw/chonkie/sqlite_vec, and
 the copy's ``.mcp.json`` points its two REAL servers -- chunker + vector-store
 -- at ``sys.executable`` with ``PYTHONPATH`` pinned to this checkout, mirroring
 ``test_fp0063_p3_rag_pipelines.py``'s ``_server_env()`` precedent) --
-so ``plugin_install``'s dependency-materialisation step (real ``uv``, real
-network) never triggers at all, and the ``require_http_get("pypi.org")``
+so ``plugin_install``'s dependency-materialisation step (real ``python -m
+venv`` + real ``pip install``, real network) never triggers at all, and the
+``require_http_get("pypi.org")``
 permission gate it would need is never reached. The THIRD server
 (markitdown) is the SAME disclosed real-FastMCP-stub substitution p3 uses
 (the real ``markitdown-mcp`` PyPI package is not installed here). Only the
@@ -220,9 +221,10 @@ def _prepare_local_plugin_copy(tmp_path: Path) -> Path:
     """Copy the real ``rag`` plugin tree into ``tmp_path``, then:
 
     - DROP ``requirements.txt`` entirely, so ``plugin_install``'s dependency
-      materialisation step (real ``uv venv`` + real network fetch) never
-      triggers -- this sandbox's ``builtin-rag`` extra already satisfies
-      apsw/chonkie/sqlite_vec ambient-side, and this is a LOCAL install, not
+      materialisation step (real ``python -m venv`` + ``pip install`` + real
+      network fetch) never triggers -- this sandbox's ``builtin-rag`` extra
+      already satisfies apsw/chonkie/sqlite_vec ambient-side, and this is a
+      LOCAL install, not
       the builtin fast-path, so the copy is what gets network-audited.
     - Rewrite ``.mcp.json``: the plugin's own two REAL servers (chunker,
       vector-store -- the ONLY two it declares; markitdown is deliberately

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -644,7 +644,7 @@ async def test_materialise_deps_rewrites_mcp_spawn_to_venv_interpreter(tmp_path,
 
     assert result["status"] == "installed", f"install failed: {result}"
 
-    venv_python = plugins_root() / "venvplugin" / ".venv" / "bin" / "python"
+    venv_python = _venv_interpreter_path(plugins_root() / "venvplugin" / ".venv")
     assert venv_python.exists(), "per-plugin venv interpreter was not materialised at install time"
 
     mcp_yaml = ctx.workspace.base_dir / ".reyn" / "config" / "mcp.yaml"
@@ -951,7 +951,7 @@ async def test_dep_materialise_proceeds_when_pypi_http_get_approved(tmp_path, mo
     result = await install_handle(op, ctx)
 
     assert result["status"] == "installed", f"approved-pypi materialise failed: {result}"
-    assert (plugins_root() / "okdeps" / ".venv" / "bin" / "python").exists()
+    assert _venv_interpreter_path(plugins_root() / "okdeps" / ".venv").exists()
 
 
 @pytest.mark.asyncio
@@ -993,7 +993,7 @@ async def test_materialise_succeeds_with_uv_stripped_from_path(tmp_path, monkeyp
     result = await install_handle(op, ctx)
 
     assert result["status"] == "installed", f"materialise failed without uv on PATH: {result}"
-    venv_python = plugins_root() / "nouvdeps" / ".venv" / "bin" / "python"
+    venv_python = _venv_interpreter_path(plugins_root() / "nouvdeps" / ".venv")
     assert venv_python.exists()
     site_packages = subprocess.run(
         [str(venv_python), "-c", "import six; print(six.__file__)"],
@@ -1090,7 +1090,7 @@ async def test_plugin_install_derives_pypi_grant_no_indefinite_await(tmp_path, m
     result = await asyncio.wait_for(install_handle(op, ctx), timeout=30.0)
 
     assert result["status"] == "installed", f"install failed/denied: {result}"
-    assert (plugins_root() / "needsdeps4" / ".venv" / "bin" / "python").exists()
+    assert _venv_interpreter_path(plugins_root() / "needsdeps4" / ".venv").exists()
     assert not bus.asks, (
         "a separate pypi.org intervention prompt was raised — the derive did "
         "not suppress it (this is exactly the prompt that hangs under "


### PR DESCRIPTION
**[per-PR-coder]** — part of #3202

Two small, non-blocker follow-ups surfaced during #3204/#3205 co-vet.

## ① `tests/test_fp0063_arc_witness.py` docstring drift (doc-only)
Two docstrings still described the plugin dependency-materialisation step as
real `uv` (`uv venv` / `uv pip`), stale after #3204 moved `_materialise_deps`
in `src/reyn/core/op_runtime/plugin_install.py` to stdlib
`sys.executable -m venv` + `<venv_python> -m pip install`. Grounded this
directly against the current implementation (no `uv` reference remains in
`plugin_install.py`'s runtime path — only historical comments contrasting
with the old approach) before editing. Updated both docstrings (near old
`:86` / `:223`) to say `python -m venv` + `pip install`.

Grepped the rest of the file and sibling tests for other `uv`-as-materialise
assumptions: `tests/test_fp0063_p3_rag_pipelines.py`'s `uv`/`uvx` references
are about the unrelated `markitdown-mcp` server, not `plugin_install`'s
materialise step, so not drift. `docs/deep-dives/proposals/0064-plugin-model.md`
already documents the uv→pip move in its own §3.11a update — no drift there
either.

## ② `bin/python` POSIX-hardcoded assertions in `tests/test_plugin_install.py`
Four assertions (including the #3202 symptom-2 "materialise succeeds with
`uv` stripped from `PATH`" witness) hardcoded `<venv>/.venv/bin/python`,
which is POSIX-only — ironic for tests exercising a PR whose own point was
fixing a POSIX-only venv-path assumption for Windows. Reused #3204's
existing sysconfig-based `_venv_interpreter_path` resolver (already imported
in this test file for its own dedicated unit tests) instead of inventing a
new POSIX/Windows branch. Fixed all four sites for consistency, not just the
one symptom-2 test.

## Verification
- Both target test files pass locally (`test_plugin_install.py`: 26 passed;
  `test_fp0063_arc_witness.py`: 1 passed, still green after the docstring
  edit).
- `_venv_interpreter_path` itself already has dedicated coverage
  (`test_venv_interpreter_path_resolves_real_venv_via_sysconfig` etc.), so
  reusing it in these four assertions is not a fresh untested path.
- Full local gate run (this sandbox is POSIX, so the fix's Windows-path
  benefit isn't independently observable here — it is a correctness fix
  based on reading `_venv_interpreter_path`'s own tested contract, not a
  locally-falsified regression).

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_plugin_install.py tests/test_fp0063_arc_witness.py` — 27/27 OK, 0 Tier-4
- [x] `pytest` (full suite, foreground) — 9432 passed, 36 skipped, 0 failed
- [x] `python scripts/verify_module_docstrings.py` — N/A, no `src/` files changed

No production code changed (docstring-only + test-only).