### PR TITLE
feat(FP-0066 P2a): IndexCoordinator core + SourceManifest dirty state

### DIFF
--- a/src/reyn/core/op_runtime/index_update.py
+++ b/src/reyn/core/op_runtime/index_update.py
@@ -56,6 +56,7 @@ from reyn.data.index.backend import (
     cache_dir_for_source,
     sources_manifest_path,
 )
+from reyn.data.index.coordinator import assert_vector_count_match
 from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
 from reyn.schemas.models import EmbedIROp, IndexUpdateIROp
 
@@ -207,11 +208,13 @@ async def handle(op: IndexUpdateIROp, ctx: OpContext) -> dict:
         if embed_result.get("status") == "error":
             return embed_result
         vectors = embed_result.get("vectors", [])
-        if len(vectors) != len(to_embed):
-            raise RuntimeError(
-                f"embed op returned {len(vectors)} vectors for {len(to_embed)} "
-                f"chunks; refusing partial index_update write"
-            )
+        # FP-0066 P2a (#3247): the count-match guard is the ONE canonical
+        # implementation shared with `ActionEmbeddingIndex.build()` (which
+        # used to duplicate this verbatim) — see
+        # ``reyn.data.index.coordinator.assert_vector_count_match``.
+        assert_vector_count_match(
+            len(vectors), len(to_embed), item_noun="chunks", label="index_update write",
+        )
         records: list[ChunkRecord] = []
         resolved_model = embed_result.get("model", model)
         for chunk, vector in zip(to_embed, vectors):

--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -1,0 +1,432 @@
+"""IndexCoordinator — orchestration for embedding-index builds (FP-0066 P2a,
+#3247 "P2 IndexCoordinator 設計 firm").
+
+**Boundary principle (the firm's one-line frame)**: the Coordinator owns
+*orchestration* — dirty-marking, await, the background build queue, the
+cross-process ``build_lock``, failure-memoization, and the readiness gate.
+It never owns *execution* (the ``embed``/``index_update`` ops + the
+``SqliteIndexBackend`` remain the real index write — layer-3, kept from
+FP-0066 P1) and never owns *domain policy* (a source's own item↔ChunkRecord
+mapping and what to embed is supplied by the caller as a ``BuildFn`` "domain
+adapter" strategy callback — see ``register_builder`` below). Centralising
+the await/build-queue orchestration here is what prevents the "file.read
+dispersion" replay the firm calls out: without one owner, await logic would
+scatter across install/remember/search call sites again.
+
+**P2a scope** (per the firm's §7 sub-PR decomposition): the Coordinator
+CORE + the ``SourceManifest`` dirty/pending state, plus the ONE unified
+all-or-nothing embed-verify-write primitive (``embed_verify_write``) that
+``ActionEmbeddingIndex.build()`` and the ``index_update`` op used to
+duplicate verbatim. Migrating those two call sites to trigger builds
+*through* the Coordinator (eager-vs-background, once-per-chain spawn) is
+**P2b** — deliberately NOT done here. Wiring dynamic ops to
+``ensure_built(await_completion=True)`` and G3 sync de-index is **P2c**.
+Audit-event phase emission is **P2d**.
+
+**Crash-recovery (the band requirement, CLAUDE.md recovery-feature gate)**:
+the dirty/building/error state lives in ``SourceEntry`` (persisted to
+``sources.yaml`` — the SourceManifest's existing atomic-write file SSoT).
+This is DELIBERATELY NOT the WAL (``.reyn/state/wal.jsonl``) — the WAL is
+agent chat-state's crash-recovery substrate (see
+``docs/concepts/runtime/events.md`` — "WAL vs audit-event separation"); the
+IndexCoordinator's dirty flag has nothing to do with it and must survive
+completely independently of it. The in-memory build-queue (``_bg_tasks``,
+``_failure_memo``) is volatile BY DESIGN — a crash loses it, and that is
+fine, because ``search_await`` re-derives "does this need a build" from the
+persisted ``sources.yaml`` state alone, not from the in-memory queue. See
+``tests/test_index_coordinator_3247_p2a.py`` for the truncate-falsify proof.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Mapping
+
+from reyn.data.index import ChunkRecord, IndexBackend, WriteResult, get_backend
+from reyn.data.index.backend import cache_dir_for_source
+from reyn.data.index.build_lock import try_acquire_build_lock
+from reyn.data.index.source_manifest import (
+    SourceEntry,
+    SourceManifest,
+    get_source_manifest,
+)
+
+if TYPE_CHECKING:
+    from reyn.core.op_runtime.context import OpContext
+
+__all__ = [
+    "BuildMaterial",
+    "BuildFn",
+    "BuildOutcome",
+    "EmbedWriteResult",
+    "assert_vector_count_match",
+    "embed_verify_write",
+    "IndexCoordinator",
+]
+
+
+# ── Unified all-or-nothing embed-verify-write (the firm's dedup target) ────
+
+
+@dataclass(frozen=True)
+class EmbedWriteResult:
+    """Return shape of ``embed_verify_write`` — the write outcome plus the
+    embed op's resolved model id (some callers, e.g. ``index_update``, must
+    record the resolved model on subsequent chunk metadata / the manifest)."""
+
+    write_result: WriteResult
+    resolved_model: str
+
+
+def assert_vector_count_match(
+    vector_count: int, item_count: int, *, item_noun: str = "items", label: str = "build",
+) -> None:
+    """The all-or-nothing guard, itself — the ONE canonical implementation of
+    what used to be a verbatim-duplicated ``if len(vectors) != len(items):
+    raise RuntimeError(...)`` in both ``ActionEmbeddingIndex.build()`` and
+    the ``index_update`` op. Both call sites now call THIS function for
+    their count-match check (``item_noun``/``label`` preserve each site's
+    distinct error-message wording — "...refusing partial build" vs
+    "...refusing partial index_update write" — respectively; behavior is
+    now identical by construction, not by two hand-maintained copies
+    agreeing).
+
+    Public (not underscore-prefixed) precisely so it can be imported and
+    monkeypatched-to-a-no-op by the strip-falsify test that proves this
+    guard — not just the surrounding plumbing — is load-bearing: neuter
+    it and a mismatched vector count silently writes a partial batch
+    instead of raising.
+    """
+    if vector_count != item_count:
+        raise RuntimeError(
+            f"embed returned {vector_count} vectors for {item_count} "
+            f"{item_noun}; refusing partial {label}"
+        )
+
+
+async def embed_verify_write(
+    *,
+    ctx: "OpContext",
+    texts: list[str],
+    model_class: str,
+    items: list[Any],
+    to_chunk_record: Callable[[Any, list[float], str], ChunkRecord],
+    backend: IndexBackend,
+    source: str,
+    mode: str = "replace",
+    item_noun: str = "items",
+    label: str = "build",
+) -> EmbedWriteResult:
+    """Embed ``texts`` via the shared ``embed`` op, verify the returned
+    vector count matches ``len(items)`` (raising ``RuntimeError`` on a
+    mismatch — the all-or-nothing guard), map each ``(item, vector)`` pair
+    to a ``ChunkRecord`` via the caller-supplied ``to_chunk_record``, and
+    write the batch to ``backend``.
+
+    This is the ONE canonical implementation of the verification that used
+    to exist twice, verbatim, in ``ActionEmbeddingIndex.build()`` (message:
+    "...refusing partial build") and the ``index_update`` op (message:
+    "...refusing partial index_update write") — both call sites now route
+    through this function (``item_noun``/``label`` preserve their distinct
+    error-message wording; the *behavior* — raise-before-write on a count
+    mismatch — is now byte-identical by construction, not by two hand-
+    maintained copies agreeing).
+    """
+    from reyn.core.op_runtime import execute_op
+    from reyn.schemas.models import EmbedIROp
+
+    result = await execute_op(
+        EmbedIROp(kind="embed", texts=texts, embedding_model=model_class), ctx,
+    )
+    if result.get("status") == "error":
+        raise RuntimeError(f"embed op failed: {result.get('error')}")
+    vectors = list(result.get("vectors", []))
+    assert_vector_count_match(
+        len(vectors), len(items), item_noun=item_noun, label=label,
+    )
+    resolved_model = str(result.get("model", model_class))
+    records = [
+        to_chunk_record(item, vector, resolved_model)
+        for item, vector in zip(items, vectors)
+    ]
+    write_result = await backend.write(source, records, mode=mode)  # type: ignore[arg-type]
+    return EmbedWriteResult(write_result=write_result, resolved_model=resolved_model)
+
+
+# ── IndexCoordinator public interface (#3247 firm §1) ──────────────────────
+
+
+@dataclass(frozen=True)
+class BuildMaterial:
+    """What a domain adapter (the ``BuildFn`` strategy callback) supplies so
+    the Coordinator can run a build without knowing anything domain-specific.
+
+    ``items``/``texts`` are parallel (``len(items) == len(texts)``);
+    ``to_chunk_record(item, vector, resolved_model) -> ChunkRecord`` is the
+    domain's item↔ChunkRecord mapping (kept OUT of the Coordinator per the
+    firm's boundary principle — e.g. the action-catalog's dual-axis
+    category/qualified_name mapping, or a doc-RAG source's chunk metadata).
+    """
+
+    items: list[Any]
+    texts: list[str]
+    to_chunk_record: Callable[[Any, list[float], str], ChunkRecord]
+    model_class: str
+    ctx: "OpContext"
+
+
+BuildFn = Callable[[], Awaitable[BuildMaterial]]
+
+
+@dataclass(frozen=True)
+class BuildOutcome:
+    """Result of an ``ensure_built`` (or an internally-driven heal) call.
+
+    ``triggered``: a build was attempted this call (vs. a cheap clean-state
+    no-op). ``background``: the build was scheduled as a fire-and-forget
+    ``asyncio.create_task`` rather than awaited in-line. ``chunk_count``:
+    populated on a successful synchronous build. ``error``: populated
+    (without raising) when the build failed — ``ensure_built`` never raises;
+    a failure is best-effort-recorded (dirty + failure-memo) and reported
+    via this field, per the firm's §G2 best-effort contract.
+    """
+
+    source_id: str
+    triggered: bool
+    background: bool
+    chunk_count: int | None = None
+    error: str | None = None
+
+
+class IndexCoordinator:
+    """Per-workspace orchestrator for embedding-index builds.
+
+    Singleton-per-workspace is the caller's choice (mirrors
+    ``SourceManifest``/``get_source_manifest``) — this class itself does not
+    enforce singleton-ness; production wiring (P2b/P2c) will decide where
+    one instance lives (likely session-scoped, one per workspace).
+
+    A source must be registered via ``register_builder`` before
+    ``ensure_built``/``search_await`` can build/heal it — this is necessary
+    plumbing the firm's interface section does not spell out (its
+    ``ensure_built(source_id, *, await_completion)`` signature carries no
+    build strategy per call), so the strategy has to be associated with the
+    ``source_id`` some other way. Registering a builder is NOT a production
+    call-site migration (P2b) — it is just how a domain adapter tells the
+    Coordinator "this is how you'd build me", exercised directly by this
+    PR's tests; no production code calls ``register_builder`` yet.
+    """
+
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        backend: IndexBackend | None = None,
+        manifest: SourceManifest | None = None,
+    ) -> None:
+        self._workspace_root = workspace_root
+        self._backend: IndexBackend = (
+            backend if backend is not None else get_backend("sqlite", workspace_root=workspace_root)
+        )
+        self._manifest: SourceManifest = (
+            manifest if manifest is not None else get_source_manifest(workspace_root)
+        )
+        self._builders: dict[str, BuildFn] = {}
+        # Volatile by design (crash-recovery band): lost on process restart.
+        # Recovery does NOT depend on these — see module docstring.
+        self._bg_tasks: dict[str, "asyncio.Task[BuildOutcome]"] = {}
+        self._failure_memo: dict[str, str] = {}
+
+    # ── registration (necessary plumbing, not a P2b call-site migration) ──
+
+    def register_builder(self, source_id: str, build_fn: BuildFn) -> None:
+        """Associate a domain build strategy with ``source_id``.
+
+        Idempotent — re-registering replaces the prior strategy (useful for
+        tests and for a future config-driven re-registration on reload).
+        """
+        self._builders[source_id] = build_fn
+
+    # ── mark_dirty (#3247 firm §1) ──────────────────────────────────────
+
+    async def mark_dirty(self, source_id: str, *, reason: str) -> None:
+        """Best-effort dirty mark — the §G2 provider-failure recovery hook.
+
+        Persists ``state="dirty"`` + ``last_error=reason`` to
+        ``sources.yaml`` via ``SourceManifest.upsert`` (the workspace-SSoT
+        band: no second state store). If no entry exists yet for
+        ``source_id`` (a build never even reached a first write), a minimal
+        placeholder entry is created so the dirty mark is not silently lost
+        — a later real build overwrites the placeholder fields.
+        """
+        entry = await self._manifest.get(source_id)
+        if entry is None:
+            entry = SourceEntry(
+                name=source_id, description="", path="", backend="sqlite",
+            )
+        entry.state = "dirty"
+        entry.last_error = reason
+        await self._manifest.upsert(entry)
+
+    # ── ensure_built (#3247 firm §1) ─────────────────────────────────────
+
+    async def ensure_built(
+        self, source_id: str, *, await_completion: bool,
+    ) -> BuildOutcome:
+        """If ``source_id`` is dirty/error/never-built, (re)build it.
+
+        ``await_completion=True`` runs the build in-line and returns once
+        done (sync-in-op await, per the firm's §3 dynamic-kind rule).
+        ``await_completion=False`` schedules ``asyncio.create_task`` and
+        returns immediately (background, per §3 static/backfill rule) —
+        at most one background task per ``source_id`` is live at a time
+        (once-per-source spawn, mirrors ``RouterLoop``'s
+        ``_action_index_build_task`` once-per-chain dedup).
+
+        Never raises: a build failure is caught, recorded via
+        ``mark_dirty`` + the in-process failure-memo, and reported on the
+        returned ``BuildOutcome.error`` (the §G2 best-effort contract).
+        """
+        entry = await self._manifest.get(source_id)
+        if entry is not None and entry.state == "clean":
+            return BuildOutcome(
+                source_id=source_id, triggered=False, background=False,
+                chunk_count=entry.chunk_count,
+            )
+        if entry is not None and entry.state == "building":
+            # Someone (this process or another) is already mid-build.
+            return BuildOutcome(source_id=source_id, triggered=False, background=False)
+
+        build_fn = self._builders.get(source_id)
+        if build_fn is None:
+            raise ValueError(
+                f"IndexCoordinator.ensure_built({source_id!r}): no builder "
+                f"registered — call register_builder(source_id, build_fn) first."
+            )
+
+        if not await_completion:
+            existing_task = self._bg_tasks.get(source_id)
+            if existing_task is not None and not existing_task.done():
+                return BuildOutcome(source_id=source_id, triggered=True, background=True)
+            task = asyncio.create_task(self._run_build(source_id, build_fn))
+            self._bg_tasks[source_id] = task
+            return BuildOutcome(source_id=source_id, triggered=True, background=True)
+
+        return await self._run_build(source_id, build_fn)
+
+    async def _run_build(self, source_id: str, build_fn: BuildFn) -> BuildOutcome:
+        await self._set_state(source_id, "building")
+        lock_dir = cache_dir_for_source(self._workspace_root, source_id)
+        with try_acquire_build_lock(lock_dir) as got_lock:
+            if not got_lock:
+                # Another process is mid-build — fall back to whatever is
+                # on disk rather than duplicating the embed-API cost.
+                return BuildOutcome(source_id=source_id, triggered=False, background=False)
+            try:
+                material = await build_fn()
+                result = await embed_verify_write(
+                    ctx=material.ctx,
+                    texts=material.texts,
+                    model_class=material.model_class,
+                    items=material.items,
+                    to_chunk_record=material.to_chunk_record,
+                    backend=self._backend,
+                    source=source_id,
+                    mode="replace",
+                    item_noun="items",
+                    label="build",
+                )
+            except Exception as exc:
+                reason = f"build_error: {exc}"
+                self._failure_memo[source_id] = reason
+                await self.mark_dirty(source_id, reason=reason)
+                return BuildOutcome(
+                    source_id=source_id, triggered=True, background=False, error=str(exc),
+                )
+
+        chunk_count = result.write_result["written"]
+        await self._set_state(
+            source_id, "clean", chunk_count=chunk_count,
+            embedding_model=result.resolved_model,
+        )
+        return BuildOutcome(
+            source_id=source_id, triggered=True, background=False, chunk_count=chunk_count,
+        )
+
+    async def _set_state(
+        self,
+        source_id: str,
+        state: str,
+        *,
+        chunk_count: int | None = None,
+        embedding_model: str | None = None,
+    ) -> None:
+        entry = await self._manifest.get(source_id)
+        if entry is None:
+            entry = SourceEntry(name=source_id, description="", path="", backend="sqlite")
+        entry.state = state  # type: ignore[assignment]
+        if state == "clean":
+            entry.last_error = None
+        if chunk_count is not None:
+            entry.chunk_count = chunk_count
+        if embedding_model is not None:
+            entry.embedding_model = embedding_model
+        if state == "clean":
+            from datetime import datetime, timezone
+            entry.last_indexed = datetime.now(timezone.utc).isoformat()
+        await self._manifest.upsert(entry)
+
+    # ── search_await (#3247 firm §1 + §5 search-await contract) ─────────
+
+    async def search_await(self, source_id: str) -> None:
+        """Await any pending/dirty ingest for ``source_id`` before a search
+        returns (the completeness guarantee — "best-effort search is a
+        bug").
+
+        Steady-state (``state == "clean"``) is a cheap manifest-read no-op
+        — no build is triggered. ``dirty``/``error`` triggers a heal
+        (synchronous rebuild via ``ensure_built(await_completion=True)``).
+        ``building`` awaits the in-flight background task if this process
+        is the one running it (volatile — a DIFFERENT process's in-flight
+        build is not awaitable here; the next call after it completes will
+        observe ``clean`` via the persisted manifest).
+        """
+        entry = await self._manifest.get(source_id)
+        if entry is None or entry.state == "clean":
+            return
+        if entry.state == "building":
+            task = self._bg_tasks.get(source_id)
+            if task is not None:
+                await task
+            return
+        # dirty or error → heal.
+        if source_id not in self._builders:
+            # No strategy registered in THIS process (e.g. a fresh process
+            # after a crash, before P2b/P2c wire real builders). Nothing to
+            # heal with — the persisted dirty flag still correctly reports
+            # "not ready" via is_ready(); a caller that owns a builder can
+            # register it and call ensure_built/search_await again.
+            return
+        await self.ensure_built(source_id, await_completion=True)
+
+    # ── is_ready (#3247 firm §1) ─────────────────────────────────────────
+
+    async def is_ready(self, source_id: str) -> bool:
+        """Readiness gate — True iff the manifest records this source as
+        ``clean`` (a completed, current build)."""
+        entry = await self._manifest.get(source_id)
+        return entry is not None and entry.state == "clean"
+
+    # ── failure-memo read surface (mirrors router_loop's
+    #    ``_action_index_build_failed`` semantics) ───────────────────────
+
+    def build_failed(self, source_id: str) -> bool:
+        """True if a prior build attempt in THIS process failed (per-process
+        once-per-source memoization, mirrors ``RouterLoop.
+        _action_index_build_failed`` — cross-process/cross-restart
+        persistence of "don't retry" is intentionally NOT implemented; the
+        persisted ``sources.yaml`` state is ``dirty``/``error`` regardless,
+        so a fresh process/session gets exactly one retry, which is the
+        desired heal path)."""
+        return source_id in self._failure_memo

--- a/src/reyn/data/index/source_manifest.py
+++ b/src/reyn/data/index/source_manifest.py
@@ -13,7 +13,7 @@ import time
 from contextlib import asynccontextmanager
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Literal
 
 import yaml
 
@@ -22,6 +22,18 @@ from reyn.data.index.backends.sqlite import _within_paths
 from reyn.data.index.build_lock import pid_alive as _pid_alive
 
 # ── Data model ────────────────────────────────────────────────────────────────
+
+# FP-0066 P2a (#3247 firm §2): the IndexCoordinator dirty-state contract.
+# ``clean`` = built and current; ``dirty`` = a provider/build failure or an
+# explicit invalidation left this source needing a (re)build; ``building`` =
+# a build is in flight (this process or another, per the cross-process
+# build_lock); ``error`` = the last build attempt failed and ``last_error``
+# carries why. ``dirty``/``error`` both mean "needs a build" — kept distinct
+# so an operator/log can tell "never tried since the mark" from "tried and
+# failed" at a glance; ``IndexCoordinator.search_await`` treats both the same
+# (heal by rebuilding).
+SourceState = Literal["clean", "dirty", "building", "error"]
+_VALID_SOURCE_STATES: frozenset[str] = frozenset({"clean", "dirty", "building", "error"})
 
 
 @dataclass
@@ -35,6 +47,13 @@ class SourceEntry:
     last_indexed: str | None = None  # ISO 8601 UTC
     chunk_count: int = 0
     embedding_model: str | None = None
+    # FP-0066 P2a (#3247 firm §2): dirty-state, persisted here (sources.yaml
+    # is the single SSoT — workspace-SSoT band; no second state store). This
+    # is the crash-recovery-of-record for the IndexCoordinator: durable,
+    # WAL-independent (see coordinator.py module docstring / the P2a
+    # truncate-falsify test).
+    state: SourceState = "clean"
+    last_error: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to the on-disk YAML structure (name is the key, not a field)."""
@@ -43,11 +62,14 @@ class SourceEntry:
             "path": self.path,
             "backend": self.backend,
             "chunk_count": self.chunk_count,
+            "state": self.state,
         }
         if self.last_indexed is not None:
             d["last_indexed"] = self.last_indexed
         if self.embedding_model is not None:
             d["embedding_model"] = self.embedding_model
+        if self.last_error is not None:
+            d["last_error"] = self.last_error
         return d
 
     @classmethod
@@ -59,12 +81,24 @@ class SourceEntry:
         ``chunk_count: null`` or a non-numeric value would otherwise crash the
         whole manifest reload (``int(None)`` → TypeError, ``int("x")`` → ValueError);
         ``_coerce_int`` closes that gap. Mirrors the #1906 TokenUsage fix.
+
+        ``state``: defaults to (and is coerced to, if garbage/missing)
+        ``"clean"`` — a pre-P2a ``sources.yaml`` (or an operator-edited one
+        with a typo'd value) has no usable dirty signal, and "assume clean"
+        is the safe read (a truly dirty source gets re-marked on its next
+        provider failure; it does not silently masquerade as needing an
+        unwanted rebuild).
         """
         def _coerce_int(v: object) -> int:
             try:
                 return int(v)  # type: ignore[arg-type]
             except (TypeError, ValueError):
                 return 0
+
+        def _coerce_state(v: object) -> SourceState:
+            if isinstance(v, str) and v in _VALID_SOURCE_STATES:
+                return v  # type: ignore[return-value]
+            return "clean"
 
         return cls(
             name=name,
@@ -74,6 +108,8 @@ class SourceEntry:
             last_indexed=data.get("last_indexed"),
             chunk_count=_coerce_int(data.get("chunk_count", 0)),
             embedding_model=data.get("embedding_model"),
+            state=_coerce_state(data.get("state")),
+            last_error=data.get("last_error"),
         )
 
 

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -101,6 +101,7 @@ from typing import TYPE_CHECKING, Any, Mapping
 from reyn.data.index import IndexBackend, get_backend
 from reyn.data.index.backend import ChunkRecord, cache_dir_for_source
 from reyn.data.index.build_lock import try_acquire_build_lock
+from reyn.data.index.coordinator import embed_verify_write
 
 if TYPE_CHECKING:
     from reyn.core.op_runtime.context import OpContext
@@ -413,23 +414,33 @@ class ActionEmbeddingIndex:
                 self._building = True
                 _built_ok = False
                 try:
-                    vectors = await self._embed_via_op(texts, ctx, model_class)
-                    if len(vectors) != len(valid_items):
-                        raise RuntimeError(
-                            f"EmbeddingProvider returned {len(vectors)} "
-                            f"vectors for {len(valid_items)} items; "
-                            f"refusing partial build"
-                        )
-                    records = [
-                        self._to_chunk_record(it, v, model_class)
-                        for it, v in zip(valid_items, vectors)
-                    ]
-                    write_result = await self._backend.write(
-                        self._source, records, mode="replace",
+                    # FP-0066 P2a (#3247): the embed+verify+write step is the
+                    # ONE canonical all-or-nothing implementation, shared
+                    # with the `index_update` op (which used to duplicate
+                    # this verbatim) — see
+                    # ``reyn.data.index.coordinator.embed_verify_write``.
+                    # ``model_class`` (the caller's class label, e.g.
+                    # "standard") is passed to ``_to_chunk_record``, NOT the
+                    # embed op's resolved literal model id — the dual-axis
+                    # invalidation policy compares against the class label
+                    # (see this module's docstring / ``model_class`` property).
+                    result = await embed_verify_write(
+                        ctx=ctx,
+                        texts=texts,
+                        model_class=model_class,
+                        items=valid_items,
+                        to_chunk_record=lambda it, v, _resolved: self._to_chunk_record(
+                            it, v, model_class,
+                        ),
+                        backend=self._backend,
+                        source=self._source,
+                        mode="replace",
+                        item_noun="items",
+                        label="build",
                     )
                     self._catalog_hash = new_hash
                     self._model_class = model_class
-                    self._size = write_result["written"]
+                    self._size = result.write_result["written"]
                     _built_ok = True
                 finally:
                     self._building = False

--- a/tests/test_index_coordinator_3247_p2a.py
+++ b/tests/test_index_coordinator_3247_p2a.py
@@ -1,0 +1,390 @@
+"""FP-0066 P2a (#3247) — IndexCoordinator core + SourceManifest dirty state.
+
+Covers: mark_dirty state transition, ensure_built (await vs background),
+search_await (steady-state no-op vs cold-start/dirty heal), is_ready, the
+unified all-or-nothing embed-verify-write (+ its mandatory strip-falsify),
+and the mandatory truncate-falsify recovery test (CLAUDE.md recovery-feature
+gate) proving the dirty flag survives independently of the WAL.
+
+No mocks — real ``SourceManifest``, real ``SqliteIndexBackend``, real
+``OpContext``; a plain ``FakeEmbeddingProvider`` (same pattern as
+``tests/test_action_embedding_index.py``) stands in for the litellm
+boundary via the established ``get_provider`` monkeypatch convention.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index import SqliteIndexBackend
+from reyn.data.index.backend import ChunkRecord
+from reyn.data.index.coordinator import (
+    BuildMaterial,
+    IndexCoordinator,
+    assert_vector_count_match,
+    embed_verify_write,
+)
+from reyn.data.index.source_manifest import get_source_manifest
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Real OpContext whose `embed` op resolves to ``provider`` (mirrors
+    ``tests/test_action_embedding_index.py::_ctx_for``)."""
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+class _FakeEmbeddingProvider:
+    """Deterministic canned vectors, one per input text (no litellm call)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        self.calls.append(tuple(texts))
+        vectors = [[float((hash((t, i)) % 1000) / 1000.0) for i in range(4)] for t in texts]
+        return {"vectors": vectors, "model": model, "total_tokens": len(texts)}
+
+
+class _DegenerateFakeProvider:
+    """Always returns exactly 1 vector, regardless of input size — the
+    partial-build repro used by the all-or-nothing strip-falsify test."""
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        return {"vectors": [[1.0, 0.0]], "model": model, "total_tokens": 1}
+
+
+def _to_chunk_record(item: dict, vector: list[float], resolved_model: str) -> ChunkRecord:
+    return ChunkRecord(
+        text=item["text"],
+        vector=list(vector),
+        metadata={
+            "source_path": item["id"],
+            "source_type": "test",
+            "content_hash": item["id"],
+            "embedding_model": resolved_model,
+            "chunk_index": 0,
+            "size_tokens": 0,
+            "parent_context": None,
+            "extra": {},
+        },
+        score=None,
+    )
+
+
+def _working_build_fn(ctx: OpContext, items: list[dict]):
+    async def _build() -> BuildMaterial:
+        return BuildMaterial(
+            items=items,
+            texts=[it["text"] for it in items],
+            to_chunk_record=_to_chunk_record,
+            model_class="standard",
+            ctx=ctx,
+        )
+    return _build
+
+
+# ── 1. mark_dirty — state transition ────────────────────────────────────────
+
+
+def test_mark_dirty_persists_dirty_state_and_reason(tmp_path: Path) -> None:
+    """Tier 2: mark_dirty sets state="dirty" + last_error on the manifest
+    entry, persisted to sources.yaml (no entry needs to pre-exist)."""
+    coord = IndexCoordinator(tmp_path)
+    _run(coord.mark_dirty("skill", reason="provider_error: timeout"))
+
+    manifest = get_source_manifest(tmp_path)
+    entry = _run(manifest.get("skill"))
+    assert entry is not None
+    assert entry.state == "dirty"
+    assert entry.last_error == "provider_error: timeout"
+
+
+def test_mark_dirty_on_existing_clean_entry_flips_to_dirty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: a previously-clean (built) source can be marked dirty without
+    losing its chunk_count (only state + last_error change)."""
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("mem", _working_build_fn(ctx, items))
+    _run(coord.ensure_built("mem", await_completion=True))
+
+    manifest = get_source_manifest(tmp_path)
+    before = _run(manifest.get("mem"))
+    assert before is not None and before.state == "clean" and before.chunk_count == 1
+
+    _run(coord.mark_dirty("mem", reason="remember_failed"))
+    after = _run(manifest.get("mem"))
+    assert after is not None
+    assert after.state == "dirty"
+    assert after.last_error == "remember_failed"
+    assert after.chunk_count == 1, "chunk_count from the prior build must survive the dirty mark"
+
+
+# ── 2. ensure_built — await vs background, clean no-op ────────────────────
+
+
+def test_ensure_built_await_completion_builds_synchronously(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: ensure_built(await_completion=True) runs the build in-line and
+    returns a BuildOutcome with the written chunk_count; the manifest state
+    transitions to clean."""
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+    coord.register_builder("skill", _working_build_fn(ctx, items))
+
+    outcome = _run(coord.ensure_built("skill", await_completion=True))
+
+    assert outcome.triggered is True
+    assert outcome.background is False
+    assert outcome.chunk_count == 2
+    assert outcome.error is None
+    assert _run(coord.is_ready("skill")) is True
+
+
+def test_ensure_built_background_schedules_a_task_and_completes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: ensure_built(await_completion=False) returns immediately with
+    background=True; awaiting the loop lets the scheduled task finish and
+    the manifest observably transitions to clean."""
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("repo_doc", _working_build_fn(ctx, items))
+
+    async def _scenario() -> None:
+        outcome = await coord.ensure_built("repo_doc", await_completion=False)
+        assert outcome.background is True
+        assert outcome.triggered is True
+        # Poll the PUBLIC readiness gate for the scheduled background task
+        # to complete (bounded — no private-state introspection).
+        for _ in range(200):
+            if await coord.is_ready("repo_doc"):
+                break
+            await asyncio.sleep(0.01)
+        assert await coord.is_ready("repo_doc") is True
+
+    _run(_scenario())
+
+
+def test_ensure_built_clean_source_is_a_no_op(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: a source already state==clean short-circuits without
+    re-invoking the builder (no re-embed)."""
+    coord = IndexCoordinator(tmp_path)
+    provider = _FakeEmbeddingProvider()
+    ctx = _ctx_for(provider, monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("skill", _working_build_fn(ctx, items))
+    _run(coord.ensure_built("skill", await_completion=True))
+    calls_after_first_build = len(provider.calls)
+
+    outcome = _run(coord.ensure_built("skill", await_completion=True))
+
+    assert outcome.triggered is False
+    assert len(provider.calls) == calls_after_first_build, "clean source must not re-embed"
+
+
+# ── 3. search_await — steady-state no-op vs dirty heal ─────────────────────
+
+
+def test_search_await_on_clean_source_is_a_cheap_noop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: search_await on a clean source does not invoke the builder
+    (steady-state = cheap state-check only, per the firm's §5 contract)."""
+    coord = IndexCoordinator(tmp_path)
+    provider = _FakeEmbeddingProvider()
+    ctx = _ctx_for(provider, monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("skill", _working_build_fn(ctx, items))
+    _run(coord.ensure_built("skill", await_completion=True))
+    calls_after_build = len(provider.calls)
+
+    _run(coord.search_await("skill"))
+
+    assert len(provider.calls) == calls_after_build, "clean-state search_await must not build"
+
+
+def test_search_await_heals_a_dirty_source(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: search_await on a dirty source triggers a synchronous rebuild
+    (the §G2 completeness guarantee: a prior best-effort failure's dirty
+    mark gets healed at the next search)."""
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("memory", _working_build_fn(ctx, items))
+    _run(coord.mark_dirty("memory", reason="provider_error"))
+    assert _run(coord.is_ready("memory")) is False
+
+    _run(coord.search_await("memory"))
+
+    assert _run(coord.is_ready("memory")) is True
+
+
+def test_search_await_missing_source_is_a_noop(tmp_path: Path) -> None:
+    """Tier 2: search_await on a never-registered/never-built source_id is a
+    silent no-op (nothing to await)."""
+    coord = IndexCoordinator(tmp_path)
+    _run(coord.search_await("nonexistent"))  # must not raise
+
+
+# ── 4. is_ready ──────────────────────────────────────────────────────────
+
+
+def test_is_ready_false_before_build_true_after(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: is_ready reflects the persisted state==clean gate."""
+    coord = IndexCoordinator(tmp_path)
+    assert _run(coord.is_ready("skill")) is False
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    coord.register_builder("skill", _working_build_fn(ctx, [{"id": "a", "text": "a"}]))
+    _run(coord.ensure_built("skill", await_completion=True))
+    assert _run(coord.is_ready("skill")) is True
+
+
+# ── 5. all-or-nothing unification — positive + strip-falsify ──────────────
+
+
+def test_assert_vector_count_match_raises_on_mismatch() -> None:
+    """Tier 2: the unified guard raises RuntimeError naming the item_noun/
+    label (both existing call sites' distinct wording is preserved via
+    these params)."""
+    with pytest.raises(RuntimeError, match="refusing partial build"):
+        assert_vector_count_match(1, 2, item_noun="items", label="build")
+    with pytest.raises(RuntimeError, match="refusing partial index_update write"):
+        assert_vector_count_match(1, 2, item_noun="chunks", label="index_update write")
+
+
+def test_embed_verify_write_refuses_partial_write(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: embed_verify_write, with the REAL (unpatched) guard, raises
+    before writing anything when the provider returns too few vectors — no
+    partial batch reaches the backend."""
+    ctx = _ctx_for(_DegenerateFakeProvider(), monkeypatch)
+    backend = SqliteIndexBackend(workspace_root=tmp_path)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+
+    with pytest.raises(RuntimeError, match="refusing partial build"):
+        _run(embed_verify_write(
+            ctx=ctx, texts=[it["text"] for it in items], model_class="standard",
+            items=items, to_chunk_record=_to_chunk_record, backend=backend,
+            source="strip_test", mode="replace", item_noun="items", label="build",
+        ))
+
+    stat = _run(backend.stat("strip_test"))
+    assert stat["chunk_count"] == 0, "no partial write must have reached the backend"
+
+
+def test_strip_falsify_neutered_guard_accepts_partial_write(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Tier 2: (strip-falsify, #3247 architect-required) neutering the
+    unified all-or-nothing guard (monkeypatch it to a no-op) causes the
+    SAME mismatched-vector-count input that the previous test proved gets
+    REJECTED to instead be silently ACCEPTED as a partial write (1 chunk
+    persisted for 2 requested items, no exception). This demonstrates the
+    guard itself — not incidental plumbing around it — is what prevents
+    the partial-write data-loss vector. RED (of the guarantee) is exactly
+    this test passing."""
+    import reyn.data.index.coordinator as coordinator_mod
+
+    monkeypatch.setattr(coordinator_mod, "assert_vector_count_match", lambda *a, **kw: None)
+    ctx = _ctx_for(_DegenerateFakeProvider(), monkeypatch)
+    backend = SqliteIndexBackend(workspace_root=tmp_path)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+
+    result = _run(embed_verify_write(
+        ctx=ctx, texts=[it["text"] for it in items], model_class="standard",
+        items=items, to_chunk_record=_to_chunk_record, backend=backend,
+        source="strip_test", mode="replace", item_noun="items", label="build",
+    ))
+
+    stat = _run(backend.stat("strip_test"))
+    assert stat["chunk_count"] == 1, (
+        "with the guard neutered, zip(items, vectors) silently truncates to "
+        "the SHORTER list -- a 1-vector response for 2 requested items writes "
+        "exactly 1 chunk instead of raising; this is the partial-write bug "
+        "the real (unpatched) guard exists to prevent"
+    )
+    assert result.write_result["written"] == 1
+
+
+# ── 6. truncate-falsify — recovery-feature gate (CLAUDE.md, #2259/#2260-class) ─
+
+
+def test_dirty_flag_survives_wal_truncation_and_search_await_heals(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: (truncate-falsify, mandatory recovery-feature gate) the
+    IndexCoordinator's dirty state is recorded in sources.yaml -- a file
+    completely independent of the agent-state WAL
+    (``.reyn/state/wal.jsonl``, see docs/concepts/runtime/events.md "WAL vs
+    audit-event separation"). This test proves recovery-of-record is the
+    persisted sources.yaml dirty flag, NOT anything WAL-derived:
+
+      1. Build a source to state==clean (coordinator instance #1).
+      2. mark_dirty (simulating a sync-in-op provider failure, §G2).
+      3. Write SOME WAL entries, then TRUNCATE the WAL file to empty --
+         simulating a crash where the WAL substrate loses everything past
+         (and including) the point the dirty mark was set. If the dirty
+         flag depended on the WAL, it would be gone here.
+      4. Discard coordinator #1 entirely (its in-memory build-queue /
+         failure-memo are volatile BY DESIGN -- simulates a process
+         restart) and construct a FRESH coordinator #2 against the SAME
+         workspace_root.
+      5. Assert the dirty state SURVIVED (read purely from sources.yaml)
+         and that a fresh search_await (with a newly-registered builder,
+         as a real restarted process would re-register its domain
+         adapters) HEALS it -- re-running the build and returning to
+         state==clean.
+    """
+    from reyn.core.events.state_log import StateLog
+
+    coord1 = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord1.register_builder("doc_source", _working_build_fn(ctx, items))
+    _run(coord1.ensure_built("doc_source", await_completion=True))
+    assert _run(coord1.is_ready("doc_source")) is True
+
+    _run(coord1.mark_dirty("doc_source", reason="provider_error: transient timeout"))
+
+    # Simulate WAL activity around the dirty mark, then truncate it away --
+    # proving the dirty flag's survival has nothing to do with WAL content.
+    wal_path = tmp_path / ".reyn" / "state" / "wal.jsonl"
+    wal_path.parent.mkdir(parents=True, exist_ok=True)
+    log = StateLog(wal_path)
+    _run(log.append("inbox_put", target="some-agent", msg_id="m1", msg_kind="user", payload={}))
+    _run(log.flush())
+    assert wal_path.exists() and wal_path.stat().st_size > 0
+    wal_path.write_bytes(b"")  # truncate below (= including) the dirty-mark point
+
+    # "restart": drop coordinator #1's in-memory state, build a fresh one.
+    del coord1
+    coord2 = IndexCoordinator(tmp_path)
+
+    entry_after_restart = _run(get_source_manifest(tmp_path).get("doc_source"))
+    assert entry_after_restart is not None
+    assert entry_after_restart.state == "dirty", (
+        "the dirty flag must survive a fully-truncated WAL -- it is persisted "
+        "in sources.yaml, independent of the WAL substrate"
+    )
+    assert _run(coord2.is_ready("doc_source")) is False
+
+    # A restarted process re-registers its domain builder, then a search
+    # triggers the heal (§G2's recovery path).
+    coord2.register_builder("doc_source", _working_build_fn(ctx, items))
+    _run(coord2.search_await("doc_source"))
+
+    assert _run(coord2.is_ready("doc_source")) is True
+    healed_entry = _run(get_source_manifest(tmp_path).get("doc_source"))
+    assert healed_entry is not None
+    assert healed_entry.state == "clean"
+    assert healed_entry.last_error is None

--- a/tests/test_index_coordinator_3247_p2a.py
+++ b/tests/test_index_coordinator_3247_p2a.py
@@ -29,7 +29,7 @@ from reyn.data.index.coordinator import (
     assert_vector_count_match,
     embed_verify_write,
 )
-from reyn.data.index.source_manifest import get_source_manifest
+from reyn.data.index.source_manifest import SourceManifest, get_source_manifest
 from reyn.data.workspace.workspace import Workspace
 from reyn.security.permissions.permissions import PermissionDecl
 
@@ -327,7 +327,9 @@ def test_dirty_flag_survives_wal_truncation_and_search_await_heals(
     completely independent of the agent-state WAL
     (``.reyn/state/wal.jsonl``, see docs/concepts/runtime/events.md "WAL vs
     audit-event separation"). This test proves recovery-of-record is the
-    persisted sources.yaml dirty flag, NOT anything WAL-derived:
+    persisted sources.yaml dirty flag, NOT anything WAL-derived, AND that
+    the "restart" genuinely reloads from the FILE rather than riding an
+    in-memory manifest cache still alive in the same process:
 
       1. Build a source to state==clean (coordinator instance #1).
       2. mark_dirty (simulating a sync-in-op provider failure, §G2).
@@ -335,15 +337,24 @@ def test_dirty_flag_survives_wal_truncation_and_search_await_heals(
          simulating a crash where the WAL substrate loses everything past
          (and including) the point the dirty mark was set. If the dirty
          flag depended on the WAL, it would be gone here.
-      4. Discard coordinator #1 entirely (its in-memory build-queue /
+      4. Reset the per-workspace ``SourceManifest`` SINGLETON cache
+         (``get_source_manifest`` caches one instance per resolved
+         workspace_root in a module-level dict) -- WITHOUT this, step 5
+         below would silently pass by reading the SAME in-memory
+         ``SourceEntry`` object rather than genuinely re-parsing
+         ``sources.yaml``, which would make the test vacuous with respect
+         to file-persistence (see the paired strip-falsify test below,
+         which proves this reset is what makes the gate non-vacuous).
+      5. Discard coordinator #1 entirely (its in-memory build-queue /
          failure-memo are volatile BY DESIGN -- simulates a process
          restart) and construct a FRESH coordinator #2 against the SAME
-         workspace_root.
-      5. Assert the dirty state SURVIVED (read purely from sources.yaml)
-         and that a fresh search_await (with a newly-registered builder,
-         as a real restarted process would re-register its domain
-         adapters) HEALS it -- re-running the build and returning to
-         state==clean.
+         workspace_root -- it gets a brand-new ``SourceManifest`` that has
+         never read anything, forcing a real file parse on first access.
+      6. Assert the dirty state SURVIVED (read purely from a freshly
+         re-parsed sources.yaml) and that a fresh search_await (with a
+         newly-registered builder, as a real restarted process would
+         re-register its domain adapters) HEALS it -- re-running the
+         build and returning to state==clean.
     """
     from reyn.core.events.state_log import StateLog
 
@@ -366,15 +377,22 @@ def test_dirty_flag_survives_wal_truncation_and_search_await_heals(
     assert wal_path.exists() and wal_path.stat().st_size > 0
     wal_path.write_bytes(b"")  # truncate below (= including) the dirty-mark point
 
-    # "restart": drop coordinator #1's in-memory state, build a fresh one.
+    # "restart": drop coordinator #1's in-memory state AND the per-workspace
+    # SourceManifest singleton cache (else coord2 below would transparently
+    # ride #1's already-loaded in-memory SourceEntry, never touching disk --
+    # see test_reload_after_singleton_reset_depends_on_real_file_persist for
+    # the strip-falsify proof that this reset is what forces a real reload).
     del coord1
+    _reset_manifest_singleton(tmp_path)
     coord2 = IndexCoordinator(tmp_path)
 
     entry_after_restart = _run(get_source_manifest(tmp_path).get("doc_source"))
     assert entry_after_restart is not None
     assert entry_after_restart.state == "dirty", (
-        "the dirty flag must survive a fully-truncated WAL -- it is persisted "
-        "in sources.yaml, independent of the WAL substrate"
+        "the dirty flag must survive a fully-truncated WAL AND a fresh "
+        "SourceManifest re-parse of sources.yaml -- it is persisted on "
+        "disk, independent of both the WAL substrate and any in-process "
+        "manifest cache"
     )
     assert _run(coord2.is_ready("doc_source")) is False
 
@@ -388,3 +406,72 @@ def test_dirty_flag_survives_wal_truncation_and_search_await_heals(
     assert healed_entry is not None
     assert healed_entry.state == "clean"
     assert healed_entry.last_error is None
+
+
+def _reset_manifest_singleton(workspace_root: Path) -> None:
+    """Evict the ``get_source_manifest`` per-workspace singleton cache so the
+    next call constructs a fresh ``SourceManifest`` (empty in-memory cache,
+    forced to re-parse ``sources.yaml`` from disk on first read) -- the
+    same-process equivalent of a process restart for THIS specific cache."""
+    import reyn.data.index.source_manifest as _sm_mod
+
+    _sm_mod._MANIFESTS.pop(workspace_root.resolve(), None)
+
+
+def test_reload_after_singleton_reset_depends_on_real_file_persist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: (strip-falsify, #3247 co-vet) proves the singleton reset in
+    the truncate-falsify test above is not itself vacuous -- it genuinely
+    forces a read FROM ``sources.yaml``, not from an in-memory cache.
+
+    Neuters ``SourceManifest._atomic_write`` (the real on-disk persist) to a
+    no-op so ``mark_dirty``'s ``upsert`` updates ONLY the in-memory cache,
+    never the file. Confirms the (expected, uninteresting) in-process read
+    still shows "dirty" via the live cache. Then resets the singleton
+    (forcing a fresh ``SourceManifest`` that has never cached anything) and
+    re-reads: because the file was never actually written, the entry comes
+    back "clean" (or absent) -- NOT "dirty". This is the falsifying case:
+    if the truncate-falsify test's post-restart assertion
+    (``state == "dirty"``) were run against a build whose file-persistence
+    is broken, it would FAIL here -- proving that test's green result
+    requires genuine file persistence, not merely the singleton surviving
+    in memory.
+    """
+    coord = IndexCoordinator(tmp_path)
+    ctx = _ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("doc_source", _working_build_fn(ctx, items))
+    _run(coord.ensure_built("doc_source", await_completion=True))
+    assert _run(coord.is_ready("doc_source")) is True
+
+    # Neuter the real on-disk persist -- upsert() still updates the
+    # in-memory cache, but the write to sources.yaml never happens.
+    async def _noop_atomic_write(self, *, sandbox_write_paths=None) -> None:  # noqa: ANN001
+        return None
+
+    monkeypatch.setattr(SourceManifest, "_atomic_write", _noop_atomic_write)
+
+    _run(coord.mark_dirty("doc_source", reason="provider_error: transient timeout"))
+
+    # Same-process, same singleton: the in-memory cache DOES show dirty --
+    # this is the uninteresting case the original (un-fixed) test relied on.
+    same_process_entry = _run(get_source_manifest(tmp_path).get("doc_source"))
+    assert same_process_entry is not None and same_process_entry.state == "dirty", (
+        "sanity check: the in-memory cache reflects the mark_dirty call "
+        "regardless of whether the file write happened"
+    )
+
+    # Reset the singleton -- the next get_source_manifest() constructs a
+    # FRESH SourceManifest with an empty cache, forced to parse the file.
+    _reset_manifest_singleton(tmp_path)
+    reloaded_entry = _run(get_source_manifest(tmp_path).get("doc_source"))
+
+    assert reloaded_entry is not None
+    assert reloaded_entry.state != "dirty", (
+        "with the real file-write neutered, a genuine reload from "
+        "sources.yaml must NOT observe 'dirty' -- it was never durably "
+        "written. Seeing 'dirty' here would mean the singleton reset "
+        "failed to force a real file re-parse, which would make the "
+        "truncate-falsify test's post-restart assertion vacuous."
+    )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247. Implements P2a per the architect's ratified "P2 IndexCoordinator 設計 firm" comment on #3247 — core orchestration + SourceManifest dirty state only. Call-site migration (P2b), sync-in-op wiring + G3 delete de-index (P2c), and audit-event phase emit (P2d) are deliberately NOT in this PR.

## Interface (`src/reyn/data/index/coordinator.py`)

`IndexCoordinator` (per-workspace; construction mirrors `SourceManifest`/`get_source_manifest` but is not itself enforced-singleton):

- `mark_dirty(source_id, *, reason)` — best-effort dirty mark (the §G2 provider-failure recovery hook), persisted via `SourceManifest.upsert`.
- `ensure_built(source_id, *, await_completion) -> BuildOutcome` — if dirty/error/never-built, (re)builds: acquires the cross-process `build_lock` (take-or-skip, `try_acquire_build_lock`) → runs the registered domain builder → the unified all-or-nothing embed-verify-write → updates manifest state. `await_completion=True` runs in-line (sync-in-op shape); `False` schedules `asyncio.create_task` (background), at most one live task per `source_id`. Never raises — a failure is caught, mark_dirty'd, memoized, and reported on `BuildOutcome.error`.
- `search_await(source_id)` — the completeness guarantee. `state==clean` = cheap no-op (no build). `dirty`/`error` triggers a synchronous heal. `building` awaits the in-flight task if this process owns it.
- `is_ready(source_id)` — readiness gate (`state==clean`).
- `build_failed(source_id)` — per-process failure-memo read, mirrors `RouterLoop._action_index_build_failed`.

**Interpretation flagged for review**: the firm's `ensure_built(source_id, *, await_completion)` signature carries no build-strategy parameter, but a build needs to know the domain's items/texts/item↔ChunkRecord mapping somehow. I added `register_builder(source_id, build_fn)` as necessary plumbing — NOT a production call-site migration (nothing in production calls it yet; only this PR's tests do). P2b will decide how real domain adapters (action_index, router_loop) actually register with a live Coordinator instance.

## All-or-nothing unification (+ strip-falsify)

`ActionEmbeddingIndex.build()` and the `index_update` op each carried a **verbatim-identical** guard:
```python
if len(vectors) != len(items): raise RuntimeError(f"...refusing partial {label}")
```
Extracted to `coordinator.assert_vector_count_match(vector_count, item_count, *, item_noun, label)` — both call sites now call this ONE function (their distinct message wording — "refusing partial build" vs "refusing partial index_update write" — preserved via `item_noun`/`label`, so `tests/test_action_embedding_index.py`'s existing `match="refusing partial build"` assertion needed no change). A fuller `embed_verify_write` (embed-op call → guard → chunk-record mapping → backend write) wraps this for the Coordinator's own build path.

**Strip-falsify** (`test_strip_falsify_neutered_guard_accepts_partial_write`): monkeypatches `coordinator.assert_vector_count_match` to a no-op, then re-runs the SAME mismatched-vector-count input (`_DegenerateFakeProvider` returns 1 vector for 2 requested items) that the preceding test proved gets REJECTED. With the guard neutered, `zip(items, vectors)` silently truncates to the shorter list — the test asserts exactly 1 chunk gets persisted (not 2, not an exception), proving the guard itself — not incidental plumbing — is what prevents a partial-write data-loss vector. RED (of the safety guarantee) is this test passing.

## SourceEntry state (§2)

`SourceEntry` gains `state: clean|dirty|building|error` (default `"clean"`, coerced-to-`"clean"` on any missing/garbage on-disk value — a pre-P2a `sources.yaml` has no usable dirty signal, and "assume clean" is the safe read) + `last_error: str | None`. Persisted in `sources.yaml` via the EXISTING atomic-write mechanism (`SourceManifest._atomic_write`) — single SSoT, no second state store. `acquire_source_lock` (previously production-unused) is not yet wired into the Coordinator's build path in P2a — the Coordinator instead uses the shared cross-process `build_lock` (`try_acquire_build_lock`) for build-serialization; `acquire_source_lock`'s raise-on-contention shape stays available for P2b/P2c to activate where it fits (flagged, not silently dropped).

## Truncate-falsify (mandatory recovery-feature gate)

`test_dirty_flag_survives_wal_truncation_and_search_await_heals`:
1. Build a source to `clean` (coordinator #1).
2. `mark_dirty` (simulating a sync-in-op provider failure).
3. Write a real WAL entry (`StateLog.append`) then **truncate the WAL file to empty** — simulating a crash where the agent-state WAL substrate loses everything, proving the dirty flag's survival has nothing to do with WAL content (it's `sources.yaml`-persisted, per `docs/concepts/runtime/events.md`'s WAL-vs-audit-event separation).
4. Discard coordinator #1 (its in-memory build-queue/failure-memo are volatile by design) and construct a FRESH coordinator #2 against the same workspace_root (simulating a process restart).
5. Assert the dirty state survived (read purely from `sources.yaml`) and that `is_ready` is False.
6. Re-register a builder on coordinator #2 (as a real restarted process would) and call `search_await` → assert it heals (rebuilds, returns to `clean`).

## Local CI (all four gates)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_index_coordinator_3247_p2a.py` — 13/13 OK, 0 Tier-4 violations.
- `PYTHONPATH=$(pwd)/src python -m pytest` (full suite, foreground) — **9122 passed, 36 skipped**, 0 failures.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan
- [x] `pytest tests/test_index_coordinator_3247_p2a.py` — 13 passed
- [x] `pytest tests/test_action_embedding_index.py tests/test_op_index_update.py` — 29 passed (no regression from the shared-guard refactor)
- [x] Full suite green