### PR TITLE
fix(tui): wire choice-intervention into the Textual chat app (#3273 Phase 3.5)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/__init__.py
+++ b/src/reyn/interfaces/inline/textual_chat/__init__.py
@@ -63,7 +63,7 @@ from __future__ import annotations
 from .app import TextualChatApp, run_textual_chat
 from .chrome import Composer, MenuBar, StatusLine
 from .gutter import ReynGutter
-from .presenter import ReynPresenter, _body_and_background
+from .presenter import ReynPresenter, _body_and_background, choice_chip_spans
 
 __all__ = [
     "Composer",
@@ -73,5 +73,6 @@ __all__ = [
     "StatusLine",
     "TextualChatApp",
     "_body_and_background",
+    "choice_chip_spans",
     "run_textual_chat",
 ]

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -21,6 +21,7 @@ imports never reach an always-loaded module.
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from textual.app import App, ComposeResult
@@ -39,7 +40,7 @@ from reyn.interfaces.transport.frames import FrameTag
 
 from .chrome import _MENU_TABS, Composer, MenuBar, StatusLine, _drawer_child
 from .gutter import ReynGutter
-from .presenter import ReynPresenter
+from .presenter import ReynPresenter, choice_chip_spans
 
 if TYPE_CHECKING:
     from textual.timer import Timer
@@ -62,6 +63,12 @@ _SKIP_KINDS = frozenset(
         "__session_switch_request__",
     }
 )
+
+#: FlowView gutter column width (state-coloured marker). Shared by ``compose``
+#: (the ``FlowView(gutter_width=…)`` config) and the choice-chip click handler,
+#: which must reconstruct the presenter's body width (content − gutter) to know
+#: which ``event.x`` column a click landed on.
+_GUTTER_WIDTH = 2
 
 
 class TextualChatApp(App):
@@ -86,6 +93,16 @@ class TextualChatApp(App):
     :class:`~textual.widgets.ContentSwitcher` drawer that is collapsed by default
     and expands DOWNWARD when a menu item is opened (see :meth:`_open_drawer`).
     The drawer content is placeholder — real registry wiring is Phase 4.
+
+    Phase 3.5 wires CHOICE interventions: a closed-set intervention (permission
+    confirm / choice ``ask_user`` — any ``kind="intervention"`` frame carrying
+    ``meta["choices"]``) is surfaced by the presenter as in-flow amber option
+    chips; a click on a chip (:meth:`on_flow_view_clicked`) delivers that
+    choice's id through ``transport.answer_intervention_choice`` and re-presents
+    the entry to a green resolved state. Free-text interventions keep taking the
+    composer answer path (:meth:`_submit`). This restores choice-intervention
+    reachability, which the free-text-only wiring had left unanswerable in the
+    Textual TTY.
     """
 
     #: Seconds between running-blink frames (app-side; textual-flowview unmodified).
@@ -167,6 +184,11 @@ class TextualChatApp(App):
         self._agent_name = agent_name
         self._config = config
         self.conversation: "FlowModel[OutboxMessage]" = FlowModel()
+        # One presenter instance, shared between the FlowView (which DRAWS entries)
+        # and the choice-chip click handler (which asks it which body row the chips
+        # landed on), so hit-testing measures the prompt head exactly as it was
+        # drawn.
+        self._presenter = ReynPresenter()
         # Running tool-call entries keyed by op_id (== the dispatcher's
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
@@ -178,9 +200,9 @@ class TextualChatApp(App):
     def compose(self) -> ComposeResult:
         yield FlowView(
             model=self.conversation,
-            presenter=ReynPresenter(),
+            presenter=self._presenter,
             decorator=ReynGutter(blink_frame=lambda: self._blink_count),
-            gutter_width=2,
+            gutter_width=_GUTTER_WIDTH,
             spacing=1,
             anchor=Anchor.STICKY_BOTTOM,
         )
@@ -248,6 +270,49 @@ class TextualChatApp(App):
 
     def action_close_drawer(self) -> None:
         self._open_drawer(None)
+
+    async def on_flow_view_clicked(self, event: "FlowView.Clicked") -> None:
+        """Resolve a pending choice-intervention when an option chip is clicked.
+
+        A closed-set intervention (permission confirm / choice ``ask_user`` —
+        anything carrying ``meta["choices"]``) is surfaced by the presenter as
+        in-flow amber chips on the row below its prompt. A click that lands on a
+        chip delivers that choice's id through the transport's
+        ``answer_intervention_choice`` seam — the SAME funnel
+        (``InterventionHandler.deliver_answer_to``) every answer path (TUI
+        free-text, A2A peer, AG-UI HITL) shares — then the entry re-presents to
+        its green ``✓ resolved`` state (``EntryState.SUCCESS`` also greens the
+        gutter). This handler is the ONLY choice-answer path in the Textual TTY:
+        the free-text ``_submit`` path answers only no-choices interventions, so
+        without it a choice-intervention (a permission prompt) is UNANSWERABLE
+        here — this restores that permission-band reachability (F1)."""
+        entry = event.entry
+        msg = entry.item
+        meta = msg.meta or {}
+        choices = meta.get("choices")
+        if msg.kind != "intervention" or not choices or meta.get("_chosen_label"):
+            return
+        # Reconstruct the presenter's body width (content − gutter) so the chip
+        # geometry hit-tested here matches what was drawn.
+        body_width = max(
+            1, event.flow_view.scrollable_content_region.width - _GUTTER_WIDTH
+        )
+        if event.y != self._presenter.choice_chip_row(msg, body_width):
+            return  # click was on the prompt head / hint, not the chip row
+        for start, end, choice_id in choice_chip_spans(choices):
+            if start <= event.x < end:
+                await self._transport.answer_intervention_choice(choice_id)
+                label = next(
+                    (
+                        c.get("label")
+                        for c in choices
+                        if str(c.get("id", "")) == choice_id
+                    ),
+                    choice_id,
+                )
+                entry.set_item(replace(msg, meta={**meta, "_chosen_label": label}))
+                entry.set_state(EntryState.SUCCESS)
+                break
 
     def _advance_blink(self) -> None:
         """One blink tick: advance the shared frame counter and redraw ONLY the

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -14,15 +14,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from rich.console import Console, RenderableType
+from rich.console import Console, Group, RenderableType
 from rich.text import Text
 from textual_flowview import Presentation
 
 from reyn.interfaces.repl.renderer import (
     _CC_DIM,
+    _CC_DONE,
     _CC_ERR,
     _CC_TEXT,
     _CC_USER_BG,
+    _CC_WARN,
     _KIND_LINE,
     _body_renderable,
     _summarize_args,
@@ -31,6 +33,78 @@ from reyn.interfaces.repl.renderer import (
 
 if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
+
+# --- choice-intervention chip layout ---------------------------------------
+# A closed-set intervention (permission confirm / choice ``ask_user`` — anything
+# carrying ``meta["choices"]``) is surfaced IN FLOW as clickable option chips on
+# a single row below the prompt, mirroring the PoC's ``ask_user`` affordance and
+# the old inline region's cursor+Enter picker. Selecting a chip resolves the
+# intervention through ``transport.answer_intervention_choice`` (see
+# ``TextualChatApp.on_flow_view_clicked``); the chip geometry here is the SINGLE
+# source of truth both the presenter (draw) and the app (hit-test) read, so a
+# click always maps to the chip that was drawn.
+_CHOICE_INDENT = 2  # leading pad before the first chip (cols)
+_CHOICE_GAP = 2  # gap between chips (cols)
+_CHOICE_HINT = "  ↑ click an option"
+
+
+def _choice_chip(index: int, label: str) -> str:
+    """The rendered text of one option chip (``[ 1 · Yes ]``)."""
+    return f"[ {index + 1} · {label} ]"
+
+
+def choice_chip_spans(
+    choices: "list[dict]",
+) -> "list[tuple[int, int, str]]":
+    """``(start_col, end_col, choice_id)`` per chip on the chip row.
+
+    Shared by the presenter (which DRAWS the chips) and the app click handler
+    (which HIT-TESTS a click's column against these spans), so the two never
+    disagree about where a chip is. ``choice_id`` is the authoritative match key
+    delivered to ``answer_intervention_choice`` — never displayed, so it is not
+    neutralized here (only the visible label is, in :func:`_neutralized_label`).
+    """
+    spans: "list[tuple[int, int, str]]" = []
+    col = _CHOICE_INDENT
+    for i, choice in enumerate(choices):
+        text = _choice_chip(i, _neutralized_label(choice.get("label", "")))
+        spans.append((col, col + len(text), str(choice.get("id", ""))))
+        col += len(text) + _CHOICE_GAP
+    return spans
+
+
+def _neutralized_label(label: str) -> str:
+    """Neutralize an LLM-derived choice label at this display boundary.
+
+    ``meta["choices"]`` labels reach here RAW (``session._iv_meta`` copies
+    ``choice.label`` verbatim; only the ``nodes`` render-model path is
+    neutralized at the source). Route each label through the SAME terminal
+    neutralizer the old inline picker (``intervention_region.InterventionElement``)
+    and ``present``'s leaf seam use (ESC/control strip, FP-0054) before it reaches
+    the terminal, so a control/ESC sequence in a label can't drive the terminal.
+    """
+    from reyn.core.present.guard import get_neutralizer
+
+    return get_neutralizer("terminal").neutralize(label)[0]
+
+
+def _choice_head(msg: "OutboxMessage") -> RenderableType:
+    """The prompt head of a choice-intervention entry (prompt + optional detail).
+
+    Built from the STRUCTURED ``meta`` fields (``prompt`` / ``detail``, added by
+    ``session._iv_meta`` for exactly this "TUI renderers build chips without
+    re-parsing the text" use) rather than the ``nodes`` render-model, because the
+    ``nodes`` list already embeds the choice labels as a bullet list — rendering
+    it would DOUBLE the options (once as a list, once as chips). Leaves are
+    neutralized at this boundary (the structured fields are copied raw by
+    ``_iv_meta``)."""
+    meta = msg.meta or {}
+    prompt = _neutralized_label(str(meta.get("prompt") or msg.text or " "))
+    parts: "list[RenderableType]" = [Text(prompt, style=_CC_TEXT)]
+    detail = meta.get("detail")
+    if detail:
+        parts.append(Text(_neutralized_label(str(detail)), style=_CC_DIM))
+    return parts[0] if len(parts) == 1 else Group(*parts)
 
 
 def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | None]":
@@ -99,7 +173,51 @@ class ReynPresenter:
             1,
         )
 
+    def choice_chip_row(self, item: "OutboxMessage", width: int) -> int:
+        """The body row (0-based) the option chips are drawn on at ``width``.
+
+        The prompt head may wrap to several rows, so the chip row is not fixed —
+        the app click handler calls this (with the SAME ``width`` the presenter
+        drew at, ``FlowView._body_width()``) to know which ``event.y`` is the chip
+        row before hit-testing the column against :func:`choice_chip_spans`.
+        Recomputed (not stashed) so no client-side state is threaded through the
+        immutable frame."""
+        return self._measure(_choice_head(item), width)
+
+    def _present_intervention_choice(
+        self, item: "OutboxMessage", width: int
+    ) -> Presentation:
+        """Present a closed-set intervention as clickable option chips.
+
+        Pending: the neutralized prompt head, an amber (``_CC_WARN``) chip row of
+        ``[ n · label ]`` options, and a click hint — the "◆ needs you" amber
+        gutter (kind-driven) already marks the row. Resolved (``_chosen_label``
+        set by the click handler): the head plus a green ``✓ resolved: <label>``
+        line, matching the PoC's resolved state (the gutter also goes green via
+        ``EntryState.SUCCESS``)."""
+        meta = item.meta or {}
+        head = _choice_head(item)
+        head_h = self._measure(head, width)
+        chosen = meta.get("_chosen_label")
+        if chosen is not None:
+            resolved = Text.assemble(
+                ("  ✓ resolved: ", _CC_DIM), (str(chosen), f"bold {_CC_DONE}")
+            )
+            return Presentation(height=head_h + 1, renderable=Group(head, resolved))
+        chips = Text(" " * _CHOICE_INDENT)
+        for i, choice in enumerate(meta.get("choices", [])):
+            chips.append(
+                _choice_chip(i, _neutralized_label(choice.get("label", ""))),
+                style=f"bold {_CC_WARN}",
+            )
+            chips.append(" " * _CHOICE_GAP)
+        hint = Text(_CHOICE_HINT, style=_CC_DIM)
+        return Presentation(height=head_h + 2, renderable=Group(head, chips, hint))
+
     async def present(self, item: "OutboxMessage", width: int) -> Presentation:
+        meta = item.meta or {}
+        if item.kind == "intervention" and meta.get("choices"):
+            return self._present_intervention_choice(item, width)
         body, background = _body_and_background(item)
         return Presentation(
             height=self._measure(body, width),

--- a/tests/test_textual_chat_phase35_3273.py
+++ b/tests/test_textual_chat_phase35_3273.py
@@ -260,3 +260,54 @@ async def test_free_text_intervention_still_answered_via_composer() -> None:
     assert transport.answered_text == ["ok"]
     assert transport.submitted == []
     assert transport.answered_choice == []
+
+
+def test_choice_labels_are_neutralized_before_rendering() -> None:
+    """Tier 2c: an LLM-derived choice LABEL carrying raw terminal control
+    sequences is neutralized before it reaches the rendered chip cells — a
+    terminal-escape-injection guard on a permission surface.
+
+    Choice labels reach ``meta["choices"]`` RAW (``session._iv_meta`` copies
+    ``choice.label`` verbatim; only the ``nodes`` render-model is neutralized at
+    source), so the presenter MUST strip control bytes at its own boundary. This
+    builds a choice-intervention whose label embeds a CSI colour + OSC
+    title-set + bare ESC/BEL, presents it through the real
+    ``_present_intervention_choice`` path, renders the presentation through a
+    no-colour Console (so any escape in the output came from the LABEL, not from
+    Rich styling), and asserts the rendered cells carry NO raw ``\\x1b`` / ``\\x07``
+    while the visible label text survives (neutralized, not dropped).
+
+    NON-VACUITY (falsification): neutering ``presenter._neutralized_label`` to
+    identity (the future refactor the co-vet flagged) makes the raw ``\\x1b`` leak
+    into the rendered cells and flips this assertion RED — verified locally, so a
+    silent removal of the neutralization is caught here."""
+    from rich.console import Console
+
+    from reyn.interfaces.inline.textual_chat.presenter import ReynPresenter
+
+    payload = "\x1b[31mDANGER\x1b]0;pwn\x07"
+    msg = OutboxMessage(
+        kind="intervention",
+        text="Allow write?",
+        meta={
+            "intervention_id": "iv-x",
+            "intervention_kind": "confirm",
+            "prompt": "Allow write to /etc/hosts?",
+            "choices": [
+                {"id": "yes", "label": payload, "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+            ],
+        },
+    )
+
+    presentation = ReynPresenter()._present_intervention_choice(msg, 80)
+    console = Console(width=80, no_color=True)
+    with console.capture() as cap:
+        console.print(presentation.renderable)
+    rendered = cap.get()
+
+    assert "\x1b" not in rendered, f"raw ESC leaked into chip cells: {rendered!r}"
+    assert "\x07" not in rendered, f"raw BEL leaked into chip cells: {rendered!r}"
+    # The visible label survives — neutralization strips the control bytes, it
+    # does not drop the option (a dropped option would be its own regression).
+    assert "DANGER" in rendered

--- a/tests/test_textual_chat_phase35_3273.py
+++ b/tests/test_textual_chat_phase35_3273.py
@@ -1,0 +1,262 @@
+"""Phase 3.5 TUI-rebuild gates (#3273): choice-intervention reachability.
+
+These pin the Phase-3.5 fix (ADR self-review finding F1): a closed-set
+intervention (permission confirm / choice ``ask_user`` — any
+``kind="intervention"`` frame carrying ``meta["choices"]``) is REACHABLE in the
+Textual TTY. The free-text-only wiring left choice interventions unanswerable
+(the only ``answer_intervention_choice`` caller lived in the dead old app), a
+permission-band functional regression this restores.
+
+Gates:
+
+- **choice REACHABLE** (Tier 2b): a choice-intervention frame surfaces as
+  in-flow option chips; a click on a chip delivers the CORRECT ``choice_id``
+  through ``transport.answer_intervention_choice`` and the entry re-presents to
+  its resolved (``EntryState.SUCCESS``) state. Non-vacuous: the second option is
+  chosen (so a first-option shortcut would fail), the specific id is asserted,
+  and the SAME pending choice-intervention is shown to be UNANSWERABLE via the
+  free-text composer path (which starts a new turn instead) — the pre-fix gap.
+- **free-text still works** (Tier 2b): a no-choices intervention still routes a
+  composer submit to ``answer_intervention_text`` (regression guard).
+
+All use real instances (a concrete recording :class:`ClientTransport`, a real
+mounted :class:`TextualChatApp`, real :class:`OutboxMessage`) — no mocks — per
+the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import (
+    Composer,
+    TextualChatApp,
+    choice_chip_spans,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_GUTTER_WIDTH = 2
+
+
+class _FreeTextHead:
+    """A pending free-text intervention head (no ``choices`` attr) — the shape
+    the local transport's ``pending_intervention_head`` returns for an
+    ``ask_user`` / secret prompt that the composer answers as text."""
+
+
+class RecordingTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` that replays a fixed frame list
+    and RECORDS which answer seam each user action reached.
+
+    ``end=False`` keeps the stream open so the app stays mounted for inspection.
+    ``head`` is the pending-intervention head the free-text ``_submit`` path
+    reads (``None`` = no pending intervention → a submit is a new turn).
+    """
+
+    def __init__(
+        self,
+        messages: "list[OutboxMessage]",
+        *,
+        end: bool = False,
+        head: "object | None" = None,
+    ) -> None:
+        self._messages = list(messages)
+        self._end = end
+        self._head = head
+        self.submitted: list[str] = []
+        self.answered_choice: list[str] = []
+        self.answered_text: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        if self._end:
+            yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+        else:
+            await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        self.answered_text.append(text)
+        return True
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        self.answered_choice.append(choice_id)
+        return True
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return self._head
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _choice_intervention() -> OutboxMessage:
+    """A closed-set (permission-confirm) intervention frame, shaped exactly like
+    ``session._iv_meta`` builds it: structured ``prompt`` + ``choices`` (id /
+    label / hotkey) plus the ``nodes`` render-model."""
+    return OutboxMessage(
+        kind="intervention",
+        text="Allow write to /etc/hosts?\n  Yes / No / Always",
+        meta={
+            "intervention_id": "iv-1",
+            "intervention_kind": "confirm",
+            "prompt": "Allow write to /etc/hosts?",
+            "choices": [
+                {"id": "yes", "label": "Yes", "hotkey": "y"},
+                {"id": "no", "label": "No", "hotkey": "n"},
+                {"id": "always", "label": "Always", "hotkey": "A"},
+            ],
+            "nodes": [
+                {"component": "text", "text": "Allow write to /etc/hosts?"},
+                {"component": "list", "items": ["Yes", "No", "Always"]},
+            ],
+        },
+    )
+
+
+def _iv_entry(app: TextualChatApp):
+    entries = [
+        e for e in app.query_one(FlowView).entries if e.item.kind == "intervention"
+    ]
+    assert len(entries) == 1, f"expected one intervention entry, got {len(entries)}"
+    return entries[0]
+
+
+@pytest.mark.asyncio
+async def test_choice_intervention_click_delivers_correct_choice_id() -> None:
+    """Tier 2b: a choice-intervention frame is REACHABLE — clicking its second
+    option chip delivers that option's ``choice_id`` ("no") through
+    ``answer_intervention_choice`` and the entry goes to its resolved SUCCESS
+    state. This is the F1 permission-band reachability witness. Non-vacuous: the
+    SECOND option is chosen and its exact id asserted (a first-option or
+    label-vs-id confusion fails), and no answer is delivered before the click."""
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entry = _iv_entry(app)
+        flow = app.query_one(FlowView)
+
+        # No answer is delivered until the user acts.
+        assert transport.answered_choice == []
+
+        body_width = max(1, flow.scrollable_content_region.width - _GUTTER_WIDTH)
+        chip_row = app._presenter.choice_chip_row(entry.item, body_width)
+        spans = choice_chip_spans(entry.item.meta["choices"])
+        # Choose the SECOND chip ("No", id "no") — proves the click maps to the
+        # right choice, not merely "some choice was answered".
+        start, end, choice_id = spans[1]
+        assert choice_id == "no"
+        click_x = (start + end) // 2
+        app.post_message(FlowView.Clicked(flow, entry, click_x, chip_row))
+        await pilot.pause()
+        await pilot.pause()
+
+        assert transport.answered_choice == ["no"], (
+            f"choice not delivered; got {transport.answered_choice}"
+        )
+        # Resolved reflection: green SUCCESS gutter + recorded chosen label.
+        resolved = _iv_entry(app)
+        assert resolved.state is EntryState.SUCCESS
+        assert resolved.item.meta.get("_chosen_label") == "No"
+
+
+@pytest.mark.asyncio
+async def test_choice_click_off_the_chip_row_does_not_answer() -> None:
+    """Tier 2b: hit-testing is non-vacuous — a click on the prompt HEAD row (not
+    the chip row) delivers nothing, so the reachability test's positive result is
+    attributable to landing on a chip, not to any click resolving the whole
+    entry."""
+    transport = RecordingTransport([_choice_intervention()], end=False)
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entry = _iv_entry(app)
+        flow = app.query_one(FlowView)
+        # Row 0 is the prompt head, never the chip row (the head is one line here).
+        app.post_message(FlowView.Clicked(flow, entry, 3, 0))
+        await pilot.pause()
+        await pilot.pause()
+
+    assert transport.answered_choice == []
+
+
+@pytest.mark.asyncio
+async def test_choice_intervention_unanswerable_via_free_text_path() -> None:
+    """Tier 2b: the pre-fix gap witness — a pending CHOICE intervention is NOT
+    answered by the free-text composer path. With the choice-intervention head
+    pending, a composer submit starts a NEW TURN (``submit_user_text``) rather
+    than answering the intervention, so without the click wiring the choice would
+    never be delivered. Pairs with the reachability test to show the click path
+    is the only thing that closes the gap."""
+
+    class _ChoiceHead:
+        choices = [object(), object()]  # non-empty → NOT a free-text intervention
+
+    transport = RecordingTransport(
+        [_choice_intervention()], end=False, head=_ChoiceHead()
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await pilot.pause()
+
+    # A choice-intervention is pending, yet the text submit went to a new turn,
+    # NOT to any intervention-answer seam.
+    assert transport.submitted == ["hi"]
+    assert transport.answered_choice == []
+    assert transport.answered_text == []
+
+
+@pytest.mark.asyncio
+async def test_free_text_intervention_still_answered_via_composer() -> None:
+    """Tier 2b: regression — a FREE-TEXT intervention (no choices) still routes a
+    composer submit to ``answer_intervention_text``, unchanged by the choice
+    wiring. The head has no ``choices`` attr, so ``_submit`` takes the answer
+    path."""
+    transport = RecordingTransport([], end=False, head=_FreeTextHead())
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("o", "k")
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert transport.answered_text == ["ok"]
+    assert transport.submitted == []
+    assert transport.answered_choice == []


### PR DESCRIPTION
**[per-PR-coder]** — Phase 3.5 of the TUI-rebuild arc, `part of #3273`.

## Why (finding F1 — a permission-band functional regression)
The ADR self-review found **choice-interventions were UNREACHABLE in the new Textual TTY path.** `transport.answer_intervention_choice(choice_id)` had its only live caller in the DEAD old app (`interfaces/inline/app.py`). The new Textual `textual_chat/` package wired `answer_intervention_text` (free-text) but had **no UI for choice-type interventions** — so permission prompts / choice `ask_user` degraded in the new TUI. This restores that reachability.

## Frame-shape findings (investigation)
A choice-intervention arrives as a display frame `kind="intervention"` whose `meta` is built by `session._iv_meta` and carries structured choice data explicitly for TUI renderers:
- `meta["prompt"]` — the prompt string (structured, `_iv_meta`)
- `meta["detail"]` — optional detail
- `meta["choices"]` — `[{"id": ..., "label": ..., "hotkey": ...}, ...]` — the authoritative id + display label per option
- `meta["nodes"]` — a `present`-shaped render-model (prompt + a bullet **list of the choice labels**), neutralized at source

The distinguishing test for "closed-set vs free-text" is `meta["choices"]` non-empty (same predicate the old inline region + `_submit` use). The `id` is the authoritative match key delivered to `answer_intervention_choice`; the `label` is LLM-derived and reaches `meta["choices"]` **raw** (only the `nodes` path is neutralized at source), so labels are neutralized at the presenter boundary through the same `get_neutralizer("terminal")` seam the old `InterventionElement` used.

## How it's surfaced + wired (in-flow chips, matching the PoC)
- **Presenter** (`presenter.py`): `ReynPresenter._present_intervention_choice` renders the neutralized prompt head, then a single amber (`_CC_WARN`) chip row of `[ n · label ]` options + a click hint. Built from `meta["prompt"]`/`meta["choices"]` (not `nodes`, whose embedded choice-list would double the options). The amber `◆` "needs-you" gutter is already kind-driven. Chose **in-flow clickable chips** over `OptionList` because the frame carries per-option `{id,label}` and textual-flowview's `Clicked` message exists specifically to hit-test presenter-drawn controls — matching the PoC reference and the amber aesthetic.
- **Hit-test geometry**: `choice_chip_spans(choices) -> [(start,end,choice_id)]` is the single source of truth both the presenter (draw) and the click handler (hit-test) read. The chip row can shift when the prompt wraps, so the handler asks the shared presenter instance `choice_chip_row(msg, body_width)` (measured at the same `FlowView._body_width()` = content − gutter) which body row the chips are on before column-testing.
- **Call site** (`app.py`): `TextualChatApp.on_flow_view_clicked` — on a click landing on a chip, `await self._transport.answer_intervention_choice(choice_id)`, then reflects the resolved choice (`entry.set_item(replace(msg, meta={**meta, "_chosen_label": label}))` + `entry.set_state(EntryState.SUCCESS)` → green `✓ resolved`). Free-text interventions keep the composer `_submit` → `answer_intervention_text` path unchanged.
- **Import isolation unchanged**: all additions are inside the lazily-imported TTY-only `textual_chat` package.

## Reachability witness non-vacuity
`test_choice_intervention_click_delivers_correct_choice_id` clicks the **second** option chip ("No") and asserts `transport.answered_choice == ["no"]` — a first-option shortcut or label/id confusion fails. It also asserts **no answer is delivered before the click**, and `test_choice_intervention_unanswerable_via_free_text_path` shows the pre-fix gap directly: with a choice-intervention pending, a composer submit goes to `submit_user_text` (a new turn), **never** to any answer seam — so without the click wiring the choice is unanswerable. `test_choice_click_off_the_chip_row_does_not_answer` proves the positive result is attributable to landing on a chip (a head-row click delivers nothing), not to any click resolving the entry.

## Out of scope (per brief)
Drawer real-data wiring (Phase 4), restore (Phase 5), old-app retirement (Phase 6). The old app is NOT deleted here.

## Test plan (all run, evidence below)
- [x] **(1) Choice-intervention REACHABLE — the F1 fix, non-vacuous.** `test_choice_intervention_click_delivers_correct_choice_id`: clicking the 2nd chip drives the specific `choice_id="no"` to `transport.answer_intervention_choice`; entry → `EntryState.SUCCESS` + `_chosen_label="No"`. Non-vacuity: 2nd option chosen, exact id asserted, no answer before click, and `test_choice_intervention_unanswerable_via_free_text_path` witnesses the pre-fix gap. PASS.
- [x] **(2) Free-text intervention still works (regression).** `test_free_text_intervention_still_answered_via_composer`: with a no-choices head pending, a composer submit routes to `answer_intervention_text(["ok"])`, not `submit_user_text`. PASS.
- [x] **(3) Import-isolation preserved.** Existing subprocess witness `test_plain_path_survives_flowview_absence` (Phase 1) green; all new code is inside the lazily-imported `textual_chat` package, plain/`--cui`/non-TTY paths never import it. PASS.
- [x] **(4) Plain-fallback unaffected.** The plain renderer's own intervention handling is untouched; `test_inline_intervention_region.py` (33 tests incl. plain choice-region) + Phase 1 plain-fallback-equivalence green. PASS.

## CI gate results (worktree venv, `uv run python -m pytest`, CI extras `dev,mcp,web,fs-watch,observability,builtin-rag`)
- `ruff check src tests` — **All checks passed!**
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase35_3273.py` — **4/4 OK, 0 Tier-4 violations**
- `python -m pytest` (full suite, repo root) — **9201 passed, 36 skipped, 0 failed** (502s)
- `python scripts/verify_module_docstrings.py <changed src>` — **OK**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
