### PR TITLE
fix(tui): force-settle orphaned running tools at turn boundary — #72

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
+++ b/src/reyn/interfaces/inline/textual_chat/_meta_keys.py
@@ -28,4 +28,14 @@ RESULT_KIND_KEY = "_result_kind"
 #: frame's ``meta`` (carries ``result`` / ``error_message`` / ``error_kind``).
 RESULT_META_KEY = "_result"
 
-__all__ = ["RESULT_KIND_KEY", "RESULT_META_KEY"]
+#: A sentinel value for :data:`RESULT_KIND_KEY` marking a RUNNING tool row that
+#: was force-settled at the TURN BOUNDARY because no completion frame ever
+#: arrived — an orphan (#72). Distinct from a real completion frame's kind
+#: (``"tool_call_completed"`` / ``"tool_call_failed"``) so the presenter can
+#: render it NEUTRAL: neither a success nor a failure, just "no result ever
+#: came". Stamped by ``app.py``'s ``_sweep_orphaned_running_tools`` (the live
+#: path only — there is no restore-path equivalent: a persisted turn is, by
+#: definition, one that already settled).
+ORPHANED_RESULT_KIND = "_orphaned_no_result"
+
+__all__ = ["RESULT_KIND_KEY", "RESULT_META_KEY", "ORPHANED_RESULT_KIND"]

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -43,6 +43,7 @@ from textual_flowview import (
 from reyn.interfaces.repl.renderer import summarize_tool_result
 from reyn.interfaces.transport.frames import FrameTag
 
+from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
 from .chrome import (
     _MENU_TABS,
     Composer,
@@ -87,6 +88,18 @@ _SKIP_KINDS = frozenset(
 # The options are still rendered above as chips, so the hint re-affirms them
 # without echoing the (LLM-derived) labels back into the terminal.
 _CHOICE_HINT_TEXT = "Please choose one of the options above (or click a chip)."
+
+# Turn-end event types (#72): when one of these lands on the EVENT-tag frame
+# path, any tool row still RUNNING is a confirmed ORPHAN — its completion frame
+# can never arrive for THIS turn, since the turn itself just ended. Mirrors the
+# plain renderer's ``on_chat_event`` turn-end branch
+# (``src/reyn/interfaces/repl/renderer.py``): ``turn_settled`` fires for EVERY
+# turn kind (incl. slash short-circuits) and is the primary signal;
+# ``turn_completed`` / ``turn_cancelled`` are belt-and-suspenders. Deliberately
+# NOT a max-age timer — a time threshold cannot distinguish an orphan (tool
+# truly gone) from a slow-but-alive tool (a legitimately long ``exec``); the
+# turn-boundary signal is deterministic instead of guessed.
+_TURN_END_EVENT_TYPES = frozenset({"turn_settled", "turn_completed", "turn_cancelled"})
 
 
 def _match_choice_input(text: str, choices: "object") -> "str | None":
@@ -724,6 +737,59 @@ class TextualChatApp(App):
                 EntryState.ERROR if summary.startswith("✗") else EntryState.SUCCESS
             )
 
+    def _sweep_orphaned_running_tools(self) -> None:
+        """Force-settle any tool row still RUNNING at a TURN BOUNDARY (#72).
+
+        An ORPHAN is a tool whose completion frame never arrives — its report is
+        lost, or the turn ends without it — leaving its ② live spinner
+        (``⠙ elapsed Ns``) spinning FOREVER. The fix is deterministic rather than
+        a max-age timer: a time threshold cannot tell an orphan (tool truly gone)
+        apart from a slow-but-alive tool (a legitimately long ``exec``), but when
+        the TURN itself settles, there can be no more completions for that
+        turn's tools — any entry still in :attr:`_running_tools` at that instant
+        is a confirmed orphan. Called from :meth:`_pump_frames` on
+        ``turn_settled`` / ``turn_completed`` / ``turn_cancelled``.
+
+        Each orphan is settled exactly like :meth:`_coalesce_tool_result` (stop
+        the ② animation, strip :data:`_RUNNING_SINCE_KEY`, stash a result-kind
+        marker so the presenter folds a ``⎿`` sub-line under the header) EXCEPT
+        the stashed kind is the NEUTRAL sentinel
+        :data:`~reyn.interfaces.inline.textual_chat._meta_keys.ORPHANED_RESULT_KIND`
+        — never a failure. The tool did not fail; its report simply never
+        arrived, so the row goes :attr:`EntryState.CANCELLED` (dim gutter, same
+        as ``ReynGutter``'s DEFAULT/CANCELLED colour) rather than ``SUCCESS``
+        (would imply it worked) or ``ERROR`` (would imply it failed — the #3296
+        don't-fabricate-a-failure lesson). Every step is guarded so one orphan's
+        settle failure never kills the pump or leaves the others un-swept; the
+        dict is cleared unconditionally at the end so no turn's leftovers bleed
+        into the next."""
+        for entry in list(self._running_tools.values()):
+            try:
+                self._flow.stop_entry_animation(entry)
+            except Exception:
+                logger.exception(
+                    "textual chat: could not stop orphaned-tool animation"
+                )
+            try:
+                meta = {
+                    k: v
+                    for k, v in (entry.item.meta or {}).items()
+                    if k != _RUNNING_SINCE_KEY
+                }
+                meta[_RESULT_KIND_KEY] = _ORPHANED_RESULT_KIND
+                entry.set_item(replace(entry.item, meta=meta))
+            except Exception:
+                logger.exception(
+                    "textual chat: could not settle orphaned-tool entry"
+                )
+            try:
+                entry.set_state(EntryState.CANCELLED)
+            except Exception:
+                logger.exception(
+                    "textual chat: could not set orphaned-tool state"
+                )
+        self._running_tools.clear()
+
     def _begin_running_indicator(self, entry: "Entry[OutboxMessage]") -> None:
         """Start the live spinner + elapsed body for a RUNNING tool entry (②).
 
@@ -765,12 +831,23 @@ class TextualChatApp(App):
         :meth:`_ingest_frame` — appending a new entry, or COALESCING a correlated
         tool result into its RUNNING started entry (② settle-in-place). ``__end__``
         stops the app (the session closed). Event frames are the working-indicator
-        path — consumed but not yet drawn. A single frame's failure must not kill
-        the pump, so ingest is guarded.
+        path — consumed but not drawn, EXCEPT for the turn-end subset
+        (:data:`_TURN_END_EVENT_TYPES`), which triggers
+        :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
+        RUNNING when its turn ends — a confirmed orphan). A single frame's
+        failure must not kill the pump, so ingest is guarded.
         """
         try:
             async for frame in self._transport.frames():
                 if frame.tag is FrameTag.EVENT:
+                    etype = getattr(frame.event, "type", None)
+                    if etype in _TURN_END_EVENT_TYPES:
+                        try:
+                            self._sweep_orphaned_running_tools()
+                        except Exception:
+                            logger.exception(
+                                "textual chat: orphaned-tool sweep failed"
+                            )
                     continue
                 msg = frame.message
                 if msg.kind == "__end__":

--- a/src/reyn/interfaces/inline/textual_chat/presenter.py
+++ b/src/reyn/interfaces/inline/textual_chat/presenter.py
@@ -34,6 +34,7 @@ from reyn.interfaces.repl.renderer import (
     summarize_tool_result,
 )
 
+from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
 from ._meta_keys import RESULT_KIND_KEY as _RESULT_KIND_KEY
 from ._meta_keys import RESULT_META_KEY as _RESULT_META_KEY
 
@@ -69,7 +70,12 @@ _SPINNER_SPEED = 8
 # The restore path (``restore.py``) stamps the SAME two keys onto its projected
 # frames so a restored tool turn coalesces identically — both modules import
 # the string values from ``_meta_keys`` (restore.py must stay textual-free, so
-# the constants live there rather than here).
+# the constants live there rather than here). A THIRD, orphan case (#72): when
+# the turn ends with a tool still RUNNING (its completion never arrived), the
+# app force-settles it at the turn boundary with ``_RESULT_KIND_KEY`` stamped
+# to the sentinel :data:`_ORPHANED_RESULT_KIND` rather than a real completion
+# kind — :func:`_tool_result_line` renders that as a NEUTRAL dim
+# ``⎿ (no result — turn ended)`` line, never a ``✗`` failure.
 
 # --- choice-intervention chip layout ---------------------------------------
 # A closed-set intervention (permission confirm / choice ``ask_user`` — anything
@@ -169,6 +175,11 @@ def _tool_result_line(msg: "OutboxMessage") -> "tuple[Text, str | None]":
     coral (``_CC_ERR``), matching the standalone failure row."""
     meta = msg.meta or {}
     result_meta = meta.get(_RESULT_META_KEY) or {}
+    if meta.get(_RESULT_KIND_KEY) == _ORPHANED_RESULT_KIND:
+        # Force-settled at the turn boundary (#72): the tool's report never
+        # arrived. NEUTRAL, not a failure — no ``✗``, no coral tint (the #3296
+        # don't-fabricate-a-failure lesson).
+        return Text("  ⎿ (no result — turn ended)", style=_CC_DIM), None
     if meta.get(_RESULT_KIND_KEY) == "tool_call_failed":
         err = (
             result_meta.get("error_message")

--- a/tests/test_textual_chat_orphan_sweep_72.py
+++ b/tests/test_textual_chat_orphan_sweep_72.py
@@ -1,0 +1,222 @@
+"""Force-settle orphaned RUNNING tools at the turn boundary (#72).
+
+An ORPHAN is a tool whose completion frame never arrives (the report is lost,
+or the turn ends without it) — without a fix, its ② live spinner
+(``⠙ elapsed Ns``) spins FOREVER. The design (architect-settled, F5c) is a
+TURN-BOUNDARY sweep, deliberately NOT a max-age timer: a time threshold cannot
+distinguish an orphan (tool truly gone) from a slow-but-alive tool (a
+legitimately long ``exec``), but the turn-completion signal is deterministic —
+when the turn settles there can be no more completions for that turn's tools.
+
+These gates:
+
+- **non-vacuity** (Tier 2b): an orphaned RUNNING tool + a ``turn_settled`` event
+  settles the entry (animation stopped, neutral body, state CANCELLED — not
+  RUNNING). Proven non-vacuous by the paired
+  ``test_without_the_sweep_the_orphan_would_stay_running`` witness, which
+  removes the trigger (no turn-end event delivered) and shows the entry stays
+  RUNNING/marked-live — the sweep call is what closes the gap.
+- **no-false-kill** (Tier 2b): a tool that COMPLETED within the turn (already
+  popped from ``_running_tools`` by the coalesce path) is untouched by the
+  sweep — its coalesced ``⎿ result`` and SUCCESS state survive ``turn_settled``.
+- **neutral-not-coral** (Tier 1 + Tier 2b): the settled-incomplete entry's state
+  is NOT ``EntryState.ERROR`` (nor ``SUCCESS``) and its body is the dim
+  ``⎿ (no result — turn ended)`` line, never a ``✗`` failure summary — the
+  #3296 don't-fabricate-a-failure lesson applied to the orphan case.
+- **deterministic** (Tier 2b): the sweep fires off the ``turn_settled`` /
+  ``turn_completed`` / ``turn_cancelled`` EVENT frame, never a clock/sleep —
+  pinned by driving a frozen, non-advancing clock through the whole test.
+
+All use a real, mounted :class:`TextualChatApp`, real
+:class:`~reyn.runtime.outbox.OutboxMessage` / :class:`~reyn.interfaces.transport.frames.EventFrame`,
+and a real :class:`~reyn.schemas.models.Event` — no ``MagicMock``, per the
+testing policy.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import EntryState, FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.presenter import (
+    _RESULT_KIND_KEY,
+    _RUNNING_SINCE_KEY,
+    ReynPresenter,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import DisplayFrame, EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+
+def _started(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_started", text=tool, meta={"tool": tool, "op_id": op_id, "args": {}}
+    )
+
+
+def _completed(op_id: str, tool: str = "grep") -> OutboxMessage:
+    return OutboxMessage(
+        kind="tool_call_completed",
+        text="",
+        meta={"tool": tool, "op_id": op_id, "result": {"op": tool, "count": 3}},
+    )
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue — display OR event frames — so a test can push a ``started`` tool,
+    inspect its live RUNNING row, THEN push a turn-end event and inspect the
+    sweep, with the stream staying open throughout."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_display(self, msg: OutboxMessage) -> None:
+        await self._queue.put(DisplayFrame(msg))
+
+    async def push_event(self, event_type: str) -> None:
+        await self._queue.put(EventFrame(Event(type=event_type)))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _entries(app: TextualChatApp):
+    return app.query_one(FlowView).entries
+
+
+@pytest.mark.asyncio
+async def test_orphaned_running_tool_settles_neutral_on_turn_settled() -> None:
+    """Tier 2b: an orphaned RUNNING tool + ``turn_settled`` settles it — animation
+    stopped, state CANCELLED (not RUNNING, not spinning), neutral body."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_started("op-orphan"))
+        await pilot.pause()
+        entry = _entries(app)[0]
+        assert entry.state is EntryState.RUNNING
+        assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is not None
+
+        await transport.push_event("turn_settled")
+        await pilot.pause()
+
+        assert entry.state is EntryState.CANCELLED
+        assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is None
+        meta = entry.item.meta or {}
+        assert meta.get(_RESULT_KIND_KEY) not in ("tool_call_completed", "tool_call_failed")
+        pres = await ReynPresenter(clock=lambda: 100.0).present(entry.item, 80)
+        body = pres.renderable
+        from rich.console import Console
+
+        console = Console(width=80)
+        with console.capture() as cap:
+            console.print(body)
+        text = cap.get()
+        assert "no result — turn ended" in text
+        assert "✗" not in text
+
+
+@pytest.mark.asyncio
+async def test_without_the_sweep_the_orphan_would_stay_running() -> None:
+    """Tier 2b: non-vacuity witness — with NO turn-end event ever delivered, the
+    orphaned tool stays RUNNING and marked live — proving the sweep call (not
+    some other mechanism) is what closes the gap in the paired test above."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_started("op-still-running"))
+        await pilot.pause()
+        await pilot.pause()
+        entry = _entries(app)[0]
+        assert entry.state is EntryState.RUNNING
+        assert (entry.item.meta or {}).get(_RUNNING_SINCE_KEY) is not None
+
+
+@pytest.mark.asyncio
+async def test_completed_tool_is_untouched_by_the_sweep() -> None:
+    """Tier 2b: no-false-kill — a tool that COMPLETED within the turn (already
+    popped from ``_running_tools`` by the coalesce path) is not re-touched by
+    the sweep; its coalesced result + SUCCESS state survive ``turn_settled``."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_display(_started("op-done"))
+        await pilot.pause()
+        await transport.push_display(_completed("op-done"))
+        await pilot.pause()
+        entry = _entries(app)[0]
+        assert entry.state is EntryState.SUCCESS
+        result_kind_before = (entry.item.meta or {}).get(_RESULT_KIND_KEY)
+        assert result_kind_before == "tool_call_completed"
+
+        await transport.push_event("turn_settled")
+        await pilot.pause()
+
+        assert entry.state is EntryState.SUCCESS
+        assert (entry.item.meta or {}).get(_RESULT_KIND_KEY) == "tool_call_completed"
+        pres = await ReynPresenter(clock=lambda: 100.0).present(entry.item, 80)
+        from rich.console import Console
+
+        console = Console(width=80)
+        with console.capture() as cap:
+            console.print(pres.renderable)
+        assert "⎿" in cap.get()
+
+
+@pytest.mark.asyncio
+async def test_turn_completed_and_turn_cancelled_also_sweep() -> None:
+    """Tier 2b: the belt-and-suspenders turn-end events (``turn_completed`` /
+    ``turn_cancelled``) trigger the same sweep as the primary ``turn_settled``."""
+    for event_type in ("turn_completed", "turn_cancelled"):
+        transport = QueueTransport()
+        app = TextualChatApp(transport=transport, clock=lambda: 100.0)
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await transport.push_display(_started(f"op-{event_type}"))
+            await pilot.pause()
+            entry = _entries(app)[0]
+            assert entry.state is EntryState.RUNNING
+
+            await transport.push_event(event_type)
+            await pilot.pause()
+
+            assert entry.state is EntryState.CANCELLED, event_type


### PR DESCRIPTION
**[per-PR-coder]** — Force-settles a Textual chat tool row whose completion frame never arrives (an orphan) at the deterministic turn boundary, per architect co-vet design (settled, not a redesign).

## Hook point + the three turn events
`_pump_frames` (`src/reyn/interfaces/inline/textual_chat/app.py`) previously blanket-skipped every `FrameTag.EVENT` frame. It now reads `frame.event.type` and, when it is one of `turn_settled` / `turn_completed` / `turn_cancelled` (`_TURN_END_EVENT_TYPES`, mirroring `renderer.py`'s `on_chat_event` turn-end branch — `turn_settled` fires for every turn kind incl. slash short-circuits and is primary; the other two are belt-and-suspenders), calls the new `_sweep_orphaned_running_tools()` before `continue`ing — event frames are still not drawn, out of scope per the brief.

`_sweep_orphaned_running_tools` iterates `self._running_tools` (populated in `_apply_lifecycle_state`, drained by `_ingest_frame`/`_coalesce_tool_result` on a real completion). Any entry still present is a confirmed orphan: stop its ② animation (`stop_entry_animation`), strip `_RUNNING_SINCE_KEY`, stash a settle marker, set the terminal state, then unconditionally clear `_running_tools`. Guarded per-step (mirrors `_coalesce_tool_result`) so one orphan's settle failure never kills the pump or blocks sweeping the rest.

Deliberately turn-boundary, not a max-age timer: a time threshold can't tell an orphan (tool truly gone) apart from a slow-but-alive tool (a legitimately long `exec`); the turn-completion signal is deterministic instead.

## Neutral-not-coral settle + EntryState choice
New sentinel `ORPHANED_RESULT_KIND = "_orphaned_no_result"` (`_meta_keys.py`) is stashed under `_RESULT_KIND_KEY` instead of a real completion kind. `presenter.py`'s `_tool_result_line` renders it as a dim `⎿ (no result — turn ended)` sub-line under the `⏺ tool(args)` header — never a `✗`/failure line.

**EntryState.CANCELLED** (not SUCCESS, not ERROR, not DEFAULT) — per explicit adjudication mid-implementation. SUCCESS would imply the tool worked; ERROR is coral and would imply it failed (the exact #3296 don't-fabricate-a-failure anti-pattern this arc just fixed). DEFAULT is for rows that never ran; this one DID start. CANCELLED honestly reads "lifecycle ended RUNNING→interrupted", and `ReynGutter._STATE_COLOR[EntryState.CANCELLED] = _CC_DIM` (gutter.py) already renders it dim — no gutter change needed.

## Non-vacuity + no-false-kill proof
New `tests/test_textual_chat_orphan_sweep_72.py` (4 tests, real `TextualChatApp` + real `OutboxMessage`/`EventFrame`/`Event`, no `MagicMock`):

- `test_orphaned_running_tool_settles_neutral_on_turn_settled` — orphan + `turn_settled` → CANCELLED, animation stopped, dim "no result" body, no `✗`.
- `test_without_the_sweep_the_orphan_would_stay_running` — non-vacuity witness: with no turn-end event, the orphan stays RUNNING/marked live.
- `test_completed_tool_is_untouched_by_the_sweep` — no-false-kill: a tool that completed within the turn keeps its coalesced `⎿ result` + SUCCESS after `turn_settled`.
- `test_turn_completed_and_turn_cancelled_also_sweep` — the belt-and-suspenders events also trigger the sweep.

Manually falsified by temporarily disabling the `_sweep_orphaned_running_tools()` call: the orphan-specific tests correctly FAIL (entry stays RUNNING) while the no-false-kill test still passes — confirming the sweep, not some other mechanism, is what closes the gap.

## Gates
- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict tests/test_textual_chat_orphan_sweep_72.py` — 4/4 OK, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120` (foreground, full suite) — **9132 passed, 36 skipped, 0 failed** (512s)
- `python scripts/verify_module_docstrings.py` (app.py, presenter.py, _meta_keys.py) — OK

## Test plan
- [x] `ruff check src tests` green
- [x] `test_tier_audit.py --strict` green (4/4, Tier 2b)
- [x] Full `pytest --timeout=120` foreground: 9132 passed, 36 skipped, 0 failed
- [x] `verify_module_docstrings.py` green
- [x] Non-vacuity falsified manually (sweep-call removed → orphan tests fail as expected)

Part of #3283. Addresses the architect-flagged F5c orphan-spinner gap referenced in #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)