### PR TITLE
feat(tui): Phase 4 — wire bottom-chrome drawer to real reyn data (#3273)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/__init__.py
+++ b/src/reyn/interfaces/inline/textual_chat/__init__.py
@@ -35,9 +35,12 @@ highlighted item's drawer, and ``↑``/``Esc`` close it and return focus to the
 composer (arrow-move alone never opens — opening is an explicit Enter).
 Interactive panes are Textual :class:`~textual.widgets.OptionList` widgets
 (Model/Agent/History/Menu); static readouts are plain Rich
-:class:`~textual.widgets.Static` (Cost/Ctx/Help). The drawer content is
-PLACEHOLDER here — wiring it to reyn's real registries (model/agent/history/cost/
-ctx/slash-commands/keybindings) is Phase 4.
+:class:`~textual.widgets.Static` (Cost/Ctx/Help). Phase 4 wires every pane to its
+canonical reyn source — the status snapshot (model/agent/cost/ctx), the slash
+``REGISTRY`` (menu), the live conversation (history), and the app BINDINGS (help)
+— with the enumerating panes (Model/Agent/Menu) deriving their FULL set from the
+registry (never a curated subset). See
+:func:`~reyn.interfaces.inline.textual_chat.chrome.pane_payload`.
 
 Package layout (Phase 3F split — this ``__init__`` is the single lazy import
 boundary and re-exports the public API):
@@ -49,8 +52,9 @@ boundary and re-exports the public API):
 - :mod:`~reyn.interfaces.inline.textual_chat.gutter` — ``ReynGutter`` +
   running-frame constants (state-coloured gutter marker).
 - :mod:`~reyn.interfaces.inline.textual_chat.chrome` — ``Composer``,
-  ``StatusLine``, ``MenuBar``, ``_drawer_child``, ``_MENU_TABS`` (input +
-  bottom-chrome widgets).
+  ``StatusLine``, ``MenuBar``, ``_MENU_TABS``, and the pure pane formatters
+  (``pane_payload`` / ``status_line_text`` / ``build_drawer_pane``) that derive
+  each pane's rows from its canonical source (input + bottom-chrome widgets).
 
 Import boundary (load-bearing): this package imports :mod:`textual` and
 :mod:`textual_flowview` at import time (through its submodules), so it must only

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -38,7 +38,15 @@ from textual_flowview import (
 from reyn.interfaces.repl.renderer import summarize_tool_result
 from reyn.interfaces.transport.frames import FrameTag
 
-from .chrome import _MENU_TABS, Composer, MenuBar, StatusLine, _drawer_child
+from .chrome import (
+    _MENU_TABS,
+    Composer,
+    MenuBar,
+    StatusLine,
+    build_drawer_pane,
+    pane_payload,
+    status_line_text,
+)
 from .gutter import ReynGutter
 from .presenter import ReynPresenter, choice_chip_spans
 
@@ -70,6 +78,11 @@ _SKIP_KINDS = frozenset(
 #: which ``event.x`` column a click landed on.
 _GUTTER_WIDTH = 2
 
+#: Sentinel for :meth:`TextualChatApp._pane_rows`'s optional ``snap`` argument —
+#: distinguishes "no snapshot passed, read a fresh one" from an explicit ``None``
+#: snapshot (pre-session), which must NOT trigger a second read.
+_UNSET: object = object()
+
 
 class TextualChatApp(App):
     """The TTY conversation pane: a FlowView of the live conversation + a
@@ -92,7 +105,19 @@ class TextualChatApp(App):
     :class:`StatusLine` + a focusable :class:`MenuBar`, and a
     :class:`~textual.widgets.ContentSwitcher` drawer that is collapsed by default
     and expands DOWNWARD when a menu item is opened (see :meth:`_open_drawer`).
-    The drawer content is placeholder — real registry wiring is Phase 4.
+
+    Phase 4 wires each drawer pane to its canonical reyn source, rebuilding the
+    pane from a fresh status snapshot (:meth:`_snapshot`) on each open: Model/Agent
+    from ``model_classes`` / ``agent_names`` (the enumerating pickers derive their
+    FULL set from the registry, never a curated subset), Cost/Ctx from the live
+    token/cost figures (F5b — also surfaced on the always-visible status line),
+    Menu from the slash ``REGISTRY``, History from the retained live conversation,
+    Help from the app BINDINGS. Selecting a Model/Agent row routes the equivalent
+    ``/model`` / ``/attach`` slash through the transport. Cross-session restore
+    from ``history.jsonl`` (Phase 5) needs a new ``ChatReadModel`` history
+    accessor — the read model's frame-sufficiency boundary means a REMOTE client
+    cannot enumerate a session's past turns off the wire today — so History shows
+    the live conversation now and the restore seam is deferred to Phase 5.
 
     Phase 3.5 wires CHOICE interventions: a closed-set intervention (permission
     confirm / choice ``ask_user`` — any ``kind="intervention"`` frame carrying
@@ -196,6 +221,13 @@ class TextualChatApp(App):
         # Shared blink frame counter read by ReynGutter; advanced by the timer.
         self._blink_count = 0
         self._blink_timer: "Timer | None" = None
+        # Per-picker parallel id lists (class names / agent names), keyed by tab
+        # id and kept in lock-step with the OptionList options a pane was last
+        # refreshed with, so an ``OptionSelected.option_index`` maps back to the
+        # canonical id the ``/model`` / ``/attach`` slash needs. Populated on each
+        # drawer refresh (:meth:`_refresh_pane`) from the SAME snapshot that built
+        # the rows, so the option row and its id never drift.
+        self._pane_selection_ids: "dict[str, list[str]]" = {}
 
     def compose(self) -> ComposeResult:
         yield FlowView(
@@ -211,21 +243,88 @@ class TextualChatApp(App):
             yield Composer(
                 placeholder="Type a message — Enter to send, Shift+Enter for a newline…"
             )
-        # Bottom chrome (Phase 3): a slim status-values line + a focusable menu
-        # row, then a drawer (ContentSwitcher) that stays collapsed until a menu
-        # item opens it downward. Content is placeholder (Phase 4 wires the data).
+        # Bottom chrome: a slim status-values line + a focusable menu row, then a
+        # drawer (ContentSwitcher) that stays collapsed until a menu item opens it
+        # downward. Phase 4 fills each pane from its canonical reyn source; each
+        # pane is rebuilt from a fresh snapshot when opened (:meth:`_refresh_pane`).
         yield StatusLine(self._status_text())
         yield MenuBar(*(Tab(label, id=tid) for tid, label in _MENU_TABS), id="menubar")
         with ContentSwitcher(initial=None, id="drawer"):
             for tid, _label in _MENU_TABS:
-                yield _drawer_child(tid)
+                yield build_drawer_pane(tid, self._pane_rows(tid))
+
+    def _snapshot(self) -> "dict | None":
+        """The live status snapshot (model/agent/cost/ctx) off the client read
+        model — the SAME seam the plain path's status bar reads. ``None`` when
+        there is no read model or no attached session yet (pre-session): every
+        pure pane formatter degrades gracefully to empty/zero on ``None``, so the
+        drawer never fabricates a value and the plain-fallback stays untouched."""
+        if self._read_model is None:
+            return None
+        try:
+            return self._read_model.snapshot(self._config)
+        except Exception:
+            logger.exception("textual chat: status snapshot read failed")
+            return None
+
+    def _app_binding_help(self) -> "list[tuple[str, str]]":
+        """The app's declarative ``BINDINGS`` as ``(key, description)`` pairs for
+        the Help pane — sourced from the binding table itself, not re-typed."""
+        out: list[tuple[str, str]] = []
+        for b in self.BINDINGS:
+            if isinstance(b, tuple) and len(b) >= 3:
+                out.append((b[0], b[2]))
+        return out
+
+    def _history_turns(self, *, limit: int = 12) -> "list[str]":
+        """Recent conversation turns from the retained live model (the frame
+        stream the app already drains) — ``role · <first line>`` rows, newest
+        ``limit``. This is the honest in-package History source today; enumerating
+        PAST sessions for restore (``history.jsonl``) is a Phase-5 read-model-seam
+        decision (see the class docstring), not fabricated here."""
+        rows: list[str] = []
+        for entry in self.conversation:
+            msg = entry.item
+            if msg.kind not in ("user", "reply", "agent"):
+                continue
+            body = (msg.text or "").strip()
+            head = body.splitlines()[0][:60] if body else ""
+            role = "you" if msg.kind == "user" else "reyn"
+            rows.append(f"{role} · {head}")
+        return rows[-limit:]
+
+    def _pane_rows(self, tab_id: str, snap: "dict | None | object" = _UNSET) -> "list[str]":
+        """The display rows for ``tab_id``'s pane, derived from canonical sources:
+        the status snapshot (model/agent/cost/ctx), the slash ``REGISTRY`` (menu),
+        the live conversation (history), and the app BINDINGS (help). Pass ``snap``
+        to reuse an already-read snapshot (keeps the rows and the selection ids
+        derived from ONE snapshot)."""
+        from reyn.interfaces.slash import REGISTRY  # noqa: PLC0415 — TTY-local
+        snapshot = self._snapshot() if snap is _UNSET else snap
+        return pane_payload(
+            tab_id,
+            snapshot=snapshot,  # type: ignore[arg-type]
+            commands=REGISTRY.all_commands(),
+            history=self._history_turns(),
+            app_bindings=self._app_binding_help(),
+        )
+
+    def _selection_ids(self, tab_id: str, snap: "dict | None") -> "list[str]":
+        """The canonical ids parallel to a picker pane's option rows (class names
+        for Model, agent names for Agent), for mapping an ``option_index`` back to
+        the ``/model`` / ``/attach`` argument. Empty for non-actionable panes."""
+        s = snap or {}
+        if tab_id == "model":
+            return list(s.get("model_classes") or [])
+        if tab_id == "agent":
+            return list(s.get("agent_names") or [])
+        return []
 
     def _status_text(self) -> str:
-        """The status-values line (``model │ agent │ cost │ ctx``). PLACEHOLDER
-        values in Phase 3 — Phase 4 sources them from reyn's cost/token trackers
-        and the model/agent selection. The agent name is the one already threaded
-        into the app so at least that value is live."""
-        return f"model sonnet │ agent {self._agent_name} │ cost $0.0000 │ ctx 0%"
+        """The status-values line (``model │ agent │ cost │ ctx``), from the live
+        status snapshot (F5b: running cost + context percent are visible even with
+        the drawer closed). Falls back to the threaded ``agent_name`` pre-session."""
+        return status_line_text(self._snapshot(), self._agent_name)
 
     def on_mount(self) -> None:
         # The running-blink timer starts PAUSED and is resumed only while a
@@ -255,17 +354,50 @@ class TextualChatApp(App):
             self.query_one(Composer).focus()
             return
         drawer.current = tab_id
+        # Rebuild the pane from a fresh snapshot right before it becomes visible,
+        # so an opened Model/Agent/Cost/Ctx pane always reflects the CURRENT state
+        # (a snapshot read once at compose time would be stale by first open).
+        self._refresh_pane(tab_id)
         drawer.display = True
         child = drawer.query_one(f"#{tab_id}")
         if isinstance(child, OptionList):
             child.focus()
 
+    def _refresh_pane(self, tab_id: str) -> None:
+        """Re-derive ``tab_id``'s pane content from the current canonical sources
+        and update the mounted widget in place (``OptionList`` options or the
+        ``Static`` text). One snapshot read feeds BOTH the rows and the parallel
+        selection ids, so an ``OptionSelected`` maps back to the right id."""
+        snap = self._snapshot()
+        rows = self._pane_rows(tab_id, snap)
+        self._pane_selection_ids[tab_id] = self._selection_ids(tab_id, snap)
+        child = self.query_one(f"#{tab_id}")
+        if isinstance(child, OptionList):
+            child.clear_options()
+            if rows:
+                child.add_options(rows)
+        elif isinstance(child, Static):
+            child.update("\n".join(rows))
+
     def on_menu_bar_selected(self, event: "MenuBar.Selected") -> None:
         self._open_drawer(None if event.tab_id == "__close__" else event.tab_id)
 
-    def on_option_list_option_selected(self, event: "OptionList.OptionSelected") -> None:
-        # A real impl (Phase 4) applies the picked model/agent/etc.; Phase 3 just
-        # collapses back to the composer.
+    async def on_option_list_option_selected(
+        self, event: "OptionList.OptionSelected"
+    ) -> None:
+        """Apply a picked Model/Agent by routing the equivalent slash command
+        through the transport — the SAME ``/model <class>`` / ``/attach <name>``
+        contract the plain path's status-bar picker (``CommandUIElement``)
+        dispatches. Non-actionable panes (History/Menu = readout/Phase-5) just
+        collapse. Then close the drawer and return focus to the composer."""
+        tab_id = event.option_list.id
+        ids = self._pane_selection_ids.get(tab_id or "", [])
+        if 0 <= event.option_index < len(ids):
+            chosen = ids[event.option_index]
+            if tab_id == "model":
+                await self._submit(f"/model {chosen}")
+            elif tab_id == "agent":
+                await self._submit(f"/attach {chosen}")
         self._open_drawer(None)
 
     def action_close_drawer(self) -> None:
@@ -396,8 +528,25 @@ class TextualChatApp(App):
                     logger.exception(
                         "textual chat: state tracking failed for kind=%r", msg.kind
                     )
+                # F5b: refresh the always-visible status-values line (cost + ctx%)
+                # as each turn lands, so the running cost is legible in the Textual
+                # TTY like the plain path's cost_summary. Bounded by message rate
+                # (far less frequent than a render loop) and guarded so a snapshot
+                # read failure never kills the pump.
+                try:
+                    self._refresh_status()
+                except Exception:
+                    logger.exception("textual chat: status refresh failed")
         finally:
             self.exit()
+
+    def _refresh_status(self) -> None:
+        """Re-render the bottom status-values line from a fresh snapshot."""
+        try:
+            line = self.query_one(StatusLine)
+        except Exception:
+            return  # not yet mounted
+        line.update(self._status_text())
 
     async def on_composer_submitted(self, event: "Composer.Submitted") -> None:
         text = event.value.strip()
@@ -420,7 +569,17 @@ class TextualChatApp(App):
         """
         try:
             head = self._transport.pending_intervention_head()
-            if head is not None and not getattr(head, "choices", None):
+            # A ``/``-prefixed line is never an intervention answer — it is a slash
+            # command (dispatched by the session turn loop), so it must take the
+            # normal submit path even while a free-text intervention is pending
+            # (mirrors ``stream_client.submit_or_answer``'s guard). Without this,
+            # a picker-issued ``/model`` / ``/attach`` (or a typed slash) during a
+            # pending intervention would be mis-delivered as the answer text.
+            if (
+                head is not None
+                and not getattr(head, "choices", None)
+                and not text.startswith("/")
+            ):
                 await self._transport.answer_intervention_text(text)
                 return
             await self._transport.submit_user_text(text)

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -4,17 +4,41 @@ The :class:`Composer` is the multi-line Claude-Code-style input (Enter submits,
 Shift+Enter newlines). The bottom chrome (Phase 3) is a slim :class:`StatusLine`
 of ``model │ agent │ cost │ ctx`` values plus a focusable :class:`MenuBar` (a
 ``Tabs`` row); opening a menu item expands a ``ContentSwitcher`` drawer whose
-per-tab panes are built by :func:`_drawer_child` (an :class:`OptionList` for the
+per-tab panes are built by :func:`pane_payload` (an :class:`OptionList` for the
 interactive pickers, a plain Rich :class:`Static` for the read-only readouts).
-Drawer content is PLACEHOLDER here — real registry wiring is Phase 4. The drawer
-container itself is assembled by
-:class:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp`.
+
+Phase 4 wires every pane to its CANONICAL reyn source (no placeholders):
+
+- **Model** — the operator-configured model classes + active class from the
+  status snapshot's ``model_classes`` / ``model_active_class`` (ultimately
+  ``Session.known_model_classes()`` → ``ModelResolver.known_classes()``).
+- **Agent** — the loaded agents + attach focus from the snapshot's
+  ``agent_names`` / ``attached_name`` (``AgentRegistry.loaded_names()``).
+- **History** — recent turns of the live conversation model the app already
+  retains from the frame stream (cross-session restore from ``history.jsonl`` is
+  a Phase-5 read-model-seam decision, see the app docstring).
+- **Cost / Ctx** — the live token/cost + context-window figures from the same
+  status snapshot the plain path's status bar reads (``usage`` / ``cost_agent`` /
+  ``cost_total`` / ``ctx_used`` / ``ctx_window``).
+- **Menu** — the full slash-command registry (:data:`reyn.interfaces.slash.REGISTRY`).
+- **Help** — the app's declarative ``BINDINGS`` plus the imperative navigation
+  keys each widget owns (:data:`COMPOSER_KEYS` / :data:`MENUBAR_KEYS`).
+
+Every ENUMERATING pane (Model / Agent / Menu) derives its full set from the
+canonical registry — never a hand-curated subset — so a newly-configured model
+class, a freshly-loaded agent, or a newly-registered slash command appears in the
+drawer automatically. The formatting is pure (:func:`pane_payload` and its
+per-pane helpers take plain inputs and return ``list[str]``) so completeness is
+directly testable without mounting a widget. The drawer container itself is
+assembled by :class:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp`.
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily via
 :mod:`reyn.interfaces.repl.client_driver`); its ``textual`` imports never reach an
 always-loaded module.
 """
 from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from rich.text import Text
 from textual import events
@@ -26,6 +50,11 @@ from textual.widgets import (
     Tabs,
     TextArea,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from reyn.interfaces.slash import SlashCommand
 
 
 class Composer(TextArea):
@@ -87,13 +116,13 @@ class Composer(TextArea):
         self._sync_height()
 
 
-# ── Phase 3: bottom-chrome tab-drawer ────────────────────────────────────────
+# ── bottom-chrome tab-drawer ─────────────────────────────────────────────────
 # Default collapsed = a slim status-values line + a focusable menu row. Pressing
 # ↓ from the composer focuses the menu; opening an item expands a drawer
 # DOWNWARD. Interactive panes are Textual OptionLists (Model/Agent/History/Menu —
 # keyboard selection); static readouts are plain Rich in a Static (Cost/Ctx/Help)
-# — the "Textual only where there is a selection" split. Content is PLACEHOLDER
-# here; wiring to reyn's real registries is Phase 4.
+# — the "Textual only where there is a selection" split. Phase 4 fills each pane
+# from its canonical reyn source (see :func:`pane_payload`).
 
 _MENU_TABS: "list[tuple[str, str]]" = [
     ("model", "Model"),
@@ -105,67 +134,188 @@ _MENU_TABS: "list[tuple[str, str]]" = [
     ("help", "Help"),
 ]
 
+#: Menu items whose pane is an interactive :class:`OptionList` picker (keyboard
+#: selection); every other tab renders as a read-only Rich :class:`Static`.
+_LIST_PANES = frozenset({"model", "agent", "history", "menu"})
 
-def _drawer_child(tab_id: str) -> Widget:
-    """Build the drawer pane for a menu item: an :class:`OptionList` for the
-    interactive pickers (Model/Agent/History/Menu — keyboard selection), a plain
-    Rich :class:`Static` for the read-only readouts (Cost/Ctx/Help).
+#: The composer's navigation keys, co-located with the widget that OWNS them (they
+#: are imperative ``Composer._on_key`` overrides, not declarative ``BINDINGS``, so
+#: the Help pane sources them from here rather than re-hardcoding a second copy).
+COMPOSER_KEYS: "list[tuple[str, str]]" = [
+    ("enter", "send"),
+    ("shift+enter", "newline"),
+    ("↓", "focus menu"),
+]
 
-    The content is PLACEHOLDER (Phase 3 ports the STRUCTURE only). Phase 4 swaps
-    each pane's body for its canonical reyn registry (model/agent registries,
-    session history, cost/token trackers, the slash-command registry, keybindings).
-    """
+#: The menu row's navigation keys (imperative ``MenuBar._on_key`` overrides).
+MENUBAR_KEYS: "list[tuple[str, str]]" = [
+    ("← →", "move"),
+    ("enter", "open"),
+    ("↑ / esc", "close"),
+]
+
+
+def pane_is_list(tab_id: str) -> bool:
+    """Whether ``tab_id``'s drawer pane is an interactive :class:`OptionList`
+    picker (vs a read-only :class:`Static` readout)."""
+    return tab_id in _LIST_PANES
+
+
+# ── per-pane pure formatters (registry inputs → display strings) ──────────────
+# Each takes plain data (never a widget) and returns ``list[str]``, so the
+# derive-from-registry completeness of the enumerating panes is directly testable
+# without mounting Textual. A pane that enumerates a set (model/agent/menu) MUST
+# render its FULL input — never a hand-curated subset — so a new registry entry
+# surfaces automatically.
+
+
+def model_pane_options(classes: "Sequence[str]", active: "str | None") -> list[str]:
+    """One row per operator-configured model class, active class marked. Derived
+    from the snapshot's ``model_classes`` (= ``ModelResolver.known_classes()``) —
+    the FULL configured set, so a newly-added class appears without code change."""
+    return [f"{c}  · active" if c == active else c for c in classes]
+
+
+def agent_pane_options(names: "Sequence[str]", active: "str | None") -> list[str]:
+    """One row per loaded agent, the attached agent marked. Derived from the
+    snapshot's ``agent_names`` (= ``AgentRegistry.loaded_names()``) — the FULL
+    loaded set, so a freshly-created/attached agent appears automatically."""
+    return [f"{n}  · active" if n == active else n for n in names]
+
+
+def history_pane_options(turns: "Sequence[str]") -> list[str]:
+    """Recent turns of the live conversation (already-formatted ``role · text``
+    rows). A readout of the retained conversation model, not a registry set."""
+    return list(turns) if turns else ["(no conversation yet)"]
+
+
+def menu_pane_options(commands: "Iterable[SlashCommand]") -> list[str]:
+    """One ``/<name> — <summary>`` row per NON-hidden slash command, sorted by
+    name. Derived from the whole :data:`reyn.interfaces.slash.REGISTRY` — a newly
+    ``@slash``-registered command appears automatically (no curated subset)."""
+    visible = sorted((c for c in commands if not c.hidden), key=lambda c: c.name)
+    return [f"/{c.name} — {c.summary}" for c in visible]
+
+
+def _ctx_pct(snap: "dict | None") -> str:
+    """Context-occupancy percent, or ``—`` before any LLM call has completed
+    (``used``/``window`` still 0) — mirrors the plain path's ``_ctx_pct``."""
+    snap = snap or {}
+    window = snap.get("ctx_window", 0)
+    used = snap.get("ctx_used", 0)
+    if window <= 0 or used <= 0:
+        return "—"
+    return f"{round(100 * used / window)}%"
+
+
+def _ctx_bar(used: int, window: int, *, cells: int = 24) -> str:
+    """A ``cells``-wide filled/empty occupancy bar (▓ filled, ░ empty)."""
+    if window <= 0 or used <= 0:
+        return "░" * cells
+    filled = min(cells, round(cells * used / window))
+    return "▓" * filled + "░" * (cells - filled)
+
+
+def cost_pane_lines(snap: "dict | None") -> list[str]:
+    """The Cost readout — live token/cost figures from the SAME status snapshot
+    the plain path's cost chip reads (``usage`` / ``cost_agent`` / ``cost_total``).
+    This is the F5b surface: cost becomes visible in the Textual TTY."""
+    snap = snap or {}
+    p, c, t = snap.get("usage", (0, 0, 0))
+    cost_agent = snap.get("cost_agent", 0.0)
+    cost_total = snap.get("cost_total", cost_agent)
+    return [
+        "Usage · this session",
+        f"  agent   ${cost_agent:.4f}",
+        f"  total   ${cost_total:.4f}",
+        f"  tokens  {p:,} in · {c:,} out · {t:,} total",
+    ]
+
+
+def ctx_pane_lines(snap: "dict | None") -> list[str]:
+    """The Ctx readout — last-call prompt tokens against the model's real context
+    window (``ctx_used`` / ``ctx_window``), with an occupancy bar and percent."""
+    snap = snap or {}
+    used = snap.get("ctx_used", 0)
+    window = snap.get("ctx_window", 0)
+    return [
+        "Context window",
+        f"  {used:,} / {window:,} tokens  ({_ctx_pct(snap)})",
+        f"  {_ctx_bar(used, window)}",
+    ]
+
+
+def help_pane_lines(
+    app_bindings: "Iterable[tuple[str, str]]" = (),
+    *,
+    composer_keys: "Sequence[tuple[str, str]]" = tuple(COMPOSER_KEYS),
+    menubar_keys: "Sequence[tuple[str, str]]" = tuple(MENUBAR_KEYS),
+) -> list[str]:
+    """The Help readout — the app's declarative ``BINDINGS`` (passed as
+    ``(key, description)`` pairs) plus the imperative composer/menu navigation keys
+    each widget owns. Not a registry-enumeration pane: key handling is split
+    between declarative ``BINDINGS`` and imperative ``_on_key`` overrides, so the
+    keys are sourced from where they are DEFINED (the widgets' key constants + the
+    app's BINDINGS) rather than a single enumerable table."""
+    lines = ["Shortcuts"]
+    lines += [f"  {key}  {desc}" for key, desc in composer_keys]
+    lines += [f"  {key}  {desc}" for key, desc in menubar_keys]
+    lines += [f"  {key}  {desc}" for key, desc in app_bindings]
+    return lines
+
+
+def pane_payload(
+    tab_id: str,
+    *,
+    snapshot: "dict | None" = None,
+    commands: "Iterable[SlashCommand]" = (),
+    history: "Sequence[str]" = (),
+    app_bindings: "Iterable[tuple[str, str]]" = (),
+) -> list[str]:
+    """The display rows for ``tab_id``'s drawer pane, derived from canonical reyn
+    sources. For a list pane (:func:`pane_is_list`) the rows are OptionList
+    options; for a readout the rows are Static lines. All inputs are plain data
+    (the app assembles them from its live snapshot / the slash REGISTRY / the
+    conversation model) so this stays pure + testable."""
+    snap = snapshot or {}
     if tab_id == "model":
-        return OptionList(
-            "sonnet   · active", "opus", "haiku", "gemini-2.5-flash-lite",
-            id="model",
+        return model_pane_options(
+            snap.get("model_classes") or [],
+            snap.get("model_active_class") or snap.get("model"),
         )
     if tab_id == "agent":
-        return OptionList(
-            "default   · active", "planner", "reviewer", "researcher",
-            id="agent",
-        )
+        return agent_pane_options(snap.get("agent_names") or [], snap.get("attached_name"))
     if tab_id == "history":
-        return OptionList(
-            "1 · (placeholder) previous conversation turn…",
-            "2 · (placeholder) another previous turn…",
-            id="history",
-        )
+        return history_pane_options(history)
     if tab_id == "menu":
-        return OptionList(
-            "/model — switch model",
-            "/agent — switch agent",
-            "/clear — clear conversation",
-            "/quit — exit",
-            id="menu",
-        )
+        return menu_pane_options(commands)
     if tab_id == "cost":
-        return Static(
-            Text.from_markup(
-                "[b]Usage · this session[/b] (placeholder)\n"
-                "  turn    $0.0000\n"
-                "  total   $0.0000\n"
-                "  tokens  0 in · 0 out"
-            ),
-            id="cost",
-        )
+        return cost_pane_lines(snap)
     if tab_id == "ctx":
-        return Static(
-            Text.from_markup(
-                "[b]Context window[/b] (placeholder)\n"
-                "  0 / 200 000 tokens  (0%)\n"
-                "  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁"
-            ),
-            id="ctx",
-        )
-    return Static(
-        Text.from_markup(
-            "[b]Shortcuts[/b]\n"
-            "  enter send · shift+enter newline\n"
-            "  ↓ focus menu · ← → move · enter open · esc close"
-        ),
-        id="help",
-    )
+        return ctx_pane_lines(snap)
+    return help_pane_lines(app_bindings)
+
+
+def status_line_text(snap: "dict | None", agent_name: str) -> str:
+    """The slim ``model │ agent │ cost │ ctx`` status-values line, from the live
+    status snapshot (F5b: the running cost + context percent are visible here even
+    when the drawer is closed). Falls back to the threaded ``agent_name`` and
+    ``—``/``$0.0000``/``—`` when no snapshot is available yet (pre-session)."""
+    snap = snap or {}
+    model = snap.get("model_active_class") or snap.get("model") or "—"
+    agent = snap.get("attached_name") or agent_name
+    cost = snap.get("cost_agent", 0.0)
+    return f"model {model} │ agent {agent} │ cost ${cost:.4f} │ ctx {_ctx_pct(snap)}"
+
+
+def build_drawer_pane(tab_id: str, rows: "Sequence[str]") -> Widget:
+    """Build the mounted drawer pane widget for ``tab_id`` from its display
+    ``rows``: an :class:`OptionList` for a picker pane, a Rich :class:`Static`
+    for a readout. The app rebuilds ``rows`` from a fresh snapshot on each open
+    (see :meth:`TextualChatApp._refresh_pane`)."""
+    if pane_is_list(tab_id):
+        return OptionList(*rows, id=tab_id)
+    return Static(Text("\n".join(rows)), id=tab_id)
 
 
 class StatusLine(Static):

--- a/tests/test_textual_chat_phase4_3273.py
+++ b/tests/test_textual_chat_phase4_3273.py
@@ -1,0 +1,380 @@
+"""Phase 4 TUI-rebuild gates (#3273): the bottom-chrome drawer wired to reyn's
+REAL data (registries + live status snapshot), replacing the Phase-3 placeholders.
+
+The graded invariants:
+
+- **Derive-from-registry completeness** (Tier 1 + Tier 2): every ENUMERATING pane
+  (Model / Agent / Menu) renders the FULL canonical set, never a hand-curated
+  subset — a fake entry added to the registry surfaces in the drawer. Model/Agent
+  derive from the status snapshot's ``model_classes`` / ``agent_names`` (=
+  ``ModelResolver.known_classes()`` / ``AgentRegistry.loaded_names()``); Menu
+  derives from the whole :data:`reyn.interfaces.slash.REGISTRY`.
+- **No placeholder residue** (Tier 1): with no snapshot the pickers are EMPTY
+  (not the old hardcoded ``sonnet/opus/…`` list) and the readouts show zeros, not
+  ``(placeholder)`` — content comes only from real sources.
+- **Cost/ctx visible — F5b** (Tier 1 + Tier 2): the live cost/ctx figures surface
+  both on the always-visible status line and in the Cost/Ctx drawer panes.
+- **Import isolation preserved** (Tier 2c): the Phase-4 wiring adds no top-level
+  textual import to an always-loaded module — the plain path still imports green
+  with ``textual`` / ``textual_flowview`` unimportable.
+
+Enumerating-pane completeness is proved as a chain: the pure formatter fully
+enumerates its input (a fake entry appears), AND the app feeds it the WHOLE
+registry (the drawer options equal the real registry's contents) — so a newly
+registered command / configured class / loaded agent appears with no code change.
+All app-level tests use real instances (a concrete ``ClientTransport`` +
+``ChatReadModel`` seam impl + the real app/pilot) — no mocks — per the policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+
+from reyn.interfaces.inline.textual_chat.chrome import (
+    agent_pane_options,
+    cost_pane_lines,
+    ctx_pane_lines,
+    menu_pane_options,
+    model_pane_options,
+    pane_payload,
+    status_line_text,
+)
+from reyn.interfaces.repl.read_model import ChatReadModel
+from reyn.interfaces.slash import REGISTRY, SlashCommand, SlashRegistry
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# A real-shaped status snapshot (ONLY keys ``interfaces/inline/app.py:_snapshot``
+# actually produces — no invented field). Reused across the wiring tests.
+_SNAP = {
+    "model": "claude-opus-4-8",
+    "model_active_class": "opus",
+    "model_classes": ["light", "opus", "strong", "zzz-fake-class"],
+    "agent_names": ["default", "planner", "zzz-fake-agent"],
+    "attached_name": "default",
+    "session_tree": [],
+    "usage": (1200, 340, 1540),
+    "cost_usd": 0.0123,
+    "cost_agent": 0.0123,
+    "cost_total": 0.0500,
+    "agent_tokens": 1540,
+    "ctx_used": 90000,
+    "ctx_window": 200000,
+    "ctx_source": "model",
+    "ctx_recent_usage": (90000, 40000),
+}
+
+
+# ── Tier 1: derive-from-registry completeness of the pure formatters ──────────
+
+
+def test_model_pane_enumerates_full_class_set_no_subset() -> None:
+    """Tier 1: the Model pane renders EVERY configured class (the active one
+    marked), never a curated subset — a fake class added to the input appears, so
+    a newly-configured ``ModelResolver`` class surfaces automatically."""
+    classes = ["light", "opus", "strong", "zzz-fake-class"]
+    rows = model_pane_options(classes, active="opus")
+    # Every class is present (map row → underlying class by stripping the marker).
+    rendered = {r.split("  · active")[0] for r in rows}
+    assert rendered == set(classes), "Model pane dropped/added a class vs the registry"
+    assert "zzz-fake-class" in rendered, "a fresh registry class did not appear"
+    assert rows[classes.index("opus")] == "opus  · active", "active class not marked"
+
+
+def test_agent_pane_enumerates_full_agent_set_no_subset() -> None:
+    """Tier 1: the Agent pane renders EVERY loaded agent (the attached one marked),
+    never a curated subset — a fake agent added to the input appears, so a freshly
+    loaded/attached agent surfaces automatically."""
+    names = ["default", "planner", "zzz-fake-agent"]
+    rows = agent_pane_options(names, active="default")
+    rendered = {r.split("  · active")[0] for r in rows}
+    assert rendered == set(names), "Agent pane dropped/added an agent vs the registry"
+    assert "zzz-fake-agent" in rendered, "a fresh registry agent did not appear"
+    assert rows[0] == "default  · active", "attached agent not marked"
+
+
+def test_menu_pane_enumerates_full_slash_registry_no_subset() -> None:
+    """Tier 1: the Menu pane renders EVERY non-hidden slash command from a REAL
+    ``SlashRegistry`` — a freshly-registered command appears, a hidden one is
+    excluded. Proves the formatter enumerates the whole registry (no subset)."""
+    reg = SlashRegistry()
+    reg.register(SlashCommand("realcmd", "a real command", handler=_noop))
+    reg.register(SlashCommand("zzz-fake", "the fresh entry", handler=_noop))
+    reg.register(SlashCommand("secret", "hidden one", handler=_noop, hidden=True))
+
+    rows = menu_pane_options(reg.all_commands())
+    names = {r.split(" — ")[0] for r in rows}
+    assert names == {"/realcmd", "/zzz-fake"}, f"menu != full visible registry: {names}"
+    assert "/zzz-fake — the fresh entry" in rows, "a fresh registry command did not appear"
+    assert not any(r.startswith("/secret") for r in rows), "hidden command leaked into menu"
+
+
+# ── Tier 1: no placeholder residue (behavioral — empty/zero, not hardcoded) ───
+
+
+def test_no_placeholder_residue_pickers_empty_readouts_zero() -> None:
+    """Tier 1: with NO snapshot the pickers are empty (not the Phase-3 hardcoded
+    ``sonnet/opus/haiku/gemini`` list) and the readouts show zeros, not
+    ``(placeholder)`` — content is sourced only from real data."""
+    assert pane_payload("model", snapshot=None) == [], "Model fell back to a hardcoded list"
+    assert pane_payload("agent", snapshot=None) == [], "Agent fell back to a hardcoded list"
+    cost_blob = " ".join(cost_pane_lines(None))
+    ctx_blob = " ".join(ctx_pane_lines(None))
+    assert "placeholder" not in cost_blob.lower()
+    assert "placeholder" not in ctx_blob.lower()
+    assert "$0.0000" in cost_blob, "cost readout should show a real (zero) figure"
+
+
+# ── Tier 1: F5b — cost/ctx surfaced on the status line + Cost/Ctx panes ───────
+
+
+def test_f5b_cost_and_ctx_surface_on_status_line() -> None:
+    """Tier 1: the status-values line reflects the live cost + context percent
+    from the snapshot (F5b: cost is legible in the Textual TTY, drawer closed)."""
+    line = status_line_text(_SNAP, "default")
+    assert "$0.0123" in line, "running cost missing from the status line"
+    assert "ctx 45%" in line, "context percent (90k/200k) missing from the status line"
+    assert "opus" in line and "default" in line, "model/agent missing from the status line"
+
+
+def test_f5b_cost_and_ctx_panes_reflect_usage() -> None:
+    """Tier 1: the Cost + Ctx drawer readouts reflect the snapshot's live token /
+    cost / context figures (F5b), not a placeholder constant."""
+    cost = " ".join(cost_pane_lines(_SNAP))
+    assert "$0.0123" in cost and "$0.0500" in cost, "cost pane missing agent/total cost"
+    assert "1,200 in" in cost and "340 out" in cost, "cost pane missing token counts"
+    ctx = " ".join(ctx_pane_lines(_SNAP))
+    assert "90,000 / 200,000 tokens" in ctx, "ctx pane missing used/window figures"
+    assert "45%" in ctx, "ctx pane missing occupancy percent"
+
+
+# ── App wiring (Tier 2): the mounted drawer reflects the canonical sources ────
+
+
+def _noop(session=None, args: str = "") -> None:  # pragma: no cover - handler stub
+    return None
+
+
+class _SnapshotReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam impl (like ``RegistryReadModel`` /
+    ``RemoteReadModel``) returning a fixed real-shaped snapshot — the app reads
+    model/agent/cost/ctx off this same seam the plain status bar uses."""
+
+    def __init__(self, snap: "dict | None") -> None:
+        self._snap = snap
+
+    def snapshot(self, config=None):
+        return self._snap
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_phase4_history")
+
+
+class ScriptedTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
+    open so the app stays mounted for drawer inspection; submissions are captured
+    so a picker-issued ``/model`` / ``/attach`` slash can be asserted."""
+
+    def __init__(self, messages: "list[OutboxMessage] | None" = None) -> None:
+        self._messages = list(messages or [])
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _option_prompts(option_list) -> list[str]:
+    return [str(option_list.get_option_at_index(i).prompt) for i in range(option_list.option_count)]
+
+
+@pytest.mark.asyncio
+async def test_model_drawer_reflects_snapshot_classes_full_set() -> None:
+    """Tier 2: opening the Model drawer shows EVERY class from the read-model
+    snapshot (the registry projection), including a fake one — proving the pane
+    derives from the canonical source, not a hardcoded list (the KEY GATE at the
+    app boundary)."""
+    from textual.widgets import OptionList
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_SnapshotReadModel(_SNAP)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("model")
+        await pilot.pause()
+        prompts = _option_prompts(app.query_one("#model", OptionList))
+        rendered = {p.split("  · active")[0] for p in prompts}
+        assert rendered == set(_SNAP["model_classes"]), (
+            f"Model drawer != full class set: {rendered}"
+        )
+        assert "zzz-fake-class" in rendered, "a fresh registry class did not appear in the drawer"
+
+
+@pytest.mark.asyncio
+async def test_menu_drawer_equals_full_slash_registry() -> None:
+    """Tier 2: the Menu drawer options equal the REAL global slash ``REGISTRY``'s
+    visible command set (no hand-curated subset) — a command registered anywhere
+    via ``@slash`` is already present."""
+    from textual.widgets import OptionList
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_SnapshotReadModel(_SNAP)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("menu")
+        await pilot.pause()
+        prompts = _option_prompts(app.query_one("#menu", OptionList))
+        drawer_names = {p.split(" — ")[0].lstrip("/") for p in prompts}
+        assert drawer_names == set(REGISTRY.names()), (
+            "Menu drawer is a curated subset of the slash registry"
+        )
+
+
+@pytest.mark.asyncio
+async def test_status_line_and_cost_pane_show_live_cost_f5b() -> None:
+    """Tier 2: F5b end-to-end — the mounted status line and the Cost drawer pane
+    both reflect the snapshot's live cost/ctx (previously the Textual path showed
+    no cost at all)."""
+    from textual.widgets import Static
+
+    from reyn.interfaces.inline.textual_chat import StatusLine, TextualChatApp
+
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_SnapshotReadModel(_SNAP)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        status = str(app.query_one(StatusLine).render())
+        assert "$0.0123" in status and "ctx 45%" in status, f"status line lacks cost/ctx: {status}"
+        app._open_drawer("cost")
+        await pilot.pause()
+        cost_text = str(app.query_one("#cost", Static).render())
+        assert "$0.0123" in cost_text and "1,200 in" in cost_text, (
+            f"Cost pane lacks live figures: {cost_text}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_selecting_model_row_routes_model_slash() -> None:
+    """Tier 2: selecting a Model row applies the pick by routing the equivalent
+    ``/model <class>`` slash through the transport (the same contract the plain
+    path's status-bar picker dispatches), then collapses the drawer."""
+    from textual.widgets import ContentSwitcher, OptionList
+
+    from reyn.interfaces.inline.textual_chat import TextualChatApp
+
+    transport = ScriptedTransport()
+    app = TextualChatApp(transport=transport, read_model=_SnapshotReadModel(_SNAP))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app._open_drawer("model")
+        await pilot.pause()
+        option_list = app.query_one("#model", OptionList)
+        # Select the "strong" class (index 2 in model_classes).
+        idx = _SNAP["model_classes"].index("strong")
+        option_list.post_message(OptionList.OptionSelected(option_list, option_list.get_option_at_index(idx), idx))
+        await pilot.pause()
+        assert "/model strong" in transport.submitted, f"picker did not route /model: {transport.submitted}"
+        assert app.query_one("#drawer", ContentSwitcher).display is False, "drawer did not collapse"
+
+
+# ── Tier 2c: import isolation preserved (Phase 4 adds no always-loaded import) ─
+
+_ISOLATION_SUBPROCESS = '''
+import sys
+
+
+class _Block:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in ("textual", "textual_flowview"):
+            raise ModuleNotFoundError("blocked for isolation test: " + name)
+        return None
+
+
+sys.meta_path.insert(0, _Block())
+
+import reyn.interfaces.repl.client_driver  # noqa: E402,F401
+import reyn.interfaces.repl.stream_client  # noqa: E402,F401
+import reyn.interfaces.cli.commands.chat  # noqa: E402,F401
+import reyn.interfaces.slash  # noqa: E402,F401  (menu pane source — must stay textual-free)
+
+assert "textual_flowview" not in sys.modules, "flowview imported at module load"
+assert "textual" not in sys.modules, "textual imported at module load"
+print("ISOLATION_OK")
+'''
+
+
+def test_phase4_wiring_imports_stay_tty_only() -> None:
+    """Tier 2c: with ``textual`` / ``textual_flowview`` unimportable, the plain /
+    non-TTY path (plus the slash registry the Menu pane reads) still imports green
+    — Phase 4's registry wiring added no top-level textual import to an
+    always-loaded module. Runs the strip in a clean subprocess."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _ISOLATION_SUBPROCESS],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"


### PR DESCRIPTION
**[per-PR-coder]** — Phase 4 of the TUI-rebuild arc (part of #3273). Wires the bottom-chrome drawer panes to reyn's REAL data, replacing the Phase-3 placeholders.

## Canonical source wired per pane
| Pane | Source (file:line) | Derives-from-registry |
|------|--------------------|------------------------|
| **Model** | snapshot `model_classes`/`model_active_class` → `Session.known_model_classes()` (`session.py:1556`) → `ModelResolver.known_classes()` (`model_resolver.py:341`) | ✅ full class set |
| **Agent** | snapshot `agent_names`/`attached_name` → `AgentRegistry.loaded_names()` (`registry.py:3183`) | ✅ full loaded set |
| **Menu** | `reyn.interfaces.slash.REGISTRY.all_commands()` (`slash/__init__.py:101`), hidden excluded | ✅ full registry |
| **Cost** | snapshot `usage`/`cost_agent`/`cost_total` (`inline/app.py:_snapshot` 898) | readout |
| **Ctx** | snapshot `ctx_used`/`ctx_window`/`ctx_recent_usage` | readout |
| **History** | retained live conversation `FlowModel` (frame stream) | readout — see deferral |
| **Help** | app `BINDINGS` + each widget's own nav keys (`COMPOSER_KEYS`/`MENUBAR_KEYS`) | readout |

The snapshot is read off the existing `ChatReadModel` seam (`read_model.py`) — the SAME source the plain path's status bar consumes, so local≡remote by construction. Panes rebuild from a fresh snapshot on open (`_refresh_pane`); the status line refreshes per turn.

## Derive-from-registry completeness (the KEY GATE)
Each enumerating pane's completeness is enforced as a two-link chain, so a future model/agent/command can't be silently missing:
1. the pure formatter renders its FULL input (a fake entry appears; no curated subset) — `model_pane_options`/`agent_pane_options`/`menu_pane_options`;
2. the app feeds it the WHOLE registry — the mounted drawer's options are asserted **equal to** the real registry's contents (`Menu drawer == REGISTRY.names()`; `Model drawer == snapshot model_classes` incl a `zzz-fake-class`).

## F5b (cost display)
The Textual path previously showed no cost. Now the live cost/ctx surface **both** on the always-visible `StatusLine` (`model │ agent │ cost │ ctx`) and in the Cost/Ctx drawer panes, sourced from the read-model snapshot (analog of the plain path's `cost_summary`).

## Deferred / flagged
- **History cross-session restore** — the History pane shows recent turns of the *live* conversation (real, in-package). Enumerating PAST sessions from `history.jsonl` (Phase 5 restore) needs a new `ChatReadModel` history accessor: the read model's frame-sufficiency boundary means a REMOTE client can't enumerate a session's past turns off the wire. Flagged as a Phase-5 seam decision rather than reaching around the seam now. (Help remains a readout: key handling is split between declarative `BINDINGS` and imperative `_on_key` overrides, so it's sourced from where keys are defined, not a single enumerable table.)

## Selection wiring
Selecting a Model/Agent row routes the equivalent `/model <class>` / `/attach <name>` slash through the transport — the same contract the plain path's status-bar `CommandUIElement` picker dispatches (session turn loop dispatches `/`-prefixed text). `_submit` gains the `/`-guard so a picker-issued slash during a pending free-text intervention isn't mis-delivered as the answer (mirrors `stream_client.submit_or_answer`).

## Test plan (gates)
- [x] **1. Derive-from-registry completeness** — `test_{model,agent,menu}_pane_enumerates_full_*_no_subset` (pure) + `test_model_drawer_reflects_snapshot_classes_full_set` / `test_menu_drawer_equals_full_slash_registry` (app boundary, real `REGISTRY`). Fake entry appears; hidden excluded.
- [x] **2. No placeholder residue** — `test_no_placeholder_residue_pickers_empty_readouts_zero`: with no snapshot the pickers are EMPTY (not the hardcoded sonnet/opus list), readouts show zeros not `(placeholder)`.
- [x] **3. Cost/ctx visible (F5b)** — `test_f5b_*` (status line + panes) + `test_status_line_and_cost_pane_show_live_cost_f5b` (mounted app).
- [x] **4. Import-isolation + plain-fallback preserved** — `test_phase4_wiring_imports_stay_tty_only` (subprocess witness, incl. slash registry stays textual-free).

## CI gates run locally (worktree venv, CI extras)
- [x] `ruff check src tests` — clean
- [x] `test_tier_audit.py --strict` (new test file) — 11/11 OK, 0 Tier-4
- [x] `verify_module_docstrings.py` (changed src) — clean
- [x] `python -m pytest` (repo root, foreground) — **9212 passed, 37 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)