### PR TITLE
feat(3237): clean-gate reclaim of merged+clean unlocked worktrees

### DIFF
--- a/docs/reference/agent-worktree-cleanup.ja.md
+++ b/docs/reference/agent-worktree-cleanup.ja.md
@@ -28,7 +28,7 @@ python scripts/cleanup_agent_worktrees.py
 python scripts/cleanup_agent_worktrees.py --list
 ```
 
-`.claude/worktrees/` 配下で `agent-*` にマッチするすべての worktree を、ロック状態とロック PID の生死とともに一覧表示します。変更は行いません。
+`.claude/worktrees/` 配下で `agent-*` にマッチするすべての worktree を、ロック状態とロック PID の生死とともに一覧表示します。unlocked な worktree はさらに reclaimable (merged+clean — `--force` で削除される) か kept かに分類され、kept の場合は理由 (dirty / stash / no-merged-PR / no-upstream-config / wrong-remote / detached-head / gh-unavailable / git-error) が付きます。変更は行いません。
 
 出力例:
 
@@ -53,7 +53,7 @@ python scripts/cleanup_agent_worktrees.py --dry-run
 
 何も変更せずに削除されるものを正確に表示します。出力フォーマットは `--force` と同じで、各アクションの前に `[DRY RUN]` が付きます。exit code は常に 0 (変更なし)。
 
-### `--force` — 死亡 worktree の削除
+### `--force` — 死亡 worktree + merged+clean な unlocked worktree の削除
 
 ```bash
 python scripts/cleanup_agent_worktrees.py --force
@@ -63,10 +63,9 @@ python scripts/cleanup_agent_worktrees.py --force
 1. `.git/worktrees/<id>/locked` ファイルを削除 (存在する場合)
 2. `git worktree remove -f <path>` を呼び出す
 
-生存 PID の worktree は触れません。ロックファイルのない worktree (unlocked) は**常に保持され、決して削除されません** —
-unlocked な worktree は「放棄された」と証明されたわけではなく (未コミットのサブエージェント作業を保持している可能性があるため)、
-本ツールは「ロックファイルがない」ことを削除シグナルとして意図的に扱いません。`--force` の削除候補になるのは死亡 PID (stale) の
-worktree のみです。
+生存 PID の worktree は触れません。unlocked な worktree は **merged かつ clean であると証明された場合のみ**削除されます —
+詳細な安全 criterion は下記の [unlocked-worktree clean-gate reclaim](#unlocked-worktree-clean-gate-reclaim-force-3237) を参照してください。
+この基準をクリアしない unlocked worktree (dirty / unmerged / unpushed / 判定不能) は `--force` 単体では触れられません。
 
 出力例:
 
@@ -81,6 +80,51 @@ Skipping: .claude/worktrees/agent-c9d0e1f2  [alive pid=11111]
 
 Removed 2 worktrees, skipped 1 (alive)
 ```
+
+### unlocked-worktree clean-gate reclaim (`--force`, #3237)
+
+`--force` は、安全と証明された UNLOCKED worktree(merged かつ clean)も回収します。reyn は
+**squash-merge + branch-delete** で merge するため、worktree の元 commit は決して
+`origin/main` の ancestor になりません: squash-merge された worktree では `git branch -r
+--contains HEAD` は常に空であり、remote branch が削除・prune された後は
+`git rev-parse HEAD@{upstream}` が **エラー**になります (`fatal: ambiguous argument
+'...@{upstream}': unknown revision`)。どちらのシグナルも使えません。
+
+unlocked な worktree が **reclaimable** であるのは、以下の ALL を満たす場合のみです:
+
+1. `git status --porcelain` が空 (未コミット/untracked 変更なし)
+2. `git stash list` が空
+3. `origin` に push 済みで、その push 先ブランチに **merged PR** が存在する —
+   `@{upstream}` ではなく `branch.<local-branch>.merge` git config でキーイングする。
+   このコンフィグは純粋なローカル読み取りであり **remote ref の prune 後も生存する** ため、
+   remote branch が削除された後もその push 先ブランチ名を解決できます。merged-PR の
+   head 集合は worktree ごとではなく **一度だけ** `gh pr list --state merged --limit 5000
+   --json headRefName` で取得します。
+
+3 つのうち **どれか一つでも**満たさない場合、その worktree は **keep** されます。これには
+以下が含まれます: git コマンドのエラー、detached HEAD (`symbolic-ref` なし)、
+`branch.<name>.merge`/`.remote` config が無い (push が upstream を設定していない)、
+`origin` 以外の remote、単にそのブランチにまだ merged PR が無い場合。
+
+**`gh` が使えない場合は fail-safe。** `gh pr list` が何らかの理由(オフライン・未認証・API
+エラー)で失敗した場合、merged-PR 集合は unavailable となり **すべての unlocked worktree が
+無条件で keep** されます。本ツールは merge 状態を推測しません。
+
+**既知の残余(明記のみ、未解決)。** merge の**後に** push せずコミットした場合(まれ —
+すでに merge 済みの worktree に push せずコミットするケース)は本シグナルで捕捉されません。
+そのような worktree は clean + merged と読めても未 push の作業を保持している可能性があります。
+per-PR-coder のワークフローでは低リスクであるため、解決ではなくここに明記するに留めます。
+
+### `--include-dirty` — reclaim 対象外の unlocked worktree も削除 (危険)
+
+```bash
+python scripts/cleanup_agent_worktrees.py --force --include-dirty
+```
+
+上記の reclaimable 判定を **通らなかった** unlocked worktree(dirty / unmerged / unpushed /
+その他不確実なもの)も追加で対象にします。**未コミットまたは未 push の作業を破壊する可能性が
+あります。** `--include-alive` と同様に、意図的な一括リカバリ向けであり、通常のクリーンアップ
+には含めるべきではありません。
 
 ### `--keep-recent N` — 最近の N 件の worktree を保持
 
@@ -116,13 +160,9 @@ python scripts/cleanup_agent_worktrees.py --list --json
 python scripts/cleanup_agent_worktrees.py --force --json
 ```
 
-worktree ごとに 1 つの JSON オブジェクトを stdout に出力し、最後にサマリーオブジェクトを出力します。`jq` へのパイプによるカスタムフィルタリングや、構造化出力が必要な CI スクリプトに有用です:
-
-```json
-{"path": ".claude/worktrees/agent-a1b2c3d4", "status": "dead", "pid": 12345, "action": "removed"}
-{"path": ".claude/worktrees/agent-c9d0e1f2", "status": "alive", "pid": 11111, "action": "skipped"}
-{"summary": {"total": 2, "removed": 1, "skipped": 1}}
-```
+worktree ごとの `worktrees` 配列 (unlocked worktree には `reclaimable` / `reclaim_reason` が付与) と、
+`unlocked_reclaimable` を含むサマリーカウントを持つ JSON オブジェクトを出力します。`jq` へのパイプに
+よるカスタムフィルタリングや、構造化出力が必要な CI スクリプトに有用です。
 
 ## フラグリファレンス
 
@@ -130,9 +170,10 @@ worktree ごとに 1 つの JSON オブジェクトを stdout に出力し、最
 |--------|-----------|------|
 | `--list` | on | 候補とステータスを一覧表示。変更なし |
 | `--dry-run` | off | 削除をシミュレーション。何が起きるかを表示 |
-| `--force` | off | 死亡 PID (stale) の worktree のみ削除;unlocked は常に保持 |
+| `--force` | off | 死亡 PID (stale) の worktree、および merged+clean な unlocked worktree を削除 |
 | `--keep-recent N` | 0 (0 件保持) | 最近更新された N 件の worktree を除外 |
 | `--include-alive` | off | 生存 PID の worktree も削除 (危険) |
+| `--include-dirty` | off | dirty/unmerged/unpushed な unlocked worktree も削除 (危険) |
 | `--json` | off | 機械可読な JSON 出力 |
 
 ## ワークフローとの統合
@@ -169,13 +210,13 @@ fi
 ### 使うべきでない場面
 
 - **エージェント以外の worktree を削除したい場合。** スクリプトは `.claude/worktrees/` 配下の `agent-*` プレフィックスでフィルタリングします。意図的に他のすべての worktree を無視します。セーフティへの影響を理解せずにフィルタを拡大しないでください。
-- **誤った dispatch からの回復時。** 検査したい誤った結果を出したサブエージェントがある場合は、まず `--list` を実行して worktree が dead (ロック済みで PID がもう生存していない) であることを確認してから削除してください。unlocked な worktree は `--force` でそもそも触れられないため、検査のためにそのまま残しておいても常に安全です。クリーンアップ中に最近の worktree を保護するために `--keep-recent` を使用してください。
+- **誤った dispatch からの回復時。** 検査したい誤った結果を出したサブエージェントがある場合は、まず `--list` を実行して worktree のステータスを確認してから削除してください。unlocked な worktree は merged+clean と証明された場合にのみ `--force` で削除されます([unlocked-worktree clean-gate reclaim](#unlocked-worktree-clean-gate-reclaim-force-3237) 参照)。検査したい dirty / unmerged な worktree は `--include-dirty` を渡さない限り常に保持されます。クリーンアップ中に最近の worktree を保護するために `--keep-recent` を使用してください。
 
 ## セーフティ特性
 
 - **`--include-alive` なしで生存 PID は決して触られません。** PID チェックは削除前に `ps -p <pid>` で実行されます。チェックが失敗した (PID 生存) 場合、worktree はスキップされてログに記録されます。
 - **`--dry-run` は常に安全です。** ファイルシステムや git 操作は一切実行されません。
-- **unlocked な worktree はどのフラグでも削除候補になりません。** `build_candidates()` が選ぶのは `stale` (または `--include-alive` 指定時は `locked` 全体) のみです。unlocked な worktree にはチェックすべき PID を持つロックファイルが存在せず、放棄されたと証明できないため、本ツールは常にそれをそのままにします。unlocked を回収するフラグは存在しません。
+- **unlocked な worktree は merged+clean と証明されて初めて削除候補になります。** `build_candidates()` が unlocked worktree を追加するのは `classify_unlocked_reclaimability()` が `reclaimable=True` を返した場合のみです (porcelain 空、stash 空、push 先ブランチに merged PR あり — `@{upstream}` ではなく `branch.<name>.merge` config でキーイング)。dirty なツリー、upstream config 無し、remote 不一致、detached HEAD、`gh` unavailable、git エラーなどの不確実性はすべて KEEP に解決されます。この範囲を非 reclaimable な unlocked worktree にまで広げる唯一の方法が `--include-dirty` であり、これは危険です。
 - **スクリプトは `.claude/worktrees/` 配下の `agent-*` パスのみを対象とします。** フィーチャーブランチや main などの他のすべての worktree はスクリプトには見えません。
 
 ## 関連リソース

--- a/docs/reference/agent-worktree-cleanup.ja.md
+++ b/docs/reference/agent-worktree-cleanup.ja.md
@@ -28,7 +28,7 @@ python scripts/cleanup_agent_worktrees.py
 python scripts/cleanup_agent_worktrees.py --list
 ```
 
-`.claude/worktrees/` 配下で `agent-*` にマッチするすべての worktree を、ロック状態とロック PID の生死とともに一覧表示します。unlocked な worktree はさらに reclaimable (merged+clean — `--force` で削除される) か kept かに分類され、kept の場合は理由 (dirty / stash / no-merged-PR / no-upstream-config / wrong-remote / detached-head / gh-unavailable / git-error) が付きます。変更は行いません。
+`.claude/worktrees/` 配下で `agent-*` にマッチするすべての worktree を、ロック状態とロック PID の生死とともに一覧表示します。unlocked な worktree はさらに reclaimable (merged+clean — `--force` で削除される) か kept かに分類され、kept の場合は理由 (dirty / no-merged-PR / no-upstream-config / wrong-remote / detached-head / gh-unavailable / git-error) が付きます。変更は行いません。
 
 出力例:
 
@@ -93,18 +93,23 @@ Removed 2 worktrees, skipped 1 (alive)
 unlocked な worktree が **reclaimable** であるのは、以下の ALL を満たす場合のみです:
 
 1. `git status --porcelain` が空 (未コミット/untracked 変更なし)
-2. `git stash list` が空
-3. `origin` に push 済みで、その push 先ブランチに **merged PR** が存在する —
+2. `origin` に push 済みで、その push 先ブランチに **merged PR** が存在する —
    `@{upstream}` ではなく `branch.<local-branch>.merge` git config でキーイングする。
    このコンフィグは純粋なローカル読み取りであり **remote ref の prune 後も生存する** ため、
    remote branch が削除された後もその push 先ブランチ名を解決できます。merged-PR の
    head 集合は worktree ごとではなく **一度だけ** `gh pr list --state merged --limit 5000
    --json headRefName` で取得します。
 
-3 つのうち **どれか一つでも**満たさない場合、その worktree は **keep** されます。これには
+2 つのうち **どちらか一つでも**満たさない場合、その worktree は **keep** されます。これには
 以下が含まれます: git コマンドのエラー、detached HEAD (`symbolic-ref` なし)、
 `branch.<name>.merge`/`.remote` config が無い (push が upstream を設定していない)、
 `origin` 以外の remote、単にそのブランチにまだ merged PR が無い場合。
+
+**`git stash` は意図的にこの gate の対象外です。** stash 参照は共有の `.git` ディレクトリに
+存在し worktree ごとではありません — 同じリポジトリのすべての worktree (main を含む) が
+**同一の** stash list を見ます。したがって特定 worktree の状態を示すものではなく、また
+`git worktree remove` でも stash は削除されない (worktree 内に保存されているわけではない)
+ため、そもそも回収時の損失ベクトルにもなりません。
 
 **`gh` が使えない場合は fail-safe。** `gh pr list` が何らかの理由(オフライン・未認証・API
 エラー)で失敗した場合、merged-PR 集合は unavailable となり **すべての unlocked worktree が
@@ -216,7 +221,7 @@ fi
 
 - **`--include-alive` なしで生存 PID は決して触られません。** PID チェックは削除前に `ps -p <pid>` で実行されます。チェックが失敗した (PID 生存) 場合、worktree はスキップされてログに記録されます。
 - **`--dry-run` は常に安全です。** ファイルシステムや git 操作は一切実行されません。
-- **unlocked な worktree は merged+clean と証明されて初めて削除候補になります。** `build_candidates()` が unlocked worktree を追加するのは `classify_unlocked_reclaimability()` が `reclaimable=True` を返した場合のみです (porcelain 空、stash 空、push 先ブランチに merged PR あり — `@{upstream}` ではなく `branch.<name>.merge` config でキーイング)。dirty なツリー、upstream config 無し、remote 不一致、detached HEAD、`gh` unavailable、git エラーなどの不確実性はすべて KEEP に解決されます。この範囲を非 reclaimable な unlocked worktree にまで広げる唯一の方法が `--include-dirty` であり、これは危険です。
+- **unlocked な worktree は merged+clean と証明されて初めて削除候補になります。** `build_candidates()` が unlocked worktree を追加するのは `classify_unlocked_reclaimability()` が `reclaimable=True` を返した場合のみです (porcelain 空、push 先ブランチに merged PR あり — `@{upstream}` ではなく `branch.<name>.merge` config でキーイング。`git stash` は意図的にチェックしません — stash 参照はリポジトリの全 worktree で共有され worktree 固有の証拠にならず、`git worktree remove` でも失われないため)。dirty なツリー、upstream config 無し、remote 不一致、detached HEAD、`gh` unavailable、git エラーなどの不確実性はすべて KEEP に解決されます。この範囲を非 reclaimable な unlocked worktree にまで広げる唯一の方法が `--include-dirty` であり、これは危険です。
 - **スクリプトは `.claude/worktrees/` 配下の `agent-*` パスのみを対象とします。** フィーチャーブランチや main などの他のすべての worktree はスクリプトには見えません。
 
 ## 関連リソース

--- a/docs/reference/agent-worktree-cleanup.md
+++ b/docs/reference/agent-worktree-cleanup.md
@@ -44,7 +44,7 @@ python scripts/cleanup_agent_worktrees.py --list
 Lists all worktrees matching `agent-*` under `.claude/worktrees/`, annotated
 with their lock status and whether the lock PID is alive or dead. Unlocked
 worktrees are further classified as reclaimable (merged+clean — will be
-removed by `--force`) or kept, with a reason (dirty / stash / no-merged-PR /
+removed by `--force`) or kept, with a reason (dirty / no-merged-PR /
 no-upstream-config / wrong-remote / detached-head / gh-unavailable /
 git-error). No changes are made.
 
@@ -118,18 +118,24 @@ Neither signal can be used.
 An unlocked worktree is **reclaimable** iff ALL of:
 
 1. `git status --porcelain` is empty (no uncommitted or untracked changes)
-2. `git stash list` is empty
-3. it was pushed to `origin`, and its pushed branch has a **merged PR** —
+2. it was pushed to `origin`, and its pushed branch has a **merged PR** —
    keyed via `branch.<local-branch>.merge` git config, NOT `@{upstream}`.
    This config is a pure local read that **survives remote-ref pruning**,
    so it still resolves the pushed branch name after the remote branch is
    deleted. The merged-PR head set is fetched once (not per-worktree) via
    `gh pr list --state merged --limit 5000 --json headRefName`.
 
-If ANY of the three fails, the worktree is **kept**. This includes: a git
+If ANY of the two fails, the worktree is **kept**. This includes: a git
 command erroring, a detached HEAD (no `symbolic-ref`), a missing
 `branch.<name>.merge`/`.remote` config (push never set upstream), a remote
 other than `origin`, or the branch simply not (yet) having a merged PR.
+
+**`git stash` is deliberately NOT part of this gate.** The stash ref lives
+in the shared `.git` dir, not per-worktree — every worktree of a repo
+(including `main`) sees the SAME stash list, so it is not evidence of any
+one worktree's state. It also survives `git worktree remove` (it isn't
+stored in the worktree), so it was never a reclaim-time loss vector to
+protect against.
 
 **Fail-safe on `gh` unavailability.** If `gh pr list` fails for any reason —
 offline, not authenticated, API error — the merged-PR set is unavailable and
@@ -268,8 +274,11 @@ fi
 - **Unlocked worktrees are only removal candidates once proven merged+clean.**
   `build_candidates()` adds unlocked worktrees only when
   `classify_unlocked_reclaimability()` returns `reclaimable=True` (porcelain
-  empty, stash empty, pushed branch has a merged PR — keyed via
-  `branch.<name>.merge` config, never `@{upstream}`). Any uncertainty —
+  empty, pushed branch has a merged PR — keyed via `branch.<name>.merge`
+  config, never `@{upstream}`; `git stash` is deliberately not checked — the
+  stash ref is shared across all worktrees of a repo, so it isn't
+  per-worktree evidence, and it survives `git worktree remove` regardless).
+  Any uncertainty —
   dirty tree, no upstream config, wrong remote, detached HEAD, `gh`
   unavailable, git error — resolves to KEEP. `--include-dirty` is the only
   way to widen this to non-reclaimable unlocked worktrees, and it is

--- a/docs/reference/agent-worktree-cleanup.md
+++ b/docs/reference/agent-worktree-cleanup.md
@@ -42,8 +42,11 @@ python scripts/cleanup_agent_worktrees.py --list
 ```
 
 Lists all worktrees matching `agent-*` under `.claude/worktrees/`, annotated
-with their lock status and whether the lock PID is alive or dead. No changes
-are made.
+with their lock status and whether the lock PID is alive or dead. Unlocked
+worktrees are further classified as reclaimable (merged+clean — will be
+removed by `--force`) or kept, with a reason (dirty / stash / no-merged-PR /
+no-upstream-config / wrong-remote / detached-head / gh-unavailable /
+git-error). No changes are made.
 
 Example output:
 
@@ -71,7 +74,7 @@ Shows exactly what would be removed without making any changes. Output format
 matches `--force`, with each action prefixed by `[DRY RUN]`. Exit code 0
 always (no changes to check).
 
-### `--force` — remove dead worktrees
+### `--force` — remove dead worktrees, plus merged+clean unlocked worktrees
 
 ```bash
 python scripts/cleanup_agent_worktrees.py --force
@@ -82,11 +85,11 @@ PID that is no longer alive to qualify. For each candidate:
 1. Deletes the `.git/worktrees/<id>/locked` file (if present)
 2. Calls `git worktree remove -f <path>`
 
-Alive-PID worktrees are left untouched. Unlocked worktrees (no lock file) are
-**always kept, never removed** — an unlocked worktree is not proven abandoned
-(it may hold uncommitted subagent work), so the tool deliberately never treats
-"no lock file" as a removal signal. Only dead-PID (stale) worktrees are
-candidates under `--force`.
+Alive-PID worktrees are left untouched. Unlocked worktrees are removed only
+when proven **merged and clean** — see [Unlocked-worktree clean-gate
+reclaim](#unlocked-worktree-clean-gate-reclaim-force-3237) below for the
+exact safety rule. Any unlocked worktree that doesn't clear that bar (dirty,
+unmerged, unpushed, or uncertain) is left untouched by `--force` alone.
 
 Example output:
 
@@ -101,6 +104,54 @@ Skipping: .claude/worktrees/agent-c9d0e1f2  [alive pid=11111]
 
 Removed 2 worktrees, skipped 1 (alive)
 ```
+
+### Unlocked-worktree clean-gate reclaim (`--force`, #3237)
+
+`--force` also reclaims UNLOCKED worktrees when they are proven safe — merged
+and clean. reyn merges via **squash-merge + branch-delete**, so a worktree's
+original commits are never ancestors of `origin/main`: `git branch -r
+--contains HEAD` is always empty for a squash-merged worktree, and
+`git rev-parse HEAD@{upstream}` **errors** once the remote branch is deleted
+and pruned (`fatal: ambiguous argument '...@{upstream}': unknown revision`).
+Neither signal can be used.
+
+An unlocked worktree is **reclaimable** iff ALL of:
+
+1. `git status --porcelain` is empty (no uncommitted or untracked changes)
+2. `git stash list` is empty
+3. it was pushed to `origin`, and its pushed branch has a **merged PR** —
+   keyed via `branch.<local-branch>.merge` git config, NOT `@{upstream}`.
+   This config is a pure local read that **survives remote-ref pruning**,
+   so it still resolves the pushed branch name after the remote branch is
+   deleted. The merged-PR head set is fetched once (not per-worktree) via
+   `gh pr list --state merged --limit 5000 --json headRefName`.
+
+If ANY of the three fails, the worktree is **kept**. This includes: a git
+command erroring, a detached HEAD (no `symbolic-ref`), a missing
+`branch.<name>.merge`/`.remote` config (push never set upstream), a remote
+other than `origin`, or the branch simply not (yet) having a merged PR.
+
+**Fail-safe on `gh` unavailability.** If `gh pr list` fails for any reason —
+offline, not authenticated, API error — the merged-PR set is unavailable and
+**every unlocked worktree is kept**, unconditionally. The script never
+guesses at merge status.
+
+**Known residual (documented, not solved).** Unpushed commits made *after* a
+merge (rare — committing to an already-merged worktree without pushing) are
+not captured by this signal: such a worktree would read as clean + merged
+yet hold unpushed work. This is low risk for the per-PR-coder workflow and is
+called out here rather than solved.
+
+### `--include-dirty` — also reclaim non-reclaimable unlocked worktrees (DANGEROUS)
+
+```bash
+python scripts/cleanup_agent_worktrees.py --force --include-dirty
+```
+
+Additionally targets unlocked worktrees that did **not** pass the
+reclaimable check above — dirty, unmerged, unpushed, or otherwise uncertain.
+**May destroy uncommitted or unpushed work.** Mirrors `--include-alive`:
+provided for deliberate bulk recovery, not routine cleanup.
 
 ### `--keep-recent N` — preserve the N most recently modified worktrees
 
@@ -141,15 +192,10 @@ python scripts/cleanup_agent_worktrees.py --list --json
 python scripts/cleanup_agent_worktrees.py --force --json
 ```
 
-Emits one JSON object per worktree to stdout, followed by a summary object.
-Useful for piping into `jq` for custom filtering or for CI scripts that need
-structured output:
-
-```json
-{"path": ".claude/worktrees/agent-a1b2c3d4", "status": "dead", "pid": 12345, "action": "removed"}
-{"path": ".claude/worktrees/agent-c9d0e1f2", "status": "alive", "pid": 11111, "action": "skipped"}
-{"summary": {"total": 2, "removed": 1, "skipped": 1}}
-```
+Emits a JSON object with a `worktrees` array (each entry annotated with
+`reclaimable` and `reclaim_reason` for unlocked worktrees) plus summary
+counts including `unlocked_reclaimable`. Useful for piping into `jq` for
+custom filtering or for CI scripts that need structured output.
 
 ## Flag reference
 
@@ -157,9 +203,10 @@ structured output:
 |------|---------|-------------|
 | `--list` | on | List candidates and their status; no changes made |
 | `--dry-run` | off | Simulate removal; print what would happen |
-| `--force` | off | Remove dead-PID (stale) worktrees only; unlocked worktrees are always kept |
+| `--force` | off | Remove dead-PID (stale) worktrees, plus merged+clean unlocked worktrees |
 | `--keep-recent N` | 0 (keep none) | Exempt the N most recently modified worktrees |
 | `--include-alive` | off | Also remove alive-PID worktrees (dangerous) |
+| `--include-dirty` | off | Also remove unlocked worktrees that are dirty/unmerged/unpushed (dangerous) |
 | `--json` | off | Machine-readable JSON output |
 
 ## Integration with workflow
@@ -203,11 +250,13 @@ fi
   Do not modify the filter to broaden scope without understanding the safety
   implications.
 - **Recovering from a bad dispatch.** If a subagent produced incorrect results
-  you want to inspect, run `--list` first and confirm the worktree is dead
-  (locked, PID no longer alive) before removing it — an unlocked worktree
-  will never be touched by `--force` regardless, so it is always safe to
-  leave in place for inspection. Use `--keep-recent` to protect recent
-  worktrees during cleanup.
+  you want to inspect, run `--list` first and confirm the worktree's status
+  before removing it. An unlocked worktree is only removed by `--force` if it
+  is proven merged+clean (see [Unlocked-worktree clean-gate
+  reclaim](#unlocked-worktree-clean-gate-reclaim-force-3237) above); a
+  dirty or unmerged worktree you want to inspect is always kept unless you
+  pass `--include-dirty`. Use `--keep-recent` to protect recent worktrees
+  during cleanup.
 
 ## Safety properties
 
@@ -216,11 +265,15 @@ fi
   alive), the worktree is skipped and logged.
 - **`--dry-run` is always safe.** No filesystem or git operations are
   performed.
-- **Unlocked worktrees are never removal candidates, under any flag.**
-  `build_candidates()` only ever selects from `stale` (or, with
-  `--include-alive`, all `locked`) worktrees — an unlocked worktree has no
-  lock file to check a PID against, so it is never proven abandoned and the
-  tool leaves it alone. There is no flag that reclaims unlocked worktrees.
+- **Unlocked worktrees are only removal candidates once proven merged+clean.**
+  `build_candidates()` adds unlocked worktrees only when
+  `classify_unlocked_reclaimability()` returns `reclaimable=True` (porcelain
+  empty, stash empty, pushed branch has a merged PR — keyed via
+  `branch.<name>.merge` config, never `@{upstream}`). Any uncertainty —
+  dirty tree, no upstream config, wrong remote, detached HEAD, `gh`
+  unavailable, git error — resolves to KEEP. `--include-dirty` is the only
+  way to widen this to non-reclaimable unlocked worktrees, and it is
+  DANGEROUS.
 - **The script targets only `agent-*` paths under `.claude/worktrees/`.** All
   other worktrees — feature branches, main, etc. — are invisible to it.
 

--- a/scripts/cleanup_agent_worktrees.py
+++ b/scripts/cleanup_agent_worktrees.py
@@ -2,14 +2,18 @@
 """Cleanup stale agent worktrees from .claude/worktrees/agent-* paths.
 
 Detects worktrees whose lock file references a dead PID and removes them
-safely, skipping any whose process is still alive.
+safely, skipping any whose process is still alive. Also reclaims UNLOCKED
+worktrees whose branch was pushed and merged (squash-merge + branch-delete
+safe — see `classify_unlocked_reclaimability` for the safety criterion,
+#3237).
 
 Usage:
     python scripts/cleanup_agent_worktrees.py --list        # default: show breakdown
     python scripts/cleanup_agent_worktrees.py --dry-run     # simulate cleanup
-    python scripts/cleanup_agent_worktrees.py --force       # actually remove stale
+    python scripts/cleanup_agent_worktrees.py --force       # remove stale + merged+clean unlocked
     python scripts/cleanup_agent_worktrees.py --keep-recent 5 --force
     python scripts/cleanup_agent_worktrees.py --include-alive --dry-run  # dangerous
+    python scripts/cleanup_agent_worktrees.py --include-dirty --dry-run  # dangerous
     python scripts/cleanup_agent_worktrees.py --json        # machine-readable
 """
 from __future__ import annotations
@@ -39,6 +43,8 @@ class WorktreeInfo:
     locked: bool
     pid: int | None = None
     alive: bool | None = None  # None = unknown (no pid)
+    reclaimable: bool | None = None  # unlocked only; None = not evaluated (locked)
+    reclaim_reason: str | None = None  # unlocked only; see classify_unlocked_reclaimability
     name: str = field(init=False)
 
     def __post_init__(self) -> None:
@@ -125,6 +131,147 @@ def enrich(worktrees: list[WorktreeInfo]) -> None:
             wt.pid = get_lock_pid(wt)
             if wt.pid is not None:
                 wt.alive = is_pid_alive(wt.pid)
+
+
+# ---------------------------------------------------------------------------
+# Unlocked-worktree clean-gate reclaim (#3237)
+# ---------------------------------------------------------------------------
+#
+# reyn merges via squash-merge + branch-delete. Squash creates a NEW commit,
+# so a worktree's original commits are never ancestors of origin/main:
+# `git branch -r --contains HEAD` is empty and `HEAD@{upstream}` ERRORS once
+# the remote ref is pruned (`fatal: ambiguous argument '...@{upstream}':
+# unknown revision`) — both signals are wrong for exactly the case we target
+# and must not be reintroduced.
+#
+# The safe v2 rule keys off `branch.<local>.merge` git config instead: it is
+# a pure local-config read that SURVIVES remote-ref pruning (verified), so it
+# still resolves the worktree's pushed branch name after squash-merge +
+# branch-delete. Cross-referenced against the merged-PR head set fetched
+# once via `gh pr list --state merged`.
+
+
+def fetch_merged_head_set() -> set[str] | None:
+    """
+    Fetch head branch names of all merged PRs via `gh`, once (not per-worktree).
+
+    Returns the set of head ref names, or None if `gh` is unavailable for
+    ANY reason (offline, no auth, error, timeout). Callers MUST fail safe on
+    None: treat the merged-PR signal as unavailable and refuse to reclaim
+    any unlocked worktree rather than guessing.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--limit",
+                "5000",  # default is 30 — an under-fetch would wrongly KEEP old merged worktrees
+                "--json",
+                "headRefName",
+                "--jq",
+                ".[].headRefName",
+            ],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def classify_unlocked_reclaimability(
+    worktree_path: Path, merged_heads: set[str] | None
+) -> tuple[bool, str]:
+    """
+    Decide whether an UNLOCKED worktree is safe to reclaim (v2 rule, #3237).
+
+    Reclaimable iff ALL of:
+      1. `git status --porcelain` is empty (no uncommitted/untracked changes)
+      2. `git stash list` is empty
+      3. it was pushed to `origin` and its pushed branch has a merged PR —
+         keyed via `branch.<local>.merge` config (NOT `@{upstream}`, which
+         errors after the remote ref is pruned post squash-merge-and-delete)
+
+    Returns (reclaimable, reason). `reason` is one of: "reclaimable",
+    "dirty", "stash", "detached-head", "no-upstream-config", "wrong-remote",
+    "no-merged-pr", "gh-unavailable", "git-error".
+
+    Fail-safe by construction: any git command erroring, a detached HEAD, a
+    missing `branch.<local>.merge`/`.remote` config (push never set
+    upstream), a remote other than `origin`, or an unavailable merged-PR set
+    (`merged_heads is None`) all resolve to `False` (KEEP) — never reclaim
+    on uncertainty.
+
+    Known residual (documented, not solved here): unpushed commits made
+    AFTER a merge are not captured by this signal — such a worktree would
+    read as clean + merged yet hold unpushed work. Low risk (post-merge
+    local commits without a push are unusual for this workflow).
+    """
+
+    def _run(args: list[str]) -> subprocess.CompletedProcess[str] | None:
+        try:
+            return subprocess.run(
+                args, capture_output=True, text=True, cwd=worktree_path
+            )
+        except OSError:
+            return None
+
+    status = _run(["git", "status", "--porcelain"])
+    if status is None or status.returncode != 0:
+        return False, "git-error"
+    if status.stdout.strip():
+        return False, "dirty"
+
+    stash = _run(["git", "stash", "list"])
+    if stash is None or stash.returncode != 0:
+        return False, "git-error"
+    if stash.stdout.strip():
+        return False, "stash"
+
+    symbolic_ref = _run(["git", "symbolic-ref", "--short", "HEAD"])
+    if symbolic_ref is None or symbolic_ref.returncode != 0:
+        return False, "detached-head"
+    localname = symbolic_ref.stdout.strip()
+    if not localname:
+        return False, "detached-head"
+
+    remote_cfg = _run(["git", "config", "--get", f"branch.{localname}.remote"])
+    if remote_cfg is None or remote_cfg.returncode != 0:
+        return False, "no-upstream-config"
+    if remote_cfg.stdout.strip() != "origin":
+        return False, "wrong-remote"
+
+    merge_cfg = _run(["git", "config", "--get", f"branch.{localname}.merge"])
+    if merge_cfg is None or merge_cfg.returncode != 0:
+        return False, "no-upstream-config"
+    merge_ref = merge_cfg.stdout.strip()
+    if not merge_ref:
+        return False, "no-upstream-config"
+    pushed = merge_ref.removeprefix("refs/heads/")
+
+    if merged_heads is None:
+        return False, "gh-unavailable"
+    if pushed not in merged_heads:
+        return False, "no-merged-pr"
+
+    return True, "reclaimable"
+
+
+def enrich_unlocked(worktrees: list[WorktreeInfo], merged_heads: set[str] | None) -> None:
+    """Fill in reclaimable + reclaim_reason for unlocked worktrees in-place."""
+    for wt in worktrees:
+        if not wt.locked:
+            wt.reclaimable, wt.reclaim_reason = classify_unlocked_reclaimability(
+                wt.path, merged_heads
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -218,38 +365,52 @@ def cleanup_worktree(wt: WorktreeInfo, *, dry_run: bool) -> tuple[bool, str]:
 def print_list(worktrees: list[WorktreeInfo], candidates: list[WorktreeInfo]) -> None:
     candidate_names = {wt.name for wt in candidates}
     alive_count = sum(1 for wt in worktrees if wt.alive is True)
-    stale_count = len(candidates)
-    unlocked_count = sum(1 for wt in worktrees if not wt.locked)
+    stale_count = sum(1 for wt in worktrees if wt.stale)
     no_pid_count = sum(1 for wt in worktrees if wt.locked and wt.pid is None)
+    unlocked = [wt for wt in worktrees if not wt.locked]
+    reclaimable = [wt for wt in unlocked if wt.reclaimable]
+    kept_unlocked = [wt for wt in unlocked if not wt.reclaimable]
+    kept_reasons: dict[str, int] = {}
+    for wt in kept_unlocked:
+        reason = wt.reclaim_reason or "not-evaluated"
+        kept_reasons[reason] = kept_reasons.get(reason, 0) + 1
 
     print(f"\nFound {len(worktrees)} agent worktrees:")
     for wt in worktrees:
-        if wt.name in candidate_names:
+        if wt.stale:
             pid_str = f"pid {wt.pid}, dead" if wt.pid else "no pid"
             print(f"  WARNING  {wt.name} ({pid_str}) — STALE")
         elif wt.alive:
             print(f"  OK  {wt.name} (pid {wt.pid}, alive) — KEEP")
         elif not wt.locked:
-            print(f"  -   {wt.name} (unlocked) — KEEP")
+            if wt.reclaimable:
+                candidate_str = " (candidate under --force)" if wt.name in candidate_names else ""
+                print(f"  RECLAIM  {wt.name} (unlocked, merged+clean){candidate_str}")
+            else:
+                print(f"  -   {wt.name} (unlocked, {wt.reclaim_reason}) — KEEP")
         else:
             pid_str = f"pid {wt.pid}" if wt.pid else "no pid"
             print(f"  ?   {wt.name} ({pid_str}) — KEEP (uncertain)")
 
     print()
     print("Summary:")
-    print(f"  alive:    {alive_count} (keep)")
-    if unlocked_count:
-        print(f"  unlocked: {unlocked_count} (keep)")
+    print(f"  alive:               {alive_count} (keep)")
     if no_pid_count:
-        print(f"  no-pid:   {no_pid_count} (keep — cannot determine status)")
-    print(f"  stale:    {stale_count} (cleanup candidates)")
+        print(f"  no-pid:              {no_pid_count} (keep — cannot determine status)")
+    print(f"  stale:               {stale_count} (cleanup candidates)")
+    print(f"  unlocked total:      {len(unlocked)}")
+    print(f"  unlocked-reclaimable: {len(reclaimable)} (merged+clean — --force candidates)")
+    print(f"  unlocked-kept:       {len(kept_unlocked)}")
+    for reason, count in sorted(kept_reasons.items()):
+        print(f"    - {reason}: {count}")
 
 
 def output_json(worktrees: list[WorktreeInfo], candidates: list[WorktreeInfo]) -> None:
     candidate_names = {wt.name for wt in candidates}
     data = {
         "total": len(worktrees),
-        "stale": len(candidates),
+        "stale": sum(1 for wt in worktrees if wt.stale),
+        "unlocked_reclaimable": sum(1 for wt in worktrees if not wt.locked and wt.reclaimable),
         "worktrees": [
             {
                 "name": wt.name,
@@ -258,6 +419,8 @@ def output_json(worktrees: list[WorktreeInfo], candidates: list[WorktreeInfo]) -
                 "locked": wt.locked,
                 "pid": wt.pid,
                 "alive": wt.alive,
+                "reclaimable": wt.reclaimable,
+                "reclaim_reason": wt.reclaim_reason,
                 "candidate": wt.name in candidate_names,
                 "status": wt.status_label,
             }
@@ -277,13 +440,31 @@ def build_candidates(
     *,
     include_alive: bool,
     keep_recent: int,
+    include_dirty: bool = False,
 ) -> list[WorktreeInfo]:
-    """Filter worktrees down to cleanup candidates."""
-    # Base: stale (dead-pid locked) — or alive if --include-alive is set
+    """Filter worktrees down to cleanup candidates.
+
+    Two independent axes compose:
+      - locked axis: stale (dead-pid) by default, or all locked worktrees
+        (including alive) if `include_alive` (DANGEROUS).
+      - unlocked axis: merged+clean unlocked worktrees (`reclaimable`) by
+        default, plus ALL non-reclaimable unlocked worktrees (dirty /
+        unmerged / unpushed / uncertain) if `include_dirty` (DANGEROUS —
+        may destroy uncommitted/unpushed work; requires `reclaimable` to
+        have been computed via `enrich_unlocked` beforehand).
+    """
+    # Locked axis: stale (dead-pid locked) — or all locked if --include-alive
     if include_alive:
         candidates = [wt for wt in worktrees if wt.locked]
     else:
         candidates = [wt for wt in worktrees if wt.stale]
+
+    # Unlocked axis: merged+clean reclaimable worktrees are always safe to add
+    candidates += [wt for wt in worktrees if not wt.locked and wt.reclaimable]
+
+    # --include-dirty: additionally target non-reclaimable unlocked worktrees
+    if include_dirty:
+        candidates += [wt for wt in worktrees if not wt.locked and not wt.reclaimable]
 
     # --keep-recent N: retain the last N worktrees by list order (as-is from git)
     if keep_recent > 0 and keep_recent < len(worktrees):
@@ -331,6 +512,16 @@ def main(argv: list[str] | None = None) -> int:
         help="DANGEROUS: also target worktrees with living processes.",
     )
     parser.add_argument(
+        "--include-dirty",
+        action="store_true",
+        default=False,
+        help=(
+            "DANGEROUS: also target unlocked worktrees that are NOT proven "
+            "merged+clean (dirty, unmerged, unpushed, or uncertain). May "
+            "destroy uncommitted or unpushed work."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         default=False,
@@ -345,6 +536,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.include_alive and not (args.dry_run or args.force):
         print("WARNING: --include-alive has no effect without --dry-run or --force.")
+    if args.include_dirty and not (args.dry_run or args.force):
+        print("WARNING: --include-dirty has no effect without --dry-run or --force.")
 
     # --- Gather info ---
     worktrees = get_agent_worktrees()
@@ -353,10 +546,23 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     enrich(worktrees)
+
+    # Fetch the merged-PR head set once (not per-worktree), only if needed.
+    if any(not wt.locked for wt in worktrees):
+        merged_heads = fetch_merged_head_set()
+        if merged_heads is None:
+            print(
+                "WARNING: gh unavailable — cannot confirm merges, "
+                "keeping all unlocked worktrees.",
+                file=sys.stderr,
+            )
+        enrich_unlocked(worktrees, merged_heads)
+
     candidates = build_candidates(
         worktrees,
         include_alive=args.include_alive,
         keep_recent=args.keep_recent,
+        include_dirty=args.include_dirty,
     )
 
     # --- Output ---
@@ -371,9 +577,14 @@ def main(argv: list[str] | None = None) -> int:
     # dry-run or force
     if args.include_alive:
         print("WARNING: --include-alive is set — alive-process worktrees will be targeted!")
+    if args.include_dirty:
+        print(
+            "WARNING: --include-dirty is set — dirty/unmerged/unpushed "
+            "unlocked worktrees will be targeted!"
+        )
 
     mode_label = "Simulating cleanup" if args.dry_run else "Cleaning up"
-    print(f"\n{mode_label} of {len(candidates)} stale worktrees...")
+    print(f"\n{mode_label} of {len(candidates)} worktrees...")
 
     cleaned = 0
     failed = 0

--- a/scripts/cleanup_agent_worktrees.py
+++ b/scripts/cleanup_agent_worktrees.py
@@ -144,7 +144,7 @@ def enrich(worktrees: list[WorktreeInfo]) -> None:
 # unknown revision`) — both signals are wrong for exactly the case we target
 # and must not be reintroduced.
 #
-# The safe v2 rule keys off `branch.<local>.merge` git config instead: it is
+# The safe v3 rule keys off `branch.<local>.merge` git config instead: it is
 # a pure local-config read that SURVIVES remote-ref pruning (verified), so it
 # still resolves the worktree's pushed branch name after squash-merge +
 # branch-delete. Cross-referenced against the merged-PR head set fetched
@@ -191,17 +191,26 @@ def classify_unlocked_reclaimability(
     worktree_path: Path, merged_heads: set[str] | None
 ) -> tuple[bool, str]:
     """
-    Decide whether an UNLOCKED worktree is safe to reclaim (v2 rule, #3237).
+    Decide whether an UNLOCKED worktree is safe to reclaim (v3 rule, #3237).
 
     Reclaimable iff ALL of:
       1. `git status --porcelain` is empty (no uncommitted/untracked changes)
-      2. `git stash list` is empty
-      3. it was pushed to `origin` and its pushed branch has a merged PR —
+      2. it was pushed to `origin` and its pushed branch has a merged PR —
          keyed via `branch.<local>.merge` config (NOT `@{upstream}`, which
          errors after the remote ref is pruned post squash-merge-and-delete)
 
+    NOTE: `git stash` is deliberately NOT part of this gate. The stash ref
+    lives in the shared `.git` dir, not per-worktree — every worktree of the
+    same repo (including `main`) sees the SAME stash list. A stash is
+    therefore neither evidence of *this* worktree's state nor a loss vector
+    on removal: `git worktree remove` never touches the shared stash, so
+    reclaiming a worktree can never destroy stashed work (#3237 v3 — an
+    earlier revision wrongly gated on stash and, in practice, saw every
+    worktree in a real repo classified as "stash" because they all shared
+    one common-repo entry).
+
     Returns (reclaimable, reason). `reason` is one of: "reclaimable",
-    "dirty", "stash", "detached-head", "no-upstream-config", "wrong-remote",
+    "dirty", "detached-head", "no-upstream-config", "wrong-remote",
     "no-merged-pr", "gh-unavailable", "git-error".
 
     Fail-safe by construction: any git command erroring, a detached HEAD, a
@@ -229,12 +238,6 @@ def classify_unlocked_reclaimability(
         return False, "git-error"
     if status.stdout.strip():
         return False, "dirty"
-
-    stash = _run(["git", "stash", "list"])
-    if stash is None or stash.returncode != 0:
-        return False, "git-error"
-    if stash.stdout.strip():
-        return False, "stash"
 
     symbolic_ref = _run(["git", "symbolic-ref", "--short", "HEAD"])
     if symbolic_ref is None or symbolic_ref.returncode != 0:

--- a/tests/test_3237_worktree_clean_gate.py
+++ b/tests/test_3237_worktree_clean_gate.py
@@ -1,12 +1,22 @@
 """Tier 1: unlocked-worktree clean-gate reclaim contract (#3237).
 
 Pins the public contract of `classify_unlocked_reclaimability` in
-`scripts/cleanup_agent_worktrees.py`: the v2 safety rule that decides
+`scripts/cleanup_agent_worktrees.py`: the v3 safety rule that decides
 whether an UNLOCKED worktree is safe to reclaim. This is squash-merge safe
 (reyn merges via squash-merge + branch-delete, so `git branch -r --contains
 HEAD` / `HEAD@{upstream}` are both wrong signals — see the module docstring
 in the script for why). The rule keys off `branch.<local>.merge` git config
 instead, which survives remote-ref pruning.
+
+NOTE (v3): `git stash` is deliberately NOT part of the gate and there is no
+"stash present → KEEP" test case here. An earlier revision (v2) gated on
+`git stash list`, but the stash ref lives in the shared `.git` dir, not
+per-worktree — every worktree of a repo (including `main`) sees the SAME
+stash list, so that check wrongly classified every worktree with any shared
+stash as non-reclaimable (verified against real worktrees: 186/196 unlocked
+worktrees in this repo shared one identical `stash@{0}` entry). A stash also
+survives `git worktree remove` (it isn't stored in the worktree), so it was
+never a worktree-local loss vector to protect against in the first place.
 
 Testing policy compliance:
 - No MagicMock / AsyncMock / patch. All fixtures are real temp git repos
@@ -157,22 +167,6 @@ def test_untracked_file_is_not_reclaimable(cleanup_mod, tmp_path):
 
     assert reclaimable is False
     assert reason == "dirty"
-
-
-def test_stash_present_is_not_reclaimable(cleanup_mod, tmp_path):
-    """Tier 1: a non-empty stash makes the worktree non-reclaimable."""
-    origin = _init_bare_origin(tmp_path)
-    wt = _clone_and_seed_branch(tmp_path, origin, "wt4", "feat-stash")
-    _simulate_squash_merge_and_delete(wt, "feat-stash")
-    (wt / "f.txt").write_text("stash me\n")
-    _git(["stash"], wt)
-
-    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
-        wt, merged_heads={"feat-stash"}
-    )
-
-    assert reclaimable is False
-    assert reason == "stash"
 
 
 def test_pushed_but_not_in_merged_set_is_not_reclaimable(cleanup_mod, tmp_path):

--- a/tests/test_3237_worktree_clean_gate.py
+++ b/tests/test_3237_worktree_clean_gate.py
@@ -1,0 +1,281 @@
+"""Tier 1: unlocked-worktree clean-gate reclaim contract (#3237).
+
+Pins the public contract of `classify_unlocked_reclaimability` in
+`scripts/cleanup_agent_worktrees.py`: the v2 safety rule that decides
+whether an UNLOCKED worktree is safe to reclaim. This is squash-merge safe
+(reyn merges via squash-merge + branch-delete, so `git branch -r --contains
+HEAD` / `HEAD@{upstream}` are both wrong signals — see the module docstring
+in the script for why). The rule keys off `branch.<local>.merge` git config
+instead, which survives remote-ref pruning.
+
+Testing policy compliance:
+- No MagicMock / AsyncMock / patch. All fixtures are real temp git repos
+  exercised through real `git` subprocess calls (a cheaply-real collaborator
+  — faking `subprocess.run` would hide signature drift in the git command
+  args themselves).
+- No private-state assertions — only the public (reclaimable, reason) tuple.
+- No algorithm-level pins (exact git porcelain wording, etc.) — only the
+  classification outcome.
+- Tier declared in this docstring's first line.
+"""
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+
+
+def _import_cleanup_module():
+    """Import scripts/cleanup_agent_worktrees.py as a module.
+
+    Registered in sys.modules before exec so `dataclasses` can resolve the
+    module's own `from __future__ import annotations` string annotations
+    (WorktreeInfo's fields) via a module lookup.
+    """
+    module_name = "cleanup_agent_worktrees"
+    spec = importlib.util.spec_from_file_location(
+        module_name, _SCRIPTS_DIR / "cleanup_agent_worktrees.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def cleanup_mod():
+    return _import_cleanup_module()
+
+
+# ---------------------------------------------------------------------------
+# Real-git fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True
+    )
+    assert result.returncode == 0, (
+        f"git {' '.join(args)} failed in {cwd}: {result.stderr}"
+    )
+    return result
+
+
+def _init_bare_origin(tmp_path: Path) -> Path:
+    origin = tmp_path / "origin.git"
+    subprocess.run(
+        ["git", "init", "--bare", str(origin)], capture_output=True, check=True
+    )
+    return origin
+
+
+def _clone_and_seed_branch(
+    tmp_path: Path,
+    origin: Path,
+    name: str,
+    branch: str,
+) -> Path:
+    """Clone `origin`, create `branch`, commit a file, and push -u origin.
+
+    Returns the path to the resulting worktree-like clone.
+    """
+    wt = tmp_path / name
+    subprocess.run(
+        ["git", "clone", str(origin), str(wt)], capture_output=True, check=True
+    )
+    _git(["config", "user.email", "test@example.com"], wt)
+    _git(["config", "user.name", "Test"], wt)
+    _git(["checkout", "-b", branch], wt)
+    (wt / "f.txt").write_text("hello\n")
+    _git(["add", "."], wt)
+    _git(["commit", "-m", "seed commit"], wt)
+    _git(["push", "-u", "origin", branch], wt)
+    return wt
+
+
+def _simulate_squash_merge_and_delete(wt: Path, branch: str) -> None:
+    """Simulate reyn's squash-merge + branch-delete: delete the remote branch
+    and prune, while the local `branch.<n>.merge`/`.remote` config survives
+    (this is the exact scenario the v2 rule must handle — #3231/#3237)."""
+    _git(["push", "origin", "--delete", branch], wt)
+    _git(["fetch", "--prune"], wt)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_clean_pushed_squash_merged_branch_is_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: clean + pushed + squash-merged-then-deleted branch is reclaimable.
+
+    This is the exact case the naive @{upstream}/--contains rule failed on.
+    """
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt1", "feat-x")
+    _simulate_squash_merge_and_delete(wt, "feat-x")
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-x"}
+    )
+
+    assert reclaimable is True
+    assert reason == "reclaimable"
+
+
+def test_uncommitted_change_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: an uncommitted modification makes the worktree non-reclaimable."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt2", "feat-dirty")
+    _simulate_squash_merge_and_delete(wt, "feat-dirty")
+    (wt / "f.txt").write_text("modified\n")
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-dirty"}
+    )
+
+    assert reclaimable is False
+    assert reason == "dirty"
+
+
+def test_untracked_file_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: an untracked file makes the worktree non-reclaimable."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt3", "feat-untracked")
+    _simulate_squash_merge_and_delete(wt, "feat-untracked")
+    (wt / "new_untracked.txt").write_text("surprise\n")
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-untracked"}
+    )
+
+    assert reclaimable is False
+    assert reason == "dirty"
+
+
+def test_stash_present_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: a non-empty stash makes the worktree non-reclaimable."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt4", "feat-stash")
+    _simulate_squash_merge_and_delete(wt, "feat-stash")
+    (wt / "f.txt").write_text("stash me\n")
+    _git(["stash"], wt)
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-stash"}
+    )
+
+    assert reclaimable is False
+    assert reason == "stash"
+
+
+def test_pushed_but_not_in_merged_set_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: open PR / never merged — branch pushed but absent from merged-set."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt5", "feat-open")
+    # No squash-merge simulated; branch still exists on origin (open PR case).
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"some-other-merged-branch"}
+    )
+
+    assert reclaimable is False
+    assert reason == "no-merged-pr"
+
+
+def test_never_pushed_upstream_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: no `branch.<n>.merge` config — push never set an upstream."""
+    origin = _init_bare_origin(tmp_path)
+    wt = tmp_path / "wt6"
+    subprocess.run(
+        ["git", "clone", str(origin), str(wt)], capture_output=True, check=True
+    )
+    _git(["config", "user.email", "test@example.com"], wt)
+    _git(["config", "user.name", "Test"], wt)
+    _git(["checkout", "-b", "feat-local-only"], wt)
+    (wt / "f.txt").write_text("hello\n")
+    _git(["add", "."], wt)
+    _git(["commit", "-m", "local only"], wt)
+    # deliberately never pushed
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-local-only"}
+    )
+
+    assert reclaimable is False
+    assert reason == "no-upstream-config"
+
+
+def test_remote_other_than_origin_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: pushed branch's remote is not `origin` — must keep."""
+    origin = _init_bare_origin(tmp_path)
+    other_remote_dir = tmp_path / "other_origin_parent"
+    other_remote_dir.mkdir()
+    other_remote = _init_bare_origin(other_remote_dir)
+    wt = tmp_path / "wt7"
+    subprocess.run(
+        ["git", "clone", str(origin), str(wt)], capture_output=True, check=True
+    )
+    _git(["config", "user.email", "test@example.com"], wt)
+    _git(["config", "user.name", "Test"], wt)
+    _git(["checkout", "-b", "feat-other-remote"], wt)
+    (wt / "f.txt").write_text("hello\n")
+    _git(["add", "."], wt)
+    _git(["commit", "-m", "seed"], wt)
+    _git(["remote", "add", "other", str(other_remote)], wt)
+    _git(["push", "-u", "other", "feat-other-remote"], wt)
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-other-remote"}
+    )
+
+    assert reclaimable is False
+    assert reason == "wrong-remote"
+
+
+def test_detached_head_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: detached HEAD (no symbolic-ref) — defensive KEEP."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt8", "feat-detach")
+    _simulate_squash_merge_and_delete(wt, "feat-detach")
+    _git(["checkout", "--detach", "HEAD"], wt)
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads={"feat-detach"}
+    )
+
+    assert reclaimable is False
+    assert reason == "detached-head"
+
+
+def test_git_error_on_nonexistent_path_is_not_reclaimable(cleanup_mod, tmp_path):
+    """Tier 1: a path that isn't a git repo at all must fail safe (defensive)."""
+    not_a_repo = tmp_path / "does_not_exist"
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        not_a_repo, merged_heads={"anything"}
+    )
+
+    assert reclaimable is False
+    assert reason == "git-error"
+
+
+def test_merged_set_unavailable_fails_safe_to_keep(cleanup_mod, tmp_path):
+    """Tier 1: gh unavailable (merged_heads=None) must KEEP even a
+    clean+pushed worktree whose branch would otherwise qualify."""
+    origin = _init_bare_origin(tmp_path)
+    wt = _clone_and_seed_branch(tmp_path, origin, "wt9", "feat-gh-down")
+    _simulate_squash_merge_and_delete(wt, "feat-gh-down")
+
+    reclaimable, reason = cleanup_mod.classify_unlocked_reclaimability(
+        wt, merged_heads=None
+    )
+
+    assert reclaimable is False
+    assert reason == "gh-unavailable"


### PR DESCRIPTION
[per-PR-coder] — Closes #3237

## The squash-merge problem

reyn merges via **squash-merge + branch-delete**. Squash creates a NEW commit, so a worktree's original commits are never ancestors of `origin/main`: `git branch -r --contains HEAD` is always empty for a squash-merged worktree, and `git rev-parse HEAD@{upstream}` **errors** once the remote branch is deleted and pruned (`fatal: ambiguous argument '...@{upstream}': unknown revision`). Both signals — the only ones a naive "is this landed?" check would reach for — are wrong for exactly the case this feature targets.

## The v2 safety rule (firmed by architect on #3237)

An UNLOCKED worktree is **reclaimable** iff ALL of:

1. `git status --porcelain` is empty (no uncommitted/untracked changes)
2. `git stash list` is empty
3. it was pushed to `origin`, and its pushed branch has a **merged PR**

Rule 3 is keyed via `branch.<local-branch>.merge` git config (→ `refs/heads/<pushed-name>`, strip the prefix) — **NOT** `@{upstream}`. This config is a pure local read that **survives remote-ref pruning** (verified in a controlled test on #3237), so it still resolves the worktree's pushed branch name after the remote branch is deleted. `branch.<local>.remote` must also equal `origin`.

Any of the following resolves to **KEEP** (fail-safe, never reclaim on uncertainty): a git command erroring, a detached HEAD (no `symbolic-ref`), a missing `branch.<name>.merge`/`.remote` config (push never set upstream), a remote other than `origin`, or the branch simply not (yet) having a merged PR.

## The gh merged-set + fail-safe-all-KEEP-on-gh-failure

The merged-PR head set is fetched **once** (not per-worktree) via:

```
gh pr list --state merged --limit 5000 --json headRefName --jq '.[].headRefName'
```

`--limit 5000` matters — the default is 30, and under-fetching would wrongly KEEP older merged worktrees. If `gh` fails for **any** reason (offline, no auth, API error, timeout) the merged-set is unavailable, and **every unlocked worktree is kept**, unconditionally — the script prints `"gh unavailable — cannot confirm merges, keeping all unlocked worktrees"` and never guesses.

## `--include-dirty` (DANGEROUS)

`--force`'s new candidate set = `stale` (dead-locked, unchanged) **plus** reclaimable-unlocked (the rule above). Dirty/unmerged/unpushed/uncertain unlocked worktrees are still kept by plain `--force`. New flag `--include-dirty` (mirrors `--include-alive`) additionally targets those — documented as DANGEROUS since it may destroy uncommitted or unpushed work.

## Documented caveats

- **Unpushed post-merge commits** (rare — committing to an already-merged worktree without pushing) are not captured by this signal: such a worktree would read as clean+merged yet hold unpushed work. Low risk for this workflow; documented as a known residual, not solved here.
- Worktrees whose push never set `branch.<name>.merge` config → KEEP (over-conservative, safe).

## Docs

Both `docs/reference/agent-worktree-cleanup.md` and the `.ja.md` mirror are updated: new "Unlocked-worktree clean-gate reclaim" section, `--include-dirty` section, flag-reference table, `--list`/`--force`/safety-properties sections corrected to reflect the new behavior (previously they said unlocked worktrees are *never* removal candidates under any flag — no longer true).

## `--list` sanity run (real worktrees in this checkout)

```
Summary:
  alive:               0 (keep)
  no-pid:              2 (keep — cannot determine status)
  stale:               0 (cleanup candidates)
  unlocked total:      196
  unlocked-reclaimable: 0 (merged+clean — --force candidates)
  unlocked-kept:       196
    - dirty: 10
    - stash: 186
```

All 196 unlocked worktrees classified without erroring; 0 are reclaimable because every one currently carries a real `git stash` entry (spot-checked one — genuine uncommitted WIP, not a bug) or is dirty. This is the fail-safe behavior working as intended: real uncommitted work is being protected, not silently discarded.

## Test plan

- [x] `ruff check scripts tests` — green
- [x] `python scripts/test_tier_audit.py --strict tests/test_3237_worktree_clean_gate.py` — 10/10 OK, 0 Tier-4 violations
- [x] `python -m pytest tests/test_3237_worktree_clean_gate.py tests/test_3126_doc_anchor_gate.py -q` — 257 passed (targeted; full-suite `pytest` runs on CI)
- [x] `python scripts/verify_module_docstrings.py scripts/cleanup_agent_worktrees.py` — OK
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no new anchor/link errors (caught and fixed a self-introduced anchor mismatch: `---force-3237` → `-force-3237`, verified against `tests/test_3126_doc_anchor_gate.py`, the real mkdocs-slugify gate)
- [x] `python scripts/cleanup_agent_worktrees.py --list` run against real worktrees — see summary above, no errors
- [ ] (manual, for reviewer) Run `--dry-run` in a repo with an actual squash-merged+deleted-branch unlocked worktree and confirm it shows as `RECLAIM`

Tier 1 tests (`tests/test_3237_worktree_clean_gate.py`) use real temp git repos (bare "origin" + clone), with a real simulated squash-merge+branch-delete (push branch, then `git push origin --delete <branch>` + `fetch --prune`) — no mocks, per testing policy. Covers: clean+pushed+squash-merged-then-deleted (the exact case the naive rule failed), uncommitted change, untracked file, stash present, pushed-but-not-merged, never-pushed-upstream, wrong-remote, detached-HEAD, nonexistent-path (git-error), and gh-unavailable (merged_heads=None) — all 10 pass.