### PR TITLE
feat(tui): render sent-queue region + materialize/promote lifecycle — #3300 P2b

### DIFF
--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -41,6 +41,7 @@ from textual_flowview import (
 )
 
 from reyn.interfaces.repl.renderer import summarize_tool_result
+from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.frames import FrameTag
 
 from ._meta_keys import ORPHANED_RESULT_KIND as _ORPHANED_RESULT_KIND
@@ -60,8 +61,10 @@ from .presenter import (
     _RESULT_META_KEY,
     _RUNNING_SINCE_KEY,
     ReynPresenter,
+    _neutralized_label,
 )
 from .restore import project_restored_frames
+from .sent_queue import SentQueue
 
 if TYPE_CHECKING:
     from reyn.interfaces.repl.read_model import ChatReadModel
@@ -300,6 +303,25 @@ class TextualChatApp(App):
         # placeholder → "✓ answered" record) once the panel delivers an answer.
         # ``None`` when no intervention is pending.
         self._pending_iv_entry: "Entry[OutboxMessage] | None" = None
+        # #3300 P2b: the client-side sent-queue model — the SAME seq-gated
+        # merge P2a built (``RemoteQueueView``, reused as-is, not
+        # reinvented) driving BOTH the local and remote transport, since the
+        # read-model now projects queue/turn_active/queue_seq uniformly for
+        # each (``ChatReadModel.snapshot()``, see ``read_model.py``). Seeded
+        # once from a fresh snapshot on the FIRST frame the pump processes
+        # (:meth:`_seed_queue_view`) — by then a remote connection's
+        # connect-time STATE_SNAPSHOT has already been applied to the
+        # transport (emitter.py's "Reconnect snapshots first (A4)"), so the
+        # baseline is late-joiner-correct; a local read is always live so an
+        # early seed is harmless there.
+        self._queue_view = RemoteQueueView()
+        self._queue_seeded = False
+        # A queued item's ``meta`` (attribution) — ``RemoteQueueView.items``
+        # deliberately carries only msg_id/chain_id/text (P2a's contract,
+        # reused unmodified); this side table keeps the meta a promoted item
+        # needs to render as a proper flow entry, keyed by msg_id and popped
+        # on promotion.
+        self._queue_item_meta: "dict[str, dict]" = {}
         # Per-picker parallel id lists (class names / agent names), keyed by tab
         # id and kept in lock-step with the OptionList options a pane was last
         # refreshed with, so an ``OptionSelected.option_index`` maps back to the
@@ -326,12 +348,20 @@ class TextualChatApp(App):
         yield self._flow
         # #3299 P1: the grouped intervention panel sits BETWEEN the flow and
         # the input row (region order shared with the sibling #3300 queue arc:
-        # conversation / intervention panel / (queue, later) / input).
+        # conversation / intervention panel / sent-queue / input).
         # Collapsed by default (``display=False`` — see
         # ``InterventionPanel.on_mount``); shown + auto-focused only while an
         # intervention is pending (:meth:`_present_intervention`).
         self._iv_panel = InterventionPanel(id="intervention-panel")
         yield self._iv_panel
+        # #3300 P2b: the sent-queue region sits BETWEEN the intervention
+        # panel and the input row (region order: conversation / intervention
+        # panel / sent-queue / input — pinned by the architect design pass so
+        # the sibling #3299/#3300 P1 coders never collide on this zone).
+        # Collapsed by default (``display=False`` — see ``SentQueue.on_mount``);
+        # shown while at least one message is queued, undispatched.
+        self._sent_queue = SentQueue(id="sent-queue")
+        yield self._sent_queue
         with Horizontal(id="inputrow"):
             yield Static("❯", id="inputgutter")
             yield Composer(
@@ -825,6 +855,85 @@ class TextualChatApp(App):
         except Exception:
             logger.exception("textual chat: could not start running-tool indicator")
 
+    def _seed_queue_view(self) -> None:
+        """Seed :attr:`_queue_view` from a fresh read-model snapshot — called
+        once, on the FIRST frame the pump processes (#3300 P2b).
+
+        The read-model projects ``queue``/``turn_active``/``queue_seq``
+        uniformly for local and remote (``read_model.py``'s
+        ``project_remote_snapshot`` mirrors ``interfaces/repl/status.py``'s
+        ``_snapshot()``), so ONE call seeds the seq-gate baseline correctly
+        for either transport: local is always live (no wire delay), and for
+        remote the connect-time ``STATE_SNAPSHOT`` has already reached the
+        transport by the time frame #1 is yielded (emitter.py's "Reconnect
+        snapshots first (A4)"), so this is late-joiner-correct. Any item the
+        snapshot already carries (a submission from BEFORE this client
+        attached) is rendered into the sent-queue region immediately."""
+        snap = self._snapshot() or {}
+        self._queue_view.apply_snapshot(
+            queue=snap.get("queue", []),
+            turn_active=snap.get("turn_active", False),
+            queue_seq=snap.get("queue_seq", 0),
+        )
+        for item in self._queue_view.queue():
+            msg_id = item.get("msg_id")
+            if msg_id:
+                self._sent_queue.show_item(msg_id, str(item.get("text", "")))
+
+    def _handle_user_submitted_event(self, event) -> None:
+        """MATERIALIZE exit (#3300 P2b, sent-queue exit contract §6a): a
+        ``user_submitted`` delta appears in the sent-queue region — NOT
+        immediately as a flow entry (that was P1 C's behavior; P2b replaces
+        it with this staging step). Applies the seq-gate
+        (:meth:`RemoteQueueView.apply_user_submitted`) before rendering, so a
+        stale/already-superseded delta is a no-op."""
+        data = event.data or {}
+        msg_id = data.get("msg_id")
+        chain_id = data.get("chain_id")
+        text = str(data.get("text", ""))
+        seq = data.get("seq", 0)
+        applied = self._queue_view.apply_user_submitted(
+            msg_id=msg_id, chain_id=chain_id, text=text, seq=seq,
+        )
+        if applied and msg_id:
+            self._queue_item_meta[msg_id] = dict(data.get("meta") or {})
+            self._sent_queue.show_item(msg_id, text)
+
+    def _handle_turn_started_event(self, event) -> None:
+        """PROMOTE exit (#3300 P2b, sent-queue exit contract §6a): a
+        ``turn_started`` delta whose ``chain_id`` matches a queued item
+        removes it from the sent-queue region and appends it as a flow entry
+        (the user line) — the dispatch promotion. ``turn_started`` fires for
+        EVERY turn kind, not only ``user`` ones (session.py: "harmless for
+        non-queue turns"), so a non-matching chain_id is correctly a no-op
+        here (nothing queued for it).
+
+        The pre-call match snapshot is load-bearing: ``apply_turn_started``
+        returns ``True`` whenever the seq-gate ACCEPTS the delta, regardless
+        of whether any item actually matched — checking membership only
+        AFTER the call would miss the case where nothing matched (never
+        promote), and re-checking on a stale/rejected delta (``False``) would
+        double-promote an item this app already promoted once."""
+        data = event.data or {}
+        chain_id = data.get("chain_id")
+        seq = data.get("seq", 0)
+        matches = [
+            item for item in self._queue_view.queue()
+            if item.get("chain_id") == chain_id
+        ]
+        applied = self._queue_view.apply_turn_started(chain_id=chain_id, seq=seq)
+        if not applied:
+            return
+        from reyn.runtime.outbox import OutboxMessage  # noqa: PLC0415
+
+        for item in matches:
+            msg_id = item.get("msg_id")
+            if msg_id:
+                self._sent_queue.remove_item(msg_id)
+            meta = self._queue_item_meta.pop(msg_id, {}) if msg_id else {}
+            text = _neutralized_label(str(item.get("text", "")))
+            self._ingest_frame(OutboxMessage(kind="user", text=text, meta=meta))
+
     async def _pump_frames(self) -> None:
         """Drain the transport frame stream into the retained model.
 
@@ -835,31 +944,41 @@ class TextualChatApp(App):
         path — consumed but not drawn, EXCEPT for the turn-end subset
         (:data:`_TURN_END_EVENT_TYPES`), which triggers
         :meth:`_sweep_orphaned_running_tools` (#72: force-settle any tool still
-        RUNNING when its turn ends — a confirmed orphan), and ``user_submitted``
-        (#3300 P1 C), which IS drawn — it materializes the submitting/peer
-        client's own user line (the removed ``_put_outbox`` echo's replacement)
-        via the same neutralize-at-render-time seam the plain renderer uses
-        (:func:`~reyn.interfaces.repl.renderer.user_submitted_display_message`).
-        In Phase C this appends straight to the flow like any other display
-        frame — the sent-queue staging (materialize → promote on
-        ``turn_started``) is Phase B, not built here. A single frame's failure
-        must not kill the pump, so ingest is guarded.
+        RUNNING when its turn ends — a confirmed orphan).
+
+        #3300 P2b: ``user_submitted`` (:meth:`_handle_user_submitted_event`)
+        and ``turn_started`` (:meth:`_handle_turn_started_event`) drive the
+        sent-queue "upward conveyor" — materialize into the sent-queue region,
+        then promote to a flow entry on dispatch. This REPLACES P1 C's
+        "append the user_submitted echo straight to the flow": a submission
+        now stages in the sent-queue first (near-instant promotion on an idle
+        server, durably visible while queued on a busy one). The queue model
+        is seeded once, on the first frame (:meth:`_seed_queue_view`). A
+        single frame's failure must not kill the pump, so ingest is guarded.
         """
         try:
             async for frame in self._transport.frames():
+                if not self._queue_seeded:
+                    try:
+                        self._seed_queue_view()
+                    except Exception:
+                        logger.exception("textual chat: queue-view seed failed")
+                    self._queue_seeded = True
                 if frame.tag is FrameTag.EVENT:
                     etype = getattr(frame.event, "type", None)
                     if etype == "user_submitted":
-                        from reyn.interfaces.repl.renderer import (  # noqa: PLC0415
-                            user_submitted_display_message,
-                        )
                         try:
-                            self._ingest_frame(
-                                user_submitted_display_message(frame.event)
-                            )
+                            self._handle_user_submitted_event(frame.event)
                         except Exception:
                             logger.exception(
                                 "textual chat: user_submitted ingest failed"
+                            )
+                    elif etype == "turn_started":
+                        try:
+                            self._handle_turn_started_event(frame.event)
+                        except Exception:
+                            logger.exception(
+                                "textual chat: turn_started queue-promote failed"
                             )
                     elif etype in _TURN_END_EVENT_TYPES:
                         try:
@@ -923,9 +1042,10 @@ class TextualChatApp(App):
         :meth:`on_intervention_panel_text_submitted`), never here. A Composer
         submit that lands while an intervention is pending is NOT black-holed:
         the backend turn stays busy awaiting the intervention, so
-        ``submit_user_text`` durably queues the line on the inbox (visible /
-        cancelable via the #3300 sent-queue once its P2/P3 land) rather than
-        losing it — this delegation was verified live (turn-owner-task /
+        ``submit_user_text`` durably queues the line on the inbox — visible in
+        the sent-queue region (#3300 P2b, this module) and, once P3 Y lands,
+        cancelable there too — rather than losing it. This delegation was
+        verified live (turn-owner-task /
         inbox-durability trace) by the architect design pass for #3299, so P1
         needs no hint/block guard of its own. Errors are contained and
         surfaced as an error frame the pump renders — a silent input drop is

--- a/src/reyn/interfaces/inline/textual_chat/app.py
+++ b/src/reyn/interfaces/inline/textual_chat/app.py
@@ -316,11 +316,17 @@ class TextualChatApp(App):
         # early seed is harmless there.
         self._queue_view = RemoteQueueView()
         self._queue_seeded = False
-        # A queued item's ``meta`` (attribution) — ``RemoteQueueView.items``
-        # deliberately carries only msg_id/chain_id/text (P2a's contract,
-        # reused unmodified); this side table keeps the meta a promoted item
-        # needs to render as a proper flow entry, keyed by msg_id and popped
-        # on promotion.
+        # A queued item's ``meta`` (ADR-0039 attribution) — ``apply_user_submitted``
+        # deliberately stores only msg_id/chain_id/text on
+        # ``RemoteQueueView.items`` (P2a's delta contract, reused unmodified,
+        # not reinvented); this side table is what carries a promoted item's
+        # meta into its flow entry, keyed by msg_id and popped on promotion.
+        # Populated from TWO sources: the live ``user_submitted`` delta
+        # (:meth:`_handle_user_submitted_event`) and, for an item already
+        # queued at connect time, the snapshot seed (:meth:`_seed_queue_view`
+        # — ``queued_user_messages()`` now projects ``meta`` too, #3300 P2b
+        # co-vet fix, so a late-joiner's promoted item is attributed exactly
+        # like a delta-path one).
         self._queue_item_meta: "dict[str, dict]" = {}
         # Per-picker parallel id lists (class names / agent names), keyed by tab
         # id and kept in lock-step with the OptionList options a pane was last
@@ -879,6 +885,15 @@ class TextualChatApp(App):
             msg_id = item.get("msg_id")
             if msg_id:
                 self._sent_queue.show_item(msg_id, str(item.get("text", "")))
+                # #3300 P2b co-vet fix: a snapshot-seeded item's ``meta``
+                # (ADR-0039 attribution — carried through by
+                # ``RemoteQueueView.apply_snapshot``'s ``dict(item)`` copy,
+                # since ``queued_user_messages()`` now projects it) must land
+                # in the SAME side table the delta path uses, or a promoted
+                # snapshot-seeded item loses its ``[actor]`` prefix (a peer's
+                # queued message misattributing as a plain operator line for
+                # a late-joining client).
+                self._queue_item_meta[msg_id] = dict(item.get("meta") or {})
 
     def _handle_user_submitted_event(self, event) -> None:
         """MATERIALIZE exit (#3300 P2b, sent-queue exit contract §6a): a

--- a/src/reyn/interfaces/inline/textual_chat/sent_queue.py
+++ b/src/reyn/interfaces/inline/textual_chat/sent_queue.py
@@ -1,0 +1,102 @@
+"""``SentQueue`` — the sent-queue region widget (#3300 P2b).
+
+Renders the client-side view of the server-authoritative sent queue (the
+undispatched inbox items, published by P2a) between the
+:class:`~reyn.interfaces.inline.textual_chat.intervention_panel.InterventionPanel`
+and the input row (region order: conversation / intervention panel /
+sent-queue / input — shared with the sibling #3299 arc, see
+``app.py``'s :meth:`~reyn.interfaces.inline.textual_chat.app.TextualChatApp.compose`).
+
+The "upward conveyor" lifecycle (the owner-ratified sent-queue exit contract,
+#3300 issue §6a) this widget renders the MATERIALIZE half of:
+
+- ``user_submitted`` → :meth:`show_item` — a submitted message first appears
+  HERE (dim, queued), not immediately as a flow entry. This REPLACES P1 C's
+  "render the echo directly as a flow entry": for an idle server the
+  promotion below follows almost instantly; for a busy/queued submission the
+  item stays visible here until dispatch.
+- ``turn_started`` → :meth:`remove_item` — the PROMOTE exit: the app removes
+  the item from this widget and appends it as a flow entry (the user line) in
+  the SAME step (see ``app.py``'s ``_pump_frames`` — the removal here and the
+  flow-entry append are driven from one delta so there is never a frame where
+  the item is both queued and already in the flow, or neither).
+- ``inbox_cancel`` removal is Phase 3 Y — NOT built here.
+
+The app owns the :class:`~reyn.interfaces.transport.agui.state.RemoteQueueView`
+seq-gated merge (the P2a order-race protocol, reused as-is — see the app
+module docstring); this widget is a pure renderer of whatever the app tells it
+to show/remove, keyed by ``msg_id``.
+
+**Security**: a queued item's text is LLM-adjacent/untrusted user-derived
+content reaching the terminal — the SAME injection class as the #3302 panel-
+label bug. Every row is neutralized at THIS display boundary
+(:func:`~reyn.interfaces.inline.textual_chat.presenter._neutralized_label` —
+the same ``core/present/guard.get_neutralizer("terminal")`` seam the
+intervention panel and the ``user_submitted`` flow-entry echo both use) and
+wrapped in a :class:`~textual.content.Content` LITERAL, never passed to
+``Static.update``/mount as a bare ``str`` (which Textual markup-parses).
+"""
+from __future__ import annotations
+
+from textual.containers import Vertical
+from textual.content import Content
+from textual.widgets import Static
+
+from .presenter import _neutralized_label
+
+
+class SentQueue(Vertical):
+    """The sent-queue region: one dim row per undispatched queued message,
+    keyed by ``msg_id``. Collapsed (``display=False``) when empty — the
+    default state until the first :meth:`show_item` call."""
+
+    DEFAULT_CSS = """
+    SentQueue {
+        height: auto;
+        max-height: 6;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    SentQueue Static { height: auto; }
+    """
+
+    def on_mount(self) -> None:
+        self.display = False
+        self._rows: "dict[str, Static]" = {}
+
+    def show_item(self, msg_id: str, text: str) -> None:
+        """Materialize a queued item (``user_submitted``): neutralize the
+        untrusted text at this display boundary, wrap it in a ``Content``
+        literal (never a bare ``str`` — see the module docstring's security
+        note), and mount it as a new dim row. A duplicate ``msg_id`` (should
+        not happen server-side, but guarded) replaces the existing row rather
+        than stacking a second one."""
+        if msg_id in self._rows:
+            self.remove_item(msg_id)
+        label = _neutralized_label(text)
+        row = Static(Content(f"⧗ {label}"))
+        self._rows[msg_id] = row
+        self.mount(row)
+        self.display = True
+
+    def remove_item(self, msg_id: str) -> None:
+        """Remove a queued item's row (the PROMOTE or, later, cancel exit).
+        No-op for an unknown ``msg_id``. Collapses the region back to hidden
+        once the last item is gone."""
+        row = self._rows.pop(msg_id, None)
+        if row is not None:
+            row.remove()
+        if not self._rows:
+            self.display = False
+
+    def rendered_texts(self) -> "list[str]":
+        """The currently-queued rows' rendered text, oldest first — the
+        public read a caller (a test, or a future consumer) uses to inspect
+        displayed content without reaching into private widget state."""
+        return [str(row.content) for row in self._rows.values()]
+
+    def is_empty(self) -> bool:
+        return not self._rows
+
+
+__all__ = ["SentQueue"]

--- a/src/reyn/interfaces/repl/read_model.py
+++ b/src/reyn/interfaces/repl/read_model.py
@@ -205,6 +205,18 @@ def project_remote_snapshot(values: "dict | None") -> dict:
         "visibility_items": [],
         "hook_items": [],
         "pipelines": [],
+        # #3300 P2b: the server-authoritative sent-queue state IS on the wire
+        # (state.py's ``_WIRE_KEYS`` / ``project_status``, folded in by P2a) —
+        # project it through unlike the session-local keys above, so
+        # ``ChatReadModel.snapshot()`` returns queue info uniformly for BOTH
+        # local (``RegistryReadModel``, straight off ``_snapshot()``) and
+        # remote clients (local ≡ remote by construction, the read-model's own
+        # governing rule — see the module docstring). This is what lets the
+        # Textual sent-queue widget seed its ``RemoteQueueView`` baseline from
+        # ONE seam (``read_model.snapshot()``) regardless of transport.
+        "queue": v.get("queue", []),
+        "turn_active": v.get("turn_active", False),
+        "queue_seq": v.get("queue_seq", 0),
     }
 
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -2855,8 +2855,19 @@ class Session:
         # propagates through any agent_request / agent_response generated in
         # response. Logged in history meta + events.jsonl for cross-agent trace.
         chain_id = _new_chain_id()
+        # #3300 P2b co-vet fix: computed ONCE and stored on the inbox payload
+        # too (additively — router/history readers only ever read
+        # payload["text"]/["chain_id"], never assert an exact key set), not
+        # just emitted on the event below. Without this, `meta` only ever
+        # reaches a LIVE delta subscriber — a client that instead seeds its
+        # queue view from the connect STATE_SNAPSHOT (`queued_user_messages()`
+        # below, #3300 P2a/P2b) would see attribution silently dropped for
+        # any item that was already queued at connect time (a remote peer's
+        # submit rendering as a plain, unattributed operator line once
+        # promoted — an ADR-0039 regression for the late-joiner path).
+        meta = _user_frame_meta(attribution)
         msg_id = await self._put_inbox(
-            "user", {"text": text, "chain_id": chain_id},
+            "user", {"text": text, "chain_id": chain_id, "meta": meta},
         )
         # #3300 P1 (C): the user-line echo is DRIVEN BY a `user_submitted`
         # chat-event, not a parallel `_put_outbox` write (removed — was a
@@ -2897,7 +2908,7 @@ class Session:
             chain_id=chain_id,
             msg_id=msg_id,
             seq=self._bump_queue_seq(),
-            meta=_user_frame_meta(attribution),
+            meta=meta,
         )
 
     async def submit_agent_request(
@@ -4772,16 +4783,24 @@ class Session:
         ``pipeline_result`` inbox items are internal wake triggers, never
         rendered as a queued user message).
 
-        Each item: ``{"msg_id": str, "chain_id": str | None, "text": str | None}``
-        — ``msg_id``/``chain_id`` are the correlation ids a client matches
-        against the ``user_submitted`` (enqueue) / ``turn_started`` (dispatch)
-        chat-event deltas to keep its queue model in sync.
+        Each item: ``{"msg_id": str, "chain_id": str | None, "text": str | None,
+        "meta": dict}`` — ``msg_id``/``chain_id`` are the correlation ids a
+        client matches against the ``user_submitted`` (enqueue) /
+        ``turn_started`` (dispatch) chat-event deltas to keep its queue model
+        in sync. ``meta`` (#3300 P2b co-vet fix) is the SAME ADR-0039
+        attribution ``submit_user_text`` stamps on the ``user_submitted``
+        event (``_user_frame_meta`` — now ALSO stored on the inbox payload,
+        see ``submit_user_text``) — carrying it here is what lets a client
+        that seeds its queue view from THIS snapshot (rather than only the
+        live delta) still render the correct ``[actor]`` prefix once the
+        item promotes to a flow entry.
         """
         return [
             {
                 "msg_id": item.get("id"),
                 "chain_id": item.get("payload", {}).get("chain_id"),
                 "text": item.get("payload", {}).get("text"),
+                "meta": item.get("payload", {}).get("meta") or {},
             }
             for item in self.journal.snapshot.inbox
             if item.get("kind") == "user"

--- a/tests/test_3300_p2b_sentqueue_render.py
+++ b/tests/test_3300_p2b_sentqueue_render.py
@@ -1,0 +1,385 @@
+"""#3300 P2b — render the sent-queue region + materialize/promote lifecycle.
+
+Phase 2b of the input-message-lifecycle arc (render-only per the architect's
+P2b scope comment): adds the sent-queue region to the Textual chat zone
+(between the #3299 intervention panel and the input row) and realizes the
+"upward conveyor" the owner's sent-queue exit contract (#3300 issue §6a)
+describes for the render side:
+
+- ``user_submitted`` -> MATERIALIZE: a submitted message appears in the
+  sent-queue region (dim, queued) — NOT immediately as a flow entry. This
+  REPLACES P1 C's "render the echo directly as a flow entry"
+  (``tests/test_user_submitted_render_3300.py`` retargets its own
+  TextualChatApp assertions to match).
+- ``turn_started(seq, chain_id)`` -> PROMOTE: the matching queued item is
+  removed from the sent-queue and appended as a flow entry (the user line) —
+  the dispatch promotion.
+- ``inbox_cancel`` removal is Phase 3 Y — not covered here.
+
+The client queue model is driven by ``RemoteQueueView`` (#3300 P2a, REUSED
+as-is — its seq-gated merge is not reinvented here), fed by the SAME
+``user_submitted``/``turn_started`` chat-events every surface already
+receives.
+
+Gates covered (per the architect's P2b scope comment):
+
+1. **materialize + promote** — the core lifecycle, end to end.
+2. **neutralize + rendered-content fidelity witness** (the concentrated
+   security gate — the #3302-class injection lesson applied here: a queued
+   item's text is LLM-adjacent/untrusted user-derived content reaching the
+   terminal). Non-vacuity manually verified (per repo discipline: temporarily
+   removing the ``_neutralized_label`` call in
+   ``SentQueue.show_item`` made this test's assertion fail with a raw ESC
+   byte present in the rendered content, then restored).
+3. **delta live update** — the region reflects enqueue/promote deltas as they
+   arrive; an automated strip test (monkeypatching the app's own delta
+   handler to a no-op) proves the positive assertion is not vacuous.
+4. **reconnect-reseed witness** (architect-required) — ``apply_snapshot``'s
+   ``_last_seq`` reseed on (re)connect protects against a stale,
+   post-disconnect delta resurrecting an already-superseded item; an
+   automated strip test (neutering the reseed) proves the positive assertion
+   is load-bearing.
+
+Real ``TextualChatApp`` + a real minimal ``ClientTransport`` throughout — no
+``unittest.mock``. Renders are observed via the mounted widgets' PUBLIC
+surface (``SentQueue.rendered_texts()`` / ``FlowView.entries``), never
+private state.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from textual_flowview import FlowView
+
+from reyn.interfaces.inline.textual_chat import TextualChatApp
+from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.transport.agui.state import RemoteQueueView
+from reyn.interfaces.transport.client_transport import ClientTransport
+from reyn.interfaces.transport.frames import EventFrame
+from reyn.runtime.outbox import OutboxMessage
+from reyn.schemas.models import Event
+
+_RAW_ESC_OSC = "\x1b[31mRED\x1b]0;pwn\x07"
+
+
+class QueueTransport(ClientTransport):
+    """A real, minimal :class:`ClientTransport` fed one frame at a time from
+    a queue (mirrors ``test_user_submitted_render_3300.py``'s helper) — lets
+    a test push an ``EventFrame`` and inspect ``TextualChatApp``'s retained
+    conversation model + mounted widgets afterward, stream staying open
+    throughout."""
+
+    def __init__(self) -> None:
+        self._queue: "asyncio.Queue[object]" = asyncio.Queue()
+
+    async def push_event(self, event: Event) -> None:
+        await self._queue.put(EventFrame(event))
+
+    def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def frames(self) -> "AsyncIterator[object]":
+        while True:
+            yield await self._queue.get()
+
+    async def submit_user_text(self, text: str) -> None:  # pragma: no cover
+        pass
+
+    async def answer_intervention_text(self, text: str) -> bool:  # pragma: no cover
+        return False
+
+    async def answer_intervention_choice(self, choice_id: str) -> bool:  # pragma: no cover
+        return False
+
+    def has_session(self) -> bool:
+        return True
+
+    def pending_intervention_head(self) -> "object | None":
+        return None
+
+    def put_display(self, msg: "OutboxMessage") -> None:  # pragma: no cover
+        pass
+
+    async def cancel_inflight(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def shutdown(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def _user_submitted(*, msg_id: str, chain_id: str, text: str, seq: int) -> Event:
+    return Event(
+        type="user_submitted",
+        data={"text": text, "chain_id": chain_id, "msg_id": msg_id, "seq": seq, "meta": {}},
+    )
+
+
+def _turn_started(*, chain_id: str, seq: int) -> Event:
+    return Event(type="turn_started", data={"kind": "user", "chain_id": chain_id, "seq": seq})
+
+
+def _flow_user_entries(app: TextualChatApp):
+    return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Materialize + promote (the core lifecycle)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_materialize_stages_in_sent_queue_not_flow() -> None:
+    """Tier 2b: a "user_submitted" delta materializes in the sent-queue
+    region — the item is NOT a flow entry yet."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="first message", seq=1)
+        )
+        await pilot.pause()
+
+        assert not _flow_user_entries(app), "materialize must not append a flow entry"
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.display is True
+        (row,) = sent_queue.rendered_texts()
+        assert "first message" in row
+
+
+@pytest.mark.asyncio
+async def test_turn_started_promotes_matching_item_to_flow_entry() -> None:
+    """Tier 2b: a "turn_started" delta whose chain_id matches a queued item
+    removes it from the sent-queue AND appends it as a flow entry — the
+    dispatch promotion, in the SAME step (no frame where it is both queued
+    and already in the flow, or neither)."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="dispatch me", seq=1)
+        )
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert not sent_queue.is_empty()
+
+        await transport.push_event(_turn_started(chain_id="c1", seq=2))
+        await pilot.pause()
+
+        assert sent_queue.is_empty(), "promoted item must leave the sent-queue"
+        (entry,) = _flow_user_entries(app)
+        assert entry.item.text == "dispatch me"
+
+
+@pytest.mark.asyncio
+async def test_turn_started_for_unrelated_chain_id_is_a_noop() -> None:
+    """Tier 2b: non-vacuity — a "turn_started" for a DIFFERENT chain_id
+    (e.g. an agent-driven turn; ``turn_started`` fires for every turn kind,
+    not only user ones) does not touch an unrelated queued item, proving the
+    promotion above is keyed by chain_id, not "any turn_started"."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="still queued", seq=1)
+        )
+        await pilot.pause()
+
+        await transport.push_event(_turn_started(chain_id="some-other-chain", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert "still queued" in sent_queue.rendered_texts()[0]
+        assert not _flow_user_entries(app)
+
+
+# ---------------------------------------------------------------------------
+# 2. ★Neutralize + rendered-content fidelity witness (#3302-class gate)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sent_queue_neutralizes_raw_esc_osc_injection() -> None:
+    """Tier 2b: ★security gate — a queued item's text is LLM-adjacent/
+    untrusted user-derived content reaching the terminal, the SAME injection
+    class as the #3302 panel-label bug. A raw ESC/OSC payload injected into a
+    queued item's text must NOT survive into the rendered/queried content.
+
+    Non-vacuity (manually verified per repo discipline): temporarily
+    removing the ``_neutralized_label(text)`` call in
+    ``SentQueue.show_item`` (substituting the bare ``text``) makes this
+    assertion fail — the raw ``\\x1b`` byte leaks into
+    ``sent_queue.rendered_texts()`` — then the call was restored. ESC is the
+    load-bearing byte: Textual's ``Content`` strips BEL/BS/VT/FF/CR itself
+    but never ESC, so the neutralize call is what carries this gate.
+    """
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_RAW_ESC_OSC, seq=1)
+        )
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        (row,) = sent_queue.rendered_texts()
+        assert "\x1b" not in row, "raw ESC byte leaked into the rendered sent-queue row"
+        assert "RED" in row  # the harmless literal remainder still renders
+
+
+@pytest.mark.asyncio
+async def test_promoted_flow_entry_also_neutralizes_raw_esc_osc_injection() -> None:
+    """Tier 2b: the SAME untrusted text, once PROMOTED to a flow entry, stays
+    neutralized there too — the promotion path re-neutralizes from the raw
+    item text (:func:`~reyn.interfaces.inline.textual_chat.presenter._neutralized_label`),
+    it does not just trust whatever the sent-queue row already rendered."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text=_RAW_ESC_OSC, seq=1)
+        )
+        await pilot.pause()
+        await transport.push_event(_turn_started(chain_id="c1", seq=2))
+        await pilot.pause()
+
+        (entry,) = _flow_user_entries(app)
+        assert "\x1b" not in entry.item.text
+        assert "RED" in entry.item.text
+
+
+# ---------------------------------------------------------------------------
+# 3. Delta live update (+ automated strip witness)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sent_queue_updates_live_as_deltas_arrive() -> None:
+    """Tier 2b: the sent-queue region tracks MULTIPLE items across a mixed
+    enqueue/dispatch sequence — item appears on ``user_submitted``, is
+    removed/promoted on ITS OWN ``turn_started``, and a still-undispatched
+    sibling stays visible throughout."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(_user_submitted(msg_id="m1", chain_id="c1", text="alpha", seq=1))
+        await transport.push_event(_user_submitted(msg_id="m2", chain_id="c2", text="beta", seq=2))
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert {"alpha", "beta"} <= {t.split(" ", 1)[-1] for t in sent_queue.rendered_texts()}
+
+        await transport.push_event(_turn_started(chain_id="c1", seq=3))
+        await pilot.pause()
+
+        # Variable-binding idiom (per test-audit policy) instead of a bare
+        # len(...) == N pin: exactly one row remains, and it is "beta" — not
+        # a fresh append, the SAME sibling that was already there.
+        (remaining,) = sent_queue.rendered_texts()
+        assert "beta" in remaining
+        assert "alpha" not in remaining
+        (entry,) = _flow_user_entries(app)
+        assert entry.item.text == "alpha"
+
+
+@pytest.mark.asyncio
+async def test_strip_delta_subscription_leaves_sent_queue_stale(monkeypatch) -> None:
+    """Tier 2b: non-vacuity — neutering the app's ``user_submitted`` delta
+    handler (the "drop the delta subscription" strip the architect's gate
+    names) leaves the sent-queue region STALE (never populated) despite a
+    real delta arriving, proving the positive test above is not vacuous."""
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport)
+    monkeypatch.setattr(
+        TextualChatApp, "_handle_user_submitted_event", lambda self, event: None,
+    )
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(
+            _user_submitted(msg_id="m1", chain_id="c1", text="should be stale", seq=1)
+        )
+        await pilot.pause()
+
+        sent_queue = app.query_one(SentQueue)
+        assert sent_queue.is_empty(), "stripped handler should leave the region stale"
+        assert not _flow_user_entries(app)
+
+
+# ---------------------------------------------------------------------------
+# 4. ★Reconnect-reseed witness (architect-required, #3300 P2b)
+# ---------------------------------------------------------------------------
+
+
+def test_reconnect_reseed_prevents_stale_delta_resurrection_after_reconnect() -> None:
+    """Tier 1: reconnect-reseed witness — ``RemoteQueueView.apply_snapshot``'s
+    ``_last_seq`` reseed on (re)connect protects against a stale,
+    post-disconnect delta resurrecting an item the reconnect snapshot already
+    supersedes.
+
+    Scenario: the client enqueues "m1" (seq=1), then DISCONNECTS. While
+    offline, the server dispatches m1 (seq=2), enqueues an unrelated m2
+    (seq=3), and dispatches m2 too (seq=4) — the client sees none of this
+    live. On RECONNECT, a fresh ``STATE_SNAPSHOT`` reflects the current
+    truth (both items long gone) and reseeds the gate to ``queue_seq=4``. A
+    STALE "user_submitted" for m2 (seq=3, from before the reconnect) then
+    gets redelivered — e.g. an SSE buffering/replay overlap at the moment of
+    reconnect — and the reseed must reject it.
+    """
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
+    view.apply_user_submitted(msg_id="m1", chain_id="c1", text="hi", seq=1)
+    assert [i["msg_id"] for i in view.queue()] == ["m1"]
+
+    # RECONNECT: reseeds the gate to the server's current truth.
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=4)
+    assert view.queue() == []
+
+    resurrected = view.apply_user_submitted(
+        msg_id="m2", chain_id="c2", text="ghost", seq=3,
+    )
+    assert resurrected is False, "reseed failed to protect against a stale post-disconnect delta"
+    assert view.queue() == [], "a stale delta must not resurrect an item the reconnect snapshot already superseded"
+
+
+def test_reconnect_reseed_witness_strip_without_reseed_resurrects(monkeypatch) -> None:
+    """Tier 1: non-vacuity — neutering ``apply_snapshot`` so it never
+    reseeds ``_last_seq`` from ``queue_seq`` (only replaces
+    ``items``/``turn_active``, the strip the architect's gate names) makes
+    the EXACT SAME stale delta from the test above wrongly resurrect the
+    already-dispatched item, proving the reseed line is load-bearing."""
+
+    def _broken_apply_snapshot(self, *, queue, turn_active, queue_seq):
+        self.items = {
+            item["msg_id"]: dict(item) for item in queue if item.get("msg_id")
+        }
+        self.turn_active = turn_active
+        # BUG under test: `self._last_seq` is never reseeded from `queue_seq`.
+
+    monkeypatch.setattr(RemoteQueueView, "apply_snapshot", _broken_apply_snapshot)
+
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
+    view.apply_user_submitted(msg_id="m1", chain_id="c1", text="hi", seq=1)
+
+    # Broken reconnect: queue_seq=4 arrives but `_last_seq` stays at 1.
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=4)
+
+    resurrected = view.apply_user_submitted(
+        msg_id="m2", chain_id="c2", text="ghost", seq=3,
+    )
+    assert resurrected is True, (
+        "the broken (unreseeded) gate should incorrectly accept this stale delta"
+    )
+    assert [i["msg_id"] for i in view.queue()] == ["m2"], (
+        "ghost item resurrected — proves the reseed line matters"
+    )

--- a/tests/test_3300_p2b_sentqueue_render.py
+++ b/tests/test_3300_p2b_sentqueue_render.py
@@ -48,6 +48,7 @@ private state.
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from typing import AsyncIterator
 
 import pytest
@@ -55,6 +56,7 @@ from textual_flowview import FlowView
 
 from reyn.interfaces.inline.textual_chat import TextualChatApp
 from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+from reyn.interfaces.repl.read_model import ChatReadModel
 from reyn.interfaces.transport.agui.state import RemoteQueueView
 from reyn.interfaces.transport.client_transport import ClientTransport
 from reyn.interfaces.transport.frames import EventFrame
@@ -125,6 +127,45 @@ def _turn_started(*, chain_id: str, seq: int) -> Event:
 
 def _flow_user_entries(app: TextualChatApp):
     return [e for e in app.query_one(FlowView).entries if e.item.kind == "user"]
+
+
+class _SnapshotSeededReadModel(ChatReadModel):
+    """A real, minimal :class:`ChatReadModel` whose :meth:`snapshot` returns a
+    FIXED status dict carrying one already-queued, ATTRIBUTED item — standing
+    in for "this client connected while a peer's submit was already sitting
+    in the server-authoritative queue" (the connect ``STATE_SNAPSHOT``/
+    ``queued_user_messages()`` path, #3300 P2a/P2b), without needing a real
+    remote transport. Every other accessor degrades to the same graceful
+    empty/None ``RemoteReadModel`` uses — this read-model's only job is the
+    ``queue``/``turn_active``/``queue_seq`` snapshot shape."""
+
+    def __init__(self, queue_item: dict) -> None:
+        self._queue_item = queue_item
+
+    def snapshot(self, config=None):
+        return {
+            "queue": [self._queue_item], "turn_active": False, "queue_seq": 1,
+        }
+
+    def intervention_head(self):
+        return None
+
+    def pending_command_ui(self):
+        return None
+
+    def clear_pending_command_ui(self) -> None:
+        return None
+
+    @property
+    def has_command_ui_region(self) -> bool:
+        return False
+
+    @property
+    def history_path(self) -> Path:
+        return Path("/dev/null")
+
+    def conversation_history(self, *, limit: "int | None" = None):
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -383,3 +424,100 @@ def test_reconnect_reseed_witness_strip_without_reseed_resurrects(monkeypatch) -
     assert [i["msg_id"] for i in view.queue()] == ["m2"], (
         "ghost item resurrected — proves the reseed line matters"
     )
+
+
+# ---------------------------------------------------------------------------
+# 5. ★Snapshot-seeded attribution (co-vet finding) — ADR-0039 parity for the
+#    late-joiner path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_snapshot_seeded_item_keeps_attribution_after_promotion() -> None:
+    """Tier 2b: a client that connects while a PEER's attributed submit is
+    already sitting in the server-authoritative queue (the connect
+    ``STATE_SNAPSHOT`` / ``queued_user_messages()`` path, not a live delta)
+    must still render the correct ``[actor]`` attribution once that item
+    promotes to a flow entry — the SAME ADR-0039 provenance a live
+    ``user_submitted`` delta already carries (``meta["actor"]``,
+    ``renderer._meta_prefix``'s vocabulary). Regression coverage for the
+    co-vet finding: ``queued_user_messages()`` (session.py) now projects
+    ``meta`` alongside msg_id/chain_id/text, and the sent-queue's snapshot
+    seed (``TextualChatApp._seed_queue_view``) carries it into the SAME
+    ``_queue_item_meta`` side table the live delta path populates."""
+    read_model = _SnapshotSeededReadModel(
+        {
+            "msg_id": "m1", "chain_id": "c1", "text": "peer's queued line",
+            "meta": {"actor": "alice", "auth_user_id": "alice"},
+        }
+    )
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        # The queue view is seeded on the FIRST frame the pump processes
+        # (:meth:`TextualChatApp._seed_queue_view`) — a harmless, unhandled
+        # event type triggers that seed without mutating any state, so the
+        # snapshot-seeded item's pre-promotion visibility can be observed
+        # before the (separate) turn_started frame promotes it.
+        await transport.push_event(Event(type="__noop__", data={}))
+        await pilot.pause()
+        sent_queue = app.query_one(SentQueue)
+        assert "peer's queued line" in sent_queue.rendered_texts()[0]
+
+        await transport.push_event(_turn_started(chain_id="c1", seq=2))
+        await pilot.pause()
+
+        (entry,) = _flow_user_entries(app)
+        assert entry.item.text == "peer's queued line"
+        assert entry.item.meta.get("actor") == "alice", (
+            "a snapshot-seeded item lost its ADR-0039 attribution on "
+            "promotion — it must render like a delta-path item, not a "
+            "plain unattributed operator line"
+        )
+
+
+@pytest.mark.asyncio
+async def test_strip_snapshot_meta_carry_loses_attribution(monkeypatch) -> None:
+    """Tier 2b: non-vacuity — neutering the snapshot-seed's meta-carry (the
+    ``self._queue_item_meta[msg_id] = dict(item.get("meta") or {})`` line in
+    ``_seed_queue_view``, patched here to drop it) reproduces the co-vet
+    finding: the promoted item's meta is empty and the ``[actor]``
+    attribution is lost, proving the positive test above is not vacuous."""
+    from reyn.interfaces.inline.textual_chat import app as app_module
+
+    def _seed_without_meta_carry(self) -> None:
+        snap = self._snapshot() or {}
+        self._queue_view.apply_snapshot(
+            queue=snap.get("queue", []),
+            turn_active=snap.get("turn_active", False),
+            queue_seq=snap.get("queue_seq", 0),
+        )
+        for item in self._queue_view.queue():
+            msg_id = item.get("msg_id")
+            if msg_id:
+                self._sent_queue.show_item(msg_id, str(item.get("text", "")))
+                # BUG under test: the meta-carry line is dropped.
+
+    monkeypatch.setattr(
+        app_module.TextualChatApp, "_seed_queue_view", _seed_without_meta_carry,
+    )
+
+    read_model = _SnapshotSeededReadModel(
+        {
+            "msg_id": "m1", "chain_id": "c1", "text": "peer's queued line",
+            "meta": {"actor": "alice", "auth_user_id": "alice"},
+        }
+    )
+    transport = QueueTransport()
+    app = TextualChatApp(transport=transport, read_model=read_model)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        await transport.push_event(_turn_started(chain_id="c1", seq=2))
+        await pilot.pause()
+
+        (entry,) = _flow_user_entries(app)
+        assert entry.item.meta.get("actor") is None, (
+            "the broken (meta-carry-stripped) seed should reproduce the "
+            "misattribution — an empty meta on the promoted entry"
+        )

--- a/tests/test_user_submitted_render_3300.py
+++ b/tests/test_user_submitted_render_3300.py
@@ -12,9 +12,14 @@ time — this file proves that per surface:
 - ``InlineChatRenderer.on_chat_event`` (the ``chat.render_mode: plain``-on-a-
   TTY fallback — reachable only when the Textual app is bypassed).
 - ``TextualChatApp._pump_frames`` (the default interactive-TTY surface,
-  ``interfaces/inline/textual_chat/app.py``) — appends the echo straight to
-  the retained conversation model via the SAME
-  ``user_submitted_display_message`` seam.
+  ``interfaces/inline/textual_chat/app.py``) — #3300 P2b REPLACES the direct-
+  to-flow append this file originally pinned with the sent-queue "upward
+  conveyor": a ``user_submitted`` event now MATERIALIZES in the sent-queue
+  region (not the flow) and only PROMOTES to a flow entry on a matching
+  ``turn_started``. The two TextualChatApp tests below are retargeted to that
+  lifecycle (mirrors how #3299 P1's test file retargeted the #3273 chip tests
+  to the new panel path); the full materialize/promote/neutralize/live-update
+  gate suite lives in ``tests/test_3300_p2b_sentqueue_render.py``.
 
 Also covers the cross-cutting invariants the design pass called out:
 ordering (echo precedes the agent's turn) and multi-client (every attached
@@ -363,43 +368,36 @@ async def test_multi_client_each_subscriber_gets_its_own_echo_no_double_render(
 
 
 @pytest.mark.asyncio
-async def test_textual_chat_app_renders_user_submitted_event() -> None:
-    """Tier 2b: TextualChatApp._pump_frames appends a "user" entry to the
-    retained conversation model from a "user_submitted" EVENT frame — the
-    Textual surface's replacement for the removed outbox echo. In Phase C
-    this is a normal flow entry (the sent-queue staging is Phase B)."""
+async def test_textual_chat_app_materializes_user_submitted_in_sent_queue() -> None:
+    """Tier 2b: #3300 P2b — a "user_submitted" EVENT frame MATERIALIZES in the
+    sent-queue region, NOT as a flow entry (that direct-to-flow behavior was
+    P1 C's; P2b replaces it with the sent-queue "upward conveyor" — see
+    ``tests/test_3300_p2b_sentqueue_render.py`` for the full materialize/
+    promote/neutralize/live-update gate suite)."""
+    from reyn.interfaces.inline.textual_chat.sent_queue import SentQueue
+
     transport = QueueTransport()
     app = TextualChatApp(transport=transport)
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await transport.push_event(
-            Event(type="user_submitted", data={"text": "hi from textual", "meta": {}})
+            Event(
+                type="user_submitted",
+                data={
+                    "text": "hi from textual", "meta": {},
+                    "msg_id": "m1", "chain_id": "c1", "seq": 1,
+                },
+            )
         )
         await pilot.pause()
 
         entries = app.query_one(FlowView).entries
-        (entry,) = [e for e in entries if e.item.kind == "user"]
-        assert entry.item.text == "hi from textual"
-
-
-@pytest.mark.asyncio
-async def test_textual_chat_app_neutralizes_at_render() -> None:
-    """Tier 2b: a raw ESC/control sequence submitted via the event does not
-    reach TextualChatApp's retained model — same neutralize-at-display seam
-    every surface calls (``user_submitted_display_message``)."""
-    transport = QueueTransport()
-    app = TextualChatApp(transport=transport)
-    async with app.run_test(size=(100, 30)) as pilot:
-        await pilot.pause()
-        await transport.push_event(
-            Event(type="user_submitted", data={"text": _RAW_ESC, "meta": {}})
+        assert not [e for e in entries if e.item.kind == "user"], (
+            "a bare user_submitted must NOT append a flow entry (P1 C's "
+            "behavior) — it stages in the sent-queue until dispatched"
         )
-        await pilot.pause()
-
-        entries = app.query_one(FlowView).entries
-        (entry,) = [e for e in entries if e.item.kind == "user"]
-        assert "\x1b" not in entry.item.text
-        assert "danger" in entry.item.text
+        sent_queue = app.query_one(SentQueue)
+        assert "hi from textual" in sent_queue.rendered_texts()[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**[per-PR-coder]** — Phase 2b (render-only) of the input-message-lifecycle arc (part of #3300). Renders P2a's server-authoritative sent-queue state and realizes the render side of the owner-ratified sent-queue exit contract (issue §6a).

## (a) Region placement + the upward conveyor
The sent-queue region sits between the #3299 intervention panel and the input row: `conversation / intervention panel / sent-queue / input` (`app.py::compose`).

- `user_submitted` → **MATERIALIZE**: the submitted message appears in the sent-queue region (dim, queued) — this **REPLACES P1 C's** "render the echo directly as a flow entry" behavior. `tests/test_user_submitted_render_3300.py`'s two `TextualChatApp` assertions are retargeted to this new lifecycle (mirrors how #3299 P1 retargeted the #3273 chip tests).
- `turn_started(chain_id)` → **PROMOTE**: the matching queued item is removed from the sent-queue and appended as a flow entry (the user line), in the same step — never a frame where it's both queued and in the flow, or neither.
- `inbox_cancel` removal stays Phase 3 Y — not built here.

## (b) ★Neutralize + rendered-content fidelity witness (#3302-class gate)
A queued item's text is LLM-adjacent/untrusted user-derived content reaching the terminal — the same injection class as the #3302 panel-label bug. `SentQueue.show_item` neutralizes at this display boundary (`presenter._neutralized_label`, the same `core/present/guard.get_neutralizer("terminal")` seam) and wraps the result in a `Content(...)` literal, never a bare `str`.

Witnessed by `test_sent_queue_neutralizes_raw_esc_osc_injection` (raw ESC/OSC payload → asserts no `\x1b` in the rendered row). **Non-vacuity manually verified**: temporarily replaced `_neutralized_label(text)` with the bare `text` in `SentQueue.show_item`, re-ran the test → RED (`AssertionError: raw ESC byte leaked...`), then restored. A second test (`test_promoted_flow_entry_also_neutralizes_raw_esc_osc_injection`) covers the promoted flow-entry path too.

## (c) Delta live update (+ automated strip witness)
`test_sent_queue_updates_live_as_deltas_arrive` drives a mixed enqueue/dispatch sequence across two items, asserting the region tracks each independently. `test_strip_delta_subscription_leaves_sent_queue_stale` monkeypatches the app's `_handle_user_submitted_event` to a no-op and asserts the region goes stale — an automated (not just prose) non-vacuity witness.

## (d) ★Reconnect-reseed witness (architect-required)
Per the architect's P2b scope ruling, no new reconnect logic is added (the emitter already snapshot-firsts on (re)connect, A4) — only the witness. `test_reconnect_reseed_prevents_stale_delta_resurrection_after_reconnect` models a disconnect/reconnect where the client missed several deltas, then a stale post-disconnect delta arrives — the `apply_snapshot` reseed rejects it. `test_reconnect_reseed_witness_strip_without_reseed_resurrects` monkeypatches `apply_snapshot` to skip the `_last_seq` reseed and proves the SAME stale delta wrongly resurrects the item without it.

## (e) Seq-gate reuse, not reinvented
The client queue model is `RemoteQueueView` (#3300 P2a) used exactly as shipped — no changes to its seq-gate logic. `project_remote_snapshot` (`read_model.py`) is extended to project `queue`/`turn_active`/`queue_seq` (previously dropped for the status-bar shape), completing local≡remote parity for this data so `ChatReadModel.snapshot()` seeds the queue view identically for either transport.

## (f) Gates
- `ruff check src tests` — green.
- `python scripts/test_tier_audit.py --strict tests/test_3300_p2b_sentqueue_render.py tests/test_user_submitted_render_3300.py` — 20/20 OK, 0 Tier-4 violations.
- `uv run python -m pytest --timeout=120 -q -n auto` (foreground, isolated run) — **9162 passed, 36 skipped, 0 failed** (5m19s).
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan
- [x] `ruff check src tests`
- [x] `python scripts/test_tier_audit.py --strict` on changed test files
- [x] `uv run python -m pytest --timeout=120` full suite, 0 failures
- [x] `python scripts/verify_module_docstrings.py` on changed src files
- [x] Manually verified the neutralize strip → RED → restore (documented in the test docstring)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>