### PR TITLE
fix(tui): restore projects coalesced tool call+result (no orphan ⎿) — #3283

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
+++ b/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
@@ -1,0 +1,31 @@
+"""Shared display-frame ``meta`` key constants for the coalesced tool-call shape.
+
+:data:`RESULT_KIND_KEY` / :data:`RESULT_META_KEY` are the two meta keys that
+mark a ``tool_call_started`` display frame as SETTLED (coalesced) — i.e. its
+result has been folded into the same entry rather than appended as a separate
+row. Two producers stamp this shape and must agree on the exact key strings:
+
+- ``app.py``'s ``_coalesce_tool_result`` (the LIVE path — a RUNNING started
+  entry settles in place when its completion frame arrives).
+- ``restore.py``'s :func:`~reyn.interfaces.inline.textual_chat.restore.project_restored_frames`
+  (the RESTORE path — a persisted tool result is projected straight into the
+  same coalesced shape so a restored turn reads identically to a live one).
+
+``restore.py`` MUST stay import-pure (no ``textual`` / ``textual_flowview`` —
+see its module docstring), so these two plain ``str`` constants live in this
+tiny textual-free module rather than in ``presenter.py`` (which imports
+``textual_flowview``). ``presenter.py`` re-exports the same names so existing
+importers are unaffected.
+"""
+from __future__ import annotations
+
+#: Present on a ``tool_call_started`` frame's ``meta`` once it has settled —
+#: the value is the ORIGINAL completion frame's ``kind``
+#: (``"tool_call_completed"`` / ``"tool_call_failed"``).
+RESULT_KIND_KEY = "_result_kind"
+
+#: Present alongside :data:`RESULT_KIND_KEY` — the ORIGINAL completion
+#: frame's ``meta`` (carries ``result`` / ``error_message`` / ``error_kind``).
+RESULT_META_KEY = "_result"
+
+__all__ = ["RESULT_KIND_KEY", "RESULT_META_KEY"]

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -464,15 +464,19 @@ class TextualChatApp(App):
         (:meth:`~reyn.interfaces.repl.read_model.ChatReadModel.conversation_history`
         — ``history.jsonl``, NOT the P6 audit-event log) and appends each projected
         frame to ``self.conversation`` (:func:`.restore.project_restored_frames`).
-        Every restored entry is RESOLVED, never RUNNING: a completed tool result
-        gets the SUCCESS/ERROR lifecycle state the live path's completion handler
-        (:meth:`_coalesce_tool_result`) would have assigned, and user/agent rows
-        keep DEFAULT (their live state). Restore projects a standalone
-        ``tool_call_completed`` row (never a started+completed pair), so there is
-        nothing to coalesce here — it renders as its own settled result row. A REMOTE read model returns an empty log
-        (frame-sufficiency: past turns are not on the wire) → this is a no-op and
-        the pane starts blank, exactly as before. Fully guarded — a restore
-        failure must never stop the app from mounting and pumping live frames."""
+        Every restored entry is RESOLVED, never RUNNING: a restored tool turn is
+        already projected into the SAME coalesced ``tool_call_started`` shape
+        the live path's :meth:`_coalesce_tool_result` settles a completed tool
+        into (call header + folded result, one entry — see
+        ``restore.project_restored_frames``'s docstring), so this method just
+        derives the terminal SUCCESS/ERROR state from the coalesced result
+        (the ``if msg.kind == "tool_call_completed"`` branch a pre-coalesce
+        restore shape would have hit no longer fires for tool rows; user/agent
+        rows keep DEFAULT, their live state). A REMOTE read model returns an
+        empty log (frame-sufficiency: past turns are not on the wire) → this is
+        a no-op and the pane starts blank, exactly as before. Fully guarded — a
+        restore failure must never stop the app from mounting and pumping live
+        frames."""
         if self._read_model is None:
             return
         try:
@@ -497,7 +501,20 @@ class TextualChatApp(App):
             # transition for a settled tool result (SUCCESS unless the summary
             # marks a failure); non-tool rows keep DEFAULT.
             meta = msg.meta or {}
-            if msg.kind == "tool_call_completed":
+            if msg.kind == "tool_call_started" and _RESULT_KIND_KEY in meta:
+                result_meta = meta.get(_RESULT_META_KEY) or {}
+                if meta[_RESULT_KIND_KEY] == "tool_call_failed":
+                    entry.set_state(EntryState.ERROR)
+                else:
+                    summary = summarize_tool_result(
+                        meta.get("tool"), result_meta.get("result")
+                    )
+                    entry.set_state(
+                        EntryState.ERROR
+                        if summary.startswith("✗")
+                        else EntryState.SUCCESS
+                    )
+            elif msg.kind == "tool_call_completed":
                 summary = summarize_tool_result(meta.get("tool"), meta.get("result"))
                 entry.set_state(
                     EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -34,6 +34,9 @@ from reyn.interfaces.repl.renderer import (
     summarize_tool_result,
 )
 
+from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
+from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
+
 if TYPE_CHECKING:
     from reyn.runtime.outbox import OutboxMessage
 
@@ -63,8 +66,10 @@ _SPINNER_SPEED = 8
 # under the ``tool(args)`` header. A completion with no matching started entry is
 # still appended as its own row (kept via :func:`_body_and_background`'s
 # ``tool_call_completed`` / ``tool_call_failed`` branches), so nothing regresses.
-_RESULT_KIND_KEY = "_result_kind"
-_RESULT_META_KEY = "_result"
+# The restore path (``restore.py``) stamps the SAME two keys onto its projected
+# frames so a restored tool turn coalesces identically — both modules import
+# the string values from ``_meta_keys`` (restore.py must stay textual-free, so
+# the constants live there rather than here).
 
 # --- choice-intervention chip layout ---------------------------------------
 # A closed-set intervention (permission confirm / choice ``ask_user`` — anything

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -26,22 +26,36 @@ events) does not apply here: there is no WAL-derived state to lose. If a future
 change makes any restored surface WAL-reconstructed rather than read straight
 from the ChatMessage log, that gate WOULD apply and this note must be revisited.
 
-**Resolved, never RUNNING.** A restored tool result is a SETTLED outcome, so it
-projects to a ``tool_call_completed`` frame; the caller (``_hydrate_from_history``)
-gives it the SUCCESS/ERROR lifecycle state the live path's completion handler
-would have, derived from the SAME ``summarize_tool_result`` the presenter reads —
-so gutter colour and body agree. The transient ``tool_call_started`` progress
-header (a live-pump affordance with no meaning in a static restore) is
-intentionally omitted, and the ``system`` / ``summary`` roles are Reyn-internal
-chrome (filtered at the LLM wire boundary), so both are skipped.
+**Coalesced, resolved, never RUNNING.** A restored tool result is a SETTLED
+outcome and is projected into the SAME coalesced shape the LIVE path settles a
+completed tool into (``app.py``'s ``_coalesce_tool_result``): a single
+``kind="tool_call_started"`` frame whose ``meta`` carries both the ORIGINAL
+tool call (``tool`` / ``args``, correlated from the preceding assistant
+message's ``tool_calls`` by ``tool_call_id``) and the result, stashed under
+``RESULT_KIND_KEY`` / ``RESULT_META_KEY`` (:mod:`._meta_keys`). The presenter's
+existing ``tool_call_started`` branch renders this as ONE block —
+``⏺ tool(args)`` + ``⎿ result`` — with no presenter change needed, so a
+restored tool turn is visually identical to a live settled one (no orphan
+``⎿``-only row). An uncorrelated result (no matching ``tool_call_id`` — e.g.
+truncated history) still projects to the same coalesced shape with just the
+tool name as header (empty args) — it never regresses to an orphan row. The
+caller (``_hydrate_from_history``) gives the entry the SUCCESS/ERROR lifecycle
+state the live path's completion handler would have, derived from the SAME
+``summarize_tool_result`` the presenter reads, so gutter colour and body
+agree. The ``system`` / ``summary`` roles are Reyn-internal chrome (filtered
+at the LLM wire boundary), so both are skipped.
 
-This module imports only :class:`~reyn.runtime.outbox.OutboxMessage` (no
-``textual`` / ``textual_flowview``): the projection is pure and unit-testable
-without mounting the app.
+This module imports only :class:`~reyn.runtime.outbox.OutboxMessage` and the
+plain ``str`` constants in :mod:`._meta_keys` (no ``textual`` /
+``textual_flowview``): the projection is pure and unit-testable without
+mounting the app.
 """
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
+
+from ._meta_keys import RESULT_KIND_KEY, RESULT_META_KEY
 
 if TYPE_CHECKING:
     from reyn.runtime.chat_message import ChatMessage
@@ -64,6 +78,39 @@ RESTORED_META_KEY = "_restored"
 _RESUME_DIVIDER = "⤺ resumed previous conversation"
 
 
+def _correlated_calls(messages: "list[ChatMessage]") -> "dict[str, dict]":
+    """Map ``tool_call_id -> {"name": ..., "args": ...}`` from assistant turns.
+
+    Every ``role=="assistant"`` message's ``.tool_calls`` (a
+    ``list[dict]`` of ``{"id": <tool_call_id>, "function": {"name": ...,
+    "arguments": <json str>}}``) contributes one entry per call. ``arguments``
+    is parsed defensively — a malformed / non-JSON string falls back to the
+    raw string, never raises — so a corrupt history entry degrades to a
+    plain-text arg summary rather than crashing the projection.
+    """
+    calls: "dict[str, dict]" = {}
+    for m in messages:
+        if m.role != "assistant" or not m.tool_calls:
+            continue
+        for call in m.tool_calls:
+            call_id = call.get("id")
+            if not call_id:
+                continue
+            fn = call.get("function") or {}
+            name = fn.get("name")
+            raw_args = fn.get("arguments")
+            args: object = {}
+            if isinstance(raw_args, str) and raw_args:
+                try:
+                    args = json.loads(raw_args)
+                except (ValueError, TypeError):
+                    args = raw_args
+            elif raw_args is not None:
+                args = raw_args
+            calls[call_id] = {"name": name, "args": args}
+    return calls
+
+
 def project_restored_frames(
     messages: "list[ChatMessage]",
 ) -> "list[OutboxMessage]":
@@ -73,19 +120,28 @@ def project_restored_frames(
 
     - ``user`` (non-empty text)      → ``kind="user"``
     - ``assistant`` (non-empty text) → ``kind="agent"``
-    - ``tool`` (a tool RESULT)       → ``kind="tool_call_completed"`` carrying
-      ``meta["tool"]`` / ``meta["result"]`` for the presenter's result summary
+    - ``tool`` (a tool RESULT)       → a SINGLE ``kind="tool_call_started"``
+      frame carrying the coalesced call+result shape (see the module
+      docstring): ``meta["tool"]`` / ``meta["args"]`` (correlated from the
+      preceding assistant message's ``tool_calls`` by ``tool_call_id``,
+      falling back to ``m.name`` / empty args when uncorrelated) plus
+      ``RESULT_KIND_KEY="tool_call_completed"`` and
+      ``RESULT_META_KEY={"result": m.text}``.
     - ``system`` / ``summary``       → skipped (internal chrome)
 
-    A ``tool_call_started`` header is NOT emitted (a live-progress affordance
-    with no meaning in a static restore). Every frame is stamped
-    ``meta[RESTORED_META_KEY]=True``. Returns ``[]`` for an empty log (no
-    divider), so a first-ever run stays blank.
+    An assistant message carrying ONLY ``tool_calls`` (empty text) produces no
+    ``agent`` frame of its own — the call header is delivered entirely through
+    the coalesced ``tool`` projection above, matching how the live coalesce
+    path folds a call into its result rather than emitting two rows.
+
+    Every frame is stamped ``meta[RESTORED_META_KEY]=True``. Returns ``[]``
+    for an empty log (no divider), so a first-ever run stays blank.
     """
     from reyn.runtime.outbox import (
         OutboxMessage,  # noqa: PLC0415 — keep module textual-free at import
     )
 
+    calls_by_id = _correlated_calls(messages)
     frames: "list[OutboxMessage]" = []
     for m in messages:
         role = m.role
@@ -104,14 +160,18 @@ def project_restored_frames(
                     OutboxMessage(kind="agent", text=text, meta={RESTORED_META_KEY: True})
                 )
         elif role == "tool":
+            call = calls_by_id.get(m.tool_call_id or "", {})
+            tool_name = call.get("name") or m.name
             frames.append(
                 OutboxMessage(
-                    kind="tool_call_completed",
-                    text=m.name or "",
+                    kind="tool_call_started",
+                    text=tool_name or "",
                     meta={
                         RESTORED_META_KEY: True,
-                        "tool": m.name,
-                        "result": m.text,
+                        "tool": tool_name,
+                        "args": call.get("args") or {},
+                        RESULT_KIND_KEY: "tool_call_completed",
+                        RESULT_META_KEY: {"result": m.text},
                     },
                 )
             )

--- a/tests/test_textual_chat_phase5_3273.py
+++ b/tests/test_textual_chat_phase5_3273.py
@@ -38,6 +38,10 @@ import pytest
 from textual_flowview import EntryState, FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat._meta_keys import (
+    RESULT_KIND_KEY,
+    RESULT_META_KEY,
+)
 from reyn.interfaces.inline.textual_chat.restore import (
     RESTORED_META_KEY,
     project_restored_frames,
@@ -139,13 +143,32 @@ def _entries(app: TextualChatApp):
     return list(app.query_one(FlowView).entries)
 
 
-# A fixture conversation log: a user turn, an assistant reply, a tool result, and
-# a trailing turn — plus a ``system`` and a ``summary`` entry that must NOT
-# surface (internal chrome, filtered at the LLM wire boundary).
+# A fixture conversation log: a user turn, an assistant reply, a CORRELATED tool
+# call+result (a real tool name + real non-empty args, per the round-trip
+# non-default-value requirement), and a trailing turn — plus a ``system`` and a
+# ``summary`` entry that must NOT surface (internal chrome, filtered at the LLM
+# wire boundary). The tool-calling assistant turn carries only ``tool_calls``
+# (empty text) — matching how the LLM actually emits a call — so it contributes
+# no standalone ``agent`` frame; the call header reaches the display entirely
+# through the coalesced ``tool`` projection.
 def _fixture_log() -> "list[ChatMessage]":
     return [
         ChatMessage(role="user", content="first question"),
         ChatMessage(role="assistant", content="first answer"),
+        ChatMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "file__read",
+                        "arguments": '{"path": "foo.py", "limit": 42}',
+                    },
+                }
+            ],
+        ),
         ChatMessage(
             role="tool", content="Read 42 lines", name="file__read",
             tool_call_id="call_1",
@@ -160,32 +183,65 @@ def _fixture_log() -> "list[ChatMessage]":
 
 
 def test_projection_maps_roles_preserves_order_and_names_source() -> None:
-    """Tier 1: ``project_restored_frames`` maps user→user, assistant→agent,
-    tool→tool_call_completed, preserving conversation order, and skips the
-    internal ``system``/``summary`` roles. Its input is the ``ChatMessage`` log
-    (NOT audit-events) — the projection consumes ``ChatMessage`` values only."""
+    """Tier 1: ``project_restored_frames`` maps user→user, assistant→agent, and a
+    correlated tool call+result → a SINGLE coalesced ``tool_call_started`` frame
+    (call header + folded result, matching the live-coalesce shape — no orphan
+    ``tool_call_completed`` row), preserving conversation order and skipping the
+    internal ``system``/``summary`` roles plus the tool-calling assistant turn's
+    own (empty-text) row. Its input is the ``ChatMessage`` log (NOT
+    audit-events) — the projection consumes ``ChatMessage`` values only."""
     frames = project_restored_frames(_fixture_log())
-    # Leading resume divider (system) then the conversation, summary dropped.
+    # Leading resume divider (system) then the conversation, summary dropped,
+    # and the tool-calling assistant turn contributes no standalone row.
     kinds = [f.kind for f in frames]
     assert kinds == [
         "system",  # ⤺ resume divider
-        "user", "agent", "tool_call_completed", "user", "agent",
+        "user", "agent", "tool_call_started", "user", "agent",
     ], f"unexpected projection kinds: {kinds}"
+    # No orphan tool_call_completed frame anywhere in the projection.
+    assert "tool_call_completed" not in kinds
+
     # Order + text preserved for the conversational rows.
     convo = [(f.kind, f.text) for f in frames if f.kind != "system"]
     assert convo == [
         ("user", "first question"),
         ("agent", "first answer"),
-        ("tool_call_completed", "file__read"),
+        ("tool_call_started", "file__read"),
         ("user", "second question"),
         ("agent", "second answer"),
     ]
-    # The tool row carries the result summary meta the presenter reads.
-    tool = next(f for f in frames if f.kind == "tool_call_completed")
+    # The coalesced tool row carries BOTH the correlated call (a REAL non-default
+    # tool name + non-empty args, correlated by tool_call_id) AND the result.
+    tool = next(f for f in frames if f.kind == "tool_call_started")
     assert tool.meta.get("tool") == "file__read"
-    assert tool.meta.get("result") == "Read 42 lines"
+    assert tool.meta.get("args") == {"path": "foo.py", "limit": 42}
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_completed"
+    assert tool.meta.get(RESULT_META_KEY) == {"result": "Read 42 lines"}
     # Every restored frame is marked as such.
     assert all(f.meta.get(RESTORED_META_KEY) is True for f in frames)
+
+
+def test_projection_uncorrelated_tool_result_still_yields_header() -> None:
+    """Tier 1: non-vacuity — a tool result with NO matching ``tool_call_id`` (e.g.
+    truncated history: the correlating assistant turn is gone) still projects to
+    the coalesced shape with the tool NAME as header (empty args), never an
+    orphan ``⎿``-only row (``tool_call_completed`` with no call)."""
+    frames = project_restored_frames([
+        ChatMessage(
+            role="tool", content="orphaned result", name="shell__run",
+            tool_call_id="missing_call",
+        ),
+    ])
+    tool_frames = [f for f in frames if f.kind != "system"]
+    assert [f.kind for f in tool_frames] == ["tool_call_started"], (
+        "an uncorrelated tool result must still project to exactly one "
+        f"coalesced tool_call_started frame, got kinds={[f.kind for f in tool_frames]}"
+    )
+    tool = tool_frames[0]
+    assert tool.meta.get("tool") == "shell__run"
+    assert tool.meta.get("args") == {}
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_completed"
+    assert tool.meta.get(RESULT_META_KEY) == {"result": "orphaned result"}
 
 
 def test_projection_empty_log_yields_no_frames_no_divider() -> None:
@@ -229,7 +285,7 @@ async def test_restart_shows_previous_conversation_before_live_frames() -> None:
             ("system", "⤺ resumed previous conversation"),
             ("user", "first question"),
             ("agent", "first answer"),
-            ("tool_call_completed", "file__read"),
+            ("tool_call_started", "file__read"),
             ("user", "second question"),
             ("agent", "second answer"),
             ("user", "LIVE turn after restart"),
@@ -255,7 +311,7 @@ async def test_restored_entries_render_resolved_never_running() -> None:
         assert all(e.state is not EntryState.RUNNING for e in entries), (
             "a restored turn is RUNNING — settled past turns must be resolved"
         )
-        tool = next(e for e in entries if e.item.kind == "tool_call_completed")
+        tool = next(e for e in entries if e.item.kind == "tool_call_started")
         assert tool.state is EntryState.SUCCESS, "restored tool result not resolved to SUCCESS"
 
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #3283

## Bug

On `reyn chat` restart, a restored tool turn rendered as an orphan `⎿ result` row with no `⏺ tool(args)` header above it — not a live event loss, a restore-projection gap. `project_restored_frames` (`restore.py`) projected each `role=="tool"` `ChatMessage` into a standalone `kind="tool_call_completed"` frame carrying only the result; the presenter's `tool_call_completed` branch renders only the result summary, never a header.

## Fix

Since #3294 the LIVE path settles a completed tool by *coalescing* the result into its `RUNNING` started entry — one `tool_call_started` frame whose meta carries both the call and the result under `_result_kind` / `_result`. Restore now projects the SAME shape:

- `project_restored_frames` builds a `tool_call_id -> {name, args}` correlation map from every `role=="assistant"` message's `.tool_calls` (parsing the JSON `arguments` string defensively — malformed JSON falls back to the raw string, never raises).
- Each `role=="tool"` result message emits a SINGLE `kind="tool_call_started"` frame: `meta["tool"]`/`meta["args"]` from the correlated call (or just the tool name with empty args when uncorrelated — e.g. truncated history), plus `RESULT_KIND_KEY="tool_call_completed"` / `RESULT_META_KEY={"result": ...}`. This renders through the EXISTING presenter `tool_call_started` branch as one coalesced `⏺ tool(args)` + `⎿ result` block — no presenter change needed for the happy path.
- `_hydrate_from_history` (app.py) now derives the terminal SUCCESS/ERROR state from the coalesced result shape (the old `tool_call_completed`-kind branch no longer fires for tool rows; kept as a defensive fallback).

### (a) Textual-free seam

`restore.py` must stay import-pure (no `textual` / `textual_flowview` — see its module docstring + the `test_phase5_accessor_imports_stay_tty_only` isolation gate). The two shared meta-key string constants (`_RESULT_KIND_KEY` / `_RESULT_META_KEY`) previously lived only in `presenter.py` (which imports `textual_flowview`), so I moved them to a new tiny `_meta_keys.py` (stdlib-only, plain `str` constants) that both `restore.py` and `presenter.py` import — `presenter.py` re-exports the same private names so its own call sites are unchanged.

### (b) Docstring drift (CLAUDE.md hard rule)

`restore.py`'s module docstring and `project_restored_frames`'s docstring previously asserted the tool-call header is "intentionally omitted" and that a tool result maps to `tool_call_completed`. Both claims are now false — rewrote both sections to describe the coalesced projection accurately, including the uncorrelated-result behavior. `app.py`'s `_hydrate_from_history` docstring was also updated (it previously said restore "renders as its own settled result row", no longer true).

### (c) Non-vacuity — correlated vs uncorrelated

- `test_projection_maps_roles_preserves_order_and_names_source`: a real fixture (`file__read` tool, non-default args `{"path": "foo.py", "limit": 42}`) round-trips through a CORRELATED assistant `tool_calls` entry → asserts the single coalesced frame carries BOTH the call (tool+args) and the result, and asserts NO `tool_call_completed` frame appears anywhere in the projection.
- `test_projection_uncorrelated_tool_result_still_yields_header`: a tool result with no matching `tool_call_id` (simulating truncated history) still projects to the coalesced shape with the tool name as header and empty args — never an orphan `⎿`-only row.
- Existing app-level tests (`test_restart_shows_previous_conversation_before_live_frames`, `test_restored_entries_render_resolved_never_running`) retargeted from asserting `tool_call_completed` to `tool_call_started`.

### (d) Four CI gates (foreground, from worktree root)

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase5_3273.py` — 11/11 OK, 0 Tier-4 violations.
- `uv run python -m pytest --timeout=120` (full suite, not a subset) — **9120 passed, 36 skipped**, 0 failures.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK, no narrative violations.

## Test plan

- [x] `project_restored_frames` correlated-call test passes (call+result coalesced, no orphan `tool_call_completed`)
- [x] Uncorrelated-result non-vacuity test passes (header present, empty args)
- [x] Full pytest suite green (9120 passed / 36 skipped)
- [x] ruff clean
- [x] test-tier audit clean
- [x] module-docstring gate clean