### PR TITLE
fix(FP-0066 P3-helper): unify semantic-search emit/await wrap + fix catalog complete-emit leak

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -74,6 +74,7 @@ __all__ = [
     "EmbedWriteResult",
     "assert_vector_count_match",
     "embed_verify_write",
+    "emit_wrapped_semantic_search",
     "IndexCoordinator",
     "get_index_coordinator",
 ]
@@ -652,3 +653,68 @@ def get_index_coordinator(workspace_root: Path) -> IndexCoordinator:
     if workspace_root not in _COORDINATORS:
         _COORDINATORS[workspace_root] = IndexCoordinator(workspace_root)
     return _COORDINATORS[workspace_root]
+
+
+# ── search-emit helper (P3-helper, #3247 firm §6) ─────────────────────────
+#
+# `semantic_search_started -> search_await -> query -> semantic_search_
+# complete` was duplicated verbatim at the two live query call sites
+# (RouterLoop.search_actions in router_loop.py, universal_catalog.
+# _handle_search_actions) — a third caller (search_knowledge, P3c) would
+# have made it three, so the firm calls for a single-source helper BEFORE
+# that lands (do not let the dup become an established pattern).
+#
+# ``coordinator``/``op_ctx`` are argument-injected rather than resolved
+# inside the helper: the two call sites acquire them asymmetrically
+# (RouterLoop via ``self._get_index_coordinator()`` + ``self.host.
+# make_router_op_context()``; the catalog handler via ``get_index_
+# coordinator(ctx.workspace.base_dir)`` gated on ``ctx.workspace`` being
+# set + ``rs.op_context_factory()``) — the helper must not special-case
+# either acquisition path, so it never calls ``get_index_coordinator``
+# itself. ``coordinator=None`` is honored as "skip search_await" (the
+# catalog site's pre-existing degrade when ``ctx.workspace`` is unset).
+# ``events`` is None-tolerant for the same reason (the catalog handler
+# may be invoked without an events sink).
+#
+# ★ Bug fix this extraction exposes: the catalog call site had NO
+# try/finally around ``index.query()`` — a query failure emitted
+# ``semantic_search_started`` but never its matching ``_complete``, a
+# dangling started-without-complete in the audit trail (undetected
+# because nothing previously asserted the pairing under failure). The
+# router_loop site already wrapped the query in try/finally (with its
+# own best-effort except/log around the whole thing); this helper folds
+# that guarantee in ONE place so both sites get it uniformly — on any
+# exception raised by ``search_await``/``index.query``, ``_complete``
+# still fires (with ``results=0``) before the exception re-raises to the
+# caller, which decides for itself whether to swallow it (best-effort
+# presentation, per ``RouterLoop.search_actions``) or propagate it
+# (the catalog handler, unchanged from before).
+async def emit_wrapped_semantic_search(
+    *,
+    events: "EventLog | None",
+    coordinator: "IndexCoordinator | None",
+    source_id: str,
+    index: Any,
+    query: str,
+    op_ctx: "OpContext",
+    model_class: str,
+    top_k: int,
+) -> list[dict[str, Any]]:
+    """Unified ``semantic_search_started`` -> ``search_await`` -> ``query``
+    -> ``semantic_search_complete`` wrap (#3247 firm §6). Guarantees
+    ``semantic_search_complete`` always fires (``results=0`` on failure)
+    even when ``search_await``/``index.query`` raises, then re-raises so
+    the caller retains its own error-handling policy."""
+    if events is not None:
+        events.emit("semantic_search_started", source_id=source_id)
+    results: list[dict[str, Any]] = []
+    try:
+        if coordinator is not None:
+            await coordinator.search_await(source_id)
+        results = await index.query(query, op_ctx, model_class, top_k=top_k)
+    finally:
+        if events is not None:
+            events.emit(
+                "semantic_search_complete", source_id=source_id, results=len(results),
+            )
+    return results

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -2914,32 +2914,38 @@ class RouterLoop:
         prior sync-in-op build left the source ``dirty``/mid-``building``
         (the "best-effort search is a bug" completeness guarantee). Wraps
         the search in ``semantic_search_started``/``_complete`` audit-events
-        (results count) — this call site (not ``Coordinator.search_await``
-        itself, which has no visibility into the actual query results) is
-        where the count is known, so ``_complete`` fires here.
+        (results count) via the shared ``emit_wrapped_semantic_search``
+        helper (P3-helper, #3247 firm §6) — the unification of this wrap
+        with the ``universal_catalog._handle_search_actions`` copy.
         """
+        from reyn.data.index.coordinator import emit_wrapped_semantic_search
+
         index = self.host.get_action_embedding_index()
         provider = self.host.get_embedding_provider()
         model_class = self.host.get_embedding_model_class()
         if index is None or provider is None:
             return []
         source_id = getattr(index, "source_name", None) or "actions"
-        events = self.host.events
-        self.host.events.emit("semantic_search_started", source_id=source_id)
         results: list[dict[str, Any]] = []
         try:
             coordinator = self._get_index_coordinator()
-            await coordinator.search_await(source_id)
             # FP-0057 #2856 Part A: idx.query() routes through the shared
             # `embed` op (execute_op) instead of calling ``provider`` directly
             # — needs an OpContext, not the provider instance itself.
             op_ctx = self.host.make_router_op_context()
-            results = await index.query(query, op_ctx, model_class, top_k=top_k)
+            results = await emit_wrapped_semantic_search(
+                events=self.host.events,
+                coordinator=coordinator,
+                source_id=source_id,
+                index=index,
+                query=query,
+                op_ctx=op_ctx,
+                model_class=model_class,
+                top_k=top_k,
+            )
         except Exception as e:  # noqa: BLE001 — search is best-effort presentation aid
             import logging
             logging.getLogger(__name__).warning("search_actions failed: %s", e)
-        finally:
-            events.emit("semantic_search_complete", source_id=source_id, results=len(results))
         return [r["qualified_name"] for r in results if r.get("qualified_name")]
 
     def resolve(self, llm_response, tool_catalog: dict) -> list[dict]:

--- a/src/reyn/tools/universal_catalog.py
+++ b/src/reyn/tools/universal_catalog.py
@@ -968,21 +968,31 @@ async def _handle_search_actions(
     # state (source already "clean"), or a heal-await if a prior sync-in-op
     # build left the source dirty/mid-building (the "best-effort search is
     # a bug" completeness guarantee). Wrapped in semantic_search_started/
-    # _complete audit-events (results count) — this call site, not
-    # ``Coordinator.search_await`` itself, is where the result count is
-    # actually known.
-    from reyn.data.index.coordinator import get_index_coordinator
+    # _complete audit-events (results count) via the shared
+    # ``emit_wrapped_semantic_search`` helper (P3-helper, #3247 firm §6) —
+    # the unification of this wrap with the ``RouterLoop.search_actions``
+    # copy, which ALSO fixes a bug this call site used to have: no
+    # try/finally meant a query failure emitted ``semantic_search_started``
+    # without its matching ``_complete``. The helper guarantees
+    # ``_complete`` fires (``results=0``) even on failure, then re-raises
+    # (this handler's own error handling is unchanged — it still propagates).
+    from reyn.data.index.coordinator import emit_wrapped_semantic_search, get_index_coordinator
 
     source_id = getattr(idx, "source_name", None) or "actions"
     events = ctx.events
-    if events is not None:
-        events.emit("semantic_search_started", source_id=source_id)
-    if ctx.workspace is not None:
-        coordinator = get_index_coordinator(ctx.workspace.base_dir)
-        await coordinator.search_await(source_id)
-    results = await idx.query(query, op_ctx, model_class, top_k=raw_top_k)
-    if events is not None:
-        events.emit("semantic_search_complete", source_id=source_id, results=len(results))
+    coordinator = (
+        get_index_coordinator(ctx.workspace.base_dir) if ctx.workspace is not None else None
+    )
+    results = await emit_wrapped_semantic_search(
+        events=events,
+        coordinator=coordinator,
+        source_id=source_id,
+        index=idx,
+        query=query,
+        op_ctx=op_ctx,
+        model_class=model_class,
+        top_k=raw_top_k,
+    )
 
     if category_set:
         from reyn.tools.universal_catalog import split_qualified_name

--- a/tests/test_fp0066_p3_helper_3247_search_emit.py
+++ b/tests/test_fp0066_p3_helper_3247_search_emit.py
@@ -1,0 +1,196 @@
+"""FP-0066 P3-helper (#3247 firm §6) — the unified ``emit_wrapped_semantic_
+search`` helper + the catalog-site complete-emit bug fix it exposes.
+
+Context: ``semantic_search_started -> search_await -> query ->
+semantic_search_complete`` was duplicated verbatim at the two live query
+call sites (``RouterLoop.search_actions`` in ``router_loop.py`` ~L2904-2943,
+``universal_catalog._handle_search_actions`` ~L974-985) — a third caller
+(``search_knowledge``, P3c) would make it three, so the firm (#3247, P3
+"設計 firm" §6) calls for extraction into ``reyn.data.index.coordinator.
+emit_wrapped_semantic_search`` BEFORE that lands.
+
+Covers:
+  1. ★ The bug fix — pre-helper, the catalog call site had NO try/finally,
+     so an ``index.query()`` failure emitted ``semantic_search_started``
+     without its matching ``_complete`` (a dangling started-without-
+     complete in the audit trail). This test drives that path through the
+     REAL production handler (``SEARCH_ACTIONS.handler``) with a query
+     that genuinely fails (a failing embedding provider swapped in for the
+     query-time embed, mirroring ``test_index_coordinator_3247_p2d.py``'s
+     established fake-provider convention) and asserts ``_complete`` FIRES
+     (``results=0``) despite the failure, the error re-raises, and
+     started/complete come in a matched pair.
+  2. The helper is ``events``-None-tolerant and ``coordinator``-None-
+     tolerant (the catalog site's pre-existing degrade when
+     ``ctx.workspace`` is unset) without raising.
+  3. The router_loop call site's pre-existing behavioral test
+     (``test_router_loop_search_actions_wires_search_await_and_emits_audit``
+     in ``test_index_coordinator_3247_p2d.py``) is UNCHANGED by this PR —
+     not re-declared here; its continued green run is this PR's byte-
+     identical-preservation proof for that site.
+
+No mocks — real ``IndexCoordinator``, real ``ActionEmbeddingIndex``, a real
+``EventLog``/``EventStore`` pair (audit-events read back from the actual
+on-disk JSONL, not private state), a real ``OpContext``; a plain fake
+embedding provider (same established convention as
+``test_index_coordinator_3247_p2d.py``) stands in for the litellm boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from reyn.core.events.event_store import EventStore
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index.coordinator import emit_wrapped_semantic_search, get_index_coordinator
+from reyn.data.workspace.workspace import Workspace
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.tools.action_index import ActionEmbeddingIndex
+from reyn.tools.types import RouterCallerState, ToolContext
+from reyn.tools.universal_catalog import SEARCH_ACTIONS
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+def _events_and_store(tmp_path: Path) -> tuple[EventLog, EventStore]:
+    """A real EventLog subscribed to a real EventStore rooted under
+    ``tmp_path / ".reyn" / "events"`` — audit-events are read back from the
+    actual on-disk JSONL, per CLAUDE.md's real-instance testing policy."""
+    store = EventStore(tmp_path / ".reyn" / "events")
+    log = EventLog(subscribers=[store])
+    return log, store
+
+
+async def _read_back(store: EventStore) -> list[dict]:
+    await store.flush()
+    return [e.model_dump(mode="json") for e in store.iter_all()]
+
+
+class _FakeEmbeddingProvider:
+    """Deterministic canned vectors, one per input text (no litellm call)."""
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        vectors = [[float((hash((t, i)) % 1000) / 1000.0) for i in range(4)] for t in texts]
+        return {"vectors": vectors, "model": model, "total_tokens": len(texts)}
+
+
+class _FailingEmbeddingProvider:
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        raise RuntimeError("embedding API unreachable")
+
+
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch, events: EventLog) -> OpContext:
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+# ── 1. ★ bug-fix proof — catalog site now guarantees complete-emit ────────
+
+
+def test_catalog_search_actions_emits_complete_on_query_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 2: pre-``emit_wrapped_semantic_search``, ``universal_catalog.
+    _handle_search_actions`` had NO try/finally around ``idx.query()`` — a
+    query failure left ``semantic_search_started`` emitted with no matching
+    ``semantic_search_complete`` (a real, previously-unproven leak). After
+    the P3-helper extraction, the helper's try/finally guarantees
+    ``_complete`` (``results=0``) fires even when the query fails, and the
+    original error still re-raises to the caller (the handler itself does
+    not swallow it — unchanged from before)."""
+    log, store = _events_and_store(tmp_path)
+    build_provider = _FakeEmbeddingProvider()
+    build_ctx = _op_ctx_for(build_provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    items = [{"qualified_name": "skill__alpha", "short_description": "Alpha skill"}]
+    _run(idx.build(items, build_ctx, "standard"))
+    assert idx.is_ready() is True
+
+    # Mark the coordinator's manifest "clean" so search_await is a no-op —
+    # this test's claim is about the query-failure leak, not build/heal.
+    coordinator = get_index_coordinator(tmp_path)
+    from reyn.data.index.source_manifest import SourceEntry, get_source_manifest
+    manifest = get_source_manifest(tmp_path)
+    _run(manifest.upsert(SourceEntry(
+        name="actions", description="", path="", kind="static", state="clean",
+    )))
+
+    # The query-time embed call now fails (swap in a failing provider for
+    # THIS OpContext) — idx.query() raises RuntimeError (per
+    # ActionEmbeddingIndex._embed_via_op's documented raise-on-op-failure
+    # contract), independent of the earlier successful build.
+    query_provider = _FailingEmbeddingProvider()
+    query_ctx = _op_ctx_for(query_provider, monkeypatch, log)
+
+    ws = Workspace(events=log, base_dir=tmp_path)
+    rs = RouterCallerState(
+        action_embedding_index=idx,
+        embedding_provider=query_provider,
+        embedding_model_class="standard",
+        op_context_factory=lambda: query_ctx,
+    )
+    ctx = ToolContext(
+        events=log, permission_resolver=None, workspace=ws,
+        caller_kind="router", router_state=rs,
+    )
+
+    async def _scenario() -> list[dict]:
+        with pytest.raises(RuntimeError, match="embed op failed"):
+            await SEARCH_ACTIONS.handler({"query": "alpha", "limit": 5}, ctx)
+        return await _read_back(store)
+
+    events = _run(_scenario())
+    kinds = [e["type"] for e in events if e["type"].startswith("semantic_search_")]
+    assert kinds == ["semantic_search_started", "semantic_search_complete"], (
+        "started/complete must come as a MATCHED PAIR even on query "
+        "failure — pre-helper, complete never fired here (the bug this "
+        "extraction fixes)"
+    )
+    complete = next(e for e in events if e["type"] == "semantic_search_complete")
+    assert complete["data"]["source_id"] == "actions"
+    assert complete["data"]["results"] == 0, (
+        "results must be 0 on a query failure, not omitted/stale"
+    )
+    del coordinator  # referenced only to force the manifest write above
+
+
+# ── 2. helper is events-None-tolerant and coordinator-None-tolerant ───────
+
+
+def test_helper_is_events_and_coordinator_none_tolerant(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    """Tier 1: ``emit_wrapped_semantic_search`` accepts ``events=None``
+    (silently no-ops the emits) and ``coordinator=None`` (skips
+    ``search_await`` entirely) without raising — the catalog call site's
+    pre-existing degrade when ``ctx.events``/``ctx.workspace`` are unset,
+    now the helper's own explicit contract (#3247 firm §6)."""
+    log = EventLog(subscribers=[])
+    provider = _FakeEmbeddingProvider()
+    op_ctx = _op_ctx_for(provider, monkeypatch, log)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    items = [{"qualified_name": "skill__alpha", "short_description": "Alpha skill"}]
+    _run(idx.build(items, op_ctx, "standard"))
+
+    async def _scenario() -> list[dict]:
+        return await emit_wrapped_semantic_search(
+            events=None,
+            coordinator=None,
+            source_id="actions",
+            index=idx,
+            query="alpha",
+            op_ctx=op_ctx,
+            model_class="standard",
+            top_k=5,
+        )
+
+    results = _run(_scenario())
+    assert results, "the query itself must still serve real results"


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247

## What

Implements FP-0066 P3-helper (the architect's "P3 設計 firm" §6, ratified on
#3247), the prerequisite that goes before `search_knowledge` (P3c).

**New helper** — `src/reyn/data/index/coordinator.py::emit_wrapped_semantic_search`:

```python
async def emit_wrapped_semantic_search(
    *, events, coordinator, source_id, index, query, op_ctx, model_class, top_k,
) -> list[dict]:
```

Performs, in order: emit `semantic_search_started` (source_id) →
`await coordinator.search_await(source_id)` (skipped when
`coordinator is None`) → `results = await index.query(query, op_ctx,
model_class, top_k=top_k)` → emit `semantic_search_complete` (results
count) — with a **try/finally** so `_complete` ALWAYS fires (`results=0`
on failure) before re-raising. `events=None` no-ops the emits (the
catalog site's existing degrade). `coordinator`/`op_ctx` are argument-
injected (never resolved via `get_index_coordinator()` inside the
helper) since the two call sites acquire them asymmetrically.

**Two call sites replaced:**
- `RouterLoop.search_actions` (`src/reyn/runtime/router_loop.py`) — resolves
  its own `coordinator`/`op_ctx`, calls the helper inside its existing
  try/except (best-effort presentation — logs + returns `[]` on failure).
  Observable behavior unchanged (started+complete on success, correct count) —
  proven by the pre-existing
  `test_router_loop_search_actions_wires_search_await_and_emits_audit`
  (`tests/test_index_coordinator_3247_p2d.py`), which stays green untouched.
- `universal_catalog._handle_search_actions` — same replacement, but this
  site previously had **no try/finally at all**.

## ★ The bug fix

Pre-helper, `universal_catalog._handle_search_actions` emitted
`semantic_search_started` then called `idx.query()` with NO try/finally —
a query failure (embed-op error, provider outage, etc.) left `_started`
emitted with **no matching `_complete`**, a dangling audit-event pair.
The new helper's try/finally guarantees `_complete` (`results=0`) fires
uniformly at BOTH sites, then re-raises so each caller keeps its own
error-handling policy (router_loop's best-effort swallow is unchanged;
the catalog handler still propagates, as before — it just no longer
leaks the events on the way out).

## Tests (`tests/test_fp0066_p3_helper_3247_search_emit.py`)

- `test_catalog_search_actions_emits_complete_on_query_failure` — drives
  the REAL `SEARCH_ACTIONS.handler` production path with a query-time
  embed failure (a failing fake provider swapped in for that
  `OpContext`, same convention as `test_index_coordinator_3247_p2d.py`)
  and asserts `semantic_search_started`/`_complete` come as a **matched
  pair** with `results=0`, and the `RuntimeError` still re-raises.
  Docstring notes the pre-helper leak this proves was fixed.
- `test_helper_is_events_and_coordinator_none_tolerant` — `events=None`
  and `coordinator=None` are honored without raising.
- Byte-identical for router_loop: no new test — its pre-existing
  behavioral test in `test_index_coordinator_3247_p2d.py` stays green,
  unmodified.

All real instances (real `IndexCoordinator`, real `ActionEmbeddingIndex`,
real `EventLog`/`EventStore`, real `OpContext`) — no mocks of cheaply-
constructible collaborators, per CLAUDE.md testing policy.

## Local CI gates (all green)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_fp0066_p3_helper_3247_search_emit.py` — 2/2 OK, 0 Tier-4
- `PYTHONPATH=$(pwd)/src python -m pytest <changed + affected test files>` — 204 passed
- `python scripts/verify_module_docstrings.py <changed src files>` — OK

## Test plan

- [x] `ruff check src tests`
- [x] `test_tier_audit.py --strict` on the new test file
- [x] Full affected pytest run (router_loop + universal_catalog search-actions
      tests, IndexCoordinator P2a/P2b/P2d suites, the new P3-helper suite) —
      204 passed
- [x] `verify_module_docstrings.py` on changed src files

## Out of scope (per brief)

- `search_knowledge` / `knowledge__search` category — P3c
- Visibility-gate set-sharing — P3c
- skill/memory ingest (P3a) / repo (P3b)