### PR TITLE
fix(2732): surface agent-step-spawn LLM exceptions as typed AgentStepError (was swallowed to empty reply)

### DIFF
--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -55,7 +55,7 @@ from reyn.runtime.chat_message import (  # #312 C1: extracted VO + helpers
     _now_iso,
 )
 from reyn.runtime.error_format import classify_router_error
-from reyn.runtime.errors import RouterCapExceeded, StructuredOutputError
+from reyn.runtime.errors import AgentStepError, RouterCapExceeded, StructuredOutputError
 from reyn.runtime.limits.limit_handler import (
     LimitDecision,
     handle_limit_exceeded,
@@ -5500,6 +5500,29 @@ class Session:
                 )
             except Exception:  # noqa: BLE001 — instrumentation must never break the path
                 pass
+            # #2732: this except is a CATCH-ALL (any LLM-call or router-loop
+            # exception, not only cred errors) — the ORIGINAL swallow-to-empty-
+            # reply bug. Interactive chat (self._ephemeral is False) keeps the
+            # pre-existing render-not-raise behavior below: the classified
+            # summary reaches the TUI/renderer as an OutboxMessage, which is
+            # correct there. But an agent-step spawn's leaf session IS ALWAYS
+            # ephemeral (spawn_ephemeral_session hardcodes mode="ephemeral"),
+            # and its ``kind="agent"``-only join in
+            # ``session_api.run_agent_step`` silently drops this ``kind="error"``
+            # outbox message, returning "" with no exception — the pipeline
+            # executor's ``except AgentStepError`` (executor.py) never fires and
+            # the step looks like it succeeded with an empty answer. Gate the
+            # re-raise on ``self._ephemeral`` (NOT unconditional — an
+            # unconditional raise here would break the interactive chat loop,
+            # which relies on this method returning normally after queuing the
+            # error reply) so only the agent-step-spawn leg gets a typed
+            # failure the caller can observe. Re-raise the BASE
+            # ``AgentStepError`` (not an LLM-specific subclass) because this
+            # catch-all also covers non-LLM exceptions; `from exc` preserves
+            # the original exception via chaining (already retained above by
+            # the audit event + traceback log for both branches).
+            if self._ephemeral:
+                raise AgentStepError(classify_router_error(exc)) from exc
             await self._put_outbox(OutboxMessage(
                 kind="error", text=classify_router_error(exc),
                 meta={"chain_id": chain_id},

--- a/tests/test_pipeline_r5_run_agent_step.py
+++ b/tests/test_pipeline_r5_run_agent_step.py
@@ -38,9 +38,11 @@ import pytest
 
 from reyn.core.events.state_log import StateLog
 from reyn.core.pipeline.schema import SchemaRegistry
+from reyn.llm.credentials import MissingCredentialsError
 from reyn.llm.llm import LLMToolCallResult
 from reyn.llm.pricing import TokenUsage
 from reyn.runtime.errors import AgentStepError
+from reyn.runtime.message_bus import MessageBus
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
 from reyn.runtime.session_api import (
@@ -49,6 +51,7 @@ from reyn.runtime.session_api import (
     spawn_ephemeral_session,
 )
 from reyn.runtime.session_params import PresentationWiring
+from reyn.runtime.transport import SystemRef
 from tests._support.agent_session import make_session
 
 # ── real-callable LLM stub (Tier 2c: LLM is incidental) ─────────────────────
@@ -70,6 +73,24 @@ class _ScriptedAgentReply:
             content=self.content, tool_calls=[], finish_reason="stop",
             usage=TokenUsage(),
         )
+
+
+class _RaisingAgentReply:
+    """#2732: a real ``_llm_caller``-shaped callable (same typed signature as
+    ``_ScriptedAgentReply`` — a signature drift raises ``TypeError`` here
+    exactly as in production) that raises instead of returning, standing in
+    for the ``call_llm`` chokepoint failing (e.g. ``MissingCredentialsError``
+    or any other router-loop exception) — the class of failure
+    ``session.py``'s catch-all ``except Exception`` at the bottom of
+    ``_handle_user_message`` swallows."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+        self.calls = 0
+
+    async def __call__(self, **kwargs: Any) -> LLMToolCallResult:
+        self.calls += 1
+        raise self.exc
 
 
 def _registry(tmp_path: Path, scripted: "_ScriptedAgentReply | None") -> AgentRegistry:
@@ -278,3 +299,88 @@ async def test_run_agent_step_ephemeral_session_vanishes(tmp_path: Path) -> None
             await vanish_task
 
     assert spawned_sid not in reg.session_ids("worker")
+
+
+# ── #2732: LLM-call exception surfacing (ephemeral raises / interactive renders) ──
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_llm_exception_raises_agent_step_error(tmp_path: Path) -> None:
+    """Tier 2c: an agent-step spawn's leaf session is ALWAYS ephemeral
+    (``spawn_ephemeral_session`` hardcodes ``mode="ephemeral"``). When its
+    ``_llm_caller`` raises, ``session.py``'s catch-all ``except Exception``
+    in ``_handle_user_message`` must re-raise a typed ``AgentStepError``
+    (chained via ``from exc``) instead of returning normally — the prior
+    (buggy) behavior let the turn finish with an outbox ``kind="error"``
+    message that ``run_agent_step``'s ``kind == "agent"``-only join
+    silently drops, yielding an empty ``""`` reply with no exception at
+    all. This is the ephemeral leg of the dual, strip-falsifiable pair
+    with ``test_run_agent_step_interactive_llm_exception_renders_not_raises``
+    below — together they guard the ``if self._ephemeral:`` conditional
+    gate in ``session.py``."""
+    original = MissingCredentialsError(
+        model="gpt-4", provider="openai", env_var="OPENAI_API_KEY",
+    )
+    scripted = _RaisingAgentReply(original)
+    reg = _registry(tmp_path, scripted)
+
+    with pytest.raises(AgentStepError) as excinfo:
+        await run_agent_step(reg, identity="worker", prompt="do the thing")
+
+    assert excinfo.value.__cause__ is original
+    assert scripted.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_run_agent_step_interactive_llm_exception_renders_not_raises(tmp_path: Path) -> None:
+    """Tier 2c: guards refinement 1 (the ``self._ephemeral`` conditional
+    gate) — the SAME raising ``_llm_caller``, driven through a NON-ephemeral
+    (interactive-chat-shaped) session's normal turn via
+    ``MessageBus.request(kind="user")``, must NOT raise. Interactive chat
+    relies on ``_handle_user_message`` returning normally after queuing an
+    ``OutboxMessage(kind="error", ...)`` so the TUI/renderer can surface it
+    (render-not-raise) — an unconditional re-raise would break that loop.
+
+    Strip-falsifiable: if the ``if self._ephemeral:`` gate in ``session.py``
+    is deleted (made unconditional), THIS session (``_ephemeral`` is False,
+    the default post-construction value — never set True outside
+    ``spawn_ephemeral_session``'s ``mode="ephemeral"`` path) would flip to
+    raising ``AgentStepError`` out of ``MessageBus.request`` here, turning
+    this test RED. Verified by running with the gate stripped (see PR
+    description) rather than asserted in-test (stripping the gate in a
+    fixture would defeat the point of testing production code)."""
+    from reyn.llm.model_resolver import ModelResolver
+
+    original = MissingCredentialsError(
+        model="gpt-4", provider="openai", env_var="OPENAI_API_KEY",
+    )
+    scripted = _RaisingAgentReply(original)
+    state_log = StateLog(tmp_path / ".reyn" / "wal.jsonl")
+    resolver = ModelResolver({"standard": "gemini/gemini-2.5-flash-lite"})
+    session = make_session(
+        agent_name="interactive-worker", state_log=state_log,
+        non_interactive=True, resolver=resolver,
+    )
+    session._loop_driver._loop_observer = (  # noqa: SLF001 — production seam, precedent above
+        lambda loop: setattr(loop, "_llm_caller", scripted)
+    )
+    # ``session`` is built directly via ``make_session`` (the plain
+    # interactive-chat construction path, never touching
+    # ``spawn_ephemeral_session``'s ``mode="ephemeral"``), so it is
+    # non-ephemeral BY CONSTRUCTION — no private-state peek needed to know
+    # this test is driving the gate's "else" branch.
+
+    bus = MessageBus()
+    replies = await bus.request(
+        session, kind="user",
+        payload={"text": "do the thing", "chain_id": "chain-2732"},
+        reply_to=SystemRef(), timeout=10.0,
+    )
+
+    assert scripted.calls == 1
+    # Tuple-unpack (not a size check): raises ValueError itself if the turn
+    # produced zero or more than one ``kind="error"`` reply — behavioral,
+    # not a format/size pin (mirrors the tuple-unpack precedent in
+    # ``test_run_agent_step_ephemeral_session_vanishes`` above).
+    (error_reply,) = [r for r in replies if r.kind == "error"]
+    assert error_reply.text


### PR DESCRIPTION
[per-PR-coder] — Closes #2732

## The swallow bug (verified flow-trace)
An agent-step spawn's session-loop swallowed every LLM-call exception into an empty `"agent"` reply:

- `src/reyn/runtime/session.py`'s `_handle_user_message` has a catch-all `except Exception as exc:` that logs the exception, emits a `router_loop_terminated_by_exception` audit event, puts an `OutboxMessage(kind="error", text=classify_router_error(exc))` onto the outbox, and **returns normally** (never re-raises).
- `src/reyn/runtime/session_api.py`'s `run_agent_step` joins ONLY `r.kind == "agent"` replies (`text = "\n\n".join(r.text for r in replies if r.kind == "agent")`) → the `kind="error"` message is silently dropped → the function returns `""`. No exception ever reaches the pipeline executor's `except AgentStepError` (`src/reyn/core/pipeline/executor.py`), so a failed agent step looks like it succeeded with an empty answer.
- Precedent mirrored: `except StructuredOutputError: raise` immediately above this catch-all already re-raises a typed error out of a normal turn — the outer `finally` (`_maybe_schedule_ephemeral_vanish`) guarantees ephemeral teardown even when the turn raises, a reviewed, exercised path.

## Fix — conditional re-raise, gated on `self._ephemeral`
The catch-all now re-raises a typed error **only when `self._ephemeral` is True**:

- **Why gated, not unconditional**: generic LLM exceptions ALSO occur in interactive chat sessions, where the CURRENT behavior (emit `OutboxMessage(kind="error", ...)`, return normally) is correct — the TUI/renderer surfaces it. An unconditional raise would break that render-not-raise loop. `self._ephemeral` is set post-construction by the registry; `spawn_ephemeral_session` hardcodes `mode="ephemeral"`, so every `run_agent_step` leaf worker is always ephemeral and every interactive chat session is not — the gate exactly separates the two legs.
- **Base `AgentStepError`, not an LLM-specific subclass**: the `except Exception` is a catch-all (any exception, not only LLM-call failures), so wrapping it in something like `AgentStepLLMError` would mislabel non-LLM exceptions. `AgentStepError` is the same base type `executor.py`'s `except AgentStepError` already catches and converts to `PipelineExecutionError`.
- **Original exception preserved**: `raise AgentStepError(classify_router_error(exc)) from exc` chains the original exception (`__cause__`); the audit event + traceback log still fire in BOTH branches.

## Tests (Tier 2c, real Session/registry/bus — no mocks)
Extended `tests/test_pipeline_r5_run_agent_step.py` (real `AgentRegistry`/`Session`/`RouterLoop`/`MessageBus`; only the LLM completion call is a typed stand-in via the existing `_llm_caller` seam) with a dual, strip-falsifiable pair:

1. `test_run_agent_step_llm_exception_raises_agent_step_error` — ephemeral leg: `run_agent_step` (which always spawns an ephemeral leaf session) with a raising `_llm_caller` (`MissingCredentialsError`) now raises `AgentStepError` with `__cause__` chained to the original exception, instead of returning `""`.
2. `test_run_agent_step_interactive_llm_exception_renders_not_raises` — interactive leg (guards the `_ephemeral` gate): the SAME raising `_llm_caller`, driven through a non-ephemeral session's normal turn via `MessageBus.request(kind="user")`, does NOT raise and instead surfaces an `OutboxMessage(kind="error", ...)`.

This is strip-falsifiable: I manually deleted the `if self._ephemeral:` gate (made the raise unconditional), re-ran the suite, and confirmed test 2 flips RED (raises `AgentStepError` instead of rendering) — then restored the gate and confirmed both tests pass again.

## CI gates (all run locally, foreground)
- `ruff check src tests` — All checks passed!
- `python scripts/test_tier_audit.py --strict tests/test_pipeline_r5_run_agent_step.py` — 9/9 OK, 0 Tier-4 violations
- `python -m pytest tests/test_pipeline_r5_run_agent_step.py -q` — 9 passed
- `python scripts/verify_module_docstrings.py src/reyn/runtime/session.py` — OK

## Test plan
- [x] `ruff check src tests` passes
- [x] `test_tier_audit.py --strict` passes on the changed test file
- [x] Targeted pytest run (9/9) passes
- [x] `verify_module_docstrings.py` passes on `session.py`
- [x] Ephemeral leg raises `AgentStepError` with `__cause__` chained
- [x] Interactive leg renders (does not raise), surfaces `kind="error"` outbox message
- [x] Strip-falsifiability manually verified: deleting the `_ephemeral` gate flips the interactive-leg test RED; restored and re-confirmed green