### PR TITLE
fix(1909): opt-in mid-turn untrusted-content capability narrowing (default off, monotonic latch)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -393,6 +393,7 @@ safety:
     max_tool_calls_per_turn: 50 # max tool_calls honoured from ONE completion (cost-bound); 0 = unlimited
     max_hook_driven_turns: 25  # loop valve: cap hook self-continuation; resets on user turn; 0 = unlimited
     max_agent_hops: 3          # maximum delegation depth
+    intra_turn_untrusted_narrowing: false  # #1909 OPT-IN: re-narrow capability every router-loop iteration (not just once per turn) once external_source-tagged content is live; default false = today's turn-boundary-only narrowing (byte-identical)
   timeout:
     llm_call_seconds: 60       # per-call HTTP timeout (--llm-timeout)
     llm_max_retries: 3         # transient-error retries per call (--llm-max-retries)
@@ -424,6 +425,7 @@ safety:
 | `safety.loop.max_tool_calls_per_turn` | int | `50` | — | Cost-bound: maximum `tool_calls` honoured from a SINGLE LLM completion. A degenerate completion can emit thousands (observed 3451); the OS processes only the first N, drops the overflow, and appends a re-grounding notice. `0` = unlimited. |
 | `safety.loop.max_hook_driven_turns` | int | `25` | — | Loop valve: caps hook self-continuation. Each hook-originated (`kind="hook"`) turn counts 1; the counter resets on each human user turn. When the count would exceed the cap the next hook turn hits the `safety.on_limit` checkpoint (warn → ask_user → abort) instead of running — a backstop that does not obstruct intentional loop-engineering. `0` = unlimited. |
 | `safety.loop.max_agent_hops` | int | `3` | — | Maximum delegation depth (user → A → B → C = 3 hops). |
+| `safety.loop.intra_turn_untrusted_narrowing` | bool | `false` | — | #1909 OPT-IN security hardening. `false` (default): contextual-permission narrowing for `external_source`-tagged content is resolved once per turn (byte-identical to pre-#1909 — no mid-turn capability loss). `true`: re-resolved every router-loop iteration, so external content encountered mid-turn narrows the very next dispatch in the SAME turn (closes the same-turn injection window), at the cost of a legitimate external→privileged flow being narrowed mid-flow and having to resume next turn. Narrowing is monotonic once engaged in a turn (a turn-scoped latch survives a later compaction evicting the tainted history entry) and emits an `untrusted_narrowing_engaged` audit-event the first time it engages in a turn. |
 
 ### `safety.timeout` fields
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -597,6 +597,15 @@
 #     max_tool_calls_per_turn: 50  # cost-bound: max tool_calls honoured from ONE completion; 0 = unlimited
 #     max_hook_driven_turns: 25  # #1800 loop valve: cap hook self-continuation per user turn; resets on user turn; 0 = unlimited
 #     max_agent_hops: 3
+#     # #1909 OPT-IN security hardening (default false = byte-identical to
+#     # today's turn-boundary-only narrowing, no mid-turn capability loss).
+#     # true: re-resolve contextual-permission narrowing every router-loop
+#     # iteration once external_source-tagged content is live, closing the
+#     # same-turn injection window at the cost of narrowing a legitimate
+#     # external->privileged flow mid-turn. Monotonic once engaged (a
+#     # turn-scoped latch survives a later compaction evicting the tainted
+#     # entry); emits an untrusted_narrowing_engaged audit-event on engage.
+#     intra_turn_untrusted_narrowing: false
 #     # plan() tool call parse-error self-correction (B51 NF-W6-3). 0 = disable.
 #     plan_invalid_retries: 1
 #     # Per-(chain, skill) spawn / token caps (= CostLimitConfig shape):

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -53,6 +53,30 @@ class LoopConfig:
             ``safety.on_limit`` checkpoint (warn → ask_user → abort) instead of
             running. A backstop only — does NOT obstruct intentional
             loop-engineering (the operator raises the cap). ``0`` = unlimited.
+        intra_turn_untrusted_narrowing:
+            #1909 (OPT-IN, default ``False``). When ``False`` (default),
+            contextual-permission narrowing for ``external_source``-tagged
+            content is resolved ONCE per turn (turn-boundary narrowing,
+            today's behavior) — an agent that touches external content
+            mid-turn does not lose capabilities until the *next* turn.
+            This is the predictable default: no mid-turn capability loss,
+            byte-identical to pre-#1909 behavior.
+
+            When ``True``, the OS re-resolves the contextual permission at
+            the top of every router-loop iteration within a turn, so
+            external content encountered in round *N* narrows dispatch in
+            round *N+1* of the *same* turn — closing the same-turn
+            injection window (the "lethal trifecta" mid-turn dispatch
+            gap). The trade-off (Product Think / operator legibility):
+            a legitimate external-content → privileged-action flow that
+            would have completed within one turn now gets narrowed
+            mid-flow and must resume next turn. Narrowing is monotonic
+            once engaged (a turn-scoped latch) — it does not un-narrow
+            mid-turn even if a later compaction evicts the tainted
+            history entry, closing a taint-laundering hole where
+            compaction could otherwise "launder" the taint away and let
+            capabilities recover within the same turn. An audit-event
+            fires the first time narrowing engages in a turn.
     """
 
     max_router_calls_per_turn: int = 3
@@ -60,6 +84,7 @@ class LoopConfig:
     max_router_iterations: int = 5
     max_tool_calls_per_turn: int = 50
     max_hook_driven_turns: int = 25
+    intra_turn_untrusted_narrowing: bool = False
 
 
 @dataclass
@@ -687,6 +712,10 @@ def _build_safety_config(raw: object) -> SafetyConfig:
         )),
         max_hook_driven_turns=int(loop_raw.get(
             "max_hook_driven_turns", loop_defaults.max_hook_driven_turns,
+        )),
+        intra_turn_untrusted_narrowing=bool(loop_raw.get(
+            "intra_turn_untrusted_narrowing",
+            loop_defaults.intra_turn_untrusted_narrowing,
         )),
     )
     timeout = TimeoutConfig(

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1103,6 +1103,8 @@ class RouterLoop:
         response_format: "dict | None" = None,  # 0062: schema-constrained answer turn; None = byte-identical (no other caller sets this)
         schema_validate_fn: "Any | None" = None,  # 0062: Callable[[Any], list[str]] — parsed-value -> validation-error strings ([] = conforming)
         max_schema_reprompt_attempts: int = 2,  # 0062 §2.1 failure-mode-(c): bounded re-prompt budget (extra attempts beyond the first)
+        intra_turn_contextual_for_turn_fn: "Any | None" = None,  # #1909 OPT-IN: () -> ContextualPermission|None, re-invoked every run() iteration. None (default) = off — self._contextual_permission stays turn-frozen (byte-identical). RouterLoopDriver only threads this when safety.loop.intra_turn_untrusted_narrowing is True.
+        contextual_static_baseline: "object | None" = None,  # #1909: the UN-narrowed static contextual (identity anchor) — a per-iteration resolve equal (by identity) to this means "not tainted"; anything else means the untrusted-composed profile engaged. Only consulted when intra_turn_contextual_for_turn_fn is not None.
     ):
         self.host = host
         self.chain_id = chain_id
@@ -1227,6 +1229,18 @@ class RouterLoop:
         # config selection (tool_use:{chat,step,phase}) plugs in here; with all
         # layers defaulting to universal-category it is byte-identical today.
         self._scheme = _resolve_tool_use_scheme(scheme_name)
+        # #1909 OPT-IN (default off): intra-turn untrusted-content re-narrowing.
+        # None (the default, every caller except the opt-in path) means run()'s
+        # per-iteration re-resolve block below is skipped entirely — no new
+        # code path executes, so the default posture is structurally
+        # byte-identical to pre-#1909 (turn-frozen ``_contextual_permission``).
+        self._intra_turn_contextual_for_turn_fn = intra_turn_contextual_for_turn_fn
+        self._contextual_static_baseline = contextual_static_baseline
+        # Turn-scoped monotonic latch (only meaningful when the above is set):
+        # once tainted this turn, stays tainted through turn end regardless of
+        # a later compaction evicting the ``external_source`` marker.
+        self._untrusted_latched: bool = False
+        self._untrusted_latched_permission: "object | None" = None
 
     @property
     def total_usage(self) -> TokenUsage:
@@ -1671,6 +1685,45 @@ class RouterLoop:
                 host.events.emit("turn_cancelled", chain_id=self.chain_id)
                 _loop_cancelled = True
                 break
+            # #1909 (OPT-IN, default off): intra-turn untrusted-content
+            # re-narrowing. ``self._intra_turn_contextual_for_turn_fn`` is
+            # None unless ``safety.loop.intra_turn_untrusted_narrowing`` is
+            # True (RouterLoopDriver only threads it on the opt-in path) —
+            # so the default posture takes NEITHER branch here and
+            # ``self._contextual_permission`` stays the turn-frozen value
+            # set at __init__ (byte-identical to pre-#1909 behaviour).
+            #
+            # On the opt-in path: re-invoke the live history tag-scan every
+            # iteration so external content spliced in round N narrows
+            # dispatch in round N+1 of the SAME turn (closes the same-turn
+            # injection window). ★ Monotonic latch: once ANY iteration this
+            # turn observes the ``external_source`` taint, stay narrowed
+            # through the rest of the turn even if a later compaction
+            # evicts the tainted history entry — ``_effective_contextual_
+            # for_turn`` self-clears on compaction (until-compaction
+            # scope), so a naive re-scan would let capability RECOVER
+            # mid-turn after compaction (a taint-laundering hole). The
+            # latch closes it; it clears only at the turn boundary (a
+            # fresh RouterLoop per user turn).
+            if self._intra_turn_contextual_for_turn_fn is not None:
+                _resolved_contextual = self._intra_turn_contextual_for_turn_fn()
+                _live_tainted = (
+                    _resolved_contextual is not self._contextual_static_baseline
+                )
+                if _live_tainted:
+                    if not self._untrusted_latched:
+                        self._untrusted_latched = True
+                        host.events.emit(
+                            "untrusted_narrowing_engaged",
+                            chain_id=self.chain_id,
+                            iteration=_iteration,
+                            provenance="external_source",
+                        )
+                    self._untrusted_latched_permission = _resolved_contextual
+                    self._contextual_permission = _resolved_contextual
+                elif self._untrusted_latched:
+                    # Compaction evicted the marker mid-turn — latch holds.
+                    self._contextual_permission = self._untrusted_latched_permission
             resolved_model = host.resolve_model(self.router_model)
             # #1654: the FULL ModelSpec (model + operator kwargs) for the LLM
             # call below, so per-model kwargs (reasoning_effort #1650/#1652,

--- a/src/reyn/runtime/services/router_loop_driver.py
+++ b/src/reyn/runtime/services/router_loop_driver.py
@@ -430,6 +430,28 @@ class RouterLoopDriver:
             response_format=self._response_format,
             schema_validate_fn=self._schema_validate_fn,
             max_schema_reprompt_attempts=self._max_schema_reprompt_attempts,
+            # #1909 (OPT-IN, default off — safety.loop.intra_turn_untrusted_
+            # narrowing): only thread the per-iteration re-resolve callable
+            # (+ its un-narrowed identity baseline) into RouterLoop when the
+            # operator has opted in. Default False → neither kwarg is passed
+            # (both stay None on the RouterLoop side) → RouterLoop's
+            # per-iteration re-resolve block is a no-op — byte-identical to
+            # pre-#1909 turn-frozen behaviour.
+            **(
+                {
+                    "intra_turn_contextual_for_turn_fn": self._contextual_for_turn_fn,
+                    "contextual_static_baseline": self._contextual_permission,
+                }
+                if (
+                    bool(getattr(
+                        getattr(self._safety, "loop", None),
+                        "intra_turn_untrusted_narrowing",
+                        False,
+                    ))
+                    and self._contextual_for_turn_fn is not None
+                )
+                else {}
+            ),
         )
         if self._loop_observer:
             self._loop_observer(loop)

--- a/tests/test_1909_intra_turn_opt_in_narrowing.py
+++ b/tests/test_1909_intra_turn_opt_in_narrowing.py
@@ -1,0 +1,212 @@
+"""Tier 2: opt-in intra-turn untrusted-content capability narrowing (#1909).
+
+#3187 landed the ``external_source`` taint propagation for tool-results into
+history ``meta`` (the S4/#1827 marker convention), but ``RouterLoop.
+_contextual_permission`` is resolved ONCE per turn (``RouterLoopDriver.
+run_turn`` calls ``contextual_for_turn_fn()`` once, before constructing
+``RouterLoop``) and stays frozen for every LLM/tool round WITHIN that turn's
+``run()``. So an external tool-result spliced in round *N* of a turn does NOT
+narrow round *N+1*'s dispatch in the SAME turn — the same-turn injection
+window this issue names.
+
+Owner directive: UX/predictability > security — security is OPT-IN. Default
+behavior (``safety.loop.intra_turn_untrusted_narrowing=False``) must stay
+BYTE-IDENTICAL to today (turn-boundary narrowing only). Only when an operator
+opts in does the mid-turn narrowing engage, with a turn-scoped MONOTONIC
+LATCH: ``_effective_contextual_for_turn`` self-clears its taint once the
+tainted history entry compacts out (until-compaction scope) — a naive
+per-iteration re-scan would let an injected-content-triggered mid-turn
+compaction evict the marker and let capabilities RECOVER within the same
+turn (a taint-laundering hole). The latch keeps narrowing engaged through
+turn end regardless of a later compaction.
+
+Real ``Session`` + real history + real tool registry + scripted
+``call_llm_tools`` throughout (mirrors ``test_1909_external_tool_result_
+narrowing.py`` / ``test_context_auto_1827_s4b.py``) — no ``_FakeMessage`` /
+hand-rolled host stand-in (#2957 PR-A precedent).
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from reyn.config.chat import LoopConfig, SafetyConfig
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_USAGE = TokenUsage(prompt_tokens=10, completion_tokens=5)
+
+_REMEMBER_ARGS = {
+    "slug": "y", "name": "n", "description": "d", "type": "user", "body": "x",
+}
+
+
+def _tool_call_result(calls: list[dict]) -> LLMToolCallResult:
+    tool_calls = [
+        {
+            "id": c.get("id", f"tc_{i}"),
+            "type": "function",
+            "function": {"name": c["name"], "arguments": json.dumps(c.get("args", {}))},
+        }
+        for i, c in enumerate(calls)
+    ]
+    return LLMToolCallResult(
+        content=None, tool_calls=tool_calls, finish_reason="tool_calls", usage=_USAGE,
+    )
+
+
+def _text_result(text: str) -> LLMToolCallResult:
+    return LLMToolCallResult(content=text, tool_calls=[], finish_reason="stop", usage=_USAGE)
+
+
+def _scripted_llm(rounds: list, on_round: "dict[int, Any] | None" = None):
+    """Scripted ``call_llm_tools`` replacement. ``on_round`` maps a 0-based
+    round index to a zero-arg callback invoked (as a side effect) exactly
+    when that round is served — used to simulate a mid-turn compaction
+    happening between two LLM rounds of the SAME turn."""
+    state = {"n": 0}
+    on_round = on_round or {}
+
+    async def _call(**kwargs: Any) -> LLMToolCallResult:
+        idx = state["n"]
+        r = rounds[idx]
+        state["n"] += 1
+        cb = on_round.get(idx)
+        if cb is not None:
+            cb()
+        return r
+    return _call
+
+
+def _make(safety: SafetyConfig | None = None) -> Session:
+    return make_session(agent_name="test_agent", safety=safety or SafetyConfig())
+
+
+@pytest.mark.asyncio
+async def test_off_default_not_narrowed_mid_turn_same_turn(tmp_path, monkeypatch):
+    """Tier 2: OFF (default) — a same-TURN external tool-result does NOT
+    narrow a later round's dispatch in that same turn (today's behavior,
+    preserved byte-identically). ``remember_shared`` (denied by the built-in
+    ``_untrusted`` floor once narrowed) still succeeds in round 2 of the
+    SAME ``_handle_user_message`` call that dispatched the external
+    ``list_memory`` in round 1 — proving the off-path leaves
+    ``RouterLoop._contextual_permission`` turn-frozen."""
+    monkeypatch.chdir(tmp_path)
+    session = _make()  # SafetyConfig() default: intra_turn_untrusted_narrowing=False
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_r"}]),
+            _text_result("done"),
+        ]),
+    )
+    await session._handle_user_message("look something up then remember it", chain_id="c1")
+
+    (msg,) = [m for m in session.history if m.tool_call_id == "tc_r"]
+    assert "tool_excluded" not in str(msg.content)
+
+
+@pytest.mark.asyncio
+async def test_on_engages_mid_turn_and_emits_audit_event(tmp_path, monkeypatch):
+    """Tier 2: ON — the SAME single-turn sequence as the off-leg above, but
+    with ``intra_turn_untrusted_narrowing=True``: round 2's ``remember_shared``
+    dispatch (in the SAME ``_handle_user_message`` call, same turn, after
+    round 1's external ``list_memory``) IS denied — narrowing engaged
+    mid-turn. Also asserts the audit-event fires exactly once on the
+    engage transition."""
+    monkeypatch.chdir(tmp_path)
+    session = _make(SafetyConfig(loop=LoopConfig(intra_turn_untrusted_narrowing=True)))
+    captured = []
+    session.subscribe_chat_events(
+        lambda ev: captured.append(ev)
+        if getattr(ev, "type", None) == "untrusted_narrowing_engaged"
+        else None
+    )
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm([
+            _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+            _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_denied"}]),
+            _text_result("done"),
+        ]),
+    )
+    await session._handle_user_message("look something up then remember it", chain_id="c1")
+
+    (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
+    assert "tool_excluded" in str(denied_msg.content)
+    assert "remember_shared" in str(denied_msg.content)
+    # Fires on the engage TRANSITION only (iteration 1, where the taint is
+    # first observed) — not again on iteration 2's re-resolve, even though
+    # that iteration is still tainted (already latched).
+    assert [e.data.get("iteration") for e in captured] == [1]
+    assert captured[0].data.get("provenance") == "external_source"
+
+
+@pytest.mark.asyncio
+async def test_on_latch_survives_mid_turn_compaction(tmp_path, monkeypatch):
+    """Tier 2: ON + monotonic latch, compaction-immune (★ LOAD-BEARING).
+
+    Round 1 dispatches the external ``list_memory`` (taints history) and the
+    top-of-iteration-2 re-resolve observes the taint and LATCHES (first
+    engage). Round 2 is a harmless trusted call (``list_agents``); its
+    scripted side effect simulates a mid-turn compaction that EVICTS the
+    ``external_source``-tagged history entry AFTER the latch already engaged
+    but BEFORE the top-of-iteration-3 re-resolve runs (the exact eviction
+    technique ``test_context_auto_1827_s4b.py`` / ``test_1909_external_tool_
+    result_narrowing.py`` use for the turn-boundary self-clear witness — here
+    happening WITHIN one turn's multi-round loop instead of across a turn
+    boundary). Round 3's ``remember_shared`` dispatch must STILL be denied —
+    the latch holds even though a live history re-scan at that instant would
+    see no taint (the marker is gone).
+
+    ★ Strip-falsify: this test is the one the monotonic latch exists for.
+    Removing the latch (i.e. reverting the per-iteration narrowing decision
+    to a pure live-scan of ``self._intra_turn_contextual_for_turn_fn()``
+    with no ``self._untrusted_latched`` / ``self._untrusted_latched_
+    permission`` carry-over) makes this test flip RED: round 2's live scan
+    would see the (now-evicted) history as untainted, ``remember_shared``
+    would succeed, and capability would have RECOVERED mid-turn after
+    compaction — the taint-laundering hole this design closes. Verified by
+    hand during development (temporarily reverting the latch branches to a
+    bare re-resolve): RED as predicted, confirming the latch is load-bearing
+    and not incidental.
+    """
+    monkeypatch.chdir(tmp_path)
+    session = _make(SafetyConfig(loop=LoopConfig(intra_turn_untrusted_narrowing=True)))
+
+    def _simulate_mid_turn_compaction() -> None:
+        session.history = [
+            m for m in session.history if not (m.meta or {}).get("external_source")
+        ]
+
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _scripted_llm(
+            [
+                _tool_call_result([{"name": "list_memory", "args": {"path": ""}, "id": "tc_ext"}]),
+                _tool_call_result([{"name": "list_agents", "args": {}, "id": "tc_trusted"}]),
+                _tool_call_result([{"name": "remember_shared", "args": _REMEMBER_ARGS, "id": "tc_denied"}]),
+                _text_result("done"),
+            ],
+            # Fires exactly when round index 1 (the harmless list_agents
+            # round) is SERVED — i.e. AFTER round 0's tool-result tainted
+            # history AND AFTER the top-of-iteration-1 re-resolve already
+            # latched (that re-resolve runs before this LLM call), but
+            # BEFORE the top-of-iteration-2 re-resolve that precedes round
+            # 2's (remember_shared) dispatch decision.
+            on_round={1: _simulate_mid_turn_compaction},
+        ),
+    )
+    await session._handle_user_message("look something up then remember it", chain_id="c1")
+
+    assert not any((m.meta or {}).get("external_source") for m in session.history), (
+        "the compaction simulation must have actually evicted the tainted entry"
+    )
+    (denied_msg,) = [m for m in session.history if m.tool_call_id == "tc_denied"]
+    assert "tool_excluded" in str(denied_msg.content)
+    assert "remember_shared" in str(denied_msg.content)


### PR DESCRIPTION
[per-PR-coder] — implements #1909 per the owner + architect firmed design in the issue thread (opt-in, default off, monotonic latch).

Closes #1909

## Owner directive (load-bearing)

**UX/predictability > security; security is opt-in.** Default behavior must stay byte-identical to today (turn-boundary narrowing only). Only when an operator opts in does mid-turn narrowing engage.

## What this closes

`RouterLoop._contextual_permission` is resolved ONCE per turn (`RouterLoopDriver.run_turn` calls `contextual_for_turn_fn()` once before constructing `RouterLoop`) and stays frozen for every LLM/tool round within that turn. So external content spliced into history in round *N* (tagged `external_source` — the #1827/#3187 marker convention) does not narrow round *N+1*'s dispatch in the SAME turn — the same-turn injection window this issue names.

## Design (owner + architect firmed in the issue thread)

- **Config**: `safety.loop.intra_turn_untrusted_narrowing: bool = False` — a per-iteration run-loop security-*timing* policy, cohesive with the existing `safety.loop.*` caps (not `permissions.*` = capability grant, not `_untrusted.yaml` = WHAT narrows).
- **Default-off = byte-identical**: `RouterLoopDriver.run_turn` only threads the per-iteration re-resolve callable (`contextual_for_turn_fn`) + its un-narrowed identity baseline into `RouterLoop` when the flag is `True`. Off (default), neither kwarg is passed — `RouterLoop`'s per-iteration re-resolve block is structurally a no-op, `self._contextual_permission` stays turn-frozen exactly as before.
- **On-path**: at the top of every `run()` iteration, `RouterLoop` re-invokes the resolver against live `Session.history` (`Session._effective_contextual_for_turn`, unchanged) and reassigns `self._contextual_permission`.
- **★ Monotonic latch (closes a taint-laundering hole)**: `_effective_contextual_for_turn`'s taint self-clears once the tainted history entry compacts out (until-compaction scope). A naive per-iteration re-scan would let a mid-turn compaction evict the marker and let capabilities RECOVER within the same turn — the exact laundering path the architect flagged as load-bearing. The fix: once ANY iteration in a turn observes the taint, latch it (`self._untrusted_latched` + the captured narrowed permission); for the rest of the turn the narrowed profile is reused REGARDLESS of what a fresh live-scan would show. The latch clears only at the turn boundary (a fresh `RouterLoop` per user turn).
- **Audit-event**: `untrusted_narrowing_engaged` fires once, on the engage transition (not every iteration), naming `provenance="external_source"`.
- `capability_profile.py`'s marker/derive/compose primitives are unchanged and reused as-is.

## Files

- `src/reyn/config/chat.py` — `LoopConfig.intra_turn_untrusted_narrowing: bool = False` + parse wiring + docstring trade-off note.
- `src/reyn/runtime/router_loop.py` — `RouterLoop.__init__` gains `intra_turn_contextual_for_turn_fn` / `contextual_static_baseline` (both `None` by default); the per-iteration re-resolve + latch + audit-event block at the top of the `run()` loop.
- `src/reyn/runtime/services/router_loop_driver.py` — `run_turn` conditionally threads the two new kwargs into `RouterLoop` only when `safety.loop.intra_turn_untrusted_narrowing` is `True`.
- `docs/reference/config/reyn-yaml.md` + `reyn.local.yaml.example` — new field documented (config-mirror-coverage gate, #1056).
- `tests/test_1909_intra_turn_opt_in_narrowing.py` — new, 3 legs (below).

## Tests — 3 legs, strip-falsifiable

1. **OFF (default)**: `test_off_default_not_narrowed_mid_turn_same_turn` — a single-turn, multi-round `_handle_user_message` call (external `list_memory` in round 1, `remember_shared` in round 2 of the SAME turn) — `remember_shared` succeeds (not narrowed), proving the off-path leaves `_contextual_permission` turn-frozen.
2. **ON → engage**: `test_on_engages_mid_turn_and_emits_audit_event` — same single-turn sequence, flag `True` — round 2's `remember_shared` is denied (`tool_excluded`), and the `untrusted_narrowing_engaged` audit-event fires exactly once, at the engage transition (asserted via the extracted iteration-index list, not a bare `len(...) == N`, per the Tier-4 format-pin gate).
3. **★ ON + latch (load-bearing)**: `test_on_latch_survives_mid_turn_compaction` — round 1 taints history (`list_memory`), the top-of-next-iteration re-resolve latches; round 2 (`list_agents`, trusted) carries a scripted side effect that evicts the `external_source`-tagged entry from `session.history` mid-turn (simulating compaction); round 3 (`remember_shared`) is STILL denied — the latch holds even though a live re-scan at that point would see no taint.

**Strip-falsifiability verified by hand**: temporarily reverted the latch branches to a bare re-resolve (`self._contextual_permission = self._intra_turn_contextual_for_turn_fn()`, no latch carry-over, no audit-event). Result: leg 3 flipped RED (`remember_shared` succeeded — capability recovered mid-turn after the simulated compaction), and leg 2 also went RED (its audit-event assertion, since the emit code was removed along with the latch in that revert). This is the taint-laundering hole the design closes; the latch is load-bearing, not incidental. Reverted the strip immediately after confirming RED; all 3 legs green again.

## CI gates (all run locally, foreground)

1. `ruff check src tests` — **pass**
2. `python scripts/test_tier_audit.py --strict tests/test_1909_intra_turn_opt_in_narrowing.py` — **pass** (0 errors; two Tier-4 issues found and fixed during development: a `len(captured) == 1` format-pin → rewritten as an extracted-value equality assertion on the captured iteration indices; a docstring "Tier 2 — ★ LOAD-BEARING..." → reformatted to `"""Tier 2: ... (★ LOAD-BEARING)."""`)
3. `python -m pytest tests/test_1909_intra_turn_opt_in_narrowing.py tests/test_context_auto_1827_s4b.py tests/test_1909_external_tool_result_narrowing.py -q` — **14 passed**
4. `python scripts/verify_module_docstrings.py <changed src files>` — **pass**
5. Full `pytest -q -n auto --timeout=120` — **9184 passed, 36 skipped**, 3 failed initially:
   - `test_config_mirror_coverage_1056.py::test_docs_documents_every_config_field` / `test_example_documents_every_config_field` — caused by the new config field not yet being documented in the reference doc / example template. **Fixed** (both docs updated); both now pass.
   - `test_3162_rag_skill_body_read_reachable.py::test_real_rag_skill_router_and_every_bundled_reference_reachable_without_approval` — **pre-existing, unrelated**: verified by `git stash`-ing this PR's changes and re-running the same test on unmodified `main` — it fails identically (a RAG-skill file-truncation issue, nothing to do with this PR's files). Not introduced by this change.

## Default-off byte-identical confirmation

No LLMReplay/fp0063 fixture drift observed anywhere in the full suite — the off-path change is structural (kwargs simply aren't passed to `RouterLoop` when the flag is `False`), so no LLM payload shape changes.

## Config

`safety.loop.intra_turn_untrusted_narrowing: bool = False` (default off).

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_1909_intra_turn_opt_in_narrowing.py`
- [x] `python -m pytest tests/test_1909_intra_turn_opt_in_narrowing.py tests/test_context_auto_1827_s4b.py tests/test_1909_external_tool_result_narrowing.py -q`
- [x] `python scripts/verify_module_docstrings.py <changed src files>`
- [x] Full `pytest -q -n auto --timeout=120` (1 pre-existing unrelated failure documented above)
- [x] Manual: hand-verified strip-falsifiability of the monotonic latch (leg 3 flips RED without it)