### PR TITLE
feat(llm): capability-gated streaming loop in recorded_acompletion (whole-result equivalent) — #3288 ③a

### DIFF
--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -269,23 +269,33 @@ class LLMReplay:
             elif not (message.tool_calls or []):
                 yield _chunk(Delta(role="assistant"))
 
-            for tc in (message.tool_calls or []):
+            # #3288 co-vet BLOCK fix: each PARALLEL tool_call gets its OWN
+            # ``index`` (enumerate), not a shared ``index=0``.
+            # ``stream_chunk_builder`` accumulates tool_call deltas PER
+            # INDEX — every chunk claiming index=0 makes it merge N parallel
+            # tool calls into ONE (arguments concatenated into invalid JSON,
+            # silently — no exception). reyn does emit parallel tool calls,
+            # so this must round-trip them distinctly, matching the index a
+            # real provider stream assigns per parallel call.
+            for tc_index, tc in enumerate(message.tool_calls or []):
                 args = tc.function.arguments or ""
                 mid = len(args) // 2
                 if mid > 0:
                     yield _chunk(Delta(tool_calls=[
                         ChatCompletionDeltaToolCall(
-                            id=tc.id, index=0, type="function",
+                            id=tc.id, index=tc_index, type="function",
                             function=Function(name=tc.function.name, arguments=args[:mid]),
                         ),
                     ]))
                     yield _chunk(Delta(tool_calls=[
-                        ChatCompletionDeltaToolCall(index=0, function=Function(arguments=args[mid:])),
+                        ChatCompletionDeltaToolCall(
+                            index=tc_index, function=Function(arguments=args[mid:]),
+                        ),
                     ]))
                 else:
                     yield _chunk(Delta(tool_calls=[
                         ChatCompletionDeltaToolCall(
-                            id=tc.id, index=0, type="function",
+                            id=tc.id, index=tc_index, type="function",
                             function=Function(name=tc.function.name, arguments=args),
                         ),
                     ]))

--- a/src/reyn/dev/testing/replay.py
+++ b/src/reyn/dev/testing/replay.py
@@ -191,16 +191,117 @@ class LLMReplay:
 
         Replay mode: look up by key; raise ``MissingFixture`` on miss.
         Record mode: forward to real LLM; save response; return response.
+
+        #3288 ③a: the fixture format is unchanged (always a whole
+        ``ModelResponse``) — a ``stream=True`` caller (reyn's
+        capability-gated streaming loop in ``recorded_acompletion``) is
+        served the SAME recorded/replayed response, wrapped into a small
+        synthetic multi-chunk stream (see ``_synthetic_stream``) rather than
+        by recording/replaying real provider chunks. This keeps every
+        existing fixture valid for both the streaming and non-streaming
+        code paths — reconstructing the synthetic stream must yield the
+        byte-identical response, which doubles as a live stream≡whole
+        equivalence check across the whole fixture-based test suite.
         """
         tools: list[dict] | None = kwargs.get("tools")
         tool_choice: str | None = kwargs.get("tool_choice")
         key = self.key(model, messages, tools=tools, tool_choice=tool_choice)
+        stream = bool(kwargs.get("stream"))
 
         if self.mode == "replay":
-            return self._replay(key, model, messages)
+            response = self._replay(key, model, messages)
+        else:
+            # record mode: always fetch/store the WHOLE response — strip
+            # ``stream``/``stream_options`` from the forwarded call so the
+            # real LLM call + fixture format are unaffected by what THIS
+            # call happened to request.
+            record_kwargs = {
+                k: v for k, v in kwargs.items() if k not in ("stream", "stream_options")
+            }
+            response = await self._record(key, model, messages, record_kwargs)
 
-        # record mode
-        return await self._record(key, model, messages, kwargs)
+        if stream:
+            return self._synthetic_stream(response)
+        return response
+
+    @staticmethod
+    def _synthetic_stream(response: Any):
+        """Wrap a whole ``ModelResponse`` into a small async-iterable of
+        ``ModelResponseStream`` chunks reconstructing to the SAME response.
+
+        Splits text content and (per tool_call) argument strings across two
+        chunks each when long enough — exercising the SAME delta-accumulation
+        path (content concatenation, per-index tool_call argument
+        accumulation) a real provider stream would, instead of a single
+        pass-through chunk. Usage is attached on the terminal chunk so
+        ``litellm.stream_chunk_builder``'s reconstruction carries the exact
+        recorded/real usage (no token-count re-estimate drift).
+        """
+        from litellm.types.utils import (
+            ChatCompletionDeltaToolCall,
+            Delta,
+            Function,
+            ModelResponseStream,
+            StreamingChoices,
+        )
+
+        async def _gen():
+            message = response.choices[0].message
+            model_name = getattr(response, "model", None) or "replay"
+
+            def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+                return ModelResponseStream(
+                    id=getattr(response, "id", "replay-stream"),
+                    created=getattr(response, "created", 0) or 0,
+                    model=model_name,
+                    object="chat.completion.chunk",
+                    choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+                )
+
+            content = message.content
+            if content:
+                mid = len(content) // 2
+                if mid > 0:
+                    yield _chunk(Delta(role="assistant", content=content[:mid]))
+                    yield _chunk(Delta(content=content[mid:]))
+                else:
+                    yield _chunk(Delta(role="assistant", content=content))
+            elif not (message.tool_calls or []):
+                yield _chunk(Delta(role="assistant"))
+
+            for tc in (message.tool_calls or []):
+                args = tc.function.arguments or ""
+                mid = len(args) // 2
+                if mid > 0:
+                    yield _chunk(Delta(tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id=tc.id, index=0, type="function",
+                            function=Function(name=tc.function.name, arguments=args[:mid]),
+                        ),
+                    ]))
+                    yield _chunk(Delta(tool_calls=[
+                        ChatCompletionDeltaToolCall(index=0, function=Function(arguments=args[mid:])),
+                    ]))
+                else:
+                    yield _chunk(Delta(tool_calls=[
+                        ChatCompletionDeltaToolCall(
+                            id=tc.id, index=0, type="function",
+                            function=Function(name=tc.function.name, arguments=args),
+                        ),
+                    ]))
+
+            finish_reason = None
+            try:
+                finish_reason = response.choices[0].finish_reason
+            except Exception:
+                pass
+            last = _chunk(Delta(), finish_reason=finish_reason)
+            usage = getattr(response, "usage", None)
+            if usage is not None:
+                last.usage = usage
+            yield last
+
+        return _gen()
 
     def _replay(self, key: str, model: str, messages: list[dict]) -> Any:
         """Return a reconstructed ``ModelResponse`` from the fixture."""

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1553,6 +1553,58 @@ def _emit_chat_cost_events(model: str, usage: "TokenUsage | None") -> None:
         pass
 
 
+# ---------------------------------------------------------------------------
+# #3288 ③a: capability-gated streaming (core LLM streaming loop)
+# ---------------------------------------------------------------------------
+
+
+def _streaming_capable(model: str, has_tools: bool) -> bool:
+    """Capability-gated streaming decision (#3288 ③a) — a litellm inline
+    capability query, mirroring the existing ``litellm.supports_response_schema``
+    precedent (``router_loop.py``'s structured-output precheck). NEVER a
+    hardcoded provider/model-name check (owner design principle) — this is
+    the ONLY place ③a decides whether a given call streams.
+
+    Two capability axes, composed conservatively:
+
+    - ``litellm.utils.supports_native_streaming``: can this model stream at
+      all? False only for the handful of reasoning-only endpoints (e.g.
+      ``o1-pro`` / ``gpt-5-pro``) that reject ``stream=True`` outright;
+      ``None``/unset in litellm's model map is treated by litellm itself as
+      an optimistic True default.
+    - IF ``tools`` are attached to this call: additionally require
+      ``litellm.supports_function_calling`` — the historical Gemini
+      streaming+tools bug (litellm#21041, fixed upstream since) only bites
+      the streaming+tools COMBINATION, so a tools-bearing call needs both
+      axes to hold, not just plain-text streaming.
+
+    Queried WITHOUT an explicit ``custom_llm_provider`` (``None`` → litellm
+    infers the provider from the bare model name). This matters: reyn's proxy
+    routing (``proxy_kwargs()``) forces ``custom_llm_provider="openai"`` on
+    the wire for ALL models when an operator proxy is configured — passing
+    that routing artifact into the capability query would misresolve e.g.
+    ``gemini-2.5-flash`` as an unmapped "openai" model and always report
+    "no capability" for the very providers this feature targets. Capability
+    is a property of the MODEL, not of the transport used to reach it.
+
+    Any lookup failure (unmapped model name, litellm internal error) is
+    caught and treated as "unknown" — returns False (whole-collect
+    fallback). Conservative by construction, never an optimistic guess.
+    """
+    try:
+        import litellm  # noqa: PLC0415
+        from litellm.utils import supports_native_streaming  # noqa: PLC0415
+        if not supports_native_streaming(model=model, custom_llm_provider=None):
+            return False
+        if has_tools and not litellm.supports_function_calling(
+            model=model, custom_llm_provider=None,
+        ):
+            return False
+        return True
+    except Exception:  # noqa: BLE001 — unknown capability → conservative fallback
+        return False
+
+
 async def recorded_acompletion(
     *,
     model: str,
@@ -1693,6 +1745,70 @@ async def recorded_acompletion(
     except Exception:  # noqa: BLE001
         pass
 
+    async def _stream_and_reconstruct(model: str, msgs: list, call_kwargs: dict) -> object:
+        """#3288 ③a streaming loop: call litellm with ``stream=True``, drain
+        the async chunk stream, and reconstruct the SAME raw-response shape
+        ``litellm.acompletion(..., stream=False)`` would have returned — so
+        this chokepoint's callers (``msg = response.choices[0].message``,
+        ``_extract_usage(response)`` below) see NO behavioral difference
+        (③a is an internal optimization, not a caller-visible change; ③b/c/d
+        are later phases that change what callers see). Nested INSIDE
+        ``recorded_acompletion`` (not module-level) so its
+        ``litellm.acompletion`` call stays within the #1190 AST-guarded
+        chokepoint span — no second completion call-site.
+
+        Reconstruction uses litellm's OWN ``stream_chunk_builder`` (content
+        deltas concatenated; tool_call argument deltas accumulated PER
+        INDEX, the documented shape multi-argument tool calls arrive in;
+        usage summed across chunks) rather than a hand-rolled accumulator —
+        litellm's tested, canonical stream-to-response reconstruction,
+        reused instead of duplicated.
+
+        ★usage/cost single-emission (#3288 ③a architect gate): this
+        function returns ONE reconstructed response with ONE ``.usage``;
+        the enclosing ``recorded_acompletion`` calls
+        ``recorder.record_llm(...)`` exactly once against it below,
+        IDENTICAL to the whole-collect path — usage is summed HERE, across
+        chunks, never emitted per-chunk. ``budget.py`` (the cost band,
+        ``record_llm`` at budget.py:1135) is untouched by ③a.
+
+        ``stream_options={"include_usage": True}`` is added ONLY when
+        litellm's own supported-params query confirms the model accepts it
+        (an OpenAI-specific param; Gemini/Anthropic reject it) — again a
+        capability query, not a provider check. Its absence is harmless:
+        ``stream_chunk_builder`` falls back to a token-count estimate for
+        usage, the same graceful degradation litellm's own non-Reyn callers
+        rely on.
+        """
+        stream_kwargs = dict(call_kwargs)
+        stream_kwargs.pop("stream", None)
+        stream_kwargs.pop("stream_options", None)
+        stream_kwargs["stream"] = True
+        try:
+            _supported_params = litellm.get_supported_openai_params(model=model) or []
+        except Exception:  # noqa: BLE001 — params query is best-effort
+            _supported_params = []
+        if "stream_options" in _supported_params:
+            stream_kwargs["stream_options"] = {"include_usage": True}
+
+        chunk_stream = await litellm.acompletion(model=model, messages=msgs, **stream_kwargs)
+        if not hasattr(chunk_stream, "__aiter__"):
+            # Defensive: the callee did not honor stream=True (returned an
+            # already-complete response synchronously instead of an async
+            # chunk iterator) — accept it as the final response rather than
+            # crashing. Real litellm always returns an async-iterable
+            # (CustomStreamWrapper) here; this only fires against a
+            # non-compliant transport, never against production litellm.
+            return chunk_stream
+        chunks = [chunk async for chunk in chunk_stream]
+        reconstructed = litellm.stream_chunk_builder(chunks, messages=msgs)
+        if reconstructed is None:
+            # No chunks at all (degenerate empty stream) — degrade to the
+            # whole-collect call rather than surface None to a caller that
+            # expects a message-bearing response object.
+            return await litellm.acompletion(model=model, messages=msgs, **call_kwargs)
+        return reconstructed
+
     async def _once(rf: dict | None) -> object:
         call_kwargs = dict(base_kwargs)
         if rf is not None:
@@ -1711,6 +1827,15 @@ async def recorded_acompletion(
             return await _single_deployment_router(effective_model).acompletion(
                 model=effective_model, messages=messages, **router_kwargs
             )
+        # #3288 ③a: capability-gated streaming loop, INSIDE the single #1190
+        # funnel (the two ``litellm.acompletion`` call sites remain exactly
+        # this one and the Router branch above — no second completion
+        # call-site was added). The decision is a litellm capability query
+        # (``_streaming_capable``), never a hardcoded provider check.
+        # Unknown/uncertain capability → the existing whole-collect call
+        # below (conservative fallback, byte-identical to pre-③a behavior).
+        if _streaming_capable(effective_model, has_tools=bool(call_kwargs.get("tools"))):
+            return await _stream_and_reconstruct(effective_model, messages, call_kwargs)
         return await litellm.acompletion(model=effective_model, messages=messages, **call_kwargs)
 
     # response_format fallback (predates #1212): on a provider that rejects
@@ -1819,8 +1944,12 @@ async def call_llm_tools(
     """Tool-use variant of call_llm. Returns raw assistant message.
 
     Forces gemini-safe settings:
-      - stream=False (Gemini #21041 streaming+tools bug)
       - thinking disabled (Gemini #17949 multi-turn parallel + thinking bug)
+
+    Streaming (#3288 ③a) is decided per-call by ``recorded_acompletion`` via
+    a litellm capability query (see ``_streaming_capable``) — NOT forced off
+    here. The historical Gemini streaming+tools bug (litellm#21041) is
+    absorbed by that capability check, not by this function.
 
     budget: optional BudgetTracker. When provided, check_pre_llm is called
       before the LLM call (raises BudgetExceeded if refused) and record_llm
@@ -1940,11 +2069,16 @@ async def call_llm_tools(
         **({} if not tools else {"tool_choice": tool_choice}),
         # spec.kwargs passthrough (operator-declared, e.g. temperature)
         **spec_kwargs,
-        # Gemini-safe forced settings override spec_kwargs:
-        "stream": False,             # Gemini #21041: streaming + tools bug
         # No thinking kwargs: disabled by default on all providers
         **extra,
     }
+    # #3288 ③a: no ``stream`` key set here — the decision (capability-gated,
+    # never a hardcoded "Gemini doesn't stream") is made INSIDE
+    # ``recorded_acompletion`` (the #1190 single funnel), which reconstructs
+    # the SAME raw-response shape when it streams, so this function's
+    # ``msg = response.choices[0].message`` extraction below is unaffected
+    # either way. Was: unconditional ``"stream": False`` (Gemini litellm#21041
+    # streaming+tools bug) — replaced by a per-call litellm capability query.
     # #2210: an EXPLICIT timeout (the kernel path threads `safety.timeout.llm_call_seconds`
     # via the LLMCallRecorder) WINS and is used as-is — zero kernel regression. Only the
     # router path, which passes no `timeout`, falls back to the ambient per-LLM-call policy

--- a/src/reyn/llm/llm.py
+++ b/src/reyn/llm/llm.py
@@ -1796,9 +1796,21 @@ async def recorded_acompletion(
             # Defensive: the callee did not honor stream=True (returned an
             # already-complete response synchronously instead of an async
             # chunk iterator) — accept it as the final response rather than
-            # crashing. Real litellm always returns an async-iterable
-            # (CustomStreamWrapper) here; this only fires against a
-            # non-compliant transport, never against production litellm.
+            # crashing. Real litellm ALWAYS returns an async-iterable
+            # (CustomStreamWrapper) here, so this never fires against
+            # production litellm — but it DOES fire routinely in this
+            # repo's own tests: many pre-③a test doubles stub
+            # ``litellm.acompletion`` with a plain async function that
+            # returns a flat response regardless of the ``stream`` kwarg
+            # (they never had to branch on it before ③a, since streaming
+            # was previously hardcoded off). Such a test silently exercises
+            # this fallback (whole-collect), NOT the streaming
+            # reconstruction path below, even though the call requested
+            # ``stream=True`` — a test that wants to prove IT specifically
+            # exercised the streaming reconstruction must witness real
+            # chunk consumption (e.g. a counter incremented while iterating
+            # the async generator), not just that ``stream=True`` was
+            # passed in the call kwargs.
             return chunk_stream
         chunks = [chunk async for chunk in chunk_stream]
         reconstructed = litellm.stream_chunk_builder(chunks, messages=msgs)

--- a/tests/test_llm_streaming_capability_driver_3288.py
+++ b/tests/test_llm_streaming_capability_driver_3288.py
@@ -1,0 +1,96 @@
+"""Tier 1: Contract — #3288 ③a capability-is-driver gate.
+
+The streaming decision (``reyn.llm.llm._streaming_capable``) must be driven
+by a litellm inline capability query, NEVER a hardcoded provider/model-name
+check (owner design principle — no "Gemini doesn't stream" string literal).
+
+Two independent proofs:
+
+1. Structural: ``_streaming_capable``'s source contains no provider-name
+   string literal (gemini/openai/anthropic/vertex/...) — a hardcoded branch
+   would show up as a literal compared against ``model``.
+2. Behavioral strip: neuter the underlying litellm capability query (a real
+   function replacement — ``monkeypatch.setattr`` with a real callable, the
+   allowed idiom, not a MagicMock) to a fixed value and show the branch
+   selection FOLLOWS it — proving the decision genuinely reads the query
+   result instead of e.g. always returning True/False regardless.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+
+import litellm
+import litellm.utils as litellm_utils
+
+from reyn.llm.llm import _streaming_capable
+
+_PROVIDER_NAME_HINTS = (
+    "gemini", "vertex", "openai", "anthropic", "claude", "bedrock", "azure",
+)
+
+
+def test_no_hardcoded_provider_name_in_capability_check() -> None:
+    """Tier 1: strip — ``_streaming_capable``'s source names no provider."""
+    src = inspect.getsource(_streaming_capable)
+    # Strip the docstring (prose may legitimately discuss "Gemini" as
+    # historical context) — only the executable body must be hardcode-free.
+    body = re.sub(r'""".*?"""', "", src, flags=re.DOTALL)
+    lowered = body.lower()
+    offenders = [name for name in _PROVIDER_NAME_HINTS if name in lowered]
+    assert not offenders, (
+        f"_streaming_capable's executable body names provider(s) {offenders} — "
+        "the streaming decision must come from a litellm capability query, "
+        "never a hardcoded provider/model-name check."
+    )
+
+
+def test_capability_query_drives_the_decision(monkeypatch) -> None:
+    """Tier 1: behavioral strip — neuter the capability query to a fixed
+    value and observe the branch selection change with it (RED would be:
+    the decision stays the same regardless of what the query reports, i.e.
+    the "query" is decorative and something else — a hardcode — actually
+    decides)."""
+    # gpt-4o-mini genuinely supports native streaming per litellm's own data
+    # — confirm the baseline is True before neutering.
+    assert _streaming_capable("gpt-4o-mini", has_tools=False) is True
+
+    def _always_false(model: str, custom_llm_provider=None) -> bool:  # noqa: ANN001
+        return False
+
+    monkeypatch.setattr(litellm_utils, "supports_native_streaming", _always_false)
+    assert _streaming_capable("gpt-4o-mini", has_tools=False) is False, (
+        "neutering the capability query to False must flip the decision to "
+        "False — if it stays True, something other than the query is driving "
+        "the branch (a hardcode)."
+    )
+
+
+def test_capability_query_gates_tools_axis_too(monkeypatch) -> None:
+    """Tier 1: the tools-present axis (supports_function_calling) is ALSO
+    query-driven, not skipped/hardcoded. Neuter it to False and confirm a
+    tools-bearing call is denied even though plain streaming is allowed."""
+    assert _streaming_capable("gpt-4o-mini", has_tools=True) is True
+
+    def _no_function_calling(model: str, custom_llm_provider=None) -> bool:  # noqa: ANN001
+        return False
+
+    monkeypatch.setattr(litellm, "supports_function_calling", _no_function_calling)
+    assert _streaming_capable("gpt-4o-mini", has_tools=True) is False
+    # Plain-text (no tools) is unaffected — the function-calling axis is only
+    # consulted when tools are actually attached.
+    assert _streaming_capable("gpt-4o-mini", has_tools=False) is True
+
+
+def test_unknown_model_is_conservative_fallback() -> None:
+    """Tier 1: an unmapped/unknown model → False (whole-collect fallback),
+    never an optimistic guess."""
+    assert _streaming_capable("totally-unknown-model-xyz-3288", has_tools=False) is False
+    assert _streaming_capable("totally-unknown-model-xyz-3288", has_tools=True) is False
+
+
+def test_reasoning_only_endpoint_denied_streaming() -> None:
+    """Tier 1: a real, non-hardcoded litellm capability fact — o1-pro's
+    model-info map entry says supports_native_streaming=False (litellm's own
+    data, not reyn's) — must deny streaming."""
+    assert _streaming_capable("o1-pro", has_tools=False) is False

--- a/tests/test_llm_streaming_equivalence_3288.py
+++ b/tests/test_llm_streaming_equivalence_3288.py
@@ -67,43 +67,71 @@ def _whole_response(model: str) -> "litellm.ModelResponse":
     )
 
 
-async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
-    """A real, scripted stand-in for ``litellm.acompletion`` — NOT a mock.
-    Branches on ``stream`` exactly like the real litellm client does."""
-    if not kw.get("stream"):
-        return _whole_response(model)
+def _make_fake_acompletion(chunk_witness: "list[int] | None" = None):
+    """Factory for a real, scripted stand-in for ``litellm.acompletion`` —
+    NOT a mock. Branches on ``stream`` exactly like the real litellm client
+    does.
 
-    def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
-        return ModelResponseStream(
-            id="resp-1", created=1, model=model, object="chat.completion.chunk",
-            choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
-        )
+    ``chunk_witness`` (optional, closure-captured): when given, one entry is
+    appended to it for EVERY chunk actually pulled off the async generator —
+    a live proof that the real streaming reconstruction loop iterated real
+    chunks, not that the defensive non-aiter-able fallback (see
+    ``recorded_acompletion``'s ``_stream_and_reconstruct``) silently
+    substituted the whole response instead. A call requesting ``stream=True``
+    does NOT by itself prove the streaming path ran to completion — only
+    actual chunk consumption does; the fallback fires whenever the callee
+    (real or faked) does not honor the request, which is exactly what a
+    non-stream-aware fake would do.
+    """
+    async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        if not kw.get("stream"):
+            return _whole_response(model)
 
-    async def _gen():
-        mid = len(_CONTENT) // 2
-        yield _chunk(Delta(role="assistant", content=_CONTENT[:mid]))
-        yield _chunk(Delta(content=_CONTENT[mid:]))
-        amid = len(_ARGS) // 2
-        yield _chunk(Delta(tool_calls=[
-            ChatCompletionDeltaToolCall(
-                id="call_1", index=0, type="function",
-                function=Function(name="get_weather", arguments=_ARGS[:amid]),
-            ),
-        ]))
-        yield _chunk(Delta(tool_calls=[
-            ChatCompletionDeltaToolCall(index=0, function=Function(arguments=_ARGS[amid:])),
-        ]))
-        last = _chunk(Delta(), finish_reason="tool_calls")
-        last.usage = Usage(**_USAGE)
-        yield last
+        def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-1", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
 
-    return _gen()
+        async def _gen():
+            mid = len(_CONTENT) // 2
+            pieces = [
+                _chunk(Delta(role="assistant", content=_CONTENT[:mid])),
+                _chunk(Delta(content=_CONTENT[mid:])),
+            ]
+            amid = len(_ARGS) // 2
+            pieces.append(_chunk(Delta(tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    id="call_1", index=0, type="function",
+                    function=Function(name="get_weather", arguments=_ARGS[:amid]),
+                ),
+            ])))
+            pieces.append(_chunk(Delta(tool_calls=[
+                ChatCompletionDeltaToolCall(index=0, function=Function(arguments=_ARGS[amid:])),
+            ])))
+            last = _chunk(Delta(), finish_reason="tool_calls")
+            last.usage = Usage(**_USAGE)
+            pieces.append(last)
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
+
+        return _gen()
+
+    return _fake_acompletion
+
+
+# Default instance (no witness) for tests that don't need chunk-consumption
+# proof beyond what they already assert directly on the reconstructed result.
+_fake_acompletion = _make_fake_acompletion()
 
 
 def test_stream_equals_whole_result(monkeypatch) -> None:
     """Tier 3a: streamed reconstruction == whole-collect result for the same
     model output (content, multi-arg tool_call, finish_reason, usage)."""
-    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_acompletion(chunk_witness))
 
     # gpt-4o-mini: real litellm capability data says native-streaming +
     # function-calling are both supported → the ③a streaming branch runs.
@@ -111,6 +139,16 @@ def test_stream_equals_whole_result(monkeypatch) -> None:
         model="gpt-4o-mini", messages=[{"role": "user", "content": "weather?"}],
         purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
     ))
+    # Witness: the streaming reconstruction loop actually pulled all 5
+    # scripted chunks off the async generator — proves this exercised the
+    # real per-chunk accumulation path, not the non-aiter-able fallback
+    # (which would leave chunk_witness empty even though "streamed" above
+    # still returned a valid-looking result via the whole-collect shortcut).
+    assert chunk_witness == [1, 1, 1, 1, 1], (
+        "expected all 5 scripted chunks consumed — got "
+        f"{len(chunk_witness)}; a mismatch means the fallback (not the real "
+        "streaming loop) produced `streamed`."
+    )
     # o1-pro: real litellm capability data says supports_native_streaming is
     # False (a genuine reasoning-only-endpoint limitation) → the existing
     # whole-collect path runs unconditionally, regardless of tools.
@@ -140,13 +178,22 @@ def test_stream_equals_whole_result(monkeypatch) -> None:
 
 def test_stream_path_actually_used_for_capable_model(monkeypatch) -> None:
     """Tier 3a: sanity witness — the streaming branch is genuinely exercised
-    (not accidentally always falling back to whole-collect), by asserting the
-    scripted callable observed ``stream=True`` for the capable model."""
+    (not accidentally always falling back to whole-collect). Two independent
+    witnesses: (1) the scripted callable observed ``stream=True`` requested
+    for the capable model, AND (2) real chunks were actually consumed off
+    the async generator — (1) alone is insufficient, since a call can
+    request ``stream=True`` and still fall through the non-aiter-able
+    defensive fallback without ever touching the per-chunk reconstruction
+    loop (exactly what happens for several PRE-existing test doubles
+    elsewhere in this suite that stub ``litellm.acompletion`` without
+    branching on ``stream`` — see ``_stream_and_reconstruct``'s docstring)."""
     seen: list[bool] = []
+    chunk_witness: list[int] = []
+    _fake = _make_fake_acompletion(chunk_witness)
 
     async def _observing(model: str, messages: list, **kw: Any) -> Any:
         seen.append(bool(kw.get("stream")))
-        return await _fake_acompletion(model, messages, **kw)
+        return await _fake(model, messages, **kw)
 
     monkeypatch.setattr(litellm, "acompletion", _observing)
     asyncio.run(recorded_acompletion(
@@ -154,3 +201,73 @@ def test_stream_path_actually_used_for_capable_model(monkeypatch) -> None:
         purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
     ))
     assert seen == [True], "capable model + tools must select the streaming branch"
+    assert chunk_witness == [1, 1, 1, 1, 1], (
+        "stream=True was requested but no chunks were actually consumed — "
+        "the call must have gone through the non-aiter-able fallback instead "
+        "of the real streaming reconstruction loop."
+    )
+
+
+def test_llm_replay_synthetic_stream_preserves_parallel_tool_calls() -> None:
+    """Tier 1: co-vet BLOCK fix — ``LLMReplay._synthetic_stream`` must assign
+    each PARALLEL tool_call its OWN index, not a shared ``index=0``.
+
+    ``litellm.stream_chunk_builder`` accumulates tool_call argument deltas
+    PER INDEX. Before the fix, every synthetic chunk claimed index=0
+    regardless of which tool_call it belonged to, so 2 parallel tool calls
+    MERGED into 1 on reconstruction (their argument strings concatenated
+    into invalid JSON) — silently, no exception. reyn does emit parallel
+    tool calls, so a fixture recorded with 2+ tool calls in one turn would
+    corrupt on replay under streaming.
+
+    Non-vacuity: this test is RED against the pre-fix (index=0-for-all)
+    ``_synthetic_stream`` (asserts below would fail: 1 reconstructed
+    tool_call instead of 2, and/or invalid JSON args) and GREEN against the
+    ``enumerate``-based fix.
+    """
+    import json
+
+    import litellm
+
+    from reyn.dev.testing.replay import LLMReplay
+
+    whole = litellm.ModelResponse(
+        id="resp-parallel", created=1, model="gpt-4o-mini", object="chat.completion",
+        choices=[{
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant", "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a", "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "/a.txt"}'},
+                    },
+                    {
+                        "id": "call_b", "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "/b.txt"}'},
+                    },
+                ],
+            },
+        }],
+        usage={"prompt_tokens": 30, "completion_tokens": 12, "total_tokens": 42},
+    )
+
+    async def _drain() -> object:
+        gen = LLMReplay._synthetic_stream(whole)
+        chunks = [chunk async for chunk in gen]
+        return litellm.stream_chunk_builder(chunks, messages=[{"role": "user", "content": "read both"}])
+
+    rebuilt = asyncio.run(_drain())
+    rebuilt_calls = rebuilt.choices[0].message.tool_calls
+
+    # Both parallel tool calls survive distinctly (a merge would collapse
+    # this to a single entry).
+    assert [tc.id for tc in rebuilt_calls] == ["call_a", "call_b"]
+    assert [tc.function.name for tc in rebuilt_calls] == ["read_file", "read_file"]
+
+    # Each call's arguments are valid, UN-concatenated JSON matching its own
+    # whole-response counterpart — a merge would produce
+    # '{"path":"/a.txt"}{"path":"/b.txt"}' (invalid JSON, raises on parse).
+    rebuilt_args = [json.loads(tc.function.arguments) for tc in rebuilt_calls]
+    assert rebuilt_args == [{"path": "/a.txt"}, {"path": "/b.txt"}]

--- a/tests/test_llm_streaming_equivalence_3288.py
+++ b/tests/test_llm_streaming_equivalence_3288.py
@@ -1,0 +1,156 @@
+"""Tier 3a: LLM-replay behavior — #3288 ③a stream≡whole equivalence (MAIN gate).
+
+For the same model output, the capability-gated streaming loop inside
+``recorded_acompletion`` must reconstruct an IDENTICAL result (content +
+tool_calls + finish_reason + usage) to the whole-collect path. Streaming is
+an internal optimization in this phase — callers see no behavioral
+difference.
+
+Uses a scripted ``litellm.acompletion`` replacement (a real async callable,
+per the repo's allowed monkeypatch-with-a-real-callable idiom — see
+``docs/deep-dives/contributing/testing.md`` "monkeypatch.setattr with a real
+callable"). NOT a MagicMock: the streaming branch returns REAL
+``litellm.types.utils.ModelResponseStream`` chunks that flow through the
+production code's REAL ``litellm.stream_chunk_builder`` call, and the
+whole-collect branch returns a REAL ``litellm.ModelResponse`` — the actual
+litellm types production code depends on, so a shape/signature drift in
+either would raise, not silently pass.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import litellm
+from litellm.types.utils import (
+    ChatCompletionDeltaToolCall,
+    Delta,
+    Function,
+    ModelResponseStream,
+    StreamingChoices,
+    Usage,
+)
+
+from reyn.llm.llm import recorded_acompletion
+
+_TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+    },
+}]
+
+# A multi-arg tool_call, split across TWO argument-delta chunks (exercises the
+# per-index accumulation the ADR requires), plus text content split across
+# TWO content-delta chunks.
+_CONTENT = "Hello world"
+_ARGS = '{"city": "Tokyo", "unit": "celsius"}'
+_USAGE = {"prompt_tokens": 42, "completion_tokens": 13, "total_tokens": 55}
+
+
+def _whole_response(model: str) -> "litellm.ModelResponse":
+    return litellm.ModelResponse(
+        id="resp-1", created=1, model=model, object="chat.completion",
+        choices=[{
+            "index": 0,
+            "finish_reason": "tool_calls",
+            "message": {
+                "role": "assistant", "content": _CONTENT,
+                "tool_calls": [{
+                    "id": "call_1", "type": "function",
+                    "function": {"name": "get_weather", "arguments": _ARGS},
+                }],
+            },
+        }],
+        usage=dict(_USAGE),
+    )
+
+
+async def _fake_acompletion(model: str, messages: list, **kw: Any) -> Any:
+    """A real, scripted stand-in for ``litellm.acompletion`` — NOT a mock.
+    Branches on ``stream`` exactly like the real litellm client does."""
+    if not kw.get("stream"):
+        return _whole_response(model)
+
+    def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+        return ModelResponseStream(
+            id="resp-1", created=1, model=model, object="chat.completion.chunk",
+            choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+        )
+
+    async def _gen():
+        mid = len(_CONTENT) // 2
+        yield _chunk(Delta(role="assistant", content=_CONTENT[:mid]))
+        yield _chunk(Delta(content=_CONTENT[mid:]))
+        amid = len(_ARGS) // 2
+        yield _chunk(Delta(tool_calls=[
+            ChatCompletionDeltaToolCall(
+                id="call_1", index=0, type="function",
+                function=Function(name="get_weather", arguments=_ARGS[:amid]),
+            ),
+        ]))
+        yield _chunk(Delta(tool_calls=[
+            ChatCompletionDeltaToolCall(index=0, function=Function(arguments=_ARGS[amid:])),
+        ]))
+        last = _chunk(Delta(), finish_reason="tool_calls")
+        last.usage = Usage(**_USAGE)
+        yield last
+
+    return _gen()
+
+
+def test_stream_equals_whole_result(monkeypatch) -> None:
+    """Tier 3a: streamed reconstruction == whole-collect result for the same
+    model output (content, multi-arg tool_call, finish_reason, usage)."""
+    monkeypatch.setattr(litellm, "acompletion", _fake_acompletion)
+
+    # gpt-4o-mini: real litellm capability data says native-streaming +
+    # function-calling are both supported → the ③a streaming branch runs.
+    streamed = asyncio.run(recorded_acompletion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "weather?"}],
+        purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+    ))
+    # o1-pro: real litellm capability data says supports_native_streaming is
+    # False (a genuine reasoning-only-endpoint limitation) → the existing
+    # whole-collect path runs unconditionally, regardless of tools.
+    whole = asyncio.run(recorded_acompletion(
+        model="o1-pro", messages=[{"role": "user", "content": "weather?"}],
+        purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+    ))
+
+    s_msg = streamed.choices[0].message
+    w_msg = whole.choices[0].message
+    assert s_msg.content == w_msg.content == _CONTENT
+    # Behavioral: compare the extracted (name, arguments) pairs directly —
+    # this also implicitly requires exactly one reconstructed tool_call on
+    # each side (an empty or multi-entry list would fail the equality, not
+    # just a bare cardinality count).
+    assert [tc.function.name for tc in s_msg.tool_calls] == ["get_weather"]
+    assert [tc.function.name for tc in w_msg.tool_calls] == ["get_weather"]
+    assert s_msg.tool_calls[0].function.arguments == w_msg.tool_calls[0].function.arguments == _ARGS
+    assert streamed.choices[0].finish_reason == whole.choices[0].finish_reason == "tool_calls"
+    assert streamed.usage.prompt_tokens == whole.usage.prompt_tokens == _USAGE["prompt_tokens"]
+    assert (
+        streamed.usage.completion_tokens
+        == whole.usage.completion_tokens
+        == _USAGE["completion_tokens"]
+    )
+
+
+def test_stream_path_actually_used_for_capable_model(monkeypatch) -> None:
+    """Tier 3a: sanity witness — the streaming branch is genuinely exercised
+    (not accidentally always falling back to whole-collect), by asserting the
+    scripted callable observed ``stream=True`` for the capable model."""
+    seen: list[bool] = []
+
+    async def _observing(model: str, messages: list, **kw: Any) -> Any:
+        seen.append(bool(kw.get("stream")))
+        return await _fake_acompletion(model, messages, **kw)
+
+    monkeypatch.setattr(litellm, "acompletion", _observing)
+    asyncio.run(recorded_acompletion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "weather?"}],
+        purpose="main", recorder=None, extra_kwargs={"tools": _TOOLS},
+    ))
+    assert seen == [True], "capable model + tools must select the streaming branch"

--- a/tests/test_llm_streaming_usage_single_emission_3288.py
+++ b/tests/test_llm_streaming_usage_single_emission_3288.py
@@ -1,0 +1,121 @@
+"""Tier 2: OS invariant — #3288 ③a usage/cost single-emission gate.
+
+★architect pin: usage arriving across streamed chunks is SUMMED inside
+``recorded_acompletion`` and emitted via the existing ``recorder.record_llm``
+seam EXACTLY ONCE per call — never per-chunk. This preserves the #1190
+single-cost-observability-chokepoint invariant; ``budget.py``'s
+``record_llm`` signature is untouched by ③a.
+
+A hand-written recorder (not a mock — a real class implementing the exact
+``record_llm(**kw)`` collaborator contract, per ``test_cost_chokepoint_1190.py``'s
+own ``_Recorder`` precedent) counts calls. The strip: a per-chunk emit would
+double/multi-count — this test would go RED under that regression.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import litellm
+from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
+
+from reyn.llm.llm import recorded_acompletion
+from reyn.llm.pricing import TokenUsage
+
+_TOOLS = [{
+    "type": "function",
+    "function": {"name": "noop", "parameters": {"type": "object", "properties": {}}},
+}]
+
+
+class _Recorder:
+    """Hand-written recorder capturing record_llm calls (not a mock) —
+    mirrors ``test_cost_chokepoint_1190.py``'s ``_Recorder``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def record_llm(self, **kw: Any) -> None:
+        self.calls.append(kw)
+
+
+async def _fake_streaming_acompletion(model: str, messages: list, **kw: Any) -> Any:
+    """A real, scripted stand-in for litellm.acompletion's stream=True
+    contract: FIVE chunks, usage attached only to the terminal one — the
+    shape a real provider stream arrives in (usage is a terminal-chunk or
+    cross-chunk phenomenon, never available per-chunk up front)."""
+    assert kw.get("stream") is True, "this fixture only models the streaming call shape"
+
+    def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+        return ModelResponseStream(
+            id="resp-1", created=1, model=model, object="chat.completion.chunk",
+            choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+        )
+
+    async def _gen():
+        yield _chunk(Delta(role="assistant", content="Hel"))
+        yield _chunk(Delta(content="lo "))
+        yield _chunk(Delta(content="there"))
+        last = _chunk(Delta(), finish_reason="stop")
+        last.usage = Usage(prompt_tokens=20, completion_tokens=8, total_tokens=28)
+        yield last
+
+    return _gen()
+
+
+def test_usage_recorded_exactly_once_when_streamed(monkeypatch) -> None:
+    """Tier 2: record_llm fires exactly once per recorded_acompletion call,
+    even though usage arrived split across streamed chunks (summed inside
+    the chokepoint, not per-chunk)."""
+    monkeypatch.setattr(litellm, "acompletion", _fake_streaming_acompletion)
+
+    rec = _Recorder()
+    response = asyncio.run(recorded_acompletion(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=rec, agent="a1",
+    ))
+
+    # ★ the gate: exactly ONE record_llm call tagged "main", not N (one per
+    # chunk, which would show up as multiple "main" entries) and not zero
+    # (usage silently dropped because it arrived late). Comparing the whole
+    # derived purpose-sequence to a single-element list (not a bare `len(...)
+    # == N` count) encodes the same cardinality claim behaviorally.
+    assert [c["purpose"] for c in rec.calls] == ["main"], (
+        f"expected exactly one record_llm call tagged 'main', got {rec.calls} — "
+        "a per-chunk emit would double/multi-count cost."
+    )
+    usage = rec.calls[0]["usage"]
+    assert isinstance(usage, TokenUsage)
+    assert usage.prompt_tokens == 20
+    assert usage.completion_tokens == 8
+    # response.usage (post-reconstruction) carries the SAME summed values the
+    # single record_llm call used — proving "summed here, once" rather than
+    # "some other partial number recorded".
+    assert response.usage.prompt_tokens == 20
+    assert response.usage.completion_tokens == 8
+
+
+def test_usage_recorded_once_for_whole_collect_baseline(monkeypatch) -> None:
+    """Tier 2: baseline — the pre-existing non-streaming path already
+    records exactly once (regression guard: ③a must not have changed this
+    invariant for the fallback path either)."""
+    async def _fake_whole(model: str, messages: list, **kw: Any) -> Any:
+        assert not kw.get("stream")
+        return litellm.ModelResponse(
+            id="resp-2", created=1, model=model, object="chat.completion",
+            choices=[{
+                "index": 0, "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "ok"},
+            }],
+            usage={"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+        )
+
+    monkeypatch.setattr(litellm, "acompletion", _fake_whole)
+    rec = _Recorder()
+    # o1-pro: real litellm capability data denies streaming outright, so this
+    # exercises the whole-collect branch specifically.
+    asyncio.run(recorded_acompletion(
+        model="o1-pro", messages=[{"role": "user", "content": "hi"}],
+        purpose="main", recorder=rec, agent="a1",
+    ))
+    assert [c["purpose"] for c in rec.calls] == ["main"]

--- a/tests/test_llm_streaming_usage_single_emission_3288.py
+++ b/tests/test_llm_streaming_usage_single_emission_3288.py
@@ -39,41 +39,62 @@ class _Recorder:
         self.calls.append(kw)
 
 
-async def _fake_streaming_acompletion(model: str, messages: list, **kw: Any) -> Any:
-    """A real, scripted stand-in for litellm.acompletion's stream=True
-    contract: FIVE chunks, usage attached only to the terminal one — the
-    shape a real provider stream arrives in (usage is a terminal-chunk or
-    cross-chunk phenomenon, never available per-chunk up front)."""
-    assert kw.get("stream") is True, "this fixture only models the streaming call shape"
+def _make_fake_streaming_acompletion(chunk_witness: "list[int] | None" = None):
+    """Factory for a real, scripted stand-in for litellm.acompletion's
+    stream=True contract: FIVE chunks, usage attached only to the terminal
+    one — the shape a real provider stream arrives in (usage is a
+    terminal-chunk or cross-chunk phenomenon, never available per-chunk up
+    front). ``chunk_witness`` (optional): incremented for each chunk
+    actually pulled off the generator — proves the test exercised the real
+    per-chunk streaming loop, not the non-aiter-able defensive fallback (see
+    ``_stream_and_reconstruct``'s docstring)."""
+    async def _fake_streaming_acompletion(model: str, messages: list, **kw: Any) -> Any:
+        assert kw.get("stream") is True, "this fixture only models the streaming call shape"
 
-    def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
-        return ModelResponseStream(
-            id="resp-1", created=1, model=model, object="chat.completion.chunk",
-            choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
-        )
+        def _chunk(delta: Delta, finish_reason: str | None = None) -> ModelResponseStream:
+            return ModelResponseStream(
+                id="resp-1", created=1, model=model, object="chat.completion.chunk",
+                choices=[StreamingChoices(index=0, delta=delta, finish_reason=finish_reason)],
+            )
 
-    async def _gen():
-        yield _chunk(Delta(role="assistant", content="Hel"))
-        yield _chunk(Delta(content="lo "))
-        yield _chunk(Delta(content="there"))
-        last = _chunk(Delta(), finish_reason="stop")
-        last.usage = Usage(prompt_tokens=20, completion_tokens=8, total_tokens=28)
-        yield last
+        async def _gen():
+            last = _chunk(Delta(), finish_reason="stop")
+            last.usage = Usage(prompt_tokens=20, completion_tokens=8, total_tokens=28)
+            pieces = [
+                _chunk(Delta(role="assistant", content="Hel")),
+                _chunk(Delta(content="lo ")),
+                _chunk(Delta(content="there")),
+                last,
+            ]
+            for piece in pieces:
+                if chunk_witness is not None:
+                    chunk_witness.append(1)
+                yield piece
 
-    return _gen()
+        return _gen()
+
+    return _fake_streaming_acompletion
 
 
 def test_usage_recorded_exactly_once_when_streamed(monkeypatch) -> None:
     """Tier 2: record_llm fires exactly once per recorded_acompletion call,
     even though usage arrived split across streamed chunks (summed inside
     the chokepoint, not per-chunk)."""
-    monkeypatch.setattr(litellm, "acompletion", _fake_streaming_acompletion)
+    chunk_witness: list[int] = []
+    monkeypatch.setattr(litellm, "acompletion", _make_fake_streaming_acompletion(chunk_witness))
 
     rec = _Recorder()
     response = asyncio.run(recorded_acompletion(
         model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}],
         purpose="main", recorder=rec, agent="a1",
     ))
+    # Witness: all 4 scripted chunks were actually consumed — the usage
+    # summation this test pins genuinely ran across chunks, not via the
+    # fallback silently accepting a single flat response.
+    assert chunk_witness == [1, 1, 1, 1], (
+        f"expected all 4 scripted chunks consumed, got {len(chunk_witness)} — "
+        "this must exercise the real streaming loop, not the fallback."
+    )
 
     # ★ the gate: exactly ONE record_llm call tagged "main", not N (one per
     # chunk, which would show up as multiple "main" entries) and not zero

--- a/tests/test_llm_tools.py
+++ b/tests/test_llm_tools.py
@@ -53,8 +53,13 @@ def _make_budget_tracker(*, per_agent_tokens_hard: int | None = None):
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
-async def test_stream_false_is_forced(monkeypatch):
-    """Tier 1: framework contract: stream=False must be passed to litellm regardless of caller input.
+async def test_stream_is_capability_gated_not_forced_false(monkeypatch):
+    """Tier 1: framework contract (#3288 ③a) — ``call_llm_tools`` no longer
+    forces ``stream=False`` unconditionally (the pre-③a Gemini #21041
+    workaround). The decision is now made INSIDE ``recorded_acompletion`` via
+    a litellm capability query (``_streaming_capable``): a genuinely
+    streaming+function-calling-capable model (real litellm capability data,
+    not a reyn hardcode) is called with ``stream=True``.
 
     Uses a capturing async function (not AsyncMock) to inspect kwargs.
     Framework boundary — intentional monkeypatch.
@@ -81,7 +86,10 @@ async def test_stream_false_is_forced(monkeypatch):
         tools=MINIMAL_TOOLS,
     )
 
-    assert captured.get("stream") is False
+    # MODEL ("gemini-2.5-flash-lite") supports both native streaming and
+    # function calling per litellm's own capability data → capability-gated
+    # ON, not the old unconditional False.
+    assert captured.get("stream") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — Phase ③a (core LLM streaming) of the token-streaming arc (#3288). Entirely within `src/reyn/llm/llm.py` (production) + the `LLMReplay` test Fake (`src/reyn/dev/testing/replay.py`) for compatibility. Follows the ADR (issue #3288 body) and the architect's ③a non-conflict confirmation (issue comment). part of #3288.

## (a) Capability query used

`_streaming_capable(model, has_tools)` (`src/reyn/llm/llm.py`), mirroring the existing `litellm.supports_response_schema` precedent (`router_loop.py`'s structured-output precheck):

- `litellm.utils.supports_native_streaming(model, custom_llm_provider=None)` — can this model stream at all? (False only for reasoning-only endpoints like `o1-pro`/`gpt-5-pro`, real litellm data.)
- IF `tools` are attached: additionally requires `litellm.supports_function_calling(model, custom_llm_provider=None)` — the historical Gemini streaming+tools bug (litellm#21041, closed/fixed upstream since v1.81.3) only bites the combination.

Queried **without** an explicit `custom_llm_provider` override — proxy routing (`proxy_kwargs()`) forces `custom_llm_provider="openai"` on the wire for every model when an operator proxy is configured; passing that routing artifact into the capability query would misresolve e.g. `gemini-2.5-flash` as an unmapped "openai" model and always report "no capability" for the very providers this targets. Capability is a property of the model, not the transport used to reach it.

**No provider-name hardcode** — verified structurally (`test_no_hardcoded_provider_name_in_capability_check` scans `_streaming_capable`'s executable body for provider-name literals) and behaviorally (`test_capability_query_drives_the_decision` neuters `litellm.utils.supports_native_streaming` via `monkeypatch.setattr` with a real callable and shows the branch flips).

Any lookup failure (unmapped model, litellm internal error) → `False` (conservative fallback), never an optimistic guess.

## (b) Delta reconstruction

`_stream_and_reconstruct` (nested inside `recorded_acompletion` so its `litellm.acompletion` call stays inside the #1190 AST-guarded chokepoint span — still only 2 call sites: this one + the Router branch). Calls litellm with `stream=True` (+ `stream_options={"include_usage": True}` ONLY when `litellm.get_supported_openai_params` confirms the model accepts it — OpenAI-only param, another capability query not a provider check), drains the async chunk stream, then reconstructs via litellm's OWN `stream_chunk_builder` — content deltas concatenated, tool_call argument deltas accumulated PER INDEX (the documented multi-arg shape), usage summed — rather than a hand-rolled accumulator. Defensive fallback: if the callee doesn't honor `stream=True` (returns a non-async-iterable), the response is accepted as-is instead of crashing.

## (c) Usage/cost single emission

Streaming returns ONE reconstructed response with ONE `.usage`; the existing `recorder.record_llm(...)` call in `recorded_acompletion` (and `call_llm_tools`'s own `budget.record_llm(...)`) fires exactly once, unchanged — usage is summed inside the streaming loop, never per-chunk. `budget.py` (the cost band, `record_llm` at budget.py:1135) is **untouched**. Strip-tested: `test_usage_recorded_exactly_once_when_streamed` proves exactly one `record_llm` call across a 4-chunk stream with usage on the terminal chunk only.

## (d) stream≡whole equivalence proof

`test_stream_equals_whole_result` — a scripted `litellm.acompletion` stand-in (a real async callable branching on `stream`, not a mock) drives `recorded_acompletion` for a capable model (`gpt-4o-mini`, streaming branch) and a capability-denied model (`o1-pro`, whole-collect branch) with the SAME underlying content/multi-arg tool_call/usage, and asserts the reconstructed results are identical (content, tool_call name+arguments, finish_reason, usage).

## (e) Whole-collect fallback

Unchanged `litellm.acompletion(model=..., messages=..., **call_kwargs)` call, now reached only when `_streaming_capable` returns `False` (was: unconditional).

## (f) Gates + test results

- `ruff check src tests` — clean
- `python scripts/test_tier_audit.py --strict <changed test files>` — 9/9 (new files) + 9/9 (`test_llm_tools.py`) clean, 0 Tier-4 violations
- `uv run python -m pytest --timeout=120 -q -n auto` (foreground) — **9156 passed, 36 skipped, 0 failed**
- `python scripts/verify_module_docstrings.py src/reyn/llm/llm.py src/reyn/dev/testing/replay.py` — clean

## Notable side change: `LLMReplay` now supports `stream=True`

The capability gate selects streaming for common test models (gemini/gpt), and ~30 existing test files stub `litellm.acompletion` in various ways. `LLMReplay` (`src/reyn/dev/testing/replay.py`) is extended to serve `stream=True` requests via a synthetic multi-chunk reconstruction of the SAME recorded/replayed whole response (`_synthetic_stream`) — the fixture format is unchanged; this doubles as a live stream≡whole regression check across the whole fixture-based suite. One pre-existing test (`test_llm_tools.py::test_stream_false_is_forced`) asserted the OLD hardcoded-False contract directly and was rewritten (`test_stream_is_capability_gated_not_forced_false`) to assert the new capability-gated contract instead.

One unrelated failure was observed on the full-suite run (`test_plugin_install.py::test_registered_command_pointing_at_missing_venv_fails_fast_no_fetch`) — confirmed pre-existing/timing-flaky (passes in isolation; file is disjoint from this diff).

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on all changed/added test files
- [x] `uv run python -m pytest --timeout=120 -q -n auto` — 9156 passed, 36 skipped
- [x] `python scripts/verify_module_docstrings.py` on changed src files

🤖 Generated with [Claude Code](https://claude.com/claude-code)