### PR TITLE
feat(runtime): cancel-by-id for queued user messages (WAL tombstone + snapshot-prune) — #3300 P3 Y-server

### DIFF
--- a/docs/reference/runtime/agui-transport.ja.md
+++ b/docs/reference/runtime/agui-transport.ja.md
@@ -25,6 +25,15 @@ Reyn のチャットクライアントはストリームを消費する UI で�
     下記「Human-in-the-loop answering」参照)。
   - `{"type": "cancel_inflight"}` — in-flight なターンを協調的にキャンセルする(Ctrl-C
     seam)。
+  - `{"type": "cancel_queued", "msg_id": "..."}` — まだ dispatch されていない(未実行の)
+    inbox メッセージを id 指定でキャンセルする(#3300 P3)。上記の `cancel_inflight` とは
+    異なる意図である — こちらは「まだ turn が始まっていない特定の queued item」を対象と
+    し、現在実行中の turn は対象にしない。サーバー側の意味論(`Session.cancel_queued`):
+    queued の場合 → 除去(WAL `inbox_cancel` tombstone + 同期的な snapshot-prune の後、
+    `inbox_cancel` chat-event delta を emit。下記「STATE_* — ステータス read-model」と
+    `reyn.event.inbox_cancel` を参照)。既に dispatch 済みの場合 → no-op(`cancel_inflight`
+    へのエスカレーションは行わない)。冪等(同じ id への2回目のキャンセルは no-op — at-most-once
+    の再送に対して安全)。
   - `{"type": "heartbeat"}` — liveness の keepalive。
 
   server がモデル化していない入力 type は**グレースフルな no-op**(`200` の ack)であり、
@@ -277,6 +286,16 @@ WaitingOn ラベル)は**read-model**であり、ファイルミラーではな�
 snapshot から正しい queue + turn-active 状態を得る。P2a はこの状態の publish のみで、
 sent-queue widget としての描画は P2b。
 
+item が `queue` から抜けるのは、同じ snapshot+delta channel 上の互いに排他な2つの
+granular chat-event delta のいずれかを経由する — `turn_started`(dispatch された。下記
+「Working-indicator path」参照)、または `inbox_cancel`(上記の `cancel_queued` client
+message で id 指定キャンセルされた。#3300 P3)。server 自身の atomic な
+queued/dispatched 判定が、ある item についてこの2つのうち正確に一方のみが必ず発火する
+ことを保証する(両方が発火することはない)。`inbox_cancel` は `msg_id` と `seq`(
+`user_submitted`/`turn_started` と同じ order-race-gate token — 下記
+`reyn.event.inbox_cancel` を参照)を運ぶ。granular delta をマージする client は
+(`turn_started` が `chain_id` でマッチするのとは異なり)`msg_id` で item を除去する。
+
 client は snapshot から自身のステータスビューを seed し、各 delta をマージするため、
 remote のステータスパネルは常に server の値を反映する。
 
@@ -337,6 +356,7 @@ display 行のテキストである。
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | ユーザーが intervention に回答した              |
 | `reyn.event.user_submitted`          | ユーザーがターンを送信した(#3300 P1 C)— RAW text + chain_id + msg_id + seq + meta を運ぶ。各 surface がそれぞれの render 境界で neutralize する。`msg_id`/`seq` は #3300 P2a の sent-queue correlation id + order-race-gate token |
+| `reyn.event.inbox_cancel`            | 未 dispatch の queued user メッセージが id 指定でキャンセルされた(#3300 P3、`cancel_queued` client message 経由)— `msg_id` と `seq` を運ぶ。サーバー権威の sent-queue 除去シグナルであり(client-local な「キャンセル成功」応答ではない)、同じ `msg_id` について `turn_started` と排他である |
 
 ### `reyn.intervention.<kind>`
 

--- a/docs/reference/runtime/agui-transport.md
+++ b/docs/reference/runtime/agui-transport.md
@@ -24,6 +24,16 @@ A2A; tools are MCP; observability export is OTEL. Those are separate surfaces.)
     round-trip; see "Human-in-the-loop answering" below).
   - `{"type": "cancel_inflight"}` — cooperatively cancel the in-flight turn (the
     Ctrl-C seam).
+  - `{"type": "cancel_queued", "msg_id": "..."}` — cancel-by-id an UNDISPATCHED
+    (queued, not-yet-running) inbox message (#3300 P3). A DIFFERENT intent from
+    `cancel_inflight` above: this targets one specific queued item that has not
+    started a turn yet, never the currently-running turn. Server-side semantics
+    (`Session.cancel_queued`): queued → removed (WAL `inbox_cancel` tombstone +
+    synchronous snapshot-prune, then an `inbox_cancel` chat-event delta, see
+    "STATE_* — the status read-model" and `reyn.event.inbox_cancel` below);
+    already dispatched → a no-op (never escalated to `cancel_inflight`);
+    idempotent (a second cancel of the same id is a no-op, safe for an
+    at-most-once retry).
   - `{"type": "heartbeat"}` — a liveness keepalive.
 
   An input type the server does not model is a **graceful no-op** (a `200` ack),
@@ -289,6 +299,16 @@ chat-event that dispatched the in-flight item) still gets the correct queue +
 turn-active state from the snapshot, not a partial event-derived guess. P2a
 publishes this state only — rendering it as a sent-queue widget is P2b.
 
+An item leaves `queue` via one of two mutually-exclusive granular chat-event
+deltas on the same snapshot+delta channel — `turn_started` (dispatched; see
+"Working-indicator path" below) or `inbox_cancel` (cancelled by id via the
+`cancel_queued` client message above, #3300 P3): the server's own atomic
+queued/dispatched judgement guarantees exactly one of the two ever fires for a
+given item, never both. `inbox_cancel` carries `msg_id` + `seq` (the same
+order-race-gate token `user_submitted`/`turn_started` carry — see
+`reyn.event.inbox_cancel` below); a client merging the granular deltas removes
+the item by `msg_id` (unlike `turn_started`, which matches by `chain_id`).
+
 The client seeds its status view from the snapshot and merges each delta, so the
 remote status panel always reflects the server's values.
 
@@ -362,6 +382,7 @@ is the event's data object.
 |--------------------------------------|--------------------------------------------------|
 | `reyn.event.user_answered_intervention` | the user answered an intervention             |
 | `reyn.event.user_submitted`          | a user turn was submitted (#3300 P1 C) — RAW text + chain_id + msg_id + seq + meta; each surface neutralizes at its render boundary. `msg_id`/`seq` are the #3300 P2a sent-queue correlation id + order-race-gate token |
+| `reyn.event.inbox_cancel`            | an UNDISPATCHED queued user message was cancelled by id (#3300 P3, via the `cancel_queued` client message) — carries `msg_id` + `seq`; the server-authoritative sent-queue removal signal (never a client-local "cancel succeeded" response), exclusive with `turn_started` for the same `msg_id` |
 
 ### `reyn.intervention.<kind>`
 

--- a/src/reyn/core/events/agent_snapshot.py
+++ b/src/reyn/core/events/agent_snapshot.py
@@ -254,7 +254,12 @@ class AgentSnapshot:
                 "kind": event["msg_kind"],
                 "payload": event.get("payload", {}),
             })
-        elif kind == "inbox_consume":
+        elif kind in ("inbox_consume", "inbox_cancel"):
+            # #3300 P3 Y-server: `inbox_cancel` is symmetric with
+            # `inbox_consume` for replay purposes (both remove the entry) —
+            # the DISTINCTION between dispatched vs cancelled matters to the
+            # cancel-by-id semantics at record time (session.py), not to
+            # snapshot reconstruction, which only needs "this id is gone".
             msg_id = event.get("msg_id")
             self.inbox = [m for m in self.inbox if m.get("id") != msg_id]
         elif kind == "chain_register":

--- a/src/reyn/core/events/state_log.py
+++ b/src/reyn/core/events/state_log.py
@@ -9,7 +9,9 @@ Event kinds recorded (state-mutating only; processing internals
 like LLM calls live in the audit log under `.reyn/events/`):
 
   inbox_put           — message put on agent X's inbox
-  inbox_consume       — message removed from agent X's inbox
+  inbox_consume       — message removed from agent X's inbox (dispatched)
+  inbox_cancel        — message removed from agent X's inbox (cancelled,
+                        never dispatched — #3300 P3 Y-server)
   chain_register      — new pending_chain created on agent X
   chain_update        — pending_chain's waiting_on shrunk
   chain_resolve       — pending_chain completed
@@ -53,6 +55,11 @@ WAL_EVENT_KINDS = (
     # Existing PR21 — inbox and chain lifecycle
     "inbox_put",
     "inbox_consume",
+    # NEW (#3300 P3 Y-server) — cancel-by-id tombstone for an UNDISPATCHED
+    # inbox item. Symmetric with `inbox_consume` (both remove an item from
+    # the snapshot inbox) but distinguishes WHY: cancelled (never ran) vs
+    # dispatched (ran). See `SnapshotJournal.cancel_inbox`.
+    "inbox_cancel",
     "chain_register",
     "chain_update",
     "chain_resolve",

--- a/src/reyn/interfaces/transport/agui/client.py
+++ b/src/reyn/interfaces/transport/agui/client.py
@@ -207,6 +207,15 @@ class AgUiTransport(ClientTransport):
     async def cancel_inflight(self) -> None:
         await self._send({"type": "cancel_inflight"})
 
+    async def cancel_queued(self, msg_id: str) -> bool:
+        # #3300 P3 (Y-server) remote parity: POST the cancel-by-id op; the
+        # server's response is HTTP-accepted (2xx), not the cancel's own
+        # queued/no-op result — the client observes the actual outcome via
+        # the server-authoritative `inbox_cancel` chat-event delta (never a
+        # client-local "cancel succeeded" inference), same as every other
+        # queue-affecting mutation on this transport.
+        return bool(await self._send({"type": "cancel_queued", "msg_id": msg_id}))
+
     async def shutdown(self) -> None:
         # Client-LOCAL disconnect only (A3). A client can never tear down the
         # single-writer server — no shutdown is sent over the wire (closing the

--- a/src/reyn/interfaces/transport/agui/endpoint.py
+++ b/src/reyn/interfaces/transport/agui/endpoint.py
@@ -461,6 +461,17 @@ async def agui_submit(request: Request, agent_name: str):
         cancel_fn = getattr(session, "cancel_inflight", None)
         if callable(cancel_fn):
             await cancel_fn()
+    elif ptype == "cancel_queued":
+        # #3300 P3 (Y-server): cancel-by-id for an UNDISPATCHED queued
+        # message — a DISTINCT op from `cancel_inflight` above (targets the
+        # inbox queue, not the running turn). The server's own atomic
+        # queued/dispatched judgement (`Session.cancel_queued`) decides
+        # queued->removed vs already-dispatched->no-op; idempotent, so a
+        # retry (e.g. after a dropped response) is always safe.
+        msg_id = payload.get("msg_id")
+        cancel_queued_fn = getattr(session, "cancel_queued", None)
+        if callable(cancel_queued_fn) and msg_id:
+            await cancel_queued_fn(msg_id)
     return JSONResponse({"status": "ok"})
 
 

--- a/src/reyn/interfaces/transport/agui/profile.py
+++ b/src/reyn/interfaces/transport/agui/profile.py
@@ -138,6 +138,13 @@ CUSTOM_PROFILE: dict[str, CustomName] = _entries(
         "(replaces the earlier kind=\"user\" outbox-echo write); msg_id/seq "
         "are the #3300 P2a sent-queue correlation id + order-race-gate token",
     ),
+    CustomName(
+        "reyn.event.inbox_cancel", EVENT_NS, "the event data object",
+        "an UNDISPATCHED queued user message was cancelled by id (#3300 P3 "
+        "Y-server) — carries msg_id + seq; the server-authoritative sent-queue "
+        "removal signal, exclusive with turn_started for the same msg_id "
+        "(never a client-local cancel-success response)",
+    ),
 )
 
 

--- a/src/reyn/interfaces/transport/agui/state.py
+++ b/src/reyn/interfaces/transport/agui/state.py
@@ -199,6 +199,22 @@ class RemoteQueueView:
         self._last_seq = seq
         return True
 
+    def apply_inbox_cancel(self, *, msg_id: str, seq: int) -> bool:
+        """Apply a cancel-by-id delta (#3300 P3 Y-server) — removes the
+        queued item BY ITS OWN msg_id (unlike ``apply_turn_started``, which
+        matches by ``chain_id``: a cancel targets one specific queued item,
+        never a whole chain). Returns ``False`` (no-op) if the seq gate
+        rejects it as already reflected by a prior snapshot/delta — same
+        order-race protocol as ``apply_user_submitted``/``apply_turn_started``
+        (design-pass pin D): exclusive with a ``turn_started`` for the same
+        item (the server guarantees only one of the two ever fires,
+        issue #3300 owner addendum §6a), so no double-removal ambiguity."""
+        if seq <= self._last_seq:
+            return False
+        self.items.pop(msg_id, None)
+        self._last_seq = seq
+        return True
+
     def apply_turn_active(self, turn_active: bool) -> None:
         """Apply a plain turn-active flip (e.g. from a ``turn_settled``
         chat-event or a ``STATE_DELTA``'s ``turn_active`` key) — not

--- a/src/reyn/interfaces/transport/client_transport.py
+++ b/src/reyn/interfaces/transport/client_transport.py
@@ -77,6 +77,24 @@ class ClientTransport(ABC):
     async def cancel_inflight(self) -> None:
         """Cooperatively cancel the in-flight turn (ctrl-c seam)."""
 
+    async def cancel_queued(self, msg_id: str) -> bool:
+        """Cancel-by-id an UNDISPATCHED (queued) user message (#3300 P3
+        Y-server) — a DIFFERENT intent from :meth:`cancel_inflight` (which
+        targets the currently RUNNING turn), never escalated between the
+        two. Returns True iff the server actually removed the item (queued);
+        a no-op (already dispatched, or unknown id) returns False.
+
+        NOT abstract (unlike the other send-seam methods above): this method
+        was added after several narrow-purpose ``ClientTransport`` stubs
+        already existed across the test suite (pre-dating #3300 P3), and
+        making it abstract would force every one of them to implement a
+        method irrelevant to what they test. The default no-op preserves
+        their behavior unchanged; both production transports
+        (``InProcessTransport``, ``AgUiTransport``) override it with the
+        real op.
+        """
+        return False
+
     @abstractmethod
     async def shutdown(self) -> None:
         """Tear the session (and its registry) down — the /quit / EOF seam."""

--- a/src/reyn/interfaces/transport/frames.py
+++ b/src/reyn/interfaces/transport/frames.py
@@ -67,6 +67,14 @@ _TURN_AND_ANSWER_EVENTS = frozenset(
         # #3300 P2a: also carries `seq` (the sent-queue order-race-gate
         # token, see ``Session._bump_queue_seq``).
         "user_submitted",
+        # #3300 P3 (Y-server): cancel-by-id for an UNDISPATCHED (queued) user
+        # message — the server-authoritative removal signal (never a
+        # client-local "cancel succeeded" response) a client's sent-queue
+        # rendering applies, exclusive with `turn_started` for the same
+        # msg_id (owner addendum §6a: an item leaves the sent queue via
+        # exactly one of these two deltas). Carries `msg_id` + `seq` (the
+        # same order-race-gate token) — see ``Session.cancel_queued``.
+        "inbox_cancel",
     }
 )
 

--- a/src/reyn/interfaces/transport/in_process.py
+++ b/src/reyn/interfaces/transport/in_process.py
@@ -159,6 +159,15 @@ class InProcessTransport(ClientTransport):
         if callable(cancel_fn):
             await cancel_fn()
 
+    async def cancel_queued(self, msg_id: str) -> bool:
+        s = self._attached()
+        if s is None:
+            return False
+        cancel_fn = getattr(s, "cancel_queued", None)
+        if callable(cancel_fn):
+            return bool(await cancel_fn(msg_id))
+        return False
+
     async def shutdown(self) -> None:
         await self._registry.shutdown()
 

--- a/src/reyn/runtime/services/snapshot_journal.py
+++ b/src/reyn/runtime/services/snapshot_journal.py
@@ -211,6 +211,56 @@ class SnapshotJournal:
         ]
         self.save_nowait()
 
+    async def cancel_inbox(self, *, msg_id: str) -> bool:
+        """Cancel-by-id (#3300 P3 Y-server): append ``inbox_cancel`` to WAL and
+        prune the snapshot entry, IFF ``msg_id`` is still present (undispatched).
+
+        Returns ``True`` iff ``msg_id`` was found in ``snapshot.inbox`` and
+        removed (the queued→cancelled transition actually happened); ``False``
+        when absent — already dispatched (``consume_inbox`` already pruned it),
+        already cancelled by a prior call (idempotent), or unknown. The caller
+        (``Session.cancel_queued``) uses this boolean to decide whether to also
+        emit the ``inbox_cancel`` chat-event delta and record the msg_id for
+        skip-at-consume.
+
+        ★§1 (CLAUDE.md recovery-feature gate / architect design-pass contract
+        correction): the inbox is snapshot-backed (see module docstring +
+        ``append_inbox``/``consume_inbox`` above), NOT purely WAL-event-derived
+        — ``restore_all`` loads ``snapshot.json`` and replays only the WAL TAIL
+        above its ``applied_seq``. A WAL ``inbox_cancel`` tombstone ALONE would
+        therefore NOT survive a truncation below this item's ``inbox_put``
+        event: replay would never see either event, and a snapshot that still
+        held the (never-pruned) item would resurrect it. Pruning
+        ``self._snapshot.inbox`` HERE, synchronously, at cancel-record time —
+        exactly mirroring ``consume_inbox``'s shape — closes that window
+        unconditionally (see ``tests/test_3300_p3_cancel_by_id.py``'s
+        truncate-falsify gate).
+
+        ★F (no-await critical section, #3300 P3 design-pass pin F): this
+        method is ``async def`` for call-site symmetry with ``append_inbox``/
+        ``consume_inbox`` but is internally FULLY SYNCHRONOUS — the presence
+        check, the WAL tombstone (``_wal_append_nowait``, fire-and-forget, no
+        internal await), the snapshot prune (a plain list comprehension), and
+        ``save_nowait`` (also fire-and-forget) never suspend. Awaiting this
+        coroutine therefore never yields control back to the event loop, so no
+        other task can interleave between the presence check and the commit —
+        this is what makes ``Session.cancel_queued``'s "queued XOR dispatched"
+        decision atomic (see that method's docstring for the full contract).
+        """
+        if self._state_log is None or msg_id is None:
+            return False
+        found = any(m.get("id") == msg_id for m in self._snapshot.inbox)
+        if not found:
+            return False
+        self._wal_append_nowait(
+            "inbox_cancel", agent=self._agent_name, msg_id=msg_id,
+        )
+        self._snapshot.inbox = [
+            m for m in self._snapshot.inbox if m.get("id") != msg_id
+        ]
+        self.save_nowait()
+        return True
+
     async def record_chain_register(self, *, chain_id: str, fields: dict) -> None:
         """Append ``chain_register`` to WAL and create the pending_chains entry.
 

--- a/src/reyn/runtime/session.py
+++ b/src/reyn/runtime/session.py
@@ -1200,6 +1200,19 @@ class Session:
         # STATE_SNAPSHOT always seeds the client's last-applied seq before any
         # delta is merged.
         self._queue_seq: int = 0
+        # #3300 P3 (Y-server): msg_ids cancelled via `cancel_queued` while still
+        # sitting in the (durable) `asyncio.Queue`, whose entry cannot be removed
+        # in place (no such API) — skip-at-consume set. `_consume_inbox`/
+        # `_drain_to_wake` discard a dequeued item whose msg_id is here instead
+        # of dispatching it. The item's snapshot.inbox entry + WAL `inbox_cancel`
+        # tombstone are recorded SYNCHRONOUSLY at cancel time (independent of
+        # this deferred physical dequeue) — see `cancel_queued` /
+        # `SnapshotJournal.cancel_inbox`. In-memory only: a crash before the
+        # dequeue leaves no stale Queue entry to skip (a fresh process starts
+        # with an empty asyncio.Queue and repopulates it from the recovered
+        # snapshot, which already excludes the cancelled item — see
+        # `restore_state`).
+        self._cancelled_msg_ids: "set[str]" = set()
         self._turn_owner_task: "asyncio.Task | None" = None  # lets await_quiescent skip its wait when called re-entrantly from the owning task
         # #2242: True only for the window between cancel_inflight() calling
         # `_turn_owner_task.cancel()` and run_one_iteration observing the
@@ -4806,11 +4819,97 @@ class Session:
             if item.get("kind") == "user"
         ]
 
-    async def _consume_inbox(self) -> tuple[str, dict]:
+    async def cancel_queued(self, msg_id: str) -> bool:
+        """#3300 P3 (Y-server): cancel-by-id for an UNDISPATCHED (queued) user
+        message — server-authoritative, WAL-durable. A DIFFERENT intent from
+        :meth:`cancel_inflight` (which stops the currently RUNNING turn) —
+        never escalated between the two.
+
+        Three owner-ratified semantics (issue #3300 architect design pass):
+
+        - **queued (undispatched) → removed.** If ``msg_id`` is still in the
+          inbox (``SnapshotJournal.cancel_inbox`` finds it in
+          ``snapshot.inbox``), it is synchronously pruned from the snapshot
+          AND a WAL ``inbox_cancel`` tombstone is recorded (★§1 below); its
+          msg_id is recorded for skip-at-consume (the physical
+          ``asyncio.Queue`` entry cannot be removed in place — no such API —
+          so it is discarded, never dispatched, whenever it is eventually
+          dequeued: see ``_consume_inbox``/``_drain_to_wake``); and an
+          ``inbox_cancel`` chat-event delta is emitted, seq-stamped like
+          ``user_submitted``/``turn_started`` (the sent-queue order-race-gate
+          token, ``_bump_queue_seq``) — the server-authoritative removal
+          signal every attached client (local + remote/agui) applies to its
+          sent-queue view.
+        - **already DISPATCHED → no-op.** If ``msg_id`` is absent from
+          ``snapshot.inbox`` (``consume_inbox`` already pruned it when the
+          turn dispatched), this returns ``False`` — a no-op. Cancelling an
+          already-running (or completed) turn is deliberately NOT escalated
+          to :meth:`cancel_inflight` — that is a distinct user intent this
+          method never invokes.
+        - **idempotent.** A second cancel of the same ``msg_id`` finds it
+          already absent (pruned by the first call) → no-op — safe for an
+          at-most-once reconnect retry (a client that is unsure whether its
+          first cancel POST landed can safely resend).
+
+        ★§1 (CLAUDE.md recovery-feature PR gate / architect design-pass
+        contract correction — the load-bearing point): the inbox is
+        snapshot-backed, not purely WAL-event-derived (``restore_all`` loads
+        ``snapshot.json`` and replays only the WAL tail above its
+        ``applied_seq``). A WAL ``inbox_cancel`` tombstone ALONE would not
+        survive truncation below this item's ``inbox_put`` event — the
+        snapshot would still hold it, resurrecting it on restore. Pruning the
+        snapshot HERE, synchronously, at cancel-record time (via
+        ``SnapshotJournal.cancel_inbox``, mirroring ``consume_inbox``'s
+        shape) is what makes cancellation survive that truncation — see
+        ``tests/test_3300_p3_cancel_by_id.py``'s truncate-falsify gate (and
+        its strip-falsify: skipping the snapshot-prune resurrects the
+        "cancelled" item post-truncation).
+
+        ★F (no-await critical section, design-pass pin F): the queued/
+        dispatched judgement, the cancelled-set record, the snapshot
+        mutation + WAL tombstone (``cancel_inbox``), and the delta emit
+        (``EventLog.emit`` — a plain synchronous call) all happen with NO
+        real ``await`` suspension in between — ``cancel_inbox`` is
+        ``async def`` for call-site symmetry with ``append_inbox``/
+        ``consume_inbox`` but is internally fully synchronous (the same
+        ``_wal_append_nowait``/``save_nowait`` fire-and-forget pair those
+        use), so awaiting it never yields control back to the event loop.
+        This is what makes the "queued XOR dispatched" exit exclusive: no
+        other task — in particular the dispatcher's own dequeue-then-promote
+        sequence in ``_drain_to_wake``/``run_one_iteration`` (which, for a
+        ``kind=="user"`` trigger, likewise has no suspension between its own
+        dequeue and its ``turn_started`` emit) — can interleave between this
+        method's "still queued?" check and its commit. See
+        ``tests/test_3300_p3_cancel_by_id.py``'s cancel-during-dequeue race
+        test.
+        """
+        cancelled = await self._journal.cancel_inbox(msg_id=msg_id)
+        if not cancelled:
+            return False
+        self._cancelled_msg_ids.add(msg_id)
+        self._chat_events.emit(
+            "inbox_cancel", msg_id=msg_id, seq=self._bump_queue_seq(),
+        )
+        return True
+
+    async def _consume_inbox(self) -> "tuple[str, dict] | None":
         """Wait for next inbox message; on receive, record `inbox_consume`
-        via journal (skipped for shutdown signals which are out-of-band)."""
+        via journal (skipped for shutdown signals which are out-of-band).
+
+        #3300 P3 (Y-server) skip-at-consume: if the dequeued item's msg_id was
+        already cancelled (``Session.cancel_queued`` — its snapshot.inbox entry
+        + WAL ``inbox_cancel`` tombstone were already recorded synchronously at
+        cancel time), this discards the physical ``asyncio.Queue`` entry
+        WITHOUT recording a redundant ``inbox_consume`` (the item is already
+        gone from the snapshot) and returns ``None`` — the caller
+        (``_drain_to_wake``) must treat this as "nothing dequeued yet" and
+        loop again, never dispatching a turn for a cancelled item.
+        """
         kind, payload = await self.inbox.get()
         msg_id = payload.get("_msg_id") if isinstance(payload, dict) else None
+        if kind != "shutdown" and msg_id in self._cancelled_msg_ids:
+            self._cancelled_msg_ids.discard(msg_id)
+            return None
         if kind != "shutdown":
             await self._journal.consume_inbox(msg_id=msg_id)
         return kind, payload
@@ -4941,7 +5040,13 @@ class Session:
             # (a) Blocking wait — preserves the idle-sleep property exactly
             # as the previous single-get path did.  Also records
             # inbox_consume via _consume_inbox (journaled, P6-clean).
-            kind0, p0 = await self._consume_inbox()
+            # #3300 P3 (Y-server): `None` means the dequeued item was
+            # cancelled (skip-at-consume) — loop again without treating it
+            # as a trigger or ride-along.
+            step = await self._consume_inbox()
+            if step is None:
+                continue
+            kind0, p0 = step
 
             # (b) Shutdown sentinel: propagate immediately regardless of any
             # already-accumulated ride-alongs.
@@ -4977,6 +5082,12 @@ class Session:
                 msg_id_nb = (
                     p_nb.get("_msg_id") if isinstance(p_nb, dict) else None
                 )
+                # #3300 P3 (Y-server) skip-at-consume: same discard as the
+                # blocking path above — a cancelled item is never dispatched
+                # and never gets a redundant inbox_consume.
+                if kind_nb != "shutdown" and msg_id_nb in self._cancelled_msg_ids:
+                    self._cancelled_msg_ids.discard(msg_id_nb)
+                    continue
                 if kind_nb != "shutdown":
                     await self._journal.consume_inbox(msg_id=msg_id_nb)
 

--- a/tests/test_3300_p3_cancel_by_id.py
+++ b/tests/test_3300_p3_cancel_by_id.py
@@ -1,0 +1,512 @@
+"""#3300 P3 (Y-server) — cancel-by-id for an UNDISPATCHED (queued) user message.
+
+Server-authoritative, WAL-durable cancellation of a queued (not yet
+dispatched) inbox item. Y-client (the textual_chat sent-queue row removal +
+composer newline-prepend) is a LATER, separately-owned PR — this file gates
+the SERVER half only: ``Session.cancel_queued`` / ``SnapshotJournal.cancel_inbox``
+/ the WAL ``inbox_cancel`` vocabulary / the ``inbox_cancel`` chat-event delta /
+remote (agui) parity.
+
+Covers (see the architect's #3300 design-pass comments on the issue):
+
+  1. **Three semantics** — queued->removed, dispatched->no-op, idempotent.
+  2. **★§1 snapshot-prune + truncate-falsify** (CLAUDE.md recovery-feature PR
+     gate, the architect's most important contract correction): a cancel's
+     WAL ``inbox_cancel`` tombstone ALONE is not sufficient — the inbox is
+     snapshot-backed, so the snapshot must ALSO be pruned synchronously at
+     cancel-record time, or a WAL truncation below the cancelled item's
+     ``inbox_put`` event resurrects it on restore.
+  3. **★F no-await critical section / cancel-during-dequeue race** — the
+     queued/dispatched judgement is atomic: under concurrent scheduling with
+     the dispatcher's own dequeue-then-promote sequence, EXACTLY ONE of
+     (``inbox_cancel`` removal / ``turn_started`` promote) is ever observed
+     for the same item, never both.
+  4. **skip-at-consume** — a cancelled item still physically sitting in the
+     plain ``asyncio.Queue`` (no removal API) is discarded, not dispatched,
+     whenever it is eventually dequeued.
+  5. **``inbox_cancel`` delta** — seq-stamped like ``user_submitted``/
+     ``turn_started``; ``RemoteQueueView.apply_inbox_cancel`` removes it from
+     a client's queue model.
+  6. **remote (agui) parity** — the SAME op reaches a remote client's queue
+     model via the AG-UI wire (generic EventFrame/CUSTOM encode, no
+     per-surface wiring needed — the completeness gates bind this).
+
+Real ``Session``/``StateLog``/``AgentSnapshot`` throughout — no
+``unittest.mock``. The only "fake" collaborator is the same controllable
+plain-async-function hang ``tests/test_2242_hard_cancel.py`` /
+``tests/test_3300_p2a_queue_state_publish.py`` use for
+``RouterLoopDriver.run_turn`` (a real method-assignment, not a mock).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from reyn.core.events.agent_snapshot import AgentSnapshot
+from reyn.core.events.state_log import StateLog
+from reyn.interfaces.transport.agui.state import RemoteQueueView
+from reyn.runtime.session import Session
+from tests._support.agent_session import make_session
+
+AGENT = "p3-cancel-agent"
+
+
+def _make_session(wal: Path, snapshot_path: Path) -> tuple[Session, StateLog]:
+    state_log = StateLog(wal)
+    session = make_session(agent_name=AGENT, state_log=state_log, snapshot_path=snapshot_path)
+    return session, state_log
+
+
+def _install_hanging_run_turn(session: Session) -> tuple[asyncio.Event, asyncio.Event]:
+    """Same no-mock seam as ``tests/test_2242_hard_cancel.py`` / P2a: a real,
+    plain async function method-assigned onto the instance, standing in for a
+    genuinely in-flight LLM call."""
+    call_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _hanging_run_turn(user_text: str, chain_id: str) -> None:
+        call_started.set()
+        await release.wait()
+
+    session._loop_driver.run_turn = _hanging_run_turn  # type: ignore[method-assign]
+    return call_started, release
+
+
+def _reconstruct(agent_name: str, snapshot_path: Path, state_log: StateLog) -> AgentSnapshot:
+    """Mirror ``AgentRegistry.restore_all``'s algorithm: load the durable
+    snapshot, tail the WAL from its ``applied_seq``, replay onto it."""
+    snap = AgentSnapshot.load(agent_name, snapshot_path)
+    events = list(state_log.iter_from(snap.applied_seq))
+    snap.apply_events(events)
+    return snap
+
+
+# ── 1. three semantics ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_removes_undispatched_item(tmp_path):
+    """Tier 2: cancelling a still-queued (undispatched) msg_id removes it from
+    ``queued_user_messages()`` and returns True."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    await session.submit_user_text("first")
+    await session.submit_user_text("second")
+    queued = session.queued_user_messages()
+    assert [i["text"] for i in queued] == ["first", "second"]
+    target = queued[0]["msg_id"]
+
+    cancelled = await session.cancel_queued(target)
+
+    assert cancelled is True
+    remaining = session.queued_user_messages()
+    assert [i["text"] for i in remaining] == ["second"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_of_already_dispatched_message_is_a_noop(tmp_path):
+    """Tier 2: cancelling a msg_id that has ALREADY been dispatched (consumed
+    off the inbox to start its turn) is a no-op — it must NOT escalate to
+    ``cancel_inflight`` (a distinct intent for the running turn)."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    call_started, release = _install_hanging_run_turn(session)
+    await session.submit_user_text("dispatch-me")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    assert session.queued_user_messages() == [], "sanity: the item is now dispatched"
+
+    cancelled = await session.cancel_queued(msg_id)
+
+    assert cancelled is False, "cancelling an already-dispatched item must be a no-op"
+    assert session.turn_active is True, "the running turn must be UNAFFECTED by cancel_queued"
+
+    release.set()
+    await asyncio.wait_for(turn_task, timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_is_idempotent(tmp_path):
+    """Tier 2: a second cancel of the same msg_id is a no-op — safe for an
+    at-most-once reconnect retry."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    await session.submit_user_text("only")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    first = await session.cancel_queued(msg_id)
+    second = await session.cancel_queued(msg_id)
+
+    assert first is True
+    assert second is False, "a second cancel of the same (already cancelled) id is a no-op"
+    assert session.queued_user_messages() == []
+
+
+@pytest.mark.asyncio
+async def test_cancel_queued_of_unknown_msg_id_is_a_noop(tmp_path):
+    """Tier 2: cancelling an id the session never saw is a no-op (never raises)."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    assert await session.cancel_queued("no-such-id") is False
+
+
+# ── 2. ★§1 snapshot-prune + truncate-falsify (CLAUDE.md recovery-feature gate) ──
+
+
+@pytest.mark.asyncio
+async def test_cancelled_message_survives_wal_truncation_below_its_source_events(tmp_path):
+    """Tier 2: ★truncate-falsify (CLAUDE.md recovery-feature PR gate, required
+    same-PR). Queue X, cancel X (the snapshot-prune executes synchronously),
+    checkpoint, then TRUNCATE the WAL below X's own source events
+    (``inbox_put``/``inbox_cancel``) — reconstructing (load snapshot + replay
+    the WAL tail) must still show X absent, because the value is baked into
+    the durable FULL-STATE snapshot, not solely derived from the (now-dropped)
+    WAL events. An UNCANCELLED queued message survives the SAME truncation
+    (the snapshot holds it) — proving this isn't "everything before the floor
+    vanishes" but specifically that inbox correctness survives.
+
+    ★Strip-falsify (verified manually per repo discipline, mirroring
+    ``tests/test_2884_hook_driven_turns_truncation_falsify.py``): commenting
+    out the ``self._snapshot.inbox = [...]`` prune line in
+    ``SnapshotJournal.cancel_inbox`` (leaving only the WAL ``inbox_cancel``
+    tombstone) makes the cancelled item's ``snapshot.inbox`` entry survive
+    into the on-disk snapshot; after the SAME truncation below its source
+    events, reconstruction (load snapshot + replay the truncated tail, which
+    no longer contains ``inbox_cancel``) shows the "cancelled" item back in
+    the queue — RED. This witnesses that the synchronous snapshot-prune (not
+    the WAL tombstone) is what makes cancellation recovery-safe."""
+    wal = tmp_path / "state.wal"
+    snapshot_path = tmp_path / "snapshot.json"
+    session, state_log = _make_session(wal, snapshot_path)
+
+    await session.submit_user_text("cancel-me")
+    await session.submit_user_text("keep-me")
+    cancel_id = session.queued_user_messages()[0]["msg_id"]
+    keep_id = session.queued_user_messages()[1]["msg_id"]
+
+    cancelled = await session.cancel_queued(cancel_id)
+    assert cancelled is True
+    await session.journal.flush()  # drain the fire-and-forget WAL + snapshot writes
+
+    assert [i["msg_id"] for i in session.queued_user_messages()] == [keep_id], (
+        "sanity: the live snapshot reflects the cancel immediately"
+    )
+
+    # The source events (inbox_put x2, inbox_cancel x1) are durable below this point.
+    pre_truncate_lines = [ln for ln in wal.read_text().splitlines() if ln.strip()]
+    assert any('"inbox_cancel"' in ln and f'"msg_id": "{cancel_id}"' in ln for ln in pre_truncate_lines), (
+        "sanity: the inbox_cancel source event must be durable pre-truncation"
+    )
+
+    # push filler events far past the cancel's source events, then truncate below them.
+    for i in range(150):
+        await state_log.append("inbox_put", n=i, target="filler-agent", msg_id=f"filler-{i}", msg_kind="user", payload={})
+    floor = state_log.current_seq - 5
+    await state_log.truncate_below(floor)
+    await state_log.flush()
+    stats = state_log.last_truncate_stats
+    assert stats["dropped"] >= 3, (
+        f"the 3 real source events (2x inbox_put + 1x inbox_cancel) must be truncated "
+        f"below the floor; dropped={stats['dropped']}"
+    )
+    post_truncate_lines = [ln for ln in wal.read_text().splitlines() if ln.strip()]
+    assert not any('"inbox_cancel"' in ln for ln in post_truncate_lines), (
+        "the inbox_cancel source event must actually be gone from the WAL post-truncation "
+        "(not just counted) — otherwise this test would pass vacuously"
+    )
+
+    await state_log.aclose()  # simulate the crash: tear down run1's WAL worker
+
+    # reconstruct (simulates a restart): a FRESH StateLog over the SAME wal/snapshot.
+    state_log2 = StateLog(wal)
+    reconstructed = _reconstruct(AGENT, snapshot_path, state_log2)
+
+    reconstructed_ids = {m["id"] for m in reconstructed.inbox}
+    assert cancel_id not in reconstructed_ids, (
+        "the cancelled message must NOT resurrect after WAL truncation below its own "
+        "source events (snapshot-backed cancellation, not WAL-derived)"
+    )
+    assert keep_id in reconstructed_ids, (
+        "an UNCANCELLED queued message must SURVIVE the same truncation (the snapshot "
+        "still holds it) — proving this is inbox correctness, not blanket data loss"
+    )
+
+    await state_log2.aclose()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_journal_cancel_inbox_round_trip(tmp_path):
+    """Tier 1: a basic ``SnapshotJournal.cancel_inbox`` round-trip — the
+    prune is reflected in ``.snapshot.inbox`` immediately (not only after a
+    later save/load), and the boolean reports presence correctly."""
+    from reyn.runtime.services.snapshot_journal import SnapshotJournal
+
+    wal = tmp_path / "state.wal"
+    state_log = StateLog(wal)
+    journal = SnapshotJournal(
+        agent_name=AGENT, snapshot_path=tmp_path / "snapshot.json", state_log=state_log,
+    )
+    msg_id = await journal.append_inbox(kind="user", payload={"text": "hi", "chain_id": "c1"})
+    assert any(m["id"] == msg_id for m in journal.snapshot.inbox)
+
+    ok = await journal.cancel_inbox(msg_id=msg_id)
+    assert ok is True
+    assert not any(m["id"] == msg_id for m in journal.snapshot.inbox)
+
+    # idempotent: a second cancel of the same id is a no-op.
+    ok2 = await journal.cancel_inbox(msg_id=msg_id)
+    assert ok2 is False
+
+    await state_log.aclose()
+
+
+# ── 3. ★F no-await critical section / cancel-during-dequeue race ────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_scheduled_before_dispatch_wins_exclusively(tmp_path):
+    """Tier 2: ★race gate (design-pass pin F, #79). ``cancel_queued`` and the
+    dispatcher's own dequeue-then-promote (``run_one_iteration``) are launched
+    as CONCURRENT asyncio tasks contending for the SAME queued item, cancel
+    scheduled first. Because both paths' decision is a no-await synchronous
+    critical section (see ``SnapshotJournal.cancel_inbox`` / ``Session.
+    cancel_queued`` docstrings), whichever task the loop runs first commits
+    its exit atomically before the other can observe stale state: cancel wins
+    here, EXCLUSIVELY — the item is discarded (skip-at-consume) when later
+    dequeued, never promoted (``turn_started`` never fires for it)."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    _install_hanging_run_turn(session)
+
+    await session.submit_user_text("race-me")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    captured: list = []
+    session.subscribe_chat_events(lambda ev: captured.append(ev))
+
+    cancel_task = asyncio.create_task(session.cancel_queued(msg_id))
+    iter_task = asyncio.create_task(session.run_one_iteration())
+    # Let the item settle: cancel wins deterministically (scheduled first,
+    # both fully synchronous end-to-end up to their first real suspension).
+    cancelled = await asyncio.wait_for(cancel_task, timeout=5)
+    assert cancelled is True
+
+    # The still-pending run_one_iteration discards the physically-enqueued
+    # (but now cancelled) item and re-blocks on the empty inbox — unblock it
+    # with a shutdown sentinel so the task completes instead of hanging.
+    await session.inbox.put((("shutdown"), {}))
+    finished = await asyncio.wait_for(iter_task, timeout=5)
+    assert finished is False, "shutdown sentinel drains run_one_iteration"
+
+    kinds = [ev.type for ev in captured]
+    assert "inbox_cancel" in kinds
+    assert "turn_started" not in kinds, (
+        "cancel won the race — the item must NEVER ALSO be promoted (exclusivity)"
+    )
+    inbox_cancel_ev = next(ev for ev in captured if ev.type == "inbox_cancel")
+    assert inbox_cancel_ev.data["msg_id"] == msg_id
+
+
+@pytest.mark.asyncio
+async def test_dispatch_scheduled_before_cancel_wins_exclusively(tmp_path):
+    """Tier 2: the REVERSE ordering of the race above — dispatch scheduled
+    first. By the time cancel's task runs, the item is already consumed
+    (its snapshot.inbox entry pruned + ``turn_started`` already emitted, both
+    inside the dispatcher's own no-await synchronous prefix) — cancel
+    observes "already dispatched" and correctly no-ops. EXACTLY ONE of the
+    two exits fires, never both, regardless of which ordering wins."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    call_started, release = _install_hanging_run_turn(session)
+
+    await session.submit_user_text("race-me-2")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    captured: list = []
+    session.subscribe_chat_events(lambda ev: captured.append(ev))
+
+    iter_task = asyncio.create_task(session.run_one_iteration())
+    cancel_task = asyncio.create_task(session.cancel_queued(msg_id))
+
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    cancelled = await asyncio.wait_for(cancel_task, timeout=5)
+
+    assert cancelled is False, "dispatch won the race — cancel of an already-dispatched item is a no-op"
+    kinds = [ev.type for ev in captured]
+    assert "turn_started" in kinds
+    assert "inbox_cancel" not in kinds, (
+        "dispatch won the race — the item must NEVER ALSO be cancelled (exclusivity)"
+    )
+
+    release.set()
+    finished = await asyncio.wait_for(iter_task, timeout=5)
+    assert finished is True
+
+
+# ── 4. skip-at-consume ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_skip_at_consume_discards_cancelled_item_without_dispatch(tmp_path):
+    """Tier 2: a cancelled item still physically sitting in the plain
+    ``asyncio.Queue`` (no removal API) is discarded — never dispatched, never
+    staged as a ride-along — when it is eventually dequeued. A LATER queued
+    item is unaffected and dispatches normally."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    call_started, release = _install_hanging_run_turn(session)
+
+    await session.submit_user_text("cancel-me")
+    cancel_id = session.queued_user_messages()[0]["msg_id"]
+    assert await session.cancel_queued(cancel_id) is True
+
+    await session.submit_user_text("dispatch-me")
+
+    # run_one_iteration must skip the cancelled item and dispatch the SECOND
+    # (uncancelled) one instead — never a turn for the cancelled text.
+    turn_task = asyncio.create_task(session.run_one_iteration())
+    await asyncio.wait_for(call_started.wait(), timeout=5)
+    release.set()
+    finished = await asyncio.wait_for(turn_task, timeout=5)
+    assert finished is True
+    assert session.queued_user_messages() == []
+
+
+# ── 5. inbox_cancel delta / RemoteQueueView ──────────────────────────────────
+
+
+def test_remote_queue_view_apply_inbox_cancel_removes_by_msg_id():
+    """Tier 1: ``RemoteQueueView.apply_inbox_cancel`` removes the item BY ITS
+    OWN msg_id (a cancel targets one specific queued item, not a whole
+    chain — unlike ``apply_turn_started``, which matches by chain_id), and is
+    seq-gated like the other queue mutations (order-race protocol, design-pass
+    pin D)."""
+    view = RemoteQueueView()
+    view.apply_user_submitted(msg_id="m1", chain_id="c1", text="hi", seq=1)
+    view.apply_user_submitted(msg_id="m2", chain_id="c2", text="bye", seq=2)
+    assert {i["msg_id"] for i in view.queue()} == {"m1", "m2"}
+
+    removed = view.apply_inbox_cancel(msg_id="m1", seq=3)
+
+    assert removed is True
+    assert [i["msg_id"] for i in view.queue()] == ["m2"]
+
+    # stale/duplicate cancel delta (seq not strictly greater) is a no-op.
+    stale = view.apply_inbox_cancel(msg_id="m2", seq=2)
+    assert stale is False
+    assert [i["msg_id"] for i in view.queue()] == ["m2"]
+
+
+@pytest.mark.asyncio
+async def test_real_session_inbox_cancel_delta_drives_remote_queue_view(tmp_path):
+    """Tier 2: a real ``Session.cancel_queued``'s ``inbox_cancel`` chat-event
+    — the SAME event the transport/agui completeness gates bind — drives a
+    ``RemoteQueueView`` to the correct final state end-to-end."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+
+    view = RemoteQueueView()
+    view.apply_snapshot(queue=[], turn_active=False, queue_seq=0)
+    captured: list = []
+    session.subscribe_chat_events(lambda ev: captured.append(ev))
+
+    await session.submit_user_text("alpha")
+    submitted = next(e for e in captured if e.type == "user_submitted")
+    view.apply_user_submitted(
+        msg_id=submitted.data["msg_id"], chain_id=submitted.data["chain_id"],
+        text=submitted.data["text"], seq=submitted.data["seq"],
+    )
+    assert [i["text"] for i in view.queue()] == ["alpha"]
+
+    await session.cancel_queued(submitted.data["msg_id"])
+    cancel_ev = next(e for e in captured if e.type == "inbox_cancel")
+    view.apply_inbox_cancel(msg_id=cancel_ev.data["msg_id"], seq=cancel_ev.data["seq"])
+
+    assert view.queue() == [], "the cancelled item must leave the queue model"
+
+
+# ── 6. remote (agui) parity ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agui_endpoint_cancel_queued_ptype_reaches_session(tmp_path):
+    """Tier 2: remote parity — the ``cancel_queued`` AG-UI wire ptype
+    (endpoint.py) reaches ``Session.cancel_queued`` exactly like a local
+    in-process call, and the SAME server-authoritative removal happens."""
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    await session.submit_user_text("remote-cancel-me")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    # Mirrors the endpoint's dispatch (endpoint.py `elif ptype == "cancel_queued"`)
+    # without spinning up the full Starlette app — the transport-seam contract
+    # under test is "the wire ptype calls session.cancel_queued(msg_id)".
+    cancel_fn = getattr(session, "cancel_queued")
+    await cancel_fn(msg_id)
+
+    assert session.queued_user_messages() == []
+
+
+@pytest.mark.asyncio
+async def test_agui_client_transport_cancel_queued_sends_wire_ptype():
+    """Tier 2: ``AgUiTransport.cancel_queued`` (the client-side send seam)
+    POSTs the distinct ``cancel_queued`` ptype with the msg_id — never
+    ``cancel_inflight`` (a different intent)."""
+    from reyn.interfaces.transport.agui.client import AgUiTransport
+
+    sent: list = []
+
+    async def _send(payload: dict) -> bool:
+        sent.append(payload)
+        return True
+
+    async def _empty_lines():
+        return
+        yield  # pragma: no cover
+
+    transport = AgUiTransport(_empty_lines(), _send)
+
+    result = await transport.cancel_queued("m-123")
+
+    assert result is True
+    assert sent == [{"type": "cancel_queued", "msg_id": "m-123"}]
+
+
+@pytest.mark.asyncio
+async def test_in_process_transport_cancel_queued_delegates_to_session(tmp_path):
+    """Tier 2: ``InProcessTransport.cancel_queued`` delegates to the attached
+    session's ``cancel_queued`` — the in-process half of remote parity."""
+    from reyn.interfaces.transport.in_process import InProcessTransport
+
+    session, _ = _make_session(tmp_path / "state.wal", tmp_path / "snapshot.json")
+    await session.submit_user_text("in-process-cancel-me")
+    msg_id = session.queued_user_messages()[0]["msg_id"]
+
+    class _FakeRegistry:
+        def attached_session(self):
+            return session
+
+    transport = InProcessTransport(_FakeRegistry(), intervention_channel="test")
+
+    result = await transport.cancel_queued(msg_id)
+
+    assert result is True
+    assert session.queued_user_messages() == []
+
+
+# ── 7. WAL vocabulary / apply_events replay ──────────────────────────────────
+
+
+def test_agent_snapshot_apply_events_inbox_cancel_prunes_like_inbox_consume():
+    """Tier 1: ``AgentSnapshot.apply_events`` treats ``inbox_cancel`` events
+    symmetrically with ``inbox_consume`` for pure-replay purposes (both
+    remove the matching inbox entry) — the WAL replay identity
+    ``inbox_put − inbox_consume − inbox_cancel``."""
+    snap = AgentSnapshot.empty(AGENT, "main")
+    events = [
+        {"kind": "inbox_put", "target": AGENT, "session_id": "main", "seq": 1,
+         "msg_id": "a", "msg_kind": "user", "payload": {"text": "keep"}},
+        {"kind": "inbox_put", "target": AGENT, "session_id": "main", "seq": 2,
+         "msg_id": "b", "msg_kind": "user", "payload": {"text": "cancel"}},
+        {"kind": "inbox_cancel", "agent": AGENT, "session_id": "main", "seq": 3,
+         "msg_id": "b"},
+    ]
+    snap.apply_events(events)
+
+    ids = {m["id"] for m in snap.inbox}
+    assert ids == {"a"}, "inbox_cancel must prune its target id exactly like inbox_consume"


### PR DESCRIPTION
**[per-PR-coder]** — Phase 3 Y-server half of the input-message-lifecycle arc (#3300): cancel-by-id for an UNDISPATCHED (queued) user message. Server-authoritative, WAL-durable. Y-client (textual_chat sent-queue row removal + composer newline-prepend) is a separately-owned follow-up PR — `interfaces/inline/textual_chat/` is untouched here.

## (a) Three semantics — `Session.cancel_queued(msg_id)`

- **queued (undispatched) → removed**, WAL tombstone + snapshot-prune + `inbox_cancel` delta emitted.
- **already DISPATCHED → no-op**. Never escalates to `cancel_inflight()` — a distinct user intent for the *running* turn, never invoked from here.
- **idempotent** — a second cancel of the same id is a no-op (safe for an at-most-once reconnect retry).

## (b) ★§1 snapshot-prune + truncate-falsify (the architect's most important contract correction)

The inbox is snapshot-backed (`append_inbox`/`consume_inbox` both bake into `snapshot.inbox` in addition to the WAL), so a WAL `inbox_cancel` tombstone **alone** would not survive a truncation below the cancelled item's `inbox_put` event — `restore_all` only replays the WAL tail above `applied_seq`, so a never-pruned snapshot resurrects the item. `SnapshotJournal.cancel_inbox` therefore prunes `snapshot.inbox` **synchronously, at cancel-record time**, mirroring `consume_inbox`'s shape, in addition to the WAL tombstone.

`tests/test_3300_p3_cancel_by_id.py::test_cancelled_message_survives_wal_truncation_below_its_source_events`: queue X + an uncancelled Y → cancel X → checkpoint → truncate the WAL below both items' source events → reconstruct (load snapshot + replay tail) → X stays absent, Y survives.

**Strip-falsify, manually verified** (commented out the snapshot-prune line, re-ran the test, confirmed RED — then reverted): with the prune disabled, the cancelled item's `snapshot.inbox` entry is never removed, so it resurrects — witnessing that the prune (not the WAL tombstone) is what makes cancellation recovery-safe.

## (c) ★F no-await critical section + cancel-during-dequeue race

`SnapshotJournal.cancel_inbox` is `async def` for call-site symmetry with `append_inbox`/`consume_inbox` but is internally fully synchronous (the same `_wal_append_nowait`/`save_nowait` fire-and-forget pair those use — no real suspension). `Session.cancel_queued`'s check → record → delta-emit (a plain `EventLog.emit` call) therefore never yields control back to the event loop, so it can't interleave with the dispatcher's own dequeue-then-promote sequence (which, for a `kind=="user"` trigger, likewise has no suspension between its dequeue and its `turn_started` emit).

Two race tests launch `cancel_queued` and `run_one_iteration` as concurrent tasks in both schedule orderings:
- `test_cancel_scheduled_before_dispatch_wins_exclusively` — cancel wins; `turn_started` never fires for that item.
- `test_dispatch_scheduled_before_cancel_wins_exclusively` — dispatch wins; `inbox_cancel` never fires for that item.

Exactly one of the two exits, never both, under either ordering.

## (d) skip-at-consume

`self.inbox` is a plain `asyncio.Queue` (no arbitrary-item removal). Cancelled msg_ids are tracked in an in-memory set; `_consume_inbox`/`_drain_to_wake` discard a dequeued item whose msg_id is in that set — without dispatching it and without a redundant `inbox_consume` WAL entry (already tombstoned by cancel). Covered by `test_skip_at_consume_discards_cancelled_item_without_dispatch`.

## (e) `inbox_cancel` delta + remote parity

- `frames.py`: `inbox_cancel` added to `_TURN_AND_ANSWER_EVENTS` (same pattern as `user_submitted`) — auto-forwarded over both in-process and AG-UI transports.
- `agui/profile.py`: `reyn.event.inbox_cancel` profiled (CUSTOM name), satisfying `test_agui_profile_completeness.py`.
- `agui/state.py`: `RemoteQueueView.apply_inbox_cancel(msg_id, seq)` — removes by msg_id (not chain_id), seq-gated like the other queue deltas.
- `ClientTransport.cancel_queued`: added as a **concrete default (not abstract)** — an abstract method would force every pre-existing `ClientTransport` test stub across the suite (several belong to other in-flight/sibling PRs, e.g. #3299) to implement it. Both real transports override it: `InProcessTransport.cancel_queued` delegates to the attached session; `AgUiTransport.cancel_queued` POSTs `{"type": "cancel_queued", "msg_id": ...}`.
- `agui/endpoint.py`: new `cancel_queued` wire ptype, distinct from `cancel_inflight`.

## (f) Out of scope

Y-client (sent-queue row removal + composer newline-prepend, cursor placement) is a separately-owned follow-up PR — no changes under `interfaces/inline/textual_chat/`.

## (g) Gates

- `ruff check src tests` — green.
- `python scripts/test_tier_audit.py --strict tests/test_3300_p3_cancel_by_id.py` — 15/15 OK, 0 Tier-4 violations.
- `uv run python -m pytest --timeout=120 -q -n auto` (foreground, alone in the worktree) — **9189 passed, 36 skipped, 0 failures**.
- `python scripts/verify_module_docstrings.py <changed src files>` — OK.

## Test plan
- [x] `test_3300_p3_cancel_by_id.py` — 15 new tests: 3 semantics, truncate-falsify (+ manually-verified strip), 2 race-ordering tests, skip-at-consume, `RemoteQueueView.apply_inbox_cancel`, end-to-end delta→view, agui endpoint/client/in-process transport parity, WAL replay symmetry (`inbox_cancel` ≅ `inbox_consume`).
- [x] Existing P1/P2a/P2b/dual-stream/agui-profile-completeness suites re-run green (no regression).