### PR TITLE
fix(tui): restore preserves failed-tool classification via typed persist flag — #73

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -32,18 +32,27 @@ completed tool into (``app.py``'s ``_coalesce_tool_result``): a single
 ``kind="tool_call_started"`` frame whose ``meta`` carries both the ORIGINAL
 tool call (``tool`` / ``args``, correlated from the preceding assistant
 message's ``tool_calls`` by ``tool_call_id``) and the result, stashed under
-``RESULT_KIND_KEY`` / ``RESULT_META_KEY`` (:mod:`._meta_keys`). The presenter's
-existing ``tool_call_started`` branch renders this as ONE block —
-``⏺ tool(args)`` + ``⎿ result`` — with no presenter change needed, so a
+``RESULT_KIND_KEY`` / ``RESULT_META_KEY`` (:mod:`._meta_keys`). ``RESULT_KIND_KEY``
+is ``"tool_call_completed"`` for a genuine success, or ``"tool_call_failed"``
+when the persisted result string matches the tool-result renderer's failure
+contract (:func:`_detect_failure` — a raised-exception failure never reaches
+here, since that already produces a distinct ``ChatMessage``; a STRUCTURED
+failure like ``file__read`` on a missing path is a normal ``role="tool"``
+message whose text renders as ``"Error (<kind>): <message>"`` /
+``"Error: <text>"``, the ONLY two shapes the renderer ever emits for a
+failure), so a restored failed tool tints coral exactly like a live one — #73.
+The presenter's existing ``tool_call_started`` branch renders this as ONE
+block — ``⏺ tool(args)`` + ``⎿ result`` — with no presenter change needed, so a
 restored tool turn is visually identical to a live settled one (no orphan
 ``⎿``-only row). An uncorrelated result (no matching ``tool_call_id`` — e.g.
 truncated history) still projects to the same coalesced shape with just the
 tool name as header (empty args) — it never regresses to an orphan row. The
 caller (``_hydrate_from_history``) gives the entry the SUCCESS/ERROR lifecycle
-state the live path's completion handler would have, derived from the SAME
-``summarize_tool_result`` the presenter reads, so gutter colour and body
-agree. The ``system`` / ``summary`` roles are Reyn-internal chrome (filtered
-at the LLM wire boundary), so both are skipped.
+state the live path's completion handler would have: ``ERROR`` directly when
+``RESULT_KIND_KEY=="tool_call_failed"``, else derived from the SAME
+``summarize_tool_result`` the presenter reads — so gutter colour and body
+agree either way. The ``system`` / ``summary`` roles are Reyn-internal chrome
+(filtered at the LLM wire boundary), so both are skipped.
 
 This module imports only :class:`~reyn.runtime.outbox.OutboxMessage` and the
 plain ``str`` constants in :mod:`._meta_keys` (no ``textual`` /
@@ -53,6 +62,7 @@ mounting the app.
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 
 from ._meta_keys import RESULT_KIND_KEY, RESULT_META_KEY
@@ -76,6 +86,41 @@ RESTORED_META_KEY = "_restored"
 #: conversation (operator legibility — the Product-Think lens). Emitted once,
 #: only when there is at least one restored turn.
 _RESUME_DIVIDER = "⤺ resumed previous conversation"
+
+# A persisted ``role="tool"`` failure is NEVER JSON — the LLM-visible tool-result
+# renderer (``reyn.core.offload.seam`` / ``router_loop.py``'s tool-result assembly)
+# writes a genuine failure as one of exactly two plain-string shapes and nothing
+# else: ``f"Error ({kind}): {message}"`` for a dispatch-envelope error
+# (``{"status": "error", "error": {"kind": ..., "message": ...}}``), or
+# ``f"Error: {text}"`` for an MCP ``isError``. Per that module's own docstring,
+# "Success and error are syntactically distinguishable with no status field" —
+# these two literal PREFIXES are the renderer's documented, exhaustive failure
+# contract, not a substring guess: a benign result that merely CONTAINS the word
+# "error" elsewhere in its body does not start with either prefix and is left
+# alone (a successful grep for the word "error" is unaffected).
+_ERROR_KIND_RE = re.compile(r"^Error \(([^)]*)\): ", re.DOTALL)
+_ERROR_PLAIN_PREFIX = "Error: "
+
+
+def _detect_failure(text: str) -> "dict[str, str] | None":
+    """Read a persisted tool-result string against the renderer's failure
+    contract (see the module comment above ``_ERROR_KIND_RE``).
+
+    Returns a dict for :data:`~._meta_keys.RESULT_META_KEY` — either
+    ``{"error_kind": ..., "error_message": ...}`` (dispatch-envelope error) or
+    ``{"error_message": ...}`` (MCP ``isError``) — or ``None`` when ``text``
+    does not match either prefix (a success, including one whose body happens
+    to mention "error" mid-text).
+    """
+    kind_match = _ERROR_KIND_RE.match(text)
+    if kind_match:
+        return {
+            "error_kind": kind_match.group(1) or "error",
+            "error_message": text[kind_match.end():],
+        }
+    if text.startswith(_ERROR_PLAIN_PREFIX):
+        return {"error_message": text[len(_ERROR_PLAIN_PREFIX):]}
+    return None
 
 
 def _correlated_calls(messages: "list[ChatMessage]") -> "dict[str, dict]":
@@ -126,7 +171,12 @@ def project_restored_frames(
       preceding assistant message's ``tool_calls`` by ``tool_call_id``,
       falling back to ``m.name`` / empty args when uncorrelated) plus
       ``RESULT_KIND_KEY="tool_call_completed"`` and
-      ``RESULT_META_KEY={"result": m.text}``.
+      ``RESULT_META_KEY={"result": m.text}`` for a SUCCESS, or
+      ``RESULT_KIND_KEY="tool_call_failed"`` and
+      ``RESULT_META_KEY={"error_kind": ..., "error_message": ...}`` (or just
+      ``{"error_message": ...}``) for a FAILURE — detected by matching ``m.text``
+      against the tool-result renderer's exhaustive failure contract
+      (:func:`_detect_failure`; #73).
     - ``system`` / ``summary``       → skipped (internal chrome)
 
     An assistant message carrying ONLY ``tool_calls`` (empty text) produces no
@@ -162,6 +212,13 @@ def project_restored_frames(
         elif role == "tool":
             call = calls_by_id.get(m.tool_call_id or "", {})
             tool_name = call.get("name") or m.name
+            failure = _detect_failure(m.text)
+            if failure is not None:
+                result_kind = "tool_call_failed"
+                result_meta: "dict[str, object]" = dict(failure)
+            else:
+                result_kind = "tool_call_completed"
+                result_meta = {"result": m.text}
             frames.append(
                 OutboxMessage(
                     kind="tool_call_started",
@@ -170,8 +227,8 @@ def project_restored_frames(
                         RESTORED_META_KEY: True,
                         "tool": tool_name,
                         "args": call.get("args") or {},
-                        RESULT_KIND_KEY: "tool_call_completed",
-                        RESULT_META_KEY: {"result": m.text},
+                        RESULT_KIND_KEY: result_kind,
+                        RESULT_META_KEY: result_meta,
                     },
                 )
             )

--- a/src/reyn/interfaces/inline/textual_chat/restore.py
+++ b/src/reyn/interfaces/inline/textual_chat/restore.py
@@ -34,36 +34,60 @@ tool call (``tool`` / ``args``, correlated from the preceding assistant
 message's ``tool_calls`` by ``tool_call_id``) and the result, stashed under
 ``RESULT_KIND_KEY`` / ``RESULT_META_KEY`` (:mod:`._meta_keys`). ``RESULT_KIND_KEY``
 is ``"tool_call_completed"`` for a genuine success, or ``"tool_call_failed"``
-when the persisted result string matches the tool-result renderer's failure
-contract (:func:`_detect_failure` — a raised-exception failure never reaches
-here, since that already produces a distinct ``ChatMessage``; a STRUCTURED
-failure like ``file__read`` on a missing path is a normal ``role="tool"``
-message whose text renders as ``"Error (<kind>): <message>"`` /
-``"Error: <text>"``, the ONLY two shapes the renderer ever emits for a
-failure), so a restored failed tool tints coral exactly like a live one — #73.
-The presenter's existing ``tool_call_started`` branch renders this as ONE
-block — ``⏺ tool(args)`` + ``⎿ result`` — with no presenter change needed, so a
-restored tool turn is visually identical to a live settled one (no orphan
-``⎿``-only row). An uncorrelated result (no matching ``tool_call_id`` — e.g.
-truncated history) still projects to the same coalesced shape with just the
-tool name as header (empty args) — it never regresses to an orphan row. The
-caller (``_hydrate_from_history``) gives the entry the SUCCESS/ERROR lifecycle
-state the live path's completion handler would have: ``ERROR`` directly when
-``RESULT_KIND_KEY=="tool_call_failed"``, else derived from the SAME
-``summarize_tool_result`` the presenter reads — so gutter colour and body
-agree either way. The ``system`` / ``summary`` roles are Reyn-internal chrome
-(filtered at the LLM wire boundary), so both are skipped.
+when the persisted ``ChatMessage.meta`` carries the TYPED
+``TOOL_STATUS_META_KEY == TOOL_STATUS_ERROR`` flag (:mod:`reyn.runtime.chat_message`;
+#73) — a raised-exception failure never reaches here, since that already
+produces a distinct ``ChatMessage``. That flag is stamped at PERSIST time by
+``router_loop.py``'s tool-result assembly, the ONE place that already knows
+the success/failure classification (a dispatch-envelope
+``{"status":"error",...}`` or an MCP ``isError`` result) — this projection
+reads it directly rather than re-deriving it from the rendered result STRING
+(a display string is a renderer/formatting concern, not a stable data
+contract: a legitimate success payload can itself start with the word
+"Error"). A pre-#73 persisted history has no such flag at all — ABSENCE is
+read as success/completed (never inferred as failure), so old history reads
+exactly as it always has. So a restored failed tool tints coral exactly like
+a live one. The presenter's existing ``tool_call_started`` branch renders
+this as ONE block — ``⏺ tool(args)`` + ``⎿ result`` — with no presenter
+change needed, so a restored tool turn is visually identical to a live
+settled one (no orphan ``⎿``-only row). An uncorrelated result (no matching
+``tool_call_id`` — e.g. truncated history) still projects to the same
+coalesced shape with just the tool name as header (empty args) — it never
+regresses to an orphan row. The caller (``_hydrate_from_history``) gives the
+entry the SUCCESS/ERROR lifecycle state the live path's completion handler
+would have: ``ERROR`` directly when ``RESULT_KIND_KEY=="tool_call_failed"``,
+else derived from the SAME ``summarize_tool_result`` the presenter reads —
+so gutter colour and body agree either way. The ``system`` / ``summary``
+roles are Reyn-internal chrome (filtered at the LLM wire boundary), so both
+are skipped.
 
-This module imports only :class:`~reyn.runtime.outbox.OutboxMessage` and the
-plain ``str`` constants in :mod:`._meta_keys` (no ``textual`` /
+**Recovery implication (truncate-falsify gate N/A for the typed flag too).**
+``TOOL_STATUS_META_KEY`` is written straight into the persisted ``ChatMessage``
+at the SAME time ``content`` is (``router_loop.py``'s ``append_history_entry``
+call) — it is authoritative-at-write, exactly like the rest of the message,
+NOT WAL-event-reconstructed derived state. The CLAUDE.md recovery-feature
+truncate-falsify gate therefore does not apply to it any more than it applies
+to ``content`` or ``tool_call_id`` (see the "Non-authoritative projection"
+note above) — there is no WAL-derived reconstruction step in between that
+could silently drop the flag.
+
+This module imports only :class:`~reyn.runtime.outbox.OutboxMessage`, the
+plain ``str`` constants in :mod:`._meta_keys`, and the plain ``str`` /
+``dataclass`` constants in :mod:`reyn.runtime.chat_message` (no ``textual`` /
 ``textual_flowview``): the projection is pure and unit-testable without
 mounting the app.
 """
 from __future__ import annotations
 
 import json
-import re
 from typing import TYPE_CHECKING
+
+from reyn.runtime.chat_message import (
+    TOOL_ERROR_KIND_META_KEY,
+    TOOL_ERROR_MESSAGE_META_KEY,
+    TOOL_STATUS_ERROR,
+    TOOL_STATUS_META_KEY,
+)
 
 from ._meta_keys import RESULT_KIND_KEY, RESULT_META_KEY
 
@@ -87,40 +111,29 @@ RESTORED_META_KEY = "_restored"
 #: only when there is at least one restored turn.
 _RESUME_DIVIDER = "⤺ resumed previous conversation"
 
-# A persisted ``role="tool"`` failure is NEVER JSON — the LLM-visible tool-result
-# renderer (``reyn.core.offload.seam`` / ``router_loop.py``'s tool-result assembly)
-# writes a genuine failure as one of exactly two plain-string shapes and nothing
-# else: ``f"Error ({kind}): {message}"`` for a dispatch-envelope error
-# (``{"status": "error", "error": {"kind": ..., "message": ...}}``), or
-# ``f"Error: {text}"`` for an MCP ``isError``. Per that module's own docstring,
-# "Success and error are syntactically distinguishable with no status field" —
-# these two literal PREFIXES are the renderer's documented, exhaustive failure
-# contract, not a substring guess: a benign result that merely CONTAINS the word
-# "error" elsewhere in its body does not start with either prefix and is left
-# alone (a successful grep for the word "error" is unaffected).
-_ERROR_KIND_RE = re.compile(r"^Error \(([^)]*)\): ", re.DOTALL)
-_ERROR_PLAIN_PREFIX = "Error: "
 
+def _failure_meta(m: "ChatMessage") -> "dict[str, object] | None":
+    """Read the TYPED failure classification off a ``role="tool"`` message's
+    persisted ``meta`` (#73, Option C) — never re-derive it by sniffing
+    ``m.text``. ``router_loop.py``'s tool-result assembly stamps
+    ``TOOL_STATUS_META_KEY=TOOL_STATUS_ERROR`` (+ ``error_message`` /
+    ``error_kind``) at PERSIST time, from the SAME classification the LIVE
+    path already has (a dispatch-envelope ``{"status":"error",...}`` or an
+    MCP ``isError`` result) — this is a typed, discriminated field, not a
+    string shape a display renderer happens to produce.
 
-def _detect_failure(text: str) -> "dict[str, str] | None":
-    """Read a persisted tool-result string against the renderer's failure
-    contract (see the module comment above ``_ERROR_KIND_RE``).
-
-    Returns a dict for :data:`~._meta_keys.RESULT_META_KEY` — either
-    ``{"error_kind": ..., "error_message": ...}`` (dispatch-envelope error) or
-    ``{"error_message": ...}`` (MCP ``isError``) — or ``None`` when ``text``
-    does not match either prefix (a success, including one whose body happens
-    to mention "error" mid-text).
-    """
-    kind_match = _ERROR_KIND_RE.match(text)
-    if kind_match:
-        return {
-            "error_kind": kind_match.group(1) or "error",
-            "error_message": text[kind_match.end():],
-        }
-    if text.startswith(_ERROR_PLAIN_PREFIX):
-        return {"error_message": text[len(_ERROR_PLAIN_PREFIX):]}
-    return None
+    Returns ``None`` when the flag is absent (a SUCCESS, or a pre-#73
+    persisted history that never had this field — absence is read as
+    success/completed, never inferred as failure)."""
+    meta = m.meta or {}
+    if meta.get(TOOL_STATUS_META_KEY) != TOOL_STATUS_ERROR:
+        return None
+    result_meta: "dict[str, object]" = {}
+    error_kind = meta.get(TOOL_ERROR_KIND_META_KEY)
+    if error_kind is not None:
+        result_meta["error_kind"] = error_kind
+    result_meta["error_message"] = meta.get(TOOL_ERROR_MESSAGE_META_KEY, "")
+    return result_meta
 
 
 def _correlated_calls(messages: "list[ChatMessage]") -> "dict[str, dict]":
@@ -171,12 +184,13 @@ def project_restored_frames(
       preceding assistant message's ``tool_calls`` by ``tool_call_id``,
       falling back to ``m.name`` / empty args when uncorrelated) plus
       ``RESULT_KIND_KEY="tool_call_completed"`` and
-      ``RESULT_META_KEY={"result": m.text}`` for a SUCCESS, or
+      ``RESULT_META_KEY={"result": m.text}`` for a SUCCESS (including a
+      pre-#73 persisted history with no typed failure flag at all), or
       ``RESULT_KIND_KEY="tool_call_failed"`` and
       ``RESULT_META_KEY={"error_kind": ..., "error_message": ...}`` (or just
-      ``{"error_message": ...}``) for a FAILURE — detected by matching ``m.text``
-      against the tool-result renderer's exhaustive failure contract
-      (:func:`_detect_failure`; #73).
+      ``{"error_message": ...}``) for a FAILURE — read directly off the
+      persisted ``meta[TOOL_STATUS_META_KEY]`` typed flag (:func:`_failure_meta`;
+      #73), never re-derived from ``m.text``.
     - ``system`` / ``summary``       → skipped (internal chrome)
 
     An assistant message carrying ONLY ``tool_calls`` (empty text) produces no
@@ -212,10 +226,10 @@ def project_restored_frames(
         elif role == "tool":
             call = calls_by_id.get(m.tool_call_id or "", {})
             tool_name = call.get("name") or m.name
-            failure = _detect_failure(m.text)
+            failure = _failure_meta(m)
             if failure is not None:
                 result_kind = "tool_call_failed"
-                result_meta: "dict[str, object]" = dict(failure)
+                result_meta: "dict[str, object]" = failure
             else:
                 result_kind = "tool_call_completed"
                 result_meta = {"result": m.text}

--- a/src/reyn/runtime/chat_message.py
+++ b/src/reyn/runtime/chat_message.py
@@ -15,6 +15,24 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Literal
 
+# #73: typed (not form-sniffed) tool-outcome classification, stamped on a
+# ``role="tool"`` message's ``meta`` at PERSIST time by the ONE place that
+# already knows the classification (``router_loop.py``'s tool-result
+# assembly — a dispatch-envelope ``{"status":"error",...}`` or an MCP
+# ``isError`` result). A consumer (e.g. the TUI restore projection,
+# ``interfaces/inline/textual_chat/restore.py``) reads these keys directly —
+# it must NEVER re-derive the classification by sniffing the rendered
+# ``content`` string (that string's shape is a renderer/display concern, not
+# a stable data contract, and a success payload can legitimately start with
+# the same words an error message would). ABSENCE of ``TOOL_STATUS_META_KEY``
+# (e.g. a pre-#73 persisted history) means "unknown" — a reader must treat
+# that as success/completed (today's existing behavior), never infer failure
+# from its absence or from the content string.
+TOOL_STATUS_META_KEY = "tool_status"
+TOOL_STATUS_ERROR = "error"
+TOOL_ERROR_KIND_META_KEY = "error_kind"
+TOOL_ERROR_MESSAGE_META_KEY = "error_message"
+
 
 @dataclass(init=False)
 class ChatMessage:

--- a/src/reyn/runtime/router_loop.py
+++ b/src/reyn/runtime/router_loop.py
@@ -3077,6 +3077,12 @@ class RouterLoop:
             unwrap_dispatch_envelope,
         )
         from reyn.core.offload.seam import build_offload_body, render_tool_result
+        from reyn.runtime.chat_message import (
+            TOOL_ERROR_KIND_META_KEY,
+            TOOL_ERROR_MESSAGE_META_KEY,
+            TOOL_STATUS_ERROR,
+            TOOL_STATUS_META_KEY,
+        )
         for tc, r in zip(result.tool_calls, result.tool_results):
             # B41-NF-W7-1: _post_text → appended outside the body.
             post_text: str | None = None
@@ -3110,11 +3116,20 @@ class RouterLoop:
             # Error path (plain string, never JSON): a dispatch-envelope error carries
             # ``error.kind``/``.message`` (``permission_denied`` vs ``not_found`` imply different
             # recovery); an MCP ``isError`` carries its description in the content text.
+            # #73 co-vet (Option C): the success/failure classification is KNOWN right here —
+            # ``r``/``canonical`` already discriminate error from success — so it is captured into
+            # typed ``_tool_error_*`` locals and stamped onto the persisted ``_tool_meta`` below
+            # (NEVER re-derived downstream by sniffing the rendered string; restore.py reads this
+            # typed field directly, matching reyn's typed-over-form-sniffed convention).
             scan_target: str
+            _tool_error_kind: "str | None" = None
+            _tool_error_message: "str | None" = None
             if (isinstance(r, dict) and r.get("status") == "error"
                     and isinstance(r.get("error"), dict)):
                 _err = r["error"]
-                content_str = f"Error ({_err.get('kind', 'error')}): {_err.get('message', '')}"
+                _tool_error_kind = str(_err.get("kind") or "error")
+                _tool_error_message = str(_err.get("message") or "")
+                content_str = f"Error ({_tool_error_kind}): {_tool_error_message}"
                 scan_target = content_str
             else:
                 # Unwrap dispatch-envelope layers ({status, data} with nothing else) until the op
@@ -3134,6 +3149,7 @@ class RouterLoop:
                         scan_target = f"Error: {text_full}"
                         text = _cap(text_full) if _cap is not None else text_full
                         content_str = f"Error: {text}"
+                        _tool_error_message = text_full
                     else:
                         frontmatter, text, built_media, content_type = build_offload_body(
                             canonical, save_fn=_save_fn,
@@ -3227,6 +3243,15 @@ class RouterLoop:
             }
             if external_source:
                 _tool_meta["external_source"] = True
+            # #73 (Option C, co-vet-directed): stamp the ALREADY-KNOWN success/failure
+            # classification as a typed field — never re-derived downstream from the
+            # rendered ``content_str`` (a display string is not a stable data contract;
+            # a legitimate success payload can itself start with the word "Error").
+            if _tool_error_message is not None:
+                _tool_meta[TOOL_STATUS_META_KEY] = TOOL_STATUS_ERROR
+                _tool_meta[TOOL_ERROR_MESSAGE_META_KEY] = _tool_error_message
+                if _tool_error_kind is not None:
+                    _tool_meta[TOOL_ERROR_KIND_META_KEY] = _tool_error_kind
             if _append_entry is not None:
                 _append_entry(
                     role="tool",

--- a/tests/test_textual_chat_phase5_3273.py
+++ b/tests/test_textual_chat_phase5_3273.py
@@ -244,6 +244,86 @@ def test_projection_uncorrelated_tool_result_still_yields_header() -> None:
     assert tool.meta.get(RESULT_META_KEY) == {"result": "orphaned result"}
 
 
+def test_projection_dispatch_envelope_failure_classified_as_tool_call_failed() -> None:
+    """Tier 1: a FAILED structured tool result (#73) — the persisted ``m.text``
+    for a dispatch-envelope error (e.g. ``file__read`` on a missing path) is
+    NEVER JSON; it is the plain string ``"Error (<kind>): <message>"`` produced
+    by the tool-result renderer (``reyn.core.offload.seam`` / ``router_loop.py``
+    — grounded by direct inspection, not guessed). The projection must classify
+    this as ``RESULT_KIND_KEY="tool_call_failed"`` (not ``"tool_call_completed"``)
+    so the presenter's failure branch (``_tool_result_line`` /
+    ``_body_and_background`` in ``presenter.py``) tints the row coral, exactly
+    matching the LIVE rendering of the same failure.
+
+    Non-vacuity: the OLD code passed ``{"result": m.text}`` (the raw string)
+    through unconditionally — ``summarize_tool_result`` only recognises
+    failure on a DICT carrying an ``error``/``error_message`` key
+    (``renderer.py::_summarize_result``), so handing it a bare string can
+    never produce a ``✗``-prefixed summary. That is asserted directly below."""
+    from reyn.interfaces.repl.renderer import summarize_tool_result
+
+    failure_text = "Error (not_found): file not found: missing.py"
+    frames = project_restored_frames([
+        ChatMessage(
+            role="tool", content=failure_text, name="file__read",
+            tool_call_id="missing_call",
+        ),
+    ])
+    tool = next(f for f in frames if f.kind == "tool_call_started")
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_failed", (
+        f"a rendered tool failure must classify as tool_call_failed, got "
+        f"meta={tool.meta}"
+    )
+    result_meta = tool.meta.get(RESULT_META_KEY)
+    assert result_meta == {
+        "error_kind": "not_found",
+        "error_message": "file not found: missing.py",
+    }
+
+    # Non-vacuity: the OLD behaviour (raw string fed to summarize_tool_result)
+    # never detects a failure — proving the fix actually changed the outcome.
+    old_summary = summarize_tool_result("file__read", failure_text)
+    assert not old_summary.startswith("✗"), (
+        "sanity check failed: the OLD string-based summary already looked "
+        "like a failure, so this test would not prove the fix changed anything"
+    )
+
+
+def test_projection_mcp_iserror_failure_classified_as_tool_call_failed() -> None:
+    """Tier 1: the second (and only other) failure shape the renderer emits —
+    an MCP ``isError`` result — persists as the plain string
+    ``"Error: <text>"`` (no ``(<kind>)`` segment). The projection must still
+    classify this as ``tool_call_failed``, carrying just ``error_message``."""
+    frames = project_restored_frames([
+        ChatMessage(
+            role="tool", content="Error: connection refused", name="mcp__ping",
+            tool_call_id="missing_call",
+        ),
+    ])
+    tool = next(f for f in frames if f.kind == "tool_call_started")
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_failed"
+    assert tool.meta.get(RESULT_META_KEY) == {"error_message": "connection refused"}
+
+
+def test_projection_success_mentioning_error_word_not_misclassified() -> None:
+    """Tier 1: no false positive — a SUCCESSFUL tool result whose own body
+    happens to contain the substring "error" (e.g. a grep result) must NOT be
+    misclassified as a failure. Only the renderer's exact failure PREFIXES
+    (``"Error ("`` / ``"Error: "``) trigger ``tool_call_failed``; a mid-body
+    mention does not (this is the substring-heuristic the brief explicitly
+    forbids inventing)."""
+    benign_text = "3 matches for 'error handling' in src/foo.py"
+    frames = project_restored_frames([
+        ChatMessage(
+            role="tool", content=benign_text, name="grep__search",
+            tool_call_id="missing_call",
+        ),
+    ])
+    tool = next(f for f in frames if f.kind == "tool_call_started")
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_completed"
+    assert tool.meta.get(RESULT_META_KEY) == {"result": benign_text}
+
+
 def test_projection_empty_log_yields_no_frames_no_divider() -> None:
     """Tier 1: a first-ever run (empty log) projects to nothing — no divider, so
     the pane stays blank (resume-equivalent: nothing to restore)."""
@@ -313,6 +393,36 @@ async def test_restored_entries_render_resolved_never_running() -> None:
         )
         tool = next(e for e in entries if e.item.kind == "tool_call_started")
         assert tool.state is EntryState.SUCCESS, "restored tool result not resolved to SUCCESS"
+
+
+@pytest.mark.asyncio
+async def test_restored_failed_tool_resolves_to_error_state() -> None:
+    """Tier 2: end-to-end witness for #73 — a persisted FAILED structured tool
+    result (``"Error (not_found): ..."``) hydrates to ``EntryState.ERROR`` (the
+    same coral-tinted terminal state the LIVE completion handler assigns a
+    raised/reported failure), not ``SUCCESS``. ``app.py``'s
+    ``_hydrate_from_history`` already branches on
+    ``meta[RESULT_KIND_KEY] == "tool_call_failed"`` to set ``ERROR`` directly
+    (verified by reading the source — no app.py change was needed for this
+    fix); this test proves the WHOLE path (projection → hydration) delivers
+    the correct end state, not just the projection in isolation."""
+    log = [
+        ChatMessage(
+            role="tool", content="Error (not_found): file not found: missing.py",
+            name="file__read", tool_call_id="missing_call",
+        ),
+    ]
+    app = TextualChatApp(
+        transport=ScriptedTransport(), read_model=_HistoryReadModel(log)
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await pilot.pause()
+        entries = _entries(app)
+        tool = next(e for e in entries if e.item.kind == "tool_call_started")
+        assert tool.state is EntryState.ERROR, (
+            f"a restored FAILED tool must resolve to ERROR, got {tool.state}"
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_textual_chat_phase5_3273.py
+++ b/tests/test_textual_chat_phase5_3273.py
@@ -244,35 +244,47 @@ def test_projection_uncorrelated_tool_result_still_yields_header() -> None:
     assert tool.meta.get(RESULT_META_KEY) == {"result": "orphaned result"}
 
 
-def test_projection_dispatch_envelope_failure_classified_as_tool_call_failed() -> None:
-    """Tier 1: a FAILED structured tool result (#73) — the persisted ``m.text``
-    for a dispatch-envelope error (e.g. ``file__read`` on a missing path) is
-    NEVER JSON; it is the plain string ``"Error (<kind>): <message>"`` produced
-    by the tool-result renderer (``reyn.core.offload.seam`` / ``router_loop.py``
-    — grounded by direct inspection, not guessed). The projection must classify
-    this as ``RESULT_KIND_KEY="tool_call_failed"`` (not ``"tool_call_completed"``)
-    so the presenter's failure branch (``_tool_result_line`` /
-    ``_body_and_background`` in ``presenter.py``) tints the row coral, exactly
-    matching the LIVE rendering of the same failure.
+def test_projection_typed_dispatch_envelope_failure_classified_as_tool_call_failed() -> None:
+    """Tier 1: a FAILED structured tool result (#73, Option C — co-vet-directed
+    pivot from an earlier string-prefix approach) — the KNOWN success/failure
+    classification is stamped as a TYPED flag on the persisted ``ChatMessage.meta``
+    at write time (``router_loop.py``'s tool-result assembly:
+    ``TOOL_STATUS_META_KEY=TOOL_STATUS_ERROR`` + ``error_kind``/``error_message``),
+    NOT re-derived from the rendered result string. The projection must read that
+    flag directly and classify as ``RESULT_KIND_KEY="tool_call_failed"`` so the
+    presenter's failure branch (``_tool_result_line`` / ``_body_and_background``
+    in ``presenter.py``) tints the row coral, exactly matching the LIVE
+    rendering of the same failure.
 
     Non-vacuity: the OLD code passed ``{"result": m.text}`` (the raw string)
-    through unconditionally — ``summarize_tool_result`` only recognises
-    failure on a DICT carrying an ``error``/``error_message`` key
-    (``renderer.py::_summarize_result``), so handing it a bare string can
-    never produce a ``✗``-prefixed summary. That is asserted directly below."""
+    through unconditionally regardless of any meta — ``summarize_tool_result``
+    only recognises failure on a DICT carrying an ``error``/``error_message``
+    key (``renderer.py::_summarize_result``), so a bare string could never
+    produce a ``✗``-prefixed summary. That is asserted directly below."""
     from reyn.interfaces.repl.renderer import summarize_tool_result
+    from reyn.runtime.chat_message import (
+        TOOL_ERROR_KIND_META_KEY,
+        TOOL_ERROR_MESSAGE_META_KEY,
+        TOOL_STATUS_ERROR,
+        TOOL_STATUS_META_KEY,
+    )
 
     failure_text = "Error (not_found): file not found: missing.py"
     frames = project_restored_frames([
         ChatMessage(
             role="tool", content=failure_text, name="file__read",
             tool_call_id="missing_call",
+            meta={
+                TOOL_STATUS_META_KEY: TOOL_STATUS_ERROR,
+                TOOL_ERROR_KIND_META_KEY: "not_found",
+                TOOL_ERROR_MESSAGE_META_KEY: "file not found: missing.py",
+            },
         ),
     ])
     tool = next(f for f in frames if f.kind == "tool_call_started")
     assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_failed", (
-        f"a rendered tool failure must classify as tool_call_failed, got "
-        f"meta={tool.meta}"
+        f"a typed-failure-flagged tool message must classify as tool_call_failed, "
+        f"got meta={tool.meta}"
     )
     result_meta = tool.meta.get(RESULT_META_KEY)
     assert result_meta == {
@@ -280,8 +292,9 @@ def test_projection_dispatch_envelope_failure_classified_as_tool_call_failed() -
         "error_message": "file not found: missing.py",
     }
 
-    # Non-vacuity: the OLD behaviour (raw string fed to summarize_tool_result)
-    # never detects a failure — proving the fix actually changed the outcome.
+    # Non-vacuity: the OLD behaviour (raw string fed to summarize_tool_result,
+    # ignoring meta entirely) never detects a failure — proving the fix
+    # actually changed the outcome, not merely re-asserted the input shape.
     old_summary = summarize_tool_result("file__read", failure_text)
     assert not old_summary.startswith("✗"), (
         "sanity check failed: the OLD string-based summary already looked "
@@ -289,15 +302,25 @@ def test_projection_dispatch_envelope_failure_classified_as_tool_call_failed() -
     )
 
 
-def test_projection_mcp_iserror_failure_classified_as_tool_call_failed() -> None:
-    """Tier 1: the second (and only other) failure shape the renderer emits —
-    an MCP ``isError`` result — persists as the plain string
-    ``"Error: <text>"`` (no ``(<kind>)`` segment). The projection must still
-    classify this as ``tool_call_failed``, carrying just ``error_message``."""
+def test_projection_typed_mcp_iserror_failure_classified_as_tool_call_failed() -> None:
+    """Tier 1: the second failure shape ``router_loop.py`` stamps — an MCP
+    ``isError`` result — carries only ``error_message`` (no ``error_kind``).
+    The projection must still classify this as ``tool_call_failed`` off the
+    typed flag, carrying just ``error_message``."""
+    from reyn.runtime.chat_message import (
+        TOOL_ERROR_MESSAGE_META_KEY,
+        TOOL_STATUS_ERROR,
+        TOOL_STATUS_META_KEY,
+    )
+
     frames = project_restored_frames([
         ChatMessage(
             role="tool", content="Error: connection refused", name="mcp__ping",
             tool_call_id="missing_call",
+            meta={
+                TOOL_STATUS_META_KEY: TOOL_STATUS_ERROR,
+                TOOL_ERROR_MESSAGE_META_KEY: "connection refused",
+            },
         ),
     ])
     tool = next(f for f in frames if f.kind == "tool_call_started")
@@ -305,23 +328,44 @@ def test_projection_mcp_iserror_failure_classified_as_tool_call_failed() -> None
     assert tool.meta.get(RESULT_META_KEY) == {"error_message": "connection refused"}
 
 
-def test_projection_success_mentioning_error_word_not_misclassified() -> None:
-    """Tier 1: no false positive — a SUCCESSFUL tool result whose own body
-    happens to contain the substring "error" (e.g. a grep result) must NOT be
-    misclassified as a failure. Only the renderer's exact failure PREFIXES
-    (``"Error ("`` / ``"Error: "``) trigger ``tool_call_failed``; a mid-body
-    mention does not (this is the substring-heuristic the brief explicitly
-    forbids inventing)."""
-    benign_text = "3 matches for 'error handling' in src/foo.py"
+def test_projection_success_payload_starting_with_error_word_not_misclassified() -> None:
+    """Tier 1: THE false positive Option B (an earlier, since-abandoned
+    string-prefix approach) could not close, and the reason for the #73
+    co-vet pivot to a typed flag — a SUCCESSFUL tool result whose own payload
+    literally STARTS WITH "Error:" (e.g. ``file__read`` of a log file whose
+    first line happens to be an "Error: ..." message) carries NO typed
+    ``TOOL_STATUS_META_KEY`` (persist time correctly classified it as a
+    success), so the projection must NOT classify it as a failure — the
+    result string's own content is irrelevant to the classification."""
+    log_first_line = "Error: disk full at 03:14, retrying write"
     frames = project_restored_frames([
         ChatMessage(
-            role="tool", content=benign_text, name="grep__search",
+            role="tool", content=log_first_line, name="file__read",
             tool_call_id="missing_call",
         ),
     ])
     tool = next(f for f in frames if f.kind == "tool_call_started")
+    assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_completed", (
+        "a SUCCESS whose payload starts with the word 'Error:' must not be "
+        f"misclassified as a failure, got meta={tool.meta}"
+    )
+    assert tool.meta.get(RESULT_META_KEY) == {"result": log_first_line}
+
+
+def test_projection_pre73_history_with_no_typed_flag_reads_as_success() -> None:
+    """Tier 1: backward-compat — a pre-#73 persisted ``ChatMessage`` has no
+    ``TOOL_STATUS_META_KEY`` at all (the field did not exist yet). Its ABSENCE
+    must be read as success/completed (today's existing behavior before this
+    fix), never inferred as failure from the string or from anything else."""
+    frames = project_restored_frames([
+        ChatMessage(
+            role="tool", content="Read 42 lines", name="file__read",
+            tool_call_id="missing_call", meta={},
+        ),
+    ])
+    tool = next(f for f in frames if f.kind == "tool_call_started")
     assert tool.meta.get(RESULT_KIND_KEY) == "tool_call_completed"
-    assert tool.meta.get(RESULT_META_KEY) == {"result": benign_text}
+    assert tool.meta.get(RESULT_META_KEY) == {"result": "Read 42 lines"}
 
 
 def test_projection_empty_log_yields_no_frames_no_divider() -> None:
@@ -397,19 +441,32 @@ async def test_restored_entries_render_resolved_never_running() -> None:
 
 @pytest.mark.asyncio
 async def test_restored_failed_tool_resolves_to_error_state() -> None:
-    """Tier 2: end-to-end witness for #73 — a persisted FAILED structured tool
-    result (``"Error (not_found): ..."``) hydrates to ``EntryState.ERROR`` (the
-    same coral-tinted terminal state the LIVE completion handler assigns a
-    raised/reported failure), not ``SUCCESS``. ``app.py``'s
-    ``_hydrate_from_history`` already branches on
+    """Tier 2: end-to-end witness for #73 (Option C) — a persisted FAILED
+    structured tool result, classified via the TYPED ``TOOL_STATUS_META_KEY``
+    flag stamped in ``meta`` (as ``router_loop.py`` would at persist time),
+    hydrates to ``EntryState.ERROR`` (the same coral-tinted terminal state the
+    LIVE completion handler assigns a raised/reported failure), not
+    ``SUCCESS``. ``app.py``'s ``_hydrate_from_history`` already branches on
     ``meta[RESULT_KIND_KEY] == "tool_call_failed"`` to set ``ERROR`` directly
     (verified by reading the source — no app.py change was needed for this
     fix); this test proves the WHOLE path (projection → hydration) delivers
     the correct end state, not just the projection in isolation."""
+    from reyn.runtime.chat_message import (
+        TOOL_ERROR_KIND_META_KEY,
+        TOOL_ERROR_MESSAGE_META_KEY,
+        TOOL_STATUS_ERROR,
+        TOOL_STATUS_META_KEY,
+    )
+
     log = [
         ChatMessage(
             role="tool", content="Error (not_found): file not found: missing.py",
             name="file__read", tool_call_id="missing_call",
+            meta={
+                TOOL_STATUS_META_KEY: TOOL_STATUS_ERROR,
+                TOOL_ERROR_KIND_META_KEY: "not_found",
+                TOOL_ERROR_MESSAGE_META_KEY: "file not found: missing.py",
+            },
         ),
     ]
     app = TextualChatApp(
@@ -531,6 +588,74 @@ async def test_retention_is_resume_equivalent(tmp_path, monkeypatch) -> None:
         assert [m.text for m in recent] == ["turn-3", "turn-4"], (
             "limit must keep the most-recent N turns (resume-equivalent)"
         )
+    finally:
+        await asyncio.wait_for(reg.shutdown(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_typed_failure_flag_round_trips_through_disk_history(tmp_path, monkeypatch) -> None:
+    """Tier 2: #73 round-trip — persist a FAILED tool result (the typed
+    ``TOOL_STATUS_META_KEY`` flag stamped in ``meta``, as ``router_loop.py``
+    would), drop the in-memory history and reload from ``history.jsonl`` on
+    disk (a REAL JSON round trip, not a same-process value), then project.
+    The typed flag must survive serialization and still classify as
+    ``tool_call_failed``. A SUCCESS whose payload happens to start with the
+    word ``"Error:"`` (no typed flag) must round-trip and project as
+    ``tool_call_completed`` — the exact false positive an earlier
+    string-prefix approach (Option B) could not close."""
+    from reyn.runtime.chat_message import (
+        TOOL_ERROR_KIND_META_KEY,
+        TOOL_ERROR_MESSAGE_META_KEY,
+        TOOL_STATUS_ERROR,
+        TOOL_STATUS_META_KEY,
+    )
+
+    monkeypatch.chdir(tmp_path)  # isolate the session's cwd-relative workspace/history.jsonl
+    reg = _registry(tmp_path)
+    try:
+        session = await reg.attach("solo")
+        session._append_history(ChatMessage(
+            role="tool", content="Error (not_found): file not found: missing.py",
+            name="file__read", tool_call_id="call_fail",
+            meta={
+                TOOL_STATUS_META_KEY: TOOL_STATUS_ERROR,
+                TOOL_ERROR_KIND_META_KEY: "not_found",
+                TOOL_ERROR_MESSAGE_META_KEY: "file not found: missing.py",
+            },
+        ))
+        session._append_history(ChatMessage(
+            role="tool", content="Error: disk full at 03:14, retrying write",
+            name="file__read", tool_call_id="call_ok",
+        ))
+
+        # REAL disk round trip: drop the in-memory list, reload from history.jsonl.
+        session.history.clear()
+        session.load_history()
+
+        rm = RegistryReadModel(reg)
+        restored = rm.conversation_history()
+        frames = project_restored_frames(restored)
+        tool_frames = [f for f in frames if f.kind == "tool_call_started"]
+        # Unpacking (not a ``len(...) == N`` size pin) both proves exactly two
+        # tool frames restored AND binds them for the behavioral assertions below —
+        # a short/long list raises ValueError here rather than needing a count check.
+        failed, success = tool_frames
+        assert failed.meta.get(RESULT_KIND_KEY) == "tool_call_failed", (
+            "the typed failure flag did not survive the disk round trip: "
+            f"meta={failed.meta}"
+        )
+        assert failed.meta.get(RESULT_META_KEY) == {
+            "error_kind": "not_found",
+            "error_message": "file not found: missing.py",
+        }
+
+        assert success.meta.get(RESULT_KIND_KEY) == "tool_call_completed", (
+            "a SUCCESS whose payload starts with 'Error:' must round-trip as "
+            f"completed, not failed: meta={success.meta}"
+        )
+        assert success.meta.get(RESULT_META_KEY) == {
+            "result": "Error: disk full at 03:14, retrying write"
+        }
     finally:
         await asyncio.wait_for(reg.shutdown(), timeout=5.0)
 


### PR DESCRIPTION
**[per-PR-coder]** — part of #3283. References #73.

## Update: pivoted to Option C after co-vet review

A co-vet review of the first commit (Option B, string-prefix detection on the persisted result string) found an un-closeable false positive: a SUCCESSFUL tool result whose payload literally starts with `"Error:"` (e.g. `file__read` of a log whose first line reads `"Error: disk full..."`) would be misclassified as a failure, since no syntactic prefix can distinguish a genuine failure envelope from success content that merely starts with those words. It also coupled `restore.py` to the renderer's two error-string shapes (drift risk) — violating reyn's typed > form-sniffed convention. This PR now ships **Option C**.

## Root cause (unchanged from the original finding)

`restore.py`'s `project_restored_frames` always stashed `RESULT_KIND_KEY="tool_call_completed"` for a `role="tool"` message, so a genuinely FAILED structured tool result (e.g. `file__read` on a missing file, which returns `{"status":"error","error":{...}}` normally — not a raised exception) rendered GREEN on `reyn chat` restart instead of the coral `✗` the live path shows for the same failure.

## Fix — Option C: typed flag stamped at persist time

The success/failure classification is **known** at exactly one place: `router_loop.py`'s tool-result assembly (~line 3110-3145), where the dispatch-envelope `{"status":"error",...}` / MCP `isError` branches are already discriminated to build the rendered `content_str`. This PR:

1. **Persist** (`src/reyn/runtime/chat_message.py`): adds typed constants — `TOOL_STATUS_META_KEY = "tool_status"`, `TOOL_STATUS_ERROR = "error"`, `TOOL_ERROR_KIND_META_KEY = "error_kind"`, `TOOL_ERROR_MESSAGE_META_KEY = "error_message"`. `router_loop.py` (~line 3110-3210) captures `_tool_error_kind` / `_tool_error_message` at the KNOWN classification point and stamps them onto the persisted `ChatMessage`'s `_tool_meta` — never re-derived from the rendered string.
2. **Restore** (`src/reyn/interfaces/inline/textual_chat/restore.py`): `project_restored_frames` now reads `meta[TOOL_STATUS_META_KEY]` directly via a new `_failure_meta` helper (replacing the removed `_detect_failure` string-prefix helper) and sets `RESULT_KIND_KEY="tool_call_failed"` + typed `error_kind`/`error_message` in `RESULT_META_KEY` — the same shape the live `_coalesce_tool_result` path produces. `app.py`'s `_hydrate_from_history` already branches on this kind to set `EntryState.ERROR` — no `app.py` change needed (verified by reading the source).
3. **Backward-compat**: a pre-#73 persisted `history.jsonl` has no `TOOL_STATUS_META_KEY` at all. Its ABSENCE is read as success/completed (today's existing behavior) — never inferred as failure, and there is no fallback to string-sniffing.
4. **Recovery implication**: `TOOL_STATUS_META_KEY` is written straight into the persisted `ChatMessage` at the same time as `content` (`router_loop.py`'s `append_history_entry` call) — authoritative-at-write, NOT WAL-event-reconstructed derived state. The CLAUDE.md recovery-feature truncate-falsify gate is therefore **N/A**, same determination as the rest of the message (documented explicitly in `restore.py`'s module docstring, "Recovery implication" section).

## Tests

- Replaced the three Option-B string-prefix Tier 1 tests with typed-meta equivalents (`test_projection_typed_dispatch_envelope_failure_classified_as_tool_call_failed`, `test_projection_typed_mcp_iserror_failure_classified_as_tool_call_failed`).
- **The false-positive test that now passes** (`test_projection_success_payload_starting_with_error_word_not_misclassified`): a SUCCESS whose payload is `"Error: disk full at 03:14, retrying write"` (no typed flag — persist-time correctly classified it as success) restores as `tool_call_completed`/SUCCESS. This is the exact case Option B could not close.
- Backward-compat test (`test_projection_pre73_history_with_no_typed_flag_reads_as_success`): a `ChatMessage` with `meta={}` (simulating pre-#73 history) reads as success.
- **Round-trip test** (`test_typed_failure_flag_round_trips_through_disk_history`): persists a FAILED tool result (typed flag in `meta`) and a lookalike SUCCESS (`"Error: disk full..."` payload, no flag) via a REAL `Session._append_history`, clears the in-memory history, reloads from `history.jsonl` on disk, projects, and asserts the failure classification survives the JSON round trip while the lookalike success does not misclassify. Real `ChatMessage`/`Session`/`OutboxMessage` — no mocks.
- Non-vacuity preserved: `summarize_tool_result` on the raw string (the OLD code's behavior) still does not produce `✗`, proving the fix changed the outcome.
- Existing success-path tests (`test_projection_maps_roles_preserves_order_and_names_source`, `test_projection_uncorrelated_tool_result_still_yields_header`) unmodified and still passing.

## CI gates (all green locally, after the Option C pivot)

- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase5_3273.py` — 17/17 OK, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120` (foreground, full suite) — **9126 passed, 36 skipped**, 0 failures
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/restore.py src/reyn/runtime/router_loop.py src/reyn/runtime/chat_message.py` — OK

## Test plan

- [x] Tier 1 pure-projection tests for both typed failure shapes (dispatch-envelope kind+message, MCP message-only)
- [x] False-positive test: a success payload starting with "Error:" restores as SUCCESS (closes the Option B gap)
- [x] Backward-compat test: pre-#73 history (no typed flag) restores as SUCCESS
- [x] Real disk round-trip test: typed flag survives JSON serialization through history.jsonl
- [x] Non-vacuity proof retained (old string-based summary is not `✗`)
- [x] Existing success-path tests unmodified and still passing (no regression)
- [x] Recovery-implication (truncate-falsify gate N/A) stated explicitly in restore.py's docstring