### PR TITLE
build(deps): add git-pinned textual-flowview dep (TUI-rebuild Phase 0, #3273)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,21 @@ dependencies = [
     "pyyaml>=6.0",
     "prompt_toolkit>=3.0",   # plain CUI (--cui flag) keeps this
     "ddgs>=8.0",
-    "rich>=13",              # inline CUI renderer (direct dep; was transitive via textual)
+    "rich>=13",              # inline CUI renderer — DIRECT dep (plain renderer imports it).
+                             # Kept explicit deliberately: textual is back in the tree
+                             # transitively via textual-flowview (below), and rich would
+                             # otherwise silently revert to "transitive via textual" — but
+                             # the plain renderer uses rich directly, independent of textual.
+    # TUI-rebuild arc Phase 0 (#3273): the new TTY conversation pane is a Textual app,
+    # built on the textual-flowview primitives (Presentation.background, FlowView(spacing=)).
+    # Git-pinned to a specific commit of the PUBLIC repo (no auth needed). This RE-INTRODUCES
+    # textual (flowview depends on textual>=0.80) — intentional per #3273. textual is accepted
+    # TRANSITIVELY via flowview for now: reyn core imports no textual symbol yet (Phase 0 is the
+    # dependency addition only; app code is Phase 1+), so a direct `textual` dep with no direct
+    # import would itself be the silent-phantom-dep antipattern in reverse. Phase 1 promotes
+    # textual to an explicit DIRECT dependency when the app code that imports it lands (same
+    # reasoning that keeps rich direct above).
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@15a942c27bdb82ddfe7f550f0f35d121c63440c8",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 file__read encoding detection (MIT, pure-python)
@@ -241,6 +255,13 @@ norecursedirs = ["dogfood/fixtures", ".reyn", ".claude", "reyn-worktrees"]
 # entries can never silently drop out if a future file under one of these
 # globs is untracked/gitignored (the top omission risk called out in 0061
 # §3.1 — dropping any of the 3 = a silently-broken wheel).
+# Allow the git-pinned `textual-flowview @ git+https://...@<sha>` direct
+# reference in `project.dependencies` (TUI-rebuild arc Phase 0, #3273).
+# Hatchling refuses direct (URL/VCS) references by default; this opt-in is
+# required for the pinned-commit flowview dep to build/resolve.
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/reyn"]
 artifacts = [

--- a/uv.lock
+++ b/uv.lock
@@ -2041,6 +2041,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "litellm"
 version = "1.89.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2203,6 +2215,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
 [[package]]
 name = "markupsafe"
 version = "3.0.3"
@@ -2300,6 +2317,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -3730,6 +3759,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "textual-flowview" },
 ]
 
 [package.optional-dependencies]
@@ -3834,6 +3864,7 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6" },
     { name = "sqlite-vec", marker = "extra == 'builtin-rag'", specifier = ">=0.1.9" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=1.0,<1.3" },
+    { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=15a942c27bdb82ddfe7f550f0f35d121c63440c8" },
     { name = "trafilatura", marker = "extra == 'fetch'", specifier = ">=1.8" },
     { name = "twine", marker = "extra == 'release'", specifier = ">=5.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
@@ -4182,6 +4213,31 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
+name = "textual-flowview"
+version = "0.3.0.dev0"
+source = { git = "https://github.com/tya5/textual-flowview.git?rev=15a942c27bdb82ddfe7f550f0f35d121c63440c8#15a942c27bdb82ddfe7f550f0f35d121c63440c8" }
+dependencies = [
+    { name = "textual" },
+]
+
+[[package]]
 name = "tiktoken"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4458,6 +4514,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/48/55/15e2340963d2bfedcc6042da3911438fd336f8ae96b65bdbe3a29766da0c/tzlocal-5.4.3.tar.gz", hash = "sha256:3a8c9bc18cf47e1dcde252ea0e6a72a6cde320a400b6ac6db1f1f8cccd553c00", size = 30873, upload-time = "2026-06-17T04:17:41.764Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/42/28/fc144409c71569e928585f8f3c629d80d1ca3ef40175e9222f01588f98c9/tzlocal-5.4.3-py3-none-any.whl", hash = "sha256:24ce97bb58e2a973f7640ec2553ab4e6f6d5a0d0d1aa9dc43bca21d89e1feb82", size = 18039, upload-time = "2026-06-17T04:17:40.027Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**[per-PR-coder]** — Phase 0 of the TUI-rebuild arc (part of #3273): add `textual-flowview` as a git-pinned dependency. **Dependency addition only — no TUI/Textual application code** (that is Phase 1+).

## What changed
- **`pyproject.toml`**: added the git-pinned dep to core `dependencies`:
  ```
  textual-flowview @ git+https://github.com/tya5/textual-flowview.git@15a942c27bdb82ddfe7f550f0f35d121c63440c8
  ```
  (public repo, no auth) — the primitive layer (`Presentation.background`, `FlowView(spacing=)`) the new Textual TTY conversation pane will build on.
- **`[tool.hatch.metadata] allow-direct-references = true`**: Hatchling refuses VCS/URL direct references in `project.dependencies` by default; this opt-in is required for the pinned-commit dep to build/resolve.
- **`uv.lock`**: re-locked — adds `textual v8.2.8`, `textual-flowview v0.3.0.dev0 (15a942c2)`, and their transitive leaves (linkify-it-py, mdit-py-plugins, uc-micro-py). `uv lock --check` passes.

## How the textual re-introduction is handled (direct vs transitive)
reyn deliberately removed Textual earlier; flowview depends on `textual>=0.80`, so this **re-introduces textual** — intentional per #3273.
- **textual is accepted TRANSITIVELY via flowview** (resolves to 8.2.8). Rationale: reyn core imports no `textual` symbol yet — Phase 0 is the dependency addition only, app code is Phase 1+. A direct `textual` dep with no direct import would be the silent-phantom-dep antipattern in reverse. **Phase 1 promotes textual to an explicit DIRECT dependency** when the app code that imports it lands — the same reasoning that keeps `rich` direct.
- **`rich` stays an explicit DIRECT dep.** The prior comment implied textual's absence ("was transitive via textual"); that is now falsified, so I rewrote it (CLAUDE.md same-PR doc-drift rule). The plain renderer uses rich directly, independent of textual, so rich must not silently revert to transitive-via-textual.

## requires-python reconciliation
reyn's `requires-python` is already `>=3.11`, which satisfies flowview's `>=3.11`. **No floor change needed** — no conflict, nothing to escalate.

## Test plan / CI gates (all run locally in the worktree venv)
- [x] `ruff check src tests` — All checks passed
- [x] `pytest` (repo root, CI extras `dev,mcp,web,fs-watch,observability,builtin-rag`) — 9179 passed, 36 skipped
- [x] `python scripts/test_tier_audit.py --strict` — N/A (no test files changed)
- [x] `python scripts/verify_module_docstrings.py` — N/A (no src files changed)
- [x] `uv lock --check` — up to date
- [x] dep resolves + installs: `from textual_flowview import FlowView` imports OK; textual 8.2.8, flowview 0.3.0.dev0 (pinned commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)