### PR TITLE
docs(fp-0035): exec__sandboxed_exec→exec__run qualified-name tidy (post-#3231)

### DIFF
--- a/docs/deep-dives/research/fp-0035-permission-communication-analysis.md
+++ b/docs/deep-dives/research/fp-0035-permission-communication-analysis.md
@@ -134,7 +134,7 @@ error message は区別済み。変更不要。
 OS がそれに従って backend を選択・実行する。Permission gate が事前に走らないため
 wasted call が発生しない設計になっている。
 
-**変更不要**。ただし `describe_action("exec__sandboxed_exec")` のレスポンスに
+**変更不要**。ただし `describe_action("exec__run")` のレスポンスに
 `SandboxPolicy` フィールドの説明を補足すると LLM の policy 選択精度が上がる可能性がある
 (= Phase 2 候補)。
 
@@ -237,7 +237,7 @@ scenarios:
 | P0 | web config-deny 時に `list_actions` から除外 (Pattern D) | SMALL | 新 issue 発行 |
 | P1 | budget SP section (Pattern A, 残量 threshold 以下で表示) | SMALL | FP-0035 Phase 2 候補 |
 | P2 | FP-0036 framework 着地後に dogfood scenario set `permissions.yaml` を authoring | MEDIUM | FP-0036 scenario wave |
-| P3 | `describe_action("exec__sandboxed_exec")` に SandboxPolicy フィールド説明を追加 (Pattern C 強化) | SMALL | FP-0035 Phase 2 候補 |
+| P3 | `describe_action("exec__run")` に SandboxPolicy フィールド説明を追加 (Pattern C 強化) | SMALL | FP-0035 Phase 2 候補 |
 | defer | Pattern A の full file scope disclosure | — | dogfood 結果次第 |
 
 ---


### PR DESCRIPTION
[per-PR-coder] — part of #3226

## Summary
PR #3231 renamed the `sandboxed_exec` tool to `exec`, so the qualified tool name `exec__sandboxed_exec` is now `exec__run`. This left two stale `describe_action("exec__sandboxed_exec")` references in `docs/deep-dives/research/fp-0035-permission-communication-analysis.md` (lines ~137, ~240).

## Scope note for reviewer — op-kind kept vs qualified-name stale
This doc also references the bare **op-kind** `sandboxed_exec` in several places (table row line 34, heading `### 3.5 sandboxed_exec` line 122, `"kind": "sandboxed_exec"` line 127, and table rows lines 162/164). Those are **intentionally untouched** — `OP_KIND_MODEL_MAP["sandboxed_exec"]` and `SandboxedExecIROp` are preserved for recovery-safety per the shell-abolition arc design (#3226), even though the LLM-facing *tool* was renamed. Only the qualified `exec__<verb>` tool-name form (`exec__sandboxed_exec` → `exec__run`) was stale; the bare op-kind string is still correct and should not be changed.

## Test plan
- [x] `grep -n 'exec__sandboxed_exec' docs/deep-dives/research/fp-0035-permission-communication-analysis.md` → 0 matches (was 2 before)
- [x] `grep -n 'sandboxed_exec' docs/deep-dives/research/fp-0035-permission-communication-analysis.md` → 5 remaining bare op-kind references, all untouched (lines 34, 122, 127, 162, 164)
- [x] Docs-only change; no src/tests touched, no CI gates applicable beyond doc build

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>