### PR TITLE
feat(FP-0066 P2b): per-kind source split + migrate action-catalog build to IndexCoordinator (byte-identical)

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -48,6 +48,7 @@ from reyn.data.index.backend import cache_dir_for_source
 from reyn.data.index.build_lock import try_acquire_build_lock
 from reyn.data.index.source_manifest import (
     SourceEntry,
+    SourceKind,
     SourceManifest,
     get_source_manifest,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "assert_vector_count_match",
     "embed_verify_write",
     "IndexCoordinator",
+    "get_index_coordinator",
 ]
 
 
@@ -237,16 +239,32 @@ class IndexCoordinator:
         # Recovery does NOT depend on these — see module docstring.
         self._bg_tasks: dict[str, "asyncio.Task[BuildOutcome]"] = {}
         self._failure_memo: dict[str, str] = {}
+        # FP-0066 P2b (#3247 firm §2): per-source kind, remembered so a
+        # freshly-created manifest entry (mark_dirty/_set_state on a
+        # source never seen before) is tagged correctly instead of falling
+        # through to the "backfill" dataclass default. Registered
+        # alongside the build strategy (see ``register_builder``/
+        # ``ensure_built_self_contained``); a source that never registers
+        # a kind stays "backfill" (predates the taxonomy).
+        self._kinds: dict[str, SourceKind] = {}
 
     # ── registration (necessary plumbing, not a P2b call-site migration) ──
 
-    def register_builder(self, source_id: str, build_fn: BuildFn) -> None:
+    def register_builder(
+        self, source_id: str, build_fn: BuildFn, *, kind: SourceKind = "backfill",
+    ) -> None:
         """Associate a domain build strategy with ``source_id``.
 
         Idempotent — re-registering replaces the prior strategy (useful for
         tests and for a future config-driven re-registration on reload).
+        ``kind`` (FP-0066 P2b, #3247 firm §2) tags a freshly-created
+        manifest entry for this source with its taxonomy classification;
+        re-registering with a different ``kind`` updates the remembered
+        value for the NEXT freshly-created entry (an already-persisted
+        entry's ``kind`` is not silently overwritten by re-registration).
         """
         self._builders[source_id] = build_fn
+        self._kinds[source_id] = kind
 
     # ── mark_dirty (#3247 firm §1) ──────────────────────────────────────
 
@@ -264,6 +282,7 @@ class IndexCoordinator:
         if entry is None:
             entry = SourceEntry(
                 name=source_id, description="", path="", backend="sqlite",
+                kind=self._kinds.get(source_id, "backfill"),
             )
         entry.state = "dirty"
         entry.last_error = reason
@@ -364,7 +383,10 @@ class IndexCoordinator:
     ) -> None:
         entry = await self._manifest.get(source_id)
         if entry is None:
-            entry = SourceEntry(name=source_id, description="", path="", backend="sqlite")
+            entry = SourceEntry(
+                name=source_id, description="", path="", backend="sqlite",
+                kind=self._kinds.get(source_id, "backfill"),
+            )
         entry.state = state  # type: ignore[assignment]
         if state == "clean":
             entry.last_error = None
@@ -430,3 +452,116 @@ class IndexCoordinator:
         so a fresh process/session gets exactly one retry, which is the
         desired heal path)."""
         return source_id in self._failure_memo
+
+    # ── ensure_built_self_contained (FP-0066 P2b, #3247) ─────────────────
+    #
+    # ``ensure_built`` (above) is for a domain adapter that hands the
+    # Coordinator raw MATERIAL (items/texts/mapping) and lets the
+    # Coordinator own the cross-process lock + ``embed_verify_write``. That
+    # shape does not fit every domain adapter discovered while actually
+    # doing the P2b migration: ``ActionEmbeddingIndex.build()`` already owns
+    # its OWN cross-process lock (``try_acquire_build_lock`` at the SAME
+    # ``cache_dir_for_source`` path ``ensure_built`` would acquire) plus a
+    # disk-adopt / dual-axis invalidation policy that is deeply entangled
+    # with whether it writes at all — splitting it into a material-only
+    # ``BuildFn`` would either duplicate that policy here (violating the
+    # firm's "domain adapter owns invalidation policy" boundary) or cause a
+    # SECOND acquisition of the same advisory lock within one process
+    # (self-deadlock-shaped: the second ``try_acquire_build_lock`` call
+    # would see ITS OWN pid as a live holder and skip, silently no-op-ing
+    # every build).
+    #
+    # ``ensure_built_self_contained`` narrows the Coordinator's role for
+    # such an adapter to pure orchestration — once-per-source background-
+    # task dedup (``_bg_tasks``) + failure-memo (``_failure_memo``) +
+    # manifest state bookkeeping — while the SELF-CONTAINED builder
+    # (``build_coro``) keeps owning its own lock/write/invalidation policy
+    # end to end, exactly as it did pre-migration. See
+    # ``RouterLoop._ensure_action_index_built`` for the production caller.
+    async def ensure_built_self_contained(
+        self,
+        source_id: str,
+        build_coro: Callable[[], Awaitable[None]],
+        *,
+        await_completion: bool,
+        is_ready_probe: Callable[[], bool],
+        chunk_count_probe: Callable[[], int] | None = None,
+        kind: SourceKind = "backfill",
+    ) -> BuildOutcome:
+        """Orchestrate (dedup/failure-memo/state) a self-contained builder.
+
+        ``build_coro`` is called with no args and is expected to perform
+        the ENTIRE build (its own locking, its own write) and raise on
+        failure (never swallow) — ``is_ready_probe`` is then consulted
+        (not ``build_coro``'s return value) to decide whether the manifest
+        should record ``clean`` (matches the domain adapter's own
+        source-of-truth for "did this actually succeed", e.g.
+        ``ActionEmbeddingIndex.is_ready()`` post-``build()``).
+
+        Same await/background split as ``ensure_built``: ``await_completion
+        =True`` runs inline; ``=False`` schedules via ``asyncio.create_task``
+        with the same once-per-source in-flight dedup (``_bg_tasks``).
+        Never raises — a failure is caught, mark_dirty'd, memoized, and
+        reported on the returned ``BuildOutcome.error``.
+        """
+        self._kinds[source_id] = kind
+        entry = await self._manifest.get(source_id)
+        if entry is not None and entry.state == "clean" and is_ready_probe():
+            return BuildOutcome(
+                source_id=source_id, triggered=False, background=False,
+                chunk_count=entry.chunk_count,
+            )
+
+        async def _run() -> BuildOutcome:
+            await self._set_state(source_id, "building")
+            try:
+                await build_coro()
+            except Exception as exc:
+                reason = f"build_error: {exc}"
+                self._failure_memo[source_id] = reason
+                await self.mark_dirty(source_id, reason=reason)
+                return BuildOutcome(
+                    source_id=source_id, triggered=True, background=False,
+                    error=str(exc),
+                )
+            if is_ready_probe():
+                chunk_count = chunk_count_probe() if chunk_count_probe else None
+                await self._set_state(source_id, "clean", chunk_count=chunk_count)
+                return BuildOutcome(
+                    source_id=source_id, triggered=True, background=False,
+                    chunk_count=chunk_count,
+                )
+            # The builder ran without raising but didn't reach readiness
+            # (e.g. its own lock-skip fallback: "another process is mid-
+            # build") — leave manifest state as-is (not clean), matching
+            # the pre-migration silent-fallback semantics.
+            return BuildOutcome(source_id=source_id, triggered=True, background=False)
+
+        if not await_completion:
+            existing_task = self._bg_tasks.get(source_id)
+            if existing_task is not None and not existing_task.done():
+                return BuildOutcome(source_id=source_id, triggered=True, background=True)
+            task = asyncio.create_task(_run())
+            self._bg_tasks[source_id] = task
+            return BuildOutcome(source_id=source_id, triggered=True, background=True)
+
+        return await _run()
+
+
+# ── Module-level singleton registry (per-workspace) ───────────────────────
+#
+# Mirrors ``get_source_manifest`` (FP-0066 P2b, #3247): a session/router-
+# scoped caller (``RouterLoop._get_index_coordinator``) needs the SAME
+# ``IndexCoordinator`` instance across turns within a chain (and across
+# chains within the same workspace) so ``_bg_tasks``/``_failure_memo``
+# once-per-source dedup actually dedups rather than resetting every call.
+
+_COORDINATORS: dict[Path, IndexCoordinator] = {}
+
+
+def get_index_coordinator(workspace_root: Path) -> IndexCoordinator:
+    """Get or create the IndexCoordinator singleton for a workspace."""
+    workspace_root = workspace_root.resolve()
+    if workspace_root not in _COORDINATORS:
+        _COORDINATORS[workspace_root] = IndexCoordinator(workspace_root)
+    return _COORDINATORS[workspace_root]

--- a/src/reyn/data/index/source_manifest.py
+++ b/src/reyn/data/index/source_manifest.py
@@ -35,6 +35,21 @@ from reyn.data.index.build_lock import pid_alive as _pid_alive
 SourceState = Literal["clean", "dirty", "building", "error"]
 _VALID_SOURCE_STATES: frozenset[str] = frozenset({"clean", "dirty", "building", "error"})
 
+# FP-0066 P2b (#3247 firm §2): per-kind source taxonomy. ``dynamic`` = a
+# source whose content changes via an operator-driven op (skill load/
+# install, remember, index_update) — P2c wires these to sync-in-op
+# ``ensure_built(await_completion=True)``. ``static`` = a source that
+# changes out-of-band of any single op (the builtin action-catalog,
+# repo_doc, repo_src) — built in the BACKGROUND per the firm's §3
+# sync-vs-background table (never a foreground surprise to an unaware
+# operation). ``backfill`` = a source that already existed before
+# ``embedding.enabled`` was ever flipped on — the SAFE coercion default
+# for any pre-P2b ``sources.yaml`` entry (or one missing/garbled ``kind``),
+# since "assume this predates the taxonomy" is the least-surprising read
+# (mirrors the ``state`` coercion default rationale below).
+SourceKind = Literal["dynamic", "static", "backfill"]
+_VALID_SOURCE_KINDS: frozenset[str] = frozenset({"dynamic", "static", "backfill"})
+
 
 @dataclass
 class SourceEntry:
@@ -54,6 +69,13 @@ class SourceEntry:
     # truncate-falsify test).
     state: SourceState = "clean"
     last_error: str | None = None
+    # FP-0066 P2b (#3247 firm §2): per-kind taxonomy, persisted alongside
+    # ``state`` (same file SSoT — no second state store). Defaults to
+    # "backfill" for the dataclass itself (a freshly-constructed entry with
+    # no caller-supplied kind is, by construction, not yet classified as
+    # dynamic/static — "predates the taxonomy" is the safe read, same
+    # rationale as the on-disk coercion default in ``from_dict``).
+    kind: SourceKind = "backfill"
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to the on-disk YAML structure (name is the key, not a field)."""
@@ -63,6 +85,7 @@ class SourceEntry:
             "backend": self.backend,
             "chunk_count": self.chunk_count,
             "state": self.state,
+            "kind": self.kind,
         }
         if self.last_indexed is not None:
             d["last_indexed"] = self.last_indexed
@@ -100,6 +123,14 @@ class SourceEntry:
                 return v  # type: ignore[return-value]
             return "clean"
 
+        def _coerce_kind(v: object) -> SourceKind:
+            if isinstance(v, str) and v in _VALID_SOURCE_KINDS:
+                return v  # type: ignore[return-value]
+            # Missing/garbled kind on a pre-P2b (or operator-edited)
+            # sources.yaml → "backfill" (predates the taxonomy), per this
+            # field's own docstring.
+            return "backfill"
+
         return cls(
             name=name,
             description=data.get("description", ""),
@@ -110,6 +141,7 @@ class SourceEntry:
             embedding_model=data.get("embedding_model"),
             state=_coerce_state(data.get("state")),
             last_error=data.get("last_error"),
+            kind=_coerce_kind(data.get("kind")),
         )
 
 

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1156,13 +1156,13 @@ class RouterLoop:
             )
         else:
             self._contextual_permission = None
-        # FP-0034 Phase 2 step 1: action embedding index background
-        # build task handle.  None until the first turn that finds the
-        # index configured + not ready, then asyncio.Task while
-        # building.  Stays set after completion so we don't re-spawn
-        # (the build itself is idempotent via catalog hash, but we
-        # avoid the extra Task overhead).
-        self._action_index_build_task: "asyncio.Task[None] | None" = None
+        # FP-0034 Phase 2 step 1 / FP-0066 P2b (#3247): the action embedding
+        # index background-build once-per-chain dedup used to live on a
+        # RouterLoop instance attr (``_action_index_build_task``). That
+        # dedup is now owned by ``IndexCoordinator._bg_tasks`` (per-
+        # workspace singleton, see ``_get_index_coordinator`` below) —
+        # absorbed per the #3247 firm §1/§7, so there is no
+        # RouterLoop-instance-scoped task handle to declare here anymore.
         # ADR-0025: optional sub-loop LLM call memoization. When set,
         # ``call_llm_tools`` invocations consult the provider before
         # invoking — args_hash hit returns the recorded LLMToolCallResult
@@ -1285,12 +1285,21 @@ class RouterLoop:
         # fixture SP keys unaffected.
         _env_info_getter = getattr(host, "get_environment_info", None)
         _environment_info = _env_info_getter() if callable(_env_info_getter) else None
-        # FP-0034 Phase 2 step 1: D14 visibility gate for search_actions.
-        # Only show search_actions when (a) wrappers are on, (b) the
-        # operator configured an embedding model class, AND (c) the
-        # session has an ActionEmbeddingIndex that is_ready().  Any
+        # FP-0034 Phase 2 step 1 / FP-0066 P2b (#3247): D14 visibility gate
+        # for search_actions. Only show search_actions when (a) wrappers are
+        # on, (b) the operator configured an embedding model class, AND (c)
+        # the session has an ActionEmbeddingIndex that is_ready().  Any
         # missing signal degrades to "hide" so the LLM does not see a
         # tool whose query would return empty results.
+        #
+        # P2b: the eager-vs-background DECISION + once-per-chain spawn dedup
+        # + failure-memo are now routed through ``IndexCoordinator`` (see
+        # ``_ensure_action_index_built`` / ``ensure_built_self_contained``)
+        # instead of the RouterLoop-instance-scoped ``_action_index_build_task``
+        # flag. ``_build_action_embedding_index_background`` itself (the
+        # actual build primitive: fetch catalog, call ``idx.build()``,
+        # handle failure — pinned by #1458's tests) is UNCHANGED; only its
+        # caller-side orchestration moved.
         _search_visible = False
         if _univ_enabled:
             _idx_getter = getattr(host, "get_action_embedding_index", None)
@@ -1301,15 +1310,15 @@ class RouterLoop:
             _provider = _provider_getter() if _provider_getter else None
             _model_class = _model_getter() if _model_getter else None
             _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
+            # #1458: skip both build paths when a prior attempt in this session
+            # failed (per-session failure memoization). The failed flag is set
+            # in _build_action_embedding_index_background on any exception.
+            _build_failed = getattr(self, "_action_index_build_failed", False)
             # B25-S5-1: when eager flag is set, await the build synchronously
             # before computing _search_visible. This pays the build cost on
             # the first turn (= once per session; subsequent turns see
             # is_ready() True via SQLite cache) but eliminates the cold-start
             # race where search_actions is hidden from the LLM on Turn 1.
-            # #1458: skip both build paths when a prior attempt in this session
-            # failed (per-session failure memoization). The failed flag is set
-            # in _build_action_embedding_index_background on any exception.
-            _build_failed = getattr(self, "_action_index_build_failed", False)
             if (
                 _eager_embedding_build
                 and _idx is not None
@@ -1318,8 +1327,8 @@ class RouterLoop:
                 and not getattr(_idx, "is_ready", lambda: False)()
                 and not _build_failed
             ):
-                await self._build_action_embedding_index_background(
-                    _idx, _provider, _model_class,
+                await self._ensure_action_index_built(
+                    _idx, _provider, _model_class, await_completion=True,
                 )
             if (
                 _idx is not None
@@ -1327,24 +1336,22 @@ class RouterLoop:
                 and getattr(_idx, "is_ready", lambda: False)()
             ):
                 _search_visible = True
-            # FP-0034 Phase 2 step 1: kick off the background build
-            # when the index is configured but not yet ready.  The
+            # FP-0034 Phase 2 step 1 / FP-0066 P2b: kick off the background
+            # build when the index is configured but not yet ready.  The
             # build is idempotent (= same catalog hash → no-op) and
-            # serialised by the index's internal lock.  Only spawned
-            # once per RouterLoop (= per chain) via the
-            # ``_action_index_build_task`` flag below.
+            # serialised by the index's internal lock; once-per-source
+            # in-flight dedup is now IndexCoordinator's
+            # ``ensure_built_self_contained`` (``_bg_tasks``), not a
+            # RouterLoop instance flag.
             if (
                 _idx is not None
                 and _provider is not None
                 and _model_class
                 and not getattr(_idx, "is_ready", lambda: False)()
-                and getattr(self, "_action_index_build_task", None) is None
                 and not _build_failed
             ):
-                self._action_index_build_task = asyncio.create_task(
-                    self._build_action_embedding_index_background(
-                        _idx, _provider, _model_class,
-                    )
+                await self._ensure_action_index_built(
+                    _idx, _provider, _model_class, await_completion=False,
                 )
         # D2-wrapper scope expansion (B38): build session-level resource
         # metadata maps when universal wrappers are enabled — regardless of
@@ -3357,6 +3364,87 @@ class RouterLoop:
     # wired by one flag, and the cross-seam guard asserts every ADVERTISED bare router
     # tool carries it. Per-tool rationale now lives on each ToolDefinition.
     REGISTRY_DISPATCH_TOOLS: "frozenset[str]" = _derive_registry_dispatch_tools()
+
+    def _get_index_coordinator(self) -> Any:
+        """Return the per-workspace ``IndexCoordinator`` singleton (FP-0066
+        P2b, #3247) used to orchestrate the action-catalog build.
+
+        Prefers a host-provided coordinator (``host.get_index_coordinator``,
+        a seam for tests/hosts that want to inject one — mirrors the
+        ``get_action_embedding_index`` getattr-fallback pattern used
+        throughout this method); falls back to the module-level
+        ``get_index_coordinator(workspace_root)`` singleton, keyed by
+        ``host.workspace_root`` (or ``Path.cwd()`` when the host does not
+        expose one — mirrors ``ActionEmbeddingIndex.__init__``'s own
+        default).
+        """
+        from pathlib import Path as _Path
+
+        _coord_getter = getattr(self.host, "get_index_coordinator", None)
+        if _coord_getter is not None:
+            _coord = _coord_getter()
+            if _coord is not None:
+                return _coord
+        from reyn.data.index.coordinator import get_index_coordinator
+
+        workspace_root = getattr(self.host, "workspace_root", None) or _Path.cwd()
+        return get_index_coordinator(workspace_root)
+
+    async def _ensure_action_index_built(
+        self, idx: Any, provider: Any, model_class: str, *, await_completion: bool,
+    ) -> None:
+        """FP-0066 P2b (#3247): route the action-catalog build's eager-vs-
+        background DECISION + once-per-chain spawn dedup + failure-memo
+        through ``IndexCoordinator.ensure_built_self_contained``.
+
+        ``ActionEmbeddingIndex.build()`` (invoked via
+        ``_build_action_embedding_index_background``, UNCHANGED — see that
+        method's docstring and #1458's pinning tests) already owns its own
+        cross-process build lock + disk-adopt + dual-axis invalidation
+        policy — domain-adapter policy the #3247 firm keeps OUT of the
+        Coordinator. Using the material-producing ``ensure_built`` here
+        would either duplicate that policy in the Coordinator or acquire
+        the SAME advisory lock a second time within one process (self-
+        deadlock-shaped). ``ensure_built_self_contained`` narrows the
+        Coordinator's role to orchestration only: once-per-source
+        background-task dedup, failure-memo, and manifest state — the
+        build itself stays exactly as it was.
+
+        Readiness/visibility (``idx.is_ready()``) and the retry gate
+        (``self._action_index_build_failed``) are read directly off
+        ``idx``/``self`` by the caller (unchanged) rather than off the
+        Coordinator's own ``is_ready()``/``build_failed()`` — those stay
+        genuinely accurate here (``idx.build()`` always runs for real),
+        whereas the Coordinator's manifest write for a background build
+        settles one event-loop tick after ``idx``'s own state does, which
+        would otherwise open a window where the tool is advertised
+        visible before ``idx.query()`` can serve it. The Coordinator's
+        manifest/is_ready() stays a truthful PARALLEL observability
+        surface for future kinds/consumers (P2c/P2d).
+        """
+        coordinator = self._get_index_coordinator()
+        source_id = getattr(idx, "source_name", None) or "actions"
+
+        async def _build_coro() -> None:
+            await self._build_action_embedding_index_background(
+                idx, provider, model_class,
+            )
+            if getattr(self, "_action_index_build_failed", False):
+                # _build_action_embedding_index_background swallows its own
+                # exception (memoizing the failure + emitting the event/log
+                # itself); re-raise a synthetic error here so the
+                # Coordinator's own failure-memo/mark_dirty bookkeeping
+                # stays consistent with the RouterLoop-side flag.
+                raise RuntimeError("action index build failed (see prior log)")
+
+        await coordinator.ensure_built_self_contained(
+            source_id,
+            _build_coro,
+            await_completion=await_completion,
+            is_ready_probe=lambda: bool(getattr(idx, "is_ready", lambda: False)()),
+            chunk_count_probe=lambda: int(getattr(idx, "size", lambda: 0)()),
+            kind="static",
+        )
 
     async def _build_action_embedding_index_background(
         self, idx: Any, provider: Any, model_class: str,

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -189,6 +189,14 @@ class ActionEmbeddingIndex:
         self._build_lock = asyncio.Lock()
         self._building = False
 
+    # ── identity ────────────────────────────────────────────────────────
+
+    @property
+    def source_name(self) -> str:
+        """The logical source id this instance rides on the IndexBackend /
+        IndexCoordinator (FP-0066 P2b, #3247) — ``"actions"`` by default."""
+        return self._source
+
     # ── paths ───────────────────────────────────────────────────────────
 
     @property

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -1,0 +1,271 @@
+"""FP-0066 P2b (#3247) — per-kind source split + action-catalog migration.
+
+Covers:
+  1. ``SourceEntry.kind`` taxonomy — persist + coerce-default ("backfill").
+  2. ``IndexCoordinator.ensure_built_self_contained`` — the orchestration-
+     only entry point ``RouterLoop._ensure_action_index_built`` uses to
+     migrate the action-catalog build (which owns its OWN cross-process
+     lock + disk-adopt + dual-axis invalidation policy, so it cannot use
+     the material-producing ``ensure_built`` without double-acquiring the
+     lock — see ``coordinator.py``'s docstring on that method).
+  3. **Equivalence test (mandatory)**: the migrated
+     ``RouterLoop._ensure_action_index_built`` path reproduces the
+     pre-migration observable behavior for the 5 pinned cases —
+     eager→sync build, non-eager→background, disk-adopt hit→no rebuild,
+     build failure→memoized (not re-attempted), ready-gate reflects state.
+
+No mocks — real ``IndexCoordinator``, real ``SourceManifest``, real
+``RouterLoop`` instances (constructed the same minimal-subclass way
+``tests/test_action_embedding_build_failure_1458.py`` already does, since
+a full host/session is not needed to exercise this orchestration layer);
+a plain fake index (real class, not a Mock) stands in for
+``ActionEmbeddingIndex`` so build success/failure/timing is controllable
+without a real embedding provider.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from reyn.data.index.coordinator import IndexCoordinator
+from reyn.data.index.source_manifest import SourceEntry, SourceManifest
+from reyn.runtime.router_loop import RouterLoop
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+# ── 1. SourceEntry.kind taxonomy ──────────────────────────────────────────
+
+
+def test_kind_persists_and_round_trips(tmp_path: Path) -> None:
+    """Tier 2: kind survives a to_dict/from_dict + on-disk round trip."""
+    manifest = SourceManifest(tmp_path)
+    entry = SourceEntry(
+        name="actions", description="action catalog", path="", kind="static",
+    )
+    _run(manifest.upsert(entry))
+
+    fresh = SourceManifest(tmp_path)
+    reloaded = _run(fresh.get("actions"))
+    assert reloaded is not None
+    assert reloaded.kind == "static"
+
+
+def test_kind_defaults_to_backfill_when_missing_or_garbled(tmp_path: Path) -> None:
+    """Tier 2: a pre-P2b (or operator-edited garbled) sources.yaml entry
+    coerces to "backfill" — the documented safe default (predates the
+    taxonomy), mirroring the existing ``state`` coercion rationale."""
+    assert SourceEntry.from_dict("x", {}).kind == "backfill"
+    assert SourceEntry.from_dict("x", {"kind": "not-a-real-kind"}).kind == "backfill"
+    assert SourceEntry.from_dict("x", {"kind": "dynamic"}).kind == "dynamic"
+    assert SourceEntry.from_dict("x", {"kind": "static"}).kind == "static"
+
+
+def test_freshly_created_entry_uses_registered_kind(tmp_path: Path) -> None:
+    """Tier 2: mark_dirty on a never-seen source_id tags the NEW entry with
+    the kind remembered from register_builder/ensure_built_self_contained,
+    not the "backfill" dataclass default. Reads back through a SEPARATE
+    ``SourceManifest`` instance against the same file SSoT (public surface
+    only — no private-state introspection)."""
+    manifest = SourceManifest(tmp_path)
+    coord = IndexCoordinator(tmp_path, manifest=manifest)
+
+    async def _build() -> None:
+        return None
+
+    _run(coord.ensure_built_self_contained(
+        "actions", _build, await_completion=True,
+        is_ready_probe=lambda: False, kind="static",
+    ))
+    entry = _run(manifest.get("actions"))
+    assert entry is not None
+    assert entry.kind == "static"
+
+
+# ── 2 + 3. ensure_built_self_contained + the 5-case equivalence set ──────
+
+
+class _FakeActionIndex:
+    """Real fake standing in for ActionEmbeddingIndex — controllable
+    success/failure/timing, no embedding provider needed."""
+
+    def __init__(self, *, should_fail: bool = False, delay: float = 0.0) -> None:
+        self.should_fail = should_fail
+        self.delay = delay
+        self.build_calls = 0
+        self._ready = False
+        self._size = 0
+        self.source_name = "actions"
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def size(self) -> int:
+        return self._size
+
+    async def build(self, items: list[dict], ctx: Any, model_class: str) -> None:
+        self.build_calls += 1
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.should_fail:
+            raise RuntimeError("simulated provider failure")
+        self._ready = True
+        self._size = len(items)
+
+
+class _StubHost:
+    """Minimal host — only what RouterLoop._ensure_action_index_built /
+    _build_action_embedding_index_background touch."""
+
+    def __init__(self) -> None:
+        self.events = _StubEvents()
+        self.op_ctx_stub: Any = "ctx"
+
+    def make_router_op_context(self) -> Any:
+        return self.op_ctx_stub
+
+
+class _StubEvents:
+    def __init__(self) -> None:
+        self.emitted: list[dict] = []
+
+    def emit(self, kind: str, **kwargs: Any) -> None:
+        self.emitted.append({"kind": kind, **kwargs})
+
+
+class _LoopForP2b(RouterLoop):
+    """RouterLoop subclass exercising the P2b orchestration methods without
+    a full host/session — same minimal-subclass pattern as
+    ``test_action_embedding_build_failure_1458.py``."""
+
+    def __init__(self, workspace_root: Path) -> None:
+        self.host = _StubHost()  # type: ignore[assignment]
+        self.chain_id = "test-chain"
+        self._workspace_root_for_test = workspace_root
+
+    async def _build_router_caller_state(self) -> Any:
+        return None
+
+    def _get_index_coordinator(self) -> IndexCoordinator:
+        # Deterministic per-test coordinator instance (bypasses the
+        # module singleton so tests don't leak state across each other).
+        if not hasattr(self, "_test_coordinator"):
+            self._test_coordinator = IndexCoordinator(self._workspace_root_for_test)
+        return self._test_coordinator
+
+
+def test_eager_awaits_sync_build(tmp_path: Path) -> None:
+    """Tier 2: equivalence case 1 — eager (await_completion=True) runs the
+    build INLINE — by the time the call returns, the index is ready."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex()
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+    assert idx.is_ready() is True
+    assert idx.build_calls == 1
+    coordinator = loop._get_index_coordinator()
+    assert _run(coordinator.is_ready("actions")) is True
+
+
+def test_non_eager_schedules_background(tmp_path: Path) -> None:
+    """Tier 2: equivalence case 2 — non-eager (await_completion=False)
+    schedules the build in the BACKGROUND — the call returns before the
+    (delayed) build completes, and the index becomes ready only once the
+    background task finishes."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex(delay=0.05)
+
+    async def _scenario() -> None:
+        await loop._ensure_action_index_built(
+            idx, "provider", "standard", await_completion=False,
+        )
+        # Returned immediately — build not done yet (background, not sync).
+        assert idx.is_ready() is False
+        coordinator = loop._get_index_coordinator()
+        # Poll the PUBLIC readiness gate for the scheduled background task
+        # to complete (bounded — no private-state introspection, mirrors
+        # test_index_coordinator_3247_p2a.py's equivalent poll).
+        for _ in range(200):
+            if await coordinator.is_ready("actions"):
+                break
+            await asyncio.sleep(0.01)
+        assert idx.is_ready() is True
+        assert await coordinator.is_ready("actions") is True
+
+    _run(_scenario())
+
+
+def test_disk_adopt_hit_skips_rebuild(tmp_path: Path) -> None:
+    """Tier 2: equivalence case 3 — once the manifest already records
+    state=="clean" AND the domain adapter itself reports ready (the
+    Coordinator-level analogue of a disk-adopt cache hit — a fresh
+    process/instance that finds a completed prior build), a second
+    ``ensure_built_self_contained`` call does NOT re-invoke the builder."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex()
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+    assert idx.build_calls == 1
+
+    # Second call — index is still ready (nothing invalidated it) — must
+    # be a no-op (no re-embed cost).
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+    assert idx.build_calls == 1, "a clean+ready source must not rebuild"
+
+
+def test_build_failure_memoized_not_reattempted(tmp_path: Path) -> None:
+    """Tier 2: equivalence case 4 — a build failure is memoized on BOTH the
+    RouterLoop-side flag (#1458, unchanged) AND the Coordinator's own
+    failure-memo (``build_failed``) — and the production retry guard
+    (checked by the caller before invoking again) prevents a second
+    attempt."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex(should_fail=True)
+
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+    assert idx.build_calls == 1
+    assert getattr(loop, "_action_index_build_failed", False) is True
+    coordinator = loop._get_index_coordinator()
+    assert coordinator.build_failed("actions") is True
+
+    # Production retry guard (mirrors RouterLoop.run()'s own gate): do NOT
+    # call again once the failure flag is set.
+    if not getattr(loop, "_action_index_build_failed", False):
+        _run(loop._ensure_action_index_built(
+            idx, "provider", "standard", await_completion=True,
+        ))
+    assert idx.build_calls == 1, "memoized failure must prevent a retry"
+
+
+def test_ready_gate_reflects_state(tmp_path: Path) -> None:
+    """Tier 2: equivalence case 5 — is_ready() (both idx's own gate — used
+    for search_actions visibility — and the Coordinator's parallel
+    manifest-backed gate) is False before a build and True after."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex()
+    coordinator = loop._get_index_coordinator()
+
+    assert idx.is_ready() is False
+    assert _run(coordinator.is_ready("actions")) is False
+
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+
+    assert idx.is_ready() is True
+    assert _run(coordinator.is_ready("actions")) is True
+
+
+def test_1458_pinned_build_primitive_still_used_unchanged(tmp_path: Path) -> None:
+    """Tier 2: the P2b migration routes THROUGH
+    ``_build_action_embedding_index_background`` (#1458's pinned failure-
+    event/log/memo primitive) rather than bypassing it — regression pin
+    that the migration didn't orphan that method into dead code reachable
+    only from its own unit test."""
+    loop = _LoopForP2b(tmp_path)
+    idx = _FakeActionIndex(should_fail=True)
+    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
+    kinds = [e["kind"] for e in loop.host.events.emitted]
+    assert "action_index_build_failed" in kinds, (
+        "the #1458 action_index_build_failed event must still fire via the "
+        "unchanged _build_action_embedding_index_background primitive"
+    )


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247

## What this delivers (per the architect's P2 firm, §2/§7)

**1. Per-kind source taxonomy (§2)**: `SourceEntry.kind: dynamic | static | backfill`, persisted in `sources.yaml` (single SSoT, existing atomic-write). Coerces to `"backfill"` for any pre-P2b (or garbled) entry — "predates the taxonomy" is the safe read, mirroring the existing `state` coercion default. `IndexCoordinator` remembers a source's registered `kind` (via `register_builder`/`ensure_built_self_contained`) so a freshly-created manifest entry is tagged correctly.

**2. Action-catalog build migrated onto IndexCoordinator.**

## Migration boundary — moved vs. stayed

**Moved into the Coordinator** (new `ensure_built_self_contained`, see below):
- The eager-vs-background DECISION (`RouterLoop`'s ~L1299-1330).
- Once-per-chain spawn dedup (was `self._action_index_build_task`, now `IndexCoordinator._bg_tasks`, per-workspace singleton via the new `get_index_coordinator(workspace_root)`).
- Failure-memoization surfaced via `IndexCoordinator.build_failed()` (parallel to the existing `self._action_index_build_failed`, kept — see below).
- Manifest state bookkeeping (`clean`/`dirty`/`building`/`error`) for the `"actions"` source.

**Stayed as domain-adapter policy** (per the firm's boundary principle):
- `ActionEmbeddingIndex.build()` — UNCHANGED. Still owns its own cross-process `try_acquire_build_lock`, `_try_adopt_from_disk`, the dual-axis (catalog-hash + model-class) invalidation, and the item↔ChunkRecord mapping.
- `RouterLoop._build_action_embedding_index_background` — UNCHANGED (still calls `idx.build()`, still sets `self._action_index_build_failed` + emits `action_index_build_failed` + logs the decision-enabling warning on failure — the exact contract #1458's tests pin).

## Why `ensure_built_self_contained`, not the P2a `ensure_built`

While doing the actual migration I hit a real shape mismatch the P2a design doesn't cover: `ActionEmbeddingIndex.build()` already acquires the cross-process advisory `build_lock` at the SAME `cache_dir_for_source` path `IndexCoordinator.ensure_built`/`_run_build` would acquire it at. Routing the action-catalog through the material-producing `ensure_built` (which itself acquires that lock before calling the registered `BuildFn`) would either:
- duplicate `build()`'s dual-axis/disk-adopt policy inside the Coordinator (violating "domain adapter owns invalidation policy"), or
- have `build()` try to acquire the SAME lock a second time within one process — a self-deadlock shape (the second acquisition sees its own PID as a live holder and silently no-ops the build).

`ensure_built_self_contained` (`src/reyn/data/index/coordinator.py`) narrows the Coordinator's role for this class of builder to pure orchestration — once-per-source background-task dedup, failure-memo, manifest state — while the domain builder keeps owning its own lock/write/invalidation end to end. `ensure_built`/`register_builder`/`BuildMaterial` (P2a's original material-producing path) are untouched and still used by their own tests.

## Equivalence evidence (mandatory gate)

New `tests/test_index_coordinator_3247_p2b.py`, all passing, covering the 5 mandated cases plus the kind taxonomy:

1. **eager → sync build**: `test_eager_awaits_sync_build` — `await_completion=True` runs inline; index ready + `coordinator.is_ready()` True by the time the call returns.
2. **non-eager → background**: `test_non_eager_schedules_background` — call returns before the (artificially delayed) build finishes; index becomes ready only once the scheduled task completes (polled via the PUBLIC `is_ready()` gate, no private-state introspection).
3. **disk-adopt hit → no rebuild**: `test_disk_adopt_hit_skips_rebuild` — a second call against an already-ready source does not re-invoke the builder.
4. **build failure → memoized (not re-attempted)**: `test_build_failure_memoized_not_reattempted` — failure sets both `self._action_index_build_failed` (unchanged #1458 flag) and `coordinator.build_failed()`; the production retry guard prevents a second attempt.
5. **ready-gate reflects state**: `test_ready_gate_reflects_state` — both `idx.is_ready()` and `coordinator.is_ready()` are False pre-build, True post-build.

Plus `test_1458_pinned_build_primitive_still_used_unchanged` — a regression pin proving the migration routes THROUGH `_build_action_embedding_index_background` (not around it), so that method stays a live production call site rather than becoming dead code kept alive only by its own unit test.

## Pre-existing behavioral pins verified unchanged (not deleted/weakened)

- `tests/test_action_embedding_index.py` (24 tests) + `tests/test_action_embedding_index_concurrency.py` — `ActionEmbeddingIndex.build()`'s public contract, byte-identical, since `build()` was not touched.
- `tests/test_action_embedding_build_failure_1458.py` (9 tests) — `_build_action_embedding_index_background`'s failure/event/log contract, byte-identical, since that method was not touched.
- `tests/test_index_coordinator_3247_p2a.py` (P2a's own suite) — untouched, `ensure_built`/`register_builder`/`BuildMaterial` unchanged.
- `tests/test_router_tools_universal_wrappers.py`, `tests/test_list_actions_hidden_state_hint.py`, `tests/test_universal_catalog.py` — unaffected (build_tools-level tests, don't touch this orchestration layer).

## Known, documented nuance (not silently swept)

The router_loop visibility gate (`_search_visible`) and `idx.query()`'s internal readiness gate both read `idx.is_ready()` directly (unchanged) rather than `coordinator.is_ready()`, because `idx.is_ready()` stays genuinely accurate here (`_build_action_embedding_index_background` always runs the real `idx.build()`), whereas the Coordinator's manifest write for a background build settles one event-loop tick before its wrapping `asyncio.Task` is observably "done" — using the Coordinator's gate for VISIBILITY specifically would open a narrow window where the tool is advertised before `query()` can serve it. The Coordinator's `is_ready()`/manifest state stays a truthful PARALLEL observability surface for future kinds/consumers (P2c/P2d), which is where the `search_await` contract's `search_*` wiring belongs per the firm's §7 decomposition — out of scope here.

## Guardrails honored

- Did NOT touch `plugin_install.py` (sole scope explicitly excluded by both my brief and the firm's §1).
- Did NOT wire skill/memory/doc-RAG sync-in-op (P2c) or audit-events (P2d).
- Did NOT change all-or-nothing semantics (P2a's `assert_vector_count_match`/`embed_verify_write` untouched) or the sandbox-cap fail-closed backend gate (P1c).

## Local CI (all four gates, foreground)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_index_coordinator_3247_p2b.py` — 9/9 OK, 0 errors.
- `PYTHONPATH=$(pwd)/src python -m pytest` (full suite, foreground) — 9132 passed, 36 skipped, 0 failed.
- `python scripts/verify_module_docstrings.py <4 changed src files>` — OK.

## Test plan

- [x] Full local test suite green (9132 passed, 36 skipped).
- [x] ruff clean.
- [x] Tier-audit strict clean on the new test file.
- [x] Module-docstring gate clean on all 4 changed src files.
- [x] Manually traced the double-lock hazard (`try_acquire_build_lock` is `O_CREAT|O_EXCL`, non-reentrant within a process) that motivated `ensure_built_self_contained` rather than reusing `ensure_built`.