### PR TITLE
feat(FP-0066 P4a): Transport axis + valid-(scheme,transport) registry (behavior-preserving)

### DIFF
--- a/src/reyn/tools/transport.py
+++ b/src/reyn/tools/transport.py
@@ -1,0 +1,105 @@
+"""Transport axis + valid-(scheme,transport) registry (FP-0066 P4a, #3247).
+
+Tool-use decomposes into two orthogonal axes (FP-0066 §2): **scheme**
+(presentation — how capabilities are shown/discovered: ``category`` /
+``enumerate-all`` / ``retrieval``) x **transport** (how the model expresses the
+chosen action: ``tool_calls`` / ``content_fence``). Today the two axes are
+conflated in a single flat ``_SCHEMES`` registry (``reyn.tools.scheme``) where
+``codeact`` is really the ``content_fence`` transport applied to the
+``enumerate-all`` presentation, registered as if it were a 4th sibling scheme.
+
+This module is **internal-only and behavior-preserving** (P4a): it introduces
+the ``Transport`` type and a registry that names which (scheme, transport)
+cells are actually resolvable, WITHOUT changing config (``tool_use.chat`` stays
+the selector — P4b), WITHOUT removing ``codeact`` from ``_SCHEMES`` (P4c), and
+WITHOUT physically splitting ``ToolUseScheme`` into two protocols (firm §2 J3 —
+``Presentation`` already carries the transport freedom via
+``llm_tools_payload`` emptiness + ``tool_use_sp`` + the ``Interpretation``
+Execute/CodeBlock branch; transport is expressed as a construction-strategy +
+interpret-branch SELECTION, not a bundle reshuffle).
+
+Only two transports are implemented today (``tool_calls``, ``content_fence``);
+a third (``structured_output``, ``response_format``/json_schema) is deferred to
+#3249 — no reserved slot is added here (YAGNI, firm §3 P4d).
+
+Splitting scheme x transport into two axes does not make the full 3x2 cartesian
+product resolvable: ``category`` x ``content_fence`` and everything x a future
+``structured_output`` are UNIMPLEMENTED cells. ``resolve_scheme_for_transport``
+is fail-closed on an unregistered cell — mirrors the #3026 "enumeration is not
+resolution" pin (``reyn.tools.universal_catalog``): splitting an axis / set does
+not silently widen what is actually resolvable.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Transport(str, Enum):
+    """How the model expresses a chosen action. Two implemented values only —
+    see the module docstring for why ``structured_output`` is deliberately
+    absent (#3249, deferred, no reserved slot)."""
+
+    TOOL_CALLS = "tool_calls"
+    CONTENT_FENCE = "content_fence"
+
+
+# The valid-(scheme, transport) registry (firm §2 J1) — the ONLY resolvable
+# cells, explicitly enumerated from the FP-0066 §1 census of the current
+# `_SCHEMES` registry (`reyn.tools.scheme._SCHEMES`):
+#
+#   presentation \ transport | tool_calls | content_fence
+#   -------------------------|------------|---------------
+#   category                 | universal-category | (unimplemented)
+#   enumerate-all             | enumerate-all      | codeact
+#   retrieval                 | retrieval          | (unimplemented)
+#
+# "category" / "enumerate-all" / "retrieval" here are the FP-0066 §2
+# presentation-axis names; the value is the name currently registered in
+# `reyn.tools.scheme._SCHEMES` that implements that (scheme, transport) cell
+# TODAY (byte-identical — P4a moves no logic). `codeact` census-verified as
+# `enumerate-all` presentation (identical full flat catalog via
+# `dispatchable_catalog=entries` / `ops.catalog_entries()`) expressed over the
+# `content_fence` transport (`llm_tools_payload=[]` + `tool_use_sp` rendered
+# code-API + the CodeBlock interpret branch) — see FP-0066 issue #3247, P4
+# firm §1.
+_VALID_SCHEME_TRANSPORT_PAIRS: "dict[tuple[str, Transport], str]" = {
+    ("category", Transport.TOOL_CALLS): "universal-category",
+    ("enumerate-all", Transport.TOOL_CALLS): "enumerate-all",
+    ("enumerate-all", Transport.CONTENT_FENCE): "codeact",
+    ("retrieval", Transport.TOOL_CALLS): "retrieval",
+}
+
+
+def resolve_scheme_for_transport(scheme: str, transport: Transport) -> str:
+    """Resolve a (presentation-scheme, transport) pair to the ``_SCHEMES`` name
+    that implements it today — fail-closed (firm §2 J1): an unregistered cell
+    (e.g. ``category`` x ``content_fence``, anything x a future
+    ``structured_output``) raises a legible ``ValueError`` rather than being
+    silently allowed or silently falling back to a default. A silently-accepted
+    unregistered cell is exactly the "configuration doesn't do what it says"
+    trap the firm's J1 calls out (mirrors #3026 "enumeration is not
+    resolution": splitting the axis in two does not widen the resolvable set
+    past what is explicitly registered)."""
+    try:
+        return _VALID_SCHEME_TRANSPORT_PAIRS[(scheme, transport)]
+    except KeyError:
+        valid = ", ".join(
+            f"({s!r}, {t.value!r})" for s, t in valid_scheme_transport_pairs()
+        )
+        raise ValueError(
+            f"no (scheme, transport) registration for (scheme={scheme!r}, "
+            f"transport={transport.value!r}); valid pairs: {valid}"
+        ) from None
+
+
+def valid_scheme_transport_pairs() -> "list[tuple[str, Transport]]":
+    """Sorted ``(scheme, transport)`` keys of the valid-pair registry
+    (introspection / tests)."""
+    return sorted(_VALID_SCHEME_TRANSPORT_PAIRS, key=lambda pair: (pair[0], pair[1].value))
+
+
+__all__ = [
+    "Transport",
+    "resolve_scheme_for_transport",
+    "valid_scheme_transport_pairs",
+]

--- a/tests/test_fp0066_p4a_transport_axis_3247.py
+++ b/tests/test_fp0066_p4a_transport_axis_3247.py
@@ -1,0 +1,129 @@
+"""Tier 1: FP-0066 P4a — Transport axis + valid-(scheme,transport) registry (#3247).
+
+Internal, behavior-preserving (per the P4 firm, issue #3247): introduces
+``reyn.tools.transport.Transport`` (the two implemented values,
+``tool_calls`` / ``content_fence`` — ``structured_output`` deliberately absent,
+deferred to #3249) + the explicit valid-(scheme,transport) registry (firm §2 J1)
+that maps a (presentation-scheme, transport) pair to the ``_SCHEMES`` name that
+implements it TODAY, fail-closed on any unregistered cell.
+
+Pins:
+  - the registry's census is exactly the 4 known-implemented cells (vacuity
+    guard: non-empty + no more/less than the census);
+  - an unregistered cell (e.g. ``category`` x ``content_fence``) raises a
+    legible ``ValueError`` rather than being silently accepted — the
+    fail-closed guard is load-bearing (strip-falsify: a naive permissive
+    lookup, the shape the guard replaces, WOULD silently accept it);
+  - ``codeact`` is the (enumerate-all, content_fence) cell's live
+    implementation, and P4a made zero changes to it (no import of
+    ``reyn.tools.schemes.codeact`` internals is touched by this module — the
+    registry only NAMES the existing, unmodified ``_SCHEMES`` entry).
+
+No mocks: ``Transport`` / the registry are pure data + functions, no
+collaborators to fake.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = Path(__file__).parent.parent / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+# Ensure the built-in schemes (codeact / enumerate-all / retrieval /
+# universal-category) are registered — importing the package runs each
+# module's self-register-on-import side effect (mirrors test_scheme_self_register_1608.py).
+import reyn.tools.schemes  # noqa: E402,F401
+from reyn.tools.scheme import get_scheme  # noqa: E402
+from reyn.tools.transport import (  # noqa: E402
+    Transport,
+    resolve_scheme_for_transport,
+    valid_scheme_transport_pairs,
+)
+
+_CENSUS: "dict[tuple[str, Transport], str]" = {
+    ("category", Transport.TOOL_CALLS): "universal-category",
+    ("enumerate-all", Transport.TOOL_CALLS): "enumerate-all",
+    ("enumerate-all", Transport.CONTENT_FENCE): "codeact",
+    ("retrieval", Transport.TOOL_CALLS): "retrieval",
+}
+
+
+def test_transport_has_only_the_two_implemented_values() -> None:
+    """Tier 1: Transport carries exactly tool_calls/content_fence — no reserved
+    structured_output slot (firm §3 P4d — YAGNI, deferred to #3249)."""
+    assert {t.value for t in Transport} == {"tool_calls", "content_fence"}
+    assert not hasattr(Transport, "STRUCTURED_OUTPUT")
+
+
+def test_valid_pair_registry_census_matches_the_four_known_cells() -> None:
+    """Tier 1: the valid-pair registry enumerates exactly the 4 census-verified
+    cells (FP-0066 issue #3247, P4 firm §1) — vacuity guard (non-empty) folded
+    into the exact-match assertion (a registry with 0 or >4 entries fails this)."""
+    pairs = valid_scheme_transport_pairs()
+    assert pairs, "valid-pair registry must not be vacuous"
+    assert set(pairs) == set(_CENSUS)
+
+
+@pytest.mark.parametrize(
+    ("scheme", "transport", "expected"),
+    [(s, t, expected) for (s, t), expected in _CENSUS.items()],
+)
+def test_valid_pairs_resolve_to_the_census_scheme(
+    scheme: str, transport: Transport, expected: str,
+) -> None:
+    """Tier 1: each of the 4 valid cells resolves to its census-verified
+    _SCHEMES name, and that name is actually a registered, live scheme."""
+    resolved = resolve_scheme_for_transport(scheme, transport)
+    assert resolved == expected
+    assert get_scheme(resolved) is not None
+
+
+def test_codeact_is_the_enumerate_all_content_fence_cell_unmodified() -> None:
+    """Tier 1: (enumerate-all, content_fence) resolves to the SAME registered
+    ``codeact`` scheme instance the pre-P4a ``_SCHEMES`` registry already held
+    — P4a adds a naming layer on top of the existing registry, it does not
+    reconstruct or wrap the scheme (byte-identical: 0 behavior change)."""
+    resolved_name = resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)
+    assert resolved_name == "codeact"
+    assert get_scheme("codeact") is get_scheme(resolved_name)
+
+
+@pytest.mark.parametrize(
+    ("scheme", "transport"),
+    [
+        ("category", Transport.CONTENT_FENCE),
+        ("retrieval", Transport.CONTENT_FENCE),
+    ],
+)
+def test_unregistered_cell_fails_closed(scheme: str, transport: Transport) -> None:
+    """Tier 1: an unregistered (scheme,transport) cell raises a legible
+    ValueError — NOT a silent fallback to some default scheme. Mirrors #3026
+    "enumeration is not resolution": splitting into two axes does not widen
+    the resolvable set past what is explicitly registered (firm §2 J1)."""
+    with pytest.raises(ValueError, match=r"no \(scheme, transport\) registration"):
+        resolve_scheme_for_transport(scheme, transport)
+
+
+def test_strip_falsify_fail_closed_guard_is_load_bearing() -> None:
+    """Tier 1: strip-falsify — a naive permissive lookup — the shape
+    ``resolve_scheme_for_transport`` deliberately does NOT use (a plain
+    ``dict.get`` with a silent fallback default) — WOULD silently accept the
+    unregistered ``(category, content_fence)`` cell and hand back a wrong
+    scheme name instead of raising. This demonstrates the real function's
+    ``raise`` is load-bearing: strip it back to a ``.get(..., default)`` shape
+    and the failure mode silently degrades from a loud error to a wrong-scheme
+    selection — exactly the "configuration doesn't do what it says" trap J1
+    guards against."""
+    registry = {pair: resolve_scheme_for_transport(*pair) for pair in _CENSUS}
+    unregistered = ("category", Transport.CONTENT_FENCE)
+    assert unregistered not in registry
+
+    naive_silent_lookup = registry.get(unregistered, "enumerate-all")
+    assert naive_silent_lookup == "enumerate-all"  # the un-guarded shape silently "succeeds"
+
+    with pytest.raises(ValueError):
+        resolve_scheme_for_transport(*unregistered)  # the real, guarded function does not


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247

Implements FP-0066 **P4a** per the architect's P4 firm (issue #3247, "FP-0066 P4 設計 firm" comment, §2/§3). Internal, behavior-preserving — no config change (P4b), no codeact removal from `_SCHEMES` (P4c), no `structured_output` slot (P4d, deferred to #3249).

## What's delivered

**`src/reyn/tools/transport.py` (new)**:
- `Transport` enum — exactly two values, `tool_calls` / `content_fence` (no `structured_output` — YAGNI, no reserved slot per firm §3 P4d).
- `_VALID_SCHEME_TRANSPORT_PAIRS` — the explicit valid-(scheme,transport) registry (firm §2 **J1**), naming the 4 census-verified cells from the firm's §1 3x2 census of the current `_SCHEMES` registry:
  - `(category, tool_calls)` → `universal-category`
  - `(enumerate-all, tool_calls)` → `enumerate-all`
  - `(enumerate-all, content_fence)` → `codeact`
  - `(retrieval, tool_calls)` → `retrieval`
- `resolve_scheme_for_transport(scheme, transport)` — **fail-closed**: an unregistered cell (`category`×`content_fence`, anything×`structured_output`) raises a legible `ValueError` rather than silently resolving or falling back. Mirrors the `#3026` "enumeration ≠ resolution" pin (`reyn.tools.universal_catalog`) — splitting an axis in two does not widen what's actually resolvable past the explicit registration.
- `valid_scheme_transport_pairs()` — introspection helper for tests.

## codeact mapping + the J3 no-physical-split approach

Per firm **§2 J3**: `codeact` maps to the `(enumerate-all, content_fence)` cell (census-verified in the firm — same full flat catalog via `dispatchable_catalog`/`ops.catalog_entries()`, `content_fence` expression via `llm_tools_payload=[]` + rendered `tool_use_sp` + the `CodeBlock` interpret branch). `ToolUseScheme` is **not** physically split into two protocols — `Presentation` already carries the transport freedom, so P4a expresses the mapping as a **naming/resolution layer on top of the existing `_SCHEMES` registry**: `resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)` returns `"codeact"`, and `get_scheme("codeact")` is the literal same registered instance as before P4a.

**What moved**: nothing inside `codeact.py` / `enumerate_all.py` / `universal_category.py` / `retrieval.py` / `scheme.py` — all five files are untouched. The only new code is the transport module + its tests. This keeps the diff to exactly "the transport-selection mechanism" per the firm's guardrail against a construction-shuffle (#3082 lesson).

## Fail-closed strip-falsify evidence

`tests/test_fp0066_p4a_transport_axis_3247.py::test_strip_falsify_fail_closed_guard_is_load_bearing` builds a naive permissive lookup (`dict.get(pair, "enumerate-all")` — the shape the real function deliberately does NOT use) alongside the real guarded `resolve_scheme_for_transport`, and shows:
- the naive lookup **silently accepts** `("category", Transport.CONTENT_FENCE)` and returns a wrong scheme name (`"enumerate-all"`);
- the real, guarded function **raises** `ValueError` for the same input.

This demonstrates the `raise` is load-bearing — reverting to a `.get(..., default)` shape degrades the failure mode from a loud error to a silent wrong-scheme selection (the exact trap J1 guards against).

## Byte-identical / 0-fixture-drift confirmation

No scheme module was edited. Ran the full scheme/codeact/enumerate-all/retrieval/fp0063-arc-witness test set (68 tests) plus the new P4a test file — all green, no fixture re-record needed:

```
tests/test_fp0066_p4a_transport_axis_3247.py (6, new)
tests/test_codeact_scheme_1593.py
tests/test_codeact_coexistence_1593.py
tests/test_codeact_name_collision_3041.py
tests/test_enumerate_all_scheme_1593.py
tests/test_retrieval_scheme_1593.py
tests/test_2895_retrieval_scheme_requires_embedding.py
tests/test_scheme_interpretation_match_1593.py
tests/test_scheme_self_register_1608.py
tests/test_scheme_sp_fragment_1593.py
tests/test_tool_use_scheme_1593.py
tests/test_fp0063_arc_witness.py
→ 68 passed
```

Full repo `pytest`: **9178 passed, 36 skipped** (pre-existing skips, unrelated to this PR).

## Local CI gates (all green)

- `ruff check src tests` → All checks passed
- `python scripts/test_tier_audit.py --strict tests/test_fp0066_p4a_transport_axis_3247.py` → 6/6 OK, 0 Tier-4 violations
- `PYTHONPATH=.../src python -m pytest` (full suite, foreground) → 9178 passed, 36 skipped
- `python scripts/verify_module_docstrings.py src/reyn/tools/transport.py` → OK

## Test plan
- [x] `Transport` carries only `tool_calls`/`content_fence` (no `structured_output`)
- [x] Valid-pair registry census matches the 4 known cells (vacuity guard: non-empty)
- [x] All 4 valid pairs resolve to their census scheme, which is a live registered scheme
- [x] `codeact` is the `(enumerate-all, content_fence)` cell, same registered instance (byte-identical)
- [x] Unregistered cells fail closed with a legible `ValueError`
- [x] Strip-falsify: naive un-guarded lookup silently accepts the same unregistered cell the guarded function rejects
- [x] Full scheme/codeact/fp0063-arc-witness test set green, 0 fixture drift
- [x] Full repo pytest green (9178 passed)