### PR TITLE
build(deps): re-pin textual-flowview to dynamic-content HEAD 319cf9e6 (#3283 P0')

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     # LAZILY on the TTY path only, so the plain / --cui / non-TTY / CI paths never
     # touch textual or flowview and stay green even if flowview fails to resolve.
     "textual>=0.80",
-    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@15a942c27bdb82ddfe7f550f0f35d121c63440c8",
+    "textual-flowview @ git+https://github.com/tya5/textual-flowview.git@319cf9e6ca761beb7c0ccad572b879e455427753",
     "numpy>=1.24",           # RAG index backend cosine similarity (ADR-0033)
     "croniter>=2.0",         # cron expression parsing for FP-0009 Component B
     "charset-normalizer>=3.0",  # #1452 file__read encoding detection (MIT, pure-python)

--- a/uv.lock
+++ b/uv.lock
@@ -3866,7 +3866,7 @@ requires-dist = [
     { name = "sqlite-vec", marker = "extra == 'builtin-rag'", specifier = ">=0.1.9" },
     { name = "starlette", marker = "extra == 'web'", specifier = ">=1.0,<1.3" },
     { name = "textual", specifier = ">=0.80" },
-    { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=15a942c27bdb82ddfe7f550f0f35d121c63440c8" },
+    { name = "textual-flowview", git = "https://github.com/tya5/textual-flowview.git?rev=319cf9e6ca761beb7c0ccad572b879e455427753" },
     { name = "trafilatura", marker = "extra == 'fetch'", specifier = ">=1.8" },
     { name = "twine", marker = "extra == 'release'", specifier = ">=5.0" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.27" },
@@ -4234,7 +4234,7 @@ wheels = [
 [[package]]
 name = "textual-flowview"
 version = "0.3.0.dev0"
-source = { git = "https://github.com/tya5/textual-flowview.git?rev=15a942c27bdb82ddfe7f550f0f35d121c63440c8#15a942c27bdb82ddfe7f550f0f35d121c63440c8" }
+source = { git = "https://github.com/tya5/textual-flowview.git?rev=319cf9e6ca761beb7c0ccad572b879e455427753#319cf9e6ca761beb7c0ccad572b879e455427753" }
 dependencies = [
     { name = "textual" },
 ]


### PR DESCRIPTION
**[per-PR-coder]** — part of #3283 (flowview-dynamic-content arc, P0').

## What
Re-pin the `textual-flowview` git dependency to `origin/main` HEAD so phases ①-⑤ of #3283 can build on the dynamic-content extension.

- **FROM** `...@15a942c27bdb82ddfe7f550f0f35d121c63440c8`
- **TO**   `...@319cf9e6ca761beb7c0ccad572b879e455427753`

New surface this brings in (additive): `animate_entry`, `animation_fps`, `track_visibility`, right-gutter (`right_decorator`, `right_gutter_width`), `set_hidden`, `separator`.

**Scope:** pin bump + lockfile ONLY. No feature code — the 5 applications are later phases ①-⑤ of #3283.

## Compatibility
Backward-compatible with reyn's current usage. `Presentation{height,renderable,background}`, `Entry.set_state/set_metadata/set_item/update`, `FlowView(model,presenter,decorator,gutter_width,anchor,spacing,...)`, `FlowView.Clicked`, `EntryState`, `Anchor`, `FlowModel`, `FlowDecorator` all still present; new params are additive. No reyn code change required — none was made.

## Test plan
- [x] **Dep resolves at new pin** — `uv lock --check` clean (Resolved 213 packages); `from textual_flowview import FlowView, Presentation, Entry, EntryState, Anchor, FlowModel, FlowDecorator` imports OK; resolved flowview version `0.3.0.dev0` (319cf9e6). New surface confirmed present (`FlowView.animate_entry`, `Entry.set_hidden`).
- [x] **Backward-compat / no regression** — full suite green: **9091 passed, 36 skipped** (exit 0). Targeted re-run of `textual_chat` + import-isolation + flowview: **44 passed, 2 skipped**. No test needed a change → no compat break.
- [x] **No feature code** — diff is `pyproject.toml` + `uv.lock` only (`2 files changed, 3 insertions(+), 3 deletions(-)`).

## CI gates run locally
- [x] `ruff check src tests` — All checks passed
- [x] `uv run python -m pytest --timeout=120` — 9091 passed, 36 skipped
- [x] tier-audit — N/A (no test files changed)
- [x] verify_module_docstrings — N/A (no src files changed)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)