### PR TITLE
fix(3032): migrate hand-pinned/unpinned reyn-subprocess tests onto out_of_process_reyn seam

### DIFF
--- a/tests/test_3027_budget_guard_survives_optimize.py
+++ b/tests/test_3027_budget_guard_survives_optimize.py
@@ -22,15 +22,6 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
-from pathlib import Path
-
-# The repo may be `pip install -e`'d from a different checkout (e.g. another
-# worktree) than the one pytest is running from — pytest itself picks up the
-# right `src/` via `pythonpath = ["src"]` in pyproject.toml, but a bare
-# subprocess `python -c` does not. Point PYTHONPATH at *this* checkout's
-# `src/` explicitly so the subprocess imports the code under test, not
-# whatever `reyn` happens to be installed in site-packages.
-_SRC_DIR = str(Path(__file__).resolve().parent.parent / "src")
 
 _SCRIPT_TEMPLATE = """
 import sys
@@ -48,17 +39,17 @@ print("NO_RAISE", file=sys.stdout)
 """
 
 
-def _run(script: str, *, optimize: bool) -> subprocess.CompletedProcess:
+def _run(src_root: str, script: str, *, optimize: bool) -> subprocess.CompletedProcess:
     args = [sys.executable]
     if optimize:
         args.append("-O")
     args += ["-c", script]
     env = dict(os.environ)
-    env["PYTHONPATH"] = _SRC_DIR + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = src_root + os.pathsep + env.get("PYTHONPATH", "")
     return subprocess.run(args, capture_output=True, text=True, timeout=60, env=env)
 
 
-def test_effective_trigger_guard_fires_under_dash_o() -> None:
+def test_effective_trigger_guard_fires_under_dash_o(out_of_process_reyn) -> None:
     """Tier 2: the effective_trigger<=0 guard raises even under `python -O`.
 
     This is the load-bearing witness for #3027: before the fix, this exact
@@ -66,7 +57,7 @@ def test_effective_trigger_guard_fires_under_dash_o() -> None:
     -O instead of raising.
     """
     script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=-7)
-    result = _run(script, optimize=True)
+    result = _run(out_of_process_reyn, script, optimize=True)
     assert result.returncode != 0, (
         f"guard did NOT fire under -O (stdout={result.stdout!r}): "
         f"a negative effective_trigger silently flowed through"
@@ -76,27 +67,27 @@ def test_effective_trigger_guard_fires_under_dash_o() -> None:
     assert "NO_RAISE" not in result.stdout
 
 
-def test_effective_trigger_guard_fires_in_normal_mode() -> None:
+def test_effective_trigger_guard_fires_in_normal_mode(out_of_process_reyn) -> None:
     """Tier 2: regression — the guard still fires in normal (non -O) mode."""
     script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=-7)
-    result = _run(script, optimize=False)
+    result = _run(out_of_process_reyn, script, optimize=False)
     assert result.returncode != 0
     assert "CompactionBudgetSelfConsistencyError" in result.stderr, result.stderr
     assert "effective_trigger = -7" in result.stderr, result.stderr
 
 
-def test_valid_budgets_do_not_fire_under_dash_o() -> None:
+def test_valid_budgets_do_not_fire_under_dash_o(out_of_process_reyn) -> None:
     """Tier 2: control — a self-consistent budget config does NOT raise
     under -O (the guard is not over-firing)."""
     script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=5000)
-    result = _run(script, optimize=True)
+    result = _run(out_of_process_reyn, script, optimize=True)
     assert result.returncode == 0, f"stderr={result.stderr!r}"
     assert "NO_RAISE" in result.stdout
 
 
-def test_valid_budgets_do_not_fire_in_normal_mode() -> None:
+def test_valid_budgets_do_not_fire_in_normal_mode(out_of_process_reyn) -> None:
     """Tier 2: control — same as above in normal mode (no over-firing)."""
     script = _SCRIPT_TEMPLATE.format(b_m=5000, effective_trigger=5000)
-    result = _run(script, optimize=False)
+    result = _run(out_of_process_reyn, script, optimize=False)
     assert result.returncode == 0, f"stderr={result.stderr!r}"
     assert "NO_RAISE" in result.stdout

--- a/tests/test_fastmcp_core_dep_import_chain.py
+++ b/tests/test_fastmcp_core_dep_import_chain.py
@@ -16,11 +16,12 @@ OS invariant:
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 
 
-def test_mcp_connection_service_import_chain_reaches_fastmcp():
+def test_mcp_connection_service_import_chain_reaches_fastmcp(out_of_process_reyn):
     """Tier 2: importing the MCP client stack succeeds and loads fastmcp in a fresh interpreter."""
     code = (
         "import reyn.mcp.connection_service;"
@@ -36,6 +37,7 @@ def test_mcp_connection_service_import_chain_reaches_fastmcp():
         capture_output=True,
         text=True,
         timeout=60,
+        env={**os.environ, "PYTHONPATH": out_of_process_reyn},
     )
     assert result.returncode == 0, (
         "MCP import chain failed in a core install (fastmcp not importable?).\n"

--- a/tests/test_fp0063_arc_witness.py
+++ b/tests/test_fp0063_arc_witness.py
@@ -201,15 +201,14 @@ class FakeEmbeddingProvider:
         return 3
 
 
-def _server_env() -> dict[str, str]:
+def _server_env(src_root: str) -> dict[str, str]:
     """Env for the plugin's real MCP server subprocesses -- pins PYTHONPATH to
-    THIS checkout (see test_fp0063_p3_rag_pipelines.py's ``_server_env`` for
-    the full rationale: the MCP SDK's stdio transport passes only a 6-key env
-    whitelist that drops PYTHONPATH, so a plain ``env=os.environ`` inherit is
-    not enough in a multi-worktree dev box)."""
-    import reyn
-
-    src_root = str(Path(reyn.__file__).resolve().parent.parent)
+    *src_root* (the ``out_of_process_reyn`` fixture value, threaded in from
+    the calling test rather than a fresh ``import reyn``/``__file__``
+    computation here; see test_fp0063_p3_rag_pipelines.py's ``_server_env``
+    for the full rationale: the MCP SDK's stdio transport passes only a
+    6-key env whitelist that drops PYTHONPATH, so a plain ``env=os.environ``
+    inherit is not enough in a multi-worktree dev box)."""
     passthrough = {
         k: v for k, v in os.environ.items()
         if k in ("PATH", "HOME", "LOGNAME", "SHELL", "TERM", "USER", "TMPDIR")
@@ -217,7 +216,7 @@ def _server_env() -> dict[str, str]:
     return {**passthrough, "PYTHONPATH": src_root}
 
 
-def _prepare_local_plugin_copy(tmp_path: Path) -> Path:
+def _prepare_local_plugin_copy(tmp_path: Path, src_root: str) -> Path:
     """Copy the real ``rag`` plugin tree into ``tmp_path``, then:
 
     - DROP ``requirements.txt`` entirely, so ``plugin_install``'s dependency
@@ -247,7 +246,7 @@ def _prepare_local_plugin_copy(tmp_path: Path) -> Path:
 
     mcp_json_path = dest / ".mcp.json"
     mcp_json = json.loads(mcp_json_path.read_text(encoding="utf-8"))
-    env = _server_env()
+    env = _server_env(src_root)
     for name, spec in mcp_json["mcpServers"].items():
         spec["command"] = sys.executable
         spec["env"] = env
@@ -569,7 +568,7 @@ def _install_key_normalizer(monkeypatch: pytest.MonkeyPatch, base_dir: Path) -> 
 
 @pytest.mark.asyncio
 async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, out_of_process_reyn: str,
 ) -> None:
     """Tier 3a: an LLM (replayed via LLMReplay at the real litellm.acompletion
     boundary) drives plugin_management__install -> run_pipeline(rag_ingest.ingest)
@@ -677,7 +676,7 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
             "mcp": {"servers": {
                 "reyn_markitdown": {
                     "type": "stdio", "command": sys.executable,
-                    "args": [str(markitdown_stub)], "env": _server_env(),
+                    "args": [str(markitdown_stub)], "env": _server_env(out_of_process_reyn),
                 },
             }},
             # A plain ``reyn pipe run`` CLI invocation auto-grants any MCP
@@ -697,7 +696,7 @@ async def test_llm_driven_install_ingest_query_arc_reaches_the_ingested_chunk(
         encoding="utf-8",
     )
 
-    plugin_src = _prepare_local_plugin_copy(tmp_path)
+    plugin_src = _prepare_local_plugin_copy(tmp_path, out_of_process_reyn)
     registry, _perm_resolver = _build_registry(tmp_path, project_root)
 
     from reyn.dev.testing.replay import LLMReplay

--- a/tests/test_fp0063_p3_rag_pipelines.py
+++ b/tests/test_fp0063_p3_rag_pipelines.py
@@ -153,7 +153,7 @@ def _ns(**kwargs: Any) -> argparse.Namespace:
     return argparse.Namespace(**kwargs)
 
 
-def _server_env() -> dict[str, str]:
+def _server_env(src_root: str) -> dict[str, str]:
     """Env for the builtin MCP server subprocesses, pinning them to the SAME
     reyn tree this test process imported.
 
@@ -167,14 +167,16 @@ def _server_env() -> dict[str, str]:
     diff). Pinning it makes the module docstring's "REAL builtin MCP servers"
     claim true about THIS tree in both environments.
 
+    *src_root* is the ``out_of_process_reyn`` fixture value, threaded in from
+    the calling test (rather than a fresh ``import reyn``/``__file__``
+    computation here), so the pin is the same declared dependency every
+    other out-of-process spawn in this suite uses.
+
     ``env`` REPLACES the subprocess environment rather than extending it (the
     MCP SDK otherwise passes a 6-key whitelist that excludes PYTHONPATH), so
     the handful of vars the interpreter and uvx actually need are carried
     over explicitly.
     """
-    import reyn
-
-    src_root = str(Path(reyn.__file__).resolve().parent.parent)
     passthrough = {
         k: v for k, v in os.environ.items()
         if k in ("PATH", "HOME", "LOGNAME", "SHELL", "TERM", "USER", "TMPDIR")
@@ -228,7 +230,9 @@ def _fake_embedding_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(embed_mod, "get_provider", lambda *a, **k: fake)
 
 
-def _write_project(tmp_path: Path, *, vectorstore_server: str = "reyn_vector_store") -> Path:
+def _write_project(
+    tmp_path: Path, src_root: str, *, vectorstore_server: str = "reyn_vector_store",
+) -> Path:
     """Write a reyn.yaml wiring the 3 MCP servers (2 real, 1 stub) + the two
     builtin RAG pipeline entries, and return project_root."""
     stub_path = tmp_path / "stub_markitdown_server.py"
@@ -245,19 +249,19 @@ def _write_project(tmp_path: Path, *, vectorstore_server: str = "reyn_vector_sto
                             "type": "stdio",
                             "command": sys.executable,
                             "args": [str(stub_path)],
-                            "env": _server_env(),
+                            "env": _server_env(src_root),
                         },
                         "reyn_chunker": {
                             "type": "stdio",
                             "command": sys.executable,
                             "args": ["-m", "reyn.builtin.plugins.rag.scripts.chunker_server"],
-                            "env": _server_env(),
+                            "env": _server_env(src_root),
                         },
                         vectorstore_server: {
                             "type": "stdio",
                             "command": sys.executable,
                             "args": ["-m", "reyn.builtin.plugins.rag.scripts.vector_store_server"],
-                            "env": _server_env(),
+                            "env": _server_env(src_root),
                         },
                     },
                 },
@@ -325,12 +329,13 @@ def test_rag_query_pipeline_parses() -> None:
 
 def test_ingest_add_then_dedup_then_update_then_remove(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: C5's full add/update/remove convergence + X5's dedup
     visibility, driven end-to-end via 'reyn pipe run' against the REAL
     chunker + vector-store MCP servers."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("Alpha document about apples and oranges.", encoding="utf-8")
@@ -371,6 +376,7 @@ def test_ingest_add_then_dedup_then_update_then_remove(
 
 def test_only_real_document_content_reaches_the_store(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: a file that yields no usable document is NOT indexed, and IS reported (#3010).
 
@@ -403,7 +409,7 @@ def test_only_real_document_content_reaches_the_store(
     UnicodeDecodeError). No sentinel or special-case branch is added to the stub.
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     # A real document -- the falsify direction: the gates must skip the unusable files WITHOUT
@@ -439,6 +445,7 @@ def test_only_real_document_content_reaches_the_store(
 
 def test_a_none_conversion_is_reported_as_a_failure_not_indexed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: a conversion whose whole output is "None" is treated as a failed conversion (#3010).
 
@@ -453,7 +460,7 @@ def test_a_none_conversion_is_reported_as_a_failure_not_indexed(
     None is indexed untouched.
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     # The bug's signature: the converter's entire output is "None".
@@ -486,6 +493,7 @@ def test_a_none_conversion_is_reported_as_a_failure_not_indexed(
 
 def test_the_none_filter_is_opt_out(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: an operator can turn the None filter off, and then "None" is indexed as content.
 
@@ -494,7 +502,7 @@ def test_the_none_filter_is_opt_out(
     default that cannot be overridden would make the corpus lossy with no recourse.
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "literally_none.txt").write_text("None", encoding="utf-8")
@@ -514,6 +522,7 @@ def test_the_none_filter_is_opt_out(
 
 def test_ingest_reports_mojibake_via_files_ingested_preview(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: #3010 cause-3 -- a charset-mismatched (mojibake) conversion is
     NOT detectable/skippable (garbled bytes are semantically indistinguishable
@@ -546,7 +555,7 @@ def test_ingest_reports_mojibake_via_files_ingested_preview(
     now pinned as an invariant rather than re-derived per-cause).
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     good_text = "Bananas are a good source of potassium."
@@ -594,6 +603,7 @@ def test_ingest_reports_mojibake_via_files_ingested_preview(
 
 def test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: C4 -- every upserted chunk's embedding_model column names the
     model that ACTUALLY produced its vector (embed's envelope.model), not the
@@ -606,7 +616,7 @@ def test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias(
     FP-0057's C1 gate exists to prevent. Read straight back out of the real
     sqlite store."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("A short note about penguins.", encoding="utf-8")
@@ -627,6 +637,7 @@ def test_upserted_chunk_embedding_model_is_the_resolved_model_not_the_alias(
 
 def test_ingest_reports_metered_spend_not_the_chars4_estimate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: X2a -- the summary's tokens_embedded is embed's OWN METERED
     total_tokens (envelope meta), not the pipeline's chars/4 estimate.
@@ -636,7 +647,7 @@ def test_ingest_reports_metered_spend_not_the_chars4_estimate(
     attributable to exactly one source. Also pins that the resolved model
     and the priced flag ride the same envelope meta."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     body = "Alpha document about apples and oranges. " * 20
@@ -663,11 +674,12 @@ def test_ingest_reports_metered_spend_not_the_chars4_estimate(
 
 def test_rag_query_returns_the_ingested_chunk_as_top_result(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: rag_query.query, run after rag_ingest.ingest, returns a
     top-k result whose metadata source_path is the ingested file."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     target = docs_dir / "notes.txt"
@@ -700,6 +712,7 @@ def test_rag_query_returns_the_ingested_chunk_as_top_result(
 
 def test_query_missing_db_param_is_diagnosed_not_misdiagnosed_as_unreachable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2955 -- a live dogfood witness had a weak model call
     ``rag_query.query`` with an invented param name (``vector_store_path``
@@ -715,7 +728,7 @@ def test_query_missing_db_param_is_diagnosed_not_misdiagnosed_as_unreachable(
     names the missing parameter.
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("content", encoding="utf-8")
@@ -747,13 +760,14 @@ def test_query_missing_db_param_is_diagnosed_not_misdiagnosed_as_unreachable(
 
 def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: X1 -- pointing vectorstore_server at a name NOT present in
     mcp.servers blocks the run with a decision-enabling message naming that
     server + a concrete remedy (never a bare transport exception), and does
     NOT attempt any embedding spend (falsified below by the working case)."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)  # only registers "reyn_vector_store"
+    project_root = _write_project(tmp_path, out_of_process_reyn)  # only registers "reyn_vector_store"
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("content", encoding="utf-8")
@@ -773,6 +787,7 @@ def test_ingest_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
 
 def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #3095 -- `_ingest_body`'s file discovery (the #3101 upfront
     `glob_files` gate against `input_path` itself, followed by a `for_each`
@@ -816,7 +831,7 @@ def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
     test while developing the fix).
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     # A folder OUTSIDE project_root with no permission grant -- Workspace's
     # own default-deny boundary for absolute paths outside base_dir/state_dir
     # (see tests/test_workspace_glob_outside_root_perm.py) with `reyn pipe
@@ -851,6 +866,7 @@ def test_ingest_file_discovery_aborts_clean_on_unreadable_input_path(
 
 def test_ingest_is_unaffected_by_a_hostile_ambient_python3(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2972 -- the ingest completes normally even when the ambient
     `python3` is broken, because the pipeline runs no python of its own.
@@ -868,7 +884,7 @@ def test_ingest_is_unaffected_by_a_hostile_ambient_python3(
     the deletion behaviourally rather than by grepping the pipeline for the
     absence of a `shell:` step (see the sibling structural test for that)."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("Alpha document about apples.", encoding="utf-8")
@@ -896,6 +912,7 @@ def test_ingest_is_unaffected_by_a_hostile_ambient_python3(
 
 def test_ingest_pipeline_shells_out_to_nothing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2972 -- the ingest pipeline reaches the shell zero times.
 
@@ -916,7 +933,7 @@ def test_ingest_pipeline_shells_out_to_nothing(
 
     monkeypatch.setattr(sandboxed_exec_mod, "handle", _explode)
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("Alpha document about apples.", encoding="utf-8")
@@ -927,6 +944,7 @@ def test_ingest_pipeline_shells_out_to_nothing(
 
 def test_ingest_scans_every_file_past_the_glob_default_cap(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2972/#2994 -- a folder with more files than `glob_files`'
     own 50 default is ingested WHOLE, because the pipeline passes
@@ -939,7 +957,7 @@ def test_ingest_scans_every_file_past_the_glob_default_cap(
     (60 -> 50): that is the whole point of asserting it end-to-end on a
     corpus straddling the cap rather than pinning the YAML text."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     for i in range(60):
@@ -955,13 +973,14 @@ def test_ingest_scans_every_file_past_the_glob_default_cap(
 
 def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: FALSIFY control for the block above -- the SAME setup with
     the real, configured server name proceeds past pre-flight into the
     real ingest body (proves the sibling test's block is attributable to
     the unreachable server, not a broken pre-flight gate)."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("content", encoding="utf-8")
@@ -980,6 +999,7 @@ def test_ingest_preflight_falsify_proceeds_with_the_real_server_name(
 
 def test_query_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2955 follow-up -- rag_query's own pre-flight (restructured
     into `_query_preflight`, mirroring rag_ingest's X1) still blocks a
@@ -987,7 +1007,7 @@ def test_query_preflight_blocks_on_unreachable_vectorstore_with_named_remedy(
     server + a concrete remedy, once a valid `db` param rules out the
     missing-param diagnosis (the sibling test above)."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)  # only registers "reyn_vector_store"
+    project_root = _write_project(tmp_path, out_of_process_reyn)  # only registers "reyn_vector_store"
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("content", encoding="utf-8")
@@ -1042,6 +1062,7 @@ class FailingEmbeddingProvider:
 
 def test_query_embed_failure_surfaces_the_real_provider_error_not_a_field_absent_crash(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #2955 follow-up -- when the `embed` op fails (a real
     provider error, e.g. litellm's own `insufficient_quota` message), the
@@ -1062,7 +1083,7 @@ def test_query_embed_failure_surfaces_the_real_provider_error_not_a_field_absent
     (`insufficient_quota: the operator's API key`) nowhere in stderr.
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("content", encoding="utf-8")
@@ -1102,6 +1123,7 @@ def test_query_embed_failure_surfaces_the_real_provider_error_not_a_field_absent
 
 def test_ingest_with_relative_input_path_indexes_the_corpus(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #3102 -- a RELATIVE ``input_path`` (the natural way an
     operator points this pipeline at a project-root corpus, e.g. ``docs`` or
@@ -1140,7 +1162,7 @@ def test_ingest_with_relative_input_path_indexes_the_corpus(
     developing this fix).
     """
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "a.txt").write_text("Alpha document about apples.", encoding="utf-8")
@@ -1175,6 +1197,7 @@ def test_ingest_with_relative_input_path_indexes_the_corpus(
 
 def test_ingest_all_discovered_files_skipped_flag_names_the_zero_yield_run(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture,
+    out_of_process_reyn: str,
 ) -> None:
     """Tier 2b: #3102 -- when EVERY discovered file is unusable, the
     summary's ``all_discovered_files_skipped`` flag is True: 0 chunks
@@ -1184,7 +1207,7 @@ def test_ingest_all_discovered_files_skipped_flag_names_the_zero_yield_run(
     Falsified in the same test: a normal, at-least-partially-successful
     ingest reports False (not a flag that is vacuously always True)."""
     monkeypatch.chdir(tmp_path)
-    project_root = _write_project(tmp_path)
+    project_root = _write_project(tmp_path, out_of_process_reyn)
     docs_dir = project_root / "docs"
     docs_dir.mkdir()
     (docs_dir / "corrupt.pdf").write_bytes(b"\xff\xfe\x00\x01broken")

--- a/tests/test_httpx_lazy_load_cli_entry.py
+++ b/tests/test_httpx_lazy_load_cli_entry.py
@@ -26,13 +26,10 @@ import os
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
-
-SRC_DIR = Path(__file__).resolve().parents[1] / "src"
 
 
-def _run(script: str) -> subprocess.CompletedProcess:
-    env = {**os.environ, "PYTHONPATH": str(SRC_DIR)}
+def _run(src_root: str, script: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": src_root}
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(script)],
         capture_output=True,
@@ -42,7 +39,7 @@ def _run(script: str) -> subprocess.CompletedProcess:
     )
 
 
-def test_chat_command_module_import_does_not_import_httpx() -> None:
+def test_chat_command_module_import_does_not_import_httpx(out_of_process_reyn) -> None:
     """Tier 2: importing `reyn.interfaces.cli.commands.chat` leaves httpx unimported.
 
     FALSIFY: restoring the eager `from reyn.llm.llm import run_async` at module
@@ -55,12 +52,12 @@ def test_chat_command_module_import_does_not_import_httpx() -> None:
         assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_mcp_command_module_import_does_not_import_httpx() -> None:
+def test_mcp_command_module_import_does_not_import_httpx(out_of_process_reyn) -> None:
     """Tier 2: importing `reyn.interfaces.cli.commands.mcp` leaves httpx unimported."""
     script = """
         import sys
@@ -68,12 +65,12 @@ def test_mcp_command_module_import_does_not_import_httpx() -> None:
         assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_llm_module_import_does_not_import_httpx() -> None:
+def test_llm_module_import_does_not_import_httpx(out_of_process_reyn) -> None:
     """Tier 2: importing `reyn.llm.llm` directly leaves httpx unimported — the
     two `isinstance(exc, httpx.X)` exception-classification sites must resolve
     httpx lazily, not via a module-level `import httpx`."""
@@ -83,12 +80,12 @@ def test_llm_module_import_does_not_import_httpx() -> None:
         assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_cli_help_invocation_does_not_import_httpx() -> None:
+def test_cli_help_invocation_does_not_import_httpx(out_of_process_reyn) -> None:
     """Tier 2: the full `reyn --help` entry path (the actual cold-start
     invocation this fix targets) never touches httpx.
 
@@ -107,12 +104,12 @@ def test_cli_help_invocation_does_not_import_httpx() -> None:
         assert "httpx" not in sys.modules, sorted(m for m in sys.modules if "httpx" in m)
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout
 
 
-def test_httpx_exception_classification_still_resolves_lazily() -> None:
+def test_httpx_exception_classification_still_resolves_lazily(out_of_process_reyn) -> None:
     """Tier 2: `_get_httpx_exc_types()` (the httpx-equivalent of
     `_get_retryable_litellm_exceptions`) imports httpx on first call and
     returns the real `(httpx.ConnectError, httpx.ReadTimeout)` pair, so the
@@ -135,6 +132,6 @@ def test_httpx_exception_classification_still_resolves_lazily() -> None:
         assert read_timeout_exc is httpx.ReadTimeout
         print("OK")
         """
-    result = _run(script)
+    result = _run(out_of_process_reyn, script)
     assert result.returncode == 0, result.stderr
     assert "OK" in result.stdout

--- a/tests/test_landlock_exec_shim_1344e.py
+++ b/tests/test_landlock_exec_shim_1344e.py
@@ -126,20 +126,14 @@ def test_apply_landlock_refuses_when_unavailable():
 @pytest.mark.skipif(
     _landlock_available(), reason="Landlock available — enforcement path Linux-validated separately"
 )
-def test_main_subprocess_refuses_when_unavailable():
+def test_main_subprocess_refuses_when_unavailable(out_of_process_reyn: str):
     """Tier 2: run as a real subprocess on a no-Landlock host, the shim exits
     non-zero and does NOT exec the target (end-to-end of the refuse path)."""
-    import os
-    from pathlib import Path
-
-    import reyn
-
     pol = SandboxPolicy()
     exe, argv = build_landlock_exec_argv(pol, "/bin/echo", ["SHOULD-NOT-RUN"])
     # Run the shim against the reyn under test (not a venv-installed copy) by
     # pinning PYTHONPATH to this checkout's src root (env-dependent path lesson).
-    src_root = Path(reyn.__file__).resolve().parent.parent
-    env = {**os.environ, "PYTHONPATH": str(src_root)}
+    env = {**os.environ, "PYTHONPATH": out_of_process_reyn}
     proc = subprocess.run(
         [exe, *argv], capture_output=True, text=True, timeout=30, env=env,
     )
@@ -160,30 +154,34 @@ requires_landlock = pytest.mark.skipif(
 )
 
 
-def _shim_run(policy: SandboxPolicy, argv: list[str]) -> subprocess.CompletedProcess:
+def _shim_run(
+    src_root: str, policy: SandboxPolicy, argv: list[str]
+) -> subprocess.CompletedProcess:
     """Launch *argv* through the backend's real ``wrap_command`` — the production
     seam (MCP stdio / CodeAct) — and return the finished process.
 
-    PYTHONPATH is pinned to this checkout (as the refuse-path test above does) so
-    the shim re-execs the reyn under test rather than an installed copy.
+    PYTHONPATH is pinned to *src_root* (the ``out_of_process_reyn`` fixture
+    value, as the refuse-path test above does) so the shim re-execs the reyn
+    under test rather than an installed copy. Custom ``PATH`` preserved — the
+    landlock test needs it.
     """
-    import reyn
     from reyn.security.sandbox.backends.landlock import LandlockBackend
 
     wrapped = LandlockBackend().wrap_command(argv, policy)
-    src_root = Path(reyn.__file__).resolve().parent.parent
     return subprocess.run(
         wrapped.argv,
         capture_output=True,
         text=True,
         timeout=60,
         stdin=subprocess.DEVNULL,
-        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": str(src_root)},
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": src_root},
     )
 
 
 @requires_landlock
-def test_shim_denies_a_write_outside_write_paths(tmp_path: Path) -> None:
+def test_shim_denies_a_write_outside_write_paths(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
     """Tier 2c: the shim actually restricts the filesystem — a write outside
     ``write_paths`` does not happen, while one inside it does.
 
@@ -206,7 +204,7 @@ def test_shim_denies_a_write_outside_write_paths(tmp_path: Path) -> None:
     )
 
     control = granted / "control"
-    _shim_run(policy, [touch, str(control)])
+    _shim_run(out_of_process_reyn, policy, [touch, str(control)])
     assert control.exists(), (
         "the shim could not write to a path the policy GRANTS, so a denied write "
         "below would prove nothing (this is #2980's shape: the shim raising "
@@ -214,7 +212,7 @@ def test_shim_denies_a_write_outside_write_paths(tmp_path: Path) -> None:
     )
 
     escape = denied / "escape"
-    proc = _shim_run(policy, [touch, str(escape)])
+    proc = _shim_run(out_of_process_reyn, policy, [touch, str(escape)])
     assert not escape.exists(), (
         f"no deny fired: the shim wrote {escape}, outside the policy's only "
         f"write grant — it execs the target unrestricted (rc={proc.returncode}, "
@@ -223,7 +221,9 @@ def test_shim_denies_a_write_outside_write_paths(tmp_path: Path) -> None:
 
 
 @requires_landlock
-def test_shim_denies_a_fork_when_allow_subprocess_is_false(tmp_path: Path) -> None:
+def test_shim_denies_a_fork_when_allow_subprocess_is_false(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
     """Tier 2c: the shim's seccomp filter LOADS and denies process creation —
     the axis #3020 broke by importing pyseccomp after Landlock had restricted it.
 
@@ -260,14 +260,14 @@ def test_shim_denies_a_fork_when_allow_subprocess_is_false(tmp_path: Path) -> No
                           f"| {shlex.quote(cat)}"]
 
     control = granted / "control-spawn"
-    _shim_run(policy(True), forking(control))
+    _shim_run(out_of_process_reyn, policy(True), forking(control))
     assert control.exists(), (
         "the shim could not spawn even with allow_subprocess=True, so a missing "
         "marker under False would prove nothing"
     )
 
     alive = granted / "control-nofork"
-    proc = _shim_run(policy(False), [touch, str(alive)])
+    proc = _shim_run(out_of_process_reyn, policy(False), [touch, str(alive)])
     assert alive.exists(), (
         f"under allow_subprocess=False the shim could not run even a NON-forking "
         f"command — it is failing wholesale rather than denying process creation "
@@ -277,7 +277,7 @@ def test_shim_denies_a_fork_when_allow_subprocess_is_false(tmp_path: Path) -> No
     )
 
     spawned = granted / "spawned"
-    proc = _shim_run(policy(False), forking(spawned))
+    proc = _shim_run(out_of_process_reyn, policy(False), forking(spawned))
     assert not spawned.exists(), (
         f"no subprocess deny fired: a command that must fork to run wrote "
         f"{spawned} under allow_subprocess=False — the seccomp filter is not "

--- a/tests/test_mcp_install_ux_fixes_318_319_320.py
+++ b/tests/test_mcp_install_ux_fixes_318_319_320.py
@@ -187,7 +187,7 @@ def test_resolve_github_canonical_server_name_post_319() -> None:
 # ── #320: macOS /tmp install-time warning ────────────────────────────
 
 
-def test_install_command_warns_on_tmp_args_on_darwin(tmp_path) -> None:
+def test_install_command_warns_on_tmp_args_on_darwin(tmp_path, reyn_console_scripts) -> None:
     """Tier 2: on macOS, ``reyn mcp install --args /tmp/...`` emits a
     warning explaining the symlink gotcha. Skipped on non-Darwin
     because the warning is platform-gated.
@@ -206,9 +206,10 @@ def test_install_command_warns_on_tmp_args_on_darwin(tmp_path) -> None:
     # subsequent install failure is irrelevant to the assertion.
     import shutil
     reyn_bin = shutil.which("reyn")
-    if reyn_bin is None:
-        import pytest
-        pytest.skip("reyn executable not on PATH for subprocess invocation")
+    assert reyn_bin is not None, (
+        "reyn_console_scripts already verified this venv declares the "
+        "console script; shutil.which should find it"
+    )
     # #1442: install now resolves a project root and fails loud outside one
     # (error-not-silent-cwd), so give tmp_path a reyn.yaml — the #320 /tmp-args
     # warning fires inside the source install, past project resolution.

--- a/tests/test_python_harness_no_litellm_import.py
+++ b/tests/test_python_harness_no_litellm_import.py
@@ -12,12 +12,24 @@ OS invariant (FP-0008 C4):
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import time
 
 
-def test_harness_import_does_not_load_litellm():
+def _run(src_root: str, code: str) -> subprocess.CompletedProcess:
+    env = {**os.environ, "PYTHONPATH": src_root}
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=env,
+    )
+
+
+def test_harness_import_does_not_load_litellm(out_of_process_reyn):
     """Tier 2: fresh subprocess import of harness leaves litellm out of sys.modules."""
     code = (
         "import reyn.core.kernel._python_harness; "
@@ -25,12 +37,7 @@ def test_harness_import_does_not_load_litellm():
         "assert 'litellm' not in sys.modules, "
         "'litellm was eagerly loaded by harness import: ' + str(sorted(k for k in sys.modules if k.startswith('litellm')))"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    result = _run(out_of_process_reyn, code)
     assert result.returncode == 0, (
         f"harness import loaded litellm (or failed).\n"
         f"stdout: {result.stdout}\n"
@@ -38,7 +45,7 @@ def test_harness_import_does_not_load_litellm():
     )
 
 
-def test_harness_import_does_not_load_agent_llm_chain():
+def test_harness_import_does_not_load_agent_llm_chain(out_of_process_reyn):
     """Tier 2: fresh subprocess import of harness leaves the agent/llm/httpx chain out.
 
     #1367 — the C4 lazy-litellm fix removed litellm from the harness path, but
@@ -55,12 +62,7 @@ def test_harness_import_does_not_load_agent_llm_chain():
         "          if m in sys.modules]; "
         "assert not leaked, 'harness import eagerly loaded heavy chain: ' + str(leaked)"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    result = _run(out_of_process_reyn, code)
     assert result.returncode == 0, (
         f"harness import loaded the agent/llm/httpx chain (or failed).\n"
         f"stdout: {result.stdout}\n"
@@ -68,7 +70,7 @@ def test_harness_import_does_not_load_agent_llm_chain():
     )
 
 
-def test_harness_import_time_is_below_ceiling():
+def test_harness_import_time_is_below_ceiling(out_of_process_reyn):
     """Tier 2: harness import completes well under the preprocessor timeout ceiling.
 
     Ceiling is 3.0s — generous enough to avoid flake on slow CI, but well
@@ -83,12 +85,7 @@ def test_harness_import_time_is_below_ceiling():
         "elapsed = time.time() - t; "
         "assert elapsed < 3.0, f'harness import took {elapsed:.2f}s (ceiling 3.0s)'"
     )
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
+    result = _run(out_of_process_reyn, code)
     assert result.returncode == 0, (
         f"harness import exceeded ceiling.\n"
         f"stdout: {result.stdout}\n"

--- a/tests/test_sandbox_seccomp_network_3030.py
+++ b/tests/test_sandbox_seccomp_network_3030.py
@@ -84,23 +84,24 @@ requires_landlock = pytest.mark.skipif(
 )
 
 
-def _shim_run(policy: SandboxPolicy, argv: list[str]) -> subprocess.CompletedProcess:
+def _shim_run(
+    src_root: str, policy: SandboxPolicy, argv: list[str]
+) -> subprocess.CompletedProcess:
     """Launch *argv* through the backend's real ``wrap_command`` (the production
-    MCP-stdio / CodeAct seam), pinned to run THIS checkout (env-dependent path
-    lesson: without PYTHONPATH the shim re-execs an installed reyn copy, not the
-    one under test)."""
-    import reyn
+    MCP-stdio / CodeAct seam), pinned to run THIS checkout via *src_root* (the
+    ``out_of_process_reyn`` fixture value — env-dependent path lesson: without
+    PYTHONPATH the shim re-execs an installed reyn copy, not the one under
+    test). Custom ``PATH`` preserved — the sandbox test needs it."""
     from reyn.security.sandbox.backends.landlock import LandlockBackend
 
     wrapped = LandlockBackend().wrap_command(argv, policy)
-    src_root = Path(reyn.__file__).resolve().parent.parent
     return subprocess.run(
         wrapped.argv,
         capture_output=True,
         text=True,
         timeout=60,
         stdin=subprocess.DEVNULL,
-        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": str(src_root)},
+        env={"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "PYTHONPATH": src_root},
     )
 
 
@@ -109,7 +110,7 @@ def _shim_run(policy: SandboxPolicy, argv: list[str]) -> subprocess.CompletedPro
 
 @requires_landlock
 def test_shim_denies_outbound_connect_when_network_false_and_subprocess_allowed(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: the shim denies connect() under ``network=False,
     allow_subprocess=True`` — the exact policy #3030 measured as broken.
@@ -168,7 +169,7 @@ def test_shim_denies_outbound_connect_when_network_false_and_subprocess_allowed(
 
         # 1. Positive control.
         control = granted / "control-connect"
-        proc = _shim_run(policy(True), connect_argv(control))
+        proc = _shim_run(out_of_process_reyn, policy(True), connect_argv(control))
         assert control.exists(), (
             f"the shim could not connect() even with network=True, so a "
             f"missing marker under network=False would prove nothing "
@@ -178,7 +179,7 @@ def test_shim_denies_outbound_connect_when_network_false_and_subprocess_allowed(
         # 2. Non-networking control — isolates a dead filter from a network-specific
         #    deny (mirrors #3030's own falsification set, arm 2).
         alive = granted / "control-nonet"
-        proc = _shim_run(policy(False), [touch, str(alive)])
+        proc = _shim_run(out_of_process_reyn, policy(False), [touch, str(alive)])
         assert alive.exists(), (
             f"under network=False, allow_subprocess=True the shim could not run "
             f"even a NON-networking command — it is failing wholesale, not denying "
@@ -187,7 +188,7 @@ def test_shim_denies_outbound_connect_when_network_false_and_subprocess_allowed(
 
         # 3. The deny — the actual #3030 claim.
         escape = granted / "escaped-connect"
-        proc = _shim_run(policy(False), connect_argv(escape))
+        proc = _shim_run(out_of_process_reyn, policy(False), connect_argv(escape))
         assert not escape.exists(), (
             f"no network deny fired: connect() succeeded under network=False, "
             f"allow_subprocess=True — the exact #3030 condition (rc={proc.returncode}, "
@@ -198,7 +199,7 @@ def test_shim_denies_outbound_connect_when_network_false_and_subprocess_allowed(
 
 
 @requires_landlock
-def test_shim_allows_socket_and_bind_when_network_false(tmp_path: Path) -> None:
+def test_shim_allows_socket_and_bind_when_network_false(tmp_path: Path, out_of_process_reyn: str) -> None:
     """Tier 2c: #3060 — socket() and a LOOPBACK bind() both succeed through the
     shim even under ``network=False, allow_subprocess=True``, the exact
     condition under which urllib3's import-time IPv6-support probe
@@ -225,7 +226,7 @@ def test_shim_allows_socket_and_bind_when_network_false(tmp_path: Path) -> None:
         "s.bind(('::1', 0))\n"
         f"open({str(marker)!r}, 'w').close()\n"
     )
-    proc = _shim_run(policy, [sys.executable, "-c", code])
+    proc = _shim_run(out_of_process_reyn, policy, [sys.executable, "-c", code])
     assert marker.exists(), (
         f"socket()+bind(('::1', 0)) must succeed under network=False — this is "
         f"the exact urllib3 IPv6-probe shape #3060 fixes "
@@ -239,7 +240,7 @@ def test_shim_allows_socket_and_bind_when_network_false(tmp_path: Path) -> None:
 
 @requires_landlock
 def test_shim_allows_null_addr_socketpair_sendto_recvfrom_when_network_false(
-    tmp_path: Path,
+    tmp_path: Path, out_of_process_reyn: str,
 ) -> None:
     """Tier 2c: #3060 case-(b) POSITIVE witness — ``sendto``/``recvfrom`` with a
     NULL address pointer SUCCEED under ``network=False``.
@@ -272,7 +273,7 @@ def test_shim_allows_null_addr_socketpair_sendto_recvfrom_when_network_false(
         "assert b.recv(4) == b'ping'\n"
         f"open({str(marker)!r}, 'w').close()\n"
     )
-    proc = _shim_run(policy, [sys.executable, "-c", code])
+    proc = _shim_run(out_of_process_reyn, policy, [sys.executable, "-c", code])
     assert marker.exists(), (
         f"NULL-addr socketpair sendto/recvfrom must SUCCEED under network=False "
         f"(the async event-loop self-pipe #3060 fixes) — rc={proc.returncode}, "
@@ -281,7 +282,9 @@ def test_shim_allows_null_addr_socketpair_sendto_recvfrom_when_network_false(
 
 
 @requires_landlock
-def test_shim_denies_addressed_sendto_when_network_false(tmp_path: Path) -> None:
+def test_shim_denies_addressed_sendto_when_network_false(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
     """Tier 2c: #3060 case-(b) NEGATIVE witness (egress-safety — the load-bearing
     one) — an ADDRESSED ``sendto`` (real UDP egress,
     ``sendto(fd, buf, len, flags, &sockaddr_in, addrlen)``) stays EPERM-DENIED
@@ -318,7 +321,7 @@ def test_shim_denies_addressed_sendto_when_network_false(tmp_path: Path) -> None
         "s.sendto(b'x', ('93.184.216.34', 53))\n"
         f"open({str(marker)!r}, 'w').close()\n"
     )
-    proc = _shim_run(policy, [sys.executable, "-c", code])
+    proc = _shim_run(out_of_process_reyn, policy, [sys.executable, "-c", code])
     assert not marker.exists(), (
         f"addressed sendto (real UDP egress) MUST stay denied under "
         f"network=False — the NULL-addr sendto/recvfrom exception must NOT open "
@@ -365,7 +368,9 @@ def _bare_io_uring_supported() -> bool:
     reason="io_uring_setup not usable unsandboxed on this host/kernel — cannot "
     "distinguish a seccomp EPERM from ENOSYS",
 )
-def test_shim_denies_io_uring_setup_unconditionally(tmp_path: Path) -> None:
+def test_shim_denies_io_uring_setup_unconditionally(
+    tmp_path: Path, out_of_process_reyn: str,
+) -> None:
     """Tier 2c: io_uring_setup is refused EPERM through the shim REGARDLESS of
     policy — the exact gap a syscall-name denylist (the design #3030's issue
     considered and rejected) would have missed, since io_uring's opcodes never
@@ -380,7 +385,7 @@ def test_shim_denies_io_uring_setup_unconditionally(tmp_path: Path) -> None:
     policy = SandboxPolicy(
         write_paths=[str(granted)], read_deny_paths=[], network=True, allow_subprocess=True,
     )
-    proc = _shim_run(policy, [sys.executable, "-c", _IO_URING_PROBE_SRC])
+    proc = _shim_run(out_of_process_reyn, policy, [sys.executable, "-c", _IO_URING_PROBE_SRC])
     assert "URING_ERR errno=" in proc.stdout, (
         f"io_uring_setup was NOT refused through the shim (stdout={proc.stdout!r}, "
         f"rc={proc.returncode}, stderr={proc.stderr[:300]!r}) — a denylist-shaped "

--- a/tests/test_scheme_self_register_1608.py
+++ b/tests/test_scheme_self_register_1608.py
@@ -13,29 +13,25 @@ import os
 import subprocess
 import sys
 import textwrap
-from pathlib import Path
-
-import reyn
-
-# This test tree's src root — propagated to the subprocess so it imports the SAME
-# reyn (the #1609 worktree-drift lesson: sys.executable's default reyn may resolve
-# to a different worktree's venv).
-_SRC = str(Path(reyn.__file__).resolve().parent.parent)
 
 
-def _fresh_interpreter(code: str) -> subprocess.CompletedProcess:
-    env = {**os.environ, "PYTHONPATH": _SRC + os.pathsep + os.environ.get("PYTHONPATH", "")}
+def _fresh_interpreter(src_root: str, code: str) -> subprocess.CompletedProcess:
+    # `out_of_process_reyn` propagates this test tree's src root to the subprocess
+    # so it imports the SAME reyn (the #1609 worktree-drift lesson: sys.executable's
+    # default reyn may resolve to a different worktree's venv).
+    env = {**os.environ, "PYTHONPATH": src_root + os.pathsep + os.environ.get("PYTHONPATH", "")}
     return subprocess.run(
         [sys.executable, "-c", textwrap.dedent(code)],
         capture_output=True, text=True, env=env,
     )
 
 
-def test_all_builtins_resolve_in_fresh_interpreter() -> None:
+def test_all_builtins_resolve_in_fresh_interpreter(out_of_process_reyn) -> None:
     """Tier 2: #1608 ④ — a fresh interpreter that imports ONLY the schemes package
     (no explicit scheme-class import) finds all 4 built-ins registered + resolvable,
     and the default is unchanged. This is the completeness gate."""
     result = _fresh_interpreter(
+        out_of_process_reyn,
         """
         # The ONLY scheme-related import — must self-register the full built-in set.
         import reyn.tools.schemes  # noqa: F401
@@ -57,11 +53,12 @@ def test_all_builtins_resolve_in_fresh_interpreter() -> None:
     assert "RESOLVE_OK" in result.stdout
 
 
-def test_resolver_finds_all_builtins_without_naming_them() -> None:
+def test_resolver_finds_all_builtins_without_naming_them(out_of_process_reyn) -> None:
     """Tier 2: #1608 ④ — _resolve_tool_use_scheme (the OS resolver, which names NO
     scheme class) resolves each built-in name from a fresh interpreter, and an
     unknown name falls back to the default. Behaviour-invariant vs the old lazy loop."""
     result = _fresh_interpreter(
+        out_of_process_reyn,
         """
         from reyn.runtime.router_loop import _resolve_tool_use_scheme
         for n in ("universal-category", "enumerate-all", "retrieval", "codeact"):

--- a/tests/web/test_openui_shell.py
+++ b/tests/web/test_openui_shell.py
@@ -310,7 +310,7 @@ def test_design_file_stdlib_warm(tmp_project: Path, monkeypatch: pytest.MonkeyPa
 # 5. CLI --default-design flag
 # ---------------------------------------------------------------------------
 
-def test_web_help_includes_default_design() -> None:
+def test_web_help_includes_default_design(out_of_process_reyn) -> None:
     """Tier 2b: `reyn web --help` mentions --default-design."""
     result = subprocess.run(
         [sys.executable, "-c",
@@ -319,7 +319,7 @@ def test_web_help_includes_default_design() -> None:
         text=True,
         env={
             **__import__("os").environ,
-            "PYTHONPATH": str(_WORKTREE_SRC),
+            "PYTHONPATH": out_of_process_reyn,
         },
         timeout=15,
     )

--- a/tests/web/test_smoke.py
+++ b/tests/web/test_smoke.py
@@ -57,7 +57,7 @@ def test_routers_mounted() -> None:
 # 2. CLI smoke test
 # ---------------------------------------------------------------------------
 
-def test_reyn_web_help() -> None:
+def test_reyn_web_help(out_of_process_reyn) -> None:
     """Tier 2b: `reyn web --help` exits cleanly (exit code 0, stdout contains usage).
 
     Uses the reyn._cli:main entry point directly so we don't depend on the
@@ -70,7 +70,7 @@ def test_reyn_web_help() -> None:
         text=True,
         env={
             **__import__("os").environ,
-            "PYTHONPATH": str(_WORKTREE_SRC),
+            "PYTHONPATH": out_of_process_reyn,
         },
         timeout=15,
     )


### PR DESCRIPTION
**[per-PR-coder]** — Closes #3032

## What this does

Moves the remaining test call-sites that spawn a `reyn`-importing subprocess onto the existing `out_of_process_reyn` fixture (or `reyn_console_scripts` for console-script spawns), so the checkout-under-test PYTHONPATH pin is a DECLARED fixture dependency instead of a per-file hand-rolled computation. #3024 landed the seam; #3234 added an in-process backstop; this closes the remaining migration.

## (c) — unpinned reyn-spawns (the actual false-green bug, highest value)

- `tests/test_python_harness_no_litellm_import.py` — 3 spawns had NO `env=` at all (fully inherited ambient env, reading whatever checkout the ambient editable `.pth` resolves). Added `out_of_process_reyn` + a `_run` helper pinning PYTHONPATH.
- `tests/test_fastmcp_core_dep_import_chain.py` — same shape, 1 spawn, now pinned.
- `tests/test_mcp_install_ux_fixes_318_319_320.py` — spawns the CONSOLE SCRIPT (`shutil.which("reyn")`) with a hand-rolled skip-when-absent. Now requests `reyn_console_scripts` (the seam's dedicated guard — skip off-CI, fail under CI) instead; console scripts aren't fixed by PYTHONPATH so this is the correct fixture, not `out_of_process_reyn`.

## (b) — hand-pinned PYTHONPATH → fixture (consistency swap)

- `tests/test_httpx_lazy_load_cli_entry.py` — dropped its own `SRC_DIR = Path(__file__)...` computation, `_run` now takes `src_root` from the fixture.
- `tests/test_scheme_self_register_1608.py` — dropped its own `import reyn` + `Path(reyn.__file__)` computation.
- `tests/test_3027_budget_guard_survives_optimize.py` — dropped `_SRC_DIR` module constant.
- `tests/test_sandbox_seccomp_network_3030.py` — `_shim_run` now takes `src_root` as a parameter; custom `PATH` env preserved (the sandbox test needs it).
- `tests/test_landlock_exec_shim_1344e.py` — two helpers (`test_main_subprocess_refuses_when_unavailable`'s inline computation + the `_shim_run` helper) both migrated; custom `PATH`/landlock env preserved.
- `tests/web/test_smoke.py` / `tests/web/test_openui_shell.py` — only the SUBPROCESS env (`reyn web --help` invocation) was swapped to the fixture. The in-process `_WORKTREE_SRC` `sys.path.insert` at module scope (needed for the test module's own imports, not a subprocess spawn) was deliberately left untouched.

## FP-0063 MCP env-whitelist wrapper — judgment sites, wrapper KEPT

- `tests/test_fp0063_p3_rag_pipelines.py` / `tests/test_fp0063_arc_witness.py` — the MCP SDK's stdio transport drops PYTHONPATH from a 6-key env whitelist, so these build a passthrough dict (`_server_env`). Per the brief's guidance, the wrapper itself is unchanged; `_server_env` now takes `src_root: str` as a parameter (threaded from `out_of_process_reyn` through `_write_project` / `_prepare_local_plugin_copy` and into every calling test) instead of doing its own `import reyn` / `__file__` resolution.

## Excluded

- `tests/test_3233_inprocess_env_identity.py` — deliberately spawns with a DECOY PYTHONPATH to prove tree-divergence is caught by the in-process guard; migrating it onto the seam would invert its own purpose. Left untouched per the brief.
- All (d) non-reyn spawns (git/docker/stdlib-only/argv-only-assert/monkeypatched-subprocess) — out of scope, not touched.

## CI gates (all run foreground, all green)

1. `ruff check tests` — clean (one `I001` import-sort auto-fixed with `--fix`).
2. `python scripts/test_tier_audit.py --strict <all 12 changed files>` — 87 tests inspected, 0 errors, 0 warnings.
3. `python -m pytest <all 12 changed files> -q` — **76 passed, 11 skipped** (the 11 skips are the Landlock-enforcement tests in `test_sandbox_seccomp_network_3030.py` / `test_landlock_exec_shim_1344e.py`, which SKIP by design off Linux — this is a macOS dev box; every migrated test that CAN run here passed its original assertion).
4. No `src/` files changed — `verify_module_docstrings.py` N/A.

Per-file confirmation each migrated test still passes its original assertion:
- `test_python_harness_no_litellm_import.py` — 3/3 passed
- `test_fastmcp_core_dep_import_chain.py` — 1/1 passed
- `test_mcp_install_ux_fixes_318_319_320.py` — 14/14 passed
- `test_httpx_lazy_load_cli_entry.py` — 5/5 passed
- `test_scheme_self_register_1608.py` — 2/2 passed
- `test_3027_budget_guard_survives_optimize.py` — 4/4 passed
- `test_sandbox_seccomp_network_3030.py` — 6 passed, 11 Landlock-gated skipped (expected on macOS)
- `test_landlock_exec_shim_1344e.py` — included in the same 6-passed/11-skipped run above
- `web/test_smoke.py` — 5/5 passed
- `web/test_openui_shell.py` — 14/14 passed
- `test_fp0063_p3_rag_pipelines.py` — 21/21 passed
- `test_fp0063_arc_witness.py` — 1/1 passed

No production code touched — tests only, per the brief.

## Test plan

- [x] `tests/test_python_harness_no_litellm_import.py` — 3 tests pass
- [x] `tests/test_fastmcp_core_dep_import_chain.py` — 1 test passes
- [x] `tests/test_mcp_install_ux_fixes_318_319_320.py` — 14 tests pass
- [x] `tests/test_httpx_lazy_load_cli_entry.py` — 5 tests pass
- [x] `tests/test_scheme_self_register_1608.py` — 2 tests pass
- [x] `tests/test_3027_budget_guard_survives_optimize.py` — 4 tests pass
- [x] `tests/test_sandbox_seccomp_network_3030.py` — 6 pass, 11 skip (Landlock unavailable, macOS)
- [x] `tests/test_landlock_exec_shim_1344e.py` — same run as above
- [x] `tests/web/test_smoke.py` — 5 tests pass
- [x] `tests/web/test_openui_shell.py` — 14 tests pass
- [x] `tests/test_fp0063_p3_rag_pipelines.py` — 21 tests pass
- [x] `tests/test_fp0063_arc_witness.py` — 1 test passes