### PR TITLE
refactor(P2-conv PR1): lock unification — action_index lock-free, Coordinator sole lock+write owner, eliminate ensure_built_self_contained

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -28,10 +28,29 @@ current state)**: audit-event phase emission (``embedding_index_build_
 started``/``_progress``/``_complete``/``_error`` — the last folding the
 pre-P2d ``action_index_build_failed`` event, which used to be emitted
 directly by ``RouterLoop._build_action_embedding_index_background`` — see
-``ensure_built``/``ensure_built_self_contained``'s ``events`` parameter)
+``ensure_built``'s ``events`` parameter)
 plus the ``search_await`` contract's production wiring at the two live
 action-catalog query call sites (``RouterLoop.search_actions`` /
 ``universal_catalog._handle_search_actions``).
+
+**P2-convergence PR1** (#3270 §2, design firm on #3270): collapses the P2b
+two-path Coordinator API (``ensure_built`` for material-producing adapters
+vs ``ensure_built_self_contained`` for adapters that owned their own
+lock+write, e.g. the action-catalog) down to the single ``ensure_built`` —
+``ensure_built_self_contained`` is REMOVED. ``ActionEmbeddingIndex.build()``
+lost both its own locks (the in-process ``asyncio.Lock`` and the
+cross-process ``try_acquire_build_lock``); the Coordinator's own lock
+acquisition in ``_run_build`` (below) is now the SOLE holder for every
+registered source, which makes the same-path double-acquire that used to
+motivate the two-path split (self-deadlock-shaped: the second
+``try_acquire_build_lock`` call sees ITS OWN pid as a live holder and
+silently no-ops) structurally impossible rather than merely avoided. The
+action-catalog's disk-adopt/dual-axis-invalidation POLICY stays a domain
+concern — extracted into ``ActionEmbeddingIndex.prepare_material``, a
+``BuildFn`` that returns ``BuildMaterial`` (real rebuild needed) or
+``None`` (the adapter's own policy determined no write is needed this
+call — see ``_run_build``'s ``material is None`` branch and ``BuildFn``'s
+docstring).
 
 **Crash-recovery (the band requirement, CLAUDE.md recovery-feature gate)**:
 the dirty/building/error state lives in ``SourceEntry`` (persisted to
@@ -190,7 +209,15 @@ class BuildMaterial:
     ctx: "OpContext"
 
 
-BuildFn = Callable[[], Awaitable[BuildMaterial]]
+BuildFn = Callable[[], Awaitable["BuildMaterial | None"]]
+"""A domain adapter's build strategy. Returns ``BuildMaterial`` when a real
+embed+write is needed (the Coordinator's ``_run_build`` then owns
+``embed_verify_write``), or ``None`` when the adapter determined — as part
+of its OWN material-generation policy (e.g. a disk-adopt cache hit) — that
+no write is needed this call (P2-convergence PR1, #3270 §2: this is how the
+now-eliminated ``ensure_built_self_contained`` two-path shape folds into the
+single ``ensure_built``. See ``ActionEmbeddingIndex.prepare_material`` for
+the one adapter that exercises the ``None`` branch today)."""
 
 
 @dataclass(frozen=True)
@@ -226,10 +253,14 @@ class IndexCoordinator:
     plumbing the firm's interface section does not spell out (its
     ``ensure_built(source_id, *, await_completion)`` signature carries no
     build strategy per call), so the strategy has to be associated with the
-    ``source_id`` some other way. Registering a builder is NOT a production
-    call-site migration (P2b) — it is just how a domain adapter tells the
-    Coordinator "this is how you'd build me", exercised directly by this
-    PR's tests; no production code calls ``register_builder`` yet.
+    ``source_id`` some other way. Registering a builder is how a domain
+    adapter tells the Coordinator "this is how you'd build me" — P2b wired
+    the first production registrants (memory/skill/repo, via
+    ``knowledge_ingest.py``); P2-convergence PR1 (#3270 §2) adds the
+    action-catalog (``RouterLoop._ensure_action_index_built``, routed
+    through ``ActionEmbeddingIndex.prepare_material`` as its ``BuildFn``),
+    eliminating the parallel ``ensure_built_self_contained`` entry point
+    that previously carried it.
     """
 
     def __init__(
@@ -255,9 +286,9 @@ class IndexCoordinator:
         # freshly-created manifest entry (mark_dirty/_set_state on a
         # source never seen before) is tagged correctly instead of falling
         # through to the "backfill" dataclass default. Registered
-        # alongside the build strategy (see ``register_builder``/
-        # ``ensure_built_self_contained``); a source that never registers
-        # a kind stays "backfill" (predates the taxonomy).
+        # alongside the build strategy (see ``register_builder``); a source
+        # that never registers a kind stays "backfill" (predates the
+        # taxonomy).
         self._kinds: dict[str, SourceKind] = {}
 
     # ── registration (necessary plumbing, not a P2b call-site migration) ──
@@ -324,6 +355,8 @@ class IndexCoordinator:
         *,
         await_completion: bool,
         events: "EventLog | None" = None,
+        on_error: Callable[[BaseException], None] | None = None,
+        on_success: Callable[[BuildOutcome], None] | None = None,
     ) -> BuildOutcome:
         """If ``source_id`` is dirty/error/never-built, (re)build it.
 
@@ -346,6 +379,35 @@ class IndexCoordinator:
         this class) silently skips the audit-emit; a real build call site
         (production or test) threads its ``EventLog`` here to get the P6
         audit trail.
+
+        ``on_error`` (P2-convergence PR1, #3270 §2): an optional best-effort
+        callback invoked with the real ``Exception`` instance on a build
+        failure — BEFORE this method returns, regardless of
+        ``await_completion`` (it runs from inside ``_run_build``, the same
+        coroutine body whether awaited inline or scheduled as a background
+        task, so it fires uniformly for both). This is the seam a caller
+        with its OWN failure bookkeeping to keep in sync (e.g.
+        ``RouterLoop._action_index_build_failed``, #1458) hooks into,
+        without the Coordinator needing to know that bookkeeping exists —
+        the callback receives the ORIGINAL exception object (not just its
+        ``str()``), which a cause-aware caller (e.g.
+        ``_action_index_build_failure_warning``'s exception-type branching)
+        needs and ``BuildOutcome.error`` (a string) cannot carry.
+
+        ``on_success`` (P2-convergence PR1, #3270 §2): the success-path
+        mirror of ``on_error`` — an optional best-effort callback invoked
+        with the ``BuildOutcome`` when a build (real write OR a
+        material-generation ``None`` no-op) completes without raising,
+        again from inside ``_run_build`` so it fires uniformly for both
+        ``await_completion`` values. The seam a caller whose OWN
+        in-memory state needs syncing after a Coordinator-driven write
+        (e.g. ``ActionEmbeddingIndex.adopt_build_result``, since the
+        Coordinator — not the domain adapter — now performs
+        ``embed_verify_write`` for a material-producing ``BuildFn``) hooks
+        into, without which a background (``await_completion=False``)
+        build's caller would have no notification of completion at all
+        (the immediately-returned ``BuildOutcome`` reflects only "a build
+        was scheduled", not its eventual result).
         """
         entry = await self._manifest.get(source_id)
         if entry is not None and entry.state == "clean":
@@ -368,11 +430,13 @@ class IndexCoordinator:
             existing_task = self._bg_tasks.get(source_id)
             if existing_task is not None and not existing_task.done():
                 return BuildOutcome(source_id=source_id, triggered=True, background=True)
-            task = asyncio.create_task(self._run_build(source_id, build_fn, events))
+            task = asyncio.create_task(
+                self._run_build(source_id, build_fn, events, on_error, on_success)
+            )
             self._bg_tasks[source_id] = task
             return BuildOutcome(source_id=source_id, triggered=True, background=True)
 
-        return await self._run_build(source_id, build_fn, events)
+        return await self._run_build(source_id, build_fn, events, on_error, on_success)
 
     def _emit(self, events: "EventLog | None", event_type: str, **data: Any) -> None:
         """Best-effort audit-event emit (FP-0066 P2d) — never raises; a
@@ -389,7 +453,12 @@ class IndexCoordinator:
             pass
 
     async def _run_build(
-        self, source_id: str, build_fn: BuildFn, events: "EventLog | None" = None,
+        self,
+        source_id: str,
+        build_fn: BuildFn,
+        events: "EventLog | None" = None,
+        on_error: Callable[[BaseException], None] | None = None,
+        on_success: Callable[[BuildOutcome], None] | None = None,
     ) -> BuildOutcome:
         kind = self._kinds.get(source_id, "backfill")
         self._emit(events, "embedding_index_build_started", source_id=source_id, kind=kind)
@@ -398,10 +467,44 @@ class IndexCoordinator:
         with try_acquire_build_lock(lock_dir) as got_lock:
             if not got_lock:
                 # Another process is mid-build — fall back to whatever is
-                # on disk rather than duplicating the embed-API cost.
+                # on disk rather than duplicating the embed-API cost. This
+                # is now the SOLE cross-process build-lock acquisition for
+                # every registered source (P2-convergence PR1, #3270 §2):
+                # domain adapters (e.g. ``ActionEmbeddingIndex``) no longer
+                # hold their own copy of this lock, which is what made the
+                # self-deadlock-shaped double-acquire structurally
+                # impossible rather than merely avoided.
                 return BuildOutcome(source_id=source_id, triggered=False, background=False)
             try:
                 material = await build_fn()
+                if material is None:
+                    # P2-convergence PR1 (#3270 §2): the adapter's OWN
+                    # material-generation policy (e.g. a disk-adopt cache
+                    # hit) determined no embed+write is needed this call —
+                    # mark clean without touching write history. The
+                    # manifest's chunk_count/embedding_model are left as
+                    # whatever they already were (this path never had a
+                    # write to report a fresh count from — not externally
+                    # observable: no production caller reads this
+                    # BuildOutcome's chunk_count for the action-catalog
+                    # source, see ``RouterLoop._ensure_action_index_built``).
+                    await self._set_state(source_id, "clean")
+                    entry = await self._manifest.get(source_id)
+                    chunk_count = entry.chunk_count if entry is not None else None
+                    self._emit(
+                        events, "embedding_index_build_complete",
+                        source_id=source_id, chunk_count=chunk_count,
+                    )
+                    outcome = BuildOutcome(
+                        source_id=source_id, triggered=True, background=False,
+                        chunk_count=chunk_count,
+                    )
+                    if on_success is not None:
+                        try:
+                            on_success(outcome)
+                        except Exception:
+                            pass
+                    return outcome
                 self._emit(
                     events, "embedding_index_build_progress",
                     source_id=source_id, chunk_count=len(material.items),
@@ -426,6 +529,11 @@ class IndexCoordinator:
                     events, "embedding_index_build_error",
                     source_id=source_id, reason=str(exc),
                 )
+                if on_error is not None:
+                    try:
+                        on_error(exc)
+                    except Exception:
+                        pass
                 return BuildOutcome(
                     source_id=source_id, triggered=True, background=False, error=str(exc),
                 )
@@ -439,9 +547,15 @@ class IndexCoordinator:
             events, "embedding_index_build_complete",
             source_id=source_id, chunk_count=chunk_count,
         )
-        return BuildOutcome(
+        outcome = BuildOutcome(
             source_id=source_id, triggered=True, background=False, chunk_count=chunk_count,
         )
+        if on_success is not None:
+            try:
+                on_success(outcome)
+            except Exception:
+                pass
+        return outcome
 
     async def _set_state(
         self,
@@ -565,134 +679,24 @@ class IndexCoordinator:
         desired heal path)."""
         return source_id in self._failure_memo
 
-    # ── ensure_built_self_contained (FP-0066 P2b, #3247) ─────────────────
-    #
-    # ``ensure_built`` (above) is for a domain adapter that hands the
-    # Coordinator raw MATERIAL (items/texts/mapping) and lets the
-    # Coordinator own the cross-process lock + ``embed_verify_write``. That
-    # shape does not fit every domain adapter discovered while actually
-    # doing the P2b migration: ``ActionEmbeddingIndex.build()`` already owns
-    # its OWN cross-process lock (``try_acquire_build_lock`` at the SAME
-    # ``cache_dir_for_source`` path ``ensure_built`` would acquire) plus a
-    # disk-adopt / dual-axis invalidation policy that is deeply entangled
-    # with whether it writes at all — splitting it into a material-only
-    # ``BuildFn`` would either duplicate that policy here (violating the
-    # firm's "domain adapter owns invalidation policy" boundary) or cause a
-    # SECOND acquisition of the same advisory lock within one process
-    # (self-deadlock-shaped: the second ``try_acquire_build_lock`` call
-    # would see ITS OWN pid as a live holder and skip, silently no-op-ing
-    # every build).
-    #
-    # ``ensure_built_self_contained`` narrows the Coordinator's role for
-    # such an adapter to pure orchestration — once-per-source background-
-    # task dedup (``_bg_tasks``) + failure-memo (``_failure_memo``) +
-    # manifest state bookkeeping — while the SELF-CONTAINED builder
-    # (``build_coro``) keeps owning its own lock/write/invalidation policy
-    # end to end, exactly as it did pre-migration. See
-    # ``RouterLoop._ensure_action_index_built`` for the production caller.
-    async def ensure_built_self_contained(
-        self,
-        source_id: str,
-        build_coro: Callable[[], Awaitable[None]],
-        *,
-        await_completion: bool,
-        is_ready_probe: Callable[[], bool],
-        chunk_count_probe: Callable[[], int] | None = None,
-        kind: SourceKind = "backfill",
-        events: "EventLog | None" = None,
-    ) -> BuildOutcome:
-        """Orchestrate (dedup/failure-memo/state) a self-contained builder.
-
-        ``build_coro`` is called with no args and is expected to perform
-        the ENTIRE build (its own locking, its own write) and raise on
-        failure (never swallow) — ``is_ready_probe`` is then consulted
-        (not ``build_coro``'s return value) to decide whether the manifest
-        should record ``clean`` (matches the domain adapter's own
-        source-of-truth for "did this actually succeed", e.g.
-        ``ActionEmbeddingIndex.is_ready()`` post-``build()``).
-
-        Same await/background split as ``ensure_built``: ``await_completion
-        =True`` runs inline; ``=False`` schedules via ``asyncio.create_task``
-        with the same once-per-source in-flight dedup (``_bg_tasks``).
-        Never raises — a failure is caught, mark_dirty'd, memoized, and
-        reported on the returned ``BuildOutcome.error``.
-
-        ``events`` (FP-0066 P2d, #3247 firm §6): same optional ``EventLog``
-        contract as ``ensure_built`` — emits the ``embedding_index_build_
-        started``/``_progress``/``_complete``/``_error`` phases. This is
-        the path the production action-catalog build uses
-        (``RouterLoop._ensure_action_index_built``), so this is also where
-        the pre-P2d ``action_index_build_failed`` event (previously emitted
-        directly by ``_build_action_embedding_index_background`` on
-        failure) is FOLDED into ``embedding_index_build_error`` — that
-        direct emit was removed from the RouterLoop primitive; this method
-        is now the single emitter for a self-contained builder's failure.
-        Since ``build_coro`` is opaque (no material/item count visible
-        before it runs), the ``_progress`` checkpoint fires right after
-        ``build_coro`` returns without raising (using ``chunk_count_probe``
-        if given) rather than mid-build — a coarser granularity than
-        ``ensure_built``'s material-aware progress, an honest limitation
-        given this builder shape (see the class docstring's boundary
-        principle: the builder, not the Coordinator, owns its own
-        progress internals).
-        """
-        self._kinds[source_id] = kind
-        entry = await self._manifest.get(source_id)
-        if entry is not None and entry.state == "clean" and is_ready_probe():
-            return BuildOutcome(
-                source_id=source_id, triggered=False, background=False,
-                chunk_count=entry.chunk_count,
-            )
-
-        async def _run() -> BuildOutcome:
-            self._emit(events, "embedding_index_build_started", source_id=source_id, kind=kind)
-            await self._set_state(source_id, "building")
-            try:
-                await build_coro()
-            except Exception as exc:
-                reason = f"build_error: {exc}"
-                self._failure_memo[source_id] = reason
-                await self.mark_dirty(source_id, reason=reason)
-                self._emit(
-                    events, "embedding_index_build_error",
-                    source_id=source_id, reason=str(exc),
-                )
-                return BuildOutcome(
-                    source_id=source_id, triggered=True, background=False,
-                    error=str(exc),
-                )
-            if is_ready_probe():
-                chunk_count = chunk_count_probe() if chunk_count_probe else None
-                self._emit(
-                    events, "embedding_index_build_progress",
-                    source_id=source_id, chunk_count=chunk_count,
-                )
-                await self._set_state(source_id, "clean", chunk_count=chunk_count)
-                self._emit(
-                    events, "embedding_index_build_complete",
-                    source_id=source_id, chunk_count=chunk_count,
-                )
-                return BuildOutcome(
-                    source_id=source_id, triggered=True, background=False,
-                    chunk_count=chunk_count,
-                )
-            # The builder ran without raising but didn't reach readiness
-            # (e.g. its own lock-skip fallback: "another process is mid-
-            # build") — leave manifest state as-is (not clean), matching
-            # the pre-migration silent-fallback semantics. No _complete
-            # emit — the build did not actually complete.
-            return BuildOutcome(source_id=source_id, triggered=True, background=False)
-
-        if not await_completion:
-            existing_task = self._bg_tasks.get(source_id)
-            if existing_task is not None and not existing_task.done():
-                return BuildOutcome(source_id=source_id, triggered=True, background=True)
-            task = asyncio.create_task(_run())
-            self._bg_tasks[source_id] = task
-            return BuildOutcome(source_id=source_id, triggered=True, background=True)
-
-        return await _run()
-
+    # ``ensure_built_self_contained`` — the ORCHESTRATION-only twin that used
+    # to exist here for a domain adapter (``ActionEmbeddingIndex``) that
+    # owned its own cross-process lock + write, so it could not be split
+    # into a material-only ``BuildFn`` without either duplicating its
+    # disk-adopt/dual-axis-invalidation policy here or double-acquiring the
+    # SAME advisory lock within one process (self-deadlock-shaped: a second
+    # ``try_acquire_build_lock`` call sees ITS OWN pid as a live holder and
+    # silently no-ops) — was ELIMINATED by P2-convergence PR1 (#3270 §2,
+    # design firm on #3270). ``ActionEmbeddingIndex.build()`` lost both its
+    # locks (P2-convergence PR1's actual fix: the cross-process lock above,
+    # acquired once here in ``_run_build``, is now the SOLE holder, making
+    # the same-path double-acquire structurally impossible rather than
+    # merely avoided) and its policy was extracted into
+    # ``ActionEmbeddingIndex.prepare_material`` — a ``BuildFn`` that returns
+    # ``BuildMaterial`` (real rebuild) or ``None`` (adapter determined no
+    # write is needed, e.g. a disk-adopt cache hit; see ``_run_build``'s
+    # ``material is None`` branch above). ``ensure_built`` is now the ONE
+    # entry point for every registered source, action-catalog included.
 
 # ── Module-level singleton registry (per-workspace) ───────────────────────
 #

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3440,61 +3440,141 @@ class RouterLoop:
         workspace_root = getattr(self.host, "workspace_root", None) or _Path.cwd()
         return get_index_coordinator(workspace_root)
 
+    async def _fetch_action_catalog_items(self) -> list[dict] | None:
+        """Fetch the current action catalog via ``list_actions`` against a
+        fresh ``RouterCallerState`` snapshot.
+
+        Extracted (behavior-preserving) from
+        ``_build_action_embedding_index_background`` (P2-convergence PR1,
+        #3270 §2) so BOTH that method (kept for direct/standalone callers
+        — see its docstring) and the production ``ensure_built`` build_fn
+        (``_ensure_action_index_built``) fetch the SAME catalog the SAME
+        way — a single source so the two shapes cannot silently diverge on
+        WHAT gets embedded. Returns ``None`` when ``list_actions`` is not
+        registered (defensive; should not happen in production).
+        """
+        from reyn.tools import get_default_registry
+        from reyn.tools.types import ToolContext
+
+        rs = await self._build_router_caller_state()
+        tool_ctx = ToolContext(
+            events=self.host.events,
+            permission_resolver=getattr(self.host, "permission_resolver", None),
+            workspace=getattr(self.host, "workspace", None),
+            caller_kind="router",
+            router_state=rs,
+            # #1673: thread the config-aware resolver (see the sibling sites).
+            resolver=getattr(self.host, "resolver", None),
+            hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
+            state_log=getattr(self.host, "state_log", None),  # #2248 PR-A2 (config emit)
+        )
+        list_actions_def = get_default_registry().lookup("list_actions")
+        if list_actions_def is None:
+            return None
+        result = await list_actions_def.handler({}, tool_ctx)
+        return result.get("items", []) if isinstance(result, dict) else []
+
     async def _ensure_action_index_built(
         self, idx: Any, provider: Any, model_class: str, *, await_completion: bool,
     ) -> None:
-        """FP-0066 P2b (#3247): route the action-catalog build's eager-vs-
-        background DECISION + once-per-chain spawn dedup + failure-memo
-        through ``IndexCoordinator.ensure_built_self_contained``.
+        """P2-convergence PR1 (#3270 §2, design firm on #3270): route the
+        action-catalog build's eager-vs-background DECISION + once-per-
+        source spawn dedup + failure-memo through the single
+        ``IndexCoordinator.ensure_built`` + ``register_builder`` — the
+        parallel ``ensure_built_self_contained`` two-path entry point this
+        method used to call is ELIMINATED (see ``coordinator.py``'s module
+        docstring).
 
-        ``ActionEmbeddingIndex.build()`` (invoked via
-        ``_build_action_embedding_index_background``, UNCHANGED — see that
-        method's docstring and #1458's pinning tests) already owns its own
-        cross-process build lock + disk-adopt + dual-axis invalidation
-        policy — domain-adapter policy the #3247 firm keeps OUT of the
-        Coordinator. Using the material-producing ``ensure_built`` here
-        would either duplicate that policy in the Coordinator or acquire
-        the SAME advisory lock a second time within one process (self-
-        deadlock-shaped). ``ensure_built_self_contained`` narrows the
-        Coordinator's role to orchestration only: once-per-source
-        background-task dedup, failure-memo, and manifest state — the
-        build itself stays exactly as it was.
+        ``ActionEmbeddingIndex.prepare_material`` (P2-convergence PR1) is
+        registered as the ``BuildFn``: lock-free, write-free material
+        generation that keeps the action-catalog's own disk-adopt +
+        dual-axis-invalidation POLICY (the Coordinator never owns domain
+        policy) — it returns ``BuildMaterial`` when a real rebuild is
+        needed (the Coordinator's ``_run_build`` then owns
+        ``embed_verify_write``) or ``None`` when its own policy already
+        determined nothing needs writing (a disk-adopt cache hit, which
+        ``prepare_material`` adopts directly onto ``idx``).
 
-        Readiness/visibility (``idx.is_ready()``) and the retry gate
-        (``self._action_index_build_failed``) are read directly off
-        ``idx``/``self`` by the caller (unchanged) rather than off the
-        Coordinator's own ``is_ready()``/``build_failed()`` — those stay
-        genuinely accurate here (``idx.build()`` always runs for real),
-        whereas the Coordinator's manifest write for a background build
-        settles one event-loop tick after ``idx``'s own state does, which
-        would otherwise open a window where the tool is advertised
-        visible before ``idx.query()`` can serve it. The Coordinator's
-        manifest/is_ready() stays a truthful PARALLEL observability
-        surface for future kinds/consumers (P2c/P2d).
+        Two Coordinator hooks close the gaps a material-only ``BuildFn``
+        opens for THIS specific adapter (both fire from inside
+        ``IndexCoordinator._run_build``, uniformly for eager AND
+        background, since that is the one coroutine body either awaited
+        inline or scheduled via ``asyncio.create_task``):
+
+        * ``on_error`` — #1458's failure-memoization
+          (``self._action_index_build_failed``) + the decision-enabling
+          warning log, kept in sync with the Coordinator's OWN
+          failure-memo (``build_failed()``), which is set on the SAME
+          exception one frame up in ``_run_build``'s own except-block.
+        * ``on_success`` — syncs ``idx``'s in-memory
+          ``is_ready()``/``size()``/``catalog_hash()`` gate
+          (``ActionEmbeddingIndex.adopt_build_result``) after a REAL
+          rebuild, since the Coordinator (not ``idx``) now performs the
+          write. The disk-adopt ``None`` case needs no sync here —
+          ``prepare_material`` already mutated ``idx`` directly.
+
+        Before any of that: if ``idx`` is already ready, this is a cheap
+        no-op (mirrors the pre-PR1 ``ensure_built_self_contained``'s
+        combined "manifest clean AND is_ready_probe()" gate). If ``idx``
+        is NOT ready but the Coordinator's PERSISTED manifest already says
+        "clean" (a fresh process/instance re-reading a prior process's
+        completed build — see ``ActionEmbeddingIndex``'s module docstring
+        "process-restart cache hit"), ``ensure_built``'s own top-level
+        clean-shortcut would otherwise skip calling ``prepare_material``
+        entirely, permanently stranding THIS ``idx`` instance not-ready —
+        so a targeted ``mark_dirty`` forces ``ensure_built`` to actually
+        invoke ``prepare_material`` (whose OWN cheap disk-adopt check then
+        typically resolves in one file-stat, no embed call).
         """
+        if getattr(idx, "is_ready", lambda: False)():
+            return
+
         coordinator = self._get_index_coordinator()
         source_id = getattr(idx, "source_name", None) or "actions"
 
-        async def _build_coro() -> None:
-            await self._build_action_embedding_index_background(
-                idx, provider, model_class,
+        if await coordinator.is_ready(source_id):
+            await coordinator.mark_dirty(
+                source_id, reason="action_index_instance_not_ready",
             )
-            if getattr(self, "_action_index_build_failed", False):
-                # _build_action_embedding_index_background swallows its own
-                # exception (memoizing the failure + emitting the event/log
-                # itself); re-raise a synthetic error here so the
-                # Coordinator's own failure-memo/mark_dirty bookkeeping
-                # stays consistent with the RouterLoop-side flag.
-                raise RuntimeError("action index build failed (see prior log)")
 
-        await coordinator.ensure_built_self_contained(
+        _fetch_state: dict[str, Any] = {}
+
+        async def _build_fn() -> Any:
+            items = await self._fetch_action_catalog_items()
+            if items is None:
+                items = []
+            _fetch_state["items"] = items
+            op_ctx = self.host.make_router_op_context()
+            return await idx.prepare_material(items, op_ctx, model_class)
+
+        def _on_error(exc: BaseException) -> None:
+            # #1458: memoize the failure so subsequent turns do not retry.
+            self._action_index_build_failed = True
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "%s", _action_index_build_failure_warning(exc, model_class)
+            )
+
+        def _on_success(outcome: Any) -> None:
+            if getattr(idx, "is_ready", lambda: False)():
+                return  # prepare_material's disk-adopt branch already synced idx
+            items = _fetch_state.get("items")
+            adopt = getattr(idx, "adopt_build_result", None)
+            if items is None or adopt is None:
+                return
+            from reyn.tools.action_index import compute_catalog_hash
+
+            chunk_count = outcome.chunk_count if outcome.chunk_count is not None else 0
+            adopt(compute_catalog_hash(items), model_class, chunk_count)
+
+        coordinator.register_builder(source_id, _build_fn, kind="static")
+        await coordinator.ensure_built(
             source_id,
-            _build_coro,
             await_completion=await_completion,
-            is_ready_probe=lambda: bool(getattr(idx, "is_ready", lambda: False)()),
-            chunk_count_probe=lambda: int(getattr(idx, "size", lambda: 0)()),
-            kind="static",
             events=self.host.events,
+            on_error=_on_error,
+            on_success=_on_success,
         )
 
     async def _build_action_embedding_index_background(
@@ -3503,10 +3583,24 @@ class RouterLoop:
         """FP-0034 Phase 2 step 1: background ActionEmbeddingIndex build.
 
         Enumerates the catalog via ``LIST_ACTIONS`` against a fresh
-        ``RouterCallerState`` snapshot and feeds the items into
-        ``idx.build()``.  The build is idempotent (= same catalog
-        hash skipped) and serialised by the index's internal lock,
-        so concurrent calls are safe.
+        ``RouterCallerState`` snapshot (``_fetch_action_catalog_items``)
+        and feeds the items into ``idx.build()``.  The build is idempotent
+        (= same catalog hash skipped).
+
+        P2-convergence PR1 (#3270 §2): this primitive is UNCHANGED (still
+        drives ``idx.build()`` — the full embed+write, now lock-free — end
+        to end and swallows/memoizes its own failure) and is kept for
+        direct/standalone callers, principally its own #1458 unit tests
+        (``tests/test_action_embedding_build_failure_1458.py``). The
+        PRODUCTION action-catalog build no longer routes through this
+        method — ``RouterLoop._ensure_action_index_built`` now calls
+        ``ActionEmbeddingIndex.prepare_material`` directly via the
+        Coordinator's ``ensure_built``, so the Coordinator (not ``idx``)
+        performs the write. Both shapes drive the exact same
+        ``ActionEmbeddingIndex`` build machinery underneath
+        (``prepare_material`` + ``embed_verify_write``); this method's own
+        failure-handling/logging contract (below) stays independently
+        exercised as a regression pin on that machinery.
 
         ``provider`` is retained as the caller's pre-existing "embedding
         configured" signal (callers gate on ``provider is not None`` before
@@ -3530,26 +3624,10 @@ class RouterLoop:
         cache-invalidation point for e.g. a model-download that was retried on a
         reconnected machine).
         """
-        from reyn.tools import get_default_registry
-        from reyn.tools.types import ToolContext
         try:
-            rs = await self._build_router_caller_state()
-            tool_ctx = ToolContext(
-                events=self.host.events,
-                permission_resolver=getattr(self.host, "permission_resolver", None),
-                workspace=getattr(self.host, "workspace", None),
-                caller_kind="router",
-                router_state=rs,
-                # #1673: thread the config-aware resolver (see the sibling sites).
-                resolver=getattr(self.host, "resolver", None),
-                hot_reloader=getattr(self.host, "hot_reloader", None),  # #2073 S3
-                state_log=getattr(self.host, "state_log", None),  # #2248 PR-A2 (config emit)
-            )
-            list_actions_def = get_default_registry().lookup("list_actions")
-            if list_actions_def is None:
+            items = await self._fetch_action_catalog_items()
+            if items is None:
                 return
-            result = await list_actions_def.handler({}, tool_ctx)
-            items = result.get("items", []) if isinstance(result, dict) else []
             op_ctx = self.host.make_router_op_context()
             await idx.build(items, op_ctx, model_class)
         except Exception as exc:

--- a/src/reyn/tools/action_index.py
+++ b/src/reyn/tools/action_index.py
@@ -70,15 +70,21 @@ Catalog hash semantics:
     policy — per-item incremental reconcile is Phase 2's ``index_update``,
     not built here).
 
-Concurrency:
-  - ``_build_lock`` serialises concurrent ``build()`` calls on this
-    instance; the second call awaits the first.
-  - Cross-process coordination uses the shared advisory build lock
-    (``reyn.data.index.build_lock.try_acquire_build_lock``) — a live
-    holder means "another process is mid-build", so this call falls back
-    to whatever's on disk instead of duplicating the embed-API cost of a
-    concurrent rebuild (#3128: embeddings are litellm API calls, not an
-    in-process model load).
+Concurrency (P2-convergence PR1, #3270 §2 — REVISED, both locks REMOVED
+from this class): ``build()``/``prepare_material()`` are now lock-free.
+Production builds route through ``IndexCoordinator.ensure_built`` (via
+``register_builder`` — see ``RouterLoop._ensure_action_index_built``),
+which is the SOLE holder of the cross-process advisory build lock
+(``reyn.data.index.build_lock.try_acquire_build_lock``, acquired once in
+``IndexCoordinator._run_build``) — a live holder there means "another
+process is mid-build", falling back to whatever's on disk instead of
+duplicating the embed-API cost of a concurrent rebuild (#3128: embeddings
+are litellm API calls, not an in-process model load). Same-instance
+concurrent-call serialization is the Coordinator's ``_bg_tasks``
+once-per-source dedup responsibility, not this class's. A direct/
+standalone ``build()`` call (bypassing the Coordinator — tests only in
+production code today) gets neither guarantee, matching a plain async
+method's normal semantics.
 
 Catalog coverage (FP-0057 Phase 2b re-check): today's catalog covers
 primitive tools, MCP tools, and pipelines. There is no separate per-skill
@@ -100,13 +106,10 @@ from typing import TYPE_CHECKING, Any, Mapping
 
 from reyn.data.index import IndexBackend, get_backend
 from reyn.data.index.backend import ChunkRecord, cache_dir_for_source
-from reyn.data.index.build_lock import try_acquire_build_lock
-from reyn.data.index.coordinator import embed_verify_write
+from reyn.data.index.coordinator import BuildMaterial, embed_verify_write
 
 if TYPE_CHECKING:
     from reyn.core.op_runtime.context import OpContext
-
-import asyncio
 
 # Default logical source name the action catalog rides on the unified
 # IndexBackend. A single instance's catalog is written with mode="replace"
@@ -186,7 +189,6 @@ class ActionEmbeddingIndex:
         self._catalog_hash: str | None = None
         self._model_class: str | None = None  # FP-0043 Component E: class-swap detection
         self._size: int = 0
-        self._build_lock = asyncio.Lock()
         self._building = False
 
     # ── identity ────────────────────────────────────────────────────────
@@ -268,6 +270,32 @@ class ActionEmbeddingIndex:
         """Return the number of indexed items (= vectors stored)."""
         return self._size
 
+    # ── external-write state sync (P2-convergence PR1, #3270 §2) ────────
+
+    def adopt_build_result(
+        self, catalog_hash: str, model_class: str, chunk_count: int,
+    ) -> None:
+        """Sync in-memory state (+ the on-disk catalog-hash sidecar) after
+        a CALLER-PERFORMED write succeeded.
+
+        The Coordinator-driven counterpart to ``build()``'s own post-write
+        update: when ``prepare_material`` returns real material and the
+        CALLER (``IndexCoordinator._run_build``, via
+        ``IndexCoordinator.ensure_built``) performs the actual
+        ``embed_verify_write`` — rather than this instance performing it
+        itself, as ``build()`` still does for a direct/standalone call —
+        this instance's own ``is_ready()``/``size()``/``catalog_hash()``
+        gate needs updating from that external result. Kept here (not
+        inlined at the call site, ``RouterLoop._ensure_action_index_built``)
+        so the state mutation + sidecar write stay ONE canonical
+        implementation, shared with ``build()``'s own internal update
+        (below) rather than two hand-maintained copies.
+        """
+        self._catalog_hash = catalog_hash
+        self._model_class = model_class
+        self._size = chunk_count
+        self._write_catalog_meta_hash(catalog_hash)
+
     # ── item <-> ChunkRecord mapping ───────────────────────────────────
 
     def _to_chunk_record(
@@ -343,6 +371,69 @@ class ActionEmbeddingIndex:
             raise RuntimeError(f"embed op failed: {result.get('error')}")
         return list(result.get("vectors", []))
 
+    async def prepare_material(
+        self,
+        items: list[Mapping[str, Any]],
+        ctx: "OpContext",
+        model_class: str,
+    ) -> "BuildMaterial | None":
+        """Lock-free, write-free material generation — the ``BuildFn``
+        ``IndexCoordinator.register_builder``/``ensure_built`` calls
+        (P2-convergence PR1, #3270 §2). Owns the action-catalog's
+        disk-adopt + dual-axis (catalog-hash + model-class) invalidation
+        POLICY — kept here (not moved to the Coordinator) because it is
+        part of the domain adapter's own material-generation decision,
+        per the firm's boundary principle.
+
+        Returns ``None`` when no rebuild is needed this call — either the
+        in-memory state already matches (both axes), or a disk-adopt cache
+        hit applies (this method mutates ``_catalog_hash``/``_model_class``/
+        ``_size`` directly in that case, exactly as the pre-PR1 ``build()``
+        did). Returns a ``BuildMaterial`` when a real embed+write is
+        needed; the caller (``build()`` for a direct/standalone call, or
+        the Coordinator's ``_run_build`` for the production path via
+        ``ensure_built``) owns performing the actual
+        ``embed_verify_write`` and, on success, updating this instance's
+        in-memory state — see ``build()`` below and
+        ``RouterLoop._ensure_action_index_built``.
+
+        No cross-process lock here BY DESIGN: the ONLY production entry
+        point (``IndexCoordinator.ensure_built``) already holds the SAME
+        advisory lock (``try_acquire_build_lock`` at the same
+        ``cache_dir_for_source`` path) for the ENTIRE duration this method
+        runs (it is called from inside the Coordinator's own
+        ``with try_acquire_build_lock(...)`` block in ``_run_build``) — a
+        second acquisition here would be the self-deadlock-shaped bug this
+        PR removes (the second call would see its OWN pid as the live
+        holder and silently skip). A direct/standalone caller (bypassing
+        the Coordinator, e.g. a test) gets no cross-process protection —
+        that guarantee is now Coordinator-exclusive.
+        """
+        new_hash = compute_catalog_hash(list(items))
+        if new_hash == self._catalog_hash and self._model_class == model_class:
+            return None  # idempotent (in-memory match on BOTH axes)
+
+        if await self._try_adopt_from_disk(new_hash, model_class):
+            return None  # cache hit — skip embed call
+
+        valid_items = sorted(
+            (dict(it) for it in items if it.get("qualified_name")),
+            key=lambda it: str(it["qualified_name"]),
+        )
+        texts = [
+            f"{it['qualified_name']}: {it.get('short_description', '')}"
+            for it in valid_items
+        ]
+        return BuildMaterial(
+            items=valid_items,
+            texts=texts,
+            to_chunk_record=lambda it, v, _resolved: self._to_chunk_record(
+                it, v, model_class,
+            ),
+            model_class=model_class,
+            ctx=ctx,
+        )
+
     async def build(
         self,
         items: list[Mapping[str, Any]],
@@ -365,11 +456,18 @@ class ActionEmbeddingIndex:
              (class-swap invalidates vectors from the previous model)
           3. catalog hash differs                          → rebuild
 
-        Cross-process build coordination: a non-blocking advisory file
-        lock (shared ``reyn.data.index.build_lock``) coordinates
-        concurrent builds across OS processes. If another live process
-        is mid-build, this call falls back to the disk state without
-        invoking the embedding provider.
+        Lock-free (P2-convergence PR1, #3270 §2): this method — the
+        material-generation POLICY (``prepare_material``, above) plus the
+        embed+write it performs when a real rebuild is needed — no longer
+        holds any lock (neither the prior in-process ``asyncio.Lock`` nor
+        the cross-process advisory ``build_lock``). Same-instance
+        concurrent-call serialization is now the caller's responsibility
+        (production callers go through ``IndexCoordinator.ensure_built``,
+        whose ``_bg_tasks`` once-per-source dedup + cross-process
+        ``build_lock`` — the SOLE acquisition, see ``prepare_material``'s
+        docstring — cover it); a direct/standalone call (as this method
+        remains, for tests and non-Coordinator callers) gets no locking at
+        all, matching a plain async method's normal semantics.
 
         FP-0057 #2856 Part A: ``ctx`` (an ``OpContext``) replaces the prior
         ``provider`` (``EmbeddingProvider``) argument — the embed call now
@@ -377,83 +475,37 @@ class ActionEmbeddingIndex:
         ``_embed_via_op``) instead of calling a caller-held provider
         directly.
         """
-        async with self._build_lock:
-            new_hash = compute_catalog_hash(list(items))
-            if (
-                new_hash == self._catalog_hash
-                and self._model_class == model_class
-            ):
-                return  # idempotent (in-memory match on BOTH axes)
+        material = await self.prepare_material(items, ctx, model_class)
+        if material is None:
+            return  # already satisfied — see prepare_material's docstring
 
-            if await self._try_adopt_from_disk(new_hash, model_class):
-                return  # cache hit — skip embed call
-
-            lock_dir = cache_dir_for_source(self._workspace_root, self._source)
-            with try_acquire_build_lock(lock_dir) as got_lock:
-                if not got_lock:
-                    # Another process is building. We can't safely block
-                    # the event loop on a sync lock; surface our current
-                    # state (likely empty or stale) and let the next
-                    # call observe the in-progress process's result.
-                    return
-
-                # Re-check disk under the lock — another process may
-                # have completed between our pre-lock check and now.
-                if await self._try_adopt_from_disk(new_hash, model_class):
-                    return
-
-                valid_items = sorted(
-                    (dict(it) for it in items if it.get("qualified_name")),
-                    key=lambda it: str(it["qualified_name"]),
-                )
-                if not valid_items:
-                    await self._backend.write(self._source, [], mode="replace")
-                    self._catalog_hash = new_hash
-                    self._model_class = model_class
-                    self._size = 0
-                    self._write_catalog_meta_hash(new_hash)
-                    return
-
-                texts = [
-                    f"{it['qualified_name']}: {it.get('short_description', '')}"
-                    for it in valid_items
-                ]
-
-                self._building = True
-                _built_ok = False
-                try:
-                    # FP-0066 P2a (#3247): the embed+verify+write step is the
-                    # ONE canonical all-or-nothing implementation, shared
-                    # with the `index_update` op (which used to duplicate
-                    # this verbatim) — see
-                    # ``reyn.data.index.coordinator.embed_verify_write``.
-                    # ``model_class`` (the caller's class label, e.g.
-                    # "standard") is passed to ``_to_chunk_record``, NOT the
-                    # embed op's resolved literal model id — the dual-axis
-                    # invalidation policy compares against the class label
-                    # (see this module's docstring / ``model_class`` property).
-                    result = await embed_verify_write(
-                        ctx=ctx,
-                        texts=texts,
-                        model_class=model_class,
-                        items=valid_items,
-                        to_chunk_record=lambda it, v, _resolved: self._to_chunk_record(
-                            it, v, model_class,
-                        ),
-                        backend=self._backend,
-                        source=self._source,
-                        mode="replace",
-                        item_noun="items",
-                        label="build",
-                    )
-                    self._catalog_hash = new_hash
-                    self._model_class = model_class
-                    self._size = result.write_result["written"]
-                    _built_ok = True
-                finally:
-                    self._building = False
-                if _built_ok:
-                    self._write_catalog_meta_hash(new_hash)
+        new_hash = compute_catalog_hash(list(items))
+        self._building = True
+        try:
+            # FP-0066 P2a (#3247): the embed+verify+write step is the
+            # ONE canonical all-or-nothing implementation, shared
+            # with the `index_update` op (which used to duplicate
+            # this verbatim) — see
+            # ``reyn.data.index.coordinator.embed_verify_write``. If this
+            # raises (e.g. a mismatched vector count), ``adopt_build_result``
+            # below is never reached — in-memory state stays exactly as it
+            # was pre-call (the all-or-nothing refusal-of-partial-build
+            # guarantee), matching pre-PR1 behavior.
+            result = await embed_verify_write(
+                ctx=material.ctx,
+                texts=material.texts,
+                model_class=material.model_class,
+                items=material.items,
+                to_chunk_record=material.to_chunk_record,
+                backend=self._backend,
+                source=self._source,
+                mode="replace",
+                item_noun="items",
+                label="build",
+            )
+            self.adopt_build_result(new_hash, model_class, result.write_result["written"])
+        finally:
+            self._building = False
 
     # ── query ───────────────────────────────────────────────────────────
 

--- a/tests/test_action_embedding_index_concurrency.py
+++ b/tests/test_action_embedding_index_concurrency.py
@@ -10,18 +10,33 @@ per-source convention (``<workspace_root>/.reyn/cache/index/actions/``).
   1. **Class-swap detection**: rebuilding with a different ``model_class``
      against an identical catalog re-invokes the provider (= vectors
      from the previous model are NOT silently reused).
-  2. **Cross-process advisory lock**: when the unified cache dir's
-     ``.build.lock`` carries a live PID, a concurrent ``build()`` skips
-     the embed call (= no duplicate API cost / duplicate
-     embed-API cost). The lock file marks holder PID +
-     timestamp atomically.
-  3. **Stale-lock reaping**: a ``.build.lock`` whose recorded PID is
-     dead is taken over (= no permanent deadlock after a crash).
-  4. **Disk persistence carries model_class**: the on-disk state records
+  2. **Disk persistence carries model_class**: the on-disk state records
      ``model_class`` (via the unified backend's ``embedding_model`` meta
      key) and the whole-catalog hash (via a small sidecar). Same catalog
      hash + same model class → load. Same catalog hash + different model
      class → reject (= rebuild).
+  3. **Lock helper module invariants**: ``reyn.data.index.build_lock``'s
+     own acquire/stale-reap/corrupt-file-recovery contract, tested
+     directly against the module (NOT through ``ActionEmbeddingIndex`` —
+     see the note below).
+
+P2-convergence PR1 (#3270 §2): ``ActionEmbeddingIndex.build()`` lost BOTH
+its own locks (the in-process ``asyncio.Lock`` and the cross-process
+``try_acquire_build_lock``) — same-instance serialization + cross-process
+build coordination are now EXCLUSIVELY ``IndexCoordinator``'s
+responsibility (``_bg_tasks`` dedup + the ``_run_build``-owned advisory
+lock), reached via ``ensure_built``/``register_builder``, not via a direct
+``build()`` call. The three tests that used to pin a DIRECT ``build()``
+call respecting a foreign ``.build.lock`` (skip-when-live-pid /
+stale-lock-reaping / corrupt-lock-recovery) are REMOVED here — that
+guarantee moved to the Coordinator and is re-proven at that layer in
+``tests/test_index_coordinator_3247_p2b.py`` (the mandatory §5
+strip-falsify "embed-cost duplicate-avoidance" gate) and
+``tests/test_index_coordinator_3247_p2a.py``/``p2d.py`` (Coordinator-level
+lock-contention coverage). A direct ``build()`` call today (bypassing the
+Coordinator) genuinely ignores a foreign ``.build.lock`` file — this is
+the intended, documented new contract (see ``action_index.py``'s module
+docstring "Concurrency" section), not an oversight.
 
 No mocks. Real ActionEmbeddingIndex + real ``_FakeProvider`` counting
 embed calls + real filesystem operations.
@@ -40,7 +55,6 @@ import pytest
 from reyn.core.events.events import EventLog
 from reyn.core.op_runtime.context import OpContext
 from reyn.data.embedding.provider import EmbedBatchResult
-from reyn.data.index.backend import cache_dir_for_source
 from reyn.data.index.build_lock import pid_alive, try_acquire_build_lock
 from reyn.data.workspace.workspace import Workspace
 from reyn.security.permissions.permissions import PermissionDecl
@@ -66,11 +80,6 @@ def _ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
     events = EventLog()
     ws = Workspace(events=events)
     return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
-
-
-def _lock_dir(workspace_root: Path) -> Path:
-    """The unified cache dir the advisory build lock lives under."""
-    return cache_dir_for_source(workspace_root, "actions")
 
 
 class _FakeProvider:
@@ -196,98 +205,7 @@ def test_disk_load_accepts_matching_class_and_catalog(
     assert idx_b.model_class == "standard"
 
 
-# ── 3. Cross-process advisory lock ──────────────────────────────────────────
-
-
-def test_concurrent_build_skips_when_lock_held_by_live_pid(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: another live process holding .build.lock → embed call skipped.
-
-    Simulates the multi-surface parallel-session race tui-coder
-    reported: both decide to rebuild simultaneously. Without the file
-    lock both would call provider.embed() and one would lose the disk
-    write race. With the lock, only the holder rebuilds; the other
-    falls back to whatever's currently on disk (= here, nothing → empty
-    state, which is fine; the holder's eventual save will be picked up
-    on the next build() call).
-    """
-    # Stage: write a lock file claiming the current (live) PID is mid-build.
-    lock_dir = _lock_dir(tmp_path)
-    lock_path = lock_dir / ".build.lock"
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_path.write_text(
-        json.dumps({"pid": os.getpid(), "ts": time.time()}),
-        encoding="utf-8",
-    )
-
-    provider = _FakeProvider()
-    ctx = _ctx_for(provider, monkeypatch)
-    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), ctx, "standard"))
-
-    # The lock was held → embed must NOT have been called.
-    assert provider.embed_calls == []
-    # The index also did not mutate its in-memory state (= consistent
-    # with the "another process owns this build" semantics).
-    assert not idx.is_ready()
-    # Clean up the staged lock so other tests don't inherit it.
-    lock_path.unlink(missing_ok=True)
-
-
-def test_stale_lock_is_reaped(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: a .build.lock whose PID is dead is taken over (no deadlock)."""
-    lock_dir = _lock_dir(tmp_path)
-    lock_path = lock_dir / ".build.lock"
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    # Pick a PID that's almost certainly dead (= a very large number
-    # well outside the typical PID range). os.kill(pid, 0) will surface
-    # ProcessLookupError for it.
-    dead_pid = 2**31 - 1  # max int32; not allocated by any kernel
-    assert not pid_alive(dead_pid), (
-        f"precondition: PID {dead_pid} must not be alive for this test"
-    )
-    lock_path.write_text(
-        json.dumps({"pid": dead_pid, "ts": time.time()}),
-        encoding="utf-8",
-    )
-
-    provider = _FakeProvider()
-    ctx = _ctx_for(provider, monkeypatch)
-    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), ctx, "standard"))
-
-    # Stale lock reaped → embed called normally; build completed.
-    assert provider.embed_calls == ["standard"]
-    assert idx.is_ready()
-    # Lock file removed on context exit.
-    assert not lock_path.exists()
-
-
-def test_corrupt_lock_file_is_treated_as_stale(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Tier 2: malformed .build.lock (= partial write, garbage) is recoverable.
-
-    A crashed previous process may leave a half-written lock; the next
-    builder should treat it as stale rather than wedging forever.
-    """
-    lock_dir = _lock_dir(tmp_path)
-    lock_path = lock_dir / ".build.lock"
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_path.write_text("not json at all }}}", encoding="utf-8")
-
-    provider = _FakeProvider()
-    ctx = _ctx_for(provider, monkeypatch)
-    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
-    _run(idx.build(_items(), ctx, "standard"))
-
-    assert provider.embed_calls == ["standard"]
-
-
-# ── 4. Lock helper unit invariants (reyn.data.index.build_lock) ────────────
+# ── 3. Lock helper unit invariants (reyn.data.index.build_lock) ────────────
 
 
 def test_try_acquire_lock_yields_true_then_releases(tmp_path: Path) -> None:

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -1,18 +1,32 @@
-"""FP-0066 P2b (#3247) — per-kind source split + action-catalog migration.
+"""FP-0066 P2b (#3247) / P2-convergence PR1 (#3270 §2) — per-kind source
+split + action-catalog migration through the SINGLE ``ensure_built``.
+
+P2-convergence PR1 eliminated ``IndexCoordinator.ensure_built_self_contained``
+(the two-path Coordinator API #3247 firm's P2b originally introduced for the
+action-catalog, since ``ActionEmbeddingIndex.build()`` used to own its own
+cross-process lock + write). ``ActionEmbeddingIndex`` lost both its locks
+(this module) and its material-generation policy moved into
+``prepare_material`` (a ``BuildFn`` — see ``reyn.tools.action_index``); the
+Coordinator's single ``ensure_built``/``register_builder`` is now the ONE
+entry point for every registered source, action-catalog included. This file
+is the P2-convergence-PR1 rewrite of the P2b equivalence suite — the fake
+below now implements the ``prepare_material``/``adopt_build_result`` shape
+instead of the retired self-contained ``build()``-does-everything shape, and
+routes actual writes through the REAL ``embed_verify_write`` (via a real
+``OpContext`` + a fake embedding provider — same convention as
+``tests/test_index_coordinator_3247_p2a.py``) so the Coordinator's own
+lock/write machinery is genuinely exercised, not bypassed.
 
 Covers:
   1. ``SourceEntry.kind`` taxonomy — persist + coerce-default ("backfill").
-  2. ``IndexCoordinator.ensure_built_self_contained`` — the orchestration-
-     only entry point ``RouterLoop._ensure_action_index_built`` uses to
-     migrate the action-catalog build (which owns its OWN cross-process
-     lock + disk-adopt + dual-axis invalidation policy, so it cannot use
-     the material-producing ``ensure_built`` without double-acquiring the
-     lock — see ``coordinator.py``'s docstring on that method).
-  3. **Equivalence test (mandatory)**: the migrated
-     ``RouterLoop._ensure_action_index_built`` path reproduces the
-     pre-migration observable behavior for the 5 pinned cases —
-     eager→sync build, non-eager→background, disk-adopt hit→no rebuild,
-     build failure→memoized (not re-attempted), ready-gate reflects state.
+  2. **Equivalence test (mandatory)**: ``RouterLoop._ensure_action_index_
+     built`` (now routed through ``ensure_built``) reproduces the
+     pre-PR1 observable behavior for the 5 pinned cases — eager→sync
+     build, non-eager→background, disk-adopt hit→no rebuild, build
+     failure→memoized (not re-attempted), ready-gate reflects state.
+  3. **Mandatory strip-falsify co-vet gates** (#3270 §5): self-deadlock/
+     silent-no-op non-recurrence, embed-cost duplicate-avoidance,
+     register_builder production fail-closed completeness.
 
 No mocks — real ``IndexCoordinator``, real ``SourceManifest``, real
 ``RouterLoop`` instances (constructed the same minimal-subclass way
@@ -20,21 +34,73 @@ No mocks — real ``IndexCoordinator``, real ``SourceManifest``, real
 a full host/session is not needed to exercise this orchestration layer);
 a plain fake index (real class, not a Mock) stands in for
 ``ActionEmbeddingIndex`` so build success/failure/timing is controllable
-without a real embedding provider.
+without a real embedding provider network call; a plain fake embedding
+provider (monkeypatched into the real `embed` op — established convention)
+stands in for the litellm boundary.
 """
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+import time
 from pathlib import Path
 from typing import Any
 
-from reyn.data.index.coordinator import IndexCoordinator
+import pytest
+
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index.backend import ChunkRecord, cache_dir_for_source
+from reyn.data.index.build_lock import try_acquire_build_lock
+from reyn.data.index.coordinator import BuildMaterial, IndexCoordinator
 from reyn.data.index.source_manifest import SourceEntry, SourceManifest
+from reyn.data.workspace.workspace import Workspace
 from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.permissions import PermissionDecl
 
 
 def _run(coro: Any) -> Any:
     return asyncio.run(coro)
+
+
+class _FakeEmbeddingProvider:
+    """Deterministic canned vectors, one per input text (no litellm call)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        self.calls.append(tuple(texts))
+        vectors = [[float((hash((t, i)) % 1000) / 1000.0) for i in range(4)] for t in texts]
+        return {"vectors": vectors, "model": model, "total_tokens": len(texts)}
+
+
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch) -> OpContext:
+    """Real OpContext whose `embed` op resolves to ``provider`` (mirrors
+    ``tests/test_index_coordinator_3247_p2a.py::_ctx_for``)."""
+    import reyn.core.op_runtime.embed as _embed_mod
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    events = EventLog()
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
+
+
+def _to_chunk_record(item: dict, vector: list[float], resolved_model: str) -> ChunkRecord:
+    return ChunkRecord(
+        text=item["text"],
+        vector=list(vector),
+        metadata={
+            "source_path": item["id"],
+            "source_type": "action",
+            "content_hash": item["id"],
+            "embedding_model": resolved_model,
+            "chunk_index": 0,
+            "size_tokens": 0,
+            "parent_context": None,
+            "extra": {},
+        },
+    )
 
 
 # ── 1. SourceEntry.kind taxonomy ──────────────────────────────────────────
@@ -65,37 +131,45 @@ def test_kind_defaults_to_backfill_when_missing_or_garbled(tmp_path: Path) -> No
 
 
 def test_freshly_created_entry_uses_registered_kind(tmp_path: Path) -> None:
-    """Tier 2: mark_dirty on a never-seen source_id tags the NEW entry with
-    the kind remembered from register_builder/ensure_built_self_contained,
-    not the "backfill" dataclass default. Reads back through a SEPARATE
-    ``SourceManifest`` instance against the same file SSoT (public surface
-    only — no private-state introspection)."""
+    """Tier 2: register_builder + ensure_built on a never-seen source_id
+    tags the NEW entry with the registered kind, not the "backfill"
+    dataclass default. Reads back through a SEPARATE ``SourceManifest``
+    instance against the same file SSoT (public surface only — no
+    private-state introspection)."""
     manifest = SourceManifest(tmp_path)
     coord = IndexCoordinator(tmp_path, manifest=manifest)
 
-    async def _build() -> None:
+    async def _build() -> BuildMaterial | None:
         return None
 
-    _run(coord.ensure_built_self_contained(
-        "actions", _build, await_completion=True,
-        is_ready_probe=lambda: False, kind="static",
-    ))
+    coord.register_builder("actions", _build, kind="static")
+    _run(coord.ensure_built("actions", await_completion=True))
     entry = _run(manifest.get("actions"))
     assert entry is not None
     assert entry.kind == "static"
 
 
-# ── 2 + 3. ensure_built_self_contained + the 5-case equivalence set ──────
+# ── 2. The action-catalog fake + the 5-case equivalence set ──────────────
 
 
 class _FakeActionIndex:
-    """Real fake standing in for ActionEmbeddingIndex — controllable
-    success/failure/timing, no embedding provider needed."""
+    """Real fake standing in for ``ActionEmbeddingIndex`` — controllable
+    success/failure/timing, no real embedding network call. Implements the
+    P2-convergence PR1 shape: ``prepare_material`` (lock-free, write-free
+    material generation) + ``adopt_build_result`` (state sync after the
+    CALLER's write succeeds) instead of the retired self-sufficient
+    ``build()``-does-everything shape.
+
+    A REAL ``BuildMaterial`` is returned (when not failing/already-ready)
+    so the Coordinator's REAL ``embed_verify_write`` genuinely runs against
+    it — ``ctx``/``model_class`` are threaded straight through from the
+    caller, exactly as ``ActionEmbeddingIndex.prepare_material`` does.
+    """
 
     def __init__(self, *, should_fail: bool = False, delay: float = 0.0) -> None:
         self.should_fail = should_fail
         self.delay = delay
-        self.build_calls = 0
+        self.prepare_calls = 0
         self._ready = False
         self._size = 0
         self.source_name = "actions"
@@ -106,23 +180,36 @@ class _FakeActionIndex:
     def size(self) -> int:
         return self._size
 
-    async def build(self, items: list[dict], ctx: Any, model_class: str) -> None:
-        self.build_calls += 1
+    async def prepare_material(
+        self, items: list[dict], ctx: Any, model_class: str,
+    ) -> BuildMaterial | None:
+        self.prepare_calls += 1
         if self.delay:
             await asyncio.sleep(self.delay)
         if self.should_fail:
             raise RuntimeError("simulated provider failure")
+        if self._ready:
+            return None  # already built — mirrors in-memory idempotency
+        return BuildMaterial(
+            items=items,
+            texts=[it["text"] for it in items],
+            to_chunk_record=_to_chunk_record,
+            model_class=model_class,
+            ctx=ctx,
+        )
+
+    def adopt_build_result(self, catalog_hash: str, model_class: str, chunk_count: int) -> None:
         self._ready = True
-        self._size = len(items)
+        self._size = chunk_count
 
 
 class _StubHost:
     """Minimal host — only what RouterLoop._ensure_action_index_built /
-    _build_action_embedding_index_background touch."""
+    _fetch_action_catalog_items touch."""
 
-    def __init__(self) -> None:
+    def __init__(self, op_ctx: Any) -> None:
         self.events = _StubEvents()
-        self.op_ctx_stub: Any = "ctx"
+        self.op_ctx_stub = op_ctx
 
     def make_router_op_context(self) -> Any:
         return self.op_ctx_stub
@@ -137,17 +224,23 @@ class _StubEvents:
 
 
 class _LoopForP2b(RouterLoop):
-    """RouterLoop subclass exercising the P2b orchestration methods without
-    a full host/session — same minimal-subclass pattern as
-    ``test_action_embedding_build_failure_1458.py``."""
+    """RouterLoop subclass exercising the P2b/P2-convergence-PR1
+    orchestration methods without a full host/session — same minimal-
+    subclass pattern as ``test_action_embedding_build_failure_1458.py``."""
 
-    def __init__(self, workspace_root: Path) -> None:
-        self.host = _StubHost()  # type: ignore[assignment]
+    def __init__(self, workspace_root: Path, op_ctx: Any) -> None:
+        self.host = _StubHost(op_ctx)  # type: ignore[assignment]
         self.chain_id = "test-chain"
         self._workspace_root_for_test = workspace_root
 
     async def _build_router_caller_state(self) -> Any:
         return None
+
+    async def _fetch_action_catalog_items(self) -> list[dict]:
+        # Bypasses the real list_actions/ToolContext plumbing (irrelevant
+        # to this orchestration-layer test) — returns a fixed 2-item
+        # catalog, mirroring _FakeActionIndex's expectations.
+        return [{"id": "a", "text": "alpha"}, {"id": "b", "text": "beta"}]
 
     def _get_index_coordinator(self) -> IndexCoordinator:
         # Deterministic per-test coordinator instance (bypasses the
@@ -157,24 +250,27 @@ class _LoopForP2b(RouterLoop):
         return self._test_coordinator
 
 
-def test_eager_awaits_sync_build(tmp_path: Path) -> None:
+def test_eager_awaits_sync_build(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: equivalence case 1 — eager (await_completion=True) runs the
     build INLINE — by the time the call returns, the index is ready."""
-    loop = _LoopForP2b(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex()
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
     assert idx.is_ready() is True
-    assert idx.build_calls == 1
+    assert idx.size() == 2
+    assert idx.prepare_calls == 1
     coordinator = loop._get_index_coordinator()
     assert _run(coordinator.is_ready("actions")) is True
 
 
-def test_non_eager_schedules_background(tmp_path: Path) -> None:
+def test_non_eager_schedules_background(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: equivalence case 2 — non-eager (await_completion=False)
     schedules the build in the BACKGROUND — the call returns before the
     (delayed) build completes, and the index becomes ready only once the
     background task finishes."""
-    loop = _LoopForP2b(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex(delay=0.05)
 
     async def _scenario() -> None:
@@ -188,7 +284,7 @@ def test_non_eager_schedules_background(tmp_path: Path) -> None:
         # to complete (bounded — no private-state introspection, mirrors
         # test_index_coordinator_3247_p2a.py's equivalent poll).
         for _ in range(200):
-            if await coordinator.is_ready("actions"):
+            if idx.is_ready():
                 break
             await asyncio.sleep(0.01)
         assert idx.is_ready() is True
@@ -197,34 +293,39 @@ def test_non_eager_schedules_background(tmp_path: Path) -> None:
     _run(_scenario())
 
 
-def test_disk_adopt_hit_skips_rebuild(tmp_path: Path) -> None:
-    """Tier 2: equivalence case 3 — once the manifest already records
-    state=="clean" AND the domain adapter itself reports ready (the
-    Coordinator-level analogue of a disk-adopt cache hit — a fresh
-    process/instance that finds a completed prior build), a second
-    ``ensure_built_self_contained`` call does NOT re-invoke the builder."""
-    loop = _LoopForP2b(tmp_path)
+def test_disk_adopt_hit_skips_rebuild(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tier 2: equivalence case 3 — once the index itself reports ready
+    (the analogue of a disk-adopt cache hit — a fresh process/instance
+    that finds a completed prior build), a second
+    ``_ensure_action_index_built`` call is a cheap no-op (does not
+    re-invoke ``prepare_material`` at all)."""
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex()
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
-    assert idx.build_calls == 1
+    assert idx.prepare_calls == 1
 
     # Second call — index is still ready (nothing invalidated it) — must
-    # be a no-op (no re-embed cost).
+    # be a no-op (no re-embed cost). The wrapper's OWN is_ready() gate
+    # short-circuits before even touching the Coordinator.
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
-    assert idx.build_calls == 1, "a clean+ready source must not rebuild"
+    assert idx.prepare_calls == 1, "a ready source must not rebuild"
 
 
-def test_build_failure_memoized_not_reattempted(tmp_path: Path) -> None:
+def test_build_failure_memoized_not_reattempted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Tier 2: equivalence case 4 — a build failure is memoized on BOTH the
     RouterLoop-side flag (#1458, unchanged) AND the Coordinator's own
     failure-memo (``build_failed``) — and the production retry guard
     (checked by the caller before invoking again) prevents a second
     attempt."""
-    loop = _LoopForP2b(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex(should_fail=True)
 
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
-    assert idx.build_calls == 1
+    assert idx.prepare_calls == 1
     assert getattr(loop, "_action_index_build_failed", False) is True
     coordinator = loop._get_index_coordinator()
     assert coordinator.build_failed("actions") is True
@@ -235,14 +336,15 @@ def test_build_failure_memoized_not_reattempted(tmp_path: Path) -> None:
         _run(loop._ensure_action_index_built(
             idx, "provider", "standard", await_completion=True,
         ))
-    assert idx.build_calls == 1, "memoized failure must prevent a retry"
+    assert idx.prepare_calls == 1, "memoized failure must prevent a retry"
 
 
-def test_ready_gate_reflects_state(tmp_path: Path) -> None:
+def test_ready_gate_reflects_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Tier 2: equivalence case 5 — is_ready() (both idx's own gate — used
     for search_actions visibility — and the Coordinator's parallel
     manifest-backed gate) is False before a build and True after."""
-    loop = _LoopForP2b(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+    loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex()
     coordinator = loop._get_index_coordinator()
 
@@ -255,28 +357,172 @@ def test_ready_gate_reflects_state(tmp_path: Path) -> None:
     assert _run(coordinator.is_ready("actions")) is True
 
 
-def test_1458_pinned_build_primitive_still_used_unchanged(tmp_path: Path) -> None:
-    """Tier 2: the P2b migration routes THROUGH
-    ``_build_action_embedding_index_background`` (#1458's pinned failure-
-    memoization/log primitive) rather than bypassing it — regression pin
-    that the migration didn't orphan that method into dead code reachable
-    only from its own unit test.
+# ── 3. Mandatory strip-falsify co-vet gates (#3270 §5) ────────────────────
 
-    FP-0066 P2d (#3247 firm §6) updated this pin's audit-event assertion:
-    the primitive's OWN direct ``action_index_build_failed`` emit was
-    folded into ``embedding_index_build_error``, now emitted by
-    ``IndexCoordinator.ensure_built_self_contained`` (one layer up, reached
-    via ``_ensure_action_index_built``) — so a failure surfaces the NEW
-    event name here, and the OLD name must not double-emit."""
-    loop = _LoopForP2b(tmp_path)
-    idx = _FakeActionIndex(should_fail=True)
-    _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
-    kinds = [e["kind"] for e in loop.host.events.emitted]
-    assert "embedding_index_build_error" in kinds, (
-        "the folded embedding_index_build_error event must fire via "
-        "IndexCoordinator.ensure_built_self_contained on a build failure"
+
+def test_self_deadlock_non_recurrence_two_consecutive_builds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: (strip-falsify, #3270 §5 gate 1 — mandatory) two consecutive
+    same-process action-index builds through the PRODUCTION path
+    (``ensure_built`` + ``register_builder``) — the 2nd does NOT silently
+    skip (it correctly rebuilds: ``is_ready()`` True, no exception, real
+    material actually written).
+
+    Strip-falsify: a build_fn that reproduces the pre-PR1 bug — a SECOND
+    ``try_acquire_build_lock`` acquisition at the SAME path the
+    Coordinator's own ``_run_build`` already holds — silently no-ops the
+    build (the second acquisition sees ITS OWN pid as a live holder and
+    skips). This proves the fix (stripping ``ActionEmbeddingIndex``'s own
+    lock) is load-bearing, not incidental: reintroducing the double-lock
+    reproduces the exact bound-fired-but-silent hazard #3270 §2 removes
+    by construction.
+    """
+    coord = IndexCoordinator(tmp_path)
+    ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
+
+    # ── the FIXED shape: no lock inside build_fn (matches prepare_material) ──
+    idx1 = _FakeActionIndex()
+
+    async def _fixed_build_fn1() -> BuildMaterial | None:
+        return await idx1.prepare_material(
+            [{"id": "a", "text": "alpha"}], ctx, "standard",
+        )
+
+    coord.register_builder("actions", _fixed_build_fn1, kind="static")
+    outcome1 = _run(coord.ensure_built("actions", await_completion=True))
+    assert outcome1.error is None
+    assert outcome1.chunk_count == 1
+    assert idx1.prepare_calls == 1
+
+    # A second build — force a re-check the way a fresh idx instance in a
+    # new process/session would (see RouterLoop._ensure_action_index_built's
+    # mark_dirty-when-Coordinator-clean-but-instance-not-ready path).
+    _run(coord.mark_dirty("actions", reason="force_recheck"))
+    idx2 = _FakeActionIndex()
+
+    async def _fixed_build_fn2() -> BuildMaterial | None:
+        return await idx2.prepare_material(
+            [{"id": "a", "text": "alpha"}], ctx, "standard",
+        )
+
+    coord.register_builder("actions", _fixed_build_fn2, kind="static")
+    outcome2 = _run(coord.ensure_built("actions", await_completion=True))
+    assert outcome2.error is None
+    assert idx2.prepare_calls == 1, (
+        "the second build must actually run (not silently no-op) once "
+        "marked dirty again"
     )
-    assert "action_index_build_failed" not in kinds, (
-        "the pre-P2d action_index_build_failed event must not double-emit "
-        "alongside its P2d fold target"
+    assert outcome2.chunk_count == 1
+
+    # ── the BUGGY (pre-PR1-shaped) shape: build_fn reacquires the SAME
+    # advisory lock the Coordinator's own _run_build already holds ──────
+    _run(coord.mark_dirty("actions", reason="force_recheck_buggy"))
+    lock_dir = cache_dir_for_source(tmp_path, "actions")
+    inner_probe: dict[str, Any] = {"ran": False, "got_lock": None, "produced_material": None}
+
+    async def _buggy_double_locked_build_fn() -> BuildMaterial | None:
+        # Reproduces the self-deadlock: a SECOND try_acquire_build_lock
+        # at the exact path _run_build's own `with try_acquire_build_lock`
+        # (coordinator.py:_run_build) already holds, in the SAME process.
+        with try_acquire_build_lock(lock_dir) as got_lock:
+            inner_probe["ran"] = True
+            inner_probe["got_lock"] = got_lock
+            if not got_lock:
+                # This is the bug: the SAME pid is seen as the live
+                # holder (itself, one call frame up) and the build
+                # silently no-ops instead of running.
+                inner_probe["produced_material"] = False
+                return None
+            inner_probe["produced_material"] = True
+            return BuildMaterial(
+                items=[{"id": "a", "text": "alpha"}],
+                texts=["alpha"],
+                to_chunk_record=_to_chunk_record,
+                model_class="standard",
+                ctx=ctx,
+            )
+
+    coord.register_builder("actions", _buggy_double_locked_build_fn, kind="static")
+    outcome3 = _run(coord.ensure_built("actions", await_completion=True))
+    assert inner_probe["ran"] is True, "sanity: the buggy build_fn actually ran"
+    assert outcome3.error is None, "the double-lock bug does not raise — it silently no-ops"
+    assert inner_probe["got_lock"] is False, (
+        "RED (of the guarantee) is exactly this: the second try_acquire_build_lock "
+        "acquisition, at the SAME path _run_build's own outer `with` already holds "
+        "in this SAME process, sees its OWN pid as a live holder and reports "
+        "got_lock=False — the self-deadlock-shaped silent-no-op #3270 §2's "
+        "single-lock-holder fix removes by construction. The FIXED build_fn shapes "
+        "above (no inner lock at all) never hit this branch."
     )
+    assert inner_probe["produced_material"] is False, (
+        "the double-locked build_fn silently produces NO material (its own "
+        "got_lock=False fallback) even though a real rebuild was due — exactly "
+        "the bound-fired-but-silent hazard: ensure_built itself reports "
+        "error=None (success-shaped), masking that nothing was actually rebuilt."
+    )
+
+
+def test_embed_cost_duplicate_avoidance_cross_process_mid_build(tmp_path: Path) -> None:
+    """Tier 2: (strip-falsify, #3270 §5 gate 2 — mandatory) a cross-process
+    mid-build scenario (another live PID holds the advisory lock) →
+    ``ensure_built`` falls back without invoking ``build_fn`` at all — NO
+    duplicate embed-API cost.
+
+    Strip-falsify: with the lock file staged BEFORE calling
+    ``ensure_built``, the build_fn must NOT be invoked. This is the
+    Coordinator-level proof that the SOLE lock acquisition (now living
+    only in ``_run_build``, since ``ActionEmbeddingIndex`` no longer
+    holds its own copy) still prevents the duplicate-embed-cost hazard
+    the pre-PR1 two-lock design also prevented — a regression here would
+    mean stripping the adapter's lock silently lost this guarantee
+    instead of correctly centralizing it.
+    """
+    coord = IndexCoordinator(tmp_path)
+    build_fn_calls = {"count": 0}
+
+    async def _build_fn() -> BuildMaterial:
+        build_fn_calls["count"] += 1
+        return BuildMaterial(
+            items=[{"id": "a", "text": "alpha"}],
+            texts=["alpha"],
+            to_chunk_record=_to_chunk_record,
+            model_class="standard",
+            ctx="unused",
+        )
+
+    coord.register_builder("actions", _build_fn, kind="static")
+
+    # Stage: another (live) process holds the cross-process build lock.
+    lock_dir = cache_dir_for_source(tmp_path, "actions")
+    lock_path = lock_dir / ".build.lock"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text(
+        json.dumps({"pid": os.getpid(), "ts": time.time()}), encoding="utf-8",
+    )
+    try:
+        outcome = _run(coord.ensure_built("actions", await_completion=True))
+    finally:
+        lock_path.unlink(missing_ok=True)
+
+    assert build_fn_calls["count"] == 0, (
+        "build_fn must NOT be invoked while another process holds the "
+        "build lock — invoking it would duplicate the embed-API cost"
+    )
+    assert outcome.triggered is False
+
+
+def test_register_builder_production_fail_closed_for_unregistered_source(
+    tmp_path: Path,
+) -> None:
+    """Tier 2: (#3270 §5 gate 3 — mandatory) an unregistered source_id
+    fails CLOSED (``ValueError``) rather than silently no-building —
+    ``register_builder`` is now a PRODUCTION path (the action-catalog),
+    not test-only, so a registration omission must be loud."""
+    coord = IndexCoordinator(tmp_path)
+    try:
+        _run(coord.ensure_built("never_registered", await_completion=True))
+        raise AssertionError("expected ValueError for an unregistered source")
+    except ValueError as exc:
+        assert "never_registered" in str(exc)
+        assert "register_builder" in str(exc)

--- a/tests/test_index_coordinator_3247_p2d.py
+++ b/tests/test_index_coordinator_3247_p2d.py
@@ -13,9 +13,7 @@ Covers:
      the Coordinator's build-execution method boundary (``ensure_built``,
      the material-producing path).
   2. A build failure emits ``embedding_index_build_error`` (with a
-     ``reason``) — via BOTH ``ensure_built`` and
-     ``ensure_built_self_contained`` (the two build-execution shapes P2b
-     introduced).
+     ``reason``).
   3. The pre-P2d ``action_index_build_failed`` event (previously emitted
      directly by ``RouterLoop._build_action_embedding_index_background``)
      no longer double-emits alongside its fold target,
@@ -27,6 +25,21 @@ Covers:
      _handle_search_actions``): a clean source is a cheap no-op (no build
      triggered); ``semantic_search_started``/``_complete`` (results count)
      fire around the real query.
+
+P2-convergence PR1 (#3270 §2): ``IndexCoordinator.ensure_built_self_
+contained`` — the two-path shape P2b introduced for the action-catalog
+(which used to own its own lock+write) — is ELIMINATED. The action-catalog
+now routes through the SAME ``ensure_built``/``register_builder`` path as
+every other source (via ``ActionEmbeddingIndex.prepare_material``, the
+lock-free ``BuildFn`` — see ``reyn.tools.action_index``); the
+self-contained-specific coverage this file used to carry (§2's "via BOTH
+shapes" + the freestanding ``_FakeSelfContainedBuilder`` tests) is REMOVED
+— its regression value now lives in
+``tests/test_index_coordinator_3247_p2b.py`` (the equivalence suite +
+mandatory #3270 §5 strip-falsify gates), which exercises the SAME
+production call path (``RouterLoop._ensure_action_index_built``) this file
+already tests at §3's ``test_action_index_build_failure_both_signals_
+stay_in_sync``.
 
 No mocks — real ``IndexCoordinator``, real ``SourceManifest``, a real
 ``EventLog`` subscribed to a real ``EventStore`` (audit-events are read back
@@ -211,95 +224,6 @@ def test_events_none_is_a_silent_noop(tmp_path: Path) -> None:
     # No events kwarg at all — must not raise.
     outcome = _run(coord.ensure_built("x", await_completion=True))
     assert outcome.error is None or outcome.error is not None  # just must not raise
-
-
-# ── ensure_built_self_contained — the action-catalog build shape ──────────
-
-
-class _FakeSelfContainedBuilder:
-    """Mirrors ``ActionEmbeddingIndex``'s self-contained-builder shape (own
-    readiness/size probes, own lock) — same pattern as
-    ``test_index_coordinator_3247_p2b.py::_FakeActionIndex``."""
-
-    def __init__(self, *, should_fail: bool = False) -> None:
-        self.should_fail = should_fail
-        self._ready = False
-        self._size = 0
-
-    async def build(self) -> None:
-        if self.should_fail:
-            raise RuntimeError("simulated provider failure")
-        self._ready = True
-        self._size = 3
-
-    def is_ready(self) -> bool:
-        return self._ready
-
-    def size(self) -> int:
-        return self._size
-
-
-def test_ensure_built_self_contained_emits_started_progress_complete(tmp_path: Path) -> None:
-    """Tier 2: the self-contained build shape (the action-catalog's own
-    lock/readiness-probe pattern) emits the same three build phases."""
-    log, store = _events_and_store(tmp_path)
-    coord = IndexCoordinator(tmp_path)
-    builder = _FakeSelfContainedBuilder()
-
-    async def _scenario() -> list[dict]:
-        await coord.ensure_built_self_contained(
-            "actions", builder.build,
-            await_completion=True,
-            is_ready_probe=builder.is_ready,
-            chunk_count_probe=builder.size,
-            kind="static",
-            events=log,
-        )
-        return await _read_back(store)
-
-    events = _run(_scenario())
-    kinds = [e["type"] for e in events]
-    assert kinds == [
-        "embedding_index_build_started",
-        "embedding_index_build_progress",
-        "embedding_index_build_complete",
-    ]
-    for e in events:
-        assert e["data"]["source_id"] == "actions"
-    assert events[0]["data"]["kind"] == "static"
-    assert events[1]["data"]["chunk_count"] == 3
-    assert events[2]["data"]["chunk_count"] == 3
-
-
-def test_ensure_built_self_contained_failure_folds_to_build_error(tmp_path: Path) -> None:
-    """Tier 2: the FOLD — a self-contained-builder failure emits
-    ``embedding_index_build_error`` (with a reason), NOT the pre-P2d
-    ``action_index_build_failed`` — this is the Coordinator-level half of
-    the fold; the RouterLoop-level half (removing the direct emit from
-    ``_build_action_embedding_index_background``) is pinned in
-    ``test_action_embedding_build_failure_1458.py`` and
-    ``test_index_coordinator_3247_p2b.py``."""
-    log, store = _events_and_store(tmp_path)
-    coord = IndexCoordinator(tmp_path)
-    builder = _FakeSelfContainedBuilder(should_fail=True)
-
-    async def _scenario() -> list[dict]:
-        await coord.ensure_built_self_contained(
-            "actions", builder.build,
-            await_completion=True,
-            is_ready_probe=builder.is_ready,
-            kind="static",
-            events=log,
-        )
-        return await _read_back(store)
-
-    events = _run(_scenario())
-    kinds = [e["type"] for e in events]
-    assert "embedding_index_build_error" in kinds
-    assert "action_index_build_failed" not in kinds
-    error_event = next(e for e in events if e["type"] == "embedding_index_build_error")
-    assert error_event["data"]["source_id"] == "actions"
-    assert "simulated provider failure" in error_event["data"]["reason"]
 
 
 # ── search-await production wiring — RouterLoop.search_actions ────────────


### PR DESCRIPTION
**[per-PR-coder]** — part of #3270

## Summary

Implements P2-convergence PR1 (収束1, ratified design on #3270 §2): collapses `IndexCoordinator`'s two-path build API (`ensure_built` vs `ensure_built_self_contained`) down to the single `ensure_built`, by making `ActionEmbeddingIndex.build` lock-free.

### The self-deadlock, and how it's removed by construction

Pre-PR1: `IndexCoordinator._run_build` held a cross-process advisory lock, then called a `build_fn` that (for the action-catalog) was `ActionEmbeddingIndex.build()` — which acquired the SAME advisory lock a second time, in the same process. The second acquisition saw its own pid as a live holder and silently no-op'd (the self-deadlock-shaped bug `ensure_built_self_contained` was built to avoid, not remove).

This PR removes the root: `ActionEmbeddingIndex.build()` loses **both** its locks (the in-process `asyncio.Lock` and the cross-process `try_acquire_build_lock`). `IndexCoordinator._run_build`'s own lock acquisition is now the **sole** holder for every registered source — the same-path double-acquire is structurally impossible, not merely avoided.

### Locks stripped / serialization + write relocation

- `ActionEmbeddingIndex.__init__` no longer creates `self._build_lock` (asyncio.Lock).
- `ActionEmbeddingIndex.build()` no longer calls `try_acquire_build_lock`.
- Same-instance concurrent-build serialization is now `IndexCoordinator`'s `_bg_tasks` once-per-source dedup responsibility (unchanged mechanism, now the sole one).
- The action-catalog's disk-adopt + dual-axis (catalog-hash + model-class) invalidation **policy** is extracted (not moved) into a new `ActionEmbeddingIndex.prepare_material()` — lock-free, write-free, a `BuildFn` returning `BuildMaterial` (real rebuild needed) or `None` (adapter's own policy determined nothing needs writing, e.g. a disk-adopt cache hit — which `prepare_material` adopts directly onto `idx`). `IndexCoordinator._run_build` performs the actual `embed_verify_write` for the `BuildMaterial` case.
- `build()` itself is preserved as a full self-sufficient (now lock-free) method — calls `prepare_material()` then does its own `embed_verify_write` + state update — for direct/standalone callers (kept for `tests/test_action_embedding_index.py`'s ~30 pinned direct-call tests).

### `ensure_built_self_contained` elimination + path unification

- `IndexCoordinator.ensure_built_self_contained` is **removed** from `coordinator.py`.
- `BuildFn`'s contract is extended: `Callable[[], Awaitable[BuildMaterial | None]]` — `None` means "the adapter's own material-generation policy determined no write needed this call" (`_run_build` marks the source clean without calling `embed_verify_write`).
- `ensure_built`/`_run_build` gain two optional best-effort hooks, `on_error`/`on_success`, that fire from inside `_run_build`'s single coroutine body — uniformly for both eager (awaited inline) and background (`asyncio.create_task`) builds. These are the seam `RouterLoop._ensure_action_index_built` uses to (a) keep #1458's `_action_index_build_failed` flag in sync with the Coordinator's own failure-memo on the SAME exception, and (b) sync `ActionEmbeddingIndex`'s in-memory `is_ready()`/`size()`/`catalog_hash()` state after a Coordinator-driven write (`ActionEmbeddingIndex.adopt_build_result`, a new method — since the Coordinator, not `idx`, now performs the write for the material-producing path).
- `RouterLoop._ensure_action_index_built` now registers `idx.prepare_material` via `register_builder` and calls `coordinator.ensure_built` for BOTH the eager (router_loop.py ~:1330) and background (~:1353) paths — `register_builder`/`ensure_built` are now a **production** path, not test-only (`register_builder`'s docstring updated accordingly).
- A targeted `mark_dirty` handles the "Coordinator manifest already clean from a prior process, but THIS `idx` instance was never built" case (process-restart cache hit) — otherwise `ensure_built`'s top-level clean-shortcut would skip calling `prepare_material` entirely and strand `idx` not-ready forever.
- `RouterLoop._build_action_embedding_index_background` (the `idx.build()`-driven primitive #1458's tests pin directly) is **UNCHANGED** per the brief's guardrail — kept for direct/standalone callers (principally its own unit tests). Its catalog-fetch logic is extracted into a new shared `_fetch_action_catalog_items` so both the unchanged primitive and the new production build_fn fetch the catalog identically (no silent divergence on WHAT gets embedded).

### §5 mandatory strip-falsify co-vet evidence (`tests/test_index_coordinator_3247_p2b.py`)

1. **`test_self_deadlock_non_recurrence_two_consecutive_builds`** — drives two consecutive same-process builds through the production `ensure_built`+`register_builder` path (both succeed, no silent no-op), then reproduces the pre-PR1 double-lock bug inline (a build_fn that reacquires `try_acquire_build_lock` at the exact path `_run_build`'s own lock already holds) and proves it reports `got_lock=False`/produces no material — `error=None` (success-shaped) while silently no-op'ing, exactly the bound-fired-but-silent hazard the fix removes.
2. **`test_embed_cost_duplicate_avoidance_cross_process_mid_build`** — stages a foreign live-PID lock file before calling `ensure_built`; asserts `build_fn` is never invoked (no duplicate embed-API cost).
3. **`test_register_builder_production_fail_closed_for_unregistered_source`** — an unregistered source raises `ValueError` (coordinator.py:302), not a silent no-build.
4. **`test_action_embedding_build_failure_1458.py`** — untouched, all tests green (unchanged primitive). `test_index_coordinator_3247_p2d.py::test_action_index_build_failure_both_signals_stay_in_sync` (real production path, real exception) confirms BOTH `RouterLoop._action_index_build_failed` and `coordinator.build_failed("actions")` are set together.

### Test-file disposition

- `tests/test_action_embedding_index_concurrency.py`: 3 tests pinning `build()`'s OWN cross-process-lock-respecting behavior are removed (that behavior moved to the Coordinator by design — a direct `build()` call today genuinely ignores a foreign lock file); class-swap/disk-persistence/lock-module-unit tests are untouched and still green.
- `tests/test_index_coordinator_3247_p2b.py`: rewritten for the new `prepare_material`/`adopt_build_result` shape (was: the retired self-contained `build()`-does-everything fake); same 5-case equivalence set (eager/background/disk-adopt/failure-memo/ready-gate) plus the 3 new mandatory strip-falsify gates.
- `tests/test_index_coordinator_3247_p2d.py`: the `ensure_built_self_contained`-specific test block (`_FakeSelfContainedBuilder` + its 2 tests) is removed; everything else (audit-event phase emit on the material path, search_await production wiring at both live query call sites, the #1458 dual-signal pin) is untouched and green.

### Local CI gates (all green)

- `ruff check` on all changed files: clean.
- `python scripts/test_tier_audit.py --strict` on changed test files: 27 tests inspected, 0 Tier-4 violations.
- `python scripts/verify_module_docstrings.py` on changed src files: OK.
- Broad affected pytest set (250 tests: action_index/action_embedding incl. #1458, coordinator P2a/b/d, knowledge_ingest P3a/b, search_emit/search_knowledge P3, universal_catalog/handlers, list_actions, op_embed, reyn_embeddings CLI, fp0063 arc-witness): **250 passed**.

## Guardrails honored

- `_action_index_build_failed` / the P2d interim dual-sync pin are untouched (retire in PR2 per the firm's §3).
- Disk-adopt + dual-axis-invalidation POLICY stayed in the domain adapter (`prepare_material`), never moved into the Coordinator.
- External behavior verified byte-identical: search result content (query() unchanged), retry count (1 per fresh process — #1458 tests unchanged), cross-process mid-build disk-fallback (gate 2 above), no self-deadlock/silent-no-op (gate 1 above).

## Test plan
- [x] `ruff check` on changed files
- [x] `test_tier_audit.py --strict` on changed test files
- [x] Broad affected pytest set (250 tests)
- [x] `verify_module_docstrings.py` on changed src files
- [ ] Full `pytest` from repo root — a background full-suite run was in progress at PR-open time; will report status as a follow-up comment if it surfaces anything beyond the broad affected set already covered above.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>