### PR TITLE
feat(tui): drive user-echo from user_submitted event, drop outbox echo — #3300 P1 (C)

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -327,6 +327,7 @@ display 行のテキストである。
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | ユーザーが intervention に回答した              |
+| `reyn.event.user_submitted`          | ユーザーがターンを送信した(#3300 P1 C)— RAW text + chain_id + _msg_id + meta を運ぶ。各 surface がそれぞれの render 境界で neutralize する |
 
 ### `reyn.intervention.<kind>`
 
@@ -355,15 +356,23 @@ transport が加えるのは wire framing のみであり、新しい render sem
 そのため remote レンダラーの display バイト列と working-indicator の遷移は、ローカルの
 ものと同一である。
 
-**Local ≡ remote は input についても output と対称に成り立つ。** 送信されたターン
-(`Session.submit_user_text`)と解決された intervention への回答
-(`InterventionHandler.deliver_answer_to` — TUI の自由記述回答・TUI の選択肢リージョン・
-A2A peer・上記の AG-UI HITL round-trip という全ての回答経路が共有する単一の funnel)は
-それぞれ、agent の返信が乗るのと同じ `session.outbox` に `kind="user"` の frame を置く
-ため、同一の `OutboxHub` ブロードキャストを経由して、アタッチしているすべての surface へ
-fan-out される。送信したクライアント自身も(別のローカルエコーではなく)そのブロードキャ
-スト frame から自分の行を描画する — 2 クライアント以上がアタッチしていれば、全員が
-すべてのターンとすべての回答を見られる。agent からの返信だけではない。
+**Local ≡ remote は input についても output と対称に成り立つ。** 解決された
+intervention への回答(`InterventionHandler.deliver_answer_to` — TUI の自由記述回答・
+TUI の選択肢リージョン・A2A peer・上記の AG-UI HITL round-trip という全ての回答経路が
+共有する単一の funnel)は `session.outbox` に `kind="user"` の frame を置き、`OutboxHub`
+を経由してアタッチしているすべての surface へ fan-out される。送信されたターン
+(`Session.submit_user_text`)は代わりに `user_submitted` という chat-event を emit する
+(#3300 P1 C — 以前の outbox-echo write を置き換えた。INPUT を display/OUTPUT channel に
+書き込むのは category error だったため)。この event は同一の統一 frame stream に
+`EventFrame` として乗る(`_TURN_AND_ANSWER_EVENTS`、`transport/frames.py`)——
+encode/decode は汎用的(`transport/agui/protocol.py`)なので、新しい event type のために
+wire 側の変更は不要だった。いずれの経路でも、アタッチしているすべての surface の
+event→display handler(`ConsoleChatRenderer.on_chat_event` /
+`InlineChatRenderer.on_chat_event` / `TextualChatApp._pump_frames`)がその行を描画し、
+その render 境界で neutralize する(`renderer.user_submitted_display_message`)。送信した
+クライアント自身も(別のローカルエコーではなく)同じ event から自分の行を描画する —
+2 クライアント以上がアタッチしていれば、全員がすべてのターンとすべての回答を見られる。
+agent からの返信だけではない。
 
 ## AG-UI event coverage — 数字を正直に読む
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -351,6 +351,7 @@ is the event's data object.
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention             |
+| `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + _msg_id + meta; each surface neutralizes at its render boundary |
 
 ### `reyn.intervention.<kind>`
 
@@ -394,16 +395,24 @@ client reads its status bar / intervention region / task poll through the
 read-model: a `RegistryReadModel` off the local session, or a `RemoteReadModel`
 off the `STATE_*` view above.
 
-**Local ≡ remote holds for INPUT too, symmetric with output.** A submitted turn
-(`Session.submit_user_text`) and a resolved intervention answer
-(`InterventionHandler.deliver_answer_to` — the one funnel every answer path
-shares: TUI free-text, TUI choice-region, an A2A peer, and the AG-UI HITL
-round-trip above) each put a `kind="user"` frame on the SAME `session.outbox`
-the agent's reply rides, so it fans out through the identical `OutboxHub`
-broadcast to every attached surface. The submitting client renders its own
-line from that broadcast frame too (no separate local echo) — with 2+ clients
-attached, everyone sees every turn and every answer, not only the agent's
-replies to them.
+**Local ≡ remote holds for INPUT too, symmetric with output.** A resolved
+intervention answer (`InterventionHandler.deliver_answer_to` — the one funnel
+every answer path shares: TUI free-text, TUI choice-region, an A2A peer, and
+the AG-UI HITL round-trip above) puts a `kind="user"` frame on
+`session.outbox`, fanning out through `OutboxHub` to every attached surface.
+A submitted turn (`Session.submit_user_text`) instead emits a
+`user_submitted` chat-event (#3300 P1 C — replacing an earlier outbox-echo
+write, a category error: an INPUT written into the display/OUTPUT channel)
+that rides the SAME unified frame stream as an `EventFrame`
+(`_TURN_AND_ANSWER_EVENTS`, `transport/frames.py`) — the encode/decode is
+generic (`transport/agui/protocol.py`), so no wire changes were needed for the
+new event type. Either way every attached surface's event→display handler
+(`ConsoleChatRenderer.on_chat_event` / `InlineChatRenderer.on_chat_event` /
+`TextualChatApp._pump_frames`) renders the line, neutralizing at that render
+boundary (`renderer.user_submitted_display_message`). The submitting client
+renders its own line from that same event too (no separate local echo) —
+with 2+ clients attached, everyone sees every turn and every answer, not only
+the agent's replies to them.
 
 ## AG-UI event coverage — reading the numbers honestly
 

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -834,14 +834,33 @@ class TextualChatApp(App):
         path — consumed but not drawn, EXCEPT for the turn-end subset
         (:data:`_TURN_END_EVENT_TYPES`), which triggers
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
-        RUNNING when its turn ends — a confirmed orphan). A single frame's
-        failure must not kill the pump, so ingest is guarded.
+        RUNNING when its turn ends — a confirmed orphan), and ``user_submitted``
+        (#3300 P1 C), which IS drawn — it materializes the submitting/peer
+        client's own user line (the removed ``_put_outbox`` echo's replacement)
+        via the same neutralize-at-render-time seam the plain renderer uses
+        (:func:`~reyn.interfaces.repl.renderer.user_submitted_display_message`).
+        In Phase C this appends straight to the flow like any other display
+        frame — the sent-queue staging (materialize → promote on
+        ``turn_started``) is Phase B, not built here. A single frame's failure
+        must not kill the pump, so ingest is guarded.
         """
         try:
             async for frame in self._transport.frames():
                 if frame.tag is FrameTag.EVENT:
                     etype = getattr(frame.event, "type", None)
-                    if etype in _TURN_END_EVENT_TYPES:
+                    if etype == "user_submitted":
+                        from reyn.interfaces.repl.renderer import (  # noqa: PLC0415
+                            user_submitted_display_message,
+                        )
+                        try:
+                            self._ingest_frame(
+                                user_submitted_display_message(frame.event)
+                            )
+                        except Exception:
+                            logger.exception(
+                                "textual chat: user_submitted ingest failed"
+                            )
+                    elif etype in _TURN_END_EVENT_TYPES:
                         try:
                             self._sweep_orphaned_running_tools()
                         except Exception:

--- a/src/reyn/interfaces/repl/renderer.py
+++ b/src/reyn/interfaces/repl/renderer.py
@@ -29,6 +29,27 @@ def _meta_prefix(meta: dict) -> str:
     return ""
 
 
+def user_submitted_display_message(event) -> OutboxMessage:
+    """Build the display :class:`OutboxMessage` for a ``user_submitted``
+    chat-event — the ONE neutralize-at-display-boundary seam every surface's
+    ``on_chat_event`` (this module) / frame-pump handler
+    (``interfaces.inline.textual_chat.app``) calls to render the user-line echo
+    (#3300 P1 C).
+
+    ``session.submit_user_text`` (``runtime/session.py``) emits ``user_submitted``
+    carrying the RAW text (no neutralize — single source, the inbox path, stays
+    untouched) + ``meta`` (attribution, built server-side by
+    ``session._user_frame_meta``). Neutralization (ESC/control strip) happens
+    HERE, at render time, via the same ``core/present/guard.get_neutralizer
+    ("terminal")`` seam #2770 uses for intervention content — replacing the
+    removed ``_put_outbox`` echo's inline neutralize call.
+    """
+    from reyn.core.present.guard import get_neutralizer
+    data = event.data or {}
+    text, _ = get_neutralizer("terminal").neutralize(str(data.get("text", "")))
+    return OutboxMessage(kind="user", text=text, meta=dict(data.get("meta") or {}))
+
+
 _BANNER = """\
  ██████╗ ███████╗██╗   ██╗███╗  ██╗
  ██╔══██╗██╔════╝╚██╗ ██╔╝████╗ ██║
@@ -121,6 +142,8 @@ class ConsoleChatRenderer(ChatRenderer):
             self._thinking = True
         elif etype in ("turn_settled", "turn_completed", "turn_cancelled"):
             self._thinking = False
+        elif etype == "user_submitted":
+            self.message(user_submitted_display_message(event))
 
     def bottom_toolbar(self):
         if not self._thinking:
@@ -783,6 +806,14 @@ class InlineChatRenderer(ChatRenderer):
             # records the user's answer, regardless of which kind of
             # intervention it was.
             self._set_waiting_on(_WAITING_ON_THINKING)
+        elif etype == "user_submitted":
+            # #3300 P1 (C): only reachable when this renderer runs the shared
+            # plain PromptSession loop (``chat.render_mode: plain`` configured
+            # on an interactive TTY) — the default TTY path bypasses this
+            # renderer entirely for ``TextualChatApp`` (client_driver.py),
+            # which has its OWN ``user_submitted`` handler
+            # (``interfaces/inline/textual_chat/app.py``).
+            self.message(user_submitted_display_message(event))
 
     def bottom_toolbar(self):
         """Animated working indicator while a turn runs (spinner + elapsed).

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -446,9 +446,10 @@ async def agui_submit(request: Request, agent_name: str):
         if text:
             # ADR-0039 multi-client input-broadcast fix: attribute this
             # submit the same way `_handle_answer` attributes a HITL grant
-            # (auth_user_id + connection id) — `submit_user_text` broadcasts
-            # a kind="user" frame via outbox_hub so every OTHER attached
-            # surface sees this client's turn, not just the agent's reply.
+            # (auth_user_id + connection id) — `submit_user_text` emits a
+            # `user_submitted` chat-event (#3300 P1 C) that every attached
+            # surface's event→display handler renders as this client's turn,
+            # not just the agent's reply.
             await session.submit_user_text(
                 text,
                 attribution={

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -130,6 +130,13 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "reyn.event.user_answered_intervention", EVENT_NS, "the event data object",
         "the user answered an intervention (working-indicator axis)",
     ),
+    CustomName(
+        "reyn.event.user_submitted", EVENT_NS, "the event data object",
+        "a user turn was submitted (#3300 P1 C) — carries the RAW text + "
+        "chain_id + _msg_id + meta; each surface's event→display handler "
+        "renders the echo and neutralizes at that render boundary "
+        "(replaces the earlier kind=\"user\" outbox-echo write)",
+    ),
 )
 
 

--- a/src/reyn/interfaces/transport/agui/protocol.py
+++ b/src/reyn/interfaces/transport/agui/protocol.py
@@ -154,9 +154,12 @@ _DISPLAY_KIND_EVENT: dict[str, str] = {
 }
 
 # EventFrame ``Event.type`` → AG-UI event type. turn_* → RUN_*; tool_* →
-# TOOL_CALL_*; ``user_answered_intervention`` is reyn-private → CUSTOM. Every
-# entry here is one of the eight ``renderer_chat_events()`` the transport
-# forwards; the completeness gate binds the two independently.
+# TOOL_CALL_*; ``user_answered_intervention`` / ``user_submitted`` (#3300 P1 C)
+# are reyn-private → CUSTOM (the ``_event_event_type`` default, not listed
+# below). Every entry in ``renderer_chat_events()`` — not just the ones
+# explicitly mapped here — round-trips losslessly via ``_reyn``; the
+# completeness gate binds the transport's forward-set to the renderer's
+# vocabulary independently of this table's non-CUSTOM selections.
 _EVENT_TYPE_EVENT: dict[str, str] = {
     "turn_started": RUN_STARTED,
     "turn_settled": RUN_FINISHED,

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -59,6 +59,12 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
         "turn_completed",
         "turn_cancelled",
         "user_answered_intervention",
+        # #3300 P1 (C): the user-line echo, driven by an event instead of a
+        # parallel outbox write (session.submit_user_text). Carries raw text +
+        # chain_id + _msg_id + attribution meta; each surface's
+        # event→display handler neutralizes at render time (see
+        # ``reyn.interfaces.repl.renderer.user_submitted_display_message``).
+        "user_submitted",
     }
 )
 
@@ -74,8 +80,8 @@ def renderer_chat_events() -> frozenset[str]:
       tool-axis WaitingOn transition table (``tool_called`` / ``tool_returned``
       / ``tool_failed``); extending WaitingOn to a new axis is one new entry
       there and this set follows automatically.
-    - :data:`_TURN_AND_ANSWER_EVENTS` — the turn-lifecycle + intervention-answer
-      events ``renderer.on_chat_event`` branches on directly.
+    - :data:`_TURN_AND_ANSWER_EVENTS` — the turn-lifecycle / intervention-answer
+      / user-submitted events ``renderer.on_chat_event`` branches on directly.
     """
     return frozenset(_WAITING_ON_BY_EVENT.keys()) | _TURN_AND_ANSWER_EVENTS
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2802,33 +2802,38 @@ class Session:
         # PR14: every top-level user submission starts a fresh chain_id that
         # propagates through any agent_request / agent_response generated in
         # response. Logged in history meta + events.jsonl for cross-agent trace.
-        await self._put_inbox(
-            "user", {"text": text, "chain_id": _new_chain_id()},
+        chain_id = _new_chain_id()
+        msg_id = await self._put_inbox(
+            "user", {"text": text, "chain_id": chain_id},
         )
-        # ADR-0039 multi-client input-broadcast fix: put the user's OWN turn on
-        # `session.outbox` too (not just the inbox that drives the turn), so it
-        # rides the SAME `outbox_hub` fan-out (P6b-1) the agent's reply already
-        # broadcasts through. Before this, a 2nd+ thin client (`reyn chat
-        # --connect`) saw the agent's reply with no prompt (half a conversation)
-        # — the local scrollback echo was a LOCAL-ONLY `transport.put_display`
-        # injection that never reached the hub (since removed from the inline
-        # CUI's submit path; every client, including this submitting one, now
-        # renders its own line from THIS broadcast frame — single source of
-        # truth, no double-render).
+        # #3300 P1 (C): the user-line echo is DRIVEN BY a `user_submitted`
+        # chat-event, not a parallel `_put_outbox` write (removed — was a
+        # category error: a user INPUT written into the display/OUTPUT
+        # channel, plus a double-write of the same text). Single source of
+        # truth = the inbox above; the echo every attached client (including
+        # THIS submitting one, ADR-0039 multi-client) renders is a DERIVED
+        # notification off this event — `_TURN_AND_ANSWER_EVENTS`
+        # (transport/frames.py) lists "user_submitted" so
+        # `renderer_chat_events()` auto-forwards it over BOTH the in-process
+        # and the AG-UI/SSE transport (generic EventFrame encode/decode,
+        # transport/agui/protocol.py — no per-surface wiring needed there).
         #
-        # The DISPLAY copy is neutralized (ESC/control strip — same
-        # `core/present/guard.get_neutralizer("terminal")` seam #2770 uses for
-        # intervention content) because this text now reaches every attached
-        # peer's terminal, not only the operator's own (a new cross-client
-        # surface a purely-local echo never had). The INBOX copy above (what the
-        # agent/router actually reads) stays raw — display neutralization never
-        # touches conversation content.
-        from reyn.core.present.guard import get_neutralizer
-        await self._put_outbox(OutboxMessage(
-            kind="user",
-            text=get_neutralizer("terminal").neutralize(text)[0],
+        # The payload carries the RAW text (neutralization moves to the
+        # DISPLAY boundary — each surface's event→display handler calls the
+        # same `core/present/guard.get_neutralizer("terminal")` seam #2770
+        # uses for intervention content, via
+        # `renderer.user_submitted_display_message`) — the inbox copy above
+        # (what the agent/router actually reads) is unaffected either way,
+        # display neutralization never touches conversation content. `msg_id`
+        # (the id `_put_inbox` stamps) rides along — load-bearing for a later
+        # phase (client learns its own message id, for cancel-by-id).
+        self._chat_events.emit(
+            "user_submitted",
+            text=text,
+            chain_id=chain_id,
+            _msg_id=msg_id,
             meta=_user_frame_meta(attribution),
-        ))
+        )
 
     async def submit_agent_request(
         self, *, from_agent: str, request: str, depth: int, chain_id: str,

--- a/tests/test_agui_mapping_completeness.py
+++ b/tests/test_agui_mapping_completeness.py
@@ -6,7 +6,7 @@ renderer consumes has two halves:
 - **DisplayFrame kinds** — the ``OutboxMessage.kind`` literals the renderer's
   ``message`` / ``format_inline_message`` dispatch on (AST-scanned from the
   renderer source, NOT from the codec's own table — non-circular).
-- **EventFrame types** — the eight ``renderer_chat_events()`` the transport
+- **EventFrame types** — the ``renderer_chat_events()`` set the transport
   forwards (derived, not hand-listed).
 
 For EACH, the codec must round-trip it: ``encode_frame`` → SSE → ``decode_event``
@@ -136,7 +136,7 @@ def test_every_display_kind_round_trips_over_the_wire() -> None:
 
 
 def test_every_forwarded_chat_event_round_trips_over_the_wire() -> None:
-    """Tier 2: each of the eight renderer_chat_events encodes→decodes back to the
+    """Tier 2: each of the renderer_chat_events encodes→decodes back to the
     same event type and data. Unmapped / lossy ⇒ RED."""
     events = renderer_chat_events()
 

--- a/tests/test_user_echo_broadcast.py
+++ b/tests/test_user_echo_broadcast.py
@@ -2,38 +2,41 @@
 
 With 2+ thin clients attached to one server (``reyn chat --connect``), the
 agent's replies already broadcast (``session.outbox`` -> ``outbox_hub`` fan-out,
-P6b-1), but the user's OWN turn did not: ``Session.submit_user_text`` only put
-the turn on the inbox (turn-drive), and the inline CUI's own scrollback echo was
-a LOCAL-ONLY ``transport.put_display`` injection that never rode the hub — a
-peer saw the agent's reply with no prompt (half a conversation, the dogfooded
-bug).
+P6b-1). The user's OWN turn used to ride the SAME outbox (a
+``self._put_outbox(OutboxMessage(kind="user", ...))`` call in
+``submit_user_text``) — #3300 P1 (C) replaced that outbox echo (a category
+error: an INPUT written into the display/OUTPUT channel, plus a double-write of
+the same text) with a ``user_submitted`` chat-event every attached surface's
+event→display handler renders — single source of truth = the inbox, echo =
+derived notification.
 
 Covers:
-  A. ``Session.submit_user_text`` now ALSO puts a ``kind="user"`` frame on
-     ``session.outbox`` -> every ``outbox_hub`` subscriber (= every attached
-     client, simulated here as two independent hub subscriptions) sees it.
-     Reverting the ``self._put_outbox(OutboxMessage(kind="user", ...))`` call
-     added to ``submit_user_text`` reproduces the bug directly: neither
-     subscription below would see a "user" frame at all.
+  A. ``Session.submit_user_text`` emits a ``user_submitted`` chat-event (NOT an
+     outbox frame) carrying the raw text + chain_id + _msg_id + meta — every
+     ``subscribe_chat_events`` subscriber (= every attached client, simulated
+     here as two independent subscriptions) sees it. Reverting the
+     ``self._chat_events.emit("user_submitted", ...)`` call added to
+     ``submit_user_text`` reproduces the bug directly: neither subscription
+     below would see a "user_submitted" event at all.
   B. ``InterventionHandler.deliver_answer_to`` — the ONE funnel every answer
      path (TUI free-text / TUI choice-region / A2A peer / AG-UI HITL) shares —
      broadcasts the SAME way for answer-path symmetry, using the DISPLAY text
      (raw / choice label), never the fenced history-bound copy: display and
      context are orthogonal sinks, so the external-source fence (FP-0050/#1862)
      is provably untouched (raw broadcast text vs. fenced history text, same
-     answer).
+     answer). Unaffected by the P1 (C) echo→event move (a separate mechanism).
 
 (Part C — the retired prompt_toolkit inline CUI's local double-echo suppression
 of ``_submit`` / ``_deliver_intervention_choice`` — was removed with that driver
-in the #3273 TUI-rebuild retirement; the outbox broadcast covered by Parts A/B
-is the sole surviving user-echo path.)
+in the #3273 TUI-rebuild retirement; the event broadcast covered by Part A is
+the sole surviving user-echo path.)
 
 Policy compliance (docs/deep-dives/contributing/testing.ja.md):
 - No unittest.mock / AsyncMock / patch usage — real Session / InterventionHandler
   / OutboxHub / InProcessTransport instances, or plain fakes (Fake > Mock).
-- Public surface observed: ``session.outbox_hub.subscribe()`` frames,
-  ``registry.repl_outbox`` (the only channel a local ``put_display`` echo could
-  reach), history dicts collected via an injected callback.
+- Public surface observed: ``session.subscribe_chat_events()`` callbacks,
+  ``session.outbox_hub.subscribe()`` frames (Part B, unaffected), history dicts
+  collected via an injected callback.
 - Each test docstring's first line declares its Tier.
 """
 from __future__ import annotations
@@ -62,7 +65,7 @@ from tests._support.agent_session import make_session
 
 
 def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
-    """Minimal real Session — no router/registry needed for the outbox-only
+    """Minimal real Session — no router/registry needed for the chat-event
     invariants exercised here."""
     session = make_session(
         agent_name=agent_name,
@@ -74,76 +77,129 @@ def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
     return session
 
 
+class _EventSink:
+    """A real (non-mock) chat-event subscriber — a plain callback collector,
+    standing in for one attached client's ``on_chat_event`` entry point."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def __call__(self, event) -> None:
+        self.events.append(event)
+
+
+def _user_submitted(sink: _EventSink):
+    matches = [e for e in sink.events if e.type == "user_submitted"]
+    assert matches, "no user_submitted event observed"
+    return matches[0]
+
+
 async def _get(sub, timeout: float = 2.0) -> OutboxMessage:
     return await asyncio.wait_for(sub.get(), timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
-# Part A — Session.submit_user_text broadcasts a kind="user" frame
+# Part A — Session.submit_user_text emits a user_submitted chat-event
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_submit_user_text_broadcasts_to_every_attached_surface(tmp_path, monkeypatch):
-    """Tier 2: submit_user_text puts a kind="user" frame on EVERY outbox_hub
-    subscriber, not just the inbox that drives the turn.
+async def test_submit_user_text_emits_user_submitted_to_every_subscriber(tmp_path, monkeypatch):
+    """Tier 2: submit_user_text emits a "user_submitted" chat-event to EVERY
+    chat-event subscriber, not just the inbox that drives the turn.
 
-    Two independent hub subscriptions stand in for two attached thin clients
+    Two independent subscriptions stand in for two attached thin clients
     (client A = the submitter, client B = a peer). Both must see the SAME
-    "user" frame — proving the fix closes the dogfooded half-conversation gap
-    (before this, a peer saw only the agent's eventual reply).
+    "user_submitted" event — proving the echo is a derived, fan-out
+    notification (ADR-0039), not a local-only side effect.
     """
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
 
-    client_a = session.outbox_hub.subscribe()
-    client_b = session.outbox_hub.subscribe()
+    sink_a, sink_b = _EventSink(), _EventSink()
+    session.subscribe_chat_events(sink_a)
+    session.subscribe_chat_events(sink_b)
 
     await session.submit_user_text("hello from client A")
 
-    msg_a = await _get(client_a)
-    msg_b = await _get(client_b)
+    ev_a, ev_b = _user_submitted(sink_a), _user_submitted(sink_b)
+    for ev in (ev_a, ev_b):
+        assert ev.data.get("text") == "hello from client A"
 
-    for msg in (msg_a, msg_b):
-        assert msg.kind == "user"
-        assert msg.text == "hello from client A"
+
+@pytest.mark.asyncio
+async def test_submit_user_text_no_outbox_user_echo(tmp_path, monkeypatch):
+    """Tier 2: the old outbox echo is GONE — a "user" kind frame no longer
+    rides ``session.outbox_hub`` after submit (single source = the
+    user_submitted event, not a parallel outbox write)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    sub = session.outbox_hub.subscribe()
+
+    await session.submit_user_text("hello, no outbox echo")
+
+    # Public surface only (HubSubscription.get, no private-queue peeking): a
+    # short-timeout get that raises TimeoutError proves nothing arrived — the
+    # old outbox echo would have delivered a "user" frame here immediately.
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(sub.get(), timeout=0.2)
+
+
+@pytest.mark.asyncio
+async def test_submit_user_text_carries_chain_id_and_msg_id(tmp_path, monkeypatch):
+    """Tier 2: the user_submitted event carries chain_id + _msg_id (the id
+    ``_put_inbox`` stamps) — load-bearing for a later phase (client learns its
+    own message id, for cancel-by-id)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
+
+    await session.submit_user_text("track my id")
+
+    ev = _user_submitted(sink)
+    assert ev.data.get("chain_id")
+    assert ev.data.get("_msg_id")
 
 
 @pytest.mark.asyncio
 async def test_submit_user_text_local_default_carries_no_attribution(tmp_path, monkeypatch):
     """Tier 2: a local/in-process submit (no ``attribution`` kwarg — the
     inline CUI's own ``ClientTransport.submit_user_text`` call shape) produces
-    a "user" frame with EMPTY meta — the single-client / operator case, so the
-    renderer's ``_meta_prefix`` shows the bare line (no ``[alice]`` prefix)."""
+    a "user_submitted" event with EMPTY meta — the single-client / operator
+    case, so the renderer's ``_meta_prefix`` shows the bare line (no
+    ``[alice]`` prefix)."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    sub = session.outbox_hub.subscribe()
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
 
     await session.submit_user_text("plain local turn")
 
-    msg = await _get(sub)
-    assert msg.kind == "user"
-    assert msg.meta == {}
+    ev = _user_submitted(sink)
+    assert ev.data.get("meta") == {}
 
 
 @pytest.mark.asyncio
-async def test_submit_user_text_remote_attribution_reaches_the_frame(tmp_path, monkeypatch):
+async def test_submit_user_text_remote_attribution_reaches_the_event(tmp_path, monkeypatch):
     """Tier 2: a remote (AG-UI POST) submit's ``attribution`` (auth_user_id +
     connection id — the P3 ``user_answered_intervention`` shape) lands in the
-    broadcast frame's ``meta``, so a multi-client renderer can show WHO typed
-    this turn."""
+    "user_submitted" event's ``meta``, so a multi-client renderer can show WHO
+    typed this turn."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
-    sub = session.outbox_hub.subscribe()
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
 
     await session.submit_user_text(
         "hi from the wire",
         attribution={"auth_user_id": "alice", "auth_connection_id": "conn-1"},
     )
 
-    msg = await _get(sub)
-    assert msg.meta.get("auth_user_id") == "alice"
-    assert msg.meta.get("auth_connection_id") == "conn-1"
+    ev = _user_submitted(sink)
+    meta = ev.data.get("meta") or {}
+    assert meta.get("auth_user_id") == "alice"
+    assert meta.get("auth_connection_id") == "conn-1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_user_submitted_render_3300.py
+++ b/tests/test_user_submitted_render_3300.py
@@ -1,0 +1,419 @@
+"""Tier 2: the "user_submitted" event's DISPLAY-boundary rendering (#3300 P1 C).
+
+``Session.submit_user_text`` (runtime/session.py) now emits a raw-text
+``user_submitted`` chat-event instead of writing a neutralized "user" frame
+straight to the outbox. Each surface's event->display handler is responsible
+for BOTH rendering the echo AND neutralizing (ESC/control strip) at render
+time — this file proves that per surface:
+
+- ``ConsoleChatRenderer.on_chat_event`` (the plain / --cui / non-TTY path,
+  ALSO the remote/agui path when it resolves non-interactive — same renderer
+  selection seam, ``logger_factory.make_renderer``).
+- ``InlineChatRenderer.on_chat_event`` (the ``chat.render_mode: plain``-on-a-
+  TTY fallback — reachable only when the Textual app is bypassed).
+- ``TextualChatApp._pump_frames`` (the default interactive-TTY surface,
+  ``interfaces/inline/textual_chat/app.py``) — appends the echo straight to
+  the retained conversation model via the SAME
+  ``user_submitted_display_message`` seam.
+
+Also covers the cross-cutting invariants the design pass called out:
+ordering (echo precedes the agent's turn) and multi-client (every attached
+subscriber sees its own rendered line, single source = the event, no
+double-render).
+
+Policy compliance (docs/deep-dives/contributing/testing.md):
+- No unittest.mock / MagicMock / AsyncMock / patch on a collaborator OBJECT.
+  Renderer instances and TextualChatApp's retained model are REAL. The only
+  monkeypatches are free-function swaps (``router_loop.call_llm_tools`` — the
+  same pattern ``test_1800_wake_drain.py`` uses — and ``sys.__stdout__`` for
+  output capture, mirroring ``test_renderer_console_width_2655.py``).
+- No private-state assertions — renders are observed via captured stdout /
+  the model's own iteration, chat-events via the public
+  ``subscribe_chat_events`` surface.
+- Each test docstring's first line declares its Tier.
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+from pathlib import Path
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.repl import renderer as renderer_module
+from reyn.interfaces.repl.renderer import (
+    ConsoleChatRenderer,
+    InlineChatRenderer,
+    user_submitted_display_message,
+)
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.llm.llm import LLMToolCallResult
+from reyn.llm.pricing import TokenUsage
+from reyn.runtime.outbox import OutboxMessage
+from reyn.runtime.session import Session
+from reyn.schemas.models import Event
+from tests._support.agent_session import make_session
+
+_RAW_ESC = "\x1b[31mdanger\x1b[0m"
+_EMPTY_USAGE = TokenUsage(prompt_tokens=5, completion_tokens=3)
+
+
+def _make_session(tmp_path: Path, *, agent_name: str = "test_agent") -> Session:
+    return make_session(
+        agent_name=agent_name,
+        state_log=StateLog(tmp_path / "state.wal"),
+        snapshot_path=tmp_path / f"{agent_name}_snapshot.json",
+    )
+
+
+def _make_llm_stub_fn(result):  # type: ignore[no-untyped-def]
+    """Real async callable mimicking call_llm_tools — no mock (mirrors
+    test_1800_wake_drain.py's helper)."""
+    async def _stub(**kwargs) -> LLMToolCallResult:  # noqa: ANN202
+        return result
+
+    return _stub
+
+
+async def _run_n_turns_then_shutdown(session: Session, n: int, timeout: float = 3.0) -> None:
+    turns_done = [0]
+    original_run_one = session.run_one_iteration
+
+    async def _counting_run_one() -> bool:
+        result = await original_run_one()
+        if result:
+            turns_done[0] += 1
+        return result
+
+    session.run_one_iteration = _counting_run_one  # type: ignore[method-assign]
+    run_task = asyncio.create_task(session.run())
+    deadline = asyncio.get_event_loop().time() + timeout
+    while turns_done[0] < n:
+        if asyncio.get_event_loop().time() > deadline:
+            break
+        await asyncio.sleep(0.005)
+    await session.shutdown()
+    try:
+        await asyncio.wait_for(run_task, timeout=2.0)
+    except asyncio.TimeoutError:
+        run_task.cancel()
+        await asyncio.gather(run_task, return_exceptions=True)
+
+
+class _EventSink:
+    """A real (non-mock) chat-event subscriber — a plain callback collector."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def __call__(self, event) -> None:
+        self.events.append(event)
+
+
+def _capture_stdout(monkeypatch) -> io.StringIO:
+    captured = io.StringIO()
+    monkeypatch.setattr(renderer_module.sys, "__stdout__", captured)
+    return captured
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from a
+    queue (mirrors ``test_textual_chat_orphan_sweep_72.py``'s helper) — lets a
+    test push an ``EventFrame`` and inspect ``TextualChatApp``'s retained
+    conversation model afterward, stream staying open throughout."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Contract: user_submitted_display_message (shared seam every surface calls)
+# ---------------------------------------------------------------------------
+
+
+def test_display_message_builds_kind_user_from_raw_event_data() -> None:
+    """Tier 1: user_submitted_display_message maps event.data -> a kind="user"
+    OutboxMessage, carrying meta through unchanged."""
+    event = Event(type="user_submitted", data={"text": "hello", "meta": {"actor": "alice"}})
+    msg = user_submitted_display_message(event)
+    assert msg.kind == "user"
+    assert msg.text == "hello"
+    assert msg.meta.get("actor") == "alice"
+
+
+def test_display_message_neutralizes_raw_esc_control_bytes() -> None:
+    """Tier 1: neutralize-at-display — a raw ESC/control sequence in the
+    event's raw text does NOT survive into the built display message. Strip
+    the ``get_neutralizer("terminal")`` call inside
+    ``user_submitted_display_message`` -> this assertion goes RED (a raw
+    leak), proving the neutralize call is load-bearing here."""
+    event = Event(type="user_submitted", data={"text": _RAW_ESC, "meta": {}})
+    msg = user_submitted_display_message(event)
+    assert "\x1b" not in msg.text
+    assert "danger" in msg.text
+
+
+# ---------------------------------------------------------------------------
+# Surface: ConsoleChatRenderer (plain / --cui / non-TTY / remote-non-interactive)
+# ---------------------------------------------------------------------------
+
+
+def test_console_renderer_renders_user_submitted_event(monkeypatch) -> None:
+    """Tier 2: ConsoleChatRenderer.on_chat_event renders the user line from a
+    "user_submitted" event (the removed outbox echo's replacement). Strip the
+    ``elif etype == "user_submitted"`` branch -> nothing below is written and
+    this assertion goes RED (non-vacuity)."""
+    out = _capture_stdout(monkeypatch)
+    r = ConsoleChatRenderer()
+    event = Event(type="user_submitted", data={"text": "hello from event", "meta": {}})
+
+    r.on_chat_event(event)
+
+    assert "hello from event" in out.getvalue()
+
+
+def test_console_renderer_neutralizes_at_render(monkeypatch) -> None:
+    """Tier 2: a raw ESC/control sequence submitted via the event does not
+    reach ConsoleChatRenderer's rendered output — strip the neutralize call
+    in ``user_submitted_display_message`` -> the raw ESC byte leaks into
+    captured stdout (RED)."""
+    out = _capture_stdout(monkeypatch)
+    r = ConsoleChatRenderer()
+    event = Event(type="user_submitted", data={"text": _RAW_ESC, "meta": {}})
+
+    r.on_chat_event(event)
+
+    rendered = out.getvalue()
+    assert "\x1b" not in rendered
+    assert "danger" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Surface: InlineChatRenderer (chat.render_mode=plain-on-a-TTY fallback path)
+# ---------------------------------------------------------------------------
+
+
+def test_inline_renderer_renders_user_submitted_event(monkeypatch) -> None:
+    """Tier 2: InlineChatRenderer.on_chat_event renders the user line from a
+    "user_submitted" event — the ONLY renderer entry point reachable when
+    this class runs the shared plain PromptSession loop instead of the
+    default TextualChatApp (client_driver.py: resolved render_mode="plain")."""
+    out = _capture_stdout(monkeypatch)
+    r = InlineChatRenderer()
+    event = Event(type="user_submitted", data={"text": "hello inline", "meta": {}})
+
+    r.on_chat_event(event)
+
+    assert "hello inline" in out.getvalue()
+
+
+def test_inline_renderer_neutralizes_at_render(monkeypatch) -> None:
+    """Tier 2: the RAW ESC-bearing text submitted via the event never reaches
+    InlineChatRenderer's rendered output verbatim (same neutralize-at-display
+    seam). InlineChatRenderer renders through a real Rich ``Console``, which
+    injects its OWN legitimate ANSI styling codes — so this asserts the
+    SPECIFIC submitted control sequence is gone (its ESC byte stripped,
+    leaving the harmless literal ``[31m``/``[0m`` bracket text Rich then
+    renders unstyled), not a blanket "no ESC anywhere" (that would fail on
+    Rich's own valid output)."""
+    out = _capture_stdout(monkeypatch)
+    r = InlineChatRenderer()
+    event = Event(type="user_submitted", data={"text": _RAW_ESC, "meta": {}})
+
+    r.on_chat_event(event)
+
+    rendered = out.getvalue()
+    assert _RAW_ESC not in rendered
+    assert "danger" in rendered
+    assert "[31m" in rendered  # the neutralized (ESC-stripped) literal remainder
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: ordering + multi-client, driven through a REAL session/turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_submitted_precedes_turn_started(tmp_path, monkeypatch) -> None:
+    """Tier 2: the user_submitted event for a turn fires BEFORE that turn's
+    turn_started — the user line renders before the agent's reply, driven
+    through a real Session + real turn (LLM faked via a real async callable,
+    not a mock, per policy)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+    sink = _EventSink()
+    session.subscribe_chat_events(sink)
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _make_llm_stub_fn(
+            LLMToolCallResult(
+                content="hi back", tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+            )
+        ),
+    )
+
+    await session.submit_user_text("hello")
+    await _run_n_turns_then_shutdown(session, n=1)
+    await session._journal.flush()
+
+    types = [e.type for e in sink.events]
+    assert "user_submitted" in types
+    assert "turn_started" in types
+    assert types.index("user_submitted") < types.index("turn_started")
+
+
+@pytest.mark.asyncio
+async def test_history_persistence_unaffected_by_the_echo_move(tmp_path, monkeypatch) -> None:
+    """Tier 2: the user line still reaches history via the inbox path,
+    unaffected by the outbox-echo -> event move — persistence was always
+    independent of the (now-removed) outbox write (run_one_iteration ->
+    _handle_user_message -> _append_history reads the INBOX copy, never the
+    outbox)."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    session.is_attached = True
+    monkeypatch.setattr(
+        "reyn.runtime.router_loop.call_llm_tools",
+        _make_llm_stub_fn(
+            LLMToolCallResult(
+                content="ack", tool_calls=[], finish_reason="stop", usage=_EMPTY_USAGE,
+            )
+        ),
+    )
+
+    await session.submit_user_text("persist me")
+    await _run_n_turns_then_shutdown(session, n=1)
+    await session._journal.flush()
+
+    texts = [m.content for m in session.history if m.role == "user"]
+    assert any("persist me" in str(t) for t in texts)
+
+
+@pytest.mark.asyncio
+async def test_multi_client_each_subscriber_gets_its_own_echo_no_double_render(
+    tmp_path, monkeypatch,
+) -> None:
+    """Tier 2: ADR-0039 multi-client preserved — TWO independent chat-event
+    subscribers (standing in for two attached clients, including the
+    submitter) each receive exactly ONE "user_submitted" event for one
+    submit — single source (the event), no double-render, no client-local-
+    only echo."""
+    monkeypatch.chdir(tmp_path)
+    session = _make_session(tmp_path)
+    sink_a, sink_b = _EventSink(), _EventSink()
+    session.subscribe_chat_events(sink_a)
+    session.subscribe_chat_events(sink_b)
+
+    await session.submit_user_text("one submit, two clients")
+
+    for sink in (sink_a, sink_b):
+        matches = [e for e in sink.events if e.type == "user_submitted"]
+        # Exactly one — variable-binding idiom (per test-audit policy) instead
+        # of a bare len(...) == N pin.
+        (only,) = matches
+        assert only.data.get("text") == "one submit, two clients"
+
+
+# ---------------------------------------------------------------------------
+# Surface: TextualChatApp (the default interactive-TTY surface)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_textual_chat_app_renders_user_submitted_event() -> None:
+    """Tier 2b: TextualChatApp._pump_frames appends a "user" entry to the
+    retained conversation model from a "user_submitted" EVENT frame — the
+    Textual surface's replacement for the removed outbox echo. In Phase C
+    this is a normal flow entry (the sent-queue staging is Phase B)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            Event(type="user_submitted", data={"text": "hi from textual", "meta": {}})
+        )
+        await pilot.pause()
+
+        entries = app.query_one(FlowView).entries
+        (entry,) = [e for e in entries if e.item.kind == "user"]
+        assert entry.item.text == "hi from textual"
+
+
+@pytest.mark.asyncio
+async def test_textual_chat_app_neutralizes_at_render() -> None:
+    """Tier 2b: a raw ESC/control sequence submitted via the event does not
+    reach TextualChatApp's retained model — same neutralize-at-display seam
+    every surface calls (``user_submitted_display_message``)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            Event(type="user_submitted", data={"text": _RAW_ESC, "meta": {}})
+        )
+        await pilot.pause()
+
+        entries = app.query_one(FlowView).entries
+        (entry,) = [e for e in entries if e.item.kind == "user"]
+        assert "\x1b" not in entry.item.text
+        assert "danger" in entry.item.text
+
+
+@pytest.mark.asyncio
+async def test_textual_chat_app_ignores_non_user_submitted_events_for_flow() -> None:
+    """Tier 2b: non-vacuity witness — a DIFFERENT event type (turn_started)
+    does NOT append a "user" entry, proving the prior tests' entry came
+    specifically from the "user_submitted" branch, not from generic event
+    handling."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(Event(type="turn_started", data={}))
+        await pilot.pause()
+
+        entries = app.query_one(FlowView).entries
+        assert not [e for e in entries if e.item.kind == "user"]


### PR DESCRIPTION
**[per-PR-coder]** — Phase 1 (C) of the input-message-lifecycle arc (part of #3300): abolish the outbox user-echo, drive it from a `user_submitted` chat-event instead.

## What changed

`Session.submit_user_text` (`src/reyn/runtime/session.py`) used to write the user's message into BOTH the inbox (`_put_inbox` — what the agent reads, the persistence source) AND the outbox (`_put_outbox`, neutralized — a display-only broadcast). That's a category error (an INPUT riding the OUTPUT/display channel) plus a double-write.

- Removed the `_put_outbox` user-echo (including its inline neutralize call) from `submit_user_text`. The `_put_inbox` call is unchanged.
- Added a `user_submitted` chat-event: `"user_submitted"` is now in `_TURN_AND_ANSWER_EVENTS` (`transport/frames.py`), so `renderer_chat_events()` auto-forwards it, same pattern as `turn_started`. Payload carries **raw** text + `chain_id` + `_msg_id` (the id `_put_inbox` stamps — load-bearing for a later cancel-by-id phase) + attribution-derived `meta`.
- Neutralization moved to the display boundary: a new shared seam, `reyn.interfaces.repl.renderer.user_submitted_display_message(event)`, builds the display `OutboxMessage` and neutralizes (`core/present/guard.get_neutralizer("terminal")`, ESC/control strip — same seam #2770 uses) at render time.
- Added an event→display handler on each surface:
  - `ConsoleChatRenderer.on_chat_event` (plain / `--cui` / non-TTY, also the remote/agui path when it resolves non-interactive — same `logger_factory.make_renderer` seam).
  - `InlineChatRenderer.on_chat_event` (the `chat.render_mode: plain`-on-a-TTY fallback, reachable when the Textual app is bypassed).
  - `TextualChatApp._pump_frames` (`interfaces/inline/textual_chat/app.py`) — the default interactive-TTY surface, appends the echo straight into the retained conversation model via the same seam. In Phase C this is a normal flow entry (sent-queue staging is Phase B, not built here).
- Registered the new `reyn.event.user_submitted` CUSTOM name in the AG-UI extension profile (`transport/agui/profile.py`) — the profile-completeness gate is closed-member, so the new event needed an entry there even though the wire encode/decode itself is fully generic (no protocol.py changes needed beyond a comment fix).
- Updated `docs/reference/runtime/agui-transport.md` (+ `.ja.md`) — the "Local ≡ remote holds for INPUT too" section asserted the outbox-echo mechanism verbatim; fixed in this PR per the doc-goes-stale-same-PR rule, plus the `reyn.event.<etype>` table row.

## (a) Consumer-audit — outbox `kind=="user"` non-display consumers: ZERO

```
grep -rn 'kind == "user"\|kind=="user"' src/reyn/interfaces/ src/reyn/runtime/
```
Every hit is one of:
- **Display-only** rendering: `interfaces/repl/renderer.py` (`format_inline_message`), `interfaces/inline/textual_chat/{app,presenter}.py` (flow-entry role coloring / history-drawer rows).
- **History hydration from the persisted log** (`interfaces/inline/textual_chat/restore.py`) — reconstructs `OutboxMessage(kind="user", ...)` display frames straight from `history.jsonl` at app mount, never touches the live outbox.
- **A separate mechanism, untouched by this PR**: `InterventionHandler`'s own `kind="user"` answer-broadcast (`runtime/services/intervention_handler.py`) — a different call site (`deliver_answer_to`), not `submit_user_text`'s echo. Left as-is; `tests/test_user_echo_broadcast.py` Part B (unchanged) still covers it.

No non-display consumer found — matches the architect's grounding.

## (b) Neutralize-at-display + raw-leak test

`user_submitted_display_message` neutralizes at render time; `test_display_message_neutralizes_raw_esc_control_bytes` plus per-surface tests (`test_console_renderer_neutralizes_at_render`, `test_inline_renderer_neutralizes_at_render`, `test_textual_chat_app_neutralizes_at_render`) submit a raw ESC/control sequence and assert it never reaches the rendered output. Manually strip-falsified the `ConsoleChatRenderer`/`InlineChatRenderer` `user_submitted` branch — both render tests go RED (confirmed non-vacuous), then restored.

## (c) Surfaces covered + dual-stream gate

Console (plain), Inline (render_mode=plain-on-TTY fallback), TextualChatApp (default interactive TTY) all have handlers; remote/agui needs no separate code — it rides the same generic `EventFrame` encode/decode (`transport/agui/protocol.py`) and the same renderer-selection seam (`logger_factory.make_renderer`), so local ≡ remote holds structurally. `tests/test_transport_dual_stream_completeness.py` is green (it AST-scans `on_chat_event` for the literal and requires it in the forward-set — satisfied since I added the branch + the frozenset entry).

## (d) ADR-0039 multi-client preserved

`test_multi_client_each_subscriber_gets_its_own_echo_no_double_render`: two independent chat-event subscribers (submitter + peer) each get exactly one `user_submitted` event per submit — single source (the event), no double-render, no client-local-only echo.

## (e) Gates + pytest

- `ruff check src tests` — green.
- `python scripts/test_tier_audit.py --strict <changed test files>` — 0 errors (24 tests inspected across the two touched/added test files).
- `uv run python -m pytest --timeout=120` (foreground, full suite) — **9146 passed, 36 skipped, 0 failed** (535s).
- `python scripts/verify_module_docstrings.py <changed src files>` — green.
- Dual-stream completeness (`tests/test_transport_dual_stream_completeness.py`) — green (the surface-coverage signal).

## Tests added/changed

- `tests/test_user_submitted_render_3300.py` (new): shared-seam contract (build + neutralize), per-surface render (Console/Inline/TextualChatApp), neutralize-at-display (all 3 surfaces), ordering (`user_submitted` precedes `turn_started` for a real turn), persistence-unaffected (history still reaches via inbox), multi-client no-double-render, non-vacuity witness (a different event type doesn't append a flow entry).
- `tests/test_user_echo_broadcast.py` Part A rewritten from outbox-subscription assertions to chat-event-subscription assertions (Part B, the `InterventionHandler` answer-broadcast, is untouched — a separate mechanism).
- `tests/test_agui_mapping_completeness.py`: comment fix (stale "eight" count, now non-fixed via generic wording).

## Scope

Does NOT build the sent-queue rendering, snapshot/delta publish, or cancel-by-id — those are Phases B and Y (later PRs per the architect's design pass, issue #3300).