### PR TITLE
Phase 1: Textual conversation pane on textual-flowview (#3273)

### DIFF
--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -380,14 +380,19 @@ remote renderer's display bytes and working-indicator transitions are identical
 to the local ones.
 
 Local ≡ remote holds at the **renderer/loop layer**, not just the transport. The
-renderer choice (Claude Code-style inline CUI on an interactive TTY, plain console
-for `--cui` / non-TTY / piped) is one shared seam (`logger_factory.make_renderer`
-behind the `_inline_interactive` predicate), and both `reyn chat` and `reyn chat
---connect` hand a `ClientTransport` + a `ChatReadModel` to the SAME driver
-(`client_driver.run_chat_client`). The client reads its status bar / intervention
-region / task poll through the read-model: a `RegistryReadModel` off the local
-session, or a `RemoteReadModel` off the `STATE_*` view above — so an interactive
-remote attach renders the inline CUI, not a plain fallback.
+interactive-surface choice (Claude Code-style TUI on an interactive TTY, plain
+console for `--cui` / non-TTY / piped) is one shared seam
+(`renderer.uses_app_input() and is_tty`, the same predicate `make_renderer` uses
+behind `_inline_interactive`), and both `reyn chat` and `reyn chat --connect` hand
+a `ClientTransport` + a `ChatReadModel` to the SAME driver
+(`client_driver.run_chat_client`). On an interactive TTY that driver routes to the
+Textual conversation-pane app (`reyn.interfaces.inline.textual_chat`, the #3273
+TUI rebuild), which owns both input and output and drains the SAME
+`transport.frames()` stream — so an interactive remote attach renders the TUI, not
+a plain fallback, from the identical frame stream a local attach consumes. The
+client reads its status bar / intervention region / task poll through the
+read-model: a `RegistryReadModel` off the local session, or a `RemoteReadModel`
+off the `STATE_*` view above.
 
 **Local ≡ remote holds for INPUT too, symmetric with output.** A submitted turn
 (`Session.submit_user_text`) and a resolved intervention answer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,15 +50,17 @@ dependencies = [
                              # transitively via textual-flowview (below), and rich would
                              # otherwise silently revert to "transitive via textual" — but
                              # the plain renderer uses rich directly, independent of textual.
-    # TUI-rebuild arc Phase 0 (#3273): the new TTY conversation pane is a Textual app,
-    # built on the textual-flowview primitives (Presentation.background, FlowView(spacing=)).
-    # Git-pinned to a specific commit of the PUBLIC repo (no auth needed). This RE-INTRODUCES
-    # textual (flowview depends on textual>=0.80) — intentional per #3273. textual is accepted
-    # TRANSITIVELY via flowview for now: reyn core imports no textual symbol yet (Phase 0 is the
-    # dependency addition only; app code is Phase 1+), so a direct `textual` dep with no direct
-    # import would itself be the silent-phantom-dep antipattern in reverse. Phase 1 promotes
-    # textual to an explicit DIRECT dependency when the app code that imports it lands (same
-    # reasoning that keeps rich direct above).
+    # TUI-rebuild arc (#3273): the interactive TTY conversation pane
+    # (`reyn.interfaces.inline.textual_chat`) is a Textual app built on the
+    # textual-flowview primitives (Presentation.background, FlowView(spacing=)).
+    # Git-pinned to a specific commit of the PUBLIC repo (no auth needed).
+    # Phase 1 promotes `textual` to an explicit DIRECT dep now that the app code
+    # imports `textual.app`/`textual.widgets` directly (Phase 0 left it transitive
+    # via flowview) — same reasoning that keeps rich direct above. Floor matches
+    # flowview's own requirement (textual>=0.80). The app module is imported
+    # LAZILY on the TTY path only, so the plain / --cui / non-TTY / CI paths never
+    # touch textual or flowview and stay green even if flowview fails to resolve.
+    "textual>=0.80",
     "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@15a942c27bdb82ddfe7f550f0f35d121c63440c8",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B

--- a/src/reyn/interfaces/inline/textual_chat.py
+++ b/src/reyn/interfaces/inline/textual_chat.py
@@ -1,0 +1,393 @@
+"""Textual conversation-pane app for the interactive TTY chat surface.
+
+This is the TTY-path chat surface: a :class:`textual.app.App` that OWNS both
+input (a multiline :class:`Composer`) and output (a retained
+:class:`~textual_flowview.FlowModel` rendered through a
+:class:`~textual_flowview.FlowView`). It is deliberately NOT a
+:class:`~reyn.interfaces.repl.renderer.ChatRenderer` subclass: the plain
+renderer is an incremental *print* paradigm with no retained model, whereas this
+app keeps every conversation entry in a model and RE-PRESENTS the visible ones on
+every resize — the reflow the plain scrollback cannot do.
+
+The app is fed from the SAME ``transport.frames()`` stream the plain output loop
+consumes (:mod:`reyn.interfaces.repl.stream_client`): a Textual worker drains the
+stream and appends each display frame to the model, so the on-screen turn
+sequence is structurally identical to the plain renderer's — only the drawing
+differs. Composer submissions route back through the same transport send seam.
+
+Presentation reuses reyn's own Claude-Code palette and per-kind line table
+(:data:`~reyn.interfaces.repl.renderer._CC_TEXT` … / ``_KIND_LINE``) rather than
+inventing a second styling vocabulary: :class:`ReynPresenter` fills the body cell
+and :class:`ReynGutter` fills the flowview gutter column, the split flowview's
+presenter/decorator protocol expects.
+
+Import boundary (load-bearing): this module imports :mod:`textual` and
+:mod:`textual_flowview` at top level, so it must only ever be imported on the TTY
+path — :func:`~reyn.interfaces.repl.client_driver.run_chat_client` imports it
+lazily inside its inline-interactive branch. The plain / ``--cui`` / non-TTY /
+CI paths never import it, so they stay green even if flowview is absent.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from rich.console import Console, RenderableType
+from rich.text import Text
+from textual import events
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.message import Message
+from textual.widgets import Static, TextArea
+from textual_flowview import (
+    Anchor,
+    Entry,
+    FlowModel,
+    FlowView,
+    Presentation,
+)
+
+from reyn.interfaces.repl.renderer import (
+    _CC_DIM,
+    _CC_ERR,
+    _CC_TEXT,
+    _CC_USER_BG,
+    _KIND_LINE,
+    _body_renderable,
+    _summarize_args,
+    summarize_tool_result,
+)
+from reyn.interfaces.transport.frames import FrameTag
+
+if TYPE_CHECKING:
+    from reyn.interfaces.repl.read_model import ChatReadModel
+    from reyn.interfaces.transport.client_transport import ClientTransport
+    from reyn.runtime.outbox import OutboxMessage
+
+logger = logging.getLogger(__name__)
+
+# Display kinds that are command-UI / control sentinels, not conversation
+# content. The plain output loop consumes them as signals; the Phase-1
+# conversation pane simply skips them (their surfaces land in later phases).
+# ``__end__`` is handled by the pump loop (it stops the app), so it is not here.
+_SKIP_KINDS = frozenset(
+    {
+        "__copy_last_reply__",
+        "__rewind_list__",
+        "__attach_request__",
+        "__session_switch_request__",
+    }
+)
+
+
+def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | None]":
+    """The body renderable + optional full-row background for one display frame.
+
+    Reuses the plain renderer's per-kind body construction (markdown for the
+    agent reply, the tool-summary helpers for tool rows, the ``_KIND_LINE`` body
+    style otherwise) so a frame reads the same here as in the plain scrollback.
+    The user's own line carries its background via ``Presentation.background``
+    (flowview paints it edge to edge across gutter + body), matching the plain
+    renderer's faint user block without a hand-rolled grid.
+    """
+    kind = msg.kind
+    meta = msg.meta or {}
+    if kind == "presentation":
+        from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+        return render_presentation_nodes(meta.get("nodes", [])), None
+    if kind == "intervention" and meta.get("nodes") is not None:
+        from reyn.interfaces.repl.present_renderer import render_presentation_nodes
+        return render_presentation_nodes(meta["nodes"]), None
+    if kind == "tool_call_started":
+        tool = str(meta.get("tool", msg.text))
+        args = _summarize_args(meta.get("args"))
+        return Text.assemble((tool, "bold"), (f"({args})", _CC_DIM)), None
+    if kind == "tool_call_completed":
+        summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
+        style = _CC_ERR if summary.startswith("✗") else _CC_DIM
+        return Text(summary, style=style), None
+    if kind == "tool_call_failed":
+        err = meta.get("error_message") or meta.get("error_kind") or msg.text
+        return Text(f"✗ {err}", style=_CC_ERR), None
+    line = _KIND_LINE.get(kind)
+    body_style = line[2] if line else _CC_TEXT
+    body = _body_renderable(kind, msg.text or " ", body_style)
+    background = _CC_USER_BG if kind == "user" else None
+    return body, background
+
+
+def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
+    """The gutter glyph + colour for one display frame, keyed off ``_KIND_LINE``.
+
+    Mirrors the plain renderer's marker column: the ``_KIND_LINE`` glyph (its
+    leading non-space char) for message-y kinds, the ``▸`` / ``⎿`` tool markers
+    otherwise. Colour is the ``_KIND_LINE`` gutter style (state-driven colour is
+    Phase 2). Kept cheap — ``decorate`` runs on every repaint.
+    """
+    kind = msg.kind
+    if kind == "tool_call_started":
+        return "▸", _CC_TEXT
+    if kind == "tool_call_completed":
+        return "⎿", _CC_DIM
+    if kind == "tool_call_failed":
+        return "⎿", _CC_ERR
+    line = _KIND_LINE.get(kind)
+    if line is None:
+        return "", _CC_DIM
+    glyph = line[0].strip()[:1]
+    return glyph, line[1]
+
+
+class ReynPresenter:
+    """Turns a reyn display frame into a body :class:`Presentation` sized to
+    ``width`` — reusing the plain renderer's palette + per-kind body construction
+    (``_CC_*`` / ``_KIND_LINE`` / ``_body_renderable``), never a second styling
+    vocabulary. The gutter is the :class:`ReynGutter`'s job."""
+
+    def __init__(self) -> None:
+        # A private probe console for measuring wrapped height at a given width.
+        self._probe = Console()
+
+    def _measure(self, renderable: RenderableType, width: int) -> int:
+        self._probe.size = (max(width, 1), 200)
+        return max(
+            len(
+                self._probe.render_lines(
+                    renderable, self._probe.options.update_width(max(width, 1))
+                )
+            ),
+            1,
+        )
+
+    async def present(self, item: "OutboxMessage", width: int) -> Presentation:
+        body, background = _body_and_background(item)
+        return Presentation(
+            height=self._measure(body, width),
+            renderable=body,
+            background=background,
+        )
+
+
+class ReynGutter:
+    """Fills the flowview gutter column with the plain renderer's marker glyph +
+    colour (``_KIND_LINE`` / ``_CC_*``). Role/kind is read off the entry's item;
+    state-driven colour + running blink are Phase 2."""
+
+    def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
+        glyph, color = _gutter_glyph_color(entry.item)
+        return Text(glyph.ljust(width), style=color)
+
+
+class Composer(TextArea):
+    """Multi-line Claude-Code-style input: **Enter submits**, **Shift+Enter**
+    inserts a newline (the inverse of ``TextArea``'s default), auto-growing up to
+    ``MAX_ROWS`` then internally scrolling. Every other key falls through to the
+    base ``TextArea`` bindings unchanged."""
+
+    MAX_ROWS = 6
+
+    class Submitted(Message):
+        """Posted when the user presses Enter with non-blank content."""
+
+        def __init__(self, value: str) -> None:
+            self.value = value
+            super().__init__()
+
+    def on_mount(self) -> None:
+        self.show_line_numbers = False
+        self._sync_height()
+
+    async def _on_key(self, event: events.Key) -> None:
+        if event.key == "enter":
+            event.stop()
+            event.prevent_default()
+            if self.text.strip():
+                self.post_message(self.Submitted(self.text))
+            return
+        if event.key == "shift+enter":
+            event.stop()
+            event.prevent_default()
+            start, end = self.selection
+            self._replace_via_keyboard("\n", start, end)
+            return
+        await super()._on_key(event)
+
+    def on_text_area_changed(self, event: TextArea.Changed) -> None:
+        self._sync_height()
+
+    def _sync_height(self) -> None:
+        wrapped_rows = max(self.wrapped_document.height, 1)
+        self.styles.height = min(wrapped_rows, self.MAX_ROWS)
+
+    def clear_and_reset(self) -> None:
+        self.text = ""
+        self._sync_height()
+
+
+class TextualChatApp(App):
+    """The TTY conversation pane: a FlowView of the live conversation + a
+    Composer, both fed/served by one :class:`ClientTransport`.
+
+    The app drains ``transport.frames()`` in a worker, appending each display
+    frame to the retained model (event frames drive the Phase-2 working
+    indicator — skipped for now); a Composer submit routes back through the
+    transport. The user's own line is NOT echoed locally — it returns as a
+    ``kind="user"`` frame on the same stream, so the model is fed entirely from
+    frames and stays equivalent to the plain renderer's turn sequence.
+    """
+
+    CSS = """
+    Screen { layout: vertical; }
+    FlowView {
+        height: 1fr;
+        scrollbar-size-vertical: 0;
+    }
+    #inputrow {
+        height: auto;
+        max-height: 8;
+        margin-top: 1;
+        border-top: solid #3d434f;
+        border-bottom: solid #3d434f;
+    }
+    #inputgutter {
+        width: 2;
+        height: auto;
+        color: $text-muted;
+    }
+    Composer {
+        height: 3;
+        max-height: 6;
+        border: none;
+        padding: 0;
+    }
+    """
+
+    def __init__(
+        self,
+        *,
+        transport: "ClientTransport",
+        read_model: "ChatReadModel | None" = None,
+        agent_name: str = "default",
+        config=None,
+    ) -> None:
+        super().__init__()
+        self._transport = transport
+        self._read_model = read_model
+        self._agent_name = agent_name
+        self._config = config
+        self.conversation: "FlowModel[OutboxMessage]" = FlowModel()
+
+    def compose(self) -> ComposeResult:
+        yield FlowView(
+            model=self.conversation,
+            presenter=ReynPresenter(),
+            decorator=ReynGutter(),
+            gutter_width=2,
+            spacing=1,
+            anchor=Anchor.STICKY_BOTTOM,
+        )
+        with Horizontal(id="inputrow"):
+            yield Static("❯", id="inputgutter")
+            yield Composer(
+                placeholder="Type a message — Enter to send, Shift+Enter for a newline…"
+            )
+
+    def on_mount(self) -> None:
+        self.run_worker(self._pump_frames(), name="frames", exclusive=True)
+        self.query_one(Composer).focus()
+
+    async def _pump_frames(self) -> None:
+        """Drain the transport frame stream into the retained model.
+
+        Display frames append to the model (skipping command-UI sentinels);
+        ``__end__`` stops the app (the session closed). Event frames are the
+        working-indicator path — consumed but not yet drawn (Phase 2). A single
+        frame's presentation failure must not kill the pump, so append is guarded.
+        """
+        try:
+            async for frame in self._transport.frames():
+                if frame.tag is FrameTag.EVENT:
+                    continue
+                msg = frame.message
+                if msg.kind == "__end__":
+                    break
+                if msg.kind in _SKIP_KINDS:
+                    continue
+                try:
+                    self.conversation.append(msg)
+                except Exception:
+                    logger.exception(
+                        "textual chat: append failed for frame kind=%r", msg.kind
+                    )
+        finally:
+            self.exit()
+
+    async def on_composer_submitted(self, event: "Composer.Submitted") -> None:
+        text = event.value.strip()
+        self.query_one(Composer).clear_and_reset()
+        if not text:
+            return
+        if text in {"/quit", "/exit"}:
+            await self._transport.shutdown()
+            self.exit()
+            return
+        await self._submit(text)
+
+    async def _submit(self, text: str) -> None:
+        """Route one submitted line through the transport send seam.
+
+        A pending free-text intervention (no choices) takes the answer path;
+        everything else is an ordinary new turn. Errors are contained and
+        surfaced as an error frame the pump renders — a silent input drop is the
+        worst failure for a chat box.
+        """
+        try:
+            head = self._transport.pending_intervention_head()
+            if head is not None and not getattr(head, "choices", None):
+                await self._transport.answer_intervention_text(text)
+                return
+            await self._transport.submit_user_text(text)
+        except Exception as exc:
+            logger.exception("textual chat: submit failed")
+            from reyn.runtime.outbox import OutboxMessage
+            detail = f"{type(exc).__name__}: {exc}"
+            try:
+                self._transport.put_display(
+                    OutboxMessage(
+                        kind="error", text=f"input could not be submitted: {detail}"
+                    )
+                )
+            except Exception:
+                pass
+
+
+async def run_textual_chat(
+    *,
+    transport: "ClientTransport",
+    read_model: "ChatReadModel | None" = None,
+    agent_name: str = "default",
+    config=None,
+) -> None:
+    """Run the TTY conversation-pane app until the user quits or the stream ends.
+
+    Runs ``inline=True`` so the terminal's pre-launch scrollback is preserved
+    above the app region (the ADR's Phase-0-validated inline mode) rather than
+    swapping to the alternate screen. Returns so the driver's caller can tear the
+    transport down + print the cost summary.
+    """
+    app = TextualChatApp(
+        transport=transport,
+        read_model=read_model,
+        agent_name=agent_name,
+        config=config,
+    )
+    await app.run_async(inline=True)
+
+
+__all__ = [
+    "Composer",
+    "ReynGutter",
+    "ReynPresenter",
+    "TextualChatApp",
+    "run_textual_chat",
+]

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -17,6 +17,16 @@ renderer is chosen ONCE (by the caller, via the same
 ``logger_factory.make_renderer`` predicate) and the input driver is selected ONCE
 (here), so the TUI is agnostic to whether its session is a page-fault away or a
 network away.
+
+The interactive TTY surface (``renderer.uses_app_input() and is_tty``) is the
+Textual conversation-pane app (:mod:`reyn.interfaces.inline.textual_chat`), which
+OWNS both input and output and consumes the same ``transport.frames()`` stream in
+a worker — so it renders identically over a local or a remote transport. That app
+module (and its ``textual`` / ``textual_flowview`` imports) is imported LAZILY
+inside the branch, TTY-path only: the plain / ``--cui`` / non-TTY / CI paths take
+the shared :class:`~reyn.interfaces.repl.renderer.ChatRenderer` + PromptSession
+input loop below and never import flowview, so they stay green even if it is
+absent.
 """
 from __future__ import annotations
 
@@ -44,43 +54,49 @@ async def run_chat_client(
     is_tty: bool,
     config=None,
 ) -> None:
-    """Banner + input-driver selection + output loop + wait + teardown.
+    """Input-driver selection + (plain) banner/output loop + wait + teardown.
 
-    ``renderer.uses_app_input()`` AND ``is_tty`` selects the interactive inline
-    Application (its own rule-bar input, reading status/region/tasks through
-    ``read_model``); otherwise the plain PromptSession loop (``--cui`` / non-TTY /
-    piped). The output loop is shared. This is the SAME selection ``run_repl``
-    made locally — now applied identically to the remote path.
+    ``renderer.uses_app_input()`` AND ``is_tty`` routes to the Textual
+    conversation-pane app (:func:`~reyn.interfaces.inline.textual_chat.run_textual_chat`),
+    which owns both input and output and drains ``transport.frames()`` itself —
+    imported LAZILY here so the flowview/textual dependency is touched on the TTY
+    path only. Otherwise (``--cui`` / non-TTY / piped) the plain PromptSession
+    input loop + shared output loop drive the handed-in ``renderer``. This is the
+    SAME selection ``run_repl`` made locally — now applied identically to the
+    remote path.
 
     The caller owns transport lifecycle (``start``/``close`` or the httpx SSE
-    context) and any cost summary; this function only drives the two loops and
-    guarantees both are cancelled + awaited on exit.
+    context) and any cost summary; this function only drives the loop(s) and
+    guarantees any tasks it spawns are cancelled + awaited on exit.
     """
+    if renderer.uses_app_input() and is_tty:
+        from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
+        await run_textual_chat(
+            transport=transport,
+            read_model=read_model,
+            agent_name=agent_name,
+            config=config,
+        )
+        return
+
     renderer.banner(agent_name)
 
     # `set` = "no reply pending" (the PromptSession input loop's pacing gate is
-    # open); `clear` = "a turn is in flight". The inline Application path does not
-    # use it (it has its own submit flow), but the shared output loop always
+    # open); `clear` = "a turn is in flight". The shared output loop always
     # signals it so the plain-path gate never hangs.
     reply_seen: asyncio.Event = asyncio.Event()
     reply_seen.set()
 
-    if renderer.uses_app_input() and is_tty:
-        from reyn.interfaces.inline.app import run_inline_input  # noqa: PLC0415
-        inputs = asyncio.create_task(
-            run_inline_input(read_model, renderer, config, transport)
-        )
-    else:
-        from prompt_toolkit import PromptSession  # noqa: PLC0415
-        from prompt_toolkit.history import FileHistory  # noqa: PLC0415
-        from prompt_toolkit.styles import Style  # noqa: PLC0415
-        prompt_session: "PromptSession[str]" = PromptSession(
-            history=FileHistory(str(read_model.history_path)),
-            style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
-        )
-        inputs = asyncio.create_task(
-            run_input_loop(transport, prompt_session, renderer, reply_seen)
-        )
+    from prompt_toolkit import PromptSession  # noqa: PLC0415
+    from prompt_toolkit.history import FileHistory  # noqa: PLC0415
+    from prompt_toolkit.styles import Style  # noqa: PLC0415
+    prompt_session: "PromptSession[str]" = PromptSession(
+        history=FileHistory(str(read_model.history_path)),
+        style=Style.from_dict({"bottom-toolbar": "noreverse bg:default"}),
+    )
+    inputs = asyncio.create_task(
+        run_input_loop(transport, prompt_session, renderer, reply_seen)
+    )
 
     outputs = asyncio.create_task(
         run_output_loop(

--- a/tests/test_textual_chat_phase1_3273.py
+++ b/tests/test_textual_chat_phase1_3273.py
@@ -1,0 +1,314 @@
+"""Phase 1 TUI-rebuild gates (#3273): the Textual conversation pane.
+
+These pin the four architect-specified Phase-1 invariants:
+
+- **resize reflow** (Tier 2b): the whole conversation re-wraps at a new terminal
+  width — the core capability the plain scrollback cannot do.
+- **import isolation** (Tier 2c): the plain / non-TTY path stays green when
+  ``textual_flowview`` is unimportable — the flowview import is lazy, TTY-only.
+- **plain-fallback equivalence** (Tier 2c): the app models the SAME logical turn
+  sequence the plain renderer renders from an identical frame stream.
+- **input wiring** (Tier 2b): a Composer submit routes back through the transport.
+
+All use real instances (a concrete :class:`ScriptedTransport`, a real
+recording renderer) — no mocks — per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+import tomllib
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.repl.client_driver import run_chat_client
+from reyn.interfaces.repl.renderer import ChatRenderer
+from reyn.interfaces.repl.stream_client import run_output_loop
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ScriptedTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` that replays a fixed frame list.
+
+    Constructed cheaply from a list of :class:`OutboxMessage` — the same frames a
+    session's outbox would push — so both the plain output loop and the Textual
+    app can be driven from an identical script. ``end=True`` terminates the stream
+    with ``__end__``; ``end=False`` keeps it open (blocks after the script) so the
+    app under test stays mounted for a resize.
+    """
+
+    def __init__(self, messages: "list[OutboxMessage]", *, end: bool = True) -> None:
+        self._messages = list(messages)
+        self._end = end
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        if self._end:
+            yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+        else:
+            await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _RecordingRenderer(ChatRenderer):
+    """A real plain renderer that records the kind of every message it renders —
+    ``uses_app_input()`` stays False (base default) so it takes the plain path."""
+
+    def __init__(self) -> None:
+        self.kinds: list[str] = []
+
+    def message(self, msg: OutboxMessage) -> None:
+        self.kinds.append(msg.kind)
+
+
+# A conversation script covering the logical turn kinds the gate names:
+# user / assistant / tool / result / error.
+_CONVERSATION = [
+    OutboxMessage(kind="user", text="find the sandbox network gate"),
+    OutboxMessage(kind="agent", text="Looking now."),
+    OutboxMessage(
+        kind="tool_call_started", text="grep", meta={"tool": "grep", "args": {"q": "gate"}}
+    ),
+    OutboxMessage(
+        kind="tool_call_completed", text="", meta={"tool": "grep", "result": {"op": "grep", "count": 3}}
+    ),
+    OutboxMessage(kind="agent", text="It lives in sandbox/network.py."),
+    OutboxMessage(kind="error", text="transient hiccup"),
+]
+
+
+@pytest.mark.asyncio
+async def test_conversation_reflows_on_resize() -> None:
+    """Tier 2b: the whole conversation re-wraps at a new width — a long entry
+    occupies MORE rows narrow than wide. This is the headline capability (the
+    plain scrollback is frozen at its emit-time width); proven end-to-end through
+    the mounted app + ``pilot.resize_terminal``, asserting the FlowView's content
+    height (not any exact formatting) grows when narrower."""
+    from textual_flowview import FlowView
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    long_line = ("reflow " * 90).strip()
+    transport = ScriptedTransport([OutboxMessage(kind="agent", text=long_line)], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        wide_height = flow.virtual_size.height
+        await pilot.resize_terminal(40, 30)
+        await pilot.pause()
+        await pilot.pause()
+        narrow_height = flow.virtual_size.height
+
+    assert wide_height >= 1
+    assert narrow_height > wide_height, (
+        f"conversation did not reflow: wide={wide_height} narrow={narrow_height}"
+    )
+
+
+# Strip-falsify witness, run in a CLEAN subprocess interpreter: block
+# ``textual`` / ``textual_flowview`` at ``sys.meta_path`` BEFORE any reyn import,
+# then (1) import the always-loaded plain-path modules and assert neither flowview
+# nor textual entered ``sys.modules`` at module load, and (2) drive a real
+# non-TTY ``run_chat_client`` to ``__end__``, asserting the whole conversation
+# rendered. A subprocess is required: in-process, the plain-path modules are
+# already imported (cached), so a top-level ``import textual_flowview`` regression
+# would be masked — the falsify-check confirmed an in-process variant stays green
+# under that regression, so it would be a false witness.
+_ISOLATION_SUBPROCESS = '''
+import asyncio, sys
+from pathlib import Path
+
+
+class _Block:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in ("textual", "textual_flowview"):
+            raise ModuleNotFoundError("blocked for isolation test: " + name)
+        return None
+
+
+sys.meta_path.insert(0, _Block())
+
+# (1) module-load isolation: importing the plain path must not pull flowview/textual.
+import reyn.interfaces.repl.client_driver  # noqa: E402
+import reyn.interfaces.repl.stream_client  # noqa: E402
+import reyn.interfaces.cli.commands.chat  # noqa: E402
+
+assert "textual_flowview" not in sys.modules, "flowview imported at module load"
+assert "textual" not in sys.modules, "textual imported at module load"
+
+# (2) functional: a real non-TTY plain run completes without touching flowview.
+from reyn.interfaces.repl.client_driver import run_chat_client  # noqa: E402
+from reyn.interfaces.repl.read_model import ChatReadModel  # noqa: E402
+from reyn.interfaces.repl.renderer import ChatRenderer  # noqa: E402
+from reyn.interfaces.transport.client_transport import ClientTransport  # noqa: E402
+from reyn.interfaces.transport.frames import DisplayFrame  # noqa: E402
+from reyn.runtime.outbox import OutboxMessage  # noqa: E402
+
+
+class T(ClientTransport):
+    def __init__(self):
+        self.rendered = 0
+    def start(self): pass
+    def close(self): pass
+    async def frames(self):
+        yield DisplayFrame(OutboxMessage(kind="user", text="hi"))
+        yield DisplayFrame(OutboxMessage(kind="agent", text="hello"))
+        yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+    async def submit_user_text(self, text): pass
+    async def answer_intervention_text(self, text): return False
+    async def answer_intervention_choice(self, cid): return False
+    def has_session(self): return True
+    def pending_intervention_head(self): return None
+    def put_display(self, msg): pass
+    async def cancel_inflight(self): pass
+    async def shutdown(self): pass
+
+
+class RM(ChatReadModel):
+    def snapshot(self, config=None): return None
+    def intervention_head(self): return None
+    def pending_command_ui(self): return None
+    def clear_pending_command_ui(self): pass
+    @property
+    def has_command_ui_region(self): return True
+    @property
+    def history_path(self): return Path("/tmp/reyn_isolation_history")
+
+
+class R(ChatRenderer):
+    n = 0
+    def message(self, msg): R.n += 1
+
+
+asyncio.run(asyncio.wait_for(
+    run_chat_client(transport=T(), renderer=R(), read_model=RM(),
+                    agent_name="default", is_tty=False),
+    timeout=10.0,
+))
+assert R.n >= 2, "plain path did not render the conversation"
+assert "textual_flowview" not in sys.modules, "flowview imported during plain run"
+print("ISOLATION_OK")
+'''
+
+
+def test_plain_path_survives_flowview_absence() -> None:
+    """Tier 2c: with ``textual`` / ``textual_flowview`` unimportable from a clean
+    interpreter, the plain / non-TTY path imports and runs green — the flowview
+    import is lazy and TTY-only. Runs the strip in a subprocess (see the module
+    comment for why in-process would be a false witness) and asserts it reaches
+    the ``ISOLATION_OK`` sentinel."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _ISOLATION_SUBPROCESS],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+
+
+@pytest.mark.asyncio
+async def test_plain_fallback_equivalence_same_turn_sequence() -> None:
+    """Tier 2c: the Textual app models the SAME logical turn sequence the plain
+    renderer renders from an identical frame stream — same ``transport.frames()``
+    consumed, only the drawing differs. Feeds one script to the plain output loop
+    (recording renderer) and the same script to the mounted app, then asserts the
+    modeled entry kinds equal the plain-rendered kinds."""
+    from textual_flowview import FlowView
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    # Plain side: drive the real output loop with a recording renderer.
+    renderer = _RecordingRenderer()
+    plain_transport = ScriptedTransport(_CONVERSATION, end=True)
+    await asyncio.wait_for(
+        run_output_loop(plain_transport, renderer, None, command_ui_region=True),
+        timeout=5.0,
+    )
+
+    # App side: feed the identical script through the app's frame pump.
+    app_transport = ScriptedTransport(_CONVERSATION, end=False)
+    app = TextualChatApp(transport=app_transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        modeled = [e.item.kind for e in app.query_one(FlowView).entries]
+
+    assert modeled == renderer.kinds
+    assert modeled == [m.kind for m in _CONVERSATION]
+
+
+@pytest.mark.asyncio
+async def test_composer_submit_routes_to_transport() -> None:
+    """Tier 2b: a Composer submit is delivered to the session via the transport's
+    send seam (input→transport wiring). Types into the real Composer and presses
+    Enter through the pilot; asserts the text reached ``submit_user_text``."""
+    from reyn.interfaces.inline.textual_chat import Composer, TextualChatApp
+
+    transport = ScriptedTransport([], end=False)
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert transport.submitted == ["hi"]
+
+
+def test_textual_is_a_direct_dependency() -> None:
+    """Tier 1: ``textual`` is an explicit DIRECT dependency (floor-pinned), not
+    only transitive via flowview — the app code imports ``textual.app`` directly,
+    so the dependency contract must name it. Reads the real ``pyproject.toml``."""
+    data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    deps = data["project"]["dependencies"]
+    textual_reqs = [d for d in deps if d.split()[0].split(">")[0].split("=")[0] == "textual"]
+    assert textual_reqs, f"textual not a direct dependency; deps={deps}"
+    assert any(">=" in d for d in textual_reqs), (
+        f"textual direct dep must be floor-pinned; got {textual_reqs}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3759,6 +3759,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "textual" },
     { name = "textual-flowview" },
 ]
 
@@ -3864,6 +3865,7 @@ requires-dist = [
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6" },
     { name = "sqlite-vec", marker = "extra == 'builtin-rag'", specifier = ">=0.1.9" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=1.0,<1.3" },
+    { name = "textual", specifier = ">=0.80" },
     { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=15a942c27bdb82ddfe7f550f0f35d121c63440c8" },
     { name = "trafilatura", marker = "extra == 'fetch'", specifier = ">=1.8" },
     { name = "twine", marker = "extra == 'release'", specifier = ">=5.0" },


### PR DESCRIPTION
**[per-PR-coder]** — Phase 1 of the TUI-rebuild arc (`part of #3273`): the interactive TTY **conversation pane** as a Textual app on textual-flowview, wired into the real chat startup path, with the plain renderer preserved as the non-TTY fallback. Scope is the conversation pane + wiring + fallback only — gutter state-color/blink (P2), tab-drawer chrome (P3), drawer data (P4), and restore-on-restart (P5) are out of scope.

## App / wiring structure
- **`src/reyn/interfaces/inline/textual_chat.py`** (new):
  - `TextualChatApp(App)` — OWNS both input (a multiline `Composer`) and output (a retained `FlowModel` → `FlowView(spacing=1, anchor=STICKY_BOTTOM)`, scrollbar hidden, edge-to-edge). Deliberately NOT a `ChatRenderer` subclass (retained-model vs incremental-print paradigm).
  - `ReynPresenter.present(item, width) -> Presentation` and `ReynGutter.decorate(entry, width, height)` — **import and reuse** `_CC_*` / `_KIND_LINE` (+ `_body_renderable` / tool-summary helpers) from `renderer.py`; no restyling vocabulary.
  - A Textual worker drains the live `transport.frames()` stream into the model (event frames are the P2 working-indicator path — consumed, not yet drawn); Composer submit → `transport.submit_user_text` (free-text intervention answers take the answer seam). The user's own line is NOT echoed locally — it returns as a `kind="user"` frame, so the model is fed entirely from frames.
- **`client_driver.run_chat_client`**: a single branch at the existing `renderer.uses_app_input() and is_tty` gate routes to `run_textual_chat`; the plain PromptSession + shared output loop path (`--cui` / non-TTY / piped) is unchanged.

## Lazy-import isolation (the exact boundary)
`textual` and `textual_flowview` are imported at the **top of `textual_chat.py` only**. That module is imported **lazily inside the TTY branch** of `run_chat_client` (`from reyn.interfaces.inline.textual_chat import run_textual_chat` under the `if`). No always-loaded module imports flowview/textual at module top level, so plain / `--cui` / non-TTY / CI paths never touch it and stay green even if flowview is absent/unimportable.

## Dependency
`textual>=0.80` promoted to an explicit **direct** dependency (matching flowview's floor; Phase 0 left it transitive). `uv.lock` updated.

## Doc drift
`docs/reference/runtime/agui-transport.md` updated: the interactive-TTY surface is now the Textual conversation-pane app (local ≡ remote parity preserved — the branch is shared, both consume the same `transport.frames()`).

## Test plan (Phase 1 gates — all green with evidence)
- [x] **Resize-reflow witness** (`test_conversation_reflows_on_resize`, Tier 2b): headless `run_test` + `pilot.resize_terminal(100→40)`; a long entry's `FlowView.virtual_size.height` grows narrow vs wide (asserts content height, not formatting). Evidence: probe showed wide=6 rows / narrow=15 rows; test green.
- [x] **Import-isolation strip** (`test_plain_path_survives_flowview_absence`, Tier 2c): a CLEAN subprocess blocks `textual`/`textual_flowview` at `sys.meta_path`, imports the always-loaded plain-path modules (asserts neither entered `sys.modules` at module load), then drives a real non-TTY `run_chat_client` to `__end__`. **Falsification-verified**: adding a module-level `import textual_flowview` to the plain path turns it RED (in-process variants stay green under that regression — masked by module caching — so a subprocess is required).
- [x] **Plain-fallback equivalence** (`test_plain_fallback_equivalence_same_turn_sequence`, Tier 2c): the same scripted frame stream is fed to the real plain output loop (recording renderer) and to the mounted app; the app's modeled entry kinds equal the plain-rendered kind sequence (user/assistant/tool/result/error).
- [x] **textual → direct dep** (`test_textual_is_a_direct_dependency`, Tier 1): asserts `pyproject.toml` names `textual` as a floor-pinned direct dependency. `uv.lock` regenerated.
- [x] Bonus: `test_composer_submit_routes_to_transport` (Tier 2b) — pilot types + Enter → `transport.submit_user_text`.

## CI gates (run locally in the worktree venv)
- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase1_3273.py` — 5 inspected, 0 errors
- [x] `pytest` (full, CI extras `dev,mcp,web,fs-watch,observability,builtin-rag`) — **9184 passed, 36 skipped, 0 failed**
- [x] `python scripts/verify_module_docstrings.py` (changed src) — OK

## ADR ambiguity resolved
The ADR/Phase-1 gates did not mandate alt-screen vs inline. I run `app.run_async(inline=True)` — matching the ADR's Phase-0-validated inline mode (pre-launch scrollback preserved above the app region) without needing the Phase-3 bottom chrome. Flagging as the one design choice made; easy to revisit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)