### PR TITLE
feat(tui): Phase 3 — bottom-chrome tab-drawer (#3273)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat.py
+++ b/src/reyn/interfaces/inline/textual_chat.py
@@ -21,6 +21,20 @@ inventing a second styling vocabulary: :class:`ReynPresenter` fills the body cel
 and :class:`ReynGutter` fills the flowview gutter column, the split flowview's
 presenter/decorator protocol expects.
 
+Phase 3 adds the bottom-chrome tab-drawer. Below the composer sit two slim rows —
+a :class:`StatusLine` of ``model │ agent │ cost │ ctx`` values and a focusable
+:class:`MenuBar` (a ``Tabs`` row: ``Model Agent History Cost Ctx Menu Help``) —
+plus a :class:`~textual.widgets.ContentSwitcher` drawer that is collapsed by
+default and expands DOWNWARD when a menu item is opened. Focus flows ``↓`` from
+the composer's last line into the menu, ``← →`` move the highlight, ``Enter``
+opens the highlighted item's drawer, and ``↑``/``Esc`` close it and return focus
+to the composer (arrow-move alone never opens — opening is an explicit Enter).
+Interactive panes are Textual :class:`~textual.widgets.OptionList` widgets
+(Model/Agent/History/Menu); static readouts are plain Rich
+:class:`~textual.widgets.Static` (Cost/Ctx/Help). The drawer content is
+PLACEHOLDER here — wiring it to reyn's real registries (model/agent/history/cost/
+ctx/slash-commands/keybindings) is Phase 4.
+
 Import boundary (load-bearing): this module imports :mod:`textual` and
 :mod:`textual_flowview` at top level, so it must only ever be imported on the TTY
 path — :func:`~reyn.interfaces.repl.client_driver.run_chat_client` imports it
@@ -38,7 +52,15 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
 from textual.message import Message
-from textual.widgets import Static, TextArea
+from textual.widget import Widget
+from textual.widgets import (
+    ContentSwitcher,
+    OptionList,
+    Static,
+    Tab,
+    Tabs,
+    TextArea,
+)
 from textual_flowview import (
     Anchor,
     Entry,
@@ -266,6 +288,19 @@ class Composer(TextArea):
             start, end = self.selection
             self._replace_via_keyboard("\n", start, end)
             return
+        if event.key == "down":
+            # ↓ on the composer's LAST line hands focus down to the menu row
+            # (CC/reyn chrome flow: the composer is the default focus; ↓ steps
+            # into the bottom chrome). On any earlier line ↓ moves the cursor
+            # normally (falls through to the base TextArea).
+            row, _ = self.cursor_location
+            if row >= self.document.line_count - 1:
+                menubar = self.app.query(MenuBar)
+                if menubar:
+                    event.stop()
+                    event.prevent_default()
+                    menubar.first().focus()
+                    return
         await super()._on_key(event)
 
     def on_text_area_changed(self, event: TextArea.Changed) -> None:
@@ -278,6 +313,124 @@ class Composer(TextArea):
     def clear_and_reset(self) -> None:
         self.text = ""
         self._sync_height()
+
+
+# ── Phase 3: bottom-chrome tab-drawer ────────────────────────────────────────
+# Default collapsed = a slim status-values line + a focusable menu row. Pressing
+# ↓ from the composer focuses the menu; opening an item expands a drawer
+# DOWNWARD. Interactive panes are Textual OptionLists (Model/Agent/History/Menu —
+# keyboard selection); static readouts are plain Rich in a Static (Cost/Ctx/Help)
+# — the "Textual only where there is a selection" split. Content is PLACEHOLDER
+# here; wiring to reyn's real registries is Phase 4.
+
+_MENU_TABS: "list[tuple[str, str]]" = [
+    ("model", "Model"),
+    ("agent", "Agent"),
+    ("history", "History"),
+    ("cost", "Cost"),
+    ("ctx", "Ctx"),
+    ("menu", "Menu"),
+    ("help", "Help"),
+]
+
+
+def _drawer_child(tab_id: str) -> Widget:
+    """Build the drawer pane for a menu item: an :class:`OptionList` for the
+    interactive pickers (Model/Agent/History/Menu — keyboard selection), a plain
+    Rich :class:`Static` for the read-only readouts (Cost/Ctx/Help).
+
+    The content is PLACEHOLDER (Phase 3 ports the STRUCTURE only). Phase 4 swaps
+    each pane's body for its canonical reyn registry (model/agent registries,
+    session history, cost/token trackers, the slash-command registry, keybindings).
+    """
+    if tab_id == "model":
+        return OptionList(
+            "sonnet   · active", "opus", "haiku", "gemini-2.5-flash-lite",
+            id="model",
+        )
+    if tab_id == "agent":
+        return OptionList(
+            "default   · active", "planner", "reviewer", "researcher",
+            id="agent",
+        )
+    if tab_id == "history":
+        return OptionList(
+            "1 · (placeholder) previous conversation turn…",
+            "2 · (placeholder) another previous turn…",
+            id="history",
+        )
+    if tab_id == "menu":
+        return OptionList(
+            "/model — switch model",
+            "/agent — switch agent",
+            "/clear — clear conversation",
+            "/quit — exit",
+            id="menu",
+        )
+    if tab_id == "cost":
+        return Static(
+            Text.from_markup(
+                "[b]Usage · this session[/b] (placeholder)\n"
+                "  turn    $0.0000\n"
+                "  total   $0.0000\n"
+                "  tokens  0 in · 0 out"
+            ),
+            id="cost",
+        )
+    if tab_id == "ctx":
+        return Static(
+            Text.from_markup(
+                "[b]Context window[/b] (placeholder)\n"
+                "  0 / 200 000 tokens  (0%)\n"
+                "  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁"
+            ),
+            id="ctx",
+        )
+    return Static(
+        Text.from_markup(
+            "[b]Shortcuts[/b]\n"
+            "  enter send · shift+enter newline\n"
+            "  ↓ focus menu · ← → move · enter open · esc close"
+        ),
+        id="help",
+    )
+
+
+class StatusLine(Static):
+    """Slim bottom status-values line — plain, not rich. Mirrors reyn's inline
+    REPL bottom toolbar (``model │ agent │ cost │ ctx``), which sits BELOW the
+    input — matching Claude Code and reyn (not a top-docked line). The menu
+    *items* live in the focusable :class:`MenuBar` row just below it."""
+
+
+class MenuBar(Tabs):
+    """Focusable horizontal menu row (the collapsed bottom chrome). ``← →`` move
+    the highlight, ``Enter`` opens the highlighted item's drawer, and ``↑``/``Esc``
+    close it and hand focus back to the composer. Unlike a plain :class:`Tabs`,
+    moving the highlight does NOT open anything — opening is an explicit ``Enter``
+    (the base ``Tabs.TabActivated`` fired on arrow-move is intentionally ignored)."""
+
+    class Selected(Message):
+        """Posted on an explicit ``Enter`` (opening ``tab_id``) or on ``↑``/``Esc``
+        (the sentinel ``"__close__"``)."""
+
+        def __init__(self, tab_id: str) -> None:
+            self.tab_id = tab_id
+            super().__init__()
+
+    async def _on_key(self, event: events.Key) -> None:
+        if event.key == "enter":
+            event.stop()
+            event.prevent_default()
+            if self.active:
+                self.post_message(self.Selected(self.active))
+            return
+        if event.key in ("up", "escape"):
+            event.stop()
+            event.prevent_default()
+            self.post_message(self.Selected("__close__"))
+            return
+        await super()._on_key(event)
 
 
 class TextualChatApp(App):
@@ -296,10 +449,22 @@ class TextualChatApp(App):
     failed row is tinted coral edge-to-edge, and RUNNING rows blink via an
     app-side timer (:meth:`_advance_blink`). The blink is additive — neutering
     the timer leaves a static, correct gutter.
+
+    Phase 3 adds the bottom-chrome tab-drawer: below the composer, a
+    :class:`StatusLine` + a focusable :class:`MenuBar`, and a
+    :class:`~textual.widgets.ContentSwitcher` drawer that is collapsed by default
+    and expands DOWNWARD when a menu item is opened (see :meth:`_open_drawer`).
+    The drawer content is placeholder — real registry wiring is Phase 4.
     """
 
     #: Seconds between running-blink frames (app-side; textual-flowview unmodified).
     BLINK_INTERVAL = 0.5
+
+    BINDINGS = [
+        # Global fallback so Esc closes the drawer even when focus is INSIDE it
+        # (an OptionList pane); the MenuBar's own ↑/Esc handles the menu-row case.
+        ("escape", "close_drawer", "Close drawer"),
+    ]
 
     CSS = """
     Screen { layout: vertical; }
@@ -325,6 +490,36 @@ class TextualChatApp(App):
         border: none;
         padding: 0;
     }
+    StatusLine {
+        height: 1;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    MenuBar {
+        height: 1;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    MenuBar:focus-within { color: $text; }
+    MenuBar Tab { padding: 0 1; }
+    /* No separator rule between the menu row and its drawer — they read as one
+       continuous, edge-to-edge block (the $panel background is the only cue). */
+    #drawer {
+        height: auto;
+        max-height: 12;
+        background: $panel;
+        padding: 0;
+    }
+    /* OptionList ships an all-round default border — strip it so the drawer
+       content is edge-to-edge (full-width highlight rows, no side frame). */
+    #drawer OptionList {
+        height: auto;
+        max-height: 12;
+        background: $panel;
+        border: none;
+        padding: 0;
+    }
+    #drawer Static { height: auto; padding: 1 0; }
     """
 
     def __init__(
@@ -363,6 +558,21 @@ class TextualChatApp(App):
             yield Composer(
                 placeholder="Type a message — Enter to send, Shift+Enter for a newline…"
             )
+        # Bottom chrome (Phase 3): a slim status-values line + a focusable menu
+        # row, then a drawer (ContentSwitcher) that stays collapsed until a menu
+        # item opens it downward. Content is placeholder (Phase 4 wires the data).
+        yield StatusLine(self._status_text())
+        yield MenuBar(*(Tab(label, id=tid) for tid, label in _MENU_TABS), id="menubar")
+        with ContentSwitcher(initial=None, id="drawer"):
+            for tid, _label in _MENU_TABS:
+                yield _drawer_child(tid)
+
+    def _status_text(self) -> str:
+        """The status-values line (``model │ agent │ cost │ ctx``). PLACEHOLDER
+        values in Phase 3 — Phase 4 sources them from reyn's cost/token trackers
+        and the model/agent selection. The agent name is the one already threaded
+        into the app so at least that value is live."""
+        return f"model sonnet │ agent {self._agent_name} │ cost $0.0000 │ ctx 0%"
 
     def on_mount(self) -> None:
         # The running-blink timer starts PAUSED and is resumed only while a
@@ -374,7 +584,39 @@ class TextualChatApp(App):
             self.BLINK_INTERVAL, self._advance_blink, pause=True
         )
         self.run_worker(self._pump_frames(), name="frames", exclusive=True)
+        # Drawer starts collapsed — the default chrome is just the two slim rows
+        # (status-values line + menu row). It only becomes visible when a menu
+        # item is opened (:meth:`_open_drawer`).
+        self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
+
+    def _open_drawer(self, tab_id: "str | None") -> None:
+        """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``
+        sentinel) collapses it and returns focus to the composer; a tab id shows
+        that pane, focusing the :class:`OptionList` when the pane is an
+        interactive picker so ``↑``/``↓`` immediately drive the selection."""
+        drawer = self.query_one("#drawer", ContentSwitcher)
+        if tab_id is None or tab_id == "__close__":
+            drawer.display = False
+            drawer.current = None
+            self.query_one(Composer).focus()
+            return
+        drawer.current = tab_id
+        drawer.display = True
+        child = drawer.query_one(f"#{tab_id}")
+        if isinstance(child, OptionList):
+            child.focus()
+
+    def on_menu_bar_selected(self, event: "MenuBar.Selected") -> None:
+        self._open_drawer(None if event.tab_id == "__close__" else event.tab_id)
+
+    def on_option_list_option_selected(self, event: "OptionList.OptionSelected") -> None:
+        # A real impl (Phase 4) applies the picked model/agent/etc.; Phase 3 just
+        # collapses back to the composer.
+        self._open_drawer(None)
+
+    def action_close_drawer(self) -> None:
+        self._open_drawer(None)
 
     def _advance_blink(self) -> None:
         """One blink tick: advance the shared frame counter and redraw ONLY the
@@ -525,8 +767,10 @@ async def run_textual_chat(
 
 __all__ = [
     "Composer",
+    "MenuBar",
     "ReynGutter",
     "ReynPresenter",
+    "StatusLine",
     "TextualChatApp",
     "run_textual_chat",
 ]

--- a/tests/test_textual_chat_phase3_3273.py
+++ b/tests/test_textual_chat_phase3_3273.py
@@ -1,0 +1,276 @@
+"""Phase 3 TUI-rebuild gates (#3273): the bottom-chrome tab-drawer.
+
+These pin the architect-specified Phase-3 invariants:
+
+- **collapsed-by-default** (Tier 2b): the drawer is hidden on mount — the default
+  chrome is just the two slim rows (status-values line + focusable menu row).
+- **focus flow** (Tier 2b): ``↓`` from the composer focuses the menu; ``← →``
+  move the highlight WITHOUT opening; ``Enter`` opens the highlighted item's
+  drawer downward (``ContentSwitcher.current`` set + visible); ``↑``/``Esc`` close
+  it and return focus to the composer.
+- **edge-to-edge** (Tier 2c): the composer and the drawer carry no side borders,
+  and there is no separator rule between the menu row and its drawer — a
+  structural check of the mounted widgets' computed styles.
+- **import isolation preserved** (Tier 2c): the extra ``textual`` widgets the
+  chrome imports at module top level do NOT leak onto the plain / non-TTY path —
+  it stays green with ``textual`` / ``textual_flowview`` unimportable (the
+  flowview/textual import remains lazy + TTY-only).
+
+All use real instances (a concrete :class:`ScriptedTransport`, the real app +
+pilot) — no mocks — per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ScriptedTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
+    open so the app under test stays mounted for focus/style inspection."""
+
+    def __init__(self, messages: "list[OutboxMessage]", *, end: bool = False) -> None:
+        self._messages = list(messages)
+        self._end = end
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        if self._end:
+            yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+        else:
+            await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _edge_is_none(edge: object) -> bool:
+    """Textual's computed ``styles.border_<edge>`` is a ``(type, color)`` tuple;
+    ``type`` is falsy / ``"none"`` when there is no border on that edge."""
+    edge_type = edge[0] if isinstance(edge, tuple) else edge
+    return edge_type in ("", "none", None)
+
+
+# ── Gate 1: collapsed-by-default ──────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_drawer_collapsed_by_default() -> None:
+    """Tier 2b: on mount the drawer is hidden and empty — the default bottom
+    chrome is just the two slim rows (a StatusLine + a focusable MenuBar). The
+    ContentSwitcher's ``display`` is False and its ``current`` is None."""
+    from textual.widgets import ContentSwitcher
+
+    from reyn.interfaces.inline.textual_chat import MenuBar, StatusLine, TextualChatApp
+
+    app = TextualChatApp(transport=ScriptedTransport([], end=False))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        drawer = app.query_one("#drawer", ContentSwitcher)
+        assert drawer.display is False, "drawer should be collapsed on mount"
+        assert drawer.current is None, "no drawer pane should be selected on mount"
+        # The two slim rows are present.
+        assert app.query_one(StatusLine) is not None
+        assert app.query_one(MenuBar) is not None
+
+
+# ── Gate 2: focus flow (↓ focus / ←→ move / Enter open / ↑ or Esc close) ──────
+
+@pytest.mark.asyncio
+async def test_focus_flow_arrow_moves_without_opening_enter_opens_esc_closes() -> None:
+    """Tier 2b: the full focus flow. ``↓`` from the composer focuses the menu;
+    ``→`` moves the highlight but does NOT open the drawer; ``Enter`` opens the
+    highlighted item's drawer downward (ContentSwitcher.current set + visible);
+    ``Esc`` closes it and returns focus to the composer."""
+    from textual.widgets import ContentSwitcher
+
+    from reyn.interfaces.inline.textual_chat import Composer, MenuBar, TextualChatApp
+
+    app = TextualChatApp(transport=ScriptedTransport([], end=False))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+
+        # ↓ from the composer's (only) line focuses the menu row.
+        await pilot.press("down")
+        await pilot.pause()
+        assert isinstance(app.focused, MenuBar), f"↓ did not focus the menu: {app.focused!r}"
+
+        drawer = app.query_one("#drawer", ContentSwitcher)
+        first_active = app.query_one(MenuBar).active
+
+        # → moves the highlight but must NOT open the drawer (arrow != open).
+        await pilot.press("right")
+        await pilot.pause()
+        moved_active = app.query_one(MenuBar).active
+        assert moved_active != first_active, "→ did not move the menu highlight"
+        assert drawer.display is False, "arrow-move opened the drawer (must be explicit Enter)"
+        assert drawer.current is None
+
+        # Enter opens the highlighted item's drawer DOWNWARD.
+        await pilot.press("enter")
+        await pilot.pause()
+        assert drawer.display is True, "Enter did not open the drawer"
+        assert drawer.current == moved_active, "opened drawer shows the wrong pane"
+
+        # Esc closes and returns focus to the composer (works even though focus
+        # is INSIDE the drawer — the app-level binding is the fallback).
+        await pilot.press("escape")
+        await pilot.pause()
+        assert drawer.display is False, "Esc did not close the drawer"
+        assert drawer.current is None
+        assert isinstance(app.focused, Composer), f"Esc did not refocus composer: {app.focused!r}"
+
+
+@pytest.mark.asyncio
+async def test_up_from_menu_returns_to_composer_without_opening() -> None:
+    """Tier 2b: ``↑`` from the focused (but un-opened) menu row hands focus back
+    to the composer and leaves the drawer collapsed — the reverse of the ``↓``
+    step, and never an implicit open."""
+    from textual.widgets import ContentSwitcher
+
+    from reyn.interfaces.inline.textual_chat import Composer, MenuBar, TextualChatApp
+
+    app = TextualChatApp(transport=ScriptedTransport([], end=False))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert isinstance(app.focused, MenuBar)
+
+        await pilot.press("up")
+        await pilot.pause()
+        drawer = app.query_one("#drawer", ContentSwitcher)
+        assert drawer.display is False, "↑ opened the drawer (must not)"
+        assert isinstance(app.focused, Composer), f"↑ did not refocus composer: {app.focused!r}"
+
+
+# ── Gate 3: edge-to-edge (no side borders, no menu↔drawer separator) ──────────
+
+@pytest.mark.asyncio
+async def test_edge_to_edge_no_side_borders_and_no_menu_drawer_separator() -> None:
+    """Tier 2c: the chrome is edge-to-edge. The composer and every drawer
+    OptionList carry no side borders, and there is no separator rule between the
+    menu row and its drawer (MenuBar has no bottom border, the drawer no top
+    border) — inspected on the mounted widgets' computed styles, not the CSS text."""
+    from textual.widgets import ContentSwitcher, OptionList
+
+    from reyn.interfaces.inline.textual_chat import Composer, MenuBar, TextualChatApp
+
+    app = TextualChatApp(transport=ScriptedTransport([], end=False))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+
+        # The composer is borderless on all four edges (edge-to-edge input).
+        composer = app.query_one(Composer)
+        for edge in ("top", "right", "bottom", "left"):
+            assert _edge_is_none(getattr(composer.styles, f"border_{edge}")), (
+                f"composer has a {edge} border; must be edge-to-edge"
+            )
+
+        # Drawer panes (interactive OptionLists) have their side frames stripped.
+        for opt in app.query(OptionList):
+            for edge in ("left", "right"):
+                assert _edge_is_none(getattr(opt.styles, f"border_{edge}")), (
+                    f"drawer OptionList {opt.id!r} has a {edge} border; must be edge-to-edge"
+                )
+
+        # No separator between the menu row and its drawer: neither the MenuBar's
+        # bottom edge nor the drawer's top edge carries a rule.
+        menubar = app.query_one(MenuBar)
+        drawer = app.query_one("#drawer", ContentSwitcher)
+        assert _edge_is_none(menubar.styles.border_bottom), "menu row has a bottom separator"
+        assert _edge_is_none(drawer.styles.border_top), "drawer has a top separator vs the menu row"
+
+
+# ── Gate 4: import isolation preserved (chrome is TTY-only) ───────────────────
+
+# The Phase-1 witness proves the plain path survives ``textual`` absence; Phase 3
+# adds MORE top-level textual imports (ContentSwitcher/OptionList/Tabs/Tab/Widget)
+# to ``textual_chat``, so re-run the strip in a clean subprocess to prove those
+# additions did NOT leak onto the always-loaded plain path. Same shape as the
+# Phase-1 witness (a subprocess is required so cached in-process imports cannot
+# mask a top-level-import regression).
+_ISOLATION_SUBPROCESS = '''
+import sys
+
+
+class _Block:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in ("textual", "textual_flowview"):
+            raise ModuleNotFoundError("blocked for isolation test: " + name)
+        return None
+
+
+sys.meta_path.insert(0, _Block())
+
+import reyn.interfaces.repl.client_driver  # noqa: E402,F401
+import reyn.interfaces.repl.stream_client  # noqa: E402,F401
+import reyn.interfaces.cli.commands.chat  # noqa: E402,F401
+
+assert "textual_flowview" not in sys.modules, "flowview imported at module load"
+assert "textual" not in sys.modules, "textual imported at module load"
+print("ISOLATION_OK")
+'''
+
+
+def test_phase3_chrome_imports_stay_tty_only() -> None:
+    """Tier 2c: with ``textual`` / ``textual_flowview`` unimportable from a clean
+    interpreter, the plain / non-TTY path still imports green — Phase 3's extra
+    top-level textual widget imports (ContentSwitcher/OptionList/Tabs/…) live in
+    ``textual_chat``, which stays lazily imported on the TTY path only. Runs the
+    strip in a subprocess (see the module comment) and asserts ``ISOLATION_OK``."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _ISOLATION_SUBPROCESS],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"


### PR DESCRIPTION
**[per-PR-coder]** — part of #3273 (TUI-rebuild arc, Phase 3). Ports the owner-approved PoC's bottom chrome (`textual-flowview/examples/reyn_poc/reyn_chat_poc.py`) into `TextualChatApp`. Rebased cleanly onto main after Phase 2 (#3276) merged.

## What this adds (chrome STRUCTURE only — real data is Phase 4)
Extends Phase 1+2's `TextualChatApp` in `src/reyn/interfaces/inline/textual_chat.py`:
- **`StatusLine(Static)`** — slim `model │ agent │ cost │ ctx` values row (agent name is live from the app; the rest are placeholder pending Phase 4).
- **`MenuBar(Tabs)`** — focusable menu row `Model Agent History Cost Ctx Menu Help`, with a `MenuBar.Selected` message. Arrow-move moves the highlight but never opens (the base `Tabs.TabActivated` on arrow-move is intentionally ignored); opening is an explicit `Enter`.
- **`ContentSwitcher` drawer** (`id="drawer"`) — collapsed by default (`display=False`, `current=None` in `on_mount`), expands DOWNWARD when a menu item is opened.
- **`_drawer_child` / `_MENU_TABS`** — interactive panes = Textual `OptionList` (Model/Agent/History/Menu); static readouts = plain Rich `Static` (Cost/Ctx/Help). Content is PLACEHOLDER, explicitly labeled.
- **CSS** — slim `StatusLine`/`MenuBar` rows; borderless edge-to-edge drawer + `OptionList`; no menu↔drawer separator. Phase 1's `❯`-gutter + borderless Composer + 1-row spacer unchanged.

## Focus flow
- `Composer._on_key`: `↓` on the composer's LAST line focuses `MenuBar`; earlier lines fall through to normal cursor movement.
- `MenuBar._on_key`: `Enter` → `Selected(active)`; `↑`/`Esc` → `Selected("__close__")`.
- App: `on_menu_bar_selected` → `_open_drawer` (shows pane + focuses the `OptionList`, or collapses + refocuses Composer); `action_close_drawer` bound to `escape` app-wide as the fallback when focus is inside the drawer.

## Out of scope (later phases)
Real drawer content/registry wiring (Phase 4); restore-on-restart hydration (Phase 5).

## 4 CI gates (worktree venv, CI extras `dev,mcp,web,fs-watch,observability,builtin-rag`) — post-rebase
- **ruff** `check src tests` — All checks passed.
- **tier-audit** `--strict tests/test_textual_chat_phase3_3273.py` — 5 inspected, 0 Tier-4 violations.
- **pytest** (full suite, repo root, foreground) — **9197 passed, 36 skipped**.
- **verify_module_docstrings** on the changed src file — OK.

## Test plan (`tests/test_textual_chat_phase3_3273.py`, 5 tests — all green)
- [x] **Collapsed-by-default** — `test_drawer_collapsed_by_default`: on mount `drawer.display is False` and `current is None`; StatusLine + MenuBar present.
- [x] **Focus flow** — `test_focus_flow_arrow_moves_without_opening_enter_opens_esc_closes`: `↓` focuses MenuBar; `→` moves `active` but drawer stays hidden; `Enter` sets `display=True` + `current==highlighted`; `Esc` closes and refocuses Composer. Plus `test_up_from_menu_returns_to_composer_without_opening` (`↑` returns to composer without opening).
- [x] **Edge-to-edge** — `test_edge_to_edge_no_side_borders_and_no_menu_drawer_separator`: computed styles on the mounted composer (4 borderless edges), every drawer `OptionList` (no side borders), and no MenuBar-bottom / drawer-top separator.
- [x] **Plain-fallback + import-isolation preserved** — `test_phase3_chrome_imports_stay_tty_only`: clean-subprocess strip blocks `textual`/`textual_flowview`; plain-path modules import with neither entering `sys.modules`, proving Phase 3's extra top-level textual-widget imports stay TTY-only. Phase-1's original resize/isolation/equivalence witnesses also re-run green in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)