### PR TITLE
fix(3130): on_error (continue/abort/retry) on single tool: pipeline step

### DIFF
--- a/docs/reference/runtime/pipeline-dsl.md
+++ b/docs/reference/runtime/pipeline-dsl.md
@@ -178,6 +178,7 @@ TransformBody ::= "{" "value:" EXPR ["output:" NAME] "}"
 ToolBody      ::= "{" "name:" STRING
                       ["args:" ArgMap]
                       ["schema:" NAME]
+                      ["on_error:" OnError]        (* optional — omitted = no isError check (pre-#3130 behavior) *)
                       ["output:" NAME] "}"
 ArgMap        ::= "{" (KEY ":" ArgValue ("," KEY ":" ArgValue)*)? "}"
 ArgValue      ::= LITERAL | "!expr" EXPR        (* !expr only as the WHOLE value, never nested *)
@@ -287,7 +288,39 @@ registered tool name (`web_search`).
 | `name` | yes | The tool/action name (literal string). |
 | `args` | no | Mapping of argument name → value. Each value is a **literal** unless tagged `!expr` (see [Literals vs `!expr`](#literals-vs-expr) below). |
 | `schema` | no | A registered schema name the result must conform to (`verify: schema` — see [Schemas](#schemas-verify-schema)). Non-conformance fails the step (checked against the RAW tool result, before the `text`/`structured` reduction below). |
+| `on_error` | no | (#3130) One of `continue`, `abort`, or `retry(N)` — see [`tool.on_error`](#toolon_error) below. **Omitted is a distinct state**, not a synonym for `abort`: it preserves the pre-#3130 behavior (only a raised exception fails the step; a canonical-error result — `meta.isError` — passes through unchecked, e.g. for a `schema:`-gated preflight probe to inspect downstream). |
 | `output` | no | Named store to write the result to. |
+
+#### `tool.on_error`
+
+By default (the key omitted) a `tool` step only fails on a raised exception —
+a tool that returns a *canonical-error result* (`meta.isError: true`, e.g. an
+MCP tool's `isError` branch) returns **normally**; reacting to it requires a
+downstream `schema:`-gated preflight step. `on_error` (#3130) lets a single
+`tool` step react to that natively, mirroring `for_each`/`parallel`'s
+`on_error` — same three values, same `retry(n)` regex, same retry-safety
+model (a retry re-invokes the tool: any internal side effect it has may
+re-fire, same caveat as `for_each`'s `on_error: retry(n)`):
+
+- **`abort`** — a raised exception OR a canonical-error result fails the step
+  (`PipelineExecutionError`), naming the tool's own error text.
+- **`continue`** — the step does **not** fail; instead the failure is bound to
+  `output` as a **typed error-envelope** — the SAME `{text, structured, meta:
+  {isError: true}}` shape a canonical-error tool result already takes (a
+  raised exception is rendered into that same shape). This is *not* the
+  `for_each`-style "drop the item" — a single step's `output` is a NAMED
+  binding downstream steps reference by name, so dropping it would leave an
+  unbound-variable reference; binding a discriminable error-envelope instead
+  keeps `ctx.<output>.meta.isError` inspectable downstream, symmetric with the
+  success shape.
+- **`retry(N)`** — re-run the whole step (dispatch + `schema:` validation) up
+  to `N` more times; if it still fails, falls through to `abort` (there is no
+  combined "retry then continue" value, matching `for_each`).
+
+```yaml
+- tool: {name: fetch_url, args: {url: !expr ctx.link}, on_error: continue, output: page}
+- transform: {value: "get(ctx.page, 'meta.isError', false) ? 'unreachable' : ctx.page.text", output: body}
+```
 
 #### `tool` step results
 
@@ -832,7 +865,8 @@ SchemaDoc     ::= "schema:" NAME "fields:" FieldMap
 PipelineDoc   ::= "pipeline:" NAME ("description:" STRING)? "steps:" Step+
 
 Step          ::= "transform:" "{" "value:" EXPR ["output:" NAME] "}"
-                 | "tool:"     "{" "name:" STRING ["args:" ArgMap] ["schema:" NAME] ["output:" NAME] "}"
+                 | "tool:"     "{" "name:" STRING ["args:" ArgMap] ["schema:" NAME]
+                                    ["on_error:" OnError] ["output:" NAME] "}"
                  | "agent:"    "{" "prompt:" TPL ["identity:" NAME]
                                     ["capabilities:" "{" "tools:" "[" NAME* "]" "}"]
                                     ["schema:" NAME] ["model:" NAME] ["output:" NAME] "}"
@@ -882,6 +916,12 @@ run-time step failure — never a silent wrong result):
    steps](#data-flow-between-steps).
 4. `for_each.on_error` is **required** — state `continue`/`abort`/`retry(n)`
    explicitly. `parallel.on_error` is optional and defaults to `abort`.
+   `tool.on_error` (#3130) is also optional, but — unlike `parallel` —
+   **omitted is a distinct state from `"abort"`**: omitted means no
+   canonical-error (`meta.isError`) check runs at all (only a raised
+   exception fails the step, the pre-#3130 behavior); an explicit `abort`
+   additionally fails the step on a canonical-error tool result. See
+   [`tool.on_error`](#toolon_error).
 5. A `for_each`/`parallel` item or branch cannot see any other item's or
    branch's result — only `collect` sees the merged set (an ordered list for
    `for_each`, a `{branch_name: result}` map for `parallel`).

--- a/src/reyn/core/pipeline/executor.py
+++ b/src/reyn/core/pipeline/executor.py
@@ -113,6 +113,7 @@ from reyn.core.offload.canonical import (
     canonical_degraded_reason,
     canonical_fallback_reason,
     canonical_to_ctx_fields,
+    error_to_canonical,
     extract_canonical_source,
     to_canonical,
     unwrap_dispatch_envelope,
@@ -160,12 +161,32 @@ class ToolStep:
     values wrapped in :class:`ExprRef` are resolved against the context first; other
     values pass through literally). ``schema``, if set, names a
     ``SchemaRegistry``-registered schema the step's result must conform to (verify:
-    schema) — non-conformance fails the step."""
+    schema) — non-conformance fails the step.
+
+    ``on_error`` (#3130, optional, default ``None``): mirrors the fan-out
+    steps' ``on_error: continue|abort|retry(n)`` (:class:`ForEachStep` /
+    :class:`ParallelStep`), reusing the SAME parse/validation/retry mechanism
+    (:func:`_parse_on_error`) so a single top-level ``tool:`` step can react to
+    a tool's own canonical ``meta.isError`` result WITHOUT the ``schema:
+    PreflightCheck`` crutch (#3096/#3105's "last piece").
+
+    ``None`` (the field's default AND what an omitted DSL key parses to) is a
+    DISTINCT state from the string ``"abort"`` — it means "no ``on_error`` was
+    declared" and preserves today's exact byte-identical behavior: a raised
+    exception still propagates unchanged, and a canonical-error dict result
+    (``meta.isError``) still passes through UNCHECKED (the existing
+    ``schema:``-gated preflight pattern some pipelines already rely on keeps
+    working exactly as before). Only an EXPLICIT ``on_error`` string
+    (``"abort"``/``"continue"``/``"retry(n)"``) turns on the new
+    canonical-error-aware handling in :func:`_run_tool_step` — see that
+    function's docstring for the continue/abort/retry semantics.
+    """
 
     name: str
     args: "dict[str, Any]" = field(default_factory=dict)
     output: "str | None" = None
     schema: "str | None" = None
+    on_error: "str | None" = None
 
 
 @dataclass(frozen=True)
@@ -826,6 +847,94 @@ async def _run_transform_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[
 
 
 async def _run_tool_step(inv: "_StepInvocation") -> "tuple[Any, bool, dict[str, Any]]":
+    """Dispatch a ``tool:`` step, then apply ``step.on_error`` (#3130).
+
+    ``step.on_error is None`` (the field's default, and what an omitted DSL
+    key parses to) skips ALL of the logic below entirely — :func:`_dispatch_tool_step_once`
+    is called exactly once, a raised exception propagates unchanged, and a
+    canonical-error result (``meta.isError``) is returned unchecked. This is
+    the exact byte-identical pre-#3130 behavior.
+
+    An EXPLICIT ``on_error`` reuses the fan-out ``_OnError`` mechanism
+    (:func:`_parse_on_error`) — the SAME retry-safety model ``for_each``/
+    ``parallel`` already rely on (a retry re-invokes the tool body, so any
+    internal side-effect may re-fire; the WAL only records a FINISHED step
+    once — see this module's top-of-file retry-safety notes): ``retry(n)``
+    re-attempts the WHOLE dispatch (including schema validation) up to ``n``
+    extra times; if still failing, it falls through to ``abort`` — mirroring
+    ``for_each``'s hard-coded "retry(n) exhausted -> abort" fallback (there is
+    no combined "retry then continue" DSL value, single-step or fan-out).
+
+    ``"continue"``: the failed attempt's result is bound to ``output`` as a
+    typed error-envelope — NOT the for_each-style DROPPED-item marker (that
+    only makes sense for a fan-out COLLECTION; a single step's ``output`` is a
+    NAMED binding downstream steps reference, so dropping it would leave an
+    unbound-variable reference). If the failure was a canonical-error tool
+    RESULT (``meta.isError``), that result IS ALREADY the existing typed
+    error-envelope shape (``to_canonical``/``canonical_to_ctx_fields`` — the
+    same shape a success result takes, just with ``meta.isError: True`` and
+    non-empty ``text``) and is bound as-is. If the failure was a RAISED
+    exception (no dict result to canonicalize), the SAME shape is synthesized
+    via :func:`~reyn.core.offload.canonical.error_to_canonical` — reusing the
+    codebase's one typed-error-result constructor rather than inventing a
+    second envelope shape. Either way the bound value is discriminable from a
+    success result via ``meta.isError``, symmetric with the success path.
+
+    ``"abort"`` (explicit): identical detection, but any failure — after
+    exhausting retries, if ``retry(n)`` — raises :class:`PipelineExecutionError`
+    naming the step and the tool's own error text, instead of proceeding."""
+    step: ToolStep = inv.step  # type: ignore[assignment]
+    on_err = _parse_on_error(step.on_error) if step.on_error is not None else None
+    if on_err is None:
+        # #3130 byte-identical path: no on_error declared -> exactly today's
+        # behavior (exception propagates; canonical error passes through
+        # unchecked for a schema-crutch pipeline to inspect downstream).
+        ctx_result, durable, completed = await _dispatch_tool_step_once(inv)
+        return ctx_result, durable, completed
+
+    attempts = 1 + (on_err.retries if on_err.kind == "retry" else 0)
+    last_exc: "Exception | None" = None
+    last_error_ctx: Any = None
+    for _attempt in range(attempts):
+        try:
+            ctx_result, durable, completed = await _dispatch_tool_step_once(inv)
+        except Exception as exc:  # noqa: BLE001 - on_error policy boundary (#3130)
+            last_exc = exc
+            last_error_ctx = None
+            continue
+        canonical_error = _tool_step_canonical_error(step, ctx_result)
+        if canonical_error is None:
+            return ctx_result, durable, completed
+        last_exc = None
+        last_error_ctx = ctx_result
+
+    if on_err.kind == "continue":
+        if last_error_ctx is not None:
+            return last_error_ctx, True, inv.completed_step_results
+        envelope = canonical_to_ctx_fields(error_to_canonical({"error": str(last_exc)}))
+        return envelope, True, inv.completed_step_results
+
+    reason = str(last_exc) if last_exc is not None else _tool_step_canonical_error(
+        step, last_error_ctx
+    )
+    raise PipelineExecutionError(
+        f"step {inv.step_label} (tool {step.name!r}) failed "
+        f"(on_error={step.on_error!r}): {reason}"
+    )
+
+
+async def _dispatch_tool_step_once(
+    inv: "_StepInvocation",
+) -> "tuple[Any, bool, dict[str, Any]]":
+    """One dispatch attempt of a ``tool:`` step — the pre-#3130 body of
+    ``_run_tool_step``, factored out so :func:`_run_tool_step` can retry it
+    (``on_error: retry(n)``) or catch its exceptions (``on_error:
+    continue``/``abort``) without duplicating the dispatch/schema/canonicalize
+    logic. Raises on a genuine failure (tool_dispatch exception, missing
+    schema_registry, schema non-conformance) exactly like before; a
+    canonical-error tool RESULT (``meta.isError``) still returns NORMALLY —
+    the caller (:func:`_run_tool_step`) is what decides whether that triggers
+    ``on_error``."""
     step: ToolStep = inv.step  # type: ignore[assignment]
     deps = inv.deps
     resolved_args = {

--- a/src/reyn/core/pipeline/parser.py
+++ b/src/reyn/core/pipeline/parser.py
@@ -316,7 +316,7 @@ def _reject_unknown_keys(
 # ---------------------------------------------------------------------------
 
 _TRANSFORM_KEYS = frozenset({"value", "output"})
-_TOOL_KEYS = frozenset({"name", "args", "schema", "output"})
+_TOOL_KEYS = frozenset({"name", "args", "schema", "output", "on_error"})
 _AGENT_KEYS = frozenset({"prompt", "identity", "capabilities", "schema", "model", "output"})
 _CALL_KEYS = frozenset({"pipeline", "pass", "output"})
 _MATCH_KEYS = frozenset({"on", "cases", "default", "output"})
@@ -332,6 +332,16 @@ def _parse_transform_step(body: "dict[str, Any]") -> TransformStep:
 
 
 def _parse_tool_step(body: "dict[str, Any]") -> ToolStep:
+    """``tool = {name:LIT, args?:{NAME:EXPR|LIT}, schema?:LIT, on_error?:
+    abort|continue|retry(n), output?:NAME}`` — the ONLY non-fan-out step kind
+    with a side effect. ``on_error`` is OPTIONAL (#3130, unlike ``for_each``'s
+    REQUIRED ``on_error`` — see :func:`_parse_for_each_step`): an omitted key
+    parses to ``None``, which is a DISTINCT state from the string ``"abort"``
+    (see :class:`~reyn.core.pipeline.executor.ToolStep`'s docstring) —
+    preserving byte-identical behavior for every existing pipeline that never
+    declared it. When present, it is the SAME three values, validated with the
+    SAME regex (:data:`_ON_ERROR_RE`) and error-message shape ``for_each``/
+    ``parallel`` already use."""
     _reject_unknown_keys(body, _TOOL_KEYS, where="tool step")
     if "name" not in body:
         _fail("tool step: missing required field 'name'")
@@ -348,7 +358,18 @@ def _parse_tool_step(body: "dict[str, Any]") -> ToolStep:
     schema = body.get("schema")
     if schema is not None and not isinstance(schema, str):
         _fail(f"tool step 'schema': expected a schema-name string, got {type(schema).__name__}")
-    return ToolStep(name=name, args=args, output=body.get("output"), schema=schema)
+    on_error = body.get("on_error")
+    if on_error is not None and (
+        not isinstance(on_error, str)
+        or (on_error not in ("continue", "abort") and _ON_ERROR_RE.match(on_error) is None)
+    ):
+        _fail(
+            "tool step 'on_error': must be 'continue', 'abort', or "
+            f"'retry(n)' (a positive integer n), got {on_error!r}"
+        )
+    return ToolStep(
+        name=name, args=args, output=body.get("output"), schema=schema, on_error=on_error,
+    )
 
 
 def _parse_agent_step(body: "dict[str, Any]") -> AgentStep:

--- a/src/reyn/core/pipeline/serde.py
+++ b/src/reyn/core/pipeline/serde.py
@@ -97,6 +97,10 @@ def _encode_tool(step: "ToolStep") -> "dict[str, Any]":
         "args": {k: _encode_arg(step.name, k, v) for k, v in step.args.items()},
         "output": step.output,
         "schema": step.schema,
+        # #3130: optional, mirrors for_each/parallel's on_error string — None
+        # (the default) round-trips as None, preserving the byte-identical
+        # "no on_error declared" state through a work-order persist/resume.
+        "on_error": step.on_error,
     }
 
 
@@ -122,6 +126,7 @@ def _decode_tool(data: "dict[str, Any]") -> "ToolStep":
         args={k: _decode_arg(v) for k, v in dict(data.get("args") or {}).items()},
         output=data.get("output"),
         schema=data.get("schema"),
+        on_error=data.get("on_error"),
     )
 
 

--- a/tests/test_3130_tool_step_on_error.py
+++ b/tests/test_3130_tool_step_on_error.py
@@ -1,0 +1,230 @@
+"""Tier 2: OS invariant — a top-level ``tool:`` step's ``on_error`` (#3130).
+
+Closes the "last piece" gap #3096/#3105 left open (per the architect, the
+original designer of the 6-defects-ONE-gap framing): the typed canonical-error
+seam (``meta.isError`` via ``reyn.core.offload.canonical``) was already
+consumed by the FAN-OUT steps (``for_each``/``parallel``'s ``on_error``), but
+a single top-level ``tool:`` step could only abort on a RAISED exception — a
+canonical-error RESULT (e.g. an MCP tool's ``isError`` branch) passed through
+silently, requiring a ``schema: PreflightCheck`` crutch to react to it.
+
+This adds ``ToolStep.on_error`` (``continue``/``abort``/``retry(n)``),
+reusing the exact for_each/parallel parse shape (``_ON_ERROR_RE``) and the
+SAME ``_parse_on_error``/retry mechanism at the executor layer:
+
+  1. ``abort`` (the *implicit* default — ``on_error`` OMITTED) is
+     byte-identical to pre-#3130 behavior: a RAISED exception still aborts
+     the pipeline (unchanged), and this test also covers the now-available
+     EXPLICIT ``on_error: abort``, which additionally aborts on a canonical
+     ``meta.isError`` RESULT (the new, opt-in behavior this issue asks for).
+  2. ``continue`` binds a typed error-envelope to the step's ``output`` (the
+     SAME ``{text, structured, meta: {isError: true}}`` shape a canonical
+     tool error already takes, or its exception-derived equivalent via
+     ``error_to_canonical``) — NOT a for_each-style dropped/null binding,
+     since a single step's ``output`` is a NAMED binding downstream steps
+     reference, unlike a fan-out COLLECTION item. The pipeline proceeds and
+     a downstream step can discriminate the envelope via ``meta.isError``.
+  3. ``retry(n)``: a flaky tool that fails then succeeds within ``n``
+     retries ends up succeeding (bound normally, no error envelope); a tool
+     that fails ALL ``n`` retries falls through to abort (mirroring
+     ``for_each``'s hard-coded "retry exhausted -> abort" fallback — tested
+     against BOTH an ``on_error: retry(n)`` config, which aborts on
+     exhaustion, and an ``on_error: continue`` config with no retries, which
+     never aborts at all).
+
+Real ``PipelineExecutor`` + a real (non-mocked) ``tool_dispatch`` callable
+throughout — no mocks; ``state_log=None``/``run_id`` mirrors
+``test_pipeline_for_each_primitive.py``'s own on_error harness exactly.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from reyn.core.pipeline.executor import (
+    Pipeline,
+    PipelineExecutionError,
+    PipelineExecutor,
+    ToolStep,
+    TransformStep,
+)
+
+# ── abort (implicit default: on_error omitted) — byte-identical ─────────────
+
+
+@pytest.mark.asyncio
+async def test_on_error_unset_a_raised_exception_still_aborts():
+    """Tier 2: ``on_error`` OMITTED (the field's default, ``None``) — a tool
+    that RAISES still aborts the pipeline exactly like before #3130 (no
+    behavior change for the byte-identical "unset" case)."""
+    def _dispatch(name: str, args: dict) -> Any:
+        raise RuntimeError("boom")
+
+    pipeline = Pipeline(steps=[ToolStep(name="work", args={})])
+    # today's exact behavior: the raw exception propagates UNWRAPPED (never a
+    # PipelineExecutionError) — nothing in the dispatch path catches it when
+    # on_error is unset.
+    with pytest.raises(RuntimeError, match="boom"):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-tool-unset-raise",
+        )
+
+
+@pytest.mark.asyncio
+async def test_on_error_unset_a_canonical_error_result_passes_through_unchecked():
+    """Tier 2: ``on_error`` OMITTED — a tool that returns NORMALLY with a
+    canonical-error result (``meta.isError``) does NOT abort — this is the
+    exact pre-#3130 behavior the schema-crutch pattern relies on, preserved
+    byte-identical when the field is unset."""
+    def _dispatch(name: str, args: dict) -> Any:
+        return {"content": [{"type": "text", "text": "tool failed"}], "isError": True}
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="work", args={}, output="result"),
+        TransformStep(value="ctx.result.meta.isError", output="flag"),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-tool-unset-canonical",
+    )
+    # the pipeline ran to completion (no abort) and the canonical error is
+    # inspectable downstream exactly like today's schema-crutch pattern needs.
+    assert result.pipe_data is True
+
+
+@pytest.mark.asyncio
+async def test_on_error_explicit_abort_also_fails_on_canonical_error_result():
+    """Tier 2: an EXPLICIT ``on_error: abort`` is the NEW opt-in behavior this
+    issue asks for — it aborts on a canonical-error RESULT too (not just a
+    raised exception), closing the schema-crutch gap natively."""
+    def _dispatch(name: str, args: dict) -> Any:
+        return {"error": "tool failed", "isError": True}
+
+    pipeline = Pipeline(steps=[ToolStep(name="work", args={}, on_error="abort")])
+    with pytest.raises(PipelineExecutionError) as exc_info:
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-tool-explicit-abort",
+        )
+    assert "tool failed" in str(exc_info.value)
+
+
+# ── continue: typed error-envelope binding ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_error_continue_binds_error_envelope_from_canonical_result():
+    """Tier 2: ``on_error: continue`` on a canonical-error RESULT binds that
+    SAME error-envelope shape to ``output`` (not null, not dropped) — the
+    pipeline proceeds and a downstream step can discriminate it via
+    ``meta.isError``, symmetric with a success result's shape."""
+    def _dispatch(name: str, args: dict) -> Any:
+        return {"error": "tool failed", "isError": True}
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="work", args={}, on_error="continue", output="result"),
+        TransformStep(
+            value="get(ctx.result, 'meta.isError', false)",
+            output="discriminated",
+        ),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-tool-continue-canonical",
+    )
+    assert result.named_stores["result"]["meta"]["isError"] is True
+    assert "tool failed" in result.named_stores["result"]["text"]
+    # downstream step DISCRIMINATES the bound envelope from a success result.
+    assert result.pipe_data is True
+
+
+@pytest.mark.asyncio
+async def test_on_error_continue_binds_error_envelope_from_raised_exception():
+    """Tier 2: ``on_error: continue`` on a RAISED exception (no dict result to
+    canonicalize) synthesizes the SAME typed error-envelope shape via
+    ``error_to_canonical`` — not a second, invented shape — so downstream code
+    discriminates a raised-exception failure identically to a canonical-error
+    RESULT failure."""
+    def _dispatch(name: str, args: dict) -> Any:
+        raise RuntimeError("boom")
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="work", args={}, on_error="continue", output="result"),
+        TransformStep(value="ctx.result.meta.isError", output="flag"),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-tool-continue-exception",
+    )
+    assert result.named_stores["result"]["meta"]["isError"] is True
+    assert "boom" in result.named_stores["result"]["text"]
+    assert result.pipe_data is True
+
+
+# ── retry(n) ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_reruns_flaky_step_until_success():
+    """Tier 2: ``on_error: retry(2)`` on a step that fails twice then succeeds
+    on the 3rd attempt ends up succeeding — bound normally (no error
+    envelope), reusing the SAME retry-safety model ``for_each.on_error:
+    retry(n)`` already relies on (a retry re-invokes the tool body)."""
+    attempts = {"n": 0}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        attempts["n"] += 1
+        if attempts["n"] < 3:
+            raise RuntimeError("transient")
+        return "recovered"
+
+    pipeline = Pipeline(steps=[ToolStep(name="work", args={}, on_error="retry(2)")])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-tool-retry-ok",
+    )
+    assert result.pipe_data == {"text": "recovered"}
+    assert attempts["n"] == 3  # 1 initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_on_error_retry_exhausted_falls_back_to_abort():
+    """Tier 2: ``on_error: retry(1)`` on an ALWAYS-failing step exhausts its
+    retries and falls back to ABORT (mirroring ``for_each``'s hard-coded
+    "retry exhausted -> abort" — there is no combined "retry then continue"
+    DSL value)."""
+    calls = {"n": 0}
+
+    def _dispatch(name: str, args: dict) -> Any:
+        calls["n"] += 1
+        raise RuntimeError("permanent")
+
+    pipeline = Pipeline(steps=[ToolStep(name="work", args={}, on_error="retry(1)")])
+    with pytest.raises(PipelineExecutionError):
+        await PipelineExecutor().run(
+            pipeline, None,
+            tool_dispatch=_dispatch, state_log=None, run_id="run-tool-retry-exhaust",
+        )
+    assert calls["n"] == 2  # 1 initial + 1 retry, then abort
+
+
+@pytest.mark.asyncio
+async def test_on_error_continue_never_aborts_even_without_retries():
+    """Tier 2: contrast with the retry-exhausted-abort case above — an
+    always-failing step configured with ``on_error: continue`` (no retries at
+    all) never aborts; it binds the error-envelope on the FIRST failure. Two
+    on_error configs over the same always-failing tool land on opposite
+    outcomes (abort vs continue), exactly per each config's own semantics."""
+    def _dispatch(name: str, args: dict) -> Any:
+        raise RuntimeError("permanent")
+
+    pipeline = Pipeline(steps=[
+        ToolStep(name="work", args={}, on_error="continue", output="result"),
+    ])
+    result = await PipelineExecutor().run(
+        pipeline, None,
+        tool_dispatch=_dispatch, state_log=None, run_id="run-tool-continue-no-retry",
+    )
+    assert result.named_stores["result"]["meta"]["isError"] is True

--- a/tests/test_pipeline_for_each_serde_parser_analyzer.py
+++ b/tests/test_pipeline_for_each_serde_parser_analyzer.py
@@ -58,7 +58,7 @@ def test_for_each_serde_round_trip_non_default_values_with_nested_do_and_collect
             "kind": "call", "pipeline": "summarize-one",
             "pass": [["item", "item"]], "output": "r",
         },
-        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None},
+        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None, "on_error": None},
         "output": "results",
     }
     assert pipeline_from_dict(json.loads(json.dumps(wire))) == pipeline

--- a/tests/test_pipeline_parallel_serde_parser_analyzer.py
+++ b/tests/test_pipeline_parallel_serde_parser_analyzer.py
@@ -63,9 +63,10 @@ def test_parallel_serde_round_trip_non_default_values_with_nested_branches_and_c
             },
             "score": {
                 "kind": "tool", "name": "scorer", "args": {}, "output": "sc", "schema": None,
+                "on_error": None,
             },
         },
-        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None},
+        "collect": {"kind": "tool", "name": "merge", "args": {}, "output": "merged", "schema": None, "on_error": None},
         "on_error": "retry(3)",
         "output": "results",
     }


### PR DESCRIPTION
[per-PR-coder] — implements #3130.

Closes #3130

## Gap
The typed tool-result error contract (`meta.isError`, FP-0056) is consumed by
the fan-out steps' `on_error` (`for_each` #3105, `parallel`) but a top-level
single `tool:` step could only abort on a **raised exception** — a canonical
error **result** (e.g. an MCP tool's `isError` branch) returned normally and
required a `schema: PreflightCheck` crutch downstream to react to it. This is
the "last piece" the typed-error arc left open (per architect, umbrella
#3096; substrate #3105/#3104/FP-0056/#3098).

## Design (architect-firmed, this PR follows it exactly)

`ToolStep` gets an optional `on_error: str | None = None` (`schema.py`/
`executor.py`'s `ToolStep`, `parser.py`'s `_parse_tool_step`, `serde.py`
round-trip) — same three values, same regex (`_ON_ERROR_RE`), same error
message shape `for_each`/`parallel` already use.

**`None` (omitted key) is a distinct state from the string `"abort"`.** This
is the one deliberate design decision beyond a literal reading of "default
abort": if an omitted `on_error` meant "abort, and abort now also checks
`meta.isError`", every existing pipeline that relies on the `schema:`-gated
preflight pattern to inspect an error result *without* aborting would
silently start aborting instead — a real behavior break, not a byte-identical
no-op. So:

- **omitted** → exactly today's behavior: a raised exception still propagates
  unwrapped; a canonical-error *result* passes through unchecked (the
  existing crutch keeps working).
- **explicit `on_error: abort`** → the NEW opt-in behavior this issue asks
  for: a canonical-error result *also* fails the step (`PipelineExecutionError`),
  same as a raised exception.
- **`continue`** → binds a **typed error-envelope** to `output` — NOT a
  for_each-style dropped/null binding. `for_each`'s `continue` drops the
  failed item from a *collection* `collect` consumes; a single step's
  `output` is a *named binding* downstream steps reference directly, so
  dropping it would leave an unbound-variable reference. The envelope reuses
  the codebase's one existing typed-error-result shape
  (`to_canonical`/`canonical_to_ctx_fields`, i.e. `{text, structured, meta:
  {isError: true}}`) — a canonical-error tool *result* already computes this
  shape as `ctx_result`, so it's bound as-is; a *raised* exception (no dict to
  canonicalize) gets the same shape synthesized via `error_to_canonical`
  rather than inventing a second shape. Either way the bound value is
  discriminable from a success result via `meta.isError`, symmetric with
  success.
- **`retry(n)`** → reuses the exact `for_each`/`parallel` retry-safety model
  (a retry re-invokes the whole tool body — dispatch + `schema:` validation —
  so an internal side effect may re-fire, same caveat `for_each.on_error:
  retry(n)` already carries; the WAL still only records a *finished* step
  once). Retries exhausted → falls through to `abort` (mirroring `for_each`'s
  hard-coded fallback — there is no combined "retry then continue" DSL
  value, single-step or fan-out).

`abort`-when-omitted is **byte-identical** to pre-#3130 behavior — verified
by a dedicated test asserting the raw (unwrapped) exception still propagates
and a canonical-error result still passes through untouched when `on_error`
is not declared.

## Implementation
- `src/reyn/core/pipeline/executor.py`: `ToolStep.on_error` field;
  `_run_tool_step` now branches on it, delegating the actual dispatch to a
  new `_dispatch_tool_step_once` helper (the pre-#3130 body, unchanged) so
  retry/continue/abort wrap it without duplicating dispatch/schema/canonicalize
  logic.
- `src/reyn/core/pipeline/parser.py`: `_TOOL_KEYS` + `_parse_tool_step` parse
  `on_error`, reusing `_ON_ERROR_RE`.
- `src/reyn/core/pipeline/serde.py`: `_encode_tool`/`_decode_tool` round-trip
  the field (defaults to `None`).
- `docs/reference/runtime/pipeline-dsl.md`: `ToolBody`/Appendix-B grammar +
  field table + a new `tool.on_error` subsection describing the
  omitted-vs-abort distinction and the error-envelope shape, plus a Hard
  Rules note.

## Tests (`tests/test_3130_tool_step_on_error.py`, Tier 2, real
`PipelineExecutor` + real `tool_dispatch` callables, no mocks)
1. `on_error` omitted: a raised exception still aborts UNWRAPPED (byte-
   identical); a canonical-error result passes through unchecked.
2. explicit `on_error: abort`: now also aborts on a canonical-error result.
3. `on_error: continue`: binds the typed error-envelope from both a
   canonical-error result and a raised exception; a downstream step
   discriminates it via `meta.isError`.
4. `on_error: retry(n)`: a flaky tool recovers within `n` retries and
   succeeds normally; an always-failing tool exhausts `retry(n)` and falls
   through to abort; contrasted against `on_error: continue` (no retries),
   which never aborts at all on the same always-failing tool.

Also updated two pre-existing serde golden-shape tests
(`test_pipeline_for_each_serde_parser_analyzer.py`,
`test_pipeline_parallel_serde_parser_analyzer.py`) whose literal encoded-dict
assertions needed the new `"on_error": None` key for a nested `tool:` sub-step.

## Test plan
- [x] `ruff check src tests` — clean
- [x] `python scripts/test_tier_audit.py --strict tests/test_3130_tool_step_on_error.py` — 8/8 OK, 0 Tier-4
- [x] `python -m pytest tests/test_3130_tool_step_on_error.py tests/test_pipeline_for_each*.py -q` — green
- [x] `python scripts/verify_module_docstrings.py src/reyn/core/pipeline/schema.py src/reyn/core/pipeline/parser.py src/reyn/core/pipeline/executor.py` — OK
- [x] `python -m pytest tests/ -k pipeline -q` — 559 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)