### PR TITLE
chore: roi:low cleanup — fix 2 stale doc lines (#3218 held back, not a real orphan)

### DIFF
--- a/docs/deep-dives/proposals/0057-rag-retrieval-redesign.md
+++ b/docs/deep-dives/proposals/0057-rag-retrieval-redesign.md
@@ -1,4 +1,4 @@
-# FP-0057 — RAG / Retrieval redesign (proposal, draft)
+# FP-0057 — RAG / Retrieval redesign (VALIDATED — partially landed)
 
 **[lead-coder]** — Owner-designed in consultation; captured for architect co-vet + phasing. **Design VALIDATED by owner; partially landed** — Phase 1 (`embed` op, #2846), Phase 2a (`index_update`+`semantic_search`, #2848), Phase 2b (retire `embed_and_index`, #2851), and Phase 4 (offline degrade, #2854) merged; the default-embedding mechanism Phase 4 covered was later superseded by #3128. The near-term-deferred scope (automatic retrieval, ephemeral-attachment auto-flow) remains unbuilt by design, not blocked on owner GO.
 

--- a/tests/_support/builtin_skill_tool_names.py
+++ b/tests/_support/builtin_skill_tool_names.py
@@ -84,7 +84,10 @@ def _internal_dispatch_target_names() -> "set[str]":
     always the #3090/#3092 drift shape — the pre-refactor "friendly" host
     function name instead of the qualified catalog name — never a false
     positive on an unrelated identifier, because these strings are reserved
-    to routing-internal use by the routing table itself."""
+    to routing-internal use by the routing table itself (#3141: this does
+    NOT exclude fenced code blocks, so a dual-use name such as
+    ``semantic_search`` shown in a legitimate Python-step example could
+    still trip this check)."""
     from reyn.tools.universal_dispatch import _OPERATION_RULES, _RESOURCE_RULES
 
     return (


### PR DESCRIPTION
[per-PR-coder] — closes 2 of the 3 originally-scoped issues; #3218 is deliberately excluded (see below).

## Change 1 (#3164) — fix stale 0057 proposal title/status
`docs/deep-dives/proposals/0057-rag-retrieval-redesign.md`'s title line said "(proposal, draft)" while the paragraph directly below it says the design is "VALIDATED by owner; partially landed". Updated the title/status line to match: `(VALIDATED — partially landed)`.

Verification: read the full body paragraph to confirm the accurate wording before applying it; only that one line changed.

## Change 2 (#3141) — soften drift-gate docstring overclaim
`tests/_support/builtin_skill_tool_names.py`'s `_internal_dispatch_target_names()` docstring claimed the bare-call check is "never a false positive ... because these strings are reserved to routing-internal use". True for the identifier match itself, but the scan does not exclude fenced code blocks in SKILL.md — a dual-use name like `semantic_search` (legitimately callable from a safe-mode Python step per CLAUDE.md) shown in a Python example would still trip the check. Added a short parenthetical acknowledging this (architect's preferred option 1 from #3141 — soften the docstring, keep the gate fail-closed; did not touch gate logic).

Verification: confirmed via `gh issue view 3141` that this is the exact docstring + exact architect-preferred fix; re-ran `tests/test_builtin_skill_tool_name_drift_3092.py` (the gate consuming this helper) — still green, no logic changed.

## #3218 — NOT included, stopping per guardrail
The brief characterized `ReynConfig.mcp_search_threshold` as a dead orphan safe to delete. On inspection this does not hold:

- `tests/test_config_mcp_merge_1146.py`, `tests/test_config_schema_enforcement_1056.py`, `tests/test_config_schema_introspection.py`, and `tests/test_config_loader_pure_helpers.py` all assert real Tier 2 OS-invariant behavior against `ReynConfig.mcp_search_threshold` / `_parse_mcp_search_threshold` (merge-preservation of the `mcp.search_threshold` operator key, schema-internal-flag omission from `walk_config_schema`, parse-helper clamping behavior).
- `src/reyn/config/root.py:174-183` documents the field as *deliberately* `schema_internal` — parsed-but-not-yet-threaded-to-`build_tools()` is a documented, intentional pending-wiring state (FP-0024 Component D), not an accidental orphan.
- Deleting it per the brief would break 4 real test files and contradict the documented design intent (the doc explicitly says a future caller should thread it through, not that it should be removed).

Per the per-PR-coder guardrail ("if ANY turns out non-trivial ... STOP and report that one — don't force it; the other two can still ship"), #3218 is left untouched here and reported back separately rather than forced into this PR. Issue #3218 is not closed by this PR.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/_support/builtin_skill_tool_names.py` — 0 test functions (helper module), no Tier violations
- [x] `python -m pytest tests/test_builtin_skill_tool_name_drift_3092.py tests/test_fp0063_p4_builtin_rag_skill.py -q` — 14 passed
- [x] `mkdocs build --strict -f .mkdocs/mkdocs.yml` — exit 0, no new warnings
- [x] (skipped — full pytest N/A, no src/ files changed; only docs + one test-support docstring touched)

Closes #3164
Closes #3141