### PR TITLE
fix(3212): plugin install/uninstall concurrency — liveness-reconcile + per-name lock + atomic-rename copy

### DIFF
--- a/src/reyn/core/op_runtime/plugin_install.py
+++ b/src/reyn/core/op_runtime/plugin_install.py
@@ -87,14 +87,62 @@ not apply to them. The reconcile in this module is a filesystem/registry
 consistency check; the registry entries THEMSELVES (mcp/pipelines/skills.yaml)
 still ride the existing config-generation recovery path via the
 sub-handlers they call.
+
+**Concurrency (#3212)**: ``~/.reyn/plugins/`` is DELIBERATELY a single
+global, session/workspace-UNSCOPED path (ADR 0064 §3.3 — "install once, use
+everywhere"); this is unchanged by #3212. What #3212 fixes is that two
+concurrent ``plugin_install``/``plugin_uninstall`` calls (same or different
+sessions) racing on the SAME global path could wipe each other's in-flight
+work:
+
+  - The step-0 reconcile above previously could not tell a genuinely-crashed
+    partial install (marker present, no live owner) from a CONCURRENT
+    still-in-progress install of the SAME name (marker present, owner very
+    much alive) — both looked identical, so a concurrent reconcile could
+    ``rmtree`` a live install mid-copy. Fixed by making the
+    ``_install_state.json`` marker carry ``{pid, ts}`` (mirroring
+    ``reyn.data.index.build_lock``'s marker shape) and having reconcile check
+    liveness via ``build_lock.pid_alive`` PER ENTRY before rolling anything
+    back: a live owner is skipped (back off, not wiped), only a dead/missing/
+    legacy (no-pid) marker is treated as crashed and rolled back as before.
+  - ``plugin_name_lock`` (below) is a blocking, bounded-wait, cross-process
+    per-plugin-name advisory lock (same marker-file primitive, reused from
+    ``build_lock.py``, but BLOCK-AND-WAIT semantics rather than
+    ``build_lock``'s take-or-skip index-build contract — a skipped uninstall
+    would surprise the operator) serializing every mutating step of
+    ``plugin_install``/``plugin_uninstall`` on the same name, so an install's
+    ``copytree`` can never interleave with a concurrent uninstall's
+    ``rmtree`` (or another install of the same name). Reconcile's own
+    rollback of a dead entry also takes this lock (short timeout) before
+    touching it, so the sweep can never race a live mutator either.
+  - The content copy itself (``_copy_plugin_tree``) is staged into a unique
+    ``~/.reyn/plugins/.staging/<name>-<uuid>/`` dir (same filesystem as the
+    final target, so the final move is an atomic ``Path.replace``) and only
+    swapped into place at ``plugin_root`` once fully copied — a concurrent
+    reader (e.g. ``pipe list`` resolving an absolute registered path) always
+    sees either the complete old tree or the complete new tree, never a
+    half-copied one. The staging dir carries the SAME liveness marker (it
+    IS the eventual ``_install_state.json``, moved into place by the rename),
+    so reconcile's ``.staging`` sweep is liveness-aware too, not a blanket
+    wipe — it must not delete a concurrent install's in-progress staging.
 """
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
+import os
 import shutil
+import time
 from pathlib import Path
 from uuid import uuid4
 
+from reyn.data.index.build_lock import (
+    pid_alive,
+    read_lock_holder,
+    remove_lock_marker,
+    write_lock_marker,
+)
 from reyn.plugins.manifest import (
     PluginManifestError,
     load_plugin_manifest,
@@ -137,6 +185,83 @@ def plugins_root() -> Path:
     """``~/.reyn/plugins/`` — the global plugin-code cache (ADR §3.3: code
     installs once to global, enablement is project-local)."""
     return Path.home() / ".reyn" / "plugins"
+
+
+# ---------------------------------------------------------------------------
+# Per-plugin-name cross-process lock (#3212 layer b)
+# ---------------------------------------------------------------------------
+
+_LOCK_POLL_INTERVAL_S = 0.05
+DEFAULT_PLUGIN_LOCK_TIMEOUT_S = 30.0
+
+
+def _locks_dir(root: Path) -> Path:
+    return root / ".locks"
+
+
+def _plugin_lock_path(root: Path, name: str) -> Path:
+    return _locks_dir(root) / f"{name}.lock"
+
+
+@contextlib.asynccontextmanager
+async def plugin_name_lock(
+    name: str,
+    root: "Path | None" = None,
+    *,
+    timeout: float = DEFAULT_PLUGIN_LOCK_TIMEOUT_S,
+):
+    """Blocking, bounded-wait, cross-process advisory lock serializing every
+    MUTATING step of ``plugin_install``/``plugin_uninstall`` on the same
+    plugin *name* (#3212 layer b) — so an install's ``copytree`` can never
+    interleave with a concurrent uninstall's ``rmtree`` (or another install
+    of the same name).
+
+    Reuses ``reyn.data.index.build_lock``'s ``{pid, ts}`` marker-file
+    primitives (``pid_alive`` / ``read_lock_holder`` / ``write_lock_marker`` /
+    ``remove_lock_marker``) for the atomic take + staleness check, but with
+    **BLOCKING wait** semantics bounded by *timeout* seconds — NOT
+    ``build_lock``'s take-or-skip contract (a skipped uninstall would
+    surprise the operator; here the caller genuinely needs the mutation to
+    happen, just serialized). A stale lock (dead holder pid) is reclaimed
+    immediately rather than waited out.
+
+    Raises ``TimeoutError`` if *timeout* elapses with a live holder still
+    present.
+    """
+    base = root if root is not None else plugins_root()
+    locks_dir = _locks_dir(base)
+    locks_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = _plugin_lock_path(base, name)
+
+    def _take_atomic() -> bool:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except OSError:
+            return False
+        os.close(fd)
+        write_lock_marker(lock_path)
+        return True
+
+    deadline = time.monotonic() + timeout
+    while True:
+        if _take_atomic():
+            break
+        holder_pid = read_lock_holder(lock_path)
+        if holder_pid is None or not pid_alive(holder_pid):
+            # Stale/legacy/dead lock — reclaim immediately, no waiting.
+            remove_lock_marker(lock_path)
+            continue
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"timed out after {timeout}s waiting for the plugin lock on "
+                f"{name!r} (held by pid {holder_pid})"
+            )
+        await asyncio.sleep(_LOCK_POLL_INTERVAL_S)
+
+    try:
+        yield
+    finally:
+        remove_lock_marker(lock_path)
 
 
 # ---------------------------------------------------------------------------
@@ -213,11 +338,22 @@ def _install_state_path(plugin_root: Path) -> Path:
     return plugin_root / ".reyn-plugin" / _INSTALL_STATE_FILENAME
 
 
-def _write_install_state(plugin_root: Path, kind: str) -> None:
+def _write_install_state(plugin_root: Path, kind: str, *, pid: "int | None" = None) -> None:
+    """Write the in-progress marker, carrying ``{pid, ts}`` (#3212) so
+    ``reconcile_plugin_installs`` can tell a genuinely-crashed partial (dead
+    pid) from a concurrent still-in-progress install of the SAME name (live
+    pid) — both previously looked identical (marker present), which is the
+    #3212 root cause. ``pid`` defaults to the CURRENT process
+    (``os.getpid()``, the real production path); callers simulating a crash
+    for tests pass an explicit dead pid."""
     state_path = _install_state_path(plugin_root)
     state_path.parent.mkdir(parents=True, exist_ok=True)
     state_path.write_text(
-        json.dumps({"name": plugin_root.name, "kind": kind, "status": "installing"}),
+        json.dumps({
+            "name": plugin_root.name, "kind": kind, "status": "installing",
+            "pid": pid if pid is not None else os.getpid(),
+            "ts": time.time(),
+        }),
         encoding="utf-8",
     )
 
@@ -278,6 +414,17 @@ async def reconcile_plugin_installs(
     correct behavior when there is no project registry in scope.
 
     Returns the list of plugin names rolled back.
+
+    **Liveness-aware (#3212 layer a)**: a marker whose ``pid`` is ALIVE means
+    a CONCURRENT install of this same name is still in progress — not a
+    crashed partial — so it is SKIPPED (back off, do not wipe) rather than
+    rolled back. Only a dead / missing / legacy (no-``pid`` field) marker is
+    treated as a crashed partial and rolled back, same as before #3212. Each
+    rollback additionally takes the #3212 per-name ``plugin_name_lock``
+    (short timeout) before touching the entry, so this sweep can never race
+    a live ``plugin_install``/``plugin_uninstall`` mutator either — if the
+    lock cannot be acquired promptly (some other mutator just grabbed it),
+    the entry is left for the next reconcile pass rather than forced.
     """
     base = root if root is not None else plugins_root()
     if not base.is_dir():
@@ -289,21 +436,49 @@ async def reconcile_plugin_installs(
         state = _read_install_state(entry)
         if state is None:
             continue
+        marker_pid = state.get("pid")
+        if isinstance(marker_pid, int) and marker_pid > 0 and pid_alive(marker_pid):
+            # A concurrent install of THIS name is still in progress — not a
+            # crashed partial. Skip; do not wipe a live install (#3212).
+            continue
         # Drop-registry-FIRST (§3.11): remove any entries this partial install
-        # registered before deleting the copy they point at.
-        if project_root is not None:
-            await _reconcile_drop_registry_entries(
-                project_root, entry.name, state_log=state_log, events=events,
-            )
-        shutil.rmtree(entry, ignore_errors=True)
-        rolled_back.append(entry.name)
-        if events is not None:
-            events.emit("plugin_install_reconciled", name=entry.name, action="rolled_back")
-    # A staging clone dir interrupted mid-clone is never "installed" under
-    # any name — always safe to sweep in full.
+        # registered before deleting the copy they point at. Guarded by the
+        # per-name lock so this rollback cannot interleave with a concurrent
+        # mutator that just took ownership of this name.
+        try:
+            async with plugin_name_lock(entry.name, base, timeout=5.0):
+                if project_root is not None:
+                    await _reconcile_drop_registry_entries(
+                        project_root, entry.name, state_log=state_log, events=events,
+                    )
+                shutil.rmtree(entry, ignore_errors=True)
+                rolled_back.append(entry.name)
+                if events is not None:
+                    events.emit(
+                        "plugin_install_reconciled", name=entry.name, action="rolled_back",
+                    )
+        except TimeoutError:
+            # Someone else holds this name's lock right now — leave it for
+            # the next reconcile pass rather than forcing the rollback.
+            continue
+    # A staging dir (git-clone OR the atomic-copy staging, #3212 layer c) is
+    # never "installed" under any name. Atomic-copy staging carries the SAME
+    # ``_install_state.json`` marker it will be renamed into place with, so
+    # it is liveness-checked the same way as a top-level entry above — a
+    # concurrent install's in-progress staging must not be swept. Git-clone
+    # staging carries no such marker and is always safe to sweep (its window
+    # is a single synchronous clone call, never left half-formed across
+    # reconcile passes under a live owner).
     staging = base / ".staging"
     if staging.is_dir():
-        shutil.rmtree(staging, ignore_errors=True)
+        for child in sorted(staging.iterdir()):
+            if not child.is_dir():
+                continue
+            child_state = _read_install_state(child)
+            child_pid = child_state.get("pid") if child_state else None
+            if isinstance(child_pid, int) and child_pid > 0 and pid_alive(child_pid):
+                continue
+            shutil.rmtree(child, ignore_errors=True)
     return rolled_back
 
 
@@ -626,103 +801,125 @@ async def handle(op: PluginInstallIROp, ctx: OpContext) -> dict:
                      "~/.reyn/plugins/. This is a path-containment violation.",
         }
 
-    # ── 3. Name-collision precedence (§3.8/§3.10) ─────────────────────────────
-    existing_state = _read_install_state(plugin_root)
-    existing_kind = None
-    if plugin_root.is_dir() and existing_state is None:
-        # A completed prior install has no _install_state.json marker (cleared
-        # on success) — its own kind is recorded in .reyn-plugin/plugin.json's
-        # sibling manifest read is not authoritative for SOURCE kind, so a
-        # completed install's provenance is tracked via a lightweight sidecar
-        # written alongside the manifest at registration time (below).
-        existing_kind = _read_completed_kind(plugin_root)
-    if existing_kind is not None and existing_kind != source_kind:
-        winner = resolve_name_collision([existing_kind, source_kind])
-        if winner != source_kind:
-            if staging_cleanup:
-                shutil.rmtree(staging_cleanup, ignore_errors=True)
-            return {
-                "kind": "plugin_install", "status": "skipped", "name": safe_name,
-                "error": f"plugin {safe_name!r} is already installed from a "
-                         f"higher-trust {existing_kind!r} source; refusing to "
-                         f"shadow it with a {source_kind!r} source (ADR 0064 "
-                         "§3.8 precedence: builtin <= local << git).",
-            }
+    # ── 3.–8. Per-name-locked mutation (#3212 layer b) ────────────────────────
+    # Everything from the name-collision check (which READS plugin_root's
+    # current state) through completion is serialized against any concurrent
+    # plugin_install/plugin_uninstall of the SAME name — so a collision
+    # decision, the copy, and the register/complete steps all observe (and
+    # leave) a consistent state, and a concurrent uninstall's rmtree can never
+    # interleave with this copy.
+    async with plugin_name_lock(safe_name, root):
+        # ── 3. Name-collision precedence (§3.8/§3.10) ─────────────────────────
+        existing_state = _read_install_state(plugin_root)
+        existing_kind = None
+        if plugin_root.is_dir() and existing_state is None:
+            # A completed prior install has no _install_state.json marker
+            # (cleared on success) — its own kind is recorded in a lightweight
+            # sidecar written alongside the manifest at registration time
+            # (below), since the manifest itself carries no source-kind field.
+            existing_kind = _read_completed_kind(plugin_root)
+        if existing_kind is not None and existing_kind != source_kind:
+            winner = resolve_name_collision([existing_kind, source_kind])
+            if winner != source_kind:
+                if staging_cleanup:
+                    shutil.rmtree(staging_cleanup, ignore_errors=True)
+                return {
+                    "kind": "plugin_install", "status": "skipped", "name": safe_name,
+                    "error": f"plugin {safe_name!r} is already installed from a "
+                             f"higher-trust {existing_kind!r} source; refusing to "
+                             f"shadow it with a {source_kind!r} source (ADR 0064 "
+                             "§3.8 precedence: builtin <= local << git).",
+                }
 
-    ctx.events.emit("plugin_install_started", name=safe_name, source_kind=source_kind)
+        ctx.events.emit("plugin_install_started", name=safe_name, source_kind=source_kind)
 
-    # ── 4. Permission gate 1 — global-copy write outside the workspace ────────
-    if ctx.permission_resolver is not None:
-        sandbox = _sandbox_policy_from_ctx(ctx)
-        await ctx.permission_resolver.require_file_write(
-            ctx.permission_decl, str(plugin_root), ctx.actor,
-            sandbox_policy=sandbox, bus=ctx.intervention_bus,
-        )
-
-    # ── 5. Copy ─────────────────────────────────────────────────────────────
-    plugin_root.mkdir(parents=True, exist_ok=True)
-    _write_install_state(plugin_root, source_kind)
-    _copy_plugin_tree(source_dir, plugin_root)
-    if staging_cleanup:
-        shutil.rmtree(staging_cleanup, ignore_errors=True)
-    ctx.events.emit("plugin_install_copied", name=safe_name, plugin_root=str(plugin_root))
-
-    # ── 6. Expand ${REYN_*} stable-location tokens ────────────────────────────
-    token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=project_root)
-    _expand_plugin_files(plugin_root, token_ctx)
-
-    # ── 7. Register capabilities (#3209: register-only — no dep materialise) ──
-    manifest_path = manifest_path_for(plugin_root)
-    reloaded_manifest = load_plugin_manifest(plugin_root) if manifest_path.exists() else manifest
-    registered: dict[str, list] = {"mcp": [], "pipelines": [], "skills": []}
-
-    for cap in reloaded_manifest.capabilities:
-        if cap.kind == "mcp":
-            registered["mcp"] = await _register_mcp(
-                plugin_root, safe_name, ctx, project_root,
+        # ── 4. Permission gate 1 — global-copy write outside the workspace ────
+        if ctx.permission_resolver is not None:
+            sandbox = _sandbox_policy_from_ctx(ctx)
+            await ctx.permission_resolver.require_file_write(
+                ctx.permission_decl, str(plugin_root), ctx.actor,
+                sandbox_policy=sandbox, bus=ctx.intervention_bus,
             )
-        elif cap.kind == "pipelines":
-            pipelines_dir = plugin_root / "pipelines"
-            files = (
-                [pipelines_dir / e for e in cap.entries]
-                if cap.entries
-                else (sorted(pipelines_dir.glob("*.yaml")) if pipelines_dir.is_dir() else [])
-            )
-            for dsl_file in files:
-                sub_op = PipelineInstallIROp(
-                    kind="pipeline_install", path=str(dsl_file), plugin_id=safe_name,
+
+        # ── 5. Copy — atomic temp-then-rename (#3212 layer c) ──────────────────
+        # Build the full new tree in a UNIQUE staging dir under the same
+        # ~/.reyn/plugins/ filesystem (so the final swap is an atomic
+        # Path.replace), carrying the SAME _install_state.json marker it will
+        # be renamed into place with (reconcile's liveness check above applies
+        # to it unchanged, whether it is still under .staging/ or has already
+        # been renamed to plugin_root). A concurrent reader resolving
+        # plugin_root's absolute path always sees either the complete old tree
+        # or the complete new one — never a half-copied one.
+        atomic_staging = root / ".staging" / f"{safe_name}-{uuid4().hex}"
+        atomic_staging.mkdir(parents=True, exist_ok=True)
+        _write_install_state(atomic_staging, source_kind)
+        _copy_plugin_tree(source_dir, atomic_staging)
+        if staging_cleanup:
+            shutil.rmtree(staging_cleanup, ignore_errors=True)
+        if plugin_root.exists():
+            # Updating an existing install: replace it wholesale (clean
+            # atomic swap) rather than merging over stale files the new
+            # source no longer carries.
+            shutil.rmtree(plugin_root, ignore_errors=True)
+        atomic_staging.replace(plugin_root)
+        ctx.events.emit("plugin_install_copied", name=safe_name, plugin_root=str(plugin_root))
+
+        # ── 6. Expand ${REYN_*} stable-location tokens ─────────────────────────
+        token_ctx = PluginTokenContext(plugin_root=plugin_root, project_dir=project_root)
+        _expand_plugin_files(plugin_root, token_ctx)
+
+        # ── 7. Register capabilities (#3209: register-only — no dep materialise) ──
+        manifest_path = manifest_path_for(plugin_root)
+        reloaded_manifest = load_plugin_manifest(plugin_root) if manifest_path.exists() else manifest
+        registered: dict[str, list] = {"mcp": [], "pipelines": [], "skills": []}
+
+        for cap in reloaded_manifest.capabilities:
+            if cap.kind == "mcp":
+                registered["mcp"] = await _register_mcp(
+                    plugin_root, safe_name, ctx, project_root,
                 )
-                sub_result = await _pipeline_install_handle(sub_op, ctx)
-                registered["pipelines"].append(sub_result)
-        elif cap.kind == "skills":
-            skills_dir = plugin_root / "skills"
-            dirs = (
-                [skills_dir / e for e in cap.entries]
-                if cap.entries
-                else (sorted(p for p in skills_dir.glob("*") if p.is_dir()) if skills_dir.is_dir() else [])
-            )
-            for skill_dir in dirs:
-                sub_op = SkillInstallIROp(
-                    kind="skill_install", path=str(skill_dir), plugin_id=safe_name,
+            elif cap.kind == "pipelines":
+                pipelines_dir = plugin_root / "pipelines"
+                files = (
+                    [pipelines_dir / e for e in cap.entries]
+                    if cap.entries
+                    else (sorted(pipelines_dir.glob("*.yaml")) if pipelines_dir.is_dir() else [])
                 )
-                sub_result = await _skill_install_handle(sub_op, ctx)
-                registered["skills"].append(sub_result)
+                for dsl_file in files:
+                    sub_op = PipelineInstallIROp(
+                        kind="pipeline_install", path=str(dsl_file), plugin_id=safe_name,
+                    )
+                    sub_result = await _pipeline_install_handle(sub_op, ctx)
+                    registered["pipelines"].append(sub_result)
+            elif cap.kind == "skills":
+                skills_dir = plugin_root / "skills"
+                dirs = (
+                    [skills_dir / e for e in cap.entries]
+                    if cap.entries
+                    else (sorted(p for p in skills_dir.glob("*") if p.is_dir()) if skills_dir.is_dir() else [])
+                )
+                for skill_dir in dirs:
+                    sub_op = SkillInstallIROp(
+                        kind="skill_install", path=str(skill_dir), plugin_id=safe_name,
+                    )
+                    sub_result = await _skill_install_handle(sub_op, ctx)
+                    registered["skills"].append(sub_result)
 
-    ctx.events.emit("plugin_install_registered", name=safe_name, registered=registered)
+        ctx.events.emit("plugin_install_registered", name=safe_name, registered=registered)
 
-    # ── 8. Complete ────────────────────────────────────────────────────────────
-    _clear_install_state(plugin_root)
-    _write_completed_kind(plugin_root, source_kind)
-    ctx.events.emit("plugin_install_completed", name=safe_name)
+        # ── 8. Complete ────────────────────────────────────────────────────────
+        _clear_install_state(plugin_root)
+        _write_completed_kind(plugin_root, source_kind)
+        ctx.events.emit("plugin_install_completed", name=safe_name)
 
-    return {
-        "status": "installed",
-        "name": safe_name,
-        "plugin_root": str(plugin_root),
-        "source_kind": source_kind,
-        "capabilities": sorted(reloaded_manifest.capability_kinds),
-        "registered": registered,
-    }
+        return {
+            "status": "installed",
+            "name": safe_name,
+            "plugin_root": str(plugin_root),
+            "source_kind": source_kind,
+            "capabilities": sorted(reloaded_manifest.capability_kinds),
+            "registered": registered,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/src/reyn/core/op_runtime/plugin_uninstall.py
+++ b/src/reyn/core/op_runtime/plugin_uninstall.py
@@ -11,6 +11,16 @@ explicitly).
 Not WAL-derived (§3.11): same rationale as ``plugin_install`` — these are
 file/registry mutations, not WAL-event-derived state, so the CLAUDE.md
 truncate-falsify recovery gate does not apply.
+
+**Concurrency (#3212)**: both the registry-drop and the copy-removal below
+are wrapped in ``plugin_install.plugin_name_lock`` — the SAME per-name,
+blocking, bounded-wait, cross-process advisory lock ``plugin_install``
+takes around its own copy/register/complete steps. Without this, an
+uninstall's ``rmtree`` of ``~/.reyn/plugins/<name>/`` could interleave with
+a concurrent install of the same name's ``copytree`` (or vice versa),
+corrupting the shared global copy mid-write. See ``plugin_install.py``'s
+module docstring for the full #3212 write-up (liveness-aware reconcile +
+this lock + atomic-rename copy, the three layers together).
 """
 from __future__ import annotations
 
@@ -24,6 +34,7 @@ from .context import OpContext
 from .context import sandbox_policy_from_ctx as _sandbox_policy_from_ctx
 from .plugin_install import (
     drop_entries_by_plugin_id,
+    plugin_name_lock,
     plugins_root,
     registry_config_paths,
     registry_entries_section,
@@ -75,49 +86,56 @@ async def handle(op: PluginUninstallIROp, ctx: OpContext) -> dict:
 
     ctx.events.emit("plugin_uninstall_started", name=name)
 
-    # ── 1. Drop registry entries FIRST (§3.11 crash-safety ordering) ─────────
-    removed: dict[str, list[str]] = {}
-    for registry_kind, config_path in registry_config_paths(project_root).items():
-        removed[registry_kind] = await _drop_plugin_entries(registry_kind, config_path, name, ctx)
-
-    if any(removed.values()):
-        from reyn.runtime.hot_reload import dispatch_install_reload
-        # A drop is a same-name-removal, not a pure addition — it always
-        # takes the deferred turn-boundary reload path (mirrors
-        # mcp_drop_server's non-immediate-apply behavior); dispatch_install_reload
-        # with is_addition=False routes there uniformly across all three seams.
-        for registry_kind in ("mcp", "pipelines", "skills"):
-            if removed.get(registry_kind):
-                seam_source = {
-                    "mcp": "mcp__install_local", "pipelines": "pipeline_install",
-                    "skills": "skill_install",
-                }[registry_kind]
-                await dispatch_install_reload(
-                    getattr(ctx, "hot_reloader", None), source=seam_source, is_addition=False,
-                )
-
-    ctx.events.emit("plugin_uninstall_registry_dropped", name=name, removed=removed)
-
-    # ── 2. Remove the global copy ─────────────────────────────────────────────
-    plugin_root = plugins_root() / name
-    copy_removed = plugin_root.is_dir()
-    if copy_removed:
-        if ctx.permission_resolver is not None:
-            sandbox = _sandbox_policy_from_ctx(ctx)
-            await ctx.permission_resolver.require_file_write(
-                ctx.permission_decl, str(plugin_root), ctx.actor,
-                sandbox_policy=sandbox, bus=ctx.intervention_bus,
+    root = plugins_root()
+    # ── #3212 layer b: same per-name lock plugin_install takes — serializes
+    # this uninstall's registry-drop + rmtree against a concurrent install/
+    # uninstall of the SAME name so a copytree/rmtree can never interleave.
+    async with plugin_name_lock(name, root):
+        # ── 1. Drop registry entries FIRST (§3.11 crash-safety ordering) ─────
+        removed: dict[str, list[str]] = {}
+        for registry_kind, config_path in registry_config_paths(project_root).items():
+            removed[registry_kind] = await _drop_plugin_entries(
+                registry_kind, config_path, name, ctx,
             )
-        shutil.rmtree(plugin_root, ignore_errors=True)
 
-    ctx.events.emit("plugin_uninstall_completed", name=name, copy_removed=copy_removed)
+        if any(removed.values()):
+            from reyn.runtime.hot_reload import dispatch_install_reload
+            # A drop is a same-name-removal, not a pure addition — it always
+            # takes the deferred turn-boundary reload path (mirrors
+            # mcp_drop_server's non-immediate-apply behavior); dispatch_install_reload
+            # with is_addition=False routes there uniformly across all three seams.
+            for registry_kind in ("mcp", "pipelines", "skills"):
+                if removed.get(registry_kind):
+                    seam_source = {
+                        "mcp": "mcp__install_local", "pipelines": "pipeline_install",
+                        "skills": "skill_install",
+                    }[registry_kind]
+                    await dispatch_install_reload(
+                        getattr(ctx, "hot_reloader", None), source=seam_source, is_addition=False,
+                    )
 
-    return {
-        "status": "uninstalled",
-        "name": name,
-        "removed": removed,
-        "copy_removed": copy_removed,
-    }
+        ctx.events.emit("plugin_uninstall_registry_dropped", name=name, removed=removed)
+
+        # ── 2. Remove the global copy ─────────────────────────────────────────
+        plugin_root = root / name
+        copy_removed = plugin_root.is_dir()
+        if copy_removed:
+            if ctx.permission_resolver is not None:
+                sandbox = _sandbox_policy_from_ctx(ctx)
+                await ctx.permission_resolver.require_file_write(
+                    ctx.permission_decl, str(plugin_root), ctx.actor,
+                    sandbox_policy=sandbox, bus=ctx.intervention_bus,
+                )
+            shutil.rmtree(plugin_root, ignore_errors=True)
+
+        ctx.events.emit("plugin_uninstall_completed", name=name, copy_removed=copy_removed)
+
+        return {
+            "status": "uninstalled",
+            "name": name,
+            "removed": removed,
+            "copy_removed": copy_removed,
+        }
 
 
 from reyn.core.offload.canonical import STRUCTURED_PASSTHROUGH  # noqa: E402

--- a/tests/test_3212_plugin_install_concurrency.py
+++ b/tests/test_3212_plugin_install_concurrency.py
@@ -1,0 +1,279 @@
+"""Tier 2: OS invariant — #3212 plugin install/uninstall concurrency fix.
+
+#3212 root cause: ``reconcile_plugin_installs`` (step 0 of ``plugin_install``)
+could not distinguish a genuinely-crashed partial install (an
+``_install_state.json`` marker left behind by a dead process) from a
+CONCURRENT still-in-progress install of the SAME name (marker present, owner
+very much alive) — both looked identical, so a concurrent reconcile could
+``rmtree`` a live install mid-copy (the reported symptom: ``rag_ingest``/
+``rag_query`` FAILED "No such file or directory" under concurrent
+install/uninstall cycles). ``~/.reyn/plugins/`` stays a DELIBERATE single
+global path (ADR 0064 §3.3 "install once, use everywhere") — this is a pure
+concurrency-correctness fix, no scope change.
+
+Tests:
+  1. THE RACE (primary #3212 symptom): a marker with a LIVE pid (the current
+     process) is NOT wiped by reconcile — a concurrent in-flight install is
+     respected, not treated as crashed.
+  2. Crash-partial rollback (recovery correctness): a marker with a DEAD pid
+     IS rolled back — reconcile can still tell a genuine crash from a live
+     install; #1 and #2 together are the discriminator #3212 requires.
+  3. Atomic rename: the copy is staged into a temp dir under
+     ``~/.reyn/plugins/.staging/`` and only appears at the final
+     ``plugin_root`` via an atomic ``Path.replace`` — a reader never
+     observes a partially-copied tree at the final path, and no staging
+     leftovers survive a successful install.
+  4. Lock serialization: ``plugin_name_lock`` (the same per-name lock
+     ``plugin_install``/``plugin_uninstall`` take around their mutating
+     steps) blocks a second acquirer of the same name and raises
+     ``TimeoutError`` on a bounded wait rather than allowing the two to
+     interleave. Tested via the lock primitive directly (deterministic, no
+     sleep-races).
+  5. Legacy marker (no pid field): a pre-#3212 marker with no ``pid`` key is
+     treated as crashed (rolled back) — matches ``reconcile_plugin_installs``'
+     documented "dead / missing / legacy marker -> roll back" contract.
+
+Real filesystem (HOME monkeypatched to a tmp dir) throughout — no mocks.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+
+import pytest
+
+from reyn.core.op_runtime import plugin_install
+from reyn.core.op_runtime.context import OpContext
+from reyn.core.op_runtime.plugin_install import (
+    _install_state_path,
+    _write_install_state,
+    plugin_name_lock,
+    plugins_root,
+    reconcile_plugin_installs,
+)
+from reyn.core.op_runtime.plugin_install import handle as install_handle
+from reyn.schemas.models import PluginInstallIROp
+from reyn.security.permissions.permissions import PermissionDecl, PermissionResolver
+
+# A PID very unlikely to be allocated on any kernel (mirrors the existing
+# precedent in tests/test_action_embedding_index_concurrency.py).
+_DEAD_PID = 2**31 - 1
+
+
+class _StubWorkspace:
+    def __init__(self, base_dir) -> None:
+        self.base_dir = base_dir
+
+
+class _Events:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    def emit(self, *args, **kwargs) -> None:
+        self.calls.append((args, kwargs))
+
+
+def _make_ctx(tmp_path):
+    """A real OpContext + PermissionResolver, session-approving the global
+    plugin-copy write + registry writes — same shape as test_plugin_install.py's
+    ``_make_ctx`` (approve-everything baseline; this file is not testing the
+    permission gates, those already have dedicated coverage)."""
+    project_root = tmp_path / "proj"
+    project_root.mkdir(parents=True, exist_ok=True)
+    resolver = PermissionResolver(config_permissions={}, project_root=project_root, interactive=False)
+    resolver.session_approve_path(str(plugins_root()), "test", "file.write", recursive=True)
+    for cfg in ("pipelines.yaml", "skills.yaml", "mcp.yaml"):
+        resolver.session_approve_path(
+            str(project_root / ".reyn" / "config" / cfg), "test", "file.write",
+        )
+    decl = PermissionDecl(file_write=[{"path": str(plugins_root()), "scope": "recursive"}])
+    return OpContext(
+        workspace=_StubWorkspace(base_dir=project_root),
+        events=_Events(),
+        permission_decl=decl,
+        permission_resolver=resolver,
+        actor="test",
+        intervention_bus=None,
+    )
+
+
+def _make_plugin_source(base, name: str = "concplugin"):
+    plugin_dir = base / name
+    (plugin_dir / ".reyn-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / ".reyn-plugin" / "plugin.json").write_text(
+        json.dumps({
+            "name": name, "version": "0.1.0", "description": "concurrency test plugin",
+            "capabilities": [{"kind": "skills"}],
+        }),
+        encoding="utf-8",
+    )
+    (plugin_dir / "skills" / "hello").mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "skills" / "hello" / "SKILL.md").write_text(
+        "---\nname: hello\ndescription: says hi\n---\n\nBody.\n", encoding="utf-8",
+    )
+    return plugin_dir
+
+
+# ── Test 1: the race — a LIVE marker is NOT wiped ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_live_concurrent_install(tmp_path, monkeypatch):
+    """Tier 2: #3212 THE RACE — a marker whose pid is the CURRENT (alive)
+    process models a concurrent, still-in-progress install of this name.
+    reconcile must NOT wipe it. RED (pre-#3212 behavior) if this entry is
+    rolled back — that is the exact symptom: a concurrent reconcile wiping a
+    live install's in-flight copy mid-run."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    in_flight = plugins_root() / "in-flight-plugin"
+    (in_flight / "skills" / "s").mkdir(parents=True)
+    _write_install_state(in_flight, "local", pid=os.getpid())
+
+    rolled_back = await reconcile_plugin_installs(plugins_root())
+
+    assert rolled_back == [], (
+        "reconcile wiped a marker with a LIVE pid — the exact #3212 race "
+        "(a concurrent in-flight install looked identical to a crashed one)"
+    )
+    assert in_flight.exists(), "the live in-flight install's copy was deleted"
+    assert _install_state_path(in_flight).exists(), "the live marker was removed"
+
+
+# ── Test 2: crash-partial rollback — a DEAD marker IS wiped ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rolls_back_dead_pid_partial(tmp_path, monkeypatch):
+    """Tier 2: recovery-reconstruction correctness witness — a marker with a
+    DEAD pid (crashed process) is still rolled back, same as pre-#3212. This
+    is the discriminator: #1 (live -> keep) and #2 (dead -> roll back) prove
+    reconcile can tell the two apart, which is the whole #3212 fix."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    assert not plugin_install.pid_alive(_DEAD_PID), (
+        f"precondition: PID {_DEAD_PID} must not be alive for this test"
+    )
+
+    crashed = plugins_root() / "crashed-plugin"
+    (crashed / "skills" / "s").mkdir(parents=True)
+    _write_install_state(crashed, "local", pid=_DEAD_PID)
+
+    rolled_back = await reconcile_plugin_installs(plugins_root())
+
+    assert rolled_back == ["crashed-plugin"]
+    assert not crashed.exists(), "a dead-pid crashed partial was not rolled back"
+
+
+# ── Test 3: atomic rename copy ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_install_copy_is_staged_then_atomically_renamed(tmp_path, monkeypatch):
+    """Tier 2: #3212 layer c — the copy is built in a unique staging dir
+    under ``.staging/`` and only appears at the final ``plugin_root`` via an
+    atomic ``Path.replace``: while ``_copy_plugin_tree`` is writing, the
+    FINAL destination does not exist yet (nothing for a concurrent reader to
+    observe half-formed); after a successful install, no staging leftovers
+    remain. RED if the copy writes directly into ``plugin_root`` (pre-#3212:
+    a concurrent reader could see a partially-copied tree)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    source = _make_plugin_source(tmp_path / "src")
+    ctx = _make_ctx(tmp_path)
+
+    final_root = plugins_root() / "concplugin"
+    observed_dest_paths: list = []
+    real_copy = plugin_install._copy_plugin_tree
+
+    def _spy_copy(src_dir, dest_dir):
+        observed_dest_paths.append(dest_dir)
+        # While the copy is happening, the FINAL path must not exist yet —
+        # the tree is being built in staging, not in place.
+        assert not final_root.exists(), (
+            "plugin_root exists WHILE the copy is still in progress — the "
+            "copy is not staged, a concurrent reader could see a partial tree"
+        )
+        real_copy(src_dir, dest_dir)
+
+    monkeypatch.setattr(plugin_install, "_copy_plugin_tree", _spy_copy)
+
+    op = PluginInstallIROp(kind="plugin_install", source={"kind": "local", "path": str(source)})
+    result = await install_handle(op, ctx)
+
+    assert result["status"] == "installed", f"install failed: {result}"
+    assert observed_dest_paths, "the copy spy was never invoked"
+    assert observed_dest_paths[0] != final_root, "copy wrote directly to plugin_root, not a staging dir"
+    assert observed_dest_paths[0].parent.name == ".staging"
+
+    assert final_root.is_dir(), "the final plugin_root was never populated (rename missing)"
+    assert (final_root / "skills" / "hello" / "SKILL.md").exists()
+
+    staging_root = plugins_root() / ".staging"
+    remaining = [p for p in staging_root.iterdir()] if staging_root.is_dir() else []
+    assert remaining == [], f"staging leftovers survived a successful install: {remaining}"
+
+
+# ── Test 4: lock serialization (deterministic — the primitive directly) ──────
+
+
+@pytest.mark.asyncio
+async def test_plugin_name_lock_blocks_and_times_out(tmp_path):
+    """Tier 2: #3212 layer b — ``plugin_name_lock`` serializes mutations on
+    the same plugin name: while one holder has the lock, a second acquirer
+    for the SAME name times out (``TimeoutError``) rather than proceeding
+    concurrently (which is exactly what would let an install's copytree
+    interleave with an uninstall's rmtree). Uses the lock primitive directly
+    (no real subprocess/thread races needed — deterministic)."""
+    root = tmp_path / "plugins"
+
+    async with plugin_name_lock("shared-name", root, timeout=1.0):
+        with pytest.raises(TimeoutError):
+            async with plugin_name_lock("shared-name", root, timeout=0.2):
+                pytest.fail("should never enter — the outer lock is still held")
+
+    # A DIFFERENT name is not blocked by the first name's lock.
+    async with plugin_name_lock("other-name", root, timeout=1.0):
+        pass
+
+    # After the outer lock above is released, the SAME name is acquirable again.
+    async with plugin_name_lock("shared-name", root, timeout=1.0):
+        pass
+
+
+# ── Test 5: legacy marker (no pid field) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_treats_legacy_no_pid_marker_as_crashed(tmp_path, monkeypatch):
+    """Tier 2: a pre-#3212 marker with no ``pid`` key at all (written by an
+    older reyn version, or corrupted) is treated as crashed and rolled back —
+    matches ``reconcile_plugin_installs``' documented contract ("dead /
+    missing / legacy marker -> roll back as today"). Err-safe direction is
+    KEEP-on-live-pid (test 1); a marker that carries no liveness signal at
+    all falls back to the pre-#3212 default of rolling it back."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    legacy = plugins_root() / "legacy-plugin"
+    (legacy / "skills" / "s").mkdir(parents=True)
+    state_path = _install_state_path(legacy)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"name": "legacy-plugin", "kind": "local", "status": "installing"}),
+        encoding="utf-8",
+    )
+    assert "pid" not in json.loads(state_path.read_text(encoding="utf-8"))
+
+    rolled_back = await reconcile_plugin_installs(plugins_root())
+
+    assert rolled_back == ["legacy-plugin"]
+    assert not legacy.exists(), "a legacy no-pid marker was not treated as crashed"

--- a/tests/test_plugin_install.py
+++ b/tests/test_plugin_install.py
@@ -414,9 +414,14 @@ async def test_reconcile_rolls_back_partial_install_registry_and_copy(tmp_path, 
     project_root.mkdir()
 
     # A partial copy (marker present = never completed) that DID register a skill.
+    # #3212: the marker now carries a pid; a DEAD pid is what distinguishes a
+    # genuinely-crashed partial (this test) from a concurrent still-in-progress
+    # install of the same name (test_3212's "the race" scenario) — the current
+    # process (an alive pid) would be treated as a live, in-progress install
+    # and correctly SKIPPED rather than rolled back.
     partial = plugins_root() / "crashed-plugin"
     (partial / "skills" / "s").mkdir(parents=True)
-    _write_install_state(partial, "local")
+    _write_install_state(partial, "local", pid=2**31 - 1)
 
     skills_yaml = project_root / ".reyn" / "config" / "skills.yaml"
     skills_yaml.parent.mkdir(parents=True, exist_ok=True)
@@ -458,7 +463,7 @@ def test_reconcile_bare_sweep_without_project_root_drops_only_copies(tmp_path, m
 
     partial = plugins_root() / "crashed"
     partial.mkdir(parents=True)
-    _write_install_state(partial, "git")
+    _write_install_state(partial, "git", pid=2**31 - 1)  # #3212: dead pid = crashed
     completed = plugins_root() / "done"
     completed.mkdir(parents=True)
 


### PR DESCRIPTION
[per-PR-coder] — Closes #3212

## Root cause (verified)

`plugin_install`'s step 0, `reconcile_plugin_installs` (`src/reyn/core/op_runtime/plugin_install.py`), iterates every entry under the shared global `~/.reyn/plugins/` and, for any entry whose `_install_state.json` marker is present, treats it as a crashed partial → drops its registry entries + `shutil.rmtree`. The marker carried **no pid/ts liveness signal**, so a concurrent, still-in-progress `plugin_install` of the SAME plugin name looked identical to a crashed one → a concurrent session's reconcile could wipe another session's in-flight copy mid-run. Reported symptom: `rag_ingest`/`rag_query` FAILED "No such file or directory" under concurrent install/uninstall cycles (#3210 live e2e, reproduced independently by dogfood-coder + tui-coder). `plugin_uninstall` also `rmtree`'d the whole plugin dir with no lock vs. a concurrent install's `copytree`.

**`~/.reyn/plugins/` stays global** (ADR 0064 §3.3 "install once, use everywhere") — this PR does NOT re-litigate scope; it is a pure concurrency-correctness fix, no schema/registry-format change.

## The fix — 3 layers (all required)

**(a) Liveness-aware reconcile.** `_write_install_state` now stamps `{pid, ts}` on the marker (mirrors the shape already used by `reyn.data.index.build_lock`). `reconcile_plugin_installs` checks liveness **per entry** via `build_lock.pid_alive`: a live owner is SKIPPED (an in-flight concurrent install, not a crash); only a dead/missing/legacy (no-`pid`) marker is treated as crashed and rolled back, same as before. This closes the reported race directly.

**(b) Blocking per-plugin-name cross-process lock.** `plugin_name_lock` (new, in `plugin_install.py`, imported by `plugin_uninstall.py`) reuses `build_lock.py`'s `{pid, ts}` marker-file primitives (`pid_alive` / `read_lock_holder` / `write_lock_marker` / `remove_lock_marker`) for the atomic take + stale-lock reclaim, but with **BLOCKING, bounded-wait** semantics — **30s timeout**, then `TimeoutError` — rather than `build_lock`'s take-or-skip contract (a skipped uninstall would silently surprise the operator). It wraps `plugin_install.handle`'s name-collision-check → copy → register → complete steps, and `plugin_uninstall.handle`'s registry-drop → copy-removal steps, for the same name. `reconcile_plugin_installs`' own rollback also takes this lock (5s timeout) before touching an entry — so the reconcile sweep can never race a live mutator either; if the lock can't be acquired promptly, that entry is left for the next reconcile pass rather than forced.

**(c) Atomic temp-then-rename copy.** The content copy is now staged into a unique `~/.reyn/plugins/.staging/<name>-<uuid>/` dir (same filesystem as the target, so the final move is an atomic `Path.replace`) and only swapped into `plugin_root` once fully populated. A concurrent reader (e.g. `pipe list` resolving a registered absolute path) always sees either the complete old tree or the complete new one, never a half-copied one. The staging dir carries the SAME `_install_state.json` marker it will be renamed into place with, so reconcile's `.staging` sweep is liveness-aware too (not a blanket wipe that would nuke a concurrent install's in-progress staging).

Why all three: (a)+(c) give reader-safety (a concurrent reconcile or file-read never sees/wipes a live, half-formed install); (b) gives writer-serialization (an install's `copytree` and an uninstall's/another install's `rmtree`/`copytree` on the same name can never interleave). (a) alone would still leave (b)/(c)'s races open; (b) alone wouldn't fix reconcile's own live-vs-crashed ambiguity.

## Tests — `tests/test_3212_plugin_install_concurrency.py` (Tier 2, real filesystem, no mocks)

1. **The race (primary)**: a marker with a LIVE pid (current process) → reconcile does NOT wipe it. PASS.
2. **Crash-partial rollback**: a marker with a DEAD pid (`2**31-1`, mirrors the existing `pid_alive` test precedent) → reconcile DOES roll it back. PASS.
3. **Atomic rename**: spies on `_copy_plugin_tree` to assert the final `plugin_root` does not exist while the copy is in progress (staging-only), and that no `.staging` leftovers survive a successful install. PASS.
4. **Lock serialization**: `plugin_name_lock` tested directly (deterministic, no sleep-races) — a second acquirer of the same name times out (`TimeoutError`) while the first holds it; a different name is unaffected; the name is acquirable again after release. PASS.
5. **Legacy marker (no pid field)**: a pre-#3212 marker with no `pid` key is treated as crashed and rolled back (matches the documented "dead/missing/legacy -> roll back" contract). PASS.

Existing `tests/test_plugin_install.py` reconcile tests (`test_reconcile_rolls_back_partial_install_registry_and_copy`, `test_reconcile_bare_sweep_without_project_root_drops_only_copies`) were updated to pass an explicit DEAD pid to `_write_install_state` — under the new liveness semantics, the test process's OWN (alive) pid would otherwise be (correctly) treated as a live concurrent install rather than a crash, which is the exact discriminator #3212 requires.

## Test plan

- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict tests/test_3212_plugin_install_concurrency.py` (5/5, 0 Tier-4 violations)
- [x] `python -m pytest tests/test_3212_plugin_install_concurrency.py tests/test_plugin_install.py -q` (23 passed — no separate `test_plugin_uninstall.py` file exists; uninstall coverage lives in `test_plugin_install.py`)
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/op_runtime/plugin_install.py src/reyn/core/op_runtime/plugin_uninstall.py`
- [ ] Full-repo `pytest` — kicked off locally in background per CLAUDE.md guidance not to block on it; CI runs the authoritative full suite.