### PR TITLE
feat(FP-0066 P2d): IndexCoordinator audit-event phases + search-await wiring (action-catalog)

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -19,9 +19,19 @@ all-or-nothing embed-verify-write primitive (``embed_verify_write``) that
 ``ActionEmbeddingIndex.build()`` and the ``index_update`` op used to
 duplicate verbatim. Migrating those two call sites to trigger builds
 *through* the Coordinator (eager-vs-background, once-per-chain spawn) is
-**P2b** — deliberately NOT done here. Wiring dynamic ops to
-``ensure_built(await_completion=True)`` and G3 sync de-index is **P2c**.
-Audit-event phase emission is **P2d**.
+**P2b** — done (#3260). The architect's decomposition-correction comment on
+#3247 folds the original P2c (sync-in-op op wiring + G3 delete-de-index)
+INTO P3 — its only producers (skill/memory knowledge ingest, doc-RAG
+``index_update``) are all P3-dependent (0 live callers today), so building
+that wiring here would be a producer-less framework. **P2d (this module's
+current state)**: audit-event phase emission (``embedding_index_build_
+started``/``_progress``/``_complete``/``_error`` — the last folding the
+pre-P2d ``action_index_build_failed`` event, which used to be emitted
+directly by ``RouterLoop._build_action_embedding_index_background`` — see
+``ensure_built``/``ensure_built_self_contained``'s ``events`` parameter)
+plus the ``search_await`` contract's production wiring at the two live
+action-catalog query call sites (``RouterLoop.search_actions`` /
+``universal_catalog._handle_search_actions``).
 
 **Crash-recovery (the band requirement, CLAUDE.md recovery-feature gate)**:
 the dirty/building/error state lives in ``SourceEntry`` (persisted to
@@ -54,6 +64,7 @@ from reyn.data.index.source_manifest import (
 )
 
 if TYPE_CHECKING:
+    from reyn.core.events.events import EventLog
     from reyn.core.op_runtime.context import OpContext
 
 __all__ = [
@@ -291,7 +302,11 @@ class IndexCoordinator:
     # ── ensure_built (#3247 firm §1) ─────────────────────────────────────
 
     async def ensure_built(
-        self, source_id: str, *, await_completion: bool,
+        self,
+        source_id: str,
+        *,
+        await_completion: bool,
+        events: "EventLog | None" = None,
     ) -> BuildOutcome:
         """If ``source_id`` is dirty/error/never-built, (re)build it.
 
@@ -306,6 +321,14 @@ class IndexCoordinator:
         Never raises: a build failure is caught, recorded via
         ``mark_dirty`` + the in-process failure-memo, and reported on the
         returned ``BuildOutcome.error`` (the §G2 best-effort contract).
+
+        ``events`` (FP-0066 P2d, #3247 firm §6): an optional ``EventLog`` to
+        emit the ``embedding_index_build_started``/``_progress``/
+        ``_complete``/``_error`` audit-event phases to. ``None`` (the
+        default — matches every other best-effort-optional collaborator on
+        this class) silently skips the audit-emit; a real build call site
+        (production or test) threads its ``EventLog`` here to get the P6
+        audit trail.
         """
         entry = await self._manifest.get(source_id)
         if entry is not None and entry.state == "clean":
@@ -328,13 +351,31 @@ class IndexCoordinator:
             existing_task = self._bg_tasks.get(source_id)
             if existing_task is not None and not existing_task.done():
                 return BuildOutcome(source_id=source_id, triggered=True, background=True)
-            task = asyncio.create_task(self._run_build(source_id, build_fn))
+            task = asyncio.create_task(self._run_build(source_id, build_fn, events))
             self._bg_tasks[source_id] = task
             return BuildOutcome(source_id=source_id, triggered=True, background=True)
 
-        return await self._run_build(source_id, build_fn)
+        return await self._run_build(source_id, build_fn, events)
 
-    async def _run_build(self, source_id: str, build_fn: BuildFn) -> BuildOutcome:
+    def _emit(self, events: "EventLog | None", event_type: str, **data: Any) -> None:
+        """Best-effort audit-event emit (FP-0066 P2d) — never raises; a
+        broken/absent sink must not fail a build or a search (mirrors
+        ``emit_cli_event``'s "audit-emit failure must not propagate"
+        contract). ``event_type`` (not ``kind``) to avoid colliding with
+        the ``kind=`` (dynamic/static/backfill taxonomy) keyword every
+        build-phase emit also carries as data."""
+        if events is None:
+            return
+        try:
+            events.emit(event_type, **data)
+        except Exception:
+            pass
+
+    async def _run_build(
+        self, source_id: str, build_fn: BuildFn, events: "EventLog | None" = None,
+    ) -> BuildOutcome:
+        kind = self._kinds.get(source_id, "backfill")
+        self._emit(events, "embedding_index_build_started", source_id=source_id, kind=kind)
         await self._set_state(source_id, "building")
         lock_dir = cache_dir_for_source(self._workspace_root, source_id)
         with try_acquire_build_lock(lock_dir) as got_lock:
@@ -344,6 +385,10 @@ class IndexCoordinator:
                 return BuildOutcome(source_id=source_id, triggered=False, background=False)
             try:
                 material = await build_fn()
+                self._emit(
+                    events, "embedding_index_build_progress",
+                    source_id=source_id, chunk_count=len(material.items),
+                )
                 result = await embed_verify_write(
                     ctx=material.ctx,
                     texts=material.texts,
@@ -360,6 +405,10 @@ class IndexCoordinator:
                 reason = f"build_error: {exc}"
                 self._failure_memo[source_id] = reason
                 await self.mark_dirty(source_id, reason=reason)
+                self._emit(
+                    events, "embedding_index_build_error",
+                    source_id=source_id, reason=str(exc),
+                )
                 return BuildOutcome(
                     source_id=source_id, triggered=True, background=False, error=str(exc),
                 )
@@ -368,6 +417,10 @@ class IndexCoordinator:
         await self._set_state(
             source_id, "clean", chunk_count=chunk_count,
             embedding_model=result.resolved_model,
+        )
+        self._emit(
+            events, "embedding_index_build_complete",
+            source_id=source_id, chunk_count=chunk_count,
         )
         return BuildOutcome(
             source_id=source_id, triggered=True, background=False, chunk_count=chunk_count,
@@ -487,6 +540,7 @@ class IndexCoordinator:
         is_ready_probe: Callable[[], bool],
         chunk_count_probe: Callable[[], int] | None = None,
         kind: SourceKind = "backfill",
+        events: "EventLog | None" = None,
     ) -> BuildOutcome:
         """Orchestrate (dedup/failure-memo/state) a self-contained builder.
 
@@ -503,6 +557,25 @@ class IndexCoordinator:
         with the same once-per-source in-flight dedup (``_bg_tasks``).
         Never raises — a failure is caught, mark_dirty'd, memoized, and
         reported on the returned ``BuildOutcome.error``.
+
+        ``events`` (FP-0066 P2d, #3247 firm §6): same optional ``EventLog``
+        contract as ``ensure_built`` — emits the ``embedding_index_build_
+        started``/``_progress``/``_complete``/``_error`` phases. This is
+        the path the production action-catalog build uses
+        (``RouterLoop._ensure_action_index_built``), so this is also where
+        the pre-P2d ``action_index_build_failed`` event (previously emitted
+        directly by ``_build_action_embedding_index_background`` on
+        failure) is FOLDED into ``embedding_index_build_error`` — that
+        direct emit was removed from the RouterLoop primitive; this method
+        is now the single emitter for a self-contained builder's failure.
+        Since ``build_coro`` is opaque (no material/item count visible
+        before it runs), the ``_progress`` checkpoint fires right after
+        ``build_coro`` returns without raising (using ``chunk_count_probe``
+        if given) rather than mid-build — a coarser granularity than
+        ``ensure_built``'s material-aware progress, an honest limitation
+        given this builder shape (see the class docstring's boundary
+        principle: the builder, not the Coordinator, owns its own
+        progress internals).
         """
         self._kinds[source_id] = kind
         entry = await self._manifest.get(source_id)
@@ -513,6 +586,7 @@ class IndexCoordinator:
             )
 
         async def _run() -> BuildOutcome:
+            self._emit(events, "embedding_index_build_started", source_id=source_id, kind=kind)
             await self._set_state(source_id, "building")
             try:
                 await build_coro()
@@ -520,13 +594,25 @@ class IndexCoordinator:
                 reason = f"build_error: {exc}"
                 self._failure_memo[source_id] = reason
                 await self.mark_dirty(source_id, reason=reason)
+                self._emit(
+                    events, "embedding_index_build_error",
+                    source_id=source_id, reason=str(exc),
+                )
                 return BuildOutcome(
                     source_id=source_id, triggered=True, background=False,
                     error=str(exc),
                 )
             if is_ready_probe():
                 chunk_count = chunk_count_probe() if chunk_count_probe else None
+                self._emit(
+                    events, "embedding_index_build_progress",
+                    source_id=source_id, chunk_count=chunk_count,
+                )
                 await self._set_state(source_id, "clean", chunk_count=chunk_count)
+                self._emit(
+                    events, "embedding_index_build_complete",
+                    source_id=source_id, chunk_count=chunk_count,
+                )
                 return BuildOutcome(
                     source_id=source_id, triggered=True, background=False,
                     chunk_count=chunk_count,
@@ -534,7 +620,8 @@ class IndexCoordinator:
             # The builder ran without raising but didn't reach readiness
             # (e.g. its own lock-skip fallback: "another process is mid-
             # build") — leave manifest state as-is (not clean), matching
-            # the pre-migration silent-fallback semantics.
+            # the pre-migration silent-fallback semantics. No _complete
+            # emit — the build did not actually complete.
             return BuildOutcome(source_id=source_id, triggered=True, background=False)
 
         if not await_completion:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2906,13 +2906,30 @@ class RouterLoop:
         match to ``query`` → matched qualified names. Reuses the FP-0034
         ``ActionEmbeddingIndex`` (the same substrate the ``search_actions`` tool uses);
         ``query`` awaits the embedding of the dynamic query (the reason presentation
-        is async). Returns ``[]`` when the index / provider is unavailable (degrade)."""
+        is async). Returns ``[]`` when the index / provider is unavailable (degrade).
+
+        FP-0066 P2d (#3247 firm §5/§6): before serving, awaits
+        ``IndexCoordinator.search_await`` — a cheap manifest-read no-op in
+        the steady state (source already ``clean``), or a heal-await if a
+        prior sync-in-op build left the source ``dirty``/mid-``building``
+        (the "best-effort search is a bug" completeness guarantee). Wraps
+        the search in ``semantic_search_started``/``_complete`` audit-events
+        (results count) — this call site (not ``Coordinator.search_await``
+        itself, which has no visibility into the actual query results) is
+        where the count is known, so ``_complete`` fires here.
+        """
         index = self.host.get_action_embedding_index()
         provider = self.host.get_embedding_provider()
         model_class = self.host.get_embedding_model_class()
         if index is None or provider is None:
             return []
+        source_id = getattr(index, "source_name", None) or "actions"
+        events = self.host.events
+        self.host.events.emit("semantic_search_started", source_id=source_id)
+        results: list[dict[str, Any]] = []
         try:
+            coordinator = self._get_index_coordinator()
+            await coordinator.search_await(source_id)
             # FP-0057 #2856 Part A: idx.query() routes through the shared
             # `embed` op (execute_op) instead of calling ``provider`` directly
             # — needs an OpContext, not the provider instance itself.
@@ -2921,7 +2938,8 @@ class RouterLoop:
         except Exception as e:  # noqa: BLE001 — search is best-effort presentation aid
             import logging
             logging.getLogger(__name__).warning("search_actions failed: %s", e)
-            return []
+        finally:
+            events.emit("semantic_search_complete", source_id=source_id, results=len(results))
         return [r["qualified_name"] for r in results if r.get("qualified_name")]
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:
@@ -3444,6 +3462,7 @@ class RouterLoop:
             is_ready_probe=lambda: bool(getattr(idx, "is_ready", lambda: False)()),
             chunk_count_probe=lambda: int(getattr(idx, "size", lambda: 0)()),
             kind="static",
+            events=self.host.events,
         )
 
     async def _build_action_embedding_index_background(
@@ -3504,14 +3523,15 @@ class RouterLoop:
         except Exception as exc:
             # #1458: memoize the failure so subsequent turns do not retry.
             self._action_index_build_failed = True
-            try:
-                self.host.events.emit(
-                    "action_index_build_failed",
-                    error=repr(exc),
-                    model_class=model_class,
-                )
-            except Exception:
-                pass
+            # FP-0066 P2d (#3247): the audit-event for this failure used to
+            # be emitted HERE directly (``action_index_build_failed``).
+            # It is now folded into ``embedding_index_build_error``,
+            # emitted by ``IndexCoordinator.ensure_built_self_contained``
+            # (this method's only production caller routes through it via
+            # ``_ensure_action_index_built``'s ``_build_coro`` wrapper,
+            # which re-raises on this exact failure so the Coordinator's
+            # except-block observes it) — see ``coordinator.py``. Emitting
+            # both here AND there would double-emit for the same failure.
             # #1458: decision-enabling operator warning — names the likely
             # cause + three actionable outs, same family as the
             # ``_build_embedding_config`` / ``_validate_retrieval_scheme_embedding``

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3522,6 +3522,16 @@ class RouterLoop:
             await idx.build(items, op_ctx, model_class)
         except Exception as exc:
             # #1458: memoize the failure so subsequent turns do not retry.
+            # FP-0066 P2d/#3247 convergence-debt (co-vet, pre-merge): this
+            # flag and the Coordinator's own failure-memo
+            # (``IndexCoordinator._failure_memo`` / ``build_failed()``) are
+            # BOTH set on this same exception today (byte-identical two-path
+            # retention from P2b) — keep them in sync until the #3247
+            # convergence follow-up unifies failure-state into one signal.
+            # A future edit to only ONE of the two paths silently desyncs
+            # them; see the interim guard pin
+            # ``test_action_index_build_failure_both_signals_stay_in_sync``
+            # in ``tests/test_index_coordinator_3247_p2d.py``.
             self._action_index_build_failed = True
             # FP-0066 P2d (#3247): the audit-event for this failure used to
             # be emitted HERE directly (``action_index_build_failed``).

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -903,6 +903,12 @@ async def _handle_search_actions(
     the handler is only invoked when the index is configured.  The
     None-checks above are defense-in-depth for narrow callers (= plan
     steps / test sites) that bypass the gate.
+
+    FP-0066 P2d (#3247 firm §5/§6): before ``idx.query()`` serves, awaits
+    ``IndexCoordinator.search_await(source_id)`` (steady-state clean =
+    cheap no-op; dirty/building = heals/awaits first) and emits
+    ``semantic_search_started``/``semantic_search_complete`` (results
+    count) audit-events around the query.
     """
     query = args.get("query")
     if not isinstance(query, str) or not query.strip():
@@ -956,7 +962,27 @@ async def _handle_search_actions(
     # Over-fetch when filtering by category so we still return up to
     # ``limit`` after the post-filter cut.
     raw_top_k = limit * len(CATEGORIES) if category_set else limit
+
+    # FP-0066 P2d (#3247 firm §5/§6): await the Coordinator's search-await
+    # contract before serving — a cheap manifest-read no-op in the steady
+    # state (source already "clean"), or a heal-await if a prior sync-in-op
+    # build left the source dirty/mid-building (the "best-effort search is
+    # a bug" completeness guarantee). Wrapped in semantic_search_started/
+    # _complete audit-events (results count) — this call site, not
+    # ``Coordinator.search_await`` itself, is where the result count is
+    # actually known.
+    from reyn.data.index.coordinator import get_index_coordinator
+
+    source_id = getattr(idx, "source_name", None) or "actions"
+    events = ctx.events
+    if events is not None:
+        events.emit("semantic_search_started", source_id=source_id)
+    if ctx.workspace is not None:
+        coordinator = get_index_coordinator(ctx.workspace.base_dir)
+        await coordinator.search_await(source_id)
     results = await idx.query(query, op_ctx, model_class, top_k=raw_top_k)
+    if events is not None:
+        events.emit("semantic_search_complete", source_id=source_id, results=len(results))
 
     if category_set:
         from reyn.tools.universal_catalog import split_qualified_name

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -38,10 +38,14 @@ class _FailingProvider:
 class _FailingIndex:
     """Real fake index whose build() method raises."""
 
+    def __init__(self) -> None:
+        self.build_calls = 0
+
     def is_ready(self) -> bool:
         return False
 
     async def build(self, *_args, **_kwargs):  # type: ignore[override]
+        self.build_calls += 1
         raise RuntimeError("Index build failed — provider error")
 
 
@@ -86,11 +90,12 @@ class _LoopWithFailingBuild(RouterLoop):
         return None  # list_actions handler is not reached; provider raises first
 
 
-def _run_build(loop: _LoopWithFailingBuild) -> None:
-    idx = _FailingIndex()
+def _run_build(loop: _LoopWithFailingBuild, idx: "_FailingIndex | None" = None) -> "_FailingIndex":
+    idx = idx if idx is not None else _FailingIndex()
     provider = _FailingProvider()
     loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
     asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
+    return idx
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
@@ -99,25 +104,41 @@ def _run_build(loop: _LoopWithFailingBuild) -> None:
 def test_build_failure_prevents_retry_same_session() -> None:
     """Tier 2: #1458 — after a build failure the memoization flag is set, so a
     second call that checks the flag (as the production guard does) does not
-    re-invoke the build. Observable via event count: a retry would emit another
-    action_index_build_failed event; no retry → count stays at 1."""
+    re-invoke the build. Observable via ``idx.build_calls``: a retry would
+    invoke ``idx.build()`` a second time; no retry → count stays at 1.
+
+    (FP-0066 P2d, #3247: this used to be observed via the
+    ``action_index_build_failed`` audit-event count. That event is no longer
+    emitted from this primitive — see ``test_build_failure_no_audit_event_
+    emitted_here`` — folded into ``embedding_index_build_error``, emitted by
+    ``IndexCoordinator`` one layer up. ``idx.build_calls`` is the public
+    observable this test needs and does not depend on that.)"""
     loop = _LoopWithFailingBuild()
-    _run_build(loop)
-    first_count = len(loop.host.events.emitted)
+    idx = _FailingIndex()
+    _run_build(loop, idx)
+    assert idx.build_calls == 1
     # Simulate the production guard: only call again if the flag is NOT set.
     if not getattr(loop, "_action_index_build_failed", False):
-        _run_build(loop)
+        _run_build(loop, idx)
     # Count must be unchanged — the guard prevented the retry.
-    assert len(loop.host.events.emitted) == first_count
+    assert idx.build_calls == 1
 
 
-def test_build_failure_emits_event() -> None:
-    """Tier 2: #1458 — the existing action_index_build_failed event is still
-    emitted (regression pin: existing downstream consumers must not break)."""
+def test_build_failure_no_audit_event_emitted_here() -> None:
+    """Tier 2: FP-0066 P2d (#3247 firm §6) — the pre-P2d
+    ``action_index_build_failed`` audit-event, previously emitted directly
+    by ``_build_action_embedding_index_background`` on failure, is FOLDED
+    into ``embedding_index_build_error`` emitted by
+    ``IndexCoordinator.ensure_built_self_contained`` one layer up (see
+    ``tests/test_index_coordinator_3247_p2d.py``). This low-level primitive,
+    called directly (bypassing the Coordinator, as this test file does),
+    now emits NO audit-event at all — a double-emit would occur if both
+    layers still emitted for the same failure."""
     loop = _LoopWithFailingBuild()
     _run_build(loop)
     kinds = [e["kind"] for e in loop.host.events.emitted]
-    assert "action_index_build_failed" in kinds
+    assert "action_index_build_failed" not in kinds
+    assert kinds == [], f"expected no audit-event emit from this primitive, got {kinds!r}"
 
 
 def test_build_failure_search_stays_hidden() -> None:

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -258,14 +258,25 @@ def test_ready_gate_reflects_state(tmp_path: Path) -> None:
 def test_1458_pinned_build_primitive_still_used_unchanged(tmp_path: Path) -> None:
     """Tier 2: the P2b migration routes THROUGH
     ``_build_action_embedding_index_background`` (#1458's pinned failure-
-    event/log/memo primitive) rather than bypassing it — regression pin
+    memoization/log primitive) rather than bypassing it — regression pin
     that the migration didn't orphan that method into dead code reachable
-    only from its own unit test."""
+    only from its own unit test.
+
+    FP-0066 P2d (#3247 firm §6) updated this pin's audit-event assertion:
+    the primitive's OWN direct ``action_index_build_failed`` emit was
+    folded into ``embedding_index_build_error``, now emitted by
+    ``IndexCoordinator.ensure_built_self_contained`` (one layer up, reached
+    via ``_ensure_action_index_built``) — so a failure surfaces the NEW
+    event name here, and the OLD name must not double-emit."""
     loop = _LoopForP2b(tmp_path)
     idx = _FakeActionIndex(should_fail=True)
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
     kinds = [e["kind"] for e in loop.host.events.emitted]
-    assert "action_index_build_failed" in kinds, (
-        "the #1458 action_index_build_failed event must still fire via the "
-        "unchanged _build_action_embedding_index_background primitive"
+    assert "embedding_index_build_error" in kinds, (
+        "the folded embedding_index_build_error event must fire via "
+        "IndexCoordinator.ensure_built_self_contained on a build failure"
+    )
+    assert "action_index_build_failed" not in kinds, (
+        "the pre-P2d action_index_build_failed event must not double-emit "
+        "alongside its P2d fold target"
     )

--- a/tests/test_index_coordinator_3247_p2d.py
+++ b/tests/test_index_coordinator_3247_p2d.py
@@ -1,0 +1,484 @@
+"""FP-0066 P2d (#3247) — IndexCoordinator audit-event phase emit + the
+``search_await`` contract's production wiring at the two live action-catalog
+query call sites.
+
+The architect's decomposition-correction comment on #3247 folds the
+original P2c (sync-in-op op wiring + G3 delete-de-index) INTO P3 — its only
+producers are P3-dependent (0 live callers today) — and dispatches P2d
+FIRST, verified against the one live embedding-index producer: the
+action-catalog build/search (P2b, #3260).
+
+Covers:
+  1. ``embedding_index_build_started``/``_progress``/``_complete`` fire at
+     the Coordinator's build-execution method boundary (``ensure_built``,
+     the material-producing path).
+  2. A build failure emits ``embedding_index_build_error`` (with a
+     ``reason``) — via BOTH ``ensure_built`` and
+     ``ensure_built_self_contained`` (the two build-execution shapes P2b
+     introduced).
+  3. The pre-P2d ``action_index_build_failed`` event (previously emitted
+     directly by ``RouterLoop._build_action_embedding_index_background``)
+     no longer double-emits alongside its fold target,
+     ``embedding_index_build_error`` — see also the updated pins in
+     ``test_action_embedding_build_failure_1458.py`` and
+     ``test_index_coordinator_3247_p2b.py``.
+  4. ``search_await`` production wiring at BOTH live query call sites
+     (``RouterLoop.search_actions`` / ``universal_catalog.
+     _handle_search_actions``): a clean source is a cheap no-op (no build
+     triggered); ``semantic_search_started``/``_complete`` (results count)
+     fire around the real query.
+
+No mocks — real ``IndexCoordinator``, real ``SourceManifest``, a real
+``EventLog`` subscribed to a real ``EventStore`` (audit-events are read back
+from the actual ``.reyn/events`` JSONL files, not asserted against private
+state), a real ``ActionEmbeddingIndex`` + real ``OpContext``; a plain fake
+embedding provider (same established convention as
+``tests/test_action_embedding_index.py`` / ``test_index_coordinator_3247_
+p2a.py``) stands in for the litellm boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index.backend import ChunkRecord
+from reyn.data.index.coordinator import BuildMaterial, IndexCoordinator
+from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.tools.action_index import ActionEmbeddingIndex
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import SEARCH_ACTIONS
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _events_and_store(tmp_path: Path) -> tuple[EventLog, EventStore]:
+    """A real EventLog subscribed to a real EventStore rooted under
+    ``tmp_path / ".reyn" / "events"`` — audit-events are read back from
+    the actual on-disk JSONL, per CLAUDE.md's real-instance testing policy."""
+    store = EventStore(tmp_path / ".reyn" / "events")
+    log = EventLog(subscribers=[store])
+    return log, store
+
+
+async def _read_back(store: EventStore) -> list[dict]:
+    """Drain the store's off-loop write queue, then read every event back
+    from disk (public API — ``iter_all()`` — not private state)."""
+    await store.flush()
+    return [e.model_dump(mode="json") for e in store.iter_all()]
+
+
+class _FakeEmbeddingProvider:
+    """Deterministic canned vectors, one per input text (no litellm call)."""
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        vectors = [[float((hash((t, i)) % 1000) / 1000.0) for i in range(4)] for t in texts]
+        return {"vectors": vectors, "model": model, "total_tokens": len(texts)}
+
+
+class _FailingEmbeddingProvider:
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        raise RuntimeError("embedding API unreachable")
+
+
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch, events: EventLog) -> OpContext:
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+def _to_chunk_record(item: dict, vector: list[float], resolved_model: str) -> ChunkRecord:
+    return ChunkRecord(
+        text=item["text"],
+        vector=list(vector),
+        metadata={
+            "source_path": item["id"],
+            "source_type": "test",
+            "content_hash": item["id"],
+            "embedding_model": resolved_model,
+            "chunk_index": 0,
+            "size_tokens": 0,
+            "parent_context": None,
+            "extra": {},
+        },
+    )
+
+
+def _material_build_fn(ctx: OpContext, items: list[dict]):
+    async def _build() -> BuildMaterial:
+        return BuildMaterial(
+            items=items,
+            texts=[it["text"] for it in items],
+            to_chunk_record=_to_chunk_record,
+            model_class="standard",
+            ctx=ctx,
+        )
+    return _build
+
+
+# ── 1 + 2. Audit-event phase emit — ensure_built (material path) ──────────
+
+
+def test_ensure_built_emits_started_progress_complete(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: a successful ``ensure_built`` build emits the three build
+    phases in order, read back from the real on-disk audit-event log."""
+    log, store = _events_and_store(tmp_path)
+    coord = IndexCoordinator(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch, log)
+    items = [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
+    coord.register_builder("doc_source", _material_build_fn(ctx, items), kind="dynamic")
+
+    async def _scenario() -> list[dict]:
+        outcome = await coord.ensure_built(
+            "doc_source", await_completion=True, events=log,
+        )
+        assert outcome.error is None
+        assert outcome.chunk_count == 2
+        return await _read_back(store)
+
+    events = _run(_scenario())
+    # Filter to the P2d build-phase events — the `embed` op's own execution
+    # machinery (e.g. `permission_granted`) shares this EventLog and is
+    # irrelevant to this test's claim (build-phase ORDER + payload).
+    phase_events = [e for e in events if e["type"].startswith("embedding_index_build_")]
+    kinds = [e["type"] for e in phase_events]
+    assert kinds == [
+        "embedding_index_build_started",
+        "embedding_index_build_progress",
+        "embedding_index_build_complete",
+    ]
+    started = phase_events[0]["data"]
+    assert started["source_id"] == "doc_source"
+    assert started["kind"] == "dynamic"
+    progress = phase_events[1]["data"]
+    assert progress["source_id"] == "doc_source"
+    assert progress["chunk_count"] == 2
+    complete = phase_events[2]["data"]
+    assert complete["source_id"] == "doc_source"
+    assert complete["chunk_count"] == 2
+
+
+def test_ensure_built_failure_emits_build_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: a build failure emits ``embedding_index_build_error`` with a
+    ``reason`` — no ``_complete`` event fires."""
+    log, store = _events_and_store(tmp_path)
+    coord = IndexCoordinator(tmp_path)
+    ctx = _op_ctx_for(_FailingEmbeddingProvider(), monkeypatch, log)
+    items = [{"id": "a", "text": "alpha"}]
+    coord.register_builder("doc_source", _material_build_fn(ctx, items), kind="dynamic")
+
+    async def _scenario() -> list[dict]:
+        outcome = await coord.ensure_built(
+            "doc_source", await_completion=True, events=log,
+        )
+        assert outcome.error is not None
+        return await _read_back(store)
+
+    events = _run(_scenario())
+    kinds = [e["type"] for e in events]
+    assert "embedding_index_build_error" in kinds
+    assert "embedding_index_build_complete" not in kinds
+    error_event = next(e for e in events if e["type"] == "embedding_index_build_error")
+    assert error_event["data"]["source_id"] == "doc_source"
+    assert "unreachable" in error_event["data"]["reason"]
+
+
+def test_events_none_is_a_silent_noop(tmp_path: Path) -> None:
+    """Tier 2: ``events=None`` (the default) skips audit-emit entirely
+    without raising — every other Coordinator collaborator (backend,
+    manifest) is similarly best-effort-optional."""
+    coord = IndexCoordinator(tmp_path)
+
+    async def _build_fn() -> BuildMaterial:
+        raise AssertionError("not reached — no builder registered")
+
+    coord.register_builder("x", _build_fn)
+    # No events kwarg at all — must not raise.
+    outcome = _run(coord.ensure_built("x", await_completion=True))
+    assert outcome.error is None or outcome.error is not None  # just must not raise
+
+
+# ── ensure_built_self_contained — the action-catalog build shape ──────────
+
+
+class _FakeSelfContainedBuilder:
+    """Mirrors ``ActionEmbeddingIndex``'s self-contained-builder shape (own
+    readiness/size probes, own lock) — same pattern as
+    ``test_index_coordinator_3247_p2b.py::_FakeActionIndex``."""
+
+    def __init__(self, *, should_fail: bool = False) -> None:
+        self.should_fail = should_fail
+        self._ready = False
+        self._size = 0
+
+    async def build(self) -> None:
+        if self.should_fail:
+            raise RuntimeError("simulated provider failure")
+        self._ready = True
+        self._size = 3
+
+    def is_ready(self) -> bool:
+        return self._ready
+
+    def size(self) -> int:
+        return self._size
+
+
+def test_ensure_built_self_contained_emits_started_progress_complete(tmp_path: Path) -> None:
+    """Tier 2: the self-contained build shape (the action-catalog's own
+    lock/readiness-probe pattern) emits the same three build phases."""
+    log, store = _events_and_store(tmp_path)
+    coord = IndexCoordinator(tmp_path)
+    builder = _FakeSelfContainedBuilder()
+
+    async def _scenario() -> list[dict]:
+        await coord.ensure_built_self_contained(
+            "actions", builder.build,
+            await_completion=True,
+            is_ready_probe=builder.is_ready,
+            chunk_count_probe=builder.size,
+            kind="static",
+            events=log,
+        )
+        return await _read_back(store)
+
+    events = _run(_scenario())
+    kinds = [e["type"] for e in events]
+    assert kinds == [
+        "embedding_index_build_started",
+        "embedding_index_build_progress",
+        "embedding_index_build_complete",
+    ]
+    for e in events:
+        assert e["data"]["source_id"] == "actions"
+    assert events[0]["data"]["kind"] == "static"
+    assert events[1]["data"]["chunk_count"] == 3
+    assert events[2]["data"]["chunk_count"] == 3
+
+
+def test_ensure_built_self_contained_failure_folds_to_build_error(tmp_path: Path) -> None:
+    """Tier 2: the FOLD — a self-contained-builder failure emits
+    ``embedding_index_build_error`` (with a reason), NOT the pre-P2d
+    ``action_index_build_failed`` — this is the Coordinator-level half of
+    the fold; the RouterLoop-level half (removing the direct emit from
+    ``_build_action_embedding_index_background``) is pinned in
+    ``test_action_embedding_build_failure_1458.py`` and
+    ``test_index_coordinator_3247_p2b.py``."""
+    log, store = _events_and_store(tmp_path)
+    coord = IndexCoordinator(tmp_path)
+    builder = _FakeSelfContainedBuilder(should_fail=True)
+
+    async def _scenario() -> list[dict]:
+        await coord.ensure_built_self_contained(
+            "actions", builder.build,
+            await_completion=True,
+            is_ready_probe=builder.is_ready,
+            kind="static",
+            events=log,
+        )
+        return await _read_back(store)
+
+    events = _run(_scenario())
+    kinds = [e["type"] for e in events]
+    assert "embedding_index_build_error" in kinds
+    assert "action_index_build_failed" not in kinds
+    error_event = next(e for e in events if e["type"] == "embedding_index_build_error")
+    assert error_event["data"]["source_id"] == "actions"
+    assert "simulated provider failure" in error_event["data"]["reason"]
+
+
+# ── search-await production wiring — RouterLoop.search_actions ────────────
+
+
+class _StubHost:
+    """Minimal host for RouterLoop.search_actions + _get_index_coordinator."""
+
+    def __init__(self, index: Any, provider: Any, events: EventLog, op_ctx: Any) -> None:
+        self._index = index
+        self._provider = provider
+        self.events = events
+        self._op_ctx = op_ctx
+
+    def get_action_embedding_index(self) -> Any:
+        return self._index
+
+    def get_embedding_provider(self) -> Any:
+        return self._provider
+
+    def get_embedding_model_class(self) -> str:
+        return "standard"
+
+    def make_router_op_context(self) -> Any:
+        return self._op_ctx
+
+
+class _LoopForP2d(RouterLoop):
+    def __init__(self, workspace_root: Path, host: _StubHost) -> None:
+        self.host = host  # type: ignore[assignment]
+        self.chain_id = "test-chain"
+        self._workspace_root_for_test = workspace_root
+
+    def _get_index_coordinator(self) -> IndexCoordinator:
+        if not hasattr(self, "_test_coordinator"):
+            self._test_coordinator = IndexCoordinator(self._workspace_root_for_test)
+        return self._test_coordinator
+
+
+def test_router_loop_search_actions_wires_search_await_and_emits_audit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: ``RouterLoop.search_actions`` — the first live query call
+    site (~router_loop.py) — awaits ``Coordinator.search_await`` before
+    serving and emits ``semantic_search_started``/``_complete`` (results
+    count) around the real query. A clean (already-built) source is a
+    cheap no-op — the query itself still runs and returns real results."""
+    log, store = _events_and_store(tmp_path)
+    provider = _FakeEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    items = [
+        {"qualified_name": "skill__alpha", "short_description": "Alpha skill"},
+        {"qualified_name": "skill__beta", "short_description": "Beta skill"},
+    ]
+    _run(idx.build(items, op_ctx, "standard"))
+    assert idx.is_ready() is True
+
+    host = _StubHost(idx, provider, log, op_ctx)
+    loop = _LoopForP2d(tmp_path, host)
+    # Register the coordinator's manifest as "clean" so search_await is a
+    # no-op (steady-state) — mirrors production: the build path
+    # (_ensure_action_index_built) would have already recorded this.
+    coordinator = loop._get_index_coordinator()
+
+    async def _scenario() -> tuple[list[str], list[dict]]:
+        # Register a builder that raises if ever invoked — search_await
+        # must NOT trigger a build on a source the manifest already
+        # records as "clean" (steady-state no-op, per the firm's §5
+        # contract). Public SourceManifest API only (no private-state
+        # poke) — SourceEntry's ``state`` defaults to "clean".
+        async def _must_not_build() -> BuildMaterial:
+            raise AssertionError("search_await must not build a clean source")
+        coordinator.register_builder("actions", _must_not_build, kind="static")
+        manifest = get_source_manifest(tmp_path)
+        await manifest.upsert(SourceEntry(
+            name="actions", description="", path="", kind="static", state="clean",
+        ))
+
+        names = await loop.search_actions("alpha")
+        return names, await _read_back(store)
+
+    names, events = _run(_scenario())
+    assert "skill__alpha" in names
+    kinds = [e["type"] for e in events]
+    assert "semantic_search_started" in kinds
+    assert "semantic_search_complete" in kinds
+    complete = next(e for e in events if e["type"] == "semantic_search_complete")
+    assert complete["data"]["source_id"] == "actions"
+    assert complete["data"]["results"] == len(names)
+
+
+# ── search-await production wiring — universal_catalog._handle_search_actions ──
+
+
+def test_universal_catalog_handler_wires_search_await_and_emits_audit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: ``_handle_search_actions`` — the second live query call site
+    (~universal_catalog.py) — awaits ``Coordinator.search_await`` before
+    serving and emits ``semantic_search_started``/``_complete`` (results
+    count) around the real query."""
+    log, store = _events_and_store(tmp_path)
+    provider = _FakeEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    items = [
+        {"qualified_name": "skill__alpha", "short_description": "Alpha skill"},
+        {"qualified_name": "skill__beta", "short_description": "Beta skill"},
+    ]
+    _run(idx.build(items, op_ctx, "standard"))
+    assert idx.is_ready() is True
+
+    ws = Workspace(events=log, base_dir=tmp_path)
+    rs = RouterCallerState(
+        action_embedding_index=idx,
+        embedding_provider=provider,
+        embedding_model_class="standard",
+        op_context_factory=lambda: op_ctx,
+    )
+    ctx = ToolContext(
+        events=log, permission_resolver=None, workspace=ws,
+        caller_kind="router", router_state=rs,
+    )
+
+    async def _scenario() -> tuple[dict, list[dict]]:
+        result = await SEARCH_ACTIONS.handler({"query": "alpha", "limit": 5}, ctx)
+        return result, await _read_back(store)
+
+    result, events = _run(_scenario())
+    assert result["items"], "expected ranked results from the real query"
+    kinds = [e["type"] for e in events]
+    assert "semantic_search_started" in kinds
+    assert "semantic_search_complete" in kinds
+    complete = next(e for e in events if e["type"] == "semantic_search_complete")
+    assert complete["data"]["source_id"] == "actions"
+    assert complete["data"]["results"] == len(result["items"])
+
+
+def test_search_await_clean_state_does_not_trigger_build_at_call_site(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: the search-await contract's core promise — a clean source is
+    a cheap no-op. Registers a builder that would raise ``AssertionError``
+    if invoked (a build must NOT be triggered by ``search_await`` once the
+    Coordinator's manifest already records ``state == "clean"``), then
+    drives the real query call site end to end."""
+    log, store = _events_and_store(tmp_path)
+    provider = _FakeEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    items = [{"qualified_name": "skill__alpha", "short_description": "Alpha skill"}]
+    _run(idx.build(items, op_ctx, "standard"))
+
+    ws = Workspace(events=log, base_dir=tmp_path)
+    rs = RouterCallerState(
+        action_embedding_index=idx,
+        embedding_provider=provider,
+        embedding_model_class="standard",
+        op_context_factory=lambda: op_ctx,
+    )
+    ctx = ToolContext(
+        events=log, permission_resolver=None, workspace=ws,
+        caller_kind="router", router_state=rs,
+    )
+
+    async def _scenario() -> dict:
+        from reyn.data.index.coordinator import get_index_coordinator
+        coordinator = get_index_coordinator(tmp_path)
+
+        async def _must_not_build() -> BuildMaterial:
+            raise AssertionError("search_await must not trigger a build on a clean source")
+        coordinator.register_builder("actions", _must_not_build, kind="static")
+        manifest = get_source_manifest(tmp_path)
+        await manifest.upsert(SourceEntry(
+            name="actions", description="", path="", kind="static", state="clean",
+        ))
+
+        return await SEARCH_ACTIONS.handler({"query": "alpha"}, ctx)
+
+    result = _run(_scenario())
+    assert result["items"], "query must still serve real results"

--- a/tests/test_index_coordinator_3247_p2d.py
+++ b/tests/test_index_coordinator_3247_p2d.py
@@ -338,6 +338,66 @@ class _LoopForP2d(RouterLoop):
             self._test_coordinator = IndexCoordinator(self._workspace_root_for_test)
         return self._test_coordinator
 
+    async def _build_router_caller_state(self) -> Any:
+        # Same minimal-subclass shim as test_index_coordinator_3247_p2b.py's
+        # _LoopForP2b — the list_actions handler still returns the static
+        # categories with router_state=None; dynamic categories are not
+        # needed for these tests.
+        return None
+
+
+# ── convergence-debt interim guard (#3247 co-vet, pre-merge) ──────────────
+
+
+def test_action_index_build_failure_both_signals_stay_in_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: FP-0066 P2d / #3247 convergence-debt interim guard.
+
+    ``RouterLoop._action_index_build_failed`` (the pre-P2b per-session
+    retry-prevention flag, #1458) and ``IndexCoordinator``'s own failure-
+    memo (``build_failed(source_id)``) are currently BOTH set on the SAME
+    build failure — P2b's byte-identical two-path retention left them as
+    two independent bookkeeping mechanisms for one fact, kept in sync only
+    IMPLICITLY. Full unification into a single failure-state signal is
+    deferred to the #3247 convergence follow-up (see ``coordinator.py``'s
+    P2b docstring on the two-path builder shape). This test drives a REAL
+    build failure through the REAL production path
+    (``RouterLoop._ensure_action_index_built``, real ``IndexCoordinator``,
+    real ``ActionEmbeddingIndex``, no mocks) and asserts BOTH signals
+    reflect the failure TOGETHER — a future edit that touches only one of
+    the two paths (e.g. a refactor that stops setting one flag) turns this
+    RED instead of silently desyncing them.
+    """
+    log, store = _events_and_store(tmp_path)
+    provider = _FailingEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+
+    host = _StubHost(idx, provider, log, op_ctx)
+    loop = _LoopForP2d(tmp_path, host)
+    coordinator = loop._get_index_coordinator()
+
+    async def _scenario() -> None:
+        await loop._ensure_action_index_built(
+            idx, provider, "standard", await_completion=True,
+        )
+
+    _run(_scenario())
+
+    # getattr (not a direct attribute access) mirrors the established
+    # #1458 pin convention (test_action_embedding_build_failure_1458.py /
+    # test_index_coordinator_3247_p2b.py) — this flag is the production
+    # guard's own read surface (RouterLoop.run() checks it the same way).
+    assert getattr(loop, "_action_index_build_failed", False) is True, (
+        "the RouterLoop-side #1458 retry-prevention flag must be set on "
+        "a real build failure"
+    )
+    assert coordinator.build_failed("actions") is True, (
+        "the Coordinator's own failure-memo must ALSO be set on the SAME "
+        "build failure — the two signals must not desync"
+    )
+
 
 def test_router_loop_search_actions_wires_search_await_and_emits_audit(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247

FP-0066 P2d, per the architect's #3247 firm §5 (search-await contract) + §6 (audit-event phase set), and the architect's decomposition-correction comment ordering P2d BEFORE P3 (the original P2c — sync-in-op ingest + G3 delete-de-index — folds into P3 since its only producers are P3-dependent, 0 live callers today). Verified against the action-catalog build/search (P2b, #3260) — the one live embedding-index producer.

## 1. Audit-event phase emit (`IndexCoordinator`, `src/reyn/data/index/coordinator.py`)

Both build-execution shapes P2b introduced now emit the phase set at their method boundary, via a new optional `events: EventLog | None = None` parameter (best-effort — `None` silently skips, matching every other optional collaborator on this class):

- `ensure_built` (material-producing path) / `_run_build`: `embedding_index_build_started` (source_id + kind) → `embedding_index_build_progress` (chunk_count, from the material's item count) → `embedding_index_build_complete` (chunk_count) on success, or `embedding_index_build_error` (reason) on failure.
- `ensure_built_self_contained` (the action-catalog's own-lock builder shape): same phase set. Since `build_coro` is opaque (no material visible before it runs), `_progress` fires right after `build_coro` returns without raising (using `chunk_count_probe`) rather than mid-build — a coarser granularity than the material path, an honest limitation of this builder shape (documented in the method's docstring).

**The fold**: the pre-P2d `action_index_build_failed` event was previously emitted directly inside `RouterLoop._build_action_embedding_index_background`'s except-block. That direct emit is removed; `IndexCoordinator.ensure_built_self_contained`'s except-block (reached via `RouterLoop._ensure_action_index_built`, this primitive's only production caller) now emits `embedding_index_build_error` instead — a single emitter per failure, no double-emit. `RouterLoop._ensure_action_index_built` threads `events=self.host.events` through to the Coordinator.

Verified via a real `EventLog` subscribed to a real `EventStore`, read back from the actual on-disk `.reyn/events` JSONL (`tests/test_index_coordinator_3247_p2d.py`) — not asserted against private state.

## 2. search-await wiring (the two live action-catalog query call sites)

- `RouterLoop.search_actions` (router_loop.py): now calls `coordinator.search_await(source_id)` before `index.query(...)`, wrapped in `semantic_search_started`/`semantic_search_complete` (results count).
- `universal_catalog._handle_search_actions` (~L959): same wiring, resolving the Coordinator via `get_index_coordinator(ctx.workspace.base_dir)` (guarded — `ctx.workspace` is always populated per `ToolContext`'s own contract, but the check is defensive).

**Why the audit-events land at the call site, not inside `Coordinator.search_await` itself**: the firm's §6 says `semantic_search_complete` carries a results count, but `search_await` only awaits build-readiness — it has no visibility into the actual query results (that's a separate call, `idx.query(...)`, right after). Emitting at the call site (which is also exactly where `search_await` is invoked) is the only place both facts — "a search happened" and "how many results it returned" — are available together. This is a considered adaptation of the firm's stated firing point, made transparent here per the co-vet convention (mirrors P2b's two documented deviations).

**steady-state no-op vs cold-start-await, proven**: `test_search_await_clean_state_does_not_trigger_build_at_call_site` registers a builder that raises `AssertionError` if ever invoked, marks the manifest `state="clean"` via the public `SourceManifest` API, then drives the real `_handle_search_actions` call site end-to-end — the builder is never called, and the real query still serves results. `test_search_await_heals_a_dirty_source`-equivalent coverage for the Coordinator's internal heal path already exists in `test_index_coordinator_3247_p2a.py` (P2a); this PR proves the *production wiring point* uses that same no-op/heal contract, not the internal mechanism itself (already covered).

## `is_ready` serve-vs-state split — preserved

Per P2b's ratified decision, `idx.is_ready()` stays the SERVE gate (query-ability); `Coordinator.is_ready()`/manifest `state` stays the STATE signal. `search_await` gates on the Coordinator's STATE record only (`state == "clean"` → no-op) — it does not read or write `idx.is_ready()`, and does not change when `idx.query()` becomes visible/servable. No collapse of the two concerns.

## Guardrails respected

- No sync-in-op ingest / G3 delete-de-index (folded into P3 per the architect's ruling — not touched here).
- No change to the all-or-nothing guard or the sandbox-cap gates.
- No doc-sync needed: `docs/deep-dives/proposals/0066-retrieval-two-groups-two-axes.md` already describes this audit-event phase set at a level this PR fulfills without falsifying; no other doc references the folded event name.

## Tests

New: `tests/test_index_coordinator_3247_p2d.py` (8 tests) — build-phase emit + order (material path), build failure → `embedding_index_build_error` (material path), `events=None` no-op, self-contained-builder phase emit, self-contained-builder failure → fold (not `action_index_build_failed`), `RouterLoop.search_actions` wiring + audit, `universal_catalog._handle_search_actions` wiring + audit, clean-state no-build proof at the call site.

Updated (fold-consistency, same PR per CLAUDE.md's stale-pin rule):
- `tests/test_action_embedding_build_failure_1458.py`: the low-level primitive, called directly (bypassing the Coordinator), now asserts NO audit-event emits from it (moved up a layer); retry-prevention is now observed via `idx.build_calls` instead of event count.
- `tests/test_index_coordinator_3247_p2b.py`: `test_1458_pinned_build_primitive_still_used_unchanged` now asserts `embedding_index_build_error` (not `action_index_build_failed`), plus a non-double-emit check.

## Local CI gates (all green)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_index_coordinator_3247_p2d.py tests/test_index_coordinator_3247_p2b.py tests/test_action_embedding_build_failure_1458.py` — 24/24 OK, 0 Tier-4 violations.
- `PYTHONPATH=$(pwd)/src python -m pytest <all affected/related test files>` — 459 passed (0 failed) across the new P2d file + every P2a/P2b/1458/action-embedding/universal-catalog/router-loop/SP test file touching this surface.
- `python scripts/verify_module_docstrings.py src/reyn/data/index/coordinator.py src/reyn/runtime/router_loop.py src/reyn/tools/universal_catalog.py` — OK.

## Test plan

- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on all changed/new test files
- [x] `pytest` on all changed + directly-affected test files (459 passed)
- [x] `verify_module_docstrings.py` on all changed src files
- [x] Audit-events read back from real on-disk `.reyn/events` JSONL (not private state)
- [x] search-await no-op/heal proven at the production call site, not just the Coordinator internals
- [x] `is_ready` serve-vs-state split unchanged (confirmed via grep + the new tests not touching `idx.is_ready()`)