### PR TITLE
fix(3213): make rag_ingest/rag_query exact param names prominent in SKILL.md body

### DIFF
--- a/src/reyn/builtin/plugins/rag/skills/build_and_query_rag_corpus/SKILL.md
+++ b/src/reyn/builtin/plugins/rag/skills/build_and_query_rag_corpus/SKILL.md
@@ -88,9 +88,28 @@ Once installed:
    or every chunk it embeds is wasted spend. Have an API key? read
    `configure-embedding-provider.md`. No key / offline? read
    `configure-local-embedding-model.md`.
-2. **Run it.** Read `run-ingest-and-query-workflow.md` for the exact
-   `pipeline__run` calls, parameter names, and the `embedding_model`
-   mismatch that silently ruins a corpus.
+2. **Run it.** The exact `pipeline__run` calls -- copy these param names
+   **verbatim**, a light model has generated `corpus_path`/`db_path`
+   (ingest) and other plausible-sounding names unprompted:
+
+   ```
+   pipeline__run(name="rag_ingest.ingest", input={
+     "input_path": "/abs/path/to/docs",   # required; absolute; folder or one file
+     "output_db": "./rag/docs.sqlite",    # required; cwd-relative, zero-config
+   })
+
+   pipeline__run(name="rag_query.query", input={
+     "query_text": "how does X work?",    # required
+     "db": "./rag/docs.sqlite",           # required; SAME file output_db wrote.
+                                           # EXACT name "db" -- not "db_path",
+                                           # not "vector_store_path", not "corpus_path".
+   })
+   ```
+
+   Full detail (absolute-vs-cwd-relative path rules, `top_k`/
+   `embedding_model` defaults, the returned summary fields, and the
+   `embedding_model` mismatch that silently ruins a corpus):
+   `run-ingest-and-query-workflow.md`.
 3. **Internals.** For the sqlite schema, incremental re-ingest, tuning, or
    swapping the vector-store/chunker/parser backend, read
    `corpus-internals-schema-tuning-and-backend-swap.md`.


### PR DESCRIPTION
**[per-PR-coder]** — part of #3213 (top checklist item: "param 名の skill 明示 — 最高 ROI").

## Problem
In the live RAG turnkey run (#3210 live-verify), the model repeatedly generated wrong `pipeline__run` param names for the builtin RAG pipelines:
- `rag_ingest.ingest`: guessed `corpus_path`/`db_path` instead of the real `input_path`/`output_db`.
- `rag_query.query`: guessed wrong names instead of the real `query_text`/`db`.

This cost 2 of 5 prompts in that run as correction turns. The bundled reference (`references/run-ingest-and-query-workflow.md`) already had correct examples, but `:name` skill-load only surfaces the `SKILL.md` **body**, not bundled references — so the exact names were never prominent at the moment a light model needed them.

## Exact param names (quoted from the pipeline definitions)
- `src/reyn/builtin/plugins/rag/pipelines/rag_ingest.yaml:34-45` (`Inputs` comment): `input_path` (required) and `output_db` (required).
- `src/reyn/builtin/plugins/rag/pipelines/rag_query.yaml:8-11` (`Inputs` comment): `query_text` (required) and `db` (required) — explicitly *not* `db_path`/`vector_store_path`.

## Change
`src/reyn/builtin/plugins/rag/skills/build_and_query_rag_corpus/SKILL.md` — under "Next steps" item 2 ("Run it"), added a compact, copy-pasteable `pipeline__run` example for both `rag_ingest.ingest` and `rag_query.query` directly in the body, with the exact required param names inline and the wrong-name pitfalls called out (`corpus_path`/`db_path`/`vector_store_path`). The bundled reference (`run-ingest-and-query-workflow.md`) is unchanged and still holds the full detail (path-absolute-vs-relative rules, defaults, returned fields) — the body is now the authoritative quick-reference for the exact names.

Documentation only — no pipeline code, param names, or runtime behavior changed.

## Gates run locally
- `ruff check src tests` — all checks passed.
- `pytest tests/test_3162_plugin_body_read_parity.py -q` — 9 passed.
- `pytest tests/test_skill_md_default_inline_cap_gate.py tests/test_fp0063_p4_builtin_rag_skill.py -q` — 9 passed (the SKILL.md-specific gates, including the inline-size-cap test referenced in #3162).
- `SKILL.md` size: 7435 bytes, comfortably under the 8_192-char default inline cap (`MAX_CONTROL_IR_RESULT_INLINE_BYTES`).

## Test plan
- [x] Confirmed exact param names against the pipeline YAML source (not guessed).
- [x] `ruff check` clean.
- [x] `test_3162_plugin_body_read_parity.py` green.
- [x] `test_skill_md_default_inline_cap_gate.py` + `test_fp0063_p4_builtin_rag_skill.py` green (SKILL.md-specific gates).
- [ ] (skipped — full pytest suite not run; this is an md-only doc change per dispatch scope, and CI will run the full suite)