### PR TITLE
feat(tui): Phase 5 — restore-on-restart hydration for the Textual chat app (#3273)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -49,6 +49,7 @@ from .chrome import (
 )
 from .gutter import ReynGutter
 from .presenter import ReynPresenter, choice_chip_spans
+from .restore import project_restored_frames
 
 if TYPE_CHECKING:
     from textual.timer import Timer
@@ -113,11 +114,19 @@ class TextualChatApp(App):
     token/cost figures (F5b — also surfaced on the always-visible status line),
     Menu from the slash ``REGISTRY``, History from the retained live conversation,
     Help from the app BINDINGS. Selecting a Model/Agent row routes the equivalent
-    ``/model`` / ``/attach`` slash through the transport. Cross-session restore
-    from ``history.jsonl`` (Phase 5) needs a new ``ChatReadModel`` history
-    accessor — the read model's frame-sufficiency boundary means a REMOTE client
-    cannot enumerate a session's past turns off the wire today — so History shows
-    the live conversation now and the restore seam is deferred to Phase 5.
+    ``/model`` / ``/attach`` slash through the transport.
+
+    Phase 5 adds restore-on-restart (CC ``--resume`` parity): :meth:`on_mount`
+    hydrates the retained model from the PERSISTED conversation log BEFORE the
+    live frame pump starts (:meth:`_hydrate_from_history` →
+    :func:`.restore.project_restored_frames`), reading the durable ``ChatMessage``
+    log off the new ``ChatReadModel.conversation_history`` seam (``history.jsonl``,
+    NOT the P6 audit-event log). Restored turns render RESOLVED (never RUNNING)
+    through the same presenter/gutter path a live frame does, so a restart shows
+    the previous conversation instead of a blank pane. The History drawer pane
+    reads the same retained model, so it now shows those restored turns too. A
+    REMOTE read model returns an empty log (frame-sufficiency: past turns are not
+    on the wire) → hydration is a no-op and the pane starts blank as before.
 
     Phase 3.5 wires CHOICE interventions: a closed-set intervention (permission
     confirm / choice ``ask_user`` — any ``kind="intervention"`` frame carrying
@@ -277,11 +286,14 @@ class TextualChatApp(App):
         return out
 
     def _history_turns(self, *, limit: int = 12) -> "list[str]":
-        """Recent conversation turns from the retained live model (the frame
-        stream the app already drains) — ``role · <first line>`` rows, newest
-        ``limit``. This is the honest in-package History source today; enumerating
-        PAST sessions for restore (``history.jsonl``) is a Phase-5 read-model-seam
-        decision (see the class docstring), not fabricated here."""
+        """Recent conversation turns from the retained model — ``role · <first
+        line>`` rows, newest ``limit``. The model holds BOTH the live frame
+        stream the app drains AND (Phase 5) the restored prior turns
+        :meth:`_hydrate_from_history` seeds at ``on_mount`` from ``history.jsonl``,
+        so the History drawer is cross-session by construction: restoring the
+        conversation into the model is what backs this pane's past-session view
+        (no separate accessor call here — reading the model is sufficient once it
+        is hydrated)."""
         rows: list[str] = []
         for entry in self.conversation:
             msg = entry.item
@@ -327,6 +339,13 @@ class TextualChatApp(App):
         return status_line_text(self._snapshot(), self._agent_name)
 
     def on_mount(self) -> None:
+        # Phase 5 (#3273): hydrate the retained model from the PERSISTED
+        # conversation log BEFORE the live frame pump starts, so a restart shows
+        # the previous conversation (CC ``--resume`` parity) instead of a blank
+        # pane. Restored turns render resolved (never RUNNING) through the exact
+        # same presenter/gutter path a live frame does. Must run before
+        # ``run_worker`` so the prior turns sit ABOVE the first live frame.
+        self._hydrate_from_history()
         # The running-blink timer starts PAUSED and is resumed only while a
         # tool call is RUNNING (and paused again when none remain) — it never
         # spins on an idle conversation. The blink is app-side + ADDITIVE:
@@ -341,6 +360,53 @@ class TextualChatApp(App):
         # item is opened (:meth:`_open_drawer`).
         self.query_one("#drawer", ContentSwitcher).display = False
         self.query_one(Composer).focus()
+
+    def _hydrate_from_history(self) -> None:
+        """Restore-on-restart (#3273 Phase 5): project the persisted conversation
+        log into the retained model so a restart shows the PREVIOUS conversation.
+
+        Reads the durable ``ChatMessage`` log via the read-model seam
+        (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
+        — ``history.jsonl``, NOT the P6 audit-event log) and appends each projected
+        frame to ``self.conversation`` (:func:`.restore.project_restored_frames`).
+        Every restored entry is RESOLVED, never RUNNING: a completed tool result
+        gets the SUCCESS/ERROR lifecycle state the live path's completion handler
+        (:meth:`_track_tool_state`) would have assigned, and user/agent rows keep
+        DEFAULT (their live state). A REMOTE read model returns an empty log
+        (frame-sufficiency: past turns are not on the wire) → this is a no-op and
+        the pane starts blank, exactly as before. Fully guarded — a restore
+        failure must never stop the app from mounting and pumping live frames."""
+        if self._read_model is None:
+            return
+        try:
+            messages = self._read_model.conversation_history()
+        except Exception:
+            logger.exception("textual chat: conversation-history read failed")
+            return
+        try:
+            frames = project_restored_frames(messages)
+        except Exception:
+            logger.exception("textual chat: history projection failed")
+            return
+        for msg in frames:
+            try:
+                entry = self.conversation.append(msg)
+            except Exception:
+                logger.exception(
+                    "textual chat: restore append failed for kind=%r", msg.kind
+                )
+                continue
+            # Resolved, never RUNNING — mirror _track_tool_state's terminal
+            # transition for a settled tool result (SUCCESS unless the summary
+            # marks a failure); non-tool rows keep DEFAULT.
+            meta = msg.meta or {}
+            if msg.kind == "tool_call_completed":
+                summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
+                entry.set_state(
+                    EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
+                )
+            elif msg.kind == "tool_call_failed":
+                entry.set_state(EntryState.ERROR)
 
     def _open_drawer(self, tab_id: "str | None") -> None:
         """Expand/collapse the downward drawer. ``None`` (or the ``"__close__"``

--- a/src/reyn/interfaces/inline/textual_chat/chrome.py
+++ b/src/reyn/interfaces/inline/textual_chat/chrome.py
@@ -14,9 +14,11 @@ Phase 4 wires every pane to its CANONICAL reyn source (no placeholders):
   ``Session.known_model_classes()`` → ``ModelResolver.known_classes()``).
 - **Agent** — the loaded agents + attach focus from the snapshot's
   ``agent_names`` / ``attached_name`` (``AgentRegistry.loaded_names()``).
-- **History** — recent turns of the live conversation model the app already
-  retains from the frame stream (cross-session restore from ``history.jsonl`` is
-  a Phase-5 read-model-seam decision, see the app docstring).
+- **History** — recent turns of the conversation model the app retains. Phase 5
+  hydrates that model at startup from the persisted ``history.jsonl`` log (via the
+  ``ChatReadModel.conversation_history`` seam), so this pane is cross-session by
+  construction — it shows restored PRIOR turns alongside the live ones (see the
+  app docstring).
 - **Cost / Ctx** — the live token/cost + context-window figures from the same
   status snapshot the plain path's status bar reads (``usage`` / ``cost_agent`` /
   ``cost_total`` / ``ctx_used`` / ``ctx_window``).

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -1,0 +1,126 @@
+"""Restore-on-restart projection: persisted ``ChatMessage`` log → display frames.
+
+Phase 5 of the TUI-rebuild arc (#3273). On ``reyn chat`` restart the Textual
+conversation pane should show the PREVIOUS conversation (Claude-Code ``--resume``
+parity) rather than starting blank. :func:`project_restored_frames` is the pure
+projection that turns the persisted conversation log — a ``list[ChatMessage]``
+loaded from ``history.jsonl`` (``Session.load_history``) — into the
+:class:`~reyn.runtime.outbox.OutboxMessage` display frames the app's retained
+``FlowModel`` is fed from, so a restored turn renders through the EXACT SAME
+presenter/gutter path a live frame does (only the timing differs: these are
+appended once at ``on_mount`` BEFORE the live frame pump starts).
+
+**Source of truth (D1, architect-ratified).** The restore source is the
+persisted ``ChatMessage`` log (``history.jsonl``), NOT the P6 audit-event log:
+audit-events do not carry assistant text / tool results and rotate. This
+projection reads ONLY ``ChatMessage`` instances (see the accessor
+:meth:`reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`).
+
+**Non-authoritative projection (recovery truncate-falsify gate is N/A).** The
+``FlowModel`` this feeds is a *projection*; the authority is
+``history.jsonl`` / the ``ChatMessage`` log itself. This reads that authoritative
+store DIRECTLY — it is derived-at-read, NOT WAL-event-reconstructed state — so
+the CLAUDE.md recovery-feature truncate-falsify gate (which guards
+WAL-event-derived reconstruction state against WAL truncation below its source
+events) does not apply here: there is no WAL-derived state to lose. If a future
+change makes any restored surface WAL-reconstructed rather than read straight
+from the ChatMessage log, that gate WOULD apply and this note must be revisited.
+
+**Resolved, never RUNNING.** A restored tool result is a SETTLED outcome, so it
+projects to a ``tool_call_completed`` frame; the caller (``_hydrate_from_history``)
+gives it the SUCCESS/ERROR lifecycle state the live path's completion handler
+would have, derived from the SAME ``summarize_tool_result`` the presenter reads —
+so gutter colour and body agree. The transient ``tool_call_started`` progress
+header (a live-pump affordance with no meaning in a static restore) is
+intentionally omitted, and the ``system`` / ``summary`` roles are Reyn-internal
+chrome (filtered at the LLM wire boundary), so both are skipped.
+
+This module imports only :class:`~reyn.runtime.outbox.OutboxMessage` (no
+``textual`` / ``textual_flowview``): the projection is pure and unit-testable
+without mounting the app.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reyn.runtime.chat_message import ChatMessage
+    from reyn.runtime.outbox import OutboxMessage
+
+# Roles with no operator-facing conversation surface: ``system`` is persisted
+# lifecycle chrome and ``summary`` is the chat-compactor's internal carry —
+# both filtered at the LLM wire boundary, so neither belongs in the restored
+# scrollback.
+_SKIP_ROLES = frozenset({"system", "summary"})
+
+#: Marker stamped on every restored frame's ``meta`` so a consumer (or a test)
+#: can tell a hydrated turn from a live one. Purely informational — the frame
+#: renders identically either way.
+RESTORED_META_KEY = "_restored"
+
+#: Leading divider row announcing that what follows is the resumed prior
+#: conversation (operator legibility — the Product-Think lens). Emitted once,
+#: only when there is at least one restored turn.
+_RESUME_DIVIDER = "⤺ resumed previous conversation"
+
+
+def project_restored_frames(
+    messages: "list[ChatMessage]",
+) -> "list[OutboxMessage]":
+    """Project a persisted ``ChatMessage`` log into restore display frames.
+
+    Oldest→newest, preserving conversation order. Mapping:
+
+    - ``user`` (non-empty text)      → ``kind="user"``
+    - ``assistant`` (non-empty text) → ``kind="agent"``
+    - ``tool`` (a tool RESULT)       → ``kind="tool_call_completed"`` carrying
+      ``meta["tool"]`` / ``meta["result"]`` for the presenter's result summary
+    - ``system`` / ``summary``       → skipped (internal chrome)
+
+    A ``tool_call_started`` header is NOT emitted (a live-progress affordance
+    with no meaning in a static restore). Every frame is stamped
+    ``meta[RESTORED_META_KEY]=True``. Returns ``[]`` for an empty log (no
+    divider), so a first-ever run stays blank.
+    """
+    from reyn.runtime.outbox import (
+        OutboxMessage,  # noqa: PLC0415 — keep module textual-free at import
+    )
+
+    frames: "list[OutboxMessage]" = []
+    for m in messages:
+        role = m.role
+        if role in _SKIP_ROLES:
+            continue
+        if role == "user":
+            text = m.text
+            if text.strip():
+                frames.append(
+                    OutboxMessage(kind="user", text=text, meta={RESTORED_META_KEY: True})
+                )
+        elif role == "assistant":
+            text = m.text
+            if text.strip():
+                frames.append(
+                    OutboxMessage(kind="agent", text=text, meta={RESTORED_META_KEY: True})
+                )
+        elif role == "tool":
+            frames.append(
+                OutboxMessage(
+                    kind="tool_call_completed",
+                    text=m.name or "",
+                    meta={
+                        RESTORED_META_KEY: True,
+                        "tool": m.name,
+                        "result": m.text,
+                    },
+                )
+            )
+    if not frames:
+        return frames
+    divider = OutboxMessage(
+        kind="system", text=_RESUME_DIVIDER, meta={RESTORED_META_KEY: True}
+    )
+    return [divider, *frames]
+
+
+__all__ = ["RESTORED_META_KEY", "project_restored_frames"]

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -29,9 +29,11 @@ the MAIN-bar subset onto the wire (``state.py``'s ``project_status`` /
 / ``agent_tokens`` · ``ctx_used`` / ``ctx_window`` · ``waiting_on``. Those chip
 VALUES render on remote. The dropdown EXPANSIONS (cost/ctx detail tuples, the
 ``/model`` class picker, the agent/session tree, the ``…`` sub-bar
-toggle counts) and the interactive intervention / rewind PICKERS are
-session-local and are NOT on the wire — the remote model returns
-empty/``—``/0 for them (graceful degrade), never a fake value.
+toggle counts), the interactive intervention / rewind PICKERS, and the
+persisted past-turn CONVERSATION log (``conversation_history`` — the #3273
+Phase-5 restore-on-restart source) are session-local and are NOT on the wire —
+the remote model returns empty/``—``/0 for them (graceful degrade), never a fake
+value.
 """
 from __future__ import annotations
 
@@ -41,6 +43,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from reyn.interfaces.transport.client_transport import ClientTransport
+    from reyn.runtime.chat_message import ChatMessage
 
 
 class ChatReadModel(ABC):
@@ -85,6 +88,26 @@ class ChatReadModel(ABC):
     def history_path(self) -> Path:
         """Filesystem path for the input-history file."""
 
+    @abstractmethod
+    def conversation_history(self, *, limit: "int | None" = None) -> "list[ChatMessage]":
+        """Recent persisted CONVERSATION turns (the ``ChatMessage`` log loaded
+        from ``history.jsonl``), oldest→newest, for the Textual app's
+        restore-on-restart hydration (#3273 Phase 5).
+
+        This is the DURABLE conversation log (assistant text + tool results), NOT
+        the input-history file :attr:`history_path` (↑-recall) and NOT the P6
+        audit-event log (which carries neither and rotates). ``limit`` caps to the
+        most-recent N turns; ``None`` returns the whole loaded log (resume-
+        equivalent — whatever survives in ``history.jsonl``; turns rotated out are
+        simply not restored, exactly like ``--resume``).
+
+        **Frame-sufficiency boundary.** Like every other session-local read
+        (dropdown expansions, the rewind picker), the past-turn log is NOT
+        projected onto the AG-UI wire — a REMOTE client holds no session and
+        cannot enumerate it. The remote impl therefore degrades gracefully to an
+        empty list (never a fabricated turn); cross-session restore is a
+        LOCAL-attach affordance today."""
+
 
 class RegistryReadModel(ChatReadModel):
     """LOCAL read-model — delegates to the same registry/session accessors the
@@ -126,6 +149,20 @@ class RegistryReadModel(ChatReadModel):
                 "(call registry.attach() before run_inline_input)"
             )
         return s.workspace_dir / ".input_history"
+
+    def conversation_history(self, *, limit: "int | None" = None):
+        # The attached Session's ``history`` list IS the ChatMessage log loaded
+        # from ``history.jsonl`` by ``Session.load_history`` at attach time — read
+        # it straight (no audit-event path). Return a shallow copy so a caller can
+        # not mutate the live session history. ``None`` = whole log (resume-
+        # equivalent); a positive ``limit`` keeps the most-recent N.
+        s = self._attached()
+        if s is None:
+            return []
+        history = list(getattr(s, "history", []) or [])
+        if limit is not None and limit >= 0:
+            return history[-limit:]
+        return history
 
 
 def project_remote_snapshot(values: "dict | None") -> dict:
@@ -203,6 +240,13 @@ class RemoteReadModel(ChatReadModel):
         base = Path.home() / ".reyn"
         base.mkdir(parents=True, exist_ok=True)
         return base / "remote-input-history"
+
+    def conversation_history(self, *, limit: "int | None" = None):
+        # Frame-sufficiency: a remote client holds no session and the past-turn
+        # ChatMessage log is NOT projected onto the wire (like the dropdown
+        # expansions / rewind picker). Degrade gracefully to empty — never a
+        # fabricated turn. Restore-on-restart is a local-attach affordance today.
+        return []
 
 
 __all__ = [

--- a/tests/test_textual_chat_phase1_3273.py
+++ b/tests/test_textual_chat_phase1_3273.py
@@ -212,6 +212,7 @@ class RM(ChatReadModel):
     def has_command_ui_region(self): return True
     @property
     def history_path(self): return Path("/tmp/reyn_isolation_history")
+    def conversation_history(self, *, limit=None): return []
 
 
 class R(ChatRenderer):

--- a/tests/test_textual_chat_phase4_3273.py
+++ b/tests/test_textual_chat_phase4_3273.py
@@ -189,6 +189,9 @@ class _SnapshotReadModel(ChatReadModel):
     def history_path(self) -> Path:
         return Path("/tmp/reyn_phase4_history")
 
+    def conversation_history(self, *, limit=None):
+        return []
+
 
 class ScriptedTransport(ClientTransport):
     """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream

--- a/tests/test_textual_chat_phase5_3273.py
+++ b/tests/test_textual_chat_phase5_3273.py
@@ -1,0 +1,416 @@
+"""Phase 5 TUI-rebuild gates (#3273): restore-on-restart hydration.
+
+On ``reyn chat`` restart the Textual conversation pane should show the PREVIOUS
+conversation (Claude-Code ``--resume`` parity) rather than starting blank. The
+app hydrates its retained ``FlowModel`` from the persisted ``ChatMessage`` log
+(``history.jsonl``) BEFORE the live frame pump starts, projecting each turn
+through the SAME presenter/gutter path a live frame uses.
+
+Graded invariants (mapped to the PR test plan):
+
+1. **Restart shows the previous conversation** — a fixture ``ChatMessage`` log
+   hydrates the model in order, resolved (never RUNNING), and those turns sit
+   ABOVE the first live frame.
+2. **Source = history.jsonl, not audit-events** — the LOCAL accessor reads the
+   durable ``ChatMessage`` log loaded from ``history.jsonl`` (re-read from disk),
+   never the P6 audit-event log.
+3. **Non-authoritative projection / truncate-falsify N/A** — the ``FlowModel`` is
+   a projection of the AUTHORITATIVE ``history.jsonl`` store, read DIRECTLY (not
+   WAL-event-reconstructed), so the CLAUDE.md recovery truncate-falsify gate does
+   not apply (there is no WAL-derived state to lose). See
+   ``test_restore_source_is_authoritative_chat_log_gate_na``'s docstring.
+4. **Retention = resume-equivalent** — the accessor restores whatever is in the
+   log (a ``limit`` keeps the most-recent N; turns not in the log are absent).
+5. **Import isolation + plain fallback preserved** — the accessor addition pulls
+   no textual import into an always-loaded module; the subprocess witness re-runs.
+
+All app-level tests use real instances (a concrete ``ClientTransport`` +
+``ChatReadModel`` seam impl + the real app/pilot) and the accessor test uses a
+real ``AgentRegistry`` + real ``Session`` — no mocks, per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.restore import (
+    RESTORED_META_KEY,
+    project_restored_frames,
+)
+from reyn.interfaces.repl.read_model import ChatReadModel, RegistryReadModel, RemoteReadModel
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.chat_message import ChatMessage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── real seam impls (no mocks) ────────────────────────────────────────────────
+
+
+class _HistoryReadModel(ChatReadModel):
+    """A real :class:`ChatReadModel` seam impl (like ``RegistryReadModel``)
+    returning a fixed persisted ``ChatMessage`` log — the app hydrates its model
+    off ``conversation_history`` exactly as it would off the local registry."""
+
+    def __init__(self, messages: "list[ChatMessage]") -> None:
+        self._messages = list(messages)
+
+    def snapshot(self, config=None):
+        return None
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return True
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/tmp/reyn_phase5_input_history")
+
+    def conversation_history(self, *, limit=None):
+        return self._messages[-limit:] if limit is not None else list(self._messages)
+
+
+class ScriptedTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport`. ``end=False`` keeps the stream
+    open so the app stays mounted; ``messages`` are the LIVE frames pumped AFTER
+    the mount-time hydration."""
+
+    def __init__(self, messages: "list[OutboxMessage] | None" = None) -> None:
+        self._messages = list(messages or [])
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _entries(app: TextualChatApp):
+    return list(app.query_one(FlowView).entries)
+
+
+# A fixture conversation log: a user turn, an assistant reply, a tool result, and
+# a trailing turn — plus a ``system`` and a ``summary`` entry that must NOT
+# surface (internal chrome, filtered at the LLM wire boundary).
+def _fixture_log() -> "list[ChatMessage]":
+    return [
+        ChatMessage(role="user", content="first question"),
+        ChatMessage(role="assistant", content="first answer"),
+        ChatMessage(
+            role="tool", content="Read 42 lines", name="file__read",
+            tool_call_id="call_1",
+        ),
+        ChatMessage(role="summary", content="(compactor carry — never shown)"),
+        ChatMessage(role="user", content="second question"),
+        ChatMessage(role="assistant", content="second answer"),
+    ]
+
+
+# ── Tier 1: pure projection (source-naming + ordering) ────────────────────────
+
+
+def test_projection_maps_roles_preserves_order_and_names_source() -> None:
+    """Tier 1: ``project_restored_frames`` maps user→user, assistant→agent,
+    tool→tool_call_completed, preserving conversation order, and skips the
+    internal ``system``/``summary`` roles. Its input is the ``ChatMessage`` log
+    (NOT audit-events) — the projection consumes ``ChatMessage`` values only."""
+    frames = project_restored_frames(_fixture_log())
+    # Leading resume divider (system) then the conversation, summary dropped.
+    kinds = [f.kind for f in frames]
+    assert kinds == [
+        "system",  # ⤺ resume divider
+        "user", "agent", "tool_call_completed", "user", "agent",
+    ], f"unexpected projection kinds: {kinds}"
+    # Order + text preserved for the conversational rows.
+    convo = [(f.kind, f.text) for f in frames if f.kind != "system"]
+    assert convo == [
+        ("user", "first question"),
+        ("agent", "first answer"),
+        ("tool_call_completed", "file__read"),
+        ("user", "second question"),
+        ("agent", "second answer"),
+    ]
+    # The tool row carries the result summary meta the presenter reads.
+    tool = next(f for f in frames if f.kind == "tool_call_completed")
+    assert tool.meta.get("tool") == "file__read"
+    assert tool.meta.get("result") == "Read 42 lines"
+    # Every restored frame is marked as such.
+    assert all(f.meta.get(RESTORED_META_KEY) is True for f in frames)
+
+
+def test_projection_empty_log_yields_no_frames_no_divider() -> None:
+    """Tier 1: a first-ever run (empty log) projects to nothing — no divider, so
+    the pane stays blank (resume-equivalent: nothing to restore)."""
+    assert project_restored_frames([]) == []
+
+
+def test_projection_skips_blank_text_turns() -> None:
+    """Tier 1: a whitespace-only user/assistant turn is not projected (it would
+    render an empty row); a tool result with no text still projects (its meta
+    carries the summary)."""
+    frames = project_restored_frames([
+        ChatMessage(role="user", content="   "),
+        ChatMessage(role="assistant", content=""),
+    ])
+    assert frames == []
+
+
+# ── Tier 2: app hydration end-to-end ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_restart_shows_previous_conversation_before_live_frames() -> None:
+    """Tier 2: the CORE witness — mounting the app hydrates the retained model
+    from the persisted ``ChatMessage`` log so the PREVIOUS conversation is present
+    in order, and those restored turns sit ABOVE the first LIVE frame (hydration
+    runs at ``on_mount`` before the frame pump)."""
+    live = OutboxMessage(kind="user", text="LIVE turn after restart")
+    app = TextualChatApp(
+        transport=ScriptedTransport([live]),
+        read_model=_HistoryReadModel(_fixture_log()),
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entries = _entries(app)
+        rows = [(e.item.kind, e.item.text) for e in entries]
+        # Restored conversation (divider + turns) precedes the live frame.
+        assert rows == [
+            ("system", "⤺ resumed previous conversation"),
+            ("user", "first question"),
+            ("agent", "first answer"),
+            ("tool_call_completed", "file__read"),
+            ("user", "second question"),
+            ("agent", "second answer"),
+            ("user", "LIVE turn after restart"),
+        ], f"restore/live ordering wrong: {rows}"
+        # The live frame is LAST — restore happened before the pump.
+        assert rows[-1] == ("user", "LIVE turn after restart")
+
+
+@pytest.mark.asyncio
+async def test_restored_entries_render_resolved_never_running() -> None:
+    """Tier 2: every restored entry is RESOLVED, never RUNNING — a restored tool
+    result carries SUCCESS (green gutter), user/agent rows keep DEFAULT. A restart
+    must never leave a phantom RUNNING (blinking) row for a settled past turn."""
+    app = TextualChatApp(
+        transport=ScriptedTransport(),
+        read_model=_HistoryReadModel(_fixture_log()),
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entries = _entries(app)
+        assert entries, "no entries were hydrated"
+        assert all(e.state is not EntryState.RUNNING for e in entries), (
+            "a restored turn is RUNNING — settled past turns must be resolved"
+        )
+        tool = next(e for e in entries if e.item.kind == "tool_call_completed")
+        assert tool.state is EntryState.SUCCESS, "restored tool result not resolved to SUCCESS"
+
+
+@pytest.mark.asyncio
+async def test_remote_read_model_hydrates_nothing_graceful_degrade() -> None:
+    """Tier 2: a read model that cannot serve past turns (remote frame-sufficiency
+    boundary → empty log) hydrates nothing — the app mounts with a blank pane and
+    no fabricated turn, exactly as before Phase 5."""
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_HistoryReadModel([])
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        assert _entries(app) == [], "an empty log must hydrate zero entries (no divider)"
+
+
+def test_remote_read_model_conversation_history_is_empty() -> None:
+    """Tier 2: the REAL ``RemoteReadModel`` returns an empty conversation log —
+    the past-turn ``ChatMessage`` log is session-local and NOT on the AG-UI wire,
+    so a remote client degrades gracefully (never a fabricated turn)."""
+    rm = RemoteReadModel(ScriptedTransport())
+    assert rm.conversation_history() == []
+    assert rm.conversation_history(limit=5) == []
+
+
+# ── Tier 2: LOCAL accessor source + retention (real registry + Session) ───────
+
+
+def _registry(tmp_path) -> AgentRegistry:
+    def factory(profile: AgentProfile) -> Session:
+        agent_dir = tmp_path / ".reyn" / "agents" / profile.name
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        s = make_session(
+            agent_name=profile.name,
+            agent_role=profile.role,
+            snapshot_path=agent_dir / "state" / "snapshot.json",
+        )
+        # Production parity (chat.py): rehydrate the persisted conversation from
+        # history.jsonl at build time.
+        s.load_history()
+        return s
+
+    reg = AgentRegistry(project_root=tmp_path, session_factory=factory)
+    reg.create("solo")
+    return reg
+
+
+@pytest.mark.asyncio
+async def test_restore_source_is_authoritative_chat_log_gate_na(tmp_path, monkeypatch) -> None:
+    """Tier 2: the LOCAL accessor restores from the durable ``ChatMessage`` log on
+    disk (``history.jsonl``), NOT the P6 audit-event log — turns appended and
+    persisted survive a drop of the in-memory list + a fresh ``load_history``.
+
+    Truncate-falsify recovery gate — DETERMINATION: N/A. The CLAUDE.md
+    recovery-feature gate guards WAL-event-DERIVED reconstruction state (state a
+    truncation of ``wal.jsonl`` below its source events would silently lose).
+    Restore here is NOT that: ``history.jsonl`` is the AUTHORITATIVE conversation
+    store and the accessor reads it DIRECTLY (derived-at-read, not
+    WAL-reconstructed), so there is no WAL-derived state to lose and no truncate-
+    falsify obligation. This test witnesses the authoritative-disk source; were a
+    future change to make any restored surface WAL-reconstructed, the gate WOULD
+    apply and this determination must be revisited."""
+    monkeypatch.chdir(tmp_path)  # isolate the session's cwd-relative workspace/history.jsonl
+    reg = _registry(tmp_path)
+    try:
+        session = await reg.attach("solo")
+        session._append_history(ChatMessage(role="user", content="restore me please"))
+        session._append_history(ChatMessage(role="assistant", content="here is your restore"))
+        # Prove the DISK log (history.jsonl) is the source: drop the in-memory
+        # list and re-read from disk. If restore rode audit-events (which do not
+        # carry assistant text), the reply text would be gone.
+        session.history.clear()
+        session.load_history()
+
+        rm = RegistryReadModel(reg)
+        restored = rm.conversation_history()
+        assert [(m.role, m.text) for m in restored] == [
+            ("user", "restore me please"),
+            ("assistant", "here is your restore"),
+        ], "accessor did not return the disk-persisted ChatMessage log"
+        assert session.history_path.name == "history.jsonl"
+        assert session.history_path.exists(), "the source file is history.jsonl on disk"
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_retention_is_resume_equivalent(tmp_path, monkeypatch) -> None:
+    """Tier 2: retention is resume-equivalent — the accessor restores whatever is
+    in the log (N turns), and a ``limit`` keeps only the most-recent N (a caller's
+    cross-session view need not restore the whole log). Nothing outside the log is
+    ever returned."""
+    monkeypatch.chdir(tmp_path)  # isolate the session's cwd-relative workspace/history.jsonl
+    reg = _registry(tmp_path)
+    try:
+        session = await reg.attach("solo")
+        for i in range(5):
+            session._append_history(ChatMessage(role="user", content=f"turn-{i}"))
+        rm = RegistryReadModel(reg)
+
+        full = rm.conversation_history()
+        assert [m.text for m in full] == [f"turn-{i}" for i in range(5)], (
+            "full restore must return every persisted turn, in order"
+        )
+        recent = rm.conversation_history(limit=2)
+        assert [m.text for m in recent] == ["turn-3", "turn-4"], (
+            "limit must keep the most-recent N turns (resume-equivalent)"
+        )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+# ── Tier 2c: import isolation preserved (accessor adds no always-loaded import) ─
+
+_ISOLATION_SUBPROCESS = '''
+import sys
+
+
+class _Block:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in ("textual", "textual_flowview"):
+            raise ModuleNotFoundError("blocked for isolation test: " + name)
+        return None
+
+
+sys.meta_path.insert(0, _Block())
+
+import reyn.interfaces.repl.client_driver  # noqa: E402,F401
+import reyn.interfaces.repl.read_model  # noqa: E402,F401  (the accessor lives here — must stay textual-free)
+import reyn.interfaces.repl.stream_client  # noqa: E402,F401
+import reyn.interfaces.cli.commands.chat  # noqa: E402,F401
+import reyn.runtime.chat_message  # noqa: E402,F401  (the accessor's return type)
+
+assert "textual_flowview" not in sys.modules, "flowview imported at module load"
+assert "textual" not in sys.modules, "textual imported at module load"
+print("ISOLATION_OK")
+'''
+
+
+def test_phase5_accessor_imports_stay_tty_only() -> None:
+    """Tier 2c: with ``textual`` / ``textual_flowview`` unimportable, the plain /
+    non-TTY path — INCLUDING ``read_model`` (where the new ``conversation_history``
+    accessor lives) and ``chat_message`` (its return type) — still imports green.
+    The Phase-5 accessor added no top-level textual import to an always-loaded
+    module. Runs the strip in a clean subprocess."""
+    import subprocess
+    import sys
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _ISOLATION_SUBPROCESS],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    assert "ISOLATION_OK" in proc.stdout, f"stdout={proc.stdout}\nstderr={proc.stderr}"


### PR DESCRIPTION
**[per-PR-coder]** — Phase 5 of the TUI-rebuild arc, `part of #3273` (NOT closes).

## What

On `reyn chat` restart the Textual conversation pane now shows the PREVIOUS conversation (Claude-Code `--resume` parity) instead of a blank pane. The app hydrates its retained `FlowModel` from the persisted `ChatMessage` log (`history.jsonl`) BEFORE the live frame pump starts, projecting each turn through the SAME presenter/gutter path a live frame uses. Restored turns render RESOLVED (never RUNNING).

## How

- **`ChatReadModel.conversation_history()` seam** (`interfaces/repl/read_model.py`) — new accessor on the ABC + both impls.
  - `RegistryReadModel` (LOCAL): reads the attached `Session.history` (the `ChatMessage` log `load_history()` loads from `history.jsonl`), optional `limit` keeps the most-recent N.
  - `RemoteReadModel` (REMOTE): returns `[]` — the past-turn log is session-local and NOT on the AG-UI wire (the read model's frame-sufficiency boundary), so a remote client degrades gracefully (never a fabricated turn). Resolves the seam Phase 4 flagged.
- **`textual_chat/restore.py`** (new) — pure, textual-free `project_restored_frames`: `ChatMessage` → `OutboxMessage` display frames (`user`→`user`, `assistant`→`agent`, `tool`→resolved `tool_call_completed` carrying the result summary meta; `system`/`summary` skipped; a leading `⤺ resumed previous conversation` divider). Unit-testable without mounting the app.
- **`app.on_mount`** calls `_hydrate_from_history()` BEFORE `run_worker(self._pump_frames())`, so restored turns sit ABOVE the first live frame. Restored tool rows get the SUCCESS/ERROR state via the same `summarize_tool_result` the presenter reads; user/agent rows keep DEFAULT. The History drawer pane reads the same retained model, so it becomes cross-session by construction (no separate accessor call).
- Stale docstrings updated in the same PR (doc-drift rule): `app.py` class docstring + `_history_turns`, `chrome.py` History bullet, `read_model.py` frame-sufficiency paragraph — all previously said restore was "deferred to Phase 5".

## Source = history.jsonl, NOT audit-events (D1)

The restore source is the persisted `ChatMessage` log; audit-events carry neither assistant text nor tool results and rotate. The accessor reads the loaded log directly.

## Truncate-falsify recovery gate: N/A (determination)

Per CLAUDE.md's recovery-feature gate, stating WHY it does not apply: the `FlowModel` is a **projection** of the **authoritative** `history.jsonl` store, read **directly** (derived-at-read, NOT WAL-event-reconstructed). The truncate-falsify gate guards WAL-event-DERIVED reconstruction state against WAL truncation below its source events; there is no WAL-derived state here to lose, so the gate does not apply. I looked for any WAL-reconstructed restored surface and found none — if a future change introduces one, the gate WOULD apply and this determination must be revisited. Documented in `restore.py`'s module docstring and the accessor test's docstring.

## OUT OF SCOPE

Old-app retirement (Phase 6). F5c (orphan RUNNING timeout) / F5d (remote-parity witness) are separate track items — not touched.

## Test plan (all gates green)

- [x] **1. Restart shows previous conversation** — `test_restart_shows_previous_conversation_before_live_frames`: fixture `ChatMessage` log hydrates the model in order and those turns sit ABOVE the first live frame (Tier 2, real app + pilot).
- [x] **2. Source = history.jsonl, not audit-events** — `test_restore_source_is_authoritative_chat_log_gate_na`: real `AgentRegistry` + `Session`; appended turns persisted to `history.jsonl`, in-memory list dropped, re-read from disk → accessor returns them (assistant text survives, which audit-events could not carry). Plus the pure projection test names the `ChatMessage` source.
- [x] **3. Non-authoritative projection / truncate-falsify N/A** — documented in `restore.py` module docstring + the accessor test docstring. No WAL-reconstructed derived state found.
- [x] **4. Retention resume-equivalent** — `test_retention_is_resume_equivalent`: N persisted turns all restored in order; `limit` keeps the most-recent N; nothing outside the log returned.
- [x] **5. Import-isolation + plain-fallback preserved** — `test_phase5_accessor_imports_stay_tty_only`: subprocess witness with `textual`/`textual_flowview` blocked; the plain path (incl. `read_model` where the accessor lives, and `chat_message` its return type) imports green.
- [x] `test_remote_read_model_conversation_history_is_empty` + `test_remote_read_model_hydrates_nothing_graceful_degrade` — remote graceful-degrade witness.

## CI gates run locally (worktree venv, extras dev,mcp,web,fs-watch,observability,builtin-rag)

- [x] `ruff check src tests` — All checks passed
- [x] `python scripts/test_tier_audit.py --strict <changed test files>` — OK 26/26
- [x] `python scripts/verify_module_docstrings.py <changed src>` — OK
- [x] `uv run python -m pytest` (full, foreground) — **9223 passed, 36 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)