### PR TITLE
feat(tui): pivot chat TUI to alt-screen + operator-selectable chat.render_mode (#3273)

### DIFF
--- a/docs/reference/config/reyn-yaml.md
+++ b/docs/reference/config/reyn-yaml.md
@@ -352,15 +352,33 @@ unaffected). Both defaults are `true`.
 
 Chat-session runtime knobs. `chat.compaction` controls chat-history compaction
 (ratio-based budget; see `reyn.local.yaml.example`). `chat.reasoning` controls
-model reasoning/"thinking" text handling.
+model reasoning/"thinking" text handling. `chat.render_mode` selects the
+interactive chat renderer/driver.
 
 ```yaml
 chat:
+  render_mode: alt-screen # interactive chat renderer: alt-screen (default) | inline | plain | auto
   reasoning:
     continuity: true      # persist reasoning to history + replay recent turns
     display: true         # show reasoning in the UI (TUI + web, collapsible)
     recent_turns: 3       # turns of reasoning to replay; <=0 = unbounded
 ```
+
+### `chat.render_mode`
+
+Selects which renderer/driver `reyn chat` uses on a **TTY**. A **non-TTY**
+session (piped, CI, or a host with no real terminal) always falls back to
+`plain` regardless of this value — the interactive Textual drivers need a real
+terminal.
+
+| Value | Behaviour |
+|-------|-----------|
+| `alt-screen` | **Default.** Full-screen Textual (alt-screen driver). Terminal scrollback is auto-saved on enter and restored on exit; the previous conversation is rebuilt from `history.jsonl` on restart. This is the recommended mode — it sidesteps the upstream inline-driver bugs (stale frames stacking on resize, pane collapse) that `inline` still carries. |
+| `inline` | Legacy bounded inline driver — keeps your pre-launch scrollback in place above a bounded region. **Caveat**: this mode still carries upstream Textual inline-driver bugs (on resize old frames stack, and the conversation pane can collapse to ~1 line). Kept as an escape hatch for users who prefer scrollback-in-place; not recommended until those land upstream. |
+| `plain` | Force the plain line-based renderer (no Textual), equivalent to `--cui`. |
+| `auto` | Resolve to `alt-screen` on a TTY (behaviourally identical to `alt-screen` given the non-TTY→`plain` guard). |
+
+An unrecognised value warns and falls back to `alt-screen`.
 
 ### `chat.reasoning` fields
 

--- a/reyn.local.yaml.example
+++ b/reyn.local.yaml.example
@@ -345,6 +345,18 @@
 #     recent_turns: 3         # how many recent turns' reasoning to replay.
 #                             #   <= 0 (e.g. 0 / -1) = unbounded (keep all).
 
+# chat.render_mode: interactive chat renderer/driver on a TTY (#3273). A non-TTY
+# session (piped / CI / no real terminal) always falls back to `plain`.
+# See docs/reference/config/reyn-yaml.md.
+#   render_mode: alt-screen   # alt-screen (default) | inline | plain | auto
+#                             #   alt-screen = full-screen (recommended; scrollback
+#                             #     auto-saved/restored on enter/exit).
+#                             #   inline = legacy bounded driver, keeps scrollback
+#                             #     in place BUT carries upstream resize/collapse
+#                             #     bugs (#3285/#3286) — escape hatch only.
+#                             #   plain = force plain renderer (= --cui).
+#                             #   auto = alt-screen on a TTY.
+
 
 # -----------------------------------------------------------------------------
 # events: audit-log rotation policy. Chat events land under

--- a/src/reyn/config/chat.py
+++ b/src/reyn/config/chat.py
@@ -478,11 +478,41 @@ class ReasoningConfig:
     recent_turns: int = 3
 
 
+# #3273 (#3285/#3286): the interactive chat renderer/driver selection. The
+# Textual conversation-pane app has two driver modes; ``plain`` forces the
+# ConsoleChatRenderer path even on a TTY.
+#
+# - ``alt-screen`` (DEFAULT): full-screen Textual (alt-screen driver). Sidesteps
+#   the two upstream inline-driver bugs — stale frames stacking on resize (#3285)
+#   and the pane collapsing to ~1 line (#3286) — and auto-saves/restores terminal
+#   scrollback on enter/exit.
+# - ``inline``: the legacy bounded inline driver, kept as an escape hatch for
+#   users who prefer their pre-launch scrollback preserved in place above the
+#   region. CAVEAT: this mode still carries the upstream Textual inline-driver
+#   bugs #3285/#3286 (resize stacking + pane collapse); it is not the recommended
+#   default and will improve only when those land upstream.
+# - ``plain``: force the plain ConsoleChatRenderer (no Textual), equivalent to
+#   ``--cui``.
+# - ``auto``: resolve to ``alt-screen`` on a real TTY (identical to ``alt-screen``
+#   given the TTY guard, which falls any interactive mode back to ``plain`` off a
+#   TTY); provided as the Codex-style ``auto/always/never`` affordance.
+CHAT_RENDER_MODES = ("alt-screen", "inline", "plain", "auto")
+
+
 @dataclass
 class ChatConfig:
-    """`chat:` — chat-session-specific runtime knobs."""
+    """`chat:` — chat-session-specific runtime knobs.
+
+    ``render_mode`` (#3273): selects the interactive chat renderer/driver —
+    ``alt-screen`` (default, full-screen), ``inline`` (legacy bounded driver,
+    carries upstream bugs #3285/#3286), ``plain`` (force ConsoleChatRenderer),
+    or ``auto`` (resolve to alt-screen on a TTY). A non-TTY session always falls
+    back to ``plain`` regardless of this value (the interactive Textual drivers
+    need a real terminal).
+    """
     compaction: CompactionConfig = field(default_factory=CompactionConfig)
     reasoning: ReasoningConfig = field(default_factory=ReasoningConfig)
+    render_mode: Literal["alt-screen", "inline", "plain", "auto"] = "alt-screen"
 
 
 @dataclass
@@ -533,15 +563,33 @@ def _build_reasoning_config(raw: object) -> ReasoningConfig:
     )
 
 
+def _build_render_mode(raw: object) -> str:
+    """#3273: parse ``chat.render_mode``. Unknown / non-str → default (warn)."""
+    default = ChatConfig().render_mode
+    if raw is None:
+        return default
+    mode = str(raw)
+    if mode not in CHAT_RENDER_MODES:
+        import logging
+        logging.getLogger(__name__).warning(
+            "chat.render_mode=%r is not one of %s; using %r",
+            mode, CHAT_RENDER_MODES, default,
+        )
+        return default
+    return mode
+
+
 def _build_chat_config(raw: object) -> ChatConfig:
     if not isinstance(raw, dict):
         return ChatConfig()
     # #1652: reasoning parses independently of compaction (a chat: block with
     # only `reasoning:` and no `compaction:` must still honour it).
     reasoning = _build_reasoning_config(raw.get("reasoning"))
+    # #3273: render_mode parses independently of compaction too.
+    render_mode = _build_render_mode(raw.get("render_mode"))
     compaction_raw = raw.get("compaction") or {}
     if not isinstance(compaction_raw, dict):
-        return ChatConfig(reasoning=reasoning)
+        return ChatConfig(reasoning=reasoning, render_mode=render_mode)  # type: ignore[arg-type]
     # #1128: head_size/tail_size (step 3) + trigger_total_tokens/min_compact_batch
     # (PR-a, axis-1 removal) were removed — head/tail sizing is token-budget via
     # component_weights and auto-compaction is window-relative (no turn-count
@@ -618,7 +666,9 @@ def _build_chat_config(raw: object) -> ChatConfig:
         ),
         section_token_caps=section,
     )
-    return ChatConfig(compaction=compaction, reasoning=reasoning)
+    return ChatConfig(
+        compaction=compaction, reasoning=reasoning, render_mode=render_mode,  # type: ignore[arg-type]
+    )
 
 
 def _build_phase_act_results_compaction_config(

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -660,13 +660,27 @@ async def run_textual_chat(
     read_model: "ChatReadModel | None" = None,
     agent_name: str = "default",
     config=None,
+    inline: bool = False,
 ) -> None:
     """Run the TTY conversation-pane app until the user quits or the stream ends.
 
-    Runs ``inline=True`` so the terminal's pre-launch scrollback is preserved
-    above the app region (the ADR's Phase-0-validated inline mode) rather than
-    swapping to the alternate screen. Returns so the driver's caller can tear the
-    transport down + print the cost summary.
+    ``inline`` selects the Textual driver: ``False`` (DEFAULT) runs full-screen
+    (alt-screen), ``True`` runs the legacy bounded inline driver. The caller
+    (:func:`~reyn.interfaces.repl.client_driver.run_chat_client`) resolves this
+    from ``chat.render_mode`` (#3273) — see :func:`resolve_render_mode`.
+
+    Full-screen is the default because two inline-driver bugs made bounded inline
+    unshippable: on resize the old bounded frame is not cleared so stale copies
+    stack (#3285), and the conversation pane collapses to ~1 line regardless of
+    terminal height (#3286). Both are owned by Textual's inline driver, so reyn
+    cannot fix them in inline mode; alt-screen sidesteps the driver entirely and
+    both vanish. The scrollback-preservation rationale that originally motivated
+    inline is now redundant — alt-screen auto-saves/restores terminal scrollback
+    on enter/exit, and Phase 5 restore rebuilds the conversation from
+    ``history.jsonl`` on restart. ``inline=True`` remains selectable as an escape
+    hatch (``chat.render_mode: inline``) for scrollback-preferring users, with
+    the #3285/#3286 caveat. Returns so the driver's caller can tear the transport
+    down + print the cost summary.
     """
     app = TextualChatApp(
         transport=transport,
@@ -674,4 +688,4 @@ async def run_textual_chat(
         agent_name=agent_name,
         config=config,
     )
-    await app.run_async(inline=True)
+    await app.run_async(inline=inline)

--- a/src/reyn/interfaces/repl/client_driver.py
+++ b/src/reyn/interfaces/repl/client_driver.py
@@ -45,6 +45,44 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def resolve_render_mode(mode: str, *, is_tty: bool) -> str:
+    """Resolve a configured ``chat.render_mode`` + TTY presence to a concrete path.
+
+    Returns one of ``"alt-screen"``, ``"inline"``, ``"plain"`` — the three
+    physical render paths (the first two are the Textual conversation-pane app's
+    driver modes; the last is the plain :class:`ChatRenderer`).
+
+    The TTY guard is universal: a non-TTY session (piped, CI, sandbox with no
+    real terminal, or a host where alt-screen would silently no-op) can never
+    enter an interactive Textual driver, so it always resolves to ``"plain"``
+    regardless of the configured mode. On a TTY: ``"plain"`` forces the plain
+    path (config equivalent of ``--cui``); ``"inline"`` selects the legacy
+    bounded inline driver (retains upstream bugs #3285/#3286); ``"auto"`` and
+    ``"alt-screen"`` both resolve to ``"alt-screen"`` (full-screen). An
+    unrecognised mode is treated as the ``alt-screen`` default — config parsing
+    already validates+warns, this is a belt-and-braces fallback.
+    """
+    if not is_tty:
+        return "plain"
+    if mode == "plain":
+        return "plain"
+    if mode == "inline":
+        return "inline"
+    # "alt-screen", "auto", or any unexpected value → full-screen alt-screen.
+    return "alt-screen"
+
+
+def _configured_render_mode(config) -> str:
+    """Read ``config.chat.render_mode``; default ``alt-screen`` if unavailable."""
+    default = "alt-screen"
+    if config is None:
+        return default
+    try:
+        return str(config.chat.render_mode)
+    except AttributeError:
+        return default
+
+
 async def run_chat_client(
     *,
     transport: "ClientTransport",
@@ -56,28 +94,35 @@ async def run_chat_client(
 ) -> None:
     """Input-driver selection + (plain) banner/output loop + wait + teardown.
 
-    ``renderer.uses_app_input()`` AND ``is_tty`` routes to the Textual
-    conversation-pane app (:func:`~reyn.interfaces.inline.textual_chat.run_textual_chat`),
-    which owns both input and output and drains ``transport.frames()`` itself —
-    imported LAZILY here so the flowview/textual dependency is touched on the TTY
-    path only. Otherwise (``--cui`` / non-TTY / piped) the plain PromptSession
-    input loop + shared output loop drive the handed-in ``renderer``. This is the
-    SAME selection ``run_repl`` made locally — now applied identically to the
-    remote path.
+    When the renderer ``uses_app_input()``, ``chat.render_mode`` (#3273) +
+    ``is_tty`` are resolved by :func:`resolve_render_mode` to one of three paths:
+    ``alt-screen`` / ``inline`` (both the Textual conversation-pane app
+    :func:`~reyn.interfaces.inline.textual_chat.run_textual_chat`, which owns
+    both input and output and drains ``transport.frames()`` itself — imported
+    LAZILY here so the flowview/textual dependency is touched on that path only)
+    or ``plain`` (the plain PromptSession input loop + shared output loop below).
+    A non-TTY session (``--cui`` / piped / CI / no real terminal) always resolves
+    to ``plain`` regardless of mode. This is the SAME selection ``run_repl`` made
+    locally — now applied identically to the remote path.
 
     The caller owns transport lifecycle (``start``/``close`` or the httpx SSE
     context) and any cost summary; this function only drives the loop(s) and
     guarantees any tasks it spawns are cancelled + awaited on exit.
     """
-    if renderer.uses_app_input() and is_tty:
-        from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
-        await run_textual_chat(
-            transport=transport,
-            read_model=read_model,
-            agent_name=agent_name,
-            config=config,
+    if renderer.uses_app_input():
+        resolved = resolve_render_mode(
+            _configured_render_mode(config), is_tty=is_tty,
         )
-        return
+        if resolved != "plain":
+            from reyn.interfaces.inline.textual_chat import run_textual_chat  # noqa: PLC0415
+            await run_textual_chat(
+                transport=transport,
+                read_model=read_model,
+                agent_name=agent_name,
+                config=config,
+                inline=(resolved == "inline"),
+            )
+            return
 
     renderer.banner(agent_name)
 
@@ -113,4 +158,4 @@ async def run_chat_client(
         await asyncio.gather(inputs, outputs, return_exceptions=True)
 
 
-__all__ = ["run_chat_client"]
+__all__ = ["resolve_render_mode", "run_chat_client"]

--- a/tests/test_chat_render_mode_3273.py
+++ b/tests/test_chat_render_mode_3273.py
@@ -1,0 +1,74 @@
+"""Tier 2: chat.render_mode config knob + TTY-guarded render-path resolution (#3273).
+
+The #3273 TUI pivot makes the interactive chat renderer/driver operator-selectable
+instead of hardcoding one render mode (charter "no uncustomizable hardcoded
+choices"). Two OS invariants are pinned here:
+
+- **config parse**: ``chat.render_mode`` accepts the four declared values
+  (``alt-screen`` default / ``inline`` / ``plain`` / ``auto``); an unknown value
+  falls back to the ``alt-screen`` default rather than aborting or silently
+  selecting a bogus path.
+- **resolution + TTY guard**: :func:`resolve_render_mode` maps
+  ``(mode, is_tty)`` to one of the three physical paths. A non-TTY session ALWAYS
+  resolves to ``plain`` regardless of mode (the interactive Textual drivers need a
+  real terminal — this is the guard that keeps CI / piped / sandbox paths off the
+  alt-screen driver). On a TTY each mode routes to its own path.
+
+Both are pure functions over real config dataclasses — no mocks.
+"""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from reyn.config.chat import CHAT_RENDER_MODES, ChatConfig, _build_chat_config
+from reyn.interfaces.repl.client_driver import resolve_render_mode
+
+
+def test_render_mode_default_is_alt_screen() -> None:
+    """Tier 2: the default render mode is alt-screen — the fixed-out-of-the-box
+    mode where the #3285/#3286 inline-driver bugs do not occur."""
+    assert ChatConfig().render_mode == "alt-screen"
+    # Missing/empty chat block → default.
+    assert _build_chat_config(None).render_mode == "alt-screen"
+    assert _build_chat_config({}).render_mode == "alt-screen"
+
+
+@pytest.mark.parametrize("mode", CHAT_RENDER_MODES)
+def test_render_mode_each_declared_value_parses(mode: str) -> None:
+    """Tier 2: each of the four declared values round-trips through the parser."""
+    assert _build_chat_config({"render_mode": mode}).render_mode == mode
+    # And still parses when a sibling compaction block is present (the two parse
+    # independently).
+    cfg = _build_chat_config({"render_mode": mode, "compaction": {"body_token_cap": 99}})
+    assert cfg.render_mode == mode
+    assert cfg.compaction.body_token_cap == 99
+
+
+def test_render_mode_unknown_value_falls_back_to_default() -> None:
+    """Tier 2: an operator typo / unknown value does not select a bogus path or
+    abort startup — it warns and falls back to the alt-screen default."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert _build_chat_config({"render_mode": "fullscreen"}).render_mode == "alt-screen"
+        assert _build_chat_config({"render_mode": 123}).render_mode == "alt-screen"
+
+
+@pytest.mark.parametrize("mode", ["alt-screen", "inline", "plain", "auto", "bogus"])
+def test_non_tty_always_resolves_plain(mode: str) -> None:
+    """Tier 2: the universal TTY guard — no configured mode can enter an
+    interactive Textual driver without a real terminal; every mode → plain."""
+    assert resolve_render_mode(mode, is_tty=False) == "plain"
+
+
+def test_tty_resolution_routes_each_mode() -> None:
+    """Tier 2: on a TTY, each mode routes to its own physical path — alt-screen
+    and auto to full-screen alt-screen, inline to the legacy bounded driver, plain
+    to the plain renderer. An unexpected value defaults to alt-screen."""
+    assert resolve_render_mode("alt-screen", is_tty=True) == "alt-screen"
+    assert resolve_render_mode("auto", is_tty=True) == "alt-screen"
+    assert resolve_render_mode("inline", is_tty=True) == "inline"
+    assert resolve_render_mode("plain", is_tty=True) == "plain"
+    # Belt-and-braces: an unvalidated/unexpected mode on a TTY → alt-screen default.
+    assert resolve_render_mode("something-else", is_tty=True) == "alt-screen"


### PR DESCRIPTION
**[per-PR-coder]** — part of #3273 (references #3285, #3286 — NOT closing; they close when the real-TTY witness confirms).

## What

Pivots the `reyn chat` Textual TUI from **inline mode to full-screen (alt-screen)**, and — per co-vet — makes render mode an operator-selectable config knob instead of swapping one hardcoded mode for another.

Both live-e2e bugs are isolated to Textual's **inline-mode driver** (reproduce in a minimal inline Textual app without flowview/reyn):
- **#3285**: on terminal resize the old bounded inline frame isn't cleared — stale copies stack cumulatively.
- **#3286**: the conversation pane collapses to ~1 line regardless of terminal height.

The region-clear/sizing is driver-owned, so reyn cannot fix it in inline mode. Alt-screen sidesteps the inline driver entirely and both bugs vanish. The original inline rationale (scrollback preserved on exit) is now redundant: alt-screen auto-saves/restores terminal scrollback on enter/exit, and Phase 5 restore rebuilds the conversation from `history.jsonl` on restart.

## Changes

1. **Launch flip** — `src/reyn/interfaces/inline/textual_chat/app.py::run_textual_chat` now takes `inline: bool = False` and calls `app.run_async(inline=inline)` (was hardcoded `inline=True`). Default `False` = full-screen alt-screen. Confirmed this was the ONLY `inline=True` launch entry point.
2. **`chat.render_mode` config knob** (`src/reyn/config/chat.py`) — follows the existing `safety.on_limit.mode` shape (Literal field + `CHAT_RENDER_MODES` tuple + validate-or-warn-and-default parser, wired through `loader.py:_build_chat_config`). Values:
   - **`alt-screen` (DEFAULT)** — full-screen; the bugs are fixed out of the box.
   - `inline` — legacy bounded driver, kept as an escape hatch for scrollback-preferring users. **Documented caveat**: still carries the upstream #3285/#3286 inline-driver bugs.
   - `plain` — force `ConsoleChatRenderer` (= `--cui`).
   - `auto` — resolve to alt-screen on a TTY (Codex-style `auto/always/never` affordance).
3. **TTY-guard** — `resolve_render_mode(mode, is_tty)` in `client_driver.py` (pure, exported). A **non-TTY session always resolves to `plain`** regardless of mode (piped / CI / sandbox with no real terminal). `run_chat_client` routes on the resolved path; `run_textual_chat` gets `inline=(resolved == "inline")`.
4. **CSS** — **none needed**. App CSS is already height-relative (`Screen { layout: vertical }`, `FlowView { height: 1fr }`, chrome fixed/`max-height`). No bounded `Screen { height: N }` existed (that was PoC-only).
5. **Docs** — `docs/reference/config/reyn-yaml.md` `chat` block + `reyn.local.yaml.example` document the new knob and the inline caveat.

Rebased cleanly onto `origin/main` after #3289 (native-blink `FlowView(animation_fps=...)`) merged — both #3289's animation clock and this pivot are present; app.py regions were adjacent, no overlap.

## Inline-specific tests: retargeted/removed

**None to retarget or delete.** I grepped tests for inline-driver semantics (`inline=True`, `run_async(inline`, scrollback-marker-above-region, bounded-region-under-cursor, scrollback-preserved-on-exit, `Phase-0` witness) — there is **no** test asserting inline-driver-specific behavior. The Phase-1 conversation-reflow / presenter / gutter / restore / intervention / plain-fallback tests are all **driver-agnostic** (they use `run_test`, a headless driver, not the inline driver) and stay green unchanged. `test_inline_closed_set_intervention_no_scrollback_dup.py` is about the **plain-path renderer's** scrollback print, not the Textual inline driver — untouched, still green. (The package name `interfaces/inline/` means "inline-interactive REPL", not the Textual inline driver — not renamed.)

## Test plan (headless gates — DONE)

1. **Full-suite green in alt-screen** — `uv run python -m pytest --timeout=120` (CI extras `dev,mcp,web,fs-watch,observability,builtin-rag`): **9103 passed, 36 skipped**. Driver-agnostic textual_chat tests (phase1-5 + 3.5): **47 passed**. (One transient `test_config_mirror_coverage_1056` failure during the run was a race with an in-progress edit to `reyn.local.yaml.example`; green against the committed state.)
2. **Inline-specific tests retargeted/removed** — none exist (see above).
3. **Import-isolation + plain-fallback preserved** — Phase-1 subprocess witness (`textual`/`textual_flowview` blocked at `sys.meta_path`, non-TTY `run_chat_client` → `plain`, no flowview import) passes. Non-TTY always resolves to `plain` (new `resolve_render_mode` guard).
4. **New knob honored (headless)** — `tests/test_chat_render_mode_3273.py` (Tier 2): each `render_mode` value parses; unknown → warn+default; `resolve_render_mode` routing table (non-TTY→plain for every mode; TTY routes alt-screen/auto→alt-screen, inline→inline, plain→plain). **13 passed.**
5. Other gates green: `ruff check src tests` (clean), `test_tier_audit.py --strict` (5/5 OK), `verify_module_docstrings.py` (clean).

## Required pre-merge check — PENDING tui-coder (real TTY / tmux)

The actual fix — that **#3285 resize-stacking and #3286 1-line-collapse are GONE** and resize reflows cleanly in place — is **only observable on a real TTY**. Headless `run_test` uses a different driver and never exercised the inline bug (that is exactly why Phase-1's headless resize gate was green while the real TTY was broken). This PR delivers the code + config knob + test retarget + headless gates; the real-TTY witness is a **separate manual gate for tui-coder on tmux**:

- [ ] **PENDING tui-coder (tmux)** — smoke EACH `render_mode`: `alt-screen` fixes #3285 (no stale-frame stacking on resize) + #3286 (pane fills terminal height, reflows on resize); `inline` still selectable (bugs expected); `plain` works.

Do NOT merge until this box is checked (#3285/#3286 do not close until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
