### PR TITLE
fix(docs): correct stale MCP_SEARCH_THRESHOLD default in build_tools() docstring

### DIFF
--- a/src/reyn/runtime/router_tools.py
+++ b/src/reyn/runtime/router_tools.py
@@ -37,9 +37,15 @@ from typing import Literal
 # demand, rather than receiving all N schemas upfront.
 #
 # Spring AI experiment shows 63–64% token reduction for 40+ MCP tools.
-# Override per-project via ``mcp.search_threshold:`` in reyn.yaml (parsed by
-# config._parse_mcp_search_threshold; injected into build_tools() as kwarg).
-# Setting threshold=0 disables the switch (always inline).
+# Nominally overridable per-project via ``mcp.search_threshold:`` in reyn.yaml
+# (parsed into ``ReynConfig.mcp_search_threshold`` by
+# config._parse_mcp_search_threshold), but as of this writing neither
+# router_loop.py call site (SchemeOps.present / SchemeOps.base_tools) passes
+# that config value through to build_tools()'s ``mcp_search_threshold=``
+# kwarg — the config field is parsed but not threaded, so build_tools()
+# always falls back to the module-level MCP_SEARCH_THRESHOLD constant below
+# regardless of reyn.yaml. Setting threshold=0 disables the switch (always
+# inline).
 #
 # The exact Anthropic ``tool_search_tool`` API spec as of 2025-11:
 #   {
@@ -254,8 +260,14 @@ def build_tools(
         FP-0024 Component D. When the total MCP tool count is >= this value
         (and > 0), the D1–D3 inline MCP tools are replaced by a single
         tool_search_tool meta-tool that loads specific tools on demand.
-        Default: MCP_SEARCH_THRESHOLD (30). Set 0 to always inline.
-        Override per-project via ``mcp.search_threshold:`` in reyn.yaml.
+        Default: MCP_SEARCH_THRESHOLD (0) — always inline. ``ReynConfig.
+        mcp_search_threshold`` (parsed from ``mcp.search_threshold:`` in
+        reyn.yaml, config-side default 30) is NOT currently threaded through
+        to this parameter by either router_loop.py call site
+        (``present()`` / ``base_tools()``), so the effective runtime default
+        is 0 regardless of ``reyn.yaml``. A caller that wants the config
+        value honored must pass it explicitly:
+        ``build_tools(..., mcp_search_threshold=cfg.mcp_search_threshold)``.
     """
     # RETRO-H1+H2 fix: dynamic enum injection for delegate_to_agent.to closes
     # the schema-level hallucination gap (P4 alignment — LLM picks only from


### PR DESCRIPTION
**[per-PR-coder]** — Doc-accuracy fix + threading investigation, reported by e2e-coder.

## The bug
`src/reyn/runtime/router_tools.py:257` — `build_tools()`'s docstring said "Default: MCP_SEARCH_THRESHOLD (30). Set 0 to always inline." The constant it names, `MCP_SEARCH_THRESHOLD`, was changed from 30 → 0 by FP-0032 (see the comment right below the constant at line 57-61). The `(30)` was stale doc-drift.

## Threading investigation — ground truth found

Traced the real call path rather than trusting either docstring or the adjacent comment:

- `ReynConfig.mcp_search_threshold` (`config/root.py:181`, config-side default `30`) IS parsed correctly: `config/loader.py:334` `_parse_mcp_search_threshold` → `config/loader.py:710` sets it on `ReynConfig`. Covered by `tests/test_config_mcp_merge_1146.py`.
- However, **the config value never reaches `build_tools()`**. There are exactly two call sites of `build_tools()` in the whole repo, both in `router_loop.py`:
  - `SchemeOps.present()` (`router_loop.py:2767`)
  - `SchemeOps.base_tools()` (`router_loop.py:2787`)

  Neither passes `mcp_search_threshold=` as a kwarg. Grep for `.mcp_search_threshold` across `src/` turns up only the config parse/plumbing — no reader of `cfg.mcp_search_threshold` that threads it into `build_tools()`.

- **Conclusion: config default 30 does NOT reach `build_tools()` at runtime.** The function always falls back to its own parameter default, the module constant `MCP_SEARCH_THRESHOLD = 0`. So `mcp.search_threshold:` in `reyn.yaml` is currently a no-op for this code path — it's parsed into `ReynConfig` but silently discarded before it can affect tool-search-tool activation.

- The module-level comment at `router_tools.py:41` ("injected into build_tools() as kwarg") was itself inaccurate — nothing injects it. Fixed alongside the docstring.

## Fix (this PR)
- `build_tools()` docstring (`router_tools.py:~253`): states the true default is `MCP_SEARCH_THRESHOLD (0)`, and documents that `ReynConfig.mcp_search_threshold` is parsed but not currently threaded through by either call site, with the effective default always 0 regardless of `reyn.yaml`.
- Adjacent module comment (`router_tools.py:39-42`): corrected the false "injected into build_tools() as kwarg" claim to describe the actual (missing) threading.

## Flagged for lead/owner — NOT acted on in this PR
`ReynConfig.mcp_search_threshold` is currently a dead/inert config field: it's parsed with a config default of 30 that can never take effect, since no call site threads it to `build_tools()`. Combined with FP-0033 (full removal of `tool_search_tool` tracked as a separate follow-up), this raises the question of whether the config field should be (a) wired through to `build_tools()`'s call sites, or (b) removed as dead config surface. Scoped out of this PR per the per-PR-coder brief — this is a decision for the lead/owner, not a unilateral deletion here.

## Gates run locally
- `ruff check src/reyn/runtime/router_tools.py` — pass
- `python scripts/verify_module_docstrings.py src/reyn/runtime/router_tools.py` — pass
- No runtime code touched (docstring/comment only), so no pytest run required per brief.

## Test plan
- [x] Re-read `build_tools()` call sites in `router_loop.py` to confirm neither passes `mcp_search_threshold=` (verified via grep + direct read of both call sites)
- [x] Confirmed `ReynConfig.mcp_search_threshold` parse path via `config/loader.py:334,710` and existing test `tests/test_config_mcp_merge_1146.py`
- [x] ruff + docstring-verify gates pass locally