### PR TITLE
docs(agent-worktree-cleanup): correct unlocked-worktrees-kept behavior (en+ja doc-drift)

### DIFF
--- a/docs/reference/agent-worktree-cleanup.ja.md
+++ b/docs/reference/agent-worktree-cleanup.ja.md
@@ -59,11 +59,14 @@ python scripts/cleanup_agent_worktrees.py --dry-run
 python scripts/cleanup_agent_worktrees.py --force
 ```
 
-死亡 PID (またはロックファイルなし) の worktree をすべて削除します。各候補に対して:
+死亡 PID の worktree をすべて削除します(ロックされていて、かつその PID がもう生存していない場合のみ対象)。各候補に対して:
 1. `.git/worktrees/<id>/locked` ファイルを削除 (存在する場合)
 2. `git worktree remove -f <path>` を呼び出す
 
-生存 PID の worktree は触れません。ロックファイルのない worktree (unlocked) も実行中のプロセスに守られていないため、デフォルトで削除されます。
+生存 PID の worktree は触れません。ロックファイルのない worktree (unlocked) は**常に保持され、決して削除されません** —
+unlocked な worktree は「放棄された」と証明されたわけではなく (未コミットのサブエージェント作業を保持している可能性があるため)、
+本ツールは「ロックファイルがない」ことを削除シグナルとして意図的に扱いません。`--force` の削除候補になるのは死亡 PID (stale) の
+worktree のみです。
 
 出力例:
 
@@ -127,7 +130,7 @@ worktree ごとに 1 つの JSON オブジェクトを stdout に出力し、最
 |--------|-----------|------|
 | `--list` | on | 候補とステータスを一覧表示。変更なし |
 | `--dry-run` | off | 削除をシミュレーション。何が起きるかを表示 |
-| `--force` | off | 死亡 PID と unlocked の worktree を削除 |
+| `--force` | off | 死亡 PID (stale) の worktree のみ削除;unlocked は常に保持 |
 | `--keep-recent N` | 0 (0 件保持) | 最近更新された N 件の worktree を除外 |
 | `--include-alive` | off | 生存 PID の worktree も削除 (危険) |
 | `--json` | off | 機械可読な JSON 出力 |
@@ -166,12 +169,13 @@ fi
 ### 使うべきでない場面
 
 - **エージェント以外の worktree を削除したい場合。** スクリプトは `.claude/worktrees/` 配下の `agent-*` プレフィックスでフィルタリングします。意図的に他のすべての worktree を無視します。セーフティへの影響を理解せずにフィルタを拡大しないでください。
-- **誤った dispatch からの回復時。** 検査したい誤った結果を出したサブエージェントがある場合は、まず `--list` を実行して worktree が dead/unlocked リストにあることを確認してから削除してください。クリーンアップ中に最近の worktree を保護するために `--keep-recent` を使用してください。
+- **誤った dispatch からの回復時。** 検査したい誤った結果を出したサブエージェントがある場合は、まず `--list` を実行して worktree が dead (ロック済みで PID がもう生存していない) であることを確認してから削除してください。unlocked な worktree は `--force` でそもそも触れられないため、検査のためにそのまま残しておいても常に安全です。クリーンアップ中に最近の worktree を保護するために `--keep-recent` を使用してください。
 
 ## セーフティ特性
 
 - **`--include-alive` なしで生存 PID は決して触られません。** PID チェックは削除前に `ps -p <pid>` で実行されます。チェックが失敗した (PID 生存) 場合、worktree はスキップされてログに記録されます。
 - **`--dry-run` は常に安全です。** ファイルシステムや git 操作は一切実行されません。
+- **unlocked な worktree はどのフラグでも削除候補になりません。** `build_candidates()` が選ぶのは `stale` (または `--include-alive` 指定時は `locked` 全体) のみです。unlocked な worktree にはチェックすべき PID を持つロックファイルが存在せず、放棄されたと証明できないため、本ツールは常にそれをそのままにします。unlocked を回収するフラグは存在しません。
 - **スクリプトは `.claude/worktrees/` 配下の `agent-*` パスのみを対象とします。** フィーチャーブランチや main などの他のすべての worktree はスクリプトには見えません。
 
 ## 関連リソース

--- a/docs/reference/agent-worktree-cleanup.md
+++ b/docs/reference/agent-worktree-cleanup.md
@@ -77,12 +77,16 @@ always (no changes to check).
 python scripts/cleanup_agent_worktrees.py --force
 ```
 
-Removes all worktrees with dead PIDs (or no lock file). For each candidate:
+Removes all worktrees with dead PIDs — a worktree must be locked with a
+PID that is no longer alive to qualify. For each candidate:
 1. Deletes the `.git/worktrees/<id>/locked` file (if present)
 2. Calls `git worktree remove -f <path>`
 
 Alive-PID worktrees are left untouched. Unlocked worktrees (no lock file) are
-also removed by default — they have no running process protecting them.
+**always kept, never removed** — an unlocked worktree is not proven abandoned
+(it may hold uncommitted subagent work), so the tool deliberately never treats
+"no lock file" as a removal signal. Only dead-PID (stale) worktrees are
+candidates under `--force`.
 
 Example output:
 
@@ -153,7 +157,7 @@ structured output:
 |------|---------|-------------|
 | `--list` | on | List candidates and their status; no changes made |
 | `--dry-run` | off | Simulate removal; print what would happen |
-| `--force` | off | Remove dead-PID and unlocked worktrees |
+| `--force` | off | Remove dead-PID (stale) worktrees only; unlocked worktrees are always kept |
 | `--keep-recent N` | 0 (keep none) | Exempt the N most recently modified worktrees |
 | `--include-alive` | off | Also remove alive-PID worktrees (dangerous) |
 | `--json` | off | Machine-readable JSON output |
@@ -199,9 +203,11 @@ fi
   Do not modify the filter to broaden scope without understanding the safety
   implications.
 - **Recovering from a bad dispatch.** If a subagent produced incorrect results
-  you want to inspect, run `--list` first and confirm the worktree is in the
-  dead/unlocked list before removing it. Use `--keep-recent` to protect
-  recent worktrees during cleanup.
+  you want to inspect, run `--list` first and confirm the worktree is dead
+  (locked, PID no longer alive) before removing it — an unlocked worktree
+  will never be touched by `--force` regardless, so it is always safe to
+  leave in place for inspection. Use `--keep-recent` to protect recent
+  worktrees during cleanup.
 
 ## Safety properties
 
@@ -210,6 +216,11 @@ fi
   alive), the worktree is skipped and logged.
 - **`--dry-run` is always safe.** No filesystem or git operations are
   performed.
+- **Unlocked worktrees are never removal candidates, under any flag.**
+  `build_candidates()` only ever selects from `stale` (or, with
+  `--include-alive`, all `locked`) worktrees — an unlocked worktree has no
+  lock file to check a PID against, so it is never proven abandoned and the
+  tool leaves it alone. There is no flag that reclaims unlocked worktrees.
 - **The script targets only `agent-*` paths under `.claude/worktrees/`.** All
   other worktrees — feature branches, main, etc. — are invisible to it.
 


### PR DESCRIPTION
[per-PR-coder] — Standalone doc-drift fix. No issue to close; this is a self-contained observation+fix (not filed as an issue first, per the "resolve tech debt actively" / "investigate before filing" guidance — the drift was small, unambiguous, and cheap to fix directly).

## What was wrong

Both `docs/reference/agent-worktree-cleanup.md` (EN) and its `.ja.md` sibling claimed unlocked worktrees are removed by `--force`:

- EN ~L84-85: "Unlocked worktrees (no lock file) are also removed by default — they have no running process protecting them."
- EN ~L156 flag table: `--force` | off | Remove dead-PID **and unlocked** worktrees |
- JA ~L66: "ロックファイルのない worktree (unlocked) も...**デフォルトで削除されます**。"
- JA ~L130 flag table: mirrored the same false claim.
- EN also had an internal contradiction: L84 said unlocked *are* removed while the surrounding "Alive-PID worktrees are left untouched" sentence structure implied only alive is spared — the two passages disagreed on what "default" removal covers.
- A smaller drift in the same paragraph: "Removes all worktrees with dead PIDs (or no lock file)" — the "(or no lock file)" parenthetical is also false.

## What's actually true (verified against `scripts/cleanup_agent_worktrees.py`)

- `WorktreeInfo.stale` = `locked AND pid is not None AND alive is False` (dead-PID **locked** only; unlocked worktrees can never be `stale`).
- `build_candidates()`: without `--include-alive`, candidates = `stale` worktrees; with `--include-alive`, candidates = all `locked` worktrees (alive+dead). **Unlocked worktrees are never selected under any flag combination** — there is no `--include-unlocked`.
- Confirmed empirically: `python scripts/cleanup_agent_worktrees.py --dry-run` reports `0` cleanup candidates in an environment with many unlocked worktrees present (unlocked → always kept).

Rationale for the design (now documented): an unlocked worktree is not proven abandoned — it may hold uncommitted subagent work — so the tool deliberately never treats "no lock file" as a removal signal.

## Fix

Corrected both docs' prose, flag-reference table row, and "when NOT to use" / recovery guidance to consistently state: `--force` removes stale (dead-PID locked) worktrees only; `--include-alive` extends to locked-alive; **unlocked worktrees are always kept, never removed, under any flag**. Added a "Safety properties" bullet in both docs making this explicit and pointing at `build_candidates()` as the ground truth. Removed the EN/JA contradiction between the prose and the flag table.

**Out of scope** (explicitly, per the brief): whether to add an opt-in `--include-unlocked` reclaim mode is a separate future design decision, not addressed here — this PR only corrects the doc to match current impl behavior.

## Verification

- `scripts/cleanup_agent_worktrees.py` was **not modified** — doc-only change.
- `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, clean (pre-existing INFO-level cross-reference anchor notices in unrelated files, none referencing the two files touched here).

## Test plan
- [x] Read both doc files fully + the script's `stale`/`build_candidates`/`main` before editing.
- [x] Verified `--dry-run` empirically reports 0 stale candidates with many unlocked worktrees present.
- [x] `mkdocs build --strict` passes.
- [x] Confirmed script untouched (`git diff --stat` shows only the two doc files).