### PR TITLE
feat(tui): live spinner+elapsed on RUNNING tool rows, coalesced settle — #3283 ②

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -14,7 +14,9 @@ chrome the widgets in :mod:`~reyn.interfaces.inline.textual_chat.chrome`. This a
 wires them, drives the frame pump, and routes composer submissions back through
 the transport send seam. The running-blink gutter animates itself off
 textual-flowview's native ``FlowView(animation_fps=N)`` clock — there is no
-app-side blink timer.
+app-side blink timer. A RUNNING tool row additionally grows a live spinner +
+elapsed BODY, driven by a viewport-gated per-entry ``FlowView.animate_entry``
+that is stopped when the tool completes (Phase ②, #3283).
 
 This module is part of the TTY-only ``textual_chat`` package (imported lazily via
 :mod:`reyn.interfaces.repl.client_driver`); its ``textual`` / ``textual_flowview``
@@ -23,8 +25,9 @@ imports never reach an always-loaded module.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal
@@ -50,7 +53,13 @@ from .chrome import (
     status_line_text,
 )
 from .gutter import _RUNNING_FRAME_PERIOD, ReynGutter
-from .presenter import ReynPresenter, choice_chip_spans
+from .presenter import (
+    _RESULT_KIND_KEY,
+    _RESULT_META_KEY,
+    _RUNNING_SINCE_KEY,
+    ReynPresenter,
+    choice_chip_spans,
+)
 from .restore import project_restored_frames
 
 if TYPE_CHECKING:
@@ -150,6 +159,20 @@ class TextualChatApp(App):
     the frame from a monotonic clock — no app-side timer, no shared counter. The
     blink is additive: a frozen clock (``frame_period<=0``) leaves a static,
     correct amber gutter.
+
+    Phase ② (#3283) adds a LIVE BODY to a RUNNING tool row: while in flight the
+    row shows a spinner + an app-computed ``elapsed Ns`` under its ``tool(args)``
+    header, driven by a per-entry ``FlowView.animate_entry`` (viewport-gated: an
+    off-screen RUNNING tool neither spins nor recomputes). On completion the row
+    SETTLES IN PLACE — the per-entry animation is stopped and the result is
+    COALESCED into the SAME entry as a ``⎿ <result>`` sub-line (CC's
+    ``⏺ tool(args)`` + ``⎿ result`` block; the started + completed frames are ONE
+    row, not two). A completion with no matching started entry still appends its
+    own row, so nothing regresses. This composes with ①: ① animates the GUTTER
+    glyph off the always-on ``animation_fps`` clock, ② the tool BODY off a
+    per-entry timer. Tool frames carry no elapsed/progress (ADR finding D2), so
+    elapsed is computed from the app-side arrival time (``self._clock``); the
+    indicator is a spinner (indeterminate), NOT a progress bar.
 
     Phase 3 adds the bottom-chrome tab-drawer: below the composer, a
     :class:`StatusLine` + a focusable :class:`MenuBar`, and a
@@ -259,6 +282,15 @@ class TextualChatApp(App):
     #drawer Static { height: auto; padding: 1 0; }
     """
 
+    #: Per-entry BODY animation rate (Hz) for the live RUNNING-tool indicator
+    #: (Phase ②). Drives ``FlowView.animate_entry`` so the spinner + elapsed body
+    #: of an in-flight tool row re-presents at this cadence — but ONLY while the
+    #: entry is on screen (``animate_entry`` is viewport-gated: off-screen RUNNING
+    #: tools neither spin nor recompute). Matches the plain renderer's ~12fps
+    #: working spinner. Distinct from :data:`ANIMATION_FPS` (the always-on GUTTER
+    #: blink clock, Phase ①): ① animates the gutter glyph, ② the tool body.
+    RUNNING_BODY_FPS = 12.0
+
     def __init__(
         self,
         *,
@@ -266,18 +298,26 @@ class TextualChatApp(App):
         read_model: "ChatReadModel | None" = None,
         agent_name: str = "default",
         config=None,
+        clock: "Callable[[], float]" = time.monotonic,
+        presenter: "ReynPresenter | None" = None,
     ) -> None:
         super().__init__()
         self._transport = transport
         self._read_model = read_model
         self._agent_name = agent_name
         self._config = config
+        # App-side monotonic clock for the RUNNING-tool elapsed timer: tool frames
+        # carry no RUNNING-start timestamp (ADR finding D2), so elapsed is computed
+        # from when the started frame arrived here. Injectable so a test drives the
+        # live indicator deterministically; the presenter reads the SAME clock.
+        self._clock = clock
         self.conversation: "FlowModel[OutboxMessage]" = FlowModel()
         # One presenter instance, shared between the FlowView (which DRAWS entries)
         # and the choice-chip click handler (which asks it which body row the chips
         # landed on), so hit-testing measures the prompt head exactly as it was
-        # drawn.
-        self._presenter = ReynPresenter()
+        # drawn. Injectable (default a fresh one on the app clock) so a test can
+        # observe presentation.
+        self._presenter = presenter or ReynPresenter(clock=self._clock)
         # Running tool-call entries keyed by op_id (== the dispatcher's
         # deterministic args_hash, meta["op_id"]) so a later completion/failure
         # frame transitions the SAME entry RUNNING → SUCCESS/ERROR (CC parity).
@@ -291,7 +331,10 @@ class TextualChatApp(App):
         self._pane_selection_ids: "dict[str, list[str]]" = {}
 
     def compose(self) -> ComposeResult:
-        yield FlowView(
+        # Held so the frame pump can start/stop the per-entry BODY animation
+        # (``animate_entry``/``stop_entry_animation``) that drives a RUNNING tool
+        # row's live spinner + elapsed (Phase ②).
+        self._flow: "FlowView[OutboxMessage]" = FlowView(
             model=self.conversation,
             presenter=self._presenter,
             decorator=ReynGutter(frame_period=_RUNNING_FRAME_PERIOD),
@@ -302,6 +345,7 @@ class TextualChatApp(App):
             # re-invokes the time-based ReynGutter each tick (no app-side timer).
             animation_fps=self.ANIMATION_FPS,
         )
+        yield self._flow
         with Horizontal(id="inputrow"):
             yield Static("❯", id="inputgutter")
             yield Composer(
@@ -422,8 +466,10 @@ class TextualChatApp(App):
         frame to ``self.conversation`` (:func:`.restore.project_restored_frames`).
         Every restored entry is RESOLVED, never RUNNING: a completed tool result
         gets the SUCCESS/ERROR lifecycle state the live path's completion handler
-        (:meth:`_track_tool_state`) would have assigned, and user/agent rows keep
-        DEFAULT (their live state). A REMOTE read model returns an empty log
+        (:meth:`_coalesce_tool_result`) would have assigned, and user/agent rows
+        keep DEFAULT (their live state). Restore projects a standalone
+        ``tool_call_completed`` row (never a started+completed pair), so there is
+        nothing to coalesce here — it renders as its own settled result row. A REMOTE read model returns an empty log
         (frame-sufficiency: past turns are not on the wire) → this is a no-op and
         the pane starts blank, exactly as before. Fully guarded — a restore
         failure must never stop the app from mounting and pumping live frames."""
@@ -447,7 +493,7 @@ class TextualChatApp(App):
                     "textual chat: restore append failed for kind=%r", msg.kind
                 )
                 continue
-            # Resolved, never RUNNING — mirror _track_tool_state's terminal
+            # Resolved, never RUNNING — mirror the completion handler's terminal
             # transition for a settled tool result (SUCCESS unless the summary
             # marks a failure); non-tool rows keep DEFAULT.
             meta = msg.meta or {}
@@ -563,51 +609,137 @@ class TextualChatApp(App):
                 entry.set_state(EntryState.SUCCESS)
                 break
 
-    def _track_tool_state(self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]") -> None:
-        """Drive the Phase-2 lifecycle state of tool-call / error rows.
+    def _ingest_frame(self, msg: "OutboxMessage") -> None:
+        """Fold one display frame into the retained model — appending a new entry,
+        or COALESCING a correlated tool result into its RUNNING started entry.
+
+        A ``tool_call_completed`` / ``tool_call_failed`` frame whose ``op_id``
+        matches a tracked RUNNING tool does NOT append a second row: it SETTLES the
+        started entry in place (:meth:`_coalesce_tool_result` — stop the ② live
+        spinner, fold the ``⎿ result`` into the same entry, go SUCCESS/ERROR), so a
+        call and its result read as ONE block (CC's ``⏺ tool(args)`` + ``⎿ result``,
+        the PoC's ``_present_tool_call`` grouping). Every OTHER frame — including a
+        completion with NO matching started entry (already settled / uncorrelated)
+        — is appended as its own entry and handed to :meth:`_apply_lifecycle_state`,
+        so nothing regresses for the plain-fallback turn sequence."""
+        kind = msg.kind
+        op_id = (msg.meta or {}).get("op_id")
+        if kind in ("tool_call_completed", "tool_call_failed") and op_id is not None:
+            started = self._running_tools.pop(op_id, None)
+            if started is not None:
+                self._coalesce_tool_result(started, msg)
+                return
+        entry = self.conversation.append(msg)
+        self._apply_lifecycle_state(msg, entry)
+
+    def _apply_lifecycle_state(
+        self, msg: "OutboxMessage", entry: "Entry[OutboxMessage]"
+    ) -> None:
+        """Drive the Phase-2 lifecycle state + Phase-② live body of a NEWLY appended
+        row (the non-coalesced path).
 
         A ``tool_call_started`` row (with an ``op_id`` correlation key) becomes
-        RUNNING (its gutter blinks amber off the native animation clock); the
-        matching ``tool_call_completed`` / ``tool_call_failed`` frame transitions
-        that SAME entry to SUCCESS/ERROR (its gutter goes amber → green/coral).
-        ``error`` rows go straight to ERROR. Frames without an ``op_id`` carry no
-        state (DEFAULT) — they append exactly as in Phase 1, so the plain-fallback
-        turn sequence is unchanged.
+        RUNNING (its gutter blinks amber off the native animation clock) AND grows
+        a LIVE body — a spinner + app-computed ``elapsed Ns`` — driven by
+        :meth:`_begin_running_indicator`; its matching completion later coalesces
+        into it (:meth:`_ingest_frame`). An UNCORRELATED ``tool_call_failed`` (no
+        tracked started) or an ``error`` row goes straight to ERROR (coral gutter +
+        tint). Frames without an ``op_id`` carry no state (DEFAULT) — they append
+        exactly as in Phase 1, so the plain-fallback turn sequence is unchanged.
 
-        ``_running_tools`` keys the RUNNING entry by ``op_id`` purely for this
-        RUNNING → SUCCESS/ERROR correlation (NOT for the blink — the blink is now
-        time-based in :class:`ReynGutter`, driven by the native animation tick)."""
+        ``_running_tools`` keys the RUNNING entry by ``op_id`` for the settle: it is
+        the handle the completion frame coalesces + stops the animation on. The
+        gutter blink itself is time-based in :class:`ReynGutter`, driven by the
+        native animation tick."""
         kind = msg.kind
-        meta = msg.meta or {}
-        op_id = meta.get("op_id")
-        if kind == "tool_call_started":
-            if op_id is not None:
-                entry.set_state(EntryState.RUNNING)
-                self._running_tools[op_id] = entry
-        elif kind == "tool_call_completed":
-            summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
-            started = self._running_tools.pop(op_id, None) if op_id is not None else None
-            if started is not None:
-                started.set_state(
-                    EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
+        op_id = (msg.meta or {}).get("op_id")
+        if kind == "tool_call_started" and op_id is not None:
+            entry.set_state(EntryState.RUNNING)
+            self._running_tools[op_id] = entry
+            self._begin_running_indicator(entry)
+        elif kind in ("tool_call_failed", "error"):
+            entry.set_state(EntryState.ERROR)
+
+    def _coalesce_tool_result(
+        self, started: "Entry[OutboxMessage]", result_msg: "OutboxMessage"
+    ) -> None:
+        """Settle a RUNNING tool row IN PLACE with its result (② completion).
+
+        Stops the per-entry ② live-spinner animation (``stop_entry_animation`` — no
+        leaked timer survives completion), then folds the completion frame's kind +
+        meta into the started entry's item (stripping the :data:`_RUNNING_SINCE_KEY`
+        live marker and stashing the result under :data:`_RESULT_KIND_KEY` /
+        :data:`_RESULT_META_KEY`) so the presenter renders ``tool(args)`` + a
+        ``⎿ <result>`` sub-line in this SAME entry — no separate result row, no
+        lingering spinner. Finally sets the terminal state: ERROR (coral) on a
+        failure or a ``✗`` result summary, SUCCESS (green) otherwise. Each step is
+        guarded so a settle failure never kills the pump."""
+        try:
+            self._flow.stop_entry_animation(started)
+        except Exception:
+            logger.exception("textual chat: could not stop running-tool animation")
+        started_meta = started.item.meta or {}
+        result_meta = result_msg.meta or {}
+        merged = {k: v for k, v in started_meta.items() if k != _RUNNING_SINCE_KEY}
+        merged[_RESULT_KIND_KEY] = result_msg.kind
+        merged[_RESULT_META_KEY] = result_meta
+        try:
+            started.set_item(replace(started.item, meta=merged))
+        except Exception:
+            logger.exception("textual chat: could not coalesce tool result")
+        if result_msg.kind == "tool_call_failed":
+            started.set_state(EntryState.ERROR)
+        else:
+            summary = summarize_tool_result(
+                started_meta.get("tool"), result_meta.get("result")
+            )
+            started.set_state(
+                EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
+            )
+
+    def _begin_running_indicator(self, entry: "Entry[OutboxMessage]") -> None:
+        """Start the live spinner + elapsed body for a RUNNING tool entry (②).
+
+        Stamps the monotonic START time into the entry's item meta
+        (:data:`_RUNNING_SINCE_KEY`) — its presence is what makes the presenter
+        render the live indicator instead of the static ``tool(args)`` line — then
+        registers a viewport-gated per-entry animation (``FlowView.animate_entry``)
+        whose tick simply re-presents the body (``entry.update()``), so the spinner
+        frame + elapsed count advance with wall time while the row is ON SCREEN
+        (off-screen RUNNING tools are auto-paused by ``animate_entry`` — no spin,
+        no recompute). The animation is released by :meth:`_coalesce_tool_result`
+        on completion (and dropped automatically by flowview if the entry is
+        removed), so it never outlives the RUNNING state. Fully guarded: a live
+        indicator is cosmetic, so a failure to start it must never break the pump
+        (the row still shows its static state-coloured gutter).
+
+        Body re-present cadence: the per-entry ``animate_entry`` tick bumps the
+        entry revision (``entry.update()``); the re-present materializes on the
+        next viewport paint — immediately at up to ``RUNNING_BODY_FPS`` while the
+        conversation is scrolled (the on-screen band is fresh), and at least at the
+        native ``animation_fps`` gutter-tick cadence otherwise (that repaint
+        re-presents the bumped revision). So the spinner + elapsed always advance;
+        they are simply smoother in a scrolled conversation."""
+        try:
+            entry.set_item(
+                replace(
+                    entry.item,
+                    meta={**(entry.item.meta or {}), _RUNNING_SINCE_KEY: self._clock()},
                 )
-        elif kind == "tool_call_failed":
-            started = self._running_tools.pop(op_id, None) if op_id is not None else None
-            if started is not None:
-                started.set_state(EntryState.ERROR)
-            entry.set_state(EntryState.ERROR)
-        elif kind == "error":
-            entry.set_state(EntryState.ERROR)
+            )
+            self._flow.animate_entry(entry, 1.0 / self.RUNNING_BODY_FPS, lambda e: e.update())
+        except Exception:
+            logger.exception("textual chat: could not start running-tool indicator")
 
     async def _pump_frames(self) -> None:
         """Drain the transport frame stream into the retained model.
 
-        Display frames append to the model (skipping command-UI sentinels);
-        ``__end__`` stops the app (the session closed). Event frames are the
-        working-indicator path — consumed but not yet drawn. Each appended entry
-        is then handed to :meth:`_track_tool_state` for its Phase-2 lifecycle
-        colour. A single frame's presentation failure must not kill the pump, so
-        append is guarded.
+        Display frames fold into the model (skipping command-UI sentinels) via
+        :meth:`_ingest_frame` — appending a new entry, or COALESCING a correlated
+        tool result into its RUNNING started entry (② settle-in-place). ``__end__``
+        stops the app (the session closed). Event frames are the working-indicator
+        path — consumed but not yet drawn. A single frame's failure must not kill
+        the pump, so ingest is guarded.
         """
         try:
             async for frame in self._transport.frames():
@@ -619,17 +751,10 @@ class TextualChatApp(App):
                 if msg.kind in _SKIP_KINDS:
                     continue
                 try:
-                    entry = self.conversation.append(msg)
+                    self._ingest_frame(msg)
                 except Exception:
                     logger.exception(
-                        "textual chat: append failed for frame kind=%r", msg.kind
-                    )
-                    continue
-                try:
-                    self._track_tool_state(msg, entry)
-                except Exception:
-                    logger.exception(
-                        "textual chat: state tracking failed for kind=%r", msg.kind
+                        "textual chat: frame ingest failed for kind=%r", msg.kind
                     )
                 # F5b: refresh the always-visible status-values line (cost + ctx%)
                 # as each turn lands, so the running cost is legible in the Textual

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -12,13 +12,15 @@ never reaches an always-loaded module.
 """
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, Callable
 
 from rich.console import Console, Group, RenderableType
 from rich.text import Text
 from textual_flowview import Presentation
 
 from reyn.interfaces.repl.renderer import (
+    _CC_ACCENT,
     _CC_DIM,
     _CC_DONE,
     _CC_ERR,
@@ -26,6 +28,7 @@ from reyn.interfaces.repl.renderer import (
     _CC_USER_BG,
     _CC_WARN,
     _KIND_LINE,
+    _SPINNER,
     _body_renderable,
     _summarize_args,
     summarize_tool_result,
@@ -33,6 +36,35 @@ from reyn.interfaces.repl.renderer import (
 
 if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
+
+# --- live RUNNING-tool indicator (Phase ②) ---------------------------------
+# A ``tool_call_started`` entry that is in flight carries a monotonic START
+# timestamp under this meta key (stamped app-side by
+# ``TextualChatApp._begin_running_indicator`` when the entry goes RUNNING — tool frames
+# themselves carry no elapsed/progress, ADR finding D2). Its PRESENCE is what
+# tells :meth:`ReynPresenter.present` to render the live spinner + elapsed body
+# instead of the static ``tool(args)`` line; the completion handler REMOVES it to
+# settle the row back to static. Kept private (leading underscore) so it never
+# collides with a real display-frame meta field.
+_RUNNING_SINCE_KEY = "_running_since"
+
+# The braille-spinner advance rate (frames/sec), reusing the plain renderer's
+# working-line idiom (``_SPINNER[int(now * 8) % len]`` — see
+# :func:`reyn.interfaces.repl.status.working_line`) so the Textual tool spinner
+# reads identically to the bottom-toolbar working spinner.
+_SPINNER_SPEED = 8
+
+# --- coalesced tool call + result (one entry, CC ``⏺ tool(args)`` + ``⎿ result``)
+# When a tool completes, the frame pump SETTLES its RUNNING started entry IN PLACE
+# — folding the result into the SAME entry rather than appending a separate result
+# row (mirrors CC's block + the PoC's ``_present_tool_call`` grouping). The pump
+# stashes the completion frame's kind + meta under these keys on the started
+# item; their presence tells the presenter to render the ``⎿ <result>`` line
+# under the ``tool(args)`` header. A completion with no matching started entry is
+# still appended as its own row (kept via :func:`_body_and_background`'s
+# ``tool_call_completed`` / ``tool_call_failed`` branches), so nothing regresses.
+_RESULT_KIND_KEY = "_result_kind"
+_RESULT_META_KEY = "_result"
 
 # --- choice-intervention chip layout ---------------------------------------
 # A closed-set intervention (permission confirm / choice ``ask_user`` — anything
@@ -107,6 +139,64 @@ def _choice_head(msg: "OutboxMessage") -> RenderableType:
     return parts[0] if len(parts) == 1 else Group(*parts)
 
 
+def _tool_head(msg: "OutboxMessage") -> Text:
+    """The ``tool(args)`` header line of a tool-call row.
+
+    The SINGLE source of that header, shared by the static
+    :func:`_body_and_background` tool-call branch and the live
+    :meth:`ReynPresenter._present_running_tool` indicator, so a RUNNING row and
+    its settled form read identically (only the appended spinner/elapsed line
+    differs while in flight)."""
+    meta = msg.meta or {}
+    tool = str(meta.get("tool", msg.text))
+    args = _summarize_args(meta.get("args"))
+    return Text.assemble((tool, "bold"), (f"({args})", _CC_DIM))
+
+
+def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
+    """The ``⎿ <result summary>`` sub-line + optional coral tint of a SETTLED tool
+    row — the completion folded into its started entry (:data:`_RESULT_KIND_KEY`).
+
+    Reuses the plain renderer's tool-result summary (:func:`summarize_tool_result`)
+    and failure vocabulary so a coalesced result reads the same as the pre-coalesce
+    separate ``tool_call_completed`` / ``tool_call_failed`` row — only the nesting
+    (``⎿`` under the call, in one entry) is new. A failure tints the whole row
+    coral (``_CC_ERR``), matching the standalone failure row."""
+    meta = msg.meta or {}
+    result_meta = meta.get(_RESULT_META_KEY) or {}
+    if meta.get(_RESULT_KIND_KEY) == "tool_call_failed":
+        err = (
+            result_meta.get("error_message")
+            or result_meta.get("error_kind")
+            or result_meta.get("text")
+            or ""
+        )
+        return Text(f"  ⎿ ✗ {err}", style=_CC_ERR), _CC_ERR
+    summary = summarize_tool_result(meta.get("tool"), result_meta.get("result"))
+    failed = summary.startswith("✗")
+    return (
+        Text(f"  ⎿ {summary}", style=_CC_ERR if failed else _CC_DIM),
+        (_CC_ERR if failed else None),
+    )
+
+
+def _running_indicator(msg: "OutboxMessage", now: float) -> Text:
+    """The live ``⠙ elapsed Ns`` indicator line for an in-flight tool row.
+
+    A time-driven braille spinner (:data:`_SPINNER`, advanced at
+    :data:`_SPINNER_SPEED` off ``now``) plus the app-computed elapsed seconds
+    since the entry went RUNNING (``now - meta[_RUNNING_SINCE_KEY]``). ``now`` is
+    the caller's monotonic clock reading; because it is re-read on each
+    ``animate_entry`` tick, both the spinner frame and the elapsed count advance
+    with wall time (the live-indicator non-vacuity). Elapsed is clamped at 0 so a
+    clock skew never renders a negative age."""
+    meta = msg.meta or {}
+    since = float(meta.get(_RUNNING_SINCE_KEY) or now)
+    elapsed = max(0, int(now - since))
+    frame = _SPINNER[int(now * _SPINNER_SPEED) % len(_SPINNER)]
+    return Text.assemble((f"{frame} ", _CC_ACCENT), (f"elapsed {elapsed}s", _CC_DIM))
+
+
 def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | None]":
     """The body renderable + optional full-row background for one display frame.
 
@@ -129,9 +219,12 @@ def _body_and_background(msg: "OutboxMessage") -> "tuple[RenderableType, str | N
         from reyn.interfaces.repl.present_renderer import render_presentation_nodes
         return render_presentation_nodes(meta["nodes"]), None
     if kind == "tool_call_started":
-        tool = str(meta.get("tool", msg.text))
-        args = _summarize_args(meta.get("args"))
-        return Text.assemble((tool, "bold"), (f"({args})", _CC_DIM)), None
+        head = _tool_head(msg)
+        if meta.get(_RESULT_KIND_KEY) is not None:
+            # Settled (coalesced): the tool call folded together with its result.
+            result_line, background = _tool_result_line(msg)
+            return Group(head, result_line), background
+        return head, None
     if kind == "tool_call_completed":
         summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
         failed = summary.startswith("✗")
@@ -156,11 +249,22 @@ class ReynPresenter:
     """Turns a reyn display frame into a body :class:`Presentation` sized to
     ``width`` — reusing the plain renderer's palette + per-kind body construction
     (``_CC_*`` / ``_KIND_LINE`` / ``_body_renderable``), never a second styling
-    vocabulary. The gutter is the :class:`ReynGutter`'s job."""
+    vocabulary. The gutter is the :class:`ReynGutter`'s job.
 
-    def __init__(self) -> None:
+    An in-flight tool-call row (``tool_call_started`` whose entry carries the
+    :data:`_RUNNING_SINCE_KEY` meta marker) renders a LIVE body — the static
+    ``tool(args)`` header plus a spinner + app-computed ``elapsed Ns`` line — at a
+    FIXED height (header rows + 1) so the per-tick re-present never reflows. The
+    body is re-derived on each ``animate_entry`` tick (viewport-gated), reading
+    ``clock`` for the current spinner frame + elapsed; ``clock`` is injectable
+    (default :func:`time.monotonic`) so a test drives the animation
+    deterministically. The completion handler removes the marker, settling the row
+    back to its static ``tool(args)`` form."""
+
+    def __init__(self, *, clock: "Callable[[], float]" = time.monotonic) -> None:
         # A private probe console for measuring wrapped height at a given width.
         self._probe = Console()
+        self._clock = clock
 
     def _measure(self, renderable: RenderableType, width: int) -> int:
         self._probe.size = (max(width, 1), 200)
@@ -214,10 +318,30 @@ class ReynPresenter:
         hint = Text(_CHOICE_HINT, style=_CC_DIM)
         return Presentation(height=head_h + 2, renderable=Group(head, chips, hint))
 
+    def _present_running_tool(
+        self, item: "OutboxMessage", width: int
+    ) -> Presentation:
+        """Present an in-flight tool-call row with a LIVE spinner + elapsed body.
+
+        The static ``tool(args)`` header (:func:`_tool_head`) with a
+        ``⠙ elapsed Ns`` line under it (:func:`_running_indicator`, read off
+        ``self._clock``). Height is FIXED at ``header_rows + 1``: the header does
+        not change while in flight and the indicator is always one line, so the
+        per-tick re-present (driven by ``animate_entry``) never reflows — only the
+        spinner frame + elapsed count advance. The completion handler strips the
+        :data:`_RUNNING_SINCE_KEY` marker, after which :meth:`present` renders the
+        static tool-call body instead (settle)."""
+        head = _tool_head(item)
+        indicator = _running_indicator(item, self._clock())
+        head_h = self._measure(head, width)
+        return Presentation(height=head_h + 1, renderable=Group(head, indicator))
+
     async def present(self, item: "OutboxMessage", width: int) -> Presentation:
         meta = item.meta or {}
         if item.kind == "intervention" and meta.get("choices"):
             return self._present_intervention_choice(item, width)
+        if item.kind == "tool_call_started" and meta.get(_RUNNING_SINCE_KEY) is not None:
+            return self._present_running_tool(item, width)
         body, background = _body_and_background(item)
         return Presentation(
             height=self._measure(body, width),

--- a/tests/test_textual_chat_phase2_3273.py
+++ b/tests/test_textual_chat_phase2_3273.py
@@ -132,7 +132,7 @@ def _entry_by_kind(app: TextualChatApp, kind: str):
 def _make_running_entry():
     """A real RUNNING :class:`~textual_flowview.Entry` (no mount needed): append a
     ``tool_call_started`` message to a real :class:`~textual_flowview.FlowModel`
-    and set it RUNNING — the exact state the live path's ``_track_tool_state``
+    and set it RUNNING — the exact state the live path's ``_apply_lifecycle_state``
     assigns. Real instances only (no mock)."""
     from textual_flowview import FlowModel
 
@@ -328,23 +328,28 @@ async def test_running_to_success_turns_gutter_green() -> None:
 @pytest.mark.asyncio
 async def test_running_to_error_turns_gutter_coral_and_tints_failure_row() -> None:
     """Tier 2b: RUNNING → ERROR — a failed tool call transitions the started
-    entry to ERROR (gutter ``_CC_ERR`` coral) AND the failure row itself is
-    tinted ``_CC_ERR`` edge-to-edge (CC block-tint). Feeds the correlated
-    started+failed pair and inspects both the started entry's gutter and the
-    failed entry's presentation background."""
+    entry to ERROR (gutter ``_CC_ERR`` coral) AND, under the #3283 ② coalesce,
+    the failure is folded into that SAME started entry (no separate row) whose
+    presentation is tinted ``_CC_ERR`` edge-to-edge (CC block-tint). Feeds the
+    correlated started+failed pair and inspects the coalesced entry's gutter and
+    presentation background."""
     transport = ScriptedTransport([_started("op-err"), _failed("op-err")], end=False)
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await pilot.pause()
+        # Coalesced: the started+failed pair is ONE entry, not two.
+        from textual_flowview import FlowView
+
+        assert [e.item.kind for e in app.query_one(FlowView).entries] == ["tool_call_started"]
+        assert not _entry_by_kind(app, "tool_call_failed")  # no separate failure row
         started = _entry_by_kind(app, "tool_call_started")[0]
         assert started.state is EntryState.ERROR
         gutter = ReynGutter()
         assert gutter.decorate(started, 2, 1).style == _CC_ERR
 
-        # The failure row is tinted coral edge-to-edge.
-        failed_item = _entry_by_kind(app, "tool_call_failed")[0].item
-        pres = await ReynPresenter().present(failed_item, 80)
+        # The coalesced failure entry is tinted coral edge-to-edge.
+        pres = await ReynPresenter().present(started.item, 80)
         assert pres.background == _CC_ERR
 
 

--- a/tests/test_textual_chat_phase2b_live_tool_3283.py
+++ b/tests/test_textual_chat_phase2b_live_tool_3283.py
@@ -1,0 +1,508 @@
+"""Phase ② gates (#3283): a LIVE spinner + elapsed body on RUNNING tool rows,
+settling into a COALESCED ``tool(args)`` + ``⎿ result`` block on completion.
+
+A ``tool_call_started`` entry that is in flight grows a live BODY — a braille
+spinner + an app-computed ``elapsed Ns`` under its ``tool(args)`` header — driven
+by a per-entry, viewport-gated ``FlowView.animate_entry``. On completion the row
+SETTLES IN PLACE: the per-entry animation is stopped and the result is folded
+into the SAME entry as a ``⎿ <result>`` sub-line (a call and its result are ONE
+row, CC's ``⏺ tool(args)`` + ``⎿ result`` block), not a second stacked entry.
+These pin the architect-specified ② gates + the owner's coalesce request:
+
+- **live indicator, non-vacuous** (Tier 1): a RUNNING tool body CHANGES as its
+  monotonic clock advances (spinner frame + elapsed count); a FROZEN clock leaves
+  it static — so the positive assertion is load-bearing, not tautological.
+- **settle on completion** (Tier 1 + Tier 2b): the RUNNING marker is stripped and
+  the result folded in; the presenter renders the STATIC ``tool(args)`` +
+  ``⎿ result`` body; the mounted app does this on RUNNING→SUCCESS/ERROR.
+- **coalesce into one entry** (Tier 2b): a correlated started+completed/failed
+  pair produces exactly ONE model entry carrying both the call and the ``⎿``
+  result; an UNCORRELATED result (no matching op_id) still appends its own entry.
+- **drives the real mechanism / no leak** (Tier 2b): the app's ``animate_entry``
+  re-presents the RUNNING body live while on screen, and ``settle``
+  (``stop_entry_animation``) halts it — the settled row is not re-presented again
+  (no leaked timer). Off-screen RUNNING tools are auto-paused (viewport gating).
+- **no regression** (Tier 2b): ①'s gutter blink still animates; a plain
+  (non-tool) row is unaffected.
+
+All use real instances — a concrete ``QueueTransport`` / ``ScriptedTransport``, a
+real mounted :class:`TextualChatApp`, real :class:`OutboxMessage`, a real
+list-backed clock, and a real counting :class:`ReynPresenter` SUBCLASS (not a
+mock) — per the testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from rich.console import Console
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import ReynPresenter, TextualChatApp
+from reyn.interfaces.inline.textual_chat.presenter import (
+    _RESULT_KIND_KEY,
+    _RUNNING_SINCE_KEY,
+    _running_indicator,
+    _tool_head,
+)
+from reyn.interfaces.repl.renderer import _SPINNER
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.runtime.outbox import OutboxMessage
+
+
+def _started(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started", text=tool, meta={"tool": tool, "op_id": op_id, "args": {}}
+    )
+
+
+def _completed(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="",
+        meta={"tool": tool, "op_id": op_id, "result": {"op": tool, "count": 3}},
+    )
+
+
+def _failed(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_failed",
+        text=tool,
+        meta={"tool": tool, "op_id": op_id, "error_kind": "Boom", "error_message": "it broke"},
+    )
+
+
+def _running_item(op_id: str, since: float, tool: str = "grep") -> OutboxMessage:
+    """A ``tool_call_started`` frame carrying the live-indicator START marker — the
+    exact item shape the app stamps when the entry goes RUNNING."""
+    return OutboxMessage(
+        kind="tool_call_started",
+        text=tool,
+        meta={"tool": tool, "op_id": op_id, "args": {}, _RUNNING_SINCE_KEY: since},
+    )
+
+
+def _render(renderable, width: int = 80) -> str:
+    console = Console(width=width)
+    with console.capture() as cap:
+        console.print(renderable)
+    return cap.get()
+
+
+class ScriptedTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` replaying a fixed frame list.
+
+    ``end=False`` keeps the stream open after the script so the app under test
+    stays mounted for inspection."""
+
+    def __init__(self, messages: "list[OutboxMessage]", *, end: bool = False) -> None:
+        self._messages = list(messages)
+        self._end = end
+        self.submitted: list[str] = []
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        for msg in self._messages:
+            yield DisplayFrame(msg)
+        if self._end:
+            yield DisplayFrame(OutboxMessage(kind="__end__", text=""))
+        else:
+            await asyncio.Event().wait()
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        self._messages.append(msg)
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class QueueTransport(ClientTransport):
+    """A real :class:`ClientTransport` fed one frame at a time from a queue, so a
+    test can push a ``started`` frame, inspect the RUNNING row, THEN push the
+    completion and inspect the settle — with the stream staying open in between."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[OutboxMessage]" = asyncio.Queue()
+        self.submitted: list[str] = []
+
+    async def push(self, msg: OutboxMessage) -> None:
+        await self._queue.put(msg)
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[DisplayFrame]":
+        while True:
+            msg = await self._queue.get()
+            yield DisplayFrame(msg)
+
+    async def submit_user_text(self, text: str) -> None:
+        self.submitted.append(text)
+
+    async def answer_intervention_text(self, text: str) -> bool:
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+class _CountingPresenter(ReynPresenter):
+    """A real :class:`ReynPresenter` that also counts how many times each tool
+    row is presented, keyed by ``op_id`` — a REAL subclass (not a mock) so the
+    genuine body construction still runs; the count witnesses the per-entry
+    ``animate_entry`` re-presenting the RUNNING body (and stopping on settle)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.present_counts: "dict[object, int]" = {}
+
+    async def present(self, item: "OutboxMessage", width: int):
+        if item.kind == "tool_call_started":
+            op = (item.meta or {}).get("op_id")
+            self.present_counts[op] = self.present_counts.get(op, 0) + 1
+        return await super().present(item, width)
+
+
+def _fast_app(**kwargs) -> TextualChatApp:
+    """A real app with the animation clocks raised so a body re-present lands
+    inside a short test pause. Only the CADENCE differs from production — the
+    mechanism (gutter ``animation_fps`` refresh backstop + per-entry
+    ``animate_entry``) is identical."""
+    app = TextualChatApp(**kwargs)
+    app.ANIMATION_FPS = 20.0
+    app.RUNNING_BODY_FPS = 20.0
+    return app
+
+
+def _entry_by_kind(app: TextualChatApp, kind: str):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == kind]
+
+
+# ── Gate 1: live indicator, non-vacuous ───────────────────────────────────────
+
+def test_running_tool_body_advances_as_the_clock_advances() -> None:
+    """Tier 1: a RUNNING tool body CHANGES as its monotonic clock advances.
+
+    The live-indicator non-vacuity witness (#3283 ②): the presenter renders the
+    spinner frame + elapsed off a clock it re-reads on each ``animate_entry``
+    tick, so successive reads at different times produce a DIFFERENT body. Drives
+    the REAL presenter with a real list-backed clock (no mock).
+
+    Non-vacuous by construction: the paired
+    ``test_frozen_clock_leaves_a_static_running_body`` freezes the clock and the
+    body then does NOT change — so this positive assertion is load-bearing."""
+    now = [1000.0]
+    presenter = ReynPresenter(clock=lambda: now[0])
+    item = _running_item("op-live", since=1000.0)
+
+    async def go() -> None:
+        now[0] = 1002.0
+        a = await presenter.present(item, 80)
+        now[0] = 1007.0
+        b = await presenter.present(item, 80)
+        # Fixed height across ticks (no reflow): header row + the indicator row.
+        assert a.height == b.height == 2
+        ta, tb = _render(a.renderable), _render(b.renderable)
+        assert ta != tb, f"running body did not advance across ticks: {ta!r}"
+        # Both are genuine live bodies: the elapsed count grew and a spinner frame
+        # is present.
+        assert "elapsed 2s" in ta and "elapsed 7s" in tb
+        assert any(frame in ta for frame in _SPINNER)
+
+    asyncio.run(go())
+
+
+def test_frozen_clock_leaves_a_static_running_body() -> None:
+    """Tier 1: a FROZEN clock leaves the RUNNING body STATIC (the ② non-vacuity
+    strip). Reading the same instant twice yields an identical body — the paired
+    positive test proves it moves when the clock advances, so the animation is the
+    only thing driving the change (not incidental noise)."""
+    presenter = ReynPresenter(clock=lambda: 500.0)
+    item = _running_item("op-frozen", since=490.0)
+
+    async def go() -> None:
+        a = await presenter.present(item, 80)
+        b = await presenter.present(item, 80)
+        assert _render(a.renderable) == _render(b.renderable), "frozen clock must not animate"
+
+    asyncio.run(go())
+
+
+def test_running_indicator_line_carries_spinner_and_elapsed() -> None:
+    """Tier 1: the indicator line is a spinner frame + ``elapsed Ns`` computed from
+    the RUNNING-start marker (``now - _running_since``), clamped at 0. Pins
+    :func:`_running_indicator` directly (a pure function of item + now)."""
+    item = _running_item("op-i", since=100.0)
+    line = _running_indicator(item, now=104.0)
+    text = line.plain
+    assert "elapsed 4s" in text
+    assert text[0] in _SPINNER
+    # A clock skew (now before since) never renders a negative age.
+    assert "elapsed 0s" in _running_indicator(item, now=99.0).plain
+
+
+# ── Gate 2: settle on completion (static, coalesced body) ─────────────────────
+
+def test_settled_tool_body_is_static_and_matches_the_header() -> None:
+    """Tier 1: a marker-free ``tool_call_started`` item (a pre-RUNNING / restored
+    row) renders the STATIC ``tool(args)`` header only — clock-invariant, no
+    spinner. Presented at two DIFFERENT clock readings the body is identical."""
+    now = [10.0]
+    presenter = ReynPresenter(clock=lambda: now[0])
+    settled = _started("op-settled")  # no _RUNNING_SINCE_KEY marker
+
+    async def go() -> None:
+        a = await presenter.present(settled, 80)
+        now[0] = 9999.0
+        b = await presenter.present(settled, 80)
+        assert _render(a.renderable) == _render(b.renderable), "settled body must be static"
+        assert a.height == 1  # header only, no indicator row
+        assert _render(a.renderable).strip() == _tool_head(settled).plain
+
+    asyncio.run(go())
+
+
+@pytest.mark.asyncio
+async def test_app_marks_running_body_live_then_coalesces_on_success() -> None:
+    """Tier 2b: the mounted app stamps the RUNNING-start marker on a started tool
+    row (making its body live) and, on completion, SETTLES it — stripping the
+    marker, folding the ``⎿ result`` into the same entry, and going SUCCESS.
+
+    Two runs isolate the two states deterministically (no timing): a started-only
+    stream leaves the row RUNNING+marked+spinning; a started+completed stream
+    leaves it SUCCESS with a static ``tool(args)`` + ``⎿ result`` body."""
+    # In flight: marker present, state RUNNING, body renders the live indicator.
+    live_app = TextualChatApp(transport=ScriptedTransport([_started("op-a")], end=False))
+    async with live_app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entry = _entry_by_kind(live_app, "tool_call_started")[0]
+        assert entry.state is EntryState.RUNNING
+        assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is not None
+        pres = await ReynPresenter().present(entry.item, 80)
+        assert pres.height == 2  # header + live indicator row
+        assert any(frame in _render(pres.renderable) for frame in _SPINNER)
+
+    # Completed: marker stripped, state SUCCESS, body is the coalesced result.
+    done_app = TextualChatApp(
+        transport=ScriptedTransport([_started("op-a"), _completed("op-a")], end=False)
+    )
+    async with done_app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entry = _entry_by_kind(done_app, "tool_call_started")[0]
+        assert entry.state is EntryState.SUCCESS
+        assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
+        pres = await ReynPresenter().present(entry.item, 80)
+        body = _render(pres.renderable)
+        assert "⎿" in body  # the folded-in result sub-line
+        assert not any(frame in body for frame in _SPINNER)  # no lingering spinner
+
+
+@pytest.mark.asyncio
+async def test_app_coalesces_a_failure_and_tints_it() -> None:
+    """Tier 2b: RUNNING → ERROR also settles in place — the started row's live
+    marker is stripped, the failure folds into the SAME entry as a coral
+    ``⎿ ✗ …`` sub-line, and its state goes ERROR."""
+    app = TextualChatApp(
+        transport=ScriptedTransport([_started("op-e"), _failed("op-e")], end=False)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        started = _entry_by_kind(app, "tool_call_started")[0]
+        assert started.state is EntryState.ERROR
+        assert (started.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
+        pres = await ReynPresenter().present(started.item, 80)
+        from reyn.interfaces.repl.renderer import _CC_ERR
+
+        assert pres.background == _CC_ERR
+        assert "⎿" in _render(pres.renderable)
+
+
+# ── Gate 5: coalesce into one entry (owner request) ───────────────────────────
+
+@pytest.mark.asyncio
+async def test_correlated_pair_coalesces_into_exactly_one_entry() -> None:
+    """Tier 2b: a correlated ``tool_call_started`` + its matching completion
+    produce EXACTLY ONE model entry carrying BOTH the call and the ``⎿`` result —
+    not two stacked rows.
+
+    Non-vacuity: the model length is asserted to be exactly 1 for the pair (a
+    regression to the old append-a-second-row behavior would make it 2)."""
+    app = TextualChatApp(
+        transport=ScriptedTransport([_started("op-1"), _completed("op-1")], end=False)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        # Exactly one entry — the started row carrying the folded-in result — not a
+        # second stacked result row.
+        assert [e.item.kind for e in flow.entries] == ["tool_call_started"]
+        entry = flow.entries[0]
+        assert (entry.item.meta or {}).get(_RESULT_KIND_KEY) == "tool_call_completed"
+        body = _render((await ReynPresenter().present(entry.item, 80)).renderable)
+        assert "grep" in body and "⎿" in body  # call header AND result, one block
+
+
+@pytest.mark.asyncio
+async def test_uncorrelated_result_still_appends_its_own_entry() -> None:
+    """Tier 2b: a ``tool_call_completed`` with NO matching started entry (already
+    settled / uncorrelated) still appends as its OWN entry — the coalesce path
+    must not swallow an uncorrelated result (no regression for the plain-fallback
+    turn sequence)."""
+    app = TextualChatApp(transport=ScriptedTransport([_completed("orphan")], end=False))
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        # The uncorrelated result appears as its own row (not swallowed).
+        assert [e.item.kind for e in flow.entries] == ["tool_call_completed"]
+
+
+# ── Gate 3: drives the real mechanism live, releases on settle (no leak) ───────
+
+@pytest.mark.asyncio
+async def test_running_body_animates_live_then_stops_on_settle() -> None:
+    """Tier 2b: the app's per-entry ``animate_entry`` RE-PRESENTS the RUNNING body
+    live while it is on screen, and ``settle`` (``stop_entry_animation``) halts it
+    — the settled row is not re-presented again (no leaked timer).
+
+    Drives the REAL mechanism (real FlowView animation timers under ``run_test``)
+    with a real counting presenter: the RUNNING row's present-count keeps climbing
+    while in flight, then FREEZES after completion. The freeze is the no-leak
+    witness — a leaked ``animate_entry`` timer would keep the count climbing."""
+    transport = QueueTransport()
+    presenter = _CountingPresenter()  # held locally — assert on its PUBLIC count
+    app = _fast_app(transport=transport, presenter=presenter)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push(_started("op-live"))
+        await pilot.pause()
+        await pilot.pause(0.4)  # let the live body re-present several times
+        live_count = presenter.present_counts.get("op-live", 0)
+        assert live_count >= 3, f"running body did not animate live: {live_count} presents"
+
+        # Complete it → settle stops the per-entry animation (coalesce in place).
+        await transport.push(_completed("op-live"))
+        await pilot.pause()
+        await pilot.pause(0.1)  # let the one settle re-present land
+        settled_count = presenter.present_counts.get("op-live", 0)
+        # After settle the body must not be presented again — no leaked timer.
+        await pilot.pause(0.4)
+        frozen_count = presenter.present_counts.get("op-live", 0)
+        assert frozen_count == settled_count, (
+            f"body kept animating after settle (leaked timer): "
+            f"{settled_count} → {frozen_count}"
+        )
+        entry = app.query_one(FlowView).entries[0]
+        assert entry.state is EntryState.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_offscreen_running_tool_is_not_animated() -> None:
+    """Tier 2b: an OFF-SCREEN RUNNING tool is not animated (viewport gating).
+
+    ``animate_entry`` auto-pauses when the entry scrolls out of the viewport, and
+    an off-screen entry is not repainted, so a RUNNING tool pushed above the fold
+    neither spins nor recomputes. Push a started tool, then enough later frames to
+    scroll it off the top (a small viewport, STICKY_BOTTOM anchor), confirm it is
+    OFF-SCREEN via the public ``visible_range()``, and assert its present-count is
+    frozen across a pause."""
+    transport = QueueTransport()
+    presenter = _CountingPresenter()  # held locally — assert on its PUBLIC count
+    app = _fast_app(transport=transport, presenter=presenter)
+    async with app.run_test(size=(80, 8)) as pilot:
+        await pilot.pause()
+        await transport.push(_started("op-off"))
+        await pilot.pause(0.1)
+        # Fill past the fold with many later rows, then scroll to the bottom so
+        # the started tool (row 0) is above the visible range.
+        for i in range(40):
+            await transport.push(OutboxMessage(kind="agent", text=f"line {i}"))
+        await pilot.pause()
+        flow = app.query_one(FlowView)
+        flow.scroll_to_bottom()
+        await pilot.pause()
+
+        entries = flow.entries
+        idx = next(i for i, e in enumerate(entries) if e.item.meta.get("op_id") == "op-off")
+        start, stop = flow.visible_range()
+        assert not (start <= idx < stop), (
+            f"precondition: started row must be off-screen, got idx={idx} in [{start},{stop})"
+        )
+
+        baseline = presenter.present_counts.get("op-off", 0)
+        await pilot.pause(0.4)
+        assert presenter.present_counts.get("op-off", 0) == baseline, (
+            "off-screen RUNNING tool was animated (viewport gating failed)"
+        )
+
+
+# ── Gate 4: no regression ─────────────────────────────────────────────────────
+
+def test_gutter_blink_and_body_animation_are_distinct_rates() -> None:
+    """Tier 1: ① (gutter blink) and ② (body spinner) are DISTINCT positive
+    animation rates — ① stays the always-on ``animation_fps`` gutter clock, ② adds
+    a per-entry body cadence. Neither is zero, so both animate."""
+    assert TextualChatApp.ANIMATION_FPS > 0  # ① gutter blink clock (unchanged)
+    assert TextualChatApp.RUNNING_BODY_FPS > 0  # ② per-entry body animation
+
+
+@pytest.mark.asyncio
+async def test_plain_row_is_not_given_a_live_body() -> None:
+    """Tier 2b: a plain (non-tool) row is untouched by ② — no RUNNING marker, no
+    live body — so the plain-fallback turn sequence is unchanged."""
+    app = TextualChatApp(
+        transport=ScriptedTransport([OutboxMessage(kind="agent", text="hello")], end=False)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entry = _entry_by_kind(app, "agent")[0]
+        assert entry.state is EntryState.DEFAULT
+        assert _RUNNING_SINCE_KEY not in (entry.item.meta or {})


### PR DESCRIPTION
**[per-PR-coder]** — Phase ② of the flowview-dynamic-content arc (umbrella #3283): a LIVE animated indicator on RUNNING tool-call rows, settling into a coalesced `tool(args)` + `⎿ result` block on completion. Branched off `main` @8932e7f1 (has ① #3289, alt-screen #3291). `part of #3283` (NOT closes).

## What

Today a RUNNING tool-call row is a static `▸ tool(args)` line (amber gutter). This adds live "working" feedback in the **body** and folds the result into the same entry on completion.

1. **Live indicator (②).** A `tool_call_started` entry entering RUNNING gets a monotonic START marker (`_running_since`) stamped into its item; the presenter then renders `tool(args)` + a `⠙ elapsed Ns` line (reyn's existing `_SPINNER` braille frames + app-computed elapsed) at a **fixed height** (header rows + 1 → no reflow). Driven by a per-entry **`FlowView.animate_entry`** whose tick re-presents the body (`entry.update()`).
   - Tool frames carry **no** elapsed/progress (ADR finding D2) — elapsed derives from the **app-side arrival time** (`self._clock`, injectable), and the indicator is a **spinner (indeterminate)**, not a progress bar.
2. **Settle + coalesce (owner request).** On RUNNING→SUCCESS/ERROR the app **stops the per-entry animation** (`stop_entry_animation`) and **coalesces** the result into the SAME started entry as a `⎿ <result>` sub-line (CC's `⏺ tool(args)` + `⎿ result` block) — **not** a second stacked row. A completion with **no matching `op_id`** still appends its own row (no regression). Failures fold in as a coral `⎿ ✗ …` and tint the row.
3. **Composes with ① + alt-screen.** ① animates the GUTTER glyph off the always-on `animation_fps` clock; ② animates the tool BODY off a per-entry timer. Reuses the existing presenter / `_CC_*` palette / `summarize_tool_result` — no reinvent.

### How `animate_entry` is wired + the re-present cadence
The per-entry `animate_entry(entry, 1/RUNNING_BODY_FPS, lambda e: e.update())` bumps the entry revision each tick; the body re-present materializes on the next viewport paint. In flowview @319cf9e that is **at least** the native `animation_fps` gutter-refresh cadence (its `_tick_animation` → `refresh()` → `_entry_strips` present-on-render-miss re-presents the bumped revision), and **up to** `RUNNING_BODY_FPS` while the conversation is scrolled (the on-screen band is fresh). So the spinner + elapsed always advance; they are simply smoother in a scrolled conversation. The spinner frame + elapsed are read from the injectable clock inside `present()`, so successive re-presents differ.

### Completion settle + release
`_ingest_frame` routes a correlated `tool_call_completed`/`tool_call_failed` to `_coalesce_tool_result(started, msg)`: `stop_entry_animation(started)` (releases the per-entry timer + visibility tracker — no leaked handle; the app holds no per-entry handle collection of its own), then `set_item` folds the result in (stripping `_running_since`, stashing `_result_kind`/`_result`) and sets SUCCESS/ERROR. Off-screen RUNNING tools are auto-paused by `animate_entry` (viewport-gated) and not repainted.

## Test plan (gates)

- [x] **(1) Live indicator, non-vacuous** — `test_running_tool_body_advances_as_the_clock_advances`: a RUNNING body rendered at two clock readings differs (elapsed 2s→7s, spinner frame advances), fixed height 2. **Non-vacuity strip**: `test_frozen_clock_leaves_a_static_running_body` — same instant twice → identical body (a frozen clock → the positive test would go RED).
- [x] **(2) Settle on completion** — `test_app_marks_running_body_live_then_coalesces_on_success` (marker present + spinner while RUNNING → marker stripped + `⎿` result + no spinner on SUCCESS) and `test_app_coalesces_a_failure_and_tints_it` (coral `⎿ ✗` + `_CC_ERR` background on ERROR).
- [x] **(3) Viewport-gated / no leak** — `test_running_body_animates_live_then_stops_on_settle`: a real counting `ReynPresenter` subclass shows the RUNNING body re-presents live (≥3 presents) then FREEZES after settle (leaked timer would keep climbing). `test_offscreen_running_tool_is_not_animated`: a started row scrolled off-screen (confirmed via public `visible_range()`) has a frozen present-count.
- [x] **(4) No regression** — `test_gutter_blink_and_body_animation_are_distinct_rates` (① and ② rates both > 0); `test_plain_row_is_not_given_a_live_body`; all 60 existing textual_chat phase1–5 tests pass; import-isolation + plain-fallback preserved.
- [x] **(5) Tool+result coalesce** — `test_correlated_pair_coalesces_into_exactly_one_entry` (started+completed → exactly one `tool_call_started` entry carrying the `⎿` result) and `test_uncorrelated_result_still_appends_its_own_entry` (completed with no matching op_id → its own row). Retargeted phase-2 `test_running_to_error_...` to the coalesced single entry.

## CI gates (all green locally, worktree venv, CI extras)

- `ruff check` — All checks passed.
- `test_tier_audit.py --strict` (changed test files) — 21 tests, 0 errors.
- `python -m pytest --timeout=120` (repo root) — **9119 passed, 36 skipped, 0 failures** (9m16s).
- `verify_module_docstrings.py` (changed src) — OK.

## Docs
Updated in the same PR (app/presenter module + class docstrings describe the live body + coalesce settle). No user-facing doc describes the tool-row rendering (it lives in the app docstrings). Restore path unchanged — it already projects a single `tool_call_completed` row (never a started+completed pair), so nothing to coalesce there.

## Scope
OUT: ③ streaming (separate arc #3288), ④ right gutter (owner-deferred). Only the RUNNING-tool live spinner+elapsed + the owner-requested completion coalesce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)