### PR TITLE
feat(FP-0066 P4c): remove codeact scheme (content-fence transport) + clean-break

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -503,7 +503,7 @@ Not every `(scheme, transport)` combination is implemented. The valid pairs toda
 | `scheme` \ `transport` | `tool_calls` | `content_fence` |
 |---|---|---|
 | `category` | `universal-category` | *(unimplemented)* |
-| `enumerate-all` | `enumerate-all` (default) | `codeact` |
+| `enumerate-all` | `enumerate-all` (default) | CodeAct |
 | `retrieval` | `retrieval` | *(unimplemented)* |
 
 An unregistered pair (e.g. `scheme: category` + `transport: content_fence`) raises

--- a/src/reyn/runtime/capability_visibility.py
+++ b/src/reyn/runtime/capability_visibility.py
@@ -218,7 +218,8 @@ class CapabilityVisibility:
         self._contextual_permission = contextual_permission
         self._excluded_categories = frozenset(excluded_categories or ())
         # #3220: the chat-layer ``ToolUseScheme`` name (``reyn.tools.scheme.get_scheme``
-        # registry key — "enumerate-all" / "universal-category" / "codeact" / "retrieval").
+        # registry key — "enumerate-all" / "universal-category" / "retrieval" / the
+        # (enumerate-all, content_fence) CodeAct cell's resolved name, FP-0066 P4c #3247).
         # Immutable for the session's lifetime (Session never reassigns
         # ``self._chat_tool_use_scheme`` post-construction — same stability class as
         # ``agent_name``), so a plain field is correct here, not a live provider.

--- a/src/reyn/runtime/factory_config.py
+++ b/src/reyn/runtime/factory_config.py
@@ -113,7 +113,8 @@ class SessionFactoryConfig:
             # FP-0066 P4b: resolve the (scheme, transport) 2-axis config
             # through P4a's valid-pair registry to the concrete registered
             # ``ToolUseScheme`` name (e.g. (enumerate-all, content_fence) →
-            # "codeact") — this is the ONE resolution point; every downstream
+            # the CodeAct cell's resolved name, P4c #3247 — no longer the
+            # bare "codeact") — this is the ONE resolution point; every downstream
             # consumer (Session / RouterLoopDriver / RouterLoop) threads the
             # already-resolved concrete name unchanged. Already validated at
             # config-parse time (_build_tool_use_config), so this cannot

--- a/src/reyn/tools/schemes/codeact.py
+++ b/src/reyn/tools/schemes/codeact.py
@@ -1,4 +1,5 @@
-"""CodeActScheme — the CodeAct tool-use scheme (#1593 PR-3).
+"""CodeActScheme — the (enumerate-all, content_fence) transport-cell
+implementation (#1593 PR-3; FP-0066 P4c, #3247).
 
 Unlike universal-category (which delegates to the router's existing JSON tool
 logic), CodeAct implements its own scheme logic: the LLM writes a Python snippet
@@ -6,6 +7,17 @@ and tool calls happen as **in-code ``tool()`` calls**, each round-tripping throu
 the sandboxed ``CodeActRunner`` to the OS per-call gate (exclude + ``dispatch_tool``
 + permission, P5). A CodeAct call is therefore gated **>=** a JSON call (same gate
 + sandbox containment).
+
+FP-0066 P4c clean-break: this class is no longer registered under the bare
+name ``"codeact"`` (which read as if it were a 4th sibling scheme alongside
+``category`` / ``enumerate-all`` / ``retrieval``). It self-registers under
+``reyn.tools.transport.CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME`` — reachable
+ONLY by resolving ``(scheme="enumerate-all", transport=Transport.CONTENT_FENCE)``
+through the P4a valid-pair registry (``tool_use.scheme: codeact`` was never a
+valid config value; this closes the matching ``_SCHEMES``-level naming gap).
+The class body — presentation-construction over the enum-all catalog
+(``_render_code_api``) + the CodeBlock interpret-branch + ``CodeActRunner``
+execution — is byte-identical to pre-P4c.
 
 The 4 ToolUseScheme methods:
   - ``build_presentation`` → render the permission-eligible actions as a *code-API*
@@ -78,6 +90,7 @@ from reyn.tools.scheme import (
     flat_catalog_entries,
     register_scheme,
 )
+from reyn.tools.transport import CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
 
 # A fenced code block — how the CodeAct LLM emits its snippet in the message
 # content. #1618 root-3 (#5): accept the Gemini-native ``tool_code`` fence label
@@ -166,9 +179,13 @@ def _format_codeact_observation(out: dict) -> str:
 
 
 class CodeActScheme:
-    """CodeAct scheme (#1593 PR-3). Own logic (not delegating)."""
+    """CodeAct scheme (#1593 PR-3). Own logic (not delegating).
 
-    name: str = "codeact"
+    ``name`` is the P4c-relocated ``_SCHEMES`` key (see module docstring) —
+    not the literal ``"codeact"`` string; that name no longer exists in the
+    registry."""
+
+    name: str = CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
 
     def __init__(self, runner: CodeActRunner | None = None) -> None:
         self._runner = runner or CodeActRunner()

--- a/src/reyn/tools/transport.py
+++ b/src/reyn/tools/transport.py
@@ -8,18 +8,29 @@ conflated in a single flat ``_SCHEMES`` registry (``reyn.tools.scheme``) where
 ``codeact`` is really the ``content_fence`` transport applied to the
 ``enumerate-all`` presentation, registered as if it were a 4th sibling scheme.
 
-This module is **internal-only and behavior-preserving** (P4a): it introduces
-the ``Transport`` type and a registry that names which (scheme, transport)
-cells are actually resolvable. P4b (config surface, #3247) now uses this
-registry as the live parse-time validation authority for the
+This module is **internal-only and behavior-preserving** (P4a/P4c): it
+introduces the ``Transport`` type and a registry that names which (scheme,
+transport) cells are actually resolvable. P4b (config surface, #3247) uses
+this registry as the live parse-time validation authority for the
 ``tool_use.scheme`` x ``tool_use.transport`` 2-key config (the former
-``tool_use.chat`` is removed, clean-break). P4a itself is WITHOUT removing
-``codeact`` from ``_SCHEMES`` (P4c), and WITHOUT physically splitting
-``ToolUseScheme`` into two protocols (firm §2 J3 —
-``Presentation`` already carries the transport freedom via
-``llm_tools_payload`` emptiness + ``tool_use_sp`` + the ``Interpretation``
-Execute/CodeBlock branch; transport is expressed as a construction-strategy +
-interpret-branch SELECTION, not a bundle reshuffle).
+``tool_use.chat`` is removed, clean-break). WITHOUT physically splitting
+``ToolUseScheme`` into two protocols (firm §2 J3 — ``Presentation`` already
+carries the transport freedom via ``llm_tools_payload`` emptiness +
+``tool_use_sp`` + the ``Interpretation`` Execute/CodeBlock branch; transport
+is expressed as a construction-strategy + interpret-branch SELECTION, not a
+bundle reshuffle).
+
+P4c (#3247) completed the clean-break: ``codeact`` is no longer a name in
+``reyn.tools.scheme._SCHEMES`` (and is therefore no longer independently
+config-selectable — it never was, since ``tool_use.scheme`` only accepts
+presentation-axis names, but this closes the ``_SCHEMES``-level naming gap
+too). The (enumerate-all, content_fence) cell's implementation (still the
+same ``CodeActScheme`` class — presentation-construction over the enum-all
+catalog + the CodeBlock interpret-branch, byte-identical logic) now
+self-registers under ``CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME`` below, a
+name reachable ONLY by resolving ``("enumerate-all", Transport.CONTENT_FENCE)``
+through this module's registry — not a name an operator or a test can select
+directly by typing "codeact".
 
 Only two transports are implemented today (``tool_calls``, ``content_fence``);
 a third (``structured_output``, ``response_format``/json_schema) is deferred to
@@ -46,6 +57,19 @@ class Transport(str, Enum):
     CONTENT_FENCE = "content_fence"
 
 
+# P4c (#3247): the ``_SCHEMES`` registry name for the (enumerate-all,
+# content_fence) cell's resolved implementation — the class formerly
+# self-registered under the bare name ``"codeact"`` as if it were a 4th
+# sibling scheme. NOT a valid ``tool_use.scheme`` value (the presentation
+# axis only accepts "category" / "enumerate-all" / "retrieval") and not an
+# independently-selectable ``_SCHEMES`` name either — reachable ONLY via
+# ``resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)``.
+# Exported so ``reyn.tools.schemes.codeact`` registers its (unmodified)
+# ``CodeActScheme`` instance under this exact key — single source of truth,
+# no duplicated literal between the registry and the registrant.
+CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME = "enumerate-all+content_fence"
+
+
 # The valid-(scheme, transport) registry (firm §2 J1) — the ONLY resolvable
 # cells, explicitly enumerated from the FP-0066 §1 census of the current
 # `_SCHEMES` registry (`reyn.tools.scheme._SCHEMES`):
@@ -53,22 +77,25 @@ class Transport(str, Enum):
 #   presentation \ transport | tool_calls | content_fence
 #   -------------------------|------------|---------------
 #   category                 | universal-category | (unimplemented)
-#   enumerate-all             | enumerate-all      | codeact
+#   enumerate-all             | enumerate-all      | enumerate-all+content_fence (CodeAct)
 #   retrieval                 | retrieval          | (unimplemented)
 #
 # "category" / "enumerate-all" / "retrieval" here are the FP-0066 §2
 # presentation-axis names; the value is the name currently registered in
 # `reyn.tools.scheme._SCHEMES` that implements that (scheme, transport) cell
-# TODAY (byte-identical — P4a moves no logic). `codeact` census-verified as
-# `enumerate-all` presentation (identical full flat catalog via
+# TODAY. The (enumerate-all, content_fence) cell is CodeAct — census-verified
+# as `enumerate-all` presentation (identical full flat catalog via
 # `dispatchable_catalog=entries` / `ops.catalog_entries()`) expressed over the
 # `content_fence` transport (`llm_tools_payload=[]` + `tool_use_sp` rendered
 # code-API + the CodeBlock interpret branch) — see FP-0066 issue #3247, P4
-# firm §1.
+# firm §1. P4c (#3247) removed the standalone `"codeact"` `_SCHEMES` name
+# (clean-break: codeact is reached ONLY via this (scheme, transport) pair,
+# never as a scheme name of its own); the same unmodified implementation now
+# self-registers under `CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME`.
 _VALID_SCHEME_TRANSPORT_PAIRS: "dict[tuple[str, Transport], str]" = {
     ("category", Transport.TOOL_CALLS): "universal-category",
     ("enumerate-all", Transport.TOOL_CALLS): "enumerate-all",
-    ("enumerate-all", Transport.CONTENT_FENCE): "codeact",
+    ("enumerate-all", Transport.CONTENT_FENCE): CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
     ("retrieval", Transport.TOOL_CALLS): "retrieval",
 }
 
@@ -103,6 +130,7 @@ def valid_scheme_transport_pairs() -> "list[tuple[str, Transport]]":
 
 __all__ = [
     "Transport",
+    "CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME",
     "resolve_scheme_for_transport",
     "valid_scheme_transport_pairs",
 ]

--- a/tests/test_3220_capability_visibility_composed_payload.py
+++ b/tests/test_3220_capability_visibility_composed_payload.py
@@ -33,7 +33,14 @@ from reyn.core.events.state_log import StateLog
 from reyn.runtime.profile import AgentProfile
 from reyn.runtime.registry import AgentRegistry
 from reyn.runtime.session import Session
+from reyn.tools.transport import Transport, resolve_scheme_for_transport
 from tests._support.agent_session import make_session
+
+# FP-0066 P4c (#3247): the CodeAct behavior is reached via the (enumerate-all,
+# content_fence) cell's resolved ``_SCHEMES`` name, not the bare "codeact"
+# (removed, clean-break) — resolve it once so this suite never hardcodes the
+# internal registry key.
+_CODEACT_CELL_SCHEME_NAME = resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)
 
 
 def _make_registry(tmp_path: Path, *, chat_tool_use_scheme: str) -> AgentRegistry:
@@ -244,7 +251,7 @@ async def _oracle_payload_names(session: Session, scheme_name: str) -> "tuple[se
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("scheme_name", ["enumerate-all", "codeact"])
+@pytest.mark.parametrize("scheme_name", ["enumerate-all", _CODEACT_CELL_SCHEME_NAME])
 async def test_visibility_census_exactly_matches_composed_payload(tmp_path, monkeypatch, scheme_name):
     """Tier 2: architect-required conformance test. capability_visibility_state's
     "tool" census must EXACTLY equal the reachable-capability set of the scheme's

--- a/tests/test_codeact_scheme_1593.py
+++ b/tests/test_codeact_scheme_1593.py
@@ -237,12 +237,44 @@ async def test_full_sp_for_codeact_session_carries_os_frame_autonomy_rule() -> N
 
 
 def test_codeact_scheme_registered_and_selectable() -> None:
-    """Tier 2: CodeActScheme is registered under 'codeact' and resolves by name
-    (selectable via tool_use=codeact); universal stays the default (not codeact)."""
+    """Tier 2: FP-0066 P4c (#3247) clean-break — CodeActScheme is registered
+    under the (enumerate-all, content_fence) cell's resolved name, NOT the
+    bare 'codeact' ('codeact' is no longer independently selectable and
+    ``_resolve_tool_use_scheme("codeact")`` now falls back to the default,
+    same as any other unregistered name — the real selection path is the
+    2-axis config: ``tool_use.scheme: enumerate-all`` +
+    ``tool_use.transport: content_fence``, validated + resolved through
+    ``reyn.tools.transport.resolve_scheme_for_transport``). Universal stays
+    the default (not codeact)."""
     from reyn.runtime.router_loop import _resolve_tool_use_scheme
+    from reyn.tools.transport import (
+        CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
+        Transport,
+        resolve_scheme_for_transport,
+    )
 
-    selected = _resolve_tool_use_scheme("codeact")
-    assert selected.name == "codeact"
+    # "codeact" is no longer a registered _SCHEMES name → unknown-name fallback.
+    assert _resolve_tool_use_scheme("codeact").name == "enumerate-all"
+
+    # The real selection path: resolve the (scheme, transport) pair.
+    resolved_name = resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)
+    assert resolved_name == CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
+    selected = _resolve_tool_use_scheme(resolved_name)
+    assert selected.name == resolved_name
     assert isinstance(selected, CodeActScheme)
     # #1657: default is now enumerate-all (not codeact, not universal).
     assert _resolve_tool_use_scheme(None).name == "enumerate-all"  # #1657
+
+
+def test_tool_use_scheme_codeact_is_config_invalid() -> None:
+    """Tier 1: FP-0066 P4c (#3247) clean-break — ``tool_use.scheme: codeact``
+    is a config-parse-time error, the same legible-error style P4b introduced
+    for the removed ``tool_use.chat`` key. 'codeact' was never a valid
+    presentation-axis ``scheme`` value (only 'category' / 'enumerate-all' /
+    'retrieval' are), and now doubly so: no ``_SCHEMES`` entry named
+    'codeact' exists either. CodeAct is reached ONLY via
+    ``scheme: enumerate-all`` + ``transport: content_fence``."""
+    from reyn.config.execution import _build_tool_use_config
+
+    with pytest.raises(ValueError, match=r"no \(scheme, transport\) registration"):
+        _build_tool_use_config({"scheme": "codeact"})

--- a/tests/test_enumerate_all_scheme_1593.py
+++ b/tests/test_enumerate_all_scheme_1593.py
@@ -262,7 +262,11 @@ def test_default_chat_layer_resolves_to_enumerate_all() -> None:
     RouterLoopDriver → RouterLoop(scheme_name=)."""
     from reyn.config import _build_tool_use_config
     from reyn.runtime.router_loop import _resolve_tool_use_scheme
-    from reyn.tools.transport import Transport, resolve_scheme_for_transport
+    from reyn.tools.transport import (
+        CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
+        Transport,
+        resolve_scheme_for_transport,
+    )
 
     # #1657: default scheme/transport → enumerate-all (resolves to EnumerateAllScheme).
     default_cfg = _build_tool_use_config(None)
@@ -284,12 +288,13 @@ def test_default_chat_layer_resolves_to_enumerate_all() -> None:
     assert _resolve_tool_use_scheme(resolved).name == "universal-category"
 
     # A former ``chat: codeact`` becomes scheme=enumerate-all x
-    # transport=content_fence, resolving to the same codeact scheme.
+    # transport=content_fence, resolving to the CodeAct-implementing scheme
+    # under its P4c-relocated name (#3247 — no longer the bare "codeact").
     codeact_cfg = _build_tool_use_config(
         {"scheme": "enumerate-all", "transport": "content_fence"}
     )
     resolved_codeact = resolve_scheme_for_transport(
         codeact_cfg.scheme, Transport(codeact_cfg.transport)
     )
-    assert resolved_codeact == "codeact"
-    assert _resolve_tool_use_scheme(resolved_codeact).name == "codeact"
+    assert resolved_codeact == CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
+    assert _resolve_tool_use_scheme(resolved_codeact).name == resolved_codeact

--- a/tests/test_fp0066_p4a_transport_axis_3247.py
+++ b/tests/test_fp0066_p4a_transport_axis_3247.py
@@ -14,10 +14,13 @@ Pins:
     legible ``ValueError`` rather than being silently accepted — the
     fail-closed guard is load-bearing (strip-falsify: a naive permissive
     lookup, the shape the guard replaces, WOULD silently accept it);
-  - ``codeact`` is the (enumerate-all, content_fence) cell's live
-    implementation, and P4a made zero changes to it (no import of
-    ``reyn.tools.schemes.codeact`` internals is touched by this module — the
-    registry only NAMES the existing, unmodified ``_SCHEMES`` entry).
+  - CodeAct is the (enumerate-all, content_fence) cell's live implementation.
+    P4c (#3247) relocated its ``_SCHEMES`` registration off the bare name
+    ``"codeact"`` onto ``CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME`` (clean
+    break — ``"codeact"`` no longer resolves at all); this module was
+    updated in the SAME PR that landed that rename (P4a's own hard rule:
+    a doc/test describing a mechanism goes stale the moment the mechanism
+    changes).
 
 No mocks: ``Transport`` / the registry are pure data + functions, no
 collaborators to fake.
@@ -39,6 +42,7 @@ if str(_SRC) not in sys.path:
 import reyn.tools.schemes  # noqa: E402,F401
 from reyn.tools.scheme import get_scheme  # noqa: E402
 from reyn.tools.transport import (  # noqa: E402
+    CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
     Transport,
     resolve_scheme_for_transport,
     valid_scheme_transport_pairs,
@@ -47,7 +51,7 @@ from reyn.tools.transport import (  # noqa: E402
 _CENSUS: "dict[tuple[str, Transport], str]" = {
     ("category", Transport.TOOL_CALLS): "universal-category",
     ("enumerate-all", Transport.TOOL_CALLS): "enumerate-all",
-    ("enumerate-all", Transport.CONTENT_FENCE): "codeact",
+    ("enumerate-all", Transport.CONTENT_FENCE): CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
     ("retrieval", Transport.TOOL_CALLS): "retrieval",
 }
 
@@ -82,14 +86,16 @@ def test_valid_pairs_resolve_to_the_census_scheme(
     assert get_scheme(resolved) is not None
 
 
-def test_codeact_is_the_enumerate_all_content_fence_cell_unmodified() -> None:
-    """Tier 1: (enumerate-all, content_fence) resolves to the SAME registered
-    ``codeact`` scheme instance the pre-P4a ``_SCHEMES`` registry already held
-    — P4a adds a naming layer on top of the existing registry, it does not
-    reconstruct or wrap the scheme (byte-identical: 0 behavior change)."""
+def test_codeact_is_the_enumerate_all_content_fence_cell_and_codeact_name_is_gone() -> None:
+    """Tier 1: (enumerate-all, content_fence) resolves to the registered
+    CodeAct-implementing scheme instance under its P4c-relocated name — and
+    the bare ``"codeact"`` name no longer resolves at all (clean-break, #3247
+    P4c): it is reachable ONLY via this (scheme, transport) pair, never as an
+    independent ``_SCHEMES`` name."""
     resolved_name = resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)
-    assert resolved_name == "codeact"
-    assert get_scheme("codeact") is get_scheme(resolved_name)
+    assert resolved_name == CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
+    assert get_scheme(resolved_name) is not None
+    assert get_scheme("codeact") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_scheme_self_register_1608.py
+++ b/tests/test_scheme_self_register_1608.py
@@ -38,8 +38,15 @@ def test_all_builtins_resolve_in_fresh_interpreter(out_of_process_reyn) -> None:
         from reyn.tools.scheme import (
             DEFAULT_SCHEME_NAME, get_scheme, registered_scheme_names,
         )
-        expected = {"universal-category", "enumerate-all", "retrieval", "codeact"}
+        # FP-0066 P4c (#3247): the CodeAct implementation self-registers under the
+        # (enumerate-all, content_fence) cell's resolved name, not the bare "codeact".
+        from reyn.tools.transport import CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
+        expected = {
+            "universal-category", "enumerate-all", "retrieval",
+            CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
+        }
         names = set(registered_scheme_names())
+        assert "codeact" not in names
         assert expected <= names, f"missing built-ins: {expected - names}"
         for n in expected:
             s = get_scheme(n)
@@ -61,11 +68,20 @@ def test_resolver_finds_all_builtins_without_naming_them(out_of_process_reyn) ->
         out_of_process_reyn,
         """
         from reyn.runtime.router_loop import _resolve_tool_use_scheme
-        for n in ("universal-category", "enumerate-all", "retrieval", "codeact"):
+        # FP-0066 P4c (#3247): CodeAct resolves under its (enumerate-all,
+        # content_fence)-relocated name, not the bare "codeact".
+        from reyn.tools.transport import CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME
+        for n in (
+            "universal-category", "enumerate-all", "retrieval",
+            CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME,
+        ):
             s = _resolve_tool_use_scheme(n)
             assert s is not None and s.name == n, n
-        # Unknown / None → default.
+        # Unknown / None → default. "codeact" is now an unknown name (P4c
+        # clean-break) so it falls back to the default too, same as any
+        # other unregistered string.
         assert _resolve_tool_use_scheme("no-such").name == "enumerate-all"
+        assert _resolve_tool_use_scheme("codeact").name == "enumerate-all"
         assert _resolve_tool_use_scheme(None).name == "enumerate-all"
         print("RESOLVE_OK")
         """


### PR DESCRIPTION
**[per-PR-coder]** — part of #3247

Completes the codeact clean-break the P4 firm (architect, #3247) designed. `codeact` is no longer registered as a 4th sibling `_SCHEMES` name — it is reached ONLY via `tool_use.scheme=enumerate-all` + `tool_use.transport=content_fence`.

## KEEP / REMOVE split

- **KEEP (execution engine, untouched)**: `src/reyn/core/kernel/codeact_runner.py` (`CodeActRunner`), `_python_harness.py`, `src/reyn/prompt/codeact.py` (`_render_code_api` primitives) — the content-fence execution + rendering substrate. Zero changes.
- **REMOVE (scheme registration)**: the `_SCHEMES["codeact"]` entry. `CodeActScheme`'s class body (presentation-construction over the enum-all catalog + the CodeBlock interpret-branch + `CodeActRunner` execution) is otherwise **byte-identical** — only its `name` attribute changed.

## J3 transport-resolution approach

Per the firm's J3 ("do NOT physically split `ToolUseScheme` into two protocols"): no new protocol, no bundle reshuffle. `reyn.tools.transport` now owns a single source-of-truth constant, `CONTENT_FENCE_ENUMERATE_ALL_SCHEME_NAME = "enumerate-all+content_fence"`. The valid-(scheme, transport) registry maps `(enumerate-all, content_fence)` to this name instead of the bare `"codeact"`; `CodeActScheme.name` reads the same constant. `resolve_scheme_for_transport("enumerate-all", Transport.CONTENT_FENCE)` is still the ONE resolution point (unchanged since P4a) — it now hands back the relocated name instead of `"codeact"`. Every downstream consumer (`Session` / `RouterLoopDriver` / `RouterLoop` / `CapabilityVisibility`) threads the resolved name unchanged, exactly as before — no signature or plumbing changes needed (they only ever held an opaque `_SCHEMES` key string).

`codeact` is now config-invalid **twice over**: `tool_use.scheme` was already presentation-axis-only (`category`/`enumerate-all`/`retrieval` — `resolve_scheme_for_transport("codeact", ...)` already raised pre-P4c), and now no `_SCHEMES` entry named `"codeact"` exists either — `get_scheme("codeact")` is `None`, `_resolve_tool_use_scheme("codeact")` falls back to the default like any other unregistered name. New test pins `tool_use.scheme: codeact` -> legible `ValueError` at config-parse time.

## Byte-identical result — 0 fixture drift

**Target achieved.** No scheme name is ever serialized into an LLM-replay fixture (fixtures record LLM payload content, not the internal registry key used to select the scheme). Grepped `tests/fixtures/**` + all `.json`/`.jsonl` under `tests/` for `"codeact"` — **zero hits**. No fixture re-record needed; diffstat is entirely non-fixture (registry rename + doc line + test updates for the renamed key).

```
docs/reference/config/reyn-yaml.md                 |  2 +-
src/reyn/runtime/capability_visibility.py          |  3 +-
src/reyn/runtime/factory_config.py                 |  3 +-
src/reyn/tools/schemes/codeact.py                  | 23 +++++++--
src/reyn/tools/transport.py                        | 60 ++++++++++++++++------
tests/test_3220_capability_visibility_composed_payload.py |  9 +++-
tests/test_codeact_scheme_1593.py                  | 39 +++++++++++--
tests/test_enumerate_all_scheme_1593.py            | 13 +++--
tests/test_fp0066_p4a_transport_axis_3247.py       | 30 ++++++-----
tests/test_scheme_self_register_1608.py            | 22 ++++++--
10 files changed, 159 insertions(+), 46 deletions(-)
```

## Sibling-gate enumeration (per the architect's P3c reflection)

| Gate | Applied? | Finding |
|---|---|---|
| `#1822` fencing tests | Not applicable | Grepped every `*1822*` test file for `"codeact"` — zero hits. Architect's §4 already established content-fence doesn't need fencing changes (internal-catalog SP render, not external content). |
| `_ROUTE_CONTRACT_SAMPLES` (`test_universal_dispatch.py`) | Not applicable | Zero `"codeact"` references — that sample table is about tool-route dispatch, not scheme naming. |
| Naming-convention drift gate (`test_tool_naming_convention_gate_3223.py`) | Not applicable | Zero `"codeact"` references — codeact is a scheme, not a tool. Ran green unchanged. |
| Tool-schema baseline (`_pre_migration_tool_schemas_baseline.json`) | Confirmed unchanged | Zero `"codeact"` occurrences — codeact was never a `tool`, only a scheme. |
| Scheme self-registration (`test_scheme_self_register_1608.py`) | **Applied** | Both fresh-interpreter tests hardcoded `"codeact"` in their expected-name sets — updated to the relocated constant + added an explicit `"codeact" not in names` assertion. |
| Transport-axis registry (`test_fp0066_p4a_transport_axis_3247.py`) | **Applied** | `_CENSUS` + the cell-resolution test asserted the old name and `get_scheme("codeact") is get_scheme(...)` — updated + added `get_scheme("codeact") is None`. |
| CodeAct scheme registration/selectability (`test_codeact_scheme_1593.py`) | **Applied** | `test_codeact_scheme_registered_and_selectable` directly selected `"codeact"` by name — rewritten to show the fallback-to-default behavior for the now-unregistered name, plus the real (scheme,transport) selection path. Added `test_tool_use_scheme_codeact_is_config_invalid`. |
| Capability-visibility composed-payload (`test_3220_...py`) | **Applied** | `parametrize("scheme_name", [..., "codeact"])` hardcoded the old name — replaced with a dynamically resolved constant (no re-hardcoding). |
| Enumerate-all config-resolution (`test_enumerate_all_scheme_1593.py`) | **Applied** | Asserted `resolve_scheme_for_transport(...) == "codeact"` — updated to the relocated constant. |
| `docs/reference/config/reyn-yaml.md` valid-pairs table | **Applied** | Cell said literal `codeact`; replaced with the human-facing "CodeAct" term already used elsewhere in the doc (the internal `_SCHEMES` key was never user-facing, so the table now describes behavior, not an implementation detail). `tool-use-schemes.md` was already accurate (never claimed a `codeact` scheme name) — no change needed. |

## Local CI (all four gates, foreground)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 49 tests inspected, 0 errors, 0 warnings.
- `PYTHONPATH=$(pwd)/src python -m pytest tests/ -k "scheme or codeact or transport or tool_use or config_execution or dispatch or fp0063 or 3220 or 2093"` — **563 passed, 2 skipped** (pre-existing, unrelated).
- `python scripts/verify_module_docstrings.py <changed src files>` — clean.

## Test plan
- [x] `tool_use.scheme: codeact` raises a legible `ValueError` at config-parse time (new test `test_tool_use_scheme_codeact_is_config_invalid`).
- [x] `(enumerate-all, content_fence)` still produces CodeAct's behavior (rendering + `CodeActRunner` execution) — existing behavioral tests re-pointed at the relocated name, assertions intact, all green.
- [x] `get_scheme("codeact")` is `None`; `"codeact"` absent from `registered_scheme_names()`.
- [x] `CodeActRunner` / execution-engine tests green, untouched.
- [x] 0 fixture drift verified by direct grep, not inference.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>