### PR TITLE
fix(3233): pytest_configure in-process import-identity guard (wrong-worktree false-green)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,93 @@
+"""Root pytest configuration: in-process import-identity guard (#3233).
+
+`#3231`'s real incident: a coder ran `pytest` in a git worktree whose ambient
+venv had an editable `.pth` pointing at a DIFFERENT worktree. In-process
+`import reyn` resolved that OTHER checkout, so the whole suite ran stale code
+and reported a false-green ("9150 passed") that hid a real RED an architect's
+fresh-worktree run caught.
+
+`scripts/verify_env_identity.py` (#3024) already guards this family of
+mismatch, but only for a SPAWNED subprocess's resolution, via two opt-in
+`tests/conftest.py` fixtures (`out_of_process_reyn` / `reyn_console_scripts`)
+a test requests when it spawns something. Neither fires for the incident
+above: no test asked for a spawn-guard, because the divergence was in the
+IN-PROCESS `import reyn` every test file performs implicitly, not in anything
+a test spawned. This module is the complement: it checks the resolution the
+whole process is already relying on, unconditionally, before a single test is
+collected.
+
+Lives at the repo root (not `tests/conftest.py`) and hooks `pytest_configure`
+rather than an autouse fixture so it fires for ANY bare `pytest` invocation —
+including `pytest --collect-only` with zero tests selected — since root
+`conftest.py` files load, and `pytest_configure` runs, before collection
+starts. A session-scoped autouse fixture would not fire until at least one
+test is collected AND run, which is a weaker guarantee than "any pytest
+startup in this tree is protected".
+
+Contract grounding for why this is a genuine wrong-worktree signal rather
+than a fragile heuristic: `pyproject.toml`'s `[tool.pytest.ini_options]`
+declares `pythonpath = ["src"]`, and CI always runs this checkout in
+src-mode (no separate `reyn` install) — so in every correctly-configured
+environment `reyn.__file__` resolves under `<rootdir>/src` trivially, and
+this check passes without ever looking at anything. It can only fire where
+an editable `.pth` from ANOTHER checkout wins over that pin, which is
+precisely the wrong-worktree case #3231 hit.
+
+NOTE (future installed-mode workflow): if a workflow is ever added that
+intentionally runs this test suite against an INSTALLED (site-packages)
+`reyn` rather than this checkout's `src/reyn` — i.e. one where
+`pythonpath = ["src"]` is deliberately not the operative resolution — this
+guard will need a scope exception (e.g. an opt-out env var) for that mode,
+since a correctly-resolving installed `reyn` is indistinguishable from this
+check's own vantage point from the wrong-worktree case it exists to catch.
+No such workflow exists today, so no exception is wired.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent
+
+
+def _load_env_identity():
+    """Load `scripts/verify_env_identity.py` by path (mirrors `tests/conftest.py`).
+
+    `scripts/` carries no `__init__.py` and is not on `sys.path` by default, so
+    the module is loaded from its file location rather than imported by name.
+    """
+    path = _REPO_ROOT / "scripts" / "verify_env_identity.py"
+    spec = importlib.util.spec_from_file_location("_reyn_env_identity_root_guard", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Fail loudly, before collection, if in-process `reyn` resolves outside this tree.
+
+    `import reyn` here is deliberate and unavoidable: this check's whole subject
+    is "what does `import reyn` resolve to in THIS process", and Python caches
+    modules by name in `sys.modules` — the module object this import returns is
+    the exact same object every collected test file's own `import reyn` will
+    receive. There is no reyn-free way to ask this question in-process (contrast
+    `scripts/verify_env_identity.py`'s out-of-process checks, which stay
+    reyn-free precisely because they ask it of a *different* process).
+    """
+    import reyn
+
+    env_identity = _load_env_identity()
+    finding = env_identity.check_in_process_tree(
+        Path(reyn.__file__), Path(config.rootpath)
+    )
+    if finding is None:
+        return
+    pytest.exit(
+        f"env-identity (in-process, #3233):\n{finding.render()}",
+        returncode=1,
+    )

--- a/scripts/verify_env_identity.py
+++ b/scripts/verify_env_identity.py
@@ -326,9 +326,77 @@ def check_console_scripts(root: Path) -> list[Finding]:
     return findings
 
 
+def check_in_process_tree(reyn_file: Path, root: Path) -> Finding | None:
+    """The in-process ``reyn`` — the one THIS interpreter already imported — must
+    resolve under ``<root>/src`` (#3233).
+
+    This is the in-process complement to `check_tree_identity` / `check_pinned_tree`
+    above, not a third entry in the same shape. Both of those measure a SPAWNED
+    subprocess's resolution while deliberately never importing `reyn` themselves —
+    `reyn`'s own resolution is the subject under test, so an importing checker
+    would assert with the very mechanism in question. This check asks a different
+    question: given that the CALLER has already imported `reyn` (a root
+    `conftest.py`'s `pytest_configure` necessarily has — that import IS the thing
+    every collected test file's own `import reyn` will read, since Python caches
+    modules by name in `sys.modules`), did it come from this checkout?
+
+    That is why this function is NOT registered in `CHECKS` / dispatched through
+    `verify()`: every `CHECKS` entry is `Callable[[Path], list[Finding]]` and stays
+    reyn-free so `main()` can run it standalone, out-of-process, with no `reyn` on
+    `sys.path` at all. This check's whole point is the opposite — it inspects an
+    `import reyn` that has ALREADY happened — so it takes the resolved
+    ``reyn.__file__`` as an argument from a caller that did the import, rather than
+    performing one itself.
+
+    A git worktree with no venv of its own resolves `import reyn` through whatever
+    checkout the ambient venv's editable ``.pth`` points at — a DIFFERENT checkout
+    than the one `pytest` was started from. `pytest`'s own `pythonpath = ["src"]`
+    (`pyproject.toml`) puts `<rootdir>/src` on `sys.path`, but an editable `.pth`
+    entry can still resolve first depending on `sys.path` ordering, and once
+    `reyn` is in `sys.modules` every subsequent `import reyn` in the process
+    — including every test file's — reads that same (possibly wrong) module
+    object. #3231: a coder's local `pytest` ran this way, against a DIFFERENT
+    worktree's stale code, and reported a false-green ("9150 passed") that hid a
+    real RED an architect's fresh-worktree run caught.
+    """
+    expected = (root / "src").resolve()
+    actual = Path(reyn_file).resolve()
+    try:
+        actual.relative_to(expected)
+        return None
+    except ValueError:
+        pass
+    return Finding(
+        check="in-process-tree",
+        detail=(
+            f"the in-process `reyn` this interpreter already imported resolves OUTSIDE "
+            f"the tree pytest was started from.\n"
+            f"    pytest rootdir:  {root}\n"
+            f"    expected under:  {expected}\n"
+            f"    reyn.__file__ resolves to: {actual}\n"
+            f"    Every test file's `import reyn` in THIS process reads this same "
+            f"(wrong) module — a whole suite can report green while measuring a "
+            f"different checkout's code (#3231)."
+        ),
+        remedy=(
+            f"run pytest from this worktree ({root}) rather than another checkout's "
+            f"venv/shell; or fix the editable install so its `.pth` points at "
+            f"{expected}; or set PYTHONPATH={expected} for this invocation so it "
+            f"wins over the stale `.pth` entry."
+        ),
+    )
+
+
 # The enumeration. A check is registered here or it does not run — `main` and the
 # `tests/conftest.py` fixtures both derive their work from this map rather than
 # from a hand-kept call list, so adding a check cannot leave a caller behind.
+#
+# `check_in_process_tree` above is deliberately NOT registered here — see its
+# docstring: every entry in this map is reyn-free and takes only `root`, so
+# `main()` can run standalone with no `reyn` on `sys.path`. The in-process check
+# takes an already-resolved `reyn.__file__` from a caller that necessarily
+# imported `reyn` itself (the root `conftest.py`'s `pytest_configure`), which
+# breaks that shape on purpose.
 CHECKS = {
     "tree-identity": check_tree_identity,
     "pinned-tree": check_pinned_tree,

--- a/tests/test_3233_inprocess_env_identity.py
+++ b/tests/test_3233_inprocess_env_identity.py
@@ -1,0 +1,133 @@
+"""Tier 1: `check_in_process_tree` contract, and a wiring witness for the root
+`conftest.py` guard it feeds (#3233).
+
+Two tests, deliberately different shapes, per the architect's #3233 gap note:
+a Tier-1 contract test on the pure function alone stays green even if someone
+deletes the `pytest_configure` call that wires it into pytest startup — the
+function would still return correct findings, just never asked. The second
+test below spawns a REAL `pytest --collect-only` subprocess with a decoy
+`PYTHONPATH` so a `reyn` OUTSIDE this checkout resolves first, and asserts on
+the subprocess's actual exit code and stderr — the only way to falsify "the
+guard is wired, not just present as dead code".
+
+Neither test moves the real `reyn.__file__`: the contract test passes synthetic
+paths to the pure function directly, and the wiring test manufactures a decoy
+package in a `tmp_path` rather than touching this checkout's own `src/reyn`.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _REPO_ROOT / "scripts" / "verify_env_identity.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("_env_identity_3233_under_test", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_a_reyn_file_outside_root_src_is_flagged_with_both_paths_and_a_remedy(
+    tmp_path: Path,
+) -> None:
+    """Tier 1: a `reyn.__file__` outside `<root>/src` returns a Finding naming both
+    paths and a concrete remedy.
+
+    FALSIFY: without this check, a wrong-worktree `import reyn` resolution is
+    silently accepted and every collected test measures the wrong checkout's code.
+    """
+    module = _load()
+    root = tmp_path / "this_checkout"
+    other = tmp_path / "other_checkout" / "src" / "reyn" / "__init__.py"
+    other.parent.mkdir(parents=True)
+    other.write_text("")
+
+    finding = module.check_in_process_tree(other, root)
+
+    assert finding is not None
+    assert finding.check == "in-process-tree"
+    assert str(root) in finding.detail
+    assert str(other) in finding.detail
+    # The remedy must be concrete and actionable, not a generic "fix your env".
+    assert "PYTHONPATH" in finding.remedy
+    assert "worktree" in finding.remedy or str(root) in finding.remedy
+
+
+def test_a_reyn_file_under_root_src_is_clean(tmp_path: Path) -> None:
+    """Tier 1: a `reyn.__file__` under `<root>/src` returns None (negative control)."""
+    module = _load()
+    root = tmp_path / "this_checkout"
+    reyn_file = root / "src" / "reyn" / "__init__.py"
+    reyn_file.parent.mkdir(parents=True)
+    reyn_file.write_text("")
+
+    assert module.check_in_process_tree(reyn_file, root) is None
+
+
+def test_a_decoy_reyn_cached_before_pytest_starts_makes_startup_exit_nonzero(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: the root `conftest.py`'s `pytest_configure` is actually wired in.
+
+    This is the load-bearing witness the architect flagged as missing from a
+    pure-function test alone: it drives a REAL `python -m pytest --collect-only`
+    subprocess against this repo and asserts on its actual exit code and
+    output. If the `pytest_configure` call were ever deleted from
+    `conftest.py`, the pure-function tests above would stay green while this
+    one goes red — proving the WIRING, not just the logic, is under test.
+
+    A plain decoy `PYTHONPATH` entry is not sufficient to reproduce the
+    divergence: pytest's own `pythonpath = ["src"]` (`pyproject.toml`) inserts
+    this checkout's `src` at `sys.path[0]` *after* interpreter startup, which
+    wins over anything already on `PYTHONPATH` (verified empirically — a bare
+    decoy `PYTHONPATH` entry left the guard silent). The real #3231 incident
+    reproduces only when a decoy `reyn` is already cached in `sys.modules`
+    BEFORE pytest runs — exactly what an ambient venv's editable `.pth` does at
+    interpreter startup, ahead of anything pytest itself controls. A
+    `sitecustomize.py` on `PYTHONPATH` reproduces that same "already resolved,
+    before pytest's own insertion" timing without touching any real venv.
+    """
+    decoy_reyn = tmp_path / "decoy_src" / "reyn"
+    decoy_reyn.mkdir(parents=True)
+    (decoy_reyn / "__init__.py").write_text("")
+
+    site_hook = tmp_path / "site_hook"
+    site_hook.mkdir()
+    (site_hook / "sitecustomize.py").write_text(
+        f"import sys\n"
+        f"sys.path.insert(0, {str(tmp_path / 'decoy_src')!r})\n"
+        f"import reyn  # noqa: F401  cache the decoy before pytest starts\n"
+    )
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(site_hook), str(tmp_path / "decoy_src"), env.get("PYTHONPATH", "")]
+    )
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "--no-header"],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert proc.returncode != 0, (
+        f"expected a decoy `reyn` cached before pytest startup to make the "
+        f"in-process guard fire; stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+    combined = proc.stdout + proc.stderr
+    assert "env-identity (in-process, #3233)" in combined
+    assert "PYTHONPATH" in combined
+    assert str(decoy_reyn / "__init__.py") in combined


### PR DESCRIPTION
[per-PR-coder] — Closes #3233

## The hazard
#3231's real incident: a coder ran `pytest` in a git worktree whose ambient venv had an editable `.pth` pointing at a DIFFERENT worktree. In-process `import reyn` resolved that other checkout, so the whole suite ran stale code and reported a false-green ("9150 passed") that hid a real RED an architect's fresh-worktree run caught.

## In-process vs #3024 out-of-process
`scripts/verify_env_identity.py` (#3024) already guards this family of mismatch, but its `CHECKS` (`tree-identity`, `pinned-tree`, `console-scripts`) all ask what a **spawned subprocess** resolves, and stay deliberately reyn-free — `reyn`'s own resolution is the subject under test, so an importing checker would assert with the very mechanism in question. `tests/conftest.py`'s `out_of_process_reyn` / `reyn_console_scripts` fixtures are the opt-in consumers of those checks — a test declares the dependency when it spawns something.

Nothing guarded the **in-process** `import reyn` every test file performs implicitly. This PR adds that complement:

- `check_in_process_tree(reyn_file, root)` in `scripts/verify_env_identity.py` — a pure function asserting `Path(reyn_file).resolve()` is under `<root>/src`. It is **deliberately NOT registered in `CHECKS`**: every `CHECKS` entry is `Callable[[Path], list[Finding]]` and stays reyn-free so `main()` can run standalone with no `reyn` on `sys.path`. This check's subject is the opposite — an `import reyn` that has *already happened* — so it takes the resolved path as an argument from a caller (necessarily) that imported it, rather than importing it itself.
- A new **repo-root** `conftest.py` with `pytest_configure(config)` that imports `reyn`, resolves `reyn.__file__`, calls `check_in_process_tree` against `config.rootpath`, and `pytest.exit(...)` loudly before collection on divergence. Root conftest + `pytest_configure` (not a session-autouse fixture) so it fires for **any** bare `pytest` invocation, including `--collect-only` with 0 tests, per the architect's placement call in #3233.

## Tests (both required)
1. **Tier 1 contract** on `check_in_process_tree`: a `reyn.__file__` outside `<root>/src` returns a `Finding` naming both paths + the remedy; one inside returns `None`.
2. **Wiring witness** (load-bearing): spawns a real `python -m pytest --collect-only` subprocess against this repo with a decoy `reyn` package **cached into `sys.modules` before pytest starts** (via a `sitecustomize.py` on `PYTHONPATH` — reproducing the actual timing of an ambient venv's editable `.pth`), and asserts non-zero exit + the remedy string in output.

   Note on realism: a **plain decoy `PYTHONPATH`** entry alone does NOT reproduce the divergence — I verified empirically that `pyproject.toml`'s `pythonpath = ["src"]` inserts this checkout's `src` at `sys.path[0]` *after* interpreter startup, which wins over anything already on `PYTHONPATH`. The wiring test only reproduces the real failure mode once the decoy `reyn` is already cached in `sys.modules` before pytest's own insertion runs — matching how an editable-install `.pth` resolves ahead of anything pytest controls.

**Green-on-strip closed**: I manually removed the `pytest_configure` body's `import reyn` call and re-ran the test file — the wiring test went RED (the pure-function contract tests stayed green), confirming it is strip-falsifiable and not just a restatement of the pure function's own logic.

## Installed-mode scope exception
The root `conftest.py` docstring records: if a future workflow runs this suite against an INSTALLED (site-packages) `reyn` rather than this checkout's `src/reyn` (i.e. `pythonpath = ["src"]` deliberately not in effect), this guard needs a scope exception (e.g. an opt-out env var) for that mode — a correctly-resolving installed `reyn` is indistinguishable, from this check's vantage point, from the wrong-worktree case it exists to catch. No such workflow exists today, so no exception is wired.

## Test plan
- [x] `ruff check src tests scripts conftest.py` — pass
- [x] `python scripts/test_tier_audit.py --strict tests/test_3233_inprocess_env_identity.py` — pass (3/3 OK, 0 errors)
- [x] `pytest` from repo root — 9162 passed, 36 skipped (0 failures; one pre-existing unrelated failure in `tests/test_3162_rag_skill_body_read_reachable.py` confirmed present on `main` without this branch's changes, deselected for this run)
- [x] `python scripts/verify_module_docstrings.py scripts/verify_env_identity.py conftest.py tests/test_3233_inprocess_env_identity.py` — pass
- [x] Manually verified strip-falsify: removing the `pytest_configure`→`check_in_process_tree` wiring turns the wiring-witness test RED while the pure-function tests stay green