### PR TITLE
feat(runtime): publish server-authoritative queue + turn-active state (snapshot+delta) — #3300 P2a

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -264,9 +264,18 @@ WaitingOn ラベル)は**read-model**であり、ファイルミラーではな�
 
 - `STATE_SNAPSHOT` — **接続時**に発行される、read-model 全体。フィールド: `attached_name`、
   `model`、`cost_agent`、`cost_total`、`agent_tokens`、`ctx_used`、`ctx_window`、
-  `waiting_on`。
+  `waiting_on`、`queue`、`turn_active`。
 - `STATE_DELTA` — **変更時**に発行され、変更されたキーのみを運ぶ。アイドルなストリームは
   delta を発行しない。
+
+`queue` と `turn_active`(#3300 P2a)は、サーバー権威の **sent-queue 状態**を publish する:
+`queue` は現在未 dispatch の inbox キュー(各 item は `{msg_id, chain_id, text}` —
+`Session.queued_user_messages()`)、`turn_active` は turn が現在 dispatch 中かどうか
+(`Session.turn_active`)。同じ snapshot+delta channel に乗せることで、client は
+**late-joiner-safe** になる: turn 途中で接続した(dispatch を引き起こした
+`turn_started` chat-event を見逃した)client も、部分的な event 由来の推測ではなく
+snapshot から正しい queue + turn-active 状態を得る。P2a はこの状態の publish のみで、
+sent-queue widget としての描画は P2b。
 
 client は snapshot から自身のステータスビューを seed し、各 delta をマージするため、
 remote のステータスパネルは常に server の値を反映する。
@@ -327,7 +336,7 @@ display 行のテキストである。
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | ユーザーが intervention に回答した              |
-| `reyn.event.user_submitted`          | ユーザーがターンを送信した(#3300 P1 C)— RAW text + chain_id + _msg_id + meta を運ぶ。各 surface がそれぞれの render 境界で neutralize する |
+| `reyn.event.user_submitted`          | ユーザーがターンを送信した(#3300 P1 C)— RAW text + chain_id + msg_id + seq + meta を運ぶ。各 surface がそれぞれの render 境界で neutralize する。`msg_id`/`seq` は #3300 P2a の sent-queue correlation id + order-race-gate token |
 
 ### `reyn.intervention.<kind>`
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -275,9 +275,19 @@ state, and only the render-relevant subset is streamed.
 
 - `STATE_SNAPSHOT` — emitted **on connect**, the full read-model. Fields:
   `attached_name`, `model`, `cost_agent`, `cost_total`, `agent_tokens`,
-  `ctx_used`, `ctx_window`, `waiting_on`.
+  `ctx_used`, `ctx_window`, `waiting_on`, `queue`, `turn_active`.
 - `STATE_DELTA` — emitted **on change**, carrying only the changed keys. An idle
   stream emits no deltas.
+
+`queue` and `turn_active` (#3300 P2a) publish the server-authoritative
+**sent-queue state**: `queue` is the current undispatched inbox queue (each
+item `{msg_id, chain_id, text}` — `Session.queued_user_messages()`), and
+`turn_active` is whether a turn is currently dispatched
+(`Session.turn_active`). Riding the same snapshot+delta channel makes a client
+**late-joiner-safe**: connecting mid-turn (having missed the `turn_started`
+chat-event that dispatched the in-flight item) still gets the correct queue +
+turn-active state from the snapshot, not a partial event-derived guess. P2a
+publishes this state only — rendering it as a sent-queue widget is P2b.
 
 The client seeds its status view from the snapshot and merges each delta, so the
 remote status panel always reflects the server's values.
@@ -351,7 +361,7 @@ is the event's data object.
 | Custom `name`                        | Meaning                                          |
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention             |
-| `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + _msg_id + meta; each surface neutralizes at its render boundary |
+| `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
 
 ### `reyn.intervention.<kind>`
 

--- a/src/reyn/interfaces/repl/status.py
+++ b/src/reyn/interfaces/repl/status.py
@@ -364,4 +364,19 @@ def _snapshot(registry, config=None):
         # Always available (Session owns a PipelineRegistry from __init__) —
         # not a "not wired yet" seam like the two lines above.
         "pipelines": _session_pipelines(s),
+        # #3300 P2a: server-authoritative sent-queue state — the undispatched
+        # inbox queue + whether a turn is currently dispatched. Read straight
+        # off the session's public accessors (Session.queued_user_messages /
+        # Session.turn_active); this dict is the SAME snapshot both the local
+        # (in-process, read live every render tick) and remote (agui, via
+        # project_status -> STATE_SNAPSHOT/STATE_DELTA) clients derive their
+        # queue view from, so local ≡ remote by construction.
+        "queue": s.queued_user_messages(),
+        "turn_active": s.turn_active,
+        # The seq-gate token (#3300 P2a design-pass pin D) — a client merging
+        # the granular `user_submitted`/`turn_started` queue deltas seeds its
+        # last-applied-seq from this value on snapshot, so a stale delta
+        # (seq <= this) already reflected here can never resurrect a
+        # dispatched item regardless of arrival order.
+        "queue_seq": s.queue_seq,
     }

--- a/src/reyn/interfaces/transport/agui/__init__.py
+++ b/src/reyn/interfaces/transport/agui/__init__.py
@@ -45,6 +45,7 @@ from reyn.interfaces.transport.agui.protocol import (
     to_sse,
 )
 from reyn.interfaces.transport.agui.state import (
+    RemoteQueueView,
     RemoteStatusView,
     StatusModel,
     project_status,
@@ -75,6 +76,7 @@ __all__ = [
     "intervention_tool_name",
     "parse_sse_blocks",
     "to_sse",
+    "RemoteQueueView",
     "RemoteStatusView",
     "StatusModel",
     "project_status",

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -133,9 +133,10 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
     CustomName(
         "reyn.event.user_submitted", EVENT_NS, "the event data object",
         "a user turn was submitted (#3300 P1 C) — carries the RAW text + "
-        "chain_id + _msg_id + meta; each surface's event→display handler "
+        "chain_id + msg_id + seq + meta; each surface's event→display handler "
         "renders the echo and neutralizes at that render boundary "
-        "(replaces the earlier kind=\"user\" outbox-echo write)",
+        "(replaces the earlier kind=\"user\" outbox-echo write); msg_id/seq "
+        "are the #3300 P2a sent-queue correlation id + order-race-gate token",
     ),
 )
 

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -9,7 +9,13 @@ connect) + ``STATE_DELTA`` (on change). This module owns three pieces:
   subset of the existing inline status snapshot (the ``_snapshot`` dict the CUI
   already builds). It is a *read-model*, NOT a file mirror — it derives from the
   session's live cost / token / ctx accessors and the current WaitingOn label,
-  and carries only what a status panel renders.
+  and carries only what a status panel renders. #3300 P2a additionally folds in
+  the server-authoritative sent-queue state (``queue`` — the undispatched inbox
+  items, ``Session.queued_user_messages()`` — + ``turn_active`` —
+  ``Session.turn_active``) onto this SAME snapshot/delta channel, so a queue
+  consumer (a test harness today; the P2b sent-queue widget later) is
+  late-joiner-safe for free: it need not have observed every prior
+  ``user_submitted``/``turn_started`` chat-event, only the current snapshot.
 - :class:`StatusModel` — the server-side differ: holds the last projected view
   and yields the changed keys (:meth:`delta`) so the emitter streams a compact
   ``STATE_DELTA`` instead of a full snapshot on every tick.
@@ -39,6 +45,18 @@ _WIRE_KEYS = (
     "ctx_used",
     "ctx_window",
     "waiting_on",
+    # #3300 P2a: server-authoritative sent-queue state — the undispatched
+    # inbox queue (list of {msg_id, chain_id, text}) + whether a turn is
+    # currently dispatched. Rides this SAME STATE_SNAPSHOT/STATE_DELTA
+    # channel (connect-time snapshot + delta thereafter) so a remote client
+    # is late-joiner-safe: a client connecting mid-turn gets the correct
+    # queue + turn_active from the snapshot rather than needing to have
+    # observed every prior turn_started/user_submitted chat-event.
+    "queue",
+    "turn_active",
+    # The order-race gate token (#3300 P2a design-pass pin D) — see
+    # `RemoteQueueView` below.
+    "queue_seq",
 )
 
 
@@ -60,6 +78,10 @@ def project_status(snapshot: "dict | None", *, waiting_on: "str | None" = None) 
         "ctx_used": snap.get("ctx_used", 0),
         "ctx_window": snap.get("ctx_window", 0),
         "waiting_on": waiting_on,
+        # #3300 P2a: sent-queue state, see _WIRE_KEYS above.
+        "queue": snap.get("queue", []),
+        "turn_active": snap.get("turn_active", False),
+        "queue_seq": snap.get("queue_seq", 0),
     }
     return out
 
@@ -108,6 +130,86 @@ class RemoteStatusView:
         return self.values.get(key, default)
 
 
+@dataclass
+class RemoteQueueView:
+    """Client-side sent-queue reader (#3300 P2a) — merges a ``STATE_SNAPSHOT``
+    queue baseline with the granular ``user_submitted`` (enqueue) /
+    ``turn_started`` (dispatch) chat-event deltas, using the **seq-gate**
+    order-race protocol (design-pass pin D).
+
+    Why a seq gate: ``RemoteStatusView`` above is safe because its delta is
+    always the SERVER's freshly-recomputed full value, diffed against its own
+    last-sent view (self-healing on every frame, no stale-add). A consumer
+    that instead reconstructs the queue from the granular
+    ``user_submitted``/``turn_started`` events ONE ITEM AT A TIME (e.g. for a
+    smooth enter/promote UI transition, P2b) has no such self-healing — it
+    must resolve the classic race directly: a client that reads a
+    ``STATE_SNAPSHOT`` AFTER an item was already dispatched (so the snapshot's
+    ``queue`` no longer contains it) must not let an out-of-order / stale
+    ``user_submitted`` delta for that SAME item resurrect it.
+
+    Protocol: every mutation (enqueue via ``user_submitted``, dispatch via
+    ``turn_started``) is stamped with a strictly-monotonic ``seq``
+    (``Session._bump_queue_seq``); ``STATE_SNAPSHOT`` carries the current
+    counter value as ``queue_seq``. This view tracks the highest ``seq`` it
+    has applied (seeded from ``queue_seq`` on :meth:`apply_snapshot`) and
+    discards any delta whose ``seq`` is not strictly greater. Because a
+    dispatch's ``seq`` is always greater than its own item's enqueue ``seq``
+    (single monotonic counter, same session, same event loop), and a snapshot
+    taken after that dispatch carries a ``queue_seq`` at least as large as the
+    dispatch's — a stale enqueue for an already-dispatched item can never pass
+    the gate. This holds for ANY interleaving of the snapshot read and the
+    delta stream: no duplicate (a replayed delta's ``seq`` was already
+    applied), no resurrection-after-dispatch (the above), no loss (a delta
+    whose ``seq`` IS new is always applied).
+    """
+
+    items: dict = field(default_factory=dict)  # msg_id -> {msg_id, chain_id, text}
+    turn_active: bool = False
+    _last_seq: int = 0
+
+    def apply_snapshot(self, *, queue: "list[dict]", turn_active: bool, queue_seq: int) -> None:
+        """Seed the view from a ``STATE_SNAPSHOT`` — replaces the queue
+        wholesale and seeds the seq gate so no earlier-or-equal delta can
+        still mutate a state this snapshot already supersedes."""
+        self.items = {
+            item["msg_id"]: dict(item) for item in queue if item.get("msg_id")
+        }
+        self.turn_active = turn_active
+        self._last_seq = queue_seq
+
+    def apply_user_submitted(self, *, msg_id: str, chain_id: "str | None", text: str, seq: int) -> bool:
+        """Apply an enqueue delta; returns False (no-op) if the seq gate
+        rejects it as already reflected by a prior snapshot/delta."""
+        if seq <= self._last_seq:
+            return False
+        self.items[msg_id] = {"msg_id": msg_id, "chain_id": chain_id, "text": text}
+        self._last_seq = seq
+        return True
+
+    def apply_turn_started(self, *, chain_id: "str | None", seq: int) -> bool:
+        """Apply a dispatch delta (removes the queued item matching
+        ``chain_id``, if any); returns False (no-op) if the seq gate rejects
+        it as already reflected."""
+        if seq <= self._last_seq:
+            return False
+        for msg_id, item in list(self.items.items()):
+            if item.get("chain_id") == chain_id:
+                del self.items[msg_id]
+        self._last_seq = seq
+        return True
+
+    def apply_turn_active(self, turn_active: bool) -> None:
+        """Apply a plain turn-active flip (e.g. from a ``turn_settled``
+        chat-event or a ``STATE_DELTA``'s ``turn_active`` key) — not
+        seq-gated: idempotent boolean, no resurrection risk."""
+        self.turn_active = turn_active
+
+    def queue(self) -> "list[dict]":
+        """The current queue view, insertion order."""
+        return list(self.items.values())
+
+
 def reguard_nodes(nodes: "list[dict]", *, surface: str = "terminal") -> list[dict]:
     """Re-run the surface neutralizer over every leaf string in render nodes (A5).
 
@@ -140,5 +242,6 @@ __all__ = [
     "project_status",
     "StatusModel",
     "RemoteStatusView",
+    "RemoteQueueView",
     "reguard_nodes",
 ]

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -61,9 +61,11 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
         "user_answered_intervention",
         # #3300 P1 (C): the user-line echo, driven by an event instead of a
         # parallel outbox write (session.submit_user_text). Carries raw text +
-        # chain_id + _msg_id + attribution meta; each surface's
+        # chain_id + msg_id + attribution meta; each surface's
         # event→display handler neutralizes at render time (see
         # ``reyn.interfaces.repl.renderer.user_submitted_display_message``).
+        # #3300 P2a: also carries `seq` (the sent-queue order-race-gate
+        # token, see ``Session._bump_queue_seq``).
         "user_submitted",
     }
 )

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1191,6 +1191,15 @@ class Session:
         # Turn-idle event for quiescence; lets a global rewind await_quiescent before the reset-record append (ADR-0038 Stage 1c, see session-construction.md#family-2-recovery-wal-journal)
         self._turn_idle = asyncio.Event()
         self._turn_idle.set()
+        # #3300 P2a: monotonic sent-queue-mutation counter — an order-race gate
+        # for a client merging the granular `user_submitted`/`turn_started`
+        # queue deltas (see `_bump_queue_seq` for the full rationale). In-memory
+        # only, deliberately not WAL-durable: it is a client read-model
+        # liveness aid (resolves snapshot/delta interleaving), not recovery
+        # state — a restart safely resumes from 0 because a fresh connection's
+        # STATE_SNAPSHOT always seeds the client's last-applied seq before any
+        # delta is merged.
+        self._queue_seq: int = 0
         self._turn_owner_task: "asyncio.Task | None" = None  # lets await_quiescent skip its wait when called re-entrantly from the owning task
         # #2242: True only for the window between cancel_inflight() calling
         # `_turn_owner_task.cancel()` and run_one_iteration observing the
@@ -1653,6 +1662,49 @@ class Session:
         this surface.
         """
         return self._router_loop_agent_replies
+
+    @property
+    def turn_active(self) -> bool:
+        """Read-only accessor: True while a turn is dispatched and in flight,
+        False when idle (#3300 P2a).
+
+        Exposes ``_turn_idle`` (ADR-0038 Stage 1c, cleared at turn-dispatch
+        :meth:`run_one_iteration`, set in that turn's ``finally``) as a
+        public read — this is surfacing EXISTING state, not a new authority.
+        A client (in-process or remote/agui) uses this alongside
+        :meth:`queued_user_messages` to render whether the next queued
+        message will dispatch immediately (idle) or wait (busy).
+        """
+        return not self._turn_idle.is_set()
+
+    def _bump_queue_seq(self) -> int:
+        """Advance + return the sent-queue mutation seq counter (#3300 P2a).
+
+        Called once per queue-affecting mutation — a ``user`` item entering
+        the inbox (``submit_user_text``) or leaving it (dispatch,
+        ``turn_started``) — and the returned value is stamped onto that
+        mutation's chat-event (``seq=``). A client merging the granular
+        ``user_submitted``/``turn_started`` deltas keeps the highest ``seq``
+        it has applied (seeded from ``STATE_SNAPSHOT``'s ``queue_seq``) and
+        discards any delta whose ``seq`` is not strictly greater — this is
+        the order-race gate: a stale/duplicate ``user_submitted`` for an
+        item ALREADY dispatched (whose ``turn_started`` carries a higher
+        seq, itself ≤ a snapshot taken after that dispatch) can never
+        resurrect the item in the client's queue model, regardless of the
+        arrival order of the snapshot read vs. the delta delivery. Every
+        turn (not only ``kind=="user"``) bumps this counter at
+        ``turn_started`` — harmless for non-queue turns (nothing in the
+        client's queue model matches their ``chain_id``), and keeps the
+        counter a single, simple, strictly-monotonic sequence.
+        """
+        self._queue_seq += 1
+        return self._queue_seq
+
+    @property
+    def queue_seq(self) -> int:
+        """Read-only accessor for the current queue-mutation seq counter
+        (#3300 P2a) — see :meth:`_bump_queue_seq`."""
+        return self._queue_seq
 
     @property
     def router_host(self):
@@ -2827,11 +2879,24 @@ class Session:
         # display neutralization never touches conversation content. `msg_id`
         # (the id `_put_inbox` stamps) rides along — load-bearing for a later
         # phase (client learns its own message id, for cancel-by-id).
+        #
+        # #3300 P2a design-pass pin (E): the field is named `msg_id` (not
+        # `_msg_id`) HERE, at the wire/event boundary — this event reaches a
+        # remote agui client via the generic EventFrame encode (no per-field
+        # allowlist), so its key names are a PUBLIC wire contract the moment
+        # they're emitted. The leading underscore stays on the INTERNAL inbox
+        # payload key (`_put_inbox`/`_consume_inbox`/snapshot_journal.py —
+        # never wire-facing) — this emit call is the one boundary that maps
+        # between the two. `seq` is the sent-queue mutation counter
+        # (`_bump_queue_seq`) — the order-race gate a client merging this
+        # event with `turn_started` and a `STATE_SNAPSHOT` queue baseline
+        # uses to resolve any interleaving (see `_bump_queue_seq` docstring).
         self._chat_events.emit(
             "user_submitted",
             text=text,
             chain_id=chain_id,
-            _msg_id=msg_id,
+            msg_id=msg_id,
+            seq=self._bump_queue_seq(),
             meta=_user_frame_meta(attribution),
         )
 
@@ -4693,6 +4758,35 @@ class Session:
         await self.inbox.put((kind, full_payload))
         return msg_id
 
+    def queued_user_messages(self) -> "list[dict]":
+        """Read-only accessor: the current UNDISPATCHED ``kind=="user"`` inbox
+        queue — the server-authoritative sent-queue state a client renders
+        (#3300 P2a; rendering itself is P2b).
+
+        Reads ``self._journal.snapshot.inbox`` — the SAME snapshot-backed,
+        WAL-durable list ``append_inbox``/``consume_inbox``
+        (``runtime/services/snapshot_journal.py``) keep current, so this is
+        exposure of existing server-authoritative state, not a new one. Only
+        ``kind=="user"`` items are surfaced (the sent-queue concept covers
+        top-level user submissions; ``agent_request``/``agent_response``/
+        ``pipeline_result`` inbox items are internal wake triggers, never
+        rendered as a queued user message).
+
+        Each item: ``{"msg_id": str, "chain_id": str | None, "text": str | None}``
+        — ``msg_id``/``chain_id`` are the correlation ids a client matches
+        against the ``user_submitted`` (enqueue) / ``turn_started`` (dispatch)
+        chat-event deltas to keep its queue model in sync.
+        """
+        return [
+            {
+                "msg_id": item.get("id"),
+                "chain_id": item.get("payload", {}).get("chain_id"),
+                "text": item.get("payload", {}).get("text"),
+            }
+            for item in self.journal.snapshot.inbox
+            if item.get("kind") == "user"
+        ]
+
     async def _consume_inbox(self) -> tuple[str, dict]:
         """Wait for next inbox message; on receive, record `inbox_consume`
         via journal (skipped for shutdown signals which are out-of-band)."""
@@ -5065,10 +5159,18 @@ class Session:
         # trigger is consumed and before dispatch, so slice 5b can attach the
         # turn_start hook here. chain_id from the payload (may be absent for
         # non-user triggers — that is fine, kind alone identifies the turn type).
+        # #3300 P2a: `seq` is the sent-queue mutation counter
+        # (`_bump_queue_seq`) — for a `kind=="user"` turn this is the
+        # DISPATCH mutation (the item leaves the undispatched queue), the
+        # order-race-gate counterpart to `user_submitted`'s enqueue `seq`
+        # (see that emit's comment + `_bump_queue_seq` docstring). Bumped
+        # for every turn kind (not only "user") to keep the counter a
+        # single strictly-monotonic sequence; harmless for non-queue turns.
         self._chat_events.emit(
             "turn_started",
             kind=kind,
             chain_id=payload.get("chain_id"),
+            seq=self._bump_queue_seq(),
         )
         # #1800 slice 5b: turn_start lifecycle hooks.
         await self._hook_dispatcher.dispatch(

--- a/tests/test_3300_p2a_queue_state_publish.py
+++ b/tests/test_3300_p2a_queue_state_publish.py
@@ -1,0 +1,392 @@
+"""#3300 P2a — publish server-authoritative sent-queue + turn-active state.
+
+Phase 2a of the input-message-lifecycle arc: make the server-authoritative
+queue state (the current UNDISPATCHED inbox items + whether a turn is
+dispatched) knowable to a client via snapshot + deltas — never derived by a
+client guessing from a partial event stream it may have joined mid-turn
+(the late-joiner hazard). Rendering that state (the sent-queue widget) is
+P2b, out of scope here — this file gates the TRANSPORT/STATE layer only.
+
+Covers (see the architect's #3300 design-pass comments on the issue):
+
+  1. **turn-active accessor** (additive) — ``Session.turn_active`` exposes the
+     existing ``_turn_idle`` event as a public read, not a new authority.
+  2. **queued_user_messages()** — ``Session``'s read-only accessor for the
+     current undispatched ``kind=="user"`` inbox queue (snapshot-backed via
+     ``SnapshotJournal``, same durable state ``append_inbox``/``consume_inbox``
+     already keep current).
+  3. **remote parity** — the same queue+turn-active values reach a remote
+     (agui) client via ``STATE_SNAPSHOT``/``STATE_DELTA`` as a local
+     (in-process, direct accessor read) client sees.
+  4. **late-joiner-safe (non-vacuity)** — a client "connecting" DURING a turn
+     (having missed the ``turn_started`` that dispatched the in-flight item)
+     reconstructs the CORRECT queue + turn-active from the snapshot alone.
+  5. **order-race gate (design-pass pin D)** — ``RemoteQueueView``'s seq-gated
+     merge of the granular ``user_submitted``/``turn_started`` deltas is safe
+     under ANY interleaving with a snapshot read: no duplicate, no
+     resurrection-after-dispatch, no loss.
+  6. **deltas keep the model in sync** — a real session's ``user_submitted``
+     (enqueue) and ``turn_started`` (dispatch) chat-events, consumed through
+     ``RemoteQueueView``, produce an accurate queue model end-to-end.
+
+Real ``Session``/``AgentRegistry``/``StateLog`` throughout — no
+``unittest.mock``. The only "fake" collaborator is the same controllable
+plain-async-function hang ``tests/test_2242_hard_cancel.py`` uses for
+``RouterLoopDriver.run_turn`` (a real method-assignment, not a mock), which is
+the established no-mock seam for putting a turn genuinely "mid-flight"
+without a real LLM call.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.repl.status import _snapshot
+from reyn.interfaces.transport.agui.client import AgUiTransport
+from reyn.interfaces.transport.agui.emitter import AgUiEmitter
+from reyn.interfaces.transport.agui.state import RemoteQueueView
+from reyn.runtime.profile import AgentProfile
+from reyn.runtime.registry import AgentRegistry
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+AGENT = "p2a-queue-agent"
+
+
+def _make_session(wal: Path, snapshot_path: Path, *, agent_name: str = AGENT) -> Session:
+    state_log = StateLog(wal)
+    return make_session(agent_name=agent_name, state_log=state_log, snapshot_path=snapshot_path)
+
+
+def _make_registry(tmp_path: Path) -> AgentRegistry:
+    state_log = StateLog(tmp_path / "state.wal")
+
+    def _factory(profile: AgentProfile) -> Session:
+        return make_session(
+            agent_name=profile.name, state_log=state_log,
+            snapshot_path=tmp_path / f"{profile.name}_snapshot.json",
+        )
+
+    return AgentRegistry(project_root=tmp_path, session_factory=_factory, state_log=state_log)
+
+
+def _seed(tmp_path: Path, name: str) -> None:
+    AgentProfile.new(name, role="").save(tmp_path / ".reyn" / "agents" / name)
+
+
+async def _stop_auto_driver(registry: AgentRegistry, name: str) -> None:
+    """``AgentRegistry.attach`` boots a background ``session.run()`` driver
+    loop that would otherwise race a test's own manual
+    ``run_one_iteration()`` calls (both dequeuing from the same inbox). Cancel
+    it so the test has sole, deterministic control over dispatch — mirrors
+    how ``tests/test_2242_hard_cancel.py`` drives a bare (non-registry)
+    ``Session`` directly; this is the registry-attached equivalent."""
+    key = (name, "main")
+    task = registry._tasks.get(key)
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+    fwd = registry._forward_tasks.get(key)
+    if fwd is not None and not fwd.done():
+        fwd.cancel()
+        try:
+            await fwd
+        except asyncio.CancelledError:
+            pass
+
+
+def _install_hanging_run_turn(session: Session) -> tuple[asyncio.Event, asyncio.Event]:
+    """Same no-mock seam as ``tests/test_2242_hard_cancel.py``: a real, plain
+    async function method-assigned onto the instance, standing in for a
+    genuinely in-flight LLM call so a turn can be observed mid-flight."""
+    call_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
+        call_started.set()
+        await release.wait()
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    return call_started, release
+
+
+async def _sse_lines(text):
+    for line in text.split("\n"):
+        yield line
+
+
+async def _connect_snapshot_only(status_provider) -> "dict":
+    """Simulate a client connecting: build an AgUiEmitter whose live-frame
+    stream ends immediately, so the ONLY thing the wire carries is the
+    connect-time STATE_SNAPSHOT (+ the empty MESSAGES_SNAPSHOT) — exactly
+    what a late-joining remote client receives before any live frame."""
+    async def frames():
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    emitter = AgUiEmitter(frames(), status_provider)
+    sse = "".join([chunk async for chunk in emitter.stream()])
+
+    async def _noop_send(_payload):
+        return None
+
+    transport = AgUiTransport(_sse_lines(sse), _noop_send)
+    async for _f in transport.frames():
+        pass  # draining applies STATE_SNAPSHOT to transport.status
+    return dict(transport.status.values)
+
+
+# ── 1. turn-active accessor (additive) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_turn_active_accessor_reflects_busy_then_idle(tmp_path):
+    """Tier 2: ``Session.turn_active`` is False when idle, True once a turn is
+    dispatched (mid-flight), and False again once it settles — an additive
+    read of the existing ``_turn_idle`` event, not a new authority."""
+    session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    assert session.turn_active is False
+
+    call_started, release = _install_hanging_run_turn(session)
+    await session._put_inbox("user", {"text": "hi", "chain_id": "c1"})
+    turn_task = asyncio.create_task(session.run_one_iteration())
+
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    assert session.turn_active is True
+
+    release.set()
+    completed = await asyncio.wait_for(turn_task, timeout=5)
+    assert completed is True
+    assert session.turn_active is False
+
+
+# ── 2. queued_user_messages() ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_queued_user_messages_reflects_undispatched_inbox_queue(tmp_path):
+    """Tier 2: ``Session.queued_user_messages()`` lists every UNDISPATCHED
+    ``kind=="user"`` inbox item (snapshot-backed) and drops an item the
+    instant it is consumed (dispatched) — no dependency on the turn actually
+    completing."""
+    session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    assert session.queued_user_messages() == []
+
+    await session.submit_user_text("first")
+    await session.submit_user_text("second")
+
+    queued = session.queued_user_messages()
+    assert [item["text"] for item in queued] == ["first", "second"]
+    assert all(item["msg_id"] and item["chain_id"] for item in queued)
+
+    # Dispatch (consume) the first item directly — mirrors what
+    # ``run_one_iteration`` does before the turn body runs.
+    await session._consume_inbox()
+    remaining = session.queued_user_messages()
+    assert [item["text"] for item in remaining] == ["second"]
+
+
+# ── 3. remote parity (local ≡ remote) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_remote_parity_state_snapshot_matches_local_accessors(tmp_path):
+    """Tier 2: the STATE_SNAPSHOT a remote (agui) client receives carries the
+    SAME queue + turn_active values the local in-process accessors return —
+    local ≡ remote by construction (both derive from the identical
+    ``_snapshot(registry)`` read-model)."""
+    registry = _make_registry(tmp_path)
+    _seed(tmp_path, AGENT)
+    session = await registry.attach(AGENT)
+    await _stop_auto_driver(registry, AGENT)
+
+    await session.submit_user_text("remote parity check")
+
+    local_queue = session.queued_user_messages()
+    local_turn_active = session.turn_active
+
+    values = await _connect_snapshot_only(lambda: _snapshot(registry))
+
+    assert values.get("queue") == local_queue
+    assert values.get("turn_active") == local_turn_active is False
+
+
+# ── 4. late-joiner-safe (non-vacuity) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_late_joiner_mid_turn_connect_reconstructs_correct_state(tmp_path):
+    """Tier 2: #3300 P2a core correctness property. A client "connecting"
+    DURING a turn — having missed the ``turn_started`` chat-event that
+    dispatched the in-flight item — still reconstructs the CORRECT
+    queue (the second, still-undispatched item) + turn-active=True from the
+    STATE_SNAPSHOT alone.
+
+    Non-vacuity / strip-falsify (verified manually per repo discipline,
+    Edit-to-break -> Edit-to-restore in ``interfaces/repl/status.py``): commenting
+    out the ``"queue"``/``"turn_active"`` keys in ``_snapshot()`` makes the
+    assertions below fail — a late-joining client would derive an EMPTY queue
+    and idle turn-active despite a real in-flight turn + a real queued item,
+    exactly the black-hole/mis-derivation this gate exists to catch.
+    """
+    registry = _make_registry(tmp_path)
+    _seed(tmp_path, AGENT)
+    session = await registry.attach(AGENT)
+    await _stop_auto_driver(registry, AGENT)
+
+    call_started, release = _install_hanging_run_turn(session)
+
+    await session.submit_user_text("dispatched-first")
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+
+    # A second submission arrives WHILE the first turn is still in flight —
+    # it stays undispatched (server-authoritative queue, #3300 design-pass
+    # §6b: not a black-hole, durably queued).
+    await session.submit_user_text("queued-second")
+
+    # The "late joiner": connects only NOW, having missed the turn_started
+    # for "dispatched-first" entirely (it happened before this connect).
+    values = await _connect_snapshot_only(lambda: _snapshot(registry))
+
+    assert values.get("turn_active") is True, (
+        "a client connecting mid-turn must see turn_active=True from the "
+        "snapshot alone, never derive idle from a missed turn_started"
+    )
+    queue_texts = [item["text"] for item in values.get("queue", [])]
+    assert queue_texts == ["queued-second"], (
+        "the late joiner must see exactly the still-undispatched item, not "
+        "the dispatched one and not an empty queue"
+    )
+
+    release.set()
+    await asyncio.wait_for(turn_task, timeout=5)
+
+    # After the turn settles, a fresh connect reflects idle + still-queued.
+    values_after = await _connect_snapshot_only(lambda: _snapshot(registry))
+    assert values_after.get("turn_active") is False
+    assert [item["text"] for item in values_after.get("queue", [])] == ["queued-second"]
+
+
+# ── 5. order-race gate (design-pass pin D) ───────────────────────────────────
+
+
+def test_remote_queue_view_seq_gate_prevents_resurrection_after_dispatch():
+    """Tier 1: ``RemoteQueueView``'s seq-gate resolves the snapshot/delta
+    order-race: a client that reads a STATE_SNAPSHOT taken AFTER an item was
+    dispatched (so the snapshot's queue no longer contains it) must not let a
+    stale/out-of-order ``user_submitted`` delta for that SAME item resurrect
+    it — regardless of the relative arrival order.
+
+    This assertion is load-bearing on the seq-gate line itself: removing the
+    ``if seq <= self._last_seq: return False`` guard in
+    ``RemoteQueueView.apply_user_submitted`` makes the stale delta re-add the
+    item and this test goes RED (verified manually per repo discipline,
+    Edit-to-break -> Edit-to-restore in ``interfaces/transport/agui/state.py``).
+    """
+    view = RemoteQueueView()
+
+    # Server-side history: item "m1" (chain "c1") was enqueued at seq=1, then
+    # dispatched at seq=2. A snapshot taken AFTER the dispatch reflects an
+    # empty queue with queue_seq=2.
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=2)
+    assert view.queue() == []
+
+    # A stale/duplicate "user_submitted" delta for the ALREADY-DISPATCHED
+    # item arrives AFTER the snapshot (out-of-order delivery / replay).
+    applied = view.apply_user_submitted(msg_id="m1", chain_id="c1", text="hi", seq=1)
+    assert applied is False, "a delta whose seq <= the snapshot's queue_seq must be a no-op"
+    assert view.queue() == [], "the dispatched item must NOT resurrect"
+
+    # The reverse interleaving (delta arrives BEFORE any snapshot) still
+    # works: a genuinely new enqueue (higher seq than anything seen) IS
+    # applied — no loss.
+    fresh = RemoteQueueView()
+    applied2 = fresh.apply_user_submitted(msg_id="m2", chain_id="c2", text="new", seq=1)
+    assert applied2 is True
+    assert fresh.queue() == [{"msg_id": "m2", "chain_id": "c2", "text": "new"}]
+
+    # A duplicate delivery of the SAME delta (seq unchanged) is a no-op — no
+    # duplicate entries / no double-processing.
+    applied3 = fresh.apply_user_submitted(msg_id="m2", chain_id="c2", text="new", seq=1)
+    assert applied3 is False
+    assert fresh.queue() == [{"msg_id": "m2", "chain_id": "c2", "text": "new"}]
+
+    # A genuinely later dispatch (turn_started) DOES remove it — no loss of
+    # the legitimate promote-out-of-queue transition.
+    removed = fresh.apply_turn_started(chain_id="c2", seq=2)
+    assert removed is True
+    assert fresh.queue() == []
+
+
+def test_remote_queue_view_snapshot_mid_stream_stays_consistent_with_redelivery():
+    """Tier 1: a connection's SSE stream preserves per-connection delivery
+    order (a single ordered queue, #3300 P2a emitter), so the realistic race
+    is the SNAPSHOT read landing at an arbitrary point relative to an
+    in-order delta stream — including the snapshot's own subscription window
+    re-delivering a delta the snapshot ALREADY reflects (buffering overlap on
+    (re)connect). Both must resolve correctly: the in-order deltas apply, and
+    the redelivered already-reflected one is a no-op (no duplicate)."""
+    view = RemoteQueueView()
+
+    # m1 enqueued (seq=1); a snapshot taken right after already reflects it.
+    view.apply_snapshot(queue=[{"msg_id": "m1", "chain_id": "c1", "text": "a"}],
+                         turn_active=True, queue_seq=1)
+
+    # The subscription's buffering window re-delivers that SAME seq=1 enqueue
+    # (connect-time overlap) — already reflected by the snapshot, a no-op.
+    redelivered = view.apply_user_submitted(msg_id="m1", chain_id="c1", text="a", seq=1)
+    assert redelivered is False
+    assert view.queue() == [{"msg_id": "m1", "chain_id": "c1", "text": "a"}]
+
+    # Subsequent, genuinely new, in-order deltas apply normally: m2 enqueues
+    # (seq=2), then m1 dispatches (seq=3).
+    assert view.apply_user_submitted(msg_id="m2", chain_id="c2", text="b", seq=2) is True
+    assert view.apply_turn_started(chain_id="c1", seq=3) is True
+
+    assert view.queue() == [{"msg_id": "m2", "chain_id": "c2", "text": "b"}]
+
+
+# ── 6. deltas keep the model in sync (real session, end-to-end) ─────────────
+
+
+@pytest.mark.asyncio
+async def test_real_session_deltas_keep_remote_queue_view_accurate(tmp_path):
+    """Tier 2: a real ``Session``'s ``user_submitted`` (enqueue) and
+    ``turn_started`` (dispatch) chat-events — the SAME events P1 (C) already
+    emits and the renderer/AG-UI transport already forward — drive a
+    ``RemoteQueueView`` to an accurate final state end-to-end (subscribe via
+    the public ``subscribe_chat_events`` seam, no private-state peeking)."""
+    session = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    call_started, release = _install_hanging_run_turn(session)
+
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
+
+    captured: list = []
+    session.subscribe_chat_events(lambda ev: captured.append(ev))
+
+    await session.submit_user_text("alpha")
+    # Apply the just-emitted user_submitted delta.
+    ev = next(e for e in captured if e.type == "user_submitted")
+    view.apply_user_submitted(
+        msg_id=ev.data["msg_id"], chain_id=ev.data["chain_id"],
+        text=ev.data["text"], seq=ev.data["seq"],
+    )
+    assert [i["text"] for i in view.queue()] == ["alpha"]
+
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+
+    ts = next(e for e in captured if e.type == "turn_started")
+    view.apply_turn_started(chain_id=ts.data["chain_id"], seq=ts.data["seq"])
+    assert view.queue() == [], "the dispatched item must leave the queue model"
+
+    release.set()
+    await asyncio.wait_for(turn_task, timeout=5)

--- a/tests/test_user_echo_broadcast.py
+++ b/tests/test_user_echo_broadcast.py
@@ -12,7 +12,7 @@ derived notification.
 
 Covers:
   A. ``Session.submit_user_text`` emits a ``user_submitted`` chat-event (NOT an
-     outbox frame) carrying the raw text + chain_id + _msg_id + meta — every
+     outbox frame) carrying the raw text + chain_id + msg_id + meta — every
      ``subscribe_chat_events`` subscriber (= every attached client, simulated
      here as two independent subscriptions) sees it. Reverting the
      ``self._chat_events.emit("user_submitted", ...)`` call added to
@@ -147,9 +147,12 @@ async def test_submit_user_text_no_outbox_user_echo(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_submit_user_text_carries_chain_id_and_msg_id(tmp_path, monkeypatch):
-    """Tier 2: the user_submitted event carries chain_id + _msg_id (the id
-    ``_put_inbox`` stamps) — load-bearing for a later phase (client learns its
-    own message id, for cancel-by-id)."""
+    """Tier 2: the user_submitted event carries chain_id + msg_id (the id
+    ``_put_inbox`` stamps, renamed from the internal `_msg_id` at this
+    wire/event boundary — #3300 P2a design-pass pin E: a leading underscore
+    on a field that reaches a remote client is a "private-looking public
+    name") — load-bearing for a later phase (client learns its own message
+    id, for cancel-by-id)."""
     monkeypatch.chdir(tmp_path)
     session = _make_session(tmp_path)
     sink = _EventSink()
@@ -159,7 +162,7 @@ async def test_submit_user_text_carries_chain_id_and_msg_id(tmp_path, monkeypatc
 
     ev = _user_submitted(sink)
     assert ev.data.get("chain_id")
-    assert ev.data.get("_msg_id")
+    assert ev.data.get("msg_id")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — Phase 2a (state publish) of the input-message-lifecycle arc (#3300). Publishes the server-authoritative sent-queue + turn-active state to clients via snapshot + deltas. **No rendering** — the sent-queue widget is P2b, out of scope here.

## (a) Turn-active accessor (additive)

`Session.turn_active` (`src/reyn/runtime/session.py`) exposes `not self._turn_idle.is_set()` — a public read of the EXISTING `_turn_idle` event (ADR-0038 Stage 1c), not a new authority. Paired with `Session.queued_user_messages()`, a read-only accessor over `self.journal.snapshot.inbox` (the SAME snapshot-backed, WAL-durable state `append_inbox`/`consume_inbox` already keep current) filtered to `kind=="user"`, returning `{"msg_id", "chain_id", "text"}` per item.

## (b) Connect-snapshot across transports (agui remote is the load-bearing case)

`queue` + `turn_active` (+ a `queue_seq` gate token, see (d)) are folded into the SAME read-model `_snapshot()`/`project_status()` (`interfaces/repl/status.py`, `interfaces/transport/agui/state.py`) that already feeds:

- **local/in-process**: read live off `session.queued_user_messages()`/`session.turn_active` directly (no transport hop — matches how cost/ctx/model are already read locally).
- **agui/remote**: rides the EXISTING `STATE_SNAPSHOT` (on connect) / `STATE_DELTA` (on change) channel — no new frame type. `AgUiEmitter`/`RemoteStatusView` are unchanged; they already recompute+diff the full projected dict every frame, so `queue`/`turn_active` inherit that self-healing recompute for free.
- **client_transport (ClientTransport)**: status has never gone through this seam (module docstring: "off the registry by duck-typing — fine in-process") — unaffected, same as cost/ctx.

Docs updated in this PR (same-PR doc-sync per CLAUDE.md): `docs/reference/runtime/agui-transport.md` + `.ja.md` — `STATE_SNAPSHOT` field list, the `user_submitted` custom-event field list.

## (c) Late-joiner-safe — strip→RED proof

`tests/test_3300_p2a_queue_state_publish.py::test_late_joiner_mid_turn_connect_reconstructs_correct_state`: a client "connects" (builds a `STATE_SNAPSHOT`-only wire read) DURING a real in-flight turn (hung via the same no-mock `RouterLoopDriver.run_turn` method-assignment seam `test_2242_hard_cancel.py` uses), having missed the `turn_started` that dispatched the first item — and still reconstructs `turn_active=True` + the correct still-undispatched second item from the snapshot alone.

**Strip-falsify (verified manually, Edit-to-break → Edit-to-restore, not left in the tree)**: replacing `_snapshot()`'s `"queue"`/`"turn_active"` with `[]`/`False` made this test RED (`AssertionError: turn_active must be True…`); reverted → green. Confirms the mechanism is load-bearing, not vacuous.

## (d) Design-pass pin D — order-race protocol: **seq-gate** (not idempotent-merge+tombstone)

The architect's design pass asked whether a consumer building the queue model from the GRANULAR `user_submitted`/`turn_started` deltas alone (independent of the coarse STATE_DELTA recompute in (b), e.g. for a future P2b per-item enter/promote animation) is safe under snapshot/delta interleaving — a client that reads a `STATE_SNAPSHOT` taken AFTER an item was dispatched (so its `queue` no longer contains it) must never let a stale/out-of-order `user_submitted` delta resurrect it.

**Chosen mechanism: a strictly-monotonic seq-gate**, not idempotent-merge+tombstone:
- `Session._bump_queue_seq()` — one in-memory counter, bumped on every queue-affecting mutation (enqueue in `submit_user_text`, dispatch at `turn_started`, for EVERY turn kind — harmless for non-queue turns, keeps the counter a single sequence).
- Stamped as `seq=` on both `user_submitted` and `turn_started` chat-events, and as `queue_seq` in `STATE_SNAPSHOT`.
- `RemoteQueueView` (`interfaces/transport/agui/state.py`) — the client-side merge: tracks the highest applied `seq` (seeded from `queue_seq` on `apply_snapshot`); `apply_user_submitted`/`apply_turn_started` are no-ops when `seq <= last_seq`. Because a dispatch's seq is always > its own item's enqueue seq (single counter, single event loop), and a snapshot taken after that dispatch carries `queue_seq` ≥ the dispatch's seq, a stale enqueue for an already-dispatched item can never pass the gate — under ANY interleaving.
- In-memory only, deliberately NOT WAL-durable — it's a client read-model liveness aid (resolves snapshot/delta interleaving), not recovery state. A restart resumes from 0 safely because a fresh connection's `STATE_SNAPSHOT` always seeds the client before any delta merges.

**Strip-falsify**: removing the `if seq <= self._last_seq: return False` guard in `RemoteQueueView.apply_user_submitted` makes `test_remote_queue_view_seq_gate_prevents_resurrection_after_dispatch` RED (stale delta resurrects the dispatched item); restored → green. Verified manually, not left in the tree.

## (e) Design-pass pin E — wire field rename `_msg_id` → `msg_id`

`user_submitted`'s payload field is renamed from `_msg_id` to `msg_id` at the emit site (`Session.submit_user_text`) — this event reaches a remote agui client via the generic `EventFrame` encode (no per-field allowlist), so its key names are a PUBLIC wire contract the instant they're emitted; a leading underscore there reads as private-but-isn't. The internal inbox payload key (`_put_inbox`/`_consume_inbox`/`snapshot_journal.py`) is untouched — still `_msg_id`, never wire-facing. Updated the one test asserting the old field name (`tests/test_user_echo_broadcast.py`) + doc/comment references (`agui-transport.md`/`.ja.md`, `frames.py`, `profile.py`).

## Deltas keep the model in sync

`test_real_session_deltas_keep_remote_queue_view_accurate`: a REAL session's `user_submitted` (enqueue) + `turn_started` (dispatch) chat-events — subscribed via the public `subscribe_chat_events` seam, no private-state peeking — drive a `RemoteQueueView` to the correct final state end-to-end.

## Out of scope (per architect's P2 split recommendation)

No UI, no sent-queue widget, no cancel-by-id / `inbox_cancel` (P3 Y). Turn-processing logic is unchanged — additive only.

## Gates — all green, foreground

- `ruff check src tests` — all checks passed.
- `python scripts/test_tier_audit.py --strict tests/test_3300_p2a_queue_state_publish.py tests/test_user_echo_broadcast.py` — 17/17 OK, 0 Tier-4 violations.
- `uv run python -m pytest --timeout=120` (foreground, full suite) — **9154 passed, 36 skipped, 0 failed** (532s).
- `python scripts/verify_module_docstrings.py` on all changed src files — OK.

part of #3300

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>