### PR TITLE
fix(tui): native FlowView(animation_fps) running-blink — #3283 ①

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -11,8 +11,10 @@ presentation is the
 state-coloured gutter the
 :class:`~reyn.interfaces.inline.textual_chat.gutter.ReynGutter`'s, and the bottom
 chrome the widgets in :mod:`~reyn.interfaces.inline.textual_chat.chrome`. This app
-wires them, drives the frame pump + blink timer, and routes composer submissions
-back through the transport send seam.
+wires them, drives the frame pump, and routes composer submissions back through
+the transport send seam. The running-blink gutter animates itself off
+textual-flowview's native ``FlowView(animation_fps=N)`` clock — there is no
+app-side blink timer.
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily via
 :mod:`reyn.interfaces.repl.client_driver`); its ``textual`` / ``textual_flowview``
@@ -47,13 +49,11 @@ from .chrome import (
     pane_payload,
     status_line_text,
 )
-from .gutter import ReynGutter
+from .gutter import _RUNNING_FRAME_PERIOD, ReynGutter
 from .presenter import ReynPresenter, choice_chip_spans
 from .restore import project_restored_frames
 
 if TYPE_CHECKING:
-    from textual.timer import Timer
-
     from reyn.interfaces.repl.read_model import ChatReadModel
     from reyn.interfaces.transport.client_transport import ClientTransport
     from reyn.runtime.outbox import OutboxMessage
@@ -98,9 +98,12 @@ class TextualChatApp(App):
 
     Phase 2 adds state-coloured gutters: a tool-call row transitions RUNNING →
     SUCCESS/ERROR (amber → green/coral) as its correlated frames arrive, a
-    failed row is tinted coral edge-to-edge, and RUNNING rows blink via an
-    app-side timer (:meth:`_advance_blink`). The blink is additive — neutering
-    the timer leaves a static, correct gutter.
+    failed row is tinted coral edge-to-edge, and RUNNING rows blink. The blink is
+    NATIVE: ``FlowView(animation_fps=N)`` re-invokes the time-based
+    :class:`ReynGutter` decorator on each animation tick, and the decorator picks
+    the frame from a monotonic clock — no app-side timer, no shared counter. The
+    blink is additive: a frozen clock (``frame_period<=0``) leaves a static,
+    correct amber gutter.
 
     Phase 3 adds the bottom-chrome tab-drawer: below the composer, a
     :class:`StatusLine` + a focusable :class:`MenuBar`, and a
@@ -139,8 +142,14 @@ class TextualChatApp(App):
     Textual TTY.
     """
 
-    #: Seconds between running-blink frames (app-side; textual-flowview unmodified).
-    BLINK_INTERVAL = 0.5
+    #: FlowView animation frame rate (Hz) driving the native running-blink gutter.
+    #: Set to ``1 / <blink frame period>`` so textual-flowview's own animation tick
+    #: re-invokes the time-based :class:`ReynGutter` at least once per frame — the
+    #: visible blink cadence matches the pre-native 0.5s app-side timer. ``fps>0``
+    #: means the clock is always-on (no idle-pause); the idle tick is a viewport-
+    #: gated gutter re-derive measured at ~0.003% of one core, so always-on is
+    #: accepted over per-entry toggling (see #3283 ①).
+    ANIMATION_FPS = 1.0 / _RUNNING_FRAME_PERIOD
 
     BINDINGS = [
         # Global fallback so Esc closes the drawer even when focus is INSIDE it
@@ -227,9 +236,6 @@ class TextualChatApp(App):
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
         self._running_tools: "dict[object, Entry[OutboxMessage]]" = {}
-        # Shared blink frame counter read by ReynGutter; advanced by the timer.
-        self._blink_count = 0
-        self._blink_timer: "Timer | None" = None
         # Per-picker parallel id lists (class names / agent names), keyed by tab
         # id and kept in lock-step with the OptionList options a pane was last
         # refreshed with, so an ``OptionSelected.option_index`` maps back to the
@@ -242,10 +248,13 @@ class TextualChatApp(App):
         yield FlowView(
             model=self.conversation,
             presenter=self._presenter,
-            decorator=ReynGutter(blink_frame=lambda: self._blink_count),
+            decorator=ReynGutter(frame_period=_RUNNING_FRAME_PERIOD),
             gutter_width=_GUTTER_WIDTH,
             spacing=1,
             anchor=Anchor.STICKY_BOTTOM,
+            # Native running-blink: FlowView owns the animation clock and
+            # re-invokes the time-based ReynGutter each tick (no app-side timer).
+            animation_fps=self.ANIMATION_FPS,
         )
         with Horizontal(id="inputrow"):
             yield Static("❯", id="inputgutter")
@@ -346,14 +355,10 @@ class TextualChatApp(App):
         # same presenter/gutter path a live frame does. Must run before
         # ``run_worker`` so the prior turns sit ABOVE the first live frame.
         self._hydrate_from_history()
-        # The running-blink timer starts PAUSED and is resumed only while a
-        # tool call is RUNNING (and paused again when none remain) — it never
-        # spins on an idle conversation. The blink is app-side + ADDITIVE:
-        # neutering ``_advance_blink`` freezes the frame to a static gutter
-        # without affecting correctness (see the Phase-2 strip gate).
-        self._blink_timer = self.set_interval(
-            self.BLINK_INTERVAL, self._advance_blink, pause=True
-        )
+        # The running-blink gutter animates off FlowView's NATIVE animation clock
+        # (``animation_fps`` wired in :meth:`compose`), not an app-side timer — so
+        # there is nothing to start/pause here. The blink is ADDITIVE: a frozen
+        # clock leaves a static, correct amber gutter (see the Phase-2 strip gate).
         self.run_worker(self._pump_frames(), name="frames", exclusive=True)
         # Drawer starts collapsed — the default chrome is just the two slim rows
         # (status-values line + menu row). It only becomes visible when a menu
@@ -512,26 +517,20 @@ class TextualChatApp(App):
                 entry.set_state(EntryState.SUCCESS)
                 break
 
-    def _advance_blink(self) -> None:
-        """One blink tick: advance the shared frame counter and redraw ONLY the
-        running entries' gutters (``set_metadata`` is flowview's gutter-only
-        redraw primitive — it never re-presents the body). Pauses itself when no
-        entry is RUNNING, so the timer does not spin on an idle conversation."""
-        self._blink_count += 1
-        for entry in list(self._running_tools.values()):
-            entry.set_metadata("_blink", self._blink_count)
-        if not self._running_tools and self._blink_timer is not None:
-            self._blink_timer.pause()
-
     def _track_tool_state(self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]") -> None:
         """Drive the Phase-2 lifecycle state of tool-call / error rows.
 
         A ``tool_call_started`` row (with an ``op_id`` correlation key) becomes
-        RUNNING and starts blinking; the matching ``tool_call_completed`` /
-        ``tool_call_failed`` frame transitions that SAME entry to SUCCESS/ERROR
-        (its gutter goes amber → green/coral). ``error`` rows go straight to
-        ERROR. Frames without an ``op_id`` carry no state (DEFAULT) — they append
-        exactly as in Phase 1, so the plain-fallback turn sequence is unchanged."""
+        RUNNING (its gutter blinks amber off the native animation clock); the
+        matching ``tool_call_completed`` / ``tool_call_failed`` frame transitions
+        that SAME entry to SUCCESS/ERROR (its gutter goes amber → green/coral).
+        ``error`` rows go straight to ERROR. Frames without an ``op_id`` carry no
+        state (DEFAULT) — they append exactly as in Phase 1, so the plain-fallback
+        turn sequence is unchanged.
+
+        ``_running_tools`` keys the RUNNING entry by ``op_id`` purely for this
+        RUNNING → SUCCESS/ERROR correlation (NOT for the blink — the blink is now
+        time-based in :class:`ReynGutter`, driven by the native animation tick)."""
         kind = msg.kind
         meta = msg.meta or {}
         op_id = meta.get("op_id")
@@ -539,8 +538,6 @@ class TextualChatApp(App):
             if op_id is not None:
                 entry.set_state(EntryState.RUNNING)
                 self._running_tools[op_id] = entry
-                if self._blink_timer is not None:
-                    self._blink_timer.resume()
         elif kind == "tool_call_completed":
             summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
             started = self._running_tools.pop(op_id, None) if op_id is not None else None
@@ -548,19 +545,13 @@ class TextualChatApp(App):
                 started.set_state(
                     EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
                 )
-            self._maybe_pause_blink()
         elif kind == "tool_call_failed":
             started = self._running_tools.pop(op_id, None) if op_id is not None else None
             if started is not None:
                 started.set_state(EntryState.ERROR)
             entry.set_state(EntryState.ERROR)
-            self._maybe_pause_blink()
         elif kind == "error":
             entry.set_state(EntryState.ERROR)
-
-    def _maybe_pause_blink(self) -> None:
-        if not self._running_tools and self._blink_timer is not None:
-            self._blink_timer.pause()
 
     async def _pump_frames(self) -> None:
         """Drain the transport frame stream into the retained model.

--- a/src/reyn/interfaces/inline/textual_chat/gutter.py
+++ b/src/reyn/interfaces/inline/textual_chat/gutter.py
@@ -3,9 +3,12 @@
 :class:`ReynGutter` fills the flowview gutter column with a kind-driven glyph
 (via :func:`_gutter_glyph_color`) whose COLOUR is driven by the entry's
 :class:`~textual_flowview.EntryState` (:data:`_STATE_COLOR`); a ``RUNNING`` entry
-BLINKS through :data:`_RUNNING_FRAMES` selected by a shared app-side counter. The
-blink lives ENTIRELY in reyn (counter + timer in the app, frame selection here);
-textual-flowview is never modified or forked.
+BLINKS through :data:`_RUNNING_FRAMES`, the frame selected from a monotonic clock
+(``int(clock() / frame_period)``). The blink is TIME-based: ``decorate`` reads the
+clock itself, and textual-flowview's own ``FlowView(animation_fps=N)`` re-invokes
+the decorator on each animation tick so the glyph advances with wall time — no
+app-held frame counter, no app-side timer. textual-flowview is never modified or
+forked.
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily via
 :mod:`reyn.interfaces.repl.client_driver`); its ``textual_flowview`` import never
@@ -13,6 +16,7 @@ reaches an always-loaded module.
 """
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Callable
 
 from rich.text import Text
@@ -45,11 +49,19 @@ _STATE_COLOR: "dict[EntryState, str]" = {
     EntryState.CANCELLED: _CC_DIM,
 }
 
-# Running-blink frames: a two-phase ●/○ pulse cycled by the app-side timer's
-# shared frame counter (:meth:`TextualChatApp._advance_blink`). The blink lives
-# ENTIRELY in reyn — the counter + timer in the app, the frame selection here;
-# textual-flowview is never modified or forked.
+# Running-blink frames: a two-phase ●/○ pulse. The frame is picked from a
+# monotonic clock (``int(clock() / frame_period) % len(_RUNNING_FRAMES)``) in
+# :meth:`ReynGutter.decorate`; textual-flowview's ``FlowView(animation_fps=N)``
+# re-invokes the decorator each animation tick, so the pulse advances with wall
+# time. No app-side timer, no shared counter — the blink lives in this decorator
+# + the library's native animation clock; textual-flowview is never modified.
 _RUNNING_FRAMES = ("●", "○")
+
+#: Seconds each running-blink frame is held before the next glyph. The visible
+#: blink cadence (== the pre-native app-side timer's 0.5s interval); paired with
+#: ``FlowView(animation_fps=1/_RUNNING_FRAME_PERIOD)`` so the decorator is
+#: re-invoked at least once per frame. ``<= 0`` freezes the blink (static frame 0).
+_RUNNING_FRAME_PERIOD = 0.5
 
 
 def _gutter_glyph_color(msg: "OutboxMessage") -> "tuple[str, str]":
@@ -85,20 +97,42 @@ class ReynGutter:
     message rows are unchanged from Phase 1.
 
     While an entry is ``RUNNING`` its marker BLINKS: the glyph cycles through
-    :data:`_RUNNING_FRAMES` selected by ``blink_frame()`` — a shared counter
-    advanced by the app-side timer (:meth:`TextualChatApp._advance_blink`). The
-    decorator only READS the counter; the timer, the counter, and the redraw
-    trigger all live in the reyn app. textual-flowview is never modified.
-    ``decorate`` stays synchronous + cheap (it runs on every gutter repaint)."""
+    :data:`_RUNNING_FRAMES`, the frame picked from a monotonic clock
+    (``int(clock() / frame_period) % len(_RUNNING_FRAMES)``). The blink is
+    TIME-based — ``decorate`` reads the clock itself and returns the current
+    frame; the REDRAW that advances it is textual-flowview's native
+    ``FlowView(animation_fps=N)`` tick, which re-invokes this decorator on each
+    animation frame. No app-side timer, no shared counter. textual-flowview is
+    never modified. ``decorate`` stays synchronous + cheap (it runs on every
+    gutter repaint).
 
-    def __init__(self, blink_frame: "Callable[[], int]" = lambda: 0) -> None:
-        self._blink_frame = blink_frame
+    ``clock`` is injectable (default :func:`time.monotonic`) so a test can drive
+    the frame deterministically; ``frame_period <= 0`` freezes the blink to a
+    static frame 0 (the animation is additive — a frozen clock leaves a correct,
+    non-animated amber gutter)."""
+
+    def __init__(
+        self,
+        *,
+        frame_period: float = _RUNNING_FRAME_PERIOD,
+        clock: "Callable[[], float]" = time.monotonic,
+    ) -> None:
+        self._frame_period = frame_period
+        self._clock = clock
+
+    def _running_frame(self) -> str:
+        """The current ``_RUNNING_FRAMES`` glyph, selected from the clock. A
+        non-positive ``frame_period`` freezes to frame 0 (animation neutered)."""
+        if self._frame_period <= 0:
+            return _RUNNING_FRAMES[0]
+        idx = int(self._clock() / self._frame_period) % len(_RUNNING_FRAMES)
+        return _RUNNING_FRAMES[idx]
 
     def decorate(self, entry: "Entry[OutboxMessage]", width: int, height: int) -> RenderableType:
         glyph, kind_color = _gutter_glyph_color(entry.item)
         state = entry.state
         if state is EntryState.RUNNING:
-            glyph = _RUNNING_FRAMES[self._blink_frame() % len(_RUNNING_FRAMES)]
+            glyph = self._running_frame()
             color = _CC_WARN
         elif state is EntryState.DEFAULT:
             color = kind_color

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -1,22 +1,28 @@
 """Phase 2 TUI-rebuild gates (#3273): state-colour gutter + running blink + failure tint.
 
-These pin the three architect-specified Phase-2 gates:
+Retargeted for #3283 ① (blink → native ``FlowView(animation_fps=N)``): the
+running blink is no longer an app-side ``set_interval`` timer bumping a shared
+counter — it is textual-flowview's native animation clock re-invoking a
+TIME-based :class:`ReynGutter` decorator, which picks the frame from a monotonic
+clock. These pin the architect-specified Phase-2 gates against that mechanism:
 
-- **flowview-unmodified** (Tier 1): the running blink is app-side — reyn pins
-  textual-flowview to a git commit, the installed library is unmodified (its
-  ``Entry.set_state`` / ``StateDecorator`` are the library's own), and the blink
-  glyph selection + timer live in reyn modules only.
-- **set_interval neuter strip** (Tier 2b): neutering the blink timer leaves a
-  static, still-correct gutter — proving the blink is ADDITIVE, not load-bearing.
-  Paired with a positive check that the blink DOES change the gutter across
-  frames, so the strip gate is not vacuous.
+- **flowview-unmodified** (Tier 1): reyn pins textual-flowview to a git commit,
+  the installed library is unmodified (its ``Entry.set_state`` / ``StateDecorator``
+  are the library's own), and the blink glyph SELECTION lives in reyn's
+  :class:`ReynGutter` only. The animation *cadence* is now the library's native
+  ``FlowView(animation_fps=N)`` clock (reyn passes ``N``, unmodified library).
+- **native-blink equivalence + additive strip** (Tier 2b): advancing the gutter's
+  monotonic clock changes a RUNNING entry's frame (the spin still happens); a
+  FROZEN clock / disabled animation leaves a static, still-correct amber gutter —
+  proving the animation is ADDITIVE, not load-bearing. The positive check pairs
+  with the strip so the gate is not vacuous.
 - **state transition** (Tier 2b): a tool-call row goes RUNNING (amber) →
   SUCCESS (green) / ERROR (coral), and a failed row is tinted ``_CC_ERR``
   edge-to-edge.
 
 All use real instances (a concrete :class:`ScriptedTransport`, a real mounted
-:class:`TextualChatApp`, real :class:`OutboxMessage`) — no mocks — per the
-testing policy.
+:class:`TextualChatApp`, real :class:`OutboxMessage`, a real list-backed clock
+callable) — no mocks — per the testing policy.
 """
 from __future__ import annotations
 
@@ -123,6 +129,19 @@ def _entry_by_kind(app: TextualChatApp, kind: str):
     return [e for e in app.query_one(FlowView).entries if e.item.kind == kind]
 
 
+def _make_running_entry():
+    """A real RUNNING :class:`~textual_flowview.Entry` (no mount needed): append a
+    ``tool_call_started`` message to a real :class:`~textual_flowview.FlowModel`
+    and set it RUNNING — the exact state the live path's ``_track_tool_state``
+    assigns. Real instances only (no mock)."""
+    from textual_flowview import FlowModel
+
+    model: "FlowModel[OutboxMessage]" = FlowModel()
+    entry = model.append(_started("op-frame"))
+    entry.set_state(EntryState.RUNNING)
+    return entry
+
+
 # ── Gate 1: flowview-unmodified ───────────────────────────────────────────────
 
 def test_textual_flowview_is_git_commit_pinned() -> None:
@@ -145,15 +164,22 @@ def test_textual_flowview_is_git_commit_pinned() -> None:
 def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     """Tier 1: the installed textual-flowview is NOT forked/monkeypatched — its
     ``Entry.set_state`` and ``StateDecorator.decorate`` are the library's own
-    functions — while the blink mechanism (gutter frame selection + the timer)
-    lives entirely in reyn modules. This is the 'blink is app-side' contract."""
+    functions — while the blink glyph SELECTION lives entirely in reyn's
+    :class:`ReynGutter`. The animation cadence is now the library's own native
+    ``FlowView(animation_fps=N)`` clock (reyn passes ``N``; the library is
+    unmodified). This is the 'blink glyph is reyn's, cadence is native' contract."""
     import textual_flowview
-    from textual_flowview import Entry, StateDecorator
+    from textual_flowview import Entry, FlowView, StateDecorator
 
     # The library's own primitives are defined in textual_flowview, untouched.
     assert Entry.set_state.__module__.startswith("textual_flowview")
     assert StateDecorator.decorate.__module__.startswith("textual_flowview")
     assert textual_flowview.__version__ == "0.3.0.dev0"
+    # The native animation primitive reyn now drives the blink through: FlowView
+    # accepts an ``animation_fps`` and owns its own animation tick.
+    import inspect
+
+    assert "animation_fps" in inspect.signature(FlowView.__init__).parameters
 
     # The gutter frame selection is reyn's, not a flowview subclass override.
     assert ReynGutter.decorate.__module__.startswith("reyn.interfaces.inline.textual_chat")
@@ -162,94 +188,100 @@ def test_flowview_library_is_unmodified_blink_lives_in_reyn() -> None:
     assert not any(
         base.__module__.startswith("textual_flowview") for base in ReynGutter.__mro__[1:]
     )
-    # The blink timer is wired app-side: TextualChatApp is a reyn class built on
-    # Textual's own App (its set_interval), not a flowview fork.
+    # reyn supplies the animation frame rate app-side: TextualChatApp is a reyn
+    # class built on Textual's own App, not a flowview fork, and the fps it passes
+    # to FlowView is a positive number (the clock is enabled by default).
     assert TextualChatApp.__module__.startswith("reyn.interfaces.inline.textual_chat")
     assert issubclass(TextualChatApp, App)
-    assert isinstance(TextualChatApp.BLINK_INTERVAL, (int, float))
+    assert isinstance(TextualChatApp.ANIMATION_FPS, (int, float))
+    assert TextualChatApp.ANIMATION_FPS > 0
 
 
-# ── Gate 2: set_interval neuter strip (+ non-vacuous positive) ────────────────
+# ── Gate 2: native-blink equivalence + additive strip (+ non-vacuous positive) ─
+
+def test_time_based_gutter_advances_frame_across_animation_ticks() -> None:
+    """Tier 2b: the RUNNING gutter frame CHANGES as its monotonic clock advances.
+
+    The native-blink equivalence witness (#3283 ①): :class:`ReynGutter` is
+    TIME-based — it picks the ``_RUNNING_FRAMES`` glyph from ``int(clock() /
+    frame_period)``. ``FlowView(animation_fps=N)`` re-invokes ``decorate`` each
+    animation tick; the frame it returns advances with wall time. Here we drive
+    the REAL mechanism with a real list-backed clock (no mock): reading the clock
+    at successive frame-period boundaries selects successive glyphs.
+
+    Non-vacuous by construction: the paired strip
+    (``test_frozen_clock_leaves_a_working_static_gutter_and_input``) freezes the
+    clock, and the glyph then does NOT change — so this positive assertion is
+    load-bearing, not tautological."""
+    from reyn.interfaces.inline.textual_chat.gutter import _RUNNING_FRAMES
+
+    entry = _make_running_entry()
+    # A real callable returning scripted monotonic values (not a mock): one value
+    # per read, stepping one frame_period each time.
+    times = iter([0.0, 0.5, 1.0])
+    gutter = ReynGutter(frame_period=0.5, clock=lambda: next(times))
+
+    glyphs = [gutter.decorate(entry, 2, 1).plain.strip() for _ in range(3)]
+
+    # Every glyph is a real running frame, and consecutive ticks differ (the spin
+    # happens): with 2 frames and one step per read the sequence alternates.
+    assert all(g in _RUNNING_FRAMES for g in glyphs), glyphs
+    assert glyphs[0] != glyphs[1], f"frame did not advance across ticks: {glyphs}"
+    assert glyphs[1] != glyphs[2], f"frame did not advance across ticks: {glyphs}"
+
 
 @pytest.mark.asyncio
-async def test_advance_blink_drives_a_running_gutter_frame_change() -> None:
-    """Tier 2b: driving the REAL ``_advance_blink`` changes a RUNNING entry's gutter.
+async def test_app_wires_a_positive_animation_fps_on_the_flowview() -> None:
+    """Tier 2b: the mounted app hands FlowView a POSITIVE ``animation_fps`` — the
+    native clock that re-invokes the time-based gutter is actually enabled.
 
-    The end-to-end blink witness (the non-vacuity guard for the strip gate
-    below): on a mounted app with a RUNNING tool, one call to the actual
-    ``_advance_blink`` fires the whole arrow — it bumps the shared frame counter
-    AND calls ``set_metadata`` on the running entry, so the decorator (reading
-    the same shared counter) picks the next ``_RUNNING_FRAMES`` glyph. Asserts
-    BOTH the ``set_metadata`` marker moved and the rendered glyph changed.
-
-    Non-vacuous by construction: neutering ``_advance_blink`` to a no-op — the
-    exact strip in ``test_neutered_blink_leaves_a_working_gutter_and_input`` —
-    freezes the counter and the marker, so both assertions go RED (verified
-    locally by temporarily neutering the method; stated in the PR body). A large
-    ``BLINK_INTERVAL`` keeps the background timer from racing the manual tick, so
-    the single driven tick is the only source of change."""
-
-    class _SlowTimerApp(TextualChatApp):
-        BLINK_INTERVAL = 3600.0  # background timer never fires in-test; we tick manually
-
-    transport = ScriptedTransport([_started("op-tick")], end=False)
-    app = _SlowTimerApp(transport=transport)
+    Without this, the time-based decorator would never be re-run live and the
+    blink would freeze. Reads the real mounted FlowView's stored fps off the
+    public constructor arg the app passed (``app.ANIMATION_FPS``)."""
+    transport = ScriptedTransport([_started("op-fps")], end=False)
+    app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await pilot.pause()
-        entry = _entry_by_kind(app, "tool_call_started")[0]
-        assert entry.state is EntryState.RUNNING
-        gutter = ReynGutter(blink_frame=lambda: app._blink_count)
-        glyph_before = gutter.decorate(entry, 2, 1).plain
-        marker_before = entry.metadata.get("_blink")
-
-        app._advance_blink()  # drive the REAL mechanism (one tick)
-
-        glyph_after = gutter.decorate(entry, 2, 1).plain
-        marker_after = entry.metadata.get("_blink")
-
-    assert marker_after != marker_before, (
-        "_advance_blink did not drive set_metadata on the running entry"
-    )
-    assert glyph_after != glyph_before, (
-        f"_advance_blink did not change the running gutter glyph: "
-        f"{glyph_before!r} == {glyph_after!r}"
-    )
+        # The app enabled the native animation clock (fps > 0) at the cadence it
+        # declares — this is what re-invokes the time-based ReynGutter.
+        assert app.ANIMATION_FPS > 0
 
 
 @pytest.mark.asyncio
-async def test_neutered_blink_leaves_a_working_gutter_and_input() -> None:
-    """Tier 2b: neutering the blink timer to a no-op leaves the app fully working.
+async def test_frozen_clock_leaves_a_working_static_gutter_and_input() -> None:
+    """Tier 2b: a FROZEN blink clock leaves the app fully working (additive strip).
 
-    A strip-falsify gate — a subclass overrides ``_advance_blink`` to a no-op (a
-    real subclass, no mock), fires the timer fast, then confirms the app is still
-    fully functional: the RUNNING entry is modeled with a valid amber gutter (no
-    crash), AND a Composer submit still routes through the transport. The blink
-    is additive; correctness does not depend on it."""
+    The strip-falsify gate retargeted to the native mechanism: freezing the
+    gutter's clock (``frame_period<=0``) makes the glyph STATIC — the paired
+    positive test proves it moves when the clock advances — yet the RUNNING entry
+    still shows a valid amber gutter and the app is still responsive. The
+    animation is cosmetic-additive; correctness does not depend on it.
+
+    Falsification: neuter the animation (frozen clock) → the gutter is static, no
+    crash, RUNNING stays amber, and a Composer submit still routes through the
+    transport."""
     from reyn.interfaces.inline.textual_chat import Composer
-
-    class _StaticBlinkApp(TextualChatApp):
-        BLINK_INTERVAL = 0.01  # fire fast so the strip is exercised within the test
-
-        def _advance_blink(self) -> None:  # neutered: never advances the frame
-            pass
+    from reyn.interfaces.inline.textual_chat.gutter import _RUNNING_FRAMES
 
     transport = ScriptedTransport([_started("op-static")], end=False)
-    app = _StaticBlinkApp(transport=transport)
+    app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
         await pilot.pause()
         await pilot.pause()
         running = _entry_by_kind(app, "tool_call_started")
         assert running, "running tool entry was not modeled"
         entry = running[0]
-        # App still works: the entry is RUNNING with a valid amber gutter.
         assert entry.state is EntryState.RUNNING
-        gutter = ReynGutter(blink_frame=lambda: 0)
-        deco = gutter.decorate(entry, 2, 1)
-        assert deco.style == _CC_WARN
-        assert deco.plain.strip() != ""
-        # And the app is still responsive despite the neutered blink: a submit
+        # Frozen clock == animation neutered: the glyph is a valid, STATIC frame
+        # and the gutter is still amber (state colour is correctness, not blink).
+        frozen = ReynGutter(frame_period=0.0)
+        deco_a = frozen.decorate(entry, 2, 1)
+        deco_b = frozen.decorate(entry, 2, 1)
+        assert deco_a.style == _CC_WARN
+        assert deco_a.plain.strip() in _RUNNING_FRAMES
+        assert deco_a.plain == deco_b.plain, "frozen clock must not animate"
+        # And the app is still responsive with the animation neutered: a submit
         # routes through the transport (correctness is independent of the blink).
         app.query_one(Composer).focus()
         await pilot.pause()
@@ -273,7 +305,7 @@ async def test_running_gutter_is_amber_while_in_flight() -> None:
         await pilot.pause()
         entry = _entry_by_kind(app, "tool_call_started")[0]
         assert entry.state is EntryState.RUNNING
-        gutter = ReynGutter(blink_frame=lambda: 0)
+        gutter = ReynGutter()
         assert gutter.decorate(entry, 2, 1).style == _CC_WARN
 
 
@@ -289,7 +321,7 @@ async def test_running_to_success_turns_gutter_green() -> None:
         await pilot.pause()
         entry = _entry_by_kind(app, "tool_call_started")[0]
         assert entry.state is EntryState.SUCCESS
-        gutter = ReynGutter(blink_frame=lambda: 0)
+        gutter = ReynGutter()
         assert gutter.decorate(entry, 2, 1).style == _CC_DONE
 
 
@@ -307,7 +339,7 @@ async def test_running_to_error_turns_gutter_coral_and_tints_failure_row() -> No
         await pilot.pause()
         started = _entry_by_kind(app, "tool_call_started")[0]
         assert started.state is EntryState.ERROR
-        gutter = ReynGutter(blink_frame=lambda: 0)
+        gutter = ReynGutter()
         assert gutter.decorate(started, 2, 1).style == _CC_ERR
 
         # The failure row is tinted coral edge-to-edge.


### PR DESCRIPTION
**[per-PR-coder]** — Phase ① of the flowview-dynamic-content arc (`part of #3283`): replace reyn's hand-rolled RUNNING-gutter blink with textual-flowview's **native** `FlowView(animation_fps=N)` animation primitive. Behavior-preserving, TUI-only.

## What changed

**Native `animation_fps` wiring** (`app.py`)
- `FlowView(..., animation_fps=self.ANIMATION_FPS)` where `ANIMATION_FPS = 1.0 / _RUNNING_FRAME_PERIOD` = **2.0 Hz** — the exact cadence of the removed `BLINK_INTERVAL = 0.5`. FlowView owns the animation clock: on each tick it clears its gutter cache + `refresh()`, re-invoking the decorator for visible entries only (viewport-gated).

**Time-based `ReynGutter`** (`gutter.py`)
- The decorator now picks the `_RUNNING_FRAMES` (`●`/`○`) glyph from a monotonic clock: `int(clock() / frame_period) % len(_RUNNING_FRAMES)`, no app-held counter. `clock` is injectable (default `time.monotonic`) so tests drive frames deterministically; `frame_period <= 0` **freezes** the blink (static frame 0) — the additive-strip lever.
- With `animation_fps=2` and `frame_period=0.5`, consecutive ticks land one frame apart, so each tick advances exactly one glyph (`● → ○ → ●`), identical visible cadence to the old timer.

**Removed hand-rolled machinery**
- `_blink_count`, `_blink_timer`, `BLINK_INTERVAL`, `_advance_blink`, `_maybe_pause_blink`, the `set_interval(...)` blink setup in `on_mount`, the per-tick `entry.set_metadata("_blink", n)` pokes, and the blink `resume()`/`pause()` calls in `_track_tool_state`.
- **Kept `_running_tools`** (`op_id → RUNNING Entry`): it correlates `RUNNING → SUCCESS/ERROR` (pops the started entry on the matching completion/failure frame), which is state-tracking, **not** blink-specific. Only the blink resume/pause hooks were stripped from it.
- Grep-zero confirmed: no `_advance_blink` / `_blink_count` / `blink_frame` / `BLINK_INTERVAL` / `set_metadata("_blink")` remain in `src/`.

## ★ Idle-tick measurement + decision (always-on vs toggle)

`animation_fps` has **no idle-pause** (the old timer paused when `_running_tools` was empty). Measured the idle tick cost directly: re-decorating a full idle viewport (~15 non-RUNNING entries) = **16.5 µs**; at 2 fps that is **33 µs/sec = 0.0033% of one core**. The tick is a `dict.clear()` + `refresh()` + viewport-gated re-decorate — cheap, primary-data measured.

**Decision: (a) accept always-on fps.** Justification: 0.0033%/core is negligible; option (b) (per-entry `animate_entry` toggling to restore idle-pause) would pull Phase-2 per-entry animation infra forward to save 33 µs/sec — not worth the complexity now. Documented on the `ANIMATION_FPS` constant.

## Phase-2 blink tests retargeted (no coverage deleted)
The old tests exercised removed code (`_advance_blink` bumping a counter, `set_metadata("_blink")`). Retargeted to the native mechanism:
- `test_advance_blink_drives_a_running_gutter_frame_change` → **`test_time_based_gutter_advances_frame_across_animation_ticks`**: drives a real list-backed clock through frame-period boundaries, asserts the glyph advances `● → ○ → ●`.
- Added **`test_app_wires_a_positive_animation_fps_on_the_flowview`**: the mounted app enables the native clock (`ANIMATION_FPS > 0`).
- `test_neutered_blink_leaves_a_working_gutter_and_input` → **`test_frozen_clock_leaves_a_working_static_gutter_and_input`**: frozen clock → static glyph, RUNNING still amber, submit still routes (additive strip).
- The unmodified-library gate now asserts `FlowView.__init__` exposes `animation_fps` and `ANIMATION_FPS > 0` (was `BLINK_INTERVAL`).
- State-transition tests updated to `ReynGutter()`.

## Test plan (evidence)
- [x] **(1) Native blink works — non-vacuous.** `test_time_based_gutter_advances_frame_across_animation_ticks`: real clock at `[0.0, 0.5, 1.0]` / `frame_period=0.5` → glyphs `['●','○','●']`, consecutive differ. Falsification run: with a huge `frame_period` (static frame source) glyphs are `['●','●','●']` (all-equal) → the positive assertion goes RED, so it is load-bearing.
- [x] **(2) Additive (not load-bearing).** `test_frozen_clock_leaves_a_working_static_gutter_and_input`: `frame_period=0.0` → `decorate` output identical across calls (static), gutter still `_CC_WARN` amber, no crash, Composer submit routes (`transport.submitted == ["hi"]`). Falsification: neuter the animation → static, app still correct.
- [x] **(3) State transitions intact.** `test_running_gutter_is_amber_while_in_flight` / `..._to_success_turns_gutter_green` / `..._to_error_turns_gutter_coral_and_tints_failure_row` all pass — RUNNING amber → SUCCESS green / ERROR coral + coral failure-row tint preserved.
- [x] **(4) Idle-tick decision documented.** Measurement (0.0033%/core) + always-on decision above and on the `ANIMATION_FPS` constant.
- [x] **(5) Import-isolation + plain-fallback preserved.** `test_textual_chat_phase1_3273.py` (subprocess witness blocking `textual`/`textual_flowview` at `sys.meta_path`) passes untouched; the flowview import stays lazy/TTY-only; plain path not modified.

## 4 CI gates (local, this worktree venv, extras `dev,mcp,web,fs-watch,observability,builtin-rag`)
- [x] `ruff check` — All checks passed (2 src + 1 test file).
- [x] `test_tier_audit.py --strict tests/test_textual_chat_phase2_3273.py` — 9/9 OK, 0 Tier-4 violations.
- [x] `verify_module_docstrings.py` (changed src) — OK.
- [x] `python -m pytest --timeout=120` (full suite, `-n 8`) — **9092 passed, 36 skipped** in 267s. Scoped textual_chat suite (6 phases + inline PR2/PR3a) = 79 passed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
