### PR TITLE
fix(tui): never black-hole free text during a pending choice-intervention (#3290)

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -73,6 +73,52 @@ _SKIP_KINDS = frozenset(
     }
 )
 
+# Re-affirmation shown when a free-text submit lands during a pending
+# choice-intervention but matches no option — the anti-black-hole hint (#3290).
+# The options are still rendered above as chips, so the hint re-affirms them
+# without echoing the (LLM-derived) labels back into the terminal.
+_CHOICE_HINT_TEXT = "Please choose one of the options above (or click a chip)."
+
+
+def _match_choice_input(text: str, choices: "object") -> "str | None":
+    """Return the id of the ONE choice whose label or hotkey equals ``text``.
+
+    Type-or-click parity for a pending choice-intervention (#3290): a free-text
+    submit that names an option (typing ``yes`` for the ``Yes`` chip) resolves
+    the same intervention a chip click would. Matching is trimmed and
+    case-insensitive against BOTH the choice ``label`` and its ``hotkey``; the
+    ``choice_id`` is the authoritative delivery key (never itself matched, so a
+    label-as-id confusion can't sneak in).
+
+    Returns ``None`` when nothing matches OR the match is ambiguous (two distinct
+    choices match) — the caller then keeps the intervention pending and hints,
+    never falling through to a new turn (the black-hole the seam guards against).
+
+    Distinct from :func:`reyn.user_intervention.match_choice` (hotkey-only,
+    case-sensitive — the stdin-bus contract): this is the TUI's forgiving
+    type-or-click affordance, so it is a separate seam, not that one reused.
+    ``choices`` are ``InterventionChoice``-shaped (``.id`` / ``.label`` /
+    ``.hotkey``); attributes are read defensively so a partial head cannot raise.
+    """
+    needle = text.strip().casefold()
+    if not needle:
+        return None
+    matched_ids: set[str] = set()
+    for choice in choices or ():
+        cid = getattr(choice, "id", None)
+        if cid is None:
+            continue
+        candidates = {
+            str(value).strip().casefold()
+            for value in (getattr(choice, "label", None), getattr(choice, "hotkey", None))
+            if value is not None and str(value).strip()
+        }
+        if needle in candidates:
+            matched_ids.add(str(cid))
+    if len(matched_ids) == 1:
+        return next(iter(matched_ids))
+    return None
+
 #: FlowView gutter column width (state-coloured marker). Shared by ``compose``
 #: (the ``FlowView(gutter_width=…)`` config) and the choice-chip click handler,
 #: which must reconstruct the presenter's body width (content − gutter) to know
@@ -619,24 +665,38 @@ class TextualChatApp(App):
     async def _submit(self, text: str) -> None:
         """Route one submitted line through the transport send seam.
 
-        A pending free-text intervention (no choices) takes the answer path;
-        everything else is an ordinary new turn. Errors are contained and
-        surfaced as an error frame the pump renders — a silent input drop is the
-        worst failure for a chat box.
+        A pending free-text intervention (no choices) takes the text answer path;
+        a pending CHOICE intervention takes the type-or-click parity path (match
+        the text to an option → answer that choice; no match → re-affirm the
+        options and keep the intervention pending — NEVER fall through to a new
+        turn, which the backend would black-hole while it waits for the choice
+        answer, #3290); everything else is an ordinary new turn. Errors are
+        contained and surfaced as an error frame the pump renders — a silent
+        input drop is the worst failure for a chat box.
         """
         try:
             head = self._transport.pending_intervention_head()
             # A ``/``-prefixed line is never an intervention answer — it is a slash
             # command (dispatched by the session turn loop), so it must take the
-            # normal submit path even while a free-text intervention is pending
-            # (mirrors ``stream_client.submit_or_answer``'s guard). Without this,
-            # a picker-issued ``/model`` / ``/attach`` (or a typed slash) during a
+            # normal submit path even while an intervention is pending (mirrors
+            # ``stream_client.submit_or_answer``'s guard). Without this, a
+            # picker-issued ``/model`` / ``/attach`` (or a typed slash) during a
             # pending intervention would be mis-delivered as the answer text.
-            if (
-                head is not None
-                and not getattr(head, "choices", None)
-                and not text.startswith("/")
-            ):
+            if head is not None and not text.startswith("/"):
+                choices = getattr(head, "choices", None)
+                if choices:
+                    # Closed-set (choice) intervention pending: type-or-click
+                    # parity. On an unambiguous match answer that choice; on no
+                    # match re-affirm the options and keep it pending — routing a
+                    # non-match to ``submit_user_text`` here is the #3290 black
+                    # hole (backend blocked on the choice, 0 events, UI lies).
+                    matched_id = _match_choice_input(text, choices)
+                    if matched_id is not None:
+                        await self._transport.answer_intervention_choice(matched_id)
+                    else:
+                        self._surface_choice_hint()
+                    return
+                # Free-text intervention (no choices) → deliver as the answer text.
                 await self._transport.answer_intervention_text(text)
                 return
             await self._transport.submit_user_text(text)
@@ -652,6 +712,25 @@ class TextualChatApp(App):
                 )
             except Exception:
                 pass
+
+    def _surface_choice_hint(self) -> None:
+        """Re-affirm the pending choice options after an unmatched free-text
+        submit — the #3290 anti-black-hole hint.
+
+        Injected as a ``kind="system"`` display frame (a dim lifecycle marker,
+        NOT an error) through the same ``put_display`` seam the pump drains, so it
+        lands in FIFO order below the still-rendered option chips. The
+        intervention is left pending — the user can click a chip or retype a
+        matching option — so free text is never black-holed into a blocked
+        backend."""
+        from reyn.runtime.outbox import OutboxMessage
+
+        try:
+            self._transport.put_display(
+                OutboxMessage(kind="system", text=_CHOICE_HINT_TEXT)
+            )
+        except Exception:
+            logger.exception("textual chat: choice hint surface failed")
 
 
 async def run_textual_chat(

--- a/tests/test_textual_chat_phase35_3273.py
+++ b/tests/test_textual_chat_phase35_3273.py
@@ -7,6 +7,14 @@ Textual TTY. The free-text-only wiring left choice interventions unanswerable
 (the only ``answer_intervention_choice`` caller lived in the dead old app), a
 permission-band functional regression this restores.
 
+Also pins the #3290 anti-black-hole fix (part of #3273): a free-text submit
+landing during a pending CHOICE intervention must NEVER fall through to
+``submit_user_text`` (the backend is blocked waiting for the choice answer, so
+that submit is a permanent black hole — 0 events, the UI optimistically lies
+that the text was sent). Instead: type-or-click parity — matching text answers
+the choice; non-matching text keeps the intervention pending and re-affirms the
+options.
+
 Gates:
 
 - **choice REACHABLE** (Tier 2b): a choice-intervention frame surfaces as
@@ -14,13 +22,18 @@ Gates:
   through ``transport.answer_intervention_choice`` and the entry re-presents to
   its resolved (``EntryState.SUCCESS``) state. Non-vacuous: the second option is
   chosen (so a first-option shortcut would fail), the specific id is asserted,
-  and the SAME pending choice-intervention is shown to be UNANSWERABLE via the
-  free-text composer path (which starts a new turn instead) — the pre-fix gap.
+  and no answer is delivered before the click.
+- **black-hole gone + type-or-click parity** (Tier 2b, #3290): with a choice
+  intervention pending, typing an option's label answers that choice via
+  ``answer_intervention_choice`` (never ``submit_user_text``); typing a
+  non-matching line keeps the intervention pending and surfaces a hint, and
+  STILL never reaches ``submit_user_text``.
 - **free-text still works** (Tier 2b): a no-choices intervention still routes a
   composer submit to ``answer_intervention_text`` (regression guard).
 
 All use real instances (a concrete recording :class:`ClientTransport`, a real
-mounted :class:`TextualChatApp`, real :class:`OutboxMessage`) — no mocks — per
+mounted :class:`TextualChatApp`, real :class:`OutboxMessage`,
+:class:`UserIntervention` / :class:`InterventionChoice` heads) — no mocks — per
 the testing policy.
 """
 from __future__ import annotations
@@ -36,9 +49,11 @@ from reyn.interfaces.inline.textual_chat import (
     TextualChatApp,
     choice_chip_spans,
 )
+from reyn.interfaces.inline.textual_chat.app import _match_choice_input
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
 from reyn.runtime.outbox import OutboxMessage
+from reyn.user_intervention import InterventionChoice, UserIntervention
 
 _GUTTER_WIDTH = 2
 
@@ -71,6 +86,7 @@ class RecordingTransport(ClientTransport):
         self.submitted: list[str] = []
         self.answered_choice: list[str] = []
         self.answered_text: list[str] = []
+        self.displayed: list[OutboxMessage] = []
 
     def start(self) -> None:  # pragma: no cover - trivial
         pass
@@ -104,6 +120,7 @@ class RecordingTransport(ClientTransport):
         return self._head
 
     def put_display(self, msg: "OutboxMessage") -> None:
+        self.displayed.append(msg)
         self._messages.append(msg)
 
     async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
@@ -134,6 +151,23 @@ def _choice_intervention() -> OutboxMessage:
                 {"component": "list", "items": ["Yes", "No", "Always"]},
             ],
         },
+    )
+
+
+def _choice_head() -> UserIntervention:
+    """A real pending CHOICE-intervention head (Yes / No / Always), matching the
+    ``choices`` of :func:`_choice_intervention`. This is the shape
+    ``transport.pending_intervention_head`` returns for a permission confirm —
+    a real :class:`UserIntervention`, not a stand-in, so ``_submit`` reads the
+    same ``.choices`` (``.id`` / ``.label`` / ``.hotkey``) production reads."""
+    return UserIntervention(
+        kind="permission.write",
+        prompt="Allow write to /etc/hosts?",
+        choices=[
+            InterventionChoice(id="yes", label="Yes", hotkey="y"),
+            InterventionChoice(id="no", label="No", hotkey="n"),
+            InterventionChoice(id="always", label="Always", hotkey="A"),
+        ],
     )
 
 
@@ -209,19 +243,49 @@ async def test_choice_click_off_the_chip_row_does_not_answer() -> None:
 
 
 @pytest.mark.asyncio
-async def test_choice_intervention_unanswerable_via_free_text_path() -> None:
-    """Tier 2b: the pre-fix gap witness — a pending CHOICE intervention is NOT
-    answered by the free-text composer path. With the choice-intervention head
-    pending, a composer submit starts a NEW TURN (``submit_user_text``) rather
-    than answering the intervention, so without the click wiring the choice would
-    never be delivered. Pairs with the reachability test to show the click path
-    is the only thing that closes the gap."""
+async def test_choice_free_text_match_answers_choice_not_new_turn() -> None:
+    """Tier 2b: type-or-click parity (#3290) — with a choice-intervention
+    pending, typing an option's LABEL ("yes", case-insensitive) answers the Yes
+    chip via ``answer_intervention_choice`` and NEVER starts a new turn.
 
-    class _ChoiceHead:
-        choices = [object(), object()]  # non-empty → NOT a free-text intervention
-
+    Non-vacuous (black-hole gone): the pre-fix code fell straight through to
+    ``submit_user_text`` for ANY choice-head submit — the #3290 black hole
+    (backend blocked on the choice, 0 events). Asserting ``submitted == []`` is
+    exactly what neutering the new choice branch (reverting to the fall-through)
+    flips RED. The delivered id is the Yes chip's ``id`` ("yes"), not the first
+    chip index nor the label string — a label-as-id confusion fails."""
     transport = RecordingTransport(
-        [_choice_intervention()], end=False, head=_ChoiceHead()
+        [_choice_intervention()], end=False, head=_choice_head()
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("y", "e", "s")
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert transport.answered_choice == ["yes"], (
+        f"typed option not routed to the choice; got {transport.answered_choice}"
+    )
+    assert transport.submitted == []  # never black-holed into a new turn
+    assert transport.answered_text == []
+
+
+@pytest.mark.asyncio
+async def test_choice_free_text_no_match_keeps_pending_and_hints() -> None:
+    """Tier 2b: the anti-black-hole no-match leg (#3290) — with a choice
+    intervention pending, a free-text line that matches NO option does NOT reach
+    ``submit_user_text`` (the black hole); it surfaces a hint and keeps the
+    intervention pending so the user can still click a chip or retype.
+
+    Non-vacuous: ``submitted == []`` is what the pre-fix fall-through violated,
+    and a ``kind="system"`` hint frame is asserted present — so the input was
+    neither delivered as a choice nor dropped silently."""
+    transport = RecordingTransport(
+        [_choice_intervention()], end=False, head=_choice_head()
     )
     app = TextualChatApp(transport=transport)
 
@@ -233,11 +297,62 @@ async def test_choice_intervention_unanswerable_via_free_text_path() -> None:
         await pilot.press("enter")
         await pilot.pause()
 
-    # A choice-intervention is pending, yet the text submit went to a new turn,
-    # NOT to any intervention-answer seam.
-    assert transport.submitted == ["hi"]
+    assert transport.submitted == []  # #3290: not black-holed into a blocked backend
     assert transport.answered_choice == []
     assert transport.answered_text == []
+    hints = [m for m in transport.displayed if m.kind == "system"]
+    assert hints, "no re-affirm hint surfaced for the unmatched choice submit"
+
+
+@pytest.mark.asyncio
+async def test_slash_command_during_choice_intervention_takes_normal_path() -> None:
+    """Tier 2b: the ``/``-guard survives (#3290 regression) the restructured
+    branch — a ``/``-prefixed line submitted while a CHOICE intervention is
+    pending is a slash command, so it routes to ``submit_user_text`` (the session
+    turn loop dispatches it), NOT to the choice-answer seam nor the hint."""
+    transport = RecordingTransport(
+        [_choice_intervention()], end=False, head=_choice_head()
+    )
+    app = TextualChatApp(transport=transport)
+
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        app.query_one(Composer).focus()
+        await pilot.pause()
+        await pilot.press("slash", "m", "o", "d", "e", "l")
+        await pilot.press("enter")
+        await pilot.pause()
+
+    assert transport.submitted == ["/model"]
+    assert transport.answered_choice == []
+    assert transport.answered_text == []
+
+
+def test_match_choice_input_label_hotkey_case_and_ambiguity() -> None:
+    """Tier 1: the ``_match_choice_input`` contract — trimmed, case-insensitive
+    match against BOTH label and hotkey; the ``choice_id`` (never itself matched)
+    is returned; ambiguity and no-match both return ``None``."""
+    choices = [
+        InterventionChoice(id="yes", label="Yes", hotkey="y"),
+        InterventionChoice(id="no", label="No", hotkey="n"),
+        InterventionChoice(id="always", label="Always", hotkey="A"),
+    ]
+    # Label match, case-insensitive + trimmed.
+    assert _match_choice_input("yes", choices) == "yes"
+    assert _match_choice_input("  YES  ", choices) == "yes"
+    # Hotkey match, case-insensitive (hotkey "A" for Always).
+    assert _match_choice_input("a", choices) == "always"
+    # The id itself is NOT a match key (would confuse label-vs-id).
+    assert _match_choice_input("no", choices) == "no"
+    # No match / empty → None (caller keeps pending + hints, never black-holes).
+    assert _match_choice_input("maybe", choices) is None
+    assert _match_choice_input("   ", choices) is None
+    # Ambiguity → None: two distinct choices sharing the same label.
+    dup = [
+        InterventionChoice(id="a", label="Go", hotkey="g"),
+        InterventionChoice(id="b", label="Go", hotkey="h"),
+    ]
+    assert _match_choice_input("go", dup) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — part of #3273, fixes the high-priority permission-surface soft-lock #3290.

## The bug (#3290)
In the Textual chat TUI, when a **choice-intervention** (closed-set prompt — e.g. a permission prompt with Yes/No chips) is pending and the user **submits FREE TEXT** (instead of clicking a chip), `_submit`'s choices branch was undefined and fell through to `transport.submit_user_text(...)` → the backend is BLOCKED waiting for the choice answer → **0 events fire, the session is permanently stuck (black hole), and the UI optimistically shows the text as "sent" (a lie)**. Typing "yes" to a Yes/No permission prompt is a natural action, so this was hit frequently. Primary evidence (tui-coder, #3290): audit-event log / history.jsonl showed 0 events after 3 free-text sends during a pending choice-intervention.

## Fix
`TextualChatApp._submit` (`src/reyn/interfaces/inline/textual_chat/app.py`) now handles a pending **choice**-intervention (a head with non-empty `.choices`) BEFORE the fall-through:

1. **Type-or-click parity** — new module-level `_match_choice_input(text, choices)` matches the trimmed, **case-insensitive** text against each choice's **label AND hotkey**. On an **unambiguous** match → `transport.answer_intervention_choice(<that choice_id>)` (typing "yes" resolves the Yes chip via the SAME seam a chip click uses). The `choice_id` is the delivery key and is never itself matched (no label-as-id confusion). Ambiguity (two distinct choices match) → treated as no-match. Attributes are read defensively so a partial head cannot raise.
2. **No / ambiguous match** — do NOT `submit_user_text`; instead surface a `kind="system"` re-affirm hint ("Please choose one of the options above (or click a chip).") via `put_display` and keep the intervention pending. The user is never black-holed.
3. **Unchanged** — the `/`-guard (slash command during a pending intervention still takes the normal path), free-**text** intervention → `answer_intervention_text`, chip-click → `answer_intervention_choice`, and normal `submit_user_text` (no pending intervention).

`_match_choice_input` is deliberately a separate TUI seam from `reyn.user_intervention.match_choice` (hotkey-only, case-sensitive — the stdin-bus contract); this is the forgiving type-or-click affordance.

## Test plan (all gates run locally)
- [x] **Black-hole gone, non-vacuous** (`test_choice_free_text_match_answers_choice_not_new_turn`, `test_choice_free_text_no_match_keeps_pending_and_hints`) — with a choice-intervention pending, a free-text submit no longer routes to `submit_user_text`; match → `answer_intervention_choice(["yes"])`, no-match → no answer call + `kind="system"` hint surfaced + intervention pending. **Non-vacuity proven**: neutering the new choice branch (`if False and choices`) flips both tests RED (`submitted`/`answered_text` gains the text) — verified locally.
- [x] **Type-or-click parity** — submitting "yes" (matching "Yes" label, case-insensitive) → `answer_intervention_choice(["yes"])` (Yes chip's id, not first-chip / not label-as-id). Non-matching text → no answer + pending. Unit contract pinned in `test_match_choice_input_label_hotkey_case_and_ambiguity` (label/hotkey, case, trim, ambiguity).
- [x] **No regression** — chip-click still answers (existing reachability test); free-text intervention → `answer_intervention_text` (`test_free_text_intervention_still_answered_via_composer`); `/`-guard intact (`test_slash_command_during_choice_intervention_takes_normal_path`); normal `submit_user_text` unaffected (phase4 `/model` routing).
- [x] **Import-isolation + plain-fallback preserved** — `verify_module_docstrings` clean; no always-loaded import added.

## Gates (worktree venv, CI extras dev,mcp,web,fs-watch,observability,builtin-rag)
- [x] `ruff check src tests` — All checks passed
- [x] `test_tier_audit.py --strict tests/test_textual_chat_phase35_3273.py` — 8/8 OK, 0 errors
- [x] `python -m pytest --timeout=120` — **9107 passed, 36 skipped**
- [x] `verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)