### PR TITLE
fix(tui): match full-word choice labels ([y]es -> "yes") -- #3290

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -90,14 +90,20 @@ _CHOICE_HINT_TEXT = "Please choose one of the options above (or click a chip)."
 
 
 def _match_choice_input(text: str, choices: "object") -> "str | None":
-    """Return the id of the ONE choice whose label or hotkey equals ``text``.
+    """Return the id of the ONE choice whose label, hotkey, or de-decorated
+    label equals ``text``.
 
     Type-or-click parity for a pending choice-intervention (#3290): a free-text
     submit that names an option (typing ``yes`` for the ``Yes`` chip) resolves
     the same intervention a chip click would. Matching is trimmed and
-    case-insensitive against BOTH the choice ``label`` and its ``hotkey``; the
-    ``choice_id`` is the authoritative delivery key (never itself matched, so a
-    label-as-id confusion can't sneak in).
+    case-insensitive against THREE forms: the raw choice ``label``, its
+    ``hotkey``, and a de-decorated label with the ``[`` ``]`` bracket
+    characters stripped — labels are conventionally hotkey-decorated
+    (``"[y]es"``, ``"[N]o"``, ``"[j]ust this path always"``), so without
+    de-decoration typing the FULL WORD (``"yes"``) never equals the raw
+    ``"[y]es"`` label and only the bare hotkey (``"y"``) would match (#3290
+    follow-up). The ``choice_id`` is the authoritative delivery key (never
+    itself matched, so a label-as-id confusion can't sneak in).
 
     Returns ``None`` when nothing matches OR the match is ambiguous (two distinct
     choices match) — the caller then keeps the intervention pending and hints,
@@ -117,11 +123,15 @@ def _match_choice_input(text: str, choices: "object") -> "str | None":
         cid = getattr(choice, "id", None)
         if cid is None:
             continue
+        label = getattr(choice, "label", None)
+        raw_forms = (label, getattr(choice, "hotkey", None))
         candidates = {
-            str(value).strip().casefold()
-            for value in (getattr(choice, "label", None), getattr(choice, "hotkey", None))
-            if value is not None and str(value).strip()
+            str(value).strip().casefold() for value in raw_forms if value is not None and str(value).strip()
         }
+        if label is not None:
+            undecorated = str(label).replace("[", "").replace("]", "").strip().casefold()
+            if undecorated:
+                candidates.add(undecorated)
         if needle in candidates:
             matched_ids.add(str(cid))
     if len(matched_ids) == 1:

--- a/tests/test_textual_chat_phase35_3273.py
+++ b/tests/test_textual_chat_phase35_3273.py
@@ -52,6 +52,15 @@ from reyn.interfaces.inline.textual_chat import (
 from reyn.interfaces.inline.textual_chat.app import _match_choice_input
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import DisplayFrame
+from reyn.intervention_choices import (
+    ALWAYS,
+    JUST_PATH,
+    NEVER,
+    NO,
+    YES,
+    file_access_choices,
+    generic_yn_choices,
+)
 from reyn.runtime.outbox import OutboxMessage
 from reyn.user_intervention import InterventionChoice, UserIntervention
 
@@ -353,6 +362,64 @@ def test_match_choice_input_label_hotkey_case_and_ambiguity() -> None:
         InterventionChoice(id="b", label="Go", hotkey="h"),
     ]
     assert _match_choice_input("go", dup) is None
+
+
+def test_match_choice_input_full_word_matches_bracket_decorated_label() -> None:
+    """Tier 1: #3290 follow-up — bracket-decorated labels (the real
+    ``generic_yn_choices()`` / ``file_access_choices()`` shape, e.g.
+    ``"[y]es"``) must resolve on the FULL WORD (``"yes"``), not only the
+    hotkey. Non-vacuity: the OLD exact-match (raw label + hotkey only) would
+    have failed ``"yes"`` against ``"[y]es"`` (``"yes" != "[y]es"`` and
+    ``"yes" != "y"``) — this proves the de-decoration candidate actually
+    changed the outcome, not just added a redundant path."""
+    choices = generic_yn_choices()  # [y]es / [A]lways / [n]o / [N]ever
+
+    # OLD behavior would have returned None here (falsifies vacuity).
+    old_exact_match_candidates = {
+        str(v).strip().casefold()
+        for c in choices
+        for v in (c.label, c.hotkey)
+    }
+    assert "yes" not in old_exact_match_candidates
+
+    # NEW behavior: full word resolves via the de-decorated candidate.
+    assert _match_choice_input("yes", choices) == YES
+    assert _match_choice_input("no", choices) == NO
+    assert _match_choice_input("always", choices) == ALWAYS
+    assert _match_choice_input("never", choices) == NEVER
+    # Hotkeys still resolve (regression guard — existing candidates kept).
+    # ("n" is skipped here: NO's hotkey "n" and NEVER's hotkey "N" casefold to
+    # the same needle, a pre-existing case-insensitive hotkey collision in the
+    # 4-choice generic_yn set that predates and is unrelated to this fix.)
+    assert _match_choice_input("y", choices) == YES
+    # Trimmed + case-insensitive, same as the raw-label path.
+    assert _match_choice_input("  YES  ", choices) == YES
+    # Unrelated word still returns None (stays pending, hints).
+    assert _match_choice_input("maybe", choices) is None
+
+    # A longer decorated label ("[j]ust this path always") also de-decorates.
+    file_choices = file_access_choices("/some/dir")
+    assert _match_choice_input("just this path always", file_choices) == JUST_PATH
+    assert _match_choice_input("yes", file_choices) == YES
+
+
+def test_match_choice_input_standard_yn_set_no_new_collision() -> None:
+    """Tier 1: #3290 follow-up ambiguity guard — de-decorating the standard
+    yes/no/always/never label set must NOT introduce a new cross-choice
+    collision (each de-decorated word is distinct), so each still resolves to
+    exactly one id rather than falling to ``None`` via the ambiguity guard."""
+    choices = generic_yn_choices()
+    resolved = {
+        word: _match_choice_input(word, choices)
+        for word in ("yes", "no", "always", "never")
+    }
+    assert resolved == {
+        "yes": YES,
+        "no": NO,
+        "always": ALWAYS,
+        "never": NEVER,
+    }
+    assert len(set(resolved.values())) == 4  # all four distinct, none collided to None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — Fixes a `#3290` follow-up: typing the hotkey `y` resolved the Yes chip in the Textual chat TUI's pending choice-intervention, but typing the full word `yes` fell through to the anti-black-hole hint instead of resolving.

## Root cause
`_match_choice_input` in `src/reyn/interfaces/inline/textual_chat/app.py` matched the trimmed casefolded needle against a choice's raw `label` and `hotkey` only, via exact set membership. Yes/No-style choices are bracket-decorated (`intervention_choices.py`: `InterventionChoice(id=YES, label="[y]es", hotkey="y")`, and similarly `"[N]o"`, `"[A]lways"`, `"[N]ever"`, `"[j]ust this path always"`). `casefold("[y]es") == "[y]es"`, so typing `yes` never matched — only the bare hotkey `y` did.

## Fix
Added a third match candidate per choice: the label with `[` / `]` stripped, then trimmed + casefolded ("de-decorated" form), alongside the existing raw-label and hotkey candidates. The existing ambiguity guard is untouched — two distinct matching choice ids still returns `None` (stays pending + hints). Docstring updated to describe the three match forms.

## Non-vacuity
`test_match_choice_input_full_word_matches_bracket_decorated_label` first asserts `"yes"` is NOT in the set of raw-label/hotkey candidates for `generic_yn_choices()` (proving the OLD exact-match would have failed), then asserts the NEW `_match_choice_input("yes", choices) == YES` resolves — same for `no`/`always`/`never`, plus a longer decorated label (`"[j]ust this path always"` → `"just this path always"`). Hotkeys (`y`) still resolve as a regression guard.

## Ambiguity guard preserved
`test_match_choice_input_standard_yn_set_no_new_collision` asserts the standard yes/no/always/never set resolves unambiguously post-fix (each de-decorated word is distinct, so none collides to `None`). Note: `"n"` alone was already ambiguous pre-fix between NO's hotkey `"n"` and NEVER's hotkey `"N"` (case-insensitive hotkey collision, unrelated to and predating this change) — documented in the test rather than asserted on.

## Gates (all green, foreground)
- `ruff check src tests` — all checks passed
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_phase35_3273.py` — 10/10 OK, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120` — **9122 passed, 36 skipped**, 0 failures
- `python scripts/verify_module_docstrings.py src/reyn/interfaces/inline/textual_chat/app.py` — OK

part of #3290

## Test plan
- [x] `ruff check src tests` clean
- [x] `test_tier_audit.py --strict` clean (10/10 OK)
- [x] Full `pytest --timeout=120` green (9122 passed, 36 skipped, 0 failed)
- [x] `verify_module_docstrings.py` clean