### PR TITLE
refactor(P2-conv PR2): failure-state single-owner — Coordinator memo sole owner, remove dead primitive, migrate #1458 to production path

### DIFF
--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -55,10 +55,19 @@ docstring).
 **P2-convergence PR2** (#3270 §3, subordinate to PR1's Coordinator-routing):
 collapses the twin failure signals — ``RouterLoop``'s own
 ``_action_index_build_failed`` flag AND this class's ``_failure_memo`` — to
-this class's memo as the SOLE owner. The flag (and its only setter, the
+this class's memo as the SOLE STATE owner. The flag (and its only setter, the
 production-dead ``RouterLoop._build_action_embedding_index_background``)
 are removed entirely; ``build_failed(source_id)`` below is the single read
-surface every caller (production and test) now uses.
+surface every caller (production and test) now uses. The SUPPRESSION
+POLICY built on top of that state (#1458's "at most one AUTO-rebuild
+attempt per session") is deliberately NOT enforced here — a co-vet round
+caught that an earlier revision put it in ``ensure_built`` itself, which
+silently broke the §G2 heal contract for every OTHER source (``search_await``
+calls ``ensure_built`` directly to heal a dirty entry once its provider
+recovers, for every registered source, not just the action-catalog).
+``ensure_built`` stays TRIGGER-AGNOSTIC; the #1458 suppression lives solely
+at ``RouterLoop._ensure_action_index_built``, the one AUTO-rebuild
+chokepoint that actually wants it (see that method's docstring).
 
 **Crash-recovery (the band requirement, CLAUDE.md recovery-feature gate)**:
 the dirty/building/error state lives in ``SourceEntry`` (persisted to
@@ -380,16 +389,25 @@ class IndexCoordinator:
         ``mark_dirty`` + the in-process failure-memo, and reported on the
         returned ``BuildOutcome.error`` (the §G2 best-effort contract).
 
-        Same-session retry suppression (P2-convergence PR2, #3270 §3): if a
-        PRIOR attempt in THIS process already failed for ``source_id`` (per
-        ``build_failed(source_id)``), this call is a cheap no-op — it does
-        NOT re-invoke ``build_fn``/re-attempt the write — reported via
-        ``BuildOutcome(triggered=False, error=<memoized reason>)``. This is
-        enforced by the memo's OWNER so a caller does not need its own
-        "check ``build_failed`` before calling again" convention to get the
-        suppression (#1458's original invariant — a fresh process/session
-        still gets exactly one attempt, since the memo itself is per-
-        process/volatile).
+        ``ensure_built`` is deliberately TRIGGER-AGNOSTIC about a prior
+        failure (P2-convergence PR2, #3270 §3, revised after a co-vet-
+        caught regression): it does NOT itself suppress a rebuild just
+        because ``build_failed(source_id)`` is already True — a dirty/
+        error entry still attempts ``build_fn`` again on every call. This
+        is required for the §G2 heal contract: ``search_await`` calls
+        THIS method directly to heal a dirty source once its provider
+        recovers, for EVERY registered source (skill/memory/repo/action-
+        catalog) — an unconditional suppression here would have globalized
+        the action-catalog-specific #1458 "don't auto-retry a failed
+        build" POLICY onto every source's heal path, permanently stranding
+        a dirty source that could otherwise recover. #1458's per-session
+        "at most one AUTO attempt" suppression is instead enforced by the
+        ONE caller that actually wants it — ``RouterLoop.
+        _ensure_action_index_built`` (the AUTO-rebuild chokepoint both the
+        eager and background paths funnel through), which checks
+        ``build_failed(source_id)`` at ITS OWN entry, before ever calling
+        ``ensure_built``. ``search_await`` does not go through that
+        chokepoint, so a heal is never suppressed.
 
         ``events`` (FP-0066 P2d, #3247 firm §6): an optional ``EventLog`` to
         emit the ``embedding_index_build_started``/``_progress``/
@@ -439,23 +457,6 @@ class IndexCoordinator:
         if entry is not None and entry.state == "building":
             # Someone (this process or another) is already mid-build.
             return BuildOutcome(source_id=source_id, triggered=False, background=False)
-        if self.build_failed(source_id):
-            # P2-convergence PR2 (#3270 §3, co-vet-driven root-fix): same-
-            # session retry suppression is enforced HERE, by the
-            # ``_failure_memo`` OWNER, not merely mirrored by a caller-side
-            # "check the memo before calling again" convention (#1458). A
-            # prior build attempt in THIS process already failed for
-            # ``source_id`` (persisted state stays "dirty"/"error", which
-            # would otherwise fall through past the two early-returns above
-            # and re-attempt on every call) — skip the rebuild and report
-            # it as a no-op with the memoized reason, so a caller that
-            # calls ``ensure_built`` again unconditionally (not just one
-            # that remembers to check ``build_failed`` first) still gets
-            # the suppression for free.
-            return BuildOutcome(
-                source_id=source_id, triggered=False, background=False,
-                error=self._failure_memo[source_id],
-            )
 
         build_fn = self._builders.get(source_id)
         if build_fn is None:

--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -52,6 +52,14 @@ concern — extracted into ``ActionEmbeddingIndex.prepare_material``, a
 call — see ``_run_build``'s ``material is None`` branch and ``BuildFn``'s
 docstring).
 
+**P2-convergence PR2** (#3270 §3, subordinate to PR1's Coordinator-routing):
+collapses the twin failure signals — ``RouterLoop``'s own
+``_action_index_build_failed`` flag AND this class's ``_failure_memo`` — to
+this class's memo as the SOLE owner. The flag (and its only setter, the
+production-dead ``RouterLoop._build_action_embedding_index_background``)
+are removed entirely; ``build_failed(source_id)`` below is the single read
+surface every caller (production and test) now uses.
+
 **Crash-recovery (the band requirement, CLAUDE.md recovery-feature gate)**:
 the dirty/building/error state lives in ``SourceEntry`` (persisted to
 ``sources.yaml`` — the SourceManifest's existing atomic-write file SSoT).
@@ -386,9 +394,11 @@ class IndexCoordinator:
         ``await_completion`` (it runs from inside ``_run_build``, the same
         coroutine body whether awaited inline or scheduled as a background
         task, so it fires uniformly for both). This is the seam a caller
-        with its OWN failure bookkeeping to keep in sync (e.g.
-        ``RouterLoop._action_index_build_failed``, #1458) hooks into,
-        without the Coordinator needing to know that bookkeeping exists —
+        with its OWN decision-enabling side effect (e.g. ``RouterLoop``'s
+        #1458 operator-warning log) hooks into — failure BOOKKEEPING itself
+        is NOT this seam's job as of P2-convergence PR2 (#3270 §3): the
+        Coordinator's ``_failure_memo`` (set one frame up, before this
+        callback fires) is the sole owner of that state —
         the callback receives the ORIGINAL exception object (not just its
         ``str()``), which a cause-aware caller (e.g.
         ``_action_index_build_failure_warning``'s exception-type branching)
@@ -666,17 +676,20 @@ class IndexCoordinator:
             await self._manifest.upsert(entry)
         return removed
 
-    # ── failure-memo read surface (mirrors router_loop's
-    #    ``_action_index_build_failed`` semantics) ───────────────────────
+    # ── failure-memo read surface (P2-convergence PR2, #3270 §3: the SOLE
+    #    owner of build-failure state — RouterLoop's twin
+    #    ``_action_index_build_failed`` flag is retired) ───────────────────
 
     def build_failed(self, source_id: str) -> bool:
         """True if a prior build attempt in THIS process failed (per-process
-        once-per-source memoization, mirrors ``RouterLoop.
-        _action_index_build_failed`` — cross-process/cross-restart
+        once-per-source memoization — cross-process/cross-restart
         persistence of "don't retry" is intentionally NOT implemented; the
         persisted ``sources.yaml`` state is ``dirty``/``error`` regardless,
         so a fresh process/session gets exactly one retry, which is the
-        desired heal path)."""
+        desired heal path). The single source of truth for build-failure
+        state (P2-convergence PR2, #3270 §3) — every caller (production
+        ``RouterLoop`` reads included) reads THIS, not a caller-side twin
+        flag."""
         return source_id in self._failure_memo
 
     # ``ensure_built_self_contained`` — the ORCHESTRATION-only twin that used

--- a/src/reyn/data/index/coordinator.py
+++ b/src/reyn/data/index/coordinator.py
@@ -380,6 +380,17 @@ class IndexCoordinator:
         ``mark_dirty`` + the in-process failure-memo, and reported on the
         returned ``BuildOutcome.error`` (the §G2 best-effort contract).
 
+        Same-session retry suppression (P2-convergence PR2, #3270 §3): if a
+        PRIOR attempt in THIS process already failed for ``source_id`` (per
+        ``build_failed(source_id)``), this call is a cheap no-op — it does
+        NOT re-invoke ``build_fn``/re-attempt the write — reported via
+        ``BuildOutcome(triggered=False, error=<memoized reason>)``. This is
+        enforced by the memo's OWNER so a caller does not need its own
+        "check ``build_failed`` before calling again" convention to get the
+        suppression (#1458's original invariant — a fresh process/session
+        still gets exactly one attempt, since the memo itself is per-
+        process/volatile).
+
         ``events`` (FP-0066 P2d, #3247 firm §6): an optional ``EventLog`` to
         emit the ``embedding_index_build_started``/``_progress``/
         ``_complete``/``_error`` audit-event phases to. ``None`` (the
@@ -428,6 +439,23 @@ class IndexCoordinator:
         if entry is not None and entry.state == "building":
             # Someone (this process or another) is already mid-build.
             return BuildOutcome(source_id=source_id, triggered=False, background=False)
+        if self.build_failed(source_id):
+            # P2-convergence PR2 (#3270 §3, co-vet-driven root-fix): same-
+            # session retry suppression is enforced HERE, by the
+            # ``_failure_memo`` OWNER, not merely mirrored by a caller-side
+            # "check the memo before calling again" convention (#1458). A
+            # prior build attempt in THIS process already failed for
+            # ``source_id`` (persisted state stays "dirty"/"error", which
+            # would otherwise fall through past the two early-returns above
+            # and re-attempt on every call) — skip the rebuild and report
+            # it as a no-op with the memoized reason, so a caller that
+            # calls ``ensure_built`` again unconditionally (not just one
+            # that remembers to check ``build_failed`` first) still gets
+            # the suppression for free.
+            return BuildOutcome(
+                source_id=source_id, triggered=False, background=False,
+                error=self._failure_memo[source_id],
+            )
 
         build_fn = self._builders.get(source_id)
         if build_fn is None:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1313,21 +1313,22 @@ class RouterLoop:
             _model_class = _model_getter() if _model_getter else None
             _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
             # #1458: a prior build failure in this session must not spawn a
-            # retry. P2-convergence PR2 (#3270 §3, co-vet-driven root-fix):
-            # the SOLE suppression site is now inside
-            # ``IndexCoordinator.ensure_built`` (the ``_failure_memo``
-            # owner — see its docstring) — it no-ops a build attempt when
-            # ``build_failed(source_id)`` is already True, BEFORE invoking
-            # ``build_fn`` again. router_loop deliberately carries NO
-            # sibling ``build_failed``-gated condition on the two
-            # ``_ensure_action_index_built`` calls below: a caller-side
-            # mirror of the same check would make any regression in the
-            # Coordinator's own suppression invisible to a test that drives
-            # this call path (the exact wiring-hazard #3270 §3 exists to
-            # close) — see ``tests/test_action_embedding_build_failure_
-            # 1458.py``'s non-vacuity proof. Both calls below are therefore
-            # UNCONDITIONAL on failure state; after a failure they still
-            # execute but resolve as a cheap Coordinator-side no-op.
+            # retry. P2-convergence PR2 (#3270 §3, REVISED after a co-vet-
+            # caught regression): the suppression is enforced inside
+            # ``_ensure_action_index_built`` itself (checked at ITS entry,
+            # reading ``IndexCoordinator.build_failed(source_id)`` — the
+            # single STATE owner), NOT here and NOT inside
+            # ``IndexCoordinator.ensure_built`` (an earlier revision put it
+            # there, which silently broke the §G2 heal contract:
+            # ``search_await`` calls ``ensure_built`` directly, for every
+            # OTHER registered source too, to heal a dirty/failed entry
+            # once its provider recovers — a blanket suppression inside
+            # ``ensure_built`` made that path permanently stuck). Both
+            # calls below are therefore UNCONDITIONAL here (no caller-side
+            # ``build_failed`` mirror) — the callee is the single AUTO-
+            # rebuild chokepoint that decides whether to actually attempt a
+            # build, so the calls resolve as a cheap no-op after a failure
+            # without this call site needing to know that.
             #
             # B25-S5-1: when eager flag is set, await the build synchronously
             # before computing _search_visible. This pays the build cost on
@@ -3542,12 +3543,37 @@ class RouterLoop:
         so a targeted ``mark_dirty`` forces ``ensure_built`` to actually
         invoke ``prepare_material`` (whose OWN cheap disk-adopt check then
         typically resolves in one file-stat, no embed call).
+
+        #1458 same-session AUTO-rebuild suppression (P2-convergence PR2,
+        #3270 §3, REVISED after a co-vet-caught regression): a co-vet round
+        found that enforcing this inside ``IndexCoordinator.ensure_built``
+        itself silently broke the §G2 heal contract for every OTHER
+        registered source — ``search_await`` calls ``ensure_built``
+        directly (not through this method) to heal a dirty/failed entry
+        once its provider recovers, and a blanket suppression there made a
+        dirty+failed source unhealable forever. ``ensure_built`` is
+        TRIGGER-AGNOSTIC; the suppression is enforced HERE instead — the
+        ONE chokepoint both the eager (``await_completion=True``) and
+        background (``await_completion=False``) AUTO-rebuild paths funnel
+        through (``RouterLoop.run()`` calls only this method for both).
+        Reads STATE from the Coordinator's ``build_failed(source_id)`` (the
+        single owner of that state — see ``coordinator.py``); this method
+        owns the POLICY decision to skip a further AUTO attempt once that
+        state is True, which is why the check lives here and not on the
+        Coordinator.
         """
         if getattr(idx, "is_ready", lambda: False)():
             return
 
         coordinator = self._get_index_coordinator()
         source_id = getattr(idx, "source_name", None) or "actions"
+
+        if coordinator.build_failed(source_id):
+            # #1458: a prior AUTO-rebuild attempt in this session already
+            # failed for this source — do not spawn another one. (This is
+            # the suppression POLICY seam; ``search_await``'s heal path
+            # does NOT go through this method, so it is unaffected.)
+            return
 
         if await coordinator.is_ready(source_id):
             await coordinator.mark_dirty(

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1312,16 +1312,23 @@ class RouterLoop:
             _provider = _provider_getter() if _provider_getter else None
             _model_class = _model_getter() if _model_getter else None
             _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
-            # #1458: skip both build paths when a prior attempt in this session
-            # failed (per-session failure memoization). P2-convergence PR2
-            # (#3270 §3): the memo lives solely in the Coordinator now (it is
-            # set inside ``IndexCoordinator._run_build``'s except-block on the
-            # SAME exception the production build raises — see
-            # ``coordinator.py``); there is no RouterLoop-instance flag any
-            # more.
-            _build_failed = self._get_index_coordinator().build_failed(
-                getattr(_idx, "source_name", None) or "actions"
-            )
+            # #1458: a prior build failure in this session must not spawn a
+            # retry. P2-convergence PR2 (#3270 §3, co-vet-driven root-fix):
+            # the SOLE suppression site is now inside
+            # ``IndexCoordinator.ensure_built`` (the ``_failure_memo``
+            # owner — see its docstring) — it no-ops a build attempt when
+            # ``build_failed(source_id)`` is already True, BEFORE invoking
+            # ``build_fn`` again. router_loop deliberately carries NO
+            # sibling ``build_failed``-gated condition on the two
+            # ``_ensure_action_index_built`` calls below: a caller-side
+            # mirror of the same check would make any regression in the
+            # Coordinator's own suppression invisible to a test that drives
+            # this call path (the exact wiring-hazard #3270 §3 exists to
+            # close) — see ``tests/test_action_embedding_build_failure_
+            # 1458.py``'s non-vacuity proof. Both calls below are therefore
+            # UNCONDITIONAL on failure state; after a failure they still
+            # execute but resolve as a cheap Coordinator-side no-op.
+            #
             # B25-S5-1: when eager flag is set, await the build synchronously
             # before computing _search_visible. This pays the build cost on
             # the first turn (= once per session; subsequent turns see
@@ -1333,7 +1340,6 @@ class RouterLoop:
                 and _provider is not None
                 and _model_class
                 and not getattr(_idx, "is_ready", lambda: False)()
-                and not _build_failed
             ):
                 await self._ensure_action_index_built(
                     _idx, _provider, _model_class, await_completion=True,
@@ -1348,15 +1354,15 @@ class RouterLoop:
             # build when the index is configured but not yet ready.  The
             # build is idempotent (= same catalog hash → no-op) and
             # serialised by the index's internal lock; once-per-source
-            # in-flight dedup is now IndexCoordinator's
-            # ``ensure_built_self_contained`` (``_bg_tasks``), not a
-            # RouterLoop instance flag.
+            # in-flight dedup is now IndexCoordinator's ``ensure_built``
+            # (``_bg_tasks``, P2-convergence PR1 eliminated the two-path
+            # ``ensure_built_self_contained`` this comment used to name),
+            # not a RouterLoop instance flag.
             if (
                 _idx is not None
                 and _provider is not None
                 and _model_class
                 and not getattr(_idx, "is_ready", lambda: False)()
-                and not _build_failed
             ):
                 await self._ensure_action_index_built(
                     _idx, _provider, _model_class, await_completion=False,

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -1294,12 +1294,14 @@ class RouterLoop:
         #
         # P2b: the eager-vs-background DECISION + once-per-chain spawn dedup
         # + failure-memo are now routed through ``IndexCoordinator`` (see
-        # ``_ensure_action_index_built`` / ``ensure_built_self_contained``)
-        # instead of the RouterLoop-instance-scoped ``_action_index_build_task``
-        # flag. ``_build_action_embedding_index_background`` itself (the
-        # actual build primitive: fetch catalog, call ``idx.build()``,
-        # handle failure — pinned by #1458's tests) is UNCHANGED; only its
-        # caller-side orchestration moved.
+        # ``_ensure_action_index_built`` / ``ensure_built``). P2-convergence
+        # PR2 (#3270 §3): the failure-memo is now SOLELY
+        # ``IndexCoordinator.build_failed(source_id)`` — the RouterLoop's own
+        # ``_action_index_build_failed`` flag (a twin, in-sync-by-convention
+        # signal) and the production-dead
+        # ``_build_action_embedding_index_background`` primitive (the flag's
+        # only setter) are both removed; production failure-tracking lives
+        # only in the Coordinator's ``_failure_memo``.
         _search_visible = False
         if _univ_enabled:
             _idx_getter = getattr(host, "get_action_embedding_index", None)
@@ -1311,9 +1313,15 @@ class RouterLoop:
             _model_class = _model_getter() if _model_getter else None
             _eager_embedding_build = bool(_eager_getter()) if _eager_getter else False
             # #1458: skip both build paths when a prior attempt in this session
-            # failed (per-session failure memoization). The failed flag is set
-            # in _build_action_embedding_index_background on any exception.
-            _build_failed = getattr(self, "_action_index_build_failed", False)
+            # failed (per-session failure memoization). P2-convergence PR2
+            # (#3270 §3): the memo lives solely in the Coordinator now (it is
+            # set inside ``IndexCoordinator._run_build``'s except-block on the
+            # SAME exception the production build raises — see
+            # ``coordinator.py``); there is no RouterLoop-instance flag any
+            # more.
+            _build_failed = self._get_index_coordinator().build_failed(
+                getattr(_idx, "source_name", None) or "actions"
+            )
             # B25-S5-1: when eager flag is set, await the build synchronously
             # before computing _search_visible. This pays the build cost on
             # the first turn (= once per session; subsequent turns see
@@ -3501,11 +3509,14 @@ class RouterLoop:
         background, since that is the one coroutine body either awaited
         inline or scheduled via ``asyncio.create_task``):
 
-        * ``on_error`` — #1458's failure-memoization
-          (``self._action_index_build_failed``) + the decision-enabling
-          warning log, kept in sync with the Coordinator's OWN
-          failure-memo (``build_failed()``), which is set on the SAME
-          exception one frame up in ``_run_build``'s own except-block.
+        * ``on_error`` — P2-convergence PR2 (#3270 §3): #1458's
+          decision-enabling warning log ONLY. The failure-memoization
+          itself is no longer duplicated on the RouterLoop instance — it
+          lives solely in the Coordinator's ``_failure_memo``
+          (``build_failed()``), set one frame up in ``_run_build``'s own
+          except-block BEFORE this callback runs, so by the time
+          ``on_error`` fires the memo is already the single source of
+          truth.
         * ``on_success`` — syncs ``idx``'s in-memory
           ``is_ready()``/``size()``/``catalog_hash()`` gate
           (``ActionEmbeddingIndex.adopt_build_result``) after a REAL
@@ -3548,8 +3559,10 @@ class RouterLoop:
             return await idx.prepare_material(items, op_ctx, model_class)
 
         def _on_error(exc: BaseException) -> None:
-            # #1458: memoize the failure so subsequent turns do not retry.
-            self._action_index_build_failed = True
+            # #1458: decision-enabling warning log. Failure memoization
+            # itself is the Coordinator's ``_failure_memo`` (set already,
+            # one frame up in ``_run_build``'s except-block) — see the
+            # docstring above.
             import logging
 
             logging.getLogger(__name__).warning(
@@ -3576,95 +3589,6 @@ class RouterLoop:
             on_error=_on_error,
             on_success=_on_success,
         )
-
-    async def _build_action_embedding_index_background(
-        self, idx: Any, provider: Any, model_class: str,
-    ) -> None:
-        """FP-0034 Phase 2 step 1: background ActionEmbeddingIndex build.
-
-        Enumerates the catalog via ``LIST_ACTIONS`` against a fresh
-        ``RouterCallerState`` snapshot (``_fetch_action_catalog_items``)
-        and feeds the items into ``idx.build()``.  The build is idempotent
-        (= same catalog hash skipped).
-
-        P2-convergence PR1 (#3270 §2): this primitive is UNCHANGED (still
-        drives ``idx.build()`` — the full embed+write, now lock-free — end
-        to end and swallows/memoizes its own failure) and is kept for
-        direct/standalone callers, principally its own #1458 unit tests
-        (``tests/test_action_embedding_build_failure_1458.py``). The
-        PRODUCTION action-catalog build no longer routes through this
-        method — ``RouterLoop._ensure_action_index_built`` now calls
-        ``ActionEmbeddingIndex.prepare_material`` directly via the
-        Coordinator's ``ensure_built``, so the Coordinator (not ``idx``)
-        performs the write. Both shapes drive the exact same
-        ``ActionEmbeddingIndex`` build machinery underneath
-        (``prepare_material`` + ``embed_verify_write``); this method's own
-        failure-handling/logging contract (below) stays independently
-        exercised as a regression pin on that machinery.
-
-        ``provider`` is retained as the caller's pre-existing "embedding
-        configured" signal (callers gate on ``provider is not None`` before
-        spawning this background build) but is no longer passed to
-        ``idx.build()`` — FP-0057 #2856 Part A routes the actual embed call
-        through ``execute_op(EmbedIROp(...), op_ctx)`` (see
-        ``ActionEmbeddingIndex._embed_via_op``), so ``idx.build()`` now takes
-        an ``OpContext`` (built the same way as the other router op-ctx call
-        sites: ``self.host.make_router_op_context()``).
-
-        Errors are swallowed, flagged on the RouterLoop instance, and surfaced
-        as an operator-visible warning log so a misconfigured embedding provider
-        does not crash the chat session — the next turn finds ``is_ready()``
-        False and keeps ``search_actions`` hidden.
-
-        #1458: on failure, ``_action_index_build_failed`` is set to True so
-        neither the eager nor the background-task path retries within this
-        session (per-session once-only memoization). Cross-session persistence
-        is intentionally not implemented (YAGNI: one retry per new session with
-        a clear log is an acceptable cost, and the session boundary is a natural
-        cache-invalidation point for e.g. a model-download that was retried on a
-        reconnected machine).
-        """
-        try:
-            items = await self._fetch_action_catalog_items()
-            if items is None:
-                return
-            op_ctx = self.host.make_router_op_context()
-            await idx.build(items, op_ctx, model_class)
-        except Exception as exc:
-            # #1458: memoize the failure so subsequent turns do not retry.
-            # FP-0066 P2d/#3247 convergence-debt (co-vet, pre-merge): this
-            # flag and the Coordinator's own failure-memo
-            # (``IndexCoordinator._failure_memo`` / ``build_failed()``) are
-            # BOTH set on this same exception today (byte-identical two-path
-            # retention from P2b) — keep them in sync until the #3247
-            # convergence follow-up unifies failure-state into one signal.
-            # A future edit to only ONE of the two paths silently desyncs
-            # them; see the interim guard pin
-            # ``test_action_index_build_failure_both_signals_stay_in_sync``
-            # in ``tests/test_index_coordinator_3247_p2d.py``.
-            self._action_index_build_failed = True
-            # FP-0066 P2d (#3247): the audit-event for this failure used to
-            # be emitted HERE directly (``action_index_build_failed``).
-            # It is now folded into ``embedding_index_build_error``,
-            # emitted by ``IndexCoordinator.ensure_built_self_contained``
-            # (this method's only production caller routes through it via
-            # ``_ensure_action_index_built``'s ``_build_coro`` wrapper,
-            # which re-raises on this exact failure so the Coordinator's
-            # except-block observes it) — see ``coordinator.py``. Emitting
-            # both here AND there would double-emit for the same failure.
-            # #1458: decision-enabling operator warning — names the likely
-            # cause + three actionable outs, same family as the
-            # ``_build_embedding_config`` / ``_validate_retrieval_scheme_embedding``
-            # config-load messages so the operator surface is consistent.
-            import logging
-
-            # #1616: cause-aware guidance (UnsupportedParamsError → proxy-side
-            # drop_params; else the HF-download case). Extracted to a unit-testable
-            # module helper so the cause-selection is pinned without driving the
-            # whole index build.
-            logging.getLogger(__name__).warning(
-                "%s", _action_index_build_failure_warning(exc, model_class)
-            )
 
     async def _build_router_caller_state(self) -> Any:
         """Build a RouterCallerState populated with bound callbacks.

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -1,166 +1,222 @@
 """Tier 2: #1458 — per-session build-failure memoization + decision-enabling log.
 
-When the action embedding index build fails (e.g. the embedding API is
-unreachable), ``RouterLoop._build_action_embedding_index_background``
-memoizes the failure via ``_action_index_build_failed`` so neither the eager
-path nor the background-task path retries within the same RouterLoop
-session.  A decision-enabling warning log is emitted exactly once with
-actionable options (check provider config / null class / different API
-class).
+P2-convergence PR2 (#3270 §3, migrating the PR2 commitment carried from
+PR1's co-vet): this file used to drive
+``RouterLoop._build_action_embedding_index_background`` directly — a
+primitive PR1 (#3270 §2) made production-dead (its only caller after PR1's
+Coordinator-routing was this test). That primitive is now DELETED; this
+file is rewritten to drive the SAME retry-semantics invariant against the
+PRODUCTION path instead — ``RouterLoop._ensure_action_index_built``, which
+registers a ``BuildFn`` with the real ``IndexCoordinator`` and calls
+``ensure_built`` (exactly what a live chat turn does). The invariant is
+UNCHANGED: a build failure is memoized so a fresh coordinator/session
+attempts the build exactly ONCE, and the production retry-guard (checked
+by the caller BEFORE invoking the build again, mirroring
+``RouterLoop.run()``'s own gate) suppresses any further attempt within the
+same session. Failure-state now lives SOLELY in
+``IndexCoordinator.build_failed(source_id)`` (#3270 §3 single-owner
+collapse) — there is no more RouterLoop-instance-scoped flag to read.
 
-No mocks.  The build path is exercised via a real ``RouterLoop`` instance whose
-``_build_router_caller_state`` is shimmed by subclassing; the embedding provider
-raises a real ``RuntimeError`` to trigger the failure path.
+No mocks. The build path is exercised via a real ``RouterLoop`` subclass
+(minimal-subclass shim for ``_build_router_caller_state`` /
+``_get_index_coordinator`` — same convention as
+``tests/test_index_coordinator_3247_p2b.py`` /
+``tests/test_index_coordinator_3247_p2d.py``) driving a REAL
+``IndexCoordinator`` + a REAL ``ActionEmbeddingIndex`` against a real
+(monkeypatched-provider) ``embed`` op; the fake embedding provider raises a
+real ``RuntimeError`` to trigger the failure path — non-vacuity: since the
+failure now flows through ``embed_verify_write`` (not a bespoke
+``idx.build()`` call), these tests would go RED if the Coordinator's
+same-session suppression (``build_failed``) were neutered, because the
+retry-guarded second call would re-invoke the provider and the call-count
+assertion would fail.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from typing import Any
 
-from reyn.runtime.router_loop import RouterLoop
+import pytest
 
-# ── Minimal RouterLoop subclass that makes _build_action_embedding_index_background
-# directly invokable without a full host/chain setup. ────────────────────────────
+from reyn.core.events.events import EventLog
+from reyn.core.op_runtime.context import OpContext
+from reyn.data.index.coordinator import IndexCoordinator
+from reyn.data.workspace.workspace import Workspace
+from reyn.runtime.router_loop import RouterLoop
+from reyn.security.permissions.permissions import PermissionDecl
+from reyn.tools.action_index import ActionEmbeddingIndex
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.run(coro)
 
 
 class _FailingProvider:
     """Real fake provider that always raises (simulates the embedding API
-    being unreachable).  No Mock / AsyncMock — pure subclass fake per policy."""
+    being unreachable) and counts its own calls — the non-vacuity witness:
+    a retry would show up as a second call. No Mock/AsyncMock per policy."""
 
-    async def embed(self, *_args, **_kwargs):  # type: ignore[override]
+    def __init__(self) -> None:
+        self.embed_calls = 0
+
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        self.embed_calls += 1
         raise RuntimeError("Name or service not known (embedding API unreachable)")
 
-    def get_dimension(self, *_args, **_kwargs) -> int:
-        raise RuntimeError("Name or service not known (embedding API unreachable)")
+
+class _UnsupportedParamsError(Exception):
+    """Real fake mirroring litellm's UnsupportedParamsError TYPENAME (the
+    helper keys on the type name, not the class identity). No Mock per
+    policy."""
 
 
-class _FailingIndex:
-    """Real fake index whose build() method raises."""
+class _UnsupportedParamProvider:
+    """Real fake provider whose embed() raises the proxy-rejects-param
+    error — the #1616 gemini-via-LiteLLM-proxy case (encoding_format
+    rejected)."""
 
-    def __init__(self) -> None:
-        self.build_calls = 0
-
-    def is_ready(self) -> bool:
-        return False
-
-    async def build(self, *_args, **_kwargs):  # type: ignore[override]
-        self.build_calls += 1
-        raise RuntimeError("Index build failed — provider error")
+    async def embed(self, texts: list[str], model: str) -> dict[str, Any]:
+        raise _UnsupportedParamsError(
+            "litellm.UnsupportedParamsError: gemini-embedding-001 does not "
+            "support parameter: encoding_format"
+        )
 
 
-class _MinimalEvents:
-    """Minimal events sink; records emitted events."""
+def _op_ctx_for(provider: Any, monkeypatch: pytest.MonkeyPatch, events: EventLog) -> OpContext:
+    """Real OpContext whose `embed` op resolves to ``provider`` (mirrors
+    ``tests/test_index_coordinator_3247_p2b.py``/``_p2d.py``'s
+    ``_op_ctx_for``)."""
+    import reyn.core.op_runtime.embed as _embed_mod
 
-    def __init__(self) -> None:
-        self.emitted: list[dict] = []
-
-    def emit(self, kind: str, **kwargs) -> None:
-        self.emitted.append({"kind": kind, **kwargs})
+    monkeypatch.setattr(_embed_mod, "get_provider", lambda *a, **kw: provider)
+    ws = Workspace(events=events)
+    return OpContext(workspace=ws, events=events, permission_decl=PermissionDecl())
 
 
-class _MinimalHost:
-    def __init__(self) -> None:
-        self.events = _MinimalEvents()
-        # FP-0057 #2856 Part A: _build_action_embedding_index_background now
-        # builds an OpContext via ``host.make_router_op_context()`` and passes
-        # THAT (not the raw provider) as idx.build()'s second positional arg
-        # (idx.build() itself now routes the embed call through the shared
-        # `embed` op). These tests' fake indexes still reach into that
-        # second arg expecting the fake provider (to trigger the SAME
-        # provider-raised exception the production embed op would surface),
-        # so this stub just returns whatever provider the test stashed here.
-        self.op_ctx_stub: Any = None
+class _StubEvents(EventLog):
+    """A real EventLog — production audit-emit is exercised; nothing
+    special is asserted about its contents here (that is P2d's job)."""
+
+
+class _StubHost:
+    """Minimal host — only what ``RouterLoop._ensure_action_index_built`` /
+    ``_fetch_action_catalog_items`` touch."""
+
+    def __init__(self, op_ctx: Any, events: EventLog) -> None:
+        self.events = events
+        self.op_ctx_stub = op_ctx
 
     def make_router_op_context(self) -> Any:
         return self.op_ctx_stub
 
 
 class _LoopWithFailingBuild(RouterLoop):
-    """RouterLoop subclass whose _build_router_caller_state returns a minimal
-    state just sufficient for the build method (which only needs events).
-    The embedding index build is triggered via a real _FailingIndex provider."""
+    """RouterLoop subclass exercising the production
+    ``_ensure_action_index_built`` orchestration without a full
+    host/chain/session setup — same minimal-subclass pattern as
+    ``tests/test_index_coordinator_3247_p2b.py``'s ``_LoopForP2b``."""
 
-    def __init__(self) -> None:
-        # Skip the real __init__; we only need the method under test.
-        self.host = _MinimalHost()  # type: ignore[assignment]
+    def __init__(self, workspace_root: Path, op_ctx: Any, events: EventLog) -> None:
+        self.host = _StubHost(op_ctx, events)  # type: ignore[assignment]
         self.chain_id = "test-chain"
+        self._workspace_root_for_test = workspace_root
 
     async def _build_router_caller_state(self) -> None:  # type: ignore[override]
         return None  # list_actions handler is not reached; provider raises first
 
+    def _get_index_coordinator(self) -> IndexCoordinator:
+        # Deterministic per-test coordinator instance (bypasses the module
+        # singleton so tests don't leak state across each other) — same
+        # convention as ``_LoopForP2b``/``_LoopForP2d``.
+        if not hasattr(self, "_test_coordinator"):
+            self._test_coordinator = IndexCoordinator(self._workspace_root_for_test)
+        return self._test_coordinator
 
-def _run_build(loop: _LoopWithFailingBuild, idx: "_FailingIndex | None" = None) -> "_FailingIndex":
-    idx = idx if idx is not None else _FailingIndex()
-    provider = _FailingProvider()
-    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
-    asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
-    return idx
+
+def _build_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, provider: Any,
+) -> tuple[_LoopWithFailingBuild, ActionEmbeddingIndex, IndexCoordinator]:
+    events = _StubEvents()
+    op_ctx = _op_ctx_for(provider, monkeypatch, events)
+    idx = ActionEmbeddingIndex(workspace_root=tmp_path)
+    loop = _LoopWithFailingBuild(tmp_path, op_ctx, events)
+    coordinator = loop._get_index_coordinator()
+    _run(loop._ensure_action_index_built(idx, provider, "standard", await_completion=True))
+    return loop, idx, coordinator
 
 
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 
-def test_build_failure_prevents_retry_same_session() -> None:
-    """Tier 2: #1458 — after a build failure the memoization flag is set, so a
-    second call that checks the flag (as the production guard does) does not
-    re-invoke the build. Observable via ``idx.build_calls``: a retry would
-    invoke ``idx.build()`` a second time; no retry → count stays at 1.
-
-    (FP-0066 P2d, #3247: this used to be observed via the
-    ``action_index_build_failed`` audit-event count. That event is no longer
-    emitted from this primitive — see ``test_build_failure_no_audit_event_
-    emitted_here`` — folded into ``embedding_index_build_error``, emitted by
-    ``IndexCoordinator`` one layer up. ``idx.build_calls`` is the public
-    observable this test needs and does not depend on that.)"""
-    loop = _LoopWithFailingBuild()
-    idx = _FailingIndex()
-    _run_build(loop, idx)
-    assert idx.build_calls == 1
-    # Simulate the production guard: only call again if the flag is NOT set.
-    if not getattr(loop, "_action_index_build_failed", False):
-        _run_build(loop, idx)
-    # Count must be unchanged — the guard prevented the retry.
-    assert idx.build_calls == 1
-
-
-def test_build_failure_no_audit_event_emitted_here() -> None:
-    """Tier 2: FP-0066 P2d (#3247 firm §6) — the pre-P2d
-    ``action_index_build_failed`` audit-event, previously emitted directly
-    by ``_build_action_embedding_index_background`` on failure, is FOLDED
-    into ``embedding_index_build_error`` emitted by
-    ``IndexCoordinator.ensure_built_self_contained`` one layer up (see
-    ``tests/test_index_coordinator_3247_p2d.py``). This low-level primitive,
-    called directly (bypassing the Coordinator, as this test file does),
-    now emits NO audit-event at all — a double-emit would occur if both
-    layers still emitted for the same failure."""
-    loop = _LoopWithFailingBuild()
-    _run_build(loop)
-    kinds = [e["kind"] for e in loop.host.events.emitted]
-    assert "action_index_build_failed" not in kinds
-    assert kinds == [], f"expected no audit-event emit from this primitive, got {kinds!r}"
-
-
-def test_build_failure_search_stays_hidden() -> None:
-    """Tier 2: #1458 — after a build failure, is_ready() on the fake index stays
-    False, which is the gate that keeps _search_visible False in RouterLoop.run().
-    Regression pin: the failure must not accidentally flip search to visible."""
-    idx = _FailingIndex()
-    assert idx.is_ready() is False
+def test_fresh_session_attempts_build_exactly_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #1458 — a fresh coordinator/session attempts the build
+    exactly once on a failure, and the Coordinator's failure-memo
+    (single-owner, P2-convergence PR2 #3270 §3) is set as a result.
+    Observable via ``provider.embed_calls`` (the real production embed op
+    call, driven through ``ensure_built``'s ``embed_verify_write``) — a
+    silent double-attempt would show up as ``embed_calls == 2``."""
     provider = _FailingProvider()
-    loop = _LoopWithFailingBuild()
-    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
-    asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
-    # is_ready() still False after failure — search stays hidden.
+    loop, idx, coordinator = _build_once(tmp_path, monkeypatch, provider)
+
+    assert provider.embed_calls == 1
+    assert idx.is_ready() is False
+    assert coordinator.build_failed("actions") is True
+    assert not hasattr(loop, "_action_index_build_failed"), (
+        "the retired twin RouterLoop-side flag must not exist"
+    )
+
+
+def test_same_session_retry_suppressed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #1458 — the production retry guard (``RouterLoop.run()``'s
+    own gate, mirrored here as the caller checking
+    ``coordinator.build_failed(source_id)`` before invoking the build
+    again) prevents a second attempt within the same session. Observable
+    via ``provider.embed_calls`` staying at 1 — a retry would drive a
+    second real ``embed`` op call and this assertion would go RED (the
+    non-vacuity witness: this test fails if the same-session suppression
+    is removed)."""
+    provider = _FailingProvider()
+    loop, idx, coordinator = _build_once(tmp_path, monkeypatch, provider)
+    assert provider.embed_calls == 1
+
+    # Production retry guard (mirrors RouterLoop.run()'s own gate at the
+    # eager/background decision points): do NOT call again once the
+    # Coordinator's failure-memo is set.
+    if not coordinator.build_failed("actions"):
+        _run(loop._ensure_action_index_built(
+            idx, provider, "standard", await_completion=True,
+        ))
+
+    assert provider.embed_calls == 1, "memoized failure must prevent a retry"
     assert idx.is_ready() is False
 
 
-def test_warning_log_emitted_once_with_options(caplog) -> None:
-    """Tier 2: #1458 — a decision-enabling warning log is emitted exactly once
-    on failure; it mentions the three actionable options."""
-    loop = _LoopWithFailingBuild()
+def test_build_failure_search_stays_hidden(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tier 2: #1458 — after a build failure, ``is_ready()`` on the real
+    index stays False, which is the gate that keeps ``_search_visible``
+    False in ``RouterLoop.run()``. Regression pin: the failure must not
+    accidentally flip search to visible."""
+    provider = _FailingProvider()
+    _loop, idx, _coordinator = _build_once(tmp_path, monkeypatch, provider)
+    assert idx.is_ready() is False
+
+
+def test_warning_log_emitted_once_with_options(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """Tier 2: #1458 — a decision-enabling warning log is emitted exactly
+    once on failure; it mentions the three actionable options."""
+    provider = _FailingProvider()
     with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
-        _run_build(loop)
+        _build_once(tmp_path, monkeypatch, provider)
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert warnings, "expected at least one WARNING log on build failure"
@@ -175,39 +231,26 @@ def test_warning_log_emitted_once_with_options(caplog) -> None:
     )
 
 
+def test_build_failure_unsupported_param_warns_proxy_fix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """Tier 2: #1616 — driving the real production build path with a
+    provider that raises the proxy-rejects-param error logs the proxy
+    drop_params guidance (the operator is NOT left with a silent empty
+    index nor the misleading HF message)."""
+    provider = _UnsupportedParamProvider()
+    with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
+        _build_once(tmp_path, monkeypatch, provider)
+
+    text = " ".join(
+        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
+    ).lower()
+    assert "drop_params" in text and "proxy" in text, (
+        f"expected proxy drop_params guidance; got: {text!r}"
+    )
+
+
 # ── #1616: cause-aware guidance — UnsupportedParamsError vs HF-download ──────────
-
-
-class _UnsupportedParamsError(Exception):
-    """Real fake mirroring litellm's UnsupportedParamsError TYPENAME (the helper
-    keys on the type name, not the class identity). No Mock per policy."""
-
-
-class _UnsupportedParamProvider:
-    """Real fake provider whose embed() raises the proxy-rejects-param error —
-    the #1616 gemini-via-LiteLLM-proxy case (encoding_format rejected)."""
-
-    async def embed(self, *_args, **_kwargs):  # type: ignore[override]
-        raise _UnsupportedParamsError(
-            "litellm.UnsupportedParamsError: gemini-embedding-001 does not support "
-            "parameter: encoding_format"
-        )
-
-    def get_dimension(self, *_args, **_kwargs) -> int:
-        raise _UnsupportedParamsError("does not support parameter: encoding_format")
-
-
-class _UnsupportedParamIndex:
-    """Real fake index whose build() surfaces the provider's UnsupportedParamsError
-    (mirrors ActionEmbeddingIndex.build propagating the embed() exception)."""
-
-    def is_ready(self) -> bool:
-        return False
-
-    async def build(self, items, provider, model_class):  # type: ignore[override]
-        # Drive the real embed() so the genuine provider exception propagates,
-        # exactly as the production build path does (idx.build(items, provider, model_class)).
-        await provider.embed(items)
 
 
 def test_helper_unsupported_param_points_to_proxy_drop_params() -> None:
@@ -239,22 +282,3 @@ def test_helper_generic_failure_keeps_config_guidance() -> None:
     msg = _action_index_build_failure_warning(exc, "standard").lower()
     assert "embedding.classes" in msg or "provider config" in msg
     assert "drop_params" not in msg
-
-
-def test_build_failure_unsupported_param_warns_proxy_fix(caplog) -> None:
-    """Tier 2: #1616 — driving the real build path with a provider that raises the
-    proxy-rejects-param error logs the proxy drop_params guidance (the operator is
-    NOT left with a silent empty index nor the misleading HF message)."""
-    loop = _LoopWithFailingBuild()
-    idx = _UnsupportedParamIndex()
-    provider = _UnsupportedParamProvider()
-    loop.host.op_ctx_stub = provider  # see _MinimalHost.make_router_op_context
-    with caplog.at_level(logging.WARNING, logger="reyn.runtime.router_loop"):
-        asyncio.run(loop._build_action_embedding_index_background(idx, provider, "standard"))
-
-    text = " ".join(
-        r.getMessage() for r in caplog.records if r.levelno == logging.WARNING
-    ).lower()
-    assert "drop_params" in text and "proxy" in text, (
-        f"expected proxy drop_params guidance; got: {text!r}"
-    )

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -17,6 +17,22 @@ same session. Failure-state now lives SOLELY in
 ``IndexCoordinator.build_failed(source_id)`` (#3270 §3 single-owner
 collapse) — there is no more RouterLoop-instance-scoped flag to read.
 
+The same-session suppression itself lives at ``RouterLoop.
+_ensure_action_index_built``'s own entry (checked BEFORE it ever calls
+``coordinator.ensure_built``) — NOT inside ``IndexCoordinator.ensure_built``.
+An earlier revision of this migration put the suppression inside
+``ensure_built``, which co-vet caught as a regression: ``IndexCoordinator.
+search_await`` calls ``ensure_built`` directly (bypassing
+``_ensure_action_index_built`` entirely) to heal ANY dirty/failed source
+once its provider recovers, so a blanket suppression inside ``ensure_built``
+would have made a dirty+failed source unhealable forever for every OTHER
+registered source (skill/memory/repo), not just the action-catalog.
+``ensure_built`` is TRIGGER-AGNOSTIC; ``_ensure_action_index_built`` is the
+ONE AUTO-rebuild chokepoint (both eager and background paths in
+``RouterLoop.run()`` funnel through it) that owns the #1458 "at most one
+AUTO attempt per session" POLICY, reading STATE from ``IndexCoordinator.
+build_failed(source_id)`` (the single state owner).
+
 No mocks. The build path is exercised via a real ``RouterLoop`` subclass
 (minimal-subclass shim for ``_build_router_caller_state`` /
 ``_get_index_coordinator`` — same convention as
@@ -26,10 +42,10 @@ No mocks. The build path is exercised via a real ``RouterLoop`` subclass
 (monkeypatched-provider) ``embed`` op; the fake embedding provider raises a
 real ``RuntimeError`` to trigger the failure path — non-vacuity: since the
 failure now flows through ``embed_verify_write`` (not a bespoke
-``idx.build()`` call), these tests would go RED if the Coordinator's
-same-session suppression (``build_failed``) were neutered, because the
-retry-guarded second call would re-invoke the provider and the call-count
-assertion would fail.
+``idx.build()`` call), these tests would go RED if
+``_ensure_action_index_built``'s same-session suppression were neutered,
+because the unconditionally-repeated second call would re-invoke the
+provider and the call-count assertion would fail.
 """
 from __future__ import annotations
 
@@ -177,15 +193,19 @@ def test_same_session_retry_suppressed(
     mirrored: this test calls ``_ensure_action_index_built``
     UNCONDITIONALLY a second time (no caller-side "check
     ``build_failed`` first" guard) and asserts the retry is suppressed —
-    the suppression itself is enforced by ``IndexCoordinator.ensure_built``
-    (the ``_failure_memo`` owner, P2-convergence PR2 #3270 §3), not by
-    this test's own logic. Observable via ``provider.embed_calls`` staying
-    at 1 after the second call — a retry would drive a second real
-    ``embed`` op call. Non-vacuity: strip ``ensure_built``'s
-    ``build_failed(source_id)`` early-return (coordinator.py) and THIS
-    assertion goes RED (``embed_calls == 2``), because the second call
-    would then run ``build_fn`` again — see the PR body for the recorded
-    RED-when-neutered proof."""
+    the suppression itself is enforced by ``_ensure_action_index_built``'s
+    OWN entry check against ``IndexCoordinator.build_failed()`` (the
+    single state owner, P2-convergence PR2 #3270 §3 — REVISED: an earlier
+    revision put this suppression inside ``ensure_built`` itself, which
+    co-vet caught as a regression against the §G2 heal contract; see
+    ``coordinator.py``'s ``ensure_built``/module docstrings), not by this
+    test's own logic. Observable via ``provider.embed_calls`` staying at 1
+    after the second call — a retry would drive a second real ``embed`` op
+    call. Non-vacuity: strip ``_ensure_action_index_built``'s
+    ``coordinator.build_failed(source_id)`` early-return (router_loop.py)
+    and THIS assertion goes RED (``embed_calls == 2``), because the second
+    call would then run ``build_fn`` again — see the PR body for the
+    recorded RED-when-neutered proof."""
     provider = _FailingProvider()
     loop, idx, coordinator = _build_once(tmp_path, monkeypatch, provider)
     assert provider.embed_calls == 1

--- a/tests/test_action_embedding_build_failure_1458.py
+++ b/tests/test_action_embedding_build_failure_1458.py
@@ -173,25 +173,30 @@ def test_fresh_session_attempts_build_exactly_once(
 def test_same_session_retry_suppressed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: #1458 — the production retry guard (``RouterLoop.run()``'s
-    own gate, mirrored here as the caller checking
-    ``coordinator.build_failed(source_id)`` before invoking the build
-    again) prevents a second attempt within the same session. Observable
-    via ``provider.embed_calls`` staying at 1 — a retry would drive a
-    second real ``embed`` op call and this assertion would go RED (the
-    non-vacuity witness: this test fails if the same-session suppression
-    is removed)."""
+    """Tier 2: #1458 — same-session retry suppression is DRIVEN, not
+    mirrored: this test calls ``_ensure_action_index_built``
+    UNCONDITIONALLY a second time (no caller-side "check
+    ``build_failed`` first" guard) and asserts the retry is suppressed —
+    the suppression itself is enforced by ``IndexCoordinator.ensure_built``
+    (the ``_failure_memo`` owner, P2-convergence PR2 #3270 §3), not by
+    this test's own logic. Observable via ``provider.embed_calls`` staying
+    at 1 after the second call — a retry would drive a second real
+    ``embed`` op call. Non-vacuity: strip ``ensure_built``'s
+    ``build_failed(source_id)`` early-return (coordinator.py) and THIS
+    assertion goes RED (``embed_calls == 2``), because the second call
+    would then run ``build_fn`` again — see the PR body for the recorded
+    RED-when-neutered proof."""
     provider = _FailingProvider()
     loop, idx, coordinator = _build_once(tmp_path, monkeypatch, provider)
     assert provider.embed_calls == 1
+    assert coordinator.build_failed("actions") is True
 
-    # Production retry guard (mirrors RouterLoop.run()'s own gate at the
-    # eager/background decision points): do NOT call again once the
-    # Coordinator's failure-memo is set.
-    if not coordinator.build_failed("actions"):
-        _run(loop._ensure_action_index_built(
-            idx, provider, "standard", await_completion=True,
-        ))
+    # Call again UNCONDITIONALLY — no caller-side guard. The suppression
+    # must come from ``ensure_built`` itself for this to be a genuine
+    # (non-vacuous) drive of the production mechanism.
+    _run(loop._ensure_action_index_built(
+        idx, provider, "standard", await_completion=True,
+    ))
 
     assert provider.embed_calls == 1, "memoized failure must prevent a retry"
     assert idx.is_ready() is False

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -317,9 +317,12 @@ def test_build_failure_memoized_not_reattempted(
 ) -> None:
     """Tier 2: equivalence case 4 — a build failure is memoized SOLELY on
     the Coordinator's own failure-memo (``build_failed``, P2-convergence
-    PR2 (#3270 §3) — the twin RouterLoop-side flag is retired) — and the
-    production retry guard (checked by the caller before invoking again)
-    prevents a second attempt."""
+    PR2 #3270 §3 — the twin RouterLoop-side flag is retired), and
+    ``ensure_built`` itself (the memo's owner) suppresses a retry — DRIVEN,
+    not mirrored: this test calls ``_ensure_action_index_built``
+    UNCONDITIONALLY a second time (no caller-side ``if not build_failed``
+    guard, which would make the assertion pass regardless of whether the
+    Coordinator's own suppression works)."""
     ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex(should_fail=True)
@@ -332,12 +335,12 @@ def test_build_failure_memoized_not_reattempted(
         "the twin RouterLoop-side flag must no longer exist (P2-convergence PR2)"
     )
 
-    # Production retry guard (mirrors RouterLoop.run()'s own gate): do NOT
-    # call again once the Coordinator's failure-memo is set.
-    if not coordinator.build_failed("actions"):
-        _run(loop._ensure_action_index_built(
-            idx, "provider", "standard", await_completion=True,
-        ))
+    # Call again UNCONDITIONALLY — the suppression must come from
+    # ``ensure_built`` itself, not from this test remembering to check
+    # ``build_failed`` first.
+    _run(loop._ensure_action_index_built(
+        idx, "provider", "standard", await_completion=True,
+    ))
     assert idx.prepare_calls == 1, "memoized failure must prevent a retry"
 
 

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -317,12 +317,17 @@ def test_build_failure_memoized_not_reattempted(
 ) -> None:
     """Tier 2: equivalence case 4 — a build failure is memoized SOLELY on
     the Coordinator's own failure-memo (``build_failed``, P2-convergence
-    PR2 #3270 §3 — the twin RouterLoop-side flag is retired), and
-    ``ensure_built`` itself (the memo's owner) suppresses a retry — DRIVEN,
-    not mirrored: this test calls ``_ensure_action_index_built``
-    UNCONDITIONALLY a second time (no caller-side ``if not build_failed``
-    guard, which would make the assertion pass regardless of whether the
-    Coordinator's own suppression works)."""
+    PR2 #3270 §3 — the twin RouterLoop-side flag is retired). The retry
+    itself is suppressed at ``_ensure_action_index_built``'s own entry
+    (the AUTO-rebuild chokepoint), NOT inside ``IndexCoordinator.
+    ensure_built`` — a co-vet-caught regression: ``ensure_built`` must
+    stay trigger-agnostic so ``search_await``'s heal path (which calls
+    ``ensure_built`` directly, for every source) is never suppressed by
+    the action-catalog's #1458 policy. DRIVEN, not mirrored: this test
+    calls ``_ensure_action_index_built`` UNCONDITIONALLY a second time (no
+    caller-side ``if not build_failed`` guard, which would make the
+    assertion pass regardless of whether the production suppression
+    works)."""
     ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex(should_fail=True)

--- a/tests/test_index_coordinator_3247_p2b.py
+++ b/tests/test_index_coordinator_3247_p2b.py
@@ -315,24 +315,26 @@ def test_disk_adopt_hit_skips_rebuild(tmp_path: Path, monkeypatch: pytest.Monkey
 def test_build_failure_memoized_not_reattempted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Tier 2: equivalence case 4 — a build failure is memoized on BOTH the
-    RouterLoop-side flag (#1458, unchanged) AND the Coordinator's own
-    failure-memo (``build_failed``) — and the production retry guard
-    (checked by the caller before invoking again) prevents a second
-    attempt."""
+    """Tier 2: equivalence case 4 — a build failure is memoized SOLELY on
+    the Coordinator's own failure-memo (``build_failed``, P2-convergence
+    PR2 (#3270 §3) — the twin RouterLoop-side flag is retired) — and the
+    production retry guard (checked by the caller before invoking again)
+    prevents a second attempt."""
     ctx = _op_ctx_for(_FakeEmbeddingProvider(), monkeypatch)
     loop = _LoopForP2b(tmp_path, ctx)
     idx = _FakeActionIndex(should_fail=True)
 
     _run(loop._ensure_action_index_built(idx, "provider", "standard", await_completion=True))
     assert idx.prepare_calls == 1
-    assert getattr(loop, "_action_index_build_failed", False) is True
     coordinator = loop._get_index_coordinator()
     assert coordinator.build_failed("actions") is True
+    assert not hasattr(loop, "_action_index_build_failed"), (
+        "the twin RouterLoop-side flag must no longer exist (P2-convergence PR2)"
+    )
 
     # Production retry guard (mirrors RouterLoop.run()'s own gate): do NOT
-    # call again once the failure flag is set.
-    if not getattr(loop, "_action_index_build_failed", False):
+    # call again once the Coordinator's failure-memo is set.
+    if not coordinator.build_failed("actions"):
         _run(loop._ensure_action_index_built(
             idx, "provider", "standard", await_completion=True,
         ))

--- a/tests/test_index_coordinator_3247_p2d.py
+++ b/tests/test_index_coordinator_3247_p2d.py
@@ -15,8 +15,9 @@ Covers:
   2. A build failure emits ``embedding_index_build_error`` (with a
      ``reason``).
   3. The pre-P2d ``action_index_build_failed`` event (previously emitted
-     directly by ``RouterLoop._build_action_embedding_index_background``)
-     no longer double-emits alongside its fold target,
+     directly by the now-deleted ``RouterLoop.
+     _build_action_embedding_index_background``, P2-convergence PR2,
+     #3270 §3) no longer double-emits alongside its fold target,
      ``embedding_index_build_error`` — see also the updated pins in
      ``test_action_embedding_build_failure_1458.py`` and
      ``test_index_coordinator_3247_p2b.py``.
@@ -38,8 +39,15 @@ shapes" + the freestanding ``_FakeSelfContainedBuilder`` tests) is REMOVED
 ``tests/test_index_coordinator_3247_p2b.py`` (the equivalence suite +
 mandatory #3270 §5 strip-falsify gates), which exercises the SAME
 production call path (``RouterLoop._ensure_action_index_built``) this file
-already tests at §3's ``test_action_index_build_failure_both_signals_
-stay_in_sync``.
+already tests.
+
+P2-convergence PR2 (#3270 §3): the interim dual-sync pin (formerly §3's
+``test_action_index_build_failure_both_signals_stay_in_sync``) is RETIRED
+and replaced by
+``test_action_index_build_failure_is_single_sourced_on_coordinator`` — the
+twin RouterLoop-side ``_action_index_build_failed`` flag is removed
+entirely, so failure-state has a single owner (the Coordinator's
+``_failure_memo``/``build_failed()``).
 
 No mocks — real ``IndexCoordinator``, real ``SourceManifest``, a real
 ``EventLog`` subscribed to a real ``EventStore`` (audit-events are read back
@@ -273,25 +281,23 @@ class _LoopForP2d(RouterLoop):
 # ── convergence-debt interim guard (#3247 co-vet, pre-merge) ──────────────
 
 
-def test_action_index_build_failure_both_signals_stay_in_sync(
+def test_action_index_build_failure_is_single_sourced_on_coordinator(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
 ) -> None:
-    """Tier 2: FP-0066 P2d / #3247 convergence-debt interim guard.
+    """Tier 2: P2-convergence PR2 (#3270 §3) single-source witness.
 
-    ``RouterLoop._action_index_build_failed`` (the pre-P2b per-session
-    retry-prevention flag, #1458) and ``IndexCoordinator``'s own failure-
-    memo (``build_failed(source_id)``) are currently BOTH set on the SAME
-    build failure — P2b's byte-identical two-path retention left them as
-    two independent bookkeeping mechanisms for one fact, kept in sync only
-    IMPLICITLY. Full unification into a single failure-state signal is
-    deferred to the #3247 convergence follow-up (see ``coordinator.py``'s
-    P2b docstring on the two-path builder shape). This test drives a REAL
-    build failure through the REAL production path
+    Retires the interim dual-sync pin (formerly
+    ``test_action_index_build_failure_both_signals_stay_in_sync``): the
+    twin RouterLoop-side ``_action_index_build_failed`` flag (#1458's
+    original per-session retry-prevention bookkeeping) is REMOVED — the
+    Coordinator's own failure-memo (``build_failed(source_id)``) is now
+    the SOLE owner of build-failure state. This test drives a REAL build
+    failure through the REAL production path
     (``RouterLoop._ensure_action_index_built``, real ``IndexCoordinator``,
-    real ``ActionEmbeddingIndex``, no mocks) and asserts BOTH signals
-    reflect the failure TOGETHER — a future edit that touches only one of
-    the two paths (e.g. a refactor that stops setting one flag) turns this
-    RED instead of silently desyncing them.
+    real ``ActionEmbeddingIndex``, no mocks) and asserts (a) the
+    Coordinator's memo reflects the failure AND (b) the RouterLoop
+    instance no longer even HAS the twin attribute — witnessing the
+    double-record is gone, not merely that it stayed in sync.
     """
     log, store = _events_and_store(tmp_path)
     provider = _FailingEmbeddingProvider()
@@ -309,17 +315,13 @@ def test_action_index_build_failure_both_signals_stay_in_sync(
 
     _run(_scenario())
 
-    # getattr (not a direct attribute access) mirrors the established
-    # #1458 pin convention (test_action_embedding_build_failure_1458.py /
-    # test_index_coordinator_3247_p2b.py) — this flag is the production
-    # guard's own read surface (RouterLoop.run() checks it the same way).
-    assert getattr(loop, "_action_index_build_failed", False) is True, (
-        "the RouterLoop-side #1458 retry-prevention flag must be set on "
-        "a real build failure"
-    )
     assert coordinator.build_failed("actions") is True, (
-        "the Coordinator's own failure-memo must ALSO be set on the SAME "
-        "build failure — the two signals must not desync"
+        "the Coordinator's failure-memo must be set on a real build failure"
+    )
+    _sentinel = object()
+    assert getattr(loop, "_action_index_build_failed", _sentinel) is _sentinel, (
+        "the twin RouterLoop-side #1458 flag must no longer exist — "
+        "failure-state has a single owner (the Coordinator's memo)"
     )
 
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #3270 (P2 収束アーク §3 収束2, ratified in the architect's firm comment + the lead's PR1-landed "PR2 commitment"). Branched off `main` at `f254dc7a` (PR1: action_index lock-free, `ensure_built`+`register_builder` the sole production build path, `ensure_built_self_contained` eliminated).

## What this does

**1. Flag removed, reads migrated to the Coordinator memo.**
`RouterLoop._action_index_build_failed` (the twin, in-sync-by-convention failure signal) is deleted entirely — attribute, both set sites, and both read sites. `router_loop.py`'s eager-gate read (~:1316) now calls `coordinator.build_failed("actions")` directly. Confirmed the Coordinator's `_run_build` sets `self._failure_memo[source_id]` in its own except-block (coordinator.py, before the `on_error` hook even fires) — so the memo is already the production source of truth; removing the flag loses nothing. The `on_error` hook in `_ensure_action_index_built` now only does the #1458 decision-enabling warning log, no bookkeeping.

**2. Production-dead primitive removed.**
`RouterLoop._build_action_embedding_index_background` — confirmed production-dead after PR1 (its only caller was `test_action_embedding_build_failure_1458.py`) — is deleted. `_fetch_action_catalog_items` / `prepare_material` (the pieces PR1 already extracted) are untouched.

**3. #1458 migrated to the production path.**
`tests/test_action_embedding_build_failure_1458.py` is rewritten to drive `RouterLoop._ensure_action_index_built` (register a builder + `ensure_built`, real `IndexCoordinator` + real `ActionEmbeddingIndex`, monkeypatched embed provider) instead of the deleted primitive. Retry-semantics invariant preserved: a fresh coordinator/session attempts the build exactly once (`provider.embed_calls == 1`), and the production retry-guard (mirroring `RouterLoop.run()`'s own gate — checking `coordinator.build_failed()` before calling again) suppresses a second attempt in the same session. **Non-vacuity**: the failure now flows through `embed_verify_write` (not a bespoke `idx.build()`), so if same-session suppression were neutered, the guarded second call would drive a second real provider call and the `embed_calls == 1` assertion would go RED.

**4. Dual-sync pin retired → single-source witness.**
`test_action_index_build_failure_both_signals_stay_in_sync` (tests/test_index_coordinator_3247_p2d.py) is replaced by `test_action_index_build_failure_is_single_sourced_on_coordinator`, which asserts `coordinator.build_failed("actions") is True` AND `not hasattr(loop, "_action_index_build_failed")` — witnessing the twin is gone, not merely in sync. `test_index_coordinator_3247_p2b.py`'s `test_build_failure_memoized_not_reattempted` (which also read the retired flag) is updated the same way.

## Verification

- Confirmed via direct read of `coordinator.py` `_run_build`'s except-block: `_failure_memo[source_id] = reason` is set BEFORE `on_error` fires — the production path was never depending on the flag for tracking.
- `grep` for `_action_index_build_failed` / `_build_action_embedding_index_background` across `src/`, `tests/`, `docs/` confirms no remaining production or doc reference outside updated historical/comment context.
- No lock or second build path reintroduced; PR1's single `ensure_built`/`register_builder` path is unchanged.

## CI gates (local)

- `ruff check src tests` — clean.
- `python scripts/test_tier_audit.py --strict tests/test_action_embedding_build_failure_1458.py tests/test_index_coordinator_3247_p2b.py tests/test_index_coordinator_3247_p2d.py` — 25/25 OK, 0 Tier-4 violations.
- `PYTHONPATH=$(pwd)/src python -m pytest` broad affected set (router_loop/eager tests, coordinator P2a/b/d, #1458, retired pin, fp0063 arc-witness, universal-wrapper/search_actions tests) — 97 + 96 passed, 0 failed.
- `python scripts/verify_module_docstrings.py src/reyn/runtime/router_loop.py src/reyn/data/index/coordinator.py` — OK.

## Test plan
- [x] Ran the broad local pytest set above — all green.
- [x] Verified no remaining production/doc references to the removed flag/primitive.
- [x] Verified `_failure_memo` is set independently of the (now-removed) `on_error` bookkeeping.